### PR TITLE
fix: honest budget overruns + post_update gets a real (advisory) budget

### DIFF
--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -345,9 +345,13 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   {
     // Runs after reboot via checkContinuation — picks up dispatcher scripts,
     // sysctls, and other root fixups that landed in the new install.sh.
+    // 5 min, not 60s: on a freshly-installed device the fixups run on cold
+    // caches (clawkeep pip force-reinstall, vnc apt work) and routinely
+    // outlive a 1-minute budget — which painted a false-red step on an
+    // otherwise successful update.
     id: "post_update",
     label: "Applying system fixups",
-    timeoutMs: 60_000,
+    timeoutMs: 300_000,
     requiresRoot: true,
   },
 ];
@@ -363,9 +367,26 @@ async function execAsRoot(stepId: string, timeoutMs: number): Promise<void> {
   await execFile("/usr/bin/systemctl", ["reset-failed", serviceName], {
     timeout: 10_000,
   }).catch(() => {});
-  await execFile("/usr/bin/systemctl", ["start", serviceName], {
-    timeout: timeoutMs + 30_000,
-  });
+  const startedAt = Date.now();
+  try {
+    await execFile("/usr/bin/systemctl", ["start", serviceName], {
+      timeout: timeoutMs + 30_000,
+    });
+  } catch (err) {
+    // When OUR timeout kills the blocking `systemctl start`, the unit itself
+    // usually keeps running (it has its own much larger TimeoutStartSec) and
+    // often finishes fine in the background. Report that as a budget overrun
+    // — otherwise the caller dresses up the unit's most recent (often
+    // successful) log line as the failure, which is how a healthy update
+    // once showed "failed: Linkdown routing sysctl installed".
+    if ((err as { killed?: boolean }).killed) {
+      const waitedS = Math.round((Date.now() - startedAt) / 1000);
+      throw new Error(
+        `${stepId} was still running after ${waitedS}s — gave up waiting (it may finish on its own in the background)`,
+      );
+    }
+    throw err;
+  }
 }
 
 let cachedTargetVersion: string | null = null;
@@ -752,7 +773,10 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       console.log(`[Updater] Completed: ${step.label}`);
     } catch (err) {
       let message = err instanceof Error ? err.message : "Unknown error";
-      if (step.requiresRoot) {
+      // Only let the unit's journal override the error when the unit actually
+      // FAILED — on a budget overrun it's still running, and its last log line
+      // is just whatever fixup happened to finish most recently.
+      if (step.requiresRoot && (await getRootStepResult(step.id)) === "failed") {
         const rootFailure = await readRootStepFailure(step.id);
         if (rootFailure) message = rootFailure;
       }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -37,7 +37,18 @@ interface UpdateStepDef {
   requiresRoot?: boolean;
   failFast?: boolean;
   customRun?: () => Promise<void>;
+  /**
+   * A budget overrun doesn't fail the update for this step — it's marked
+   * completed and the run carries on. For steps whose content is non-fatal
+   * by design (post_update: every fixup inside is `|| warn`), an overrun
+   * painting "Update failed" on a successful update is worse than letting
+   * the unit finish in the background. Genuine unit failures still fail.
+   */
+  advisoryOnOverrun?: boolean;
 }
+
+/** Thrown by execAsRoot when OUR wait budget expired but the unit runs on. */
+class BudgetOverrunError extends Error {}
 
 export type StepStatus =
   | "pending"
@@ -348,11 +359,15 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     // 5 min, not 60s: on a freshly-installed device the fixups run on cold
     // caches (clawkeep pip force-reinstall, vnc apt work) and routinely
     // outlive a 1-minute budget — which painted a false-red step on an
-    // otherwise successful update.
+    // otherwise successful update. The fixups can legitimately wait even
+    // longer (wait_for_apt alone allows 900s), so an overrun past these 5
+    // minutes is advisory: the unit finishes on its own (TimeoutStartSec is
+    // 30 min) and everything inside it is non-fatal by design.
     id: "post_update",
     label: "Applying system fixups",
     timeoutMs: 300_000,
     requiresRoot: true,
+    advisoryOnOverrun: true,
   },
 ];
 
@@ -381,7 +396,7 @@ async function execAsRoot(stepId: string, timeoutMs: number): Promise<void> {
     // once showed "failed: Linkdown routing sysctl installed".
     if ((err as { killed?: boolean }).killed) {
       const waitedS = Math.round((Date.now() - startedAt) / 1000);
-      throw new Error(
+      throw new BudgetOverrunError(
         `${stepId} was still running after ${waitedS}s — gave up waiting (it may finish on its own in the background)`,
       );
     }
@@ -773,6 +788,15 @@ async function runUpdate(steps: UpdateStepDef[], startFrom: number, options: Run
       console.log(`[Updater] Completed: ${step.label}`);
     } catch (err) {
       let message = err instanceof Error ? err.message : "Unknown error";
+      // An overrun on an advisory step doesn't fail the update: the unit is
+      // still running and will finish on its own — mark the step completed
+      // and move on, instead of painting "Update failed" (with a Retry that
+      // would re-run the whole update) over a successful one.
+      if (err instanceof BudgetOverrunError && step.advisoryOnOverrun) {
+        state.steps[i].status = "completed";
+        console.warn(`[Updater] ${step.label}: ${message} — treating as advisory`);
+        continue;
+      }
       // Only let the unit's journal override the error when the unit actually
       // FAILED — on a budget overrun it's still running, and its last log line
       // is just whatever fixup happened to finish most recently.

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -227,6 +227,8 @@ describe("updater", () => {
     it("uses the root step journal output when a root update step fails", async () => {
       setupExecFileMock({
         "start clawbox-root-update@apt_update.service": new Error("systemctl failed"),
+        // The journal only overrides the error when the unit reports failed.
+        "show clawbox-root-update@apt_update.service": { stdout: "failed\n", stderr: "" },
         "/usr/bin/journalctl": {
           stdout: "Waiting for apt lock...\nE: Could not get lock /var/lib/dpkg/lock-frontend\n",
           stderr: "",
@@ -257,9 +259,48 @@ describe("updater", () => {
       expect(aptStep?.error).toBe("E: Could not get lock /var/lib/dpkg/lock-frontend");
     });
 
+    it("reports a budget overrun instead of the journal when a root step times out", async () => {
+      // execFile kills the blocking `systemctl start` when OUR timeout
+      // expires (err.killed) — the unit itself usually keeps running. The
+      // journal's last line at that moment is just whatever fixup finished
+      // most recently and must NOT be presented as the failure.
+      const timeoutErr = Object.assign(new Error("Command failed"), { killed: true });
+      setupExecFileMock({
+        "start clawbox-root-update@apt_update.service": timeoutErr,
+        "show clawbox-root-update@apt_update.service": { stdout: "success\n", stderr: "" },
+        "/usr/bin/journalctl": {
+          stdout: "Linkdown routing sysctl installed\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      updater.startUpdate();
+      await vi.waitFor(() => {
+        const state = updater.getUpdateState();
+        const aptStep = state.steps.find((step) => step.id === "apt_update");
+        expect(aptStep?.status).toBe("failed");
+      });
+
+      const aptStep = updater.getUpdateState().steps.find((step) => step.id === "apt_update");
+      expect(aptStep?.error).toContain("was still running after");
+      expect(aptStep?.error).not.toContain("Linkdown");
+    });
+
     it("stops the update sequence when bootstrap_updater fails", async () => {
       setupExecFileMock({
         "start clawbox-root-update@bootstrap_updater.service": new Error("systemctl failed"),
+        "show clawbox-root-update@bootstrap_updater.service": { stdout: "failed\n", stderr: "" },
         "/usr/bin/journalctl": {
           stdout: "fatal: invalid branch name in .update-branch\n",
           stderr: "",

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -297,6 +297,43 @@ describe("updater", () => {
       expect(aptStep?.error).not.toContain("Linkdown");
     });
 
+    it("treats a post_update budget overrun as advisory — the update still completes", async () => {
+      // post_update's content is non-fatal by design (every fixup is
+      // `|| warn`); an overrun just means cold caches made it slow. Failing
+      // the whole update over it painted "Update failed" (with a Retry that
+      // re-runs everything) on a successful update.
+      const timeoutErr = Object.assign(new Error("Command failed"), { killed: true });
+      setupExecFileMock({
+        "start clawbox-root-update@post_update.service": timeoutErr,
+        "show clawbox-root-update@post_update.service": { stdout: "success\n", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      updater = await import("@/lib/updater");
+
+      // Drive it through the post-restart continuation: resumes at post_update.
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue(true);
+      const result = await updater.checkContinuation();
+      expect(result).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().phase).toBe("completed");
+      });
+      const postStep = updater.getUpdateState().steps.find((step) => step.id === "post_update");
+      expect(postStep?.status).toBe("completed");
+      expect(mockSetMany).toHaveBeenCalledWith(
+        expect.objectContaining({ update_completed: true }),
+      );
+    });
+
     it("stops the update sequence when bootstrap_updater fails", async () => {
       setupExecFileMock({
         "start clawbox-root-update@bootstrap_updater.service": new Error("systemctl failed"),


### PR DESCRIPTION
## The incident
On a freshly-installed device, updating to v3.1.2 showed **"Update failed — Applying system fixups: Linkdown routing sysctl installed"** — a *success* log line dressed up as an error, on an update that had actually succeeded. Retrying "fixed" it (caches were warm by then).

## Root causes
1. `post_update`'s budget was **60s**, but on a fresh device its fixups run on cold caches (clawkeep `pip --force-reinstall`, vnc apt work — and `wait_for_apt` alone may legitimately hold it for 900s). The updater killed its blocking `systemctl start` while the unit kept running fine in the background.
2. The journal override in the failure path ran **unconditionally**, so the timeout was reported as whatever the unit's most recent (often successful) log line happened to be.
3. Even with an honest message, the overrun flipped the **whole update to "failed"** — blocking `update_completed` and offering a Retry that re-runs the entire update (rebuild + reboot) — over a step whose content is non-fatal by design (every fixup inside `step_post_update` is `|| warn`).

## Changes
- `post_update` budget 60s → **5 min**, and budget overruns on it are **advisory**: step marked completed with a console warning, update finishes honestly (`advisoryOnOverrun` on the step def; `BudgetOverrunError` from `execAsRoot` when *our* timeout killed the wait). Genuine unit failures (`Result=failed`) still fail.
- Budget overruns on non-advisory root steps now say **"was still running after Ns — gave up waiting"** instead of parroting the journal.
- The journal only overrides the error when the unit actually reports `Result=failed` — this also fixes a latent hole where a `systemctl start` failure for non-unit reasons (polkit/dbus) would surface a *stale previous run's* journal line.

## Validation
- 22/22 updater unit tests on a Jetson Orin Nano — three new: budget-overrun message (non-advisory step), advisory post_update overrun completes the update + persists `update_completed`, and the updated journal-gating tests.
- Reviewed via the 4-agent simplify pass; the advisory treatment is its altitude finding (message-only would have left the false-"Update failed" UX intact).

Field context: hit live on a fresh Nano today updating to v3.1.2 — first attempt false-red, second green once caches were warm.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timeout scenarios during system updates, allowing the update process to continue even when certain steps exceed their time budget
  * Extended timeout period for post-update steps to accommodate longer-running operations
  * Enhanced error reporting for timeout-related failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->