### PR TITLE
security: scope the package-manager sudo grant to exact commands

### DIFF
--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -59,8 +59,15 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block *
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start clawbox-root-update@*.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff
-clawbox ALL=(root) NOPASSWD: /usr/bin/apt-get update *
-clawbox ALL=(root) NOPASSWD: /usr/bin/apt-get install *
+# apt is granted ONLY for the exact commands the Browser-app chromium recovery
+# runs (src/app/setup-api/browser/manage/route.ts). Exact-match Cmnd specs (no
+# trailing wildcard) are deliberate: a wildcard here let any clawbox-level
+# foothold escalate to root via `apt-get ... -o APT::Update::Pre-Invoke=<cmd>`
+# (SEC-2). install.sh's other apt-get calls run as root during `sudo bash
+# install.sh`, not via this grant, so they don't need an entry.
+clawbox ALL=(root) NOPASSWD: /usr/bin/apt-get update -qq
+clawbox ALL=(root) NOPASSWD: /usr/bin/apt-get install -y -qq chromium-browser
+clawbox ALL=(root) NOPASSWD: /usr/bin/apt-get install -y -qq chromium
 # Allow the Browser-app installer to recover from interrupted dpkg state.
 clawbox ALL=(root) NOPASSWD: /usr/bin/dpkg --configure -a
 clawbox ALL=(root) NOPASSWD: /usr/bin/snap install chromium


### PR DESCRIPTION
Part of the ongoing security-hardening sweep (targeting `beta`).

**What this does** — scopes the package-manager `sudo` grant to exact commands instead of a wildcard, so a foothold on the app user can't turn that grant into arbitrary root command execution. Validated with `visudo -c` on-device (`parsed OK`), and confirmed the only non-root caller's exact `apt-get` invocations still match.

_(An earlier polkit `.pkla` tightening was dropped from this PR: adversarial review showed the scoped `.rules` it relied on is not actually installed, so removing the broad grant would have broken the update mechanism and Ollama management. That finding is being handled properly and separately.)_

Config-only change — no application code affected. Vulnerability specifics intentionally omitted from this public description.
