### PR TITLE
fix(sw): precache /clawbox-icon.png and bump cache to v3

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,9 +1,14 @@
 // ClawBox Service Worker — PWA installability + asset caching
-const CACHE_NAME = 'clawbox-v2'
+//
+// Bumping CACHE_NAME here is the supported way to invalidate previously
+// cached assets on existing installs — the `activate` handler deletes any
+// cache whose name doesn't match, so users get a clean slate on next visit.
+const CACHE_NAME = 'clawbox-v3'
 const PRECACHE = [
   '/',
   '/icon-192.png',
   '/icon-512.png',
+  '/clawbox-icon.png',
   '/clawbox-logo.png',
   '/clawbox-crab.png',
   '/clawbox-wallpaper.jpeg',


### PR DESCRIPTION
## Summary

The header logo (`/clawbox-icon.png`) renders as a broken image on some devices because the service worker cached a stale/404 response from an earlier state and never invalidates it. This PR fixes the missing precache entry and bumps the SW cache name so existing installs recover automatically on their next visit.

## Root cause

`public/sw.js` intercepts every `.png` request with a **cache-first** strategy:

```js
if (CACHEABLE_EXT.test(url.pathname) || url.pathname.startsWith('/_next/static/')) {
  event.respondWith(
    caches.match(event.request).then((cached) => {
      if (cached) return cached
      return fetch(event.request).then((response) => {
        if (response.ok) {
          const clone = response.clone()
          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone))
        }
        return response
      }).catch(() => cached || Response.error())
    })
  )
}
```

But the `PRECACHE` list only contained `/clawbox-logo.png`, not `/clawbox-icon.png` — even though the latter is what `SetupWizard.tsx` header uses:

```tsx
<Image src="/clawbox-icon.png" alt="ClawBox" width={36} height={36} ... />
```

If a browser ever fetched `/clawbox-icon.png` before the asset was available (during a build, a deploy, or before the file landed in `.next/standalone/public/`), the SW's cache-first code cached the failure. Every subsequent visit then returned that bad cached response, and the user saw a broken image icon in the top-left of the setup wizard / dashboard with no obvious fix.

Observed live on a Jetson running `beta`: users had to manually Unregister the SW in DevTools → Application, then clear site data, then hard-reload before the icon would render correctly.

## Changes

1. **Add `/clawbox-icon.png` to PRECACHE** — so the asset is always warmed correctly when the SW installs, and never has a window where a cache-first miss can cache a 404.

2. **Bump `CACHE_NAME`: `clawbox-v2` → `clawbox-v3`** — the SW's existing `activate` handler already deletes every cache whose name doesn't match `CACHE_NAME`, so this one-line bump **invalidates any bad cached response on existing installs** and gives affected users a clean slate on their next visit without manual DevTools work.

3. **Document why we bump CACHE_NAME** in a short comment at the top of the file so future maintainers know the convention.

## Verification

Tested on a Jetson that was exhibiting the broken-icon bug on a Windows Chrome client:

- Before patch: icon shows broken image placeholder in header. Hard-reload is the only workaround.
- After patch + rebuild + deploy + single refresh: old `clawbox-v2` cache is deleted by the `activate` handler, `clawbox-v3` is populated fresh with `/clawbox-icon.png` in the PRECACHE list, icon renders correctly. No DevTools action needed from the user.

## Test plan

- [x] `public/sw.js` parses as valid JS
- [x] Manual repro on affected browser, verified auto-recovery after CACHE_NAME bump
- [x] `/clawbox-icon.png` is 200 OK on the server and a valid PNG — issue was purely SW-side