### PR TITLE
fix: route google through OpenAI-compat endpoint so Gemini runs on 2026.6.8

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -36,7 +36,7 @@ import {
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_CURATED_MODELS, OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
-import { isValidModelId, isCatalogProvider } from "@/lib/provider-models";
+import { isValidModelId, isCatalogProvider, GOOGLE_MODELS } from "@/lib/provider-models";
 import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
 
 const OPENCLAW_BIN = findOpenclawBin();
@@ -404,6 +404,7 @@ export async function POST(request: Request) {
     const isLlamaCpp = provider === "llamacpp";
     const isClawAI = provider === "clawai";
     const isOpenRouter = provider === "openrouter";
+    const isGoogle = provider === "google";
     const isLocalScope = scope === "local";
     if (!provider || (!normalizedApiKey && !isOllama && !isLlamaCpp && !isClawAI)) {
       return NextResponse.json(
@@ -880,6 +881,38 @@ export async function POST(request: Request) {
       }
       await ensureFallbackModel(config.defaultModel);
       console.log(`[AI Config] Set openrouter provider in openclaw.json: default=${defaultModelId}`);
+    } else if (isGoogle) {
+      // OpenClaw's native google plugin REGISTERS Gemini models but its auth
+      // fails at call time on 2026.6.8 — runs fall back with reason=auth and the
+      // chat silently answers as the fallback model. Route google through
+      // Google's OpenAI-compatible endpoint with the key inline: the same proven
+      // openai-completions path used for openrouter above, so the gateway
+      // actually authenticates the call. Seed with GOOGLE_MODELS (the picker's
+      // curated list) plus the user's pick; the chat-header switch in
+      // /setup-api/chat/model auto-extends this array for any other Gemini id.
+      const defaultModelId = config.defaultModel.replace(/^google\//, "");
+      const modelIds = new Set<string>([
+        defaultModelId,
+        ...GOOGLE_MODELS.map((option) => option.id),
+      ]);
+      const providerDef = JSON.stringify({
+        baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+        api: "openai-completions",
+        apiKey: normalizedApiKey,
+        models: Array.from(modelIds).map((id) => ({ id, name: id })),
+      });
+      await runCommand(OPENCLAW_BIN, [
+        "config", "set", "models.providers.google", providerDef, "--json",
+      ]);
+      try {
+        await runCommand(OPENCLAW_BIN, [
+          "config", "set", "models.mode", "merge",
+        ]);
+      } catch {
+        // Non-fatal: merge is the default behavior anyway
+      }
+      await ensureFallbackModel(config.defaultModel);
+      console.log(`[AI Config] Set google provider (openai-compat) in openclaw.json: default=${defaultModelId}`);
     } else {
       // Switching away from Ollama/ClawBox AI — reset models.mode so cloud providers
       // auto-detect their model catalog normally.

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -341,7 +341,19 @@ export async function POST(request: Request) {
         // ai-models/configure).
         if (parsed.provider === "openrouter" || parsed.provider === "google") {
           const providerId = parsed.provider;
-          const openclawConfig = await readConfig().catch(() => ({} as OpenClawConfig));
+          let openclawConfig: OpenClawConfig;
+          try {
+            openclawConfig = await readConfig();
+          } catch (err) {
+            // Don't fall back to an empty config: existingModels would be [] and
+            // we'd overwrite models.providers.<p>.models with ONLY the new id,
+            // dropping every other configured model. Fail loud instead.
+            console.error(`[chat/model] readConfig failed during ${providerId} auto-extend:`, err);
+            return NextResponse.json(
+              { error: `Could not read the model configuration to register ${requestedModel}. Please try again.` },
+              { status: 500 },
+            );
+          }
           const providerDef = openclawConfig.models?.providers?.[providerId] as
             | { models?: { id?: string; name?: string }[] }
             | undefined;

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -330,51 +330,47 @@ export async function POST(request: Request) {
         if (!providerConfigured) {
           return NextResponse.json({ error: "Selected AI provider is not configured" }, { status: 400 });
         }
-        // OpenRouter quirk: OpenClaw needs the chosen model to be listed
-        // in `models.providers.openrouter.models`, otherwise the gateway
-        // silently falls back to local with no error message the user can
-        // see. Previously we'd fail-fast here when the slug wasn't in the
-        // configured list — now we auto-extend instead, since the chat
-        // header pulls from the live OpenRouter catalog (340+ models)
-        // and forcing a "Re-save in Settings" round trip on every fresh
-        // pick is hostile UX. Other providers (anthropic/openai/google)
-        // have built-in catalogs in OpenClaw so this dance is OpenRouter-
-        // only.
-        if (parsed.provider === "openrouter") {
+        // OpenAI-compatible providers (openrouter, google) need the chosen
+        // model listed in `models.providers.<p>.models`, otherwise the gateway
+        // silently falls back with no error the user can see. The chat header
+        // pulls from the live catalog, so instead of forcing a "Re-save in
+        // Settings" round trip on every fresh pick we auto-extend the configured
+        // list. clawai/anthropic/openai/codex use OpenClaw's built-in catalogs,
+        // so this is openai-completions-provider-only — google qualifies because
+        // ClawBox routes it through Google's OpenAI-compat endpoint (see
+        // ai-models/configure).
+        if (parsed.provider === "openrouter" || parsed.provider === "google") {
+          const providerId = parsed.provider;
           const openclawConfig = await readConfig().catch(() => ({} as OpenClawConfig));
-          const providerDef = openclawConfig.models?.providers?.openrouter as
+          const providerDef = openclawConfig.models?.providers?.[providerId] as
             | { models?: { id?: string; name?: string }[] }
             | undefined;
           const existingModels = providerDef?.models ?? [];
           const configuredIds = existingModels
             .map((m) => m?.id)
             .filter((id): id is string => typeof id === "string" && id.length > 0);
-          // Append whenever the requested slug isn't already there — even
-          // for a freshly-configured provider with an empty models[]. The
-          // earlier `configuredIds.length > 0` guard caused the gateway to
-          // silently fall back to local on the first chat-header switch
-          // after a clean openrouter setup, because the seed providerDef
-          // has only the user's chosen default and any other slug would
-          // be skipped by the guard.
+          // Append whenever the requested slug isn't already there — even for a
+          // freshly-configured provider whose seed providerDef has only the
+          // user's chosen default (the earlier `length > 0` guard silently fell
+          // back to local on the first switch after a clean setup).
           if (!configuredIds.includes(parsed.modelId)) {
-            // Append + persist. We emit only `id`+`name` because OpenClaw
-            // looks the rest (contextWindow, modalities, cost) up from
-            // its bundled provider catalog by id.
+            // Emit only `id`+`name`; OpenClaw looks the rest (contextWindow,
+            // modalities, cost) up from its bundled provider catalog by id.
             const nextModels = [
               ...existingModels,
               { id: parsed.modelId, name: parsed.modelId },
             ];
             try {
               await runOpenclawConfigSet([
-                "models.providers.openrouter.models",
+                `models.providers.${providerId}.models`,
                 JSON.stringify(nextModels),
                 "--json",
               ]);
             } catch (err) {
-              console.error("[chat/model] auto-extend openrouter providerDef failed:", err);
+              console.error(`[chat/model] auto-extend ${providerId} providerDef failed:`, err);
               return NextResponse.json(
                 {
-                  error: `Could not register ${requestedModel} with the OpenRouter provider. Re-save OpenRouter in Settings to refresh the model list.`,
+                  error: `Could not register ${requestedModel} with the ${labelForProvider(providerId, providerId)} provider. Re-save it in Settings to refresh the model list.`,
                 },
                 { status: 502 },
               );

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -78,8 +78,15 @@ export const CODEX_MODELS: readonly ProviderModelOption[] = [
   { id: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "Fast, cheap." },
 ] as const;
 
+// Unlike the other picker lists, GOOGLE_MODELS is ALSO the seed for
+// models.providers.google.models (ai-models/configure routes google through
+// Google's OpenAI-compat endpoint), so each id here is selectable AND runnable
+// — not just picker cold-start. Keep to current stable flagships; live
+// /v1beta/models discovery will eventually own the full list.
 export const GOOGLE_MODELS: readonly ProviderModelOption[] = [
   { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", hint: "Default. Best price-performance." },
+  { id: "gemini-3.5-flash", label: "Gemini 3.5 Flash", hint: "Newest flagship." },
+  { id: "gemini-3.1-flash-lite", label: "Gemini 3.1 Flash-Lite", hint: "Frontier-class, low cost." },
   { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash-Lite", hint: "Fastest, budget-friendly." },
   { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", hint: "Complex reasoning." },
 ] as const;

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -794,6 +794,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     const modelIds = providerDef.models?.map((m: { id: string }) => m.id) ?? [];
     expect(modelIds).toContain("gemini-2.5-flash");
     expect(modelIds).toContain("gemini-3.5-flash");
+    expect(modelIds).toContain("gemini-3.1-flash-lite");
 
     // ...and the managed auth profile is api_key with the inline key.
     const writtenContent = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -770,4 +770,35 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(400);
     expect(body.error).toMatch(/Invalid OpenRouter model ID/);
   });
+
+  it("configures google as an openai-compat provider with the key inline", async () => {
+    // OpenClaw's native google plugin fails auth at call time on 2026.6.8, so
+    // ClawBox routes google through Google's OpenAI-compatible endpoint with the
+    // key inline (the proven openai-completions path) rather than the plugin.
+    const res = await configurePost(jsonRequest({
+      provider: "google",
+      apiKey: "AIzaTestKey123",
+    }));
+    expect(res.status).toBe(200);
+
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands.some((command) => command.includes("config set models.providers.google"))).toBe(true);
+    expect(commands).toContain("config set agents.defaults.model.primary google/gemini-2.5-flash");
+
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.google");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    expect(providerDef.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta/openai");
+    expect(providerDef.api).toBe("openai-completions");
+    // Real key inlined (the fix) — not delegated to the native plugin.
+    expect(providerDef.apiKey).toBe("AIzaTestKey123");
+    const modelIds = providerDef.models?.map((m: { id: string }) => m.id) ?? [];
+    expect(modelIds).toContain("gemini-2.5-flash");
+    expect(modelIds).toContain("gemini-3.5-flash");
+
+    // ...and the managed auth profile is api_key with the inline key.
+    const writtenContent = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(writtenContent.profiles["google:default"]).toEqual(
+      expect.objectContaining({ type: "api_key", provider: "google", key: "AIzaTestKey123" })
+    );
+  });
 });


### PR DESCRIPTION
## Problem

On OpenClaw **2026.6.8**, Gemini chats register fine but **fail auth at call time** and silently fall back to the fallback model:

```
[model-fallback/decision] requested=google/gemini-2.5-flash ... reason=auth
Model Fallback: deepseek/deepseek-v4-flash (selected google/gemini-2.5-flash; auth)
```

OpenClaw's **native google plugin** doesn't apply the API key on the actual call — even with a valid `api_key` auth profile (which #214 already fixed). This is a *distinct* failure from the 401 #214 addressed.

## Fix

Configure **google the same way ClawBox already handles OpenRouter**: an `openai-completions` provider pointed at Google's **`/v1beta/openai`** endpoint with the key **inline**, so the gateway authenticates the call itself instead of going through the broken native-plugin path.

- **`configure/route.ts`** — add an `isGoogle` branch writing `models.providers.google` (openai-compat, inline key, seeded from `GOOGLE_MODELS`), mirroring `isOpenRouter`.
- **`chat/model/route.ts`** — generalize the `models.providers.<p>.models` auto-extend from openrouter-only to **openrouter + google** (google is now an openai-completions provider, so a picked model not in the seed needs registering — the exact same quirk). The old "google has a built-in catalog" comment is corrected.
- **`provider-models.ts`** — add `gemini-3.5-flash` + `gemini-3.1-flash-lite` to `GOOGLE_MODELS` (now load-bearing: it seeds the provider, documented inline).

## Verification

- **End-to-end on device** (Jetson, OpenClaw 2026.6.8): applied this exact config shape by hand → every Gemini model (2.5-flash/-lite/-pro, 3.1-flash-lite, 3.5-flash) resolves and runs, **no auth fallback**. Both Google's native `:generateContent` and `/v1beta/openai/chat/completions` return 200 for the key.
- Unit test added: google configure writes the openai-compat provider with the inline key + `api_key` auth profile + the seeded models.

## Follow-ups (not this PR)

- The `isOpenRouter` / `isGoogle` blocks are now near-identical; extract a `writeOpenAICompatProvider()` helper when a 3rd openai-compat provider lands (deferred — `/simplify` agreed 2 instances is borderline).
- Live Google `/v1beta/models` discovery (deferred) should eventually own the hardcoded `GOOGLE_MODELS` flagships.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google as a supported AI model provider with OpenAI-compatible integration
  * Enabled automatic model list expansion for Google when using unconfigured models
  * Added new Gemini flash models to the default model options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->