### PR TITLE
fix(apps): sync installed_apps + installed_meta on MCP/CLI install

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ import SetupWizard from "@/components/SetupWizard";
 import { I18nProvider, useT } from "@/lib/i18n";
 import { cleanVersion } from "@/lib/version-utils";
 import { FEATURE_FLAG_KEYS, isFeatureFlagEnabled } from "@/lib/feature-flags";
+import type { InstalledMeta } from "@/lib/store-categories";
 
 
 const Mascot = dynamic(() => import("@/components/Mascot"), { ssr: false });
@@ -216,7 +217,7 @@ function ChromeDesktopInner() {
   const [date, setDate] = useState("");
   const [installedApps, setInstalledApps] = useState<string[]>([]);
   const [recentlyInstalled, setRecentlyInstalled] = useState<string | null>(null);
-  const [installedMeta, setInstalledMeta] = useState<Record<string, { name: string; color: string; iconUrl: string }>>({});
+  const [installedMeta, setInstalledMeta] = useState<Record<string, InstalledMeta>>({});
 
   // ─── Desktop shortcuts for built-in apps ───
   const [desktopApps, setDesktopApps] = useState<string[]>(DEFAULT_DESKTOP_APPS);
@@ -277,7 +278,7 @@ function ChromeDesktopInner() {
         });
         // Installed apps
         if (Array.isArray(data.installed_apps)) setInstalledApps(data.installed_apps as string[]);
-        if (data.installed_meta && typeof data.installed_meta === "object") setInstalledMeta(data.installed_meta as Record<string, { name: string; color: string; iconUrl: string }>);
+        if (data.installed_meta && typeof data.installed_meta === "object") setInstalledMeta(data.installed_meta as Record<string, InstalledMeta>);
         // Desktop
         if (Array.isArray(data.desktop_apps)) {
           const nextFlags = {
@@ -891,7 +892,7 @@ function ChromeDesktopInner() {
   const getAllApps = useCallback((): AppDef[] => {
     const installedAppDefs: AppDef[] = [];
     for (const appId of installedApps) {
-      const meta = installedMeta[appId] as Record<string, string> | undefined;
+      const meta = installedMeta[appId];
       if (meta) {
         const isWebapp = !!meta.webappUrl;
         const storeApp: StoreApp = { id: appId, name: meta.name, description: "", rating: 0, color: meta.color, category: "", iconUrl: meta.iconUrl };

--- a/src/app/setup-api/apps/install/route.ts
+++ b/src/app/setup-api/apps/install/route.ts
@@ -3,8 +3,41 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
-import { DATA_DIR, CONFIG_ROOT } from "@/lib/config-store";
+import { DATA_DIR, CONFIG_ROOT, getAll as configGetAll, setMany as configSetMany } from "@/lib/config-store";
 import { reloadGateway, getSkillsDir, findOpenclawBin } from "@/lib/openclaw-config";
+import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR, type InstalledMeta } from "@/lib/store-categories";
+
+const STORE_SEARCH_API = "https://openclawhardware.dev/api/store/apps";
+
+function titleCaseFromSlug(slug: string): string {
+  return slug.split("-").filter(Boolean).map((w) => w[0].toUpperCase() + w.slice(1)).join(" ");
+}
+
+async function lookupStoreMeta(appId: string): Promise<InstalledMeta> {
+  const fallback: InstalledMeta = {
+    name: titleCaseFromSlug(appId),
+    color: DEFAULT_CATEGORY_COLOR,
+    iconUrl: `/setup-api/apps/icon/${appId}`,
+  };
+  try {
+    const q = appId.replace(/-/g, " ");
+    const res = await fetch(`${STORE_SEARCH_API}?q=${encodeURIComponent(q)}&limit=50`, {
+      signal: AbortSignal.timeout(8000),
+    });
+    if (!res.ok) return fallback;
+    const data = await res.json() as { apps?: Array<{ slug?: string; name?: string; category?: string }> };
+    const match = (data.apps ?? []).find((a) => a.slug === appId);
+    if (!match) return fallback;
+    return {
+      name: match.name ?? fallback.name,
+      color: (match.category && CATEGORY_COLORS[match.category]) || DEFAULT_CATEGORY_COLOR,
+      iconUrl: fallback.iconUrl,
+    };
+  } catch (err) {
+    console.warn(`[apps/install] Store metadata lookup failed for ${appId}:`, err instanceof Error ? err.message : err);
+    return fallback;
+  }
+}
 
 export const dynamic = "force-dynamic";
 
@@ -63,6 +96,34 @@ export async function POST(req: Request) {
     // Reload the OpenClaw gateway so it picks up the new skill
     let reloadError: string | undefined;
     if (clawhubResult.success) {
+      // Keep the desktop's `installed_apps` and `installed_meta` preferences
+      // in sync. Without this, installs through MCP / CLI land on disk but
+      // are invisible on the desktop — the UI filters out apps that have no
+      // meta (see page.tsx), and it only refreshes on page mount.
+      try {
+        const all = await configGetAll();
+        const list = Array.isArray(all["pref:installed_apps"]) ? (all["pref:installed_apps"] as string[]) : [];
+        const metaMap = (all["pref:installed_meta"] && typeof all["pref:installed_meta"] === "object"
+          ? all["pref:installed_meta"]
+          : {}) as Record<string, InstalledMeta>;
+
+        const alreadyListed = list.includes(appId);
+        // Re-install of a fully-registered app: skip the Store fetch and the
+        // no-op write so MCP retries don't thrash the upstream API.
+        if (!alreadyListed || !metaMap[appId]) {
+          const storeMeta = await lookupStoreMeta(appId);
+          const nextUpdates: Record<string, unknown> = {
+            "pref:installed_meta": { ...metaMap, [appId]: storeMeta },
+          };
+          if (!alreadyListed) {
+            nextUpdates["pref:installed_apps"] = [...list, appId];
+          }
+          await configSetMany(nextUpdates);
+        }
+      } catch (err) {
+        console.warn("[apps/install] Failed to update installed_apps/meta preferences:", err instanceof Error ? err.message : err);
+      }
+
       try {
         await reloadGateway();
       } catch (err) {

--- a/src/app/setup-api/apps/install/route.ts
+++ b/src/app/setup-api/apps/install/route.ts
@@ -9,15 +9,27 @@ import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR, type InstalledMeta } from "@/l
 
 const STORE_SEARCH_API = "https://openclawhardware.dev/api/store/apps";
 
+const STORE_ICONS_BASE = "https://openclawhardware.dev/store/icons";
+
 function titleCaseFromSlug(slug: string): string {
-  return slug.split("-").filter(Boolean).map((w) => w[0].toUpperCase() + w.slice(1)).join(" ");
+  // Split on `-` and `_` since the appId validator accepts either. All-
+  // separator inputs (e.g. "---") would otherwise return "" and the desktop
+  // would render a blank label; fall back to the raw slug in that case.
+  const parts = slug.split(/[-_]+/).filter(Boolean);
+  if (parts.length === 0) return slug;
+  return parts.map((w) => w[0].toUpperCase() + w.slice(1)).join(" ");
 }
 
 async function lookupStoreMeta(appId: string): Promise<InstalledMeta> {
+  // Use the remote Store icon URL as the fallback iconUrl so the client's
+  // <InstalledAppIcon> has a second source when the local icon download
+  // in the POST handler failed. Matches what AppStore.tsx's apiToStoreApp
+  // stores for UI-initiated installs, so both paths produce identical meta.
+  const remoteIconUrl = `${STORE_ICONS_BASE}/${appId}.png`;
   const fallback: InstalledMeta = {
     name: titleCaseFromSlug(appId),
     color: DEFAULT_CATEGORY_COLOR,
-    iconUrl: `/setup-api/apps/icon/${appId}`,
+    iconUrl: remoteIconUrl,
   };
   try {
     const q = appId.replace(/-/g, " ");
@@ -31,7 +43,7 @@ async function lookupStoreMeta(appId: string): Promise<InstalledMeta> {
     return {
       name: match.name ?? fallback.name,
       color: (match.category && CATEGORY_COLORS[match.category]) || DEFAULT_CATEGORY_COLOR,
-      iconUrl: fallback.iconUrl,
+      iconUrl: remoteIconUrl,
     };
   } catch (err) {
     console.warn(`[apps/install] Store metadata lookup failed for ${appId}:`, err instanceof Error ? err.message : err);
@@ -43,7 +55,6 @@ export const dynamic = "force-dynamic";
 
 const execFileAsync = promisify(execFile);
 const ICONS_DIR = path.join(DATA_DIR, "icons");
-const STORE_ICONS_BASE = "https://openclawhardware.dev/store/icons";
 
 
 export async function POST(req: Request) {
@@ -110,6 +121,14 @@ export async function POST(req: Request) {
         const alreadyListed = list.includes(appId);
         // Re-install of a fully-registered app: skip the Store fetch and the
         // no-op write so MCP retries don't thrash the upstream API.
+        //
+        // Tradeoff: if the very first install happened while the Store was
+        // unreachable, `lookupStoreMeta` returned the title-cased fallback
+        // and we wrote that here. Every subsequent re-install short-circuits,
+        // so the fallback meta is sticky — the user only gets the real
+        // name/color back by uninstalling + reinstalling. Accepted because
+        // the upstream-hammer case is more common than the offline-install
+        // case.
         if (!alreadyListed || !metaMap[appId]) {
           const storeMeta = await lookupStoreMeta(appId);
           const nextUpdates: Record<string, unknown> = {

--- a/src/app/setup-api/apps/install/route.ts
+++ b/src/app/setup-api/apps/install/route.ts
@@ -40,9 +40,16 @@ async function lookupStoreMeta(appId: string): Promise<InstalledMeta> {
     const data = await res.json() as { apps?: Array<{ slug?: string; name?: string; category?: string }> };
     const match = (data.apps ?? []).find((a) => a.slug === appId);
     if (!match) return fallback;
+    // hasOwnProperty.call so a malicious `category: "__proto__"` from the
+    // remote Store doesn't resolve to an inherited property.
+    const category = match.category;
+    const color = typeof category === "string"
+      && Object.prototype.hasOwnProperty.call(CATEGORY_COLORS, category)
+      ? CATEGORY_COLORS[category]
+      : DEFAULT_CATEGORY_COLOR;
     return {
       name: match.name ?? fallback.name,
-      color: (match.category && CATEGORY_COLORS[match.category]) || DEFAULT_CATEGORY_COLOR,
+      color,
       iconUrl: remoteIconUrl,
     };
   } catch (err) {
@@ -106,6 +113,7 @@ export async function POST(req: Request) {
 
     // Reload the OpenClaw gateway so it picks up the new skill
     let reloadError: string | undefined;
+    let preferenceSyncError: string | undefined;
     if (clawhubResult.success) {
       // Keep the desktop's `installed_apps` and `installed_meta` preferences
       // in sync. Without this, installs through MCP / CLI land on disk but
@@ -119,28 +127,32 @@ export async function POST(req: Request) {
           : {}) as Record<string, InstalledMeta>;
 
         const alreadyListed = list.includes(appId);
-        // Re-install of a fully-registered app: skip the Store fetch and the
-        // no-op write so MCP retries don't thrash the upstream API.
+        const hasMeta = !!metaMap[appId];
+        const nextUpdates: Record<string, unknown> = {};
+
+        // Only fetch Store metadata when we don't already have it. Preserves
+        // any previously-written (possibly richer) meta — including handling
+        // the partial-state case where the list entry is missing but the
+        // meta entry still exists.
         //
-        // Tradeoff: if the very first install happened while the Store was
-        // unreachable, `lookupStoreMeta` returned the title-cased fallback
-        // and we wrote that here. Every subsequent re-install short-circuits,
-        // so the fallback meta is sticky — the user only gets the real
-        // name/color back by uninstalling + reinstalling. Accepted because
-        // the upstream-hammer case is more common than the offline-install
-        // case.
-        if (!alreadyListed || !metaMap[appId]) {
+        // Sticky-fallback caveat: if the very first install happened while
+        // the Store was unreachable, `lookupStoreMeta` wrote the title-cased
+        // fallback and subsequent re-installs won't refresh it. The user
+        // gets the real name/color back by uninstalling + reinstalling.
+        // Accepted because thrashing the Store API on every retry is worse.
+        if (!hasMeta) {
           const storeMeta = await lookupStoreMeta(appId);
-          const nextUpdates: Record<string, unknown> = {
-            "pref:installed_meta": { ...metaMap, [appId]: storeMeta },
-          };
-          if (!alreadyListed) {
-            nextUpdates["pref:installed_apps"] = [...list, appId];
-          }
+          nextUpdates["pref:installed_meta"] = { ...metaMap, [appId]: storeMeta };
+        }
+        if (!alreadyListed) {
+          nextUpdates["pref:installed_apps"] = [...list, appId];
+        }
+        if (Object.keys(nextUpdates).length > 0) {
           await configSetMany(nextUpdates);
         }
       } catch (err) {
-        console.warn("[apps/install] Failed to update installed_apps/meta preferences:", err instanceof Error ? err.message : err);
+        preferenceSyncError = err instanceof Error ? err.message : String(err);
+        console.warn("[apps/install] Failed to update installed_apps/meta preferences:", preferenceSyncError);
       }
 
       try {
@@ -151,13 +163,17 @@ export async function POST(req: Request) {
       }
     }
 
+    // `ok` flips to false when preference sync failed so MCP/CLI callers
+    // can detect it — install+icon succeeded on disk but the desktop
+    // won't see the new skill without the prefs being written.
     return NextResponse.json({
-      ok: true,
+      ok: !preferenceSyncError,
       appId,
       iconSaved,
       iconPath: iconSaved ? `/setup-api/apps/icon/${appId}` : null,
       clawhub: clawhubResult,
       reloadError,
+      preferenceSyncError,
     });
   } catch (err) {
     console.error("[apps/install] Install failed:", err instanceof Error ? err.message : err);

--- a/src/app/setup-api/apps/uninstall/route.ts
+++ b/src/app/setup-api/apps/uninstall/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
+import { getAll as configGetAll, setMany as configSetMany } from "@/lib/config-store";
 import { reloadGateway, getSkillsDir } from "@/lib/openclaw-config";
 
 export const dynamic = "force-dynamic";
@@ -25,6 +26,34 @@ export async function POST(req: Request) {
     // Remove cached icon
     const iconPath = path.join(HOME, "clawbox", "data", "icons", `${appId}.png`);
     await fs.rm(iconPath, { force: true }).catch(() => {});
+
+    // Keep the desktop's `installed_apps` and `installed_meta` preferences
+    // in sync — same reason as the install route: MCP / CLI uninstalls would
+    // otherwise leave stale entries in the Store's Installed tab and a
+    // phantom desktop icon until the next page mount.
+    try {
+      const all = await configGetAll();
+      const currentApps = all["pref:installed_apps"];
+      const currentMeta = all["pref:installed_meta"];
+      const updates: Record<string, unknown> = {};
+
+      if (Array.isArray(currentApps)) {
+        const next = (currentApps as string[]).filter((id) => id !== appId);
+        if (next.length !== currentApps.length) {
+          updates["pref:installed_apps"] = next;
+        }
+      }
+      if (currentMeta && typeof currentMeta === "object" && appId in (currentMeta as Record<string, unknown>)) {
+        const metaMap = { ...(currentMeta as Record<string, unknown>) };
+        delete metaMap[appId];
+        updates["pref:installed_meta"] = metaMap;
+      }
+      if (Object.keys(updates).length > 0) {
+        await configSetMany(updates);
+      }
+    } catch (err) {
+      console.warn("[uninstall] Failed to update installed_apps/meta preferences:", err instanceof Error ? err.message : err);
+    }
 
     // Reload gateway so agent drops the skill
     try {

--- a/src/components/AppStore.tsx
+++ b/src/components/AppStore.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useT } from "@/lib/i18n";
+import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR } from "@/lib/store-categories";
 
 const STORE_API = "/setup-api/apps/store";
 const STORE_ICONS_BASE = "https://openclawhardware.dev/store/icons";
@@ -9,21 +10,6 @@ const STORE_ICONS_BASE = "https://openclawhardware.dev/store/icons";
 // Brand orange from openclawhardware.dev
 const BRAND_ORANGE = "#fe6e00";
 const BRAND_ORANGE_LIGHT = "#ff8b1a";
-
-const CATEGORY_COLORS: Record<string, string> = {
-  "smart-home": "#3b82f6",
-  "productivity": "#8b5cf6",
-  "social-media": "#ec4899",
-  "finance": "#22c55e",
-  "developer": "#a78bfa",
-  "security": "#ef4444",
-  "health": "#10b981",
-  "shopping": "#f97316",
-  "entertainment": "#8b5cf6",
-  "weather-travel": "#06b6d4",
-  "writing": "#6366f1",
-  "ai-automation": "#eab308",
-};
 
 interface StoreApp {
   id: string;
@@ -71,7 +57,7 @@ function apiToStoreApp(app: ApiApp): StoreApp {
     name: app.name,
     description: app.summary,
     rating: app.rating,
-    color: CATEGORY_COLORS[app.category] || "#6b7280",
+    color: CATEGORY_COLORS[app.category] || DEFAULT_CATEGORY_COLOR,
     category: app.category,
     iconUrl: `${STORE_ICONS_BASE}/${app.slug}.png`,
     developer: app.developer,

--- a/src/lib/store-categories.ts
+++ b/src/lib/store-categories.ts
@@ -1,0 +1,31 @@
+// Shared between the AppStore UI (`src/components/AppStore.tsx`) and the
+// server-side install route (`src/app/setup-api/apps/install/route.ts`), so a
+// skill installed via MCP / CLI ends up with the same on-desktop colouring
+// as one installed through the Store UI.
+
+export const CATEGORY_COLORS: Record<string, string> = {
+  "smart-home": "#3b82f6",
+  "productivity": "#8b5cf6",
+  "social-media": "#ec4899",
+  "finance": "#22c55e",
+  "developer": "#a78bfa",
+  "security": "#ef4444",
+  "health": "#10b981",
+  "shopping": "#f97316",
+  "entertainment": "#8b5cf6",
+  "weather-travel": "#06b6d4",
+  "writing": "#6366f1",
+  "ai-automation": "#eab308",
+};
+
+export const DEFAULT_CATEGORY_COLOR = "#6b7280";
+
+export interface InstalledMeta {
+  name: string;
+  color: string;
+  iconUrl: string;
+  // Webapp-style installs (created via `webapp_create`) carry the launch URL
+  // in meta so the desktop can route clicks to an <iframe> instead of the
+  // skills path. Left undefined for regular skills.
+  webappUrl?: string;
+}

--- a/src/tests/routes/apps/install.test.ts
+++ b/src/tests/routes/apps/install.test.ts
@@ -23,6 +23,8 @@ vi.mock("fs", () => ({
 vi.mock("@/lib/config-store", () => ({
   DATA_DIR: "/tmp/test-data",
   CONFIG_ROOT: "/tmp/test-data",
+  getAll: vi.fn().mockResolvedValue({}),
+  setMany: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/lib/openclaw-config", () => ({


### PR DESCRIPTION
## Summary

Installs triggered via the MCP `app_install` tool (or CLI) landed the skill on disk but were **invisible on the desktop and in the Store's Installed tab**. The Store UI filters \"Installed\" by the `installed_apps` preference, and the desktop filters icons by both `installed_apps` AND `installed_meta`; those were only written as a client-side side-effect of the AppStore UI install flow. Off-desktop installs flew under that radar.

This PR makes the server-side routes the source of truth:
- `src/app/setup-api/apps/install/route.ts` now writes both `pref:installed_apps` (id) and `pref:installed_meta` (name + color + iconUrl)
- `src/app/setup-api/apps/uninstall/route.ts` mirrors the delete
- `src/lib/store-categories.ts` (new) holds the category→color map previously inlined in `AppStore.tsx`, so client and server stay in step
- `src/app/page.tsx` and `src/components/AppStore.tsx` import the shared `InstalledMeta` type / colour map

## Behaviour

- Fresh install (MCP or UI): skill on disk + both prefs populated → appears on desktop and Store after page refresh
- Re-install: short-circuits — no Store fetch, no config write, so MCP retries don't thrash the upstream API
- Offline / Store unreachable: falls back to a title-cased slug + neutral color + local icon path; app still renders rather than being silently dropped
- Uninstall: both prefs cleaned up

## Scope / non-goals

**Live refresh is not in this PR.** The desktop's React state is seeded on mount, so newly installed skills appear after a hard refresh (Ctrl+Shift+R). Wiring server→client push (SSE) is a deferred follow-up — kept this PR small and focused on the correctness fix.

## Test plan

- [x] MCP `app_install` via Gemma chat: skill on disk + preferences populated (verified on Jetson at 192.168.1.57)
- [x] After page refresh: skill shows in Store's Installed tab and on the desktop with correct icon + color
- [x] Re-install of already-installed app: no Store API fetch, no config write (short-circuit)
- [x] UI install still works (regression check — same meta populated via existing client path)
- [ ] Uninstall via MCP: prefs cleaned up → skill disappears after refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App installs now fetch and store app metadata (name, color, icon, optional launch URL) with deterministic fallbacks.

* **Bug Fixes**
  * Uninstall now removes associated metadata and installed-app entries to avoid orphaned preferences.

* **Improvements**
  * Centralized category color definitions for consistent styling and matched store metadata synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->