### PR TITLE
docs: pin supported platform to JetPack 6.2 + document the install layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The installer expects to run from `/home/clawbox/clawbox` as the `clawbox`
 user's checkout (the same layout shipped devices use):
 
 ```bash
-sudo useradd -m -s /bin/bash clawbox 2>/dev/null || true
+id -u clawbox >/dev/null 2>&1 || sudo useradd -m -s /bin/bash clawbox
 sudo git clone https://github.com/ID-Robots/clawbox.git /home/clawbox/clawbox
 sudo chown -R clawbox:clawbox /home/clawbox/clawbox
 cd /home/clawbox/clawbox

--- a/README.md
+++ b/README.md
@@ -60,11 +60,34 @@ The OpenClaw AI agent controls the entire device through MCP (Model Context Prot
 
 ## 🚀 Quick Start
 
+### Requirements
+
+| | Supported |
+|---|---|
+| **Device** | NVIDIA Jetson Orin Nano 8GB (Super) |
+| **OS image** | **JetPack 6.2** (Ubuntu 22.04 / L4T R36.x) — [download](https://developer.nvidia.com/embedded/jetpack-sdk-62) |
+
+> ⚠️ **JetPack 7.x (Ubuntu 24.04) is not supported yet.** NVIDIA's newest images
+> default to JetPack 7 — flash **JetPack 6.2** instead. On 24.04 the installer
+> fails on Python's externally-managed-environment policy (PEP 668), among
+> other differences. JetPack 6.2 is the platform every shipped ClawBox runs.
+
+### Install
+
+The installer expects to run from `/home/clawbox/clawbox` as the `clawbox`
+user's checkout (the same layout shipped devices use):
+
 ```bash
+sudo useradd -m -s /bin/bash clawbox 2>/dev/null || true
+sudo git clone https://github.com/ID-Robots/clawbox.git /home/clawbox/clawbox
+sudo chown -R clawbox:clawbox /home/clawbox/clawbox
+cd /home/clawbox/clawbox
 sudo bash install.sh
 ```
 
-Connect to the **ClawBox-Setup** WiFi network (open, no password) and navigate to:
+The install provisions everything from scratch (20–40 min on a fresh image).
+When it finishes, connect to the **ClawBox-Setup** WiFi network (open, no
+password) and navigate to:
 - `http://clawbox.local/`
 - `http://10.42.0.1/`
 


### PR DESCRIPTION
README's Quick Start was a bare `sudo bash install.sh` with no platform version and no clone-location guidance — exactly the two traps a from-scratch user (Caio, prepping a video on a fresh NVIDIA image) just hit:

1. Fresh NVIDIA downloads now default to **JetPack 7 / Ubuntu 24.04**, where the installer fails on PEP 668 (`externally-managed-environment`) in every pip step (clawkeep, jetson-stats, the `hf` CLI behind Enable Gemma 4). ClawBox's supported/validated platform is **JetPack 6.2 / Ubuntu 22.04** — what every shipped box runs.
2. The installer expects `/home/clawbox/clawbox`; running from a personal user's clone crashes at step 4 (`optimize-ollama.sh: No such file`) because the script references the hardcoded path before `step_git_pull` would populate it.

This PR fixes the docs side only (per decision: no JetPack 7 migration for now, and no installer-guard changes): explicit JetPack 6.2 requirement with download link, a loud 24.04 warning, and the supported clone-as-clawbox recipe.

Note for docs.clawbox.tech (#174): the Quickstart there needs the same pin — flagged to Yanko since the site source lives in his PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Start section with comprehensive system requirements table (JetPack, Ubuntu, L4T versions)
  * Added compatibility warning that JetPack 7.x and Ubuntu 24.04 are not supported
  * Enhanced installation instructions with complete setup workflow including user creation, repository cloning, and ownership configuration
  * Clarified expected working directory paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->