### PR TITLE
Stabilize Local AI state and simplify provider setup

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -86,12 +86,28 @@ jobs:
           E2E_RESULT: ${{ needs.e2e.result }}
         with:
           script: |
-            const marker = '<!-- clawbox-e2e -->';
+            const marker = '<!-- clawbox-ci-summary -->';
+            const testsStart = '<!-- clawbox-ci-tests:start -->';
+            const testsEnd = '<!-- clawbox-ci-tests:end -->';
+            const e2eStart = '<!-- clawbox-ci-e2e:start -->';
+            const e2eEnd = '<!-- clawbox-ci-e2e:end -->';
             const ok = process.env.E2E_RESULT === 'success';
             const icon = ok ? '✅' : '❌';
-            const body = `${marker}\n## ${icon} E2E Test Report\n- Result: **${ok ? 'passed' : 'failed'}**\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const wrappedSection = `${e2eStart}\n## ${icon} E2E\n- Result: **${ok ? 'passed' : 'failed'}**\n- [View run](${runUrl})\n${e2eEnd}`;
+            const defaultBody = `${marker}\n# CI Summary\n\n${testsStart}\n## ⏳ Tests\n- Waiting for test workflow to finish.\n${testsEnd}\n\n${wrappedSection}`;
             const { owner, repo } = context.repo;
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number: context.issue.number, per_page: 100 });
             const existing = comments.find(c => c.user?.type === 'Bot' && c.body?.includes(marker));
+
+            const updateSection = (body, start, end, replacement) => {
+              const pattern = new RegExp(`${start}[\\s\\S]*?${end}`);
+              return pattern.test(body) ? body.replace(pattern, replacement) : `${body}\n\n${replacement}`;
+            };
+
+            const body = existing
+              ? updateSection(existing.body, e2eStart, e2eEnd, wrappedSection)
+              : defaultBody;
+
             if (existing) await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
             else await github.rest.issues.createComment({ owner, repo, issue_number: context.issue.number, body });

--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -11,6 +11,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    outputs:
+      found: ${{ steps.coverage.outputs.found }}
+      statements: ${{ steps.coverage.outputs.statements }}
+      branches: ${{ steps.coverage.outputs.branches }}
+      functions: ${{ steps.coverage.outputs.functions }}
+      lines: ${{ steps.coverage.outputs.lines }}
     steps:
       - uses: actions/checkout@v4
 
@@ -55,14 +61,40 @@ jobs:
         uses: actions/github-script@v7
         env:
           TEST_RESULT: ${{ needs.test.result }}
+          COVERAGE_FOUND: ${{ needs.test.outputs.found }}
+          COVERAGE_STATEMENTS: ${{ needs.test.outputs.statements }}
+          COVERAGE_BRANCHES: ${{ needs.test.outputs.branches }}
+          COVERAGE_FUNCTIONS: ${{ needs.test.outputs.functions }}
+          COVERAGE_LINES: ${{ needs.test.outputs.lines }}
         with:
           script: |
-            const marker = '<!-- clawbox-tests -->';
+            const marker = '<!-- clawbox-ci-summary -->';
+            const testsStart = '<!-- clawbox-ci-tests:start -->';
+            const testsEnd = '<!-- clawbox-ci-tests:end -->';
+            const e2eStart = '<!-- clawbox-ci-e2e:start -->';
+            const e2eEnd = '<!-- clawbox-ci-e2e:end -->';
             const ok = process.env.TEST_RESULT === 'success';
             const icon = ok ? '✅' : '❌';
-            const body = `${marker}\n## ${icon} Test Report\n- Result: **${ok ? 'passed' : 'failed'}**\n\n[View run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let section = `## ${icon} Tests\n- Result: **${ok ? 'passed' : 'failed'}**\n- [View run](${runUrl})`;
+            if (process.env.COVERAGE_FOUND === 'true') {
+              section += `\n- Coverage: statements **${process.env.COVERAGE_STATEMENTS}%**, branches **${process.env.COVERAGE_BRANCHES}%**, functions **${process.env.COVERAGE_FUNCTIONS}%**, lines **${process.env.COVERAGE_LINES}%**`;
+            }
+            const wrappedSection = `${testsStart}\n${section}\n${testsEnd}`;
+            const defaultBody = `${marker}\n# CI Summary\n\n${wrappedSection}\n\n${e2eStart}\n## ⏳ E2E\n- Waiting for E2E workflow to finish.\n${e2eEnd}`;
+
             const {owner, repo} = context.repo;
             const comments = await github.paginate(github.rest.issues.listComments, {owner, repo, issue_number: context.issue.number, per_page: 100});
             const existing = comments.find(c => c.user?.type === 'Bot' && c.body?.includes(marker));
+
+            const updateSection = (body, start, end, replacement) => {
+              const pattern = new RegExp(`${start}[\\s\\S]*?${end}`);
+              return pattern.test(body) ? body.replace(pattern, replacement) : `${body}\n\n${replacement}`;
+            };
+
+            const body = existing
+              ? updateSection(existing.body, testsStart, testsEnd, wrappedSection)
+              : defaultBody;
+
             if (existing) await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
             else await github.rest.issues.createComment({owner, repo, issue_number: context.issue.number, body});

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -831,7 +831,7 @@ export async function completeSetupWizard(page: Page) {
   await page.getByRole("button", { name: "Save" }).click();
 
   await expect(page.getByTestId("setup-step-local-ai")).toBeVisible();
-  await page.getByRole("button", { name: /Install & Use llama\.cpp/i }).click();
+  await page.getByRole("button", { name: /Enable Gemma 4/i }).click();
 
   await expect(page.getByTestId("setup-step-ai-models")).toBeVisible();
   await page.getByRole("button", { name: "Start for free" }).click();
@@ -841,6 +841,11 @@ export async function completeSetupWizard(page: Page) {
 }
 
 export async function openLauncher(page: Page) {
-  await page.locator('[data-testid="shelf-launcher-button"]:visible').click({ force: true });
-  await expect(page.getByTestId("app-launcher")).toBeVisible();
+  const launcher = page.getByTestId("app-launcher");
+  const alreadyOpen = await launcher.isVisible().catch(() => false);
+  if (alreadyOpen) return;
+
+  const button = page.locator('[data-testid="shelf-launcher-button"]:visible').first();
+  await button.click({ force: true });
+  await expect(launcher).toBeVisible();
 }

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -5,6 +5,9 @@ type SetupState = {
   wifi_configured: boolean;
   update_completed: boolean;
   password_configured: boolean;
+  local_ai_configured: boolean;
+  local_ai_provider?: string | null;
+  local_ai_model?: string | null;
   ai_model_configured: boolean;
   telegram_configured: boolean;
 };
@@ -51,6 +54,9 @@ const DEFAULT_SETUP: SetupState = {
   wifi_configured: false,
   update_completed: false,
   password_configured: false,
+  local_ai_configured: false,
+  local_ai_provider: null,
+  local_ai_model: null,
   ai_model_configured: false,
   telegram_configured: false,
 };
@@ -272,6 +278,9 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
         wifi_configured: true,
         update_completed: true,
         password_configured: true,
+        local_ai_configured: true,
+        local_ai_provider: "llamacpp",
+        local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
         ai_model_configured: true,
         telegram_configured: true,
       });
@@ -559,15 +568,57 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
       return;
     }
 
+    if (path === "/setup-api/llamacpp/status") {
+      await fulfillJson(route, {
+        running: setupState.local_ai_provider === "llamacpp",
+        models: setupState.local_ai_provider === "llamacpp" && setupState.local_ai_model
+          ? [{ id: setupState.local_ai_model.split("/").pop(), owned_by: "llama.cpp" }]
+          : [],
+        baseUrl: "http://127.0.0.1:8080/v1",
+      });
+      return;
+    }
+
+    if (path === "/setup-api/llamacpp/install" && method === "POST") {
+      const payload = await readRequestJson<{ model?: string; scope?: "primary" | "local" }>(route);
+      const model = payload.model || "gemma4-e2b-it-q4_0";
+      setupState.local_ai_configured = true;
+      setupState.local_ai_provider = "llamacpp";
+      setupState.local_ai_model = `llamacpp/${model}`;
+
+      if (payload.scope !== "local") {
+        setupState.ai_model_configured = true;
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/x-ndjson",
+        body: `${JSON.stringify({ status: `Preparing llama.cpp for ${model}...` })}\n${JSON.stringify({ status: "llama.cpp is ready. Applying ClawBox configuration..." })}\n${JSON.stringify({ success: true, model, status: `${model} is installed, running, and configured.` })}\n`,
+      });
+      return;
+    }
+
+    if (path === "/setup-api/ollama/status") {
+      await fulfillJson(route, {
+        running: true,
+        models: setupState.local_ai_provider === "ollama" && setupState.local_ai_model
+          ? [{ name: setupState.local_ai_model.split("/").pop(), size: 3_400_000_000 }]
+          : [],
+      });
+      return;
+    }
+
     if (path === "/setup-api/ai-models/status") {
       await fulfillJson(route, setupState.ai_model_configured
         ? {
             connected: true,
+            provider: "deepseek",
             providerLabel: "ClawBox AI",
             model: "clawai/deepseek-r1",
           }
         : {
             connected: false,
+            provider: null,
             providerLabel: null,
             model: null,
           });
@@ -575,7 +626,16 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
     }
 
     if (path === "/setup-api/ai-models/configure" && method === "POST") {
-      setupState.ai_model_configured = true;
+      const payload = await readRequestJson<{ provider?: string; apiKey?: string; scope?: "primary" | "local" }>(route);
+      if (payload.scope === "local") {
+        setupState.local_ai_configured = true;
+        setupState.local_ai_provider = payload.provider ?? "llamacpp";
+        setupState.local_ai_model = payload.provider === "ollama"
+          ? `ollama/${payload.apiKey || "llama3.2:3b"}`
+          : `llamacpp/${payload.apiKey || "gemma4-e2b-it-q4_0"}`;
+      } else {
+        setupState.ai_model_configured = true;
+      }
       await fulfillJson(route, { success: true });
       return;
     }
@@ -769,6 +829,9 @@ export async function completeSetupWizard(page: Page) {
   await page.locator("#hotspot-password").fill("hotspot-pass");
   await page.locator("#hotspot-confirm").fill("hotspot-pass");
   await page.getByRole("button", { name: "Save" }).click();
+
+  await expect(page.getByTestId("setup-step-local-ai")).toBeVisible();
+  await page.getByRole("button", { name: /Install & Use llama\.cpp/i }).click();
 
   await expect(page.getByTestId("setup-step-ai-models")).toBeVisible();
   await page.getByRole("button", { name: "Start for free" }).click();

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -1,13 +1,16 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-test("settings covers appearance, network, ai, telegram, system, and about flows", async ({ page }) => {
+test("settings covers appearance, network, ai, local ai, telegram, system, and about flows", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,
       wifi_configured: true,
       update_completed: true,
       password_configured: true,
+      local_ai_configured: true,
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
       ai_model_configured: false,
       telegram_configured: false,
     },
@@ -42,6 +45,15 @@ test("settings covers appearance, network, ai, telegram, system, and about flows
   await settingsWindow.getByRole("button", { name: "AI Provider" }).click();
   await settingsWindow.getByRole("button", { name: "Save" }).click();
   await expect(settingsWindow.getByText("ClawBox AI").first()).toBeVisible();
+  await expect(settingsWindow.getByText("llama.cpp Local")).toHaveCount(0);
+
+  await settingsWindow.getByRole("button", { name: "Local AI" }).click();
+  await expect(settingsWindow.getByText("Gemma 4 Local")).toBeVisible();
+  await expect(settingsWindow.getByText("gemma4-e2b-it-q4_0").first()).toBeVisible();
+  const localProviderGroup = settingsWindow.getByRole("radiogroup", { name: "AI Provider" });
+  await expect(localProviderGroup.getByText("llama.cpp Local")).toBeVisible();
+  await expect(localProviderGroup.getByText("Ollama Local")).toBeVisible();
+  await expect(localProviderGroup.getByText("ClawBox AI")).toHaveCount(0);
 
   await settingsWindow.getByRole("button", { name: "Telegram" }).click();
   await settingsWindow.locator("#settings-tg-token").fill("123456789:ABCdefGHI");

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -51,8 +51,8 @@ test("settings covers appearance, network, ai, local ai, telegram, system, and a
   await expect(settingsWindow.getByText("Gemma 4 Local")).toBeVisible();
   await expect(settingsWindow.getByText("gemma4-e2b-it-q4_0").first()).toBeVisible();
   const localProviderGroup = settingsWindow.getByRole("radiogroup", { name: "AI Provider" });
-  await expect(localProviderGroup.getByText("llama.cpp Local")).toBeVisible();
-  await expect(localProviderGroup.getByText("Ollama Local")).toBeVisible();
+  await expect(localProviderGroup.getByText("Gemma 4")).toBeVisible();
+  await expect(localProviderGroup.getByText("Ollama")).toBeVisible();
   await expect(localProviderGroup.getByText("ClawBox AI")).toHaveCount(0);
 
   await settingsWindow.getByRole("button", { name: "Telegram" }).click();

--- a/e2e/setup-local-ai-order.spec.ts
+++ b/e2e/setup-local-ai-order.spec.ts
@@ -22,19 +22,19 @@ test("setup configures Local AI before the primary AI provider step", async ({ p
   const localAiStep = page.getByTestId("setup-step-local-ai");
   const localProviderGroup = localAiStep.getByRole("radiogroup", { name: "AI Provider" });
   await expect(localAiStep).toBeVisible();
-  await expect(localProviderGroup.getByText("llama.cpp Local")).toBeVisible();
-  await expect(localProviderGroup.getByText("Ollama Local")).toBeVisible();
-  await expect(localAiStep.getByRole("button", { name: /Install & Use llama\.cpp/i })).toBeVisible();
+  await expect(localProviderGroup.getByText("Gemma 4")).toBeVisible();
+  await expect(localProviderGroup.getByText("Ollama")).toBeVisible();
+  await expect(localAiStep.getByRole("button", { name: /Enable Gemma 4/i })).toBeVisible();
   await expect(localProviderGroup.getByText("ClawBox AI")).toHaveCount(0);
   await expect(localProviderGroup.getByText("OpenAI GPT")).toHaveCount(0);
 
-  await localAiStep.getByRole("button", { name: /Install & Use llama\.cpp/i }).click();
+  await localAiStep.getByRole("button", { name: /Enable Gemma 4/i }).click();
 
   const providerStep = page.getByTestId("setup-step-ai-models");
   const providerGroup = providerStep.getByRole("radiogroup", { name: "AI Provider" });
   await expect(providerStep).toBeVisible();
   await expect(providerGroup.getByText("ClawBox AI")).toBeVisible();
   await expect(providerGroup.getByText("OpenAI GPT")).toBeVisible();
-  await expect(providerGroup.getByText("llama.cpp Local")).toHaveCount(0);
-  await expect(providerGroup.getByText("Ollama Local")).toHaveCount(0);
+  await expect(providerGroup.getByText("Gemma 4")).toHaveCount(0);
+  await expect(providerGroup.getByText("Ollama")).toHaveCount(0);
 });

--- a/e2e/setup-local-ai-order.spec.ts
+++ b/e2e/setup-local-ai-order.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "./helpers/coverage";
+import { installClawboxMocks } from "./helpers/clawbox";
+
+test("setup configures Local AI before the primary AI provider step", async ({ page }) => {
+  await installClawboxMocks(page);
+
+  await page.goto("/setup");
+
+  await expect(page.getByTestId("setup-step-wifi")).toBeVisible();
+  await page.getByRole("button", { name: "Connect to WiFi" }).click();
+  await page.getByRole("button", { name: "Clawbox Lab" }).click();
+  await page.locator("#wifi-password").fill("wireless-pass");
+  await page.getByRole("button", { name: "Connect" }).click();
+
+  await expect(page.getByTestId("setup-step-credentials")).toBeVisible();
+  await page.locator("#cred-password").fill("clawbox-pass");
+  await page.locator("#cred-confirm").fill("clawbox-pass");
+  await page.locator("#hotspot-password").fill("hotspot-pass");
+  await page.locator("#hotspot-confirm").fill("hotspot-pass");
+  await page.getByRole("button", { name: "Save" }).click();
+
+  const localAiStep = page.getByTestId("setup-step-local-ai");
+  const localProviderGroup = localAiStep.getByRole("radiogroup", { name: "AI Provider" });
+  await expect(localAiStep).toBeVisible();
+  await expect(localProviderGroup.getByText("llama.cpp Local")).toBeVisible();
+  await expect(localProviderGroup.getByText("Ollama Local")).toBeVisible();
+  await expect(localAiStep.getByRole("button", { name: /Install & Use llama\.cpp/i })).toBeVisible();
+  await expect(localProviderGroup.getByText("ClawBox AI")).toHaveCount(0);
+  await expect(localProviderGroup.getByText("OpenAI GPT")).toHaveCount(0);
+
+  await localAiStep.getByRole("button", { name: /Install & Use llama\.cpp/i }).click();
+
+  const providerStep = page.getByTestId("setup-step-ai-models");
+  const providerGroup = providerStep.getByRole("radiogroup", { name: "AI Provider" });
+  await expect(providerStep).toBeVisible();
+  await expect(providerGroup.getByText("ClawBox AI")).toBeVisible();
+  await expect(providerGroup.getByText("OpenAI GPT")).toBeVisible();
+  await expect(providerGroup.getByText("llama.cpp Local")).toHaveCount(0);
+  await expect(providerGroup.getByText("Ollama Local")).toHaveCount(0);
+});

--- a/e2e/setup-openai-path.spec.ts
+++ b/e2e/setup-openai-path.spec.ts
@@ -19,6 +19,9 @@ test("setup supports the OpenAI API-key path and telegram configuration", async 
   await page.locator("#hotspot-confirm").fill("hotspot-pass");
   await page.getByRole("button", { name: "Save" }).click();
 
+  await expect(page.getByTestId("setup-step-local-ai")).toBeVisible();
+  await page.getByRole("button", { name: /Install & Use llama\.cpp/i }).click();
+
   await expect(page.getByTestId("setup-step-ai-models")).toBeVisible();
   await page.getByText("OpenAI GPT").click();
   await page.locator("#ai-api-key").fill("sk-test-openai-key");

--- a/e2e/setup-openai-path.spec.ts
+++ b/e2e/setup-openai-path.spec.ts
@@ -20,7 +20,7 @@ test("setup supports the OpenAI API-key path and telegram configuration", async 
   await page.getByRole("button", { name: "Save" }).click();
 
   await expect(page.getByTestId("setup-step-local-ai")).toBeVisible();
-  await page.getByRole("button", { name: /Install & Use llama\.cpp/i }).click();
+  await page.getByRole("button", { name: /Enable Gemma 4/i }).click();
 
   await expect(page.getByTestId("setup-step-ai-models")).toBeVisible();
   await page.getByText("OpenAI GPT").click();

--- a/e2e/setup-resume.spec.ts
+++ b/e2e/setup-resume.spec.ts
@@ -7,6 +7,9 @@ test("setup resumes on the ai models step for partially configured devices", asy
       wifi_configured: true,
       update_completed: true,
       password_configured: true,
+      local_ai_configured: true,
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
     },
   });
 

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -4,11 +4,13 @@ import { NextResponse } from "next/server";
 import { spawn } from "child_process";
 import fs from "fs/promises";
 import path from "path";
-import { setMany } from "@/lib/config-store";
+import { getAll, setMany } from "@/lib/config-store";
 import {
   restartGateway,
   findOpenclawBin,
   DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR,
+  inferConfiguredLocalModel,
+  readConfig as readOpenClawConfig,
 } from "@/lib/openclaw-config";
 import {
   getDefaultLlamaCppModel,
@@ -46,6 +48,8 @@ interface ProviderConfig {
   /** Override config used when authMode is "subscription" (OAuth). */
   subscriptionOverride?: { defaultModel: string; profileKey?: string };
 }
+
+type ConfigureScope = "primary" | "local";
 
 const PROVIDERS: Record<string, ProviderConfig> = {
   clawai: {
@@ -212,6 +216,62 @@ async function configureClawboxAi(setFallback: boolean) {
   return true;
 }
 
+async function setFallbackModels(models: string[]) {
+  await runCommand(OPENCLAW_BIN, [
+    "config",
+    "set",
+    "agents.defaults.model.fallbacks",
+    JSON.stringify(models),
+    "--json",
+  ]);
+}
+
+async function getStoredLocalFallbackModel(): Promise<string | null> {
+  try {
+    const config = await getAll();
+    if (Object.prototype.hasOwnProperty.call(config, "local_ai_configured") && config.local_ai_configured === false) {
+      return null;
+    }
+    const stored = config.local_ai_configured && typeof config.local_ai_model === "string"
+      ? config.local_ai_model
+      : null;
+    if (stored) return stored;
+  } catch {
+    // Fall through to OpenClaw config inference.
+  }
+
+  try {
+    const openclawConfig = await readOpenClawConfig();
+    return inferConfiguredLocalModel(openclawConfig)?.model ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureFallbackModel(primaryModel?: string | null, preferredLocalModel?: string) {
+  const fallbackCandidates = [preferredLocalModel, await getStoredLocalFallbackModel()]
+    .filter((model): model is string => !!model && model !== primaryModel);
+
+  if (fallbackCandidates.length > 0) {
+    await setFallbackModels([fallbackCandidates[0]]);
+    console.log(`[AI Config] Configured local fallback model: ${fallbackCandidates[0]}`);
+    return;
+  }
+
+  try {
+    const fallbackConfigured = await configureClawboxAi(true);
+    if (fallbackConfigured) {
+      console.log("[AI Config] Configured ClawBox AI as fallback model");
+      return;
+    }
+
+    await setFallbackModels([]);
+    console.log("[AI Config] Cleared stale fallback (no local or ClawBox AI backup available)");
+  } catch (err) {
+    console.warn("[AI Config] Failed to configure fallback model:", err instanceof Error ? err.message : err);
+  }
+}
+
 export async function POST(request: Request) {
   try {
     let body: {
@@ -221,6 +281,7 @@ export async function POST(request: Request) {
       refreshToken?: string;
       expiresIn?: number;
       projectId?: string;
+      scope?: ConfigureScope;
     };
     try {
       body = await request.json();
@@ -228,13 +289,20 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { provider, apiKey, authMode = "token", refreshToken, expiresIn, projectId } = body;
+    const { provider, apiKey, authMode = "token", refreshToken, expiresIn, projectId, scope = "primary" } = body;
     const isOllama = provider === "ollama";
     const isLlamaCpp = provider === "llamacpp";
     const isClawAI = provider === "clawai";
+    const isLocalScope = scope === "local";
     if (!provider || (!apiKey && !isOllama && !isLlamaCpp && !isClawAI)) {
       return NextResponse.json(
         { error: "Provider is required; API key required for non-local providers" },
+        { status: 400 }
+      );
+    }
+    if (isLocalScope && !isOllama && !isLlamaCpp) {
+      return NextResponse.json(
+        { error: "Local AI scope is only supported for Ollama and llama.cpp" },
         { status: 400 }
       );
     }
@@ -254,23 +322,6 @@ export async function POST(request: Request) {
     const llamaCppContextWindow = getLlamaCppContextWindow();
     const llamaCppMaxTokens = getLlamaCppMaxTokens();
     const ocProvider = config.profileKey.split(":")[0];
-    const ensureClawboxFallback = async () => {
-      try {
-        const fallbackConfigured = await configureClawboxAi(true);
-        if (fallbackConfigured) {
-          console.log("[AI Config] Configured ClawBox AI as fallback model");
-          return;
-        }
-
-        await runCommand(OPENCLAW_BIN, [
-          "config", "set", "agents.defaults.model.fallbacks", "[]", "--json",
-        ]);
-        console.log("[AI Config] Cleared stale fallback (no ClawBox AI key)");
-      } catch (err) {
-        console.warn("[AI Config] Failed to configure ClawBox AI fallback:", err instanceof Error ? err.message : err);
-      }
-    };
-
     // For Ollama the front-end supplies the model name (e.g. "llama3.2:3b")
     // via the `apiKey` field — there is no real API key for a local provider.
     if (isOllama) {
@@ -347,12 +398,14 @@ export async function POST(request: Request) {
         : { provider: ocProvider, mode: authMode === "subscription" ? "oauth" : "token" }),
       "--json",
     ]);
-    await runCommand(OPENCLAW_BIN, [
-      "config",
-      "set",
-      "agents.defaults.model.primary",
-      config.defaultModel,
-    ]);
+    if (!isLocalScope) {
+      await runCommand(OPENCLAW_BIN, [
+        "config",
+        "set",
+        "agents.defaults.model.primary",
+        config.defaultModel,
+      ]);
+    }
     await runCommand(OPENCLAW_BIN, [
       "config",
       "set",
@@ -384,11 +437,20 @@ export async function POST(request: Request) {
     );
 
     // 6. Persist to ClawBox config store
-    await setMany({
-      ai_model_configured: true,
-      ai_model_provider: ocProvider,
-      ai_model_configured_at: new Date().toISOString(),
-    });
+    if (isLocalScope) {
+      await setMany({
+        local_ai_configured: true,
+        local_ai_provider: ocProvider,
+        local_ai_model: config.defaultModel,
+        local_ai_configured_at: new Date().toISOString(),
+      });
+    } else {
+      await setMany({
+        ai_model_configured: true,
+        ai_model_provider: ocProvider,
+        ai_model_configured_at: new Date().toISOString(),
+      });
+    }
 
     // 7. For ClawBox AI (DeepSeek) or Ollama, define a custom provider in openclaw.json
     // and set models.mode=replace so the gateway uses our definition.
@@ -397,6 +459,7 @@ export async function POST(request: Request) {
       await runCommand(OPENCLAW_BIN, [
         "config", "set", "models.mode", "merge",
       ]);
+      await ensureFallbackModel(config.defaultModel);
       console.log(`[AI Config] Set ClawBox AI provider in openclaw.json via proxy ${CLAWBOX_AI_PROXY_URL} (context=${CLAWBOX_AI_CONTEXT_WINDOW})`);
     } else if (isOllama) {
       const modelName = config.defaultModel.replace(/^ollama\//, "");
@@ -418,9 +481,9 @@ export async function POST(request: Request) {
         "config", "set", "models.providers.ollama", providerDef, "--json",
       ]);
       await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.mode", "replace",
+        "config", "set", "models.mode", isLocalScope ? "merge" : "replace",
       ]);
-      await ensureClawboxFallback();
+      await ensureFallbackModel(isLocalScope ? null : config.defaultModel, config.defaultModel);
       // Ensure Ollama service has memory optimizations (q8_0 KV cache, flash attention)
       try {
         await runCommand("sudo", ["/home/clawbox/clawbox/scripts/optimize-ollama.sh"]);
@@ -449,9 +512,9 @@ export async function POST(request: Request) {
         "config", "set", "models.providers.llamacpp", providerDef, "--json",
       ]);
       await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.mode", "replace",
+        "config", "set", "models.mode", isLocalScope ? "merge" : "replace",
       ]);
-      await ensureClawboxFallback();
+      await ensureFallbackModel(isLocalScope ? null : config.defaultModel, config.defaultModel);
       console.log(`[AI Config] Set llama.cpp provider in openclaw.json: ${modelName} (context=${llamaCppContextWindow}, mode=replace)`);
     } else {
       // Switching away from Ollama/ClawBox AI — reset models.mode so cloud providers
@@ -464,7 +527,7 @@ export async function POST(request: Request) {
         // Non-fatal: merge is the default behavior anyway
       }
 
-      await ensureClawboxFallback();
+      await ensureFallbackModel(config.defaultModel);
     }
 
     // 8. Restart OpenClaw gateway so it picks up the new auth profile and model

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -4,7 +4,7 @@ import { readConfig } from "@/lib/openclaw-config";
 export const dynamic = "force-dynamic";
 
 const PROVIDER_LABELS: Record<string, string> = {
-  deepseek: "ClawBox AI",
+  clawai: "ClawBox AI",
   anthropic: "Anthropic Claude",
   openai: "OpenAI GPT",
   google: "Google Gemini",
@@ -12,6 +12,19 @@ const PROVIDER_LABELS: Record<string, string> = {
   ollama: "Ollama Local",
   llamacpp: "llama.cpp Local",
 };
+
+function normalizeProvider(provider: string | null): string | null {
+  if (!provider) return null;
+  const normalized = provider.trim().toLowerCase();
+  if (normalized === "deepseek" || normalized === "clawai") return "clawai";
+  if (normalized.startsWith("openai")) return "openai";
+  if (normalized.startsWith("google")) return "google";
+  if (normalized.startsWith("anthropic")) return "anthropic";
+  if (normalized.startsWith("openrouter")) return "openrouter";
+  if (normalized.startsWith("ollama")) return "ollama";
+  if (normalized.startsWith("llamacpp")) return "llamacpp";
+  return normalized;
+}
 
 export async function GET() {
   try {
@@ -42,15 +55,27 @@ export async function GET() {
       provider = entry?.provider ?? activeKey.split(":")[0];
       mode = entry?.mode ?? null;
     }
+    const normalizedProvider = normalizeProvider(provider);
 
     return NextResponse.json({
-      connected: !!provider,
-      provider,
-      providerLabel: provider ? (PROVIDER_LABELS[provider] ?? provider) : null,
+      connected: !!normalizedProvider,
+      provider: normalizedProvider,
+      providerLabel: normalizedProvider ? (PROVIDER_LABELS[normalizedProvider] ?? normalizedProvider) : null,
       mode,
       model,
+    }, {
+      headers: {
+        "Cache-Control": "no-store",
+      },
     });
   } catch {
-    return NextResponse.json({ connected: false, provider: null, providerLabel: null, mode: null, model: null });
+    return NextResponse.json(
+      { connected: false, provider: null, providerLabel: null, mode: null, model: null },
+      {
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      },
+    );
   }
 }

--- a/src/app/setup-api/llamacpp/install/route.ts
+++ b/src/app/setup-api/llamacpp/install/route.ts
@@ -31,7 +31,9 @@ function getLastLogLine(logText: string): string | null {
   return lines.length > 0 ? lines[lines.length - 1] : null;
 }
 
-async function configureLlamaCpp(alias: string): Promise<{ ok: boolean; error?: string }> {
+type ConfigureScope = "primary" | "local";
+
+async function configureLlamaCpp(alias: string, scope: ConfigureScope): Promise<{ ok: boolean; error?: string }> {
   const req = new Request("http://localhost/setup-api/ai-models/configure", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -39,6 +41,7 @@ async function configureLlamaCpp(alias: string): Promise<{ ok: boolean; error?: 
       provider: "llamacpp",
       apiKey: alias,
       authMode: "local",
+      scope,
     }),
   });
   const res = await configureAiModel(req);
@@ -50,7 +53,7 @@ async function configureLlamaCpp(alias: string): Promise<{ ok: boolean; error?: 
 }
 
 export async function POST(request: Request) {
-  let body: { model?: string };
+  let body: { model?: string; scope?: ConfigureScope };
   try {
     body = await request.json();
   } catch {
@@ -58,6 +61,7 @@ export async function POST(request: Request) {
   }
 
   const alias = body.model?.trim() || getDefaultLlamaCppModel();
+  const scope = body.scope === "local" ? "local" : "primary";
   if (!MODEL_ID_RE.test(alias)) {
     return NextResponse.json({ error: "Invalid llama.cpp model ID" }, { status: 400 });
   }
@@ -73,7 +77,7 @@ export async function POST(request: Request) {
         const existingModels = await queryLlamaCppModels(spec.baseUrl);
         if (existingModels.includes(alias)) {
           emit(controller, { status: "llama.cpp is already running. Applying configuration..." });
-          const configured = await configureLlamaCpp(alias);
+          const configured = await configureLlamaCpp(alias, scope);
           if (!configured.ok) {
             emit(controller, { error: configured.error });
             controller.close();
@@ -136,7 +140,7 @@ export async function POST(request: Request) {
           const models = await queryLlamaCppModels(spec.baseUrl);
           if (models.includes(alias)) {
             emit(controller, { status: "llama.cpp is ready. Applying ClawBox configuration..." });
-            const configured = await configureLlamaCpp(alias);
+            const configured = await configureLlamaCpp(alias, scope);
             if (!configured.ok) {
               emit(controller, { error: configured.error });
               controller.close();

--- a/src/app/setup-api/llamacpp/status/route.ts
+++ b/src/app/setup-api/llamacpp/status/route.ts
@@ -29,8 +29,16 @@ export async function GET() {
         }))
       : [];
 
-    return NextResponse.json({ running: true, baseUrl, models });
+    return NextResponse.json({ running: true, baseUrl, models }, {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
   } catch {
-    return NextResponse.json({ running: false, baseUrl, models: [] });
+    return NextResponse.json({ running: false, baseUrl, models: [] }, {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
   }
 }

--- a/src/app/setup-api/local-ai/route.ts
+++ b/src/app/setup-api/local-ai/route.ts
@@ -1,0 +1,100 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { promisify } from "util";
+import { execFile as execFileCb } from "child_process";
+import { setMany } from "@/lib/config-store";
+import { clearLlamaCppPid, getLlamaCppLaunchSpec, readLlamaCppPid } from "@/lib/llamacpp-server";
+import { readConfig as readOpenClawConfig, inferConfiguredLocalModel, findOpenclawBin, restartGateway } from "@/lib/openclaw-config";
+
+const execFile = promisify(execFileCb);
+const OPENCLAW_BIN = findOpenclawBin();
+
+async function runCommand(cmd: string, args: string[]) {
+  return await execFile(cmd, args, {
+    cwd: "/home/clawbox",
+    env: { ...process.env, HOME: "/home/clawbox" },
+    timeout: 30_000,
+  });
+}
+
+async function disableLlamaCpp(alias?: string) {
+  const spec = getLlamaCppLaunchSpec(alias);
+  const pid = await readLlamaCppPid(spec.pidPath);
+  if (pid) {
+    try {
+      process.kill(pid, "SIGTERM");
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      try {
+        process.kill(pid, 0);
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // Process is already gone.
+      }
+    } catch {}
+    await clearLlamaCppPid(spec.pidPath);
+  }
+}
+
+async function disableOllama() {
+  try {
+    await execFile("systemctl", ["stop", "ollama"], { timeout: 30_000 });
+  } catch {
+    // Non-fatal: if systemd stop fails, fall back to process termination attempt.
+    const pgrep = await execFile("pgrep", ["-f", "ollama serve"], { timeout: 5_000 }).catch(() => null);
+    const pids = pgrep?.stdout?.trim().split("\n").filter(Boolean) ?? [];
+    for (const pid of pids) {
+      try {
+        process.kill(Number(pid), "SIGTERM");
+      } catch {}
+    }
+  }
+}
+
+export async function POST(request: Request) {
+  let body: { action?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (body.action !== "disable") {
+    return NextResponse.json({ error: "Unsupported action" }, { status: 400 });
+  }
+
+  try {
+    const config = await readOpenClawConfig();
+    const inferredLocal = inferConfiguredLocalModel(config);
+
+    if (inferredLocal?.provider === "llamacpp") {
+      await disableLlamaCpp(inferredLocal.model.replace(/^llamacpp\//, ""));
+    } else if (inferredLocal?.provider === "ollama") {
+      await disableOllama();
+    }
+
+    await setMany({
+      local_ai_configured: false,
+      local_ai_provider: undefined,
+      local_ai_model: undefined,
+      local_ai_configured_at: undefined,
+    });
+
+    await runCommand(OPENCLAW_BIN, [
+      "config",
+      "set",
+      "agents.defaults.model.fallbacks",
+      JSON.stringify([]),
+      "--json",
+    ]).catch(() => {});
+
+    await restartGateway().catch(() => {});
+
+    return NextResponse.json({ success: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to disable Local AI" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/setup-api/ollama/status/route.ts
+++ b/src/app/setup-api/ollama/status/route.ts
@@ -19,8 +19,16 @@ export async function GET() {
       size: m.size,
       modified_at: m.modified_at,
     }));
-    return NextResponse.json({ running: true, models });
+    return NextResponse.json({ running: true, models }, {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
   } catch {
-    return NextResponse.json({ running: false, models: [] });
+    return NextResponse.json({ running: false, models: [] }, {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    });
   }
 }

--- a/src/app/setup-api/setup/status/route.ts
+++ b/src/app/setup-api/setup/status/route.ts
@@ -1,24 +1,49 @@
 import { NextResponse } from "next/server";
 import { getAll } from "@/lib/config-store";
+import { inferConfiguredLocalModel, readConfig as readOpenClawConfig } from "@/lib/openclaw-config";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
-    const config = await getAll();
+    const [config, openclawConfig] = await Promise.all([
+      getAll(),
+      readOpenClawConfig().catch(() => ({})),
+    ]);
+    const hasExplicitLocalAiFlag = Object.prototype.hasOwnProperty.call(config, "local_ai_configured");
+    const inferredLocal = inferConfiguredLocalModel(openclawConfig);
+    const localAiConfigured = hasExplicitLocalAiFlag ? !!config.local_ai_configured : !!inferredLocal;
+    const localAiProvider = hasExplicitLocalAiFlag
+      ? (config.local_ai_provider || null)
+      : (config.local_ai_provider || inferredLocal?.provider || null);
+    const localAiModel = hasExplicitLocalAiFlag
+      ? (config.local_ai_model || null)
+      : (config.local_ai_model || inferredLocal?.model || null);
     return NextResponse.json({
       setup_complete: !!config.setup_complete,
       password_configured: !!config.password_configured,
       update_completed: !!config.update_completed,
       wifi_configured: !!config.wifi_configured,
+      local_ai_configured: localAiConfigured,
+      local_ai_provider: localAiProvider,
+      local_ai_model: localAiModel,
       ai_model_configured: !!config.ai_model_configured,
       ai_model_provider: config.ai_model_provider || null,
       telegram_configured: !!config.telegram_bot_token,
+    }, {
+      headers: {
+        "Cache-Control": "no-store",
+      },
     });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Status check failed" },
-      { status: 500 }
+      {
+        status: 500,
+        headers: {
+          "Cache-Control": "no-store",
+        },
+      }
     );
   }
 }

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -4,7 +4,12 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import StatusMessage from "./StatusMessage";
 import OllamaModelPanel from "./OllamaModelPanel";
 import LlamaCppModelPanel from "./LlamaCppModelPanel";
+import AIProviderIcon from "./AIProviderIcon";
 import { parseAuthInput, tryCloseOAuthWindow } from "@/lib/oauth-utils";
+import {
+  getLlamaCppOverlayProgress,
+  getOllamaOverlayProgress,
+} from "@/lib/ai-provider-progress";
 import { useOllamaModels } from "@/hooks/useOllamaModels";
 import type { OllamaCallbacks } from "@/hooks/useOllamaModels";
 import { useLlamaCppModels } from "@/hooks/useLlamaCppModels";
@@ -15,6 +20,14 @@ interface AIModelsStepProps {
   onNext?: () => void;
   embedded?: boolean;
   onConfigured?: () => void;
+  providerIds?: string[];
+  defaultProviderId?: string;
+  currentProviderId?: string | null;
+  currentModel?: string | null;
+  title?: string;
+  description?: string;
+  configureScope?: "primary" | "local";
+  testId?: string;
 }
 
 type AuthMode = "token" | "subscription" | "local";
@@ -35,51 +48,62 @@ interface Provider {
   authOptions: AuthOption[];
 }
 
+function normalizeSelectableProvider(provider: string | null | undefined): string | null {
+  if (!provider) return null;
+  const normalized = provider.trim().toLowerCase();
+  if (normalized === "deepseek" || normalized === "clawai") return "clawai";
+  if (normalized.startsWith("openai")) return "openai";
+  if (normalized.startsWith("google")) return "google";
+  if (normalized.startsWith("anthropic")) return "anthropic";
+  if (normalized.startsWith("openrouter")) return "openrouter";
+  if (normalized.startsWith("ollama")) return "ollama";
+  if (normalized.startsWith("llamacpp")) return "llamacpp";
+  return normalized;
+}
+
 const ButtonSpinner = (
   <span className="inline-block w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
 );
 
-const PROVIDER_ICONS: Record<string, string> = {
-  clawai: "🐾",
-  anthropic: "🧠",
-  openai: "⚡",
-  google: "✨",
-  openrouter: "🔀",
-  ollama: "🦙",
-  llamacpp: "⚙️",
-};
-
 const CONFIGURING_STEP_DELAYS = [0, 2000, 5000, 12000, 22000];
 
-function ConfiguringOverlay({ provider, onDone, t }: { provider: string; onDone: () => void; t: (key: string, params?: Record<string, string | number>) => string }) {
-  const [phase, setPhase] = useState(0);
+type ConfiguringKind = "generic" | "ollama" | "llamacpp";
+
+interface ConfiguringState {
+  provider: string;
+  kind: ConfiguringKind;
+  phase: number;
+  detail: string | null;
+  progressPercent: number | null;
+  completed: boolean;
+}
+
+function ConfiguringOverlay({
+  provider,
+  steps,
+  phase,
+  detail,
+  progressPercent,
+  completed,
+  t,
+}: {
+  provider: string;
+  steps: string[];
+  phase: number;
+  detail: string | null;
+  progressPercent: number | null;
+  completed: boolean;
+  t: (key: string, params?: Record<string, string | number>) => string;
+}) {
   const [dots, setDots] = useState("");
   const providerName = PROVIDERS.find((p) => p.id === provider)?.name ?? "AI";
-  const icon = PROVIDER_ICONS[provider] ?? "🤖";
-
-  const CONFIGURING_STEPS = [
-    { label: t("ai.credentialsVerified"), delay: 0 },
-    { label: t("ai.updatingConfig"), delay: 2000 },
-    { label: t("ai.restartingGateway"), delay: 5000 },
-    { label: t("ai.warmingUp"), delay: 12000 },
-    { label: t("ai.almostReady"), delay: 22000 },
-  ];
 
   const overlayRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const timers = CONFIGURING_STEP_DELAYS.map((delay, i) =>
-      i > 0 ? setTimeout(() => setPhase(i), delay) : null
-    );
-    const lastDelay = CONFIGURING_STEP_DELAYS[CONFIGURING_STEP_DELAYS.length - 1];
-    const done = setTimeout(onDone, lastDelay + 10000);
     // Trap focus inside overlay
     overlayRef.current?.focus();
-    return () => {
-      timers.forEach((t) => t && clearTimeout(t));
-      clearTimeout(done);
-    };
-  }, [onDone]);
+  }, []);
 
   useEffect(() => {
     const id = setInterval(() => setDots((d) => (d.length >= 3 ? "" : d + ".")), 500);
@@ -105,46 +129,45 @@ function ConfiguringOverlay({ provider, onDone, t }: { provider: string; onDone:
         <div className="absolute inset-2 rounded-full border border-emerald-500/10" style={{ animation: "aimodels-pulse-ring 2s ease-in-out infinite 0.5s" }} />
 
         {/* Orbiting dots */}
-        {phase >= 1 && [0, 1, 2].map((i) => (
+        {!completed && phase >= 1 && [0, 1, 2].map((i) => (
           <div key={i} className="absolute inset-0 flex items-center justify-center" style={{ animation: `aimodels-orbit ${3 + i * 0.5}s linear infinite`, animationDelay: `${i * 0.4}s` }}>
             <div className="w-2 h-2 rounded-full bg-[var(--coral-bright)]" style={{ opacity: 0.4 + i * 0.2 }} />
           </div>
         ))}
 
-        {/* Check circle (phase 0) then provider icon (phase 1+) */}
-        {phase === 0 ? (
+        {completed ? (
           <svg width="48" height="48" viewBox="0 0 56 56" fill="none" className="aimodels-fade-in">
             <circle cx="28" cy="28" r="25" stroke="#22c55e" strokeWidth="3" strokeDasharray="157" strokeDashoffset="157" style={{ animation: "aimodels-check-circle 0.6s ease-out 0.1s forwards" }} />
             <path d="M17 28l7 7 15-15" stroke="#22c55e" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" strokeDasharray="35" strokeDashoffset="35" style={{ animation: "aimodels-check-draw 0.4s ease-out 0.5s forwards" }} />
           </svg>
         ) : (
-          <span className="text-5xl aimodels-fade-in">{icon}</span>
+          <AIProviderIcon provider={provider} size={56} className="aimodels-fade-in" />
         )}
       </div>
 
       {/* Provider name */}
       <div className="text-center aimodels-fade-in" style={{ animationDelay: "0.3s" }}>
         <h2 className="text-lg font-bold text-[var(--text-primary)] mb-1">
-          {phase === 0 ? t("connected") : t("ai.settingUp", { provider: providerName })}
+          {completed ? t("connected") : t("ai.settingUp", { provider: providerName })}
         </h2>
         <p className="text-sm text-[var(--text-muted)]">
-          {phase === 0
-            ? t("ai.credentialsVerifiedDesc")
-            : `${t("ai.configuringAssistant")}${dots}`}
+          {completed
+            ? detail || t("ai.configured")
+            : detail || `${t("ai.configuringAssistant")}${dots}`}
         </p>
       </div>
 
       {/* Progress steps */}
       <div className="w-full max-w-[280px] space-y-2.5 mt-2">
-        {CONFIGURING_STEPS.map((step, i) => (
+        {steps.map((step, i) => (
           <div
             key={i}
             className={`flex items-center gap-2.5 text-xs transition-all duration-300 ${
-              i <= phase ? "opacity-100" : "opacity-0 translate-y-1"
+              completed || i <= phase ? "opacity-100" : "opacity-0 translate-y-1"
             }`}
-            style={i <= phase ? { animation: "aimodels-fade-in 0.3s ease-out both", animationDelay: `${i * 0.1}s` } : undefined}
+            style={completed || i <= phase ? { animation: "aimodels-fade-in 0.3s ease-out both", animationDelay: `${i * 0.1}s` } : undefined}
           >
-            {i < phase ? (
+            {completed || i < phase ? (
               <span className="flex items-center justify-center w-5 h-5 rounded-full bg-emerald-500/20 text-emerald-400 shrink-0">
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12l5 5L19 7" /></svg>
               </span>
@@ -157,15 +180,30 @@ function ConfiguringOverlay({ provider, onDone, t }: { provider: string; onDone:
                 <span className="w-1.5 h-1.5 rounded-full bg-gray-600" />
               </span>
             )}
-            <span className={i <= phase ? (i < phase ? "text-emerald-400" : "text-[var(--text-primary)]") : "text-[var(--text-muted)]"}>
-              {step.label}
+            <span className={completed || i <= phase ? (completed || i < phase ? "text-emerald-400" : "text-[var(--text-primary)]") : "text-[var(--text-muted)]"}>
+              {step}
             </span>
           </div>
         ))}
       </div>
 
+      {progressPercent !== null && !completed && (
+        <div className="w-full max-w-[280px] mt-1">
+          <div className="flex items-center justify-between text-[11px] text-[var(--text-muted)] mb-1.5">
+            <span>{providerName}</span>
+            <span>{progressPercent}%</span>
+          </div>
+          <div className="w-full h-2 bg-[var(--bg-deep)] rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gradient-to-r from-orange-500 to-amber-400 rounded-full transition-all duration-300"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+        </div>
+      )}
+
       {/* Reassuring footer */}
-      {phase >= 1 && (
+      {!completed && phase >= 1 && (
         <p className="text-xs text-[var(--text-muted)] text-center mt-2 aimodels-step-enter">
           {t("ai.pleaseDontClose")}
         </p>
@@ -177,6 +215,32 @@ function ConfiguringOverlay({ provider, onDone, t }: { provider: string; onDone:
 const PRIMARY_PROVIDER_IDS = new Set(["anthropic", "openai", "google", "clawai"]);
 
 const PROVIDERS: Provider[] = [
+  {
+    id: "llamacpp",
+    name: "Gemma 4",
+    description: "Fast local AI for this device",
+    authOptions: [
+      {
+        mode: "local" as AuthMode,
+        label: "Local",
+        placeholder: "",
+        hint: "No API key needed. ClawBox manages the local Gemma 4 model for you.",
+      },
+    ],
+  },
+  {
+    id: "ollama",
+    name: "Ollama",
+    description: "Use Ollama models locally",
+    authOptions: [
+      {
+        mode: "local" as AuthMode,
+        label: "Local",
+        placeholder: "",
+        hint: "No API key needed. Models run on this device.",
+      },
+    ],
+  },
   {
     id: "clawai",
     name: "ClawBox AI",
@@ -256,41 +320,87 @@ const PROVIDERS: Provider[] = [
       },
     ],
   },
-  {
-    id: "ollama",
-    name: "Ollama Local",
-    description: "Run AI models locally on device",
-    authOptions: [
-      {
-        mode: "local" as AuthMode,
-        label: "Local",
-        placeholder: "",
-        hint: "No API key needed. Models run on this device.",
-      },
-    ],
-  },
-  {
-    id: "llamacpp",
-    name: "llama.cpp Local",
-    description: "Recommended for Gemma 4 E2B Q4/INT4 on 8GB devices",
-    authOptions: [
-      {
-        mode: "local" as AuthMode,
-        label: "Local",
-        placeholder: "",
-        hint: "No API key needed. Connect to a local llama-server endpoint serving a GGUF quant.",
-      },
-    ],
-  },
 ];
 
 // Providers that use device code flow instead of redirect-based OAuth
 const DEVICE_AUTH_PROVIDERS = new Set(["openai"]);
 
 
-export default function AIModelsStep({ onNext, embedded = false, onConfigured }: AIModelsStepProps) {
+export default function AIModelsStep({
+  onNext,
+  embedded = false,
+  onConfigured,
+  providerIds,
+  defaultProviderId,
+  currentProviderId = null,
+  currentModel = null,
+  title,
+  description,
+  configureScope = "primary",
+  testId = "setup-step-ai-models",
+}: AIModelsStepProps) {
   const { t } = useT();
-  const [selectedProvider, setSelectedProvider] = useState<string | null>("clawai");
+  const normalizedCurrentProvider = useMemo(
+    () => normalizeSelectableProvider(currentProviderId),
+    [currentProviderId],
+  );
+  const providerIdSet = useMemo(() => providerIds ? new Set(providerIds) : null, [providerIds]);
+  const allowedProviders = useMemo(
+    () => providerIdSet ? PROVIDERS.filter((provider) => providerIdSet.has(provider.id)) : PROVIDERS,
+    [providerIdSet],
+  );
+  const resolvedDefaultProvider = useMemo(
+    () => {
+      if (defaultProviderId && allowedProviders.some((provider) => provider.id === defaultProviderId)) {
+        return defaultProviderId;
+      }
+      return allowedProviders[0]?.id ?? "clawai";
+    },
+    [allowedProviders, defaultProviderId],
+  );
+  const genericSteps = useMemo(
+    () => [
+      t("ai.credentialsVerified"),
+      t("ai.updatingConfig"),
+      t("ai.restartingGateway"),
+      t("ai.warmingUp"),
+      t("ai.almostReady"),
+    ],
+    [t],
+  );
+  const ollamaInstallSteps = useMemo(
+    () => [
+      "Preparing Ollama",
+      "Downloading model files",
+      "Applying ClawBox configuration",
+      "Warming up local model",
+    ],
+    [],
+  );
+  const llamaCppInstallSteps = useMemo(
+    () => [
+      "Preparing llama.cpp runtime",
+      "Downloading Gemma model",
+      "Starting llama.cpp runtime",
+      "Applying ClawBox configuration",
+      "Warming up local model",
+    ],
+    [],
+  );
+  const getStepsForKind = useCallback(
+    (kind: ConfiguringKind) => {
+      switch (kind) {
+        case "ollama":
+          return ollamaInstallSteps;
+        case "llamacpp":
+          return llamaCppInstallSteps;
+        default:
+          return genericSteps;
+      }
+    },
+    [genericSteps, llamaCppInstallSteps, ollamaInstallSteps],
+  );
+  const [selectedProvider, setSelectedProvider] = useState<string | null>(resolvedDefaultProvider);
   const [authMode, setAuthMode] = useState<AuthMode>("local");
   const [showMoreProviders, setShowMoreProviders] = useState(false);
   const [availableOAuth, setAvailableOAuth] = useState<string[] | null>(null);
@@ -304,7 +414,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
 
   const [selectedOllamaModel, setSelectedOllamaModel] = useState("llama3.2:3b");
   const [selectedLlamaCppModel, setSelectedLlamaCppModel] = useState("");
-  const [configuring, setConfiguring] = useState(false);
+  const [configuringState, setConfiguringState] = useState<ConfiguringState | null>(null);
 
   // OAuth redirect flow state (Anthropic)
   const [oauthStarted, setOauthStarted] = useState(false);
@@ -317,7 +427,6 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
   const [devicePolling, setDevicePolling] = useState(false);
   const [deviceSaving, setDeviceSaving] = useState(false);
 
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveControllerRef = useRef<AbortController | null>(null);
   const exchangeControllerRef = useRef<AbortController | null>(null);
@@ -325,16 +434,26 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
   const pollControllerRef = useRef<AbortController | null>(null);
   const oauthWindowRef = useRef<Window | null>(null);
 
-  const clearPendingTimers = useCallback(() => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current);
-      timeoutRef.current = null;
+  useEffect(() => {
+    if (!allowedProviders.some((provider) => provider.id === selectedProvider)) {
+      setSelectedProvider(resolvedDefaultProvider);
     }
-    if (pollRef.current) {
-      clearTimeout(pollRef.current);
-      pollRef.current = null;
+  }, [allowedProviders, resolvedDefaultProvider, selectedProvider]);
+
+  useEffect(() => {
+    if (!normalizedCurrentProvider) return;
+    if (!allowedProviders.some((provider) => provider.id === normalizedCurrentProvider)) return;
+
+    setSelectedProvider(normalizedCurrentProvider);
+
+    if (typeof currentModel === "string") {
+      if (currentModel.startsWith("ollama/")) {
+        setSelectedOllamaModel(currentModel.replace(/^ollama\//, ""));
+      } else if (currentModel.startsWith("llamacpp/")) {
+        setSelectedLlamaCppModel(currentModel.replace(/^llamacpp\//, ""));
+      }
     }
-  }, []);
+  }, [allowedProviders, currentModel, normalizedCurrentProvider]);
 
   const stopPolling = useCallback(() => {
     setDevicePolling(false);
@@ -354,36 +473,60 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
         setAvailableOAuth([]);
       });
     return () => {
-      clearPendingTimers();
       saveControllerRef.current?.abort();
       exchangeControllerRef.current?.abort();
       oauthStartControllerRef.current?.abort();
       pollControllerRef.current?.abort();
     };
-  }, [clearPendingTimers]);
+  }, []);
 
-  const showError = (message: string) => {
-    setConfiguring(false);
+  const showError = useCallback((message: string) => {
+    setConfiguringState(null);
     setStatus({ type: "error", message });
-  };
+  }, []);
 
-  const showConfiguring = () => {
+  const showConfiguring = useCallback((kind: ConfiguringKind = "generic") => {
     tryCloseOAuthWindow(oauthWindowRef);
     setSaving(false);
     setExchanging(false);
     setDeviceSaving(false);
-    setConfiguring(true);
-  };
+    setConfiguringState({
+      provider: selectedProvider ?? "anthropic",
+      kind,
+      phase: 0,
+      detail: null,
+      progressPercent: null,
+      completed: false,
+    });
+  }, [selectedProvider]);
 
-  const showSuccessAndContinue = () => {
+  const completeConfiguring = useCallback((providerOverride?: string) => {
+    const fallbackProvider = providerOverride ?? selectedProvider ?? "anthropic";
+    setConfiguringState((current) => {
+      const nextProvider = current?.provider ?? fallbackProvider;
+      const nextKind = current?.kind
+        ?? (nextProvider === "ollama" ? "ollama" : nextProvider === "llamacpp" ? "llamacpp" : "generic");
+      const steps = getStepsForKind(nextKind);
+      return {
+        provider: nextProvider,
+        kind: nextKind,
+        phase: Math.max(0, steps.length - 1),
+        detail: current?.detail ?? null,
+        progressPercent: current?.progressPercent ?? null,
+        completed: true,
+      };
+    });
+  }, [getStepsForKind, selectedProvider]);
+
+  const showSuccessAndContinue = useCallback(() => {
     tryCloseOAuthWindow(oauthWindowRef);
-    // Overlay is already showing — it will call handleConfiguringDone when done
-  };
+    completeConfiguring();
+  }, [completeConfiguring]);
 
-  const extractError = async (res: Response, fallback: string) => {
+  const extractError = useCallback(async (res: Response, fallback: string) => {
     const data = await res.json().catch(() => ({}));
     return typeof data.error === "string" ? data.error : fallback;
-  };
+  }, []);
 
   // Ollama hook
   const ollamaCallbacks = useMemo<OllamaCallbacks>(() => ({
@@ -391,7 +534,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
     onSaveError: (message: string) => showError(message),
     onPullError: (message: string) => showError(message),
     onClearStatus: () => setStatus(null),
-  }), []);
+  }), [showError, showSuccessAndContinue]);
 
   const {
     ollamaRunning,
@@ -409,27 +552,92 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
     deleteOllamaModel,
     formatOllamaBytes,
     clearSearch,
-  } = useOllamaModels(ollamaCallbacks);
+  } = useOllamaModels(ollamaCallbacks, configureScope);
 
   const llamaCppCallbacks = useMemo<LlamaCppCallbacks>(() => ({
     onSaveSuccess: () => showSuccessAndContinue(),
     onSaveError: (message: string) => showError(message),
     onClearStatus: () => setStatus(null),
-  }), []);
+  }), [showError, showSuccessAndContinue]);
 
   const {
     llamaCppRunning,
-    llamaCppModels,
-    llamaCppEndpoint,
     llamaCppSaving,
     llamaCppProgress,
     checkLlamaCppStatus,
     saveLlamaCppConfig,
-  } = useLlamaCppModels(llamaCppCallbacks);
+  } = useLlamaCppModels(llamaCppCallbacks, configureScope);
+
+  const configuringKind = configuringState?.kind;
+  const configuringCompleted = configuringState?.completed ?? false;
+
+  useEffect(() => {
+    if (configuringKind !== "generic" || configuringCompleted) return;
+
+    const timers = CONFIGURING_STEP_DELAYS.map((delay, index) =>
+      index === 0
+        ? null
+        : setTimeout(() => {
+            setConfiguringState((current) => {
+              if (!current || current.kind !== "generic" || current.completed) return current;
+              return { ...current, phase: Math.max(current.phase, index) };
+            });
+          }, delay),
+    );
+
+    return () => {
+      timers.forEach((timer) => {
+        if (timer) clearTimeout(timer);
+      });
+    };
+  }, [configuringCompleted, configuringKind]);
+
+  useEffect(() => {
+    if (selectedProvider !== "ollama") return;
+    if (!ollamaPulling && !ollamaSaving) return;
+
+    const next = getOllamaOverlayProgress(
+      {
+        pulling: ollamaPulling,
+        saving: !!ollamaSaving,
+        pullProgress: ollamaPullProgress,
+      },
+      ollamaInstallSteps.length,
+    );
+
+    setConfiguringState({
+      provider: "ollama",
+      kind: "ollama",
+      phase: next.phase,
+      detail: next.detail,
+      progressPercent: next.progressPercent,
+      completed: false,
+    });
+  }, [
+    ollamaInstallSteps.length,
+    ollamaPullProgress,
+    ollamaPulling,
+    ollamaSaving,
+    selectedProvider,
+  ]);
+
+  useEffect(() => {
+    if (selectedProvider !== "llamacpp" || !llamaCppSaving) return;
+
+    const next = getLlamaCppOverlayProgress(llamaCppProgress, llamaCppInstallSteps.length);
+    setConfiguringState({
+      provider: "llamacpp",
+      kind: "llamacpp",
+      phase: next.phase,
+      detail: next.detail,
+      progressPercent: next.progressPercent,
+      completed: false,
+    });
+  }, [llamaCppInstallSteps.length, llamaCppProgress, llamaCppSaving, selectedProvider]);
 
   const selectProvider = (id: string) => {
     stopPolling();
-    const provider = PROVIDERS.find((p) => p.id === id);
+    const provider = allowedProviders.find((p) => p.id === id);
     setSelectedProvider(id);
     // Pick the first auth mode that's actually available
     const options = provider?.authOptions.filter((opt) => {
@@ -447,6 +655,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
     setDeviceCode(null);
     setDeviceUrl(null);
     setDeviceSaving(false);
+    setConfiguringState(null);
     if (id === "ollama") checkOllamaStatus();
     if (id === "llamacpp") checkLlamaCppStatus();
   };
@@ -462,7 +671,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
       const res = await fetch("/setup-api/ai-models/configure", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ scope: configureScope, ...payload }),
         signal: controller.signal,
       });
       if (controller.signal.aborted) return;
@@ -510,6 +719,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          scope: configureScope,
           provider: selectedProvider,
           apiKey: tokenData.access_token,
           authMode: "subscription",
@@ -532,7 +742,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
       if (err instanceof DOMException && err.name === "AbortError") return;
       showError(`Failed: ${err instanceof Error ? err.message : err}`);
     }
-  }, [selectedProvider]);
+  }, [configureScope, extractError, selectedProvider, showConfiguring, showError, showSuccessAndContinue]);
 
   // --- Device auth flow (OpenAI, Google) ---
 
@@ -595,7 +805,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
       // Network error — retry
       pollRef.current = setTimeout(() => pollDeviceAuth(interval), interval * 1000);
     }
-  }, [stopPolling, saveOAuthToken]);
+  }, [extractError, showError, stopPolling, saveOAuthToken]);
 
   const startDeviceAuth = async () => {
     stopPolling();
@@ -711,7 +921,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
     llamacpp: "GGUF + llama.cpp for 8GB devices",
   };
 
-  const selected = PROVIDERS.find((p) => p.id === selectedProvider);
+  const selected = allowedProviders.find((p) => p.id === selectedProvider);
   // Filter out subscription option for providers whose OAuth isn't configured on the backend
   const effectiveAuthOptions = selected?.authOptions.filter((opt) => {
     if (opt.mode === "subscription" && availableOAuth !== null) {
@@ -904,31 +1114,55 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
 
   const handleConfiguringDone = useCallback(() => {
     if (embedded) {
-      setConfiguring(false);
+      setConfiguringState(null);
       setStatus({ type: "success", message: t("ai.configured") });
       onConfigured?.();
     } else if (onNext) {
       onNext();
+    } else {
+      setConfiguringState(null);
+      setStatus({ type: "success", message: t("ai.configured") });
     }
   }, [embedded, onNext, onConfigured, t]);
 
+  useEffect(() => {
+    if (!configuringState?.completed) return;
+    const timer = setTimeout(handleConfiguringDone, 900);
+    return () => clearTimeout(timer);
+  }, [configuringState?.completed, handleConfiguringDone]);
+
+  const displayedProviders = providerIdSet
+    ? allowedProviders
+    : PROVIDERS.filter((provider) => PRIMARY_PROVIDER_IDS.has(provider.id) || showMoreProviders || selectedProvider === provider.id);
+  const shouldShowMoreProviders = !providerIdSet && !showMoreProviders && PROVIDERS.some((provider) => !PRIMARY_PROVIDER_IDS.has(provider.id));
+  const resolvedTitle = title ?? t("ai.title");
+  const resolvedDescription = description ?? t("ai.description");
+
   return (
-    <div className="w-full max-w-[520px]" data-testid="setup-step-ai-models">
+    <div className="w-full max-w-[520px]" data-testid={testId}>
       <div className="card-surface rounded-2xl p-8 relative overflow-hidden">
-        {configuring && (
-          <ConfiguringOverlay provider={selectedProvider ?? "anthropic"} onDone={handleConfiguringDone} t={t} />
+        {configuringState && (
+          <ConfiguringOverlay
+            provider={configuringState.provider}
+            steps={getStepsForKind(configuringState.kind)}
+            phase={configuringState.phase}
+            detail={configuringState.detail}
+            progressPercent={configuringState.progressPercent}
+            completed={configuringState.completed}
+            t={t}
+          />
         )}
         {/* Hide form content when configuring overlay is shown */}
-        <div className={configuring ? "invisible h-0 overflow-hidden" : ""}>
+        <div className={configuringState ? "invisible h-0 overflow-hidden" : ""}>
         <h1 className="text-2xl font-bold font-display mb-2">
-          {t("ai.title")}
+          {resolvedTitle}
         </h1>
         <p className="text-[var(--text-secondary)] mb-5 leading-relaxed">
-          {t("ai.description")}
+          {resolvedDescription}
         </p>
 
         <div role="radiogroup" aria-label="AI Provider" className="border border-[var(--border-subtle)] rounded-lg bg-[var(--bg-deep)]/50 overflow-hidden">
-          {PROVIDERS.filter((p) => PRIMARY_PROVIDER_IDS.has(p.id) || showMoreProviders || selectedProvider === p.id).map((provider) => {
+          {displayedProviders.map((provider) => {
             const isSelected = selectedProvider === provider.id;
             return (
               <label
@@ -962,9 +1196,6 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
                 <div className="flex-1">
                   <span className="flex items-center gap-2 text-sm font-medium text-gray-200">
                     {provider.name}
-                    {provider.id === "openai" && (
-                      <span className="px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide rounded bg-orange-500/15 text-orange-400 leading-none">{t("recommended")}</span>
-                    )}
                   </span>
                   <span className="block text-xs text-[var(--text-muted)]">
                     {providerDesc[provider.id] ?? provider.description}
@@ -973,7 +1204,7 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
               </label>
             );
           })}
-          {!showMoreProviders && (
+          {shouldShowMoreProviders && (
             <button
               type="button"
               onClick={() => setShowMoreProviders(true)}
@@ -1021,8 +1252,6 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
           <div className="mt-5 space-y-4">
             <LlamaCppModelPanel
               llamaCppRunning={llamaCppRunning}
-              llamaCppModels={llamaCppModels}
-              llamaCppEndpoint={llamaCppEndpoint}
               llamaCppSaving={llamaCppSaving}
               llamaCppProgress={llamaCppProgress}
               selectedLlamaCppModel={selectedLlamaCppModel}
@@ -1059,9 +1288,6 @@ export default function AIModelsStep({ onNext, embedded = false, onConfigured }:
                     }`}
                   >
                     {opt.mode === "token" ? t("ai.apiKey") : opt.mode === "subscription" ? t("ai.subscription") : opt.mode === "local" && selected?.id === "clawai" ? t("ai.free") : opt.mode === "local" ? t("ai.local") : opt.label}
-                    {opt.mode === "subscription" && selectedProvider === "openai" && (
-                      <span className="ml-1 px-1 py-px text-[9px] font-semibold uppercase tracking-wide rounded bg-orange-500/15 text-orange-400 leading-none">{t("recommended")}</span>
-                    )}
                   </button>
                 ))}
               </div>

--- a/src/components/AIProviderIcon.tsx
+++ b/src/components/AIProviderIcon.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import Image from "next/image";
+import { useId, type ReactNode } from "react";
+
+interface AIProviderIconProps {
+  provider: string | null | undefined;
+  size?: number;
+  className?: string;
+}
+
+function normalizeProvider(provider: string | null | undefined): string {
+  if (provider === "deepseek") return "clawai";
+  return provider?.trim().toLowerCase() || "";
+}
+
+function SvgFrame({
+  size,
+  className = "",
+  children,
+  viewBox = "0 0 24 24",
+}: {
+  size: number;
+  className?: string;
+  children: ReactNode;
+  viewBox?: string;
+}) {
+  return (
+    <svg
+      viewBox={viewBox}
+      width={size}
+      height={size}
+      className={className}
+      aria-hidden="true"
+      focusable="false"
+    >
+      {children}
+    </svg>
+  );
+}
+
+export default function AIProviderIcon({
+  provider,
+  size = 24,
+  className = "",
+}: AIProviderIconProps) {
+  const normalized = normalizeProvider(provider);
+  const geminiGradientId = useId().replace(/:/g, "");
+
+  if (normalized === "clawai") {
+    return (
+      <span
+        className={`relative inline-flex items-center justify-center overflow-hidden ${className}`}
+        style={{ width: size, height: size }}
+        aria-hidden="true"
+      >
+        <Image
+          src="/clawbox-crab.png"
+          alt=""
+          width={size}
+          height={size}
+          className="w-full h-full object-contain"
+        />
+      </span>
+    );
+  }
+
+  if (normalized === "openai") {
+    return (
+      <SvgFrame size={size} className={className}>
+        <g transform="translate(12 12)">
+          {[0, 60, 120, 180, 240, 300].map((rotation) => (
+            <g key={rotation} transform={`rotate(${rotation})`}>
+              <rect
+                x="-2.25"
+                y="-8.35"
+                width="4.5"
+                height="8.8"
+                rx="2.25"
+                fill="#F3F4F6"
+                opacity="0.98"
+              />
+            </g>
+          ))}
+          <circle cx="0" cy="0" r="2.6" fill="#111827" />
+        </g>
+      </SvgFrame>
+    );
+  }
+
+  if (normalized === "anthropic") {
+    return (
+      <SvgFrame size={size} className={className}>
+        <path
+          d="M12 3 19.5 21h-3.2l-1.55-3.86H9.2L7.65 21H4.5L12 3Zm0 5.06-1.7 4.35h3.42L12 8.06Z"
+          fill="#F4E7C8"
+        />
+      </SvgFrame>
+    );
+  }
+
+  if (normalized === "google") {
+    return (
+      <SvgFrame size={size} className={className}>
+        <defs>
+          <linearGradient id={geminiGradientId} x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="#7DD3FC" />
+            <stop offset="55%" stopColor="#A78BFA" />
+            <stop offset="100%" stopColor="#F9A8D4" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M12 2.5 14.65 9.35 21.5 12l-6.85 2.65L12 21.5l-2.65-6.85L2.5 12l6.85-2.65L12 2.5Z"
+          fill={`url(#${geminiGradientId})`}
+        />
+        <circle cx="12" cy="12" r="2.1" fill="#E0F2FE" fillOpacity="0.95" />
+      </SvgFrame>
+    );
+  }
+
+  if (normalized === "openrouter") {
+    return (
+      <SvgFrame size={size} className={className}>
+        <path
+          d="M8.1 5.2h7.7l-1.7-1.7 1.35-1.35 4 4-4 4-1.35-1.35 1.7-1.7H8.1a2.9 2.9 0 0 0-2.9 2.9v.45H3.3V10a4.8 4.8 0 0 1 4.8-4.8Zm7.8 8.95H8.2l1.7 1.7-1.35 1.35-4-4 4-4 1.35 1.35-1.7 1.7h7.7a2.9 2.9 0 0 0 2.9-2.9V9.9h1.9v.45a4.8 4.8 0 0 1-4.8 4.8Z"
+          fill="#60A5FA"
+        />
+      </SvgFrame>
+    );
+  }
+
+  if (normalized === "ollama") {
+    return (
+      <SvgFrame size={size} className={className}>
+        <path
+          d="M8.25 4.6h4.4a3.2 3.2 0 0 1 3.2 3.2v2.05c.92.38 1.55 1.3 1.55 2.37v4.08c0 1.14-.92 2.07-2.07 2.07H8.67A2.07 2.07 0 0 1 6.6 16.3v-4.08c0-1.1.67-2.04 1.65-2.4V7.8a3.2 3.2 0 0 1 0-3.2Z"
+          fill="#F9FAFB"
+        />
+        <circle cx="10.05" cy="12.55" r="0.95" fill="#0F172A" />
+        <circle cx="14.1" cy="12.55" r="0.95" fill="#0F172A" />
+        <path d="M10.2 15.45c1 .75 2.45.75 3.45 0" stroke="#0F172A" strokeWidth="1.2" strokeLinecap="round" />
+      </SvgFrame>
+    );
+  }
+
+  if (normalized === "llamacpp") {
+    return (
+      <SvgFrame size={size} className={className}>
+        <rect x="3.5" y="4" width="17" height="16" rx="3" fill="#1E293B" stroke="#F97316" strokeWidth="1.3" />
+        <path d="m8 10 2.6 2L8 14" stroke="#FDBA74" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M12.9 14.6h3.1" stroke="#FDBA74" strokeWidth="1.6" strokeLinecap="round" />
+      </SvgFrame>
+    );
+  }
+
+  return (
+    <SvgFrame size={size} className={className}>
+      <circle cx="12" cy="12" r="9" fill="#334155" />
+      <path
+        d="M8.5 13.5a3.5 3.5 0 1 1 7 0v2.2a1.3 1.3 0 0 1-1.3 1.3H9.8a1.3 1.3 0 0 1-1.3-1.3v-2.2Z"
+        fill="#E2E8F0"
+      />
+    </SvgFrame>
+  );
+}

--- a/src/components/DoneStep.tsx
+++ b/src/components/DoneStep.tsx
@@ -697,8 +697,6 @@ export default function DoneStep({ setupComplete = false, onComplete }: DoneStep
 
   const {
     llamaCppRunning,
-    llamaCppModels,
-    llamaCppEndpoint,
     llamaCppSaving,
     llamaCppProgress,
     checkLlamaCppStatus,
@@ -1101,14 +1099,11 @@ export default function DoneStep({ setupComplete = false, onComplete }: DoneStep
             <div className="space-y-3">
               <LlamaCppModelPanel
                 llamaCppRunning={llamaCppRunning}
-                llamaCppModels={llamaCppModels}
-                llamaCppEndpoint={llamaCppEndpoint}
                 llamaCppSaving={llamaCppSaving}
                 llamaCppProgress={llamaCppProgress}
                 selectedLlamaCppModel={selectedLlamaCppModel}
                 setSelectedLlamaCppModel={setSelectedLlamaCppModel}
                 saveLlamaCppConfig={saveLlamaCppConfig}
-                inputClassName={INPUT_CLASS}
                 buttonClassName={`mt-2 ${SAVE_BUTTON_CLASS} flex items-center gap-2`}
                 buttonSpinner={ButtonSpinner}
               />

--- a/src/components/LlamaCppModelPanel.tsx
+++ b/src/components/LlamaCppModelPanel.tsx
@@ -1,26 +1,19 @@
 "use client";
 
 import { useEffect } from "react";
-import type { KeyboardEvent, ReactNode } from "react";
-import { LLAMACPP_RECOMMENDED_MODELS, getDefaultLlamaCppModel } from "@/lib/llamacpp";
-import type { LlamaCppModel } from "@/hooks/useLlamaCppModels";
+import type { ReactNode } from "react";
+import { getDefaultLlamaCppModel } from "@/lib/llamacpp";
 
 interface LlamaCppModelPanelProps {
   llamaCppRunning: boolean;
-  llamaCppModels: LlamaCppModel[];
-  llamaCppEndpoint: string;
   llamaCppSaving: string | false;
   llamaCppProgress?: string | null;
   selectedLlamaCppModel: string;
   setSelectedLlamaCppModel: (model: string) => void;
   saveLlamaCppConfig: (model: string) => void;
-  inputClassName?: string;
   buttonClassName?: string;
   buttonSpinner?: ReactNode;
 }
-
-const DEFAULT_INPUT_CLASS =
-  "w-full px-3.5 py-2 bg-[var(--bg-deep)] border border-gray-600 rounded-lg text-sm text-gray-200 outline-none focus:border-[var(--coral-bright)] transition-colors placeholder-gray-500";
 const DEFAULT_BUTTON_CLASS =
   "mt-3 px-5 py-3 btn-gradient text-white rounded-lg font-semibold text-sm transition transform hover:scale-105 shadow-lg shadow-[rgba(249,115,22,0.25)] cursor-pointer disabled:opacity-50 disabled:hover:scale-100 flex items-center gap-2";
 const DEFAULT_SPINNER = (
@@ -29,146 +22,48 @@ const DEFAULT_SPINNER = (
 
 export default function LlamaCppModelPanel({
   llamaCppRunning,
-  llamaCppModels,
-  llamaCppEndpoint,
   llamaCppSaving,
   llamaCppProgress,
   selectedLlamaCppModel,
   setSelectedLlamaCppModel,
   saveLlamaCppConfig,
-  inputClassName = DEFAULT_INPUT_CLASS,
   buttonClassName = DEFAULT_BUTTON_CLASS,
   buttonSpinner = DEFAULT_SPINNER,
 }: LlamaCppModelPanelProps) {
   useEffect(() => {
     if (selectedLlamaCppModel) return;
-    if (llamaCppModels.length > 0) {
-      setSelectedLlamaCppModel(llamaCppModels[0].id);
-    } else {
-      setSelectedLlamaCppModel(getDefaultLlamaCppModel());
-    }
-  }, [llamaCppModels, selectedLlamaCppModel, setSelectedLlamaCppModel]);
-
-  const handleRecommendedModelKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
-    if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(event.key)) return;
-    event.preventDefault();
-
-    const delta = event.key === "ArrowUp" || event.key === "ArrowLeft" ? -1 : 1;
-    const nextIndex = (index + delta + LLAMACPP_RECOMMENDED_MODELS.length) % LLAMACPP_RECOMMENDED_MODELS.length;
-    const nextModel = LLAMACPP_RECOMMENDED_MODELS[nextIndex];
-    if (!nextModel) return;
-
-    setSelectedLlamaCppModel(nextModel.id);
-    const radios = event.currentTarget.parentElement?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
-    radios?.[nextIndex]?.focus();
-  };
+    setSelectedLlamaCppModel(getDefaultLlamaCppModel());
+  }, [selectedLlamaCppModel, setSelectedLlamaCppModel]);
 
   return (
     <div className="space-y-3">
-      <p className={`text-xs ${llamaCppRunning ? "text-[var(--text-secondary)]" : "text-yellow-400"}`}>
-        {llamaCppRunning
-          ? `Connected to llama.cpp at ${llamaCppEndpoint || "the configured endpoint"}.`
-          : `llama.cpp is not responding at ${llamaCppEndpoint || "the configured endpoint"}. ClawBox can download the recommended Gemma model and start llama-server for you, or you can point this at an existing endpoint.`}
-      </p>
-
       <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--bg-deep)]/70 p-3">
-        <p className="text-xs font-semibold text-[var(--text-secondary)] mb-2">
-          Recommended for 8GB devices
-        </p>
-        <div role="radiogroup" aria-label="Recommended llama.cpp models" className="space-y-2">
-          {LLAMACPP_RECOMMENDED_MODELS.map((model) => (
-            <button
-              key={model.id}
-              type="button"
-              onClick={() => setSelectedLlamaCppModel(model.id)}
-              onKeyDown={(event) => handleRecommendedModelKeyDown(event, LLAMACPP_RECOMMENDED_MODELS.findIndex((m) => m.id === model.id))}
-              role="radio"
-              aria-checked={selectedLlamaCppModel === model.id}
-              aria-label={model.label}
-              tabIndex={selectedLlamaCppModel === model.id ? 0 : -1}
-              className={`w-full rounded-lg border px-3 py-2 text-left transition-colors cursor-pointer ${
-                selectedLlamaCppModel === model.id
-                  ? "border-[var(--coral-bright)] bg-orange-500/10"
-                  : "border-[var(--border-subtle)] hover:bg-[var(--bg-surface)]/40"
-              }`}
-            >
-              <span className="block text-sm font-semibold text-gray-100">{model.label}</span>
-              <span className="block text-xs text-[var(--text-secondary)] mt-1">{model.description}</span>
-              <span className="block text-xs text-[var(--text-muted)] mt-1">{model.memoryNote}</span>
-              <span className="block text-[11px] text-[var(--text-muted)] mt-1.5 font-mono">
-                Suggested model id: {model.id}
-              </span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {llamaCppModels.length > 0 && (
-        <div>
-          <p className="text-xs text-[var(--text-secondary)] mb-2">Detected models</p>
-          <div className="space-y-1.5">
-            {llamaCppModels.map((model) => (
-              <div
-                key={model.id}
-                className="flex items-center justify-between py-2 px-3 bg-[var(--bg-deep)] rounded-lg"
-              >
-                <div className="min-w-0 mr-3">
-                  <span className="text-sm text-gray-200 block truncate">{model.id}</span>
-                  {model.owned_by && (
-                    <span className="text-xs text-[var(--text-muted)] block truncate">
-                      {model.owned_by}
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => saveLlamaCppConfig(model.id)}
-                  disabled={!!llamaCppSaving}
-                  aria-label={`Use ${model.id}`}
-                  className="px-3 py-1 text-xs font-semibold text-white btn-gradient rounded cursor-pointer disabled:opacity-50 flex items-center gap-1.5"
-                >
-                  {llamaCppSaving === model.id && (
-                    <span aria-hidden="true" className="inline-block w-3 h-3 border-2 border-white border-t-transparent rounded-full animate-spin" />
-                  )}
-                  {llamaCppSaving === model.id && <span className="sr-only">{`Saving ${model.id}`}</span>}
-                  {llamaCppSaving === model.id ? "Saving..." : "Use"}
-                </button>
-              </div>
-            ))}
+        <div className="flex items-center gap-3">
+          <div className="w-11 h-11 rounded-xl bg-orange-500/10 border border-orange-500/20 flex items-center justify-center shrink-0">
+            <span className="material-symbols-rounded text-orange-300" style={{ fontSize: 24 }}>terminal</span>
+          </div>
+          <div>
+            <div className="text-base font-semibold text-gray-100">Gemma 4</div>
+            <p className="text-sm text-[var(--text-secondary)]">
+              Private on-device AI for ClawBox.
+            </p>
           </div>
         </div>
-      )}
-
-      <div>
-        <label
-          htmlFor="llamacpp-model-id"
-          className="block text-xs font-semibold text-[var(--text-secondary)] mb-1.5"
-        >
-          Model ID
-        </label>
-        <input
-          id="llamacpp-model-id"
-          type="text"
-          value={selectedLlamaCppModel}
-          onChange={(e) => setSelectedLlamaCppModel(e.target.value)}
-          placeholder={getDefaultLlamaCppModel()}
-          spellCheck={false}
-          autoComplete="off"
-          className={inputClassName}
-        />
-        <p className="mt-1.5 text-xs text-[var(--text-muted)]">
-          Match the model id exposed by <code>llama-server</code> at <code>/v1/models</code>. If you launch your own Gemma 4 E2B Q4/INT4 quant, reusing the suggested alias above makes setup easier.
+        <p className="mt-3 text-sm text-[var(--text-secondary)] leading-relaxed">
+          {llamaCppRunning
+            ? "Gemma 4 is enabled and ready to use."
+            : "Enable Gemma 4 to give ClawBox a local model that keeps working even when cloud providers are unavailable."}
         </p>
       </div>
 
       <button
         type="button"
         onClick={() => saveLlamaCppConfig(selectedLlamaCppModel)}
-        disabled={!!llamaCppSaving || !selectedLlamaCppModel.trim()}
+        disabled={!!llamaCppSaving}
         className={buttonClassName}
       >
         {llamaCppSaving && buttonSpinner}
-        {llamaCppSaving ? "Installing..." : llamaCppRunning ? "Use llama.cpp" : "Install & Use llama.cpp"}
+        {llamaCppSaving ? "Enabling Gemma 4..." : llamaCppRunning ? "Enable Gemma 4" : "Enable Gemma 4"}
       </button>
 
       {llamaCppSaving && llamaCppProgress && (

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -18,7 +18,14 @@ function badgeColor(isDone: boolean, isActive: boolean): string {
 
 export default function ProgressBar({ currentStep }: ProgressBarProps) {
   const { t } = useT();
-  const STEP_LABELS = [t("progress.wifi"), t("progress.update"), t("progress.security"), t("progress.aiModel"), t("progress.telegram")];
+  const STEP_LABELS = [
+    t("progress.wifi"),
+    t("progress.update"),
+    t("progress.security"),
+    "Local AI",
+    t("settings.aiProvider"),
+    t("progress.telegram"),
+  ];
 
   return (
     <div
@@ -32,7 +39,6 @@ export default function ProgressBar({ currentStep }: ProgressBarProps) {
       {STEP_LABELS.map((label, i) => {
         const num = i + 1;
         const isCurrent = num === currentStep;
-        const isActive = num <= currentStep;
         const isDone = num < currentStep;
         return (
           <div

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { createPortal } from "react-dom";
 import StatusMessage from "./StatusMessage";
 import SignalBars from "./SignalBars";
+import AIProviderIcon from "./AIProviderIcon";
 import type { WifiNetwork } from "@/lib/wifi-utils";
 import { signalToLevel } from "@/lib/wifi-utils";
 import AIModelsStep from "./AIModelsStep";
@@ -52,14 +53,15 @@ interface SystemStats {
 }
 
 
-const SECTIONS = ["appearance", "wifi", "ai", "telegram", "system", "about"] as const;
+const SECTIONS = ["appearance", "wifi", "ai", "localAi", "telegram", "system", "about"] as const;
 type Section = typeof SECTIONS[number];
 
 /* ── Sidebar nav items ── */
-const NAV_ITEMS: { id: Section; icon: string; labelKey: string }[] = [
+const NAV_ITEMS: { id: Section; icon: string; labelKey?: string; label?: string }[] = [
   { id: "appearance", icon: "palette", labelKey: "settings.appearance" },
   { id: "wifi", icon: "wifi", labelKey: "settings.network" },
   { id: "ai", icon: "smart_toy", labelKey: "settings.aiProvider" },
+  { id: "localAi", icon: "memory", label: "Local AI" },
   { id: "telegram", icon: "send", labelKey: "settings.telegram" },
   { id: "system", icon: "monitor_heart", labelKey: "settings.system" },
   { id: "about", icon: "info", labelKey: "settings.about" },
@@ -97,6 +99,7 @@ function Toggle({ on, onToggle, label }: { on: boolean; onToggle: (v: boolean) =
 
 export default function SettingsApp({ ui }: SettingsAppProps) {
   const { t, locale, setLocale } = useT();
+  const navLabel = useCallback((item: { label?: string; labelKey?: string }) => item.label ?? (item.labelKey ? t(item.labelKey) : ""), [t]);
   const [langOpen, setLangOpen] = useState(false);
   const langRef = useRef<HTMLDivElement>(null);
   const currentLang = LANGUAGES.find(l => l.code === locale) ?? LANGUAGES[0];
@@ -403,11 +406,65 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   };
 
   /* ── AI Provider ── */
-  const [aiProvider, setAiProvider] = useState<{ connected: boolean; providerLabel: string | null; mode: string | null; model: string | null } | null>(null);
+  const [aiProvider, setAiProvider] = useState<{ connected: boolean; provider: string | null; providerLabel: string | null; mode: string | null; model: string | null } | null>(null);
   useEffect(() => {
     if (section !== "ai") return;
-    fetch("/setup-api/ai-models/status").then(r => r.json()).then(setAiProvider).catch(() => {});
+    fetch("/setup-api/ai-models/status", { cache: "no-store" }).then(r => r.json()).then(setAiProvider).catch(() => {});
   }, [section]);
+  const [localAiStatus, setLocalAiStatus] = useState<{ configured: boolean; provider: string | null; model: string | null; running: boolean | null } | null>(null);
+  const [localAiDisabling, setLocalAiDisabling] = useState(false);
+  const [localAiError, setLocalAiError] = useState<string | null>(null);
+  const refreshLocalAiStatus = useCallback(async () => {
+    try {
+      const res = await fetch("/setup-api/setup/status", { cache: "no-store" });
+      const data = await res.json();
+      const configured = !!data.local_ai_configured;
+      const provider = typeof data.local_ai_provider === "string" ? data.local_ai_provider : null;
+      const model = typeof data.local_ai_model === "string" ? data.local_ai_model : null;
+
+      let running: boolean | null = null;
+      if (configured && provider === "llamacpp") {
+        const llamaRes = await fetch("/setup-api/llamacpp/status", { cache: "no-store" }).then(r => r.json()).catch(() => null);
+        running = !!llamaRes?.running;
+      } else if (configured && provider === "ollama") {
+        const ollamaRes = await fetch("/setup-api/ollama/status", { cache: "no-store" }).then(r => r.json()).catch(() => null);
+        running = !!ollamaRes?.running;
+      }
+
+      setLocalAiStatus({ configured, provider, model, running });
+      setLocalAiError(null);
+    } catch {
+      setLocalAiStatus({ configured: false, provider: null, model: null, running: null });
+    }
+  }, []);
+  const disableLocalAi = useCallback(async () => {
+    setLocalAiDisabling(true);
+    setLocalAiError(null);
+    try {
+      const res = await fetch("/setup-api/local-ai", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "disable" }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || !data.success) {
+        throw new Error(typeof data.error === "string" ? data.error : "Failed to disable Local AI");
+      }
+      await refreshLocalAiStatus();
+    } catch (err) {
+      setLocalAiError(err instanceof Error ? err.message : "Failed to disable Local AI");
+    } finally {
+      setLocalAiDisabling(false);
+    }
+  }, [refreshLocalAiStatus]);
+  useEffect(() => {
+    if (section !== "localAi") return;
+    refreshLocalAiStatus();
+    const interval = setInterval(() => {
+      refreshLocalAiStatus().catch(() => {});
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [refreshLocalAiStatus, section]);
 
   /* ── Telegram ── */
   const [tgToken, setTgToken] = useState("");
@@ -929,8 +986,11 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 </div>
               ) : aiProvider.connected ? (
                 <div className="flex items-center gap-4 bg-green-500/[0.06] border border-green-500/15 rounded-xl px-4 py-3.5">
-                  <div className="w-10 h-10 rounded-full bg-green-500/15 flex items-center justify-center shrink-0">
-                    <span className="material-symbols-rounded text-green-400" style={{ fontSize: 22 }}>check_circle</span>
+                  <div className="relative w-10 h-10 rounded-full bg-green-500/15 border border-green-400/10 flex items-center justify-center shrink-0">
+                    <AIProviderIcon provider={aiProvider.provider} size={24} />
+                    <span className="absolute -right-1 -bottom-1 w-5 h-5 rounded-full bg-[#10261d] border border-green-500/25 flex items-center justify-center">
+                      <span className="material-symbols-rounded text-green-400" style={{ fontSize: 14 }}>check</span>
+                    </span>
                   </div>
                   <div className="flex-1 min-w-0">
                     <div className="text-sm text-[var(--text-primary)] font-medium">{aiProvider.providerLabel}</div>
@@ -955,9 +1015,141 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               )}
             </div>
 
-            <I18nProvider><AIModelsStep embedded onConfigured={() => {
-              fetch("/setup-api/ai-models/status").then(r => r.json()).then(setAiProvider).catch(() => {});
-            }} /></I18nProvider>
+            <I18nProvider><AIModelsStep
+              embedded
+              providerIds={["clawai", "openai", "anthropic", "google", "openrouter"]}
+              defaultProviderId="clawai"
+              currentProviderId={aiProvider?.provider ?? null}
+              currentModel={aiProvider?.model ?? null}
+              title="Connect AI Provider"
+              description="Choose the primary AI service your assistant should use day to day. Your Local AI setup stays available as a private on-device fallback."
+              onConfigured={() => {
+              fetch("/setup-api/ai-models/status", { cache: "no-store" }).then(r => r.json()).then(setAiProvider).catch(() => {});
+            }}
+            /></I18nProvider>
+          </div>
+        )}
+
+        {/* ─── Local AI ─── */}
+        {activeSection === "localAi" && (
+          <div className="max-w-lg space-y-5">
+            <h2 className="text-lg font-semibold text-[var(--text-primary)]">Local AI</h2>
+
+            <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+              <div className="flex items-center gap-2 mb-4">
+                <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>memory</span>
+                <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</label>
+              </div>
+              {localAiStatus === null ? (
+                <div className="flex items-center gap-3 text-[var(--text-muted)] text-sm">
+                  <div className="w-5 h-5 border-2 border-white/15 border-t-[var(--coral-bright)] rounded-full animate-spin" />
+                  {t("settings.checking")}
+                </div>
+              ) : localAiStatus.configured ? (
+                <div className={`flex items-center gap-4 rounded-xl px-4 py-3.5 border ${
+                  localAiStatus.running === false
+                    ? "bg-amber-500/[0.06] border-amber-500/15"
+                    : "bg-cyan-500/[0.06] border-cyan-500/15"
+                }`}>
+                  <div className={`relative w-10 h-10 rounded-full border flex items-center justify-center shrink-0 ${
+                    localAiStatus.running === false
+                      ? "bg-amber-500/10 border-amber-400/10"
+                      : "bg-cyan-500/10 border-cyan-400/10"
+                  }`}>
+                    <AIProviderIcon provider={localAiStatus.provider} size={24} />
+                    <span className={`absolute -right-1 -bottom-1 w-5 h-5 rounded-full border flex items-center justify-center ${
+                      localAiStatus.running === false
+                        ? "bg-[#2a1d10] border-amber-500/25"
+                        : "bg-[#10212a] border-cyan-500/25"
+                    }`}>
+                      <span className={`material-symbols-rounded ${
+                        localAiStatus.running === false ? "text-amber-300" : "text-cyan-300"
+                      }`} style={{ fontSize: 14 }}>
+                        {localAiStatus.running === false ? "warning" : "check"}
+                      </span>
+                    </span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-[var(--text-primary)] font-medium">
+                      {localAiStatus.provider === "llamacpp" ? "Gemma 4 Local" : localAiStatus.provider === "ollama" ? "Ollama Local" : "Local AI"}
+                    </div>
+                    <div className="flex items-center gap-1.5 mt-0.5">
+                      <span className={`w-1.5 h-1.5 rounded-full animate-pulse ${
+                        localAiStatus.running === false ? "bg-amber-300" : "bg-cyan-300"
+                      }`} />
+                      <span className={`text-xs ${
+                        localAiStatus.running === false ? "text-amber-300/80" : "text-cyan-300/80"
+                      }`}>
+                        {localAiStatus.running === false
+                          ? `${localAiStatus.model ? localAiStatus.model.split("/").pop() : "Configured"} · endpoint not responding`
+                          : (localAiStatus.model ? localAiStatus.model.split("/").pop() : "Ready as fallback")}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5">
+                  <div className="w-10 h-10 rounded-full bg-white/5 flex items-center justify-center shrink-0">
+                    <span className="material-symbols-rounded text-[var(--text-muted)]" style={{ fontSize: 22 }}>memory</span>
+                  </div>
+                  <div>
+                    <div className="text-sm text-[var(--text-muted)]">No local model configured</div>
+                    <div className="text-xs text-[var(--text-muted)] opacity-50 mt-0.5">Turn on Gemma 4 or Ollama to add a private on-device backup.</div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {localAiError && (
+              <div className="rounded-xl border border-red-500/20 bg-red-500/[0.06] px-4 py-3 text-sm text-red-300">
+                {localAiError}
+              </div>
+            )}
+
+            {localAiStatus?.configured && (
+              <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <div className="text-lg font-semibold text-[var(--text-primary)]">
+                      {localAiStatus.provider === "llamacpp" ? "Gemma 4" : "Ollama"}
+                    </div>
+                    <p className="text-sm text-[var(--text-secondary)] mt-1">
+                      {localAiStatus.running === false
+                        ? "Configured, but currently offline."
+                        : "Enabled and ready as your local backup model."}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={disableLocalAi}
+                    disabled={localAiDisabling}
+                    className="px-4 py-2.5 bg-red-500/10 text-red-300 border border-red-500/20 rounded-xl text-sm font-semibold cursor-pointer hover:bg-red-500/20 transition-colors disabled:opacity-50"
+                  >
+                    {localAiDisabling ? "Disabling..." : "Disable"}
+                  </button>
+                </div>
+                <p className="text-xs text-[var(--text-muted)] mt-3">
+                  Disabling Local AI stops the local model and frees the memory it is using.
+                </p>
+              </div>
+            )}
+
+            <I18nProvider><AIModelsStep
+              embedded
+              providerIds={["llamacpp", "ollama"]}
+              defaultProviderId="llamacpp"
+              currentProviderId={localAiStatus?.provider ?? null}
+              currentModel={localAiStatus?.model ?? null}
+              title="Set Up Local AI"
+              description={localAiStatus?.configured
+                ? "Choose a different local engine if you want to switch your on-device fallback."
+                : "Turn on a local model so ClawBox always has a private on-device backup."}
+              configureScope="local"
+              testId="settings-local-ai-step"
+              onConfigured={() => {
+                refreshLocalAiStatus().catch(() => {});
+              }}
+            /></I18nProvider>
           </div>
         )}
 
@@ -1451,7 +1643,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   className="flex items-center gap-3 px-5 py-3.5 text-sm border-none cursor-pointer transition-colors text-[var(--text-secondary)] hover:bg-white/[0.04] active:bg-white/[0.08]"
                 >
                   <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 20 }}>{item.icon}</span>
-                  <span className="flex-1 text-left">{t(item.labelKey)}</span>
+                  <span className="flex-1 text-left">{navLabel(item)}</span>
                   <span className="material-symbols-rounded text-[var(--text-muted)] opacity-40" style={{ fontSize: 18 }}>chevron_right</span>
                 </button>
               ))}
@@ -1468,7 +1660,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M15 18l-6-6 6-6" /></svg>
               </button>
               <span className="text-sm font-medium text-[var(--text-primary)]">
-                {(() => { const nav = NAV_ITEMS.find(i => i.id === mobileSection); return nav ? t(nav.labelKey) : t("settings.title"); })()}
+                {(() => { const nav = NAV_ITEMS.find(i => i.id === mobileSection); return nav ? navLabel(nav) : t("settings.title"); })()}
               </span>
             </div>
             <div className="flex-1 overflow-y-auto p-4">
@@ -1632,7 +1824,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               }`}
             >
               <span className="material-symbols-rounded" style={{ fontSize: 18, color: active ? "var(--coral-bright)" : "var(--text-muted)" }}>{item.icon}</span>
-              {t(item.labelKey)}
+              {navLabel(item)}
             </button>
           );
         })}

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -34,6 +34,8 @@ function applyStatusData(
     return;
   }
   if (data.ai_model_configured) {
+    setCurrentStep(6);
+  } else if (data.local_ai_configured) {
     setCurrentStep(5);
   } else if (data.password_configured) {
     setCurrentStep(4);
@@ -148,10 +150,14 @@ function HelpPopover({ step, onClose, t }: { step: number; onClose: () => void; 
       body: t("wizard.help3Body"),
     },
     4: {
+      title: "Local AI Setup",
+      body: "Install a local model first so ClawBox always has an on-device backup. Gemma 4 on llama.cpp is the recommended default for 8GB devices, and Ollama stays available if you prefer it.",
+    },
+    5: {
       title: t("wizard.help4Title"),
       body: t("wizard.help4Body"),
     },
-    5: {
+    6: {
       title: t("wizard.help5Title"),
       body: t("wizard.help5Body"),
     },
@@ -202,7 +208,7 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
         if (!cancelled) setIsLoading(false);
       });
     return () => { cancelled = true; controller.abort(); };
-  }, [retryCount]);
+  }, [onComplete, retryCount]);
 
   if (isLoading) {
     return (
@@ -290,9 +296,26 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
           <CredentialsStep onNext={() => setCurrentStep(4)} />
         )}
         {currentStep === 4 && (
-          <AIModelsStep onNext={() => setCurrentStep(5)} />
+          <AIModelsStep
+            providerIds={["llamacpp", "ollama"]}
+            defaultProviderId="llamacpp"
+            title="Set Up Local AI"
+            description="Install a local model first so OpenClaw always has a private on-device fallback. Gemma 4 on llama.cpp is recommended by default, with Ollama available if you prefer it."
+            configureScope="local"
+            testId="setup-step-local-ai"
+            onNext={() => setCurrentStep(5)}
+          />
         )}
         {currentStep === 5 && (
+          <AIModelsStep
+            providerIds={["clawai", "openai", "anthropic", "google", "openrouter"]}
+            defaultProviderId="clawai"
+            title="Connect AI Provider"
+            description={t("ai.description")}
+            onNext={() => setCurrentStep(6)}
+          />
+        )}
+        {currentStep === 6 && (
           <TelegramStep onNext={() => completeSetup(onComplete)} />
         )}
       </main>

--- a/src/hooks/useLlamaCppModels.ts
+++ b/src/hooks/useLlamaCppModels.ts
@@ -13,7 +13,9 @@ export interface LlamaCppCallbacks {
   onClearStatus?: () => void;
 }
 
-export function useLlamaCppModels(callbacks: LlamaCppCallbacks) {
+type ConfigureScope = "primary" | "local";
+
+export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: ConfigureScope = "primary") {
   const { onSaveSuccess, onSaveError, onClearStatus } = callbacks;
   const [llamaCppRunning, setLlamaCppRunning] = useState(false);
   const [llamaCppModels, setLlamaCppModels] = useState<LlamaCppModel[]>([]);
@@ -57,6 +59,7 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks) {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           model: trimmedModel,
+          scope: configureScope,
         }),
       });
 
@@ -123,7 +126,7 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks) {
       setLlamaCppSaving(false);
       setLlamaCppProgress(null);
     }
-  }, [checkLlamaCppStatus, onClearStatus, onSaveError, onSaveSuccess]);
+  }, [checkLlamaCppStatus, configureScope, onClearStatus, onSaveError, onSaveSuccess]);
 
   return {
     llamaCppRunning,

--- a/src/hooks/useOllamaModels.ts
+++ b/src/hooks/useOllamaModels.ts
@@ -22,7 +22,9 @@ export interface OllamaCallbacks {
   onClearStatus?: () => void;
 }
 
-export function useOllamaModels(callbacks: OllamaCallbacks) {
+type ConfigureScope = "primary" | "local";
+
+export function useOllamaModels(callbacks: OllamaCallbacks, configureScope: ConfigureScope = "primary") {
   const [ollamaRunning, setOllamaRunning] = useState(false);
   const [ollamaModels, setOllamaModels] = useState<OllamaModel[]>([]);
   const [ollamaSearch, setOllamaSearch] = useState("");
@@ -115,6 +117,7 @@ export function useOllamaModels(callbacks: OllamaCallbacks) {
             provider: "ollama",
             apiKey: model,
             authMode: "local",
+            scope: configureScope,
           }),
         });
         const data = await res.json();
@@ -131,7 +134,7 @@ export function useOllamaModels(callbacks: OllamaCallbacks) {
         setOllamaSaving(false);
       }
     },
-    [callbacks]
+    [callbacks, configureScope]
   );
 
   const pullOllamaModel = useCallback(

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -125,15 +125,25 @@ export async function startLlamaCppServer() {
 }
 
 async function bootLlamaCppServer() {
-  const [{ readConfig }, llamaCpp] = await Promise.all([
+  const [{ getAll }, { readConfig }, llamaCpp] = await Promise.all([
+    import('./lib/config-store'),
     import('./lib/openclaw-config'),
     import('./lib/llamacpp-server'),
   ])
 
-  const config = await readConfig()
+  const [config, state] = await Promise.all([readConfig(), getAll().catch(() => ({} as Record<string, unknown>))])
+  const hasExplicitLocalAiFlag = Object.prototype.hasOwnProperty.call(state, 'local_ai_configured')
+  if (hasExplicitLocalAiFlag && state['local_ai_configured'] === false) {
+    const primaryModel = config.agents?.defaults?.model?.primary?.trim()
+    if (!primaryModel || !primaryModel.startsWith('llamacpp/')) {
+      console.log('[instrumentation] llama.cpp auto-start skipped (Local AI explicitly disabled)')
+      return
+    }
+  }
+
   const alias = llamaCpp.getConfiguredLlamaCppModelAlias(config)
   if (!alias) {
-    console.log('[instrumentation] llama.cpp auto-start skipped (primary model is not llamacpp)')
+    console.log('[instrumentation] llama.cpp auto-start skipped (no llama.cpp primary or local fallback configured)')
     return
   }
 

--- a/src/lib/ai-provider-progress.ts
+++ b/src/lib/ai-provider-progress.ts
@@ -1,0 +1,93 @@
+export interface OverlayProgressState {
+  phase: number;
+  detail: string | null;
+  progressPercent: number | null;
+}
+
+export interface OllamaProgressInput {
+  pulling: boolean;
+  saving: boolean;
+  pullProgress: {
+    status: string;
+    completed?: number;
+    total?: number;
+  } | null;
+}
+
+function clampPhase(phase: number, stepCount: number): number {
+  return Math.max(0, Math.min(phase, Math.max(0, stepCount - 1)));
+}
+
+function calculateProgressPercent(completed?: number, total?: number): number | null {
+  if (!total || total <= 0) return null;
+  return Math.max(0, Math.min(100, Math.round(((completed || 0) / total) * 100)));
+}
+
+export function getOllamaOverlayProgress(
+  input: OllamaProgressInput,
+  stepCount: number,
+): OverlayProgressState {
+  const { pulling, saving, pullProgress } = input;
+  if (saving) {
+    return {
+      phase: clampPhase(2, stepCount),
+      detail: "Applying ClawBox configuration...",
+      progressPercent: null,
+    };
+  }
+
+  if (!pulling) {
+    return {
+      phase: 0,
+      detail: "Preparing Ollama...",
+      progressPercent: null,
+    };
+  }
+
+  const status = pullProgress?.status?.trim() || "Downloading model files...";
+  const normalized = status.toLowerCase();
+  const phase = normalized.includes("pulling manifest") || normalized.includes("verifying")
+    ? 0
+    : 1;
+
+  return {
+    phase: clampPhase(phase, stepCount),
+    detail: status,
+    progressPercent: calculateProgressPercent(pullProgress?.completed, pullProgress?.total),
+  };
+}
+
+export function getLlamaCppOverlayProgress(
+  status: string | null,
+  stepCount: number,
+): OverlayProgressState {
+  const detail = status?.trim() || "Preparing llama.cpp runtime...";
+  const normalized = detail.toLowerCase();
+
+  let phase = 0;
+  if (
+    normalized.includes("installed, running, and configured")
+    || normalized.includes("ready and configured")
+  ) {
+    phase = 4;
+  } else if (
+    normalized.includes("applying clawbox configuration")
+    || normalized.includes("applying configuration")
+  ) {
+    phase = 3;
+  } else if (
+    normalized.includes("starting llama-server")
+    || normalized.includes("already starting")
+    || normalized.includes("waiting for it to become ready")
+  ) {
+    phase = 2;
+  } else if (normalized.includes("downloading")) {
+    phase = 1;
+  }
+
+  return {
+    phase: clampPhase(phase, stepCount),
+    detail,
+    progressPercent: null,
+  };
+}

--- a/src/lib/llamacpp-server.ts
+++ b/src/lib/llamacpp-server.ts
@@ -9,7 +9,7 @@ import {
   getLlamaCppBaseUrl,
   getLlamaCppServerContextSize,
 } from "./llamacpp";
-import type { OpenClawConfig } from "./openclaw-config";
+import { inferConfiguredLocalModel, type OpenClawConfig } from "./openclaw-config";
 
 const LLAMACPP_RUNTIME_DIR = path.join(DATA_DIR, "llamacpp");
 const LLAMACPP_PID_PATH = path.join(LLAMACPP_RUNTIME_DIR, "server.pid");
@@ -38,10 +38,17 @@ export interface LlamaCppLaunchSpec {
 
 export function getConfiguredLlamaCppModelAlias(config: OpenClawConfig): string | null {
   const primaryModel = config.agents?.defaults?.model?.primary?.trim();
-  if (!primaryModel || !primaryModel.startsWith("llamacpp/")) return null;
+  if (primaryModel && primaryModel.startsWith("llamacpp/")) {
+    const alias = primaryModel.slice("llamacpp/".length).trim();
+    return alias || getDefaultLlamaCppModel();
+  }
 
-  const alias = primaryModel.slice("llamacpp/".length).trim();
-  return alias || getDefaultLlamaCppModel();
+  const localFallback = inferConfiguredLocalModel(config);
+  if (localFallback?.provider === "llamacpp") {
+    return localFallback.model.replace(/^llamacpp\//, "") || getDefaultLlamaCppModel();
+  }
+
+  return null;
 }
 
 export function getLlamaCppLaunchSpec(alias = getDefaultLlamaCppModel()): LlamaCppLaunchSpec {

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -26,13 +26,64 @@ export interface OpenClawConfig {
   auth?: {
     profiles?: Record<string, { provider?: string; mode?: string }>;
   };
+  models?: {
+    mode?: string;
+    providers?: Record<string, {
+      models?: Array<{ id?: string; name?: string }>;
+      [key: string]: unknown;
+    }>;
+  };
   agents?: {
     defaults?: {
-      model?: { primary?: string };
+      model?: { primary?: string; fallbacks?: string[] };
       workspace?: string;
       compaction?: { reserveTokensFloor?: number };
     };
   };
+}
+
+function normalizeLocalProvider(provider: string | null | undefined): "llamacpp" | "ollama" | null {
+  if (!provider) return null;
+  const normalized = provider.trim().toLowerCase();
+  if (normalized.startsWith("llamacpp")) return "llamacpp";
+  if (normalized.startsWith("ollama")) return "ollama";
+  return null;
+}
+
+function toLocalModel(provider: "llamacpp" | "ollama", modelId: string | null | undefined): string | null {
+  const trimmed = modelId?.trim();
+  if (!trimmed) return null;
+  return `${provider}/${trimmed}`;
+}
+
+export function inferConfiguredLocalModel(config: OpenClawConfig): { provider: "llamacpp" | "ollama"; model: string } | null {
+  const modelDefaults = config.agents?.defaults?.model;
+  const localCandidates = [
+    ...(Array.isArray(modelDefaults?.fallbacks) ? modelDefaults.fallbacks : []),
+    modelDefaults?.primary,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => {
+      const [provider, ...rest] = value.split("/");
+      const normalizedProvider = normalizeLocalProvider(provider);
+      if (!normalizedProvider || rest.length === 0) return null;
+      return { provider: normalizedProvider, model: value };
+    })
+    .filter((value): value is { provider: "llamacpp" | "ollama"; model: string } => value !== null);
+
+  if (localCandidates.length > 0) {
+    return localCandidates[0];
+  }
+
+  const providerDefs = config.models?.providers ?? {};
+  for (const provider of ["llamacpp", "ollama"] as const) {
+    const candidate = toLocalModel(provider, providerDefs[provider]?.models?.[0]?.id);
+    if (candidate) {
+      return { provider, model: candidate };
+    }
+  }
+
+  return null;
 }
 
 export async function readConfig(): Promise<OpenClawConfig> {

--- a/src/tests/components/ai-models-step.test.tsx
+++ b/src/tests/components/ai-models-step.test.tsx
@@ -1,0 +1,143 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@/tests/helpers/test-utils";
+import AIModelsStep from "@/components/AIModelsStep";
+
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({
+    t: (key: string) => {
+      const translations: Record<string, string> = {
+        "ai.credentialsVerified": "Credentials verified",
+        "ai.updatingConfig": "Updating AI configuration",
+        "ai.restartingGateway": "Restarting gateway service",
+        "ai.warmingUp": "Warming up models",
+        "ai.almostReady": "Almost ready",
+        "ai.title": "Connect AI Model",
+        "ai.description": "Select your AI provider and enter your API key or subscription token.",
+        "ai.clawaiDesc": "Most affordable - start for free",
+        "ai.claudeModels": "Claude models by Anthropic",
+        "ai.gptModels": "GPT models by OpenAI",
+        "ai.geminiModels": "Gemini models by Google",
+        "ai.multiProvider": "Multi-provider AI gateway",
+        "ai.runLocally": "Run AI models locally on device",
+        "ai.showMore": "Show more providers...",
+        recommended: "Recommended",
+        save: "Save",
+        "settings.aiProvider": "AI Provider",
+      };
+      return translations[key] ?? key;
+    },
+  }),
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useOllamaModels", () => ({
+  useOllamaModels: () => ({
+    ollamaRunning: true,
+    ollamaModels: [],
+    ollamaSearch: "",
+    ollamaSearchResults: [],
+    ollamaSearching: false,
+    ollamaPulling: false,
+    ollamaPullProgress: null,
+    ollamaSaving: false,
+    checkOllamaStatus: vi.fn(),
+    handleOllamaSearchChange: vi.fn(),
+    pullOllamaModel: vi.fn(),
+    saveOllamaConfig: vi.fn(),
+    deleteOllamaModel: vi.fn(),
+    formatOllamaBytes: vi.fn((bytes: number) => `${bytes}`),
+    clearSearch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useLlamaCppModels", () => ({
+  useLlamaCppModels: () => ({
+    llamaCppRunning: false,
+    llamaCppModels: [],
+    llamaCppEndpoint: "http://127.0.0.1:8080/v1",
+    llamaCppSaving: false,
+    llamaCppProgress: null,
+    checkLlamaCppStatus: vi.fn(),
+    saveLlamaCppConfig: vi.fn(),
+  }),
+}));
+
+describe("AIModelsStep variants", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ providers: [] }),
+    }));
+  });
+
+  it("renders only local providers in Local AI mode and defaults to llama.cpp", async () => {
+    const { getByRole, getByText, queryByText } = render(
+      <AIModelsStep
+        embedded
+        providerIds={["llamacpp", "ollama"]}
+        defaultProviderId="llamacpp"
+        title="Set Up Local AI"
+        description="Local models first"
+        configureScope="local"
+        testId="local-ai-test"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers");
+    });
+
+    expect(getByText("Set Up Local AI")).toBeInTheDocument();
+    const providerGroup = getByRole("radiogroup", { name: "AI Provider" });
+    expect(providerGroup).toHaveTextContent("Gemma 4");
+    expect(providerGroup).toHaveTextContent("Ollama");
+    expect(queryByText("ClawBox AI")).not.toBeInTheDocument();
+    expect(queryByText("OpenAI GPT")).not.toBeInTheDocument();
+    expect(getByText("Enable Gemma 4")).toBeInTheDocument();
+  });
+
+  it("renders only cloud and ClawBox providers in provider mode", async () => {
+    const { getByText, queryByText } = render(
+      <AIModelsStep
+        embedded
+        providerIds={["clawai", "openai", "anthropic", "google", "openrouter"]}
+        defaultProviderId="clawai"
+        title="Connect AI Provider"
+        description="Primary provider"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers");
+    });
+
+    expect(getByText("Connect AI Provider")).toBeInTheDocument();
+    expect(getByText("ClawBox AI")).toBeInTheDocument();
+    expect(getByText("OpenAI GPT")).toBeInTheDocument();
+    expect(queryByText("llama.cpp Local")).not.toBeInTheDocument();
+    expect(queryByText("Ollama Local")).not.toBeInTheDocument();
+  });
+
+  it("selects the currently configured provider alias in settings mode", async () => {
+    const { getByRole } = render(
+      <AIModelsStep
+        embedded
+        providerIds={["clawai", "openai", "anthropic", "google", "openrouter"]}
+        defaultProviderId="clawai"
+        currentProviderId="openai-codex"
+        currentModel="openai-codex/gpt-5.4"
+        title="Connect AI Provider"
+        description="Primary provider"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers");
+    });
+
+    await waitFor(() => {
+      expect(getByRole("radio", { name: /OpenAI GPT/i })).toBeChecked();
+    });
+  });
+});

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -19,6 +19,7 @@ vi.mock("fs/promises", () => ({
 }));
 
 vi.mock("@/lib/config-store", () => ({
+  getAll: vi.fn(),
   setMany: vi.fn(),
 }));
 
@@ -26,13 +27,18 @@ vi.mock("@/lib/openclaw-config", () => ({
   DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR: 24000,
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
+  readConfig: vi.fn(),
+  inferConfiguredLocalModel: vi.fn(),
 }));
 
-import { setMany } from "@/lib/config-store";
-import { restartGateway } from "@/lib/openclaw-config";
+import { getAll, setMany } from "@/lib/config-store";
+import { inferConfiguredLocalModel, readConfig, restartGateway } from "@/lib/openclaw-config";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
+const mockGetAll = vi.mocked(getAll);
 const mockSetMany = vi.mocked(setMany);
+const mockInferConfiguredLocalModel = vi.mocked(inferConfiguredLocalModel);
+const mockReadOpenClawConfig = vi.mocked(readConfig);
 const mockRestartGateway = vi.mocked(restartGateway);
 const mockFs = vi.mocked(fsp);
 
@@ -88,6 +94,9 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockFs.rename.mockResolvedValue();
     mockFs.chown.mockResolvedValue();
     mockFs.mkdir.mockResolvedValue(undefined);
+    mockGetAll.mockResolvedValue({});
+    mockReadOpenClawConfig.mockResolvedValue({});
+    mockInferConfiguredLocalModel.mockReturnValue(null);
     mockSetMany.mockResolvedValue();
     mockRestartGateway.mockResolvedValue();
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
@@ -216,6 +225,29 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(commands).toContain("config set gateway.auth.token clawbox");
   });
 
+  it("stores local AI state separately when configuring llama.cpp as Local AI", async () => {
+    const res = await configurePost(jsonRequest({
+      provider: "llamacpp",
+      scope: "local",
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockSetMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        local_ai_configured: true,
+        local_ai_provider: "llamacpp",
+        local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+      }),
+    );
+
+    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    expect(commands).not.toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
+    expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
+    expect(commands).toContain("config set models.mode merge");
+  });
+
   it("configures subscription auth mode for oauth", async () => {
     const res = await configurePost(jsonRequest({
       provider: "openai",
@@ -336,6 +368,55 @@ describe("POST /setup-api/ai-models/configure", () => {
         key: "test-clawbox-ai-key",
       })
     );
+  });
+
+  it("prefers the configured local AI model as the OpenClaw fallback", async () => {
+    mockGetAll.mockResolvedValue({
+      local_ai_configured: true,
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+    });
+
+    await configurePost(jsonRequest({
+      provider: "openai",
+      apiKey: "sk-openai-key",
+    }));
+
+    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
+    expect(commands.some((command) => command.includes("config set models.providers.deepseek"))).toBe(false);
+  });
+
+  it("falls back to an inferred local model from openclaw config when config-store state is missing", async () => {
+    mockInferConfiguredLocalModel.mockReturnValue({
+      provider: "llamacpp",
+      model: "llamacpp/gemma4-e2b-it-q4_0",
+    });
+
+    await configurePost(jsonRequest({
+      provider: "openai",
+      apiKey: "sk-openai-key",
+    }));
+
+    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
+  });
+
+  it("does not use inferred local fallback when local AI is explicitly disabled", async () => {
+    mockGetAll.mockResolvedValue({
+      local_ai_configured: false,
+    });
+    mockInferConfiguredLocalModel.mockReturnValue({
+      provider: "llamacpp",
+      model: "llamacpp/gemma4-e2b-it-q4_0",
+    });
+
+    await configurePost(jsonRequest({
+      provider: "openai",
+      apiKey: "sk-openai-key",
+    }));
+
+    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    expect(commands).not.toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
   });
 
   it("configures ClawBox AI with the default proxy token when no device key is set", async () => {

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -84,7 +84,7 @@ describe("/setup-api/ai-models/status", () => {
     } as never);
     const res = await GET();
     const body = await res.json();
-    expect(body.provider).toBe("deepseek");
+    expect(body.provider).toBe("clawai");
     expect(body.providerLabel).toBe("ClawBox AI");
     expect(body.mode).toBe("api_key");
     expect(body.model).toBe("deepseek/deepseek-chat");
@@ -108,5 +108,25 @@ describe("/setup-api/ai-models/status", () => {
     expect(body.provider).toBe("llamacpp");
     expect(body.providerLabel).toBe("llama.cpp Local");
     expect(body.model).toBe("llamacpp/gemma-q4");
+  });
+
+  it("normalizes provider aliases like openai-codex for the UI", async () => {
+    mockReadConfig.mockResolvedValue({
+      auth: {
+        profiles: {
+          "openai-codex:default": { provider: "openai-codex", mode: "oauth" },
+        },
+      },
+      agents: {
+        defaults: { model: { primary: "openai-codex/gpt-5.4" } },
+      },
+    } as never);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.provider).toBe("openai");
+    expect(body.providerLabel).toBe("OpenAI GPT");
+    expect(body.model).toBe("openai-codex/gpt-5.4");
   });
 });

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -144,4 +144,28 @@ describe("POST /setup-api/llamacpp/install", () => {
     expect(text).toContain("Starting llama.cpp");
     expect(text).toContain("installed, running, and configured");
   });
+
+  it("forwards local scope to the configure route during llama.cpp install", async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ data: [{ id: "gemma4-e2b-it-q4_0" }] }),
+      });
+    vi.stubGlobal("fetch", mockFetch);
+    mockSpawn.mockReturnValue(createSpawnedProcess());
+
+    const res = await installPost(jsonRequest({ model: "gemma4-e2b-it-q4_0", scope: "local" }));
+    await readStream(res);
+
+    expect(mockConfigureAiModel).toHaveBeenCalledTimes(1);
+    const configureRequest = mockConfigureAiModel.mock.calls[0]?.[0] as Request;
+    expect(configureRequest).toBeDefined();
+    const payload = await configureRequest.json();
+    expect(payload.scope).toBe("local");
+    expect(payload.provider).toBe("llamacpp");
+  });
 });

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -6,6 +6,7 @@ import { NextResponse } from "next/server";
 
 vi.mock("child_process", () => ({
   spawn: vi.fn(),
+  execFile: vi.fn(),
 }));
 
 vi.mock("fs/promises", () => ({

--- a/src/tests/routes/local-ai.test.ts
+++ b/src/tests/routes/local-ai.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as childProcess from "child_process";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+vi.mock("@/lib/config-store", () => ({
+  setMany: vi.fn(),
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
+  inferConfiguredLocalModel: vi.fn(),
+  readConfig: vi.fn(),
+  restartGateway: vi.fn(),
+}));
+
+vi.mock("@/lib/llamacpp-server", () => ({
+  clearLlamaCppPid: vi.fn(),
+  getLlamaCppLaunchSpec: vi.fn().mockReturnValue({ pidPath: "/tmp/llamacpp.pid" }),
+  readLlamaCppPid: vi.fn(),
+}));
+
+import { setMany } from "@/lib/config-store";
+import { clearLlamaCppPid, getLlamaCppLaunchSpec, readLlamaCppPid } from "@/lib/llamacpp-server";
+import { inferConfiguredLocalModel, readConfig, restartGateway } from "@/lib/openclaw-config";
+
+const mockExecFile = vi.mocked(childProcess.execFile);
+const mockSetMany = vi.mocked(setMany);
+const mockClearLlamaCppPid = vi.mocked(clearLlamaCppPid);
+const mockGetLlamaCppLaunchSpec = vi.mocked(getLlamaCppLaunchSpec);
+const mockReadLlamaCppPid = vi.mocked(readLlamaCppPid);
+const mockInferConfiguredLocalModel = vi.mocked(inferConfiguredLocalModel);
+const mockReadConfig = vi.mocked(readConfig);
+const mockRestartGateway = vi.mocked(restartGateway);
+
+function jsonRequest(body: unknown): Request {
+  return new Request("http://localhost/setup-api/local-ai", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function setupExecFileMock() {
+  mockExecFile.mockImplementation(((
+    _cmd: string,
+    _args: string[],
+    optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+    maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => {
+    const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+    callback?.(null, { stdout: "", stderr: "" });
+    return {
+      then: (resolve: (value: { stdout: string; stderr: string }) => void) => {
+        resolve({ stdout: "", stderr: "" });
+        return {
+          catch: () => ({})
+        };
+      },
+      catch: () => ({}),
+    } as unknown as ReturnType<typeof childProcess.execFile>;
+  }) as unknown as typeof childProcess.execFile);
+}
+
+describe("POST /setup-api/local-ai", () => {
+  let localAiPost: (req: Request) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockSetMany.mockResolvedValue();
+    mockReadConfig.mockResolvedValue({});
+    mockInferConfiguredLocalModel.mockReturnValue({ provider: "llamacpp", model: "llamacpp/gemma4-e2b-it-q4_0" });
+    mockRestartGateway.mockResolvedValue();
+    mockGetLlamaCppLaunchSpec.mockReturnValue({ pidPath: "/tmp/llamacpp.pid" } as never);
+    mockReadLlamaCppPid.mockResolvedValue(12345);
+    mockClearLlamaCppPid.mockResolvedValue();
+    setupExecFileMock();
+
+    const mod = await import("@/app/setup-api/local-ai/route");
+    localAiPost = mod.POST;
+  });
+
+  it("disables llama.cpp local AI and clears stored setup flags", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    const res = await localAiPost(jsonRequest({ action: "disable" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockReadLlamaCppPid).toHaveBeenCalled();
+    expect(killSpy).toHaveBeenCalledWith(12345, "SIGTERM");
+    expect(mockClearLlamaCppPid).toHaveBeenCalledWith("/tmp/llamacpp.pid");
+    expect(mockRestartGateway).toHaveBeenCalled();
+    expect(mockSetMany).toHaveBeenCalledWith({
+      local_ai_configured: false,
+      local_ai_provider: undefined,
+      local_ai_model: undefined,
+      local_ai_configured_at: undefined,
+    });
+
+    killSpy.mockRestore();
+  });
+});

--- a/src/tests/routes/setup/status.test.ts
+++ b/src/tests/routes/setup/status.test.ts
@@ -6,6 +6,8 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 const TEST_ROOT = path.join(os.tmpdir(), `clawbox-setup-status-tests-${process.pid}-${Date.now()}`);
 const DATA_DIR = path.join(TEST_ROOT, "data");
 const CONFIG_PATH = path.join(DATA_DIR, "config.json");
+const OPENCLAW_HOME = path.join(TEST_ROOT, ".openclaw");
+const OPENCLAW_CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 
 type RouteGet = (request?: Request) => Promise<Response>;
 
@@ -13,17 +15,22 @@ let statusGet: RouteGet;
 
 beforeAll(async () => {
   process.env.CLAWBOX_ROOT = TEST_ROOT;
+  process.env.OPENCLAW_HOME = OPENCLAW_HOME;
   await fs.mkdir(DATA_DIR, { recursive: true });
+  await fs.mkdir(OPENCLAW_HOME, { recursive: true });
+  await fs.writeFile(OPENCLAW_CONFIG_PATH, JSON.stringify({}), "utf-8");
   vi.resetModules();
   ({ GET: statusGet } = await import("@/app/setup-api/setup/status/route"));
 });
 
 beforeEach(async () => {
   await fs.rm(CONFIG_PATH, { force: true });
+  await fs.writeFile(OPENCLAW_CONFIG_PATH, JSON.stringify({}), "utf-8");
 });
 
 afterAll(async () => {
   delete process.env.CLAWBOX_ROOT;
+  delete process.env.OPENCLAW_HOME;
   await fs.rm(TEST_ROOT, { recursive: true, force: true });
 });
 
@@ -37,6 +44,9 @@ describe("GET /setup-api/setup/status", () => {
     expect(body.password_configured).toBe(false);
     expect(body.update_completed).toBe(false);
     expect(body.wifi_configured).toBe(false);
+    expect(body.local_ai_configured).toBe(false);
+    expect(body.local_ai_provider).toBeNull();
+    expect(body.local_ai_model).toBeNull();
     expect(body.ai_model_configured).toBe(false);
     expect(body.ai_model_provider).toBeNull();
     expect(body.telegram_configured).toBe(false);
@@ -91,6 +101,82 @@ describe("GET /setup-api/setup/status", () => {
     expect(body.ai_model_provider).toBe("anthropic");
   });
 
+  it("returns local_ai_configured with provider and model when set", async () => {
+    await fs.writeFile(CONFIG_PATH, JSON.stringify({
+      local_ai_configured: true,
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+    }), "utf-8");
+
+    const res = await statusGet();
+    const body = await res.json();
+
+    expect(body.local_ai_configured).toBe(true);
+    expect(body.local_ai_provider).toBe("llamacpp");
+    expect(body.local_ai_model).toBe("llamacpp/gemma4-e2b-it-q4_0");
+  });
+
+  it("infers local AI configuration from openclaw.json when config-store flags are missing", async () => {
+    await fs.writeFile(
+      OPENCLAW_CONFIG_PATH,
+      JSON.stringify({
+        agents: {
+          defaults: {
+            model: {
+              primary: "deepseek/deepseek-chat",
+              fallbacks: ["deepseek/deepseek-chat"],
+            },
+          },
+        },
+        models: {
+          providers: {
+            llamacpp: {
+              models: [{ id: "gemma4-e2b-it-q4_0" }],
+            },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const res = await statusGet();
+    const body = await res.json();
+
+    expect(body.local_ai_configured).toBe(true);
+    expect(body.local_ai_provider).toBe("llamacpp");
+    expect(body.local_ai_model).toBe("llamacpp/gemma4-e2b-it-q4_0");
+  });
+
+  it("honors an explicit disabled local AI flag instead of inferring from openclaw.json", async () => {
+    await fs.writeFile(
+      CONFIG_PATH,
+      JSON.stringify({
+        local_ai_configured: false,
+      }),
+      "utf-8",
+    );
+    await fs.writeFile(
+      OPENCLAW_CONFIG_PATH,
+      JSON.stringify({
+        models: {
+          providers: {
+            llamacpp: {
+              models: [{ id: "gemma4-e2b-it-q4_0" }],
+            },
+          },
+        },
+      }),
+      "utf-8",
+    );
+
+    const res = await statusGet();
+    const body = await res.json();
+
+    expect(body.local_ai_configured).toBe(false);
+    expect(body.local_ai_provider).toBeNull();
+    expect(body.local_ai_model).toBeNull();
+  });
+
   it("returns telegram_configured as true when bot token is set", async () => {
     await fs.writeFile(CONFIG_PATH, JSON.stringify({
       telegram_bot_token: "123456:ABC",
@@ -108,6 +194,9 @@ describe("GET /setup-api/setup/status", () => {
       password_configured: true,
       update_completed: true,
       wifi_configured: true,
+      local_ai_configured: true,
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
       ai_model_configured: true,
       ai_model_provider: "openai",
       telegram_bot_token: "token123",
@@ -120,6 +209,9 @@ describe("GET /setup-api/setup/status", () => {
     expect(body.password_configured).toBe(true);
     expect(body.update_completed).toBe(true);
     expect(body.wifi_configured).toBe(true);
+    expect(body.local_ai_configured).toBe(true);
+    expect(body.local_ai_provider).toBe("llamacpp");
+    expect(body.local_ai_model).toBe("llamacpp/gemma4-e2b-it-q4_0");
     expect(body.ai_model_configured).toBe(true);
     expect(body.ai_model_provider).toBe("openai");
     expect(body.telegram_configured).toBe(true);

--- a/src/tests/unit/ai-provider-progress.test.ts
+++ b/src/tests/unit/ai-provider-progress.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  getLlamaCppOverlayProgress,
+  getOllamaOverlayProgress,
+} from "@/lib/ai-provider-progress";
+
+describe("ai-provider-progress", () => {
+  describe("getOllamaOverlayProgress", () => {
+    it("starts in a preparation step before download telemetry arrives", () => {
+      expect(
+        getOllamaOverlayProgress(
+          { pulling: true, saving: false, pullProgress: null },
+          4,
+        ),
+      ).toEqual({
+        phase: 1,
+        detail: "Downloading model files...",
+        progressPercent: null,
+      });
+    });
+
+    it("surfaces download percentage while pulling", () => {
+      expect(
+        getOllamaOverlayProgress(
+          {
+            pulling: true,
+            saving: false,
+            pullProgress: { status: "downloading", completed: 50, total: 100 },
+          },
+          4,
+        ),
+      ).toEqual({
+        phase: 1,
+        detail: "downloading",
+        progressPercent: 50,
+      });
+    });
+
+    it("moves to configuration once the model is downloaded", () => {
+      expect(
+        getOllamaOverlayProgress(
+          { pulling: false, saving: true, pullProgress: null },
+          4,
+        ),
+      ).toEqual({
+        phase: 2,
+        detail: "Applying ClawBox configuration...",
+        progressPercent: null,
+      });
+    });
+  });
+
+  describe("getLlamaCppOverlayProgress", () => {
+    it("recognizes download, startup, and configuration phases", () => {
+      expect(
+        getLlamaCppOverlayProgress("Preparing llama.cpp for gemma4-e2b-it-q4_0...", 5),
+      ).toEqual({
+        phase: 0,
+        detail: "Preparing llama.cpp for gemma4-e2b-it-q4_0...",
+        progressPercent: null,
+      });
+
+      expect(
+        getLlamaCppOverlayProgress("[llamacpp] Downloading gguf-org/gemma-4-e2b-it-gguf/file.gguf", 5),
+      ).toEqual({
+        phase: 1,
+        detail: "[llamacpp] Downloading gguf-org/gemma-4-e2b-it-gguf/file.gguf",
+        progressPercent: null,
+      });
+
+      expect(
+        getLlamaCppOverlayProgress("[llamacpp] Starting llama-server with /models/gemma.gguf", 5),
+      ).toEqual({
+        phase: 2,
+        detail: "[llamacpp] Starting llama-server with /models/gemma.gguf",
+        progressPercent: null,
+      });
+
+      expect(
+        getLlamaCppOverlayProgress("llama.cpp is ready. Applying ClawBox configuration...", 5),
+      ).toEqual({
+        phase: 3,
+        detail: "llama.cpp is ready. Applying ClawBox configuration...",
+        progressPercent: null,
+      });
+    });
+  });
+});

--- a/src/tests/unit/llamacpp.test.ts
+++ b/src/tests/unit/llamacpp.test.ts
@@ -73,4 +73,26 @@ describe("llamacpp config helpers", () => {
       },
     })).toBeNull();
   });
+
+  it("infers the auto-start alias from a configured local llama.cpp fallback", async () => {
+    const mod = await import("@/lib/llamacpp-server");
+
+    expect(mod.getConfiguredLlamaCppModelAlias({
+      agents: {
+        defaults: {
+          model: {
+            primary: "deepseek/deepseek-chat",
+            fallbacks: ["deepseek/deepseek-chat"],
+          },
+        },
+      },
+      models: {
+        providers: {
+          llamacpp: {
+            models: [{ id: "gemma4-e2b-it-q4_0" }],
+          },
+        },
+      },
+    })).toBe("gemma4-e2b-it-q4_0");
+  });
 });

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -594,4 +594,49 @@ describe("openclaw-config", () => {
       }
     });
   });
+
+  describe("inferConfiguredLocalModel", () => {
+    it("prefers a local fallback model when present", () => {
+      const result = openclawConfig.inferConfiguredLocalModel({
+        agents: {
+          defaults: {
+            model: {
+              primary: "deepseek/deepseek-chat",
+              fallbacks: ["llamacpp/gemma4-e2b-it-q4_0"],
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        provider: "llamacpp",
+        model: "llamacpp/gemma4-e2b-it-q4_0",
+      });
+    });
+
+    it("falls back to local provider definitions when config-store style state is missing", () => {
+      const result = openclawConfig.inferConfiguredLocalModel({
+        agents: {
+          defaults: {
+            model: {
+              primary: "deepseek/deepseek-chat",
+              fallbacks: ["deepseek/deepseek-chat"],
+            },
+          },
+        },
+        models: {
+          providers: {
+            llamacpp: {
+              models: [{ id: "gemma4-e2b-it-q4_0" }],
+            },
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        provider: "llamacpp",
+        model: "llamacpp/gemma4-e2b-it-q4_0",
+      });
+    });
+  });
 });


### PR DESCRIPTION
Local AI had drifted between config-store state, openclaw.json inference, and runtime processes. This change makes the settings surfaces reflect the live configured model, keeps explicit disable authoritative, and restarts local/gateway services in the right places so enable and disable actually change runtime state.

The UI is also simplified for beginners: Local AI now centers on Gemma 4 with a clearer enable/disable flow, while the provider chooser is reduced to a cleaner text-only list.

Constraint: Existing devices may have local model state only in openclaw.json, not data/config.json

Constraint: Disabling Local AI must stop llama.cpp and prevent instrumentation from auto-starting it again

Rejected: Trust inferred openclaw local model state unconditionally | explicit disable would be ignored and llama.cpp would restart

Rejected: Keep advanced local model controls in the main UI | too complex for the intended beginner flow

Confidence: high

Scope-risk: moderate

Reversibility: clean

Directive: Treat config-store local_ai_configured=false as authoritative over inferred openclaw fallback state

Tested: Vitest route/unit/component coverage for Local AI, llama.cpp, setup status, provider status, and progress mapping

Tested: Playwright targeted setup/settings Local AI flows

Tested: Production build (bun run build)

Tested: Live service restarts and curl/process verification for enable/disable behavior

Not-tested: Full end-to-end suite across every existing Settings workflow