### PR TITLE
fix(install): redeploy clawbox-vnc.service on update path

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1123,9 +1123,19 @@ step_vnc_refresh() {
   # those are already on-disk from the original install and re-touching them
   # here risks extra reboot-time reruns (the firstboot flag) or racey restarts
   # of services that aren't involved in this particular bugfix.
-  apt-get install -y -qq autocutsel
+  #
+  # apt-get may collide with unattended-upgrades or a user-triggered install,
+  # so wait for the dpkg lock first. Make the install non-fatal — a transient
+  # apt failure here shouldn't block the more important unit refresh below.
+  wait_for_apt
+  if ! apt-get install -y -qq autocutsel; then
+    echo "  Warning: autocutsel install failed (non-fatal; continuing with unit refresh)"
+  fi
 
-  cat > /etc/systemd/system/clawbox-vnc.service <<VNCSVC
+  local unit_path=/etc/systemd/system/clawbox-vnc.service
+  local unit_tmp
+  unit_tmp="$(mktemp)"
+  cat > "$unit_tmp" <<VNCSVC
 [Unit]
 Description=ClawBox VNC (virtual desktop)
 After=network.target
@@ -1142,9 +1152,21 @@ RestartSec=5
 WantedBy=multi-user.target
 VNCSVC
 
-  systemctl daemon-reload
-  systemctl restart clawbox-vnc.service || true
-  echo "  VNC service refreshed (CLAWBOX_VNC_MODE=virtual, autocutsel installed)"
+  # Only reload + restart when the unit actually changed — the restart
+  # disconnects any active VNC viewer, so we don't want to kick sessions
+  # on an idempotent re-run. Websockify is tied to the VNC service via
+  # Requires=, but that only propagates *stops*, not restarts, so we
+  # bounce it alongside when the VNC unit changed to keep the proxy
+  # aligned with the freshly-restarted server.
+  if [ ! -f "$unit_path" ] || ! cmp -s "$unit_tmp" "$unit_path"; then
+    install -m 644 "$unit_tmp" "$unit_path"
+    systemctl daemon-reload
+    systemctl restart clawbox-vnc.service clawbox-websockify.service || true
+    echo "  VNC service refreshed (CLAWBOX_VNC_MODE=virtual, autocutsel installed)"
+  else
+    echo "  VNC service already up-to-date, skipping restart"
+  fi
+  rm -f "$unit_tmp"
 }
 
 step_desktop_theme() {

--- a/install.sh
+++ b/install.sh
@@ -793,6 +793,10 @@ step_post_update() {
   step_set_hostname || echo "  Warning: set_hostname step failed (non-fatal)"
   step_nm_dispatcher || echo "  Warning: nm_dispatcher step failed (non-fatal)"
   step_sysctl_linkdown || echo "  Warning: sysctl_linkdown step failed (non-fatal)"
+  # step_vnc_refresh is a tiny idempotent refresh of the clawbox-vnc.service
+  # unit + autocutsel package. Devices installed before the display-:99 move
+  # and the clipboard-sync addition get both here without needing a reinstall.
+  step_vnc_refresh || echo "  Warning: vnc_refresh step failed (non-fatal)"
 }
 
 step_polkit_rules() {
@@ -1105,6 +1109,44 @@ FIRSTBOOTVNC
   echo "  First reboot will re-ensure VNC services are active"
 }
 
+step_vnc_refresh() {
+  # Idempotent subset of step_vnc_install, safe to run on every update path.
+  # Picks up changes to the clawbox-vnc.service unit (e.g. the CLAWBOX_VNC_MODE
+  # env var added when we moved VNC off display :0) and installs packages
+  # added in later PRs (e.g. autocutsel for bidirectional VNC clipboard sync).
+  # Without this step, existing devices updating via the in-app updater never
+  # receive those fixes — they'd keep mirroring GDM's greeter + have no
+  # clipboard support until the owner did a fresh install.
+  #
+  # Deliberately a narrow subset of step_vnc_install — no firstboot-pending
+  # flag, no websockify unit rewrite, no clawbox-browser unit re-copy. All of
+  # those are already on-disk from the original install and re-touching them
+  # here risks extra reboot-time reruns (the firstboot flag) or racey restarts
+  # of services that aren't involved in this particular bugfix.
+  apt-get install -y -qq autocutsel
+
+  cat > /etc/systemd/system/clawbox-vnc.service <<VNCSVC
+[Unit]
+Description=ClawBox VNC (virtual desktop)
+After=network.target
+
+[Service]
+Type=simple
+User=$CLAWBOX_USER
+Environment=CLAWBOX_VNC_MODE=virtual
+ExecStart=$PROJECT_DIR/scripts/start-vnc.sh
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+VNCSVC
+
+  systemctl daemon-reload
+  systemctl restart clawbox-vnc.service || true
+  echo "  VNC service refreshed (CLAWBOX_VNC_MODE=virtual, autocutsel installed)"
+}
+
 step_desktop_theme() {
   local theme_script="$PROJECT_DIR/scripts/apply-desktop-theme.sh"
   local autostart_dir="$CLAWBOX_HOME/.config/autostart"
@@ -1188,7 +1230,7 @@ step_browser_launch() {
 # Steps available for --step dispatch (must have a corresponding step_NAME function)
 DISPATCH_STEPS=(
   apt_update nvidia_jetpack performance_mode jtop_install ollama_install llamacpp_install
-  chromium_install ai_tools_install vnc_install
+  chromium_install ai_tools_install vnc_install vnc_refresh
   openclaw_setup openclaw_install openclaw_patch openclaw_config openclaw_models
   network_setup set_hostname setup_config system_config
   git_pull build rebuild rebuild_reboot restart restart_ap recover


### PR DESCRIPTION
## Summary
Follow-up to the outside-diff Major finding from CodeRabbit's review of PR #66 — devices updating via the in-app updater never re-ran `step_vnc_install`, so they stayed on the pre-PR #66 VNC config:

- Missing `Environment=CLAWBOX_VNC_MODE=virtual` → VNC viewer shows GDM greeter instead of Chromium
- Missing `autocutsel` package → bidirectional clipboard has nothing to keep the X selection alive between windows

Adds `step_vnc_refresh`, an idempotent subset of `step_vnc_install`:
- `apt-get install -y -qq autocutsel` (no-op when already installed)
- Rewrites `/etc/systemd/system/clawbox-vnc.service` with `CLAWBOX_VNC_MODE=virtual`
- `systemctl daemon-reload` + `restart clawbox-vnc.service`

Called from `step_post_update` (runs after reboot on every in-app update). By then `git_pull` has placed the updated `start-vnc.sh` on disk, so the restart picks up both the new env var and the script that honors it.

Also whitelisted in `DISPATCH_STEPS` so `install.sh --step vnc_refresh` works for hotfix scenarios.

## Why narrower than `step_vnc_install`
Deliberately skips the firstboot-pending flag (would cause `clawbox-firstboot-vnc` to re-run on every reboot), the websockify unit, and the clawbox-browser service unit. Those are already on-disk from the original install and aren't involved in this specific regression.

## Test plan
- [x] Syntax-checked via `bash -n install.sh`
- [x] Ran `sudo bash install.sh --step vnc_refresh` on Jetson — unit rewritten with `CLAWBOX_VNC_MODE=virtual`, service restart completes
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Added VNC refresh capability for quick configuration updates without full reinstallation.
  - In-app updates now deliver VNC and clipboard synchronization enhancements together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->