### PR TITLE
fix: release ClawBox 3.1.8 update recovery

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1357,6 +1357,13 @@ step_post_update() {
   # `pip install` is a no-op even after restore/scheduler bug fixes land —
   # we have to force-reinstall.
   step_clawkeep_install || echo "  Warning: clawkeep_install step failed (non-fatal)"
+  # Re-assert the gateway service after an in-app update. The full update
+  # syncs repo files and rebuilds before this continuation runs; older devices
+  # can therefore reach the new UI while the gateway is still using stale
+  # service/drop-in state or is simply down from the reboot handoff. Run the
+  # same idempotent setup used by fresh installs so a completed update leaves
+  # clawbox-gateway as the active single source of truth.
+  step_gateway_setup || echo "  Warning: gateway_setup step failed (non-fatal)"
   step_update_smoke || echo "  Warning: update_smoke reported issues (non-fatal)"
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawbox-setup",
-      "version": "3.1.7",
+      "version": "3.1.8",
       "dependencies": {
         "@types/ws": "^8.18.1",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {

--- a/src/app/setup-api/update/status/route.ts
+++ b/src/app/setup-api/update/status/route.ts
@@ -3,6 +3,10 @@ import { getUpdateState, isUpdateCompleted, checkContinuation, getVersionInfo } 
 
 export const dynamic = "force-dynamic";
 
+function needsUpdate(component: { updateAvailable?: boolean; target: string | null }): boolean {
+  return component.updateAvailable ?? !!component.target;
+}
+
 export async function GET() {
   try {
     const state = getUpdateState();
@@ -14,17 +18,24 @@ export async function GET() {
         return NextResponse.json(getUpdateState());
       }
 
-      // If previously completed, synthesize all-completed state
+      const versions = await getVersionInfo();
+
+      // If previously completed and still current, synthesize all-completed
+      // state. But do not let a stale persisted completion flag hide a newer
+      // release: older boxes had `update_completed=true` forever, so
+      // /update/status returned "completed" without versions and the setup
+      // update card showed "You're up to date" even when /update/versions
+      // would have reported a fresh release.
       const completed = await isUpdateCompleted();
-      if (completed) {
+      if (completed && !needsUpdate(versions.clawbox) && !needsUpdate(versions.openclaw)) {
         return NextResponse.json({
           ...state,
           phase: "completed",
           steps: state.steps.map((s) => ({ ...s, status: "completed" })),
+          versions,
         });
       }
 
-      const versions = await getVersionInfo();
       return NextResponse.json({ ...state, targetVersion: versions.clawbox.target, versions });
     }
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -590,25 +590,15 @@ export async function getTargetVersion(): Promise<string | null> {
       return null;
     }
     semverTags.sort(compareSemverTags);
-    // A tag is only a valid update target if the device's current HEAD is an
-    // ancestor of the tag's commit — otherwise the tag sits on a sibling
-    // branch and "updating" would roll local work back. Walk from newest to
-    // oldest and return the first one that passes.
-    for (let i = semverTags.length - 1; i >= 0; i--) {
-      const tag = semverTags[i];
-      const isForward = await execShell(
-        `git -c safe.directory=${PROJECT_DIR} -C ${PROJECT_DIR} merge-base --is-ancestor HEAD refs/tags/${tag}`,
-        { timeout: 10_000 },
-      ).then(() => true).catch(() => false);
-      if (isForward) {
-        cachedTargetVersion = tag;
-        targetVersionCacheTime = Date.now();
-        return tag;
-      }
-    }
-    cachedTargetVersion = null;
+    // ClawBox is an appliance: the updater hard-syncs to the configured
+    // upstream release branch before rebuilding. Do not require the current
+    // device HEAD to be an ancestor of the latest tag; factory-reset or
+    // branch-pinned boxes can legitimately sit on a sibling/ref-history path,
+    // and the old ancestry guard made those devices show "Latest: -" and
+    // "You're up to date" while a newer release was published.
+    cachedTargetVersion = semverTags[semverTags.length - 1];
     targetVersionCacheTime = Date.now();
-    return null;
+    return cachedTargetVersion;
   } catch {
     cachedTargetVersion = null;
     targetVersionCacheTime = Date.now();

--- a/src/tests/routes/update/status.test.ts
+++ b/src/tests/routes/update/status.test.ts
@@ -59,8 +59,12 @@ describe("GET /setup-api/update/status", () => {
     expect(body.versions).toBeDefined();
   });
 
-  it("returns completed state when update was completed", async () => {
+  it("returns completed state when update was completed and no updates are available", async () => {
     mockIsUpdateCompleted.mockResolvedValue(true);
+    mockGetVersionInfo.mockResolvedValue({
+      clawbox: { current: "1.1.0", target: null, updateAvailable: false },
+      openclaw: { current: "0.5.1", target: null, updateAvailable: false },
+    });
 
     const res = await updateStatusGet();
     const body = await res.json();
@@ -68,6 +72,23 @@ describe("GET /setup-api/update/status", () => {
     expect(res.status).toBe(200);
     expect(body.phase).toBe("completed");
     expect(body.steps.every((s: { status: string }) => s.status === "completed")).toBe(true);
+    expect(body.versions).toBeDefined();
+  });
+
+  it("returns idle version info when a newer update exists despite a stale completion flag", async () => {
+    mockIsUpdateCompleted.mockResolvedValue(true);
+    mockGetVersionInfo.mockResolvedValue({
+      clawbox: { current: "1.0.0", target: "1.1.0", updateAvailable: true },
+      openclaw: { current: "0.5.1", target: null, updateAvailable: false },
+    });
+
+    const res = await updateStatusGet();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.phase).toBe("idle");
+    expect(body.targetVersion).toBe("1.1.0");
+    expect(body.versions.clawbox.updateAvailable).toBe(true);
   });
 
   it("continues from post-restart state", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -465,6 +465,23 @@ describe("updater", () => {
       expect(version).toBe("v2.0.0");
     });
 
+    it("returns latest semver tag even when the current HEAD is not its ancestor", async () => {
+      setupExecMock({
+        "ls-remote": {
+          stdout: "abc123\trefs/tags/v1.0.0\ndef456\trefs/tags/v1.1.0\n",
+          stderr: "",
+        },
+        "merge-base --is-ancestor": new Error("not an ancestor"),
+      });
+
+      vi.resetModules();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      const freshUpdater = await import("@/lib/updater");
+
+      const version = await freshUpdater.getTargetVersion();
+      expect(version).toBe("v1.1.0");
+    });
+
     it("returns null when no semver tags", async () => {
       setupExecMock({
         "ls-remote": { stdout: "abc123\trefs/tags/release-candidate\n", stderr: "" },


### PR DESCRIPTION
## Summary
- fix update detection so boxes on older/sibling refs still see the latest release tag instead of `Latest: -`
- prevent stale `update_completed=true` from hiding newer updates in `/setup-api/update/status`
- re-assert/restart `clawbox-gateway.service` during post-update fixups so boxes left with gateway down can recover on the next hotfix update
- bump ClawBox to v3.1.8

## Verification
- `bash -n install.sh`
- `npm test -- src/tests/unit/updater.test.ts src/tests/routes/update/status.test.ts`
- `npm run build`