### PR TITLE
feat: file manager, login auth, VS Code integration, context menus

### DIFF
--- a/config/clawbox-browser.service
+++ b/config/clawbox-browser.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=ClawBox Browser (Chromium with CDP)
+Requires=clawbox-vnc.service
+After=clawbox-vnc.service
+
+[Service]
+Type=simple
+Environment=DISPLAY=:99
+Environment=CDP_PORT=18800
+ExecStart=/home/clawbox/clawbox/scripts/launch-browser.sh
+Restart=no
+TimeoutStartSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/config/clawbox-setup.service
+++ b/config/clawbox-setup.service
@@ -20,7 +20,7 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETUID CAP_SETGID
 ProtectSystem=strict
 ProtectHome=read-only
-ReadWritePaths=/home/clawbox/clawbox /home/clawbox/.bun /home/clawbox/.npm-global /home/clawbox/.npm /home/clawbox/.openclaw /tmp /run/sudo
+ReadWritePaths=/home/clawbox /tmp /run/sudo
 
 [Install]
 WantedBy=multi-user.target

--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -11,3 +11,5 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl restart clawbox-ap.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl stop clawbox-ap.service
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start clawbox-browser.service
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl stop clawbox-browser.service

--- a/install.sh
+++ b/install.sh
@@ -761,6 +761,9 @@ step_captive_portal_dns
 log "Setting up directories and permissions..."
 step_directories_permissions
 
+# Clean up default NVIDIA desktop shortcuts
+rm -f "$CLAWBOX_HOME/Desktop"/*.desktop 2>/dev/null || true
+
 log "Installing systemd services..."
 step_systemd_services
 

--- a/install.sh
+++ b/install.sh
@@ -567,48 +567,9 @@ step_claude_code_install() {
 }
 
 step_vnc_install() {
-  # Install x11vnc, Xvfb (virtual framebuffer fallback), and websockify
-  apt-get install -y x11vnc xvfb websockify dbus-x11
+  # Install x11vnc, Xvfb (virtual framebuffer fallback), websockify, and a lightweight WM
+  apt-get install -y x11vnc xvfb websockify dbus-x11 openbox xterm
 
-  # Create the VNC startup script — detects physical display or starts virtual one
-  cat > "$PROJECT_DIR/scripts/start-vnc.sh" <<'VNCSH'
-#!/bin/bash
-# Mirrors the physical GNOME desktop if a monitor is connected,
-# otherwise starts a virtual GNOME session on a framebuffer.
-
-DISPLAY_NUM=0
-XAUTH="/run/user/$(id -u)/gdm/Xauthority"
-
-# Check if physical display :0 is available
-if xdpyinfo -display :0 >/dev/null 2>&1; then
-  echo "[vnc] Physical display :0 detected — mirroring"
-  exec x11vnc -display :0 -auth "$XAUTH" -forever -shared -nopw -localhost -noxdamage
-fi
-
-# No physical display — start a virtual framebuffer + GNOME session
-echo "[vnc] No physical display — starting virtual desktop on :99"
-DISPLAY_NUM=99
-
-# Start Xvfb if not already running
-if ! xdpyinfo -display :${DISPLAY_NUM} >/dev/null 2>&1; then
-  Xvfb :${DISPLAY_NUM} -screen 0 1920x1080x24 &
-  sleep 1
-fi
-
-export DISPLAY=:${DISPLAY_NUM}
-export DBUS_SESSION_BUS_ADDRESS=""
-
-# Start a GNOME session (or fallback to xfce/openbox)
-if command -v gnome-session &>/dev/null; then
-  gnome-session --session=ubuntu &
-elif command -v startxfce4 &>/dev/null; then
-  startxfce4 &
-fi
-sleep 2
-
-# Mirror the virtual display
-exec x11vnc -display :${DISPLAY_NUM} -forever -shared -nopw -localhost -noxdamage
-VNCSH
   chmod +x "$PROJECT_DIR/scripts/start-vnc.sh"
   chown "$CLAWBOX_USER:$CLAWBOX_USER" "$PROJECT_DIR/scripts/start-vnc.sh"
 
@@ -647,6 +608,10 @@ RestartSec=5
 WantedBy=multi-user.target
 WSSVC
 
+  # Browser CDP service (launched on demand, not auto-started)
+  chmod +x "$PROJECT_DIR/scripts/launch-browser.sh"
+  cp "$PROJECT_DIR/config/clawbox-browser.service" /etc/systemd/system/
+
   systemctl daemon-reload
   systemctl enable clawbox-vnc.service clawbox-websockify.service
   systemctl start clawbox-vnc.service clawbox-websockify.service || true
@@ -679,6 +644,11 @@ step_rebuild_reboot() {
   reboot
 }
 
+step_browser_launch() {
+  # Launch Chromium with CDP remote debugging — runs as root then drops to clawbox via runuser
+  DISPLAY=:99 bash "$PROJECT_DIR/scripts/launch-browser.sh"
+}
+
 # ── Single-step mode (used by clawbox-root-update@.service) ──────────────────
 
 # Steps available for --step dispatch (must have a corresponding step_NAME function)
@@ -687,7 +657,7 @@ DISPATCH_STEPS=(
   chromium_install code_server_install claude_code_install vnc_install openclaw_install openclaw_patch openclaw_config openclaw_models
   git_pull build rebuild rebuild_reboot restart restart_ap recover
   chpasswd gateway_setup ffmpeg_install polkit_rules systemd_services
-  fix_git_perms
+  fix_git_perms browser_launch
 )
 
 if [ "${1:-}" = "--step" ]; then

--- a/production-server.js
+++ b/production-server.js
@@ -14,6 +14,25 @@ const WebSocket = require("ws");
 const GATEWAY_PORT = parseInt(process.env.GATEWAY_PORT || "18789", 10);
 const IS_DEV = process.env.NODE_ENV === "development";
 
+// ─── Session secret ───
+// Generate or load a persistent secret for signing session cookies.
+// Must be set before Next.js server starts so middleware can access it.
+const SESSION_SECRET_PATH = path.join(__dirname, "data", ".session-secret");
+try {
+  let sessionSecret;
+  try {
+    sessionSecret = fs.readFileSync(SESSION_SECRET_PATH, "utf-8").trim();
+  } catch {}
+  if (!sessionSecret || sessionSecret.length < 32) {
+    sessionSecret = require("crypto").randomBytes(32).toString("hex");
+    fs.mkdirSync(path.dirname(SESSION_SECRET_PATH), { recursive: true });
+    fs.writeFileSync(SESSION_SECRET_PATH, sessionSecret, { mode: 0o600 });
+  }
+  process.env.SESSION_SECRET = sessionSecret;
+} catch (err) {
+  console.warn("[production-server] Failed to set up session secret:", err.message);
+}
+
 // HTTP upgrade proxy — raw TCP pipe (works fine with bun's http.Server)
 function attachUpgradeProxy(server) {
   server.on("upgrade", (req, socket, head) => {

--- a/scripts/launch-browser.sh
+++ b/scripts/launch-browser.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Launch Chromium with CDP remote debugging on the VNC virtual display.
+# Called by clawbox-browser-cdp.service (systemd)
+
+USER="clawbox"
+HOME="/home/$USER"
+PROFILE="$HOME/.config/clawbox-browser"
+CDP_PORT="${CDP_PORT:-18800}"
+DISPLAY="${DISPLAY:-:99}"
+
+# Find chromium
+CHROMIUM=""
+for bin in chromium-browser chromium google-chrome-stable; do
+  p=$(which "$bin" 2>/dev/null) && CHROMIUM="$p" && break
+done
+[ -z "$CHROMIUM" ] && [ -x /snap/bin/chromium ] && CHROMIUM="/snap/bin/chromium"
+[ -z "$CHROMIUM" ] && echo "Chromium not found" >&2 && exit 1
+
+# Check if already running
+if curl -s "http://127.0.0.1:$CDP_PORT/json/version" >/dev/null 2>&1; then
+  echo "Browser already running on CDP port $CDP_PORT"
+  exit 0
+fi
+
+# Clean lock files
+rm -f "$PROFILE/SingletonLock" "$PROFILE/SingletonSocket" "$PROFILE/SingletonCookie"
+mkdir -p "$PROFILE"
+chown -R "$USER:$USER" "$PROFILE"
+
+echo "Starting Chromium on DISPLAY=$DISPLAY with CDP port $CDP_PORT"
+exec runuser -u "$USER" -- env DISPLAY="$DISPLAY" HOME="$HOME" \
+  "$CHROMIUM" \
+  --remote-debugging-port="$CDP_PORT" \
+  --remote-allow-origins=* \
+  --user-data-dir="$PROFILE" \
+  --no-first-run \
+  --no-default-browser-check \
+  --start-maximized \
+  --disable-gpu \
+  --restore-last-session \
+  "https://www.google.com"

--- a/scripts/start-vnc.sh
+++ b/scripts/start-vnc.sh
@@ -1,36 +1,50 @@
 #!/bin/bash
-# Mirrors the physical GNOME desktop if a monitor is connected,
-# otherwise starts a virtual GNOME session on a framebuffer.
+# Mirrors the physical display :0 if accessible,
+# otherwise starts a minimal virtual desktop (openbox) for GUI apps.
 
-DISPLAY_NUM=0
-XAUTH="/run/user/$(id -u)/gdm/Xauthority"
+VNC_PORT="${VNC_PORT:-5900}"
 
-# Check if physical display :0 is available
-if xdpyinfo -display :0 >/dev/null 2>&1; then
-  echo "[vnc] Physical display :0 detected — mirroring"
-  exec x11vnc -display :0 -auth "$XAUTH" -forever -shared -nopw -localhost -noxdamage
+# ─── Try to mirror the physical/GDM display :0 ───────────────────────────────
+
+find_xauth() {
+  local xorg_pid
+  xorg_pid=$(pgrep -f "Xorg.*-auth" | head -1)
+  if [ -n "$xorg_pid" ]; then
+    local auth
+    auth=$(tr '\0' '\n' < /proc/"$xorg_pid"/cmdline | grep -A1 -- "-auth" | tail -1)
+    [ -f "$auth" ] && echo "$auth" && return 0
+  fi
+  for f in /run/user/*/gdm/Xauthority /var/run/gdm*/auth-for-*/database; do
+    [ -f "$f" ] && echo "$f" && return 0
+  done
+  return 1
+}
+
+XAUTH=$(find_xauth 2>/dev/null)
+if [ -n "$XAUTH" ] && XAUTHORITY="$XAUTH" xdpyinfo -display :0 >/dev/null 2>&1; then
+  echo "[vnc] Display :0 found — mirroring"
+  exec x11vnc -display :0 -auth "$XAUTH" -rfbport "$VNC_PORT" -forever -shared -nopw -localhost -noxdamage
 fi
 
-# No physical display — start a virtual framebuffer + GNOME session
-echo "[vnc] No physical display — starting virtual desktop on :99"
-DISPLAY_NUM=99
+# ─── Virtual desktop ─────────────────────────────────────────────────────────
 
-# Start Xvfb if not already running
-if ! xdpyinfo -display :${DISPLAY_NUM} >/dev/null 2>&1; then
-  Xvfb :${DISPLAY_NUM} -screen 0 1920x1080x24 &
+VDISPLAY=99
+echo "[vnc] Starting virtual desktop on :${VDISPLAY}"
+
+if ! xdpyinfo -display ":${VDISPLAY}" >/dev/null 2>&1; then
+  Xvfb ":${VDISPLAY}" -screen 0 1280x720x24 &
   sleep 1
 fi
 
-export DISPLAY=:${DISPLAY_NUM}
+export DISPLAY=":${VDISPLAY}"
 export DBUS_SESSION_BUS_ADDRESS=""
 
-# Start a GNOME session (or fallback to xfce/openbox)
-if command -v gnome-session &>/dev/null; then
-  gnome-session --session=ubuntu &
-elif command -v startxfce4 &>/dev/null; then
-  startxfce4 &
+# Minimal WM — just enough to render and manage app windows
+if command -v openbox &>/dev/null; then
+  openbox &
+elif command -v xterm &>/dev/null; then
+  xterm -geometry 100x30+0+0 &
 fi
-sleep 2
+sleep 1
 
-# Mirror the virtual display
-exec x11vnc -display :${DISPLAY_NUM} -forever -shared -nopw -localhost -noxdamage
+exec x11vnc -display ":${VDISPLAY}" -rfbport "${VNC_PORT}" -forever -shared -nopw -localhost -noxdamage

--- a/src/app/login-api/logout/route.ts
+++ b/src/app/login-api/logout/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const res = NextResponse.json({ success: true });
+  res.cookies.set("clawbox_session", "", {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: 0,
+    secure: false,
+  });
+  return res;
+}

--- a/src/app/login-api/route.ts
+++ b/src/app/login-api/route.ts
@@ -28,14 +28,15 @@ function rateLimit(ip: string): boolean {
   return rec.count <= RATE_LIMIT_MAX;
 }
 
-function clientIP(req: Request): string {
+function clientIP(req: Request): string | null {
   return req.headers.get("x-forwarded-for")?.split(",")[0].trim()
     || req.headers.get("x-real-ip")
-    || "unknown";
+    || req.headers.get("cf-connecting-ip")
+    || null;
 }
 
 export async function POST(request: Request) {
-  const ip = clientIP(request);
+  const ip = clientIP(request) || "no-ip";
   if (!rateLimit(ip)) {
     return NextResponse.json({ error: "Too many attempts. Try again later." }, { status: 429 });
   }

--- a/src/app/login-api/route.ts
+++ b/src/app/login-api/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from "next/server";
+import { get } from "@/lib/config-store";
+import { verifyPassword, createSessionCookie, getOrCreateSecret } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+const VALID_DURATIONS = new Set([1200, 21600, 43200, 86400]);
+
+// Rate limiting
+const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
+const RATE_LIMIT_MAX = 10;
+const attempts = new Map<string, { count: number; first: number }>();
+
+function rateLimit(ip: string): boolean {
+  const now = Date.now();
+  const rec = attempts.get(ip);
+  if (!rec || now - rec.first > RATE_LIMIT_WINDOW_MS) {
+    // Prune stale entries periodically
+    if (attempts.size > 100) {
+      for (const [k, v] of attempts) {
+        if (now - v.first > RATE_LIMIT_WINDOW_MS) attempts.delete(k);
+      }
+    }
+    attempts.set(ip, { count: 1, first: now });
+    return true;
+  }
+  rec.count++;
+  return rec.count <= RATE_LIMIT_MAX;
+}
+
+function clientIP(req: Request): string {
+  return req.headers.get("x-forwarded-for")?.split(",")[0].trim()
+    || req.headers.get("x-real-ip")
+    || "unknown";
+}
+
+export async function POST(request: Request) {
+  const ip = clientIP(request);
+  if (!rateLimit(ip)) {
+    return NextResponse.json({ error: "Too many attempts. Try again later." }, { status: 429 });
+  }
+
+  // If password not configured, skip auth
+  const configured = await get("password_configured");
+  if (!configured) {
+    return NextResponse.json({ error: "Password not configured. Complete setup first." }, { status: 400 });
+  }
+
+  let body: { password?: string; duration?: number };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { password, duration } = body;
+  if (!password) {
+    return NextResponse.json({ error: "Password is required" }, { status: 400 });
+  }
+  if (!duration || !VALID_DURATIONS.has(duration)) {
+    return NextResponse.json({ error: "Invalid session duration" }, { status: 400 });
+  }
+
+  const valid = await verifyPassword(password);
+  if (!valid) {
+    return NextResponse.json({ error: "Incorrect password" }, { status: 401 });
+  }
+
+  // Reset rate limit on success
+  attempts.delete(ip);
+
+  const secret = await getOrCreateSecret();
+  const cookie = createSessionCookie(duration, secret);
+
+  const res = NextResponse.json({ success: true });
+  res.cookies.set("clawbox_session", cookie, {
+    httpOnly: true,
+    sameSite: "lax",
+    path: "/",
+    maxAge: duration,
+    secure: false, // HTTP on local network
+  });
+  return res;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -44,8 +44,9 @@ export default function LoginPage() {
       // Redirect to the original page or home (validate to prevent open redirect)
       const params = new URLSearchParams(window.location.search);
       const raw = params.get("redirect") || "/";
-      const redirect = raw.startsWith("/") && !raw.startsWith("//") && !raw.includes(":") ? raw : "/";
-      window.location.href = redirect;
+      const decoded = decodeURIComponent(raw);
+      const safe = decoded.startsWith("/") && !decoded.startsWith("//") && !decoded.includes(":") && !decoded.includes("\\");
+      window.location.href = safe ? decoded : "/";
     } catch {
       setError("Connection failed");
       setLoading(false);

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+
+const DURATION_OPTIONS = [
+  { value: 1200, label: "20 minutes" },
+  { value: 21600, label: "6 hours" },
+  { value: 43200, label: "12 hours" },
+  { value: 86400, label: "24 hours" },
+];
+
+export default function LoginPage() {
+  const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [duration, setDuration] = useState(43200);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!password.trim()) {
+      setError("Password is required");
+      return;
+    }
+
+    setLoading(true);
+    setError("");
+
+    try {
+      const res = await fetch("/login-api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password, duration }),
+      });
+      const data = await res.json();
+
+      if (!res.ok) {
+        setError(data.error || "Login failed");
+        setLoading(false);
+        return;
+      }
+
+      // Redirect to the original page or home (validate to prevent open redirect)
+      const params = new URLSearchParams(window.location.search);
+      const raw = params.get("redirect") || "/";
+      const redirect = raw.startsWith("/") && !raw.startsWith("//") && !raw.includes(":") ? raw : "/";
+      window.location.href = redirect;
+    } catch {
+      setError("Connection failed");
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: "var(--bg-deep)" }}>
+      <div className="w-full max-w-[380px]">
+        <div className="card-surface rounded-2xl p-8">
+          <div className="flex flex-col items-center gap-3 mb-6">
+            <Image
+              src="/clawbox-crab.png"
+              alt="ClawBox"
+              width={80}
+              height={80}
+              className="w-[80px] h-[80px] object-contain"
+              priority
+            />
+            <h1 className="text-xl font-bold font-display text-[var(--text-primary)]">
+              ClawBox
+            </h1>
+            <p className="text-sm text-[var(--text-muted)]">
+              Enter your password to continue
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+            <div>
+              <label
+                htmlFor="login-password"
+                className="block text-xs font-semibold text-[var(--text-secondary)] mb-1.5"
+              >
+                Password
+              </label>
+              <div className="relative">
+                <input
+                  id="login-password"
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="System password"
+                  autoFocus
+                  autoComplete="current-password"
+                  className="w-full px-3.5 py-2.5 pr-10 bg-[var(--bg-deep)] border border-gray-600 rounded-lg text-sm text-gray-200 outline-none focus:border-[var(--coral-bright)] transition-colors placeholder-gray-500"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-primary)] bg-transparent border-none cursor-pointer p-0.5"
+                >
+                  <span className="material-symbols-rounded" style={{ fontSize: 18 }}>
+                    {showPassword ? "visibility_off" : "visibility"}
+                  </span>
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label
+                htmlFor="login-duration"
+                className="block text-xs font-semibold text-[var(--text-secondary)] mb-1.5"
+              >
+                Stay logged in for
+              </label>
+              <select
+                id="login-duration"
+                value={duration}
+                onChange={(e) => setDuration(Number(e.target.value))}
+                className="w-full px-3.5 py-2.5 bg-[var(--bg-deep)] border border-gray-600 rounded-lg text-sm text-gray-200 outline-none focus:border-[var(--coral-bright)] transition-colors cursor-pointer appearance-none"
+                style={{
+                  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='%236b7280'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E")`,
+                  backgroundRepeat: "no-repeat",
+                  backgroundPosition: "right 12px center",
+                }}
+              >
+                {DURATION_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {error && (
+              <div className="px-3.5 py-2.5 rounded-lg text-xs bg-red-500/10 text-red-400 border border-red-500/20">
+                {error}
+              </div>
+            )}
+
+            <button
+              type="submit"
+              disabled={loading || !password.trim()}
+              className="w-full py-3 btn-gradient text-white rounded-lg text-sm font-semibold transition transform hover:scale-[1.02] shadow-lg shadow-[rgba(249,115,22,0.25)] disabled:opacity-50 disabled:hover:scale-100 cursor-pointer"
+            >
+              {loading ? "Logging in..." : "Log In"}
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,6 +124,7 @@ interface OpenWindow {
   y?: number;
   width?: number;
   height?: number;
+  meta?: Record<string, string>;
 }
 
 // Icon component for installed store apps — tries local cached icon first, then store URL
@@ -862,6 +863,27 @@ export default function ChromeDesktop() {
     return () => window.removeEventListener("popstate", handleBack);
   }, [launcherOpen, trayOpen, openWindows, closeWindow]);
 
+  // ─── Open file in VS Code from other apps (e.g. file manager) ───
+  const nextZIndexRef = useRef(nextZIndex);
+  nextZIndexRef.current = nextZIndex;
+
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { filePath?: string };
+      const fp = detail?.filePath;
+      if (!fp) return;
+      const windowId = `vscode-${Date.now()}`;
+      const z = nextZIndexRef.current;
+      setOpenWindows((prev) => [
+        ...prev,
+        { id: windowId, appId: "vscode", zIndex: z, minimized: false, meta: { filePath: fp } },
+      ]);
+      setNextZIndex(z + 1);
+    };
+    window.addEventListener("clawbox:open-in-vscode", handler);
+    return () => window.removeEventListener("clawbox:open-in-vscode", handler);
+  }, []);
+
   const updateWindowGeometry = useCallback((windowId: string, geo: { x: number; y: number; width: number; height: number }) => {
     setOpenWindows((prev) =>
       prev.map((w) => w.id === windowId ? { ...w, x: geo.x, y: geo.y, width: geo.width, height: geo.height } : w)
@@ -922,7 +944,7 @@ export default function ChromeDesktop() {
 
   const pinnedApps = getAllApps().filter((a) => isAppPinned(a.id));
 
-  const renderWindowContent = (appId: string) => {
+  const renderWindowContent = (appId: string, meta?: Record<string, string>) => {
     const allApps = getAllApps();
     const app = allApps.find((a) => a.id === appId);
     if (!app) return null;
@@ -981,7 +1003,7 @@ export default function ChromeDesktop() {
       case "vnc":
         return <VNCApp />;
       case "vscode":
-        return <VSCodeApp />;
+        return <VSCodeApp filePath={meta?.filePath} />;
       case "placeholder":
         return (
           <div className="h-full flex flex-col items-center justify-center gap-4 text-white/60">
@@ -1270,7 +1292,7 @@ export default function ChromeDesktop() {
 
       {/* Mascot - tapping toggles chat popup */}
       <Mascot frozen={chatOpen} onTap={(x?: number) => { if (x !== undefined) setMascotX(x); setChatOpen(prev => !prev); }} onPositionChange={chatOpen ? setMascotX : undefined} />
-      <ChatPopup isOpen={chatOpen} onClose={() => setChatOpen(false)} mascotX={mascotX} />
+      <ChatPopup isOpen={chatOpen} onClose={() => setChatOpen(false)} mascotX={mascotHidden ? 85 : mascotX} trayMode={mascotHidden} />
 
       {/* Windows — mobile: fullscreen, desktop: ChromeWindow */}
       {isMobile ? (
@@ -1314,7 +1336,7 @@ export default function ChromeDesktop() {
               </div>
               {/* Mobile window content */}
               <div className="flex-1 overflow-hidden">
-                {renderWindowContent(top.appId)}
+                {renderWindowContent(top.appId, top.meta)}
               </div>
             </div>
           );
@@ -1364,7 +1386,7 @@ export default function ChromeDesktop() {
               onGeometryChange={(geo) => updateWindowGeometry(window.id, geo)}
               minimized={window.minimized}
             >
-              {renderWindowContent(window.appId)}
+              {renderWindowContent(window.appId, window.meta)}
             </ChromeWindow>
           );
         })
@@ -1473,6 +1495,8 @@ export default function ChromeDesktop() {
           setOpenWindows(prev => prev.filter(w => w.appId !== appId));
         }}
         onShelfSettings={() => openApp("settings")}
+        onChatClick={() => setChatOpen(prev => !prev)}
+        showChatButton={mascotHidden}
         time={time}
       />
 

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { readConfig } from "@/lib/openclaw-config";
+
+export const dynamic = "force-dynamic";
+
+const PROVIDER_LABELS: Record<string, string> = {
+  anthropic: "Anthropic Claude",
+  openai: "OpenAI GPT",
+  google: "Google Gemini",
+  openrouter: "OpenRouter",
+  ollama: "Ollama Local",
+};
+
+export async function GET() {
+  try {
+    const config = await readConfig();
+
+    const profiles = config.auth?.profiles ?? {};
+    const model = config.agents?.defaults?.model?.primary ?? null;
+
+    // Find the first connected provider
+    const profileKeys = Object.keys(profiles);
+    let provider: string | null = null;
+    let mode: string | null = null;
+
+    if (profileKeys.length > 0) {
+      const first = profiles[profileKeys[0]];
+      provider = first?.provider ?? profileKeys[0].split(":")[0];
+      mode = first?.mode ?? null;
+    }
+
+    return NextResponse.json({
+      connected: !!provider,
+      provider,
+      providerLabel: provider ? (PROVIDER_LABELS[provider] ?? provider) : null,
+      mode,
+      model,
+    });
+  } catch {
+    return NextResponse.json({ connected: false, provider: null, providerLabel: null, mode: null, model: null });
+  }
+}

--- a/src/app/setup-api/browser/manage/route.ts
+++ b/src/app/setup-api/browser/manage/route.ts
@@ -5,57 +5,50 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
+import { readConfig } from "@/lib/openclaw-config";
 
 const exec = promisify(execFile);
 const CLAWBOX_USER = process.env.SUDO_USER || process.env.USER || "clawbox";
 const HOME = CLAWBOX_USER === "root" ? "/home/clawbox" : `/home/${CLAWBOX_USER}`;
-const OPENCLAW_HOME = process.env.OPENCLAW_HOME || path.join(HOME, ".openclaw");
-const OPENCLAW_CONFIG = path.join(OPENCLAW_HOME, "openclaw.json");
+const PROFILE_DIR = path.join(HOME, ".config", "clawbox-browser");
+const CDP_PORT = 18800;
 
-// Find openclaw binary
-function findOpenClaw(): string {
-  const existsSync = require("fs").existsSync;
-  const nodeDir = path.dirname(process.execPath);
-  const npmGlobal = path.join(HOME, ".npm-global", "bin", "openclaw");
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function findOpenClaw(): Promise<string> {
   const candidates = [
-    path.join(nodeDir, "openclaw"),
-    npmGlobal,
+    path.join(HOME, ".npm-global", "bin", "openclaw"),
+    path.join(path.dirname(process.execPath), "openclaw"),
     "/usr/local/bin/openclaw",
     "/usr/bin/openclaw",
   ];
-  const nvmDir = path.join(HOME, ".nvm", "versions", "node");
-  try {
-    const versions = require("fs").readdirSync(nvmDir) as string[];
-    for (const v of versions.sort().reverse()) {
-      candidates.push(path.join(nvmDir, v, "bin", "openclaw"));
-    }
-  } catch {}
   for (const p of candidates) {
-    if (existsSync(p)) return p;
+    try { await fs.access(p); return p; } catch {}
   }
   return "openclaw";
 }
 
-// Check if Chromium is installed
 async function checkChromium(): Promise<{ installed: boolean; path?: string; version?: string }> {
+  // Check all candidates in parallel
   const candidates = ["chromium-browser", "chromium", "google-chrome", "google-chrome-stable"];
-  for (const bin of candidates) {
+  const results = await Promise.all(candidates.map(async (bin) => {
     try {
-      const { stdout } = await exec("which", [bin], { timeout: 5000 });
-      const chromPath = stdout.trim();
-      if (chromPath) {
-        try {
-          const { stdout: ver } = await exec(chromPath, ["--version"], { timeout: 5000 });
-          return { installed: true, path: chromPath, version: ver.trim() };
-        } catch {
-          return { installed: true, path: chromPath };
-        }
-      }
-    } catch {}
+      const { stdout } = await exec("which", [bin], { timeout: 3000 });
+      return stdout.trim() || null;
+    } catch { return null; }
+  }));
+  const found = results.find(p => p);
+  if (found) {
+    try {
+      const { stdout: ver } = await exec(found, ["--version"], { timeout: 3000 });
+      return { installed: true, path: found, version: ver.trim() };
+    } catch {
+      return { installed: true, path: found };
+    }
   }
-  // Check snap chromium
+  // Check snap
   try {
-    const { stdout } = await exec("snap", ["list", "chromium"], { timeout: 5000 });
+    const { stdout } = await exec("snap", ["list", "chromium"], { timeout: 3000 });
     if (stdout.includes("chromium")) {
       return { installed: true, path: "/snap/bin/chromium", version: stdout.split("\n")[1]?.trim() };
     }
@@ -63,48 +56,65 @@ async function checkChromium(): Promise<{ installed: boolean; path?: string; ver
   return { installed: false };
 }
 
-// Check if browser is currently running
-async function isBrowserRunning(): Promise<{ running: boolean; pid?: number }> {
+async function cleanBrowserLocks() {
+  await Promise.all(
+    ["SingletonLock", "SingletonSocket", "SingletonCookie"].map(f =>
+      fs.unlink(path.join(PROFILE_DIR, f)).catch(() => {})
+    )
+  );
+}
+
+/** Check if browser is running and CDP is accessible */
+async function getBrowserStatus(): Promise<{ running: boolean; pid?: number; cdpReady: boolean }> {
+  // Check CDP endpoint first (most reliable)
   try {
-    const { stdout } = await exec("pgrep", ["-f", "chrom.*--user-data-dir.*clawbox-browser"], { timeout: 5000 });
-    const pids = stdout.trim().split("\n").map(s => parseInt(s)).filter(n => !isNaN(n) && n > 0);
-    if (pids.length > 0) return { running: true, pid: pids[0] };
+    const res = await fetch(`http://127.0.0.1:${CDP_PORT}/json/version`, { signal: AbortSignal.timeout(2000) });
+    if (res.ok) {
+      // Find the main process PID
+      try {
+        const { stdout } = await exec("pgrep", ["-f", `remote-debugging-port=${CDP_PORT}`], { timeout: 3000 });
+        const pid = parseInt(stdout.trim().split("\n")[0]);
+        return { running: true, pid: isNaN(pid) ? undefined : pid, cdpReady: true };
+      } catch {
+        return { running: true, cdpReady: true };
+      }
+    }
   } catch {}
-  return { running: false };
-}
-
-// Read OpenClaw config
-async function readOpenClawConfig(): Promise<Record<string, unknown>> {
+  // Fallback: check process
   try {
-    const raw = await fs.readFile(OPENCLAW_CONFIG, "utf-8");
-    return JSON.parse(raw);
-  } catch {
-    return {};
-  }
+    const { stdout } = await exec("pgrep", ["-f", "chrom.*--user-data-dir.*clawbox-browser"], { timeout: 3000 });
+    const pids = stdout.trim().split("\n").map(s => parseInt(s)).filter(n => !isNaN(n) && n > 0);
+    if (pids.length > 0) return { running: true, pid: pids[0], cdpReady: false };
+  } catch {}
+  return { running: false, cdpReady: false };
 }
 
+const readOpenClawConfig = readConfig;
+
+// ─── GET — status ────────────────────────────────────────────────────────────
 
 export async function GET() {
   try {
     const [chromium, browser, config] = await Promise.all([
       checkChromium(),
-      isBrowserRunning(),
+      getBrowserStatus(),
       readOpenClawConfig(),
     ]);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const computerUse = (config as any)?.agents?.defaults?.tools?.computer_use;
-    const enabled = !!computerUse?.enabled;
+    const enabled = config.tools?.profile === "full";
 
     return NextResponse.json({
       chromium,
       browser,
       enabled,
+      cdpPort: CDP_PORT,
     });
   } catch (err) {
     return NextResponse.json({ error: err instanceof Error ? err.message : "Status check failed" }, { status: 500 });
   }
 }
+
+// ─── POST — actions ──────────────────────────────────────────────────────────
 
 export async function POST(req: Request) {
   try {
@@ -112,7 +122,6 @@ export async function POST(req: Request) {
 
     switch (action) {
       case "install-chromium": {
-        // Try apt first, then snap
         try {
           await exec("sudo", ["apt-get", "update", "-qq"], { timeout: 30000 });
           await exec("sudo", ["apt-get", "install", "-y", "-qq", "chromium-browser"], { timeout: 120000 });
@@ -120,7 +129,6 @@ export async function POST(req: Request) {
           try {
             await exec("sudo", ["snap", "install", "chromium"], { timeout: 120000 });
           } catch (snapErr) {
-            // Try chromium package name (Debian/Ubuntu variations)
             try {
               await exec("sudo", ["apt-get", "install", "-y", "-qq", "chromium"], { timeout: 120000 });
             } catch {
@@ -128,148 +136,120 @@ export async function POST(req: Request) {
             }
           }
         }
-        const status = await checkChromium();
-        return NextResponse.json({ ok: true, chromium: status });
+        return NextResponse.json({ ok: true, chromium: await checkChromium() });
       }
 
       case "enable": {
-        // Configure OpenClaw with computer-use browser settings
         const chromium = await checkChromium();
         if (!chromium.installed) {
           return NextResponse.json({ error: "Chromium not installed" }, { status: 400 });
         }
 
-        const profileDir = path.join(HOME, ".config", "clawbox-browser");
-        await fs.mkdir(profileDir, { recursive: true });
+        await fs.mkdir(PROFILE_DIR, { recursive: true });
 
-        // Enable computer_use via CLI (avoids writing unrecognized keys to config)
-        const openclawBin = findOpenClaw();
+        const openclawBin = await findOpenClaw();
         try {
-          await exec(openclawBin, [
-            "config", "set", "agents.defaults.tools.computer_use.enabled", "true", "--json",
-          ], { timeout: 10000 });
-        } catch {}
+          await Promise.all([
+            exec(openclawBin, ["config", "set", "tools.profile", "full"], { timeout: 10000 }),
+            exec(openclawBin, ["config", "set", "tools.web.search.enabled", "true", "--json"], { timeout: 10000 }),
+          ]);
+        } catch (err) {
+          console.error("[browser] Failed to set tools config:", err);
+        }
 
-        return NextResponse.json({ ok: true, enabled: true, profileDir });
+        let enableRestartOk = true;
+        try {
+          await exec("sudo", ["systemctl", "restart", "clawbox-gateway"], { timeout: 15000 });
+        } catch (err) {
+          console.error("[browser] Gateway restart failed:", err);
+          enableRestartOk = false;
+        }
+
+        return NextResponse.json({ ok: true, enabled: true, profileDir: PROFILE_DIR, gatewayRestarted: enableRestartOk });
       }
 
       case "disable": {
-        const openclawBin = findOpenClaw();
+        const openclawBin = await findOpenClaw();
         try {
-          await exec(openclawBin, [
-            "config", "set", "agents.defaults.tools.computer_use.enabled", "false", "--json",
-          ], { timeout: 10000 });
-        } catch {}
-        return NextResponse.json({ ok: true, enabled: false });
+          await exec(openclawBin, ["config", "set", "tools.profile", "coding"], { timeout: 10000 });
+        } catch (err) {
+          console.error("[browser] Failed to unset tools config:", err);
+        }
+
+        let disableRestartOk = true;
+        try {
+          await exec("sudo", ["systemctl", "restart", "clawbox-gateway"], { timeout: 15000 });
+        } catch (err) {
+          console.error("[browser] Gateway restart failed:", err);
+          disableRestartOk = false;
+        }
+
+        return NextResponse.json({ ok: true, enabled: false, gatewayRestarted: disableRestartOk });
       }
 
       case "open-browser": {
+        // Check if already running via CDP
+        const existing = await getBrowserStatus();
+        if (existing.cdpReady) {
+          return NextResponse.json({ ok: true, alreadyRunning: true, pid: existing.pid, cdpPort: CDP_PORT });
+        }
+
         const chromium = await checkChromium();
         if (!chromium.installed || !chromium.path) {
           return NextResponse.json({ error: "Chromium not installed" }, { status: 400 });
         }
 
-        // Check if already running
-        const running = await isBrowserRunning();
-        if (running.running) {
-          return NextResponse.json({ ok: true, alreadyRunning: true, pid: running.pid });
-        }
+        await fs.mkdir(PROFILE_DIR, { recursive: true });
 
-        const profileDir = path.join(HOME, ".config", "clawbox-browser");
-        await fs.mkdir(profileDir, { recursive: true });
-
-        // Detect active X display dynamically
-        let display = process.env.DISPLAY || ":0";
-        try {
-          const { stdout: xdpy } = await exec("bash", ["-c",
-            "for d in 1 0 2; do if DISPLAY=\":$d\" xdpyinfo >/dev/null 2>&1; then echo \":$d\"; exit; fi; done; echo ':0'"
-          ], { timeout: 3000 });
-          display = xdpy.trim();
-        } catch {}
-
-        // Launch browser
-        const isRoot = process.getuid?.() === 0;
-        const args = [
-          `--user-data-dir=${profileDir}`,
-          "--no-first-run",
-          "--no-default-browser-check",
-          "--start-maximized",
-          "--disable-gpu",
-          "--disable-gpu-compositing",
-          "--disable-gpu-sandbox",
-          "--enable-features=UseOzonePlatform",
-          "--ozone-platform=x11",
-          "--in-process-gpu",
-          ...(isRoot ? ["--no-sandbox"] : []),
-          "https://www.google.com",
-        ];
+        await cleanBrowserLocks();
 
         try {
-          // Find Xauthority for the display
-          let xauth = "/run/user/1000/gdm/Xauthority";
-          try {
-            const { stdout: xa } = await exec("bash", ["-c",
-              "ps aux | grep '[X]org' | grep -oP '\\-auth \\K\\S+' | head -1"
-            ], { timeout: 3000 });
-            if (xa.trim()) xauth = xa.trim();
-          } catch {}
-
-          // Launch browser with correct DISPLAY and XAUTHORITY
-          // Use bash -c so the snap wrapper script works correctly
-          const launchCmd = `${chromium.path} ${args.map(a => `'${a}'`).join(" ")}`;
-          console.log(`[browser] Launching: bash -c ${launchCmd}`);
-          console.log(`[browser] DISPLAY=${display} XAUTHORITY=${xauth} USER=${CLAWBOX_USER}`);
-          const child = require("child_process").spawn("bash", ["-c", launchCmd], {
-            detached: true,
-            stdio: ["ignore", "pipe", "pipe"],
-            env: {
-              ...process.env,
-              DISPLAY: display,
-              XAUTHORITY: xauth,
-              DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1000/bus",
-              HOME,
-            },
+          console.log(`[browser] Starting clawbox-browser.service (CDP port ${CDP_PORT})`);
+          // Start dedicated service — runs as root, drops to clawbox via runuser
+          await exec("sudo", [
+            "/usr/bin/systemctl", "start", "clawbox-browser.service",
+          ], { timeout: 5000 }).catch((err) => {
+            console.error("[browser] systemctl start failed:", err);
           });
 
-          child.stderr?.on("data", (d: Buffer) => {
-            console.error(`[browser-stderr] ${d.toString().trim()}`);
-          });
-          child.on("exit", (code: number) => {
-            console.log(`[browser] Process exited with code ${code}`);
-          });
-          child.unref();
-
-          // Wait briefly and check if it started
-          await new Promise(r => setTimeout(r, 3000));
-          const status = await isBrowserRunning();
-          const ok = status.running;
-          if (!ok) {
-            return NextResponse.json({ error: "Browser process exited immediately. Check server logs." }, { status: 500 });
+          // Wait for CDP to become ready
+          for (let i = 0; i < 10; i++) {
+            await new Promise(r => setTimeout(r, 1000));
+            try {
+              const res = await fetch(`http://127.0.0.1:${CDP_PORT}/json/version`, { signal: AbortSignal.timeout(1000) });
+              if (res.ok) {
+                const version = await res.json();
+                return NextResponse.json({
+                  ok: true,
+                  cdpPort: CDP_PORT,
+                  cdpReady: true,
+                  browser: version.Browser || version.product,
+                });
+              }
+            } catch {}
           }
-          return NextResponse.json({ ok: true, pid: status.pid || child.pid });
+
+          // CDP didn't respond but process might be running
+          const status = await getBrowserStatus();
+          if (status.running) {
+            return NextResponse.json({ ok: true, pid: status.pid, cdpPort: CDP_PORT, cdpReady: false });
+          }
+          return NextResponse.json({ error: "Browser failed to start. Check /tmp/clawbox-browser.log" }, { status: 500 });
         } catch (err) {
           return NextResponse.json({ error: `Failed to launch browser: ${err instanceof Error ? err.message : "unknown"}` }, { status: 500 });
         }
       }
 
       case "close-browser": {
-        const running = await isBrowserRunning();
-        if (!running.running || !running.pid) {
-          return NextResponse.json({ ok: true, wasRunning: false });
-        }
+        try {
+          await exec("sudo", ["/usr/bin/systemctl", "stop", "clawbox-browser.service"], { timeout: 10000 });
+        } catch {}
         try {
           await exec("pkill", ["-f", "chrom.*--user-data-dir.*clawbox-browser"], { timeout: 5000 });
         } catch {}
-        // Wait for processes to die, then clean up stale lock files
-        // so the next launch doesn't think an instance is already running
         await new Promise(r => setTimeout(r, 1000));
-        const profileDir = path.join(HOME, ".config", "clawbox-browser");
-        await Promise.all(
-          ["SingletonLock", "SingletonSocket", "SingletonCookie"].map(f =>
-            fs.unlink(path.join(profileDir, f)).catch(() => {})
-          )
-        );
-        return NextResponse.json({ ok: true, wasRunning: true });
+        await cleanBrowserLocks();
+        return NextResponse.json({ ok: true });
       }
 
       default:

--- a/src/app/setup-api/files/[...path]/route.ts
+++ b/src/app/setup-api/files/[...path]/route.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 export const dynamic = "force-dynamic";
 
-const BASE_DIR = process.env.CLAWBOX_ROOT ?? path.join(process.cwd(), "local-data");
+const BASE_DIR = process.env.FILES_ROOT ?? (process.env.HOME || "/home/clawbox");
 
 function safePath(segments: string[]): string | null {
   const rel = segments.join("/");

--- a/src/app/setup-api/files/route.ts
+++ b/src/app/setup-api/files/route.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 export const dynamic = "force-dynamic";
 
-const BASE_DIR = process.env.CLAWBOX_ROOT ?? path.join(process.cwd(), "local-data");
+const BASE_DIR = process.env.FILES_ROOT ?? (process.env.HOME || "/home/clawbox");
 
 function safePath(rel: string): string | null {
   const resolved = path.resolve(BASE_DIR, rel);
@@ -13,7 +13,14 @@ function safePath(rel: string): string | null {
 }
 
 function ensureBaseDir() {
-  if (!fs.existsSync(BASE_DIR)) fs.mkdirSync(BASE_DIR, { recursive: true });
+  try { if (!fs.existsSync(BASE_DIR)) fs.mkdirSync(BASE_DIR, { recursive: true }); } catch { /* read-only fs */ }
+  // Ensure standard home subdirectories exist (skip when FILES_ROOT is explicitly set, e.g. tests)
+  if (!process.env.FILES_ROOT) {
+    for (const sub of ["Documents", "Downloads", "Desktop"]) {
+      const p = path.join(BASE_DIR, sub);
+      try { if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true }); } catch { /* read-only fs */ }
+    }
+  }
 }
 
 // GET /setup-api/files?dir=relative/path
@@ -35,7 +42,7 @@ export async function GET(req: NextRequest) {
   const stat = fs.statSync(abs);
   if (!stat.isDirectory()) return NextResponse.json({ error: "Not a directory" }, { status: 400 });
 
-  const entries = fs.readdirSync(abs);
+  const entries = fs.readdirSync(abs).filter((name) => !name.startsWith("."));
   const files = entries
     .map((name) => {
       try {
@@ -53,7 +60,7 @@ export async function GET(req: NextRequest) {
     })
     .filter(Boolean);
 
-  return NextResponse.json({ files });
+  return NextResponse.json({ files, baseDir: BASE_DIR });
 }
 
 // POST /setup-api/files?dir=relative/path

--- a/src/app/setup-api/files/route.ts
+++ b/src/app/setup-api/files/route.ts
@@ -60,7 +60,7 @@ export async function GET(req: NextRequest) {
     })
     .filter(Boolean);
 
-  return NextResponse.json({ files, baseDir: BASE_DIR });
+  return NextResponse.json({ files });
 }
 
 // POST /setup-api/files?dir=relative/path
@@ -98,6 +98,13 @@ export async function POST(req: NextRequest) {
     if (fs.existsSync(newDir)) return NextResponse.json({ error: "Already exists" }, { status: 409 });
     fs.mkdirSync(newDir, { recursive: true });
     return NextResponse.json({ ok: true });
+  }
+
+  if (body.action === "resolve") {
+    if (!body.filePath) return NextResponse.json({ error: "filePath required" }, { status: 400 });
+    const resolved = safePath(body.filePath);
+    if (!resolved) return NextResponse.json({ error: "Invalid path" }, { status: 400 });
+    return NextResponse.json({ absPath: resolved });
   }
 
   return NextResponse.json({ error: "Unknown action" }, { status: 400 });

--- a/src/components/BrowserApp.tsx
+++ b/src/components/BrowserApp.tsx
@@ -13,8 +13,9 @@ const BRAND_ORANGE_LIGHT = "#ff8b1a";
 
 interface BrowserStatus {
   chromium: { installed: boolean; path?: string; version?: string };
-  browser: { running: boolean; pid?: number };
+  browser: { running: boolean; pid?: number; cdpReady?: boolean };
   enabled: boolean;
+  cdpPort?: number;
 }
 
 interface BrowserAppProps {
@@ -29,15 +30,23 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  const actionErrorRef = useRef(false);
+  const lastStatusJson = useRef("");
+
   const fetchStatus = useCallback(async () => {
     try {
       const res = await fetch("/setup-api/browser/manage");
       if (!res.ok) throw new Error("Failed to fetch status");
       const data: BrowserStatus = await res.json();
-      setStatus(data);
-      setError(null);
+      // Only update state if data actually changed to avoid unnecessary re-renders
+      const json = JSON.stringify(data);
+      if (json !== lastStatusJson.current) {
+        lastStatusJson.current = json;
+        setStatus(data);
+      }
+      if (!actionErrorRef.current) setError(null);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to connect");
+      if (!actionErrorRef.current) setError(err instanceof Error ? err.message : "Failed to connect");
     } finally {
       setLoading(false);
     }
@@ -53,6 +62,7 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
     setActionLoading(loadingLabel);
     setError(null);
     setSuccessMsg(null);
+    actionErrorRef.current = false;
     try {
       const res = await fetch("/setup-api/browser/manage", {
         method: "POST",
@@ -67,6 +77,7 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
       }
       await fetchStatus();
     } catch (err) {
+      actionErrorRef.current = true;
       setError(err instanceof Error ? err.message : "Action failed");
     } finally {
       setActionLoading(null);
@@ -183,10 +194,14 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
                   : "Connect the browser to OpenClaw so your AI assistant can use it for web browsing, research, and automation."}
               </p>
               {isEnabled && (
-                <div className="mt-2 flex items-center gap-4">
+                <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1">
                   <div className="flex items-center gap-1.5">
                     <span className="w-2 h-2 rounded-full" style={{ backgroundColor: BRAND_ORANGE }} />
-                    <span className="text-xs text-white/40">computer_use tool enabled</span>
+                    <span className="text-xs text-white/40">tools profile: full</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className="material-symbols-rounded text-white/30" style={{ fontSize: 14 }}>bug_report</span>
+                    <span className="text-xs text-white/30 font-mono">CDP port {status?.cdpPort ?? 18800}</span>
                   </div>
                   <div className="flex items-center gap-1.5">
                     <span className="material-symbols-rounded text-white/30" style={{ fontSize: 14 }}>folder</span>
@@ -232,10 +247,18 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
                   ? "Chromium is running on the desktop. OpenClaw can interact with it in real time."
                   : "Launch a real Chromium window on the desktop that OpenClaw can control."}
               </p>
-              {browserRunning && status?.browser?.pid && (
-                <div className="mt-2 flex items-center gap-1.5">
-                  <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
-                  <span className="text-xs text-white/40">Running (PID {status.browser.pid})</span>
+              {browserRunning && (
+                <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1">
+                  <div className="flex items-center gap-1.5">
+                    <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+                    <span className="text-xs text-white/40">PID {status?.browser?.pid ?? "?"}</span>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span className={`w-2 h-2 rounded-full ${status?.browser?.cdpReady ? "bg-green-400" : "bg-yellow-400"}`} />
+                    <span className="text-xs text-white/40 font-mono">
+                      CDP :{status?.cdpPort ?? 18800} {status?.browser?.cdpReady ? "ready" : "starting..."}
+                    </span>
+                  </div>
                 </div>
               )}
             </div>
@@ -303,11 +326,11 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
             </div>
             <div className="flex gap-3">
               <span className="material-symbols-rounded text-white/30 shrink-0" style={{ fontSize: 18 }}>link</span>
-              <p className="text-xs text-white/50"><span className="text-white/70">Enable</span> — Configures OpenClaw&apos;s computer_use tool to control the browser. Your AI can navigate, click, type, and read pages.</p>
+              <p className="text-xs text-white/50"><span className="text-white/70">Enable</span> — Sets OpenClaw tools profile to &quot;full&quot; for browser control via the built-in browser tool.</p>
             </div>
             <div className="flex gap-3">
               <span className="material-symbols-rounded text-white/30 shrink-0" style={{ fontSize: 18 }}>desktop_windows</span>
-              <p className="text-xs text-white/50"><span className="text-white/70">Open/Close</span> — Launches or stops the real Chromium window on your desktop. The browser keeps its profile between sessions.</p>
+              <p className="text-xs text-white/50"><span className="text-white/70">Open Browser</span> — Launches Chromium with remote debugging (CDP port {status?.cdpPort ?? 18800}). OpenClaw connects via <code className="text-white/60">ws://127.0.0.1:{status?.cdpPort ?? 18800}</code> to navigate, click, type, and read pages. Profile persists logins and cookies.</p>
             </div>
           </div>
         </div>

--- a/src/components/BrowserApp.tsx
+++ b/src/components/BrowserApp.tsx
@@ -264,23 +264,36 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
             </div>
             <div className="flex gap-2 shrink-0">
               {browserRunning ? (
-                <button
-                  onClick={() => doAction("close-browser", "Closing...", "Browser closed")}
-                  disabled={!!actionLoading}
-                  className="px-4 py-1.5 rounded-lg text-xs font-medium bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors cursor-pointer disabled:opacity-50"
-                >
-                  {actionLoading === "Closing..." ? (
-                    <span className="flex items-center gap-1.5">
-                      <span className="material-symbols-rounded animate-spin" style={{ fontSize: 14 }}>progress_activity</span>
-                      Closing...
-                    </span>
-                  ) : (
-                    <span className="flex items-center gap-1.5">
-                      <span className="material-symbols-rounded" style={{ fontSize: 14 }}>close</span>
-                      Close Browser
-                    </span>
+                <>
+                  {onOpenApp && (
+                    <button
+                      onClick={() => onOpenApp("vnc")}
+                      className="px-3 py-1.5 rounded-lg text-xs font-medium text-white/70 bg-white/10 hover:bg-white/15 transition-colors cursor-pointer"
+                    >
+                      <span className="flex items-center gap-1.5">
+                        <span className="material-symbols-rounded" style={{ fontSize: 14 }}>desktop_windows</span>
+                        Preview
+                      </span>
+                    </button>
                   )}
-                </button>
+                  <button
+                    onClick={() => doAction("close-browser", "Closing...", "Browser closed")}
+                    disabled={!!actionLoading}
+                    className="px-4 py-1.5 rounded-lg text-xs font-medium bg-red-500/10 text-red-400 hover:bg-red-500/20 transition-colors cursor-pointer disabled:opacity-50"
+                  >
+                    {actionLoading === "Closing..." ? (
+                      <span className="flex items-center gap-1.5">
+                        <span className="material-symbols-rounded animate-spin" style={{ fontSize: 14 }}>progress_activity</span>
+                        Closing...
+                      </span>
+                    ) : (
+                      <span className="flex items-center gap-1.5">
+                        <span className="material-symbols-rounded" style={{ fontSize: 14 }}>close</span>
+                        Close Browser
+                      </span>
+                    )}
+                  </button>
+                </>
               ) : (
                 <button
                   onClick={() => doAction("open-browser", "Opening...", "Browser launched")}
@@ -301,36 +314,6 @@ export default function BrowserApp({ onOpenApp }: BrowserAppProps) {
                   )}
                 </button>
               )}
-              {onOpenApp && (
-                <button
-                  onClick={() => onOpenApp("vnc")}
-                  className="px-3 py-1.5 rounded-lg text-xs font-medium text-white/70 bg-white/10 hover:bg-white/15 transition-colors cursor-pointer"
-                >
-                  <span className="flex items-center gap-1.5">
-                    <span className="material-symbols-rounded" style={{ fontSize: 14 }}>desktop_windows</span>
-                    Preview
-                  </span>
-                </button>
-              )}
-            </div>
-          </div>
-        </div>
-
-        {/* Info card */}
-        <div className="rounded-xl border border-white/5 bg-white/[0.02] p-4">
-          <h3 className="text-xs font-semibold text-white/40 uppercase tracking-wider mb-3">How it works</h3>
-          <div className="space-y-3">
-            <div className="flex gap-3">
-              <span className="material-symbols-rounded text-white/30 shrink-0" style={{ fontSize: 18 }}>download</span>
-              <p className="text-xs text-white/50"><span className="text-white/70">Install</span> — Sets up Chromium with a dedicated ClawBox profile for persistent sessions and logins.</p>
-            </div>
-            <div className="flex gap-3">
-              <span className="material-symbols-rounded text-white/30 shrink-0" style={{ fontSize: 18 }}>link</span>
-              <p className="text-xs text-white/50"><span className="text-white/70">Enable</span> — Sets OpenClaw tools profile to &quot;full&quot; for browser control via the built-in browser tool.</p>
-            </div>
-            <div className="flex gap-3">
-              <span className="material-symbols-rounded text-white/30 shrink-0" style={{ fontSize: 18 }}>desktop_windows</span>
-              <p className="text-xs text-white/50"><span className="text-white/70">Open Browser</span> — Launches Chromium with remote debugging (CDP port {status?.cdpPort ?? 18800}). OpenClaw connects via <code className="text-white/60">ws://127.0.0.1:{status?.cdpPort ?? 18800}</code> to navigate, click, type, and read pages. Profile persists logins and cookies.</p>
             </div>
           </div>
         </div>

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -11,8 +11,6 @@ import * as kv from '@/lib/client-kv'
 const MASCOT_LINES_KEY = 'clawbox-mascot-convo-lines'
 const MAX_RETRIES = 8
 const RETRY_DELAY = 3000
-let snippetFlushTimer: ReturnType<typeof setTimeout> | null = null
-
 function saveMascotSnippet(text: string) {
   if (!text || text.length < 10) return
   const sentences = text
@@ -24,7 +22,6 @@ function saveMascotSnippet(text: string) {
     .filter(s => !s.includes('```') && !s.includes('http') && !s.includes('**'))
   if (sentences.length === 0) return
   const picks = sentences.slice(0, 2)
-  // In-memory merge + debounced flush (avoids GET+POST per message)
   const existing = kv.getJSON<{ lines: string[]; date: string }>(MASCOT_LINES_KEY) || { lines: [], date: '' }
   const today = new Date().toISOString().slice(0, 10)
   if (existing.date !== today) { existing.lines = []; existing.date = today }
@@ -35,9 +32,6 @@ function saveMascotSnippet(text: string) {
   if (!changed) return
   if (existing.lines.length > 50) existing.lines = existing.lines.slice(-50)
   kv.setJSON(MASCOT_LINES_KEY, existing)
-  // Debounce: only flush to server after 5s of quiet
-  if (snippetFlushTimer) clearTimeout(snippetFlushTimer)
-  snippetFlushTimer = setTimeout(() => { snippetFlushTimer = null }, 5000)
 }
 
 interface ChatPopupProps {
@@ -47,6 +41,7 @@ interface ChatPopupProps {
   onThinkingChange?: (thinking: boolean) => void
   mascotX?: number
   mobile?: boolean
+  trayMode?: boolean
 }
 
 interface ChatMessage {
@@ -120,7 +115,7 @@ function uuid(): string {
 
 const DEFAULT_SIZE = { w: 400, h: 500 }
 
-function ChatPopup({ isOpen, onClose, onOpenFull, onThinkingChange, mascotX, mobile = false }: ChatPopupProps) {
+function ChatPopup({ isOpen, onClose, onOpenFull, onThinkingChange, mascotX, mobile = false, trayMode = false }: ChatPopupProps) {
   const [visible, setVisible] = useState(false)
   const [status, setStatus] = useState<'connecting' | 'connected' | 'error'>('connecting')
   const [messages, setMessages] = useState<ChatMessage[]>([])
@@ -549,7 +544,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onThinkingChange, mascotX, mob
     ? { left: 0, top: 0, right: 0, bottom: 220 }
     : pos
       ? { left: pos.x, top: pos.y, bottom: 'auto' }
-      : { left: defaultLeft, bottom: 170 }
+      : trayMode
+        ? { right: 8, bottom: 52 }
+        : { left: defaultLeft, bottom: 170 }
 
   return (
     <div

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -545,7 +545,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onThinkingChange, mascotX, mob
     : pos
       ? { left: pos.x, top: pos.y, bottom: 'auto' }
       : trayMode
-        ? { right: 8, bottom: 52 }
+        ? { right: 8, bottom: 65 }
         : { left: defaultLeft, bottom: 170 }
 
   return (

--- a/src/components/ChromeShelf.tsx
+++ b/src/components/ChromeShelf.tsx
@@ -23,6 +23,8 @@ interface ChromeShelfProps {
   onCloseApp?: (id: string) => void;
   onShelfSettings?: () => void;
   onPowerClick?: () => void;
+  onChatClick?: () => void;
+  showChatButton?: boolean;
   time: string;
 }
 
@@ -37,6 +39,8 @@ export default function ChromeShelf({
   onCloseApp,
   onShelfSettings,
   onPowerClick,
+  onChatClick,
+  showChatButton,
   time,
 }: ChromeShelfProps) {
   const [ctxMenu, setCtxMenu] = useState<{ x: number; y: number; app: ShelfApp } | null>(null);
@@ -192,6 +196,16 @@ export default function ChromeShelf({
 
         {/* Right side: system tray */}
         <div className="absolute right-2 flex items-center gap-1">
+          {showChatButton && (
+            <button
+              onClick={onChatClick}
+              className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+              title="Chat"
+              aria-label="Chat"
+            >
+              <span className="material-symbols-rounded text-[#f97316]" style={{ fontSize: 20 }}>chat_bubble</span>
+            </button>
+          )}
           <button
             onClick={onTrayClick}
             className="flex items-center h-10 px-3 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"

--- a/src/components/FilesApp.tsx
+++ b/src/components/FilesApp.tsx
@@ -127,7 +127,6 @@ export default function FilesApp() {
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(() => typeof window !== "undefined" ? window.innerWidth >= 768 : true);
   const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
-  const [baseDir, setBaseDir] = useState("/home/clawbox");
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dropZoneRef = useRef<HTMLDivElement>(null);
@@ -143,7 +142,6 @@ export default function FilesApp() {
       const res = await fetch(`/setup-api/files?dir=${encodeURIComponent(dir)}`);
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Failed to load");
-      if (data.baseDir) setBaseDir(data.baseDir);
       const sorted = [...(data.files as FileEntry[])].sort((a, b) => {
         if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
         return a.name.localeCompare(b.name);
@@ -278,10 +276,19 @@ export default function FilesApp() {
 
   // ─── Open in VS Code ───────────────────────────────────────────────────────
 
-  const openInVSCode = (entry: FileEntry) => {
-    const sep = baseDir.endsWith("/") ? "" : "/";
-    const absPath = `${baseDir}${sep}${currentPath ? currentPath + "/" : ""}${entry.name}`;
-    window.dispatchEvent(new CustomEvent("clawbox:open-in-vscode", { detail: { filePath: absPath } }));
+  const openInVSCode = async (entry: FileEntry) => {
+    const filePath = currentPath ? `${currentPath}/${entry.name}` : entry.name;
+    try {
+      const res = await fetch("/setup-api/files", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "resolve", filePath }),
+      });
+      const data = await res.json();
+      if (data.absPath) {
+        window.dispatchEvent(new CustomEvent("clawbox:open-in-vscode", { detail: { filePath: data.absPath } }));
+      }
+    } catch { /* resolve failed */ }
   };
 
   // ─── Context menu ──────────────────────────────────────────────────────────

--- a/src/components/FilesApp.tsx
+++ b/src/components/FilesApp.tsx
@@ -19,13 +19,19 @@ interface DialogState {
   value?: string;
 }
 
+type ContextMenuState = {
+  entry: FileEntry;
+  x: number;
+  y: number;
+} | null;
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const FAVORITES = [
-  { label: "Home", icon: "🏠", path: "" },
-  { label: "Documents", icon: "📄", path: "Documents" },
-  { label: "Downloads", icon: "⬇️", path: "Downloads" },
-  { label: "Desktop", icon: "🖥️", path: "Desktop" },
+  { label: "Home", icon: "home", path: "" },
+  { label: "Documents", icon: "description", path: "Documents" },
+  { label: "Downloads", icon: "download", path: "Downloads" },
+  { label: "Desktop", icon: "desktop_windows", path: "Desktop" },
 ];
 
 function formatSize(bytes: number | null): string {
@@ -50,21 +56,61 @@ function fileExtension(name: string): string {
   return dot !== -1 ? name.slice(dot + 1).toLowerCase() : "";
 }
 
-function FileIcon({ entry, large = false }: { entry: FileEntry; large?: boolean }) {
-  const size = large ? "text-4xl" : "text-xl";
-  if (entry.type === "directory") return <span className={size}>📁</span>;
-  const ext = fileExtension(entry.name);
-  const map: Record<string, string> = {
-    pdf: "📕", doc: "📘", docx: "📘", xls: "📗", xlsx: "📗",
-    ppt: "📙", pptx: "📙", txt: "📝", md: "📝", csv: "📊",
-    jpg: "🖼️", jpeg: "🖼️", png: "🖼️", gif: "🖼️", svg: "🖼️", webp: "🖼️",
-    mp4: "🎬", mov: "🎬", avi: "🎬", mkv: "🎬",
-    mp3: "🎵", wav: "🎵", flac: "🎵",
-    zip: "📦", tar: "📦", gz: "📦", rar: "📦",
-    js: "📜", ts: "📜", py: "🐍", json: "🔧", yaml: "🔧", yml: "🔧",
-    sh: "⚙️", bash: "⚙️",
+function fileIcon(name: string, type: "file" | "directory"): { icon: string; color: string } {
+  if (type === "directory") return { icon: "folder", color: "#f97316" };
+  const ext = fileExtension(name);
+  const map: Record<string, { icon: string; color: string }> = {
+    pdf: { icon: "picture_as_pdf", color: "#ef4444" },
+    doc: { icon: "article", color: "#3b82f6" },
+    docx: { icon: "article", color: "#3b82f6" },
+    xls: { icon: "table_chart", color: "#22c55e" },
+    xlsx: { icon: "table_chart", color: "#22c55e" },
+    ppt: { icon: "slideshow", color: "#f59e0b" },
+    pptx: { icon: "slideshow", color: "#f59e0b" },
+    txt: { icon: "text_snippet", color: "#9ca3af" },
+    md: { icon: "text_snippet", color: "#9ca3af" },
+    csv: { icon: "table_chart", color: "#22c55e" },
+    jpg: { icon: "image", color: "#a855f7" },
+    jpeg: { icon: "image", color: "#a855f7" },
+    png: { icon: "image", color: "#a855f7" },
+    gif: { icon: "image", color: "#a855f7" },
+    svg: { icon: "image", color: "#a855f7" },
+    webp: { icon: "image", color: "#a855f7" },
+    mp4: { icon: "movie", color: "#ec4899" },
+    mov: { icon: "movie", color: "#ec4899" },
+    avi: { icon: "movie", color: "#ec4899" },
+    mkv: { icon: "movie", color: "#ec4899" },
+    mp3: { icon: "music_note", color: "#06b6d4" },
+    wav: { icon: "music_note", color: "#06b6d4" },
+    flac: { icon: "music_note", color: "#06b6d4" },
+    zip: { icon: "folder_zip", color: "#f59e0b" },
+    tar: { icon: "folder_zip", color: "#f59e0b" },
+    gz: { icon: "folder_zip", color: "#f59e0b" },
+    rar: { icon: "folder_zip", color: "#f59e0b" },
+    js: { icon: "code", color: "#facc15" },
+    ts: { icon: "code", color: "#3b82f6" },
+    py: { icon: "code", color: "#22c55e" },
+    json: { icon: "data_object", color: "#f59e0b" },
+    yaml: { icon: "settings", color: "#9ca3af" },
+    yml: { icon: "settings", color: "#9ca3af" },
+    sh: { icon: "terminal", color: "#22c55e" },
+    bash: { icon: "terminal", color: "#22c55e" },
   };
-  return <span className={size}>{map[ext] ?? "📄"}</span>;
+  return map[ext] ?? { icon: "draft", color: "#6b7280" };
+}
+
+function Icon({ name, size = 20, color, className = "", ariaLabel }: { name: string; size?: number; color?: string; className?: string; ariaLabel?: string }) {
+  return (
+    <span
+      className={`material-symbols-rounded ${className}`}
+      style={{ fontSize: size, color, lineHeight: 1 }}
+      aria-hidden={ariaLabel ? undefined : true}
+      aria-label={ariaLabel}
+      role={ariaLabel ? "img" : undefined}
+    >
+      {name}
+    </span>
+  );
 }
 
 // ─── Main Component ───────────────────────────────────────────────────────────
@@ -80,9 +126,12 @@ export default function FilesApp() {
   const [dragOver, setDragOver] = useState(false);
   const [statusMsg, setStatusMsg] = useState<string | null>(null);
   const [sidebarOpen, setSidebarOpen] = useState(() => typeof window !== "undefined" ? window.innerWidth >= 768 : true);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState>(null);
+  const [baseDir, setBaseDir] = useState("/home/clawbox");
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const dropZoneRef = useRef<HTMLDivElement>(null);
+  const longPressRef = useRef<{ timer: ReturnType<typeof setTimeout>; entry: FileEntry } | null>(null);
 
   // ─── Load directory ────────────────────────────────────────────────────────
 
@@ -94,6 +143,7 @@ export default function FilesApp() {
       const res = await fetch(`/setup-api/files?dir=${encodeURIComponent(dir)}`);
       const data = await res.json();
       if (!res.ok) throw new Error(data.error ?? "Failed to load");
+      if (data.baseDir) setBaseDir(data.baseDir);
       const sorted = [...(data.files as FileEntry[])].sort((a, b) => {
         if (a.type !== b.type) return a.type === "directory" ? -1 : 1;
         return a.name.localeCompare(b.name);
@@ -143,7 +193,7 @@ export default function FilesApp() {
 
   const uploadFiles = async (fileList: FileList | null) => {
     if (!fileList || fileList.length === 0) return;
-    setStatusMsg(`Uploading ${fileList.length} file(s)…`);
+    setStatusMsg(`Uploading ${fileList.length} file(s)...`);
     let ok = 0;
     for (const file of Array.from(fileList)) {
       const form = new FormData();
@@ -226,22 +276,63 @@ export default function FilesApp() {
     setDialog({ type: null });
   };
 
+  // ─── Open in VS Code ───────────────────────────────────────────────────────
+
+  const openInVSCode = (entry: FileEntry) => {
+    const sep = baseDir.endsWith("/") ? "" : "/";
+    const absPath = `${baseDir}${sep}${currentPath ? currentPath + "/" : ""}${entry.name}`;
+    window.dispatchEvent(new CustomEvent("clawbox:open-in-vscode", { detail: { filePath: absPath } }));
+  };
+
+  // ─── Context menu ──────────────────────────────────────────────────────────
+
+  const openContextMenu = (e: React.MouseEvent, entry: FileEntry) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setSelected(entry.name);
+    // Clamp position so menu doesn't overflow viewport
+    const x = Math.min(e.clientX, window.innerWidth - 180);
+    const y = Math.min(e.clientY, window.innerHeight - 200);
+    setContextMenu({ entry, x, y });
+  };
+
+  const handleLongPressStart = (e: React.TouchEvent, entry: FileEntry) => {
+    const touch = e.touches[0];
+    const x = Math.min(touch.clientX, window.innerWidth - 180);
+    const y = Math.min(touch.clientY, window.innerHeight - 200);
+    longPressRef.current = {
+      entry,
+      timer: setTimeout(() => {
+        setSelected(entry.name);
+        setContextMenu({ entry, x, y });
+        longPressRef.current = null;
+      }, 500),
+    };
+  };
+
+  const handleLongPressEnd = () => {
+    if (longPressRef.current) {
+      clearTimeout(longPressRef.current.timer);
+      longPressRef.current = null;
+    }
+  };
+
+  const closeContextMenu = () => setContextMenu(null);
+
   // ─── Render ───────────────────────────────────────────────────────────────
 
   return (
-    <div className="flex h-full overflow-hidden relative" style={{ background: "#1e1e2e", color: "#e0e0e0", fontFamily: "system-ui, sans-serif" }}>
+    <div className="flex h-full overflow-hidden relative bg-[var(--bg-deep)] text-[var(--text-primary)] font-body" onClick={closeContextMenu}>
 
       {/* ── Sidebar ── */}
       {sidebarOpen && (
         <>
-          {/* Overlay on mobile to close sidebar when tapping outside */}
           <div
-            className="fixed inset-0 z-[5] bg-black/40 md:hidden"
+            className="fixed inset-0 z-[5] bg-black/50 md:hidden"
             onClick={() => setSidebarOpen(false)}
           />
-          <aside style={{ width: 200, background: "#16161e", flexShrink: 0, borderRight: "1px solid rgba(255,255,255,0.07)" }}
-            className="flex flex-col py-4 overflow-y-auto absolute md:relative z-[6] h-full">
-            <div className="px-4 pb-2 text-xs font-semibold uppercase tracking-widest" style={{ color: "rgba(224,224,224,0.4)" }}>
+          <aside className="flex flex-col py-4 overflow-y-auto absolute md:relative z-[6] h-full w-[200px] shrink-0 bg-[var(--bg-surface)] border-r border-[var(--border-subtle)]">
+            <div className="px-4 pb-2 text-[10px] font-semibold uppercase tracking-widest text-[var(--text-muted)]">
               Favorites
             </div>
             {FAVORITES.map((fav) => {
@@ -250,14 +341,13 @@ export default function FilesApp() {
                 <button
                   key={fav.path}
                   onClick={() => { load(fav.path); if (window.innerWidth < 768) setSidebarOpen(false); }}
-                  className="flex items-center gap-2 px-4 py-2 text-sm transition-colors text-left"
-                  style={{
-                    background: active ? "rgba(255,255,255,0.08)" : "transparent",
-                    color: active ? "#fff" : "rgba(224,224,224,0.7)",
-                    borderLeft: active ? "2px solid #f97316" : "2px solid transparent",
-                  }}
+                  className={`flex items-center gap-2.5 px-4 py-2 text-sm transition-colors text-left border-l-2 ${
+                    active
+                      ? "bg-white/[0.08] text-[var(--text-primary)] border-[var(--coral-bright)]"
+                      : "text-[var(--text-secondary)] border-transparent hover:bg-white/[0.04] hover:text-[var(--text-primary)]"
+                  }`}
                 >
-                  <span>{fav.icon}</span>
+                  <Icon name={fav.icon} size={18} color={active ? "var(--coral-bright)" : "var(--text-muted)"} />
                   <span>{fav.label}</span>
                 </button>
               );
@@ -266,10 +356,9 @@ export default function FilesApp() {
             <div className="mt-auto px-4 pt-4">
               <button
                 onClick={() => fileInputRef.current?.click()}
-                className="w-full flex items-center justify-center gap-2 py-2 rounded-lg text-sm transition-colors"
-                style={{ background: "rgba(249,115,22,0.2)", color: "#f97316", border: "1px solid rgba(249,115,22,0.3)" }}
+                className="w-full flex items-center justify-center gap-2 py-2.5 rounded-lg text-sm font-semibold transition-colors bg-[var(--coral-bright)]/15 text-[var(--coral-bright)] border border-[var(--coral-bright)]/30 hover:bg-[var(--coral-bright)]/25 cursor-pointer"
               >
-                <span className="material-symbols-rounded" style={{ fontSize: 16 }}>upload</span>
+                <Icon name="upload" size={16} />
                 Upload
               </button>
             </div>
@@ -281,17 +370,14 @@ export default function FilesApp() {
       <div className="flex flex-col flex-1 min-w-0">
 
         {/* ── Toolbar ── */}
-        <div className="flex items-center gap-2 px-3 py-2 shrink-0" style={{ borderBottom: "1px solid rgba(255,255,255,0.07)", background: "#1e1e2e" }}>
-          {/* Sidebar toggle (visible on mobile) */}
+        <div className="flex items-center gap-1.5 px-3 py-2 shrink-0 border-b border-[var(--border-subtle)] bg-[var(--bg-surface)]">
           <button
             onClick={() => setSidebarOpen(p => !p)}
-            className="p-1.5 rounded-md transition-colors md:hidden"
-            style={{ color: "rgba(224,224,224,0.8)" }}
+            className="p-1.5 rounded-md transition-colors text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-white/[0.06] md:hidden cursor-pointer"
             title="Favorites"
           >
-            <span className="material-symbols-rounded" style={{ fontSize: 16 }}>menu</span>
+            <Icon name="menu" size={18} />
           </button>
-          {/* Back */}
           <button
             onClick={() => {
               if (!currentPath) return;
@@ -300,22 +386,22 @@ export default function FilesApp() {
               load(parts.join("/"));
             }}
             disabled={!currentPath}
-            className="p-1.5 rounded-md transition-colors"
-            style={{ color: currentPath ? "rgba(224,224,224,0.8)" : "rgba(224,224,224,0.25)", background: "transparent" }}
+            className="p-1.5 rounded-md transition-colors cursor-pointer disabled:opacity-25 disabled:cursor-default text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-white/[0.06]"
             title="Go up"
           >
-            <span className="material-symbols-rounded" style={{ fontSize: 16 }}>chevron_left</span>
+            <Icon name="chevron_left" size={18} />
           </button>
 
           {/* Breadcrumb */}
           <div className="flex items-center gap-1 flex-1 text-sm overflow-hidden">
             {breadcrumbs.map((crumb, idx) => (
               <span key={idx} className="flex items-center gap-1 shrink-0">
-                {idx > 0 && <span style={{ color: "rgba(224,224,224,0.3)" }}>›</span>}
+                {idx > 0 && <Icon name="chevron_right" size={14} color="var(--text-muted)" />}
                 <button
                   onClick={() => navigateBreadcrumb(idx)}
-                  className="hover:underline truncate max-w-[120px]"
-                  style={{ color: idx === breadcrumbs.length - 1 ? "#e0e0e0" : "rgba(224,224,224,0.5)" }}
+                  className={`hover:underline truncate max-w-[120px] cursor-pointer ${
+                    idx === breadcrumbs.length - 1 ? "text-[var(--text-primary)] font-medium" : "text-[var(--text-muted)]"
+                  }`}
                 >
                   {crumb}
                 </button>
@@ -325,37 +411,27 @@ export default function FilesApp() {
 
           {/* Actions */}
           <div className="flex items-center gap-1 shrink-0">
-            {/* New folder */}
             <button
               onClick={() => setDialog({ type: "mkdir", value: "" })}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm transition-colors"
-              style={{ background: "rgba(255,255,255,0.06)", color: "rgba(224,224,224,0.8)" }}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm transition-colors bg-white/[0.06] text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-white/[0.1] cursor-pointer"
               title="New Folder"
             >
-              <span className="material-symbols-rounded" style={{ fontSize: 16 }}>create_new_folder</span>
+              <Icon name="create_new_folder" size={16} />
               <span className="hidden sm:inline">New Folder</span>
             </button>
-
-            {/* Refresh */}
             <button
               onClick={() => load(currentPath)}
-              className="p-1.5 rounded-md transition-colors"
-              style={{ color: "rgba(224,224,224,0.6)", background: "transparent" }}
+              className="p-1.5 rounded-md transition-colors text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-white/[0.06] cursor-pointer"
               title="Refresh"
             >
-              <span className="material-symbols-rounded" style={{ fontSize: 16 }}>refresh</span>
+              <Icon name="refresh" size={18} />
             </button>
-
-            {/* View toggle */}
             <button
               onClick={() => setViewMode(v => v === "grid" ? "list" : "grid")}
-              className="p-1.5 rounded-md transition-colors"
-              style={{ color: "rgba(224,224,224,0.6)", background: "transparent" }}
+              className="p-1.5 rounded-md transition-colors text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-white/[0.06] cursor-pointer"
               title={viewMode === "grid" ? "Switch to list" : "Switch to grid"}
             >
-              <span className="material-symbols-rounded" style={{ fontSize: 16 }}>
-                {viewMode === "grid" ? "view_list" : "grid_view"}
-              </span>
+              <Icon name={viewMode === "grid" ? "view_list" : "grid_view"} size={18} />
             </button>
           </div>
         </div>
@@ -363,35 +439,34 @@ export default function FilesApp() {
         {/* ── File Area ── */}
         <div
           ref={dropZoneRef}
-          className="flex-1 overflow-y-auto relative"
-          style={{ background: dragOver ? "rgba(249,115,22,0.05)" : "transparent", transition: "background 0.15s" }}
+          className={`flex-1 overflow-y-auto relative transition-colors ${dragOver ? "bg-[var(--coral-bright)]/5" : ""}`}
           onDragOver={handleDragOver}
           onDragLeave={handleDragLeave}
           onDrop={handleDrop}
         >
           {dragOver && (
-            <div className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none" style={{ border: "2px dashed rgba(249,115,22,0.5)", margin: 8, borderRadius: 12 }}>
-              <div className="text-center" style={{ color: "#f97316" }}>
-                <div className="text-4xl mb-2">⬆️</div>
+            <div className="absolute inset-2 z-20 flex items-center justify-center pointer-events-none rounded-xl border-2 border-dashed border-[var(--coral-bright)]/50">
+              <div className="text-center text-[var(--coral-bright)]">
+                <Icon name="upload_file" size={48} className="mb-2" />
                 <div className="text-sm font-medium">Drop files to upload</div>
               </div>
             </div>
           )}
 
           {loading ? (
-            <div className="flex items-center justify-center h-full" style={{ color: "rgba(224,224,224,0.4)" }}>
-              <span className="material-symbols-rounded animate-spin mr-2" style={{ fontSize: 24 }}>progress_activity</span>
-              Loading…
+            <div className="flex items-center justify-center h-full text-[var(--text-muted)]">
+              <Icon name="progress_activity" size={24} className="animate-spin mr-2" />
+              Loading...
             </div>
           ) : error ? (
-            <div className="flex items-center justify-center h-full flex-col gap-2" style={{ color: "#f87171" }}>
-              <span className="text-3xl">⚠️</span>
+            <div className="flex items-center justify-center h-full flex-col gap-2 text-red-400">
+              <Icon name="error" size={40} />
               <span className="text-sm">{error}</span>
-              <button onClick={() => load(currentPath)} className="text-xs underline mt-1" style={{ color: "rgba(224,224,224,0.5)" }}>Retry</button>
+              <button onClick={() => load(currentPath)} className="text-xs underline mt-1 text-[var(--text-muted)] hover:text-[var(--text-primary)] cursor-pointer">Retry</button>
             </div>
           ) : files.length === 0 ? (
-            <div className="flex items-center justify-center h-full flex-col gap-2" style={{ color: "rgba(224,224,224,0.3)" }}>
-              <span className="text-5xl">📂</span>
+            <div className="flex items-center justify-center h-full flex-col gap-2 text-[var(--text-muted)]">
+              <Icon name="folder_open" size={56} color="var(--border-subtle)" />
               <span className="text-sm">Empty folder</span>
               <span className="text-xs">Drop files here or click Upload</span>
             </div>
@@ -401,9 +476,10 @@ export default function FilesApp() {
               selected={selected}
               onSelect={setSelected}
               onOpen={navigateTo}
-              onDownload={downloadFile}
-              onRename={(e) => setDialog({ type: "rename", entry: e, value: e.name })}
-              onDelete={(e) => setDialog({ type: "delete", entry: e })}
+              onOpenFile={openInVSCode}
+              onContextMenu={openContextMenu}
+              onLongPressStart={handleLongPressStart}
+              onLongPressEnd={handleLongPressEnd}
             />
           ) : (
             <ListView
@@ -411,18 +487,18 @@ export default function FilesApp() {
               selected={selected}
               onSelect={setSelected}
               onOpen={navigateTo}
-              onDownload={downloadFile}
-              onRename={(e) => setDialog({ type: "rename", entry: e, value: e.name })}
-              onDelete={(e) => setDialog({ type: "delete", entry: e })}
+              onOpenFile={openInVSCode}
+              onContextMenu={openContextMenu}
+              onLongPressStart={handleLongPressStart}
+              onLongPressEnd={handleLongPressEnd}
             />
           )}
         </div>
 
         {/* ── Status bar ── */}
-        <div className="px-4 py-1.5 text-xs flex items-center justify-between shrink-0"
-          style={{ borderTop: "1px solid rgba(255,255,255,0.07)", color: "rgba(224,224,224,0.4)" }}>
+        <div className="px-4 py-1.5 text-xs flex items-center justify-between shrink-0 border-t border-[var(--border-subtle)] text-[var(--text-muted)]">
           <span>{statusMsg ?? `${files.length} item${files.length !== 1 ? "s" : ""}`}</span>
-          {currentPath && <span style={{ color: "rgba(224,224,224,0.25)" }}>~/{currentPath}</span>}
+          {currentPath && <span className="opacity-60">~/{currentPath}</span>}
         </div>
       </div>
 
@@ -434,6 +510,21 @@ export default function FilesApp() {
         className="hidden"
         onChange={(e) => uploadFiles(e.target.files)}
       />
+
+      {/* ── Context Menu ── */}
+      {contextMenu && (
+        <ContextMenu
+          entry={contextMenu.entry}
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onOpen={() => { closeContextMenu(); navigateTo(contextMenu.entry); }}
+          onDownload={() => { closeContextMenu(); downloadFile(contextMenu.entry); }}
+          onOpenInVSCode={() => { closeContextMenu(); openInVSCode(contextMenu.entry); }}
+          onRename={() => { closeContextMenu(); setDialog({ type: "rename", entry: contextMenu.entry, value: contextMenu.entry.name }); }}
+          onDelete={() => { closeContextMenu(); setDialog({ type: "delete", entry: contextMenu.entry }); }}
+          onClose={closeContextMenu}
+        />
+      )}
 
       {/* ── Dialogs ── */}
       {dialog.type && (
@@ -450,49 +541,41 @@ export default function FilesApp() {
 
 // ─── Grid View ────────────────────────────────────────────────────────────────
 
-function GridView({ files, selected, onSelect, onOpen, onDownload, onRename, onDelete }: {
+function GridView({ files, selected, onSelect, onOpen, onOpenFile, onContextMenu, onLongPressStart, onLongPressEnd }: {
   files: FileEntry[];
   selected: string | null;
   onSelect: (name: string | null) => void;
   onOpen: (entry: FileEntry) => void;
-  onDownload: (entry: FileEntry) => void;
-  onRename: (entry: FileEntry) => void;
-  onDelete: (entry: FileEntry) => void;
+  onOpenFile: (entry: FileEntry) => void;
+  onContextMenu: (e: React.MouseEvent, entry: FileEntry) => void;
+  onLongPressStart: (e: React.TouchEvent, entry: FileEntry) => void;
+  onLongPressEnd: () => void;
 }) {
   return (
-    <div className="p-4 grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(110px, 1fr))" }}
+    <div className="p-4 grid gap-2" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(100px, 1fr))" }}
       onClick={() => onSelect(null)}>
       {files.map((entry) => {
         const isSelected = selected === entry.name;
+        const fi = fileIcon(entry.name, entry.type);
         return (
           <div
             key={entry.name}
-            className="flex flex-col items-center gap-1.5 p-2 rounded-xl cursor-pointer group relative transition-colors"
-            style={{
-              background: isSelected ? "rgba(249,115,22,0.15)" : "transparent",
-              border: isSelected ? "1px solid rgba(249,115,22,0.4)" : "1px solid transparent",
-            }}
+            className={`flex flex-col items-center gap-1.5 p-3 rounded-xl cursor-pointer transition-all select-none ${
+              isSelected
+                ? "bg-[var(--coral-bright)]/10 border border-[var(--coral-bright)]/40"
+                : "border border-transparent hover:bg-white/[0.04]"
+            }`}
             onClick={(e) => { e.stopPropagation(); onSelect(entry.name); }}
-            onDoubleClick={() => entry.type === "directory" ? onOpen(entry) : onDownload(entry)}
+            onDoubleClick={() => entry.type === "directory" ? onOpen(entry) : onOpenFile(entry)}
+            onContextMenu={(e) => onContextMenu(e, entry)}
+            onTouchStart={(e) => onLongPressStart(e, entry)}
+            onTouchEnd={onLongPressEnd}
+            onTouchMove={onLongPressEnd}
           >
-            <FileIcon entry={entry} large />
-            <span className="text-xs text-center line-clamp-2 w-full leading-tight" style={{ color: "#e0e0e0", wordBreak: "break-word" }}>
+            <Icon name={fi.icon} size={36} color={fi.color} />
+            <span className="text-xs text-center line-clamp-2 w-full leading-tight text-[var(--text-primary)]" style={{ wordBreak: "break-word" }}>
               {entry.name}
             </span>
-            {/* Hover actions */}
-            <div className="absolute top-1 right-1 hidden group-hover:flex gap-0.5">
-              {entry.type === "file" && (
-                <ActionBtn title="Download" onClick={(e) => { e.stopPropagation(); onDownload(entry); }}>
-                  ⬇️
-                </ActionBtn>
-              )}
-              <ActionBtn title="Rename" onClick={(e) => { e.stopPropagation(); onRename(entry); }}>
-                ✏️
-              </ActionBtn>
-              <ActionBtn title="Delete" onClick={(e) => { e.stopPropagation(); onDelete(entry); }}>
-                🗑️
-              </ActionBtn>
-            </div>
           </div>
         );
       })}
@@ -502,63 +585,48 @@ function GridView({ files, selected, onSelect, onOpen, onDownload, onRename, onD
 
 // ─── List View ────────────────────────────────────────────────────────────────
 
-function ListView({ files, selected, onSelect, onOpen, onDownload, onRename, onDelete }: {
+function ListView({ files, selected, onSelect, onOpen, onOpenFile, onContextMenu, onLongPressStart, onLongPressEnd }: {
   files: FileEntry[];
   selected: string | null;
   onSelect: (name: string | null) => void;
   onOpen: (entry: FileEntry) => void;
-  onDownload: (entry: FileEntry) => void;
-  onRename: (entry: FileEntry) => void;
-  onDelete: (entry: FileEntry) => void;
+  onOpenFile: (entry: FileEntry) => void;
+  onContextMenu: (e: React.MouseEvent, entry: FileEntry) => void;
+  onLongPressStart: (e: React.TouchEvent, entry: FileEntry) => void;
+  onLongPressEnd: () => void;
 }) {
   return (
     <div className="w-full" onClick={() => onSelect(null)}>
       {/* Header */}
-      <div className="grid px-4 py-2 text-xs font-medium sticky top-0"
-        style={{
-          gridTemplateColumns: "1fr 80px 160px 90px",
-          borderBottom: "1px solid rgba(255,255,255,0.07)",
-          background: "#1e1e2e",
-          color: "rgba(224,224,224,0.4)",
-        }}>
+      <div className="grid px-4 py-2 text-xs font-medium sticky top-0 border-b border-[var(--border-subtle)] bg-[var(--bg-deep)] text-[var(--text-muted)]"
+        style={{ gridTemplateColumns: "1fr 80px 160px" }}>
         <span>Name</span>
         <span className="text-right">Size</span>
         <span className="text-right">Modified</span>
-        <span className="text-right">Actions</span>
       </div>
       {files.map((entry) => {
         const isSelected = selected === entry.name;
+        const fi = fileIcon(entry.name, entry.type);
         return (
           <div
             key={entry.name}
-            className="grid px-4 py-2 items-center cursor-pointer group transition-colors"
-            style={{
-              gridTemplateColumns: "1fr 80px 160px 90px",
-              background: isSelected ? "rgba(249,115,22,0.1)" : "transparent",
-              borderBottom: "1px solid rgba(255,255,255,0.04)",
-            }}
+            className={`grid px-4 py-2 items-center cursor-pointer transition-colors border-b border-white/[0.03] select-none ${
+              isSelected ? "bg-[var(--coral-bright)]/10" : "hover:bg-white/[0.03]"
+            }`}
+            style={{ gridTemplateColumns: "1fr 80px 160px" }}
             onClick={(e) => { e.stopPropagation(); onSelect(entry.name); }}
-            onDoubleClick={() => entry.type === "directory" ? onOpen(entry) : onDownload(entry)}
+            onDoubleClick={() => entry.type === "directory" ? onOpen(entry) : onOpenFile(entry)}
+            onContextMenu={(e) => onContextMenu(e, entry)}
+            onTouchStart={(e) => onLongPressStart(e, entry)}
+            onTouchEnd={onLongPressEnd}
+            onTouchMove={onLongPressEnd}
           >
-            <span className="flex items-center gap-2 truncate">
-              <FileIcon entry={entry} />
-              <span className="truncate text-sm" style={{ color: "#e0e0e0" }}>{entry.name}</span>
+            <span className="flex items-center gap-2.5 truncate">
+              <Icon name={fi.icon} size={20} color={fi.color} />
+              <span className="truncate text-sm text-[var(--text-primary)]">{entry.name}</span>
             </span>
-            <span className="text-right text-xs" style={{ color: "rgba(224,224,224,0.5)" }}>{formatSize(entry.size)}</span>
-            <span className="text-right text-xs" style={{ color: "rgba(224,224,224,0.5)" }}>{formatDate(entry.modified)}</span>
-            <span className="flex items-center justify-end gap-1">
-              {entry.type === "file" && (
-                <ActionBtn title="Download" onClick={(e) => { e.stopPropagation(); onDownload(entry); }}>
-                  ⬇️
-                </ActionBtn>
-              )}
-              <ActionBtn title="Rename" onClick={(e) => { e.stopPropagation(); onRename(entry); }}>
-                ✏️
-              </ActionBtn>
-              <ActionBtn title="Delete" onClick={(e) => { e.stopPropagation(); onDelete(entry); }}>
-                🗑️
-              </ActionBtn>
-            </span>
+            <span className="text-right text-xs text-[var(--text-muted)]">{formatSize(entry.size)}</span>
+            <span className="text-right text-xs text-[var(--text-muted)]">{formatDate(entry.modified)}</span>
           </div>
         );
       })}
@@ -566,18 +634,103 @@ function ListView({ files, selected, onSelect, onOpen, onDownload, onRename, onD
   );
 }
 
-// ─── Small action button ──────────────────────────────────────────────────────
+// ─── Context Menu ────────────────────────────────────────────────────────────
 
-function ActionBtn({ children, title, onClick }: { children: React.ReactNode; title: string; onClick: (e: React.MouseEvent) => void }) {
+function ContextMenu({ entry, x, y, onOpen, onDownload, onOpenInVSCode, onRename, onDelete, onClose }: {
+  entry: FileEntry;
+  x: number;
+  y: number;
+  onOpen: () => void;
+  onDownload: () => void;
+  onOpenInVSCode: () => void;
+  onRename: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [focusedIndex, setFocusedIndex] = useState(0);
+
+  useEffect(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    el.focus();
+    const rect = el.getBoundingClientRect();
+    if (rect.bottom > window.innerHeight) {
+      el.style.top = `${y - rect.height}px`;
+    }
+    if (rect.right > window.innerWidth) {
+      el.style.left = `${x - rect.width}px`;
+    }
+  }, [x, y]);
+
+  const items: { icon: string; label: string; onClick: () => void; danger?: boolean; color?: string }[] = [];
+
+  if (entry.type === "directory") {
+    items.push({ icon: "folder_open", label: "Open", onClick: onOpen });
+  } else {
+    items.push({ icon: "download", label: "Download", onClick: onDownload });
+  }
+  items.push({ icon: "code", label: "Open in VS Code", onClick: onOpenInVSCode, color: "#007acc" });
+  items.push({ icon: "edit", label: "Rename", onClick: onRename });
+  items.push({ icon: "delete", label: "Delete", onClick: onDelete, danger: true });
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setFocusedIndex((i) => (i + 1) % items.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setFocusedIndex((i) => (i - 1 + items.length) % items.length);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        items[focusedIndex].onClick();
+        break;
+      case "Escape":
+        e.preventDefault();
+        onClose();
+        break;
+    }
+  };
+
   return (
-    <button
-      title={title}
-      onClick={onClick}
-      className="text-xs px-1 py-0.5 rounded transition-colors opacity-70 hover:opacity-100"
-      style={{ background: "rgba(255,255,255,0.1)" }}
+    <div
+      ref={menuRef}
+      role="menu"
+      aria-label={`Actions for ${entry.name}`}
+      tabIndex={-1}
+      className="fixed z-50 min-w-[160px] py-1.5 rounded-xl shadow-2xl border border-[var(--border-subtle)] overflow-hidden outline-none"
+      style={{ left: x, top: y, background: "var(--bg-elevated)", backdropFilter: "blur(16px)" }}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={handleKeyDown}
     >
-      {children}
-    </button>
+      {/* File info header */}
+      <div className="px-3 py-2 border-b border-[var(--border-subtle)] flex items-center gap-2">
+        <Icon name={fileIcon(entry.name, entry.type).icon} size={16} color={fileIcon(entry.name, entry.type).color} />
+        <span className="text-xs text-[var(--text-secondary)] truncate max-w-[120px]">{entry.name}</span>
+      </div>
+      {items.map((item, i) => (
+        <button
+          key={item.label}
+          role="menuitem"
+          tabIndex={i === focusedIndex ? 0 : -1}
+          onClick={item.onClick}
+          className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left cursor-pointer ${
+            i === focusedIndex ? "bg-white/[0.08]" : ""
+          } ${
+            item.danger
+              ? "text-red-400 hover:bg-red-500/10"
+              : "text-[var(--text-primary)] hover:bg-white/[0.06]"
+          }`}
+        >
+          <Icon name={item.icon} size={18} color={item.danger ? "#f87171" : item.color ?? "var(--text-muted)"} />
+          {item.label}
+        </button>
+      ))}
+    </div>
   );
 }
 
@@ -598,16 +751,22 @@ function DialogOverlay({ dialog, onChange, onCancel, onSubmit }: {
     : `Delete "${dialog.entry?.name}"?`;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: "rgba(0,0,0,0.6)" }}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
       onClick={onCancel}>
       <div
-        className="rounded-2xl p-6 w-80 shadow-2xl"
-        style={{ background: "#2a2a3e", border: "1px solid rgba(255,255,255,0.1)" }}
+        className="card-surface rounded-2xl p-6 w-80 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <h3 className="text-base font-semibold mb-4" style={{ color: "#e0e0e0" }}>{title}</h3>
+        <h3 className="text-base font-semibold mb-4 text-[var(--text-primary)] flex items-center gap-2">
+          <Icon
+            name={isDelete ? "delete" : dialog.type === "mkdir" ? "create_new_folder" : "edit"}
+            size={20}
+            color={isDelete ? "#ef4444" : "var(--coral-bright)"}
+          />
+          {title}
+        </h3>
         {isDelete ? (
-          <p className="text-sm mb-5" style={{ color: "rgba(224,224,224,0.6)" }}>
+          <p className="text-sm mb-5 text-[var(--text-secondary)]">
             This action cannot be undone. {dialog.entry?.type === "directory" ? "All contents will be deleted." : ""}
           </p>
         ) : (
@@ -617,23 +776,24 @@ function DialogOverlay({ dialog, onChange, onCancel, onSubmit }: {
             value={dialog.value ?? ""}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") onSubmit(); if (e.key === "Escape") onCancel(); }}
-            className="w-full px-3 py-2 rounded-lg text-sm mb-5 outline-none"
-            style={{ background: "rgba(255,255,255,0.07)", color: "#e0e0e0", border: "1px solid rgba(255,255,255,0.12)" }}
+            className="w-full px-3.5 py-2.5 bg-[var(--bg-deep)] border border-gray-600 rounded-lg text-sm text-gray-200 outline-none focus:border-[var(--coral-bright)] transition-colors placeholder-gray-500 mb-5"
             placeholder={dialog.type === "mkdir" ? "Folder name" : "New name"}
           />
         )}
         <div className="flex gap-2 justify-end">
           <button
             onClick={onCancel}
-            className="px-4 py-2 rounded-lg text-sm transition-colors"
-            style={{ background: "rgba(255,255,255,0.06)", color: "rgba(224,224,224,0.7)" }}
+            className="px-4 py-2 rounded-lg text-sm transition-colors bg-white/[0.06] text-[var(--text-secondary)] hover:bg-white/[0.1] hover:text-[var(--text-primary)] cursor-pointer"
           >
             Cancel
           </button>
           <button
             onClick={onSubmit}
-            className="px-4 py-2 rounded-lg text-sm font-medium transition-colors"
-            style={{ background: isDelete ? "#dc2626" : "#f97316", color: "#fff" }}
+            className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors cursor-pointer text-white ${
+              isDelete
+                ? "bg-red-600 hover:bg-red-500"
+                : "btn-gradient hover:opacity-90"
+            }`}
           >
             {isDelete ? "Delete" : "OK"}
           </button>

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -1310,7 +1310,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange }: { onTap?: 
             </button>
           )}
           <button
-            onClick={() => { setHidden(true); kv.set('clawbox-mascot-hidden', '1'); setCtxMenu(null) }}
+            onClick={() => { setHidden(true); kv.set('clawbox-mascot-hidden', '1'); setCtxMenu(null); window.dispatchEvent(new Event('clawbox-hide-mascot')) }}
             className="w-full px-4 py-2 text-left hover:bg-white/10 flex items-center gap-3 text-red-400"
           >
             <span className="text-base">👁️‍🗨️</span> Hide mascot

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import StatusMessage from "./StatusMessage";
 import AIModelsStep from "./AIModelsStep";
 import { QRCodeSVG } from "qrcode.react";
-import type { StepStatus, UpdateState } from "@/lib/updater";
+import type { UpdateState } from "@/lib/updater";
 
 /* ── Types ── */
 
@@ -46,14 +46,6 @@ interface SystemStats {
 }
 
 
-const RESET_STEPS = [
-  "Clearing configuration...",
-  "Removing credentials...",
-  "Wiping AI model data...",
-  "Resetting gateway...",
-  "Finalizing...",
-];
-
 type Section = "appearance" | "wifi" | "ai" | "telegram" | "system" | "about";
 
 /* ── Sidebar nav items ── */
@@ -81,7 +73,7 @@ function barColor(pct: number): string {
 function Toggle({ on, onToggle, label }: { on: boolean; onToggle: (v: boolean) => void; label: string }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-sm text-white/80">{label}</span>
+      <span className="text-sm text-[var(--text-primary)]">{label}</span>
       <button
         onClick={() => onToggle(!on)}
         className={`relative inline-flex items-center w-10 h-5 rounded-full transition-colors cursor-pointer border-none shrink-0 ${on ? "bg-orange-500" : "bg-white/15"}`}
@@ -95,24 +87,6 @@ function Toggle({ on, onToggle, label }: { on: boolean; onToggle: (v: boolean) =
   );
 }
 
-
-/* ── Update step helpers ── */
-
-function updateStepTextClass(status: StepStatus): string {
-  switch (status) {
-    case "running": return "text-orange-400 font-medium";
-    case "completed": return "text-white/40";
-    case "failed": return "text-red-400";
-    default: return "text-white/25";
-  }
-}
-
-function UpdateStepIcon({ status }: { status: StepStatus }) {
-  if (status === "running") return <div className="w-4 h-4 border-2 border-orange-400 border-t-transparent rounded-full animate-spin shrink-0" />;
-  if (status === "completed") return <div className="w-4 h-4 rounded-full bg-emerald-500 flex items-center justify-center text-white text-[10px] font-bold shrink-0">&#10003;</div>;
-  if (status === "failed") return <div className="w-4 h-4 rounded-full bg-red-500 flex items-center justify-center text-white text-[10px] font-bold shrink-0">&#10005;</div>;
-  return <div className="w-4 h-4 rounded-full bg-white/10 shrink-0" />;
-}
 
 export default function SettingsApp({ ui }: SettingsAppProps) {
   const [section, setSection] = useState<Section>("appearance");
@@ -191,7 +165,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       .catch(() => {});
   }, []);
 
-  const isUpdateRunning = updateStarted && updateState?.phase === "running";
+
 
   const openUpdateConfirm = async () => {
     setVersionLoading(true);
@@ -288,6 +262,11 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   };
 
   /* ── AI Provider ── */
+  const [aiProvider, setAiProvider] = useState<{ connected: boolean; providerLabel: string | null; mode: string | null; model: string | null } | null>(null);
+  useEffect(() => {
+    if (section !== "ai") return;
+    fetch("/setup-api/ai-models/status").then(r => r.json()).then(setAiProvider).catch(() => {});
+  }, [section]);
 
   /* ── Telegram ── */
   const [tgToken, setTgToken] = useState("");
@@ -349,8 +328,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   /* ── Factory Reset ── */
   const [resetConfirm, setResetConfirm] = useState(false);
   const [resetting, setResetting] = useState(false);
-  const [resetStep, setResetStep] = useState(0);
-  const [resetProgress, setResetProgress] = useState(0);
+
 
   const [resetPhase, setResetPhase] = useState<"waiting" | "reconnecting" | "done" | null>(null);
   const [resetDots, setResetDots] = useState(0);
@@ -402,13 +380,13 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         {/* ─── Appearance ─── */}
         {activeSection === "appearance" && (
           <div className="max-w-2xl space-y-5">
-            <h2 className="text-lg font-semibold text-white/90">Appearance</h2>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">Appearance</h2>
 
             {/* Wallpaper card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
-                <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>wallpaper</span>
-                <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Wallpaper</label>
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>wallpaper</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Wallpaper</label>
               </div>
               <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
                 {ui.wallpapers.map(wp => {
@@ -468,7 +446,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 })}
                 <button
                   onClick={() => ui.onWallpaperUpload()}
-                  className="rounded-xl aspect-video border-2 border-dashed border-white/10 hover:border-orange-400/40 hover:bg-orange-500/5 flex flex-col items-center justify-center gap-1.5 text-white/30 hover:text-orange-400/70 transition-all cursor-pointer"
+                  className="rounded-xl aspect-video border-2 border-dashed border-[var(--border-subtle)] hover:border-orange-400/40 hover:bg-orange-500/5 flex flex-col items-center justify-center gap-1.5 text-[var(--text-muted)] opacity-60 hover:text-[var(--coral-bright)]/70 transition-all cursor-pointer"
                 >
                   <span className="material-symbols-rounded" style={{ fontSize: 24 }}>add_photo_alternate</span>
                   <span className="text-[10px] font-medium">Upload</span>
@@ -477,10 +455,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             </div>
 
             {/* Display Settings card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5 space-y-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5 space-y-5">
               <div className="flex items-center gap-2">
-                <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>tune</span>
-                <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Display</label>
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>tune</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Display</label>
               </div>
 
               {/* Fit mode */}
@@ -494,7 +472,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                         key={mode}
                         onClick={() => ui.onWpFitChange(mode)}
                         className={`flex-1 flex items-center justify-center gap-1.5 py-2 rounded-lg text-xs font-semibold transition-all cursor-pointer border-none capitalize ${
-                          ui.wpFit === mode ? "bg-orange-500/15 text-orange-400 shadow-sm" : "text-white/35 hover:text-white/60 hover:bg-white/[0.04]"
+                          ui.wpFit === mode ? "bg-orange-500/15 text-[var(--coral-bright)] shadow-sm" : "text-white/35 hover:text-[var(--text-secondary)] hover:bg-white/[0.04]"
                         }`}
                       >
                         <span className="material-symbols-rounded" style={{ fontSize: 14 }}>{icons[mode]}</span>
@@ -509,7 +487,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               <div>
                 <div className="flex items-center justify-between mb-2">
                   <label className="text-[11px] font-medium text-white/35 uppercase tracking-wider">Opacity</label>
-                  <span className="text-xs font-mono text-orange-400/80 bg-orange-500/10 px-2 py-0.5 rounded-md">{ui.wpOpacity}%</span>
+                  <span className="text-xs font-mono text-[var(--coral-bright)]/80 bg-orange-500/10 px-2 py-0.5 rounded-md">{ui.wpOpacity}%</span>
                 </div>
                 <div className="relative h-6 flex items-center">
                   <input
@@ -531,21 +509,21 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     <input
                       type="color" value={ui.wpBgColor}
                       onChange={e => ui.onWpBgColorChange(e.target.value)}
-                      className="w-10 h-10 rounded-xl cursor-pointer border-2 border-white/10 hover:border-white/20 transition-colors"
+                      className="w-10 h-10 rounded-xl cursor-pointer border-2 border-[var(--border-subtle)] hover:border-white/20 transition-colors"
                     />
                   </div>
                   <div className="flex items-center gap-2 bg-white/[0.04] rounded-lg px-3 py-2">
-                    <span className="text-xs text-white/40 font-mono tracking-wide">{ui.wpBgColor}</span>
+                    <span className="text-xs text-[var(--text-muted)] font-mono tracking-wide">{ui.wpBgColor}</span>
                   </div>
                 </div>
               </div>
             </div>
 
             {/* Extras card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
-                <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>auto_awesome</span>
-                <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Extras</label>
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>auto_awesome</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Extras</label>
               </div>
               <Toggle on={!ui.mascotHidden} onToggle={v => {
                 const hidden = !v;
@@ -559,13 +537,13 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         {/* ─── Network ─── */}
         {activeSection === "wifi" && (
           <div className="max-w-lg space-y-5">
-            <h2 className="text-lg font-semibold text-white/90">Network</h2>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">Network</h2>
 
             {/* Connection status card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
-                <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>wifi</span>
-                <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Status</label>
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>wifi</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Status</label>
               </div>
               {connectedSSID ? (
                 <div className="flex items-center gap-4 bg-green-500/[0.06] border border-green-500/15 rounded-xl px-4 py-3.5">
@@ -573,7 +551,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     <span className="material-symbols-rounded text-green-400" style={{ fontSize: 22 }}>wifi</span>
                   </div>
                   <div className="flex-1 min-w-0">
-                    <div className="text-sm text-white/90 font-medium truncate">{connectedSSID}</div>
+                    <div className="text-sm text-[var(--text-primary)] font-medium truncate">{connectedSSID}</div>
                     <div className="flex items-center gap-1.5 mt-0.5">
                       <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
                       <span className="text-xs text-green-400/80">Connected</span>
@@ -583,25 +561,25 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               ) : (
                 <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5">
                   <div className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center shrink-0">
-                    <span className="material-symbols-rounded text-white/25" style={{ fontSize: 22 }}>wifi_off</span>
+                    <span className="material-symbols-rounded text-[var(--text-muted)] opacity-50" style={{ fontSize: 22 }}>wifi_off</span>
                   </div>
                   <div>
-                    <div className="text-sm text-white/50">No WiFi connection</div>
-                    <div className="text-xs text-white/25 mt-0.5">Connect to a network below</div>
+                    <div className="text-sm text-[var(--text-muted)]">No WiFi connection</div>
+                    <div className="text-xs text-[var(--text-muted)] opacity-50 mt-0.5">Connect to a network below</div>
                   </div>
                 </div>
               )}
             </div>
 
             {/* Hotspot toggle card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-3">
                   <div className={`w-10 h-10 rounded-full flex items-center justify-center shrink-0 ${hotspotEnabled ? "bg-orange-500/15" : "bg-white/5"}`}>
-                    <span className={`material-symbols-rounded ${hotspotEnabled ? "text-orange-400" : "text-white/25"}`} style={{ fontSize: 22 }}>wifi_tethering</span>
+                    <span className={`material-symbols-rounded ${hotspotEnabled ? "text-[var(--coral-bright)]" : "text-[var(--text-muted)] opacity-50"}`} style={{ fontSize: 22 }}>wifi_tethering</span>
                   </div>
                   <div>
-                    <div className="text-sm text-white/90 font-medium">Hotspot</div>
+                    <div className="text-sm text-[var(--text-primary)] font-medium">Hotspot</div>
                     <div className="text-xs text-white/35 mt-0.5">{hotspotSSID}</div>
                   </div>
                 </div>
@@ -614,38 +592,38 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 </button>
               </div>
               {hotspotEnabled && (
-                <p className="text-[11px] text-white/25 mt-3 leading-relaxed">
-                  The hotspot broadcasts <span className="text-white/40 font-medium">{hotspotSSID}</span> so you can connect to this device directly.
+                <p className="text-[11px] text-[var(--text-muted)] opacity-50 mt-3 leading-relaxed">
+                  The hotspot broadcasts <span className="text-[var(--text-muted)] font-medium">{hotspotSSID}</span> so you can connect to this device directly.
                 </p>
               )}
             </div>
 
             {/* Connect to network card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
-                <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>add_circle</span>
-                <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Connect to Network</label>
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>add_circle</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Connect to Network</label>
               </div>
               <div className="space-y-4">
                 <div>
                   <label className="block text-[11px] font-medium text-white/35 uppercase tracking-wider mb-2">Network Name (SSID)</label>
                   <div className="relative">
-                    <span className="material-symbols-rounded absolute left-3 top-1/2 -translate-y-1/2 text-white/20" style={{ fontSize: 18 }}>router</span>
+                    <span className="material-symbols-rounded absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)] opacity-40" style={{ fontSize: 18 }}>router</span>
                     <input
                       type="text" value={ssid} onChange={e => setSsid(e.target.value)}
                       placeholder="Enter WiFi network name"
-                      className="w-full pl-10 pr-4 py-2.5 bg-white/[0.04] border border-white/[0.08] rounded-xl text-sm text-white/90 outline-none focus:border-orange-400/60 focus:bg-white/[0.06] transition-all placeholder-white/15"
+                      className="w-full pl-10 pr-4 py-2.5 bg-white/[0.04] border border-white/[0.08] rounded-xl text-sm text-[var(--text-primary)] outline-none focus:border-orange-400/60 focus:bg-white/[0.06] transition-all placeholder-white/15"
                     />
                   </div>
                 </div>
                 <div>
                   <label className="block text-[11px] font-medium text-white/35 uppercase tracking-wider mb-2">Password</label>
                   <div className="relative">
-                    <span className="material-symbols-rounded absolute left-3 top-1/2 -translate-y-1/2 text-white/20" style={{ fontSize: 18 }}>lock</span>
+                    <span className="material-symbols-rounded absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)] opacity-40" style={{ fontSize: 18 }}>lock</span>
                     <input
                       type="password" value={wifiPass} onChange={e => setWifiPass(e.target.value)}
                       placeholder="Enter WiFi password"
-                      className="w-full pl-10 pr-4 py-2.5 bg-white/[0.04] border border-white/[0.08] rounded-xl text-sm text-white/90 outline-none focus:border-orange-400/60 focus:bg-white/[0.06] transition-all placeholder-white/15"
+                      className="w-full pl-10 pr-4 py-2.5 bg-white/[0.04] border border-white/[0.08] rounded-xl text-sm text-[var(--text-primary)] outline-none focus:border-orange-400/60 focus:bg-white/[0.06] transition-all placeholder-white/15"
                       onKeyDown={e => e.key === "Enter" && connectWifi()}
                     />
                   </div>
@@ -684,7 +662,49 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {/* ─── AI Provider ─── */}
         {activeSection === "ai" && (
-          <div className="max-w-lg">
+          <div className="max-w-lg space-y-5">
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">AI Provider</h2>
+
+            {/* Provider status card */}
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+              <div className="flex items-center gap-2 mb-4">
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>smart_toy</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Status</label>
+              </div>
+              {aiProvider === null ? (
+                <div className="flex items-center gap-3 text-[var(--text-muted)] text-sm">
+                  <div className="w-5 h-5 border-2 border-white/15 border-t-[var(--coral-bright)] rounded-full animate-spin" />
+                  Checking...
+                </div>
+              ) : aiProvider.connected ? (
+                <div className="flex items-center gap-4 bg-green-500/[0.06] border border-green-500/15 rounded-xl px-4 py-3.5">
+                  <div className="w-10 h-10 rounded-full bg-green-500/15 flex items-center justify-center shrink-0">
+                    <span className="material-symbols-rounded text-green-400" style={{ fontSize: 22 }}>check_circle</span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-[var(--text-primary)] font-medium">{aiProvider.providerLabel}</div>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+                      <span className="text-xs text-green-400/80">
+                        {aiProvider.model ? aiProvider.model.split("/").pop() : "Connected"}
+                        {aiProvider.mode ? ` · ${aiProvider.mode}` : ""}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5">
+                  <div className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center shrink-0">
+                    <span className="material-symbols-rounded text-[var(--text-muted)]" style={{ fontSize: 22 }}>link_off</span>
+                  </div>
+                  <div>
+                    <div className="text-sm text-[var(--text-muted)]">No provider connected</div>
+                    <div className="text-xs text-[var(--text-muted)] opacity-50 mt-0.5">Select a provider below</div>
+                  </div>
+                </div>
+              )}
+            </div>
+
             <AIModelsStep embedded />
           </div>
         )}
@@ -692,16 +712,16 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         {/* ─── Telegram ─── */}
         {activeSection === "telegram" && (
           <div className="max-w-lg space-y-5">
-            <h2 className="text-lg font-semibold text-white/90">Telegram</h2>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">Telegram</h2>
 
             {/* Status card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="#f97316"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.96 6.504-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.492-1.302.48-.428-.012-1.252-.242-1.865-.44-.751-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>
-                <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Status</label>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Status</label>
               </div>
               {tgConfigured === null ? (
-                <div className="flex items-center gap-3 text-white/30 text-sm">
+                <div className="flex items-center gap-3 text-[var(--text-muted)] opacity-60 text-sm">
                   <div className="w-5 h-5 border-2 border-white/15 border-t-orange-400 rounded-full animate-spin" />
                   Checking...
                 </div>
@@ -712,7 +732,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       <span className="material-symbols-rounded text-green-400" style={{ fontSize: 22 }}>check_circle</span>
                     </div>
                     <div className="flex-1 min-w-0">
-                      <div className="text-sm text-white/90 font-medium">Bot Connected</div>
+                      <div className="text-sm text-[var(--text-primary)] font-medium">Bot Connected</div>
                       <div className="flex items-center gap-1.5 mt-0.5">
                         <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
                         <span className="text-xs text-green-400/80">Telegram channel active</span>
@@ -721,7 +741,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   </div>
                   <button
                     onClick={() => { setTgReconfigure(true); setTgStatus(null); }}
-                    className="text-sm text-orange-400 hover:text-orange-300 bg-transparent border-none cursor-pointer underline underline-offset-2"
+                    className="text-sm text-[var(--coral-bright)] hover:text-orange-300 bg-transparent border-none cursor-pointer underline underline-offset-2"
                   >
                     Reconfigure bot token
                   </button>
@@ -729,11 +749,11 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               ) : (
                 <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5">
                   <div className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center shrink-0">
-                    <span className="material-symbols-rounded text-white/25" style={{ fontSize: 22 }}>link_off</span>
+                    <span className="material-symbols-rounded text-[var(--text-muted)] opacity-50" style={{ fontSize: 22 }}>link_off</span>
                   </div>
                   <div>
-                    <div className="text-sm text-white/50">Not configured</div>
-                    <div className="text-xs text-white/25 mt-0.5">Set up a Telegram bot below</div>
+                    <div className="text-sm text-[var(--text-muted)]">Not configured</div>
+                    <div className="text-xs text-[var(--text-muted)] opacity-50 mt-0.5">Set up a Telegram bot below</div>
                   </div>
                 </div>
               )}
@@ -741,10 +761,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
             {/* Setup card — shown when not configured or reconfiguring */}
             {(tgConfigured === false || tgReconfigure) && (
-              <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+              <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                 <div className="flex items-center gap-2 mb-4">
-                  <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>add_circle</span>
-                  <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">
+                  <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>add_circle</span>
+                  <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
                     {tgReconfigure ? "Reconfigure Bot" : "Setup Bot"}
                   </label>
                 </div>
@@ -757,20 +777,20 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   <ol className="ml-0 pl-5 leading-[1.9] text-sm text-white/70 list-decimal">
                     <li>
                       Scan the QR or open{" "}
-                      <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" className="text-orange-400 hover:text-orange-300 font-semibold no-underline">
+                      <a href="https://t.me/BotFather" target="_blank" rel="noopener noreferrer" className="text-[var(--coral-bright)] hover:text-orange-300 font-semibold no-underline">
                         @BotFather
                       </a>{" "}
                       in Telegram
                     </li>
                     <li>
                       Send{" "}
-                      <code className="bg-white/[0.06] px-1.5 py-0.5 rounded text-xs text-orange-400">
+                      <code className="bg-white/[0.06] px-1.5 py-0.5 rounded text-xs text-[var(--coral-bright)]">
                         /newbot
                       </code>{" "}
                       and follow the prompts
                     </li>
                     <li>
-                      Copy the <strong className="text-white/90">Bot Token</strong> and paste below
+                      Copy the <strong className="text-[var(--text-primary)]">Bot Token</strong> and paste below
                     </li>
                   </ol>
                 </div>
@@ -779,7 +799,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <div>
                   <label htmlFor="settings-tg-token" className="block text-[11px] font-medium text-white/35 uppercase tracking-wider mb-2">Bot Token</label>
                   <div className="relative">
-                    <span className="material-symbols-rounded absolute left-3 top-1/2 -translate-y-1/2 text-white/20" style={{ fontSize: 18 }}>key</span>
+                    <span className="material-symbols-rounded absolute left-3 top-1/2 -translate-y-1/2 text-[var(--text-muted)] opacity-40" style={{ fontSize: 18 }}>key</span>
                     <input
                       id="settings-tg-token"
                       type={tgShowToken ? "text" : "password"}
@@ -788,13 +808,13 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       placeholder="123456789:ABCdefGHIjklMNOpqrsTUVwxyz"
                       spellCheck={false}
                       autoComplete="off"
-                      className="w-full pl-10 pr-10 py-2.5 bg-white/[0.04] border border-white/[0.08] rounded-xl text-sm text-white/90 outline-none focus:border-orange-400/60 focus:bg-white/[0.06] transition-all placeholder-white/15"
+                      className="w-full pl-10 pr-10 py-2.5 bg-white/[0.04] border border-white/[0.08] rounded-xl text-sm text-[var(--text-primary)] outline-none focus:border-orange-400/60 focus:bg-white/[0.06] transition-all placeholder-white/15"
                       onKeyDown={e => e.key === "Enter" && saveTelegram()}
                     />
                     <button
                       type="button"
                       onClick={() => setTgShowToken(v => !v)}
-                      className="absolute right-2.5 top-1/2 -translate-y-1/2 text-white/25 hover:text-white/60 bg-transparent border-none cursor-pointer p-0.5"
+                      className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)] opacity-50 hover:text-[var(--text-secondary)] bg-transparent border-none cursor-pointer p-0.5"
                     >
                       <span className="material-symbols-rounded" style={{ fontSize: 18 }}>{tgShowToken ? "visibility_off" : "visibility"}</span>
                     </button>
@@ -824,7 +844,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   {tgReconfigure && (
                     <button
                       onClick={() => { setTgReconfigure(false); setTgStatus(null); setTgToken(""); }}
-                      className="text-sm text-white/40 hover:text-white/60 bg-transparent border-none cursor-pointer"
+                      className="text-sm text-[var(--text-muted)] hover:text-[var(--text-secondary)] bg-transparent border-none cursor-pointer"
                     >
                       Cancel
                     </button>
@@ -834,12 +854,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             )}
 
             {/* Info card */}
-            <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-3">
-                <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>info</span>
-                <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">How it works</label>
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>info</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">How it works</label>
               </div>
-              <p className="text-xs text-white/40 leading-relaxed">
+              <p className="text-xs text-[var(--text-muted)] leading-relaxed">
                 Once configured, you can chat with your ClawBox AI assistant directly from Telegram. 
                 Send messages to your bot and it will respond using the AI provider configured in the AI Provider settings.
                 Your conversations are private and processed on your device.
@@ -851,70 +871,70 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         {/* ─── System ─── */}
         {activeSection === "system" && (
           <div className="max-w-2xl space-y-5">
-            <h2 className="text-lg font-semibold text-white/90">System</h2>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">System</h2>
 
             {stats ? (
               <>
                 {/* Device info card */}
-                <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+                <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>computer</span>
-                    <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Device</label>
-                    <span className="ml-auto text-xs font-mono text-orange-400/70 bg-orange-500/10 px-2 py-0.5 rounded-md">{stats.overview.uptime}</span>
+                    <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>computer</span>
+                    <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Device</label>
+                    <span className="ml-auto text-xs font-mono text-[var(--coral-bright)]/70 bg-orange-500/10 px-2 py-0.5 rounded-md">{stats.overview.uptime}</span>
                   </div>
                   <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-sm">
-                    <div className="flex justify-between"><span className="text-white/35">Hostname</span><span className="text-white/80 font-mono text-xs">{stats.overview.hostname}</span></div>
-                    <div className="flex justify-between"><span className="text-white/35">OS</span><span className="text-white/80 font-mono text-xs truncate ml-2">{stats.overview.os}</span></div>
-                    <div className="flex justify-between"><span className="text-white/35">Kernel</span><span className="text-white/80 font-mono text-xs truncate ml-2">{stats.overview.kernel}</span></div>
-                    <div className="flex justify-between"><span className="text-white/35">Arch</span><span className="text-white/80">{stats.overview.arch}</span></div>
+                    <div className="flex justify-between"><span className="text-white/35">Hostname</span><span className="text-[var(--text-primary)] font-mono text-xs">{stats.overview.hostname}</span></div>
+                    <div className="flex justify-between"><span className="text-white/35">OS</span><span className="text-[var(--text-primary)] font-mono text-xs truncate ml-2">{stats.overview.os}</span></div>
+                    <div className="flex justify-between"><span className="text-white/35">Kernel</span><span className="text-[var(--text-primary)] font-mono text-xs truncate ml-2">{stats.overview.kernel}</span></div>
+                    <div className="flex justify-between"><span className="text-white/35">Arch</span><span className="text-[var(--text-primary)]">{stats.overview.arch}</span></div>
                   </div>
                 </div>
 
                 {/* CPU + Memory card */}
-                <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+                <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>speed</span>
-                    <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Resources</label>
+                    <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>speed</span>
+                    <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Resources</label>
                   </div>
 
                   {/* CPU bar */}
                   <div className="mb-4">
                     <div className="flex items-center justify-between mb-1.5">
-                      <span className="text-xs text-white/50">CPU</span>
+                      <span className="text-xs text-[var(--text-muted)]">CPU</span>
                       <span className="text-xs font-mono font-semibold" style={{ color: barColor(stats.cpu.usage) }}>{stats.cpu.usage}%</span>
                     </div>
                     <div className="w-full h-2 rounded-full bg-white/[0.06] overflow-hidden">
                       <div className="h-full rounded-full transition-all duration-700" style={{ width: `${stats.cpu.usage}%`, backgroundColor: barColor(stats.cpu.usage) }} />
                     </div>
                     <div className="flex items-center justify-between mt-1.5">
-                      <span className="text-[10px] text-white/25 font-mono truncate max-w-[60%]">{stats.cpu.model}</span>
-                      <span className="text-[10px] text-white/25">{stats.cpu.cores} cores &middot; Load {stats.cpu.loadAvg[0]}</span>
+                      <span className="text-[10px] text-[var(--text-muted)] opacity-50 font-mono truncate max-w-[60%]">{stats.cpu.model}</span>
+                      <span className="text-[10px] text-[var(--text-muted)] opacity-50">{stats.cpu.cores} cores &middot; Load {stats.cpu.loadAvg[0]}</span>
                     </div>
                   </div>
 
                   {/* Memory bar */}
                   <div className="mb-4">
                     <div className="flex items-center justify-between mb-1.5">
-                      <span className="text-xs text-white/50">Memory</span>
-                      <span className="text-xs font-mono text-white/50">{formatBytes(stats.memory.used)} / {formatBytes(stats.memory.total)}</span>
+                      <span className="text-xs text-[var(--text-muted)]">Memory</span>
+                      <span className="text-xs font-mono text-[var(--text-muted)]">{formatBytes(stats.memory.used)} / {formatBytes(stats.memory.total)}</span>
                     </div>
                     <div className="w-full h-2 rounded-full bg-white/[0.06] overflow-hidden">
                       <div className="h-full rounded-full transition-all duration-700" style={{ width: `${stats.memory.usedPercent}%`, backgroundColor: barColor(stats.memory.usedPercent) }} />
                     </div>
-                    <div className="text-right text-[10px] text-white/25 mt-1">{stats.memory.usedPercent}% &middot; {formatBytes(stats.memory.free)} free</div>
+                    <div className="text-right text-[10px] text-[var(--text-muted)] opacity-50 mt-1">{stats.memory.usedPercent}% &middot; {formatBytes(stats.memory.free)} free</div>
                   </div>
 
                   {/* Swap bar (if any) */}
                   {stats.memory.swap.total > 0 && (
                     <div>
                       <div className="flex items-center justify-between mb-1.5">
-                        <span className="text-xs text-white/50">Swap</span>
-                        <span className="text-xs font-mono text-white/50">{formatBytes(stats.memory.swap.used)} / {formatBytes(stats.memory.swap.total)}</span>
+                        <span className="text-xs text-[var(--text-muted)]">Swap</span>
+                        <span className="text-xs font-mono text-[var(--text-muted)]">{formatBytes(stats.memory.swap.used)} / {formatBytes(stats.memory.swap.total)}</span>
                       </div>
                       <div className="w-full h-2 rounded-full bg-white/[0.06] overflow-hidden">
                         <div className="h-full rounded-full transition-all duration-700" style={{ width: `${stats.memory.swap.percent}%`, backgroundColor: "#a855f7" }} />
                       </div>
-                      <div className="text-right text-[10px] text-white/25 mt-1">{stats.memory.swap.percent}% used</div>
+                      <div className="text-right text-[10px] text-[var(--text-muted)] opacity-50 mt-1">{stats.memory.swap.percent}% used</div>
                     </div>
                   )}
 
@@ -922,7 +942,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   {stats.gpu != null && (
                     <div className="mt-4">
                       <div className="flex items-center justify-between mb-1.5">
-                        <span className="text-xs text-white/50">GPU</span>
+                        <span className="text-xs text-[var(--text-muted)]">GPU</span>
                         <span className="text-xs font-mono font-semibold" style={{ color: barColor(stats.gpu.usage) }}>{stats.gpu.usage}%</span>
                       </div>
                       <div className="w-full h-2 rounded-full bg-white/[0.06] overflow-hidden">
@@ -934,16 +954,16 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
                 {/* Temperature card */}
                 {stats.temperature?.value != null && (
-                  <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+                  <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                     <div className="flex items-center gap-2 mb-4">
-                      <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>thermostat</span>
-                      <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Temperature</label>
+                      <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>thermostat</span>
+                      <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Temperature</label>
                     </div>
                     <div className="flex items-end gap-3">
                       <span className="text-3xl font-mono font-bold" style={{ color: stats.temperature.value > 80 ? "#ef4444" : stats.temperature.value > 60 ? "#f97316" : "#22d3ee" }}>
                         {stats.temperature.display}
                       </span>
-                      <span className="text-xs text-white/25 mb-1.5">
+                      <span className="text-xs text-[var(--text-muted)] opacity-50 mb-1.5">
                         {stats.temperature.value > 80 ? "Critical" : stats.temperature.value > 60 ? "Warm" : "Normal"}
                       </span>
                     </div>
@@ -956,29 +976,29 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                         }}
                       />
                     </div>
-                    <div className="flex justify-between text-[10px] text-white/20 mt-1.5 font-mono">
+                    <div className="flex justify-between text-[10px] text-[var(--text-muted)] opacity-40 mt-1.5 font-mono">
                       <span>0°C</span><span>50°C</span><span>100°C</span>
                     </div>
                   </div>
                 )}
 
                 {/* Storage card */}
-                <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5">
+                <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                   <div className="flex items-center gap-2 mb-4">
-                    <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 18 }}>hard_drive</span>
-                    <label className="text-xs font-semibold text-white/50 uppercase tracking-wider">Storage</label>
+                    <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>hard_drive</span>
+                    <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">Storage</label>
                   </div>
                   <div className="space-y-3">
                     {stats.storage.filter(m => m.mountpoint !== "/boot/efi").map(m => (
                       <div key={m.mountpoint}>
                         <div className="flex items-center justify-between mb-1.5">
-                          <span className="text-xs text-white/60 font-mono">{m.mountpoint}</span>
+                          <span className="text-xs text-[var(--text-secondary)] font-mono">{m.mountpoint}</span>
                           <span className="text-xs text-white/35 font-mono">{m.used} / {m.size}</span>
                         </div>
                         <div className="w-full h-2 rounded-full bg-white/[0.06] overflow-hidden">
                           <div className="h-full rounded-full transition-all duration-700" style={{ width: `${m.usePercent}%`, backgroundColor: barColor(m.usePercent) }} />
                         </div>
-                        <div className="text-right text-[10px] text-white/25 mt-1">{m.usePercent}% &middot; {m.avail} free</div>
+                        <div className="text-right text-[10px] text-[var(--text-muted)] opacity-50 mt-1">{m.usePercent}% &middot; {m.avail} free</div>
                       </div>
                     ))}
                   </div>
@@ -986,7 +1006,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
               </>
             ) : (
-              <div className="flex items-center justify-center py-12 text-white/30">
+              <div className="flex items-center justify-center py-12 text-[var(--text-muted)] opacity-60">
                 <div className="w-6 h-6 border-2 border-white/20 rounded-full animate-spin mr-3" style={{ borderTopColor: "#fe6e00" }} />
                 <span className="text-sm">Loading system stats...</span>
               </div>
@@ -998,29 +1018,29 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         {/* ─── About ─── */}
         {activeSection === "about" && (
           <div className="max-w-md space-y-6">
-            <h2 className="text-lg font-semibold text-white/90 mb-4">About ClawBox</h2>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-4">About ClawBox</h2>
 
             <div className="bg-white/5 rounded-xl p-5 space-y-4">
               <div className="flex items-center gap-4">
                 <img src="/icon-512.png" alt="ClawBox" className="w-14 h-14 rounded-2xl" onError={e => { (e.target as HTMLImageElement).style.display = "none"; }} />
                 <div>
-                  <div className="text-lg font-bold text-white/90">ClawBox</div>
-                  <div className="text-xs text-white/40">Personal AI Assistant Device</div>
+                  <div className="text-lg font-bold text-[var(--text-primary)]">ClawBox</div>
+                  <div className="text-xs text-[var(--text-muted)]">Personal AI Assistant Device</div>
                 </div>
               </div>
 
-              <div className="space-y-2 pt-2 border-t border-white/5">
+              <div className="space-y-2 pt-2 border-t border-[var(--border-subtle)]">
                 <div className="flex justify-between text-sm">
-                  <span className="text-white/40">Version</span>
-                  <span className="text-white/80">{versionInfo?.clawbox.current ?? process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown"}</span>
+                  <span className="text-[var(--text-muted)]">Version</span>
+                  <span className="text-[var(--text-primary)]">{versionInfo?.clawbox.current ?? process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown"}</span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-white/40">Runtime</span>
-                  <span className="text-white/80">Next.js + Bun</span>
+                  <span className="text-[var(--text-muted)]">Runtime</span>
+                  <span className="text-[var(--text-primary)]">Next.js + Bun</span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-white/40">Platform</span>
-                  <span className="text-white/80">{stats ? `${stats.overview.arch} ${stats.overview.platform}` : "..."}</span>
+                  <span className="text-[var(--text-muted)]">Platform</span>
+                  <span className="text-[var(--text-primary)]">{stats ? `${stats.overview.arch} ${stats.overview.platform}` : "..."}</span>
                 </div>
               </div>
             </div>
@@ -1029,7 +1049,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               href="https://openclawhardware.dev/docs"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-3 bg-white/5 rounded-xl px-4 py-3 text-sm text-white/60 hover:text-white/80 transition-colors no-underline"
+              className="flex items-center gap-3 bg-white/5 rounded-xl px-4 py-3 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors no-underline"
             >
               <span className="material-symbols-rounded" style={{ fontSize: 20 }}>help</span>
               Documentation
@@ -1040,7 +1060,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               href="https://t.me/ClawBoxSupportBot"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-3 bg-white/5 rounded-xl px-4 py-3 text-sm text-white/60 hover:text-white/80 transition-colors no-underline"
+              className="flex items-center gap-3 bg-white/5 rounded-xl px-4 py-3 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors no-underline"
             >
               <span className="material-symbols-rounded" style={{ fontSize: 20 }}>support_agent</span>
               Support
@@ -1051,29 +1071,28 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               href="https://discord.gg/FbKmnxYnpq"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-3 bg-white/5 rounded-xl px-4 py-3 text-sm text-white/60 hover:text-white/80 transition-colors no-underline"
+              className="flex items-center gap-3 bg-white/5 rounded-xl px-4 py-3 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors no-underline"
             >
               <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor"><path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.874-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.095 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z"/></svg>
               Discord Community
               <span className="material-symbols-rounded ml-auto" style={{ fontSize: 16 }}>open_in_new</span>
             </a>
 
-            <div className="space-y-2 pt-2">
-              <button
-                onClick={() => openUpdateConfirm()}
-                className="flex items-center gap-3 w-full bg-green-500/10 rounded-xl px-4 py-3 text-sm text-green-400/80 hover:text-green-400 border border-green-500/20 hover:bg-green-500/15 transition-colors cursor-pointer"
-              >
-                <span className="material-symbols-rounded" style={{ fontSize: 20 }}>system_update</span>
-                System Update
-              </button>
-              <button
-                onClick={() => setResetConfirm(true)}
-                className="flex items-center gap-3 w-full bg-red-500/5 rounded-xl px-4 py-3 text-sm text-red-400/60 hover:text-red-400 transition-colors cursor-pointer"
-              >
-                <span className="material-symbols-rounded" style={{ fontSize: 20 }}>restart_alt</span>
-                Factory Reset
-              </button>
-            </div>
+            <button
+              onClick={() => openUpdateConfirm()}
+              className="flex items-center gap-3 w-full bg-green-500/10 rounded-xl px-4 py-3 text-sm text-green-400/80 hover:text-green-400 border border-green-500/20 hover:bg-green-500/15 transition-colors cursor-pointer"
+            >
+              <span className="material-symbols-rounded" style={{ fontSize: 20 }}>system_update</span>
+              System Update
+            </button>
+
+            <button
+              onClick={() => setResetConfirm(true)}
+              className="flex items-center gap-3 w-full bg-red-500/5 rounded-xl px-4 py-3 text-sm text-red-400/60 hover:text-red-400 transition-colors cursor-pointer"
+            >
+              <span className="material-symbols-rounded" style={{ fontSize: 20 }}>restart_alt</span>
+              Factory Reset
+            </button>
           </div>
         )}
     </>
@@ -1082,21 +1101,21 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   // ─── Mobile layout: full-screen nav or full-screen content ───
   if (isMobile) {
     return (
-      <div className="flex flex-col h-full bg-[#0d1117]">
+      <div className="flex flex-col h-full bg-[var(--bg-deep)]">
         {mobileSection === null ? (
           /* Nav list */
           <div className="flex-1 overflow-y-auto">
-            <h2 className="text-lg font-semibold text-white/90 px-5 pt-4 pb-2">Settings</h2>
+            <h2 className="text-lg font-semibold text-[var(--text-primary)] px-5 pt-4 pb-2">Settings</h2>
             <nav className="flex flex-col">
               {NAV_ITEMS.map(item => (
                 <button
                   key={item.id}
                   onClick={() => { setSection(item.id); setMobileSection(item.id); }}
-                  className="flex items-center gap-3 px-5 py-3.5 text-sm border-none cursor-pointer transition-colors text-white/70 hover:bg-white/5 active:bg-white/10"
+                  className="flex items-center gap-3 px-5 py-3.5 text-sm border-none cursor-pointer transition-colors text-[var(--text-secondary)] hover:bg-white/[0.04] active:bg-white/[0.08]"
                 >
-                  <span className="material-symbols-rounded text-orange-400" style={{ fontSize: 20 }}>{item.icon}</span>
+                  <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 20 }}>{item.icon}</span>
                   <span className="flex-1 text-left">{item.label}</span>
-                  <span className="material-symbols-rounded text-white/20" style={{ fontSize: 18 }}>chevron_right</span>
+                  <span className="material-symbols-rounded text-[var(--text-muted)] opacity-40" style={{ fontSize: 18 }}>chevron_right</span>
                 </button>
               ))}
             </nav>
@@ -1104,14 +1123,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         ) : (
           /* Content with back button */
           <>
-            <div className="flex items-center gap-2 px-3 py-2 border-b border-white/[0.06] shrink-0">
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--border-subtle)] shrink-0">
               <button
                 onClick={() => setMobileSection(null)}
-                className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/10 text-white/60 cursor-pointer"
+                className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/10 text-[var(--text-secondary)] cursor-pointer"
               >
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M15 18l-6-6 6-6" /></svg>
               </button>
-              <span className="text-sm font-medium text-white/80">
+              <span className="text-sm font-medium text-[var(--text-primary)]">
                 {NAV_ITEMS.find(i => i.id === mobileSection)?.label ?? "Settings"}
               </span>
             </div>
@@ -1124,32 +1143,32 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         {/* Update confirmation modal */}
       {updateConfirm && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
-          <div className="bg-[#1e2030] border border-white/10 rounded-2xl shadow-2xl p-6 max-w-sm w-full">
-            <h3 className="text-lg font-bold text-white/90 mb-2">System Update</h3>
-            <p className="text-sm text-white/50 mb-4 leading-relaxed">
+          <div className="bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-2xl shadow-2xl p-6 max-w-sm w-full">
+            <h3 className="text-lg font-bold text-[var(--text-primary)] mb-2">System Update</h3>
+            <p className="text-sm text-[var(--text-muted)] mb-4 leading-relaxed">
               This will pull the latest updates and restart the device. The process may take a few minutes.
             </p>
             {versionLoading ? (
-              <div className="mb-4 text-xs text-white/30">Checking versions...</div>
+              <div className="mb-4 text-xs text-[var(--text-muted)] opacity-60">Checking versions...</div>
             ) : versionInfo && (
               <div className="mb-4 space-y-2 text-xs">
                 <div className="flex items-center justify-between bg-white/[0.04] rounded-lg px-3 py-2">
-                  <span className="text-white/50 font-medium">ClawBox</span>
-                  <span className="text-white/80">
+                  <span className="text-[var(--text-muted)] font-medium">ClawBox</span>
+                  <span className="text-[var(--text-primary)]">
                     {versionInfo.clawbox.current}
                     {versionInfo.clawbox.target ? (
-                      <span className="text-white/30">{" → "}<span className="text-emerald-400">{versionInfo.clawbox.target}</span></span>
+                      <span className="text-[var(--text-muted)] opacity-60">{" → "}<span className="text-emerald-400">{versionInfo.clawbox.target}</span></span>
                     ) : (
                       <span className="text-emerald-400 ml-2 text-[10px] uppercase font-semibold">Latest</span>
                     )}
                   </span>
                 </div>
                 <div className="flex items-center justify-between bg-white/[0.04] rounded-lg px-3 py-2">
-                  <span className="text-white/50 font-medium">OpenClaw</span>
-                  <span className="text-white/80">
+                  <span className="text-[var(--text-muted)] font-medium">OpenClaw</span>
+                  <span className="text-[var(--text-primary)]">
                     {versionInfo.openclaw.current ?? "not installed"}
                     {versionInfo.openclaw.target ? (
-                      <span className="text-white/30">{" → "}<span className="text-emerald-400">{versionInfo.openclaw.target}</span></span>
+                      <span className="text-[var(--text-muted)] opacity-60">{" → "}<span className="text-emerald-400">{versionInfo.openclaw.target}</span></span>
                     ) : versionInfo.openclaw.current ? (
                       <span className="text-emerald-400 ml-2 text-[10px] uppercase font-semibold">Latest</span>
                     ) : null}
@@ -1160,7 +1179,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             {/* Branch selector */}
             {!versionLoading && (updateBranch || /^v\d+\.\d+\.\d+-.+/.test(versionInfo?.clawbox.current ?? "")) && (
               <div className="mb-4">
-                <label htmlFor="settings-update-branch" className="text-xs text-white/30 mb-1 block">Update branch</label>
+                <label htmlFor="settings-update-branch" className="text-xs text-[var(--text-muted)] opacity-60 mb-1 block">Update branch</label>
                 <div className="flex gap-2">
                   <input
                     id="settings-update-branch"
@@ -1168,7 +1187,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     value={branchInput}
                     onChange={(e) => { setBranchInput(e.target.value); setBranchError(null); }}
                     placeholder="main"
-                    className="flex-1 bg-white/[0.04] border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white/80 placeholder:text-white/20 outline-none focus:border-orange-500"
+                    className="flex-1 bg-white/[0.04] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] opacity-40 outline-none focus:border-[var(--coral-bright)]"
                   />
                   <button
                     type="button"
@@ -1187,12 +1206,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   </div>
                 )}
                 {!updateBranch && !branchError && (
-                  <p className="mt-1 text-xs text-white/20">Leave empty to follow current branch or main</p>
+                  <p className="mt-1 text-xs text-[var(--text-muted)] opacity-40">Leave empty to follow current branch or main</p>
                 )}
               </div>
             )}
             <div className="flex items-center gap-3 justify-end">
-              <button type="button" onClick={() => setUpdateConfirm(false)} className="px-5 py-2.5 bg-white/10 text-white/80 border border-white/10 rounded-lg text-sm font-semibold cursor-pointer hover:bg-white/15 transition-colors">
+              <button type="button" onClick={() => setUpdateConfirm(false)} className="px-5 py-2.5 bg-white/10 text-[var(--text-primary)] border border-[var(--border-subtle)] rounded-lg text-sm font-semibold cursor-pointer hover:bg-white/15 transition-colors">
                 Cancel
               </button>
               <button type="button" disabled={branchSaving} onClick={() => { setUpdateConfirm(false); triggerUpdate(); }} className="px-5 py-2.5 bg-orange-500 text-white rounded-lg text-sm font-semibold cursor-pointer hover:bg-orange-600 hover:scale-105 transition-all disabled:opacity-40 disabled:hover:scale-100">
@@ -1206,11 +1225,11 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       {/* Factory Reset confirmation modal */}
       {resetConfirm && !resetting && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="bg-[#1a1f2e] rounded-2xl p-6 max-w-sm w-full shadow-2xl border border-white/10">
-            <h3 className="text-lg font-bold text-white/90 mb-2">Factory Reset?</h3>
-            <p className="text-sm text-white/50 mb-5">This will erase all settings, credentials, and AI configuration. The setup wizard will restart.</p>
+          <div className="bg-[var(--bg-elevated)] rounded-2xl p-6 max-w-sm w-full shadow-2xl border border-[var(--border-subtle)]">
+            <h3 className="text-lg font-bold text-[var(--text-primary)] mb-2">Factory Reset?</h3>
+            <p className="text-sm text-[var(--text-muted)] mb-5">This will erase all settings, credentials, and AI configuration. The setup wizard will restart.</p>
             <div className="flex gap-3">
-              <button onClick={() => setResetConfirm(false)} className="flex-1 py-2.5 bg-white/5 text-white/60 rounded-xl text-sm font-semibold cursor-pointer border-none hover:bg-white/10 transition-colors">
+              <button onClick={() => setResetConfirm(false)} className="flex-1 py-2.5 bg-white/5 text-[var(--text-secondary)] rounded-xl text-sm font-semibold cursor-pointer border-none hover:bg-white/10 transition-colors">
                 Cancel
               </button>
               <button onClick={resetSetup} className="flex-1 py-2.5 bg-red-500 text-white rounded-xl text-sm font-semibold cursor-pointer border-none hover:bg-red-600 transition-colors">
@@ -1230,25 +1249,25 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <span className="material-symbols-rounded text-white" style={{ fontSize: 32 }}>check</span>
               </div>
             ) : (
-              <div className="w-16 h-16 rounded-full border-[3px] border-white/10 animate-spin" style={{ borderTopColor: "#f97316" }} />
+              <div className="w-16 h-16 rounded-full border-[3px] border-[var(--border-subtle)] animate-spin" style={{ borderTopColor: "#f97316" }} />
             )}
 
             {resetPhase === "waiting" && (
               <>
                 <h2 className="text-xl font-semibold text-white">Resetting{".".repeat(resetDots)}</h2>
-                <p className="text-sm text-white/50">Erasing all settings and restarting. Please wait.</p>
+                <p className="text-sm text-[var(--text-muted)]">Erasing all settings and restarting. Please wait.</p>
               </>
             )}
             {resetPhase === "reconnecting" && (
               <>
                 <h2 className="text-xl font-semibold text-white">Reconnecting{".".repeat(resetDots)}</h2>
-                <p className="text-sm text-white/50">Waiting for device to come back online.</p>
+                <p className="text-sm text-[var(--text-muted)]">Waiting for device to come back online.</p>
               </>
             )}
             {resetPhase === "done" && (
               <>
                 <h2 className="text-xl font-semibold text-white">Device is back online</h2>
-                <p className="text-sm text-white/50">Starting setup wizard...</p>
+                <p className="text-sm text-[var(--text-muted)]">Starting setup wizard...</p>
               </>
             )}
           </div>
@@ -1260,23 +1279,26 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
   // ─── Desktop layout: sidebar + content ───
   return (
-    <div className="flex h-full bg-[#0d1117]">
+    <div className="flex h-full bg-[var(--bg-deep)]">
       {/* Sidebar */}
-      <nav className="w-48 shrink-0 bg-white/[0.02] border-r border-white/5 py-3 flex flex-col">
-        {NAV_ITEMS.map(item => (
-          <button
-            key={item.id}
-            onClick={() => setSection(item.id)}
-            className={`flex items-center gap-3 px-4 py-2.5 text-sm border-none cursor-pointer transition-colors ${
-              activeSection === item.id
-                ? "bg-orange-500/10 text-orange-400 border-r-2 border-r-orange-400"
-                : "text-white/50 hover:text-white/80 hover:bg-white/5"
-            }`}
-          >
-            <span className="material-symbols-rounded" style={{ fontSize: 20 }}>{item.icon}</span>
-            {item.label}
-          </button>
-        ))}
+      <nav className="w-48 shrink-0 bg-[var(--bg-surface)] border-r border-[var(--border-subtle)] py-3 flex flex-col">
+        {NAV_ITEMS.map(item => {
+          const active = activeSection === item.id;
+          return (
+            <button
+              key={item.id}
+              onClick={() => setSection(item.id)}
+              className={`flex items-center gap-2.5 px-4 py-2.5 text-sm border-none cursor-pointer transition-colors text-left border-l-2 ${
+                active
+                  ? "bg-white/[0.08] text-[var(--text-primary)] border-l-[var(--coral-bright)]"
+                  : "text-[var(--text-secondary)] border-l-transparent hover:bg-white/[0.04] hover:text-[var(--text-primary)]"
+              }`}
+            >
+              <span className="material-symbols-rounded" style={{ fontSize: 18, color: active ? "var(--coral-bright)" : "var(--text-muted)" }}>{item.icon}</span>
+              {item.label}
+            </button>
+          );
+        })}
         <div className="flex-1" />
       </nav>
 
@@ -1288,32 +1310,32 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       {/* Update confirmation modal */}
       {updateConfirm && (
         <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 backdrop-blur-sm px-4">
-          <div className="bg-[#1e2030] border border-white/10 rounded-2xl shadow-2xl p-6 max-w-sm w-full">
-            <h3 className="text-lg font-bold text-white/90 mb-2">System Update</h3>
-            <p className="text-sm text-white/50 mb-4 leading-relaxed">
+          <div className="bg-[var(--bg-elevated)] border border-[var(--border-subtle)] rounded-2xl shadow-2xl p-6 max-w-sm w-full">
+            <h3 className="text-lg font-bold text-[var(--text-primary)] mb-2">System Update</h3>
+            <p className="text-sm text-[var(--text-muted)] mb-4 leading-relaxed">
               This will pull the latest updates and restart the device. The process may take a few minutes.
             </p>
             {versionLoading ? (
-              <div className="mb-4 text-xs text-white/30">Checking versions...</div>
+              <div className="mb-4 text-xs text-[var(--text-muted)] opacity-60">Checking versions...</div>
             ) : versionInfo && (
               <div className="mb-4 space-y-2 text-xs">
                 <div className="flex items-center justify-between bg-white/[0.04] rounded-lg px-3 py-2">
-                  <span className="text-white/50 font-medium">ClawBox</span>
-                  <span className="text-white/80">
+                  <span className="text-[var(--text-muted)] font-medium">ClawBox</span>
+                  <span className="text-[var(--text-primary)]">
                     {versionInfo.clawbox.current}
                     {versionInfo.clawbox.target ? (
-                      <span className="text-white/30">{" → "}<span className="text-emerald-400">{versionInfo.clawbox.target}</span></span>
+                      <span className="text-[var(--text-muted)] opacity-60">{" → "}<span className="text-emerald-400">{versionInfo.clawbox.target}</span></span>
                     ) : (
                       <span className="text-emerald-400 ml-2 text-[10px] uppercase font-semibold">Latest</span>
                     )}
                   </span>
                 </div>
                 <div className="flex items-center justify-between bg-white/[0.04] rounded-lg px-3 py-2">
-                  <span className="text-white/50 font-medium">OpenClaw</span>
-                  <span className="text-white/80">
+                  <span className="text-[var(--text-muted)] font-medium">OpenClaw</span>
+                  <span className="text-[var(--text-primary)]">
                     {versionInfo.openclaw.current ?? "not installed"}
                     {versionInfo.openclaw.target ? (
-                      <span className="text-white/30">{" → "}<span className="text-emerald-400">{versionInfo.openclaw.target}</span></span>
+                      <span className="text-[var(--text-muted)] opacity-60">{" → "}<span className="text-emerald-400">{versionInfo.openclaw.target}</span></span>
                     ) : versionInfo.openclaw.current ? (
                       <span className="text-emerald-400 ml-2 text-[10px] uppercase font-semibold">Latest</span>
                     ) : null}
@@ -1323,7 +1345,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             )}
             {!versionLoading && (updateBranch || /^v\d+\.\d+\.\d+-.+/.test(versionInfo?.clawbox.current ?? "")) && (
               <div className="mb-4">
-                <label htmlFor="settings-update-branch-d" className="text-xs text-white/30 mb-1 block">Update branch</label>
+                <label htmlFor="settings-update-branch-d" className="text-xs text-[var(--text-muted)] opacity-60 mb-1 block">Update branch</label>
                 <div className="flex gap-2">
                   <input
                     id="settings-update-branch-d"
@@ -1331,7 +1353,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     value={branchInput}
                     onChange={(e) => { setBranchInput(e.target.value); setBranchError(null); }}
                     placeholder="main"
-                    className="flex-1 bg-white/[0.04] border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white/80 placeholder:text-white/20 outline-none focus:border-orange-500"
+                    className="flex-1 bg-white/[0.04] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--text-primary)] placeholder:text-[var(--text-muted)] opacity-40 outline-none focus:border-[var(--coral-bright)]"
                   />
                   <button
                     type="button"
@@ -1350,12 +1372,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   </div>
                 )}
                 {!updateBranch && !branchError && (
-                  <p className="mt-1 text-xs text-white/20">Leave empty to follow current branch or main</p>
+                  <p className="mt-1 text-xs text-[var(--text-muted)] opacity-40">Leave empty to follow current branch or main</p>
                 )}
               </div>
             )}
             <div className="flex items-center gap-3 justify-end">
-              <button type="button" onClick={() => setUpdateConfirm(false)} className="px-5 py-2.5 bg-white/10 text-white/80 border border-white/10 rounded-lg text-sm font-semibold cursor-pointer hover:bg-white/15 transition-colors">
+              <button type="button" onClick={() => setUpdateConfirm(false)} className="px-5 py-2.5 bg-white/10 text-[var(--text-primary)] border border-[var(--border-subtle)] rounded-lg text-sm font-semibold cursor-pointer hover:bg-white/15 transition-colors">
                 Cancel
               </button>
               <button type="button" disabled={branchSaving} onClick={() => { setUpdateConfirm(false); triggerUpdate(); }} className="px-5 py-2.5 bg-orange-500 text-white rounded-lg text-sm font-semibold cursor-pointer hover:bg-orange-600 hover:scale-105 transition-all disabled:opacity-40 disabled:hover:scale-100">
@@ -1369,11 +1391,11 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       {/* Factory Reset confirmation modal */}
       {resetConfirm && !resetting && (
         <div className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm">
-          <div className="bg-[#1a1f2e] rounded-2xl p-6 max-w-sm w-full shadow-2xl border border-white/10">
-            <h3 className="text-lg font-bold text-white/90 mb-2">Factory Reset?</h3>
-            <p className="text-sm text-white/50 mb-5">This will erase all settings, credentials, and AI configuration. The setup wizard will restart.</p>
+          <div className="bg-[var(--bg-elevated)] rounded-2xl p-6 max-w-sm w-full shadow-2xl border border-[var(--border-subtle)]">
+            <h3 className="text-lg font-bold text-[var(--text-primary)] mb-2">Factory Reset?</h3>
+            <p className="text-sm text-[var(--text-muted)] mb-5">This will erase all settings, credentials, and AI configuration. The setup wizard will restart.</p>
             <div className="flex gap-3">
-              <button onClick={() => setResetConfirm(false)} className="flex-1 py-2.5 bg-white/5 text-white/60 rounded-xl text-sm font-semibold cursor-pointer border-none hover:bg-white/10 transition-colors">
+              <button onClick={() => setResetConfirm(false)} className="flex-1 py-2.5 bg-white/5 text-[var(--text-secondary)] rounded-xl text-sm font-semibold cursor-pointer border-none hover:bg-white/10 transition-colors">
                 Cancel
               </button>
               <button onClick={resetSetup} className="flex-1 py-2.5 bg-red-500 text-white rounded-xl text-sm font-semibold cursor-pointer border-none hover:bg-red-600 transition-colors">
@@ -1393,25 +1415,25 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <span className="material-symbols-rounded text-white" style={{ fontSize: 32 }}>check</span>
               </div>
             ) : (
-              <div className="w-16 h-16 rounded-full border-[3px] border-white/10 animate-spin" style={{ borderTopColor: "#f97316" }} />
+              <div className="w-16 h-16 rounded-full border-[3px] border-[var(--border-subtle)] animate-spin" style={{ borderTopColor: "#f97316" }} />
             )}
 
             {resetPhase === "waiting" && (
               <>
                 <h2 className="text-xl font-semibold text-white">Resetting{".".repeat(resetDots)}</h2>
-                <p className="text-sm text-white/50">Erasing all settings and restarting. Please wait.</p>
+                <p className="text-sm text-[var(--text-muted)]">Erasing all settings and restarting. Please wait.</p>
               </>
             )}
             {resetPhase === "reconnecting" && (
               <>
                 <h2 className="text-xl font-semibold text-white">Reconnecting{".".repeat(resetDots)}</h2>
-                <p className="text-sm text-white/50">Waiting for device to come back online.</p>
+                <p className="text-sm text-[var(--text-muted)]">Waiting for device to come back online.</p>
               </>
             )}
             {resetPhase === "done" && (
               <>
                 <h2 className="text-xl font-semibold text-white">Device is back online</h2>
-                <p className="text-sm text-white/50">Starting setup wizard...</p>
+                <p className="text-sm text-[var(--text-muted)]">Starting setup wizard...</p>
               </>
             )}
           </div>

--- a/src/components/SystemTray.tsx
+++ b/src/components/SystemTray.tsx
@@ -236,24 +236,36 @@ export default function SystemTray({
           </div>
 
           {/* Bottom actions */}
-          <div className="p-4 grid grid-cols-2 gap-2">
+          <div className="p-4 flex flex-col gap-2">
+            <div className="grid grid-cols-2 gap-2">
+              <button
+                onClick={() => handlePower("restart")}
+                className={`flex items-center justify-center gap-2 h-10 rounded-lg transition-colors cursor-pointer ${
+                  confirmAction === "restart" ? "bg-yellow-500/30 hover:bg-yellow-500/40" : "bg-white/10 hover:bg-white/15"
+                }`}
+              >
+                <span className="material-symbols-rounded text-white/70 shrink-0" style={{ fontSize: 16 }}>restart_alt</span>
+                <span className="text-sm text-white/80 whitespace-nowrap">{confirmAction === "restart" ? "Confirm?" : "Restart"}</span>
+              </button>
+              <button
+                onClick={() => handlePower("shutdown")}
+                className={`flex items-center justify-center gap-2 h-10 rounded-lg transition-colors cursor-pointer ${
+                  confirmAction === "shutdown" ? "bg-red-500/30 hover:bg-red-500/40" : "bg-white/10 hover:bg-white/15"
+                }`}
+              >
+                <span className="material-symbols-rounded text-white/70 shrink-0" style={{ fontSize: 16 }}>power_settings_new</span>
+                <span className="text-sm text-white/80 whitespace-nowrap">{confirmAction === "shutdown" ? "Confirm?" : "Shut Down"}</span>
+              </button>
+            </div>
             <button
-              onClick={() => handlePower("restart")}
-              className={`flex items-center justify-center gap-2 h-10 rounded-lg transition-colors cursor-pointer ${
-                confirmAction === "restart" ? "bg-yellow-500/30 hover:bg-yellow-500/40" : "bg-white/10 hover:bg-white/15"
-              }`}
+              onClick={async () => {
+                await fetch("/login-api/logout", { method: "POST" }).catch(() => {});
+                window.location.href = "/login";
+              }}
+              className="flex items-center justify-center gap-2 h-10 rounded-lg transition-colors cursor-pointer bg-white/10 hover:bg-white/15 w-full"
             >
-              <span className="material-symbols-rounded text-white/70 shrink-0" style={{ fontSize: 16 }}>restart_alt</span>
-              <span className="text-sm text-white/80 whitespace-nowrap">{confirmAction === "restart" ? "Confirm?" : "Restart"}</span>
-            </button>
-            <button
-              onClick={() => handlePower("shutdown")}
-              className={`flex items-center justify-center gap-2 h-10 rounded-lg transition-colors cursor-pointer ${
-                confirmAction === "shutdown" ? "bg-red-500/30 hover:bg-red-500/40" : "bg-white/10 hover:bg-white/15"
-              }`}
-            >
-              <span className="material-symbols-rounded text-white/70 shrink-0" style={{ fontSize: 16 }}>power_settings_new</span>
-              <span className="text-sm text-white/80 whitespace-nowrap">{confirmAction === "shutdown" ? "Confirm?" : "Shut Down"}</span>
+              <span className="material-symbols-rounded text-white/70 shrink-0" style={{ fontSize: 16 }}>lock</span>
+              <span className="text-sm text-white/80">Lock</span>
             </button>
           </div>
         </div>

--- a/src/components/VNCApp.tsx
+++ b/src/components/VNCApp.tsx
@@ -70,14 +70,14 @@ export default function VNCApp() {
         rfb.addEventListener("connect", () => {
           setStatus("connected");
           setError(null);
-          // Focus the VNC canvas so keyboard events pass through
           rfb?.focus();
-          // Ensure the internal canvas element is focusable
           const canvas = canvasContainerRef.current?.querySelector("canvas");
           if (canvas) {
             canvas.tabIndex = 0;
             canvas.focus();
           }
+          // Prevent browser context menu so right-clicks pass to the remote desktop
+          canvasContainerRef.current?.addEventListener("contextmenu", (e) => e.preventDefault());
         });
 
         rfb.addEventListener("disconnect", (e: CustomEvent) => {

--- a/src/components/VNCApp.tsx
+++ b/src/components/VNCApp.tsx
@@ -1,11 +1,5 @@
 "use client";
 
-/**
- * VNCApp — Remote desktop viewer using noVNC.
- * Connects to a VNC server via a WebSocket proxy running on port 6080.
- * If no VNC server is detected, shows setup instructions.
- */
-
 import React, { useEffect, useRef, useState, useCallback } from "react";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected" | "error";
@@ -15,21 +9,14 @@ export default function VNCApp() {
   const rfbRef = useRef<InstanceType<typeof import("@novnc/novnc/lib/rfb").default> | null>(null);
   const [status, setStatus] = useState<ConnectionStatus>("connecting");
   const [error, setError] = useState<string | null>(null);
-  const [vncInfo, setVncInfo] = useState<{ host: string; wsPort: number; vncPort: number } | null>(null);
-  const [clipboardText, setClipboardText] = useState("");
-  const [showClipboard, setShowClipboard] = useState(false);
-  const [scale, setScale] = useState(true);
+  const [vncInfo, setVncInfo] = useState<{ host: string; wsPort: number } | null>(null);
 
   const checkVnc = useCallback(async () => {
     try {
       const res = await fetch("/setup-api/vnc");
       const data = await res.json();
       if (data.available) {
-        setVncInfo({
-          host: window.location.hostname,
-          wsPort: data.wsPort || 6080,
-          vncPort: data.vncPort || 5900,
-        });
+        setVncInfo({ host: window.location.hostname, wsPort: data.wsPort || 6080 });
       } else {
         setStatus("error");
         setError(data.error || "No VNC server detected");
@@ -40,12 +27,8 @@ export default function VNCApp() {
     }
   }, []);
 
-  // Check VNC availability on mount
-  useEffect(() => {
-    checkVnc();
-  }, [checkVnc]);
+  useEffect(() => { checkVnc(); }, [checkVnc]);
 
-  // Connect to VNC when info available
   useEffect(() => {
     if (!vncInfo || !canvasContainerRef.current) return;
 
@@ -54,10 +37,7 @@ export default function VNCApp() {
     const connect = async () => {
       try {
         const { default: RFB } = await import("@novnc/novnc/lib/rfb");
-
-        const wsUrl = `ws://${vncInfo.host}:${vncInfo.wsPort}`;
-
-        rfb = new RFB(canvasContainerRef.current!, wsUrl, {
+        rfb = new RFB(canvasContainerRef.current!, `ws://${vncInfo.host}:${vncInfo.wsPort}`, {
           credentials: { password: "" },
         });
 
@@ -72,23 +52,13 @@ export default function VNCApp() {
           setError(null);
           rfb?.focus();
           const canvas = canvasContainerRef.current?.querySelector("canvas");
-          if (canvas) {
-            canvas.tabIndex = 0;
-            canvas.focus();
-          }
-          // Prevent browser context menu so right-clicks pass to the remote desktop
+          if (canvas) { canvas.tabIndex = 0; canvas.focus(); }
           canvasContainerRef.current?.addEventListener("contextmenu", (e) => e.preventDefault());
         });
 
         rfb.addEventListener("disconnect", (e: CustomEvent) => {
           setStatus("disconnected");
-          if (e.detail?.clean === false) {
-            setError("Connection lost unexpectedly");
-          }
-        });
-
-        rfb.addEventListener("clipboard", (e: CustomEvent) => {
-          if (e.detail?.text) setClipboardText(e.detail.text);
+          if (e.detail?.clean === false) setError("Connection lost unexpectedly");
         });
 
         rfbRef.current = rfb;
@@ -99,59 +69,31 @@ export default function VNCApp() {
     };
 
     connect();
-
-    return () => {
-      if (rfb) {
-        rfb.disconnect();
-        rfbRef.current = null;
-      }
-    };
+    return () => { if (rfb) { rfb.disconnect(); rfbRef.current = null; } };
   }, [vncInfo]);
 
-  // Update scale without reconnecting
-  useEffect(() => {
-    if (rfbRef.current) rfbRef.current.scaleViewport = scale;
-  }, [scale]);
-
-  // Track whether the VNC window is the "active" window so we know when to
-  // forward keyboard events. We set this on mousedown inside the VNC container.
+  // Track VNC focus for keyboard forwarding
   const vncActiveRef = useRef(false);
-
   useEffect(() => {
     if (status !== "connected") return;
     const container = canvasContainerRef.current;
     if (!container) return;
-
-    // Mark VNC as active when clicking inside the container
     const activate = () => { vncActiveRef.current = true; };
-    // Deactivate when clicking outside
     const deactivate = (e: MouseEvent) => {
-      if (!container.contains(e.target as Node)) {
-        vncActiveRef.current = false;
-      }
+      if (!container.contains(e.target as Node)) vncActiveRef.current = false;
     };
-
     container.addEventListener("mousedown", activate, true);
     document.addEventListener("mousedown", deactivate);
-
-    // Initially active since we just connected
     vncActiveRef.current = true;
-
     return () => {
       container.removeEventListener("mousedown", activate, true);
       document.removeEventListener("mousedown", deactivate);
     };
   }, [status]);
 
-  // Intercept keyboard events at the document level and send them to the VNC
-  // server using RFB.sendKey(). This bypasses all focus issues — we simply
-  // translate browser key events to X11 keysyms and send them directly.
+  // Forward keyboard events to VNC via X11 keysyms
   useEffect(() => {
     if (status !== "connected") return;
-
-    // Map browser event.key → X11 keysym
-    // Printable characters use their Unicode codepoint directly.
-    // Special keys are mapped explicitly.
     const specialKeys: Record<string, number> = {
       Backspace: 0xff08, Tab: 0xff09, Enter: 0xff0d, Escape: 0xff1b,
       Delete: 0xffff, Home: 0xff50, End: 0xff57,
@@ -164,28 +106,21 @@ export default function VNCApp() {
       CapsLock: 0xffe5, NumLock: 0xff7f, ScrollLock: 0xff14,
       " ": 0x0020,
     };
-
     const toKeysym = (e: KeyboardEvent): number | null => {
       if (e.key in specialKeys) return specialKeys[e.key];
-      // Single printable character → Unicode codepoint
       if (e.key.length === 1) return e.key.charCodeAt(0);
       return null;
     };
-
     const handler = (e: KeyboardEvent) => {
       if (!vncActiveRef.current || !rfbRef.current) return;
-      // Don't steal from real HTML input fields
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return;
-
       const keysym = toKeysym(e);
       if (keysym === null) return;
-
       rfbRef.current.sendKey(keysym, e.code, e.type === "keydown");
       e.preventDefault();
       e.stopPropagation();
     };
-
     document.addEventListener("keydown", handler, true);
     document.addEventListener("keyup", handler, true);
     return () => {
@@ -201,35 +136,14 @@ export default function VNCApp() {
     checkVnc();
   }, [checkVnc]);
 
-  const sendClipboard = useCallback(() => {
-    if (rfbRef.current && clipboardText) {
-      rfbRef.current.clipboardPasteFrom(clipboardText);
-    }
-  }, [clipboardText]);
-
-  const sendCtrlAltDel = useCallback(() => {
-    rfbRef.current?.sendCtrlAltDel();
-  }, []);
-
   if (status === "error" && !vncInfo) {
     return (
-      <div className="flex flex-col items-center justify-center h-full bg-[#1a1a2e] text-white/70 gap-4 p-8">
-        <span className="material-symbols-rounded text-amber-400" style={{ fontSize: 48 }}>desktop_windows</span>
+      <div className="flex flex-col items-center justify-center h-full bg-black text-white/70 gap-4 p-8">
+        <span className="material-symbols-rounded text-red-400" style={{ fontSize: 48 }}>error</span>
         <p className="text-sm text-center max-w-md">{error}</p>
-        <div className="bg-white/5 rounded-lg p-4 text-xs text-white/50 max-w-lg w-full space-y-2">
-          <p className="text-white/70 font-medium">To enable Remote Desktop:</p>
-          <p>1. Install a VNC server:</p>
-          <code className="block bg-black/30 px-2 py-1 rounded">sudo apt install tigervnc-standalone-server</code>
-          <p>2. Start a VNC session:</p>
-          <code className="block bg-black/30 px-2 py-1 rounded">vncserver :0 -localhost no -geometry 1280x720</code>
-          <p>3. Install websockify (VNC → WebSocket proxy):</p>
-          <code className="block bg-black/30 px-2 py-1 rounded">sudo apt install websockify</code>
-          <p>4. Start the WebSocket proxy:</p>
-          <code className="block bg-black/30 px-2 py-1 rounded">websockify 6080 localhost:5900</code>
-        </div>
         <button
           onClick={handleReconnect}
-          className="mt-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded-lg text-sm text-white transition-colors"
+          className="mt-2 px-4 py-2 btn-gradient rounded-lg text-sm text-white transition-colors cursor-pointer"
         >
           Retry Connection
         </button>
@@ -238,105 +152,36 @@ export default function VNCApp() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-[#1a1a2e]">
-      {/* Toolbar — onMouseDown preventDefault keeps focus on VNC canvas */}
-      <div className="flex items-center gap-2 px-2 py-1.5 bg-[#252547] border-b border-white/10" onMouseDown={(e) => { if ((e.target as HTMLElement).tagName !== 'INPUT') e.preventDefault(); }}>
-        {/* Status indicator */}
-        <div className="flex items-center gap-1.5">
-          <div className={`w-2 h-2 rounded-full ${
-            status === "connected" ? "bg-green-400" :
-            status === "connecting" ? "bg-yellow-400 animate-pulse" :
-            "bg-red-400"
-          }`} />
-          <span className="text-xs text-white/60 capitalize">{status}</span>
-        </div>
-
-        <div className="w-px h-4 bg-white/10" />
-
-        {/* Scale toggle */}
-        <button
-          onClick={() => setScale(!scale)}
-          className={`p-1 rounded text-xs ${scale ? "bg-white/10 text-white/80" : "text-white/40 hover:text-white/60"}`}
-          title={scale ? "Fit to window" : "Native resolution"}
-        >
-          <span className="material-symbols-rounded" style={{ fontSize: 16 }}>
-            {scale ? "fit_screen" : "fullscreen"}
-          </span>
-        </button>
-
-        {/* Clipboard */}
-        <button
-          onClick={() => setShowClipboard(!showClipboard)}
-          className="p-1 rounded hover:bg-white/10 text-white/50"
-          title="Clipboard"
-        >
-          <span className="material-symbols-rounded" style={{ fontSize: 16 }}>content_paste</span>
-        </button>
-
-        {/* Ctrl+Alt+Del */}
-        <button
-          onClick={sendCtrlAltDel}
-          className="p-1 rounded hover:bg-white/10 text-white/50 text-xs"
-          title="Send Ctrl+Alt+Del"
-        >
-          Ctrl+Alt+Del
-        </button>
-
-        <div className="flex-1" />
-
-        {/* Reconnect */}
-        {status !== "connected" && (
-          <button
-            onClick={handleReconnect}
-            className="px-2 py-0.5 bg-blue-600 hover:bg-blue-500 rounded text-xs text-white"
-          >
-            Reconnect
-          </button>
-        )}
-      </div>
-
-      {/* Clipboard panel */}
-      {showClipboard && (
-        <div className="flex items-center gap-2 px-2 py-1.5 bg-[#1e1e3a] border-b border-white/10">
-          <input
-            type="text"
-            value={clipboardText}
-            onChange={(e) => setClipboardText(e.target.value)}
-            placeholder="Paste text to send to remote..."
-            className="flex-1 px-2 py-1 text-sm bg-black/30 text-white/80 rounded border border-white/10 focus:border-blue-500 focus:outline-none"
-          />
-          <button
-            onClick={sendClipboard}
-            className="px-2 py-1 bg-blue-600 hover:bg-blue-500 rounded text-xs text-white"
-          >
-            Send
-          </button>
+    <div
+      ref={canvasContainerRef}
+      className="h-full overflow-hidden bg-black relative"
+      tabIndex={0}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        requestAnimationFrame(() => { rfbRef.current?.focus(); });
+      }}
+    >
+      {(status === "connecting" || status === "disconnected") && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center text-white/50 gap-3 z-10">
+          {status === "connecting" ? (
+            <>
+              <span className="material-symbols-rounded animate-spin" style={{ fontSize: 48 }}>progress_activity</span>
+              <p className="text-sm">Connecting to remote desktop...</p>
+            </>
+          ) : (
+            <>
+              <span className="material-symbols-rounded text-red-400" style={{ fontSize: 48 }}>link_off</span>
+              <p className="text-sm">{error || "Disconnected"}</p>
+              <button
+                onClick={handleReconnect}
+                className="mt-2 px-4 py-2 btn-gradient rounded-lg text-sm text-white cursor-pointer"
+              >
+                Reconnect
+              </button>
+            </>
+          )}
         </div>
       )}
-
-      {/* VNC canvas */}
-      <div
-        ref={canvasContainerRef}
-        className="flex-1 overflow-hidden bg-black"
-        style={{ position: "relative" }}
-        tabIndex={0}
-        onMouseDown={(e) => {
-          // Prevent the Window wrapper from stealing focus away from the canvas
-          e.stopPropagation();
-          // Let noVNC's own focusOnClick handle focusing the canvas
-          // If that doesn't work, force it after a microtask
-          requestAnimationFrame(() => {
-            rfbRef.current?.focus();
-          });
-        }}
-      >
-        {status === "connecting" && (
-          <div className="absolute inset-0 flex flex-col items-center justify-center text-white/50 gap-3">
-            <span className="material-symbols-rounded animate-spin" style={{ fontSize: 48 }}>progress_activity</span>
-            <p className="text-sm">Connecting to remote desktop...</p>
-          </div>
-        )}
-      </div>
     </div>
   );
 }

--- a/src/components/VSCodeApp.tsx
+++ b/src/components/VSCodeApp.tsx
@@ -7,7 +7,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 
-export default function VSCodeApp() {
+export default function VSCodeApp({ filePath }: { filePath?: string }) {
   const [status, setStatus] = useState<"checking" | "running" | "not-running">("checking");
   const [port, setPort] = useState(8080);
 
@@ -106,9 +106,20 @@ cert: false`}
   // code-server doesn't set X-Frame-Options or frame-ancestors
   const hostname = typeof window !== "undefined" ? window.location.hostname : "localhost";
 
+  // If filePath is provided, open the file's parent folder and goto the file
+  const baseUrl = `http://${hostname}:${port}`;
+  let src: string;
+  if (filePath) {
+    const lastSlash = filePath.lastIndexOf("/");
+    const folder = lastSlash > 0 ? filePath.substring(0, lastSlash) : "/home";
+    src = `${baseUrl}?folder=${encodeURIComponent(folder)}&goto=${encodeURIComponent(filePath)}`;
+  } else {
+    src = `${baseUrl}?folder=/home`;
+  }
+
   return (
     <iframe
-      src={`http://${hostname}:${port}?folder=/home`}
+      src={src}
       className="w-full h-full border-0"
       title="VS Code"
       allow="clipboard-read; clipboard-write"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,63 @@
+import { spawn } from "child_process";
+import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { DATA_DIR } from "./config-store";
+
+const SECRET_PATH = path.join(DATA_DIR, ".session-secret");
+
+/** Get or create a persistent HMAC secret for session cookies. */
+export async function getOrCreateSecret(): Promise<string> {
+  try {
+    const existing = (await fs.readFile(SECRET_PATH, "utf-8")).trim();
+    if (existing.length >= 32) return existing;
+  } catch { /* doesn't exist yet */ }
+
+  const secret = crypto.randomBytes(32).toString("hex");
+  await fs.mkdir(path.dirname(SECRET_PATH), { recursive: true });
+  await fs.writeFile(SECRET_PATH, secret, { mode: 0o600 });
+  return secret;
+}
+
+/** Verify password against the Linux user `clawbox` using unix_chkpwd (PAM helper). */
+export async function verifyPassword(password: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn("/usr/sbin/unix_chkpwd", ["clawbox", "nullok"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5000,
+    });
+    child.stdin.end(password + "\0");
+    child.on("close", (code) => resolve(code === 0));
+    child.on("error", () => resolve(false));
+  });
+}
+
+/** Create a signed session cookie value. */
+export function createSessionCookie(durationSeconds: number, secret: string): string {
+  const exp = Math.floor(Date.now() / 1000) + durationSeconds;
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  const sig = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+  return `${payload}.${sig}`;
+}
+
+/** Verify a session cookie — returns true if valid and not expired. */
+export function verifySessionCookie(cookie: string, secret: string): boolean {
+  const [payload, sig] = cookie.split(".");
+  if (!payload || !sig) return false;
+  // Validate sig is valid hex and correct length (SHA-256 = 64 hex chars)
+  if (!/^[0-9a-f]{64}$/i.test(sig)) return false;
+
+  try {
+    const expectedSig = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+    const sigBuf = Buffer.from(sig, "hex");
+    const expectedBuf = Buffer.from(expectedSig, "hex");
+    if (sigBuf.length !== expectedBuf.length || !crypto.timingSafeEqual(sigBuf, expectedBuf)) {
+      return false;
+    }
+
+    const data = JSON.parse(Buffer.from(payload, "base64url").toString());
+    return typeof data.exp === "number" && data.exp > Math.floor(Date.now() / 1000);
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -5,9 +5,9 @@ import { promisify } from "util";
 
 const exec = promisify(execFile);
 const OPENCLAW_HOME = process.env.OPENCLAW_HOME || "/home/clawbox/.openclaw";
-const CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
+export const CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 
-interface OpenClawConfig {
+export interface OpenClawConfig {
   [key: string]: unknown;
   channels?: {
     [name: string]: {
@@ -17,9 +17,19 @@ interface OpenClawConfig {
       [key: string]: unknown;
     };
   };
+  tools?: {
+    profile?: string;
+    web?: { search?: { enabled?: boolean } };
+  };
+  auth?: {
+    profiles?: Record<string, { provider?: string; mode?: string }>;
+  };
+  agents?: {
+    defaults?: { model?: { primary?: string } };
+  };
 }
 
-async function readConfig(): Promise<OpenClawConfig> {
+export async function readConfig(): Promise<OpenClawConfig> {
   try {
     const raw = await fs.readFile(CONFIG_PATH, "utf-8");
     return JSON.parse(raw);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 
+// ─── Captive Portal ──────────────────────────────────────────────────────────
+
 function getPortalUrl(): string {
   const raw = process.env.PORTAL_URL;
   if (raw) {
@@ -17,13 +19,13 @@ function getPortalUrl(): string {
 const PORTAL_URL = getPortalUrl();
 
 const REDIRECT_PATHS = new Set([
-  "/generate_204", // Android
-  "/gen_204", // Android
-  "/connecttest.txt", // Windows NCSI
-  "/redirect", // Windows NCSI
-  "/ncsi.txt", // Windows NCSI
-  "/canonical.html", // Firefox
-  "/success.txt", // Firefox
+  "/generate_204",
+  "/gen_204",
+  "/connecttest.txt",
+  "/redirect",
+  "/ncsi.txt",
+  "/canonical.html",
+  "/success.txt",
 ]);
 
 const APPLE_PATHS = new Set([
@@ -31,36 +33,123 @@ const APPLE_PATHS = new Set([
   "/library/test/success.html",
 ]);
 
-export function middleware(request: NextRequest) {
+// ─── Auth ────────────────────────────────────────────────────────────────────
+
+const PUBLIC_PREFIXES = [
+  "/login",
+  "/setup",
+  "/setup-api/",
+  "/login-api",
+  "/_next/",
+  "/fonts/",
+  "/images/",
+];
+
+const PUBLIC_EXACT = new Set([
+  "/manifest.json",
+  "/favicon.ico",
+  "/favicon.svg",
+  "/favicon-32.png",
+  "/clawbox-crab.png",
+]);
+
+function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_EXACT.has(pathname)) return true;
+  for (const prefix of PUBLIC_PREFIXES) {
+    if (pathname.startsWith(prefix)) return true;
+  }
+  return false;
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Verify HMAC-SHA256 session cookie using Web Crypto API (Edge Runtime compatible) */
+async function verifySessionCookie(cookie: string): Promise<boolean> {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) return false;
+
+  const dotIdx = cookie.indexOf(".");
+  if (dotIdx < 0) return false;
+  const payload = cookie.substring(0, dotIdx);
+  const sig = cookie.substring(dotIdx + 1);
+  if (!payload || !sig) return false;
+
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(secret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"]
+    );
+    const expected = new Uint8Array(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload)));
+    const expectedHex = bytesToHex(expected);
+
+    // Constant-time comparison
+    if (sig.length !== expectedHex.length) return false;
+    let diff = 0;
+    for (let i = 0; i < sig.length; i++) {
+      diff |= sig.charCodeAt(i) ^ expectedHex.charCodeAt(i);
+    }
+    if (diff !== 0) return false;
+
+    // Check expiration
+    const decoded = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
+    const data = JSON.parse(decoded);
+    return typeof data.exp === "number" && data.exp > Math.floor(Date.now() / 1000);
+  } catch {
+    return false;
+  }
+}
+
+// ─── Middleware ───────────────────────────────────────────────────────────────
+
+export async function middleware(request: NextRequest) {
   const pathname = request.nextUrl.pathname.toLowerCase();
 
+  // 1. Captive portal detection
   if (REDIRECT_PATHS.has(pathname)) {
     return NextResponse.redirect(PORTAL_URL, 302);
   }
-
   if (APPLE_PATHS.has(pathname)) {
     return new NextResponse(
       "<!DOCTYPE html><HTML><HEAD><TITLE>ClawBox Setup</TITLE></HEAD><BODY>Please complete setup.</BODY></HTML>",
-      {
-        status: 200,
-        headers: { "Content-Type": "text/html" },
-      }
+      { status: 200, headers: { "Content-Type": "text/html" } }
     );
   }
 
-  return NextResponse.next();
+  // 2. Public paths — no auth needed
+  if (isPublicPath(pathname)) {
+    return NextResponse.next();
+  }
+
+  // 3. If no session secret configured, auth is not active (pre-setup)
+  if (!process.env.SESSION_SECRET) {
+    return NextResponse.next();
+  }
+
+  // 4. Check session cookie
+  const sessionCookie = request.cookies.get("clawbox_session")?.value;
+  if (sessionCookie && await verifySessionCookie(sessionCookie)) {
+    return NextResponse.next();
+  }
+
+  // 5. API requests get 401, page requests redirect to login
+  const accept = request.headers.get("accept") || "";
+  if (accept.includes("application/json") || pathname.startsWith("/api/")) {
+    return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+  }
+
+  const loginUrl = new URL("/login", request.url);
+  loginUrl.searchParams.set("redirect", request.nextUrl.pathname);
+  return NextResponse.redirect(loginUrl);
 }
 
 export const config = {
   matcher: [
-    "/generate_204",
-    "/gen_204",
-    "/hotspot-detect.html",
-    "/library/test/success.html",
-    "/connecttest.txt",
-    "/redirect",
-    "/ncsi.txt",
-    "/canonical.html",
-    "/success.txt",
+    // Match all paths except static assets
+    "/((?!_next/static|_next/image|fonts/|images/).*)",
   ],
 };

--- a/src/tests/routes/files/path.test.ts
+++ b/src/tests/routes/files/path.test.ts
@@ -22,7 +22,7 @@ function createParams(pathSegments: string[]): { params: Promise<{ path: string[
 }
 
 beforeAll(async () => {
-  process.env.CLAWBOX_ROOT = TEST_ROOT;
+  process.env.FILES_ROOT = TEST_ROOT;
   await fsp.mkdir(TEST_ROOT, { recursive: true });
   vi.resetModules();
   ({ GET: filesPathGet, PUT: filesPathPut, DELETE: filesPathDelete } = await import("@/app/setup-api/files/[...path]/route"));
@@ -34,7 +34,7 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
-  delete process.env.CLAWBOX_ROOT;
+  delete process.env.FILES_ROOT;
   await fsp.rm(TEST_ROOT, { recursive: true, force: true });
 });
 

--- a/src/tests/routes/files/route.test.ts
+++ b/src/tests/routes/files/route.test.ts
@@ -17,7 +17,7 @@ function createRequest(pathname: string, options?: RequestInit): NextRequest {
 }
 
 beforeAll(async () => {
-  process.env.CLAWBOX_ROOT = TEST_ROOT;
+  process.env.FILES_ROOT = TEST_ROOT;
   await fsp.mkdir(TEST_ROOT, { recursive: true });
   vi.resetModules();
   ({ GET: filesGet, POST: filesPost } = await import("@/app/setup-api/files/route"));
@@ -30,7 +30,7 @@ beforeEach(async () => {
 });
 
 afterAll(async () => {
-  delete process.env.CLAWBOX_ROOT;
+  delete process.env.FILES_ROOT;
   await fsp.rm(TEST_ROOT, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
- Fix file manager to browse user home directory instead of non-existent local-data
- Add right-click context menu with keyboard/ARIA support (arrow keys, Escape)
- Replace all emoji icons with Material Symbols, match setup wizard theme
- Add "Open in VS Code" for all files via context menu and double-click
- Add session-based login with password verification via unix_chkpwd (PAM)
- Login page with session duration selector (20min/6h/12h/24h)
- Middleware auth check on protected paths, cookie-based sessions
- Lock button in system tray to log out
- Chat button in shelf when mascot is hidden, tray-mode popup positioning
- Sync mascot hidden state between Settings toggle and right-click hide
- Remove NVIDIA desktop shortcuts on install
- Widen systemd ReadWritePaths to /home/clawbox for file manager writes
- Open redirect protection on login redirect param
- Async getOrCreateSecret, rate limit pruning, timingSafeEqual guards

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>