### PR TITLE
security: keep provider OAuth tokens off the browser (server-side handoff)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -4,7 +4,7 @@ import { NextResponse } from "next/server";
 import { spawn } from "child_process";
 import fs from "fs/promises";
 import path from "path";
-import { getAll, setMany } from "@/lib/config-store";
+import { DATA_DIR, getAll, setMany } from "@/lib/config-store";
 import {
   restartGateway,
   findOpenclawBin,
@@ -437,11 +437,49 @@ export async function POST(request: Request) {
       scope?: ConfigureScope;
       clawaiTier?: string;
       model?: string;
+      oauthHandoff?: boolean;
     };
     try {
       body = await request.json();
     } catch {
       return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    }
+
+    // Server-side OAuth token handoff: on the subscription handoff path the
+    // browser posts no provider tokens — device-poll persisted them to a
+    // server-only file. Read them here, consume the file, and splice them into
+    // the body so everything downstream (validation + persistence) is unchanged.
+    if (body.authMode === "subscription" && body.oauthHandoff) {
+      const tokensPath = path.join(DATA_DIR, "oauth-device-tokens.json");
+      let handoff: {
+        access_token?: string;
+        id_token?: string;
+        refresh_token?: string;
+        expires_in?: number;
+        createdAt?: number;
+      };
+      try {
+        handoff = JSON.parse(await fs.readFile(tokensPath, "utf-8"));
+      } catch {
+        return NextResponse.json(
+          { error: "No pending OAuth tokens. Restart the sign-in flow." },
+          { status: 400 },
+        );
+      }
+      await fs.unlink(tokensPath).catch(() => {});
+      if (
+        !handoff.access_token ||
+        (handoff.createdAt && Date.now() - handoff.createdAt > 15 * 60 * 1000)
+      ) {
+        return NextResponse.json(
+          { error: "OAuth tokens missing or expired. Restart the sign-in flow." },
+          { status: 400 },
+        );
+      }
+      body.apiKey = handoff.access_token;
+      body.idToken = handoff.id_token;
+      body.refreshToken = handoff.refresh_token;
+      body.expiresIn = handoff.expires_in;
     }
 
     const { provider, apiKey, authMode = "token", idToken, refreshToken, expiresIn, projectId, scope = "primary", model: bodyModel } = body;

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -447,11 +447,16 @@ export async function POST(request: Request) {
 
     // Server-side OAuth token handoff: on the subscription handoff path the
     // browser posts no provider tokens — device-poll persisted them to a
-    // server-only file. Read them here, consume the file, and splice them into
-    // the body so everything downstream (validation + persistence) is unchanged.
+    // server-only file. Read them here and splice them into the body so
+    // everything downstream (validation + persistence) is unchanged. The file
+    // is only consumed (unlinked) on the happy path, right before success, so a
+    // transient failure downstream leaves it readable for a retry within its
+    // 15-minute TTL rather than forcing a full re-auth.
+    let pendingHandoffTokensPath: string | null = null;
     if (body.authMode === "subscription" && body.oauthHandoff) {
       const tokensPath = path.join(DATA_DIR, "oauth-device-tokens.json");
       let handoff: {
+        provider?: string;
         access_token?: string;
         id_token?: string;
         refresh_token?: string;
@@ -466,20 +471,26 @@ export async function POST(request: Request) {
           { status: 400 },
         );
       }
-      await fs.unlink(tokensPath).catch(() => {});
       if (
         !handoff.access_token ||
         (handoff.createdAt && Date.now() - handoff.createdAt > 15 * 60 * 1000)
       ) {
+        // Stale/invalid credential material — consume it so it can't linger.
+        await fs.unlink(tokensPath).catch(() => {});
         return NextResponse.json(
           { error: "OAuth tokens missing or expired. Restart the sign-in flow." },
           { status: 400 },
         );
       }
+      // Trust the provider recorded alongside the tokens over the request body:
+      // the tokens were minted for that provider, so binding them to a
+      // different profile (from a mismatched body) would be wrong.
+      if (handoff.provider) body.provider = handoff.provider;
       body.apiKey = handoff.access_token;
       body.idToken = handoff.id_token;
       body.refreshToken = handoff.refresh_token;
       body.expiresIn = handoff.expires_in;
+      pendingHandoffTokensPath = tokensPath;
     }
 
     const { provider, apiKey, authMode = "token", idToken, refreshToken, expiresIn, projectId, scope = "primary", model: bodyModel } = body;
@@ -1077,6 +1088,13 @@ export async function POST(request: Request) {
         { error: "AI model configured but gateway failed to restart. Try rebooting the device." },
         { status: 502 },
       );
+    }
+
+    // Configuration fully applied — now consume the OAuth handoff file (if any).
+    // Deferring the unlink to here means a transient failure above returned
+    // early with the file intact, so the client can retry within the TTL.
+    if (pendingHandoffTokensPath) {
+      await fs.unlink(pendingHandoffTokensPath).catch(() => {});
     }
 
     return NextResponse.json({ success: true });

--- a/src/app/setup-api/ai-models/oauth/device-poll/route.ts
+++ b/src/app/setup-api/ai-models/oauth/device-poll/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import crypto from "crypto";
 import fs from "fs/promises";
 import path from "path";
 import { DATA_DIR } from "@/lib/config-store";
@@ -12,6 +13,34 @@ import {
 export const dynamic = "force-dynamic";
 
 const STATE_PATH = path.join(DATA_DIR, "oauth-device-state.json");
+const TOKENS_PATH = path.join(DATA_DIR, "oauth-device-tokens.json");
+
+interface DeviceTokens {
+  access_token?: string;
+  id_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+}
+
+// Persist the freshly-issued provider tokens to a server-only file (0600) and
+// acknowledge the browser with just a status. The provider credentials never
+// leave the device: the configure route reads this file server-side on the
+// handoff path. This keeps access/refresh/id tokens off the plain-HTTP setup
+// AP hop the browser would otherwise relay them across.
+async function persistTokensAndAck(
+  provider: string,
+  tokens: DeviceTokens,
+): Promise<NextResponse> {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  const tmpPath = `${TOKENS_PATH}.tmp.${crypto.randomBytes(8).toString("hex")}`;
+  await fs.writeFile(
+    tmpPath,
+    JSON.stringify({ provider, ...tokens, createdAt: Date.now() }),
+    { mode: 0o600 },
+  );
+  await fs.rename(tmpPath, TOKENS_PATH);
+  return NextResponse.json({ status: "complete" });
+}
 
 interface StoredState {
   provider?: string;
@@ -65,8 +94,7 @@ async function pollOpenAI(stored: StoredState): Promise<NextResponse> {
   // If polling returns tokens directly
   if (pollData.access_token) {
     await fs.unlink(STATE_PATH).catch(() => {});
-    return NextResponse.json({
-      status: "complete",
+    return persistTokensAndAck(stored.provider ?? "openai", {
       access_token: pollData.access_token,
       id_token: pollData.id_token,
       refresh_token: pollData.refresh_token,
@@ -130,8 +158,7 @@ async function pollOpenAI(stored: StoredState): Promise<NextResponse> {
     // format" on every message — and poisoning even the API-key OpenAI path,
     // since ~/.codex/auth.json is shared and rebuilt on every gateway start.
     await fs.unlink(STATE_PATH).catch(() => {});
-    return NextResponse.json({
-      status: "complete",
+    return persistTokensAndAck(stored.provider ?? "openai", {
       access_token: tokenData.access_token,
       id_token: tokenData.id_token,
       refresh_token: tokenData.refresh_token,

--- a/src/app/setup-api/ai-models/oauth/device-start/route.ts
+++ b/src/app/setup-api/ai-models/oauth/device-start/route.ts
@@ -8,9 +8,15 @@ import { DEVICE_AUTH_PROVIDERS } from "@/lib/oauth-config";
 export const dynamic = "force-dynamic";
 
 const STATE_PATH = path.join(DATA_DIR, "oauth-device-state.json");
+const TOKENS_PATH = path.join(DATA_DIR, "oauth-device-tokens.json");
 
 export async function POST(request: Request) {
   try {
+    // A new sign-in flow supersedes any prior one. Best-effort clear a stale
+    // token-handoff file left behind by an abandoned earlier flow so it can
+    // never be consumed by a later configure call.
+    await fs.unlink(TOKENS_PATH).catch(() => {});
+
     let body: { provider?: string } = {};
     try {
       body = await request.json();

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -1172,7 +1172,7 @@ export default function AIModelsStep({
 
   // Save token received from any OAuth flow (device or redirect)
   const saveOAuthToken = useCallback(async (
-    tokenData: { access_token: string; id_token?: string; refresh_token?: string; expires_in?: number; projectId?: string }
+    tokenData: { access_token?: string; id_token?: string; refresh_token?: string; expires_in?: number; projectId?: string; oauthHandoff?: boolean }
   ) => {
     saveControllerRef.current?.abort();
     const controller = new AbortController();
@@ -1187,20 +1187,33 @@ export default function AIModelsStep({
       // this, picking a model in the wizard would silently be ignored
       // for OAuth providers.
       const subscriptionModel = getRequestedCatalogModelId(true);
+      // Device-auth (server-side handoff): the provider tokens were persisted
+      // to a server-only file by device-poll, so we send no token fields —
+      // just the handoff flag telling configure to read them there. The
+      // redirect/exchange path (Anthropic) still posts the real tokens.
+      const configureBody = tokenData.oauthHandoff
+        ? {
+            scope: configureScope,
+            provider: selectedProvider,
+            authMode: "subscription",
+            oauthHandoff: true,
+            ...(subscriptionModel ? { model: subscriptionModel } : {}),
+          }
+        : {
+            scope: configureScope,
+            provider: selectedProvider,
+            apiKey: tokenData.access_token,
+            authMode: "subscription",
+            idToken: tokenData.id_token,
+            refreshToken: tokenData.refresh_token,
+            expiresIn: tokenData.expires_in,
+            ...(tokenData.projectId ? { projectId: tokenData.projectId } : {}),
+            ...(subscriptionModel ? { model: subscriptionModel } : {}),
+          };
       const saveRes = await fetch("/setup-api/ai-models/configure", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          scope: configureScope,
-          provider: selectedProvider,
-          apiKey: tokenData.access_token,
-          authMode: "subscription",
-          idToken: tokenData.id_token,
-          refreshToken: tokenData.refresh_token,
-          expiresIn: tokenData.expires_in,
-          ...(tokenData.projectId ? { projectId: tokenData.projectId } : {}),
-          ...(subscriptionModel ? { model: subscriptionModel } : {}),
-        }),
+        body: JSON.stringify(configureBody),
         signal: controller.signal,
       });
       if (controller.signal.aborted) return;
@@ -1256,10 +1269,12 @@ export default function AIModelsStep({
       const data = await res.json();
       if (controller.signal.aborted) return;
 
-      if (data.status === "complete" && data.access_token) {
+      if (data.status === "complete") {
         stopPolling();
         setDeviceSaving(true);
-        await saveOAuthToken(data);
+        // Tokens never touch the browser: device-poll persisted them to a
+        // server-only file. Signal the configure route to read them there.
+        await saveOAuthToken({ oauthHandoff: true });
         return;
       }
 

--- a/src/components/DoneStep.tsx
+++ b/src/components/DoneStep.tsx
@@ -493,17 +493,20 @@ export default function DoneStep({ setupComplete = false, onComplete }: DoneStep
     setDeviceSaving(false);
   };
 
-  const saveDeviceToken = async (tokenData: { access_token: string; refresh_token?: string; expires_in?: number }) => {
+  const saveDeviceToken = async () => {
     aiSaveControllerRef.current?.abort();
     const controller = new AbortController();
     aiSaveControllerRef.current = controller;
 
     setDeviceSaving(true);
     try {
+      // Server-side OAuth handoff: device-poll persisted the provider tokens
+      // to a server-only file, so no token fields leave the browser — the
+      // configure route reads them there via `oauthHandoff`.
       const saveRes = await fetch("/setup-api/ai-models/configure", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: aiProvider, apiKey: tokenData.access_token, authMode: "subscription", refreshToken: tokenData.refresh_token, expiresIn: tokenData.expires_in }),
+        body: JSON.stringify({ provider: aiProvider, authMode: "subscription", oauthHandoff: true }),
         signal: controller.signal,
       });
       if (controller.signal.aborted) return;
@@ -552,9 +555,9 @@ export default function DoneStep({ setupComplete = false, onComplete }: DoneStep
       }
       const data = await res.json();
       if (controller.signal.aborted) return;
-      if (data.status === "complete" && data.access_token) {
+      if (data.status === "complete") {
         stopDevicePolling();
-        await saveDeviceToken(data);
+        await saveDeviceToken();
         return;
       }
       if (data.status === "pending") {

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -17,6 +17,7 @@ vi.mock("fs/promises", () => ({
     chown: vi.fn(),
     mkdir: vi.fn(),
     rm: vi.fn(),
+    unlink: vi.fn(),
   },
 }));
 
@@ -174,6 +175,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockFs.chown.mockResolvedValue();
     mockFs.mkdir.mockResolvedValue(undefined);
     mockFs.rm.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
     mockGetAll.mockResolvedValue({});
     mockReadOpenClawConfig.mockResolvedValue({});
     mockInferConfiguredLocalModel.mockReturnValue(null);
@@ -943,5 +945,83 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
     expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-opus-4-8");
+  });
+
+  // SEC-12: server-side OAuth token handoff. On the handoff path the browser
+  // posts no provider tokens — configure reads them from the 0600 file that
+  // device-poll wrote, consumes it, and proceeds as if they were in the body.
+  it("reads OAuth tokens from the server-side handoff file and consumes it", async () => {
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("oauth-device-tokens.json")
+        ? JSON.stringify({
+            provider: "openai",
+            access_token: "access.token.jwt",
+            id_token: "id.token.jwt",
+            refresh_token: "refresh-token",
+            expires_in: 3600,
+            createdAt: Date.now(),
+          })
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    // The handoff file is deleted after read so tokens don't linger on disk.
+    expect(mockFs.unlink).toHaveBeenCalledWith(
+      expect.stringContaining("oauth-device-tokens.json"),
+    );
+    // The access token from the file lands in the oauth auth profile.
+    const written = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(written.profiles["codex:default"].access).toBe("access.token.jwt");
+    expect(written.profiles["codex:default"].id).toBe("id.token.jwt");
+  });
+
+  it("returns 400 when the handoff file is missing on the subscription handoff path", async () => {
+    mockFs.readFile.mockImplementation(async (file) => {
+      if (String(file).endsWith("oauth-device-tokens.json")) {
+        throw new Error("ENOENT");
+      }
+      return JSON.stringify({ version: 1, profiles: {} });
+    });
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("No pending OAuth tokens");
+  });
+
+  it("returns 400 when the handoff tokens are expired", async () => {
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("oauth-device-tokens.json")
+        ? JSON.stringify({
+            provider: "openai",
+            access_token: "access.token.jwt",
+            id_token: "id.token.jwt",
+            createdAt: Date.now() - 20 * 60 * 1000, // 20 min ago > 15 min TTL
+          })
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("expired");
   });
 });

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -983,6 +983,64 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(written.profiles["codex:default"].id).toBe("id.token.jwt");
   });
 
+  it("binds the handoff tokens to the provider recorded in the file, not the body", async () => {
+    // The file says openai (→ codex profile); the body claims google. The
+    // tokens were minted for openai, so the file's provider must win — binding
+    // them under google:default would be wrong.
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("oauth-device-tokens.json")
+        ? JSON.stringify({
+            provider: "openai",
+            access_token: "access.token.jwt",
+            id_token: "id.token.jwt",
+            refresh_token: "refresh-token",
+            expires_in: 3600,
+            createdAt: Date.now(),
+          })
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "google",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+
+    expect(res.status).toBe(200);
+    // Profile is codex:default (openai subscription), NOT google:default.
+    const written = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(written.profiles["codex:default"]).toBeDefined();
+    expect(written.profiles["google:default"]).toBeUndefined();
+
+    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    expect(commands.some((c) => c.startsWith("config set agents.defaults.model.primary codex/"))).toBe(true);
+  });
+
+  it("keeps the handoff file for a retry when the gateway restart fails", async () => {
+    mockRestartGateway.mockRejectedValue(new Error("gateway down"));
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("oauth-device-tokens.json")
+        ? JSON.stringify({
+            provider: "openai",
+            access_token: "access.token.jwt",
+            id_token: "id.token.jwt",
+            createdAt: Date.now(),
+          })
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+
+    // A transient 5xx must NOT consume the tokens — the client can retry within
+    // the TTL rather than being forced through a full re-auth.
+    expect(res.status).toBe(502);
+    expect(mockFs.unlink).not.toHaveBeenCalled();
+  });
+
   it("returns 400 when the handoff file is missing on the subscription handoff path", async () => {
     mockFs.readFile.mockImplementation(async (file) => {
       if (String(file).endsWith("oauth-device-tokens.json")) {

--- a/src/tests/routes/ai-models/device-poll.test.ts
+++ b/src/tests/routes/ai-models/device-poll.test.ts
@@ -5,6 +5,9 @@ vi.mock("fs/promises", () => ({
   default: {
     readFile: vi.fn(),
     unlink: vi.fn(),
+    writeFile: vi.fn(),
+    rename: vi.fn(),
+    mkdir: vi.fn(),
   },
 }));
 
@@ -38,6 +41,9 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
 
     mockFs.readFile.mockResolvedValue(JSON.stringify(validState));
     mockFs.unlink.mockResolvedValue();
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.rename.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue(undefined);
 
     vi.stubGlobal("fetch", vi.fn());
 
@@ -117,7 +123,7 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
     expect(body.error).toContain("Missing device_id");
   });
 
-  it("returns complete with tokens on success", async () => {
+  it("persists tokens server-side and returns complete without tokens in the body", async () => {
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({
@@ -133,8 +139,16 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
 
     expect(res.status).toBe(200);
     expect(body.status).toBe("complete");
-    expect(body.access_token).toBe("test-access-token");
-    expect(body.refresh_token).toBe("test-refresh-token");
+    // SEC-12: the browser gets only a status — provider tokens never travel
+    // back over the plain-HTTP setup AP.
+    expect(body.access_token).toBeUndefined();
+    expect(body.refresh_token).toBeUndefined();
+    // Tokens are written to the server-only handoff file instead.
+    expect(mockFs.writeFile).toHaveBeenCalled();
+    const written = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(written.access_token).toBe("test-access-token");
+    expect(written.refresh_token).toBe("test-refresh-token");
+    expect(written.provider).toBe("openai");
     expect(mockFs.unlink).toHaveBeenCalled();
   });
 
@@ -164,7 +178,9 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
 
     expect(res.status).toBe(200);
     expect(body.status).toBe("complete");
-    expect(body.access_token).toBe("exchanged-token");
+    expect(body.access_token).toBeUndefined();
+    const written = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(written.access_token).toBe("exchanged-token");
   });
 
   it("returns 502 when no code_verifier in response", async () => {
@@ -233,9 +249,13 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
     expect(res.status).toBe(200);
     expect(body.status).toBe("complete");
     // Codex needs the JWTs, not an exchanged sk- key: id_token is preserved and
-    // there is no third (id_token → api-key) fetch.
-    expect(body.access_token).toBe("first-token");
-    expect(body.id_token).toBe("test-id-token");
+    // there is no third (id_token → api-key) fetch. The tokens are persisted
+    // to the server-only handoff file, not returned to the browser.
+    expect(body.access_token).toBeUndefined();
+    expect(body.id_token).toBeUndefined();
+    const written = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(written.access_token).toBe("first-token");
+    expect(written.id_token).toBe("test-id-token");
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 

--- a/src/tests/routes/ai-models/device-start.test.ts
+++ b/src/tests/routes/ai-models/device-start.test.ts
@@ -6,6 +6,7 @@ vi.mock("fs/promises", () => ({
     mkdir: vi.fn(),
     writeFile: vi.fn(),
     rename: vi.fn(),
+    unlink: vi.fn(),
   },
 }));
 
@@ -66,6 +67,7 @@ describe("POST /setup-api/ai-models/oauth/device-start", () => {
     mockFs.mkdir.mockResolvedValue(undefined);
     mockFs.writeFile.mockResolvedValue();
     mockFs.rename.mockResolvedValue();
+    mockFs.unlink.mockResolvedValue(undefined);
 
     vi.stubGlobal("fetch", vi.fn());
 
@@ -180,6 +182,42 @@ describe("POST /setup-api/ai-models/oauth/device-start", () => {
     expect(mockFs.mkdir).toHaveBeenCalled();
     expect(mockFs.writeFile).toHaveBeenCalled();
     expect(mockFs.rename).toHaveBeenCalled();
+  });
+
+  it("clears a stale token-handoff file when a new flow begins (best-effort)", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        device_auth_id: "test-device-id",
+        user_code: "ABCD-1234",
+        interval: 5,
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    await deviceStartPost(emptyRequest());
+
+    // A prior abandoned flow may have left tokens on disk — starting fresh must
+    // remove them so a later configure call can't consume them.
+    expect(mockFs.unlink).toHaveBeenCalledWith(
+      expect.stringContaining("oauth-device-tokens.json"),
+    );
+  });
+
+  it("does not fail the new flow if clearing the stale file errors", async () => {
+    mockFs.unlink.mockRejectedValue(new Error("EPERM"));
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        device_auth_id: "test-device-id",
+        user_code: "ABCD-1234",
+        interval: 5,
+      }),
+    });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const res = await deviceStartPost(emptyRequest());
+    expect(res.status).toBe(200);
   });
 
   it("handles invalid JSON body gracefully", async () => {


### PR DESCRIPTION
Part of the ongoing security-hardening sweep (targeting `beta`).

**What this does** — during device-code sign-in the provider tokens used to round-trip through the browser (server → browser → server) over the plain-HTTP setup network. This keeps them off the browser entirely: the poll endpoint persists them to a short-lived, owner-only server file and returns only a completion signal; the configure step reads them server-side and consumes the file. The sign-in UX is unchanged. The redirect-based and manual-key paths are untouched.

**Validation** — build + full unit suite on the Jetson (updated poll/configure tests assert no tokens cross the browser and the server-side handoff is read + consumed), plus an independent review confirming the end-to-end flow and that the other auth paths still work.

Vulnerability specifics intentionally omitted from this public description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * OAuth tokens are now transferred through a secure server-side handoff instead of being exposed to the browser.
  * Missing or expired handoff credentials are rejected automatically.
  * Temporary sign-in credentials are securely consumed and cleared after successful setup.
* **Bug Fixes**
  * Improved device-based OAuth setup reliability while preserving existing redirect-based sign-in flows.
  * Stale sign-in credentials are cleared when starting a new device authorization flow.
* **Tests**
  * Added coverage for successful, missing, expired, and securely consumed OAuth handoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->