### PR TITLE
fix(mascot): stop crab teleporting to the left corner on tap

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,7 +3,7 @@
 // Bumping CACHE_NAME here is the supported way to invalidate previously
 // cached assets on existing installs — the `activate` handler deletes any
 // cache whose name doesn't match, so users get a clean slate on next visit.
-const CACHE_NAME = 'clawbox-v4'
+const CACHE_NAME = 'clawbox-v5'
 const PRECACHE = [
   '/',
   '/icon-192.png',

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -998,7 +998,16 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange }: { onTap?: 
         style={{
         position: 'fixed', left: 0,
         bottom: physicsActive ? 0 : 8,
-        transform: physicsActive ? undefined : `translateX(calc(${crabOnBox ? boxXRef.current : xRef.current}vw - 50%)) scaleX(${facing === 'left' ? -1 : 1})`,
+        // Keep the crab's real translateX (and hop height) while physics/drag is
+        // active instead of dropping to `undefined`. Clearing the transform
+        // reverts the crab to its base `left:0` — so a plain TAP (which flips
+        // physicsActive on pointerdown, before any imperative transform is set)
+        // snapped the crab to the bottom-LEFT corner for the ~100ms the pointer
+        // was held, reading as "the crab teleports to the corner" before the
+        // chat opens. The physics/drag rAF loop still overrides this per-frame.
+        transform: physicsActive
+          ? `translateX(calc(${xRef.current}vw - 50%)) translateY(${-physicsRef.current.posY}px)`
+          : `translateX(calc(${crabOnBox ? boxXRef.current : xRef.current}vw - 50%)) scaleX(${facing === 'left' ? -1 : 1})`,
         zIndex: 10001, pointerEvents: 'auto',
         cursor: 'grab',
         touchAction: 'none',


### PR DESCRIPTION
## The bug (Georgi / todor.local)
Tapping the crab makes it **teleport to the bottom-left corner for ~0.1s** before the chat opens.

## Root cause
`handlePointerDown` sets `physicsActive=true` immediately (before tap-vs-drag is known). The crab's JSX `transform` was `physicsActive ? undefined : translateX(...)`, so it went **`undefined` → crab reverts to base `left:0`** = bottom-left corner. On a plain tap nothing sets an imperative transform (only drag-move does), so the crab **sits in the corner** until `pointerup` fires `setPhysicsActive(false)`.

## Proof (measured on a real box, .40)
Simulated a held tap and tracked the crab's centre-x:
```
rest: 1241px  → press: 75px (held ~140ms) → release: 1241px
```

## Fix
Keep applying the crab's real `translateX` (+ hop `translateY`) while `physicsActive`, instead of clearing the transform. The imperative physics/drag rAF loop (lines 389-390 / 438-439) still overrides per-frame, so **drag/throw physics are unchanged**. Bump SW cache `clawbox-v4 → v5` so existing installs fetch the new bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)