### PR TITLE
fix: remove DeepSeek reference, fix hooks ordering

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -170,7 +170,7 @@ const PROVIDERS: Provider[] = [
   {
     id: "clawai",
     name: "ClawAI",
-    description: "Powered by DeepSeek — free, no setup needed",
+    description: "Free, no setup needed",
     authOptions: [
       {
         mode: "local" as AuthMode,

--- a/src/components/UpdateStep.tsx
+++ b/src/components/UpdateStep.tsx
@@ -160,6 +160,18 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
   }, []);
 
   const isIdle = !state || state.phase === "idle";
+  const isUpToDateEarly = !loading && isIdle && !starting && versions && !versions.clawbox.target && !versions.openclaw.target;
+
+  // Auto-advance if already up to date — show brief flash then continue
+  const autoAdvancedRef = useRef(false);
+  useEffect(() => {
+    if (isUpToDateEarly && !autoAdvancedRef.current) {
+      autoAdvancedRef.current = true;
+      const timer = setTimeout(() => onNext(), 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [isUpToDateEarly, onNext]);
+
   const isDone = state?.phase === "completed";
   const isFailed = state?.phase === "failed";
   const isRunning = state?.phase === "running";
@@ -212,16 +224,6 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
 
   // Idle state — show trigger button or "up to date"
   const isUpToDate = versions && !versions.clawbox.target && !versions.openclaw.target;
-
-  // Auto-advance if already up to date — show brief flash then continue
-  const autoAdvancedRef = useRef(false);
-  useEffect(() => {
-    if (isIdle && !starting && isUpToDate && !autoAdvancedRef.current) {
-      autoAdvancedRef.current = true;
-      const timer = setTimeout(() => onNext(), 1500);
-      return () => clearTimeout(timer);
-    }
-  }, [isIdle, starting, isUpToDate, onNext]);
 
   if (isIdle && !starting) {
     return (


### PR DESCRIPTION
## Summary
- Remove DeepSeek branding from ClawAI UI description
- Fix React hooks ordering violation in UpdateStep (useRef/useEffect after early returns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)