### PR TITLE
security: pin the browser debug-interface allowed origin

### DIFF
--- a/scripts/launch-browser.sh
+++ b/scripts/launch-browser.sh
@@ -119,7 +119,7 @@ exec env DISPLAY="$DISPLAY" HOME="$HOME" DBUS_SESSION_BUS_ADDRESS="disabled:" \
   "$CHROMIUM" \
   "${SANDBOX_FLAGS[@]}" \
   --remote-debugging-port="$CDP_PORT" \
-  --remote-allow-origins=* \
+  --remote-allow-origins="http://127.0.0.1:${CDP_PORT}" \
   --user-data-dir="$PROFILE" \
   --no-first-run \
   --no-default-browser-check \

--- a/src/app/setup-api/browser/route.ts
+++ b/src/app/setup-api/browser/route.ts
@@ -116,7 +116,15 @@ async function getSharedBrowser(): Promise<import("playwright").Browser> {
       // 30 s matches Playwright's own default — previously 10 s to fail fast
       // against the Bun-WS hang, which is no longer relevant now that we
       // run under Node.
-      const browser = await pw.chromium.connectOverCDP(CDP_ENDPOINT, { timeout: 30_000 });
+      const browser = await pw.chromium.connectOverCDP(CDP_ENDPOINT, {
+        timeout: 30_000,
+        // Chromium gates the CDP WebSocket upgrade on Origin against
+        // --remote-allow-origins (pinned to this exact value in
+        // scripts/launch-browser.sh). Send a matching Origin so our automation
+        // connects while a rebound web page's own origin is rejected — closing
+        // the CDP DNS-rebinding takeover. Keep this byte-identical to the flag.
+        headers: { Origin: CDP_ENDPOINT },
+      });
       browser.on("disconnected", () => {
         if (cachedBrowser === browser) cachedBrowser = null;
         // Also drop a stale in-flight promise so a disconnect that races


### PR DESCRIPTION
Part of the ongoing security-hardening sweep (targeting `beta`).

**What this does** — the browser-automation debug interface accepted connections from any origin, which let a page the automation browser visited speak to that interface (via a DNS-rebinding trick) and take control of it. This pins the allowed origin to the exact loopback value and has our own automation client send a matching origin, so legitimate control still works while a visited page's origin is rejected. The interface remains loopback-bound.

**Validation** — on-device: a mismatched origin's upgrade is rejected (403) and the matching loopback origin is accepted (101). No behavior change for our automation (it now sends the matching origin).

Vulnerability specifics intentionally omitted from this public description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved browser connection security by restricting remote debugging access to the configured local endpoint.
  - Ensured browser automation connections provide the expected origin information, reducing the risk of unauthorized connection attempts.
  - Existing connection timeout behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->