### PR TITLE
fix(mcp): bearer-token auth so the MCP server can reach session-gated /setup-api/*

### DIFF
--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -23,6 +23,14 @@ import { resolve, relative, dirname, extname, join, basename } from "path";
 // ══════════════════════════════════════════════════════════════════════
 
 const API_BASE = process.env.CLAWBOX_API_BASE || "http://127.0.0.1:80";
+// Per-install bearer token gateway-pre-start.sh injects into our env so
+// we can authenticate to /setup-api/* (which is session-cookie-gated by
+// src/middleware.ts after setup completes). Without this, every API
+// call from the MCP — GET or POST — gets 307'd to /login: POSTs
+// surface as 405 (login is GET-only), GETs return the login HTML page
+// that JSON.parse chokes on with "Failed to parse JSON". See
+// src/lib/mcp-token.ts for the matching verifier.
+const API_TOKEN = process.env.CLAWBOX_MCP_TOKEN || "";
 const HOME = process.env.HOME || "/home/clawbox";
 const DEFAULT_CWD = process.env.CLAWBOX_ROOT || "/home/clawbox/clawbox";
 const COMMAND_TIMEOUT = 30_000;
@@ -67,7 +75,14 @@ const CLAWBOX_MCP_INSTRUCTIONS = `${CLAWBOX_STUB}\n\n${BROWSER_ROUTING_INSTRUCTI
 // ══════════════════════════════════════════════════════════════════════
 
 async function api(path: string, options?: RequestInit) {
-  const res = await fetch(`${API_BASE}${path}`, options);
+  // Inject the MCP bearer on every call. middleware.ts accepts this for
+  // /setup-api/* paths in lieu of a session cookie; without it we hit
+  // the 307→/login redirect described at the API_TOKEN definition.
+  const headers = new Headers(options?.headers);
+  if (API_TOKEN && !headers.has("authorization")) {
+    headers.set("authorization", `Bearer ${API_TOKEN}`);
+  }
+  const res = await fetch(`${API_BASE}${path}`, { ...options, headers });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`API ${res.status}: ${body}`);

--- a/production-server.js
+++ b/production-server.js
@@ -59,6 +59,32 @@ try {
   console.warn("[production-server] Failed to set up session secret:", err.message);
 }
 
+// ─── MCP bearer token ───
+// Per-install token the ClawBox MCP server (mcp/clawbox-mcp.ts) uses to
+// authenticate back to /setup-api/* — see src/lib/mcp-token.ts. The MCP
+// runs as a stdio subprocess of openclaw and has no session cookie, so
+// without this every tool call from a Codex / Claude agent gets 307'd
+// to /login (POSTs surface as 405, GETs receive the login HTML page).
+// Seeded here so middleware.ts can resolve the same value via env on
+// the very first request, before src/lib/mcp-token.ts would lazily mint
+// one. gateway-pre-start.sh reads the same file to inject the value
+// into the MCP server's env when registering it with openclaw.
+const MCP_TOKEN_PATH = path.join(__dirname, "data", ".mcp-token");
+try {
+  let mcpToken;
+  try {
+    mcpToken = fs.readFileSync(MCP_TOKEN_PATH, "utf-8").trim();
+  } catch {}
+  if (!mcpToken || mcpToken.length < 32) {
+    mcpToken = require("crypto").randomBytes(32).toString("hex");
+    fs.mkdirSync(path.dirname(MCP_TOKEN_PATH), { recursive: true });
+    fs.writeFileSync(MCP_TOKEN_PATH, mcpToken, { mode: 0o600 });
+  }
+  process.env.CLAWBOX_MCP_TOKEN = mcpToken;
+} catch (err) {
+  console.warn("[production-server] Failed to set up MCP token:", err.message);
+}
+
 // ─── Local-AI bearer token ───
 // Per-install token openclaw uses to call our /setup-api/local-ai/* proxy.
 // Mirrors the session secret bootstrap so middleware + the proxy route can

--- a/production-server.js
+++ b/production-server.js
@@ -80,6 +80,12 @@ try {
     fs.mkdirSync(path.dirname(MCP_TOKEN_PATH), { recursive: true });
     fs.writeFileSync(MCP_TOKEN_PATH, mcpToken, { mode: 0o600 });
   }
+  // Re-harden mode on every boot. fs.writeFileSync only applies mode
+  // when creating; an existing file from an older install (or one
+  // that drifted to broader perms via manual edit) would otherwise
+  // stay readable to other local users. The bearer is the sole
+  // /setup-api/* credential, so don't trust a reused file's perms.
+  fs.chmodSync(MCP_TOKEN_PATH, 0o600);
   process.env.CLAWBOX_MCP_TOKEN = mcpToken;
 } catch (err) {
   console.warn("[production-server] Failed to set up MCP token:", err.message);

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -355,15 +355,25 @@ if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$(wc -c < "$MCP_TOKEN_FILE" 2>/dev/null || e
   else
     head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE"
   fi
-  chmod 600 "$MCP_TOKEN_FILE"
 fi
+# Re-harden mode unconditionally: chmod only ran on the regeneration
+# path before, so a file with drifted permissions (manual edit, upgrade
+# from a pre-0600 build) would keep being trusted as-is. The bearer
+# is the sole /setup-api/* credential.
+chmod 600 "$MCP_TOKEN_FILE"
 
 # Always reconcile the MCP server registration in openclaw.json with
 # the current token. Done in Python so the atomic-rename pattern used
 # elsewhere in this script applies — and so we can detect a no-op
 # update (token already current) without paying the ~10 s cost of
 # `openclaw config set`.
-export CLAWBOX_MCP_TOKEN_VAL="$(cat "$MCP_TOKEN_FILE")"
+#
+# Split the assignment from the export so `set -euo pipefail` catches
+# a failed `cat` (e.g. permission drift, mount issue). The combined
+# `export VAR="$(cmd)"` form swallows command-substitution failures
+# and the Python block would silently exit 0 with an empty token.
+CLAWBOX_MCP_TOKEN_VAL="$(cat "$MCP_TOKEN_FILE")"
+export CLAWBOX_MCP_TOKEN_VAL
 python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, os, sys, tempfile
 

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -337,12 +337,73 @@ if [ "$NEEDS_CODEX_PLUGIN" = "1" ] && [ ! -f "$CODEX_PLUGIN_DIR/package.json" ];
     || echo "  WARN: openclaw plugins install codex failed; Codex chats will fail until resolved"
 fi
 
-# Register ClawBox MCP server (only if not already set). Kept as a CLI
-# call because MCP config has richer schema validation in the CLI path
-# and we only hit this branch on fresh installs / factory resets.
-if ! python3 -c "import json; c=json.load(open('$OPENCLAW_CONFIG')); assert c.get('mcp',{}).get('servers',{}).get('clawbox',{}).get('command')" 2>/dev/null; then
-  "$OPENCLAW_BIN" config set mcp.servers.clawbox '{"command":"/home/clawbox/.bun/bin/bun","args":["run","/home/clawbox/clawbox/mcp/clawbox-mcp.ts"],"env":{"CLAWBOX_API_BASE":"http://127.0.0.1:80"}}' --json 2>/dev/null || true
+# Ensure the per-install MCP bearer token exists and is wired into the
+# openclaw MCP server registration. The token lets the MCP subprocess
+# (mcp/clawbox-mcp.ts) authenticate back to /setup-api/* on port 80 —
+# without it, middleware.ts 307s every tool call to /login: POSTs
+# surface as 405 ("Method Not Allowed" on the GET-only login route)
+# and GETs receive the login HTML page that JSON.parse chokes on
+# ("Failed to parse JSON"). See src/lib/mcp-token.ts for the matching
+# verifier. production-server.js also seeds this file at Next.js boot;
+# we mirror that here so the gateway can register the MCP server even
+# if it comes up before clawbox-setup on a fresh boot.
+MCP_TOKEN_FILE="${CLAWBOX_ROOT:-/home/clawbox/clawbox}/data/.mcp-token"
+if [ ! -s "$MCP_TOKEN_FILE" ] || [ "$(wc -c < "$MCP_TOKEN_FILE" 2>/dev/null || echo 0)" -lt 32 ]; then
+  mkdir -p "$(dirname "$MCP_TOKEN_FILE")"
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32 > "$MCP_TOKEN_FILE"
+  else
+    head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$MCP_TOKEN_FILE"
+  fi
+  chmod 600 "$MCP_TOKEN_FILE"
 fi
+
+# Always reconcile the MCP server registration in openclaw.json with
+# the current token. Done in Python so the atomic-rename pattern used
+# elsewhere in this script applies — and so we can detect a no-op
+# update (token already current) without paying the ~10 s cost of
+# `openclaw config set`.
+export CLAWBOX_MCP_TOKEN_VAL="$(cat "$MCP_TOKEN_FILE")"
+python3 - "$OPENCLAW_CONFIG" <<'PY'
+import json, os, sys, tempfile
+
+cfg_path = sys.argv[1]
+token = os.environ.get("CLAWBOX_MCP_TOKEN_VAL", "")
+if not token:
+    sys.exit(0)
+try:
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+except (FileNotFoundError, json.JSONDecodeError):
+    sys.exit(0)
+
+desired = {
+    "command": "/home/clawbox/.bun/bin/bun",
+    "args": ["run", "/home/clawbox/clawbox/mcp/clawbox-mcp.ts"],
+    "env": {
+        "CLAWBOX_API_BASE": "http://127.0.0.1:80",
+        "CLAWBOX_MCP_TOKEN": token,
+    },
+}
+mcp_servers = cfg.setdefault("mcp", {}).setdefault("servers", {})
+if mcp_servers.get("clawbox") == desired:
+    print("  MCP server registration already current, skipping write")
+    sys.exit(0)
+mcp_servers["clawbox"] = desired
+tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(cfg_path), prefix=".openclaw.", suffix=".tmp")
+try:
+    with os.fdopen(tmp_fd, "w") as f:
+        json.dump(cfg, f, indent=2)
+    os.replace(tmp_path, cfg_path)
+except Exception:
+    try:
+        os.unlink(tmp_path)
+    except Exception:
+        pass
+    raise
+print("  Updated MCP server registration with bearer token")
+PY
+unset CLAWBOX_MCP_TOKEN_VAL
 
 # Seed CLAWBOX.md in the OpenClaw workspace so the agent's session-start
 # context includes ClawBox-specific guidance (where user-installed skills

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -368,11 +368,23 @@ chmod 600 "$MCP_TOKEN_FILE"
 # update (token already current) without paying the ~10 s cost of
 # `openclaw config set`.
 #
-# Split the assignment from the export so `set -euo pipefail` catches
-# a failed `cat` (e.g. permission drift, mount issue). The combined
-# `export VAR="$(cmd)"` form swallows command-substitution failures
-# and the Python block would silently exit 0 with an empty token.
+# Validate explicitly before exporting. `set -euo pipefail` doesn't
+# catch a non-failing-but-empty `cat` (the file exists but is empty,
+# or the read returned no bytes), and `export VAR="$(cmd)"` masks
+# command-substitution exit codes entirely. Without this guard the
+# Python block would `sys.exit(0)` on an empty token and silently
+# skip the openclaw.json reconcile — leaving the MCP subprocess
+# with a stale or missing CLAWBOX_MCP_TOKEN and every tool call
+# 307'd to /login again.
+if [ ! -r "$MCP_TOKEN_FILE" ]; then
+  echo "  ERROR: MCP token file is not readable: $MCP_TOKEN_FILE" >&2
+  exit 1
+fi
 CLAWBOX_MCP_TOKEN_VAL="$(cat "$MCP_TOKEN_FILE")"
+if [ -z "$CLAWBOX_MCP_TOKEN_VAL" ]; then
+  echo "  ERROR: MCP token file is empty: $MCP_TOKEN_FILE" >&2
+  exit 1
+fi
 export CLAWBOX_MCP_TOKEN_VAL
 python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, os, sys, tempfile

--- a/src/lib/mcp-token.ts
+++ b/src/lib/mcp-token.ts
@@ -1,0 +1,82 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+
+/**
+ * Per-install bearer token used to authenticate the ClawBox MCP server
+ * back to its own Next.js API at `/setup-api/*`.
+ *
+ * The MCP server (`mcp/clawbox-mcp.ts`) runs as a stdio subprocess of
+ * openclaw and has no session cookie. Once the setup wizard finishes,
+ * `src/middleware.ts` gates every `/setup-api/*` request on a valid
+ * HMAC-signed session cookie, so without this carve-out every tool
+ * call from a Codex / Claude agent gets 307'd to `/login` — POSTs
+ * surface as 405 (the login route is GET-only), GETs receive the
+ * login HTML page that `JSON.parse` chokes on with "Failed to parse
+ * JSON".
+ *
+ * Token semantics mirror `src/lib/local-ai-token.ts` exactly: a
+ * per-install secret persisted to `data/.mcp-token`, env-overridable
+ * for tests via `CLAWBOX_MCP_TOKEN`, lazy creation on first read so
+ * `production-server.js` doesn't have to be the only seeder. No
+ * legacy sentinels — this is a fresh capability with no upgrade
+ * compatibility window to maintain.
+ *
+ * Verification is constant-time via `crypto.timingSafeEqual` to keep
+ * the bearer check robust against timing oracles.
+ */
+
+const DATA_ROOT = process.env.CLAWBOX_ROOT
+  || (process.env.NODE_ENV === "development" ? process.cwd() : "/home/clawbox/clawbox");
+const TOKEN_PATH = path.join(DATA_ROOT, "data", ".mcp-token");
+
+let cached: string | null = null;
+
+function readOrCreateToken(): string {
+  const fromEnv = process.env.CLAWBOX_MCP_TOKEN;
+  if (fromEnv && fromEnv.length >= 16) return fromEnv;
+
+  try {
+    const raw = fs.readFileSync(TOKEN_PATH, "utf-8").trim();
+    if (raw && raw.length >= 16) return raw;
+  } catch {
+    // fall through to mint a fresh token
+  }
+
+  const fresh = crypto.randomBytes(32).toString("hex");
+  try {
+    fs.mkdirSync(path.dirname(TOKEN_PATH), { recursive: true });
+    fs.writeFileSync(TOKEN_PATH, fresh, { mode: 0o600 });
+  } catch {
+    // Disk write failed (read-only fs in tests, permission). The token
+    // is still valid for this process; we just can't share it back to
+    // the MCP subprocess. Caller surfaces a 401 if the MCP sends a
+    // stale (or missing) credential.
+  }
+  return fresh;
+}
+
+export function getMcpToken(): string {
+  if (!cached) cached = readOrCreateToken();
+  return cached;
+}
+
+export function verifyMcpBearer(headerValue: string | null): boolean {
+  if (!headerValue) return false;
+  const match = headerValue.match(/^Bearer\s+(.+)$/i);
+  if (!match) return false;
+  const presented = match[1].trim();
+  if (!presented) return false;
+
+  const expected = getMcpToken();
+  const presentedBuf = Buffer.from(presented);
+  const expectedBuf = Buffer.from(expected);
+  return (
+    presentedBuf.byteLength === expectedBuf.byteLength
+    && crypto.timingSafeEqual(presentedBuf, expectedBuf)
+  );
+}
+
+export function _resetMcpTokenCacheForTests(): void {
+  cached = null;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import fs from "fs";
 import path from "path";
+import { verifyMcpBearer } from "@/lib/mcp-token";
 
 // ─── Setup completion ────────────────────────────────────────────────────────
 //
@@ -223,6 +224,21 @@ export async function middleware(request: NextRequest) {
   // boots under CLAWBOX_TEST_MODE.
   if (process.env.CLAWBOX_TEST_MODE === "1" && pathname.startsWith("/setup-api/")) {
     return NextResponse.next();
+  }
+
+  // 3c. MCP server bearer-token bypass. The ClawBox MCP runs as a stdio
+  // subprocess of openclaw (mcp/clawbox-mcp.ts) and has no session
+  // cookie, so every /setup-api/* fetch it makes would be 307'd to
+  // /login without this carve-out — POSTs surface as 405, GETs return
+  // HTML that JSON.parse chokes on. Mirrors the local-ai-proxy pattern:
+  // service-to-service auth via a per-install bearer (see
+  // src/lib/mcp-token.ts), scoped to /setup-api/* only so the dashboard
+  // and login flow still go through the normal session gate.
+  if (pathname.startsWith("/setup-api/")) {
+    const authHeader = request.headers.get("authorization");
+    if (authHeader && verifyMcpBearer(authHeader)) {
+      return NextResponse.next();
+    }
   }
 
   // 4. Check session cookie

--- a/src/tests/unit/mcp-token.test.ts
+++ b/src/tests/unit/mcp-token.test.ts
@@ -1,17 +1,18 @@
-import { describe, expect, it, beforeEach } from "vitest";
+import { describe, expect, it, beforeEach, vi } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
 
-// Each test gets its own temp directory + module cache reset so the
-// module-level `cached` value and file-system state don't leak across
-// cases. The module reads CLAWBOX_ROOT once at import time to derive
-// the token path, so we set it before dynamic import.
+// The module reads CLAWBOX_ROOT once at import time to derive the
+// token path, so every test that needs a different root has to load
+// a fresh copy of the module. `vi.resetModules()` clears Vitest's
+// registry so the next dynamic import re-runs the module's top-level
+// code with the current env.
 async function loadModule(tmpDir: string) {
   process.env.CLAWBOX_ROOT = tmpDir;
   delete process.env.CLAWBOX_MCP_TOKEN;
-  // Bust the import cache so the new CLAWBOX_ROOT is picked up.
-  const mod = await import(`@/lib/mcp-token?cachebust=${Date.now()}-${Math.random()}`);
+  vi.resetModules();
+  const mod = await import("@/lib/mcp-token");
   mod._resetMcpTokenCacheForTests();
   return mod;
 }
@@ -52,7 +53,8 @@ describe("mcp-token", () => {
 
     process.env.CLAWBOX_ROOT = tmpDir;
     process.env.CLAWBOX_MCP_TOKEN = "env-override-token-must-be-long-enough";
-    const mod = await import(`@/lib/mcp-token?cachebust=${Date.now()}-${Math.random()}`);
+    vi.resetModules();
+    const mod = await import("@/lib/mcp-token");
     mod._resetMcpTokenCacheForTests();
 
     expect(mod.getMcpToken()).toBe("env-override-token-must-be-long-enough");

--- a/src/tests/unit/mcp-token.test.ts
+++ b/src/tests/unit/mcp-token.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// Each test gets its own temp directory + module cache reset so the
+// module-level `cached` value and file-system state don't leak across
+// cases. The module reads CLAWBOX_ROOT once at import time to derive
+// the token path, so we set it before dynamic import.
+async function loadModule(tmpDir: string) {
+  process.env.CLAWBOX_ROOT = tmpDir;
+  delete process.env.CLAWBOX_MCP_TOKEN;
+  // Bust the import cache so the new CLAWBOX_ROOT is picked up.
+  const mod = await import(`@/lib/mcp-token?cachebust=${Date.now()}-${Math.random()}`);
+  mod._resetMcpTokenCacheForTests();
+  return mod;
+}
+
+function makeTmp(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-mcp-token-"));
+}
+
+describe("mcp-token", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmp();
+  });
+
+  it("getMcpToken mints and persists a token on first read", async () => {
+    const { getMcpToken } = await loadModule(tmpDir);
+    const tokenPath = path.join(tmpDir, "data", ".mcp-token");
+    expect(fs.existsSync(tokenPath)).toBe(false);
+
+    const token = getMcpToken();
+
+    expect(token).toMatch(/^[0-9a-f]{64}$/);
+    expect(fs.readFileSync(tokenPath, "utf-8").trim()).toBe(token);
+  });
+
+  it("getMcpToken returns the persisted token on subsequent reads", async () => {
+    const { getMcpToken, _resetMcpTokenCacheForTests } = await loadModule(tmpDir);
+    const first = getMcpToken();
+    _resetMcpTokenCacheForTests();
+    const second = getMcpToken();
+    expect(second).toBe(first);
+  });
+
+  it("CLAWBOX_MCP_TOKEN env override wins over the file", async () => {
+    fs.mkdirSync(path.join(tmpDir, "data"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "data", ".mcp-token"), "ondisk".repeat(8));
+
+    process.env.CLAWBOX_ROOT = tmpDir;
+    process.env.CLAWBOX_MCP_TOKEN = "env-override-token-must-be-long-enough";
+    const mod = await import(`@/lib/mcp-token?cachebust=${Date.now()}-${Math.random()}`);
+    mod._resetMcpTokenCacheForTests();
+
+    expect(mod.getMcpToken()).toBe("env-override-token-must-be-long-enough");
+    delete process.env.CLAWBOX_MCP_TOKEN;
+  });
+
+  describe("verifyMcpBearer", () => {
+    it("accepts a matching Bearer header", async () => {
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      const token = getMcpToken();
+      expect(verifyMcpBearer(`Bearer ${token}`)).toBe(true);
+    });
+
+    it("accepts the case-insensitive `bearer` prefix", async () => {
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      const token = getMcpToken();
+      expect(verifyMcpBearer(`bearer ${token}`)).toBe(true);
+    });
+
+    it("rejects null / empty / non-Bearer headers", async () => {
+      const { verifyMcpBearer } = await loadModule(tmpDir);
+      expect(verifyMcpBearer(null)).toBe(false);
+      expect(verifyMcpBearer("")).toBe(false);
+      expect(verifyMcpBearer("Basic some-creds")).toBe(false);
+      expect(verifyMcpBearer("Bearer")).toBe(false);
+      expect(verifyMcpBearer("Bearer ")).toBe(false);
+    });
+
+    it("rejects a Bearer token that doesn't match", async () => {
+      const { verifyMcpBearer } = await loadModule(tmpDir);
+      expect(verifyMcpBearer("Bearer wrong-token-value-here-do-not-match")).toBe(false);
+    });
+
+    it("rejects a token that's a prefix of the real one", async () => {
+      // Guard against any accidental startsWith comparison — timingSafeEqual
+      // requires equal lengths so this should be a fast reject.
+      const { getMcpToken, verifyMcpBearer } = await loadModule(tmpDir);
+      const token = getMcpToken();
+      expect(verifyMcpBearer(`Bearer ${token.slice(0, 16)}`)).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Every ClawBox MCP tool call from a Codex / Claude agent currently
fails on devices where the setup wizard has completed: writes
surface as **405 Method Not Allowed**, reads as **"Failed to parse
JSON"** because the `/setup-api/*` middleware 307s the MCP's
cookie-less fetches to `/login`.

## Root cause

`src/middleware.ts` gates every `/setup-api/*` route on an
HMAC-signed session cookie once setup completes. The ClawBox MCP
(`mcp/clawbox-mcp.ts`) runs as a stdio subprocess of openclaw with
no cookie, so every `fetch()` it makes hits the auth wall:

- POSTs surface as **405** (the `/login` route is GET-only)
- GETs receive the login HTML page that `JSON.parse` chokes on

13 endpoints affected: `apps/{install,uninstall}`, `browser`, `code`,
`kv`, `preferences`, `system/{info,power,stats}`, `vnc`, `webapps`,
`wifi/{scan,status}`.

## Fix

Mirror the existing `local-ai-proxy` service-to-service auth pattern
(`src/lib/local-ai-token.ts`):

1. Per-install bearer token persisted at `data/.mcp-token`.
2. `src/middleware.ts` new step 3c accepts `Authorization: Bearer
   <token>` on `/setup-api/*` in lieu of the session cookie.
3. `mcp/clawbox-mcp.ts` `api()` helper sends the bearer on every
   request (env var `CLAWBOX_MCP_TOKEN`).
4. `scripts/gateway-pre-start.sh` seeds the token if missing and
   reconciles `mcp.servers.clawbox` in `openclaw.json` so the MCP
   subprocess sees the value via env. Idempotent.
5. `production-server.js` seeds `data/.mcp-token` at Next.js boot,
   like `.session-secret` / `.local-ai-token`.
6. Unit tests for `verifyMcpBearer` (good / wrong / prefix attack /
   missing / case-insensitive).

## Smoke-tested live on Jetson `krasi`

```
GET  /setup-api/system/info  no auth     → 307 → /login        (correct)
GET  /setup-api/system/info  Bearer X    → 200 + JSON          (the fix)
POST /setup-api/preferences  Bearer X    → 200                 (was 405)
GET  /setup-api/system/info  wrong-tok   → 307 → /login        (correct)
```

## Security

- 256-bit hex token, mode 0600.
- No loopback IP restriction (same posture as `local-ai-token`); the
  bearer itself is the credential.
- Constant-time compare via `crypto.timingSafeEqual` (length-checked).
- No legacy fallback — old MCP processes that don't send the bearer
  stay 307'd (they were already broken with 405; net improvement).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented per-installation bearer token authentication system for setup operations, with automatic token generation and secure storage.
  * Enhanced API request handling to automatically include bearer token credentials for setup phases without manual configuration.
  * Added token validation and verification to middleware for improved security during installation.

* **Chores**
  * Updated installation bootstrap process to initialize and manage authentication credentials.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->