### PR TITLE
Setup wizard mobile/UX follow-ups + chpasswd PATH fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -844,7 +844,7 @@ step_chpasswd() {
     echo "Error: password input file not found" >&2
     exit 1
   fi
-  chpasswd < "$INPUT_FILE"
+  /usr/sbin/chpasswd < "$INPUT_FILE"
   rm -f "$INPUT_FILE"
 }
 

--- a/src/components/CredentialsStep.tsx
+++ b/src/components/CredentialsStep.tsx
@@ -111,6 +111,9 @@ export default function CredentialsStep({ onNext }: CredentialsStepProps) {
 
     setSaving(true);
     setStatus(null);
+    const newHost = `${normalizedHostname}.local`;
+    const newSetupUrl = new URL("/setup", window.location.href);
+    newSetupUrl.hostname = newHost;
     try {
       // Save hostname (applies live; mDNS update is non-fatal on failure)
       try {
@@ -171,9 +174,33 @@ export default function CredentialsStep({ onNext }: CredentialsStepProps) {
         message: t("credentials.settingsSaved"),
       });
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      timeoutRef.current = setTimeout(() => onNext(), 1500);
+      const currentHost = window.location.hostname.toLowerCase();
+      if (currentHost.endsWith(".local") && currentHost !== newHost) {
+        timeoutRef.current = setTimeout(() => window.location.replace(newSetupUrl.toString()), 1500);
+      } else {
+        timeoutRef.current = setTimeout(() => onNext(), 1500);
+      }
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
+      if (err instanceof TypeError && err.message.includes("fetch")) {
+        // Connection dropped mid-save — most likely the hostname just changed
+        // and mDNS is pointing at the new name. Probe the new URL before
+        // redirecting so we don't strand the user on a dead hostname.
+        try {
+          await fetch(newSetupUrl.toString(), {
+            method: "HEAD",
+            signal: AbortSignal.timeout(5000),
+          });
+          window.location.replace(newSetupUrl.toString());
+          return;
+        } catch {
+          setStatus({
+            type: "error",
+            message: `Could not reach ${newSetupUrl.toString()} — settings were saved, but mDNS may not be ready. Try opening the URL manually.`,
+          });
+          return;
+        }
+      }
       setStatus({
         type: "error",
         message: `Failed: ${err instanceof Error ? err.message : err}`,
@@ -398,8 +425,11 @@ export default function CredentialsStep({ onNext }: CredentialsStepProps) {
             type="button"
             onClick={save}
             disabled={saving || !password || !confirmPassword || (hotspotEnabled && (!hotspotPassword || !confirmHotspotPassword))}
-            className="w-full sm:w-auto px-8 py-3 btn-gradient text-white rounded-lg font-semibold text-sm transition transform hover:scale-105 shadow-lg shadow-[rgba(249,115,22,0.25)] cursor-pointer disabled:opacity-50 disabled:hover:scale-100"
+            className="w-full sm:w-auto px-8 py-3 btn-gradient text-white rounded-lg font-semibold text-sm transition transform hover:scale-105 shadow-lg shadow-[rgba(249,115,22,0.25)] cursor-pointer disabled:opacity-50 disabled:hover:scale-100 flex items-center justify-center gap-2"
           >
+            {saving && (
+              <span aria-hidden="true" className="inline-block w-3.5 h-3.5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+            )}
             {saving ? t("connecting") : t("settings.connect")}
           </button>
         </div>

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -505,7 +505,7 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
       </header>
 
       <main
-        className="flex-1 min-h-0 overflow-y-auto flex flex-col items-center px-4 pt-2 pb-4 sm:p-6"
+        className="flex-1 min-h-0 overflow-y-auto flex flex-col items-center px-4 pt-2 pb-24 sm:p-6"
       >
         <div className="w-full flex flex-col items-center my-auto">
         {completionStarted ? (

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -311,11 +311,11 @@ export async function getTargetVersion(): Promise<string | null> {
   if (Date.now() - targetVersionCacheTime < TARGET_VERSION_CACHE_TTL) return cachedTargetVersion;
   try {
     await execShell(
-      "git -c safe.directory=/home/clawbox/clawbox -C /home/clawbox/clawbox fetch --quiet --tags origin",
+      `git -c safe.directory=${PROJECT_DIR} -C ${PROJECT_DIR} fetch --quiet --tags origin`,
       { timeout: 20_000 },
     ).catch(() => {});
     const { stdout } = await execShell(
-      "git -c safe.directory=/home/clawbox/clawbox -C /home/clawbox/clawbox ls-remote --tags --refs origin",
+      `git -c safe.directory=${PROJECT_DIR} -C ${PROJECT_DIR} ls-remote --tags --refs origin`,
       { timeout: 10_000 },
     );
     const tags = stdout
@@ -337,7 +337,7 @@ export async function getTargetVersion(): Promise<string | null> {
     for (let i = semverTags.length - 1; i >= 0; i--) {
       const tag = semverTags[i];
       const isForward = await execShell(
-        `git -c safe.directory=/home/clawbox/clawbox -C /home/clawbox/clawbox merge-base --is-ancestor HEAD refs/tags/${tag}`,
+        `git -c safe.directory=${PROJECT_DIR} -C ${PROJECT_DIR} merge-base --is-ancestor HEAD refs/tags/${tag}`,
         { timeout: 10_000 },
       ).then(() => true).catch(() => false);
       if (isForward) {


### PR DESCRIPTION
## Summary

Bundle of small fixes discovered while walking through a fresh factory-reset on a Jetson device.

- **`install.sh`**: invoke `chpasswd` via absolute `/usr/sbin/chpasswd` so the `clawbox-root-update@chpasswd.service` step doesn't fail with `command not found` (systemd's PATH doesn't include `/usr/sbin`). This was the reason setup step 3 was failing on fresh installs.
- **`SetupWizard`**: add `pb-24` to the main scroll area on mobile so mobile browser toolbars (Brave, Chrome Android) don't overlap the bottom content.
- **`CredentialsStep`**:
  - Show an aria-hidden spinner inside the Connect button while saving (was just a text label flip before).
  - Build the new-hostname redirect URL via the `URL` API instead of string concatenation — more robust for edge cases.
  - On `TypeError: Failed to fetch` during save, **probe the new mDNS URL with a HEAD request (5s timeout) before redirecting**; if unreachable, surface a visible error message with the target URL instead of stranding the user on a dead hostname.
- **`updater.ts`**: use the existing `PROJECT_DIR` constant in all `git` invocations instead of hardcoded `/home/clawbox/clawbox` (three call sites).

## Test plan

- [ ] Factory reset → walk through setup → step 3 (Credentials) completes without the chpasswd service error.
- [ ] Change the hostname during step 3 → page follows the new `<newname>.local` URL cleanly.
- [ ] Step 3 Connect button shows a spinning ring next to "Connecting…".
- [ ] On mobile Chrome/Brave, step 5 (Local AI) bottom content is not hidden behind the browser toolbar when the card is tall.
- [ ] `bun run test src/tests/unit/updater.test.ts` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)