### PR TITLE
chore: sync issue-triage files with main (post-#238)

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -7,10 +7,6 @@ on:
   issues:
     types: [opened, reopened]
 
-permissions:
-  issues: write
-  contents: read
-
 concurrency:
   group: issue-triage-${{ github.event.issue.number }}
   cancel-in-progress: true
@@ -18,25 +14,37 @@ concurrency:
 jobs:
   triage:
     runs-on: ubuntu-latest
+    # Job-scoped (not workflow-scoped) so future jobs don't inherit write
+    # access: the triage script labels + comments via GH_TOKEN.
+    permissions:
+      issues: write
+      contents: read
     # Skip issues opened by bots to avoid loops.
     if: ${{ !endsWith(github.actor, '[bot]') }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        # SHA-pinned: this workflow runs on every opened issue with
+        # issues:write and a paid API secret in scope.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # The script auths to GitHub via GH_TOKEN only — no need to persist
           # GITHUB_TOKEN into the runner's git config.
           persist-credentials: false
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
 
       - name: Install Anthropic SDK
         # Pinned — the script depends on the output_config + messages.create
         # shapes; a floating latest could shift them. Bump deliberately.
-        run: npm install --no-save @anthropic-ai/sdk@0.106.0
+        # --prefix scripts: installing at the repo root makes npm reify the
+        # ENTIRE project tree (node-pty gyp compile + Playwright browser
+        # downloads ≈ minutes per issue, plus flake risk on this bun-managed
+        # tree). Scoped to scripts/, only the SDK installs (~5 s); ESM
+        # resolution finds scripts/node_modules from the script's own path.
+        run: npm install --prefix scripts --no-save @anthropic-ai/sdk@0.106.0
 
       - name: Triage with Claude
         env:

--- a/scripts/issue-triage.mjs
+++ b/scripts/issue-triage.mjs
@@ -56,15 +56,22 @@ async function main() {
     ],
   });
 
-  const text = resp.content.find((b) => b.type === "text")?.text ?? "{}";
+  const text = resp.content.find((b) => b.type === "text")?.text;
+  // Throw rather than default to "{}" — an empty object here would create
+  // and apply labels literally named "undefined"; the outer catch logs and
+  // exits 0 (triage must never fail issue creation).
+  if (!text) throw new Error("no text block in model response");
   const t = JSON.parse(text);
 
   // Ensure the priority/area labels exist (idempotent), then apply.
   const ensure = (name, color, desc) => {
     try {
       gh(["label", "create", name, "--color", color, "--description", desc, "--repo", REPO]);
-    } catch {
-      /* label already exists — fine */
+    } catch (err) {
+      // Usually "label already exists" (fine); log the message so a real
+      // failure (auth, rate limit) is diagnosable instead of silently
+      // degrading into an `issue edit` error with no context.
+      console.log(`label ensure '${name}':`, err?.message?.split("\n")[0] ?? err);
     }
   };
   const prioColor = t.priority === "high" ? "b60205" : t.priority === "medium" ? "fbca04" : "0e8a16";


### PR DESCRIPTION
Byte-for-byte sync of `issue-triage.yml` + `scripts/issue-triage.mjs` with main after #238's review fixes (job-scoped permissions, SHA-pinned actions, `--prefix scripts` install, throw-on-missing-text, logged label ensure). Keeps the branches identical so the next release merge can't add/add-conflict. No behavior change on beta — these files only function on the default branch anyway.