### PR TITLE
test(e2e): cover the WiFi-handoff path; fix the CSP that broke its auto-redirect (#167)

### DIFF
--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -1109,19 +1109,29 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
   });
 }
 
+/**
+ * The wizard step right after WiFi: the update step auto-advances to
+ * credentials the moment it sees there's nothing to install, and with test
+ * timers capped (installClawboxMocks) that can happen before Playwright
+ * catches the update step on screen — so race the two steps rather than
+ * assuming the update step lingers long enough to assert.
+ */
+export function wizardStepAfterWifi(page: Page) {
+  return page
+    .getByTestId("setup-step-update")
+    .or(page.getByTestId("setup-step-credentials"))
+    .first();
+}
+
 export async function completeSetupWizard(page: Page) {
   await expect(page.getByTestId("setup-step-wifi")).toBeVisible();
   // Ethernet-first happy path: a wired uplink lets the wizard advance in-page.
-  // (The WiFi path redirects through the handoff overlay — untestable, see #167.)
+  // (The WiFi path is covered by setup-wifi-handoff.spec.ts.)
   await page.getByRole("button", { name: "Continue with Ethernet" }).click();
 
-  // The update step auto-advances to credentials the moment it sees there's
-  // nothing to install. With test timers capped (installClawboxMocks) that can
-  // happen before Playwright catches the update step on screen, so race the two
-  // steps rather than assuming the update step lingers long enough to assert.
   const updateStep = page.getByTestId("setup-step-update");
   const credentialsStep = page.getByTestId("setup-step-credentials");
-  await expect(updateStep.or(credentialsStep).first()).toBeVisible({ timeout: 10_000 });
+  await expect(wizardStepAfterWifi(page)).toBeVisible({ timeout: 10_000 });
   if (await updateStep.isVisible().catch(() => false)) {
     const advancedAutomatically = await expect(credentialsStep).toBeVisible({ timeout: 4_000 })
       .then(() => true)

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -524,9 +524,9 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
 
     if (path === "/setup-api/wifi/ethernet") {
       // Ethernet present: the setup specs drive the Ethernet-first happy path
-      // ("Continue with Ethernet"), which advances in-page. The WiFi path tears
-      // down the hotspot and redirects to the box's new address — untestable in
-      // e2e, tracked in #167.
+      // ("Continue with Ethernet"), which advances in-page. The WiFi-handoff
+      // path is covered by setup-wifi-handoff.spec.ts, which overrides this
+      // route (no cable) and mocks the box's home-network origin.
       await fulfillJson(route, { connected: true, cable: true });
       return;
     }

--- a/e2e/setup-wifi-handoff.spec.ts
+++ b/e2e/setup-wifi-handoff.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "./helpers/coverage";
+import { installClawboxMocks } from "./helpers/clawbox";
+
+/**
+ * Covers the WiFi-handoff path (#167): joining a home network on the
+ * single-radio box tears down the setup hotspot, so WifiStep raises the
+ * full-screen WifiHandoffOverlay, which probes the box's home-network address
+ * (an <img> load — fetch is CORS-blocked cross-origin) and redirects there
+ * once the box answers.
+ *
+ * There's no second box in e2e, so the home-network origin
+ * (http://clawbox.local — useDeviceAddress's fallback, since the mocks answer
+ * /setup-api/system/hostname with `{}`) is mocked at the network layer:
+ * the icon probe is fulfilled with a PNG so the overlay "finds" the box, and
+ * the cross-origin /setup navigation is bounced straight back to the test
+ * origin. That exercises the overlay's real probe/redirect logic end to end —
+ * no test-only hooks in the components.
+ */
+
+// 1x1 transparent PNG — all the <img> probe needs for onload to fire.
+const PROBE_PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+test("wifi connect hands off through the overlay and resumes the wizard", async ({ page }, testInfo) => {
+  await installClawboxMocks(page);
+
+  // No ethernet: routes are checked newest-first, so this overrides the
+  // helper's cable-connected default and drives the WiFi-first path.
+  await page.route("**/setup-api/wifi/ethernet", (route) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ connected: false, cable: false }),
+    }),
+  );
+
+  // The box's "new address" on the home network.
+  const baseURL = testInfo.project.use.baseURL ?? "http://localhost:3000";
+  await page.route("http://clawbox.local/clawbox-icon.png*", (route) =>
+    route.fulfill({ contentType: "image/png", body: PROBE_PNG }),
+  );
+  await page.route("http://clawbox.local/setup", (route) =>
+    route.fulfill({ status: 302, headers: { location: `${baseURL}/setup` } }),
+  );
+
+  await page.goto("/setup");
+  await expect(page.getByTestId("setup-step-wifi")).toBeVisible();
+
+  // Pick a network and connect.
+  await page.getByRole("button", { name: "Use Wi-Fi instead" }).click();
+  await page.getByRole("button", { name: "Clawbox Lab" }).click();
+  await page.locator("#wifi-password").fill("wifi-pass-123");
+  await page.getByRole("button", { name: "Connect", exact: true }).click();
+
+  // The handoff overlay comes up. Timers are capped by installClawboxMocks,
+  // so it may already be past "joining" and into the back-online phase —
+  // accept either to avoid racing the capped grace/probe loop.
+  const joining = page.getByText("Joining your WiFi");
+  const backOnline = page.getByText("Device is back online");
+  await expect(joining.or(backOnline).first()).toBeVisible({ timeout: 10_000 });
+
+  // Probe answers → overlay redirects to the box's new address → bounced back
+  // to the test origin → the wizard reloads and resumes PAST the WiFi step
+  // (the connect mock set wifi_configured). Update may auto-advance to
+  // credentials, so accept either resume target.
+  const updateStep = page.getByTestId("setup-step-update");
+  const credentialsStep = page.getByTestId("setup-step-credentials");
+  await expect(updateStep.or(credentialsStep).first()).toBeVisible({ timeout: 15_000 });
+});

--- a/e2e/setup-wifi-handoff.spec.ts
+++ b/e2e/setup-wifi-handoff.spec.ts
@@ -24,7 +24,12 @@ const PROBE_PNG = Buffer.from(
 );
 
 test("wifi connect hands off through the overlay and resumes the wizard", async ({ page }, testInfo) => {
-  await installClawboxMocks(page);
+  // The default 50ms timer cap also crushes imgProbe's own 4s timeout — on
+  // slow hardware the route-interception round trip doesn't fit in 50ms, so
+  // every probe attempt "times out" and the overlay never finds the box.
+  // 500ms keeps the grace/probe/redirect loop fast but gives the intercepted
+  // probe response room to land.
+  await installClawboxMocks(page, { timeoutCapMs: 500 });
 
   // No ethernet: routes are checked newest-first, so this overrides the
   // helper's cable-connected default and drives the WiFi-first path.

--- a/e2e/setup-wifi-handoff.spec.ts
+++ b/e2e/setup-wifi-handoff.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "./helpers/coverage";
-import { installClawboxMocks } from "./helpers/clawbox";
+import { installClawboxMocks, wizardStepAfterWifi } from "./helpers/clawbox";
 
 /**
  * Covers the WiFi-handoff path (#167): joining a home network on the
@@ -23,7 +23,7 @@ const PROBE_PNG = Buffer.from(
   "base64",
 );
 
-test("wifi connect hands off through the overlay and resumes the wizard", async ({ page }, testInfo) => {
+test("wifi connect hands off through the overlay and resumes the wizard", async ({ page, baseURL }) => {
   // The default 50ms timer cap also crushes imgProbe's own 4s timeout — on
   // slow hardware the route-interception round trip doesn't fit in 50ms, so
   // every probe attempt "times out" and the overlay never finds the box.
@@ -41,7 +41,6 @@ test("wifi connect hands off through the overlay and resumes the wizard", async 
   );
 
   // The box's "new address" on the home network.
-  const baseURL = testInfo.project.use.baseURL ?? "http://localhost:3000";
   await page.route("http://clawbox.local/clawbox-icon.png*", (route) =>
     route.fulfill({ contentType: "image/png", body: PROBE_PNG }),
   );
@@ -67,9 +66,6 @@ test("wifi connect hands off through the overlay and resumes the wizard", async 
 
   // Probe answers → overlay redirects to the box's new address → bounced back
   // to the test origin → the wizard reloads and resumes PAST the WiFi step
-  // (the connect mock set wifi_configured). Update may auto-advance to
-  // credentials, so accept either resume target.
-  const updateStep = page.getByTestId("setup-step-update");
-  const credentialsStep = page.getByTestId("setup-step-credentials");
-  await expect(updateStep.or(credentialsStep).first()).toBeVisible({ timeout: 15_000 });
+  // (the connect mock set wifi_configured).
+  await expect(wizardStepAfterWifi(page)).toBeVisible({ timeout: 15_000 });
 });

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,10 @@ import { execSync } from "child_process";
 
 const isDev = process.env.NODE_ENV === "development";
 const GATEWAY_URL = process.env.GATEWAY_URL || "http://127.0.0.1:18789";
+// LAN origins the box can reappear at after a network/hostname change —
+// shared by connect-src (fetch probes) and img-src (the handoff overlays'
+// <img> probes) so the two CSP directives can't drift apart.
+const LOCAL_LAN_SOURCES = "http://*.local http://*.local:* https://*.local https://*.local:*";
 // Git-based version: "v2.0.0" on tag, "v2.0.0-3-gca62836" after commits
 const APP_VERSION = (() => {
   try {
@@ -88,14 +92,14 @@ const nextConfig: NextConfig = {
               "default-src 'self'",
               `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
               "style-src 'self' 'unsafe-inline'",
-              // The .local sources mirror connect-src below: the WiFi/credentials
-              // handoff overlays detect the box at its new address with an <img>
-              // probe (fetch is CORS-blocked cross-origin), and without them the
-              // browser CSP-blocks the probe before it leaves the page — the
+              // LOCAL_LAN_SOURCES in img-src: the WiFi/credentials handoff
+              // overlays detect the box at its new address with an <img> probe
+              // (fetch is CORS-blocked cross-origin), and without it the browser
+              // CSP-blocks the probe before it leaves the page — the
               // auto-redirect never fires and users must follow the manual URL.
-              "img-src 'self' data: blob: http://*.local http://*.local:* https://*.local https://*.local:*",
+              `img-src 'self' data: blob: ${LOCAL_LAN_SOURCES}`,
               "font-src 'self'",
-              "connect-src 'self' ws: wss: http://*.local http://*.local:* https://*.local https://*.local:*",
+              `connect-src 'self' ws: wss: ${LOCAL_LAN_SOURCES}`,
               // Allow code-server iframe and webapp iframes (same origin)
               `frame-src 'self' blob:`,
               `frame-ancestors ${frameAncestors}`,

--- a/next.config.ts
+++ b/next.config.ts
@@ -88,7 +88,12 @@ const nextConfig: NextConfig = {
               "default-src 'self'",
               `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
               "style-src 'self' 'unsafe-inline'",
-              "img-src 'self' data: blob:",
+              // The .local sources mirror connect-src below: the WiFi/credentials
+              // handoff overlays detect the box at its new address with an <img>
+              // probe (fetch is CORS-blocked cross-origin), and without them the
+              // browser CSP-blocks the probe before it leaves the page — the
+              // auto-redirect never fires and users must follow the manual URL.
+              "img-src 'self' data: blob: http://*.local http://*.local:* https://*.local https://*.local:*",
               "font-src 'self'",
               "connect-src 'self' ws: wss: http://*.local http://*.local:* https://*.local https://*.local:*",
               // Allow code-server iframe and webapp iframes (same origin)

--- a/scripts/e2e-coverage-report.mjs
+++ b/scripts/e2e-coverage-report.mjs
@@ -28,7 +28,12 @@ const BASE_ORIGIN = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${cover
 // home-network address — untestable in e2e (no real box to probe), so that
 // new code stays uncovered and pins the aggregate at ~39%. Raise back to 40
 // once #167 lands e2e for the handoff flow.
-const MIN_APP_COVERAGE = 38;
+//
+// 2026-06-10: raised 38 → 40. setup-wifi-handoff.spec.ts now drives the
+// WiFi-handoff path end to end (the home-network origin is mocked at the
+// network layer, so WifiHandoffOverlay's real probe/redirect logic runs),
+// which un-pins the handoff/overlay code that forced the 06-05 drop.
+const MIN_APP_COVERAGE = 40;
 
 async function walk(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });

--- a/scripts/e2e-coverage-report.mjs
+++ b/scripts/e2e-coverage-report.mjs
@@ -29,11 +29,15 @@ const BASE_ORIGIN = process.env.PLAYWRIGHT_BASE_URL || `http://localhost:${cover
 // new code stays uncovered and pins the aggregate at ~39%. Raise back to 40
 // once #167 lands e2e for the handoff flow.
 //
-// 2026-06-10: raised 38 → 40. setup-wifi-handoff.spec.ts now drives the
+// 2026-06-10: raised 38 → 39. setup-wifi-handoff.spec.ts now drives the
 // WiFi-handoff path end to end (the home-network origin is mocked at the
 // network layer, so WifiHandoffOverlay's real probe/redirect logic runs),
-// which un-pins the handoff/overlay code that forced the 06-05 drop.
-const MIN_APP_COVERAGE = 40;
+// which un-pins the handoff/overlay code that forced the 06-05 drop. CI
+// measured the aggregate at 39.61% with the new spec — short of the hoped-for
+// 40, so the floor sits at 39; the remaining gap is the long-standing
+// under-covered apps from the 05-02 note (AIModelsStep, ClawKeepApp,
+// SettingsApp, FilesApp). Raise to 40+ as those gain specs.
+const MIN_APP_COVERAGE = 39;
 
 async function walk(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });


### PR DESCRIPTION
Closes the e2e-coverage half of #167.

## What this covers
The single-radio WiFi handoff was the one wizard path with no e2e: WifiStep raises `WifiHandoffOverlay`, which `<img>`-probes the box's home-network address and redirects there. With no second box, the probe had nothing to find — so the path stayed untested and the coverage floor was dropped 40 → 38 (2026-06-05, with "raise back once #167 lands").

`setup-wifi-handoff.spec.ts` closes the gap **without any test-only hooks in components**: Playwright intercepts cross-origin requests, so the spec fulfills the icon probe with a PNG and bounces the `http://clawbox.local/setup` navigation back to the test origin. The overlay's real grace/probe/redirect logic runs end to end and the wizard resumes past the WiFi step.

## The production bug it found
The spec's probe was blocked by **our own CSP** — and the same header ships to real boxes: `img-src 'self' data: blob:` blocks the handoff probe before it leaves the page, so **the auto-redirect has never fired in production**; users always had to follow the manual "open http://clawbox.local" instruction. `connect-src` was already extended with the `.local` origins for the handoff stack, but `img-src` — the directive the probe actually uses (fetch is CORS-blocked cross-origin) — wasn't.

Fix: allow the same `.local` origins in `img-src`, hoisted into a shared `LOCAL_LAN_SOURCES` so the two directives can't drift. Verified against every `imgProbe` call site: cross-origin probes only ever target `.local` hosts (WifiStep passes `localUrl`; the credentials handoff goes cross-origin only for a validated `.local` hostname change), so no broader `http:` source is needed. The new spec runs against the dev server's real headers, so it also regression-pins this CSP fix — revert it and the spec fails.

## Coverage floor
Raised back **38 → 40** per the 06-05 comment's own condition. CI's e2e job (`test:e2e:coverage`) enforces it; if the runner's aggregate lands under 40 I'll adjust to the measured value.

## Validation
- Spec is green on a Jetson Orin Nano (Chromium, dev server): `1 passed (10.2s)`.
- Root cause confirmed from the Playwright trace: 30+ probe attempts all blocked with `violates the following Content Security Policy directive: "img-src 'self' data: blob:"`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test for WiFi handoff overlay, verifying the setup wizard resumes correctly after WiFi connection through the overlay transition

* **Chores**
  * Updated Content Security Policy headers for consistent local network resource access
  * Updated e2e test coverage baselines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->