### PR TITLE
fix(tests): unblock 14 pre-existing failures in ai-models test suite

### DIFF
--- a/src/tests/components/ai-models-step.test.tsx
+++ b/src/tests/components/ai-models-step.test.tsx
@@ -104,6 +104,11 @@ describe("AIModelsStep variants", () => {
         description="Local models first"
         configureScope="local"
         testId="local-ai-test"
+        // Gemma is currently the active chat provider — required for the
+        // panel to render the "configured" pill rather than the orange
+        // "Switch to Gemma 4" call-to-action (which appears when Gemma is
+        // on disk but some other provider is primary).
+        currentProviderId="llamacpp"
       />,
     );
 
@@ -118,10 +123,6 @@ describe("AIModelsStep variants", () => {
     expect(queryByText("ClawBox AI")).not.toBeInTheDocument();
     expect(queryByText("OpenAI GPT")).not.toBeInTheDocument();
     expect(getByText("Recommended")).toBeInTheDocument();
-    // With the mocked hook returning llamaCppInstalled: true (i.e. Gemma is
-    // already on disk but the runtime is idle), the panel renders a green
-    // "configured" pill instead of the install button. Users should only see
-    // the orange "Enable Gemma 4" call-to-action on truly fresh devices.
     expect(getByText("Gemma 4 is already configured")).toBeInTheDocument();
   });
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -25,6 +25,22 @@ vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
 }));
 
+// Hoisted so the vi.mock factories below (which are themselves hoisted by
+// vitest) can see these. A plain const declaration at file-body position
+// would be in the TDZ when the mock factory evaluates.
+const { parseFullyQualifiedModelImpl, LLAMACPP_PROXY_BASE_URL } = vi.hoisted(() => ({
+  // Mirror real `parseFullyQualifiedModel` byte-for-byte — a sloppier
+  // split-on-"/" mock would accept "foo/" where the real impl rejects it,
+  // masking real regressions. Inlined to avoid `vi.importActual` which
+  // would pull in openclaw-config's side-effectful init.
+  parseFullyQualifiedModelImpl(fq: string) {
+    const idx = fq.indexOf("/");
+    if (idx <= 0 || idx === fq.length - 1) return null;
+    return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+  },
+  LLAMACPP_PROXY_BASE_URL: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+}));
+
 vi.mock("@/lib/openclaw-config", () => ({
   DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR: 24000,
   restartGateway: vi.fn(),
@@ -32,10 +48,35 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
+  // Added by PR #83 — the configure route sweeps agent sessions so the
+  // new primary provider takes effect on the open chat without a reset.
+  applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
+  parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
+}));
+
+// llamacpp / local-ai-runtime have pure getters, but local-ai-runtime
+// transitively imports `@/instrumentation-node` (which starts a server).
+// Mock both to keep tests hermetic.
+vi.mock("@/lib/llamacpp", () => ({
+  getDefaultLlamaCppModel: vi.fn().mockReturnValue("gemma4-e2b-it-q4_0"),
+  getLlamaCppContextWindow: vi.fn().mockReturnValue(131072),
+  // Real impl defaults to `getLlamaCppContextWindow()` when the env var is unset.
+  getLlamaCppMaxTokens: vi.fn().mockReturnValue(131072),
+  getLlamaCppProxyBaseUrl: vi.fn().mockReturnValue(LLAMACPP_PROXY_BASE_URL),
+}));
+
+vi.mock("@/lib/local-ai-runtime", () => ({
+  getLocalAiProxyBaseUrl: vi.fn((provider: string) =>
+    provider === "llamacpp"
+      ? LLAMACPP_PROXY_BASE_URL
+      : `http://127.0.0.1/setup-api/local-ai/${provider}`,
+  ),
 }));
 
 import { getAll, setMany } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
+import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
+import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
@@ -44,6 +85,13 @@ const mockInferConfiguredLocalModel = vi.mocked(inferConfiguredLocalModel);
 const mockReadOpenClawConfig = vi.mocked(readConfig);
 const mockRestartGateway = vi.mocked(restartGateway);
 const mockFs = vi.mocked(fsp);
+const mockApplyModelOverrideToAllAgentSessions = vi.mocked(applyModelOverrideToAllAgentSessions);
+const mockParseFullyQualifiedModel = vi.mocked(parseFullyQualifiedModel);
+const mockGetDefaultLlamaCppModel = vi.mocked(getDefaultLlamaCppModel);
+const mockGetLlamaCppContextWindow = vi.mocked(getLlamaCppContextWindow);
+const mockGetLlamaCppMaxTokens = vi.mocked(getLlamaCppMaxTokens);
+const mockGetLlamaCppProxyBaseUrl = vi.mocked(getLlamaCppProxyBaseUrl);
+const mockGetLocalAiProxyBaseUrl = vi.mocked(getLocalAiProxyBaseUrl);
 
 // Create a mock child process that immediately succeeds
 function createSuccessfulChildProcess(): ChildProcess {
@@ -103,6 +151,21 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockRestartGateway.mockResolvedValue();
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+
+    // Re-apply implementations cleared by vi.clearAllMocks above. Factory
+    // defaults set in `vi.mock(...)` hold across vi.resetModules but are
+    // wiped by mockClear call history cleanup, so we seed them per-test.
+    mockApplyModelOverrideToAllAgentSessions.mockResolvedValue(undefined);
+    mockParseFullyQualifiedModel.mockImplementation(parseFullyQualifiedModelImpl);
+    mockGetDefaultLlamaCppModel.mockReturnValue("gemma4-e2b-it-q4_0");
+    mockGetLlamaCppContextWindow.mockReturnValue(131072);
+    mockGetLlamaCppMaxTokens.mockReturnValue(131072);
+    mockGetLlamaCppProxyBaseUrl.mockReturnValue(LLAMACPP_PROXY_BASE_URL);
+    mockGetLocalAiProxyBaseUrl.mockImplementation((provider) =>
+      provider === "llamacpp"
+        ? LLAMACPP_PROXY_BASE_URL
+        : `http://127.0.0.1/setup-api/local-ai/${provider}`,
+    );
 
     const mod = await import("@/app/setup-api/ai-models/configure/route");
     configurePost = mod.POST;

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -46,9 +46,11 @@ describe("/setup-api/chat/model", () => {
     vi.mocked(promisify).mockReturnValue(mockExec as never);
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
     vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    // Mirror real `parseFullyQualifiedModel` from `@/lib/openclaw-config`
+    // exactly — trailing-slash rejection matters, a lax mock can mask bugs.
     vi.mocked(parseFullyQualifiedModel).mockImplementation((fq: string) => {
       const idx = fq.indexOf("/");
-      if (idx <= 0) return null;
+      if (idx <= 0 || idx === fq.length - 1) return null;
       return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
     });
 


### PR DESCRIPTION
## Summary

14 tests had been red on beta since the Gemma / provider-switch work in PRs #82/#83 landed. CI was useless as a signal — every PR inherited 14 failures regardless of actual correctness. This PR is test-only — no production code changes — and gets CI back to green so real regressions stop hiding in the noise.

## Root causes (three independent)

1. **Mock drift from configure route's real imports.** The route now calls `applyModelOverrideToAllAgentSessions` and `parseFullyQualifiedModel` (added in #83 for session sweeping), plus four getters from `@/lib/llamacpp` and one from `@/lib/local-ai-runtime`. The test mocked none of these. First request-time call threw, outer catch returned 500, every test asserting 200 cascaded red. Added the missing mocks with real-shape implementations.

2. **vitest-under-bun clears mock implementations along with call history.** Factory defaults set inside `vi.mock(...)` survive `vi.resetModules` but not `vi.clearAllMocks()`. Tests passed in isolation, failed in sequence. Re-apply the implementations in `beforeEach`.

3. **`ai-models-step.test.tsx` relied on `llamaCppIsActive` defaulting true.** The panel only sets it true when `currentProviderId === "llamacpp"`. Added the prop.

## Simplifier findings applied

- Mirror real `parseFullyQualifiedModel` byte-for-byte (`idx <= 0 || idx === fq.length - 1`) so trailing-slash inputs reject as expected. Fixed the same drift in `chat-model.test.ts`.
- Extract shared proxy-URL constant via `vi.hoisted` to avoid duplicating a magic string across two mock factories.

## Result

Before: 14 failed / 1055 passed (93 files, 2 red)
After: **1069 passed** (93 files, all green)

## Test plan

- [x] `bun run test` — 1069/1069 pass locally
- [ ] CI should now show `test: SUCCESS` for the first time in weeks