### PR TITLE
chore(release): bump version to 3.1.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.1.10",
+  "version": "3.1.11",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {


### PR DESCRIPTION
## Why

The in-UI "update available" card is driven by `src/lib/updater.ts`:

- `getTargetVersion()` — newest `vX.Y.Z` **tag on origin** whose commit has the device's HEAD as an ancestor
- `getVersionInfo()` — compares that tag against the device's `package.json` version

`beta` still reports `3.1.10`. If we tag `v3.1.11` without this bump, every box that successfully updates would still report `current=v3.1.10` against `target=v3.1.11` — the update card would **reappear after the update and never clear**.

## What

`package.json` `3.1.10` → `3.1.11`. Only version reference in the tree.

## Release context

Unblocks tagging `v3.1.11` so the update prompt can be validated on a real box through the normal customer flow, before promoting to `main`.

Note: `v3.1.10` was never tagged on origin (latest tag is `v3.1.9`), which is why no box has surfaced an update card since that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 3.1.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->