### PR TITLE
chore(dependabot): security-first posture — ignore majors, keep grouped patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,12 @@
 # Dependabot config. Posture: security-first, low-churn.
 #
 # Two jobs only:
-#   1. Real vulnerabilities — security-update PRs. These need "Dependabot
-#      alerts" enabled in Settings → Code security (admin toggle). They ALWAYS
-#      target the default branch, ignore the groups/ignore rules below, and only
-#      bump package-lock.json — run `bun install` to refresh bun.lock before
-#      merging one.
+#   1. Real vulnerabilities — security-update PRs. These need BOTH "Dependabot
+#      alerts" AND "Dependabot security updates" enabled in Settings → Code
+#      security (admin toggles) — alerts alone surface the CVE but don't open a
+#      PR. They ALWAYS target the default branch, ignore the groups/ignore rules
+#      below, and only bump package-lock.json — run `bun install` to refresh
+#      bun.lock before merging one.
 #   2. Routine version updates — grouped minor+patch ONLY. Major bumps are
 #      ignored on purpose: on an edge-deployed device OS, framework major jumps
 #      (e.g. TypeScript 5→7, or @types/node overshooting the Node 22 runtime)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,19 @@
-# Dependabot version updates. Alerts also require "Dependabot alerts" enabled
-# in Settings → Code security (admin toggle).
+# Dependabot config. Posture: security-first, low-churn.
 #
-# NOTE: target-branch only affects VERSION updates. Security-update PRs always
-# target main, ignore these labels/groups, and only bump package-lock.json —
-# run `bun install` to refresh bun.lock before merging one.
+# Two jobs only:
+#   1. Real vulnerabilities — security-update PRs. These need "Dependabot
+#      alerts" enabled in Settings → Code security (admin toggle). They ALWAYS
+#      target the default branch, ignore the groups/ignore rules below, and only
+#      bump package-lock.json — run `bun install` to refresh bun.lock before
+#      merging one.
+#   2. Routine version updates — grouped minor+patch ONLY. Major bumps are
+#      ignored on purpose: on an edge-deployed device OS, framework major jumps
+#      (e.g. TypeScript 5→7, or @types/node overshooting the Node 22 runtime)
+#      are opt-in, not automatic. Bump majors by hand when you actually want one.
 version: 2
 updates:
   # Version updates for the bun-managed app. bun.lock is authoritative
-  # (CI runs `bun install --frozen-lockfile`). Weekly + grouped.
+  # (CI runs `bun install --frozen-lockfile`). Weekly, grouped, minor+patch only.
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
@@ -16,6 +22,10 @@ updates:
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # Majors are opt-in — do them by hand, not on Dependabot's schedule.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # npm entry exists ONLY for security-update PRs (the bun ecosystem doesn't
   # support them; package-lock.json is kept in sync for this + the dependency
@@ -27,10 +37,14 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 0
 
-  # GitHub Actions pins (checkout, setup-node, gh-pages, …)
+  # GitHub Actions pins (checkout, setup-node, gh-pages, …). Minor+patch only;
+  # action majors are opt-in for the same reason as above.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
     target-branch: "beta"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Why

Dependabot is currently emitting risky **major** version bumps as individual PRs — TypeScript 5→7, `@types/node` 20→26 (against a **Node 22** runtime), jsdom 28→30, jest-dom 6→7 — while its actual value, **security-update PRs**, is dormant because repo **Dependabot alerts are disabled**.

For an edge-deployed, network-exposed device OS, stability beats currency for routine deps. This shifts Dependabot to a **security-first, low-churn** posture.

## What changed

- Add `ignore` rules for `version-update:semver-major` on the **bun** and **github-actions** ecosystems.
- Routine version updates are now **grouped patch+minor only**; framework majors become an opt-in, by-hand decision.
- **Security-update PRs are unaffected** — they bypass `ignore`/group rules and still land when alerts are enabled. Majors that fix a real CVE still come through as security updates.
- The npm `open-pull-requests-limit: 0` (security-only) entry is unchanged.

## Companion action (admin, not in this PR)

Enable **Dependabot alerts** in *Settings → Code security* — that turns on the security-update PRs this config is built around. Without it, the security half stays dormant.

## Queue cleanup

The open major-bump PRs (#291, #293, #290, #292, #286, #287, #288) are being closed as superseded by this policy. The grouped patch/minor PR (#289) is kept for a device-build check before merge.

Config file only — no runtime code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update settings to distinguish security updates from routine version updates.
  * Excluded major-version updates for Bun and GitHub Actions.
  * Configured weekly GitHub Actions update checks on the beta branch.
  * Limited open GitHub Actions update proposals to three at a time and grouped minor and patch updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->