### PR TITLE
Promote v3.1.10 gateway recovery to main

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1364,7 +1364,70 @@ step_post_update() {
   # same idempotent setup used by fresh installs so a completed update leaves
   # clawbox-gateway as the active single source of truth.
   step_gateway_setup || echo "  Warning: gateway_setup step failed (non-fatal)"
+  step_gateway_legacy_state_recovery || echo "  Warning: gateway_legacy_state_recovery step failed (non-fatal)"
   step_update_smoke || echo "  Warning: update_smoke reported issues (non-fatal)"
+}
+
+gateway_port_listening() {
+  local gw_port="${GATEWAY_PORT:-18789}"
+  ss -ltn 2>/dev/null | grep -qE "[:.]${gw_port}[[:space:]]"
+}
+
+step_gateway_legacy_state_recovery() {
+  local gw_port="${GATEWAY_PORT:-18789}"
+  if gateway_port_listening; then
+    echo "  Gateway is listening on ${gw_port}, skipping legacy state recovery"
+    return 0
+  fi
+
+  echo "  Gateway is not listening on ${gw_port}; running OpenClaw doctor recovery"
+  as_clawbox "$OPENCLAW_BIN" doctor --fix --yes --non-interactive || true
+  systemctl restart clawbox-gateway.service || true
+  sleep 8
+  if gateway_port_listening; then
+    echo "  Gateway recovered after doctor --fix"
+    return 0
+  fi
+
+  local journal_tail
+  journal_tail=$(journalctl -u clawbox-gateway.service -n 160 --no-pager 2>/dev/null || true)
+  if ! printf '%s\n' "$journal_tail" | grep -Eq 'installs\.json|conflicting plugin install metadata|carl_pir|belongs to agent piper'; then
+    echo "  Gateway still offline, but logs do not match known legacy-state blockers"
+    return 0
+  fi
+
+  local ts qdir moved=0
+  ts=$(date +%Y%m%d-%H%M%S)
+  qdir="$CLAWBOX_HOME/openclaw-legacy-quarantine-$ts"
+  mkdir -p "$qdir"
+
+  echo "  Quarantining known legacy OpenClaw migration blockers in $qdir"
+  systemctl stop clawbox-gateway.service || true
+  for f in \
+    "$CLAWBOX_HOME/.openclaw/plugins/installs.json"* \
+    "$CLAWBOX_HOME/.openclaw/memory/carl_pir.sqlite"* \
+    "$CLAWBOX_HOME/.openclaw/agents/carl_pir/agent/openclaw-agent.sqlite"*
+  do
+    if [ -e "$f" ]; then
+      mv -v "$f" "$qdir/" && moved=1
+    fi
+  done
+
+  if [ "$moved" -eq 0 ]; then
+    echo "  No known legacy migration blocker files found to quarantine"
+  fi
+
+  as_clawbox "$OPENCLAW_BIN" doctor --fix --yes --non-interactive || true
+  systemctl start clawbox-gateway.service || true
+  sleep 12
+
+  if gateway_port_listening; then
+    echo "  Gateway recovered after legacy state quarantine"
+    return 0
+  fi
+
+  echo "  Warning: gateway still not listening on ${gw_port} after legacy state recovery"
+  return 1
 }
 
 step_update_smoke() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawbox-setup",
-      "version": "3.1.9",
+      "version": "3.1.10",
       "dependencies": {
         "@types/ws": "^8.18.1",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {

--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 // Bumping CACHE_NAME here is the supported way to invalidate previously
 // cached assets on existing installs — the `activate` handler deletes any
 // cache whose name doesn't match, so users get a clean slate on next visit.
-const CACHE_NAME = 'clawbox-v3'
+const CACHE_NAME = 'clawbox-v4'
 const PRECACHE = [
   '/',
   '/icon-192.png',

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -154,6 +154,70 @@ if isinstance(primary_model, str) and primary_model.lower() in (
     model_defaults["primary"] = "llamacpp/gemma4-e2b-it-q4_0"
     changed = True
 
+# Model migration: legacy ChatGPT-subscription devices can have their active
+# model — or a fallback — stored as `openai/<gpt>` from before the setup UI
+# routed ChatGPT picks through Codex. On a device with ChatGPT (Codex OAuth)
+# auth and NO OpenAI API key, that id resolves to api.openai.com, which 401s
+# with "Missing bearer or basic authentication in header": either on the
+# active turn, or — more often — only once the OAuth token first refreshes
+# and the failover chain reaches the keyless `openai/*` fallback, which
+# surfaces as a FailoverError days into use. The chat-model pick route already
+# rewrites `openai/<gpt>` -> `codex/<gpt>`, but only when the user re-picks the
+# model; existing configs never re-pick, so migrate primary + fallbacks here on
+# gateway start. Mirrors CODEX_SUPPORTED_MODEL_RE / hasOpenAiApiKeyProfile /
+# hasCodexOauthProfile in src/app/setup-api/chat/model/route.ts. Guarded on
+# "codex OAuth present AND no OpenAI API key" so dual-auth / API-key boxes,
+# where openai/* is a valid keyed route, are left untouched.
+_CODEX_SUPPORTED = ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini")
+
+def _auth_profiles():
+    _auth = cfg.get("auth")
+    _profiles = _auth.get("profiles") if isinstance(_auth, dict) else None
+    return _profiles.values() if isinstance(_profiles, dict) else []
+
+def _has_openai_api_key_profile():
+    for _entry in _auth_profiles():
+        if not isinstance(_entry, dict):
+            continue
+        _p = str(_entry.get("provider", "")).strip().lower()
+        _m = str(_entry.get("mode", "")).strip().lower()
+        if _p == "openai" and _m in ("token", "api_key", "api-key"):
+            return True
+    return False
+
+def _has_codex_oauth_profile():
+    for _entry in _auth_profiles():
+        if not isinstance(_entry, dict):
+            continue
+        _p = str(_entry.get("provider", "")).strip().lower()
+        _m = str(_entry.get("mode", "")).strip().lower()
+        if _p == "codex" and _m == "oauth":
+            return True
+    return False
+
+def _openai_gpt_to_codex(model_id):
+    # `openai/<codex-supported gpt>` -> `codex/<gpt>`; otherwise None (leave as-is).
+    if not isinstance(model_id, str):
+        return None
+    _m = model_id.strip()
+    if not _m.lower().startswith("openai/"):
+        return None
+    _bare = _m[len("openai/"):]
+    return "codex/" + _bare if _bare.lower() in _CODEX_SUPPORTED else None
+
+if _has_codex_oauth_profile() and not _has_openai_api_key_profile():
+    _migrated_primary = _openai_gpt_to_codex(model_defaults.get("primary"))
+    if _migrated_primary:
+        model_defaults["primary"] = _migrated_primary
+        changed = True
+    _fallbacks = model_defaults.get("fallbacks")
+    if isinstance(_fallbacks, list):
+        for _i, _fb in enumerate(_fallbacks):
+            _migrated_fb = _openai_gpt_to_codex(_fb)
+            if _migrated_fb and _migrated_fb != _fallbacks[_i]:
+                _fallbacks[_i] = _migrated_fb
+                changed = True
+
 # Strip orphaned per-model keys that a newer-than-pinned plugin wrote and a
 # version downgrade left behind, which fail strict config validation and
 # brick the AI provider page until `openclaw doctor --fix`. `agentRuntime`

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,14 +140,20 @@ h6 {
   gap: 6px;
   flex: 1 1 auto;
   min-width: 0;
-  /* Dropdown popovers are absolutely positioned below their trigger pills.
-   * Keep labels truncating on the trigger itself, but do not clip the open
-   * menu to the row height. */
-  overflow: visible;
+  /* Keep the pills on a SINGLE row: as the chat panel narrows they squeeze
+   * and their labels truncate with "..." (each trigger reserves 24px on the
+   * right so the chevron never disappears) — they never wrap to a second row
+   * or overlap. overflow:hidden clips any final overshoot cleanly; the chat
+   * window enforces a min-width (see ChatPopup) so the pills can't be
+   * squeezed past a readable size. The open menu is portaled to <body>
+   * (see HeaderDropdown), so clipping the row here can't hide the popover. */
+  overflow: hidden;
 }
 
 .header-dropdown {
   min-width: 0;
+  /* No grow (keep natural width when there's room, like the wide layout),
+   * shrink when the row runs out of space so all pills give ground evenly. */
   flex: 0 1 auto;
 }
 
@@ -171,6 +177,13 @@ h6 {
   display: inline-flex;
   align-items: center;
   position: relative;
+  /* Fill the (flex-shrinking) .header-dropdown so the button shrinks WITH its
+   * parent instead of keeping its content width and spilling out. Without
+   * this the pills stay full-width on a narrow header and overlap / get clipped
+   * by .chat-header-pills' overflow:hidden; with it, each pill gives ground
+   * evenly and its label truncates with "...". max-width still caps the roomy
+   * width so a long model name can't dominate the row. */
+  width: 100%;
   max-width: 100%;
   min-width: 0;
   border-radius: 999px;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2008,9 +2008,13 @@ function ChromeDesktopInner() {
         )}
       </div>
 
-      {/* Mascot - tapping toggles chat popup, hidden when chat is docked as panel */}
+      {/* Mascot - tapping toggles chat popup, hidden when chat is docked as panel.
+          mascotX is captured once from onTap; we intentionally do NOT stream the
+          frozen mascot's position while the chat is open — that used to nudge
+          mascotX for a frame right after opening, flashing the popup to the wrong
+          corner before it settled. */}
       {chatPanelWidth === 0 && !isMobile && (
-        <Mascot frozen={chatOpen} onTap={(x?: number) => { if (x !== undefined) setMascotX(x); setChatOpen(prev => !prev); }} onPositionChange={chatOpen ? setMascotX : undefined} />
+        <Mascot frozen={chatOpen} onTap={(x?: number) => { if (x !== undefined) setMascotX(x); setChatOpen(prev => !prev); }} />
       )}
       <ChatPopup isOpen={chatOpen} onClose={() => setChatOpen(false)} onOpenSettingsSection={openSettingsSection} onPanelModeChange={handleChatPanelModeChange} initialPanelWidth={chatPanelWidth} mascotX={mascotHidden ? 85 : mascotX} trayMode={mascotHidden} mobile={isMobile} />
 

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -174,6 +174,11 @@ function extractText(msg: unknown): string {
 
 const DEFAULT_SIZE = { w: 400, h: 500 }
 const DEFAULT_PANEL_WIDTH = DEFAULT_SIZE.w
+// Floor for the chat window width. Below this the header selector pills would
+// squeeze past a readable size, so the resize handles (floating + docked panel)
+// and the rendered width all clamp here — the chat simply stops getting
+// narrower instead of smashing the pills.
+const MIN_CHAT_WIDTH = 340
 
 function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThinkingChange, onPanelModeChange, initialPanelWidth, mascotX, mobile = false, trayMode = false }: ChatPopupProps) {
   const { t } = useT()
@@ -273,7 +278,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     const startW = popupRef.current?.getBoundingClientRect().width ?? DEFAULT_PANEL_WIDTH
     const onMove = (ev: MouseEvent | TouchEvent) => {
       const cx = 'touches' in ev ? ev.touches[0].clientX : (ev as MouseEvent).clientX
-      const newW = Math.max(280, Math.min(startW - (cx - startX), window.innerWidth * 0.6))
+      const newW = Math.max(MIN_CHAT_WIDTH, Math.min(startW - (cx - startX), window.innerWidth * 0.6))
       // Direct DOM update during drag — no React re-renders
       if (popupRef.current) popupRef.current.style.width = newW + 'px'
     }
@@ -284,7 +289,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       window.removeEventListener('touchend', onUp)
       // Commit final width to React state + notify parent
       const cx = 'changedTouches' in ev ? ev.changedTouches[0].clientX : (ev as MouseEvent).clientX
-      const finalW = Math.max(280, Math.min(startW - (cx - startX), window.innerWidth * 0.6))
+      const finalW = Math.max(MIN_CHAT_WIDTH, Math.min(startW - (cx - startX), window.innerWidth * 0.6))
       setPanelWidth(finalW)
       onPanelModeChange?.(finalW)
     }
@@ -331,9 +336,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       const dx = cx - start.x
       const dy = cy - start.y
       let newW = start.w, newH = start.h, newX = start.left, newY = start.top
-      if (edge.includes('r')) newW = Math.max(280, start.w + dx)
+      if (edge.includes('r')) newW = Math.max(MIN_CHAT_WIDTH, start.w + dx)
       if (edge.includes('b')) newH = Math.max(250, start.h + dy)
-      if (edge.includes('l')) { newW = Math.max(280, start.w - dx); newX = start.left + (start.w - newW) }
+      if (edge.includes('l')) { newW = Math.max(MIN_CHAT_WIDTH, start.w - dx); newX = start.left + (start.w - newW) }
       if (edge.includes('t')) { newH = Math.max(250, start.h - dy); newY = start.top + (start.h - newH) }
       setSize({ w: newW, h: newH })
       setPos({ x: newX, y: newY })
@@ -1379,6 +1384,16 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
           ? { right: 8, bottom: 65 }
           : { left: defaultLeft, bottom: 170 }
 
+  // macOS-style open: grow the popup OUT of the mascot. The transform-origin
+  // is pinned to the popup's bottom edge, horizontally aligned with the
+  // mascot, so the scale animation emanates from where the user tapped
+  // instead of from the popup's centre.
+  const winW = typeof window !== 'undefined' ? window.innerWidth : 1000
+  const mascotCenterPx = ((mascotX ?? 85) / 100) * winW
+  const anchorLeft = pos ? pos.x : (trayMode ? winW - size.w - 8 : defaultLeft)
+  const originX = Math.max(20, Math.min(mascotCenterPx - anchorLeft, size.w - 20))
+  const transformOrigin = panelMode ? 'right center' : mobile ? 'center bottom' : `${originX}px bottom`
+
   const greetingPending = isBootstrappingHistory || (sending && messages.length === 0)
 
   return (
@@ -1389,20 +1404,40 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         position: 'fixed',
         ...posStyle,
         ...(panelMode
-          ? { width: panelWidth, height: 'auto', maxHeight: 'none', borderRadius: 0 }
+          ? { width: panelWidth, minWidth: MIN_CHAT_WIDTH, height: 'auto', maxHeight: 'none', borderRadius: 0 }
           : mobile
             ? { width: 'auto', height: 'auto', maxHeight: 'none', borderRadius: 0 }
-            : { width: size.w, height: size.h, maxHeight: 'calc(100vh - 60px)', borderRadius: 16 }),
+            : {
+                width: size.w,
+                minWidth: MIN_CHAT_WIDTH,
+                height: size.h,
+                // The un-dragged popup is anchored from the BOTTOM (bottom:170
+                // above the mascot / bottom:65 in tray mode), so the height
+                // budget must subtract that anchor too — the old flat
+                // `100vh - 60px` let a 500px-tall popup shove its header (pills,
+                // close button) off the TOP of short/zoomed viewports, which
+                // looked completely broken. Reserve anchor + 12px top margin.
+                maxHeight: pos
+                  ? 'calc(100vh - 60px)'
+                  : trayMode
+                    ? 'calc(100vh - 77px)'
+                    : 'calc(100vh - 182px)',
+                borderRadius: 16,
+              }),
         zIndex: 10010,
         overflow: 'hidden',
         boxShadow: panelMode ? '-4px 0 20px rgba(0,0,0,0.4), -1px 0 0 rgba(255,255,255,0.08)' : mobile ? 'none' : '0 8px 40px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.08)',
         background: '#0d1117',
         display: 'flex',
         flexDirection: 'column',
+        transformOrigin,
         opacity: visible ? 1 : 0,
-        transform: visible ? 'scale(1) translateY(0)' : (mobile ? 'translateY(100%)' : 'scale(0.92) translateY(16px)'),
-        transition: dragRef.current ? 'none' : 'opacity 0.2s ease, transform 0.2s ease',
+        transform: visible ? 'scale(1) translateY(0)' : (mobile ? 'translateY(100%)' : 'scale(0.82) translateY(6px)'),
+        // macOS-like: quick opacity, smooth easeOutExpo scale that decelerates
+        // into place. No transition mid-drag so the window tracks the cursor 1:1.
+        transition: dragRef.current ? 'none' : 'opacity 0.22s ease, transform 0.36s cubic-bezier(0.16, 1, 0.3, 1)',
         pointerEvents: visible ? 'auto' : 'none',
+        willChange: 'transform, opacity',
       }}
     >
       {/* Header — drag handle (desktop) / simple bar (mobile) */}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -4,6 +4,7 @@ import { readFile } from "fs/promises";
 import path from "path";
 import { get, set, setMany } from "./config-store";
 import { findOpenclawBin, restartGateway } from "./openclaw-config";
+import { isPortOpen } from "./port-probe";
 
 const PROJECT_DIR = "/home/clawbox/clawbox";
 const UPDATE_BRANCH_FILE = path.join(PROJECT_DIR, ".update-branch");
@@ -283,6 +284,101 @@ async function updateClawBoxAndReboot(): Promise<void> {
 // 2-3 min; shared across both UPDATE_STEPS and OPENCLAW_UPDATE_STEPS so the
 // two flows can't drift apart.
 const OPENCLAW_INSTALL_TIMEOUT_MS = 300_000;
+const GATEWAY_PORT = Number(process.env.GATEWAY_PORT || "18789");
+const GATEWAY_WAIT_INTERVAL_MS = 1_500;
+const LEGACY_GATEWAY_BLOCKER_RE =
+  /installs\.json|conflicting plugin install metadata|carl_pir|belongs to agent piper/i;
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForGateway(timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await isPortOpen(GATEWAY_PORT, "127.0.0.1", 1_000)) return true;
+    await delay(GATEWAY_WAIT_INTERVAL_MS);
+  }
+  return false;
+}
+
+async function runOpenclawDoctorFix(): Promise<void> {
+  try {
+    await execFile(OPENCLAW_BIN, ["doctor", "--fix", "--yes", "--non-interactive"], {
+      timeout: 90_000,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+  } catch {
+    // Doctor can still repair some state before exiting non-zero. Continue
+    // into a restart + positive gateway probe rather than trusting exit code.
+  }
+}
+
+async function readGatewayJournalTail(): Promise<string> {
+  try {
+    const { stdout } = await execFile(
+      "/usr/bin/journalctl",
+      ["-u", "clawbox-gateway.service", "-n", "160", "--no-pager"],
+      { timeout: 10_000, maxBuffer: 2 * 1024 * 1024 },
+    );
+    return stdout;
+  } catch {
+    return "";
+  }
+}
+
+async function quarantineLegacyOpenclawState(): Promise<void> {
+  const script = `
+set -u
+CLAWBOX_HOME="/home/clawbox"
+TS="$(date +%Y%m%d-%H%M%S)"
+QDIR="$CLAWBOX_HOME/openclaw-legacy-quarantine-$TS"
+mkdir -p "$QDIR"
+/usr/bin/sudo /usr/bin/systemctl stop clawbox-gateway.service || true
+mv -v "$CLAWBOX_HOME/.openclaw/plugins/installs.json"* "$QDIR/" 2>/dev/null || true
+mv -v "$CLAWBOX_HOME/.openclaw/memory/carl_pir.sqlite"* "$QDIR/" 2>/dev/null || true
+mv -v "$CLAWBOX_HOME/.openclaw/agents/carl_pir/agent/openclaw-agent.sqlite"* "$QDIR/" 2>/dev/null || true
+`;
+  await execFile("/bin/bash", ["-lc", script], {
+    timeout: 30_000,
+    maxBuffer: 2 * 1024 * 1024,
+  });
+}
+
+async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): Promise<void> {
+  if (options.restartFirst) {
+    await restartGateway();
+  }
+
+  if (await waitForGateway(30_000)) return;
+
+  await runOpenclawDoctorFix();
+  await restartGateway().catch(() => {});
+  if (await waitForGateway(30_000)) return;
+
+  const beforeRecoveryLog = await readGatewayJournalTail();
+  if (!LEGACY_GATEWAY_BLOCKER_RE.test(beforeRecoveryLog)) {
+    const lastLog = getLastLogLine(beforeRecoveryLog);
+    throw new Error(
+      lastLog
+        ? `OpenClaw gateway is not listening on port ${GATEWAY_PORT}: ${lastLog}`
+        : `OpenClaw gateway is not listening on port ${GATEWAY_PORT}`,
+    );
+  }
+
+  await quarantineLegacyOpenclawState();
+  await runOpenclawDoctorFix();
+  await restartGateway();
+  if (await waitForGateway(45_000)) return;
+
+  const afterRecoveryLog = await readGatewayJournalTail();
+  const lastLog = getLastLogLine(afterRecoveryLog);
+  throw new Error(
+    lastLog
+      ? `OpenClaw gateway still offline after legacy state recovery: ${lastLog}`
+      : "OpenClaw gateway still offline after legacy state recovery",
+  );
+}
 
 const UPDATE_STEPS: UpdateStepDef[] = [
   {
@@ -368,6 +464,13 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     timeoutMs: 300_000,
     requiresRoot: true,
     advisoryOnOverrun: true,
+  },
+  {
+    id: "gateway_verify",
+    label: "Verifying gateway health",
+    timeoutMs: 90_000,
+    customRun: () => ensureGatewayHealthy(),
+    failFast: true,
   },
 ];
 
@@ -742,7 +845,7 @@ const OPENCLAW_UPDATE_STEPS: UpdateStepDef[] = [
     id: "gateway_restart",
     label: "Restarting OpenClaw gateway",
     timeoutMs: 30_000,
-    customRun: () => restartGateway(),
+    customRun: () => ensureGatewayHealthy({ restartFirst: true }),
   },
 ];
 

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -17,7 +17,12 @@ vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(),
 }));
 
+vi.mock("@/lib/port-probe", () => ({
+  isPortOpen: vi.fn(),
+}));
+
 import { get, set, setMany } from "@/lib/config-store";
+import { isPortOpen } from "@/lib/port-probe";
 
 const mockGet = vi.mocked(get);
 const mockSet = vi.mocked(set);
@@ -25,6 +30,7 @@ const mockSetMany = vi.mocked(setMany);
 const mockExec = vi.mocked(childProcess.exec);
 const mockExecFile = vi.mocked(childProcess.execFile);
 const mockReadFile = vi.mocked(fs.readFile);
+const mockIsPortOpen = vi.mocked(isPortOpen);
 
 function setupExecMock(results: Record<string, { stdout: string; stderr: string } | Error> = {}) {
   mockExec.mockImplementation(((
@@ -132,6 +138,7 @@ describe("updater", () => {
     mockSet.mockResolvedValue();
     mockSetMany.mockResolvedValue();
     mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    mockIsPortOpen.mockResolvedValue(true);
 
     setupExecMock({
       "ls-remote": { stdout: "abc123\trefs/tags/v1.0.0\ndef456\trefs/tags/v1.1.0\n", stderr: "" },


### PR DESCRIPTION
## Summary
- promote the tested beta candidate for v3.1.10 to main
- includes gateway health verification after updates and conservative legacy OpenClaw state recovery

## Beta validation
- beta was aligned with main/v3.1.9 before the hotfix
- PR #263 merged into beta after all checks passed
- CI passed on beta PR: test, review, e2e, e2e-install, CodeRabbit

## Safety
- this PR exists only to promote beta to main after beta checks
- no direct push to main
- recovery moves known legacy blocker files to timestamped quarantine directories instead of deleting them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added gateway health verification after updates, including connectivity checks and automated recovery/repair.
  - Added legacy gateway-state quarantine and retry logic to improve post-update startup reliability.
  - Added legacy Codex OAuth config migration (remapping stored model identifiers) during gateway pre-start.

- **Bug Fixes**
  - Improve recovery when the gateway is not reachable after an update, with additional journal/log-based validation.

- **Tests**
  - Updated updater unit tests to mock port probing.

- **Chores**
  - Bumped the application version to 3.1.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->