### PR TITLE
fix(auth): return JSON 401 for all expired /setup-api/* requests (closes #304)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -247,9 +247,30 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 5. API requests get 401, page requests redirect to login
+  // 5. Auth failed — choose a JSON 401 or an HTML login redirect.
+  //
+  // Everything under /setup-api/* (and /api/*) is an API surface consumed by
+  // fetch()/XHR that parses the body as JSON. A raw fetch() sends
+  // `Accept: */*`, so the old `accept.includes("application/json")` gate missed
+  // it and fell through to the login *redirect* — whose HTML body then made the
+  // caller's `.json()` throw on an expired session. #231/#303 patched this one
+  // caller at a time; return a JSON 401 for the whole prefix instead so every
+  // caller (~30 across ~15 files) gets a structured 401 it can detect, with no
+  // client changes (#304).
+  //
+  // Deliberate trade-off: a few /setup-api/* routes are loaded by direct
+  // browser navigation/embedding (webapps?app= iframes, apps/icon/[appId]
+  // <img>, file downloads) rather than fetch(), and now get a 401 too instead
+  // of a login page. That's fine — a login page rendered inside an <img> or a
+  // download stream is useless anyway, and the desktop shell drives the real
+  // re-login. Genuine top-level page navigations (no /setup-api/ or /api/
+  // prefix) still redirect below.
   const accept = request.headers.get("accept") || "";
-  if (accept.includes("application/json") || pathname.startsWith("/api/")) {
+  if (
+    pathname.startsWith("/setup-api/") ||
+    pathname.startsWith("/api/") ||
+    accept.includes("application/json")
+  ) {
     return NextResponse.json({ error: "Authentication required" }, { status: 401 });
   }
 

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -253,6 +253,20 @@ describe("middleware", () => {
       expect(response.status).toBe(401);
     });
 
+    it("returns a parseable JSON 401 for /setup-api/* with no Accept header (#304)", async () => {
+      // The bug: a raw fetch("/setup-api/...") sends Accept: */*, hit the login
+      // *redirect*, and the caller's `.json()` threw on the login page's HTML.
+      // Guard that an expired session now yields a JSON 401 the caller can parse.
+      process.env.SESSION_SECRET = "test-secret";
+      markSetupComplete();
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest("/setup-api/system/info"));
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Authentication required" });
+    });
+
     it.each(["/login", "/setup", "/setup-api/setup/status", "/_next/chunk.js", "/fonts/test.woff", "/images/logo.png", "/manifest.json", "/favicon.ico", "/portal/subscribe"])("allows public path %s", async (p) => {
       process.env.SESSION_SECRET = "test-secret";
       vi.resetModules();
@@ -269,11 +283,13 @@ describe("middleware", () => {
       vi.resetModules();
       const mod = await import("@/middleware");
 
+      // createRequest() sends no Accept header — exactly like a raw fetch()
+      // (Accept: */*). Every /setup-api/* consumer parses JSON, so an expired
+      // session must return a JSON 401, not an HTML login redirect that makes
+      // the caller's .json() throw (#304).
       const req = createRequest(p);
       const response = await mod.middleware(req);
-      // No session cookie -> page-style requests redirect to /login (307).
-      expect(response.status).toBe(307);
-      expect(response.headers.get("Location")).toContain("/login");
+      expect(response.status).toBe(401);
     });
 
     it.each(["/setup-api/wifi/scan", "/setup-api/update/status", "/setup-api/update/run", "/setup-api/system/credentials", "/setup-api/ai-models/configure", "/setup-api/telegram/configure"])("allows %s during setup wizard bootstrap", async (p) => {
@@ -300,8 +316,9 @@ describe("middleware", () => {
 
       markSetupComplete();
       const locked = await mod.middleware(createRequest("/setup-api/wifi/scan"));
-      expect(locked.status).toBe(307);
-      expect(locked.headers.get("Location")).toContain("/login");
+      // Re-locked API surface returns a JSON 401 (not a login redirect) so
+      // fetch() callers can detect the expired session — see #304.
+      expect(locked.status).toBe(401);
     });
 
     it("skips auth on /setup-api/* when CLAWBOX_TEST_MODE=1 (e2e-install harness)", async () => {
@@ -329,8 +346,8 @@ describe("middleware", () => {
 
       const req = createRequest("/setup-api/wifi/scan");
       const response = await mod.middleware(req);
-      expect(response.status).toBe(307);
-      expect(response.headers.get("Location")).toContain("/login");
+      // Auth still enforced -> /setup-api/* yields a JSON 401 (not a bypass).
+      expect(response.status).toBe(401);
     });
 
     it("still redirects page requests to /login under CLAWBOX_TEST_MODE", async () => {


### PR DESCRIPTION
Closes #304 — the follow-up to #231/#303, which each patched a single caller.

## The latent bug

A raw `fetch("/setup-api/...")` sends `Accept: */*`. The middleware gate was:

```ts
if (accept.includes("application/json") || pathname.startsWith("/api/")) { return 401 }
// else -> HTML redirect to /login
```

So a fetch without an explicit `Accept: application/json` header fell through to the **login-page redirect**, and the caller's `.json()` then threw on the HTML body when the session had expired. ~30 callers across ~15 files (`i18n.tsx`, `SettingsApp.tsx`, `mascot-client.ts`, `useOllamaModels`, `FilesApp`, `DoneStep`, `AIModelsStep`, …) carried this.

## Fix (the issue's preferred "deepest fix")

Return a JSON 401 for the whole `/setup-api/*` (and `/api/*`) prefix regardless of the `Accept` header. Every caller now gets a structured 401 it can detect — **no client changes**. Top-level page navigations (no API prefix) still redirect to `/login`.

**Deliberate trade-off:** the handful of `/setup-api/*` routes loaded by direct browser embedding (`webapps?app=` iframes, `apps/icon/[appId]` `<img>`, file downloads) now get a 401 instead of a login page. That's fine — a login page inside an `<img>` or a download stream is useless anyway; the desktop shell drives the real re-login.

## Tests

- Updated the middleware suite: `/setup-api/*` with no `Accept` header now asserts **401** (was the buggy 307).
- Added a regression test asserting the 401 **body is parseable JSON** (the actual failure mode).
- **47/47 middleware tests passing on a real Jetson.**