### PR TITLE
fix(vnc): harden setup API calls against expired-auth redirects (#231)

### DIFF
--- a/src/components/VNCApp.tsx
+++ b/src/components/VNCApp.tsx
@@ -4,6 +4,10 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import { useT } from "@/lib/i18n";
 import { getTrackedVncKey, type TrackedKey } from "@/lib/vnc-keys";
 import { copyToClipboard } from "@/lib/clipboard";
+import {
+  fetchSetupJson,
+  SETUP_AUTH_EXPIRED_MESSAGE,
+} from "@/lib/fetch-setup-json";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected" | "error";
 
@@ -22,6 +26,11 @@ const REMOTE_MODIFIER_CODES = new Set(REMOTE_MODIFIER_RELEASES.map((key) => key.
 function isEditableTarget(target: EventTarget | null): target is HTMLElement {
   if (!(target instanceof HTMLElement)) return false;
   return target.isContentEditable || ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName);
+}
+
+function apiError(data: unknown): string | undefined {
+  if (!data || typeof data !== "object" || !("error" in data)) return undefined;
+  return typeof data.error === "string" ? data.error : undefined;
 }
 
 export default function VNCApp() {
@@ -61,6 +70,8 @@ export default function VNCApp() {
   // change arrived while we were mid-fetch so we re-fetch exactly once.
   const remoteClipboardInflightRef = useRef(false);
   const remoteClipboardPendingRef = useRef(false);
+  const authExpiredRef = useRef(false);
+  const [authExpired, setAuthExpired] = useState(false);
   // Late-bound refs so the Ctrl+V handler (which lives inside a useEffect
   // closure declared before openPasteModal / writeAndPaste exist) can call
   // them. Filled in via a `useEffect` further down.
@@ -71,10 +82,34 @@ export default function VNCApp() {
   // change signal and read the real UTF-8 via xclip on the server.
   const fetchRemoteClipboardRef = useRef<(() => Promise<void>) | null>(null);
 
+  const handleAuthExpired = useCallback(() => {
+    if (authExpiredRef.current) return;
+    authExpiredRef.current = true;
+    remoteClipboardPendingRef.current = false;
+    setAuthExpired(true);
+    setVncInfo(null);
+    setStatus("error");
+    setError(SETUP_AUTH_EXPIRED_MESSAGE);
+    setRepairState("failed");
+    setRepairError(null);
+    setPasteError(SETUP_AUTH_EXPIRED_MESSAGE);
+  }, []);
+
   const checkVnc = useCallback(async () => {
     try {
-      const res = await fetch("/setup-api/vnc");
-      const data = await res.json();
+      const result = await fetchSetupJson<{ available?: boolean; wsPort?: number; error?: string }>(
+        "/setup-api/vnc",
+      );
+      if (result.kind === "auth-expired") {
+        handleAuthExpired();
+        return;
+      }
+      if (result.kind === "error") {
+        setStatus("error");
+        setError(apiError(result.data) || `VNC check failed (HTTP ${result.response.status})`);
+        return;
+      }
+      const data = result.data;
       if (data.available) {
         // Keep host/wsPort in the state shape for backwards compatibility but
         // the WebSocket URL is actually built below against same-origin.
@@ -87,7 +122,7 @@ export default function VNCApp() {
       setStatus("error");
       setError(err instanceof Error ? err.message : "VNC check failed");
     }
-  }, []);
+  }, [handleAuthExpired]);
 
   useEffect(() => {
     checkVnc();
@@ -393,6 +428,8 @@ export default function VNCApp() {
   }, [getInputCanvas, status]);
 
   const handleReconnect = useCallback(() => {
+    authExpiredRef.current = false;
+    setAuthExpired(false);
     setStatus("connecting");
     setError(null);
     setVncInfo(null);
@@ -403,14 +440,19 @@ export default function VNCApp() {
     setRepairError(null);
     setRepairState("repairing");
     try {
-      const res = await fetch("/setup-api/install/run-step", {
+      const result = await fetchSetupJson<{ ok?: boolean; error?: string }>("/setup-api/install/run-step", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ step: "vnc_install" }),
       });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || !data.ok) {
-        setRepairError(data?.error || `vnc_install failed (HTTP ${res.status})`);
+      if (result.kind === "auth-expired") {
+        handleAuthExpired();
+        return;
+      }
+      if (result.kind === "error" || !result.data.ok) {
+        setRepairError(
+          apiError(result.data) || `vnc_install failed (HTTP ${result.response.status})`,
+        );
         setRepairState("failed");
         return;
       }
@@ -420,14 +462,20 @@ export default function VNCApp() {
       // "rebooting" state once the request is accepted; a 4xx/5xx here
       // would otherwise leave the UI stuck on the rebooting spinner.
       try {
-        const rebootRes = await fetch("/setup-api/system/power", {
+        const rebootResult = await fetchSetupJson<{ error?: string }>("/setup-api/system/power", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ action: "restart" }),
         });
-        if (!rebootRes.ok) {
-          const body = await rebootRes.json().catch(() => ({}));
-          setRepairError(body?.error || `Reboot request failed (HTTP ${rebootRes.status})`);
+        if (rebootResult.kind === "auth-expired") {
+          handleAuthExpired();
+          return;
+        }
+        if (rebootResult.kind === "error") {
+          setRepairError(
+            apiError(rebootResult.data)
+              || `Reboot request failed (HTTP ${rebootResult.response.status})`,
+          );
           setRepairState("failed");
           return;
         }
@@ -447,9 +495,16 @@ export default function VNCApp() {
       while (Date.now() - start < TIMEOUT_MS) {
         await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
         try {
-          const probe = await fetch("/setup-api/vnc", { cache: "no-store" });
-          if (!probe.ok) continue;
-          const data = await probe.json().catch(() => ({}));
+          const probe = await fetchSetupJson<{ available?: boolean; wsPort?: number }>(
+            "/setup-api/vnc",
+            { cache: "no-store" },
+          );
+          if (probe.kind === "auth-expired") {
+            handleAuthExpired();
+            return;
+          }
+          if (probe.kind === "error") continue;
+          const data = probe.data;
           if (data?.available) {
             setRepairState("idle");
             setRepairError(null);
@@ -465,7 +520,7 @@ export default function VNCApp() {
       setRepairError(err instanceof Error ? err.message : "Repair request failed");
       setRepairState("failed");
     }
-  }, []);
+  }, [handleAuthExpired]);
 
   const openPasteModal = useCallback(() => {
     setPasteText("");
@@ -494,14 +549,19 @@ export default function VNCApp() {
   const writeAndPaste = useCallback(async (text: string): Promise<boolean> => {
     if (!text) return false;
     try {
-      const res = await fetch("/setup-api/vnc/clipboard", {
+      const result = await fetchSetupJson<{ error?: string }>("/setup-api/vnc/clipboard", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text }),
       });
-      if (!res.ok) {
-        const body = (await res.json().catch(() => ({}))) as { error?: string };
-        setPasteError(body.error || `Clipboard write failed (HTTP ${res.status})`);
+      if (result.kind === "auth-expired") {
+        handleAuthExpired();
+        return false;
+      }
+      if (result.kind === "error") {
+        setPasteError(
+          apiError(result.data) || `Clipboard write failed (HTTP ${result.response.status})`,
+        );
         return false;
       }
     } catch (err) {
@@ -517,7 +577,7 @@ export default function VNCApp() {
     rfb.sendKey(0x76, "KeyV", false);
     rfb.sendKey(0xffe3, "ControlLeft", false);
     return true;
-  }, []);
+  }, [handleAuthExpired]);
 
   const sendPaste = useCallback(async () => {
     // Rapid Ctrl+Enter / double-click can re-enter this callback before the
@@ -546,6 +606,7 @@ export default function VNCApp() {
   // delivers. Tries the modern Clipboard API first (HTTPS / localhost), and
   // falls back to the manual-copy toast on insecure origins.
   const fetchRemoteClipboard = useCallback(async () => {
+    if (authExpiredRef.current) return;
     if (remoteClipboardInflightRef.current) {
       // Another fetch is already in flight — record that we need a second
       // pass once it resolves so we don't miss the latest selection.
@@ -556,9 +617,16 @@ export default function VNCApp() {
     try {
       let text = "";
       try {
-        const res = await fetch("/setup-api/vnc/clipboard", { cache: "no-store" });
-        if (!res.ok) return;
-        const body = (await res.json().catch(() => ({}))) as { text?: string };
+        const result = await fetchSetupJson<{ text?: string }>(
+          "/setup-api/vnc/clipboard",
+          { cache: "no-store" },
+        );
+        if (result.kind === "auth-expired") {
+          handleAuthExpired();
+          return;
+        }
+        if (result.kind === "error") return;
+        const body = result.data;
         text = typeof body.text === "string" ? body.text : "";
       } catch {
         return;
@@ -576,7 +644,7 @@ export default function VNCApp() {
         setTimeout(() => { void fetchRemoteClipboard(); }, 0);
       }
     }
-  }, []);
+  }, [handleAuthExpired]);
 
   // Keep the late-bound refs pointing at the current callbacks so the
   // Ctrl+V handler (in a useEffect closure declared earlier) can invoke
@@ -632,7 +700,15 @@ export default function VNCApp() {
             {repairError}
           </p>
         )}
-        {rebooting ? (
+        {authExpired ? (
+          <button
+            type="button"
+            onClick={() => window.location.reload()}
+            className="px-4 py-2 btn-gradient rounded-lg text-sm text-white cursor-pointer"
+          >
+            Refresh to sign in again
+          </button>
+        ) : rebooting ? (
           <div className="flex flex-col items-center gap-2 mt-2">
             <span className="material-symbols-rounded animate-spin text-orange-400" style={{ fontSize: 28 }}>progress_activity</span>
             <p className="text-sm text-white/80">Rebooting device — Remote Desktop will be ready in ~30s.</p>

--- a/src/components/VNCApp.tsx
+++ b/src/components/VNCApp.tsx
@@ -7,6 +7,7 @@ import { copyToClipboard } from "@/lib/clipboard";
 import {
   fetchSetupJson,
   SETUP_AUTH_EXPIRED_MESSAGE,
+  type SetupFetchOutcome,
 } from "@/lib/fetch-setup-json";
 
 type ConnectionStatus = "connecting" | "connected" | "disconnected" | "error";
@@ -95,15 +96,30 @@ export default function VNCApp() {
     setPasteError(SETUP_AUTH_EXPIRED_MESSAGE);
   }, []);
 
-  const checkVnc = useCallback(async () => {
-    try {
-      const result = await fetchSetupJson<{ available?: boolean; wsPort?: number; error?: string }>(
-        "/setup-api/vnc",
-      );
+  // Fetch a setup endpoint and fold in expired-session handling: on an expired
+  // session, show the auth-expired screen and return null so callers can bail
+  // with their own return value; otherwise return the resolved outcome.
+  const setupFetch = useCallback(
+    async <T,>(
+      input: RequestInfo | URL,
+      init?: RequestInit,
+    ): Promise<SetupFetchOutcome<T> | null> => {
+      const result = await fetchSetupJson<T>(input, init);
       if (result.kind === "auth-expired") {
         handleAuthExpired();
-        return;
+        return null;
       }
+      return result;
+    },
+    [handleAuthExpired],
+  );
+
+  const checkVnc = useCallback(async () => {
+    try {
+      const result = await setupFetch<{ available?: boolean; wsPort?: number; error?: string }>(
+        "/setup-api/vnc",
+      );
+      if (!result) return;
       if (result.kind === "error") {
         setStatus("error");
         setError(apiError(result.data) || `VNC check failed (HTTP ${result.response.status})`);
@@ -122,7 +138,7 @@ export default function VNCApp() {
       setStatus("error");
       setError(err instanceof Error ? err.message : "VNC check failed");
     }
-  }, [handleAuthExpired]);
+  }, [setupFetch]);
 
   useEffect(() => {
     checkVnc();
@@ -440,15 +456,12 @@ export default function VNCApp() {
     setRepairError(null);
     setRepairState("repairing");
     try {
-      const result = await fetchSetupJson<{ ok?: boolean; error?: string }>("/setup-api/install/run-step", {
+      const result = await setupFetch<{ ok?: boolean; error?: string }>("/setup-api/install/run-step", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ step: "vnc_install" }),
       });
-      if (result.kind === "auth-expired") {
-        handleAuthExpired();
-        return;
-      }
+      if (!result) return;
       if (result.kind === "error" || !result.data.ok) {
         setRepairError(
           apiError(result.data) || `vnc_install failed (HTTP ${result.response.status})`,
@@ -462,15 +475,12 @@ export default function VNCApp() {
       // "rebooting" state once the request is accepted; a 4xx/5xx here
       // would otherwise leave the UI stuck on the rebooting spinner.
       try {
-        const rebootResult = await fetchSetupJson<{ error?: string }>("/setup-api/system/power", {
+        const rebootResult = await setupFetch<{ error?: string }>("/setup-api/system/power", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ action: "restart" }),
         });
-        if (rebootResult.kind === "auth-expired") {
-          handleAuthExpired();
-          return;
-        }
+        if (!rebootResult) return;
         if (rebootResult.kind === "error") {
           setRepairError(
             apiError(rebootResult.data)
@@ -495,14 +505,11 @@ export default function VNCApp() {
       while (Date.now() - start < TIMEOUT_MS) {
         await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
         try {
-          const probe = await fetchSetupJson<{ available?: boolean; wsPort?: number }>(
+          const probe = await setupFetch<{ available?: boolean; wsPort?: number }>(
             "/setup-api/vnc",
             { cache: "no-store" },
           );
-          if (probe.kind === "auth-expired") {
-            handleAuthExpired();
-            return;
-          }
+          if (!probe) return;
           if (probe.kind === "error") continue;
           const data = probe.data;
           if (data?.available) {
@@ -520,7 +527,7 @@ export default function VNCApp() {
       setRepairError(err instanceof Error ? err.message : "Repair request failed");
       setRepairState("failed");
     }
-  }, [handleAuthExpired]);
+  }, [setupFetch]);
 
   const openPasteModal = useCallback(() => {
     setPasteText("");
@@ -549,15 +556,12 @@ export default function VNCApp() {
   const writeAndPaste = useCallback(async (text: string): Promise<boolean> => {
     if (!text) return false;
     try {
-      const result = await fetchSetupJson<{ error?: string }>("/setup-api/vnc/clipboard", {
+      const result = await setupFetch<{ error?: string }>("/setup-api/vnc/clipboard", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ text }),
       });
-      if (result.kind === "auth-expired") {
-        handleAuthExpired();
-        return false;
-      }
+      if (!result) return false;
       if (result.kind === "error") {
         setPasteError(
           apiError(result.data) || `Clipboard write failed (HTTP ${result.response.status})`,
@@ -577,7 +581,7 @@ export default function VNCApp() {
     rfb.sendKey(0x76, "KeyV", false);
     rfb.sendKey(0xffe3, "ControlLeft", false);
     return true;
-  }, [handleAuthExpired]);
+  }, [setupFetch]);
 
   const sendPaste = useCallback(async () => {
     // Rapid Ctrl+Enter / double-click can re-enter this callback before the
@@ -617,14 +621,11 @@ export default function VNCApp() {
     try {
       let text = "";
       try {
-        const result = await fetchSetupJson<{ text?: string }>(
+        const result = await setupFetch<{ text?: string }>(
           "/setup-api/vnc/clipboard",
           { cache: "no-store" },
         );
-        if (result.kind === "auth-expired") {
-          handleAuthExpired();
-          return;
-        }
+        if (!result) return;
         if (result.kind === "error") return;
         const body = result.data;
         text = typeof body.text === "string" ? body.text : "";
@@ -644,7 +645,7 @@ export default function VNCApp() {
         setTimeout(() => { void fetchRemoteClipboard(); }, 0);
       }
     }
-  }, [handleAuthExpired]);
+  }, [setupFetch]);
 
   // Keep the late-bound refs pointing at the current callbacks so the
   // Ctrl+V handler (in a useEffect closure declared earlier) can invoke

--- a/src/lib/fetch-setup-json.ts
+++ b/src/lib/fetch-setup-json.ts
@@ -1,0 +1,49 @@
+export const SETUP_AUTH_EXPIRED_MESSAGE =
+  "Your ClawBox session has expired. Refresh the page and sign in again.";
+
+export type SetupFetchResult<T> =
+  | { kind: "ok"; data: T; response: Response }
+  | { kind: "auth-expired"; response: Response }
+  | { kind: "error"; data: unknown; response: Response };
+
+function redirectedToLogin(response: Response): boolean {
+  if (!response.redirected || !response.url) return false;
+  try {
+    return new URL(response.url, "https://example.invalid").pathname === "/login";
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Fetch a protected setup endpoint without following an expired session into
+ * a misleading HTML/405 failure. The Accept header makes middleware return a
+ * JSON 401; the final-URL check also covers already-followed login redirects.
+ */
+export async function fetchSetupJson<T>(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<SetupFetchResult<T>> {
+  const headers = new Headers(init?.headers);
+  headers.set("Accept", "application/json");
+
+  const response = await fetch(input, { ...init, headers });
+  if (response.status === 401 || redirectedToLogin(response)) {
+    return { kind: "auth-expired", response };
+  }
+
+  const data = await readJson(response);
+  if (!response.ok || data === undefined) {
+    return { kind: "error", data, response };
+  }
+
+  return { kind: "ok", data: data as T, response };
+}

--- a/src/lib/fetch-setup-json.ts
+++ b/src/lib/fetch-setup-json.ts
@@ -6,10 +6,14 @@ export type SetupFetchResult<T> =
   | { kind: "auth-expired"; response: Response }
   | { kind: "error"; data: unknown; response: Response };
 
+/** A resolved outcome — the auth-expired case has already been handled. */
+export type SetupFetchOutcome<T> = Exclude<SetupFetchResult<T>, { kind: "auth-expired" }>;
+
 function redirectedToLogin(response: Response): boolean {
   if (!response.redirected || !response.url) return false;
   try {
-    return new URL(response.url, "https://example.invalid").pathname.endsWith("/login");
+    // Response.url is always an absolute serialized URL, so no base is needed.
+    return new URL(response.url).pathname.endsWith("/login");
   } catch {
     return false;
   }

--- a/src/lib/fetch-setup-json.ts
+++ b/src/lib/fetch-setup-json.ts
@@ -9,7 +9,7 @@ export type SetupFetchResult<T> =
 function redirectedToLogin(response: Response): boolean {
   if (!response.redirected || !response.url) return false;
   try {
-    return new URL(response.url, "https://example.invalid").pathname === "/login";
+    return new URL(response.url, "https://example.invalid").pathname.endsWith("/login");
   } catch {
     return false;
   }

--- a/src/tests/components/vnc-app.test.tsx
+++ b/src/tests/components/vnc-app.test.tsx
@@ -86,7 +86,7 @@ describe("VNCApp", () => {
         redirected: false,
         url: "https://example.test/setup-api/vnc",
         json: vi.fn(),
-      } as Response;
+      } as unknown as Response;
     });
     vi.stubGlobal("fetch", fetchMock);
 

--- a/src/tests/components/vnc-app.test.tsx
+++ b/src/tests/components/vnc-app.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
 import VNCApp from "@/components/VNCApp";
 import { getTrackedVncKey } from "@/lib/vnc-keys";
+import { SETUP_AUTH_EXPIRED_MESSAGE } from "@/lib/fetch-setup-json";
 
 type RfbListener = (event?: Event | CustomEvent) => void;
 
@@ -73,6 +74,58 @@ describe("VNCApp", () => {
       ok: true,
       json: async () => ({ available: true, wsPort: 6080 }),
     })));
+  });
+
+  it("shows a sign-in prompt instead of parsing a 401 response", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+      void _input;
+      void _init;
+      return {
+        ok: false,
+        status: 401,
+        redirected: false,
+        url: "https://example.test/setup-api/vnc",
+        json: vi.fn(),
+      } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getByRole, queryByText } = render(<VNCApp />);
+
+    await waitFor(() => {
+      expect(getByRole("button", { name: "Refresh to sign in again" })).toBeInTheDocument();
+    });
+    expect(queryByText(SETUP_AUTH_EXPIRED_MESSAGE)).toBeInTheDocument();
+    expect(queryByText("Install / Repair & Reboot")).not.toBeInTheDocument();
+    expect(new Headers(fetchMock.mock.calls[0][1]?.headers).get("Accept")).toBe("application/json");
+  });
+
+  it("stops the repair flow when authentication expires", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        redirected: false,
+        url: "https://example.test/setup-api/vnc",
+        json: async () => ({ available: false, error: "No VNC server detected" }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        redirected: false,
+        url: "https://example.test/setup-api/install/run-step",
+        json: vi.fn(),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { findByRole, getByRole } = render(<VNCApp />);
+    fireEvent.click(await findByRole("button", { name: /Install \/ Repair & Reboot/ }));
+
+    await waitFor(() => {
+      expect(getByRole("button", { name: "Refresh to sign in again" })).toBeInTheDocument();
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[1][0]).toBe("/setup-api/install/run-step");
   });
 
   it("forwards keyboard events to the RFB connection when focus drifts off the noVNC canvas", async () => {

--- a/src/tests/unit/fetch-setup-json.test.ts
+++ b/src/tests/unit/fetch-setup-json.test.ts
@@ -45,4 +45,20 @@ describe("fetchSetupJson", () => {
     expect(result.kind).toBe("auth-expired");
     expect(json).not.toHaveBeenCalled();
   });
+
+  it("classifies a base-path login redirect as expired authentication", async () => {
+    const json = vi.fn(async () => {
+      throw new SyntaxError("Unexpected token '<'");
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => response({
+      redirected: true,
+      url: "https://example.test/base/login?redirect=%2Fbase%2Fsetup-api%2Fvnc",
+      json,
+    })));
+
+    const result = await fetchSetupJson("/base/setup-api/vnc");
+
+    expect(result.kind).toBe("auth-expired");
+    expect(json).not.toHaveBeenCalled();
+  });
 });

--- a/src/tests/unit/fetch-setup-json.test.ts
+++ b/src/tests/unit/fetch-setup-json.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchSetupJson } from "@/lib/fetch-setup-json";
+
+function response(overrides: Partial<Response>): Response {
+  return {
+    ok: true,
+    status: 200,
+    redirected: false,
+    url: "https://example.test/setup-api/vnc",
+    json: async () => ({ available: true }),
+    ...overrides,
+  } as Response;
+}
+
+describe("fetchSetupJson", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("requests JSON and classifies a 401 as expired authentication", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      expect(new Headers(init?.headers).get("Accept")).toBe("application/json");
+      return response({ ok: false, status: 401 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await fetchSetupJson("/setup-api/vnc");
+
+    expect(result.kind).toBe("auth-expired");
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("classifies an already-followed login redirect before parsing HTML", async () => {
+    const json = vi.fn(async () => {
+      throw new SyntaxError("Unexpected token '<'");
+    });
+    vi.stubGlobal("fetch", vi.fn(async () => response({
+      redirected: true,
+      url: "https://example.test/login?redirect=%2Fsetup-api%2Fvnc",
+      json,
+    })));
+
+    const result = await fetchSetupJson("/setup-api/vnc");
+
+    expect(result.kind).toBe("auth-expired");
+    expect(json).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #231. Supersedes #294 — same fix, cherry-picked clean onto `beta` so it carries only the change, not the v3.1.10/v3.1.11 promote-merges #294 dragged in (61 files → 4).

## Why
On an expired session, VNC's setup-api calls followed the middleware's HTML login redirect and crashed when the login page was parsed as JSON (`res.json()` on `<!doctype html>` with no catch) — surfacing a raw SyntaxError instead of a "session expired" message.

## What
- New `src/lib/fetch-setup-json.ts`: sets `Accept: application/json` so middleware returns a JSON 401, treats 401 **or** a followed redirect-to-`/login` as auth-expired, and never parses login HTML as JSON.
- `VNCApp.tsx` migrated to it — availability probe, install/repair, reboot, poll, and clipboard read/write now surface a "session expired — sign in again" state instead of crashing/hanging.
- Cherry-picked from @jamesachurchill's #294 (**authorship preserved**), rebased onto `beta`.
- `/simplify` pass: folded the repeated auth-expired handling into a small `setupFetch` wrapper; dropped a dead `new URL(..., base)` arg; cast the mock Response via `unknown` for strict `tsc`.

## Verified on the Jetson (aarch64)
- `tsc --noEmit`: clean — no errors in changed files (matches `beta` baseline).
- Unit + component tests: **14 pass** (`fetch-setup-json.test.ts`, `vnc-app.test.tsx`).
- Helper exercised against a **real local HTTP server**: 401 → auth-expired, redirect-to-login → auth-expired, login-HTML → no JSON-parse throw, JSON → ok.

## Follow-up (separate issue)
The same latent bug lives in ~30 other raw `/setup-api` callers. The deepest fix is making `middleware.ts` return JSON 401 for `/setup-api/*` unconditionally (with care for a few non-JSON routes like `apps/icon`/`files`). Filed separately rather than scope-creeping this VNC PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of expired authentication during VNC setup, repair, reboot, polling, and clipboard actions.
  * Displays a clear sign-in prompt when the session expires and prevents further repair actions.
  * Supports reliable login redirects for applications hosted at the root or under a base path.
  * Reconnecting now resets the expired-session state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->