### PR TITLE
fix(setup-auth): gate portal tunnel-control pre-setup + own-property provider guards

### DIFF
--- a/src/app/setup-api/ai-models/oauth/device-start/route.ts
+++ b/src/app/setup-api/ai-models/oauth/device-start/route.ts
@@ -25,7 +25,10 @@ export async function POST(request: Request) {
     }
 
     const providerName = body.provider || "openai";
-    const config = DEVICE_AUTH_PROVIDERS[providerName];
+    // Own-property check so inherited keys ("__proto__"/"constructor") can't
+    // resolve to a truthy Object.prototype value and bypass this 400 (they'd
+    // otherwise proceed with undefined config fields → a fetch(undefined) 500).
+    const config = Object.hasOwn(DEVICE_AUTH_PROVIDERS, providerName) ? DEVICE_AUTH_PROVIDERS[providerName] : undefined;
     if (!config) {
       return NextResponse.json(
         { error: `Device auth not supported for provider: ${providerName}` },

--- a/src/app/setup-api/ai-models/oauth/start/route.ts
+++ b/src/app/setup-api/ai-models/oauth/start/route.ts
@@ -29,7 +29,10 @@ export async function POST(request: Request) {
         { status: 400 }
       );
     }
-    const config = OAUTH_PROVIDERS[provider];
+    // Own-property check: a bare index would let inherited keys like
+    // "__proto__"/"constructor" resolve to Object.prototype (truthy) and slip
+    // past the `!config` guard, yielding a junk 200 instead of this 400.
+    const config = Object.hasOwn(OAUTH_PROVIDERS, provider) ? OAUTH_PROVIDERS[provider] : undefined;
     if (!config) {
       return NextResponse.json(
         { error: `OAuth not supported for provider: ${provider}` },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -136,6 +136,7 @@ const PRE_AUTH_SENSITIVE_PREFIXES = [
   "/setup-api/terminal",
   "/setup-api/clawkeep",    // backup restore/encryption/pairing — data-injection surface
   "/setup-api/tunnel",      // enabling remote tunnel access
+  "/setup-api/portal",      // same privileged tunnel start/stop/enable as /tunnel
   "/setup-api/apps/install",
   "/setup-api/apps/uninstall",
   "/setup-api/gateway/ws-config", // hands back the live gateway auth token

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -472,6 +472,8 @@ describe("middleware", () => {
       "/setup-api/terminal",
       "/setup-api/clawkeep/restore",
       "/setup-api/tunnel/enable",
+      "/setup-api/portal/start", // same privileged tunnel control as /tunnel
+      "/setup-api/portal/stop",
       "/setup-api/apps/install",
       "/setup-api/apps/uninstall",
       "/setup-api/gateway/ws-config",
@@ -496,6 +498,18 @@ describe("middleware", () => {
       const mod = await import("@/middleware");
 
       const response = await mod.middleware(createRequest("/setup-api/gateway/health"));
+      expect(response.status).toBe(200);
+    });
+
+    it("still allows /setup-api/portal/heartbeat-tick during the setup window", async () => {
+      // The heartbeat timer hits this on a freshly-booted device before login;
+      // gating the /setup-api/portal prefix must not catch this whitelisted
+      // sibling (it does no privileged work).
+      process.env.SESSION_SECRET = "test-secret";
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest("/setup-api/portal/heartbeat-tick"));
       expect(response.status).toBe(200);
     });
 


### PR DESCRIPTION
Robustness hardening for the setup window and provider lookups.

- middleware: the pre-setup sensitive-surface gate covered `/setup-api/tunnel` but not the functionally-equivalent `/setup-api/portal` routes, which perform the same privileged tunnel start/stop/enable. Added `/setup-api/portal` to the gate (the whitelisted `portal/heartbeat-tick` still passes via the public-path check). Regression tests added for both.
- ai-models oauth start + device-start: use an own-property check when resolving the provider so inherited object keys can't slip past the unsupported-provider 400.

Build green, 1719 tests pass on-device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for OAuth provider selections, rejecting unsupported or invalid provider values.
  * Secured setup portal endpoints so sensitive operations require authentication during setup.
  * Preserved access to setup heartbeat checks before setup is complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->