### PR TITLE
docs: pin supported platform to JetPack 6.2 (fast-track to main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,34 @@ The OpenClaw AI agent controls the entire device through MCP (Model Context Prot
 
 ## 🚀 Quick Start
 
+### Requirements
+
+| | Supported |
+|---|---|
+| **Device** | NVIDIA Jetson Orin Nano 8GB (Super) |
+| **OS image** | **JetPack 6.2** (Ubuntu 22.04 / L4T R36.x) — [download](https://developer.nvidia.com/embedded/jetpack-sdk-62) |
+
+> ⚠️ **JetPack 7.x (Ubuntu 24.04) is not supported yet.** NVIDIA's newest images
+> default to JetPack 7 — flash **JetPack 6.2** instead. On 24.04 the installer
+> fails on Python's externally-managed-environment policy (PEP 668), among
+> other differences. JetPack 6.2 is the platform every shipped ClawBox runs.
+
+### Install
+
+The installer expects to run from `/home/clawbox/clawbox` as the `clawbox`
+user's checkout (the same layout shipped devices use):
+
 ```bash
+id -u clawbox >/dev/null 2>&1 || sudo useradd -m -s /bin/bash clawbox
+sudo git clone https://github.com/ID-Robots/clawbox.git /home/clawbox/clawbox
+sudo chown -R clawbox:clawbox /home/clawbox/clawbox
+cd /home/clawbox/clawbox
 sudo bash install.sh
 ```
 
-Connect to the **ClawBox-Setup** WiFi network (open, no password) and navigate to:
+The install provisions everything from scratch (20–40 min on a fresh image).
+When it finishes, connect to the **ClawBox-Setup** WiFi network (open, no
+password) and navigate to:
 - `http://clawbox.local/`
 - `http://10.42.0.1/`
 


### PR DESCRIPTION
Docs-only cherry-pick of #199 (already merged to beta, CI-green there, CodeRabbit finding applied).

The repo front page renders main's README — which still shows the bare `sudo bash install.sh` quickstart with no platform version and no clone-location guidance. A collaborator preparing a video walkthrough just lost a day to exactly those two traps (JetPack 7/24.04 PEP 668 failures + foreign-clone path crash). Fast-tracking so the default-branch README stops reproducing it.

No code, no version bump — `README.md` only, identical content to beta's `4bb9d07`.