### PR TITLE
docs: link to ClawBox AI product page (clawboxai.dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ cp .env.example .env
 ## 🌍 Community & Links
 
 - **🌐 Website:** [openclawhardware.dev](https://openclawhardware.dev)
+- **🧠 Product page — [ClawBox AI](https://clawboxai.dev):** specs, FAQ, and buyer guide for the ClawBox AI appliance
 - **💬 Discord:** [discord.gg/FbKmnxYnpq](https://discord.gg/FbKmnxYnpq) (78K+ members)
 - **📖 Docs:** [openclawhardware.dev/docs](https://openclawhardware.dev/docs)
 - **🛒 Buy ClawBox:** [openclawhardware.dev](https://openclawhardware.dev) — €549, free worldwide shipping


### PR DESCRIPTION
Adds a Community & Links entry pointing to the dedicated ClawBox AI product page at https://clawboxai.dev — the page covers specs, FAQ, and buyer context for the appliance this repo ships.

Why now: clawboxai.dev is live and targeting 'clawbox ai' as the primary query. A link from the canonical clawbox repo README is the most topically relevant external backlink we have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new external product page link to available community resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->