### PR TITLE
fix: heal invalid telegram groupPolicy that silences the bot

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -167,6 +167,17 @@ if isinstance(channels, dict):
             if k in telegram:
                 del telegram[k]
                 changed = True
+        # Config-validity migration: a Telegram bot set up on an older OpenClaw
+        # can carry a channels.telegram.groupPolicy value the current schema no
+        # longer accepts (allowed: open, disabled, allowlist). One invalid value
+        # makes the WHOLE config invalid, so the gateway loads nothing and the
+        # bot goes silent ("Telegram channel active" but never replies). Reset
+        # unknown values to the secure default so the device self-heals on the
+        # next gateway start — ClawBox exposes no group-chat UI, so "disabled"
+        # (bot ignores group chats; owner DMs still work) is the safe choice.
+        if telegram.get("groupPolicy") not in (None, "open", "disabled", "allowlist"):
+            telegram["groupPolicy"] = "disabled"
+            changed = True
 
 # Migration: devices that configured OpenRouter before the provider-def
 # fix have `auth.profiles.openrouter:default` set but no


### PR DESCRIPTION
## Problem

A customer's Telegram bot connects ("Telegram channel active") but never replies. The OpenClaw settings show:

```
OpenClaw config is invalid
  - channels.telegram.groupPolicy: invalid config: must be equal to one of the allowed values (allowed: "open", "disabled", "allowlist")
```

`channels.telegram.groupPolicy` is a strict OpenClaw enum (`open` / `disabled` / `allowlist`). A Telegram bot first configured on an **older OpenClaw** can carry a `groupPolicy` value the current schema no longer accepts. OpenClaw validates the config as a whole and **fails closed** — one invalid enum makes the *entire* config invalid, so the gateway aborts on startup and the bot goes silent for **every** message, DMs included (not just group chats).

ClawBox never writes `groupPolicy` itself (it's OpenClaw-managed), and `gateway-pre-start.sh` already sanitizes the sibling keys `dmPolicy`/`allowFrom` but not `groupPolicy` — so a stale value survives every update and keeps bricking the config.

## Fix

Extend the existing Telegram config migration in `gateway-pre-start.sh`: if `channels.telegram.groupPolicy` holds anything outside the valid enum, reset it to the secure default `disabled` (ClawBox has no group-chat UI, so the bot ignoring groups is the safe choice; owner DMs are unaffected). Devices self-heal on the next gateway start — no bot reconfigure or factory reset needed. It's a no-op on already-valid configs, so it can't clobber a legitimate value.

This mirrors the adjacent `bind` out-of-enum reset and the `dmPolicy`/`allowFrom` strip — same in-place, `changed`-gated, atomic-write pattern. Deliberately kept as a targeted single-key migration rather than a generic coercer or an `openclaw doctor --fix` spawn, which would reintroduce the ~70s-per-restart CLI latency the whole block was rewritten to avoid.

## Validation (on a real OpenClaw 2026.6.6 device)

Tested against a temp copy of a live box config (gateway never restarted):

- **Reproduce** — injected `groupPolicy: "all"` → `openclaw config get` and `doctor --lint` both report the exact customer error; the whole config is rejected (`doctor` aborts at config-validation, `checksRun: 1`).
- **Heal** — ran the real migration block → `groupPolicy` becomes `disabled`, `config get` returns a valid block, `doctor --lint` advances to `checksRun: 22` with **zero errors** (only pre-existing warnings).
- **No-clobber** — ran against a config with no `groupPolicy` → telegram block unchanged.

Note for support: after self-heal the bot replies to the owner via OpenClaw's `dmPolicy: "pairing"` default (a pairing prompt, not silence) — the owner completes pairing once, then the bot answers normally.
