### PR TITLE
fix(ai-models): mark deepseek-v4-flash as reasoning-capable

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -223,11 +223,16 @@ function buildClawboxAiProviderDefinition(apiKey: string) {
     baseUrl: CLAWBOX_AI_PROXY_URL,
     api: "openai-completions",
     apiKey,
+    // `reasoning: true` on both entries is what tells the OpenClaw
+    // gateway to forward `reasoning_effort` (and `thinking: { type:
+    // "disabled" }` for off) to DeepSeek. Both V4 surfaces are
+    // thinking-capable per OpenClaw's built-in catalog; flipping
+    // either to false silently makes the chat's Effort picker a no-op.
     models: [
       {
         id: CLAWBOX_AI_FLASH_MODEL_ID,
         name: "ClawBox AI Flash",
-        reasoning: false,
+        reasoning: true,
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       },
       {


### PR DESCRIPTION
## Summary

The configure route was emitting \`reasoning: false\` for **ClawBox AI Flash** in the deepseek provider definition. OpenClaw's gateway uses that flag to gate effort-param forwarding, so on Flash:

- The chat's **Effort picker became a no-op** — switching between Off / Low / Medium / High / Max produced a \"Switched effort to X\" toast but the agent kept reporting *\"thinking off\"* regardless.
- \`reasoning_effort\` was **never sent** to DeepSeek.
- \`thinking: { type: \"disabled\" }\` was **never sent** when picking Off, so users couldn't actually disable reasoning to get snappy chat.

Per OpenClaw's [thinking-levels docs](https://docs.openclaw.ai/tools/thinking) and built-in catalog, **both V4 surfaces are thinking-capable**: \`deepseek-v4-flash\` and \`deepseek-v4-pro\` are both classified as \"V4 thinking-capable surface.\" Pro's flag was already correct; Flash was the outlier.

## Verification

Direct test against the cloud API:

| Payload | reasoning_tokens | total tokens | Effect |
|---|---|---|---|
| baseline (no control) | 31 | 44 | default reasoning |
| \`reasoning_effort: low\` | 19 | 32 | reduced |
| \`reasoning_effort: max\` | (per docs) | (heavy) | maximum depth |
| **\`thinking: { type: \"disabled\" }\`** | **none** | **12** | **fully disabled** |

The cloud honors the exact payloads OpenClaw's gateway sends — the flag was the only blocker.

## Change

- \`reasoning: false → true\` for \`deepseek-v4-flash\`
- Lift the explanatory comment to **struct-level** so it covers both Flash and Pro (a future regression on Pro's flag would now have a one-line warning sitting right next to it)
- Comment cites the upstream behavior so future readers know why the flag matters even though Flash is \"only\" the cheap tier

## Test plan

- [x] Verified manually on a Jetson: with \`reasoning: true\`, Effort=Off → agent reports \"thinking off\" + responds in ~1s; Effort=High → reasoning kicks in.
- [ ] CI \`test\` passes (no test asserts \`reasoning: false\` for Flash — grep'd the test directory)
- [ ] CI \`e2e\` passes
- [ ] CodeRabbit review

## Behavioral note

After this lands, fresh installs on Flash will start advertising the Effort picker as functional. No perf impact server-side; the gateway forwards a small extra param. The user-visible change is exactly what was missing: Effort: Off → fast no-thinking responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enabled reasoning capabilities for the AI Flash model, allowing it to provide more advanced analytical and problem-solving features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->