### PR TITLE
fix(gateway): preserve canonical token SecretRefs (#249)

### DIFF
--- a/install-x64.sh
+++ b/install-x64.sh
@@ -409,11 +409,19 @@ c.gateway.auth.mode='token';
 // plain literal "clawbox" here would reintroduce the shared-token vuln (#149).
 {
   // Keep this predicate in lockstep with is_strong_gateway_token() in
-  // scripts/gateway-pre-start.sh: SecretRef object with a known ref key,
-  // a non-empty ${ENV} interpolation, or a >=32-char non-legacy string.
+  // scripts/gateway-pre-start.sh: a canonical SecretRef object, a
+  // non-empty ${ENV} interpolation, or a >=32-char non-legacy string.
   const t=c.gateway.auth.token;
+  const own=(o,k)=>Object.prototype.hasOwnProperty.call(o,k);
+  const keys=o=>Object.keys(o);
+  const nonEmptyString=v=>typeof v==='string'&&v.trim().length>0;
+  const source=t&&typeof t==='object'&&!Array.isArray(t)&&t.source;
+  const canonicalRef =
+    (source==='env'||source==='file'||source==='exec') &&
+    nonEmptyString(t.provider) && nonEmptyString(t.id) &&
+    keys(t).length===3 && own(t,'source') && own(t,'provider') && own(t,'id');
   const strong =
-    (t&&typeof t==='object'&&!Array.isArray(t)&&('env' in t||'file' in t||'exec' in t)) ||
+    canonicalRef ||
     (typeof t==='string' && (/^\$\{.+\}$/.test(t) || (t!=='clawbox' && t.length>=32)));
   if(!strong) c.gateway.auth.token=require('crypto').randomBytes(32).toString('hex');
 }

--- a/install.sh
+++ b/install.sh
@@ -1482,7 +1482,16 @@ except Exception:
     print("missing"); sys.exit()
 t = ((c.get("gateway", {}) or {}).get("auth", {}) or {}).get("token")
 if isinstance(t, dict):
-    print("secretref")
+    keys = set(t)
+    source = t.get("source")
+    ref_id = t.get("id")
+    canonical = (
+        source in ("env", "file", "exec") and
+        isinstance(ref_id, str) and ref_id.strip() and
+        keys == {"source", "provider", "id"} and
+        isinstance(t.get("provider"), str) and t["provider"].strip()
+    )
+    print("secretref" if canonical else "weak")
 elif isinstance(t, str) and t.startswith("${") and t.endswith("}") and len(t) > 3:
     print("interp")
 elif isinstance(t, str) and t and t != "clawbox" and len(t) >= 32:

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -97,10 +97,17 @@ LEGACY_GATEWAY_TOKEN = "clawbox"
 MIN_GATEWAY_TOKEN_LENGTH = 32
 
 def is_strong_gateway_token(v):
-    # SecretRef object — managed externally. Require a known ref key so an
-    # empty/malformed {} isn't mistaken for a resolvable secret.
+    # SecretRef object — managed externally. OpenClaw stores canonical refs as
+    # {source, provider, id}. Reject legacy key-style, providerless, partial,
+    # and extra-key objects: current OpenClaw rejects all of those shapes.
     if isinstance(v, dict):
-        return any(k in v for k in ("env", "file", "exec"))
+        source = v.get("source")
+        ref_id = v.get("id")
+        if source in ("env", "file", "exec") and isinstance(ref_id, str) and ref_id.strip():
+            provider = v.get("provider")
+            if set(v) == {"source", "provider", "id"} and isinstance(provider, str) and provider.strip():
+                return True
+        return False
     if isinstance(v, str):
         # `${VAR}` interpolation (non-empty body) resolves from env at runtime.
         if v.startswith("${") and v.endswith("}") and len(v) > 3:

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -784,9 +784,13 @@ export async function POST(request: Request) {
     await runCommand(OPENCLAW_BIN, [
       "config", "set", "gateway.auth.mode", "token",
     ]);
-    await runCommand(OPENCLAW_BIN, [
-      "config", "set", "gateway.auth.token", gatewayToken,
-    ]);
+    // A null result means the token is externally managed. Preserve the
+    // SecretRef/interpolation instead of replacing it with plaintext.
+    if (gatewayToken !== null) {
+      await runCommand(OPENCLAW_BIN, [
+        "config", "set", "gateway.auth.token", gatewayToken,
+      ]);
+    }
     await runCommand(OPENCLAW_BIN, [
       "config", "set", "gateway.controlUi.allowInsecureAuth", "true", "--json",
     ]);

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -83,10 +83,11 @@ export function isGatewaySecretRef(value: unknown): value is GatewaySecretRef {
   const keys = Object.keys(ref);
   const source = ref.source;
   if (source === "env" || source === "file" || source === "exec") {
+    // source is a valid enum and id/provider are non-empty strings, so with
+    // exactly 3 keys they must be {source, id, provider} — no need to re-assert
+    // each key is present.
     if (!isNonEmptyString(ref.id)) return false;
-    return keys.length === 3 && keys.includes("source") &&
-      keys.includes("id") && keys.includes("provider") &&
-      isNonEmptyString(ref.provider);
+    return keys.length === 3 && isNonEmptyString(ref.provider);
   }
   return false;
 }

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -70,7 +70,32 @@ const CLAWBOX_BAR = `<div id="clawbox-bar" style="position:fixed;top:0;left:50%;
 <a href="/" style="color:#f97316;text-decoration:none;font-weight:600">ClawBox</a>
 </div>`;
 
-export async function getGatewayToken(): Promise<string> {
+type GatewaySecretRef =
+  { source: "env" | "file" | "exec"; provider: string; id: string };
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function isGatewaySecretRef(value: unknown): value is GatewaySecretRef {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const ref = value as Record<string, unknown>;
+  const keys = Object.keys(ref);
+  const source = ref.source;
+  if (source === "env" || source === "file" || source === "exec") {
+    if (!isNonEmptyString(ref.id)) return false;
+    return keys.length === 3 && keys.includes("source") &&
+      keys.includes("id") && keys.includes("provider") &&
+      isNonEmptyString(ref.provider);
+  }
+  return false;
+}
+
+function isGatewayTokenInterpolation(value: unknown): value is string {
+  return typeof value === "string" && /^\$\{.+\}$/.test(value);
+}
+
+async function readGatewayTokenInput(): Promise<unknown> {
   try {
     const raw = await fs.readFile(OPENCLAW_CONFIG_PATH, "utf-8");
     const config = JSON.parse(raw);
@@ -78,6 +103,15 @@ export async function getGatewayToken(): Promise<string> {
   } catch {
     return "";
   }
+}
+
+export async function getGatewayToken(): Promise<string> {
+  const token = await readGatewayTokenInput();
+  // ClawBox cannot resolve managed refs safely. Do not serialize a SecretRef
+  // object or an unresolved ${ENV} marker into the browser as an auth token.
+  return typeof token === "string" && !isGatewayTokenInterpolation(token)
+    ? token
+    : "";
 }
 
 // Legacy literal that earlier ClawBox builds wrote into `gateway.auth.token`.
@@ -88,16 +122,20 @@ const LEGACY_GATEWAY_TOKEN = "clawbox";
 const MIN_GATEWAY_TOKEN_LENGTH = 32;
 
 /**
- * Returns the existing per-device gateway auth token, or freshly generates
- * one when the on-disk value is missing, the legacy literal `"clawbox"`, or
- * shorter than the minimum random length.
+ * Returns null for an externally managed token, the existing per-device
+ * literal token when strong, or a fresh token when the on-disk value is
+ * missing, the legacy literal `"clawbox"`, malformed, or too short.
  *
  * Caller is responsible for persisting the returned value (via
  * `runOpenclawConfigSet`, `runCommand`, or a direct seed write).
  */
-export async function getOrGenerateGatewayToken(): Promise<string> {
-  const existing = await getGatewayToken();
+export async function getOrGenerateGatewayToken(): Promise<string | null> {
+  const existing = await readGatewayTokenInput();
+  if (isGatewaySecretRef(existing) || isGatewayTokenInterpolation(existing)) {
+    return null;
+  }
   if (
+    typeof existing === "string" &&
     existing &&
     existing !== LEGACY_GATEWAY_TOKEN &&
     existing.length >= MIN_GATEWAY_TOKEN_LENGTH

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -418,6 +418,30 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(commands).not.toContain("config set gateway.auth.token clawbox");
   });
 
+  it("preserves an externally managed gateway token when settings are saved", async () => {
+    const secretRef = {
+      source: "exec",
+      provider: "vault",
+      id: "gateway-token",
+    };
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("openclaw.json")
+        ? JSON.stringify({ gateway: { auth: { token: secretRef } } })
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({ provider: "llamacpp" }));
+    expect(res.status).toBe(200);
+
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map(
+      (call) => ["config", "set", ...(call[0] ?? [])].join(" "),
+    );
+    expect(commands).toContain("config set gateway.auth.mode token");
+    expect(commands.some((command) =>
+      command.startsWith("config set gateway.auth.token "),
+    )).toBe(false);
+  });
+
   it("promotes local AI to the active default when no primary AI provider was configured", async () => {
     const res = await configurePost(jsonRequest({
       provider: "llamacpp",

--- a/src/tests/unit/gateway-pre-start-token.test.ts
+++ b/src/tests/unit/gateway-pre-start-token.test.ts
@@ -79,12 +79,19 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh token policy", () => {
     it("empty ${} interpolation is weak", () => {
       expect(classify("${}")).toBe("weak");
     });
-    it("SecretRef object with a known key is strong (externally managed)", () => {
-      expect(classify({ env: "OPENCLAW_GATEWAY_TOKEN" })).toBe("strong");
-      // file/exec are equally valid SecretRef shapes — assert each so a
-      // regression that drops one from the accepted-key set is caught.
-      expect(classify({ file: "/run/secrets/gateway-token" })).toBe("strong");
-      expect(classify({ exec: "cat /run/secrets/token" })).toBe("strong");
+    it("canonical SecretRef objects are strong (externally managed)", () => {
+      expect(classify({ source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" })).toBe("strong");
+      expect(classify({ source: "file", provider: "mounted", id: "/gateway/token" })).toBe("strong");
+      expect(classify({ source: "exec", provider: "vault", id: "gateway-token" })).toBe("strong");
+    });
+    it("malformed SecretRef objects are weak", () => {
+      expect(classify({ source: "bogus", provider: "default", id: "TOKEN" })).toBe("weak");
+      expect(classify({ source: "exec" })).toBe("weak");
+      expect(classify({ source: "exec", provider: "", id: "gateway-token" })).toBe("weak");
+      expect(classify({ source: "exec", provider: "vault", id: "gateway-token", extra: true })).toBe("weak");
+      expect(classify({ exec: "" })).toBe("weak");
+      expect(classify({ source: "exec", id: "gateway-token" })).toBe("weak");
+      expect(classify({ env: "OPENCLAW_GATEWAY_TOKEN" })).toBe("weak");
     });
     it("empty/keyless object is weak (not a resolvable secret)", () => {
       expect(classify({})).toBe("weak");
@@ -111,6 +118,14 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh token policy", () => {
       expect(rotateOutcome("${OPENCLAW_GATEWAY_TOKEN}")).toBe(
         "${OPENCLAW_GATEWAY_TOKEN}",
       );
+    });
+    it("preserves a canonical SecretRef unchanged", () => {
+      const ref = { source: "exec", provider: "vault", id: "gateway-token" };
+      const output = runPython(
+        `import json, sys, secrets\nt = json.loads(sys.argv[1])\nprint(json.dumps(t if is_strong_gateway_token(t) else secrets.token_hex(32), sort_keys=True))`,
+        JSON.stringify(ref),
+      );
+      expect(JSON.parse(output)).toEqual(ref);
     });
   });
 });

--- a/src/tests/unit/gateway-proxy.test.ts
+++ b/src/tests/unit/gateway-proxy.test.ts
@@ -148,9 +148,40 @@ describe("gateway-proxy", () => {
 
       expect(a).not.toBe(b);
     });
+
+    it("preserves a canonical SecretRef without resolving it", async () => {
+      const token = { source: "env", provider: "default", id: "OPENCLAW_GATEWAY_TOKEN" };
+      mockFs.readFile.mockResolvedValue(JSON.stringify({ gateway: { auth: { token } } }));
+      await expect(gatewayProxy.getOrGenerateGatewayToken()).resolves.toBeNull();
+    });
+
+    it("rotates malformed SecretRef objects", async () => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({
+        gateway: { auth: { token: { source: "exec", provider: "vault" } } },
+      }));
+      await expect(gatewayProxy.getOrGenerateGatewayToken()).resolves.toMatch(HEX_64);
+    });
   });
 
   describe("serveGatewayHTML", () => {
+    it("does not serialize a SecretRef into the browser", async () => {
+      mockFs.readFile.mockResolvedValue(JSON.stringify({
+        gateway: { auth: { token: { source: "exec", provider: "vault", id: "gateway-token" } } },
+      }));
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("<html><body>Gateway Content</body></html>"),
+      }));
+
+      const response = await gatewayProxy.serveGatewayHTML(
+        createRequest("http://clawbox.local/", { host: "clawbox.local" }),
+      );
+      const html = await response.text();
+
+      expect(html).not.toContain("gateway-token");
+      expect(html).not.toContain("[object Object]");
+      expect(html).not.toContain('h.set("token"');
+    });
     it("fetches and injects ClawBox bar", async () => {
       const mockFetch = vi.fn().mockResolvedValue({
         ok: true,


### PR DESCRIPTION
Fixes #249. Supersedes #296 — same fix (@jamesachurchill's commit, authorship preserved), re-homed onto current beta and run through our flow.

## The bug
`gateway-pre-start.sh`'s token predicate checked for keys literally named `env`/`file`/`exec`, but OpenClaw's canonical SecretRef uses `{source, provider, id}` (the *source value* is env/file/exec). So the predicate failed to recognize a valid ref and **clobbered a secret-managed `gateway.auth.token` with a random literal on every gateway start** — confirmed on-device.

## The fix
Recognize the canonical `{source, provider, id}` shape (source ∈ env/file/exec, non-empty string provider+id, exact key set) across all four places the predicate is mirrored (`gateway-pre-start.sh` Python, `install.sh`, `install-x64.sh`, `src/lib/gateway-proxy.ts`), preserving the ref instead of overwriting it. Also hardens `getGatewayToken()` to return `""` for an unresolved SecretRef/`${ENV}` rather than serialising it into the browser.

## Verified on the Jetson (aarch64)
- `tsc --noEmit`: clean (no errors in changed files; matches beta baseline).
- Tests: **78 pass** (`gateway-pre-start-token.test.ts`, `gateway-proxy.test.ts`, `ai-models/configure.test.ts`).
- Earlier runtime validation on the box: canonical ref preserved byte-identical; a malformed ref correctly rotated to a fresh token.