### PR TITLE
ci(codeql): also scan PRs targeting beta

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, beta]
   pull_request:
-    branches: [main]
+    branches: [main, beta]
   schedule:
     # Weekly full scan (Mondays 02:30 UTC) to catch advisories in code that
     # hasn't changed since the last push.


### PR DESCRIPTION
The `pull_request` trigger was scoped to `[main]`, but the team opens PRs against `beta` — so CodeQL silently skipped every real PR (the 3s no-op 'pass' on #326 proved it). Adds `beta` to the trigger so the PR-review security gate actually runs. Surfaced by `/code-review` on #326.