### PR TITLE
fix(harness): retry liveness probe to avoid false 'not available'

### DIFF
--- a/src/lib/harness.ts
+++ b/src/lib/harness.ts
@@ -64,18 +64,35 @@ export async function setActiveHarness(harness: Harness): Promise<void> {
  * response (even 401/404) proves the process is up; only a connection failure
  * or timeout counts as down. Loopback-only, short timeout so a down harness
  * doesn't stall the status route.
+ *
+ * The probe is retried a couple of times before giving up: on a loaded Jetson
+ * a single 2.5 s timeout produces false negatives — most visibly right after a
+ * harness switch, where the just-finished identity sync momentarily starves the
+ * event loop and the still-running gateway fails to answer in time, which would
+ * otherwise report a healthy harness as "not available" and block switching
+ * back to it. A genuinely down harness still fails every attempt.
  */
+const HEALTH_PROBE_ATTEMPTS = 3;
+const HEALTH_PROBE_TIMEOUT_MS = 2500;
+const HEALTH_PROBE_RETRY_GAP_MS = 250;
+
 export async function harnessHealthy(harness: Harness): Promise<boolean> {
   // Prefer a live server probe: any HTTP response means the process is up.
-  try {
-    const res = await fetch(`${HARNESSES[harness].baseUrl}/`, {
-      signal: AbortSignal.timeout(2500),
-    });
-    // Drain the body we don't read so undici frees the pooled socket now.
-    res.body?.cancel();
-    return true;
-  } catch {
-    // fall through
+  for (let attempt = 0; attempt < HEALTH_PROBE_ATTEMPTS; attempt++) {
+    try {
+      const res = await fetch(`${HARNESSES[harness].baseUrl}/`, {
+        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+      });
+      // Drain the body we don't read so undici frees the pooled socket now.
+      res.body?.cancel();
+      return true;
+    } catch {
+      // Transient timeout/refusal under load — retry a couple of times before
+      // falling through to the per-harness fallback / "down" verdict.
+      if (attempt < HEALTH_PROBE_ATTEMPTS - 1) {
+        await new Promise((r) => setTimeout(r, HEALTH_PROBE_RETRY_GAP_MS));
+      }
+    }
   }
   // Hermes chat uses the `hermes -z` CLI, not the serve endpoint, so it's
   // usable whenever the binary is installed — the serve probe above is just a

--- a/src/tests/unit/harness-health.test.ts
+++ b/src/tests/unit/harness-health.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+// harnessHealthy probes the harness's loopback server and, for hermes, falls
+// back to the CLI binary. Mock fetch + fs so we can drive both paths.
+vi.mock("fs", () => ({
+  default: { accessSync: vi.fn() },
+  accessSync: vi.fn(),
+  constants: { X_OK: 1 },
+}));
+
+import fs from "fs";
+import { harnessHealthy } from "@/lib/harness";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("harnessHealthy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when the first probe answers", async () => {
+    mockFetch.mockResolvedValue({ body: { cancel: vi.fn() } });
+    expect(await harnessHealthy("openclaw")).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient failure and succeeds on a later attempt", async () => {
+    // First two probes fail (e.g. event-loop starvation right after a switch),
+    // the third answers — the harness must be reported healthy, not "down".
+    mockFetch
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce({ body: { cancel: vi.fn() } });
+    expect(await harnessHealthy("openclaw")).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("reports openclaw down when every probe fails", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    expect(await harnessHealthy("openclaw")).toBe(false);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("falls back to the hermes CLI binary when the serve probe is down", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.mocked(fs.accessSync).mockReturnValue(undefined);
+    expect(await harnessHealthy("hermes")).toBe(true);
+  });
+
+  it("reports hermes down when the probe fails and the binary is missing", async () => {
+    mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+    vi.mocked(fs.accessSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(await harnessHealthy("hermes")).toBe(false);
+  });
+});

--- a/src/tests/unit/harness-health.test.ts
+++ b/src/tests/unit/harness-health.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 // harnessHealthy probes the harness's loopback server and, for hermes, falls
 // back to the CLI binary. Mock fetch + fs so we can drive both paths.
-vi.mock("fs", () => ({
-  default: { accessSync: vi.fn() },
-  accessSync: vi.fn(),
-  constants: { X_OK: 1 },
-}));
+vi.mock("fs", () => {
+  const accessSync = vi.fn();
+  const constants = { X_OK: 1 };
+  // harness.ts does `import fs from "fs"` then `fs.accessSync` + `fs.constants`,
+  // so the default export must carry both.
+  return { default: { accessSync, constants }, accessSync, constants };
+});
 
 import fs from "fs";
 import { harnessHealthy } from "@/lib/harness";


### PR DESCRIPTION
Found during on-device E2E of the harness switcher.

Switching openclaw→hermes succeeds, but switching **back** intermittently returned 409 "openclaw is not available" even though the gateway was healthy. Root cause: `harnessHealthy` used a single 2.5 s HTTP probe, which produces false negatives on a loaded Jetson — most visibly right after a switch, where the just-finished identity sync momentarily starves the event loop and the still-running gateway can't answer in time.

Fix: retry the liveness probe up to 3 times (250 ms gap) before falling through to the per-harness fallback / down verdict. A genuinely down harness still fails every attempt. Adds unit tests for first-try success, retry-then-success, all-fail, and the hermes CLI-binary fallback.

Build green, 1716 tests pass on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health checks by retrying temporary connectivity failures before reporting an issue.
  * Added a fallback validation path when the primary service probe remains unavailable.
  * Health checks now handle responses more reliably, including cleanup after requests.

* **Tests**
  * Added coverage for successful checks, transient failures, persistent failures, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->