### PR TITLE
feat(update): surface 'updates paused' for diverged devices + one-click reset to channel

### DIFF
--- a/src/app/setup-api/update/reset/route.ts
+++ b/src/app/setup-api/update/reset/route.ts
@@ -1,0 +1,22 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { forceResetToChannel } from "@/lib/updater";
+
+/**
+ * "Reset to channel & update" — for a device stranded on a non-release branch
+ * with local commits, where the normal update is silently withheld. Pins
+ * `.update-branch` to the channel and runs the update (whose hard-sync discards
+ * the local commits). DESTRUCTIVE; the UI confirms before calling this.
+ */
+export async function POST() {
+  try {
+    const result = await forceResetToChannel();
+    return NextResponse.json(result);
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to reset to channel" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -8,6 +8,9 @@ import { cleanVersion } from "@/lib/version-utils";
 interface VersionInfo {
   clawbox: { current: string; target: string | null };
   openclaw: { current: string | null; target: string | null };
+  diverged?: boolean;
+  pausedReason?: string | null;
+  channel?: string;
 }
 
 interface BranchInfo {
@@ -39,7 +42,7 @@ function isUpdateAvailable(current: string | null | undefined, target: string | 
   return compareSemver(target, current) > 0;
 }
 
-type Status = "loading" | "up-to-date" | "available" | "updating" | "completed" | "failed" | "fetch-error";
+type Status = "loading" | "up-to-date" | "available" | "paused" | "updating" | "completed" | "failed" | "fetch-error";
 
 function StepIcon({ status }: { status: StepStatus }) {
   if (status === "completed") {
@@ -81,6 +84,7 @@ export default function SystemUpdateApp() {
   const [branchSaving, setBranchSaving] = useState(false);
   const [branchError, setBranchError] = useState<string | null>(null);
   const [betaConfirm, setBetaConfirm] = useState(false);
+  const [resetConfirm, setResetConfirm] = useState(false);
 
   const pollRef = useRef<number | null>(null);
   const pollControllerRef = useRef<AbortController | null>(null);
@@ -224,6 +228,27 @@ export default function SystemUpdateApp() {
     }
   }, [startPolling]);
 
+  // "Reset to channel & update" — for a device stranded on a non-release branch.
+  // The backend pins .update-branch to the channel and runs the normal update,
+  // whose hard-sync discards the local commits. Destructive → gated by a modal.
+  const resetAndUpdate = useCallback(async () => {
+    setResetConfirm(false);
+    setUpdateStarted(true);
+    setUpdateError(null);
+    setUpdateState(null);
+    try {
+      const res = await fetch("/setup-api/update/reset", { method: "POST" });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setUpdateError(typeof data.error === "string" ? data.error : `Failed to reset (HTTP ${res.status})`);
+        return;
+      }
+      startPolling();
+    } catch (err) {
+      setUpdateError(err instanceof Error ? err.message : "Failed to reset to channel");
+    }
+  }, [startPolling]);
+
   const dismissResult = useCallback(() => {
     setUpdateStarted(false);
     setUpdateError(null);
@@ -259,6 +284,9 @@ export default function SystemUpdateApp() {
     }
     if (versionsError && !versions) return "fetch-error";
     if (!versions) return "loading";
+    // Local commits the channel lacks make the backend withhold the offer;
+    // surface that instead of a misleading "up to date".
+    if (versions.diverged) return "paused";
     // Only ClawBox drives availability now — OpenClaw is bumped as part
     // of the ClawBox update, so an OpenClaw-pin delta without a ClawBox
     // delta means a ClawBox release hasn't been cut yet and there's
@@ -300,6 +328,13 @@ export default function SystemUpdateApp() {
           tone: "available" as const,
         };
       }
+      case "paused":
+        return {
+          icon: "pause_circle", iconClass: "text-amber-300",
+          headline: "Updates paused",
+          subhead: versions?.pausedReason ?? "Updates are paused while this device has local changes.",
+          tone: "warn" as const,
+        };
       case "updating":
         return {
           icon: "downloading", iconClass: "text-orange-300",
@@ -333,6 +368,7 @@ export default function SystemUpdateApp() {
   }[hero.tone];
 
   const clawboxAvail = !!versions && isUpdateAvailable(versions.clawbox.current, versions.clawbox.target);
+  const resetChannel = versions?.channel ?? "main";
 
   return (
     <div className="relative h-full w-full overflow-y-auto bg-[var(--bg-app)] text-gray-200">
@@ -389,6 +425,26 @@ export default function SystemUpdateApp() {
               </div>
             )}
 
+            {status === "paused" && (
+              <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setResetConfirm(true)}
+                  className="px-6 py-2.5 rounded-full bg-amber-500 hover:bg-amber-400 text-black text-sm font-semibold shadow-lg cursor-pointer"
+                >
+                  Reset to {resetChannel} &amp; update
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void fetchVersions(true)}
+                  disabled={refreshing}
+                  className="px-6 py-2.5 rounded-full border border-white/15 bg-white/[0.04] text-sm font-semibold text-gray-200 hover:bg-white/[0.08] disabled:opacity-50 cursor-pointer"
+                >
+                  {refreshing ? "Checking…" : "Re-check"}
+                </button>
+              </div>
+            )}
+
             {status === "fetch-error" && (
               <button
                 type="button"
@@ -410,7 +466,7 @@ export default function SystemUpdateApp() {
               whatever was last published to npm, which is what we just
               moved away from. The OpenClaw version is still shown in the
               ClawBox card's release notes / version-info section. */}
-          {versions && status !== "updating" && status !== "completed" && status !== "failed" && (
+          {versions && status !== "updating" && status !== "completed" && status !== "failed" && status !== "paused" && (
             <div className="grid grid-cols-1 gap-3">
               <ComponentCard
                 name="ClawBox"
@@ -551,6 +607,50 @@ export default function SystemUpdateApp() {
                 className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
               >
                 Enable beta
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {resetConfirm && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="reset-confirm-title"
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+          onClick={() => setResetConfirm(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-white/10 bg-[var(--bg-deep)] shadow-2xl overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 px-5 pt-5">
+              <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-amber-500/15 text-amber-300">
+                <span className="material-symbols-rounded" style={{ fontSize: 22 }}>warning</span>
+              </div>
+              <h2 id="reset-confirm-title" className="text-base font-semibold text-gray-100">Reset to {resetChannel} &amp; update?</h2>
+            </div>
+            <div className="px-5 pt-3 pb-4 text-sm leading-relaxed text-[var(--text-secondary)]">
+              <p>
+                This device has local changes that aren&apos;t on <code className="bg-black/30 px-1 rounded">{resetChannel}</code>. Resetting <strong>discards those local commits</strong>, syncs the device to <code className="bg-black/30 px-1 rounded">{resetChannel}</code>, then updates and reboots. Your settings, files, and AI/Telegram config are kept — they live outside the code.
+              </p>
+            </div>
+            <div className="flex justify-end gap-2 px-5 pb-5 pt-2 border-t border-white/5">
+              <button
+                type="button"
+                onClick={() => setResetConfirm(false)}
+                className="px-4 py-2 rounded-lg text-sm font-medium border border-white/10 text-gray-200 hover:bg-white/5 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                autoFocus
+                onClick={() => void resetAndUpdate()}
+                className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
+              >
+                Reset &amp; update
               </button>
             </div>
           </div>

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,6 +1,6 @@
 import { exec as execCb, execFile as execFileCb } from "child_process";
 import { promisify } from "util";
-import { readFile } from "fs/promises";
+import { readFile, writeFile } from "fs/promises";
 import path from "path";
 import { get, set, setMany } from "./config-store";
 import { findOpenclawBin, restartGateway } from "./openclaw-config";
@@ -229,6 +229,59 @@ async function resolveUpdateBranch(gitCmd: string): Promise<ResolvedBranch> {
   return main;
 }
 
+/**
+ * The release channel the device should track: the `.update-branch` pin, else
+ * "main". Unlike resolveUpdateBranch this deliberately IGNORES the current
+ * branch — a diverged box's current branch is exactly what "Reset to channel"
+ * escapes from, so we must not let it win here.
+ */
+async function resolveChannelBranch(): Promise<string> {
+  try {
+    const pinned = (await readFile(UPDATE_BRANCH_FILE, "utf-8")).trim();
+    if (pinned && SAFE_BRANCH.test(pinned)) return pinned;
+  } catch { /* no pin → default channel */ }
+  return "main";
+}
+
+export interface Divergence {
+  diverged: boolean;
+  reason: string | null;
+  /** The channel a "Reset to channel & update" would target (the pin, else main). */
+  channel: string;
+}
+
+/**
+ * Detect when the device has local commits the release channel lacks — the case
+ * that makes `getTargetVersion` silently withhold the update (it never offers a
+ * tag that isn't a forward-ancestor of HEAD, so a diverged box looks identical
+ * to an up-to-date one). Requires `ahead > 0 && behind > 0`: a box merely AHEAD
+ * of the channel (e.g. a dev box on a local tag) has nothing newer to install,
+ * so we don't nag it to reset. Relies on the `fetch` getTargetVersion already
+ * ran in the same getVersionInfo() pass, so it adds no network I/O of its own.
+ */
+async function getChannelDivergence(): Promise<Divergence> {
+  const channel = await resolveChannelBranch();
+  const gitCmd = `git -c safe.directory=${PROJECT_DIR} -C ${PROJECT_DIR}`;
+  try {
+    // One walk for both counts: `--left-right --count A...B` prints
+    // "<left>\t<right>" = "<behind>\t<ahead>" (left = commits only on the
+    // channel, right = commits only on HEAD).
+    const out = (await execShell(
+      `${gitCmd} rev-list --left-right --count origin/${channel}...HEAD`,
+      { timeout: 10_000 },
+    )).stdout.trim();
+    const [behind, ahead] = out.split(/\s+/).map((n) => Number(n) || 0);
+    if (ahead > 0 && behind > 0) {
+      return {
+        diverged: true,
+        reason: `This device is on a non-release branch with local changes (${ahead} commit${ahead === 1 ? "" : "s"} ahead of ${channel}). Reset to ${channel} to resume updates.`,
+        channel,
+      };
+    }
+  } catch { /* origin/<channel> missing, offline, etc. → treat as not diverged */ }
+  return { diverged: false, reason: null, channel };
+}
+
 async function updateClawBoxAndReboot(): Promise<void> {
   // Fix .git ownership — previous root operations (install.sh) may have
   // created root-owned files (e.g. FETCH_HEAD) that block git pull as clawbox.
@@ -415,6 +468,12 @@ const CLAWBOX_PKG = path.join(PROJECT_DIR, "package.json");
 interface VersionInfo {
   clawbox: { current: string; target: string | null };
   openclaw: { current: string | null; target: string | null };
+  /** True when local commits keep the release channel's updates from being
+   *  offered (the silent "up to date" trap); `pausedReason` explains it. */
+  diverged: boolean;
+  pausedReason: string | null;
+  /** The channel a "Reset to channel & update" would target (the pin, else main). */
+  channel: string;
 }
 
 let cachedVersionInfo: VersionInfo | null = null;
@@ -512,6 +571,12 @@ export async function getVersionInfo(): Promise<VersionInfo> {
     ? targetVersion
     : null;
 
+  // Surface the "updates paused" state. MUST run after the Promise.all above —
+  // not inside it — so getTargetVersion's fetch has already refreshed
+  // origin/<channel>; reordering it earlier would read a stale ref. Adds no
+  // fetch of its own.
+  const divergence = await getChannelDivergence();
+
   cachedVersionInfo = {
     clawbox: {
       current: rawVersion,
@@ -521,6 +586,9 @@ export async function getVersionInfo(): Promise<VersionInfo> {
       current: openclawCurrent,
       target: openclawTarget && openclawCurrent && openclawCurrent.includes(openclawTarget) ? null : openclawTarget,
     },
+    diverged: divergence.diverged,
+    pausedReason: divergence.reason,
+    channel: divergence.channel,
   };
   versionInfoCacheTime = Date.now();
   return cachedVersionInfo;
@@ -689,6 +757,22 @@ export function startUpdate(): { started: boolean; error?: string } {
 
   launchUpdate(UPDATE_STEPS, 0, { markCompleted: true });
   return { started: true };
+}
+
+/**
+ * "Reset to channel & update": pin `.update-branch` to the release channel
+ * (the existing pin, else "main") so the hard-sync in updateClawBoxAndReboot
+ * targets the channel instead of the diverged current branch, then run the
+ * normal update. The pin also stops the device silently re-diverging later.
+ *
+ * DESTRUCTIVE: the update's `git reset --hard origin/<channel>` discards local
+ * commits/changes — the UI gates this behind a confirmation.
+ */
+export async function forceResetToChannel(): Promise<{ started: boolean; error?: string; channel: string }> {
+  const channel = await resolveChannelBranch();
+  await writeFile(UPDATE_BRANCH_FILE, channel, "utf-8");
+  invalidateVersionCache();
+  return { ...startUpdate(), channel };
 }
 
 // Scoped update path: re-installs OpenClaw + re-applies the gateway patch

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -530,5 +530,39 @@ describe("updater", () => {
       expect(info.clawbox.target).toBe(null);
       expect(info.openclaw.current).toBe(null);
     });
+
+    it("reports diverged when HEAD has local commits the channel lacks", async () => {
+      setupExecMock({
+        "ls-remote": { stdout: "abc\trefs/tags/v2.0.0\n", stderr: "" },
+        // `rev-list --left-right --count origin/main...HEAD` -> "<behind>\t<ahead>"
+        "origin/main...HEAD": { stdout: "18\t3\n", stderr: "" }, // behind 18, ahead 3
+      });
+      setupExecFileMock({ openclaw: { stdout: "1.0.0", stderr: "" } });
+
+      vi.resetModules();
+      mockReadFile.mockRejectedValue(new Error("ENOENT")); // no .update-branch -> channel = main
+      const freshUpdater = await import("@/lib/updater");
+
+      const info = await freshUpdater.getVersionInfo();
+      expect(info.diverged).toBe(true);
+      expect(info.channel).toBe("main");
+      expect(info.pausedReason).toContain("3 commits ahead of main");
+    });
+
+    it("is not diverged when HEAD is merely behind (a normal update) or ahead-only", async () => {
+      setupExecMock({
+        "ls-remote": { stdout: "abc\trefs/tags/v2.0.0\n", stderr: "" },
+        "origin/main...HEAD": { stdout: "5\t0\n", stderr: "" }, // behind 5, ahead 0 -> normal
+      });
+      setupExecFileMock({ openclaw: { stdout: "1.0.0", stderr: "" } });
+
+      vi.resetModules();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      const freshUpdater = await import("@/lib/updater");
+
+      const info = await freshUpdater.getVersionInfo();
+      expect(info.diverged).toBe(false);
+      expect(info.pausedReason).toBe(null);
+    });
   });
 });


### PR DESCRIPTION
## Why

A device on a non-release branch with local commits gets **every update silently withheld**: `getTargetVersion` only offers a release tag that's a forward-ancestor of HEAD, so a diverged HEAD returns `null` → the System Update screen shows **"You're up to date" forever** and the device never receives fixes. We hit this three times — two dev boxes (georgi, the telegram-pairing box on `clawbox.local`) and the same trap can catch a **customer box whose on-box AI agent commits to the repo**. The box looks current and silently stops updating.

## What

- **`updater.ts`**
  - `getChannelDivergence()` — detects local commits the release channel lacks (`ahead > 0 && behind > 0`, via a single `git rev-list --left-right --count origin/<channel>...HEAD`). Requires `behind > 0` so a box merely *ahead* of the channel (a dev box on a local tag, nothing newer to install) isn't nagged. Reuses the `fetch` `getTargetVersion` already ran — no extra network I/O.
  - `getVersionInfo` now returns `diverged` / `pausedReason` / `channel`.
  - `forceResetToChannel()` — pins `.update-branch` to the channel (the pin, else `main`; deliberately **not** the current branch) so the existing hard-sync targets the channel and discards the diverged commits, then runs the normal update. The pin also stops the device re-diverging silently.
- **`POST /setup-api/update/reset`** — thin route over `forceResetToChannel`.
- **`SystemUpdateApp.tsx`** — a `paused` state replaces the misleading "up to date" hero with the reason + a **"Reset to `<channel>` & update"** button, gated behind a **confirm modal** (it's destructive — discards local commits). The "CURRENT" card is hidden while paused. The channel shown is the backend's `versions.channel` (single source of truth, can't drift from what the reset targets).
- **Unit tests** for divergence detection (diverged vs behind-only/ahead-only).

## Notes / verification
- `bash`/type-level: this is plain TS; the new logic is covered by the unit tests added here — **CI runs typecheck + vitest**. I'll watch CI + CodeRabbit and fix anything red before merge.
- Reuses the existing, battle-tested update path (`startUpdate` → `updateClawBoxAndReboot`); the reset's `reset --hard origin/<channel>` is the same hard-sync used today.
- Closes the silent-no-update gap for georgi, the telegram box, and any agent-modified customer box.