### PR TITLE
fix(ui): standardize Discord invite to canonical discord.gg/vsTsaY4Tuk

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Found a vulnerability? **Do not open a public issue.** Email **yanko@idrobots.co
 
 ## Community
 
-- [Discord](https://discord.gg/FbKmnxYnpq) — get help, share your setup
+- [Discord](https://discord.gg/vsTsaY4Tuk) — get help, share your setup
 - [Discussions](https://github.com/ID-Robots/clawbox/discussions) — ideas and Q&A
 
 ## Code of Conduct

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -2973,7 +2973,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
             </a>
 
             <a
-              href="https://discord.gg/FbKmnxYnpq"
+              href="https://discord.gg/vsTsaY4Tuk"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-3 bg-white/5 rounded-xl px-4 py-3 text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] transition-colors no-underline"

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -622,7 +622,7 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
           <Image src="/clawbox-logo.png" alt="ClawBox" width={28} height={28} className="w-7 h-7 object-contain" />
         </a>
         <a
-          href="https://discord.gg/FbKmnxYnpq"
+          href="https://discord.gg/vsTsaY4Tuk"
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Join our Discord"

--- a/src/components/Taskbar.tsx
+++ b/src/components/Taskbar.tsx
@@ -61,7 +61,7 @@ export default function Taskbar({ windows, onWindowClick, onExternalLink }: Task
             />
           </button>
           <button
-            onClick={() => onExternalLink("https://discord.gg/FbKmnxYnpq")}
+            onClick={() => onExternalLink("https://discord.gg/vsTsaY4Tuk")}
             aria-label="Join our Discord"
             className="flex items-center justify-center w-10 h-10 rounded-xl bg-[var(--bg-elevated)] border border-[var(--border-subtle)] text-[#5865F2] transition transform hover:scale-110"
             title="Discord"


### PR DESCRIPTION
The device UI (Settings → Discord link, setup-wizard error screen, taskbar) and CONTRIBUTING.md still linked the stale invite `FbKmnxYnpq`. The canonical community invite is `vsTsaY4Tuk` — already used across docs.clawbox.tech and (as of #236) the README. String-only change, no logic touched.