### PR TITLE
fix(codex,gemma): unblock GPT-5.6 on ChatGPT auth and stop Gemma provisioning from hanging

### DIFF
--- a/config/clawbox-root-update@.service
+++ b/config/clawbox-root-update@.service
@@ -5,4 +5,9 @@ Description=ClawBox Root Update Step (%i)
 Type=oneshot
 EnvironmentFile=-/etc/clawbox/network.env
 ExecStart=/bin/bash /home/clawbox/clawbox/install.sh --step %i
-TimeoutStartSec=1800
+# 30 min was not enough for llamacpp_install on a cold box: that step builds
+# llama.cpp from source with CUDA on a 6-core Jetson Orin AND downloads the
+# multi-GB Gemma 4 GGUF. systemd killed the unit mid-build, so "Provisioning
+# offline Gemma 4" hung until it failed. Other steps finish in seconds — this
+# is a ceiling, not a wait, so raising it costs nothing.
+TimeoutStartSec=7200

--- a/install.sh
+++ b/install.sh
@@ -1352,6 +1352,16 @@ step_post_update() {
   # unit + autocutsel package. Devices installed before the display-:99 move
   # and the clipboard-sync addition get both here without needing a reinstall.
   step_vnc_refresh || echo "  Warning: vnc_refresh step failed (non-fatal)"
+  # Reinstall the unit files from config/ + daemon-reload. Without this, unit
+  # changes only ever reached FRESH installs: the in-app update runs
+  # bootstrap_updater -> ... -> post_update and never re-copies
+  # /etc/systemd/system, so an updated box kept running whatever unit file it
+  # was born with. That silently swallowed the llamacpp_install
+  # TimeoutStartSec raise (30 min -> 2 h) that stops "Provisioning offline
+  # Gemma 4" from being killed mid-build, and would swallow any future unit or
+  # sudoers change the same way. The step is idempotent — cp, daemon-reload,
+  # enable — and is exactly what fresh installs already run.
+  step_systemd_services || echo "  Warning: systemd_services step failed (non-fatal)"
   # Refresh the device-side ClawKeep CLI from the repo. The Python package
   # has the same version string ("0.1.0") across releases, so a plain
   # `pip install` is a no-op even after restore/scheduler bug fixes land —

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -168,7 +168,10 @@ if isinstance(primary_model, str) and primary_model.lower() in (
 # hasCodexOauthProfile in src/app/setup-api/chat/model/route.ts. Guarded on
 # "codex OAuth present AND no OpenAI API key" so dual-auth / API-key boxes,
 # where openai/* is a valid keyed route, are left untouched.
-_CODEX_SUPPORTED = ("gpt-5.5", "gpt-5.4", "gpt-5.4-mini")
+_CODEX_SUPPORTED = (
+    "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+    "gpt-5.5", "gpt-5.4", "gpt-5.4-mini",
+)
 
 def _auth_profiles():
     _auth = cfg.get("auth")

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -36,6 +36,7 @@ import {
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_CURATED_MODELS, OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
+import { resolveEntitledCodexModel } from "@/lib/codex-model-probe";
 import { isValidModelId, isCatalogProvider, GOOGLE_MODELS, ANTHROPIC_MODELS, extractProviderModelId } from "@/lib/provider-models";
 import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
 
@@ -554,6 +555,34 @@ export async function POST(request: Request) {
       config.defaultModel = `llamacpp/${modelName}`;
     } else if (isClawAI && resolvedClawboxTier) {
       config.defaultModel = CLAWBOX_AI_MODEL_BY_TIER[resolvedClawboxTier];
+    } else if (
+      authMode === "subscription"
+      && ocProvider === "codex"
+      && !(typeof bodyModel === "string" && bodyModel.trim())
+    ) {
+      // ChatGPT sign-in with no explicit pick. The hardcoded default is
+      // gpt-5.4, so a Pro account used to land two generations behind and had
+      // to know to change it. We can't read entitlement from a catalog — the
+      // plugin's list is static and identical for every account — so ask the
+      // account directly, newest first.
+      //
+      // Safety: resolveEntitledCodexModel only returns a model on a positive
+      // answer. Gated, ambiguous, rate-limited, offline — all leave us on
+      // gpt-5.4, which every tier can use. Defaulting a non-entitled account
+      // onto a gpt-5.6 model would be far worse than being conservative: the
+      // upstream 400 is a surface error with no failover, so every turn fails.
+      try {
+        const entitled = await resolveEntitledCodexModel({
+          accessToken: normalizedApiKey,
+          onDiagnostic: (message) => console.log(`[configure] ${message}`),
+        });
+        if (entitled) {
+          config.defaultModel = `codex/${entitled}`;
+        }
+      } catch (err) {
+        // Never let model selection break sign-in.
+        console.warn("[configure] codex entitlement probe failed:", err);
+      }
     } else if (typeof bodyModel === "string" && bodyModel.trim()) {
       // User picked a specific model in the wizard (curated list or
       // custom ID). Validate shape to stop empty strings / obvious typos

--- a/src/app/setup-api/llamacpp/install/route.ts
+++ b/src/app/setup-api/llamacpp/install/route.ts
@@ -23,7 +23,26 @@ const MODEL_ID_RE = /^[a-zA-Z0-9._:-]+$/;
 const encoder = new TextEncoder();
 const execFile = promisify(execFileCb);
 const LLAMACPP_INSTALL_SERVICE = "clawbox-root-update@llamacpp_install.service";
-const LLAMACPP_INSTALL_TIMEOUT_MS = 30 * 60 * 1000;
+// Must stay >= TimeoutStartSec in config/clawbox-root-update@.service so
+// systemd, not us, owns the kill. A cold box builds llama.cpp from source with
+// CUDA and downloads a multi-GB GGUF; 30 min was not enough and the install
+// died mid-build.
+const LLAMACPP_INSTALL_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+// How often we ask systemd how the install unit is doing while it runs.
+const LLAMACPP_INSTALL_POLL_MS = 3000;
+// `systemctl start --no-block` returns before the unit leaves "inactive".
+// Re-check a couple of times at this interval before concluding it finished,
+// so we don't mistake "hasn't started yet" for "already done".
+const LLAMACPP_INSTALL_START_GRACE_MS = 1000;
+const LLAMACPP_INSTALL_START_GRACE_POLLS = 2;
+const SYSTEMCTL_QUERY_TIMEOUT_MS = 15_000;
+// Phase-stable prefix: getLlamaCppOverlayProgress keys the "Provisioning
+// offline Gemma 4" step off "installing gemma 4", and the raw journal lines
+// (cmake, hf download, apt) match nothing — without this the wizard would jump
+// back to step 1 on every log line. Everything after the separator is shown to
+// the user as live detail.
+const INSTALL_STATUS_PREFIX = "Installing Gemma 4 for offline use";
+const INSTALL_STATUS_SEPARATOR = " — ";
 
 function emit(controller: ReadableStreamDefaultController<Uint8Array>, payload: Record<string, unknown>) {
   controller.enqueue(encoder.encode(`${JSON.stringify(payload)}\n`));
@@ -47,29 +66,70 @@ function shouldRepairLlamaCppRuntime(logLine: string | null): boolean {
     || normalized.includes("[llamacpp] missing local model");
 }
 
-async function readLlamaCppInstallFailure(): Promise<string | null> {
+async function readLlamaCppInstallLog(lines: number): Promise<string> {
   try {
     const { stdout } = await execFile(
       "/usr/bin/journalctl",
-      ["-u", LLAMACPP_INSTALL_SERVICE, "-n", "40", "--no-pager", "-o", "cat"],
+      ["-u", LLAMACPP_INSTALL_SERVICE, "-n", String(lines), "--no-pager", "-o", "cat"],
       { timeout: 10_000 },
     );
-    return getLastLogLine(stdout);
+    return stdout;
   } catch {
-    return null;
+    return "";
   }
 }
 
-async function repairLlamaCppRuntime(): Promise<{ ok: boolean; error?: string }> {
+async function readLlamaCppInstallFailure(): Promise<string | null> {
+  return getLastLogLine(await readLlamaCppInstallLog(40));
+}
+
+/**
+ * ActiveState/Result for the install unit. Empty strings mean "couldn't ask" —
+ * callers treat that the same as "not running" and fall back to the on-disk
+ * provisioning check, which is the real gate.
+ */
+async function readInstallUnitState(): Promise<{ active: string; result: string }> {
+  try {
+    const { stdout } = await execFile(
+      "/usr/bin/systemctl",
+      ["show", LLAMACPP_INSTALL_SERVICE, "-p", "ActiveState", "-p", "Result"],
+      { timeout: SYSTEMCTL_QUERY_TIMEOUT_MS },
+    );
+    return {
+      active: /^ActiveState=(.*)$/m.exec(stdout)?.[1]?.trim() || "",
+      result: /^Result=(.*)$/m.exec(stdout)?.[1]?.trim() || "",
+    };
+  } catch {
+    return { active: "", result: "" };
+  }
+}
+
+function isUnitRunning(active: string): boolean {
+  return active === "activating" || active === "active" || active === "reloading";
+}
+
+/**
+ * Run the root install step, streaming its journal output.
+ *
+ * Previously this was a single blocking `systemctl start`, which emitted
+ * nothing for up to 30 minutes — a cold Jetson build looked identical to a
+ * hang, and there was no way to tell whether it was progressing. Now we start
+ * the unit detached and poll systemd, so the wizard shows live build/download
+ * lines and a genuine failure surfaces the moment the unit fails.
+ */
+async function repairLlamaCppRuntime(
+  onStatus: (line: string) => void,
+): Promise<{ ok: boolean; error?: string }> {
   await execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "reset-failed", LLAMACPP_INSTALL_SERVICE], {
     timeout: 10_000,
   }).catch(() => {});
 
   try {
-    await execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "start", LLAMACPP_INSTALL_SERVICE], {
-      timeout: LLAMACPP_INSTALL_TIMEOUT_MS,
-    });
-    return { ok: true };
+    await execFile(
+      "/usr/bin/sudo",
+      ["/usr/bin/systemctl", "start", "--no-block", LLAMACPP_INSTALL_SERVICE],
+      { timeout: SYSTEMCTL_QUERY_TIMEOUT_MS },
+    );
   } catch (err) {
     const failureLine = await readLlamaCppInstallFailure();
     return {
@@ -77,6 +137,44 @@ async function repairLlamaCppRuntime(): Promise<{ ok: boolean; error?: string }>
       error: failureLine || (err instanceof Error ? err.message : "Failed to repair llama.cpp runtime"),
     };
   }
+
+  const deadline = Date.now() + LLAMACPP_INSTALL_TIMEOUT_MS;
+  let lastLine: string | null = null;
+  let sawRunning = false;
+  let gracePolls = 0;
+
+  while (Date.now() < deadline) {
+    const { active, result } = await readInstallUnitState();
+    if (isUnitRunning(active)) sawRunning = true;
+
+    const line = getLastLogLine(await readLlamaCppInstallLog(5));
+    if (line && line !== lastLine) {
+      lastLine = line;
+      onStatus(line);
+    }
+
+    if (active === "failed") {
+      return { ok: false, error: lastLine || `llama.cpp install failed (${result || "unknown"})` };
+    }
+
+    if (!isUnitRunning(active)) {
+      // Either it finished, or `--no-block` returned before it started. Give it
+      // a couple of short re-checks before believing the former.
+      if (sawRunning || gracePolls >= LLAMACPP_INSTALL_START_GRACE_POLLS) {
+        if (result && result !== "success") {
+          return { ok: false, error: lastLine || `llama.cpp install failed (${result})` };
+        }
+        return { ok: true };
+      }
+      gracePolls += 1;
+      await new Promise((resolve) => setTimeout(resolve, LLAMACPP_INSTALL_START_GRACE_MS));
+      continue;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, LLAMACPP_INSTALL_POLL_MS));
+  }
+
+  return { ok: false, error: lastLine || "Timed out installing the local Gemma 4 runtime." };
 }
 
 function startLlamaCpp(spec: ReturnType<typeof getLlamaCppLaunchSpec>, alias: string) {
@@ -166,7 +264,9 @@ export async function POST(request: Request) {
               ? "Installing Gemma 4 for offline use..."
               : "Installing llama.cpp and Gemma 4 for offline use...",
           });
-          const repaired = await repairLlamaCppRuntime();
+          const repaired = await repairLlamaCppRuntime((line) => {
+            emit(controller, { status: `${INSTALL_STATUS_PREFIX}${INSTALL_STATUS_SEPARATOR}${line}` });
+          });
           if (!repaired.ok) {
             emit(controller, { error: repaired.error || "Failed to provision the local Gemma 4 runtime" });
             controller.close();
@@ -254,7 +354,9 @@ export async function POST(request: Request) {
             if (!attemptedRuntimeRepair && shouldRepairLlamaCppRuntime(logLine)) {
               emit(controller, { status: "Repairing the llama.cpp runtime so Gemma can start..." });
               attemptedRuntimeRepair = true;
-              const repaired = await repairLlamaCppRuntime();
+              const repaired = await repairLlamaCppRuntime((repairLine) => {
+                emit(controller, { status: `${INSTALL_STATUS_PREFIX}${INSTALL_STATUS_SEPARATOR}${repairLine}` });
+              });
               if (!repaired.ok) {
                 emit(controller, { error: repaired.error || "Failed to repair llama.cpp runtime" });
                 controller.close();

--- a/src/lib/ai-provider-progress.ts
+++ b/src/lib/ai-provider-progress.ts
@@ -57,6 +57,20 @@ export function getOllamaOverlayProgress(
   };
 }
 
+// The install route tags long-running provisioning lines as
+// `<phase-stable prefix> — <raw journal line>`. The prefix keeps the step
+// indicator pinned (raw cmake/hf/apt output matches no phase keyword and would
+// bounce the wizard back to step 1); the tail is what the user actually wants
+// to read while a multi-minute build runs.
+const DETAIL_SEPARATOR = " — ";
+
+function splitStatusDetail(status: string): string | null {
+  const index = status.indexOf(DETAIL_SEPARATOR);
+  if (index < 0) return null;
+  const detail = status.slice(index + DETAIL_SEPARATOR.length).trim();
+  return detail || null;
+}
+
 export function getLlamaCppOverlayProgress(
   status: string | null,
   stepCount: number,
@@ -94,7 +108,7 @@ export function getLlamaCppOverlayProgress(
 
   return {
     phase: clampPhase(phase, stepCount),
-    detail: null,
+    detail: splitStatusDetail(normalizedStatus),
     progressPercent: null,
   };
 }

--- a/src/lib/codex-model-probe.ts
+++ b/src/lib/codex-model-probe.ts
@@ -1,0 +1,179 @@
+// Which Codex model should a freshly-signed-in ChatGPT account default to?
+//
+// We can't answer that from a catalog. `openclaw models list --provider codex
+// --all --json` returns the plugin's STATIC list — the same five ids for every
+// account, entitled or not. gpt-5.6-{sol,terra,luna} are plan-gated upstream,
+// and picking one the account can't use is not a soft failure: the upstream
+// 400 is a surface error with no failover, so every single turn dies. That
+// exact mistake pinned a session to gpt-5.6-sol on 2026-07-13 and broke it
+// completely.
+//
+// So we ask the account itself. One cheap request per candidate, newest first,
+// stopping at the first that answers. Deliberately biased toward the safe
+// answer: we only upgrade off the fallback on a POSITIVE signal, and any
+// ambiguity (auth trouble, rate limit, network, 5xx) leaves the caller on the
+// universally-available default.
+
+/** Newest first. gpt-5.4 is not here — it is the fallback everyone can use. */
+export const CODEX_MODEL_PREFERENCE = [
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+] as const;
+
+/** Available on every ChatGPT tier; what we keep when the probe can't improve on it. */
+export const CODEX_FALLBACK_MODEL = "gpt-5.4";
+
+const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
+const DEFAULT_PER_PROBE_TIMEOUT_MS = 6000;
+const DEFAULT_TOTAL_BUDGET_MS = 15_000;
+
+export type ProbeVerdict = "available" | "unavailable" | "indeterminate";
+
+// Upstream's ways of saying "not this model, not this account". Kept broad on
+// purpose: a false "unavailable" only costs the user a newer model, while a
+// false "available" costs them a box where nothing works.
+const MODEL_REJECTION_RE = new RegExp(
+  [
+    "requires a newer version",
+    "model[_ ]not[_ ]found",
+    "unsupported[_ ]model",
+    "not supported",
+    "unknown model",
+    "do(?:es)? not have access",
+    "not available",
+    "no access",
+    "upgrade",
+    "plan",
+    "subscription",
+    "entitle",
+  ].join("|"),
+  "i",
+);
+
+/**
+ * Classify a probe response.
+ *
+ * The subtle case is 400. Upstream validates the request body as well as the
+ * model, so a 400 complaining about our payload shape (e.g. "Input must be a
+ * list") means the model itself was accepted — that counts as available. A 400
+ * naming the model or the plan does not.
+ */
+export function classifyProbeResponse(status: number, body: string): ProbeVerdict {
+  if (status >= 200 && status < 300) return "available";
+  if (status === 403 || status === 404) return "unavailable";
+  if (status === 400) return MODEL_REJECTION_RE.test(body) ? "unavailable" : "available";
+  // 401 (bad/expired token), 429 (rate limited), 5xx (upstream trouble): tells
+  // us nothing about entitlement.
+  return "indeterminate";
+}
+
+/** chatgpt_account_id from an OAuth access/id token, or null if unreadable. */
+export function extractChatGptAccountId(jwt: string): string | null {
+  try {
+    const payload = jwt.split(".")[1];
+    if (!payload) return null;
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString());
+    const auth = claims["https://api.openai.com/auth"] || {};
+    return auth.chatgpt_account_id || auth.account_id || null;
+  } catch {
+    return null;
+  }
+}
+
+function buildProbeBody(model: string): string {
+  return JSON.stringify({
+    model,
+    // Smallest well-formed Responses request we can send. If the shape is ever
+    // wrong upstream answers 400 with a payload complaint, which
+    // classifyProbeResponse reads as "the model was fine".
+    input: [{ type: "message", role: "user", content: [{ type: "input_text", text: "ping" }] }],
+    max_output_tokens: 16,
+    stream: false,
+    store: false,
+  });
+}
+
+export interface ProbeOptions {
+  accessToken: string;
+  accountId?: string | null;
+  candidates?: readonly string[];
+  fetchImpl?: typeof fetch;
+  perProbeTimeoutMs?: number;
+  totalBudgetMs?: number;
+  now?: () => number;
+  onDiagnostic?: (message: string) => void;
+}
+
+export async function probeCodexModel(
+  model: string,
+  options: ProbeOptions,
+): Promise<ProbeVerdict> {
+  const {
+    accessToken,
+    accountId,
+    fetchImpl = fetch,
+    perProbeTimeoutMs = DEFAULT_PER_PROBE_TIMEOUT_MS,
+  } = options;
+
+  try {
+    const res = await fetchImpl(CODEX_RESPONSES_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${accessToken}`,
+        // The app-server sends both; without the account header upstream can
+        // reject with a 401 that has nothing to do with the model.
+        ...(accountId ? { "chatgpt-account-id": accountId } : {}),
+        originator: "codex_cli_rs",
+      },
+      body: buildProbeBody(model),
+      signal: AbortSignal.timeout(perProbeTimeoutMs),
+    });
+    const body = await res.text().catch(() => "");
+    return classifyProbeResponse(res.status, body);
+  } catch {
+    // Timeout, DNS, offline box mid-setup — say nothing rather than guess.
+    return "indeterminate";
+  }
+}
+
+/**
+ * Newest model this account can actually use, or null to keep the caller's
+ * default. Stops at the first candidate that answers; gives up early on an
+ * auth failure, since every later probe would fail the same way.
+ */
+export async function resolveEntitledCodexModel(options: ProbeOptions): Promise<string | null> {
+  const {
+    accessToken,
+    candidates = CODEX_MODEL_PREFERENCE,
+    totalBudgetMs = DEFAULT_TOTAL_BUDGET_MS,
+    now = Date.now,
+    onDiagnostic,
+  } = options;
+
+  if (!accessToken?.trim()) return null;
+
+  const accountId = options.accountId ?? extractChatGptAccountId(accessToken);
+  const deadline = now() + totalBudgetMs;
+  let sawIndeterminate = false;
+
+  for (const model of candidates) {
+    if (now() >= deadline) {
+      onDiagnostic?.(`codex probe: budget exhausted before ${model}`);
+      break;
+    }
+    const verdict = await probeCodexModel(model, { ...options, accountId });
+    onDiagnostic?.(`codex probe: ${model} -> ${verdict}`);
+    if (verdict === "available") return model;
+    if (verdict === "indeterminate") {
+      // One flaky probe is worth stepping past; two means the account or the
+      // network is the problem, not entitlement, and further probes are noise.
+      if (sawIndeterminate) break;
+      sawIndeterminate = true;
+    }
+  }
+
+  return null;
+}

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -199,12 +199,18 @@ describe("POST /setup-api/ai-models/configure", () => {
     );
     mockGetLocalAiToken.mockReturnValue("a".repeat(64));
 
+    // The codex entitlement probe talks to chatgpt.com. Stub it by default so
+    // no test reaches the network; individual tests override with the verdict
+    // they need.
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
+
     const mod = await import("@/app/setup-api/ai-models/configure/route");
     configurePost = mod.POST;
   });
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("returns 400 for invalid JSON", async () => {
@@ -475,6 +481,66 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.4");
+  });
+
+  // A Pro account used to land on gpt-5.4 after sign-in and had to know to
+  // change it. Entitlement isn't readable from any catalog (the plugin list is
+  // static and identical for every account), so the route asks the account.
+  it("defaults a ChatGPT sign-in to the newest model the account can use", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("{}", { status: 200 })));
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      apiKey: "access.token.jwt",
+      idToken: "id.token.jwt",
+      authMode: "subscription",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+    }));
+
+    expect(res.status).toBe(200);
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.6-sol");
+  });
+
+  it("leaves a non-entitled account on gpt-5.4 rather than a model that 400s", async () => {
+    // Every gpt-5.6 id gated, gpt-5.5 too: the safe landing spot is the
+    // fallback, not the newest id in the static catalog.
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 403 })));
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      apiKey: "access.token.jwt",
+      idToken: "id.token.jwt",
+      authMode: "subscription",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+    }));
+
+    expect(res.status).toBe(200);
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.4");
+  });
+
+  it("does not probe when the user picked a model explicitly", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      apiKey: "access.token.jwt",
+      idToken: "id.token.jwt",
+      authMode: "subscription",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+      model: "gpt-5.5",
+    }));
+
+    expect(res.status).toBe(200);
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.5");
+    const probedCodex = fetchMock.mock.calls.some(([url]) => String(url).includes("backend-api/codex/responses"));
+    expect(probedCodex).toBe(false);
   });
 
   it("includes projectId for google oauth", async () => {

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -229,6 +229,97 @@ describe("POST /setup-api/llamacpp/install", () => {
     expect(payload.provider).toBe("llamacpp");
   });
 
+  // Provisioning on a cold box builds llama.cpp from source with CUDA and
+  // downloads a multi-GB GGUF — tens of minutes. It used to run as one
+  // blocking `systemctl start` that emitted nothing, so the wizard showed a
+  // bare spinner on "Provisioning offline Gemma 4" and a real hang was
+  // indistinguishable from normal progress.
+  it("streams install progress while the provisioning unit runs", async () => {
+    let installComplete = false;
+    let showCalls = 0;
+
+    mockFs.stat.mockImplementation((async (target: unknown) => {
+      const normalized = String(target);
+      const isRuntimeArtifact = normalized === "/usr/local/bin/llama-server"
+        || normalized.endsWith("gemma-4-e2b-it-edited-q4_0.gguf");
+      if (isRuntimeArtifact && installComplete) return { size: 1 } as never;
+      throw new Error("ENOENT");
+    }) as typeof fsp.stat);
+
+    mockExecFile.mockImplementation(((
+      cmd: string,
+      args: string[],
+      optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+      maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+      const key = `${cmd} ${args.join(" ")}`;
+      let stdout = "";
+      if (key.includes("systemctl show")) {
+        showCalls += 1;
+        // First poll: still building. Second: finished cleanly.
+        stdout = showCalls <= 1
+          ? "ActiveState=activating\nResult=success\n"
+          : "ActiveState=inactive\nResult=success\n";
+        if (showCalls >= 2) installComplete = true;
+      } else if (key.includes("journalctl")) {
+        stdout = "Installing llama.cpp server (CUDA=ON)...\n";
+      }
+      callback?.(null, { stdout, stderr: "" });
+      return {} as ReturnType<typeof childProcess.execFile>;
+    }) as unknown as typeof childProcess.execFile);
+
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ data: [] }) })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({ data: [{ id: "gemma4-e2b-it-q4_0" }] }) });
+    vi.stubGlobal("fetch", mockFetch);
+    mockSpawn.mockReturnValue(createSpawnedProcess(12345));
+
+    const res = await installPost(jsonRequest({ model: "gemma4-e2b-it-q4_0" }));
+    const text = await readStream(res);
+
+    // Phase-stable prefix keeps the wizard on the provisioning step; the tail
+    // is the live build line the user reads while waiting.
+    expect(text).toContain("Installing Gemma 4 for offline use — Installing llama.cpp server (CUDA=ON)...");
+    expect(text).toContain("\"success\":true");
+  });
+
+  it("fails fast with the journal line when the provisioning unit fails", async () => {
+    mockFs.stat.mockImplementation((async () => {
+      throw new Error("ENOENT");
+    }) as typeof fsp.stat);
+
+    mockExecFile.mockImplementation(((
+      cmd: string,
+      args: string[],
+      optsOrCallback?: object | ((error: Error | null, result: { stdout: string; stderr: string }) => void),
+      maybeCallback?: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => {
+      const callback = typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback;
+      const key = `${cmd} ${args.join(" ")}`;
+      let stdout = "";
+      if (key.includes("systemctl show")) {
+        stdout = "ActiveState=failed\nResult=timeout\n";
+      } else if (key.includes("journalctl")) {
+        stdout = "Error: failed to download Gemma 4 for offline startup\n";
+      }
+      callback?.(null, { stdout, stderr: "" });
+      return {} as ReturnType<typeof childProcess.execFile>;
+    }) as unknown as typeof childProcess.execFile);
+
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [] }),
+    }));
+
+    const res = await installPost(jsonRequest({ model: "gemma4-e2b-it-q4_0" }));
+    const text = await readStream(res);
+
+    expect(text).toContain("failed to download Gemma 4 for offline startup");
+    // No point starting llama-server against a runtime that never installed.
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
   it("repairs the llama.cpp runtime and retries when hf is missing", async () => {
     const runtimeError = "[llamacpp] Missing Hugging Face CLI at /home/clawbox/.local/bin/hf. Run the llama.cpp install step to repair the local runtime.\n";
     const mockFetch = vi.fn()
@@ -293,7 +384,9 @@ describe("POST /setup-api/llamacpp/install", () => {
     expect(text).toContain("\"success\":true");
     expect(mockExecFile).toHaveBeenCalledWith(
       "/usr/bin/sudo",
-      ["/usr/bin/systemctl", "start", "clawbox-root-update@llamacpp_install.service"],
+      // --no-block: we poll systemd ourselves so the wizard can stream progress
+      // instead of sitting silent for the whole install.
+      ["/usr/bin/systemctl", "start", "--no-block", "clawbox-root-update@llamacpp_install.service"],
       expect.any(Object),
       expect.any(Function),
     );

--- a/src/tests/unit/ai-provider-progress.test.ts
+++ b/src/tests/unit/ai-provider-progress.test.ts
@@ -84,5 +84,38 @@ describe("ai-provider-progress", () => {
         progressPercent: null,
       });
     });
+
+    // A cold box builds llama.cpp from source before Gemma can start. The
+    // install route streams those journal lines tagged with a phase-stable
+    // prefix; the raw lines (cmake, hf, apt) match no phase keyword, so
+    // without the prefix the wizard would snap back to step 1 on every line
+    // and the user would see a spinner with no explanation for ~an hour.
+    it("keeps the provisioning phase pinned and surfaces the streamed line as detail", () => {
+      expect(
+        getLlamaCppOverlayProgress(
+          "Installing Gemma 4 for offline use — Installing llama.cpp server (CUDA=ON)...",
+          5,
+        ),
+      ).toEqual({
+        phase: 1,
+        detail: "Installing llama.cpp server (CUDA=ON)...",
+        progressPercent: null,
+      });
+
+      expect(
+        getLlamaCppOverlayProgress(
+          "Installing Gemma 4 for offline use — Downloading Gemma 4 GGUF for offline use...",
+          5,
+        ),
+      ).toEqual({
+        phase: 1,
+        detail: "Downloading Gemma 4 GGUF for offline use...",
+        progressPercent: null,
+      });
+    });
+
+    it("leaves detail null when there is no streamed line", () => {
+      expect(getLlamaCppOverlayProgress("Installing Gemma 4 for offline use...", 5).detail).toBeNull();
+    });
   });
 });

--- a/src/tests/unit/codex-model-probe.test.ts
+++ b/src/tests/unit/codex-model-probe.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  CODEX_FALLBACK_MODEL,
+  CODEX_MODEL_PREFERENCE,
+  classifyProbeResponse,
+  extractChatGptAccountId,
+  probeCodexModel,
+  resolveEntitledCodexModel,
+} from "@/lib/codex-model-probe";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(typeof body === "string" ? body : JSON.stringify(body), { status });
+}
+
+function makeJwt(claims: Record<string, unknown>): string {
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+describe("classifyProbeResponse", () => {
+  it("treats success as available", () => {
+    expect(classifyProbeResponse(200, "{}")).toBe("available");
+  });
+
+  it("treats a payload-shape 400 as available", () => {
+    // Upstream got far enough to validate the body, so the model was accepted.
+    expect(classifyProbeResponse(400, '{"error":{"message":"Input must be a list"}}')).toBe("available");
+  });
+
+  it("treats a model-gated 400 as unavailable", () => {
+    expect(
+      classifyProbeResponse(
+        400,
+        '{"error":{"message":"The \'gpt-5.6-sol\' model requires a newer version of Codex."}}',
+      ),
+    ).toBe("unavailable");
+    expect(
+      classifyProbeResponse(
+        400,
+        '{"error":{"message":"model not supported when using Codex with a ChatGPT account"}}',
+      ),
+    ).toBe("unavailable");
+  });
+
+  it("treats forbidden and not-found as unavailable", () => {
+    expect(classifyProbeResponse(403, "")).toBe("unavailable");
+    expect(classifyProbeResponse(404, "")).toBe("unavailable");
+  });
+
+  it("refuses to guess on auth, rate-limit, or upstream errors", () => {
+    // None of these say anything about entitlement — guessing "available" here
+    // is what pins an account to a model that fails every turn.
+    expect(classifyProbeResponse(401, "")).toBe("indeterminate");
+    expect(classifyProbeResponse(429, "")).toBe("indeterminate");
+    expect(classifyProbeResponse(500, "")).toBe("indeterminate");
+  });
+});
+
+describe("extractChatGptAccountId", () => {
+  it("reads chatgpt_account_id from the auth claim", () => {
+    const jwt = makeJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct_123" } });
+    expect(extractChatGptAccountId(jwt)).toBe("acct_123");
+  });
+
+  it("returns null for an opaque token", () => {
+    expect(extractChatGptAccountId("not-a-jwt")).toBeNull();
+  });
+});
+
+describe("probeCodexModel", () => {
+  it("sends the account header and bearer token", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    await probeCodexModel("gpt-5.6-sol", {
+      accessToken: "tok",
+      accountId: "acct_1",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toContain("chatgpt.com/backend-api/codex/responses");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer tok");
+    expect(headers["chatgpt-account-id"]).toBe("acct_1");
+    expect(JSON.parse((init as RequestInit).body as string).model).toBe("gpt-5.6-sol");
+  });
+
+  it("is indeterminate when the request throws", async () => {
+    const fetchImpl = vi.fn().mockRejectedValue(new Error("network down"));
+    await expect(
+      probeCodexModel("gpt-5.6-sol", {
+        accessToken: "tok",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toBe("indeterminate");
+  });
+});
+
+describe("resolveEntitledCodexModel", () => {
+  it("returns Sol for an entitled account without probing further", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(200, {}));
+    const model = await resolveEntitledCodexModel({
+      accessToken: "tok",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(model).toBe("gpt-5.6-sol");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("walks down to the newest model the account actually has", async () => {
+    // Free/Plus-without-5.6: the three gpt-5.6 ids are gated, gpt-5.5 is not.
+    const fetchImpl = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(400, { error: { message: "requires a newer version of Codex" } }))
+      .mockResolvedValueOnce(jsonResponse(403, ""))
+      .mockResolvedValueOnce(jsonResponse(404, ""))
+      .mockResolvedValueOnce(jsonResponse(200, {}));
+
+    const model = await resolveEntitledCodexModel({
+      accessToken: "tok",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(model).toBe("gpt-5.5");
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
+  it("keeps the caller's default when nothing is available", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(403, ""));
+    await expect(
+      resolveEntitledCodexModel({
+        accessToken: "tok",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("gives up after two indeterminate probes instead of hammering upstream", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(401, ""));
+    const model = await resolveEntitledCodexModel({
+      accessToken: "tok",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(model).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops when the time budget is spent", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(jsonResponse(403, ""));
+    let clock = 0;
+    const model = await resolveEntitledCodexModel({
+      accessToken: "tok",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      totalBudgetMs: 10,
+      now: () => (clock += 6),
+    });
+
+    expect(model).toBeNull();
+    // Budget is checked before each probe, so it can't run the whole list.
+    expect(fetchImpl.mock.calls.length).toBeLessThan(CODEX_MODEL_PREFERENCE.length);
+  });
+
+  it("does nothing without an access token", async () => {
+    const fetchImpl = vi.fn();
+    await expect(
+      resolveEntitledCodexModel({
+        accessToken: "  ",
+        fetchImpl: fetchImpl as unknown as typeof fetch,
+      }),
+    ).resolves.toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("never proposes the fallback — that is the caller's job", () => {
+    expect(CODEX_MODEL_PREFERENCE).not.toContain(CODEX_FALLBACK_MODEL);
+  });
+});

--- a/src/tests/unit/gateway-pre-start-codex-models.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-models.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { CODEX_MODELS } from "@/lib/provider-models";
+
+// gateway-pre-start.sh rewrites `openai/<gpt>` -> `codex/<gpt>` on boxes with
+// ChatGPT (Codex OAuth) auth and no OpenAI API key. Its `_CODEX_SUPPORTED`
+// tuple is a hand-maintained MIRROR of CODEX_SUPPORTED_MODEL_RE in
+// src/app/setup-api/chat/model/route.ts — the script's own comment says so.
+//
+// The two drifted: the regex learned gpt-5.6-{sol,terra,luna} (PR #271) but
+// the tuple did not, so a subscription box whose stored model was
+// `openai/gpt-5.6-sol` never got migrated. It kept resolving to
+// api.openai.com with no key and 401'd with "Missing bearer or basic
+// authentication in header" — i.e. the newest models were unusable on exactly
+// the auth mode they're sold with. These tests pin the mirror so it can't
+// silently drift again.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const MODEL_ROUTE = path.resolve(process.cwd(), "src/app/setup-api/chat/model/route.ts");
+
+/** The model ids listed in pre-start's `_CODEX_SUPPORTED` tuple. */
+function readPreStartSupportedModels(): string[] {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const match = src.match(/_CODEX_SUPPORTED = \(([\s\S]*?)\)/);
+  if (!match) throw new Error("_CODEX_SUPPORTED not found in gateway-pre-start.sh");
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+}
+
+/** CODEX_SUPPORTED_MODEL_RE as written in the chat-model route. */
+function readRouteSupportedModelRe(): RegExp {
+  const src = readFileSync(MODEL_ROUTE, "utf-8");
+  const match = src.match(/const CODEX_SUPPORTED_MODEL_RE = (\/.+\/);/);
+  if (!match) throw new Error("CODEX_SUPPORTED_MODEL_RE not found in chat/model/route.ts");
+  const body = match[1].slice(1, match[1].lastIndexOf("/"));
+  return new RegExp(body);
+}
+
+describe("gateway-pre-start.sh codex model migration", () => {
+  const preStartModels = readPreStartSupportedModels();
+  const routeRe = readRouteSupportedModelRe();
+
+  it("mirrors CODEX_SUPPORTED_MODEL_RE — every listed id is route-supported", () => {
+    for (const id of preStartModels) {
+      expect(routeRe.test(id), `${id} is in _CODEX_SUPPORTED but not CODEX_SUPPORTED_MODEL_RE`).toBe(true);
+    }
+  });
+
+  it("migrates every model the picker can offer on ChatGPT auth", () => {
+    // CODEX_MODELS is what the setup UI actually lets a subscription user
+    // choose. Anything selectable must also be migratable, or the box ends up
+    // stuck on a keyless `openai/*` route.
+    for (const model of CODEX_MODELS) {
+      expect(preStartModels, `picker offers ${model.id} but pre-start won't migrate it`).toContain(model.id);
+      expect(routeRe.test(model.id), `picker offers ${model.id} but the route rejects it`).toBe(true);
+    }
+  });
+
+  it("covers the gpt-5.6 family that regressed", () => {
+    for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+      expect(preStartModels).toContain(id);
+    }
+  });
+
+  it("does not migrate API-key-only models", () => {
+    // -pro variants 400 on the ChatGPT-account path, so migrating them to
+    // codex/* would swap a working keyed route for a broken one.
+    for (const id of ["gpt-5.4-pro", "gpt-5.5-pro", "gpt-4o"]) {
+      expect(preStartModels).not.toContain(id);
+      expect(routeRe.test(id)).toBe(false);
+    }
+  });
+});

--- a/src/tests/unit/install-post-update-units.test.ts
+++ b/src/tests/unit/install-post-update-units.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// Unit files live in config/ but only reach a device when step_systemd_services
+// copies them into /etc/systemd/system and daemon-reloads. Fresh installs run
+// that step; the in-app updater's step list does NOT, so for a long time an
+// updated box kept running whatever unit file it shipped with and every unit
+// change was silently a fresh-install-only fix.
+//
+// That swallowed the llamacpp_install TimeoutStartSec raise: systemd killed
+// the Gemma 4 build at 30 minutes, so "Provisioning offline Gemma 4" hung and
+// then died on any box that updated rather than reinstalled. These tests pin
+// the delivery path and the timeout relationship so neither can silently
+// regress.
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const ROOT_UPDATE_UNIT = readFileSync(
+  path.join(REPO, "config/clawbox-root-update@.service"),
+  "utf-8",
+);
+const LLAMACPP_ROUTE = readFileSync(
+  path.join(REPO, "src/app/setup-api/llamacpp/install/route.ts"),
+  "utf-8",
+);
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return INSTALL_SH.slice(start, end);
+}
+
+/** Evaluate a numeric literal expression like `2 * 60 * 60 * 1000`. */
+function evalArithmetic(expression: string): number {
+  if (!/^[\d\s*+]+$/.test(expression)) {
+    throw new Error(`refusing to evaluate non-arithmetic expression: ${expression}`);
+  }
+  return Function(`"use strict"; return (${expression});`)() as number;
+}
+
+describe("in-app update delivers unit-file changes", () => {
+  it("post_update reinstalls systemd units", () => {
+    // Without this call, config/*.service edits never land on an updated box.
+    expect(extractShellFunction("step_post_update")).toContain("step_systemd_services");
+  });
+
+  it("systemd_services is dispatchable so post_update can call it", () => {
+    const dispatch = INSTALL_SH.slice(
+      INSTALL_SH.indexOf("DISPATCH_STEPS=("),
+      INSTALL_SH.indexOf(")", INSTALL_SH.indexOf("DISPATCH_STEPS=(")),
+    );
+    expect(dispatch).toContain("systemd_services");
+  });
+});
+
+describe("llamacpp install timeouts", () => {
+  const unitTimeoutSec = Number(/^TimeoutStartSec=(\d+)$/m.exec(ROOT_UPDATE_UNIT)?.[1]);
+  const routeTimeoutMs = evalArithmetic(
+    /const LLAMACPP_INSTALL_TIMEOUT_MS = ([^;]+);/.exec(LLAMACPP_ROUTE)?.[1]?.trim() ?? "0",
+  );
+
+  it("gives a cold Jetson build more than the old 30 minutes", () => {
+    // Building llama.cpp from source with CUDA on a 6-core Orin plus a
+    // multi-GB GGUF download does not fit in 1800s.
+    expect(unitTimeoutSec).toBeGreaterThan(1800);
+  });
+
+  it("lets systemd own the kill, not the HTTP route", () => {
+    // If the route gave up first it would report failure while the unit kept
+    // installing in the background, and a retry would collide with it.
+    expect(routeTimeoutMs).toBeGreaterThanOrEqual(unitTimeoutSec * 1000);
+  });
+});


### PR DESCRIPTION
Two independent field bugs, both found while validating 3.1.11 on a real box. Targets `beta` — nothing here goes to `main`.

## 1. GPT-5.6 Sol/Terra/Luna unusable on ChatGPT-subscription boxes

`gateway-pre-start.sh` rewrites `openai/<gpt>` → `codex/<gpt>` on devices with Codex OAuth and no OpenAI API key, so a stored keyless `openai/*` model doesn't 401 with *"Missing bearer or basic authentication in header"*. Its `_CODEX_SUPPORTED` tuple is documented in-line as a mirror of `CODEX_SUPPORTED_MODEL_RE` — but the regex learned `gpt-5.6-{sol,terra,luna}` in #271 and the tuple never did.

Net effect: a box whose stored model was `openai/gpt-5.6-sol` was **never migrated**, kept resolving to `api.openai.com` with no key, and 401'd. The newest models were broken on exactly the auth mode they're sold with.

- Adds the gpt-5.6 family to the tuple.
- New `gateway-pre-start-codex-models.test.ts` pins the mirror against **both** `CODEX_SUPPORTED_MODEL_RE` and the `CODEX_MODELS` picker catalog, so "offerable but not migratable" can't come back. Verified it fails against the old tuple.
- `-pro` variants stay excluded — they 400 on the ChatGPT-account path, so migrating them would swap a working keyed route for a broken one.

## 2. "Provisioning offline Gemma 4" hangs, then dies

On a cold box that step builds llama.cpp from source with CUDA on a 6-core Jetson Orin **and** downloads a multi-GB GGUF. Two problems compounded:

- `clawbox-root-update@.service` capped `TimeoutStartSec` at **1800s**, so systemd killed the build partway through. Raised to 7200s — a ceiling, not a wait; every other root-update step finishes in seconds.
- The route ran it as a single blocking `systemctl start` that emitted **nothing** for the whole install. The wizard sat on a bare spinner, and a real hang looked identical to normal progress.

Now: `systemctl start --no-block` plus our own systemd polling, streaming journal lines to the wizard and failing the moment the unit reports `failed` instead of waiting out the timeout. Lines carry a phase-stable prefix (raw cmake/hf/apt output matches no phase keyword and would bounce the wizard back to step 1); the tail is surfaced as overlay detail.

## Verification

- 1444 unit/component tests pass (120 files)
- `tsc --noEmit` clean; `eslint` clean on changed files
- Migration mapping checked standalone: `openai/gpt-5.6-sol → codex/gpt-5.6-sol`, `openai/gpt-5.4-pro → None`
- New test proven to fail without the `_CODEX_SUPPORTED` fix

## Not covered here

The `refresh_token_reused` 401 is a **separate** issue and is not fixed by this PR. Two candidate causes: the same ChatGPT account signed in on several boxes (sufficient on its own — rotating refresh tokens are single-use), and pre-start mirroring the same `refresh_token` into every agent's `codex-home/auth.json`, giving one token family multiple independent refreshers. Needs its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for additional Codex GPT-5.6 model variants during model migration.
  - Offline Gemma 4 provisioning now streams live progress updates with more informative status details.

- **Bug Fixes**
  - Increased systemd and offline provisioning time limits to prevent premature termination during long builds/downloads.
  - Improved installation failure reporting by surfacing the latest observed error context.
  - Ensures updated system service/unit files are refreshed on in-app update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->