### PR TITLE
fix(ai): write OpenRouter provider definition so chat actually works

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -337,6 +337,7 @@ export async function POST(request: Request) {
     const isOllama = provider === "ollama";
     const isLlamaCpp = provider === "llamacpp";
     const isClawAI = provider === "clawai";
+    const isOpenRouter = provider === "openrouter";
     const isLocalScope = scope === "local";
     if (!provider || (!normalizedApiKey && !isOllama && !isLlamaCpp && !isClawAI)) {
       return NextResponse.json(
@@ -576,6 +577,42 @@ export async function POST(request: Request) {
       ]);
       await ensureFallbackModel(shouldPromoteLocalToPrimary ? config.defaultModel : (isLocalScope ? null : config.defaultModel), config.defaultModel);
       console.log(`[AI Config] Set llama.cpp provider in openclaw.json: ${modelName} (context=${llamaCppContextWindow}, mode=replace)`);
+    } else if (isOpenRouter) {
+      // OpenClaw has no built-in provider adapter for OpenRouter the way it
+      // does for openai / anthropic / google, so without this explicit
+      // provider definition the runtime has no baseUrl to call — the chat
+      // turn silently returns `usage: 0/0/0` and the UI appears dead.
+      // Writing this entry restores the full OpenAI-compatible path.
+      // The `models` array is used for UI enumeration only; OpenClaw
+      // routes any `openrouter/<slug>` string through the same baseUrl, so
+      // listing just the default is enough to make every OpenRouter model
+      // reachable via `agents.defaults.model.primary`.
+      const defaultModelId = config.defaultModel.replace(/^openrouter\//, "");
+      const providerDef = JSON.stringify({
+        baseUrl: "https://openrouter.ai/api/v1",
+        api: "openai-completions",
+        apiKey: "openrouter-ref",
+        models: [{
+          id: defaultModelId,
+          name: defaultModelId,
+          input: ["text"],
+          contextWindow: 131072,
+          maxTokens: 8192,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        }],
+      });
+      await runCommand(OPENCLAW_BIN, [
+        "config", "set", "models.providers.openrouter", providerDef, "--json",
+      ]);
+      try {
+        await runCommand(OPENCLAW_BIN, [
+          "config", "set", "models.mode", "merge",
+        ]);
+      } catch {
+        // Non-fatal: merge is the default behavior anyway
+      }
+      await ensureFallbackModel(config.defaultModel);
+      console.log(`[AI Config] Set openrouter provider in openclaw.json: default=${defaultModelId}`);
     } else {
       // Switching away from Ollama/ClawBox AI — reset models.mode so cloud providers
       // auto-detect their model catalog normally.

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -598,4 +598,30 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     expect(providerDef.baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/ollama");
   });
+
+  it("configures openrouter provider definition in openclaw", async () => {
+    // OpenClaw has no built-in OpenRouter adapter, so without an explicit
+    // models.providers.openrouter entry the runtime short-circuits every
+    // chat turn to `usage: 0/0/0` and the UI appears dead. Regression test
+    // for that silent-failure bug.
+    const res = await configurePost(jsonRequest({
+      provider: "openrouter",
+      apiKey: "sk-or-v1-test",
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands.some((command) => command.includes("config set models.providers.openrouter"))).toBe(true);
+    expect(commands).toContain("config set agents.defaults.model.primary openrouter/moonshotai/kimi-k2-0905");
+
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.openrouter");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+
+    expect(providerDef.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(providerDef.api).toBe("openai-completions");
+    expect(providerDef.models?.[0]?.id).toBe("moonshotai/kimi-k2-0905");
+  });
 });


### PR DESCRIPTION
## Summary

OpenRouter has been silently broken since the configure route gained local-AI provider definitions: ClawBox writes `auth.profiles.openrouter:default` but **never writes `models.providers.openrouter`**. OpenClaw has no built-in adapter for OpenRouter (unlike openai/anthropic/google), so without that entry the runtime has no baseUrl to call — every chat turn returns `usage: { input: 0, output: 0 }`, the assistant message is empty, and the UI shows nothing.

The only trace in the logs: `[agent/embedded] incomplete turn detected … stopReason=stop payloads=0 — surfacing error to user`.

## What shipped

- **`src/app/setup-api/ai-models/configure/route.ts`** — add an `isOpenRouter` branch that writes `models.providers.openrouter` with `baseUrl: https://openrouter.ai/api/v1`, `api: openai-completions`, and the default model. Mirrors the pattern already used for llamacpp / ollama.
- **`src/tests/routes/ai-models/configure.test.ts`** — new test asserting the openrouter branch writes the provider definition with the correct baseUrl, api, and default model slug. Regression coverage for the silent-failure mode.

The `models` array is UI-only — OpenClaw routes any `openrouter/<slug>` string through the same baseUrl. Verified on-device: after injecting the same provider def this PR writes, `openrouter/anthropic/claude-haiku-4-5` works even though only `moonshotai/kimi-k2-0905` is in the list.

## Verification

- `bun run test` — 1073/1073 pass on real Jetson (was 1072, +1 new test)
- Live-tested on Jetson with the injection this PR automates:
  - Before: kimi and haiku both silent (`payloads=0`)
  - After: both reply normally, usage accounts properly

## Scope / non-goals

- Leaves `models[]` at length 1 (just the default kimi). The UI doesn't have an OpenRouter model picker yet; when it does, this list can grow or fetch live from `/api/v1/models`. Filed as follow-up — not part of this PR.
- Existing devices that set up OpenRouter before this fix need a reconfigure (re-submit the API key through Settings → AI Provider → OpenRouter) to get the provider def written. Separate one-shot migration would be a follow-up if needed; for now the configure flow itself is the migration.

## Test plan

- [x] `bun run test` — 1073/1073
- [x] Fresh OpenRouter setup on Jetson → chat replies
- [x] Switch primary to a non-default OpenRouter model (`anthropic/claude-haiku-4-5`) → chat replies
- [ ] (for reviewers) Fresh install from scratch → setup wizard → enter OpenRouter key → chat works with default model

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OpenRouter as a new AI model provider option, enabling seamless integration of OpenRouter services into your setup.
  * Automatically configures OpenAI-compatible API endpoints and provider settings.
  * Includes intelligent fallback model selection and automatic provider mode optimization.

* **Tests**
  * Added comprehensive test coverage for OpenRouter provider configuration and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->