### PR TITLE
Route reset users back into setup instead of an auth loop

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -20,14 +20,13 @@ function LoginForm() {
   const [loading, setLoading] = useState(false);
   const [ready, setReady] = useState(false);
 
-  // If setup isn't complete, send the user to the desktop UI, which opens
-  // the setup wizard in a window on boot.
+  // Incomplete setups should always resume on the dedicated setup route.
   useEffect(() => {
     fetch("/setup-api/setup/status")
       .then((r) => r.ok ? r.json() : null)
       .then((data) => {
         if (data && !data.setup_complete) {
-          window.location.href = "/";
+          window.location.replace("/setup");
           return;
         }
         setReady(true);

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -178,7 +178,15 @@ export async function POST() {
       }
     }, 1_000);
 
-    return NextResponse.json({ success: true });
+    const response = NextResponse.json({ success: true });
+    response.cookies.set("clawbox_session", "", {
+      httpOnly: true,
+      sameSite: "lax",
+      path: "/",
+      maxAge: 0,
+      secure: false,
+    });
+    return response;
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Factory reset failed" },

--- a/src/components/DoneStep.tsx
+++ b/src/components/DoneStep.tsx
@@ -872,7 +872,7 @@ export default function DoneStep({ setupComplete = false, onComplete }: DoneStep
         setResetProgress(100);
         // Device is rebooting — wait then try to reload (page will come back after reboot)
         await new Promise((r) => setTimeout(r, 3000));
-        window.location.href = "/";
+        window.location.replace("/setup");
         return;
       }
       setCompleteError("Factory reset failed");

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -499,7 +499,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             if (resetPollRef.current) clearInterval(resetPollRef.current);
             if (resetDotsRef.current) clearInterval(resetDotsRef.current);
             setResetPhase("done");
-            setTimeout(() => { window.location.href = "/"; }, 1500);
+            setTimeout(() => { window.location.replace("/setup"); }, 1500);
           }
         } catch { /* still offline */ }
       }, 3000);

--- a/src/tests/components/login-page.test.tsx
+++ b/src/tests/components/login-page.test.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { render, waitFor } from "@/tests/helpers/test-utils";
+import LoginPage from "@/app/login/page";
+
+vi.mock("next/image", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/lib/i18n", () => ({
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useT: () => ({ t: (key: string) => key }),
+}));
+
+describe("LoginPage", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ setup_complete: false }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("redirects incomplete setups to /setup instead of looping back to /login", async () => {
+    const replaceMock = vi.fn();
+    vi.stubGlobal("location", {
+      ...window.location,
+      href: "http://localhost/login?redirect=%2F",
+      pathname: "/login",
+      search: "?redirect=%2F",
+      replace: replaceMock,
+    });
+
+    render(<LoginPage />);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/setup-api/setup/status");
+    });
+    await waitFor(() => {
+      expect(replaceMock).toHaveBeenCalledWith("/setup");
+    });
+  });
+});

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -113,6 +113,15 @@ describe("POST /setup-api/setup/reset", () => {
     expect(mockResetUpdateState).toHaveBeenCalled();
   });
 
+  it("clears the session cookie in the reset response", async () => {
+    const res = await resetPost();
+    const setCookie = res.headers.get("set-cookie");
+
+    expect(setCookie).toContain("clawbox_session=");
+    expect(setCookie).toContain("Max-Age=0");
+    expect(setCookie).toContain("Path=/");
+  });
+
   it("resets update state", async () => {
     await resetPost();
     expect(mockResetUpdateState).toHaveBeenCalled();


### PR DESCRIPTION
After factory reset, the browser could keep a stale session cookie while the UI navigated back to '/'. That left incomplete setups vulnerable to falling through auth and landing on '/login?redirect=%2F' instead of resuming setup.

This change makes all reset recovery paths land on '/setup' directly and expires the session cookie in the reset response so the browser cannot reuse pre-reset auth state. It also adds regressions for the login handoff and reset cookie clearing.

Constraint: Middleware auth currently does not read setup state directly

Rejected: Add setup-aware server redirects in middleware now | broader behavior change than needed for this bug

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Keep post-reset recovery targeting '/setup' until auth and setup state are unified server-side

Tested: vitest login-page component regression

Tested: vitest setup reset route suite

Tested: bun run build

Tested: systemctl restart clawbox-setup

Not-tested: Manual factory reset in a browser against a physical device