### PR TITLE
config: route ClawHub through openclawhardware.dev edge proxy

### DIFF
--- a/config/clawbox-gateway.service
+++ b/config/clawbox-gateway.service
@@ -16,6 +16,10 @@ Environment=NODE_ENV=production
 Environment=NODE_OPTIONS=--max-old-space-size=1024
 Environment=OPENAI_TTS_BASE_URL=http://localhost:8880/v1
 Environment=OPENCLAW_VERBOSE=1
+# Route ClawHub traffic through our cached edge proxy by default.
+# Override with `systemctl edit clawbox-gateway.service` or by setting
+# OPENCLAW_CLAWHUB_URL in /home/clawbox/clawbox/data/network.env (loaded next).
+Environment=OPENCLAW_CLAWHUB_URL=https://openclawhardware.dev
 EnvironmentFile=-/home/clawbox/clawbox/data/network.env
 
 [Install]

--- a/config/clawbox-setup.service
+++ b/config/clawbox-setup.service
@@ -15,6 +15,10 @@ EnvironmentFile=-/home/clawbox/clawbox/.env
 Environment=NODE_ENV=production
 Environment=PORT=80
 Environment=HOSTNAME=0.0.0.0
+# Route ClawHub traffic through our cached edge proxy by default.
+# Override via `systemctl edit clawbox-setup.service` or by setting
+# OPENCLAW_CLAWHUB_URL in /home/clawbox/clawbox/.env.
+Environment=OPENCLAW_CLAWHUB_URL=https://openclawhardware.dev
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 NoNewPrivileges=true


### PR DESCRIPTION
## Summary

- Adds `OPENCLAW_CLAWHUB_URL=https://openclawhardware.dev` to both systemd units that spawn openclaw on every device (`clawbox-gateway.service` and `clawbox-setup.service`).
- All openclaw skill installs / metadata fetches / search calls now flow through the new edge proxy at `clawbox-website` instead of hitting clawhub.ai directly.
- The proxy aggressively caches immutable skill downloads on the Vercel edge (24h s-maxage, immutable), so popular skills are served from CDN — no more 30 req/min IP-bucket 429s.

## Why

Live repro on a beta device today:

```
$ openclaw skills install nano-banana-pro --force
Downloading nano-banana-pro@1.0.1 from ClawHub…
ClawHub /api/v1/download failed (429): Rate limit exceeded
```

clawhub.ai's anonymous IP bucket is 30/min. A single device bootstrapping multiple skills (or any NAT'd network) trips it routinely. With this patch:

```
$ OPENCLAW_CLAWHUB_URL=https://openclawhardware.dev openclaw skills install nano-banana-pro --force
Downloading nano-banana-pro@1.0.1 from ClawHub…
Installing to /home/clawbox/.openclaw/workspace/skills/nano-banana-pro…
Installed nano-banana-pro@1.0.1
```

## Override path

Operators who need a different ClawHub mirror (regional, self-hosted, future migration) can drop a systemd override or set `OPENCLAW_CLAWHUB_URL` in `network.env` / `.env` (both loaded after the unit-baked Environment= so they win conflict resolution).

## Test plan

- [x] Inline command verified end-to-end on a real ClawBox device — `nano-banana-pro` install that was 429-ing now succeeds.
- [x] Proxy returns `cache-control: public, max-age=3600, immutable` on `/api/v1/download` and `x-vercel-cache: HIT` on second fetch of the same (slug, version).
- [ ] After merge, `systemctl daemon-reload` + restart `clawbox-gateway` + `clawbox-setup` on a device, confirm dashboard install regression-free.

## Pairs with

- openclaw client retry-on-Retry-After (ID-Robots/openclaw#1).
- clawbox-website edge proxy (commits 87851aa, 844b932, 76ae41c on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added `OPENCLAW_CLAWHUB_URL` environment variable to system services with a default value of `https://openclawhardware.dev`. The configuration is customizable through systemd drop-in overrides or environment files, providing flexible override options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->