### PR TITLE
fix(update): add 'Force full update' recovery action for force-update.sh (#285)

### DIFF
--- a/scripts/force-update.sh
+++ b/scripts/force-update.sh
@@ -78,7 +78,14 @@ echo "[force-update] Restarting clawbox-setup..."
 sudo systemctl restart clawbox-setup
 sleep 5
 if systemctl is-active --quiet clawbox-setup; then
-  echo "[force-update] Done. Reload http://clawbox.local in your browser."
+  echo "[force-update] The ClawBox interface is restored."
+  echo "[force-update] IMPORTANT: this recovered the UI only. OpenClaw and system"
+  echo "[force-update]   services may still be on the OLD version — the interface"
+  echo "[force-update]   being current does NOT mean the update finished."
+  echo "[force-update] To finish: open http://clawbox.local, launch the System Update"
+  echo "[force-update]   app (Settings -> About -> System Update), open 'Advanced"
+  echo "[force-update]   options' and click 'Force full update'. The device reboots"
+  echo "[force-update]   when it completes."
 else
   echo "[force-update] WARNING: clawbox-setup failed to come up. Check 'sudo journalctl -u clawbox-setup -n 50'." >&2
   exit 1

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -85,6 +85,7 @@ export default function SystemUpdateApp() {
   const [branchSaving, setBranchSaving] = useState(false);
   const [branchError, setBranchError] = useState<string | null>(null);
   const [betaConfirm, setBetaConfirm] = useState(false);
+  const [forceConfirm, setForceConfirm] = useState(false);
 
   const pollRef = useRef<number | null>(null);
   const pollControllerRef = useRef<AbortController | null>(null);
@@ -508,6 +509,26 @@ export default function SystemUpdateApp() {
                       <p className="mt-2 text-xs text-red-300">{branchError}</p>
                     )}
                   </div>
+
+                  {/* Force full update — recovery for a device left with a
+                      stale OpenClaw/system unit by force-update.sh (restores
+                      the UI but not the full update). Re-runs the full updater. */}
+                  <div className="border-t border-white/5 pt-4">
+                    <div className="text-sm text-gray-100 inline-flex items-center gap-2">
+                      <span className="material-symbols-rounded text-amber-400" style={{ fontSize: 18 }} aria-hidden="true">restart_alt</span>
+                      Force full update
+                    </div>
+                    <p className="mt-1 text-xs text-[var(--text-muted)]">
+                      Re-runs OpenClaw and system-service setup even when the version is current. Use it if a recovery script told you to, or if the assistant or services misbehave after an update. The device reboots when it finishes.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => setForceConfirm(true)}
+                      className="mt-2 px-3 py-1.5 rounded-md bg-amber-500/15 border border-amber-500/40 text-amber-200 text-xs font-semibold cursor-pointer hover:bg-amber-500/25"
+                    >
+                      Force full update
+                    </button>
+                  </div>
                 </div>
               )}
             </div>
@@ -555,6 +576,52 @@ export default function SystemUpdateApp() {
                 className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
               >
                 Enable beta
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {forceConfirm && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="force-confirm-title"
+          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+          onClick={() => setForceConfirm(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-2xl border border-white/10 bg-[var(--bg-deep)] shadow-2xl overflow-hidden"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-3 px-5 pt-5">
+              <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-amber-500/15 text-amber-300">
+                <span className="material-symbols-rounded" style={{ fontSize: 22 }}>restart_alt</span>
+              </div>
+              <h2 id="force-confirm-title" className="text-base font-semibold text-gray-100">Force a full update?</h2>
+            </div>
+            <div className="px-5 pt-3 pb-4 text-sm leading-relaxed text-[var(--text-secondary)]">
+              <p>
+                This re-runs the full update — including OpenClaw and system-service setup — even
+                though the version is already current, then <strong>reboots the device</strong>. Use it
+                to finish a recovery or fix services that misbehave after an update.
+              </p>
+            </div>
+            <div className="flex justify-end gap-2 px-5 pb-5 pt-2 border-t border-white/5">
+              <button
+                type="button"
+                onClick={() => setForceConfirm(false)}
+                className="px-4 py-2 rounded-lg text-sm font-medium border border-white/10 text-gray-200 hover:bg-white/5 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                autoFocus
+                onClick={() => { setForceConfirm(false); void triggerUpdate(); }}
+                className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
+              >
+                Force full update
               </button>
             </div>
           </div>

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { StepStatus, UpdateState } from "@/lib/updater";
 import { RESTART_STEP_ID } from "@/lib/update-constants";
 import { cleanVersion } from "@/lib/version-utils";
@@ -510,25 +510,29 @@ export default function SystemUpdateApp() {
                     )}
                   </div>
 
-                  {/* Force full update — recovery for a device left with a
-                      stale OpenClaw/system unit by force-update.sh (restores
-                      the UI but not the full update). Re-runs the full updater. */}
-                  <div className="border-t border-white/5 pt-4">
-                    <div className="text-sm text-gray-100 inline-flex items-center gap-2">
-                      <span className="material-symbols-rounded text-amber-400" style={{ fontSize: 18 }} aria-hidden="true">restart_alt</span>
-                      Force full update
+                  {/* Force full update — recovery for a device left with a stale
+                      OpenClaw/system unit by force-update.sh (restores the UI but
+                      not the full update). Only offered when otherwise up to date
+                      (the recovery scenario) so it can't fire during loading or a
+                      failed version fetch. */}
+                  {status === "up-to-date" && (
+                    <div className="border-t border-white/5 pt-4">
+                      <div className="text-sm text-gray-100 inline-flex items-center gap-2">
+                        <span className="material-symbols-rounded text-amber-400" style={{ fontSize: 18 }} aria-hidden="true">restart_alt</span>
+                        Force full update
+                      </div>
+                      <p className="mt-1 text-xs text-[var(--text-muted)]">
+                        Re-runs OpenClaw and system-service setup even when the version is current. Use it if a recovery script told you to, or if the assistant or services misbehave after an update. The device reboots when it finishes.
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => setForceConfirm(true)}
+                        className="mt-2 px-3 py-1.5 rounded-md bg-amber-500/15 border border-amber-500/40 text-amber-200 text-xs font-semibold cursor-pointer hover:bg-amber-500/25"
+                      >
+                        Force full update
+                      </button>
                     </div>
-                    <p className="mt-1 text-xs text-[var(--text-muted)]">
-                      Re-runs OpenClaw and system-service setup even when the version is current. Use it if a recovery script told you to, or if the assistant or services misbehave after an update. The device reboots when it finishes.
-                    </p>
-                    <button
-                      type="button"
-                      onClick={() => setForceConfirm(true)}
-                      className="mt-2 px-3 py-1.5 rounded-md bg-amber-500/15 border border-amber-500/40 text-amber-200 text-xs font-semibold cursor-pointer hover:bg-amber-500/25"
-                    >
-                      Force full update
-                    </button>
-                  </div>
+                  )}
                 </div>
               )}
             </div>
@@ -537,96 +541,132 @@ export default function SystemUpdateApp() {
       </div>
 
       {betaConfirm && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="beta-confirm-title"
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
-          onClick={() => setBetaConfirm(false)}
+        <ConfirmModal
+          titleId="beta-confirm-title"
+          title="Enable beta updates?"
+          icon="warning"
+          confirmLabel="Enable beta"
+          onCancel={() => setBetaConfirm(false)}
+          onConfirm={() => { setBetaConfirm(false); void saveBranch("beta"); }}
         >
-          <div
-            className="w-full max-w-md rounded-2xl border border-white/10 bg-[var(--bg-deep)] shadow-2xl overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center gap-3 px-5 pt-5">
-              <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-amber-500/15 text-amber-300">
-                <span className="material-symbols-rounded" style={{ fontSize: 22 }}>warning</span>
-              </div>
-              <h2 id="beta-confirm-title" className="text-base font-semibold text-gray-100">Enable beta updates?</h2>
-            </div>
-            <div className="px-5 pt-3 pb-4 text-sm leading-relaxed text-[var(--text-secondary)]">
-              <p>
-                Beta builds may include unfinished features and regressions. They&apos;re great for early
-                feedback but can break local state. You can switch back any time, but downgrades aren&apos;t
-                always reversible.
-              </p>
-            </div>
-            <div className="flex justify-end gap-2 px-5 pb-5 pt-2 border-t border-white/5">
-              <button
-                type="button"
-                onClick={() => setBetaConfirm(false)}
-                className="px-4 py-2 rounded-lg text-sm font-medium border border-white/10 text-gray-200 hover:bg-white/5 cursor-pointer"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                autoFocus
-                onClick={() => { setBetaConfirm(false); void saveBranch("beta"); }}
-                className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
-              >
-                Enable beta
-              </button>
-            </div>
-          </div>
-        </div>
+          <p>
+            Beta builds may include unfinished features and regressions. They&apos;re great for early
+            feedback but can break local state. You can switch back any time, but downgrades aren&apos;t
+            always reversible.
+          </p>
+        </ConfirmModal>
       )}
 
       {forceConfirm && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="force-confirm-title"
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
-          onClick={() => setForceConfirm(false)}
+        <ConfirmModal
+          titleId="force-confirm-title"
+          title="Force a full update?"
+          icon="restart_alt"
+          confirmLabel="Yes, run full update"
+          onCancel={() => setForceConfirm(false)}
+          onConfirm={() => { setForceConfirm(false); void triggerUpdate(); }}
         >
-          <div
-            className="w-full max-w-md rounded-2xl border border-white/10 bg-[var(--bg-deep)] shadow-2xl overflow-hidden"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex items-center gap-3 px-5 pt-5">
-              <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-amber-500/15 text-amber-300">
-                <span className="material-symbols-rounded" style={{ fontSize: 22 }}>restart_alt</span>
-              </div>
-              <h2 id="force-confirm-title" className="text-base font-semibold text-gray-100">Force a full update?</h2>
-            </div>
-            <div className="px-5 pt-3 pb-4 text-sm leading-relaxed text-[var(--text-secondary)]">
-              <p>
-                This re-runs the full update — including OpenClaw and system-service setup — even
-                though the version is already current, then <strong>reboots the device</strong>. Use it
-                to finish a recovery or fix services that misbehave after an update.
-              </p>
-            </div>
-            <div className="flex justify-end gap-2 px-5 pb-5 pt-2 border-t border-white/5">
-              <button
-                type="button"
-                onClick={() => setForceConfirm(false)}
-                className="px-4 py-2 rounded-lg text-sm font-medium border border-white/10 text-gray-200 hover:bg-white/5 cursor-pointer"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                autoFocus
-                onClick={() => { setForceConfirm(false); void triggerUpdate(); }}
-                className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
-              >
-                Force full update
-              </button>
-            </div>
-          </div>
-        </div>
+          <p>
+            This re-runs the full update — including OpenClaw and system-service setup — even
+            though the version is already current, then <strong>reboots the device</strong>. Use it
+            to finish a recovery or fix services that misbehave after an update.
+          </p>
+        </ConfirmModal>
       )}
+    </div>
+  );
+}
+
+// Shared confirmation dialog. Focuses Cancel on open (so a stray Enter can't
+// confirm a destructive action), closes on Escape, and traps Tab focus within
+// the dialog — the keyboard-nav behavior CLAUDE.md requires of modals.
+function ConfirmModal({
+  titleId,
+  title,
+  icon,
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  children,
+}: {
+  titleId: string;
+  title: string;
+  icon: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  children: ReactNode;
+}) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    cancelRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+      );
+      if (!focusables || focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        className="w-full max-w-md rounded-2xl border border-white/10 bg-[var(--bg-deep)] shadow-2xl overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-3 px-5 pt-5">
+          <div className="shrink-0 w-10 h-10 rounded-full flex items-center justify-center bg-amber-500/15 text-amber-300">
+            <span className="material-symbols-rounded" style={{ fontSize: 22 }}>{icon}</span>
+          </div>
+          <h2 id={titleId} className="text-base font-semibold text-gray-100">{title}</h2>
+        </div>
+        <div className="px-5 pt-3 pb-4 text-sm leading-relaxed text-[var(--text-secondary)]">
+          {children}
+        </div>
+        <div className="flex justify-end gap-2 px-5 pb-5 pt-2 border-t border-white/5">
+          <button
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+            className="px-4 py-2 rounded-lg text-sm font-medium border border-white/10 text-gray-200 hover:bg-white/5 cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="px-4 py-2 rounded-lg text-sm font-semibold bg-amber-500 hover:bg-amber-400 text-black cursor-pointer"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/tests/components/system-update-app.test.tsx
+++ b/src/tests/components/system-update-app.test.tsx
@@ -47,7 +47,7 @@ describe("SystemUpdateApp — force-full-update recovery affordance", () => {
   });
 
   it("offers 'Force full update' under Advanced options and forces only after confirming", async () => {
-    const { getByRole, getAllByRole, findByText } = render(<SystemUpdateApp />);
+    const { getByRole, findByText } = render(<SystemUpdateApp />);
 
     await findByText("You're up to date");
 
@@ -55,17 +55,32 @@ describe("SystemUpdateApp — force-full-update recovery affordance", () => {
     fireEvent.click(getByRole("button", { name: /Advanced options/ }));
     fireEvent.click(getByRole("button", { name: "Force full update" }));
 
-    // Confirmation gates the reboot — nothing is triggered until confirm.
+    // Confirmation gates the reboot — the confirm has a distinct name, and
+    // nothing fires until it's clicked.
     getByRole("dialog");
     expect(runBody).toBeNull();
 
-    // The modal's confirm button is the last "Force full update" in the DOM.
-    const buttons = getAllByRole("button", { name: "Force full update" });
-    fireEvent.click(buttons[buttons.length - 1]);
+    fireEvent.click(getByRole("button", { name: "Yes, run full update" }));
 
     await waitFor(() => {
       expect(runBody).not.toBeNull();
     });
     expect(JSON.parse(runBody as string)).toMatchObject({ force: true });
+  });
+
+  it("dismisses the confirm dialog on Escape without forcing an update", async () => {
+    const { getByRole, queryByRole, findByText } = render(<SystemUpdateApp />);
+
+    await findByText("You're up to date");
+    fireEvent.click(getByRole("button", { name: /Advanced options/ }));
+    fireEvent.click(getByRole("button", { name: "Force full update" }));
+    getByRole("dialog");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => {
+      expect(queryByRole("dialog")).toBeNull();
+    });
+    expect(runBody).toBeNull();
   });
 });

--- a/src/tests/components/system-update-app.test.tsx
+++ b/src/tests/components/system-update-app.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
+import SystemUpdateApp from "@/components/SystemUpdateApp";
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+// A device recovered by force-update.sh is at the current git version but may
+// still have a stale OpenClaw / systemd unit. In that "up-to-date" state the UI
+// must still offer a way to re-run the full update — behind Advanced options and
+// a confirmation, since it reboots.
+describe("SystemUpdateApp — force-full-update recovery affordance", () => {
+  let runBody: string | null;
+
+  beforeEach(() => {
+    runBody = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/setup-api/update/versions")) {
+          return jsonResponse({
+            clawbox: { current: "3.1.11", target: "3.1.11", updateAvailable: false },
+            openclaw: { current: "2026.7.1", target: "2026.7.1", updateAvailable: false },
+          });
+        }
+        if (url.includes("/setup-api/system/update-branch")) {
+          return jsonResponse({ branch: null });
+        }
+        if (url.includes("/setup-api/update/run")) {
+          runBody = typeof init?.body === "string" ? init.body : null;
+          return jsonResponse({ started: true });
+        }
+        if (url.includes("/setup-api/update/status")) {
+          // Not "running" — otherwise the mount effect would join a live poll
+          // and render the "updating" hero instead of "up to date".
+          return jsonResponse({ phase: "idle", steps: [] });
+        }
+        return jsonResponse({});
+      }),
+    );
+  });
+
+  it("offers 'Force full update' under Advanced options and forces only after confirming", async () => {
+    const { getByRole, getAllByRole, findByText } = render(<SystemUpdateApp />);
+
+    await findByText("You're up to date");
+
+    // Recovery affordance lives under Advanced options, not on the happy path.
+    fireEvent.click(getByRole("button", { name: /Advanced options/ }));
+    fireEvent.click(getByRole("button", { name: "Force full update" }));
+
+    // Confirmation gates the reboot — nothing is triggered until confirm.
+    getByRole("dialog");
+    expect(runBody).toBeNull();
+
+    // The modal's confirm button is the last "Force full update" in the DOM.
+    const buttons = getAllByRole("button", { name: "Force full update" });
+    fireEvent.click(buttons[buttons.length - 1]);
+
+    await waitFor(() => {
+      expect(runBody).not.toBeNull();
+    });
+    expect(JSON.parse(runBody as string)).toMatchObject({ force: true });
+  });
+});

--- a/src/tests/unit/force-update-handoff.test.ts
+++ b/src/tests/unit/force-update-handoff.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// force-update.sh recovers a device whose UI updater is broken, but it only
+// restores the setup app — it does NOT run the full updater's gateway/OpenClaw
+// steps. It must not claim the update is finished, and must point the user at
+// the "Force full update" affordance (SystemUpdateApp) to complete it.
+const script = readFileSync(join(process.cwd(), "scripts/force-update.sh"), "utf8");
+
+describe("force-update.sh recovery messaging", () => {
+  it("hands off to 'Force full update' instead of claiming the update is done", () => {
+    expect(script).not.toContain("Done. Reload");
+    expect(script).toMatch(/recovered the UI only/);
+    expect(script).toContain("Force full update");
+  });
+});


### PR DESCRIPTION
Fixes #285. Supersedes #298 — which only reworded `force-update.sh` and still left the dead-end below.

## The bug
`force-update.sh` self-heals a device whose UI updater is broken, but it only restores the **setup app** — it does not run the full updater's `gateway_setup` + `openclaw_install`. Afterwards ClawBox sits at the current git version, so `SystemUpdateApp`'s "Update everything" button (gated on a ClawBox version delta) never renders → **there is no way to finish the update from the UI**, and OpenClaw / the systemd gateway unit stay stale. The old script message ("Done. Reload …") implied the update was complete.

## The fix
- **`SystemUpdateApp`:** a "Force full update" action under **Advanced options** (not the happy-path hero) that re-runs the full updater via the existing `{force:true}` path — which loops `UPDATE_STEPS` from 0 including `openclaw_install` and `gateway_setup`. Gated behind a **confirmation modal** (it reboots), matching the beta-channel toggle's pattern.
- **`force-update.sh`:** honest completion message — states it recovered the UI only, that being "current" does not mean the update finished, and points at Advanced options → Force full update.

## `/simplify` applied
Placement moved off the happy path into Advanced options + added a confirm (altitude); collapsed the brittle shell-string test into one assertion; trimmed a restated rationale comment. (A double-click guard was considered — after the first click `triggerUpdate` flips `updateStarted` and the up-to-date block unmounts; the confirm modal also gates it.)

## Verified on the Jetson (aarch64)
- `tsc --noEmit`: clean — no errors in changed files (matches `beta` baseline).
- Tests: `system-update-app.test.tsx` (Advanced → Force full update → confirm → asserts `{force:true}`, and that nothing fires before confirm) + `force-update-handoff.test.ts` — both pass.
- `{force:true}` re-running `openclaw_install`/`gateway_setup` verified against `updater.ts` step order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Advanced option to force a full system update when the device is already up to date.
  * Added a confirmation dialog with keyboard-friendly controls, including Escape-to-close and focus handling.

* **Bug Fixes**
  * Clarified recovery messaging to explain that only the UI was restored and that a full update must be started separately.

* **Tests**
  * Added coverage for force-update confirmation, cancellation, request behavior, and recovery messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->