### PR TITLE
fix: don't show the reasoning-effort picker for local Gemma (llamacpp)

### DIFF
--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -14,6 +14,14 @@ import {
 import { useChatToolCalls, ToolCallPills } from '@/lib/chat-tool-events'
 import { FIX_ERROR_EVENT, buildFixErrorPrompt, type FixErrorContext } from '@/lib/ui-events'
 import { isSentinel } from '@/lib/chat-sentinels'
+import {
+  type ThinkingLevel,
+  type ProviderReasoningConfig,
+  THINKING_LEVEL_LABELS,
+  getProviderReasoningConfig,
+  readPersistedThinkingLevel,
+  PERSIST_KEY_PREFIX,
+} from '@/lib/chat-reasoning'
 
 const MASCOT_LINES_KEY = 'clawbox-mascot-convo-lines'
 const MAX_RETRIES = 8
@@ -166,81 +174,6 @@ function extractText(msg: unknown): string {
 
 const DEFAULT_SIZE = { w: 400, h: 500 }
 const DEFAULT_PANEL_WIDTH = DEFAULT_SIZE.w
-
-// Reasoning effort levels accepted by the OpenClaw gateway. The wire
-// vocabulary is broader than what any single upstream API supports —
-// each provider only honors a subset, with the gateway translating
-// (e.g. DeepSeek `xhigh`→`max`, Google `adaptive`→`thinking_budget=-1`).
-type ThinkingLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max' | 'adaptive'
-const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
-  off: 'Off',
-  minimal: 'Minimal',
-  low: 'Low',
-  medium: 'Medium',
-  high: 'High',
-  xhigh: 'X-High',
-  max: 'Max',
-  adaptive: 'Adaptive',
-}
-
-// Per-provider effort levels and defaults. Sourced from each upstream's
-// official API docs (see fix/clawai-account-tier branch history for the
-// research notes). Showing the universal 8-level dropdown for every
-// provider was misleading — `Max` doesn't exist on OpenAI, `Minimal`
-// was dropped from gpt-5.4+, Google has `Adaptive` (thinking_budget=-1)
-// where others have `Default`, etc. Per-provider config keeps the UI
-// honest.
-interface ProviderReasoningConfig {
-  levels: readonly ThinkingLevel[]
-  default: ThinkingLevel
-}
-
-const REASONING_BY_PROVIDER: Record<string, ProviderReasoningConfig> = {
-  openai: { levels: ['off', 'low', 'medium', 'high', 'xhigh'], default: 'medium' },
-  'openai-codex': { levels: ['off', 'low', 'medium', 'high', 'xhigh'], default: 'medium' },
-  // Anthropic effort docs: `low | medium | high | max` on Opus 4.6+,
-  // Sonnet 4.6, Opus 4.7, Mythos. Default per platform.claude.com is
-  // `high`. xhigh is Opus-4.7-only; we omit until we add per-model
-  // gating.
-  anthropic: { levels: ['low', 'medium', 'high', 'max'], default: 'high' },
-  // Gemini 2.5 thinking_budget: 0=off (Flash/Lite only — Pro silently
-  // ignores), -1=adaptive (auto). Picker stays provider-wide; Pro will
-  // fall back to adaptive when user picks Off.
-  google: { levels: ['off', 'low', 'medium', 'high', 'adaptive'], default: 'adaptive' },
-  // DeepSeek V4 docs accept low/medium/high/xhigh/max but compatibility
-  // layer maps low+medium→high and xhigh→max upstream, so the user-facing
-  // useful scale is just three.
-  deepseek: { levels: ['low', 'medium', 'high'], default: 'high' },
-  // ClawBox AI routes via DeepSeek today.
-  clawai: { levels: ['low', 'medium', 'high'], default: 'high' },
-  // OpenRouter normalizes per underlying model — surface the full set
-  // they document at openrouter.ai/docs/guides/best-practices/reasoning-tokens.
-  openrouter: { levels: ['off', 'minimal', 'low', 'medium', 'high', 'xhigh'], default: 'medium' },
-}
-
-const FALLBACK_REASONING_CONFIG: ProviderReasoningConfig = {
-  levels: ['off', 'low', 'medium', 'high'],
-  default: 'medium',
-}
-
-function getProviderReasoningConfig(provider: string | null | undefined): ProviderReasoningConfig {
-  if (!provider) return FALLBACK_REASONING_CONFIG
-  return REASONING_BY_PROVIDER[provider] ?? FALLBACK_REASONING_CONFIG
-}
-
-const PERSIST_KEY_PREFIX = 'clawbox:chat:thinkingLevel'
-
-function readPersistedThinkingLevel(
-  provider: string | null | undefined,
-  cfg: ProviderReasoningConfig,
-): ThinkingLevel {
-  if (typeof window === 'undefined' || !provider) return cfg.default
-  try {
-    const raw = window.localStorage?.getItem(`${PERSIST_KEY_PREFIX}:${provider}`)
-    if (raw && cfg.levels.includes(raw as ThinkingLevel)) return raw as ThinkingLevel
-  } catch { /* localStorage unavailable */ }
-  return cfg.default
-}
 
 function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThinkingChange, onPanelModeChange, initialPanelWidth, mascotX, mobile = false, trayMode = false }: ChatPopupProps) {
   const { t } = useT()
@@ -1559,22 +1492,27 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             )
           })()}
           {/* Per-provider effort levels — see REASONING_BY_PROVIDER for
-              the upstream-API-accurate set per provider. The wire
-              vocabulary is the OpenClaw gateway's full union; the
-              gateway translates per-provider (DeepSeek `xhigh`→`max`,
-              Google `adaptive`→`thinking_budget=-1`, etc.). */}
-          <HeaderDropdown
-            ariaLabel="Reasoning effort"
-            value={effectiveThinkingLevel}
-            options={visibleThinkingLevels.map(level => ({
-              id: level,
-              label: THINKING_LEVEL_LABELS[level] ?? level,
-            }))}
-            onChange={handleThinkingLevelChange}
-            onPointerDown={stopHeaderDrag}
-            triggerMaxWidth={100}
-            popoverWidth={180}
-          />
+              the upstream-API-accurate set per provider. The wire vocabulary
+              is the OpenClaw gateway's full union; the gateway translates
+              per-provider (DeepSeek `xhigh`→`max`, Google `adaptive`→
+              `thinking_budget=-1`, etc.). Hidden entirely for providers with
+              no real reasoning choice (off-only, e.g. local Gemma) — a
+              single-option dropdown is pointless and picking a level errors at
+              the gateway ("thinkingLevel … not supported for llamacpp/gemma…"). */}
+          {visibleThinkingLevels.length > 1 && (
+            <HeaderDropdown
+              ariaLabel="Reasoning effort"
+              value={effectiveThinkingLevel}
+              options={visibleThinkingLevels.map(level => ({
+                id: level,
+                label: THINKING_LEVEL_LABELS[level] ?? level,
+              }))}
+              onChange={handleThinkingLevelChange}
+              onPointerDown={stopHeaderDrag}
+              triggerMaxWidth={100}
+              popoverWidth={180}
+            />
+          )}
         </div>
         <div style={{ flex: 1 }} />
         {(status === 'connecting' || switchingModel) && (

--- a/src/lib/chat-reasoning.ts
+++ b/src/lib/chat-reasoning.ts
@@ -1,0 +1,95 @@
+// Reasoning-effort vocabulary + per-provider configuration for the chat
+// header's "Reasoning effort" picker. Extracted from ChatPopup so the gating
+// (which providers offer which levels) is unit-testable without rendering the
+// whole chat component.
+
+// Reasoning effort levels accepted by the OpenClaw gateway. The wire
+// vocabulary is broader than what any single upstream API supports — each
+// provider only honors a subset, with the gateway translating (e.g. DeepSeek
+// `xhigh`→`max`, Google `adaptive`→`thinking_budget=-1`).
+export type ThinkingLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "max"
+  | "adaptive";
+
+export const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
+  off: "Off",
+  minimal: "Minimal",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "X-High",
+  max: "Max",
+  adaptive: "Adaptive",
+};
+
+// Per-provider effort levels and defaults. Sourced from each upstream's
+// official API docs. Showing the universal 8-level dropdown for every provider
+// was misleading — `Max` doesn't exist on OpenAI, `Minimal` was dropped from
+// gpt-5.4+, Google has `Adaptive` (thinking_budget=-1) where others have
+// `Default`, etc. Per-provider config keeps the UI honest.
+export interface ProviderReasoningConfig {
+  levels: readonly ThinkingLevel[];
+  default: ThinkingLevel;
+}
+
+export const REASONING_BY_PROVIDER: Record<string, ProviderReasoningConfig> = {
+  openai: { levels: ["off", "low", "medium", "high", "xhigh"], default: "medium" },
+  "openai-codex": { levels: ["off", "low", "medium", "high", "xhigh"], default: "medium" },
+  // Anthropic effort docs: `low | medium | high | max` on Opus 4.6+, Sonnet
+  // 4.6, Opus 4.7, Mythos. Default per platform.claude.com is `high`. xhigh is
+  // Opus-4.7-only; we omit until we add per-model gating.
+  anthropic: { levels: ["low", "medium", "high", "max"], default: "high" },
+  // Gemini 2.5 thinking_budget: 0=off (Flash/Lite only — Pro silently
+  // ignores), -1=adaptive (auto). Picker stays provider-wide; Pro will fall
+  // back to adaptive when user picks Off.
+  google: { levels: ["off", "low", "medium", "high", "adaptive"], default: "adaptive" },
+  // DeepSeek V4 docs accept low/medium/high/xhigh/max but compatibility layer
+  // maps low+medium→high and xhigh→max upstream, so the user-facing useful
+  // scale is just three.
+  deepseek: { levels: ["low", "medium", "high"], default: "high" },
+  // ClawBox AI routes via DeepSeek today.
+  clawai: { levels: ["low", "medium", "high"], default: "high" },
+  // OpenRouter normalizes per underlying model — surface the full set they
+  // document at openrouter.ai/docs/guides/best-practices/reasoning-tokens.
+  openrouter: { levels: ["off", "minimal", "low", "medium", "high", "xhigh"], default: "medium" },
+  // Local Gemma (llama.cpp) exposes no reasoning-effort control — the gateway
+  // rejects any thinkingLevel other than `off` ("thinkingLevel … is not
+  // supported for llamacpp/gemma… (use off)"). Declaring it off-only hides the
+  // picker (the header only renders it when there's more than one level) and
+  // keeps the wire value at `off`, which the gateway accepts.
+  llamacpp: { levels: ["off"], default: "off" },
+};
+
+export const FALLBACK_REASONING_CONFIG: ProviderReasoningConfig = {
+  levels: ["off", "low", "medium", "high"],
+  default: "medium",
+};
+
+export function getProviderReasoningConfig(
+  provider: string | null | undefined,
+): ProviderReasoningConfig {
+  if (!provider) return FALLBACK_REASONING_CONFIG;
+  return REASONING_BY_PROVIDER[provider] ?? FALLBACK_REASONING_CONFIG;
+}
+
+export const PERSIST_KEY_PREFIX = "clawbox:chat:thinkingLevel";
+
+export function readPersistedThinkingLevel(
+  provider: string | null | undefined,
+  cfg: ProviderReasoningConfig,
+): ThinkingLevel {
+  if (typeof window === "undefined" || !provider) return cfg.default;
+  try {
+    const raw = window.localStorage?.getItem(`${PERSIST_KEY_PREFIX}:${provider}`);
+    if (raw && cfg.levels.includes(raw as ThinkingLevel)) return raw as ThinkingLevel;
+  } catch {
+    /* localStorage unavailable */
+  }
+  return cfg.default;
+}

--- a/src/tests/unit/chat-reasoning.test.ts
+++ b/src/tests/unit/chat-reasoning.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  getProviderReasoningConfig,
+  readPersistedThinkingLevel,
+  REASONING_BY_PROVIDER,
+  FALLBACK_REASONING_CONFIG,
+  THINKING_LEVEL_LABELS,
+} from "@/lib/chat-reasoning";
+
+describe("chat-reasoning", () => {
+  describe("getProviderReasoningConfig", () => {
+    it("returns off-only for local Gemma (llamacpp) so the header hides the picker", () => {
+      const cfg = getProviderReasoningConfig("llamacpp");
+      // Gemma exposes no reasoning-effort control; the gateway rejects any
+      // thinkingLevel other than `off`. Off-only (length 1) is what makes the
+      // chat header drop the effort dropdown instead of erroring on select.
+      expect(cfg.levels).toEqual(["off"]);
+      expect(cfg.default).toBe("off");
+      expect(cfg.levels.length).toBe(1);
+    });
+
+    it("returns the upstream-accurate set for cloud providers", () => {
+      expect(getProviderReasoningConfig("openai").levels).toContain("xhigh");
+      expect(getProviderReasoningConfig("anthropic").levels).toEqual([
+        "low",
+        "medium",
+        "high",
+        "max",
+      ]);
+      expect(getProviderReasoningConfig("google").default).toBe("adaptive");
+    });
+
+    it("falls back for unknown or empty providers", () => {
+      expect(getProviderReasoningConfig("ollama")).toBe(FALLBACK_REASONING_CONFIG);
+      expect(getProviderReasoningConfig(null)).toBe(FALLBACK_REASONING_CONFIG);
+      expect(getProviderReasoningConfig(undefined)).toBe(FALLBACK_REASONING_CONFIG);
+      expect(getProviderReasoningConfig("")).toBe(FALLBACK_REASONING_CONFIG);
+    });
+
+    it("keeps every config self-consistent (labelled levels, default in range)", () => {
+      for (const cfg of Object.values(REASONING_BY_PROVIDER)) {
+        expect(cfg.levels.length).toBeGreaterThan(0);
+        expect(cfg.levels).toContain(cfg.default);
+        for (const level of cfg.levels) {
+          expect(THINKING_LEVEL_LABELS[level]).toBeTruthy();
+        }
+      }
+    });
+  });
+
+  describe("readPersistedThinkingLevel", () => {
+    it("returns the provider default when no choice is persisted", () => {
+      const cfg = getProviderReasoningConfig("llamacpp");
+      expect(readPersistedThinkingLevel("llamacpp", cfg)).toBe("off");
+    });
+
+    it("returns the default when the provider is missing", () => {
+      const cfg = getProviderReasoningConfig("openai");
+      expect(readPersistedThinkingLevel(null, cfg)).toBe(cfg.default);
+    });
+  });
+});


### PR DESCRIPTION
## Problem
Switching the chat's reasoning effort to anything but **Off** while using local **Gemma** (`llamacpp/gemma…`) threw:

> Failed to change effort: thinkingLevel "low" is not supported for llamacpp/gemma4-e2b-it-q4_0 (use off)

Gemma exposes no reasoning-effort control, but `llamacpp` had no entry in the per-provider config, so it fell through to the default `off/low/medium/high` set. The chat then pushed `sessions.patch { thinkingLevel }` to the gateway, which rejected it.

## Fix
- **Extract** the per-provider reasoning config + helpers out of the 1.6k-line `ChatPopup` into a small, testable lib — `src/lib/chat-reasoning.ts` — and declare `llamacpp` as **off-only** (`{ levels: ["off"], default: "off" }`).
- **Hide** the effort dropdown when the active provider offers no real choice (`visibleThinkingLevels.length > 1` is false). A one-option dropdown is pointless, and it keeps the wire value at `off`, which the gateway accepts. This generalizes — any future off-only provider gets the right behavior for free; there's no `provider === "llamacpp"` special-case.
- Cloud providers (OpenAI / Anthropic / Google / OpenRouter / ClawBox AI) are unchanged — they keep their full effort dropdowns.

## Tests
New `src/tests/unit/chat-reasoning.test.ts` — off-only Gemma hides the picker, cloud providers keep their sets, unknown/empty providers fall back, and every config is self-consistent (default ∈ levels, every level labelled).

## Validation
Built and tested on a live device — `bun run build` clean (type-check included), 6/6 `chat-reasoning` tests pass. Verified on the box that Gemma now shows no effort picker and no longer errors.