### PR TITLE
Install JetPack, performance mode, and Chromium during initial install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -440,7 +440,7 @@ fi
 
 # ── Full Install Mode ───────────────────────────────────────────────────────
 
-TOTAL_STEPS=15
+TOTAL_STEPS=18
 step=0
 log() {
   step=$((step + 1))
@@ -455,6 +455,12 @@ step_ensure_user
 
 log "Installing system packages..."
 step_apt_update
+
+log "Installing NVIDIA JetPack..."
+step_nvidia_jetpack
+
+log "Enabling max performance mode..."
+step_performance_mode
 
 log "Detecting WiFi interface..."
 step_detect_wifi
@@ -492,6 +498,9 @@ step_polkit_rules
 
 log "Installing voice pipeline..."
 step_voice_install
+
+log "Installing Chromium..."
+step_chrome_install
 
 log "Starting services..."
 step_start_services


### PR DESCRIPTION
Move nvidia-jetpack and performance_mode before voice pipeline so CUDA is available for GPU-accelerated models. Add chrome_install at the end. Total install steps: 15 → 18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Full installation workflow now includes NVIDIA JetPack installation step
  * Performance mode optimization enabled automatically during setup
  * Chromium browser installation integrated into the installation sequence
  * Installation progress tracking updated with enhanced step counting for improved visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->