### PR TITLE
Fix voice pipeline installer issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -322,7 +322,7 @@ step_polkit_rules() {
 }
 
 step_voice_install() {
-  apt-get install -y -qq espeak-ng libsndfile1
+  apt-get install -y -qq espeak-ng libsndfile1 cmake build-essential
   bash "$PROJECT_DIR/scripts/install-voice.sh"
   echo "  Voice pipeline installed"
   bash "$PROJECT_DIR/scripts/setup-optimizations.sh"

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -98,6 +98,12 @@ su - "$CLAWBOX_USER" -c "$PIP install --user 'transformers<5'" 2>&1 | tail -3
 # ── Step 5: Pre-download models ─────────────────────────────────────────────
 
 echo "[5/7] Pre-downloading Whisper model (base)..."
+# Clear corrupted cache (0-byte blobs from failed/rate-limited HF downloads)
+WHISPER_CACHE="$CLAWBOX_HOME/.cache/huggingface/hub/models--Systran--faster-whisper-base"
+if [ -d "$WHISPER_CACHE/blobs" ] && find "$WHISPER_CACHE/blobs" -maxdepth 1 -type f -empty | grep -q .; then
+  echo "  Clearing corrupted Whisper model cache..."
+  rm -rf "$WHISPER_CACHE"
+fi
 DEVICE="cpu"
 COMPUTE="auto"
 if $HAS_CUDA; then

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -89,7 +89,11 @@ fi
 # ── Step 4: Install Kokoro TTS ───────────────────────────────────────────────
 
 echo "[4/7] Installing Kokoro TTS..."
-su - "$CLAWBOX_USER" -c "$PIP install --user 'numpy<2' 'transformers<5' kokoro soundfile Pillow" 2>&1 | tail -3
+# Install kokoro first, then force transformers<5 as a separate step.
+# pip 22's resolver won't downgrade huggingface-hub (pulled in by faster-whisper)
+# to satisfy transformers<5 in a single command, so it silently picks transformers 5.x.
+su - "$CLAWBOX_USER" -c "$PIP install --user 'numpy<2' kokoro soundfile 'Pillow>=10'" 2>&1 | tail -3
+su - "$CLAWBOX_USER" -c "$PIP install --user 'transformers<5'" 2>&1 | tail -3
 
 # ── Step 5: Pre-download models ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **Split pip install into two commands** — pip 22's resolver won't downgrade `huggingface-hub` (pulled by faster-whisper) to satisfy `transformers<5` in a single command, silently installing transformers 5.x which breaks Kokoro's `AlbertModel` import
- **Pin `Pillow>=10`** — Ubuntu 22.04's system Pillow 9.0.1 is missing `PIL.Image.Resampling`, causing transformers import failures
- **Add `cmake build-essential`** to system deps — required for CTranslate2 CUDA build
- **Clear corrupt Whisper model cache** — detect and remove 0-byte HuggingFace blobs from failed/rate-limited downloads before re-downloading

## Test plan
- [ ] Run `sudo bash install.sh` on a fresh Jetson with JetPack 6
- [ ] Verify Kokoro TTS model loads (`python3 -c "from kokoro import KPipeline; KPipeline(lang_code='a')"`)
- [ ] Verify Whisper STT model loads (`python3 -c "from faster_whisper import WhisperModel; WhisperModel('base')"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced voice module installation with additional system dependencies for better compatibility
  * Improved installation stability through automated cache cleanup to prevent corrupted files and dependency conflicts
  * Reorganized voice package installation steps for more reliable builds

<!-- end of auto-generated comment: release notes by coderabbit.ai -->