### PR TITLE
security: harden the pre-authentication request surface

### DIFF
--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -19,8 +19,15 @@ export async function GET(request: NextRequest) {
       return gatewayOfflineResponse(await getGatewayServiceHealth());
     }
     let html = await res.text();
-    // Use the request hostname so WebSocket connects to the right address
-    const host = request.headers.get("host")?.replace(/:\d+$/, "") || "clawbox.local";
+    // Use the request hostname so WebSocket connects to the right address.
+    // The Host header is attacker-controllable and gets embedded in the inline
+    // <script> below, so only accept hostname / IP-literal characters — anything
+    // else (quotes, angle brackets) falls back to the mDNS name so it can't
+    // break out of the JS string context (reflected XSS).
+    const rawHost = request.headers.get("host")?.replace(/:\d+$/, "") || "";
+    const host = /^[A-Za-z0-9.-]+$/.test(rawHost) || /^\[[0-9a-fA-F:]+\]$/.test(rawHost)
+      ? rawHost
+      : "clawbox.local";
     const wsUrl = `ws://${host}:${GATEWAY_PORT}`;
     // Rewrite relative asset paths (./assets/... → /assets/...) so they
     // resolve through Next.js rewrites which proxy to the gateway.
@@ -29,7 +36,7 @@ export async function GET(request: NextRequest) {
     const autoConnect = `<script>
       (function(){
         var KEY="openclaw.control.settings.v1";
-        var wsUrl="${wsUrl}";
+        var wsUrl=${JSON.stringify(wsUrl)};
         try{
           var s=JSON.parse(localStorage.getItem(KEY)||"{}");
           s.url=wsUrl;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -107,6 +107,39 @@ const LOOPBACK_PROXY_PREFIXES = [
   "/setup-api/local-ai/ollama",
 ];
 
+// Sensitive /setup-api/* surfaces that must NEVER be reachable without a session
+// (or the MCP bearer) — not even during the pre-setup wizard window. These are
+// desktop-app / agent backends (file access, browser automation, the code
+// workspace, the remote-desktop bridge, and the gateway-token endpoints) with
+// no role in first-boot onboarding. The blanket pre-setup pass below used to
+// expose them unauthenticated while the open `ClawBox-Setup` AP was up, turning
+// otherwise-local issues into network-adjacent, pre-auth ones.
+const PRE_AUTH_SENSITIVE_PREFIXES = [
+  "/setup-api/files",
+  "/setup-api/browser",
+  "/setup-api/code",        // code workspace file ops / build (also /code/*)
+  "/setup-api/code-server",
+  "/setup-api/webapps",
+  "/setup-api/vnc",
+  "/setup-api/terminal",
+  "/setup-api/gateway/ws-config", // hands back the live gateway auth token
+];
+// Exact-match only: a bare `/setup-api/gateway` subtree deny would also catch
+// `/setup-api/gateway/health`, which the wizard's readiness check legitimately
+// polls before setup completes. The SPA proxy at the bare path injects the
+// gateway token into HTML, so it stays gated.
+const PRE_AUTH_SENSITIVE_EXACT = new Set([
+  "/setup-api/gateway",
+]);
+
+function isSensitiveSetupApi(pathname: string): boolean {
+  if (PRE_AUTH_SENSITIVE_EXACT.has(pathname)) return true;
+  for (const p of PRE_AUTH_SENSITIVE_PREFIXES) {
+    if (pathname === p || pathname.startsWith(p + "/")) return true;
+  }
+  return false;
+}
+
 const PUBLIC_EXACT = new Set([
   "/manifest.json",
   "/favicon.ico",
@@ -213,7 +246,12 @@ export async function middleware(request: NextRequest) {
   // run the updater, set the password, etc. Once setup completes the gate
   // closes and every /setup-api/* request requires a valid session.
   if (pathname.startsWith("/setup-api/") && !isSetupComplete()) {
-    return NextResponse.next();
+    // ...except the sensitive surfaces above, which stay gated even pre-setup
+    // (they play no part in onboarding). They fall through to the session /
+    // MCP-bearer checks below, so an authenticated caller still reaches them.
+    if (!isSensitiveSetupApi(pathname)) {
+      return NextResponse.next();
+    }
   }
 
   // 3b. Trusted-test-environment escape hatch for the e2e-install harness.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -122,6 +122,10 @@ const PRE_AUTH_SENSITIVE_PREFIXES = [
   "/setup-api/webapps",
   "/setup-api/vnc",
   "/setup-api/terminal",
+  "/setup-api/clawkeep",    // backup restore/encryption/pairing — data-injection surface
+  "/setup-api/tunnel",      // enabling remote tunnel access
+  "/setup-api/apps/install",
+  "/setup-api/apps/uninstall",
   "/setup-api/gateway/ws-config", // hands back the live gateway auth token
 ];
 // Exact-match only: a bare `/setup-api/gateway` subtree deny would also catch
@@ -133,9 +137,12 @@ const PRE_AUTH_SENSITIVE_EXACT = new Set([
 ]);
 
 function isSensitiveSetupApi(pathname: string): boolean {
-  if (PRE_AUTH_SENSITIVE_EXACT.has(pathname)) return true;
+  // Normalize a trailing slash so `/setup-api/gateway/` can't dodge the exact
+  // match (Next.js may not always redirect it before middleware runs).
+  const p0 = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  if (PRE_AUTH_SENSITIVE_EXACT.has(p0)) return true;
   for (const p of PRE_AUTH_SENSITIVE_PREFIXES) {
-    if (pathname === p || pathname.startsWith(p + "/")) return true;
+    if (p0 === p || p0.startsWith(p + "/")) return true;
   }
   return false;
 }

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -421,8 +421,13 @@ describe("middleware", () => {
       "/setup-api/webapps",
       "/setup-api/vnc/status",
       "/setup-api/terminal",
+      "/setup-api/clawkeep/restore",
+      "/setup-api/tunnel/enable",
+      "/setup-api/apps/install",
+      "/setup-api/apps/uninstall",
       "/setup-api/gateway/ws-config",
       "/setup-api/gateway",
+      "/setup-api/gateway/", // trailing slash must not dodge the exact match
     ])("gates sensitive %s during the setup window", async (p) => {
       process.env.SESSION_SECRET = "test-secret";
       vi.resetModules();

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -407,6 +407,59 @@ describe("middleware", () => {
     });
   });
 
+  describe("pre-auth sensitive-surface gate (setup window)", () => {
+    // SESSION_SECRET is provisioned but setup_complete is NOT yet written — the
+    // pre-setup wizard window. Sensitive desktop/agent backends must stay gated
+    // here (they play no part in onboarding), even though the wizard's own
+    // routes pass. Regression guard for the pre-auth reachability multiplier.
+    it.each([
+      "/setup-api/files/clawbox/data/.session-secret",
+      "/setup-api/files",
+      "/setup-api/browser/navigate",
+      "/setup-api/code/project/init",
+      "/setup-api/code-server/start",
+      "/setup-api/webapps",
+      "/setup-api/vnc/status",
+      "/setup-api/terminal",
+      "/setup-api/gateway/ws-config",
+      "/setup-api/gateway",
+    ])("gates sensitive %s during the setup window", async (p) => {
+      process.env.SESSION_SECRET = "test-secret";
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest(p));
+      // Falls through to the session gate → JSON 401 (no valid cookie).
+      expect(response.status).toBe(401);
+    });
+
+    it("still allows /setup-api/gateway/health during the setup window", async () => {
+      // The wizard polls gateway readiness before setup_complete is written, so
+      // health must stay open even though the sibling ws-config / SPA proxy are
+      // gated.
+      process.env.SESSION_SECRET = "test-secret";
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest("/setup-api/gateway/health"));
+      expect(response.status).toBe(200);
+    });
+
+    it("allows a sensitive route once a valid session is presented", async () => {
+      process.env.SESSION_SECRET = "test-secret";
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const req = new NextRequest(new URL("http://localhost/setup-api/files"), {
+        headers: {
+          cookie: `clawbox_session=${await createSignedSessionCookie(Math.floor(Date.now() / 1000) + 60)}`,
+        },
+      });
+      const response = await mod.middleware(req);
+      expect(response.status).toBe(200);
+    });
+  });
+
   describe("config export", () => {
     it("exports matcher config", async () => {
       const mod = await import("@/middleware");


### PR DESCRIPTION
Part of the ongoing security-hardening sweep (targeting `beta`).

**What this does** — narrows what is reachable before a session exists: several privileged `/setup-api/*` surfaces that play no part in first-boot onboarding are no longer served during the pre-setup window, while the wizard's own routes (including the gateway readiness check) keep working. Also hardens a reflected request-header sink by validating and encoding it before it reaches an inline script.

Authenticated callers and the MCP bearer path are unaffected — the gated routes simply fall through to the normal session checks.

**Validation** — build + full unit suite on the Jetson; new middleware coverage for the gate (sensitive routes blocked pre-setup, readiness route still open, valid session allowed) passes 59/59 in isolation. The one unrelated failure in the full run is the known `updater` timing flake (fixed separately in #332).

Vulnerability specifics intentionally omitted from this public description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Protected sensitive setup API routes with session or bearer authentication, including during initial setup.
  * Added validation for gateway host values and safe handling of generated WebSocket URLs.
* **Bug Fixes**
  * Kept gateway health checks accessible while requiring authentication for protected setup endpoints.
  * Added coverage for unauthenticated and authenticated access scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->