### PR TITLE
Add ClawBox AI fallback model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ ALLOW_INSECURE_CONTROL_UI=true
 # These are set automatically by install.sh — no manual config needed.
 # GOOGLE_OAUTH_CLIENT_ID=
 # GOOGLE_OAUTH_CLIENT_SECRET=
+
+# Optional: enables ClawBox AI as an automatic OpenClaw fallback model.
+# CLAWBOX_AI_API_KEY=

--- a/install.sh
+++ b/install.sh
@@ -319,10 +319,27 @@ step_openclaw_patch() {
 
 step_openclaw_config() {
   local CLAWBOX_CONFIG="$PROJECT_DIR/data/config.json"
+  local CLAWBOX_AI_ENV="$PROJECT_DIR/.env"
+  local CLAWBOX_AI_KEY="${CLAWBOX_AI_API_KEY:-}"
+  local AUTH_PROFILES="$CLAWBOX_HOME/.openclaw/agents/main/agent/auth-profiles.json"
 
   # Sequential config set calls to avoid ConfigMutationConflictError
   as_clawbox "$OPENCLAW_BIN" config set agents.defaults.model.primary "anthropic/claude-sonnet-4-20250514"
   echo "  Default model set"
+
+  if [ -z "$CLAWBOX_AI_KEY" ] && [ -f "$CLAWBOX_AI_ENV" ]; then
+    CLAWBOX_AI_KEY=$(grep '^CLAWBOX_AI_API_KEY=' "$CLAWBOX_AI_ENV" 2>/dev/null | tail -1 | cut -d= -f2- || true)
+  fi
+  if [ -n "$CLAWBOX_AI_KEY" ]; then
+    local CLAWBOX_AI_PROVIDER_JSON
+    CLAWBOX_AI_PROVIDER_JSON=$(node -e 'const key=process.argv[1]; process.stdout.write(JSON.stringify({baseUrl:"https://api.deepseek.com",api:"openai-completions",apiKey:key,models:[{id:"deepseek-chat",name:"ClawBox AI",reasoning:false,input:["text"],cost:{input:0,output:0,cacheRead:0,cacheWrite:0},contextWindow:65536,maxTokens:8192}]}));' "$CLAWBOX_AI_KEY")
+    mkdir -p "$(dirname "$AUTH_PROFILES")"
+    CLAWBOX_AI_KEY="$CLAWBOX_AI_KEY" AUTH_PROFILES="$AUTH_PROFILES" node -e 'const fs=require("fs"); const p=process.env.AUTH_PROFILES; let data={version:1,profiles:{}}; try{data=JSON.parse(fs.readFileSync(p,"utf8"));}catch{} data.profiles["deepseek:default"]={type:"api_key",provider:"deepseek",key:process.env.CLAWBOX_AI_KEY}; fs.writeFileSync(p, JSON.stringify(data,null,2), { mode: 0o600 });'
+    as_clawbox "$OPENCLAW_BIN" config set auth.profiles.deepseek:default '{"provider":"deepseek","mode":"api_key"}' --json
+    as_clawbox "$OPENCLAW_BIN" config set models.providers.deepseek "$CLAWBOX_AI_PROVIDER_JSON" --json
+    as_clawbox "$OPENCLAW_BIN" config set agents.defaults.model.fallback "deepseek/deepseek-chat"
+    echo "  ClawBox AI fallback model configured"
+  fi
 
   as_clawbox "$OPENCLAW_BIN" config set gateway.auth.mode none
   echo "  Gateway auth mode set to none"
@@ -387,6 +404,10 @@ step_directories_permissions() {
   if ! grep -q '^GOOGLE_OAUTH_CLIENT_SECRET=' "$ENV_FILE" 2>/dev/null; then
     printf 'GOOGLE_OAUTH_CLIENT_SECRET=%s\n' "$G_SEC" >> "$ENV_FILE"
     echo "  Added GOOGLE_OAUTH_CLIENT_SECRET to $ENV_FILE"
+  fi
+  if [ -n "${CLAWBOX_AI_API_KEY:-}" ] && ! grep -q '^CLAWBOX_AI_API_KEY=' "$ENV_FILE" 2>/dev/null; then
+    printf 'CLAWBOX_AI_API_KEY=%s\n' "$CLAWBOX_AI_API_KEY" >> "$ENV_FILE"
+    echo "  Added CLAWBOX_AI_API_KEY to $ENV_FILE"
   fi
   echo "  Done"
 }

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -12,6 +12,10 @@ const AUTH_PROFILES_PATH =
   "/home/clawbox/.openclaw/agents/main/agent/auth-profiles.json";
 const CLAWBOX_UID = process.getuid?.() ?? 1000;
 const CLAWBOX_GID = process.getgid?.() ?? 1000;
+const CLAWBOX_AI_API_KEY = process.env.CLAWBOX_AI_API_KEY?.trim() ?? "";
+const CLAWBOX_AI_PROFILE_KEY = "deepseek:default";
+const CLAWBOX_AI_PROVIDER = "deepseek";
+const CLAWBOX_AI_MODEL = "deepseek/deepseek-chat";
 
 // Ollama pre-allocates KV cache for the full context window. The default 128K
 // context would need ~12.5 GB on a 3B model, exceeding the Jetson's 8 GB.
@@ -21,9 +25,8 @@ const CLAWBOX_GID = process.getgid?.() ?? 1000;
 const OLLAMA_CONTEXT_WINDOW = 16384;
 const OLLAMA_MAX_TOKENS = 8192;
 
-const CLAWAI_API_KEY = "sk-d79a8071b0634ff7a809b1abe3d963f3";
-const CLAWAI_CONTEXT_WINDOW = 65536;
-const CLAWAI_MAX_TOKENS = 8192;
+const CLAWBOX_AI_CONTEXT_WINDOW = 65536;
+const CLAWBOX_AI_MAX_TOKENS = 8192;
 
 interface ProviderConfig {
   defaultModel: string;
@@ -34,8 +37,8 @@ interface ProviderConfig {
 
 const PROVIDERS: Record<string, ProviderConfig> = {
   clawai: {
-    defaultModel: "deepseek/deepseek-chat",
-    profileKey: "deepseek:default",
+    defaultModel: CLAWBOX_AI_MODEL,
+    profileKey: CLAWBOX_AI_PROFILE_KEY,
   },
   anthropic: {
     defaultModel: "anthropic/claude-sonnet-4-6",
@@ -65,6 +68,11 @@ const PROVIDERS: Record<string, ProviderConfig> = {
 
 const PROFILE_KEY_RE = /^[a-zA-Z0-9._-]+(?::[a-zA-Z0-9._-]+)*$/;
 const COMMAND_TIMEOUT_MS = 30_000;
+
+interface AuthProfilesFile {
+  version: number;
+  profiles: Record<string, unknown>;
+}
 
 function runCommand(cmd: string, args: string[], timeoutMs = COMMAND_TIMEOUT_MS): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -111,6 +119,82 @@ function runCommand(cmd: string, args: string[], timeoutMs = COMMAND_TIMEOUT_MS)
   });
 }
 
+async function readAuthProfiles(): Promise<AuthProfilesFile> {
+  try {
+    const raw = await fs.readFile(AUTH_PROFILES_PATH, "utf-8");
+    return JSON.parse(raw) as AuthProfilesFile;
+  } catch {
+    return { version: 1, profiles: {} };
+  }
+}
+
+async function writeAuthProfiles(authProfiles: AuthProfilesFile) {
+  await fs.mkdir(path.dirname(AUTH_PROFILES_PATH), { recursive: true });
+  const tmpPath = AUTH_PROFILES_PATH + `.tmp.${Date.now()}.${process.pid}`;
+  await fs.writeFile(tmpPath, JSON.stringify(authProfiles, null, 2), {
+    mode: 0o600,
+  });
+  await fs.rename(tmpPath, AUTH_PROFILES_PATH);
+  await fs.chown(AUTH_PROFILES_PATH, CLAWBOX_UID, CLAWBOX_GID);
+}
+
+function buildClawboxAiProviderDefinition() {
+  return JSON.stringify({
+    baseUrl: "https://api.deepseek.com",
+    api: "openai-completions",
+    apiKey: CLAWBOX_AI_API_KEY,
+    models: [{
+      id: "deepseek-chat",
+      name: "ClawBox AI",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: CLAWBOX_AI_CONTEXT_WINDOW,
+      maxTokens: CLAWBOX_AI_MAX_TOKENS,
+    }],
+  });
+}
+
+async function configureClawboxAi(setFallback: boolean) {
+  if (!CLAWBOX_AI_API_KEY) {
+    return false;
+  }
+
+  const authProfiles = await readAuthProfiles();
+  authProfiles.profiles[CLAWBOX_AI_PROFILE_KEY] = {
+    type: "api_key",
+    provider: CLAWBOX_AI_PROVIDER,
+    key: CLAWBOX_AI_API_KEY,
+  };
+  await writeAuthProfiles(authProfiles);
+
+  await runCommand(OPENCLAW_BIN, [
+    "config",
+    "set",
+    `auth.profiles.${CLAWBOX_AI_PROFILE_KEY}`,
+    JSON.stringify({ provider: CLAWBOX_AI_PROVIDER, mode: "api_key" }),
+    "--json",
+  ]);
+  await runCommand(OPENCLAW_BIN, [
+    "config",
+    "set",
+    `models.providers.${CLAWBOX_AI_PROVIDER}`,
+    buildClawboxAiProviderDefinition(),
+    "--json",
+  ]);
+
+  if (setFallback) {
+    await runCommand(OPENCLAW_BIN, [
+      "config",
+      "set",
+      "agents.defaults.model.fallback",
+      CLAWBOX_AI_MODEL,
+    ]);
+  }
+
+  return true;
+}
+
 export async function POST(request: Request) {
   try {
     let body: {
@@ -130,6 +214,12 @@ export async function POST(request: Request) {
     const { provider, apiKey, authMode = "token", refreshToken, expiresIn, projectId } = body;
     const isOllama = provider === "ollama";
     const isClawAI = provider === "clawai";
+    if (isClawAI && !CLAWBOX_AI_API_KEY) {
+      return NextResponse.json(
+        { error: "ClawBox AI is not configured on this device. Set CLAWBOX_AI_API_KEY first." },
+        { status: 503 }
+      );
+    }
     if (!provider || (!apiKey && !isOllama && !isClawAI)) {
       return NextResponse.json(
         { error: "Provider is required; API key required for non-local providers" },
@@ -160,22 +250,13 @@ export async function POST(request: Request) {
 
     // 1. Write token to auth-profiles.json
     {
-      let authProfiles: {
-        version: number;
-        profiles: Record<string, unknown>;
-      };
-      try {
-        const raw = await fs.readFile(AUTH_PROFILES_PATH, "utf-8");
-        authProfiles = JSON.parse(raw);
-      } catch {
-        authProfiles = { version: 1, profiles: {} };
-      }
+      const authProfiles = await readAuthProfiles();
       if (isClawAI) {
-        // ClawBox AI uses a pre-configured DeepSeek API key
+        // ClawBox AI uses the device-provided DeepSeek API key.
         authProfiles.profiles[config.profileKey] = {
           type: "api_key",
           provider: ocProvider,
-          key: CLAWAI_API_KEY,
+          key: CLAWBOX_AI_API_KEY,
         };
       } else if (isOllama) {
         // Ollama runs locally — use a dummy api_key entry
@@ -204,14 +285,7 @@ export async function POST(request: Request) {
           token: apiKey,
         };
       }
-      await fs.mkdir(path.dirname(AUTH_PROFILES_PATH), { recursive: true });
-      const tmpPath = AUTH_PROFILES_PATH + `.tmp.${Date.now()}.${process.pid}`;
-      await fs.writeFile(tmpPath, JSON.stringify(authProfiles, null, 2), {
-        mode: 0o600,
-      });
-      await fs.rename(tmpPath, AUTH_PROFILES_PATH);
-      // Fix ownership so the gateway (running as clawbox) can read it
-      await fs.chown(AUTH_PROFILES_PATH, CLAWBOX_UID, CLAWBOX_GID);
+      await writeAuthProfiles(authProfiles);
     }
 
     // 2. Validate profileKey before interpolating into config path
@@ -271,27 +345,11 @@ export async function POST(request: Request) {
     // 7. For ClawBox AI (DeepSeek) or Ollama, define a custom provider in openclaw.json
     // and set models.mode=replace so the gateway uses our definition.
     if (isClawAI) {
-      const providerDef = JSON.stringify({
-        baseUrl: "https://api.deepseek.com",
-        api: "openai-completions",
-        apiKey: CLAWAI_API_KEY,
-        models: [{
-          id: "deepseek-chat",
-          name: "DeepSeek V3",
-          reasoning: false,
-          input: ["text"],
-          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-          contextWindow: CLAWAI_CONTEXT_WINDOW,
-          maxTokens: CLAWAI_MAX_TOKENS,
-        }],
-      });
+      await configureClawboxAi(false);
       await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.providers.deepseek", providerDef, "--json",
+        "config", "set", "models.mode", "merge",
       ]);
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.mode", "replace",
-      ]);
-      console.log(`[AI Config] Set ClawBox AI (DeepSeek) provider in openclaw.json (context=${CLAWAI_CONTEXT_WINDOW}, mode=replace)`);
+      console.log(`[AI Config] Set ClawBox AI provider in openclaw.json (context=${CLAWBOX_AI_CONTEXT_WINDOW})`);
     } else if (isOllama) {
       const modelName = config.defaultModel.replace(/^ollama\//, "");
       const providerDef = JSON.stringify({
@@ -314,6 +372,14 @@ export async function POST(request: Request) {
       await runCommand(OPENCLAW_BIN, [
         "config", "set", "models.mode", "replace",
       ]);
+      try {
+        const fallbackConfigured = await configureClawboxAi(true);
+        if (fallbackConfigured) {
+          console.log("[AI Config] Configured ClawBox AI as fallback model");
+        }
+      } catch (err) {
+        console.warn("[AI Config] Failed to configure ClawBox AI fallback:", err instanceof Error ? err.message : err);
+      }
       // Ensure Ollama service has memory optimizations (q8_0 KV cache, flash attention)
       try {
         await runCommand("sudo", ["/home/clawbox/clawbox/scripts/optimize-ollama.sh"]);
@@ -333,26 +399,13 @@ export async function POST(request: Request) {
         // Non-fatal: merge is the default behavior anyway
       }
 
-      // Always configure ClawBox AI (DeepSeek) as backup provider alongside
-      // the primary, so the agent has a fallback if the primary provider fails.
       try {
-        // Add DeepSeek backup to the auth-profiles file
-        const rawProfiles = await fs.readFile(AUTH_PROFILES_PATH, "utf-8").catch(() => '{"version":1,"profiles":{}}');
-        const profiles = JSON.parse(rawProfiles);
-        profiles.profiles["deepseek:default"] = { type: "api_key", provider: "deepseek", key: CLAWAI_API_KEY };
-        const tmpPath = AUTH_PROFILES_PATH + `.tmp.${Date.now()}.${process.pid}`;
-        await fs.writeFile(tmpPath, JSON.stringify(profiles, null, 2));
-        await fs.rename(tmpPath, AUTH_PROFILES_PATH);
-        await fs.chown(AUTH_PROFILES_PATH, CLAWBOX_UID, CLAWBOX_GID);
-        await runCommand(OPENCLAW_BIN, [
-          "config", "set", "auth.profiles.deepseek:default",
-          JSON.stringify({ provider: "deepseek", mode: "api_key" }),
-          "--json",
-        ]);
-        console.log("[AI Config] Configured ClawBox AI (DeepSeek) as backup provider");
+        const fallbackConfigured = await configureClawboxAi(true);
+        if (fallbackConfigured) {
+          console.log("[AI Config] Configured ClawBox AI as fallback model");
+        }
       } catch (err) {
-        // Non-fatal: backup is a nice-to-have
-        console.warn("[AI Config] Failed to configure backup provider:", err instanceof Error ? err.message : err);
+        console.warn("[AI Config] Failed to configure ClawBox AI fallback:", err instanceof Error ? err.message : err);
       }
     }
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -80,6 +80,7 @@ describe("POST /setup-api/ai-models/configure", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    process.env.CLAWBOX_AI_API_KEY = "test-clawbox-ai-key";
 
     mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
     mockFs.writeFile.mockResolvedValue();
@@ -95,6 +96,7 @@ describe("POST /setup-api/ai-models/configure", () => {
   });
 
   afterEach(() => {
+    delete process.env.CLAWBOX_AI_API_KEY;
     vi.clearAllMocks();
   });
 
@@ -159,6 +161,16 @@ describe("POST /setup-api/ai-models/configure", () => {
     const res = await configurePost(jsonRequest({
       provider: "openai",
       apiKey: "sk-openai-key",
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+  });
+
+  it("configures ClawBox AI without a user-supplied API key", async () => {
+    const res = await configurePost(jsonRequest({
+      provider: "clawai",
     }));
     const body = await res.json();
 
@@ -276,6 +288,41 @@ describe("POST /setup-api/ai-models/configure", () => {
     const writeCall = mockFs.writeFile.mock.calls[0];
     const writtenContent = JSON.parse(writeCall[1] as string);
     expect(writtenContent.profiles["ollama:default"].key).toBe("ollama-local");
+  });
+
+  it("configures ClawBox AI as a fallback model when the device key is present", async () => {
+    await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: "sk-test",
+    }));
+
+    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    expect(commands).toContain("config set agents.defaults.model.fallback deepseek/deepseek-chat");
+    expect(commands.some((command) => command.includes("config set models.providers.deepseek"))).toBe(true);
+
+    const writtenContent = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(writtenContent.profiles["deepseek:default"]).toEqual(
+      expect.objectContaining({
+        type: "api_key",
+        provider: "deepseek",
+        key: "test-clawbox-ai-key",
+      })
+    );
+  });
+
+  it("returns 503 for ClawBox AI when the device key is missing", async () => {
+    delete process.env.CLAWBOX_AI_API_KEY;
+    vi.resetModules();
+    const mod = await import("@/app/setup-api/ai-models/configure/route");
+    configurePost = mod.POST;
+
+    const res = await configurePost(jsonRequest({
+      provider: "clawai",
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.error).toContain("CLAWBOX_AI_API_KEY");
   });
 
   it("restarts gateway after configuration", async () => {


### PR DESCRIPTION
## Summary
- add ClawBox AI as an OpenClaw fallback model using the CLAWBOX_AI_API_KEY runtime secret
- configure the installer to persist and register the fallback when the key is provided
- cover the fallback and missing-key behavior in the AI model route tests

## Testing
- npm test -- --run src/tests/routes/ai-models/configure.test.ts