### PR TITLE
fix: disable gemma 4 on initial install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1720,7 +1720,10 @@ log "Installing Ollama..."
 step_ollama_install
 
 log "Installing llama.cpp runtime..."
-step_llamacpp_install
+# TEMP: skip llama.cpp + Gemma download during flash to speed up install.
+# User installs from Settings UI → Install llama.cpp (or: bash install.sh --step llamacpp_install)
+echo "  SKIPPED — install from Settings UI post-install"
+# step_llamacpp_install
 
 log "Installing Chromium..."
 step_chromium_install


### PR DESCRIPTION
## Summary
- Disables Gemma 4 on initial install (commit e16b302)

## Test plan
- [ ] Verify initial install flow no longer pulls/enables Gemma 4
- [ ] Confirm no regression in other model selections during onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation process now defers runtime and model installation to the Settings UI, allowing users to configure these components after setup completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->