### PR TITLE
security: guard prototype-chain keys in app-settings writer

### DIFF
--- a/src/app/setup-api/apps/settings/route.ts
+++ b/src/app/setup-api/apps/settings/route.ts
@@ -61,6 +61,8 @@ export async function POST(req: Request) {
     if (writer) {
       const sanitized: Record<string, string | boolean> = {};
       for (const [k, v] of Object.entries(settings)) {
+        // Never let a caller-supplied key touch the prototype chain.
+        if (k === "__proto__" || k === "constructor" || k === "prototype") continue;
         if (typeof v === "string" || typeof v === "boolean") sanitized[k] = v;
         else if (typeof v === "number") sanitized[k] = String(v);
         else return NextResponse.json({ error: `Invalid value type for key "${k}"` }, { status: 400 });


### PR DESCRIPTION
Skip prototype-chain keys (`__proto__`/`constructor`/`prototype`) when writing app-settings config from a caller-supplied object. Resolves the two `js/remote-property-injection` CodeQL alerts — low real risk (flat primitive assignment) but a cheap, correct guard. Build + full suite green on the Jetson (1710 tests).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration sanitization by filtering potentially unsafe property keys from app settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->