### PR TITLE
fix: write api_key auth profiles for key providers (OpenClaw 2026.6.8 compat)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -625,10 +625,18 @@ export async function POST(request: Request) {
           ...(projectId ? { projectId } : {}),
         };
       } else {
+        // API-key providers (anthropic, openai, google, openrouter) authenticate
+        // with a bearer key. OpenClaw <=2026.6.6 tolerated a `type: "token"`
+        // profile here, but 2026.6.8 reworked auth resolution and no longer
+        // turns a token-mode profile into an Authorization header — the request
+        // goes out unauthenticated and the provider returns "401 Missing
+        // Authentication header". Write the same `type: "api_key"` shape the
+        // working providers above use (clawai/ollama/llamacpp) so the gateway
+        // applies the key on every release.
         authProfiles.profiles[config.profileKey] = {
-          type: "token",
+          type: "api_key",
           provider: ocProvider,
-          token: normalizedApiKey,
+          key: normalizedApiKey,
         };
       }
       await writeAuthProfiles(authProfiles);
@@ -649,9 +657,11 @@ export async function POST(request: Request) {
       "config",
       "set",
       `auth.profiles.${config.profileKey}`,
-      JSON.stringify((isOllama || isLlamaCpp || isClawAI)
-        ? { provider: ocProvider, mode: "api_key" }
-        : { provider: ocProvider, mode: authMode === "subscription" ? "oauth" : "token" }),
+      // Subscription → "oauth"; every key-based provider → "api_key". The old
+      // "token" mode 401s on 2026.6.8+ (see the auth-profile write above).
+      JSON.stringify(authMode === "subscription"
+        ? { provider: ocProvider, mode: "oauth" }
+        : { provider: ocProvider, mode: "api_key" }),
       "--json",
     ]);
     if (!isLocalScope || shouldPromoteLocalToPrimary) {
@@ -852,7 +862,10 @@ export async function POST(request: Request) {
       const providerDef = JSON.stringify({
         baseUrl: "https://openrouter.ai/api/v1",
         api: "openai-completions",
-        apiKey: "openrouter-ref",
+        // Inline the real key (was the placeholder "openrouter-ref"): 2026.6.8
+        // sends models.providers.*.apiKey verbatim, so a ref-placeholder 401s.
+        // Mirrors the clawai/deepseek providerDefs. See the auth-profile note above.
+        apiKey: normalizedApiKey,
         models: Array.from(modelIds).map((id) => ({ id, name: id })),
       });
       await runCommand(OPENCLAW_BIN, [

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -526,7 +526,9 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(body.success).toBe(true);
   });
 
-  it("writes auth profile with correct structure for token auth", async () => {
+  it("writes an api_key auth profile for key-based providers", async () => {
+    // Key providers must use type:"api_key" (not the legacy "token", which
+    // OpenClaw 2026.6.8 no longer turns into an Authorization header).
     await configurePost(jsonRequest({
       provider: "anthropic",
       apiKey: "sk-test",
@@ -537,7 +539,8 @@ describe("POST /setup-api/ai-models/configure", () => {
     const writtenContent = JSON.parse(writeCall[1] as string);
 
     expect(writtenContent.profiles["anthropic:default"]).toBeDefined();
-    expect(writtenContent.profiles["anthropic:default"].type).toBe("token");
+    expect(writtenContent.profiles["anthropic:default"].type).toBe("api_key");
+    expect(writtenContent.profiles["anthropic:default"].key).toBe("sk-test");
   });
 
   it("writes auth profile with the local-ai bearer for Ollama", async () => {
@@ -729,6 +732,18 @@ describe("POST /setup-api/ai-models/configure", () => {
     const modelIds = providerDef.models?.map((m: { id: string }) => m.id) ?? [];
     expect(modelIds).toContain("anthropic/claude-haiku-4.5");
     expect(modelIds.length).toBeGreaterThanOrEqual(1);
+
+    // The real key must be inlined on the provider, not the old "openrouter-ref"
+    // placeholder: OpenClaw 2026.6.8 sends models.providers.*.apiKey verbatim, so
+    // the placeholder went out as the bearer and OpenRouter 401'd.
+    expect(providerDef.apiKey).toBe("sk-or-v1-test");
+
+    // ...and the managed auth profile uses api_key (not the legacy token mode
+    // that 6.8 no longer turns into an Authorization header).
+    const writtenContent = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(writtenContent.profiles["openrouter:default"]).toEqual(
+      expect.objectContaining({ type: "api_key", provider: "openrouter", key: "sk-or-v1-test" })
+    );
   });
 
   it("honors an openrouter model picked by the user", async () => {


### PR DESCRIPTION
## Problem

On OpenClaw **2026.6.8**, OpenRouter (and anthropic/openai/google) chats fail with:

```
[agent/embedded] embedded run agent end: ... provider=openrouter
  error=LLM request failed. rawError=401 Missing Authentication header
```

ClawBox writes these key-based providers' auth as `type: "token"` profiles, and OpenRouter's `models.providers.openrouter.apiKey` as the placeholder `"openrouter-ref"` (a reference the old gateway resolved from the profile). OpenClaw **2026.6.6 honored that**; **2026.6.8 reworked auth resolution** — it no longer turns a `token`-mode profile into an `Authorization` header, and it sends `models.providers.*.apiKey` **verbatim**. So `"openrouter-ref"` went out as the bearer → 401.

## Fix

Write the same `type: "api_key"` shape the **already-working** providers (clawai/ollama/llamacpp) use, and inline OpenRouter's real key:

- auth-profiles.json `else` branch: `type:"token"`/`token:` → `type:"api_key"`/`key:`
- openclaw.json `auth.profiles.<key>` mode: `… : token` → `subscription ? oauth : api_key` (de-special-cases the per-provider guard)
- OpenRouter providerDef: `apiKey:"openrouter-ref"` → `apiKey: <real key>` (mirrors the clawai/deepseek providerDefs)

Covers all key-based providers, not just OpenRouter, since they all hit the same branch.

## Verification

- **End-to-end on device** (Jetson, OpenClaw 2026.6.8): applied this exact config shape by hand → gateway reloaded, `openrouter/anthropic/claude-haiku-4.5` loaded, **401 gone**, key validates against OpenRouter `/auth/key` (200).
- Unit tests updated: anthropic profile now asserts `api_key`+`key`; OpenRouter test asserts the inlined real key (not `openrouter-ref`) + `api_key` profile.

## Follow-up (not this PR)

`configure/route.ts` could extract a `writeApiKeyProfile()` helper to collapse the four now-identical `api_key` branches and migrate to `openclaw onboard --auth-choice <provider>-api-key` (the schema-robust canonical path the in-file comment already flags). Kept out of scope to keep this fix minimal.
