### PR TITLE
fix: derive AI provider from the live model, not the stale config store

### DIFF
--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -136,7 +136,12 @@ async function loadChatModelState() {
     }
   }
 
-  const primaryProvider = normalizeProvider(configStore.ai_model_provider);
+  // Prefer the live OpenClaw primary model's provider over the ClawBox config
+  // store: the store only refreshes at configure-time, so it drifts when the
+  // model changes elsewhere (#162). Fall back to the store for local/no-model.
+  const primaryProvider = (!isLocalModel(activeModel) && activeModel
+    ? normalizeProviderFromModel(activeModel)
+    : null) ?? normalizeProvider(configStore.ai_model_provider);
   // Keyed by *provider* (not by model id) so each provider gets ONE
   // row in the chat dropdown. Model variants (ClawBox AI Flash/Pro,
   // Claude Haiku/Sonnet/Opus, GPT-5.4 / -mini, etc.) are surfaced via

--- a/src/app/setup-api/setup/status/route.ts
+++ b/src/app/setup-api/setup/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { getAll } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig as readOpenClawConfig } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig as readOpenClawConfig, type OpenClawConfig } from "@/lib/openclaw-config";
 
 export const dynamic = "force-dynamic";
 
@@ -8,10 +8,20 @@ export async function GET() {
   try {
     const [config, openclawConfig] = await Promise.all([
       getAll(),
-      readOpenClawConfig().catch(() => ({})),
+      readOpenClawConfig().catch(() => ({} as OpenClawConfig)),
     ]);
     const hasExplicitLocalAiFlag = Object.prototype.hasOwnProperty.call(config, "local_ai_configured");
     const inferredLocal = inferConfiguredLocalModel(openclawConfig);
+    // Provider from the live OpenClaw primary model (e.g. "deepseek/..." →
+    // "deepseek"), preferred over the ClawBox config store, which only
+    // refreshes at configure-time and can drift when the model changes
+    // elsewhere (#162). Local models (llamacpp/ollama) carry their own provider.
+    const livePrimaryModel = typeof openclawConfig.agents?.defaults?.model?.primary === "string"
+      ? openclawConfig.agents.defaults.model.primary
+      : null;
+    const liveCloudProvider = livePrimaryModel && !/^(llamacpp|ollama)\//i.test(livePrimaryModel)
+      ? livePrimaryModel.split("/")[0]
+      : null;
     const localAiConfigured = hasExplicitLocalAiFlag ? !!config.local_ai_configured : !!inferredLocal;
     const localAiProvider = hasExplicitLocalAiFlag
       ? (config.local_ai_provider || null)
@@ -32,7 +42,7 @@ export async function GET() {
       local_ai_provider: localAiProvider,
       local_ai_model: localAiModel,
       ai_model_configured: !!config.ai_model_configured,
-      ai_model_provider: config.ai_model_provider || null,
+      ai_model_provider: liveCloudProvider || config.ai_model_provider || null,
       telegram_configured: !!config.telegram_bot_token,
     }, {
       headers: {


### PR DESCRIPTION
## Problem (#162)

`/setup-api/setup/status` and `/setup-api/chat/model` reported `ai_model_provider` from the ClawBox **config store**, which only refreshes when the model is changed through `ai-models/configure`. When the live OpenClaw primary model changes elsewhere, those surfaces **drift** — the reporter saw the live model move to `openai/...` while ClawBox still reported `openai-codex`.

## Fix

Prefer the provider derived from the **live** OpenClaw primary model (`openclaw.json → agents.defaults.model.primary`), falling back to the config store for local / no-model cases:

- **chat/model** — reuses the file's existing `normalizeProviderFromModel` + `isLocalModel` helpers (already used a few lines down), so it's consistent with how the rest of the route maps models → providers.
- **setup/status** — already reads the live `openclawConfig`; now derives the cloud-provider prefix (skipping `llamacpp`/`ollama` local models) and prefers it.

## Verification

tsc-clean on the device. On the live box (model `deepseek/deepseek-v4-pro`, config `deepseek`) both surfaces resolve to `deepseek` — now sourced from the live model, so it tracks future changes instead of going stale.

Closes #162