### PR TITLE
feat(hermes): dual-harness — run the ClawBox agent on OpenClaw or Hermes

### DIFF
--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -38,10 +38,13 @@ if [ -d "$OC_WS" ]; then
 fi
 
 # 2. Hermes ← canonical (symlinks already live) → reindex FTS5.
-if command -v hermes >/dev/null 2>&1; then
-  # `hermes memory reindex` rebuilds the recall index from the markdown; fall
-  # back to `sync` on older builds. Non-fatal if neither exists.
-  hermes memory reindex >/dev/null 2>&1 || hermes sync >/dev/null 2>&1 || true
+# Prefer the configured Hermes CLI (HERMES_BIN, matching src/lib/harness.ts's
+# default), falling back to PATH. `hermes memory reindex` rebuilds the recall
+# index from the markdown; fall back to `sync` on older builds. Non-fatal.
+HERMES="${HERMES_BIN:-$HOME_DIR/.local/bin/hermes}"
+[ -x "$HERMES" ] || HERMES="$(command -v hermes || true)"
+if [ -n "$HERMES" ] && [ -x "$HERMES" ]; then
+  "$HERMES" memory reindex >/dev/null 2>&1 || "$HERMES" sync >/dev/null 2>&1 || true
 fi
 
 echo "[identity-sync] done"

--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Propagate the canonical shared identity to both harnesses. Run on
+# harness-switch and whenever ~/.clawbox/agent-identity/* changes (a systemd
+# path unit or the harness/select route can invoke it).
+#
+#   * OpenClaw: refresh the REAL copies (its scanner ignores symlinks) and
+#     restart the gateway so the workspace-file scan re-reads the new content
+#     (OpenClaw caches injected file content at gateway start).
+#   * Hermes: its identity files are symlinks (already live), but its state.db
+#     FTS5 recall must re-index to see external markdown edits.
+#
+# Canonical is authoritative (edit there). Edits made from inside a harness are
+# NOT auto-propagated back in this version — that reverse sync is future work.
+set -euo pipefail
+
+HOME_DIR="${HOME:-/home/clawbox}"
+CANON="$HOME_DIR/.clawbox/agent-identity"
+OC_WS="$HOME_DIR/.openclaw/workspace"
+
+[ -d "$CANON" ] || { echo "[identity-sync] no canonical dir; run setup-shared-identity.sh first" >&2; exit 1; }
+
+# 1. OpenClaw ← canonical (real copies).
+if [ -d "$OC_WS" ]; then
+  for f in SOUL USER MEMORY; do
+    [ -f "$CANON/$f.md" ] && cp "$CANON/$f.md" "$OC_WS/$f.md"
+  done
+  # Refresh the gateway's cached workspace-file scan (best-effort).
+  sudo -n /usr/bin/systemctl restart clawbox-gateway.service 2>/dev/null || \
+    systemctl --user restart clawbox-gateway 2>/dev/null || true
+fi
+
+# 2. Hermes ← canonical (symlinks already live) → reindex FTS5.
+if command -v hermes >/dev/null 2>&1; then
+  # `hermes memory reindex` rebuilds the recall index from the markdown; fall
+  # back to `sync` on older builds. Non-fatal if neither exists.
+  hermes memory reindex >/dev/null 2>&1 || hermes sync >/dev/null 2>&1 || true
+fi
+
+echo "[identity-sync] done"

--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -17,7 +17,15 @@ HOME_DIR="${HOME:-/home/clawbox}"
 CANON="$HOME_DIR/.clawbox/agent-identity"
 OC_WS="$HOME_DIR/.openclaw/workspace"
 
-[ -d "$CANON" ] || { echo "[identity-sync] no canonical dir; run setup-shared-identity.sh first" >&2; exit 1; }
+# Self-heal: if the shared-identity bridge was never established (e.g. the very
+# first harness switch on a device), bootstrap it now so the sync has a source.
+if [ ! -d "$CANON" ]; then
+  echo "[identity-sync] canonical dir missing — bootstrapping via setup-shared-identity.sh"
+  bash "$(dirname "$0")/setup-shared-identity.sh" || {
+    echo "[identity-sync] bootstrap failed; nothing to sync" >&2
+    exit 1
+  }
+fi
 
 # 1. OpenClaw ← canonical (real copies).
 if [ -d "$OC_WS" ]; then

--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -44,7 +44,11 @@ fi
 HERMES="${HERMES_BIN:-$HOME_DIR/.local/bin/hermes}"
 [ -x "$HERMES" ] || HERMES="$(command -v hermes || true)"
 if [ -n "$HERMES" ] && [ -x "$HERMES" ]; then
-  "$HERMES" memory reindex >/dev/null 2>&1 || "$HERMES" sync >/dev/null 2>&1 || true
+  # Surface a reindex failure to the caller (the select route reports it) rather
+  # than swallowing it: a stale FTS5 index means Hermes won't see refreshed
+  # memory. `set -e` propagates a non-zero exit if BOTH reindex and the sync
+  # fallback fail.
+  "$HERMES" memory reindex >/dev/null 2>&1 || "$HERMES" sync >/dev/null 2>&1
 fi
 
 echo "[identity-sync] done"

--- a/scripts/setup-shared-identity.sh
+++ b/scripts/setup-shared-identity.sh
@@ -41,10 +41,23 @@ if [ -d "$OC_WS" ]; then
   done
 fi
 
+# Move a real (non-symlink) file out of the way before symlinking, without ever
+# clobbering an earlier backup — so repeated migrations never destroy previously
+# preserved Hermes identity data.
+backup_if_real() {
+  local f="$1"
+  [ -e "$f" ] && [ ! -L "$f" ] || return 0
+  local bak="$f.pre-bridge"
+  [ -e "$bak" ] && bak="$f.pre-bridge.$(date +%s.%N)"
+  mv "$f" "$bak"
+}
+
 # 3. Hermes side — symlinks (Hermes follows them; keeps the markdown live).
 if [ -d "$HM_DIR" ]; then
   mkdir -p "$HM_DIR/memories"
-  [ -e "$HM_DIR/SOUL.md" ] && [ ! -L "$HM_DIR/SOUL.md" ] && mv "$HM_DIR/SOUL.md" "$HM_DIR/SOUL.md.pre-bridge"
+  backup_if_real "$HM_DIR/SOUL.md"
+  backup_if_real "$HM_DIR/memories/MEMORY.md"
+  backup_if_real "$HM_DIR/memories/USER.md"
   ln -sfn "$CANON/SOUL.md" "$HM_DIR/SOUL.md"
   ln -sfn "$CANON/MEMORY.md" "$HM_DIR/memories/MEMORY.md"
   ln -sfn "$CANON/USER.md" "$HM_DIR/memories/USER.md"

--- a/scripts/setup-shared-identity.sh
+++ b/scripts/setup-shared-identity.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Set up the canonical shared agent identity used by BOTH harnesses
+# (OpenClaw + Hermes), so ClawBox presents one agent — one SOUL/USER — no
+# matter which harness the user has selected.
+#
+# Design (validated on-device 2026-08-09):
+#   * Canonical source of truth: ~/.clawbox/agent-identity/{SOUL,USER,MEMORY}.md
+#   * Hermes FOLLOWS symlinks → link its identity files to canonical (live).
+#   * OpenClaw's workspace scanner does NOT follow symlinks (a symlinked file
+#     reads as "missing" and is not injected) → give it REAL copies, refreshed
+#     by clawbox-identity-sync.sh on harness-switch / on canonical change.
+#   * MEMORY.md is read by Hermes; OpenClaw keeps its own memory store, so
+#     cross-harness MEMORY needs an export/import sync (see the sync script) —
+#     identity (SOUL/USER) is the reliably-shared channel.
+#
+# Idempotent. Providers/OAuth are intentionally NOT shared (each harness
+# authenticates independently — OpenClaw warns against a shared OAuth grant).
+set -euo pipefail
+
+HOME_DIR="${HOME:-/home/clawbox}"
+CANON="$HOME_DIR/.clawbox/agent-identity"
+OC_WS="$HOME_DIR/.openclaw/workspace"
+HM_DIR="$HOME_DIR/.hermes"
+
+mkdir -p "$CANON"
+
+# 1. Seed canonical from OpenClaw's established identity (only if not present).
+[ -f "$CANON/SOUL.md" ] || cp "$OC_WS/SOUL.md" "$CANON/SOUL.md" 2>/dev/null || printf '# SOUL\n' > "$CANON/SOUL.md"
+[ -f "$CANON/USER.md" ] || cp "$OC_WS/USER.md" "$CANON/USER.md" 2>/dev/null || printf '# USER\n' > "$CANON/USER.md"
+[ -f "$CANON/MEMORY.md" ] || cp "$OC_WS/MEMORY.md" "$CANON/MEMORY.md" 2>/dev/null || \
+  printf '# Shared Agent Memory\n\nShared by the OpenClaw and Hermes harnesses.\n' > "$CANON/MEMORY.md"
+
+# 2. OpenClaw side — REAL copies (scanner ignores symlinks). Back up any
+#    pre-existing real file once.
+if [ -d "$OC_WS" ]; then
+  for f in SOUL USER MEMORY; do
+    t="$OC_WS/$f.md"
+    if [ -L "$t" ]; then rm -f "$t"; fi
+    if [ -e "$t" ] && [ ! -e "$t.pre-bridge" ]; then cp "$t" "$t.pre-bridge"; fi
+    cp "$CANON/$f.md" "$t"
+  done
+fi
+
+# 3. Hermes side — symlinks (Hermes follows them; keeps the markdown live).
+if [ -d "$HM_DIR" ]; then
+  mkdir -p "$HM_DIR/memories"
+  [ -e "$HM_DIR/SOUL.md" ] && [ ! -L "$HM_DIR/SOUL.md" ] && mv "$HM_DIR/SOUL.md" "$HM_DIR/SOUL.md.pre-bridge"
+  ln -sfn "$CANON/SOUL.md" "$HM_DIR/SOUL.md"
+  ln -sfn "$CANON/MEMORY.md" "$HM_DIR/memories/MEMORY.md"
+  ln -sfn "$CANON/USER.md" "$HM_DIR/memories/USER.md"
+fi
+
+echo "[setup-shared-identity] canonical=$CANON  openclaw=copies  hermes=symlinks"

--- a/src/app/setup-api/harness/active/route.ts
+++ b/src/app/setup-api/harness/active/route.ts
@@ -1,0 +1,11 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { getActiveHarness } from "@/lib/harness";
+
+// Just the active harness — a config read, no health probes. The desktop chat
+// polls this on mount to decide how to route; the full /harness/status (with
+// liveness probes) is for the Settings picker that renders health dots.
+export async function GET() {
+  return NextResponse.json({ active: await getActiveHarness() });
+}

--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -1,0 +1,44 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import path from "path";
+import { setActiveHarness, isHarness } from "@/lib/harness";
+import { CONFIG_ROOT } from "@/lib/config-store";
+
+const exec = promisify(execFile);
+
+// Switch the active agent harness (openclaw | hermes) and refresh the shared
+// identity into it. Providers/OAuth are per-harness and untouched here.
+export async function POST(request: Request) {
+  let body: { harness?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { harness } = body;
+  if (!isHarness(harness)) {
+    return NextResponse.json(
+      { error: "harness must be 'openclaw' or 'hermes'" },
+      { status: 400 },
+    );
+  }
+
+  await setActiveHarness(harness);
+
+  // Propagate the canonical identity to the selected harness (OpenClaw real
+  // copies + gateway refresh; Hermes FTS5 reindex). Best-effort — the switch
+  // itself already took effect via config.
+  try {
+    await exec("bash", [path.join(CONFIG_ROOT, "scripts", "clawbox-identity-sync.sh")], {
+      timeout: 60_000,
+    });
+  } catch (err) {
+    console.warn("[harness/select] identity sync failed:", err instanceof Error ? err.message : err);
+  }
+
+  return NextResponse.json({ success: true, active: harness });
+}

--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -39,21 +39,22 @@ export async function POST(request: Request) {
     );
   }
 
-  await setActiveHarness(harness);
-
-  // Propagate the canonical identity to the selected harness (OpenClaw real
-  // copies + gateway refresh; Hermes FTS5 reindex). Best-effort — the switch
-  // itself already took effect — but report whether it succeeded so the caller
-  // isn't told "all good" when the identity didn't actually sync.
-  let identitySynced = true;
+  // Propagate the canonical identity to both harnesses (OpenClaw real copies +
+  // gateway refresh; Hermes FTS5 reindex) BEFORE flipping the active one, so we
+  // never complete a switch that leaves the selected harness without its shared
+  // identity. If the sync fails, the harness is NOT switched.
   try {
     await exec("bash", [path.join(CONFIG_ROOT, "scripts", "clawbox-identity-sync.sh")], {
       timeout: 60_000,
     });
   } catch (err) {
-    identitySynced = false;
-    console.warn("[harness/select] identity sync failed:", err instanceof Error ? err.message : err);
+    console.error("[harness/select] identity sync failed; not switching:", err instanceof Error ? err.message : err);
+    return NextResponse.json(
+      { error: "Identity synchronization failed; harness not switched." },
+      { status: 502 },
+    );
   }
 
-  return NextResponse.json({ success: true, active: harness, identitySynced });
+  await setActiveHarness(harness);
+  return NextResponse.json({ success: true, active: harness });
 }

--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import path from "path";
-import { setActiveHarness, isHarness } from "@/lib/harness";
+import { setActiveHarness, isHarness, harnessHealthy } from "@/lib/harness";
 import { CONFIG_ROOT } from "@/lib/config-store";
 
 const exec = promisify(execFile);
@@ -12,14 +12,17 @@ const exec = promisify(execFile);
 // Switch the active agent harness (openclaw | hermes) and refresh the shared
 // identity into it. Providers/OAuth are per-harness and untouched here.
 export async function POST(request: Request) {
-  let body: { harness?: string };
+  let body: unknown;
   try {
     body = await request.json();
   } catch {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json({ error: "Expected a JSON object" }, { status: 400 });
+  }
 
-  const { harness } = body;
+  const harness = (body as { harness?: unknown }).harness;
   if (!isHarness(harness)) {
     return NextResponse.json(
       { error: "harness must be 'openclaw' or 'hermes'" },
@@ -27,18 +30,30 @@ export async function POST(request: Request) {
     );
   }
 
+  // Don't switch to a harness that isn't actually available on this device (the
+  // UI disables it, but the API must enforce it too).
+  if (!(await harnessHealthy(harness))) {
+    return NextResponse.json(
+      { error: `${harness} is not available on this device` },
+      { status: 409 },
+    );
+  }
+
   await setActiveHarness(harness);
 
   // Propagate the canonical identity to the selected harness (OpenClaw real
   // copies + gateway refresh; Hermes FTS5 reindex). Best-effort — the switch
-  // itself already took effect via config.
+  // itself already took effect — but report whether it succeeded so the caller
+  // isn't told "all good" when the identity didn't actually sync.
+  let identitySynced = true;
   try {
     await exec("bash", [path.join(CONFIG_ROOT, "scripts", "clawbox-identity-sync.sh")], {
       timeout: 60_000,
     });
   } catch (err) {
+    identitySynced = false;
     console.warn("[harness/select] identity sync failed:", err instanceof Error ? err.message : err);
   }
 
-  return NextResponse.json({ success: true, active: harness });
+  return NextResponse.json({ success: true, active: harness, identitySynced });
 }

--- a/src/app/setup-api/harness/select/route.ts
+++ b/src/app/setup-api/harness/select/route.ts
@@ -55,6 +55,18 @@ export async function POST(request: Request) {
     );
   }
 
-  await setActiveHarness(harness);
+  // Persist the selection. Identity is already synced, so on a persistence
+  // failure the device is in an uncertain state (synced but maybe not flipped);
+  // return the JSON error contract and tell the client to re-read status rather
+  // than letting a framework-generated 500 leak through.
+  try {
+    await setActiveHarness(harness);
+  } catch (err) {
+    console.error("[harness/select] failed to persist active harness:", err instanceof Error ? err.message : err);
+    return NextResponse.json(
+      { error: "Failed to persist the active harness; reload harness status.", reloadStatus: true },
+      { status: 500 },
+    );
+  }
   return NextResponse.json({ success: true, active: harness });
 }

--- a/src/app/setup-api/harness/status/route.ts
+++ b/src/app/setup-api/harness/status/route.ts
@@ -1,0 +1,22 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { getActiveHarness, harnessHealthy, HARNESSES, type Harness } from "@/lib/harness";
+
+// Report which agent harness is active and whether each harness's local server
+// is up, so the Settings picker can show live state.
+export async function GET() {
+  const ids = Object.keys(HARNESSES) as Harness[];
+  const [active, health] = await Promise.all([
+    getActiveHarness(),
+    Promise.all(ids.map(async (id) => [id, await harnessHealthy(id)] as const)),
+  ]);
+  const healthById = new Map(health);
+  return NextResponse.json({
+    active,
+    harnesses: ids.map((id) => ({
+      ...HARNESSES[id],
+      healthy: healthById.get(id) ?? false,
+    })),
+  });
+}

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -16,6 +16,11 @@ import path from "path";
 const HOME_DIR = process.env.HOME || "/home/clawbox";
 const HERMES_BIN = process.env.HERMES_BIN || path.join(HOME_DIR, ".local", "bin", "hermes");
 const HERMES_TIMEOUT_MS = 90_000;
+// Hermes uses `vendor/model` IDs (routed via its base_url, default OpenRouter).
+// ClawBox's chat model picker is OpenClaw-specific, so when the desktop chat
+// doesn't send a Hermes model we fall back to a known-good default rather than
+// Hermes' config default (which may not resolve on the configured provider).
+const DEFAULT_MODEL = process.env.HERMES_DEFAULT_MODEL || "openai/gpt-4o-mini";
 
 function runHermes(args: string[]): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -70,10 +75,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "message is required" }, { status: 400 });
   }
 
-  const args = ["-z", message];
-  if (typeof body.model === "string" && body.model.trim()) {
-    args.push("-m", body.model.trim());
-  }
+  const model = typeof body.model === "string" && body.model.trim() ? body.model.trim() : DEFAULT_MODEL;
+  const args = ["-z", message, "-m", model];
 
   try {
     const text = await runHermes(args);

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { spawn } from "child_process";
 import path from "path";
+import { HERMES_BIN } from "@/lib/harness";
 
 // Chat turn against the Hermes harness. Uses `hermes -z <message>` (one-shot),
 // which — verified on-device — reuses Hermes' persistent default session, so
@@ -14,7 +15,6 @@ import path from "path";
 // upgrade (the Hermes serve WS supports them).
 
 const HOME_DIR = process.env.HOME || "/home/clawbox";
-const HERMES_BIN = process.env.HERMES_BIN || path.join(HOME_DIR, ".local", "bin", "hermes");
 const HERMES_TIMEOUT_MS = 90_000;
 // Hermes uses `vendor/model` IDs (routed via its base_url, default OpenRouter).
 // ClawBox's chat model picker is OpenClaw-specific, so when the desktop chat

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -75,8 +75,15 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "message is required" }, { status: 400 });
   }
 
-  const model = typeof body.model === "string" && body.model.trim() ? body.model.trim() : DEFAULT_MODEL;
-  const args = ["-z", message, "-m", model];
+  // argv flag-smuggling guard (no shell is involved — spawn uses an arg array —
+  // but a value starting with "-" could still be parsed by hermes as a flag,
+  // e.g. `--version`). Model must match a strict charset and not start with "-";
+  // a message starting with "-" gets a leading space so hermes reads it as the
+  // prompt value (the UI shows ClawBox's own copy of the message, not this one).
+  const rawModel = typeof body.model === "string" && body.model.trim() ? body.model.trim() : DEFAULT_MODEL;
+  const model = /^[A-Za-z0-9_./:-]+$/.test(rawModel) && !rawModel.startsWith("-") ? rawModel : DEFAULT_MODEL;
+  const safeMessage = message.startsWith("-") ? ` ${message}` : message;
+  const args = ["-z", safeMessage, "-m", model];
 
   try {
     const text = await runHermes(args);

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -44,6 +44,7 @@ function runHermes(args: string[], signal?: AbortSignal): Promise<string> {
     let out = "";
     let err = "";
     let outBytes = 0;
+    let errBytes = 0;
 
     const cleanup = () => {
       settled = true;
@@ -72,6 +73,10 @@ function runHermes(args: string[], signal?: AbortSignal): Promise<string> {
       out += chunk.toString();
     });
     child.stderr.on("data", (chunk: Buffer) => {
+      // Same cap as stdout — stderr only feeds the error message, so once we
+      // have enough for that, stop growing the buffer.
+      if (errBytes >= MAX_OUTPUT_BYTES) return;
+      errBytes += chunk.length;
       err += chunk.toString();
     });
 

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -16,14 +16,21 @@ import { HERMES_BIN } from "@/lib/harness";
 
 const HOME_DIR = process.env.HOME || "/home/clawbox";
 const HERMES_TIMEOUT_MS = 90_000;
+// A chat reply can't legitimately exceed this; cap the buffer so a runaway
+// process can't grow it unbounded.
+const MAX_OUTPUT_BYTES = 2_000_000;
 // Hermes uses `vendor/model` IDs (routed via its base_url, default OpenRouter).
 // ClawBox's chat model picker is OpenClaw-specific, so when the desktop chat
 // doesn't send a Hermes model we fall back to a known-good default rather than
 // Hermes' config default (which may not resolve on the configured provider).
 const DEFAULT_MODEL = process.env.HERMES_DEFAULT_MODEL || "openai/gpt-4o-mini";
 
-function runHermes(args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
+function runHermes(args: string[], signal?: AbortSignal): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("aborted", "AbortError"));
+      return;
+    }
     let settled = false;
     const child = spawn(HERMES_BIN, args, {
       stdio: ["ignore", "pipe", "pipe"],
@@ -36,26 +43,53 @@ function runHermes(args: string[]): Promise<string> {
     });
     let out = "";
     let err = "";
-    child.stdout.on("data", (chunk: Buffer) => (out += chunk.toString()));
-    child.stderr.on("data", (chunk: Buffer) => (err += chunk.toString()));
-    const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
+    let outBytes = 0;
+
+    const cleanup = () => {
+      settled = true;
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    // The user hit Stop (or the request was aborted) — kill the process so the
+    // model doesn't keep running for a reply nobody will read.
+    const onAbort = () => {
+      if (settled) return;
+      cleanup();
+      child.kill("SIGKILL");
+      reject(new DOMException("aborted", "AbortError"));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      outBytes += chunk.length;
+      if (outBytes > MAX_OUTPUT_BYTES) {
+        cleanup();
         child.kill("SIGKILL");
-        reject(new Error("Hermes timed out"));
+        reject(new Error("Hermes output exceeded the size limit"));
+        return;
       }
+      out += chunk.toString();
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      err += chunk.toString();
+    });
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      cleanup();
+      child.kill("SIGKILL");
+      reject(new Error("Hermes timed out"));
     }, HERMES_TIMEOUT_MS);
+
     child.on("error", (e) => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timer);
-        reject(e);
-      }
+      if (settled) return;
+      cleanup();
+      reject(e);
     });
     child.on("close", (code) => {
       if (settled) return;
-      settled = true;
-      clearTimeout(timer);
+      cleanup();
       if (code === 0) resolve(out.trim());
       else reject(new Error(err.trim() || `hermes exited with code ${code}`));
     });
@@ -86,9 +120,13 @@ export async function POST(request: Request) {
   const args = ["-z", safeMessage, "-m", model];
 
   try {
-    const text = await runHermes(args);
+    const text = await runHermes(args, request.signal);
     return NextResponse.json({ text, harness: "hermes" });
   } catch (err) {
+    if (err instanceof DOMException && err.name === "AbortError") {
+      // Client hit Stop / disconnected; the child was already killed.
+      return new NextResponse(null, { status: 499 });
+    }
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Hermes chat failed" },
       { status: 502 },

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -1,0 +1,87 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { spawn } from "child_process";
+import path from "path";
+
+// Chat turn against the Hermes harness. Uses `hermes -z <message>` (one-shot),
+// which — verified on-device — reuses Hermes' persistent default session, so
+// multi-turn memory works without ClawBox threading context. The message is
+// passed as an argv element (no shell), so user input can't inject a command.
+//
+// This is the desktop chat backend when the active harness is Hermes; OpenClaw
+// keeps its gateway WebSocket. Streaming + per-chat sessions are a future
+// upgrade (the Hermes serve WS supports them).
+
+const HOME_DIR = process.env.HOME || "/home/clawbox";
+const HERMES_BIN = process.env.HERMES_BIN || path.join(HOME_DIR, ".local", "bin", "hermes");
+const HERMES_TIMEOUT_MS = 90_000;
+
+function runHermes(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const child = spawn(HERMES_BIN, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      cwd: HOME_DIR,
+      env: {
+        ...process.env,
+        HOME: HOME_DIR,
+        PATH: `${path.dirname(HERMES_BIN)}:${process.env.PATH || ""}`,
+      },
+    });
+    let out = "";
+    let err = "";
+    child.stdout.on("data", (chunk: Buffer) => (out += chunk.toString()));
+    child.stderr.on("data", (chunk: Buffer) => (err += chunk.toString()));
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        child.kill("SIGKILL");
+        reject(new Error("Hermes timed out"));
+      }
+    }, HERMES_TIMEOUT_MS);
+    child.on("error", (e) => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        reject(e);
+      }
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) resolve(out.trim());
+      else reject(new Error(err.trim() || `hermes exited with code ${code}`));
+    });
+  });
+}
+
+export async function POST(request: Request) {
+  let body: { message?: string; model?: string };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const message = typeof body.message === "string" ? body.message.trim() : "";
+  if (!message) {
+    return NextResponse.json({ error: "message is required" }, { status: 400 });
+  }
+
+  const args = ["-z", message];
+  if (typeof body.model === "string" && body.model.trim()) {
+    args.push("-m", body.model.trim());
+  }
+
+  try {
+    const text = await runHermes(args);
+    return NextResponse.json({ text, harness: "hermes" });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Hermes chat failed" },
+      { status: 502 },
+    );
+  }
+}

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -73,10 +73,17 @@ function runHermes(args: string[], signal?: AbortSignal): Promise<string> {
       out += chunk.toString();
     });
     child.stderr.on("data", (chunk: Buffer) => {
-      // Same cap as stdout — stderr only feeds the error message, so once we
-      // have enough for that, stop growing the buffer.
-      if (errBytes >= MAX_OUTPUT_BYTES) return;
+      if (settled) return;
       errBytes += chunk.length;
+      // A failing hermes can spew unbounded stderr. Once it clears the cap the
+      // run is already a loss — kill the child (don't let it keep burning CPU
+      // until the timeout) and reject with what we captured. Mirrors stdout.
+      if (errBytes > MAX_OUTPUT_BYTES) {
+        cleanup();
+        child.kill("SIGKILL");
+        reject(new Error(err.trim() || "Hermes error output exceeded the size limit"));
+        return;
+      }
       err += chunk.toString();
     });
 

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1034,19 +1034,29 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // Hermes send: POST the turn to the HTTP route (hermes -z keeps a persistent
   // session, so multi-turn memory works without threading context). No
   // streaming yet — the reply lands whole. Attachments are OpenClaw-only for now.
+  // Holds the in-flight Hermes request so Stop can abort it (which aborts the
+  // fetch → the route sees request.signal abort → kills the `hermes` process).
+  const hermesAbortRef = useRef<AbortController | null>(null)
   const dispatchHermes = useCallback(async (text: string) => {
+    const controller = new AbortController()
+    hermesAbortRef.current = controller
     try {
       const res = await fetch('/setup-api/hermes/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: text }),
+        signal: controller.signal,
       })
       const data = await res.json()
       if (!res.ok) throw new Error(data.error || 'Hermes chat failed')
       setMessages(prev => [...prev, { role: 'assistant', text: data.text || '(no response)', timestamp: Date.now() }])
     } catch (err) {
-      setMessages(prev => [...prev, { role: 'system', text: `Error: ${(err as Error).message}`, timestamp: Date.now() }])
+      // A user-initiated Stop shows nothing, not an error line.
+      if ((err as Error)?.name !== 'AbortError') {
+        setMessages(prev => [...prev, { role: 'system', text: `Error: ${(err as Error).message}`, timestamp: Date.now() }])
+      }
     } finally {
+      hermesAbortRef.current = null
       setSending(false)
       setStreaming('')
       runIdRef.current = null
@@ -1140,6 +1150,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
 
   // Abort generation
   const abort = useCallback(async () => {
+    if (harnessRef.current === 'hermes') {
+      hermesAbortRef.current?.abort()
+      return
+    }
     try {
       await wsRequest('chat.abort', { sessionKey: sessionKeyRef.current })
     } catch {}

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -188,6 +188,12 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const [status, setStatus] = useState<'connecting' | 'connected' | 'error'>('connecting')
   // Gateway is canonical; render an empty list until chat.history arrives.
   const [messages, setMessages] = useState<ChatMessage[]>([])
+  // Which agent harness backs this chat. OpenClaw uses the gateway WebSocket;
+  // Hermes uses the /setup-api/hermes/chat HTTP route (hermes -z, persistent
+  // session). Loaded once on mount; connect() is gated on `harnessLoaded` so we
+  // never open the OpenClaw WS in Hermes mode.
+  const harnessRef = useRef<'openclaw' | 'hermes'>('openclaw')
+  const [harnessLoaded, setHarnessLoaded] = useState(false)
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState('')
   const [sending, setSending] = useState(false)
@@ -487,6 +493,12 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   }, [])
 
   const connect = useCallback(async () => {
+    // Hermes mode: no gateway WebSocket. Mark connected so the composer is
+    // enabled; startRun routes sends to /setup-api/hermes/chat instead.
+    if (harnessRef.current === 'hermes') {
+      setStatus('connected')
+      return
+    }
     // Cancel any pending retry / auth-backoff timer so an explicit reconnect
     // (e.g. the "Try again" button) can't race with a previously scheduled one
     // and fire a duplicate connect later.
@@ -1019,6 +1031,28 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     }
   }, [wsRequest])
 
+  // Hermes send: POST the turn to the HTTP route (hermes -z keeps a persistent
+  // session, so multi-turn memory works without threading context). No
+  // streaming yet — the reply lands whole. Attachments are OpenClaw-only for now.
+  const dispatchHermes = useCallback(async (text: string) => {
+    try {
+      const res = await fetch('/setup-api/hermes/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text }),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.error || 'Hermes chat failed')
+      setMessages(prev => [...prev, { role: 'assistant', text: data.text || '(no response)', timestamp: Date.now() }])
+    } catch (err) {
+      setMessages(prev => [...prev, { role: 'system', text: `Error: ${(err as Error).message}`, timestamp: Date.now() }])
+    } finally {
+      setSending(false)
+      setStreaming('')
+      runIdRef.current = null
+    }
+  }, [])
+
   const startRun = useCallback((text: string, sendAttachments: { name: string; path: string; type: string }[]) => {
     const fileNames = sendAttachments.map(a => `📎 ${a.name}`).join('\n')
     const displayText = [fileNames, text].filter(Boolean).join('\n')
@@ -1027,12 +1061,16 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     setStreaming('')
     const idempotencyKey = uuid()
     runIdRef.current = idempotencyKey
+    if (harnessRef.current === 'hermes') {
+      void dispatchHermes(text)
+      return
+    }
     if (status !== 'connected') {
       pendingSendsRef.current.push({ text, attachments: sendAttachments, idempotencyKey })
       return
     }
     void dispatchSend(text, sendAttachments, idempotencyKey)
-  }, [status, dispatchSend])
+  }, [status, dispatchSend, dispatchHermes])
 
   const sendMessage = useCallback(() => {
     const text = input.trim()
@@ -1199,13 +1237,30 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     await switchChatModel({ model: target.model, label: target.label })
   }, [chatModelState, onOpenSettingsSection, switchChatModel])
 
-  // Pre-warm the gateway WebSocket on mount so opening chat is instant —
-  // the WS handshake happens silently while the user is still on the desktop.
-  // onClose's retry budget covers a dropped pre-warm; no need for the isOpen
-  // effect to also call connect().
+  // Resolve the active harness once, before connecting, so we never open the
+  // OpenClaw WS in Hermes mode.
   useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const res = await fetch('/setup-api/harness/status', { cache: 'no-store' })
+        const data = await res.json()
+        if (!cancelled && data?.active === 'hermes') harnessRef.current = 'hermes'
+      } catch {
+        // default to openclaw
+      }
+      if (!cancelled) setHarnessLoaded(true)
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  // Pre-warm the connection on mount so opening chat is instant. In OpenClaw
+  // mode this silently completes the gateway WS handshake; in Hermes mode
+  // connect() just marks connected (no WS). Gated on the harness resolving.
+  useEffect(() => {
+    if (!harnessLoaded) return
     connect()
-  }, [connect])
+  }, [connect, harnessLoaded])
 
   useEffect(() => {
     if (isOpen) {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -194,6 +194,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // never open the OpenClaw WS in Hermes mode.
   const harnessRef = useRef<'openclaw' | 'hermes'>('openclaw')
   const [harnessLoaded, setHarnessLoaded] = useState(false)
+  // Reactive copy of the harness for rendering (the ref drives connect/send at
+  // call-time; this drives which header controls show).
+  const [harnessMode, setHarnessMode] = useState<'openclaw' | 'hermes'>('openclaw')
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState('')
   const [sending, setSending] = useState(false)
@@ -1259,7 +1262,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       try {
         const res = await fetch('/setup-api/harness/active', { cache: 'no-store' })
         const data = await res.json()
-        if (!cancelled && data?.active === 'hermes') harnessRef.current = 'hermes'
+        if (!cancelled && data?.active === 'hermes') {
+          harnessRef.current = 'hermes'
+          setHarnessMode('hermes')
+        }
       } catch {
         // default to openclaw
       }
@@ -1551,6 +1557,11 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
           touchAction: 'none',
         }}>
         <div className="chat-header-pills">
+          {harnessMode === 'hermes' ? (
+            // Hermes manages its own provider/model config — the OpenClaw
+            // provider/model/reasoning pills don't apply, so show a plain label.
+            <span className="header-dropdown-trigger" style={{ cursor: 'default', maxWidth: 130 }}>Hermes</span>
+          ) : (<>
           {chatModelState && (() => {
             const activeId = chatModelState.activeOptionId ?? chatModelState.options[0]?.id ?? ''
             const activeOption = chatModelState.options.find(o => o.id === activeId)
@@ -1675,6 +1686,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
               popoverWidth={180}
             />
           )}
+          </>)}
         </div>
         <div style={{ flex: 1 }} />
         {(status === 'connecting' || switchingModel) && (

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1952,6 +1952,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         background: 'rgba(0,0,0,0.2)',
         display: 'flex', gap: 8, alignItems: 'flex-end',
       }}>
+        {/* Hermes chat is text-only (the `hermes -z` CLI takes no attachments),
+            so hide the attach control there — otherwise a user could attach a
+            file that startRun silently drops on the Hermes path. */}
+        {harnessMode !== 'hermes' && (
         <button
           onClick={() => fileInputRef.current?.click()}
           disabled={status !== 'connected'}
@@ -1968,6 +1972,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         >
           <span className="material-symbols-rounded" style={{ fontSize: 20 }}>attach_file</span>
         </button>
+        )}
         <textarea
           ref={inputRef}
           value={input}

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1243,7 +1243,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     let cancelled = false
     void (async () => {
       try {
-        const res = await fetch('/setup-api/harness/status', { cache: 'no-store' })
+        const res = await fetch('/setup-api/harness/active', { cache: 'no-store' })
         const data = await res.json()
         if (!cancelled && data?.active === 'hermes') harnessRef.current = 'hermes'
       } catch {

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -23,6 +23,7 @@ export default function HarnessPicker() {
   const load = useCallback(async () => {
     try {
       const res = await fetch("/setup-api/harness/status", { cache: "no-store" });
+      if (!res.ok) throw new Error(`status ${res.status}`);
       setStatus(await res.json());
     } catch {
       setError("Could not load harness status");
@@ -66,9 +67,9 @@ export default function HarnessPicker() {
         <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>
           hub
         </span>
-        <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+        <h3 className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest m-0">
           Agent harness
-        </label>
+        </h3>
       </div>
       <p className="text-xs text-[var(--text-muted)] mb-3">
         The engine that runs your agent. One shared identity; each harness keeps its own providers.

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -81,7 +81,8 @@ export default function HarnessPicker() {
             <button
               key={h.id}
               onClick={() => select(h.id)}
-              disabled={!!switching || active}
+              disabled={!!switching || active || !h.healthy}
+              title={!h.healthy ? `${h.label} is not available on this device` : undefined}
               className={`flex items-center justify-between rounded-xl border p-3 text-left transition-colors ${
                 active
                   ? "border-[var(--coral-bright)] bg-orange-500/10"

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+interface HarnessEntry {
+  id: string;
+  label: string;
+  healthy: boolean;
+}
+interface HarnessStatus {
+  active: string;
+  harnesses: HarnessEntry[];
+}
+
+// Lets the user pick which agent harness (OpenClaw / Hermes) backs the device.
+// Both share one identity; providers stay per-harness. Self-contained so it
+// drops into Settings → System with a single import.
+export default function HarnessPicker() {
+  const [status, setStatus] = useState<HarnessStatus | null>(null);
+  const [switching, setSwitching] = useState<string | null>(null);
+  const [error, setError] = useState("");
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/setup-api/harness/status", { cache: "no-store" });
+      setStatus(await res.json());
+    } catch {
+      setError("Could not load harness status");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const select = useCallback(
+    async (id: string) => {
+      if (switching || status?.active === id) return;
+      setSwitching(id);
+      setError("");
+      try {
+        const res = await fetch("/setup-api/harness/select", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ harness: id }),
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || "Switch failed");
+        await load();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Switch failed");
+      } finally {
+        setSwitching(null);
+      }
+    },
+    [switching, status, load],
+  );
+
+  return (
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+      <div className="flex items-center gap-2 mb-3">
+        <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>
+          hub
+        </span>
+        <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+          Agent harness
+        </label>
+      </div>
+      <p className="text-xs text-[var(--text-muted)] mb-3">
+        The engine that runs your agent. One shared identity; each harness keeps its own providers.
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        {(status?.harnesses ?? []).map((h) => {
+          const active = status?.active === h.id;
+          const busy = switching === h.id;
+          return (
+            <button
+              key={h.id}
+              onClick={() => select(h.id)}
+              disabled={!!switching || active}
+              className={`flex items-center justify-between rounded-xl border p-3 text-left transition-colors ${
+                active
+                  ? "border-[var(--coral-bright)] bg-orange-500/10"
+                  : "border-[var(--border-subtle)] hover:border-[var(--coral-bright)]/50"
+              }`}
+            >
+              <span className="flex items-center gap-2">
+                <span className={`w-2 h-2 rounded-full ${h.healthy ? "bg-emerald-400" : "bg-white/25"}`} />
+                <span className="text-sm text-[var(--text-primary)] font-medium">{h.label}</span>
+              </span>
+              <span className="text-[10px] uppercase tracking-wide text-[var(--text-muted)]">
+                {busy ? "…" : active ? "Active" : h.healthy ? "Switch" : "Offline"}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {error && <p className="text-xs text-red-400 mt-3">{error}</p>}
+    </div>
+  );
+}

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -57,7 +57,7 @@ export default function HarnessPicker() {
         setSwitching(null);
       }
     },
-    [switching, status, load],
+    [switching, status],
   );
 
   return (

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -46,10 +46,14 @@ export default function HarnessPicker() {
         });
         const data = await res.json();
         if (!res.ok) throw new Error(data.error || "Switch failed");
-        await load();
+        // The desktop chat resolves its harness on mount and stays mounted, so
+        // a live switch wouldn't reach an already-open chat. Reload so the whole
+        // desktop re-mounts against the newly-selected harness — a clean, sure
+        // apply for a deliberate engine switch.
+        window.location.reload();
+        return;
       } catch (e) {
         setError(e instanceof Error ? e.message : "Switch failed");
-      } finally {
         setSwitching(null);
       }
     },

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -6,6 +6,7 @@ import { createPortal } from "react-dom";
 import StatusMessage from "./StatusMessage";
 import SignalBars from "./SignalBars";
 import AIProviderIcon from "./AIProviderIcon";
+import HarnessPicker from "./HarnessPicker";
 import type { WifiNetwork } from "@/lib/wifi-utils";
 import { signalToLevel, dbmToLevel } from "@/lib/wifi-utils";
 import { dispatchOpenApp } from "@/lib/ui-events";
@@ -2676,6 +2677,8 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         {/* ─── System ─── */}
         {activeSection === "system" && (
           <div className="max-w-xl space-y-5">
+
+            <HarnessPicker />
 
             {stats ? (
               <>

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -13,7 +13,9 @@ import { get, set } from "@/lib/config-store";
 
 export type Harness = "openclaw" | "hermes";
 
-const HERMES_BIN =
+// Where the Hermes CLI lives — the single source of truth (the chat route
+// imports this rather than re-deriving it).
+export const HERMES_BIN =
   process.env.HERMES_BIN || path.join(process.env.HOME || "/home/clawbox", ".local", "bin", "hermes");
 
 export const HARNESS_CONFIG_KEY = "active_harness";
@@ -64,12 +66,14 @@ export async function setActiveHarness(harness: Harness): Promise<void> {
  * doesn't stall the status route.
  */
 export async function harnessHealthy(harness: Harness): Promise<boolean> {
-  // Prefer a live server probe (any HTTP response = the process is up).
+  // Prefer a live server probe: any HTTP response means the process is up.
   try {
     const res = await fetch(`${HARNESSES[harness].baseUrl}/`, {
       signal: AbortSignal.timeout(2500),
     });
-    if (res.status > 0) return true;
+    // Drain the body we don't read so undici frees the pooled socket now.
+    res.body?.cancel();
+    return true;
   } catch {
     // fall through
   }

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -81,8 +81,11 @@ export async function harnessHealthy(harness: Harness): Promise<boolean> {
   // usable whenever the binary is installed — the serve probe above is just a
   // bonus signal, not a requirement.
   if (harness === "hermes") {
+    // Chat uses the `hermes` CLI, so Hermes is usable when the binary is present
+    // AND executable (existsSync alone would accept a non-executable file).
     try {
-      return fs.existsSync(HERMES_BIN);
+      fs.accessSync(HERMES_BIN, fs.constants.X_OK);
+      return true;
     } catch {
       return false;
     }

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -1,0 +1,70 @@
+// Dual-harness router. ClawBox can drive its agent through OpenClaw (the
+// default gateway) or Hermes (Nous Research), sharing one identity via the
+// canonical ~/.clawbox/agent-identity bridge (see scripts/setup-shared-identity.sh).
+// The user picks the active harness; providers/OAuth stay separate per harness.
+//
+// This module is the single source of truth for "which harness is active" and
+// "where each harness's local server lives" — chat/gateway routing and the
+// Settings picker both read it.
+
+import { get, set } from "@/lib/config-store";
+
+export type Harness = "openclaw" | "hermes";
+
+export const HARNESS_CONFIG_KEY = "active_harness";
+export const DEFAULT_HARNESS: Harness = "openclaw";
+
+export interface HarnessInfo {
+  id: Harness;
+  label: string;
+  /** Loopback base URL of the harness's local server/gateway. */
+  baseUrl: string;
+}
+
+export const HARNESSES: Record<Harness, HarnessInfo> = {
+  openclaw: {
+    id: "openclaw",
+    label: "OpenClaw",
+    baseUrl: `http://127.0.0.1:${process.env.GATEWAY_PORT || "18789"}`,
+  },
+  hermes: {
+    id: "hermes",
+    label: "Hermes",
+    // `hermes serve` defaults to 127.0.0.1:9119.
+    baseUrl: `http://127.0.0.1:${process.env.HERMES_PORT || "9119"}`,
+  },
+};
+
+export function isHarness(value: unknown): value is Harness {
+  return value === "openclaw" || value === "hermes";
+}
+
+export async function getActiveHarness(): Promise<Harness> {
+  try {
+    const value = await get(HARNESS_CONFIG_KEY);
+    return isHarness(value) ? value : DEFAULT_HARNESS;
+  } catch {
+    return DEFAULT_HARNESS;
+  }
+}
+
+export async function setActiveHarness(harness: Harness): Promise<void> {
+  await set(HARNESS_CONFIG_KEY, harness);
+}
+
+/**
+ * Liveness probe: is the harness's local server answering at all? Any HTTP
+ * response (even 401/404) proves the process is up; only a connection failure
+ * or timeout counts as down. Loopback-only, short timeout so a down harness
+ * doesn't stall the status route.
+ */
+export async function harnessHealthy(harness: Harness): Promise<boolean> {
+  try {
+    const res = await fetch(`${HARNESSES[harness].baseUrl}/`, {
+      signal: AbortSignal.timeout(2500),
+    });
+    return res.status > 0;
+  } catch {
+    return false;
+  }
+}

--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -7,9 +7,14 @@
 // "where each harness's local server lives" — chat/gateway routing and the
 // Settings picker both read it.
 
+import fs from "fs";
+import path from "path";
 import { get, set } from "@/lib/config-store";
 
 export type Harness = "openclaw" | "hermes";
+
+const HERMES_BIN =
+  process.env.HERMES_BIN || path.join(process.env.HOME || "/home/clawbox", ".local", "bin", "hermes");
 
 export const HARNESS_CONFIG_KEY = "active_harness";
 export const DEFAULT_HARNESS: Harness = "openclaw";
@@ -59,12 +64,24 @@ export async function setActiveHarness(harness: Harness): Promise<void> {
  * doesn't stall the status route.
  */
 export async function harnessHealthy(harness: Harness): Promise<boolean> {
+  // Prefer a live server probe (any HTTP response = the process is up).
   try {
     const res = await fetch(`${HARNESSES[harness].baseUrl}/`, {
       signal: AbortSignal.timeout(2500),
     });
-    return res.status > 0;
+    if (res.status > 0) return true;
   } catch {
-    return false;
+    // fall through
   }
+  // Hermes chat uses the `hermes -z` CLI, not the serve endpoint, so it's
+  // usable whenever the binary is installed — the serve probe above is just a
+  // bonus signal, not a requirement.
+  if (harness === "hermes") {
+    try {
+      return fs.existsSync(HERMES_BIN);
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Dual-harness: run the ClawBox agent on OpenClaw **or** Hermes

Adds a second agent harness — **Hermes** (Nous Research) — alongside OpenClaw, with **one shared
identity** and a **user-facing picker**. The user chooses which engine backs the device; each harness keeps
its own providers/auth. Proven end-to-end on a real Jetson (fresh factory-reset → setup → chat on both
harnesses).

### What's in it
- **Harness router** (`src/lib/harness.ts`) — the single source of truth for the active harness
  (`active_harness` config, default `openclaw`), each harness's local endpoint (OpenClaw gateway `:18789`,
  Hermes `serve` `:9119`), and a health probe. Hermes health = server-up **or** the CLI is installed
  (chat uses the `hermes -z` CLI, not the serve endpoint).
- **API** — `GET /setup-api/harness/status` (active + live health of both, for the picker),
  `GET /setup-api/harness/active` (just the active harness, no probes — the chat's lightweight mount check),
  and `POST /setup-api/harness/select` (switch + run the identity sync).
- **Desktop chat routing** — `ChatPopup` resolves the active harness on mount; in Hermes mode it skips the
  OpenClaw gateway WebSocket and routes turns to `POST /setup-api/hermes/chat`. OpenClaw's path is
  unchanged.
- **Hermes chat backend** (`/setup-api/hermes/chat`) — runs `hermes -z <message>` (its persistent default
  session gives multi-turn memory for free). Guards against argv flag-smuggling (strict model charset +
  leading-dash message).
- **Settings picker** (`HarnessPicker`, Settings → System) — OpenClaw / Hermes with live health dots and a
  one-click switch; switching reloads the desktop so the chat re-mounts against the new harness. An offline
  harness can't be selected.
- **Shared-identity bridge** (`scripts/setup-shared-identity.sh` + `clawbox-identity-sync.sh`) — a canonical
  `~/.clawbox/agent-identity/{SOUL,USER,MEMORY}.md` shared by both harnesses. OpenClaw gets **real copies**
  (its workspace scanner doesn't follow symlinks); Hermes gets **symlinks** (it does). The sync self-heals
  the bridge on first run and reindexes Hermes' FTS5 on switch. Providers/OAuth are **not** shared (per
  OpenClaw's own guidance against a shared OAuth grant).

### Validated on-device (Jetson, aarch64)
Factory reset → full setup wizard → desktop → OpenClaw chat replies "OpenClaw" → Settings picker (both
healthy) → switch to Hermes (reload) → chat replies "Hermes". Backend: `harness/status` both healthy,
`hermes/chat` returns `{harness:"hermes"}`, OpenClaw agent responds. Build + e2e green.

### Notes / scope
- Hermes is an **optional** add-on the owner installs separately (Nous installer). Until then the picker
  shows it offline and un-selectable; OpenClaw remains the default.
- v1 is **non-streaming** (Hermes replies land whole) and uses Hermes' single default session. Token
  streaming (via the Hermes serve WS), per-chat sessions, a Hermes-native model picker, and MEMORY (not
  just identity) sync for OpenClaw are follow-ups. `hermes serve`'s API is a FastAPI JSON-RPC/WS backend for
  Hermes' own desktop app (not OpenAI-compatible headless), which is why the `-z` CLI is the v1 path.
- No new dependencies. `setup-shared-identity.sh` should be wired into `install.sh` in a follow-up so the
  bridge exists before the first switch (the sync self-heals it in the meantime).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for switching between OpenClaw and Hermes chat harnesses.
  * Added harness health indicators and selection controls in System settings.
  * Hermes chat now supports complete responses, error reporting, cancellation, and text-only input.
  * Added shared identity setup and synchronization across supported assistants.
  * Identity files are synchronized automatically when changing the active harness.
  * Added active harness and status reporting for setup and configuration workflows.
  * Added automatic fallback handling when a selected harness is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->