### PR TITLE
fix: address CodeRabbit review on the v3.1.5 beta payload (9 items)

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # The script auths to GitHub via GH_TOKEN only — no need to persist
+          # GITHUB_TOKEN into the runner's git config.
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -30,7 +34,9 @@ jobs:
           node-version: 22
 
       - name: Install Anthropic SDK
-        run: npm install --no-save @anthropic-ai/sdk
+        # Pinned — the script depends on the output_config + messages.create
+        # shapes; a floating latest could shift them. Bump deliberately.
+        run: npm install --no-save @anthropic-ai/sdk@0.106.0
 
       - name: Triage with Claude
         env:

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -220,7 +220,28 @@ if has_openrouter_auth and not models_providers.get("openrouter"):
 # it; otherwise fall back to codex's default. Keep CODEX_MODELS in sync with
 # src/lib/provider-models.ts (ChatGPT-account auth: gpt-5.5, gpt-5.4, gpt-5.4-mini).
 CODEX_MODELS = ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini")
-has_codex_auth = isinstance(auth_profiles, dict) and "codex:default" in auth_profiles
+# Only migrate if the codex subscription is actually USABLE. openclaw.json's
+# auth.profiles holds metadata only (mode/provider) — the OAuth tokens live in
+# the agent's auth-profiles.json. A configured-but-unauthenticated codex profile
+# (no JWT id_token) must NOT trigger the switch, or we'd drop the working openai
+# lane and strand the device. Mirror the JWT gate the codex auth.json synthesis
+# below uses, and accept the legacy openai-codex:default key too.
+def _is_jwt_like(v):
+    if not isinstance(v, str):
+        return False
+    parts = v.split(".")
+    return len(parts) == 3 and all(parts)
+
+has_codex_auth = False
+try:
+    _ap_path = os.path.join(os.path.dirname(cfg_path), "agents", "main", "agent", "auth-profiles.json")
+    with open(_ap_path) as _f:
+        _ap_profiles = (json.load(_f) or {}).get("profiles", {}) or {}
+    _cp = _ap_profiles.get("codex:default") or _ap_profiles.get("openai-codex:default")
+    if isinstance(_cp, dict):
+        has_codex_auth = _is_jwt_like(_cp.get("id") or _cp.get("access"))
+except Exception:
+    pass
 agents_model = cfg.setdefault("agents", {}).setdefault("defaults", {}).setdefault("model", {})
 primary = agents_model.get("primary")
 if has_codex_auth and isinstance(primary, str) and primary.startswith("openai/"):
@@ -521,7 +542,9 @@ try {
   const data = JSON.parse(fs.readFileSync(apPath, "utf8"));
   const profiles = data.profiles || {};
   const p = profiles["codex:default"] || profiles["openai-codex:default"];
-  if (!p || !p.access) { console.log("  Codex auth.json: no codex OAuth profile yet, skipping"); process.exit(0); }
+  // Need the full OAuth set: a partial profile (e.g. missing refresh) yields an
+  // auth.json that survives boot but fails once the access token expires.
+  if (!p || !p.access || !p.refresh) { console.log("  Codex auth.json: no usable codex OAuth profile (need access + refresh), skipping"); process.exit(0); }
   const idToken = p.id || p.access;
   if (!isJwtLike(idToken)) { console.log("  Codex auth.json: profile id_token is not a JWT — skipping (re-auth needed)"); process.exit(0); }
   let accountId = null;
@@ -552,9 +575,13 @@ const isHealthyOAuth = (file) => {
   try {
     const cur = JSON.parse(fs.readFileSync(file, "utf8"));
     const hasKey = typeof cur.OPENAI_API_KEY === "string" && cur.OPENAI_API_KEY.length > 0;
-    const hasJwtIdToken = cur.tokens && isJwtLike(cur.tokens.id_token);
-    return !hasKey && hasJwtIdToken; // OAuth-only with a real JWT -> leave alone; a stale key OR a non-JWT token -> re-heal
-  } catch { return false; } // missing/corrupt -> (re)write
+    const t = cur.tokens || {};
+    const hasAccess = typeof t.access_token === "string" && t.access_token.length > 0;
+    const hasRefresh = typeof t.refresh_token === "string" && t.refresh_token.length > 0;
+    // Healthy only with the FULL OAuth set and no stale key. A partial file
+    // (missing access/refresh) or a stale key OR a non-JWT id_token -> re-heal.
+    return !hasKey && isJwtLike(t.id_token) && hasAccess && hasRefresh;
+  } catch { return false; } // missing/corrupt/partial -> (re)write
 };
 for (const dir of targets) {
   const file = path.join(dir, "auth.json");

--- a/scripts/issue-triage.mjs
+++ b/scripts/issue-triage.mjs
@@ -70,6 +70,11 @@ async function main() {
   const prioColor = t.priority === "high" ? "b60205" : t.priority === "medium" ? "fbca04" : "0e8a16";
   ensure(`priority: ${t.priority}`, prioColor, "Auto-triage priority");
   ensure(`area: ${t.area}`, "c5def5", "Auto-triage area");
+  // `gh issue edit` applies all labels in one call and fails the whole command
+  // if ANY is missing — so the category label must exist too, even though
+  // bug/enhancement/etc. are GitHub defaults (a repo may have deleted them).
+  const catColor = { bug: "d73a4a", enhancement: "a2eeef", documentation: "0075ca", question: "d876e3", invalid: "e4e669" }[t.category] ?? "ededed";
+  ensure(t.category, catColor, "Auto-triage category");
 
   const labels = [t.category, `priority: ${t.priority}`, `area: ${t.area}`];
   gh(["issue", "edit", String(number), "--repo", REPO, ...labels.flatMap((l) => ["--add-label", l])]);

--- a/src/app/setup-api/update/reset/route.ts
+++ b/src/app/setup-api/update/reset/route.ts
@@ -12,6 +12,11 @@ import { forceResetToChannel } from "@/lib/updater";
 export async function POST() {
   try {
     const result = await forceResetToChannel();
+    if (!result.started) {
+      // e.g. an update is already running — don't let clients that check
+      // res.ok treat this as a successful reset.
+      return NextResponse.json(result, { status: 409 });
+    }
     return NextResponse.json(result);
   } catch (err) {
     return NextResponse.json(

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -639,6 +639,7 @@ export default function SystemUpdateApp() {
             <div className="flex justify-end gap-2 px-5 pb-5 pt-2 border-t border-white/5">
               <button
                 type="button"
+                autoFocus
                 onClick={() => setResetConfirm(false)}
                 className="px-4 py-2 rounded-lg text-sm font-medium border border-white/10 text-gray-200 hover:bg-white/5 cursor-pointer"
               >
@@ -646,7 +647,6 @@ export default function SystemUpdateApp() {
               </button>
               <button
                 type="button"
-                autoFocus
                 onClick={() => void resetAndUpdate()}
                 className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
               >

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -770,9 +770,18 @@ export function startUpdate(): { started: boolean; error?: string } {
  */
 export async function forceResetToChannel(): Promise<{ started: boolean; error?: string; channel: string }> {
   const channel = await resolveChannelBranch();
+  // Try to start the update FIRST. If one is already running, startUpdate()
+  // refuses (started: false) — in that case we must not write the channel pin,
+  // or the device stays pinned to the channel for a future update it never
+  // asked for. The pin is only read by the hard-sync step, which runs well
+  // after this write, so persisting it after a successful start is safe.
+  const result = startUpdate();
+  if (!result.started) {
+    return { ...result, channel };
+  }
   await writeFile(UPDATE_BRANCH_FILE, channel, "utf-8");
   invalidateVersionCache();
-  return { ...startUpdate(), channel };
+  return { ...result, channel };
 }
 
 // Scoped update path: re-installs OpenClaw + re-applies the gateway patch

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -549,10 +549,26 @@ describe("updater", () => {
       expect(info.pausedReason).toContain("3 commits ahead of main");
     });
 
-    it("is not diverged when HEAD is merely behind (a normal update) or ahead-only", async () => {
+    it("is not diverged when HEAD is merely behind (a normal update)", async () => {
       setupExecMock({
         "ls-remote": { stdout: "abc\trefs/tags/v2.0.0\n", stderr: "" },
         "origin/main...HEAD": { stdout: "5\t0\n", stderr: "" }, // behind 5, ahead 0 -> normal
+      });
+      setupExecFileMock({ openclaw: { stdout: "1.0.0", stderr: "" } });
+
+      vi.resetModules();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      const freshUpdater = await import("@/lib/updater");
+
+      const info = await freshUpdater.getVersionInfo();
+      expect(info.diverged).toBe(false);
+      expect(info.pausedReason).toBe(null);
+    });
+
+    it("is not diverged when HEAD is ahead-only (local commits, nothing behind)", async () => {
+      setupExecMock({
+        "ls-remote": { stdout: "abc\trefs/tags/v2.0.0\n", stderr: "" },
+        "origin/main...HEAD": { stdout: "0\t3\n", stderr: "" }, // behind 0, ahead 3 -> ahead-only
       });
       setupExecFileMock({ openclaw: { stdout: "1.0.0", stderr: "" } });
 


### PR DESCRIPTION
Implements CodeRabbit's 9 actionable review items from the (now-closed) v3.1.5 release PR #226. These harden the provider-auth + update code already on beta (#221/#222/#223/#224). The release is on hold; this lands the fixes on beta first.

## Fixes
| Area | Fix |
|------|-----|
| **#224** `gateway-pre-start.sh` | Gate the openai→codex migration on a **usable** codex JWT read from `auth-profiles.json` (openclaw.json holds only metadata) — an unauthenticated codex profile can no longer strand the device by dropping the working openai lane. Accepts legacy `openai-codex:default`. |
| **#222** `gateway-pre-start.sh` | Require the **full OAuth set** (access + refresh + JWT id) before writing/preserving codex `auth.json`; a partial file survives boot but fails after token expiry. |
| **#221** `issue-triage.mjs` | Ensure the **category** label exists before applying — `gh issue edit` applies labels atomically and fails the whole command (→ no triage at all) if any is missing. |
| **#221** `issue-triage.yml` | `persist-credentials: false` on checkout; pin `@anthropic-ai/sdk@0.106.0`. |
| **#223** `reset/route.ts` | Return **409** when the reset doesn't start, so `res.ok` clients don't treat it as success (mirrors the sibling `openclaw/route.ts`). |
| **#223** `SystemUpdateApp.tsx` | Move `autoFocus` off the destructive **Reset** button onto **Cancel** — a stray Enter no longer triggers a reset. |
| **#223** `updater.ts` | Only persist the channel pin **after** `startUpdate()` accepts — an already-running update no longer leaves a stale pin. |
| **#223** `updater.test.ts` | Add the **ahead-only** divergence case the test name claimed but didn't cover. |

## Note on the #224 migration-gate fix
CodeRabbit's proposed diff read the codex JWT from `openclaw.json`'s `auth.profiles` — but those hold **metadata only** (`mode`/`provider`); the OAuth tokens live in the agent's `auth-profiles.json` (verified on a real Jetson). Applying it verbatim would make `has_codex_auth` always false → migration never fires. Implemented the **correct** version reading `auth-profiles.json`.

## Validation
- Synthetic harnesses on a real Jetson (georgi, python3): migration gate (JWT→migrate, non-JWT→skip, missing→skip, legacy key→migrate); full-OAuth-set health (guard + healthy/partial/stale-key/non-JWT).
- `bash -n` + python-block compile clean.
- `/simplify`-reviewed (reuse/simplification/efficiency/altitude) — 2 cleanups applied.