### PR TITLE
git add src/app/setup-api/ai-models/configure/route.ts src/app/setup-…

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -76,7 +76,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
     profileKey: "google:default",
   },
   openrouter: {
-    defaultModel: "openrouter/moonshotai/kimi-k2.5",
+    defaultModel: "openrouter/moonshotai/kimi-k2-0905",
     profileKey: "openrouter:default",
   },
   ollama: {

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -47,7 +47,7 @@ const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   openai: "openai/gpt-5.4",
   "openai-codex": "openai-codex/gpt-5.4",
   google: "google/gemini-2.0-flash",
-  openrouter: "openrouter/moonshotai/kimi-k2.5",
+  openrouter: "openrouter/moonshotai/kimi-k2-0905",
 };
 
 function isLocalModel(model: string | null | undefined): boolean {


### PR DESCRIPTION
…api/chat/model/route.ts && git commit -m "$(cat <<'EOF'

fix(ai-models): switch OpenRouter default to kimi-k2-0905

kimi-k2.5 is a reasoning model; with the default token budget and full MCP tool schema, reasoning-token burn can leave no room for visible output. kimi-k2-0905 is non-reasoning and returns content reliably.

## Summary

<!-- What does this PR change and why? Link related issues: Fixes #123 -->

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation / tooling
- [ ] Other: ___

## How was this tested?

<!-- Commands, steps, or hardware used (e.g. Jetson Orin Nano, x64 dev install). -->

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build` succeeds
- [ ] Manually verified on device / dev install

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] No secrets, tokens, or credentials committed
- [ ] Added/updated tests where it makes sense
- [ ] Updated docs where user-facing behavior changed

## Screenshots / logs (if UI or runtime change)

<!-- Drop images or terminal output here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the default AI model for OpenRouter provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->