### PR TITLE
docs: point 'Get ClawBox'/store links to clawbox.com

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -45,18 +45,18 @@ mint broken-links
 
 ## Publishing
 
-The intended public URL is **docs.clawbox.tech**.
+The intended public URL is **docs.clawbox.com**.
 
 Two ways to publish:
 
 1. **Mintlify hosting (matches docs.openclaw.ai).** Install the Mintlify GitHub App on
    the `ID-Robots/clawbox` repo, point it at this `docs-site/` directory, and set the
-   custom domain to `docs.clawbox.tech` in the Mintlify dashboard. Pushes to the docs
+   custom domain to `docs.clawbox.com` in the Mintlify dashboard. Pushes to the docs
    branch auto-deploy. (Custom domain / removing Mintlify branding may require a paid
    plan — confirm current Mintlify pricing.)
 
 2. **Self-host the static build.** Run `mint build` and deploy the output to Vercel (the
-   same place clawbox.tech lives) behind a `docs.clawbox.tech` subdomain. No SaaS fee.
+   same place clawbox.com lives) behind a `docs.clawbox.com` subdomain. No SaaS fee.
 
 > Decision pending: which hosting path. The content/config is identical either way.
 

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -15,7 +15,7 @@
   "logo": {
     "light": "/logo/light-wordmark.png",
     "dark": "/logo/dark-wordmark.png",
-    "href": "https://clawbox.tech"
+    "href": "https://clawbox.com"
   },
   "navigation": {
     "tabs": [
@@ -104,7 +104,7 @@
       "anchors": [
         {
           "anchor": "Buy a ClawBox",
-          "href": "https://clawbox.tech",
+          "href": "https://clawbox.com",
           "icon": "cart-shopping"
         },
         {
@@ -125,12 +125,12 @@
     "primary": {
       "type": "button",
       "label": "Get ClawBox",
-      "href": "https://clawbox.tech"
+      "href": "https://clawbox.com"
     }
   },
   "footer": {
     "socials": {
-      "website": "https://clawbox.tech",
+      "website": "https://clawbox.com",
       "discord": "https://discord.gg/vsTsaY4Tuk",
       "github": "https://github.com/ID-Robots"
     }

--- a/docs-site/hardware/clawbox-connect.mdx
+++ b/docs-site/hardware/clawbox-connect.mdx
@@ -6,7 +6,7 @@ summary: "Hardware specifications for ClawBox Connect — the always-on AI assis
 
 The entry-tier ClawBox: a compact, low-power, always-on AI assistant for your desk.
 
-<Card title="Get ClawBox Connect — €549" href="https://clawbox.tech" icon="cart-shopping" horizontal>
+<Card title="Get ClawBox Connect — €549" href="https://clawbox.com" icon="cart-shopping" horizontal>
   Pre-configured with OpenClaw. Ships ready to use.
 </Card>
 

--- a/docs-site/hardware/clawbox-workstation.mdx
+++ b/docs-site/hardware/clawbox-workstation.mdx
@@ -7,7 +7,7 @@ summary: "Hardware specifications for ClawBox Workstation — a personal AI supe
 The pro tier: a personal AI supercomputer that runs large models **fully local**,
 pre-configured with OpenClaw.
 
-<Card title="Get ClawBox Workstation — €5,499" href="https://clawbox.tech" icon="cart-shopping" horizontal>
+<Card title="Get ClawBox Workstation — €5,499" href="https://clawbox.com" icon="cart-shopping" horizontal>
   NVIDIA DGX Spark, configured and ready to run.
 </Card>
 

--- a/docs-site/hardware/requirements.mdx
+++ b/docs-site/hardware/requirements.mdx
@@ -83,7 +83,7 @@ see [ClawBox Workstation](/hardware/clawbox-workstation) (128 GB unified memory,
 
 ## Skip the DIY
 
-<Card title="Get ClawBox — pre-configured, ready in 5 minutes" href="https://clawbox.tech" icon="cart-shopping" horizontal>
+<Card title="Get ClawBox — pre-configured, ready in 5 minutes" href="https://clawbox.com" icon="cart-shopping" horizontal>
   ClawBox ships with Recommended+ specs, OpenClaw pre-installed, dual-band Wi-Fi and Bluetooth.
   Manual DIY setup is typically 2–4+ hours (plus waiting for hardware).
 </Card>

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -1,52 +1,52 @@
 # ClawBox Documentation
 
-> ClawBox is pre-configured AI hardware (NVIDIA Jetson) running OpenClaw OS — a self-hosted AI assistant reachable from Telegram and the web. This documentation covers consumer setup, deep technical reference, troubleshooting, and recovery. Site: https://docs.clawbox.tech · Source: https://github.com/ID-Robots/clawbox (docs live in docs-site/, releases are vX.Y.Z tags on main, integration branch is beta).
+> ClawBox is pre-configured AI hardware (NVIDIA Jetson) running OpenClaw OS — a self-hosted AI assistant reachable from Telegram and the web. This documentation covers consumer setup, deep technical reference, troubleshooting, and recovery. Site: https://docs.clawbox.com · Source: https://github.com/ID-Robots/clawbox (docs live in docs-site/, releases are vX.Y.Z tags on main, integration branch is beta).
 
 Key facts: web UI at http://<box-ip> port 80 (never :18789 — that's the token-gated gateway; it loads but rejects passwords); one Linux password (`clawbox` user) for both SSH and browser login; device state in /home/clawbox/clawbox/data and ~/.openclaw (survives updates; wiped by factory reset); updates are git-tag based and reboot the box at the end; provider credentials live in ~/.openclaw/agents/main/agent/auth-profiles.json.
 
 ## Start Here
 
-- [Quick Reference](https://docs.clawbox.tech/technical/quick-reference): the one-page fact sheet — ports, paths, services, commands, endpoints, gotchas. Best single page for agents.
-- [ClawBox Overview](https://docs.clawbox.tech/): what ClawBox is, models, pricing
-- [Quickstart](https://docs.clawbox.tech/quickstart): unbox → power → talk
+- [Quick Reference](https://docs.clawbox.com/technical/quick-reference): the one-page fact sheet — ports, paths, services, commands, endpoints, gotchas. Best single page for agents.
+- [ClawBox Overview](https://docs.clawbox.com/): what ClawBox is, models, pricing
+- [Quickstart](https://docs.clawbox.com/quickstart): unbox → power → talk
 
 ## Setup
 
-- [First Boot](https://docs.clawbox.tech/setup/first-boot): unbox, connect, pair via QR code — the first-run guide
-- [Connect to a Network](https://docs.clawbox.tech/setup/connect-network): joining Wi-Fi or Ethernet after setup
-- [Choose Your AI Provider](https://docs.clawbox.tech/setup/choose-ai-provider): ClawBox AI, Claude, GPT, Gemini, OpenRouter, local models
-- [OpenClaw Setup](https://docs.clawbox.tech/setup/openclaw-setup): gateway configuration
+- [First Boot](https://docs.clawbox.com/setup/first-boot): unbox, connect, pair via QR code — the first-run guide
+- [Connect to a Network](https://docs.clawbox.com/setup/connect-network): joining Wi-Fi or Ethernet after setup
+- [Choose Your AI Provider](https://docs.clawbox.com/setup/choose-ai-provider): ClawBox AI, Claude, GPT, Gemini, OpenRouter, local models
+- [OpenClaw Setup](https://docs.clawbox.com/setup/openclaw-setup): gateway configuration
 
 ## Technical Reference
 
-- [System Architecture](https://docs.clawbox.tech/technical/architecture): service topology, request routing, boot lifecycle, ClawBox↔OpenClaw relationship
-- [Networking](https://docs.clawbox.tech/technical/networking): AP mode, captive portal, mDNS/clawbox.local reliability, full port map
-- [Filesystem Layout](https://docs.clawbox.tech/technical/filesystem): where everything lives; what survives updates vs factory reset; where secrets are
-- [Authentication & Security](https://docs.clawbox.tech/technical/authentication): browser login flow (unix_chkpwd), session cookies, gateway token, service tokens
-- [AI Providers](https://docs.clawbox.tech/technical/ai-providers): every provider lane, credential storage map, the two OpenAI lanes (openai/ vs codex/), boot-time self-healing
-- [Update System](https://docs.clawbox.tech/technical/update-system): tag-based updates, channels (main/beta), divergence/"Updates paused", manual-update pitfalls
-- [Agent Interface (MCP)](https://docs.clawbox.tech/technical/agent-interface): the ~50 device tools the AI agent gets, clawbox CLI, auth model
+- [System Architecture](https://docs.clawbox.com/technical/architecture): service topology, request routing, boot lifecycle, ClawBox↔OpenClaw relationship
+- [Networking](https://docs.clawbox.com/technical/networking): AP mode, captive portal, mDNS/clawbox.local reliability, full port map
+- [Filesystem Layout](https://docs.clawbox.com/technical/filesystem): where everything lives; what survives updates vs factory reset; where secrets are
+- [Authentication & Security](https://docs.clawbox.com/technical/authentication): browser login flow (unix_chkpwd), session cookies, gateway token, service tokens
+- [AI Providers](https://docs.clawbox.com/technical/ai-providers): every provider lane, credential storage map, the two OpenAI lanes (openai/ vs codex/), boot-time self-healing
+- [Update System](https://docs.clawbox.com/technical/update-system): tag-based updates, channels (main/beta), divergence/"Updates paused", manual-update pitfalls
+- [Agent Interface (MCP)](https://docs.clawbox.com/technical/agent-interface): the ~50 device tools the AI agent gets, clawbox CLI, auth model
 
 ## Troubleshooting & Recovery
 
-- [Troubleshooting](https://docs.clawbox.tech/support/troubleshooting): symptom-first diagnostic ladders — can't reach the box, browser rejects password (SSH works), updates stuck, provider 401s, gateway token mismatch, Telegram
-- [Recovery](https://docs.clawbox.tech/support/recovery): ordered recovery options — password reset (sudo passwd clawbox), service restart, safe reinstall (hard-sync + install.sh), factory reset (password → clawbox, AP mode)
-- [Updating ClawBox](https://docs.clawbox.tech/support/updating): the supported update paths
-- [FAQ](https://docs.clawbox.tech/support/faq)
+- [Troubleshooting](https://docs.clawbox.com/support/troubleshooting): symptom-first diagnostic ladders — can't reach the box, browser rejects password (SSH works), updates stuck, provider 401s, gateway token mismatch, Telegram
+- [Recovery](https://docs.clawbox.com/support/recovery): ordered recovery options — password reset (sudo passwd clawbox), service restart, safe reinstall (hard-sync + install.sh), factory reset (password → clawbox, AP mode)
+- [Updating ClawBox](https://docs.clawbox.com/support/updating): the supported update paths
+- [FAQ](https://docs.clawbox.com/support/faq)
 
 ## Hardware
 
-- [ClawBox Connect](https://docs.clawbox.tech/hardware/clawbox-connect): Jetson Orin Nano model
-- [ClawBox Workstation](https://docs.clawbox.tech/hardware/clawbox-workstation): DGX Spark model
-- [Requirements](https://docs.clawbox.tech/hardware/requirements)
+- [ClawBox Connect](https://docs.clawbox.com/hardware/clawbox-connect): Jetson Orin Nano model
+- [ClawBox Workstation](https://docs.clawbox.com/hardware/clawbox-workstation): DGX Spark model
+- [Requirements](https://docs.clawbox.com/hardware/requirements)
 
 ## Using ClawBox
 
-- [Messaging Channels](https://docs.clawbox.tech/guides/messaging-channels): Telegram (device-managed, pairing-approved) and OpenClaw's wider channel support
-- [Subscriptions](https://docs.clawbox.tech/guides/subscriptions): ClawBox AI plans
+- [Messaging Channels](https://docs.clawbox.com/guides/messaging-channels): Telegram (device-managed, pairing-approved) and OpenClaw's wider channel support
+- [Subscriptions](https://docs.clawbox.com/guides/subscriptions): ClawBox AI plans
 
 ## External
 
 - [OpenClaw Documentation](https://docs.openclaw.ai): the upstream AI gateway ClawBox ships
-- [ClawBox Store](https://clawbox.tech)
+- [ClawBox Store](https://clawbox.com)
 - [Community Discord](https://discord.gg/vsTsaY4Tuk)

--- a/docs-site/setup/openclaw-setup.mdx
+++ b/docs-site/setup/openclaw-setup.mdx
@@ -91,6 +91,6 @@ See [Choose Your AI Provider](/setup/choose-ai-provider) for the full provider l
 
 ## Skip the setup
 
-<Card title="Get ClawBox — OpenClaw pre-installed" href="https://clawbox.tech" icon="bolt" horizontal>
+<Card title="Get ClawBox — OpenClaw pre-installed" href="https://clawbox.com" icon="bolt" horizontal>
   Plug in, connect Wi-Fi, scan a QR code. Done in 5 minutes — channels, voice, and models ready.
 </Card>

--- a/docs-site/support/faq.mdx
+++ b/docs-site/support/faq.mdx
@@ -33,7 +33,7 @@ summary: "Frequently asked questions about ClawBox hardware, software, and subsc
   </Accordion>
   <Accordion title="Where do you ship?">
     ClawBox ships worldwide via DHL Express from Bulgaria. Shipping cost and time are
-    shown at checkout on [clawbox.tech](https://clawbox.tech).
+    shown at checkout on [clawbox.com](https://clawbox.com).
   </Accordion>
   <Accordion title="How do I get support?">
     Email [yanko@idrobots.com](mailto:yanko@idrobots.com) or join the community Discord.


### PR DESCRIPTION
## What
Updates every clawbox.tech link in `docs-site/` to **clawbox.com** (37 refs across 8 files).

## Why
clawbox.com is now the primary domain (clawbox.tech 301-redirects into it via Porkbun). On docs.clawbox.com the **Get ClawBox** button and store cards pointed at `https://clawbox.tech`, so clicking bounced through a redirect. This points them directly at the canonical domain.

## Scope
- `docs.json` — top-bar 'Get ClawBox' CTA, nav href, footer website
- Hardware/setup MDX 'Get ClawBox' cards (connect, workstation, requirements, openclaw-setup)
- `support/faq.mdx` store link
- `llms.txt` + `README.md` — docs.clawbox.tech self-references → docs.clawbox.com

No content/behaviour changes beyond the domain swap. Mintlify redeploys docs.clawbox.com on merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the public documentation site and links to use the `clawbox.com` domain.
  * Updated purchasing and product call-to-action links across hardware, setup, and support pages.
  * Added release and source details to the LLM reference page.
  * Added a Community Discord link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->