### PR TITLE
chore(release): bump version to 3.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "2.2.2",
+  "version": "3.0.3",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {


### PR DESCRIPTION
Tiny follow-up to #136. The version-bump commit landed on `beta`
after #136 had already merged to `main`, so `main`'s `package.json`
is still on the stale `2.2.2` value while `beta` is now on `3.0.3`.

This PR brings the bump forward so `main` and `beta` agree.

After this lands I'll tag `v3.0.3` and publish the GitHub Release
with notes covering everything since `v3.0.2`:
- #127 Install x64 fixes
- #128–#131 + Node-22 install patches
- #132 OpenClaw 2026.5.12 compat (chat protocol v4, Free→Paid tier auto-detect, tier-change celebration modal in 10 locales, codex plugin auto-install)
- #134 CodeRabbit follow-ups on #132 (a11y + perm/path hardening)
- #135 MCP bearer-token auth (unbreaks every Codex/Claude tool call post-setup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 3.0.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->