### PR TITLE
fix(system): preserve hotspot key, gate reset before cutting connectivity, fail-closed auth-profiles read

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -188,8 +188,17 @@ async function readAuthProfiles(): Promise<AuthProfilesFile> {
   try {
     const raw = await fs.readFile(AUTH_PROFILES_PATH, "utf-8");
     return JSON.parse(raw) as AuthProfilesFile;
-  } catch {
-    return { version: 1, profiles: {} };
+  } catch (err) {
+    // Only a genuinely absent file means "no profiles yet" (first run). Any
+    // other failure — EACCES on a root-owned file, a partial/corrupt JSON, an
+    // I/O error — must NOT be treated as empty: the caller does a
+    // read-modify-write, so defaulting to {} here would overwrite the file with
+    // a single profile and silently destroy every other provider's stored
+    // credentials (there is no backup for this file). Fail closed instead.
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { version: 1, profiles: {} };
+    }
+    throw err;
   }
 }
 

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -353,6 +353,23 @@ export async function POST() {
       console.error("[Reset] Ollama cleanup failed:", err instanceof Error ? err.message : err);
     });
 
+    // Always unmask before either reboot or returning a failure — leaving the
+    // unit masked would block the gateway from coming back on the next boot.
+    await unmaskGateway();
+
+    // Surface partial-wipe failures BEFORE any connectivity-destructive step.
+    // Deleting the WiFi profile / resetting the login password without the
+    // reboot that follows (the AP only returns on reboot, and the abort path
+    // does NOT reboot) would strand a WiFi-only device offline with no way to
+    // retry. Gate first so an incomplete wipe leaves the box reachable.
+    if (allFailures.length > 0) {
+      console.warn(`[Reset] Aborting reboot — ${allFailures.length} wipe failure(s)`);
+      return NextResponse.json(
+        { error: `Factory reset incomplete: ${allFailures.length} file deletion(s) failed`, failures: allFailures },
+        { status: 500 },
+      );
+    }
+
     // 6. Delete saved WiFi connections so device returns to AP mode after reboot
     await deleteWifiConnections().catch((err) => {
       console.error("[Reset] WiFi cleanup failed:", err instanceof Error ? err.message : err);
@@ -372,22 +389,6 @@ export async function POST() {
       ], { timeout: 10_000 });
     } catch (err) {
       console.warn("[Reset] Failed to reset hostname:", err instanceof Error ? err.message : err);
-    }
-
-    // Always unmask before either reboot or returning a failure — leaving the
-    // unit masked would block the gateway from coming back on the next boot.
-    await unmaskGateway();
-
-    // Surface partial-wipe failures explicitly: returning an error here
-    // (instead of rebooting silently) keeps the user on the reset screen so
-    // they can retry or escalate. The masked-then-unmasked gateway is fine
-    // either way; mask only persists until the next reboot.
-    if (allFailures.length > 0) {
-      console.warn(`[Reset] Aborting reboot — ${allFailures.length} wipe failure(s)`);
-      return NextResponse.json(
-        { error: `Factory reset incomplete: ${allFailures.length} file deletion(s) failed`, failures: allFailures },
-        { status: 500 },
-      );
     }
 
     scheduleReboot();

--- a/src/app/setup-api/system/hotspot/route.ts
+++ b/src/app/setup-api/system/hotspot/route.ts
@@ -90,9 +90,20 @@ export async function POST(request: Request) {
       );
     }
 
+    // Preserve the stored WPA key when a request omits `password`. The Settings
+    // toggle and SSID-rename actions POST only {ssid, enabled} (the GET handler
+    // returns hasPassword, not the value, so the client can't resend it) — with
+    // the old `password || undefined`, setMany would DELETE the key and the AP
+    // would come back up OPEN. Only clear it if the caller explicitly asks.
+    const storedPassword = await get("hotspot_password");
+    const existingPassword = typeof storedPassword === "string" && storedPassword.length >= 8
+      ? storedPassword
+      : undefined;
+    const effectivePassword = password ? password : existingPassword;
+
     const updates: Record<string, unknown> = {
       hotspot_ssid: ssid.trim(),
-      hotspot_password: password || undefined,
+      hotspot_password: effectivePassword || undefined,
     };
     if (typeof enabled === "boolean") {
       updates.hotspot_enabled = enabled;
@@ -103,8 +114,8 @@ export async function POST(request: Request) {
 
     // Write shell-sourceable env file for start-ap.sh
     const envLines = [`HOTSPOT_SSID=${shellQuote(ssid.trim())}`];
-    if (password) {
-      envLines.push(`HOTSPOT_PASSWORD=${shellQuote(password)}`);
+    if (effectivePassword) {
+      envLines.push(`HOTSPOT_PASSWORD=${shellQuote(effectivePassword)}`);
     }
     if (!isEnabled) {
       envLines.push(`HOTSPOT_DISABLED=1`);

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -611,7 +611,11 @@ describe("POST /setup-api/ai-models/configure", () => {
   });
 
   it("handles missing auth profiles file", async () => {
-    mockFs.readFile.mockRejectedValue(new Error("ENOENT"));
+    // A genuinely absent file (ENOENT) → treated as no profiles yet. Real fs
+    // errors carry a `.code`; a message-only Error would now (correctly) be
+    // treated as an unexpected read failure and fail closed.
+    const enoent = Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
+    mockFs.readFile.mockRejectedValue(enoent);
 
     const res = await configurePost(jsonRequest({
       provider: "anthropic",


### PR DESCRIPTION
Three system/setup safety fixes.

- The hotspot handler deleted the stored WPA key whenever a request omitted `password` — which the Settings toggle and SSID-rename actions always do — silently bringing the AP back up as an OPEN network. It now preserves the stored password unless a new one is supplied.
- Factory reset deleted the WiFi profile and reset the login password BEFORE the gate that aborts the reboot on an incomplete wipe, so a single surviving file could strand a WiFi-only device offline with no way to retry. The gate now runs before any connectivity-destructive step.
- The AI-provider config read treated ANY read error (permissions, corruption) as 'no profiles', so a subsequent write would overwrite the file and lose other providers' stored credentials. It now only treats a genuinely absent file as empty and fails closed otherwise.

Build green, 1719 tests pass on-device.