### PR TITLE
fix(ai-models): resolve clawai tier from portal, not the wizard picker

### DIFF
--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { readConfig } from "@/lib/openclaw-config";
 import { get as getConfigValue } from "@/lib/config-store";
-import { normalizeClawboxAiTier } from "@/lib/clawbox-ai-models";
+import { normalizeClawboxAiTier, type ClawboxAiTier } from "@/lib/clawbox-ai-models";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +16,124 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 const CLAWBOX_AI_TIER_CONFIG_KEY = "clawai_tier";
+
+// Portal endpoint that maps a `claw_*` token to its current subscription
+// state. Authoritative source for the device's tier badge — local config
+// only ever stored the user's wizard *selection*, which can drift from
+// what the portal actually grants (Free user pastes a token + clicks Max
+// pill → local says "pro" but token entitles only Free).
+const PORTAL_DEVICE_INFO_URL =
+  process.env.CLAWBOX_AI_DEVICE_INFO_URL?.trim()
+  || "https://openclawhardware.dev/api/clawbox-ai/device-info";
+
+// 120s TTL > 30s poll cadence so most polls land on a warm cache. The
+// portal's reconcile-tier already self-heals on its end inside its own
+// 60s window, so 120s here is still bounded by Stripe truth on the
+// far side.
+const PORTAL_TIER_CACHE_TTL_MS = 120_000;
+// 4s timeout — this fetch sits on the render path of the chat header
+// and Settings card. Anything longer stacks behind the 30s poll cadence
+// and stalls the badge update. On timeout we treat the portal as
+// unreachable and fall back to the picker selection.
+const PORTAL_FETCH_TIMEOUT_MS = 4_000;
+// Bound for the in-memory token cache. A single device only has one
+// active claw_ token at a time, so this only matters under factory-
+// reset / multi-account dev churn — but a long-running process would
+// otherwise leak entries forever.
+const PORTAL_TIER_CACHE_MAX_ENTRIES = 64;
+
+interface DeviceInfoResponse {
+  tier?: string;
+  deviceTier?: string | null;
+}
+
+type PortalLookup =
+  | { source: "portal"; tier: ClawboxAiTier | null }
+  | { source: "unreachable" };
+
+interface PortalCacheEntry {
+  tier: ClawboxAiTier | null;
+  expiresAt: number;
+}
+
+const portalTierCache = new Map<string, PortalCacheEntry>();
+const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
+
+function rememberTier(token: string, tier: ClawboxAiTier | null, now: number) {
+  // Sweep expired entries, then enforce the size cap by dropping the
+  // oldest (insertion-order) entries until we're under the limit. Map
+  // iteration order is insertion order, so the first key is the oldest.
+  for (const [key, entry] of portalTierCache) {
+    if (entry.expiresAt <= now) portalTierCache.delete(key);
+  }
+  while (portalTierCache.size >= PORTAL_TIER_CACHE_MAX_ENTRIES) {
+    const oldest = portalTierCache.keys().next().value;
+    if (oldest === undefined) break;
+    portalTierCache.delete(oldest);
+  }
+  portalTierCache.set(token, { tier, expiresAt: now + PORTAL_TIER_CACHE_TTL_MS });
+}
+
+// Map portal's plan name + device-pair stamp to the local
+// ClawboxAiTier enum the UI badges already understand. The local enum
+// is "flash" (Pro plan / V4 Flash model) and "pro" (Max plan / V4 Pro
+// model); Free is `null` (no paid badge).
+function mapPortalTier(body: DeviceInfoResponse): ClawboxAiTier | null {
+  const stamped = normalizeClawboxAiTier(body.deviceTier);
+  if (stamped) return stamped;
+  const plan = (body.tier ?? "").trim().toLowerCase();
+  if (plan === "max") return "pro";
+  if (plan === "pro") return "flash";
+  return null;
+}
+
+async function fetchPortalTier(token: string): Promise<PortalLookup> {
+  const now = Date.now();
+  const cached = portalTierCache.get(token);
+  if (cached && cached.expiresAt > now) return { source: "portal", tier: cached.tier };
+
+  const existing = inFlightPortalLookups.get(token);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<PortalLookup> => {
+    try {
+      const res = await fetch(PORTAL_DEVICE_INFO_URL, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(PORTAL_FETCH_TIMEOUT_MS),
+      });
+      if (res.ok) {
+        const body = await res.json() as DeviceInfoResponse;
+        const tier = mapPortalTier(body);
+        rememberTier(token, tier, now);
+        return { source: "portal", tier };
+      }
+      // 401/403 are definitive — the portal *did* answer, the token just
+      // doesn't entitle anything. Cache so we don't re-hammer for the
+      // TTL. 5xx and network errors leave the cache untouched and let
+      // callers fall back to the locally-stored picker selection.
+      if (res.status === 401 || res.status === 403) {
+        rememberTier(token, null, now);
+        return { source: "portal", tier: null };
+      }
+      return { source: "unreachable" };
+    } catch {
+      return { source: "unreachable" };
+    }
+  })();
+
+  inFlightPortalLookups.set(token, promise);
+  try {
+    return await promise;
+  } finally {
+    inFlightPortalLookups.delete(token);
+  }
+}
+
+// Test-only: lets vitest reset the cache between runs.
+export function _resetPortalTierCache() {
+  portalTierCache.clear();
+  inFlightPortalLookups.clear();
+}
 
 function normalizeProvider(provider: string | null): string | null {
   if (!provider) return null;
@@ -61,9 +179,25 @@ export async function GET() {
     }
     const normalizedProvider = normalizeProvider(provider);
 
-    const clawaiTier = normalizedProvider === "clawai"
-      ? normalizeClawboxAiTier(await getConfigValue(CLAWBOX_AI_TIER_CONFIG_KEY).catch(() => null))
-      : null;
+    let clawaiTier: ClawboxAiTier | null = null;
+    let tierSource: "portal" | "picker" = "picker";
+    if (normalizedProvider === "clawai") {
+      // Default to the wizard's picker selection; the portal call below
+      // overwrites both fields when it gets a definitive answer.
+      // Falling back to the picker on transient portal outages keeps
+      // the badge from blinking off during network blips.
+      clawaiTier = normalizeClawboxAiTier(
+        await getConfigValue(CLAWBOX_AI_TIER_CONFIG_KEY).catch(() => null),
+      );
+      const token = config.models?.providers?.deepseek?.apiKey;
+      if (typeof token === "string" && token.startsWith("claw_")) {
+        const lookup = await fetchPortalTier(token);
+        if (lookup.source === "portal") {
+          clawaiTier = lookup.tier;
+          tierSource = "portal";
+        }
+      }
+    }
 
     return NextResponse.json({
       connected: !!normalizedProvider,
@@ -72,6 +206,7 @@ export async function GET() {
       mode,
       model,
       clawaiTier,
+      tierSource,
     }, {
       headers: {
         "Cache-Control": "no-store",
@@ -79,7 +214,7 @@ export async function GET() {
     });
   } catch {
     return NextResponse.json(
-      { connected: false, provider: null, providerLabel: null, mode: null, model: null, clawaiTier: null },
+      { connected: false, provider: null, providerLabel: null, mode: null, model: null, clawaiTier: null, tierSource: "picker" },
       {
         headers: {
           "Cache-Control": "no-store",

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -59,10 +59,18 @@ interface PortalCacheEntry {
 const portalTierCache = new Map<string, PortalCacheEntry>();
 const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
 
+/**
+ * Writes a token's resolved tier into the in-memory cache, sweeping
+ * expired entries and enforcing the size cap before insertion. Map
+ * iteration order is insertion order, so the first key returned by
+ * `keys()` is the oldest.
+ *
+ * @param token Portal token (`claw_*`) used as the cache key.
+ * @param tier Resolved tier (or `null` for Free / no entitlement).
+ * @param now Current epoch ms; used both for expiry comparison and to
+ *   set the new entry's `expiresAt`.
+ */
 function rememberTier(token: string, tier: ClawboxAiTier | null, now: number) {
-  // Sweep expired entries, then enforce the size cap by dropping the
-  // oldest (insertion-order) entries until we're under the limit. Map
-  // iteration order is insertion order, so the first key is the oldest.
   for (const [key, entry] of portalTierCache) {
     if (entry.expiresAt <= now) portalTierCache.delete(key);
   }
@@ -74,10 +82,17 @@ function rememberTier(token: string, tier: ClawboxAiTier | null, now: number) {
   portalTierCache.set(token, { tier, expiresAt: now + PORTAL_TIER_CACHE_TTL_MS });
 }
 
-// Map portal's plan name + device-pair stamp to the local
-// ClawboxAiTier enum the UI badges already understand. The local enum
-// is "flash" (Pro plan / V4 Flash model) and "pro" (Max plan / V4 Pro
-// model); Free is `null` (no paid badge).
+/**
+ * Maps the portal's `device-info` response to the local `ClawboxAiTier`
+ * enum the UI badges already understand. Prefers the device-pair stamp
+ * (`deviceTier`) when present; otherwise translates the user's plan
+ * name (`tier`) to its corresponding device-tier. The local enum is
+ * `"flash"` (Pro plan / V4 Flash model) and `"pro"` (Max plan / V4 Pro
+ * model); Free / unpaid resolves to `null` (no paid badge rendered).
+ *
+ * @param body Parsed JSON from `/api/clawbox-ai/device-info`.
+ * @returns The badge-facing tier, or `null` for Free.
+ */
 function mapPortalTier(body: DeviceInfoResponse): ClawboxAiTier | null {
   const stamped = normalizeClawboxAiTier(body.deviceTier);
   if (stamped) return stamped;
@@ -87,6 +102,22 @@ function mapPortalTier(body: DeviceInfoResponse): ClawboxAiTier | null {
   return null;
 }
 
+/**
+ * Resolves a `claw_*` token's current tier against the portal, with
+ * a short in-memory cache and concurrent-request de-duplication.
+ *
+ * Cache semantics:
+ *   - 200 OK: parsed tier is cached for `PORTAL_TIER_CACHE_TTL_MS`.
+ *   - 401 / 403: a definitive "no entitlement" verdict is also cached
+ *     so we don't re-hammer the portal for invalid tokens.
+ *   - 5xx / network error: cache untouched; caller falls back to the
+ *     locally-stored picker selection so the badge doesn't flicker
+ *     during transient portal outages.
+ *
+ * @param token The bearer token to look up.
+ * @returns Either a definitive `{ source: "portal", tier }` answer or
+ *   `{ source: "unreachable" }` when the portal couldn't respond.
+ */
 async function fetchPortalTier(token: string): Promise<PortalLookup> {
   const now = Date.now();
   const cached = portalTierCache.get(token);
@@ -129,7 +160,11 @@ async function fetchPortalTier(token: string): Promise<PortalLookup> {
   }
 }
 
-// Test-only: lets vitest reset the cache between runs.
+/**
+ * Test-only escape hatch — clears both the value cache and any
+ * in-flight lookups so vitest's `beforeEach` can start each test from
+ * a clean module-state. Not for production use.
+ */
 export function _resetPortalTierCache() {
   portalTierCache.clear();
   inFlightPortalLookups.clear();

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -1,20 +1,38 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(),
 }));
 
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(),
+}));
+
 import { readConfig } from "@/lib/openclaw-config";
+import { get as getConfigValue } from "@/lib/config-store";
+
 const mockReadConfig = vi.mocked(readConfig);
+const mockGetConfigValue = vi.mocked(getConfigValue);
 
 describe("/setup-api/ai-models/status", () => {
   let GET: () => Promise<Response>;
+  let resetPortalTierCache: () => void;
+  let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockGetConfigValue.mockResolvedValue(null);
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
     const mod = await import("@/app/setup-api/ai-models/status/route");
     GET = mod.GET;
+    resetPortalTierCache = mod._resetPortalTierCache;
+    resetPortalTierCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("returns connected status with provider info", async () => {
@@ -108,6 +126,127 @@ describe("/setup-api/ai-models/status", () => {
     expect(body.provider).toBe("llamacpp");
     expect(body.providerLabel).toBe("llama.cpp Local");
     expect(body.model).toBe("llamacpp/gemma-q4");
+  });
+
+  describe("clawai tier resolution from portal", () => {
+    const clawaiConfigBase = {
+      auth: {
+        profiles: {
+          "deepseek:default": { provider: "deepseek", mode: "api_key" },
+        },
+      },
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      models: { providers: { deepseek: { apiKey: "claw_test123" } } },
+    };
+
+    it("uses the portal's tier (Max plan) over the locally-stored picker", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      // Local picker says Pro (flash) — portal will say Max (pro). Portal wins.
+      mockGetConfigValue.mockResolvedValue("flash");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "max", deviceTier: "pro", allowedModels: ["deepseek-v4-flash", "deepseek-v4-pro"] }),
+        { status: 200 },
+      ));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTier).toBe("pro");
+      expect(body.tierSource).toBe("portal");
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/clawbox-ai/device-info"),
+        expect.objectContaining({ headers: { Authorization: "Bearer claw_test123" } }),
+      );
+    });
+
+    it("returns clawaiTier=null when the portal says Free, regardless of the local picker", async () => {
+      // The screenshot scenario: Free user pasted a token + clicked Max in
+      // the wizard. Local says "pro", portal says "free" — badge should go
+      // away (or render Free), not lie about Max.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "free", deviceTier: null, allowedModels: ["deepseek-v4-flash"] }),
+        { status: 200 },
+      ));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTier).toBeNull();
+      expect(body.tierSource).toBe("portal");
+    });
+
+    it("returns clawaiTier=null on portal 403 (invalid token) and caches the verdict", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response("invalid_token", { status: 403 }));
+
+      const first = await (await GET()).json();
+      const second = await (await GET()).json();
+
+      expect(first.clawaiTier).toBeNull();
+      expect(first.tierSource).toBe("portal");
+      // 403 caches; the second request must not hit the network again.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(second.clawaiTier).toBeNull();
+    });
+
+    it("falls back to the locally-stored tier when the portal is unreachable", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockRejectedValue(new Error("ETIMEDOUT"));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTier).toBe("pro");
+      expect(body.tierSource).toBe("picker");
+    });
+
+    it("falls back to local on portal 5xx (transient upstream error)", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("flash");
+      fetchSpy.mockResolvedValue(new Response("boom", { status: 502 }));
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTier).toBe("flash");
+      expect(body.tierSource).toBe("picker");
+    });
+
+    it("uses the cached portal verdict on the second request within the TTL", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "max", deviceTier: "pro" }),
+        { status: 200 },
+      ));
+
+      await GET();
+      await GET();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses local tier when the stored deepseek apiKey isn't a claw_ token", async () => {
+      // Legacy/byo-key install: the user pasted a raw deepseek API key
+      // instead of going through device-flow. Portal can't resolve it,
+      // so we keep showing the picker selection.
+      mockReadConfig.mockResolvedValue({
+        ...clawaiConfigBase,
+        models: { providers: { deepseek: { apiKey: "sk-1234" } } },
+      } as never);
+      mockGetConfigValue.mockResolvedValue("flash");
+
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTier).toBe("flash");
+      expect(body.tierSource).toBe("picker");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
   });
 
   it("normalizes provider aliases like openai-codex for the UI", async () => {


### PR DESCRIPTION
## Summary

The chat header / Settings card badge was reading whatever tier the user clicked in the wizard, **not** what the portal actually granted. Cosmetic on its face — the gateway correctly 403s overreach (verified in Mike's prod matrix on `clawbox-website` commit `3ee89a3`) — but confusing UX:

- Free user pastes a token + clicks **Max** in wizard → local config stores `clawai_tier: \"pro\"` → status route returns `clawaiTier: \"pro\"` → **\"PRO\" badge shows on every status card** despite the token only entitling Free.

This PR makes \`/setup-api/ai-models/status\` consult the **portal** (`openclawhardware.dev/api/clawbox-ai/device-info`) for the authoritative tier and returns *that* as `clawaiTier`. The wizard picker is now a fallback for when portal is unreachable.

Pairs with Mike's portal-side fixes (`23d7964`, `ab41ad3`) — once both ship, every layer agrees on what tier you actually have.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Free user pastes token + clicks Max | UI shows \"PRO\" badge | UI shows no paid badge (Free) |
| Pro plan user, picker shows Pro | UI shows \"Pro\" badge | UI shows \"Pro\" badge (now confirmed by portal) |
| Max plan user upgrades from Pro on portal | UI badge stale until next factory-save | UI badge updates within 30–120s automatically |
| Portal unreachable / 5xx | UI badge wrong if local stale | Falls back to picker (no flicker) |
| Token rejected by portal (403) | UI shows whatever picker said | UI shows no badge; verdict cached for 120s |

## Implementation

- New `fetchPortalTier(token)` helper in `status/route.ts` — bearer-auth GET to portal device-info endpoint
- 120s in-memory TTL cache (> 30s `useClawboxLogin` poll cadence so most polls land warm)
- 4s fetch timeout (this is on the chat-header render path)
- Bounded at 64 entries — single-device install only ever has one token at a time, but factory-resets / dev churn would otherwise grow the map forever
- 401/403 cached as definitive \"no tier\"; 5xx + network errors leave cache untouched (caller falls back to picker)
- New `tierSource: 'portal' | 'picker'` on the response — future UI can render a \"syncing\" hint
- `mapPortalTier` translates portal's plan names (`free`/`pro`/`max`) to local `ClawboxAiTier` enum (`null`/`flash`/`pro`)

## Test plan

- [x] 7 new unit tests cover: portal-wins-over-picker, free-overrides-picker, 403 caches, network-error fallback, 5xx fallback, cache-hit no-refetch, non-`claw_`-token bypass
- [x] Existing tests untouched (no assertions on `clawaiTier` previously)
- [ ] CI \`test\` + \`e2e\` pass
- [ ] CodeRabbit review
- [ ] Manual: on a Free-paired device, badge reads \"Free\" / no-badge instead of whatever the picker is set to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added portal-based resolution for AI model tier information with automatic fallback to local settings when unavailable.
  * Introduced tier source tracking to identify whether tier information comes from the portal or local picker.
  * Implemented intelligent caching to optimize performance and reduce redundant requests.

* **Tests**
  * Added comprehensive test coverage for portal-backed tier resolution scenarios and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->