### PR TITLE
fix(security): harden local WS/proxy auth, secret file modes, and agent egress

### DIFF
--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -14,7 +14,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { spawn, spawnSync, type ChildProcess } from "child_process";
 import type { Dirent } from "fs";
-import { readFileSync } from "fs";
+import { readFileSync, realpathSync } from "fs";
 import { readFile as fsReadFile, writeFile as fsWriteFile, readdir, stat, mkdir, unlink } from "fs/promises";
 import { resolve, relative, dirname, extname, join, basename } from "path";
 import net from "net";
@@ -54,16 +54,21 @@ function isPrivateIp(ip: string): boolean {
     if (p[0] === 172 && p[1] >= 16 && p[1] <= 31) return true;
     if (p[0] === 192 && p[1] === 168) return true;
     if (p[0] === 169 && p[1] === 254) return true; // link-local / cloud metadata
+    if (p[0] === 100 && p[1] >= 64 && p[1] <= 127) return true; // 100.64/10 CGNAT
     if (p[0] >= 224) return true; // multicast / reserved
     return false;
   }
   const lc = ip.toLowerCase();
   if (lc === "::1" || lc === "::") return true;
-  if (lc.startsWith("fe80")) return true; // link-local
-  if (lc.startsWith("fc") || lc.startsWith("fd")) return true; // unique-local
+  if (/^fe[89ab]/.test(lc)) return true; // fe80::/10 link-local (fe80–febf)
+  if (lc.startsWith("fc") || lc.startsWith("fd")) return true; // fc00::/7 unique-local
+  if (lc.startsWith("ff")) return true; // ff00::/8 multicast
   if (lc.startsWith("::ffff:")) return isPrivateIp(lc.slice(7)); // IPv4-mapped
   return false;
 }
+
+// Auth-bearing headers that must not follow a redirect to a different origin.
+const SENSITIVE_HEADERS = ["authorization", "cookie", "proxy-authorization"];
 
 /** Reject a host that is an internal IP or resolves to one. */
 async function assertPublicHost(hostname: string): Promise<void> {
@@ -90,12 +95,24 @@ async function assertPublicHost(hostname: string): Promise<void> {
  * accepted here — closing it fully needs IP-pinned connects.)
  */
 async function safeFetch(url: string, init: RequestInit, maxRedirects = 5): Promise<Response> {
-  let current = url;
+  let currentUrl = new URL(url);
+  // Normalize headers up front so we can strip auth on cross-origin redirects.
+  const headers = new Headers(init.headers);
   for (let i = 0; i <= maxRedirects; i++) {
-    await assertPublicHost(new URL(current).hostname);
-    const res = await fetch(current, { ...init, redirect: "manual" });
-    if (res.status >= 300 && res.status < 400 && res.headers.get("location")) {
-      current = new URL(res.headers.get("location")!, current).toString();
+    if (currentUrl.protocol !== "http:" && currentUrl.protocol !== "https:") {
+      throw new Error(`blocked redirect scheme: ${currentUrl.protocol}`);
+    }
+    await assertPublicHost(currentUrl.hostname);
+    const res = await fetch(currentUrl, { ...init, headers, redirect: "manual" });
+    const location = res.headers.get("location");
+    if (res.status >= 300 && res.status < 400 && location) {
+      const next = new URL(location, currentUrl);
+      // Don't leak credentials across origins: drop auth headers when the
+      // scheme/host/port changes (matches browser + undici redirect behavior).
+      if (next.origin !== currentUrl.origin) {
+        for (const h of SENSITIVE_HEADERS) headers.delete(h);
+      }
+      currentUrl = next;
       continue;
     }
     return res;
@@ -491,6 +508,31 @@ function isSecretPath(absPath: string): boolean {
   return false;
 }
 
+// Single chokepoint the read/write/edit file tools share (was duplicated inline
+// at three sites). A path is blocked if it — or, after resolving symlinks, its
+// real target — is a device node, /proc/self, or a secret store. The realpath
+// pass defeats symlink escapes (CWE-59): a benignly-named link pointing at
+// ~/.ssh or auth-profiles.json would otherwise sail past the literal-path denylist.
+function isBlockedPath(absPath: string): boolean {
+  const hit = (p: string) =>
+    BLOCKED_PATHS.has(p) || p.startsWith("/dev/") || p.startsWith("/proc/self/") || isSecretPath(p);
+  if (hit(absPath)) return true;
+  try {
+    const real = realpathSync(absPath);
+    return real !== absPath && hit(real);
+  } catch {
+    // Leaf doesn't exist yet (e.g. a fresh write target). Resolve the parent
+    // dir instead so a symlinked ancestor can't smuggle a write into a secret
+    // location; the literal-path check above already covered the leaf name.
+    try {
+      const real = join(realpathSync(dirname(absPath)), basename(absPath));
+      return real !== absPath && hit(real);
+    } catch {
+      return false;
+    }
+  }
+}
+
 function isImageFile(p: string): boolean { return IMAGE_EXTS.has(extname(p).toLowerCase()); }
 function isBinaryFile(p: string): boolean { return BINARY_EXTS.has(extname(p).toLowerCase()); }
 function isPdfFile(p: string): boolean { return extname(p).toLowerCase() === ".pdf"; }
@@ -799,8 +841,8 @@ Usage:
   async ({ file_path, offset, limit }) => {
     const absPath = resolvePath(file_path);
 
-    // Blocked device paths
-    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/") || isSecretPath(absPath)) {
+    // Blocked device paths / secret stores (incl. symlink escapes)
+    if (isBlockedPath(absPath)) {
       return { content: [{ type: "text", text: `Cannot read device path: ${file_path}` }], isError: true };
     }
 
@@ -916,8 +958,8 @@ IMPORTANT:
   async ({ file_path, content }) => {
     const absPath = resolvePath(file_path);
 
-    // Blocked device paths
-    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/") || isSecretPath(absPath)) {
+    // Blocked device paths / secret stores (incl. symlink escapes)
+    if (isBlockedPath(absPath)) {
       return { content: [{ type: "text", text: `Cannot write to device path: ${file_path}` }], isError: true };
     }
 
@@ -988,8 +1030,8 @@ RULES:
 
     const absPath = resolvePath(file_path);
 
-    // Blocked device paths
-    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/") || isSecretPath(absPath)) {
+    // Blocked device paths / secret stores (incl. symlink escapes)
+    if (isBlockedPath(absPath)) {
       return { content: [{ type: "text", text: `Cannot edit device path: ${file_path}` }], isError: true };
     }
 

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -17,6 +17,8 @@ import type { Dirent } from "fs";
 import { readFileSync } from "fs";
 import { readFile as fsReadFile, writeFile as fsWriteFile, readdir, stat, mkdir, unlink } from "fs/promises";
 import { resolve, relative, dirname, extname, join, basename } from "path";
+import net from "net";
+import { lookup as dnsLookup } from "dns/promises";
 
 // ══════════════════════════════════════════════════════════════════════
 // CONSTANTS
@@ -38,6 +40,68 @@ const MAX_COMMAND_TIMEOUT = 600_000;
 const AUTO_BG_TIMEOUT = 15_000;
 const UI_PICKUP_DELAY_MS = 2500;
 const DEFAULT_READ_LIMIT = 2000;
+
+// ══════════════════════════════════════════════════════════════════════
+// SSRF GUARD (SEC-5): keep web_fetch off the box's own internal services.
+// Without this the agent — steerable by any page it reads — could pivot to
+// the loopback gateway API, Ollama, CDP, VNC, or cloud metadata (169.254).
+// ══════════════════════════════════════════════════════════════════════
+
+function isPrivateIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const p = ip.split(".").map(Number);
+    if (p[0] === 127 || p[0] === 10 || p[0] === 0) return true;
+    if (p[0] === 172 && p[1] >= 16 && p[1] <= 31) return true;
+    if (p[0] === 192 && p[1] === 168) return true;
+    if (p[0] === 169 && p[1] === 254) return true; // link-local / cloud metadata
+    if (p[0] >= 224) return true; // multicast / reserved
+    return false;
+  }
+  const lc = ip.toLowerCase();
+  if (lc === "::1" || lc === "::") return true;
+  if (lc.startsWith("fe80")) return true; // link-local
+  if (lc.startsWith("fc") || lc.startsWith("fd")) return true; // unique-local
+  if (lc.startsWith("::ffff:")) return isPrivateIp(lc.slice(7)); // IPv4-mapped
+  return false;
+}
+
+/** Reject a host that is an internal IP or resolves to one. */
+async function assertPublicHost(hostname: string): Promise<void> {
+  const host = hostname.replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+  if (net.isIP(host)) {
+    if (isPrivateIp(host)) throw new Error(`blocked internal address: ${host}`);
+    return;
+  }
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    throw new Error(`blocked internal host: ${host}`);
+  }
+  const results = await dnsLookup(host, { all: true });
+  for (const r of results) {
+    if (isPrivateIp(r.address)) {
+      throw new Error(`blocked host ${host} → internal ${r.address}`);
+    }
+  }
+}
+
+/**
+ * fetch() with SSRF protection: validate the host on every hop and follow
+ * redirects manually so a 3xx to an internal target can't slip past the
+ * initial check. (Residual TOCTOU DNS-rebind between lookup and connect is
+ * accepted here — closing it fully needs IP-pinned connects.)
+ */
+async function safeFetch(url: string, init: RequestInit, maxRedirects = 5): Promise<Response> {
+  let current = url;
+  for (let i = 0; i <= maxRedirects; i++) {
+    await assertPublicHost(new URL(current).hostname);
+    const res = await fetch(current, { ...init, redirect: "manual" });
+    if (res.status >= 300 && res.status < 400 && res.headers.get("location")) {
+      current = new URL(res.headers.get("location")!, current).toString();
+      continue;
+    }
+    return res;
+  }
+  throw new Error("too many redirects");
+}
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 const GLOB_RESULT_LIMIT = 200;
 const GREP_RESULT_LIMIT = 250;
@@ -406,6 +470,27 @@ const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".
 const BINARY_EXTS = new Set([".zip", ".tar", ".gz", ".bz2", ".7z", ".rar", ".bin", ".exe", ".so", ".dylib", ".o", ".a", ".wasm", ".pyc", ".class", ".pdf"]);
 const BLOCKED_PATHS = new Set(["/dev/zero", "/dev/null", "/dev/random", "/dev/urandom", "/dev/stdin", "/dev/stdout", "/dev/stderr", "/dev/tty", "/dev/console", "/proc/self/mem"]);
 
+// SEC-10: keep the agent's file tools off the device's own credential stores.
+// The agent legitimately edits its workspace (~/.openclaw/workspace) and code,
+// so this denies the specific secret files, not ~/.openclaw wholesale.
+const MCP_DATA_DIR = join(DEFAULT_CWD, "data");
+const SECRET_PATH_RES: RegExp[] = [
+  /(^|\/)\.ssh(\/|$)/,
+  /(^|\/)\.codex\/auth\.json$/,
+  /(^|\/)\.openclaw\/openclaw\.json(\.bak.*)?$/,
+  /(^|\/)auth-profiles\.json$/,
+  /(^|\/)\.openclaw\/agents\/[^/]+\/agent\/[^/]*\.sqlite$/,
+  /(^|\/)\.openclaw\/credentials(\/|$)/,
+  /\/proc\/\d+\/environ$/,
+];
+function isSecretPath(absPath: string): boolean {
+  if (SECRET_PATH_RES.some((re) => re.test(absPath))) return true;
+  for (const name of [".session-secret", ".mcp-token", ".local-ai-token", "config.json", "kv.json"]) {
+    if (absPath === join(MCP_DATA_DIR, name)) return true;
+  }
+  return false;
+}
+
 function isImageFile(p: string): boolean { return IMAGE_EXTS.has(extname(p).toLowerCase()); }
 function isBinaryFile(p: string): boolean { return BINARY_EXTS.has(extname(p).toLowerCase()); }
 function isPdfFile(p: string): boolean { return extname(p).toLowerCase() === ".pdf"; }
@@ -715,7 +800,7 @@ Usage:
     const absPath = resolvePath(file_path);
 
     // Blocked device paths
-    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/")) {
+    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/") || isSecretPath(absPath)) {
       return { content: [{ type: "text", text: `Cannot read device path: ${file_path}` }], isError: true };
     }
 
@@ -832,7 +917,7 @@ IMPORTANT:
     const absPath = resolvePath(file_path);
 
     // Blocked device paths
-    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/")) {
+    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/") || isSecretPath(absPath)) {
       return { content: [{ type: "text", text: `Cannot write to device path: ${file_path}` }], isError: true };
     }
 
@@ -904,7 +989,7 @@ RULES:
     const absPath = resolvePath(file_path);
 
     // Blocked device paths
-    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/")) {
+    if (BLOCKED_PATHS.has(absPath) || absPath.startsWith("/dev/") || absPath.startsWith("/proc/self/") || isSecretPath(absPath)) {
       return { content: [{ type: "text", text: `Cannot edit device path: ${file_path}` }], isError: true };
     }
 
@@ -1200,9 +1285,10 @@ If the URL redirects to a different host, a warning is shown.`,
       const extraHeaders = headers ? JSON.parse(headers) : {};
       const originalHost = new URL(url).hostname;
 
-      const res = await fetch(url, {
+      // safeFetch (SEC-5) validates the host on every redirect hop, blocking
+      // loopback/RFC1918/link-local/metadata targets.
+      const res = await safeFetch(url, {
         headers: { "User-Agent": "ClawBox/3.0 (MCP Agent)", "Accept": "text/html,application/xhtml+xml,application/json,text/plain,*/*", ...extraHeaders },
-        redirect: "follow",
         signal: AbortSignal.timeout(15_000),
       });
 

--- a/production-server.js
+++ b/production-server.js
@@ -50,17 +50,20 @@ function resolveUpgradeTarget(reqUrl) {
 // base64url payload carries { exp }). Mirrored here in CJS because upgrades
 // bypass Next.js. Fails closed when the secret is absent.
 function hasValidSession(req) {
-  const secret = process.env.SESSION_SECRET;
-  if (!secret) return false;
-  const m = /(?:^|;\s*)clawbox_session=([^;]+)/.exec(req.headers.cookie || "");
-  if (!m) return false;
-  const cookie = decodeURIComponent(m[1]);
-  const dot = cookie.indexOf(".");
-  if (dot < 0) return false;
-  const payload = cookie.slice(0, dot);
-  const sig = cookie.slice(dot + 1);
-  if (!payload || !sig) return false;
+  // Fails closed on ANY error. This runs inside the 'upgrade' listener, so an
+  // uncaught throw here (e.g. `decodeURIComponent` on a malformed `%` cookie)
+  // would crash the whole server — hence the single all-encompassing try.
   try {
+    const secret = process.env.SESSION_SECRET;
+    if (!secret) return false;
+    const m = /(?:^|;\s*)clawbox_session=([^;]+)/.exec(req.headers.cookie || "");
+    if (!m) return false;
+    const cookie = decodeURIComponent(m[1]);
+    const dot = cookie.indexOf(".");
+    if (dot < 0) return false;
+    const payload = cookie.slice(0, dot);
+    const sig = cookie.slice(dot + 1);
+    if (!payload || !sig) return false;
     const expected = require("crypto").createHmac("sha256", secret).update(payload).digest("hex");
     const sigBuf = Buffer.from(sig);
     const expBuf = Buffer.from(expected);
@@ -225,7 +228,7 @@ function startHttpsServer(httpServer) {
         return rejectUpgrade(socket);
       }
       wss.handleUpgrade(req, socket, head, (clientWs) => {
-        const { targetPort, url } = resolveUpgradeTarget(req.url || "/");
+        const { targetPort, url } = gate;
         const upstreamUrl = `ws://127.0.0.1:${targetPort}${url}`;
         const upstream = new WebSocket(upstreamUrl, {
           headers: {

--- a/production-server.js
+++ b/production-server.js
@@ -45,9 +45,32 @@ function resolveUpgradeTarget(reqUrl) {
   return { targetPort: GATEWAY_PORT, url: reqUrl, requireAuth: false };
 }
 
+// Current session generation, read from data/config.json (mtime-cached), so WS
+// upgrades honor the same password-change revocation the Next.js middleware
+// enforces (src/middleware.ts). Without this, a cookie revoked by a password
+// change would still be accepted at the /terminal-ws (root shell) and /novnc-ws
+// gates until natural expiry. Defaults to 0 on any read error / missing field.
+const CONFIG_JSON_PATH = path.join(process.env.CLAWBOX_ROOT || __dirname, "data", "config.json");
+let sessionGenCache = null;
+function readSessionGeneration() {
+  try {
+    const stat = fs.statSync(CONFIG_JSON_PATH);
+    if (sessionGenCache && sessionGenCache.mtimeMs === stat.mtimeMs) return sessionGenCache.value;
+    const parsed = JSON.parse(fs.readFileSync(CONFIG_JSON_PATH, "utf-8"));
+    const value = typeof parsed.session_generation === "number" && Number.isFinite(parsed.session_generation)
+      ? parsed.session_generation
+      : 0;
+    sessionGenCache = { mtimeMs: stat.mtimeMs, value };
+    return value;
+  } catch {
+    sessionGenCache = { mtimeMs: -1, value: 0 };
+    return 0;
+  }
+}
+
 // Verify the HMAC-SHA256 `clawbox_session` cookie — the same scheme
 // src/middleware.ts uses (payload.sig; sig = HMAC-SHA256(payload, SESSION_SECRET);
-// base64url payload carries { exp }). Mirrored here in CJS because upgrades
+// base64url payload carries { exp, gen }). Mirrored here in CJS because upgrades
 // bypass Next.js. Fails closed when the secret is absent.
 function hasValidSession(req) {
   // Fails closed on ANY error. This runs inside the 'upgrade' listener, so an
@@ -71,7 +94,10 @@ function hasValidSession(req) {
     if (!require("crypto").timingSafeEqual(sigBuf, expBuf)) return false;
     const decoded = Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
     const data = JSON.parse(decoded);
-    return typeof data.exp === "number" && data.exp > Math.floor(Date.now() / 1000);
+    if (typeof data.exp !== "number" || data.exp <= Math.floor(Date.now() / 1000)) return false;
+    // Reject cookies from before the last password change (session revocation).
+    if ((typeof data.gen === "number" ? data.gen : 0) !== readSessionGeneration()) return false;
+    return true;
   } catch {
     return false;
   }

--- a/production-server.js
+++ b/production-server.js
@@ -21,9 +21,14 @@ const IS_DEV = process.env.NODE_ENV === "development";
 //
 //   /terminal-ws  → xterm/PTY WebSocket (scripts/terminal-server.ts)
 //   /novnc-ws     → noVNC / websockify for the remote desktop app
+// `requireAuth` gates the raw single-service sockets (terminal PTY, noVNC) on a
+// valid ClawBox session cookie. WebSocket upgrades never pass through Next.js
+// middleware, so without this check any LAN client could reach the unauth PTY /
+// VNC services straight through the port-80 proxy (SEC-1). The gateway route
+// (default) is intentionally NOT gated here — it enforces its own auth token.
 const UPGRADE_ROUTES = [
-  { prefix: "/terminal-ws", targetPort: TERMINAL_WS_PORT, stripPrefix: true },
-  { prefix: "/novnc-ws", targetPort: NOVNC_WS_PORT, stripPrefix: true },
+  { prefix: "/terminal-ws", targetPort: TERMINAL_WS_PORT, stripPrefix: true, requireAuth: true },
+  { prefix: "/novnc-ws", targetPort: NOVNC_WS_PORT, stripPrefix: true, requireAuth: true },
 ];
 
 function resolveUpgradeTarget(reqUrl) {
@@ -34,10 +39,48 @@ function resolveUpgradeTarget(reqUrl) {
       const rewritten = r.stripPrefix
         ? (!stripped || stripped.startsWith("?") ? `/${stripped}` : stripped)
         : reqUrl;
-      return { targetPort: r.targetPort, url: rewritten };
+      return { targetPort: r.targetPort, url: rewritten, requireAuth: !!r.requireAuth };
     }
   }
-  return { targetPort: GATEWAY_PORT, url: reqUrl };
+  return { targetPort: GATEWAY_PORT, url: reqUrl, requireAuth: false };
+}
+
+// Verify the HMAC-SHA256 `clawbox_session` cookie — the same scheme
+// src/middleware.ts uses (payload.sig; sig = HMAC-SHA256(payload, SESSION_SECRET);
+// base64url payload carries { exp }). Mirrored here in CJS because upgrades
+// bypass Next.js. Fails closed when the secret is absent.
+function hasValidSession(req) {
+  const secret = process.env.SESSION_SECRET;
+  if (!secret) return false;
+  const m = /(?:^|;\s*)clawbox_session=([^;]+)/.exec(req.headers.cookie || "");
+  if (!m) return false;
+  const cookie = decodeURIComponent(m[1]);
+  const dot = cookie.indexOf(".");
+  if (dot < 0) return false;
+  const payload = cookie.slice(0, dot);
+  const sig = cookie.slice(dot + 1);
+  if (!payload || !sig) return false;
+  try {
+    const expected = require("crypto").createHmac("sha256", secret).update(payload).digest("hex");
+    const sigBuf = Buffer.from(sig);
+    const expBuf = Buffer.from(expected);
+    if (sigBuf.length !== expBuf.length) return false;
+    if (!require("crypto").timingSafeEqual(sigBuf, expBuf)) return false;
+    const decoded = Buffer.from(payload.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    const data = JSON.parse(decoded);
+    return typeof data.exp === "number" && data.exp > Math.floor(Date.now() / 1000);
+  } catch {
+    return false;
+  }
+}
+
+function rejectUpgrade(socket) {
+  try {
+    socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+  } catch {
+    // socket already gone
+  }
+  socket.destroy();
 }
 
 // ─── Session secret ───
@@ -122,7 +165,10 @@ try {
 // to 127.0.0.1:<port> since upstream does need the port for Host routing.
 function attachUpgradeProxy(server) {
   server.on("upgrade", (req, socket, head) => {
-    const { targetPort, url } = resolveUpgradeTarget(req.url);
+    const { targetPort, url, requireAuth } = resolveUpgradeTarget(req.url);
+    if (requireAuth && !hasValidSession(req)) {
+      return rejectUpgrade(socket);
+    }
     const upstream = net.connect(targetPort, "127.0.0.1", () => {
       const hostHeader = `127.0.0.1:${targetPort}`;
       const originHeader = "http://127.0.0.1";
@@ -174,6 +220,10 @@ function startHttpsServer(httpServer) {
     const wss = new WebSocket.Server({ noServer: true });
 
     httpsServer.on("upgrade", (req, socket, head) => {
+      const gate = resolveUpgradeTarget(req.url || "/");
+      if (gate.requireAuth && !hasValidSession(req)) {
+        return rejectUpgrade(socket);
+      }
       wss.handleUpgrade(req, socket, head, (clientWs) => {
         const { targetPort, url } = resolveUpgradeTarget(req.url || "/");
         const upstreamUrl = `ws://127.0.0.1:${targetPort}${url}`;

--- a/scripts/terminal-server.ts
+++ b/scripts/terminal-server.ts
@@ -115,8 +115,12 @@ wss.on("connection", (ws: WebSocket, req) => {
   });
 });
 
-server.listen(PORT, "0.0.0.0", () => {
-  console.log(`[terminal-server] Listening on ws://0.0.0.0:${PORT}`);
+// Bind loopback only. This PTY server spawns an unauthenticated shell per
+// connection, so it must never be reachable directly from the LAN (SEC-1).
+// The port-80 production-server proxy reaches it via 127.0.0.1 and enforces a
+// ClawBox session cookie on the /terminal-ws upgrade.
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`[terminal-server] Listening on ws://127.0.0.1:${PORT}`);
 });
 
 process.on("SIGTERM", () => {

--- a/src/app/setup-api/browser/route.ts
+++ b/src/app/setup-api/browser/route.ts
@@ -3,10 +3,58 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import net from "net";
+import { lookup as dnsLookup } from "dns/promises";
 
 const exec = promisify(execFile);
 const CDP_PORT = 18800;
 const CDP_ENDPOINT = `http://127.0.0.1:${CDP_PORT}`;
+
+// SEC-4: the automation browser must not be steerable to `file://` (local-file
+// exfil — the JSON response hands back a screenshot of whatever it renders) or
+// to the device's own internal services (SSRF). Restrict to http(s) and reject
+// hosts that are, or resolve to, loopback/private/link-local addresses.
+function isPrivateIp(ip: string): boolean {
+  if (net.isIPv4(ip)) {
+    const p = ip.split(".").map(Number);
+    if (p[0] === 127 || p[0] === 10 || p[0] === 0) return true;
+    if (p[0] === 172 && p[1] >= 16 && p[1] <= 31) return true;
+    if (p[0] === 192 && p[1] === 168) return true;
+    if (p[0] === 169 && p[1] === 254) return true;
+    if (p[0] >= 224) return true;
+    return false;
+  }
+  const lc = ip.toLowerCase();
+  if (lc === "::1" || lc === "::") return true;
+  if (lc.startsWith("fe80") || lc.startsWith("fc") || lc.startsWith("fd")) return true;
+  if (lc.startsWith("::ffff:")) return isPrivateIp(lc.slice(7));
+  return false;
+}
+
+/** Returns an error message if the URL is not safe to navigate to, else null. */
+async function validateNavUrl(url: string): Promise<string | null> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return "Invalid URL";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `Blocked URL scheme: ${parsed.protocol} (only http/https allowed)`;
+  }
+  const host = parsed.hostname.replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host.endsWith(".localhost")) return "Blocked internal host";
+  if (net.isIP(host)) {
+    return isPrivateIp(host) ? "Blocked internal address" : null;
+  }
+  try {
+    const results = await dnsLookup(host, { all: true });
+    if (results.some((r) => isPrivateIp(r.address))) return "Blocked internal address";
+  } catch {
+    return "Host did not resolve";
+  }
+  return null;
+}
 
 // Playwright key name mapping (browser KeyboardEvent.key → Playwright key names)
 const KEY_MAP: Record<string, string> = {
@@ -155,6 +203,8 @@ export async function POST(req: Request) {
 
       const { url } = body;
       if (url) {
+        const navErr = await validateNavUrl(url);
+        if (navErr) return NextResponse.json({ error: navErr }, { status: 400 });
         await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 }).catch(() => {});
       }
 
@@ -197,6 +247,8 @@ export async function POST(req: Request) {
       case "navigate": {
         const { url } = body;
         if (!url) return NextResponse.json({ error: "URL required" }, { status: 400 });
+        const navErr = await validateNavUrl(url);
+        if (navErr) return NextResponse.json({ error: navErr }, { status: 400 });
         await page.goto(url, { waitUntil: "domcontentloaded", timeout: 15000 }).catch(() => {});
         return NextResponse.json(await respond());
       }

--- a/src/app/setup-api/browser/route.ts
+++ b/src/app/setup-api/browser/route.ts
@@ -21,14 +21,34 @@ function isPrivateIp(ip: string): boolean {
     if (p[0] === 172 && p[1] >= 16 && p[1] <= 31) return true;
     if (p[0] === 192 && p[1] === 168) return true;
     if (p[0] === 169 && p[1] === 254) return true;
+    if (p[0] === 100 && p[1] >= 64 && p[1] <= 127) return true; // 100.64/10 CGNAT
     if (p[0] >= 224) return true;
     return false;
   }
   const lc = ip.toLowerCase();
   if (lc === "::1" || lc === "::") return true;
-  if (lc.startsWith("fe80") || lc.startsWith("fc") || lc.startsWith("fd")) return true;
+  // fe80::/10 link-local spans fe80–febf, not just the fe80 prefix; fc00::/7
+  // unique-local is fc/fd. ff00::/8 is multicast.
+  if (/^fe[89ab]/.test(lc) || lc.startsWith("fc") || lc.startsWith("fd") || lc.startsWith("ff")) return true;
   if (lc.startsWith("::ffff:")) return isPrivateIp(lc.slice(7));
   return false;
+}
+
+// getaddrinfo runs on the libuv threadpool (size 4 by default). A hostile or
+// dead resolver can hang each lookup for the OS timeout, and enough concurrent
+// nav requests would exhaust the pool and stall unrelated fs/crypto work. Cap
+// the wait so validateNavUrl fails closed instead of blocking indefinitely.
+const DNS_TIMEOUT_MS = 3000;
+async function lookupWithTimeout(host: string): Promise<{ address: string }[]> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error("DNS lookup timed out")), DNS_TIMEOUT_MS);
+  });
+  try {
+    return await Promise.race([dnsLookup(host, { all: true }), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }
 
 /** Returns an error message if the URL is not safe to navigate to, else null. */
@@ -48,7 +68,7 @@ async function validateNavUrl(url: string): Promise<string | null> {
     return isPrivateIp(host) ? "Blocked internal address" : null;
   }
   try {
-    const results = await dnsLookup(host, { all: true });
+    const results = await lookupWithTimeout(host);
     if (results.some((r) => isPrivateIp(r.address))) return "Blocked internal address";
   } catch {
     return "Host did not resolve";

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -20,7 +20,16 @@ function readConfig(): Record<string, unknown> {
 
 function writeConfig(data: Record<string, unknown>): void {
   fs.mkdirSync(DATA_DIR, { recursive: true });
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(data, null, 2));
+  // 0o600: config.json holds real secrets (clawai portal token, telegram bot
+  // token). writeFileSync only applies mode when *creating* the file, so an
+  // existing file left 0644 by an older build keeps its perms — re-harden
+  // explicitly, matching the auth-profiles/session-secret/mcp-token stores.
+  fs.writeFileSync(CONFIG_PATH, JSON.stringify(data, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(CONFIG_PATH, 0o600);
+  } catch {
+    // best-effort; a failed chmod must not break config writes
+  }
 }
 
 export async function get(key: string): Promise<unknown> {

--- a/src/lib/config-store.ts
+++ b/src/lib/config-store.ts
@@ -20,16 +20,20 @@ function readConfig(): Record<string, unknown> {
 
 function writeConfig(data: Record<string, unknown>): void {
   fs.mkdirSync(DATA_DIR, { recursive: true });
-  // 0o600: config.json holds real secrets (clawai portal token, telegram bot
-  // token). writeFileSync only applies mode when *creating* the file, so an
-  // existing file left 0644 by an older build keeps its perms — re-harden
-  // explicitly, matching the auth-profiles/session-secret/mcp-token stores.
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(data, null, 2), { mode: 0o600 });
+  // config.json holds real secrets (clawai portal token, telegram bot token).
+  // Write to a fresh temp file at 0o600 then atomically rename over the target,
+  // so the live config is never briefly world-readable (writeFileSync's `mode`
+  // is ignored when the destination already exists, e.g. a 0644 file from an
+  // older build). chmod the temp too, in case a stale temp survived a crash
+  // and pre-existed at 0644 (rename would then carry those perms across).
+  const tmp = CONFIG_PATH + ".tmp";
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
   try {
-    fs.chmodSync(CONFIG_PATH, 0o600);
+    fs.chmodSync(tmp, 0o600);
   } catch {
     // best-effort; a failed chmod must not break config writes
   }
+  fs.renameSync(tmp, CONFIG_PATH);
 }
 
 export async function get(key: string): Promise<unknown> {

--- a/src/lib/kv-store.ts
+++ b/src/lib/kv-store.ts
@@ -30,14 +30,16 @@ function writeKV(data: Record<string, string>): void {
   const tmp = KV_PATH + ".tmp";
   // 0o600: kv is an untyped string store (callers may stash anything), so it
   // should not default to world-readable. Written on the tmp file before the
-  // atomic rename so the final file is never briefly 0644.
+  // atomic rename so the final file is never briefly 0644. chmod the tmp too:
+  // writeFileSync's `mode` is ignored if a stale tmp survived a crash at 0644,
+  // and rename would otherwise carry those perms onto the live file.
   fs.writeFileSync(tmp, JSON.stringify(data), { mode: 0o600 });
-  fs.renameSync(tmp, KV_PATH);
   try {
-    fs.chmodSync(KV_PATH, 0o600);
+    fs.chmodSync(tmp, 0o600);
   } catch {
     // best-effort
   }
+  fs.renameSync(tmp, KV_PATH);
 }
 
 export function kvGet(key: string): string | null {

--- a/src/lib/kv-store.ts
+++ b/src/lib/kv-store.ts
@@ -28,8 +28,16 @@ function readKV(): Record<string, string> {
 function writeKV(data: Record<string, string>): void {
   ensureDir();
   const tmp = KV_PATH + ".tmp";
-  fs.writeFileSync(tmp, JSON.stringify(data));
+  // 0o600: kv is an untyped string store (callers may stash anything), so it
+  // should not default to world-readable. Written on the tmp file before the
+  // atomic rename so the final file is never briefly 0644.
+  fs.writeFileSync(tmp, JSON.stringify(data), { mode: 0o600 });
   fs.renameSync(tmp, KV_PATH);
+  try {
+    fs.chmodSync(KV_PATH, 0o600);
+  } catch {
+    // best-effort
+  }
 }
 
 export function kvGet(key: string): string | null {

--- a/src/tests/unit/kv-store.test.ts
+++ b/src/tests/unit/kv-store.test.ts
@@ -118,6 +118,30 @@ describe("kv-store", () => {
       writeFileSyncSpy.mockRestore();
       renameSyncSpy.mockRestore();
     });
+
+    // POSIX-only: mode bits are meaningless on Windows dev machines. CI runs on
+    // the Linux device, where these assertions are the ones that actually matter.
+    const posixOnly = process.platform === "win32" ? it.skip : it;
+
+    posixOnly("writes the live file at 0600 (verified via statSync)", () => {
+      kvStore.kvSet("secretish", "value");
+      const mode = fsSync.statSync(KV_PATH).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    posixOnly("re-hardens to 0600 even when a stale 0644 tmp pre-exists", () => {
+      // Simulate a tmp left behind by a crashed write at world-readable perms.
+      // writeFileSync's `mode` is ignored for an existing file, so without the
+      // explicit chmod-before-rename the stale perms would ride onto the live
+      // file. The final file must still land at 0600.
+      fsSync.writeFileSync(KV_PATH + ".tmp", "{}", { mode: 0o644 });
+      fsSync.chmodSync(KV_PATH + ".tmp", 0o644);
+
+      kvStore.kvSet("afterStaleTmp", "value");
+
+      const mode = fsSync.statSync(KV_PATH).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
   });
 
   describe("kvDelete", () => {

--- a/src/tests/unit/kv-store.test.ts
+++ b/src/tests/unit/kv-store.test.ts
@@ -105,10 +105,12 @@ describe("kv-store", () => {
 
       kvStore.kvSet("atomic", "test");
 
-      // Should write to .tmp file first
+      // Should write to .tmp file first, with a 0600 mode (secrets may be stashed
+      // in kv; the final file must not be world-readable).
       expect(writeFileSyncSpy).toHaveBeenCalledWith(
         KV_PATH + ".tmp",
         expect.any(String),
+        { mode: 0o600 },
       );
       // Then rename to the actual path
       expect(renameSyncSpy).toHaveBeenCalledWith(KV_PATH + ".tmp", KV_PATH);


### PR DESCRIPTION
## Harden local WS/proxy auth, secret file modes, and agent egress

A batch of defensive fixes to the on-device attack surface, found in a security pass over the setup-api /
gateway / MCP layers. Each was verified on a real Jetson.

### Changes
- **Terminal WebSocket now bound + authenticated.** `scripts/terminal-server.ts` binds `127.0.0.1` only
  (was `0.0.0.0`), and the port-80 upgrade proxy (`production-server.js`) requires a valid `clawbox_session`
  cookie on the `/terminal-ws` and `/novnc-ws` upgrades — WebSocket upgrades bypass Next middleware, so the
  check is enforced in the proxy. Verified: direct `:3006` is refused off-box, an un-authenticated
  `/terminal-ws` gets 401, and an authenticated upgrade still gets 101.
- **Secret files are 0600.** `config.json` and `kv.json` are written with mode `0o600` (+ an explicit
  re-`chmod` so an existing 0644 file is hardened), matching the auth-profiles / session-secret / mcp-token
  stores.
- **SSRF guards on agent egress.** The MCP `web_fetch` tool validates the target host on every redirect hop
  and blocks loopback / RFC1918 / link-local / metadata addresses; the browser-automation route restricts
  navigation to `http(s)` and non-internal hosts (blocks `file://` local-file reads and internal SSRF).
- **MCP file-tool containment.** `read_file` / `write_file` / `edit_file` deny the device's own credential
  stores (`.ssh`, `.openclaw` creds, the session/mcp/local-ai tokens, `config.json`, `/proc/<n>/environ`)
  while keeping the agent's workspace fully accessible.

### Notes
- No new dependencies. Test updated for the new `kv.json` mode. Build + full test suite green on-device.
- These are defense-in-depth hardening fixes; the terminal-WS change is the highest-impact one and is
  already deployed on the dev device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Blocked web requests to private, local, link-local, multicast, and cloud metadata addresses, including redirect destinations.
  - Prevented access to sensitive files and credential stores.
  - Added session authentication for terminal and noVNC connections.
  - Restricted browser navigation to safe HTTP(S) destinations.
  - Limited terminal service access to the local machine.
  - Protected configuration and key-value files with restrictive permissions and safer atomic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->