### PR TITLE
fix(local-ai): unlock switching between local providers — 'Switch to Gemma 4' button + radio lock

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -561,6 +561,13 @@ export default function AIModelsStep({
     [genericSteps, llamaCppInstallSteps, ollamaInstallSteps],
   );
   const [selectedProvider, setSelectedProvider] = useState<string | null>(resolvedDefaultProvider);
+  // Once the user picks a radio (via selectProvider), stop auto-syncing the
+  // selection from the currently-active provider. Without this, polling on
+  // the parent (Settings refreshes localAiStatus every few seconds, which
+  // bumps currentProviderId) would flip the radio back to whatever is
+  // currently active — so a user on Ollama who clicks "Gemma 4" sees the
+  // radio flip straight back to Ollama within a second.
+  const userSelectedProviderRef = useRef(false);
   const [authMode, setAuthMode] = useState<AuthMode>("local");
   const [showMoreProviders, setShowMoreProviders] = useState(false);
   const [availableOAuth, setAvailableOAuth] = useState<string[] | null>(null);
@@ -614,7 +621,15 @@ export default function AIModelsStep({
     if (!normalizedCurrentProvider) return;
     if (!allowedProviders.some((provider) => provider.id === normalizedCurrentProvider)) return;
 
-    setSelectedProvider(normalizedCurrentProvider);
+    // Respect a user's explicit radio click — once they've picked a
+    // provider, don't yank the selection back to whatever the parent
+    // reports as currently-active. Still update the selected model slug
+    // inside the active provider's panel, because that affects which
+    // item is highlighted inside the list and isn't the same as the
+    // provider-switch.
+    if (!userSelectedProviderRef.current) {
+      setSelectedProvider(normalizedCurrentProvider);
+    }
 
     if (typeof currentModel === "string") {
       if (currentModel.startsWith("ollama/")) {
@@ -863,6 +878,7 @@ export default function AIModelsStep({
   const selectProvider = useCallback((id: string) => {
     stopPolling();
     const provider = allowedProviders.find((p) => p.id === id);
+    userSelectedProviderRef.current = true;
     setSelectedProvider(id);
     // Pick the first auth mode that's actually available
     const options = provider?.authOptions.filter((opt) => {
@@ -1605,6 +1621,7 @@ export default function AIModelsStep({
             <LlamaCppModelPanel
               llamaCppRunning={llamaCppRunning}
               llamaCppInstalled={llamaCppInstalled}
+              llamaCppIsActive={normalizedCurrentProvider === "llamacpp"}
               llamaCppSaving={llamaCppSaving}
               llamaCppProgress={llamaCppProgress}
               selectedLlamaCppModel={selectedLlamaCppModel}

--- a/src/components/LlamaCppModelPanel.tsx
+++ b/src/components/LlamaCppModelPanel.tsx
@@ -7,6 +7,15 @@ import { getDefaultLlamaCppModel } from "@/lib/llamacpp";
 interface LlamaCppModelPanelProps {
   llamaCppRunning: boolean;
   llamaCppInstalled: boolean;
+  /**
+   * Whether Gemma 4 (via llama.cpp) is the currently *active* local AI
+   * provider. When Gemma is installed but another provider (e.g. Ollama)
+   * is active, we still want to offer a way to switch TO Gemma — without
+   * this, the panel was rendering the "already configured" pill and no
+   * button, leaving users stuck on the wrong provider with nothing to
+   * click.
+   */
+  llamaCppIsActive?: boolean;
   llamaCppSaving: string | false;
   llamaCppProgress?: string | null;
   selectedLlamaCppModel: string;
@@ -24,6 +33,7 @@ const DEFAULT_SPINNER = (
 export default function LlamaCppModelPanel({
   llamaCppRunning,
   llamaCppInstalled,
+  llamaCppIsActive = false,
   llamaCppSaving,
   llamaCppProgress,
   selectedLlamaCppModel,
@@ -36,6 +46,29 @@ export default function LlamaCppModelPanel({
     if (selectedLlamaCppModel) return;
     setSelectedLlamaCppModel(getDefaultLlamaCppModel());
   }, [selectedLlamaCppModel, setSelectedLlamaCppModel]);
+
+  let description: string;
+  if (llamaCppRunning && llamaCppIsActive) {
+    description = "Gemma 4 is enabled and ready to use.";
+  } else if (llamaCppInstalled && !llamaCppIsActive) {
+    description = "Gemma 4 is already installed on this device. Switch to it to make it the active local AI.";
+  } else if (llamaCppInstalled) {
+    description = "Gemma 4 is already installed on this device. Enable it to start the local runtime and keep ClawBox working offline.";
+  } else {
+    description = "Enable Gemma 4 to install a local model that keeps ClawBox working even when cloud providers are unavailable.";
+  }
+
+  const showConfiguredPill = llamaCppInstalled && llamaCppIsActive && !llamaCppSaving;
+  const canSwitchToGemma = llamaCppInstalled && !llamaCppIsActive;
+
+  let buttonLabel: string;
+  if (llamaCppSaving) {
+    buttonLabel = "Enabling Gemma 4...";
+  } else if (canSwitchToGemma) {
+    buttonLabel = "Switch to Gemma 4";
+  } else {
+    buttonLabel = "Enable Gemma 4";
+  }
 
   return (
     <div className="space-y-3">
@@ -52,15 +85,11 @@ export default function LlamaCppModelPanel({
           </div>
         </div>
         <p className="mt-3 text-sm text-[var(--text-secondary)] leading-relaxed">
-          {llamaCppRunning
-            ? "Gemma 4 is enabled and ready to use."
-            : llamaCppInstalled
-              ? "Gemma 4 is already installed on this device. Enable it to start the local runtime and keep ClawBox working offline."
-              : "Enable Gemma 4 to install a local model that keeps ClawBox working even when cloud providers are unavailable."}
+          {description}
         </p>
       </div>
 
-      {llamaCppInstalled && !llamaCppSaving ? (
+      {showConfiguredPill ? (
         <div
           role="status"
           aria-live="polite"
@@ -77,7 +106,7 @@ export default function LlamaCppModelPanel({
           className={buttonClassName}
         >
           {llamaCppSaving && buttonSpinner}
-          {llamaCppSaving ? "Enabling Gemma 4..." : "Enable Gemma 4"}
+          {buttonLabel}
         </button>
       )}
 


### PR DESCRIPTION
## Summary
Two coupled bugs in the Local AI settings panel:

### 1. No button to switch to Gemma when Ollama is active
When Gemma is installed but Ollama is the currently-active local provider, clicking the Gemma radio rendered only the green "Gemma 4 is already configured" pill (added in #71) with no way to actually switch. User was stuck on Ollama.

**Fix:** new `llamaCppIsActive` prop (computed from `normalizedCurrentProvider === "llamacpp"`). Pill now renders only when installed AND active. When installed-but-not-active, the button stays visible and reads **"Switch to Gemma 4"** (vs "Enable Gemma 4" for the not-installed case).

### 2. Radio auto-flips back to the current provider
Selecting Gemma would flip back to Ollama within a second. Settings polls `localAiStatus` → updates `currentProviderId` → the sync `useEffect` called `setSelectedProvider(normalizedCurrentProvider)` on every tick, clobbering the user's click.

**Fix:** `userSelectedProviderRef` starts false, flips true inside `selectProvider`. Sync effect skips the provider-level set when true (model-slug sync inside the active provider still runs since it doesn't race).

### `/simplify` pass
Flattened the 4-branch description ternary and 3-branch button-label ternary in `LlamaCppModelPanel` into self-documenting local variables (`canSwitchToGemma`, `showConfiguredPill`, `description`, `buttonLabel`). Semantics unchanged.

## Test plan
- [x] Live on Jetson — Ollama active, click Gemma radio → radio stays, panel shows "Switch to Gemma 4" orange button + matching description
- [x] Click Switch to Gemma 4 → Gemma becomes active, panel updates to green "Gemma 4 is enabled and running" pill
- [x] Radio no longer auto-flips back during polling
- [x] Bun build clean, service healthy
- [ ] CodeRabbit review