### PR TITLE
fix(gateway): include device LAN IPv4s in Control UI origin allowlist

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -47,7 +47,34 @@ fi
 
 "$OPENCLAW_BIN" config set gateway.controlUi.allowInsecureAuth true --json 2>/dev/null || true
 "$OPENCLAW_BIN" config set gateway.controlUi.dangerouslyDisableDeviceAuth true --json 2>/dev/null || true
-"$OPENCLAW_BIN" config set gateway.controlUi.allowedOrigins "[\"http://${CONFIGURED_HOSTNAME}.local\",\"http://localhost\",\"http://127.0.0.1\",\"http://10.42.0.1\",\"http://10.43.0.1\"]" --json 2>/dev/null || true
+
+# Build the allowlist dynamically. The hardcoded set (mDNS hostname +
+# loopback + hotspot AP IPs) is always included, and on top of that we
+# enumerate every IPv4 currently assigned to a real network interface
+# on this host so any client hitting us via the device's LAN IP
+# (http://192.168.x.y, http://10.0.x.y, etc.) is accepted. Without this
+# dynamic part, users on Windows hitting the IP directly — because
+# `clawbox.local` resolution is still warming up on their machine —
+# get a "origin not allowed" gateway rejection, the Control UI
+# silently falls back to the secondary (cloud) model, and local chat
+# with Gemma quietly stops working.
+LAN_IPS=""
+if command -v ip >/dev/null 2>&1; then
+  # `ip -o -4 addr` prints one line per address, e.g.
+  # "3: wlP1p1s0  inet 192.168.1.58/24 ..." — we grab the address,
+  # strip loopback and link-local (169.254/16), and emit one JSON entry
+  # per remaining IP.
+  while read -r ip4; do
+    case "$ip4" in
+      127.*|169.254.*|"") continue ;;
+    esac
+    LAN_IPS="${LAN_IPS},\"http://${ip4}\""
+  done <<EOF_IPS
+$(ip -o -4 addr show 2>/dev/null | awk '{print $4}' | cut -d/ -f1)
+EOF_IPS
+fi
+
+"$OPENCLAW_BIN" config set gateway.controlUi.allowedOrigins "[\"http://${CONFIGURED_HOSTNAME}.local\",\"http://localhost\",\"http://127.0.0.1\",\"http://10.42.0.1\",\"http://10.43.0.1\"${LAN_IPS}]" --json 2>/dev/null || true
 "$OPENCLAW_BIN" config set gateway.bind lan 2>/dev/null || true
 "$OPENCLAW_BIN" config set gateway.mode local 2>/dev/null || true
 "$OPENCLAW_BIN" config set gateway.auth.mode token 2>/dev/null || true


### PR DESCRIPTION
## Summary
fix(gateway): include device LAN IPv4s in Control UI origin allowlist

gateway-pre-start.sh re-pins `gateway.controlUi.allowedOrigins` on
every gateway restart to a static list of
  http://<hostname>.local, http://localhost, http://127.0.0.1,
  http://10.42.0.1, http://10.43.0.1
This ignores the device's actual LAN IPv4 (e.g. 192.168.1.58 on a
typical home network).

The Control UI advertised by the OpenClaw gateway opens its WebSocket
directly to `<gateway-lan-ip>:18789` — not via same-origin through the
Next.js proxy on port 80 — because `gateway.bind=lan` exposes the
LAN IP as the canonical gateway endpoint. That means the browser
sends `Origin: http://<lan-ip>` on the upgrade, which is not in the
static allowlist above, and the gateway rejects the handshake with:

  origin not allowed (open the Control UI from the gateway host or
  allow it in gateway.controlUi.allowedOrigins)

The user sees this as the chat panel silently falling back to the
secondary model (DeepSeek via ClawBox AI) because the realtime
connection to the primary (local Gemma) never completes. On the
Jetson I observed:

  [ws] closed before connect ... origin=http://192.168.1.58 host=192.168.1.58:18789
    code=1008 reason=origin not allowed ...

Fix: at pre-start time, enumerate every IPv4 currently bound to a
non-loopback, non-link-local interface on this host with `ip -o -4
addr` and append an entry per address to the allowlist. The
hardcoded base set (mDNS hostname + loopback + hotspot APs) stays
intact so offline setup via the AP keeps working. Running the hook
on every restart keeps the allowlist accurate when DHCP hands the
Jetson a new address on reconnect.

Follow-up (not in this PR): the real fix is to flip
`gateway.bind` to `loopback`, expose the gateway only via the
Next.js / production-server.js proxy on port 80, and let the
Control UI use same-origin WebSockets. That eliminates the
allowlist entirely. Doing so here is riskier — any direct
:18789 consumer (macOS app, iOS/Android nodes pairing via LAN
IP, operator ssh tunnel) would need migration first.

## Test plan
- [x] Deployed and verified live on Jetson Orin during development session (2026-04-18)
- [ ] CodeRabbit bot review (triggered automatically on draft open)