### PR TITLE
fix(ai-models): Pro tier no longer offers a trial — only Max does

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -72,10 +72,7 @@ const CLAWAI_TIER_INFO: Record<ClawaiTier, ClawaiTierInfo> = {
     pillLabel: "Pro",
     priceEuro: 9,
     pricePeriod: "/month",
-    // Pro plan bills from day one — only Max plan ships with a trial.
-    // Keep the field on the type so the picker / plan-card components
-    // stay tier-agnostic; flipping this back to true here is the only
-    // change needed if Pro re-acquires a trial later.
+    // Pro bills from day one; flip to true if a trial returns.
     hasTrial: false,
     features: [
       "5× more usage than Free",
@@ -1914,10 +1911,6 @@ export default function AIModelsStep({
                 {CLAWAI_TIER_ORDER.map((tier) => {
                   const info = CLAWAI_TIER_INFO[tier];
                   const isActive = clawaiTier === tier;
-                  // Trial chip is shown for any tier with `hasTrial: true`.
-                  // Currently only Max — Pro now bills from day one, Free
-                  // never had a trial. The chip floats above the pill so it
-                  // doesn't add height to the radiogroup row.
                   const showPickerTrial = info.hasTrial;
                   const ariaLabel = showPickerTrial ? `${info.pillLabel} tier, Trial` : `${info.pillLabel} tier`;
                   return (

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -72,7 +72,11 @@ const CLAWAI_TIER_INFO: Record<ClawaiTier, ClawaiTierInfo> = {
     pillLabel: "Pro",
     priceEuro: 9,
     pricePeriod: "/month",
-    hasTrial: true,
+    // Pro plan bills from day one — only Max plan ships with a trial.
+    // Keep the field on the type so the picker / plan-card components
+    // stay tier-agnostic; flipping this back to true here is the only
+    // change needed if Pro re-acquires a trial later.
+    hasTrial: false,
     features: [
       "5× more usage than Free",
       "DeepSeek V4 Flash",
@@ -1910,10 +1914,11 @@ export default function AIModelsStep({
                 {CLAWAI_TIER_ORDER.map((tier) => {
                   const info = CLAWAI_TIER_INFO[tier];
                   const isActive = clawaiTier === tier;
-                  // Trial chip lives on the picker only for the Max tier;
-                  // Pro's chip moves into the orange plan card below so the
-                  // CTA reads as part of the plan body instead of a floater.
-                  const showPickerTrial = info.hasTrial && tier !== "flash";
+                  // Trial chip is shown for any tier with `hasTrial: true`.
+                  // Currently only Max — Pro now bills from day one, Free
+                  // never had a trial. The chip floats above the pill so it
+                  // doesn't add height to the radiogroup row.
+                  const showPickerTrial = info.hasTrial;
                   const ariaLabel = showPickerTrial ? `${info.pillLabel} tier, Trial` : `${info.pillLabel} tier`;
                   return (
                     <button


### PR DESCRIPTION
## Summary

Per ClawBox AI portal policy, the **Pro plan bills from day one** and only the **Max plan** ships with a 30-day free trial. The wizard was still advertising a trial chip on the Pro pill and a \`Start 30-day free trial\` CTA on the Pro plan card, both of which led users to a confusing portal dialog (\"ClawBox Pro tier needs a Max plan\") because the trial CTA actually starts a Max trial, not a Pro one.

This PR aligns the wizard UI with the portal: only Max advertises a trial; Pro presents its €9/month price without trial messaging.

## Change

- \`CLAWAI_TIER_INFO.flash.hasTrial\`: \`true\` → \`false\`
- Drop the now-redundant \`tier !== \"flash\"\` guard on \`showPickerTrial\` (the field-level toggle handles it cleanly)
- Update the comment to reflect the new policy

The picker pill and plan-card components were already gated on \`info.hasTrial\`, so this is a one-flag change with no other plumbing.

## Test plan

- [x] No test referenced the trial chip or \"Start 30-day free trial\" CTA on the Pro pill (\`grep\` of \`src/tests/\` returned nothing relevant)
- [ ] CI \`test\` job passes
- [ ] Manual: wizard's ClawBox AI step shows the trial badge only on Max, no \"Start 30-day free trial\" CTA on Pro card

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Trial badge display across AI model tiers to accurately reflect trial availability. The flash tier will no longer display a trial badge, as it does not offer trial access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->