### PR TITLE
fix(local-only): sweep per-session provider overrides on toggle

### DIFF
--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -1,12 +1,37 @@
 export const dynamic = "force-dynamic";
 
+import fs from "fs/promises";
+import path from "path";
 import { NextResponse } from "next/server";
 import { get, set, setMany } from "@/lib/config-store";
 import { readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
 
 const SAVED_PRIMARY_KEY = "local_only_saved_primary";
 const SAVED_FALLBACKS_KEY = "local_only_saved_fallbacks";
+const SAVED_SESSION_OVERRIDES_KEY = "local_only_saved_session_overrides";
 const MODE_KEY = "local_only_mode";
+
+const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || "/home/clawbox/.openclaw/agents";
+
+// Fields on each entry of `<agent>/sessions/sessions.json` that OpenClaw
+// reads to pick which provider/model the ongoing session is bound to.
+// They are independent of `agents.defaults.model.primary` — the latter
+// only seeds *new* sessions; existing sessions use whichever values are
+// baked into this per-session record at the moment they were opened.
+const SESSION_OVERRIDE_FIELDS = [
+  "providerOverride",
+  "modelOverride",
+  "modelOverrideSource",
+  "authProfileOverride",
+  "authProfileOverrideSource",
+  "modelProvider",
+  "model",
+] as const;
+
+type SessionOverrideField = (typeof SESSION_OVERRIDE_FIELDS)[number];
+type SessionOverrideSnapshot = Partial<Record<SessionOverrideField, unknown>>;
+type SessionsFileBackup = Record<string, SessionOverrideSnapshot>;
+type FilesBackup = Record<string, SessionsFileBackup>;
 
 // Route OpenClaw config mutations through the shared retry-aware helper.
 // The gateway reload + gateway-pre-start.sh write the same config file
@@ -20,6 +45,153 @@ async function setConfig(key: string, valueJson: string) {
   // 10-12 s per invocation on Jetson, so tighter bounds here produced
   // spurious "timed out" errors that made Local-only mode fail to toggle.
   await runOpenclawConfigSet([key, valueJson, "--json"]);
+}
+
+/** Parse "llamacpp/gemma4-e2b-it-q4_0" into {provider, modelId}. */
+function parseLocalModel(fq: string): { provider: string; modelId: string } | null {
+  const idx = fq.indexOf("/");
+  if (idx <= 0 || idx === fq.length - 1) return null;
+  return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+}
+
+/** Enumerate every `sessions/sessions.json` under the agents directory. */
+async function listSessionsFiles(): Promise<string[]> {
+  const results: string[] = [];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(AGENTS_DIR);
+  } catch {
+    return results;
+  }
+  for (const entry of entries) {
+    const candidate = path.join(AGENTS_DIR, entry, "sessions", "sessions.json");
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) results.push(candidate);
+    } catch {
+      // No sessions for this agent yet — skip.
+    }
+  }
+  return results;
+}
+
+/**
+ * Atomically rewrite a sessions.json file. Uses the standard temp+rename
+ * pattern so a crash mid-write can't leave a half-written file where
+ * OpenClaw would refuse to resume the session.
+ */
+async function atomicWriteJson(filePath: string, data: unknown): Promise<void> {
+  const tmp = `${filePath}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2), "utf-8");
+  await fs.rename(tmp, filePath);
+}
+
+/**
+ * Read + parse a sessions.json file, returning null (and logging) if the
+ * file is missing, unreadable, or not a JSON object. Centralises the
+ * parse-and-narrow logic so both the patch and restore passes treat
+ * malformed files the same way.
+ */
+async function readSessionsJson(
+  file: string,
+  phase: "patch" | "restore",
+): Promise<Record<string, Record<string, unknown>> | null> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await fs.readFile(file, "utf-8"));
+  } catch (err) {
+    console.error(`[local-only] Skipping unreadable sessions file on ${phase} ${file}:`, err);
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  return parsed as Record<string, Record<string, unknown>>;
+}
+
+/**
+ * For every entry in every `sessions.json` on disk, replace the model
+ * and provider override fields with the Local-only target, and return
+ * a backup of the prior values (per file, per session key) so the
+ * toggle can be reversed later.
+ *
+ * Sessions that were already pointing at a local provider are left
+ * untouched but still recorded in the backup with their exact prior
+ * values, so flipping back and forth preserves them.
+ */
+async function patchAllSessionOverrides(
+  localProvider: string,
+  localModelId: string,
+): Promise<FilesBackup> {
+  const filesBackup: FilesBackup = {};
+  const files = await listSessionsFiles();
+  for (const file of files) {
+    const parsed = await readSessionsJson(file, "patch");
+    if (!parsed) continue;
+
+    const fileBackup: SessionsFileBackup = {};
+    for (const [sessionKey, session] of Object.entries(parsed)) {
+      if (!session || typeof session !== "object") continue;
+
+      const snapshot: SessionOverrideSnapshot = {};
+      for (const field of SESSION_OVERRIDE_FIELDS) {
+        // Use Object.prototype.hasOwnProperty-style check so we can tell
+        // "field explicitly set to null" apart from "field absent". On
+        // restore, absent fields are deleted rather than written as null.
+        if (Object.prototype.hasOwnProperty.call(session, field)) {
+          snapshot[field] = session[field];
+        }
+      }
+      fileBackup[sessionKey] = snapshot;
+
+      session.providerOverride = localProvider;
+      session.modelOverride = localModelId;
+      session.modelOverrideSource = "manual";
+      session.authProfileOverride = `${localProvider}:default`;
+      session.authProfileOverrideSource = "manual";
+      session.modelProvider = localProvider;
+      session.model = localModelId;
+    }
+    filesBackup[file] = fileBackup;
+
+    try {
+      await atomicWriteJson(file, parsed);
+    } catch (err) {
+      console.error(`[local-only] Failed to write patched sessions file ${file}:`, err);
+    }
+  }
+  return filesBackup;
+}
+
+/**
+ * Reverse the effect of {@link patchAllSessionOverrides}. For every
+ * session recorded in the backup, restore each override field to its
+ * prior value — or delete it entirely if it was absent before.
+ *
+ * Sessions that have appeared since the backup was taken are left alone
+ * (no backup entry → nothing to restore → user's current state wins).
+ */
+async function restoreSessionOverrides(backup: FilesBackup): Promise<void> {
+  for (const [file, sessions] of Object.entries(backup)) {
+    const parsed = await readSessionsJson(file, "restore");
+    if (!parsed) continue;
+
+    for (const [sessionKey, snapshot] of Object.entries(sessions)) {
+      const session = parsed[sessionKey];
+      if (!session || typeof session !== "object") continue;
+      for (const field of SESSION_OVERRIDE_FIELDS) {
+        if (Object.prototype.hasOwnProperty.call(snapshot, field)) {
+          session[field] = snapshot[field];
+        } else {
+          delete session[field];
+        }
+      }
+    }
+
+    try {
+      await atomicWriteJson(file, parsed);
+    } catch (err) {
+      console.error(`[local-only] Failed to write restored sessions file ${file}:`, err);
+    }
+  }
 }
 
 export async function GET() {
@@ -50,6 +222,14 @@ export async function POST(request: Request) {
       if (!localModel) {
         return NextResponse.json({ error: "Local AI is not configured" }, { status: 400 });
       }
+      const parsedLocal = parseLocalModel(localModel);
+      if (!parsedLocal) {
+        return NextResponse.json(
+          { error: `local_ai_model is malformed: ${localModel}` },
+          { status: 400 },
+        );
+      }
+
       const config = await readConfig();
       const currentPrimary = config.agents?.defaults?.model?.primary ?? null;
       const currentFallbacks = config.agents?.defaults?.model?.fallbacks ?? [];
@@ -59,21 +239,42 @@ export async function POST(request: Request) {
       if (Array.isArray(currentFallbacks) && currentFallbacks.length > 0) {
         await set(SAVED_FALLBACKS_KEY, currentFallbacks);
       }
+
+      // 1. Flip the defaults so *new* sessions pick up local.
       await setConfig("agents.defaults.model.primary", JSON.stringify(localModel));
       await setConfig("agents.defaults.model.fallbacks", "[]");
+
+      // 2. Sweep every existing session's per-session override. Without
+      //    this step the toggle only affects sessions born after the
+      //    flip — any chat pane that was already open silently keeps
+      //    routing to its previously-bound cloud provider, and users
+      //    have no UI signal that Local-only isn't actually local.
+      const sessionBackup = await patchAllSessionOverrides(
+        parsedLocal.provider,
+        parsedLocal.modelId,
+      );
+      await set(SAVED_SESSION_OVERRIDES_KEY, sessionBackup);
+
       await set(MODE_KEY, true);
     } else {
       const savedPrimary = (await get(SAVED_PRIMARY_KEY)) as string | undefined;
       const savedFallbacks = (await get(SAVED_FALLBACKS_KEY)) as string[] | undefined;
+      const savedSessionOverrides = (await get(SAVED_SESSION_OVERRIDES_KEY)) as FilesBackup | undefined;
+
       if (savedPrimary) {
         await setConfig("agents.defaults.model.primary", JSON.stringify(savedPrimary));
       }
       if (Array.isArray(savedFallbacks) && savedFallbacks.length > 0) {
         await setConfig("agents.defaults.model.fallbacks", JSON.stringify(savedFallbacks));
       }
+      if (savedSessionOverrides) {
+        await restoreSessionOverrides(savedSessionOverrides);
+      }
+
       await setMany({
         [SAVED_PRIMARY_KEY]: undefined,
         [SAVED_FALLBACKS_KEY]: undefined,
+        [SAVED_SESSION_OVERRIDES_KEY]: undefined,
         [MODE_KEY]: undefined,
       });
     }


### PR DESCRIPTION
## Summary
fix(local-only): sweep per-session provider overrides on toggle

Local-only mode previously only flipped `agents.defaults.model.primary`
and cleared `agents.defaults.model.fallbacks` on the gateway. That
affected the *defaults for new sessions* but left every existing
session's per-session overrides untouched:

  "agent:main:main": {
    "providerOverride": "deepseek",
    "modelOverride": "deepseek-chat",
    "modelOverrideSource": "auto",
    "authProfileOverride": "deepseek:default",
    ...
  }

OpenClaw reads those fields from `<agents-dir>/<agent>/sessions/
sessions.json` on every chat request and routes the turn to the
pinned provider regardless of what the agent-level defaults say.
Result: the user toggles Local-only on, the toggle reports success,
the UI model pill says `llamacpp/gemma4-e2b-it-q4_0`, and every
chat still silently goes out to the cloud provider that was pinned
at session birth. Reproduced live on a Jetson with the local model
loaded and healthy — zero CPU on llama-server during the chat,
steady outbound TLS to openclawhardware.dev from the gateway, no
fallback-decision entries in the gateway log because no fallback
was actually happening: the primary was being resolved from the
session override, not the default.

Changes in src/app/setup-api/local-ai/exclusive/route.ts:

- Enumerate every `sessions.json` under /home/clawbox/.openclaw/agents
  (configurable via OPENCLAW_AGENTS_DIR for tests) and, for every
  session entry in each file, replace `providerOverride`,
  `modelOverride`, `modelOverrideSource`, `authProfileOverride`,
  `authProfileOverrideSource`, `modelProvider`, and `model` with the
  local target (e.g. provider=llamacpp, modelId=gemma4-e2b-it-q4_0,
  sources=manual so OpenClaw doesn't re-auto-select on next restart).
- Before overwriting, snapshot each field's prior value per-session
  (distinguishing "explicitly null" from "field absent") and save the
  entire per-file backup in ClawBox's config store under a new
  `local_only_saved_session_overrides` key. When the user toggles
  Local-only OFF, the backup is read back and fields are restored to
  their original values — or deleted entirely if they weren't set
  before — so the round-trip is lossless for sessions that existed
  at toggle-on time.
- Writes use a temp-file + rename atomic replace so a crash midway
  can't leave `sessions.json` corrupt (which would make OpenClaw
  refuse to resume those sessions).
- Sessions that appear *after* toggle-on are left alone on toggle-off:
  no backup exists for them, so the fresh override from when they

## Test plan
- [x] Deployed and verified live on Jetson Orin during development session (2026-04-18)
- [ ] CodeRabbit bot review (triggered automatically on draft open)