### PR TITLE
fix(browser): remove --no-sandbox and persist profile across restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ code-source-code/
 .omx/
 playwright-report/
 test-results/
+scripts/nm-dispatcher-failover.sh

--- a/scripts/launch-browser.sh
+++ b/scripts/launch-browser.sh
@@ -92,9 +92,6 @@ if ! wait_for_display "$DISPLAY" "${XAUTHORITY:-}"; then
   exit 1
 fi
 
-# Reset profile on each start to avoid corruption from version changes
-# (This is a CDP automation browser, not a persistent user browser)
-rm -rf "$PROFILE"
 mkdir -p "$PROFILE"
 
 echo "Starting Chromium from $CHROMIUM on DISPLAY=$DISPLAY with CDP port $CDP_PORT"
@@ -107,7 +104,6 @@ exec env DISPLAY="$DISPLAY" HOME="$HOME" DBUS_SESSION_BUS_ADDRESS="disabled:" \
   --no-default-browser-check \
   --start-maximized \
   --disable-gpu \
-  --no-sandbox \
   --disable-dev-shm-usage \
   --disable-background-networking \
   --password-store=basic \


### PR DESCRIPTION
- Drop --no-sandbox flag; kernel.unprivileged_userns_clone=1 on Jetson
  means the user-namespace sandbox works without it, and Chromium was
  showing a persistent "unsupported command-line flag" warning banner
- Stop wiping the profile dir on every launch so cookies/logins/session
  state survive service restarts (UI already advertised this as a
  "persistent profile")

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>## Summary

<!-- What does this PR change and why? Link related issues: Fixes #123 -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation / tooling
- [ ] Other: ___

## How was this tested?

<!-- Commands, steps, or hardware used (e.g. Jetson Orin Nano, x64 dev install). -->

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build` succeeds
- [ ] Manually verified on device / dev install

## Checklist

- [ ] Branch is up to date with `main`
- [ ] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] No secrets, tokens, or credentials committed
- [ ] Added/updated tests where it makes sense
- [ ] Updated docs where user-facing behavior changed

## Screenshots / logs (if UI or runtime change)

<!-- Drop images or terminal output here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Browser profile data is now retained between sessions

* **Chores**
  * Updated version control configuration to ignore additional build-related scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->