### PR TITLE
Enlarge completion-overlay logo and hold screen for 10s

### DIFF
--- a/e2e/mascot-context.spec.ts
+++ b/e2e/mascot-context.spec.ts
@@ -28,5 +28,5 @@ test("mascot tap opens the chat popup", async ({ page }) => {
     const dockVisible = await dockButton.isVisible().catch(() => false);
     const inputVisible = await chatInput.isVisible().catch(() => false);
     return dockVisible || inputVisible;
-  }).toBe(true);
+  }, { timeout: 15_000 }).toBe(true);
 });

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -234,9 +234,9 @@ function SetupCompletionOverlay({
                 <Image
                   src="/clawbox-crab.png"
                   alt="ClawBox"
-                  width={40}
-                  height={40}
-                  className="h-10 w-10 object-contain"
+                  width={60}
+                  height={60}
+                  className="h-[60px] w-[60px] object-contain"
                   priority
                 />
               </div>
@@ -409,7 +409,7 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
 
         setCompletionPhase(2);
         setCompletionComplete(true);
-        await delay(900);
+        await delay(10000);
         if (cancelled) return;
 
         if (onComplete) onComplete();

--- a/src/tests/components/setup-wizard.test.tsx
+++ b/src/tests/components/setup-wizard.test.tsx
@@ -179,6 +179,6 @@ describe("SetupWizard", () => {
 
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
-    }, { timeout: 15_000 });
-  }, 20_000);
+    }, { timeout: 30_000 });
+  }, 35_000);
 });


### PR DESCRIPTION
Bump the ClawBox crab logo in SetupCompletionOverlay from 40px to 60px and extend the post-complete delay from 900ms to 10s so users have time to read the "almost ready" state before the redirect to the desktop.

## Summary

<!-- What does this PR change and why? Link related issues: Fixes #123 -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation / tooling
- [ ] Other: ___

## How was this tested?

<!-- Commands, steps, or hardware used (e.g. Jetson Orin Nano, x64 dev install). -->

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build` succeeds
- [ ] Manually verified on device / dev install

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] No secrets, tokens, or credentials committed
- [ ] Added/updated tests where it makes sense
- [ ] Updated docs where user-facing behavior changed

## Screenshots / logs (if UI or runtime change)

<!-- Drop images or terminal output here. -->
