### PR TITLE
fix(wifi+chat): reliable setup-wizard scan + gateway auth-rejection backoff

### DIFF
--- a/scripts/start-ap.sh
+++ b/scripts/start-ap.sh
@@ -96,9 +96,38 @@ wait_for_interface() {
 # pick their network from a list instead of typing the SSID manually.
 SCAN_CACHE="/home/clawbox/clawbox/data/wifi-scan-cache.json"
 echo "[AP] Scanning for nearby WiFi networks before starting AP..."
-nmcli device wifi rescan ifname "$IFACE" 2>/dev/null || true
-sleep 2
-SCAN_OUTPUT=$(nmcli -t -f SSID,SIGNAL,SECURITY,FREQ device wifi list ifname "$IFACE" 2>/dev/null || true)
+# Make sure the interface is actually up before scanning — early in boot it may
+# still be initializing, and scanning a down interface returns nothing.
+wait_for_interface || echo "[AP] Continuing pre-scan despite interface timeout"
+# nmcli populates scan results asynchronously after a rescan, so a fixed short
+# sleep often reads an empty list (the radio was also just used for the saved-WiFi
+# connect attempts above and needs a moment to settle). Re-trigger the rescan and
+# poll the list until real networks appear, up to PRE_AP_SCAN_TIMEOUT seconds.
+SCAN_OUTPUT=""
+PRE_AP_SCAN_TIMEOUT="${PRE_AP_SCAN_TIMEOUT:-20}"
+scan_deadline=$((SECONDS + PRE_AP_SCAN_TIMEOUT))
+scan_attempt=0
+while :; do
+  scan_attempt=$((scan_attempt + 1))
+  # rescan can fail if one ran very recently ("scanning not allowed"); ignore —
+  # the list still reflects the most recent completed scan.
+  nmcli device wifi rescan ifname "$IFACE" 2>/dev/null || true
+  sleep 3
+  SCAN_OUTPUT=$(nmcli -t -f SSID,SIGNAL,SECURITY,FREQ device wifi list ifname "$IFACE" 2>/dev/null || true)
+  # Count entries with a non-empty SSID that isn't our own AP. ($1 is an
+  # approximation when an SSID contains ':', but it's good enough to decide
+  # "did we see anything real yet".)
+  found=$(printf '%s\n' "$SCAN_OUTPUT" | awk -F: -v our="$SSID" 'NF>=4 && $1!="" && $1!=our {c++} END {print c+0}')
+  if [ "$found" -gt 0 ]; then
+    echo "[AP] Pre-scan found $found network(s) on attempt $scan_attempt"
+    break
+  fi
+  if [ "$SECONDS" -ge "$scan_deadline" ]; then
+    echo "[AP] Pre-scan found no networks after ${PRE_AP_SCAN_TIMEOUT}s ($scan_attempt attempts)"
+    break
+  fi
+  echo "[AP] Pre-scan attempt $scan_attempt empty, retrying..."
+done
 if [ -n "$SCAN_OUTPUT" ]; then
   # Parse nmcli terse output into JSON array
   echo "$SCAN_OUTPUT" | awk -F: -v our_ssid="$SSID" '

--- a/scripts/start-ap.sh
+++ b/scripts/start-ap.sh
@@ -105,6 +105,13 @@ wait_for_interface || echo "[AP] Continuing pre-scan despite interface timeout"
 # poll the list until real networks appear, up to PRE_AP_SCAN_TIMEOUT seconds.
 SCAN_OUTPUT=""
 PRE_AP_SCAN_TIMEOUT="${PRE_AP_SCAN_TIMEOUT:-20}"
+# Validate before arithmetic: a non-numeric override would make the $((...))
+# below a syntax error and abort the whole script under `set -euo pipefail`,
+# which would stop the AP from coming up at all.
+if ! [[ "$PRE_AP_SCAN_TIMEOUT" =~ ^[0-9]+$ ]]; then
+  echo "[AP] Invalid PRE_AP_SCAN_TIMEOUT='$PRE_AP_SCAN_TIMEOUT'; defaulting to 20"
+  PRE_AP_SCAN_TIMEOUT=20
+fi
 scan_deadline=$((SECONDS + PRE_AP_SCAN_TIMEOUT))
 scan_attempt=0
 while :; do

--- a/src/app/setup-api/gateway/ws-config/route.ts
+++ b/src/app/setup-api/gateway/ws-config/route.ts
@@ -41,9 +41,15 @@ export async function GET(request: NextRequest) {
   // upgrade proxy forwards these WS upgrades to the OpenClaw gateway on 18789,
   // which keeps the flow working on the LAN, through the Cloudflare tunnel,
   // and under HTTPS (no mixed-content, no external port exposure).
-  return NextResponse.json({
-    wsUrl: `${scheme}://${host}`,
-    token: token || "",
-    model,
-  });
+  return NextResponse.json(
+    {
+      wsUrl: `${scheme}://${host}`,
+      token: token || "",
+      model,
+    },
+    // Never cache: this response carries the live gateway auth token, which can
+    // be regenerated (per-device reseed, post-update). A cached copy would make
+    // clients replay a stale token and get rejected with "token mismatch".
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -562,7 +562,11 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     let token: string
     let wsUrl: string
     try {
-      const res = await fetch('/setup-api/gateway/ws-config')
+      // no-store: the gateway token can be regenerated (per-device reseed, a
+      // settings change, post-update). A cached ws-config response would replay
+      // a stale token on every reconnect and the gateway would reject it with
+      // "token mismatch" forever. Always fetch the current token.
+      const res = await fetch('/setup-api/gateway/ws-config', { cache: 'no-store' })
       const config = await res.json()
       token = config.token
       wsUrl = config.wsUrl

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -548,6 +548,13 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   }, [])
 
   const connect = useCallback(async () => {
+    // Cancel any pending retry / auth-backoff timer so an explicit reconnect
+    // (e.g. the "Try again" button) can't race with a previously scheduled one
+    // and fire a duplicate connect later.
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current)
+      retryTimerRef.current = null
+    }
     if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) return
     if (wsRef.current) {
       wsRef.current.close()

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -23,6 +23,12 @@ const MAX_QUEUED_SENDS = 20
 // once it comes back instead of forcing the user to click Try again.
 const SKILL_INSTALL_MAX_RETRIES = MAX_RETRIES * 4
 const RETRY_DELAY = 3000
+// When the gateway closes the socket with an auth rejection (it rate-limits a
+// client after too many failed auth attempts), retrying on the fast RETRY_DELAY
+// cadence just re-trips the limiter and the lockout never clears. Back off hard
+// so the cooldown can expire, then the next attempt succeeds without the user
+// having to reload.
+const AUTH_BACKOFF_DELAY = 30000
 const SPINNER_STYLE: React.CSSProperties = { width: 24, height: 24, border: '2px solid rgba(249,115,22,0.2)', borderTopColor: '#f97316', borderRadius: '50%', animation: 'spin 0.8s linear infinite' }
 function saveMascotSnippet(text: string) {
   if (!text || text.length < 10) return
@@ -819,8 +825,24 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       }
     }
 
-    const onClose = () => {
+    const onClose = (event?: CloseEvent) => {
       wsRef.current = null
+
+      // Auth rejection (gateway closes with 1008 / "unauthorized" / "rate
+      // limited" — it rate-limits a client after too many failed auth
+      // attempts). Do NOT fall through to the fast RETRY_DELAY loop: hammering
+      // every 3s just re-trips the limiter so the lockout never clears. Tear
+      // down any reconnect overlay, surface the gateway's reason, and schedule
+      // a single long backoff retry so it self-heals once the cooldown expires.
+      const closeReason = event?.reason || ""
+      if (event?.code === 1008 || /unauthor|rate.?limit|too many/i.test(closeReason)) {
+        tearDownReloadOverlay()
+        if (retryTimerRef.current) clearTimeout(retryTimerRef.current)
+        setStatus('error')
+        setErrorMsg(closeReason || 'Unauthorized — retrying shortly')
+        retryTimerRef.current = setTimeout(() => { retryCountRef.current = 0; connect() }, AUTH_BACKOFF_DELAY)
+        return
+      }
 
       // If the WS drops after we'd successfully connected, the gateway
       // bounced under us (a restart from a skill install, AI-provider

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -6,6 +6,11 @@ import path from "path";
 const exec = promisify(execFile);
 const IFACE = process.env.NETWORK_INTERFACE || "wlP1p1s0";
 const NETWORK_TIMEOUT = Number(process.env.NETWORK_COMMAND_TIMEOUT) || 60000;
+// `iw scan` returns within a few seconds when it works; on single-radio adapters
+// it instead hangs while the interface is beaconing as an AP. Cap it well below
+// NETWORK_TIMEOUT so a doomed AP-mode scan fails fast and we fall back to cache
+// instead of leaving the wizard spinning for a minute.
+const IW_SCAN_TIMEOUT = Number(process.env.IW_SCAN_TIMEOUT) || 15000;
 const TEST_MODE = process.env.CLAWBOX_TEST_MODE === "1";
 const AP_RETRY_COUNT = 3;
 const AP_RETRY_DELAY = 2000;
@@ -98,7 +103,7 @@ export async function scanWifiLive(): Promise<WifiNetwork[]> {
       const proc = spawn("/usr/sbin/iw", ["dev", IFACE, "scan"]);
       let out = "";
       let err = "";
-      const timer = setTimeout(() => { proc.kill(); reject(new Error("iw scan timed out")); }, NETWORK_TIMEOUT);
+      const timer = setTimeout(() => { proc.kill(); reject(new Error("iw scan timed out")); }, IW_SCAN_TIMEOUT);
       proc.stdout.on("data", (d: Buffer) => { out += d.toString(); });
       proc.stderr.on("data", (d: Buffer) => { err += d.toString(); });
       proc.on("close", (code) => {
@@ -149,10 +154,19 @@ export async function scanWifiLive(): Promise<WifiNetwork[]> {
       });
     }
 
-    return deduplicateNetworks(networks.filter((n) => n.ssid && n.ssid !== "ClawBox-Setup"));
+    const live = deduplicateNetworks(networks.filter((n) => n.ssid && n.ssid !== "ClawBox-Setup"));
+    if (live.length > 0) return live;
+    // No live results — on single-radio adapters `iw scan` can't see neighbours
+    // while the radio is beaconing as an AP. Fall back to the pre-AP boot scan
+    // cache so the wizard still shows the networks found before the hotspot.
+    const cached = getCachedScan();
+    if (cached.length > 0) {
+      console.warn("[WiFi] iw scan returned nothing (AP mode?); serving pre-AP cache");
+    }
+    return cached;
   } catch (err) {
     console.error("[WiFi] iw scan failed:", err instanceof Error ? err.message : err);
-    return [];
+    return getCachedScan();
   }
 }
 


### PR DESCRIPTION
## What

Two device-stability fixes found while testing v3.0.7 on a Jetson, bundled to ship in the same version.

### 1. WiFi setup scan showed "No networks found"
The setup wizard listed no networks even with strong APs nearby. Root cause (confirmed on-device via boot logs): the boot-time pre-AP scan in `start-ap.sh` fired `nmcli ... rescan` then waited a fixed `sleep 2` before reading the list — but nmcli populates scan results asynchronously over 5-10s, so it read an empty list and cached `[]`. The live `iw scan` fallback can't recover because a single-radio adapter can't scan while beaconing as an AP (it hangs until timeout).

- **`scripts/start-ap.sh`** — wait for the interface to be up, then **poll** `nmcli wifi list` (re-triggering rescan) until real networks appear, bounded by `PRE_AP_SCAN_TIMEOUT` (default 20s).
- **`src/lib/network.ts`** — cap the `iw scan` timeout at 15s (was 60s) so a doomed AP-mode scan fails fast, and fall back to the pre-AP boot cache when the live scan returns nothing, so the rescan button still surfaces the boot-time networks.

**Verified on a Jetson:** before the fix the boot log read `No networks found during pre-scan` (2s) and cached `[]`; after a reboot with the fix it read `Pre-scan found 7 network(s) on attempt 1` and cached all 7. Wizard now lists them.

### 2. Chat stuck on "too many failed authentication attempts (retry later)"
After repeated gateway restarts/reboots, the chat would lock onto the gateway's auth rate-limit and never recover. The reconnect loop retried on the fast 3s cadence, and each attempt during the limiter's cooldown was re-rejected as `rate_limited`, which **reset the cooldown** — so "retry later" never cleared while the tab stayed open.

- **`src/components/ChatPopup.tsx`** — `onClose` now detects an auth-rejection close (code `1008` / "unauthorized" / "rate limited"), tears down the reconnect overlay, surfaces the gateway's reason, and schedules a **single 30s backoff retry** (`AUTH_BACKOFF_DELAY`) instead of hammering every 3s — so the cooldown can expire and the chat self-heals without a manual reload.

## Test plan
- [x] WiFi: boot-log + cache verified on a Jetson (`[]` → 7 networks after reboot)
- [x] Chat backoff: builds, deploys, normal connect unaffected on-device (auth-rejection path verified by reasoning — can't force the rate-limit race on demand)
- [ ] CI (test / e2e / e2e-install)
- [ ] CodeRabbit review

## Note
`start-ap.sh` follow-ups deferred (out of scope here): replacing the poll loop with `nmcli --rescan yes`/`-w` blocking rescan, and unifying the triplicated nmcli-terse parsing via the existing `parseNmcliTerseLine`. Deferred to avoid re-validating the just-hardware-verified boot path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WiFi scanning reliability with improved network interface detection and fallback to cached results when live scans unavailable
  * Improved connection recovery with optimized backoff strategy for authentication and rate-limit errors to reduce reconnection failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ID-Robots/clawbox/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->