### PR TITLE
chore(coderabbit): add beta to base_branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,7 @@ reviews:
       - main
       - master
       - develop
+      - beta
       - "clawbox-*"
   path_instructions:
     - path: "src/app/**/*.ts*"


### PR DESCRIPTION
## Summary
- Adds `beta` to `base_branches` in `.coderabbit.yaml` so CodeRabbit's GitHub bot auto-reviews PRs targeting beta.
- Likely side benefit: lets the CodeRabbit CLI (`coderabbit review --base beta`) scope the diff to the branch instead of falling back to main and blowing past its 150-file limit.

## Why
When running `coderabbit review --base beta --plain` locally against a small 3-file change, the CLI still reported "354 files, 204 over the limit" — it appears to ignore `--base` when the target isn't declared as a known base branch, and falls back to `main`. Declaring `beta` here should fix both the bot and the CLI path.

## Test plan
- [ ] CI: no workflow impact (config file only)
- [ ] After merge: open a fresh PR from a feature branch into beta — confirm the CodeRabbit bot posts an auto-review
- [ ] After merge: re-run `coderabbit review --base beta --plain` on a small feature branch — confirm file count reflects only the branch diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated automated review configuration to include the beta branch in automated review workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->