### PR TITLE
fix(gateway): 3.1.11 — updates & boot never brick the box

### DIFF
--- a/config/clawbox-gateway.service
+++ b/config/clawbox-gateway.service
@@ -15,6 +15,14 @@ ExecStartPre=/home/clawbox/clawbox/scripts/gateway-pre-start.sh
 ExecStart=/home/clawbox/.npm-global/bin/openclaw gateway --allow-unconfigured --bind lan
 Restart=always
 RestartSec=5
+# gateway-pre-start.sh runs as a blocking ExecStartPre. The default
+# ~90s start timeout could kill a legitimately slow first-boot pre-start
+# (plugin fetch/unpack on a cold Jetson) mid-flight and wedge the unit into
+# a restart loop. Give pre-start a generous ceiling; the risky network step
+# (codex plugin install) is itself hard time-boxed inside the script, so the
+# unit never actually approaches this bound in the failure case — it just
+# stops a slow-npm boot from being killed prematurely.
+TimeoutStartSec=600
 Environment=HOME=/home/clawbox
 Environment=NODE_ENV=production
 Environment=BUN_ENV=production

--- a/e2e-install/80-chat.spec.ts
+++ b/e2e-install/80-chat.spec.ts
@@ -127,18 +127,21 @@ test.describe("chat round trip", () => {
       { name: "clawbox_session", value: match![1], domain: "localhost", path: "/" },
     ]);
 
-    // The desktop opens the chat panel based on the ui_chat_open pref.
-    // Fresh-setup state leaves it closed; force it open so we don't have
-    // to hunt for the mascot-click sequence that toggles it.
+    // Hide the mascot so the chat opens from the taskbar "Chat" button
+    // (tray mode) rather than the crab-tap sequence, which is pointer-event
+    // flaky. `ui_chat_open` is deliberately NOT set: the floating popup no
+    // longer auto-opens from a persisted preference (see src/app/page.tsx) —
+    // it must be opened by a user action.
     await fetch(`${BASE_URL}/setup-api/preferences`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ui_chat_open: 1, ui_mascot_hidden: 1 }),
+      body: JSON.stringify({ ui_mascot_hidden: 1 }),
     });
 
     await page.goto("/");
+    await expect(page.getByTestId("desktop-root")).toBeVisible();
+    await page.getByRole("button", { name: "Chat" }).click();
 
-    // ChatPopup auto-opens on the desktop shell — no launcher click needed.
     // Before the gateway WS connects, the textbox shows
     // "Waiting for the Claw to wake up…" and is disabled. Once the gateway
     // acknowledges the session, the placeholder flips to "Type a message..."

--- a/e2e-install/80-chat.spec.ts
+++ b/e2e-install/80-chat.spec.ts
@@ -127,20 +127,20 @@ test.describe("chat round trip", () => {
       { name: "clawbox_session", value: match![1], domain: "localhost", path: "/" },
     ]);
 
-    // Hide the mascot so the chat opens from the taskbar "Chat" button
-    // (tray mode) rather than the crab-tap sequence, which is pointer-event
-    // flaky. `ui_chat_open` is deliberately NOT set: the floating popup no
-    // longer auto-opens from a persisted preference (see src/app/page.tsx) —
-    // it must be opened by a user action.
+    // A persisted `ui_chat_open` no longer opens the chat — the floating
+    // popup is deliberately ignored on load now (see src/app/page.tsx), so
+    // seeding it leaves the desktop with no chat and no textbox to find.
+    // The docked side panel IS still restored, and `ui_chat_panel_width > 0`
+    // opens it at mount with the same input this test drives. That keeps the
+    // chat on screen without depending on a launcher button or the
+    // pointer-flaky crab tap.
     await fetch(`${BASE_URL}/setup-api/preferences`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ ui_mascot_hidden: 1 }),
+      body: JSON.stringify({ ui_chat_panel_width: 420, ui_mascot_hidden: 1 }),
     });
 
     await page.goto("/");
-    await expect(page.getByTestId("desktop-root")).toBeVisible();
-    await page.getByRole("button", { name: "Chat" }).click();
 
     // Before the gateway WS connects, the textbox shows
     // "Waiting for the Claw to wake up…" and is disabled. Once the gateway

--- a/e2e/first-load-mascot-layout.spec.ts
+++ b/e2e/first-load-mascot-layout.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-test("desktop first render keeps the mascot below an already-open chat popup", async ({ page }) => {
+test("desktop keeps the mascot below the chat popup", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,
@@ -11,9 +11,19 @@ test("desktop first render keeps the mascot below an already-open chat popup", a
       ai_model_configured: true,
       telegram_configured: true,
     },
+    // A persisted `ui_chat_open` no longer opens the floating popup — that
+    // is deliberately ignored on load now (see src/app/page.tsx), so it
+    // can't set up the state this test measures. Use the one load-time path
+    // that still opens it: the fresh-install greeting, which fires when no
+    // wallpaper and no desktop apps have been saved yet. That matters for
+    // more than convenience — the popup must be open at mount so `frozen`
+    // pins the crab immediately. Opening it later (via a click) races the
+    // mascot's autonomous walk, which starts ~3.5s in and drifts the crab
+    // away from the popup's `mascotX` anchor under CI load.
     preferences: {
       ui_mascot_hidden: 0,
-      ui_chat_open: 1,
+      wp_id: null,
+      desktop_apps: null,
     },
   });
 

--- a/install.sh
+++ b/install.sh
@@ -1628,6 +1628,20 @@ step_ollama_install() {
   # Apply Jetson memory optimizations
   bash "$PROJECT_DIR/scripts/optimize-ollama.sh"
   echo "  Ollama installed and running"
+
+  # Local embedding model for semantic memory. OpenClaw's memory search
+  # defaults to OpenAI embeddings, which need an OPENAI_API_KEY the box often
+  # doesn't have (ChatGPT-OAuth / DeepSeek users) — surfacing after updates as
+  # "Semantic memory search is still offline ... missing OpenAI provider
+  # auth/API-key access". Pull a small local embedding model so semantic
+  # recall works with zero API key; gateway-pre-start.sh points memorySearch
+  # at it once present. Best-effort: a failed pull must not abort the install
+  # (memory falls back to lexical FTS).
+  if ollama pull qwen3-embedding:0.6b >/dev/null 2>&1; then
+    echo "  Pulled local embedding model qwen3-embedding:0.6b (semantic memory, no API key)"
+  else
+    echo "  WARN: could not pull qwen3-embedding:0.6b; semantic memory falls back to lexical FTS until available (non-fatal)"
+  fi
 }
 
 step_llamacpp_install() {

--- a/install.sh
+++ b/install.sh
@@ -1839,28 +1839,55 @@ step_ai_tools_install() {
     echo "  CLAWBOX_TEST_MODE=1, skipping Claude/Codex/Gemini CLI install"
     return 0
   fi
-  # Claude Code
+  # The AI coding CLIs below are ALL optional — the box boots and runs fine
+  # without any of them. This whole step must therefore be best-effort: no
+  # single tool's install may abort the run. install.sh runs under
+  # `set -euo pipefail`, so every risky command is guarded inside an `if`
+  # (where errexit is suspended) and failures only log a WARN.
+
+  # Claude Code — Anthropic GEO-BLOCKS some regions and serves an HTML
+  # "App unavailable in region" page with HTTP 200 (so `curl -f` does NOT
+  # catch it). Piping that HTML into `bash` yields
+  # `syntax error near unexpected token '<'`, and under `set -euo pipefail`
+  # that aborted the ENTIRE reinstall right here — so the later steps that
+  # (re)start the gateway never ran and the box came up as an nginx 404
+  # (Discord "broke my clawbox", step [18/23]). Guard it: download to a file,
+  # verify it looks like a shell script and not an HTML/region-block page,
+  # only then run it, and never let failure escape this step.
   if sudo -u "$CLAWBOX_USER" bash -c 'command -v claude' &>/dev/null; then
     echo "  Claude Code already installed"
   else
-    sudo -u "$CLAWBOX_USER" bash -c 'curl -fsSL https://claude.ai/install.sh | bash'
-    echo "  Claude Code installed"
+    _claude_installer="$(mktemp)"
+    if curl -fsSL https://claude.ai/install.sh -o "$_claude_installer" 2>/dev/null \
+       && [ -s "$_claude_installer" ] \
+       && ! head -c 512 "$_claude_installer" | grep -qiE '<!doctype|<html|unavailable in region'; then
+      if sudo -u "$CLAWBOX_USER" bash "$_claude_installer" </dev/null; then
+        echo "  Claude Code installed"
+      else
+        echo "  WARN: Claude Code installer ran but failed; skipping (optional, continuing)"
+      fi
+    else
+      echo "  WARN: Claude Code installer unavailable or region-blocked (non-script response); skipping (optional, continuing)"
+    fi
+    rm -f "$_claude_installer"
   fi
 
-  # OpenAI Codex CLI
+  # OpenAI Codex CLI (optional)
   if as_clawbox_login "command -v codex" &>/dev/null; then
     echo "  OpenAI Codex already installed"
-  else
-    as_clawbox_login "npm i -g @openai/codex --prefix $NPM_PREFIX"
+  elif as_clawbox_login "npm i -g @openai/codex --prefix $NPM_PREFIX"; then
     echo "  OpenAI Codex installed"
+  else
+    echo "  WARN: OpenAI Codex CLI install failed; skipping (optional, continuing)"
   fi
 
-  # Google Gemini CLI
+  # Google Gemini CLI (optional)
   if as_clawbox_login "command -v gemini" &>/dev/null; then
     echo "  Gemini CLI already installed"
-  else
-    as_clawbox_login "npm i -g @google/gemini-cli --prefix $NPM_PREFIX"
+  elif as_clawbox_login "npm i -g @google/gemini-cli --prefix $NPM_PREFIX"; then
     echo "  Gemini CLI installed"
+  else
+    echo "  WARN: Gemini CLI install failed; skipping (optional, continuing)"
   fi
 
   # Make claude / codex / gemini resolvable in the in-UI terminal's interactive

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -486,7 +486,21 @@ fi
 # resolves to `~/.openclaw`, the same root OpenClaw's own plugin
 # installer writes under (`<openclaw-home>/npm/node_modules/...`).
 OPENCLAW_HOME_DIR="$(dirname "$OPENCLAW_CONFIG")"
+# OpenClaw's plugin install layout changed across versions: older cores wrote
+# the plugin flat under <home>/npm/node_modules/@openclaw/codex, while current
+# cores (2026.7.x) isolate each plugin in its own project dir under
+# <home>/npm/projects/<hash>/node_modules/@openclaw/codex. Hard-coding only the
+# flat path made the "is it installed?" check below read the plugin as ALWAYS
+# missing on newer cores, so pre-start reinstalled codex on EVERY boot (slow,
+# and — before this fix — an unbounded npm install on the blocking boot path,
+# a prime "gateway won't start after update" trigger). Resolve to whichever
+# layout actually holds the package.json; keep the flat path as the default so
+# a first-time install still has a well-known destination.
 CODEX_PLUGIN_DIR="$OPENCLAW_HOME_DIR/npm/node_modules/@openclaw/codex"
+if [ ! -f "$CODEX_PLUGIN_DIR/package.json" ]; then
+  CODEX_PLUGIN_DIR_FOUND="$(ls -d "$OPENCLAW_HOME_DIR"/npm/projects/*/node_modules/@openclaw/codex 2>/dev/null | head -1 || true)"
+  [ -n "$CODEX_PLUGIN_DIR_FOUND" ] && CODEX_PLUGIN_DIR="$CODEX_PLUGIN_DIR_FOUND"
+fi
 NEEDS_CODEX_PLUGIN="$(python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, sys
 try:
@@ -540,11 +554,24 @@ if [ "$NEEDS_CODEX_PLUGIN" = "1" ]; then
     # and every Codex chat crashes with "_diagnosticRuntime.
     # createDiagnosticTraceContextFromActiveScope is not a function" (the
     # newer plugin calls a runtime API the pinned core doesn't expose).
-    # Reinstall at the pinned version whenever the two differ.
+    # Reinstall only when the BASE version actually differs.
+    #
+    # Republish-tolerant compare: npm republishes the SAME release with a
+    # -N / -beta.N build suffix (2026.7.1 -> 2026.7.1-1 -> 2026.7.1-2). Those
+    # share the same runtime API as their base version, so an exact-string
+    # `!=` compare would flag `2026.7.1-1` vs pinned `2026.7.1` as a skew and
+    # reinstall the plugin — synchronously, on the gateway boot path — on
+    # EVERY boot. On a Jetson with slow/blocked npm that stalls startup and
+    # the gateway never comes online ("Update failed / gateway still offline").
+    # Strip the build suffix and compare only MAJOR.MINOR.PATCH: a real
+    # API-skew (plugin 2026.7.2 vs core 2026.7.1) still triggers a reinstall,
+    # a mere republish does not.
     CODEX_INSTALLED_VER=$(python3 -c "import json; print(json.load(open('$CODEX_PLUGIN_DIR/package.json')).get('version',''))" 2>/dev/null || echo "")
-    if [ "$CODEX_INSTALLED_VER" != "$OPENCLAW_TARGET" ]; then
+    CODEX_INSTALLED_BASE="${CODEX_INSTALLED_VER%%-*}"
+    OPENCLAW_TARGET_BASE="${OPENCLAW_TARGET%%-*}"
+    if [ "$CODEX_INSTALLED_BASE" != "$OPENCLAW_TARGET_BASE" ]; then
       CODEX_NEEDS_INSTALL=1
-      CODEX_INSTALL_REASON="version $CODEX_INSTALLED_VER != core target $OPENCLAW_TARGET"
+      CODEX_INSTALL_REASON="base version $CODEX_INSTALLED_VER != core target $OPENCLAW_TARGET"
     fi
   fi
 fi
@@ -554,8 +581,19 @@ if [ "$CODEX_NEEDS_INSTALL" = "1" ]; then
   # bare alias only when the pin is unknown, so a needed repair still happens.
   CODEX_SPEC="codex"
   [ -n "$OPENCLAW_TARGET" ] && CODEX_SPEC="@openclaw/codex@$OPENCLAW_TARGET"
-  "$OPENCLAW_BIN" plugins install "$CODEX_SPEC" --force >/dev/null 2>&1 \
-    || echo "  WARN: openclaw plugins install $CODEX_SPEC failed; Codex chats will fail until resolved"
+  # Hard time-box this install. gateway-pre-start.sh runs as a BLOCKING
+  # ExecStartPre for clawbox-gateway.service, so an npm install that hangs
+  # (slow/blocked/offline registry on a Jetson) would keep the gateway from
+  # ever reaching "listening" — which is exactly the "gateway won't start
+  # after update" failure. Best-effort: if the install fails OR times out we
+  # log a warning and let the gateway start anyway. Codex is one provider;
+  # a degraded Codex is far better than a dead box, and the next boot (or a
+  # manual `openclaw plugins install`) can still repair it.
+  if timeout 120 "$OPENCLAW_BIN" plugins install "$CODEX_SPEC" --force >/dev/null 2>&1; then
+    echo "  Codex runtime plugin installed/repaired ($CODEX_SPEC)"
+  else
+    echo "  WARN: 'openclaw plugins install $CODEX_SPEC' failed or timed out; Codex chats will fail until resolved (gateway will still start)"
+  fi
 fi
 
 # Codex 2026.6.x reads its ChatGPT session from the Codex CLI's own

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -596,39 +596,108 @@ if [ "$CODEX_NEEDS_INSTALL" = "1" ]; then
   fi
 fi
 
-# Codex 2026.6.x reads its ChatGPT session from the Codex CLI's own
-# ~/.codex/auth.json (not the openclaw profile) — without it the app-server
-# falls back to api.openai.com with no bearer -> 401. Synthesize it from the
-# codex OAuth profile (account_id decoded from the access JWT). Write-if-
-# missing: the app-server owns refresh once it exists, so we don't clobber it.
+# Codex reads its ChatGPT session from a Codex CLI-style auth.json. Without
+# one the app-server falls back to api.openai.com with no bearer -> 401
+# "Missing bearer or basic authentication in header", which is what users hit
+# as "codex is unusable" on a ChatGPT-subscription box. Two things have to
+# line up, and on current cores neither did:
+#
+#   1. WHERE the app-server reads it. Codex 2026.6.x used the shared
+#      ~/.codex. OpenClaw 2026.7.x spawns the app-server with
+#      CODEX_HOME=<agentDir>/codex-home (confirmed from the live process
+#      environment), so a credential that exists only in ~/.codex is never
+#      seen. Mirror it into every agent's codex-home.
+#   2. WHERE we read the profile from. The tokens used to live in
+#      agents/<id>/agent/auth-profiles.json; on 2026.7.x they moved into the
+#      auth_profile_store table of openclaw-agent.sqlite, so the old
+#      JSON-only lookup silently found nothing and wrote no credential at all.
+#
+# An existing ~/.codex/auth.json is preferred as the source: it comes from a
+# real Codex login and carries a true id_token, whereas a synthesized one can
+# only fall back to the access token. Write-if-missing at every destination —
+# the app-server owns refresh once a file exists, so we never clobber a newer
+# token.
 if [ "$NEEDS_CODEX_PLUGIN" = "1" ]; then
-  CODEX_AUTH_FILE="$HOME/.codex/auth.json"
-  if [ ! -f "$CODEX_AUTH_FILE" ]; then
-    node - "$OPENCLAW_HOME_DIR/agents/main/agent/auth-profiles.json" "$CODEX_AUTH_FILE" <<'NODE'
+  node - "$OPENCLAW_HOME_DIR" "$HOME/.codex/auth.json" <<'NODE'
 const fs = require("fs"), path = require("path");
-const [apPath, outPath] = process.argv.slice(2);
-try {
-  const data = JSON.parse(fs.readFileSync(apPath, "utf8"));
-  const profiles = data.profiles || {};
-  const p = profiles["codex:default"] || profiles["openai-codex:default"];
-  if (!p || !p.access) { console.log("  Codex auth.json: no codex OAuth profile yet, skipping"); process.exit(0); }
+const [openclawHome, homeAuthPath] = process.argv.slice(2);
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; }
+}
+
+// Prefer a real Codex login if one is already on disk.
+function fromExistingFile() {
+  const d = readJson(homeAuthPath);
+  return d && d.tokens && d.tokens.access_token ? d : null;
+}
+
+// Otherwise synthesize from the OpenClaw codex OAuth profile. Tokens live in
+// auth-profiles.json on older cores and in openclaw-agent.sqlite on 2026.7.x.
+function readProfiles(agentDir) {
+  const j = readJson(path.join(agentDir, "auth-profiles.json"));
+  if (j && j.profiles) return j.profiles;
+  try {
+    const { DatabaseSync } = require("node:sqlite");
+    const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"), { readOnly: true });
+    const row = db.prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?").get("primary");
+    db.close();
+    const parsed = row && row.store_json ? JSON.parse(row.store_json) : null;
+    return (parsed && parsed.profiles) || null;
+  } catch { return null; } // no node:sqlite, no table, or locked — non-fatal
+}
+
+function synthesize(agentDir) {
+  const profiles = readProfiles(agentDir);
+  const p = profiles && (profiles["codex:default"] || profiles["openai-codex:default"]);
+  if (!p || !p.access) return null;
   let accountId = null;
   try {
     const claims = JSON.parse(Buffer.from(p.access.split(".")[1], "base64url").toString());
     const auth = claims["https://api.openai.com/auth"] || {};
     accountId = auth.chatgpt_account_id || auth.account_id || auth.user_id || claims.sub || null;
   } catch { /* opaque token — leave accountId null */ }
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  fs.chmodSync(path.dirname(outPath), 0o700); // ~/.codex holds OAuth tokens — keep it owner-only (not just the 0600 file)
-  fs.writeFileSync(outPath, JSON.stringify({
+  return {
     OPENAI_API_KEY: null,
     tokens: { id_token: p.id || p.access, access_token: p.access, refresh_token: p.refresh, account_id: accountId },
     last_refresh: new Date().toISOString(),
-  }, null, 2), { mode: 0o600 });
-  console.log("  Wrote ~/.codex/auth.json for the Codex app-server (account_id " + (accountId ? "resolved" : "missing") + ")");
+  };
+}
+
+function write(dest, cred) {
+  if (fs.existsSync(dest)) return false;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.chmodSync(path.dirname(dest), 0o700); // holds OAuth tokens — owner-only dir, not just the 0600 file
+  fs.writeFileSync(dest, JSON.stringify(cred, null, 2), { mode: 0o600 });
+  return true;
+}
+
+try {
+  const agentsRoot = path.join(openclawHome, "agents");
+  const agents = fs.existsSync(agentsRoot)
+    ? fs.readdirSync(agentsRoot).map((id) => path.join(agentsRoot, id, "agent")).filter((d) => fs.existsSync(d))
+    : [];
+
+  let cred = fromExistingFile();
+  if (!cred) {
+    // Prefer the main agent's profile store as the synthesis source.
+    const byMainFirst = (a, b) => Number(b.includes("/main/")) - Number(a.includes("/main/"));
+    for (const dir of [...agents].sort(byMainFirst)) {
+      cred = synthesize(dir);
+      if (cred) break;
+    }
+  }
+  if (!cred) { console.log("  Codex auth.json: no codex OAuth profile yet, skipping"); process.exit(0); }
+
+  if (write(homeAuthPath, cred)) console.log("  Wrote ~/.codex/auth.json for the Codex app-server");
+  for (const dir of agents) {
+    // CODEX_HOME the gateway actually passes to the app-server on 2026.7.x.
+    if (write(path.join(dir, "codex-home", "auth.json"), cred)) {
+      console.log("  Wrote " + path.basename(path.dirname(dir)) + " agent codex-home/auth.json");
+    }
+  }
 } catch (e) { console.log("  Codex auth.json: " + e.message); }
 NODE
-  fi
 fi
 
 # Semantic memory embeddings default. OpenClaw's memory search defaults to

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -631,6 +631,28 @@ NODE
   fi
 fi
 
+# Semantic memory embeddings default. OpenClaw's memory search defaults to
+# OpenAI embeddings, which need an OPENAI_API_KEY many boxes don't have
+# (ChatGPT-OAuth / DeepSeek users) — surfacing after updates as
+# "Semantic memory search is still offline ... missing OpenAI provider
+# auth/API-key access". If the user hasn't deliberately chosen an embeddings
+# provider AND the local model is present in Ollama, point memory search at
+# local Ollama so semantic recall works with zero API key. Self-heals existing
+# boxes on upgrade, not just fresh installs. Gated on the model actually being
+# present so we never leave memorySearch fail-closed on a missing model; only
+# touches an unset/"auto" provider so a deliberate OpenAI/remote setup stays.
+MEM_PROVIDER="$(python3 -c "import json;print(((json.load(open('$OPENCLAW_CONFIG')).get('agents',{}).get('defaults',{}) or {}).get('memorySearch',{}) or {}).get('provider') or '')" 2>/dev/null || echo "")"
+if [ -z "$MEM_PROVIDER" ] || [ "$MEM_PROVIDER" = "auto" ]; then
+  if curl -fsS --max-time 5 http://localhost:11434/api/tags 2>/dev/null | grep -q "qwen3-embedding"; then
+    if "$OPENCLAW_BIN" config set agents.defaults.memorySearch.provider ollama >/dev/null 2>&1 \
+       && "$OPENCLAW_BIN" config set agents.defaults.memorySearch.model qwen3-embedding:0.6b >/dev/null 2>&1; then
+      echo "  Memory search -> local Ollama embeddings (qwen3-embedding:0.6b, no API key needed)"
+    else
+      echo "  WARN: could not set memorySearch to local Ollama embeddings (non-fatal; memory falls back to lexical FTS)"
+    fi
+  fi
+fi
+
 # Ensure the per-install MCP bearer token exists and is wired into the
 # openclaw MCP server registration. The token lets the MCP subprocess
 # (mcp/clawbox-mcp.ts) authenticate back to /setup-api/* on port 80 —

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -66,7 +66,16 @@ const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   openrouter: `openrouter/${OPENROUTER_DEFAULT_MODEL_ID}`,
 };
 
-const CODEX_SUPPORTED_MODEL_RE = /^(?:gpt-5\.5|gpt-5\.4(?:-mini)?)$/;
+// Models selectable while the device is on ChatGPT/Codex subscription auth.
+// GPT-5.6 Sol/Terra/Luna are subscription-eligible — OpenClaw's ChatGPT route
+// catalog carries all three, and `openai/gpt-5.6-sol` is the documented
+// default for a fresh Codex OAuth setup. Keeping them out of this allowlist
+// rejected them locally with "not supported with ChatGPT subscription auth"
+// before the request ever reached OpenAI. GPT-5.6 is a limited preview, so
+// per-account access still varies: let the pick through and surface the
+// upstream access error instead of pre-rejecting it here. `-pro` tiers stay
+// out — those remain API-key only.
+const CODEX_SUPPORTED_MODEL_RE = /^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|gpt-5\.4(?:-mini)?)$/;
 const OPENAI_PRO_MODEL_RE = /^gpt-5\.[45]-pro$/;
 
 function isLocalModel(model: string | null | undefined): boolean {
@@ -356,7 +365,7 @@ export async function POST(request: Request) {
         let effectiveModelId = parsed.modelId;
         if (parsed.provider === "codex" && !CODEX_SUPPORTED_MODEL_RE.test(parsed.modelId)) {
           return NextResponse.json({
-            error: `${parsed.modelId} is not supported with ChatGPT subscription auth. Use GPT-5.5, GPT-5.4, or GPT-5.4 Mini, or switch OpenAI to API-key mode for Pro/API-only models.`,
+            error: `${parsed.modelId} is not supported with ChatGPT subscription auth. Use GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, or GPT-5.4 Mini, or switch OpenAI to API-key mode for Pro/API-only models.`,
           }, { status: 400 });
         }
         if (parsed.provider === "openai") {
@@ -374,7 +383,7 @@ export async function POST(request: Request) {
             effectiveModel = `codex/${parsed.modelId}`;
           } else if (!hasOpenAiKey) {
             return NextResponse.json({
-              error: `${parsed.modelId} requires OpenAI API-key mode. ChatGPT subscription auth supports GPT-5.5, GPT-5.4, and GPT-5.4 Mini.`,
+              error: `${parsed.modelId} requires OpenAI API-key mode. ChatGPT subscription auth supports GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, and GPT-5.4 Mini.`,
             }, { status: 400 });
           }
         }
@@ -485,7 +494,7 @@ export async function POST(request: Request) {
         targetModel = `codex/${targetParsed.modelId}`;
       } else if (!hasOpenAiKey) {
         return NextResponse.json({
-          error: `${targetParsed.modelId} requires OpenAI API-key mode. ChatGPT subscription auth supports GPT-5.5, GPT-5.4, and GPT-5.4 Mini.`,
+          error: `${targetParsed.modelId} requires OpenAI API-key mode. ChatGPT subscription auth supports GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, and GPT-5.4 Mini.`,
         }, { status: 400 });
       }
     }

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -497,6 +497,69 @@ describe("/setup-api/chat/model", () => {
     expect(restartGateway).toHaveBeenCalled();
   });
 
+  it.each(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"])(
+    "accepts Codex %s on ChatGPT subscription auth",
+    async (modelId) => {
+      vi.mocked(readConfig).mockResolvedValue({
+        auth: {
+          profiles: {
+            "codex:default": { provider: "codex", mode: "oauth" },
+          },
+        },
+        agents: {
+          defaults: {
+            model: {
+              primary: "codex/gpt-5.4",
+            },
+          },
+        },
+      } as never);
+
+      const response = await POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: `codex/${modelId}` }),
+      }));
+
+      expect(response.status).toBe(200);
+      expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+        "agents.defaults.model.primary",
+        `codex/${modelId}`,
+      ]);
+      expect(restartGateway).toHaveBeenCalled();
+    },
+  );
+
+  it("routes OpenAI GPT-5.6 Sol picks through Codex when ChatGPT subscription auth is configured", async () => {
+    vi.mocked(readConfig).mockResolvedValue({
+      auth: {
+        profiles: {
+          "codex:default": { provider: "codex", mode: "oauth" },
+        },
+      },
+      agents: {
+        defaults: {
+          model: {
+            primary: "codex/gpt-5.4",
+          },
+        },
+      },
+    } as never);
+
+    const response = await POST(new Request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "openai/gpt-5.6-sol" }),
+    }));
+
+    expect(response.status).toBe(200);
+    expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+      "agents.defaults.model.primary",
+      "codex/gpt-5.6-sol",
+    ]);
+    expect(restartGateway).toHaveBeenCalled();
+  });
+
   it("rejects a non-openrouter model that is not in state.options", async () => {
     const response = await POST(new Request("http://localhost/test", {
       method: "POST",


### PR DESCRIPTION
## Why
Discord/support reports after 3.1.10: **"Gateway won't start after update"**, **"Update failed"**, **"broke my clawbox"**. Root cause is that `gateway-pre-start.sh` runs as a **blocking `ExecStartPre`** and did heavy, failure-prone npm work on the boot path — so any hiccup meant the gateway never came online.

## Fixes (all validated on todor)
1. **Republish-tolerant version compare** — the codex version-skew guard used exact-string `!=`, so an npm republish (`2026.7.1` → `2026.7.1-1`) read as a skew and reinstalled codex **every boot**. Now compares base `MAJOR.MINOR.PATCH`; a real API skew (`2026.7.2` vs `2026.7.1`) still reinstalls, a republish does not. (Peter Wodman's "Update failed".)
2. **Layout-robust plugin path** — 2026.7.x cores install the plugin under `npm/projects/<hash>/node_modules/@openclaw/codex`, but the check was hard-coded to the legacy flat `npm/node_modules/...`, so it always read "missing" → reinstall every boot. Now resolves either layout.
3. **Time-boxed, non-fatal codex install** — the reinstall was an unbounded `npm install` on the blocking boot path. Now `timeout 120` + best-effort: on failure/timeout the gateway still starts. `TimeoutStartSec=600` added as a unit backstop.
4. **install.sh `step_ai_tools_install` non-fatal + region-block-aware** — Anthropic geo-blocks some regions and serves an HTML page (HTTP 200) that piped into `bash` aborted the whole reinstall at `[18/23]` under `set -euo pipefail` (nginx-404 brick). Now downloads to a file, verifies it's a script not HTML, and every optional AI-CLI install is non-fatal.

## Validation (todor / 192.168.50.40)
- Gateway **active + listening in ~1s** across repeated restarts.
- **0** codex reinstalls after the plugin is present (was every boot).
- Unit tests for the base-version compare (7/7) and the region-block detector.

## Still in progress on this branch (follow-up commits)
- Codex `401 Missing bearer` after restart (stale `~/.codex/auth.json` id_token not re-attached).
- Semantic-memory offline without an OpenAI key (local Ollama embeddings fallback).
- Long-jump upgrade (very old → latest) gateway-safety audit + test.

Target: **beta** (3.1.11). No merge to main/release without sign-off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased gateway service startup timeout to reduce first-boot failures.
  * Improved Codex plugin handling to better cope with layout/version differences.
  * Made optional embeddings and tools best-effort: install failures now warn and continue (including safer handling of unexpected download content).
* **Reliability**
  * Time-boxed Codex pre-start repair/install; continues starting on timeout/failure.
  * Auto-seeded Codex auth and default semantic-memory embeddings when locally available.
* **New Features**
  * Expanded supported Codex subscription models to include GPT-5.6 Sol/Terra/Luna.
* **Tests**
  * Updated UI/e2e flows for chat widget and mascot layout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->