### PR TITLE
fix: raise inotify limits to prevent gateway EMFILE crashes

### DIFF
--- a/scripts/setup-optimizations.sh
+++ b/scripts/setup-optimizations.sh
@@ -12,7 +12,7 @@ echo "=== ClawBox Optimizations ==="
 
 # ── 1. TTS Caching Script ─────────────────────────────────────────────────
 
-echo "[1/4] Installing TTS cache system..."
+echo "[1/5] Installing TTS cache system..."
 mkdir -p "$SCRIPTS_DST"
 
 cat > "$SCRIPTS_DST/tts-cached.sh" << 'TTS_EOF'
@@ -65,7 +65,7 @@ echo "  ✓ TTS cache script installed"
 
 # ── 2. CPU Optimization Script ────────────────────────────────────────────
 
-echo "[2/4] Installing CPU optimizer..."
+echo "[2/5] Installing CPU optimizer..."
 
 cat > "$SCRIPTS_DST/optimize-cpu.sh" << 'CPU_EOF'
 #!/bin/bash
@@ -125,15 +125,34 @@ echo "  ✓ CPU optimizer installed"
 
 # ── 3. Pre-cache Common Phrases ───────────────────────────────────────────
 
-echo "[3/4] Skipping TTS pre-cache (servers start on demand)"
+echo "[3/5] Skipping TTS pre-cache (servers start on demand)"
 
 # ── 4. Apply CPU Optimization ─────────────────────────────────────────────
 
-echo "[4/4] Applying CPU optimization..."
+echo "[4/5] Applying CPU optimization..."
 su - "$CLAWBOX_USER" -c "bash '$SCRIPTS_DST/optimize-cpu.sh'" 2>/dev/null || true
+
+# ── 5. inotify limits for the OpenClaw gateway's file watchers ─────────────
+
+echo "[5/5] Raising inotify limits for gateway file watchers..."
+# The gateway runs several file watchers (skills/workspace, config reload,
+# MEMORY.md). Jetson's stock ceilings (128 instances / 65536 watches) can be
+# exhausted under load and surface as "EMFILE: too many open files" crashes +
+# restart loops. Persist higher limits and apply now — best-effort: the apply
+# is a no-op (and must not fail the install) inside CI/containers where
+# /proc/sys is read-only. See ID-Robots/clawbox#160.
+cat > /etc/sysctl.d/99-clawbox-inotify.conf << 'INOTIFY_EOF' || true
+# ClawBox: raise inotify ceilings so the OpenClaw gateway's watchers don't hit
+# EMFILE under load. See ID-Robots/clawbox#160.
+fs.inotify.max_user_instances = 512
+fs.inotify.max_user_watches = 524288
+INOTIFY_EOF
+sysctl -p /etc/sysctl.d/99-clawbox-inotify.conf >/dev/null 2>&1 || true
+echo "  ✓ inotify limits raised (instances=512, watches=524288)"
 
 echo ""
 echo "=== Optimizations Complete ==="
 echo "  • TTS caching system installed"
 echo "  • CPU affinity optimization for AI workloads"
 echo "  • Threading environment variables configured"
+echo "  • inotify limits raised for gateway watchers"


### PR DESCRIPTION
## Problem (#160)

The OpenClaw gateway runs several file watchers — skills/workspace, config reload, `MEMORY.md`. On Jetson the stock inotify ceilings are low (`max_user_instances=128`, `max_user_watches=65536`), and under load they exhaust → `EMFILE: too many open files` during watch setup, which crashes the gateway and drives a restart loop (the reporter saw `NRestarts=8` + `dbus-daemon: Cannot initialize inotify`).

There was **no inotify tuning anywhere** in `scripts/`/`install.sh`.

## Fix

`setup-optimizations.sh` now persists higher limits via `/etc/sysctl.d/99-clawbox-inotify.conf` (instances **512**, watches **524288**) and applies them. The apply is **best-effort and guarded** (`|| true`) so it can't fail the install inside the e2e-install container where `/proc/sys` is read-only.

## Verification

- `bash -n` clean.
- Applied on a **real Jetson**: limits raised `128 → 512` and `65536 → 524288`. (The live box was at 42/128 instances at idle — now mitigated.)

Note: this is the device-side **mitigation**; the watcher-count root cause is upstream OpenClaw.

Closes #160