### PR TITLE
chore: open repo to external contributions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — required reviewers for PRs into main.
+# Only members of @ID-Robots/id-robots-core-team can approve and merge.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+*       @ID-Robots/id-robots-core-team

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What does this PR change and why? Link related issues: Fixes #123 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Documentation / tooling
+- [ ] Other: ___
+
+## How was this tested?
+
+<!-- Commands, steps, or hardware used (e.g. Jetson Orin Nano, x64 dev install). -->
+
+- [ ] `bun run lint` passes
+- [ ] `bun run test` passes
+- [ ] `bun run build` succeeds
+- [ ] Manually verified on device / dev install
+
+## Checklist
+
+- [ ] Branch is up to date with `main`
+- [ ] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] No secrets, tokens, or credentials committed
+- [ ] Added/updated tests where it makes sense
+- [ ] Updated docs where user-facing behavior changed
+
+## Screenshots / logs (if UI or runtime change)
+
+<!-- Drop images or terminal output here. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,15 @@ jobs:
       - run: bun run build
 
   comment:
-    if: ${{ github.event_name == 'pull_request' }}
+    # Skip for fork PRs: GITHUB_TOKEN is always read-only on fork PRs regardless
+    # of repo/workflow permissions, so the comment would 403. Native PR checks
+    # UI already shows the same status.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: [lint, test, build]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Comment PR
         if: ${{ always() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,29 +2,71 @@
 
 Thanks for your interest in ClawBox! 🦞
 
-## Current Status
+We welcome pull requests from the community. External contributors can open PRs from a fork; the [ID Robots core team](https://github.com/orgs/ID-Robots/teams/id-robots-core-team) reviews, approves, and merges.
 
-ClawBox is **source-available** — you can view and study the code, but we're not accepting pull requests at this time.
+## Ways to contribute
 
-## How You Can Help
+### Pull requests
 
-### 🐛 Bug Reports
-Found a bug? [Open an issue](https://github.com/yalexx/clawbox/issues/new) with:
+1. **Fork** [ID-Robots/clawbox](https://github.com/ID-Robots/clawbox) to your account.
+2. **Clone** your fork and create a feature branch:
+   ```bash
+   git clone git@github.com:<you>/clawbox.git
+   cd clawbox
+   git checkout -b my-change
+   ```
+3. **Set up** the dev environment (see [README.md](README.md) and [CLAUDE.md](CLAUDE.md)):
+   ```bash
+   bun install
+   bun run dev
+   ```
+4. **Make your change.** Keep PRs focused — one logical change per PR.
+5. **Run checks locally** before pushing:
+   ```bash
+   bun run lint
+   bun run test
+   bun run build
+   ```
+6. **Open a PR** against `main`. The PR template will guide you through the checklist.
+7. A core team member will review. Address feedback by pushing new commits to the same branch.
+
+### Bug reports
+
+[Open an issue](https://github.com/ID-Robots/clawbox/issues/new/choose) with:
 - Steps to reproduce
 - Expected vs actual behavior
-- Device info (Jetson model, OS version)
+- Device info (Jetson model, JetPack version, ClawBox version)
 - Screenshots or terminal output
 
-### 💡 Feature Requests
-Have an idea? [Start a discussion](https://github.com/yalexx/clawbox/discussions/new?category=ideas) and we'll consider it for the roadmap.
+### Feature requests
 
-### 🔒 Security
-Found a vulnerability? Please email **yanko@idrobots.com** directly — do not open a public issue.
+[Start a discussion](https://github.com/ID-Robots/clawbox/discussions) and we'll consider it for the roadmap.
 
-### 💬 Community
-- Join our [Discord](https://discord.gg/FbKmnxYnpq) (78K+ members)
-- Help other users in the support channel
-- Share your ClawBox setup and use cases
+### Security
+
+Found a vulnerability? **Do not open a public issue.** Email **yanko@idrobots.com** directly.
+
+## Guidelines
+
+- **Code style:** ESLint + TypeScript. Run `bun run lint` before committing.
+- **Tests:** Add or update tests in `src/tests/*.test.ts`. Coverage target is 80%.
+- **Commits:** Keep commit messages clear and descriptive. Squash noisy WIP commits before review.
+- **Shell commands:** Use `execFile`, never `exec`, to avoid injection (see existing code in `src/lib/network.ts`).
+- **API routes:** Always export `export const dynamic = "force-dynamic"`.
+- **No direct pushes to `main`** — protected branch. All changes go through PR.
+- **Signed-off commits are welcome but not required.**
+
+## Review process
+
+- 1 approving review from a code owner (`@ID-Robots/id-robots-core-team`) is required
+- All CI checks (Test, Build, Lint) must pass
+- All review conversations must be resolved
+- PRs are merged by the core team once approved
+
+## Community
+
+- [Discord](https://discord.gg/FbKmnxYnpq) — get help, share your setup
+- [Discussions](https://github.com/ID-Robots/clawbox/discussions) — ideas and Q&A
 
 ## Code of Conduct
 


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` — routes all review requests to `@ID-Robots/id-robots-core-team`
- Add `.github/pull_request_template.md` — checklist for new PRs
- Rewrite `CONTRIBUTING.md` — replaces "not accepting PRs" with fork → PR workflow for external contributors

Companion to repo-side admin changes already applied:
- Branch protection on `main` now requires 1 code-owner review, conversation resolution, and restricts merges to `@ID-Robots/id-robots-core-team`
- Team `id-robots-core-team` granted `maintain` permission
- Auto-delete head branches on merge enabled

## Test plan

- [ ] CI (Test, Build, Lint) passes
- [ ] CODEOWNERS auto-requests review from core team on this PR
- [ ] External contributor flow works: fork → branch → PR → core team review → merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines with step-by-step PR workflow, review rules, and community links.
  * Introduced a structured pull request template to standardize submissions and checks.

* **Chores**
  * Added repository code ownership configuration to improve governance.
  * Adjusted CI comment job to run only for same-repo PRs and expanded permissions for comment creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->