### PR TITLE
fix(install): require node_api.h before using system Node headers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -196,12 +196,12 @@ print_native_build_preflight() {
     gpp_version="g++ missing"
   fi
 
-  if [ -d /usr/include/nodejs ]; then
+  if [ -d /usr/include/nodejs ] && [ -f /usr/include/nodejs/node_api.h ]; then
     node_header_dir="/usr/include/nodejs"
-  elif [ -d /usr/include/node ]; then
+  elif [ -d /usr/include/node ] && [ -f /usr/include/node/node_api.h ]; then
     node_header_dir="/usr/include/node"
   else
-    node_header_dir="not found"
+    node_header_dir="auto (node-gyp will fetch into ~/.cache/node-gyp/<version>/)"
   fi
 
   echo "  Native build preflight:"
@@ -231,13 +231,20 @@ ensure_node_pty() {
     "$CLAWBOX_HOME/.cache/node-gyp" \
     "$PROJECT_DIR/node_modules" 2>/dev/null || true
 
+  # Only point node-gyp at system headers if they actually contain node_api.h
+  # for the running Node ABI. Ubuntu's libnode-dev / nodejs packages can leave
+  # a /usr/include/node directory that's missing node_api.h or holds headers
+  # for a Node version different from the one installed via NodeSource — both
+  # break the node-addon-api include chain. When neither path is usable, leave
+  # npm_config_nodedir unset so node-gyp auto-fetches matching headers into
+  # ~/.cache/node-gyp/<version>/.
   local rebuild_cmd="
     cd $PROJECT_DIR &&
     export npm_config_python=/usr/bin/python3 &&
     export npm_config_build_from_source=true &&
-    if [ -d /usr/include/nodejs ]; then
+    if [ -d /usr/include/nodejs ] && [ -f /usr/include/nodejs/node_api.h ]; then
       export npm_config_nodedir=/usr/include/nodejs
-    elif [ -d /usr/include/node ]; then
+    elif [ -d /usr/include/node ] && [ -f /usr/include/node/node_api.h ]; then
       export npm_config_nodedir=/usr/include/node
     fi &&
     npm rebuild node-pty --foreground-scripts


### PR DESCRIPTION
## Summary
- `ensure_node_pty` (install.sh:238-242) and `print_native_build_preflight` both pointed node-gyp at `/usr/include/node` when that directory existed, without checking it actually held headers for the running Node ABI.
- On a fresh Jetson R36 box that installs Node 22 from NodeSource during step 2, that directory is populated by Ubuntu's `libnode-dev` with Node-12-era headers that lack `node_api.h`. Forcing `npm_config_nodedir=/usr/include/node` then makes `node-pty`'s native build fail at `fatal error: node_api.h: No such file or directory`, aborting `install.sh` at step 8/23 before any clawbox systemd unit ever gets installed.
- This PR adds a `[ -f .../node_api.h ]` guard to both spots. When neither system path qualifies, `npm_config_nodedir` is left unset so node-gyp auto-fetches matching headers into `~/.cache/node-gyp/<version>/` — the same path that worked when `unset npm_config_nodedir; npm rebuild node-pty` was run by hand on a Jetson where the original code path failed twice.

## Behavioral change
- `print_native_build_preflight` now prints `Node headers: auto (node-gyp will fetch into ~/.cache/node-gyp/<version>/)` instead of misleadingly reporting `/usr/include/node` when those headers are unusable.
- On boxes where `/usr/include/node/node_api.h` is present and matches the active Node, behavior is unchanged.

## Test plan
- [x] `bash -n install.sh` passes.
- [x] Manual reproduction on a Jetson where the original path failed: with `npm_config_nodedir` unset, `npm rebuild node-pty --foreground-scripts` compiles `pty.cc → pty.o → pty.node` cleanly, and `node -e "require('node-pty')"` loads the module.
- [ ] End-to-end: re-flash a fresh Jetson with this branch checked out via `flash.sh` and confirm step 8/23 (`Building ClawBox`) no longer dies. Will run after merge.

## Out of scope (follow-ups)
- Doesn't catch the rarer case where `node_api.h` is present but for a wrong-ABI Node (would need to compare `NODE_MODULE_VERSION` from `node_version.h` against `process.versions.modules`).
- `flash.sh`'s per-box setup pipes SSH through `sed`, which masks SSH's nonzero exit and let the original failure look like "Flashed 2/2 successfully." A one-line `set -o pipefail` (or moving the `sed` to a process substitution) would close that hole. Better as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)