### PR TITLE
fix(config): constrain language into persona files + bound kv writes + reject reserved keys

### DIFF
--- a/src/app/setup-api/kv/route.ts
+++ b/src/app/setup-api/kv/route.ts
@@ -4,9 +4,21 @@ import { kvGet, kvSet, kvDelete, kvGetAll, kvSetMany } from "@/lib/kv-store";
 export const dynamic = "force-dynamic";
 
 const SAFE_KEY = /^[\w.:-]{1,256}$/;
+// Reserved/dunder names slip through SAFE_KEY (all `\w`) but corrupt the plain
+// object backing the store — e.g. `data["__proto__"] = "x"` is a silent no-op
+// that reports success yet stores nothing, and a read returns Object.prototype.
+const RESERVED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+// Bound each value and the batch size so a caller can't grow data/kv.json
+// without limit (disk-exhaustion DoS — the whole file is rewritten per set).
+const MAX_VALUE_BYTES = 256 * 1024; // 256 KB per value
+const MAX_ENTRIES = 500;
 
 function isValidKey(key: string): boolean {
-  return SAFE_KEY.test(key);
+  return SAFE_KEY.test(key) && !RESERVED_KEYS.has(key);
+}
+
+function isValidValue(v: unknown): v is string {
+  return typeof v === "string" && Buffer.byteLength(v, "utf8") <= MAX_VALUE_BYTES;
 }
 
 // GET /setup-api/kv?key=foo        → single key
@@ -38,15 +50,22 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: true });
     }
     if (body.entries && typeof body.entries === "object") {
+      const rawKeys = Object.keys(body.entries);
+      if (rawKeys.length > MAX_ENTRIES) {
+        return NextResponse.json({ error: `Too many entries (max ${MAX_ENTRIES})` }, { status: 413 });
+      }
       const entries: Record<string, string> = {};
       for (const [k, v] of Object.entries(body.entries)) {
-        if (isValidKey(k) && typeof v === "string") entries[k] = v;
+        if (isValidKey(k) && isValidValue(v)) entries[k] = v;
       }
       if (Object.keys(entries).length > 0) kvSetMany(entries);
       return NextResponse.json({ ok: true });
     }
     if (typeof body.key === "string" && typeof body.value === "string") {
       if (!isValidKey(body.key)) return NextResponse.json({ error: "Invalid key" }, { status: 400 });
+      if (!isValidValue(body.value)) {
+        return NextResponse.json({ error: `Value too large (max ${MAX_VALUE_BYTES} bytes)` }, { status: 413 });
+      }
       kvSet(body.key, body.value);
       return NextResponse.json({ ok: true });
     }

--- a/src/app/setup-api/preferences/route.ts
+++ b/src/app/setup-api/preferences/route.ts
@@ -61,7 +61,13 @@ export async function POST(req: Request) {
         fr: "Français", it: "Italiano", ja: "日本語", nl: "Nederlands",
         sv: "Svenska", zh: "中文",
       };
-      const lang = body.ui_language;
+      // Constrain to a known language code before it's interpolated into the
+      // agent's SOUL.md/USER.md persona files. The raw request value must never
+      // reach those files — a value with newlines/Markdown headings would
+      // otherwise inject arbitrary instructions into the agent's system prompt
+      // (reachable pre-auth during the setup-AP window).
+      const requested = body.ui_language;
+      const lang = Object.hasOwn(LANG_NAMES, requested) ? requested : "en";
       const langName = LANG_NAMES[lang] ?? "English";
       const wsDir = "/home/clawbox/.openclaw/workspace";
       await fs.mkdir(wsDir, { recursive: true }).catch(() => {});


### PR DESCRIPTION
Config/KV/preferences hardening.

- The UI-language value was interpolated verbatim into the agent's persona files (SOUL.md/USER.md); a value with newlines/Markdown could inject instructions into the system prompt (reachable during the pre-setup window). Now constrained to the known-language allow-list before any file write.
- The KV store accepted values and batches of unbounded size, so the backing JSON file could be grown without limit (disk-exhaustion DoS). Added per-value byte and per-batch entry caps (413 on overflow).
- The key validator accepted reserved names like `__proto__`, which silently no-op'd on write yet returned a bogus non-null read. Reserved/dunder keys are now rejected.

Build green, 1719 tests pass on-device.