### PR TITLE
chore: port external-contributions setup to beta

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS — required reviewers for PRs into protected branches.
+# Only members of @ID-Robots/id-robots-core-team can approve and merge.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+*       @ID-Robots/id-robots-core-team

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,32 @@
+## Summary
+
+<!-- What does this PR change and why? Link related issues: Fixes #123 -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Documentation / tooling
+- [ ] Other: ___
+
+## How was this tested?
+
+<!-- Commands, steps, or hardware used (e.g. Jetson Orin Nano, x64 dev install). -->
+
+- [ ] `bun run lint` passes
+- [ ] `bun run test` passes
+- [ ] `bun run build` succeeds
+- [ ] Manually verified on device / dev install
+
+## Checklist
+
+- [ ] Branch is up to date with the target branch
+- [ ] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] No secrets, tokens, or credentials committed
+- [ ] Added/updated tests where it makes sense
+- [ ] Updated docs where user-facing behavior changed
+
+## Screenshots / logs (if UI or runtime change)
+
+<!-- Drop images or terminal output here. -->

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -73,11 +73,15 @@ jobs:
           retention-days: 7
 
   comment:
-    if: ${{ github.event_name == 'pull_request' }}
+    # Skip for fork PRs: GITHUB_TOKEN is always read-only on fork PRs regardless
+    # of repo/workflow permissions, so the comment would 403. Native PR checks
+    # UI already shows the same status.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: e2e
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Comment PR
         if: ${{ always() }}

--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -50,11 +50,15 @@ jobs:
           fi
 
   comment:
-    if: ${{ github.event_name == 'pull_request' }}
+    # Skip for fork PRs: GITHUB_TOKEN is always read-only on fork PRs regardless
+    # of repo/workflow permissions, so the comment would 403. Native PR checks
+    # UI already shows the same status.
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
     needs: test
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Comment PR
         if: ${{ always() }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to ClawBox
+
+Thanks for your interest in ClawBox! 🦞
+
+We welcome pull requests from the community. External contributors can open PRs from a fork; the [ID Robots core team](https://github.com/orgs/ID-Robots/teams/id-robots-core-team) reviews, approves, and merges.
+
+## Ways to contribute
+
+### Pull requests
+
+1. **Fork** [ID-Robots/clawbox](https://github.com/ID-Robots/clawbox) to your account.
+2. **Clone** your fork and create a feature branch:
+   ```bash
+   git clone git@github.com:<you>/clawbox.git
+   cd clawbox
+   git checkout -b my-change
+   ```
+3. **Set up** the dev environment (see [README.md](README.md) and [CLAUDE.md](CLAUDE.md)):
+   ```bash
+   bun install
+   bun run dev
+   ```
+4. **Make your change.** Keep PRs focused — one logical change per PR.
+5. **Run checks locally** before pushing:
+   ```bash
+   bun run lint
+   bun run test
+   bun run build
+   ```
+6. **Open a PR** against the appropriate branch (`main` for stable fixes, `beta` for pre-release work). The PR template will guide you through the checklist.
+7. A core team member will review. Address feedback by pushing new commits to the same branch.
+
+### Bug reports
+
+[Open an issue](https://github.com/ID-Robots/clawbox/issues/new/choose) with:
+- Steps to reproduce
+- Expected vs actual behavior
+- Device info (Jetson model, JetPack version, ClawBox version)
+- Screenshots or terminal output
+
+### Feature requests
+
+[Start a discussion](https://github.com/ID-Robots/clawbox/discussions) and we'll consider it for the roadmap.
+
+### Security
+
+Found a vulnerability? **Do not open a public issue.** Email **yanko@idrobots.com** directly.
+
+## Guidelines
+
+- **Code style:** ESLint + TypeScript. Run `bun run lint` before committing.
+- **Tests:** Add or update tests in `src/tests/*.test.ts`. Coverage target is 80%.
+- **Commits:** Keep commit messages clear and descriptive. Squash noisy WIP commits before review.
+- **Shell commands:** Use `execFile`, never `exec`, to avoid injection (see existing code in `src/lib/network.ts`).
+- **API routes:** Always export `export const dynamic = "force-dynamic"`.
+- **No direct pushes to `main`** — protected branch. All changes go through PR.
+- **Signed-off commits are welcome but not required.**
+
+## Review process
+
+- 1 approving review from a code owner (`@ID-Robots/id-robots-core-team`) is required
+- All CI checks must pass
+- All review conversations must be resolved
+- PRs are merged by the core team once approved
+
+## Community
+
+- [Discord](https://discord.gg/FbKmnxYnpq) — get help, share your setup
+- [Discussions](https://github.com/ID-Robots/clawbox/discussions) — ideas and Q&A
+
+## Code of Conduct
+
+Be respectful. We're building something cool together. 🤝


### PR DESCRIPTION
## Summary

Port the external-contributions setup from `main` (#46) to `beta`. Cherry-pick didn't apply cleanly — `beta` has diverged (CONTRIBUTING.md was deleted, main's `ci.yml` is split into `pr-tests-coverage.yml` + `e2e-tests.yml`) — so this is an adapted port.

- Add `.github/CODEOWNERS` routing all reviews to `@ID-Robots/id-robots-core-team`
- Add `.github/pull_request_template.md`
- Recreate `CONTRIBUTING.md` with the fork → PR flow for external contributors
- Fix both beta workflows so fork-PR CI stops 403'ing on the comment step:
  - Add `issues: write` to the comment job permissions
  - Skip the comment job on fork PRs (`GITHUB_TOKEN` is always read-only for fork-triggered runs, so the comment would 403 — native PR checks UI already shows the same status)

Repo-level Actions → Workflow permissions default is already set to `write` (applied when fixing main), which also applies here.

## Test plan

- [ ] CI workflows on this PR pass (same-repo PR — comment should post successfully)
- [ ] On PR #47 (fork PR from `O-Alidzhikov:logo-fix` → `beta`), after this is merged: comment job is skipped instead of 403'ing, Lint/Test/E2E still run and report via native checks UI

## Notes

`beta` is currently **unprotected** — CODEOWNERS won't be auto-enforced on PRs into beta until branch protection is added. Separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)