### PR TITLE
fix(openai): stop Codex subscription OAuth corrupting the id token

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -383,6 +383,7 @@ export async function POST(request: Request) {
       provider?: string;
       apiKey?: string;
       authMode?: string;
+      idToken?: string;
       refreshToken?: string;
       expiresIn?: number;
       projectId?: string;
@@ -396,7 +397,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
     }
 
-    const { provider, apiKey, authMode = "token", refreshToken, expiresIn, projectId, scope = "primary", model: bodyModel } = body;
+    const { provider, apiKey, authMode = "token", idToken, refreshToken, expiresIn, projectId, scope = "primary", model: bodyModel } = body;
     const requestedClawboxAiTier = normalizeClawboxAiTier(body.clawaiTier);
     const normalizedApiKey = typeof apiKey === "string" ? apiKey.trim() : "";
     const isOllama = provider === "ollama";
@@ -585,11 +586,16 @@ export async function POST(request: Request) {
         markLocalAiTokenMigrated();
       } else if (authMode === "subscription") {
         // OAuth credential format expected by OpenClaw:
-        // { type: "oauth", provider, access, refresh, expires, projectId? }
+        // { type: "oauth", provider, access, id?, refresh, expires, projectId? }
+        // `id` is the OAuth id_token (a JWT). The Codex app-server authenticates
+        // with it, and gateway-pre-start's ~/.codex/auth.json synthesis uses
+        // `id` (falling back to `access`). Persisting it keeps the synthesized
+        // id_token a valid JWT instead of whatever `access` happens to be.
         authProfiles.profiles[config.profileKey] = {
           type: "oauth",
           provider: ocProvider,
           access: normalizedApiKey,
+          ...(typeof idToken === "string" && idToken ? { id: idToken } : {}),
           refresh: refreshToken || "",
           expires: expiresIn
             ? Date.now() + expiresIn * 1000

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -465,6 +465,28 @@ export async function POST(request: Request) {
     const llamaCppContextWindow = getLlamaCppContextWindow();
     const llamaCppMaxTokens = getLlamaCppMaxTokens();
     const ocProvider = config.profileKey.split(":")[0];
+
+    // Codex (OpenAI subscription) authenticates with a JWT id_token, and the
+    // gateway synthesizes ~/.codex/auth.json from `id` (falling back to
+    // `access`). If neither is JWT-shaped, that synthesis produces an invalid
+    // id_token and every request fails with "invalid ID token format" — reject
+    // the save here so the failure surfaces at config time, not in the chat.
+    const normalizedIdToken = typeof idToken === "string" ? idToken.trim() : "";
+    const isJwtLike = (value: string) => value.split(".").length === 3;
+    if (
+      authMode === "subscription" &&
+      ocProvider === "codex" &&
+      !isJwtLike(normalizedIdToken || normalizedApiKey)
+    ) {
+      return NextResponse.json(
+        {
+          error:
+            "OpenAI subscription OAuth did not return a valid JWT credential. Please restart the authorization flow.",
+        },
+        { status: 502 },
+      );
+    }
+
     const shouldPromoteLocalToPrimary = isLocalScope && !configStore.ai_model_configured;
     // Resolve the ClawBox AI tier once and reuse it for both the primary
     // model selection (below) and the config-store write (further down).
@@ -595,7 +617,7 @@ export async function POST(request: Request) {
           type: "oauth",
           provider: ocProvider,
           access: normalizedApiKey,
-          ...(typeof idToken === "string" && idToken ? { id: idToken } : {}),
+          ...(normalizedIdToken ? { id: normalizedIdToken } : {}),
           refresh: refreshToken || "",
           expires: expiresIn
             ? Date.now() + expiresIn * 1000

--- a/src/app/setup-api/ai-models/oauth/device-poll/route.ts
+++ b/src/app/setup-api/ai-models/oauth/device-poll/route.ts
@@ -68,6 +68,7 @@ async function pollOpenAI(stored: StoredState): Promise<NextResponse> {
     return NextResponse.json({
       status: "complete",
       access_token: pollData.access_token,
+      id_token: pollData.id_token,
       refresh_token: pollData.refresh_token,
       expires_in: pollData.expires_in,
     });
@@ -121,55 +122,18 @@ async function pollOpenAI(stored: StoredState): Promise<NextResponse> {
 
     const tokenData = await exchangeRes.json();
 
-    // Try id_token → API key exchange
-    if (tokenData.id_token) {
-      try {
-        const apiKeyRes = await fetch(OPENAI_TOKEN_URL, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-          },
-          body: new URLSearchParams({
-            grant_type:
-              "urn:ietf:params:oauth:grant-type:token-exchange",
-            client_id: OPENAI_CLIENT_ID,
-            requested_token: "openai-api-key",
-            subject_token: tokenData.id_token,
-            subject_token_type:
-              "urn:ietf:params:oauth:token-type:id_token",
-          }).toString(),
-          signal: AbortSignal.timeout(30_000),
-        });
-
-        if (apiKeyRes.ok) {
-          const apiKeyData = await apiKeyRes.json();
-          console.log("[device-poll/openai] API key exchange succeeded");
-          await fs.unlink(STATE_PATH).catch(() => {});
-          return NextResponse.json({
-            status: "complete",
-            access_token:
-              apiKeyData.access_token ||
-              apiKeyData.api_key ||
-              tokenData.access_token,
-            refresh_token: tokenData.refresh_token,
-            expires_in: apiKeyData.expires_in || tokenData.expires_in,
-          });
-        }
-        console.log(
-          "[device-poll/openai] API key exchange failed, using access_token"
-        );
-      } catch (e) {
-        console.log(
-          "[device-poll/openai] API key exchange error, using access_token:",
-          e
-        );
-      }
-    }
-
+    // Codex (subscription) needs the raw OAuth JWTs — id_token + access_token +
+    // refresh_token — which get synthesized into ~/.codex/auth.json for the
+    // codex app-server. Do NOT exchange the id_token for an `openai-api-key`:
+    // that returns an `sk-` key (not a JWT), which then gets stored as the
+    // codex `access` and used as the id_token, producing "invalid ID token
+    // format" on every message — and poisoning even the API-key OpenAI path,
+    // since ~/.codex/auth.json is shared and rebuilt on every gateway start.
     await fs.unlink(STATE_PATH).catch(() => {});
     return NextResponse.json({
       status: "complete",
       access_token: tokenData.access_token,
+      id_token: tokenData.id_token,
       refresh_token: tokenData.refresh_token,
       expires_in: tokenData.expires_in,
     });

--- a/src/app/setup-api/ai-models/oauth/exchange/route.ts
+++ b/src/app/setup-api/ai-models/oauth/exchange/route.ts
@@ -145,53 +145,22 @@ export async function POST(request: Request) {
     const tokenData = await tokenRes.json();
 
     // OpenAI: try second exchange (id_token → API key), fall back to access_token
-    if (provider === "openai" && tokenData.id_token) {
-      let apiKeyToken: string | undefined;
-      let apiKeyExpires: number | undefined;
-
-      try {
-        const exchangeParams: Record<string, string> = {
-          grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-          client_id: config.clientId,
-          requested_token: "openai-api-key",
-          subject_token: tokenData.id_token,
-          subject_token_type: "urn:ietf:params:oauth:token-type:id_token",
-        };
-
-        const apiKeyRes = await fetch(config.tokenEndpoint, {
-          method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: new URLSearchParams(exchangeParams).toString(),
-          signal: AbortSignal.timeout(30_000),
-        });
-
-        if (apiKeyRes.ok) {
-          try {
-            const apiKeyData = await apiKeyRes.json();
-            apiKeyToken = apiKeyData.access_token || apiKeyData.api_key;
-            apiKeyExpires = apiKeyData.expires_in;
-            console.log("[oauth/exchange] API key exchange succeeded");
-          } catch (parseErr) {
-            const raw = await apiKeyRes.text().catch(() => "(unreadable)");
-            console.error("[oauth/exchange] API key exchange JSON parse error:", parseErr, "raw:", raw);
-          }
-        } else {
-          const errBody = await apiKeyRes.text().catch(() => "");
-          console.error("[oauth/exchange] API key exchange failed:", apiKeyRes.status, errBody);
-        }
-      } catch (e) {
-        console.error("[oauth/exchange] API key exchange error, using access_token:", e);
-      }
-
+    // OpenAI/Codex (subscription): keep the raw OAuth JWTs — access_token +
+    // id_token + refresh_token. Do NOT exchange the id_token for an
+    // `openai-api-key`: that returns an `sk-` key (not a JWT) which gets stored
+    // as the codex `access` / synthesized id_token and fails with "invalid ID
+    // token format". Mirrors the device-poll (device-code) flow.
+    if (provider === "openai") {
       await fs.unlink(STATE_PATH).catch(() => {});
       // Clean up saved org file now that exchange succeeded
       const orgPath = path.join(path.dirname(STATE_PATH), "oauth-org.json");
       await fs.unlink(orgPath).catch(() => {});
 
       return NextResponse.json({
-        access_token: apiKeyToken || tokenData.access_token,
+        access_token: tokenData.access_token,
+        id_token: tokenData.id_token,
         refresh_token: tokenData.refresh_token,
-        expires_in: apiKeyExpires || tokenData.expires_in,
+        expires_in: tokenData.expires_in,
       });
     }
 

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -1172,7 +1172,7 @@ export default function AIModelsStep({
 
   // Save token received from any OAuth flow (device or redirect)
   const saveOAuthToken = useCallback(async (
-    tokenData: { access_token: string; refresh_token?: string; expires_in?: number; projectId?: string }
+    tokenData: { access_token: string; id_token?: string; refresh_token?: string; expires_in?: number; projectId?: string }
   ) => {
     saveControllerRef.current?.abort();
     const controller = new AbortController();
@@ -1195,6 +1195,7 @@ export default function AIModelsStep({
           provider: selectedProvider,
           apiKey: tokenData.access_token,
           authMode: "subscription",
+          idToken: tokenData.id_token,
           refreshToken: tokenData.refresh_token,
           expiresIn: tokenData.expires_in,
           ...(tokenData.projectId ? { projectId: tokenData.projectId } : {}),

--- a/src/tests/oauth-routes.test.ts
+++ b/src/tests/oauth-routes.test.ts
@@ -459,7 +459,7 @@ describe("OAuth exchange route", () => {
     expect(body.error).toBe("Failed to exchange token");
   });
 
-  it("completes OpenAI two-step exchange and prefers API key token", async () => {
+  it("returns the raw OpenAI OAuth tokens (incl. id_token) without an api-key exchange", async () => {
     await writeState({ provider: "openai" });
     await fs.writeFile(
       ORG_PATH,
@@ -467,27 +467,20 @@ describe("OAuth exchange route", () => {
       "utf-8"
     );
 
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "oauth_access_token",
-            refresh_token: "oauth_refresh_token",
-            expires_in: 3600,
-            id_token: "id-token-123",
-          }),
-          { status: 200 }
-        )
+    // Only the authorization_code → token exchange runs; Codex needs the JWTs,
+    // so the id_token is preserved and there is NO second (id_token → api-key)
+    // exchange that used to overwrite `access` with a non-JWT sk- key.
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "oauth_access_token",
+          refresh_token: "oauth_refresh_token",
+          expires_in: 3600,
+          id_token: "id-token-123",
+        }),
+        { status: 200 }
       )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "openai_api_key_token",
-            expires_in: 7200,
-          }),
-          { status: 200 }
-        )
-      );
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const res = await exchangePost(jsonRequest({ code: "code-123" }));
@@ -495,11 +488,12 @@ describe("OAuth exchange route", () => {
 
     expect(res.status).toBe(200);
     expect(body).toEqual({
-      access_token: "openai_api_key_token",
+      access_token: "oauth_access_token",
+      id_token: "id-token-123",
       refresh_token: "oauth_refresh_token",
-      expires_in: 7200,
+      expires_in: 3600,
     });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
 
     const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
     const firstBody = String(firstCall[1].body);
@@ -513,138 +507,6 @@ describe("OAuth exchange route", () => {
 
     await expect(fs.readFile(STATE_PATH, "utf-8")).rejects.toBeTruthy();
     await expect(fs.readFile(ORG_PATH, "utf-8")).rejects.toBeTruthy();
-  });
-
-  it("falls back to access_token when OpenAI API-key exchange fails", async () => {
-    await writeState({ provider: "openai" });
-
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "oauth_access_token",
-            refresh_token: "oauth_refresh_token",
-            expires_in: 3600,
-            id_token: "id-token-123",
-          }),
-          { status: 200 }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(JSON.stringify({ error: "bad exchange" }), { status: 400 })
-      );
-    vi.stubGlobal("fetch", fetchMock);
-
-    const res = await exchangePost(jsonRequest({ code: "code-123" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(body).toEqual({
-      access_token: "oauth_access_token",
-      refresh_token: "oauth_refresh_token",
-      expires_in: 3600,
-    });
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("falls back to oauth access token when second-step JSON is invalid", async () => {
-    await writeState({ provider: "openai" });
-
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "oauth_access_token",
-            refresh_token: "oauth_refresh_token",
-            expires_in: 3600,
-            id_token: "id-token-123",
-          }),
-          { status: 200 }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response("not-json", {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        })
-      );
-    vi.stubGlobal("fetch", fetchMock);
-
-    const res = await exchangePost(jsonRequest({ code: "code-123" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(body).toEqual({
-      access_token: "oauth_access_token",
-      refresh_token: "oauth_refresh_token",
-      expires_in: 3600,
-    });
-  });
-
-  it("falls back to oauth access token when second-step request throws", async () => {
-    await writeState({ provider: "openai" });
-
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "oauth_access_token",
-            refresh_token: "oauth_refresh_token",
-            expires_in: 3600,
-            id_token: "id-token-123",
-          }),
-          { status: 200 }
-        )
-      )
-      .mockRejectedValueOnce(new Error("second step failed"));
-    vi.stubGlobal("fetch", fetchMock);
-
-    const res = await exchangePost(jsonRequest({ code: "code-123" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(body).toEqual({
-      access_token: "oauth_access_token",
-      refresh_token: "oauth_refresh_token",
-      expires_in: 3600,
-    });
-  });
-
-  it("uses api_key when second-step response has no access_token", async () => {
-    await writeState({ provider: "openai" });
-
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "oauth_access_token",
-            refresh_token: "oauth_refresh_token",
-            expires_in: 3600,
-            id_token: "id-token-123",
-          }),
-          { status: 200 }
-        )
-      )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            api_key: "openai_generated_api_key",
-            expires_in: 7200,
-          }),
-          { status: 200 }
-        )
-      );
-    vi.stubGlobal("fetch", fetchMock);
-
-    const res = await exchangePost(jsonRequest({ code: "code-123" }));
-    const body = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(body).toEqual({
-      access_token: "openai_generated_api_key",
-      refresh_token: "oauth_refresh_token",
-      expires_in: 7200,
-    });
   });
 
   it("returns parsed upstream error details when token exchange fails", async () => {
@@ -797,34 +659,24 @@ describe("OAuth exchange route", () => {
     await writeState({ provider: "openai" });
     vi.spyOn(fs, "unlink").mockRejectedValue(new Error("unlink denied"));
 
-    const fetchMock = vi.fn()
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "oauth_access_token",
-            refresh_token: "oauth_refresh_token",
-            expires_in: 3600,
-            id_token: "id-token-123",
-          }),
-          { status: 200 }
-        )
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          access_token: "oauth_access_token",
+          refresh_token: "oauth_refresh_token",
+          expires_in: 3600,
+          id_token: "id-token-123",
+        }),
+        { status: 200 }
       )
-      .mockResolvedValueOnce(
-        new Response(
-          JSON.stringify({
-            access_token: "openai_api_key_token",
-            expires_in: 7200,
-          }),
-          { status: 200 }
-        )
-      );
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const res = await exchangePost(jsonRequest({ code: "code-123" }));
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.access_token).toBe("openai_api_key_token");
+    expect(body.access_token).toBe("oauth_access_token");
   });
 });
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -443,7 +443,11 @@ describe("POST /setup-api/ai-models/configure", () => {
   it("configures subscription auth mode for oauth", async () => {
     const res = await configurePost(jsonRequest({
       provider: "openai",
-      apiKey: "access-token",
+      // Codex subscription credentials must be JWT-shaped (3 dot-segments) —
+      // the configure route rejects non-JWT tokens to avoid recreating the
+      // "invalid ID token format" failure.
+      apiKey: "access.token.jwt",
+      idToken: "id.token.jwt",
       authMode: "subscription",
       refreshToken: "refresh-token",
       expiresIn: 3600,

--- a/src/tests/routes/ai-models/device-poll.test.ts
+++ b/src/tests/routes/ai-models/device-poll.test.ts
@@ -207,7 +207,7 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
     expect(body.error).toContain("Token exchange failed");
   });
 
-  it("attempts API key exchange when id_token present", async () => {
+  it("returns the OAuth tokens incl. id_token without an api-key exchange", async () => {
     const mockFetch = vi.fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -224,13 +224,6 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
           refresh_token: "first-refresh",
           expires_in: 3600,
         }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          api_key: "sk-test-api-key",
-          expires_in: 86400,
-        }),
       });
     vi.stubGlobal("fetch", mockFetch);
 
@@ -239,38 +232,11 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
 
     expect(res.status).toBe(200);
     expect(body.status).toBe("complete");
-    expect(body.access_token).toBe("sk-test-api-key");
-  });
-
-  it("falls back to access_token when API key exchange fails", async () => {
-    const mockFetch = vi.fn()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          authorization_code: "test-auth-code",
-          code_verifier: "test-verifier",
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          access_token: "fallback-token",
-          id_token: "test-id-token",
-          refresh_token: "first-refresh",
-          expires_in: 3600,
-        }),
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-      });
-    vi.stubGlobal("fetch", mockFetch);
-
-    const res = await devicePollPost();
-    const body = await res.json();
-
-    expect(res.status).toBe(200);
-    expect(body.access_token).toBe("fallback-token");
+    // Codex needs the JWTs, not an exchanged sk- key: id_token is preserved and
+    // there is no third (id_token → api-key) fetch.
+    expect(body.access_token).toBe("first-token");
+    expect(body.id_token).toBe("test-id-token");
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it("returns 502 for server errors", async () => {


### PR DESCRIPTION
## The bug
A ChatGPT Plus / Codex **subscription** login fails on every message with:

> Error: failed to set external auth: invalid ID token format

…and re-running the OAuth doesn't help. After it, the OpenAI **API-key** provider also breaks with the same error (the failed OAuth credential "poisons" it), while Claude keeps working — so it's isolated to the Codex OAuth token handling. Reported on ClawBox v3.1.3, Jetson Orin NX.

## Root cause
The OpenAI subscription OAuth flows run an `id_token → openai-api-key` token exchange and store the resulting **`sk-` key** as the codex profile's `access`. `gateway-pre-start` then synthesizes `~/.codex/auth.json` with `id_token: p.id || p.access` → the API-key string, which the Codex app-server rejects as *"invalid ID token format."* Because `~/.codex/auth.json` is shared and **rebuilt on every gateway start**, the bad credential also overrides the API-key OpenAI provider and survives re-auth.

It's account-dependent: boxes where OpenAI's api-key exchange happened to *fail* kept a valid JWT `access` and worked — hence it reproduces on some accounts and not others.

## The fix
Codex (subscription) needs the raw OAuth JWTs, not an API key:
- **`oauth/device-poll`** (device-code flow) and **`oauth/exchange`** (redirect flow): drop the `id_token → api-key` exchange; return `access_token` + `id_token` + `refresh_token`. Both completion paths now behave identically, so the bug isn't left latent on either.
- **`ai-models/configure`**: persist the `id_token` as the profile's `id`, so the synthesis writes a valid JWT id_token (and `access` stays a JWT, which also fixes `account_id` resolution that splits `access` on `.`).
- **`AIModelsStep`**: forward `id_token` from the OAuth result to configure.

`gateway-pre-start`'s synthesis is unchanged — it already prefers `id` over `access`.

## Validation (on a device)
A fresh Codex device-code login now stores a JWT `access` **and** `id` (id_token), synthesizes a valid `~/.codex/auth.json` (id_token JWT ✓, access JWT ✓, account_id ✓), and **OpenAI accepts the credential** — the "invalid ID token format" is replaced by the account's normal rate-limit. Full build green on-device.

## Interim customer workaround (for affected boxes, until this ships)
Clear the corrupted `codex:*` auth profile + `~/.codex/auth.json` and restart the gateway; use Claude / ClawBox AI meanwhile.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth authentication configuration now supports capturing and storing ID tokens alongside access and refresh tokens for enhanced token management.

* **Improvements**
  * OAuth token exchanges updated to return complete raw JWT token sets, including ID tokens, instead of performing token conversion operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->