### PR TITLE
Add gateway recovery test coverage

### DIFF
--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -285,7 +285,9 @@ async function updateClawBoxAndReboot(): Promise<void> {
 // two flows can't drift apart.
 const OPENCLAW_INSTALL_TIMEOUT_MS = 300_000;
 const GATEWAY_PORT = Number(process.env.GATEWAY_PORT || "18789");
-const GATEWAY_WAIT_INTERVAL_MS = 1_500;
+const GATEWAY_HEALTH_WAIT_MS = Number(process.env.GATEWAY_HEALTH_WAIT_MS || "30000");
+const GATEWAY_RECOVERY_WAIT_MS = Number(process.env.GATEWAY_RECOVERY_WAIT_MS || "45000");
+const GATEWAY_WAIT_INTERVAL_MS = Number(process.env.GATEWAY_WAIT_INTERVAL_MS || "1500");
 const LEGACY_GATEWAY_BLOCKER_RE =
   /installs\.json|conflicting plugin install metadata|carl_pir|belongs to agent piper/i;
 
@@ -350,11 +352,11 @@ async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): P
     await restartGateway();
   }
 
-  if (await waitForGateway(30_000)) return;
+  if (await waitForGateway(GATEWAY_HEALTH_WAIT_MS)) return;
 
   await runOpenclawDoctorFix();
   await restartGateway().catch(() => {});
-  if (await waitForGateway(30_000)) return;
+  if (await waitForGateway(GATEWAY_HEALTH_WAIT_MS)) return;
 
   const beforeRecoveryLog = await readGatewayJournalTail();
   if (!LEGACY_GATEWAY_BLOCKER_RE.test(beforeRecoveryLog)) {
@@ -369,7 +371,7 @@ async function ensureGatewayHealthy(options: { restartFirst?: boolean } = {}): P
   await quarantineLegacyOpenclawState();
   await runOpenclawDoctorFix();
   await restartGateway();
-  if (await waitForGateway(45_000)) return;
+  if (await waitForGateway(GATEWAY_RECOVERY_WAIT_MS)) return;
 
   const afterRecoveryLog = await readGatewayJournalTail();
   const lastLog = getLastLogLine(afterRecoveryLog);

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -133,6 +133,9 @@ describe("updater", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    process.env.GATEWAY_HEALTH_WAIT_MS = "1";
+    process.env.GATEWAY_RECOVERY_WAIT_MS = "1";
+    process.env.GATEWAY_WAIT_INTERVAL_MS = "1";
 
     mockGet.mockResolvedValue(undefined);
     mockSet.mockResolvedValue();
@@ -157,6 +160,9 @@ describe("updater", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    delete process.env.GATEWAY_HEALTH_WAIT_MS;
+    delete process.env.GATEWAY_RECOVERY_WAIT_MS;
+    delete process.env.GATEWAY_WAIT_INTERVAL_MS;
   });
 
   describe("getUpdateState", () => {
@@ -336,6 +342,76 @@ describe("updater", () => {
       });
       const postStep = updater.getUpdateState().steps.find((step) => step.id === "post_update");
       expect(postStep?.status).toBe("completed");
+      expect(mockSetMany).toHaveBeenCalledWith(
+        expect.objectContaining({ update_completed: true }),
+      );
+    });
+
+    it("fails the continuation when gateway verification still finds no known recovery path", async () => {
+      setupExecFileMock({
+        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: "gateway crashed for an unrelated reason\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockIsPortOpen.mockResolvedValue(false);
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      const result = await updater.checkContinuation();
+      expect(result).toBe(true);
+
+      await vi.waitFor(() => {
+        const state = updater.getUpdateState();
+        expect(state.phase).toBe("failed");
+        expect(state.error).toContain("OpenClaw gateway is not listening on port 18789");
+      });
+    });
+
+    it("quarantines known legacy gateway blockers and completes when the gateway recovers", async () => {
+      setupExecFileMock({
+        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "/usr/bin/journalctl -u clawbox-gateway.service": {
+          stdout: "conflicting plugin install metadata\nopenclaw-agent.sqlite belongs to agent piper; requested agent carl_pir\n",
+          stderr: "",
+        },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+        "/bin/bash": { stdout: "moved legacy files\n", stderr: "" },
+      });
+
+      vi.resetModules();
+      mockGet.mockResolvedValue(true);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      mockIsPortOpen
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
+      updater = await import("@/lib/updater");
+
+      updater.resetUpdateState();
+      const result = await updater.checkContinuation();
+      expect(result).toBe(true);
+
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().phase).toBe("completed");
+      });
+      const bashCall = mockExecFile.mock.calls.find(([cmd]) => cmd === "/bin/bash");
+      expect(bashCall?.[1]).toEqual(expect.arrayContaining(["-lc", expect.stringContaining("installs.json")]));
+      expect(String((bashCall?.[1] as string[] | undefined)?.[1])).toContain("carl_pir.sqlite");
       expect(mockSetMany).toHaveBeenCalledWith(
         expect.objectContaining({ update_completed: true }),
       );


### PR DESCRIPTION
## Summary
- add coverage for offline gateway verification failure
- add coverage for known legacy blocker quarantine + successful recovery
- make gateway verification wait windows configurable so tests do not wait production timeouts

## Verification
- bun run test:unit -- src/tests/unit/updater.test.ts
- bunx tsc --noEmit
- bun run lint -- src/lib/updater.ts src/tests/unit/updater.test.ts
- bash -n install.sh
- git diff --check

## Notes
- addresses CodeRabbit coverage feedback on PR #264 before promoting to main