### PR TITLE
fix(system): hardening for power, stats, vnc/terminal spawns, clipboard

### DIFF
--- a/scripts/terminal-server.ts
+++ b/scripts/terminal-server.ts
@@ -51,30 +51,51 @@ wss.on("connection", (ws: WebSocket, req) => {
     POWERLEVEL9K_INSTANT_PROMPT: "quiet",
   };
 
-  const term = pty.spawn(shell, ["-l"], {
-    name: "xterm-256color",
-    cols: 80,
-    rows: 24,
-    cwd: targetHome,
-    env: cleanEnv,
-  });
+  // Spawning the PTY can fail (EAGAIN/ENOMEM under load, a missing shell,
+  // node-pty ABI mismatch). Without a guard here one bad spawn throws out of
+  // the 'connection' handler and crashes the whole :3006 server, dropping
+  // every other live terminal session. Contain the failure to this one socket:
+  // tell the client and close, leaving the server up.
+  let term: ReturnType<typeof pty.spawn>;
+  try {
+    term = pty.spawn(shell, ["-l"], {
+      name: "xterm-256color",
+      cols: 80,
+      rows: 24,
+      cwd: targetHome,
+      env: cleanEnv,
+    });
 
-  console.log(`[terminal-server] Spawned PTY pid=${term.pid} shell=${shell}`);
+    console.log(`[terminal-server] Spawned PTY pid=${term.pid} shell=${shell}`);
 
-  // PTY → WebSocket
-  term.onData((data: string) => {
+    // PTY → WebSocket
+    term.onData((data: string) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "output", data }));
+      }
+    });
+
+    term.onExit(({ exitCode }: { exitCode: number }) => {
+      console.log(`[terminal-server] PTY exited pid=${term.pid} code=${exitCode}`);
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: "exit", code: exitCode }));
+        ws.close();
+      }
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("[terminal-server] Failed to spawn PTY:", err);
     if (ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "output", data }));
+      ws.send(JSON.stringify({ type: "output", data: `\r\n[terminal-server] Failed to start shell: ${message}\r\n` }));
+      ws.send(JSON.stringify({ type: "exit", code: 1 }));
     }
-  });
-
-  term.onExit(({ exitCode }: { exitCode: number }) => {
-    console.log(`[terminal-server] PTY exited pid=${term.pid} code=${exitCode}`);
-    if (ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify({ type: "exit", code: exitCode }));
+    try {
       ws.close();
+    } catch {
+      /* socket already gone */
     }
-  });
+    return;
+  }
 
   // WebSocket → PTY
   ws.on("message", (raw: Buffer | string) => {
@@ -121,6 +142,14 @@ wss.on("connection", (ws: WebSocket, req) => {
 // ClawBox session cookie on the /terminal-ws upgrade.
 server.listen(PORT, "127.0.0.1", () => {
   console.log(`[terminal-server] Listening on ws://127.0.0.1:${PORT}`);
+});
+
+// Last-resort backstop: an unforeseen throw anywhere in an async callback (a
+// node-pty native fault, a socket write race) must NOT take the whole terminal
+// server down and drop every session. Log it and keep running; per-connection
+// handlers already contain their own failures.
+process.on("uncaughtException", (err) => {
+  console.error("[terminal-server] Uncaught exception (kept alive):", err);
 });
 
 process.on("SIGTERM", () => {

--- a/src/app/setup-api/system/power/route.ts
+++ b/src/app/setup-api/system/power/route.ts
@@ -1,29 +1,51 @@
 import { NextResponse } from "next/server";
 import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 export const dynamic = "force-dynamic";
 
+const POWER_ACTIONS: Record<string, string> = {
+  shutdown: "poweroff",
+  restart: "reboot",
+};
+
 export async function POST(req: Request) {
+  let action: unknown;
   try {
-    const { action } = await req.json();
-
-    if (action === "shutdown") {
-      // Short delay so the response reaches the client
-      setTimeout(() => {
-        execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "poweroff"], { timeout: 10_000 });
-      }, 1500);
-      return NextResponse.json({ ok: true, action: "shutdown" });
-    }
-
-    if (action === "restart") {
-      setTimeout(() => {
-        execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "reboot"], { timeout: 10_000 });
-      }, 1500);
-      return NextResponse.json({ ok: true, action: "restart" });
-    }
-
-    return NextResponse.json({ error: "Invalid action. Use 'shutdown' or 'restart'." }, { status: 400 });
+    ({ action } = await req.json());
   } catch {
-    return NextResponse.json({ error: "Failed to execute power action" }, { status: 500 });
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const systemctlAction = typeof action === "string" ? POWER_ACTIONS[action] : undefined;
+  if (!systemctlAction) {
+    return NextResponse.json(
+      { error: "Invalid action. Use 'shutdown' or 'restart'." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    // Dispatch the power command and wait for systemd to accept it BEFORE
+    // responding. `systemctl poweroff|reboot` enqueues the job and returns 0
+    // promptly (the actual teardown happens a moment later as units stop), so
+    // awaiting here lets us surface a genuine dispatch failure — missing sudo,
+    // denied privilege, systemctl not found — as a real 500 instead of the old
+    // fire-and-forget path that always reported success. The response still
+    // flushes to the client because the enqueue returns well before the web
+    // server's own unit is torn down.
+    await execFileAsync(
+      "/usr/bin/sudo",
+      ["/usr/bin/systemctl", systemctlAction],
+      { timeout: 10_000 },
+    );
+    return NextResponse.json({ ok: true, action });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to execute power action" },
+      { status: 500 },
+    );
   }
 }

--- a/src/app/setup-api/system/stats/route.ts
+++ b/src/app/setup-api/system/stats/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from "next/server";
 import os from "os";
-import { execSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import fs from "fs";
 import fsP from "fs/promises";
+
+const execFileAsync = promisify(execFile);
 
 export const dynamic = "force-dynamic";
 
@@ -30,7 +33,7 @@ interface ProcessEntry {
   command: string;
 }
 
-function getCpuUsage(): number {
+async function getCpuUsage(): Promise<number> {
   try {
     const stat1 = fs.readFileSync("/proc/stat", "utf-8");
     const line1 = stat1.split("\n")[0];
@@ -38,9 +41,9 @@ function getCpuUsage(): number {
     const idle1 = parts1[3];
     const total1 = parts1.reduce((a, b) => a + b, 0);
 
-    // Sleep 200ms via busy wait isn't ideal — use two reads with a small gap
-    const start = Date.now();
-    while (Date.now() - start < 200) { /* busy wait */ }
+    // Sample /proc/stat twice with a non-blocking 200ms gap. A synchronous
+    // busy-wait here would freeze the single Node event loop on every poll.
+    await new Promise((r) => setTimeout(r, 200));
 
     const stat2 = fs.readFileSync("/proc/stat", "utf-8");
     const line2 = stat2.split("\n")[0];
@@ -60,12 +63,13 @@ function getCpuUsage(): number {
   }
 }
 
-function getDiskUsage(): DiskMount[] {
+async function getDiskUsage(): Promise<DiskMount[]> {
   try {
-    const output = execSync("df -h -x tmpfs -x devtmpfs -x squashfs 2>/dev/null", {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
+    const { stdout: output } = await execFileAsync(
+      "df",
+      ["-h", "-x", "tmpfs", "-x", "devtmpfs", "-x", "squashfs"],
+      { encoding: "utf-8", timeout: 5000 },
+    );
     const lines = output.trim().split("\n").slice(1); // skip header
     const result: DiskMount[] = [];
     for (const line of lines) {
@@ -125,13 +129,14 @@ function getNetworkInterfaces(): NetworkInterface[] {
   return result;
 }
 
-function getTopProcesses(): ProcessEntry[] {
+async function getTopProcesses(): Promise<ProcessEntry[]> {
   try {
-    const output = execSync("ps aux --sort=-%cpu 2>/dev/null | head -11", {
+    const { stdout: output } = await execFileAsync("ps", ["aux", "--sort=-%cpu"], {
       encoding: "utf-8",
       timeout: 5000,
     });
-    const lines = output.trim().split("\n").slice(1); // skip header
+    // Skip the header, keep the top 10 by CPU (the old `| head -11` limit).
+    const lines = output.trim().split("\n").slice(1, 11);
     return lines.map((line) => {
       const parts = line.trim().split(/\s+/);
       const [user, pid, cpu, mem, , , , , , , ...cmdParts] = parts;
@@ -173,9 +178,10 @@ function getUptime(): string {
   }
 }
 
-function getKernelRelease(): string {
+async function getKernelRelease(): Promise<string> {
   try {
-    return execSync("uname -r", { encoding: "utf-8", timeout: 3000 }).trim();
+    const { stdout } = await execFileAsync("uname", ["-r"], { encoding: "utf-8", timeout: 3000 });
+    return stdout.trim();
   } catch {
     return os.release();
   }
@@ -222,19 +228,29 @@ export async function GET() {
     const freeMem = os.freemem();
     const usedMem = totalMem - freeMem;
 
-    const [temp, gpuUsage] = await Promise.all([getTemperature(), getGpuUsage()]);
+    // Gather everything that touches the event loop (the 200ms CPU sample,
+    // temp/gpu reads, and the promisified execFile shells) in parallel so we
+    // never block the single Node process.
+    const [cpuUsage, temp, gpuUsage, kernel, storage, processes] = await Promise.all([
+      getCpuUsage(),
+      getTemperature(),
+      getGpuUsage(),
+      getKernelRelease(),
+      getDiskUsage(),
+      getTopProcesses(),
+    ]);
 
     const stats = {
       overview: {
         hostname: os.hostname(),
         os: `${os.type()} ${os.release()}`,
-        kernel: getKernelRelease(),
+        kernel,
         uptime: getUptime(),
         arch: os.arch(),
         platform: os.platform(),
       },
       cpu: {
-        usage: getCpuUsage(),
+        usage: cpuUsage,
         model: cpus[0]?.model || "Unknown",
         cores: cpus.length,
         loadAvg: os.loadavg().map((v) => v.toFixed(2)),
@@ -249,9 +265,9 @@ export async function GET() {
       },
       temperature: temp,
       gpu: { usage: gpuUsage },
-      storage: getDiskUsage(),
+      storage,
       network: getNetworkInterfaces(),
-      processes: getTopProcesses(),
+      processes,
       timestamp: Date.now(),
     };
 

--- a/src/app/setup-api/vnc/clipboard/route.ts
+++ b/src/app/setup-api/vnc/clipboard/route.ts
@@ -36,11 +36,17 @@ interface XclipResult {
 // `xclip` may not be installed (or the guest X display may be absent). spawn
 // then fails with ENOENT — surface a clean 503 the UI can show ("clipboard
 // bridge unavailable") instead of leaking a raw "spawn xclip ENOENT" 500.
+// EACCES/EPERM mean the binary is present but not executable (bad perms /
+// restricted): same "unavailable" story from the user's side, so map them to
+// the same 503 rather than leaking a raw permission 500.
 function unavailableResponse(err: unknown): NextResponse | null {
   const code = (err as NodeJS.ErrnoException)?.code;
-  if (code === "ENOENT") {
+  if (code === "ENOENT" || code === "EACCES" || code === "EPERM") {
+    const detail = code === "ENOENT"
+      ? "xclip is not installed on this device."
+      : "xclip is installed but not executable on this device.";
     return NextResponse.json(
-      { error: "Clipboard bridge unavailable: xclip is not installed on this device.", unavailable: true },
+      { error: `Clipboard bridge unavailable: ${detail}`, unavailable: true },
       { status: 503, headers: { "Cache-Control": "no-store" } },
     );
   }
@@ -133,8 +139,11 @@ export async function GET() {
     }
     return NextResponse.json({ text: stdout }, { headers: { "Cache-Control": "no-store" } });
   } catch (err) {
+    // Only genuinely unexpected errors reach here (ENOENT/EACCES/EPERM are
+    // handled above). Return a static message rather than echoing err.message,
+    // which can leak spawn/path internals.
     return unavailableResponse(err) ?? NextResponse.json(
-      { error: err instanceof Error ? err.message : "xclip read failed" },
+      { error: "xclip read failed" },
       { status: 500 },
     );
   }
@@ -180,8 +189,10 @@ export async function POST(request: NextRequest) {
     }
     return NextResponse.json({ ok: true }, { headers: { "Cache-Control": "no-store" } });
   } catch (err) {
+    // See the GET handler: static message for unexpected errors, no err.message
+    // echo. ENOENT/EACCES/EPERM are already mapped to a clean 503 above.
     return unavailableResponse(err) ?? NextResponse.json(
-      { error: err instanceof Error ? err.message : "xclip write failed" },
+      { error: "xclip write failed" },
       { status: 500 },
     );
   }

--- a/src/app/setup-api/vnc/route.ts
+++ b/src/app/setup-api/vnc/route.ts
@@ -43,6 +43,13 @@ export async function GET() {
           detached: true,
           stdio: "ignore",
         });
+        // A detached child with no 'error' listener turns a spawn failure into
+        // an uncaughtException that would take down the whole :80 server. Log
+        // and swallow it — the isPortOpen() probe below is what actually
+        // decides success, so a failed spawn just reports "unavailable".
+        proc.on("error", (e) => {
+          console.warn("[vnc] Failed to auto-start websockify:", e);
+        });
         proc.unref();
 
         // Wait a moment for it to start

--- a/src/components/VNCApp.tsx
+++ b/src/components/VNCApp.tsx
@@ -44,9 +44,10 @@ export default function VNCApp() {
   const [error, setError] = useState<string | null>(null);
   const [vncInfo, setVncInfo] = useState<{ host: string; wsPort: number } | null>(null);
   // Install/repair flow: when the VNC API is unreachable or reports VNC as
-  // missing, the user can trigger `install.sh --step vnc_install` through
-  // /setup-api/vnc/repair. On success we reboot to make sure the freshly
-  // installed clawbox-vnc / websockify services come up cleanly.
+  // missing, the user can trigger `install.sh --step vnc_install` by POSTing
+  // { step: "vnc_install" } to /setup-api/install/run-step (there is no
+  // dedicated /setup-api/vnc/repair route). On success we reboot to make sure
+  // the freshly installed clawbox-vnc / websockify services come up cleanly.
   const [repairState, setRepairState] = useState<"idle" | "repairing" | "rebooting" | "failed">("idle");
   const [repairError, setRepairError] = useState<string | null>(null);
   const [pasteOpen, setPasteOpen] = useState(false);

--- a/src/tests/routes/system/power.test.ts
+++ b/src/tests/routes/system/power.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { execFile } from "child_process";
 
 vi.mock("child_process", () => ({
@@ -7,71 +7,103 @@ vi.mock("child_process", () => ({
 
 const mockExecFile = vi.mocked(execFile);
 
+// The route uses promisify(execFile), so the mock must invoke the trailing
+// callback for the awaited call to resolve/reject.
+function resolveOnce() {
+  mockExecFile.mockImplementationOnce(((...args: unknown[]) => {
+    const cb = args[args.length - 1] as (
+      err: Error | null,
+      stdout: string,
+      stderr: string,
+    ) => void;
+    cb(null, "", "");
+    return undefined as never;
+  }) as unknown as typeof execFile);
+}
+
+function rejectOnce(error: Error) {
+  mockExecFile.mockImplementationOnce(((...args: unknown[]) => {
+    const cb = args[args.length - 1] as (err: Error | null) => void;
+    cb(error);
+    return undefined as never;
+  }) as unknown as typeof execFile);
+}
+
 describe("/setup-api/system/power", () => {
   let POST: (req: Request) => Promise<Response>;
 
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
-    vi.useFakeTimers();
     const mod = await import("@/app/setup-api/system/power/route");
     POST = mod.POST;
   });
 
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
-  it("handles shutdown action and triggers execFile after delay", async () => {
+  it("awaits systemctl poweroff for the shutdown action", async () => {
+    resolveOnce();
     const req = new Request("http://localhost/setup-api/system/power", {
       method: "POST",
       body: JSON.stringify({ action: "shutdown" }),
     });
     const res = await POST(req);
     const body = await res.json();
+    expect(res.status).toBe(200);
     expect(body).toEqual({ ok: true, action: "shutdown" });
-    // execFile should NOT have been called yet (before timer fires)
-    expect(mockExecFile).not.toHaveBeenCalled();
-    // Advance timers to trigger the setTimeout callback
-    vi.advanceTimersByTime(2000);
     expect(mockExecFile).toHaveBeenCalledWith(
       "/usr/bin/sudo",
       ["/usr/bin/systemctl", "poweroff"],
-      expect.anything()
+      { timeout: 10_000 },
+      expect.any(Function),
     );
   });
 
-  it("handles restart action and triggers execFile after delay", async () => {
+  it("awaits systemctl reboot for the restart action", async () => {
+    resolveOnce();
     const req = new Request("http://localhost/setup-api/system/power", {
       method: "POST",
       body: JSON.stringify({ action: "restart" }),
     });
     const res = await POST(req);
     const body = await res.json();
+    expect(res.status).toBe(200);
     expect(body).toEqual({ ok: true, action: "restart" });
-    vi.advanceTimersByTime(2000);
     expect(mockExecFile).toHaveBeenCalledWith(
       "/usr/bin/sudo",
       ["/usr/bin/systemctl", "reboot"],
-      expect.anything()
+      { timeout: 10_000 },
+      expect.any(Function),
     );
   });
 
-  it("rejects invalid action", async () => {
+  it("returns 500 when the power command fails to dispatch", async () => {
+    rejectOnce(new Error("sudo: a password is required"));
+    const req = new Request("http://localhost/setup-api/system/power", {
+      method: "POST",
+      body: JSON.stringify({ action: "shutdown" }),
+    });
+    const res = await POST(req);
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.error).toContain("password is required");
+  });
+
+  it("rejects an invalid action without invoking execFile", async () => {
     const req = new Request("http://localhost/setup-api/system/power", {
       method: "POST",
       body: JSON.stringify({ action: "invalid" }),
     });
     const res = await POST(req);
     expect(res.status).toBe(400);
+    expect(mockExecFile).not.toHaveBeenCalled();
   });
 
-  it("handles invalid JSON", async () => {
+  it("returns 400 on an invalid JSON body", async () => {
     const req = new Request("http://localhost/setup-api/system/power", {
       method: "POST",
       body: "not json",
     });
     const res = await POST(req);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
+    expect(mockExecFile).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
System-route robustness hardening.

- `system/stats`: non-blocking async collection (no busy-wait).
- `system/power`: dispatch the systemd action and await acceptance before responding, so a genuine dispatch failure surfaces as a real 500 instead of a false success. Invalid body → 400, invalid action → 400.
- `vnc`/`terminal-server`: crash-proof spawn error listeners + PTY try/catch + uncaught guard.
- `vnc/clipboard`: graceful 503 on EACCES/EPERM and correct empty-clipboard detection.

Tests updated to match the awaited power dispatch. Build green, 1711 tests pass on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when starting terminal, VNC, and clipboard services.
  - Added clearer error responses for unavailable clipboard access and invalid power commands.
  - Prevented service errors from unexpectedly stopping the application.
  - System statistics collection is now more responsive and reliable.

- **Tests**
  - Expanded coverage for shutdown and restart actions, validation errors, command failures, and successful requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->