### PR TITLE
perf(anim): reduced-motion support + drop per-frame filter repaints + mascot/ProgressBar fixes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -370,7 +370,9 @@ html {
   border: 2px solid var(--border-subtle);
   border-top-color: var(--coral-bright);
   border-radius: 50%;
-  animation: spin 0.6s linear infinite;
+  /* Match Tailwind's animate-spin (1s) so the two spinner systems that appear
+     together in the wizard rotate at the same speed. */
+  animation: spin 1s linear infinite;
   display: inline-block;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -640,13 +640,18 @@ html {
 }
 
 @keyframes welcome-powerup {
-  0%, 100% { transform: translateY(0) scale(1.05) rotate(0deg); filter: drop-shadow(0 0 8px rgba(249,115,22,0.4)); }
-  33% { transform: translateY(-6px) scale(1.1) rotate(-2deg); filter: drop-shadow(0 0 14px rgba(249,115,22,0.6)); }
-  66% { transform: translateY(-4px) scale(1.08) rotate(2deg); filter: drop-shadow(0 0 10px rgba(249,115,22,0.5)); }
+  0%, 100% { transform: translateY(0) scale(1.05) rotate(0deg); }
+  33% { transform: translateY(-6px) scale(1.1) rotate(-2deg); }
+  66% { transform: translateY(-4px) scale(1.08) rotate(2deg); }
 }
 
 .animate-welcome-powerup {
   animation: welcome-powerup 1.5s ease-in-out infinite;
+  /* Static glow: animating filter:drop-shadow repaints the filtered region on
+     every frame (expensive on the Jetson iGPU). Keep the glow, animate only the
+     compositor-friendly transform above. */
+  filter: drop-shadow(0 0 10px rgba(249, 115, 22, 0.5));
+  will-change: transform;
 }
 
 @keyframes clawbox-notification-shield-blink {
@@ -775,4 +780,22 @@ input[type="range"].appearance-none::-moz-range-track {
 }
 .clawkeep-shelf-glow-orange {
   --glow-color: rgba(245, 158, 11, 0.95);
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+   Reduced motion (WCAG 2.3.3). The setup wizard and desktop run many perpetual
+   decorative animations at once (mascot idle, pulse rings, orbits, spinners,
+   shelf glow). Honor the OS "reduce motion" setting: near-zero durations and a
+   single iteration collapse infinite loops to a static end state while keeping
+   layout intact. The mascot's rAF movement loop is gated separately in JS.
+   ───────────────────────────────────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1452,19 +1452,21 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             ? 'opacity 0.2s ease, transform 0.42s cubic-bezier(0.22, 1.28, 0.36, 1)'
             : 'opacity 0.18s ease',
         pointerEvents: visible ? 'auto' : 'none',
-        willChange: 'transform, opacity, filter',
+        willChange: 'transform, opacity',
       }}
     >
-      {/* Insane entrance: spring burst out of the mascot with an overshoot,
-          a tilt-wobble, a soft blur-in and an orange energy-glow pulse.
-          transform-origin (set on the container) pins it to where the crab is,
-          so the whole thing erupts from the tapped mascot and settles clean. */}
+      {/* Spring burst out of the mascot: overshoot + tilt-wobble, transform +
+          opacity only. transform-origin (set on the container) pins it to where
+          the crab is. The previous version also tweened filter:blur/brightness/
+          drop-shadow every frame — a full-layer repaint per frame that dropped
+          frames on the Jetson iGPU (esp. while chat is connecting). The
+          transform spring already carries the "erupt and settle" feel. */}
       <style>{`@keyframes clawChatBurstIn {
-        0%   { opacity: 0; transform: scale(0.12) translateY(38px) rotate(-8deg); filter: blur(16px) brightness(1.55) drop-shadow(0 0 0 rgba(249,115,22,0)); }
-        45%  { opacity: 1; transform: scale(1.08) translateY(-6px) rotate(2.4deg); filter: blur(0px) brightness(1.18) drop-shadow(0 0 26px rgba(249,115,22,0.6)); }
-        65%  { transform: scale(0.965) translateY(3px) rotate(-1.4deg); filter: brightness(1.05) drop-shadow(0 0 12px rgba(249,115,22,0.32)); }
-        82%  { transform: scale(1.015) translateY(-1px) rotate(0.5deg); filter: drop-shadow(0 0 5px rgba(249,115,22,0.16)); }
-        100% { opacity: 1; transform: scale(1) translateY(0) rotate(0deg); filter: blur(0px) brightness(1) drop-shadow(0 0 0 rgba(249,115,22,0)); }
+        0%   { opacity: 0; transform: scale(0.12) translateY(38px) rotate(-8deg); }
+        45%  { opacity: 1; transform: scale(1.08) translateY(-6px) rotate(2.4deg); }
+        65%  { transform: scale(0.965) translateY(3px) rotate(-1.4deg); }
+        82%  { transform: scale(1.015) translateY(-1px) rotate(0.5deg); }
+        100% { opacity: 1; transform: scale(1) translateY(0) rotate(0deg); }
       }`}</style>
       {/* Header — drag handle (desktop) / simple bar (mobile) */}
       <div

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -972,10 +972,25 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
     }
   })()
 
-  // Freeze/unfreeze mascot (e.g. when chat popup is open) — enter power stance
+  // Honor the OS "reduce motion" setting. The global CSS guard neutralizes the
+  // crab's keyframe animations, but its autonomous walking/dancing is driven by
+  // a JS rAF loop — continuous motion a vestibular-sensitive user can't stop.
+  // Reuse the freeze mechanism to hold the crab still under reduced-motion.
+  const [reducedMotion, setReducedMotion] = useState(false)
   useEffect(() => {
-    frozenRef.current = !!frozen
-    if (frozen) {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const update = () => setReducedMotion(mq.matches)
+    update()
+    mq.addEventListener?.('change', update)
+    return () => mq.removeEventListener?.('change', update)
+  }, [])
+
+  // Freeze/unfreeze mascot (chat popup open, or reduced-motion) — enter power stance
+  useEffect(() => {
+    const effFrozen = frozen || reducedMotion
+    frozenRef.current = effFrozen
+    if (effFrozen) {
       // Stop all movement — stay in place (don't teleport to box)
       if (stateTimeout.current) clearTimeout(stateTimeout.current)
       if (walkInterval.current) { cancelAnimationFrame(walkInterval.current as unknown as number); clearInterval(walkInterval.current) }
@@ -989,7 +1004,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
       if (stateTimeout.current) clearTimeout(stateTimeout.current)
       stateTimeout.current = setTimeout(() => doActionRef.current(), 1000)
     }
-  }, [frozen])
+  }, [frozen, reducedMotion])
 
   // ─── Keep the crab clear of a docked chat panel ───
   // When the chat opens as a vertical side panel (rightInset = its width in px),

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -53,9 +53,14 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
 
   // Speech
   const [speech, setSpeech] = useState('')
+  const speechTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const say = useCallback((text: string, ms = 3000) => {
+    // Clear any in-flight clear timer first: without this, an older bubble's
+    // timeout fires and blanks a newer bubble early (visible flicker during
+    // frenzy / rapid taps), and a late fire can setState after unmount.
+    if (speechTimerRef.current) clearTimeout(speechTimerRef.current)
     setSpeech(text)
-    setTimeout(() => setSpeech(''), ms)
+    speechTimerRef.current = setTimeout(() => setSpeech(''), ms)
   }, [])
   const sayRef = useRef<((text: string, ms?: number) => void) | null>(null)
   sayRef.current = say
@@ -946,6 +951,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
       frenzyIntervalsRef.current.forEach(clearInterval)
       if (physicsRAF.current) cancelAnimationFrame(physicsRAF.current)
       if (boxPhysicsRAF.current) cancelAnimationFrame(boxPhysicsRAF.current)
+      if (speechTimerRef.current) clearTimeout(speechTimerRef.current)
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -837,6 +837,10 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
     const moneyEmojis = ['💰', '💵', '💸', '🤑', '💎', '🪙', '💲', '€']
 
     const handleNewOrder = () => {
+      // Skip the frenzy (60s of autonomous running + spawns) when motion is
+      // reduced or the crab is frozen (chat open) — frozenRef reflects
+      // `frozen || reducedMotion`, so this honours the OS reduce-motion setting.
+      if (frozenRef.current) return
       // Cancel current action
       if (stateTimeout.current) clearTimeout(stateTimeout.current)
       if (walkInterval.current) { cancelAnimationFrame(walkInterval.current as unknown as number); clearInterval(walkInterval.current) }

--- a/src/components/Mascot.tsx
+++ b/src/components/Mascot.tsx
@@ -858,6 +858,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
 
       let lastFrenzyFrame = 0
       const frenzyAnimate = (now: number) => {
+        if (frozenRef.current) return // stop rescheduling once frozen mid-frenzy
         if (!lastFrenzyFrame) lastFrenzyFrame = now
         const dt = now - lastFrenzyFrame
         if (dt >= 16) { // ~60fps cap
@@ -902,6 +903,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
         if (Math.random() < 0.4) {
           const jStart = performance.now()
           const jLoop = (now: number) => {
+            if (frozenRef.current) { setJumpY(0); return } // freeze cancels an in-flight jump
             const t = Math.min((now - jStart) / 375, 1) // 15 frames * 25ms
             setJumpY(-Math.sin(t * Math.PI) * 35)
             if (t < 1) requestAnimationFrame(jLoop)
@@ -915,11 +917,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
 
       // End frenzy after 60 seconds
       frenzyTimeout.current = setTimeout(() => {
-        setFrenzy(false)
-        setMoneyParticles([])
-        frenzyIntervalsRef.current.forEach(clearInterval)
-        frenzyIntervalsRef.current = []
-        if (walkInterval.current) { cancelAnimationFrame(walkInterval.current as unknown as number); clearInterval(walkInterval.current) }
+        stopFrenzy()
         doActionRef.current()
       }, 60000)
     }
@@ -990,6 +988,23 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
     return () => mq.removeEventListener?.('change', update)
   }, [])
 
+  // Tear down an in-flight frenzy: the rAF walk loop, the quote/money/jump
+  // intervals, the 60s end-timer, and the visual state they drove. Safe to call
+  // when no frenzy is running. Used both by the natural 60s end and when the
+  // crab freezes mid-frenzy (chat opens, or reduced-motion turns on) — without
+  // it those intervals would keep firing say()/money/jumps for up to a minute
+  // after the crab was supposed to hold still. (An already-scheduled jump rAF
+  // can't be cancelled by handle here, so its jLoop also bails on frozenRef.)
+  const stopFrenzy = useCallback(() => {
+    if (frenzyTimeout.current) { clearTimeout(frenzyTimeout.current); frenzyTimeout.current = null }
+    frenzyIntervalsRef.current.forEach(clearInterval)
+    frenzyIntervalsRef.current = []
+    if (walkInterval.current) { cancelAnimationFrame(walkInterval.current as unknown as number); clearInterval(walkInterval.current); walkInterval.current = null }
+    setFrenzy(false)
+    setMoneyParticles([])
+    setJumpY(0)
+  }, [])
+
   // Freeze/unfreeze mascot (chat popup open, or reduced-motion) — enter power stance
   useEffect(() => {
     const effFrozen = frozen || reducedMotion
@@ -997,7 +1012,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
     if (effFrozen) {
       // Stop all movement — stay in place (don't teleport to box)
       if (stateTimeout.current) clearTimeout(stateTimeout.current)
-      if (walkInterval.current) { cancelAnimationFrame(walkInterval.current as unknown as number); clearInterval(walkInterval.current) }
+      stopFrenzy() // cancel an active frenzy, not just block new ones
       setBoxGlow(true)
       setState('idle')
       setSpeech('')
@@ -1008,7 +1023,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
       if (stateTimeout.current) clearTimeout(stateTimeout.current)
       stateTimeout.current = setTimeout(() => doActionRef.current(), 1000)
     }
-  }, [frozen, reducedMotion])
+  }, [frozen, reducedMotion, stopFrenzy])
 
   // ─── Keep the crab clear of a docked chat panel ───
   // When the chat opens as a vertical side panel (rightInset = its width in px),
@@ -1102,7 +1117,7 @@ function ClawBoxMascot({ onTap, frozen, thinking, onPositionChange, rightInset }
                 : 'none',
       }}>
         {/* Body */}
-        <div style={{ animation: bodyAnim, width: 150, height: 150, position: 'relative', willChange: 'transform' }}>
+        <div data-frenzy={frenzy ? '1' : undefined} style={{ animation: bodyAnim, width: 150, height: 150, position: 'relative', willChange: 'transform' }}>
           <img src="/clawbox-crab.png" alt="" style={{
             width: 150, height: 150, objectFit: 'contain',
           }} />

--- a/src/components/ProgressBar.tsx
+++ b/src/components/ProgressBar.tsx
@@ -44,10 +44,13 @@ export default function ProgressBar({ currentStep }: ProgressBarProps) {
             key={num}
             aria-current={isCurrent ? "step" : undefined}
             aria-disabled={num > currentStep ? true : undefined}
-            className={`flex items-center gap-1.5 px-1.5 py-1.5 sm:px-3 rounded-full text-xs font-medium transition-all ${stepColors(isDone, isCurrent)} ${isCurrent ? "scale-105" : ""}`}
+            className={`flex items-center gap-1.5 px-1.5 py-1.5 sm:px-3 rounded-full text-xs font-medium transition-[transform,color,background-color,box-shadow] duration-200 ${stepColors(isDone, isCurrent)} ${isCurrent ? "scale-105" : ""}`}
           >
+            {/* Fixed 24px badge; the current step is emphasised via transform
+                scale (GPU-composited) instead of animating w/h — the latter
+                reflowed the sticky header (micro-CLS) on every step change. */}
             <span
-              className={`inline-flex items-center justify-center rounded-full text-[11px] font-bold text-white shrink-0 transition-all ${badgeColor(isDone, isCurrent)} ${isCurrent ? "w-6 h-6" : "w-5 h-5"}`}
+              className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-[11px] font-bold text-white shrink-0 transition-transform duration-200 ${badgeColor(isDone, isCurrent)} ${isCurrent ? "" : "scale-[0.83]"}`}
             >
               {isDone ? (
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12l5 5L19 7" /></svg>

--- a/src/tests/components/mascot-frenzy.test.tsx
+++ b/src/tests/components/mascot-frenzy.test.tsx
@@ -13,7 +13,13 @@ vi.mock("@/lib/client-kv", () => ({
 }));
 vi.mock("@/lib/mascot-client", () => ({
   fetchUserName: () => Promise.resolve(null),
-  fetchPhraseSet: () => Promise.resolve({ phrases: null, snippets: [] }),
+  // Must resolve a REAL phrase set — the component reads `phrases.sass` on load.
+  // Dynamic-import the (unmocked) phrases module inside the factory so this
+  // survives vi.mock's hoisting above the top-level imports.
+  fetchPhraseSet: async () => ({
+    phrases: (await import("@/lib/mascot-phrases")).INSPIRATION_PHRASES,
+    snippets: [],
+  }),
   pickNameGreeting: () => "",
 }));
 

--- a/src/tests/components/mascot-frenzy.test.tsx
+++ b/src/tests/components/mascot-frenzy.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, act, waitFor, cleanup } from "@/tests/helpers/test-utils";
+import Mascot from "@/components/Mascot";
+
+// The mascot pulls its name/phrases over the network and reads persisted UI
+// state — stub both so the component mounts deterministically in jsdom.
+vi.mock("@/lib/i18n", () => ({ useT: () => ({ t: (k: string) => k, locale: "en" }) }));
+vi.mock("@/lib/client-kv", () => ({
+  get: () => null,
+  getJSON: () => null,
+  set: vi.fn(),
+  setJSON: vi.fn(),
+}));
+vi.mock("@/lib/mascot-client", () => ({
+  fetchUserName: () => Promise.resolve(null),
+  fetchPhraseSet: () => Promise.resolve({ phrases: null, snippets: [] }),
+  pickNameGreeting: () => "",
+}));
+
+// Drive `prefers-reduced-motion` per-test. matchMedia is consulted once on mount.
+let reduceMotion = false;
+function installMatchMedia() {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("prefers-reduced-motion") ? reduceMotion : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  })) as unknown as typeof window.matchMedia;
+}
+
+describe("Mascot frenzy — reduced-motion / freeze gating", () => {
+  beforeEach(() => {
+    reduceMotion = false;
+    installMatchMedia();
+    // Neutralize the self-scheduling frenzy walk loop so it can't spin in jsdom;
+    // the frenzy *state* (which the accessibility gate controls) is set
+    // synchronously and independently of the rAF loop.
+    vi.stubGlobal("requestAnimationFrame", () => 1 as unknown as number);
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  function fireNewOrder() {
+    act(() => {
+      window.dispatchEvent(new Event("clawbox-new-order"));
+    });
+  }
+
+  it("does NOT enter frenzy on a new order when prefers-reduced-motion is set", async () => {
+    reduceMotion = true;
+    const { container } = render(<Mascot />);
+    // Let the mount effects (including the reduced-motion read) settle.
+    await waitFor(() => expect(container.querySelector("img")).toBeTruthy());
+
+    fireNewOrder();
+
+    // The frenzy block never renders — the crab holds still for a
+    // vestibular-sensitive user even though an order arrived.
+    expect(container.querySelector('[data-frenzy="1"]')).toBeNull();
+  });
+
+  it("starts a frenzy normally, then cancels it when the crab freezes", async () => {
+    const { container, rerender } = render(<Mascot frozen={false} />);
+    await waitFor(() => expect(container.querySelector("img")).toBeTruthy());
+
+    fireNewOrder();
+    // Motion allowed → frenzy is live.
+    await waitFor(() => expect(container.querySelector('[data-frenzy="1"]')).not.toBeNull());
+
+    // Freezing mid-frenzy (e.g. chat opens) must tear the frenzy down, not just
+    // block future ones.
+    act(() => rerender(<Mascot frozen={true} />));
+    await waitFor(() => expect(container.querySelector('[data-frenzy="1"]')).toBeNull());
+  });
+});


### PR DESCRIPTION
## Desktop & setup animation polish

Smooths out the setup wizard and desktop animations, fixes a mascot bug, and adds the missing
`prefers-reduced-motion` support — from a 3-agent animation audit of ~110 animations across the wizard,
window manager, and mascot/chat surfaces.

### Fixes
- **Reduced-motion support (was entirely absent — WCAG 2.3.3).** Added a global
  `@media (prefers-reduced-motion: reduce)` guard in `globals.css` that collapses infinite decorative
  loops, and a JS gate on the mascot's rAF movement loop (it's not a CSS keyframe, so the guard alone
  wouldn't stop the crab walking) — reusing the existing `frozen` pause.
- **Dropped per-frame `filter` repaints (Jetson iGPU jank).** The welcome hero's `animate-welcome-powerup`
  now keeps a *static* glow and animates only the compositor-friendly transform; `ChatPopup`'s
  `clawChatBurstIn` entrance is transform+opacity only (dropped the per-frame `blur`/`brightness`/
  `drop-shadow`), with `willChange` trimmed to match.
- **Bug: mascot speech-bubble flicker.** `Mascot.say()` stored no timer, so an older bubble's timeout could
  blank a newer bubble early (and fire after unmount). Now stored + cleared per call and on unmount.
- **`ProgressBar` micro-CLS.** The active step badge animated `w/h` (reflowing the sticky header on every
  step); now a fixed size emphasised via `transform: scale`, with scoped transitions.
- **Spinner consistency.** The custom `.spinner` (0.6s) now matches Tailwind's `animate-spin` (1s) so the
  two spinner systems that appear together in the wizard rotate at the same speed.

### Notes
No behavior changes beyond animation; no new dependencies. Property discipline was already good
(transform/opacity) — this closes the reduced-motion gap and the few per-frame `filter` hot spots that
mattered most on the Jetson. Follow-ups (deferred, not in this PR): the `ChromeWindow` drag/resize
rAF+transform refactor and a handful of missing enter/exit transitions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added reduced-motion support to minimize animations, pause mascot movement, and disable smooth scrolling.
  * Mascot frenzy now stops when motion is reduced or the mascot is frozen.

* **Bug Fixes**
  * Improved mascot speech timer cleanup to prevent stale updates.
  * Refined popup, progress bar, and welcome animations for smoother performance.

* **Visual Improvements**
  * Updated loading spinner timing and progress step badge sizing.
  * Preserved the welcome animation glow while improving motion rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->