### PR TITLE
fix(clawkeep): scheduled backups run a real backup + correct multibyte output decoding

### DIFF
--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -30,7 +30,12 @@ function clear() {
 function fireBackup(): void {
   // Best-effort: if a manual backup is already running the daemon will
   // serialise via its own heartbeat lock, so we don't gate here.
-  void runBackup({ idle: true })
+  //
+  // A scheduled run must create + upload a REAL backup — `idle: true` only
+  // sends a heartbeat ping (and short-circuits within the heartbeat interval),
+  // so it would silently never back anything up. The manual "Backup now" path
+  // uses idle:false; the scheduler must too.
+  void runBackup({ idle: false })
     .catch((err) => {
       console.warn("[clawkeep-scheduler] auto-backup failed:", err instanceof Error ? err.message : err);
     })

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -21,6 +21,7 @@ import { randomBytes } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 
 import { findOpenclawBin } from "@/lib/openclaw-config";
 
@@ -782,15 +783,21 @@ function spawnCliJson<T>(
 
     let stdout = "";
     let stderr = "";
+    // Decode through a StringDecoder so a multibyte UTF-8 sequence split across
+    // two 'data' events (e.g. a Cyrillic snapshot label straddling a chunk
+    // boundary) isn't corrupted into U+FFFD — the decoder buffers the partial
+    // trailing bytes until the next chunk (flushed via .end() on close).
+    const outDecoder = new StringDecoder("utf8");
+    const errDecoder = new StringDecoder("utf8");
     const killTimer = setTimeout(() => {
       try { child.kill("SIGKILL"); } catch { /* already gone */ }
     }, timeoutMs);
 
     child.stdout.on("data", (b: Buffer) => {
-      stdout = appendCapped(stdout, b.toString("utf8"));
+      stdout = appendCapped(stdout, outDecoder.write(b));
     });
     child.stderr.on("data", (b: Buffer) => {
-      stderr = appendCapped(stderr, b.toString("utf8"));
+      stderr = appendCapped(stderr, errDecoder.write(b));
     });
     child.on("error", (err) => {
       clearTimeout(killTimer);
@@ -805,6 +812,10 @@ function spawnCliJson<T>(
     });
     child.on("close", (code) => {
       clearTimeout(killTimer);
+      // Flush any bytes the decoder is still holding (a trailing partial
+      // multibyte sequence) before parsing.
+      stdout = appendCapped(stdout, outDecoder.end());
+      stderr = appendCapped(stderr, errDecoder.end());
       // Both `clawkeep snapshots` and `clawkeep restore` print a single JSON
       // object on stdout — even on errors. Parse first; fall back to stderr
       // text if parsing fails so the caller still gets a usable message.


### PR DESCRIPTION
Two ClawKeep fixes.

- **Scheduled/unattended backups never actually backed up.** The in-process scheduler fired the backup with the heartbeat-only `idle` flag, so every scheduled run just pinged the daemon and created/uploaded nothing — a silent data-protection failure on any device with a schedule enabled. Scheduled runs now perform a real backup (matching the manual 'Backup now' path).
- The daemon-output reader decoded each stdout/stderr chunk independently, so a multibyte UTF-8 sequence split across two read events was corrupted into replacement characters (e.g. garbled non-ASCII snapshot labels). Now decoded through a StringDecoder that buffers partial trailing bytes.

Build green, 1716 tests pass on-device.