### PR TITLE
feat(gateway): support configurable trusted control-UI origins (#232)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ bun run test             # Unit tests (Vitest)
 | `SESSION_SECRET` | Auto-generated | Session cookie signing key |
 | `OLLAMA_HOST` | `http://127.0.0.1:11434` | Ollama server URL |
 | `CLAWBOX_ROOT` | `/home/clawbox/clawbox` | Project root directory |
-| `CLAWBOX_CONTROL_UI_ORIGINS_FILE` | `data/control-ui-origins.json` | Extra trusted control UI origins (see below) |
+| `CLAWBOX_CONTROL_UI_ORIGINS_FILE` | `/home/clawbox/clawbox/data/control-ui-origins.json` | Extra trusted control UI origins (see below) |
 
 Additional options (OAuth client IDs, ClawBox AI, llama.cpp tuning) live in `.env.example`.
 

--- a/README.md
+++ b/README.md
@@ -249,8 +249,35 @@ bun run test             # Unit tests (Vitest)
 | `SESSION_SECRET` | Auto-generated | Session cookie signing key |
 | `OLLAMA_HOST` | `http://127.0.0.1:11434` | Ollama server URL |
 | `CLAWBOX_ROOT` | `/home/clawbox/clawbox` | Project root directory |
+| `CLAWBOX_CONTROL_UI_ORIGINS_FILE` | `data/control-ui-origins.json` | Extra trusted control UI origins (see below) |
 
 Additional options (OAuth client IDs, ClawBox AI, llama.cpp tuning) live in `.env.example`.
+
+#### Trusted control UI origins
+
+This is only for genuine cross-origin/custom-origin deployments — for example,
+a reverse proxy that serves the Control UI from a different hostname or port.
+Same-origin access via `<hostname>.local`, a
+Tailscale `.ts.net` name, or a private LAN IP already works out of the box
+(see `ALLOWED_HOSTS` above and the mDNS/IP handling in
+`src/lib/gateway-proxy.ts`) and normally needs no entry here.
+
+To trust an additional origin, put a JSON array of exact `http`/`https`
+origins in `data/control-ui-origins.json` (or the path set by
+`CLAWBOX_CONTROL_UI_ORIGINS_FILE`):
+
+```json
+["https://control.example.com", "http://192.0.2.10:8080"]
+```
+
+Entries are validated strictly — no wildcards, credentials, paths, query
+strings, or fragments — and normalized (lowercased scheme/host, default
+ports dropped). Invalid entries are dropped with a warning; a missing file
+is normal and adds nothing. Matching is exact: a configured origin does not
+grant trust to the same hostname on a different scheme or port. See
+`scripts/gateway_origins.py` (loaded by `gateway-pre-start.sh` into the
+gateway's own `allowedOrigins`) and `src/lib/control-ui-origins.ts` (used by
+the Next.js proxy's redirect-origin reflection).
 
 ## 🤝 Contributing
 

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -92,8 +92,7 @@ export CLAWBOX_LAN_IPS
 # Loaded from CLAWBOX_CONTROL_UI_ORIGINS_FILE (or the module's default
 # path) via scripts/gateway_origins.py. Missing helper module or missing
 # config file both fall through to "no extras" — defaults still boot.
-export CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR="$SCRIPT_DIR"
-CLAWBOX_EXTRA_ORIGINS="$(python3 - <<'PY'
+CLAWBOX_EXTRA_ORIGINS="$(CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR="$SCRIPT_DIR" python3 - <<'PY'
 import os, sys
 
 script_dir = os.environ.get("CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR", "")
@@ -102,11 +101,24 @@ if script_dir:
 
 try:
     import gateway_origins
-except Exception:
+except Exception as exc:
+    print(
+        "  WARN: trusted control UI origins helper unavailable "
+        f"({type(exc).__name__}); using defaults only",
+        file=sys.stderr,
+    )
     sys.exit(0)
 
-path = gateway_origins.resolve_origins_path()
-origins, warnings = gateway_origins.load_configured_origins(path)
+try:
+    path = gateway_origins.resolve_origins_path()
+    origins, warnings = gateway_origins.load_configured_origins(path)
+except Exception as exc:
+    print(
+        "  WARN: trusted control UI origins helper failed "
+        f"({type(exc).__name__}); using defaults only",
+        file=sys.stderr,
+    )
+    sys.exit(0)
 for warning in warnings:
     print(f"  WARN: {warning}", file=sys.stderr)
 for origin in origins:

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -18,6 +18,8 @@
 # switch, and crash-triggered restart.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 OPENCLAW_BIN="/home/clawbox/.npm-global/bin/openclaw"
 OPENCLAW_CONFIG="/home/clawbox/.openclaw/openclaw.json"
 HOSTNAME_ENV="/home/clawbox/clawbox/data/hostname.env"
@@ -83,6 +85,41 @@ else
 fi
 export CLAWBOX_LAN_IPS
 
+# Trusted control UI origins — a narrow escape hatch for genuinely
+# cross-origin/custom-origin Control UI deployments (see README and
+# scripts/gateway_origins.py). Same-origin access via `<hostname>.local`,
+# `.ts.net`, or a private LAN IP already works without any entry here.
+# Loaded from CLAWBOX_CONTROL_UI_ORIGINS_FILE (or the module's default
+# path) via scripts/gateway_origins.py. Missing helper module or missing
+# config file both fall through to "no extras" — defaults still boot.
+export CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR="$SCRIPT_DIR"
+CLAWBOX_EXTRA_ORIGINS="$(python3 - <<'PY'
+import os, sys
+
+script_dir = os.environ.get("CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR", "")
+if script_dir:
+    sys.path.insert(0, script_dir)
+
+try:
+    import gateway_origins
+except Exception:
+    sys.exit(0)
+
+path = gateway_origins.resolve_origins_path()
+origins, warnings = gateway_origins.load_configured_origins(path)
+for warning in warnings:
+    print(f"  WARN: {warning}", file=sys.stderr)
+for origin in origins:
+    print(origin)
+PY
+)"
+if [ -n "$CLAWBOX_EXTRA_ORIGINS" ]; then
+  while IFS= read -r origin; do
+    [ -n "$origin" ] && echo "  Trusted control UI origin: $origin"
+  done <<<"$CLAWBOX_EXTRA_ORIGINS"
+fi
+export CLAWBOX_EXTRA_ORIGINS
+
 python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, os, sys, tempfile, secrets
 
@@ -118,6 +155,7 @@ def is_strong_gateway_token(v):
 cfg_path = sys.argv[1]
 hostname = os.environ.get("CLAWBOX_HOSTNAME", "clawbox")
 lan_ips = [line for line in os.environ.get("CLAWBOX_LAN_IPS", "").split("\n") if line]
+extra_origins = [line for line in os.environ.get("CLAWBOX_EXTRA_ORIGINS", "").split("\n") if line]
 
 allowed_origins = [
     f"http://{hostname}.local",
@@ -127,6 +165,12 @@ allowed_origins = [
     "http://10.43.0.1",
     *lan_ips,
 ]
+# Merge already-validated extra origins (scripts/gateway_origins.py) into the
+# generated defaults, deterministically and before the set comparison below —
+# defaults first, extras appended in file order, de-duplicated.
+for _extra in extra_origins:
+    if _extra not in allowed_origins:
+        allowed_origins.append(_extra)
 
 try:
     with open(cfg_path) as f:

--- a/scripts/gateway_origins.py
+++ b/scripts/gateway_origins.py
@@ -1,0 +1,165 @@
+"""Strict validation/loading of operator-supplied trusted control UI origins.
+
+This is a narrow escape hatch for genuinely cross-origin or custom-origin
+Control UI deployments (for example, a reverse proxy on a different
+hostname or port). Same-origin access via `<hostname>.local`,
+Tailscale `.ts.net` names, or a private LAN IP already works without any
+entry here — see gateway-proxy.ts's isReflectableHost() and
+gateway-pre-start.sh's LAN_IPS enumeration.
+
+Contract: a JSON array of strings at CLAWBOX_CONTROL_UI_ORIGINS_FILE (or the
+default path below) is read, validated, and merged into the gateway's
+generated `controlUi.allowedOrigins` list. A missing file is normal (no
+extras, no warning). Anything malformed is dropped with a warning — this
+module never raises, since a malformed file must not block gateway boot.
+"""
+
+import ipaddress
+import json
+import os
+import re
+import urllib.parse
+
+DEFAULT_ORIGINS_PATH = "/home/clawbox/clawbox/data/control-ui-origins.json"
+ORIGINS_PATH_ENV_VAR = "CLAWBOX_CONTROL_UI_ORIGINS_FILE"
+
+# DNS-style hostname: dot-separated labels, each starting/ending with an
+# alphanumeric, letters/digits/hyphens in between. Dotted-decimal input is
+# validated separately as IPv4 so the Python and TypeScript loaders cannot
+# disagree about malformed values such as 999.999.999.999.
+_HOSTNAME_RE = re.compile(
+    r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$"
+)
+
+
+def resolve_origins_path():
+    """The path to read configured extra origins from, honoring the env override."""
+    return os.environ.get(ORIGINS_PATH_ENV_VAR) or DEFAULT_ORIGINS_PATH
+
+
+def normalize_origin(raw):
+    """Validate and normalize a single origin.
+
+    Accepts exact http/https origins only — no wildcard, no credentials, no
+    path beyond "/", no query, no fragment, and a resolvable host[:port].
+    Normalizes scheme/host to lowercase, IPv6 hosts to bracket form, and
+    drops the port when it's the scheme's default (or when the origin has
+    a bare "/" or no path).
+
+    Returns (normalized_origin, warning) — exactly one of the two is None.
+    """
+    if not isinstance(raw, str):
+        return None, f"origin must be a string, got {type(raw).__name__}: {raw!r}"
+
+    value = raw.strip()
+    if not value:
+        return None, "origin is empty"
+    if "*" in value:
+        return None, f"wildcard origins are not allowed: {raw!r}"
+
+    try:
+        parsed = urllib.parse.urlsplit(value)
+    except ValueError:
+        # e.g. a malformed bracketed IPv6 host — urlsplit validates and
+        # raises ValueError itself rather than just leaving fields empty.
+        return None, f"origin could not be parsed: {raw!r}"
+
+    scheme = parsed.scheme.lower()
+    if scheme not in ("http", "https"):
+        return None, f"origin scheme must be http or https: {raw!r}"
+
+    if parsed.username is not None or parsed.password is not None:
+        return None, f"origin must not contain credentials: {raw!r}"
+
+    if parsed.path not in ("", "/"):
+        return None, f"origin must not contain a path: {raw!r}"
+    if parsed.query:
+        return None, f"origin must not contain a query string: {raw!r}"
+    if parsed.fragment:
+        return None, f"origin must not contain a fragment: {raw!r}"
+
+    try:
+        port = parsed.port
+    except ValueError:
+        return None, f"origin has an invalid port: {raw!r}"
+
+    hostname = parsed.hostname
+    if not hostname:
+        return None, f"origin is missing a host: {raw!r}"
+    hostname = hostname.lower()
+
+    if ":" in hostname:
+        # Bracketed IPv6 literal — urlsplit strips the brackets for .hostname.
+        try:
+            ipaddress.IPv6Address(hostname)
+        except ValueError:
+            return None, f"origin has an invalid IPv6 host: {raw!r}"
+        host_part = f"[{hostname}]"
+    else:
+        if not _HOSTNAME_RE.match(hostname):
+            return None, f"origin has an invalid host: {raw!r}"
+        if re.fullmatch(r"[0-9.]+", hostname):
+            try:
+                ipaddress.IPv4Address(hostname)
+            except ValueError:
+                return None, f"origin has an invalid IPv4 host: {raw!r}"
+        host_part = hostname
+
+    default_port = 443 if scheme == "https" else 80
+    port_part = "" if port is None or port == default_port else f":{port}"
+
+    return f"{scheme}://{host_part}{port_part}", None
+
+
+def load_configured_origins(path):
+    """Load, validate, and de-duplicate the JSON array of extra origins at `path`.
+
+    A missing file returns ([], []) — no extras, no warning. Any other
+    failure (unreadable file, invalid JSON, non-array top level, invalid
+    entries) is reported as a warning string and excluded from the result;
+    this function never raises.
+    """
+    if not path or not os.path.isfile(path):
+        return [], []
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            raw_text = f.read()
+    except OSError as exc:
+        return [], [f"could not read control UI origins file {path}: {exc}"]
+
+    try:
+        data = json.loads(raw_text)
+    except json.JSONDecodeError as exc:
+        return [], [f"control UI origins file {path} is not valid JSON: {exc}"]
+
+    if not isinstance(data, list):
+        return [], [
+            f"control UI origins file {path} must contain a JSON array, "
+            f"got {type(data).__name__}"
+        ]
+
+    warnings = []
+    origins = []
+    seen = set()
+    for index, entry in enumerate(data):
+        normalized, warning = normalize_origin(entry)
+        if warning:
+            warnings.append(f"control UI origins file {path} entry {index}: {warning}")
+            continue
+        if normalized not in seen:
+            seen.add(normalized)
+            origins.append(normalized)
+
+    return origins, warnings
+
+
+def merge_origins(defaults, extras):
+    """Merge `extras` into `defaults`: defaults first, de-duplicated, order preserved."""
+    merged = list(defaults)
+    seen = set(merged)
+    for origin in extras:
+        if origin not in seen:
+            seen.add(origin)
+            merged.append(origin)
+    return merged

--- a/scripts/gateway_origins.py
+++ b/scripts/gateway_origins.py
@@ -51,6 +51,16 @@ def normalize_origin(raw):
     if not isinstance(raw, str):
         return None, f"origin must be a string, got {type(raw).__name__}: {raw!r}"
 
+    # urllib.parse and the WHATWG URL parser disagree on several raw inputs
+    # (for example, WHATWG silently removes tabs/newlines while urlsplit can
+    # reinterpret backslashes around userinfo). Keep the accepted language to
+    # printable ASCII and reject parser-sensitive escape characters before
+    # either implementation gets a chance to normalize them.
+    if any(ord(char) < 0x20 or ord(char) > 0x7E for char in raw) or any(
+        char in raw for char in ("\\", "%")
+    ):
+        return None, f"origin contains a forbidden raw character: {raw!r}"
+
     value = raw.strip()
     if not value:
         return None, "origin is empty"
@@ -91,10 +101,10 @@ def normalize_origin(raw):
     if ":" in hostname:
         # Bracketed IPv6 literal — urlsplit strips the brackets for .hostname.
         try:
-            ipaddress.IPv6Address(hostname)
+            ipv6 = ipaddress.IPv6Address(hostname)
         except ValueError:
             return None, f"origin has an invalid IPv6 host: {raw!r}"
-        host_part = f"[{hostname}]"
+        host_part = f"[{ipv6.compressed}]"
     else:
         if not _HOSTNAME_RE.match(hostname):
             return None, f"origin has an invalid host: {raw!r}"
@@ -123,10 +133,12 @@ def load_configured_origins(path):
         return [], []
 
     try:
-        with open(path, "r", encoding="utf-8") as f:
+        with open(path, encoding="utf-8") as f:
             raw_text = f.read()
     except OSError as exc:
         return [], [f"could not read control UI origins file {path}: {exc}"]
+    except UnicodeDecodeError as exc:
+        return [], [f"control UI origins file {path} is not valid UTF-8: {exc}"]
 
     try:
         data = json.loads(raw_text)
@@ -135,8 +147,10 @@ def load_configured_origins(path):
 
     if not isinstance(data, list):
         return [], [
-            f"control UI origins file {path} must contain a JSON array, "
-            f"got {type(data).__name__}"
+            (
+                f"control UI origins file {path} must contain a JSON array, "
+                f"got {type(data).__name__}"
+            )
         ]
 
     warnings = []

--- a/src/lib/control-ui-origins.ts
+++ b/src/lib/control-ui-origins.ts
@@ -1,0 +1,197 @@
+import fs from "fs";
+import net from "net";
+
+// Strict validation/loading of operator-supplied trusted control UI origins.
+//
+// Narrow escape hatch for genuinely cross-origin/custom-origin Control UI
+// deployments (for example, a reverse proxy on a different hostname or
+// port). Same-origin access via `<hostname>.local`,
+// Tailscale `.ts.net` names, or a private LAN IP already works without any
+// entry here — see gateway-proxy.ts's isReflectableHost().
+//
+// Contract: a JSON array of strings at CLAWBOX_CONTROL_UI_ORIGINS_FILE (or
+// the default path below) is read and validated. A missing file is normal
+// (no extras, no warning). Anything malformed is dropped with a warning —
+// this module never throws, since a malformed file must not break the proxy.
+// Mirrors scripts/gateway_origins.py; keep the two in sync.
+
+const DEFAULT_ORIGINS_PATH = "/home/clawbox/clawbox/data/control-ui-origins.json";
+const ORIGINS_PATH_ENV_VAR = "CLAWBOX_CONTROL_UI_ORIGINS_FILE";
+
+// DNS-style hostname: dot-separated labels, each starting/ending with an
+// alphanumeric, letters/digits/hyphens in between. Dotted-decimal input is
+// validated separately as IPv4 so this loader stays aligned with the Python
+// pre-start loader.
+const HOSTNAME_RE =
+  /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/;
+
+export interface NormalizedOrigin {
+  origin: string | null;
+  warning: string | null;
+}
+
+export interface ConfiguredOrigins {
+  origins: string[];
+  warnings: string[];
+}
+
+export function resolveOriginsPath(): string {
+  return process.env[ORIGINS_PATH_ENV_VAR] || DEFAULT_ORIGINS_PATH;
+}
+
+/**
+ * Validate and normalize a single origin.
+ *
+ * Accepts exact http/https origins only — no wildcard, no credentials, no
+ * path beyond "/", no query, no fragment, and a resolvable host[:port].
+ * Normalizes scheme/host to lowercase, keeps IPv6 hosts in bracket form,
+ * and drops the port when it's the scheme's default.
+ */
+export function normalizeOrigin(raw: unknown): NormalizedOrigin {
+  if (typeof raw !== "string") {
+    return {
+      origin: null,
+      warning: `origin must be a string, got ${typeof raw}: ${JSON.stringify(raw)}`,
+    };
+  }
+
+  const value = raw.trim();
+  if (!value) {
+    return { origin: null, warning: "origin is empty" };
+  }
+  if (value.includes("*")) {
+    return { origin: null, warning: `wildcard origins are not allowed: ${JSON.stringify(raw)}` };
+  }
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return { origin: null, warning: `origin is not a valid URL: ${JSON.stringify(raw)}` };
+  }
+
+  const scheme = url.protocol.slice(0, -1).toLowerCase();
+  if (scheme !== "http" && scheme !== "https") {
+    return { origin: null, warning: `origin scheme must be http or https: ${JSON.stringify(raw)}` };
+  }
+
+  if (url.username || url.password) {
+    return { origin: null, warning: `origin must not contain credentials: ${JSON.stringify(raw)}` };
+  }
+
+  if (url.pathname !== "" && url.pathname !== "/") {
+    return { origin: null, warning: `origin must not contain a path: ${JSON.stringify(raw)}` };
+  }
+  if (url.search) {
+    return { origin: null, warning: `origin must not contain a query string: ${JSON.stringify(raw)}` };
+  }
+  if (url.hash) {
+    return { origin: null, warning: `origin must not contain a fragment: ${JSON.stringify(raw)}` };
+  }
+
+  const hostname = url.hostname.toLowerCase();
+  if (!hostname) {
+    return { origin: null, warning: `origin is missing a host: ${JSON.stringify(raw)}` };
+  }
+
+  let hostPart: string;
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    const bare = hostname.slice(1, -1);
+    if (!net.isIPv6(bare)) {
+      return { origin: null, warning: `origin has an invalid IPv6 host: ${JSON.stringify(raw)}` };
+    }
+    hostPart = `[${bare}]`;
+  } else {
+    if (!HOSTNAME_RE.test(hostname)) {
+      return { origin: null, warning: `origin has an invalid host: ${JSON.stringify(raw)}` };
+    }
+    if (/^[0-9.]+$/.test(hostname) && !net.isIPv4(hostname)) {
+      return { origin: null, warning: `origin has an invalid IPv4 host: ${JSON.stringify(raw)}` };
+    }
+    hostPart = hostname;
+  }
+
+  const defaultPort = scheme === "https" ? "443" : "80";
+  const port = url.port && url.port !== defaultPort ? url.port : "";
+  const portPart = port ? `:${port}` : "";
+
+  return { origin: `${scheme}://${hostPart}${portPart}`, warning: null };
+}
+
+/**
+ * Load, validate, and de-duplicate the JSON array of extra origins at `path`.
+ *
+ * A missing file returns `{ origins: [], warnings: [] }` — no extras, no
+ * warning. Any other failure (unreadable file, invalid JSON, non-array top
+ * level, invalid entries) is reported as a warning and excluded from the
+ * result; this function never throws.
+ */
+export function loadConfiguredOrigins(path: string): ConfiguredOrigins {
+  if (!path || !fs.existsSync(path)) {
+    return { origins: [], warnings: [] };
+  }
+
+  let rawText: string;
+  try {
+    rawText = fs.readFileSync(path, "utf-8");
+  } catch (err) {
+    return {
+      origins: [],
+      warnings: [`could not read control UI origins file ${path}: ${(err as Error).message}`],
+    };
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(rawText);
+  } catch (err) {
+    return {
+      origins: [],
+      warnings: [`control UI origins file ${path} is not valid JSON: ${(err as Error).message}`],
+    };
+  }
+
+  if (!Array.isArray(data)) {
+    return {
+      origins: [],
+      warnings: [
+        `control UI origins file ${path} must contain a JSON array, got ${typeof data}`,
+      ],
+    };
+  }
+
+  const warnings: string[] = [];
+  const origins: string[] = [];
+  const seen = new Set<string>();
+  data.forEach((entry, index) => {
+    const { origin, warning } = normalizeOrigin(entry);
+    if (warning) {
+      warnings.push(`control UI origins file ${path} entry ${index}: ${warning}`);
+      return;
+    }
+    if (origin && !seen.has(origin)) {
+      seen.add(origin);
+      origins.push(origin);
+    }
+  });
+
+  return { origins, warnings };
+}
+
+/** Merge `extras` into `defaults`: defaults first, de-duplicated, order preserved. */
+export function mergeOrigins(defaults: string[], extras: string[]): string[] {
+  const merged = [...defaults];
+  const seen = new Set(merged);
+  for (const origin of extras) {
+    if (!seen.has(origin)) {
+      seen.add(origin);
+      merged.push(origin);
+    }
+  }
+  return merged;
+}
+
+/** Load configured extra origins from the resolved path (env override or default). */
+export function loadConfiguredOriginsFromEnv(): ConfiguredOrigins {
+  return loadConfiguredOrigins(resolveOriginsPath());
+}

--- a/src/lib/control-ui-origins.ts
+++ b/src/lib/control-ui-origins.ts
@@ -86,6 +86,16 @@ export function normalizeOrigin(raw: unknown): NormalizedOrigin {
     return { origin: null, warning: `origin scheme must be http or https: ${JSON.stringify(raw)}` };
   }
 
+  // Match the stricter Python loader (gateway_origins.py) on the RAW input —
+  // the WHATWG URL parser is more lenient than urllib.urlsplit, and any origin
+  // the proxy trusts but the gateway rejects only half-works. `@` in the
+  // authority is userinfo even when empty (`http://@host`), which url.username
+  // cannot see once WHATWG strips it.
+  const rawAuthority = value.slice(value.indexOf("://") + 3).split(/[/?#]/)[0];
+  if (rawAuthority.includes("@")) {
+    return { origin: null, warning: `origin must not contain credentials: ${JSON.stringify(raw)}` };
+  }
+
   if (url.username || url.password) {
     return { origin: null, warning: `origin must not contain credentials: ${JSON.stringify(raw)}` };
   }
@@ -118,6 +128,13 @@ export function normalizeOrigin(raw: unknown): NormalizedOrigin {
     }
     if (/^[0-9.]+$/.test(hostname) && !net.isIPv4(hostname)) {
       return { origin: null, warning: `origin has an invalid IPv4 host: ${JSON.stringify(raw)}` };
+    }
+    // WHATWG rewrites IPv4 shorthand/integer/octal ("2130706433", "127.1",
+    // "010.0.0.1") to a canonical dotted quad; urllib.urlsplit does not, so the
+    // gateway would reject what we normalized. Only trust an already-canonical
+    // dotted quad.
+    if (net.isIPv4(hostname) && rawAuthority.replace(/:\d+$/, "").toLowerCase() !== hostname) {
+      return { origin: null, warning: `origin has a non-canonical IPv4 host: ${JSON.stringify(raw)}` };
     }
     hostPart = hostname;
   }

--- a/src/lib/control-ui-origins.ts
+++ b/src/lib/control-ui-origins.ts
@@ -24,6 +24,7 @@ const ORIGINS_PATH_ENV_VAR = "CLAWBOX_CONTROL_UI_ORIGINS_FILE";
 // pre-start loader.
 const HOSTNAME_RE =
   /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)*$/;
+const FORBIDDEN_RAW_ORIGIN_RE = /[\\%]|[^\x20-\x7e]/;
 
 export interface NormalizedOrigin {
   origin: string | null;
@@ -52,6 +53,16 @@ export function normalizeOrigin(raw: unknown): NormalizedOrigin {
     return {
       origin: null,
       warning: `origin must be a string, got ${typeof raw}: ${JSON.stringify(raw)}`,
+    };
+  }
+
+  // Keep this in lockstep with scripts/gateway_origins.py. The WHATWG URL
+  // parser silently discards some controls and treats backslashes specially,
+  // while Python's urlsplit behaves differently.
+  if (FORBIDDEN_RAW_ORIGIN_RE.test(raw)) {
+    return {
+      origin: null,
+      warning: `origin contains a forbidden raw character: ${JSON.stringify(raw)}`,
     };
   }
 
@@ -137,7 +148,7 @@ export function loadConfiguredOrigins(path: string): ConfiguredOrigins {
   } catch (err) {
     return {
       origins: [],
-      warnings: [`could not read control UI origins file ${path}: ${(err as Error).message}`],
+      warnings: [`could not read control UI origins file ${path}: ${errorMessage(err)}`],
     };
   }
 
@@ -147,7 +158,7 @@ export function loadConfiguredOrigins(path: string): ConfiguredOrigins {
   } catch (err) {
     return {
       origins: [],
-      warnings: [`control UI origins file ${path} is not valid JSON: ${(err as Error).message}`],
+      warnings: [`control UI origins file ${path} is not valid JSON: ${errorMessage(err)}`],
     };
   }
 
@@ -176,6 +187,10 @@ export function loadConfiguredOrigins(path: string): ConfiguredOrigins {
   });
 
   return { origins, warnings };
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 /** Merge `extras` into `defaults`: defaults first, de-duplicated, order preserved. */

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -3,7 +3,12 @@ import fs from "fs/promises";
 import os from "os";
 import net from "net";
 import crypto from "crypto";
-import { loadConfiguredOriginsFromEnv, normalizeOrigin } from "./control-ui-origins";
+import { statSync } from "node:fs";
+import {
+  loadConfiguredOrigins,
+  normalizeOrigin,
+  resolveOriginsPath,
+} from "./control-ui-origins";
 
 const GATEWAY_PORT = process.env.GATEWAY_PORT || "18789";
 const OPENCLAW_CONFIG_PATH = process.env.OPENCLAW_HOME
@@ -53,20 +58,48 @@ function isReflectableHost(rawHost: string): boolean {
 // port (including a non-default port) all have to agree with an entry in
 // the configured list. A configured hostname does not get reflected on a
 // different scheme or port than what was configured.
-let cachedConfiguredOrigins: Set<string> | undefined; // undefined = not loaded yet
-function getConfiguredOrigins(): Set<string> {
-  if (cachedConfiguredOrigins !== undefined) return cachedConfiguredOrigins;
-  const { origins, warnings } = loadConfiguredOriginsFromEnv();
+interface ConfiguredOriginState {
+  origins: Set<string>;
+  hosts: Set<string>;
+}
+
+let cachedConfiguredOrigins: ConfiguredOriginState | undefined;
+let cachedConfiguredOriginsSignature: string | undefined;
+
+function configuredOriginsSignature(path: string): string {
+  try {
+    const stat = statSync(path, { bigint: true });
+    return `${path}:${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeNs}:${stat.ctimeNs}`;
+  } catch {
+    return `${path}:missing`;
+  }
+}
+
+function getConfiguredOrigins(): ConfiguredOriginState {
+  const path = resolveOriginsPath();
+  const signature = configuredOriginsSignature(path);
+  if (
+    cachedConfiguredOrigins !== undefined &&
+    cachedConfiguredOriginsSignature === signature
+  ) {
+    return cachedConfiguredOrigins;
+  }
+
+  const { origins, warnings } = loadConfiguredOrigins(path);
   for (const warning of warnings) {
     console.warn(`[gateway-proxy] ${warning}`);
   }
-  cachedConfiguredOrigins = new Set(origins);
+  cachedConfiguredOrigins = {
+    origins: new Set(origins),
+    hosts: new Set(origins.map((origin) => new URL(origin).hostname.toLowerCase())),
+  };
+  cachedConfiguredOriginsSignature = signature;
   return cachedConfiguredOrigins;
 }
 
 function isConfiguredOrigin(proto: string, hostHeader: string): boolean {
   const { origin } = normalizeOrigin(`${proto}://${hostHeader}`);
-  return origin !== null && getConfiguredOrigins().has(origin);
+  return origin !== null && getConfiguredOrigins().origins.has(origin);
 }
 
 export function redirectToSetup(request: NextRequest): NextResponse {
@@ -78,9 +111,17 @@ export function redirectToSetup(request: NextRequest): NextResponse {
       .find((t) => ALLOWED_PROTOS.has(t)) ?? "http";
   const hostHeader = request.headers.get("host");
   const rawHost = hostHeader?.toLowerCase().replace(/:\d+$/, "");
-  const reflectable =
-    !!rawHost &&
-    (isReflectableHost(rawHost) || (!!hostHeader && isConfiguredOrigin(proto, hostHeader)));
+  const configuredOrigins = getConfiguredOrigins();
+  const exactConfiguredMatch =
+    !!hostHeader && isConfiguredOrigin(proto, hostHeader);
+  // A configured host opts into exact origin matching even when it would
+  // otherwise match the broad IPv4/ALLOWED_HOSTS reflection path. Hosts with
+  // no configured entry retain the existing same-host behavior.
+  const reflectable = !!rawHost && (
+    configuredOrigins.hosts.has(rawHost)
+      ? exactConfiguredMatch
+      : isReflectableHost(rawHost) || exactConfiguredMatch
+  );
   if (reflectable) {
     return NextResponse.redirect(
       new URL(`${proto}://${hostHeader}/setup`),

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -121,10 +121,13 @@ export function redirectToSetup(request: NextRequest): NextResponse {
   const reflectable =
     !!rawHost && (isReflectableHost(rawHost) || exactConfiguredMatch);
   if (reflectable) {
-    return NextResponse.redirect(
-      new URL(`${proto}://${hostHeader}/setup`),
-      302
-    );
+    try {
+      return NextResponse.redirect(new URL(`${proto}://${hostHeader}/setup`), 302);
+    } catch {
+      // Malformed Host header (e.g. an out-of-range port like `:99999`, which
+      // rawHost strips before the reflection check) — fall through to the
+      // canonical origin instead of throwing a 500.
+    }
   }
   return NextResponse.redirect(new URL(`${CANONICAL_ORIGIN}/setup`), 302);
 }

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import os from "os";
 import net from "net";
 import crypto from "crypto";
+import { loadConfiguredOriginsFromEnv, normalizeOrigin } from "./control-ui-origins";
 
 const GATEWAY_PORT = process.env.GATEWAY_PORT || "18789";
 const OPENCLAW_CONFIG_PATH = process.env.OPENCLAW_HOME
@@ -45,6 +46,29 @@ function isReflectableHost(rawHost: string): boolean {
   return false;
 }
 
+// Trusted control UI origins — a narrow escape hatch for genuinely
+// cross-origin/custom-origin deployments (see control-ui-origins.ts and
+// README). Unlike isReflectableHost() above (host-only, scheme/port-
+// agnostic), a configured origin must match EXACTLY: scheme, host, and
+// port (including a non-default port) all have to agree with an entry in
+// the configured list. A configured hostname does not get reflected on a
+// different scheme or port than what was configured.
+let cachedConfiguredOrigins: Set<string> | undefined; // undefined = not loaded yet
+function getConfiguredOrigins(): Set<string> {
+  if (cachedConfiguredOrigins !== undefined) return cachedConfiguredOrigins;
+  const { origins, warnings } = loadConfiguredOriginsFromEnv();
+  for (const warning of warnings) {
+    console.warn(`[gateway-proxy] ${warning}`);
+  }
+  cachedConfiguredOrigins = new Set(origins);
+  return cachedConfiguredOrigins;
+}
+
+function isConfiguredOrigin(proto: string, hostHeader: string): boolean {
+  const { origin } = normalizeOrigin(`${proto}://${hostHeader}`);
+  return origin !== null && getConfiguredOrigins().has(origin);
+}
+
 export function redirectToSetup(request: NextRequest): NextResponse {
   const rawProto = request.headers.get("x-forwarded-proto");
   const proto =
@@ -52,13 +76,14 @@ export function redirectToSetup(request: NextRequest): NextResponse {
       ?.split(",")
       .map((t) => t.trim().toLowerCase())
       .find((t) => ALLOWED_PROTOS.has(t)) ?? "http";
-  const rawHost = request.headers
-    .get("host")
-    ?.toLowerCase()
-    .replace(/:\d+$/, "");
-  if (rawHost && isReflectableHost(rawHost)) {
+  const hostHeader = request.headers.get("host");
+  const rawHost = hostHeader?.toLowerCase().replace(/:\d+$/, "");
+  const reflectable =
+    !!rawHost &&
+    (isReflectableHost(rawHost) || (!!hostHeader && isConfiguredOrigin(proto, hostHeader)));
+  if (reflectable) {
     return NextResponse.redirect(
-      new URL(`${proto}://${request.headers.get("host")}/setup`),
+      new URL(`${proto}://${hostHeader}/setup`),
       302
     );
   }

--- a/src/lib/gateway-proxy.ts
+++ b/src/lib/gateway-proxy.ts
@@ -111,17 +111,15 @@ export function redirectToSetup(request: NextRequest): NextResponse {
       .find((t) => ALLOWED_PROTOS.has(t)) ?? "http";
   const hostHeader = request.headers.get("host");
   const rawHost = hostHeader?.toLowerCase().replace(/:\d+$/, "");
-  const configuredOrigins = getConfiguredOrigins();
   const exactConfiguredMatch =
     !!hostHeader && isConfiguredOrigin(proto, hostHeader);
-  // A configured host opts into exact origin matching even when it would
-  // otherwise match the broad IPv4/ALLOWED_HOSTS reflection path. Hosts with
-  // no configured entry retain the existing same-host behavior.
-  const reflectable = !!rawHost && (
-    configuredOrigins.hosts.has(rawHost)
-      ? exactConfiguredMatch
-      : isReflectableHost(rawHost) || exactConfiguredMatch
-  );
+  // A default-reflectable host (LAN IP / localhost / mDNS name) keeps its broad
+  // reflection even when an operator also configures an exact origin for it:
+  // configuring `https://10.42.0.1` must not stop plain `http://10.42.0.1` from
+  // working on the SoftAP. Configured non-default origins reflect on an exact
+  // scheme+host+port match.
+  const reflectable =
+    !!rawHost && (isReflectableHost(rawHost) || exactConfiguredMatch);
   if (reflectable) {
     return NextResponse.redirect(
       new URL(`${proto}://${hostHeader}/setup`),

--- a/src/tests/unit/control-ui-origins.test.ts
+++ b/src/tests/unit/control-ui-origins.test.ts
@@ -59,6 +59,24 @@ describe("control-ui-origins", () => {
       expect(result.warning).toMatch(/wildcard/);
     });
 
+    it("rejects empty userinfo the Python loader also rejects", () => {
+      // WHATWG strips the empty userinfo so url.username can't see it; match the
+      // gateway's stricter urlsplit parity.
+      const result = normalizeOrigin("http://@example.com");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/credentials/);
+    });
+
+    it("rejects IPv4 shorthand the Python loader also rejects", () => {
+      // WHATWG rewrites these to a dotted quad; the gateway (urlsplit) rejects
+      // them, so the proxy must too or it trusts an origin the gateway refuses.
+      for (const bad of ["http://2130706433", "http://127.1", "http://010.0.0.1"]) {
+        const result = normalizeOrigin(bad);
+        expect(result.origin, bad).toBeNull();
+        expect(result.warning, bad).toMatch(/IPv4/);
+      }
+    });
+
     it("rejects credentials in the origin", () => {
       const result = normalizeOrigin("http://user:pass@" + "example.com");
       expect(result.origin).toBeNull();

--- a/src/tests/unit/control-ui-origins.test.ts
+++ b/src/tests/unit/control-ui-origins.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -47,6 +47,10 @@ describe("control-ui-origins", () => {
     it("keeps bracketed IPv6 hosts, dropping the default port", () => {
       expect(normalizeOrigin("https://[::1]:443")).toEqual({ origin: "https://[::1]", warning: null });
       expect(normalizeOrigin("http://[::1]:9000")).toEqual({ origin: "http://[::1]:9000", warning: null });
+      expect(normalizeOrigin("http://[0:0:0:0:0:0:0:1]")).toEqual({
+        origin: "http://[::1]",
+        warning: null,
+      });
     });
 
     it("rejects a wildcard origin", () => {
@@ -88,11 +92,27 @@ describe("control-ui-origins", () => {
     it("rejects an out-of-range port", () => {
       const result = normalizeOrigin("http://example.com:99999");
       expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/not a valid URL/);
     });
 
     it("rejects an out-of-range dotted-decimal host", () => {
       const result = normalizeOrigin("http://999.999.999.999");
       expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/not a valid URL/);
+    });
+
+    it("rejects raw characters whose URL-parser behavior is not portable", () => {
+      const inputs = [
+        "http://evil.com\\`@good.com`",
+        "http://exa\nmple.com",
+        "http://example.com/%65",
+        "http://éxample.com",
+      ];
+      for (const input of inputs) {
+        const result = normalizeOrigin(input);
+        expect(result.origin).toBeNull();
+        expect(result.warning).toMatch(/forbidden raw character/);
+      }
     });
 
     it("rejects a non-string entry without throwing", () => {
@@ -186,9 +206,22 @@ describe("control-ui-origins", () => {
       expect(result.warnings).toHaveLength(1);
     });
 
-    it("never throws, even on an unreadable path", () => {
-      expect(() => loadConfiguredOrigins("/root/definitely-not-readable/origins.json")).not.toThrow();
-    });
+    it.skipIf(typeof process.getuid === "function" && process.getuid() === 0)(
+      "returns a warning for an existing but unreadable file",
+      () => {
+        dir = mkdtempSync(path.join(tmpdir(), "control-ui-origins-"));
+        const file = path.join(dir, "origins.json");
+        writeFileSync(file, JSON.stringify(["http://a.example.com"]));
+        chmodSync(file, 0o000);
+        try {
+          const result = loadConfiguredOrigins(file);
+          expect(result.origins).toEqual([]);
+          expect(result.warnings).toHaveLength(1);
+        } finally {
+          chmodSync(file, 0o600);
+        }
+      },
+    );
   });
 
   describe("resolveOriginsPath / loadConfiguredOriginsFromEnv", () => {

--- a/src/tests/unit/control-ui-origins.test.ts
+++ b/src/tests/unit/control-ui-origins.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  loadConfiguredOrigins,
+  loadConfiguredOriginsFromEnv,
+  mergeOrigins,
+  normalizeOrigin,
+  resolveOriginsPath,
+} from "@/lib/control-ui-origins";
+
+// TS counterpart to scripts/gateway_origins.py, used by gateway-proxy.ts to
+// validate operator-supplied trusted control UI origins. Kept behaviorally
+// aligned with the Python module (see gateway-origins.test.ts) since both
+// read the same JSON contract file.
+
+describe("control-ui-origins", () => {
+  describe("normalizeOrigin", () => {
+    it("accepts a bare http origin unchanged", () => {
+      expect(normalizeOrigin("http://example.com")).toEqual({ origin: "http://example.com", warning: null });
+    });
+
+    it("lowercases scheme and host", () => {
+      expect(normalizeOrigin("HTTP://EXAMPLE.com")).toEqual({ origin: "http://example.com", warning: null });
+    });
+
+    it("strips the default port for http", () => {
+      expect(normalizeOrigin("http://example.com:80")).toEqual({ origin: "http://example.com", warning: null });
+    });
+
+    it("strips the default port for https", () => {
+      expect(normalizeOrigin("https://example.com:443")).toEqual({ origin: "https://example.com", warning: null });
+    });
+
+    it("keeps a non-default port", () => {
+      expect(normalizeOrigin("http://example.com:8080")).toEqual({
+        origin: "http://example.com:8080",
+        warning: null,
+      });
+    });
+
+    it("normalizes a trailing slash away", () => {
+      expect(normalizeOrigin("https://example.com/")).toEqual({ origin: "https://example.com", warning: null });
+    });
+
+    it("keeps bracketed IPv6 hosts, dropping the default port", () => {
+      expect(normalizeOrigin("https://[::1]:443")).toEqual({ origin: "https://[::1]", warning: null });
+      expect(normalizeOrigin("http://[::1]:9000")).toEqual({ origin: "http://[::1]:9000", warning: null });
+    });
+
+    it("rejects a wildcard origin", () => {
+      const result = normalizeOrigin("*");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/wildcard/);
+    });
+
+    it("rejects credentials in the origin", () => {
+      const result = normalizeOrigin("http://user:pass@" + "example.com");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/credentials/);
+    });
+
+    it("rejects a non-root path", () => {
+      const result = normalizeOrigin("http://example.com/setup");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/path/);
+    });
+
+    it("rejects a query string", () => {
+      const result = normalizeOrigin("http://example.com?x=1");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/query/);
+    });
+
+    it("rejects a fragment", () => {
+      const result = normalizeOrigin("http://example.com#frag");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/fragment/);
+    });
+
+    it("rejects a non-http(s) scheme", () => {
+      const result = normalizeOrigin("ftp://example.com");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/scheme/);
+    });
+
+    it("rejects an out-of-range port", () => {
+      const result = normalizeOrigin("http://example.com:99999");
+      expect(result.origin).toBeNull();
+    });
+
+    it("rejects an out-of-range dotted-decimal host", () => {
+      const result = normalizeOrigin("http://999.999.999.999");
+      expect(result.origin).toBeNull();
+    });
+
+    it("rejects a non-string entry without throwing", () => {
+      expect(() => normalizeOrigin(42)).not.toThrow();
+      expect(() => normalizeOrigin(null)).not.toThrow();
+      expect(() => normalizeOrigin(undefined)).not.toThrow();
+      expect(() => normalizeOrigin({})).not.toThrow();
+      expect(normalizeOrigin(42).warning).toMatch(/string/);
+    });
+
+    it("rejects an invalid IPv6 host without throwing", () => {
+      expect(() => normalizeOrigin("http://[gg::1]")).not.toThrow();
+      expect(normalizeOrigin("http://[gg::1]").origin).toBeNull();
+    });
+
+    it("never throws on garbage input", () => {
+      const garbage = [
+        "http://[", "http://]", "http://[::", "://", "http:///",
+        "http://a b", "\x00", "  ", "\n", "http://a..b", "http://.",
+        "javascript:alert(1)", "http://a:b:c@" + "evil.com",
+      ];
+      for (const g of garbage) {
+        expect(() => normalizeOrigin(g)).not.toThrow();
+      }
+    });
+  });
+
+  describe("mergeOrigins", () => {
+    it("appends extras after defaults, de-duplicated, order preserved", () => {
+      expect(mergeOrigins(["http://a.com", "http://b.com"], ["http://b.com", "http://c.com"])).toEqual([
+        "http://a.com",
+        "http://b.com",
+        "http://c.com",
+      ]);
+    });
+
+    it("returns defaults unchanged when extras is empty", () => {
+      expect(mergeOrigins(["http://a.com"], [])).toEqual(["http://a.com"]);
+    });
+  });
+
+  describe("loadConfiguredOrigins", () => {
+    let dir: string;
+
+    afterEach(() => {
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("returns no origins and no warning when the file is missing", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "control-ui-origins-"));
+      const missing = path.join(dir, "nope.json");
+      expect(loadConfiguredOrigins(missing)).toEqual({ origins: [], warnings: [] });
+    });
+
+    it("loads, normalizes, and de-duplicates a valid array", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "control-ui-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(
+        file,
+        JSON.stringify(["http://a.example.com", "HTTP://A.example.com:80", "https://b.example.com:8443"]),
+      );
+      const result = loadConfiguredOrigins(file);
+      expect(result.origins).toEqual(["http://a.example.com", "https://b.example.com:8443"]);
+      expect(result.warnings).toEqual([]);
+    });
+
+    it("drops invalid entries with a warning, keeps valid ones", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "control-ui-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, JSON.stringify(["http://good.example.com", "not-a-url-but-string", "*"]));
+      const result = loadConfiguredOrigins(file);
+      expect(result.origins).toEqual(["http://good.example.com"]);
+      expect(result.warnings).toHaveLength(2);
+    });
+
+    it("returns a warning and no origins for invalid JSON", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "control-ui-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, "{not json");
+      const result = loadConfiguredOrigins(file);
+      expect(result.origins).toEqual([]);
+      expect(result.warnings).toHaveLength(1);
+    });
+
+    it("returns a warning and no origins for a non-array top level", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "control-ui-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, JSON.stringify({ a: 1 }));
+      const result = loadConfiguredOrigins(file);
+      expect(result.origins).toEqual([]);
+      expect(result.warnings).toHaveLength(1);
+    });
+
+    it("never throws, even on an unreadable path", () => {
+      expect(() => loadConfiguredOrigins("/root/definitely-not-readable/origins.json")).not.toThrow();
+    });
+  });
+
+  describe("resolveOriginsPath / loadConfiguredOriginsFromEnv", () => {
+    const ENV_VAR = "CLAWBOX_CONTROL_UI_ORIGINS_FILE";
+    const original = process.env[ENV_VAR];
+
+    afterEach(() => {
+      if (original === undefined) delete process.env[ENV_VAR];
+      else process.env[ENV_VAR] = original;
+    });
+
+    it("defaults to the well-known data path", () => {
+      delete process.env[ENV_VAR];
+      expect(resolveOriginsPath()).toBe("/home/clawbox/clawbox/data/control-ui-origins.json");
+    });
+
+    it("honors the env override", () => {
+      process.env[ENV_VAR] = "/tmp/custom-origins.json";
+      expect(resolveOriginsPath()).toBe("/tmp/custom-origins.json");
+    });
+
+    it("loadConfiguredOriginsFromEnv reads from the env-overridden path", () => {
+      const dir = mkdtempSync(path.join(tmpdir(), "control-ui-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, JSON.stringify(["http://env-origin.example.com"]));
+      process.env[ENV_VAR] = file;
+      expect(loadConfiguredOriginsFromEnv()).toEqual({
+        origins: ["http://env-origin.example.com"],
+        warnings: [],
+      });
+      rmSync(dir, { recursive: true, force: true });
+    });
+  });
+});

--- a/src/tests/unit/gateway-origins.test.ts
+++ b/src/tests/unit/gateway-origins.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -73,6 +73,10 @@ describe.skipIf(!hasPython3)("scripts/gateway_origins.py", () => {
     it("keeps bracketed IPv6 hosts, dropping the default port", () => {
       expect(normalize("https://[::1]:443")).toEqual({ origin: "https://[::1]", warning: null });
       expect(normalize("http://[::1]:9000")).toEqual({ origin: "http://[::1]:9000", warning: null });
+      expect(normalize("http://[0:0:0:0:0:0:0:1]")).toEqual({
+        origin: "http://[::1]",
+        warning: null,
+      });
     });
 
     it("rejects a wildcard origin", () => {
@@ -138,13 +142,32 @@ describe.skipIf(!hasPython3)("scripts/gateway_origins.py", () => {
       const result = normalize("http://999.999.999.999");
       expect(result.origin).toBeNull();
     });
+
+    it("rejects raw characters whose URL-parser behavior is not portable", () => {
+      const inputs = [
+        "http://evil.com\\`@good.com`",
+        "http://exa\nmple.com",
+        "http://example.com/%65",
+        "http://éxample.com",
+      ];
+      for (const input of inputs) {
+        const result = normalize(input);
+        expect(result.origin).toBeNull();
+        expect(result.warning).toMatch(/forbidden raw character/);
+      }
+    });
   });
 
   describe("load_configured_origins", () => {
     let dir: string;
 
+    afterEach(() => {
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    });
+
     it("returns no origins and no warning when the file is missing", () => {
-      const missing = path.join(mkdtempSync(path.join(tmpdir(), "gw-origins-")), "nope.json");
+      dir = mkdtempSync(path.join(tmpdir(), "gw-origins-"));
+      const missing = path.join(dir, "nope.json");
       expect(loadConfigured(missing)).toEqual({ origins: [], warnings: [] });
     });
 
@@ -158,7 +181,6 @@ describe.skipIf(!hasPython3)("scripts/gateway_origins.py", () => {
       const result = loadConfigured(file);
       expect(result.origins).toEqual(["http://a.example.com", "https://b.example.com:8443"]);
       expect(result.warnings).toEqual([]);
-      rmSync(dir, { recursive: true, force: true });
     });
 
     it("drops invalid entries with a warning, keeps valid ones", () => {
@@ -168,7 +190,6 @@ describe.skipIf(!hasPython3)("scripts/gateway_origins.py", () => {
       const result = loadConfigured(file);
       expect(result.origins).toEqual(["http://good.example.com"]);
       expect(result.warnings).toHaveLength(2);
-      rmSync(dir, { recursive: true, force: true });
     });
 
     it("returns a warning and no origins for invalid JSON", () => {
@@ -178,7 +199,6 @@ describe.skipIf(!hasPython3)("scripts/gateway_origins.py", () => {
       const result = loadConfigured(file);
       expect(result.origins).toEqual([]);
       expect(result.warnings).toHaveLength(1);
-      rmSync(dir, { recursive: true, force: true });
     });
 
     it("returns a warning and no origins for a non-array top level", () => {
@@ -188,7 +208,16 @@ describe.skipIf(!hasPython3)("scripts/gateway_origins.py", () => {
       const result = loadConfigured(file);
       expect(result.origins).toEqual([]);
       expect(result.warnings).toHaveLength(1);
-      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("returns a warning and no origins for invalid UTF-8", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "gw-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, Buffer.from([0xff, 0xfe, 0xfd]));
+      const result = loadConfigured(file);
+      expect(result.origins).toEqual([]);
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toMatch(/not valid UTF-8/);
     });
   });
 
@@ -295,6 +324,10 @@ function runMerge(hostname: string, lanIps: string[], extraOrigins: string[]): s
 describe.skipIf(!hasPython3)("gateway-pre-start.sh trusted-origins wiring", () => {
   let dir: string;
 
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
   it("default: no config file yields no extras, defaults only", () => {
     dir = mkdtempSync(path.join(tmpdir(), "gw-wiring-"));
     const missing = path.join(dir, "nope.json");
@@ -311,7 +344,6 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh trusted-origins wiring", () =
       "http://10.43.0.1",
       "http://192.0.2.5",
     ]);
-    rmSync(dir, { recursive: true, force: true });
   });
 
   it("merges validated extras after defaults, deterministically", () => {
@@ -335,7 +367,6 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh trusted-origins wiring", () =
       "http://192.0.2.5",
       "https://custom.example.com",
     ]);
-    rmSync(dir, { recursive: true, force: true });
   });
 
   it("is idempotent — re-running the loader+merge on unchanged input yields the same list", () => {
@@ -350,7 +381,6 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh trusted-origins wiring", () =
     };
 
     expect(run()).toEqual(run());
-    rmSync(dir, { recursive: true, force: true });
   });
 
   it("invalid JSON produces a warning on stderr and no extras — defaults still merge cleanly", () => {
@@ -369,10 +399,9 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh trusted-origins wiring", () =
       "http://10.42.0.1",
       "http://10.43.0.1",
     ]);
-    rmSync(dir, { recursive: true, force: true });
   });
 
-  it("missing helper module falls through to no extras (boot unaffected)", () => {
+  it("missing helper module warns and falls through to no extras (boot unaffected)", () => {
     const env: NodeJS.ProcessEnv = {
       ...process.env,
       CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR: "/nonexistent/scripts/dir",
@@ -380,6 +409,30 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh trusted-origins wiring", () =
     delete env.CLAWBOX_CONTROL_UI_ORIGINS_FILE;
     const result = spawnSync("python3", ["-c", extractLoaderSnippet()], { encoding: "utf-8", env });
     expect(result.stdout.trim()).toBe("");
-    expect(result.stderr).toBe("");
+    expect(result.stderr).toMatch(/WARN.*helper unavailable.*using defaults only/);
+    expect(result.status).toBe(0);
+  });
+
+  it("unexpected helper failure warns and falls through without blocking boot", () => {
+    dir = mkdtempSync(path.join(tmpdir(), "gw-wiring-"));
+    writeFileSync(
+      path.join(dir, "gateway_origins.py"),
+      [
+        "def resolve_origins_path():",
+        "    raise RuntimeError('unexpected sensitive detail')",
+        "",
+        "def load_configured_origins(path):",
+        "    raise AssertionError('unreachable')",
+      ].join("\n"),
+    );
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR: dir,
+    };
+    const result = spawnSync("python3", ["-c", extractLoaderSnippet()], { encoding: "utf-8", env });
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("");
+    expect(result.stderr).toMatch(/WARN.*helper failed \(RuntimeError\).*using defaults only/);
+    expect(result.stderr).not.toContain("unexpected sensitive detail");
   });
 });

--- a/src/tests/unit/gateway-origins.test.ts
+++ b/src/tests/unit/gateway-origins.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+// scripts/gateway_origins.py is the boot-path (Python) implementation of
+// trusted control-UI origin validation/loading — the counterpart to
+// src/lib/control-ui-origins.ts used by the Next.js proxy. Exercised
+// directly via python3 so these tests track the real shipped module (same
+// convention as gateway-pre-start-token.test.ts).
+
+const SCRIPTS_DIR = path.resolve(process.cwd(), "scripts");
+
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+function runPython(program: string): string {
+  return execFileSync("python3", ["-c", program], { encoding: "utf-8" }).trim();
+}
+
+function normalize(raw: unknown): { origin: string | null; warning: string | null } {
+  const program = [
+    `import sys, json`,
+    `sys.path.insert(0, ${JSON.stringify(SCRIPTS_DIR)})`,
+    `import gateway_origins as g`,
+    `origin, warning = g.normalize_origin(json.loads(sys.argv[1]))`,
+    `print(json.dumps({"origin": origin, "warning": warning}))`,
+  ].join("\n");
+  return JSON.parse(
+    execFileSync("python3", ["-c", program, JSON.stringify(raw)], { encoding: "utf-8" }).trim(),
+  );
+}
+
+function loadConfigured(filePath: string): { origins: string[]; warnings: string[] } {
+  const program = [
+    `import sys, json`,
+    `sys.path.insert(0, ${JSON.stringify(SCRIPTS_DIR)})`,
+    `import gateway_origins as g`,
+    `origins, warnings = g.load_configured_origins(sys.argv[1])`,
+    `print(json.dumps({"origins": origins, "warnings": warnings}))`,
+  ].join("\n");
+  return JSON.parse(
+    execFileSync("python3", ["-c", program, filePath], { encoding: "utf-8" }).trim(),
+  );
+}
+
+describe.skipIf(!hasPython3)("scripts/gateway_origins.py", () => {
+  describe("normalize_origin", () => {
+    it("accepts a bare http origin unchanged", () => {
+      expect(normalize("http://example.com")).toEqual({ origin: "http://example.com", warning: null });
+    });
+
+    it("lowercases scheme and host", () => {
+      expect(normalize("HTTP://EXAMPLE.com")).toEqual({ origin: "http://example.com", warning: null });
+    });
+
+    it("strips the default port for http", () => {
+      expect(normalize("http://example.com:80")).toEqual({ origin: "http://example.com", warning: null });
+    });
+
+    it("strips the default port for https", () => {
+      expect(normalize("https://example.com:443")).toEqual({ origin: "https://example.com", warning: null });
+    });
+
+    it("keeps a non-default port", () => {
+      expect(normalize("http://example.com:8080")).toEqual({ origin: "http://example.com:8080", warning: null });
+    });
+
+    it("normalizes a trailing slash away", () => {
+      expect(normalize("https://example.com/")).toEqual({ origin: "https://example.com", warning: null });
+    });
+
+    it("keeps bracketed IPv6 hosts, dropping the default port", () => {
+      expect(normalize("https://[::1]:443")).toEqual({ origin: "https://[::1]", warning: null });
+      expect(normalize("http://[::1]:9000")).toEqual({ origin: "http://[::1]:9000", warning: null });
+    });
+
+    it("rejects a wildcard origin", () => {
+      const result = normalize("*");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/wildcard/);
+    });
+
+    it("rejects credentials in the origin", () => {
+      const result = normalize("http://user:pass@" + "example.com");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/credentials/);
+    });
+
+    it("rejects a non-root path", () => {
+      const result = normalize("http://example.com/setup");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/path/);
+    });
+
+    it("rejects a query string", () => {
+      const result = normalize("http://example.com?x=1");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/query/);
+    });
+
+    it("rejects a fragment", () => {
+      const result = normalize("http://example.com#frag");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/fragment/);
+    });
+
+    it("rejects a non-http(s) scheme", () => {
+      const result = normalize("ftp://example.com");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/scheme/);
+    });
+
+    it("rejects a missing host", () => {
+      const result = normalize("http://");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/host/);
+    });
+
+    it("rejects an out-of-range port", () => {
+      const result = normalize("http://example.com:99999");
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/port/);
+    });
+
+    it("rejects a non-string entry", () => {
+      const result = normalize(42);
+      expect(result.origin).toBeNull();
+      expect(result.warning).toMatch(/string/);
+    });
+
+    it("rejects an invalid IPv6 host", () => {
+      const result = normalize("http://[gg::1]");
+      expect(result.origin).toBeNull();
+    });
+
+    it("rejects an out-of-range dotted-decimal host", () => {
+      const result = normalize("http://999.999.999.999");
+      expect(result.origin).toBeNull();
+    });
+  });
+
+  describe("load_configured_origins", () => {
+    let dir: string;
+
+    it("returns no origins and no warning when the file is missing", () => {
+      const missing = path.join(mkdtempSync(path.join(tmpdir(), "gw-origins-")), "nope.json");
+      expect(loadConfigured(missing)).toEqual({ origins: [], warnings: [] });
+    });
+
+    it("loads, normalizes, and de-duplicates a valid array", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "gw-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(
+        file,
+        JSON.stringify(["http://a.example.com", "HTTP://A.example.com:80", "https://b.example.com:8443"]),
+      );
+      const result = loadConfigured(file);
+      expect(result.origins).toEqual(["http://a.example.com", "https://b.example.com:8443"]);
+      expect(result.warnings).toEqual([]);
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("drops invalid entries with a warning, keeps valid ones", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "gw-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, JSON.stringify(["http://good.example.com", "not-a-url", "*"]));
+      const result = loadConfigured(file);
+      expect(result.origins).toEqual(["http://good.example.com"]);
+      expect(result.warnings).toHaveLength(2);
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("returns a warning and no origins for invalid JSON", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "gw-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, "{not json");
+      const result = loadConfigured(file);
+      expect(result.origins).toEqual([]);
+      expect(result.warnings).toHaveLength(1);
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("returns a warning and no origins for a non-array top level", () => {
+      dir = mkdtempSync(path.join(tmpdir(), "gw-origins-"));
+      const file = path.join(dir, "origins.json");
+      writeFileSync(file, JSON.stringify({ a: 1 }));
+      const result = loadConfigured(file);
+      expect(result.origins).toEqual([]);
+      expect(result.warnings).toHaveLength(1);
+      rmSync(dir, { recursive: true, force: true });
+    });
+  });
+
+  describe("merge_origins", () => {
+    it("appends extras after defaults, de-duplicated, order preserved", () => {
+      const program = [
+        `import sys, json`,
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_DIR)})`,
+        `import gateway_origins as g`,
+        `print(json.dumps(g.merge_origins(["http://a.com", "http://b.com"], ["http://b.com", "http://c.com"])))`,
+      ].join("\n");
+      expect(JSON.parse(runPython(program))).toEqual(["http://a.com", "http://b.com", "http://c.com"]);
+    });
+  });
+
+  describe("resolve_origins_path", () => {
+    it("defaults to the well-known data path", () => {
+      const program = [
+        `import sys`,
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_DIR)})`,
+        `import os`,
+        `os.environ.pop("CLAWBOX_CONTROL_UI_ORIGINS_FILE", None)`,
+        `import gateway_origins as g`,
+        `print(g.resolve_origins_path())`,
+      ].join("\n");
+      expect(runPython(program)).toBe("/home/clawbox/clawbox/data/control-ui-origins.json");
+    });
+
+    it("honors the CLAWBOX_CONTROL_UI_ORIGINS_FILE env override", () => {
+      const program = [
+        `import sys, os`,
+        `os.environ["CLAWBOX_CONTROL_UI_ORIGINS_FILE"] = "/tmp/custom-origins.json"`,
+        `sys.path.insert(0, ${JSON.stringify(SCRIPTS_DIR)})`,
+        `import gateway_origins as g`,
+        `print(g.resolve_origins_path())`,
+      ].join("\n");
+      expect(runPython(program)).toBe("/tmp/custom-origins.json");
+    });
+  });
+});
+
+// The following exercises the ACTUAL merge wiring inside gateway-pre-start.sh
+// (not a reimplementation): the origins-loading heredoc that produces
+// CLAWBOX_EXTRA_ORIGINS, and the heredoc block that folds it into
+// allowed_origins before the config's set-comparison. Both blocks are
+// extracted verbatim so a regression in the shipped script is caught here.
+
+const SCRIPT = path.join(SCRIPTS_DIR, "gateway-pre-start.sh");
+
+function extractBetween(src: string, startMarker: string, endMarker: string): string {
+  const start = src.indexOf(startMarker);
+  const end = src.indexOf(endMarker, start);
+  if (start < 0 || end < 0) {
+    throw new Error(`markers not found: ${JSON.stringify({ startMarker, endMarker })}`);
+  }
+  return src.slice(start, end);
+}
+
+function extractLoaderSnippet(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  return extractBetween(src, "import os, sys\n\nscript_dir", "\nPY\n)\"");
+}
+
+function extractMergeSnippet(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  return extractBetween(
+    src,
+    "hostname = os.environ.get(\"CLAWBOX_HOSTNAME\"",
+    "\n\ntry:\n    with open(cfg_path) as f:",
+  );
+}
+
+/** Runs the real loader heredoc against a given origins file and env. */
+function runLoader(originsFile: string | undefined): { stdout: string; stderr: string } {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR: SCRIPTS_DIR,
+  };
+  if (originsFile) {
+    env.CLAWBOX_CONTROL_UI_ORIGINS_FILE = originsFile;
+  } else {
+    delete env.CLAWBOX_CONTROL_UI_ORIGINS_FILE;
+  }
+  const result = spawnSync("python3", ["-c", extractLoaderSnippet()], {
+    encoding: "utf-8",
+    env,
+  });
+  return { stdout: result.stdout, stderr: result.stderr };
+}
+
+/** Runs the real merge heredoc given hostname/lan_ips/extra_origins env inputs. */
+function runMerge(hostname: string, lanIps: string[], extraOrigins: string[]): string[] {
+  const program = "import json, os\n" + extractMergeSnippet() + "\nprint(json.dumps(allowed_origins))";
+  const env = {
+    ...process.env,
+    CLAWBOX_HOSTNAME: hostname,
+    CLAWBOX_LAN_IPS: lanIps.length ? lanIps.join("\n") + "\n" : "",
+    CLAWBOX_EXTRA_ORIGINS: extraOrigins.length ? extraOrigins.join("\n") + "\n" : "",
+  };
+  const out = execFileSync("python3", ["-c", program, "/unused/config/path"], { encoding: "utf-8", env });
+  return JSON.parse(out.trim());
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh trusted-origins wiring", () => {
+  let dir: string;
+
+  it("default: no config file yields no extras, defaults only", () => {
+    dir = mkdtempSync(path.join(tmpdir(), "gw-wiring-"));
+    const missing = path.join(dir, "nope.json");
+    const { stdout, stderr } = runLoader(missing);
+    expect(stdout.trim()).toBe("");
+    expect(stderr).toBe("");
+
+    const merged = runMerge("device", ["http://192.0.2.5"], []);
+    expect(merged).toEqual([
+      "http://device.local",
+      "http://localhost",
+      "http://127.0.0.1",
+      "http://10.42.0.1",
+      "http://10.43.0.1",
+      "http://192.0.2.5",
+    ]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("merges validated extras after defaults, deterministically", () => {
+    dir = mkdtempSync(path.join(tmpdir(), "gw-wiring-"));
+    const file = path.join(dir, "origins.json");
+    writeFileSync(file, JSON.stringify(["https://custom.example.com", "http://192.0.2.5"]));
+    const { stdout, stderr } = runLoader(file);
+    expect(stderr).toBe("");
+    const extras = stdout.trim().split("\n").filter(Boolean);
+    expect(extras).toEqual(["https://custom.example.com", "http://192.0.2.5"]);
+
+    const merged = runMerge("device", ["http://192.0.2.5"], extras);
+    // http://192.0.2.5 already present from LAN_IPS — the extras merge
+    // must de-dupe it, not append a second copy.
+    expect(merged).toEqual([
+      "http://device.local",
+      "http://localhost",
+      "http://127.0.0.1",
+      "http://10.42.0.1",
+      "http://10.43.0.1",
+      "http://192.0.2.5",
+      "https://custom.example.com",
+    ]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("is idempotent — re-running the loader+merge on unchanged input yields the same list", () => {
+    dir = mkdtempSync(path.join(tmpdir(), "gw-wiring-"));
+    const file = path.join(dir, "origins.json");
+    writeFileSync(file, JSON.stringify(["https://custom.example.com"]));
+
+    const run = () => {
+      const { stdout } = runLoader(file);
+      const extras = stdout.trim().split("\n").filter(Boolean);
+      return runMerge("device", [], extras);
+    };
+
+    expect(run()).toEqual(run());
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("invalid JSON produces a warning on stderr and no extras — defaults still merge cleanly", () => {
+    dir = mkdtempSync(path.join(tmpdir(), "gw-wiring-"));
+    const file = path.join(dir, "origins.json");
+    writeFileSync(file, "{not json");
+    const { stdout, stderr } = runLoader(file);
+    expect(stdout.trim()).toBe("");
+    expect(stderr).toMatch(/WARN.*not valid JSON/);
+
+    const merged = runMerge("device", [], []);
+    expect(merged).toEqual([
+      "http://device.local",
+      "http://localhost",
+      "http://127.0.0.1",
+      "http://10.42.0.1",
+      "http://10.43.0.1",
+    ]);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("missing helper module falls through to no extras (boot unaffected)", () => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      CLAWBOX_GATEWAY_ORIGINS_SCRIPT_DIR: "/nonexistent/scripts/dir",
+    };
+    delete env.CLAWBOX_CONTROL_UI_ORIGINS_FILE;
+    const result = spawnSync("python3", ["-c", extractLoaderSnippet()], { encoding: "utf-8", env });
+    expect(result.stdout.trim()).toBe("");
+    expect(result.stderr).toBe("");
+  });
+});

--- a/src/tests/unit/gateway-proxy-origins.test.ts
+++ b/src/tests/unit/gateway-proxy-origins.test.ts
@@ -203,6 +203,20 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
     expect(ipResponse.headers.get("location")).toContain("192.0.2.3");
   });
 
+  it("falls back to the canonical origin on a malformed Host port instead of throwing", async () => {
+    process.env[ENV_VAR] = path.join(dir, "absent.json");
+    await importFresh();
+
+    // rawHost strips the port before the reflection check, so an out-of-range
+    // port in the Host header reaches the reflect path; new URL(...:99999/setup)
+    // would throw a 500. (Request URL stays valid — only the Host header is bad.)
+    const request = createRequest("http://clawbox.local/", { host: "clawbox.local:99999" });
+    expect(() => gatewayProxy.redirectToSetup(request)).not.toThrow();
+    const location = gatewayProxy.redirectToSetup(request).headers.get("location");
+    expect(location).toContain("clawbox.local");
+    expect(location).not.toContain("99999");
+  });
+
   it("an invalid origins file yields no extras and does not affect existing host reflection", async () => {
     const file = path.join(dir, "origins.json");
     writeFileSync(file, "{not json");

--- a/src/tests/unit/gateway-proxy-origins.test.ts
+++ b/src/tests/unit/gateway-proxy-origins.test.ts
@@ -123,27 +123,45 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
     expect(response.headers.get("location")).toContain("clawbox.local");
   });
 
-  it("enforces exact scheme and port for a configured IPv4 origin", async () => {
-    writeOrigins(["http://192.0.2.10:8080"]);
+  it("enforces exact scheme and port for a configured non-default origin", async () => {
+    writeOrigins(["http://box.example.com:8080"]);
     await importFresh();
 
     const exact = gatewayProxy.redirectToSetup(
-      createRequest("http://192.0.2.10:8080/", { host: "192.0.2.10:8080" }),
+      createRequest("http://box.example.com:8080/", { host: "box.example.com:8080" }),
     );
-    expect(exact.headers.get("location")).toBe("http://192.0.2.10:8080/setup");
+    expect(exact.headers.get("location")).toBe("http://box.example.com:8080/setup");
 
     const wrongPort = gatewayProxy.redirectToSetup(
-      createRequest("http://192.0.2.10:9999/", { host: "192.0.2.10:9999" }),
+      createRequest("http://box.example.com:9999/", { host: "box.example.com:9999" }),
     );
     expect(wrongPort.headers.get("location")).toContain("clawbox.local");
 
     const wrongScheme = gatewayProxy.redirectToSetup(
-      createRequest("http://192.0.2.10:8080/", {
-        host: "192.0.2.10:8080",
+      createRequest("http://box.example.com:8080/", {
+        host: "box.example.com:8080",
         "x-forwarded-proto": "https",
       }),
     );
     expect(wrongScheme.headers.get("location")).toContain("clawbox.local");
+  });
+
+  it("keeps broad reflection for a default host even when a matching origin is configured", async () => {
+    // Regression: configuring https://10.42.0.1 must not stop plain
+    // http://10.42.0.1 (a default-reflectable LAN IP) from reflecting on the
+    // SoftAP — otherwise the user dead-ends at the unresolvable clawbox.local.
+    writeOrigins(["https://10.42.0.1"]);
+    await importFresh();
+
+    const plainHttp = gatewayProxy.redirectToSetup(
+      createRequest("http://10.42.0.1/", { host: "10.42.0.1" }),
+    );
+    expect(plainHttp.headers.get("location")).toBe("http://10.42.0.1/setup");
+
+    const otherPort = gatewayProxy.redirectToSetup(
+      createRequest("http://10.42.0.1:9999/", { host: "10.42.0.1:9999" }),
+    );
+    expect(otherPort.headers.get("location")).toBe("http://10.42.0.1:9999/setup");
   });
 
   it("refreshes configured origins after the source file changes", async () => {

--- a/src/tests/unit/gateway-proxy-origins.test.ts
+++ b/src/tests/unit/gateway-proxy-origins.test.ts
@@ -34,6 +34,7 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     rmSync(dir, { recursive: true, force: true });
     if (originalEnv === undefined) delete process.env[ENV_VAR];
     else process.env[ENV_VAR] = originalEnv;
@@ -122,8 +123,56 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
     expect(response.headers.get("location")).toContain("clawbox.local");
   });
 
+  it("enforces exact scheme and port for a configured IPv4 origin", async () => {
+    writeOrigins(["http://192.0.2.10:8080"]);
+    await importFresh();
+
+    const exact = gatewayProxy.redirectToSetup(
+      createRequest("http://192.0.2.10:8080/", { host: "192.0.2.10:8080" }),
+    );
+    expect(exact.headers.get("location")).toBe("http://192.0.2.10:8080/setup");
+
+    const wrongPort = gatewayProxy.redirectToSetup(
+      createRequest("http://192.0.2.10:9999/", { host: "192.0.2.10:9999" }),
+    );
+    expect(wrongPort.headers.get("location")).toContain("clawbox.local");
+
+    const wrongScheme = gatewayProxy.redirectToSetup(
+      createRequest("http://192.0.2.10:8080/", {
+        host: "192.0.2.10:8080",
+        "x-forwarded-proto": "https",
+      }),
+    );
+    expect(wrongScheme.headers.get("location")).toContain("clawbox.local");
+  });
+
+  it("refreshes configured origins after the source file changes", async () => {
+    writeOrigins(["http://first.example.com"]);
+    await importFresh();
+
+    const first = gatewayProxy.redirectToSetup(
+      createRequest("http://first.example.com/", { host: "first.example.com" }),
+    );
+    expect(first.headers.get("location")).toContain("first.example.com");
+
+    writeOrigins(["http://replacement.example.com:8080"]);
+    const replacement = gatewayProxy.redirectToSetup(
+      createRequest("http://replacement.example.com:8080/", {
+        host: "replacement.example.com:8080",
+      }),
+    );
+    expect(replacement.headers.get("location")).toBe(
+      "http://replacement.example.com:8080/setup",
+    );
+
+    const stale = gatewayProxy.redirectToSetup(
+      createRequest("http://first.example.com/", { host: "first.example.com" }),
+    );
+    expect(stale.headers.get("location")).toContain("clawbox.local");
+  });
+
   it("retains existing ALLOWED_HOSTS/IP reflection when no origins are configured", async () => {
-    delete process.env[ENV_VAR];
+    process.env[ENV_VAR] = path.join(dir, "absent.json");
     await importFresh();
 
     const request = createRequest("http://clawbox.local/", { host: "clawbox.local" });
@@ -141,6 +190,7 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
     writeFileSync(file, "{not json");
     process.env[ENV_VAR] = file;
     await importFresh();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const request = createRequest("http://clawbox.local/", { host: "clawbox.local" });
     const response = gatewayProxy.redirectToSetup(request);
@@ -151,5 +201,6 @@ describe("gateway-proxy trusted control UI origin reflection", () => {
     });
     const untrustedResponse = gatewayProxy.redirectToSetup(untrustedRequest);
     expect(untrustedResponse.headers.get("location")).not.toContain("untrusted.example.com");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("not valid JSON"));
   });
 });

--- a/src/tests/unit/gateway-proxy-origins.test.ts
+++ b/src/tests/unit/gateway-proxy-origins.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { NextRequest } from "next/server";
+
+// gateway-proxy.ts's redirectToSetup() reflects the request's own origin
+// back into the /setup redirect URL when the host is trusted, instead of
+// always falling back to CANONICAL_ORIGIN. This exercises the NEW trusted
+// control-UI origins path: unlike the pre-existing ALLOWED_HOSTS/mDNS/IP
+// matching (host-only, scheme/port-agnostic), a configured origin from
+// control-ui-origins.json must match scheme+host+port EXACTLY.
+
+const ENV_VAR = "CLAWBOX_CONTROL_UI_ORIGINS_FILE";
+
+describe("gateway-proxy trusted control UI origin reflection", () => {
+  let dir: string;
+  let originalEnv: string | undefined;
+  let gatewayProxy: typeof import("@/lib/gateway-proxy");
+
+  function createRequest(url: string, headers?: Record<string, string>): NextRequest {
+    return new NextRequest(new URL(url), { headers: new Headers(headers) });
+  }
+
+  function writeOrigins(entries: string[]) {
+    const file = path.join(dir, "origins.json");
+    writeFileSync(file, JSON.stringify(entries));
+    process.env[ENV_VAR] = file;
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "gateway-proxy-origins-"));
+    originalEnv = process.env[ENV_VAR];
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    if (originalEnv === undefined) delete process.env[ENV_VAR];
+    else process.env[ENV_VAR] = originalEnv;
+  });
+
+  async function importFresh() {
+    vi.resetModules();
+    gatewayProxy = await import("@/lib/gateway-proxy");
+  }
+
+  it("reflects a configured origin on an exact scheme+host+port match", async () => {
+    writeOrigins(["http://custom.example.com:8080"]);
+    await importFresh();
+
+    const request = createRequest("http://custom.example.com:8080/", {
+      host: "custom.example.com:8080",
+    });
+    const response = gatewayProxy.redirectToSetup(request);
+
+    expect(response.headers.get("location")).toBe("http://custom.example.com:8080/setup");
+  });
+
+  it("does NOT reflect the same configured hostname on a different port", async () => {
+    writeOrigins(["http://custom.example.com:8080"]);
+    await importFresh();
+
+    const request = createRequest("http://custom.example.com:9999/", {
+      host: "custom.example.com:9999",
+    });
+    const response = gatewayProxy.redirectToSetup(request);
+
+    // Falls through to CANONICAL_ORIGIN default, not the request's own host.
+    expect(response.headers.get("location")).not.toContain("custom.example.com:9999");
+    expect(response.headers.get("location")).toContain("clawbox.local");
+  });
+
+  it("does NOT reflect the same configured hostname on a different scheme", async () => {
+    writeOrigins(["http://custom.example.com"]);
+    await importFresh();
+
+    const request = createRequest("http://custom.example.com/", {
+      host: "custom.example.com",
+      "x-forwarded-proto": "https",
+    });
+    const response = gatewayProxy.redirectToSetup(request);
+
+    expect(response.headers.get("location")).not.toContain("custom.example.com");
+    expect(response.headers.get("location")).toContain("clawbox.local");
+  });
+
+  it("reflects when the exact scheme is also configured separately", async () => {
+    writeOrigins(["http://custom.example.com", "https://custom.example.com"]);
+    await importFresh();
+
+    const request = createRequest("http://custom.example.com/", {
+      host: "custom.example.com",
+      "x-forwarded-proto": "https",
+    });
+    const response = gatewayProxy.redirectToSetup(request);
+
+    expect(response.headers.get("location")).toBe("https://custom.example.com/setup");
+  });
+
+  it("reflects a configured origin at the default port with no port in the Host header", async () => {
+    writeOrigins(["http://custom.example.com"]);
+    await importFresh();
+
+    const request = createRequest("http://custom.example.com/", {
+      host: "custom.example.com",
+    });
+    const response = gatewayProxy.redirectToSetup(request);
+
+    expect(response.headers.get("location")).toBe("http://custom.example.com/setup");
+  });
+
+  it("does not reflect an origin absent from the configured list", async () => {
+    writeOrigins(["http://trusted.example.com"]);
+    await importFresh();
+
+    const request = createRequest("http://untrusted.example.com/", {
+      host: "untrusted.example.com",
+    });
+    const response = gatewayProxy.redirectToSetup(request);
+
+    expect(response.headers.get("location")).not.toContain("untrusted.example.com");
+    expect(response.headers.get("location")).toContain("clawbox.local");
+  });
+
+  it("retains existing ALLOWED_HOSTS/IP reflection when no origins are configured", async () => {
+    delete process.env[ENV_VAR];
+    await importFresh();
+
+    const request = createRequest("http://clawbox.local/", { host: "clawbox.local" });
+    const response = gatewayProxy.redirectToSetup(request);
+
+    expect(response.headers.get("location")).toContain("clawbox.local");
+
+    const ipRequest = createRequest("http://192.0.2.3/", { host: "192.0.2.3" });
+    const ipResponse = gatewayProxy.redirectToSetup(ipRequest);
+    expect(ipResponse.headers.get("location")).toContain("192.0.2.3");
+  });
+
+  it("an invalid origins file yields no extras and does not affect existing host reflection", async () => {
+    const file = path.join(dir, "origins.json");
+    writeFileSync(file, "{not json");
+    process.env[ENV_VAR] = file;
+    await importFresh();
+
+    const request = createRequest("http://clawbox.local/", { host: "clawbox.local" });
+    const response = gatewayProxy.redirectToSetup(request);
+    expect(response.headers.get("location")).toContain("clawbox.local");
+
+    const untrustedRequest = createRequest("http://untrusted.example.com/", {
+      host: "untrusted.example.com",
+    });
+    const untrustedResponse = gatewayProxy.redirectToSetup(untrustedRequest);
+    expect(untrustedResponse.headers.get("location")).not.toContain("untrusted.example.com");
+  });
+});


### PR DESCRIPTION
Fixes #232. Supersedes #295 — same feature (@jamesachurchill's commits, authorship preserved), re-homed onto current beta (auto-merged cleanly with the #306 SecretRef and #308 breaker changes to `gateway-proxy.ts` / `gateway-pre-start.sh`) and run through our flow.

## What
Operators can register extra trusted control-UI origins (VPN / MagicDNS names, a stable HTTPS origin) via `data/control-ui-origins.json`. Validated extras merge into `controlUi.allowedOrigins`; every invalid form — bare host, wildcard, path, credentials, wrong scheme, out-of-range port — is rejected so a configured value can never quietly widen cross-origin access. Validation lives in an importable, unit-tested Python module (`gateway_origins.py`) and a matching TS enforcer (`control-ui-origins.ts` + `gateway-proxy.ts`), with a pre-parse filter against the urlsplit-vs-WHATWG parser differential.

## Why it is needed
`isReflectableHost()` only reflects `ALLOWED_HOSTS` + the mDNS `.local` name + bare IPv4 — an arbitrary DNS name (Tailscale `*.ts.net`, a reverse-proxy domain) is bounced, and `gateway-pre-start.sh` rewrites `controlUi.allowedOrigins` on every boot, so a hand-edit is wiped. This is the only durable, boot-surviving way to register such an origin.

## Verified on the Jetson (aarch64)
- `tsc --noEmit`: clean (no errors in changed files).
- **117 tests pass** across the full gateway suite — the 3 origin suites *plus* the #306 SecretRef and #308 breaker/health tests — confirming the auto-merge is semantically coherent.
- Earlier runtime validation on the box: a valid origin merged exactly once; every invalid form rejected/warned; a configured host not reflected on a different scheme/port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring additional trusted Control UI origins through a JSON configuration file.
  * Added validation, normalization, de-duplication, and exact scheme/host/port matching for configured origins.
  * Configuration changes are detected automatically, with warnings for invalid or unreadable entries.

* **Bug Fixes**
  * Improved gateway redirect handling to reject untrusted or mismatched origins while preserving existing valid behavior.

* **Documentation**
  * Documented configuration, validation rules, and missing-file behavior.

* **Tests**
  * Added comprehensive coverage for configuration loading, validation, gateway integration, and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->