### PR TITLE
docs(readme): point marketing/website links to clawbox.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://openclawhardware.dev"><img alt="Website" src="https://img.shields.io/badge/🌐_Website-openclawhardware.dev-orange?style=flat-square" /></a>
+  <a href="https://clawbox.tech"><img alt="Website" src="https://img.shields.io/badge/🌐_Website-clawbox.tech-orange?style=flat-square" /></a>
   <a href="https://discord.gg/FbKmnxYnpq"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join_Community-5865F2?style=flat-square&logo=discord&logoColor=white" /></a>
   <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-Source_Available-blue?style=flat-square" /></a>
   <img alt="Platform" src="https://img.shields.io/badge/platform-NVIDIA_Jetson-76b900?style=flat-square&logo=nvidia" />
@@ -26,7 +26,7 @@
 
 ## What is ClawBox?
 
-ClawBox is **OpenClaw OS** — the operating system for [OpenClaw Hardware](https://openclawhardware.dev/), a private AI assistant running on NVIDIA Jetson (Tegra/ARM). Unlike cloud AI, your data never leaves your device. It manages the full device lifecycle: broadcasts a WiFi access point for first-boot setup from any phone/laptop, transitions to the home network, then serves a Chrome OS-style desktop environment with built-in apps.
+ClawBox is **OpenClaw OS** — the operating system for [OpenClaw Hardware](https://clawbox.tech/), a private AI assistant running on NVIDIA Jetson (Tegra/ARM). Unlike cloud AI, your data never leaves your device. It manages the full device lifecycle: broadcasts a WiFi access point for first-boot setup from any phone/laptop, transitions to the home network, then serves a Chrome OS-style desktop environment with built-in apps.
 
 The OpenClaw AI agent controls the entire device through MCP (Model Context Protocol) tools — making ClawBox an OS the AI can operate, not just a UI the user clicks through.
 
@@ -292,21 +292,21 @@ bun run test             # Unit tests (Vitest)
 
 ## 🌍 Community & Links
 
-- **🌐 Website:** [openclawhardware.dev](https://openclawhardware.dev)
+- **🌐 Website:** [clawbox.tech](https://clawbox.tech)
 - **💬 Discord:** [discord.gg/FbKmnxYnpq](https://discord.gg/FbKmnxYnpq)
-- **📖 Docs:** [openclawhardware.dev/docs](https://openclawhardware.dev/docs)
-- **🛒 Buy ClawBox:** [openclawhardware.dev](https://openclawhardware.dev)
+- **📖 Docs:** [docs.clawbox.tech](https://docs.clawbox.tech)
+- **🛒 Buy ClawBox:** [clawbox.tech](https://clawbox.tech)
 - **🤖 Powered by:** [OpenClaw](https://github.com/openclaw/openclaw)
 
 ---
 
 ## 📄 License
 
-ClawBox is released under the [ClawBox Source Available License v1.0](LICENSE). Free to use, modify, and redistribute for **personal, non-commercial purposes**. Commercial use requires a separate license from [IDRobots Ltd.](https://openclawhardware.dev/) — contact yanko@idrobots.com.
+ClawBox is released under the [ClawBox Source Available License v1.0](LICENSE). Free to use, modify, and redistribute for **personal, non-commercial purposes**. Commercial use requires a separate license from [IDRobots Ltd.](https://clawbox.tech/) — contact yanko@idrobots.com.
 
 ---
 
 <p align="center">
-  <a href="https://openclawhardware.dev/">openclawhardware.dev</a><br/>
+  <a href="https://clawbox.tech/">clawbox.tech</a><br/>
   Built with ❤️ by <a href="https://github.com/ID-Robots">ID Robots</a> in the EU 🇪🇺 — source available
 </p>


### PR DESCRIPTION
Updates README website links per the domain migration (clawbox.tech is the marketing domain).

## Changed → clawbox.tech
- Website badge (header)
- "OpenClaw Hardware" intro link
- Community & Links → **Website** + **Buy ClawBox**
- License → IDRobots Ltd. link
- Footer link

## Docs
- **Docs** link → `docs.clawbox.tech` (the live docs site)

## Intentionally left on openclawhardware.dev
- **App Store** skill-source line (line ~134) — functional store backend used by fielded devices (`/store` stays per migration). Say the word if you want this moved too.

## Note (not changed)
- Discord invite is still the old `FbKmnxYnpq`; current invite is `ztJGcfbRBU` — can update in a follow-up if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all documentation links and references from openclawhardware.dev to clawbox.tech, including website badge, community resources, documentation and purchase links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->