### PR TITLE
test(e2e-install): navigate to clawbox.tech, not the old domain

### DIFF
--- a/e2e-install/70-browser.spec.ts
+++ b/e2e-install/70-browser.spec.ts
@@ -73,15 +73,17 @@ test.describe("browser + VNC happy path", () => {
     expect(state.browser.cdpReady).toBe(true);
   });
 
-  test("launch session and navigate to openclawhardware.dev", async () => {
+  test("launch session and navigate to clawbox.tech", async () => {
     test.setTimeout(180_000);
-    // openclawhardware.dev is used instead of youtube.com to avoid flakiness
-    // from YouTube's bot detection / region gating. It's also the site this
+    // clawbox.tech is used instead of youtube.com to avoid flakiness from
+    // YouTube's bot detection / region gating. It's also the site this
     // product ships with, so a navigation failure here points at something
     // genuinely broken in ClawBox rather than the target site.
-    const launched = await browserLaunch("https://openclawhardware.dev/");
+    // (openclawhardware.dev 308-redirects here, so navigate to the canonical
+    // host directly to avoid asserting on the pre-redirect URL.)
+    const launched = await browserLaunch("https://clawbox.tech/");
     sessionId = launched.sessionId;
-    expect(launched.url).toContain("openclawhardware.dev");
+    expect(launched.url).toContain("clawbox.tech");
     expect(launched.title.length).toBeGreaterThan(0);
     expect(launched.screenshot).toBeTruthy();
   });


### PR DESCRIPTION
## Why

`openclawhardware.dev` now **308-redirects to `clawbox.tech`** (permanent). The browser e2e test launches `https://openclawhardware.dev/` and asserts `launched.url` contains the old domain — but the browser follows the redirect, so the final URL is `https://clawbox.tech/` and the assertion fails. This is the only test that breaks on the redirect (the clawkeep/app-store specs use mocks or survive the GET redirect), and it's currently the **sole blocker on the beta→main promotion #153** (the codex-pin fix).

## Change

`e2e-install/70-browser.spec.ts` — navigate directly to the canonical `clawbox.tech` and assert on it. Test intent (browser launches → navigates → returns url/title/screenshot) is unchanged. One file, 7 lines.

## Scope note

This only fixes the *test*. The broader `openclawhardware.dev → clawbox.tech` migration touches ~30 files including production code (`src/app/setup-api/ai-models/clawai/poll/route.ts`, portal/OAuth URLs in `next.config.ts`, etc.). That's deliberately **out of scope here** and needs its own migration PR + verification that ClawBox AI activation works against the new domain (the 308 may not survive POST/auth). Flagging separately.

## Test plan

- [ ] e2e-install green on this branch
- [ ] Once merged to beta, re-run #153's checks → unblocks the codex-pin promotion to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated browser integration test to target a new host for verification purposes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->