### PR TITLE
fix(install): mask conflicting user-level openclaw-gateway.service

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1438,6 +1438,35 @@ step_recover() {
 step_gateway_setup() {
   cp "$PROJECT_DIR/config/clawbox-gateway.service" /etc/systemd/system/
 
+  # Mask any leftover user-level openclaw-gateway.service. Standalone
+  # OpenClaw (and some older `openclaw gateway install` paths) dropped a
+  # unit file at ~/.config/systemd/user/openclaw-gateway.service that
+  # competes with our system unit for port 18789. When both wake up,
+  # operators get port-ownership conflicts, restart churn, and misleading
+  # failed-status messages on the wrong unit. ClawBox owns
+  # `clawbox-gateway.service` as the single source of truth; the user
+  # variant has no role on an appliance install. Replacing the unit file
+  # with a symlink to /dev/null is the on-disk equivalent of
+  # `systemctl --user mask` — works without needing a live user session.
+  # Idempotent: if it's already masked we leave it alone. Reported via
+  # ID-Robots/clawbox#141.
+  local USER_SYSTEMD_DIR="$CLAWBOX_HOME/.config/systemd/user"
+  local USER_GATEWAY_UNIT="$USER_SYSTEMD_DIR/openclaw-gateway.service"
+  if [ -e "$USER_GATEWAY_UNIT" ] || [ -L "$USER_GATEWAY_UNIT" ]; then
+    local CURRENT_TARGET
+    CURRENT_TARGET=$(readlink "$USER_GATEWAY_UNIT" 2>/dev/null || echo "")
+    if [ "$CURRENT_TARGET" = "/dev/null" ]; then
+      echo "  User-level openclaw-gateway.service already masked"
+    else
+      echo "  Masking conflicting user-level openclaw-gateway.service"
+      mkdir -p "$USER_SYSTEMD_DIR"
+      chown "$CLAWBOX_USER:$CLAWBOX_USER" "$USER_SYSTEMD_DIR"
+      rm -f "$USER_GATEWAY_UNIT"
+      ln -s /dev/null "$USER_GATEWAY_UNIT"
+      chown -h "$CLAWBOX_USER:$CLAWBOX_USER" "$USER_GATEWAY_UNIT" 2>/dev/null || true
+    fi
+  fi
+
   # IPv4-first DNS for the gateway. Without this, on networks where the
   # ISP advertises an IPv6 prefix but doesn't actually route public v6
   # traffic (common on home/SMB networks), every Node `fetch` to a

--- a/install.sh
+++ b/install.sh
@@ -1459,6 +1459,18 @@ step_gateway_setup() {
       echo "  User-level openclaw-gateway.service already masked"
     else
       echo "  Masking conflicting user-level openclaw-gateway.service"
+      # Stop a running user-level instance first so port 18789 is freed
+      # immediately — otherwise the old process keeps holding the port
+      # until the user's next login session, defeating this run.
+      # Non-fatal: no active session yet, or the unit isn't running, both
+      # are fine and the on-disk mask still takes effect.
+      local CLAWBOX_UID
+      CLAWBOX_UID=$(id -u "$CLAWBOX_USER" 2>/dev/null || echo "")
+      if [ -n "$CLAWBOX_UID" ]; then
+        sudo -u "$CLAWBOX_USER" \
+          XDG_RUNTIME_DIR="/run/user/$CLAWBOX_UID" \
+          systemctl --user stop openclaw-gateway.service 2>/dev/null || true
+      fi
       mkdir -p "$USER_SYSTEMD_DIR"
       chown "$CLAWBOX_USER:$CLAWBOX_USER" "$USER_SYSTEMD_DIR"
       rm -f "$USER_GATEWAY_UNIT"


### PR DESCRIPTION
## Summary

Reported in #141 by @jamesachurchill: on installs where standalone OpenClaw (or an older `openclaw gateway install` path) dropped a user-level unit at `~/.config/systemd/user/openclaw-gateway.service`, both that user service AND ClawBox's system-level `clawbox-gateway.service` try to bind port 18789. Result: port-ownership conflicts, restart churn, and misleading failed-status messages on the wrong unit.

ClawBox owns `clawbox-gateway.service` as the single source of truth on an appliance install — the user variant has no role.

## Fix

In `install.sh`'s `step_gateway_setup`, replace `~/.config/systemd/user/openclaw-gateway.service` with a symlink to `/dev/null` (on-disk equivalent of `systemctl --user mask`, works without a live user session).

After CodeRabbit feedback on the original PR (#145), also **stop a running user-level instance first** via `sudo -u clawbox systemctl --user stop` with `XDG_RUNTIME_DIR=/run/user/<uid>` — otherwise the old process keeps holding port 18789 until the user's next login, defeating this run.

Idempotent:
- If already masked (symlink to `/dev/null`), no-op
- Stop is non-fatal: gracefully handles no active user session or unit not running

## Why this PR replaces #145

GitHub kept #145 pinned to `7c855c3` (the pre-branch-deletion HEAD) and refused to re-attach to the recreated branch after I pushed the CodeRabbit fix. Close+reopen, empty commits, and real pushes all left `head_sha` frozen. Fresh PR is cleaner than fighting the index.

## Test plan

- [ ] On a Jetson with a stale user-level `openclaw-gateway.service` running: verify `step_gateway_setup` stops the user service, masks the file, and the system unit binds port 18789 cleanly on next start
- [ ] On a fresh device with no user-level unit: verify the masking step is a no-op (no errors, no spurious output)
- [ ] On an already-masked device: verify "already masked" branch and skip