### PR TITLE
feat(ui): cosmetic upgrade gates for ClawKeep + Remote Desktop

### DIFF
--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { copyToClipboard } from "@/lib/clipboard";
 import { useT } from "@/lib/i18n";
+import { useClawboxLogin } from "@/lib/use-clawbox-login";
 import FreeTierUpgradeCard from "./FreeTierUpgradeCard";
 
 type ScheduleFrequency = "daily" | "weekly";
@@ -182,13 +183,12 @@ export default function ClawKeepApp() {
     danger?: boolean;
     onConfirm: () => void;
   } | null>(null);
-  // ClawBox-AI tier — read from /setup-api/ai-models/status, drives the
-  // upgrade-required card when the user is on Free. Portal also gates the
+  // ClawBox-AI tier drives the Free-user upgrade card. Portal also gates
   // upload/repo endpoints with `clawkeepQuotaBytes <= 0 → 403`, but
-  // showing the gate up front avoids a click that would silently bounce.
-  // Undefined = not yet loaded (don't render either branch); null = Free;
-  // string = paid tier.
-  const [clawaiTier, setClawaiTier] = useState<"flash" | "pro" | null | undefined>(undefined);
+  // surfacing it here avoids a click that would silently bounce. While
+  // `loading` is true we render nothing to prevent flicker between
+  // PairCard (paid path) and FreeTierUpgradeCard (Free path).
+  const { tier: clawaiTier, loading: clawaiLoading } = useClawboxLogin();
   const pollIntervalRef = useRef<number | null>(null);
 
   const refresh = useCallback(async () => {
@@ -206,21 +206,6 @@ export default function ClawKeepApp() {
   useEffect(() => {
     refresh();
   }, [refresh]);
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const r = await fetch("/setup-api/ai-models/status", { cache: "no-store" });
-        if (!r.ok) { if (!cancelled) setClawaiTier(null); return; }
-        const body = (await r.json()) as { clawaiTier?: "flash" | "pro" | null };
-        if (!cancelled) setClawaiTier(body.clawaiTier ?? null);
-      } catch {
-        if (!cancelled) setClawaiTier(null);
-      }
-    })();
-    return () => { cancelled = true; };
-  }, []);
 
   // Poll the dashboard every 3s while a backup is in progress. The server
   // is the source of truth, so reopening the window mid-run still picks up
@@ -567,7 +552,7 @@ export default function ClawKeepApp() {
                 </button>
               </div>
             </>
-          ) : clawaiTier === undefined ? null : clawaiTier === null ? (
+          ) : clawaiLoading ? null : clawaiTier === null ? (
             <FreeTierUpgradeCard
               featureName="ClawKeep cloud backups"
               description="ClawKeep encrypts your ClawBox data and syncs it to your portal account. Pro plan gets 5 GB; Max plan gets 50 GB."

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { copyToClipboard } from "@/lib/clipboard";
 import { useT } from "@/lib/i18n";
+import FreeTierUpgradeCard from "./FreeTierUpgradeCard";
 
 type ScheduleFrequency = "daily" | "weekly";
 interface ClawKeepSchedule {
@@ -181,6 +182,13 @@ export default function ClawKeepApp() {
     danger?: boolean;
     onConfirm: () => void;
   } | null>(null);
+  // ClawBox-AI tier — read from /setup-api/ai-models/status, drives the
+  // upgrade-required card when the user is on Free. Portal also gates the
+  // upload/repo endpoints with `clawkeepQuotaBytes <= 0 → 403`, but
+  // showing the gate up front avoids a click that would silently bounce.
+  // Undefined = not yet loaded (don't render either branch); null = Free;
+  // string = paid tier.
+  const [clawaiTier, setClawaiTier] = useState<"flash" | "pro" | null | undefined>(undefined);
   const pollIntervalRef = useRef<number | null>(null);
 
   const refresh = useCallback(async () => {
@@ -198,6 +206,21 @@ export default function ClawKeepApp() {
   useEffect(() => {
     refresh();
   }, [refresh]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const r = await fetch("/setup-api/ai-models/status", { cache: "no-store" });
+        if (!r.ok) { if (!cancelled) setClawaiTier(null); return; }
+        const body = (await r.json()) as { clawaiTier?: "flash" | "pro" | null };
+        if (!cancelled) setClawaiTier(body.clawaiTier ?? null);
+      } catch {
+        if (!cancelled) setClawaiTier(null);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
 
   // Poll the dashboard every 3s while a backup is in progress. The server
   // is the source of truth, so reopening the window mid-run still picks up
@@ -544,6 +567,11 @@ export default function ClawKeepApp() {
                 </button>
               </div>
             </>
+          ) : clawaiTier === undefined ? null : clawaiTier === null ? (
+            <FreeTierUpgradeCard
+              featureName="ClawKeep cloud backups"
+              description="ClawKeep encrypts your ClawBox data and syncs it to your portal account. Pro plan gets 5 GB; Max plan gets 50 GB."
+            />
           ) : (
             <PairCard onPair={onPair} busy={busy === "pair"} />
           )}

--- a/src/components/FreeTierUpgradeCard.tsx
+++ b/src/components/FreeTierUpgradeCard.tsx
@@ -1,0 +1,47 @@
+import { PORTAL_SUBSCRIBE_URL } from "@/lib/max-subscription";
+
+interface FreeTierUpgradeCardProps {
+  /** Feature being gated, used in the headline ("X needs a paid plan"). */
+  featureName: string;
+  /** Body copy. Should explain what unlocks at Pro vs. Max if relevant. */
+  description: string;
+}
+
+/**
+ * Cosmetic gate shown when a Free user attempts a Pro/Max-only feature.
+ * The portal still rejects the underlying API call (paid_plan_required),
+ * but rendering the upgrade CTA up-front avoids the user clicking a
+ * working-looking button only to bounce off a server-side 402.
+ */
+export default function FreeTierUpgradeCard({ featureName, description }: FreeTierUpgradeCardProps) {
+  return (
+    <div className="max-w-xl">
+      <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-6 flex flex-col items-center text-center gap-4">
+        <img
+          src="/clawbox-crab.png"
+          alt=""
+          width={64}
+          height={64}
+          className="select-none pointer-events-none drop-shadow-[0_0_12px_rgba(249,115,22,0.5)]"
+        />
+        <div>
+          <h3 className="text-base font-semibold text-[var(--text-primary)] mb-1">
+            {featureName} needs a paid plan
+          </h3>
+          <p className="text-sm text-[var(--text-muted)] leading-relaxed">
+            {description}
+          </p>
+        </div>
+        <a
+          href={PORTAL_SUBSCRIBE_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl btn-gradient text-sm font-medium text-white cursor-pointer no-underline"
+        >
+          <span className="material-symbols-rounded" style={{ fontSize: 18 }}>open_in_new</span>
+          Subscribe to Pro or Max
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -145,6 +145,25 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     setLoginModal({ open: true, feature });
     return true;
   }, [clawboxLogin.loading, clawboxLogin.loggedIn]);
+
+  // Three-state pick for the Remote Control section: needs portal sign-in,
+  // needs paid plan, or shows the panel. While `clawboxLogin.loading` we
+  // render nothing rather than flicker between states.
+  const renderRemoteSection = () => {
+    if (!clawboxLogin.loggedIn && !clawboxLogin.loading) {
+      return <RemoteLoginPlaceholder onSignIn={() => setLoginModal({ open: true, feature: "remote" })} />;
+    }
+    if (clawboxLogin.loading) return null;
+    if (clawboxLogin.tier === null) {
+      return (
+        <FreeTierUpgradeCard
+          featureName="Remote Desktop"
+          description="Remote Desktop publishes a secure tunnel from this ClawBox to your portal account so you can reach it from anywhere. Available on Pro and Max plans."
+        />
+      );
+    }
+    return <RemoteControlPanel />;
+  };
   // Section setter that intercepts gated sections. Use this everywhere a
   // user action wants to navigate; bypass it for programmatic restorations
   // (URL deep-link, tier-based redirects) where blocking would be confusing.
@@ -891,10 +910,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   /* ── AI Provider ── */
   const [aiProvider, setAiProvider] = useState<{ connected: boolean; provider: string | null; providerLabel: string | null; mode: string | null; model: string | null; clawaiTier: "flash" | "pro" | null } | null>(null);
   useEffect(() => {
-    // Fetch when AI section opens (badge), Remote section opens (paid-tier
-    // gate), or on mobile where the badge is always visible. Other sections
-    // don't need the data.
-    if (section !== "ai" && section !== "remote" && !isMobile) return;
+    if (section !== "ai" && !isMobile) return;
     fetch("/setup-api/ai-models/status", { cache: "no-store" }).then(r => r.json()).then(setAiProvider).catch(() => {});
   }, [section, isMobile]);
   const [localAiStatus, setLocalAiStatus] = useState<{ configured: boolean; provider: string | null; model: string | null; running: boolean | null; standbyEnabled: boolean } | null>(null);
@@ -2585,26 +2601,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         )}
 
         {/* ─── Remote Control ─── */}
-        {activeSection === "remote" && (() => {
-          if (!clawboxLogin.loggedIn && !clawboxLogin.loading) {
-            return <RemoteLoginPlaceholder onSignIn={() => setLoginModal({ open: true, feature: "remote" })} />;
-          }
-          // Free users get the upgrade CTA — the portal's heartbeat
-          // endpoint also rejects with 402 paid_plan_required, but
-          // surfacing the gate here avoids a working-looking toggle that
-          // bounces server-side. While aiProvider is loading we render
-          // nothing rather than flicker between Panel and Upgrade card.
-          if (aiProvider === null) return null;
-          if (aiProvider.clawaiTier === null) {
-            return (
-              <FreeTierUpgradeCard
-                featureName="Remote Desktop"
-                description="Remote Desktop publishes a secure tunnel from this ClawBox to your portal account so you can reach it from anywhere. Available on Pro and Max plans."
-              />
-            );
-          }
-          return <RemoteControlPanel />;
-        })()}
+        {activeSection === "remote" && renderRemoteSection()}
 
         {/* ─── About ─── */}
         {activeSection === "about" && (<>

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -12,6 +12,7 @@ import { dispatchOpenApp } from "@/lib/ui-events";
 import AIModelsStep from "./AIModelsStep";
 import TelegramConfiguringOverlay from "./TelegramConfiguringOverlay";
 import RemoteControlPanel from "./RemoteControlPanel";
+import FreeTierUpgradeCard from "./FreeTierUpgradeCard";
 import { copyToClipboard } from "@/lib/clipboard";
 import ClawBoxLoginModal, { type ClawBoxLoginFeature } from "./ClawBoxLoginModal";
 import { useClawboxLogin } from "@/lib/use-clawbox-login";
@@ -890,7 +891,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   /* ── AI Provider ── */
   const [aiProvider, setAiProvider] = useState<{ connected: boolean; provider: string | null; providerLabel: string | null; mode: string | null; model: string | null; clawaiTier: "flash" | "pro" | null } | null>(null);
   useEffect(() => {
-    if (section !== "ai" && !isMobile) return;
+    // Fetch when AI section opens (badge), Remote section opens (paid-tier
+    // gate), or on mobile where the badge is always visible. Other sections
+    // don't need the data.
+    if (section !== "ai" && section !== "remote" && !isMobile) return;
     fetch("/setup-api/ai-models/status", { cache: "no-store" }).then(r => r.json()).then(setAiProvider).catch(() => {});
   }, [section, isMobile]);
   const [localAiStatus, setLocalAiStatus] = useState<{ configured: boolean; provider: string | null; model: string | null; running: boolean | null; standbyEnabled: boolean } | null>(null);
@@ -2581,13 +2585,26 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         )}
 
         {/* ─── Remote Control ─── */}
-        {activeSection === "remote" && (
-          clawboxLogin.loggedIn || clawboxLogin.loading ? (
-            <RemoteControlPanel />
-          ) : (
-            <RemoteLoginPlaceholder onSignIn={() => setLoginModal({ open: true, feature: "remote" })} />
-          )
-        )}
+        {activeSection === "remote" && (() => {
+          if (!clawboxLogin.loggedIn && !clawboxLogin.loading) {
+            return <RemoteLoginPlaceholder onSignIn={() => setLoginModal({ open: true, feature: "remote" })} />;
+          }
+          // Free users get the upgrade CTA — the portal's heartbeat
+          // endpoint also rejects with 402 paid_plan_required, but
+          // surfacing the gate here avoids a working-looking toggle that
+          // bounces server-side. While aiProvider is loading we render
+          // nothing rather than flicker between Panel and Upgrade card.
+          if (aiProvider === null) return null;
+          if (aiProvider.clawaiTier === null) {
+            return (
+              <FreeTierUpgradeCard
+                featureName="Remote Desktop"
+                description="Remote Desktop publishes a secure tunnel from this ClawBox to your portal account so you can reach it from anywhere. Available on Pro and Max plans."
+              />
+            );
+          }
+          return <RemoteControlPanel />;
+        })()}
 
         {/* ─── About ─── */}
         {activeSection === "about" && (<>


### PR DESCRIPTION
## Summary

Free users currently see fully-functional **Pair ClawKeep** / **Enable Remote Desktop** buttons that silently bounce off portal-side gates:

- ClawKeep upload/read endpoints return **403** (quota=0 for Free) — already gated, just opaque to the user
- Cloudflare tunnel heartbeat will return **402 paid_plan_required** once openclaw/clawbox-website ships the gate (paired with #120's device-pair gate; see the email thread)

Both produce a working-looking UI that errors out the moment the user clicks. This PR adds a small shared upgrade card and renders it up-front when the user is on Free.

## Changes

| File | What |
|---|---|
| `src/components/FreeTierUpgradeCard.tsx` | New shared component — icon, headline, description, "Subscribe to Pro or Max" CTA opening `PORTAL_SUBSCRIBE_URL` in a new tab |
| `src/components/ClawKeepApp.tsx` | Fetch tier from `/setup-api/ai-models/status` on mount; render `FreeTierUpgradeCard` instead of `PairCard` when `clawaiTier === null` |
| `src/components/SettingsApp.tsx` | Widen the existing `aiProvider` fetch to fire on Remote Control section too; render `FreeTierUpgradeCard` instead of `RemoteControlPanel` when `clawaiTier === null` |

The portal still enforces the actual gates — this is **pure UX**. The portal-side gates are the real protection; this just stops the user from finding out by clicking.

## Test plan

- [ ] Free user opens ClawKeep app → sees "ClawKeep cloud backups needs a paid plan" with Subscribe CTA
- [ ] Pro user opens ClawKeep app → sees the existing PairCard (no regression)
- [ ] Free user opens Settings → Remote Control → sees the upgrade card
- [ ] Pro user opens Settings → Remote Control → sees `RemoteControlPanel` (no regression)
- [ ] Subscribe CTA opens `https://openclawhardware.dev/portal/subscribe` in a new tab
- [ ] CodeRabbit / vitest / e2e green

## Coordinates with

- PR #120 (already merged or pending) — establishes `clawaiTier` as authoritative on the device side
- openclaw/clawbox-website — pending heartbeat 402 gate (Mike's email thread). This PR is independent of that landing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription tier detection that gates premium features behind paid plans.
  * Free tier users now see upgrade prompts with links to subscribe when accessing certain features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->