### PR TITLE
release: v3.1.2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -942,24 +942,46 @@ step_openclaw_patch() {
   echo "  Device identity bypass patch applied and verified"
 }
 
+# `openclaw config set` (OpenClaw 2026.6.x) does an optimistic-concurrency
+# check: if anything else writes openclaw.json between its load and write —
+# the live gateway, or the CLI's own state migrations triggered by the
+# PREVIOUS call — it dies with ConfigMutationConflictError. Under
+# `set -euo pipefail` that aborted the whole step mid-update and left
+# devices half-updated: rebuild_reboot never reached the rebuild, while the
+# updater still reported success (see fix in src/lib/updater.ts). Each retry
+# reloads the config fresh, so a transient conflict resolves itself.
+oc_config_set() {
+  local attempt
+  for attempt in 1 2 3; do
+    if as_clawbox "$OPENCLAW_BIN" config set "$@"; then
+      return 0
+    fi
+    if [ "$attempt" -lt 3 ]; then
+      echo "  config set $1 failed (attempt $attempt/3) — retrying..."
+      sleep 2
+    fi
+  done
+  echo "  ERROR: config set $1 failed after 3 attempts" >&2
+  return 1
+}
+
 step_openclaw_config() {
   local CLAWBOX_CONFIG="$PROJECT_DIR/data/config.json"
   local CLAWBOX_AI_ENV="$PROJECT_DIR/.env"
   local CLAWBOX_AI_KEY="${CLAWBOX_AI_API_KEY:-}"
   local AUTH_PROFILES="$CLAWBOX_HOME/.openclaw/agents/main/agent/auth-profiles.json"
 
-  # Sequential config set calls to avoid ConfigMutationConflictError
   # Only seed the primary model if unset — preserves the user's provider choice
   # across updates (rebuild_reboot re-invokes this step).
   local CURRENT_PRIMARY
   CURRENT_PRIMARY=$(as_clawbox "$OPENCLAW_BIN" config get agents.defaults.model.primary 2>/dev/null || echo "")
   if [ -z "$CURRENT_PRIMARY" ] || [ "$CURRENT_PRIMARY" = "null" ]; then
-    as_clawbox "$OPENCLAW_BIN" config set agents.defaults.model.primary "anthropic/claude-sonnet-4-20250514"
+    oc_config_set agents.defaults.model.primary "anthropic/claude-sonnet-4-20250514"
     echo "  Default model set"
   else
     echo "  Default model already set ($CURRENT_PRIMARY) — preserving"
   fi
-  as_clawbox "$OPENCLAW_BIN" config set agents.defaults.compaction.reserveTokensFloor 24000
+  oc_config_set agents.defaults.compaction.reserveTokensFloor 24000
   echo "  Compaction reserve floor set"
 
   if [ -z "$CLAWBOX_AI_KEY" ] && [ -f "$CLAWBOX_AI_ENV" ]; then
@@ -970,44 +992,21 @@ step_openclaw_config() {
     CLAWBOX_AI_PROVIDER_JSON=$(node -e 'const key=process.argv[1]; process.stdout.write(JSON.stringify({baseUrl:"https://api.deepseek.com",api:"openai-completions",apiKey:key,models:[{id:"deepseek-chat",name:"ClawBox AI",reasoning:false,input:["text"],cost:{input:0,output:0,cacheRead:0,cacheWrite:0},contextWindow:65536,maxTokens:8192}]}));' "$CLAWBOX_AI_KEY")
     mkdir -p "$(dirname "$AUTH_PROFILES")"
     CLAWBOX_AI_KEY="$CLAWBOX_AI_KEY" AUTH_PROFILES="$AUTH_PROFILES" node -e 'const fs=require("fs"); const p=process.env.AUTH_PROFILES; let data={version:1,profiles:{}}; try{data=JSON.parse(fs.readFileSync(p,"utf8"));}catch{} data.profiles["deepseek:default"]={type:"api_key",provider:"deepseek",key:process.env.CLAWBOX_AI_KEY}; fs.writeFileSync(p, JSON.stringify(data,null,2), { mode: 0o600 });'
-    as_clawbox "$OPENCLAW_BIN" config set auth.profiles.deepseek:default '{"provider":"deepseek","mode":"api_key"}' --json
-    as_clawbox "$OPENCLAW_BIN" config set models.providers.deepseek "$CLAWBOX_AI_PROVIDER_JSON" --json
-    as_clawbox "$OPENCLAW_BIN" config set agents.defaults.model.fallback "deepseek/deepseek-chat"
+    oc_config_set auth.profiles.deepseek:default '{"provider":"deepseek","mode":"api_key"}' --json
+    oc_config_set models.providers.deepseek "$CLAWBOX_AI_PROVIDER_JSON" --json
+    oc_config_set agents.defaults.model.fallback "deepseek/deepseek-chat"
     echo "  ClawBox AI fallback model configured"
   fi
 
-  as_clawbox "$OPENCLAW_BIN" config set gateway.auth.mode token
-  # Seed a strong per-device gateway token (not the public legacy literal).
-  # gateway-pre-start.sh preserves it on every start; the gateway resolves it
-  # from config (no --token flag). Only seed when missing/weak so re-runs of
-  # the installer don't rotate a token a device is already using.
-  # Strong = a `${ENV}` interpolation or a >=32-char non-legacy string
-  # (kept in lockstep with is_strong_gateway_token in gateway-pre-start.sh).
-  # `|| true`: on a fresh install the token key doesn't exist yet, so
-  # `config get` exits non-zero — without this, set -euo pipefail would abort
-  # the whole installer here (caught by the e2e-install harness).
-  EXISTING_GW_TOKEN=$(as_clawbox "$OPENCLAW_BIN" config get gateway.auth.token 2>/dev/null | tr -d '"[:space:]') || true
-  if [[ "$EXISTING_GW_TOKEN" =~ ^\$\{.+\}$ ]]; then
-    GW_TOKEN_STRONG=1
-  elif [ -n "$EXISTING_GW_TOKEN" ] && [ "$EXISTING_GW_TOKEN" != "clawbox" ] && [ "${#EXISTING_GW_TOKEN}" -ge 32 ]; then
-    GW_TOKEN_STRONG=1
-  else
-    GW_TOKEN_STRONG=0
-  fi
-  if [ "$GW_TOKEN_STRONG" -eq 0 ]; then
-    GW_TOKEN=$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
-    as_clawbox "$OPENCLAW_BIN" config set gateway.auth.token "$GW_TOKEN"
-    echo "  Gateway auth token generated (per-device)"
-  else
-    echo "  Gateway auth token preserved (already strong)"
-  fi
-  echo "  Gateway auth mode set to token"
-
-  as_clawbox "$OPENCLAW_BIN" config set gateway.controlUi.allowInsecureAuth true --json
-  echo "  allowInsecureAuth enabled"
-
-  as_clawbox "$OPENCLAW_BIN" config set gateway.controlUi.dangerouslyDisableDeviceAuth true --json
-  echo "  dangerouslyDisableDeviceAuth enabled"
+  # gateway.auth.mode/token and gateway.controlUi.{allowInsecureAuth,
+  # dangerouslyDisableDeviceAuth} are deliberately NOT set here:
+  # gateway-pre-start.sh owns them, enforcing all four atomically (single
+  # read-modify-write on openclaw.json) on every gateway start — including
+  # the start right after this installer/updater finishes. Setting them here
+  # too made two writers race the live gateway; the controlUi pair was the
+  # exact `config set` that died with ConfigMutationConflictError mid-update
+  # and aborted rebuild_reboot before the rebuild.
+  echo "  Gateway auth/controlUi config deferred to gateway-pre-start.sh"
 
   # Register Telegram channel (if token exists)
   if [ -f "$CLAWBOX_CONFIG" ]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -68,9 +68,67 @@ export interface UpdateState {
 export { RESTART_STEP_ID } from "./update-constants";
 import { RESTART_STEP_ID } from "./update-constants";
 
-/** Wait indefinitely for systemd to SIGTERM us (during rebuild/reboot). */
-function waitForTermination(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 30_000));
+// Ceiling for the rebuild/restart hand-off: bun build alone runs minutes on a
+// Jetson, plus the config/redeploy steps before it and the reboot after.
+const REBUILD_TAKEOVER_TIMEOUT_MS = 900_000;
+
+// The root unit that performs the rebuild + restart. Distinct from
+// RESTART_STEP_ID ("restart"), which is the UI step's identity — querying
+// `clawbox-root-update@restart.service` would hit a unit that doesn't exist
+// (and `systemctl show -p Result` reports "success" for unloaded units, which
+// would silently disable the failure detection below).
+const REBUILD_ROOT_STEP = "rebuild_reboot";
+
+/** `systemctl show <unit> -p Result --value`, or null if unqueryable. */
+async function getRootStepResult(stepId: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFile(
+      "/usr/bin/systemctl",
+      ["show", `clawbox-root-update@${stepId}.service`, "-p", "Result", "--value"],
+      { timeout: 10_000 },
+    );
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Read .next/BUILD_ID — regenerated on every successful `next build`. */
+async function readBuildId(): Promise<string> {
+  try {
+    return (await readFile(path.join(PROJECT_DIR, ".next", "BUILD_ID"), "utf-8")).trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Wait for the rebuild_reboot root unit to take this process down (it
+ * restarts clawbox-setup / reboots the box on success). The old
+ * implementation was a blind 30s sleep that resolved SUCCESS — so a rebuild
+ * that failed (or merely outlived the sleep) let the update march on to
+ * "Update complete" while the box kept serving the old build, with the
+ * promised restart never coming. Watch the unit instead: a failure surfaces
+ * as a failed step with the real error, and only systemd killing us counts
+ * as success — this function never returns normally.
+ */
+async function waitForRebuildToTakeOver(): Promise<never> {
+  const deadline = Date.now() + REBUILD_TAKEOVER_TIMEOUT_MS;
+  let message = "Rebuild did not restart the device within the expected window";
+  while (Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+    if ((await getRootStepResult(REBUILD_ROOT_STEP)) === "failed") {
+      const lastLog = await readRootStepFailure(REBUILD_ROOT_STEP);
+      message = lastLog
+        ? `Rebuild failed: ${lastLog}`
+        : "Rebuild failed — see clawbox-root-update@rebuild_reboot logs";
+      break;
+    }
+  }
+  // Either way the restart isn't coming — clear the flag so the next server
+  // start doesn't "continue" a rebuild that never happened.
+  await set("update_needs_continuation", undefined);
+  throw new Error(message);
 }
 
 function getLastLogLine(logText: string): string | null {
@@ -200,9 +258,14 @@ async function updateClawBoxAndReboot(): Promise<void> {
     ` && ${gitCmd} clean -fd`,
     { timeout: 60_000, maxBuffer: 2 * 1024 * 1024 },
   );
-  await set("update_needs_continuation", true);
-  await startRootServiceFireAndForget("rebuild_reboot");
-  await waitForTermination();
+  // Record the pre-rebuild build identity in the flag: BUILD_ID changes on
+  // every successful `next build`, so the continuation can demand positive
+  // evidence the rebuild actually happened. Without it, a power cycle in the
+  // few seconds between unit failure and our watcher noticing would reset the
+  // unit's systemd state and let the continuation fake a completed update.
+  await set("update_needs_continuation", (await readBuildId()) || "no-previous-build");
+  await startRootServiceFireAndForget(REBUILD_ROOT_STEP);
+  await waitForRebuildToTakeOver();
 }
 
 // First-time `npm install -g openclaw` on cold Jetson caches routinely runs
@@ -269,8 +332,15 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   {
     id: RESTART_STEP_ID,
     label: "Updating ClawBox and restarting",
-    timeoutMs: 90_000,
+    // timeoutMs is unenforced for customRun steps; the real budget lives in
+    // REBUILD_TAKEOVER_TIMEOUT_MS inside waitForRebuildToTakeOver — same
+    // constant, so it can't drift.
+    timeoutMs: REBUILD_TAKEOVER_TIMEOUT_MS,
     customRun: updateClawBoxAndReboot,
+    // If the rebuild failed, the new install.sh never deployed — running
+    // post_update fixups from a half-applied state helps nobody. Stop here
+    // and surface the error.
+    failFast: true,
   },
   {
     // Runs after reboot via checkContinuation — picks up dispatcher scripts,
@@ -531,6 +601,33 @@ export async function checkContinuation(): Promise<boolean> {
 
   const restartIndex = UPDATE_STEPS.findIndex((s) => s.id === RESTART_STEP_ID);
   const startFrom = restartIndex + 1;
+
+  // The flag only proves the rebuild unit was STARTED, not that it rebuilt
+  // and restarted anything. Resuming blindly would stamp "Update complete"
+  // on a box still running its old build. Demand evidence the rebuild
+  // happened: the unit must not sit in `failed`, and the on-disk BUILD_ID
+  // must differ from the one recorded before the rebuild (systemd unit state
+  // resets across reboots, so the Result check alone can be erased by a
+  // power cycle; the BUILD_ID can't). Legacy boolean flags (written by the
+  // previous updater version) carry no build identity — for those only the
+  // unit check applies.
+  const unitFailed = (await getRootStepResult(REBUILD_ROOT_STEP)) === "failed";
+  const recordedBuildId = typeof needsContinuation === "string" ? needsContinuation : null;
+  const buildUnchanged = recordedBuildId !== null && recordedBuildId === (await readBuildId());
+  if (unitFailed || buildUnchanged) {
+    const message = unitFailed
+      ? (await readRootStepFailure(REBUILD_ROOT_STEP)) ?? "Rebuild failed before the restart"
+      : "The device restarted without producing a new build — see clawbox-root-update@rebuild_reboot logs";
+    state = createInitialState();
+    state.phase = "failed";
+    for (let i = 0; i < restartIndex; i++) {
+      state.steps[i].status = "completed";
+    }
+    state.steps[restartIndex].status = "failed";
+    state.steps[restartIndex].error = message;
+    state.error = message;
+    return false;
+  }
 
   running = true;
   state = createInitialState();

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -318,6 +318,55 @@ describe("updater", () => {
       expect(result).toBe(true);
       expect(mockSet).toHaveBeenCalledWith("update_needs_continuation", undefined);
     });
+
+    it("reports a failed update instead of resuming when the rebuild unit failed", async () => {
+      // The continuation flag only proves the rebuild unit STARTED. If the
+      // server came back without the unit succeeding (georgi: a config-set
+      // conflict killed it before the build), resuming would stamp "Update
+      // complete" on a box still running its old build.
+      setupExecFileMock({
+        "show clawbox-root-update@rebuild_reboot.service -p Result": { stdout: "failed\n", stderr: "" },
+        "/usr/bin/journalctl": {
+          stdout: "ConfigMutationConflictError: config changed since last load\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue(true);
+
+      const result = await updater.checkContinuation();
+
+      expect(result).toBe(false);
+      // Flag still cleared — the failure must not replay on every poll.
+      expect(mockSet).toHaveBeenCalledWith("update_needs_continuation", undefined);
+      const state = updater.getUpdateState();
+      expect(state.phase).toBe("failed");
+      expect(state.error).toBe("ConfigMutationConflictError: config changed since last load");
+      // The UI step's id is "restart"; "rebuild_reboot" is the root UNIT name.
+      const rebuildStep = state.steps.find((step) => step.id === "restart");
+      expect(rebuildStep?.status).toBe("failed");
+    });
+
+    it("reports a failed update when no new build was produced", async () => {
+      // Power-cycle scenario: the rebuild unit failed, the box was rebooted
+      // before the watcher noticed (so the unit's systemd Result reset), and
+      // the stale flag survived. The recorded BUILD_ID still matching the
+      // on-disk one is the proof no rebuild happened.
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue("build-aaa");
+      mockReadFile.mockResolvedValue("build-aaa\n");
+
+      const result = await updater.checkContinuation();
+
+      expect(result).toBe(false);
+      const state = updater.getUpdateState();
+      expect(state.phase).toBe("failed");
+      expect(state.error).toContain("without producing a new build");
+    });
   });
 
   describe("getTargetVersion", () => {


### PR DESCRIPTION
Patch release: makes update failures visible instead of silently leaving boxes on old builds.

## The bug it fixes (#192)
A real device updating to v3.1.1 synced the code, showed every step green and "Update complete — the device will restart in a moment" — then never rebuilt, never restarted, and kept serving the old build. Two compounding causes:
- `install.sh` died mid-update on OpenClaw 2026.6.x's config-write concurrency check (`ConfigMutationConflictError`) before the rebuild step ran.
- The updater's restart step was a blind 30s sleep that reported success regardless, so the failure was invisible.

## Changes
- Gateway auth/controlUi config keys have a single owner now (`gateway-pre-start.sh`, atomic write on every gateway start); the installer no longer races it — also shaves ~30–50s of Jetson install time.
- Remaining installer `config set` calls retry through transient conflicts.
- The updater watches the rebuild unit and fails the step with the real journal error if the rebuild dies; post-update fixups don't run from a half-applied state.
- Resuming after restart now requires positive evidence the rebuild happened (fresh `.next/BUILD_ID`), closing the power-cycle fake-success window.

## Validation
- 20/20 updater unit tests on a Jetson Orin Nano (two new failure-path tests).
- Full CI green, including e2e-install's containerized update→restart→continuation flow on the new code.
- Live field test: in-app updater run on the same device that hit the original bug, gateway live — genuine rebuild (BUILD_ID changed), genuine reboot, honest completion, continuation flag cleaned up.

## After merge
Tag `v3.1.2` so the fleet's update check offers it.
