### PR TITLE
security: tighten Files API path containment

### DIFF
--- a/src/app/setup-api/files/[...path]/route.ts
+++ b/src/app/setup-api/files/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
+import { isProtectedFilePath } from "@/lib/file-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -18,6 +19,8 @@ function safePath(segments: string[]): string | null {
   const rel = segments.join("/");
   const resolved = path.resolve(BASE_DIR, rel);
   if (!resolved.startsWith(path.resolve(BASE_DIR) + path.sep) && resolved !== path.resolve(BASE_DIR)) return null;
+  // Browse root is $HOME → secret stores live inside the sandbox; deny them.
+  if (isProtectedFilePath(resolved)) return null;
   return resolved;
 }
 
@@ -62,6 +65,10 @@ export async function PUT(req: NextRequest, { params }: Params) {
   const newAbs = path.resolve(parentDir, body.newName);
   const base = path.resolve(BASE_DIR);
   if (newAbs !== base && !newAbs.startsWith(base + path.sep)) {
+    return NextResponse.json({ error: "Invalid destination" }, { status: 400 });
+  }
+  // Don't let a rename create/clobber a secret store name either.
+  if (isProtectedFilePath(newAbs)) {
     return NextResponse.json({ error: "Invalid destination" }, { status: 400 });
   }
   if (fs.existsSync(newAbs)) return NextResponse.json({ error: "Already exists" }, { status: 409 });

--- a/src/app/setup-api/files/route.ts
+++ b/src/app/setup-api/files/route.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import Busboy from "busboy";
+import { isProtectedFilePath } from "@/lib/file-guard";
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -32,6 +33,10 @@ function safePath(rel: string): string | null {
   // Require either an exact base match or a path inside base (with separator),
   // otherwise sibling dirs like "/home/clawboxmalicious" would slip through.
   if (resolved !== base && !resolved.startsWith(base + path.sep)) return null;
+  // The browse root is $HOME, so secret stores (.ssh, .openclaw, the data/
+  // tokens) sit inside the sandbox — deny them at the single resolve chokepoint
+  // that every read/write/rename/download path funnels through.
+  if (isProtectedFilePath(resolved)) return null;
   return resolved;
 }
 
@@ -71,6 +76,8 @@ async function searchTree(rootAbs: string, query: string, includeHidden: boolean
       if (!includeHidden && name.startsWith(".")) continue;
       const isDir = dirent.isDirectory();
       const full = path.join(dir, name);
+      // Never surface or descend into secret stores, even with ?hidden=1.
+      if (isProtectedFilePath(full)) continue;
       if (name.toLowerCase().includes(query)) {
         let size: number | null = null;
         let modified = "";
@@ -144,6 +151,8 @@ export async function GET(req: NextRequest) {
     .map((name) => {
       try {
         const fullPath = path.join(abs, name);
+        // Keep secret stores out of the listing entirely (not just un-openable).
+        if (isProtectedFilePath(fullPath)) return null;
         const s = fs.statSync(fullPath);
         return {
           name,

--- a/src/lib/file-guard.ts
+++ b/src/lib/file-guard.ts
@@ -1,0 +1,53 @@
+import path from "path";
+import fs from "fs";
+import { DATA_DIR } from "./config-store";
+
+// ── Files API secret guard ──────────────────────────────────────────────────
+//
+// The Files API browses the home directory, so its every secret store lives
+// *inside* the sandbox root — `..` containment alone doesn't protect them. This
+// denylist keeps credential/key material off the read, write, list, rename and
+// download paths (mirrors the MCP file-tool denylist). Matched against the
+// realpath'd path so an in-base symlink can't dodge the check (CWE-59).
+
+const PROTECTED_DIR_RES: RegExp[] = [
+  /(^|\/)\.ssh(\/|$)/,
+  /(^|\/)\.openclaw(\/|$)/,
+  /(^|\/)\.codex(\/|$)/,
+  /(^|\/)\.gnupg(\/|$)/,
+  /(^|\/)\.aws(\/|$)/,
+  /(^|\/)\.config\/(gcloud|gh)(\/|$)/,
+];
+
+// Exact secret files in the ClawBox data dir: the session-secret (forge cookies),
+// the service bearer tokens, and the config/kv stores that carry provider keys.
+const PROTECTED_FILES = new Set(
+  [".session-secret", ".mcp-token", ".local-ai-token", "config.json", "kv.json"]
+    .map((n) => path.join(DATA_DIR, n)),
+);
+
+function isProtected(abs: string): boolean {
+  if (PROTECTED_FILES.has(abs)) return true;
+  return PROTECTED_DIR_RES.some((re) => re.test(abs));
+}
+
+/**
+ * True if `abs` — or, after resolving symlinks, its real target — is a protected
+ * secret store. Callers should treat a `true` result as "not found / forbidden".
+ */
+export function isProtectedFilePath(abs: string): boolean {
+  if (isProtected(abs)) return true;
+  try {
+    const real = fs.realpathSync(abs);
+    return real !== abs && isProtected(real);
+  } catch {
+    // Path (or leaf) doesn't exist yet, e.g. an upload target — resolve the
+    // parent so a symlinked ancestor can't smuggle a write into a secret dir.
+    try {
+      const real = path.join(fs.realpathSync(path.dirname(abs)), path.basename(abs));
+      return real !== abs && isProtected(real);
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/lib/file-guard.ts
+++ b/src/lib/file-guard.ts
@@ -7,8 +7,10 @@ import { DATA_DIR } from "./config-store";
 // The Files API browses the home directory, so its every secret store lives
 // *inside* the sandbox root — `..` containment alone doesn't protect them. This
 // denylist keeps credential/key material off the read, write, list, rename and
-// download paths (mirrors the MCP file-tool denylist). Matched against the
-// realpath'd path so an in-base symlink can't dodge the check (CWE-59).
+// download paths. Matched against the realpath'd path so an in-base symlink
+// can't dodge the check (CWE-59). (realpath resolves symlinks, not hard links —
+// a hard link to a secret already needs read access to create, a separate
+// fuller-privilege surface.)
 
 const PROTECTED_DIR_RES: RegExp[] = [
   /(^|\/)\.ssh(\/|$)/,
@@ -16,7 +18,21 @@ const PROTECTED_DIR_RES: RegExp[] = [
   /(^|\/)\.codex(\/|$)/,
   /(^|\/)\.gnupg(\/|$)/,
   /(^|\/)\.aws(\/|$)/,
-  /(^|\/)\.config\/(gcloud|gh)(\/|$)/,
+  /(^|\/)\.kube(\/|$)/,
+  /(^|\/)\.docker(\/|$)/,
+  /(^|\/)\.config\/(gcloud|gh|rclone)(\/|$)/,
+];
+
+// Credential files matched by basename anywhere under the browse root — common
+// on a dev box (git/npm/pip/postgres tokens). Blocking the whole file is fine:
+// a file manager has no legitimate reason to surface a credential store.
+const PROTECTED_FILE_RES: RegExp[] = [
+  /(^|\/)\.netrc$/,
+  /(^|\/)\.npmrc$/,
+  /(^|\/)\.pypirc$/,
+  /(^|\/)\.pgpass$/,
+  /(^|\/)\.git-credentials$/,
+  /(^|\/)\.config\/git\/credentials$/,
 ];
 
 // Exact secret files in the ClawBox data dir: the session-secret (forge cookies),
@@ -28,6 +44,7 @@ const PROTECTED_FILES = new Set(
 
 function isProtected(abs: string): boolean {
   if (PROTECTED_FILES.has(abs)) return true;
+  if (PROTECTED_FILE_RES.some((re) => re.test(abs))) return true;
   return PROTECTED_DIR_RES.some((re) => re.test(abs));
 }
 

--- a/src/tests/unit/file-guard.test.ts
+++ b/src/tests/unit/file-guard.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, beforeAll, afterAll, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// file-guard reads DATA_DIR from config-store at import time, which resolves
+// from CLAWBOX_ROOT — set it before importing so the data-secret paths are
+// deterministic under a temp root.
+let TEST_ROOT: string;
+let DATA_DIR: string;
+let guard: typeof import("@/lib/file-guard");
+
+beforeAll(async () => {
+  TEST_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-fileguard-"));
+  process.env.CLAWBOX_ROOT = TEST_ROOT;
+  DATA_DIR = path.join(TEST_ROOT, "data");
+  fs.mkdirSync(DATA_DIR, { recursive: true });
+  guard = await import("@/lib/file-guard");
+});
+
+afterAll(() => {
+  delete process.env.CLAWBOX_ROOT;
+  fs.rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe("isProtectedFilePath", () => {
+  const home = "/home/clawbox";
+
+  it.each([
+    `${home}/.ssh/id_rsa`,
+    `${home}/.ssh`,
+    `${home}/.openclaw/openclaw.json`,
+    `${home}/.openclaw/agents/x/agent/y.sqlite`,
+    `${home}/.codex/auth.json`,
+    `${home}/.gnupg/secring.gpg`,
+    `${home}/.aws/credentials`,
+    `${home}/.config/gcloud/credentials.db`,
+    `${home}/.config/gh/hosts.yml`,
+  ])("flags credential store %s", (p) => {
+    expect(guard.isProtectedFilePath(p)).toBe(true);
+  });
+
+  it("flags the ClawBox data-dir secrets", () => {
+    for (const n of [".session-secret", ".mcp-token", ".local-ai-token", "config.json", "kv.json"]) {
+      expect(guard.isProtectedFilePath(path.join(DATA_DIR, n))).toBe(true);
+    }
+  });
+
+  it.each([
+    `${home}/Documents/notes.txt`,
+    `${home}/Downloads/photo.png`,
+    `${home}/Desktop/config.json`, // a config.json OUTSIDE the data dir is fine
+    `${home}/project/src/index.ts`,
+  ])("allows ordinary file %s", (p) => {
+    expect(guard.isProtectedFilePath(p)).toBe(false);
+  });
+
+  it("defeats an in-base symlink pointing at a secret dir (CWE-59)", () => {
+    // Real secret dir + an innocuously-named symlink to it. Resolving the link
+    // must still classify the target as protected.
+    const secretDir = path.join(TEST_ROOT, ".ssh");
+    fs.mkdirSync(secretDir, { recursive: true });
+    fs.writeFileSync(path.join(secretDir, "id_rsa"), "KEY");
+    const link = path.join(TEST_ROOT, "innocent-link");
+    try {
+      fs.symlinkSync(secretDir, link, "dir");
+    } catch {
+      // Some CI filesystems disallow symlinks — skip rather than fail.
+      return;
+    }
+    expect(guard.isProtectedFilePath(path.join(link, "id_rsa"))).toBe(true);
+  });
+});

--- a/src/tests/unit/file-guard.test.ts
+++ b/src/tests/unit/file-guard.test.ts
@@ -47,6 +47,30 @@ describe("isProtectedFilePath", () => {
   });
 
   it.each([
+    `${home}/.kube/config`,
+    `${home}/.docker/config.json`,
+    `${home}/.config/rclone/rclone.conf`,
+    `${home}/.netrc`,
+    `${home}/.npmrc`,
+    `${home}/.pypirc`,
+    `${home}/.pgpass`,
+    `${home}/.git-credentials`,
+    `${home}/.config/git/credentials`,
+  ])("flags dev-box credential store %s", (p) => {
+    expect(guard.isProtectedFilePath(p)).toBe(true);
+  });
+
+  it.each([
+    `${home}/notopenclaw/file.txt`,   // .openclaw pattern must not match without the dot
+    `${home}/my.openclaw-backup/x`,   // trailing char is '-', not '/'
+    `${home}/.ssh-notes.txt`,         // .ssh must be a full segment
+    `${home}/.config/git/config`,     // gitconfig is NOT the credential file
+    `${home}/project/.npmrc.example`, // basename must match exactly
+  ])("does NOT over-block %s", (p) => {
+    expect(guard.isProtectedFilePath(p)).toBe(false);
+  });
+
+  it.each([
     `${home}/Documents/notes.txt`,
     `${home}/Downloads/photo.png`,
     `${home}/Desktop/config.json`, // a config.json OUTSIDE the data dir is fine


### PR DESCRIPTION
Part of the ongoing security-hardening sweep (targeting `beta`).

**What this does** — the file-management API browses the home directory, so sensitive stores live inside its sandbox and path-containment alone doesn't protect them. Adds a shared, realpath-based guard applied at the single path-resolution chokepoint plus the directory listing and recursive search, so credential/token stores can't be listed, read, downloaded, renamed, or written through the API. The realpath step also closes an in-sandbox symlink escape.

**Validation** — build + targeted unit tests on the Jetson (new `file-guard` suite covering credential stores, ordinary files, the data-dir secrets, and a symlink-escape case; middleware suite green). The one unrelated failure in a full run is the known `updater` timing flake (fixed separately in #332).

Vulnerability specifics intentionally omitted from this public description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Protected credential and sensitive application data from access through file browsing, searching, path resolution, and renaming.
  - Blocked indirect access to protected locations through symbolic links.
  - Excluded protected entries from directory listings and recursive searches.
  - Protected files and directories are now unavailable through supported file-management features.

- **Tests**
  - Added coverage for protected paths, regular files, near-matching paths, and symbolic-link scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->