### PR TITLE
fix(updater): skip openclaw re-install when already up-to-date

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -196,10 +196,14 @@ step_openclaw_install() {
   LATEST=$(npm view openclaw version --registry https://registry.npmjs.org 2>/dev/null || echo "")
   local TARGET="${LATEST:-$OPENCLAW_VERSION}"
   if [ -x "$OPENCLAW_BIN" ]; then
-    local INSTALLED
+    local INSTALLED INSTALLED_VER
+    # `openclaw --version` prints "OpenClaw X.Y.Z (hash)"; extract field 2 so
+    # we can compare exactly against the bare npm version. Literal "=" on the
+    # full string would always miss because of the prefix/hash.
     INSTALLED=$("$OPENCLAW_BIN" --version 2>/dev/null || echo "none")
+    INSTALLED_VER=$(echo "$INSTALLED" | awk '{print $2}')
     echo "  Installed: $INSTALLED, Target: $TARGET"
-    if [ "$INSTALLED" = "$TARGET" ]; then
+    if [ "$INSTALLED_VER" = "$TARGET" ]; then
       echo "  OpenClaw is already up to date"
       return 0
     fi

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -149,6 +149,11 @@ async function updateClawBoxAndReboot(): Promise<void> {
   await waitForTermination();
 }
 
+// First-time `npm install -g openclaw` on cold Jetson caches routinely runs
+// 2-3 min; the old 120 s budget surfaced as a scary X on 'Updating OpenClaw'
+// even when the install ultimately succeeded in the background.
+const OPENCLAW_INSTALL_TIMEOUT_MS = 300_000;
+
 const UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: "apt_update",
@@ -177,7 +182,7 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: "openclaw_install",
     label: "Updating OpenClaw",
-    timeoutMs: 120_000,
+    timeoutMs: OPENCLAW_INSTALL_TIMEOUT_MS,
     requiresRoot: true,
   },
   {


### PR DESCRIPTION
## Summary

- `step_openclaw_install` compared `openclaw --version` output (`OpenClaw X.Y.Z (hash)`) against the bare npm version tag with literal `=`. Those strings never match, so `npm install -g openclaw@$TARGET` re-ran on every update — reinstalling the same version, taking 2-3 min on Jetson, blowing through the 120 s step timeout, and surfacing as a scary `X` on 'Updating OpenClaw' even when nothing needed to change.
- Extract the bare version with `awk '{print $2}'` and compare exactly. Happy-path now returns in ~1 s instead of ~150 s.
- Bump the step timeout 120 s → 300 s via `OPENCLAW_INSTALL_TIMEOUT_MS` as a defensive net so a genuine cold-cache install still fits. 300 s matches the sibling `ollama_install` budget.

## Symptoms this fixes

- Fresh Jetson setup: 'Updating OpenClaw' flashes a red `X` mid-run (install really did finish, the 150 s UI timeout just fired first)
- Every subsequent update: same `X`, because the idempotency check never triggers
- `UpdateOverlay` shows 'Update Failed' at the top even when the rebuild+reboot succeeded

## Test plan

- [ ] Fresh Jetson install: 'Updating OpenClaw' completes without the red `X`
- [ ] Re-run update with no upstream version bump: step returns in ~1 s (log: `OpenClaw is already up to date`)
- [ ] Force a version bump server-side: install actually runs and has 5 min budget instead of 2