### PR TITLE
fix(chat): model-dropdown switches actually stick

### DIFF
--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from "next/server";
 import { getAll } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, type OpenClawConfig } from "@/lib/openclaw-config";
+import {
+  inferConfiguredLocalModel,
+  readConfig,
+  restartGateway,
+  runOpenclawConfigSet,
+  applyModelOverrideToAllAgentSessions,
+  parseFullyQualifiedModel,
+  type OpenClawConfig,
+} from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 
 export const dynamic = "force-dynamic";
@@ -296,13 +304,41 @@ export async function POST(request: Request) {
       await sqliteSet(PRIMARY_MODEL_KEY, state.activeModel);
     }
 
-    // runOpenclawConfigSet retries on transient ConfigMutationConflictError
-    // so users switching chat models don't see a bogus failure when the
-    // gateway reloads concurrently with the write. Leave timeoutMs on the
-    // helper's default — the OpenClaw CLI itself takes 10-12 s per call
-    // on Jetson Orin hardware, so a tighter bound here was producing
-    // spurious "timed out" errors on every legitimate invocation.
+    // 1. Update the agent-level default so any *future* session starts
+    //    with the user's chosen model. runOpenclawConfigSet retries on
+    //    transient ConfigMutationConflictError and uses a 30 s per-attempt
+    //    timeout by default (CLI startup alone is ~10 s on Jetson Orin),
+    //    so users switching chat models don't see a bogus failure when the
+    //    gateway reloads concurrently with the write.
     await runOpenclawConfigSet(["agents.defaults.model.primary", targetModel]);
+
+    // 2. Sweep every existing session's per-session override to the
+    //    same model, tagged `source: "user"` so OpenClaw's per-turn
+    //    model resolver returns early and leaves the override alone
+    //    on each subsequent message. Without this step, changing the
+    //    chat model dropdown only affected newly-opened sessions —
+    //    the currently-open chat pane kept routing to whatever
+    //    provider its `modelOverrideSource: "auto"` entry had picked,
+    //    making the UI dropdown feel broken. (NB: "manual" *looks*
+    //    like the right string but isn't recognised anywhere in the
+    //    OpenClaw dist; only "user" is sticky. See the docstring on
+    //    `applyModelOverrideToAllAgentSessions`.)
+    const parsed = parseFullyQualifiedModel(targetModel);
+    if (parsed) {
+      try {
+        await applyModelOverrideToAllAgentSessions({
+          provider: parsed.provider,
+          modelId: parsed.modelId,
+          source: "user",
+        });
+      } catch (err) {
+        // Non-fatal: the default change (step 1) still takes effect
+        // for brand-new sessions. Worst case the user has to /reset
+        // the open chat. Log and continue.
+        console.error("[chat/model] Failed to sweep session overrides:", err);
+      }
+    }
+
     await restartGateway();
 
     const nextState = await loadChatModelState();

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1066,33 +1066,38 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
           </div>
         )}
 
-        {!reloadingSkill && messages.map((msg, i) => (
-          <div key={i} style={{
-            display: 'flex',
-            justifyContent: msg.role === 'user' ? 'flex-end' : 'flex-start',
-          }}>
-            <div style={{
-              maxWidth: '85%',
-              padding: msg.role === 'system' ? '6px 12px' : '8px 14px',
-              borderRadius: msg.role === 'user' ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
-              background: msg.role === 'user'
-                ? 'linear-gradient(135deg, #f97316 0%, #ea580c 100%)'
-                : msg.role === 'system'
-                  ? (msg.variant === 'success' ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)')
-                  : 'rgba(255,255,255,0.06)',
-              color: msg.role === 'user'
-                ? '#fff'
-                : msg.role === 'system'
-                  ? (msg.variant === 'success' ? '#22c55e' : '#ef4444')
-                  : 'rgba(255,255,255,0.85)',
-              fontSize: 13.5,
-              lineHeight: 1.45,
-              wordBreak: 'break-word',
+        {!reloadingSkill && messages.map((msg, i) => {
+          const isSuccess = msg.variant === 'success';
+          const systemBg = isSuccess ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)';
+          const systemColor = isSuccess ? '#22c55e' : '#ef4444';
+          return (
+            <div key={i} style={{
+              display: 'flex',
+              justifyContent: msg.role === 'user' ? 'flex-end' : 'flex-start',
             }}>
-              {msg.role === 'user' ? msg.text : renderText(msg.text)}
+              <div style={{
+                maxWidth: '85%',
+                padding: msg.role === 'system' ? '6px 12px' : '8px 14px',
+                borderRadius: msg.role === 'user' ? '14px 14px 4px 14px' : '14px 14px 14px 4px',
+                background: msg.role === 'user'
+                  ? 'linear-gradient(135deg, #f97316 0%, #ea580c 100%)'
+                  : msg.role === 'system'
+                    ? systemBg
+                    : 'rgba(255,255,255,0.06)',
+                color: msg.role === 'user'
+                  ? '#fff'
+                  : msg.role === 'system'
+                    ? systemColor
+                    : 'rgba(255,255,255,0.85)',
+                fontSize: 13.5,
+                lineHeight: 1.45,
+                wordBreak: 'break-word',
+              }}>
+                {msg.role === 'user' ? msg.text : renderText(msg.text)}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
 
         {/* Streaming message */}
         {!reloadingSkill && streaming && (

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -56,6 +56,14 @@ interface ChatMessage {
   role: 'user' | 'assistant' | 'system'
   text: string
   timestamp: number
+  /**
+   * Visual variant for `system` role messages. "error" is the default
+   * (red pill) and is what surfaces for WebSocket failures, model-switch
+   * errors, and similar user-visible problems. "success" (green pill)
+   * is for confirmations — e.g. "Switched chat to X" after the user
+   * picks a new model. Ignored for 'user' and 'assistant' roles.
+   */
+  variant?: 'success' | 'error'
 }
 
 interface ChatModelState {
@@ -693,6 +701,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         role: 'system',
         text: `Switched chat to ${target.model}.`,
         timestamp: Date.now(),
+        variant: 'success',
       }])
       retryCountRef.current = 0
       connect()
@@ -1069,9 +1078,13 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
               background: msg.role === 'user'
                 ? 'linear-gradient(135deg, #f97316 0%, #ea580c 100%)'
                 : msg.role === 'system'
-                  ? 'rgba(239,68,68,0.15)'
+                  ? (msg.variant === 'success' ? 'rgba(34,197,94,0.15)' : 'rgba(239,68,68,0.15)')
                   : 'rgba(255,255,255,0.06)',
-              color: msg.role === 'user' ? '#fff' : msg.role === 'system' ? '#ef4444' : 'rgba(255,255,255,0.85)',
+              color: msg.role === 'user'
+                ? '#fff'
+                : msg.role === 'system'
+                  ? (msg.variant === 'success' ? '#22c55e' : '#ef4444')
+                  : 'rgba(255,255,255,0.85)',
               fontSize: 13.5,
               lineHeight: 1.45,
               wordBreak: 'break-word',

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -141,8 +141,156 @@ function spawnOpenclawConfigSet(
   });
 }
 const OPENCLAW_HOME = process.env.OPENCLAW_HOME || "/home/clawbox/.openclaw";
+const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || path.join(OPENCLAW_HOME, "agents");
 export const CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 export const DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR = 24000;
+
+// Fields on each entry of `<agents-dir>/<agent>/sessions/sessions.json`
+// that OpenClaw reads to decide which provider/model a running session
+// uses. These are *independent* of `agents.defaults.model.primary` —
+// that's just the seed for newly-opened sessions. Existing sessions
+// use whichever values are baked into this per-session record, and
+// OpenClaw's own auto-picker will re-populate them at chat time unless
+// `modelOverrideSource` is already "manual".
+const SESSION_OVERRIDE_FIELDS = [
+  "providerOverride",
+  "modelOverride",
+  "modelOverrideSource",
+  "authProfileOverride",
+  "authProfileOverrideSource",
+  "modelProvider",
+  "model",
+] as const;
+
+interface SessionOverrideUpdate {
+  /** Provider id, e.g. "llamacpp", "deepseek", "openai". */
+  provider: string;
+  /** Model id within the provider, e.g. "gemma4-e2b-it-q4_0". */
+  modelId: string;
+  /**
+   * Source tag stored alongside the override. Pass **"user"** for any
+   * user-initiated choice (UI clicks, explicit Local-only toggle).
+   * OpenClaw's per-turn model resolver returns early when it sees
+   * `modelOverrideSource === "user"` on an existing entry, which is
+   * the only reliable way to make an override stick against the
+   * auto-picker. `"manual"` is *not* a sticky value — OpenClaw's
+   * resolver doesn't special-case it and will happily overwrite it
+   * back to `"auto"` on the next turn. Pass `"auto"` only when the
+   * caller is the resolver itself (not us).
+   */
+  source?: "user" | "manual" | "auto";
+  /** Auth profile key. Defaults to `<provider>:default`. */
+  authProfile?: string;
+}
+
+async function listAgentSessionsFiles(agentsDir: string): Promise<string[]> {
+  const results: string[] = [];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(agentsDir);
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const candidate = path.join(agentsDir, entry, "sessions", "sessions.json");
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) results.push(candidate);
+    } catch {
+      // No sessions directory for this agent — skip.
+    }
+  }
+  return results;
+}
+
+async function atomicWriteSessionsFile(filePath: string, data: unknown): Promise<void> {
+  const tmp = `${filePath}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf-8");
+  await fs.rename(tmp, filePath);
+}
+
+/**
+ * Rewrite every session's per-session model/provider override across
+ * every agent on disk to the given target, tagged with the given
+ * source. Returns how many sessions were touched.
+ *
+ * Use `source: "user"` (also the default) when the caller is acting
+ * on a direct user choice — chat-panel model dropdown, Local-only
+ * toggle, etc. OpenClaw's per-turn model resolver explicitly returns
+ * early for entries whose `modelOverrideSource === "user"`, which is
+ * the only value that survives the auto-picker re-evaluating on
+ * every message. `"manual"` looks reasonable but is not special-cased
+ * anywhere in the OpenClaw dist and gets silently overwritten back
+ * to `"auto"` on the next turn.
+ *
+ * Writes are atomic (temp + rename). If any individual sessions.json
+ * fails to parse/write, the error is logged and the sweep continues —
+ * one bad file should not block the rest.
+ */
+export async function applyModelOverrideToAllAgentSessions(
+  update: SessionOverrideUpdate,
+  opts: { agentsDir?: string } = {},
+): Promise<{ filesUpdated: number; sessionsUpdated: number }> {
+  const agentsDir = opts.agentsDir ?? AGENTS_DIR;
+  const source = update.source ?? "user";
+  const authProfile = update.authProfile ?? `${update.provider}:default`;
+
+  let filesUpdated = 0;
+  let sessionsUpdated = 0;
+
+  const files = await listAgentSessionsFiles(agentsDir);
+  for (const file of files) {
+    let parsed: Record<string, Record<string, unknown>>;
+    try {
+      const raw = await fs.readFile(file, "utf-8");
+      parsed = JSON.parse(raw);
+    } catch (err) {
+      console.error(`[openclaw-config] Skipping unreadable sessions file ${file}:`, err);
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+
+    let fileDirty = false;
+    for (const sessionKey of Object.keys(parsed)) {
+      const session = parsed[sessionKey];
+      if (!session || typeof session !== "object") continue;
+      session.providerOverride = update.provider;
+      session.modelOverride = update.modelId;
+      session.modelOverrideSource = source;
+      session.authProfileOverride = authProfile;
+      session.authProfileOverrideSource = source;
+      session.modelProvider = update.provider;
+      session.model = update.modelId;
+      fileDirty = true;
+      sessionsUpdated += 1;
+    }
+
+    if (!fileDirty) continue;
+    try {
+      await atomicWriteSessionsFile(file, parsed);
+      filesUpdated += 1;
+    } catch (err) {
+      console.error(`[openclaw-config] Failed to write patched sessions file ${file}:`, err);
+    }
+  }
+
+  return { filesUpdated, sessionsUpdated };
+}
+
+/**
+ * Parse a fully-qualified model id "<provider>/<modelId>" (e.g.
+ * "llamacpp/gemma4-e2b-it-q4_0"). Returns null when the format is
+ * unrecognised — callers should fall back to skipping the session
+ * sweep rather than writing a broken override.
+ */
+export function parseFullyQualifiedModel(fq: string): { provider: string; modelId: string } | null {
+  const idx = fq.indexOf("/");
+  if (idx <= 0 || idx === fq.length - 1) return null;
+  return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+}
+// Expose field list for downstream callers (e.g. exclusive/route.ts
+// which still needs to snapshot + restore the raw per-field state).
+export const SESSION_OVERRIDE_FIELD_LIST: readonly string[] = SESSION_OVERRIDE_FIELDS;
 
 export interface OpenClawConfig {
   [key: string]: unknown;

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -152,7 +152,10 @@ export const DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR = 24000;
 // use whichever values are baked into this per-session record, and
 // OpenClaw's own auto-picker will re-populate them at chat time unless
 // `modelOverrideSource` is already "manual".
-const SESSION_OVERRIDE_FIELDS = [
+//
+// Exported for downstream callers (e.g. exclusive/route.ts) that need
+// to snapshot + restore the raw per-field state.
+export const SESSION_OVERRIDE_FIELDS = [
   "providerOverride",
   "modelOverride",
   "modelOverrideSource",
@@ -240,19 +243,18 @@ export async function applyModelOverrideToAllAgentSessions(
 
   const files = await listAgentSessionsFiles(agentsDir);
   for (const file of files) {
-    let parsed: Record<string, Record<string, unknown>>;
+    let parsed: unknown;
     try {
-      const raw = await fs.readFile(file, "utf-8");
-      parsed = JSON.parse(raw);
+      parsed = JSON.parse(await fs.readFile(file, "utf-8"));
     } catch (err) {
       console.error(`[openclaw-config] Skipping unreadable sessions file ${file}:`, err);
       continue;
     }
     if (!parsed || typeof parsed !== "object") continue;
 
-    let fileDirty = false;
-    for (const sessionKey of Object.keys(parsed)) {
-      const session = parsed[sessionKey];
+    const sessions = parsed as Record<string, Record<string, unknown>>;
+    let touchedInFile = 0;
+    for (const session of Object.values(sessions)) {
       if (!session || typeof session !== "object") continue;
       session.providerOverride = update.provider;
       session.modelOverride = update.modelId;
@@ -261,14 +263,14 @@ export async function applyModelOverrideToAllAgentSessions(
       session.authProfileOverrideSource = source;
       session.modelProvider = update.provider;
       session.model = update.modelId;
-      fileDirty = true;
-      sessionsUpdated += 1;
+      touchedInFile += 1;
     }
 
-    if (!fileDirty) continue;
+    if (touchedInFile === 0) continue;
     try {
-      await atomicWriteSessionsFile(file, parsed);
+      await atomicWriteSessionsFile(file, sessions);
       filesUpdated += 1;
+      sessionsUpdated += touchedInFile;
     } catch (err) {
       console.error(`[openclaw-config] Failed to write patched sessions file ${file}:`, err);
     }
@@ -288,9 +290,6 @@ export function parseFullyQualifiedModel(fq: string): { provider: string; modelI
   if (idx <= 0 || idx === fq.length - 1) return null;
   return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
 }
-// Expose field list for downstream callers (e.g. exclusive/route.ts
-// which still needs to snapshot + restore the raw per-field state).
-export const SESSION_OVERRIDE_FIELD_LIST: readonly string[] = SESSION_OVERRIDE_FIELDS;
 
 export interface OpenClawConfig {
   [key: string]: unknown;

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -19,6 +19,8 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
+  applyModelOverrideToAllAgentSessions: vi.fn(),
+  parseFullyQualifiedModel: vi.fn(),
 }));
 
 vi.mock("@/lib/sqlite-store", () => ({
@@ -27,7 +29,7 @@ vi.mock("@/lib/sqlite-store", () => ({
 }));
 
 import { getAll } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { promisify } from "util";
 
@@ -43,6 +45,12 @@ describe("/setup-api/chat/model", () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
     vi.mocked(promisify).mockReturnValue(mockExec as never);
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(parseFullyQualifiedModel).mockImplementation((fq: string) => {
+      const idx = fq.indexOf("/");
+      if (idx <= 0) return null;
+      return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+    });
 
     vi.mocked(getAll).mockResolvedValue({
       ai_model_provider: "clawai",


### PR DESCRIPTION
## Summary
fix(chat): green confirmation pill on model switch, keep red for errors

The chat panel's `ChatMessage` type uses the same `role: 'system'`
for both error banners (WebSocket dropped, model switch failed) and
the "Switched chat to X." confirmation we emit after a successful
dropdown pick. The shared style renders both in a red pill with red
text, so a successful model switch looks like a failure in the
stream. In the screenshot the user showed, "Switched chat to
llamacpp/gemma4-e2b-it-q4_0." appeared directly above a real
`Error:` banner in identical styling — no visual distinction.

Changes in src/components/ChatPopup.tsx:

- Add an optional `variant: 'success' | 'error'` to the `ChatMessage`
  interface. Defaults to `'error'` (no behaviour change for existing
  call sites: all the error paths keep their red styling).
- Tag the `Switched chat to X.` message with `variant: 'success'`.
- Update the inline message styles in the renderer to branch on
  `msg.variant` for `system`-role bubbles: emerald (`#22c55e` fg,
  `rgba(34,197,94,0.15)` bg) for success, keep the existing red
  (`#ef4444` fg, `rgba(239,68,68,0.15)` bg) for errors.

Other system-role call sites — WS error banners, connection
failures, "provider not configured" hints — all keep the default
`'error'` variant and render red, so nothing else regresses.

fix(chat): model-dropdown switches actually stick to the active session

The ClawBox chat-panel model dropdown (`ChatPopup.tsx`) POSTs to
`/setup-api/chat/model` when the user picks a model. That route
previously did only two things:

  await exec(openclaw, ["config", "set", "agents.defaults.model.primary", target]);
  await restartGateway();

Both writes are correct, and new sessions opened after the restart
inherit the chosen model. But they left the *currently open chat
session's per-session override* untouched. That override lives in
`<agents-dir>/<agent>/sessions/sessions.json` as:

  "providerOverride":       "deepseek",
  "modelOverride":          "deepseek-chat",
  "modelOverrideSource":    "auto",
  "authProfileOverride":    "deepseek:default",
  ...

and it's what OpenClaw actually consults at chat time to decide which
provider to dial. Because the source was `"auto"`, OpenClaw's own
auto-picker happily rewrote it to whatever it preferred on every new
message — usually the local provider when reachable — so the chat

## Test plan
- [x] Deployed and verified live on Jetson Orin during development session (2026-04-18)
- [ ] CodeRabbit bot review (triggered automatically on draft open)