### PR TITLE
fix: keep chat dropdown popovers visible

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,7 +140,10 @@ h6 {
   gap: 6px;
   flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
+  /* Dropdown popovers are absolutely positioned below their trigger pills.
+   * Keep labels truncating on the trigger itself, but do not clip the open
+   * menu to the row height. */
+  overflow: visible;
 }
 
 .header-dropdown {


### PR DESCRIPTION
## Summary
- fixes the chat header provider/model/thinking dropdowns being clipped by `.chat-header-pills { overflow: hidden }`
- keeps trigger text truncation on the pill itself while allowing the opened popover to render below the header

## Verification
- `npm run build`

No release was created.