### PR TITLE
fix(local-ai): show 'Gemma 4 configured' pill when installed, even across standby

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -788,6 +788,11 @@ export default function AIModelsStep({
   const configuringCompleted = configuringState?.completed ?? false;
 
   useEffect(() => {
+    if (selectedProvider === "llamacpp") checkLlamaCppStatus();
+    if (selectedProvider === "ollama") checkOllamaStatus();
+  }, [selectedProvider, checkLlamaCppStatus, checkOllamaStatus]);
+
+  useEffect(() => {
     if (configuringKind !== "generic" || configuringCompleted) return;
 
     const timers = CONFIGURING_STEP_DELAYS.map((delay, index) =>

--- a/src/components/LlamaCppModelPanel.tsx
+++ b/src/components/LlamaCppModelPanel.tsx
@@ -60,15 +60,26 @@ export default function LlamaCppModelPanel({
         </p>
       </div>
 
-      <button
-        type="button"
-        onClick={() => saveLlamaCppConfig(selectedLlamaCppModel)}
-        disabled={!!llamaCppSaving}
-        className={buttonClassName}
-      >
-        {llamaCppSaving && buttonSpinner}
-        {llamaCppSaving ? "Enabling Gemma 4..." : llamaCppRunning ? "Enable Gemma 4" : "Enable Gemma 4"}
-      </button>
+      {llamaCppInstalled && !llamaCppSaving ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="mt-3 px-5 py-3 rounded-lg font-semibold text-sm border border-emerald-500/40 bg-emerald-500/10 text-emerald-300 flex items-center gap-2"
+        >
+          <span className="material-symbols-rounded" style={{ fontSize: 20 }}>check_circle</span>
+          {llamaCppRunning ? "Gemma 4 is enabled and running" : "Gemma 4 is already configured"}
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => saveLlamaCppConfig(selectedLlamaCppModel)}
+          disabled={!!llamaCppSaving}
+          className={buttonClassName}
+        >
+          {llamaCppSaving && buttonSpinner}
+          {llamaCppSaving ? "Enabling Gemma 4..." : "Enable Gemma 4"}
+        </button>
+      )}
 
       {llamaCppSaving && llamaCppProgress && (
         <p className="text-xs text-[var(--text-secondary)] leading-relaxed">

--- a/src/tests/components/ai-models-step.test.tsx
+++ b/src/tests/components/ai-models-step.test.tsx
@@ -118,7 +118,11 @@ describe("AIModelsStep variants", () => {
     expect(queryByText("ClawBox AI")).not.toBeInTheDocument();
     expect(queryByText("OpenAI GPT")).not.toBeInTheDocument();
     expect(getByText("Recommended")).toBeInTheDocument();
-    expect(getByText("Enable Gemma 4")).toBeInTheDocument();
+    // With the mocked hook returning llamaCppInstalled: true (i.e. Gemma is
+    // already on disk but the runtime is idle), the panel renders a green
+    // "configured" pill instead of the install button. Users should only see
+    // the orange "Enable Gemma 4" call-to-action on truly fresh devices.
+    expect(getByText("Gemma 4 is already configured")).toBeInTheDocument();
   });
 
   it("skips Local AI setup by advancing to the next step", async () => {


### PR DESCRIPTION
## Summary
fix(local-ai): show 'Gemma 4 configured' pill when installed, even across standby

Two separate bugs combined to produce the same symptom: the 'Enable Gemma 4'
button kept rendering even after Gemma was fully installed and configured,
tempting users to reinstall.

1. LlamaCppModelPanel: the pill condition was gated on llamaCppRunning, but
   the llama-server process idle-stops after 10 min via standby mode, so
   'running' flips back to false between chats. Switched the pill to gate
   on llamaCppInstalled (persists across standby), with copy that reflects
   whether the process is currently live or idle.

2. AIModelsStep: checkLlamaCppStatus / checkOllamaStatus were only called
   inside selectProvider, which fires on user click. If llamacpp is the
   pre-selected default (as in Local AI mode), the status fetch never ran
   on mount — both llamaCppInstalled and llamaCppRunning stayed at their
   useState(false) defaults, and the panel rendered the 'not installed'
   branch despite the API returning installed: true. Added a useEffect
   that queries status whenever the selected provider is llamacpp/ollama.

Also removed the old ternary 'llamaCppRunning ? "Enable Gemma 4" : "Enable Gemma 4"'
(two identical branches, leftover from a half-finished edit).

## Test plan
- [x] Deployed and verified live on Jetson Orin during development session (2026-04-18)
- [ ] CodeRabbit bot review (triggered automatically on draft open)