### PR TITLE
fix(settings): redirect to home after full update completes

### DIFF
--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -12,7 +12,7 @@ import AIModelsStep from "./AIModelsStep";
 import TelegramConfiguringOverlay from "./TelegramConfiguringOverlay";
 import { I18nProvider, useT, LANGUAGES, type Locale } from "@/lib/i18n";
 import { QRCodeSVG } from "qrcode.react";
-import type { UpdateState } from "@/lib/updater";
+import { RESTART_STEP_ID, type UpdateState } from "@/lib/updater";
 import { cleanVersion } from "@/lib/version-utils";
 import { FEATURE_FLAGS, FEATURE_FLAG_KEYS, isFeatureFlagEnabled } from "@/lib/feature-flags";
 
@@ -266,17 +266,26 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
 
   useEffect(() => () => stopUpdatePolling(), [stopUpdatePolling]);
 
-  // Auto-dismiss the update overlay for OpenClaw-only updates (no device restart).
+  // Auto-dismiss the update overlay once the update finishes. Full updates
+  // (with a `restart` step) get a longer grace window and a hard navigation
+  // to `/` so the browser picks up any freshly built client bundle; scoped
+  // updates just clear the overlay in place.
   useEffect(() => {
     if (updateState?.phase !== "completed") return;
-    const isFullUpdate = updateState.steps.some(s => s.id === "restart");
-    if (isFullUpdate) return;
+    const isFullUpdate = updateState.steps.some(s => s.id === RESTART_STEP_ID);
     const timer = setTimeout(() => {
+      if (isFullUpdate) {
+        stopUpdatePolling();
+        // replace() instead of assigning href so Back doesn't land on the
+        // stale Settings URL whose in-memory state is already gone.
+        window.location.replace("/");
+        return;
+      }
       setUpdateStarted(false);
       setUpdateError(null);
       setUpdateState(null);
       stopUpdatePolling();
-    }, 3000);
+    }, isFullUpdate ? 5000 : 3000);
     return () => clearTimeout(timer);
   }, [updateState?.phase, updateState?.steps, stopUpdatePolling]);
 
@@ -3208,7 +3217,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               </h2>
               <p className="text-sm text-white/40">
                 {updateState?.phase === "completed"
-                  ? (updateState.steps.some(s => s.id === "restart") ? t("settings.restartingDevice") : t("settings.updateDone"))
+                  ? (updateState.steps.some(s => s.id === RESTART_STEP_ID) ? t("settings.restartingDevice") : t("settings.updateDone"))
                   : updateError || updateState?.phase === "failed" ? "" : "Please don\u2019t turn off your device"}
               </p>
             </div>

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -52,7 +52,7 @@ export interface UpdateState {
   error?: string;
 }
 
-const RESTART_STEP_ID = "restart";
+export const RESTART_STEP_ID = "restart";
 
 /** Wait indefinitely for systemd to SIGTERM us (during rebuild/reboot). */
 function waitForTermination(): Promise<void> {


### PR DESCRIPTION
## Summary

- After a full update finishes, the overlay showed 'Update complete / Restarting device...' forever. The device doesn't actually reboot on that step — only `clawbox-setup.service` restarts — so the user was stuck at a terminal UI with no way back.
- Auto-dismiss effect now handles both paths:
  - Full update (has `restart` step): 5 s grace then `window.location.href = '/'` — hard-nav picks up the freshly built client bundle
  - Scoped update (OpenClaw-only): unchanged, 3 s in-place dismiss

## Before / after

Before: overlay stays on 'Update complete' with 'Рестартиране на устройството...' subtitle indefinitely.
After: overlay auto-closes and drops user on the desktop at `/`.

## Test plan

- [ ] Trigger Settings → System Update on a device already on latest: overlay closes after ~5 s, lands on desktop
- [ ] Trigger Settings → OpenClaw Update (scoped): overlay closes after ~3 s, Settings window remains open
- [ ] Trigger a failing update (e.g. kill gateway mid-run): overlay stays on failure screen (no auto-redirect)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update completion workflow: updates requiring device restart now provide a 5-second grace period before automatic redirection to the home page. Enhanced overlay management ensures smoother transitions between different update states. Refined visual status indicators provide clearer feedback about device restart requirements and completion status throughout the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->