### PR TITLE
fix(wizard,config): robust setup wizard, telegram/browser/clawai config paths

### DIFF
--- a/src/app/setup-api/ai-models/clawai/poll/route.ts
+++ b/src/app/setup-api/ai-models/clawai/poll/route.ts
@@ -14,6 +14,11 @@ const CLAWBOX_AI_DEVICE_POLL_URL =
   process.env.CLAWBOX_AI_DEVICE_POLL_URL?.trim()
   || "https://openclawhardware.dev/api/clawbox-ai/device-poll";
 
+// Max time a session may sit in `configuring` before the poll route gives up
+// on the background configure and surfaces a retryable error. A gateway
+// restart takes ~50 s; 3 min leaves comfortable headroom for a slow Jetson.
+const CONFIGURING_TIMEOUT_MS = 3 * 60 * 1000;
+
 interface UpstreamPollResponse {
   status?: string;
   access_token?: string;
@@ -115,11 +120,24 @@ export async function POST() {
   if (session.status === "complete") {
     return NextResponse.json({ status: "complete" });
   }
-  if (session.status === "configuring") {
-    return NextResponse.json({ status: "configuring" });
-  }
   if (session.status === "error" && session.error) {
     return NextResponse.json({ status: "error", error: session.error });
+  }
+  if (session.status === "configuring") {
+    // The background configure normally flips the session to complete/error
+    // within a gateway-restart cycle. If it never reports back (process died
+    // mid-restart, etc.) the session would sit in `configuring` forever and
+    // the UI would poll indefinitely. Time it out into a retryable error so
+    // the user can request a fresh code.
+    const configuringStartedAt = session.configuringStartedAt ?? session.createdAt;
+    if (Date.now() - configuringStartedAt > CONFIGURING_TIMEOUT_MS) {
+      await clearClawAiSession();
+      return NextResponse.json(
+        { status: "error", error: "ClawBox AI setup timed out while finishing up. Please request a new code and try again." },
+        { status: 408 },
+      );
+    }
+    return NextResponse.json({ status: "configuring" });
   }
 
   if (isClawAiSessionExpired(session)) {
@@ -208,7 +226,12 @@ export async function POST() {
   // off the configure off the request lifecycle and acknowledge the
   // poll quickly. The next poll tick — typically within `interval`
   // seconds — sees `configuring` or `complete` and the UI advances.
-  const configuringSession: ClawAiConnectSession = { ...session, status: "configuring", error: null };
+  const configuringSession: ClawAiConnectSession = {
+    ...session,
+    status: "configuring",
+    error: null,
+    configuringStartedAt: Date.now(),
+  };
   await writeClawAiSession(configuringSession);
   void runConfigureInBackground(configuringSession, accessToken);
 

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1099,11 +1099,12 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ success: true });
   } catch (err) {
+    // Never surface the raw error: it can carry CLI internals and filesystem
+    // paths. Log it server-side for diagnosis and return a generic, actionable
+    // message (mirrors the sanitized gateway-restart branch above).
+    console.error("[configure] Failed to configure AI model:", err instanceof Error ? err.message : err);
     return NextResponse.json(
-      {
-        error:
-          err instanceof Error ? err.message : "Failed to configure AI model",
-      },
+      { error: "Failed to configure AI model. Please check your credentials and try again." },
       { status: 500 }
     );
   }

--- a/src/app/setup-api/apps/settings/route.ts
+++ b/src/app/setup-api/apps/settings/route.ts
@@ -44,7 +44,7 @@ export async function POST(req: Request) {
           "config", "set",
           `skills.entries.${appId}.enabled`,
           enabled ? "true" : "false",
-          "--strict-json",
+          "--json",
         ], {
           timeout: 10_000,
           env: { ...process.env, PATH: `${path.dirname(OPENCLAW_BIN)}:${process.env.PATH}` },

--- a/src/app/setup-api/browser/manage/route.ts
+++ b/src/app/setup-api/browser/manage/route.ts
@@ -6,7 +6,7 @@ import { promisify } from "util";
 import { constants as fsConstants } from "fs";
 import fs from "fs/promises";
 import path from "path";
-import { readConfig, findOpenclawBin } from "@/lib/openclaw-config";
+import { readConfig, runOpenclawConfigSet } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 
 const exec = promisify(execFile);
@@ -230,10 +230,9 @@ export async function POST(req: Request) {
 
         await fs.mkdir(PROFILE_DIR, { recursive: true });
 
-        const openclawBin = findOpenclawBin();
         try {
-          await exec(openclawBin, ["config", "set", "tools.profile", "full"], { timeout: 30000 });
-          await exec(openclawBin, ["config", "set", "tools.web.search.enabled", "true", "--json"], { timeout: 30000 });
+          await runOpenclawConfigSet(["tools.profile", "full"]);
+          await runOpenclawConfigSet(["tools.web.search.enabled", "true", "--json"]);
           await persistBrowserEnabled(true);
         } catch (err) {
           console.error("[browser] Failed to set tools config:", err);
@@ -255,9 +254,8 @@ export async function POST(req: Request) {
       }
 
       case "disable": {
-        const openclawBin = findOpenclawBin();
         try {
-          await exec(openclawBin, ["config", "set", "tools.profile", "coding"], { timeout: 30000 });
+          await runOpenclawConfigSet(["tools.profile", "coding"]);
           await persistBrowserEnabled(false);
         } catch (err) {
           console.error("[browser] Failed to unset tools config:", err);

--- a/src/app/setup-api/browser/route.ts
+++ b/src/app/setup-api/browser/route.ts
@@ -265,7 +265,6 @@ export async function POST(req: Request) {
         title: await page.title().catch(() => ""),
         screenshot: screenshot ? screenshot.toString("base64") : null,
         canGoBack: await page.evaluate(() => window.history.length > 1).catch(() => false),
-        canGoForward: false,
       };
     };
 
@@ -316,12 +315,21 @@ export async function POST(req: Request) {
 
       case "keydown": {
         const { key } = body;
+        if (typeof key !== "string" || key.length === 0) {
+          return NextResponse.json({ error: "key required" }, { status: 400 });
+        }
         const pwKey = KEY_MAP[key] || key;
-        // Single printable character → type it; special key → press it
-        if (pwKey.length === 1 && !KEY_MAP[key]) {
-          await page.keyboard.type(pwKey);
-        } else {
-          await page.keyboard.press(pwKey);
+        // Single printable character → type it; special key → press it. A
+        // key name Playwright doesn't recognise makes press() throw — treat
+        // that as a client error rather than letting it become a raw 500.
+        try {
+          if (pwKey.length === 1 && !KEY_MAP[key]) {
+            await page.keyboard.type(pwKey);
+          } else {
+            await page.keyboard.press(pwKey);
+          }
+        } catch {
+          return NextResponse.json({ error: `Unknown key: ${key}` }, { status: 400 });
         }
         await page.waitForTimeout(100);
         return NextResponse.json(await respond());

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -97,6 +97,13 @@ function runHermes(args: string[], signal?: AbortSignal): Promise<string> {
     child.on("error", (e) => {
       if (settled) return;
       cleanup();
+      // A missing binary surfaces as ENOENT with the full spawn path in the
+      // message (`spawn /home/clawbox/.local/bin/hermes ENOENT`). Don't leak
+      // that path to the client — report the actionable cause instead.
+      if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+        reject(new Error("Hermes is not installed on this device"));
+        return;
+      }
       reject(e);
     });
     child.on("close", (code) => {

--- a/src/app/setup-api/telegram/configure/route.ts
+++ b/src/app/setup-api/telegram/configure/route.ts
@@ -49,10 +49,24 @@ export async function POST(request: Request) {
       await set("telegram_approved_names", undefined);
     }
 
-    // Restart gateway so it picks up the new channel (and the reset allowlist)
-    await restartGateway();
+    // Restart gateway so it picks up the new channel (and the reset allowlist).
+    // The token is already persisted at this point, so a restart failure must
+    // not fail the whole save — report it as a soft warning that'll apply on
+    // the next gateway restart (mirrors /telegram/streaming). Never surface the
+    // raw exec error.
+    try {
+      await restartGateway();
+    } catch (restartErr) {
+      console.error("[telegram/configure] Gateway restart failed:", restartErr);
+      return NextResponse.json({
+        success: true,
+        reset: tokenChanged,
+        restarted: false,
+        warning: "Saved — will apply on next gateway restart",
+      });
+    }
 
-    return NextResponse.json({ success: true, reset: tokenChanged });
+    return NextResponse.json({ success: true, reset: tokenChanged, restarted: true });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to save" },

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -569,7 +569,11 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
           <SetupCompletionOverlay phase={completionPhase} completed={completionComplete} t={t} />
         ) : (
           <>
-            {completionError && currentStep === 5 && (
+            {/* Completion failed and is no longer in flight (we're in the
+                !completionStarted branch). Show it regardless of step — the
+                resume path lands on step 6, which has no body, so gating on
+                step 5 would leave a blank card. */}
+            {completionError && (
               <div className="w-full max-w-[520px] mb-4">
                 <StatusMessage type="error" message={completionError} />
                 <button

--- a/src/components/TelegramStep.tsx
+++ b/src/components/TelegramStep.tsx
@@ -16,6 +16,7 @@ export default function TelegramStep({ onNext }: TelegramStepProps) {
   const [showToken, setShowToken] = useState(false);
   const [saving, setSaving] = useState(false);
   const [configuring, setConfiguring] = useState(false);
+  const [configurePromise, setConfigurePromise] = useState<Promise<void> | undefined>(undefined);
   const [status, setStatus] = useState<{
     type: "success" | "error";
     message: string;
@@ -39,6 +40,23 @@ export default function TelegramStep({ onNext }: TelegramStepProps) {
 
     setSaving(true);
     setConfiguring(true);
+    setStatus(null);
+
+    // Expose the configure outcome so the overlay only advances the wizard
+    // (onDone → onNext) once the save has actually succeeded — gateway
+    // health alone must not be read as success. Mirrors SettingsApp's
+    // Telegram flow via TelegramConfiguringOverlay's `waitFor` prop.
+    const {
+      promise: cfgPromise,
+      resolve: configureResolve,
+      reject: configureReject,
+    } = Promise.withResolvers<void>();
+    // Swallow the rejection at the promise level so unhandled-rejection
+    // doesn't fire; the failed state is surfaced via setStatus below and
+    // the overlay is torn down by setConfiguring(false).
+    cfgPromise.catch(() => {});
+    setConfigurePromise(cfgPromise);
+
     try {
       const res = await fetch("/setup-api/telegram/configure", {
         method: "POST",
@@ -46,9 +64,13 @@ export default function TelegramStep({ onNext }: TelegramStepProps) {
         body: JSON.stringify({ botToken: token.trim() }),
         signal: controller.signal,
       });
-      if (controller.signal.aborted) return;
+      if (controller.signal.aborted) {
+        configureReject(new Error("aborted"));
+        return;
+      }
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
+        configureReject(new Error(data.error || "configure failed"));
         setConfiguring(false);
         setStatus({
           type: "error",
@@ -57,8 +79,14 @@ export default function TelegramStep({ onNext }: TelegramStepProps) {
         return;
       }
       const data = await res.json();
-      if (controller.signal.aborted) return;
-      if (!data.success) {
+      if (controller.signal.aborted) {
+        configureReject(new Error("aborted"));
+        return;
+      }
+      if (data.success) {
+        configureResolve();
+      } else {
+        configureReject(new Error(data.error || "configure returned success=false"));
         setConfiguring(false);
         setStatus({
           type: "error",
@@ -66,7 +94,11 @@ export default function TelegramStep({ onNext }: TelegramStepProps) {
         });
       }
     } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
+      if (err instanceof DOMException && err.name === "AbortError") {
+        configureReject(err);
+        return;
+      }
+      configureReject(err);
       setConfiguring(false);
       setStatus({
         type: "error",
@@ -81,7 +113,7 @@ export default function TelegramStep({ onNext }: TelegramStepProps) {
     <div className="w-full max-w-[520px]" data-testid="setup-step-telegram">
       <div className="card-surface rounded-2xl p-5 sm:p-8 relative overflow-hidden">
         {configuring && (
-          <TelegramConfiguringOverlay onDone={onNext} />
+          <TelegramConfiguringOverlay waitFor={configurePromise} onDone={onNext} />
         )}
         <div className={configuring ? "invisible h-0 overflow-hidden" : ""}>
         <h1 className="text-xl sm:text-2xl font-bold font-display mb-2 flex flex-wrap items-center gap-2.5">

--- a/src/components/UpdateStep.tsx
+++ b/src/components/UpdateStep.tsx
@@ -62,6 +62,9 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
   const [fetchError, setFetchError] = useState(false);
   const [loading, setLoading] = useState(true);
   const [starting, setStarting] = useState(false);
+  // Bumped by the fetchError-branch "Retry" to re-run the status GET below.
+  // Retry must only re-check status — never kick off a full update+reboot.
+  const [statusReloadCount, setStatusReloadCount] = useState(0);
   // The update reboots the device at the "Updating ClawBox and restarting"
   // step. Once the server stops answering, hand off to the reconnecting overlay
   // so the user gets the same animated loop as a manual restart; it polls until
@@ -125,6 +128,8 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
   useEffect(() => {
     const controller = new AbortController();
     async function init() {
+      setFetchError(false);
+      setLoading(true);
       try {
         const res = await fetch("/setup-api/update/status", {
           signal: controller.signal,
@@ -150,7 +155,7 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
       controller.abort();
       stopPolling();
     };
-  }, [startPolling, stopPolling]);
+  }, [startPolling, stopPolling, statusReloadCount]);
 
   const triggerUpdate = async () => {
     actionControllerRef.current?.abort();
@@ -231,7 +236,7 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
           <div className="flex items-center gap-3">
             <button
               type="button"
-              onClick={triggerUpdate}
+              onClick={() => setStatusReloadCount((c) => c + 1)}
               className="px-8 py-3 btn-gradient text-white rounded-lg font-semibold text-sm transition transform hover:scale-105 shadow-lg shadow-[rgba(249,115,22,0.25)] cursor-pointer"
             >
               {t("retry")}

--- a/src/lib/clawai-connect.ts
+++ b/src/lib/clawai-connect.ts
@@ -30,6 +30,13 @@ export interface ClawAiConnectSession {
   verificationUrl?: string;
   error?: string | null;
   completedAt?: number;
+  /**
+   * When the session entered the `configuring` state. Used by the poll
+   * route to time out a session whose background configure never reported
+   * back (e.g. the process died mid gateway-restart), instead of leaving
+   * the UI polling `configuring` forever.
+   */
+  configuringStartedAt?: number;
 }
 
 const STATE_PATH = path.join(DATA_DIR, "clawai-connect-state.json");

--- a/src/tests/routes/browser/manage.test.ts
+++ b/src/tests/routes/browser/manage.test.ts
@@ -20,6 +20,9 @@ vi.mock("fs/promises", () => ({
 vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn().mockResolvedValue({ tools: { profile: "full" } }),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
+  // enable/disable now route their config writes through this helper instead
+  // of shelling out directly; default it to a successful no-op.
+  runOpenclawConfigSet: vi.fn().mockResolvedValue({ stdout: "", stderr: "" }),
 }));
 
 vi.mock("@/lib/sqlite-store", () => ({

--- a/src/tests/routes/telegram/configure.test.ts
+++ b/src/tests/routes/telegram/configure.test.ts
@@ -153,14 +153,21 @@ describe("POST /setup-api/telegram/configure", () => {
     expect(body.error).toBe("Gateway unreachable");
   });
 
-  it("returns 500 when restartGateway fails", async () => {
+  it("saves with a soft warning when restartGateway fails", async () => {
+    // The token is already persisted before the restart, so a restart failure
+    // must not fail the whole save — it's reported as a soft warning that
+    // applies on the next gateway restart.
     mockRestartGateway.mockRejectedValue(new Error("Restart failed"));
 
     const res = await telegramConfigurePost(jsonRequest({ botToken: "123:abc" }));
     const body = await res.json();
 
-    expect(res.status).toBe(500);
-    expect(body.error).toBe("Restart failed");
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.restarted).toBe(false);
+    expect(typeof body.warning).toBe("string");
+    // The raw exec error must never be surfaced.
+    expect(JSON.stringify(body)).not.toContain("Restart failed");
   });
 
   it("returns generic error for non-Error throws", async () => {


### PR DESCRIPTION
Setup-wizard and config-path robustness.

- `apps/settings`: correct openclaw config flag.
- `browser/manage` + `browser`: route config writes through the shared helper; validate keydown input and drop dead `canGoForward`.
- `telegram/configure`: token is persisted before the gateway restart, so a restart failure is a soft warning (applies on next restart) rather than failing the whole save; never surfaces the raw exec error.
- `ai-models/clawai/poll`: time out a session stuck in `configuring` into a retryable error instead of polling forever.
- `ai-models/configure` + `clawai-connect`: sanitize error responses (no raw CLI/filesystem internals).
- `hermes/chat`: friendly ENOENT message.
- SetupWizard / TelegramStep / UpdateStep: retry-independent completion, resilient status waits, retry→recheck.

Tests updated to match. Build green, 1710 tests pass on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Stalled AI model setup sessions now time out after three minutes and offer a retry.
  - Setup errors remain visible during resume flows.
  - Retrying status checks no longer restarts the update process.
  - Telegram setup succeeds even if the gateway restart fails, with a warning shown.
  - Missing Hermes installations now display a clear, safe message.
  - Browser keyboard actions validate unsupported keys and return clearer errors.

- **Improvements**
  - Configuration progress is reported more consistently.
  - Browser and skill settings updates are more reliable.
  - Sensitive technical error details are no longer exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->