### PR TITLE
fix(codex): route codex turns through the app-server harness so they work

### DIFF
--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -165,6 +165,85 @@ function writeMirror(dest, credential) {
   return reason;
 }
 
+
+/**
+ * Collapse destinations that resolve to the same file. <agentDir>/codex-home
+ * is sometimes a symlink to ~/.codex; without this the same file gets written
+ * twice, and a previous version deleted the real credential through the link.
+ */
+function dedupePaths(files) {
+  const seen = new Map();
+  for (const file of files) {
+    let key = file;
+    try {
+      key = path.join(fs.realpathSync.native(path.dirname(file)), path.basename(file));
+    } catch {
+      // Directory doesn't exist yet — the raw path is unique enough.
+    }
+    if (!seen.has(key)) seen.set(key, file);
+  }
+  return [...seen.values()];
+}
+
+/**
+ * Write an app-server rotation back into core's auth profile store, so core
+ * stops handing out a refresh token that has already been spent.
+ */
+function writeBackToCore(agentDirs, tokens) {
+  if (!tokens || !tokens.refresh_token) return false;
+  let wrote = false;
+
+  // Legacy JSON store, still the source on some boxes.
+  for (const agentDir of agentDirs) {
+    const jsonPath = path.join(agentDir, "auth-profiles.json");
+    const data = readJson(jsonPath);
+    const profiles = data && data.profiles;
+    if (!profiles) continue;
+    const id = profiles["codex:default"] ? "codex:default" : "openai-codex:default";
+    if (!profiles[id]) continue;
+    profiles[id].access = tokens.access_token || profiles[id].access;
+    profiles[id].refresh = tokens.refresh_token;
+    if (tokens.id_token) profiles[id].id = tokens.id_token;
+    try {
+      fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+      wrote = true;
+    } catch {
+      // Non-fatal; the sqlite store below is the one core reads.
+    }
+  }
+
+  for (const agentDir of agentDirs) {
+    const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
+    if (!fs.existsSync(dbPath)) continue;
+    try {
+      const { DatabaseSync } = require("node:sqlite");
+      const db = new DatabaseSync(dbPath);
+      try {
+        const row = db
+          .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+          .get("primary");
+        if (!row || !row.store_json) continue;
+        const store = JSON.parse(row.store_json);
+        const profiles = store.profiles || {};
+        const id = profiles["codex:default"] ? "codex:default" : "openai-codex:default";
+        if (!profiles[id]) continue;
+        profiles[id].access = tokens.access_token || profiles[id].access;
+        profiles[id].refresh = tokens.refresh_token;
+        if (tokens.id_token) profiles[id].id = tokens.id_token;
+        store.profiles = profiles;
+        db.prepare("UPDATE auth_profile_store SET store_json = ?, updated_at = ? WHERE store_key = ?")
+          .run(JSON.stringify(store), Date.now(), "primary");
+        wrote = true;
+      } finally {
+        db.close();
+      }
+    } catch {
+      // Locked or unavailable — the next timer tick retries.
+    }
+  }
+  return wrote;
+}
+
 function main() {
   const agentsRoot = path.join(openclawHome, "agents");
   const agentDirs = fs.existsSync(agentsRoot)
@@ -189,27 +268,56 @@ function main() {
     return;
   }
 
-  // ONLY ~/.codex/auth.json. The codex plugin reads it and never writes it,
-  // and nothing runs with CODEX_HOME=~/.codex, so this copy is never rotated.
-  const reason = writeMirror(homeAuthPath, credential);
-  if (reason) log(`Codex auth.json ${reason}: ${homeAuthPath}`);
-  else log("Codex auth.json: credential already current");
+  // Both locations are required:
+  //   ~/.codex/auth.json              - read by the codex plugin
+  //   <agentDir>/codex-home/auth.json - CODEX_HOME for the Codex app-server,
+  //                                     the only path that addresses the real
+  //                                     Codex API correctly
+  // An earlier attempt deleted the second one; the app-server then had no
+  // credential, codex fell back to core's HTTP transport, and every turn hit a
+  // Cloudflare-challenged browser endpoint. See #280.
+  const destinations = dedupePaths([
+    homeAuthPath,
+    ...agentDirs.map((dir) => path.join(dir, "codex-home", "auth.json")),
+  ]);
 
-  // <agentDir>/codex-home/auth.json is the file the Codex app-server rotates.
-  // A credential there is a second rotator against core's single-use refresh
-  // token and burns the whole family (401 refresh_token_reused). Core pushes
-  // the app-server its tokens over account/login/start, so the file is not
-  // needed -- remove any that 3.1.11 left behind.
-  for (const dir of agentDirs) {
-    const rotated = path.join(dir, "codex-home", "auth.json");
-    if (!fs.existsSync(rotated)) continue;
-    try {
-      fs.rmSync(rotated);
-      log(`Codex auth.json removed rotating copy: ${rotated}`);
-    } catch (error) {
-      log(`Codex auth.json: could not remove ${rotated}: ${error.message}`);
+  // The app-server rotates its own CODEX_HOME credential. Refresh tokens are
+  // single-use, so if it has already rotated, core's stored copy is the DEAD
+  // one -- overwriting the file with it would burn the family on next use.
+  // Core follows the app-server, never the other way round.
+  const rotated = destinations
+    .map((dest) => ({ dest, data: readJson(dest) }))
+    .find(({ data }) => {
+      const tokens = (data && data.tokens) || {};
+      return (
+        typeof tokens.refresh_token === "string" &&
+        tokens.refresh_token &&
+        tokens.refresh_token !== credential.refreshToken
+      );
+    });
+
+  if (rotated) {
+    const tokens = rotated.data.tokens;
+    if (writeBackToCore(agentDirs, tokens)) {
+      log(`Codex auth.json: adopted app-server rotation from ${rotated.dest}`);
+      credential = {
+        accessToken: tokens.access_token || credential.accessToken,
+        refreshToken: tokens.refresh_token,
+        idToken: tokens.id_token || credential.idToken,
+        accountId: tokens.account_id || credential.accountId,
+      };
     }
   }
+
+  let synced = 0;
+  for (const dest of destinations) {
+    const reason = writeMirror(dest, credential);
+    if (reason) {
+      synced += 1;
+      log(`Codex auth.json ${reason}: ${dest}`);
+    }
+  }
+  if (synced === 0) log("Codex auth.json: credential already current");
 }
 
 try {

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -221,18 +221,62 @@ if _has_codex_oauth_profile() and not _has_openai_api_key_profile():
                 _fallbacks[_i] = _migrated_fb
                 changed = True
 
-# Strip orphaned per-model keys that a newer-than-pinned plugin wrote and a
-# version downgrade left behind, which fail strict config validation and
-# brick the AI provider page until `openclaw doctor --fix`. `agentRuntime`
-# is written by @openclaw/codex >= 2026.5.27 into agents.defaults.models[*];
-# when the plugin is realigned to the pinned core (< that version) the key is
-# orphaned. Drop it on every gateway start so affected devices self-heal.
+# agentRuntime routing for codex models.
+#
+# `agents.defaults.models["codex/*"].agentRuntime = {"id": "codex"}` is what
+# sends a codex turn through the Codex app-server harness. WITHOUT it core
+# falls back to its generic HTTP responses transport, which posts to
+# https://chatgpt.com/backend-api/responses -- a browser endpoint Cloudflare
+# managed-challenges -- and every turn dies with "the provider returned an HTML
+# error page". The real Codex API is /backend-api/codex/responses, and only the
+# app-server addresses it correctly. Proven on a live box 2026-07-28: with the
+# key, `CODEX OK`; remove the key, restart, same box, HTML challenge. See #280.
+#
+# ClawBox used to delete this key unconditionally, because
+# @openclaw/codex >= 2026.5.27 writes it and an older *pinned* core rejected it
+# in strict config validation, bricking the AI provider page. That is still
+# worth guarding, so the strip is kept for everything that is NOT a codex
+# model -- an orphaned agentRuntime on some other provider has no purpose.
+#
+# Also seed the entry for any codex model the box is actually configured to
+# use, so picking one in the UI works after the next gateway start rather than
+# needing the key added by hand.
 agents_models = agents_defaults.get("models")
-if isinstance(agents_models, dict):
-    for _model_key, _model_val in agents_models.items():
-        if isinstance(_model_val, dict) and "agentRuntime" in _model_val:
-            del _model_val["agentRuntime"]
-            changed = True
+if not isinstance(agents_models, dict):
+    agents_models = {}
+
+def _is_codex_ref(model_id):
+    return isinstance(model_id, str) and model_id.strip().lower().startswith("codex/")
+
+_codex_refs = set()
+if _is_codex_ref(model_defaults.get("primary")):
+    _codex_refs.add(model_defaults["primary"].strip())
+for _fb in model_defaults.get("fallbacks") or []:
+    if _is_codex_ref(_fb):
+        _codex_refs.add(_fb.strip())
+for _model_key in list(agents_models.keys()):
+    if _is_codex_ref(_model_key):
+        _codex_refs.add(_model_key)
+
+for _model_key, _model_val in list(agents_models.items()):
+    if not isinstance(_model_val, dict):
+        continue
+    if not _is_codex_ref(_model_key) and "agentRuntime" in _model_val:
+        del _model_val["agentRuntime"]
+        changed = True
+
+for _ref in sorted(_codex_refs):
+    _entry = agents_models.get(_ref)
+    if not isinstance(_entry, dict):
+        _entry = {}
+        agents_models[_ref] = _entry
+        changed = True
+    if _entry.get("agentRuntime") != {"id": "codex"}:
+        _entry["agentRuntime"] = {"id": "codex"}
+        changed = True
+
+if _codex_refs or agents_models:
+    agents_defaults["models"] = agents_models
 
 # Security migration: older ClawBox versions silently wrote
 # channels.telegram.dmPolicy="open" + allowFrom=["*"] at bot-token setup,

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -521,6 +521,22 @@ export async function POST(request: Request) {
     //    gateway reloads concurrently with the write.
     await runOpenclawConfigSet(["agents.defaults.model.primary", targetModel]);
 
+    // 1b. Codex turns only work through the Codex app-server harness, which is
+    //     selected by agentRuntime. Without it core uses its generic HTTP
+    //     responses transport, which posts to
+    //     https://chatgpt.com/backend-api/responses — a browser endpoint
+    //     Cloudflare managed-challenges — and every turn fails with "the
+    //     provider returned an HTML error page". gateway-pre-start.sh sets this
+    //     too, but a model change applies WITHOUT a restart, so picking Codex
+    //     here has to arm the runtime immediately or the very next message
+    //     fails until the box is rebooted.
+    if (targetModel.toLowerCase().startsWith("codex/")) {
+      await runOpenclawConfigSet([
+        `agents.defaults.models.${targetModel}.agentRuntime.id`,
+        "codex",
+      ]);
+    }
+
     // 2. Full sweep including sessions previously tagged
     //    `modelOverrideSource: "user"` — the dropdown click *is* the
     //    user's current pick, so prior tags shouldn't make repeat

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -254,6 +254,19 @@ describe("/setup-api/chat/model", () => {
     expect(body.activeLabel).toBe("Gemma 4 Local");
   });
 
+  it("does not arm the Codex runtime for a non-Codex model", async () => {
+    await POST(new Request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "llamacpp/gemma4-e2b-it-q4_0" }),
+    }));
+
+    const armed = vi.mocked(runOpenclawConfigSet).mock.calls.some(
+      ([args]) => Array.isArray(args) && String(args[0]).includes("agentRuntime"),
+    );
+    expect(armed).toBe(false);
+  });
+
   it("switches back to the stored primary provider model", async () => {
     vi.mocked(getAll).mockResolvedValue({
       ai_model_provider: "clawai",

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -81,38 +81,59 @@ describe("codex-auth-mirror.js", () => {
     expect(parsed.tokens.access_token).toBe(accessToken("acct-1"));
   });
 
-  it("never writes the copy the Codex app-server rotates", () => {
-    // <agentDir>/codex-home/auth.json is CODEX_HOME for the app-server, which
-    // rotates whatever credential it finds there. A refresh token in that file
-    // is a second rotator against core's single-use token and burns the whole
-    // family (401 refresh_token_reused). Core pushes the app-server its tokens
-    // over account/login/start, so the file is not needed at all.
+  it("writes CODEX_HOME too — the app-server is the only correct API path", () => {
+    // Without a credential in <agentDir>/codex-home the app-server can't run,
+    // codex falls back to core's HTTP transport, and that posts to a
+    // Cloudflare-challenged browser endpoint.
     seedProfile(accessToken("acct-1"));
     run();
 
     expect(existsSync(homeAuthPath)).toBe(true);
-    expect(existsSync(codexHomeAuthPath)).toBe(false);
+    expect(existsSync(codexHomeAuthPath)).toBe(true);
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-secret");
   });
 
-  it("removes a rotating copy left behind by 3.1.11", () => {
+  it("adopts an app-server rotation instead of overwriting it with a spent token", () => {
+    // The app-server rotated its CODEX_HOME credential. Refresh tokens are
+    // single-use, so core's stored copy is now the DEAD one — writing it back
+    // over the file would burn the family on next use.
     mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
     writeFileSync(
       codexHomeAuthPath,
       JSON.stringify({
         OPENAI_API_KEY: null,
         tokens: {
-          access_token: accessToken("acct-1"),
-          refresh_token: "poisoned-rotating-token",
+          access_token: accessToken("acct-1", "rotated"),
+          refresh_token: "refresh-rotated-by-appserver",
           account_id: "acct-1",
         },
       }),
     );
-    seedProfile(accessToken("acct-1"));
+    seedProfile(accessToken("acct-1", "old"), "refresh-spent");
 
     const out = run();
 
-    expect(existsSync(codexHomeAuthPath)).toBe(false);
-    expect(out).toContain("removed rotating copy");
+    expect(out).toContain("adopted app-server rotation");
+    // The rotated token survives everywhere, including core's own store.
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-rotated-by-appserver");
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-rotated-by-appserver");
+  });
+
+  it("does not write the same file twice when codex-home is a symlink to ~/.codex", () => {
+    // A previous version resolved both destinations to one file and then
+    // deleted the real credential through the link.
+    mkdirSync(path.dirname(homeAuthPath), { recursive: true });
+    symlinkSync(path.dirname(homeAuthPath), path.join(agentDir, "codex-home"));
+    seedProfile(accessToken("acct-1"));
+
+    run();
+
+    expect(existsSync(homeAuthPath)).toBe(true);
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.access_token)
+      .toBe(accessToken("acct-1"));
   });
 
   it("mirrors the access token and account id the runtime needs", () => {
@@ -140,15 +161,22 @@ describe("codex-auth-mirror.js", () => {
     expect(out).toContain("refreshed");
   });
 
-  it("realigns when only the refresh token drifted", () => {
-    seedProfile(accessToken("acct-1"), "refresh-old");
+  it("never clobbers a drifted file with core's copy — the file is the newer one", () => {
+    // Only the app-server rotates, so a refresh token that differs from core's
+    // means the app-server moved on and core's copy is spent. Writing core's
+    // value back over the file would hand a dead token to the next request.
+    seedProfile(accessToken("acct-1"), "refresh-from-appserver");
     run();
-    seedProfile(accessToken("acct-1"), "refresh-new");
-    const out = run();
+    seedProfile(accessToken("acct-1"), "refresh-spent");
+    run();
 
     expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token)
-      .toBe("refresh-new");
-    expect(out).toContain("realigned");
+      .toBe("refresh-from-appserver");
+    // ...and core has been realigned to it rather than the other way round.
+    const store = JSON.parse(
+      readFileSync(path.join(agentDir, "auth-profiles.json"), "utf-8"),
+    );
+    expect(store.profiles["codex:default"].refresh).toBe("refresh-from-appserver");
   });
 
   it("is idempotent — a second run with no rotation rewrites nothing", () => {
@@ -213,15 +241,13 @@ describe("codex-auth-mirror.js", () => {
     expect(parsed.tokens.refresh_token).toBe("refresh-secret");
   });
 
-  it("clears rotating copies for every agent, not just main", () => {
+  it("mirrors into every agent, not just main", () => {
     const second = path.join(openclawHome, "agents", "support", "agent");
-    const secondRotating = path.join(second, "codex-home", "auth.json");
-    mkdirSync(path.dirname(secondRotating), { recursive: true });
-    writeFileSync(secondRotating, JSON.stringify({ tokens: { refresh_token: "x" } }));
+    mkdirSync(second, { recursive: true });
     seedProfile(accessToken("acct-1"));
     run();
 
-    expect(existsSync(secondRotating)).toBe(false);
+    expect(existsSync(path.join(second, "codex-home", "auth.json"))).toBe(true);
   });
 });
 

--- a/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-runtime.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// `agents.defaults.models["codex/*"].agentRuntime = {"id":"codex"}` is what
+// routes a codex turn through the Codex app-server harness. WITHOUT it core
+// uses its generic HTTP responses transport, which posts to
+// https://chatgpt.com/backend-api/responses — a browser endpoint Cloudflare
+// managed-challenges — and every turn fails with "the provider returned an HTML
+// error page". Proven on a live box on 2026-07-28: with the key `CODEX OK`;
+// remove it, restart, same box, HTML challenge.
+//
+// ClawBox used to delete this key unconditionally (it broke strict validation
+// on an older pinned core). This exercises the real policy block out of the
+// shipped script so that deletion can never come back for codex models.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+/** Pull the agentRuntime policy block out of the .sh verbatim. */
+function extractPolicy(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf("agents_models = agents_defaults.get(\"models\")");
+  const end = src.indexOf("# Security migration:", start);
+  if (start < 0 || end < 0) throw new Error("agentRuntime policy block not found");
+  return src.slice(start, end);
+}
+
+const POLICY = hasPython3 ? extractPolicy() : "";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "codex-runtime-policy-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+/** Run the extracted policy against a config and return the resulting models map. */
+function applyPolicy(config: Record<string, any>): Record<string, any> {
+  const file = path.join(dir, "config.json");
+  writeFileSync(file, JSON.stringify(config));
+  const program = [
+    "import json, sys",
+    "cfg = json.load(open(sys.argv[1]))",
+    "changed = False",
+    "agents_defaults = cfg.setdefault('agents', {}).setdefault('defaults', {})",
+    "model_defaults = agents_defaults.setdefault('model', {})",
+    POLICY,
+    "print(json.dumps(agents_defaults.get('models') or {}))",
+  ].join("\n");
+  return JSON.parse(
+    execFileSync("python3", ["-c", program, file], { encoding: "utf-8" }).trim(),
+  );
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh agentRuntime policy", () => {
+  it("sets agentRuntime on the configured codex primary", () => {
+    const models = applyPolicy({
+      agents: { defaults: { model: { primary: "codex/gpt-5.5", fallbacks: [] } } },
+    });
+    expect(models["codex/gpt-5.5"].agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("sets agentRuntime on codex fallbacks too", () => {
+    const models = applyPolicy({
+      agents: {
+        defaults: {
+          model: { primary: "deepseek/deepseek-v4-flash", fallbacks: ["codex/gpt-5.5"] },
+        },
+      },
+    });
+    expect(models["codex/gpt-5.5"].agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("never strips agentRuntime from a codex model", () => {
+    const models = applyPolicy({
+      agents: {
+        defaults: {
+          model: { primary: "codex/gpt-5.5" },
+          models: { "codex/gpt-5.5": { agentRuntime: { id: "codex" } } },
+        },
+      },
+    });
+    expect(models["codex/gpt-5.5"].agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("repairs a codex entry whose agentRuntime was removed", () => {
+    const models = applyPolicy({
+      agents: {
+        defaults: {
+          model: { primary: "codex/gpt-5.5" },
+          models: { "codex/gpt-5.5": {} },
+        },
+      },
+    });
+    expect(models["codex/gpt-5.5"].agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("still strips an orphaned agentRuntime from a non-codex model", () => {
+    // The original reason the strip existed: a newer-than-pinned plugin wrote
+    // the key, a downgrade orphaned it, and strict validation bricked the page.
+    const models = applyPolicy({
+      agents: {
+        defaults: {
+          model: { primary: "deepseek/deepseek-v4-flash" },
+          models: { "deepseek/deepseek-v4-flash": { agentRuntime: { id: "codex" } } },
+        },
+      },
+    });
+    expect(models["deepseek/deepseek-v4-flash"].agentRuntime).toBeUndefined();
+  });
+
+  it("preserves other per-model settings while adding agentRuntime", () => {
+    const models = applyPolicy({
+      agents: {
+        defaults: {
+          model: { primary: "codex/gpt-5.5" },
+          models: { "codex/gpt-5.5": { params: { thinking: "high" } } },
+        },
+      },
+    });
+    expect(models["codex/gpt-5.5"].params).toEqual({ thinking: "high" });
+    expect(models["codex/gpt-5.5"].agentRuntime).toEqual({ id: "codex" });
+  });
+
+  it("does nothing when no codex model is configured", () => {
+    const models = applyPolicy({
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+    expect(models).toEqual({});
+  });
+});


### PR DESCRIPTION
Codex was unusable on a ChatGPT-subscription box — every turn failed with *"the provider returned an HTML error page instead of an API response"*.

## Root cause is ours

`agents.defaults.models["codex/*"].agentRuntime = {"id":"codex"}` is what sends a codex turn through the **Codex app-server harness**. `gateway-pre-start.sh` **deleted that key on every gateway start.**

Without it, core falls back to its generic HTTP responses transport, which posts to `https://chatgpt.com/backend-api/responses` — a *browser* endpoint Cloudflare managed-challenges. The real Codex API is `/backend-api/codex/responses`, and only the app-server addresses it correctly.

Proven on a live box, **same IP, same token, same second**:

```
/backend-api/responses         403  Cloudflare challenge page
/backend-api/codex/responses   400  {"detail":"Input must be a list"}   <- auth accepted
```

And end to end: with the key → `CODEX OK`. Remove it, restart, same box → HTML challenge.

This also retires the earlier "it's our office IP reputation" theory. It never was.

## Why the strip existed, and what replaces it

The unconditional delete guarded a real failure: `@openclaw/codex >= 2026.5.27` writes the key, and an older *pinned* core rejected it in strict validation, bricking the AI provider page. That guard is **kept for non-codex models**, where an orphaned `agentRuntime` has no purpose anyway.

## Changes

- **`gateway-pre-start.sh`** — set `agentRuntime={id:"codex"}` for every codex model the box actually uses (primary, fallbacks, existing entries); keep stripping it elsewhere.
- **`chat/model` route** — arm the runtime immediately when Codex is picked. A model change applies **without** a gateway restart, so otherwise the next message fails until reboot.
- **`codex-auth-mirror.js`** — write `<agentDir>/codex-home/auth.json` again; the app-server needs a credential in its `CODEX_HOME`, and #279 had removed it. Destinations are de-duplicated **by real path**, because `codex-home` is sometimes a symlink to `~/.codex` and the previous version deleted the real credential through the link.
- **`codex-auth-mirror.js`** — **adopt** an app-server rotation instead of overwriting it. Refresh tokens are single-use, so a file token differing from core's means the app-server rotated and core's copy is spent; the live one is written back into core's store. One effective rotator, without starving the app-server.

## Verification

**Live box, nothing hand-applied:** cleared the key, set the primary to `codex/gpt-5.5` exactly as the UI does, restarted — pre-start restored `agentRuntime` on its own and the agent turn returned **`CODEX OK`**. Repeated for consistency; also confirmed `codex-supervisor` is *not* required.

**Tests:** 7 new `agentRuntime` policy tests extracted from the shipped script (codex primary, codex fallbacks, repair of a stripped entry, non-codex still stripped, other per-model settings preserved) + updated mirror tests incl. symlink de-dup and rotation adoption. **Full suite 1499 passed / 125 files.**

**Coverage note:** the positive chat-route case is covered by the live verification and the pre-start tests; the route unit test here is the negative guard (non-codex models must not be armed) — building a codex option inside the route's mocked state proved brittle and I chose not to ship a test fighting its own mocks.

## Still open

Durability across a **token rotation cycle** is unproven — that needs hours, not minutes. The box should run overnight on a real ChatGPT login before 3.1.11 is tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)