### PR TITLE
fix(hermes): harness switch fails on identity-sync (invalid hermes command + CRLF)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Scripts run on the Linux device (Jetson). Force LF even on Windows checkouts —
+# CRLF breaks bash (`set -euo pipefail\r` → "pipefail: invalid option name") and
+# other interpreters. Prevents a Windows-edited script from being deployed broken.
+*.sh   text eol=lf
+*.mjs  text eol=lf
+*.py   text eol=lf
+*.bash text eol=lf

--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -37,18 +37,15 @@ if [ -d "$OC_WS" ]; then
     systemctl --user restart clawbox-gateway 2>/dev/null || true
 fi
 
-# 2. Hermes ← canonical (symlinks already live) → reindex FTS5.
-# Prefer the configured Hermes CLI (HERMES_BIN, matching src/lib/harness.ts's
-# default), falling back to PATH. `hermes memory reindex` rebuilds the recall
-# index from the markdown; fall back to `sync` on older builds. Non-fatal.
-HERMES="${HERMES_BIN:-$HOME_DIR/.local/bin/hermes}"
-[ -x "$HERMES" ] || HERMES="$(command -v hermes || true)"
-if [ -n "$HERMES" ] && [ -x "$HERMES" ]; then
-  # Surface a reindex failure to the caller (the select route reports it) rather
-  # than swallowing it: a stale FTS5 index means Hermes won't see refreshed
-  # memory. `set -e` propagates a non-zero exit if BOTH reindex and the sync
-  # fallback fail.
-  "$HERMES" memory reindex >/dev/null 2>&1 || "$HERMES" sync >/dev/null 2>&1
-fi
+# 2. Hermes ← canonical: the symlinks placed by setup-shared-identity.sh ARE the
+# sync. Hermes's built-in memory (MEMORY.md/USER.md) is always active and read
+# directly from those files — in this Hermes there is NO separate recall index
+# to rebuild. `hermes memory` only manages external provider plugins
+# (honcho/mem0/…) and exposes just setup/status/off/reset; there is no
+# `reindex`/`sync` memory subcommand. The previous `hermes memory reindex ||
+# hermes sync` therefore invoked a non-existent command (and the unrelated
+# skill-`sync`), which under the service environment failed `set -e` and blocked
+# every harness switch with "Identity synchronization failed". The symlinks are
+# authoritative and live, so there is nothing further to do for Hermes here.
 
 echo "[identity-sync] done"


### PR DESCRIPTION
Fixes the harness switch failing on-device with "Identity synchronization failed; harness not switched."

**Two bugs:**
1. `clawbox-identity-sync.sh` ran `hermes memory reindex || hermes sync`, but this Hermes has no memory-reindex (`hermes memory` only manages external provider plugins; built-in `MEMORY.md`/`USER.md` is always active and read directly from the live symlinks — the symlinks *are* the sync), and `hermes sync` is the unrelated skill-sync. The invalid call failed `set -e` under the service environment and aborted every switch. Removed it.
2. `.gitattributes` now forces LF on `*.sh`/`*.py`/`*.mjs` — CRLF (from a Windows checkout) breaks bash (`set -euo pipefail\r`). Systemic guard so a script can never deploy broken.

**Validated on-device:** switch OpenClaw→Hermes and Hermes→OpenClaw both return `{"success":true}`; both harnesses report healthy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity synchronization reliability by removing unnecessary synchronization steps that could fail on unsupported commands.
  * Ensured identity links remain available without requiring additional synchronization.

* **Chores**
  * Standardized line endings for shell, MJS, Python, and Bash scripts to improve cross-platform interpreter compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->