### PR TITLE
fix(e2e): give the power-restart container-stop a realistic timeout

### DIFF
--- a/e2e-install/99-power.spec.ts
+++ b/e2e-install/99-power.spec.ts
@@ -25,7 +25,7 @@ test.describe.configure({ mode: "serial" });
 
 test.describe("power restart", () => {
   test("trigger reboot, container exits, comes back with state intact", async () => {
-    test.setTimeout(10 * 60_000);
+    test.setTimeout(13 * 60_000);
 
     // Snapshot the state we expect to survive the restart.
     const before = await getStatus();
@@ -38,8 +38,9 @@ test.describe("power restart", () => {
       // write. Either outcome is fine.
     });
 
-    // systemd takes a moment to cascade the unit stops; allow up to 2 min.
-    await waitForContainerStopped(120_000);
+    // systemd cascades the unit stops (each up to its TimeoutStopSec); under CI
+    // load this can run past 2 min, so use the helper's default 4 min ceiling.
+    await waitForContainerStopped();
 
     // Explicitly restart. entrypoint.sh runs again but sees the volume is
     // populated and skips the initial seed. clawbox-bootstrap.service sees

--- a/e2e-install/helpers/container.ts
+++ b/e2e-install/helpers/container.ts
@@ -95,8 +95,14 @@ export async function composeRestart(): Promise<void> {
  * Wait until `docker inspect` reports the container is stopped (exit
  * status). Used by the power/reboot test to confirm an in-container
  * `systemctl reboot` actually propagated out to the docker runtime.
+ *
+ * Defaults to 4 min: `systemctl reboot` stops every unit first, and a couple of
+ * services hitting their default 90s `TimeoutStopSec` can cascade past 2 min on
+ * a loaded CI runner. The container does exit — it's just slow — so the old
+ * 120s ceiling flaked intermittently (seen on `main` too). Give it room rather
+ * than force-killing, which would mask a genuine reboot regression.
  */
-export async function waitForContainerStopped(timeoutMs = 120_000): Promise<void> {
+export async function waitForContainerStopped(timeoutMs = 240_000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {


### PR DESCRIPTION
## Problem
`e2e-install`'s `99-power.spec.ts` "power restart" test triggers `systemctl reboot` and waits for the container to stop — but capped that wait at **120s**. On reboot systemd stops every unit, and a couple of services hitting their default **90s `TimeoutStopSec`** can cascade past 2 minutes on a loaded CI runner. The container *does* exit — just slowly — so the 120s ceiling **flakes intermittently**.

This has been reddening `e2e-install` across the board, **including on `main`** (run `27184348475`, today 04:43) — same test, same `container ... did not stop within 120000ms`, with `80 passed / 1 failed`. It's not specific to any feature branch.

## Fix
- `waitForContainerStopped` default `120_000` → `240_000` (4 min).
- `99-power.spec.ts` test budget `10` → `13` min (covers stop ≤4 min + `dockerStart` + `waitForHttpReady` ≤5 min with headroom), and it now uses the helper default instead of an inline `120_000`.

## Why not force-kill
Making the helper `docker kill` the container on timeout would turn the test green unconditionally — but it would **mask a genuine regression** where `systemctl reboot` fails to propagate out of the container (which is exactly what this test exists to catch). The container does stop on its own; it just needs a realistic ceiling.
