### PR TITLE
Fix OpenRouter model ID: use dot notation (4.5 not 4-5)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -42,7 +42,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
     },
   },
   openrouter: {
-    defaultModel: "openrouter/anthropic/claude-sonnet-4-5",
+    defaultModel: "openrouter/anthropic/claude-sonnet-4.5",
     profileKey: "openrouter:default",
   },
 };


### PR DESCRIPTION
The OpenClaw model catalog uses "claude-sonnet-4.5" (dot) but we had "claude-sonnet-4-5" (dash), causing "Unknown model" errors.