### PR TITLE
fix: stop ClawBox AI tier badge flapping Free <-> Pro on portal blips

### DIFF
--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { readConfig } from "@/lib/openclaw-config";
-import { get as getConfigValue } from "@/lib/config-store";
+import { get as getConfigValue, set as setConfigValue } from "@/lib/config-store";
 import { normalizeClawboxAiTier, type ClawboxAiTier } from "@/lib/clawbox-ai-models";
 
 export const dynamic = "force-dynamic";
@@ -287,6 +287,13 @@ export async function GET() {
         if (lookup.source === "portal") {
           clawaiAccountTier = lookup.tier;
           accountTierSource = "portal";
+          // Persist the portal-confirmed tier so the portal-unreachable
+          // fallback reflects the last *confirmed* tier, not a stale
+          // configure-time value (which flapped a Free badge to Pro and
+          // re-fired the celebration). Write only on change to avoid churn.
+          if (lookup.tier !== localTier) {
+            await setConfigValue(CLAWBOX_AI_TIER_CONFIG_KEY, lookup.tier).catch(() => {});
+          }
         }
       }
     }

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -6,13 +6,15 @@ vi.mock("@/lib/openclaw-config", () => ({
 
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(),
+  set: vi.fn(),
 }));
 
 import { readConfig } from "@/lib/openclaw-config";
-import { get as getConfigValue } from "@/lib/config-store";
+import { get as getConfigValue, set as setConfigValue } from "@/lib/config-store";
 
 const mockReadConfig = vi.mocked(readConfig);
 const mockGetConfigValue = vi.mocked(getConfigValue);
+const mockSetConfigValue = vi.mocked(setConfigValue);
 
 describe("/setup-api/ai-models/status", () => {
   let GET: () => Promise<Response>;
@@ -23,6 +25,7 @@ describe("/setup-api/ai-models/status", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mockGetConfigValue.mockResolvedValue(null);
+    mockSetConfigValue.mockResolvedValue(undefined);
     fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
     const mod = await import("@/app/setup-api/ai-models/status/route");
@@ -175,6 +178,36 @@ describe("/setup-api/ai-models/status", () => {
 
       expect(body.clawaiTier).toBeNull();
       expect(body.tierSource).toBe("portal");
+    });
+
+    it("persists the portal-confirmed tier so the unreachable-fallback stops flapping", async () => {
+      // Free account whose stored clawai_tier is a stale "flash" (paid badge).
+      // The portal confirms Free, so we persist null — a later portal blip
+      // then falls back to Free instead of resurfacing the paid badge and
+      // re-firing the tier-upgrade celebration.
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("flash");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "free", deviceTier: null }),
+        { status: 200 },
+      ));
+
+      await GET();
+
+      expect(mockSetConfigValue).toHaveBeenCalledWith("clawai_tier", null);
+    });
+
+    it("does not rewrite clawai_tier when the portal confirms the stored tier", async () => {
+      mockReadConfig.mockResolvedValue(clawaiConfigBase as never);
+      mockGetConfigValue.mockResolvedValue("pro");
+      fetchSpy.mockResolvedValue(new Response(
+        JSON.stringify({ tier: "max", deviceTier: "pro" }),
+        { status: 200 },
+      ));
+
+      await GET();
+
+      expect(mockSetConfigValue).not.toHaveBeenCalled();
     });
 
     it("queries the portal even when local picker is unset so Free → Paid upgrades are visible without re-login", async () => {


### PR DESCRIPTION
## What

Fixes the ClawBox AI tier badge + upgrade-celebration flapping **Free ↔ Pro** on transient portal blips — a stable Free account sees a false "Welcome to ClawBox Pro 🎉" then immediately "You're now on the Free plan".

## Cause

The status route seeds the badge tier from the stored `clawai_tier`, then overrides it with a live portal lookup. When the portal lookup is briefly **unreachable** (timeout/blip), it keeps the stored value — and a Free user's stored `clawai_tier` is a stale `"flash"` (a *paid* badge) left from the optimistic picker selection at configure time. So a blip resurfaces Pro, the next good poll returns Free, and both the upgrade and downgrade celebration modals fire.

## Fix

Persist the **portal-confirmed** tier back into `clawai_tier` whenever it changes, so the unreachable-fallback reflects the last *confirmed* tier (Free → `null`) instead of the stale picker value. This fixes the badge and the celebration together (the celebration reads the same tier):

- Paid user during an outage → stored value already reconciled to their real tier → badge preserved.
- Free user → reconciled to `null` → no flap.

Self-heals existing devices on the first portal-confirmed status poll; the write is guarded to fire only on a real change (no per-poll churn). The persisted value is the already-normalized `ClawboxAiTier` from `mapPortalTier`, so the guard is idempotent.

## Validation

- Status-route unit tests: **24/24 pass**, including 2 new cases (persist-on-change, no-write-when-confirmed-equals-stored).
- Verified the portal is healthy and correctly returns `tier: "free"` for the affected account — the flap was purely the stale fallback, not the account or portal.
