### PR TITLE
fix(openai): self-heal stale openai/* primary → codex when subscription is active

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -208,6 +208,27 @@ if has_openrouter_auth and not models_providers.get("openrouter"):
     }
     changed = True
 
+# Migration: a device that switched OpenAI from API-key mode to the ChatGPT
+# subscription but whose agent stayed pinned to the dead openai/* lane — the
+# "Mark Spivey" class. The primary openai/<model> keeps calling api.openai.com
+# with a now-invalid sk-proj key (401 every turn) while the working subscription
+# (codex) sits unused. If a codex OAuth profile is configured (subscription
+# active), repoint the primary to codex/<same-model> and drop the stale openai
+# direct-API provider + profile + openai/* fallbacks so the dead key can't win.
+has_codex_auth = isinstance(auth_profiles, dict) and "codex:default" in auth_profiles
+agents_model = cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("model", {})
+primary = agents_model.get("primary")
+if has_codex_auth and isinstance(primary, str) and primary.startswith("openai/"):
+    model_id = primary[len("openai/"):]
+    agents_model["primary"] = "codex/" + model_id
+    models_providers.pop("openai", None)
+    auth_profiles.pop("openai:default", None)
+    fb = agents_model.get("fallbacks")
+    if isinstance(fb, list):
+        agents_model["fallbacks"] = [m for m in fb if not (isinstance(m, str) and m.startswith("openai/"))]
+    changed = True
+    print("  Migrated stale openai/" + model_id + " primary -> codex/" + model_id + " (codex subscription active)")
+
 gateway = cfg.setdefault("gateway", {})
 control_ui = gateway.setdefault("controlUi", {})
 auth = gateway.setdefault("auth", {})

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -209,25 +209,31 @@ if has_openrouter_auth and not models_providers.get("openrouter"):
     changed = True
 
 # Migration: a device that switched OpenAI from API-key mode to the ChatGPT
-# subscription but whose agent stayed pinned to the dead openai/* lane — the
-# "Mark Spivey" class. The primary openai/<model> keeps calling api.openai.com
-# with a now-invalid sk-proj key (401 every turn) while the working subscription
-# (codex) sits unused. If a codex OAuth profile is configured (subscription
-# active), repoint the primary to codex/<same-model> and drop the stale openai
-# direct-API provider + profile + openai/* fallbacks so the dead key can't win.
+# subscription but whose agent stayed pinned to the dead openai/* lane. The
+# primary openai/<model> keeps calling api.openai.com with a now-invalid
+# sk-proj key (401 every turn) while the working subscription (codex) sits
+# unused. If a codex OAuth profile is configured (subscription active), repoint
+# the primary to the codex equivalent and drop the stale openai direct-API
+# provider + profile + openai/* fallbacks so the dead key can't win.
+# openai-direct and codex have DIFFERENT catalogs (gpt-5 is openai-only,
+# gpt-5.4 is codex-only), so keep the model id only when codex actually serves
+# it; otherwise fall back to codex's default. Keep CODEX_MODELS in sync with
+# src/lib/provider-models.ts (ChatGPT-account auth: gpt-5.5, gpt-5.4, gpt-5.4-mini).
+CODEX_MODELS = ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini")
 has_codex_auth = isinstance(auth_profiles, dict) and "codex:default" in auth_profiles
 agents_model = cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("model", {})
 primary = agents_model.get("primary")
 if has_codex_auth and isinstance(primary, str) and primary.startswith("openai/"):
     model_id = primary[len("openai/"):]
-    agents_model["primary"] = "codex/" + model_id
+    target_model = model_id if model_id in CODEX_MODELS else "gpt-5.4"
+    agents_model["primary"] = "codex/" + target_model
     models_providers.pop("openai", None)
     auth_profiles.pop("openai:default", None)
     fb = agents_model.get("fallbacks")
     if isinstance(fb, list):
         agents_model["fallbacks"] = [m for m in fb if not (isinstance(m, str) and m.startswith("openai/"))]
     changed = True
-    print("  Migrated stale openai/" + model_id + " primary -> codex/" + model_id + " (codex subscription active)")
+    print("  Migrated stale openai/" + model_id + " primary -> codex/" + target_model + " (codex subscription active)")
 
 gateway = cfg.setdefault("gateway", {})
 control_ui = gateway.setdefault("controlUi", {})


### PR DESCRIPTION
## The "Mark Spivey" class (real customer, this week)

A device set up OpenAI in **API-key mode**, then switched to the **ChatGPT subscription** — but the agent's primary stayed pinned to **`openai/<model>`**. That lane calls `api.openai.com` with the now-invalid `sk-proj` key and **401s every turn**, while the working subscription (`codex`) sits unused. The customer only recovered by manually driving the on-box agent to rewrite the config.

**#222 (codex-home self-heal) couldn't fix this** — the `openai` *direct* lane is keyed separately (`models.providers.openai.apiKey`), which #222 never touches.

## Fix (gateway-pre-start, on every boot)

If a **`codex` OAuth profile** is configured (subscription active) but the primary is **`openai/*`**, migrate it:
- repoint primary `openai/<m>` → `codex/<m>`
- drop the stale `models.providers.openai` (the dead key)
- drop `auth.profiles.openai:default`
- strip any `openai/*` entries from `agents.defaults.model.fallbacks` (e.g. the bogus `openai/gpt-5.3-codex`)

Because it runs on the gateway restart that follows **any** provider save, it covers both the wizard switch *and* the agent-driven path that bit Mark.

## Why no separate configure-route change
I scoped a wizard-side purge too, but it's redundant: a wizard subscription save already sets primary `codex/*` and restarts the gateway, so this self-heal runs anyway. The only thing a wizard purge would add is removing a *harmless, unused* leftover provider — not worth a separate auth-core edit.

## Validation
Logic validated on a **real Jetson (georgi, python3)** with a synthetic harness:
- ✅ Mark's case → `openai/gpt-5.4` → `codex/gpt-5.4`; `openai` provider/profile purged (`deepseek` kept); bad fallback dropped (`clawbox-ai/free` kept)
- ✅ no-subscription box → untouched (no false migration)
- ✅ already on `codex` → no-op

`bash -n` clean. Boot script — CI/`bash -n` cover syntax; the migration logic is the harness above. Real end-to-end needs a Codex account (georgi has none), same caveat as #222.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup migration for devices using a Codex subscription so the app automatically switches to the correct model provider.
  * Removed outdated fallback and authentication settings that could cause startup or connection issues.
  * Helps ensure the app launches with the expected subscription-backed model instead of an invalid legacy route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->