### PR TITLE
fix(agent): seed CLAWBOX.md so the agent knows device conventions

### DIFF
--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -1,0 +1,68 @@
+# ClawBox Integration Guide
+
+_This file is seeded by ClawBox's `gateway-pre-start.sh` into `~/.openclaw/workspace/CLAWBOX.md`. It documents how to work with the ClawBox device so you don't have to guess or rely on defaults from the base OpenClaw install._
+
+---
+
+## Skills
+
+**Where user-installed skills live:** `~/.openclaw/workspace/skills/<skill-id>/`
+
+That is the **only** directory to check when someone asks "do I have skill X installed?" or "what skills are available?". Each skill directory contains `SKILL.md` (the manifest), and optionally `scripts/`, `hooks/`, `assets/`, `references/`.
+
+**Where skills do NOT live:** `/home/clawbox/.npm-global/lib/node_modules/openclaw/skills/` — that's the built-in skills bundled with the OpenClaw npm package, not what the ClawBox App Store writes to. **Do not check there when asked about user-installed skills** — it will falsely report the skill as missing.
+
+### Installing and uninstalling skills
+
+When the user asks you to install a skill, **use the ClawBox MCP server's `app_install` tool** (it goes through the ClawBox App Store, which registers the skill in the UI and triggers a gateway reload so it's actually usable). Do not copy files into the skills directory manually — the user wouldn't be able to see or uninstall it from the UI.
+
+Likewise, use `app_uninstall` to remove a skill — don't `rm -rf` the skill directory.
+
+The App Store is also available as a desktop app (`ui_open_app("store")`) if the user wants to browse/install interactively.
+
+---
+
+## Browser (real Chromium on the device)
+
+ClawBox ships a dedicated desktop Chromium that you can control via the `browser_*` tools from the `clawbox` MCP server:
+
+| Tool | Purpose |
+|---|---|
+| `browser_launch` / `browser_open` | Start a browsing session (opens the desktop Chromium if needed) |
+| `browser_navigate` | Go to a URL |
+| `browser_screenshot` | See the current page (returns a PNG) |
+| `browser_click` | Click at x,y coordinates visible in the screenshot |
+| `browser_type` | Type text into the focused field |
+| `browser_keypress` | Send special keys (Enter, Tab, Escape, etc.) |
+| `browser_scroll` | Scroll the page |
+| `browser_close` | End the browsing session (Chromium stays running) |
+
+**Standard workflow:** `browser_launch` → `browser_screenshot` → `browser_click` / `browser_type` → `browser_screenshot` → … repeat until the task is done.
+
+### Important
+
+**Do NOT use `ui_open_app("browser")` for actual web browsing.** That opens ClawBox's Browser *Setup* panel, which configures the integration — it does not start a browsing session.
+
+The Chromium window is visible on the ClawBox desktop (accessible via the VNC viewer), so the user can see what you're doing. That's a feature, not a problem — if you're unsure about a click, the screenshot is authoritative and the user can spot the bug visually.
+
+---
+
+## Apps and UI
+
+| Tool | Purpose |
+|---|---|
+| `ui_open_app` | Open a built-in ClawBox desktop app (chat, files, settings, store, vnc, terminal, browser-setup) |
+| `ui_list_apps` | Enumerate installed desktop apps |
+| `ui_notify` | Show a toast notification on the ClawBox desktop |
+| `app_search` | Search the ClawBox App Store |
+| `app_install` | Install a skill or webapp from the Store (see Skills section above) |
+| `app_uninstall` | Uninstall a skill or webapp |
+| `webapp_create` / `webapp_update` | Build and register a custom webapp on the desktop |
+
+---
+
+## File-system and network
+
+- The ClawBox project dir is `/home/clawbox/clawbox/`. User data is in `data/`. Skills are in the OpenClaw workspace (see Skills above).
+- The gateway's own config is `~/.openclaw/openclaw.json`. Don't edit it directly — use the `openclaw config set` CLI or let ClawBox's setup routes manage it.
+- The device exposes itself at `http://clawbox.local` / `http://<LAN-IP>` / `http://10.42.0.1` (AP mode).

--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -6,7 +6,7 @@ _This file is seeded by ClawBox's `gateway-pre-start.sh` into `~/.openclaw/works
 
 ## Skills
 
-**Where user-installed skills live:** `~/.openclaw/workspace/skills/<skill-id>/`
+**Where user-installed skills live:** `<workspace>/skills/<skill-id>/`, where `<workspace>` is whatever `agents.defaults.workspace` resolves to in `~/.openclaw/openclaw.json`. On a default ClawBox install that's `~/.openclaw/workspace/`, but power-users may point it elsewhere — always read the config value rather than assuming the default.
 
 That is the **only** directory to check when someone asks "do I have skill X installed?" or "what skills are available?". Each skill directory contains `SKILL.md` (the manifest), and optionally `scripts/`, `hooks/`, `assets/`, `references/`.
 
@@ -51,7 +51,7 @@ The Chromium window is visible on the ClawBox desktop (accessible via the VNC vi
 
 | Tool | Purpose |
 |---|---|
-| `ui_open_app` | Open a built-in ClawBox desktop app (chat, files, settings, store, vnc, terminal, browser-setup) |
+| `ui_open_app` | Open a built-in ClawBox desktop app. Known app IDs: `chat`, `files`, `settings`, `store`, `vnc`, `terminal`, and `browser` (the Browser *Setup* panel — not for real web browsing; use `browser_*` tools instead, see Browser section above) |
 | `ui_list_apps` | Enumerate installed desktop apps |
 | `ui_notify` | Show a toast notification on the ClawBox desktop |
 | `app_search` | Search the ClawBox App Store |

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -160,3 +160,37 @@ PY
 if ! python3 -c "import json; c=json.load(open('$OPENCLAW_CONFIG')); assert c.get('mcp',{}).get('servers',{}).get('clawbox',{}).get('command')" 2>/dev/null; then
   "$OPENCLAW_BIN" config set mcp.servers.clawbox '{"command":"/home/clawbox/.bun/bin/bun","args":["run","/home/clawbox/clawbox/mcp/clawbox-mcp.ts"],"env":{"CLAWBOX_API_BASE":"http://127.0.0.1:80"}}' --json 2>/dev/null || true
 fi
+
+# Seed CLAWBOX.md in the OpenClaw workspace so the agent's session-start
+# context includes ClawBox-specific guidance (where user-installed skills
+# actually live, how to control the desktop Chromium via the browser_*
+# MCP tools, how to install/uninstall skills through the App Store
+# instead of manipulating the filesystem directly). Without this, the
+# base OpenClaw agent defaults don't know any of those conventions and
+# falls back to guessing paths — which has misled it before (e.g.
+# checking .npm-global/.../openclaw/skills for user skills and finding
+# "nothing", even though the skill is installed at
+# ~/.openclaw/workspace/skills/).
+#
+# Idempotent: only writes when the shipped template differs from the
+# on-disk copy, so a later edit from the agent / user doesn't get
+# clobbered on every gateway restart.
+CLAWBOX_WORKSPACE="/home/clawbox/.openclaw/workspace"
+CLAWBOX_GUIDE_SRC="/home/clawbox/clawbox/config/clawbox-workspace-guide.md"
+CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
+if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
+  if [ ! -f "$CLAWBOX_GUIDE_DST" ] || ! cmp -s "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"; then
+    install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"
+    echo "  Seeded CLAWBOX.md in OpenClaw workspace"
+  fi
+
+  # Append a one-liner reference to AGENTS.md if it exists and doesn't
+  # already mention CLAWBOX.md, so the agent loads our guide as part of
+  # its session-start context without us having to overwrite AGENTS.md
+  # (which the agent may have personalized).
+  CLAWBOX_AGENTS_MD="$CLAWBOX_WORKSPACE/AGENTS.md"
+  if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "CLAWBOX.md" "$CLAWBOX_AGENTS_MD"; then
+    printf '\n\n## ClawBox integration\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, and how to install/uninstall skills through the App Store.\n' >> "$CLAWBOX_AGENTS_MD"
+    echo "  Appended CLAWBOX.md reference to AGENTS.md"
+  fi
+fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -170,16 +170,39 @@ fi
 # falls back to guessing paths — which has misled it before (e.g.
 # checking .npm-global/.../openclaw/skills for user skills and finding
 # "nothing", even though the skill is installed at
-# ~/.openclaw/workspace/skills/).
+# <workspace>/skills/).
 #
-# Idempotent: only writes when the shipped template differs from the
-# on-disk copy, so a later edit from the agent / user doesn't get
-# clobbered on every gateway restart.
-CLAWBOX_WORKSPACE="/home/clawbox/.openclaw/workspace"
+# Resolve the workspace from agents.defaults.workspace in openclaw.json,
+# matching the same logic getSkillsDir() uses on the ClawBox API side —
+# falls back to ~/.openclaw/workspace when unset, handles absolute vs
+# tilde-relative vs bare-name values, and is safe when the file is
+# missing (fresh factory-reset state).
+CLAWBOX_WORKSPACE="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
+import json, os, sys
+default = os.path.expanduser("~/.openclaw/workspace")
+try:
+    with open(sys.argv[1]) as f:
+        cfg = json.load(f)
+    ws = cfg.get("agents", {}).get("defaults", {}).get("workspace")
+except (FileNotFoundError, json.JSONDecodeError, KeyError):
+    ws = None
+if isinstance(ws, str) and ws.strip():
+    ws = os.path.expanduser(ws.strip())
+    print(ws if os.path.isabs(ws) else os.path.join(os.path.expanduser("~/.openclaw"), ws))
+else:
+    print(default)
+PY
+)"
 CLAWBOX_GUIDE_SRC="/home/clawbox/clawbox/config/clawbox-workspace-guide.md"
 CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
-  if [ ! -f "$CLAWBOX_GUIDE_DST" ] || ! cmp -s "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"; then
+  # Seed-if-missing rather than overwrite-on-diff. The agent and the
+  # user may personalize CLAWBOX.md (add device-specific notes, remove
+  # sections that don't apply). Overwriting on every gateway start
+  # would clobber those edits. If the shipped template changes and an
+  # operator wants to pull it in, they can delete the file; the next
+  # gateway start will re-seed.
+  if [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
     install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"
     echo "  Seeded CLAWBOX.md in OpenClaw workspace"
   fi


### PR DESCRIPTION
## Summary
The OpenClaw agent's session-start context (AGENTS.md, BOOTSTRAP.md, etc.) has no ClawBox-specific guidance. Observed failure mode earlier today: user installed `self-improving-agent` via the App Store, asked the agent to confirm — the agent `read`-checked `/home/clawbox/.npm-global/lib/node_modules/openclaw/skills` (the npm package's built-in skills dir), saw nothing, and confidently reported the skill as not installed. The skill was actually at `~/.openclaw/workspace/skills/self-improving-agent/` the whole time.

Same class of problem applies to the desktop-Chromium integration and to skill installs:

- Agent doesn't know the `browser_*` MCP tools exist → defaults to `ui_open_app("browser")` which opens the Setup panel, not a browsing session.
- When asked to install a skill the agent might copy files into the skills dir manually instead of using `app_install` — which skips the App Store registration + gateway reload the user needs to see / uninstall it from the UI.

## What changed
1. New `config/clawbox-workspace-guide.md` documents:
   - Where user-installed skills live (`~/.openclaw/workspace/skills/`) and **do NOT** live (the npm-global path)
   - Skill install/uninstall must go through `app_install` / `app_uninstall` (so the App Store UI stays consistent + gateway reload actually fires)
   - Full `browser_*` MCP tool inventory with the standard launch → screenshot → click/type workflow, plus the "do not use `ui_open_app("browser")`" caveat
   - `ui_*` / `app_*` / `webapp_*` tools inventory
   - File-system + network pointers

2. `scripts/gateway-pre-start.sh` now seeds this file as `~/.openclaw/workspace/CLAWBOX.md` when:
   - The workspace dir exists (avoids racing first-boot OpenClaw init)
   - Shipped template differs from on-disk copy (`cmp -s`) — so later agent/user edits aren't clobbered on every restart
   
3. Also appends a one-liner reference to `AGENTS.md` (when it exists and doesn't already mention CLAWBOX.md), so the agent's normal session-start bootstrap loads our guide without us having to overwrite AGENTS.md.

## Test plan
- [x] `bash -n` syntax clean
- [x] First run on Jetson: seeded CLAWBOX.md + appended AGENTS.md reference
- [x] Second run: both checks logged "skipping" (idempotent)
- [x] AGENTS.md now ends with `## ClawBox integration` section pointing at CLAWBOX.md
- [ ] Next fresh session with the chat agent: ask "do I have skill X?" — should check the workspace skills path, not node_modules
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added ClawBox integration guide documenting user skill installation via App Store, browser automation workflows, device control tools, workspace configuration, and reference points for workspace integration.

* **Chores**
  * Enhanced workspace initialization to automatically seed integration documentation for agent context loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->