### PR TITLE
fix(openclaw): pin @openclaw/codex plugin to the core version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -744,6 +744,11 @@ step_openclaw_install() {
   # plugins do. Failures are non-fatal: a missing-from-npm plugin
   # shouldn't roll back the whole update; gateway-pre-start.sh will retry
   # on next boot. Gateway restart happens later in step_gateway_setup.
+  # Emit "<id>\t<npm-package>" per external plugin. The npm package is
+  # derived from rootDir (.../node_modules/@scope/name -> @scope/name) so we
+  # can pin @openclaw/* plugins to $TARGET. Reinstalling by bare id resolves
+  # @latest, which is exactly how @openclaw/codex drifted ahead of the
+  # pinned core and crashed every Codex chat.
   local INSTALLED_PLUGINS
   INSTALLED_PLUGINS=$(as_clawbox -H "$OPENCLAW_BIN" plugins list --json 2>/dev/null \
     | python3 -c '
@@ -754,15 +759,30 @@ except Exception:
     sys.exit(0)
 for p in d.get("plugins", []):
     pid = p.get("id")
-    if pid and p.get("origin") != "bundled":
-        print(pid)
+    if not pid or p.get("origin") == "bundled":
+        continue
+    root = p.get("rootDir") or p.get("source") or ""
+    pkg = ""
+    if "node_modules/" in root:
+        tail = root.split("node_modules/", 1)[1].split("/")
+        if tail and tail[0].startswith("@") and len(tail) >= 2:
+            pkg = tail[0] + "/" + tail[1]
+        elif tail:
+            pkg = tail[0]
+    print(pid + "\t" + pkg)
 ' 2>/dev/null)
   if [ -n "$INSTALLED_PLUGINS" ]; then
     echo "  Refreshing OpenClaw plugins to match core $TARGET:"
-    while IFS= read -r plugin; do
+    while IFS=$'\t' read -r plugin pkg; do
       [ -z "$plugin" ] && continue
-      echo "    - $plugin"
-      if ! as_clawbox -H "$OPENCLAW_BIN" plugins install "$plugin" --force >/dev/null 2>&1; then
+      # Pin @openclaw/* plugins to the core target; others reinstall by id
+      # (they version independently). $TARGET is the same pin the core used.
+      local spec="$plugin"
+      case "$pkg" in
+        @openclaw/*) spec="$pkg@$TARGET" ;;
+      esac
+      echo "    - $spec"
+      if ! as_clawbox -H "$OPENCLAW_BIN" plugins install "$spec" --force >/dev/null 2>&1; then
         echo "      WARN: refresh failed (non-fatal; gateway-pre-start will retry on next boot)"
       fi
     done <<< "$INSTALLED_PLUGINS"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -22,6 +22,19 @@ OPENCLAW_BIN="/home/clawbox/.npm-global/bin/openclaw"
 OPENCLAW_CONFIG="/home/clawbox/.openclaw/openclaw.json"
 HOSTNAME_ENV="/home/clawbox/clawbox/data/hostname.env"
 
+# Pinned OpenClaw target — external plugins (e.g. @openclaw/codex) must stay
+# locked to the same version as the core, or they drift ahead via @latest and
+# crash at runtime against the pinned core. Read from the repo pin file, same
+# source install.sh and updater.ts use. Empty = pin unknown, fall back to the
+# unpinned alias (preserves old behaviour rather than risk skipping a repair).
+OPENCLAW_TARGET=""
+OPENCLAW_PIN_FILE="/home/clawbox/clawbox/config/openclaw-target.txt"
+if [ -n "${OPENCLAW_PIN_VERSION:-}" ]; then
+  OPENCLAW_TARGET="${OPENCLAW_PIN_VERSION}"
+elif [ -f "$OPENCLAW_PIN_FILE" ]; then
+  OPENCLAW_TARGET=$(head -1 "$OPENCLAW_PIN_FILE" | awk '{print $1}')
+fi
+
 if [ ! -x "$OPENCLAW_BIN" ]; then
   exit 0
 fi
@@ -344,10 +357,34 @@ PY
 # `--force` on install rebuilds the symlink without reinstalling
 # unnecessary content when the package directory is already there.
 CODEX_PEER_DEP="$CODEX_PLUGIN_DIR/node_modules/openclaw/package.json"
-if [ "$NEEDS_CODEX_PLUGIN" = "1" ] && { [ ! -f "$CODEX_PLUGIN_DIR/package.json" ] || [ ! -e "$CODEX_PEER_DEP" ]; }; then
-  echo "  Installing/repairing @openclaw/codex runtime plugin (codex model selected)…"
-  "$OPENCLAW_BIN" plugins install codex --force >/dev/null 2>&1 \
-    || echo "  WARN: openclaw plugins install codex failed; Codex chats will fail until resolved"
+CODEX_NEEDS_INSTALL=0
+CODEX_INSTALL_REASON=""
+if [ "$NEEDS_CODEX_PLUGIN" = "1" ]; then
+  if [ ! -f "$CODEX_PLUGIN_DIR/package.json" ] || [ ! -e "$CODEX_PEER_DEP" ]; then
+    CODEX_NEEDS_INSTALL=1
+    CODEX_INSTALL_REASON="missing or peer-dep broken"
+  elif [ -n "$OPENCLAW_TARGET" ]; then
+    # Version-skew guard. Older builds ran `plugins install codex`, which
+    # resolves @latest — so the codex plugin drifts ahead of the pinned core
+    # and every Codex chat crashes with "_diagnosticRuntime.
+    # createDiagnosticTraceContextFromActiveScope is not a function" (the
+    # newer plugin calls a runtime API the pinned core doesn't expose).
+    # Reinstall at the pinned version whenever the two differ.
+    CODEX_INSTALLED_VER=$(python3 -c "import json; print(json.load(open('$CODEX_PLUGIN_DIR/package.json')).get('version',''))" 2>/dev/null || echo "")
+    if [ "$CODEX_INSTALLED_VER" != "$OPENCLAW_TARGET" ]; then
+      CODEX_NEEDS_INSTALL=1
+      CODEX_INSTALL_REASON="version $CODEX_INSTALLED_VER != core target $OPENCLAW_TARGET"
+    fi
+  fi
+fi
+if [ "$CODEX_NEEDS_INSTALL" = "1" ]; then
+  echo "  Installing/repairing @openclaw/codex runtime plugin ($CODEX_INSTALL_REASON)…"
+  # Pin to the core target via the full scoped npm spec; fall back to the
+  # bare alias only when the pin is unknown, so a needed repair still happens.
+  CODEX_SPEC="codex"
+  [ -n "$OPENCLAW_TARGET" ] && CODEX_SPEC="@openclaw/codex@$OPENCLAW_TARGET"
+  "$OPENCLAW_BIN" plugins install "$CODEX_SPEC" --force >/dev/null 2>&1 \
+    || echo "  WARN: openclaw plugins install $CODEX_SPEC failed; Codex chats will fail until resolved"
 fi
 
 # Ensure the per-install MCP bearer token exists and is wired into the


### PR DESCRIPTION
## Problem

Two customers on the **latest ClawBox (v3.0.5)** hit this when using OpenAI GPT / Codex:

```
Agent failed before reply: (0 , _diagnosticRuntime.createDiagnosticTraceContextFromActiveScope) is not a function
```

Root cause: **we pin the OpenClaw core but not the codex plugin.**

- Core is pinned via `config/openclaw-target.txt` (currently `2026.5.22`).
- But `gateway-pre-start.sh` (and `install.sh`'s refresh loop) installed the plugin with the **bare alias** `openclaw plugins install codex`, which resolves `@latest`.
- npm `@latest` for `@openclaw/codex` is now `2026.5.27` — ahead of the pinned core.
- The newer plugin calls `_diagnosticRuntime.createDiagnosticTraceContextFromActiveScope`, an API the pinned `2026.5.22` core doesn't expose → every Codex chat crashes.

Confirmed by package inspection: `@openclaw/codex@2026.5.22` (matches core) does **not** call that function; `@openclaw/codex@2026.5.27` does.

The nano in the lab never reproduced it because it runs DeepSeek (ClawBox AI) and never installs the codex plugin. Customers who pick OpenAI/Codex do — and a "You're up to date" box can't self-heal through the updater.

## Fix

**`scripts/gateway-pre-start.sh`** (runtime self-heal, runs on every gateway start):
- Reads the `openclaw-target.txt` pin into `OPENCLAW_TARGET` (mirrors `install.sh` / `updater.ts`).
- Codex reinstall now also triggers on **version mismatch**, not just missing/broken plugin — this auto-corrects already-drifted boxes.
- Installs the scoped pinned spec `@openclaw/codex@<target>` instead of the bare `@latest` alias. Falls back to the alias only if the pin is unknown.

**`install.sh`** (update-time plugin refresh):
- Derives each plugin's npm package from `rootDir` and pins `@openclaw/*` plugins to `@$TARGET` instead of reinstalling by bare id.

**Version bump 3.0.5 → 3.0.6** so devices that already show "up to date" receive the fix through the updater.

## Validation

On a real Jetson (core 2026.5.22):
```
reproduce → installed @openclaw/codex@2026.5.27 (drifted ahead)
heal path → detected "version 2026.5.27 != core target 2026.5.22"
          → installed @openclaw/codex@2026.5.22
result    → codex realigned to 2026.5.22, gateway 200
```

After this ships, every drifted box self-heals on the next gateway restart/reboot — no manual Terminal fix needed for future cases.

## Test plan

- [x] Validated reproduce → self-heal cycle on a Jetson
- [x] `bash -n` syntax check on both scripts
- [x] `/simplify` review (reuse / quality / efficiency) — pin-read duplication across the 3 scripts is deliberate (no shared boot-time lib); hot path adds only a `head|awk` on non-codex devices
- [ ] CI / e2e-install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bump to 3.0.6

* **Bug Fixes**
  * Improved plugin installation logic for more reliable external plugin management
  * Enhanced version pinning to ensure consistency across core plugins
  * Better error handling during plugin refresh operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->