### PR TITLE
ClawKeep: named, lockable, auto-cleanup backups

### DIFF
--- a/clawkeep/clawkeep/cli.py
+++ b/clawkeep/clawkeep/cli.py
@@ -25,6 +25,11 @@ Commands:
   daemon           Run a single backup cycle (alias for `clawkeepd`)
   snapshots        List cloud snapshots (JSON to stdout)
   restore          Restore a snapshot over the live state directory
+  label            Set/clear a snapshot's human label (manifest)
+  lock             Mark a snapshot as protected (never auto/manually deleted)
+  unlock           Remove a snapshot's protected flag
+  delete           Delete a snapshot (refused if locked)
+  prune            Apply retention now (keep newest N unlocked snapshots)
   set-passphrase   Set the device-local backup encryption passphrase
   clear-passphrase Remove the stored passphrase (future backups will need a new one)
   passphrase-status Print {"set": bool} as JSON
@@ -48,6 +53,16 @@ def clawkeep_main(argv: list[str] | None = None) -> int:
         return _snapshots_main(rest)
     if cmd == "restore":
         return _restore_main(rest)
+    if cmd == "label":
+        return _label_main(rest)
+    if cmd == "lock":
+        return _lock_main(rest, locked=True)
+    if cmd == "unlock":
+        return _lock_main(rest, locked=False)
+    if cmd == "delete":
+        return _delete_main(rest)
+    if cmd == "prune":
+        return _prune_main(rest)
     if cmd == "set-passphrase":
         return _set_passphrase_main(rest)
     if cmd == "clear-passphrase":
@@ -172,6 +187,143 @@ def _restore_main(argv: list[str]) -> int:
             for a in result.assets
         ],
     }))
+    return 0
+
+
+def _mint_creds(config_path: str | None):
+    """Shared setup for the manifest/snapshot-management subcommands: parse
+    config, load the token, mint short-lived R2 credentials."""
+    cfg, bearer = _load_cfg_and_token(config_path)
+    from . import api
+    return api.mint_credentials(cfg.server, bearer)
+
+
+def _manifest_entry(manifest: dict, name: str) -> dict:
+    """Return the manifest entry for `name`, creating a default one in place
+    if absent. New entries are stamped with createdAt=now so a snapshot first
+    annotated via label/lock still gets a creation time."""
+    from . import api
+    snaps = manifest.setdefault("snapshots", {})
+    entry = snaps.get(name)
+    if not isinstance(entry, dict):
+        entry = {"label": None, "locked": False, "createdAt": api.now_ms()}
+        snaps[name] = entry
+    return entry
+
+
+def _label_main(argv: list[str]) -> int:
+    """`clawkeep label <objectName> --text "<label>"` — set or clear a
+    snapshot's human label in the manifest. An empty/whitespace text clears
+    the label (sets it to null)."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="clawkeep label")
+    parser.add_argument("name", help="snapshot object name")
+    parser.add_argument("--text", default="", help="label text; empty clears it")
+    parser.add_argument("--config", default=None)
+    args = parser.parse_args(argv)
+
+    text = args.text.strip()
+    new_label = text if text else None
+    try:
+        creds = _mint_creds(args.config)
+        manifest = s3.read_manifest(creds)
+        entry = _manifest_entry(manifest, args.name)
+        entry["label"] = new_label
+        s3.write_manifest(creds, manifest)
+    except (cfg_mod.ConfigError, token.TokenError) as e:
+        return _emit_err(e, 64)
+    except Exception as e:  # noqa: BLE001
+        return _emit_err(e, 1)
+
+    print(json.dumps({"ok": True, "name": args.name, "label": new_label}))
+    return 0
+
+
+def _lock_main(argv: list[str], *, locked: bool) -> int:
+    """`clawkeep lock|unlock <objectName>` — toggle a snapshot's protected
+    flag in the manifest. A locked snapshot can't be deleted manually or by
+    auto-cleanup until it's unlocked."""
+    import argparse
+
+    prog = "clawkeep lock" if locked else "clawkeep unlock"
+    parser = argparse.ArgumentParser(prog=prog)
+    parser.add_argument("name", help="snapshot object name")
+    parser.add_argument("--config", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        creds = _mint_creds(args.config)
+        manifest = s3.read_manifest(creds)
+        entry = _manifest_entry(manifest, args.name)
+        entry["locked"] = locked
+        s3.write_manifest(creds, manifest)
+    except (cfg_mod.ConfigError, token.TokenError) as e:
+        return _emit_err(e, 64)
+    except Exception as e:  # noqa: BLE001
+        return _emit_err(e, 1)
+
+    print(json.dumps({"ok": True, "name": args.name, "locked": locked}))
+    return 0
+
+
+def _delete_main(argv: list[str]) -> int:
+    """`clawkeep delete <objectName>` — delete a snapshot object + its
+    manifest entry. Refused (exit 2, kind="locked") if the snapshot is
+    locked; the UI surfaces that as "Unlock first"."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="clawkeep delete")
+    parser.add_argument("name", help="snapshot object name")
+    parser.add_argument("--config", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        creds = _mint_creds(args.config)
+        manifest = s3.read_manifest(creds)
+        snaps = manifest.get("snapshots", {})
+        entry = snaps.get(args.name) if isinstance(snaps, dict) else None
+        if isinstance(entry, dict) and bool(entry.get("locked", False)):
+            print(json.dumps({
+                "ok": False,
+                "kind": "locked",
+                "error": f"snapshot {args.name} is locked; unlock it before deleting",
+            }))
+            return 2
+        s3.delete_snapshot(creds, args.name)
+        if isinstance(snaps, dict) and args.name in snaps:
+            snaps.pop(args.name, None)
+            s3.write_manifest(creds, manifest)
+    except (cfg_mod.ConfigError, token.TokenError) as e:
+        return _emit_err(e, 64)
+    except Exception as e:  # noqa: BLE001
+        return _emit_err(e, 1)
+
+    print(json.dumps({"ok": True, "name": args.name}))
+    return 0
+
+
+def _prune_main(argv: list[str]) -> int:
+    """`clawkeep prune --keep-last N` — run retention on demand: keep the
+    newest N unlocked snapshots, delete the rest. Locked snapshots are
+    always kept and don't count toward N. N<=0 is a no-op."""
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="clawkeep prune")
+    parser.add_argument("--keep-last", type=int, required=True, dest="keep_last")
+    parser.add_argument("--config", default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        from . import runner
+        creds = _mint_creds(args.config)
+        deleted = runner.apply_retention(creds, args.keep_last)
+    except (cfg_mod.ConfigError, token.TokenError) as e:
+        return _emit_err(e, 64)
+    except Exception as e:  # noqa: BLE001
+        return _emit_err(e, 1)
+
+    print(json.dumps({"ok": True, "deleted": deleted, "keepLast": args.keep_last}))
     return 0
 
 

--- a/clawkeep/clawkeep/daemon.py
+++ b/clawkeep/clawkeep/daemon.py
@@ -50,6 +50,11 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Run a single backup cycle and exit (default; reserved for clarity)",
     )
+    parser.add_argument(
+        "--label",
+        default=None,
+        help="Optional human label to record for this backup's snapshot",
+    )
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args(argv)
 
@@ -71,7 +76,8 @@ def main(argv: list[str] | None = None) -> int:
     if args.idle:
         return runner.run_idle(cfg, bearer)
 
-    return runner.run_once(cfg, bearer)
+    label = args.label.strip() if isinstance(args.label, str) and args.label.strip() else None
+    return runner.run_once(cfg, bearer, label=label)
 
 
 if __name__ == "__main__":

--- a/clawkeep/clawkeep/runner.py
+++ b/clawkeep/clawkeep/runner.py
@@ -8,17 +8,25 @@ schedule the next run.
 
 from __future__ import annotations
 
+import json
 import logging
 import tempfile
 import threading
 import time
 from pathlib import Path
 
-from . import api, crypto, openclaw, passphrase, s3, state
+from . import api, crypto, openclaw, passphrase, s3, state, token
 from .api import ApiError
 from .config import Config
 
 log = logging.getLogger(__name__)
+
+# Auto-cleanup retention default: keep the newest N unlocked snapshots after
+# each successful backup. Locked snapshots are always kept and never counted
+# against N. 0 (or negative) disables retention entirely. The user-facing
+# value is persisted by the TS bridge into schedule.json as
+# `retentionKeepLast`; we read it there so the device and UI stay in sync.
+DEFAULT_RETENTION_KEEP_LAST = 10
 
 # Exit codes — surfaceable to systemd via daemon.py.
 EXIT_OK = 0
@@ -124,8 +132,75 @@ def _resolve_staging(cfg: Config) -> tuple[Path, bool]:
     return Path(tempfile.mkdtemp(prefix="clawkeep-")), True
 
 
-def run_once(cfg: Config, token: str) -> int:
-    """One full backup cycle. Returns a process exit code."""
+def _retention_keep_last() -> int:
+    """Read `retentionKeepLast` from schedule.json in the data dir.
+
+    The TS bridge owns schedule.json; the daemon only reads this one scalar.
+    A missing file/field, or a malformed value, falls back to the default so
+    a botched write can't accidentally disable retention or wipe snapshots."""
+    path = token.data_dir() / "schedule.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return DEFAULT_RETENTION_KEEP_LAST
+    if not isinstance(raw, dict) or "retentionKeepLast" not in raw:
+        return DEFAULT_RETENTION_KEEP_LAST
+    try:
+        return int(raw["retentionKeepLast"])
+    except (TypeError, ValueError):
+        return DEFAULT_RETENTION_KEEP_LAST
+
+
+def apply_retention(creds: api.Credentials, keep_last: int) -> list[str]:
+    """Prune old snapshots, keeping the newest `keep_last` UNLOCKED ones.
+
+    Locked snapshots are always kept and never count against `keep_last`.
+    `keep_last <= 0` disables retention (no-op). Returns the list of deleted
+    object names (useful for logging/tests). Also lazily GCs manifest entries
+    whose backing object no longer exists.
+    """
+    if keep_last <= 0:
+        return []
+
+    snapshots = s3.list_snapshots(creds)  # newest-first, locked flag merged in
+    existing = {s.name for s in snapshots}
+    unlocked = [s for s in snapshots if not s.locked]
+    to_delete = unlocked[keep_last:]
+
+    deleted: list[str] = []
+    for snap in to_delete:
+        # Defence-in-depth: list_snapshots already filtered locked out, but
+        # never delete a locked object even if the partition logic regressed.
+        if snap.locked:
+            continue
+        s3.delete_snapshot(creds, snap.name)
+        log.info("retention: deleted old snapshot %s", snap.name)
+        deleted.append(snap.name)
+        existing.discard(snap.name)
+
+    # Rewrite the manifest: drop entries for everything we deleted plus any
+    # entry whose object is already gone (lazy GC).
+    manifest = s3.read_manifest(creds)
+    snaps = manifest.get("snapshots", {})
+    if isinstance(snaps, dict):
+        changed = False
+        for name in list(snaps.keys()):
+            if name not in existing:
+                snaps.pop(name, None)
+                changed = True
+        if changed:
+            s3.write_manifest(creds, manifest)
+
+    return deleted
+
+
+def run_once(cfg: Config, token: str, *, label: str | None = None) -> int:
+    """One full backup cycle. Returns a process exit code.
+
+    `label` optionally names the resulting snapshot — it's recorded in the
+    sidecar manifest after a successful upload. The TS bridge passes it
+    through from the UI's "Name this backup" field.
+    """
     st = state.load()
 
     # Encryption gate — refuse to run if no passphrase is set. The user-
@@ -306,6 +381,31 @@ def run_once(cfg: Config, token: str) -> int:
         # Upload finished — pin the readout at 100% before moving on.
         st.upload_bytes_done = st.upload_bytes_total
         state.save(st)
+
+        # Annotate the freshly-uploaded snapshot in the sidecar manifest
+        # (label from the caller; locked defaults to false). Best-effort: a
+        # manifest write failure must not fail an otherwise-good backup — the
+        # snapshot still exists and reads back as unnamed/unlocked.
+        try:
+            manifest = s3.read_manifest(creds)
+            snaps = manifest.setdefault("snapshots", {})
+            snaps[encrypted_path.name] = {
+                "label": label,
+                "locked": False,
+                "createdAt": api.now_ms(),
+            }
+            s3.write_manifest(creds, manifest)
+        except s3.S3Error as e:
+            log.warning("manifest annotate failed (continuing): %s", e)
+
+        # Auto-cleanup: prune old unlocked snapshots past the retention window.
+        # Locked snapshots are exempt. Best-effort — a retention failure must
+        # not fail the backup that just succeeded.
+        keep_last = _retention_keep_last()
+        try:
+            apply_retention(creds, keep_last)
+        except s3.S3Error as e:
+            log.warning("retention prune failed (continuing): %s", e)
 
         # Best-effort stats — leave the per-run fields *unsent* on failure
         # so a transient ListBucket doesn't clobber the portal's last-known

--- a/clawkeep/clawkeep/s3.py
+++ b/clawkeep/clawkeep/s3.py
@@ -11,6 +11,7 @@ unit tests, etc.) can run on a host that has not yet installed boto3.
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -18,6 +19,13 @@ from pathlib import Path
 from typing import Any, Optional
 
 from .api import Credentials
+
+# Sidecar object that annotates snapshots with a human label + lock flag.
+# Lives in the SAME prefix as the backups but is NEVER itself a snapshot:
+# it is excluded from list_snapshots()/stats() so it can't show up in the
+# UI or be counted against the user's quota / snapshotCount.
+MANIFEST_OBJECT = "manifest.json"
+MANIFEST_VERSION = 1
 
 
 class S3Error(Exception):
@@ -36,6 +44,11 @@ class Snapshot:
     name: str               # object name relative to the prefix (e.g. "<ts>-openclaw-backup.tar.gz")
     size_bytes: int
     last_modified_ms: int   # unix ms — easy for the React side to format with timeAgo()
+    # Annotations merged in from manifest.json. A snapshot with no manifest
+    # entry (e.g. created before this feature shipped) reads back as
+    # label=None, locked=False — i.e. unnamed and unprotected.
+    label: Optional[str] = None
+    locked: bool = False
 
 
 def _join(prefix: str, name: str) -> str:
@@ -115,6 +128,89 @@ def upload(
     return key
 
 
+def _empty_manifest() -> dict[str, Any]:
+    return {"version": MANIFEST_VERSION, "snapshots": {}}
+
+
+def read_manifest(creds: Credentials) -> dict[str, Any]:
+    """GET manifest.json from the prefix. A missing manifest (NoSuchKey) is
+    not an error — it just means nothing has been annotated yet, so we return
+    a fresh empty manifest. Any other S3 failure is surfaced as S3Error.
+
+    The returned dict always has a well-formed `{"version", "snapshots": {}}`
+    shape so callers can index `["snapshots"]` without guarding."""
+    try:
+        from botocore.exceptions import BotoCoreError, ClientError
+    except ImportError as e:  # pragma: no cover
+        raise S3Error("boto3/botocore not installed") from e
+
+    cli = _client(creds)
+    key = _join(creds.prefix, MANIFEST_OBJECT)
+    try:
+        resp = cli.get_object(Bucket=creds.bucket, Key=key)
+        raw = resp["Body"].read()
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code in ("NoSuchKey", "404", "NotFound"):
+            return _empty_manifest()
+        raise S3Error(f"manifest read failed for s3://{creds.bucket}/{key}: {e}") from e
+    except BotoCoreError as e:
+        raise S3Error(f"manifest read failed for s3://{creds.bucket}/{key}: {e}") from e
+
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        # A corrupt manifest shouldn't wedge backups — treat it as empty and
+        # the next write rewrites it cleanly.
+        return _empty_manifest()
+    if not isinstance(data, dict):
+        return _empty_manifest()
+    snaps = data.get("snapshots")
+    if not isinstance(snaps, dict):
+        data["snapshots"] = {}
+    data.setdefault("version", MANIFEST_VERSION)
+    return data
+
+
+def write_manifest(creds: Credentials, manifest: dict[str, Any]) -> None:
+    """PUT manifest.json into the prefix (overwrites)."""
+    try:
+        from botocore.exceptions import BotoCoreError, ClientError
+    except ImportError as e:  # pragma: no cover
+        raise S3Error("boto3/botocore not installed") from e
+
+    cli = _client(creds)
+    key = _join(creds.prefix, MANIFEST_OBJECT)
+    body = json.dumps(manifest, separators=(",", ":")).encode("utf-8")
+    try:
+        cli.put_object(
+            Bucket=creds.bucket,
+            Key=key,
+            Body=body,
+            ContentType="application/json",
+        )
+    except (BotoCoreError, ClientError) as e:
+        raise S3Error(f"manifest write failed for s3://{creds.bucket}/{key}: {e}") from e
+
+
+def delete_snapshot(creds: Credentials, object_name: str) -> None:
+    """DELETE one object under the prefix. Raises S3Error on failure.
+
+    This is the raw object delete — callers are responsible for the
+    locked-snapshot guard and for pruning the manifest entry."""
+    try:
+        from botocore.exceptions import BotoCoreError, ClientError
+    except ImportError as e:  # pragma: no cover
+        raise S3Error("boto3/botocore not installed") from e
+
+    cli = _client(creds)
+    key = _join(creds.prefix, object_name)
+    try:
+        cli.delete_object(Bucket=creds.bucket, Key=key)
+    except (BotoCoreError, ClientError) as e:
+        raise S3Error(f"delete failed for s3://{creds.bucket}/{key}: {e}") from e
+
+
 def _strip_prefix(prefix: str, key: str) -> str:
     """Return the object name without the user prefix (so the UI never has
     to know about the prefix layout)."""
@@ -148,6 +244,12 @@ def stats(creds: Credentials) -> CloudStats:
         paginator = cli.get_paginator("list_objects_v2")
         for page in paginator.paginate(Bucket=creds.bucket, Prefix=creds.prefix):
             for obj in page.get("Contents", []) or []:
+                name = _strip_prefix(creds.prefix, str(obj.get("Key", "")))
+                # The sidecar manifest is bookkeeping, not a backup — exclude it
+                # from both byte usage and the snapshot count so the UI/quota
+                # never see it.
+                if name == MANIFEST_OBJECT:
+                    continue
                 total += int(obj.get("Size", 0))
                 count += 1
     except (BotoCoreError, ClientError) as e:
@@ -167,6 +269,12 @@ def list_snapshots(creds: Credentials) -> list[Snapshot]:
     except ImportError as e:  # pragma: no cover
         raise S3Error("boto3/botocore not installed") from e
 
+    # Manifest annotations are merged in below. A read failure here would be
+    # surfaced as S3Error; a *missing* manifest yields an empty mapping so
+    # every snapshot reads back as unnamed + unlocked (back-compat).
+    manifest = read_manifest(creds)
+    entries = manifest.get("snapshots", {})
+
     cli = _client(creds)
     out: list[Snapshot] = []
     try:
@@ -181,10 +289,22 @@ def list_snapshots(creds: Credentials) -> list[Snapshot]:
                 # MinIO/some R2 lifecycles emit them, but they're not snapshots.
                 if not name or name.endswith("/"):
                     continue
+                # The sidecar manifest is never itself a snapshot.
+                if name == MANIFEST_OBJECT:
+                    continue
+                entry = entries.get(name) if isinstance(entries, dict) else None
+                label: Optional[str] = None
+                locked = False
+                if isinstance(entry, dict):
+                    raw_label = entry.get("label")
+                    label = raw_label if isinstance(raw_label, str) and raw_label else None
+                    locked = bool(entry.get("locked", False))
                 out.append(Snapshot(
                     name=name,
                     size_bytes=int(obj.get("Size", 0)),
                     last_modified_ms=_last_modified_ms(obj.get("LastModified")),
+                    label=label,
+                    locked=locked,
                 ))
     except (BotoCoreError, ClientError) as e:
         raise S3Error(f"list_objects_v2 failed for s3://{creds.bucket}/{creds.prefix}: {e}") from e

--- a/clawkeep/tests/test_cli.py
+++ b/clawkeep/tests/test_cli.py
@@ -1,0 +1,133 @@
+"""Tests for the snapshot-management CLI subcommands (label / lock / unlock /
+delete / prune). These drive the manifest mutations the TS bridge spawns.
+
+The S3 layer is stubbed: we only assert the command's control flow — locked
+guard, exit codes, JSON envelopes, and manifest mutations — not the wire.
+"""
+
+from __future__ import annotations
+
+import json
+
+from unittest.mock import patch
+
+import pytest
+
+from clawkeep import cli
+from clawkeep.api import Credentials
+
+
+CREDS = Credentials(
+    accessKeyId="AKIA",
+    secretAccessKey="secret",
+    sessionToken="session",
+    endpoint="https://acct.r2.cloudflarestorage.com",
+    bucket="clawkeep",
+    prefix="users/u_x/repo/",
+    expiresAt=9_999_999_999_999,
+    quotaBytes=5_368_709_120,
+    cloudBytes=0,
+)
+
+
+def test_delete_refuses_locked(capsys: pytest.CaptureFixture[str]) -> None:
+    manifest = {"version": 1, "snapshots": {"a.tar.gz.enc": {"locked": True}}}
+    with (
+        patch("clawkeep.cli._mint_creds", return_value=CREDS),
+        patch("clawkeep.cli.s3.read_manifest", return_value=manifest),
+        patch("clawkeep.cli.s3.delete_snapshot") as delete_snapshot,
+        patch("clawkeep.cli.s3.write_manifest") as write_manifest,
+    ):
+        rc = cli._delete_main(["a.tar.gz.enc"])
+    assert rc == 2
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is False
+    assert out["kind"] == "locked"
+    # The object must be left untouched — no delete, no manifest rewrite.
+    delete_snapshot.assert_not_called()
+    write_manifest.assert_not_called()
+
+
+def test_delete_allows_unlocked(capsys: pytest.CaptureFixture[str]) -> None:
+    manifest = {
+        "version": 1,
+        "snapshots": {"a.tar.gz.enc": {"locked": False, "label": "x"}},
+    }
+    with (
+        patch("clawkeep.cli._mint_creds", return_value=CREDS),
+        patch("clawkeep.cli.s3.read_manifest", return_value=manifest),
+        patch("clawkeep.cli.s3.delete_snapshot") as delete_snapshot,
+        patch("clawkeep.cli.s3.write_manifest") as write_manifest,
+    ):
+        rc = cli._delete_main(["a.tar.gz.enc"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    delete_snapshot.assert_called_once_with(CREDS, "a.tar.gz.enc")
+    # Manifest entry pruned after the object delete.
+    written = write_manifest.call_args.args[1]
+    assert "a.tar.gz.enc" not in written["snapshots"]
+
+
+def test_lock_sets_locked_true(capsys: pytest.CaptureFixture[str]) -> None:
+    manifest = {"version": 1, "snapshots": {}}
+    with (
+        patch("clawkeep.cli._mint_creds", return_value=CREDS),
+        patch("clawkeep.cli.s3.read_manifest", return_value=manifest),
+        patch("clawkeep.cli.s3.write_manifest") as write_manifest,
+        patch("clawkeep.api.now_ms", return_value=111),
+    ):
+        rc = cli._lock_main(["a.tar.gz.enc"], locked=True)
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["locked"] is True
+    written = write_manifest.call_args.args[1]
+    # A brand-new entry is created (createdAt stamped) with locked=True.
+    assert written["snapshots"]["a.tar.gz.enc"]["locked"] is True
+
+
+def test_label_clears_on_empty_text(capsys: pytest.CaptureFixture[str]) -> None:
+    manifest = {
+        "version": 1,
+        "snapshots": {"a.tar.gz.enc": {"label": "old", "locked": False}},
+    }
+    with (
+        patch("clawkeep.cli._mint_creds", return_value=CREDS),
+        patch("clawkeep.cli.s3.read_manifest", return_value=manifest),
+        patch("clawkeep.cli.s3.write_manifest") as write_manifest,
+    ):
+        rc = cli._label_main(["a.tar.gz.enc", "--text", "   "])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["label"] is None
+    written = write_manifest.call_args.args[1]
+    assert written["snapshots"]["a.tar.gz.enc"]["label"] is None
+
+
+def test_label_sets_text(capsys: pytest.CaptureFixture[str]) -> None:
+    manifest = {"version": 1, "snapshots": {}}
+    with (
+        patch("clawkeep.cli._mint_creds", return_value=CREDS),
+        patch("clawkeep.cli.s3.read_manifest", return_value=manifest),
+        patch("clawkeep.cli.s3.write_manifest") as write_manifest,
+        patch("clawkeep.api.now_ms", return_value=222),
+    ):
+        rc = cli._label_main(["a.tar.gz.enc", "--text", "Before v3 upgrade"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["label"] == "Before v3 upgrade"
+    written = write_manifest.call_args.args[1]
+    assert written["snapshots"]["a.tar.gz.enc"]["label"] == "Before v3 upgrade"
+
+
+def test_prune_delegates_to_apply_retention(capsys: pytest.CaptureFixture[str]) -> None:
+    with (
+        patch("clawkeep.cli._mint_creds", return_value=CREDS),
+        patch("clawkeep.runner.apply_retention", return_value=["old1", "old2"]) as ret,
+    ):
+        rc = cli._prune_main(["--keep-last", "5"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["deleted"] == ["old1", "old2"]
+    assert out["keepLast"] == 5
+    ret.assert_called_once_with(CREDS, 5)

--- a/clawkeep/tests/test_runner.py
+++ b/clawkeep/tests/test_runner.py
@@ -75,6 +75,18 @@ def isolate_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     yield tmp_path / "state.json"
 
 
+@pytest.fixture(autouse=True)
+def stub_manifest(monkeypatch: pytest.MonkeyPatch):
+    """The happy-path backup now writes a sidecar manifest and runs retention
+    after a successful upload. Stub the S3-backed manifest/list calls so the
+    failure-matrix tests don't make real network calls on the post-upload
+    path. Tests that exercise retention directly re-patch these inside a
+    `with patch(...)` block, which transparently overrides these stubs."""
+    monkeypatch.setattr(s3, "read_manifest", lambda creds: {"version": 1, "snapshots": {}})
+    monkeypatch.setattr(s3, "write_manifest", lambda creds, manifest: None)
+    monkeypatch.setattr(s3, "list_snapshots", lambda creds: [])
+
+
 def test_happy_path(isolate_state: Path, tmp_path: Path) -> None:
     cfg = _cfg(tmp_path)
     archive = _archive(tmp_path)
@@ -305,6 +317,95 @@ def test_stats_failure_does_not_fail_run(isolate_state: Path, tmp_path: Path) ->
     assert final["status"] == "ok"
     assert final["cloud_bytes"] is None
     assert final["snapshot_count"] is None
+
+
+# ── Retention / auto-cleanup ──────────────────────────────────────────────
+
+
+def _snap(name: str, *, locked: bool = False, ms: int = 0) -> s3.Snapshot:
+    return s3.Snapshot(name=name, size_bytes=1, last_modified_ms=ms, locked=locked)
+
+
+def test_apply_retention_keeps_newest_and_exempts_locked() -> None:
+    # newest-first, as list_snapshots returns them. s4 is locked.
+    snaps = [
+        _snap("s5", ms=5),
+        _snap("s4", ms=4, locked=True),
+        _snap("s3", ms=3),
+        _snap("s2", ms=2),
+        _snap("s1", ms=1),
+    ]
+    deleted: list[str] = []
+    with (
+        patch("clawkeep.runner.s3.list_snapshots", return_value=snaps),
+        patch(
+            "clawkeep.runner.s3.delete_snapshot",
+            side_effect=lambda creds, name: deleted.append(name),
+        ),
+        patch("clawkeep.runner.s3.read_manifest", return_value={"version": 1, "snapshots": {}}),
+        patch("clawkeep.runner.s3.write_manifest"),
+    ):
+        result = runner.apply_retention(CREDS, keep_last=2)
+    # Unlocked newest-first: s5, s3, s2, s1. Keep 2 (s5, s3) → delete s2, s1.
+    # The locked s4 is kept and never counts toward the "2".
+    assert set(result) == {"s2", "s1"}
+    assert "s4" not in deleted
+    assert "s5" not in deleted and "s3" not in deleted
+
+
+def test_apply_retention_boundary_keeps_all_when_at_limit() -> None:
+    snaps = [_snap("s3", ms=3), _snap("s2", ms=2), _snap("s1", ms=1)]
+    deleted: list[str] = []
+    with (
+        patch("clawkeep.runner.s3.list_snapshots", return_value=snaps),
+        patch(
+            "clawkeep.runner.s3.delete_snapshot",
+            side_effect=lambda creds, name: deleted.append(name),
+        ),
+        patch("clawkeep.runner.s3.read_manifest", return_value={"version": 1, "snapshots": {}}),
+        patch("clawkeep.runner.s3.write_manifest"),
+    ):
+        result = runner.apply_retention(CREDS, keep_last=3)
+    assert result == []
+    assert deleted == []
+
+
+def test_apply_retention_disabled_when_keep_last_zero() -> None:
+    with (
+        patch("clawkeep.runner.s3.list_snapshots") as ls,
+        patch("clawkeep.runner.s3.delete_snapshot") as ds,
+    ):
+        result = runner.apply_retention(CREDS, keep_last=0)
+    assert result == []
+    ls.assert_not_called()
+    ds.assert_not_called()
+
+
+def test_apply_retention_gcs_stale_manifest_entries() -> None:
+    # Only s2/s1 exist now; the manifest still references a long-gone object.
+    snaps = [_snap("s2", ms=2), _snap("s1", ms=1)]
+    manifest = {
+        "version": 1,
+        "snapshots": {
+            "s2": {"label": "keep", "locked": False, "createdAt": 2},
+            "ghost": {"label": "deleted ages ago", "locked": False, "createdAt": 0},
+        },
+    }
+    written: list[dict] = []
+    with (
+        patch("clawkeep.runner.s3.list_snapshots", return_value=snaps),
+        patch("clawkeep.runner.s3.delete_snapshot"),
+        patch("clawkeep.runner.s3.read_manifest", return_value=manifest),
+        patch(
+            "clawkeep.runner.s3.write_manifest",
+            side_effect=lambda creds, m: written.append(m),
+        ),
+    ):
+        runner.apply_retention(CREDS, keep_last=10)
+    assert len(written) == 1
+    snaps_out = written[0]["snapshots"]
+    assert "ghost" not in snaps_out  # lazily GC'd
+    assert "s2" in snaps_out
 
 
 def test_idle_skips_when_recent_heartbeat(isolate_state: Path, tmp_path: Path) -> None:

--- a/clawkeep/tests/test_s3.py
+++ b/clawkeep/tests/test_s3.py
@@ -121,6 +121,145 @@ def test_list_snapshots_strips_prefix_and_sorts_newest_first() -> None:
     assert snaps[0].last_modified_ms == int(newer.timestamp() * 1000)
 
 
+def _manifest_backed_client() -> MagicMock:
+    """A fake S3 client whose get_object/put_object back a single in-memory
+    manifest blob, so read_manifest/write_manifest round-trip realistically."""
+    from botocore.exceptions import ClientError
+
+    store: dict[str, bytes] = {}
+    fake_client = MagicMock()
+
+    def _put(Bucket: str, Key: str, Body: bytes, **_kw: object) -> dict:
+        store[Key] = Body if isinstance(Body, bytes) else bytes(Body)
+        return {}
+
+    def _get(Bucket: str, Key: str) -> dict:
+        if Key not in store:
+            raise ClientError(
+                {"Error": {"Code": "NoSuchKey", "Message": "missing"}}, "GetObject",
+            )
+        body = MagicMock()
+        body.read.return_value = store[Key]
+        return {"Body": body}
+
+    fake_client.put_object.side_effect = _put
+    fake_client.get_object.side_effect = _get
+    return fake_client
+
+
+def test_read_manifest_missing_returns_empty() -> None:
+    fake_client = _manifest_backed_client()
+    with patch("clawkeep.s3._client", return_value=fake_client):
+        m = s3.read_manifest(CREDS)
+    assert m == {"version": 1, "snapshots": {}}
+
+
+def test_manifest_write_read_round_trip() -> None:
+    fake_client = _manifest_backed_client()
+    manifest = {
+        "version": 1,
+        "snapshots": {
+            "snap.tar.gz.enc": {"label": "Before v3", "locked": True, "createdAt": 123},
+        },
+    }
+    with patch("clawkeep.s3._client", return_value=fake_client):
+        s3.write_manifest(CREDS, manifest)
+        got = s3.read_manifest(CREDS)
+    entry = got["snapshots"]["snap.tar.gz.enc"]
+    assert entry["label"] == "Before v3"
+    assert entry["locked"] is True
+    assert entry["createdAt"] == 123
+    # PUT must target manifest.json in the prefix.
+    _, kwargs = fake_client.put_object.call_args
+    assert kwargs["Key"] == "users/u_x/repo/manifest.json"
+
+
+def test_delete_snapshot_calls_delete_object() -> None:
+    fake_client = MagicMock()
+    with patch("clawkeep.s3._client", return_value=fake_client):
+        s3.delete_snapshot(CREDS, "snap.tar.gz.enc")
+    fake_client.delete_object.assert_called_once_with(
+        Bucket="clawkeep", Key="users/u_x/repo/snap.tar.gz.enc",
+    )
+
+
+def test_delete_snapshot_translates_botocore_error() -> None:
+    from botocore.exceptions import ClientError
+
+    fake_client = MagicMock()
+    fake_client.delete_object.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "no"}}, "DeleteObject",
+    )
+    with patch("clawkeep.s3._client", return_value=fake_client):
+        with pytest.raises(s3.S3Error, match="delete failed"):
+            s3.delete_snapshot(CREDS, "snap.tar.gz.enc")
+
+
+def test_list_snapshots_excludes_manifest_and_merges_annotations() -> None:
+    from datetime import datetime, timezone
+
+    from botocore.exceptions import ClientError
+
+    older = datetime(2026, 4, 28, 10, 0, 0, tzinfo=timezone.utc)
+    newer = datetime(2026, 4, 29, 10, 0, 0, tzinfo=timezone.utc)
+    fake_paginator = MagicMock()
+    fake_paginator.paginate.return_value = iter(
+        [
+            {"Contents": [
+                {"Key": "users/u_x/repo/older.tar.gz", "Size": 100, "LastModified": older},
+                {"Key": "users/u_x/repo/newer.tar.gz", "Size": 200, "LastModified": newer},
+                # The sidecar manifest must never surface as a snapshot.
+                {"Key": "users/u_x/repo/manifest.json", "Size": 42, "LastModified": newer},
+            ]},
+        ]
+    )
+    manifest = {
+        "version": 1,
+        "snapshots": {"newer.tar.gz": {"label": "Tagged", "locked": True, "createdAt": 9}},
+    }
+
+    fake_client = MagicMock()
+    fake_client.get_paginator.return_value = fake_paginator
+
+    def _get(Bucket: str, Key: str) -> dict:
+        if Key.endswith("manifest.json"):
+            body = MagicMock()
+            import json as _json
+            body.read.return_value = _json.dumps(manifest).encode("utf-8")
+            return {"Body": body}
+        raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+
+    fake_client.get_object.side_effect = _get
+    with patch("clawkeep.s3._client", return_value=fake_client):
+        snaps = s3.list_snapshots(CREDS)
+    assert [s.name for s in snaps] == ["newer.tar.gz", "older.tar.gz"]
+    assert snaps[0].label == "Tagged"
+    assert snaps[0].locked is True
+    # The unannotated one is unnamed + unlocked (back-compat default).
+    assert snaps[1].label is None
+    assert snaps[1].locked is False
+
+
+def test_stats_excludes_manifest() -> None:
+    fake_paginator = MagicMock()
+    fake_paginator.paginate.return_value = iter(
+        [
+            {"Contents": [
+                {"Key": "users/u_x/repo/a.tar.gz", "Size": 100},
+                {"Key": "users/u_x/repo/manifest.json", "Size": 42},
+                {"Key": "users/u_x/repo/b.tar.gz", "Size": 200},
+            ]},
+        ]
+    )
+    fake_client = MagicMock()
+    fake_client.get_paginator.return_value = fake_paginator
+    with patch("clawkeep.s3._client", return_value=fake_client):
+        result = s3.stats(CREDS)
+    # manifest.json contributes neither bytes nor count.
+    assert result.cloud_bytes == 300
+    assert result.snapshot_count == 2
+
+
 def test_download_calls_get_with_correct_key(tmp_path: Path) -> None:
     fake_client = MagicMock()
     dest = tmp_path / "snap.tar.gz"

--- a/docs/clawkeep-backup-mgmt-spec.md
+++ b/docs/clawkeep-backup-mgmt-spec.md
@@ -1,0 +1,78 @@
+# ClawKeep — Backup Management Spec (named / lockable / auto-cleanup)
+
+Author: Mike (architecture) for Krasi. Implement on a feature branch, open a PR. **Never push to `main`.**
+
+## Goal
+Add three capabilities to ClawKeep backups:
+1. **Named backups** — a human label per snapshot (e.g. "Before v3 upgrade").
+2. **Lock / protect flag** — a snapshot marked locked (🔒) cannot be deleted, manually or by auto-cleanup, until unlocked.
+3. **Auto-cleanup (retention)** — after each successful backup, prune old snapshots. **Default: keep last 10.** Locked snapshots are ALWAYS kept and do NOT count against the "10".
+
+## Current model (confirmed)
+- Each backup = one encrypted `.tar.gz` object in the portal-issued R2 prefix, named `<ts>-openclaw-backup.tar.gz(.enc)`.
+- `clawkeep/clawkeep/s3.py`: `upload`, `list_snapshots`, `download`, `stats`. **No delete, no metadata, no retention.**
+- `clawkeep/clawkeep/runner.py::run_once` uploads (object_name = `encrypted_path.name`, ~line 291).
+- `clawkeep/clawkeep/cli.py`: `snapshots` (JSON list) + `restore <name>` subcommands; the TS bridge spawns these.
+- TS bridge: `src/lib/clawkeep.ts`; portal routes `src/app/setup-api/clawkeep/{snapshots,restore,backup,schedule,...}/route.ts`; UI `src/components/ClawKeepApp.tsx`; i18n `src/lib/clawkeep-translations.ts` (all locales).
+
+## Storage design — sidecar manifest (DO THIS, not key-encoding)
+Store a single `manifest.json` object in the SAME R2 prefix:
+```json
+{
+  "version": 1,
+  "snapshots": {
+    "<objectName>": { "label": "Before v3 upgrade", "locked": true, "createdAt": 1733650000000 }
+  }
+}
+```
+Rationale: rename / lock / unlock = manifest rewrite, no expensive S3 object copy. Retention reads `locked` from it. The object list (`list_objects_v2`) stays the source of truth for *which* snapshots exist; the manifest only annotates them. An object with no manifest entry = unnamed, unlocked (back-compat for existing snapshots). On manifest read, drop entries whose object no longer exists (lazy GC). `manifest.json` itself must be excluded from `list_snapshots`/`stats` counting (skip key == "manifest.json").
+
+## Python changes (`clawkeep/clawkeep/`)
+### s3.py
+- `read_manifest(creds) -> dict` / `write_manifest(creds, manifest) -> None` (GET/PUT `manifest.json` in prefix; tolerate missing → empty `{"version":1,"snapshots":{}}`).
+- `delete_snapshot(creds, object_name) -> None` (delete_object; raise S3Error on failure).
+- `list_snapshots`: merge manifest annotations into each `Snapshot` → add fields `label: str|None`, `locked: bool`. Exclude `manifest.json`. Keep newest-first.
+- `stats`: exclude `manifest.json` from count/bytes.
+### runner.py
+- `run_once`: accept an optional label (from a new field in `state.json` or a one-shot file the TS bridge writes before triggering — mirror how `passphrase-file` is passed). After successful upload, write/merge the manifest entry `{label, locked:false, createdAt:now}` for the new object, THEN run retention.
+- New `apply_retention(creds, keep_last:int)`: list snapshots newest-first; partition locked vs unlocked; keep all locked; from unlocked keep the newest `keep_last`; `delete_snapshot` the rest; update manifest (drop deleted entries). Log each deletion. Never delete locked. `keep_last<=0` disables.
+### cli.py — new subcommands (JSON in/out, spawned by TS bridge)
+- `clawkeep label <objectName> --text "<label>"` → set/clear label in manifest.
+- `clawkeep lock <objectName>` / `clawkeep unlock <objectName>` → toggle locked.
+- `clawkeep delete <objectName>` → refuse with `{"ok":false,"kind":"locked"}` exit code 2 if locked; else delete object + manifest entry.
+- `clawkeep prune --keep-last N` → run `apply_retention` on demand.
+- Extend `snapshots` JSON output: each item gains `label`, `locked`.
+- Add retention config to backup flow: read `keepLast` from `schedule.json`/config (see TS below).
+
+## Retention config (user-adjustable, default 10)
+- Add `retentionKeepLast: number` (default `10`, `0` = disabled) to the schedule/config surface in `src/lib/clawkeep.ts` (`ClawKeepSchedule` + `DEFAULT_SCHEDULE` + `sanitiseSchedule`) and persist via the existing `schedule.json` mechanism + `schedule/route.ts`.
+- The device runner reads it (passed through config or read from schedule.json) and calls `apply_retention(keep_last=retentionKeepLast)` after each successful backup. `0` → skip.
+
+## TS bridge + portal routes (`src/`)
+- `src/lib/clawkeep.ts`: add functions to spawn the new CLI subcommands: `setSnapshotLabel(name,text)`, `lockSnapshot(name)`, `unlockSnapshot(name)`, `deleteSnapshot(name)`, `pruneSnapshots(keepLast)`. Extend the snapshot type with `label?`, `locked?`. Add `retentionKeepLast` to schedule read/write.
+- New/updated routes under `src/app/setup-api/clawkeep/`:
+  - `snapshots/route.ts` — return label+locked (already will, via CLI).
+  - `snapshots/label/route.ts` (POST `{name, label}`).
+  - `snapshots/lock/route.ts` (POST `{name, locked:boolean}`).
+  - `snapshots/delete/route.ts` (POST `{name}` — surface `kind:"locked"` 409).
+  - `schedule/route.ts` — accept/return `retentionKeepLast`.
+- Follow the existing route patterns (auth/guarding) in this folder exactly.
+
+## UI (`src/components/ClawKeepApp.tsx`)
+- Snapshot list rows: show **label** (fallback to formatted timestamp when no label), a 🔒 indicator when locked, and a row action menu: **Rename**, **Lock/Unlock**, **Delete**.
+- Delete: confirm dialog; if the snapshot is locked, the Delete action is disabled with a tooltip "Unlock first".
+- A "Name this backup" optional input when manually triggering a backup (passes label to the backup route → runner).
+- Settings: a "Keep last N backups" number input (default 10) + helper text "Locked backups are always kept" + an "off" affordance (0/disabled).
+- Wire all new strings through `src/lib/clawkeep-translations.ts` for **every locale present** (do not ship English-only — match existing keys across all languages).
+
+## Tests
+- Python unit tests for `apply_retention` (locked exemption, keep_last boundary, manifest GC), manifest read/write round-trip, delete refusing locked. Mirror the existing test style/location in the clawkeep package.
+- Update/extend the Playwright e2e specs (`e2e/clawkeep-*.spec.ts`) for the new list actions if feasible; at minimum don't break existing ones.
+
+## Constraints / acceptance
+- Locked snapshot is never deleted by any path (manual delete refused, retention skips).
+- Existing (pre-feature) snapshots with no manifest entry behave as unnamed + unlocked and are subject to retention.
+- `manifest.json` never appears as a snapshot and never counts toward quota/snapshotCount.
+- Default retention = keep last 10, user-adjustable, 0 disables.
+- All new UI text translated across all locales.
+- Feature branch + PR. Do not push to main/develop. Run the Python tests and `npm run build`/typecheck before opening the PR.

--- a/src/app/setup-api/clawkeep/backup/route.ts
+++ b/src/app/setup-api/clawkeep/backup/route.ts
@@ -37,7 +37,19 @@ export async function POST(request: NextRequest) {
       }
       idle = obj.idle;
     }
-    const result = await runBackup({ idle });
+    // Optional "Name this backup" label. Reject a non-string so a malformed
+    // form can't smuggle an object/array into the daemon's argv.
+    let label: string | undefined;
+    if (obj.label !== undefined && obj.label !== null) {
+      if (typeof obj.label !== "string") {
+        return NextResponse.json(
+          { error: "'label' must be a string when provided" },
+          { status: 400, headers: { "Cache-Control": "no-store" } },
+        );
+      }
+      label = obj.label;
+    }
+    const result = await runBackup({ idle, label });
     return NextResponse.json(
       {
         exitCode: result.exitCode,

--- a/src/app/setup-api/clawkeep/snapshots/delete/route.ts
+++ b/src/app/setup-api/clawkeep/snapshots/delete/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { ClawKeepError, deleteSnapshot, SnapshotLockedError } from "@/lib/clawkeep";
+
+export const dynamic = "force-dynamic";
+
+// POST /setup-api/clawkeep/snapshots/delete
+// Body: { name: "<object>" } — deletes the snapshot object + its manifest
+// entry. Refused with 409 / kind:"locked" if the snapshot is locked, so the
+// UI can prompt the user to "Unlock first".
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const name = body.name;
+    if (typeof name !== "string" || !name) {
+      return NextResponse.json(
+        { error: "'name' is required" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    await deleteSnapshot(name);
+    return NextResponse.json(
+      { ok: true },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    if (err instanceof SnapshotLockedError) {
+      // Distinct envelope so the UI distinguishes "locked, unlock first" from
+      // a generic delete failure without parsing the message string.
+      return NextResponse.json(
+        { error: err.message, kind: err.kind },
+        { status: err.status, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    const status = err instanceof ClawKeepError ? err.status : 500;
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to delete snapshot" },
+      { status, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/app/setup-api/clawkeep/snapshots/label/route.ts
+++ b/src/app/setup-api/clawkeep/snapshots/label/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { ClawKeepError, setSnapshotLabel } from "@/lib/clawkeep";
+
+export const dynamic = "force-dynamic";
+
+// POST /setup-api/clawkeep/snapshots/label
+// Body: { name: "<object>", label: "<text>" } — an empty/missing label
+// clears the snapshot's name. Spawns `clawkeep label` which rewrites the
+// sidecar manifest (no S3 object copy).
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const name = body.name;
+    if (typeof name !== "string" || !name) {
+      return NextResponse.json(
+        { error: "'name' is required" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    // `label` is optional — undefined/null clears it. A non-string is a bug
+    // in the caller, so reject rather than coerce.
+    const labelRaw = body.label;
+    if (labelRaw !== undefined && labelRaw !== null && typeof labelRaw !== "string") {
+      return NextResponse.json(
+        { error: "'label' must be a string when provided" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    const label = typeof labelRaw === "string" ? labelRaw : "";
+
+    await setSnapshotLabel(name, label);
+    return NextResponse.json(
+      { ok: true },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    const status = err instanceof ClawKeepError ? err.status : 500;
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to set label" },
+      { status, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/app/setup-api/clawkeep/snapshots/lock/route.ts
+++ b/src/app/setup-api/clawkeep/snapshots/lock/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { ClawKeepError, lockSnapshot, unlockSnapshot } from "@/lib/clawkeep";
+
+export const dynamic = "force-dynamic";
+
+// POST /setup-api/clawkeep/snapshots/lock
+// Body: { name: "<object>", locked: boolean } — locks (true) or unlocks
+// (false) the snapshot in the sidecar manifest. A locked snapshot can't be
+// deleted manually or by auto-cleanup until it's unlocked.
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json().catch(() => ({}))) as Record<string, unknown>;
+    const name = body.name;
+    if (typeof name !== "string" || !name) {
+      return NextResponse.json(
+        { error: "'name' is required" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+    if (typeof body.locked !== "boolean") {
+      return NextResponse.json(
+        { error: "'locked' must be a boolean" },
+        { status: 400, headers: { "Cache-Control": "no-store" } },
+      );
+    }
+
+    if (body.locked) {
+      await lockSnapshot(name);
+    } else {
+      await unlockSnapshot(name);
+    }
+    return NextResponse.json(
+      { ok: true, locked: body.locked },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  } catch (err) {
+    const status = err instanceof ClawKeepError ? err.status : 500;
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to update lock" },
+      { status, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+}

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -10,6 +10,8 @@ interface ClawKeepSchedule {
   frequency: ScheduleFrequency;
   timeOfDay: string;
   weekday: number;
+  /** Auto-cleanup window: keep the newest N unlocked snapshots. 0 disables. */
+  retentionKeepLast: number;
 }
 interface ClawKeepStatus {
   paired: boolean;
@@ -73,6 +75,10 @@ interface CloudSnapshot {
   name: string;
   size_bytes: number;
   last_modified_ms: number;
+  /** Human label from the manifest; null/absent = unnamed. */
+  label?: string | null;
+  /** Protected flag — locked snapshots can't be deleted or auto-pruned. */
+  locked?: boolean;
 }
 
 interface RestoreResponse {
@@ -313,16 +319,17 @@ export default function ClawKeepApp() {
     });
   }, [refresh, t]);
 
-  const runBackupNow = useCallback(async () => {
+  const runBackupNow = useCallback(async (label?: string) => {
     setBusy("backup");
     setError(null);
     setBackupResult(null);
     try {
+      const trimmed = label?.trim();
       const result = await jsonOrError<BackupResponse>(
         await fetch("/setup-api/clawkeep/backup", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: "{}",
+          body: JSON.stringify(trimmed ? { label: trimmed } : {}),
         }),
       );
       setBackupResult(result);
@@ -357,16 +364,16 @@ export default function ClawKeepApp() {
     });
   }, [refresh, t]);
 
-  const onBackup = useCallback(async () => {
+  const onBackup = useCallback(async (label?: string) => {
     // First-backup gate: encryption must be configured before we let the
     // runner upload anything. Without a device-local passphrase the runner
     // exits early with NEED_PASSPHRASE, but we'd rather surface that as a
     // friendly modal than as a red error banner.
     if (!status?.encryptionConfigured) {
-      setPassphraseSetup({ onSaved: () => { void runBackupNow(); } });
+      setPassphraseSetup({ onSaved: () => { void runBackupNow(label); } });
       return;
     }
-    void runBackupNow();
+    void runBackupNow(label);
   }, [status?.encryptionConfigured, runBackupNow]);
 
   // Inner restore call shared between the regular confirm flow and the
@@ -662,7 +669,8 @@ function ScheduleCard({
     draft.enabled !== schedule.enabled
     || draft.frequency !== schedule.frequency
     || draft.timeOfDay !== schedule.timeOfDay
-    || draft.weekday !== schedule.weekday;
+    || draft.weekday !== schedule.weekday
+    || draft.retentionKeepLast !== schedule.retentionKeepLast;
 
   const save = async (override?: ClawKeepSchedule) => {
     const payload = override ?? draft;
@@ -763,19 +771,49 @@ function ScheduleCard({
               </div>
             </div>
           )}
+        </div>
+      )}
 
-          {dirty && (
-            <div className="flex justify-end">
-              <button
-                type="button"
-                disabled={saving}
-                onClick={() => save()}
-                className="px-3 py-1.5 rounded-md bg-emerald-500 hover:bg-emerald-400 text-black text-xs font-semibold disabled:opacity-50 cursor-pointer"
-              >
-                {saving ? t("clawkeep.schedule.saving") : t("clawkeep.schedule.save")}
-              </button>
-            </div>
-          )}
+      {/* Retention applies to every backup (manual or scheduled), so it lives
+          outside the enabled-only block. */}
+      <div className="space-y-1.5 pt-1 border-t border-white/5">
+        <div className="flex items-center gap-3 flex-wrap">
+          <label htmlFor="clawkeep-keep-last" className="text-xs text-[var(--text-muted)]">
+            {t("clawkeep.schedule.keepLast")}
+          </label>
+          <input
+            id="clawkeep-keep-last"
+            type="number"
+            min={0}
+            max={9999}
+            value={draft.retentionKeepLast}
+            onChange={(e) => {
+              const n = Math.max(0, Math.floor(Number(e.target.value)));
+              setDraft((d) => ({ ...d, retentionKeepLast: Number.isFinite(n) ? n : 0 }));
+            }}
+            className="w-20 px-2.5 py-1.5 rounded-md bg-[var(--bg-app)] border border-white/10 text-sm text-gray-200 focus:outline-none focus:border-emerald-500/50"
+          />
+          <span className="text-xs text-[var(--text-muted)]">
+            {t("clawkeep.schedule.keepLastUnit")}
+          </span>
+        </div>
+        <p className="text-[11px] text-[var(--text-muted)]">
+          {draft.retentionKeepLast === 0
+            ? t("clawkeep.schedule.keepLastOff")
+            : t("clawkeep.schedule.keepLastHelp")}
+        </p>
+      </div>
+
+      {dirty && (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => save()}
+            className="px-3 py-1.5 rounded-md bg-emerald-500 hover:bg-emerald-400 text-black text-xs font-semibold disabled:opacity-50 cursor-pointer"
+          >
+            {saving ? t("clawkeep.schedule.saving") : t("clawkeep.schedule.save")}
+          </button>
         </div>
       )}
     </div>
@@ -1231,12 +1269,15 @@ function DashboardCard({
   busyKind,
 }: {
   status: ClawKeepStatus;
-  onBackup: () => void;
+  onBackup: (label?: string) => void;
   onOpenRestore: () => void;
   onResetStuck: () => void;
   busyKind: "backup" | "restore" | null;
 }) {
   const { t } = useT();
+  // Optional "Name this backup" field for the manual run — passed to the
+  // daemon as the snapshot label. Cleared after we hand it off.
+  const [backupName, setBackupName] = useState("");
   if (busyKind) {
     const stepKey = busyKind === "backup" ? STEP_LABEL_KEYS[status.currentStep] : undefined;
     return (
@@ -1314,11 +1355,32 @@ function DashboardCard({
         <Stat label={t("clawkeep.stat.snapshots")} value={status.snapshotCount.toString()} />
       </div>
 
+      {/* Optional name for this backup → becomes the snapshot's label */}
+      {!disabled && (
+        <div className="relative mt-6 w-full max-w-xs">
+          <label
+            htmlFor="clawkeep-backup-name"
+            className="block text-[10px] uppercase tracking-wider text-[var(--text-muted)] mb-1"
+          >
+            {t("clawkeep.backup.nameLabel")}
+          </label>
+          <input
+            id="clawkeep-backup-name"
+            type="text"
+            value={backupName}
+            maxLength={120}
+            onChange={(e) => setBackupName(e.target.value)}
+            placeholder={t("clawkeep.backup.namePlaceholder")}
+            className="w-full px-3 py-2 rounded-lg bg-[var(--bg-app)] border border-white/10 text-sm text-gray-200 placeholder:text-[var(--text-muted)]/60 focus:outline-none focus:border-emerald-500/50"
+          />
+        </div>
+      )}
+
       {/* Action row */}
-      <div className="relative mt-7 flex flex-wrap items-center justify-center gap-3">
+      <div className="relative mt-5 flex flex-wrap items-center justify-center gap-3">
         <button
           type="button"
-          onClick={onBackup}
+          onClick={() => onBackup(backupName)}
           disabled={disabled}
           className={`px-6 py-2.5 rounded-full ${copy.primaryClass} disabled:opacity-50 text-white text-sm font-semibold shadow-lg transition-colors cursor-pointer`}
         >
@@ -1460,6 +1522,11 @@ function RestoreModal({
   const { t } = useT();
   const [snapshots, setSnapshots] = useState<CloudSnapshot[] | null>(null);
   const [loading, setLoading] = useState(true);
+  // Per-row action state: which snapshot is being renamed (+ its draft text),
+  // which is pending a delete confirm, and which has an in-flight mutation.
+  const [editing, setEditing] = useState<{ name: string; text: string } | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<string | null>(null);
+  const [busyName, setBusyName] = useState<string | null>(null);
   // Pin the callbacks to refs so the fetch effect doesn't refire when the
   // parent passes inline arrows that change identity on every render.
   const onCloseRef = useRef(onClose);
@@ -1467,27 +1534,85 @@ function RestoreModal({
   useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
   useEffect(() => { onErrorRef.current = onError; }, [onError]);
 
-  useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await jsonOrError<{ snapshots: CloudSnapshot[] }>(
-          await fetch("/setup-api/clawkeep/snapshots", { cache: "no-store" }),
-        );
-        if (!cancelled) setSnapshots(data.snapshots);
-      } catch (e) {
-        if (!cancelled) {
-          onErrorRef.current((e as Error).message);
-          onCloseRef.current();
-        }
-      } finally {
-        if (!cancelled) setLoading(false);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+  const load = useCallback(async (opts: { initial?: boolean } = {}) => {
+    if (opts.initial) setLoading(true);
+    try {
+      const data = await jsonOrError<{ snapshots: CloudSnapshot[] }>(
+        await fetch("/setup-api/clawkeep/snapshots", { cache: "no-store" }),
+      );
+      setSnapshots(data.snapshots);
+    } catch (e) {
+      onErrorRef.current((e as Error).message);
+      // Only bail out of the modal on the very first load — a transient
+      // refetch failure after an action shouldn't yank the dialog closed.
+      if (opts.initial) onCloseRef.current();
+    } finally {
+      if (opts.initial) setLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    void load({ initial: true });
+  }, [load]);
+
+  // Rename a snapshot (empty text clears the label back to the timestamp).
+  const doRename = useCallback(async (name: string, text: string) => {
+    setBusyName(name);
+    try {
+      await jsonOrError(
+        await fetch("/setup-api/clawkeep/snapshots/label", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, label: text }),
+        }),
+      );
+      setEditing(null);
+      await load();
+    } catch (e) {
+      onErrorRef.current((e as Error).message);
+    } finally {
+      setBusyName(null);
+    }
+  }, [load]);
+
+  const doToggleLock = useCallback(async (s: CloudSnapshot) => {
+    setBusyName(s.name);
+    try {
+      await jsonOrError(
+        await fetch("/setup-api/clawkeep/snapshots/lock", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: s.name, locked: !s.locked }),
+        }),
+      );
+      await load();
+    } catch (e) {
+      onErrorRef.current((e as Error).message);
+    } finally {
+      setBusyName(null);
+    }
+  }, [load]);
+
+  const doDelete = useCallback(async (name: string) => {
+    setBusyName(name);
+    try {
+      const res = await fetch("/setup-api/clawkeep/snapshots/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      setConfirmDelete(null);
+      await load();
+    } catch (e) {
+      onErrorRef.current((e as Error).message);
+    } finally {
+      setBusyName(null);
+    }
+  }, [load]);
 
   // Esc closes the modal — basic dialog hygiene; the click-on-backdrop
   // handler covers the mouse path.
@@ -1578,47 +1703,159 @@ function RestoreModal({
               {snapshots.map((s, idx) => {
                 const parsed = parseSnapshotName(s.name);
                 const newest = idx === 0;
+                const locked = !!s.locked;
+                const rowBusy = busyName === s.name;
+                const timestampLabel = parsed ? `${parsed.date} · ${parsed.time}` : s.name;
+                // Prefer the human label; fall back to the formatted timestamp.
+                const title = s.label && s.label.trim() ? s.label : timestampLabel;
+                const isEditing = editing?.name === s.name;
+                const isConfirmingDelete = confirmDelete === s.name;
                 return (
-                  <li key={s.name}>
-                    <button
-                      type="button"
-                      onClick={() => onPick(s.name)}
-                      className="group w-full text-left rounded-xl border border-white/10 bg-white/[0.02] hover:bg-emerald-500/[0.08] hover:border-emerald-500/40 px-4 py-3 cursor-pointer transition-colors flex items-center gap-3"
-                    >
-                      <div className="shrink-0 w-10 h-10 rounded-lg bg-white/[0.04] group-hover:bg-emerald-500/15 border border-white/5 group-hover:border-emerald-500/30 flex items-center justify-center transition-colors">
+                  <li
+                    key={s.name}
+                    className="rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="shrink-0 w-10 h-10 rounded-lg bg-white/[0.04] border border-white/5 flex items-center justify-center">
                         <span
-                          className="material-symbols-rounded text-[var(--text-muted)] group-hover:text-emerald-300"
+                          className={`material-symbols-rounded ${locked ? "text-amber-300" : "text-[var(--text-muted)]"}`}
                           style={{ fontSize: 20, fontVariationSettings: "'FILL' 1" }}
                           aria-hidden="true"
                         >
-                          inventory_2
+                          {locked ? "lock" : "inventory_2"}
                         </span>
                       </div>
                       <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="text-sm font-semibold text-gray-100 truncate">
-                            {parsed ? `${parsed.date} · ${parsed.time}` : s.name}
-                          </span>
-                          {newest && (
-                            <span className="shrink-0 px-1.5 py-0.5 rounded-full bg-emerald-500/15 text-emerald-300 text-[9px] font-bold tracking-wider border border-emerald-500/30">
-                              {t("clawkeep.restoreModal.latest")}
-                            </span>
-                          )}
-                        </div>
-                        <div className="mt-0.5 text-[11px] text-[var(--text-muted)] flex items-center gap-2">
-                          <span>{formatBytes(s.size_bytes)}</span>
-                          <span aria-hidden="true">·</span>
-                          <span>{timeAgo(s.last_modified_ms, t)}</span>
-                        </div>
+                        {isEditing ? (
+                          <div className="flex items-center gap-2">
+                            <input
+                              type="text"
+                              autoFocus
+                              value={editing.text}
+                              maxLength={120}
+                              onChange={(e) => setEditing({ name: s.name, text: e.target.value })}
+                              onKeyDown={(e) => {
+                                if (e.key === "Enter") void doRename(s.name, editing.text);
+                                if (e.key === "Escape") setEditing(null);
+                              }}
+                              placeholder={t("clawkeep.snapshot.renamePlaceholder")}
+                              className="flex-1 min-w-0 px-2.5 py-1.5 rounded-md bg-[var(--bg-app)] border border-white/10 text-sm text-gray-200 focus:outline-none focus:border-emerald-500/50"
+                            />
+                            <button
+                              type="button"
+                              disabled={rowBusy}
+                              onClick={() => void doRename(s.name, editing.text)}
+                              className="shrink-0 px-2.5 py-1.5 rounded-md bg-emerald-500 hover:bg-emerald-400 text-black text-xs font-semibold disabled:opacity-50 cursor-pointer"
+                            >
+                              {t("clawkeep.snapshot.save")}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setEditing(null)}
+                              className="shrink-0 px-2.5 py-1.5 rounded-md border border-white/10 text-xs text-[var(--text-secondary)] hover:bg-white/5 cursor-pointer"
+                            >
+                              {t("clawkeep.cancel")}
+                            </button>
+                          </div>
+                        ) : (
+                          <>
+                            <div className="flex items-center gap-2">
+                              <span className="text-sm font-semibold text-gray-100 truncate">
+                                {title}
+                              </span>
+                              {locked && (
+                                <span
+                                  className="shrink-0 px-1.5 py-0.5 rounded-full bg-amber-500/15 text-amber-300 text-[9px] font-bold tracking-wider border border-amber-500/30"
+                                  title={t("clawkeep.snapshot.locked")}
+                                >
+                                  🔒 {t("clawkeep.snapshot.locked")}
+                                </span>
+                              )}
+                              {newest && (
+                                <span className="shrink-0 px-1.5 py-0.5 rounded-full bg-emerald-500/15 text-emerald-300 text-[9px] font-bold tracking-wider border border-emerald-500/30">
+                                  {t("clawkeep.restoreModal.latest")}
+                                </span>
+                              )}
+                            </div>
+                            <div className="mt-0.5 text-[11px] text-[var(--text-muted)] flex items-center gap-2">
+                              {/* When a custom label is shown above, surface the
+                                  timestamp here so the user still sees when it ran. */}
+                              {s.label && s.label.trim() && (
+                                <>
+                                  <span>{timestampLabel}</span>
+                                  <span aria-hidden="true">·</span>
+                                </>
+                              )}
+                              <span>{formatBytes(s.size_bytes)}</span>
+                              <span aria-hidden="true">·</span>
+                              <span>{timeAgo(s.last_modified_ms, t)}</span>
+                            </div>
+                          </>
+                        )}
                       </div>
-                      <span
-                        className="shrink-0 material-symbols-rounded text-[var(--text-muted)]/50 group-hover:text-emerald-400 transition-colors"
-                        style={{ fontSize: 18 }}
-                        aria-hidden="true"
-                      >
-                        chevron_right
-                      </span>
-                    </button>
+                    </div>
+
+                    {!isEditing && (
+                      <div className="mt-2.5 flex flex-wrap items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => onPick(s.name)}
+                          className="px-3 py-1.5 rounded-md bg-emerald-500/15 border border-emerald-500/30 text-emerald-200 text-xs font-semibold hover:bg-emerald-500/25 cursor-pointer flex items-center gap-1.5"
+                        >
+                          <span className="material-symbols-rounded" style={{ fontSize: 14 }} aria-hidden="true">
+                            cloud_download
+                          </span>
+                          {t("clawkeep.restoreButton")}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={rowBusy}
+                          onClick={() =>
+                            setEditing({ name: s.name, text: s.label && s.label.trim() ? s.label : "" })
+                          }
+                          className="px-3 py-1.5 rounded-md border border-white/10 text-xs text-[var(--text-secondary)] hover:bg-white/5 disabled:opacity-50 cursor-pointer"
+                        >
+                          {t("clawkeep.snapshot.rename")}
+                        </button>
+                        <button
+                          type="button"
+                          disabled={rowBusy}
+                          onClick={() => void doToggleLock(s)}
+                          className="px-3 py-1.5 rounded-md border border-white/10 text-xs text-[var(--text-secondary)] hover:bg-white/5 disabled:opacity-50 cursor-pointer"
+                        >
+                          {locked ? t("clawkeep.snapshot.unlock") : t("clawkeep.snapshot.lock")}
+                        </button>
+                        {isConfirmingDelete ? (
+                          <span className="flex items-center gap-2">
+                            <button
+                              type="button"
+                              disabled={rowBusy}
+                              onClick={() => void doDelete(s.name)}
+                              className="px-3 py-1.5 rounded-md bg-red-500/80 hover:bg-red-500 text-white text-xs font-semibold disabled:opacity-50 cursor-pointer"
+                            >
+                              {t("clawkeep.snapshot.confirmDelete")}
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => setConfirmDelete(null)}
+                              className="px-3 py-1.5 rounded-md border border-white/10 text-xs text-[var(--text-secondary)] hover:bg-white/5 cursor-pointer"
+                            >
+                              {t("clawkeep.cancel")}
+                            </button>
+                          </span>
+                        ) : (
+                          <button
+                            type="button"
+                            disabled={rowBusy || locked}
+                            title={locked ? t("clawkeep.snapshot.deleteLockedTooltip") : undefined}
+                            onClick={() => setConfirmDelete(s.name)}
+                            className="px-3 py-1.5 rounded-md border border-red-500/20 text-xs text-red-300/80 hover:bg-red-500/10 hover:text-red-200 disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+                          >
+                            {t("clawkeep.snapshot.delete")}
+                          </button>
+                        )}
+                      </div>
+                    )}
                   </li>
                 );
               })}

--- a/src/lib/clawkeep-translations.ts
+++ b/src/lib/clawkeep-translations.ts
@@ -165,6 +165,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Decrypt & restore",
     "clawkeep.encryption.wrongPassphrase": "That passphrase didn't decrypt this archive. Try again?",
     "clawkeep.encryption.restoreFailed": "Restore failed.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Name this backup (optional)",
+    "clawkeep.backup.namePlaceholder": "e.g. Before v3 upgrade",
+    "clawkeep.schedule.keepLast": "Keep last",
+    "clawkeep.schedule.keepLastUnit": "backups",
+    "clawkeep.schedule.keepLastHelp": "Locked backups are always kept.",
+    "clawkeep.schedule.keepLastOff": "0 = keep every backup (no auto-cleanup).",
+    "clawkeep.snapshot.rename": "Rename",
+    "clawkeep.snapshot.renamePlaceholder": "Backup name",
+    "clawkeep.snapshot.save": "Save",
+    "clawkeep.snapshot.lock": "Lock",
+    "clawkeep.snapshot.unlock": "Unlock",
+    "clawkeep.snapshot.locked": "Locked",
+    "clawkeep.snapshot.delete": "Delete",
+    "clawkeep.snapshot.confirmDelete": "Confirm delete",
+    "clawkeep.snapshot.deleteLockedTooltip": "Unlock first",
   },
 
   bg: {
@@ -303,6 +320,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Декриптирай и възстанови",
     "clawkeep.encryption.wrongPassphrase": "Тази парола не декриптира този архив. Опитай отново?",
     "clawkeep.encryption.restoreFailed": "Възстановяването се провали.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Назовете този архив (по избор)",
+    "clawkeep.backup.namePlaceholder": "напр. Преди ъпгрейд до v3",
+    "clawkeep.schedule.keepLast": "Запази последните",
+    "clawkeep.schedule.keepLastUnit": "архива",
+    "clawkeep.schedule.keepLastHelp": "Заключените архиви винаги се запазват.",
+    "clawkeep.schedule.keepLastOff": "0 = запазвай всеки архив (без авто-почистване).",
+    "clawkeep.snapshot.rename": "Преименуване",
+    "clawkeep.snapshot.renamePlaceholder": "Име на архива",
+    "clawkeep.snapshot.save": "Запази",
+    "clawkeep.snapshot.lock": "Заключи",
+    "clawkeep.snapshot.unlock": "Отключи",
+    "clawkeep.snapshot.locked": "Заключен",
+    "clawkeep.snapshot.delete": "Изтрий",
+    "clawkeep.snapshot.confirmDelete": "Потвърди изтриване",
+    "clawkeep.snapshot.deleteLockedTooltip": "Първо отключете",
   },
 
   de: {
@@ -441,6 +475,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Entschlüsseln & Wiederherstellen",
     "clawkeep.encryption.wrongPassphrase": "Diese Passphrase hat das Archiv nicht entschlüsselt. Erneut versuchen?",
     "clawkeep.encryption.restoreFailed": "Wiederherstellung fehlgeschlagen.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Dieses Backup benennen (optional)",
+    "clawkeep.backup.namePlaceholder": "z. B. Vor v3-Upgrade",
+    "clawkeep.schedule.keepLast": "Letzte behalten",
+    "clawkeep.schedule.keepLastUnit": "Backups",
+    "clawkeep.schedule.keepLastHelp": "Gesperrte Backups werden immer behalten.",
+    "clawkeep.schedule.keepLastOff": "0 = jedes Backup behalten (keine automatische Bereinigung).",
+    "clawkeep.snapshot.rename": "Umbenennen",
+    "clawkeep.snapshot.renamePlaceholder": "Backup-Name",
+    "clawkeep.snapshot.save": "Speichern",
+    "clawkeep.snapshot.lock": "Sperren",
+    "clawkeep.snapshot.unlock": "Entsperren",
+    "clawkeep.snapshot.locked": "Gesperrt",
+    "clawkeep.snapshot.delete": "Löschen",
+    "clawkeep.snapshot.confirmDelete": "Löschen bestätigen",
+    "clawkeep.snapshot.deleteLockedTooltip": "Zuerst entsperren",
   },
 
   es: {
@@ -579,6 +630,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Descifrar y restaurar",
     "clawkeep.encryption.wrongPassphrase": "Esa contraseña no descifró este archivo. ¿Probamos de nuevo?",
     "clawkeep.encryption.restoreFailed": "Restauración fallida.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Nombra esta copia (opcional)",
+    "clawkeep.backup.namePlaceholder": "p. ej. Antes de actualizar a v3",
+    "clawkeep.schedule.keepLast": "Conservar las últimas",
+    "clawkeep.schedule.keepLastUnit": "copias",
+    "clawkeep.schedule.keepLastHelp": "Las copias bloqueadas siempre se conservan.",
+    "clawkeep.schedule.keepLastOff": "0 = conservar todas las copias (sin limpieza automática).",
+    "clawkeep.snapshot.rename": "Renombrar",
+    "clawkeep.snapshot.renamePlaceholder": "Nombre de la copia",
+    "clawkeep.snapshot.save": "Guardar",
+    "clawkeep.snapshot.lock": "Bloquear",
+    "clawkeep.snapshot.unlock": "Desbloquear",
+    "clawkeep.snapshot.locked": "Bloqueada",
+    "clawkeep.snapshot.delete": "Eliminar",
+    "clawkeep.snapshot.confirmDelete": "Confirmar eliminación",
+    "clawkeep.snapshot.deleteLockedTooltip": "Desbloquéala primero",
   },
 
   fr: {
@@ -717,6 +785,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Déchiffrer & restaurer",
     "clawkeep.encryption.wrongPassphrase": "Ce mot de passe n'a pas déchiffré cette archive. Réessayer ?",
     "clawkeep.encryption.restoreFailed": "Échec de la restauration.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Nommer cette sauvegarde (facultatif)",
+    "clawkeep.backup.namePlaceholder": "ex. Avant la mise à niveau v3",
+    "clawkeep.schedule.keepLast": "Conserver les derniers",
+    "clawkeep.schedule.keepLastUnit": "sauvegardes",
+    "clawkeep.schedule.keepLastHelp": "Les sauvegardes verrouillées sont toujours conservées.",
+    "clawkeep.schedule.keepLastOff": "0 = conserver toutes les sauvegardes (pas de nettoyage auto).",
+    "clawkeep.snapshot.rename": "Renommer",
+    "clawkeep.snapshot.renamePlaceholder": "Nom de la sauvegarde",
+    "clawkeep.snapshot.save": "Enregistrer",
+    "clawkeep.snapshot.lock": "Verrouiller",
+    "clawkeep.snapshot.unlock": "Déverrouiller",
+    "clawkeep.snapshot.locked": "Verrouillée",
+    "clawkeep.snapshot.delete": "Supprimer",
+    "clawkeep.snapshot.confirmDelete": "Confirmer la suppression",
+    "clawkeep.snapshot.deleteLockedTooltip": "Déverrouillez d'abord",
   },
 
   it: {
@@ -855,6 +940,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Decifra e ripristina",
     "clawkeep.encryption.wrongPassphrase": "Quella passphrase non ha decifrato questo archivio. Riproviamo?",
     "clawkeep.encryption.restoreFailed": "Ripristino fallito.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Assegna un nome a questo backup (facoltativo)",
+    "clawkeep.backup.namePlaceholder": "es. Prima dell'aggiornamento a v3",
+    "clawkeep.schedule.keepLast": "Conserva gli ultimi",
+    "clawkeep.schedule.keepLastUnit": "backup",
+    "clawkeep.schedule.keepLastHelp": "I backup bloccati vengono sempre conservati.",
+    "clawkeep.schedule.keepLastOff": "0 = conserva ogni backup (nessuna pulizia automatica).",
+    "clawkeep.snapshot.rename": "Rinomina",
+    "clawkeep.snapshot.renamePlaceholder": "Nome del backup",
+    "clawkeep.snapshot.save": "Salva",
+    "clawkeep.snapshot.lock": "Blocca",
+    "clawkeep.snapshot.unlock": "Sblocca",
+    "clawkeep.snapshot.locked": "Bloccato",
+    "clawkeep.snapshot.delete": "Elimina",
+    "clawkeep.snapshot.confirmDelete": "Conferma eliminazione",
+    "clawkeep.snapshot.deleteLockedTooltip": "Sblocca prima",
   },
 
   ja: {
@@ -993,6 +1095,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "復号化して復元",
     "clawkeep.encryption.wrongPassphrase": "そのパスフレーズではこのアーカイブを復号化できませんでした。もう一度試しますか?",
     "clawkeep.encryption.restoreFailed": "復元に失敗しました。",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "このバックアップに名前を付ける（任意）",
+    "clawkeep.backup.namePlaceholder": "例: v3 アップグレード前",
+    "clawkeep.schedule.keepLast": "保持する数",
+    "clawkeep.schedule.keepLastUnit": "件",
+    "clawkeep.schedule.keepLastHelp": "ロックされたバックアップは常に保持されます。",
+    "clawkeep.schedule.keepLastOff": "0 = すべてのバックアップを保持（自動削除なし）。",
+    "clawkeep.snapshot.rename": "名前を変更",
+    "clawkeep.snapshot.renamePlaceholder": "バックアップ名",
+    "clawkeep.snapshot.save": "保存",
+    "clawkeep.snapshot.lock": "ロック",
+    "clawkeep.snapshot.unlock": "ロック解除",
+    "clawkeep.snapshot.locked": "ロック済み",
+    "clawkeep.snapshot.delete": "削除",
+    "clawkeep.snapshot.confirmDelete": "削除を確認",
+    "clawkeep.snapshot.deleteLockedTooltip": "先にロックを解除してください",
   },
 
   nl: {
@@ -1131,6 +1250,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Ontsleutelen & herstellen",
     "clawkeep.encryption.wrongPassphrase": "Dat wachtwoord ontsleutelde dit archief niet. Opnieuw proberen?",
     "clawkeep.encryption.restoreFailed": "Herstel mislukt.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Geef deze back-up een naam (optioneel)",
+    "clawkeep.backup.namePlaceholder": "bijv. Voor v3-upgrade",
+    "clawkeep.schedule.keepLast": "Bewaar laatste",
+    "clawkeep.schedule.keepLastUnit": "back-ups",
+    "clawkeep.schedule.keepLastHelp": "Vergrendelde back-ups worden altijd bewaard.",
+    "clawkeep.schedule.keepLastOff": "0 = elke back-up bewaren (geen automatische opschoning).",
+    "clawkeep.snapshot.rename": "Hernoemen",
+    "clawkeep.snapshot.renamePlaceholder": "Naam van back-up",
+    "clawkeep.snapshot.save": "Opslaan",
+    "clawkeep.snapshot.lock": "Vergrendelen",
+    "clawkeep.snapshot.unlock": "Ontgrendelen",
+    "clawkeep.snapshot.locked": "Vergrendeld",
+    "clawkeep.snapshot.delete": "Verwijderen",
+    "clawkeep.snapshot.confirmDelete": "Verwijderen bevestigen",
+    "clawkeep.snapshot.deleteLockedTooltip": "Ontgrendel eerst",
   },
 
   sv: {
@@ -1269,6 +1405,23 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "Dekryptera och återställ",
     "clawkeep.encryption.wrongPassphrase": "Den lösenfrasen dekrypterade inte arkivet. Försöka igen?",
     "clawkeep.encryption.restoreFailed": "Återställning misslyckades.",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "Namnge den här säkerhetskopian (valfritt)",
+    "clawkeep.backup.namePlaceholder": "t.ex. Före v3-uppgradering",
+    "clawkeep.schedule.keepLast": "Behåll senaste",
+    "clawkeep.schedule.keepLastUnit": "säkerhetskopior",
+    "clawkeep.schedule.keepLastHelp": "Låsta säkerhetskopior behålls alltid.",
+    "clawkeep.schedule.keepLastOff": "0 = behåll alla säkerhetskopior (ingen automatisk rensning).",
+    "clawkeep.snapshot.rename": "Byt namn",
+    "clawkeep.snapshot.renamePlaceholder": "Namn på säkerhetskopia",
+    "clawkeep.snapshot.save": "Spara",
+    "clawkeep.snapshot.lock": "Lås",
+    "clawkeep.snapshot.unlock": "Lås upp",
+    "clawkeep.snapshot.locked": "Låst",
+    "clawkeep.snapshot.delete": "Ta bort",
+    "clawkeep.snapshot.confirmDelete": "Bekräfta borttagning",
+    "clawkeep.snapshot.deleteLockedTooltip": "Lås upp först",
   },
 
   zh: {
@@ -1407,5 +1560,22 @@ export const clawkeepTranslations: Record<Locale, Record<string, string>> = {
     "clawkeep.encryption.decryptRestore": "解密并恢复",
     "clawkeep.encryption.wrongPassphrase": "该密码无法解密此归档。再试一次?",
     "clawkeep.encryption.restoreFailed": "恢复失败。",
+
+    // === Snapshot management (name / lock / retention) ===
+    "clawkeep.backup.nameLabel": "为此备份命名（可选）",
+    "clawkeep.backup.namePlaceholder": "例如：升级到 v3 之前",
+    "clawkeep.schedule.keepLast": "保留最近",
+    "clawkeep.schedule.keepLastUnit": "个备份",
+    "clawkeep.schedule.keepLastHelp": "锁定的备份始终保留。",
+    "clawkeep.schedule.keepLastOff": "0 = 保留所有备份（不自动清理）。",
+    "clawkeep.snapshot.rename": "重命名",
+    "clawkeep.snapshot.renamePlaceholder": "备份名称",
+    "clawkeep.snapshot.save": "保存",
+    "clawkeep.snapshot.lock": "锁定",
+    "clawkeep.snapshot.unlock": "解锁",
+    "clawkeep.snapshot.locked": "已锁定",
+    "clawkeep.snapshot.delete": "删除",
+    "clawkeep.snapshot.confirmDelete": "确认删除",
+    "clawkeep.snapshot.deleteLockedTooltip": "请先解锁",
   },
 };

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -84,13 +84,22 @@ export interface ClawKeepSchedule {
   timeOfDay: string;
   /** 0=Sunday … 6=Saturday. Only used when frequency === "weekly". */
   weekday: number;
+  /** Auto-cleanup: keep the newest N *unlocked* snapshots after each
+   * successful backup. Locked snapshots are always kept and never counted
+   * toward N. 0 disables retention. Read by the device runner from
+   * schedule.json. */
+  retentionKeepLast: number;
 }
+
+/** Default retention window. Keep the last 10 unlocked snapshots. */
+export const DEFAULT_RETENTION_KEEP_LAST = 10;
 
 export const DEFAULT_SCHEDULE: ClawKeepSchedule = {
   enabled: false,
   frequency: "daily",
   timeOfDay: "02:00",
   weekday: 0,
+  retentionKeepLast: DEFAULT_RETENTION_KEEP_LAST,
 };
 
 export interface ClawKeepStatus {
@@ -161,11 +170,19 @@ function sanitiseSchedule(input: unknown): ClawKeepSchedule {
   const weekday = Number.isInteger(weekdayRaw) && weekdayRaw >= 0 && weekdayRaw <= 6
     ? weekdayRaw
     : DEFAULT_SCHEDULE.weekday;
+  // retentionKeepLast: a non-negative integer; 0 disables. Anything bogus
+  // falls back to the default so a malformed file can't silently turn off
+  // retention (which would let snapshots accumulate forever).
+  const keepRaw = Number(r.retentionKeepLast);
+  const retentionKeepLast = Number.isInteger(keepRaw) && keepRaw >= 0
+    ? keepRaw
+    : DEFAULT_SCHEDULE.retentionKeepLast;
   return {
     enabled: r.enabled === true,
     frequency,
     timeOfDay: time,
     weekday,
+    retentionKeepLast,
   };
 }
 
@@ -617,6 +634,10 @@ export interface CloudSnapshot {
   name: string;
   size_bytes: number;
   last_modified_ms: number;
+  /** Human label from the sidecar manifest; null/undefined = unnamed. */
+  label?: string | null;
+  /** Protected flag — a locked snapshot can't be deleted (manual or auto). */
+  locked?: boolean;
 }
 
 interface SnapshotsResponse {
@@ -722,6 +743,101 @@ export async function listCloudSnapshots(): Promise<CloudSnapshot[]> {
   return resp.snapshots ?? [];
 }
 
+// ────────────────────────────────────────────────────────────────────
+// Snapshot management — label / lock / unlock / delete / prune
+// ────────────────────────────────────────────────────────────────────
+
+// Snapshot object names are portal-issued `<ts>-openclaw-backup.tar.gz(.enc)`.
+// Validate the shape on this side too (same regex the restore path uses) so a
+// hostile/garbled name is bounced with a clean 400 before we shell out — it
+// could never escape the portal-issued prefix anyway, but the early reject is
+// clearer for the user.
+const SNAPSHOT_NAME_RE = /^[A-Za-z0-9._-]+\.tar\.gz(\.enc)?$/;
+
+function assertSnapshotName(name: string): void {
+  if (!SNAPSHOT_NAME_RE.test(name)) {
+    throw new ClawKeepError("invalid snapshot name", 400);
+  }
+}
+
+/** Thrown when a delete is refused because the snapshot is locked. The route
+ * maps this to a 409 with `kind:"locked"` so the UI can say "Unlock first". */
+export class SnapshotLockedError extends ClawKeepError {
+  constructor(message: string, readonly kind: "locked" = "locked") {
+    super(message, 409);
+    this.name = "SnapshotLockedError";
+  }
+}
+
+interface MutationResponse {
+  ok: boolean;
+  error?: string;
+  kind?: string;
+}
+
+/** Set (or clear, when `text` is empty) a snapshot's human label. */
+export async function setSnapshotLabel(name: string, text: string): Promise<void> {
+  assertSnapshotName(name);
+  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const resp = await spawnCliJson<MutationResponse>(
+    bin,
+    "label",
+    [name, "--text", text],
+    { timeoutMs: 30_000 },
+  );
+  if (!resp.ok) {
+    throw new ClawKeepError(resp.error ?? "label failed", 502);
+  }
+}
+
+/** Mark a snapshot as protected (locked) — exempt from delete + retention. */
+export async function lockSnapshot(name: string): Promise<void> {
+  assertSnapshotName(name);
+  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const resp = await spawnCliJson<MutationResponse>(bin, "lock", [name], { timeoutMs: 30_000 });
+  if (!resp.ok) {
+    throw new ClawKeepError(resp.error ?? "lock failed", 502);
+  }
+}
+
+/** Remove a snapshot's protected flag. */
+export async function unlockSnapshot(name: string): Promise<void> {
+  assertSnapshotName(name);
+  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const resp = await spawnCliJson<MutationResponse>(bin, "unlock", [name], { timeoutMs: 30_000 });
+  if (!resp.ok) {
+    throw new ClawKeepError(resp.error ?? "unlock failed", 502);
+  }
+}
+
+/** Delete a snapshot. Refused (SnapshotLockedError) if it's locked. */
+export async function deleteSnapshot(name: string): Promise<void> {
+  assertSnapshotName(name);
+  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const resp = await spawnCliJson<MutationResponse>(bin, "delete", [name], { timeoutMs: 60_000 });
+  if (!resp.ok) {
+    if (resp.kind === "locked") {
+      throw new SnapshotLockedError(resp.error ?? "snapshot is locked");
+    }
+    throw new ClawKeepError(resp.error ?? "delete failed", 502);
+  }
+}
+
+/** Run retention on demand: keep the newest `keepLast` unlocked snapshots. */
+export async function pruneSnapshots(keepLast: number): Promise<string[]> {
+  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const resp = await spawnCliJson<MutationResponse & { deleted?: string[] }>(
+    bin,
+    "prune",
+    ["--keep-last", String(Math.max(0, Math.floor(keepLast)))],
+    { timeoutMs: 60_000 },
+  );
+  if (!resp.ok) {
+    throw new ClawKeepError(resp.error ?? "prune failed", 502);
+  }
+  return resp.deleted ?? [];
+}
+
 export async function runRestore(
   name: string,
   opts: { passphrase?: string } = {},
@@ -767,12 +883,19 @@ export async function runRestore(
   }
 }
 
-export async function runBackup(opts: { idle?: boolean } = {}): Promise<BackupResult> {
+export async function runBackup(
+  opts: { idle?: boolean; label?: string } = {},
+): Promise<BackupResult> {
   const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
   return new Promise((resolve) => {
     const env = buildSpawnEnv();
     const args = ["--config", CLAWKEEP_CONFIG_PATH];
     if (opts.idle) args.push("--idle");
+    // Optional snapshot label from the UI's "Name this backup" field. Passed
+    // as an argv pair (not a secret, unlike the passphrase) — the daemon
+    // records it in the manifest after a successful upload.
+    const label = opts.label?.trim();
+    if (label) args.push("--label", label);
     const child = spawn(bin, args, { env, stdio: ["ignore", "pipe", "pipe"] });
     let stdout = "";
     let stderr = "";

--- a/src/tests/routes/clawkeep-schedule.test.ts
+++ b/src/tests/routes/clawkeep-schedule.test.ts
@@ -74,6 +74,7 @@ describe("/setup-api/clawkeep/schedule", () => {
         frequency: "daily",
         timeOfDay: `${hh}:${mm}`,
         weekday: 0,
+        retentionKeepLast: 10,
       });
       const res = await GET();
       const body = await res.json();
@@ -90,6 +91,7 @@ describe("/setup-api/clawkeep/schedule", () => {
         frequency: "weekly",
         timeOfDay: "03:15",
         weekday: 4,
+        retentionKeepLast: 7,
       }));
       expect(res.status).toBe(200);
       const body = await res.json();
@@ -98,6 +100,7 @@ describe("/setup-api/clawkeep/schedule", () => {
         frequency: "weekly",
         timeOfDay: "03:15",
         weekday: 4,
+        retentionKeepLast: 7,
       });
       expect(scheduler.refresh).toHaveBeenCalledTimes(1);
 

--- a/src/tests/unit/clawkeep-persistence.test.ts
+++ b/src/tests/unit/clawkeep-persistence.test.ts
@@ -48,8 +48,15 @@ describe("readSchedule / writeSchedule", () => {
       frequency: "weekly",
       timeOfDay: "09:30",
       weekday: 3,
+      retentionKeepLast: 5,
     });
-    expect(written).toEqual({ enabled: true, frequency: "weekly", timeOfDay: "09:30", weekday: 3 });
+    expect(written).toEqual({
+      enabled: true,
+      frequency: "weekly",
+      timeOfDay: "09:30",
+      weekday: 3,
+      retentionKeepLast: 5,
+    });
     const reread = await clawkeep.readSchedule();
     expect(reread).toEqual(written);
   });
@@ -61,6 +68,7 @@ describe("readSchedule / writeSchedule", () => {
       frequency: "hourly",
       timeOfDay: "02:00",
       weekday: 0,
+      retentionKeepLast: 10,
     });
     expect(out.frequency).toBe("daily");
   });
@@ -71,8 +79,32 @@ describe("readSchedule / writeSchedule", () => {
       frequency: "daily",
       timeOfDay: "midnight",
       weekday: 0,
+      retentionKeepLast: 10,
     });
     expect(out.timeOfDay).toBe(clawkeep.DEFAULT_SCHEDULE.timeOfDay);
+  });
+
+  it("sanitises a bogus retentionKeepLast to the default", async () => {
+    const out = await clawkeep.writeSchedule({
+      enabled: true,
+      frequency: "daily",
+      timeOfDay: "02:00",
+      weekday: 0,
+      // @ts-expect-error -- testing runtime coercion
+      retentionKeepLast: "lots",
+    });
+    expect(out.retentionKeepLast).toBe(clawkeep.DEFAULT_SCHEDULE.retentionKeepLast);
+  });
+
+  it("keeps retentionKeepLast=0 (auto-cleanup disabled)", async () => {
+    const out = await clawkeep.writeSchedule({
+      enabled: true,
+      frequency: "daily",
+      timeOfDay: "02:00",
+      weekday: 0,
+      retentionKeepLast: 0,
+    });
+    expect(out.retentionKeepLast).toBe(0);
   });
 
   it("clamps an out-of-range weekday back to the default", async () => {
@@ -81,6 +113,7 @@ describe("readSchedule / writeSchedule", () => {
       frequency: "weekly",
       timeOfDay: "02:00",
       weekday: 12,
+      retentionKeepLast: 10,
     });
     expect(out.weekday).toBe(clawkeep.DEFAULT_SCHEDULE.weekday);
   });
@@ -92,12 +125,13 @@ describe("readSchedule / writeSchedule", () => {
       frequency: "daily",
       timeOfDay: "02:00",
       weekday: 0,
+      retentionKeepLast: 10,
     });
     expect(out.enabled).toBe(false);
   });
 
   it("schedule.json is written 0600", async () => {
-    await clawkeep.writeSchedule({ enabled: true, frequency: "daily", timeOfDay: "02:00", weekday: 0 });
+    await clawkeep.writeSchedule({ enabled: true, frequency: "daily", timeOfDay: "02:00", weekday: 0, retentionKeepLast: 10 });
     const stat = await fs.stat(path.join(DATA_DIR, "schedule.json"));
     expect(stat.mode & 0o777).toBe(0o600);
   });
@@ -115,12 +149,13 @@ describe("computeNextRunMs", () => {
       frequency: "daily",
       timeOfDay: "ninety:nine",
       weekday: 0,
+      retentionKeepLast: 10,
     };
     expect(clawkeep.computeNextRunMs(s, new Date("2026-04-29T12:00:00"))).toBe(0);
   });
 
   it("daily picks today's slot when the time is still ahead", () => {
-    const s = { enabled: true, frequency: "daily" as const, timeOfDay: "23:30", weekday: 0 };
+    const s = { enabled: true, frequency: "daily" as const, timeOfDay: "23:30", weekday: 0, retentionKeepLast: 10 };
     const now = new Date("2026-04-29T12:00:00");
     const next = new Date(clawkeep.computeNextRunMs(s, now));
     expect(next.getDate()).toBe(29);
@@ -128,7 +163,7 @@ describe("computeNextRunMs", () => {
   });
 
   it("daily rolls forward when the time has passed", () => {
-    const s = { enabled: true, frequency: "daily" as const, timeOfDay: "01:00", weekday: 0 };
+    const s = { enabled: true, frequency: "daily" as const, timeOfDay: "01:00", weekday: 0, retentionKeepLast: 10 };
     const now = new Date("2026-04-29T12:00:00");
     const next = new Date(clawkeep.computeNextRunMs(s, now));
     expect(next.getDate()).toBe(30);
@@ -136,7 +171,7 @@ describe("computeNextRunMs", () => {
   });
 
   it("weekly lands on the configured weekday in the future", () => {
-    const s = { enabled: true, frequency: "weekly" as const, timeOfDay: "02:00", weekday: 0 }; // Sunday
+    const s = { enabled: true, frequency: "weekly" as const, timeOfDay: "02:00", weekday: 0, retentionKeepLast: 10 }; // Sunday
     const now = new Date("2026-04-29T12:00:00"); // Wednesday
     const next = new Date(clawkeep.computeNextRunMs(s, now));
     expect(next.getDay()).toBe(0);
@@ -229,6 +264,7 @@ describe("getStatus", () => {
       frequency: "daily",
       timeOfDay: `${hh}:${mm}`,
       weekday: 0,
+      retentionKeepLast: 10,
     });
     const status = await clawkeep.getStatus();
     expect(status.schedule.enabled).toBe(true);

--- a/src/tests/unit/clawkeep-schedule.test.ts
+++ b/src/tests/unit/clawkeep-schedule.test.ts
@@ -7,6 +7,7 @@ const baseSchedule: ClawKeepSchedule = {
   frequency: "daily",
   timeOfDay: "02:00",
   weekday: 0,
+  retentionKeepLast: 10,
 };
 
 describe("computeNextRunMs", () => {


### PR DESCRIPTION
## What

Adds backup management to ClawKeep, per `docs/clawkeep-backup-mgmt-spec.md`. Metadata lives in a **sidecar `manifest.json`** in the same R2 prefix (not encoded in object keys), so rename/lock/unlock is a manifest rewrite with no S3 object copy.

Three capabilities:
1. **Named backups** — optional human label per snapshot.
2. **Lock / protect** — a locked snapshot (🔒) can't be deleted manually or by auto-cleanup until unlocked.
3. **Auto-cleanup (retention)** — after each successful backup, prune old snapshots. Default **keep last 10**, user-adjustable, `0` disables. Locked snapshots are always kept and never count toward the limit.

## Changes

**Python device agent (`clawkeep/clawkeep/`)**
- `s3.py`: `read_manifest`/`write_manifest`, `delete_snapshot`; `list_snapshots` merges `label`/`locked` and excludes `manifest.json`; `stats` excludes it from bytes + count. `Snapshot` gains `label`/`locked`.
- `runner.py`: writes/merges a manifest entry after a successful upload, then `apply_retention` (reads `retentionKeepLast` from `schedule.json`, default 10). Both best-effort so they can't fail an otherwise-good backup.
- `cli.py`: new `label` / `lock` / `unlock` / `delete` / `prune` subcommands; `snapshots` JSON now carries `label` + `locked`. `delete` refuses a locked snapshot with `{"ok":false,"kind":"locked"}` exit 2.
- `daemon.py`: `--label` passthrough to `run_once`.

**TS bridge (`src/lib/clawkeep.ts`)**
- `retentionKeepLast` on `ClawKeepSchedule` / `DEFAULT_SCHEDULE` / `sanitiseSchedule` (non-negative int, bogus → default).
- `setSnapshotLabel` / `lockSnapshot` / `unlockSnapshot` / `deleteSnapshot` / `pruneSnapshots`; `CloudSnapshot` gains `label?`/`locked?`; `runBackup` accepts a `label`. `SnapshotLockedError` → 409.

**Portal routes (`src/app/setup-api/clawkeep/`)**
- New `snapshots/label`, `snapshots/lock`, `snapshots/delete` (surfaces `kind:"locked"` as 409). `backup` accepts a `label`. `schedule` round-trips `retentionKeepLast` transparently via `sanitiseSchedule`.

**UI (`src/components/ClawKeepApp.tsx`)**
- Snapshot rows show label (fallback to timestamp), a 🔒 badge, and per-row **Restore / Rename / Lock-Unlock / Delete** actions. Delete is disabled with an "Unlock first" tooltip when locked, and uses a two-step inline confirm.
- "Name this backup" input on the manual backup card.
- "Keep last N backups" setting with helper text "Locked backups are always kept" (and a `0 = keep everything` hint).

**i18n (`src/lib/clawkeep-translations.ts`)**
- 15 new keys added to **all 10 locales** (en, bg, de, es, fr, it, ja, nl, sv, zh) — no English-only strings.

## Tests
- New Python tests: `apply_retention` (locked exemption, keep_last boundary, disabled-at-0, manifest GC), `manifest` read/write round-trip, `list_snapshots`/`stats` manifest exclusion, `delete_snapshot`, and CLI `delete`-refuses-locked + label/lock/prune (`test_cli.py`).
- Updated existing TS schedule/persistence tests for the new `retentionKeepLast` field.
- `npx tsc --noEmit`: clean. `npm run build`: ✓ compiled, new routes emitted. Clawkeep vitest suites: 42 passed.
- Python: `86 passed, 2 failed`. **Both failures are pre-existing on `main`** (verified via `git stash`): `test_s3.py::test_upload_calls_put_with_correct_key` and `test_runner.py::test_step_is_persisted_until_failure` assert call signatures that omit the existing `Callback`/`progress_cb` kwargs — unrelated to this feature.

## Judgment calls
- **Retention source**: the runner reads `retentionKeepLast` from `schedule.json` (owned by the TS bridge) rather than `config.toml`, keeping device + UI in sync without a config-schema change.
- **Label passing**: passed via argv (`--label`) rather than a one-shot file like the passphrase — a label isn't a secret, so the `/proc/cmdline` concern doesn't apply.
- **Manifest write + retention are best-effort**: a manifest/prune failure logs a warning and the backup still reports success (the snapshot exists; it just reads back as unnamed/unlocked).
- **Delete confirm** lives inline in the restore modal (two-step button) to avoid wiring the parent's `ConfirmDialog` across the modal boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added snapshot naming and labeling functionality to organize backups
  * Added snapshot lock/unlock protection preventing accidental deletion
  * Added automatic retention policy (keep-last N unlocked snapshots; locked snapshots always preserved)
  * Enhanced backup UI with snapshot management actions: rename, lock/unlock, delete, and retention settings
  * Added multi-language support for all new snapshot management features

* **Documentation**
  * Added comprehensive backup management specification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->