### PR TITLE
chore(ci): move CodeQL to a config file; ignore only test code

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -4,13 +4,17 @@ name: "ClawBox CodeQL config"
 queries:
   - uses: security-extended
 
-# Exclude non-runtime code from security analysis. Test fixtures, unit/route
-# tests and CI helper scripts are not part of the device's attack surface —
-# alerts there (e.g. js/insecure-temporary-file across src/tests/**) are noise.
+# Exclude test code from security analysis. Test fixtures and unit/route
+# tests are not part of the device's attack surface — alerts there
+# (e.g. js/insecure-temporary-file across src/tests/**) are noise.
+#
+# NOTE: scripts/** is intentionally NOT excluded — it holds security-critical
+# runtime code (scripts/terminal-server.ts WebSocket server, browser launcher)
+# that must stay under CodeQL coverage. CI-only script alerts are dismissed
+# individually instead.
 paths-ignore:
   - "src/tests/**"
   - "**/*.test.ts"
   - "**/*.test.tsx"
   - "**/*.test.js"
   - "**/*.test.mjs"
-  - "scripts/**"

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: "ClawBox CodeQL config"
+
+# Keep the higher-signal security queries used by the workflow.
+queries:
+  - uses: security-extended
+
+# Exclude non-runtime code from security analysis. Test fixtures, unit/route
+# tests and CI helper scripts are not part of the device's attack surface —
+# alerts there (e.g. js/insecure-temporary-file across src/tests/**) are noise.
+paths-ignore:
+  - "src/tests/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.test.js"
+  - "**/*.test.mjs"
+  - "scripts/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,9 +41,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
-          # security-extended adds higher-signal security queries on top of the
-          # default set without the noisier code-quality suite.
-          queries: security-extended
+          # Config file carries the security-extended query suite plus
+          # paths-ignore for non-runtime code (tests, CI scripts).
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           # Config file carries the security-extended query suite plus
-          # paths-ignore for non-runtime code (tests, CI scripts).
+          # paths-ignore for test code (runtime scripts stay scanned).
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
Tune CodeQL to cut false-positive noise without reducing coverage of runtime code.

- Move the `security-extended` query suite into `.github/codeql/codeql-config.yml` and wire the workflow via `config-file`.
- `paths-ignore` covers only **test code** (`src/tests/**`, `**/*.test.*`). Runtime source and the security-critical `scripts/` (terminal WS server, browser launcher) stay fully scanned.

Companion to a triage pass that dismissed the non-applicable open alerts (test-only sinks, single-user TOCTOU, authenticated-owner file flows, plaintext-to-LLM sanitizer flags) with documented reasons, and left the one genuine hardening item to a separate code PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated security analysis with expanded CodeQL checks.
  * Excluded test files and directories from security scanning while retaining analysis coverage for scripts.
  * Centralized security scanning configuration for more consistent workflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->