### PR TITLE
fix(e2e): warm Turbopack before the suite (partially addresses #114)

### DIFF
--- a/e2e/browser-vnc.spec.ts
+++ b/e2e/browser-vnc.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks, openLauncher } from "./helpers/clawbox";
 
-// FIXME: passes locally / on the Jetson worktree (verified ~7-18s) but
-// times out on GitHub Actions even with 60s per-test + 15s expect/action
-// timeouts. Root cause is environmental (likely runner memory pressure
-// with `bun run dev` under sequential workers:1). Tracked as a follow-up
-// to PR #113 — needs the e2e GH-runner profile investigated separately.
-test.fixme("browser app installs chromium, enables integration, and opens the VNC app", async ({ page }) => {
+// Re-enabled: the GH-Actions-only flake was the cold Turbopack compile of `/`
+// under `bun run dev` (workers:1) outrunning the timeouts. The global-setup
+// warmup now pays that compile before the suite starts. See #114.
+test("browser app installs chromium, enables integration, and opens the VNC app", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/browser-vnc.spec.ts
+++ b/e2e/browser-vnc.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks, openLauncher } from "./helpers/clawbox";
 
-// Re-enabled: the GH-Actions-only flake was the cold Turbopack compile of `/`
-// under `bun run dev` (workers:1) outrunning the timeouts. The global-setup
-// warmup now pays that compile before the suite starts. See #114.
-test("browser app installs chromium, enables integration, and opens the VNC app", async ({ page }) => {
+// FIXME: the global-setup warmup (#114) removed the cold-compile flake, but
+// this spec still times out on GitHub Actions at its first DOM interaction — a
+// deeper post-mount/hydration lag under `bun run dev` workers:1 that the warmup
+// doesn't touch. Passes on the Jetson; still tracked in #114.
+test.fixme("browser app installs chromium, enables integration, and opens the VNC app", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/clawkeep-interactions.spec.ts
+++ b/e2e/clawkeep-interactions.spec.ts
@@ -164,9 +164,9 @@ test("restore modal opens, fetches snapshots, and Esc dismisses it", async ({ pa
   await expect(modal).not.toBeVisible();
 });
 
-// FIXME: same GH-Actions-only flake as browser-vnc — verified passing
-// in isolation on the Jetson. Tracked as a follow-up to PR #113.
-test.fixme("unpair flow opens the confirm dialog and Esc dismisses it without unpairing", async ({ page }) => {
+// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
+// compile flake is paid up front now, and this passes on the Jetson in isolation.
+test("unpair flow opens the confirm dialog and Esc dismisses it without unpairing", async ({ page }) => {
   await setupDesktop(page);
 
   let unpairCalled = 0;

--- a/e2e/clawkeep-interactions.spec.ts
+++ b/e2e/clawkeep-interactions.spec.ts
@@ -164,9 +164,11 @@ test("restore modal opens, fetches snapshots, and Esc dismisses it", async ({ pa
   await expect(modal).not.toBeVisible();
 });
 
-// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
-// compile flake is paid up front now, and this passes on the Jetson in isolation.
-test("unpair flow opens the confirm dialog and Esc dismisses it without unpairing", async ({ page }) => {
+// FIXME: the global-setup warmup (#114) removed the cold-compile flake, but
+// this spec still times out on GitHub Actions at its first DOM interaction — a
+// deeper post-mount/hydration lag under `bun run dev` workers:1 that the warmup
+// doesn't touch. Passes on the Jetson; still tracked in #114.
+test.fixme("unpair flow opens the confirm dialog and Esc dismisses it without unpairing", async ({ page }) => {
   await setupDesktop(page);
 
   let unpairCalled = 0;

--- a/e2e/desktop-selection.spec.ts
+++ b/e2e/desktop-selection.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
-// compile flake is paid up front now, and this passes on the Jetson in isolation.
-test("desktop background context menu can launch the terminal", async ({ page }) => {
+// FIXME: the global-setup warmup (#114) removed the cold-compile flake, but
+// this spec still times out on GitHub Actions at its first DOM interaction — a
+// deeper post-mount/hydration lag under `bun run dev` workers:1 that the warmup
+// doesn't touch. Passes on the Jetson; still tracked in #114.
+test.fixme("desktop background context menu can launch the terminal", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/desktop-selection.spec.ts
+++ b/e2e/desktop-selection.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-// FIXME: same GH-Actions-only flake as browser-vnc — verified passing
-// in isolation on the Jetson. Tracked as a follow-up to PR #113.
-test.fixme("desktop background context menu can launch the terminal", async ({ page }) => {
+// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
+// compile flake is paid up front now, and this passes on the Jetson in isolation.
+test("desktop background context menu can launch the terminal", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,41 @@
+import { chromium, type FullConfig } from "@playwright/test";
+
+/**
+ * Warm the Turbopack dev server before the timed suite runs.
+ *
+ * CI serves e2e through `bun run dev` with `workers: 1`, so the FIRST request to
+ * a route pays its full on-demand Turbopack compile (route RSC + client bundle).
+ * Under GitHub Actions load the initial compile of `/` — the desktop shell, the
+ * single heaviest route — can exceed the 15s expect timeout, so whichever spec
+ * hits `/` first flakes on `getByTestId('desktop-root')` even though the app is
+ * fine (it passes on the Jetson and on every later spec once `/` is compiled).
+ * The same cold-compile cost also shows up as slow first interactions in the
+ * heavier specs. See #114.
+ *
+ * Loading the heavy routes once here, before any test starts its clock, moves
+ * that one-time compile out of the timed path. The dev server serves e2e with
+ * SESSION_SECRET unset, so middleware lets `/` through and the desktop renders
+ * without auth — no mocks needed just to trigger the compile.
+ */
+async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0]?.use?.baseURL;
+  if (!baseURL) return;
+
+  const browser = await chromium.launch();
+  try {
+    const page = await browser.newPage({ baseURL });
+    // Generous budget: this call IS the cold compile we are paying up front.
+    await page.goto("/", { waitUntil: "networkidle", timeout: 120_000 }).catch(() => {});
+    // Best-effort — the compile has happened regardless of what finally renders.
+    await page
+      .getByTestId("desktop-root")
+      .waitFor({ state: "visible", timeout: 120_000 })
+      .catch(() => {});
+    // The setup wizard is the other heavy route tree the suite hammers.
+    await page.goto("/setup", { waitUntil: "networkidle", timeout: 120_000 }).catch(() => {});
+  } finally {
+    await browser.close();
+  }
+}
+
+export default globalSetup;

--- a/e2e/installed-app-settings.spec.ts
+++ b/e2e/installed-app-settings.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-// FIXME: same GH-Actions-only flake as browser-vnc — verified passing
-// in isolation on the Jetson. Tracked as a follow-up to PR #113.
-test.fixme("installed app settings can save configuration and toggle enablement", async ({ page }) => {
+// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
+// compile flake is paid up front now, and this passes on the Jetson in isolation.
+test("installed app settings can save configuration and toggle enablement", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/installed-app-settings.spec.ts
+++ b/e2e/installed-app-settings.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
-// compile flake is paid up front now, and this passes on the Jetson in isolation.
-test("installed app settings can save configuration and toggle enablement", async ({ page }) => {
+// FIXME: the global-setup warmup (#114) removed the cold-compile flake, but
+// this spec still times out on GitHub Actions at its first DOM interaction — a
+// deeper post-mount/hydration lag under `bun run dev` workers:1 that the warmup
+// doesn't touch. Passes on the Jetson; still tracked in #114.
+test.fixme("installed app settings can save configuration and toggle enablement", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/mascot-context.spec.ts
+++ b/e2e/mascot-context.spec.ts
@@ -1,9 +1,11 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
-// compile flake is paid up front now, and this passes on the Jetson in isolation.
-test("mascot tap opens the chat popup", async ({ page }) => {
+// FIXME: the global-setup warmup (#114) removed the cold-compile flake, but
+// this spec still times out on GitHub Actions at its first DOM interaction — a
+// deeper post-mount/hydration lag under `bun run dev` workers:1 that the warmup
+// doesn't touch. Passes on the Jetson; still tracked in #114.
+test.fixme("mascot tap opens the chat popup", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/mascot-context.spec.ts
+++ b/e2e/mascot-context.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 
-// FIXME: same GH-Actions-only flake as browser-vnc — verified passing
-// in isolation on the Jetson. Tracked as a follow-up to PR #113.
-test.fixme("mascot tap opens the chat popup", async ({ page }) => {
+// Re-enabled via the global-setup warmup (see #114) — the GH-Actions cold-`/`
+// compile flake is paid up front now, and this passes on the Jetson in isolation.
+test("mascot tap opens the chat popup", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/terminal-reconnect.spec.ts
+++ b/e2e/terminal-reconnect.spec.ts
@@ -1,10 +1,9 @@
 import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks, openLauncher } from "./helpers/clawbox";
 
-// FIXME: same GH-Actions-only flake as browser-vnc. The terminal
-// WebSocket handshake races with the page-load timer on slow runners.
-// Tracked as a follow-up to PR #113.
-test.fixme("terminal can open and connect to the websocket backend", async ({ page }) => {
+// Re-enabled via the global-setup warmup (see #114): the terminal WebSocket
+// handshake no longer races the cold `/` compile now that it happens up front.
+test("terminal can open and connect to the websocket backend", async ({ page }) => {
   await page.addInitScript(() => {
     const NativeWebSocket = window.WebSocket;
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,10 @@ const baseURL = `http://localhost:${port}`;
 
 export default defineConfig({
   testDir: "./e2e",
+  // Pre-compile the heavy routes on the dev server before any test clock starts
+  // (Turbopack compiles on demand under `workers: 1`, and the cold compile of
+  // `/` can outlast the 15s expect timeout on CI). See #114 / global-setup.ts.
+  globalSetup: "./e2e/global-setup.ts",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   // Mirror CI's retry strategy locally too. Tests that compress


### PR DESCRIPTION
Partially addresses #114 (does not close it — see below).

## Root cause

The e2e job serves the app with `bun run dev` (`workers: 1`), so the **first** request to a route pays its full on-demand Turbopack compile. Under GitHub Actions load the cold compile of `/` (the desktop shell) can outlast the 15s expect timeout. That's why `chat-popup` started failing the moment the `next` 16.2 bump (#315) nudged that compile past the threshold, and it's one half of #114.

## Fix

A Playwright `globalSetup` loads `/` and `/setup` once, before any test clock starts, so the one-time compile happens up front.

## What the CI run proved

The warmup reliably fixes the **cold-compile** class:
- ✅ `chat-popup` (desktop-root render) — this unblocks the #315 security PR
- ✅ `terminal-reconnect` (WebSocket handshake no longer races the compile) — re-enabled here

It does **not** fix the **interaction-lag** class — five specs still time out at their first DOM click / context-menu on GH Actions (a deeper post-mount/hydration lag under `workers: 1`): `browser-vnc`, `desktop-selection`, `installed-app-settings`, `mascot-context`, `clawkeep-interactions`. Those stay `fixme`'d with an accurate note and remain tracked in #114.

## Net

Compile-latency root cause fixed + 1 of the 6 flaky specs restored + chat-popup made robust. The remaining 5 need the deeper CI-infra work (production build for e2e, or sharding/`workers: 2`) — the production-build path is entangled with the dev-bundle coverage report, so it's its own task. Leaving #114 open for that.
