### PR TITLE
fix: reset ClawKeep when the ClawBox AI account changes

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -23,6 +23,7 @@ import {
   getLlamaCppProxyBaseUrl,
 } from "@/lib/llamacpp";
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
+import { unpairLocal as unpairClawKeep } from "@/lib/clawkeep";
 import { getLocalAiToken, markLocalAiTokenMigrated } from "@/lib/local-ai-token";
 import { getOrGenerateGatewayToken } from "@/lib/gateway-proxy";
 import {
@@ -429,6 +430,13 @@ export async function POST(request: Request) {
       ? { ...baseConfig, ...baseConfig.subscriptionOverride }
       : { ...baseConfig };
     const configStore = await getAll().catch(() => ({} as Awaited<ReturnType<typeof getAll>>));
+    // Capture the previously-stored ClawBox AI token *before* it gets
+    // overwritten below, so the isClawAI block can detect an account switch
+    // (token change) and unpair ClawKeep.
+    const previousClawaiToken =
+      typeof configStore[CLAWBOX_AI_TOKEN_CONFIG_KEY] === "string"
+        ? (configStore[CLAWBOX_AI_TOKEN_CONFIG_KEY] as string)
+        : "";
     const clawboxAiToken = isClawAI
       ? await getConfiguredClawboxAiToken(normalizedApiKey)
       : "";
@@ -684,6 +692,25 @@ export async function POST(request: Request) {
       ]);
       await ensureFallbackModel(config.defaultModel, undefined, clawboxAiToken);
       console.log(`[AI Config] Set ClawBox AI provider in openclaw.json via proxy ${CLAWBOX_AI_PROXY_URL}`);
+
+      // Account-switch safety: ClawKeep pairs separately and is bound to its
+      // own token (the portal resolves token -> account -> storage prefix), so
+      // after switching ClawBox AI accounts it would keep backing up to the
+      // OLD account's cloud storage. When the clawai token changes from a
+      // previously-stored one, the user has switched accounts — unpair ClawKeep
+      // locally so it re-pairs against the current account. The clawai token is
+      // opaque (no embedded account id), so a changed token is the only signal
+      // available; in this flow that means the account changed.
+      if (previousClawaiToken && previousClawaiToken !== clawboxAiToken) {
+        try {
+          // clearStats: the old account's backup history doesn't belong to the
+          // new account, so wipe it rather than leave it on the dashboard.
+          await unpairClawKeep({ clearStats: true });
+          console.log("[AI Config] ClawBox AI account changed — unpaired ClawKeep so it reconnects to the new account");
+        } catch (err) {
+          console.error("[AI Config] Failed to unpair ClawKeep after account change:", err);
+        }
+      }
     } else if (isOllama) {
       const modelName = config.defaultModel.replace(/^ollama\//, "");
       const providerDef = JSON.stringify({

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -429,7 +429,22 @@ export async function POST(request: Request) {
     const config = (authMode === "subscription" && baseConfig.subscriptionOverride)
       ? { ...baseConfig, ...baseConfig.subscriptionOverride }
       : { ...baseConfig };
-    const configStore = await getAll().catch(() => ({} as Awaited<ReturnType<typeof getAll>>));
+    // Don't fail open on a config read error for ClawBox AI: previousClawaiToken
+    // would silently become "" and the account-switch unpair guard below would
+    // be skipped, potentially leaving ClawKeep paired to the previous account.
+    // For other providers a missing config is harmless, so keep the soft default.
+    let configStore: Awaited<ReturnType<typeof getAll>>;
+    try {
+      configStore = await getAll();
+    } catch {
+      if (isClawAI) {
+        return NextResponse.json(
+          { error: "Failed to read existing ClawBox AI configuration. Please retry." },
+          { status: 503 },
+        );
+      }
+      configStore = {} as Awaited<ReturnType<typeof getAll>>;
+    }
     // Capture the previously-stored ClawBox AI token *before* it gets
     // overwritten below, so the isClawAI block can detect an account switch
     // (token change) and unpair ClawKeep.

--- a/src/app/setup-api/clawkeep/pair/poll/route.ts
+++ b/src/app/setup-api/clawkeep/pair/poll/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { writeToken } from "@/lib/clawkeep";
+import { syncStateFromCloud, writeToken } from "@/lib/clawkeep";
 import {
   type ClawKeepConnectSession,
   clearClawKeepSession,
@@ -46,6 +46,12 @@ async function readErrorBody(response: Response): Promise<string> {
 async function persistTokenInBackground(session: ClawKeepConnectSession, accessToken: string) {
   try {
     await writeToken(accessToken);
+    // Seed the dashboard from this account's existing cloud backups so a
+    // re-authenticated account shows its real snapshots/size right away
+    // instead of "0 B / never" until the first local backup. Best-effort:
+    // syncStateFromCloud swallows its own errors so a cloud-list failure
+    // can't fail the pairing.
+    await syncStateFromCloud();
     await writeClawKeepSession({
       ...session,
       status: "complete",

--- a/src/app/setup-api/clawkeep/unpair/route.ts
+++ b/src/app/setup-api/clawkeep/unpair/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { ClawKeepError, deleteToken, resetRunningState } from "@/lib/clawkeep";
+import { ClawKeepError, unpairLocal } from "@/lib/clawkeep";
 
 export const dynamic = "force-dynamic";
 
@@ -16,10 +16,7 @@ export const dynamic = "force-dynamic";
 // the dashboard.
 export async function POST() {
   try {
-    await deleteToken();
-    await resetRunningState().catch((err) => {
-      console.warn("[unpair] could not reset state.json (continuing):", err);
-    });
+    await unpairLocal();
     return NextResponse.json({ ok: true });
   } catch (err) {
     const status = err instanceof ClawKeepError ? err.status : 500;

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { resetUpdateState } from "@/lib/updater";
 import { DATA_DIR } from "@/lib/config-store";
+import { CLAWKEEP_DATA_DIR } from "@/lib/clawkeep";
 import { execFile as execFileCb } from "child_process";
 import { promisify } from "util";
 import fs from "fs/promises";
@@ -167,7 +168,12 @@ export async function POST() {
     }
 
     const openclawFailures = await removeDirectoryContents(OPENCLAW_DIR);
-    const allFailures = [...dataFailures, ...openclawFailures];
+    // ClawKeep state (token, config, passphrase, schedule) lives in its own
+    // dir (~/.clawkeep), outside DATA_DIR and ~/.openclaw — so without this a
+    // factory reset would leave the device still paired to the previous
+    // account's cloud backups. Wipe it too.
+    const clawkeepFailures = await removeDirectoryContents(CLAWKEEP_DATA_DIR);
+    const allFailures = [...dataFailures, ...openclawFailures, ...clawkeepFailures];
 
     // 4. Seed minimal openclaw.json with token-based gateway auth so the
     // gateway can still bind on LAN after reboot. The token is a freshly

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -216,8 +216,13 @@ export default function ClawKeepApp() {
   // ends.
   useEffect(() => {
     const intervalMs = isBackupRunning(status) ? 3000 : 10000;
+    // Skip a tick if the previous refresh is still in flight, so a slow/hung
+    // fetch can't stack concurrent requests on the Jetson.
+    let inFlight = false;
     const id = window.setInterval(() => {
-      void refresh();
+      if (inFlight) return;
+      inFlight = true;
+      void refresh().finally(() => { inFlight = false; });
     }, intervalMs);
     return () => window.clearInterval(id);
   }, [status, refresh]);

--- a/src/components/ClawKeepApp.tsx
+++ b/src/components/ClawKeepApp.tsx
@@ -205,14 +205,20 @@ export default function ClawKeepApp() {
     refresh();
   }, [refresh]);
 
-  // Poll the dashboard every 3s while a backup is in progress. The server
-  // is the source of truth, so reopening the window mid-run still picks up
-  // the live "running" state and shows the right step.
+  // Poll the dashboard at a cadence that depends on whether a backup is
+  // running: fast (3s) during a backup so the live "running" step stays
+  // current, slow (10s) otherwise so an already-open window still reflects
+  // state changed elsewhere — e.g. switching the ClawBox AI account unpairs
+  // ClawKeep server-side, and without this the window keeps showing the stale
+  // "you're protected" screen until the user clicks something. getStatus() is
+  // a cheap local-file read (no portal call). The effect re-runs whenever
+  // `status` changes, so the period re-evaluates the moment a backup starts or
+  // ends.
   useEffect(() => {
-    if (!isBackupRunning(status)) return;
+    const intervalMs = isBackupRunning(status) ? 3000 : 10000;
     const id = window.setInterval(() => {
       void refresh();
-    }, 3000);
+    }, intervalMs);
     return () => window.clearInterval(id);
   }, [status, refresh]);
 

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -375,9 +375,14 @@ export async function resetRunningState(): Promise<void> {
  * reader never sees a half-written file. Shared by resetRunningState() and
  * syncStateFromCloud().
  */
+let stateWriteSeq = 0;
+
 async function writeStateFile(state: StateFile): Promise<void> {
   await ensureDataDir();
-  const tmp = `${STATE_PATH}.tmp`;
+  // Per-call temp name (pid + monotonic counter) so concurrent writers — e.g.
+  // a pair-time cloud sync racing a stuck-spinner reset — can't clobber each
+  // other's temp file before the atomic rename.
+  const tmp = `${STATE_PATH}.tmp.${process.pid}.${++stateWriteSeq}`;
   await fs.writeFile(tmp, JSON.stringify(state, null, 2), { mode: 0o600 });
   await fs.rename(tmp, STATE_PATH);
 }

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -303,6 +303,34 @@ export async function deleteToken(): Promise<void> {
 }
 
 /**
+ * Forget this device's ClawKeep pairing locally: delete the token and clear
+ * the in-flight "running" state. Does NOT revoke server-side, and deliberately
+ * keeps config.toml / passphrase / schedule so a re-pair against a new account
+ * reuses the same encryption + schedule. Shared by the unpair route and the
+ * ClawBox-AI-account-change reset so the two stay in lockstep.
+ *
+ * `clearStats` controls what happens to the historical "last successful"
+ * numbers (last backup time / cloud size / snapshot count):
+ *  - false (default, manual "unpair this device"): keep them, since the user
+ *    may re-pair the same account and shouldn't lose their protection history.
+ *  - true (ClawBox AI account change): wipe them — they belong to the previous
+ *    account, so leaving them would make the new account's "you're protected"
+ *    screen show the old account's snapshot count and size.
+ */
+export async function unpairLocal(opts: { clearStats?: boolean } = {}): Promise<void> {
+  await deleteToken();
+  if (opts.clearStats) {
+    await fs.rm(STATE_PATH, { force: true }).catch((err) => {
+      console.warn("[clawkeep] could not clear state.json during account-change unpair (continuing):", err);
+    });
+  } else {
+    await resetRunningState().catch((err) => {
+      console.warn("[clawkeep] could not reset state.json during unpair (continuing):", err);
+    });
+  }
+}
+
+/**
  * Clear the in-flight tracking fields in state.json so the dashboard
  * stops showing a "running" spinner inherited from a daemon that was
  * killed mid-backup (systemd restart, OOM, manual `kill`, etc.).
@@ -339,9 +367,18 @@ export async function resetRunningState(): Promise<void> {
     upload_bytes_done: 0,
     upload_started_at_ms: 0,
   };
+  await writeStateFile(cleaned);
+}
+
+/**
+ * Atomically write state.json (temp file + rename, mode 0600) so a concurrent
+ * reader never sees a half-written file. Shared by resetRunningState() and
+ * syncStateFromCloud().
+ */
+async function writeStateFile(state: StateFile): Promise<void> {
   await ensureDataDir();
   const tmp = `${STATE_PATH}.tmp`;
-  await fs.writeFile(tmp, JSON.stringify(cleaned, null, 2), { mode: 0o600 });
+  await fs.writeFile(tmp, JSON.stringify(state, null, 2), { mode: 0o600 });
   await fs.rename(tmp, STATE_PATH);
 }
 
@@ -734,13 +771,59 @@ function spawnCliJson<T>(
   });
 }
 
-export async function listCloudSnapshots(): Promise<CloudSnapshot[]> {
+async function fetchCloudSnapshots(): Promise<SnapshotsResponse> {
   const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
   const resp = await spawnCliJson<SnapshotsResponse>(bin, "snapshots", [], { timeoutMs: 60_000 });
   if (!resp.ok) {
     throw new ClawKeepError(resp.error ?? "snapshots failed", 502);
   }
-  return resp.snapshots ?? [];
+  return resp;
+}
+
+export async function listCloudSnapshots(): Promise<CloudSnapshot[]> {
+  return (await fetchCloudSnapshots()).snapshots ?? [];
+}
+
+/**
+ * Seed state.json from the account's existing cloud snapshots.
+ *
+ * The dashboard's "last backup / cloud size / snapshot count" all come from
+ * state.json, which is only written by a *local* backup run. So right after
+ * (re)pairing an account that already has backups in the cloud, the device
+ * has no local record of them and would show "0 B / 0 / never" until the next
+ * backup. Pulling the real snapshot list on pair fixes that — the dashboard
+ * reflects what's actually in the account's cloud prefix immediately.
+ *
+ * Best-effort: a cloud-list failure (offline, portal hiccup, daemon missing)
+ * leaves state.json untouched rather than blocking the pair. Combined with the
+ * account-change `unpairLocal({ clearStats })` wipe, an offline re-pair then
+ * shows a clean slate instead of the previous account's numbers.
+ */
+export async function syncStateFromCloud(): Promise<void> {
+  let resp: SnapshotsResponse;
+  try {
+    resp = await fetchCloudSnapshots();
+  } catch (err) {
+    console.warn("[clawkeep] cloud snapshot sync after pair failed (continuing):", err);
+    return;
+  }
+  const snapshots = resp.snapshots ?? [];
+  const lastBackupAtMs = snapshots.reduce((max, s) => Math.max(max, s.last_modified_ms ?? 0), 0);
+  // Prefer the daemon's authoritative prefix total; fall back to summing the
+  // per-snapshot sizes only if an older daemon doesn't report cloudBytes.
+  const cloudBytes = resp.cloudBytes ?? snapshots.reduce((sum, s) => sum + (s.size_bytes ?? 0), 0);
+  await writeStateFile({
+    last_backup_at_ms: lastBackupAtMs,
+    last_cloud_bytes: cloudBytes,
+    last_snapshot_count: snapshots.length,
+    last_heartbeat_at_ms: lastBackupAtMs,
+    last_heartbeat_status: "",
+    last_step: "",
+    last_step_at_ms: 0,
+    upload_bytes_total: 0,
+    upload_bytes_done: 0,
+    upload_started_at_ms: 0,
+  });
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -25,6 +25,10 @@ vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
 }));
 
+vi.mock("@/lib/clawkeep", () => ({
+  unpairLocal: vi.fn(),
+}));
+
 // Hoisted so the vi.mock factories below (which are themselves hoisted by
 // vitest) can see these. A plain const declaration at file-body position
 // would be in the TDZ when the mock factory evaluates.
@@ -88,6 +92,7 @@ vi.mock("@/lib/local-ai-token", () => ({
 }));
 
 import { getAll, setMany } from "@/lib/config-store";
+import { unpairLocal } from "@/lib/clawkeep";
 import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
 import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
@@ -108,6 +113,7 @@ const mockGetLlamaCppMaxTokens = vi.mocked(getLlamaCppMaxTokens);
 const mockGetLlamaCppProxyBaseUrl = vi.mocked(getLlamaCppProxyBaseUrl);
 const mockGetLocalAiProxyBaseUrl = vi.mocked(getLocalAiProxyBaseUrl);
 const mockGetLocalAiToken = vi.mocked(getLocalAiToken);
+const mockUnpairLocal = vi.mocked(unpairLocal);
 
 // Create a mock child process that immediately succeeds
 function createSuccessfulChildProcess(): ChildProcess {
@@ -167,6 +173,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockRestartGateway.mockResolvedValue();
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+    mockUnpairLocal.mockResolvedValue(undefined);
 
     // Re-apply implementations cleared by vi.clearAllMocks above. Factory
     // defaults set in `vi.mock(...)` hold across vi.resetModules but are
@@ -301,6 +308,46 @@ describe("POST /setup-api/ai-models/configure", () => {
         clawai_token: "portal-token-123",
       }),
     );
+  });
+
+  it("unpairs ClawKeep when the ClawBox AI account (token) changes", async () => {
+    // A token for a *different* account was already stored.
+    mockGetAll.mockResolvedValue({ clawai_token: "claw_OLD", ai_model_provider: "deepseek" });
+
+    const res = await configurePost(jsonRequest({
+      provider: "clawai",
+      apiKey: "claw_NEW",
+    }));
+
+    expect(res.status).toBe(200);
+    // ClawKeep is bound to its own token/account, so switching accounts must
+    // unpair it (else backups keep going to the old account's storage), and
+    // clear the old account's stats so they don't linger on the new account.
+    expect(mockUnpairLocal).toHaveBeenCalledTimes(1);
+    expect(mockUnpairLocal).toHaveBeenCalledWith({ clearStats: true });
+  });
+
+  it("does not unpair ClawKeep when the ClawBox AI token is unchanged", async () => {
+    mockGetAll.mockResolvedValue({ clawai_token: "claw_SAME", ai_model_provider: "deepseek" });
+
+    const res = await configurePost(jsonRequest({
+      provider: "clawai",
+      apiKey: "claw_SAME",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockUnpairLocal).not.toHaveBeenCalled();
+  });
+
+  it("does not unpair ClawKeep on first-time ClawBox AI setup (no previous token)", async () => {
+    // getAll default ({}) — no prior clawai_token, so nothing to reset.
+    const res = await configurePost(jsonRequest({
+      provider: "clawai",
+      apiKey: "claw_NEW",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockUnpairLocal).not.toHaveBeenCalled();
   });
 
   it("configures ollama without apiKey", async () => {


### PR DESCRIPTION
## Problem

ClawKeep pairs **independently** of the ClawBox AI account — it has its own `claw_` token that the portal resolves to an account and a cloud-storage prefix. So after switching ClawBox AI accounts:

- ClawKeep kept backing up to the **old** account's storage (verified on-device), and
- the dashboard kept showing the **old** account's stats (size / snapshot count / last backup).

## Fix

- **`ai-models/configure`** — detect an account switch (the `clawai_token` changing from a previously-stored one) and unpair ClawKeep so it re-pairs against the current account. The token is opaque (no embedded account id), so a changed token is the only available signal. Also clears the old account's stats (`clearStats`) as an offline-safe wipe.
- **`clawkeep`** — add `unpairLocal()` (shared by the unpair route + the account-change reset so they stay in lockstep) and `syncStateFromCloud()`, which seeds `state.json` from the account's **real cloud snapshots** on pair — so a re-authenticated account shows its existing backups immediately instead of `0 B / never` until the next local backup.
- **`clawkeep/pair/poll`** — sync cloud state right after writing the new token.
- **`setup/reset`** — a factory reset now also wipes `~/.clawkeep`, so it can't leave the device paired to the previous account either.
- **`ClawKeepApp`** — poll status on a single variable-cadence timer (3s during a backup, 10s otherwise) so an already-open window reflects the server-side unpair without a manual click.

## Three-mechanism design (intentional)

1. **`clearStats` wipe on switch** — the offline safety net: if `syncStateFromCloud` can't reach the portal on re-pair, the device still shows a clean slate, never the old account's numbers.
2. **`syncStateFromCloud` on pair** — the steady-state correct value (the new account's real cloud backups).
3. **`ClawKeepApp` poll** — transport: makes an already-open window observe the change.

## Testing

- New unit tests in `configure.test.ts`: unpairs on token change (with `{ clearStats: true }`), does **not** unpair on unchanged token or first-time setup.
- Verified end-to-end on a Jetson device: switching accounts unpaired ClawKeep (confirmed via `journalctl` + the token file being cleared), backups then went to the new account's storage, and `clawkeep snapshots` → `syncStateFromCloud` correctly populated the dashboard with the account's existing backups.
- `clawkeep-persistence`, `clawkeep-schedule`, and `configure` test suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced account-switch safety for ClawKeep: unpairing from previous account when changing providers to prevent backup associations with old accounts.
  * Cloud backup state now syncs immediately after re-authentication, allowing the dashboard to display existing backups right away.

* **Improvements**
  * Dashboard polling optimized: slower refresh rate (10s) when idle, faster (3s) during active backups.
  * Factory reset now completely removes ClawKeep data alongside other app data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->