### PR TITLE
fix(install): source the e2e test-mode marker so updater-triggered runs detect CI

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -50,6 +50,19 @@ CLAWBOX_HOME="/home/clawbox"
 # CLAWBOX_TEST_MODE=1 skips hardware-only steps (Jetson power modes, CUDA
 # llama.cpp build, snap Chromium, WiFi AP, VNC, cloudflared, jtop) so the
 # installer can run inside a CI container. See e2e-install/README.md.
+#
+# The e2e-install entrypoint seeds /etc/clawbox/test-mode.env before any
+# install.sh runs. Source it so EVERY invocation detects test mode up front —
+# not just the first-boot bootstrap (which gets CLAWBOX_TEST_MODE in its
+# service env), but also the updater-triggered `install.sh --step` runs via
+# clawbox-root-update@.service, which otherwise inherit only
+# /etc/clawbox/network.env (populated late, during step_network_setup) and so
+# hit the real Jetson/WiFi steps and fail on a non-Tegra CI host. The file
+# exists only in the test container, so this is a no-op on real devices.
+if [ -f /etc/clawbox/test-mode.env ]; then
+  # shellcheck disable=SC1091
+  source /etc/clawbox/test-mode.env
+fi
 CLAWBOX_TEST_MODE="${CLAWBOX_TEST_MODE:-0}"
 is_test_mode() { [ "$CLAWBOX_TEST_MODE" = "1" ]; }
 BUN="$CLAWBOX_HOME/.bun/bin/bun"


### PR DESCRIPTION
## Problem

The `e2e-install` CI check fails **intermittently** with:
```
[5/18] Detecting WiFi interface...
Error: WiFi interface 'eth0' not found or not wireless.
clawbox-bootstrap.service: Main process exited, code=exited, status=1/FAILURE
install.sh: line N: nvpmodel: command not found
→ install.sh did not finish within 40 min
```
This is `install.sh` running the **real Jetson/WiFi hardware path** inside the non-Jetson CI container — it should be skipped under `CLAWBOX_TEST_MODE=1`.

## Root cause

The `e2e-install` harness entrypoint seeds `/etc/clawbox/test-mode.env` (`CLAWBOX_TEST_MODE=1` + `NETWORK_INTERFACE=eth0`) before any install runs, *expecting install.sh to read it* — its own comment says *"so install.sh knows it's in test mode even before it has had a chance to write its own .env."*

But `install.sh` never sourced that file. It read `CLAWBOX_TEST_MODE` only from its **process environment**. So:
- The first-boot **bootstrap** is fine — `clawbox-bootstrap.service` sets `CLAWBOX_TEST_MODE=1` directly.
- But **updater-triggered** `install.sh --step` runs via `clawbox-root-update@.service` inherit only `EnvironmentFile=-/etc/clawbox/network.env`, which gets the flag **late** (only after `step_network_setup` persists it). Those runs execute with `CLAWBOX_TEST_MODE=0` → real `iw dev eth0` / `nvpmodel` / `jetson_clocks` → fail on the CI host.

That's the intermittency: whoever wins/loses the race on when the flag is present.

## Fix

Source the seeded marker at install.sh startup (mirrors the existing `source "$IFACE_ENV"` a few lines below), so **every** invocation — bootstrap and updater-triggered — detects test mode up front. The file exists only in the CI container, so it's a **no-op on real devices**.

## Validation

- `bash -n install.sh` clean.
- Simulated: with `/etc/clawbox/test-mode.env` present → `CLAWBOX_TEST_MODE=1`, `NETWORK_INTERFACE=eth0`; absent (real device) → `CLAWBOX_TEST_MODE=0`.
- The `e2e-install` check on this PR is the real end-to-end proof — it exercises exactly the updater path that was failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer reliability in test environments by ensuring test mode is properly detected and hardware-dependent steps are appropriately skipped during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->