### PR TITLE
fix(apps): gate apps/settings pre-setup, timeout icon fetch, reject flag-like appId, align icon path

### DIFF
--- a/src/app/setup-api/apps/install/route.ts
+++ b/src/app/setup-api/apps/install/route.ts
@@ -74,7 +74,12 @@ async function downloadIcon(appId: string): Promise<{ saved: boolean }> {
   const iconUrl = `${STORE_ICONS_BASE}/${appId}.png`;
   const iconPath = path.join(ICONS_DIR, `${appId}.png`);
   try {
-    const [res] = await Promise.all([fetch(iconUrl), fs.mkdir(ICONS_DIR, { recursive: true })]);
+    // Bound the icon fetch: it's awaited inline before the install proceeds, so
+    // a stalled ClawHub host would otherwise hang the whole install request.
+    const [res] = await Promise.all([
+      fetch(iconUrl, { signal: AbortSignal.timeout(10_000) }),
+      fs.mkdir(ICONS_DIR, { recursive: true }),
+    ]);
     if (!res.ok) return { saved: false };
     const buffer = Buffer.from(await res.arrayBuffer());
     await fs.writeFile(iconPath, buffer);
@@ -188,7 +193,10 @@ async function reloadGatewaySafely(): Promise<string | undefined> {
 export async function POST(req: Request) {
   try {
     const { appId } = await req.json();
-    if (!appId || typeof appId !== "string" || !/^[A-Za-z0-9_-]+$/.test(appId)) {
+    // Reject a leading hyphen: appId is passed positionally to
+    // `openclaw skills install <appId>`, so "-x"/"--force" would be parsed as a
+    // CLI flag rather than a package name.
+    if (!appId || typeof appId !== "string" || !/^(?!-)[A-Za-z0-9_-]+$/.test(appId)) {
       return NextResponse.json({ error: "Invalid appId" }, { status: 400 });
     }
 

--- a/src/app/setup-api/apps/uninstall/route.ts
+++ b/src/app/setup-api/apps/uninstall/route.ts
@@ -1,17 +1,15 @@
 import { NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
-import { getAll as configGetAll, setMany as configSetMany } from "@/lib/config-store";
+import { DATA_DIR, getAll as configGetAll, setMany as configSetMany } from "@/lib/config-store";
 import { reloadGateway, getSkillsDir } from "@/lib/openclaw-config";
 
 export const dynamic = "force-dynamic";
 
-const HOME = process.env.HOME || "/home/clawbox";
-
 export async function POST(req: Request) {
   try {
     const { appId } = await req.json();
-    if (!appId || typeof appId !== "string" || !/^[A-Za-z0-9_-]+$/.test(appId)) {
+    if (!appId || typeof appId !== "string" || !/^(?!-)[A-Za-z0-9_-]+$/.test(appId)) {
       return NextResponse.json({ error: "Invalid appId" }, { status: 400 });
     }
 
@@ -23,8 +21,10 @@ export async function POST(req: Request) {
     }
     await fs.rm(skillDir, { recursive: true, force: true });
 
-    // Remove cached icon
-    const iconPath = path.join(HOME, "clawbox", "data", "icons", `${appId}.png`);
+    // Remove cached icon from the same location the install/icon routes use
+    // (DATA_DIR/icons). The old hardcoded ~/clawbox/data/icons path diverged
+    // whenever CLAWBOX_ROOT != $HOME/clawbox, orphaning the PNG on disk.
+    const iconPath = path.join(DATA_DIR, "icons", `${appId}.png`);
     await fs.rm(iconPath, { force: true }).catch(() => {});
 
     // Keep the desktop's `installed_apps` and `installed_meta` preferences

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -139,6 +139,7 @@ const PRE_AUTH_SENSITIVE_PREFIXES = [
   "/setup-api/portal",      // same privileged tunnel start/stop/enable as /tunnel
   "/setup-api/apps/install",
   "/setup-api/apps/uninstall",
+  "/setup-api/apps/settings",  // privileged `openclaw config set skills.*` + credential writes
   "/setup-api/gateway/ws-config", // hands back the live gateway auth token
 ];
 // Exact-match only: a bare `/setup-api/gateway` subtree deny would also catch

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -474,6 +474,7 @@ describe("middleware", () => {
       "/setup-api/tunnel/enable",
       "/setup-api/portal/start", // same privileged tunnel control as /tunnel
       "/setup-api/portal/stop",
+      "/setup-api/apps/settings",
       "/setup-api/apps/install",
       "/setup-api/apps/uninstall",
       "/setup-api/gateway/ws-config",


### PR DESCRIPTION
App-store route hardening.

- apps/settings performs privileged 'openclaw config set skills.*' writes and stored credentials, but was missing from the pre-setup sensitive-surface gate — reachable unauthenticated during the open setup-AP window (unlike apps/install and apps/uninstall). Added to the gate + regression test.
- The install route's icon fetch had no timeout and is awaited inline before the install proceeds, so a stalled host would hang the whole request. Bounded with a 10s abort.
- The appId validator accepted a leading hyphen, so an appId is passed positionally to 'openclaw skills install <appId>' and a '-x' token would be parsed as a CLI flag. Now rejects a leading hyphen (install + uninstall).
- Uninstall deleted the cached icon from a hardcoded path that diverged from where install actually writes it (DATA_DIR/icons), orphaning the PNG. Now uses the same path.

Build green, 1720 tests pass on-device.