### PR TITLE
fix(install): validate Node 22 actually installed after NodeSource setup

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -354,8 +354,27 @@ step_apt_update() {
     echo "  Node.js $(node --version) already installed"
   else
     echo "  Installing Node.js 22..."
+    # NodeSource's setup script will silently exit 0 even when its inner
+    # `apt update` fails because of an apt-lock conflict (e.g. packagekitd on
+    # first boot), and apt-get install nodejs then falls back to Ubuntu's
+    # libnode72 / nodejs 12. That breaks the build at step 8/23 with a
+    # confusing optional-chaining parse error inside node-gyp. Wait for the
+    # lock first, then validate the installed version.
+    wait_for_apt
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+    wait_for_apt
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq nodejs
+    if ! node --version 2>/dev/null | grep -qE '^v(2[2-9]|[3-9][0-9])\.'; then
+      local got
+      got=$(node --version 2>/dev/null || echo "missing")
+      echo "Error: Node.js 22 install failed — \`node --version\` reports $got." >&2
+      echo "       Likely the NodeSource setup script lost a race for the apt lock" >&2
+      echo "       (commonly held by packagekitd or unattended-upgrades on first boot)" >&2
+      echo "       and apt fell back to Ubuntu's Node 12. flash.sh's Phase 0 should" >&2
+      echo "       mask packagekit.service and unattended-upgrades.service in the" >&2
+      echo "       rootfs to prevent this." >&2
+      exit 1
+    fi
     echo "  Node.js $(node --version) installed"
   fi
 }


### PR DESCRIPTION
## Summary
- NodeSource's `deb.nodesource.com/setup_22.x` script silently exits 0 even when its inner `apt update` fails (e.g. when `packagekitd` or `unattended-upgrades` holds `/var/lib/apt/lists/lock` on first boot). `step_apt_update` then runs `apt-get install -y -qq nodejs` which falls back to Ubuntu's `nodejs 12.22.9` — the install prints "Node.js v12.22.9 installed" and continues, and step 8/23 (Building ClawBox) dies with a confusing `SyntaxError: Unexpected token '?'` inside node-gyp's CLI parser (Node 12 doesn't understand `??`).
- This PR adds three minimal guards in the existing else-branch:
  1. `wait_for_apt` before the NodeSource `curl | bash` so we don't lose the lock race on a fresh-boot system.
  2. `wait_for_apt` again before `apt-get install nodejs` because NodeSource's inner `apt update` can leave residual contention.
  3. Re-grep `node --version` after install; exit 1 with an actionable message if it's not v22+. Surfaces the failure at step 2/23 instead of cascading to a confusing parse error six steps later.
- No change to the happy path. When Node 22 installs cleanly the only visible difference is the existing "Node.js v22.x.x installed" line printing the right version.

## Why now
Reproduced today on a fresh JetPack 6.2.2 mass-flash of two Jetson Orin Nano boxes. Both died at step 8/23 with `Unexpected token '?'`; the `[2/23] Installing system packages...` block earlier showed `Error: Failed to run 'apt update' (Exit Code: 0)` from NodeSource and `Setting up nodejs (12.22.9~dfsg-1ubuntu3.6)`. Pairs with a related fix in the orchestrator repo that masks `packagekit.service` + `unattended-upgrades.service` during Phase 0.

## Test plan
- [x] `bash -n install.sh` passes.
- [x] Reproduction confirmed: with `packagekitd` holding the apt lock, the unguarded code path printed "Node.js v12.22.9 installed" and let install.sh proceed; the build crashed at step 8 with the optional-chaining parse error.
- [ ] End-to-end: re-flash two fresh Jetsons with this PR + the flash.sh masking fix and confirm step 2/23 either succeeds with v22 or fails immediately with the new actionable error. Will run after merge.

## Out of scope (already in flight elsewhere)
- Masking `packagekit.service` + `unattended-upgrades.service` in `flash.sh`'s Phase 0 (the actual cure for the lock race) — separate commit on the orchestrator side.
- `flash.sh` honoring per-box install.sh exit codes (currently masked by `| sed` without `pipefail`) — separate commit on the orchestrator side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced installer stability for Node.js 22 provisioning with improved lock handling and version validation. The installer now explicitly reports errors if the incorrect Node.js version is installed, preventing installation with a potentially incompatible setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->