### PR TITLE
fix: route anthropic through OpenAI-compat endpoint (+ extract shared helper)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -36,7 +36,7 @@ import {
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_CURATED_MODELS, OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
-import { isValidModelId, isCatalogProvider, GOOGLE_MODELS } from "@/lib/provider-models";
+import { isValidModelId, isCatalogProvider, GOOGLE_MODELS, ANTHROPIC_MODELS, extractProviderModelId } from "@/lib/provider-models";
 import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
 
 const OPENCLAW_BIN = findOpenclawBin();
@@ -377,6 +377,50 @@ async function ensureFallbackModel(
   }
 }
 
+// Configure a provider through its OpenAI-compatible endpoint with the key
+// inline, instead of OpenClaw's native plugin. On 2026.6.8 the gateway sends
+// models.providers.<p>.apiKey verbatim and authenticates the call itself —
+// the only path that works for these providers: openrouter has no native
+// adapter at all, while google/anthropic native plugins read a per-agent
+// sqlite auth store that ClawBox's file-based auth profile doesn't populate
+// (so they 401 / "No API key found" at call time).
+//
+// The `models` array drives resolution, so we seed the curated picker list +
+// the user's pick; the chat-header switch (/setup-api/chat/model) auto-extends
+// it for any other id, so we don't bake in the provider's full churny
+// catalogue. We emit only id+name — contextWindow/modalities/cost are looked up
+// from OpenClaw's catalog per id (a uniform cap here lied for every model whose
+// real spec differed).
+async function writeOpenAICompatProvider(opts: {
+  provider: string;
+  baseUrl: string;
+  apiKey: string;
+  defaultModel: string; // fully-qualified, e.g. "anthropic/claude-opus-4-8"
+  curatedModels: readonly { id: string }[];
+}): Promise<void> {
+  const defaultModelId =
+    extractProviderModelId(opts.defaultModel, opts.provider) ?? opts.defaultModel;
+  const modelIds = new Set<string>([
+    defaultModelId,
+    ...opts.curatedModels.map((m) => m.id),
+  ]);
+  const providerDef = JSON.stringify({
+    baseUrl: opts.baseUrl,
+    api: "openai-completions",
+    apiKey: opts.apiKey,
+    models: Array.from(modelIds).map((id) => ({ id, name: id })),
+  });
+  await runCommand(OPENCLAW_BIN, [
+    "config", "set", `models.providers.${opts.provider}`, providerDef, "--json",
+  ]);
+  try {
+    await runCommand(OPENCLAW_BIN, ["config", "set", "models.mode", "merge"]);
+  } catch {
+    // Non-fatal: merge is the default behavior anyway
+  }
+  await ensureFallbackModel(opts.defaultModel);
+}
+
 export async function POST(request: Request) {
   try {
     let body: {
@@ -405,6 +449,7 @@ export async function POST(request: Request) {
     const isClawAI = provider === "clawai";
     const isOpenRouter = provider === "openrouter";
     const isGoogle = provider === "google";
+    const isAnthropic = provider === "anthropic";
     const isLocalScope = scope === "local";
     if (!provider || (!normalizedApiKey && !isOllama && !isLlamaCpp && !isClawAI)) {
       return NextResponse.json(
@@ -831,88 +876,41 @@ export async function POST(request: Request) {
       await ensureFallbackModel(shouldPromoteLocalToPrimary ? config.defaultModel : (isLocalScope ? null : config.defaultModel), config.defaultModel);
       console.log(`[AI Config] Set llama.cpp provider in openclaw.json: ${modelName} (context=${llamaCppContextWindow}, mode=replace)`);
     } else if (isOpenRouter) {
-      // OpenClaw has no built-in provider adapter for OpenRouter the way it
-      // does for openai / anthropic / google, so without this explicit
-      // provider definition the runtime has no baseUrl to call — the chat
-      // turn silently returns `usage: 0/0/0` and the UI appears dead.
-      // Writing this entry restores the full OpenAI-compatible path.
-      //
-      // The `models` array drives model resolution: OpenClaw needs every
-      // selectable id present here, otherwise mid-conversation switches
-      // (curated or custom) fail silently because the runtime can't
-      // resolve the new slug. We seed with the user-picked id plus a
-      // tiny static fallback (cold-start coverage). The chat-header
-      // model switch in /setup-api/chat/model auto-extends this array
-      // when the user picks a model that isn't already in it, so we
-      // don't need to bake in OpenRouter's full 340+ catalogue at save
-      // time — that catalogue churns and the seed-everything strategy
-      // bit us four times during the original PR.
-      //
-      // We intentionally emit only `id` + `name`. contextWindow,
-      // maxTokens, input modalities and cost are looked up from
-      // OpenClaw's bundled provider catalog per model id — the previous
-      // uniform 131K/8K caps lied for every model whose real spec
-      // differed (Kimi K2 256K, GPT-5 400K, Claude Haiku 200K, etc.),
-      // triggering compaction far too early and silently truncating
-      // long outputs on capable models.
-      const defaultModelId = config.defaultModel.replace(/^openrouter\//, "");
-      const modelIds = new Set<string>([
-        defaultModelId,
-        ...OPENROUTER_CURATED_MODELS.map((option) => option.id),
-      ]);
-      const providerDef = JSON.stringify({
+      // OpenRouter has no native OpenClaw adapter, so without this explicit
+      // provider entry the chat turn silently returns usage 0/0/0.
+      await writeOpenAICompatProvider({
+        provider: "openrouter",
         baseUrl: "https://openrouter.ai/api/v1",
-        api: "openai-completions",
-        // Inline the real key (was the placeholder "openrouter-ref"): 2026.6.8
-        // sends models.providers.*.apiKey verbatim, so a ref-placeholder 401s.
-        // Mirrors the clawai/deepseek providerDefs. See the auth-profile note above.
         apiKey: normalizedApiKey,
-        models: Array.from(modelIds).map((id) => ({ id, name: id })),
+        defaultModel: config.defaultModel,
+        curatedModels: OPENROUTER_CURATED_MODELS,
       });
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.providers.openrouter", providerDef, "--json",
-      ]);
-      try {
-        await runCommand(OPENCLAW_BIN, [
-          "config", "set", "models.mode", "merge",
-        ]);
-      } catch {
-        // Non-fatal: merge is the default behavior anyway
-      }
-      await ensureFallbackModel(config.defaultModel);
-      console.log(`[AI Config] Set openrouter provider in openclaw.json: default=${defaultModelId}`);
+      console.log(`[AI Config] Set openrouter provider (openai-compat): ${config.defaultModel}`);
     } else if (isGoogle) {
-      // OpenClaw's native google plugin REGISTERS Gemini models but its auth
-      // fails at call time on 2026.6.8 — runs fall back with reason=auth and the
-      // chat silently answers as the fallback model. Route google through
-      // Google's OpenAI-compatible endpoint with the key inline: the same proven
-      // openai-completions path used for openrouter above, so the gateway
-      // actually authenticates the call. Seed with GOOGLE_MODELS (the picker's
-      // curated list) plus the user's pick; the chat-header switch in
-      // /setup-api/chat/model auto-extends this array for any other Gemini id.
-      const defaultModelId = config.defaultModel.replace(/^google\//, "");
-      const modelIds = new Set<string>([
-        defaultModelId,
-        ...GOOGLE_MODELS.map((option) => option.id),
-      ]);
-      const providerDef = JSON.stringify({
+      // Native google plugin registers Gemini models but its 2026.6.8 auth
+      // fails at call time (runs fall back with reason=auth). Route through
+      // Google's OpenAI-compat endpoint instead.
+      await writeOpenAICompatProvider({
+        provider: "google",
         baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
-        api: "openai-completions",
         apiKey: normalizedApiKey,
-        models: Array.from(modelIds).map((id) => ({ id, name: id })),
+        defaultModel: config.defaultModel,
+        curatedModels: GOOGLE_MODELS,
       });
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.providers.google", providerDef, "--json",
-      ]);
-      try {
-        await runCommand(OPENCLAW_BIN, [
-          "config", "set", "models.mode", "merge",
-        ]);
-      } catch {
-        // Non-fatal: merge is the default behavior anyway
-      }
-      await ensureFallbackModel(config.defaultModel);
-      console.log(`[AI Config] Set google provider (openai-compat) in openclaw.json: default=${defaultModelId}`);
+      console.log(`[AI Config] Set google provider (openai-compat): ${config.defaultModel}`);
+    } else if (isAnthropic) {
+      // Native anthropic plugin reads a per-agent sqlite auth store that
+      // ClawBox's file auth profile doesn't populate, so it fails with
+      // "No API key found" at call time. Route through Anthropic's OpenAI-compat
+      // endpoint with the key inline instead.
+      await writeOpenAICompatProvider({
+        provider: "anthropic",
+        baseUrl: "https://api.anthropic.com/v1",
+        apiKey: normalizedApiKey,
+        defaultModel: config.defaultModel,
+        curatedModels: ANTHROPIC_MODELS,
+      });
+      console.log(`[AI Config] Set anthropic provider (openai-compat): ${config.defaultModel}`);
     } else {
       // Switching away from Ollama/ClawBox AI — reset models.mode so cloud providers
       // auto-detect their model catalog normally.

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -359,9 +359,19 @@ export async function POST(request: Request) {
             );
           }
           const providerDef = openclawConfig.models?.providers?.[providerId] as
-            | { models?: { id?: string; name?: string }[] }
+            | { models?: { id?: string; name?: string }[]; apiKey?: string }
             | undefined;
-          const existingModels = providerDef?.models ?? [];
+          // The reroute (ai-models/configure) writes baseUrl/api/apiKey alongside
+          // models. If the inline key is missing (legacy or half-written state),
+          // appending only `.models` would leave a provider that can't
+          // authenticate — make the user re-save rather than switch onto it.
+          if (!providerDef?.apiKey) {
+            return NextResponse.json(
+              { error: `${labelForProvider(providerId, providerId)} isn't fully configured. Re-save it in Settings, then pick the model again.` },
+              { status: 409 },
+            );
+          }
+          const existingModels = providerDef.models ?? [];
           const configuredIds = existingModels
             .map((m) => m?.id)
             .filter((id): id is string => typeof id === "string" && id.length > 0);

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -359,13 +359,14 @@ export async function POST(request: Request) {
             );
           }
           const providerDef = openclawConfig.models?.providers?.[providerId] as
-            | { models?: { id?: string; name?: string }[]; apiKey?: string }
+            | { models?: { id?: string; name?: string }[]; apiKey?: string; baseUrl?: string; api?: string }
             | undefined;
-          // The reroute (ai-models/configure) writes baseUrl/api/apiKey alongside
-          // models. If the inline key is missing (legacy or half-written state),
-          // appending only `.models` would leave a provider that can't
-          // authenticate — make the user re-save rather than switch onto it.
-          if (!providerDef?.apiKey) {
+          // The reroute (ai-models/configure) writes baseUrl + api + apiKey
+          // alongside models. If the endpoint, api type, or inline key is missing
+          // (legacy or half-written state), appending only `.models` would leave
+          // a provider that can't authenticate — make the user re-save rather
+          // than switch the primary onto an incomplete provider.
+          if (!providerDef?.apiKey || !providerDef?.baseUrl || !providerDef?.api) {
             return NextResponse.json(
               { error: `${labelForProvider(providerId, providerId)} isn't fully configured. Re-save it in Settings, then pick the model again.` },
               { status: 409 },

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -47,6 +47,11 @@ const PROVIDER_LABELS: Record<string, string> = {
 };
 
 const PROVIDER_ORDER = ["clawai", "openai", "anthropic", "google", "openrouter"] as const;
+// Providers ClawBox configures as explicit openai-completions entries (see
+// ai-models/configure). Their `models.providers.<p>.models` list must contain
+// the chosen id or the gateway silently falls back, so the chat-header switch
+// below auto-extends that list when a freshly-picked model isn't seeded.
+const OPENAI_COMPAT_PROVIDERS = new Set<string>(["openrouter", "google", "anthropic"]);
 // Imported from `@/lib/clawbox-ai-models` so this fallback can't drift away
 // from the configure route's tier→model mapping. Used only when a legacy
 // install has no explicit `models.providers.deepseek.models` entry; new
@@ -330,16 +335,15 @@ export async function POST(request: Request) {
         if (!providerConfigured) {
           return NextResponse.json({ error: "Selected AI provider is not configured" }, { status: 400 });
         }
-        // OpenAI-compatible providers (openrouter, google) need the chosen
-        // model listed in `models.providers.<p>.models`, otherwise the gateway
-        // silently falls back with no error the user can see. The chat header
-        // pulls from the live catalog, so instead of forcing a "Re-save in
-        // Settings" round trip on every fresh pick we auto-extend the configured
-        // list. clawai/anthropic/openai/codex use OpenClaw's built-in catalogs,
-        // so this is openai-completions-provider-only — google qualifies because
-        // ClawBox routes it through Google's OpenAI-compat endpoint (see
-        // ai-models/configure).
-        if (parsed.provider === "openrouter" || parsed.provider === "google") {
+        // OpenAI-compat providers (OPENAI_COMPAT_PROVIDERS: openrouter, google,
+        // anthropic — ClawBox routes them through their OpenAI-compatible
+        // endpoints, see ai-models/configure) need the chosen model listed in
+        // `models.providers.<p>.models`, otherwise the gateway silently falls
+        // back with no error the user can see. The chat header pulls from the
+        // live catalog, so instead of forcing a "Re-save in Settings" round trip
+        // on every fresh pick we auto-extend the configured list. clawai/openai/
+        // codex use OpenClaw's built-in catalogs, so they don't need this.
+        if (OPENAI_COMPAT_PROVIDERS.has(parsed.provider)) {
           const providerId = parsed.provider;
           let openclawConfig: OpenClawConfig;
           try {

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -830,4 +830,23 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect.objectContaining({ type: "api_key", provider: "anthropic", key: "sk-ant-test123" })
     );
   });
+
+  it("seeds a user-picked non-curated model into the provider entry", async () => {
+    // claude-opus-4-8 is newer than ANTHROPIC_MODELS — the helper must still
+    // seed the user's pick (via defaultModel) so the gateway can resolve it.
+    const res = await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: "sk-ant-test123",
+      model: "claude-opus-4-8",
+    }));
+    expect(res.status).toBe(200);
+
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.anthropic");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const modelIds = providerDef.models?.map((m: { id: string }) => m.id) ?? [];
+    expect(modelIds).toContain("claude-opus-4-8");
+
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-opus-4-8");
+  });
 });

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -802,4 +802,32 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect.objectContaining({ type: "api_key", provider: "google", key: "AIzaTestKey123" })
     );
   });
+
+  it("configures anthropic as an openai-compat provider with the key inline", async () => {
+    // Native anthropic plugin reads a per-agent sqlite auth store ClawBox
+    // doesn't populate ("No API key found" at call time), so route it through
+    // Anthropic's OpenAI-compatible endpoint with the key inline.
+    const res = await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: "sk-ant-test123",
+    }));
+    expect(res.status).toBe(200);
+
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands.some((command) => command.includes("config set models.providers.anthropic"))).toBe(true);
+    expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-sonnet-4-6");
+
+    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.anthropic");
+    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    expect(providerDef.baseUrl).toBe("https://api.anthropic.com/v1");
+    expect(providerDef.api).toBe("openai-completions");
+    expect(providerDef.apiKey).toBe("sk-ant-test123");
+    const modelIds = providerDef.models?.map((m: { id: string }) => m.id) ?? [];
+    expect(modelIds).toContain("claude-sonnet-4-6");
+
+    const writtenContent = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(writtenContent.profiles["anthropic:default"]).toEqual(
+      expect.objectContaining({ type: "api_key", provider: "anthropic", key: "sk-ant-test123" })
+    );
+  });
 });

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -334,6 +334,16 @@ describe("/setup-api/chat/model", () => {
             "openrouter:default": { provider: "openrouter", mode: "token" },
           },
         },
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.ai/api/v1",
+              api: "openai-completions",
+              apiKey: "sk-or-v1-test",
+              models: [{ id: "anthropic/claude-haiku-4-5", name: "anthropic/claude-haiku-4-5" }],
+            },
+          },
+        },
         agents: {
           defaults: {
             model: {
@@ -348,6 +358,16 @@ describe("/setup-api/chat/model", () => {
             "openrouter:default": { provider: "openrouter", mode: "token" },
           },
         },
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.ai/api/v1",
+              api: "openai-completions",
+              apiKey: "sk-or-v1-test",
+              models: [{ id: "anthropic/claude-haiku-4-5", name: "anthropic/claude-haiku-4-5" }],
+            },
+          },
+        },
         agents: {
           defaults: {
             model: {
@@ -360,6 +380,16 @@ describe("/setup-api/chat/model", () => {
         auth: {
           profiles: {
             "openrouter:default": { provider: "openrouter", mode: "token" },
+          },
+        },
+        models: {
+          providers: {
+            openrouter: {
+              baseUrl: "https://openrouter.ai/api/v1",
+              api: "openai-completions",
+              apiKey: "sk-or-v1-test",
+              models: [{ id: "anthropic/claude-haiku-4-5", name: "anthropic/claude-haiku-4-5" }],
+            },
           },
         },
         agents: {


### PR DESCRIPTION
## Problem

On OpenClaw **2026.6.8**, Anthropic chats fail with:

```
ProviderAuthError: No API key found for provider "anthropic".
Auth store: …/agents/main/agent/openclaw-agent.sqlite … | missing-provider-auth
```

6.8 added a **per-agent sqlite auth store**, and the native anthropic plugin reads auth from *there* — but ClawBox writes a file-based auth profile, which doesn't get loaded into it. So even with a valid `api_key` profile (#214), the call fails "No API key found" at runtime. Same *class* as the google bug (#215), different symptom.

## Fix

Route anthropic through **Anthropic's OpenAI-compatible endpoint** (`api.anthropic.com/v1`) with the key **inline**, exactly like google/openrouter — the gateway then authenticates the call itself.

Since this is the **third** openai-compat provider, also extracted the shared **`writeOpenAICompatProvider()`** helper (flagged on #215) and refactored openrouter + google onto it. The chat/model auto-extend gates on a shared `OPENAI_COMPAT_PROVIDERS` set.

- `configure/route.ts`: `writeOpenAICompatProvider()` helper; openrouter/google/anthropic branches use it.
- `chat/model/route.ts`: auto-extend now covers anthropic via the shared set.
- `/simplify` applied: helper reuses the tested `extractProviderModelId`; dropped a redundant guard; corrected a now-wrong comment.

### Why not openai-direct?

openai-direct (API-key) has the same root cause, but is **intentionally not rerouted**: it's untested (Codex/oauth is the common path) and OpenAI's native `/responses` + reasoning-effort behavior could degrade under a plain openai-completions shim. Separate follow-up if anyone hits it.

## Verification

- **On device** (OpenClaw 2026.6.8): `api.anthropic.com/v1/chat/completions` returns 200 + a real reply for `claude-opus-4-8`; the rerouted provider resolves and runs every Claude model, no auth fallback.
- Unit test added (anthropic → openai-compat provider with inline key + `api_key` profile).

## Follow-up (not this PR)

`/simplify` (reuse + altitude) flagged that "which providers are openai-compat" lives in two places (the configure branches + the chat/model set). A single-source-of-truth record (collapsing the three branches into one data-driven branch) is the clean fix — deferred here to keep the diff's blast radius small.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Anthropic provider can now be configured during the initial setup process.
  * Anthropic is now included in automatic model list management, matching the behavior of other compatible providers.

* **Tests**
  * Added test coverage for Anthropic provider configuration, including API key management and model selection verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->