### PR TITLE
fix(e2e): force-stop the container if reboot doesn't self-propagate

### DIFF
--- a/e2e-install/99-power.spec.ts
+++ b/e2e-install/99-power.spec.ts
@@ -16,6 +16,7 @@
 import { test, expect } from "@playwright/test";
 import {
   dockerStart,
+  dockerStop,
   waitForContainerStopped,
   waitForHttpReady,
 } from "./helpers/container";
@@ -38,9 +39,21 @@ test.describe("power restart", () => {
       // write. Either outcome is fine.
     });
 
-    // systemd cascades the unit stops (each up to its TimeoutStopSec); under CI
-    // load this can run past 2 min, so use the helper's default 4 min ceiling.
-    await waitForContainerStopped();
+    // Wait for the in-container `systemctl reboot` to exit the container.
+    // Best-effort: in CI, Docker-in-systemd reboot signaling intermittently
+    // hangs (the container never exits — reproduces on `main`, unrelated to any
+    // one change). If it doesn't propagate within the 4-min window, force-stop
+    // so the test still verifies the real guarantee below — that configured
+    // state survives a power cycle — instead of flaking the whole suite.
+    try {
+      await waitForContainerStopped();
+    } catch {
+      console.warn(
+        "[power] systemctl reboot did not exit the container within the window; " +
+        "force-stopping (CI Docker-in-systemd flake).",
+      );
+      await dockerStop();
+    }
 
     // Explicitly restart. entrypoint.sh runs again but sees the volume is
     // populated and skips the initial seed. clawbox-bootstrap.service sees

--- a/e2e-install/helpers/container.ts
+++ b/e2e-install/helpers/container.ts
@@ -124,6 +124,15 @@ export async function dockerStart(): Promise<void> {
   await execFileAsync("docker", ["start", CONTAINER_NAME], { timeout: 60_000 });
 }
 
+/**
+ * Force-stop the container (SIGTERM to PID 1, SIGKILL after the grace period).
+ * Fallback for the power test when an in-container `systemctl reboot` doesn't
+ * propagate to a container exit on its own (a CI Docker-in-systemd flake).
+ */
+export async function dockerStop(): Promise<void> {
+  await execFileAsync("docker", ["stop", "-t", "30", CONTAINER_NAME], { timeout: 60_000 });
+}
+
 export async function dockerExec(cmd: string[], opts: { user?: string; timeoutMs?: number } = {}): Promise<string> {
   const args = ["exec"];
   if (opts.user) args.push("--user", opts.user);


### PR DESCRIPTION
## Problem
The `e2e-install` power-restart test (`99-power.spec.ts`) fires an in-container `systemctl reboot` and waits for the **container to exit**. In CI, Docker-in-systemd reboot signaling **intermittently hangs** — the container never exits at all. This reproduces on `main` and correlates with runner conditions (morning runs pass, evening runs hang); it's independent of any code change.

#187 raised the graceful wait 120s→240s, which covers a *slow* reboot — but this is a *hang*, and no timeout fixes a hang (it just fails 2 min later, as seen at the full 240s).

## Fix
When the graceful wait times out, **force-stop the container** (`docker stop -t 30`) with a logged warning, then continue. The test's *real* guarantee — **configured state survives a power cycle** — remains a hard assertion (`setup_complete` / `wifi_configured` / `password_configured` after restart). Only the "reboot exits the container on its own" check is downgraded to **best-effort**, because that's an artifact of running systemd inside Docker, not a product behavior real devices depend on.

## Why not keep failing on it
It already fails on `main`, so it isn't catching a regression — it's just reddening everyone's `e2e-install` non-deterministically. The `console.warn` keeps a genuine reboot-propagation problem visible in the logs without flaking the whole suite. Builds on #187 (the 4-min graceful window still gives a legitimately-slow reboot room before the fallback triggers).
