### PR TITLE
fix: exclude .d.ts files from OpenClaw device identity patch

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -253,7 +253,7 @@ step_openclaw_patch() {
   local DEVICE_MARKER='controlUiAuthPolicy.allowBypass) return'
 
   local DEVICE_FILES
-  DEVICE_FILES=$(grep -rl 'reject-device-required' "$GATEWAY_DIST" 2>/dev/null || true)
+  DEVICE_FILES=$(grep -rl --include='*.js' 'reject-device-required' "$GATEWAY_DIST" 2>/dev/null || true)
   if [ -z "$DEVICE_FILES" ]; then
     echo "  Device identity bypass patch: pattern not found, skipping"
     return
@@ -276,7 +276,7 @@ step_openclaw_patch() {
     sed -i 's|if (roleCanSkipDeviceIdentity(params.role, params.sharedAuthOk)) return { kind: "allow" };|if (roleCanSkipDeviceIdentity(params.role, params.sharedAuthOk)) return { kind: "allow" };\n\tif (params.isControlUi \&\& params.controlUiAuthPolicy.allowBypass) return { kind: "allow" };|' "$file"
   done
 
-  # Verify ALL files with reject-device-required now have the patch
+  # Verify ALL JS files with reject-device-required now have the patch
   local UNPATCHED
   UNPATCHED=""
   for file in $DEVICE_FILES; do


### PR DESCRIPTION
## Summary
- OpenClaw 2026.4.8 already includes the device identity bypass fix natively
- The patch verification was matching `.d.ts` type declaration files which contain `reject-device-required` as a type literal but can never contain the code patch marker
- This caused `install.sh` to fail at step [11/18], killing the entire install (steps 12-18 never ran — no systemd services, no WiFi AP, no Ollama)
- Fix: add `--include='*.js'` to only check JavaScript files

## Test plan
- [x] Verified fix on 2 Jetsons that had the broken install — both completed all 18 steps
- [x] Tested full flash+setup cycle on 2 more Jetsons — 2/2 succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated installation script to target JavaScript files specifically during the patching process, refining the file selection logic without altering the overall workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->