### PR TITLE
Add skip option on AI provider step + fix ClawAI modal re-appearing

### DIFF
--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -50,9 +50,7 @@ test("settings covers appearance, network, ai, local ai, telegram, system, and a
   await clawAiTokenInput.fill("cbx-test-token");
   await clawAiTokenInput.press("Enter");
   await expect(settingsWindow.getByText("deepseek-r1")).toBeVisible();
-  await clawAiDialog.getByRole("button", { name: "Close offer" }).evaluate((button) => {
-    (button as HTMLButtonElement).click();
-  });
+  // Dialog auto-closes on successful config; verify provider status shows
   await expect(settingsWindow.getByText("ClawBox AI").first()).toBeVisible();
   await expect(settingsWindow.getByText("llama.cpp Local")).toHaveCount(0);
 

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -679,6 +679,7 @@ export default function AIModelsStep({
 
   const showSuccessAndContinue = useCallback(() => {
     tryCloseOAuthWindow(oauthWindowRef);
+    setShowClawAIOffer(false);
     completeConfiguring();
   }, [completeConfiguring]);
 
@@ -869,9 +870,11 @@ export default function AIModelsStep({
     setShowClawAIOffer(true);
   }, []);
 
+  const lastHandledOfferRef = useRef(0);
   useEffect(() => {
-    if (!openClawAIOfferRequest) return;
+    if (!openClawAIOfferRequest || openClawAIOfferRequest === lastHandledOfferRef.current) return;
     if (!allowedProviders.some((provider) => provider.id === "clawai")) return;
+    lastHandledOfferRef.current = openClawAIOfferRequest;
     selectProvider("clawai");
     setShowClawAIOffer(true);
   }, [allowedProviders, openClawAIOfferRequest, selectProvider]);
@@ -1610,7 +1613,7 @@ export default function AIModelsStep({
             </button>
           )}
         </div>
-        {!embedded && selectedProvider !== "clawai" && (
+        {!embedded && (
           <div className="mt-3 text-center">
             <button
               type="button"
@@ -1618,7 +1621,7 @@ export default function AIModelsStep({
               disabled={saving}
               className="text-xs text-[var(--text-muted)] hover:text-[var(--text-secondary)] bg-transparent border-none cursor-pointer underline transition-colors"
             >
-              {t("skip")}
+              {configureScope === "local" ? t("skip") : t("ai.skipUseLocalOnly")}
             </button>
           </div>
         )}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -107,6 +107,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "Connect AI Model",
     "ai.description": "Select your AI provider and enter your API key or subscription token.",
+    "ai.skipUseLocalOnly": "Skip — I'll use only local AI",
     "ai.clawaiDesc": "Register once, then paste your token",
     "ai.clawaiHint": "Create a ClawBox AI portal account, generate a token, and paste it during setup to connect your device.",
     "ai.useClawai": "Continue with ClawBox AI",
@@ -448,6 +449,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "Свързване на AI модел",
     "ai.description": "Изберете AI доставчик и въведете API ключ или токен за абонамент.",
+    "ai.skipUseLocalOnly": "Пропусни — ще използвам само локален AI",
     "ai.clawaiDesc": "Най-достъпен — започнете безплатно",
     "ai.clawaiHint": "ClawBox AI е безплатен и предварително конфигуриран. Просто натиснете по-долу, за да започнете — не е нужен API ключ или акаунт.",
     "ai.useClawai": "Започнете безплатно",
@@ -789,6 +791,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "KI-Modell verbinden",
     "ai.description": "Wähle deinen KI-Anbieter und gib deinen API-Schlüssel oder Abo-Token ein.",
+    "ai.skipUseLocalOnly": "Überspringen — nur lokale KI verwenden",
     "ai.clawaiDesc": "Am günstigsten — kostenlos starten",
     "ai.clawaiHint": "ClawBox AI ist kostenlos und vorkonfiguriert. Klicke einfach unten, um loszulegen — kein API-Schlüssel oder Konto nötig.",
     "ai.useClawai": "Kostenlos starten",
@@ -1130,6 +1133,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "Conectar modelo de IA",
     "ai.description": "Selecciona tu proveedor de IA e introduce tu clave API o token de suscripción.",
+    "ai.skipUseLocalOnly": "Omitir — usaré solo IA local",
     "ai.clawaiDesc": "Más asequible — empieza gratis",
     "ai.clawaiHint": "ClawBox AI es gratuito y viene preconfigurado. Solo haz clic abajo para empezar — no necesitas clave API ni cuenta.",
     "ai.useClawai": "Empieza gratis",
@@ -1471,6 +1475,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "Connecter un modèle d'IA",
     "ai.description": "Sélectionnez votre fournisseur d'IA et entrez votre clé API ou jeton d'abonnement.",
+    "ai.skipUseLocalOnly": "Passer — je n'utiliserai que l'IA locale",
     "ai.clawaiDesc": "Le plus abordable — commencez gratuitement",
     "ai.clawaiHint": "ClawBox AI est gratuit et préconfiguré. Cliquez ci-dessous pour commencer — aucune clé API ni compte nécessaire.",
     "ai.useClawai": "Commencer gratuitement",
@@ -1812,6 +1817,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "Connetti modello IA",
     "ai.description": "Seleziona il tuo fornitore di IA e inserisci la chiave API o il token dell'abbonamento.",
+    "ai.skipUseLocalOnly": "Salta — userò solo l'IA locale",
     "ai.clawaiDesc": "Più conveniente — inizia gratis",
     "ai.clawaiHint": "ClawBox AI è gratuito e preconfigurato. Clicca qui sotto per iniziare — non servono chiave API né account.",
     "ai.useClawai": "Inizia gratis",
@@ -2153,6 +2159,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "AIモデルを接続",
     "ai.description": "AIプロバイダーを選択し、APIキーまたはサブスクリプショントークンを入力してください。",
+    "ai.skipUseLocalOnly": "スキップ — ローカルAIのみを使用します",
     "ai.clawaiDesc": "最もお手頃 — 無料で始める",
     "ai.clawaiHint": "ClawBox AIは無料で設定済みです。下のボタンをクリックするだけで始められます。APIキーもアカウントも不要です。",
     "ai.useClawai": "無料で始める",
@@ -2494,6 +2501,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "AI-model verbinden",
     "ai.description": "Kies je AI-provider en voer je API-sleutel of abonnementstoken in.",
+    "ai.skipUseLocalOnly": "Overslaan — ik gebruik alleen lokale AI",
     "ai.clawaiDesc": "Meest betaalbaar — gratis beginnen",
     "ai.clawaiHint": "ClawBox AI is gratis en vooraf geconfigureerd. Klik hieronder om te beginnen — geen API-sleutel of account nodig.",
     "ai.useClawai": "Gratis beginnen",
@@ -2835,6 +2843,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "Anslut AI-modell",
     "ai.description": "Välj din AI-leverantör och ange din API-nyckel eller prenumerationstoken.",
+    "ai.skipUseLocalOnly": "Hoppa över — jag använder bara lokal AI",
     "ai.clawaiDesc": "Mest prisvärd — börja gratis",
     "ai.clawaiHint": "ClawBox AI är gratis och förkonfigurerat. Klicka nedan för att komma igång — ingen API-nyckel eller konto behövs.",
     "ai.useClawai": "Börja gratis",
@@ -3176,6 +3185,7 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     // === AIModelsStep ===
     "ai.title": "连接 AI 模型",
     "ai.description": "选择 AI 供应商并输入 API 密钥或订阅令牌。",
+    "ai.skipUseLocalOnly": "跳过 — 我只使用本地 AI",
     "ai.clawaiDesc": "最实惠 — 免费开始",
     "ai.clawaiHint": "ClawBox AI 免费且已预配置。点击下方即可开始——无需 API 密钥或账户。",
     "ai.useClawai": "免费开始",


### PR DESCRIPTION
## Summary

- **Skip option on step 4 (AI Provider)**: always visible regardless of selected provider. Label: "Skip — I'll use only local AI" (i18n'd across all 10 locales). Lets users who want only local models skip cloud provider setup entirely.
- **ClawAI modal fix**: `showClawAIOffer` is now cleared in `showSuccessAndContinue()` so the token-paste modal doesn't re-appear after a successful config when the configuring overlay dismisses (was a bug in embedded/Settings mode).

## Test plan

- [ ] Setup wizard step 4: skip link visible under ClawBox AI (default selection) and all other providers.
- [ ] Tap skip → advances to step 5 (Local AI).
- [ ] Settings → AI Provider → configure ClawBox AI with token → overlay completes → modal does NOT re-appear.
- [ ] Switch locale to bg/de/zh → skip text is localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)