### PR TITLE
docs: Technical Reference tab + deep troubleshooting/recovery + llms.txt

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -42,6 +42,8 @@ jobs:
           # GitHub Pages essentials
           touch _site/.nojekyll
           echo "docs.clawbox.tech" > _site/CNAME
+          # llms.txt — agent-discovery index (mint export doesn't emit one)
+          cp llms.txt _site/llms.txt
           # strip air-gapped helper files
           rm -f "_site/serve.js" "_site/Start Docs.bat" "_site/Start Docs.command"
 

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -91,7 +91,7 @@
             ]
           },
           {
-            "group": "Deep Support",
+            "group": "Support",
             "pages": [
               "support/troubleshooting",
               "support/recovery"

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -58,7 +58,43 @@
             "pages": [
               "support/updating",
               "support/troubleshooting",
+              "support/recovery",
               "support/faq"
+            ]
+          }
+        ]
+      },
+      {
+        "tab": "Technical Reference",
+        "groups": [
+          {
+            "group": "Overview",
+            "pages": [
+              "technical/quick-reference",
+              "technical/architecture"
+            ]
+          },
+          {
+            "group": "Internals",
+            "pages": [
+              "technical/networking",
+              "technical/filesystem",
+              "technical/authentication"
+            ]
+          },
+          {
+            "group": "Systems",
+            "pages": [
+              "technical/ai-providers",
+              "technical/update-system",
+              "technical/agent-interface"
+            ]
+          },
+          {
+            "group": "Deep Support",
+            "pages": [
+              "support/troubleshooting",
+              "support/recovery"
             ]
           }
         ]

--- a/docs-site/guides/messaging-channels.mdx
+++ b/docs-site/guides/messaging-channels.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Messaging Channels"
+icon: "comments"
 summary: "Connect Telegram, WhatsApp, Discord, and other chat apps to your ClawBox."
 ---
 

--- a/docs-site/guides/subscriptions.mdx
+++ b/docs-site/guides/subscriptions.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ClawBox AI Subscriptions"
+icon: "credit-card"
 summary: "Understand ClawBox AI subscription tiers and what support each one includes."
 ---
 

--- a/docs-site/hardware/clawbox-connect.mdx
+++ b/docs-site/hardware/clawbox-connect.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ClawBox Connect"
+icon: "cube"
 summary: "Hardware specifications for ClawBox Connect — the always-on AI assistant box built on NVIDIA Jetson Orin Nano."
 ---
 

--- a/docs-site/hardware/clawbox-workstation.mdx
+++ b/docs-site/hardware/clawbox-workstation.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ClawBox Workstation"
+icon: "server"
 summary: "Hardware specifications for ClawBox Workstation — a personal AI supercomputer built on NVIDIA DGX Spark."
 ---
 

--- a/docs-site/hardware/requirements.mdx
+++ b/docs-site/hardware/requirements.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OpenClaw Hardware Requirements"
+icon: "list-check"
 summary: "Minimum, recommended, and power-user hardware for running OpenClaw — and where ClawBox fits."
 ---
 

--- a/docs-site/hardware/requirements.mdx
+++ b/docs-site/hardware/requirements.mdx
@@ -24,11 +24,11 @@ This page covers what you actually need — from bare minimum to running local A
   </Card>
 </CardGroup>
 
-## Minimum requirements
+## Recommended baseline
 
-- **4 GB RAM** (8 GB recommended)
+- **4 GB RAM** (8 GB recommended; see the tiers below for what runs on less)
 - Modern **x86_64 or ARM64** CPU
-- **Node.js 20+**
+- **Node.js 22+**
 - Always-on internet connection
 - Runs on **Linux, macOS, or Windows**
 

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: "ClawBox"
+icon: "house"
 summary: "ClawBox is pre-configured AI hardware that runs OpenClaw — your own AI assistant, on hardware you own."
 ---
 
@@ -61,7 +62,7 @@ ClawBox is a small, always-on computer that comes with **OpenClaw** pre-installe
     Architecture, networking, auth, updates, and the agent interface — for power users and AI agents.
   </Card>
   <Card title="Troubleshooting & Recovery" href="/support/troubleshooting" icon="wrench">
-    Symptom-first fixes with exact commands, plus ordered recovery options.
+    Symptom-first fixes with exact commands, plus ordered [recovery options](/support/recovery).
   </Card>
 </Columns>
 

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -33,9 +33,7 @@ summary: "ClawBox is pre-configured AI hardware that runs OpenClaw — your own 
 
 ## What is ClawBox?
 
-ClawBox is a small, always-on computer that comes with **OpenClaw** pre-installed — a self-hosted gateway that connects your favorite chat apps to an AI agent. You power it on, run a short setup, and you have a personal AI assistant you can message from anywhere.
-
-**Who is it for?** People who want a private, dedicated AI assistant without renting cloud infrastructure or babysitting a server install.
+A small, always-on computer running **OpenClaw** — a self-hosted gateway that connects your chat apps to an AI agent. It's for people who want a private, dedicated AI assistant without renting cloud infrastructure or babysitting a server install.
 
 **What makes it different?**
 
@@ -69,5 +67,5 @@ ClawBox is a small, always-on computer that comes with **OpenClaw** pre-installe
 ## Need a hand?
 
 <Card title="Talk to support" href="mailto:yanko@idrobots.com" icon="life-ring">
-  Email us or join the community Discord — we'll get you unstuck.
+  Email us or join the [community Discord](https://discord.gg/vsTsaY4Tuk) — we'll get you unstuck.
 </Card>

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -54,6 +54,17 @@ ClawBox is a small, always-on computer that comes with **OpenClaw** pre-installe
   </Card>
 </Columns>
 
+## Going deeper
+
+<Columns cols={2}>
+  <Card title="Technical Reference" href="/technical/quick-reference" icon="book">
+    Architecture, networking, auth, updates, and the agent interface — for power users and AI agents.
+  </Card>
+  <Card title="Troubleshooting & Recovery" href="/support/troubleshooting" icon="wrench">
+    Symptom-first fixes with exact commands, plus ordered recovery options.
+  </Card>
+</Columns>
+
 ## Need a hand?
 
 <Card title="Talk to support" href="mailto:yanko@idrobots.com" icon="life-ring">

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -2,7 +2,7 @@
 
 > ClawBox is pre-configured AI hardware (NVIDIA Jetson) running OpenClaw OS — a self-hosted AI assistant reachable from Telegram and the web. This documentation covers consumer setup, deep technical reference, troubleshooting, and recovery. Site: https://docs.clawbox.tech · Source: https://github.com/ID-Robots/clawbox (docs live in docs-site/, releases are vX.Y.Z tags on main, integration branch is beta).
 
-Key facts: web UI at http://<box-ip> port 80 (never :18789 — that's the loopback gateway); one Linux password (`clawbox` user) for both SSH and browser login; device state in /home/clawbox/clawbox/data and ~/.openclaw (survives updates; wiped by factory reset); updates are git-tag based and reboot the box at the end; provider credentials live in ~/.openclaw/agents/main/agent/auth-profiles.json.
+Key facts: web UI at http://<box-ip> port 80 (never :18789 — that's the token-gated gateway; it loads but rejects passwords); one Linux password (`clawbox` user) for both SSH and browser login; device state in /home/clawbox/clawbox/data and ~/.openclaw (survives updates; wiped by factory reset); updates are git-tag based and reboot the box at the end; provider credentials live in ~/.openclaw/agents/main/agent/auth-profiles.json.
 
 ## Start Here
 
@@ -12,8 +12,8 @@ Key facts: web UI at http://<box-ip> port 80 (never :18789 — that's the loopba
 
 ## Setup
 
-- [First Boot](https://docs.clawbox.tech/setup/first-boot): the on-device setup wizard
-- [Connect to a Network](https://docs.clawbox.tech/setup/connect-network): Wi-Fi/Ethernet, ClawBox-Setup hotspot (10.42.0.1)
+- [First Boot](https://docs.clawbox.tech/setup/first-boot): unbox, connect, pair via QR code — the first-run guide
+- [Connect to a Network](https://docs.clawbox.tech/setup/connect-network): joining Wi-Fi or Ethernet after setup
 - [Choose Your AI Provider](https://docs.clawbox.tech/setup/choose-ai-provider): ClawBox AI, Claude, GPT, Gemini, OpenRouter, local models
 - [OpenClaw Setup](https://docs.clawbox.tech/setup/openclaw-setup): gateway configuration
 

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -1,0 +1,52 @@
+# ClawBox Documentation
+
+> ClawBox is pre-configured AI hardware (NVIDIA Jetson) running OpenClaw OS — a self-hosted AI assistant reachable from Telegram and the web. This documentation covers consumer setup, deep technical reference, troubleshooting, and recovery. Site: https://docs.clawbox.tech · Source: https://github.com/ID-Robots/clawbox (docs live in docs-site/, releases are vX.Y.Z tags on main, integration branch is beta).
+
+Key facts: web UI at http://<box-ip> port 80 (never :18789 — that's the loopback gateway); one Linux password (`clawbox` user) for both SSH and browser login; device state in /home/clawbox/clawbox/data and ~/.openclaw (survives updates; wiped by factory reset); updates are git-tag based and reboot the box at the end; provider credentials live in ~/.openclaw/agents/main/agent/auth-profiles.json.
+
+## Start Here
+
+- [Quick Reference](https://docs.clawbox.tech/technical/quick-reference): the one-page fact sheet — ports, paths, services, commands, endpoints, gotchas. Best single page for agents.
+- [ClawBox Overview](https://docs.clawbox.tech/): what ClawBox is, models, pricing
+- [Quickstart](https://docs.clawbox.tech/quickstart): unbox → power → talk
+
+## Setup
+
+- [First Boot](https://docs.clawbox.tech/setup/first-boot): the on-device setup wizard
+- [Connect to a Network](https://docs.clawbox.tech/setup/connect-network): Wi-Fi/Ethernet, ClawBox-Setup hotspot (10.42.0.1)
+- [Choose Your AI Provider](https://docs.clawbox.tech/setup/choose-ai-provider): ClawBox AI, Claude, GPT, Gemini, OpenRouter, local models
+- [OpenClaw Setup](https://docs.clawbox.tech/setup/openclaw-setup): gateway configuration
+
+## Technical Reference
+
+- [System Architecture](https://docs.clawbox.tech/technical/architecture): service topology, request routing, boot lifecycle, ClawBox↔OpenClaw relationship
+- [Networking](https://docs.clawbox.tech/technical/networking): AP mode, captive portal, mDNS/clawbox.local reliability, full port map
+- [Filesystem Layout](https://docs.clawbox.tech/technical/filesystem): where everything lives; what survives updates vs factory reset; where secrets are
+- [Authentication & Security](https://docs.clawbox.tech/technical/authentication): browser login flow (unix_chkpwd), session cookies, gateway token, service tokens
+- [AI Providers](https://docs.clawbox.tech/technical/ai-providers): every provider lane, credential storage map, the two OpenAI lanes (openai/ vs codex/), boot-time self-healing
+- [Update System](https://docs.clawbox.tech/technical/update-system): tag-based updates, channels (main/beta), divergence/"Updates paused", manual-update pitfalls
+- [Agent Interface (MCP)](https://docs.clawbox.tech/technical/agent-interface): the ~50 device tools the AI agent gets, clawbox CLI, auth model
+
+## Troubleshooting & Recovery
+
+- [Troubleshooting](https://docs.clawbox.tech/support/troubleshooting): symptom-first diagnostic ladders — can't reach the box, browser rejects password (SSH works), updates stuck, provider 401s, gateway token mismatch, Telegram
+- [Recovery](https://docs.clawbox.tech/support/recovery): ordered recovery options — password reset (sudo passwd clawbox), service restart, safe reinstall (hard-sync + install.sh), factory reset (password → clawbox, AP mode)
+- [Updating ClawBox](https://docs.clawbox.tech/support/updating): the supported update paths
+- [FAQ](https://docs.clawbox.tech/support/faq)
+
+## Hardware
+
+- [ClawBox Connect](https://docs.clawbox.tech/hardware/clawbox-connect): Jetson Orin Nano model
+- [ClawBox Workstation](https://docs.clawbox.tech/hardware/clawbox-workstation): DGX Spark model
+- [Requirements](https://docs.clawbox.tech/hardware/requirements)
+
+## Using ClawBox
+
+- [Messaging Channels](https://docs.clawbox.tech/guides/messaging-channels): Telegram (device-managed, pairing-approved) and OpenClaw's wider channel support
+- [Subscriptions](https://docs.clawbox.tech/guides/subscriptions): ClawBox AI plans
+
+## External
+
+- [OpenClaw Documentation](https://docs.openclaw.ai): the upstream AI gateway ClawBox ships
+- [ClawBox Store](https://clawbox.tech)
+- [Community Discord](https://discord.gg/vsTsaY4Tuk)

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quickstart"
+icon: "rocket"
 summary: "Power on your ClawBox, finish setup, and send your first message in minutes."
 ---
 

--- a/docs-site/setup/choose-ai-provider.mdx
+++ b/docs-site/setup/choose-ai-provider.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Choose Your AI Provider"
+icon: "robot"
 summary: "Use ClawBox AI out of the box, or connect Claude, GPT, Gemini, OpenRouter, or a local model."
 ---
 

--- a/docs-site/setup/connect-network.mdx
+++ b/docs-site/setup/connect-network.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Connect to a Network"
+icon: "wifi"
 summary: "Get your ClawBox online over Ethernet or Wi-Fi."
 ---
 

--- a/docs-site/setup/first-boot.mdx
+++ b/docs-site/setup/first-boot.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Setup Guide"
+title: "First Boot"
 icon: "power-off"
 summary: "Unbox, connect, pair via QR code, and start chatting with your ClawBox in ~5 minutes."
 ---

--- a/docs-site/setup/first-boot.mdx
+++ b/docs-site/setup/first-boot.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Setup Guide"
+icon: "power-off"
 summary: "Unbox, connect, pair via QR code, and start chatting with your ClawBox in ~5 minutes."
 ---
 

--- a/docs-site/setup/openclaw-setup.mdx
+++ b/docs-site/setup/openclaw-setup.mdx
@@ -1,5 +1,6 @@
 ---
 title: "OpenClaw Setup Guide"
+icon: "sliders"
 summary: "Configure OpenClaw on your ClawBox — channels, voice, AI models, and advanced options."
 ---
 

--- a/docs-site/setup/openclaw-setup.mdx
+++ b/docs-site/setup/openclaw-setup.mdx
@@ -10,7 +10,7 @@ options — whether you're on a ClawBox or a DIY install.
 
 ## Prerequisites
 
-- **Node.js 18+** installed (pre-installed on ClawBox)
+- **Node.js 22+** installed (pre-installed on ClawBox)
 - **4 GB+ RAM** recommended
 - Linux, macOS, or Windows
 - Always-on internet connection
@@ -73,9 +73,9 @@ See [Choose Your AI Provider](/setup/choose-ai-provider) for the full provider l
 
 <Tip>
 - Run `openclaw status` to check that all services are running.
-- Use `systemctl restart openclaw` if something misbehaves after a config change.
-- Tail logs in real time with `journalctl -u openclaw -f`.
-- Enable automatic updates for the latest features and security patches.
+- If something misbehaves after a config change, restart the gateway — **on a ClawBox** the service is `sudo systemctl restart clawbox-gateway` (there is no `openclaw` unit); on a DIY install use whatever unit name you created.
+- Tail logs in real time — ClawBox: `journalctl -u clawbox-gateway -f`; DIY: `journalctl -u <your-unit> -f`.
+- Keep the software current for the latest features and security patches — see [Updating ClawBox](/support/updating).
 </Tip>
 
 ## Skip the setup

--- a/docs-site/support/faq.mdx
+++ b/docs-site/support/faq.mdx
@@ -1,5 +1,6 @@
 ---
 title: "FAQ"
+icon: "circle-question"
 summary: "Frequently asked questions about ClawBox hardware, software, and subscriptions."
 ---
 

--- a/docs-site/support/recovery.mdx
+++ b/docs-site/support/recovery.mdx
@@ -1,0 +1,103 @@
+---
+title: "Recovery"
+summary: "Recovery options ordered from least to most destructive — password reset, service restart, safe reinstall, and full factory reset."
+---
+
+When something is badly wrong, work **top to bottom** — each option is more drastic than the one before. Everything here runs over SSH (`ssh clawbox@YOUR_BOX_IP`) unless noted.
+
+<Warning>
+Before anything destructive, note what is safe: your **settings, AI keys, chats, and Telegram pairing** live in `data/` and `~/.openclaw` — they survive options A–C untouched. Only the factory reset (D) erases them.
+</Warning>
+
+## A — Reset the password (10 seconds, no data loss)
+
+For "the box works but won't accept my password" (browser and/or SSH):
+
+```bash
+sudo passwd clawbox
+```
+
+Type your current password once (for `sudo`), then the **new** password twice. Both SSH and the browser login use the new password immediately — no restart needed. Use a simple ASCII password (letters/digits/simple symbols) to avoid keyboard-encoding mismatches between the terminal and the browser.
+
+## B — Restart the services (30 seconds, no data loss)
+
+For a box that's reachable over SSH but the web page or assistant is unresponsive:
+
+```bash
+sudo systemctl restart clawbox-setup clawbox-gateway
+```
+
+Wait ~30 seconds and reload `http://YOUR_BOX_IP`. If it recurs, capture logs before the next restart:
+
+```bash
+journalctl -u clawbox-setup -n 50 --no-pager
+journalctl -u clawbox-gateway -n 50 --no-pager
+```
+
+## C — Safe reinstall (10–15 minutes, no data loss)
+
+The universal fix for a half-finished update, stale build, or mysteriously broken web app. Rebuilds the entire software stack from the official release, **keeping all your data**:
+
+```bash
+cd /home/clawbox/clawbox
+git fetch origin
+git checkout -f main
+git reset --hard origin/main
+sudo bash install.sh
+sudo reboot
+```
+
+Let `install.sh` finish completely (it prints numbered steps, `[1/23] … [23/23]`), then reboot. The box is back in ~2 minutes.
+
+<Info>
+Why this works when a normal update didn't: `install.sh` refreshes **everything** — the app build, the OpenClaw core (pinned version), the systemd service files, and system packages. Partial updates (a bare `git pull`, an interrupted updater) can leave those out of sync.
+</Info>
+
+If the box is so broken the commands above fail, there is a standalone recovery script that performs the same hard-sync + rebuild:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/ID-Robots/clawbox/main/scripts/force-update.sh)
+```
+
+## D — Factory reset (wipes everything)
+
+<Warning>
+**This erases:** AI provider config and keys, chats and agent state, Telegram pairing, ClawKeep backup pairing, saved Wi-Fi networks, downloaded Ollama models, files in Documents/Downloads/Desktop, SSH authorized keys, and all settings. The system password resets to **`clawbox`**. The box reboots into first-boot setup mode.
+</Warning>
+
+### From the UI (preferred)
+
+Open **Settings → System → Factory reset** (also offered at the end of the setup wizard). The device wipes itself and reboots into the **ClawBox-Setup** hotspot.
+
+### Over SSH (when you can't log in to the UI)
+
+```bash
+sudo systemctl stop clawbox-setup clawbox-gateway
+sudo rm -rf /home/clawbox/clawbox/data/* /home/clawbox/.openclaw/* /home/clawbox/.clawkeep/*
+echo "clawbox:clawbox" | sudo chpasswd
+sudo reboot
+```
+
+### After the reset
+
+<Steps>
+  <Step title="Join the setup hotspot">
+    Wait ~2 minutes, then connect your phone or laptop to the **ClawBox-Setup** Wi-Fi network.
+  </Step>
+  <Step title="Open the wizard">
+    Browse to `http://10.42.0.1`. If a login is requested, the password is `clawbox`.
+  </Step>
+  <Step title="Run through setup">
+    Wi-Fi → new password → AI provider → Telegram — the same flow as [First Boot](/setup/first-boot).
+  </Step>
+</Steps>
+
+## Which option do I need?
+
+| Symptom | Start with |
+|---|---|
+| Password not accepted | **A** (after the [login ladder](/support/troubleshooting#the-browser-rejects-my-password-but-ssh-accepts-it)) |
+| Page won't load / assistant silent | **B**, then **C** |
+| Update failed or box half-updated | **C** |
+| Updates never appear (modified box) | **C** (the hard-sync clears local changes) |
+| Selling the box / start truly fresh / nothing else worked | **D** |

--- a/docs-site/support/recovery.mdx
+++ b/docs-site/support/recovery.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Recovery"
+icon: "life-ring"
 summary: "Recovery options ordered from least to most destructive — password reset, service restart, safe reinstall, and full factory reset."
 ---
 

--- a/docs-site/support/recovery.mdx
+++ b/docs-site/support/recovery.mdx
@@ -4,7 +4,7 @@ icon: "life-ring"
 summary: "Recovery options ordered from least to most destructive — password reset, service restart, safe reinstall, and full factory reset."
 ---
 
-When something is badly wrong, work **top to bottom** — each option is more drastic than the one before. Everything here runs over SSH (`ssh clawbox@YOUR_BOX_IP`) unless noted.
+When something is badly wrong, work **top to bottom** — the options are roughly ordered from least to most drastic. Everything here runs over SSH (`ssh clawbox@YOUR_BOX_IP`) unless noted.
 
 <Warning>
 Before anything destructive, note what is safe: your **settings, AI keys, chats, and Telegram pairing** live in `data/` and `~/.openclaw` — they survive options A–C untouched. Only the factory reset (D) erases them.

--- a/docs-site/support/troubleshooting.mdx
+++ b/docs-site/support/troubleshooting.mdx
@@ -87,24 +87,15 @@ There is **no separate admin password** — the browser login uses the same syst
     sudo systemctl restart clawbox-setup
     ```
   </Step>
-  <Step title="Rebuild the web app (a half-finished update can serve a stale build)">
-    ```bash
-    cd /home/clawbox/clawbox
-    git fetch origin
-    git checkout -f main
-    git reset --hard origin/main
-    sudo bash install.sh
-    sudo reboot
-    ```
-
-    Takes 10–15 minutes; settings and keys are kept. Retest in a private window after the reboot.
-  </Step>
-  <Step title="Last resort — set a fresh password">
+  <Step title="Set a fresh password (10 seconds, no data loss)">
     ```bash
     sudo passwd clawbox
     ```
 
-    Sets a brand-new password (10 seconds, no data loss) that both SSH and the browser use immediately. If even a fresh simple password fails in a private window, see [Recovery](/support/recovery) for the factory-reset option, and contact support with the outputs of steps 3–5.
+    Sets a brand-new password that both SSH and the browser use immediately. Use simple ASCII characters, then retest in a private window.
+  </Step>
+  <Step title="Rebuild the web app (a half-finished update can serve a stale build)">
+    Run the safe reinstall — [Recovery, option C](/support/recovery#c--safe-reinstall-1015-minutes-no-data-loss) (10–15 minutes; settings and keys are kept) — then retest in a private window after the reboot. If even a fresh password on a fresh build fails, contact support with the outputs of steps 3–5.
   </Step>
 </Steps>
 
@@ -129,13 +120,13 @@ The updater only offers a release when the device's code history matches the off
     Run the safe reinstall — [Recovery, option C](/support/recovery#c--safe-reinstall-1015-minutes-no-data-loss) — which hard-syncs the code to the release line and rebuilds everything.
   </Accordion>
   <Accordion title="On the beta channel this is automatic">
-    Devices on the beta channel (and the next stable release) detect divergence and show **"Updates paused — this device is on a non-release branch with local changes"** with a one-click **Reset to channel &amp; update** button that performs the hard-sync above for you.
+    Devices on the beta channel (and the next stable release) detect this state and show **"Updates paused"** with a one-click reset — see [Update System → Divergence](/technical/update-system#divergence-updates-paused).
   </Accordion>
 </AccordionGroup>
 
 ## Update finished but the box misbehaves
 
-A ClawBox update is more than `git pull` — the installer also refreshes the **systemd service files** and the **OpenClaw core**. Manual or interrupted updates can leave those stale. Symptoms and their fixes:
+A ClawBox update is more than `git pull` — the installer also refreshes the **systemd service files** and the **OpenClaw core**, and manual or interrupted updates can leave those stale. **The easiest fix is always the full installer** — re-run the update from the **System Update** app, or `sudo bash /home/clawbox/clawbox/install.sh` over SSH — which runs every step. The targeted repairs below are the faster, surgical alternatives:
 
 <AccordionGroup>
   <Accordion title="Chat shows 'unauthorized: gateway token mismatch' or 'too many failed authentication attempts'">
@@ -164,18 +155,15 @@ A ClawBox update is more than `git pull` — the installer also refreshes the **
     cd /home/clawbox/clawbox && sudo bash install.sh && sudo reboot
     ```
   </Accordion>
-  <Accordion title="Rule of thumb">
-    The **in-UI updater** (System Update app) and full `sudo bash install.sh` run every step — build, OpenClaw core, service files. Ad-hoc `git pull` + restarts do not. When in doubt, run the full installer.
-  </Accordion>
 </AccordionGroup>
 
-## AI provider errors (401 / "Incorrect API key")
+## AI provider errors (401 "Incorrect API key")
 
 <AccordionGroup>
   <Accordion title="'Incorrect API key … sk-proj-…' after switching OpenAI to the ChatGPT subscription">
-    ClawBox has **two separate OpenAI lanes**: the *API-key* lane (`openai/…` models, calls `api.openai.com`, billed per token) and the *ChatGPT subscription* lane (`codex/…` models, uses your ChatGPT plan). If a device was first set up with an API key and later switched to the subscription, an old dead key could keep being used — recurring `401 Incorrect API key` on every reply, coming back after each restart.
+    Cause: OpenAI has two separate lanes with different credentials, and after a switch an old dead API key can keep being used — recurring `401` on every reply, returning after each restart. (Full explanation: [AI Providers](/technical/ai-providers).)
 
-    **The beta channel (and the next stable release) self-heals this on boot** — it repoints the agent to the subscription lane and removes the stale key. To fix immediately on any version: open **Settings → AI**, choose **ChatGPT (sign in with ChatGPT)**, and complete the sign-in again — then reboot once and confirm it still works after the restart. If it doesn't stick, contact support.
+    **Fix now, on any version:** open **Settings → AI**, choose **ChatGPT (sign in with ChatGPT)**, complete the sign-in again — then reboot once and confirm it still works after the restart. The beta channel (and the next stable release) [self-heals this on boot](/technical/ai-providers#self-healing-on-boot-beta-channel); if the manual fix doesn't stick, contact support.
   </Accordion>
   <Accordion title="Replies stopped after changing provider or plan">
     Re-save the provider in **Settings → AI** (this rewrites the full provider config), then reboot. Check quota/billing on the provider's dashboard — an exhausted key returns errors that look like auth failures.

--- a/docs-site/support/troubleshooting.mdx
+++ b/docs-site/support/troubleshooting.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Troubleshooting"
+icon: "wrench"
 summary: "Symptom-first fixes for ClawBox issues — connection, login, updates, AI provider errors, and gateway problems, with exact diagnostic commands."
 ---
 
@@ -125,14 +126,7 @@ The updater only offers a release when the device's code history matches the off
   <Accordion title="Fix: hard-sync back to the release line">
     <Warning>This discards local **code** changes (commits and edits under `/home/clawbox/clawbox`). Your settings, AI keys, chats, and Telegram pairing live outside the code and are kept.</Warning>
 
-    ```bash
-    cd /home/clawbox/clawbox
-    git fetch origin
-    git checkout -f main
-    git reset --hard origin/main
-    sudo bash install.sh
-    sudo reboot
-    ```
+    Run the safe reinstall — [Recovery, option C](/support/recovery#c--safe-reinstall-1015-minutes-no-data-loss) — which hard-syncs the code to the release line and rebuilds everything.
   </Accordion>
   <Accordion title="On the beta channel this is automatic">
     Devices on the beta channel (and the next stable release) detect divergence and show **"Updates paused — this device is on a non-release branch with local changes"** with a one-click **Reset to channel &amp; update** button that performs the hard-sync above for you.

--- a/docs-site/support/troubleshooting.mdx
+++ b/docs-site/support/troubleshooting.mdx
@@ -1,50 +1,249 @@
 ---
 title: "Troubleshooting"
-summary: "Fixes for the most common ClawBox issues — can't reach the device, no internet, no replies."
+summary: "Symptom-first fixes for ClawBox issues — connection, login, updates, AI provider errors, and gateway problems, with exact diagnostic commands."
 ---
 
-Quick fixes for the most common issues.
+Find your symptom below. Each section starts with the fastest checks and escalates to deeper fixes — run them in order. Commands marked **over SSH** are typed after connecting with `ssh clawbox@YOUR_BOX_IP` (your box password).
 
-## I can't reach `clawbox.local`
+<Tip>
+**Fast triage:** Is the box reachable at all? → [Can't reach the ClawBox](#i-cant-reach-the-clawbox). Reachable but login fails? → [Browser rejects my password](#the-browser-rejects-my-password-but-ssh-accepts-it). Logged in but AI errors? → [AI provider errors](#ai-provider-errors-401-incorrect-api-key). Update problems? → [Updates](#updates-say-up-to-date-but-the-version-is-old).
+</Tip>
+
+## I can't reach the ClawBox
 
 <AccordionGroup>
-  <Accordion title="Try the device IP directly">
-    Some networks block mDNS. Find the ClawBox in your router's connected-devices list
-    and browse to `http://<device-ip>`.
+  <Accordion title="Use the plain IP — not clawbox.local, not :18789">
+    Two very common mistakes:
+
+    1. **`clawbox.local` often fails on Windows** and on routers that block mDNS between Wi-Fi and wired devices. Use the raw IP address instead.
+    2. **Don't add `:18789`** to the address. That port is the internal AI gateway — its page loads but it does not accept your password. The ClawBox screen is served at **`http://YOUR_BOX_IP`** (port 80, nothing after the IP).
   </Accordion>
-  <Accordion title="Use Ethernet">
-    Connect an Ethernet cable and power-cycle. Wired setup is the most reliable.
+  <Accordion title="Find the box's IP address">
+    - **Router method (easiest):** open your router's connected-devices list and look for `clawbox`.
+    - **If SSH by name works** (`ssh clawbox@clawbox.local` connects in a terminal even when the browser fails): run `hostname -I` over SSH — the first address is the box's LAN IP.
+
+    Bookmark the IP once found. It can change after a reboot on dynamic leases — reserve it in your router settings for a permanent address.
   </Accordion>
-  <Accordion title="Same network?">
-    Make sure your phone/laptop is on the **same** network as the ClawBox (not a guest
-    Wi-Fi or VPN).
+  <Accordion title="Nothing loads at the IP either">
+    Over SSH, restart the web services:
+
+    ```bash
+    sudo systemctl restart clawbox-setup clawbox-gateway
+    ```
+
+    Wait ~30 seconds and reload `http://YOUR_BOX_IP`. If SSH doesn't work either, power-cycle the box and wait 2 minutes.
+  </Accordion>
+  <Accordion title="Box reverted to the ClawBox-Setup hotspot">
+    If a network change (new router, changed Wi-Fi password) left the box unable to join your network, it broadcasts its own **ClawBox-Setup** Wi-Fi network. Connect to it from a phone/laptop, open `http://10.42.0.1`, and re-run the network step of the wizard.
   </Accordion>
 </AccordionGroup>
 
-## Wi-Fi won't connect
+## The browser rejects my password (but SSH accepts it)
 
-- Re-enter the password carefully — a wrong password is the most common cause.
-- Move the device closer to the router for the first connection.
-- If it still fails, connect over Ethernet to finish setup, then retry Wi-Fi.
+There is **no separate admin password** — the browser login uses the same system password as SSH. When SSH accepts it but the browser says *Incorrect password*, work down this ladder:
+
+<Steps>
+  <Step title="Confirm you're on the right page">
+    The login must be at `http://YOUR_BOX_IP` (port 80). The `:18789` page is the gateway — it will never accept your system password.
+  </Step>
+  <Step title="Rule out browser autofill">
+    Open a **private/incognito window** (`Ctrl+Shift+N`), type the URL and the password **by hand** — don't let the browser autofill. A stale saved password is the most common cause. If this works, delete the saved password for the box's IP in your browser settings.
+  </Step>
+  <Step title="Test the password exactly as the web app checks it (over SSH)">
+    ```bash
+    read -rsp 'Box password: ' PW; echo; printf '%s\0' "$PW" | /usr/sbin/unix_chkpwd clawbox nullok; echo "RESULT exit=$?"; unset PW
+    ```
+
+    - `RESULT exit=0` → the password itself is fine; continue to the next step.
+    - Any other number → the password check itself fails. If your password contains accented or non-ASCII characters, the browser may encode them differently than the terminal did when the password was set — reset to a simple ASCII password with `sudo passwd clawbox` and retry.
+  </Step>
+  <Step title="Test the login API directly (bypasses the browser)">
+    ```bash
+    read -rsp 'Box password: ' PW; echo; curl -sS -X POST http://localhost/login-api -H 'Content-Type: application/json' -d "{\"password\":\"$PW\",\"duration\":1200}"; echo; unset PW
+    ```
+
+    - `{"success":true}` → the server accepts it; the problem is browser-side (step 2).
+    - `{"error":"Incorrect password"}` → continue to the next step.
+    - A lockout message → too many attempts; wait 5 minutes and retry.
+  </Step>
+  <Step title="Check the password helper's permissions">
+    ```bash
+    ls -l /usr/sbin/unix_chkpwd /etc/shadow
+    ```
+
+    Expected (note the `s` and the `shadow` group):
+
+    ```
+    -rwxr-sr-x 1 root shadow ... /usr/sbin/unix_chkpwd
+    -rw-r----- 1 root shadow ... /etc/shadow
+    ```
+
+    If `unix_chkpwd` shows `-rwxr-xr-x` (no `s`) or a different group:
+
+    ```bash
+    sudo chgrp shadow /usr/sbin/unix_chkpwd
+    sudo chmod 2755 /usr/sbin/unix_chkpwd
+    sudo systemctl restart clawbox-setup
+    ```
+  </Step>
+  <Step title="Rebuild the web app (a half-finished update can serve a stale build)">
+    ```bash
+    cd /home/clawbox/clawbox
+    git fetch origin
+    git checkout -f main
+    git reset --hard origin/main
+    sudo bash install.sh
+    sudo reboot
+    ```
+
+    Takes 10–15 minutes; settings and keys are kept. Retest in a private window after the reboot.
+  </Step>
+  <Step title="Last resort — set a fresh password">
+    ```bash
+    sudo passwd clawbox
+    ```
+
+    Sets a brand-new password (10 seconds, no data loss) that both SSH and the browser use immediately. If even a fresh simple password fails in a private window, see [Recovery](/support/recovery) for the factory-reset option, and contact support with the outputs of steps 3–5.
+  </Step>
+</Steps>
+
+## Updates say "up to date" but the version is old
+
+The updater only offers a release when the device's code history matches the official release line. A box whose code was modified locally (committed changes — e.g. by an on-box agent or manual edits) **silently stops seeing updates** on v3.1.4 and earlier.
+
+<AccordionGroup>
+  <Accordion title="Check whether the device has diverged (over SSH)">
+    ```bash
+    cd /home/clawbox/clawbox
+    git fetch origin
+    git status
+    git rev-list --left-right --count origin/main...HEAD
+    ```
+
+    Output `X Y` = X commits behind, Y commits ahead. **Y > 0 means local commits are blocking updates.**
+  </Accordion>
+  <Accordion title="Fix: hard-sync back to the release line">
+    <Warning>This discards local **code** changes (commits and edits under `/home/clawbox/clawbox`). Your settings, AI keys, chats, and Telegram pairing live outside the code and are kept.</Warning>
+
+    ```bash
+    cd /home/clawbox/clawbox
+    git fetch origin
+    git checkout -f main
+    git reset --hard origin/main
+    sudo bash install.sh
+    sudo reboot
+    ```
+  </Accordion>
+  <Accordion title="On the beta channel this is automatic">
+    Devices on the beta channel (and the next stable release) detect divergence and show **"Updates paused — this device is on a non-release branch with local changes"** with a one-click **Reset to channel &amp; update** button that performs the hard-sync above for you.
+  </Accordion>
+</AccordionGroup>
+
+## Update finished but the box misbehaves
+
+A ClawBox update is more than `git pull` — the installer also refreshes the **systemd service files** and the **OpenClaw core**. Manual or interrupted updates can leave those stale. Symptoms and their fixes:
+
+<AccordionGroup>
+  <Accordion title="Chat shows 'unauthorized: gateway token mismatch' or 'too many failed authentication attempts'">
+    The gateway service file is stale (it passes an old token style). Over SSH:
+
+    ```bash
+    sudo bash /home/clawbox/clawbox/install.sh --step gateway_setup
+    sudo systemctl restart clawbox-gateway
+    ```
+
+    If you saw *too many failed authentication attempts*, wait ~5 minutes after the restart — the lockout expires on its own.
+  </Accordion>
+  <Accordion title="Errors like 'Config validation failed: … Unrecognized key' when selecting a provider">
+    The OpenClaw core on the device is older than the config ClawBox writes. Refresh it to the pinned version:
+
+    ```bash
+    sudo bash /home/clawbox/clawbox/install.sh --step openclaw_install
+    sudo systemctl restart clawbox-gateway
+    ```
+  </Accordion>
+  <Accordion title="UI shows the new version but behaves like the old one">
+    The version label reads from files on disk; the *running* app may still be the previous build if the rebuild step didn't finish. Verify and fix:
+
+    ```bash
+    ls -la /home/clawbox/clawbox/.next/BUILD_ID   # timestamp = when the running build was made
+    cd /home/clawbox/clawbox && sudo bash install.sh && sudo reboot
+    ```
+  </Accordion>
+  <Accordion title="Rule of thumb">
+    The **in-UI updater** (System Update app) and full `sudo bash install.sh` run every step — build, OpenClaw core, service files. Ad-hoc `git pull` + restarts do not. When in doubt, run the full installer.
+  </Accordion>
+</AccordionGroup>
+
+## AI provider errors (401 / "Incorrect API key")
+
+<AccordionGroup>
+  <Accordion title="'Incorrect API key … sk-proj-…' after switching OpenAI to the ChatGPT subscription">
+    ClawBox has **two separate OpenAI lanes**: the *API-key* lane (`openai/…` models, calls `api.openai.com`, billed per token) and the *ChatGPT subscription* lane (`codex/…` models, uses your ChatGPT plan). If a device was first set up with an API key and later switched to the subscription, an old dead key could keep being used — recurring `401 Incorrect API key` on every reply, coming back after each restart.
+
+    **The beta channel (and the next stable release) self-heals this on boot** — it repoints the agent to the subscription lane and removes the stale key. To fix immediately on any version: open **Settings → AI**, choose **ChatGPT (sign in with ChatGPT)**, and complete the sign-in again — then reboot once and confirm it still works after the restart. If it doesn't stick, contact support.
+  </Accordion>
+  <Accordion title="Replies stopped after changing provider or plan">
+    Re-save the provider in **Settings → AI** (this rewrites the full provider config), then reboot. Check quota/billing on the provider's dashboard — an exhausted key returns errors that look like auth failures.
+  </Accordion>
+  <Accordion title="Local models (Ollama / llama.cpp) not responding">
+    Local models share the Jetson's memory — only one local runtime is active at a time. Check status in **Settings → AI**. Over SSH: `systemctl status ollama` and retry after `sudo systemctl restart ollama`.
+  </Accordion>
+</AccordionGroup>
 
 ## My assistant isn't replying
 
 <AccordionGroup>
   <Accordion title="Check the channel link">
-    Re-open the **Channels** page and confirm the app is still linked. Re-pair if needed.
-    See [Messaging Channels](/guides/messaging-channels).
+    Open the **Channels** page and confirm the app (Telegram etc.) is still linked. Re-pair if needed — see [Messaging Channels](/guides/messaging-channels).
   </Accordion>
   <Accordion title="Check the AI provider">
-    If you're using your own API key, confirm it's valid and has quota. See
-    [Choose Your AI Provider](/setup/choose-ai-provider).
+    A dead key or exhausted quota looks like silence. See [AI provider errors](#ai-provider-errors-401-incorrect-api-key) above.
+  </Accordion>
+  <Accordion title="Check the gateway">
+    Over SSH:
+
+    ```bash
+    systemctl status clawbox-gateway --no-pager | head -12
+    journalctl -u clawbox-gateway -n 40 --no-pager
+    ```
+
+    Look for auth errors (see [Update finished but the box misbehaves](#update-finished-but-the-box-misbehaves)) or provider errors in the log tail. `sudo systemctl restart clawbox-gateway` clears transient wedges.
   </Accordion>
   <Accordion title="Check internet">
-    Confirm the device is online. See [Connect to a Network](/setup/connect-network).
+    `ping -c 3 8.8.8.8` over SSH. If offline, see [Connect to a Network](/setup/connect-network).
   </Accordion>
 </AccordionGroup>
 
+## Telegram-specific issues
+
+<AccordionGroup>
+  <Accordion title="Bot doesn't answer a new person">
+    New Telegram users must be **approved** on the device (a pairing request appears on the ClawBox screen). Until approved, the bot stays silent for that user.
+  </Accordion>
+  <Accordion title="Bot stopped answering after changing the bot token">
+    Changing the bot resets pairing — previously approved users must be re-approved under the new bot.
+  </Accordion>
+</AccordionGroup>
+
+## Reading logs (for bug reports)
+
+When contacting support, include the relevant log tail — it usually pins the cause in one look:
+
+```bash
+journalctl -u clawbox-setup -n 50 --no-pager     # web app / login / setup API
+journalctl -u clawbox-gateway -n 50 --no-pager   # AI gateway / providers / channels
+```
+
+You can also message the assistant `/diagnostics` in chat (if it's responding) to get a self-report.
+
 ## Still stuck?
 
-<Card title="Contact support" href="mailto:yanko@idrobots.com" icon="life-ring" horizontal>
-  Tell us what you tried and where it's blocked — include any error you see on screen.
-</Card>
+<Columns cols={2}>
+  <Card title="Recovery options" href="/support/recovery" icon="life-ring">
+    Password reset, safe reinstall, and full factory reset — ordered from least to most destructive.
+  </Card>
+  <Card title="Contact support" href="mailto:yanko@idrobots.com" icon="envelope">
+    Tell us what you tried and where it's blocked — include the log tails above and any on-screen error.
+  </Card>
+</Columns>

--- a/docs-site/support/updating.mdx
+++ b/docs-site/support/updating.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Updating ClawBox"
+icon: "download"
 summary: "The reliable way to update your ClawBox to the latest version — and how to recover if an update gets stuck."
 ---
 

--- a/docs-site/support/updating.mdx
+++ b/docs-site/support/updating.mdx
@@ -1,74 +1,70 @@
 ---
 title: "Updating ClawBox"
 icon: "download"
-summary: "The reliable way to update your ClawBox to the latest version — and how to recover if an update gets stuck."
+summary: "How to update your ClawBox — the System Update app, the SSH alternative, and the recovery updater for stuck boxes."
 ---
 
-Keeping your ClawBox current gets you the newest features and fixes. This page covers the **most reliable way to update** and how to recover if an in‑app update ever gets stuck.
+Keeping your ClawBox current gets you the newest features and fixes. Updates never touch your data — settings, AI keys, chats, and channel tokens live outside the app code and are preserved.
 
-<Note>
-Your data, settings and channel tokens live in `~/.openclaw`, separate from the app code. Updating the app does not touch them — and the steps below make a backup first, just in case.
-</Note>
-
-## Update safely (recommended)
-
-This one‑line updater syncs your box cleanly to the latest version. It works on **any** ClawBox version and is the method we recommend — especially for older boxes, where the in‑app **System Update** button can stall.
-
-Open the **Terminal** app on the ClawBox desktop, or connect over SSH from your computer:
+## Update from the ClawBox screen (recommended)
 
 <Steps>
-  <Step title="Connect (if using SSH)">
-    Use the device's **IP address** (the same one you use for `:18789`), not `clawbox.local`:
-    ```bash
-    ssh clawbox@YOUR_BOX_IP
-    ```
-    The password is the system password you set during setup (the screen won't show characters as you type — that's normal).
+  <Step title="Open System Update">
+    Browse to `http://YOUR_BOX_IP`, log in, and open the **System Update** app (also reachable from **Settings**).
   </Step>
-  <Step title="Back up your settings">
-    ```bash
-    cp -r ~/.openclaw ~/.openclaw.backup-$(date +%F)
-    ```
-    This keeps a dated copy of your data, settings and channel tokens.
+  <Step title="Start the update">
+    If a new version is available, click **Update**. The app shows live progress through every step.
   </Step>
-  <Step title="Run the updater (one line)">
-    ```bash
-    bash <(curl -fsSL https://raw.githubusercontent.com/id-robots/clawbox/main/scripts/force-update.sh)
-    ```
-    Let it finish — it fetches the latest version, rebuilds, and restarts the services. This takes a few minutes.
-  </Step>
-  <Step title="Confirm it's back">
-    Open `http://YOUR_BOX_IP` for the desktop and click **Connect** at `http://YOUR_BOX_IP:18789`. Both should work, and you'll be on the latest version.
+  <Step title="Let it reboot">
+    The final step **reboots the box** — it's offline for a minute or two. That's normal, not a hang. When it's back, the update is done.
   </Step>
 </Steps>
 
-## Always use the device IP, not `clawbox.local`
+<Tip>
+Optional, for extra peace of mind before any update — make a dated backup of your settings (over SSH or the Terminal app):
 
-`clawbox.local` relies on **mDNS** (Bonjour), which many Windows setups and home routers don't handle reliably — guest networks, "client isolation", VPNs and some mesh systems block it. The device's **IP address** always works because it's a direct connection.
+```bash
+cp -r ~/.openclaw ~/.openclaw.backup-$(date +%F)
+```
+</Tip>
 
-Find the IP in your router's connected‑devices list (it's the same address you use for the `:18789` dashboard), then browse to `http://YOUR_BOX_IP`.
+## Update over SSH (headless alternative)
 
-## An update got stuck, or I can't access the UI afterward
+Same update, no browser needed:
 
-On older versions, the in‑app **System Update** can stop midway if the device has local changes — the dashboard still loads at `:18789` but **Connect** does nothing. The fix is the same safe updater above, which syncs cleanly and bypasses the issue:
+```bash
+ssh clawbox@YOUR_BOX_IP        # your system password from setup
+sudo clawbox update
+```
+
+The password prompt won't show characters as you type — that's normal. Let the installer finish completely (it prints numbered steps), then the box reboots.
+
+## An update got stuck, or the box misbehaves afterward
+
+On older versions the in-app update could stall midway (usually when the device had local code changes). The fix is the **recovery updater** — a standalone one-liner that hard-syncs the box to the latest release and rebuilds everything, keeping your data:
 
 <Steps>
-  <Step title="Connect over SSH (use the IP)">
+  <Step title="Connect over SSH">
     ```bash
     ssh clawbox@YOUR_BOX_IP
     ```
+    Use the device's **IP address** rather than `clawbox.local` — the name relies on mDNS, which many Windows machines and routers handle unreliably (find the IP in your router's connected-devices list).
   </Step>
   <Step title="Run the recovery updater">
     ```bash
-    bash <(curl -fsSL https://raw.githubusercontent.com/id-robots/clawbox/main/scripts/force-update.sh)
+    bash <(curl -fsSL https://raw.githubusercontent.com/ID-Robots/clawbox/main/scripts/force-update.sh)
     ```
+    Takes 10–15 minutes — let it finish completely.
   </Step>
-  <Step title="Check the services are running">
+  <Step title="Confirm it's back">
     ```bash
-    systemctl is-active clawbox-gateway.service clawbox-setup.service
+    systemctl is-active clawbox-setup clawbox-gateway
     ```
-    Both should print `active`. Then reload `http://YOUR_BOX_IP` and click **Connect** at `:18789`.
+    Both should print `active`. Then reload `http://YOUR_BOX_IP` and send your assistant a message — a reply confirms everything is running.
   </Step>
 </Steps>
+
+More recovery options (password reset, safe reinstall, factory reset) are on the [Recovery](/support/recovery) page; deeper diagnosis lives in [Troubleshooting](/support/troubleshooting#update-finished-but-the-box-misbehaves). For how updates work under the hood (release channels, what survives, version pinning), see the [Update System](/technical/update-system) reference.
 
 <Warning>
 If any step returns an error, stop there rather than forcing it — reach out and we'll finish it together: email [yanko@idrobots.com](mailto:yanko@idrobots.com) or join our [Discord community](https://discord.gg/vsTsaY4Tuk).

--- a/docs-site/technical/agent-interface.mdx
+++ b/docs-site/technical/agent-interface.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Agent Interface (MCP)"
+icon: "toolbox"
 summary: "The device-control tools the AI agent gets — full MCP tool catalog, the clawbox CLI, and how webapp/code-assistant creation works."
 ---
 

--- a/docs-site/technical/agent-interface.mdx
+++ b/docs-site/technical/agent-interface.mdx
@@ -1,0 +1,87 @@
+---
+title: "Agent Interface (MCP)"
+summary: "The device-control tools the AI agent gets — full MCP tool catalog, the clawbox CLI, and how webapp/code-assistant creation works."
+---
+
+What makes ClawBox an *AI-operated OS* rather than a chat box: the OpenClaw agent is wired to a **ClawBox MCP server** (`mcp/clawbox-mcp.ts`, registered as `mcp.servers.clawbox` on every gateway start) exposing ~50 device tools. The agent can manage files, run commands, browse the real desktop Chromium, install apps, and build webapps — all authenticated back to the device APIs with a per-install bearer token.
+
+## Tool catalog
+
+### Shell & orchestration
+| Tool | Purpose |
+|---|---|
+| `bash` | Run a shell command (30 s default / 10 min max; background mode available). Destructive patterns (`rm -rf /`, `dd`, `mkfs`, force-push, …) are hard-blocked |
+| `agent` | Spawn a background sub-agent running a command sequence |
+| `task_status` | Check a background task's output |
+| `clawbox_health` | Verify the MCP token + device API reachability — "run first when tools fail" |
+
+### Files
+| Tool | Purpose |
+|---|---|
+| `read_file` | Read text/images/PDF/notebooks (line-numbered, offset/limit) |
+| `write_file` / `edit_file` | Create/overwrite or exact-string-replace (staleness-checked, returns diffs) |
+| `list_directory`, `glob`, `grep` | Browse, find by pattern, content-search (ripgrep) |
+| `notebook_edit` | Edit Jupyter cells |
+
+### Web
+| Tool | Purpose |
+|---|---|
+| `web_fetch` | Fetch a URL → readable text/markdown (cached 15 min) |
+| `web_search` | Web search |
+
+### Browser (drives the real desktop Chromium via CDP — visible in Remote Desktop)
+`browser_open` (attach + navigate + screenshot), `browser_navigate`, `browser_click`, `browser_type`, `browser_keypress`, `browser_scroll`, `browser_screenshot`, `browser_close`.
+
+### System, network & UI
+| Tool | Purpose |
+|---|---|
+| `system_stats` / `system_info` | CPU/memory/disk/temperature/GPU, hostname |
+| `system_power` | Restart or shut down the device |
+| `wifi_scan` / `wifi_status` / `vnc_status` | Network + remote-display state |
+| `ui_open_app` / `ui_list_apps` / `ui_notify` | Open desktop apps, list them, send a desktop notification |
+| `preferences_get` / `preferences_set` | Persistent user preferences |
+
+### Apps & webapps
+| Tool | Purpose |
+|---|---|
+| `app_search` / `app_install` / `app_uninstall` | The App Store (apps + skills from the portal) |
+| `webapp_create` / `webapp_update` | Single-file HTML webapps installed straight onto the desktop |
+| `code_project_init` / `code_project_list` / `code_project_build` / `code_project_delete` | Multi-file code-assistant projects — scaffold → edit with the file tools → build deploys to the desktop |
+| `task_create` / `task_update` / `task_get` / `task_list` / `task_stop` | Agent task tracking with dependencies |
+| `clawbox_context` | Returns the on-device field guide (`CLAWBOX.md`) — loaded once at session start |
+
+## The `clawbox` CLI
+
+The same capabilities are shell-callable (used by agents in the Terminal and by admins over SSH):
+
+```bash
+clawbox webapp create <appId> <name> [--html ...]   # install a desktop webapp
+clawbox app open <appId> | app list                 # drive the desktop
+clawbox notify "message"                            # desktop notification
+clawbox system stats | system info                  # metrics
+clawbox code init|build|read|write|edit|search ...  # code-assistant projects
+sudo clawbox update                                 # full system update (runs install.sh)
+```
+
+## How authentication works
+
+- The MCP server talks to the device APIs at `http://127.0.0.1:80/setup-api/*` with the **MCP bearer token** (`data/.mcp-token`, seeded at boot, 0600).
+- The gateway launches the MCP server via bun with that token in its environment — reconciled automatically on every gateway start.
+- If tools suddenly fail with auth errors, `clawbox_health` diagnoses it; a gateway restart re-reconciles the registration.
+
+## Safety rails
+
+- `bash` refuses known-destructive patterns outright and warns on risky git operations.
+- Telegram senders must be pairing-approved before the agent will act for them ([details](/technical/authentication#security-posture-summary)).
+- Webapps persist data through the device KV API (no localStorage) and run as plain HTML on the desktop.
+
+## For agent developers
+
+Working *on* a ClawBox (or building automation against one)? The stable integration surfaces are:
+
+1. **MCP tools** (this page) — through the OpenClaw agent.
+2. **`/setup-api/*` HTTP APIs** — session-cookie or MCP-bearer authenticated; the same APIs the desktop UI uses.
+3. **`clawbox` CLI** — over SSH or the Terminal app.
+4. The agent workspace guide seeded at `~/.openclaw/workspace/CLAWBOX.md` on-device.
+
+See the [Quick Reference](/technical/quick-reference) for the one-page fact sheet (ports, paths, services, commands).

--- a/docs-site/technical/ai-providers.mdx
+++ b/docs-site/technical/ai-providers.mdx
@@ -52,7 +52,7 @@ Some native OpenClaw provider plugins expect auth stores ClawBox doesn't populat
 
 ## Self-healing on boot (beta channel)
 
-`gateway-pre-start.sh` runs before every gateway start and repairs known-bad provider states. On the **beta channel** (rolling into the next stable release) this includes:
+`gateway-pre-start.sh` runs before every gateway start and repairs known-bad provider states. On the **beta channel** (and the next stable release) this includes:
 
 | Heal | Broken state it fixes |
 |---|---|

--- a/docs-site/technical/ai-providers.mdx
+++ b/docs-site/technical/ai-providers.mdx
@@ -1,0 +1,71 @@
+---
+title: "AI Providers — Technical Reference"
+summary: "Every provider lane in detail: auth modes, where credentials are stored, model namespaces, defaults, and the boot-time self-healing that keeps them working."
+---
+
+For choosing a provider as a user, see [Choose Your AI Provider](/setup/choose-ai-provider). This page is the technical reference: what actually gets written where when you configure each provider, and how the system repairs common broken states.
+
+## Provider lanes at a glance
+
+| Provider | Auth | Model namespace | Default model | Notes |
+|---|---|---|---|---|
+| **ClawBox AI** | Portal device-pairing token | `deepseek/…` | `deepseek-v4-flash` | DeepSeek-backed, proxied via the portal. Tiers: Free/Pro → `v4-flash`, Max → `v4-pro` (1.6T) |
+| **Anthropic (Claude)** | API key | `anthropic/…` | `claude-sonnet-4-6` | Routed via Anthropic's OpenAI-compatible endpoint |
+| **OpenAI (API key)** | `sk-…` API key | `openai/…` | `gpt-5.4` | Direct `api.openai.com`, per-token billing |
+| **ChatGPT subscription** | ChatGPT OAuth sign-in | `codex/…` | `codex/gpt-5.4` | Uses your ChatGPT plan. Models: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini` only (no `-pro` variants) |
+| **Google Gemini** | API key | `google/…` | `gemini-2.5-flash` | Routed via Google's OpenAI-compat endpoint |
+| **OpenRouter** | API key | `openrouter/<org>/<model>` | (curated) | Explicit provider definition required — written automatically |
+| **Ollama** (local) | none (per-install bearer) | `ollama/…` | `llama3.2:3b` | Context capped 32k / 8k output for Jetson RAM |
+| **llama.cpp** (local) | none (per-install bearer) | `llamacpp/…` | (bundled model) | OpenAI-compat local server |
+
+<Warning>
+**OpenAI has two distinct lanes.** The API-key lane (`openai/…`) and the ChatGPT-subscription lane (`codex/…`) have **different model catalogs and different credentials**. `gpt-5` exists only on the API lane; the subscription serves `gpt-5.5 / gpt-5.4 / gpt-5.4-mini`. Mixing them up is the root of most "Incorrect API key" tickets — see self-healing below.
+</Warning>
+
+## Where credentials actually go
+
+Configuring a provider writes up to four places:
+
+1. **`~/.openclaw/agents/main/agent/auth-profiles.json`** — the real secret. API keys as `{type:"api_key", provider, key}`; subscriptions as `{type:"oauth", provider, access, id, refresh, expires}`.
+2. **`openclaw.json → auth.profiles.<provider>:default`** — metadata **only** (`{provider, mode}`). No secret lives here.
+3. **`openclaw.json → models.providers.<provider>`** — the provider *definition* (baseUrl, API dialect, model list) for lanes that need one (ClawBox AI, Anthropic, Google, OpenRouter, Ollama, llama.cpp).
+4. **`~/.openclaw/agents/<agent>/agent/codex-home/auth.json`** (+ `~/.codex/auth.json`) — the ChatGPT-subscription session, synthesized from the auth profile on every gateway start.
+
+The active model is `agents.defaults.model.primary` (e.g. `codex/gpt-5.4`), with `agents.defaults.model.fallbacks` behind it (typically ClawBox AI or a local model).
+
+## Compatibility routing (why some lanes use "OpenAI-compat")
+
+Some native OpenClaw provider plugins expect auth stores ClawBox doesn't populate. ClawBox therefore routes **Anthropic** via `https://api.anthropic.com/v1` and **Google** via `https://generativelanguage.googleapis.com/v1beta/openai` — both OpenAI-compatible endpoints with the key inline in the provider definition. Behavior is identical for users; the win is call-time auth that always works. **OpenRouter** likewise requires an explicit provider definition (`https://openrouter.ai/api/v1`) — without one, chats silently return empty usage.
+
+## ClawBox AI specifics
+
+- Pairing uses a device-code flow against the portal (`openclawhardware.dev`) — the wizard shows a short code you confirm in your portal account; the resulting token is stored on-device.
+- Requests proxy through the portal's AI endpoint; both models advertise reasoning support including **X-High** effort (mapped upstream to DeepSeek's maximum reasoning mode).
+- Changing the linked portal account automatically unpairs ClawKeep (backups belong to the account).
+
+## Local models (Ollama / llama.cpp)
+
+- Local lanes authenticate with a **per-install bearer token** through a local proxy — nothing is exposed unauthenticated, even on localhost.
+- Only one local runtime is active at a time (8 GB Jetson RAM). Ollama gets tuned automatically (quantized KV cache, flash attention, single loaded model).
+- A local model can be the primary or the fallback; the wizard's fallback chain prefers a configured local model, else ClawBox AI.
+
+## Self-healing on boot (beta channel)
+
+`gateway-pre-start.sh` runs before every gateway start and repairs known-bad provider states. On the **beta channel** (rolling into the next stable release) this includes:
+
+| Heal | Broken state it fixes |
+|---|---|
+| **Codex session sync** | After switching OpenAI from API-key to ChatGPT subscription, a stale key-only `codex-home/auth.json` kept sending a dead `sk-proj-…` key → `401` on every reply, returning after each restart. Now every agent's session file is validated (full OAuth set, JWT id-token) and rewritten if stale/partial/corrupt. |
+| **openai→codex migration** | Device has a *working* ChatGPT subscription but the primary model still points at the dead `openai/…` API lane → repointed to the `codex/…` equivalent, stale key and fallbacks purged. |
+| **OpenRouter definition backfill** | Legacy devices configured before the provider-definition fix (symptom: replies with `usage 0/0/0`) get the definition written. |
+| **DeepSeek reasoning-effort backfill** | Older configs missing `supportedReasoningEfforts` made the gateway reject X-High. |
+| **Gateway token strength** | Any weak/legacy token is rotated to a strong per-device value. |
+
+All heals are idempotent — a healthy config is left untouched.
+
+## Troubleshooting pointers
+
+- `401 Incorrect API key (sk-proj-…)` after switching to the subscription → [Troubleshooting → AI provider errors](/support/troubleshooting#ai-provider-errors-401-incorrect-api-key)
+- `Config validation failed: … Unrecognized key` → stale OpenClaw core; `sudo bash install.sh --step openclaw_install`
+- Codex chats crash immediately (`createDiagnosticTraceContext… is not a function`) → `@openclaw/codex` plugin version skew vs core; re-run `sudo bash install.sh --step openclaw_install` (re-pins plugins)
+- Model picker rejects a model ID → each lane validates against its own catalog; remember the two OpenAI lanes have different catalogs.

--- a/docs-site/technical/ai-providers.mdx
+++ b/docs-site/technical/ai-providers.mdx
@@ -1,5 +1,6 @@
 ---
-title: "AI Providers — Technical Reference"
+title: "AI Providers"
+icon: "microchip"
 summary: "Every provider lane in detail: auth modes, where credentials are stored, model namespaces, defaults, and the boot-time self-healing that keeps them working."
 ---
 

--- a/docs-site/technical/architecture.mdx
+++ b/docs-site/technical/architecture.mdx
@@ -1,5 +1,6 @@
 ---
 title: "System Architecture"
+icon: "sitemap"
 summary: "How a ClawBox works inside — service topology, request routing, boot lifecycle, and the relationship between ClawBox OS and OpenClaw."
 ---
 
@@ -7,25 +8,24 @@ ClawBox is **OpenClaw OS** — a Next.js web OS wrapped around the [OpenClaw](ht
 
 ## The big picture
 
-```
-Your browser / phone
-        │  http://<box-ip>  (port 80)
-        ▼
-┌──────────────────────────────────────────────────────┐
-│  clawbox-setup  (production-server.js → Next.js)     │
-│  · desktop UI, setup wizard, login                    │
-│  · /setup-api/* device APIs                           │
-│  · proxies /api/*, WebSockets → gateway               │
-└──────────────┬───────────────────────────────────────┘
-               │ 127.0.0.1:18789 (loopback only)
-               ▼
-┌──────────────────────────────────────────────────────┐
-│  clawbox-gateway  (OpenClaw)                          │
-│  · AI agent + chat sessions                           │
-│  · providers (Claude/GPT/Gemini/local…)               │
-│  · channels (Telegram)                                │
-│  · MCP → ClawBox device tools                         │
-└──────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    U["Your browser / phone"]
+    U -- "http://box-ip &nbsp;·&nbsp; port 80" --> S
+    subgraph S["clawbox-setup — the web OS"]
+        direction TB
+        s1["Desktop UI · setup wizard · login"]
+        s2["/setup-api/* device APIs"]
+        s3["Proxies /api/* + WebSockets to the gateway"]
+    end
+    S -- "127.0.0.1:18789 &nbsp;·&nbsp; loopback only" --> G
+    subgraph G["clawbox-gateway — OpenClaw"]
+        direction TB
+        g1["AI agent + chat sessions"]
+        g2["Providers: Claude · GPT · Gemini · local"]
+        g3["Channels: Telegram"]
+        g4["MCP → ClawBox device tools"]
+    end
 ```
 
 The user never talks to the gateway directly — everything enters through port 80, and the web app proxies chat/WebSocket traffic to the loopback-bound gateway.

--- a/docs-site/technical/architecture.mdx
+++ b/docs-site/technical/architecture.mdx
@@ -1,0 +1,108 @@
+---
+title: "System Architecture"
+summary: "How a ClawBox works inside — service topology, request routing, boot lifecycle, and the relationship between ClawBox OS and OpenClaw."
+---
+
+ClawBox is **OpenClaw OS** — a Next.js web OS wrapped around the [OpenClaw](https://docs.openclaw.ai) AI gateway, running on an NVIDIA Jetson (Ubuntu/aarch64). This page maps the moving parts.
+
+## The big picture
+
+```
+Your browser / phone
+        │  http://<box-ip>  (port 80)
+        ▼
+┌──────────────────────────────────────────────────────┐
+│  clawbox-setup  (production-server.js → Next.js)     │
+│  · desktop UI, setup wizard, login                    │
+│  · /setup-api/* device APIs                           │
+│  · proxies /api/*, WebSockets → gateway               │
+└──────────────┬───────────────────────────────────────┘
+               │ 127.0.0.1:18789 (loopback only)
+               ▼
+┌──────────────────────────────────────────────────────┐
+│  clawbox-gateway  (OpenClaw)                          │
+│  · AI agent + chat sessions                           │
+│  · providers (Claude/GPT/Gemini/local…)               │
+│  · channels (Telegram)                                │
+│  · MCP → ClawBox device tools                         │
+└──────────────────────────────────────────────────────┘
+```
+
+The user never talks to the gateway directly — everything enters through port 80, and the web app proxies chat/WebSocket traffic to the loopback-bound gateway.
+
+## Services
+
+Everything runs under systemd. The two you will interact with most are **clawbox-setup** (the web OS) and **clawbox-gateway** (the AI).
+
+| Service | What it runs | Port | Restart policy |
+|---|---|---|---|
+| `clawbox-setup` | Node.js `production-server.js` → Next.js standalone build (desktop UI, wizard, `/setup-api/*`) | 80 (+443 if certs present) | always (3 s) |
+| `clawbox-gateway` | `openclaw gateway --bind lan` — preceded by `gateway-pre-start.sh` config self-heals | 18789 (loopback) | always (5 s) |
+| `clawbox-ap` | Wi-Fi hotspot **ClawBox-Setup** for first-boot setup (oneshot) | — | oneshot |
+| `clawbox-ap-watchdog.timer` | Re-raises the hotspot until setup completes (every 20 s) | — | timer |
+| `clawbox-vnc` / `clawbox-websockify` | Xvfb virtual display `:99` + x11vnc + noVNC proxy | 5900 / 6080 | on-failure |
+| `clawbox-browser` | Desktop Chromium with CDP for AI browsing (started on demand) | 18800 (CDP) | no |
+| `clawbox-heartbeat.timer` | Portal heartbeat tick every 5 min | — | timer |
+| `clawbox-tunnel` | Optional Cloudflare Quick Tunnel → port 80 | — | always |
+| `clawbox-performance` | Jetson max-performance mode (`nvpmodel` + `jetson_clocks`) | — | oneshot |
+| `clawbox-root-update@<step>` | Privileged installer steps, templated (`install.sh --step <step>`) | — | oneshot |
+| `ollama` | Local model runtime (system package) | 11434 | managed by Ollama |
+
+Two more servers run as **children of the web app** (no systemd unit): the terminal PTY WebSocket server (port 3006) and the optional llama.cpp server (port 8080), both supervised by `src/instrumentation-node.ts`.
+
+### How the unprivileged web app does root things
+
+`clawbox-setup` runs as the `clawbox` user. Anything privileged (updates, password change, hostname, reboot) is delegated to the **`clawbox-root-update@<step>`** systemd template, which runs `install.sh --step <step>` as root. A polkit rule plus a narrow sudoers file allow the `clawbox` user to start exactly these units — the web app never runs arbitrary root commands.
+
+## Request routing (port 80)
+
+1. **`production-server.js`** wraps the Next.js standalone server. On boot it seeds secrets from `data/` into env (`SESSION_SECRET`, MCP + local-AI tokens) and attaches a **WebSocket upgrade proxy**: `/terminal-ws` → port 3006, `/novnc-ws` → port 6080, everything else → gateway 18789.
+2. **Next.js rewrites** proxy `/api/*`, `/assets/*`, and any path no ClawBox route claims → the gateway.
+3. **`src/middleware.ts`** enforces, in order: captive-portal probe redirects → public-path allowlist (`/login`, `/setup`, …) → pre-setup bypass (until `setup_complete`) → MCP bearer bypass → **session cookie** check (else redirect to `/login`).
+4. **`/` (desktop)** — after setup, the root serves a Chrome-OS-style desktop (window manager, taskbar, built-in apps). The setup wizard lives at `/setup`.
+5. **Gateway HTML** — when the OpenClaw Control UI is served, `gateway-proxy.ts` injects a ClawBox nav bar and the gateway auth token so the SPA connects without manual token entry.
+
+## Boot lifecycle
+
+<Steps>
+  <Step title="Power on — AP mode (first boot / unconfigured)">
+    `clawbox-ap` raises the **ClawBox-Setup** hotspot at `10.42.0.1` (falls back to `10.43.0.1` on subnet collision). dnsmasq hijacks all DNS to the box; OS captive-portal probes are redirected so phones auto-open the wizard.
+  </Step>
+  <Step title="Setup wizard">
+    Wi-Fi → password → (update) → AI provider → Telegram. State persists in `data/config.json` (`setup_complete`, `password_configured`).
+  </Step>
+  <Step title="Steady state — home network">
+    The box joins your Wi-Fi/Ethernet, announces `clawbox.local` over mDNS (avahi), and serves the desktop at its LAN IP. The AP watchdog stands down once setup is complete.
+  </Step>
+  <Step title="Every gateway start">
+    `gateway-pre-start.sh` runs before OpenClaw: it normalizes `openclaw.json` (bind/auth/origins), enforces a strong gateway token, repairs provider config (see [AI Providers](/technical/ai-providers#self-healing-on-boot-beta-channel)), registers the ClawBox MCP server, and seeds the agent workspace.
+  </Step>
+</Steps>
+
+## ClawBox ↔ OpenClaw
+
+- **OpenClaw** is installed globally via npm at `~/.npm-global/bin/openclaw`, **pinned** to the version in `config/openclaw-target.txt`. Updates move the pin deliberately — the fleet never floats on `@latest`.
+- **Config** lives in `~/.openclaw/openclaw.json`. ClawBox writes it directly (setup wizard, Settings) and heals it on every gateway start.
+- **The `@openclaw/codex` plugin** (ChatGPT-subscription support) is auto-installed and version-pinned to match the core — version skew between them breaks Codex chats.
+- **MCP**: the gateway is configured with an `mcp.servers.clawbox` entry that launches `mcp/clawbox-mcp.ts` (via bun) — this is how the AI agent gets device control tools (files, shell, browser, apps, system). See [Agent Interface](/technical/agent-interface).
+- **Control UI**: the OpenClaw dashboard is reachable through the ClawBox desktop (OpenClaw app) — an iframe wired to the gateway WebSocket with the token injected automatically.
+
+## Stack
+
+| Layer | Technology |
+|---|---|
+| Hardware | NVIDIA Jetson (Orin) — Ubuntu 22.04 aarch64 |
+| Runtime | Node.js 22 (production), Bun (builds/package management) |
+| Web | Next.js 16 App Router (`output: standalone`), React 19, Tailwind CSS v4 |
+| AI gateway | OpenClaw (pinned), + `@openclaw/codex` plugin |
+| Local AI | Ollama (port 11434), llama.cpp (optional, port 8080) |
+| System | systemd, NetworkManager, avahi (mDNS), dnsmasq (captive portal), polkit |
+
+<Columns cols={2}>
+  <Card title="Networking details" href="/technical/networking" icon="network-wired">
+    AP mode, captive portal, mDNS, ports.
+  </Card>
+  <Card title="Filesystem layout" href="/technical/filesystem" icon="folder-tree">
+    Where everything lives on the box.
+  </Card>
+</Columns>

--- a/docs-site/technical/architecture.mdx
+++ b/docs-site/technical/architecture.mdx
@@ -11,14 +11,14 @@ ClawBox is **OpenClaw OS** — a Next.js web OS wrapped around the [OpenClaw](ht
 ```mermaid
 flowchart TB
     U["Your browser / phone"]
-    U -- "http://box-ip &nbsp;·&nbsp; port 80" --> S
+    U -- "http://box-ip · port 80" --> S
     subgraph S["clawbox-setup — the web OS"]
         direction TB
         s1["Desktop UI · setup wizard · login"]
         s2["/setup-api/* device APIs"]
         s3["Proxies /api/* + WebSockets to the gateway"]
     end
-    S -- "127.0.0.1:18789 &nbsp;·&nbsp; loopback only" --> G
+    S -- "proxies via 127.0.0.1:18789" --> G
     subgraph G["clawbox-gateway — OpenClaw"]
         direction TB
         g1["AI agent + chat sessions"]
@@ -28,7 +28,7 @@ flowchart TB
     end
 ```
 
-The user never talks to the gateway directly — everything enters through port 80, and the web app proxies chat/WebSocket traffic to the loopback-bound gateway.
+The user never talks to the gateway directly — everything enters through port 80, and the web app proxies chat/WebSocket traffic to the gateway. (The gateway itself listens on the LAN with token auth — browsing `:18789` directly is a classic mistake: it loads, but it will never accept your password.)
 
 ## Services
 
@@ -37,7 +37,7 @@ Everything runs under systemd. The two you will interact with most are **clawbox
 | Service | What it runs | Port | Restart policy |
 |---|---|---|---|
 | `clawbox-setup` | Node.js `production-server.js` → Next.js standalone build (desktop UI, wizard, `/setup-api/*`) | 80 (+443 if certs present) | always (3 s) |
-| `clawbox-gateway` | `openclaw gateway --bind lan` — preceded by `gateway-pre-start.sh` config self-heals | 18789 (loopback) | always (5 s) |
+| `clawbox-gateway` | `openclaw gateway --bind lan` — preceded by `gateway-pre-start.sh` config self-heals | 18789 (LAN, token-gated) | always (5 s) |
 | `clawbox-ap` | Wi-Fi hotspot **ClawBox-Setup** for first-boot setup (oneshot) | — | oneshot |
 | `clawbox-ap-watchdog.timer` | Re-raises the hotspot until setup completes (every 20 s) | — | timer |
 | `clawbox-vnc` / `clawbox-websockify` | Xvfb virtual display `:99` + x11vnc + noVNC proxy | 5900 / 6080 | on-failure |
@@ -81,9 +81,8 @@ Two more servers run as **children of the web app** (no systemd unit): the termi
 
 ## ClawBox ↔ OpenClaw
 
-- **OpenClaw** is installed globally via npm at `~/.npm-global/bin/openclaw`, **pinned** to the version in `config/openclaw-target.txt`. Updates move the pin deliberately — the fleet never floats on `@latest`.
+- **OpenClaw** is installed globally via npm at `~/.npm-global/bin/openclaw`, **version-pinned** along with its `@openclaw/*` plugins — see [Update System](/technical/update-system#the-update-pipeline) for how the pin works.
 - **Config** lives in `~/.openclaw/openclaw.json`. ClawBox writes it directly (setup wizard, Settings) and heals it on every gateway start.
-- **The `@openclaw/codex` plugin** (ChatGPT-subscription support) is auto-installed and version-pinned to match the core — version skew between them breaks Codex chats.
 - **MCP**: the gateway is configured with an `mcp.servers.clawbox` entry that launches `mcp/clawbox-mcp.ts` (via bun) — this is how the AI agent gets device control tools (files, shell, browser, apps, system). See [Agent Interface](/technical/agent-interface).
 - **Control UI**: the OpenClaw dashboard is reachable through the ClawBox desktop (OpenClaw app) — an iframe wired to the gateway WebSocket with the token injected automatically.
 

--- a/docs-site/technical/authentication.mdx
+++ b/docs-site/technical/authentication.mdx
@@ -1,0 +1,69 @@
+---
+title: "Authentication & Security"
+summary: "How the browser login, session cookies, gateway token, and service-to-service tokens work — and what each requires to function."
+---
+
+ClawBox has **one human password** and several machine tokens. Understanding which is which resolves most "can't log in" confusion.
+
+## The one password
+
+The browser/desktop login and SSH use the **same Linux system password** (account `clawbox`). There is no separate admin or web password. Changing it anywhere changes it everywhere:
+
+- **Settings → System → Change password** (web) — validated, rate-limited, applied via a privileged `chpasswd` step.
+- `sudo passwd clawbox` (SSH) — takes effect for the browser immediately.
+- Factory reset — resets it to `clawbox`.
+
+## Browser login flow
+
+```
+POST /login-api  { password, duration }
+  → rate limit (lockout on repeated failures — wait ~5 min)
+  → verifyPassword: spawn /usr/sbin/unix_chkpwd <user> nullok  (password on stdin)
+  → exit 0? → Set-Cookie: clawbox_session = base64(payload).HMAC-SHA256(secret)
+```
+
+**Requirements for this to work** (the checklist behind "SSH accepts it, browser doesn't"):
+
+1. The web app must resolve the right **username** — `CLAWBOX_USER` env → `SUDO_USER` → `USER` → OS user, default `clawbox`.
+2. `/usr/sbin/unix_chkpwd` must be **setgid `shadow`** (`-rwxr-sr-x root shadow`) — it's the PAM helper that reads `/etc/shadow` on behalf of the non-root web app. SSH doesn't need this (sshd is root), which is why SSH can work while the browser fails.
+3. The **running build** must be current — a stale build from a half-finished update checks with old logic.
+4. The password bytes the browser sends must match — non-ASCII passwords can be encoded differently by the browser vs the terminal that set them.
+
+The full diagnostic ladder for login failures is in [Troubleshooting](/support/troubleshooting#the-browser-rejects-my-password-but-ssh-accepts-it).
+
+### Session cookies
+
+`clawbox_session` is an HMAC-SHA256-signed expiry token (no server-side session store): `base64url({exp}) + "." + HMAC(payload, secret)`. Durations: 20 min, 6 h, 12 h, or 24 h. The signing secret persists in `data/.session-secret`. Cookies are `httpOnly`, `SameSite=Lax`, and non-`Secure` (the LAN UI is plain HTTP).
+
+Middleware enforces the cookie on every route except the public set (`/login`, `/setup`, static assets, captive-portal probes) — and skips enforcement entirely until first-boot setup completes.
+
+## Gateway token (machine, not human)
+
+The OpenClaw gateway (port 18789) authenticates its WebSocket clients with a **token** stored at `openclaw.json → gateway.auth.token`:
+
+- Per-device **random 32-byte hex** — generated on first boot/reset and preserved thereafter. (Early builds shipped a public literal `"clawbox"`; any such weak token is automatically rotated to a strong one on gateway start.)
+- The ClawBox UI injects this token into the OpenClaw Control UI automatically (via `/setup-api/gateway/ws-config` and injected HTML) — users never type it.
+- The gateway service is started **without** `--token` so the config value is the single source of truth. A stale service file that still passes `--token` causes the classic `unauthorized: gateway token mismatch` error — fix with `sudo bash install.sh --step gateway_setup`.
+
+## Service-to-service tokens
+
+| Token | File | Purpose |
+|---|---|---|
+| MCP bearer | `data/.mcp-token` | The agent's device tools (`mcp/clawbox-mcp.ts`) authenticate back to `/setup-api/*` on port 80 |
+| Local-AI bearer | `data/.local-ai-token` | The gateway's Ollama/llama.cpp calls go through an authenticated local proxy |
+| ClawKeep portal token | `~/.clawkeep/token` | Authenticates cloud backups to the portal |
+
+All are per-install random values with `0600` permissions, seeded/re-hardened automatically at boot.
+
+## Provider credentials
+
+AI provider keys and OAuth sessions live in `~/.openclaw/agents/main/agent/auth-profiles.json` — **not** in `openclaw.json` (which only holds `{provider, mode}` metadata). The ChatGPT-subscription session is additionally mirrored to each agent's `codex-home/auth.json`. See [AI Providers](/technical/ai-providers) for the full credential-flow map.
+
+## Security posture summary
+
+- Gateway is **loopback-only**; all LAN traffic passes the authenticated web app.
+- Web login is rate-limited with lockout; passwords are never logged; control characters are rejected.
+- Privileged operations run through an allowlisted systemd template (polkit + narrow sudoers), never arbitrary root exec from the web process.
+- Telegram DMs default to **pairing** mode — unknown senders are inert until the owner approves their 8-character code. Config that would open DMs to everyone (`dmPolicy:"open"` + `allowFrom:["*"]`) is actively stripped on boot.
+- Factory reset wipes credentials, SSH keys, histories, and browser profiles — see [Recovery](/support/recovery).
+- Vulnerability reports: see [SECURITY.md](https://github.com/ID-Robots/clawbox/blob/main/SECURITY.md).

--- a/docs-site/technical/authentication.mdx
+++ b/docs-site/technical/authentication.mdx
@@ -58,11 +58,11 @@ All are per-install random values with `0600` permissions, seeded/re-hardened au
 
 ## Provider credentials
 
-AI provider keys and OAuth sessions live in `~/.openclaw/agents/main/agent/auth-profiles.json` — **not** in `openclaw.json` (which only holds `{provider, mode}` metadata). The ChatGPT-subscription session is additionally mirrored to each agent's `codex-home/auth.json`. See [AI Providers](/technical/ai-providers) for the full credential-flow map.
+AI provider keys and OAuth sessions are separate from all of the above — see [AI Providers → Where credentials actually go](/technical/ai-providers#where-credentials-actually-go) for the full map.
 
 ## Security posture summary
 
-- Gateway is **loopback-only**; all LAN traffic passes the authenticated web app.
+- The gateway listens on the LAN but is **token-gated** (per-device random token); users go through the authenticated web app on port 80, which injects the token for them.
 - Web login is rate-limited with lockout; passwords are never logged; control characters are rejected.
 - Privileged operations run through an allowlisted systemd template (polkit + narrow sudoers), never arbitrary root exec from the web process.
 - Telegram DMs default to **pairing** mode — unknown senders are inert until the owner approves their 8-character code. Config that would open DMs to everyone (`dmPolicy:"open"` + `allowFrom:["*"]`) is actively stripped on boot.

--- a/docs-site/technical/authentication.mdx
+++ b/docs-site/technical/authentication.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Authentication & Security"
+icon: "shield-halved"
 summary: "How the browser login, session cookies, gateway token, and service-to-service tokens work — and what each requires to function."
 ---
 

--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -16,7 +16,7 @@ Everything ClawBox cares about lives under `/home/clawbox`. The app itself is a 
 | `…/clawbox/.update-branch` | Update-channel pin (`beta` etc.) — survives updates *and* factory reset |
 | `…/clawbox/config/openclaw-target.txt` | Pinned OpenClaw version for the fleet |
 | `…/clawbox/.next/` | Production build output (`BUILD_ID` = fingerprint of the running build) |
-| `~/.openclaw/` | **OpenClaw state**: `openclaw.json` (gateway config), `agents/<agent>/agent/auth-profiles.json` (**provider credentials**), `agents/<agent>/agent/codex-home/auth.json` (ChatGPT-subscription session), `credentials/telegram-*.json` (pairing approvals), `workspace/` (agent working dir), `npm/` (plugins) |
+| `~/.openclaw/` | **OpenClaw state**: `openclaw.json` (gateway config), `agents/` (per-agent credentials — exact paths in the table below), `credentials/` (Telegram pairing approvals), `workspace/` (agent working dir), `npm/` (plugins) |
 | `~/.codex/auth.json` | Codex CLI auth (kept in sync with the agent copies) |
 | `~/.clawkeep/` | ClawKeep backup state: portal `token`, `config.toml`, `state.json`, encryption `passphrase`, `schedule.json` |
 | `~/.npm-global/` | OpenClaw install (`bin/openclaw`) |

--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -1,0 +1,65 @@
+---
+title: "Filesystem Layout"
+summary: "Where everything lives on the device — app, config, credentials, agent state — and what survives updates and factory resets."
+---
+
+Everything ClawBox cares about lives under `/home/clawbox`. The app itself is a git checkout; all personal state is deliberately kept **outside** tracked files so updates can hard-reset the code without touching your data.
+
+## Map
+
+| Path | What it holds |
+|---|---|
+| `/home/clawbox/clawbox/` | **The app** — git checkout of [ID-Robots/clawbox](https://github.com/ID-Robots/clawbox), branch `main` (or the pinned channel) |
+| `…/clawbox/data/` | **Device state** (gitignored): `config.json` (setup/config KV), `kv.json` (UI state), `.session-secret`, `.mcp-token`, `.local-ai-token`, `network.env`, `hostname.env`, `hotspot.env`, `webapps/`, `code-projects/`, `certs/` |
+| `…/clawbox/.env` | App environment (OAuth client IDs, overrides) — gitignored, survives updates |
+| `…/clawbox/.update-branch` | Update-channel pin (`beta` etc.) — survives updates *and* factory reset |
+| `…/clawbox/config/openclaw-target.txt` | Pinned OpenClaw version for the fleet |
+| `…/clawbox/.next/` | Production build output (`BUILD_ID` = fingerprint of the running build) |
+| `~/.openclaw/` | **OpenClaw state**: `openclaw.json` (gateway config), `agents/<agent>/agent/auth-profiles.json` (**provider credentials**), `agents/<agent>/agent/codex-home/auth.json` (ChatGPT-subscription session), `credentials/telegram-*.json` (pairing approvals), `workspace/` (agent working dir), `npm/` (plugins) |
+| `~/.codex/auth.json` | Codex CLI auth (kept in sync with the agent copies) |
+| `~/.clawkeep/` | ClawKeep backup state: portal `token`, `config.toml`, `state.json`, encryption `passphrase`, `schedule.json` |
+| `~/.npm-global/` | OpenClaw install (`bin/openclaw`) |
+| `~/.bun/bin/bun` | Bun runtime (builds, MCP server) |
+| `/etc/systemd/system/clawbox-*` | Service units |
+| `/etc/avahi/avahi-daemon.conf` | mDNS config |
+| `/usr/share/ollama/` | Downloaded Ollama models |
+
+## Credentials — exactly where secrets live
+
+| Secret | Location | Notes |
+|---|---|---|
+| Login/SSH password | `/etc/shadow` (system account `clawbox`) | Checked by the web login via `unix_chkpwd` |
+| Session signing secret | `data/.session-secret` (0600) | Signs the `clawbox_session` cookie |
+| AI provider API keys / OAuth | `~/.openclaw/agents/main/agent/auth-profiles.json` (0600) | The real secrets. `openclaw.json`'s `auth.profiles` holds **metadata only** (mode/provider) |
+| ChatGPT subscription session | `~/.openclaw/agents/<agent>/agent/codex-home/auth.json` + `~/.codex/auth.json` | Synthesized/healed on gateway start |
+| Gateway token | `openclaw.json → gateway.auth.token` | Per-device random 32-byte hex |
+| MCP bearer | `data/.mcp-token` | Lets the agent's device tools call `/setup-api/*` |
+| Telegram bot token | `data/config.json` + gateway config | |
+| ClawKeep portal token / passphrase | `~/.clawkeep/token`, `~/.clawkeep/passphrase` (0600) | |
+
+## What survives what
+
+| | System update | Factory reset |
+|---|---|---|
+| App code (`/home/clawbox/clawbox` tracked files) | **hard-reset to the release** | hard-reset + wiped state |
+| `data/` (settings, tokens, webapps) | ✅ kept | ❌ wiped (except `network.env`) |
+| `.env` | ✅ kept | ✅ kept (gitignored, not in wipe list) |
+| `.update-branch` (channel pin) | ✅ kept | ✅ kept |
+| `~/.openclaw` (AI config, credentials, chats) | ✅ kept | ❌ wiped |
+| `~/.clawkeep` (backup pairing) | ✅ kept | ❌ wiped |
+| Ollama models | ✅ kept | ❌ deleted |
+| Saved Wi-Fi networks | ✅ kept | ❌ deleted (box returns to AP mode) |
+| SSH `authorized_keys`, shell history, browser profile | ✅ kept | ❌ wiped |
+| System password | ✅ kept | ❌ reset to `clawbox` |
+| Voice models (Whisper/Kokoro caches) | ✅ kept | ✅ kept (can't re-download in AP mode) |
+
+The update mechanism achieves this with `git reset --hard <release>` + `git clean -fd` (note: no `-x` — gitignored paths like `data/` and `.env` are never cleaned). Details: [Update System](/technical/update-system).
+
+## Logs
+
+| Log | Command |
+|---|---|
+| Web OS / login / setup API | `journalctl -u clawbox-setup -n 50 --no-pager` |
+| AI gateway / providers / channels | `journalctl -u clawbox-gateway -n 50 --no-pager` |
+| Update steps (root) | `journalctl -u clawbox-root-update@<step> -n 40 --no-pager` |
+| AI browser (Chromium/CDP) | `/tmp/clawbox-browser.log` |

--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Filesystem Layout"
+icon: "folder-tree"
 summary: "Where everything lives on the device — app, config, credentials, agent state — and what survives updates and factory resets."
 ---
 

--- a/docs-site/technical/networking.mdx
+++ b/docs-site/technical/networking.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Networking"
+icon: "network-wired"
 summary: "AP setup mode, captive portal, mDNS discovery, finding the device IP, and the complete port map."
 ---
 
@@ -10,10 +11,10 @@ summary: "AP setup mode, captive portal, mDNS discovery, finding the device IP, 
 | Property | Value |
 |---|---|
 | SSID | `ClawBox-Setup` (open by default; WPA-PSK if a hotspot password was configured) |
-| AP address | `10.42.0.1/24` — automatic fallback `10.43.0.1/24` if the primary subnet is already in use upstream |
+| AP address | `10.42.0.1/24` normally; the box automatically falls back to `10.43.0.1/24` if the primary subnet is already in use upstream — the captive portal and wizard follow whichever is active |
 | Wi-Fi interface | `wlP1p1s0` (Jetson default; overridable via `NETWORK_INTERFACE`) |
-| DNS | dnsmasq answers **every** name with the AP address (captive hijack) |
-| Captive portal | OS probe URLs (`/generate_204`, `/hotspot-detect.html`, `/ncsi.txt`, …) are intercepted by the web app's middleware and redirected to `http://10.42.0.1/` — phones auto-open the wizard |
+| DNS | dnsmasq answers **every** name with the active AP address (captive hijack) |
+| Captive portal | OS probe URLs (`/generate_204`, `/hotspot-detect.html`, `/ncsi.txt`, …) are intercepted by the web app's middleware and redirected to the active AP address — phones auto-open the wizard |
 | Watchdog | `clawbox-ap-watchdog.timer` re-raises the hotspot every 20 s until setup completes |
 
 If an Ethernet uplink is connected while in AP mode, the box **shares** that internet connection to hotspot clients (IP forwarding + NAT).

--- a/docs-site/technical/networking.mdx
+++ b/docs-site/technical/networking.mdx
@@ -1,0 +1,66 @@
+---
+title: "Networking"
+summary: "AP setup mode, captive portal, mDNS discovery, finding the device IP, and the complete port map."
+---
+
+## Two network modes
+
+**Setup mode (AP)** — when unconfigured (or when it can't join a known network), the box hosts its own Wi-Fi:
+
+| Property | Value |
+|---|---|
+| SSID | `ClawBox-Setup` (open by default; WPA-PSK if a hotspot password was configured) |
+| AP address | `10.42.0.1/24` — automatic fallback `10.43.0.1/24` if the primary subnet is already in use upstream |
+| Wi-Fi interface | `wlP1p1s0` (Jetson default; overridable via `NETWORK_INTERFACE`) |
+| DNS | dnsmasq answers **every** name with the AP address (captive hijack) |
+| Captive portal | OS probe URLs (`/generate_204`, `/hotspot-detect.html`, `/ncsi.txt`, …) are intercepted by the web app's middleware and redirected to `http://10.42.0.1/` — phones auto-open the wizard |
+| Watchdog | `clawbox-ap-watchdog.timer` re-raises the hotspot every 20 s until setup completes |
+
+If an Ethernet uplink is connected while in AP mode, the box **shares** that internet connection to hotspot clients (IP forwarding + NAT).
+
+**Steady state (LAN)** — after setup, the box joins your network and is reachable at:
+
+1. `http://<LAN-IP>` — always works; the canonical fallback.
+2. `http://clawbox.local` — mDNS via avahi (hostname configurable in Settings).
+
+## Why `clawbox.local` sometimes fails — and what to do
+
+mDNS (multicast DNS) is what resolves `.local` names, and it's the least reliable part of consumer networks:
+
+- **Windows** historically resolves mDNS poorly (better in 11, still flaky).
+- **Routers/APs often drop multicast between Wi-Fi and wired segments** — a wired ClawBox may be invisible by name to Wi-Fi laptops (and vice versa) while being perfectly reachable by IP.
+- **Guest networks and VPNs** isolate clients from mDNS entirely.
+
+The box already ships mitigations (avahi tuned for Windows quirks, re-announce on network changes) — but when the name fails, **use the IP**. Find it via:
+
+- Your router's connected-devices list (look for `clawbox`).
+- Over SSH (if `ssh clawbox@clawbox.local` still works in a terminal): `hostname -I` — first entry.
+- The device screen/desktop if a display is attached (System Tray → network).
+
+<Tip>Reserve the box's IP in your router's DHCP settings ("address reservation" / "static lease") so it never changes — then bookmark it.</Tip>
+
+## Port map
+
+| Port | What | Exposure |
+|---|---|---|
+| **80** | ClawBox web OS (login, desktop, wizard, `/setup-api/*`) | LAN |
+| 443 | HTTPS (only if certs are installed at `data/certs/`) | LAN |
+| **18789** | OpenClaw gateway | **loopback only** — proxied through port 80; opening it directly in a browser is a common mistake (it won't accept your password) |
+| 3006 | Terminal (xterm.js) WebSocket PTY | LAN (proxied at `/terminal-ws`) |
+| 5900 / 6080 | x11vnc / noVNC websockify (Remote Desktop app) | localhost / proxied at `/novnc-ws` |
+| 18800 | Chromium DevTools Protocol (AI browser control) | localhost |
+| 11434 | Ollama (local models) | localhost |
+| 8080 | llama.cpp server (optional) | localhost |
+| 8880 | Kokoro TTS (voice) | localhost |
+| 22 | SSH (`ssh clawbox@<ip>`) | LAN |
+
+## Remote access
+
+- **Cloudflare Quick Tunnel** — `clawbox-tunnel.service` (toggle via Settings / `setup-api/tunnel/*`) exposes port 80 through a temporary `*.trycloudflare.com` URL written to `data/cloudflared/tunnel.url`. No port-forwarding required.
+- **SSH** — standard Ubuntu OpenSSH on port 22, user `clawbox`, same password as the browser login.
+- The gateway's allowed origins are managed automatically (localhost, `<hostname>.local`, the AP addresses, and the box's live LAN IPs) — this is refreshed on every gateway start.
+
+## DNS & hostname
+
+- Hostname defaults to `clawbox`; changing it (Settings → System) updates `hostnamectl`, avahi (`<name>.local`), and is persisted in `data/hostname.env`.
+- In AP mode, `clawbox.local` is additionally answered by dnsmasq (mDNS doesn't traverse the hotspot reliably).

--- a/docs-site/technical/networking.mdx
+++ b/docs-site/technical/networking.mdx
@@ -46,7 +46,7 @@ The box already ships mitigations (avahi tuned for Windows quirks, re-announce o
 |---|---|---|
 | **80** | ClawBox web OS (login, desktop, wizard, `/setup-api/*`) | LAN |
 | 443 | HTTPS (only if certs are installed at `data/certs/`) | LAN |
-| **18789** | OpenClaw gateway | **loopback only** — proxied through port 80; opening it directly in a browser is a common mistake (it won't accept your password) |
+| **18789** | OpenClaw gateway | LAN, **token-gated** — the page loads, but never browse it directly: it won't accept your password. Everything goes through port 80 |
 | 3006 | Terminal (xterm.js) WebSocket PTY | LAN (proxied at `/terminal-ws`) |
 | 5900 / 6080 | x11vnc / noVNC websockify (Remote Desktop app) | localhost / proxied at `/novnc-ws` |
 | 18800 | Chromium DevTools Protocol (AI browser control) | localhost |

--- a/docs-site/technical/quick-reference.mdx
+++ b/docs-site/technical/quick-reference.mdx
@@ -1,0 +1,117 @@
+---
+title: "Quick Reference"
+summary: "The one-page fact sheet: ports, paths, services, commands, API endpoints, and known gotchas — optimized for fast scanning by humans and AI agents."
+---
+
+Everything load-bearing about a ClawBox on one page. Facts only — explanations live in the linked chapters.
+
+## Identity
+
+| Fact | Value |
+|---|---|
+| Product | ClawBox — OpenClaw OS on NVIDIA Jetson (Ubuntu 22.04 aarch64) |
+| Repo | `github.com/ID-Robots/clawbox` · releases = `vX.Y.Z` tags on `main` · integration branch `beta` |
+| System user | `clawbox` (uid 1000) · one password for SSH **and** browser login |
+| Web UI | `http://<box-ip>` (port 80) · `http://clawbox.local` when mDNS works |
+| Setup hotspot | SSID `ClawBox-Setup` → `http://10.42.0.1` (fallback subnet `10.43.0.1`) |
+| Stack | Next.js 16 / React 19 / Node 22 runtime / Bun builds / OpenClaw gateway (npm-pinned) |
+
+## Ports
+
+| Port | Service | Exposure |
+|---|---|---|
+| 80 | Web OS (`clawbox-setup`) — UI, login, `/setup-api/*`, proxies to gateway | LAN |
+| 18789 | OpenClaw gateway | **loopback only** — never browse it directly |
+| 22 | SSH | LAN |
+| 3006 | Terminal WS (proxied at `/terminal-ws`) | via 80 |
+| 5900/6080 | VNC / noVNC (proxied at `/novnc-ws`) | via 80 |
+| 18800 | Chromium CDP (AI browser) | localhost |
+| 11434 | Ollama | localhost |
+| 8080 / 8880 | llama.cpp / Kokoro TTS | localhost |
+
+## Paths
+
+| Path | Contents |
+|---|---|
+| `/home/clawbox/clawbox` | App (git checkout) |
+| `…/clawbox/data/` | Device state: `config.json`, `kv.json`, `.session-secret`, `.mcp-token`, `network.env` — survives updates, wiped by factory reset (except `network.env`) |
+| `…/clawbox/.env` | App env — survives everything |
+| `…/clawbox/.update-branch` | Channel pin (`beta`) — survives everything |
+| `…/clawbox/config/openclaw-target.txt` | Pinned OpenClaw version |
+| `~/.openclaw/openclaw.json` | Gateway config (auth **metadata** only) |
+| `~/.openclaw/agents/main/agent/auth-profiles.json` | **Real provider credentials** |
+| `~/.openclaw/agents/<agent>/agent/codex-home/auth.json` | ChatGPT-subscription session (synced per-agent) |
+| `~/.openclaw/credentials/telegram-*.json` | Telegram pairing approvals |
+| `~/.clawkeep/` | Backup pairing/config/passphrase |
+| `~/.npm-global/bin/openclaw` | Gateway binary |
+
+## Services (systemd)
+
+`clawbox-setup` (web, port 80) · `clawbox-gateway` (OpenClaw, pre-start self-heal script) · `clawbox-ap` (+`-watchdog.timer`) · `clawbox-vnc` + `clawbox-websockify` · `clawbox-browser` (CDP, on demand) · `clawbox-heartbeat.timer` · `clawbox-tunnel` (optional) · `clawbox-performance` · `clawbox-root-update@<step>` (privileged installer steps) · `ollama`.
+
+## Commands (over SSH)
+
+```bash
+# Health / logs
+systemctl status clawbox-setup clawbox-gateway --no-pager
+journalctl -u clawbox-setup -n 50 --no-pager      # web/login
+journalctl -u clawbox-gateway -n 50 --no-pager    # AI/providers/channels
+
+# Restart services
+sudo systemctl restart clawbox-setup clawbox-gateway
+
+# Update (full, correct way)
+sudo clawbox update            # == sudo bash /home/clawbox/clawbox/install.sh
+
+# Targeted repairs
+sudo bash install.sh --step gateway_setup     # fixes 'gateway token mismatch'
+sudo bash install.sh --step openclaw_install  # fixes stale core / 'Unrecognized key' / plugin skew
+
+# Password
+sudo passwd clawbox            # new password, effective everywhere immediately
+
+# Channel
+echo beta > /home/clawbox/clawbox/.update-branch   # opt into beta (delete file to leave)
+
+# Login check (exactly what the web app does)
+read -rsp 'PW: ' PW; echo; printf '%s\0' "$PW" | /usr/sbin/unix_chkpwd clawbox nullok; echo "exit=$?"; unset PW
+
+# Login API check (bypasses browser)
+curl -sS -X POST http://localhost/login-api -H 'Content-Type: application/json' -d '{"password":"…","duration":1200}'
+```
+
+## Key API endpoints (`/setup-api/*`, session-cookie or MCP-bearer auth)
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /login-api` `{password,duration}` | Login → `clawbox_session` cookie (durations 1200/21600/43200/86400 s) |
+| `GET /setup-api/system/info` · `system/stats` | Device info / live metrics |
+| `POST /setup-api/system/credentials` | Change password |
+| `POST /setup-api/system/power` | Restart/shutdown |
+| `GET /setup-api/update/versions?force=1` | Version check (fresh) |
+| `POST /setup-api/update/run` · `GET update/status` | Run update / poll progress |
+| `POST /setup-api/update/reset` | Reset-to-channel & update *(beta)* |
+| `GET/POST /setup-api/system/update-branch` | Read/set channel |
+| `POST /setup-api/ai-models/configure` | Write provider config |
+| `GET /setup-api/ai-models/status` · `catalog?provider=…` | Provider status / live model catalog |
+| `POST /setup-api/telegram/configure` · `pairing` | Bot token / approve pairing codes |
+| `GET /setup-api/gateway/health` · `ws-config` | Gateway health / WS URL + token |
+| `POST /setup-api/setup/reset` | **Factory reset** (destructive) |
+| `wifi/*`, `files/*`, `apps/*`, `clawkeep/*`, `code/*`, `preferences` | Wi-Fi, file manager, app store, backups, code projects, prefs |
+
+## Gotchas (hard-won)
+
+1. **`:18789` never accepts your password** — it's the gateway; use plain `http://<ip>`.
+2. **Browser login ≠ separate password** — same Linux password as SSH; failures are usually autofill, `unix_chkpwd` perms (`-rwxr-sr-x root shadow`), a stale build, or password encoding. Ladder: [Troubleshooting](/support/troubleshooting#the-browser-rejects-my-password-but-ssh-accepts-it).
+3. **`git pull` is not an update** — always finish with `sudo bash install.sh`; otherwise service files + OpenClaw core go stale (`token mismatch`, `Unrecognized key`).
+4. **Local commits silently block updates** on stable ≤ current release ("up to date" forever); beta shows "Updates paused" + one-click reset. Manual fix = hard-sync ([Recovery C](/support/recovery#c--safe-reinstall-1015-minutes-no-data-loss)).
+5. **Two OpenAI lanes**: API key = `openai/…` + `sk-…` key; ChatGPT subscription = `codex/…` + OAuth. Different catalogs (`gpt-5` vs `gpt-5.4/5.5`), different credentials. Stale-key 401s after switching are self-healed on beta.
+6. **Secrets live in `auth-profiles.json`**, not `openclaw.json` (metadata only). The codex session is *additionally* per-agent in `codex-home/auth.json`.
+7. **`clawbox.local` failing ≠ box down** — mDNS/Windows/router multicast issue; the IP always works.
+8. **The last update step reboots the box** — 1–2 min offline is normal, not a hang.
+9. **Factory reset password is `clawbox`** — and the box comes back in AP mode (`ClawBox-Setup` → `10.42.0.1`).
+10. **Version label ≠ running code** — `package.json` is read live; verify actual deployment via `.next/BUILD_ID` mtime.
+
+## Chapter index
+
+[Architecture](/technical/architecture) · [Networking](/technical/networking) · [Filesystem](/technical/filesystem) · [Auth & Security](/technical/authentication) · [AI Providers](/technical/ai-providers) · [Update System](/technical/update-system) · [Agent Interface](/technical/agent-interface) · [Troubleshooting](/support/troubleshooting) · [Recovery](/support/recovery)

--- a/docs-site/technical/quick-reference.mdx
+++ b/docs-site/technical/quick-reference.mdx
@@ -22,10 +22,10 @@ Everything load-bearing about a ClawBox on one page. Facts only — explanations
 | Port | Service | Exposure |
 |---|---|---|
 | 80 | Web OS (`clawbox-setup`) — UI, login, `/setup-api/*`, proxies to gateway | LAN |
-| 18789 | OpenClaw gateway | **loopback only** — never browse it directly |
+| 18789 | OpenClaw gateway | LAN, token-gated — **never browse it directly** |
 | 22 | SSH | LAN |
-| 3006 | Terminal WS (proxied at `/terminal-ws`) | via 80 |
-| 5900/6080 | VNC / noVNC (proxied at `/novnc-ws`) | via 80 |
+| 3006 | Terminal WS (proxied at `/terminal-ws`) | LAN |
+| 5900/6080 | VNC (localhost) / noVNC (proxied at `/novnc-ws`) | localhost / LAN |
 | 18800 | Chromium CDP (AI browser) | localhost |
 | 11434 | Ollama | localhost |
 | 8080 / 8880 | llama.cpp / Kokoro TTS | localhost |

--- a/docs-site/technical/quick-reference.mdx
+++ b/docs-site/technical/quick-reference.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Quick Reference"
+icon: "bolt"
 summary: "The one-page fact sheet: ports, paths, services, commands, API endpoints, and known gotchas — optimized for fast scanning by humans and AI agents."
 ---
 
@@ -97,7 +98,7 @@ curl -sS -X POST http://localhost/login-api -H 'Content-Type: application/json' 
 | `POST /setup-api/telegram/configure` · `pairing` | Bot token / approve pairing codes |
 | `GET /setup-api/gateway/health` · `ws-config` | Gateway health / WS URL + token |
 | `POST /setup-api/setup/reset` | **Factory reset** (destructive) |
-| `wifi/*`, `files/*`, `apps/*`, `clawkeep/*`, `code/*`, `preferences` | Wi-Fi, file manager, app store, backups, code projects, prefs |
+| `/setup-api/wifi/*` · `files/*` · `apps/*` · `clawkeep/*` · `code/*` · `preferences` | Wi-Fi, file manager, app store, backups, code projects, prefs (all under `/setup-api/`) |
 
 ## Gotchas (hard-won)
 

--- a/docs-site/technical/update-system.mdx
+++ b/docs-site/technical/update-system.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Update System"
+icon: "arrows-rotate"
 summary: "How ClawBox updates work: release tags, the update pipeline, channels, what survives, divergence handling, and manual-update pitfalls."
 ---
 

--- a/docs-site/technical/update-system.mdx
+++ b/docs-site/technical/update-system.mdx
@@ -1,0 +1,82 @@
+---
+title: "Update System"
+summary: "How ClawBox updates work: release tags, the update pipeline, channels, what survives, divergence handling, and manual-update pitfalls."
+---
+
+ClawBox updates are **git-based**: the device tracks the [ID-Robots/clawbox](https://github.com/ID-Robots/clawbox) repository, and a release is a `vX.Y.Z` tag on the `main` branch. The updater hard-syncs the code to the release and rebuilds in place.
+
+## How the device decides an update exists
+
+1. Fetch tags from origin.
+2. Consider only tags matching `vX.Y.Z`, newest first.
+3. Offer the newest tag whose history **contains the device's current commit** (a fast-forward). A device whose code has diverged from the release line sees no offer — see [Divergence](#divergence-updates-paused) below.
+4. The "Installed" version is read from `package.json`; OpenClaw's target version comes from the pin file `config/openclaw-target.txt`.
+
+## The update pipeline
+
+Started from the **System Update** app (or Settings). Steps, in order — each privileged step runs as a `clawbox-root-update@<step>` systemd unit:
+
+| Step | What it does |
+|---|---|
+| `bootstrap_updater` | Refreshes `install.sh` itself from origin first (so the rest runs the *new* updater) |
+| `apt_update` | System packages |
+| `nvidia_jetpack` | Jetson components |
+| `performance_mode` | Max-performance profile |
+| `chromium_install` / `vnc_install` | Desktop browser + remote display stack |
+| `openclaw_install` | OpenClaw core → **pinned** version from `config/openclaw-target.txt`, plus re-pins all `@openclaw/*` plugins to match |
+| `openclaw_patch` | Applies ClawBox's gateway patches |
+| `gateway_setup` | (Re)installs the gateway service file + drop-ins |
+| `restart` | **The hard-sync + rebuild**: `git fetch` → `git reset --hard HEAD` → checkout channel branch → `git reset --hard origin/<channel>` → `git clean -fd` → full `bun install` + `next build` → **reboot** |
+| `post_update` | Fixups (hostname, dispatcher, smoke checks) — advisory |
+
+Key properties:
+
+- **`git clean -fd` (no `-x`)** — gitignored paths are never touched, which is what preserves `data/`, `.env`, `node_modules`, and your state. See [what survives](/technical/filesystem#what-survives-what).
+- **The final step reboots the box.** Expect ~1–2 minutes of unreachability; the UI reconnects and resumes progress reporting afterwards.
+- After reboot, completion is only reported if the build fingerprint (`.next/BUILD_ID`) actually changed and the rebuild unit succeeded — a failed rebuild surfaces as a failed step, not a silent "complete".
+
+## Update channels
+
+The channel is a one-line file: `/home/clawbox/clawbox/.update-branch` (absent = `main`).
+
+- **`main`** — stable releases. Default.
+- **`beta`** — the integration branch, for early adopters and testing fixes ahead of release.
+
+Switch in **System Update → Advanced options** (Beta toggle / branch override), or over SSH: `echo beta > /home/clawbox/clawbox/.update-branch`. The pin survives updates **and** factory resets; clear it from the same UI or by deleting the file. All update mechanisms (UI, installer, recovery script) honor it.
+
+## Ways to update
+
+| Method | What it runs | When to use |
+|---|---|---|
+| **System Update app** (UI) | The full pipeline above | Normal case |
+| `sudo clawbox update` (SSH) | Full `install.sh` in place | Headless/remote maintenance |
+| `sudo bash install.sh` | Same as above | After manual git operations |
+| `bash <(curl -fsSL …/scripts/force-update.sh)` | Standalone hard-sync + rebuild | When the updater itself is broken — see [Recovery](/support/recovery#c--safe-reinstall-1015-minutes-no-data-loss) |
+
+<Warning>
+**A manual `git pull` + service restart is *not* an update.** It skips `openclaw_install` (core version pin) and `gateway_setup` (service files) — the two most common sources of "updated but broken" states: `gateway token mismatch` errors and `Config validation failed: Unrecognized key`. If you touched the checkout manually, finish with a full `sudo bash install.sh`. Details: [Troubleshooting](/support/troubleshooting#update-finished-but-the-box-misbehaves).
+</Warning>
+
+## Divergence ("Updates paused")
+
+If the device's git history gains **local commits** (an on-box agent committing, manual edits), its HEAD is no longer an ancestor of any release tag → the updater has nothing safe to fast-forward to, and on stable releases the device silently reports "up to date" forever.
+
+On the **beta channel** (and the next stable release), this state is detected explicitly (`ahead > 0 && behind > 0` vs the channel) and surfaced in the System Update app as:
+
+> **Updates paused** — this device is on a non-release branch with local changes (N commits ahead of main). Reset to main to resume updates.
+
+…with a one-click **Reset to `<channel>` & update** button (confirmation-gated — it discards local *code* commits, keeps all data) that pins the channel and runs the normal update. The equivalent manual fix is the hard-sync in [Recovery → Safe reinstall](/support/recovery#c--safe-reinstall-1015-minutes-no-data-loss).
+
+## OpenClaw version pinning
+
+The fleet never floats on `openclaw@latest`. `config/openclaw-target.txt` pins the exact core version; the same value pins every `@openclaw/*` plugin (version skew between core and the `@openclaw/codex` plugin breaks ChatGPT-subscription chats). Bumping the pin is a normal PR → beta-validation → release flow.
+
+## Related endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /setup-api/update/versions` | Installed/target versions (add `?force=1` to bypass the 60 s cache) |
+| `POST /setup-api/update/run` | Start the full update |
+| `GET /setup-api/update/status` | Live step progress (polled by the UI) |
+| `POST /setup-api/update/reset` | Reset-to-channel & update *(beta)* |
+| `GET/POST /setup-api/system/update-branch` | Read/set the channel pin |

--- a/docs-site/technical/update-system.mdx
+++ b/docs-site/technical/update-system.mdx
@@ -24,7 +24,7 @@ Started from the **System Update** app (or Settings). Steps, in order — each p
 | `nvidia_jetpack` | Jetson components |
 | `performance_mode` | Max-performance profile |
 | `chromium_install` / `vnc_install` | Desktop browser + remote display stack |
-| `openclaw_install` | OpenClaw core → **pinned** version from `config/openclaw-target.txt`, plus re-pins all `@openclaw/*` plugins to match |
+| `openclaw_install` | OpenClaw core → **pinned** version from `config/openclaw-target.txt`, plus re-pins all `@openclaw/*` plugins to match (the fleet never floats on `@latest` — version skew between core and the `@openclaw/codex` plugin breaks ChatGPT-subscription chats; pin bumps ship via the normal PR → beta → release flow) |
 | `openclaw_patch` | Applies ClawBox's gateway patches |
 | `gateway_setup` | (Re)installs the gateway service file + drop-ins |
 | `restart` | **The hard-sync + rebuild**: `git fetch` → `git reset --hard HEAD` → checkout channel branch → `git reset --hard origin/<channel>` → `git clean -fd` → full `bun install` + `next build` → **reboot** |
@@ -67,10 +67,6 @@ On the **beta channel** (and the next stable release), this state is detected ex
 > **Updates paused** — this device is on a non-release branch with local changes (N commits ahead of main). Reset to main to resume updates.
 
 …with a one-click **Reset to `<channel>` & update** button (confirmation-gated — it discards local *code* commits, keeps all data) that pins the channel and runs the normal update. The equivalent manual fix is the hard-sync in [Recovery → Safe reinstall](/support/recovery#c--safe-reinstall-1015-minutes-no-data-loss).
-
-## OpenClaw version pinning
-
-The fleet never floats on `openclaw@latest`. `config/openclaw-target.txt` pins the exact core version; the same value pins every `@openclaw/*` plugin (version skew between core and the `@openclaw/codex` plugin breaks ChatGPT-subscription chats). Bumping the pin is a normal PR → beta-validation → release flow.
 
 ## Related endpoints
 


### PR DESCRIPTION
Full documentation build-out for docs.clawbox.tech — technical reference, deep troubleshooting, and agent-scannability. Modeled on docs.openclaw.ai's structure (concepts / reference / symptom-first troubleshooting) and **fact-checked against the codebase** (service units, install.sh, updater.ts, auth.ts, configure/route.ts, gateway-pre-start.sh, clawbox-mcp.ts).

## New: Technical Reference tab (8 pages)

| Page | Covers |
|---|---|
| **Quick Reference** | One-page fact sheet: ports, paths, services, commands, API endpoints, 10 hard-won gotchas — the anchor page for power users and AI agents |
| Architecture | Service topology (all 12 units), request routing (port 80 → gateway), boot lifecycle, ClawBox↔OpenClaw relationship |
| Networking | AP mode + captive portal, mDNS/`clawbox.local` reliability (why it fails, what to do), full port map, remote access |
| Filesystem | On-disk layout, exact secret locations, what survives updates vs factory reset |
| Authentication | Login flow (`unix_chkpwd` requirements), session cookies, gateway token, MCP/local-AI tokens, security posture |
| AI Providers | Every lane (incl. **the two OpenAI lanes** `openai/` vs `codex/`), credential storage map, compat routing, boot-time self-heals |
| Update System | Tag-based updates, the pipeline steps, channels, divergence/"Updates paused", manual-update pitfalls |
| Agent Interface | Full MCP tool catalog (~50 tools), `clawbox` CLI, auth model |

## Upgraded: Support

- **Troubleshooting** — rewritten symptom-first with diagnostic ladders drawn from June's real support cases: browser-rejects-password-but-SSH-works (autofill → `unix_chkpwd` test → login-API curl → perms → stale build → passwd reset), silent update suppression on diverged boxes, `gateway token mismatch` / `Unrecognized key` after manual updates, provider 401s after switching to the ChatGPT subscription, Telegram pairing.
- **Recovery (new)** — ordered playbook: A password reset → B service restart → C safe reinstall → D factory reset (UI + SSH paths, post-reset steps, "which option do I need" table).

## Agent scannability

- **`llms.txt`** published at the site root (one-line `docs-deploy.yml` addition copies it into the export) — the standard LLM discovery index with per-page descriptions.
- Tables-over-prose throughout; every fact traceable to code.

## Notes

- **Version labeling is accurate**: beta-only features (updates-paused UI, provider self-heals from #222/#223/#224) are explicitly labeled beta-channel — v3.1.5 stable shipped without them. When the beta payload reaches stable, s/beta channel/vX.Y.Z+/ is a follow-up docs PR.
- Validated locally: `mint export` builds all **24 pages** clean (was 15).
- Merging this auto-deploys via the docs pipeline, including `/llms.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the documentation site with new technical reference sections covering architecture, networking, authentication, filesystem layout, updates, AI providers, and agent integration.
  * Added a new homepage “Going deeper” area linking to technical reference and recovery guides.

* **Bug Fixes**
  * Improved troubleshooting and recovery guidance with clearer symptom-based steps, log locations, and safer restore options.
  * Ensured `llms.txt` is included in the published site output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->