### PR TITLE
OpenRouter: stop rejecting every free model id

### DIFF
--- a/src/lib/openrouter-models.ts
+++ b/src/lib/openrouter-models.ts
@@ -28,12 +28,21 @@ export const OPENROUTER_DEFAULT_MODEL_ID = "anthropic/claude-haiku-4.5";
 
 /**
  * OpenRouter slugs are structured `<org>/<model>` (sometimes with more
- * path segments). Validate the shape before we accept a user-supplied
- * custom model ID — stops empty strings, whitespace, and obvious typos
- * without getting in the way of legitimate rare slugs.
+ * path segments) and may carry ONE trailing `:variant` suffix. Validate
+ * the shape before we accept a user-supplied custom model ID — stops
+ * empty strings, whitespace, and obvious typos without getting in the
+ * way of legitimate rare slugs.
+ *
+ * The `:variant` part is not optional pedantry: every free model on
+ * OpenRouter is addressed as `<org>/<model>:free`, and routing variants
+ * (`:online`, `:extended`, `:nitro`, `:thinking`) use the same syntax.
+ * The original pattern's character class had no colon, so it rejected
+ * ALL of them — a user pasting the correct id for a free model got
+ * "invalid model id" from us, not from OpenRouter. Reported in Discord
+ * 2026-07-30 for `nvidia/nemotron-3-ultra-550b-a55b:free`.
  */
 const OPENROUTER_SLUG_RE =
-  /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)+$/i;
+  /^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)+(?::[a-z0-9][a-z0-9._-]*)?$/i;
 
 export function isValidOpenRouterModelId(id: string): boolean {
   return OPENROUTER_SLUG_RE.test(id.trim());

--- a/src/tests/unit/openrouter-models.test.ts
+++ b/src/tests/unit/openrouter-models.test.ts
@@ -33,6 +33,14 @@ describe("openrouter-models", () => {
       "meta-llama/llama-3.3-70b-instruct",
       "x-ai/grok-4-fast",
       "deepseek/deepseek-chat-v3.1",
+      // `:variant` suffixes — every FREE model on OpenRouter is addressed
+      // this way, and routing variants share the syntax. These were all
+      // rejected before the slug pattern learned about the colon.
+      "nvidia/nemotron-3-ultra-550b-a55b:free",
+      "qwen/qwen-2.5-vl-72b-instruct:free",
+      "perplexity/sonar:online",
+      "openai/gpt-4o:extended",
+      "meta-llama/llama-3.3-70b-instruct:nitro",
     ])("accepts valid slug %s", (slug) => {
       expect(isValidOpenRouterModelId(slug)).toBe(true);
     });
@@ -46,6 +54,11 @@ describe("openrouter-models", () => {
       "anthropic//claude",
       "anthropic/claude/",
       "org/model//variant",
+      // a colon is allowed, but only as ONE non-empty trailing variant
+      "anthropic/claude-haiku-4.5:",
+      "anthropic/claude-haiku-4.5:free:extra",
+      "anthropic:free",
+      "anthropic/claude haiku:free",
     ])("rejects invalid slug %s", (slug) => {
       expect(isValidOpenRouterModelId(slug)).toBe(false);
     });


### PR DESCRIPTION
## The bug

`OPENROUTER_SLUG_RE` in `src/lib/openrouter-models.ts` allowed `[a-z0-9._-]` and **no colon**:

```js
/^[a-z0-9][a-z0-9._-]*(?:\/[a-z0-9][a-z0-9._-]*)+$/i
```

**Every free model on OpenRouter is addressed as `<org>/<model>:free`.** So the practical effect was that **no free OpenRouter model could be configured on a ClawBox at all** — the user pastes the correct id, and *we* hand back "invalid model id". It reads like OpenRouter rejected it; it didn't.

Routing variants (`:online`, `:extended`, `:nitro`, `:thinking`) were broken identically.

Chain: `isValidModelId('openrouter', …)` → `isValidOpenRouterModelId()` → this regex.

## Reported

Discord, 2026-07-30, for `nvidia/nemotron-3-ultra-550b-a55b:free` — verified as the real, current id against `https://openrouter.ai/api/v1/models`. The user was told twice to check his id; his id was right.

## The fix

Allow exactly **one non-empty trailing `:variant`**. Everything the pattern was written to catch still fails, and the new tests add cases it never covered:

| now accepted | still rejected |
|---|---|
| `nvidia/nemotron-3-ultra-550b-a55b:free` | `anthropic/claude-haiku-4.5:` (bare colon) |
| `qwen/qwen-2.5-vl-72b-instruct:free` | `anthropic/claude-haiku-4.5:free:extra` |
| `perplexity/sonar:online` | `anthropic:free` (no slash) |
| `openai/gpt-4o:extended` | `anthropic/claude haiku:free` (whitespace) |
| `meta-llama/llama-3.3-70b-instruct:nitro` | empty, `/leading`, `trailing/`, `a//b` |

## Tests

`openrouter-models.test.ts` 30 pass; full unit suite **810 pass**. (`tsc` reports one pre-existing unrelated error: missing `node:sqlite` types in `migrate-auth-profiles.test.ts`.)

Candidate for **3.1.12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for OpenRouter model IDs with supported variant suffixes such as `:free`, `:online`, `:extended`, and `:nitro`.
  * Correctly rejects malformed IDs with empty or multiple variant suffixes.

* **Tests**
  * Expanded coverage for valid and invalid model ID formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->