### PR TITLE
fix(chat): use shared isSentinel() in ChatApp ack-only detection

### DIFF
--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -14,7 +14,7 @@ import { renderText } from '@/lib/chat-markdown'
 import { extractImageFilesFromClipboard } from '@/lib/clipboard'
 import { useT } from '@/lib/i18n'
 import { useChatToolCalls, ToolCallPills } from '@/lib/chat-tool-events'
-import { prettifyAssistantText } from '@/lib/chat-sentinels'
+import { prettifyAssistantText, isSentinel } from '@/lib/chat-sentinels'
 
 
 function extractText(msg: unknown): string {
@@ -253,14 +253,15 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             if (text) setStreaming(text)
           } else if (state === 'final') {
             const text = extractText(msg)
-            // Suppress NO_REPLY (protocol sentinel) and "Sent." (delivery-
-            // mirror ack) from the rendered transcript — the former is a
-            // protocol marker users shouldn't see, the latter is just a
-            // server-side acknowledgement that the real reply will follow
-            // via the chat.history refetch scheduled below. Skipping the
-            // append avoids a brief "Sent." bubble flashing on the screen
-            // before the real reply replaces it.
-            const isAckOnly = !text || /^\s*Sent\.\s*$/.test(text) || /^\s*NO_REPLY\s*$/.test(text)
+            // Suppress protocol sentinels and "Sent." (delivery-mirror ack)
+            // from the rendered transcript — the former are markers users
+            // shouldn't see, the latter is just a server-side ack that the
+            // real reply will follow via the chat.history refetch scheduled
+            // below. `isSentinel` covers NO_REPLY plus any other protocol
+            // sentinel `chat-sentinels.ts` catalogues — same shared check
+            // ChatPopup uses, so the two components can't drift on which
+            // finals count as ack-only.
+            const isAckOnly = !text || /^\s*Sent\.\s*$/.test(text) || isSentinel(text)
             if (text && !isAckOnly) {
               setMessages(prev => [...prev, { role: 'assistant', text: prettifyAssistantText(text), timestamp: Date.now() }])
             }
@@ -286,7 +287,7 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             }
           } else if (state === 'aborted' || state === 'error') {
             setStreaming(prev => {
-              if (prev.trim() && !/^\s*NO_REPLY\s*$/.test(prev)) {
+              if (prev.trim() && !isSentinel(prev)) {
                 setMessages(msgs => [...msgs, { role: 'assistant', text: prettifyAssistantText(prev), timestamp: Date.now() }])
               }
               return ''
@@ -334,7 +335,7 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
         const role = (m.role as string)?.toLowerCase()
         if (role !== 'user' && role !== 'assistant') continue
         const text = extractText(m)
-        if (!text || /^\s*NO_REPLY\s*$/.test(text)) continue
+        if (!text || isSentinel(text)) continue
         const cleaned = role === 'user' ? text.replace(/^\[[^\]]+\]\s*/, '') : prettifyAssistantText(text)
         chatMsgs.push({ role: role as 'user' | 'assistant', text: cleaned, timestamp: (m.timestamp as number) || 0 })
       }


### PR DESCRIPTION
Follow-up to CodeRabbit's review on #143.

## Summary

The ack-only detection in `ChatApp.tsx` was using a local `/^\s*NO_REPLY\s*$/` regex, which misses other protocol sentinels catalogued in `chat-sentinels.ts::PROTOCOL_SENTINEL_REPLIES` ("still here, scuttling around", "all good, boss", etc.). When one of those arrives as a `final`, the current code:

- Appends the sentinel text as a visible assistant bubble (it shouldn't).
- Skips the dedupe-guarded 3-second `chat.history` refetch (so a deferred delivery-mirror reply never surfaces).

`ChatPopup.tsx` already uses `isSentinel(text)` — this brings `ChatApp.tsx` to parity, so the two components can't drift on which finals count as ack-only.

## Changes

- `isAckOnly` now uses `isSentinel(text)` (matches ChatPopup).
- The `aborted | error` streaming-flush branch switched from inline `NO_REPLY` regex to `isSentinel`.
- `loadHistory` message filter switched from inline `NO_REPLY` regex to `isSentinel`.
- One new import on the existing `chat-sentinels` line.

## Test plan

- [ ] Smoke-test chat on a Jetson — confirm a normal reply still appears in real time, no transcript regressions.
- [ ] If you can synthesize a sentinel final (e.g. NO_REPLY, "still here, scuttling around"), confirm no bubble flashes and the deferred refetch still picks up the real reply.