### PR TITLE
fix(updater,gateway): reject flag-like branch, escape token in inline script, scope asset rewrite

### DIFF
--- a/src/app/setup-api/gateway/route.ts
+++ b/src/app/setup-api/gateway/route.ts
@@ -29,10 +29,21 @@ export async function GET(request: NextRequest) {
       ? rawHost
       : "clawbox.local";
     const wsUrl = `ws://${host}:${GATEWAY_PORT}`;
-    // Rewrite relative asset paths (./assets/... → /assets/...) so they
-    // resolve through Next.js rewrites which proxy to the gateway.
-    html = html.replace(/\.\//g, '/');
-    const safeToken = gatewayToken ? JSON.stringify(gatewayToken) : '""';
+    // Rewrite relative asset paths (href="./assets/…" / src="./assets/…" →
+    // "/assets/…") so they resolve through Next.js rewrites which proxy to the
+    // gateway. Anchored to href=/src= attributes so a bare "./" inside an inline
+    // script or text node isn't corrupted (the old global replace mangled any
+    // "./" in the document).
+    html = html.replace(/\b(href|src)=(["'])\.\//gi, '$1=$2/');
+    // Escape <, >, & (in addition to JSON.stringify) before embedding the token
+    // in the inline <script>, so a token value containing "</script>" can't
+    // break out of the script context (mirrors serveGatewayHTML()).
+    const safeToken = gatewayToken
+      ? JSON.stringify(gatewayToken)
+          .replace(/&/g, "\\u0026")
+          .replace(/</g, "\\u003c")
+          .replace(/>/g, "\\u003e")
+      : '""';
     const autoConnect = `<script>
       (function(){
         var KEY="openclaw.control.settings.v1";

--- a/src/app/setup-api/system/update-branch/route.ts
+++ b/src/app/setup-api/system/update-branch/route.ts
@@ -6,7 +6,10 @@ export const dynamic = "force-dynamic";
 
 const PROJECT_DIR = "/home/clawbox/clawbox";
 const UPDATE_BRANCH_FILE = path.join(PROJECT_DIR, ".update-branch");
-const SAFE_BRANCH = /^[A-Za-z0-9._\-/]+$/;
+// Reject a leading '-' (or '/') so an attacker-chosen branch can't smuggle a
+// git option flag (e.g. "-D"/"--all") into the updater's checkout/fetch and
+// brick it. Mirrors SAFE_BRANCH in src/lib/updater.ts.
+const SAFE_BRANCH = /^(?![-/])[A-Za-z0-9._\-/]+$/;
 
 function isEnoent(err: unknown): boolean {
   return !!(err && typeof err === "object" && "code" in err && err.code === "ENOENT");

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -179,7 +179,11 @@ async function startRootServiceFireAndForget(stepId: string): Promise<void> {
 }
 
 /** Validate branch name — only safe git ref characters allowed (prevents shell injection). */
-const SAFE_BRANCH = /^[A-Za-z0-9._\-/]+$/;
+// The negative lookahead rejects a leading '-' (or '/'): a branch token that
+// starts with '-' is parsed by git as an option flag (e.g. "-D", "--all")
+// rather than a ref, which smuggles switches into the checkout/fetch commands
+// and bricks the updater. Real branch names never start with '-' or '/'.
+const SAFE_BRANCH = /^(?![-/])[A-Za-z0-9._\-/]+$/;
 
 /**
  * Determine which branch to update to, in priority order:


### PR DESCRIPTION
Updater + gateway-proxy hardening.

- The web-settable update branch accepted values beginning with a hyphen, which git then parses as option flags (argument injection) — persistently bricking the updater. The validator now rejects a leading '-' (or '/').
- The gateway control-UI token was embedded into an inline <script> with JSON.stringify only, so a token containing </script> could break out of the script context. Now also escapes <, >, & (matching the sibling HTML serializer).
- The relative-asset-path rewrite was a global './'→'/' substitution that could corrupt any inline script or text containing './'. Scoped to href=/src= attributes.

Build green, 1719 tests pass on-device.