### PR TITLE
ci: add CodeQL static analysis (JS/TS)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main, beta]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan (Mondays 02:30 UTC) to catch advisories in code that
+    # hasn't changed since the last push.
+    - cron: "30 2 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Required to upload results to the code-scanning dashboard.
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # JS + TS share one analysis; build-mode "none" needs no compile step.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended adds higher-signal security queries on top of the
+          # default set without the noisier code-quality suite.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds GitHub CodeQL scanning — the repo currently has no code-scanning analysis (the security tab's Code Scanning section is empty).

- Runs on push to `main`/`beta`, PRs to `main`, and a weekly cron.
- `javascript-typescript` with `build-mode: none` (no compile needed) and the `security-extended` query pack.
- Results land in the repo's Code Scanning dashboard.

Part of the security hardening pass (recommendation #3).