### PR TITLE
fix(vnc): clipboard bridge — install xclip, graceful fallback, empty-clipboard detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1952,8 +1952,10 @@ step_vnc_install() {
   # --privileged container. Only the GDM-mirror path is shortcut via
   # CLAWBOX_VNC_MODE=virtual, which start-vnc.sh already honors.
   wait_for_apt
-  # Install x11vnc, Xvfb (virtual framebuffer fallback), websockify, and a lightweight WM
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq x11vnc xvfb websockify dbus-x11 openbox xterm x11-xserver-utils autocutsel
+  # Install x11vnc, Xvfb (virtual framebuffer fallback), websockify, a lightweight
+  # WM, and xclip (the VNC clipboard bridge — setup-api/vnc/clipboard shells out
+  # to it; without it the paste modal 503s).
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq x11vnc xvfb websockify dbus-x11 openbox xterm x11-xserver-utils autocutsel xclip
 
   chmod +x "$PROJECT_DIR/scripts/start-vnc.sh"
   chown "$CLAWBOX_USER:$CLAWBOX_USER" "$PROJECT_DIR/scripts/start-vnc.sh"

--- a/src/app/setup-api/vnc/clipboard/route.ts
+++ b/src/app/setup-api/vnc/clipboard/route.ts
@@ -117,9 +117,12 @@ export async function GET() {
       display,
     );
     if (code !== 0) {
-      // xclip returns non-zero when the selection is empty; treat that as
-      // an empty string rather than an error so the UI can render "(empty)".
-      const isEmpty = stderr.includes("There is no owner");
+      // xclip returns non-zero when the selection is empty; treat that as an
+      // empty string rather than an error so the UI can render "(empty)".
+      // Different xclip builds word this differently: "There is no owner for
+      // the selection" (no selection at all) vs "target STRING not available"
+      // (a selection exists but holds no text) — both mean "empty" to us.
+      const isEmpty = /there is no owner|target string not available/i.test(stderr);
       if (isEmpty) {
         return NextResponse.json({ text: "" }, { headers: { "Cache-Control": "no-store" } });
       }

--- a/src/app/setup-api/vnc/clipboard/route.ts
+++ b/src/app/setup-api/vnc/clipboard/route.ts
@@ -33,6 +33,20 @@ interface XclipResult {
   code: number;
 }
 
+// `xclip` may not be installed (or the guest X display may be absent). spawn
+// then fails with ENOENT — surface a clean 503 the UI can show ("clipboard
+// bridge unavailable") instead of leaking a raw "spawn xclip ENOENT" 500.
+function unavailableResponse(err: unknown): NextResponse | null {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (code === "ENOENT") {
+    return NextResponse.json(
+      { error: "Clipboard bridge unavailable: xclip is not installed on this device.", unavailable: true },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+  return null;
+}
+
 function runXclip(args: string[], display: string, input?: string): Promise<XclipResult> {
   return new Promise((resolve, reject) => {
     const isWrite = input !== undefined;
@@ -116,7 +130,7 @@ export async function GET() {
     }
     return NextResponse.json({ text: stdout }, { headers: { "Cache-Control": "no-store" } });
   } catch (err) {
-    return NextResponse.json(
+    return unavailableResponse(err) ?? NextResponse.json(
       { error: err instanceof Error ? err.message : "xclip read failed" },
       { status: 500 },
     );
@@ -163,7 +177,7 @@ export async function POST(request: NextRequest) {
     }
     return NextResponse.json({ ok: true }, { headers: { "Cache-Control": "no-store" } });
   } catch (err) {
-    return NextResponse.json(
+    return unavailableResponse(err) ?? NextResponse.json(
       { error: err instanceof Error ? err.message : "xclip write failed" },
       { status: 500 },
     );


### PR DESCRIPTION
Fixes the VNC clipboard bridge, found by the overnight feature loop (GET returned a raw 500).

- **Missing dependency:** `setup-api/vnc/clipboard` shells out to `xclip`, which wasn't installed → `spawn xclip ENOENT` leaked as a 500. Added `xclip` to the VNC apt deps in `install.sh` (and installed it on the running device).
- **Graceful degradation:** when `xclip` is absent, return a clean 503 ("clipboard bridge unavailable") instead of a raw 500.
- **Empty-clipboard bug:** `xclip 0.13` reports an empty clipboard as `"target STRING not available"`; the route only recognized `"There is no owner"`, so an empty clipboard 500'd. Now matches both and returns `{text:""}`.

Build + full suite green on the Jetson (1710). Verified xclip present + clipboard reachable on-device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved clipboard integration in VNC sessions by adding the required clipboard utility during setup.
  - Clipboard operations now recognize empty selections consistently.

- **Bug Fixes**
  - When the clipboard bridge is unavailable, the application now returns a clear service-unavailable response instead of a generic server error.
  - Clipboard responses are no longer cached, helping ensure users receive current availability information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->