### PR TITLE
test: de-flake updater legacy-quarantine test

### DIFF
--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -396,10 +396,15 @@ describe("updater", () => {
       mockSet.mockResolvedValue();
       mockSetMany.mockResolvedValue();
       mockReadFile.mockRejectedValue(new Error("ENOENT"));
-      mockIsPortOpen
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+      // The gateway only "recovers" once the legacy-state quarantine has run.
+      // Tie the probe to that side-effect instead of a fixed false/false/true
+      // call sequence: waitForGateway polls in a loop (deadline/interval are 1ms
+      // in these tests), so the old sequence could be fully consumed by the very
+      // first poll — reporting recovery BEFORE quarantine ran and leaving no
+      // /bin/bash call to assert on. That made this test flaky (~1 in 3).
+      mockIsPortOpen.mockImplementation(async () =>
+        mockExecFile.mock.calls.some(([cmd]) => cmd === "/bin/bash"),
+      );
       updater = await import("@/lib/updater");
 
       updater.resetUpdateState();


### PR DESCRIPTION
## Problem

`updater.test.ts > "quarantines known legacy gateway blockers and completes when the gateway recovers"` fails intermittently (~1 in 3 runs) with:

```
AssertionError: expected undefined to deeply equal ArrayContaining [ "-lc", StringContaining "installs.json" ]
```

## Root cause

`waitForGateway()` polls `isPortOpen` in a `while (Date.now() < deadline)` loop, and these tests set `GATEWAY_HEALTH_WAIT_MS` / `GATEWAY_RECOVERY_WAIT_MS` / `GATEWAY_WAIT_INTERVAL_MS` all to `1`. The test drove recovery with a fixed call sequence:

```ts
mockIsPortOpen
  .mockResolvedValueOnce(false)
  .mockResolvedValueOnce(false)
  .mockResolvedValueOnce(true);
```

Because the poll deadline is ~1ms, the number of `isPortOpen` calls per `waitForGateway` invocation is timing-dependent. When the first poll loop happens to iterate more than once, it consumes the `true` **before** `quarantineLegacyOpenclawState()` runs — so the gateway "recovers" early, the `/bin/bash` quarantine step never executes, and there is no call for the assertion to find.

## Fix

Tie the probe to the actual quarantine side-effect instead of a fixed call count:

```ts
mockIsPortOpen.mockImplementation(async () =>
  mockExecFile.mock.calls.some(([cmd]) => cmd === "/bin/bash"),
);
```

Now the gateway reports "offline" until the quarantine bash step has run, guaranteeing quarantine executes before completion regardless of poll timing.

## Validation

Ran the updater suite **10× consecutively on-device** (Jetson) — 26/26 passed every time (previously ~1-in-3 failed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated gateway recovery coverage to detect recovery based on legacy-state quarantine behavior rather than a fixed port-probe sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->