### PR TITLE
fix(gateway): bound permanent startup failures (#284)

### DIFF
--- a/config/clawbox-gateway.service
+++ b/config/clawbox-gateway.service
@@ -2,6 +2,12 @@
 Description=ClawBox OpenClaw Gateway
 After=network-online.target
 Wants=network-online.target
+# A cold Jetson can legitimately spend up to TimeoutStartSec in
+# gateway-pre-start.sh. Keep the limiter window long enough to contain several
+# complete slow failures; inherited 5-in-10s defaults never tripped when one
+# failed cycle already took longer than ten seconds (issue #284).
+StartLimitIntervalSec=3600
+StartLimitBurst=5
 
 [Service]
 Type=simple
@@ -13,7 +19,8 @@ ExecStartPre=/home/clawbox/clawbox/scripts/gateway-pre-start.sh
 # gateway-proxy.ts injects into the SPA). Passing a literal here would override
 # that and reintroduce the shared-token / UI-drift bug (issues #149, #150).
 ExecStart=/home/clawbox/.npm-global/bin/openclaw gateway --allow-unconfigured --bind lan
-Restart=always
+# Retry crashes and rejected startups, but leave deliberate clean stops alone.
+Restart=on-failure
 RestartSec=5
 # gateway-pre-start.sh runs as a blocking ExecStartPre. The default
 # ~90s start timeout could kill a legitimately slow first-boot pre-start

--- a/install.sh
+++ b/install.sh
@@ -1404,6 +1404,7 @@ step_gateway_legacy_state_recovery() {
 
   echo "  Gateway is not listening on ${gw_port}; running OpenClaw doctor recovery"
   as_clawbox "$OPENCLAW_BIN" doctor --fix --yes --non-interactive || true
+  systemctl reset-failed clawbox-gateway.service 2>/dev/null || true
   systemctl restart clawbox-gateway.service || true
   sleep 8
   if gateway_port_listening; then
@@ -1440,6 +1441,7 @@ step_gateway_legacy_state_recovery() {
   fi
 
   as_clawbox "$OPENCLAW_BIN" doctor --fix --yes --non-interactive || true
+  systemctl reset-failed clawbox-gateway.service 2>/dev/null || true
   systemctl start clawbox-gateway.service || true
   sleep 12
 
@@ -1842,6 +1844,9 @@ CONF
 
   systemctl daemon-reload
   systemctl enable clawbox-gateway.service
+  # Clear any tripped start-limit (breaker) state so the restart isn't refused
+  # on a box whose gateway had been crash-looping (issue #284 breaker).
+  systemctl reset-failed clawbox-gateway.service 2>/dev/null || true
   systemctl restart clawbox-gateway.service
 }
 

--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -108,7 +108,7 @@ function gatewayOfflineResponse(health: GatewayServiceHealth) {
     status: 503,
     headers: {
       "Content-Type": "text/html; charset=utf-8",
-      "Cache-Control": "no-cache",
+      "Cache-Control": "no-store, no-cache",
     },
   });
 }

--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getGatewayToken } from "@/lib/gateway-proxy";
+import { getGatewayServiceHealth, type GatewayServiceHealth } from "@/lib/gateway-health";
 
 export const dynamic = "force-dynamic";
 
@@ -15,7 +16,7 @@ export async function GET(request: NextRequest) {
       getGatewayToken(),
     ]);
     if (!res.ok) {
-      return gatewayOfflineResponse();
+      return gatewayOfflineResponse(await getGatewayServiceHealth());
     }
     let html = await res.text();
     // Use the request hostname so WebSocket connects to the right address
@@ -61,11 +62,23 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch {
-    return gatewayOfflineResponse();
+    return gatewayOfflineResponse(await getGatewayServiceHealth());
   }
 }
 
-function gatewayOfflineResponse() {
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+  })[character] ?? character);
+}
+
+function gatewayOfflineResponse(health: GatewayServiceHealth) {
+  const breaker = health.breakerActive
+    ? `<p class="breaker" role="alert"><strong>Automatic restart breaker activated.</strong> Repair the configuration, then run <code>sudo systemctl reset-failed clawbox-gateway &amp;&amp; sudo systemctl restart clawbox-gateway</code>.</p>`
+    : "";
+  const finalError = health.finalStartupError
+    ? `<pre>${escapeHtml(health.finalStartupError)}</pre>`
+    : "";
   const html = `<!DOCTYPE html>
 <html><head><style>
   body { margin:0; height:100vh; display:flex; align-items:center; justify-content:center;
@@ -73,6 +86,12 @@ function gatewayOfflineResponse() {
   .box { text-align:center; }
   h2 { color:#e2e8f0; margin:0 0 8px; font-size:18px; }
   p { margin:0; font-size:14px; }
+  .box { max-width:720px; padding:24px; }
+  .breaker { margin-top:14px; color:#fbbf24; line-height:1.5; }
+  code, pre { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; }
+  code { color:#fed7aa; }
+  pre { margin:14px 0 0; padding:12px; text-align:left; white-space:pre-wrap; overflow-wrap:anywhere;
+        border:1px solid #7f1d1d; border-radius:8px; background:#1f1115; color:#fecaca; font-size:12px; }
   button { margin-top:16px; padding:8px 20px; border:1px solid #334155; border-radius:8px;
            background:#1e293b; color:#e2e8f0; cursor:pointer; font-size:13px; }
   button:hover { background:#334155; }
@@ -80,6 +99,8 @@ function gatewayOfflineResponse() {
 <div class="box">
   <h2>OpenClaw Gateway Offline</h2>
   <p>The gateway service is not running on port ${GATEWAY_PORT}.</p>
+  ${breaker}
+  ${finalError}
   <button onclick="location.reload()">Retry</button>
 </div>
 </body></html>`;

--- a/src/lib/gateway-health.ts
+++ b/src/lib/gateway-health.ts
@@ -1,0 +1,108 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const exec = promisify(execFile);
+const GATEWAY_UNIT = "clawbox-gateway.service";
+
+export interface GatewayServiceHealth {
+  active: boolean;
+  breakerActive: boolean;
+  activeState: string | null;
+  subState: string | null;
+  result: string | null;
+  restartCount: number | null;
+  finalStartupError: string | null;
+}
+
+export function parseGatewaySystemctlProperties(output: string): Omit<GatewayServiceHealth, "finalStartupError"> {
+  const properties: Record<string, string> = Object.fromEntries(
+    output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => {
+        const split = line.indexOf("=");
+        return split < 0 ? [line, ""] : [line.slice(0, split), line.slice(split + 1)];
+      }),
+  );
+  const restartCount = Number.parseInt(properties.NRestarts ?? "", 10);
+  return {
+    active: properties.ActiveState === "active",
+    // systemd 249 (Ubuntu 22.04) exposes rate limiting through the documented
+    // service Result enum. This remains set after the unit enters failed.
+    breakerActive: properties.Result === "start-limit-hit",
+    activeState: properties.ActiveState || null,
+    subState: properties.SubState || null,
+    result: properties.Result || null,
+    restartCount: Number.isFinite(restartCount) ? restartCount : null,
+  };
+}
+
+function sanitizeJournalLine(line: string): string {
+  return line
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, "")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ")
+    .replace(/\b\d{6,12}:[A-Za-z0-9_-]{20,}\b/g, "[redacted-telegram-token]")
+    .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]")
+    .replace(/(["']?(?:token|secret|credential)["']?\s*[:=]\s*["']?)[^\s,"'}]{8,}/gi, "$1[redacted]")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 1_000);
+}
+
+export function lastUsefulJournalLine(output: string): string | null {
+  const lines = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .filter((line) => !/^clawbox-gateway\.service: (Scheduled restart job|Main process exited|Failed with result|Start request repeated too quickly)/i.test(line))
+    .filter((line) => !/^(Stopped|Started|Failed to start) ClawBox OpenClaw Gateway/i.test(line));
+  const finalLine = lines.at(-1);
+  return finalLine ? sanitizeJournalLine(finalLine) || null : null;
+}
+
+export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
+  try {
+    const { stdout } = await exec(
+      "/usr/bin/systemctl",
+      [
+        "show",
+        GATEWAY_UNIT,
+        "--property=ActiveState,SubState,Result,NRestarts",
+        "--no-pager",
+      ],
+      { timeout: 3_000 },
+    );
+    const parsed = parseGatewaySystemctlProperties(stdout);
+    const breakerActive = parsed.breakerActive;
+    let finalStartupError: string | null = null;
+
+    if (parsed.activeState === "failed" || breakerActive) {
+      try {
+        const journal = await exec(
+          "/usr/bin/journalctl",
+          ["-u", GATEWAY_UNIT, "-n", "40", "--no-pager", "-o", "cat"],
+          { timeout: 5_000, maxBuffer: 512 * 1024 },
+        );
+        finalStartupError = lastUsefulJournalLine(journal.stdout);
+      } catch {
+        // The state itself is still useful on restricted/container installs.
+      }
+    }
+
+    return {
+      ...parsed,
+      finalStartupError,
+    };
+  } catch {
+    return {
+      active: false,
+      breakerActive: false,
+      activeState: null,
+      subState: null,
+      result: null,
+      restartCount: null,
+      finalStartupError: null,
+    };
+  }
+}

--- a/src/lib/gateway-health.ts
+++ b/src/lib/gateway-health.ts
@@ -44,7 +44,8 @@ function sanitizeJournalLine(line: string): string {
     .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, " ")
     .replace(/\b\d{6,12}:[A-Za-z0-9_-]{20,}\b/g, "[redacted-telegram-token]")
     .replace(/\b(Bearer\s+)[A-Za-z0-9._~+/=-]{12,}/gi, "$1[redacted]")
-    .replace(/(["']?(?:token|secret|credential)["']?\s*[:=]\s*["']?)[^\s,"'}]{8,}/gi, "$1[redacted]")
+    .replace(/(["']?(?:token|secret|credential|password|passwd|pwd|api[_-]?key)["']?\s*[:=]\s*["']?)[^\s,"'}]{6,}/gi, "$1[redacted]")
+    .replace(/\bsk-(?:ant-)?[A-Za-z0-9._-]{16,}\b/g, "[redacted-key]")
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, 1_000);
@@ -65,9 +66,10 @@ export function gatewayJournalArgs(systemctlOutput: string): string[] | null {
   const invocationId = /^InvocationID=([0-9a-f]{32})$/im.exec(systemctlOutput)?.[1];
   if (!invocationId) return null;
 
+  // Scope strictly to the current failed activation. Combining `-u UNIT` with a
+  // field match doesn't AND as intended (`-u` expands to OR match-groups), so
+  // match on the invocation id alone — it's globally unique to this activation.
   return [
-    "-u",
-    GATEWAY_UNIT,
     `_SYSTEMD_INVOCATION_ID=${invocationId}`,
     "-n",
     "40",
@@ -87,7 +89,7 @@ export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
         "--property=ActiveState,SubState,Result,NRestarts,InvocationID",
         "--no-pager",
       ],
-      { timeout: 3_000 },
+      { timeout: 2_000 },
     );
     const parsed = parseGatewaySystemctlProperties(stdout);
     const breakerActive = parsed.breakerActive;
@@ -100,7 +102,7 @@ export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
           const journal = await exec(
             "/usr/bin/journalctl",
             journalArgs,
-            { timeout: 5_000, maxBuffer: 512 * 1024 },
+            { timeout: 2_500, maxBuffer: 512 * 1024 },
           );
           finalStartupError = lastUsefulJournalLine(journal.stdout);
         } catch {

--- a/src/lib/gateway-health.ts
+++ b/src/lib/gateway-health.ts
@@ -61,6 +61,22 @@ export function lastUsefulJournalLine(output: string): string | null {
   return finalLine ? sanitizeJournalLine(finalLine) || null : null;
 }
 
+export function gatewayJournalArgs(systemctlOutput: string): string[] | null {
+  const invocationId = /^InvocationID=([0-9a-f]{32})$/im.exec(systemctlOutput)?.[1];
+  if (!invocationId) return null;
+
+  return [
+    "-u",
+    GATEWAY_UNIT,
+    `_SYSTEMD_INVOCATION_ID=${invocationId}`,
+    "-n",
+    "40",
+    "--no-pager",
+    "-o",
+    "cat",
+  ];
+}
+
 export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
   try {
     const { stdout } = await exec(
@@ -68,7 +84,7 @@ export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
       [
         "show",
         GATEWAY_UNIT,
-        "--property=ActiveState,SubState,Result,NRestarts",
+        "--property=ActiveState,SubState,Result,NRestarts,InvocationID",
         "--no-pager",
       ],
       { timeout: 3_000 },
@@ -78,15 +94,18 @@ export async function getGatewayServiceHealth(): Promise<GatewayServiceHealth> {
     let finalStartupError: string | null = null;
 
     if (parsed.activeState === "failed" || breakerActive) {
-      try {
-        const journal = await exec(
-          "/usr/bin/journalctl",
-          ["-u", GATEWAY_UNIT, "-n", "40", "--no-pager", "-o", "cat"],
-          { timeout: 5_000, maxBuffer: 512 * 1024 },
-        );
-        finalStartupError = lastUsefulJournalLine(journal.stdout);
-      } catch {
-        // The state itself is still useful on restricted/container installs.
+      const journalArgs = gatewayJournalArgs(stdout);
+      if (journalArgs) {
+        try {
+          const journal = await exec(
+            "/usr/bin/journalctl",
+            journalArgs,
+            { timeout: 5_000, maxBuffer: 512 * 1024 },
+          );
+          finalStartupError = lastUsefulJournalLine(journal.stdout);
+        } catch {
+          // The state itself is still useful on restricted/container installs.
+        }
       }
     }
 

--- a/src/tests/routes/gateway/gateway.test.ts
+++ b/src/tests/routes/gateway/gateway.test.ts
@@ -61,6 +61,7 @@ describe("/setup-api/gateway", () => {
     const req = new NextRequest(new URL("http://clawbox.local/setup-api/gateway"));
     const res = await GET(req);
     expect(res.status).toBe(503);
+    expect(res.headers.get("Cache-Control")).toContain("no-store");
     const html = await res.text();
     expect(html).toContain("Gateway Offline");
     expect(html).toContain("Config validation failed");

--- a/src/tests/routes/gateway/gateway.test.ts
+++ b/src/tests/routes/gateway/gateway.test.ts
@@ -8,7 +8,20 @@ vi.mock("@/lib/gateway-proxy", () => ({
   getGatewayToken: vi.fn().mockResolvedValue("test-token"),
 }));
 
+vi.mock("@/lib/gateway-health", () => ({
+  getGatewayServiceHealth: vi.fn().mockResolvedValue({
+    active: false,
+    breakerActive: false,
+    activeState: "failed",
+    subState: "failed",
+    result: "exit-code",
+    restartCount: 2,
+    finalStartupError: "Config validation failed",
+  }),
+}));
+
 import { getGatewayToken } from "@/lib/gateway-proxy";
+import { getGatewayServiceHealth } from "@/lib/gateway-health";
 
 describe("/setup-api/gateway", () => {
   let GET: (req: NextRequest) => Promise<Response>;
@@ -17,6 +30,15 @@ describe("/setup-api/gateway", () => {
     vi.resetModules();
     vi.clearAllMocks();
     vi.mocked(getGatewayToken).mockResolvedValue("test-token");
+    vi.mocked(getGatewayServiceHealth).mockResolvedValue({
+      active: false,
+      breakerActive: false,
+      activeState: "failed",
+      subState: "failed",
+      result: "exit-code",
+      restartCount: 2,
+      finalStartupError: "Config validation failed",
+    });
     const mod = await import("@/app/setup-api/gateway/route");
     GET = mod.GET;
   });
@@ -41,6 +63,7 @@ describe("/setup-api/gateway", () => {
     expect(res.status).toBe(503);
     const html = await res.text();
     expect(html).toContain("Gateway Offline");
+    expect(html).toContain("Config validation failed");
   });
 
   it("returns offline HTML when gateway responds with error", async () => {
@@ -49,5 +72,28 @@ describe("/setup-api/gateway", () => {
     const res = await GET(req);
     const html = await res.text();
     expect(html).toContain("Gateway Offline");
+  });
+
+  it("reports an activated breaker with safe actionable recovery", async () => {
+    mockFetch.mockRejectedValue(new Error("Connection refused"));
+    vi.mocked(getGatewayServiceHealth).mockResolvedValue({
+      active: false,
+      breakerActive: true,
+      activeState: "failed",
+      subState: "failed",
+      result: "start-limit-hit",
+      restartCount: 3,
+      finalStartupError: "bad config <script>alert(1)</script>",
+    });
+
+    const req = new NextRequest(new URL("http://clawbox.local/setup-api/gateway"));
+    const res = await GET(req);
+    const html = await res.text();
+
+    expect(html).toContain("Automatic restart breaker activated");
+    expect(html.match(/role="alert"/g)).toHaveLength(1);
+    expect(html).toContain("systemctl reset-failed clawbox-gateway");
+    expect(html).toContain("bad config &lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
   });
 });

--- a/src/tests/unit/gateway-health.test.ts
+++ b/src/tests/unit/gateway-health.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { lastUsefulJournalLine, parseGatewaySystemctlProperties } from "@/lib/gateway-health";
+
+describe("gateway service health", () => {
+  it("keeps the final startup error instead of a repeated restart notice", () => {
+    const journal = [
+      "Config validation failed: exec SecretRef command must resolve to a real path",
+      "clawbox-gateway.service: Main process exited, code=exited, status=1/FAILURE",
+      "clawbox-gateway.service: Scheduled restart job, restart counter is at 3.",
+    ].join("\n");
+
+    expect(lastUsefulJournalLine(journal)).toBe(
+      "Config validation failed: exec SecretRef command must resolve to a real path",
+    );
+  });
+
+  it("returns null for an empty journal", () => {
+    expect(lastUsefulJournalLine("\n")).toBeNull();
+  });
+
+  it("recognizes systemd 249's documented start-limit-hit result", () => {
+    expect(parseGatewaySystemctlProperties([
+      "ActiveState=failed",
+      "SubState=failed",
+      "Result=start-limit-hit",
+      "NRestarts=5",
+    ].join("\n"))).toEqual({
+      active: false,
+      breakerActive: true,
+      activeState: "failed",
+      subState: "failed",
+      result: "start-limit-hit",
+      restartCount: 5,
+    });
+  });
+
+  it("normalizes control characters and caps journal output", () => {
+    const unsafe = `\u001b[31mConfig\u0000 failure ${"x".repeat(2_000)}`;
+    const result = lastUsefulJournalLine(unsafe);
+
+    expect(result).toMatch(/^Config failure x+$/);
+    expect(result).toHaveLength(1_000);
+    expect(result).not.toContain("\u001b");
+  });
+
+  it("redacts credentials from the authenticated error summary", () => {
+    const line = 'Config failed token="super-secret-value" bot=123456789:ABCdefGHIjklMNOpqrSTUvwxYZ012345';
+    const result = lastUsefulJournalLine(line);
+
+    expect(result).toContain('token="[redacted]');
+    expect(result).toContain("[redacted-telegram-token]");
+    expect(result).not.toContain("super-secret-value");
+    expect(result).not.toContain("ABCdefGHI");
+  });
+});

--- a/src/tests/unit/gateway-health.test.ts
+++ b/src/tests/unit/gateway-health.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { lastUsefulJournalLine, parseGatewaySystemctlProperties } from "@/lib/gateway-health";
+import {
+  gatewayJournalArgs,
+  lastUsefulJournalLine,
+  parseGatewaySystemctlProperties,
+} from "@/lib/gateway-health";
 
 describe("gateway service health", () => {
   it("keeps the final startup error instead of a repeated restart notice", () => {
@@ -16,6 +20,18 @@ describe("gateway service health", () => {
 
   it("returns null for an empty journal", () => {
     expect(lastUsefulJournalLine("\n")).toBeNull();
+  });
+
+  it("scopes journal diagnostics to the failed activation", () => {
+    const invocationId = "0123456789abcdef0123456789abcdef";
+    const args = gatewayJournalArgs(`ActiveState=failed\nInvocationID=${invocationId}\n`);
+
+    expect(args).toContain(`_SYSTEMD_INVOCATION_ID=${invocationId}`);
+    expect(args).toContain("clawbox-gateway.service");
+  });
+
+  it("does not fall back to stale journal history without an activation ID", () => {
+    expect(gatewayJournalArgs("ActiveState=failed\nInvocationID=\n")).toBeNull();
   });
 
   it("recognizes systemd 249's documented start-limit-hit result", () => {

--- a/src/tests/unit/gateway-health.test.ts
+++ b/src/tests/unit/gateway-health.test.ts
@@ -27,7 +27,9 @@ describe("gateway service health", () => {
     const args = gatewayJournalArgs(`ActiveState=failed\nInvocationID=${invocationId}\n`);
 
     expect(args).toContain(`_SYSTEMD_INVOCATION_ID=${invocationId}`);
-    expect(args).toContain("clawbox-gateway.service");
+    // Scoped by invocation id alone — no `-u UNIT`, which would OR-expand and
+    // break the AND with the invocation filter (surfacing stale lines).
+    expect(args).not.toContain("-u");
   });
 
   it("does not fall back to stale journal history without an activation ID", () => {
@@ -60,12 +62,16 @@ describe("gateway service health", () => {
   });
 
   it("redacts credentials from the authenticated error summary", () => {
-    const line = 'Config failed token="super-secret-value" bot=123456789:ABCdefGHIjklMNOpqrSTUvwxYZ012345';
+    const line = 'Config failed token="super-secret-value" bot=123456789:ABCdefGHIjklMNOpqrSTUvwxYZ012345 password=Hunter2Long key sk-proj-BAREKEY1234567890abcdefXY';
     const result = lastUsefulJournalLine(line);
 
     expect(result).toContain('token="[redacted]');
     expect(result).toContain("[redacted-telegram-token]");
+    expect(result).toContain("password=[redacted]");
+    expect(result).toContain("[redacted-key]");
     expect(result).not.toContain("super-secret-value");
     expect(result).not.toContain("ABCdefGHI");
+    expect(result).not.toContain("Hunter2Long");
+    expect(result).not.toContain("BAREKEY");
   });
 });

--- a/src/tests/unit/install-post-update-units.test.ts
+++ b/src/tests/unit/install-post-update-units.test.ts
@@ -78,6 +78,8 @@ describe("gateway restart breaker", () => {
 
   it("uses failure-only restarts and an explicit window covering the worst-case burst", () => {
     expect(GATEWAY_UNIT).toMatch(/^Restart=on-failure$/m);
+    expect(intervalSec).toBe(3_600);
+    expect(burst).toBe(5);
     expect(intervalSec).toBeGreaterThan(burst * (timeoutSec + restartSec));
   });
 

--- a/src/tests/unit/install-post-update-units.test.ts
+++ b/src/tests/unit/install-post-update-units.test.ts
@@ -24,6 +24,10 @@ const LLAMACPP_ROUTE = readFileSync(
   path.join(REPO, "src/app/setup-api/llamacpp/install/route.ts"),
   "utf-8",
 );
+const GATEWAY_UNIT = readFileSync(
+  path.join(REPO, "config/clawbox-gateway.service"),
+  "utf-8",
+);
 
 function extractShellFunction(name: string): string {
   const start = INSTALL_SH.indexOf(`${name}() {`);
@@ -53,6 +57,43 @@ describe("in-app update delivers unit-file changes", () => {
       INSTALL_SH.indexOf(")", INSTALL_SH.indexOf("DISPATCH_STEPS=(")),
     );
     expect(dispatch).toContain("systemd_services");
+  });
+});
+
+describe("gateway restart breaker", () => {
+  const intervalSec = Number(/^StartLimitIntervalSec=(\d+)$/m.exec(GATEWAY_UNIT)?.[1]);
+  const burst = Number(/^StartLimitBurst=(\d+)$/m.exec(GATEWAY_UNIT)?.[1]);
+  const timeoutSec = Number(/^TimeoutStartSec=(\d+)$/m.exec(GATEWAY_UNIT)?.[1]);
+  const restartSec = Number(/^RestartSec=(\d+)$/m.exec(GATEWAY_UNIT)?.[1]);
+
+  function acceptedStarts(failureDurationSec: number, attempts: number): number[] {
+    const accepted: number[] = [];
+    for (let attempt = 0, at = 0; attempt < attempts; attempt += 1, at += failureDurationSec + restartSec) {
+      const inWindow = accepted.filter((startedAt) => at - startedAt <= intervalSec);
+      if (inWindow.length >= burst) break;
+      accepted.push(at);
+    }
+    return accepted;
+  }
+
+  it("uses failure-only restarts and an explicit window covering the worst-case burst", () => {
+    expect(GATEWAY_UNIT).toMatch(/^Restart=on-failure$/m);
+    expect(intervalSec).toBeGreaterThan(burst * (timeoutSec + restartSec));
+  });
+
+  it("breaks a permanent failure whose 12-second cycles defeated the old 10-second window", () => {
+    expect(acceptedStarts(12, burst + 2)).toHaveLength(burst);
+  });
+
+  it("allows a transient first failure to recover on the next start", () => {
+    expect(acceptedStarts(12, 2)).toHaveLength(2);
+  });
+
+  it("is regenerated on both fresh install and update from the canonical unit", () => {
+    expect(extractShellFunction("step_gateway_setup")).toContain(
+      'cp "$PROJECT_DIR/config/clawbox-gateway.service" /etc/systemd/system/',
+    );
+    expect(extractShellFunction("step_post_update")).toContain("step_systemd_services");
   });
 });
 


### PR DESCRIPTION
Fixes #284. Supersedes #297 — same fix (@jamesachurchill's commits, authorship preserved), re-homed onto current beta and run through our flow.

## The bug
`clawbox-gateway.service` had `Restart=always` and no start limit, so a *permanently* failing gateway restarted forever. (systemd's default 5-in-10s limiter never trips with `RestartSec=5` — the window is too short — the exact footgun behind #284.)

## The fix
- `StartLimitIntervalSec=3600` + `StartLimitBurst=5` in the **`[Unit]`** section (not `[Service]`, where modern systemd ignores them) + `Restart=on-failure`: a permanently-failing gateway now stops after 5 attempts with `start-limit-hit` instead of thrashing. Recovery is `systemctl reset-failed && restart`.
- `src/lib/gateway-health.ts`: surfaces the breaker state on the authenticated gateway-offline page (unprivileged `systemctl show`; `journalctl` only when failed, scoped to the current invocation; secret redaction + HTML-escaping).

## Verified on the Jetson (aarch64)
- `tsc --noEmit`: clean · tests: **19 pass** (`gateway.test.ts`, `gateway-health.test.ts`, `install-post-update-units.test.ts`).
- Unit confirmed valid; limiter is in `[Unit]`.
- **Live breaker test earlier on the box:** beta config restarted forever (NRestarts climbed past 5); this config stopped at exactly 5 (`failed`), and `reset-failed` recovered — with the real `clawbox-gateway` untouched (throwaway units).