### PR TITLE
fix(updater): skip openclaw re-install when already up-to-date

### DIFF
--- a/install-x64.sh
+++ b/install-x64.sh
@@ -240,10 +240,14 @@ step_openclaw_install() {
   LATEST=$("$BUN" pm view openclaw version 2>/dev/null || npm view openclaw version --registry https://registry.npmjs.org 2>/dev/null || echo "")
   local TARGET="${LATEST:-$OPENCLAW_VERSION}"
   if [ -x "$OPENCLAW_BIN" ]; then
-    local INSTALLED
+    local INSTALLED INSTALLED_VER
+    # `openclaw --version` prints "OpenClaw X.Y.Z (hash)"; extract field 2 so
+    # we can compare exactly against the bare npm version. Literal "=" on the
+    # full string would always miss because of the prefix/hash.
     INSTALLED=$("$OPENCLAW_BIN" --version 2>/dev/null || echo "none")
+    INSTALLED_VER=$(echo "$INSTALLED" | awk '{print $2}')
     echo "  Installed: $INSTALLED, Target: $TARGET"
-    if [ "$INSTALLED" = "$TARGET" ]; then
+    if [ "$INSTALLED_VER" = "$TARGET" ]; then
       echo "  OpenClaw is already up to date"
       return 0
     fi

--- a/install.sh
+++ b/install.sh
@@ -489,10 +489,14 @@ step_openclaw_install() {
   LATEST=$(npm view openclaw version --registry https://registry.npmjs.org 2>/dev/null || echo "")
   local TARGET="${LATEST:-$OPENCLAW_VERSION}"
   if [ -x "$OPENCLAW_BIN" ]; then
-    local INSTALLED
+    local INSTALLED INSTALLED_VER
+    # `openclaw --version` prints "OpenClaw X.Y.Z (hash)"; extract field 2 so
+    # we can compare exactly against the bare npm version. Literal "=" on the
+    # full string would always miss because of the prefix/hash.
     INSTALLED=$("$OPENCLAW_BIN" --version 2>/dev/null || echo "none")
+    INSTALLED_VER=$(echo "$INSTALLED" | awk '{print $2}')
     echo "  Installed: $INSTALLED, Target: $TARGET"
-    if [ "$INSTALLED" = "$TARGET" ]; then
+    if [ "$INSTALLED_VER" = "$TARGET" ]; then
       echo "  OpenClaw is already up to date"
       return 0
     fi

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -146,6 +146,11 @@ async function updateClawBoxAndReboot(): Promise<void> {
   await waitForTermination();
 }
 
+// First-time `npm install -g openclaw` on cold Jetson caches routinely runs
+// 2-3 min; shared across both UPDATE_STEPS and OPENCLAW_UPDATE_STEPS so the
+// two flows can't drift apart.
+const OPENCLAW_INSTALL_TIMEOUT_MS = 300_000;
+
 const UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: "apt_update",
@@ -180,7 +185,7 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: "openclaw_install",
     label: "Updating OpenClaw",
-    timeoutMs: 120_000,
+    timeoutMs: OPENCLAW_INSTALL_TIMEOUT_MS,
     requiresRoot: true,
   },
   {
@@ -452,7 +457,7 @@ const OPENCLAW_UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: "openclaw_install",
     label: "Updating OpenClaw",
-    timeoutMs: 120_000,
+    timeoutMs: OPENCLAW_INSTALL_TIMEOUT_MS,
     requiresRoot: true,
   },
   {


### PR DESCRIPTION
## Summary

- `step_openclaw_install` compared `openclaw --version` output (`OpenClaw X.Y.Z (hash)`) against the bare npm version tag with literal `=`. Those strings never match, so `npm install -g openclaw@$TARGET` re-ran on every update — reinstalling the same version, taking 2-3 min on Jetson, blowing through the 120 s step timeout, and surfacing as a scary `X` on 'Updating OpenClaw' even when nothing needed to change.
- Extract the bare version with `awk '{print $2}'` and compare exactly. Happy-path now returns in ~1 s instead of ~150 s.
- Bump the step timeout 120 s → 300 s via a shared `OPENCLAW_INSTALL_TIMEOUT_MS` module constant so `UPDATE_STEPS` and `OPENCLAW_UPDATE_STEPS` can't drift. 300 s matches the sibling `chromium_install` / `vnc_install` budgets.

Applies to both `install.sh` (Jetson/ARM) and `install-x64.sh` — they're deliberately parallel.

History: originally PR #84, closed when retargeting-to-main surfaced unrelated beta-only commits in the diff. PR #85 opened clean against main but hit CODEOWNERS. This re-lands the fix on beta so it ships via the normal beta→main release cycle.

## Test plan

- [ ] Fresh Jetson: 'Updating OpenClaw' completes without the red X
- [ ] Re-run update with no upstream version bump: step returns in ~1 s (log: `OpenClaw is already up to date`)