### PR TITLE
fix(chat): respect local_only_mode in chat model dropdown

### DIFF
--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -182,7 +182,16 @@ async function loadChatModelState() {
     }
   }
 
-  const primaryOptions = sortPrimaryOptions([...configuredPrimaryOptions.values()]);
+  // When Local-only mode is on, the cloud providers are intentionally
+  // disabled — dropping them from the dropdown is the UX that matches
+  // the toggle's promise ("Route everything to the local model.
+  // Disables all cloud AI providers"). Without this the user can still
+  // pick GPT/Claude/DeepSeek in the chat dropdown while Local-only is
+  // lit up, and the chat then quietly talks to the cloud provider.
+  const localOnlyMode = !!configStore.local_only_mode;
+  const primaryOptions = localOnlyMode
+    ? []
+    : sortPrimaryOptions([...configuredPrimaryOptions.values()]);
   const localOption: ChatModelOption = localModel
     ? {
         id: localModel,


### PR DESCRIPTION
## Summary
When Local-only mode is toggled on in Settings, the chat panel's model dropdown still listed cloud providers (OpenAI, Anthropic, etc.) alongside the local model. Picking one routed chat to the cloud provider — silently violating the toggle's promise ("Route everything to the local model. Disables all cloud AI providers (including fallbacks).").

## Root cause
`loadChatModelState()` in `/setup-api/chat/model/route.ts` built its options list from every configured auth profile + the current primary provider without ever reading `configStore.local_only_mode`.

## Fix
When `local_only_mode` is truthy, set `primaryOptions = []` so the dropdown renders only the local model.

The POST handler already validates `body.model` against `state.options.find()` and returns 400 when the target isn't in the list — so programmatic API calls (stale dropdown state, direct `curl`, etc.) are rejected automatically without a separate guard.

## Test plan
- [x] Live on Jetson with `local_only_mode=true`: `GET /setup-api/chat/model` now returns only the `__setup_ai__` placeholder (available=false) + the llamacpp local option
- [x] With `local_only_mode=false`: cloud providers return to the list on next request
- [x] Deployed + Bun build clean, `clawbox-setup` service healthy
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined chat model dropdown behavior for Local-only mode. Cloud-based chat providers are now properly excluded from the selection menu when Local-only mode is enabled, displaying only locally-available options. The dropdown now accurately reflects the provider configuration and constraints specific to Local-only mode, improving user experience and preventing confusion regarding available chat provider selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->