### PR TITLE
docs: clarify managed ClawBox messaging channels

### DIFF
--- a/docs-site/guides/messaging-channels.mdx
+++ b/docs-site/guides/messaging-channels.mdx
@@ -1,53 +1,59 @@
 ---
 title: "Messaging Channels"
 icon: "comments"
-summary: "Connect Telegram, WhatsApp, Discord, and other chat apps to your ClawBox."
+summary: "Connect Telegram, use web chat, and understand which OpenClaw channels are managed by ClawBox versus advanced extensions."
 ---
 
 ClawBox runs OpenClaw, which connects to your favorite chat apps so you can message
-your assistant from anywhere. One device serves multiple channels at once.
+your assistant from anywhere. The managed ClawBox setup path currently focuses on
+Telegram plus the on-device web chat. Other OpenClaw channels may be possible, but
+they are advanced configuration unless they appear in your device UI.
 
 ## Supported channels
 
-<Columns cols={3}>
+<Columns cols={2}>
   <Card title="Telegram" icon="telegram" />
-  <Card title="WhatsApp" icon="whatsapp" />
-  <Card title="Discord" icon="discord" />
   <Card title="Web Chat" icon="globe" />
-  <Card title="Slack" icon="slack" />
-  <Card title="Signal" icon="signal-messenger" />
 </Columns>
 
-...and more, including Google Chat, Microsoft Teams, Matrix, and iMessage.
+Telegram is the first-class ClawBox channel: setup, bot-token validation, pairing
+approvals, and progress streaming are handled by the ClawBox UI. Web chat is built
+into the ClawBox interface.
+
+Advanced users can add other OpenClaw-supported channels manually if their installed
+OpenClaw version and plugins support them. Treat WhatsApp, Discord, Slack, Signal,
+Matrix, Microsoft Teams, Google Chat, and iMessage as extension paths, not guaranteed
+guided setup flows.
 
 ## Linking a channel
 
-From the ClawBox settings page:
+For Telegram, from the ClawBox settings page:
 
 <Steps>
-  <Step title="Open Channels">
-    Go to the **Channels** section in your ClawBox web interface.
+  <Step title="Open Telegram settings">
+    Go to **Settings → Telegram** in your ClawBox web interface.
   </Step>
-  <Step title="Pick a channel">
-    Choose the app you want to link (e.g. Telegram).
+  <Step title="Create a bot">
+    Open Telegram, search **@BotFather**, create a bot, and copy the bot token.
   </Step>
-  <Step title="Authorize">
-    Follow the on-screen pairing flow — usually scanning a QR code or pasting a bot token.
+  <Step title="Paste the token">
+    Paste the token into ClawBox and wait for the gateway restart to finish.
   </Step>
-  <Step title="Message it">
-    Send a message from that app. Your ClawBox replies.
+  <Step title="Approve users">
+    New Telegram users send the bot a message and then approve the pairing request
+    on the ClawBox screen.
   </Step>
 </Steps>
 
 <Tip>
-You can link several channels to the same ClawBox. Messages from each surface route to
-the same assistant.
+Use the web chat when you are on the same ClawBox interface and Telegram when you
+want phone-based access.
 </Tip>
 
 ## Group chats
 
-ClawBox can participate in group chats. It's built to know when to chime in and when to
-stay quiet, so it acts like a helpful participant rather than a noisy bot.
+Telegram group behavior depends on your bot privacy settings and the OpenClaw channel
+configuration. Start with one-to-one pairing first, then test group behavior deliberately.
 
 ## Troubleshooting
 

--- a/docs-site/hardware/clawbox-connect.mdx
+++ b/docs-site/hardware/clawbox-connect.mdx
@@ -27,7 +27,7 @@ The entry-tier ClawBox: a compact, low-power, always-on AI assistant for your de
 
 ## What it's good for
 
-- A **24/7 personal assistant** you message from Telegram, WhatsApp, Discord, or the web.
+- A **24/7 personal assistant** you message from Telegram or the web, with additional OpenClaw channels available for advanced setups when supported.
 - **Browser automation** and everyday agent tasks.
 - Running with **cloud AI providers** (ClawBox AI, Claude, GPT, Gemini) or smaller local models.
 

--- a/docs-site/hardware/requirements.mdx
+++ b/docs-site/hardware/requirements.mdx
@@ -36,7 +36,7 @@ This page covers what you actually need — from bare minimum to running local A
 
 ### Minimum — messaging only
 - **Specs:** 1 vCPU, 1 GB RAM, 10 GB storage, 1 Mbps+
-- **Can do:** Telegram/WhatsApp messaging, simple text commands, basic API integrations, scheduled messages
+- **Can do:** Telegram and web messaging, simple text commands, basic API integrations, scheduled messages, and additional OpenClaw channels when configured
 - **Can't do:** browser automation, local AI models, multiple concurrent tasks, image processing
 - **Examples:** $5/mo VPS · Raspberry Pi 4 (2 GB) · old laptop
 

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -6,7 +6,7 @@ summary: "ClawBox is pre-configured AI hardware that runs OpenClaw — your own 
 
 <p align="center">
   <strong>Your own AI assistant, running 24/7 on hardware you own.</strong><br />
-  ClawBox ships pre-configured with OpenClaw — message it from Telegram, WhatsApp, Discord, or the web, and it gets things done.
+  ClawBox ships pre-configured with OpenClaw — message it from Telegram or the web, and extend it with additional OpenClaw channels when your setup supports them.
 </p>
 
 <Tip>
@@ -38,7 +38,7 @@ A small, always-on computer running **OpenClaw** — a self-hosted gateway that 
 **What makes it different?**
 
 - **Owned hardware** — it lives on your desk, drawing as little as 7–15 W.
-- **Multi-channel** — Telegram, WhatsApp, Discord, web, and more from one device.
+- **Multi-channel foundation** — Telegram and web are the managed ClawBox paths; advanced users can add more OpenClaw channels where supported.
 - **Flexible AI** — ClawBox AI out of the box, or connect Claude / GPT / Gemini / OpenRouter / local Ollama.
 - **Pre-configured** — no Linux setup, no Docker wrangling. Plug in and go.
 

--- a/docs-site/quickstart.mdx
+++ b/docs-site/quickstart.mdx
@@ -23,7 +23,7 @@ Get from a sealed box to a working AI assistant in a few minutes.
     follow [Choose Your AI Provider](/setup/choose-ai-provider).
   </Step>
   <Step title="Link a chat app">
-    Connect Telegram, WhatsApp, or Discord and message your ClawBox.
+    Connect Telegram and message your ClawBox. You can also use the web chat from the ClawBox interface.
     See [Messaging Channels](/guides/messaging-channels).
   </Step>
 </Steps>
@@ -36,7 +36,7 @@ Get from a sealed box to a working AI assistant in a few minutes.
 
 <Columns cols={2}>
   <Card title="Messaging Channels" href="/guides/messaging-channels" icon="comments">
-    Add Telegram, WhatsApp, Discord, and more.
+    Connect Telegram, use web chat, and understand advanced channel options.
   </Card>
   <Card title="Troubleshooting" href="/support/troubleshooting" icon="wrench">
     Can't reach the box? Start here.

--- a/docs-site/setup/first-boot.mdx
+++ b/docs-site/setup/first-boot.mdx
@@ -36,8 +36,7 @@ Wi-Fi or Ethernet connection.
   </Step>
   <Step title="Pair your device">
     Open your phone camera or a QR scanner and scan the QR code on the quick-start card.
-    Choose your messaging platform (Telegram recommended) and follow the pairing wizard
-    to link your account.
+    Connect Telegram when prompted, then follow the pairing wizard to link your account.
   </Step>
   <Step title="Start chatting">
     Send your first message to test the connection. Try a question or a command, then

--- a/docs-site/setup/openclaw-setup.mdx
+++ b/docs-site/setup/openclaw-setup.mdx
@@ -17,6 +17,12 @@ options — whether you're on a ClawBox or a DIY install.
 
 ## Telegram
 
+<Note>
+For ClawBox's guided setup, use **Settings → Telegram** and see
+[Messaging Channels](/guides/messaging-channels). Use the manual steps below for
+self-hosted OpenClaw setups or fallback configuration.
+</Note>
+
 <Steps>
   <Step title="Create a bot">
     Open Telegram and search **@BotFather**.

--- a/docs-site/setup/openclaw-setup.mdx
+++ b/docs-site/setup/openclaw-setup.mdx
@@ -34,6 +34,11 @@ options — whether you're on a ClawBox or a DIY install.
 
 ## Discord
 
+<Note>
+ClawBox's guided setup manages Telegram. Configure Discord only if your installed
+OpenClaw version and channel plugins support it.
+</Note>
+
 <Steps>
   <Step title="Create an application">
     Go to the **Discord Developer Portal** and create a new application.

--- a/docs-site/support/faq.mdx
+++ b/docs-site/support/faq.mdx
@@ -23,8 +23,9 @@ summary: "Frequently asked questions about ClawBox hardware, software, and subsc
     [Workstation page](/hardware/clawbox-workstation).
   </Accordion>
   <Accordion title="Which chat apps does it support?">
-    Telegram, WhatsApp, Discord, Slack, Signal, Web Chat, and more. See
-    [Messaging Channels](/guides/messaging-channels).
+    Telegram and the on-device web chat are the managed ClawBox paths today.
+    Advanced users can add other OpenClaw channels manually when their installed
+    OpenClaw version and plugins support them. See [Messaging Channels](/guides/messaging-channels).
   </Accordion>
   <Accordion title="How much power does it use?">
     ClawBox Connect draws ~7–15 W (about €39/year in electricity). ClawBox Workstation


### PR DESCRIPTION
## Summary
- Clarify Telegram and web chat as managed ClawBox messaging paths
- Reframe WhatsApp, Discord, Slack, Signal, Matrix, Teams, Google Chat, and iMessage as advanced OpenClaw extension paths
- Update quickstart, first boot, hardware, messaging channel, and FAQ docs

## Validation
- mint validate
- mint broken-links
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the messaging channels guide to center on managed **Telegram** and **on-device web chat**, with other channels presented as advanced/only-if-supported options.
  * Revised setup and quickstart pairing/linking steps to focus on Telegram flows, and shortened group chat guidance.
  * Added/updated troubleshooting guidance and clarified advanced channel support notes across the FAQ, requirements, homepage, and ClawBox Connect materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->