### PR TITLE
fix(migration): scrub missing OpenRouter provider def on existing devices

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -120,6 +120,35 @@ if isinstance(channels, dict):
                 del telegram[k]
                 changed = True
 
+# Migration: devices that configured OpenRouter before the provider-def
+# fix have `auth.profiles.openrouter:default` set but no
+# `models.providers.openrouter` entry, so OpenClaw's runtime has no
+# baseUrl to call and every chat turn silently returns `usage: 0/0/0`.
+# Fix those in place on gateway start. The configure route now writes the
+# provider def on new setups, so only legacy devices will hit this branch.
+# The `models` array is UI-only — OpenClaw routes any `openrouter/<slug>`
+# through the same baseUrl, so listing just the current default is enough.
+auth_profiles = cfg.get("auth", {}).get("profiles", {}) if isinstance(cfg.get("auth"), dict) else {}
+has_openrouter_auth = isinstance(auth_profiles, dict) and "openrouter:default" in auth_profiles
+models_providers = cfg.setdefault("models", {}).setdefault("providers", {})
+if has_openrouter_auth and not models_providers.get("openrouter"):
+    primary = (cfg.get("agents", {}).get("defaults", {}).get("model", {}) or {}).get("primary", "")
+    default_model = primary[len("openrouter/"):] if isinstance(primary, str) and primary.startswith("openrouter/") else "moonshotai/kimi-k2-0905"
+    models_providers["openrouter"] = {
+        "baseUrl": "https://openrouter.ai/api/v1",
+        "api": "openai-completions",
+        "apiKey": "openrouter-ref",
+        "models": [{
+            "id": default_model,
+            "name": default_model,
+            "input": ["text"],
+            "contextWindow": 131072,
+            "maxTokens": 8192,
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        }],
+    }
+    changed = True
+
 gateway = cfg.setdefault("gateway", {})
 control_ui = gateway.setdefault("controlUi", {})
 auth = gateway.setdefault("auth", {})


### PR DESCRIPTION
## Summary

Fleet-wide self-heal for the OpenRouter silent-failure bug fixed in PR #95. That PR stopped NEW setups from shipping devices into the broken state, but existing devices (configured before the patch landed) still have `auth.profiles.openrouter:default` set without the matching `models.providers.openrouter` entry — their chat silently returns `usage: 0/0/0` for every turn until the user re-submits their OpenRouter API key through Settings.

This PR adds a one-shot migration to `scripts/gateway-pre-start.sh` (same pattern used for the Telegram `dmPolicy` scrub): on every gateway start, if the openrouter auth profile exists and the provider def is missing or null, write the same shape the configure route now writes. Devices heal themselves on the next gateway restart after upgrade, without touching the user's settings.

## Changes

- **`scripts/gateway-pre-start.sh`** — new Python block in the existing read-modify-write step. Checks `auth.profiles.openrouter:default` presence and `models.providers.openrouter` presence; if first exists and second doesn't, writes the provider def. Uses the device's current `agents.defaults.model.primary` as the default model (falls back to `moonshotai/kimi-k2-0905` if the primary is on a different provider). Idempotent — no-op on already-patched devices, reuses the existing "skipping write" log path.

## Verification

- **End-to-end on Jetson:** removed `models.providers.openrouter` to simulate a legacy device → ran pre-start → provider def written, baseUrl correct, default model matches current primary (`anthropic/claude-haiku-4-5` on the test device). Ran pre-start again → "Gateway config already correct, skipping write".
- **Local Python unit tests (5 cases):**
  - Legacy device (has auth, no provider def, primary uses openrouter) → migrates, uses current primary as default model
  - Already-patched device → no-op, preserves existing def
  - No openrouter auth → no-op, doesn't create phantom provider
  - Auth profile exists but primary not on openrouter → falls back to kimi default
  - Provider def stored as `null` → treated as missing, migrated

## Scope / non-goals

- Does NOT add an OpenRouter model picker. Users who want to switch OpenRouter models still need to edit `openclaw.json` directly. Flagged for a follow-up PR.
- Does NOT retry the migration if the provider def is malformed (e.g., has `baseUrl` but no `models`). The "null or missing" heuristic catches the silent-failure mode; more-nuanced validation would bloat the pre-start script.

## Test plan

- [x] Local Python unit tests, 5 cases
- [x] End-to-end on Jetson, including idempotency
- [ ] (for reviewers) Sanity-check the Python edge-case handling of `cfg.get("auth")` returning a non-dict