### PR TITLE
fix(install): mask conflicting user-level openclaw-gateway.service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1438,6 +1438,35 @@ step_recover() {
 step_gateway_setup() {
   cp "$PROJECT_DIR/config/clawbox-gateway.service" /etc/systemd/system/
 
+  # Mask any leftover user-level openclaw-gateway.service. Standalone
+  # OpenClaw (and some older `openclaw gateway install` paths) dropped a
+  # unit file at ~/.config/systemd/user/openclaw-gateway.service that
+  # competes with our system unit for port 18789. When both wake up,
+  # operators get port-ownership conflicts, restart churn, and misleading
+  # failed-status messages on the wrong unit. ClawBox owns
+  # `clawbox-gateway.service` as the single source of truth; the user
+  # variant has no role on an appliance install. Replacing the unit file
+  # with a symlink to /dev/null is the on-disk equivalent of
+  # `systemctl --user mask` — works without needing a live user session.
+  # Idempotent: if it's already masked we leave it alone. Reported via
+  # ID-Robots/clawbox#141.
+  local USER_SYSTEMD_DIR="$CLAWBOX_HOME/.config/systemd/user"
+  local USER_GATEWAY_UNIT="$USER_SYSTEMD_DIR/openclaw-gateway.service"
+  if [ -e "$USER_GATEWAY_UNIT" ] || [ -L "$USER_GATEWAY_UNIT" ]; then
+    local CURRENT_TARGET
+    CURRENT_TARGET=$(readlink "$USER_GATEWAY_UNIT" 2>/dev/null || echo "")
+    if [ "$CURRENT_TARGET" = "/dev/null" ]; then
+      echo "  User-level openclaw-gateway.service already masked"
+    else
+      echo "  Masking conflicting user-level openclaw-gateway.service"
+      mkdir -p "$USER_SYSTEMD_DIR"
+      chown "$CLAWBOX_USER:$CLAWBOX_USER" "$USER_SYSTEMD_DIR"
+      rm -f "$USER_GATEWAY_UNIT"
+      ln -s /dev/null "$USER_GATEWAY_UNIT"
+      chown -h "$CLAWBOX_USER:$CLAWBOX_USER" "$USER_GATEWAY_UNIT" 2>/dev/null || true
+    fi
+  fi
+
   # IPv4-first DNS for the gateway. Without this, on networks where the
   # ISP advertises an IPv6 prefix but doesn't actually route public v6
   # traffic (common on home/SMB networks), every Node `fetch` to a


### PR DESCRIPTION
Fixes #141.

Reported by @jamesachurchill — thanks for the detailed write-up.

## Problem

A user-level `openclaw-gateway.service` (created by standalone OpenClaw, or by older `openclaw gateway install` paths) can coexist with our system-level `clawbox-gateway.service`. Both target port `18789` and both want to be the gateway owner. When that happens:

- Port-ownership conflict / restart churn
- Misleading `failed` status on the user unit while the real listener is the system one
- `openclaw doctor` and other repair tooling steer operators to debug the wrong unit

ClawBox owns `clawbox-gateway.service` as the single source of truth on appliance installs; the user variant has no role and should never be running. The reporter's stable workaround was manual masking — operator knowledge customers shouldn't need.

## Why this happens — and why it's not visible on dev devices

The user-level unit predates ClawBox by years; it was OpenClaw's native deployment shape back when OpenClaw was just a dev-laptop CLI. Once a customer's Jetson has ever run standalone OpenClaw, the unit file sits in `~/.config/systemd/user/` forever — ClawBox's installer never owned that path, so nothing has been removing it. Our internal test devices were all clean-installed straight to ClawBox, so this never surfaced on our side.

## Fix

`step_gateway_setup` (right next to the IPv4-first DNS drop-in we just added in v3.0.5) now:

1. Probes `~/.config/systemd/user/openclaw-gateway.service`
2. If it exists and isn't already a symlink to `/dev/null`, replaces it with `ln -s /dev/null` — the on-disk equivalent of `systemctl --user mask`, no live user session required
3. If it's already masked, leaves it alone (idempotent)

The original file isn't deleted, just neutralised — a developer who wants standalone OpenClaw back can `unmask` it manually. Diagnostics endpoint (a separate suggestion from the issue) deferred to a follow-up.

## Verified live on `clawbox.local` (v3.0.5 Jetson)

Created a fake competing unit, then ran the patched step twice:

| Run | Pre-state | Output | Post-state |
|-----|-----------|--------|-----------|
| 1st | Real file (97 bytes) | `Masking conflicting user-level openclaw-gateway.service` | symlink → `/dev/null` ✓ |
| 2nd | symlink → `/dev/null` | `User-level openclaw-gateway.service already masked` | unchanged ✓ |

## Test plan

- [ ] Pull on a Jetson that has a leftover user-level `openclaw-gateway.service`. Run System Update or `sudo bash install.sh --step gateway_setup`. Confirm the unit is masked, system gateway still serves on `:18789`, no port conflicts.
- [ ] Pull on a clean Jetson (no leftover user unit). Confirm the step exits silently, no errors, no spurious file creation.
- [ ] Run `sudo bash install.sh --step gateway_setup` a second time. Confirm the idempotent "already masked" log line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced installation setup to handle conflicting service configurations more gracefully, ensuring a more reliable setup process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/145?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->