### PR TITLE
chore: add Code of Conduct, Security policy, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
         can — versions and logs make bugs far faster to fix.
 
         ⚠️ **Do not report security vulnerabilities here.** See our
-        [Security Policy](../security/policy) for private reporting.
+        [Security Policy](https://github.com/ID-Robots/clawbox/security/policy) for private reporting.
   - type: textarea
     id: what-happened
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Something in ClawBox isn't working as expected
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a report. Please fill in as much as you
+        can — versions and logs make bugs far faster to fix.
+
+        ⚠️ **Do not report security vulnerabilities here.** See our
+        [Security Policy](../security/policy) for private reporting.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug and what you expected instead.
+      placeholder: When I tap Update in the portal, the gateway keeps the old version…
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can a maintainer reproduce this?
+      placeholder: |
+        1. Open Settings → System Update
+        2. Tap Update
+        3. …
+    validations:
+      required: true
+  - type: input
+    id: clawbox-version
+    attributes:
+      label: ClawBox version
+      description: Settings → System (or the footer of the setup wizard).
+      placeholder: "3.1.4"
+    validations:
+      required: true
+  - type: input
+    id: openclaw-version
+    attributes:
+      label: OpenClaw version
+      description: Shown in Settings → System, or run `openclaw --version`.
+      placeholder: "2026.6.8"
+    validations:
+      required: false
+  - type: input
+    id: hardware
+    attributes:
+      label: Jetson model / JetPack
+      description: Which device and JetPack/L4T version.
+      placeholder: "Jetson Orin Nano, JetPack 6.2"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and screenshots
+      description: |
+        Relevant output — e.g. `journalctl -u clawbox-gateway -n 200`,
+        `journalctl -u clawbox-setup -n 200`, or the installer output.
+        **Redact tokens, passwords, and device IPs.**
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: OpenClaw Hardware
+    url: https://openclawhardware.dev/
+    about: Product information, setup guides, and documentation for the device.
+  - name: Security vulnerability
+    url: https://github.com/ID-Robots/clawbox/security/policy
+    about: Please report security issues privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest an idea or improvement for ClawBox
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion! Tell us the problem first — it helps us find the
+        best solution, which may differ from the one you have in mind.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do, and where does ClawBox get in the way?
+      placeholder: I want to manage updates from the command line, but there's no…
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to see happen?
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any workarounds you currently use, or other approaches you weighed.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — mockups, links, related issues.
+    validations:
+      required: false

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at krasi@idrobots.com. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+ClawBox is the operating system for [OpenClaw Hardware](https://openclawhardware.dev/),
+running on NVIDIA Jetson. Because it manages WiFi, system credentials, OAuth tokens,
+and the on-device AI agent, we take security reports seriously.
+
+## Supported Versions
+
+Only the latest release line receives security fixes. Devices update in place via
+**Settings → System Update** or `sudo clawbox update`, so we ask everyone to stay current.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release (3.1.x) | ✅ |
+| Older releases | ❌ — please update first |
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security problems.**
+
+Report privately using **GitHub's private vulnerability reporting**:
+the repository **Security** tab → **Report a vulnerability**. This keeps the report
+confidential between you and the maintainers until a fix is available.
+
+If private reporting is unavailable, email **krasi@idrobots.com** instead. Encrypt
+or omit sensitive details (tokens, device IPs) and we will arrange a secure channel.
+
+Please include, where you can:
+
+- ClawBox and OpenClaw versions (Settings → System), and Jetson/JetPack model
+- A description of the issue and its impact
+- Steps to reproduce or a proof of concept
+- Any logs or screenshots (with secrets redacted)
+
+### What to expect
+
+- **Acknowledgement** within 3 business days.
+- An initial assessment and severity triage within 7 days.
+- Progress updates until the issue is resolved, and credit in the release notes
+  once a fix ships (unless you prefer to stay anonymous).
+
+Thank you for helping keep ClawBox devices and their owners safe.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ Report privately using **GitHub's private vulnerability reporting**:
 the repository **Security** tab → **Report a vulnerability**. This keeps the report
 confidential between you and the maintainers until a fix is available.
 
-If private reporting is unavailable, email **krasi@idrobots.com** instead. Encrypt
+If private reporting is unavailable, email **yanko@idrobots.com** instead. Encrypt
 or omit sensitive details (tokens, device IPs) and we will arrange a secure channel.
 
 Please include, where you can:


### PR DESCRIPTION
Closes the gaps in GitHub's **Community Standards** checklist (currently 62% on `main`). Three of the four missing items are files; this PR adds all three.

### Added
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, enforcement contact `krasi@idrobots.com`.
- **`SECURITY.md`** — private-reporting-first policy (Security tab → *Report a vulnerability*) with an email fallback and a supported-versions table.
- **`.github/ISSUE_TEMPLATE/`** — `bug_report.yml` (prompts for ClawBox/OpenClaw/JetPack versions + logs), `feature_request.yml`, and `config.yml` (disables blank issues, links the security policy).

### Two manual follow-ups (settings, not files — can't be committed)
1. **Enable Private vulnerability reporting**: Settings → *Code security* → *Private vulnerability reporting* → **Enable**. The API toggle is org-admin-only (I got a 404), so it needs a maintainer. Until then, `SECURITY.md`'s email fallback still works.
2. **"Repository admins accept content reports"** (the 4th checklist item): Settings → *Moderation options* — a UI toggle, no file involved.

### Note
These count toward the checklist only on the **default branch (`main`)**, so the badge stays at 62% until this rides the next beta → main release. Targeting `beta` per the usual flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Code of Conduct defining community standards, behavior expectations, and enforcement process
  * Added Security Policy with vulnerability reporting instructions and supported version information

* **Chores**
  * Introduced GitHub issue templates for structured bug reports and feature requests
  * Updated issue template configuration with support and security contact links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->