### PR TITLE
fix(files): stream downloads, guard fs errors, RFC5987 filename, guard client json()

### DIFF
--- a/src/app/setup-api/files/[...path]/route.ts
+++ b/src/app/setup-api/files/[...path]/route.ts
@@ -1,9 +1,36 @@
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
+import { Readable } from "stream";
 import { isProtectedFilePath } from "@/lib/file-guard";
 
 export const dynamic = "force-dynamic";
+
+// Translate a Node fs error into a clean HTTP response without echoing the raw
+// error string (which leaks absolute paths / syscall names).
+function fsErrorResponse(err: unknown, fallback: string): NextResponse {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (code === "EACCES" || code === "EPERM") {
+    return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+  }
+  if (code === "ENOENT") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
+
+// Same idea for mutations (rename/delete). ENOENT/EXDEV are client-side
+// mistakes (gone underneath us / cross-device rename) → 400, not 404/500.
+function mutationErrorResponse(err: unknown, fallback: string): NextResponse {
+  const code = (err as NodeJS.ErrnoException)?.code;
+  if (code === "EACCES" || code === "EPERM") {
+    return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+  }
+  if (code === "ENOENT" || code === "EXDEV") {
+    return NextResponse.json({ error: fallback }, { status: 400 });
+  }
+  return NextResponse.json({ error: fallback }, { status: 500 });
+}
 
 const MIME_TYPES: Record<string, string> = {
   jpg: 'image/jpeg', jpeg: 'image/jpeg', png: 'image/png', gif: 'image/gif',
@@ -31,21 +58,39 @@ export async function GET(_req: NextRequest, { params }: Params) {
   const { path: segments } = await params;
   const abs = safePath(segments);
   if (!abs) return NextResponse.json({ error: "Invalid path" }, { status: 400 });
-  if (!fs.existsSync(abs)) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
-  const stat = fs.statSync(abs);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(abs);
+  } catch (err) {
+    return fsErrorResponse(err, "Failed to read file");
+  }
   if (stat.isDirectory()) return NextResponse.json({ error: "Is a directory" }, { status: 400 });
 
-  const buffer = fs.readFileSync(abs);
+  // Stream the file instead of buffering the whole thing into RAM — a
+  // multi-hundred-MB download must not OOM the Jetson.
+  let nodeStream: fs.ReadStream;
+  try {
+    nodeStream = fs.createReadStream(abs);
+  } catch (err) {
+    return fsErrorResponse(err, "Failed to read file");
+  }
+
   const filename = path.basename(abs);
   const ext = filename.split('.').pop()?.toLowerCase() || '';
   const contentType = MIME_TYPES[ext] || 'application/octet-stream';
   const isInline = (contentType.startsWith('image/') && contentType !== 'image/svg+xml') || contentType === 'application/pdf';
-  return new NextResponse(buffer, {
+  // RFC 5987: quoted ASCII fallback + filename* for Unicode/spaces. The ASCII
+  // fallback strips anything outside the printable-ASCII range (and quotes/
+  // backslashes) so the quoted-string stays valid.
+  const asciiName = filename.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+  const disposition = `${isInline ? 'inline' : 'attachment'}; filename="${asciiName}"; filename*=UTF-8''${encodeURIComponent(filename)}`;
+  const body = Readable.toWeb(nodeStream) as unknown as ReadableStream;
+  return new NextResponse(body, {
     headers: {
-      "Content-Disposition": `${isInline ? 'inline' : 'attachment'}; filename="${encodeURIComponent(filename)}"`,
+      "Content-Disposition": disposition,
       "Content-Type": contentType,
-      "Content-Length": String(buffer.length),
+      "Content-Length": String(stat.size),
     },
   });
 }
@@ -73,7 +118,11 @@ export async function PUT(req: NextRequest, { params }: Params) {
   }
   if (fs.existsSync(newAbs)) return NextResponse.json({ error: "Already exists" }, { status: 409 });
 
-  fs.renameSync(abs, newAbs);
+  try {
+    fs.renameSync(abs, newAbs);
+  } catch (err) {
+    return mutationErrorResponse(err, "Failed to rename");
+  }
   return NextResponse.json({ ok: true });
 }
 
@@ -85,10 +134,14 @@ export async function DELETE(_req: NextRequest, { params }: Params) {
   if (!fs.existsSync(abs)) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   const stat = fs.statSync(abs);
-  if (stat.isDirectory()) {
-    fs.rmSync(abs, { recursive: true, force: true });
-  } else {
-    fs.unlinkSync(abs);
+  try {
+    if (stat.isDirectory()) {
+      fs.rmSync(abs, { recursive: true, force: true });
+    } else {
+      fs.unlinkSync(abs);
+    }
+  } catch (err) {
+    return mutationErrorResponse(err, "Failed to delete");
   }
   return NextResponse.json({ ok: true });
 }

--- a/src/app/setup-api/files/route.ts
+++ b/src/app/setup-api/files/route.ts
@@ -130,7 +130,16 @@ export async function GET(req: NextRequest) {
     }
   }
 
-  const stat = fs.statSync(abs);
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(abs);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "EACCES" || code === "EPERM") {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+    return NextResponse.json({ error: "Failed to read directory" }, { status: 500 });
+  }
   if (!stat.isDirectory()) return NextResponse.json({ error: "Not a directory" }, { status: 400 });
 
   // Recursive search mode: walk the tree from `abs` and return matches with
@@ -146,7 +155,18 @@ export async function GET(req: NextRequest) {
   // Return everything including dotfiles. The client (FilesApp) hides
   // them by default and toggles visibility via the visibility/visibility_off
   // button — filtering server-side would defeat that toggle.
-  const entries = fs.readdirSync(abs);
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(abs);
+  } catch (err) {
+    // A 700 / root-owned directory yields EACCES from scandir — return a clean
+    // 403 instead of a 500 that leaks the absolute path in the syscall string.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "EACCES" || code === "EPERM") {
+      return NextResponse.json({ error: "Permission denied" }, { status: 403 });
+    }
+    return NextResponse.json({ error: "Failed to read directory" }, { status: 500 });
+  }
   const files = entries
     .map((name) => {
       try {

--- a/src/components/FilesApp.tsx
+++ b/src/components/FilesApp.tsx
@@ -423,8 +423,8 @@ export default function FilesApp() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ action: "mkdir", name }),
     });
-    const data = await res.json();
-    if (!res.ok) { setStatusMsg(`Error: ${data.error}`); return; }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) { setStatusMsg(`Error: ${data.error ?? res.statusText}`); return; }
     setStatusMsg("Folder created");
     setTimeout(() => setStatusMsg(null), 2000);
     load(currentPath);
@@ -439,8 +439,8 @@ export default function FilesApp() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ newName }),
     });
-    const data = await res.json();
-    if (!res.ok) { setStatusMsg(`Error: ${data.error}`); return; }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) { setStatusMsg(`Error: ${data.error ?? res.statusText}`); return; }
     setStatusMsg("Renamed");
     setTimeout(() => setStatusMsg(null), 2000);
     refreshView();
@@ -451,8 +451,8 @@ export default function FilesApp() {
   const deleteEntry = async (entry: FileEntry) => {
     const url = `/setup-api/files/${entryRelPath(entry).split("/").map(encodeURIComponent).join("/")}`;
     const res = await fetch(url, { method: "DELETE" });
-    const data = await res.json();
-    if (!res.ok) { setStatusMsg(`Error: ${data.error}`); return; }
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) { setStatusMsg(`Error: ${data.error ?? res.statusText}`); return; }
     setStatusMsg("Deleted");
     setTimeout(() => setStatusMsg(null), 2000);
     refreshView();


### PR DESCRIPTION
Overnight-loop fixes for the Files subsystem (audit-found): stream downloads instead of readFileSync (OOM guard), wrap fs stat/read/rename/delete errors with clean status codes (no raw Node strings), RFC 5987 Content-Disposition for Unicode/space filenames, and guard client res.json() in create/rename/delete so a 500 shows an error instead of a dead button. Build + 1710 tests green on the Jetson.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - File downloads now stream reliably and include accurate file size and filename information.
  - File listing and file operations return clear responses for permission and server errors instead of failing unexpectedly.
  - Creating, renaming, and deleting folders now display the most helpful available error message when requests fail.
  - Improved handling of filesystem failures provides more consistent behavior across file management actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->