### PR TITLE
fix(openclaw): pin @openclaw/codex plugin to the core version (#152)

### DIFF
--- a/e2e-install/70-browser.spec.ts
+++ b/e2e-install/70-browser.spec.ts
@@ -73,15 +73,15 @@ test.describe("browser + VNC happy path", () => {
     expect(state.browser.cdpReady).toBe(true);
   });
 
-  test("launch session and navigate to openclawhardware.dev", async () => {
+  test("launch session and navigate to clawbox.tech", async () => {
     test.setTimeout(180_000);
-    // openclawhardware.dev is used instead of youtube.com to avoid flakiness
+    // clawbox.tech is used instead of youtube.com to avoid flakiness
     // from YouTube's bot detection / region gating. It's also the site this
     // product ships with, so a navigation failure here points at something
     // genuinely broken in ClawBox rather than the target site.
-    const launched = await browserLaunch("https://openclawhardware.dev/");
+    const launched = await browserLaunch("https://clawbox.tech/");
     sessionId = launched.sessionId;
-    expect(launched.url).toContain("openclawhardware.dev");
+    expect(launched.url).toContain("clawbox.tech");
     expect(launched.title.length).toBeGreaterThan(0);
     expect(launched.screenshot).toBeTruthy();
   });

--- a/install.sh
+++ b/install.sh
@@ -744,6 +744,11 @@ step_openclaw_install() {
   # plugins do. Failures are non-fatal: a missing-from-npm plugin
   # shouldn't roll back the whole update; gateway-pre-start.sh will retry
   # on next boot. Gateway restart happens later in step_gateway_setup.
+  # Emit "<id>\t<npm-package>" per external plugin. The npm package is
+  # derived from rootDir (.../node_modules/@scope/name -> @scope/name) so we
+  # can pin @openclaw/* plugins to $TARGET. Reinstalling by bare id resolves
+  # @latest, which is exactly how @openclaw/codex drifted ahead of the
+  # pinned core and crashed every Codex chat.
   local INSTALLED_PLUGINS
   INSTALLED_PLUGINS=$(as_clawbox -H "$OPENCLAW_BIN" plugins list --json 2>/dev/null \
     | python3 -c '
@@ -754,15 +759,30 @@ except Exception:
     sys.exit(0)
 for p in d.get("plugins", []):
     pid = p.get("id")
-    if pid and p.get("origin") != "bundled":
-        print(pid)
+    if not pid or p.get("origin") == "bundled":
+        continue
+    root = p.get("rootDir") or p.get("source") or ""
+    pkg = ""
+    if "node_modules/" in root:
+        tail = root.split("node_modules/", 1)[1].split("/")
+        if tail and tail[0].startswith("@") and len(tail) >= 2:
+            pkg = tail[0] + "/" + tail[1]
+        elif tail:
+            pkg = tail[0]
+    print(pid + "\t" + pkg)
 ' 2>/dev/null)
   if [ -n "$INSTALLED_PLUGINS" ]; then
     echo "  Refreshing OpenClaw plugins to match core $TARGET:"
-    while IFS= read -r plugin; do
+    while IFS=$'\t' read -r plugin pkg; do
       [ -z "$plugin" ] && continue
-      echo "    - $plugin"
-      if ! as_clawbox -H "$OPENCLAW_BIN" plugins install "$plugin" --force >/dev/null 2>&1; then
+      # Pin @openclaw/* plugins to the core target; others reinstall by id
+      # (they version independently). $TARGET is the same pin the core used.
+      local spec="$plugin"
+      case "$pkg" in
+        @openclaw/*) spec="$pkg@$TARGET" ;;
+      esac
+      echo "    - $spec"
+      if ! as_clawbox -H "$OPENCLAW_BIN" plugins install "$spec" --force >/dev/null 2>&1; then
         echo "      WARN: refresh failed (non-fatal; gateway-pre-start will retry on next boot)"
       fi
     done <<< "$INSTALLED_PLUGINS"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -22,6 +22,19 @@ OPENCLAW_BIN="/home/clawbox/.npm-global/bin/openclaw"
 OPENCLAW_CONFIG="/home/clawbox/.openclaw/openclaw.json"
 HOSTNAME_ENV="/home/clawbox/clawbox/data/hostname.env"
 
+# Pinned OpenClaw target — external plugins (e.g. @openclaw/codex) must stay
+# locked to the same version as the core, or they drift ahead via @latest and
+# crash at runtime against the pinned core. Read from the repo pin file, same
+# source install.sh and updater.ts use. Empty = pin unknown, fall back to the
+# unpinned alias (preserves old behaviour rather than risk skipping a repair).
+OPENCLAW_TARGET=""
+OPENCLAW_PIN_FILE="/home/clawbox/clawbox/config/openclaw-target.txt"
+if [ -n "${OPENCLAW_PIN_VERSION:-}" ]; then
+  OPENCLAW_TARGET="${OPENCLAW_PIN_VERSION}"
+elif [ -f "$OPENCLAW_PIN_FILE" ]; then
+  OPENCLAW_TARGET=$(head -1 "$OPENCLAW_PIN_FILE" | awk '{print $1}')
+fi
+
 if [ ! -x "$OPENCLAW_BIN" ]; then
   exit 0
 fi
@@ -344,10 +357,34 @@ PY
 # `--force` on install rebuilds the symlink without reinstalling
 # unnecessary content when the package directory is already there.
 CODEX_PEER_DEP="$CODEX_PLUGIN_DIR/node_modules/openclaw/package.json"
-if [ "$NEEDS_CODEX_PLUGIN" = "1" ] && { [ ! -f "$CODEX_PLUGIN_DIR/package.json" ] || [ ! -e "$CODEX_PEER_DEP" ]; }; then
-  echo "  Installing/repairing @openclaw/codex runtime plugin (codex model selected)…"
-  "$OPENCLAW_BIN" plugins install codex --force >/dev/null 2>&1 \
-    || echo "  WARN: openclaw plugins install codex failed; Codex chats will fail until resolved"
+CODEX_NEEDS_INSTALL=0
+CODEX_INSTALL_REASON=""
+if [ "$NEEDS_CODEX_PLUGIN" = "1" ]; then
+  if [ ! -f "$CODEX_PLUGIN_DIR/package.json" ] || [ ! -e "$CODEX_PEER_DEP" ]; then
+    CODEX_NEEDS_INSTALL=1
+    CODEX_INSTALL_REASON="missing or peer-dep broken"
+  elif [ -n "$OPENCLAW_TARGET" ]; then
+    # Version-skew guard. Older builds ran `plugins install codex`, which
+    # resolves @latest — so the codex plugin drifts ahead of the pinned core
+    # and every Codex chat crashes with "_diagnosticRuntime.
+    # createDiagnosticTraceContextFromActiveScope is not a function" (the
+    # newer plugin calls a runtime API the pinned core doesn't expose).
+    # Reinstall at the pinned version whenever the two differ.
+    CODEX_INSTALLED_VER=$(python3 -c "import json; print(json.load(open('$CODEX_PLUGIN_DIR/package.json')).get('version',''))" 2>/dev/null || echo "")
+    if [ "$CODEX_INSTALLED_VER" != "$OPENCLAW_TARGET" ]; then
+      CODEX_NEEDS_INSTALL=1
+      CODEX_INSTALL_REASON="version $CODEX_INSTALLED_VER != core target $OPENCLAW_TARGET"
+    fi
+  fi
+fi
+if [ "$CODEX_NEEDS_INSTALL" = "1" ]; then
+  echo "  Installing/repairing @openclaw/codex runtime plugin ($CODEX_INSTALL_REASON)…"
+  # Pin to the core target via the full scoped npm spec; fall back to the
+  # bare alias only when the pin is unknown, so a needed repair still happens.
+  CODEX_SPEC="codex"
+  [ -n "$OPENCLAW_TARGET" ] && CODEX_SPEC="@openclaw/codex@$OPENCLAW_TARGET"
+  "$OPENCLAW_BIN" plugins install "$CODEX_SPEC" --force >/dev/null 2>&1 \
+    || echo "  WARN: openclaw plugins install $CODEX_SPEC failed; Codex chats will fail until resolved"
 fi
 
 # Ensure the per-install MCP bearer token exists and is wired into the


### PR DESCRIPTION
We pin the OpenClaw core (config/openclaw-target.txt) but installed the codex plugin unpinned — `openclaw plugins install codex` resolves @latest. So the plugin drifts ahead of the pinned core and every Codex chat crashes with "_diagnosticRuntime.createDiagnosticTraceContextFrom ActiveScope is not a function" (the newer plugin calls a runtime API the pinned core doesn't expose). Two customers on the latest ClawBox hit this; "You're up to date" boxes can't self-heal via the updater.

- gateway-pre-start.sh: read the openclaw-target pin; reinstall codex when its version != the core target (not just when missing/broken); install the scoped pinned spec @openclaw/codex@<target> instead of the bare @latest alias. Drifted boxes now self-heal on next gateway start.
- install.sh: the plugin-refresh loop derives each plugin's npm package from rootDir and pins @openclaw/* plugins to $TARGET instead of reinstalling by bare id (which also resolved @latest).
- bump version 3.0.5 -> 3.0.6 so already-current devices receive the fix.

Validated on a Jetson: forced codex to 2026.5.27 against core 2026.5.22, ran the heal path, confirmed it detected the mismatch and realigned to 2026.5.22.

## Summary

<!-- What does this PR change and why? Link related issues: Fixes #123 -->

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation / tooling
- [ ] Other: ___

## How was this tested?

<!-- Commands, steps, or hardware used (e.g. Jetson Orin Nano, x64 dev install). -->

- [ ] `bun run lint` passes
- [ ] `bun run test` passes
- [ ] `bun run build` succeeds
- [ ] Manually verified on device / dev install

## Checklist

- [ ] Branch is up to date with the target branch
- [ ] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] No secrets, tokens, or credentials committed
- [ ] Added/updated tests where it makes sense
- [ ] Updated docs where user-facing behavior changed

## Screenshots / logs (if UI or runtime change)

<!-- Drop images or terminal output here. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin refresh/install behavior to better preserve compatibility and avoid disruptive reinstalls; non-fatal refresh failures are retained and reported.
  * Enhanced detection and repair for runtime version skew, reinstalling when pinned versions diverge and warning when installs fail.

* **Chores**
  * Package version bumped to 3.0.6

* **Tests**
  * Updated browser test to verify launch against the production URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/153?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->