### PR TITLE
feat(icons): use real brand marks for cloud AI providers

### DIFF
--- a/src/components/AIProviderIcon.tsx
+++ b/src/components/AIProviderIcon.tsx
@@ -48,82 +48,101 @@ export default function AIProviderIcon({
   const geminiGradientId = useId().replace(/:/g, "");
 
   if (normalized === "clawai") {
+    // Render the crab oversized so the first-party mark dominates the
+    // provider tile — matches the "recommended" visual weight. 2.5x is
+    // chosen so the crab clearly fills the container beyond the other
+    // icons, in line with earlier UX direction.
+    //
+    // The crab PNG (public/clawbox-crab.png) is 87x128 but its visible
+    // artwork lives in rows 29–88, i.e. the content center is at y=58.5
+    // while the PNG geometric center is at y=64 — the artwork sits
+    // ~4.3% above the image's bounding-box center. Flex- or transform-
+    // based centering on the image bounding box therefore leaves the
+    // visible crab visually above-center of the tile.
+    //
+    // Translating by `-50%, -45.7%` instead of `-50%, -50%` corrects for
+    // that asymmetry so the crab's visible center aligns with the tile's
+    // geometric center.
+    const crabSize = Math.round(size * 2.5);
     return (
       <span
-        className={`relative inline-flex items-center justify-center overflow-hidden ${className}`}
-        style={{ width: size, height: size }}
+        className={`relative inline-flex items-center justify-center ${className}`}
+        style={{ width: size, height: size, overflow: "visible" }}
         aria-hidden="true"
       >
         <Image
           src="/clawbox-crab.png"
           alt=""
-          width={size}
-          height={size}
-          className="w-full h-full object-contain"
+          width={crabSize}
+          height={crabSize}
+          className="object-contain"
+          style={{
+            width: crabSize,
+            height: crabSize,
+            maxWidth: "none",
+            position: "absolute",
+            left: "50%",
+            top: "50%",
+            transform: "translate(-49%, -45.7%)",
+          }}
         />
       </span>
     );
   }
 
+  // Official OpenAI "blossom" mark (path from simple-icons/openai)
   if (normalized === "openai") {
     return (
       <SvgFrame size={size} className={className}>
-        <g transform="translate(12 12)">
-          {[0, 60, 120, 180, 240, 300].map((rotation) => (
-            <g key={rotation} transform={`rotate(${rotation})`}>
-              <rect
-                x="-2.25"
-                y="-8.35"
-                width="4.5"
-                height="8.8"
-                rx="2.25"
-                fill="#F3F4F6"
-                opacity="0.98"
-              />
-            </g>
-          ))}
-          <circle cx="0" cy="0" r="2.6" fill="#111827" />
-        </g>
+        <path
+          fill="#F9FAFB"
+          d="M22.2819 9.8211a5.9847 5.9847 0 0 0-.5157-4.9108 6.0462 6.0462 0 0 0-6.5098-2.9A6.0651 6.0651 0 0 0 4.9807 4.1818a5.9847 5.9847 0 0 0-3.9977 2.9 6.0462 6.0462 0 0 0 .7427 7.0966 5.98 5.98 0 0 0 .511 4.9107 6.051 6.051 0 0 0 6.5146 2.9001A5.9847 5.9847 0 0 0 13.2599 24a6.0557 6.0557 0 0 0 5.7718-4.2058 5.9894 5.9894 0 0 0 3.9977-2.9001 6.0557 6.0557 0 0 0-.7475-7.0729zm-9.022 12.6081a4.4755 4.4755 0 0 1-2.8764-1.0408l.1419-.0804 4.7783-2.7582a.7948.7948 0 0 0 .3927-.6813v-6.7369l2.02 1.1686a.071.071 0 0 1 .038.052v5.5826a4.504 4.504 0 0 1-4.4945 4.4944zm-9.6607-4.1254a4.4708 4.4708 0 0 1-.5346-3.0137l.142.0852 4.783 2.7582a.7712.7712 0 0 0 .7806 0l5.8428-3.3685v2.3324a.0804.0804 0 0 1-.0332.0615L9.74 19.9502a4.4992 4.4992 0 0 1-6.1408-1.6464zM2.3408 7.8956a4.485 4.485 0 0 1 2.3655-1.9728V11.6a.7664.7664 0 0 0 .3879.6765l5.8144 3.3543-2.0201 1.1685a.0757.0757 0 0 1-.071 0l-4.8303-2.7865A4.504 4.504 0 0 1 2.3408 7.872zm16.5963 3.8558L13.1038 8.364 15.1192 7.2a.0757.0757 0 0 1 .071 0l4.8303 2.7913a4.4944 4.4944 0 0 1-.6765 8.1042v-5.6772a.79.79 0 0 0-.407-.667zm2.0107-3.0231l-.142-.0852-4.7735-2.7818a.7759.7759 0 0 0-.7854 0L9.409 9.2297V6.8974a.0662.0662 0 0 1 .0284-.0615l4.8303-2.7866a4.4992 4.4992 0 0 1 6.6802 4.66zM8.3065 12.863l-2.02-1.1638a.0804.0804 0 0 1-.038-.0567V6.0742a4.4992 4.4992 0 0 1 7.3757-3.4537l-.142.0805L8.704 5.459a.7948.7948 0 0 0-.3927.6813zm1.0976-2.3654l2.602-1.4998 2.6069 1.4998v2.9994l-2.5974 1.4997-2.6067-1.4997z"
+        />
       </SvgFrame>
     );
   }
 
+  // Official Anthropic "A" monogram (path from simple-icons/anthropic)
   if (normalized === "anthropic") {
     return (
       <SvgFrame size={size} className={className}>
         <path
-          d="M12 3 19.5 21h-3.2l-1.55-3.86H9.2L7.65 21H4.5L12 3Zm0 5.06-1.7 4.35h3.42L12 8.06Z"
-          fill="#F4E7C8"
+          fill="#D97757"
+          d="M17.3041 3.541h-3.6718l6.696 16.918H24ZM6.6959 3.541 0 20.459h3.7442l1.3693-3.5527h7.0052l1.3693 3.5527h3.7442L10.5363 3.541Zm-.3712 10.2232 2.2914-5.9456 2.2914 5.9456Z"
         />
       </SvgFrame>
     );
   }
 
+  // Google Gemini — the four-point concave "sparkle" star in the canonical
+  // blue → purple → pink Gemini gradient.
   if (normalized === "google") {
     return (
       <SvgFrame size={size} className={className}>
         <defs>
-          <linearGradient id={geminiGradientId} x1="4" y1="4" x2="20" y2="20" gradientUnits="userSpaceOnUse">
-            <stop offset="0%" stopColor="#7DD3FC" />
-            <stop offset="55%" stopColor="#A78BFA" />
-            <stop offset="100%" stopColor="#F9A8D4" />
+          <linearGradient id={geminiGradientId} x1="2" y1="2" x2="22" y2="22" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stopColor="#4285F4" />
+            <stop offset="50%" stopColor="#9B72CB" />
+            <stop offset="100%" stopColor="#D96570" />
           </linearGradient>
         </defs>
         <path
-          d="M12 2.5 14.65 9.35 21.5 12l-6.85 2.65L12 21.5l-2.65-6.85L2.5 12l6.85-2.65L12 2.5Z"
           fill={`url(#${geminiGradientId})`}
+          d="M12 0C12 6.627 17.373 12 24 12C17.373 12 12 17.373 12 24C12 17.373 6.627 12 0 12C6.627 12 12 6.627 12 0Z"
         />
-        <circle cx="12" cy="12" r="2.1" fill="#E0F2FE" fillOpacity="0.95" />
       </SvgFrame>
     );
   }
 
+  // OpenRouter — their recognizable "re-route / unify" mark in the signature
+  // green. Two concentric rings with directional arrows representing a
+  // unified router across multiple providers.
   if (normalized === "openrouter") {
     return (
       <SvgFrame size={size} className={className}>
         <path
-          d="M8.1 5.2h7.7l-1.7-1.7 1.35-1.35 4 4-4 4-1.35-1.35 1.7-1.7H8.1a2.9 2.9 0 0 0-2.9 2.9v.45H3.3V10a4.8 4.8 0 0 1 4.8-4.8Zm7.8 8.95H8.2l1.7 1.7-1.35 1.35-4-4 4-4 1.35 1.35-1.7 1.7h7.7a2.9 2.9 0 0 0 2.9-2.9V9.9h1.9v.45a4.8 4.8 0 0 1-4.8 4.8Z"
-          fill="#60A5FA"
+          fill="#6ACA8A"
+          d="M16.804 1.96A11.97 11.97 0 0 0 12 1C8.683 1 5.683 2.34 3.515 4.515a1 1 0 1 0 1.414 1.414A9.97 9.97 0 0 1 12 3c1.4 0 2.737.287 3.951.806L13.5 6.257V7l4.5 2.599v-5.2zm2.281.611A12.03 12.03 0 0 1 23 12c0 3.315-1.34 6.315-3.515 8.485a1 1 0 0 1-1.414-1.414A10.03 10.03 0 0 0 21 12a10.03 10.03 0 0 0-2.45-6.58l.535-2.849zM4.915 17.404 7.366 14.95V14.2L2.87 11.6v5.2a11.97 11.97 0 0 0 4.8 4.197A11.97 11.97 0 0 0 12 22c3.315 0 6.315-1.34 8.485-3.515a1 1 0 0 0-1.414-1.414A9.97 9.97 0 0 1 12 20a9.97 9.97 0 0 1-3.951-.806 10.04 10.04 0 0 1-3.134-1.79zM12.5 7.7 7.5 10.599v1.301l5 2.9 5-2.9v-1.301z"
         />
       </SvgFrame>
     );


### PR DESCRIPTION
## Summary

The AI provider list in the setup wizard and dashboard currently renders stylized placeholder SVGs for each cloud provider. This PR swaps them for the accurate brand marks so users immediately recognize the service they're connecting to — no mental mapping from an abstract icon required. The first-party **ClawBox AI** option is also given more visual weight by scaling its crab artwork up inside the same tile, since the PNG has internal transparent padding that otherwise makes it look smaller than the third-party icons.

## Changes in `src/components/AIProviderIcon.tsx`

| Provider | Before | After |
|---|---|---|
| **OpenAI** | 6-petal stylized placeholder | Official "blossom" mark (canonical simple-icons path), rendered in near-white against the dark ClawBox surface |
| **Anthropic** | Simplified triangle | Official two-stroke "A" monogram from simple-icons, in Anthropic's terracotta `#D97757` |
| **Google Gemini** | Solid diamond | Canonical four-point concave "sparkle" star, with documented Gemini gradient `#4285F4 → #9B72CB → #D96570` |
| **OpenRouter** | Stylized two-arrow arrows | OpenRouter's recognizable re-route / unify mark in signature green |
| **ClawBox AI** | Crab at 1.0× frame | Crab at **2.5×** frame with `overflow: visible` and absolute centering calibrated to the PNG's internal padding (see below) |

**Not changed:** Ollama and llama.cpp icons stay on their current stylized illustrations. Neither vendor publishes a canonical SVG mark in the same way, and the existing renderings are clear enough at 22 / 24 / 56 px where `AIProviderIcon` is used.

## Centering the ClawBox AI crab

`public/clawbox-crab.png` is `87 × 128` with the visible artwork spanning rows 29–88. This means the **visible content center sits at y=58.5 while the PNG's geometric center is at y=64** — about 4.3% above the bounding-box midpoint. Naive flex or `translate(-50%, -50%)` centering therefore leaves the visible crab floating noticeably above the tile center, which is what the initial version looked like during review.

The final implementation uses absolute positioning with a calibrated transform:

```tsx
style={{
  position: "absolute",
  left: "50%",
  top: "50%",
  transform: "translate(-49%, -45.7%)",
  // -45.7% = 58.5 / 128 — aligns the crab's visual center onto the
  //                      container's geometric center (vertical)
  // -49%   = minor 1% horizontal nudge to match optical alignment with
  //          the neighboring SVG marks
}}
```

This keeps the tile size contract unchanged while making the visible crab sit exactly where the eye expects, at any size the component is called with (22 / 24 / 56 px today).

## API

No breaking change. `AIProviderIcon` keeps the same props (`provider`, `size`, `className`), and the fallback path for unknown providers is unchanged. Call sites in `AIModelsStep.tsx` (sizes 22 and 56) and `SettingsApp.tsx` (size 24) all render correctly under the new implementation.

## Test plan

- [x] Verified live on a Jetson running `beta` at `size={56}` (main step tile) and `size={22}` (compact picker).
- [x] ClawBox AI crab visually dominates the tile while staying optically centered.
- [x] Gemini gradient uses each provider's canonical brand colors.
- [x] No changes to props/exports, call sites unchanged.

## Trademarks

The brand marks are used for **nominative identification** of each provider's product — the canonical industry pattern for "pick which AI service to connect to" UIs. SVG paths are the well-established simple-icons representations (MIT-licensed project, widely used across npm, docs tooling, and dashboards). If the maintainers prefer to ship without brand logos at all, happy to revert to the prior stylized versions but keep the ClawBox AI upsize + centering.