### PR TITLE
3.1.10 follow-ups: chat open animation, mascot polish, uniform reasoning picker, smooth provider-switch bar, gpt-5.6-sol in codex picker

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -317,11 +317,12 @@ function ChromeDesktopInner() {
         }
         // Mascot
         if (data.ui_mascot_hidden) setMascotHidden(true);
-        // Chat panel dock state
+        // Chat panel dock state — a docked side panel is a deliberate layout so
+        // we still restore it. The FLOATING chat popup, however, must never
+        // auto-open on load: it should appear only when the user taps the crab.
+        // (We intentionally ignore a persisted `ui_chat_open` here.)
         if (data.ui_chat_panel_width && Number(data.ui_chat_panel_width) > 0) {
           setChatPanelWidth(Number(data.ui_chat_panel_width));
-          setChatOpen(true);
-        } else if (data.ui_chat_open) {
           setChatOpen(true);
         }
         // Auto-open chat once after fresh install (no saved preferences yet)
@@ -2008,13 +2009,15 @@ function ChromeDesktopInner() {
         )}
       </div>
 
-      {/* Mascot - tapping toggles chat popup, hidden when chat is docked as panel.
+      {/* Mascot - tapping toggles chat popup. It stays on the desktop even when
+          the chat is docked as a vertical panel; the Mascot slides itself clear
+          of the panel (rightInset) so it isn't hidden behind it.
           mascotX is captured once from onTap; we intentionally do NOT stream the
           frozen mascot's position while the chat is open — that used to nudge
           mascotX for a frame right after opening, flashing the popup to the wrong
           corner before it settled. */}
-      {chatPanelWidth === 0 && !isMobile && (
-        <Mascot frozen={chatOpen} onTap={(x?: number) => { if (x !== undefined) setMascotX(x); setChatOpen(prev => !prev); }} />
+      {!isMobile && (
+        <Mascot frozen={chatOpen} rightInset={chatPanelWidth} onTap={(x?: number) => { if (x !== undefined) setMascotX(x); setChatOpen(prev => !prev); }} />
       )}
       <ChatPopup isOpen={chatOpen} onClose={() => setChatOpen(false)} onOpenSettingsSection={openSettingsSection} onPanelModeChange={handleChatPanelModeChange} initialPanelWidth={chatPanelWidth} mascotX={mascotHidden ? 85 : mascotX} trayMode={mascotHidden} mobile={isMobile} />
 

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -171,11 +171,16 @@ const DEPRECATED_MODEL_IDS: ReadonlySet<string> = new Set([
 // openai (API-key auth): all 5.4 + 5.5 SKUs including -pro variants.
 //   Pros require an API key and DO work on the api.openai.com path.
 //
-// codex (ChatGPT-account auth): 5.4, 5.4-mini, 5.5 only — NO
-//   -pro variants. Per developers.openai.com/codex/models, the Pro
-//   models are API-key-only and the Codex/ChatGPT-account auth path
-//   400s with "model not supported when using Codex with a ChatGPT
-//   account" if you try gpt-5.4-pro or gpt-5.5-pro.
+// codex (ChatGPT-account auth): 5.4, 5.4-mini, 5.5, plus the 5.6
+//   gpt-5.6-{sol,terra,luna} models — NO -pro variants. Per
+//   developers.openai.com/codex/models, the Pro models are API-key-only
+//   and the Codex/ChatGPT-account auth path 400s with "model not
+//   supported when using Codex with a ChatGPT account" if you try
+//   gpt-5.4-pro or gpt-5.5-pro. The gpt-5.6-sol/terra/luna models DO run
+//   on the ChatGPT-account path for accounts whose plan (Plus/Pro/Max)
+//   includes them — the live upstream catalog only returns them for such
+//   accounts, so this allowlist just stops us from stripping them; boxes
+//   on plans without 5.6 never see the entries (no dead buttons).
 //
 // Older generations (4.1, 5.0, 5.1, 5.2, 5.3) are intentionally
 // excluded per user request. New generations matching the pattern
@@ -187,8 +192,10 @@ const ALLOWED_MODEL_RE_BY_PROVIDER: Record<string, RegExp> = {
   // accept gpt-5.5-mini (which doesn't exist on the Codex auth path
   // and would 400 the same way gpt-5.4-pro did). Per
   // developers.openai.com/codex/models the supported set under
-  // ChatGPT-account auth is exactly gpt-5.4, gpt-5.4-mini, gpt-5.5.
-  codex: /^(?:gpt-5\.5|gpt-5\.4(?:-mini)?)$/,
+  // ChatGPT-account auth is gpt-5.4, gpt-5.4-mini, gpt-5.5, plus the
+  // gpt-5.6-{sol,terra,luna} models (plan-gated upstream, so they only
+  // appear in the live catalog for accounts entitled to them).
+  codex: /^(?:gpt-5\.5|gpt-5\.4(?:-mini)?|gpt-5\.6-(?:sol|terra|luna))$/,
 };
 
 // Newest-first ordering: bigger context generally means newer model on

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1432,14 +1432,38 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         flexDirection: 'column',
         transformOrigin,
         opacity: visible ? 1 : 0,
-        transform: visible ? 'scale(1) translateY(0)' : (mobile ? 'translateY(100%)' : 'scale(0.82) translateY(6px)'),
-        // macOS-like: quick opacity, smooth easeOutExpo scale that decelerates
-        // into place. No transition mid-drag so the window tracks the cursor 1:1.
-        transition: dragRef.current ? 'none' : 'opacity 0.22s ease, transform 0.36s cubic-bezier(0.16, 1, 0.3, 1)',
+        // Resting transform. On desktop the entrance is driven by the
+        // `clawChatBurstIn` keyframes below (a spring burst OUT of the mascot
+        // with an overshoot, a tilt-wobble and an orange energy-glow flash),
+        // which override this while playing and settle back onto scale(1).
+        // Mobile keeps its clean slide-up; a drag pins it to the resting state.
+        transform: visible ? 'scale(1) translateY(0)' : (mobile ? 'translateY(100%)' : 'scale(0.72) translateY(14px)'),
+        animation: (visible && !mobile && !dragRef.current)
+          ? 'clawChatBurstIn 0.62s cubic-bezier(0.34, 1.56, 0.64, 1) both'
+          : undefined,
+        // Mobile / drag still use a transition; the desktop entrance is the
+        // keyframe animation, so we only transition opacity there to avoid
+        // fighting it. No transition mid-drag so the window tracks 1:1.
+        transition: dragRef.current
+          ? 'none'
+          : mobile
+            ? 'opacity 0.2s ease, transform 0.42s cubic-bezier(0.22, 1.28, 0.36, 1)'
+            : 'opacity 0.18s ease',
         pointerEvents: visible ? 'auto' : 'none',
-        willChange: 'transform, opacity',
+        willChange: 'transform, opacity, filter',
       }}
     >
+      {/* Insane entrance: spring burst out of the mascot with an overshoot,
+          a tilt-wobble, a soft blur-in and an orange energy-glow pulse.
+          transform-origin (set on the container) pins it to where the crab is,
+          so the whole thing erupts from the tapped mascot and settles clean. */}
+      <style>{`@keyframes clawChatBurstIn {
+        0%   { opacity: 0; transform: scale(0.12) translateY(38px) rotate(-8deg); filter: blur(16px) brightness(1.55) drop-shadow(0 0 0 rgba(249,115,22,0)); }
+        45%  { opacity: 1; transform: scale(1.08) translateY(-6px) rotate(2.4deg); filter: blur(0px) brightness(1.18) drop-shadow(0 0 26px rgba(249,115,22,0.6)); }
+        65%  { transform: scale(0.965) translateY(3px) rotate(-1.4deg); filter: brightness(1.05) drop-shadow(0 0 12px rgba(249,115,22,0.32)); }
+        82%  { transform: scale(1.015) translateY(-1px) rotate(0.5deg); filter: drop-shadow(0 0 5px rgba(249,115,22,0.16)); }
+        100% { opacity: 1; transform: scale(1) translateY(0) rotate(0deg); filter: blur(0px) brightness(1) drop-shadow(0 0 0 rgba(249,115,22,0)); }
+      }`}</style>
       {/* Header — drag handle (desktop) / simple bar (mobile) */}
       <div
         onPointerDown={mobile || panelMode ? undefined : onDragStart}

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1262,17 +1262,19 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // 100). Shared by the skill/provider event handlers and the onClose restart
   // path so the easing curve stays in one place.
   const startReloadProgressTimer = useCallback(() => {
-    if (reloadTimerRef.current) clearInterval(reloadTimerRef.current)
-    let progress = 0
-    reloadTimerRef.current = setInterval(() => {
-      progress += (90 - progress) * 0.08
-      const rounded = Math.min(Math.round(progress), 90)
-      setReloadProgress(rounded)
-      if (rounded >= 90 && reloadTimerRef.current) {
-        clearInterval(reloadTimerRef.current)
-        reloadTimerRef.current = null
-      }
-    }, 200)
+    // The reload bar is now driven by a compositor-only CSS transform animation
+    // (`clawReloadFill`, see the overlay below) instead of a JS setInterval.
+    // The old timer fired setReloadProgress every 200ms, and on the Jetson —
+    // where switching provider restarts the gateway and pins the CPU — those
+    // React re-renders plus the `width` transition (which forces layout every
+    // frame) made the bar visibly stutter. A transform:scaleX keyframe runs on
+    // the compositor thread and stays smooth even while the main thread is busy.
+    // We keep `reloadProgress` purely as the 0→100 completion signal. Just clear
+    // any stale timer from an older reload path.
+    if (reloadTimerRef.current) {
+      clearInterval(reloadTimerRef.current)
+      reloadTimerRef.current = null
+    }
   }, [])
   // Tear the reconnect overlay down and reset the reload flags. Called from
   // every terminal-failure path (both retry-exhaustion branches) so the error
@@ -1688,17 +1690,25 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       }}>
         {(status === 'connecting' || reloadingSkill) && (reloadingSkill || messages.length === 0) && (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, gap: 14, color: 'rgba(255,255,255,0.5)', fontSize: 13 }}>
-            <style>{`@keyframes spin { to { transform: rotate(360deg) } } @keyframes dots { 0%,20% { content: '' } 40% { content: '.' } 60% { content: '..' } 80%,100% { content: '...' } }`}</style>
+            <style>{`@keyframes spin { to { transform: rotate(360deg) } } @keyframes dots { 0%,20% { content: '' } 40% { content: '.' } 60% { content: '..' } 80%,100% { content: '...' } } @keyframes clawReloadFill { from { transform: scaleX(0.04) } to { transform: scaleX(0.9) } }`}</style>
             {reloadingSkill ? (
               <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 14, width: '85%' }}>
                 <div style={SPINNER_STYLE} />
                 <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 10, width: '100%' }}>
                   <span>{reloadReason === 'provider' ? 'Switching AI provider...' : reloadReason === 'restart' ? 'Restarting chat...' : 'Reloading skills...'}</span>
-                  <div role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={reloadProgress} aria-label="Reload progress" style={{ width: '100%', height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+                  <div role="progressbar" aria-valuemin={0} aria-valuemax={100} aria-valuenow={reloadProgress >= 100 ? 100 : undefined} aria-busy={reloadProgress < 100} aria-label="Reload progress" style={{ width: '100%', height: 4, borderRadius: 2, background: 'rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+                    {/* Compositor-only fill: a transform:scaleX keyframe eases
+                        0→90% and holds; when the gateway answers (reloadProgress
+                        hits 100) we drop the animation and transition to full.
+                        No JS ticks, no width/layout thrash — stays smooth even
+                        while the box is pinned restarting the gateway. */}
                     <div style={{
-                      height: '100%', borderRadius: 2, background: '#f97316',
-                      transition: 'width 0.3s ease-out',
-                      width: `${reloadProgress}%`,
+                      height: '100%', width: '100%', borderRadius: 2, background: '#f97316',
+                      transformOrigin: 'left',
+                      transform: reloadProgress >= 100 ? 'scaleX(1)' : 'scaleX(0.04)',
+                      transition: reloadProgress >= 100 ? 'transform 0.3s ease-out' : undefined,
+                      animation: reloadProgress >= 100 ? undefined : 'clawReloadFill 14s cubic-bezier(0.16, 1, 0.3, 1) forwards',
+                      willChange: 'transform',
                     }} />
                   </div>
                   <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.25)' }}>This may take up to 30 seconds</span>

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -35,7 +35,7 @@ const POWER_PARTICLES = [
   { bottom: 30, left: 108, duration: 1.35, delay: 0.95 },
 ]
 
-function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange }: { onTap?: (x?: number) => void; frozen?: boolean; thinking?: boolean; onPositionChange?: (x: number) => void } = {}) {
+function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }: { onTap?: (x?: number) => void; frozen?: boolean; thinking?: boolean; onPositionChange?: (x: number) => void; rightInset?: number } = {}) {
   const { locale } = useT()
   const frozenRef = useRef(false)
   const onPositionChangeRef = useRef(onPositionChange)
@@ -401,7 +401,12 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange }: { onTap?: 
     // Right-click — let onContextMenu handle it, don't start drag/tap
     if (e.button === 2) return
     e.preventDefault(); e.stopPropagation()
-    draggingRef.current = true; setPhysicsActive(true)
+    // NOTE: do NOT enter physics mode here. physicsActive makes React render
+    // `transform: undefined`, which strips the crab's translateX and snaps it to
+    // the far-left edge. On a plain tap (no move) pointerMove never re-applies a
+    // transform, so the crab would visibly teleport left then back. We only flip
+    // physicsActive on once a real drag is detected (see handlePointerMove).
+    draggingRef.current = true
     didDragRef.current = false
     dragStartPos.current = { x: e.clientX, y: e.clientY }
     const p = physicsRef.current
@@ -422,7 +427,17 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange }: { onTap?: 
     e.preventDefault()
     // Detect actual drag vs tap
     const dx = e.clientX - dragStartPos.current.x, dy = e.clientY - dragStartPos.current.y
-    if (dx * dx + dy * dy > 25) didDragRef.current = true
+    // Below the drag threshold we treat this as a potential tap: keep the crab
+    // perfectly still (no physics mode, no transform rewrite) so clicking to
+    // open the chat never nudges it. Only on crossing the threshold do we enter
+    // physics/drag mode and re-baseline the velocity tracking to here.
+    if (!didDragRef.current) {
+      if (dx * dx + dy * dy <= 25) return
+      didDragRef.current = true
+      setPhysicsActive(true)
+      const pp = physicsRef.current
+      pp.lastPointerX = e.clientX; pp.lastPointerY = e.clientY; pp.lastPointerTime = performance.now()
+    }
     const vw = window.innerWidth, vh = window.innerHeight, now = performance.now()
     const p = physicsRef.current
     const dt = (now - p.lastPointerTime) / 1000
@@ -969,6 +984,45 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange }: { onTap?: 
       stateTimeout.current = setTimeout(() => doActionRef.current(), 1000)
     }
   }, [frozen])
+
+  // ─── Keep the crab clear of a docked chat panel ───
+  // When the chat opens as a vertical side panel (rightInset = its width in px),
+  // the crab must stay on the visible desktop to the LEFT of the panel — the
+  // panel has a higher z-index, so anything under it is hidden. If the crab (or
+  // its box) would sit behind the panel, glide it into view. When the panel
+  // closes (inset back to 0) we leave the crab where it is — no snapping.
+  useEffect(() => {
+    const inset = rightInset ?? 0
+    if (inset <= 0) return
+    const vw = window.innerWidth
+    const CRAB_HALF = 75 // half the 150px crab image
+    const GAP = 24       // breathing room between crab and panel edge
+    const maxCenterPx = vw - inset - GAP - CRAB_HALF
+    const maxXvw = Math.max(5, (maxCenterPx / vw) * 100)
+
+    const startCrab = xRef.current
+    const startBox = boxXRef.current
+    const targetCrab = Math.min(startCrab, maxXvw)
+    const targetBox = Math.min(startBox, maxXvw)
+    const moveCrab = targetCrab < startCrab
+    const moveBox = targetBox < startBox
+    if (!moveCrab && !moveBox) return
+
+    // Face left as it retreats from the panel so the walk reads naturally.
+    if (moveCrab) setFacingDirect('left')
+    let raf = 0
+    const t0 = performance.now()
+    const dur = 520
+    const step = (now: number) => {
+      const t = Math.min((now - t0) / dur, 1)
+      const e = 1 - Math.pow(1 - t, 3) // easeOutCubic
+      if (moveCrab) { xRef.current = startCrab + (targetCrab - startCrab) * e; updateCrabPos() }
+      if (moveBox) { boxXRef.current = startBox + (targetBox - startBox) * e; updateBoxPos() }
+      if (t < 1) raf = requestAnimationFrame(step)
+    }
+    raf = requestAnimationFrame(step)
+    return () => { if (raf) cancelAnimationFrame(raf) }
+  }, [rightInset, updateCrabPos, updateBoxPos, setFacingDirect])
 
   // Listen for show/hide mascot events from desktop context menu
   useEffect(() => {

--- a/src/lib/chat-reasoning.ts
+++ b/src/lib/chat-reasoning.ts
@@ -28,37 +28,40 @@ export const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
   adaptive: "Adaptive",
 };
 
-// Per-provider effort levels and defaults. Sourced from each upstream's
-// official API docs. Showing the universal 8-level dropdown for every provider
-// was misleading — `Max` doesn't exist on OpenAI, `Minimal` was dropped from
-// gpt-5.4+, Google has `Adaptive` (thinking_budget=-1) where others have
-// `Default`, etc. Per-provider config keeps the UI honest.
+// Per-provider effort levels and defaults.
+//
+// Product decision (2026-07-23): the reasoning-effort picker is UNIFORM across
+// every cloud provider — `Off / Low / Medium / High` — so the control looks and
+// behaves the same no matter which model you pick. The OpenClaw gateway accepts
+// this ladder for all of them (it normalizes/translates per provider; e.g.
+// DeepSeek folds low/medium up to its single reasoning tier). Provider-specific
+// extras (`xhigh`, `max`, `adaptive`, `minimal`) are intentionally dropped for
+// consistency.
+//
+// Defaults differ on purpose: ClawBox AI / DeepSeek default to `off` so simple
+// prompts stay fast and don't burn reasoning tokens (users opt in), while the
+// reasoning-first cloud providers default to `medium`.
 export interface ProviderReasoningConfig {
   levels: readonly ThinkingLevel[];
   default: ThinkingLevel;
 }
 
+const UNIFORM_LEVELS: readonly ThinkingLevel[] = ["off", "low", "medium", "high"];
+
 export const REASONING_BY_PROVIDER: Record<string, ProviderReasoningConfig> = {
-  openai: { levels: ["off", "low", "medium", "high", "xhigh"], default: "medium" },
+  openai: { levels: UNIFORM_LEVELS, default: "medium" },
   // ChatGPT-subscription provider, renamed from `openai-codex` in OpenClaw
   // 2026.6.x. Provider ids are normalized to `codex` before they reach here.
-  codex: { levels: ["off", "low", "medium", "high", "xhigh"], default: "medium" },
-  // Anthropic effort docs: `low | medium | high | max` on Opus 4.6+, Sonnet
-  // 4.6, Opus 4.7, Mythos. Default per platform.claude.com is `high`. xhigh is
-  // Opus-4.7-only; we omit until we add per-model gating.
-  anthropic: { levels: ["low", "medium", "high", "max"], default: "high" },
-  // Gemini 2.5 thinking_budget: 0=off (Flash/Lite only — Pro silently
-  // ignores), -1=adaptive (auto). Picker stays provider-wide; Pro will fall
-  // back to adaptive when user picks Off.
-  google: { levels: ["off", "low", "medium", "high", "adaptive"], default: "adaptive" },
-  // ClawBox AI/DeepSeek defaults to Off so simple prompts stay fast and do
-  // not burn reasoning tokens. Users opt in when the task actually needs it.
-  deepseek: { levels: ["off", "high", "xhigh"], default: "off" },
+  codex: { levels: UNIFORM_LEVELS, default: "medium" },
+  anthropic: { levels: UNIFORM_LEVELS, default: "medium" },
+  google: { levels: UNIFORM_LEVELS, default: "medium" },
+  // ClawBox AI/DeepSeek keeps `off` as its default so simple prompts stay fast;
+  // low/medium/high are offered for parity but the gateway folds low/medium up
+  // to DeepSeek's single reasoning tier.
+  deepseek: { levels: UNIFORM_LEVELS, default: "off" },
   // ClawBox AI routes via DeepSeek today.
-  clawai: { levels: ["off", "high", "xhigh"], default: "off" },
-  // OpenRouter normalizes per underlying model — surface the full set they
-  // document at openrouter.ai/docs/guides/best-practices/reasoning-tokens.
-  openrouter: { levels: ["off", "minimal", "low", "medium", "high", "xhigh"], default: "medium" },
+  clawai: { levels: UNIFORM_LEVELS, default: "off" },
+  openrouter: { levels: UNIFORM_LEVELS, default: "medium" },
   // Local Gemma (llama.cpp) exposes no reasoning-effort control — the gateway
   // rejects any thinkingLevel other than `off` ("thinkingLevel … is not
   // supported for llamacpp/gemma… (use off)"). Declaring it off-only hides the

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -70,10 +70,16 @@ export const OPENAI_MODELS: readonly ProviderModelOption[] = [
 // key. NO -pro variants — those are API-key only (they 400 with "model
 // not supported when using Codex with a ChatGPT account" on the OAuth
 // path). Per developers.openai.com/codex/models the supported set via
-// ChatGPT-account auth is gpt-5.5, gpt-5.4, gpt-5.4-mini. Filter lives
-// in ALLOWED_MODEL_RE_BY_PROVIDER (catalog route).
+// ChatGPT-account auth is gpt-5.6-{sol,terra,luna}, gpt-5.5, gpt-5.4,
+// gpt-5.4-mini. The gpt-5.6 models are plan-gated upstream (Plus/Pro/Max)
+// — the live catalog only returns them for entitled accounts, so listing
+// them here just gives them stable labels; accounts without the plan
+// never see them. Filter lives in ALLOWED_MODEL_RE_BY_PROVIDER (catalog).
 export const CODEX_MODELS: readonly ProviderModelOption[] = [
-  { id: "gpt-5.5", label: "GPT-5.5", hint: "Latest flagship." },
+  { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", hint: "Newest flagship. Plus/Pro." },
+  { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", hint: "GPT-5.6. Plus/Pro." },
+  { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", hint: "GPT-5.6, fast. Plus/Pro." },
+  { id: "gpt-5.5", label: "GPT-5.5", hint: "Flagship." },
   { id: "gpt-5.4", label: "GPT-5.4", hint: "Default. 1M context." },
   { id: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "Fast, cheap." },
 ] as const;

--- a/src/tests/unit/chat-reasoning.test.ts
+++ b/src/tests/unit/chat-reasoning.test.ts
@@ -19,23 +19,20 @@ describe("chat-reasoning", () => {
       expect(cfg.levels.length).toBe(1);
     });
 
-    it("returns the upstream-accurate set for cloud providers", () => {
-      expect(getProviderReasoningConfig("openai").levels).toContain("xhigh");
-      expect(getProviderReasoningConfig("deepseek")).toEqual({
-        levels: ["off", "high", "xhigh"],
-        default: "off",
-      });
-      expect(getProviderReasoningConfig("clawai")).toEqual({
-        levels: ["off", "high", "xhigh"],
-        default: "off",
-      });
-      expect(getProviderReasoningConfig("anthropic").levels).toEqual([
-        "low",
-        "medium",
-        "high",
-        "max",
-      ]);
-      expect(getProviderReasoningConfig("google").default).toBe("adaptive");
+    it("exposes a uniform off/low/medium/high ladder for every cloud provider", () => {
+      const uniform = ["off", "low", "medium", "high"];
+      for (const provider of ["openai", "codex", "anthropic", "google", "deepseek", "clawai", "openrouter"]) {
+        expect(getProviderReasoningConfig(provider).levels).toEqual(uniform);
+      }
+    });
+
+    it("keeps ClawBox AI / DeepSeek fast-by-default (off) while cloud providers default to medium", () => {
+      expect(getProviderReasoningConfig("deepseek").default).toBe("off");
+      expect(getProviderReasoningConfig("clawai").default).toBe("off");
+      expect(getProviderReasoningConfig("codex").default).toBe("medium");
+      expect(getProviderReasoningConfig("openai").default).toBe("medium");
+      expect(getProviderReasoningConfig("anthropic").default).toBe("medium");
+      expect(getProviderReasoningConfig("google").default).toBe("medium");
     });
 
     it("falls back for unknown or empty providers", () => {


### PR DESCRIPTION
Folds the test-box UI/UX work + fixes into beta (NOT main — hold for tagging when polished, per Karchev).

- **New chat open animation** (`clawChatBurstIn`) + mascot no longer teleports on tap + mascot slides clear of a docked chat panel; floating chat no longer auto-opens on load. (Was uncommitted on the todor.local test box.)
- **Uniform reasoning picker**: Off/Low/Medium/High across every cloud provider (dropped provider-specific xhigh/max/adaptive); ClawBox AI/DeepSeek keep an `off` default for speed.
- **Smooth provider-switch progress bar**: replaced the 200ms setInterval + width-transition (janks on the Jetson while the gateway restarts) with a compositor-only `transform: scaleX` CSS keyframe.
- **gpt-5.6-sol/terra/luna in the codex picker**: widened the codex catalog allowlist regex + added labels. Plan-gated upstream — the live catalog only returns them for entitled (Plus/Pro/Max) ChatGPT accounts, so lesser plans still never see them (no dead buttons).

Verified: typecheck 0 errors, chat-reasoning + provider-models unit tests green, `next build` succeeds on the Jetson. Tested live on box .40 (UI/animation/switch-bar). sol picker pending a fresh ChatGPT session on .40 to verify end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)