### PR TITLE
test(e2e): re-enable desktop-selection (last #114 spec)

### DIFF
--- a/e2e/desktop-selection.spec.ts
+++ b/e2e/desktop-selection.spec.ts
@@ -2,19 +2,10 @@ import { expect, test } from "./helpers/coverage";
 import { installClawboxMocks } from "./helpers/clawbox";
 import { mockTerminalWebSocket } from "./helpers/mock-backends";
 
-// FIXME (#114): surfaced what looks like a real production-build bug, not a test
-// issue. `handleDesktopContextMenu` DOES fire on the production build (verified
-// with a temporary log — "CTXFIRE 40 40") and calls setCtxMenu({x,y}), but the
-// menu never renders — `getByTestId('desktop-context-menu')` stays absent even
-// 50ms after, via every input path (real right-click, page.mouse, dispatchEvent,
-// and a raw MouseEvent). So the desktop right-click menu appears broken under
-// the standalone production build. Needs an app-side investigation before this
-// spec can be re-enabled. The terminal WS mock + surface targeting below are
-// correct groundwork.
-test.fixme("desktop background context menu can launch the terminal", async ({ page }) => {
+test("desktop background context menu can launch the terminal", async ({ page }) => {
   // The terminal app connects to /terminal-ws, which only production-server.js
-  // proxies — not the standalone e2e server or a CI runner. Fake the handshake
-  // in-browser (same as terminal-reconnect) so the window mounts and stays up.
+  // proxies — not the standalone e2e server. Fake the handshake in-browser so
+  // the launched terminal window mounts and stays up.
   await mockTerminalWebSocket(page);
 
   await installClawboxMocks(page, {
@@ -26,29 +17,24 @@ test.fixme("desktop background context menu can launch the terminal", async ({ p
       ai_model_configured: true,
       telegram_configured: true,
     },
-    preferences: {
-      ui_mascot_hidden: 0,
-    },
   });
 
   await page.goto("/");
   await expect(page.getByTestId("desktop-root")).toBeVisible();
 
-  // Dispatch the contextmenu straight to the desktop surface (the grid layer
-  // that owns handleDesktopContextMenu). A positional right-click hit-tests to
-  // whatever is topmost at that pixel — which on the production build isn't this
-  // layer — so target the element directly with an empty-area coordinate.
+  // Dispatch the contextmenu straight to the desktop surface — the grid layer
+  // that owns handleDesktopContextMenu. A positional right-click hit-tests to
+  // whatever overlay is topmost at that pixel, which isn't this layer.
   await page.getByTestId("desktop-surface").dispatchEvent("contextmenu", {
     button: 2,
-    clientX: 40,
-    clientY: 40,
+    clientX: 200,
+    clientY: 400,
     bubbles: true,
   });
 
-  // Scope to the context menu: "Terminal" also appears as a shelf/taskbar
-  // control, so an unscoped getByRole matches two elements (strict-mode).
-  const contextMenu = page.getByTestId("desktop-context-menu");
-  await expect(contextMenu).toBeVisible();
-  await contextMenu.getByRole("button", { name: "Terminal" }).click();
+  // Scope "Terminal" to the context menu — it also appears as a shelf control.
+  const menu = page.getByTestId("desktop-context-menu");
+  await expect(menu).toBeVisible();
+  await menu.getByRole("button", { name: "Terminal" }).click();
   await expect(page.getByTestId("chrome-window-terminal")).toBeVisible();
 });


### PR DESCRIPTION
Re-enables the final #114 spec. The desktop context menu was never broken — **#323 was a false alarm** from testing against a stale build that lacked the `desktop-context-menu` testid. On a clean production build the menu renders and works.

Fix:
- dispatch the `contextmenu` to the `desktop-surface` layer (a positional right-click hit-tests to an overlay on top, not the grid handler that opens the menu),
- scope `Terminal` to the context menu,
- mock the terminal WebSocket so the launched window mounts.

**Validated 3× on a Jetson prod build.** With this, all six #114 specs pass; only `clawkeep-flow` (a separate ClawKeep-redesign gap) stays `fixme`d.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Re-enabled end-to-end testing for opening a terminal from the desktop context menu.
  * Updated test interaction handling and mocked the connection handshake to keep the terminal window available during verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->