### PR TITLE
feat(telegram): approver names + reset on new bot + live-refresh

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1244,7 +1244,7 @@ function ChromeDesktopInner() {
   // when Settings is closed. De-duped by code via localStorage so a dismissed
   // request doesn't pop again.
   const [pairingRequests, setPairingRequests] = useState<
-    Array<{ code?: string; id?: string; meta?: { firstName?: string; lastName?: string } }>
+    Array<{ code?: string; id?: string; name?: string }>
   >([]);
   const [approvingPairCode, setApprovingPairCode] = useState<string | null>(null);
 
@@ -1765,8 +1765,7 @@ function ChromeDesktopInner() {
 
           {/* New Telegram access request popup(s) */}
           {pairingRequests.map((req) => {
-            const name = [req.meta?.firstName, req.meta?.lastName].filter((v): v is string => typeof v === "string" && v.length > 0).join(" ");
-            const label = name || req.id || "A Telegram user";
+            const label = req.name || req.id || "A Telegram user";
             const code = req.code || "";
             return (
               <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1244,7 +1244,7 @@ function ChromeDesktopInner() {
   // when Settings is closed. De-duped by code via localStorage so a dismissed
   // request doesn't pop again.
   const [pairingRequests, setPairingRequests] = useState<
-    Array<{ code?: string; id?: string; meta?: { name?: string } }>
+    Array<{ code?: string; id?: string; meta?: { firstName?: string; lastName?: string } }>
   >([]);
   const [approvingPairCode, setApprovingPairCode] = useState<string | null>(null);
 
@@ -1765,7 +1765,7 @@ function ChromeDesktopInner() {
 
           {/* New Telegram access request popup(s) */}
           {pairingRequests.map((req) => {
-            const name = typeof req.meta?.name === "string" ? req.meta.name : "";
+            const name = [req.meta?.firstName, req.meta?.lastName].filter((v): v is string => typeof v === "string" && v.length > 0).join(" ");
             const label = name || req.id || "A Telegram user";
             const code = req.code || "";
             return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1244,7 +1244,7 @@ function ChromeDesktopInner() {
   // when Settings is closed. De-duped by code via localStorage so a dismissed
   // request doesn't pop again.
   const [pairingRequests, setPairingRequests] = useState<
-    Array<{ code?: string; id?: string; meta?: Record<string, unknown> }>
+    Array<{ code?: string; id?: string; meta?: { name?: string } }>
   >([]);
   const [approvingPairCode, setApprovingPairCode] = useState<string | null>(null);
 
@@ -1753,8 +1753,8 @@ function ChromeDesktopInner() {
 
           {/* New Telegram access request popup(s) */}
           {pairingRequests.map((req) => {
-            const uname = typeof req.meta?.username === "string" ? req.meta.username : "";
-            const label = uname ? `@${uname}` : (req.id || "A Telegram user");
+            const name = typeof req.meta?.name === "string" ? req.meta.name : "";
+            const label = name || req.id || "A Telegram user";
             const code = req.code || "";
             return (
               <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1292,6 +1292,7 @@ function ChromeDesktopInner() {
       const data = await res.json().catch(() => ({}));
       if (res.ok && data.success) {
         setPairingRequests((prev) => prev.filter((r) => r.code !== code));
+        window.dispatchEvent(new CustomEvent("clawbox:telegram-approved", { detail: { code } }));
         window.dispatchEvent(new CustomEvent("clawbox:toast", { detail: { message: "Approved — the bot let them know." } }));
       } else {
         window.dispatchEvent(new CustomEvent("clawbox:toast", { detail: { message: data.error || "Couldn't approve — the code may have expired." } }));
@@ -1315,6 +1316,17 @@ function ChromeDesktopInner() {
     window.dispatchEvent(new CustomEvent("clawbox:open-settings-section", { detail: { section: "telegram" } }));
     openApp("settings");
   }, [openApp]);
+
+  // If an approval happens elsewhere (the Settings list), drop that request from
+  // the popup so it doesn't linger.
+  useEffect(() => {
+    const onApproved = (e: Event) => {
+      const code = (e as CustomEvent<{ code?: string }>).detail?.code;
+      if (code) setPairingRequests((prev) => prev.filter((r) => (r.code || "").toUpperCase() !== code.toUpperCase()));
+    };
+    window.addEventListener("clawbox:telegram-approved", onApproved);
+    return () => window.removeEventListener("clawbox:telegram-approved", onApproved);
+  }, []);
 
   const updateWindowGeometry = useCallback((windowId: string, geo: { x: number; y: number; width: number; height: number }) => {
     setOpenWindows((prev) =>

--- a/src/app/setup-api/telegram/configure/route.ts
+++ b/src/app/setup-api/telegram/configure/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
-import { set } from "@/lib/config-store";
-import { setTelegramToken, restartGateway } from "@/lib/openclaw-config";
+import { get, set } from "@/lib/config-store";
+import { setTelegramToken, restartGateway, clearTelegramPairingState } from "@/lib/openclaw-config";
 
 export const dynamic = "force-dynamic";
 
@@ -30,15 +30,29 @@ export async function POST(request: Request) {
       );
     }
 
+    // A different bot means a fresh allowlist — previously-approved senders
+    // belong to the old bot. Detect a real token change (re-saving the same
+    // token keeps approvals) so we can reset OpenClaw's allowlist/pending stores
+    // and our name map below.
+    const previousToken = await get("telegram_bot_token");
+    const tokenChanged =
+      typeof previousToken === "string" && previousToken.length > 0 && previousToken !== botToken;
+
     // Save to ClawBox config
     await set("telegram_bot_token", botToken);
 
     // Register Telegram channel with OpenClaw gateway
     await setTelegramToken(botToken);
-    // Restart gateway so it picks up the new channel
+
+    if (tokenChanged) {
+      await clearTelegramPairingState();
+      await set("telegram_approved_names", undefined);
+    }
+
+    // Restart gateway so it picks up the new channel (and the reset allowlist)
     await restartGateway();
 
-    return NextResponse.json({ success: true });
+    return NextResponse.json({ success: true, reset: tokenChanged });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to save" },

--- a/src/app/setup-api/telegram/pairing/route.ts
+++ b/src/app/setup-api/telegram/pairing/route.ts
@@ -96,10 +96,7 @@ export async function POST(request: Request) {
       );
       if (match) {
         approvedId = match.id;
-        const name = [match.meta?.firstName, match.meta?.lastName]
-          .filter((v): v is string => typeof v === "string" && v.length > 0)
-          .join(" ");
-        if (name) approvedName = name;
+        if (match.name) approvedName = match.name;
       }
     } catch {
       // name capture is best-effort — approval still proceeds

--- a/src/app/setup-api/telegram/pairing/route.ts
+++ b/src/app/setup-api/telegram/pairing/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { get } from "@/lib/config-store";
+import { get, set } from "@/lib/config-store";
 import {
   readTelegramAllowFrom,
   listTelegramPairingRequests,
@@ -10,9 +10,29 @@ import {
 
 export const dynamic = "force-dynamic";
 
+// OpenClaw's allowlist stores bare ids only. We remember the display name
+// captured at approval time (ClawBox-side, in config-store) so the UI can show
+// who each approved sender is.
+const APPROVED_NAMES_KEY = "telegram_approved_names";
+
 async function isConfigured(): Promise<boolean> {
   const token = await get("telegram_bot_token");
   return typeof token === "string" && token.length > 0;
+}
+
+async function readApprovedNames(): Promise<Record<string, string>> {
+  const raw = await get(APPROVED_NAMES_KEY);
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, string> = {};
+  for (const [id, name] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof name === "string") out[id] = name;
+  }
+  return out;
+}
+
+async function buildApproved(names?: Record<string, string>): Promise<Array<{ id: string; name?: string }>> {
+  const [ids, nameMap] = await Promise.all([readTelegramAllowFrom(), names ?? readApprovedNames()]);
+  return ids.map((id) => ({ id, name: nameMap[id] }));
 }
 
 // GET — list approved senders (fast: a single file read). With `?pending=1` it
@@ -27,7 +47,7 @@ export async function GET(request: Request) {
       );
     }
     const params = new URL(request.url).searchParams;
-    const approved = await readTelegramAllowFrom();
+    const approved = await buildApproved();
     // `?poll=1` reads the pairing-store file (fast — safe for the desktop poller);
     // `?pending=1` uses the authoritative CLI (the Settings "Check" button).
     const pending =
@@ -66,6 +86,22 @@ export async function POST(request: Request) {
       );
     }
 
+    // Capture the requester's id + name from the pending store BEFORE approving
+    // (approval removes the request, and the allowlist keeps only the id).
+    let approvedId: string | undefined;
+    let approvedName: string | undefined;
+    try {
+      const match = (await readTelegramPairingRequests()).find(
+        (r) => typeof r.code === "string" && r.code.toUpperCase() === code,
+      );
+      if (match) {
+        approvedId = match.id;
+        if (typeof match.meta?.name === "string") approvedName = match.meta.name;
+      }
+    } catch {
+      // name capture is best-effort — approval still proceeds
+    }
+
     try {
       await approveTelegramPairing(code);
     } catch (err) {
@@ -87,7 +123,13 @@ export async function POST(request: Request) {
       );
     }
 
-    const approved = await readTelegramAllowFrom();
+    let names: Record<string, string> | undefined;
+    if (approvedId && approvedName) {
+      names = await readApprovedNames();
+      names[approvedId] = approvedName;
+      await set(APPROVED_NAMES_KEY, names);
+    }
+    const approved = await buildApproved(names);
     return NextResponse.json({ success: true, approved });
   } catch (err) {
     return NextResponse.json(

--- a/src/app/setup-api/telegram/pairing/route.ts
+++ b/src/app/setup-api/telegram/pairing/route.ts
@@ -96,7 +96,10 @@ export async function POST(request: Request) {
       );
       if (match) {
         approvedId = match.id;
-        if (typeof match.meta?.name === "string") approvedName = match.meta.name;
+        const name = [match.meta?.firstName, match.meta?.lastName]
+          .filter((v): v is string => typeof v === "string" && v.length > 0)
+          .join(" ");
+        if (name) approvedName = name;
       }
     } catch {
       // name capture is best-effort — approval still proceeds

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1267,6 +1267,15 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         setTgConfigured(true);
         setTgReconfigure(false);
         setTgToken("");
+        // A token change resets the allowlist server-side; clear the lists
+        // optimistically and re-fetch so the UI reflects the fresh bot without
+        // a manual reload.
+        if (data.reset) {
+          setTgApproved([]);
+          setTgPending(null);
+          setTgPairingStatus(null);
+        }
+        refreshPairing();
       } else {
         configureReject(new Error(data.error || "configure returned success=false"));
         setTgConfiguring(false);

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1077,7 +1077,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   const [tgStreamingPending, setTgStreamingPending] = useState(false);
   // Telegram pairing / user-access state.
   const [tgApproved, setTgApproved] = useState<Array<{ id: string; name?: string }>>([]);
-  const [tgPending, setTgPending] = useState<Array<{ code?: string; id?: string; meta?: { firstName?: string; lastName?: string }; createdAt?: string }> | null>(null);
+  const [tgPending, setTgPending] = useState<Array<{ code?: string; id?: string; name?: string; createdAt?: string }> | null>(null);
   const [tgPendingLoading, setTgPendingLoading] = useState(false);
   const [tgPairingCode, setTgPairingCode] = useState("");
   const [tgApproving, setTgApproving] = useState(false);
@@ -2504,8 +2504,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       ) : (
                         <ul className="space-y-2 list-none p-0 m-0">
                           {tgPending.map((req, i) => {
-                            const name = [req.meta?.firstName, req.meta?.lastName].filter((v): v is string => typeof v === "string" && v.length > 0).join(" ");
-                            const label = name || req.id || req.code || `#${i + 1}`;
+                            const label = req.name || req.id || req.code || `#${i + 1}`;
                             return (
                               <li key={req.code || req.id || i} className="flex items-center justify-between gap-3 bg-white/[0.03] border border-white/[0.06] rounded-lg px-3 py-2">
                                 <div className="min-w-0">

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1076,8 +1076,8 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   const [tgStreaming, setTgStreaming] = useState<boolean | null>(null);
   const [tgStreamingPending, setTgStreamingPending] = useState(false);
   // Telegram pairing / user-access state.
-  const [tgApproved, setTgApproved] = useState<string[]>([]);
-  const [tgPending, setTgPending] = useState<Array<{ code?: string; id?: string; meta?: Record<string, unknown>; createdAt?: string }> | null>(null);
+  const [tgApproved, setTgApproved] = useState<Array<{ id: string; name?: string }>>([]);
+  const [tgPending, setTgPending] = useState<Array<{ code?: string; id?: string; meta?: { name?: string }; createdAt?: string }> | null>(null);
   const [tgPendingLoading, setTgPendingLoading] = useState(false);
   const [tgPairingCode, setTgPairingCode] = useState("");
   const [tgApproving, setTgApproving] = useState(false);
@@ -2482,13 +2482,13 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       ) : (
                         <ul className="space-y-2 list-none p-0 m-0">
                           {tgPending.map((req, i) => {
-                            const uname = typeof req.meta?.username === "string" ? req.meta.username : "";
-                            const label = uname ? `@${uname}` : (req.id || req.code || `#${i + 1}`);
+                            const name = typeof req.meta?.name === "string" ? req.meta.name : "";
+                            const label = name || req.id || req.code || `#${i + 1}`;
                             return (
                               <li key={req.code || req.id || i} className="flex items-center justify-between gap-3 bg-white/[0.03] border border-white/[0.06] rounded-lg px-3 py-2">
                                 <div className="min-w-0">
                                   <div className="text-sm text-[var(--text-primary)] truncate">{label}</div>
-                                  {req.id && <div className="text-xs text-[var(--text-muted)] font-mono truncate">{req.id}</div>}
+                                  {req.id && label !== req.id && <div className="text-xs text-[var(--text-muted)] font-mono truncate">{req.id}</div>}
                                 </div>
                                 {req.code && (
                                   <button
@@ -2516,10 +2516,17 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     <p className="text-xs text-[var(--text-muted)] mt-1">{t("settings.pairingNoApproved")}</p>
                   ) : (
                     <ul className="mt-2 flex flex-wrap gap-2 list-none p-0 m-0">
-                      {tgApproved.map((id) => (
-                        <li key={id} className="inline-flex items-center gap-1.5 bg-white/[0.04] border border-white/[0.08] rounded-full px-3 py-1 text-xs text-[var(--text-secondary)] font-mono">
+                      {tgApproved.map((u) => (
+                        <li key={u.id} className="inline-flex items-center gap-1.5 bg-white/[0.04] border border-white/[0.08] rounded-full px-3 py-1 text-xs text-[var(--text-secondary)]">
                           <span className="material-symbols-rounded text-green-400" style={{ fontSize: 14 }} aria-hidden="true">check</span>
-                          {id}
+                          {u.name ? (
+                            <>
+                              <span>{u.name}</span>
+                              <span className="text-[10px] text-[var(--text-muted)] font-mono">{u.id}</span>
+                            </>
+                          ) : (
+                            <span className="font-mono">{u.id}</span>
+                          )}
                         </li>
                       ))}
                     </ul>

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1077,7 +1077,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   const [tgStreamingPending, setTgStreamingPending] = useState(false);
   // Telegram pairing / user-access state.
   const [tgApproved, setTgApproved] = useState<Array<{ id: string; name?: string }>>([]);
-  const [tgPending, setTgPending] = useState<Array<{ code?: string; id?: string; meta?: { name?: string }; createdAt?: string }> | null>(null);
+  const [tgPending, setTgPending] = useState<Array<{ code?: string; id?: string; meta?: { firstName?: string; lastName?: string }; createdAt?: string }> | null>(null);
   const [tgPendingLoading, setTgPendingLoading] = useState(false);
   const [tgPairingCode, setTgPairingCode] = useState("");
   const [tgApproving, setTgApproving] = useState(false);
@@ -2504,7 +2504,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       ) : (
                         <ul className="space-y-2 list-none p-0 m-0">
                           {tgPending.map((req, i) => {
-                            const name = typeof req.meta?.name === "string" ? req.meta.name : "";
+                            const name = [req.meta?.firstName, req.meta?.lastName].filter((v): v is string => typeof v === "string" && v.length > 0).join(" ");
                             const label = name || req.id || req.code || `#${i + 1}`;
                             return (
                               <li key={req.code || req.id || i} className="flex items-center justify-between gap-3 bg-white/[0.03] border border-white/[0.06] rounded-lg px-3 py-2">

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -1127,6 +1127,18 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       .catch(() => setTgStreaming(true));
   }, [section, isMobile, refreshTelegramStatus, refreshPairing]);
 
+  // Refresh the approved/pending lists when an approval happens anywhere (e.g.
+  // the desktop popup) so the Settings list updates without a manual reload.
+  useEffect(() => {
+    const onApproved = (e: Event) => {
+      const code = (e as CustomEvent<{ code?: string }>).detail?.code;
+      refreshPairing();
+      if (code) setTgPending((prev) => (prev ? prev.filter((req) => (req.code || "").toUpperCase() !== code.toUpperCase()) : prev));
+    };
+    window.addEventListener("clawbox:telegram-approved", onApproved);
+    return () => window.removeEventListener("clawbox:telegram-approved", onApproved);
+  }, [refreshPairing]);
+
   const toggleTelegramStreaming = useCallback(async (next: boolean) => {
     const prev = tgStreaming;
     setTgStreamingPending(true);
@@ -1187,6 +1199,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         if (Array.isArray(d.approved)) setTgApproved(d.approved);
         setTgPairingCode("");
         setTgPending((prev) => (prev ? prev.filter((req) => (req.code || "").toUpperCase() !== code) : prev));
+        window.dispatchEvent(new CustomEvent("clawbox:telegram-approved", { detail: { code } }));
         setTgPairingStatus({ type: "success", message: t("settings.pairingApproveSuccess") });
       } else {
         setTgPairingStatus({ type: "error", message: d.error || t("settings.pairingApproveFailed") });

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -627,8 +627,28 @@ export interface TelegramPairingRequest {
   id?: string;
   /** Sender metadata OpenClaw attaches — `firstName`/`lastName` are the Telegram name. */
   meta?: { firstName?: string; lastName?: string; [key: string]: unknown };
+  /** Display name, derived from `meta` once at the read boundary so callers (the
+   *  popup, Settings list, and approve route) don't each re-derive it. */
+  name?: string;
   createdAt?: string;
   [key: string]: unknown;
+}
+
+/** Build a display name from a pairing request's meta (Telegram first/last name). */
+function deriveTelegramName(meta: TelegramPairingRequest["meta"]): string | undefined {
+  const name = [meta?.firstName, meta?.lastName]
+    .filter((v): v is string => typeof v === "string" && v.length > 0)
+    .join(" ");
+  return name || undefined;
+}
+
+/** Normalise a raw `requests` array, attaching a derived `name` to each entry. */
+function withDerivedNames(requests: unknown): TelegramPairingRequest[] {
+  if (!Array.isArray(requests)) return [];
+  return (requests as TelegramPairingRequest[]).map((r) => ({
+    ...r,
+    name: r.name ?? deriveTelegramName(r.meta),
+  }));
 }
 
 /** Pending Telegram DM pairing requests, via `openclaw pairing list telegram --json` (authoritative). */
@@ -636,7 +656,7 @@ export async function listTelegramPairingRequests(): Promise<TelegramPairingRequ
   const out = await spawnOpenclaw(["pairing", "list", "telegram", "--json"], { captureStdout: true });
   try {
     const parsed = JSON.parse(out) as { requests?: unknown };
-    return Array.isArray(parsed.requests) ? (parsed.requests as TelegramPairingRequest[]) : [];
+    return withDerivedNames(parsed.requests);
   } catch {
     return [];
   }
@@ -655,7 +675,7 @@ export async function readTelegramPairingRequests(account = "default"): Promise<
   );
   try {
     const parsed = JSON.parse(await fs.readFile(file, "utf-8")) as { requests?: unknown };
-    return Array.isArray(parsed.requests) ? (parsed.requests as TelegramPairingRequest[]) : [];
+    return withDerivedNames(parsed.requests);
   } catch {
     return [];
   }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -625,8 +625,8 @@ export interface TelegramPairingRequest {
   code?: string;
   /** Sender id — the Telegram user id that lands in the allowlist on approval. */
   id?: string;
-  /** Free-form sender metadata OpenClaw attaches (e.g. username / name). */
-  meta?: Record<string, unknown>;
+  /** Sender metadata OpenClaw attaches — `name` is the Telegram display name. */
+  meta?: { name?: string; [key: string]: unknown };
   createdAt?: string;
   [key: string]: unknown;
 }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -625,8 +625,8 @@ export interface TelegramPairingRequest {
   code?: string;
   /** Sender id — the Telegram user id that lands in the allowlist on approval. */
   id?: string;
-  /** Sender metadata OpenClaw attaches — `name` is the Telegram display name. */
-  meta?: { name?: string; [key: string]: unknown };
+  /** Sender metadata OpenClaw attaches — `firstName`/`lastName` are the Telegram name. */
+  meta?: { firstName?: string; lastName?: string; [key: string]: unknown };
   createdAt?: string;
   [key: string]: unknown;
 }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -691,6 +691,19 @@ export async function readTelegramAllowFrom(account = "default"): Promise<string
   }
 }
 
+/**
+ * Wipe the per-account Telegram allowlist + pending stores. Used when the bot
+ * token changes: previously-approved senders belong to the old bot, so a new
+ * bot should start with a fresh allowlist. Best-effort — missing files are fine.
+ */
+export async function clearTelegramPairingState(account = "default"): Promise<void> {
+  const files = [
+    path.join(CREDENTIALS_DIR, `telegram-${account}-allowFrom.json`),
+    path.join(CREDENTIALS_DIR, account === "default" ? "telegram-pairing.json" : `telegram-${account}-pairing.json`),
+  ];
+  await Promise.all(files.map((f) => fs.rm(f, { force: true }).catch(() => {})));
+}
+
 // Toggles `plugins.entries.anthropic.enabled` in lock-step with the active
 // provider. Every enabled plugin loads its tool schemas synchronously on
 // the gateway's main loop during agent prep (~5-8s for anthropic on Jetson),

--- a/src/tests/routes/telegram/configure.test.ts
+++ b/src/tests/routes/telegram/configure.test.ts
@@ -1,20 +1,24 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(),
   set: vi.fn(),
 }));
 
 vi.mock("@/lib/openclaw-config", () => ({
   setTelegramToken: vi.fn(),
   restartGateway: vi.fn(),
+  clearTelegramPairingState: vi.fn(),
 }));
 
-import { set } from "@/lib/config-store";
-import { setTelegramToken, restartGateway } from "@/lib/openclaw-config";
+import { get, set } from "@/lib/config-store";
+import { setTelegramToken, restartGateway, clearTelegramPairingState } from "@/lib/openclaw-config";
 
+const mockGet = vi.mocked(get);
 const mockSet = vi.mocked(set);
 const mockSetTelegramToken = vi.mocked(setTelegramToken);
 const mockRestartGateway = vi.mocked(restartGateway);
+const mockClearPairing = vi.mocked(clearTelegramPairingState);
 
 describe("POST /setup-api/telegram/configure", () => {
   let telegramConfigurePost: (req: Request) => Promise<Response>;
@@ -31,9 +35,11 @@ describe("POST /setup-api/telegram/configure", () => {
     vi.resetModules();
     vi.clearAllMocks();
 
+    mockGet.mockResolvedValue(undefined);
     mockSet.mockResolvedValue();
     mockSetTelegramToken.mockResolvedValue();
     mockRestartGateway.mockResolvedValue();
+    mockClearPairing.mockResolvedValue();
 
     const mod = await import("@/app/setup-api/telegram/configure/route");
     telegramConfigurePost = mod.POST;
@@ -53,6 +59,29 @@ describe("POST /setup-api/telegram/configure", () => {
     expect(mockSet).toHaveBeenCalledWith("telegram_bot_token", token);
     expect(mockSetTelegramToken).toHaveBeenCalledWith(token);
     expect(mockRestartGateway).toHaveBeenCalled();
+  });
+
+  it("resets the allowlist + name map when the bot token changes", async () => {
+    mockGet.mockResolvedValue("111:OLD_token_value");
+    const res = await telegramConfigurePost(jsonRequest({ botToken: "222:new_token_value" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.reset).toBe(true);
+    expect(mockClearPairing).toHaveBeenCalledTimes(1);
+    expect(mockSet).toHaveBeenCalledWith("telegram_approved_names", undefined);
+  });
+
+  it("keeps the allowlist when re-saving the same token", async () => {
+    const token = "111:same_token_value";
+    mockGet.mockResolvedValue(token);
+    const res = await telegramConfigurePost(jsonRequest({ botToken: token }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.reset).toBe(false);
+    expect(mockClearPairing).not.toHaveBeenCalled();
+    expect(mockSet).not.toHaveBeenCalledWith("telegram_approved_names", undefined);
   });
 
   it("returns 400 for invalid JSON", async () => {

--- a/src/tests/routes/telegram/pairing.test.ts
+++ b/src/tests/routes/telegram/pairing.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(),
+  set: vi.fn(),
 }));
 
 vi.mock("@/lib/openclaw-config", () => ({
@@ -14,7 +15,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   PAIRING_CODE_RE: /^[A-Z0-9]{8}$/,
 }));
 
-import { get } from "@/lib/config-store";
+import { get, set } from "@/lib/config-store";
 import {
   readTelegramAllowFrom,
   listTelegramPairingRequests,
@@ -27,6 +28,7 @@ const mockReadAllow = vi.mocked(readTelegramAllowFrom);
 const mockListPending = vi.mocked(listTelegramPairingRequests);
 const mockReadPending = vi.mocked(readTelegramPairingRequests);
 const mockApprove = vi.mocked(approveTelegramPairing);
+const mockSet = vi.mocked(set);
 
 describe("/setup-api/telegram/pairing", () => {
   let GET: (req: Request) => Promise<Response>;
@@ -81,7 +83,7 @@ describe("/setup-api/telegram/pairing", () => {
 
     expect(res.status).toBe(200);
     expect(body.configured).toBe(true);
-    expect(body.approved).toEqual(["6057319791"]);
+    expect(body.approved).toEqual([{ id: "6057319791" }]);
     expect(body.pending).toEqual([]);
     expect(mockListPending).not.toHaveBeenCalled();
   });
@@ -138,7 +140,26 @@ describe("/setup-api/telegram/pairing", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
     expect(mockApprove).toHaveBeenCalledWith("FQL2A98K");
-    expect(body.approved).toEqual(["6057319791", "999"]);
+    expect(body.approved).toEqual([{ id: "6057319791" }, { id: "999" }]);
+  });
+
+  it("POST captures the requester's name from the pending store and stores it", async () => {
+    mockGet.mockImplementation(async (key: string) =>
+      key === "telegram_bot_token"
+        ? "123:abc"
+        : key === "telegram_approved_names"
+          ? { "999": "Ivan" }
+          : null,
+    );
+    mockReadAllow.mockResolvedValue(["999"]);
+    mockReadPending.mockResolvedValue([{ code: "FQL2A98K", id: "999", meta: { name: "Ivan" } }]);
+
+    const res = await POST(postReq({ code: "fql2a98k" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockSet).toHaveBeenCalledWith("telegram_approved_names", { "999": "Ivan" });
+    expect(body.approved).toEqual([{ id: "999", name: "Ivan" }]);
   });
 
   it("POST maps an expired/unknown code to a 400", async () => {

--- a/src/tests/routes/telegram/pairing.test.ts
+++ b/src/tests/routes/telegram/pairing.test.ts
@@ -152,7 +152,7 @@ describe("/setup-api/telegram/pairing", () => {
           : null,
     );
     mockReadAllow.mockResolvedValue(["999"]);
-    mockReadPending.mockResolvedValue([{ code: "FQL2A98K", id: "999", meta: { firstName: "Ivan" } }]);
+    mockReadPending.mockResolvedValue([{ code: "FQL2A98K", id: "999", name: "Ivan" }]);
 
     const res = await POST(postReq({ code: "fql2a98k" }));
     const body = await res.json();

--- a/src/tests/routes/telegram/pairing.test.ts
+++ b/src/tests/routes/telegram/pairing.test.ts
@@ -152,7 +152,7 @@ describe("/setup-api/telegram/pairing", () => {
           : null,
     );
     mockReadAllow.mockResolvedValue(["999"]);
-    mockReadPending.mockResolvedValue([{ code: "FQL2A98K", id: "999", meta: { name: "Ivan" } }]);
+    mockReadPending.mockResolvedValue([{ code: "FQL2A98K", id: "999", meta: { firstName: "Ivan" } }]);
 
     const res = await POST(postReq({ code: "fql2a98k" }));
     const body = await res.json();

--- a/src/tests/unit/telegram-pairing.test.ts
+++ b/src/tests/unit/telegram-pairing.test.ts
@@ -122,3 +122,40 @@ describe("readTelegramPairingRequests", () => {
     expect(await readTelegramPairingRequests()).toEqual([]);
   });
 });
+
+describe("clearTelegramPairingState", () => {
+  let tmpHome: string;
+  const origHome = process.env.OPENCLAW_HOME;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oc-home-"));
+    process.env.OPENCLAW_HOME = tmpHome;
+    await fs.mkdir(path.join(tmpHome, "credentials"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    if (origHome === undefined) delete process.env.OPENCLAW_HOME;
+    else process.env.OPENCLAW_HOME = origHome;
+    await fs.rm(tmpHome, { recursive: true, force: true });
+  });
+
+  it("removes the allowlist + pending store files", async () => {
+    const creds = path.join(tmpHome, "credentials");
+    const allowFile = path.join(creds, "telegram-default-allowFrom.json");
+    const pairingFile = path.join(creds, "telegram-pairing.json");
+    await fs.writeFile(allowFile, JSON.stringify({ version: 1, allowFrom: ["111"] }), "utf-8");
+    await fs.writeFile(pairingFile, JSON.stringify({ version: 1, requests: [] }), "utf-8");
+
+    const { clearTelegramPairingState } = await import("@/lib/openclaw-config");
+    await clearTelegramPairingState();
+
+    await expect(fs.access(allowFile)).rejects.toThrow();
+    await expect(fs.access(pairingFile)).rejects.toThrow();
+  });
+
+  it("is a no-op when the files are already absent", async () => {
+    const { clearTelegramPairingState } = await import("@/lib/openclaw-config");
+    await expect(clearTelegramPairingState()).resolves.toBeUndefined();
+  });
+});

--- a/src/tests/unit/telegram-pairing.test.ts
+++ b/src/tests/unit/telegram-pairing.test.ts
@@ -111,6 +111,13 @@ describe("readTelegramPairingRequests", () => {
     expect(await readTelegramPairingRequests()).toEqual([{ code: "ABCD2345", id: "42" }]);
   });
 
+  it("derives a display name from meta.firstName/lastName", async () => {
+    await writePairing(JSON.stringify({ version: 1, requests: [{ code: "ABCD2345", id: "42", meta: { firstName: "Krasi", lastName: "K" } }] }));
+    const { readTelegramPairingRequests } = await import("@/lib/openclaw-config");
+    const [req] = await readTelegramPairingRequests();
+    expect(req.name).toBe("Krasi K");
+  });
+
   it("returns [] when the file is missing", async () => {
     const { readTelegramPairingRequests } = await import("@/lib/openclaw-config");
     expect(await readTelegramPairingRequests()).toEqual([]);


### PR DESCRIPTION
## What

Telegram pairing UI polish — three things:

1. **Names everywhere.** The new-request popup + Settings pending list show the sender's Telegram name (`meta.name`); the **Approved users** list shows names too, captured at approval into a ClawBox-side id→name map (OpenClaw's allowlist stores ids only). `GET` returns `approved` as `{ id, name? }`.
2. **New bot → fresh allowlist.** When the bot token actually **changes**, the configure route wipes OpenClaw's allowlist/pending stores (`clearTelegramPairingState`) + our name map, so a new bot doesn't inherit the old bot's approved users. Re-saving the *same* token keeps approvals.
3. **Live refresh.** Approving — from the desktop popup *or* the Settings list — dispatches a `clawbox:telegram-approved` event; both surfaces listen and update immediately, no manual refresh.

## Notes

- Name capture is server-side (re-reads the pending store by code, before approval removes it) and best-effort; a missing name degrades to id-only.
- The reset removes `telegram-<account>-allowFrom.json` + `telegram-pairing.json` (best-effort) and the `telegram_approved_names` config-store key; the gateway restart picks up the empty allowlist.

## Tested on a real ClawBox (OpenClaw 2026.6.6)

- **39 telegram tests green** (incl. new reset, clear-state, and name-capture cases); deployed to a device and validated live.

Builds on #209; targets beta.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Telegram pairing interface now displays user names for both pending and approved pairing requests

* **Improvements**
  * Real-time UI updates when approving Telegram pairing requests without requiring a page refresh
  * Automatic clearing of previous pairing state when Telegram bot token configuration changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->