### PR TITLE
fix(codex): restore the credential #278 broke, and migrate legacy auth profiles

### DIFF
--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -101,15 +101,29 @@ function credentialFromProfiles(agentDir) {
   if (!profile || !profile.access) return null;
   return {
     accessToken: profile.access,
+    refreshToken: profile.refresh,
     idToken: profile.id || profile.access,
     accountId: accountIdFromAccessToken(profile.access),
   };
 }
 
 /**
- * Build the file contents. Deliberately no refresh_token — see the rule above.
- * An existing OPENAI_API_KEY is carried over: that is the API-key path, which
- * core reads from this same file and which has no rotation problem.
+ * Build the file contents.
+ *
+ * refresh_token IS included, and it has to be: core's readCodexCliCredentials()
+ * hard-rejects a credential without one --
+ *
+ *   if (typeof refreshToken !== "string" || !refreshToken) return null;
+ *
+ * -- and a null credential means the codex plugin attaches no auth at all
+ * (`profile=-` in the gateway log) and every turn dies on 401. An earlier
+ * attempt at this fix stripped the field and broke Codex exactly that way.
+ *
+ * Safety comes from WHERE it is written, not from omitting it: only
+ * ~/.codex/auth.json gets a credential, and nothing rotates that file. The
+ * codex plugin reads it and never writes it, and no process runs with
+ * CODEX_HOME=~/.codex. The file the Codex app-server *does* rotate is
+ * <agentDir>/codex-home/auth.json -- see the destination list in main().
  */
 function buildAuthFile(credential, existing) {
   return {
@@ -117,6 +131,7 @@ function buildAuthFile(credential, existing) {
     tokens: {
       id_token: credential.idToken,
       access_token: credential.accessToken,
+      refresh_token: credential.refreshToken,
       account_id: credential.accountId,
     },
     last_refresh: new Date().toISOString(),
@@ -124,15 +139,14 @@ function buildAuthFile(credential, existing) {
 }
 
 /**
- * Rewrite when the access token changed or a refresh_token is present (a
- * poisoned 3.1.11 mirror, or a stale copy). Returns a short reason for the log,
- * or null when the file was already correct.
+ * Rewrite whenever the file drifts from core's profile. Core is the only
+ * rotator, so "different from core" always means "stale copy", never "newer".
  */
 function syncReason(existing, credential) {
   if (!existing) return "created";
   const tokens = existing.tokens || {};
-  if (tokens.refresh_token) return "stripped refresh_token";
   if (tokens.access_token !== credential.accessToken) return "refreshed";
+  if (tokens.refresh_token !== credential.refreshToken) return "realigned";
   return null;
 }
 
@@ -175,19 +189,27 @@ function main() {
     return;
   }
 
-  const destinations = [
-    homeAuthPath,
-    ...agentDirs.map((dir) => path.join(dir, "codex-home", "auth.json")),
-  ];
-  let synced = 0;
-  for (const dest of destinations) {
-    const reason = writeMirror(dest, credential);
-    if (reason) {
-      synced += 1;
-      log(`Codex auth.json ${reason}: ${dest}`);
+  // ONLY ~/.codex/auth.json. The codex plugin reads it and never writes it,
+  // and nothing runs with CODEX_HOME=~/.codex, so this copy is never rotated.
+  const reason = writeMirror(homeAuthPath, credential);
+  if (reason) log(`Codex auth.json ${reason}: ${homeAuthPath}`);
+  else log("Codex auth.json: credential already current");
+
+  // <agentDir>/codex-home/auth.json is the file the Codex app-server rotates.
+  // A credential there is a second rotator against core's single-use refresh
+  // token and burns the whole family (401 refresh_token_reused). Core pushes
+  // the app-server its tokens over account/login/start, so the file is not
+  // needed -- remove any that 3.1.11 left behind.
+  for (const dir of agentDirs) {
+    const rotated = path.join(dir, "codex-home", "auth.json");
+    if (!fs.existsSync(rotated)) continue;
+    try {
+      fs.rmSync(rotated);
+      log(`Codex auth.json removed rotating copy: ${rotated}`);
+    } catch (error) {
+      log(`Codex auth.json: could not remove ${rotated}: ${error.message}`);
     }
   }
-  if (synced === 0) log("Codex auth.json: mirrors already current");
 }
 
 try {

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -635,6 +635,17 @@ fi
 # the API-key path, which core reads from this file and which has no rotation
 # problem.
 if [ "$NEEDS_CODEX_PLUGIN" = "1" ]; then
+  # Credentials written by the setup wizard can land only in the legacy
+  # <agentDir>/auth-profiles.json, while core 2026.7.x resolves auth from the
+  # auth_profile_store table of openclaw-agent.sqlite. When that happens core
+  # attaches no profile (`profile=-` in the log), sends no bearer, and every
+  # turn 401s while the UI still shows the provider as connected. Migrate
+  # first, so the mirror below reads a populated store.
+  AUTH_PROFILE_MIGRATION="${CLAWBOX_ROOT:-/home/clawbox/clawbox}/scripts/migrate-auth-profiles.js"
+  if [ -f "$AUTH_PROFILE_MIGRATION" ]; then
+    node "$AUTH_PROFILE_MIGRATION" "$OPENCLAW_HOME_DIR" || true
+  fi
+
   CODEX_AUTH_MIRROR="${CLAWBOX_ROOT:-/home/clawbox/clawbox}/scripts/codex-auth-mirror.js"
   if [ -f "$CODEX_AUTH_MIRROR" ]; then
     node "$CODEX_AUTH_MIRROR" "$OPENCLAW_HOME_DIR" "$HOME/.codex/auth.json" || true

--- a/scripts/migrate-auth-profiles.js
+++ b/scripts/migrate-auth-profiles.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Migrate legacy auth-profiles.json credentials into the sqlite auth profile
+ * store that OpenClaw core reads at runtime.
+ *
+ * WHY THIS EXISTS
+ *
+ * Auth profiles used to live in <agentDir>/auth-profiles.json. On core
+ * 2026.7.x they live in the auth_profile_store table of
+ * openclaw-agent.sqlite, and the JSON file is treated as legacy — core's own
+ * doctor offers to "Repair legacy auth-profiles.json files".
+ *
+ * A ClawBox that signs in through the setup wizard can still end up with the
+ * credential only in the JSON file. Core then resolves no auth profile for the
+ * model (`profile=-` in the gateway log), sends the request with no bearer, and
+ * every turn fails with 401 — while the UI cheerfully shows the provider as
+ * connected, because the JSON file is there.
+ *
+ * Seen on a factory-fresh box on 2026-07-28: auth-profiles.json held
+ * codex:default, llamacpp:default and deepseek:default; auth_profile_store had
+ * ZERO rows. Migrating the three across moved codex from 401 to a real API
+ * response.
+ *
+ * Copy-don't-move: the JSON file is left untouched so a core downgrade still
+ * finds it, and existing sqlite entries always win (they are the live ones).
+ *
+ * Exit code is always 0 — this must never block the gateway from starting.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+
+const openclawHome =
+  process.argv[2] || process.env.OPENCLAW_HOME_DIR || path.join(os.homedir(), ".openclaw");
+const quiet = process.env.MIGRATE_AUTH_PROFILES_QUIET === "1";
+
+function log(message) {
+  if (!quiet) console.log("  " + message);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function migrateAgent(agentDir) {
+  const legacy = readJson(path.join(agentDir, "auth-profiles.json"));
+  const legacyProfiles = (legacy && legacy.profiles) || null;
+  if (!legacyProfiles || Object.keys(legacyProfiles).length === 0) return null;
+
+  const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
+  if (!fs.existsSync(dbPath)) return null;
+
+  const { DatabaseSync } = require("node:sqlite");
+  const db = new DatabaseSync(dbPath);
+  try {
+    const row = db
+      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+      .get("primary");
+    const store = row && row.store_json ? JSON.parse(row.store_json) : {};
+    store.profiles = store.profiles || {};
+
+    const migrated = [];
+    for (const [id, profile] of Object.entries(legacyProfiles)) {
+      // Never clobber: whatever core already has is the live credential.
+      if (store.profiles[id]) continue;
+      store.profiles[id] = profile;
+      migrated.push(id);
+    }
+    if (migrated.length === 0) return null;
+
+    // updated_at is NOT NULL in this table.
+    const now = Date.now();
+    if (row) {
+      db.prepare(
+        "UPDATE auth_profile_store SET store_json = ?, updated_at = ? WHERE store_key = ?",
+      ).run(JSON.stringify(store), now, "primary");
+    } else {
+      db.prepare(
+        "INSERT INTO auth_profile_store (store_key, store_json, updated_at) VALUES (?, ?, ?)",
+      ).run("primary", JSON.stringify(store), now);
+    }
+    return migrated;
+  } finally {
+    db.close();
+  }
+}
+
+function main() {
+  const agentsRoot = path.join(openclawHome, "agents");
+  if (!fs.existsSync(agentsRoot)) return;
+
+  let total = 0;
+  for (const id of fs.readdirSync(agentsRoot)) {
+    const agentDir = path.join(agentsRoot, id, "agent");
+    if (!fs.existsSync(agentDir)) continue;
+    let migrated = null;
+    try {
+      migrated = migrateAgent(agentDir);
+    } catch (error) {
+      // DB locked mid-write, missing node:sqlite, table absent — all non-fatal.
+      log(`auth profiles: ${id}: ${error.message}`);
+      continue;
+    }
+    if (migrated) {
+      total += migrated.length;
+      log(`auth profiles migrated to sqlite (${id}): ${migrated.join(", ")}`);
+    }
+  }
+  if (total === 0) log("auth profiles: sqlite store already current");
+}
+
+try {
+  main();
+} catch (error) {
+  log("auth profiles: " + error.message);
+}

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -36,7 +36,7 @@ let agentDir: string;
 let homeAuthPath: string;
 let codexHomeAuthPath: string;
 
-function seedProfile(access: string, refresh = "refresh-secret") {
+function seedProfile(access: string, refresh: string = "refresh-secret") {
   writeFileSync(
     path.join(agentDir, "auth-profiles.json"),
     JSON.stringify({
@@ -67,38 +67,34 @@ afterEach(() => {
 });
 
 describe("codex-auth-mirror.js", () => {
-  it("never writes a refresh_token into any mirror", () => {
+  it("keeps the refresh_token — core's credential reader hard-rejects without it", () => {
+    // core: readCodexCliCredentials()
+    //   if (typeof refreshToken !== "string" || !refreshToken) return null;
+    // A null credential means the codex plugin attaches no auth (`profile=-`
+    // in the gateway log) and every turn dies on 401. Stripping this field is
+    // exactly how the first attempt at the rotation fix broke Codex.
     seedProfile(accessToken("acct-1"));
     run();
 
-    for (const file of [homeAuthPath, codexHomeAuthPath]) {
-      const parsed = JSON.parse(readFileSync(file, "utf-8"));
-      expect(parsed.tokens.refresh_token).toBeUndefined();
-      // The whole serialized file, so a refresh token can't sneak in elsewhere.
-      expect(readFileSync(file, "utf-8")).not.toContain("refresh-secret");
-    }
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.refresh_token).toBe("refresh-secret");
+    expect(parsed.tokens.access_token).toBe(accessToken("acct-1"));
   });
 
-  it("mirrors the access token and account id the runtime needs", () => {
-    seedProfile(accessToken("acct-42"));
-    run();
-
-    const parsed = JSON.parse(readFileSync(codexHomeAuthPath, "utf-8"));
-    expect(parsed.tokens.access_token).toBe(accessToken("acct-42"));
-    expect(parsed.tokens.account_id).toBe("acct-42");
-    expect(parsed.tokens.id_token).toBe("id-token");
-  });
-
-  it("writes to CODEX_HOME as well as ~/.codex — the app-server only reads the former", () => {
+  it("never writes the copy the Codex app-server rotates", () => {
+    // <agentDir>/codex-home/auth.json is CODEX_HOME for the app-server, which
+    // rotates whatever credential it finds there. A refresh token in that file
+    // is a second rotator against core's single-use token and burns the whole
+    // family (401 refresh_token_reused). Core pushes the app-server its tokens
+    // over account/login/start, so the file is not needed at all.
     seedProfile(accessToken("acct-1"));
     run();
 
     expect(existsSync(homeAuthPath)).toBe(true);
-    expect(existsSync(codexHomeAuthPath)).toBe(true);
+    expect(existsSync(codexHomeAuthPath)).toBe(false);
   });
 
-  it("self-heals a mirror poisoned by 3.1.11", () => {
-    // Exactly what 3.1.11 left on disk: a mirror carrying the refresh token.
+  it("removes a rotating copy left behind by 3.1.11", () => {
     mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
     writeFileSync(
       codexHomeAuthPath,
@@ -115,31 +111,51 @@ describe("codex-auth-mirror.js", () => {
 
     const out = run();
 
-    const parsed = JSON.parse(readFileSync(codexHomeAuthPath, "utf-8"));
-    expect(parsed.tokens.refresh_token).toBeUndefined();
-    expect(out).toContain("stripped refresh_token");
+    expect(existsSync(codexHomeAuthPath)).toBe(false);
+    expect(out).toContain("removed rotating copy");
   });
 
-  it("refreshes a stale mirror when core has rotated the access token", () => {
+  it("mirrors the access token and account id the runtime needs", () => {
+    seedProfile(accessToken("acct-42"));
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.access_token).toBe(accessToken("acct-42"));
+    expect(parsed.tokens.account_id).toBe("acct-42");
+    expect(parsed.tokens.id_token).toBe("id-token");
+  });
+
+  it("refreshes a stale credential when core has rotated the access token", () => {
     seedProfile(accessToken("acct-1", "old"));
     run();
-    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.access_token)
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.access_token)
       .toBe(accessToken("acct-1", "old"));
 
     // Core rotated; the timer runs again.
     seedProfile(accessToken("acct-1", "new"));
     const out = run();
 
-    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.access_token)
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.access_token)
       .toBe(accessToken("acct-1", "new"));
     expect(out).toContain("refreshed");
+  });
+
+  it("realigns when only the refresh token drifted", () => {
+    seedProfile(accessToken("acct-1"), "refresh-old");
+    run();
+    seedProfile(accessToken("acct-1"), "refresh-new");
+    const out = run();
+
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-new");
+    expect(out).toContain("realigned");
   });
 
   it("is idempotent — a second run with no rotation rewrites nothing", () => {
     seedProfile(accessToken("acct-1"));
     run();
     const out = run();
-    expect(out).toContain("mirrors already current");
+    expect(out).toContain("credential already current");
   });
 
   it("preserves a user's OPENAI_API_KEY — that path has no rotation problem", () => {
@@ -158,10 +174,8 @@ describe("codex-auth-mirror.js", () => {
     seedProfile(accessToken("acct-1"));
     run();
 
-    for (const file of [homeAuthPath, codexHomeAuthPath]) {
-      expect(statSync(file).mode & 0o777).toBe(0o600);
-      expect(statSync(path.dirname(file)).mode & 0o777).toBe(0o700);
-    }
+    expect(statSync(homeAuthPath).mode & 0o777).toBe(0o600);
+    expect(statSync(path.dirname(homeAuthPath)).mode & 0o777).toBe(0o700);
   });
 
   it("exits cleanly before login instead of blocking gateway start", () => {
@@ -193,22 +207,21 @@ describe("codex-auth-mirror.js", () => {
 
     run();
 
-    const parsed = JSON.parse(readFileSync(codexHomeAuthPath, "utf-8"));
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
     expect(parsed.tokens.access_token).toBe(accessToken("acct-sqlite"));
     expect(parsed.tokens.account_id).toBe("acct-sqlite");
-    expect(parsed.tokens.refresh_token).toBeUndefined();
-    expect(readFileSync(codexHomeAuthPath, "utf-8")).not.toContain("refresh-secret");
+    expect(parsed.tokens.refresh_token).toBe("refresh-secret");
   });
 
-  it("mirrors into every agent, not just main", () => {
+  it("clears rotating copies for every agent, not just main", () => {
     const second = path.join(openclawHome, "agents", "support", "agent");
-    mkdirSync(second, { recursive: true });
+    const secondRotating = path.join(second, "codex-home", "auth.json");
+    mkdirSync(path.dirname(secondRotating), { recursive: true });
+    writeFileSync(secondRotating, JSON.stringify({ tokens: { refresh_token: "x" } }));
     seedProfile(accessToken("acct-1"));
     run();
 
-    const secondMirror = path.join(second, "codex-home", "auth.json");
-    expect(existsSync(secondMirror)).toBe(true);
-    expect(JSON.parse(readFileSync(secondMirror, "utf-8")).tokens.refresh_token).toBeUndefined();
+    expect(existsSync(secondRotating)).toBe(false);
   });
 });
 
@@ -218,7 +231,7 @@ describe("gateway-pre-start.sh wiring", () => {
   it("delegates to the mirror script instead of inlining a credential writer", () => {
     const src = readFileSync(PRE_START, "utf-8");
     expect(src).toContain("scripts/codex-auth-mirror.js");
-    // The inline heredoc that planted refresh tokens must be gone for good.
-    expect(src).not.toMatch(/refresh_token:\s*p\.refresh/);
+    // The inline heredoc that mirrored into every codex-home must stay gone.
+    expect(src).not.toMatch(/codex-home", "auth\.json"/);
   });
 });

--- a/src/tests/unit/migrate-auth-profiles.test.ts
+++ b/src/tests/unit/migrate-auth-profiles.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { DatabaseSync } from "node:sqlite";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// scripts/migrate-auth-profiles.js copies credentials out of the legacy
+// <agentDir>/auth-profiles.json into the sqlite auth_profile_store that core
+// 2026.7.x actually reads at runtime.
+//
+// Without it a box can show a provider as "connected" in the UI (the JSON file
+// exists) while core resolves no auth profile at all — `profile=-` in the
+// gateway log — and every turn fails with 401. Observed on a factory-fresh box
+// on 2026-07-28: three profiles in JSON, zero rows in sqlite.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/migrate-auth-profiles.js");
+
+let home: string;
+let openclawHome: string;
+let agentDir: string;
+let dbPath: string;
+
+function createDb(seedProfiles?: Record<string, unknown>) {
+  const db = new DatabaseSync(dbPath);
+  db.exec(
+    "CREATE TABLE auth_profile_store (store_key TEXT NOT NULL PRIMARY KEY, store_json TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+  );
+  if (seedProfiles) {
+    db.prepare(
+      "INSERT INTO auth_profile_store (store_key, store_json, updated_at) VALUES (?, ?, ?)",
+    ).run("primary", JSON.stringify({ profiles: seedProfiles }), 1);
+  }
+  db.close();
+}
+
+function readStore(): Record<string, any> {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  const row = db
+    .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+    .get("primary") as { store_json?: string } | undefined;
+  db.close();
+  return row?.store_json ? JSON.parse(row.store_json).profiles ?? {} : {};
+}
+
+function seedLegacy(profiles: Record<string, unknown>) {
+  writeFileSync(path.join(agentDir, "auth-profiles.json"), JSON.stringify({ profiles }));
+}
+
+function run(): string {
+  return execFileSync("node", [SCRIPT, openclawHome], { encoding: "utf-8" });
+}
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "migrate-auth-profiles-"));
+  openclawHome = path.join(home, ".openclaw");
+  agentDir = path.join(openclawHome, "agents", "main", "agent");
+  mkdirSync(agentDir, { recursive: true });
+  dbPath = path.join(agentDir, "openclaw-agent.sqlite");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("migrate-auth-profiles.js", () => {
+  it("migrates legacy profiles into an empty sqlite store", () => {
+    createDb();
+    seedLegacy({
+      "codex:default": { provider: "codex", access: "a", refresh: "r" },
+      "deepseek:default": { provider: "deepseek", key: "k" },
+    });
+
+    const out = run();
+
+    expect(Object.keys(readStore()).sort()).toEqual(["codex:default", "deepseek:default"]);
+    expect(out).toContain("auth profiles migrated to sqlite");
+  });
+
+  it("creates the store row when the table is empty", () => {
+    createDb(); // table exists, zero rows — exactly what the broken box had
+    seedLegacy({ "codex:default": { provider: "codex", access: "a", refresh: "r" } });
+
+    run();
+
+    expect(readStore()["codex:default"]).toEqual({ provider: "codex", access: "a", refresh: "r" });
+  });
+
+  it("never clobbers a profile core already has", () => {
+    createDb({ "codex:default": { provider: "codex", access: "LIVE", refresh: "LIVE" } });
+    seedLegacy({ "codex:default": { provider: "codex", access: "STALE", refresh: "STALE" } });
+
+    run();
+
+    expect(readStore()["codex:default"].access).toBe("LIVE");
+  });
+
+  it("leaves the legacy file in place so a core downgrade still finds it", () => {
+    createDb();
+    seedLegacy({ "codex:default": { provider: "codex", access: "a", refresh: "r" } });
+
+    run();
+
+    const legacy = path.join(agentDir, "auth-profiles.json");
+    expect(existsSync(legacy)).toBe(true);
+    expect(JSON.parse(readFileSync(legacy, "utf-8")).profiles["codex:default"]).toBeDefined();
+  });
+
+  it("is idempotent", () => {
+    createDb();
+    seedLegacy({ "codex:default": { provider: "codex", access: "a", refresh: "r" } });
+    run();
+
+    const out = run();
+
+    expect(out).toContain("sqlite store already current");
+  });
+
+  it("migrates every agent", () => {
+    createDb();
+    seedLegacy({ "codex:default": { provider: "codex", access: "a", refresh: "r" } });
+    const second = path.join(openclawHome, "agents", "support", "agent");
+    mkdirSync(second, { recursive: true });
+    const secondDb = new DatabaseSync(path.join(second, "openclaw-agent.sqlite"));
+    secondDb.exec(
+      "CREATE TABLE auth_profile_store (store_key TEXT NOT NULL PRIMARY KEY, store_json TEXT NOT NULL, updated_at INTEGER NOT NULL)",
+    );
+    secondDb.close();
+    writeFileSync(
+      path.join(second, "auth-profiles.json"),
+      JSON.stringify({ profiles: { "deepseek:default": { provider: "deepseek", key: "k" } } }),
+    );
+
+    const out = run();
+
+    expect(out).toContain("(main)");
+    expect(out).toContain("(support)");
+  });
+
+  it("exits cleanly with no legacy file at all", () => {
+    createDb();
+    const out = run();
+    expect(out).toContain("sqlite store already current");
+  });
+
+  it("does not blow up when the database is missing", () => {
+    seedLegacy({ "codex:default": { provider: "codex", access: "a", refresh: "r" } });
+    expect(() => run()).not.toThrow();
+  });
+});
+
+describe("gateway-pre-start.sh wiring", () => {
+  it("runs the migration before the credential mirror", () => {
+    const src = readFileSync(
+      path.resolve(process.cwd(), "scripts/gateway-pre-start.sh"),
+      "utf-8",
+    );
+    const migration = src.indexOf("scripts/migrate-auth-profiles.js");
+    const mirror = src.indexOf("scripts/codex-auth-mirror.js");
+    expect(migration).toBeGreaterThan(-1);
+    // The mirror reads the profile store, so the migration has to populate it first.
+    expect(migration).toBeLessThan(mirror);
+  });
+});


### PR DESCRIPTION
Two fixes for the same symptom: a box signed in with ChatGPT where core attaches **no auth at all** (`profile=-` in the gateway log) and every turn 401s — while the UI still shows the provider as connected.

## 1. #278 stripped a field core requires

`readCodexCliCredentials()` in core hard-rejects a credential without a refresh token:

```js
if (typeof refreshToken !== "string" || !refreshToken) return null;
```

A `null` credential means the codex plugin attaches nothing. **#278 was right about the danger and wrong about the remedy** — safety comes from *where* the credential is written, not from omitting the field.

| File | Read by | Rotated by | Now |
|---|---|---|---|
| `~/.codex/auth.json` | codex plugin | **nothing** | written, **with** refresh token |
| `<agent>/codex-home/auth.json` | Codex app-server | **the app-server** | **not written; deleted if present** |

Core pushes the app-server its tokens over `account/login/start`, so that second file was never needed. Still exactly one rotator, so the original `401 refresh_token_reused` burn stays fixed.

## 2. Credentials landing in the legacy store

The setup wizard can leave the credential only in `<agentDir>/auth-profiles.json`, while core 2026.7.x resolves auth from the `auth_profile_store` table of `openclaw-agent.sqlite`. Core itself calls the JSON file legacy ("Repair legacy auth-profiles.json files").

On a factory-fresh box on 2026-07-28: **three profiles in JSON, zero rows in sqlite.**

`scripts/migrate-auth-profiles.js` copies them across on every gateway start, before the mirror runs so it reads a populated store. Copy-don't-move (a core downgrade still finds the JSON) and never-clobber (anything already in sqlite is the live credential and wins).

## Verification

**Live box:** with both applied the gateway went from `profile=-` to `profile=sha256:6be7b650…` — auth resolves and is attached. Both scripts re-run as clean no-ops on an already-correct box.

**Tests:** 13 rewritten mirror tests (refresh token present, rotating copy never written, 3.1.11 leftovers removed, sqlite path, idempotence, perms) + 9 new migration tests. **Full suite 1490 passed / 124 files.**

## Known remaining failure — not this PR, not our code

Codex still fails afterwards. Core sends the request to `https://chatgpt.com/backend-api/responses`, a browser endpoint Cloudflare managed-challenges, instead of `/backend-api/codex/responses`. Proven from the box with its own token, same second:

```
/backend-api/responses         403  Cloudflare challenge page
/backend-api/codex/responses   400  {"detail":"Input must be a list"}   <- auth accepted
```

Not fixable here: overriding `models.providers.codex.baseUrl` corrects the URL but then the payload shape is wrong (`reason=format`). ⚠️ **Do not tag 3.1.11** — codex is broken for ChatGPT users regardless of our code, and a tag reaches the whole fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)