### PR TITLE
fix: skill install never reloaded the gateway (broken process matcher)

### DIFF
--- a/scripts/setup-optimizations.sh
+++ b/scripts/setup-optimizations.sh
@@ -97,8 +97,10 @@ if [ -n "$WHISPER_PID" ]; then
     echo "  Whisper STT → cores 3-5"
 fi
 
-# OpenClaw gateway - can use all cores
-GATEWAY_PID=$(pgrep -f openclaw-gateway || echo "")
+# OpenClaw gateway - can use all cores. The process renames its argv to just
+# "openclaw", so match the exact name rather than the (never-matching)
+# "openclaw-gateway" string.
+GATEWAY_PID=$(pgrep -x openclaw | head -n1 || echo "")
 if [ -n "$GATEWAY_PID" ]; then
     taskset -cp 0-5 "$GATEWAY_PID"
     echo "  OpenClaw Gateway → all cores"

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1272,6 +1272,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       retryCountRef.current = 0
       startReloadProgressTimer()
     }
+    // A skill install signals the gateway to restart (SIGUSR1), which drops the
+    // WS shortly after this event fires. We deliberately do NOT force a
+    // reconnect here (unlike the provider path below): the install route does
+    // not await the restart, so the WS is still up when this runs and the
+    // natural onClose → reconnect → resolve path delivers the post-restart
+    // `hello` that clears the overlay and auto-sends the skill-confirm message.
+    // Forcing a reconnect here instead races the restart and the auto-send
+    // lands on a dead socket.
     const skillHandler = makeHandler('skill')
     // Treat a primary-AI-provider change the same as a skill install:
     // the gateway is restarting, the chat WS is about to drop, and

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -601,12 +601,23 @@ export async function restartGateway(): Promise<void> {
   }
 }
 
-/** Send SIGUSR1 to the gateway process so it hot-reloads skills without a full restart. */
+/** Send SIGUSR1 to the gateway so it restarts and picks up newly-installed skills. */
 export async function reloadGateway(): Promise<void> {
   try {
-    const { stdout } = await exec("pgrep", ["-f", "openclaw-gateway"], { timeout: 5_000 });
-    const pidStr = stdout.trim().split("\n")[0];
-    const pid = parseInt(pidStr, 10);
+    // The gateway process renames its argv to just "openclaw", so the old
+    // `pgrep -f "openclaw-gateway"` matched nothing and SIGUSR1 was never sent —
+    // installing a skill left the gateway untouched and the chat's reload
+    // overlay hung forever. Resolve the PID deterministically from systemd,
+    // falling back to an exact process-name match for dev / non-systemd runs.
+    let pid = 0;
+    try {
+      const { stdout } = await exec("systemctl", ["show", "clawbox-gateway.service", "-p", "MainPID", "--value"], { timeout: 5_000 });
+      pid = parseInt(stdout.trim(), 10);
+    } catch { /* not under systemd — fall through to pgrep */ }
+    if (!Number.isFinite(pid) || pid <= 0) {
+      const { stdout } = await exec("pgrep", ["-x", "openclaw"], { timeout: 5_000 });
+      pid = parseInt(stdout.trim().split("\n")[0], 10);
+    }
     if (Number.isFinite(pid) && pid > 0) {
       process.kill(pid, "SIGUSR1");
     }

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -467,9 +467,9 @@ describe("openclaw-config", () => {
       process.kill = originalKill;
     });
 
-    it("sends SIGUSR1 to the gateway process", async () => {
+    it("sends SIGUSR1 to the gateway PID resolved from systemd", async () => {
       setupExecFileMock({
-        "pgrep -f openclaw-gateway": { stdout: "12345\n", stderr: "" },
+        "systemctl show clawbox-gateway.service -p MainPID --value": { stdout: "12345\n", stderr: "" },
       });
 
       await openclawConfig.reloadGateway();
@@ -477,9 +477,10 @@ describe("openclaw-config", () => {
       expect(process.kill).toHaveBeenCalledWith(12345, "SIGUSR1");
     });
 
-    it("uses first PID when pgrep returns multiple", async () => {
+    it("falls back to pgrep -x and uses the first PID when systemd MainPID is unavailable", async () => {
       setupExecFileMock({
-        "pgrep -f openclaw-gateway": { stdout: "12345\n67890\n", stderr: "" },
+        "systemctl show clawbox-gateway.service -p MainPID --value": { stdout: "0\n", stderr: "" },
+        "pgrep -x openclaw": { stdout: "12345\n67890\n", stderr: "" },
       });
 
       await openclawConfig.reloadGateway();
@@ -487,10 +488,11 @@ describe("openclaw-config", () => {
       expect(process.kill).toHaveBeenCalledWith(12345, "SIGUSR1");
     });
 
-    it("does not throw when pgrep finds no process (ESRCH)", async () => {
+    it("does not throw when the gateway process is not found (ESRCH)", async () => {
       const error = new Error("No process found") as NodeJS.ErrnoException;
       error.code = "ESRCH";
       setupExecFileMock({
+        "systemctl show clawbox-gateway.service -p MainPID --value": { stdout: "0\n", stderr: "" },
         pgrep: error,
       });
 
@@ -498,9 +500,10 @@ describe("openclaw-config", () => {
       await expect(openclawConfig.reloadGateway()).resolves.toBeUndefined();
     });
 
-    it("does not call process.kill when pgrep returns empty output", async () => {
+    it("does not call process.kill when no PID is found", async () => {
       setupExecFileMock({
-        "pgrep -f openclaw-gateway": { stdout: "", stderr: "" },
+        "systemctl show clawbox-gateway.service -p MainPID --value": { stdout: "0\n", stderr: "" },
+        "pgrep -x openclaw": { stdout: "", stderr: "" },
       });
 
       await openclawConfig.reloadGateway();
@@ -508,9 +511,10 @@ describe("openclaw-config", () => {
       expect(process.kill).not.toHaveBeenCalled();
     });
 
-    it("does not call process.kill when PID is NaN", async () => {
+    it("does not call process.kill when the resolved PID is NaN", async () => {
       setupExecFileMock({
-        "pgrep -f openclaw-gateway": { stdout: "not-a-number\n", stderr: "" },
+        "systemctl show clawbox-gateway.service -p MainPID --value": { stdout: "not-a-number\n", stderr: "" },
+        "pgrep -x openclaw": { stdout: "still-not-a-number\n", stderr: "" },
       });
 
       await openclawConfig.reloadGateway();
@@ -523,6 +527,7 @@ describe("openclaw-config", () => {
       const error = new Error("Unexpected error") as NodeJS.ErrnoException;
       error.code = "EPERM";
       setupExecFileMock({
+        "systemctl show clawbox-gateway.service -p MainPID --value": { stdout: "0\n", stderr: "" },
         pgrep: error,
       });
 


### PR DESCRIPTION
## Problem

Installing a skill showed **"Reloading skills…" forever** and the agent never picked up the new skill.

## Root cause

`reloadGateway()` located the gateway via `pgrep -f "openclaw-gateway"`, but the gateway process **renames its argv to just `openclaw`** — so the match returned nothing and `SIGUSR1` was **never sent**. The gateway never restarted, the chat WS never dropped, and the reload overlay hung waiting for a reconnect that never came. (Verified on a live device: `pgrep -f openclaw-gateway` → no match; `MainPID`/`pgrep -x openclaw` → the gateway.)

## Fix

- **`reloadGateway`** — resolve the PID deterministically from systemd `MainPID` (with an exact-name `pgrep -x openclaw` fallback for dev) and send `SIGUSR1`.
- **`optimize-cpu.sh`** — same broken matcher, fixed (the gateway never got its CPU affinity set).
- **ChatPopup** — a comment documenting why the skill path must **not** force a reconnect like the provider path: the install route doesn't await the restart, so the natural `onClose → reconnect → resolve` flow delivers the post-restart `hello`. Forcing a reconnect races the restart and the auto-send message lands on a dead socket (I hit exactly this mid-fix — the log showed no `chat.send` reaching the gateway).
- **tests** — `reloadGateway` specs updated for the systemd-`MainPID` resolution (7 pass on-device).

## Verification

Live on the device: install a skill → `SIGUSR1` fires → gateway restarts (`[ws] webchat disconnected … reason=service restart`) → chat reconnects → the "I just installed X" message reaches the gateway and the agent confirms the skill. Confirmed working by the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced gateway restart reliability during skill installation with more robust process detection and systemd integration.
  * Optimized process targeting in resource management scripts for improved accuracy.

* **Documentation**
  * Clarified skill installation event handling behavior to document expected reconnection outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->