### PR TITLE
feat(install): post-install validation step (services + WiFi AP + dashboard)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -39,6 +39,29 @@ GATEWAY_DIST="$NPM_PREFIX/lib/node_modules/openclaw/dist"
 DNSMASQ_DIR="/etc/NetworkManager/dnsmasq-shared.d"
 AVAHI_CONF="/etc/avahi/avahi-daemon.conf"
 
+# ── Service registry ─────────────────────────────────────────────────────────
+# Authoritative list of clawbox systemd units. Used by step_systemd_services
+# (install/enable) and step_validate_services (post-install health check).
+#
+# ACTIVE: must be enabled and active after install.
+# INSTALLED: unit file must exist on disk but the unit is not required to be
+# active because it is opt-in (clawbox-tunnel, clawbox-browser), one-shot
+# driven by a timer (clawbox-heartbeat.service), or a template that is never
+# activated standalone (clawbox-root-update@.service).
+EXPECTED_ACTIVE_SERVICES=(
+  clawbox-ap.service
+  clawbox-setup.service
+  clawbox-gateway.service
+  clawbox-performance.service
+  clawbox-heartbeat.timer
+)
+EXPECTED_INSTALLED_SERVICES=(
+  clawbox-heartbeat.service
+  clawbox-browser.service
+  clawbox-tunnel.service
+  "clawbox-root-update@.service"
+)
+
 # Load persisted WiFi interface if available
 IFACE_ENV="$PROJECT_DIR/data/network.env"
 if [ -f "$IFACE_ENV" ]; then
@@ -963,7 +986,7 @@ step_system_config() {
 }
 
 step_systemd_services() {
-  local ALL_SERVICES=(clawbox-ap.service clawbox-setup.service clawbox-gateway.service clawbox-performance.service "clawbox-root-update@.service" clawbox-browser.service clawbox-tunnel.service clawbox-heartbeat.service clawbox-heartbeat.timer)
+  local ALL_SERVICES=("${EXPECTED_ACTIVE_SERVICES[@]}" "${EXPECTED_INSTALLED_SERVICES[@]}")
   # Drift guard: every *.service / *.timer in config/ must be in
   # ALL_SERVICES, otherwise a new unit added to the repo would silently
   # not get installed on fresh devices. The opposite direction (units
@@ -1628,6 +1651,83 @@ step_browser_launch() {
   DISPLAY=:99 bash "$PROJECT_DIR/scripts/launch-browser.sh"
 }
 
+step_validate_services() {
+  # Polls expected units + functional probes for up to 30 s. Exits 1 if any
+  # check fails by the deadline, after printing a per-failure table with a
+  # systemctl status snippet for unit failures and a one-line reason for
+  # probe failures.
+  local deadline=$(( $(date +%s) + 30 ))
+  local -a failed_active=() failed_installed=() failed_probe=()
+
+  while :; do
+    failed_active=()
+    failed_installed=()
+    failed_probe=()
+
+    local svc enabled active
+    for svc in "${EXPECTED_ACTIVE_SERVICES[@]}"; do
+      if ! systemctl cat "$svc" >/dev/null 2>&1; then
+        failed_active+=("$svc (unit file missing)")
+        continue
+      fi
+      enabled=$(systemctl is-enabled "$svc" 2>/dev/null || true)
+      active=$(systemctl is-active "$svc" 2>/dev/null || true)
+      [ -z "$enabled" ] && enabled="unknown"
+      [ -z "$active" ] && active="unknown"
+      case "$enabled" in
+        enabled|enabled-runtime|alias|static) ;;
+        *) failed_active+=("$svc enabled=$enabled active=$active"); continue ;;
+      esac
+      [ "$active" = "active" ] || failed_active+=("$svc enabled=$enabled active=$active")
+    done
+
+    for svc in "${EXPECTED_INSTALLED_SERVICES[@]}"; do
+      systemctl cat "$svc" >/dev/null 2>&1 || failed_installed+=("$svc (unit file missing)")
+    done
+
+    # Probe 1: Wi-Fi AP is broadcasting on $NETWORK_INTERFACE.
+    local iface="${NETWORK_INTERFACE:-}"
+    if [ -z "$iface" ]; then
+      failed_probe+=("WiFi: NETWORK_INTERFACE not set (check /etc/clawbox/network.env)")
+    elif ! iw dev "$iface" info 2>/dev/null | grep -qE '^[[:space:]]*type AP[[:space:]]*$'; then
+      failed_probe+=("WiFi: $iface is not in AP mode (clawbox-ap.service running but radio not broadcasting)")
+    fi
+
+    # Probe 2: OpenClaw dashboard answers HTTP on localhost:80.
+    local http_code
+    http_code=$(curl -sS --max-time 5 -o /dev/null -w '%{http_code}' http://localhost/ 2>/dev/null) || http_code="000"
+    case "$http_code" in
+      2*|3*) ;;
+      *) failed_probe+=("OpenClaw: dashboard at http://localhost/ returned HTTP $http_code (expected 2xx or 3xx)") ;;
+    esac
+
+    [ ${#failed_active[@]} -eq 0 ] && [ ${#failed_installed[@]} -eq 0 ] && [ ${#failed_probe[@]} -eq 0 ] && break
+    [ "$(date +%s)" -ge "$deadline" ] && break
+    sleep 2
+  done
+
+  local probe_count=2
+  local total=$(( ${#EXPECTED_ACTIVE_SERVICES[@]} + ${#EXPECTED_INSTALLED_SERVICES[@]} + probe_count ))
+  local fails=$(( ${#failed_active[@]} + ${#failed_installed[@]} + ${#failed_probe[@]} ))
+  if [ "$fails" -eq 0 ]; then
+    echo "  ✓ All $total checks healthy (services + WiFi AP + OpenClaw dashboard)"
+    return 0
+  fi
+
+  echo "  ✗ $fails of $total checks failed:"
+  local entry unit_name
+  for entry in "${failed_active[@]}" "${failed_installed[@]}"; do
+    echo "    - $entry"
+    unit_name="${entry%% *}"
+    systemctl status "$unit_name" --no-pager -n 5 2>&1 | sed 's/^/        /' || true
+    echo
+  done
+  for entry in "${failed_probe[@]}"; do
+    echo "    - $entry"
+  done
+  return 1
+}
+
 # ── Single-step mode (used by clawbox-root-update@.service) ──────────────────
 
 # Steps available for --step dispatch (must have a corresponding step_NAME function)
@@ -1640,7 +1740,7 @@ DISPATCH_STEPS=(
   chpasswd gateway_setup ffmpeg_install polkit_rules systemd_services
   directories_permissions captive_portal_dns desktop_theme
   fix_git_perms browser_launch cloudflared_install
-  nm_dispatcher sysctl_linkdown post_update
+  nm_dispatcher sysctl_linkdown post_update validate_services
 )
 
 if [ "${1:-}" = "--step" ]; then
@@ -1664,7 +1764,7 @@ fi
 
 # ── Full Install Mode ───────────────────────────────────────────────────────
 
-TOTAL_STEPS=22
+TOTAL_STEPS=23
 step=0
 log() {
   step=$((step + 1))
@@ -1750,6 +1850,9 @@ ensure_clawbox_bashrc_path
 
 log "Starting services..."
 step_start_services
+
+log "Validating services..."
+step_validate_services
 
 # ── Done ─────────────────────────────────────────────────────────────────────
 

--- a/install.sh
+++ b/install.sh
@@ -1663,6 +1663,18 @@ step_validate_services() {
   # check fails by the deadline, after printing a per-failure table with a
   # systemctl status snippet for unit failures and a one-line reason for
   # probe failures.
+
+  # step_network_setup persists NETWORK_INTERFACE to network.env but doesn't
+  # export it, so on a fresh install our process still has it unset. Reload
+  # the file before probing.
+  if [ -f "$IFACE_ENV" ]; then
+    # shellcheck disable=SC1090
+    source "$IFACE_ENV"
+  elif [ -f /etc/clawbox/network.env ]; then
+    # shellcheck disable=SC1091
+    source /etc/clawbox/network.env
+  fi
+
   local deadline=$(( $(date +%s) + 30 ))
   local -a failed_active=() failed_installed=() failed_probe=()
 

--- a/install.sh
+++ b/install.sh
@@ -1013,8 +1013,10 @@ step_systemd_services() {
       if [ "$svc" = "$basename" ]; then registered=1; break; fi
     done
     if [ "$registered" = "0" ]; then
-      echo "Error: $basename exists in config/ but is not in ALL_SERVICES." >&2
-      echo "       Add it to step_systemd_services in install.sh so fresh installs pick it up." >&2
+      echo "Error: $basename exists in config/ but is not registered." >&2
+      echo "       Add it to EXPECTED_ACTIVE_SERVICES or EXPECTED_INSTALLED_SERVICES" >&2
+      echo "       (the module-level constants near the top of install.sh that feed ALL_SERVICES)" >&2
+      echo "       so fresh installs pick it up." >&2
       exit 1
     fi
   done
@@ -1675,6 +1677,19 @@ step_validate_services() {
     source /etc/clawbox/network.env
   fi
 
+  # In test mode, step_start_services skips clawbox-ap and clawbox-performance
+  # (no WiFi radio, no nvpmodel), so they will never come active here either.
+  # Filter them out of the expected set and skip the WiFi AP probe so CI runs
+  # don't fail on hardware that doesn't exist in the container.
+  local -a active_services=()
+  local s
+  for s in "${EXPECTED_ACTIVE_SERVICES[@]}"; do
+    if is_test_mode && [[ "$s" == "clawbox-ap.service" || "$s" == "clawbox-performance.service" ]]; then
+      continue
+    fi
+    active_services+=("$s")
+  done
+
   local deadline=$(( $(date +%s) + 30 ))
   local -a failed_active=() failed_installed=() failed_probe=()
 
@@ -1684,7 +1699,7 @@ step_validate_services() {
     failed_probe=()
 
     local svc enabled active
-    for svc in "${EXPECTED_ACTIVE_SERVICES[@]}"; do
+    for svc in "${active_services[@]}"; do
       if ! systemctl cat "$svc" >/dev/null 2>&1; then
         failed_active+=("$svc (unit file missing)")
         continue
@@ -1705,11 +1720,15 @@ step_validate_services() {
     done
 
     # Probe 1: Wi-Fi AP is broadcasting on $NETWORK_INTERFACE.
-    local iface="${NETWORK_INTERFACE:-}"
-    if [ -z "$iface" ]; then
-      failed_probe+=("WiFi: NETWORK_INTERFACE not set (check /etc/clawbox/network.env)")
-    elif ! iw dev "$iface" info 2>/dev/null | grep -qE '^[[:space:]]*type AP[[:space:]]*$'; then
-      failed_probe+=("WiFi: $iface is not in AP mode (clawbox-ap.service running but radio not broadcasting)")
+    # Skip in test mode — clawbox-ap.service was skipped above and the stub
+    # interface (eth0) isn't a wireless radio.
+    if ! is_test_mode; then
+      local iface="${NETWORK_INTERFACE:-}"
+      if [ -z "$iface" ]; then
+        failed_probe+=("WiFi: NETWORK_INTERFACE not set (check /etc/clawbox/network.env)")
+      elif ! iw dev "$iface" info 2>/dev/null | grep -qE '^[[:space:]]*type AP[[:space:]]*$'; then
+        failed_probe+=("WiFi: $iface is not in AP mode (clawbox-ap.service running but radio not broadcasting)")
+      fi
     fi
 
     # Probe 2: OpenClaw dashboard answers HTTP on localhost:80.
@@ -1726,7 +1745,8 @@ step_validate_services() {
   done
 
   local probe_count=2
-  local total=$(( ${#EXPECTED_ACTIVE_SERVICES[@]} + ${#EXPECTED_INSTALLED_SERVICES[@]} + probe_count ))
+  is_test_mode && probe_count=1
+  local total=$(( ${#active_services[@]} + ${#EXPECTED_INSTALLED_SERVICES[@]} + probe_count ))
   local fails=$(( ${#failed_active[@]} + ${#failed_installed[@]} + ${#failed_probe[@]} ))
   if [ "$fails" -eq 0 ]; then
     echo "  ✓ All $total checks healthy (services + WiFi AP + OpenClaw dashboard)"


### PR DESCRIPTION
## Summary
- Adds `step_validate_services` as the final `[23/23]` step in `install.sh`. Polls each expected systemd unit, plus a Wi-Fi AP-mode probe (`iw dev`) and a dashboard HTTP probe (`curl http://localhost/`), for up to 30 s before failing with a per-unit table that includes a `systemctl status` snippet for each bad unit.
- Promotes the previously-local `ALL_SERVICES` array in `step_systemd_services` to two module-level constants (`EXPECTED_ACTIVE_SERVICES`, `EXPECTED_INSTALLED_SERVICES`) so install and validation share one source of truth.
- Catches the "install.sh died midway but SSH still exited 0" failure mode where a `flash.sh` run reports success while services were never installed. Failure propagates through `set -euo pipefail` → SSH → `flash.sh`'s existing per-box FAIL counter — no changes to `flash.sh` needed. Also addressable as `--step validate_services` for re-running on demand.

## Test plan
- [x] Fail-path on host (no clawbox services installed): 11/11 checks fail, exit=1, clean output.
- [x] Fail-path on a Jetson with a partial install: `clawbox-performance.service` correctly reported as `enabled=enabled active=inactive` with `systemctl status` snippet; other units flagged missing; both functional probes correctly fail; exit=1.
- [x] Pass-path on a Jetson with a complete install: `[23/23] Validating services... ✓ All 11 checks healthy (services + WiFi AP + OpenClaw dashboard)`, exit=0.
- [x] External verification: `ClawBox-Setup` SSID visible from a separate machine at full signal; `iw dev` reports `type AP` with txpower 15 dBm; `curl http://<box-ip>/` returns HTTP 307.

## Out of scope
`install.sh:238-242` node-pty rebuild bug — forces `npm_config_nodedir` at incomplete system headers and breaks the build at step 8/23 on fresh flashes. Manual unblock used during pass-path testing here; tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer adds a post-install health validation that checks required services are present, enabled and running, confirms the device is broadcasting Wi‑Fi in AP mode, and verifies the local dashboard responds over HTTP. Failures are reported with service status snippets and cause the install to fail if checks don't pass within the validation window. Installation flow now runs this validation immediately after starting services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->