### PR TITLE
fix(config): robust openclaw config set — retry + Jetson-realistic timeout

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -8,6 +8,7 @@ import { getAll, setMany } from "@/lib/config-store";
 import {
   restartGateway,
   findOpenclawBin,
+  runOpenclawConfigSet,
   DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR,
   inferConfiguredLocalModel,
   readConfig as readOpenClawConfig,
@@ -95,6 +96,20 @@ interface AuthProfilesFile {
 }
 
 function runCommand(cmd: string, args: string[], timeoutMs = COMMAND_TIMEOUT_MS): Promise<void> {
+  // Route `openclaw config set …` through the shared retry-aware helper in
+  // openclaw-config.ts so callers automatically survive transient
+  // `ConfigMutationConflictError` races (gateway touching the config during
+  // reload, or two successive writes from this route landing in the same tick).
+  // Non-openclaw invocations (e.g. `sudo optimize-ollama.sh`) keep the
+  // one-shot spawn below unchanged — no retry semantics apply there.
+  if (cmd === OPENCLAW_BIN && args[0] === "config" && args[1] === "set") {
+    return runOpenclawConfigSet(args.slice(2), {
+      timeoutMs,
+      uid: CLAWBOX_UID,
+      gid: CLAWBOX_GID,
+    });
+  }
+
   return new Promise((resolve, reject) => {
     let settled = false;
     const child = spawn(cmd, args, {

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -1,13 +1,10 @@
 import { NextResponse } from "next/server";
-import { execFile } from "child_process";
-import { promisify } from "util";
 import { getAll } from "@/lib/config-store";
-import { inferConfiguredLocalModel, findOpenclawBin, readConfig, restartGateway, type OpenClawConfig } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, type OpenClawConfig } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 
 export const dynamic = "force-dynamic";
 
-const exec = promisify(execFile);
 const PRIMARY_MODEL_KEY = "chat:primary-provider-model";
 
 type ChatModelSource = "primary" | "local";
@@ -299,8 +296,13 @@ export async function POST(request: Request) {
       await sqliteSet(PRIMARY_MODEL_KEY, state.activeModel);
     }
 
-    const openclawBin = findOpenclawBin();
-    await exec(openclawBin, ["config", "set", "agents.defaults.model.primary", targetModel], { timeout: 10000 });
+    // runOpenclawConfigSet retries on transient ConfigMutationConflictError
+    // so users switching chat models don't see a bogus failure when the
+    // gateway reloads concurrently with the write. Leave timeoutMs on the
+    // helper's default — the OpenClaw CLI itself takes 10-12 s per call
+    // on Jetson Orin hardware, so a tighter bound here was producing
+    // spurious "timed out" errors on every legitimate invocation.
+    await runOpenclawConfigSet(["agents.defaults.model.primary", targetModel]);
     await restartGateway();
 
     const nextState = await loadChatModelState();

--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -1,20 +1,25 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
-import { execFile as execFileCb } from "child_process";
-import { promisify } from "util";
 import { get, set, setMany } from "@/lib/config-store";
-import { findOpenclawBin, readConfig, restartGateway } from "@/lib/openclaw-config";
-
-const execFile = promisify(execFileCb);
+import { readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
 
 const SAVED_PRIMARY_KEY = "local_only_saved_primary";
 const SAVED_FALLBACKS_KEY = "local_only_saved_fallbacks";
 const MODE_KEY = "local_only_mode";
 
+// Route OpenClaw config mutations through the shared retry-aware helper.
+// The gateway reload + gateway-pre-start.sh write the same config file
+// concurrently, so a bare `openclaw config set` here can fail with
+// ConfigMutationConflictError mid-toggle — leaving the primary model
+// flipped but fallbacks still populated, and local_only_mode unset.
+// That half-applied state is visible in the UI as a failed toggle while
+// the user's chat actually continues routing to the cloud fallback.
 async function setConfig(key: string, valueJson: string) {
-  const bin = findOpenclawBin();
-  await execFile(bin, ["config", "set", key, valueJson, "--json"], { timeout: 10_000 });
+  // Leave timeoutMs on the helper's default — the OpenClaw CLI takes
+  // 10-12 s per invocation on Jetson, so tighter bounds here produced
+  // spurious "timed out" errors that made Local-only mode fail to toggle.
+  await runOpenclawConfigSet([key, valueJson, "--json"]);
 }
 
 export async function GET() {

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1,11 +1,140 @@
 import fs from "fs/promises";
 import fsSync from "fs";
 import path from "path";
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
 import { promisify } from "util";
 import { getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 
 const exec = promisify(execFile);
+
+/**
+ * Options for {@link runOpenclawConfigSet}.
+ */
+export interface OpenclawConfigSetOptions {
+  /**
+   * Per-attempt timeout in ms. Default: 30_000.
+   *
+   * OpenClaw's CLI is a full Node.js program that loads the whole gateway
+   * SDK, parses plugins, and validates the config schema on every
+   * invocation. On a NVIDIA Jetson Orin Nano this startup cost alone is
+   * 10-12 s per call — measured consistently with three sequential runs
+   * when the box was otherwise idle. A 30 s per-attempt budget gives a
+   * healthy safety margin on the target hardware. Callers on faster
+   * machines (dev boxes, CI) can override down to 10 s if they want
+   * stricter bounds.
+   */
+  timeoutMs?: number;
+  /** Maximum attempts including the first try. Default: 4. */
+  maxAttempts?: number;
+  /** Linear backoff base — delay between attempts is `baseBackoffMs * attempt`. Default: 100. */
+  baseBackoffMs?: number;
+  /** Spawn uid (for cases where the calling process runs as a different user). */
+  uid?: number;
+  /** Spawn gid (paired with `uid`). */
+  gid?: number;
+  /** Working directory for the spawned process. Default: `/home/clawbox`. */
+  cwd?: string;
+  /** Extra env overrides merged over the default `{ HOME: "/home/clawbox", ...process.env }`. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Run `openclaw config set <args>` with automatic retry on
+ * `ConfigMutationConflictError`.
+ *
+ * OpenClaw's config writer uses optimistic concurrency (content-hash based)
+ * and its gateway process reloads on file changes. When ClawBox issues
+ * multiple `config set` calls back-to-back, or a `config set` races with the
+ * gateway touching `meta.lastTouchedAt` during a reload, one of the writes
+ * can fail with `ConfigMutationConflictError: config changed since last
+ * load`. The mutation itself is safe to retry — the next attempt re-reads
+ * the fresh hash and converges.
+ *
+ * This helper retries *only* on that specific error (other failures bubble
+ * up immediately) with a short linear backoff, so callers don't need to
+ * handle the race individually.
+ */
+export async function runOpenclawConfigSet(
+  args: string[],
+  options: OpenclawConfigSetOptions = {},
+): Promise<void> {
+  const {
+    timeoutMs = 30_000,
+    maxAttempts = 4,
+    baseBackoffMs = 100,
+  } = options;
+
+  let lastError: Error | null = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await spawnOpenclawConfigSet(args, { ...options, timeoutMs });
+      return;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      const isConflict = /ConfigMutationConflictError/i.test(lastError.message);
+      if (!isConflict || attempt === maxAttempts) {
+        throw lastError;
+      }
+      const delayMs = baseBackoffMs * attempt;
+      console.warn(
+        `[openclaw-config] ConfigMutationConflictError on attempt ${attempt}/${maxAttempts}; retrying after ${delayMs}ms`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError ?? new Error("runOpenclawConfigSet exhausted retries");
+}
+
+function spawnOpenclawConfigSet(
+  args: string[],
+  options: OpenclawConfigSetOptions & { timeoutMs: number },
+): Promise<void> {
+  const bin = findOpenclawBin();
+  const { timeoutMs, uid, gid } = options;
+  const cwd = options.cwd ?? "/home/clawbox";
+  const env = { ...process.env, HOME: "/home/clawbox", ...(options.env ?? {}) };
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const child = spawn(bin, ["config", "set", ...args], {
+      stdio: ["pipe", "pipe", "pipe"],
+      cwd,
+      ...(uid !== undefined ? { uid } : {}),
+      ...(gid !== undefined ? { gid } : {}),
+      env,
+    });
+
+    let stderr = "";
+    child.stderr?.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGKILL");
+        reject(new Error(`${bin} config set timed out after ${timeoutMs}ms`));
+      }
+    }, timeoutMs);
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      }
+    });
+
+    child.on("close", (code) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        if (code === 0) resolve();
+        else reject(new Error(stderr.trim() || `${bin} config set exited with code ${code}`));
+      }
+    });
+  });
+}
 const OPENCLAW_HOME = process.env.OPENCLAW_HOME || "/home/clawbox/.openclaw";
 export const CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 export const DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR = 24000;

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -96,8 +96,13 @@ function spawnOpenclawConfigSet(
 
   return new Promise((resolve, reject) => {
     let settled = false;
+    // stdin + stdout are "ignore" so the child isn't blocked writing into a
+    // pipe no one is reading — OpenClaw's CLI can produce a lot of stdout
+    // under verbose/debug modes, and with a full kernel pipe buffer it would
+    // deadlock waiting for someone to drain it. We only care about stderr,
+    // which carries the ConfigMutationConflictError signature used for retry.
     const child = spawn(bin, ["config", "set", ...args], {
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["ignore", "ignore", "pipe"],
       cwd,
       ...(uid !== undefined ? { uid } : {}),
       ...(gid !== undefined ? { gid } : {}),

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -31,10 +31,11 @@ vi.mock("@/lib/openclaw-config", () => ({
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
   inferConfiguredLocalModel: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
 }));
 
 import { getAll, setMany } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig, restartGateway } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
@@ -101,6 +102,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockSetMany.mockResolvedValue();
     mockRestartGateway.mockResolvedValue();
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
+    vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
 
     const mod = await import("@/app/setup-api/ai-models/configure/route");
     configurePost = mod.POST;
@@ -207,8 +209,8 @@ describe("POST /setup-api/ai-models/configure", () => {
       }),
     );
 
-    const providerCall = mockSpawn.mock.calls.find((call) => call[1]?.[2] === "models.providers.deepseek");
-    const providerDef = providerCall ? JSON.parse(providerCall[1]?.[3] ?? "{}") : {};
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.deepseek");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
     expect(providerDef.apiKey).toBe("portal-token-123");
 
     expect(mockSetMany).toHaveBeenCalledWith(
@@ -248,7 +250,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
     expect(commands).toContain("config set agents.defaults.compaction.reserveTokensFloor 24000");
     expect(commands).toContain("config set gateway.auth.mode token");
@@ -272,7 +274,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       }),
     );
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
     expect(commands).not.toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
     expect(commands).toContain("config set models.mode merge");
@@ -293,7 +295,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).not.toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
     expect(commands).toContain("config set models.mode merge");
@@ -340,7 +342,7 @@ describe("POST /setup-api/ai-models/configure", () => {
   });
 
   it("returns 500 when spawn command fails", async () => {
-    mockSpawn.mockImplementation(() => createFailingChildProcess("Command failed"));
+    vi.mocked(runOpenclawConfigSet).mockRejectedValue(new Error("Command failed"));
 
     const res = await configurePost(jsonRequest({
       provider: "anthropic",
@@ -411,7 +413,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-test",
     }));
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["deepseek/deepseek-chat"] --json');
     expect(commands.some((command) => command.includes("config set models.providers.deepseek"))).toBe(true);
 
@@ -436,7 +438,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-openai-key",
     }));
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
     expect(commands.some((command) => command.includes("config set models.providers.deepseek"))).toBe(false);
   });
@@ -452,7 +454,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-openai-key",
     }));
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
   });
 
@@ -470,7 +472,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-openai-key",
     }));
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).not.toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
   });
 
@@ -487,8 +489,8 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const providerCall = mockSpawn.mock.calls.find((call) => call[1]?.[2] === "models.providers.deepseek");
-    const providerDef = providerCall ? JSON.parse(providerCall[1]?.[3] ?? "{}") : {};
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.deepseek");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
 
     expect(providerDef.baseUrl).toBe("https://openclawhardware.dev/api/ai");
     expect(providerDef.apiKey).toBe("stored-portal-token");
@@ -509,12 +511,12 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "gemma-q4",
     }));
 
-    const commands = mockSpawn.mock.calls.map((call) => call[1]?.join(" ") ?? "");
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands.some((command) => command.includes("config set models.providers.llamacpp"))).toBe(true);
     expect(commands).toContain("config set agents.defaults.model.primary llamacpp/gemma-q4");
 
-    const providerCall = mockSpawn.mock.calls.find((call) => call[1]?.[2] === "models.providers.llamacpp");
-    const providerDef = providerCall ? JSON.parse(providerCall[1]?.[3] ?? "{}") : {};
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.llamacpp");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
     const modelDef = providerDef?.models?.[0] ?? {};
 
     expect(providerDef.baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
@@ -528,8 +530,8 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "llama3.2:3b",
     }));
 
-    const providerCall = mockSpawn.mock.calls.find((call) => call[1]?.[2] === "models.providers.ollama");
-    const providerDef = providerCall ? JSON.parse(providerCall[1]?.[3] ?? "{}") : {};
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.ollama");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
 
     expect(providerDef.baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/ollama");
   });

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -9,6 +9,7 @@ vi.mock("util", () => ({
 }));
 
 vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/home/clawbox/clawbox/data",
   getAll: vi.fn(),
 }));
 
@@ -17,6 +18,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
 }));
 
 vi.mock("@/lib/sqlite-store", () => ({
@@ -25,7 +27,7 @@ vi.mock("@/lib/sqlite-store", () => ({
 }));
 
 import { getAll } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig, restartGateway } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { promisify } from "util";
 
@@ -40,6 +42,7 @@ describe("/setup-api/chat/model", () => {
 
     mockExec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
     vi.mocked(promisify).mockReturnValue(mockExec as never);
+    vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
 
     vi.mocked(getAll).mockResolvedValue({
       ai_model_provider: "clawai",
@@ -189,11 +192,10 @@ describe("/setup-api/chat/model", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mockExec).toHaveBeenCalledWith(
-      "/usr/local/bin/openclaw",
-      ["config", "set", "agents.defaults.model.primary", "llamacpp/gemma4-e2b-it-q4_0"],
-      { timeout: 10000 },
-    );
+    expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+      "agents.defaults.model.primary",
+      "llamacpp/gemma4-e2b-it-q4_0",
+    ]);
     expect(restartGateway).toHaveBeenCalled();
     expect(body.activeSource).toBe("local");
     expect(body.activeLabel).toBe("Gemma 4 Local");
@@ -246,11 +248,10 @@ describe("/setup-api/chat/model", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(mockExec).toHaveBeenCalledWith(
-      "/usr/local/bin/openclaw",
-      ["config", "set", "agents.defaults.model.primary", "deepseek/deepseek-chat"],
-      { timeout: 10000 },
-    );
+    expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+      "agents.defaults.model.primary",
+      "deepseek/deepseek-chat",
+    ]);
     expect(body.activeSource).toBe("primary");
     expect(body.activeLabel).toBe("ClawBox AI");
   });


### PR DESCRIPTION
## Summary
fix(config): robust openclaw config set — retry + Jetson-realistic timeout

Two tightly-related problems were surfacing on a Jetson Orin Nano
running beta, both in any ClawBox route that calls `openclaw config
set`:

1. Transient `ConfigMutationConflictError` races. OpenClaw's config
   writer uses optimistic concurrency — it reads a content hash,
   computes the new state, and writes only if the hash is still the
   same. Meanwhile the gateway process watches openclaw.json and
   reloads on changes, touching `meta.lastTouchedAt`, and
   `gateway-pre-start.sh` writes a few auth flags on every gateway
   restart. So the sequences ClawBox runs — many back-to-back
   `openclaw config set` invocations, each followed by a gateway
   restart — have natural windows where one write can race another and
   surface "config changed since last load". When that happened, the
   ClawBox route returned an HTTP error, the ClawBox-side config-store
   flag (ai_model_configured, local_ai_configured, local_only_mode)
   never got written, and the setup wizard / Settings app kept
   prompting the user to retry forever even though the underlying
   OpenClaw config had actually accepted the change before the race
   killed the sequence. Observed in rapid succession on this hardware
   while configuring OpenAI OAuth, enabling ClawBox AI (Gemma 4 via
   llama.cpp), and toggling Local-only mode — same failure pattern
   every time.

2. Baseline CLI latency on Jetson. `openclaw config set` is a
   full-weight Node.js program: it boots the gateway SDK, parses
   plugins, validates the config schema, and only then performs the
   actual write. Measured on the target hardware, three sequential
   idle runs each took 10.5-10.7 s of wall time. Routes in this
   codebase were previously bounding the helper with a 10 s
   per-attempt timeout, which meant every single invocation on Jetson
   tripped the timeout and reported a "command failed: openclaw config
   set … timed out after 10000ms" error to the browser — regardless of
   whether a race happened or not. Bumping the per-attempt budget to
   30 s covers the observed baseline with headroom for light
   contention, while still bounding worst-case stalls.

Changes:

- src/lib/openclaw-config.ts: new `runOpenclawConfigSet(args, options)`
  helper that wraps `spawn openclaw config set <args>` and retries up
  to four times on `ConfigMutationConflictError` with a
  `baseBackoffMs * attempt` backoff. Defaults: 4 attempts, 100 ms
  base, 30 s per-attempt timeout (was 10 s — see problem 2 above).
  Any other spawn/exit failure still propagates on the first attempt —
  the retry is deliberately targeted at the one known-safe-to-retry
  race. Supports uid / gid / cwd / env options so callers that need
  to drop privileges to the clawbox user can do so without

## Test plan
- [x] Deployed and verified live on Jetson Orin during development session (2026-04-18)
- [ ] CodeRabbit bot review (triggered automatically on draft open)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI model configuration updates with automatic retry logic for transient conflicts.
  * Enhanced error handling and robustness in model selection and exclusive local AI mode setup.

* **Improvements**
  * Optimized internal command execution with configurable timeout and backoff mechanisms for increased resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->