### PR TITLE
chore: bump ClawBox to 3.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {


### PR DESCRIPTION
Version bump for the **v3.1.5** release. Payload accumulated on beta since v3.1.4:

- **#222** codex auth self-heal (API-key→OAuth recovery across all agents)
- **#223** update-honesty: 'Updates paused' + one-click reset for diverged devices
- **#224** openai→codex subscription migration (self-heals the stale openai-direct-key class)
- **#219** community-health files (Code of Conduct, Security policy, issue templates)
- **#221** issue-triage bot (CI)

Merge to beta, then the beta→main release PR ships v3.1.5.