### PR TITLE
fix: make the setup wizard edition-aware where it still assumed the OpenClaw gateway

### DIFF
--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -51,6 +51,12 @@ interface Props {
   testId?: string;
 }
 
+// The OpenClaw AI-models step advances the wizard ~900 ms after a successful
+// configure (AIModelsStep's handleConfiguringDone), which is long enough for the
+// "connected" state to register and short enough not to feel stalled. This panel
+// is the SAME step on a Hermes device, so it advances the same way.
+const AUTO_ADVANCE_DELAY_MS = 900;
+
 function readStoredUiTier(): ClawaiTier {
   if (typeof window === "undefined") return "flash";
   try {
@@ -98,6 +104,32 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
   const [apiKey, setApiKey] = useState("");
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<Status>(null);
+
+  // ── Auto-advance ───────────────────────────────────────────────────────────
+  //
+  // Set ONLY once a configure round-trip has actually succeeded — a provider
+  // sign-in that happens out of band (the dashboard's own OAuth page, opened in
+  // another tab by openHermesOAuth) deliberately does NOT set it: returning from
+  // that tab has not configured anything yet, the user still has to save. So a
+  // half-finished sign-in can never carry the wizard forward.
+  const [configured, setConfigured] = useState(false);
+  const advancedRef = useRef(false);
+  // `onNext` is an inline arrow from the wizard, so its identity changes on
+  // every parent render. Held in a ref so a re-render cannot restart the timer.
+  const onNextRef = useRef(onNext);
+  useEffect(() => { onNextRef.current = onNext; }, [onNext]);
+
+  useEffect(() => {
+    // Settings embeds this panel with nowhere to advance to; only the wizard
+    // passes an onNext.
+    if (!configured || embedded) return;
+    const timer = setTimeout(() => {
+      if (advancedRef.current) return;
+      advancedRef.current = true;
+      onNextRef.current?.();
+    }, AUTO_ADVANCE_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [configured, embedded]);
 
   // Tell an already-open chat popup that this device's provider/model/tier
   // changed, so its header re-seeds instead of naming the previous provider
@@ -260,9 +292,12 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
     onBusyChange: setLoginBusy,
     onConfiguring: () => setClawaiStatus({ kind: "ok", msg: "Finishing setup on this device…" }),
     onComplete: () => {
+      // Only reached on the poll's terminal `complete` status, i.e. after the
+      // device finished configuring — never mid-handshake.
       void reloadClawai();
       setSelectedProvider(CLAWAI_PROVIDER);
       setClawaiStatus({ kind: "ok", msg: "ClawBox AI is now your active model" });
+      setConfigured(true);
     },
     onError: (msg) => setClawaiStatus({ kind: "err", msg }),
   });
@@ -310,6 +345,7 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
     setSelectedProvider(CLAWAI_PROVIDER);
     notifyChatHeader();
     setClawaiStatus({ kind: "ok", msg: "ClawBox AI is now your active model" });
+    setConfigured(true);
   }
 
   async function applyClawai() {
@@ -331,6 +367,7 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
       setAppliedUiTier(uiTier);
       setClawaiStatus({ kind: "ok", msg: "ClawBox AI is now your active model" });
       notifyChatHeader();
+      setConfigured(true);
     } catch (e) {
       setClawaiStatus({ kind: "err", msg: e instanceof Error ? e.message : "Couldn't switch to ClawBox AI" });
     } finally {
@@ -400,6 +437,7 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
       if (!modelInScope) refreshModels();
       setSaveStatus({ kind: "ok", msg: savingKey ? "Key saved — provider & model updated" : "Saved" });
       notifyChatHeader();
+      setConfigured(true);
     } catch (e) {
       setSaveStatus({ kind: "err", msg: e instanceof Error ? e.message : "Save failed" });
     } finally {

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -13,21 +13,9 @@ import StatusMessage from "./StatusMessage";
 import ReconnectingOverlay from "./ReconnectingOverlay";
 import { useT, I18nProvider, LANGUAGES, type Locale } from "@/lib/i18n";
 import { DISCORD_INVITE_URL } from "@/lib/community";
-import { cachedEdition, fetchHarness } from "@/lib/client-harness";
+import { cachedEdition, resolveEdition } from "@/lib/client-harness";
 
 const SETUP_COMPLETION_MAX_HEALTH_CHECKS = 6;
-
-/**
- * The device edition, for edition-aware completion copy and readiness.
- *
- * Served from the shared client cache (src/lib/client-harness.ts), which the
- * AI-models step has already warmed by the time setup completes — so this is a
- * free read in practice, and at worst one round-trip per document. A device
- * that cannot answer is treated as OpenClaw, the native product edition.
- */
-async function resolveEdition(): Promise<string> {
-  return cachedEdition() ?? (await fetchHarness())?.edition ?? "openclaw";
-}
 
 async function extractErrorMessage(res: Response, fallback: string) {
   const data = await res.json().catch(() => ({}));

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -13,8 +13,21 @@ import StatusMessage from "./StatusMessage";
 import ReconnectingOverlay from "./ReconnectingOverlay";
 import { useT, I18nProvider, LANGUAGES, type Locale } from "@/lib/i18n";
 import { DISCORD_INVITE_URL } from "@/lib/community";
+import { cachedEdition, fetchHarness } from "@/lib/client-harness";
 
 const SETUP_COMPLETION_MAX_HEALTH_CHECKS = 6;
+
+/**
+ * The device edition, for edition-aware completion copy and readiness.
+ *
+ * Served from the shared client cache (src/lib/client-harness.ts), which the
+ * AI-models step has already warmed by the time setup completes — so this is a
+ * free read in practice, and at worst one round-trip per document. A device
+ * that cannot answer is treated as OpenClaw, the native product edition.
+ */
+async function resolveEdition(): Promise<string> {
+  return cachedEdition() ?? (await fetchHarness())?.edition ?? "openclaw";
+}
 
 async function extractErrorMessage(res: Response, fallback: string) {
   const data = await res.json().catch(() => ({}));
@@ -254,17 +267,29 @@ function LanguageMenu({
 function SetupCompletionOverlay({
   phase,
   completed,
+  hermes,
   t,
 }: {
   phase: number;
   completed: boolean;
+  /** Hermes edition: this device ships without the OpenClaw gateway. */
+  hermes: boolean;
   t: (key: string) => string;
 }) {
-  const steps = [
-    t("ai.restartingGateway"),
-    t("telegram.waitingGateway"),
-    t("ai.almostReady"),
-  ];
+  // A Hermes-edition box has no OpenClaw gateway installed at all (the unit is
+  // masked), so gateway copy would name a service that does not exist on the
+  // device — and the customer would be watching a spinner for it.
+  const steps = hermes
+    ? [
+        t("wizard.completionHermesSaving"),
+        t("wizard.completionHermesStarting"),
+        t("ai.almostReady"),
+      ]
+    : [
+        t("ai.restartingGateway"),
+        t("telegram.waitingGateway"),
+        t("ai.almostReady"),
+      ];
 
   return (
     <div className="w-full max-w-[520px]" data-testid="setup-completion-overlay">
@@ -314,7 +339,11 @@ function SetupCompletionOverlay({
 
           <div className="text-center setup-finish-fade-in" style={{ animationDelay: "0.2s" }}>
             <h2 className="text-lg font-bold text-[var(--text-primary)] mb-1">
-              {completed ? t("connected") : t("openclaw.connecting")}
+              {completed
+                ? t("connected")
+                : hermes
+                  ? t("wizard.completionHermesTitle")
+                  : t("openclaw.connecting")}
             </h2>
             <p className="text-sm text-[var(--text-muted)]">
               {completed ? t("ai.almostReady") : t("ai.pleaseDontClose")}
@@ -351,7 +380,7 @@ function SetupCompletionOverlay({
 
           {!completed && (
             <p className="text-xs text-[var(--text-muted)] text-center mt-2 setup-finish-fade-in" style={{ animationDelay: "0.3s" }}>
-              {t("telegram.pleaseWait")}
+              {hermes ? t("wizard.completionHermesWait") : t("telegram.pleaseWait")}
             </p>
           )}
         </div>
@@ -384,6 +413,22 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
   const [showHelp, setShowHelp] = useState(false);
   const [showLang, setShowLang] = useState(false);
   const [restarting, setRestarting] = useState(false);
+  // Device edition. Seeded from the process-wide cache (the edition is baked
+  // into a root-owned env file and cannot change under a live page), so on a
+  // resume it is already known and the completion overlay never paints the
+  // wrong product's copy for a frame.
+  const [edition, setEdition] = useState<string | null>(() => cachedEdition());
+  const isHermesEdition = edition === "hermes";
+
+  useEffect(() => {
+    if (edition !== null) return;
+    let alive = true;
+    void resolveEdition().then((value) => { if (alive) setEdition(value); });
+    return () => { alive = false; };
+    // Runs once: `edition` is only read to skip a redundant fetch and it never
+    // returns to null.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const persistSetupProgress = useCallback(async (step: number) => {
     try {
@@ -464,6 +509,43 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
       return false;
     }
 
+    /**
+     * Readiness on a Hermes-edition device.
+     *
+     * There is no OpenClaw gateway to poll here — it is not installed and its
+     * unit is masked, so /setup-api/gateway/health could only ever run out its
+     * attempts. What DOES have to come up is the Hermes dashboard
+     * (clawbox-hermes-dashboard.service, which the proxy unit fronts), and the
+     * models route reports exactly that: `stale` is false only when the live
+     * dashboard answered — every fallback source (the on-disk catalog, a cold
+     * start) is flagged stale. See src/lib/hermes-model-options.ts.
+     *
+     * The route is one the wizard already calls from the AI-models step, and by
+     * this point /setup/complete has issued the session cookie — so this adds no
+     * new surface and needs no new carve-out.
+     */
+    async function pollHermesReady() {
+      for (let attempt = 0; attempt < SETUP_COMPLETION_MAX_HEALTH_CHECKS; attempt += 1) {
+        if (cancelled) return false;
+        try {
+          // Unlike the gateway's TCP probe this route talks to the dashboard,
+          // so it gets its own deadline: a socket that accepts and then hangs
+          // must not stall the loop past the attempt budget.
+          const res = await fetch("/setup-api/hermes/models", {
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (res.ok) {
+            const data = await res.json();
+            if (data.stale === false) return true;
+          }
+        } catch {
+          // The agent's dashboard is still coming up.
+        }
+        await delay(2000);
+      }
+      return false;
+    }
+
     async function postCompleteWithRetry(): Promise<Response> {
       // The POST can fail transiently if the gateway restart from the AI
       // step is still settling, or the browser's connection is briefly
@@ -505,9 +587,20 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
         if (cancelled) return;
         setCompletionPhase(1);
 
-        const gatewayAvailable = await pollGatewayHealth();
-        if (!gatewayAvailable) {
-          console.warn("[SetupWizard] Gateway health did not become available during setup completion; continuing offline.");
+        // Resolve the edition inside the run rather than reading the state
+        // above it: the completion effect must never poll a harness this
+        // device does not ship, even on the resume path where the overlay is
+        // mounted before the mount effect has landed. The lookup is cached, so
+        // this costs nothing on the normal path.
+        const activeEdition = await resolveEdition();
+        if (cancelled) return;
+        setEdition(activeEdition);
+
+        const agentAvailable = activeEdition === "hermes"
+          ? await pollHermesReady()
+          : await pollGatewayHealth();
+        if (!agentAvailable) {
+          console.warn("[SetupWizard] The agent did not report ready during setup completion; continuing offline.");
         }
         if (cancelled) return;
 
@@ -658,7 +751,12 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
       <main className="setup-main">
         <div className="w-full flex flex-col items-center">
         {completionStarted ? (
-          <SetupCompletionOverlay phase={completionPhase} completed={completionComplete} t={t} />
+          <SetupCompletionOverlay
+            phase={completionPhase}
+            completed={completionComplete}
+            hermes={isHermesEdition}
+            t={t}
+          />
         ) : (
           <>
             {/* Completion failed and is no longer in flight (we're in the

--- a/src/components/TelegramConfiguringOverlay.tsx
+++ b/src/components/TelegramConfiguringOverlay.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useT } from "@/lib/i18n";
+import { cachedEdition, resolveEdition } from "@/lib/client-harness";
 
 interface TelegramConfiguringOverlayProps {
   onDone: () => void;
@@ -15,7 +16,7 @@ interface TelegramConfiguringOverlayProps {
    */
   waitFor?: Promise<void>;
   /**
-   * Max ms to poll gateway health before giving up. When the poll times
+   * Max ms to poll for readiness before giving up. When the poll times
    * out, the overlay calls onDone() without transitioning to phase 4 so
    * the parent can surface its own error instead of falsely reporting
    * "ready". Default: 60_000.
@@ -30,11 +31,22 @@ export default function TelegramConfiguringOverlay({
 }: TelegramConfiguringOverlayProps) {
   const { t } = useT();
 
+  // Device edition. Seeded from the process-wide cache (immutable for the life
+  // of the document) and otherwise resolved by the effect below, well before
+  // phase 2 — the step whose label differs — becomes visible.
+  const [edition, setEdition] = useState<string | null>(() => cachedEdition());
+  const isHermes = edition === "hermes";
+
+  // A Hermes device has no OpenClaw gateway to restart or wait for: the unit is
+  // masked and restartGateway() is a documented no-op there. What the configure
+  // route actually brings up on this edition is Hermes' own messaging gateway —
+  // the process that receives Telegram messages — so that is what the middle
+  // two steps name.
   const CONFIGURING_STEPS = [
     { label: t("telegram.tokenVerified") },
     { label: t("telegram.connectingTelegram") },
-    { label: t("telegram.restartingGateway") },
-    { label: t("telegram.waitingGateway") },
+    { label: isHermes ? t("telegram.hermesStartingService") : t("telegram.restartingGateway") },
+    { label: isHermes ? t("telegram.hermesWaitingService") : t("telegram.waitingGateway") },
     { label: t("telegram.readyToChat") },
   ];
 
@@ -54,9 +66,10 @@ export default function TelegramConfiguringOverlay({
       });
     }
 
+    const POLL_INTERVAL_MS = 2000;
+    const maxAttempts = Math.ceil(healthTimeoutMs / POLL_INTERVAL_MS);
+
     async function pollGatewayHealth(): Promise<boolean> {
-      const pollIntervalMs = 2000;
-      const maxAttempts = Math.ceil(healthTimeoutMs / pollIntervalMs);
       for (let i = 0; i < maxAttempts; i++) {
         if (cancelledRef.current) return false;
         try {
@@ -66,12 +79,58 @@ export default function TelegramConfiguringOverlay({
             if (data.available) return true;
           }
         } catch { /* gateway not ready yet */ }
-        await delay(pollIntervalMs);
+        await delay(POLL_INTERVAL_MS);
+      }
+      return false;
+    }
+
+    /**
+     * Readiness on a Hermes-edition device.
+     *
+     * /setup-api/gateway/health is meaningless here — the OpenClaw gateway is
+     * not installed and its unit is masked, so polling it burned the whole
+     * healthTimeoutMs budget and then called onDone() having never reached the
+     * "ready to chat" phase. The owner saw a minute of spinner and no green
+     * check on a save that had actually succeeded.
+     *
+     * The equivalent signal on this edition is Hermes' messaging gateway, which
+     * is what the configure route brings up (ensureHermesGateway) and what
+     * decides whether the bot answers at all. /setup-api/telegram/status already
+     * reports it: `receiving` is true only when the token is registered with
+     * Hermes AND that gateway is running — the same "something is listening"
+     * meaning `available` carries on the OpenClaw side.
+     *
+     * The route caches its Hermes probe for 15 s, so polling every 2 s costs at
+     * most one real CLI round-trip per window rather than one per attempt.
+     */
+    async function pollHermesTelegramReady(): Promise<boolean> {
+      for (let i = 0; i < maxAttempts; i++) {
+        if (cancelledRef.current) return false;
+        try {
+          const res = await fetch("/setup-api/telegram/status", {
+            cache: "no-store",
+            // The probe shells out to the Hermes CLI; a request that stalls
+            // must not eat more of the budget than one attempt is worth.
+            signal: AbortSignal.timeout(10_000),
+          });
+          if (res.ok) {
+            const data = await res.json();
+            if (data.receiving === true) return true;
+          }
+        } catch { /* messaging gateway not up yet */ }
+        await delay(POLL_INTERVAL_MS);
       }
       return false;
     }
 
     async function run() {
+      // Resolve before the phase machine reaches the steps whose meaning
+      // depends on it. Cached, so this is a no-op read in the normal case.
+      const activeEdition = await resolveEdition();
+      if (cancelledRef.current) return;
+      setEdition(activeEdition);
+      const hermes = activeEdition === "hermes";
+
       await delay(1500);
       if (cancelledRef.current) return;
       setPhase(1);
@@ -86,18 +145,18 @@ export default function TelegramConfiguringOverlay({
 
       // Wait for BOTH signals before declaring ready:
       //   1. the caller's configure request has succeeded (waitFor)
-      //   2. gateway health reports available again after the restart
-      // Running them concurrently matches the phase-3 "waiting gateway"
-      // spinner the user already sees — we don't want to add more delay,
-      // just make sure neither completes prematurely.
+      //   2. the harness's own messaging path reports it is listening again
+      // Running them concurrently matches the phase-3 spinner the user already
+      // sees — we don't want to add more delay, just make sure neither
+      // completes prematurely.
       const [ready] = await Promise.all([
-        pollGatewayHealth(),
+        hermes ? pollHermesTelegramReady() : pollGatewayHealth(),
         waitFor ?? Promise.resolve(),
       ]);
       if (cancelledRef.current) return;
       if (!ready) {
-        // Gateway never came back within healthTimeoutMs — hand control
-        // back to the parent without pretending we finished.
+        // Nothing reported itself listening within healthTimeoutMs — hand
+        // control back to the parent without pretending we finished.
         onDone();
         return;
       }
@@ -211,7 +270,7 @@ export default function TelegramConfiguringOverlay({
 
       {phase >= 1 && phase < 4 && (
         <p className="text-xs text-[var(--text-muted)] text-center mt-2 tg-step-enter">
-          {t("telegram.pleaseWait")}{dots}
+          {isHermes ? t("telegram.hermesPleaseWait") : t("telegram.pleaseWait")}{dots}
         </p>
       )}
     </div>

--- a/src/lib/client-harness.ts
+++ b/src/lib/client-harness.ts
@@ -92,3 +92,18 @@ export function fetchHarness(options?: {
   if (!options?.force) inFlight = request;
   return request;
 }
+
+/**
+ * The device edition, for edition-aware UI and readiness checks.
+ *
+ * Served from the caches above, so callers can reach for it freely: once any
+ * component has asked, it costs nothing for the rest of the document's life. A
+ * device that cannot answer is treated as OpenClaw, the native product edition.
+ *
+ * Lives here rather than in a component because more than one screen has to
+ * make the same "is there an OpenClaw gateway on this box?" decision, and two
+ * copies of the fallback would eventually disagree.
+ */
+export async function resolveEdition(): Promise<string> {
+  return cachedEdition() ?? (await fetchHarness())?.edition ?? "openclaw";
+}

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -236,6 +236,11 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "Waiting for gateway",
     "telegram.readyToChat": "Ready to chat",
     "telegram.botReady": "Telegram bot is ready",
+    // Hermes edition: the OpenClaw gateway is absent, and what the configure
+    // step actually starts is Hermes' own messaging gateway.
+    "telegram.hermesStartingService": "Starting the messaging service",
+    "telegram.hermesWaitingService": "Waiting for the messaging service",
+    "telegram.hermesPleaseWait": "Please wait while the messaging service starts",
 
     // === SetupWizard ===
     "wizard.help1Title": "Connecting to the Internet",
@@ -662,6 +667,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "Изчакване на gateway",
     "telegram.readyToChat": "Готово за чат",
     "telegram.botReady": "Telegram ботът е готов",
+    "telegram.hermesStartingService": "Стартиране на услугата за съобщения",
+    "telegram.hermesWaitingService": "Изчакване на услугата за съобщения",
+    "telegram.hermesPleaseWait": "Моля, изчакайте, докато услугата за съобщения стартира",
 
     // === SetupWizard ===
     "wizard.help1Title": "Свързване с интернет",
@@ -1085,6 +1093,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "Warte auf Gateway",
     "telegram.readyToChat": "Bereit zum Chatten",
     "telegram.botReady": "Telegram-Bot ist bereit",
+    "telegram.hermesStartingService": "Nachrichtendienst wird gestartet",
+    "telegram.hermesWaitingService": "Warte auf den Nachrichtendienst",
+    "telegram.hermesPleaseWait": "Bitte warten Sie, während der Nachrichtendienst startet",
 
     // === SetupWizard ===
     "wizard.help1Title": "Internetverbindung herstellen",
@@ -1508,6 +1519,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "Esperando al gateway",
     "telegram.readyToChat": "Listo para chatear",
     "telegram.botReady": "El bot de Telegram está listo",
+    "telegram.hermesStartingService": "Iniciando el servicio de mensajería",
+    "telegram.hermesWaitingService": "Esperando al servicio de mensajería",
+    "telegram.hermesPleaseWait": "Espera mientras se inicia el servicio de mensajería",
 
     // === SetupWizard ===
     "wizard.help1Title": "Conexión a Internet",
@@ -1931,6 +1945,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "En attente du gateway",
     "telegram.readyToChat": "Prêt à discuter",
     "telegram.botReady": "Le bot Telegram est prêt",
+    "telegram.hermesStartingService": "Démarrage du service de messagerie",
+    "telegram.hermesWaitingService": "En attente du service de messagerie",
+    "telegram.hermesPleaseWait": "Veuillez patienter pendant le démarrage du service de messagerie",
 
     // === SetupWizard ===
     "wizard.help1Title": "Connexion à Internet",
@@ -2354,6 +2371,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "In attesa del gateway",
     "telegram.readyToChat": "Pronto per chattare",
     "telegram.botReady": "Il bot Telegram è pronto",
+    "telegram.hermesStartingService": "Avvio del servizio di messaggistica",
+    "telegram.hermesWaitingService": "In attesa del servizio di messaggistica",
+    "telegram.hermesPleaseWait": "Attendi mentre il servizio di messaggistica si avvia",
 
     // === SetupWizard ===
     "wizard.help1Title": "Connessione a Internet",
@@ -2777,6 +2797,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "ゲートウェイを待機中",
     "telegram.readyToChat": "チャット準備完了",
     "telegram.botReady": "Telegramボットの準備ができました",
+    "telegram.hermesStartingService": "メッセージングサービスを起動中",
+    "telegram.hermesWaitingService": "メッセージングサービスを待機中",
+    "telegram.hermesPleaseWait": "メッセージングサービスの起動をお待ちください",
 
     // === SetupWizard ===
     "wizard.help1Title": "インターネット接続",
@@ -3200,6 +3223,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "Wachten op gateway",
     "telegram.readyToChat": "Klaar om te chatten",
     "telegram.botReady": "Telegram-bot is klaar",
+    "telegram.hermesStartingService": "Berichtenservice starten",
+    "telegram.hermesWaitingService": "Wachten op de berichtenservice",
+    "telegram.hermesPleaseWait": "Even geduld terwijl de berichtenservice start",
 
     // === SetupWizard ===
     "wizard.help1Title": "Verbinding maken met internet",
@@ -3623,6 +3649,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "Väntar på gateway",
     "telegram.readyToChat": "Redo att chatta",
     "telegram.botReady": "Telegram-boten är redo",
+    "telegram.hermesStartingService": "Startar meddelandetjänsten",
+    "telegram.hermesWaitingService": "Väntar på meddelandetjänsten",
+    "telegram.hermesPleaseWait": "Vänta medan meddelandetjänsten startar",
 
     // === SetupWizard ===
     "wizard.help1Title": "Anslut till internet",
@@ -4046,6 +4075,9 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "telegram.waitingGateway": "等待网关就绪",
     "telegram.readyToChat": "准备就绪",
     "telegram.botReady": "Telegram 机器人已就绪",
+    "telegram.hermesStartingService": "正在启动消息服务",
+    "telegram.hermesWaitingService": "正在等待消息服务",
+    "telegram.hermesPleaseWait": "请稍候，消息服务正在启动",
 
     // === SetupWizard ===
     "wizard.help1Title": "连接互联网",

--- a/src/lib/translations.ts
+++ b/src/lib/translations.ts
@@ -255,6 +255,12 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "Shut down device?",
     "wizard.restartConfirm": "Restart device?",
     "wizard.completionUnreachable": "Couldn't reach the device. Please check your connection and try again.",
+    // Hermes edition ships without the OpenClaw gateway, so the completion
+    // overlay names what is actually starting on the device.
+    "wizard.completionHermesTitle": "Starting your Hermes agent...",
+    "wizard.completionHermesSaving": "Saving your settings",
+    "wizard.completionHermesStarting": "Starting the Hermes agent",
+    "wizard.completionHermesWait": "Please wait while the agent starts",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -675,6 +681,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "Изключване на устройството?",
     "wizard.restartConfirm": "Рестартиране на устройството?",
     "wizard.completionUnreachable": "Не може да се свърже с устройството. Проверете връзката и опитайте отново.",
+    "wizard.completionHermesTitle": "Стартиране на вашия Hermes агент...",
+    "wizard.completionHermesSaving": "Запазване на настройките",
+    "wizard.completionHermesStarting": "Стартиране на Hermes агента",
+    "wizard.completionHermesWait": "Моля, изчакайте, докато агентът стартира",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -1094,6 +1104,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "Gerät ausschalten?",
     "wizard.restartConfirm": "Gerät neu starten?",
     "wizard.completionUnreachable": "Gerät konnte nicht erreicht werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.",
+    "wizard.completionHermesTitle": "Ihr Hermes-Agent wird gestartet...",
+    "wizard.completionHermesSaving": "Einstellungen werden gespeichert",
+    "wizard.completionHermesStarting": "Hermes-Agent wird gestartet",
+    "wizard.completionHermesWait": "Bitte warten Sie, während der Agent startet",
 
     // === ProgressBar ===
     "progress.wifi": "WLAN",
@@ -1513,6 +1527,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "¿Apagar el dispositivo?",
     "wizard.restartConfirm": "¿Reiniciar el dispositivo?",
     "wizard.completionUnreachable": "No se pudo conectar con el dispositivo. Comprueba tu conexión e inténtalo de nuevo.",
+    "wizard.completionHermesTitle": "Iniciando tu agente Hermes...",
+    "wizard.completionHermesSaving": "Guardando tu configuración",
+    "wizard.completionHermesStarting": "Iniciando el agente Hermes",
+    "wizard.completionHermesWait": "Espera mientras se inicia el agente",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -1932,6 +1950,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "Éteindre l'appareil ?",
     "wizard.restartConfirm": "Redémarrer l'appareil ?",
     "wizard.completionUnreachable": "Impossible de joindre l'appareil. Veuillez vérifier votre connexion et réessayer.",
+    "wizard.completionHermesTitle": "Démarrage de votre agent Hermes...",
+    "wizard.completionHermesSaving": "Enregistrement de vos paramètres",
+    "wizard.completionHermesStarting": "Démarrage de l'agent Hermes",
+    "wizard.completionHermesWait": "Veuillez patienter pendant le démarrage de l'agent",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -2351,6 +2373,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "Spegnere il dispositivo?",
     "wizard.restartConfirm": "Riavviare il dispositivo?",
     "wizard.completionUnreachable": "Impossibile raggiungere il dispositivo. Controlla la connessione e riprova.",
+    "wizard.completionHermesTitle": "Avvio del tuo agente Hermes...",
+    "wizard.completionHermesSaving": "Salvataggio delle impostazioni",
+    "wizard.completionHermesStarting": "Avvio dell'agente Hermes",
+    "wizard.completionHermesWait": "Attendi mentre l'agente si avvia",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -2770,6 +2796,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "デバイスをシャットダウンしますか？",
     "wizard.restartConfirm": "デバイスを再起動しますか？",
     "wizard.completionUnreachable": "デバイスに接続できませんでした。接続を確認してもう一度お試しください。",
+    "wizard.completionHermesTitle": "Hermes エージェントを起動しています...",
+    "wizard.completionHermesSaving": "設定を保存中",
+    "wizard.completionHermesStarting": "Hermes エージェントを起動中",
+    "wizard.completionHermesWait": "エージェントの起動をお待ちください",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -3189,6 +3219,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "Apparaat uitschakelen?",
     "wizard.restartConfirm": "Apparaat herstarten?",
     "wizard.completionUnreachable": "Kan het apparaat niet bereiken. Controleer uw verbinding en probeer opnieuw.",
+    "wizard.completionHermesTitle": "Je Hermes-agent wordt gestart...",
+    "wizard.completionHermesSaving": "Instellingen opslaan",
+    "wizard.completionHermesStarting": "Hermes-agent starten",
+    "wizard.completionHermesWait": "Even geduld terwijl de agent start",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -3608,6 +3642,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "Stänga av enheten?",
     "wizard.restartConfirm": "Starta om enheten?",
     "wizard.completionUnreachable": "Det gick inte att nå enheten. Kontrollera anslutningen och försök igen.",
+    "wizard.completionHermesTitle": "Startar din Hermes-agent...",
+    "wizard.completionHermesSaving": "Sparar dina inställningar",
+    "wizard.completionHermesStarting": "Startar Hermes-agenten",
+    "wizard.completionHermesWait": "Vänta medan agenten startar",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",
@@ -4027,6 +4065,10 @@ const setupTranslations: Record<Locale, Record<string, string>> = {
     "wizard.shutdownConfirm": "确定关机吗？",
     "wizard.restartConfirm": "确定重启吗？",
     "wizard.completionUnreachable": "无法连接到设备。请检查您的连接并重试。",
+    "wizard.completionHermesTitle": "正在启动您的 Hermes 智能体...",
+    "wizard.completionHermesSaving": "正在保存您的设置",
+    "wizard.completionHermesStarting": "正在启动 Hermes 智能体",
+    "wizard.completionHermesWait": "请稍候，智能体正在启动",
 
     // === ProgressBar ===
     "progress.wifi": "WiFi",

--- a/src/tests/components/hermes-provider-config.test.tsx
+++ b/src/tests/components/hermes-provider-config.test.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import HermesProviderConfig from "@/components/HermesProviderConfig";
+
+// The Hermes edition's AI-provider step. AIModelsStep hands the whole step to
+// this panel on a Hermes box, so the wizard's auto-advance has to live here too
+// — otherwise a customer who successfully configures a provider is left sitting
+// on a step that has already finished.
+
+vi.mock("@/lib/i18n", () => ({
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useT: () => ({ t: (key: string) => key, locale: "en", setLocale: vi.fn() }),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt = "" }: { alt?: string }) => <img alt={alt} />,
+}));
+
+const refreshModels = vi.fn();
+
+vi.mock("@/hooks/useHermesModelOptions", () => ({
+  useHermesModelOptions: () => ({
+    scope: {
+      provider: "openrouter",
+      authenticated: true,
+      models: [{ id: "vendor/model-a", description: "" }],
+      defaultModel: "vendor/model-a",
+      current: "vendor/model-a",
+      savedElsewhere: null,
+      source: "dashboard",
+      stale: false,
+      fetchedAt: Date.now(),
+    },
+    loading: false,
+    refresh: refreshModels,
+  }),
+}));
+
+/** The panel's backing routes, with a configurable outcome for the save POST. */
+function stubFetch({ saveOk = true }: { saveOk?: boolean } = {}) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+
+    if (url === "/setup-api/hermes/clawai") {
+      return {
+        ok: true,
+        json: async () => ({ hasToken: false, tier: "flash", tierStored: null, active: false, model: "" }),
+      } as Response;
+    }
+    if (url === "/setup-api/hermes/oauth") {
+      return { ok: true, json: async () => ({ providers: [] }) } as Response;
+    }
+    if (url === "/setup-api/hermes/models" && method === "POST") {
+      return saveOk
+        ? { ok: true, json: async () => ({ ok: true, model: "vendor/model-a", provider: "openrouter" }) } as Response
+        : { ok: false, status: 502, json: async () => ({ error: "hermes config failed" }) } as Response;
+    }
+    if (url === "/setup-api/hermes/models") {
+      return { ok: true, json: async () => ({ provider: "openrouter" }) } as Response;
+    }
+
+    return { ok: true, json: async () => ({}) } as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+async function saveButton() {
+  return await screen.findByRole("button", { name: /Save model & provider/i });
+}
+
+describe("HermesProviderConfig auto-advance", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    refreshModels.mockClear();
+  });
+
+  it("advances the wizard once a save has actually succeeded", async () => {
+    stubFetch();
+    const onNext = vi.fn();
+
+    render(<HermesProviderConfig onNext={onNext} testId="hermes-ai" />);
+
+    fireEvent.click(await saveButton());
+
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    }, { timeout: 4_000 });
+  });
+
+  it("advances exactly once even when the step is saved repeatedly", async () => {
+    stubFetch();
+    const onNext = vi.fn();
+
+    render(<HermesProviderConfig onNext={onNext} testId="hermes-ai" />);
+
+    const button = await saveButton();
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledTimes(1);
+    }, { timeout: 4_000 });
+
+    // Give a second timer every chance to fire before declaring it doesn't.
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    expect(onNext).toHaveBeenCalledTimes(1);
+  }, 10_000);
+
+  it("stays on the step when the save fails", async () => {
+    stubFetch({ saveOk: false });
+    const onNext = vi.fn();
+
+    render(<HermesProviderConfig onNext={onNext} testId="hermes-ai" />);
+
+    fireEvent.click(await saveButton());
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    expect(onNext).not.toHaveBeenCalled();
+  }, 10_000);
+
+  it("never advances when embedded in Settings, which has no next step", async () => {
+    stubFetch();
+    const onNext = vi.fn();
+
+    render(<HermesProviderConfig embedded onNext={onNext} testId="hermes-ai" />);
+
+    fireEvent.click(await saveButton());
+
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    expect(onNext).not.toHaveBeenCalled();
+  }, 10_000);
+});

--- a/src/tests/components/hermes-provider-config.test.tsx
+++ b/src/tests/components/hermes-provider-config.test.tsx
@@ -35,6 +35,10 @@ vi.mock("@/hooks/useHermesModelOptions", () => ({
     loading: false,
     refresh: refreshModels,
   }),
+  // The factory replaces the whole module, so every export the panel imports
+  // has to be listed here — a missing one is `undefined` at the call site and
+  // throws inside the save path, which reads as "the wizard never advanced".
+  notifyHermesModelState: vi.fn(),
 }));
 
 /** The panel's backing routes, with a configurable outcome for the save POST. */

--- a/src/tests/components/setup-wizard.test.tsx
+++ b/src/tests/components/setup-wizard.test.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SetupWizard from "@/components/SetupWizard";
+import { resetHarnessCache } from "@/lib/client-harness";
 
 vi.mock("@/lib/i18n", () => ({
   I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -75,14 +76,23 @@ function jsonResponse(data: unknown, ok = true): Response {
   } as Response;
 }
 
+/** Did the wizard call this path at least once? */
+function called(fetchMock: ReturnType<typeof vi.fn>, path: string): boolean {
+  return fetchMock.mock.calls.some(([input]) => String(input) === path);
+}
+
 describe("SetupWizard", () => {
   beforeEach(() => {
     vi.useRealTimers();
+    // The edition is cached for the lifetime of a document; without this the
+    // first test's answer would decide every later test's edition.
+    resetHarnessCache();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.useRealTimers();
+    resetHarnessCache();
   });
 
   it("resumes from persisted setup progress after a reload", async () => {
@@ -179,6 +189,9 @@ describe("SetupWizard", () => {
       if (url === "/setup-api/gateway/health") {
         return jsonResponse({ available: false });
       }
+      if (url === "/setup-api/harness/active") {
+        return jsonResponse({ active: "openclaw", edition: "openclaw" });
+      }
 
       return jsonResponse({});
     });
@@ -191,5 +204,114 @@ describe("SetupWizard", () => {
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
     }, { timeout: 30_000 });
+
+    // An OpenClaw box still waits on its gateway, and never on the Hermes side.
+    expect(called(fetchMock, "/setup-api/gateway/health")).toBe(true);
+    expect(called(fetchMock, "/setup-api/hermes/models")).toBe(false);
+  }, 35_000);
+
+  it("waits on the Hermes agent, not the OpenClaw gateway, on a hermes device", async () => {
+    const onComplete = vi.fn();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "/setup-api/setup/status") {
+        return jsonResponse({
+          setup_complete: false,
+          wifi_configured: true,
+          update_completed: true,
+          password_configured: true,
+          ai_model_configured: true,
+          local_ai_configured: true,
+          telegram_configured: false,
+          setup_progress_step: 5,
+        });
+      }
+      if (url === "/setup-api/setup/progress") {
+        return jsonResponse({ success: true, step: 5 });
+      }
+      if (url === "/setup-api/setup/complete") {
+        return jsonResponse({ success: true });
+      }
+      if (url === "/setup-api/harness/active") {
+        return jsonResponse({ active: "hermes", edition: "hermes" });
+      }
+      if (url === "/setup-api/hermes/models") {
+        // `stale: false` is the models route's "the live Hermes dashboard
+        // answered" signal.
+        return jsonResponse({ stale: false, source: "dashboard", models: [] });
+      }
+
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SetupWizard onComplete={onComplete} />);
+
+    fireEvent.click(await screen.findByText("telegram-next"));
+
+    expect(await screen.findByTestId("setup-completion-overlay")).toBeInTheDocument();
+    // The copy names the agent this device actually runs...
+    await waitFor(() => {
+      expect(screen.getByText("wizard.completionHermesTitle")).toBeInTheDocument();
+    });
+    expect(screen.getByText("wizard.completionHermesSaving")).toBeInTheDocument();
+    expect(screen.getByText("wizard.completionHermesStarting")).toBeInTheDocument();
+    // ...and never the gateway, which is not installed on a Hermes box.
+    expect(screen.queryByText("openclaw.connecting")).not.toBeInTheDocument();
+    expect(screen.queryByText("ai.restartingGateway")).not.toBeInTheDocument();
+    expect(screen.queryByText("telegram.waitingGateway")).not.toBeInTheDocument();
+    expect(screen.queryByText("telegram.pleaseWait")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    }, { timeout: 30_000 });
+
+    expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
+    expect(called(fetchMock, "/setup-api/hermes/models")).toBe(true);
+  }, 35_000);
+
+  it("still finishes on a hermes device whose agent never reports ready", async () => {
+    const onComplete = vi.fn();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url === "/setup-api/setup/status") {
+        return jsonResponse({
+          setup_complete: false,
+          wifi_configured: true,
+          update_completed: true,
+          password_configured: true,
+          ai_model_configured: true,
+          local_ai_configured: true,
+          telegram_configured: false,
+          setup_progress_step: 5,
+        });
+      }
+      if (url === "/setup-api/setup/progress") {
+        return jsonResponse({ success: true, step: 5 });
+      }
+      if (url === "/setup-api/setup/complete") {
+        return jsonResponse({ success: true });
+      }
+      if (url === "/setup-api/harness/active") {
+        return jsonResponse({ active: "hermes", edition: "hermes" });
+      }
+      if (url === "/setup-api/hermes/models") {
+        // Dashboard still coming up: every source but the live one is stale.
+        return jsonResponse({ stale: true, source: "cold-start", models: [] });
+      }
+
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SetupWizard onComplete={onComplete} />);
+
+    fireEvent.click(await screen.findByText("telegram-next"));
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledTimes(1);
+    }, { timeout: 30_000 });
+
+    expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
   }, 35_000);
 });

--- a/src/tests/components/setup-wizard.test.tsx
+++ b/src/tests/components/setup-wizard.test.tsx
@@ -312,6 +312,10 @@ describe("SetupWizard", () => {
       expect(onComplete).toHaveBeenCalledTimes(1);
     }, { timeout: 30_000 });
 
+    // Both halves matter. The negative alone would also hold if the wizard
+    // polled NOTHING — a different bug with the same symptom — so assert that
+    // it did reach for the Hermes readiness signal and simply never got it.
     expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
+    expect(called(fetchMock, "/setup-api/hermes/models")).toBe(true);
   }, 35_000);
 });

--- a/src/tests/components/telegram-configuring-overlay.test.tsx
+++ b/src/tests/components/telegram-configuring-overlay.test.tsx
@@ -1,0 +1,138 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@/tests/helpers/test-utils";
+import TelegramConfiguringOverlay from "@/components/TelegramConfiguringOverlay";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+// The Telegram configure overlay waits for "something is listening again"
+// before it shows the ready phase. On an OpenClaw box that is the gateway; on a
+// Hermes box the gateway is masked and never comes back, so the overlay used to
+// burn its whole health budget and then finish without ever reporting ready.
+
+vi.mock("@/lib/i18n", () => ({
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useT: () => ({ t: (key: string) => key, locale: "en", setLocale: vi.fn() }),
+}));
+
+function jsonResponse(data: unknown): Response {
+  return { ok: true, status: 200, json: async () => data } as Response;
+}
+
+/** Did the overlay call this path at least once? */
+function called(fetchMock: ReturnType<typeof vi.fn>, path: string): boolean {
+  return fetchMock.mock.calls.some(([input]) => String(input) === path);
+}
+
+describe("TelegramConfiguringOverlay readiness", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    resetHarnessCache();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    resetHarnessCache();
+  });
+
+  it("reaches the ready phase on hermes without polling the OpenClaw gateway", async () => {
+    const onDone = vi.fn();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/setup-api/harness/active") {
+        return jsonResponse({ active: "hermes", edition: "hermes" });
+      }
+      if (url === "/setup-api/telegram/status") {
+        // `receiving` is the route's "token registered with Hermes AND its
+        // messaging gateway is running" signal.
+        return jsonResponse({ configured: true, receiving: true, gateway: { installed: true, running: true } });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TelegramConfiguringOverlay onDone={onDone} waitFor={Promise.resolve()} />);
+
+    // The two middle steps name what actually starts on this edition...
+    await waitFor(() => {
+      expect(screen.getByText("telegram.hermesStartingService")).toBeInTheDocument();
+    });
+    expect(screen.getByText("telegram.hermesWaitingService")).toBeInTheDocument();
+    // ...and never the gateway, which is not installed on a Hermes box.
+    expect(screen.queryByText("telegram.restartingGateway")).not.toBeInTheDocument();
+    expect(screen.queryByText("telegram.waitingGateway")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledTimes(1);
+    }, { timeout: 20_000 });
+
+    expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
+    expect(called(fetchMock, "/setup-api/telegram/status")).toBe(true);
+    // Reaching phase 4 is the whole point: the previous behaviour called
+    // onDone() from the timeout branch, so the owner never saw "ready to chat".
+    // The label lands in two places at phase 4 — the visible subtitle and the
+    // sr-only live region — so count rather than expect a single node.
+    expect(screen.queryAllByText("telegram.botReady").length).toBeGreaterThan(0);
+  }, 30_000);
+
+  it("still polls the gateway on an openclaw device", async () => {
+    const onDone = vi.fn();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/setup-api/harness/active") {
+        return jsonResponse({ active: "openclaw", edition: "openclaw" });
+      }
+      if (url === "/setup-api/gateway/health") {
+        return jsonResponse({ available: true, port: 18789 });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<TelegramConfiguringOverlay onDone={onDone} waitFor={Promise.resolve()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("telegram.restartingGateway")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("telegram.hermesStartingService")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledTimes(1);
+    }, { timeout: 20_000 });
+
+    expect(called(fetchMock, "/setup-api/gateway/health")).toBe(true);
+    expect(called(fetchMock, "/setup-api/telegram/status")).toBe(false);
+  }, 30_000);
+
+  it("hands control back without a ready phase when hermes never starts listening", async () => {
+    const onDone = vi.fn();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/setup-api/harness/active") {
+        return jsonResponse({ active: "hermes", edition: "hermes" });
+      }
+      if (url === "/setup-api/telegram/status") {
+        // Token stored, but the messaging gateway did not come up.
+        return jsonResponse({ configured: true, receiving: false, gateway: { installed: true, running: false } });
+      }
+      return jsonResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Short budget so the give-up path is reached quickly.
+    render(
+      <TelegramConfiguringOverlay onDone={onDone} waitFor={Promise.resolve()} healthTimeoutMs={4_000} />,
+    );
+
+    await waitFor(() => {
+      expect(onDone).toHaveBeenCalledTimes(1);
+    }, { timeout: 20_000 });
+
+    // The parent surfaces its own error — the overlay must not claim success.
+    expect(screen.queryAllByText("telegram.botReady")).toHaveLength(0);
+    // Both halves matter: the negative alone would also hold if the overlay
+    // polled NOTHING and timed out, which is a different bug with the same
+    // outcome. Assert it did ask Hermes and simply never got a listener.
+    expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
+    expect(called(fetchMock, "/setup-api/telegram/status")).toBe(true);
+  }, 30_000);
+});

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -31,6 +31,26 @@ vi.mock("@/lib/clawkeep", () => ({
   unpairLocal: vi.fn(),
 }));
 
+// The configure route fires a catalog refresh out-of-band and deliberately does
+// NOT await it (step 8c). The real refreshInBackground starts a fetch/openclaw
+// fork and logs its outcome — `[catalog] refreshed …` or `[catalog] refresh
+// failed for …` — whenever it settles, which is after the test that triggered
+// it has already finished.
+//
+// That stray console write is what surfaced in CI as
+// `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`:
+// a log arriving while the worker was closing its RPC channel. The job reported
+// every one of its test files as passing and still exited 1 on the unhandled
+// rejection.
+//
+// Stubbing it here keeps the leak from ever starting, which is the fix — no
+// console silencing and no global unhandled-rejection swallow, either of which
+// would hide this class of bug rather than remove it. Nothing in this file
+// asserts on the refresh; it is out-of-band work by design.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  refreshInBackground: vi.fn(),
+}));
+
 // Hoisted so the vi.mock factories below (which are themselves hoisted by
 // vitest) can see these. A plain const declaration at file-body position
 // would be in the TDZ when the mock factory evaluates.


### PR DESCRIPTION
Three bugs in one family, all hit on a real Hermes-edition device: UI paths in the setup wizard that still assume the OpenClaw gateway is present.

On this SKU the gateway is not installed and its unit is masked — verified on the device: `systemctl is-enabled clawbox-gateway.service` → `masked`, `is-active` → `inactive`, nothing answering on 18789, while `clawbox-hermes-dashboard{,-proxy}.service` are both active.

## A — the completion overlay waited for a gateway that cannot exist

`SetupCompletionOverlay` hardcoded `t("openclaw.connecting")` plus the gateway restart/wait step labels, and `SetupWizard` polled `/setup-api/gateway/health` for readiness. So the copy named a service the device doesn't have, **and** the wait could only ever exhaust its attempt budget — the owner watched a spinner for something that was never coming.

Now the wizard resolves the edition through the shared `client-harness` cache — already warmed by the AI-models step, so it's a free read — and branches both copy and probe. On hermes it polls `GET /setup-api/hermes/models` and treats `stale: false` as ready: that flag is set only when the **live Hermes dashboard** answered (`source: "dashboard"`); every fallback (on-disk catalog, cold start) is flagged stale, so it cannot pass on a dashboard that is still coming up.

Probe chosen by reading the code, not invented:

- `/setup-api/harness/status` is the obvious candidate but is deliberately in `PRE_AUTH_SENSITIVE_PREFIXES` (desktop picker only) — the wizard can't use it.
- `/setup-api/hermes/oauth` returns `200 {providers: []}` on failure, so up and down are indistinguishable.
- `/setup-api/hermes/models` is already called by this same wizard step, and `/setup/complete` has issued the session cookie by the time the poll runs → no new endpoint, no new middleware carve-out.

## B — the AI-providers step did not auto-advance

On hermes, `AIModelsStep` hands the whole step to `HermesProviderConfig`, and that panel had no auto-advance: a successful save left the owner parked on a finished step with a manual "Continue" as the only way forward, while the OpenClaw branch has advanced automatically all along (`handleConfiguringDone`, 900 ms after the configure lands).

Same pattern, same delay, deliberately conservative:

- fires **once** (latched), and only after a configure round-trip has actually succeeded — the model/provider save, the ClawBox AI tier apply, a pasted portal token, or the device-login poll's terminal `complete` status;
- never when embedded in Settings, which has no next step;
- **never** for the Hermes dashboard's own OAuth, which runs out of band in another tab (`openHermesOAuth`) and still requires an explicit save. A half-finished sign-in cannot carry the wizard forward.

`onNext` is held in a ref because the wizard passes a fresh arrow every render, which would otherwise keep resetting the timer.

## C — the Telegram step waited on the wrong service

`TelegramConfiguringOverlay` showed "Restarting gateway" / "Waiting for gateway" and polled `/setup-api/gateway/health` for up to `healthTimeoutMs` (60 s default). On hermes `restartGateway()` is already a documented no-op (`src/tests/unit/gateway-restart-hermes.test.ts`), so the poll burned the full budget and then took the give-up branch: `onDone()` **without ever reaching the "ready to chat" phase**. A save that had actually succeeded looked like a minute of spinner and then nothing.

The readiness signal here is a *different* service from bug A — not the dashboard, but Hermes' own messaging gateway, the process that receives Telegram messages. The configure route already brings it up (`ensureHermesGateway`), and `/setup-api/telegram/status` already reports it: `receiving` is true only when the token is registered with Hermes **and** that gateway is running — the same "something is listening" meaning `available` carries on the OpenClaw side. The route caches its Hermes probe for 15 s, so a 2 s poll costs one CLI round-trip per window rather than one per attempt.

Both callers benefit: the wizard's Telegram step and Settings.

## Shared

`resolveEdition()` lives in `client-harness.ts`, next to the caches it reads — three screens now make the same "is there an OpenClaw gateway on this box?" decision and duplicated fallbacks drift. Seven new translation keys, all ten locales (en, de, es, fr, it, ja, nl, sv, zh, bg).

## Tests

Regression tests per fix, since edition-conditional behaviour is exactly what rots silently:

- the completion overlay must not name or poll the gateway on hermes, must poll the Hermes route instead, and must still finish when the agent never reports ready;
- the OpenClaw path must still poll the gateway and must never touch the Hermes routes;
- auto-advance fires exactly once, only after a successful configure, not on failure, not when embedded;
- the Telegram overlay reaches the ready phase on hermes without touching the gateway, still polls the gateway on OpenClaw, and on a hermes box whose messaging gateway never starts hands control back **without** claiming success.

Per CodeRabbit, the two give-up tests assert the positive as well as the negative — "did not poll the gateway" alone would also hold for a wizard that polled nothing at all, which is a different bug with the same visible result.

## Notes for review

- `SettingsApp` passes an inline arrow as the overlay's `onDone`, so the overlay's effect re-runs on every parent render and restarts its phase machine. Pre-existing (the effect already depended on `onDone`) and untouched here, but worth a separate look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup wizard automatically advances after successful provider configuration.
  * Added edition-specific setup and completion experiences for Hermes devices.
  * Hermes setup checks model and Telegram readiness through dedicated status indicators.
  * Added localized Hermes-specific status and completion messages across supported languages.

* **Bug Fixes**
  * Prevented embedded settings panels from advancing automatically.
  * Improved setup completion when device readiness information is delayed or unavailable.
  * Ensured Telegram setup reports readiness only after configuration and service checks complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->