### PR TITLE
fix: address CodeRabbit review on the 3.1.4 release (#217)

### DIFF
--- a/docs/superpowers/specs/2026-06-16-telegram-pairing-design.md
+++ b/docs/superpowers/specs/2026-06-16-telegram-pairing-design.md
@@ -52,7 +52,13 @@ No revoke (no native CLI for it; out of scope).
 **`src/components/SettingsApp.tsx`** — a "User access" card under the Telegram
 section (only when a bot is configured): approved-users list (loads with status),
 a paste-a-code field, and an opt-in "Check for requests" button that loads pending
-requests with one-click approve. No auto-poll (the list CLI is slow).
+requests with one-click approve. The card itself does not auto-poll — the pending
+CLI is slow, so it only runs on the explicit "Check for requests" click.
+
+**`src/app/page.tsx`** — a desktop notification popup so new pairing requests
+surface even when Settings is closed. It polls `GET …?poll=1` (the fast
+file-read path, not the slow CLI) every 20s, de-dups already-seen/dismissed
+requests via localStorage, and offers inline Approve / Open-in-Settings / Dismiss.
 
 **`src/lib/translations.ts`** — `settings.pairing*` keys across all 10 locales.
 

--- a/mcp/clawbox-cli.ts
+++ b/mcp/clawbox-cli.ts
@@ -331,6 +331,13 @@ async function main() {
     // terminal so you can watch each step and see exactly where it fails.
     // Requires root, so it shells out via sudo.
     const projectRoot = process.env.CLAWBOX_ROOT || "/home/clawbox/clawbox";
+    // Validate CLAWBOX_ROOT against the same SAFE_PATH guard as
+    // scripts/force-update.sh + updater.ts — a malicious env value would
+    // otherwise let `sudo bash` run an attacker-controlled script.
+    if (!/^[A-Za-z0-9._/-]+$/.test(projectRoot)) {
+      console.error(`Invalid CLAWBOX_ROOT '${projectRoot}' (allowed: A-Z a-z 0-9 . _ / -)`);
+      process.exit(1);
+    }
     const installScript = join(projectRoot, "install.sh");
     if (!existsSync(installScript)) {
       console.error(`install.sh not found at ${installScript} — set CLAWBOX_ROOT to your ClawBox checkout.`);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1784,6 +1784,7 @@ function ChromeDesktopInner() {
                     {req.id && <div className="text-[11px] text-white/40 font-mono mt-0.5 truncate">id {req.id}</div>}
                   </div>
                   <button
+                    type="button"
                     onClick={() => dismissPairingRequest(code)}
                     className="pointer-events-auto w-7 h-7 flex items-center justify-center rounded-md text-white/40 hover:text-white hover:bg-white/10 transition-colors shrink-0 bg-transparent border-none cursor-pointer"
                     aria-label="Dismiss"
@@ -1793,6 +1794,7 @@ function ChromeDesktopInner() {
                 </div>
                 <div className="pointer-events-auto flex items-center gap-2 px-4 pb-3">
                   <button
+                    type="button"
                     onClick={() => approvePairingRequest(code)}
                     disabled={!code || approvingPairCode === code}
                     className="flex-1 px-3 py-1.5 rounded-md bg-[#229ED9] hover:bg-[#1b87ba] disabled:opacity-50 disabled:cursor-not-allowed text-white text-xs font-semibold transition-colors cursor-pointer border-none inline-flex items-center justify-center gap-1.5"
@@ -1801,6 +1803,7 @@ function ChromeDesktopInner() {
                     Approve
                   </button>
                   <button
+                    type="button"
                     onClick={openTelegramPairingSettings}
                     className="px-3 py-1.5 rounded-md bg-white/5 hover:bg-white/10 text-white/70 text-xs font-medium transition-colors cursor-pointer border-none"
                   >

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -2333,7 +2333,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               currentModel={localAiStatus?.model ?? null}
               title="Set Up Local AI"
               description={localAiStatus?.configured
-                ? "Choose a different local engine if you want to switch your on-device fallback."
+                ? "Gemma 4 is configured as your private on-device fallback."
                 : "Turn on a local model so ClawBox always has a private on-device backup."}
               configureScope="local"
               testId="settings-local-ai-step"
@@ -2455,6 +2455,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     onChange={(e) => { setTgPairingCode(e.target.value.toUpperCase()); setTgPairingStatus(null); }}
                     onKeyDown={(e) => { if (e.key === "Enter" && !tgApproving) approvePairingCode(tgPairingCode); }}
                     placeholder={t("settings.pairingCodePlaceholder")}
+                    aria-label={t("settings.pairingCodePlaceholder")}
                     maxLength={8}
                     spellCheck={false}
                     autoCapitalize="characters"


### PR DESCRIPTION
CodeRabbit's review comments on the beta→main release PR #217. Small, self-contained follow-ups (no behavior change to the provider-auth fixes themselves).

- **cli** (`mcp/clawbox-cli.ts`): validate `CLAWBOX_ROOT` against a safe-path charset before `sudo bash install.sh`, mirroring the `SAFE_PATH` guard in `force-update.sh` / `updater.ts`. Blocks a tampered env from pointing the privileged install at an attacker-controlled script.
- **a11y** (`SettingsApp.tsx`, `page.tsx`): `aria-label` on the pairing-code input; `type="button"` on the three desktop pairing-popup buttons.
- **copy** (`SettingsApp.tsx`): the Local AI Settings card no longer says "choose a different local engine" — Gemma 4 has been the only local engine since #206.
- **docs** (`telegram-pairing-design.md`): document the desktop popup and its 20s `?poll=1` polling; the spec previously said "no auto-poll".

**Skipped** (one CodeRabbit note): the `chat-model.test` fixture `mode:"token"` suggestion — the chat/model route gates on `models.providers.*.apiKey`, not the auth-profile `mode`, so that fixture field is inert; changing it wouldn't exercise anything.