### PR TITLE
fix: address CodeRabbit review on #132 (auth dict guard, dynamic codex path, useReducer + a11y)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -298,7 +298,13 @@ fi
 # every chat attempt. Detect the codex provider in config and install
 # the plugin idempotently here — mirrors OpenClaw's own
 # `modelSelectionShouldEnsureCodexPlugin` detection logic.
-CODEX_PLUGIN_DIR="/home/clawbox/.openclaw/npm/node_modules/@openclaw/codex"
+# Derive the plugin directory from $OPENCLAW_CONFIG instead of hard-
+# coding `/home/clawbox/...` so the script works for non-default
+# clawbox users / per-user installs. `dirname $OPENCLAW_CONFIG`
+# resolves to `~/.openclaw`, the same root OpenClaw's own plugin
+# installer writes under (`<openclaw-home>/npm/node_modules/...`).
+OPENCLAW_HOME_DIR="$(dirname "$OPENCLAW_CONFIG")"
+CODEX_PLUGIN_DIR="$OPENCLAW_HOME_DIR/npm/node_modules/@openclaw/codex"
 NEEDS_CODEX_PLUGIN="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, sys
 try:
@@ -307,7 +313,13 @@ try:
 except (FileNotFoundError, json.JSONDecodeError):
     print("0"); sys.exit(0)
 primary = (cfg.get("agents", {}).get("defaults", {}).get("model", {}) or {}).get("primary") or ""
-profiles = cfg.get("auth", {}).get("profiles", {}) or {}
+# Defensive: `cfg["auth"]` may be missing, `None`, or a corrupted
+# scalar on a hand-edited config. Match the same isinstance pattern
+# used at line 131 for openrouter so a malformed auth block doesn't
+# crash pre-start and silently skip the codex install.
+auth = cfg.get("auth")
+profiles_raw = auth.get("profiles", {}) if isinstance(auth, dict) else {}
+profiles = profiles_raw if isinstance(profiles_raw, dict) else {}
 uses_codex = (
     isinstance(primary, str) and primary.lower().startswith("openai-codex/")
 ) or any(

--- a/src/components/TierUpgradeCelebration.tsx
+++ b/src/components/TierUpgradeCelebration.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { useEffect, useState, type MouseEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useReducer,
+  type MouseEvent,
+  type ReactNode,
+} from "react";
 import { useClawboxLogin } from "@/lib/use-clawbox-login";
 import { useT } from "@/lib/i18n";
 import { PORTAL_DASHBOARD_URL } from "@/lib/max-subscription";
@@ -32,6 +38,38 @@ type DialogState =
   | { kind: "upgrade"; tier: "flash" | "pro" }
   | { kind: "downgrade-free" };
 
+type DialogAction =
+  | { type: "OPEN_UPGRADE"; tier: "flash" | "pro" }
+  | { type: "OPEN_DOWNGRADE" }
+  | { type: "CLOSE" };
+
+// Local reducer for the dialog's open/close lifecycle. CodeRabbit's
+// review on PR #132 suggested wiring this through `useWindows.ts`,
+// but that hook is purpose-built for desktop windows with z-order /
+// minimize / maximize semantics — none of which apply to a transient
+// centred modal. A local reducer captures the spirit of the
+// "reducer pattern" coding guideline and silences the ESLint
+// `set-state-in-effect` warning without forcing a fake `appId` /
+// `icon` / `defaultWidth` through a window manager that has no
+// business managing modals. The peer `ClawBoxLoginModal.tsx`
+// follows the same shape.
+function dialogReducer(
+  state: DialogState | null,
+  action: DialogAction,
+): DialogState | null {
+  switch (action.type) {
+    case "OPEN_UPGRADE":
+      // Latch the first transition we observe; a later effect tick
+      // re-reporting the same paid tier must not bump the dialog
+      // out from under the user.
+      return state ?? { kind: "upgrade", tier: action.tier };
+    case "OPEN_DOWNGRADE":
+      return state ?? { kind: "downgrade-free" };
+    case "CLOSE":
+      return null;
+  }
+}
+
 // Per-dialog content + presentation. Keyed by the upgrade tier
 // ("flash" = Pro plan, "pro" = Max plan) or "free" for the downgrade.
 // Translation keys are referenced literally here so the i18n
@@ -40,7 +78,6 @@ type ContentKey = "flash" | "pro" | "free";
 type Tone = "paid" | "muted";
 
 interface DialogContent {
-  titleId: string;
   tone: Tone;
   badgeKey: string;
   headlineKey: string;
@@ -49,21 +86,18 @@ interface DialogContent {
 
 const CONTENT: Record<ContentKey, DialogContent> = {
   flash: {
-    titleId: "tier-upgrade-title",
     tone: "paid",
     badgeKey: "tierCelebration.proBadge",
     headlineKey: "tierCelebration.proHeadline",
     bodyKey: "tierCelebration.proBody",
   },
   pro: {
-    titleId: "tier-upgrade-title",
     tone: "paid",
     badgeKey: "tierCelebration.maxBadge",
     headlineKey: "tierCelebration.maxHeadline",
     bodyKey: "tierCelebration.maxBody",
   },
   free: {
-    titleId: "tier-downgrade-title",
     tone: "muted",
     badgeKey: "tierCelebration.freeBadge",
     headlineKey: "tierCelebration.freeHeadline",
@@ -74,7 +108,7 @@ const CONTENT: Record<ContentKey, DialogContent> = {
 export default function TierUpgradeCelebration() {
   const { tier, loading } = useClawboxLogin();
   const { t } = useT();
-  const [dialog, setDialog] = useState<DialogState | null>(null);
+  const [dialog, dispatch] = useReducer(dialogReducer, null);
 
   useEffect(() => {
     if (loading) return;
@@ -94,12 +128,12 @@ export default function TierUpgradeCelebration() {
 
     // Upgrade to a paid tier we haven't celebrated yet.
     if (currentRank > seenRank && (tier === "flash" || tier === "pro")) {
-      setDialog({ kind: "upgrade", tier });
+      dispatch({ type: "OPEN_UPGRADE", tier });
       return;
     }
     // Downgrade from any paid tier to Free.
     if (currentRank === 0 && seenRank > 0) {
-      setDialog({ kind: "downgrade-free" });
+      dispatch({ type: "OPEN_DOWNGRADE" });
       return;
     }
     // Intermediate downgrade (Max → Pro) or no-change tick: silently
@@ -116,7 +150,7 @@ export default function TierUpgradeCelebration() {
     } else {
       kv.set(SEEN_KEY, FREE_SEEN_VALUE);
     }
-    setDialog(null);
+    dispatch({ type: "CLOSE" });
   };
 
   const contentKey: ContentKey = dialog.kind === "upgrade" ? dialog.tier : "free";
@@ -155,7 +189,6 @@ export default function TierUpgradeCelebration() {
 
   return (
     <CelebrationShell
-      titleId={content.titleId}
       tone={content.tone}
       badge={t(content.badgeKey)}
       headline={t(content.headlineKey)}
@@ -167,7 +200,6 @@ export default function TierUpgradeCelebration() {
 }
 
 interface ShellProps {
-  titleId: string;
   tone: Tone;
   badge: string;
   headline: string;
@@ -176,7 +208,23 @@ interface ShellProps {
   onClose: () => void;
 }
 
-function CelebrationShell({ titleId, tone, badge, headline, body, primary, onClose }: ShellProps) {
+function CelebrationShell({ tone, badge, headline, body, primary, onClose }: ShellProps) {
+  // useId gives stable, collision-free IDs per dialog instance so
+  // assistive tech can link aria-labelledby / aria-describedby
+  // without us hand-rolling per-variant string IDs.
+  const titleId = useId();
+  const descriptionId = useId();
+
+  // Esc closes — standard modal a11y. Listener mounts only while
+  // the dialog is rendered (parent gates with `if (!dialog) return null`).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   const glowClass = tone === "paid"
     ? "drop-shadow-[0_0_18px_rgba(217,70,239,0.6)]"
     : "drop-shadow-[0_0_12px_rgba(255,255,255,0.18)]";
@@ -184,18 +232,23 @@ function CelebrationShell({ titleId, tone, badge, headline, body, primary, onClo
     ? "bg-gradient-to-r from-fuchsia-500 to-pink-500 text-white shadow-[0_4px_12px_rgba(217,70,239,0.3)]"
     : "bg-white/10 text-white/70 border border-white/15";
 
+  // Close on backdrop click only. Previously the inner card stopped
+  // propagation; using target === currentTarget is the same effect
+  // expressed positively at the source (no stopPropagation gymnastics).
+  const onOverlayClick = (e: MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
   return (
     <div
       className="fixed inset-0 z-[100001] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby={titleId}
-      onClick={onClose}
+      aria-describedby={descriptionId}
+      onClick={onOverlayClick}
     >
-      <div
-        onClick={(e: MouseEvent) => e.stopPropagation()}
-        className="w-full max-w-md rounded-2xl border border-white/10 bg-[#0f1219] p-6 shadow-2xl text-center"
-      >
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#0f1219] p-6 shadow-2xl text-center">
         <div className="flex flex-col items-center gap-4 mb-5">
           <img
             src="/clawbox-crab.png"
@@ -215,7 +268,9 @@ function CelebrationShell({ titleId, tone, badge, headline, body, primary, onClo
           <h2 id={titleId} className="text-lg font-semibold text-white">
             {headline}
           </h2>
-          <p className="text-sm text-white/65 leading-relaxed">{body}</p>
+          <p id={descriptionId} className="text-sm text-white/65 leading-relaxed">
+            {body}
+          </p>
         </div>
         {primary}
       </div>


### PR DESCRIPTION
## Summary

Follow-ups to the four CodeRabbit review prompts on PR #132 that
landed unaddressed when #132 was approved and merged. All four are
covered here, with one deliberate variation explained below.

### scripts/gateway-pre-start.sh

1. **Defensive `isinstance(auth, dict)` check** *(prompt on line 318)*.
   `cfg["auth"]` may be missing, `None`, or a corrupted scalar on a
   hand-edited config — the previous `cfg.get("auth", {}).get(...)`
   would have raised `AttributeError` and silently skipped the codex
   install. Now mirrors the same defensive pattern already used at
   line 131 for the openrouter migration.

2. **Dynamic `CODEX_PLUGIN_DIR`** *(prompt on line 323)*. Derived
   from `$(dirname "$OPENCLAW_CONFIG")` instead of hardcoded
   `/home/clawbox/.openclaw/...`. Same behaviour on the default
   Jetson layout; works for non-default clawbox users / per-user
   installs.

### src/components/TierUpgradeCelebration.tsx

3. **`useState` → local `useReducer`** *(prompt on line 120)*.
   Silences the ESLint `set-state-in-effect` warning CodeRabbit
   cited and matches the spirit of the "reducer pattern" coding
   guideline.

   **Deliberate variation:** I did not route this through
   `useWindows.ts` as the prompt literally suggested. `useWindows`
   is for desktop windows with z-order / minimize / maximize / focus
   semantics — none of which apply to a transient centred modal.
   Forcing a fake `appId` / `icon` / `defaultWidth` into a window
   manager so a modal can hitch a ride would be worse code, not
   better. `ClawBoxLoginModal.tsx` follows the same local-state
   shape and wasn't flagged. Happy to revisit if there's a stronger
   argument for full integration.

4. **Accessibility improvements** *(prompt on line 193)*:
   - `useId()` for stable, collision-free title + description IDs.
     Dropped the hand-rolled `tier-upgrade-title` /
     `tier-downgrade-title` strings and the now-redundant `titleId`
     field on the `CONTENT` table.
   - `aria-describedby` linking the body paragraph.
   - `Escape` keydown handler with cleanup on unmount.
   - Backdrop click guarded with `e.target === e.currentTarget`
     instead of relying on the inner card's `stopPropagation` — same
     end result expressed positively at the source.

   The prompt also raised an XSS concern; not applicable here since
   the rendered strings come from `t()` (static translations), not
   user input.

## How was this tested?

Smoke test on the Jetson:

```
openclaw plugins uninstall codex --force
sudo systemctl restart clawbox-gateway
```

- Pre-start resolves `CODEX_PLUGIN_DIR` via the new dynamic path,
  detects the missing `package.json`, and runs
  `openclaw plugins install codex`.
- Gateway comes up with `codex` in its loaded-plugins list:
  `[gateway] http server listening (10 plugins: ... codex ...)`.

UI: rebuilt the Next.js bundle; modal still pops on the same
upgrade / Free-downgrade transitions (existing `clawai_tier_seen`
contract unchanged), now with the keyboard / screen-reader
improvements above.

- [x] Manually verified on Jetson dev install
- [ ] `bun run lint` (will run in CI)
- [ ] `bun run test` (will run in CI)
- [ ] `bun run build` (will run in CI; passed locally on Jetson)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenClaw codex plugin installation now works with non-default installation paths.
  * Configuration parsing now handles missing or corrupted authentication values gracefully.

* **Improvements**
  * Tier upgrade/downgrade celebration modal improved with better state management.
  * Enhanced modal dialog accessibility: proper keyboard navigation (Escape to close), improved screen reader support, and consistent labeling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->