### PR TITLE
Stop advertising tunnel hostnames that no longer exist

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,51 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main, beta]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly full scan (Mondays 02:30 UTC) to catch advisories in code that
+    # hasn't changed since the last push.
+    - cron: "30 2 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # Required to upload results to the code-scanning dashboard.
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # JS + TS share one analysis; build-mode "none" needs no compile step.
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # security-extended adds higher-signal security queries on top of the
+          # default set without the noisier code-quality suite.
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/src/app/setup-api/portal/heartbeat-tick/route.ts
+++ b/src/app/setup-api/portal/heartbeat-tick/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 
-import { readTunnelUrl } from "@/lib/cloudflared";
+import { readTunnelUrl, startTunnelService } from "@/lib/cloudflared";
 import { pushHeartbeatTick } from "@/lib/portal-heartbeat";
+import { checkTunnelLiveness, markRestarted, mayRestart } from "@/lib/tunnel-liveness";
 
 export const dynamic = "force-dynamic";
 
@@ -13,19 +14,56 @@ export const dynamic = "force-dynamic";
 // to Offline 10 minutes after the last cloudflared URL rotation even
 // when they're up.
 //
-// We expose this as a *separate* route from /portal/status because the
+// Since 2026-08-09 the tick also refuses to advertise a hostname that no
+// longer resolves. Cloudflare reaps quick tunnels server-side; when that
+// happens with cloudflared still running, tunnel.url keeps a corpse and the
+// box reported it every five minutes forever, so the portal showed a green
+// Online next to a link that could not work. On the live fleet that was 5 of
+// 30 devices, and two days later 4 of 30 — the only recovery in between was a
+// box someone fixed by hand after its owner complained.
+//
+// We exposed this as a *separate* route from /portal/status because the
 // status endpoint does extra work (cloudflared install probe, systemd
 // state read) that the timer doesn't need on every tick. Keeping the
 // surfaces distinct also means a future addition to /portal/status
 // can't accidentally widen the timer's blast radius.
 //
-// Always returns 200 + `{ ok: true }`. The tick helper is fire-and-
-// forget: it no-ops on missing token, missing tunnel URL, or network
-// failure — surfacing a 500 here would just make the systemd unit
-// flap, which the timer's SuccessExitStatus already tolerates.
+// Always returns 200. The tick helper is fire-and-forget: it no-ops on
+// missing token, missing tunnel URL, or network failure — surfacing a 500
+// here would just make the systemd unit flap, which the timer's
+// SuccessExitStatus already tolerates. The restart is best-effort for the
+// same reason.
 export async function GET() {
-  pushHeartbeatTick(await readTunnelUrl());
-  return NextResponse.json({ ok: true }, {
-    headers: { "Cache-Control": "no-store" },
-  });
+  const tunnelUrl = await readTunnelUrl();
+  const liveness = await checkTunnelLiveness(tunnelUrl);
+
+  if (liveness === "dead") {
+    // Do not push. Reporting a hostname we have just proven does not exist is
+    // the whole bug. Restart instead: run-tunnel.sh clears the file and
+    // captures a fresh URL, which the next tick will pick up and push.
+    let restarted = false;
+    if (mayRestart()) {
+      try {
+        await startTunnelService();
+        markRestarted();
+        restarted = true;
+        console.warn(`[heartbeat-tick] tunnel hostname dead, restarted clawbox-tunnel (was ${tunnelUrl})`);
+      } catch (err) {
+        console.warn("[heartbeat-tick] tunnel restart failed:", err instanceof Error ? err.message : err);
+      }
+    }
+    return NextResponse.json(
+      { ok: true, tunnel: "dead", restarted },
+      { headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  // "unknown" means our own DNS is down, not that the tunnel is. Pushing the
+  // last known URL keeps the device visibly Online through a network blip,
+  // which is the behaviour it always had.
+  pushHeartbeatTick(tunnelUrl);
+  return NextResponse.json(
+    { ok: true, tunnel: liveness },
+    { headers: { "Cache-Control": "no-store" } },
+  );
 }

--- a/src/lib/tunnel-liveness.ts
+++ b/src/lib/tunnel-liveness.ts
@@ -29,8 +29,13 @@ import { promises as dns } from "dns";
  */
 const DNS_CONTROL_HOST = "cloudflare.com";
 
-/** Long enough for a slow uplink, short enough not to stall the tick. */
-const LOOKUP_TIMEOUT_MS = 5_000;
+/**
+ * Long enough for a slow uplink, short enough not to stall the tick. Kept tight
+ * because the tunnel host is now retried once and the control host checked on
+ * failure, so the worst case is 3 lookups — 3 × 2.5s = 7.5s, still under the
+ * heartbeat unit's budget.
+ */
+const LOOKUP_TIMEOUT_MS = 2_500;
 
 /**
  * A restart mints a new hostname, and the portal only learns it on the next
@@ -48,10 +53,13 @@ export type LivenessVerdict =
   | "unknown";
 
 function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
-  return Promise.race([
-    p,
-    new Promise<T>((_, reject) => setTimeout(() => reject(new Error("timeout")), ms)),
-  ]);
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timeout")), ms);
+  });
+  // clear the timer whichever side wins, so the fast path doesn't park a live
+  // reject timer for the full timeout on every lookup.
+  return Promise.race([p, timeout]).finally(() => clearTimeout(timer));
 }
 
 export function hostnameOf(tunnelUrl: string): string | null {
@@ -62,13 +70,16 @@ export function hostnameOf(tunnelUrl: string): string | null {
   }
 }
 
-async function resolves(hostname: string): Promise<boolean> {
-  try {
-    const records = await withTimeout(dns.resolve4(hostname), LOOKUP_TIMEOUT_MS);
-    return records.length > 0;
-  } catch {
-    return false;
+async function resolves(hostname: string, attempts = 1): Promise<boolean> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const records = await withTimeout(dns.resolve4(hostname), LOOKUP_TIMEOUT_MS);
+      if (records.length > 0) return true;
+    } catch {
+      // transient failure (SERVFAIL / EAI_AGAIN / timeout) — retry if any left
+    }
   }
+  return false;
 }
 
 /**
@@ -80,9 +91,12 @@ export async function checkTunnelLiveness(tunnelUrl: string | null): Promise<Liv
   const hostname = hostnameOf(tunnelUrl);
   if (!hostname) return "unknown";
 
-  if (await resolves(hostname)) return "alive";
+  // Retry the tunnel host before condemning it: a single transient failure
+  // must not restart a working tunnel and rotate its public URL (every
+  // bookmark/QR/shared link would break). Two agreeing failures is the bar.
+  if (await resolves(hostname, 2)) return "alive";
 
-  // It did not resolve. Before calling it dead, prove that anything resolves.
+  // It failed twice. Before calling it dead, prove that anything resolves.
   if (await resolves(DNS_CONTROL_HOST)) return "dead";
   return "unknown";
 }

--- a/src/lib/tunnel-liveness.ts
+++ b/src/lib/tunnel-liveness.ts
@@ -1,0 +1,104 @@
+/**
+ * Is the tunnel hostname we are about to advertise still real?
+ *
+ * Cloudflare quick tunnels are ephemeral and get reaped server-side. When that
+ * happens while cloudflared is still running, `tunnel.url` keeps a hostname
+ * that no longer resolves and the box reports it to the portal every five
+ * minutes, forever. The portal derives Online from the last heartbeat, which
+ * describes the BOX, so it shows a green dot next to a link that gives
+ * DNS_PROBE_FINISHED_NXDOMAIN.
+ *
+ * Measured on the live fleet on 2026-08-07: 5 of 30 online devices, 17%.
+ * Re-measured on 2026-08-09: 4 of 30, and the only one that recovered was the
+ * box whose owner opened a ticket. Nothing self-heals.
+ *
+ * So: resolve before reporting. A hostname that does not resolve is not
+ * reported and the tunnel is restarted instead, which mints a fresh one.
+ */
+
+import { promises as dns } from "dns";
+
+/**
+ * Resolved when the device's own DNS works at all.
+ *
+ * Without this check a box with no network would find every hostname dead and
+ * restart the tunnel on every tick, which is a worse failure than the one being
+ * fixed. Cloudflare's own domain is the control: if that does not resolve
+ * either, the problem is on this side of the wire and the right move is to do
+ * nothing and try again in five minutes.
+ */
+const DNS_CONTROL_HOST = "cloudflare.com";
+
+/** Long enough for a slow uplink, short enough not to stall the tick. */
+const LOOKUP_TIMEOUT_MS = 5_000;
+
+/**
+ * A restart mints a new hostname, and the portal only learns it on the next
+ * tick. Restarting faster than that would churn the tunnel without giving the
+ * new URL a chance to be captured and pushed.
+ */
+export const RESTART_COOLDOWN_MS = 15 * 60 * 1000;
+
+export type LivenessVerdict =
+  /** The hostname resolves. Report it. */
+  | "alive"
+  /** The hostname does not resolve, but ours does. Restart the tunnel. */
+  | "dead"
+  /** Our own DNS is down. Report nothing, change nothing, try later. */
+  | "unknown";
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_, reject) => setTimeout(() => reject(new Error("timeout")), ms)),
+  ]);
+}
+
+export function hostnameOf(tunnelUrl: string): string | null {
+  try {
+    return new URL(tunnelUrl).hostname || null;
+  } catch {
+    return null;
+  }
+}
+
+async function resolves(hostname: string): Promise<boolean> {
+  try {
+    const records = await withTimeout(dns.resolve4(hostname), LOOKUP_TIMEOUT_MS);
+    return records.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Three-way on purpose. "Cannot tell" has to be distinguishable from "dead",
+ * because the two call for opposite actions.
+ */
+export async function checkTunnelLiveness(tunnelUrl: string | null): Promise<LivenessVerdict> {
+  if (!tunnelUrl) return "unknown";
+  const hostname = hostnameOf(tunnelUrl);
+  if (!hostname) return "unknown";
+
+  if (await resolves(hostname)) return "alive";
+
+  // It did not resolve. Before calling it dead, prove that anything resolves.
+  if (await resolves(DNS_CONTROL_HOST)) return "dead";
+  return "unknown";
+}
+
+/** Module-level, so the cooldown survives across ticks within one server process. */
+let lastRestartAt = 0;
+
+export function mayRestart(now = Date.now()): boolean {
+  return now - lastRestartAt >= RESTART_COOLDOWN_MS;
+}
+
+export function markRestarted(now = Date.now()): void {
+  lastRestartAt = now;
+}
+
+/** Test seam. */
+export function resetRestartCooldown(): void {
+  lastRestartAt = 0;
+}

--- a/src/tests/routes/heartbeat-tick.test.ts
+++ b/src/tests/routes/heartbeat-tick.test.ts
@@ -54,7 +54,7 @@ describe("a live tunnel", () => {
 
 describe("a dead tunnel", () => {
   beforeEach(() => {
-    cloudflared.readTunnelUrl.mockResolvedValue("https://heel-executed-worm-hay.trycloudflare.com");
+    cloudflared.readTunnelUrl.mockResolvedValue("https://dead-tunnel-example.trycloudflare.com");
     liveness.checkTunnelLiveness.mockResolvedValue("dead");
   });
 

--- a/src/tests/routes/heartbeat-tick.test.ts
+++ b/src/tests/routes/heartbeat-tick.test.ts
@@ -1,0 +1,114 @@
+/**
+ * What the five-minute tick does with a hostname that has stopped existing.
+ *
+ * Before this, it pushed whatever was in tunnel.url. Cloudflare reaps quick
+ * tunnels, cloudflared keeps running, the file keeps a corpse, and the portal
+ * showed a green Online next to a dead link on 5 of 30 live devices.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const cloudflared = {
+  readTunnelUrl: vi.fn(),
+  startTunnelService: vi.fn(),
+};
+const heartbeat = { pushHeartbeatTick: vi.fn() };
+const liveness = {
+  checkTunnelLiveness: vi.fn(),
+  mayRestart: vi.fn(),
+  markRestarted: vi.fn(),
+};
+
+vi.mock("@/lib/cloudflared", () => cloudflared);
+vi.mock("@/lib/portal-heartbeat", () => heartbeat);
+vi.mock("@/lib/tunnel-liveness", () => liveness);
+
+async function tick() {
+  const mod = await import("@/app/setup-api/portal/heartbeat-tick/route");
+  return mod.GET();
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  liveness.mayRestart.mockReturnValue(true);
+  cloudflared.startTunnelService.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  for (const fn of [...Object.values(cloudflared), ...Object.values(heartbeat), ...Object.values(liveness)]) {
+    fn.mockReset();
+  }
+});
+
+describe("a live tunnel", () => {
+  it("is reported, as before", async () => {
+    cloudflared.readTunnelUrl.mockResolvedValue("https://alive.trycloudflare.com");
+    liveness.checkTunnelLiveness.mockResolvedValue("alive");
+
+    const res = await tick();
+    expect(res.status).toBe(200);
+    expect(heartbeat.pushHeartbeatTick).toHaveBeenCalledWith("https://alive.trycloudflare.com");
+    expect(cloudflared.startTunnelService).not.toHaveBeenCalled();
+  });
+});
+
+describe("a dead tunnel", () => {
+  beforeEach(() => {
+    cloudflared.readTunnelUrl.mockResolvedValue("https://heel-executed-worm-hay.trycloudflare.com");
+    liveness.checkTunnelLiveness.mockResolvedValue("dead");
+  });
+
+  it("is never reported", async () => {
+    // The whole bug in one assertion.
+    await tick();
+    expect(heartbeat.pushHeartbeatTick).not.toHaveBeenCalled();
+  });
+
+  it("restarts the tunnel so a fresh hostname is minted", async () => {
+    await tick();
+    expect(cloudflared.startTunnelService).toHaveBeenCalledTimes(1);
+    expect(liveness.markRestarted).toHaveBeenCalled();
+  });
+
+  it("says what it did, so the timer's log is diagnosable", async () => {
+    const res = await tick();
+    expect(await res.json()).toEqual({ ok: true, tunnel: "dead", restarted: true });
+  });
+
+  it("respects the cooldown rather than restarting every five minutes", async () => {
+    liveness.mayRestart.mockReturnValue(false);
+    const res = await tick();
+    expect(cloudflared.startTunnelService).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual({ ok: true, tunnel: "dead", restarted: false });
+  });
+
+  it("still answers 200 when the restart itself fails", async () => {
+    // A 500 here would make the systemd unit flap.
+    cloudflared.startTunnelService.mockRejectedValue(new Error("sudo: no tty"));
+    const res = await tick();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, tunnel: "dead", restarted: false });
+  });
+});
+
+describe("when the box cannot tell", () => {
+  it("keeps reporting, because the fault is probably our own network", async () => {
+    // Dropped uplink. Going quiet here would mark a healthy box Offline, and
+    // restarting its tunnel would fix nothing.
+    cloudflared.readTunnelUrl.mockResolvedValue("https://maybe.trycloudflare.com");
+    liveness.checkTunnelLiveness.mockResolvedValue("unknown");
+
+    await tick();
+    expect(heartbeat.pushHeartbeatTick).toHaveBeenCalledWith("https://maybe.trycloudflare.com");
+    expect(cloudflared.startTunnelService).not.toHaveBeenCalled();
+  });
+
+  it("passes a missing url straight through, as it always did", async () => {
+    cloudflared.readTunnelUrl.mockResolvedValue(null);
+    liveness.checkTunnelLiveness.mockResolvedValue("unknown");
+
+    const res = await tick();
+    expect(res.status).toBe(200);
+    expect(heartbeat.pushHeartbeatTick).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/tests/unit/tunnel-liveness.test.ts
+++ b/src/tests/unit/tunnel-liveness.test.ts
@@ -48,6 +48,21 @@ describe("checkTunnelLiveness", () => {
     expect(await mod.checkTunnelLiveness("https://dead-tunnel-example.trycloudflare.com")).toBe("dead");
   });
 
+  it("retries a transient tunnel-host failure instead of condemning a healthy tunnel", async () => {
+    // First lookup blips (SERVFAIL), second succeeds. A single transient
+    // failure must not restart a working tunnel and rotate its public URL.
+    let tunnelAttempts = 0;
+    resolve4.mockImplementation((host: string) => {
+      if (host === "cloudflare.com") return Promise.resolve(["104.16.0.1"]);
+      tunnelAttempts += 1;
+      return tunnelAttempts === 1
+        ? Promise.reject(new Error("SERVFAIL"))
+        : Promise.resolve(["104.16.0.1"]);
+    });
+    expect(await mod.checkTunnelLiveness("https://example-tunnel-host.trycloudflare.com")).toBe("alive");
+    expect(tunnelAttempts).toBe(2);
+  });
+
   it("says unknown when nothing resolves, because then the fault is ours", async () => {
     // A box on a dropped uplink. Restarting the tunnel here would churn it
     // every five minutes and fix nothing.

--- a/src/tests/unit/tunnel-liveness.test.ts
+++ b/src/tests/unit/tunnel-liveness.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The box must not advertise a hostname that no longer exists.
+ *
+ * Cloudflare reaps quick tunnels server-side. With cloudflared still running,
+ * tunnel.url keeps the dead hostname and the heartbeat reported it every five
+ * minutes, so the portal showed Online next to a link that gave
+ * DNS_PROBE_FINISHED_NXDOMAIN. On the live fleet: 5 of 30 devices on
+ * 2026-08-07, 4 of 30 on 2026-08-09, and the only one that recovered in
+ * between was fixed by hand after its owner complained.
+ *
+ * The distinction these tests exist to protect is "dead" versus "cannot tell".
+ * A box with no network sees every hostname as unresolvable, and treating that
+ * as dead would restart the tunnel on every tick — a worse fault than the one
+ * being fixed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolve4 = vi.fn();
+
+vi.mock("dns", () => ({
+  promises: { resolve4: (...args: unknown[]) => resolve4(...args) },
+}));
+
+let mod: typeof import("@/lib/tunnel-liveness");
+
+beforeEach(async () => {
+  vi.resetModules();
+  resolve4.mockReset();
+  mod = await import("@/lib/tunnel-liveness");
+  mod.resetRestartCooldown();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("checkTunnelLiveness", () => {
+  it("calls a resolving hostname alive", async () => {
+    resolve4.mockResolvedValue(["104.16.0.1"]);
+    expect(await mod.checkTunnelLiveness("https://spies-hardwood-mens-roughly.trycloudflare.com")).toBe("alive");
+  });
+
+  it("calls it dead when it does not resolve but our DNS does", async () => {
+    resolve4.mockImplementation((host: string) =>
+      host === "cloudflare.com" ? Promise.resolve(["104.16.0.1"]) : Promise.reject(new Error("ENOTFOUND")),
+    );
+    expect(await mod.checkTunnelLiveness("https://heel-executed-worm-hay.trycloudflare.com")).toBe("dead");
+  });
+
+  it("says unknown when nothing resolves, because then the fault is ours", async () => {
+    // A box on a dropped uplink. Restarting the tunnel here would churn it
+    // every five minutes and fix nothing.
+    resolve4.mockRejectedValue(new Error("EAI_AGAIN"));
+    expect(await mod.checkTunnelLiveness("https://heel-executed-worm-hay.trycloudflare.com")).toBe("unknown");
+  });
+
+  it("checks the control host only after the tunnel fails, not on every tick", async () => {
+    resolve4.mockResolvedValue(["104.16.0.1"]);
+    await mod.checkTunnelLiveness("https://alive.trycloudflare.com");
+    expect(resolve4).toHaveBeenCalledTimes(1);
+    expect(resolve4).toHaveBeenCalledWith("alive.trycloudflare.com");
+  });
+
+  it("treats an empty resolve as unresolved", async () => {
+    // Some resolvers answer NOERROR with no A records.
+    resolve4.mockImplementation((host: string) =>
+      host === "cloudflare.com" ? Promise.resolve(["104.16.0.1"]) : Promise.resolve([]),
+    );
+    expect(await mod.checkTunnelLiveness("https://empty.trycloudflare.com")).toBe("dead");
+  });
+
+  it("says unknown for a missing or unparseable url rather than restarting", async () => {
+    for (const url of [null, "", "not-a-url", "   "]) {
+      expect(await mod.checkTunnelLiveness(url as string | null)).toBe("unknown");
+    }
+    expect(resolve4).not.toHaveBeenCalled();
+  });
+
+  it("does not hang the tick when DNS never answers", async () => {
+    // The timer fires every five minutes; a lookup that never settles would
+    // hold the route open indefinitely.
+    resolve4.mockImplementation(() => new Promise(() => {}));
+    const verdict = await mod.checkTunnelLiveness("https://slow.trycloudflare.com");
+    expect(verdict).toBe("unknown");
+  }, 20_000);
+});
+
+describe("the restart cooldown", () => {
+  it("allows the first restart", () => {
+    expect(mod.mayRestart()).toBe(true);
+  });
+
+  it("blocks a second restart inside the window", () => {
+    const t0 = 1_000_000;
+    mod.markRestarted(t0);
+    expect(mod.mayRestart(t0 + 60_000)).toBe(false);
+  });
+
+  it("allows one again after the window", () => {
+    // A restart mints a new hostname that only reaches the portal on the next
+    // tick. The window has to outlast that round trip.
+    const t0 = 1_000_000;
+    mod.markRestarted(t0);
+    expect(mod.mayRestart(t0 + mod.RESTART_COOLDOWN_MS)).toBe(true);
+  });
+
+  it("is longer than the five-minute tick, or restarts would stack", () => {
+    expect(mod.RESTART_COOLDOWN_MS).toBeGreaterThan(5 * 60 * 1000);
+  });
+});
+
+describe("hostnameOf", () => {
+  it("pulls the host out of a tunnel url", () => {
+    expect(mod.hostnameOf("https://course-leg-correction-being.trycloudflare.com")).toBe(
+      "course-leg-correction-being.trycloudflare.com",
+    );
+  });
+
+  it("returns null rather than throwing on junk", () => {
+    expect(mod.hostnameOf("nonsense")).toBeNull();
+  });
+});

--- a/src/tests/unit/tunnel-liveness.test.ts
+++ b/src/tests/unit/tunnel-liveness.test.ts
@@ -38,21 +38,21 @@ afterEach(() => {
 describe("checkTunnelLiveness", () => {
   it("calls a resolving hostname alive", async () => {
     resolve4.mockResolvedValue(["104.16.0.1"]);
-    expect(await mod.checkTunnelLiveness("https://spies-hardwood-mens-roughly.trycloudflare.com")).toBe("alive");
+    expect(await mod.checkTunnelLiveness("https://example-tunnel-host.trycloudflare.com")).toBe("alive");
   });
 
   it("calls it dead when it does not resolve but our DNS does", async () => {
     resolve4.mockImplementation((host: string) =>
       host === "cloudflare.com" ? Promise.resolve(["104.16.0.1"]) : Promise.reject(new Error("ENOTFOUND")),
     );
-    expect(await mod.checkTunnelLiveness("https://heel-executed-worm-hay.trycloudflare.com")).toBe("dead");
+    expect(await mod.checkTunnelLiveness("https://dead-tunnel-example.trycloudflare.com")).toBe("dead");
   });
 
   it("says unknown when nothing resolves, because then the fault is ours", async () => {
     // A box on a dropped uplink. Restarting the tunnel here would churn it
     // every five minutes and fix nothing.
     resolve4.mockRejectedValue(new Error("EAI_AGAIN"));
-    expect(await mod.checkTunnelLiveness("https://heel-executed-worm-hay.trycloudflare.com")).toBe("unknown");
+    expect(await mod.checkTunnelLiveness("https://dead-tunnel-example.trycloudflare.com")).toBe("unknown");
   });
 
   it("checks the control host only after the tunnel fails, not on every tick", async () => {
@@ -112,8 +112,8 @@ describe("the restart cooldown", () => {
 
 describe("hostnameOf", () => {
   it("pulls the host out of a tunnel url", () => {
-    expect(mod.hostnameOf("https://course-leg-correction-being.trycloudflare.com")).toBe(
-      "course-leg-correction-being.trycloudflare.com",
+    expect(mod.hostnameOf("https://sample-tunnel-host.trycloudflare.com")).toBe(
+      "sample-tunnel-host.trycloudflare.com",
     );
   });
 


### PR DESCRIPTION
TASK-336. The portal shows a green Online next to a Remote Access link that gives `DNS_PROBE_FINISHED_NXDOMAIN`.

## Where the problem actually is

Cloudflare reaps quick tunnels server-side. When that happens with cloudflared still running, `data/cloudflared/tunnel.url` keeps the reaped hostname, and `GET /setup-api/portal/heartbeat-tick` pushes whatever is in that file every five minutes. Nothing ever checked that the hostname still resolves.

The portal is not lying either: it derives Online from `lastSeenAt`, which describes the **box**. The box really is alive. Only the tunnel is gone. So the two halves are each correct and the pair is misleading.

## What it costs, measured twice

| | devices | online | dead hostname |
|---|---|---|---|
| 2026-08-07 | 70 | 30 | 5 (17%) |
| 2026-08-09 | 70 | 30 | 4 (13%) |

The single recovery in between was ClawBox-Rin, the box whose owner opened a ticket, fixed by hand. Nothing self-heals. The four still dead tonight belong to paying customers who have not complained, one of them registered on 4 May.

## The fix

The tick resolves the hostname before reporting it. Dead is not reported, and `clawbox-tunnel` is restarted instead: `run-tunnel.sh` clears the file and captures a fresh URL, which the next tick pushes.

The verdict is three-way on purpose:

- **alive** — report it, as before
- **dead** — the hostname failed *and* `cloudflare.com` resolved from the same box, so the fault is upstream. Do not report, restart.
- **unknown** — nothing resolves, so the box's own uplink is down. Report the last known URL exactly as before and change nothing.

Collapsing the last two would be worse than the bug: a box on a dropped uplink would restart its tunnel every five minutes and fix nothing.

Restarts sit behind a 15-minute cooldown, longer than the tick, because a restart mints a hostname the portal only learns on the *next* tick.

## Verified against reality, not mocks

```
our DNS works     : true
this box's tunnel : ALIVE   [redacted-tunnel-hostname]
fleet hostname    : DEAD    [redacted-tunnel-hostname]    (redacted)
fleet hostname    : DEAD    [redacted-tunnel-hostname]           (redacted)
fleet hostname    : DEAD    [redacted-tunnel-hostname] (redacted)
fleet hostname    : DEAD    [redacted-tunnel-hostname]      (redacted)
```

The restart path matches an existing `NOPASSWD` line in `config/clawbox-sudoers`. I checked because a first attempt on a non-ClawBox host hit a password prompt, which would have been a silent no-op had it been real.

21 new tests, 1638 pass.

## Not in this PR

The portal side still presents `tunnelUrl` as usable without a liveness check. Once boxes update, the population shrinks to zero on its own, but a box that never updates keeps handing out a corpse. Worth a follow-up.

The four customers above need their tunnels restarted by hand or a proactive email; they will not get this fix until they update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tunnel health checks to heartbeat updates.
  * Prevented publishing URLs for confirmed dead tunnels.
  * Added automatic tunnel-service restarts with cooldown protection.
  * Added clear reporting for live, dead, unknown, and missing tunnel states.

* **Bug Fixes**
  * Preserved successful heartbeat responses even when tunnel checks or restarts fail.

* **Tests**
  * Added coverage for tunnel health detection, DNS failures, restart behavior, cooldowns, and heartbeat responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
