### PR TITLE
fix(telegram): stop opening bot DMs to everyone by default [security]

### DIFF
--- a/install-x64.sh
+++ b/install-x64.sh
@@ -371,7 +371,11 @@ try {
   const cb=JSON.parse(fs.readFileSync(process.env.CLAWBOX_CONFIG,'utf8'));
   if(cb.telegram_bot_token){
     if(!c.channels)c.channels={};
-    c.channels.telegram={...c.channels.telegram,enabled:true,botToken:cb.telegram_bot_token,dmPolicy:'open',allowFrom:['*']};
+    // dmPolicy/allowFrom intentionally NOT set — OpenClaw's "pairing"
+    // default requires owner approval before the agent responds to a new
+    // sender. See src/lib/openclaw-config.ts:setTelegramToken.
+    const {dmPolicy:_dm,allowFrom:_af,...rest}=c.channels.telegram||{};
+    c.channels.telegram={...rest,enabled:true,botToken:cb.telegram_bot_token};
     process.stderr.write('  Telegram channel registered in OpenClaw config\n');
   }
 } catch {}

--- a/install.sh
+++ b/install.sh
@@ -708,8 +708,37 @@ step_openclaw_config() {
     local TG_TOKEN
     TG_TOKEN=$(node -e "try{const c=JSON.parse(require('fs').readFileSync('$CLAWBOX_CONFIG','utf8'));if(c.telegram_bot_token)process.stdout.write(c.telegram_bot_token)}catch{}" 2>/dev/null || true)
     if [ -n "$TG_TOKEN" ]; then
-      as_clawbox "$OPENCLAW_BIN" config set channels.telegram \
-        "{\"enabled\":true,\"botToken\":\"$TG_TOKEN\",\"dmPolicy\":\"open\",\"allowFrom\":[\"*\"]}" --json
+      # Do not set dmPolicy/allowFrom here — see src/lib/openclaw-config.ts
+      # setTelegramToken for the security rationale. `openclaw config set`
+      # may deep-merge instead of replace, which would leave legacy
+      # `dmPolicy:"open"` / `allowFrom:["*"]` values alive. Do the
+      # read-modify-write ourselves with a destructure-strip so the
+      # installer can't leave insecure values behind, matching what
+      # install-x64.sh and src/lib/openclaw-config.ts:setTelegramToken
+      # do on their paths.
+      as_clawbox env TG_TOKEN="$TG_TOKEN" CFG="$CLAWBOX_HOME/.openclaw/openclaw.json" node - <<'NODE'
+const fs = require("fs");
+const path = require("path");
+const botToken = process.env.TG_TOKEN;
+const cfgPath = process.env.CFG;
+let cfg = {};
+try {
+  cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
+} catch (err) {
+  // Only tolerate "file missing" — any other read/parse error (EACCES,
+  // corrupt JSON, transient IO) must abort, otherwise we'd silently
+  // overwrite a real-but-unreadable config with only the Telegram channel,
+  // wiping auth profiles, gateway settings, AI provider config, etc.
+  if (!err || err.code !== "ENOENT") throw err;
+}
+if (!cfg.channels) cfg.channels = {};
+const { dmPolicy: _dm, allowFrom: _af, ...rest } = cfg.channels.telegram || {};
+cfg.channels.telegram = { ...rest, enabled: true, botToken };
+fs.mkdirSync(path.dirname(cfgPath), { recursive: true });
+const tmp = `${cfgPath}.tmp`;
+fs.writeFileSync(tmp, JSON.stringify(cfg, null, 2));
+fs.renameSync(tmp, cfgPath);
+NODE
       echo "  Telegram channel registered"
     fi
   fi

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -105,6 +105,21 @@ for k in ("tools", "systemPromptSuffix"):
         del agents_defaults[k]
         changed = True
 
+# Security migration: older ClawBox versions silently wrote
+# channels.telegram.dmPolicy="open" + allowFrom=["*"] at bot-token setup,
+# which opened the bot — and the agent's shell/file/system_power tools —
+# to any Telegram user who found the handle. Strip those keys on every
+# gateway start so updated devices re-secure themselves without needing
+# a bot-token reconfigure or factory reset. No-op on already-safe configs.
+channels = cfg.get("channels")
+if isinstance(channels, dict):
+    telegram = channels.get("telegram")
+    if isinstance(telegram, dict):
+        for k in ("dmPolicy", "allowFrom"):
+            if k in telegram:
+                del telegram[k]
+                changed = True
+
 gateway = cfg.setdefault("gateway", {})
 control_ui = gateway.setdefault("controlUi", {})
 auth = gateway.setdefault("auth", {})

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -298,6 +298,7 @@ export interface OpenClawConfig {
       enabled?: boolean;
       botToken?: string;
       dmPolicy?: string;
+      allowFrom?: string[];
       [key: string]: unknown;
     };
   };
@@ -466,12 +467,19 @@ export async function setTelegramToken(botToken: string): Promise<void> {
   if (!config.channels) {
     config.channels = {};
   }
+  // Do NOT set `dmPolicy` or `allowFrom` here. OpenClaw's default
+  // (`dmPolicy: "pairing"`) requires the owner to approve every new sender
+  // via an in-Telegram pairing code before the agent responds. Writing
+  // `dmPolicy: "open"` + `allowFrom: ["*"]` would open the bot — and with it
+  // the agent's shell/file/system_power tools — to any Telegram user who
+  // finds the handle. Reconfiguring a bot token on a device with those
+  // values already stored should re-secure the channel, so strip them here
+  // too rather than merging on top of the stale insecure config.
+  const { dmPolicy: _dmPolicy, allowFrom: _allowFrom, ...rest } = config.channels.telegram ?? {};
   config.channels.telegram = {
-    ...config.channels.telegram,
+    ...rest,
     enabled: true,
     botToken,
-    dmPolicy: "open",
-    allowFrom: ["*"],
   };
   await writeConfig(config);
 }

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -198,7 +198,7 @@ describe("openclaw-config", () => {
   });
 
   describe("setTelegramToken", () => {
-    it("sets Telegram token in config", async () => {
+    it("sets Telegram token in config without overriding dmPolicy/allowFrom", async () => {
       await openclawConfig.setTelegramToken("123:abc");
 
       expect(mockFs.writeFile).toHaveBeenCalled();
@@ -207,7 +207,12 @@ describe("openclaw-config", () => {
 
       expect(writtenConfig.channels.telegram.botToken).toBe("123:abc");
       expect(writtenConfig.channels.telegram.enabled).toBe(true);
-      expect(writtenConfig.channels.telegram.dmPolicy).toBe("open");
+      // Security: do NOT override OpenClaw's default dmPolicy ("pairing"),
+      // and do NOT wildcard-allow every Telegram user. `not.toHaveProperty`
+      // (stricter than toBeUndefined) catches a future write of `undefined`
+      // which would still change the key's presence in the config object.
+      expect(writtenConfig.channels.telegram).not.toHaveProperty("dmPolicy");
+      expect(writtenConfig.channels.telegram).not.toHaveProperty("allowFrom");
     });
 
     it("preserves existing config", async () => {
@@ -292,13 +297,28 @@ describe("openclaw-config", () => {
       expect(writtenConfig.channels.telegram.customField).toBe("keep-me");
     });
 
-    it("sets allowFrom to wildcard", async () => {
-      await openclawConfig.setTelegramToken("123:abc");
+    it("strips insecure dmPolicy/allowFrom left over from older configs", async () => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({
+        channels: {
+          telegram: {
+            enabled: true,
+            botToken: "old:token",
+            dmPolicy: "open",
+            allowFrom: ["*"],
+          },
+        },
+      }));
+
+      await openclawConfig.setTelegramToken("new:token");
 
       const writeCall = mockFs.writeFile.mock.calls[0];
       const writtenConfig = JSON.parse(writeCall[1] as string);
 
-      expect(writtenConfig.channels.telegram.allowFrom).toEqual(["*"]);
+      expect(writtenConfig.channels.telegram.botToken).toBe("new:token");
+      // Reconfiguring a token must re-secure the channel by removing the
+      // old wildcard bypass, not merely no-op on top of it.
+      expect(writtenConfig.channels.telegram).not.toHaveProperty("dmPolicy");
+      expect(writtenConfig.channels.telegram).not.toHaveProperty("allowFrom");
     });
 
     it("writes pretty-printed JSON", async () => {


### PR DESCRIPTION
## Summary

`setTelegramToken` (and the matching shell paths in `install.sh` / `install-x64.sh`) silently wrote `dmPolicy: "open"` + `allowFrom: ["*"]` the moment a user submitted a bot token through the setup wizard. Combined with the agent's default tool surface (shell, file IO, `system_power`, etc.), this meant **any Telegram user who could find the bot handle** could DM it and trigger arbitrary commands on the Jetson. OpenClaw's upstream default is `dmPolicy: "pairing"` — every new sender has to be approved by the owner via a pairing code. We now delegate to that default.

## Changes

- **`src/lib/openclaw-config.ts`** — `setTelegramToken`: drop the two overrides. Strip `dmPolicy`/`allowFrom` from any pre-existing config via destructure-and-rest so a device that already has the insecure values stored gets re-secured on the next reconfigure without a factory reset. Also added `allowFrom?: string[]` to the channel interface (previously only in the index signature).
- **`install.sh`** — same fix on the fresh-install path (was writing the insecure JSON directly via `openclaw config set`).
- **`install-x64.sh`** — same fix on the x86 dev-install path (Node inline script block).
- **`src/tests/unit/openclaw-config.test.ts`** — inverted the two tests that asserted the old behavior (now using `.not.toHaveProperty` so a future `dmPolicy: undefined` write still fails the assertion); added a new test covering the strip-on-reconfigure path.

## Severity

**High.** An attacker who discovers the bot handle (BotFather handles are publicly enumerable) can trigger `run_command` on the Jetson with no pairing step. Ships a silent bypass of an explicit OpenClaw safety default.

## What this PR does NOT fix (worth a follow-up)

Existing devices that already have `dmPolicy: "open"` + `allowFrom: ["*"]` written to `~/.openclaw/openclaw.json` **stay vulnerable** until the owner either (a) reconfigures the bot token through Settings (triggers the TS strip path), or (b) we add a one-shot migration to `scripts/gateway-pre-start.sh` that removes the insecure override at gateway startup. (b) is the safer fleet-wide path — happy to draft as a follow-up PR if you want.

Also worth flagging in release notes: **anyone whose bot was running under the open policy should rotate their bot token via BotFather**, since the handle may have been discovered in the meantime.

## Test plan

- [x] `bun run test` — 1072/1072 pass on-device
- [x] Verified on a real Jetson that had the insecure config: reconfiguring a bot token strips `dmPolicy`/`allowFrom` from `openclaw.json`
- [ ] Recommend a human security review from `@ID-Robots/id-robots-core-team` before merge, not just `--admin squash`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer and runtime config now only enable the Telegram bot and set its token; they no longer force default DM permissions.
  * Any existing dmPolicy/allowFrom entries are stripped during token updates and at pre-start to remove insecure defaults.
* **Tests**
  * Unit tests updated to verify the token is set/enabled and that dmPolicy/allowFrom are removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->