### PR TITLE
fix(oauth): keep auth-code tokens off the browser via server-side handoff

### DIFF
--- a/src/app/setup-api/ai-models/oauth/exchange/route.ts
+++ b/src/app/setup-api/ai-models/oauth/exchange/route.ts
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
+import crypto from "crypto";
 import fs from "fs/promises";
 import path from "path";
 import { DATA_DIR } from "@/lib/config-store";
@@ -8,6 +9,30 @@ import { OAUTH_PROVIDERS, isGoogleConfigured } from "@/lib/oauth-config";
 import { discoverGoogleProject } from "@/lib/google-project";
 
 const STATE_PATH = path.join(DATA_DIR, "oauth-state.json");
+// Server-only handoff file the configure route reads on the `oauthHandoff`
+// path — the SAME file the device-code flow (device-poll) uses.
+const TOKENS_PATH = path.join(DATA_DIR, "oauth-device-tokens.json");
+
+// Persist the freshly-issued provider tokens to a 0600 server file and return
+// just a status, so the access/refresh/id tokens never travel back through the
+// browser across the plain-HTTP setup-AP hop (the device-code flow already does
+// this; the auth-code flow here now matches). The non-secret Google projectId
+// is safe to return for the client to relay in the (tokenless) configure body.
+async function persistTokensAndAck(
+  provider: string,
+  tokens: { access_token?: string; id_token?: string; refresh_token?: string; expires_in?: number },
+  extra?: { projectId?: string },
+): Promise<NextResponse> {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  const tmpPath = `${TOKENS_PATH}.tmp.${crypto.randomBytes(8).toString("hex")}`;
+  await fs.writeFile(
+    tmpPath,
+    JSON.stringify({ provider, ...tokens, createdAt: Date.now() }),
+    { mode: 0o600 },
+  );
+  await fs.rename(tmpPath, TOKENS_PATH);
+  return NextResponse.json({ status: "complete", ...(extra?.projectId ? { projectId: extra.projectId } : {}) });
+}
 
 function parseErrorMessage(text: string, status: number): string {
   try {
@@ -156,7 +181,7 @@ export async function POST(request: Request) {
       const orgPath = path.join(path.dirname(STATE_PATH), "oauth-org.json");
       await fs.unlink(orgPath).catch(() => {});
 
-      return NextResponse.json({
+      return persistTokensAndAck("openai", {
         access_token: tokenData.access_token,
         id_token: tokenData.id_token,
         refresh_token: tokenData.refresh_token,
@@ -179,12 +204,15 @@ export async function POST(request: Request) {
       }
     }
 
-    return NextResponse.json({
-      access_token: tokenData.access_token,
-      refresh_token: tokenData.refresh_token,
-      expires_in: tokenData.expires_in,
-      ...(projectId ? { projectId } : {}),
-    });
+    return persistTokensAndAck(
+      provider,
+      {
+        access_token: tokenData.access_token,
+        refresh_token: tokenData.refresh_token,
+        expires_in: tokenData.expires_in,
+      },
+      { projectId },
+    );
   } catch (err) {
     return NextResponse.json(
       {

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -1198,6 +1198,10 @@ export default function AIModelsStep({
             provider: selectedProvider,
             authMode: "subscription",
             oauthHandoff: true,
+            // projectId is not a secret (a GCP identifier) — relay it in the
+            // body for the Google handoff since the server-only token file
+            // doesn't carry it.
+            ...(tokenData.projectId ? { projectId: tokenData.projectId } : {}),
             ...(subscriptionModel ? { model: subscriptionModel } : {}),
           }
         : {
@@ -1390,9 +1394,14 @@ export default function AIModelsStep({
       if (!exchangeRes.ok) return showError(await extractError(exchangeRes, "Token exchange failed"));
       const tokenData = await exchangeRes.json();
       if (controller.signal.aborted) return;
-      if (!tokenData.access_token) return showError("No access token received");
-
-      await saveOAuthToken(tokenData);
+      // Exchange now persists the tokens server-side and returns only a status
+      // (keeping access/refresh/id tokens off the plain-HTTP setup-AP hop), so
+      // complete the config through the same server-side handoff the
+      // device-code flow uses. projectId (non-secret) is relayed for Google.
+      if (tokenData.status !== "complete") {
+        return showError(tokenData.error || "Sign-in did not complete");
+      }
+      await saveOAuthToken({ oauthHandoff: true, projectId: tokenData.projectId });
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       showError(`Failed: ${err instanceof Error ? err.message : err}`);

--- a/src/tests/oauth-routes.test.ts
+++ b/src/tests/oauth-routes.test.ts
@@ -12,6 +12,7 @@ const TEST_ROOT = path.join(
 const DATA_DIR = path.join(TEST_ROOT, "data");
 const STATE_PATH = path.join(DATA_DIR, "oauth-state.json");
 const ORG_PATH = path.join(DATA_DIR, "oauth-org.json");
+const TOKENS_PATH = path.join(DATA_DIR, "oauth-device-tokens.json");
 
 let startPost: RoutePost;
 let exchangePost: RoutePost;
@@ -323,11 +324,14 @@ describe("OAuth exchange route", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({
-      access_token: "anthropic_access",
-      refresh_token: "anthropic_refresh",
-      expires_in: 1800,
-    });
+    // Tokens are now persisted server-side and NOT returned to the browser —
+    // the response is just a status, and the tokens land in the 0600 handoff
+    // file the configure route reads.
+    expect(body).toEqual({ status: "complete" });
+    const persisted = JSON.parse(await fs.readFile(TOKENS_PATH, "utf-8"));
+    expect(persisted.provider).toBe("anthropic");
+    expect(persisted.access_token).toBe("anthropic_access");
+    expect(persisted.refresh_token).toBe("anthropic_refresh");
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -368,7 +372,10 @@ describe("OAuth exchange route", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.access_token).toBe("anthropic_access");
+    expect(body.status).toBe("complete");
+    const persisted = JSON.parse(await fs.readFile(TOKENS_PATH, "utf-8"));
+    expect(persisted.provider).toBe("anthropic");
+    expect(persisted.access_token).toBe("anthropic_access");
     const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
     expect(firstCall[0]).toBe("https://console.anthropic.com/v1/oauth/token");
   });
@@ -399,7 +406,7 @@ describe("OAuth exchange route", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.access_token).toBe("anthropic_access");
+    expect(body.status).toBe("complete");
   });
 
   it("returns 504 when token exchange times out", async () => {
@@ -487,12 +494,13 @@ describe("OAuth exchange route", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body).toEqual({
-      access_token: "oauth_access_token",
-      id_token: "id-token-123",
-      refresh_token: "oauth_refresh_token",
-      expires_in: 3600,
-    });
+    // Tokens persist server-side; the browser only sees a status.
+    expect(body).toEqual({ status: "complete" });
+    const persisted = JSON.parse(await fs.readFile(TOKENS_PATH, "utf-8"));
+    expect(persisted.provider).toBe("openai");
+    expect(persisted.access_token).toBe("oauth_access_token");
+    expect(persisted.id_token).toBe("id-token-123");
+    expect(persisted.refresh_token).toBe("oauth_refresh_token");
     expect(fetchMock).toHaveBeenCalledTimes(1);
 
     const firstCall = fetchMock.mock.calls[0] as [string, RequestInit];
@@ -652,7 +660,9 @@ describe("OAuth exchange route", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.access_token).toBe("oauth_access_token");
+    expect(body.status).toBe("complete");
+    const persisted = JSON.parse(await fs.readFile(TOKENS_PATH, "utf-8"));
+    expect(persisted.access_token).toBe("oauth_access_token");
   });
 
   it("continues when post-success state cleanup unlink fails", async () => {
@@ -676,7 +686,7 @@ describe("OAuth exchange route", () => {
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.access_token).toBe("oauth_access_token");
+    expect(body.status).toBe("complete");
   });
 });
 


### PR DESCRIPTION
The redirect (auth-code) OAuth flow returned the provider access/refresh/id tokens to the browser, which then relayed them to /configure — so during first-boot setup they crossed the plain-HTTP setup-AP twice, where a passive Wi-Fi eavesdropper could capture them. The device-code flow already avoided this by persisting tokens to a 0600 server file and returning only a status.

This makes the auth-code exchange do the same: it persists the tokens to the same server-only handoff file and returns just {status:"complete"}; the client completes configuration through the existing server-side handoff path (no token fields sent). The non-secret Google projectId is still relayed in the body.

Unit tests updated to assert the handoff behavior. Build green, 1719 tests pass on-device.

Note: the live interactive redirect flow should get a verification pass on beta — the plumbing mirrors the already-working device-code handoff and is unit-covered, but interactive OAuth wasn't exercised end-to-end here.