### PR TITLE
fix(agent-webapps): harden code-projects + tighten built-webapp iframe sandbox

### DIFF
--- a/src/app/app/[id]/page.tsx
+++ b/src/app/app/[id]/page.tsx
@@ -79,7 +79,13 @@ export default function StandaloneAppPage() {
             <iframe
               src={`/setup-api/webapps?app=${encodeURIComponent(id.replace("installed-", ""))}`}
               style={{ width: "100%", height: "100%", border: "none", background: "#fff" }}
-              sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+              // No allow-same-origin: webapps are served from the ClawBox origin,
+              // so allow-scripts + allow-same-origin together would give the
+              // framed app the REAL origin — letting a malicious/agent-built app
+              // fetch() the session-authenticated /setup-api routes and script
+              // the parent desktop. Dropping allow-same-origin forces an opaque
+              // origin; self-contained webapps still run fine.
+              sandbox="allow-scripts allow-forms allow-popups"
               title={id}
             />
           );

--- a/src/lib/code-projects.ts
+++ b/src/lib/code-projects.ts
@@ -87,6 +87,21 @@ function safePath(projectId: string, filePath: string): string {
   return resolved;
 }
 
+/**
+ * Guard a mutating (write/edit/delete) target. The raw-string `=== "project.json"`
+ * checks were bypassable with equivalent spellings ("./project.json"), and a
+ * path resolving to the project root itself ("." / "./") would let a single
+ * file-delete recursively wipe the whole project. Check the RESOLVED path.
+ */
+function assertMutableTarget(projectId: string, absPath: string): void {
+  if (path.basename(absPath) === "project.json") {
+    throw new ValidationError("Cannot modify project.json");
+  }
+  if (absPath === path.join(PROJECTS_DIR, projectId)) {
+    throw new ValidationError("Refusing to target the project root");
+  }
+}
+
 function projectDir(projectId: string): string {
   if (!validateProjectId(projectId)) throw new ValidationError("Invalid project ID");
   return path.join(PROJECTS_DIR, projectId);
@@ -187,13 +202,20 @@ h1 {
       "utf-8"
     );
 
+    // The name is written into app.js — once as a line comment and once inside
+    // a JS template literal assigned to innerHTML. escapeHtml alone leaves the
+    // template-literal metacharacters (` $ \) and newlines untouched, so a name
+    // like "`;fetch('/setup-api/...')`" would break out of the literal and run
+    // as code when the built app loads on the ClawBox origin (stored XSS).
+    const commentName = name.replace(/[\r\n]+/g, " ");
+    const innerName = jsTemplateEscape(escapeHtml(name));
     await fs.writeFile(
       path.join(dir, "app.js"),
-      `// ${escapeHtml(name)} — ClawBox Web App
+      `// ${commentName} — ClawBox Web App
 document.addEventListener('DOMContentLoaded', () => {
   const app = document.getElementById('app');
   app.innerHTML = \`
-    <h1>${escapeHtml(name)}</h1>
+    <h1>${innerName}</h1>
     <p>Edit the project files to build your app.</p>
   \`;
 });
@@ -289,8 +311,8 @@ export async function writeFile(
   filePath: string,
   content: string
 ): Promise<void> {
-  if (filePath === "project.json") throw new ValidationError("Cannot overwrite project.json");
   const absPath = safePath(projectId, filePath);
+  assertMutableTarget(projectId, absPath);
 
   const size = Buffer.byteLength(content, "utf-8");
   if (size > MAX_FILE_SIZE) {
@@ -318,8 +340,8 @@ export async function editFile(
   newString: string,
   replaceAll = false
 ): Promise<{ applied: number }> {
-  if (filePath === "project.json") throw new ValidationError("Cannot edit project.json");
   const absPath = safePath(projectId, filePath);
+  assertMutableTarget(projectId, absPath);
   let content = await fs.readFile(absPath, "utf-8");
 
   if (!content.includes(oldString)) {
@@ -357,8 +379,8 @@ export async function editFile(
 }
 
 export async function deleteFile(projectId: string, filePath: string): Promise<void> {
-  if (filePath === "project.json") throw new ValidationError("Cannot delete project.json");
   const absPath = safePath(projectId, filePath);
+  assertMutableTarget(projectId, absPath);
   await fs.rm(absPath, { recursive: true });
   await touchProject(projectId);
 }
@@ -377,14 +399,25 @@ export async function searchFiles(
 
   let matcher: (line: string) => boolean;
   if (opts?.regex) {
-    const flags = opts.caseSensitive ? "g" : "gi";
+    // Cap the pattern length to limit worst-case backtracking a caller can set
+    // up (JS has no native regex timeout; a pattern like "(a+)+$" over a long
+    // line backtracks exponentially and would block the single-threaded event
+    // loop). Combined with the per-line slice below this bounds the work.
+    if (pattern.length > 200) {
+      throw new ValidationError("Regex pattern too long (max 200 chars)");
+    }
+    // No global flag: only test() is used, and the 'g' flag makes test()
+    // stateful (persisting lastIndex), which silently skips alternating matches.
+    const flags = opts.caseSensitive ? "" : "i";
     let re: RegExp;
     try {
       re = new RegExp(pattern, flags);
     } catch {
       throw new ValidationError(`Invalid regex pattern: ${pattern}`);
     }
-    matcher = (line) => re.test(line);
+    // Bound each test to a slice so a pathological pattern against a very long
+    // line (files can be up to 512 KB) can't hang the process.
+    matcher = (line) => re.test(line.length > 2000 ? line.slice(0, 2000) : line);
   } else {
     const needle = opts?.caseSensitive ? pattern : pattern.toLowerCase();
     matcher = (line) =>
@@ -464,7 +497,9 @@ export async function buildProject(
         const jsPath = safePath(projectId, src);
         const js = await fs.readFile(jsPath, "utf-8");
         filesInlined++;
-        return `<script>\n${js}\n</script>`;
+        // Neutralize any literal "</script>" in the source so it can't close
+        // the inlined block early and dump the remainder into the DOM.
+        return `<script>\n${escapeScriptClose(js)}\n</script>`;
       } catch {
         return match;
       }
@@ -539,6 +574,19 @@ function escapeHtml(s: string): string {
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&#39;");
+}
+
+/** Escape a value for safe embedding inside a JS template literal (`...`). */
+function jsTemplateEscape(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\$/g, "\\$");
+}
+
+/** Neutralize a literal `</script` so inlined JS can't break out of a <script>. */
+function escapeScriptClose(s: string): string {
+  return s.replace(/<\/(script)/gi, "<\\/$1");
 }
 
 function isExternalUrl(href: string): boolean {


### PR DESCRIPTION
Hardening for agent-built code projects and how their webapps are framed.

- Code search compiled the user regex with a stateful global flag (dropping alternating matches) and had no bound on pattern/line length (catastrophic-backtracking DoS on the single-threaded server). Removed the flag; bounded pattern length and per-line match length.
- The 'don't touch project.json' guard and the project-root check used raw-string comparisons that equivalent spellings bypassed — letting the metadata file be clobbered or a single file-delete recursively wipe the whole project. Now checks the resolved path's basename and refuses the project root.
- The 'app' scaffold embedded the project name into generated JS via HTML-escaping only, so template-literal metacharacters could inject code that runs on the ClawBox origin. Now escaped for the JS-template context too; the build step also neutralizes a literal '</script>' when inlining JS.
- Built webapps were framed with allow-scripts + allow-same-origin from the ClawBox origin — a self-negating sandbox that let a framed app reach the session-authenticated APIs and script the desktop. Dropped allow-same-origin (opaque origin).

Build green, 1719 tests pass on-device.