### PR TITLE
Mobile-friendly desktop, Settings polish, lock screen redesign

### DIFF
--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -39,7 +39,7 @@ test("settings covers appearance, network, ai, local ai, telegram, system, and a
   await settingsWindow.getByRole("button", { name: "Available Networks" }).click();
   await settingsWindow.getByRole("button", { name: "Guest Network" }).click();
   await settingsWindow.getByPlaceholder("Enter WiFi password").fill("guest-pass");
-  await settingsWindow.getByRole("button", { name: /^Connect$/ }).first().click();
+  await settingsWindow.getByRole("button", { name: /Connect$/ }).last().click();
   await expect(settingsWindow.getByText("Guest Network").first()).toBeVisible();
 
   await settingsWindow.getByRole("button", { name: "AI Provider" }).click();

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -70,7 +70,7 @@ test("settings covers appearance, network, ai, local ai, telegram, system, and a
   await expect(settingsWindow.getByText("Bot Connected").last()).toBeVisible();
 
   await settingsWindow.getByRole("button", { name: "System" }).click();
-  await expect(settingsWindow.getByText("clawbox")).toBeVisible();
+  await expect(settingsWindow.getByText("clawbox", { exact: true })).toBeVisible();
   await expect(settingsWindow.getByText("Ubuntu 24.04")).toBeVisible();
 
   await settingsWindow.getByRole("button", { name: "About" }).click();

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -39,7 +39,7 @@ test("settings covers appearance, network, ai, local ai, telegram, system, and a
   await settingsWindow.getByRole("button", { name: "Available Networks" }).click();
   await settingsWindow.getByRole("button", { name: "Guest Network" }).click();
   await settingsWindow.getByPlaceholder("Enter WiFi password").fill("guest-pass");
-  await settingsWindow.getByRole("button", { name: "Connect" }).click();
+  await settingsWindow.getByRole("button", { name: /^Connect$/ }).first().click();
   await expect(settingsWindow.getByText("Guest Network").first()).toBeVisible();
 
   await settingsWindow.getByRole("button", { name: "AI Provider" }).click();

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -67,7 +67,7 @@ test("settings covers appearance, network, ai, local ai, telegram, system, and a
   await settingsWindow.getByRole("button", { name: "Telegram" }).click();
   await settingsWindow.locator("#settings-tg-token").fill("123456789:ABCdefGHI");
   await settingsWindow.getByRole("button", { name: /Connect$/ }).click();
-  await expect(settingsWindow.getByText("Bot Connected")).toBeVisible();
+  await expect(settingsWindow.getByText("Bot Connected").last()).toBeVisible();
 
   await settingsWindow.getByRole("button", { name: "System" }).click();
   await expect(settingsWindow.getByText("clawbox")).toBeVisible();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -63,10 +63,17 @@ body {
   overflow-x: hidden;
   /* Prevent pull-to-refresh on mobile */
   overscroll-behavior-y: contain;
+  background: var(--background);
+}
+
+:fullscreen {
+  background: var(--background);
+}
+::backdrop {
+  background: var(--background);
 }
 
 body {
-  background: var(--background);
   color: var(--foreground);
   font-family: var(--font-body);
   /* Safe area padding for notch/rounded corners */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
-  interactiveWidget: "resizes-content",
+  interactiveWidget: "resizes-visual",
   viewportFit: "cover",
   themeColor: "#0a0f1a",
 };

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -19,6 +19,13 @@ function LoginForm() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [ready, setReady] = useState(false);
+  const [now, setNow] = useState<Date | null>(null);
+
+  useEffect(() => {
+    setNow(new Date());
+    const id = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(id);
+  }, []);
 
   // Incomplete setups should always resume on the dedicated setup route.
   useEffect(() => {
@@ -98,94 +105,109 @@ function LoginForm() {
     );
   }
 
+  const timeStr = now
+    ? now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", hour12: false })
+    : "";
+  const dateStr = now
+    ? now.toLocaleDateString([], { weekday: "long", day: "numeric", month: "long" })
+    : "";
+
   return (
-    <div className="min-h-screen flex items-center justify-center p-4" style={{ background: "var(--bg-deep)" }}>
-      <div className="w-full max-w-[380px]">
-        <div className="card-surface rounded-2xl p-8">
-          <div className="flex flex-col items-center gap-3 mb-6">
-            <Image src="/clawbox-crab.png" alt="ClawBox" width={120} height={120} className="w-[120px] h-[120px] object-contain animate-welcome-powerup" priority />
-            <h1 className="text-xl font-bold font-display text-[var(--text-primary)]">
-              ClawBox
-            </h1>
-            <p className="text-sm text-[var(--text-muted)]">
-              {t("login.subtitle")}
-            </p>
+    <div
+      className="flex flex-col items-center justify-between sm:justify-center px-5 py-6 sm:py-12 relative overflow-hidden"
+      style={{
+        minHeight: "100dvh",
+        background: "radial-gradient(ellipse at top, rgba(249,115,22,0.15), transparent 60%), radial-gradient(ellipse at bottom, rgba(249,115,22,0.08), transparent 50%), var(--bg-deep)",
+      }}
+    >
+      {/* Mobile clock — hidden on desktop where the card is centered */}
+      <div className="flex flex-col items-center gap-1 pt-8 sm:hidden" aria-hidden="true">
+        <div className="text-[64px] font-light text-white tabular-nums leading-none">{timeStr}</div>
+        <div className="text-sm text-white/60 capitalize">{dateStr}</div>
+      </div>
+
+      <div className="w-full max-w-[380px] flex flex-col items-center gap-6">
+        <div className="flex flex-col items-center gap-3">
+          <Image src="/clawbox-crab.png" alt="ClawBox" width={96} height={96} className="w-24 h-24 sm:w-[120px] sm:h-[120px] object-contain animate-welcome-powerup" priority />
+          <h1 className="text-2xl font-bold font-display text-white">ClawBox</h1>
+          <p className="text-sm text-white/50 text-center">{t("login.subtitle")}</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="w-full flex flex-col gap-4">
+          <div>
+            <label htmlFor="login-password" className="sr-only">{t("login.password")}</label>
+            <div className="relative">
+              <input
+                id="login-password"
+                type={showPassword ? "text" : "password"}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder={t("login.passwordPlaceholder")}
+                autoFocus
+                autoComplete="current-password"
+                className="w-full h-12 px-4 pr-12 bg-white/[0.06] border border-white/10 rounded-xl text-base text-white outline-none focus:border-[var(--coral-bright)] focus:bg-white/[0.08] transition-colors placeholder-white/30"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                aria-label={showPassword ? t("login.hidePassword") : t("login.showPassword")}
+                className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center w-10 h-10 text-white/40 hover:text-white bg-transparent border-none cursor-pointer"
+              >
+                <span className="material-symbols-rounded" style={{ fontSize: 20 }}>
+                  {showPassword ? "visibility_off" : "visibility"}
+                </span>
+              </button>
+            </div>
           </div>
 
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <div>
-              <label
-                htmlFor="login-password"
-                className="block text-xs font-semibold text-[var(--text-secondary)] mb-1.5"
-              >
-                {t("login.password")}
-              </label>
-              <div className="relative">
-                <input
-                  id="login-password"
-                  type={showPassword ? "text" : "password"}
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  placeholder={t("login.passwordPlaceholder")}
-                  autoFocus
-                  autoComplete="current-password"
-                  className="w-full px-3.5 py-2.5 pr-10 bg-[var(--bg-deep)] border border-gray-600 rounded-lg text-sm text-gray-200 outline-none focus:border-[var(--coral-bright)] transition-colors placeholder-gray-500"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  aria-label={showPassword ? t("login.hidePassword") : t("login.showPassword")}
-                  className="absolute right-2.5 top-1/2 -translate-y-1/2 text-[var(--text-muted)] hover:text-[var(--text-primary)] bg-transparent border-none cursor-pointer p-0.5"
-                >
-                  <span className="material-symbols-rounded" style={{ fontSize: 18 }}>
-                    {showPassword ? "visibility_off" : "visibility"}
-                  </span>
-                </button>
-              </div>
-            </div>
-
-            <div>
-              <label
-                htmlFor="login-duration"
-                className="block text-xs font-semibold text-[var(--text-secondary)] mb-1.5"
-              >
-                {t("login.duration")}
-              </label>
-              <select
-                id="login-duration"
-                value={duration}
-                onChange={(e) => setDuration(Number(e.target.value))}
-                className="w-full px-3.5 py-2.5 bg-[var(--bg-deep)] border border-gray-600 rounded-lg text-sm text-gray-200 outline-none focus:border-[var(--coral-bright)] transition-colors cursor-pointer appearance-none"
-                style={{
-                  backgroundImage: `url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='%236b7280'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E")`,
-                  backgroundRepeat: "no-repeat",
-                  backgroundPosition: "right 12px center",
-                }}
-              >
-                {DURATION_OPTIONS.map((opt) => (
-                  <option key={opt.value} value={opt.value}>
+          <div>
+            <span className="block text-[11px] font-semibold text-white/40 uppercase tracking-widest mb-2">
+              {t("login.duration")}
+            </span>
+            <div className="grid grid-cols-4 gap-1.5" role="radiogroup" aria-label={t("login.duration")}>
+              {DURATION_OPTIONS.map((opt) => {
+                const active = duration === opt.value;
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={active}
+                    onClick={() => setDuration(opt.value)}
+                    className={`h-10 rounded-lg text-xs font-medium transition-colors cursor-pointer border ${
+                      active
+                        ? "bg-[var(--coral-bright)]/20 text-[var(--coral-bright)] border-[var(--coral-bright)]/40"
+                        : "bg-white/[0.04] text-white/60 border-white/[0.08] hover:bg-white/[0.08] hover:text-white/80"
+                    }`}
+                  >
                     {t(opt.labelKey)}
-                  </option>
-                ))}
-              </select>
+                  </button>
+                );
+              })}
             </div>
+          </div>
 
-            {error && (
-              <div className="px-3.5 py-2.5 rounded-lg text-xs bg-red-500/10 text-red-400 border border-red-500/20">
-                {error}
-              </div>
+          {error && (
+            <div className="px-3.5 py-2.5 rounded-lg text-xs bg-red-500/10 text-red-400 border border-red-500/20">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || !password.trim()}
+            className="w-full h-12 btn-gradient text-white rounded-xl text-base font-semibold transition transform active:scale-[0.98] hover:scale-[1.02] shadow-lg shadow-[rgba(249,115,22,0.25)] disabled:opacity-50 disabled:hover:scale-100 cursor-pointer flex items-center justify-center gap-2"
+          >
+            {loading && (
+              <span aria-hidden="true" className="inline-block w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
             )}
-
-            <button
-              type="submit"
-              disabled={loading || !password.trim()}
-              className="w-full py-3 btn-gradient text-white rounded-lg text-sm font-semibold transition transform hover:scale-[1.02] shadow-lg shadow-[rgba(249,115,22,0.25)] disabled:opacity-50 disabled:hover:scale-100 cursor-pointer"
-            >
-              {loading ? t("login.loggingIn") : t("login.logIn")}
-            </button>
-          </form>
-        </div>
+            {loading ? t("login.loggingIn") : t("login.logIn")}
+          </button>
+        </form>
       </div>
+
+      {/* Spacer for mobile bottom alignment */}
+      <div className="sm:hidden" aria-hidden="true" />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import dynamic from "next/dynamic";
 import * as kv from "@/lib/client-kv";
 import ChromeShelf from "@/components/ChromeShelf";
@@ -418,7 +418,7 @@ function ChromeDesktopInner() {
   }, [iconPositions]);
 
   const handleGridPointerDown = useCallback((e: React.PointerEvent) => {
-    // Only start marquee on left click directly on the grid (not on icons)
+    if (isMobile) return;
     if (e.button !== 0) return;
     if ((e.target as HTMLElement).closest("button")) return;
     setSelectedIcons(new Set());
@@ -572,10 +572,30 @@ function ChromeDesktopInner() {
     arrangeIcons();
   }, [installedApps, hiddenInstalledApps, desktopApps, GRID_COLS]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Get icon position (should always be in iconPositions after effect runs)
+  // Get icon position. On mobile we ignore the persisted desktop layout
+  // (which was built around a single left-aligned column) and lay icons out
+  // in a grid that fills the viewport row-by-row, like a phone home screen.
+  const mobileIconOrder = useMemo(() => {
+    if (!isMobile) return null;
+    const visibleInstalled = installedApps.filter((id) => !hiddenInstalledApps.includes(id));
+    const builtinIds = desktopApps.map((id) => `desktop-${id}`);
+    const all = [...visibleInstalled, ...builtinIds];
+    all.sort((a, b) => {
+      const pa = iconPositions[a] || { row: 999, col: 999 };
+      const pb = iconPositions[b] || { row: 999, col: 999 };
+      return pa.row !== pb.row ? pa.row - pb.row : pa.col - pb.col;
+    });
+    const map: Record<string, { row: number; col: number }> = {};
+    all.forEach((id, i) => {
+      map[id] = { row: Math.floor(i / GRID_COLS), col: i % GRID_COLS };
+    });
+    return map;
+  }, [isMobile, installedApps, hiddenInstalledApps, desktopApps, iconPositions, GRID_COLS]);
+
   const getIconPosition = useCallback((appId: string, _index: number) => {
+    if (mobileIconOrder && mobileIconOrder[appId]) return mobileIconOrder[appId];
     return iconPositions[appId] || { row: 0, col: 0 };
-  }, [iconPositions]);
+  }, [iconPositions, mobileIconOrder]);
 
   const isGridCellOccupied = useCallback((row: number, col: number, excludeId?: string) => {
     return Object.entries(iconPositions).some(
@@ -595,12 +615,15 @@ function ChromeDesktopInner() {
   }, []);
 
   const handleIconDragStart = useCallback((appId: string, e: React.PointerEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
+    if (!isMobile) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    let mobileSynced = false;
     const startX = e.clientX;
     const startY = e.clientY;
     let isDragging = false;
-    const DRAG_THRESHOLD = 8; // px before drag activates
+    const DRAG_THRESHOLD = isMobile ? 20 : 8;
     // Check if this icon is part of a multi-selection
     const isGroupDrag = selectedIcons.size > 1 && selectedIcons.has(appId);
     const groupIds = isGroupDrag ? Array.from(selectedIcons) : [appId];
@@ -628,6 +651,12 @@ function ChromeDesktopInner() {
       if (!isDragging && Math.abs(dx) + Math.abs(dy) < DRAG_THRESHOLD) return;
       if (!isDragging) {
         isDragging = true;
+        // Sync mobile-computed positions into iconPositions only once a real
+        // drag starts, so taps don't trigger redundant state writes.
+        if (isMobile && mobileIconOrder && !mobileSynced) {
+          mobileSynced = true;
+          setIconPositions(mobileIconOrder);
+        }
         if (longPressTimer.current) { clearTimeout(longPressTimer.current); longPressTimer.current = undefined; }
         setDraggingIcon(appId);
       }
@@ -723,7 +752,7 @@ function ChromeDesktopInner() {
     };
     window.addEventListener("pointermove", onMove);
     window.addEventListener("pointerup", onUp);
-  }, [snapToGrid, isGridCellOccupied, selectedIcons]);
+  }, [snapToGrid, isGridCellOccupied, selectedIcons, isMobile, mobileIconOrder, GRID_COLS]);
 
 
   // Update clock
@@ -1242,24 +1271,6 @@ function ChromeDesktopInner() {
   const allApps = getAllApps();
   const allAppsForLauncher = allApps.filter((app) => app.id !== "setup");
 
-  // ─── Mobile fullscreen splash (every load) ───
-  const [showSplash, setShowSplash] = useState(() => {
-    if (typeof window === "undefined") return false;
-    const isMobileUA = /Android|iPhone|iPad/i.test(navigator.userAgent);
-    const isStandalone = window.matchMedia("(display-mode: standalone)").matches;
-    // Show on mobile browsers, not standalone PWA, not already fullscreen
-    return isMobileUA && !isStandalone && !document.fullscreenElement;
-  });
-
-  const handleSplashTap = useCallback(() => {
-    document.documentElement.requestFullscreen().catch(() => {});
-    setShowSplash(false);
-  }, []);
-
-  const dismissSplash = useCallback(() => {
-    setShowSplash(false);
-  }, []);
-
   // ─── Global drag-and-drop file upload ───
   const [desktopDragOver, setDesktopDragOver] = useState(false);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
@@ -1504,29 +1515,6 @@ function ChromeDesktopInner() {
           )}
         </div>
       )}
-      {/* Mobile fullscreen splash */}
-      {showSplash && (
-        <div
-          className="fixed inset-0 z-[99999] flex flex-col items-center justify-center bg-[#0a0f1a] cursor-pointer"
-          onClick={handleSplashTap}
-        >
-          <img src="/icon-512.png" alt="ClawBox" className="w-24 h-24 rounded-3xl mb-6 shadow-2xl" />
-          <h1 className="text-2xl font-bold text-white mb-2">ClawBox</h1>
-          <p className="text-white/50 text-sm mb-8">Personal AI Assistant</p>
-          <div className="flex flex-col items-center gap-3">
-            <div className="px-8 py-3 rounded-xl bg-orange-500 text-white font-semibold text-base shadow-lg">
-              Tap to Enter Fullscreen
-            </div>
-            <button
-              onClick={(e) => { e.stopPropagation(); dismissSplash(); }}
-              className="text-white/30 text-xs hover:text-white/50 bg-transparent border-none cursor-pointer mt-2"
-            >
-              Skip
-            </button>
-          </div>
-        </div>
-      )}
-
       {/* Desktop wallpaper background */}
       {(() => {
         const customIdx = wallpaperId.startsWith("custom-") ? parseInt(wallpaperId.split("-")[1]) : -1;
@@ -1552,8 +1540,8 @@ function ChromeDesktopInner() {
       {/* Hidden file input for wallpaper upload */}
       <input ref={wallpaperInputRef} type="file" accept="image/*" className="hidden" onChange={handleWallpaperUpload} />
       {/* Desktop icon grid — draggable + right-click surface */}
-      <div className="absolute inset-0 z-[1] flex justify-center" style={{ paddingBottom: 56, paddingTop: 24 }} onContextMenu={handleDesktopContextMenu} onPointerDown={handleGridPointerDown}>
-      <div ref={gridRef} className="relative" style={{ width: GRID_COLS * CELL_W, maxWidth: "100%" }}>
+      <div className="absolute inset-0 z-[1] flex justify-center" style={{ paddingBottom: 56, paddingTop: 24, overflowY: isMobile ? "auto" : "visible" }} onContextMenu={handleDesktopContextMenu} onPointerDown={handleGridPointerDown}>
+      <div ref={gridRef} className="relative" style={{ width: GRID_COLS * CELL_W, maxWidth: "100%", height: isMobile && mobileIconOrder ? `${(Math.floor((Object.keys(mobileIconOrder).length - 1) / GRID_COLS) + 1) * CELL_H}px` : undefined }}>
         {installedAppDefs.map((app, i) => {
           const pos = getIconPosition(app.id, i);
           const isBeingDragged = draggingIcon === app.id;
@@ -1725,10 +1713,10 @@ function ChromeDesktopInner() {
       </div>
 
       {/* Mascot - tapping toggles chat popup, hidden when chat is docked as panel */}
-      {chatPanelWidth === 0 && (
+      {chatPanelWidth === 0 && !isMobile && (
         <Mascot frozen={chatOpen} onTap={(x?: number) => { if (x !== undefined) setMascotX(x); setChatOpen(prev => !prev); }} onPositionChange={chatOpen ? setMascotX : undefined} />
       )}
-      <ChatPopup isOpen={chatOpen} onClose={() => setChatOpen(false)} onOpenSettingsSection={openSettingsSection} onPanelModeChange={handleChatPanelModeChange} initialPanelWidth={chatPanelWidth} mascotX={mascotHidden ? 85 : mascotX} trayMode={mascotHidden} />
+      <ChatPopup isOpen={chatOpen} onClose={() => setChatOpen(false)} onOpenSettingsSection={openSettingsSection} onPanelModeChange={handleChatPanelModeChange} initialPanelWidth={chatPanelWidth} mascotX={mascotHidden ? 85 : mascotX} trayMode={mascotHidden} mobile={isMobile} />
 
       {/* Windows — mobile: fullscreen, desktop: ChromeWindow */}
       {isMobile ? (
@@ -1934,7 +1922,7 @@ function ChromeDesktopInner() {
         }}
         onShelfSettings={() => openApp("settings")}
         onChatClick={() => setChatOpen(prev => !prev)}
-        showChatButton={mascotHidden}
+        showChatButton={mascotHidden || isMobile}
         time={time}
       />
 

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -1331,7 +1331,7 @@ export default function AIModelsStep({
   const embeddedConnectLabel = t("settings.connect");
 
   return (
-    <div className="w-full max-w-[520px]" data-testid={testId}>
+    <div className={`w-full ${embedded ? "" : "max-w-[520px]"}`} data-testid={testId}>
       <div className="card-surface rounded-2xl p-5 sm:p-8 relative overflow-hidden">
         <ClawAIOfferModal
           open={showClawAIOffer && !configuringState}

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -796,7 +796,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const posStyle: React.CSSProperties = panelMode
     ? { right: 0, top: 0, bottom: 56 }
     : mobile
-      ? { left: 0, top: 0, right: 0, bottom: 220 }
+      ? { left: 0, top: 0, right: 0, bottom: 0 }
       : pos
         ? { left: pos.x, top: pos.y, bottom: 'auto' }
         : trayMode

--- a/src/components/ChromeLauncher.tsx
+++ b/src/components/ChromeLauncher.tsx
@@ -83,7 +83,10 @@ export default function ChromeLauncher({
         setAnimationState("opening");
         focusTimer = window.setTimeout(() => {
           setAnimationState("open");
-          searchRef.current?.focus();
+          // Skip auto-focus on touch/mobile so the soft keyboard doesn't pop
+          // up automatically (causing a viewport gap above the keyboard).
+          const isTouch = typeof window !== "undefined" && (window.matchMedia("(hover: none) and (pointer: coarse)").matches || window.innerWidth < 768);
+          if (!isTouch) searchRef.current?.focus();
         }, 50);
       }, 0);
     } else if (!isOpen && prevOpenRef.current) {
@@ -194,9 +197,9 @@ export default function ChromeLauncher({
 
       {/* Launcher panel */}
       <div
-        style={{ maxWidth: gridCols * 100 + 32 }}
+        style={{ maxWidth: gridCols * 100 + 32, bottom: 56 }}
         data-testid="app-launcher"
-        className={`fixed bottom-14 left-1/2 -translate-x-1/2 w-full z-[9999] transition-all duration-200 ${
+        className={`fixed left-1/2 -translate-x-1/2 w-full z-[9999] transition-all duration-200 ${
           isClosing ? "translate-y-full opacity-0 pointer-events-none" : "translate-y-0 opacity-100"
         }`}
         onKeyDown={handleKeyDown}

--- a/src/components/ChromeShelf.tsx
+++ b/src/components/ChromeShelf.tsx
@@ -88,8 +88,16 @@ export default function ChromeShelf({
     };
   }, [ctxMenu, shelfMenu]);
 
-  const pinnedApps = apps.filter(a => a.isPinned !== false);
-  const unpinnedApps = apps.filter(a => a.isPinned === false);
+  // Pinned apps already live on the mobile home grid; the bottom bar would
+  // overflow past the visible area on narrow phones if we duplicated them
+  // here. On mobile keep only Settings pinned (frequent system access),
+  // show full set on desktop.
+  const pinnedApps = isMobile
+    ? apps.filter(a => a.id === "settings" && a.isPinned !== false)
+    : apps.filter(a => a.isPinned !== false);
+  const unpinnedApps = isMobile
+    ? apps.filter(a => a.isOpen && a.id !== "settings")
+    : apps.filter(a => a.isPinned === false);
 
   const renderApp = (app: ShelfApp) => (
     <button
@@ -158,7 +166,64 @@ export default function ChromeShelf({
           setShelfMenu({ x: e.clientX, y: e.clientY });
         }}
       >
-        {/* Launcher button — left on mobile, inline on desktop */}
+        {isMobile ? (
+          <>
+            {/* Mobile: launcher (left), chat (center), clock + fullscreen + power (right) */}
+            <div className="absolute left-2 flex items-center">
+              <button
+                onClick={onLauncherClick}
+                className="w-11 h-11 flex items-center justify-center rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+                title={t("shelf.appLauncher")}
+                aria-label={t("shelf.appLauncher")}
+                data-testid="shelf-launcher-button"
+              >
+                <div className="w-10 h-10 rounded-full flex items-center justify-center bg-gradient-to-br from-white/20 to-white/5 border border-white/10">
+                  <span className="material-symbols-rounded text-white/80" style={{ fontSize: 22 }}>apps</span>
+                </div>
+              </button>
+            </div>
+            {showChatButton && (
+              <button
+                onClick={onChatClick}
+                className="flex items-center justify-center w-12 h-12 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+                title={t("shelf.chat")}
+                aria-label={t("shelf.chat")}
+              >
+                <img src="/clawbox-crab.png" alt="Chat" className="w-12 h-12 object-contain" />
+              </button>
+            )}
+            <div className="absolute right-2 flex items-center gap-1">
+              <button
+                onClick={onTrayClick}
+                className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+                title={t("shelf.systemSettings")}
+                aria-label={t("shelf.systemSettings")}
+                data-testid="shelf-tray-button"
+              >
+                <span className="text-xs text-white/80 font-medium tabular-nums">{time}</span>
+              </button>
+              <button
+                onClick={toggleFullscreen}
+                className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+                title={isFullscreen ? t("shelf.exitFullscreen") : t("shelf.fullscreen")}
+              >
+                <span className="material-symbols-rounded text-white/60" style={{ fontSize: 18 }}>
+                  {isFullscreen ? "fullscreen_exit" : "fullscreen"}
+                </span>
+              </button>
+              <button
+                onClick={onPowerClick}
+                className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+                title={t("shelf.power")}
+                aria-label={t("shelf.power")}
+                data-testid="shelf-power-button"
+              >
+                <span className="material-symbols-rounded text-white/60" style={{ fontSize: 18 }}>power_settings_new</span>
+              </button>
+            </div>
+          </>
+        ) : <>
+        {/* Launcher button — left, mobile only (desktop renders it inline) */}
         <div className="absolute left-2 flex items-center sm:hidden">
           <button
             onClick={onLauncherClick}
@@ -173,7 +238,7 @@ export default function ChromeShelf({
           </button>
         </div>
 
-        {/* Centered: pinned apps + open apps (launcher inline on desktop) */}
+        {/* Centered: pinned + open apps */}
         <div className="flex items-center gap-1">
           {/* Launcher button — desktop only (inline) */}
           <button
@@ -217,24 +282,22 @@ export default function ChromeShelf({
           )}
           <button
             onClick={onTrayClick}
-            className="flex items-center h-10 px-3 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+            className="hidden sm:flex items-center h-10 px-3 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
             title={t("shelf.systemSettings")}
             aria-label={t("shelf.systemSettings")}
             data-testid="shelf-tray-button"
           >
-            <span className="text-sm text-white/80 font-medium hidden sm:inline">{time}</span>
+            <span className="text-sm text-white/80 font-medium">{time}</span>
           </button>
-          {isMobile && (
-            <button
-              onClick={toggleFullscreen}
-              className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
-              title={isFullscreen ? t("shelf.exitFullscreen") : t("shelf.fullscreen")}
-            >
-              <span className="material-symbols-rounded text-white/60" style={{ fontSize: 18 }}>
-                {isFullscreen ? "fullscreen_exit" : "fullscreen"}
-              </span>
-            </button>
-          )}
+          <button
+            onClick={toggleFullscreen}
+            className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
+            title={isFullscreen ? t("shelf.exitFullscreen") : t("shelf.fullscreen")}
+          >
+            <span className="material-symbols-rounded text-white/60" style={{ fontSize: 18 }}>
+              {isFullscreen ? "fullscreen_exit" : "fullscreen"}
+            </span>
+          </button>
           <button
             onClick={onPowerClick}
             className="flex items-center justify-center w-10 h-10 rounded-full hover:bg-white/10 active:bg-white/15 transition-colors cursor-pointer"
@@ -245,6 +308,7 @@ export default function ChromeShelf({
             <span className="material-symbols-rounded text-white/60" style={{ fontSize: 18 }}>power_settings_new</span>
           </button>
         </div>
+        </>}
       </div>
 
       {/* Shelf context menu */}

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -102,6 +102,7 @@ function Toggle({ on, onToggle, label }: { on: boolean; onToggle: (v: boolean) =
   );
 }
 
+type SectionStatus = { subtitle: string | null; dot: "ok" | "warn" | null };
 
 export default function SettingsApp({ ui }: SettingsAppProps) {
   const { t, locale, setLocale } = useT();
@@ -769,9 +770,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   /* ── AI Provider ── */
   const [aiProvider, setAiProvider] = useState<{ connected: boolean; provider: string | null; providerLabel: string | null; mode: string | null; model: string | null } | null>(null);
   useEffect(() => {
-    if (section !== "ai") return;
+    if (section !== "ai" && !isMobile) return;
     fetch("/setup-api/ai-models/status", { cache: "no-store" }).then(r => r.json()).then(setAiProvider).catch(() => {});
-  }, [section]);
+  }, [section, isMobile]);
   const [localAiStatus, setLocalAiStatus] = useState<{ configured: boolean; provider: string | null; model: string | null; running: boolean | null; standbyEnabled: boolean } | null>(null);
   const [localAiDisabling, setLocalAiDisabling] = useState(false);
   const [localAiError, setLocalAiError] = useState<string | null>(null);
@@ -823,13 +824,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     }
   }, [notifyChatModelStateChanged, refreshLocalAiStatus]);
   useEffect(() => {
-    if (section !== "localAi") return;
+    if (section !== "localAi" && !isMobile) return;
     refreshLocalAiStatus();
+    if (section !== "localAi") return;
     const interval = setInterval(() => {
       refreshLocalAiStatus().catch(() => {});
     }, 5000);
     return () => clearInterval(interval);
-  }, [refreshLocalAiStatus, section]);
+  }, [refreshLocalAiStatus, section, isMobile]);
 
   /* ── Telegram ── */
   const [tgToken, setTgToken] = useState("");
@@ -842,7 +844,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   const tgSaveControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    if (section !== "telegram") return;
+    if (section !== "telegram" && !isMobile) return;
     fetch("/setup-api/telegram/status").then(r => r.json()).then(d => {
       setTgConfigured(d.configured ?? false);
       if (d.configured && d.username) {
@@ -851,7 +853,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         setTgBotInfo(null);
       }
     }).catch(() => setTgConfigured(false));
-  }, [section]);
+  }, [section, isMobile]);
 
   const saveTelegram = async () => {
     if (!tgToken.trim()) {
@@ -1055,8 +1057,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     <>
         {/* ─── Appearance ─── */}
         {activeSection === "appearance" && (
-          <div className="max-w-2xl space-y-5">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t("settings.appearance")}</h2>
+          <div className="max-w-xl space-y-5">
 
             {/* Wallpaper card */}
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
@@ -1255,8 +1256,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {/* ─── Network ─── */}
         {activeSection === "wifi" && (
-          <div className="max-w-lg space-y-5">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t("settings.network")}</h2>
+          <div className="max-w-xl space-y-5">
 
             {/* Connection status card */}
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
@@ -1644,8 +1644,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {/* ─── AI Provider ─── */}
         {activeSection === "ai" && (
-          <div className="max-w-lg space-y-5">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t("settings.aiProvider")}</h2>
+          <div className="max-w-xl space-y-5">
 
             {/* Provider status card */}
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
@@ -1654,9 +1653,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</label>
               </div>
               {aiProvider === null ? (
-                <div className="flex items-center gap-3 text-[var(--text-muted)] text-sm">
-                  <div className="w-5 h-5 border-2 border-white/15 border-t-[var(--coral-bright)] rounded-full animate-spin" />
-                  {t("settings.checking")}
+                <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5 animate-pulse">
+                  <div className="w-10 h-10 rounded-full bg-white/[0.08] shrink-0" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-3 w-32 rounded bg-white/[0.08]" />
+                    <div className="h-2 w-20 rounded bg-white/[0.06]" />
+                  </div>
                 </div>
               ) : aiProvider.connected ? (
                 <div className="flex items-center gap-4 bg-green-500/[0.06] border border-green-500/15 rounded-xl px-4 py-3.5">
@@ -1709,8 +1711,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {/* ─── Local AI ─── */}
         {activeSection === "localAi" && (
-          <div className="max-w-lg space-y-5">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">Local AI</h2>
+          <div className="max-w-xl space-y-5">
 
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
               <div className="flex items-center gap-2 mb-4">
@@ -1718,9 +1719,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</label>
               </div>
               {localAiStatus === null ? (
-                <div className="flex items-center gap-3 text-[var(--text-muted)] text-sm">
-                  <div className="w-5 h-5 border-2 border-white/15 border-t-[var(--coral-bright)] rounded-full animate-spin" />
-                  {t("settings.checking")}
+                <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5 animate-pulse">
+                  <div className="w-10 h-10 rounded-full bg-white/[0.08] shrink-0" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-3 w-32 rounded bg-white/[0.08]" />
+                    <div className="h-2 w-20 rounded bg-white/[0.06]" />
+                  </div>
                 </div>
               ) : localAiStatus.configured ? (
                 <div className={`flex items-center gap-4 rounded-xl px-4 py-3.5 border ${
@@ -1837,8 +1841,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {/* ─── Telegram ─── */}
         {activeSection === "telegram" && (
-          <div className="max-w-lg space-y-5">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t("settings.telegram")}</h2>
+          <div className="max-w-xl space-y-5">
 
             {/* Status card */}
             <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
@@ -1847,9 +1850,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">{t("settings.status")}</label>
               </div>
               {tgConfigured === null ? (
-                <div className="flex items-center gap-3 text-[var(--text-muted)] opacity-60 text-sm">
-                  <div className="w-5 h-5 border-2 border-white/15 border-t-orange-400 rounded-full animate-spin" />
-                  {t("settings.checking")}
+                <div className="flex items-center gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5 animate-pulse">
+                  <div className="w-10 h-10 rounded-full bg-white/[0.08] shrink-0" />
+                  <div className="flex-1 space-y-2">
+                    <div className="h-3 w-32 rounded bg-white/[0.08]" />
+                    <div className="h-2 w-20 rounded bg-white/[0.06]" />
+                  </div>
                 </div>
               ) : tgConfigured && !tgReconfigure ? (
                 <div>
@@ -2010,8 +2016,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {/* ─── System ─── */}
         {activeSection === "system" && (
-          <div className="max-w-2xl space-y-5">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)]">{t("settings.system")}</h2>
+          <div className="max-w-xl space-y-5">
 
             {stats ? (
               <>
@@ -2262,7 +2267,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
         {/* ─── About ─── */}
         {activeSection === "about" && (<>
-          <div className="max-w-md space-y-6">
+          <div className="max-w-xl space-y-6">
             <h2 className="text-lg font-semibold text-[var(--text-primary)] mb-4">{t("settings.aboutClawBox")}</h2>
 
             <div className="bg-white/5 rounded-xl p-5 space-y-4">
@@ -2430,41 +2435,88 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     </>
   );
 
+  // ─── Section status (subtitle + indicator dot) shared by mobile list + desktop sidebar ───
+  // SectionStatus type is declared at module scope (above component)
+  const sectionStatus = (id: Section): SectionStatus => {
+    switch (id) {
+      case "appearance": {
+        const sub = ui.wallpaperId.startsWith("custom-")
+          ? `Custom ${parseInt(ui.wallpaperId.split("-")[1] || "0") + 1}`
+          : ui.wallpaperId;
+        return { subtitle: sub, dot: null };
+      }
+      case "wifi":
+        if (connectedSSID) return { subtitle: connectedSSID, dot: "ok" };
+        if (ethernet.connected) return { subtitle: ethernet.iface ? `Ethernet (${ethernet.iface})` : "Ethernet", dot: "ok" };
+        return { subtitle: t("settings.notConnected") || "Not connected", dot: "warn" };
+      case "ai": {
+        if (aiProvider === null) return { subtitle: null, dot: null };
+        if (!aiProvider.connected) return { subtitle: t("settings.notConfigured") || "Not configured", dot: "warn" };
+        return { subtitle: aiProvider.providerLabel || (aiProvider.model ? aiProvider.model.split("/").pop() ?? null : null), dot: "ok" };
+      }
+      case "localAi": {
+        if (localAiStatus === null) return { subtitle: null, dot: null };
+        if (!localAiStatus.configured) return { subtitle: t("settings.notConfigured") || "Not configured", dot: null };
+        return { subtitle: localAiStatus.model || localAiStatus.provider, dot: localAiStatus.running ? "ok" : "warn" };
+      }
+      case "telegram": {
+        if (tgConfigured === null) return { subtitle: null, dot: null };
+        if (!tgConfigured) return { subtitle: t("settings.notConfigured") || "Not configured", dot: null };
+        return { subtitle: tgBotInfo?.username ? `@${tgBotInfo.username}` : (t("settings.botConnected") || "Connected"), dot: "ok" };
+      }
+      case "system":
+        return { subtitle: hostname ? `${hostname}.local` : null, dot: null };
+      case "about":
+        return { subtitle: versionInfo?.clawbox?.current ? cleanVersion(versionInfo.clawbox.current) : null, dot: null };
+      default:
+        return { subtitle: null, dot: null };
+    }
+  };
+
   // ─── Mobile layout: full-screen nav or full-screen content ───
   if (isMobile) {
     return (
       <div className="flex flex-col h-full bg-[var(--bg-deep)]">
         {mobileSection === null ? (
-          /* Nav list */
-          <div className="flex-1 overflow-y-auto">
-            <h2 className="text-lg font-semibold text-[var(--text-primary)] px-5 pt-4 pb-2">{t("settings.title")}</h2>
-            <nav className="flex flex-col">
-              {NAV_ITEMS.map(item => (
-                <button
-                  key={item.id}
-                  onClick={() => { setSection(item.id); setMobileSection(item.id); }}
-                  className="flex items-center gap-3 px-5 py-3.5 text-sm border-none cursor-pointer transition-colors text-[var(--text-secondary)] hover:bg-white/[0.04] active:bg-white/[0.08]"
-                >
-                  <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 20 }}>{item.icon}</span>
-                  <span className="flex-1 text-left">{navLabel(item)}</span>
-                  <span className="material-symbols-rounded text-[var(--text-muted)] opacity-40" style={{ fontSize: 18 }}>chevron_right</span>
-                </button>
-              ))}
+          /* Nav list — iOS-style grouped rows with status subtitles */
+          <div className="flex-1 overflow-y-auto px-4 pt-4 pb-6">
+            <h2 className="text-2xl font-bold text-[var(--text-primary)] px-1 mb-4">{t("settings.title")}</h2>
+            <nav className="bg-white/[0.04] border border-white/[0.06] rounded-2xl overflow-hidden divide-y divide-white/[0.06]">
+              {NAV_ITEMS.map(item => {
+                const { subtitle } = sectionStatus(item.id);
+                return (
+                  <button
+                    key={item.id}
+                    onClick={() => { setSection(item.id); setMobileSection(item.id); }}
+                    className="flex items-center gap-4 w-full px-4 py-3.5 text-left border-none cursor-pointer transition-colors bg-transparent hover:bg-white/[0.04] active:bg-white/[0.08]"
+                  >
+                    <span className="flex items-center justify-center w-10 h-10 rounded-xl bg-[var(--coral-bright)]/15 shrink-0">
+                      <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 22 }}>{item.icon}</span>
+                    </span>
+                    <span className="flex-1 min-w-0 flex flex-col gap-0.5">
+                      <span className="text-[15px] font-medium text-[var(--text-primary)] leading-tight">{navLabel(item)}</span>
+                      {subtitle && (
+                        <span className="text-xs text-[var(--text-muted)] truncate">{subtitle}</span>
+                      )}
+                    </span>
+                    <span className="material-symbols-rounded text-[var(--text-muted)] opacity-40 shrink-0" style={{ fontSize: 20 }}>chevron_right</span>
+                  </button>
+                );
+              })}
             </nav>
           </div>
         ) : (
-          /* Content with back button */
+          /* Content — chrome back closes window in one tap. A small "All settings"
+              link at the top lets the user switch sections without leaving. */
           <>
-            <div className="flex items-center gap-2 px-3 py-2 border-b border-[var(--border-subtle)] shrink-0">
+            <div className="px-4 pt-3 pb-1 shrink-0">
               <button
                 onClick={() => setMobileSection(null)}
-                className="w-8 h-8 flex items-center justify-center rounded-lg hover:bg-white/10 text-[var(--text-secondary)] cursor-pointer"
+                className="flex items-center gap-1 text-xs text-[var(--coral-bright)] hover:text-orange-300 bg-transparent border-none cursor-pointer p-1"
               >
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M15 18l-6-6 6-6" /></svg>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M15 18l-6-6 6-6" /></svg>
+                <span>{t("settings.title")}</span>
               </button>
-              <span className="text-sm font-medium text-[var(--text-primary)]">
-                {(() => { const nav = NAV_ITEMS.find(i => i.id === mobileSection); return nav ? navLabel(nav) : t("settings.title"); })()}
-              </span>
             </div>
             <div className="flex-1 overflow-y-auto p-4">
               {renderContent()}
@@ -2626,21 +2678,34 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   return (
     <div className="flex h-full bg-[var(--bg-deep)]">
       {/* Sidebar */}
-      <nav className="w-48 shrink-0 bg-[var(--bg-surface)] border-r border-[var(--border-subtle)] py-3 flex flex-col">
+      <nav className="w-60 shrink-0 bg-[var(--bg-surface)] border-r border-[var(--border-subtle)] py-4 px-2 flex flex-col gap-0.5">
         {NAV_ITEMS.map(item => {
           const active = activeSection === item.id;
+          const status = sectionStatus(item.id);
           return (
             <button
               key={item.id}
               onClick={() => setSection(item.id)}
-              className={`flex items-center gap-2.5 px-4 py-2.5 text-sm border-none cursor-pointer transition-colors text-left border-l-2 ${
+              className={`flex items-center gap-3 px-2.5 py-2 rounded-xl text-[15px] border-none cursor-pointer transition-colors text-left ${
                 active
-                  ? "bg-white/[0.08] text-[var(--text-primary)] border-l-[var(--coral-bright)]"
-                  : "text-[var(--text-secondary)] border-l-transparent hover:bg-white/[0.04] hover:text-[var(--text-primary)]"
+                  ? "bg-[var(--coral-bright)]/15 text-[var(--text-primary)]"
+                  : "text-[var(--text-secondary)] hover:bg-white/[0.05] hover:text-[var(--text-primary)]"
               }`}
             >
-              <span className="material-symbols-rounded" style={{ fontSize: 18, color: active ? "var(--coral-bright)" : "var(--text-muted)" }}>{item.icon}</span>
-              {navLabel(item)}
+              <span className={`flex items-center justify-center w-9 h-9 rounded-lg shrink-0 ${active ? "bg-[var(--coral-bright)]/25" : "bg-white/[0.06]"}`}>
+                <span className="material-symbols-rounded" style={{ fontSize: 20, color: active ? "var(--coral-bright)" : "var(--text-muted)" }}>{item.icon}</span>
+              </span>
+              <span className="flex-1 min-w-0 truncate font-medium">{navLabel(item)}</span>
+              {status.subtitle && <span className="sr-only">{status.subtitle}</span>}
+              {status.dot && (
+                <span
+                  aria-hidden="true"
+                  className={`w-2 h-2 rounded-full shrink-0 ${
+                    status.dot === "ok" ? "bg-emerald-400" : status.dot === "warn" ? "bg-amber-400" : "bg-white/20"
+                  }`}
+                  title={status.subtitle ?? undefined}
+                />
+              )}
             </button>
           );
         })}
@@ -2648,8 +2713,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       </nav>
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto p-6">
-        {renderContent()}
+      <div className="flex-1 overflow-y-auto p-6 flex flex-col items-center">
+        <div className="w-full max-w-3xl flex flex-col items-stretch [&>div]:mx-auto [&>div]:w-full">
+          {renderContent()}
+        </div>
       </div>
 
       {/* Update confirmation modal */}

--- a/src/components/SystemTray.tsx
+++ b/src/components/SystemTray.tsx
@@ -108,9 +108,12 @@ export default function SystemTray({
   }, []);
 
   const handleClose = () => {
-    if (rebootState) return; // Don't close during reboot
+    if (rebootState) return;
     setClosing(true);
-    setTimeout(onClose, 150);
+    setTimeout(() => {
+      onClose();
+      setClosing(false);
+    }, 150);
   };
 
   const handlePower = async (action: "shutdown" | "restart") => {


### PR DESCRIPTION
## Summary

Comprehensive mobile UX pass across the desktop shell, Settings, and lock screen.

### Mobile desktop
- **Chat fullscreen** on mobile (edge-to-edge, no mascot — crab chat icon in taskbar instead).
- **Taskbar redesign**: mobile shows launcher (left) → chat crab (center) → clock + fullscreen + power (right). Pinned apps hidden from the bar (already on the home grid). Desktop layout unchanged.
- **App launcher**: skip auto-focus on touch devices so the keyboard doesn't pop up on open.
- **Icon grid**: computed mobile layout fills row-by-row via `mobileIconOrder`; scrollable when overflow; positions synced only on real drag start (not taps).
- **Icon drag**: 20px threshold on mobile (8 on desktop); marquee multi-select disabled on touch.
- **Fullscreen toggle** visible on both mobile and desktop.
- **`interactiveWidget: resizes-visual`** — keyboard overlays content in fullscreen instead of creating a gap strip.
- Dark `:fullscreen` + `::backdrop` CSS; `html` background set to `--background`.
- Removed the "Tap to Enter Fullscreen" splash screen.

### Settings
- **Desktop sidebar**: wider (w-60), tinted icon tiles, status dots (green = ok, amber = warn).
- **Mobile nav**: iOS-style grouped card with subtitle per section (WiFi: "KrasiNet", AI: "ClawBox AI", Telegram: "@MyBot", etc.).
- Shared `sectionStatus()` helper for both sidebar + mobile list.
- Ethernet-aware status (green dot when wired).
- Dropped redundant section h2 titles; normalized all sections to `max-w-xl`.
- Desktop content centered with `flex items-center` + child `mx-auto`.
- Skeleton loading states for AI, Local AI, Telegram.
- Mobile back-bar: one back arrow (chrome's), subtle "← Settings" text link to switch sections.
- `AIModelsStep` embedded mode matches parent width.

### Lock screen
- Phone-style: big clock (64px, mobile only), date, gradient aura background, duration as pill grid, h-12 inputs, login spinner.

### Bug fixes
- **SystemTray**: `closing` state now resets after animation, preventing the invisible backdrop from blocking all clicks.

## Test plan

- [x] Mobile: open chat → fullscreen, edge-to-edge, no mascot, crab in taskbar.
- [ ] Mobile: tap launcher → keyboard does NOT pop; tap search bar → keyboard opens.
- [ ] Mobile: drag icon between rows → works; tap icon → opens app (no accidental drag).
- [ ] Desktop + mobile fullscreen: type in chat → no white/black gap above keyboard.
- [ ] Settings desktop: sidebar has tinted tiles, status dots, content centered.
- [ ] Settings mobile: nav list shows subtitles, one back to close.
- [ ] Lock screen mobile: clock visible, duration pills, gradient bg.
- [ ] Power menu: open → click away → can interact with desktop again (no stuck backdrop).
- [ ] `bun run test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)