### PR TITLE
feat(wifi): detect wrong WiFi password during setup and surface it

### DIFF
--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -1112,15 +1112,20 @@ export async function completeSetupWizard(page: Page) {
   await page.locator("#wifi-password").fill("wireless-pass");
   await page.getByRole("button", { name: "Connect" }).click();
 
+  // The update step auto-advances to credentials the moment it sees there's
+  // nothing to install. With test timers capped (installClawboxMocks) that can
+  // happen before Playwright catches the update step on screen, so race the two
+  // steps rather than assuming the update step lingers long enough to assert.
   const updateStep = page.getByTestId("setup-step-update");
-  await expect(updateStep).toBeVisible({ timeout: 10_000 });
-  const continueButton = updateStep.getByRole("button", { name: "Continue" });
   const credentialsStep = page.getByTestId("setup-step-credentials");
-  const advancedAutomatically = await expect(credentialsStep).toBeVisible({ timeout: 4_000 })
-    .then(() => true)
-    .catch(() => false);
-  if (!advancedAutomatically) {
-    await continueButton.click();
+  await expect(updateStep.or(credentialsStep).first()).toBeVisible({ timeout: 10_000 });
+  if (await updateStep.isVisible().catch(() => false)) {
+    const advancedAutomatically = await expect(credentialsStep).toBeVisible({ timeout: 4_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (!advancedAutomatically) {
+      await updateStep.getByRole("button", { name: "Continue" }).click();
+    }
   }
   await expect(credentialsStep).toBeVisible({ timeout: 10_000 });
 

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -534,7 +534,16 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
 
     if (path === "/setup-api/wifi/connect" && method === "POST") {
       setupState.wifi_configured = true;
-      await fulfillJson(route, { success: true });
+      // Single-radio handoff: the route is fire-and-forget and returns
+      // "connecting", then the wizard polls /wifi/connect-status for the
+      // real outcome (see WifiStep). The mock has no radio to lose, so the
+      // status endpoint below reports success right away.
+      await fulfillJson(route, { status: "connecting" });
+      return;
+    }
+
+    if (path === "/setup-api/wifi/connect-status") {
+      await fulfillJson(route, { phase: "connected", ssid: "Clawbox Lab", reason: null });
       return;
     }
 

--- a/scripts/start-ap.sh
+++ b/scripts/start-ap.sh
@@ -95,6 +95,12 @@ wait_for_interface() {
 # and cache the results. The setup wizard uses this cached list so users can
 # pick their network from a list instead of typing the SSID manually.
 SCAN_CACHE="/home/clawbox/clawbox/data/wifi-scan-cache.json"
+# SKIP_PRESCAN=1 (set when restoring the AP after a failed client connect) skips
+# the ~20s scan poll and keeps the existing cache — the radio was just in use
+# and we only need the hotspot back up fast so the wizard can report the result.
+if [ "${SKIP_PRESCAN:-}" = "1" ]; then
+  echo "[AP] SKIP_PRESCAN=1 — fast AP restore, keeping existing scan cache"
+else
 echo "[AP] Scanning for nearby WiFi networks before starting AP..."
 # Make sure the interface is actually up before scanning — early in boot it may
 # still be initializing, and scanning a down interface returns nothing.
@@ -167,6 +173,7 @@ else
   echo "[]" > "$SCAN_CACHE"
   echo "[AP] No networks found during pre-scan"
 fi
+fi  # end SKIP_PRESCAN guard
 
 echo "[AP] Cleaning up any previous AP connection..."
 nmcli connection down "$CON_NAME" 2>/dev/null || true

--- a/src/app/setup-api/wifi/connect-status/route.ts
+++ b/src/app/setup-api/wifi/connect-status/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { getConnectStatus } from "@/lib/network";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Poll target for the WiFi connect handoff. The wizard loses the setup hotspot
+ * the moment the box switches to client mode, so it can't get a synchronous
+ * connect result — it polls this once it reconnects (to the restored AP on
+ * failure, or to us on the home network on success).
+ */
+export async function GET() {
+  return NextResponse.json(getConnectStatus(), {
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/src/app/setup-api/wifi/connect/route.ts
+++ b/src/app/setup-api/wifi/connect/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
-import { switchToClient } from "@/lib/network";
-import { set, setMany, get } from "@/lib/config-store";
+import {
+  switchToClient,
+  setConnectStatus,
+  WifiAuthError,
+  type ConnectFailReason,
+} from "@/lib/network";
+import { set, setMany } from "@/lib/config-store";
 
 export const dynamic = "force-dynamic";
 
@@ -26,26 +31,33 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Password must be a string" }, { status: 400 });
   }
 
-  try {
-    await set("wifi_ssid", ssid);
+  await set("wifi_ssid", ssid);
 
-    // Actually attempt connection before responding
-    await switchToClient(ssid, password as string | undefined);
+  // Single-radio handoff: switchToClient tears down the setup hotspot to join
+  // the home network, so the browser loses us mid-connect and a synchronous
+  // response can never arrive. Run it in the background, record a pollable
+  // status, and return immediately — the wizard polls /wifi/connect-status
+  // once the AP comes back (failure) or it reaches us on the home network.
+  setConnectStatus({ phase: "connecting", ssid, reason: null, message: "", at: Date.now() });
+  void (async () => {
+    // Grace period so this response is flushed before the AP drops underneath us.
+    await new Promise((resolve) => setTimeout(resolve, 1500));
+    try {
+      const { message } = await switchToClient(ssid, password as string | undefined);
+      await setMany({ wifi_configured: true, hotspot_enabled: false }).catch(() => {});
+      setConnectStatus({ phase: "connected", ssid, reason: null, message, at: Date.now() });
+    } catch (err) {
+      await set("wifi_configured", false).catch(() => {});
+      const reason: ConnectFailReason = err instanceof WifiAuthError ? "wrong-password" : "other";
+      setConnectStatus({
+        phase: "failed",
+        ssid,
+        reason,
+        message: err instanceof Error ? err.message : "Connection failed",
+        at: Date.now(),
+      });
+    }
+  })();
 
-    await setMany({ wifi_configured: true, hotspot_enabled: false });
-
-    const hostname = ((await get("hostname")) as string | undefined) || "clawbox";
-    return NextResponse.json({
-      success: true,
-      message: `Connected! Reconnect to your home WiFi and visit http://${hostname}.local to continue.`,
-    });
-  } catch (err) {
-    // switchToClient already restores the AP on failure
-    await set("wifi_configured", false).catch(() => {});
-
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Connection failed" },
-      { status: 500 }
-    );
-  }
+  return NextResponse.json({ status: "connecting" });
 }

--- a/src/components/StatusMessage.tsx
+++ b/src/components/StatusMessage.tsx
@@ -1,18 +1,20 @@
 interface StatusMessageProps {
-  type: "success" | "error";
+  type: "success" | "error" | "info";
   message: string;
 }
+
+const STYLES: Record<StatusMessageProps["type"], string> = {
+  success: "bg-[#00e5cc]/10 text-[#00e5cc] border border-green-500/20",
+  error: "bg-red-500/10 text-red-400 border border-red-500/20",
+  info: "bg-amber-400/10 text-amber-300 border border-amber-400/20",
+};
 
 export default function StatusMessage({ type, message }: StatusMessageProps) {
   return (
     <output
       aria-live={type === "error" ? "assertive" : "polite"}
       aria-atomic="true"
-      className={`mt-3 px-3.5 py-2.5 rounded-lg text-xs leading-relaxed block ${
-        type === "success"
-          ? "bg-[#00e5cc]/10 text-[#00e5cc] border border-green-500/20"
-          : "bg-red-500/10 text-red-400 border border-red-500/20"
-      }`}
+      className={`mt-3 px-3.5 py-2.5 rounded-lg text-xs leading-relaxed block ${STYLES[type]}`}
     >
       {message}
     </output>

--- a/src/components/WifiStep.tsx
+++ b/src/components/WifiStep.tsx
@@ -28,7 +28,7 @@ export default function WifiStep({ onNext }: WifiStepProps) {
   const [showPassword, setShowPassword] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [status, setStatus] = useState<{
-    type: "success" | "error";
+    type: "success" | "error" | "info";
     message: string;
   } | null>(null);
   const [ethDetected, setEthDetected] = useState<boolean | null>(null);
@@ -121,7 +121,12 @@ export default function WifiStep({ onNext }: WifiStepProps) {
     const controller = new AbortController();
     controllerRef.current = controller;
     setConnecting(true);
-    setStatus(null);
+    // The radio is single-band: joining the home network tears down the setup
+    // hotspot, so this connect can't return its result synchronously (we lose
+    // the box mid-switch). Kick it off, then poll /wifi/connect-status, which
+    // survives the outage and tells us "wrong password" / "connected".
+    setStatus({ type: "info", message: t("wifi.switching", { ssid: activeSsid }) });
+
     try {
       const res = await fetch("/setup-api/wifi/connect", {
         method: "POST",
@@ -129,35 +134,55 @@ export default function WifiStep({ onNext }: WifiStepProps) {
         body: JSON.stringify({ ssid: activeSsid, password }),
         signal: controller.signal,
       });
-      if (controller.signal.aborted) return;
-      if (!res.ok) {
+      // A 4xx is a validation error (bad SSID etc.) — surface it immediately.
+      if (res.status >= 400 && res.status < 500) {
         const errData = await res.json().catch(() => ({}));
-        throw new Error(errData.error || `Connection failed (${res.status})`);
-      }
-      setConnecting(false);
-      setStatus({
-        type: "success",
-        message: t("wifi.connectedMessage", { url: localUrl }),
-      });
-
-      setTimeout(() => onNext(), 3000);
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
-      if (err instanceof TypeError && err.message.includes("fetch")) {
         setConnecting(false);
-        setStatus({
-          type: "error",
-          message: t("wifi.lostConnection", { url: localUrl }),
-        });
+        setStatus({ type: "error", message: errData.error || `Connection failed (${res.status})` });
         return;
       }
-      setStatus({
-        type: "error",
-        message: t("wifi.connectionFailed", { error: err instanceof Error ? err.message : String(err) }),
-      });
-    } finally {
-      if (!controller.signal.aborted) setConnecting(false);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      // The hotspot may already be dropping — expected; fall through to polling.
     }
+    if (controller.signal.aborted) return;
+
+    // Poll for the outcome, tolerating the hotspot outage during the switch.
+    const deadline = Date.now() + 80_000;
+    const poll = async () => {
+      if (controller.signal.aborted) return;
+      if (Date.now() > deadline) {
+        // Never got a terminal status: almost always SUCCESS — the box joined
+        // the home network and the hotspot is gone, so we can't reach it from
+        // here. Point the user at the home network.
+        setConnecting(false);
+        setStatus({ type: "success", message: t("wifi.connectedMessage", { url: localUrl }) });
+        return;
+      }
+      try {
+        const r = await fetch("/setup-api/wifi/connect-status", { cache: "no-store", signal: controller.signal });
+        const s = await r.json();
+        if (s.phase === "failed") {
+          setConnecting(false);
+          setStatus(
+            s.reason === "wrong-password"
+              ? { type: "error", message: t("wifi.wrongPassword") }
+              : { type: "error", message: t("wifi.lostConnection", { url: localUrl }) }
+          );
+          return;
+        }
+        if (s.phase === "connected") {
+          setConnecting(false);
+          setStatus({ type: "success", message: t("wifi.connectedMessage", { url: localUrl }) });
+          setTimeout(() => { if (!controller.signal.aborted) onNext(); }, 3000);
+          return;
+        }
+      } catch {
+        // Hotspot down mid-switch — expected; keep polling until it returns.
+      }
+      if (!controller.signal.aborted) setTimeout(poll, 2500);
+    };
+    setTimeout(poll, 3000);
   };
 
   const skipEthernet = () => {

--- a/src/components/WifiStep.tsx
+++ b/src/components/WifiStep.tsx
@@ -148,7 +148,10 @@ export default function WifiStep({ onNext }: WifiStepProps) {
     if (controller.signal.aborted) return;
 
     // Poll for the outcome, tolerating the hotspot outage during the switch.
-    const deadline = Date.now() + 80_000;
+    // The failure path is connect-attempt + AP-restore, so give it generous
+    // headroom — otherwise a slow restore would trip the deadline and we'd
+    // mis-report a wrong password as success.
+    const deadline = Date.now() + 130_000;
     const poll = async () => {
       if (controller.signal.aborted) return;
       if (Date.now() > deadline) {

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -324,6 +324,58 @@ async function doScan(): Promise<WifiNetwork[]> {
   }
 }
 
+/** Thrown when a connect fails because the WPA pre-shared key was rejected. */
+export class WifiAuthError extends Error {
+  constructor(message = "Incorrect WiFi password") {
+    super(message);
+    this.name = "WifiAuthError";
+  }
+}
+
+/** Best-effort: did the most recent association attempt fail because the
+ *  pre-shared key was wrong? wpa_supplicant logs this clearly; the clawbox
+ *  service can read its journal (member of the `adm` group). */
+async function recentWrongKeyFailure(ssid: string): Promise<boolean> {
+  if (TEST_MODE) return ssid.startsWith("__wrongpass__");
+  try {
+    const { stdout } = await exec(
+      "journalctl",
+      ["-t", "wpa_supplicant", "--no-pager", "--since", "45 seconds ago"],
+      { timeout: 10_000 },
+    );
+    return /WRONG_KEY|pre-shared key may be incorrect|4-Way Handshake failed/i.test(stdout);
+  } catch {
+    return false;
+  }
+}
+
+// ── Client-connect status ────────────────────────────────────────────────────
+// The wizard loses the AP the moment we switch to client mode, so a synchronous
+// connect response can never reach it. Instead we run the connect in the
+// background and record a pollable status; the wizard polls this once the AP
+// comes back (failure) or it reconnects over the home network (success).
+export type ConnectPhase = "idle" | "connecting" | "connected" | "failed";
+export type ConnectFailReason = "wrong-password" | "other";
+export interface ConnectStatus {
+  phase: ConnectPhase;
+  ssid: string | null;
+  reason: ConnectFailReason | null;
+  message: string;
+  at: number;
+}
+let connectStatus: ConnectStatus = { phase: "idle", ssid: null, reason: null, message: "", at: 0 };
+
+export function getConnectStatus(): ConnectStatus {
+  return connectStatus;
+}
+
+/** Update the pollable connect status. The wifi/connect route drives this
+ *  around its fire-and-forget switchToClient call (it owns the config-store
+ *  side effects, so the orchestration lives there rather than here). */
+export function setConnectStatus(status: ConnectStatus): void {
+  connectStatus = status;
+}
+
 export async function switchToClient(
   ssid: string,
   password?: string
@@ -344,16 +396,19 @@ export async function switchToClient(
   // Stop the AP
   await exec("bash", [AP_STOP_SCRIPT], { timeout: NETWORK_TIMEOUT });
 
-  // Build args conditionally instead of splicing
+  // Build args conditionally instead of splicing. `--wait 20` caps each attempt
+  // so a doomed connect (e.g. wrong password) fails in ~20s instead of nmcli's
+  // 90s default — the wizard gets a quick verdict.
   const args = password
-    ? ["device", "wifi", "connect", ssid, "password", password, "ifname", IFACE]
-    : ["device", "wifi", "connect", ssid, "ifname", IFACE];
+    ? ["--wait", "20", "device", "wifi", "connect", ssid, "password", password, "ifname", IFACE]
+    : ["--wait", "20", "device", "wifi", "connect", ssid, "ifname", IFACE];
 
   // After leaving AP mode the interface needs time to discover nearby networks.
   // Retry the connect with rescans in between — the first attempt often fails
   // because the SSID hasn't been discovered yet.
   const CONNECT_RETRIES = 3;
   let lastErr: unknown;
+  let wrongKey = false;
   for (let attempt = 1; attempt <= CONNECT_RETRIES; attempt++) {
     await exec("nmcli", ["device", "wifi", "rescan", "ifname", IFACE], { timeout: NETWORK_TIMEOUT }).catch(() => {});
     await new Promise((resolve) => setTimeout(resolve, 3000));
@@ -366,6 +421,13 @@ export async function switchToClient(
       lastErr = err;
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[WiFi] Connect attempt ${attempt}/${CONNECT_RETRIES} failed: ${msg}`);
+      // A wrong password fails the WPA 4-way handshake — retrying with the same
+      // password is pointless, so stop early and report it precisely.
+      if (await recentWrongKeyFailure(ssid)) {
+        wrongKey = true;
+        console.warn("[WiFi] Connect failed due to incorrect pre-shared key");
+        break;
+      }
       if (attempt < CONNECT_RETRIES) {
         // Wait a bit longer before next retry
         await new Promise((resolve) => setTimeout(resolve, 2000));
@@ -412,6 +474,9 @@ export async function switchToClient(
       }
     }
 
+    if (wrongKey) {
+      throw new WifiAuthError(`Incorrect password for "${ssid}"`);
+    }
     throw lastErr;
 }
 

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -441,9 +441,19 @@ export async function switchToClient(
     const AP_RESTORE_BACKOFF = 3000;
     let apRestored = false;
 
+    // The radio was just driving a failed association and needs a moment to
+    // settle before it can host the AP again — without this the first restore
+    // attempt tends to fail ("device busy").
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+
     for (let attempt = 1; attempt <= AP_RESTORE_RETRIES; attempt++) {
       try {
-        await exec("bash", [AP_START_SCRIPT], { timeout: NETWORK_TIMEOUT });
+        // SKIP_PRESCAN: we don't need a fresh network scan just to bring the
+        // hotspot back — skip it so the wizard gets the connect verdict sooner.
+        await exec("bash", [AP_START_SCRIPT], {
+          timeout: NETWORK_TIMEOUT,
+          env: { ...process.env, SKIP_PRESCAN: "1" },
+        });
         // Verify AP is actually up
         const apUp = await isAPMode();
         if (apUp) {

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -844,6 +844,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "Verbinden",
     "wifi.findingNetworks": "Netzwerke werden gesucht...",
     "wifi.connectedMessage": "Verbunden! Verbinde dich mit deinem Heim-WLAN und öffne {url}, um fortzufahren.",
+    "wifi.switching": "Verbindung mit {ssid}… der Setup-Hotspot wird während des Wechsels geschlossen, das kann bis zu einer Minute dauern.",
+    "wifi.wrongPassword": "Falsches WLAN-Passwort. Überprüfe es und versuche es erneut.",
     "wifi.lostConnection": "Verbindung zu ClawBox verloren. Wenn der WLAN-Wechsel erfolgreich war, verbinde dich mit deinem Heim-WLAN und öffne {url}.",
     "wifi.connectionFailed": "Verbindung fehlgeschlagen: {error}",
 
@@ -1230,6 +1232,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "Conectar",
     "wifi.findingNetworks": "Buscando redes...",
     "wifi.connectedMessage": "¡Conectado! Conéctate a tu WiFi doméstica y visita {url} para continuar.",
+    "wifi.switching": "Conectando a {ssid}… el punto de acceso de configuración se cierra durante el cambio, así que puede tardar hasta un minuto.",
+    "wifi.wrongPassword": "Contraseña de WiFi incorrecta. Verifícala e inténtalo de nuevo.",
     "wifi.lostConnection": "Se perdió la conexión con ClawBox. Si el cambio de WiFi fue exitoso, conéctate a tu WiFi doméstica y visita {url} para continuar.",
     "wifi.connectionFailed": "Error de conexión: {error}",
 
@@ -1616,6 +1620,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "Se connecter",
     "wifi.findingNetworks": "Recherche de réseaux...",
     "wifi.connectedMessage": "Connecté ! Rejoignez votre WiFi domestique et rendez-vous sur {url} pour continuer.",
+    "wifi.switching": "Connexion à {ssid}… le point d'accès de configuration se ferme pendant le basculement, cela peut prendre jusqu'à une minute.",
+    "wifi.wrongPassword": "Mauvais mot de passe WiFi. Vérifiez-le et réessayez.",
     "wifi.lostConnection": "Connexion à ClawBox perdue. Si le WiFi a bien été changé, rejoignez votre WiFi domestique et rendez-vous sur {url} pour continuer.",
     "wifi.connectionFailed": "Échec de la connexion : {error}",
 
@@ -2002,6 +2008,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "Connetti",
     "wifi.findingNetworks": "Ricerca reti...",
     "wifi.connectedMessage": "Connesso! Collegati al WiFi di casa e visita {url} per continuare.",
+    "wifi.switching": "Connessione a {ssid}… l'hotspot di configurazione si chiude durante il passaggio, quindi può richiedere fino a un minuto.",
+    "wifi.wrongPassword": "Password WiFi errata. Controllala e riprova.",
     "wifi.lostConnection": "Connessione a ClawBox persa. Se il cambio WiFi è andato a buon fine, collegati al WiFi di casa e visita {url} per continuare.",
     "wifi.connectionFailed": "Connessione fallita: {error}",
 
@@ -2388,6 +2396,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "接続",
     "wifi.findingNetworks": "ネットワークを検索中...",
     "wifi.connectedMessage": "接続しました！自宅のWiFiに接続し直し、{url} にアクセスして続けてください。",
+    "wifi.switching": "{ssid} に接続しています… 切り替え中はセットアップ用ホットスポットが閉じるため、最大1分ほどかかることがあります。",
+    "wifi.wrongPassword": "WiFiのパスワードが間違っています。確認してもう一度お試しください。",
     "wifi.lostConnection": "ClawBoxとの接続が切れました。WiFiの切り替えに成功した場合は、自宅のWiFiに接続し直し、{url} にアクセスしてください。",
     "wifi.connectionFailed": "接続に失敗しました: {error}",
 
@@ -2774,6 +2784,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "Verbinden",
     "wifi.findingNetworks": "Netwerken zoeken...",
     "wifi.connectedMessage": "Verbonden! Maak verbinding met je thuis-WiFi en ga naar {url} om verder te gaan.",
+    "wifi.switching": "Verbinden met {ssid}… de setup-hotspot sluit tijdens het overschakelen, dus dit kan tot een minuut duren.",
+    "wifi.wrongPassword": "Verkeerd wifi-wachtwoord. Controleer het en probeer het opnieuw.",
     "wifi.lostConnection": "Verbinding met ClawBox verloren. Als het WiFi-netwerk succesvol is gewisseld, maak dan verbinding met je thuis-WiFi en ga naar {url}.",
     "wifi.connectionFailed": "Verbinding mislukt: {error}",
 
@@ -3160,6 +3172,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "Anslut",
     "wifi.findingNetworks": "Söker nätverk...",
     "wifi.connectedMessage": "Ansluten! Anslut till ditt hem-WiFi och gå till {url} för att fortsätta.",
+    "wifi.switching": "Ansluter till {ssid}… installations-hotspoten stängs under bytet, så det kan ta upp till en minut.",
+    "wifi.wrongPassword": "Fel WiFi-lösenord. Kontrollera det och försök igen.",
     "wifi.lostConnection": "Anslutningen till ClawBox bröts. Om WiFi-bytet lyckades, anslut till ditt hem-WiFi och gå till {url} för att fortsätta.",
     "wifi.connectionFailed": "Anslutningen misslyckades: {error}",
 
@@ -3546,6 +3560,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.connect": "连接",
     "wifi.findingNetworks": "正在查找网络...",
     "wifi.connectedMessage": "已连接！请连接家中 WiFi 并访问 {url} 继续。",
+    "wifi.switching": "正在连接到 {ssid}… 切换期间设置热点会关闭，因此可能需要最多一分钟。",
+    "wifi.wrongPassword": "WiFi 密码错误。请检查后重试。",
     "wifi.lostConnection": "与 ClawBox 的连接已断开。如果 WiFi 切换成功，请连接家中 WiFi 并访问 {url} 继续。",
     "wifi.connectionFailed": "连接失败：{error}",
 

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -68,6 +68,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.findingNetworks": "Finding networks...",
     "wifi.connectedMessage": "Connected! Reconnect to your home WiFi and visit {url} to continue.",
     "wifi.lostConnection": "Lost connection to ClawBox. If WiFi switched successfully, reconnect to your home WiFi and visit {url} to continue.",
+    "wifi.switching": "Connecting to {ssid}… the setup hotspot closes during the switch, so this can take up to a minute.",
+    "wifi.wrongPassword": "Wrong WiFi password. Double-check it and try again.",
     "wifi.connectionFailed": "Connection failed: {error}",
 
     // === UpdateStep ===
@@ -455,6 +457,8 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wifi.findingNetworks": "Търсене на мрежи...",
     "wifi.connectedMessage": "Свързано! Свържете се с домашната си WiFi мрежа и отворете {url}, за да продължите.",
     "wifi.lostConnection": "Загубена връзка с ClawBox. Ако WiFi мрежата е сменена успешно, свържете се с домашната си WiFi и отворете {url}, за да продължите.",
+    "wifi.switching": "Свързване към {ssid}… точката за достъп се изключва по време на превключването, така че това може да отнеме до минута.",
+    "wifi.wrongPassword": "Грешна WiFi парола. Проверете я и опитайте отново.",
     "wifi.connectionFailed": "Неуспешно свързване: {error}",
 
     // === UpdateStep ===

--- a/src/tests/routes/wifi/connect.test.ts
+++ b/src/tests/routes/wifi/connect.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
-class FakeWifiAuthError extends Error {
-  constructor(message?: string) {
-    super(message);
-    this.name = "WifiAuthError";
+// vi.mock is hoisted above this file's top-level code, so the auth-error class
+// the factory returns must be built inside vi.hoisted() to exist when it runs.
+const { FakeWifiAuthError } = vi.hoisted(() => {
+  class FakeWifiAuthError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = "WifiAuthError";
+    }
   }
-}
+  return { FakeWifiAuthError };
+});
 
 vi.mock("@/lib/network", () => ({
   switchToClient: vi.fn(),

--- a/src/tests/routes/wifi/connect.test.ts
+++ b/src/tests/routes/wifi/connect.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
+class FakeWifiAuthError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = "WifiAuthError";
+  }
+}
+
 vi.mock("@/lib/network", () => ({
   switchToClient: vi.fn(),
+  setConnectStatus: vi.fn(),
+  WifiAuthError: FakeWifiAuthError,
 }));
 
 vi.mock("@/lib/config-store", () => ({
@@ -10,10 +19,11 @@ vi.mock("@/lib/config-store", () => ({
   get: vi.fn(async () => "clawbox"),
 }));
 
-import { switchToClient } from "@/lib/network";
+import { switchToClient, setConnectStatus, WifiAuthError } from "@/lib/network";
 import { set, setMany } from "@/lib/config-store";
 
 const mockSwitchToClient = vi.mocked(switchToClient);
+const mockSetConnectStatus = vi.mocked(setConnectStatus);
 const mockSet = vi.mocked(set);
 const mockSetMany = vi.mocked(setMany);
 
@@ -42,25 +52,71 @@ describe("POST /setup-api/wifi/connect", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
-  it("connects to a WiFi network successfully", async () => {
+  // The single-radio handoff tears down the setup hotspot mid-connect, so the
+  // route is fire-and-forget: it records a "connecting" status, returns
+  // immediately, and a background task reports the real outcome via
+  // setConnectStatus (which the wizard polls through /wifi/connect-status).
+
+  it("returns connecting and records a connecting status", async () => {
     const res = await wifiConnectPost(jsonRequest({ ssid: "MyNetwork", password: "secret123" }));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.success).toBe(true);
-    expect(mockSwitchToClient).toHaveBeenCalledWith("MyNetwork", "secret123");
-    expect(mockSetMany).toHaveBeenCalledWith({ wifi_configured: true, hotspot_enabled: false });
+    expect(body.status).toBe("connecting");
+    expect(mockSet).toHaveBeenCalledWith("wifi_ssid", "MyNetwork");
+    expect(mockSetConnectStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ phase: "connecting", ssid: "MyNetwork", reason: null }),
+    );
   });
 
-  it("connects without password (open network)", async () => {
+  it("returns connecting for an open network (no password)", async () => {
     const res = await wifiConnectPost(jsonRequest({ ssid: "OpenNetwork" }));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.success).toBe(true);
-    expect(mockSwitchToClient).toHaveBeenCalledWith("OpenNetwork", undefined);
+    expect(body.status).toBe("connecting");
+  });
+
+  it("records connected and marks configured after a successful background switch", async () => {
+    vi.useFakeTimers();
+    mockSwitchToClient.mockResolvedValue({ message: "ok" });
+
+    await wifiConnectPost(jsonRequest({ ssid: "MyNetwork", password: "secret123" }));
+    await vi.advanceTimersByTimeAsync(1600);
+
+    expect(mockSwitchToClient).toHaveBeenCalledWith("MyNetwork", "secret123");
+    expect(mockSetMany).toHaveBeenCalledWith({ wifi_configured: true, hotspot_enabled: false });
+    expect(mockSetConnectStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ phase: "connected", ssid: "MyNetwork" }),
+    );
+  });
+
+  it("records reason=wrong-password when the background switch throws a WifiAuthError", async () => {
+    vi.useFakeTimers();
+    mockSwitchToClient.mockRejectedValue(new WifiAuthError("bad key"));
+
+    await wifiConnectPost(jsonRequest({ ssid: "Network", password: "wrong" }));
+    await vi.advanceTimersByTimeAsync(1600);
+
+    expect(mockSet).toHaveBeenCalledWith("wifi_configured", false);
+    expect(mockSetConnectStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ phase: "failed", reason: "wrong-password" }),
+    );
+  });
+
+  it("records reason=other when the background switch fails otherwise", async () => {
+    vi.useFakeTimers();
+    mockSwitchToClient.mockRejectedValue(new Error("Connection refused"));
+
+    await wifiConnectPost(jsonRequest({ ssid: "Network", password: "pass" }));
+    await vi.advanceTimersByTimeAsync(1600);
+
+    expect(mockSetConnectStatus).toHaveBeenLastCalledWith(
+      expect.objectContaining({ phase: "failed", reason: "other", message: "Connection refused" }),
+    );
   });
 
   it("skips WiFi setup when skip=true", async () => {
@@ -117,26 +173,5 @@ describe("POST /setup-api/wifi/connect", () => {
 
     expect(res.status).toBe(400);
     expect(body.error).toBe("Password must be a string");
-  });
-
-  it("returns 500 when connection fails", async () => {
-    mockSwitchToClient.mockRejectedValue(new Error("Connection refused"));
-
-    const res = await wifiConnectPost(jsonRequest({ ssid: "Network", password: "pass" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(500);
-    expect(body.error).toBe("Connection refused");
-    expect(mockSet).toHaveBeenCalledWith("wifi_configured", false);
-  });
-
-  it("returns generic error for non-Error throws", async () => {
-    mockSwitchToClient.mockRejectedValue("unknown error");
-
-    const res = await wifiConnectPost(jsonRequest({ ssid: "Network", password: "pass" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(500);
-    expect(body.error).toBe("Connection failed");
   });
 });


### PR DESCRIPTION
## Summary

During first-boot setup the single-radio box tears down its `ClawBox-Setup` hotspot to join the user's Wi-Fi. If the password was wrong, the box couldn't join and silently reopened the AP — the user just saw the box "disappear." This detects that failure and surfaces it so they can retry.

## What changed

- **`network.ts`** — `switchToClient` caps the connect at `--wait 20`, detects a wrong key (WRONG_KEY in the `wpa_supplicant` journal) and breaks early with a `WifiAuthError`, and restores the AP fast on failure (`SKIP_PRESCAN`). A small in-memory `ConnectStatus` follows the existing scan-status convention.
- **`wifi/connect`** is now fire-and-forget (returns `connecting` immediately — the synchronous response can't survive the AP teardown); new **`wifi/connect-status`** GET lets the wizard poll the outcome.
- **`WifiStep`** polls connect-status and shows a clear "wrong password" / "switching…" message; **`StatusMessage`** gains an `info` variant.
- **`translations.ts`** — `wifi.switching` + `wifi.wrongPassword`.

## Verification

Verified on a Jetson end-to-end: a wrong password now surfaces "Wrong Wi-Fi password" (instead of the box vanishing) and the AP reopens for a retry; a correct password completes the handoff.

## Scope / notes

Setup Wi-Fi step only. This is the **base of a stack** — the ethernet-first WiFi step builds on the `ConnectStatus` / poll plumbing here, so a couple of `ConnectStatus` fields written here (`ssid`, `at`) are consumed by that follow-up, not this PR.
