### PR TITLE
feat: add ClawBox AI provider — free, no API key needed

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -13,6 +13,14 @@ const AUTH_PROFILES_PATH =
 const CLAWBOX_UID = process.getuid?.() ?? 1000;
 const CLAWBOX_GID = process.getgid?.() ?? 1000;
 
+// ClawBox AI proxy: devices connect to our proxy at openclawhardware.dev/api/ai
+// which forwards to DeepSeek. The default proxy token allows free usage.
+const CLAWBOX_AI_PROXY_URL = process.env.CLAWBOX_AI_PROXY_URL?.trim() || "https://openclawhardware.dev/api/ai";
+const CLAWBOX_AI_DEFAULT_TOKEN = "claw-d3eps33k-v1-2026";
+const CLAWBOX_AI_API_KEY = process.env.CLAWBOX_AI_API_KEY?.trim() || CLAWBOX_AI_DEFAULT_TOKEN;
+const CLAWBOX_AI_CONTEXT_WINDOW = 65536;
+const CLAWBOX_AI_MAX_TOKENS = 8192;
+
 // Ollama pre-allocates KV cache for the full context window. The default 128K
 // context would need ~12.5 GB on a 3B model, exceeding the Jetson's 8 GB.
 // OpenClaw requires minimum 16K context. At Q4_K_M this uses ~3.5-4 GB total.
@@ -29,6 +37,10 @@ interface ProviderConfig {
 }
 
 const PROVIDERS: Record<string, ProviderConfig> = {
+  clawai: {
+    defaultModel: "deepseek/deepseek-chat",
+    profileKey: "deepseek:default",
+  },
   anthropic: {
     defaultModel: "anthropic/claude-sonnet-4-6",
     profileKey: "anthropic:default",
@@ -125,9 +137,10 @@ export async function POST(request: Request) {
 
     const { provider, apiKey, authMode = "token", refreshToken, expiresIn, projectId } = body;
     const isOllama = provider === "ollama";
-    if (!provider || (!apiKey && !isOllama)) {
+    const isClawAI = provider === "clawai";
+    if (!provider || (!apiKey && !isOllama && !isClawAI)) {
       return NextResponse.json(
-        { error: "Provider is required; API key required for non-Ollama providers" },
+        { error: "Provider is required; API key required for non-local providers" },
         { status: 400 }
       );
     }
@@ -165,7 +178,14 @@ export async function POST(request: Request) {
       } catch {
         authProfiles = { version: 1, profiles: {} };
       }
-      if (isOllama) {
+      if (isClawAI) {
+        // ClawBox AI uses the proxy token (default or from env)
+        authProfiles.profiles[config.profileKey] = {
+          type: "api_key",
+          provider: ocProvider,
+          key: CLAWBOX_AI_API_KEY,
+        };
+      } else if (isOllama) {
         // Ollama runs locally — use a dummy api_key entry
         authProfiles.profiles[config.profileKey] = {
           type: "api_key",
@@ -211,13 +231,14 @@ export async function POST(request: Request) {
     }
 
     // 3. Set auth profile in main config
+    const authProfileMode = (isOllama || isClawAI)
+      ? "api_key"
+      : authMode === "subscription" ? "oauth" : "token";
     await runCommand(OPENCLAW_BIN, [
       "config",
       "set",
       `auth.profiles.${config.profileKey}`,
-      JSON.stringify(isOllama
-        ? { provider: ocProvider, mode: "api_key" }
-        : { provider: ocProvider, mode: authMode === "subscription" ? "oauth" : "token" }),
+      JSON.stringify({ provider: ocProvider, mode: authProfileMode }),
       "--json",
     ]);
 
@@ -256,11 +277,31 @@ export async function POST(request: Request) {
       ai_model_configured_at: new Date().toISOString(),
     });
 
-    // 7. For Ollama, define the model in openclaw.json with a capped contextWindow
-    // and set models.mode=replace so the gateway uses our definition instead of
-    // auto-detecting the native context length from Ollama (which would be 128K).
-    // Also ensure the Ollama systemd service is optimized for 8GB RAM.
-    if (isOllama) {
+    // 7. For ClawBox AI or Ollama, define custom provider in openclaw.json.
+    if (isClawAI) {
+      // ClawBox AI: proxy to our server (DeepSeek under the hood)
+      const providerDef = JSON.stringify({
+        baseUrl: CLAWBOX_AI_PROXY_URL,
+        api: "openai-completions",
+        apiKey: CLAWBOX_AI_API_KEY,
+        models: [{
+          id: "deepseek-chat",
+          name: "ClawBox AI",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: CLAWBOX_AI_CONTEXT_WINDOW,
+          maxTokens: CLAWBOX_AI_MAX_TOKENS,
+        }],
+      });
+      await runCommand(OPENCLAW_BIN, [
+        "config", "set", "models.providers.deepseek", providerDef, "--json",
+      ]);
+      await runCommand(OPENCLAW_BIN, [
+        "config", "set", "models.mode", "merge",
+      ]);
+      console.log(`[AI Config] ClawBox AI configured via proxy: ${CLAWBOX_AI_PROXY_URL}`);
+    } else if (isOllama) {
       const modelName = config.defaultModel.replace(/^ollama\//, "");
       const providerDef = JSON.stringify({
         baseUrl: "http://127.0.0.1:11434",

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -33,7 +33,31 @@ const ButtonSpinner = (
   <span className="inline-block w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
 );
 
+const PROVIDER_ICONS: Record<string, string> = {
+  clawai: "🐾",
+  anthropic: "🧠",
+  openai: "⚡",
+  google: "✨",
+  openrouter: "🔀",
+  ollama: "🦙",
+};
+
+const PRIMARY_PROVIDER_IDS = new Set(["clawai", "anthropic", "openai", "google"]);
+
 const PROVIDERS: Provider[] = [
+  {
+    id: "clawai",
+    name: "ClawBox AI",
+    description: "Most affordable — start for free",
+    authOptions: [
+      {
+        mode: "local" as AuthMode,
+        label: "Free",
+        placeholder: "",
+        hint: "Pre-configured and ready to use. No API key or account needed.",
+      },
+    ],
+  },
   {
     id: "anthropic",
     name: "Anthropic Claude",
@@ -143,7 +167,7 @@ const DEVICE_AUTH_LABELS: Record<string, {
 };
 
 export default function AIModelsStep({ onNext }: AIModelsStepProps) {
-  const [selectedProvider, setSelectedProvider] = useState<string | null>("anthropic");
+  const [selectedProvider, setSelectedProvider] = useState<string | null>("clawai");
   const [authMode, setAuthMode] = useState<AuthMode>("subscription");
   const [availableOAuth, setAvailableOAuth] = useState<string[] | null>(null);
   const [apiKey, setApiKey] = useState("");
@@ -288,6 +312,37 @@ export default function AIModelsStep({ onNext }: AIModelsStepProps) {
       if (controller.signal.aborted) return;
       if (data.success) {
         showSuccessAndContinue("AI model configured! Continuing...");
+      } else {
+        showError(data.error || "Failed to configure");
+      }
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      showError(`Failed: ${err instanceof Error ? err.message : err}`);
+    } finally {
+      if (!controller.signal.aborted) setSaving(false);
+    }
+  };
+
+  const saveClawAI = async () => {
+    saveControllerRef.current?.abort();
+    const controller = new AbortController();
+    saveControllerRef.current = controller;
+
+    setSaving(true);
+    setStatus(null);
+    try {
+      const res = await fetch("/setup-api/ai-models/configure", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ provider: "clawai" }),
+        signal: controller.signal,
+      });
+      if (controller.signal.aborted) return;
+      if (!res.ok) return showError(await extractError(res, "Failed to configure"));
+      const data = await res.json();
+      if (controller.signal.aborted) return;
+      if (data.success) {
+        showSuccessAndContinue("ClawBox AI configured!");
       } else {
         showError(data.error || "Failed to configure");
       }
@@ -766,6 +821,17 @@ export default function AIModelsStep({ onNext }: AIModelsStepProps) {
           })}
         </div>
 
+        {selected?.id === "clawai" && (
+          <div className="mt-5">
+            <p className="text-xs text-[var(--text-secondary)] leading-relaxed">
+              ClawBox AI is pre-configured and ready to go. Just click below to get started &mdash; no API key or account needed.
+            </p>
+            <p className="text-xs text-emerald-400 mt-2 leading-relaxed">
+              ✓ Free &mdash; powered by our cloud proxy. No setup required.
+            </p>
+          </div>
+        )}
+
         {selected?.id === "ollama" && (
           <div className="mt-5 space-y-4">
             <OllamaModelPanel
@@ -791,7 +857,7 @@ export default function AIModelsStep({ onNext }: AIModelsStepProps) {
           </div>
         )}
 
-        {selected && selected.id !== "ollama" && activeAuth && (
+        {selected && selected.id !== "ollama" && selected.id !== "clawai" && activeAuth && (
           <div className="mt-5">
             {effectiveAuthOptions.length > 1 && (
               <div className="flex gap-1 mb-4 p-1 bg-[var(--bg-deep)] rounded-lg">
@@ -888,7 +954,17 @@ export default function AIModelsStep({ onNext }: AIModelsStepProps) {
         )}
 
         <div className="flex items-center gap-3 mt-5">
-          {selected?.id === "ollama" ? (
+          {selected?.id === "clawai" ? (
+            <button
+              type="button"
+              onClick={saveClawAI}
+              disabled={saving}
+              className="w-full py-3 btn-gradient text-white rounded-lg font-semibold text-sm transition transform hover:scale-105 shadow-lg shadow-[rgba(249,115,22,0.25)] cursor-pointer disabled:opacity-50 disabled:hover:scale-100 flex items-center justify-center gap-2"
+            >
+              {saving && ButtonSpinner}
+              {saving ? "Configuring..." : embedded ? "Save" : "Get Started — Free"}
+            </button>
+          ) : selected?.id === "ollama" ? (
             null /* Ollama has its own buttons above */
           ) : isSubscription ? (
             useDeviceAuth ? (
@@ -917,14 +993,28 @@ export default function AIModelsStep({ onNext }: AIModelsStepProps) {
               {saving ? "Saving..." : "Save & Continue"}
             </button>
           )}
-          <button
-            type="button"
-            onClick={onNext}
-            className="bg-transparent border-none text-[var(--coral-bright)] text-sm underline cursor-pointer p-1"
-          >
-            Skip for now
-          </button>
+          {selectedProvider !== "clawai" && (
+            <button
+              type="button"
+              onClick={onNext}
+              className="bg-transparent border-none text-[var(--coral-bright)] text-sm underline cursor-pointer p-1"
+            >
+              Skip for now
+            </button>
+          )}
         </div>
+        {!embedded && selectedProvider !== "clawai" && (
+          <div className="mt-3 text-center">
+            <button
+              type="button"
+              onClick={saveClawAI}
+              disabled={saving}
+              className="text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] bg-transparent border-none cursor-pointer underline transition-colors"
+            >
+              Or use ClawBox AI for free
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## What
Adds **ClawBox AI** as a provider option that works out of the box — no API key, no account, no setup.

## How it works
```
ClawBox device → openclawhardware.dev/api/ai (our proxy) → DeepSeek API
```

- Default proxy token baked into the device code
- Proxy on the website validates the token and forwards to DeepSeek
- Users just click **"Get Started — Free"** and it works

## Changes
- **AIModelsStep.tsx**: Added ClawBox AI as first provider option (pre-selected)
- **configure/route.ts**: Added `clawai` provider with proxy URL + default token
- Website PR already merged: catch-all route at `/api/ai/[...path]` (PR #10)

## Env vars (optional overrides)
- `CLAWBOX_AI_API_KEY` — custom proxy token (default: shared token)
- `CLAWBOX_AI_PROXY_URL` — custom proxy URL (default: openclawhardware.dev/api/ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added ClawBox AI as a new supported AI provider option
* ClawBox AI configuration is now available in the AI model setup flow with a dedicated interface
* Updated provider selection to display ClawBox AI alongside other available providers
* ClawBox AI is now the default selected provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->