### PR TITLE
fix(codex): stop mirroring the rotating refresh token into every codex-home

### DIFF
--- a/config/clawbox-codex-auth-sync.service
+++ b/config/clawbox-codex-auth-sync.service
@@ -29,7 +29,12 @@ NoNewPrivileges=yes
 PrivateTmp=yes
 PrivateNetwork=yes
 ProtectSystem=strict
-ReadWritePaths=/home/clawbox/.openclaw /home/clawbox/.codex
+# Leading "-" = tolerate a missing path. ~/.codex does not exist until the
+# first ChatGPT login, and systemd refuses to start a unit whose ReadWritePaths
+# names a path that isn't there — which would turn "not logged in yet" into a
+# failed unit on every fresh box. install.sh pre-creates it; this is insurance
+# for boxes that got here another way.
+ReadWritePaths=-/home/clawbox/.openclaw -/home/clawbox/.codex
 ProtectKernelTunables=yes
 ProtectKernelModules=yes
 ProtectControlGroups=yes

--- a/config/clawbox-codex-auth-sync.service
+++ b/config/clawbox-codex-auth-sync.service
@@ -1,0 +1,41 @@
+[Unit]
+Description=ClawBox Codex credential mirror sync
+After=clawbox-gateway.service
+# The mirrors are only meaningful once the gateway (and therefore core's auth
+# profile store) exists. No Requires= — a stopped gateway just means there is
+# nothing new to mirror, which the script reports and exits 0 on.
+
+[Service]
+Type=oneshot
+User=clawbox
+Group=clawbox
+# Re-sync ~/.codex/auth.json and every agent's codex-home/auth.json from core's
+# auth profile store. ChatGPT access tokens expire in about an hour, and core
+# rotates the refresh token that mints them; the mirrors carry no refresh token
+# of their own (that is what killed boxes on 3.1.11 — two rotators, one
+# single-use token family, HTTP 401 refresh_token_reused). So they must be
+# re-read from core rather than left to decay. See scripts/codex-auth-mirror.js.
+Environment=CODEX_AUTH_MIRROR_QUIET=1
+ExecStart=/usr/bin/env node /home/clawbox/clawbox/scripts/codex-auth-mirror.js
+# A missing credential is the normal pre-login state and the script already
+# exits 0 on it. Anything else is transient (DB locked mid-write) and the next
+# tick retries, so never let this unit flap into failed state.
+SuccessExitStatus=0 1
+
+# ── Sandboxing ─────────────────────────────────────────────────────────────
+# Reads core's sqlite store, writes two owner-only credential files under the
+# clawbox home. No network at all — this unit never talks to OpenAI.
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateNetwork=yes
+ProtectSystem=strict
+ReadWritePaths=/home/clawbox/.openclaw /home/clawbox/.codex
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM

--- a/config/clawbox-codex-auth-sync.timer
+++ b/config/clawbox-codex-auth-sync.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Re-sync the ClawBox Codex credential mirrors every 10 minutes
+Requires=clawbox-codex-auth-sync.service
+
+[Timer]
+# Boot sync already happens in gateway-pre-start.sh; give the gateway a moment
+# to come up before the first timer-driven pass so we mirror a settled store.
+OnBootSec=2min
+# ChatGPT access tokens last about an hour. 10 minutes leaves five chances to
+# pick up a rotation before the mirrors would serve an expired token and the
+# box regressed to "401 Missing bearer".
+OnUnitActiveSec=10min
+# The mirror is idempotent and cheap; let systemd batch the wake-up.
+AccuracySec=30s
+Unit=clawbox-codex-auth-sync.service
+
+[Install]
+WantedBy=timers.target

--- a/install.sh
+++ b/install.sh
@@ -103,6 +103,7 @@ EXPECTED_ACTIVE_SERVICES=(
   clawbox-performance.service
   clawbox-heartbeat.timer
   clawbox-ap-watchdog.timer
+  clawbox-codex-auth-sync.timer
 )
 EXPECTED_INSTALLED_SERVICES=(
   clawbox-heartbeat.service
@@ -110,6 +111,7 @@ EXPECTED_INSTALLED_SERVICES=(
   clawbox-tunnel.service
   "clawbox-root-update@.service"
   clawbox-ap-watchdog.service
+  clawbox-codex-auth-sync.service
 )
 
 # Load persisted WiFi interface if available
@@ -1272,6 +1274,7 @@ step_systemd_services() {
     [[ "$svc" == "clawbox-heartbeat.service" ]] && continue
     # Timer-driven one-shot (no [Install]); enabled via its .timer below.
     [[ "$svc" == "clawbox-ap-watchdog.service" ]] && continue
+    [[ "$svc" == "clawbox-codex-auth-sync.service" ]] && continue
     systemctl enable "$svc"
   done
   # Start the heartbeat timer immediately so the portal sees the device
@@ -1280,6 +1283,10 @@ step_systemd_services() {
   # Start the AP watchdog immediately so a dropped setup hotspot self-heals
   # without waiting for a reboot.
   systemctl enable --now clawbox-ap-watchdog.timer
+  # Start the Codex credential mirror sync immediately so a box updating into
+  # this release strips any refresh_token 3.1.11 planted in its mirrors without
+  # waiting for a reboot — that token is what burns the OAuth family.
+  systemctl enable --now clawbox-codex-auth-sync.timer
   # Clean up older installs that enabled on-demand units at boot.
   systemctl disable --now clawbox-browser.service >/dev/null 2>&1 || true
   # Migration: prior installs enabled clawbox-tunnel by default, which loops

--- a/install.sh
+++ b/install.sh
@@ -1283,6 +1283,11 @@ step_systemd_services() {
   # Start the AP watchdog immediately so a dropped setup hotspot self-heals
   # without waiting for a reboot.
   systemctl enable --now clawbox-ap-watchdog.timer
+  # The sync unit runs under ProtectSystem=strict and can only write paths named
+  # in ReadWritePaths. ~/.codex doesn't exist until the first ChatGPT login, so
+  # create it up front — otherwise the very first mirror write (the one that
+  # makes Codex work at all) hits a read-only namespace.
+  install -d -o clawbox -g clawbox -m 700 "$CLAWBOX_HOME/.codex"
   # Start the Codex credential mirror sync immediately so a box updating into
   # this release strips any refresh_token 3.1.11 planted in its mirrors without
   # waiting for a reboot — that token is what burns the OAuth family.

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Mirror the ChatGPT/Codex OAuth credential from OpenClaw core's auth profile
+ * store into the Codex CLI-style auth.json files the Codex runtime reads.
+ *
+ * WHY THIS EXISTS
+ *
+ * On a ChatGPT-subscription box the Codex runtime needs a Codex CLI-style
+ * auth.json or it falls back to api.openai.com with no bearer and every turn
+ * dies with `401 Missing bearer or basic authentication in header`. Two
+ * locations matter:
+ *
+ *   ~/.codex/auth.json                  - read by the codex plugin
+ *   <agentDir>/codex-home/auth.json     - CODEX_HOME the gateway passes to the
+ *                                         Codex app-server on core 2026.7.x
+ *
+ * THE RULE: EXACTLY ONE HOLDER MAY CARRY refresh_token.
+ *
+ * ChatGPT OAuth refresh tokens are single-use and rotating. Every holder that
+ * *uses* one rotates the family server-side, so a second holder presenting the
+ * old value gets `401 refresh_token_reused` and the family is burnt. Core owns
+ * the OAuth flow and persists rotations to openclaw-agent.sqlite, so core is
+ * the single rotator. These mirrors are access-token-only, read-only copies.
+ *
+ * 3.1.11 shipped mirrors that DID carry refresh_token, giving the box two
+ * rotators (core + the Codex app-server binary, which rotates whatever sits in
+ * its CODEX_HOME). Boxes worked for a few hours and then died. See #278.
+ *
+ * Access tokens live about an hour, so this runs at boot from
+ * gateway-pre-start.sh and periodically from clawbox-codex-auth-sync.timer.
+ *
+ * Exit code is always 0: a missing credential is a normal pre-login state, and
+ * this must never be able to block the gateway from starting.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const openclawHome =
+  process.argv[2] || process.env.OPENCLAW_HOME_DIR || path.join(os.homedir(), ".openclaw");
+const homeAuthPath =
+  process.argv[3] || path.join(os.homedir(), ".codex", "auth.json");
+const quiet = process.env.CODEX_AUTH_MIRROR_QUIET === "1";
+
+function log(message) {
+  if (!quiet) console.log("  " + message);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Auth profiles moved from agents/<id>/agent/auth-profiles.json into the
+ * auth_profile_store table of openclaw-agent.sqlite on core 2026.7.x. Read
+ * both so the mirror keeps working across a core downgrade.
+ */
+function readProfiles(agentDir) {
+  const fromJson = readJson(path.join(agentDir, "auth-profiles.json"));
+  if (fromJson && fromJson.profiles) return fromJson.profiles;
+  try {
+    const { DatabaseSync } = require("node:sqlite");
+    const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"), {
+      readOnly: true,
+    });
+    const row = db
+      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+      .get("primary");
+    db.close();
+    const parsed = row && row.store_json ? JSON.parse(row.store_json) : null;
+    return (parsed && parsed.profiles) || null;
+  } catch {
+    return null; // no node:sqlite, no table, or locked — non-fatal
+  }
+}
+
+/** chatgpt_account_id lives in the access token's claims, not the profile. */
+function accountIdFromAccessToken(accessToken) {
+  try {
+    const claims = JSON.parse(
+      Buffer.from(accessToken.split(".")[1], "base64url").toString(),
+    );
+    const auth = claims["https://api.openai.com/auth"] || {};
+    return (
+      auth.chatgpt_account_id || auth.account_id || auth.user_id || claims.sub || null
+    );
+  } catch {
+    return null; // opaque token — leave accountId null
+  }
+}
+
+function credentialFromProfiles(agentDir) {
+  const profiles = readProfiles(agentDir);
+  const profile =
+    profiles && (profiles["codex:default"] || profiles["openai-codex:default"]);
+  if (!profile || !profile.access) return null;
+  return {
+    accessToken: profile.access,
+    idToken: profile.id || profile.access,
+    accountId: accountIdFromAccessToken(profile.access),
+  };
+}
+
+/**
+ * Build the file contents. Deliberately no refresh_token — see the rule above.
+ * An existing OPENAI_API_KEY is carried over: that is the API-key path, which
+ * core reads from this same file and which has no rotation problem.
+ */
+function buildAuthFile(credential, existing) {
+  return {
+    OPENAI_API_KEY: (existing && existing.OPENAI_API_KEY) || null,
+    tokens: {
+      id_token: credential.idToken,
+      access_token: credential.accessToken,
+      account_id: credential.accountId,
+    },
+    last_refresh: new Date().toISOString(),
+  };
+}
+
+/**
+ * Rewrite when the access token changed or a refresh_token is present (a
+ * poisoned 3.1.11 mirror, or a stale copy). Returns a short reason for the log,
+ * or null when the file was already correct.
+ */
+function syncReason(existing, credential) {
+  if (!existing) return "created";
+  const tokens = existing.tokens || {};
+  if (tokens.refresh_token) return "stripped refresh_token";
+  if (tokens.access_token !== credential.accessToken) return "refreshed";
+  return null;
+}
+
+function writeMirror(dest, credential) {
+  const existing = readJson(dest);
+  const reason = syncReason(existing, credential);
+  if (!reason) return null;
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  // Holds an OAuth token — owner-only dir, not just the 0600 file.
+  fs.chmodSync(path.dirname(dest), 0o700);
+  fs.writeFileSync(
+    dest,
+    JSON.stringify(buildAuthFile(credential, existing), null, 2),
+    { mode: 0o600 },
+  );
+  return reason;
+}
+
+function main() {
+  const agentsRoot = path.join(openclawHome, "agents");
+  const agentDirs = fs.existsSync(agentsRoot)
+    ? fs
+        .readdirSync(agentsRoot)
+        .map((id) => path.join(agentsRoot, id, "agent"))
+        .filter((dir) => fs.existsSync(dir))
+    : [];
+
+  // Core's store is the source of truth; the main agent holds the real login.
+  const mainFirst = (a, b) =>
+    Number(b.includes(`${path.sep}main${path.sep}`)) -
+    Number(a.includes(`${path.sep}main${path.sep}`));
+  let credential = null;
+  for (const dir of [...agentDirs].sort(mainFirst)) {
+    credential = credentialFromProfiles(dir);
+    if (credential) break;
+  }
+
+  if (!credential) {
+    log("Codex auth.json: no codex OAuth profile yet, skipping");
+    return;
+  }
+
+  const destinations = [
+    homeAuthPath,
+    ...agentDirs.map((dir) => path.join(dir, "codex-home", "auth.json")),
+  ];
+  let synced = 0;
+  for (const dest of destinations) {
+    const reason = writeMirror(dest, credential);
+    if (reason) {
+      synced += 1;
+      log(`Codex auth.json ${reason}: ${dest}`);
+    }
+  }
+  if (synced === 0) log("Codex auth.json: mirrors already current");
+}
+
+try {
+  main();
+} catch (error) {
+  // Never block gateway start on a credential mirror.
+  log("Codex auth.json: " + error.message);
+}

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -615,92 +615,32 @@ fi
 #      auth_profile_store table of openclaw-agent.sqlite, so the old
 #      JSON-only lookup silently found nothing and wrote no credential at all.
 #
-# An existing ~/.codex/auth.json is preferred as the source: it comes from a
-# real Codex login and carries a true id_token, whereas a synthesized one can
-# only fall back to the access token. Write-if-missing at every destination —
-# the app-server owns refresh once a file exists, so we never clobber a newer
-# token.
+# THE MIRRORS MUST NOT CARRY refresh_token. ChatGPT OAuth refresh tokens are
+# single-use and rotating: the whole family dies the moment two holders each
+# present one ("refresh_token has already been used", HTTP 401
+# refresh_token_reused). 3.1.11 shipped the mirrors WITH the refresh token,
+# which gave the box two independent rotators — core (owner of the OAuth flow,
+# persists to openclaw-agent.sqlite) and the Codex app-server binary, which
+# rotates whatever sits in its CODEX_HOME. Boxes worked for a few hours and
+# then died. See #278.
+#
+# So: core stays the single rotator, and the mirrors are access-token-only,
+# read-only copies. They are REWRITTEN on every boot (not write-if-missing)
+# so they track core's current token instead of decaying, and so boxes already
+# poisoned by 3.1.11 self-heal on the next restart. Between boots
+# clawbox-codex-auth-sync.timer keeps them fresh -- an access token expires in
+# about an hour, far short of a reboot interval.
+#
+# A user-supplied OPENAI_API_KEY in ~/.codex/auth.json is preserved: that is
+# the API-key path, which core reads from this file and which has no rotation
+# problem.
 if [ "$NEEDS_CODEX_PLUGIN" = "1" ]; then
-  node - "$OPENCLAW_HOME_DIR" "$HOME/.codex/auth.json" <<'NODE'
-const fs = require("fs"), path = require("path");
-const [openclawHome, homeAuthPath] = process.argv.slice(2);
-
-function readJson(p) {
-  try { return JSON.parse(fs.readFileSync(p, "utf8")); } catch { return null; }
-}
-
-// Prefer a real Codex login if one is already on disk.
-function fromExistingFile() {
-  const d = readJson(homeAuthPath);
-  return d && d.tokens && d.tokens.access_token ? d : null;
-}
-
-// Otherwise synthesize from the OpenClaw codex OAuth profile. Tokens live in
-// auth-profiles.json on older cores and in openclaw-agent.sqlite on 2026.7.x.
-function readProfiles(agentDir) {
-  const j = readJson(path.join(agentDir, "auth-profiles.json"));
-  if (j && j.profiles) return j.profiles;
-  try {
-    const { DatabaseSync } = require("node:sqlite");
-    const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"), { readOnly: true });
-    const row = db.prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?").get("primary");
-    db.close();
-    const parsed = row && row.store_json ? JSON.parse(row.store_json) : null;
-    return (parsed && parsed.profiles) || null;
-  } catch { return null; } // no node:sqlite, no table, or locked — non-fatal
-}
-
-function synthesize(agentDir) {
-  const profiles = readProfiles(agentDir);
-  const p = profiles && (profiles["codex:default"] || profiles["openai-codex:default"]);
-  if (!p || !p.access) return null;
-  let accountId = null;
-  try {
-    const claims = JSON.parse(Buffer.from(p.access.split(".")[1], "base64url").toString());
-    const auth = claims["https://api.openai.com/auth"] || {};
-    accountId = auth.chatgpt_account_id || auth.account_id || auth.user_id || claims.sub || null;
-  } catch { /* opaque token — leave accountId null */ }
-  return {
-    OPENAI_API_KEY: null,
-    tokens: { id_token: p.id || p.access, access_token: p.access, refresh_token: p.refresh, account_id: accountId },
-    last_refresh: new Date().toISOString(),
-  };
-}
-
-function write(dest, cred) {
-  if (fs.existsSync(dest)) return false;
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
-  fs.chmodSync(path.dirname(dest), 0o700); // holds OAuth tokens — owner-only dir, not just the 0600 file
-  fs.writeFileSync(dest, JSON.stringify(cred, null, 2), { mode: 0o600 });
-  return true;
-}
-
-try {
-  const agentsRoot = path.join(openclawHome, "agents");
-  const agents = fs.existsSync(agentsRoot)
-    ? fs.readdirSync(agentsRoot).map((id) => path.join(agentsRoot, id, "agent")).filter((d) => fs.existsSync(d))
-    : [];
-
-  let cred = fromExistingFile();
-  if (!cred) {
-    // Prefer the main agent's profile store as the synthesis source.
-    const byMainFirst = (a, b) => Number(b.includes("/main/")) - Number(a.includes("/main/"));
-    for (const dir of [...agents].sort(byMainFirst)) {
-      cred = synthesize(dir);
-      if (cred) break;
-    }
-  }
-  if (!cred) { console.log("  Codex auth.json: no codex OAuth profile yet, skipping"); process.exit(0); }
-
-  if (write(homeAuthPath, cred)) console.log("  Wrote ~/.codex/auth.json for the Codex app-server");
-  for (const dir of agents) {
-    // CODEX_HOME the gateway actually passes to the app-server on 2026.7.x.
-    if (write(path.join(dir, "codex-home", "auth.json"), cred)) {
-      console.log("  Wrote " + path.basename(path.dirname(dir)) + " agent codex-home/auth.json");
-    }
-  }
-} catch (e) { console.log("  Codex auth.json: " + e.message); }
-NODE
+  CODEX_AUTH_MIRROR="${CLAWBOX_ROOT:-/home/clawbox/clawbox}/scripts/codex-auth-mirror.js"
+  if [ -f "$CODEX_AUTH_MIRROR" ]; then
+    node "$CODEX_AUTH_MIRROR" "$OPENCLAW_HOME_DIR" "$HOME/.codex/auth.json" || true
+  else
+    echo "  WARN: $CODEX_AUTH_MIRROR missing; Codex credential mirrors not synced"
+  fi
 fi
 
 # Semantic memory embeddings default. OpenClaw's memory search defaults to

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// scripts/codex-auth-mirror.js copies the ChatGPT/Codex credential out of
+// core's auth profile store into the Codex CLI-style auth.json files the Codex
+// runtime reads. The invariant it exists to protect:
+//
+//   EXACTLY ONE HOLDER MAY CARRY refresh_token.
+//
+// ChatGPT OAuth refresh tokens are single-use and rotating. 3.1.11 mirrored the
+// refresh token into every agent's codex-home/auth.json, which the Codex
+// app-server then rotated independently of core — two rotators, one token
+// family, and every box signed in with ChatGPT died with
+// `401 refresh_token_reused` a few hours after setup. See #278.
+//
+// These tests run the real shipped script against a temp OPENCLAW_HOME so a
+// regression that reintroduces refresh_token (or stops self-healing a poisoned
+// mirror) fails here rather than on a customer's box overnight.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/codex-auth-mirror.js");
+
+// Minimal JWT whose payload carries the ChatGPT account id claim.
+function accessToken(accountId: string, marker = "a"): string {
+  const payload = Buffer.from(
+    JSON.stringify({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+  ).toString("base64url");
+  return `hdr.${payload}.sig-${marker}`;
+}
+
+let home: string;
+let openclawHome: string;
+let agentDir: string;
+let homeAuthPath: string;
+let codexHomeAuthPath: string;
+
+function seedProfile(access: string, refresh = "refresh-secret") {
+  writeFileSync(
+    path.join(agentDir, "auth-profiles.json"),
+    JSON.stringify({
+      profiles: {
+        "codex:default": { access, refresh, id: "id-token" },
+      },
+    }),
+  );
+}
+
+function run(): string {
+  return execFileSync("node", [SCRIPT, openclawHome, homeAuthPath], {
+    encoding: "utf-8",
+  });
+}
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "codex-auth-mirror-"));
+  openclawHome = path.join(home, ".openclaw");
+  agentDir = path.join(openclawHome, "agents", "main", "agent");
+  mkdirSync(agentDir, { recursive: true });
+  homeAuthPath = path.join(home, ".codex", "auth.json");
+  codexHomeAuthPath = path.join(agentDir, "codex-home", "auth.json");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("codex-auth-mirror.js", () => {
+  it("never writes a refresh_token into any mirror", () => {
+    seedProfile(accessToken("acct-1"));
+    run();
+
+    for (const file of [homeAuthPath, codexHomeAuthPath]) {
+      const parsed = JSON.parse(readFileSync(file, "utf-8"));
+      expect(parsed.tokens.refresh_token).toBeUndefined();
+      // The whole serialized file, so a refresh token can't sneak in elsewhere.
+      expect(readFileSync(file, "utf-8")).not.toContain("refresh-secret");
+    }
+  });
+
+  it("mirrors the access token and account id the runtime needs", () => {
+    seedProfile(accessToken("acct-42"));
+    run();
+
+    const parsed = JSON.parse(readFileSync(codexHomeAuthPath, "utf-8"));
+    expect(parsed.tokens.access_token).toBe(accessToken("acct-42"));
+    expect(parsed.tokens.account_id).toBe("acct-42");
+    expect(parsed.tokens.id_token).toBe("id-token");
+  });
+
+  it("writes to CODEX_HOME as well as ~/.codex — the app-server only reads the former", () => {
+    seedProfile(accessToken("acct-1"));
+    run();
+
+    expect(existsSync(homeAuthPath)).toBe(true);
+    expect(existsSync(codexHomeAuthPath)).toBe(true);
+  });
+
+  it("self-heals a mirror poisoned by 3.1.11", () => {
+    // Exactly what 3.1.11 left on disk: a mirror carrying the refresh token.
+    mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
+    writeFileSync(
+      codexHomeAuthPath,
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: accessToken("acct-1"),
+          refresh_token: "poisoned-rotating-token",
+          account_id: "acct-1",
+        },
+      }),
+    );
+    seedProfile(accessToken("acct-1"));
+
+    const out = run();
+
+    const parsed = JSON.parse(readFileSync(codexHomeAuthPath, "utf-8"));
+    expect(parsed.tokens.refresh_token).toBeUndefined();
+    expect(out).toContain("stripped refresh_token");
+  });
+
+  it("refreshes a stale mirror when core has rotated the access token", () => {
+    seedProfile(accessToken("acct-1", "old"));
+    run();
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.access_token)
+      .toBe(accessToken("acct-1", "old"));
+
+    // Core rotated; the timer runs again.
+    seedProfile(accessToken("acct-1", "new"));
+    const out = run();
+
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.access_token)
+      .toBe(accessToken("acct-1", "new"));
+    expect(out).toContain("refreshed");
+  });
+
+  it("is idempotent — a second run with no rotation rewrites nothing", () => {
+    seedProfile(accessToken("acct-1"));
+    run();
+    const out = run();
+    expect(out).toContain("mirrors already current");
+  });
+
+  it("preserves a user's OPENAI_API_KEY — that path has no rotation problem", () => {
+    mkdirSync(path.dirname(homeAuthPath), { recursive: true });
+    writeFileSync(
+      homeAuthPath,
+      JSON.stringify({ OPENAI_API_KEY: "sk-user-key", tokens: {} }),
+    );
+    seedProfile(accessToken("acct-1"));
+    run();
+
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).OPENAI_API_KEY).toBe("sk-user-key");
+  });
+
+  it("writes credentials owner-only", () => {
+    seedProfile(accessToken("acct-1"));
+    run();
+
+    for (const file of [homeAuthPath, codexHomeAuthPath]) {
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      expect(statSync(path.dirname(file)).mode & 0o777).toBe(0o700);
+    }
+  });
+
+  it("exits cleanly before login instead of blocking gateway start", () => {
+    const out = run(); // no profile seeded at all
+    expect(out).toContain("no codex OAuth profile yet");
+    expect(existsSync(homeAuthPath)).toBe(false);
+  });
+
+  it("reads the sqlite auth_profile_store — where core 2026.7.x actually keeps the login", () => {
+    // Real boxes have no auth-profiles.json: core moved profiles into
+    // openclaw-agent.sqlite. If this path regresses, the mirror silently writes
+    // nothing and every ChatGPT box is back to `401 Missing bearer`.
+    const { DatabaseSync } = require("node:sqlite");
+    const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+    db.exec("CREATE TABLE auth_profile_store (store_key TEXT PRIMARY KEY, store_json TEXT)");
+    db.prepare("INSERT INTO auth_profile_store (store_key, store_json) VALUES (?, ?)").run(
+      "primary",
+      JSON.stringify({
+        profiles: {
+          "codex:default": {
+            access: accessToken("acct-sqlite"),
+            refresh: "refresh-secret",
+            id: "id-token",
+          },
+        },
+      }),
+    );
+    db.close();
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(codexHomeAuthPath, "utf-8"));
+    expect(parsed.tokens.access_token).toBe(accessToken("acct-sqlite"));
+    expect(parsed.tokens.account_id).toBe("acct-sqlite");
+    expect(parsed.tokens.refresh_token).toBeUndefined();
+    expect(readFileSync(codexHomeAuthPath, "utf-8")).not.toContain("refresh-secret");
+  });
+
+  it("mirrors into every agent, not just main", () => {
+    const second = path.join(openclawHome, "agents", "support", "agent");
+    mkdirSync(second, { recursive: true });
+    seedProfile(accessToken("acct-1"));
+    run();
+
+    const secondMirror = path.join(second, "codex-home", "auth.json");
+    expect(existsSync(secondMirror)).toBe(true);
+    expect(JSON.parse(readFileSync(secondMirror, "utf-8")).tokens.refresh_token).toBeUndefined();
+  });
+});
+
+describe("gateway-pre-start.sh wiring", () => {
+  const PRE_START = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+
+  it("delegates to the mirror script instead of inlining a credential writer", () => {
+    const src = readFileSync(PRE_START, "utf-8");
+    expect(src).toContain("scripts/codex-auth-mirror.js");
+    // The inline heredoc that planted refresh tokens must be gone for good.
+    expect(src).not.toMatch(/refresh_token:\s*p\.refresh/);
+  });
+});


### PR DESCRIPTION
## The bug

3.1.11 extended the `~/.codex/auth.json` synthesis in `gateway-pre-start.sh` to also copy the credential into `<agentDir>/codex-home/auth.json` — the `CODEX_HOME` core 2026.7.x passes to the Codex app-server. That fixed the `401 Missing bearer` boxes, but the copies carried `refresh_token`.

ChatGPT OAuth refresh tokens are **single-use and rotating**. The copies gave each box two independent rotators:

| Holder | Rotates? |
|---|---|
| Core's profile in `openclaw-agent.sqlite` | ✅ owns the OAuth flow |
| `<agent>/codex-home/auth.json` | ✅ the app-server rotates its `CODEX_HOME` |
| `~/.codex/auth.json` | ❌ plugin only reads it |

Whichever refreshed first invalidated the other → `401 refresh_token_reused`, a few hours after setup. Verified on a live box: the two files held **different** tokens, written a day apart.

`v3.1.10` wrote only `~/.codex/auth.json`, which nothing rotates — so this is new in 3.1.11 and would ship to every ChatGPT-subscription customer the moment a `v3.1.11` tag exists.

## The fix

Core stays the single rotator. Mirrors become access-token-only read-only copies, extracted from the inline heredoc into `scripts/codex-auth-mirror.js`:

- **Rewritten, not write-if-missing** — a mirror poisoned by 3.1.11 self-heals on the next gateway start instead of staying broken forever.
- **Re-synced every 10 min** by `clawbox-codex-auth-sync.timer`. Access tokens expire in ~1h; a boot-only mirror would regress the box to `401 Missing bearer` by lunchtime.
- **Preserves a user `OPENAI_API_KEY`** — that's the API-key path, no rotation problem.
- Sandboxed unit: `PrivateNetwork=yes`, `ProtectSystem=strict`, writes only the two credential paths. It never talks to OpenAI.

## Verification

**Unit:** 12 new tests in `src/tests/unit/codex-auth-mirror.test.ts` running the real shipped script — no `refresh_token` in any mirror, sqlite `auth_profile_store` path (what real boxes use), self-heal of a poisoned mirror, stale-token refresh, idempotence, `0600`/`0700` perms, clean pre-login exit.

**Full suite:** 1479 passed / 123 files, 0 failures.

**On a real box** — reconstructed the exact 3.1.11 on-disk state and ran the new mirror:

```
BEFORE
  ~/.codex/auth.json                       refresh_token=True   access_matches_core=True
  ~/.../codex-home/auth.json               refresh_token=True   access_matches_core=False   <- drifted

AFTER
  ~/.codex/auth.json                       refresh_token=False  access_matches_core=True
  ~/.../codex-home/auth.json               refresh_token=False  access_matches_core=True

SECOND PASS
  Codex auth.json: mirrors already current
```

## Testing note

This failure needs a rotation cycle to appear, so a ten-minute smoke test proves nothing. The box should be left running overnight with a real ChatGPT sign-in before this is tagged and promoted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic Codex credential synchronization after gateway startup.
  * Credentials are mirrored to the user’s Codex configuration and agent environments every 10 minutes.
  * Synchronization tracks access-token updates while excluding refresh tokens for safer authentication handling.
  * Credential files use restricted permissions and recover from outdated or conflicting mirror data.

* **Bug Fixes**
  * Improved gateway startup behavior when credentials are unavailable or change over time.
  * Preserved existing API key configuration during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->