### PR TITLE
fix(ci): lazy-load Anthropic SDK so the bots' OAuth path needs no SDK

### DIFF
--- a/scripts/issue-triage.mjs
+++ b/scripts/issue-triage.mjs
@@ -4,7 +4,9 @@
 // Needs: ANTHROPIC_API_KEY (repo secret) and GH_TOKEN (the workflow's GITHUB_TOKEN).
 import fs from "node:fs";
 import { execFileSync } from "node:child_process";
-import Anthropic from "@anthropic-ai/sdk";
+// NB: @anthropic-ai/sdk is imported lazily inside classifyViaSdk() — the OAuth
+// transport installs only the Claude Code CLI, not the SDK, so a static
+// top-level import would ERR_MODULE_NOT_FOUND before any code runs.
 
 // Haiku 4.5 — fast and cheap, ideal for a high-volume issue classifier.
 // Switch to "claude-opus-4-8" for maximum classification accuracy.
@@ -75,7 +77,8 @@ function classifyViaClaudeCli(userContent) {
 }
 
 async function classifyViaSdk(userContent) {
-  const client = new Anthropic(); // reads ANTHROPIC_API_KEY from env
+  const { default: Anthropic } = await import("@anthropic-ai/sdk"); // reads ANTHROPIC_API_KEY from env
+  const client = new Anthropic();
   const resp = await client.messages.create({
     model: MODEL,
     max_tokens: 1024,

--- a/scripts/pr-review.mjs
+++ b/scripts/pr-review.mjs
@@ -8,7 +8,9 @@
 // logs and exits 0 — a broken bot must never block a PR.
 import fs from "node:fs";
 import { execFileSync } from "node:child_process";
-import Anthropic from "@anthropic-ai/sdk";
+// NB: @anthropic-ai/sdk is imported lazily inside reviewViaSdk() — the OAuth
+// transport installs only the Claude Code CLI, not the SDK, so a static
+// top-level import would ERR_MODULE_NOT_FOUND before any code runs.
 
 // Sonnet: PR review needs real reasoning; still cents per run at PR-diff sizes.
 const MODEL = "claude-sonnet-4-6";
@@ -243,6 +245,7 @@ function reviewViaClaudeCli(userPrompt) {
 }
 
 async function reviewViaSdk(userPrompt) {
+  const { default: Anthropic } = await import("@anthropic-ai/sdk");
   const client = new Anthropic();
   const resp = await client.messages.create({
     model: MODEL,


### PR DESCRIPTION
**Hotfix for the live bots on main.** The OAuth transport (#248) installs only the Claude Code CLI, not `@anthropic-ai/sdk` — but both `scripts/pr-review.mjs` and `scripts/issue-triage.mjs` had a static top-level `import Anthropic from "@anthropic-ai/sdk"`, evaluated at module load regardless of which transport runs. Result: the `review` / `triage` job crashes with `ERR_MODULE_NOT_FOUND` before doing anything.

It slipped through because my local test machine still had the SDK installed from an earlier run; CI (OAuth-only install) exposed it — caught on the #250 CI run.

**Fix:** move the import to a dynamic `await import("@anthropic-ai/sdk")` inside `reviewViaSdk` / `classifyViaSdk`, reached only on the API-key fallback path. The OAuth/CLI path never touches it.

**Verified** by running the OAuth path locally with `scripts/node_modules` removed — full review produced, no SDK present. The identical fix rides to beta in #250.