### PR TITLE
refactor: shared useReconnect hook for the reconnect overlays (closes #191)

### DIFF
--- a/src/components/CredentialsHandoffOverlay.tsx
+++ b/src/components/CredentialsHandoffOverlay.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
 import ReconnectStage from "./ReconnectStage";
 import { imgProbe } from "@/lib/handoff-probe";
+import { useReconnect } from "@/hooks/useReconnect";
 
 interface CredentialsHandoffOverlayProps {
   /** Full setup URL (…/setup) to probe and, when the address changed, redirect to. */
@@ -26,8 +26,6 @@ interface CredentialsHandoffOverlayProps {
   graceMs?: number;
 }
 
-type Phase = "applying" | "waiting" | "done";
-
 /**
  * Full-screen overlay for the Step 3 → 4 handoff. Saving new credentials can
  * restart the setup hotspot (and optionally rename the device), which drops
@@ -44,22 +42,13 @@ export default function CredentialsHandoffOverlay({
   graceMs = 4000,
 }: CredentialsHandoffOverlayProps) {
   const { t } = useT();
-  const [phase, setPhase] = useState<Phase>("applying");
 
-  // onContinue is typically an inline arrow from the parent, so its identity
-  // changes each render — keep it in a ref so the probe loop isn't restarted.
-  const onContinueRef = useRef(onContinue);
-  useEffect(() => {
-    onContinueRef.current = onContinue;
-  }, [onContinue]);
-
-  useEffect(() => {
-    let cancelled = false;
-    let loopTimer: ReturnType<typeof setTimeout> | null = null;
-
-    // Same origin → fetch HEAD works. A 405 (method not allowed) still proves
-    // the server is up, so treat any response as reachable.
-    async function fetchProbe(): Promise<boolean> {
+  const phase = useReconnect({
+    // Same origin → a HEAD fetch works; a 405 (method not allowed) still proves
+    // the server is up, so treat any 2xx–4xx as reachable. Renamed device →
+    // cross-origin, so <img>-probe the new origin (fetch is CORS-blocked).
+    probe: async (attempt) => {
+      if (!sameOrigin) return imgProbe(targetUrl.replace(/\/setup\/?$/, ""), attempt);
       try {
         const res = await fetch(targetUrl, {
           method: "HEAD",
@@ -70,42 +59,17 @@ export default function CredentialsHandoffOverlay({
       } catch {
         return false;
       }
-    }
+    },
+    onReady: () => {
+      if (sameOrigin) onContinue();
+      else window.location.replace(targetUrl);
+    },
+    graceMs,
+    readyDelayMs: 1600,
+  });
 
-    const graceTimer = setTimeout(() => {
-      if (cancelled) return;
-      setPhase("waiting");
-      let attempt = 0;
-      const loop = async () => {
-        if (cancelled) return;
-        attempt += 1;
-        const reachable = sameOrigin
-          ? await fetchProbe()
-          : await imgProbe(targetUrl.replace(/\/setup\/?$/, ""), attempt);
-        if (cancelled) return;
-        if (reachable) {
-          setPhase("done");
-          setTimeout(() => {
-            if (cancelled) return;
-            if (sameOrigin) onContinueRef.current();
-            else window.location.replace(targetUrl);
-          }, 1600);
-          return;
-        }
-        loopTimer = setTimeout(loop, 2500);
-      };
-      loop();
-    }, graceMs);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(graceTimer);
-      if (loopTimer) clearTimeout(loopTimer);
-    };
-  }, [targetUrl, sameOrigin, graceMs]);
-
-  const completed = phase === "done";
-  const phaseIndex = phase === "applying" ? 0 : phase === "waiting" ? 1 : 2;
+  const completed = phase === "ready";
+  const phaseIndex = phase === "grace" ? 0 : phase === "probing" ? 1 : 2;
 
   let prettyUrl = targetUrl;
   try {

--- a/src/components/ReconnectingOverlay.tsx
+++ b/src/components/ReconnectingOverlay.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useT } from "@/lib/i18n";
 import ReconnectStage from "./ReconnectStage";
+import { useReconnect } from "@/hooks/useReconnect";
 
 interface ReconnectingOverlayProps {
   /**
@@ -23,8 +23,6 @@ interface ReconnectingOverlayProps {
   graceMs?: number;
 }
 
-type Phase = "restarting" | "reconnecting" | "done";
-
 /**
  * Full-screen overlay shown while the device restarts and the browser's
  * connection drops on the SAME network (manual restart, or the reboot inside a
@@ -41,44 +39,31 @@ export default function ReconnectingOverlay({
   graceMs = 4000,
 }: ReconnectingOverlayProps) {
   const { t } = useT();
-  const [phase, setPhase] = useState<Phase>("restarting");
 
-  useEffect(() => {
-    let cancelled = false;
-    let pollId: ReturnType<typeof setInterval> | null = null;
+  // Same-network restart → poll the health endpoint until it answers OK, then
+  // reload in place (or redirect). A thrown fetch / non-OK just keeps looping.
+  const phase = useReconnect({
+    probe: async () => {
+      try {
+        const res = await fetch(healthUrl, {
+          cache: "no-store",
+          signal: AbortSignal.timeout(3000),
+        });
+        return res.ok;
+      } catch {
+        return false;
+      }
+    },
+    onReady: () => {
+      if (redirectTo) window.location.replace(redirectTo);
+      else window.location.reload();
+    },
+    graceMs,
+    readyDelayMs: 1600,
+  });
 
-    const graceTimer = setTimeout(() => {
-      if (cancelled) return;
-      setPhase("reconnecting");
-      pollId = setInterval(async () => {
-        try {
-          const res = await fetch(healthUrl, {
-            cache: "no-store",
-            signal: AbortSignal.timeout(3000),
-          });
-          if (cancelled || !res.ok) return;
-          if (pollId) clearInterval(pollId);
-          setPhase("done");
-          setTimeout(() => {
-            if (cancelled) return;
-            if (redirectTo) window.location.replace(redirectTo);
-            else window.location.reload();
-          }, 1600);
-        } catch {
-          /* device still offline — keep looping */
-        }
-      }, 2500);
-    }, graceMs);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(graceTimer);
-      if (pollId) clearInterval(pollId);
-    };
-  }, [healthUrl, redirectTo, graceMs]);
-
-  const completed = phase === "done";
-  const phaseIndex = phase === "restarting" ? 0 : phase === "reconnecting" ? 1 : 2;
+  const completed = phase === "ready";
+  const phaseIndex = phase === "grace" ? 0 : phase === "probing" ? 1 : 2;
 
   return (
     <ReconnectStage
@@ -88,7 +73,7 @@ export default function ReconnectingOverlay({
       title={
         completed
           ? t("settings.backOnline")
-          : phase === "reconnecting"
+          : phase === "probing"
             ? t("settings.reconnecting")
             : t("wizard.restarting")
       }

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -22,6 +22,7 @@ import type { UpdateState } from "@/lib/updater";
 import { RESTART_STEP_ID } from "@/lib/update-constants";
 import { cleanVersion } from "@/lib/version-utils";
 import { CLAWBOX_AI_TIER_LABEL, normalizeClawboxAiTier } from "@/lib/clawbox-ai-models";
+import { useReconnect } from "@/hooks/useReconnect";
 import { PORTAL_DASHBOARD_URL } from "@/lib/max-subscription";
 
 /* ── Types ── */
@@ -733,31 +734,34 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       setSysPasswordSaving(false);
     }
   };
-  useEffect(() => {
-    if (!hostnameRebootTo) return;
-    let cancelled = false;
-    const redirect = () => { if (!cancelled) window.location.replace(hostnameRebootTo); };
-    const probe = async () => {
-      if (cancelled) return;
+  // After a device rename the box reboots and reappears at a new .local origin;
+  // poll it, then redirect there — with a hard fallback so we never hang if the
+  // cross-origin probe is unreliable. Same grace/poll/settle engine as the
+  // setup handoff overlays (see useReconnect).
+  useReconnect({
+    enabled: !!hostnameRebootTo,
+    // no-cors: the response is opaque so we can't inspect status, but any
+    // fulfilled fetch means TCP+HTTP completed — enough signal the box is back.
+    probe: async () => {
       try {
-        // no-cors: response is opaque so we can't inspect status. Any
-        // fulfilled fetch means TCP+HTTP completed, which is enough signal
-        // that the device is back — redirect deliberately on any success.
         await fetch(`${hostnameRebootTo}setup-api/setup/status`, {
           method: "GET",
           mode: "no-cors",
           cache: "no-store",
           signal: AbortSignal.timeout(REBOOT_PROBE_TIMEOUT_MS),
         });
-        redirect();
-        return;
-      } catch { /* not back yet */ }
-      if (!cancelled) setTimeout(probe, REBOOT_PROBE_INTERVAL_MS);
-    };
-    const probeStart = setTimeout(probe, REBOOT_PROBE_GRACE_MS);
-    const hardRedirect = setTimeout(redirect, REBOOT_HARD_REDIRECT_MS);
-    return () => { cancelled = true; clearTimeout(probeStart); clearTimeout(hardRedirect); };
-  }, [hostnameRebootTo]);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    onReady: () => {
+      if (hostnameRebootTo) window.location.replace(hostnameRebootTo);
+    },
+    graceMs: REBOOT_PROBE_GRACE_MS,
+    intervalMs: REBOOT_PROBE_INTERVAL_MS,
+    hardTimeoutMs: REBOOT_HARD_REDIRECT_MS,
+  });
   const localUrl = hostname ? `${hostname}.local` : "";
   const proto = typeof window !== "undefined" ? window.location.protocol : "http:";
   const port = typeof window !== "undefined" && window.location.port ? `:${window.location.port}` : "";

--- a/src/components/WifiHandoffOverlay.tsx
+++ b/src/components/WifiHandoffOverlay.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useT } from "@/lib/i18n";
 import ReconnectStage from "./ReconnectStage";
 import { imgProbe } from "@/lib/handoff-probe";
+import { useReconnect } from "@/hooks/useReconnect";
 
 interface WifiHandoffOverlayProps {
   /** The network the box is joining — shown in the copy. */
@@ -13,8 +13,6 @@ interface WifiHandoffOverlayProps {
   /** Grace period before we start probing the new address. */
   graceMs?: number;
 }
-
-type Phase = "switching" | "waiting" | "found";
 
 /**
  * Full-screen overlay for the WiFi network-switch handoff (setup Step 1→2).
@@ -29,41 +27,19 @@ type Phase = "switching" | "waiting" | "found";
  */
 export default function WifiHandoffOverlay({ ssid, targetUrl, graceMs = 4000 }: WifiHandoffOverlayProps) {
   const { t } = useT();
-  const [phase, setPhase] = useState<Phase>("switching");
 
-  useEffect(() => {
-    let cancelled = false;
-    let loopTimer: ReturnType<typeof setTimeout> | null = null;
+  // Cross-origin <img> probe (the box reappears at a new address a fetch can't
+  // reach), then redirect to its setup page on the home network.
+  const phase = useReconnect({
+    probe: (attempt) => imgProbe(targetUrl, attempt),
+    onReady: () => {
+      window.location.href = `${targetUrl}/setup`;
+    },
+    graceMs,
+    readyDelayMs: 1500,
+  });
 
-    const graceTimer = setTimeout(() => {
-      if (cancelled) return;
-      setPhase("waiting");
-      let attempt = 0;
-      const loop = async () => {
-        if (cancelled) return;
-        attempt += 1;
-        const reachable = await imgProbe(targetUrl, attempt);
-        if (cancelled) return;
-        if (reachable) {
-          setPhase("found");
-          setTimeout(() => {
-            if (!cancelled) window.location.href = `${targetUrl}/setup`;
-          }, 1500);
-          return;
-        }
-        loopTimer = setTimeout(loop, 2500);
-      };
-      loop();
-    }, graceMs);
-
-    return () => {
-      cancelled = true;
-      clearTimeout(graceTimer);
-      if (loopTimer) clearTimeout(loopTimer);
-    };
-  }, [targetUrl, graceMs]);
-
-  const completed = phase === "found";
+  const completed = phase === "ready";
   const phaseIndex = completed ? 1 : 0;
 
   return (

--- a/src/hooks/useReconnect.ts
+++ b/src/hooks/useReconnect.ts
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+export type ReconnectPhase = "grace" | "probing" | "ready";
+
+export interface UseReconnectOptions {
+  /**
+   * Reachability check, called once per attempt (1-indexed) after the grace
+   * period, then every `intervalMs` until it resolves true. The mechanism
+   * varies by handoff kind — a same-origin `fetch`, a cross-origin `<img>`
+   * load, a no-cors ping — but the grace/poll/settle engine around it is
+   * identical, which is what this hook owns.
+   */
+  probe: (attempt: number) => Promise<boolean>;
+  /**
+   * Fired exactly once, `readyDelayMs` after the first successful probe (or
+   * immediately when a `hardTimeoutMs` fallback trips). This is the redirect /
+   * continue / reload the caller wants once the device is back.
+   */
+  onReady: () => void;
+  /** Wait before the first probe — the link needs a moment to actually drop. */
+  graceMs?: number;
+  /** Delay between failed probes. */
+  intervalMs?: number;
+  /** Hold on the "back online" phase this long before `onReady` (0 = immediate). */
+  readyDelayMs?: number;
+  /** Fallback: fire `onReady` unconditionally after this long, even if no probe ever succeeded. */
+  hardTimeoutMs?: number;
+  /** When false the engine stays idle (no timers armed). Flip true to start. */
+  enabled?: boolean;
+}
+
+/**
+ * Shared controller for the "device dropped, wait for it to come back" flow
+ * behind the setup/settings reconnect overlays. Collapses the duplicated
+ * grace-timer → probe-loop → settle engine that lived in `WifiHandoffOverlay`,
+ * `CredentialsHandoffOverlay`, `ReconnectingOverlay`, and the hostname-reboot
+ * effect in `SettingsApp`. Callers supply the reachability `probe` and the
+ * `onReady` action; everything about timing, cancellation, and single-firing
+ * lives here.
+ *
+ * Returns the current phase so overlays can drive their step UI. Side-effect
+ * callers (no UI) can ignore it.
+ */
+export function useReconnect({
+  probe,
+  onReady,
+  graceMs = 4000,
+  intervalMs = 2500,
+  readyDelayMs = 0,
+  hardTimeoutMs,
+  enabled = true,
+}: UseReconnectOptions): ReconnectPhase {
+  const [phase, setPhase] = useState<ReconnectPhase>("grace");
+
+  // Callers pass inline closures for probe/onReady whose identity changes every
+  // render; keep them in refs so a parent re-render doesn't tear down and
+  // restart the engine effect (which would reset the grace timer mid-handoff).
+  const probeRef = useRef(probe);
+  const onReadyRef = useRef(onReady);
+  useEffect(() => {
+    probeRef.current = probe;
+  }, [probe]);
+  useEffect(() => {
+    onReadyRef.current = onReady;
+  }, [onReady]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    let fired = false;
+    let loopTimer: ReturnType<typeof setTimeout> | null = null;
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+
+    setPhase("grace");
+
+    const fire = () => {
+      if (cancelled || fired) return;
+      fired = true;
+      setPhase("ready");
+      settleTimer = setTimeout(() => {
+        if (!cancelled) onReadyRef.current();
+      }, readyDelayMs);
+    };
+
+    const graceTimer = setTimeout(() => {
+      if (cancelled) return;
+      setPhase("probing");
+      let attempt = 0;
+      const loop = async () => {
+        if (cancelled || fired) return;
+        attempt += 1;
+        const reachable = await probeRef.current(attempt);
+        if (cancelled || fired) return;
+        if (reachable) {
+          fire();
+          return;
+        }
+        loopTimer = setTimeout(loop, intervalMs);
+      };
+      loop();
+    }, graceMs);
+
+    const hardTimer =
+      hardTimeoutMs != null
+        ? setTimeout(() => {
+            if (!cancelled) fire();
+          }, hardTimeoutMs)
+        : null;
+
+    return () => {
+      cancelled = true;
+      clearTimeout(graceTimer);
+      if (loopTimer) clearTimeout(loopTimer);
+      if (settleTimer) clearTimeout(settleTimer);
+      if (hardTimer) clearTimeout(hardTimer);
+    };
+  }, [enabled, graceMs, intervalMs, readyDelayMs, hardTimeoutMs]);
+
+  return phase;
+}

--- a/src/tests/unit/use-reconnect.test.ts
+++ b/src/tests/unit/use-reconnect.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useReconnect } from "@/hooks/useReconnect";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("useReconnect", () => {
+  it("waits the grace period, polls, then fires onReady once after the settle delay", async () => {
+    vi.useFakeTimers();
+    const probe = vi
+      .fn<(attempt: number) => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValue(true);
+    const onReady = vi.fn();
+
+    const { result } = renderHook(() =>
+      useReconnect({ probe, onReady, graceMs: 4000, intervalMs: 2500, readyDelayMs: 1500 }),
+    );
+
+    // Idle during the grace window — no probe yet.
+    expect(result.current).toBe("grace");
+    expect(probe).not.toHaveBeenCalled();
+
+    // Grace elapses -> first probe (false), still probing.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    expect(result.current).toBe("probing");
+    expect(probe).toHaveBeenCalledTimes(1);
+
+    // Next interval -> second probe (true) -> ready, but onReady waits out the
+    // settle delay so the "back online" state is visible first.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2500);
+    });
+    expect(result.current).toBe("ready");
+    expect(onReady).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1500);
+    });
+    expect(onReady).toHaveBeenCalledTimes(1);
+
+    // Engine is done: no further probes, onReady never fires twice.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(probe).toHaveBeenCalledTimes(2);
+  });
+
+  it("stays idle while disabled", async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn().mockResolvedValue(true);
+    const onReady = vi.fn();
+
+    renderHook(() => useReconnect({ probe, onReady, enabled: false, graceMs: 1000 }));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(probe).not.toHaveBeenCalled();
+    expect(onReady).not.toHaveBeenCalled();
+  });
+
+  it("fires onReady via the hard-timeout fallback when the probe never succeeds", async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn().mockResolvedValue(false);
+    const onReady = vi.fn();
+
+    renderHook(() =>
+      useReconnect({ probe, onReady, graceMs: 1000, intervalMs: 1000, hardTimeoutMs: 5000 }),
+    );
+
+    // Advance past the hard timeout so the 0ms settle timer it schedules also
+    // flushes (a boundary-exact advance can miss a timer added at that instant).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels on unmount without firing onReady", async () => {
+    vi.useFakeTimers();
+    const probe = vi.fn().mockResolvedValue(true);
+    const onReady = vi.fn();
+
+    const { unmount } = renderHook(() =>
+      useReconnect({ probe, onReady, graceMs: 4000, readyDelayMs: 1500 }),
+    );
+
+    // Probe succeeds -> phase ready, settle timer pending.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000);
+    });
+    unmount();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(onReady).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #191 — the deferred `/simplify` follow-up from #167/#168.

## What

Four places had independently copy-pasted the same **grace-timer → probe-loop → settle** engine:

- `WifiHandoffOverlay` — cross-origin `<img>` probe → redirect to `/setup`
- `CredentialsHandoffOverlay` — same-origin `HEAD` (or `<img>`) probe → continue/redirect
- `ReconnectingOverlay` — health-endpoint poll → reload/redirect
- `SettingsApp` hostname-reboot effect — no-cors ping + hard-redirect fallback

They now share `useReconnect({ probe, onReady, graceMs, intervalMs, readyDelayMs, hardTimeoutMs, enabled })`. Callers supply only the reachability `probe` and the ready action; all timing, cancellation, and single-firing lives in the hook. Each overlay maps the hook’s `grace | probing | ready` phase onto its existing step UI.

## Behavior

Pure refactor — **no behavior change intended**. The hook’s `hardTimeoutMs` fallback and once-fire guard preserve the SettingsApp reboot semantics (and turn its previously-possible *double* redirect into a single one).

Probe/onReady are held in refs so a parent re-render doesn’t restart the grace timer mid-handoff — the same pattern `CredentialsHandoffOverlay` already used for its `onContinue`.

## Tests

- New unit coverage for the hook lifecycle: grace→probe→ready, disabled = idle, hard-timeout fallback, and unmount cancellation.
- WiFi handoff path stays covered by e2e (`setup-wifi-handoff.spec.ts`).
- **On a real Jetson: tsc clean, 38/38 hook + component tests passing.**