### PR TITLE
fix(clawkeep): allow '+' in snapshot names so restore works

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -939,9 +939,7 @@ export async function runRestore(
   // side) but bouncing it early gives the user a clearer error. Accept both
   // the new encrypted form (`.tar.gz.enc`) and the legacy unencrypted one
   // (`.tar.gz`); the daemon detects which is which on its end too.
-  if (!/^[A-Za-z0-9._+-]+\.tar\.gz(\.enc)?$/.test(name)) {
-    throw new ClawKeepError("invalid snapshot name", 400);
-  }
+  assertSnapshotName(name);
   const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
   await setRestoring(true);
   try {

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -840,7 +840,10 @@ export async function syncStateFromCloud(): Promise<void> {
 // hostile/garbled name is bounced with a clean 400 before we shell out — it
 // could never escape the portal-issued prefix anyway, but the early reject is
 // clearer for the user.
-const SNAPSHOT_NAME_RE = /^[A-Za-z0-9._-]+\.tar\.gz(\.enc)?$/;
+// NOTE: names include a `+` from the ISO timestamp's tz offset (e.g.
+// `...57.761+03-00-openclaw-backup.tar.gz.enc`), so `+` must be allowed or
+// every real snapshot is bounced with "invalid snapshot name" on restore.
+const SNAPSHOT_NAME_RE = /^[A-Za-z0-9._+-]+\.tar\.gz(\.enc)?$/;
 
 function assertSnapshotName(name: string): void {
   if (!SNAPSHOT_NAME_RE.test(name)) {
@@ -936,7 +939,7 @@ export async function runRestore(
   // side) but bouncing it early gives the user a clearer error. Accept both
   // the new encrypted form (`.tar.gz.enc`) and the legacy unencrypted one
   // (`.tar.gz`); the daemon detects which is which on its end too.
-  if (!/^[A-Za-z0-9._-]+\.tar\.gz(\.enc)?$/.test(name)) {
+  if (!/^[A-Za-z0-9._+-]+\.tar\.gz(\.enc)?$/.test(name)) {
     throw new ClawKeepError("invalid snapshot name", 400);
   }
   const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;


### PR DESCRIPTION
Isolated, single-file fix (supersedes #233 which accidentally carried unrelated docs commits).

**Bug:** ClawKeep restore fails for every snapshot with `invalid snapshot name`. Names embed the ISO timestamp's tz offset, e.g. `2026-06-22T19-31-57.761+03-00-openclaw-backup.tar.gz.enc` — the `+` was rejected by the name-validator regex (`[A-Za-z0-9._-]`) in both `assertSnapshotName()` and `runRestore()`.

**Fix:** add `+` to both regexes → `[A-Za-z0-9._+-]`. Reported by customer Peter Woodman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot filename validation now accepts `+` characters, preventing valid encrypted snapshot names from being rejected.
  * Restore input validation has been updated to use the shared snapshot name rules while still enforcing the expected `.tar.gz` / optional encrypted archive format.

* **Chores**
  * Bumped package version to **3.1.5**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->