### PR TITLE
feat(cli): add `clawbox update` command (issue #202)

### DIFF
--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -12,10 +12,12 @@
  *   clawbox notify <message>
  *   clawbox system stats
  *   clawbox system info
+ *   clawbox update
  */
 
-import { readFileSync } from "fs";
+import { readFileSync, existsSync } from "fs";
 import { join } from "path";
+import { spawnSync } from "child_process";
 
 const API_BASE = process.env.CLAWBOX_API_BASE || "http://127.0.0.1:80";
 const UI_PICKUP_DELAY_MS = 2500; // Time for the desktop UI to poll and pick up KV actions
@@ -321,6 +323,23 @@ async function main() {
     await apiPost("/setup-api/code", { action: "delete-project", projectId });
     console.log(`✅ Deleted project "${projectId}".`);
 
+  } else if (cmd === "update") {
+    // ClawBox system update: re-run the full installer in place. It git-syncs
+    // to the latest pinned code, then runs every step (system packages,
+    // OpenClaw at the pinned version, gateway config) and rebuilds — the same
+    // complete path the Settings -> Update button drives, but straight in the
+    // terminal so you can watch each step and see exactly where it fails.
+    // Requires root, so it shells out via sudo.
+    const projectRoot = process.env.CLAWBOX_ROOT || "/home/clawbox/clawbox";
+    const installScript = join(projectRoot, "install.sh");
+    if (!existsSync(installScript)) {
+      console.error(`install.sh not found at ${installScript} — set CLAWBOX_ROOT to your ClawBox checkout.`);
+      process.exit(1);
+    }
+    console.log(`Running ClawBox update — sudo bash ${installScript}\n`);
+    const res = spawnSync("sudo", ["bash", installScript], { stdio: "inherit" });
+    process.exit(res.status ?? 1);
+
   } else {
     console.log(`ClawBox CLI — Control the ClawBox device
 
@@ -333,6 +352,7 @@ Usage:
   clawbox notify <message>
   clawbox system stats
   clawbox system info
+  clawbox update                       Update ClawBox + OpenClaw in place (runs the installer; needs sudo)
 
 Code Projects:
   clawbox code init <projectId> <name> [template] [color]


### PR DESCRIPTION
## What

Adds a `clawbox update` CLI command so owners can update ClawBox from the terminal with live output.

## Why (issue #202)

There's no CLI updater for ClawBox (only OpenClaw has one), so the only way to update is the Settings UI — which runs each step as a fire-and-forget `clawbox-root-update@<step>` service and gives no visibility when a step fails. Customers can't see what's happening or drive it from the command line.

## How

`clawbox update` re-runs `install.sh` in place — the same **complete** path the UI's Update button drives (git-sync to the pinned code → system packages → OpenClaw at the pinned version → `openclaw_patch` → gateway config → rebuild). Unlike a bare `git pull && build` (which our notes flag as leaving the systemd unit / OpenClaw core stale), the full installer runs `openclaw_install` + `gateway_setup`, so it's a correct, complete update — just streamed straight to the terminal so you can watch each step and see exactly where it fails.

- Shells out via `sudo bash install.sh` with inherited stdio (live output), exits with the installer's status.
- `CLAWBOX_ROOT` overrides the install location (defaults to `/home/clawbox/clawbox`); errors clearly if `install.sh` isn't found.

## Validation

On a device (bun): bad `CLAWBOX_ROOT` → `install.sh not found … exit 1`; usage lists `clawbox update`. (The real path intentionally not run in test — it triggers a live update.)
