### PR TITLE
security: authentication & session hardening

### DIFF
--- a/src/app/login-api/logout/route.ts
+++ b/src/app/login-api/logout/route.ts
@@ -2,14 +2,14 @@ import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-export async function POST(request: Request) {
+export async function POST(request?: Request) {
   const res = NextResponse.json({ success: true });
   // Match the Secure attribute to how the request arrived so the clear reliably
   // removes a cookie that login set Secure over HTTPS (tunnel). On plain-HTTP
   // LAN access Secure must stay off or the browser would reject it.
-  const xfp = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const xfp = request?.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
   let isHttps = xfp === "https";
-  if (!xfp) {
+  if (!xfp && request) {
     try { isHttps = new URL(request.url).protocol === "https:"; } catch { isHttps = false; }
   }
   res.cookies.set("clawbox_session", "", {

--- a/src/app/login-api/logout/route.ts
+++ b/src/app/login-api/logout/route.ts
@@ -2,16 +2,22 @@ import { NextResponse } from "next/server";
 
 export const dynamic = "force-dynamic";
 
-export async function POST() {
+export async function POST(request: Request) {
   const res = NextResponse.json({ success: true });
-  // Device serves over plain HTTP on port 80 (embedded LAN deployment); cookies
-  // must not be marked Secure or browsers reject them. HTTPS is opt-in via certs.
+  // Match the Secure attribute to how the request arrived so the clear reliably
+  // removes a cookie that login set Secure over HTTPS (tunnel). On plain-HTTP
+  // LAN access Secure must stay off or the browser would reject it.
+  const xfp = request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  let isHttps = xfp === "https";
+  if (!xfp) {
+    try { isHttps = new URL(request.url).protocol === "https:"; } catch { isHttps = false; }
+  }
   res.cookies.set("clawbox_session", "", {
     httpOnly: true,
     sameSite: "lax",
     path: "/",
     maxAge: 0,
-    secure: false,
+    secure: isHttps,
   });
   return res;
 }

--- a/src/app/login-api/route.ts
+++ b/src/app/login-api/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 import { get, set } from "@/lib/config-store";
-import { verifyPassword, createSessionCookie, getSessionSigningSecret } from "@/lib/auth";
+import { verifyPassword, createSessionCookie, getSessionSigningSecret, getSessionGeneration } from "@/lib/auth";
 import {
   checkLockout,
   recordFailure,
   recordSuccess,
   padResponseTime,
+  SHARED_BUCKET_MAX_LOCK_MS,
 } from "@/lib/login-rate-limit";
 
 export const dynamic = "force-dynamic";
@@ -17,10 +18,26 @@ const VALID_DURATIONS = new Set([1200, 21600, 43200, 86400]);
 // is the only header upstream rewrites cleanly when the device is fronted by
 // the cloudflared tunnel; fall back to a single "global" bucket so an
 // IP-rotating attacker still hits the cap.
-function rateLimitKey(req: Request): string {
+// A trusted per-client key gets the full escalating lockout; the shared LAN
+// fallback bucket is capped (see maxLockMs) so it can't be used to lock the
+// owner out. `maxLockMs` undefined = no cap.
+function rateLimitKey(req: Request): { key: string; maxLockMs?: number } {
   const cf = req.headers.get("cf-connecting-ip")?.trim();
-  if (cf) return `cf:${cf}`;
-  return "global";
+  if (cf) return { key: `cf:${cf}` };
+  return { key: "global", maxLockMs: SHARED_BUCKET_MAX_LOCK_MS };
+}
+
+// Cookies are marked Secure only when the request actually arrived over HTTPS
+// (e.g. through the Cloudflare tunnel). On plain-HTTP LAN access Secure would
+// stop the browser from ever sending the cookie back, breaking login.
+function requestIsHttps(req: Request): boolean {
+  const xfp = req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  if (xfp) return xfp === "https";
+  try {
+    return new URL(req.url).protocol === "https:";
+  } catch {
+    return false;
+  }
 }
 
 function lockoutResponse(retryAfterSeconds: number): NextResponse {
@@ -38,7 +55,7 @@ function lockoutResponse(retryAfterSeconds: number): NextResponse {
 
 export async function POST(request: Request) {
   const startedAt = Date.now();
-  const key = rateLimitKey(request);
+  const { key, maxLockMs } = rateLimitKey(request);
 
   const lock = await checkLockout(key);
   if (lock.locked) {
@@ -80,7 +97,7 @@ export async function POST(request: Request) {
 
   const valid = await verifyPassword(password);
   if (!valid) {
-    const after = await recordFailure(key);
+    const after = await recordFailure(key, { maxLockMs });
     await padResponseTime(startedAt);
     if (after.locked) {
       return lockoutResponse(after.retryAfterSeconds);
@@ -91,7 +108,8 @@ export async function POST(request: Request) {
   await recordSuccess(key);
 
   const secret = await getSessionSigningSecret();
-  const cookie = createSessionCookie(duration, secret);
+  const gen = await getSessionGeneration();
+  const cookie = createSessionCookie(duration, secret, gen);
 
   await padResponseTime(startedAt);
   const res = NextResponse.json({ success: true });
@@ -100,7 +118,9 @@ export async function POST(request: Request) {
     sameSite: "lax",
     path: "/",
     maxAge: duration,
-    secure: false, // HTTP on local network
+    // Secure only over HTTPS (tunnel); plain-HTTP LAN can't set it or the cookie
+    // would never be sent back.
+    secure: requestIsHttps(request),
   });
   return res;
 }

--- a/src/app/setup-api/setup/complete/route.ts
+++ b/src/app/setup-api/setup/complete/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { setMany } from "@/lib/config-store";
-import { getSessionSigningSecret, createSessionCookie } from "@/lib/auth";
+import { getSessionSigningSecret, createSessionCookie, getSessionGeneration } from "@/lib/auth";
 
 export async function POST() {
   try {
@@ -17,7 +17,8 @@ export async function POST() {
     const res = NextResponse.json({ success: true });
     try {
       const secret = await getSessionSigningSecret();
-      const cookie = createSessionCookie(86400, secret); // 24h session
+      const gen = await getSessionGeneration();
+      const cookie = createSessionCookie(86400, secret, gen); // 24h session, current generation
       res.cookies.set("clawbox_session", cookie, {
         httpOnly: true,
         sameSite: "lax",

--- a/src/app/setup-api/system/credentials/route.ts
+++ b/src/app/setup-api/system/credentials/route.ts
@@ -5,7 +5,7 @@ import fs from "fs/promises";
 import path from "path";
 import { get, set } from "@/lib/config-store";
 import { CHPASSWD_INPUT_PATH, CHPASSWD_SERVICE_NAME, chpasswdRecord } from "@/lib/chpasswd";
-import { getSystemUsername, verifyPassword, isSafePasswordChars, bumpSessionGeneration } from "@/lib/auth";
+import { getSystemUsername, verifyPassword, isSafePasswordChars, bumpSessionGeneration, createSessionCookie, getSessionSigningSecret } from "@/lib/auth";
 import { checkRateLimit, clientIp, resetRateLimit } from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +13,35 @@ export const dynamic = "force-dynamic";
 const execFile = promisify(execFileCb);
 
 const PASSWORD_RATE_LIMIT = { windowMs: 15 * 60 * 1000, max: 5 };
+
+// Cookies are marked Secure only over HTTPS (tunnel); plain-HTTP LAN must stay
+// non-Secure or the browser would never send the cookie back.
+function requestIsHttps(req: Request): boolean {
+  const xfp = req.headers.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  if (xfp) return xfp === "https";
+  try {
+    return new URL(req.url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+// Remaining lifetime (seconds) of the caller's current session cookie, so a
+// re-issued cookie preserves the chosen duration instead of extending it. Best
+// effort — the cookie was already validated by middleware to reach this route.
+function remainingSessionSeconds(req: Request): number | null {
+  const m = /(?:^|;\s*)clawbox_session=([^;]+)/.exec(req.headers.get("cookie") || "");
+  if (!m) return null;
+  try {
+    const payload = decodeURIComponent(m[1]).split(".")[0];
+    const data = JSON.parse(Buffer.from(payload, "base64url").toString());
+    if (typeof data.exp !== "number") return null;
+    const remaining = data.exp - Math.floor(Date.now() / 1000);
+    return remaining > 60 ? Math.min(remaining, 86400) : null;
+  } catch {
+    return null;
+  }
+}
 
 export async function POST(request: Request) {
   const ip = clientIp(request);
@@ -82,11 +111,24 @@ export async function POST(request: Request) {
     await set("password_configured", true);
     await set("password_configured_at", new Date().toISOString());
 
-    // Revoke every session minted under the old password. Only matters for an
-    // actual change (there are no live sessions during first-boot setup), but
-    // bumping unconditionally is harmless and keeps the logic simple.
+    // On an actual password change, revoke every session minted under the old
+    // password (bump the generation) — but re-issue the caller's OWN session at
+    // the new generation so a routine change doesn't force-log-out the admin
+    // mid-flow. First-boot setup (no prior password) has no live session, so it
+    // neither bumps nor re-issues.
     if (passwordAlreadyConfigured) {
-      await bumpSessionGeneration();
+      const gen = await bumpSessionGeneration();
+      const secret = await getSessionSigningSecret();
+      const duration = remainingSessionSeconds(request) ?? 86400;
+      const res = NextResponse.json({ success: true, reauthenticated: true });
+      res.cookies.set("clawbox_session", createSessionCookie(duration, secret, gen), {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: duration,
+        secure: requestIsHttps(request),
+      });
+      return res;
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/setup-api/system/credentials/route.ts
+++ b/src/app/setup-api/system/credentials/route.ts
@@ -5,7 +5,7 @@ import fs from "fs/promises";
 import path from "path";
 import { get, set } from "@/lib/config-store";
 import { CHPASSWD_INPUT_PATH, CHPASSWD_SERVICE_NAME, chpasswdRecord } from "@/lib/chpasswd";
-import { getSystemUsername, verifyPassword, isSafePasswordChars } from "@/lib/auth";
+import { getSystemUsername, verifyPassword, isSafePasswordChars, bumpSessionGeneration } from "@/lib/auth";
 import { checkRateLimit, clientIp, resetRateLimit } from "@/lib/rate-limit";
 
 export const dynamic = "force-dynamic";
@@ -81,6 +81,13 @@ export async function POST(request: Request) {
 
     await set("password_configured", true);
     await set("password_configured_at", new Date().toISOString());
+
+    // Revoke every session minted under the old password. Only matters for an
+    // actual change (there are no live sessions during first-boot setup), but
+    // bumping unconditionally is harmless and keeps the logic simple.
+    if (passwordAlreadyConfigured) {
+      await bumpSessionGeneration();
+    }
 
     return NextResponse.json({ success: true });
   } catch (err) {

--- a/src/app/setup-api/system/credentials/route.ts
+++ b/src/app/setup-api/system/credentials/route.ts
@@ -27,8 +27,11 @@ function requestIsHttps(req: Request): boolean {
 }
 
 // Remaining lifetime (seconds) of the caller's current session cookie, so a
-// re-issued cookie preserves the chosen duration instead of extending it. Best
-// effort — the cookie was already validated by middleware to reach this route.
+// re-issued cookie preserves roughly the chosen duration. Best effort — the
+// cookie was already validated by middleware to reach this route. Returns null
+// (→ caller falls back to a fresh 24h) when the cookie is absent, unparseable,
+// or nearly expired; the caller just re-proved the current password, so a fresh
+// window is acceptable there.
 function remainingSessionSeconds(req: Request): number | null {
   const m = /(?:^|;\s*)clawbox_session=([^;]+)/.exec(req.headers.get("cookie") || "");
   if (!m) return null;
@@ -118,17 +121,25 @@ export async function POST(request: Request) {
     // neither bumps nor re-issues.
     if (passwordAlreadyConfigured) {
       const gen = await bumpSessionGeneration();
-      const secret = await getSessionSigningSecret();
-      const duration = remainingSessionSeconds(request) ?? 86400;
-      const res = NextResponse.json({ success: true, reauthenticated: true });
-      res.cookies.set("clawbox_session", createSessionCookie(duration, secret, gen), {
-        httpOnly: true,
-        sameSite: "lax",
-        path: "/",
-        maxAge: duration,
-        secure: requestIsHttps(request),
-      });
-      return res;
+      // Re-issue is best-effort: the password change already succeeded, so a
+      // failure to mint the replacement cookie must NOT turn into a 500 (that
+      // would log the admin out — the exact outcome we're trying to avoid).
+      // Worst case they just see the login screen, like setup/complete.
+      try {
+        const secret = await getSessionSigningSecret();
+        const duration = remainingSessionSeconds(request) ?? 86400;
+        const res = NextResponse.json({ success: true, reauthenticated: true });
+        res.cookies.set("clawbox_session", createSessionCookie(duration, secret, gen), {
+          httpOnly: true,
+          sameSite: "lax",
+          path: "/",
+          maxAge: duration,
+          secure: requestIsHttps(request),
+        });
+        return res;
+      } catch {
+        return NextResponse.json({ success: true });
+      }
     }
 
     return NextResponse.json({ success: true });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -53,13 +53,14 @@ export function isSafePasswordChars(s: string): boolean {
 
 /**
  * Verify the configured Linux user's password using unix_chkpwd (PAM helper).
- * NOTE: no `nullok` — a blank/unset OS password must never authenticate, so a
- * stale `password_configured=true` flag can't be logged into against an empty
- * credential.
+ * Uses `nonull` (not `nullok`) so a blank/unset OS password can never
+ * authenticate — a stale `password_configured=true` flag then can't be logged
+ * into against an empty credential. (The second arg is required and must be
+ * `nullok` or `nonull`; omitting it is not valid.)
  */
 export async function verifyPassword(password: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = spawn("/usr/sbin/unix_chkpwd", [getSystemUsername()], {
+    const child = spawn("/usr/sbin/unix_chkpwd", [getSystemUsername(), "nonull"], {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
     });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@ import crypto from "crypto";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { DATA_DIR } from "./config-store";
+import { DATA_DIR, get, set } from "./config-store";
 
 const SECRET_PATH = path.join(DATA_DIR, ".session-secret");
 
@@ -51,10 +51,15 @@ export function isSafePasswordChars(s: string): boolean {
   return !PASSWORD_CONTROL_CHAR_RE.test(s);
 }
 
-/** Verify the configured Linux user's password using unix_chkpwd (PAM helper). */
+/**
+ * Verify the configured Linux user's password using unix_chkpwd (PAM helper).
+ * NOTE: no `nullok` — a blank/unset OS password must never authenticate, so a
+ * stale `password_configured=true` flag can't be logged into against an empty
+ * credential.
+ */
 export async function verifyPassword(password: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = spawn("/usr/sbin/unix_chkpwd", [getSystemUsername(), "nullok"], {
+    const child = spawn("/usr/sbin/unix_chkpwd", [getSystemUsername()], {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 5000,
     });
@@ -64,16 +69,41 @@ export async function verifyPassword(password: string): Promise<boolean> {
   });
 }
 
-/** Create a signed session cookie value. */
-export function createSessionCookie(durationSeconds: number, secret: string): string {
+// ── Session revocation via a generation counter ──────────────────────────────
+//
+// The signing secret is stable (rotating it would need a service restart), so a
+// leaked/old cookie would otherwise stay valid until it expires. We stamp each
+// cookie with the current `session_generation` and bump it on a password change
+// — every prior cookie then fails the generation check and the user is forced to
+// re-authenticate. Defaults to 0 everywhere, so it is inert until the first bump
+// (existing sessions keep working across the upgrade).
+
+export async function getSessionGeneration(): Promise<number> {
+  const g = await get("session_generation");
+  return typeof g === "number" && Number.isFinite(g) ? g : 0;
+}
+
+/** Invalidate every existing session (e.g. after a password change). */
+export async function bumpSessionGeneration(): Promise<number> {
+  const next = (await getSessionGeneration()) + 1;
+  await set("session_generation", next);
+  return next;
+}
+
+/** Create a signed session cookie value bound to the given generation. */
+export function createSessionCookie(durationSeconds: number, secret: string, gen: number = 0): string {
   const exp = Math.floor(Date.now() / 1000) + durationSeconds;
-  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ exp, gen })).toString("base64url");
   const sig = crypto.createHmac("sha256", secret).update(payload).digest("hex");
   return `${payload}.${sig}`;
 }
 
-/** Verify a session cookie — returns true if valid and not expired. */
-export function verifySessionCookie(cookie: string, secret: string): boolean {
+/**
+ * Verify a session cookie — returns true if valid and not expired. When
+ * `expectedGen` is provided, the cookie's generation must match (a mismatch
+ * means it was minted before the last password change and is revoked).
+ */
+export function verifySessionCookie(cookie: string, secret: string, expectedGen?: number): boolean {
   const [payload, sig] = cookie.split(".");
   if (!payload || !sig) return false;
   // Validate sig is valid hex and correct length (SHA-256 = 64 hex chars)
@@ -88,7 +118,11 @@ export function verifySessionCookie(cookie: string, secret: string): boolean {
     }
 
     const data = JSON.parse(Buffer.from(payload, "base64url").toString());
-    return typeof data.exp === "number" && data.exp > Math.floor(Date.now() / 1000);
+    if (typeof data.exp !== "number" || data.exp <= Math.floor(Date.now() / 1000)) return false;
+    if (expectedGen !== undefined && (typeof data.gen === "number" ? data.gen : 0) !== expectedGen) {
+      return false;
+    }
+    return true;
   } catch {
     return false;
   }

--- a/src/lib/login-rate-limit.ts
+++ b/src/lib/login-rate-limit.ts
@@ -23,6 +23,11 @@ const LOCKOUT_TIERS: Array<{ failures: number; lockMs: number }> = [
   { failures: 20, lockMs: 24 * 60 * 60 * 1000 },
 ];
 
+// Max lock for a bucket with no trusted per-client identity (the shared LAN
+// "global" bucket). Bounds the owner-lockout DoS to a short, self-healing window
+// while still throttling brute force.
+export const SHARED_BUCKET_MAX_LOCK_MS = 5 * 60 * 1000;
+
 export interface AttemptRecord {
   failures: number;
   // First failure timestamp in the current window (ms since epoch). Used
@@ -126,17 +131,24 @@ export async function checkLockout(key: string): Promise<LockoutCheck> {
  * so the caller can return a single Retry-After response without an
  * extra round-trip.
  */
-export async function recordFailure(key: string): Promise<LockoutCheck> {
+export async function recordFailure(key: string, opts?: { maxLockMs?: number }): Promise<LockoutCheck> {
   const state = await loadState();
   const now = Date.now();
   pruneExpired(state, now);
+
+  // Clamp the lock for buckets with no trusted per-client identity (the shared
+  // LAN "global" bucket). Without this cap an unauthenticated attacker could
+  // drive the shared bucket to the 24h tier and lock the real owner out (DoS).
+  // A short self-healing lock still throttles brute-force (paired with the
+  // response-time pad and the 15-min window).
+  const capLock = (ms: number) => (opts?.maxLockMs !== undefined ? Math.min(ms, opts.maxLockMs) : ms);
 
   // If we'd have to evict an active lockout to admit this new key, refuse
   // admission instead. Treat the new key as locked for the highest-tier
   // duration so the IP-rotating attacker who's filling the table can't
   // also keep retrying past the cap.
   if (isOverCapForNewKey(state, now, key)) {
-    const lockMs = LOCKOUT_TIERS[LOCKOUT_TIERS.length - 1].lockMs;
+    const lockMs = capLock(LOCKOUT_TIERS[LOCKOUT_TIERS.length - 1].lockMs);
     return { locked: true, retryAfterSeconds: Math.ceil(lockMs / 1000) };
   }
 
@@ -151,7 +163,7 @@ export async function recordFailure(key: string): Promise<LockoutCheck> {
   // refreshes the lock window from "now".
   for (const tier of LOCKOUT_TIERS) {
     if (rec.failures >= tier.failures) {
-      rec.lockedUntilMs = now + tier.lockMs;
+      rec.lockedUntilMs = now + capLock(tier.lockMs);
     }
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,25 +16,37 @@ const CONFIG_ROOT = process.env.CLAWBOX_ROOT
   || (process.env.NODE_ENV === "development" ? process.cwd() : "/home/clawbox/clawbox");
 const CONFIG_PATH = path.join(CONFIG_ROOT, "data", "config.json");
 
-let setupCompleteCache: { mtimeMs: number; value: boolean } | null = null;
+let configCache: { mtimeMs: number; setupComplete: boolean; sessionGen: number } | null = null;
 
-function isSetupComplete(): boolean {
+function readConfigCached(): { setupComplete: boolean; sessionGen: number } {
   try {
     const stat = fs.statSync(CONFIG_PATH);
-    if (setupCompleteCache && setupCompleteCache.mtimeMs === stat.mtimeMs) {
-      return setupCompleteCache.value;
-    }
+    if (configCache && configCache.mtimeMs === stat.mtimeMs) return configCache;
     const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
-    const parsed = JSON.parse(raw) as { setup_complete?: unknown };
-    const value = parsed.setup_complete === true;
-    setupCompleteCache = { mtimeMs: stat.mtimeMs, value };
-    return value;
+    const parsed = JSON.parse(raw) as { setup_complete?: unknown; session_generation?: unknown };
+    const setupComplete = parsed.setup_complete === true;
+    const sessionGen = typeof parsed.session_generation === "number" && Number.isFinite(parsed.session_generation)
+      ? parsed.session_generation
+      : 0;
+    configCache = { mtimeMs: stat.mtimeMs, setupComplete, sessionGen };
+    return configCache;
   } catch {
     // Missing/unreadable config = pre-setup. Cache the negative answer so we
     // don't statSync on every request before config.json is first written.
-    setupCompleteCache = { mtimeMs: -1, value: false };
-    return false;
+    configCache = { mtimeMs: -1, setupComplete: false, sessionGen: 0 };
+    return configCache;
   }
+}
+
+function isSetupComplete(): boolean {
+  return readConfigCached().setupComplete;
+}
+
+// Current session generation — bumped on password change to revoke every cookie
+// minted earlier (see src/lib/auth.ts). Defaults to 0, so cookies are only ever
+// rejected here once a password change has actually happened.
+function currentSessionGeneration(): number {
+  return readConfigCached().sessionGen;
 }
 
 // ─── Captive Portal ──────────────────────────────────────────────────────────
@@ -142,7 +154,7 @@ function bytesToHex(bytes: Uint8Array): string {
 }
 
 /** Verify HMAC-SHA256 session cookie using Web Crypto API (available in Node 22+). */
-async function verifySessionCookie(cookie: string): Promise<boolean> {
+async function verifySessionCookie(cookie: string, expectedGen: number): Promise<boolean> {
   const secret = process.env.SESSION_SECRET;
   if (!secret) return false;
 
@@ -174,7 +186,10 @@ async function verifySessionCookie(cookie: string): Promise<boolean> {
     // Check expiration
     const decoded = atob(payload.replace(/-/g, "+").replace(/_/g, "/"));
     const data = JSON.parse(decoded);
-    return typeof data.exp === "number" && data.exp > Math.floor(Date.now() / 1000);
+    if (typeof data.exp !== "number" || data.exp <= Math.floor(Date.now() / 1000)) return false;
+    // Reject cookies from before the last password change (session revocation).
+    if ((typeof data.gen === "number" ? data.gen : 0) !== expectedGen) return false;
+    return true;
   } catch {
     return false;
   }
@@ -243,7 +258,7 @@ export async function middleware(request: NextRequest) {
 
   // 4. Check session cookie
   const sessionCookie = request.cookies.get("clawbox_session")?.value;
-  if (sessionCookie && await verifySessionCookie(sessionCookie)) {
+  if (sessionCookie && await verifySessionCookie(sessionCookie, currentSessionGeneration())) {
     return NextResponse.next();
   }
 

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -45,8 +45,16 @@ describe("middleware", () => {
     return new NextRequest(new URL(`http://localhost${pathname}`));
   }
 
-  async function createSignedSessionCookie(exp: number): Promise<string> {
-    const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  function writeConfig(fields: Record<string, unknown>) {
+    const dataDir = path.join(tmpRoot, "data");
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(path.join(dataDir, "config.json"), JSON.stringify(fields));
+  }
+
+  async function createSignedSessionCookie(exp: number, gen?: number): Promise<string> {
+    const body: Record<string, number> = { exp };
+    if (gen !== undefined) body.gen = gen;
+    const payload = Buffer.from(JSON.stringify(body)).toString("base64url");
     const key = await crypto.subtle.importKey(
       "raw",
       new TextEncoder().encode("test-secret"),
@@ -404,6 +412,47 @@ describe("middleware", () => {
       const response = await mod.middleware(req);
 
       expect(response.status).toBe(307);
+    });
+  });
+
+  describe("session generation revocation", () => {
+    const future = () => Math.floor(Date.now() / 1000) + 60;
+
+    it("accepts a matching-generation cookie", async () => {
+      process.env.SESSION_SECRET = "test-secret";
+      writeConfig({ setup_complete: true, session_generation: 3 });
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const req = new NextRequest(new URL("http://localhost/dashboard"), {
+        headers: { cookie: `clawbox_session=${await createSignedSessionCookie(future(), 3)}` },
+      });
+      expect((await mod.middleware(req)).status).toBe(200);
+    });
+
+    it("rejects a cookie from before the last password change", async () => {
+      process.env.SESSION_SECRET = "test-secret";
+      // Generation bumped to 4; a cookie stamped gen 3 is now revoked.
+      writeConfig({ setup_complete: true, session_generation: 4 });
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const req = new NextRequest(new URL("http://localhost/dashboard"), {
+        headers: { cookie: `clawbox_session=${await createSignedSessionCookie(future(), 3)}` },
+      });
+      expect((await mod.middleware(req)).status).toBe(307);
+    });
+
+    it("treats a legacy cookie with no generation as generation 0", async () => {
+      process.env.SESSION_SECRET = "test-secret";
+      writeConfig({ setup_complete: true }); // session_generation defaults to 0
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const req = new NextRequest(new URL("http://localhost/dashboard"), {
+        headers: { cookie: `clawbox_session=${await createSignedSessionCookie(future())}` },
+      });
+      expect((await mod.middleware(req)).status).toBe(200);
     });
   });
 

--- a/src/tests/routes/browser.test.ts
+++ b/src/tests/routes/browser.test.ts
@@ -143,7 +143,10 @@ describe("/setup-api/browser", () => {
   it("launches a browser session by attaching to desktop Chromium over CDP", async () => {
     const { body } = await launchSession();
 
-    expect(connectOverCDP).toHaveBeenCalledWith("http://127.0.0.1:18800", { timeout: 30_000 });
+    expect(connectOverCDP).toHaveBeenCalledWith("http://127.0.0.1:18800", {
+      timeout: 30_000,
+      headers: { Origin: "http://127.0.0.1:18800" },
+    });
     expect(mockPage.bringToFront).toHaveBeenCalled();
     expect(body.sessionId).toBeDefined();
     expect(body.url).toBe("https://www.google.com");

--- a/src/tests/routes/login-api.test.ts
+++ b/src/tests/routes/login-api.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/auth", () => ({
   verifyPassword: vi.fn(),
   createSessionCookie: vi.fn().mockReturnValue("session.cookie"),
   getSessionSigningSecret: vi.fn().mockResolvedValue("secret"),
+  getSessionGeneration: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock("@/lib/login-rate-limit", () => ({
@@ -18,6 +19,7 @@ vi.mock("@/lib/login-rate-limit", () => ({
   recordSuccess: vi.fn(),
   // No-op so tests don't sleep 300 ms each.
   padResponseTime: vi.fn().mockResolvedValue(undefined),
+  SHARED_BUCKET_MAX_LOCK_MS: 300000,
 }));
 
 import * as config from "@/lib/config-store";
@@ -77,7 +79,7 @@ describe("/login-api", () => {
     });
     const res = await POST(req);
     expect(res.status).toBe(401);
-    expect(mockRecordFailure).toHaveBeenCalledWith("cf:1.2.3.5");
+    expect(mockRecordFailure).toHaveBeenCalledWith("cf:1.2.3.5", { maxLockMs: undefined });
     expect(mockPadResponseTime).toHaveBeenCalled();
   });
 
@@ -117,7 +119,7 @@ describe("/login-api", () => {
       body: JSON.stringify({ password: "wrong", duration: 43200 }),
     });
     await POST(req);
-    expect(mockRecordFailure).toHaveBeenCalledWith("global");
+    expect(mockRecordFailure).toHaveBeenCalledWith("global", { maxLockMs: 300000 });
   });
 
   it("rejects missing password", async () => {

--- a/src/tests/routes/logout.test.ts
+++ b/src/tests/routes/logout.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 describe("/login-api/logout", () => {
-  let POST: () => Promise<Response>;
+  let POST: (request?: Request) => Promise<Response>;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -16,5 +16,18 @@ describe("/login-api/logout", () => {
     const cookie = res.headers.get("set-cookie");
     expect(cookie).toContain("clawbox_session=");
     expect(cookie).toContain("Max-Age=0");
+  });
+
+  it("does not mark the clear cookie Secure on plain HTTP", async () => {
+    const res = await POST(new Request("http://localhost/login-api/logout", { method: "POST" }));
+    expect(res.headers.get("set-cookie")).not.toContain("Secure");
+  });
+
+  it("marks the clear cookie Secure when the request arrived over HTTPS", async () => {
+    const res = await POST(new Request("https://box.example/login-api/logout", {
+      method: "POST",
+      headers: { "x-forwarded-proto": "https" },
+    }));
+    expect(res.headers.get("set-cookie")).toContain("Secure");
   });
 });

--- a/src/tests/routes/setup/complete-errors.test.ts
+++ b/src/tests/routes/setup/complete-errors.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/config-store", () => ({
 vi.mock("@/lib/auth", () => ({
   getSessionSigningSecret: vi.fn(),
   createSessionCookie: vi.fn(),
+  getSessionGeneration: vi.fn(async () => 0),
 }));
 
 import { setMany } from "@/lib/config-store";

--- a/src/tests/routes/system/credentials.test.ts
+++ b/src/tests/routes/system/credentials.test.ts
@@ -27,6 +27,8 @@ vi.mock("@/lib/auth", () => ({
   isSafePasswordChars: (s: string) => !/[\r\n\x00-\x1f\x7f]/.test(s),
   verifyPassword: vi.fn(async () => true),
   bumpSessionGeneration: vi.fn(async () => 1),
+  getSessionSigningSecret: vi.fn(async () => "test-secret"),
+  createSessionCookie: vi.fn(() => "reissued.cookie"),
 }));
 
 
@@ -213,6 +215,31 @@ describe("POST /setup-api/system/credentials", () => {
 
     expect(res.status).toBe(429);
     expect(body.error).toContain("Too many attempts");
+  });
+
+  it("bumps the session generation and re-issues the caller's cookie on a real change", async () => {
+    const { get } = await import("@/lib/config-store");
+    vi.mocked(get).mockResolvedValue(true); // password_configured → this is a change
+    const { bumpSessionGeneration } = await import("@/lib/auth");
+
+    const res = await credentialsPost(jsonRequest({
+      password: "newsecurepassword123",
+      currentPassword: "oldpassword123",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(bumpSessionGeneration)).toHaveBeenCalled();
+    // A fresh session cookie is set so the admin isn't force-logged-out.
+    expect(res.headers.get("set-cookie")).toContain("clawbox_session=reissued.cookie");
+  });
+
+  it("does NOT bump the generation on first-boot password set", async () => {
+    // get() defaults to false (password_configured unset) → first-boot path.
+    const { bumpSessionGeneration } = await import("@/lib/auth");
+    const res = await credentialsPost(jsonRequest({ password: "securepassword123" }));
+    expect(res.status).toBe(200);
+    expect(vi.mocked(bumpSessionGeneration)).not.toHaveBeenCalled();
+    expect(res.headers.get("set-cookie")).toBeNull();
   });
 
   it("resets rate limit on successful password change", async () => {

--- a/src/tests/routes/system/credentials.test.ts
+++ b/src/tests/routes/system/credentials.test.ts
@@ -26,6 +26,7 @@ vi.mock("@/lib/auth", () => ({
   PASSWORD_CONTROL_CHAR_RE: /[\r\n\x00-\x1f\x7f]/,
   isSafePasswordChars: (s: string) => !/[\r\n\x00-\x1f\x7f]/.test(s),
   verifyPassword: vi.fn(async () => true),
+  bumpSessionGeneration: vi.fn(async () => 1),
 }));
 
 

--- a/src/tests/unit/auth-verify-password.test.ts
+++ b/src/tests/unit/auth-verify-password.test.ts
@@ -40,7 +40,7 @@ describe("verifyPassword", () => {
     await expect(resultPromise).resolves.toBe(true);
     expect(mockSpawn).toHaveBeenCalledWith(
       "/usr/sbin/unix_chkpwd",
-      ["desktopuser"],
+      ["desktopuser", "nonull"],
       expect.objectContaining({
         stdio: ["pipe", "pipe", "pipe"],
         timeout: 5000,

--- a/src/tests/unit/auth-verify-password.test.ts
+++ b/src/tests/unit/auth-verify-password.test.ts
@@ -40,7 +40,7 @@ describe("verifyPassword", () => {
     await expect(resultPromise).resolves.toBe(true);
     expect(mockSpawn).toHaveBeenCalledWith(
       "/usr/sbin/unix_chkpwd",
-      ["desktopuser", "nullok"],
+      ["desktopuser"],
       expect.objectContaining({
         stdio: ["pipe", "pipe", "pipe"],
         timeout: 5000,

--- a/src/tests/unit/auth.test.ts
+++ b/src/tests/unit/auth.test.ts
@@ -324,5 +324,16 @@ describe("auth", () => {
       const cookie = auth.createSessionCookie(3600, secret, 5);
       expect(auth.verifySessionCookie(cookie, secret)).toBe(true);
     });
+
+    it("treats a truly legacy cookie (payload has no gen field) as generation 0", () => {
+      // createSessionCookie always stamps gen; hand-build a payload with ONLY
+      // exp — the shape minted before this feature existed — and sign it.
+      const exp = Math.floor(Date.now() / 1000) + 3600;
+      const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+      const sig = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+      const legacy = `${payload}.${sig}`;
+      expect(auth.verifySessionCookie(legacy, secret, 0)).toBe(true);
+      expect(auth.verifySessionCookie(legacy, secret, 1)).toBe(false);
+    });
   });
 });

--- a/src/tests/unit/auth.test.ts
+++ b/src/tests/unit/auth.test.ts
@@ -299,4 +299,30 @@ describe("auth", () => {
       expect(auth.verifySessionCookie(upperCookie, secret)).toBe(true);
     });
   });
+
+  describe("session generation binding", () => {
+    const secret = "test-secret-for-unit-tests-long-enough";
+
+    it("accepts a cookie whose generation matches the expected one", () => {
+      const cookie = auth.createSessionCookie(3600, secret, 2);
+      expect(auth.verifySessionCookie(cookie, secret, 2)).toBe(true);
+    });
+
+    it("rejects a cookie minted under an older generation", () => {
+      const cookie = auth.createSessionCookie(3600, secret, 1);
+      // Generation was bumped to 2 (e.g. password change) → old cookie revoked.
+      expect(auth.verifySessionCookie(cookie, secret, 2)).toBe(false);
+    });
+
+    it("treats a cookie with no generation as generation 0", () => {
+      const cookie = auth.createSessionCookie(3600, secret); // defaults gen 0
+      expect(auth.verifySessionCookie(cookie, secret, 0)).toBe(true);
+      expect(auth.verifySessionCookie(cookie, secret, 1)).toBe(false);
+    });
+
+    it("skips the generation check when no expected generation is given", () => {
+      const cookie = auth.createSessionCookie(3600, secret, 5);
+      expect(auth.verifySessionCookie(cookie, secret)).toBe(true);
+    });
+  });
 });

--- a/src/tests/unit/login-rate-limit.test.ts
+++ b/src/tests/unit/login-rate-limit.test.ts
@@ -31,6 +31,28 @@ describe("login-rate-limit", () => {
     expect(r.locked).toBe(false);
   });
 
+  it("caps the lock at maxLockMs for the untrusted shared bucket (DoS guard)", async () => {
+    // 20 failures would normally reach the 24h tier; with maxLockMs it must not
+    // exceed the cap, so an attacker can't lock the owner out for a day.
+    let last: import("@/lib/login-rate-limit").LockoutCheck = { locked: false, retryAfterSeconds: 0 };
+    for (let i = 0; i < 20; i++) {
+      last = await lib.recordFailure("global", { maxLockMs: lib.SHARED_BUCKET_MAX_LOCK_MS });
+    }
+    expect(last.locked).toBe(true);
+    // ~5 min cap (allow a small margin), never the 24h tier.
+    expect(last.retryAfterSeconds).toBeLessThanOrEqual(lib.SHARED_BUCKET_MAX_LOCK_MS / 1000 + 1);
+    expect(last.retryAfterSeconds).toBeGreaterThan(0);
+  });
+
+  it("keeps the full escalation for a trusted per-client key", async () => {
+    let last: import("@/lib/login-rate-limit").LockoutCheck = { locked: false, retryAfterSeconds: 0 };
+    for (let i = 0; i < 20; i++) {
+      last = await lib.recordFailure("cf:1.2.3.4");
+    }
+    // No cap → reaches the 24h tier.
+    expect(last.retryAfterSeconds).toBeGreaterThan(lib.SHARED_BUCKET_MAX_LOCK_MS / 1000);
+  });
+
   it("locks after 5 consecutive failures and reports a positive Retry-After", async () => {
     let last: import("@/lib/login-rate-limit").LockoutCheck = { locked: false, retryAfterSeconds: 0 };
     for (let i = 0; i < 5; i++) {


### PR DESCRIPTION
Part of the ongoing security-hardening sweep (targeting `beta`).

**What this does** — hardens the authentication and session layer:

- **Session revocation.** Session cookies now carry a generation counter that is bumped on a password change; the middleware rejects any cookie minted under an older generation, so changing the password immediately invalidates every existing session. Defaults to 0 and is inert until the first change, so live sessions survive the upgrade.
- **Lockout DoS.** The shared fallback rate-limit bucket (used when there is no trusted per-client identity) is capped to a short, self-healing lock, so an unauthenticated attacker can't drive it to the long-lockout tier and lock the owner out. Trusted per-client keys keep the full escalation.
- **Password check.** Uses the PAM helper's "no null password" mode so a blank/unset OS password can never authenticate.
- **Cookie Secure flag.** Set when the request arrived over HTTPS (tunnel); plain-HTTP LAN stays non-Secure so the browser still returns the cookie.

**Validation** — build + full unit suite on the Jetson: **1650 passed, 0 failed**, with new coverage across auth, rate-limit, middleware, login, and logout.

Vulnerability specifics intentionally omitted from this public description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security Improvements**
  - Password changes now revoke existing sessions, requiring users to sign in again.
  - Blank passwords can no longer authenticate.
  - Session cookies are secured for HTTPS connections and validated against current session state.

- **Bug Fixes**
  - Shared login lockouts now have a maximum duration.
  - Logout cookies correctly reflect HTTP and HTTPS connections.
  - Password changes preserve the remaining session lifetime.

- **Tests**
  - Added coverage for session revocation, secure cookies, password validation, and lockout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->