### PR TITLE
fix: codex peer-dep self-heal + don't flip badge to Free on portal auth loss

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -331,9 +331,22 @@ uses_codex = (
 print("1" if uses_codex else "0")
 PY
 )"
-if [ "$NEEDS_CODEX_PLUGIN" = "1" ] && [ ! -f "$CODEX_PLUGIN_DIR/package.json" ]; then
-  echo "  Installing @openclaw/codex runtime plugin (codex model selected)…"
-  "$OPENCLAW_BIN" plugins install codex >/dev/null 2>&1 \
+# Also check the nested peer-dep symlink. `openclaw plugins install
+# codex` writes `<codex>/node_modules/openclaw -> <global openclaw>`
+# alongside the package.json; if that symlink is missing or dangling
+# (partial install, openclaw upgrade that cleared the nested
+# node_modules, manual cleanup) the codex plugin loads but its
+# top-level imports fail at runtime with:
+#   Error: Cannot find package 'openclaw' imported from
+#   .../@openclaw/codex/dist/shared-client-…js
+# Checking only the package.json misses that broken state. `-e`
+# follows symlinks, so it catches both "missing" and "dangling".
+# `--force` on install rebuilds the symlink without reinstalling
+# unnecessary content when the package directory is already there.
+CODEX_PEER_DEP="$CODEX_PLUGIN_DIR/node_modules/openclaw/package.json"
+if [ "$NEEDS_CODEX_PLUGIN" = "1" ] && { [ ! -f "$CODEX_PLUGIN_DIR/package.json" ] || [ ! -e "$CODEX_PEER_DEP" ]; }; then
+  echo "  Installing/repairing @openclaw/codex runtime plugin (codex model selected)…"
+  "$OPENCLAW_BIN" plugins install codex --force >/dev/null 2>&1 \
     || echo "  WARN: openclaw plugins install codex failed; Codex chats will fail until resolved"
 fi
 

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -141,14 +141,21 @@ async function fetchPortalTier(token: string): Promise<PortalLookup> {
         rememberTier(token, tier, now);
         return { source: "portal", tier };
       }
-      // 401/403 are definitive — the portal *did* answer, the token just
-      // doesn't entitle anything. Cache so we don't re-hammer for the
-      // TTL. 5xx and network errors leave the cache untouched and let
-      // callers fall back to the locally-stored picker selection.
-      if (res.status === 401 || res.status === 403) {
-        rememberTier(token, null, now);
-        return { source: "portal", tier: null };
-      }
+      // 401/403 is ambiguous: it can mean "user is genuinely Free"
+      // OR "token was revoked / migrated / corrupted on a still-paid
+      // account" (e.g. portal admin revoke, account merge, backend
+      // cleanup). We can't tell from the response alone — both are
+      // status codes the portal returns when the bearer can't be
+      // resolved to a paid entitlement. Treating these as a
+      // definitive Free verdict silently downgrades paid users whose
+      // auth happens to be broken, and also fires the
+      // downgrade-to-Free celebration popup. Fall through to the
+      // unreachable branch instead: badge stays on `localTier` (last
+      // known good), no celebration triggers, and the next
+      // successful poll re-establishes truth. Also: deliberately
+      // *not* cached, so a token that recovers (re-pair, portal
+      // recovers from a transient state) is picked up on the next
+      // poll instead of waiting out the 120 s TTL on the stale null.
       return { source: "unreachable" };
     } catch {
       return { source: "unreachable" };

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -41,6 +41,16 @@ const PORTAL_FETCH_TIMEOUT_MS = 4_000;
 // reset / multi-account dev churn — but a long-running process would
 // otherwise leak entries forever.
 const PORTAL_TIER_CACHE_MAX_ENTRIES = 64;
+// Short negative-cache window for tokens whose last portal lookup
+// resolved to `unreachable` (4xx auth failure, 5xx, or network
+// error). With useClawboxLogin polling every 30s, this caps the
+// per-device portal load during a sustained auth-failure or
+// outage at ~1 request per 30s (down from 1-per-poll). Smaller
+// than PORTAL_TIER_CACHE_TTL_MS because the positive cache is
+// safe to hold longer; an unreachable verdict needs to clear
+// quickly enough that recovery (token re-pair, portal recovers)
+// shows up on the next poll, not minutes later.
+const PORTAL_UNREACHABLE_TTL_MS = 30_000;
 
 interface DeviceInfoResponse {
   tier?: string;
@@ -57,6 +67,10 @@ interface PortalCacheEntry {
 }
 
 const portalTierCache = new Map<string, PortalCacheEntry>();
+// token → epoch-ms timestamp when its unreachable verdict expires.
+// Separate from portalTierCache because the value is "we tried and
+// it failed, don't try again yet" rather than "the answer is null".
+const portalUnreachableCache = new Map<string, number>();
 const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
 
 /**
@@ -111,11 +125,15 @@ function mapPortalTier(body: DeviceInfoResponse): ClawboxAiTier | null {
  *
  * Cache semantics:
  *   - 200 OK: parsed tier is cached for `PORTAL_TIER_CACHE_TTL_MS`.
- *   - 401 / 403: a definitive "no entitlement" verdict is also cached
- *     so we don't re-hammer the portal for invalid tokens.
- *   - 5xx / network error: cache untouched; caller falls back to the
- *     locally-stored picker selection so the badge doesn't flicker
- *     during transient portal outages.
+ *   - Non-200 / network error: token is marked unreachable for
+ *     `PORTAL_UNREACHABLE_TTL_MS` so we don't hit the portal every
+ *     30 s status poll during a sustained auth failure or outage.
+ *     A successful 200 clears the unreachable mark so recovery is
+ *     responsive.
+ *
+ * 401/403 are deliberately treated the same as 5xx/network errors
+ * (unreachable) rather than as a definitive "Free" verdict — see
+ * the non-200 branch in the body for the rationale.
  *
  * @param token The bearer token to look up.
  * @returns Either a definitive `{ source: "portal", tier }` answer or
@@ -126,10 +144,19 @@ async function fetchPortalTier(token: string): Promise<PortalLookup> {
   const cached = portalTierCache.get(token);
   if (cached && cached.expiresAt > now) return { source: "portal", tier: cached.tier };
 
+  const unreachableUntil = portalUnreachableCache.get(token);
+  if (unreachableUntil !== undefined && unreachableUntil > now) {
+    return { source: "unreachable" };
+  }
+
   const existing = inFlightPortalLookups.get(token);
   if (existing) return existing;
 
   const promise = (async (): Promise<PortalLookup> => {
+    const markUnreachable = (): PortalLookup => {
+      portalUnreachableCache.set(token, now + PORTAL_UNREACHABLE_TTL_MS);
+      return { source: "unreachable" };
+    };
     try {
       const res = await fetch(PORTAL_DEVICE_INFO_URL, {
         headers: { Authorization: `Bearer ${token}` },
@@ -139,26 +166,18 @@ async function fetchPortalTier(token: string): Promise<PortalLookup> {
         const body = await res.json() as DeviceInfoResponse;
         const tier = mapPortalTier(body);
         rememberTier(token, tier, now);
+        portalUnreachableCache.delete(token);
         return { source: "portal", tier };
       }
-      // 401/403 is ambiguous: it can mean "user is genuinely Free"
-      // OR "token was revoked / migrated / corrupted on a still-paid
-      // account" (e.g. portal admin revoke, account merge, backend
-      // cleanup). We can't tell from the response alone — both are
-      // status codes the portal returns when the bearer can't be
-      // resolved to a paid entitlement. Treating these as a
-      // definitive Free verdict silently downgrades paid users whose
-      // auth happens to be broken, and also fires the
-      // downgrade-to-Free celebration popup. Fall through to the
-      // unreachable branch instead: badge stays on `localTier` (last
-      // known good), no celebration triggers, and the next
-      // successful poll re-establishes truth. Also: deliberately
-      // *not* cached, so a token that recovers (re-pair, portal
-      // recovers from a transient state) is picked up on the next
-      // poll instead of waiting out the 120 s TTL on the stale null.
-      return { source: "unreachable" };
+      // 401/403 is ambiguous: it can mean genuinely Free OR token
+      // revoked / migrated / corrupted on a still-paid account. We
+      // can't tell from the response alone, and treating it as
+      // "Free" silently downgrades paid users with broken auth (and
+      // fires the downgrade-celebration popup). Mark unreachable
+      // instead so callers preserve localTier.
+      return markUnreachable();
     } catch {
-      return { source: "unreachable" };
+      return markUnreachable();
     }
   })();
 
@@ -176,6 +195,7 @@ async function fetchPortalTier(token: string): Promise<PortalLookup> {
  * a clean module-state. Not for production use.
  */
 export function _resetPortalTierCache() {
+  portalUnreachableCache.clear();
   portalTierCache.clear();
   inFlightPortalLookups.clear();
 }

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -239,12 +239,6 @@ describe("/setup-api/ai-models/status", () => {
     });
 
     it("preserves localTier on portal 401/403 (auth lost, might still be paid)", async () => {
-      // Portal 401/403 is ambiguous: it can mean "user is genuinely
-      // Free" OR "token was revoked / migrated / corrupted on a still-
-      // paid account". We can't tell which from the response alone,
-      // so we fall back to localTier — the device keeps showing the
-      // user's last-known tier instead of silently downgrading to
-      // Free (which would also fire the downgrade-celebration popup).
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
       mockGetConfigValue.mockResolvedValue("pro");
       fetchSpy.mockResolvedValue(new Response("invalid_token", { status: 403 }));
@@ -256,21 +250,10 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.tierSource).toBe("picker");
     });
 
-    it("does not cache the auth-failure verdict — recovers on next poll", async () => {
-      // Old behaviour cached the 401/403 as a definitive null for the
-      // full 120 s TTL, so a token that recovered (re-pair, portal
-      // un-revoke, transient backend issue) couldn't be picked up
-      // until the cache expired. Now the auth-lost path returns
-      // `unreachable` which is uncached — the second poll re-tries
-      // the portal immediately and sees the fresh tier.
+    it("negative-caches an unreachable verdict so back-to-back polls don't hammer the portal", async () => {
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
       mockGetConfigValue.mockResolvedValue("pro");
-      fetchSpy
-        .mockResolvedValueOnce(new Response("invalid_token", { status: 401 }))
-        .mockResolvedValueOnce(new Response(
-          JSON.stringify({ tier: "max", deviceTier: "pro" }),
-          { status: 200 },
-        ));
+      fetchSpy.mockResolvedValue(new Response("invalid_token", { status: 401 }));
 
       const first = await (await GET()).json();
       const second = await (await GET()).json();
@@ -278,8 +261,10 @@ describe("/setup-api/ai-models/status", () => {
       expect(first.clawaiTier).toBe("pro");
       expect(first.tierSource).toBe("picker");
       expect(second.clawaiTier).toBe("pro");
-      expect(second.tierSource).toBe("portal");
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(second.tierSource).toBe("picker");
+      // Second call inside the unreachable TTL must hit the negative
+      // cache instead of re-fetching from the portal.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
 
     it("falls back to the locally-stored tier when the portal is unreachable", async () => {

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -238,19 +238,48 @@ describe("/setup-api/ai-models/status", () => {
       expect(body.tierSource).toBe("portal");
     });
 
-    it("returns clawaiTier=null on portal 403 (invalid token) and caches the verdict", async () => {
+    it("preserves localTier on portal 401/403 (auth lost, might still be paid)", async () => {
+      // Portal 401/403 is ambiguous: it can mean "user is genuinely
+      // Free" OR "token was revoked / migrated / corrupted on a still-
+      // paid account". We can't tell which from the response alone,
+      // so we fall back to localTier — the device keeps showing the
+      // user's last-known tier instead of silently downgrading to
+      // Free (which would also fire the downgrade-celebration popup).
       mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
       mockGetConfigValue.mockResolvedValue("pro");
       fetchSpy.mockResolvedValue(new Response("invalid_token", { status: 403 }));
 
+      const res = await GET();
+      const body = await res.json();
+
+      expect(body.clawaiTier).toBe("pro");
+      expect(body.tierSource).toBe("picker");
+    });
+
+    it("does not cache the auth-failure verdict — recovers on next poll", async () => {
+      // Old behaviour cached the 401/403 as a definitive null for the
+      // full 120 s TTL, so a token that recovered (re-pair, portal
+      // un-revoke, transient backend issue) couldn't be picked up
+      // until the cache expired. Now the auth-lost path returns
+      // `unreachable` which is uncached — the second poll re-tries
+      // the portal immediately and sees the fresh tier.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy
+        .mockResolvedValueOnce(new Response("invalid_token", { status: 401 }))
+        .mockResolvedValueOnce(new Response(
+          JSON.stringify({ tier: "max", deviceTier: "pro" }),
+          { status: 200 },
+        ));
+
       const first = await (await GET()).json();
       const second = await (await GET()).json();
 
-      expect(first.clawaiTier).toBeNull();
-      expect(first.tierSource).toBe("portal");
-      // 403 caches; the second request must not hit the network again.
-      expect(fetchSpy).toHaveBeenCalledTimes(1);
-      expect(second.clawaiTier).toBeNull();
+      expect(first.clawaiTier).toBe("pro");
+      expect(first.tierSource).toBe("picker");
+      expect(second.clawaiTier).toBe("pro");
+      expect(second.tierSource).toBe("portal");
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
     });
 
     it("falls back to the locally-stored tier when the portal is unreachable", async () => {


### PR DESCRIPTION
Two related post-v3.0.3 hardenings, both observed live (one on a
customer device, one on a dev box during the v3.0.3 cycle).

## 1. Codex peer-dep self-heal (`scripts/gateway-pre-start.sh`)

**Symptom on customer device:**
```
Error: Cannot find package 'openclaw' imported from
.../@openclaw/codex/dist/shared-client-…js
```

**Root cause:** `openclaw plugins install codex` writes both the
package directory *and* a `<codex>/node_modules/openclaw -> <global
openclaw>` peer-dep symlink. If something later removes the nested
`node_modules` (partial install, openclaw upgrade churn, manual
cleanup), the `package.json` remains but the peer dep is gone. Our
v3.0.3 auto-installer only checked `$CODEX_PLUGIN_DIR/package.json`,
declared the plugin "installed", and skipped repair. The plugin then
loaded but every internal import via the `openclaw` package failed at
runtime.

**Fix:** also check the nested peer-dep symlink. `-e` follows
symlinks, so both *"missing symlink"* and *"dangling symlink"*
trigger a `--force` reinstall, which rebuilds the link without
redownloading the package contents.

## 2. Portal 401/403 no longer flips badge to Free (`src/app/setup-api/ai-models/status/route.ts`)

**Symptom:** when ClawKeep auth disconnects (or the bearer is
otherwise rejected by the portal), the device flips its tier badge
to Free **and fires the downgrade-celebration popup** with a
Re-subscribe CTA — even though the user might still be on a paid
plan.

**Root cause:** `fetchPortalTier` treated 401/403 as a definitive
"user is Free" verdict and cached it for the full 120 s TTL. But the
portal returns 401/403 for several distinct cases that the response
code alone can't distinguish:
- User is genuinely Free.
- Token was revoked (admin action, account event, plan transition).
- Token migrated to a new format the device hasn't refreshed yet.
- Backend cleanup pruned the device record.

**Fix:** fall through to the existing `unreachable` branch on
401/403 instead of caching the null. Consequences:
- `clawaiAccountTier` preserves `localTier` (last known good).
- `tierSource: "picker"` (not "portal").
- Downgrade-celebration popup doesn't fire spuriously.
- `unreachable` is uncached, so the next poll re-tries the portal —
  a recovered token is picked up immediately instead of waiting out
  a stale 120 s null.

A user who legitimately downgrades still flips to Free correctly:
the portal returns `200 + tier:"free"` for that case, which goes
through `mapPortalTier` and returns `null` as before.

## Tests

Replaced the "returns clawaiTier=null on portal 403 and caches the
verdict" test with two new ones:
- `preserves localTier on portal 401/403 (auth lost, might still be paid)`
- `does not cache the auth-failure verdict — recovers on next poll`

## Verified

- **Codex resilience:** reproduced on a dev Jetson — `@openclaw/codex`
  present but nested `node_modules` removed. The new check triggers
  `--force` reinstall on gateway start, chat recovers.
- **Auth-loss handling:** covered by the two new unit tests.

Targets **beta** per workflow. After merge → beta → main release-train.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AI model tier status resolution to treat authentication failures as transient. The system now retries tier checks on subsequent attempts instead of permanently caching authentication errors.

* **Tests**
  * Updated tests to verify that authentication failures don't prevent the system from attempting to retrieve tier status on future requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->