### PR TITLE
fix(codex): default ChatGPT auth to gpt-5.5, not gpt-5.4

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -65,7 +65,8 @@ const DEFAULT_MODEL_BY_PROVIDER: Record<string, string> = {
   clawai: "deepseek-v4-flash",
   anthropic: "claude-sonnet-4-6",
   openai: "gpt-5.4",
-  codex: "gpt-5.4",
+  // Newest model on every ChatGPT tier including Free; gpt-5.6 is plan-gated.
+  codex: "gpt-5.5",
   google: "gemini-2.5-flash",
   openrouter: "anthropic/claude-haiku-4.5",
 };

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -89,7 +89,9 @@ const PROVIDERS: Record<string, ProviderConfig> = {
     defaultModel: "openai/gpt-5",
     profileKey: "openai:default",
     subscriptionOverride: {
-      defaultModel: "codex/gpt-5.4",
+      // Newest model every ChatGPT tier can run, Free included. Entitled
+      // accounts are moved up to gpt-5.6 by the sign-in probe below.
+      defaultModel: "codex/gpt-5.5",
       profileKey: "codex:default",
     },
   },
@@ -561,14 +563,14 @@ export async function POST(request: Request) {
       && !(typeof bodyModel === "string" && bodyModel.trim())
     ) {
       // ChatGPT sign-in with no explicit pick. The hardcoded default is
-      // gpt-5.4, so a Pro account used to land two generations behind and had
+      // gpt-5.5, so a Pro account used to land a generation behind and had
       // to know to change it. We can't read entitlement from a catalog — the
       // plugin's list is static and identical for every account — so ask the
       // account directly, newest first.
       //
       // Safety: resolveEntitledCodexModel only returns a model on a positive
       // answer. Gated, ambiguous, rate-limited, offline — all leave us on
-      // gpt-5.4, which every tier can use. Defaulting a non-entitled account
+      // gpt-5.5, which every tier can use. Defaulting a non-entitled account
       // onto a gpt-5.6 model would be far worse than being conservative: the
       // upstream 400 is a surface error with no failover, so every turn fails.
       try {

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -61,7 +61,8 @@ const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   deepseek: CLAWBOX_AI_MODEL_BY_TIER[CLAWBOX_AI_DEFAULT_TIER],
   anthropic: "anthropic/claude-sonnet-4-6",
   openai: "openai/gpt-5.4",
-  codex: "codex/gpt-5.4",
+  // Newest model on every ChatGPT tier including Free; gpt-5.6 is plan-gated.
+  codex: "codex/gpt-5.5",
   google: "google/gemini-2.5-flash",
   openrouter: `openrouter/${OPENROUTER_DEFAULT_MODEL_ID}`,
 };

--- a/src/lib/codex-model-probe.ts
+++ b/src/lib/codex-model-probe.ts
@@ -8,22 +8,29 @@
 // exact mistake pinned a session to gpt-5.6-sol on 2026-07-13 and broke it
 // completely.
 //
+// Only the gpt-5.6 generation is gated. gpt-5.5 runs on every ChatGPT tier
+// including Free, so it is the floor we fall back to rather than a candidate.
+//
 // So we ask the account itself. One cheap request per candidate, newest first,
 // stopping at the first that answers. Deliberately biased toward the safe
 // answer: we only upgrade off the fallback on a POSITIVE signal, and any
 // ambiguity (auth trouble, rate limit, network, 5xx) leaves the caller on the
 // universally-available default.
 
-/** Newest first. gpt-5.4 is not here — it is the fallback everyone can use. */
+/** Newest first. gpt-5.5 is not here — it is the fallback everyone can use. */
 export const CODEX_MODEL_PREFERENCE = [
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",
-  "gpt-5.5",
 ] as const;
 
-/** Available on every ChatGPT tier; what we keep when the probe can't improve on it. */
-export const CODEX_FALLBACK_MODEL = "gpt-5.4";
+/**
+ * Available on every ChatGPT tier including Free; what we keep when the probe
+ * can't improve on it. Only the gpt-5.6 generation is plan-gated, so there is
+ * nothing to gain from probing gpt-5.5 — it would spend a round-trip during
+ * setup to confirm a floor we already hold.
+ */
+export const CODEX_FALLBACK_MODEL = "gpt-5.5";
 
 const CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses";
 const DEFAULT_PER_PROBE_TIMEOUT_MS = 6000;

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -79,8 +79,8 @@ export const CODEX_MODELS: readonly ProviderModelOption[] = [
   { id: "gpt-5.6-sol", label: "GPT-5.6 Sol", hint: "Newest flagship. Plus/Pro." },
   { id: "gpt-5.6-terra", label: "GPT-5.6 Terra", hint: "GPT-5.6. Plus/Pro." },
   { id: "gpt-5.6-luna", label: "GPT-5.6 Luna", hint: "GPT-5.6, fast. Plus/Pro." },
-  { id: "gpt-5.5", label: "GPT-5.5", hint: "Flagship." },
-  { id: "gpt-5.4", label: "GPT-5.4", hint: "Default. 1M context." },
+  { id: "gpt-5.5", label: "GPT-5.5", hint: "Default. Every tier." },
+  { id: "gpt-5.4", label: "GPT-5.4", hint: "Previous gen. 1M context." },
   { id: "gpt-5.4-mini", label: "GPT-5.4 Mini", hint: "Fast, cheap." },
 ] as const;
 
@@ -141,9 +141,13 @@ export const PROVIDER_CATALOGS = Object.freeze({
     allowCustom: true,
   },
   codex: {
+    // gpt-5.5 is the newest model available on every ChatGPT tier including
+    // Free — only the gpt-5.6 generation is plan-gated — so it is the right
+    // cold-start default. Entitled accounts get moved up to gpt-5.6 by the
+    // sign-in probe (src/lib/codex-model-probe.ts).
     provider: "codex",
     models: CODEX_MODELS,
-    defaultModelId: "gpt-5.4",
+    defaultModelId: "gpt-5.5",
     allowCustom: true,
   },
   google: {

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -480,10 +480,10 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(body.success).toBe(true);
 
     const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
-    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.4");
+    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.5");
   });
 
-  // A Pro account used to land on gpt-5.4 after sign-in and had to know to
+  // A Pro account used to land on gpt-5.5 after sign-in and had to know to
   // change it. Entitlement isn't readable from any catalog (the plugin list is
   // static and identical for every account), so the route asks the account.
   it("defaults a ChatGPT sign-in to the newest model the account can use", async () => {
@@ -503,9 +503,9 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.6-sol");
   });
 
-  it("leaves a non-entitled account on gpt-5.4 rather than a model that 400s", async () => {
-    // Every gpt-5.6 id gated, gpt-5.5 too: the safe landing spot is the
-    // fallback, not the newest id in the static catalog.
+  it("leaves a non-entitled account on gpt-5.5 rather than a model that 400s", async () => {
+    // Every gpt-5.6 id gated: the safe landing spot is gpt-5.5, which runs on
+    // every tier including Free, not the newest id in the static catalog.
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status: 403 })));
 
     const res = await configurePost(jsonRequest({
@@ -519,7 +519,7 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     expect(res.status).toBe(200);
     const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
-    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.4");
+    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.5");
   });
 
   it("does not probe when the user picked a model explicitly", async () => {
@@ -533,12 +533,14 @@ describe("POST /setup-api/ai-models/configure", () => {
       authMode: "subscription",
       refreshToken: "refresh-token",
       expiresIn: 3600,
-      model: "gpt-5.5",
+      // Deliberately NOT the subscription default (gpt-5.5) — otherwise this
+      // assertion would pass even if the probe ran and found nothing.
+      model: "gpt-5.4-mini",
     }));
 
     expect(res.status).toBe(200);
     const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
-    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.5");
+    expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.4-mini");
     const probedCodex = fetchMock.mock.calls.some(([url]) => String(url).includes("backend-api/codex/responses"));
     expect(probedCodex).toBe(false);
   });

--- a/src/tests/unit/codex-model-probe.test.ts
+++ b/src/tests/unit/codex-model-probe.test.ts
@@ -108,11 +108,10 @@ describe("resolveEntitledCodexModel", () => {
   });
 
   it("walks down to the newest model the account actually has", async () => {
-    // Free/Plus-without-5.6: the three gpt-5.6 ids are gated, gpt-5.5 is not.
+    // Partial 5.6 entitlement: sol and terra gated, luna not.
     const fetchImpl = vi.fn()
       .mockResolvedValueOnce(jsonResponse(400, { error: { message: "requires a newer version of Codex" } }))
       .mockResolvedValueOnce(jsonResponse(403, ""))
-      .mockResolvedValueOnce(jsonResponse(404, ""))
       .mockResolvedValueOnce(jsonResponse(200, {}));
 
     const model = await resolveEntitledCodexModel({
@@ -120,8 +119,19 @@ describe("resolveEntitledCodexModel", () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    expect(model).toBe("gpt-5.5");
-    expect(fetchImpl).toHaveBeenCalledTimes(4);
+    expect(model).toBe("gpt-5.6-luna");
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("only probes plan-gated models — gpt-5.5 is the floor, not a candidate", () => {
+    // gpt-5.5 runs on every ChatGPT tier including Free. Probing it would spend
+    // a setup round-trip to confirm something we already hold.
+    expect([...CODEX_MODEL_PREFERENCE]).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+    ]);
+    expect(CODEX_FALLBACK_MODEL).toBe("gpt-5.5");
   });
 
   it("keeps the caller's default when nothing is available", async () => {

--- a/src/tests/unit/provider-models.test.ts
+++ b/src/tests/unit/provider-models.test.ts
@@ -16,7 +16,8 @@ describe("provider-models", () => {
   describe("getProviderCatalog", () => {
     it("returns configured provider catalogs", () => {
       expect(getProviderCatalog("openai")?.defaultModelId).toBe("gpt-5.4");
-      expect(getProviderCatalog("codex")?.defaultModelId).toBe("gpt-5.4");
+      // Codex (ChatGPT auth) starts on the newest model every tier can run.
+      expect(getProviderCatalog("codex")?.defaultModelId).toBe("gpt-5.5");
     });
 
     it("does not return inherited Object prototype members", () => {


### PR DESCRIPTION
## What

`gpt-5.4` was treated as the universally-available floor for ChatGPT (Codex) auth. It isn't — **`gpt-5.5` runs on every ChatGPT tier including Free**, and only the `gpt-5.6` generation is plan-gated. Every box signing in with a ChatGPT account was landing a generation behind for no reason.

## Changes

**Static default → `gpt-5.5`** in all four places that hardcoded `gpt-5.4` for codex:

| File | Was | Now |
|---|---|---|
| `ai-models/configure/route.ts` (`subscriptionOverride`) | `codex/gpt-5.4` | `codex/gpt-5.5` |
| `lib/provider-models.ts` (`PROVIDER_CATALOGS.codex`) | `gpt-5.4` | `gpt-5.5` |
| `chat/model/route.ts` (`DEFAULT_PROVIDER_MODELS`) | `codex/gpt-5.4` | `codex/gpt-5.5` |
| `ai-models/catalog/route.ts` (`DEFAULT_MODEL_BY_PROVIDER`) | `gpt-5.4` | `gpt-5.5` |

**Probe chain drops `gpt-5.5`.** It's now the fallback, so probing it spent a setup round-trip confirming a floor we already hold. `CODEX_MODEL_PREFERENCE` is the three plan-gated `gpt-5.6` ids only; `CODEX_FALLBACK_MODEL` is `gpt-5.5`.

The OpenAI **API-key** default (`openai/gpt-5.4`) is deliberately untouched — that path is paid per token, so it's a cost decision, not an entitlement one.

## Behaviour

- Pro/Plus account → probe confirms `gpt-5.6-sol` → lands on Sol (unchanged)
- Free account → all three `gpt-5.6` probes gated → lands on **`gpt-5.5`** (was `gpt-5.4`)
- Ambiguous (401/429/5xx/offline) → still lands on `gpt-5.5`, which every tier can run
- One fewer probe request during setup

## Verification

- 1468 tests pass, `tsc --noEmit` clean, eslint clean on changed files (one pre-existing unused-var warning in `chat/model/route.ts`)
- Rewrote the probe walk-down test for the 3-candidate chain (sol gated → terra gated → luna available)
- Added a test pinning the chain to plan-gated ids only, with `gpt-5.5` as the floor
- Fixed a latent hole in the "does not probe when the user picked a model" test: it picked `gpt-5.5` explicitly, which is now the default, so it would have passed even if the probe ran. Now picks `gpt-5.4-mini`.

Targets `beta`. Nothing to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)