### PR TITLE
fix: scale compaction reserve to model context so local models respond

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -9,7 +9,7 @@ import {
   restartGateway,
   findOpenclawBin,
   runOpenclawConfigSet,
-  DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR,
+  compactionReserveFloorForContext,
   inferConfiguredLocalModel,
   readConfig as readOpenClawConfig,
   applyModelOverrideToAllAgentSessions,
@@ -637,11 +637,21 @@ export async function POST(request: Request) {
         console.log(`[AI Config] Promoted local model to active primary: ${config.defaultModel}`);
       }
     }
+    // Reserve sized to the active model's context window. Local models run on
+    // small windows (Ollama 32K) where the flat default leaves no room for the
+    // agent's heavy system prompt + tools; cloud models (unbounded window)
+    // fall through to the full default.
+    const activeContextWindow = isOllama
+      ? OLLAMA_CONTEXT_WINDOW
+      : isLlamaCpp
+        ? llamaCppContextWindow
+        : Number.POSITIVE_INFINITY;
+    const compactionReserveFloor = compactionReserveFloorForContext(activeContextWindow);
     await runCommand(OPENCLAW_BIN, [
       "config",
       "set",
       "agents.defaults.compaction.reserveTokensFloor",
-      `${DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR}`,
+      `${compactionReserveFloor}`,
     ]);
 
     // 4c. Local device gateway setup: keep token auth enabled for LAN binding,

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -144,6 +144,25 @@ const OPENCLAW_HOME = process.env.OPENCLAW_HOME || "/home/clawbox/.openclaw";
 const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || path.join(OPENCLAW_HOME, "agents");
 export const CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 export const DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR = 24000;
+// Smallest reserve worth keeping — roughly one summary's worth of headroom.
+const MIN_COMPACTION_RESERVE_TOKENS_FLOOR = 4096;
+
+// Size the compaction reserve to a model's context window. The 24000 default
+// suits large-context cloud models, but it swallows most of a small local
+// window — Ollama caps at 32K, so a flat 24000 leaves only ~8.7K of usable
+// input, less than the agent's ~20K-token system prompt + tool schemas. Every
+// turn then fails before the model runs ("context overflow" / unrecoverable
+// auto-compaction). A quarter of the window, clamped to [MIN, default], keeps
+// small local models usable while large windows still get the full default.
+export function compactionReserveFloorForContext(contextWindow: number): number {
+  if (!Number.isFinite(contextWindow) || contextWindow <= 0) {
+    return DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR;
+  }
+  return Math.min(
+    DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR,
+    Math.max(MIN_COMPACTION_RESERVE_TOKENS_FLOOR, Math.round(contextWindow / 4)),
+  );
+}
 
 // Fields on each entry of `<agents-dir>/<agent>/sessions/sessions.json`
 // that OpenClaw reads to decide which provider/model a running session

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -48,6 +48,12 @@ const { parseFullyQualifiedModelImpl, LLAMACPP_PROXY_BASE_URL } = vi.hoisted(() 
 
 vi.mock("@/lib/openclaw-config", () => ({
   DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR: 24000,
+  // Pure helper — mirror the real implementation (unit-tested in
+  // openclaw-config.test.ts) so the configure route computes a real reserve.
+  compactionReserveFloorForContext: (contextWindow: number) =>
+    Number.isFinite(contextWindow) && contextWindow > 0
+      ? Math.min(24000, Math.max(4096, Math.round(contextWindow / 4)))
+      : 24000,
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
@@ -371,6 +377,13 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
+
+    // Ollama's 32K window gets a context-scaled reserve (32768/4 = 8192), not
+    // the flat 24000 default — a 24000 floor leaves too little usable input for
+    // the agent's system prompt + tools, so every turn overflows before the
+    // model runs.
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands).toContain("config set agents.defaults.compaction.reserveTokensFloor 8192");
   });
 
   it("configures llama.cpp without apiKey", async () => {

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -115,6 +115,23 @@ describe("openclaw-config", () => {
     });
   });
 
+  describe("compactionReserveFloorForContext", () => {
+    it("scales the reserve down for small local windows (Ollama 32K → 8192)", () => {
+      expect(openclawConfig.compactionReserveFloorForContext(32768)).toBe(8192);
+    });
+
+    it("keeps the full default for large/unbounded windows (llama.cpp 128K, cloud)", () => {
+      expect(openclawConfig.compactionReserveFloorForContext(131072)).toBe(24000);
+      expect(openclawConfig.compactionReserveFloorForContext(Number.POSITIVE_INFINITY)).toBe(24000);
+    });
+
+    it("never drops below the 4096 floor and guards invalid input", () => {
+      expect(openclawConfig.compactionReserveFloorForContext(8000)).toBe(4096);
+      expect(openclawConfig.compactionReserveFloorForContext(0)).toBe(24000);
+      expect(openclawConfig.compactionReserveFloorForContext(Number.NaN)).toBe(24000);
+    });
+  });
+
   describe("CONFIG_PATH", () => {
     it("exports CONFIG_PATH pointing to openclaw.json", () => {
       expect(openclawConfig.CONFIG_PATH).toMatch(/openclaw\.json$/);


### PR DESCRIPTION
## Problem

When the active AI provider is a **local Ollama model**, every chat turn fails before the model runs — the UI shows `Auto-compaction could not recover this turn …` (or, on a fresh session, `Context overflow: prompt too large for the model`). Cloud models and llama.cpp/Gemma are unaffected.

Root cause: ClawBox writes a flat `agents.defaults.compaction.reserveTokensFloor = 24000` for **every** provider. That suits a 200K–1M cloud window, but it swallows most of Ollama's 32K window — leaving only `32768 − 24000 = 8768` tokens of usable input, which is **less than the agent's own ~20K-token system prompt + 40 tool schemas + workspace bootstrap**. OpenClaw rejects the turn (or fails auto-compaction) before ever calling the model. The model's own hint ("raise the reserve to ≥20000") is counterproductive here — the reserve needs to go *down*.

## Fix

Size the reserve to the **active model's context window** instead of a flat constant: a quarter of the window, clamped to `[4096, 24000]`.

- Ollama (32768) → **8192**
- llama.cpp/Gemma (131072) and cloud (unbounded) → **24000** (unchanged)

Added `compactionReserveFloorForContext()` in `openclaw-config.ts`; the configure route picks the window per active provider. Large/cloud windows fall through to the existing default, so only small local models change behavior. ClawBox re-writes this on every configure, so the value always matches the active model.

## Validation (on a real OpenClaw 2026.6.6 device)

- **Reproduced** through the gateway: with reserve 24000, `openclaw agent --model ollama/llama3.2:3b` returns `Context overflow: prompt too large` and never loads the model.
- **Fixed**: lowering the reserve to ~8000 → the same turn **runs and the model responds**. Restored the box afterward (gateway untouched).
- **Tests** (run on-device against an `origin/beta` worktree): **85/85 pass**, including a new unit test for `compactionReserveFloorForContext` (32768→8192, 131072→24000, guards) and an integration assertion that the Ollama configure path writes `reserveTokensFloor 8192`.

Note: a 32K window running a heavyweight agent (20K-token system prompt) is inherently tight for long conversations — compaction will be aggressive. This fix resolves the reported failure (model errors instead of responding); a lighter local-agent profile / larger window is a separate, longer-term improvement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI model configuration now dynamically computes token reservation floors based on each model's context window, replacing fixed default values. Different providers (Ollama, llama.cpp, and others) will have optimized token allocation.

* **Tests**
  * Added comprehensive test coverage for context-based token floor calculations and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->