### PR TITLE
fix: skills browse first-run state and chat provider list refresh

### DIFF
--- a/src/app/setup-api/hermes/skills/browse/route.ts
+++ b/src/app/setup-api/hermes/skills/browse/route.ts
@@ -118,8 +118,15 @@ export async function GET(request: Request) {
   }
 
   // ── No index: answer from the CLI once, and kick a build for next time ──
-  const warming = isWarming();
+  // Kick the build FIRST, then report. Asking `isWarming()` beforehand meant the
+  // very first browse on a fresh device — the request that starts the build —
+  // described itself as a plain CLI answer, so the UI had nothing to distinguish
+  // "still preparing" from "genuinely nothing here" and showed the
+  // empty-catalogue copy over a catalogue that was seconds from existing.
+  // Still false when the post-failure cooldown declines to start another build,
+  // and then "no index, not building" is the honest answer.
   warmIndex();
+  const warming = isWarming();
   try {
     // A catalog-only source (skills.sh spelling, claude-marketplace, unknown)
     // has no `--source` flag — drop the filter rather than send hermes a value

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1526,16 +1526,39 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // Safe to re-run: every in-session choice is mirrored into localStorage by the
   // change* callbacks, and those prefs win here, so a re-sync preserves the
   // user's picks while picking up new credentials / a new device pairing.
+  //
+  // LATEST SEED WINS. Seeds overlap now that three call sites emit the
+  // invalidation (a device login, an OAuth return and a Save can land within a
+  // second of each other, and the mount seed can still be in flight when the
+  // first event arrives). They all hit the same route, so a slower EARLIER
+  // response can resolve last and reinstate the provider list, device model and
+  // selection the newer one just replaced — the same "a stale provider wins"
+  // failure the model pill guards against, reached through a different door.
+  // Each seed therefore takes a generation, cancels the one it supersedes, and
+  // writes only if it is still the newest when its answer lands.
+  const seedGenerationRef = useRef(0)
+  const seedControllerRef = useRef<AbortController | null>(null)
+
   const seedHermesHeader = useCallback(async (signal?: AbortSignal) => {
+    const generation = ++seedGenerationRef.current
+    seedControllerRef.current?.abort()
+    const controller = new AbortController()
+    seedControllerRef.current = controller
+    // The caller's signal still cancels this seed (unmount, harness switch).
+    const abortThis = () => controller.abort()
+    if (signal?.aborted) abortThis()
+    else signal?.addEventListener('abort', abortThis)
     try {
-      const mRes = await fetch('/setup-api/hermes/models', { cache: 'no-store', signal })
+      const mRes = await fetch('/setup-api/hermes/models', { cache: 'no-store', signal: controller.signal })
       const mData = await mRes.json() as {
         providers?: { id?: unknown; name?: unknown; authenticated?: unknown }[]
         provider?: unknown
         current?: unknown
         reasoning?: unknown
       }
-      if (signal?.aborted) return
+      // `aborted` alone is not enough: a response can resolve before the abort
+      // lands, and `json()` adds a second await for a newer seed to start in.
+      if (controller.signal.aborted || generation !== seedGenerationRef.current) return
       // Offer only providers Hermes has credentials for (`authenticated:
       // false` rows would give an empty model list and a failing turn).
       // `null` means the source couldn't tell — keep those.
@@ -1570,6 +1593,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       hermesReasoningKnownRef.current = knownReasoning !== null
       setHermesReasoning(knownReasoning ?? HERMES_REASONING_DEFAULT)
     } catch { /* header falls back to a plain label */ }
+    finally {
+      signal?.removeEventListener('abort', abortThis)
+      if (seedControllerRef.current === controller) seedControllerRef.current = null
+    }
   }, [])
 
   // Resolve the active harness once, before connecting, so we never open the
@@ -1602,6 +1629,11 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // This is the plain unscoped GET, which is what makes the invalidation cheap:
   // the per-provider model lists are NOT re-enumerated here, they stay with the
   // scoped hook above.
+  //
+  // The controller here only stops seeds once this effect is torn down; ORDER
+  // between overlapping seeds is not its job (one controller shared by every
+  // event could not do that anyway) and is handled by the generation guard in
+  // `seedHermesHeader`.
   useEffect(() => {
     if (harnessMode !== 'hermes') return
     const controller = new AbortController()

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -152,7 +152,7 @@ import { useProviderCatalog } from '@/hooks/useProviderCatalog'
 // get mixed. The MODEL list is scoped by the same server contract the Hermes
 // settings panel uses (GET /setup-api/hermes/models?provider=…) — no parallel
 // client-side filtering exists.
-import { useHermesModelOptions } from '@/hooks/useHermesModelOptions'
+import { HERMES_MODEL_STATE_EVENT, useHermesModelOptions } from '@/hooks/useHermesModelOptions'
 import {
   HERMES_AUTO_PROVIDER,
   hermesProviderLabel,
@@ -1594,17 +1594,22 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
 
   // Re-seed when the settings panel changes the device's provider/model/tier or
   // adds a credential. Without this the header keeps naming the OLD provider
-  // for the rest of the session — and `hermesDevice` is the sole basis for the
+  // for the rest of the session — and a provider the user just connected never
+  // reaches the picker at all. `hermesDevice` is also the sole basis for the
   // "safe to send --provider without -m" decision, so a stale copy either
   // blocks a legal turn or lets the route answer 409.
+  //
+  // This is the plain unscoped GET, which is what makes the invalidation cheap:
+  // the per-provider model lists are NOT re-enumerated here, they stay with the
+  // scoped hook above.
   useEffect(() => {
     if (harnessMode !== 'hermes') return
     const controller = new AbortController()
     const onChanged = () => { void seedHermesHeader(controller.signal) }
-    window.addEventListener('clawbox:hermes-model-state-changed', onChanged)
+    window.addEventListener(HERMES_MODEL_STATE_EVENT, onChanged)
     return () => {
       controller.abort()
-      window.removeEventListener('clawbox:hermes-model-state-changed', onChanged)
+      window.removeEventListener(HERMES_MODEL_STATE_EVENT, onChanged)
     }
   }, [harnessMode, seedHermesHeader])
 

--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -6,7 +6,7 @@ import ClawboxAiProviderRow from "./ClawboxAiProviderRow";
 import ClawboxAiPlanPicker from "./ClawboxAiPlanPicker";
 import ClawboxAiDeviceLogin from "./ClawboxAiDeviceLogin";
 import { useClawaiDeviceLogin } from "@/hooks/useClawaiDeviceLogin";
-import { useHermesModelOptions } from "@/hooks/useHermesModelOptions";
+import { notifyHermesModelState, useHermesModelOptions } from "@/hooks/useHermesModelOptions";
 import {
   HERMES_PANEL_PROVIDERS,
   CLAWAI_PROVIDER,
@@ -99,13 +99,18 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
   const [saving, setSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<Status>(null);
 
-  // Tell an already-open chat popup that this device's provider/model/tier
-  // changed, so its header re-seeds instead of naming the previous provider
-  // (and blocking legal turns) until the whole page is reloaded. Mirrors the
+  // Tell every already-open view — the chat popup's provider picker, and this
+  // panel's own scoped model list — that the device's providers/model/tier
+  // changed, so they re-read instead of naming the previous provider (and
+  // blocking legal turns) until the whole page is reloaded. Mirrors the
   // OpenClaw side's "clawbox:chat-model-state-changed".
+  //
+  // Emit it from EVERY path that leaves the device configured differently, not
+  // just the Save button: a provider connected through the ClawBox AI device
+  // login or through Hermes' own OAuth is exactly the case where the user
+  // expects to switch straight to it in chat.
   const notifyChatHeader = useCallback(() => {
-    if (typeof window === "undefined") return;
-    window.dispatchEvent(new Event("clawbox:hermes-model-state-changed"));
+    notifyHermesModelState();
   }, []);
 
   const pickProvider = useCallback((id: string) => {
@@ -236,10 +241,14 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
       oauthTabOpenedRef.current = false;
       void loadOauth();
       refreshModels();
+      // The credential that just appeared can flip a provider from
+      // `authenticated: false` to true, which is what decides whether the chat
+      // offers it at all — so the chat has to re-read too, not just this panel.
+      notifyChatHeader();
     };
     window.addEventListener("focus", onFocus);
     return () => window.removeEventListener("focus", onFocus);
-  }, [loadOauth, refreshModels]);
+  }, [loadOauth, refreshModels, notifyChatHeader]);
 
   const changeUiTier = useCallback((tier: ClawaiTier) => {
     setUiTier(tier);
@@ -262,6 +271,9 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
     onComplete: () => {
       void reloadClawai();
       setSelectedProvider(CLAWAI_PROVIDER);
+      // The device-code handoff configures the provider server-side, so this is
+      // a successful configure like any other — the chat picker has to hear it.
+      notifyChatHeader();
       setClawaiStatus({ kind: "ok", msg: "ClawBox AI is now your active model" });
     },
     onError: (msg) => setClawaiStatus({ kind: "err", msg }),

--- a/src/components/HermesSkillsStore.tsx
+++ b/src/components/HermesSkillsStore.tsx
@@ -497,7 +497,11 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
   const browsing = tab === 'browse';
   const q = catalog.query.trim();
   const rangeFrom = catalog.results.length ? 1 : 0;
-  const showFirstRun = browsing && catalog.loading && (catalog.slow || catalog.catalog?.origin === 'warming');
+  // Two ways to earn the first-run panel: the device says it is still building
+  // the index (`preparing` — true even though the request has COMPLETED, which
+  // is the whole point), or a request is genuinely taking long enough that a
+  // bare spinner stops being an explanation.
+  const showFirstRun = browsing && (catalog.preparing || (catalog.loading && catalog.slow));
   // Dated by the DOWNLOAD, not the publisher's build stamp — the latter never
   // moves on a refetch, so it said "21 days ago" about a fresh catalogue.
   const staleWhen = catalog.catalog?.stale ? relativeDate(catalog.catalog.fetchedAt) : undefined;
@@ -671,6 +675,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
             {showFirstRun && (
               <Alert tone="info" icon="hourglass_top">
                 {COPY.buildingCatalog}
+                <span className="mt-1 block text-[var(--text-secondary)]">{COPY.buildingCatalogAuto}</span>
                 <span className="mt-2 block h-1 w-full rounded-full bg-[var(--surface-card)] overflow-hidden">
                   <span className="block h-full w-1/3 bg-[var(--coral-bright)] animate-pulse" />
                 </span>
@@ -691,7 +696,9 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
                 action={<PrimaryButton onClick={catalog.reload}>{COPY.retry}</PrimaryButton>}
               />
             )}
-            {!catalog.error && !catalog.loading && catalog.results.length === 0 && (
+            {/* "Nothing here" is a claim about the catalogue, so it may only be
+                made once the device HAS one — never while it is still building. */}
+            {!catalog.error && !catalog.loading && !catalog.preparing && catalog.results.length === 0 && (
               <EmptyState
                 icon="search_off"
                 title={q ? COPY.emptySearch(q) : COPY.emptySource(sourceLabel(catalog.source))}

--- a/src/components/hermes-skills/copy.ts
+++ b/src/components/hermes-skills/copy.ts
@@ -78,6 +78,9 @@ export const COPY = {
   installedStale: 'Couldn’t refresh this list — showing the last known state.',
   buildingCatalog:
     'Building the skill catalogue — the first browse on a new device takes about a minute.',
+  // The store re-asks on a timer while the index builds, so say so: the earlier
+  // wording left people closing and reopening the window to make skills appear.
+  buildingCatalogAuto: 'Skills will appear here as soon as it is ready — you can leave this open.',
   // Keyed off when THIS device last downloaded the catalogue. The publisher's
   // own build date never moves on a refetch, so it can't say anything here.
   catalogStale: (when: string) => `Catalogue last downloaded ${when}.`,

--- a/src/components/hermes-skills/useSkillCatalog.ts
+++ b/src/components/hermes-skills/useSkillCatalog.ts
@@ -13,6 +13,12 @@ const SEARCH_DEBOUNCE_MS = 300;
 // minute). Anything slower than this gets the explanatory first-run copy
 // instead of an unexplained spinner.
 const SLOW_AFTER_MS = 4000;
+// While the index builds, the endpoint ANSWERS — quickly, with zero results and
+// `catalog.origin === 'warming'`. Nothing is in flight afterwards, so without a
+// timer the view would sit on that empty answer until the user reopened the
+// window or retyped their search. Re-ask on this cadence instead; polling stops
+// by itself the moment the origin is no longer 'warming'.
+const WARM_POLL_MS = 5000;
 
 export interface CatalogController {
   query: string;
@@ -29,6 +35,17 @@ export interface CatalogController {
   loading: boolean;
   appending: boolean;
   slow: boolean;
+  /**
+   * The device is still building its offline index and has nothing to show yet.
+   *
+   * Deliberately NOT tied to `loading`: the browse endpoint completes while the
+   * index warms (it answers from the CLI fallback, which on a fresh device has
+   * nothing either), so by the time this is rendered no request is in flight.
+   * Keying the first-run panel on `loading` therefore left the generic "nothing
+   * here / try a different term" copy describing a catalogue of ~90 000 skills
+   * that simply hadn't finished unpacking.
+   */
+  preparing: boolean;
   error: string | null;
   degraded: boolean;
   catalog: CatalogMeta | null;
@@ -162,6 +179,18 @@ export function useSkillCatalog(active: boolean): CatalogController {
     return () => inFlight.current?.abort();
   }, [active, queryKey, fetchPage]);
 
+  const preparing = catalog?.origin === 'warming' && results.length === 0 && !error;
+
+  // Self-healing poll for the state above. `catalog` is a fresh object on every
+  // response, so each answer that is still 'warming' schedules the next ask and
+  // the first non-warming one ends the chain — no separate attempt counter, and
+  // nothing left running once the index is ready or the tab is left.
+  useEffect(() => {
+    if (!active || !preparing || catalog?.origin !== 'warming') return;
+    const t = setTimeout(() => setReloadKey((k) => k + 1), WARM_POLL_MS);
+    return () => clearTimeout(t);
+  }, [active, preparing, catalog]);
+
   const loadMore = useCallback(() => {
     if (loading || appending || !hasMore) return;
     fetchPage(page + 1, true);
@@ -188,6 +217,7 @@ export function useSkillCatalog(active: boolean): CatalogController {
       loading,
       appending,
       slow,
+      preparing,
       error,
       degraded,
       catalog,
@@ -208,6 +238,7 @@ export function useSkillCatalog(active: boolean): CatalogController {
       loading,
       appending,
       slow,
+      preparing,
       error,
       degraded,
       catalog,

--- a/src/hooks/useHermesModelOptions.ts
+++ b/src/hooks/useHermesModelOptions.ts
@@ -17,6 +17,23 @@ import { useCallback, useEffect, useRef, useState } from "react";
 // very mismatch this exists to fix. The abort/no-flicker discipline is reused;
 // the data is not.
 
+/**
+ * "The device's provider set or selection changed."
+ *
+ * The invalidation is deliberately a SIGNAL, not data: the server already drops
+ * both its caches on the write that precedes it (`invalidateModelOptions` on the
+ * models/provider-key/clawai routes, and the `hermes config get` memo keys on
+ * config.yaml's mtime), so every listener only has to re-ask. It must stay
+ * lightweight — see `refresh` below for what the expensive version costs.
+ */
+export const HERMES_MODEL_STATE_EVENT = "clawbox:hermes-model-state-changed";
+
+/** Emit the signal above. Call it wherever a provider configure SUCCEEDED. */
+export function notifyHermesModelState(): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(HERMES_MODEL_STATE_EVENT));
+}
+
 export interface HermesScopedModel {
   id: string;
   description?: string;
@@ -82,6 +99,27 @@ export function useHermesModelOptions(provider: string | null): UseHermesModelOp
   const refresh = useCallback(() => {
     pendingRefreshRef.current = true;
     setNonce((n) => n + 1);
+  }, []);
+
+  // A provider configured elsewhere in the UI changes what this scope should
+  // contain, but the effect below only re-runs when the PROVIDER changes — so
+  // without this the panel and the chat header kept serving the pre-configure
+  // answer until the page was reloaded.
+  //
+  // Note what this deliberately does NOT do: call `refresh`. Bumping the nonce
+  // alone re-asks the route plainly, which is enough because the write that
+  // emitted the signal already invalidated the server's caches. Going through
+  // `refresh` would set the explicit flag and make the server bust Hermes' own
+  // per-provider disk cache and re-enumerate EVERY provider's live /v1/models —
+  // a device-wide sweep to answer "is there a new provider in the list?".
+  //
+  // It also leaves `loaded` in place, so `fresh` (and therefore `loading`) is
+  // unchanged: the chat's model pill keeps its place instead of collapsing.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const onChanged = () => setNonce((n) => n + 1);
+    window.addEventListener(HERMES_MODEL_STATE_EVENT, onChanged);
+    return () => window.removeEventListener(HERMES_MODEL_STATE_EVENT, onChanged);
   }, []);
 
   useEffect(() => {

--- a/src/tests/components/chat-header-seed-race.test.tsx
+++ b/src/tests/components/chat-header-seed-race.test.tsx
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+import { HERMES_MODEL_STATE_EVENT } from "@/hooks/useHermesModelOptions";
+
+/**
+ * The chat header re-seeds whenever a provider is configured, and there are now
+ * several places that can fire that signal within a second of each other (a
+ * ClawBox AI device login, a return from Hermes' sign-in page, the Save button),
+ * on top of the mount seed that may still be in flight.
+ *
+ * They all hit the same unscoped route, so responses can come back out of order.
+ * If a slower EARLIER seed is allowed to write when it finally lands, it
+ * reinstates the provider list and device selection the newer one just replaced
+ * — the header then names a provider the device is no longer on, which is the
+ * same class of failure chat-model-pill-stability.test.tsx exists to prevent.
+ *
+ * The ordering is the whole point of this test: the first seed is deliberately
+ * resolved LAST. Resolving them in order would pass with or without the guard.
+ */
+
+type Deferred = { resolve: (body: unknown) => void };
+
+/** A provider payload as the unscoped GET /setup-api/hermes/models returns it. */
+function seedBody(provider: string, providers: string[]) {
+  return {
+    provider,
+    current: `${provider}/model-a`,
+    reasoning: "medium",
+    providers: providers.map((id) => ({ id, name: id, authenticated: true })),
+    models: [],
+  };
+}
+
+/** Queued responses for the unscoped seed route, resolved by hand. */
+const pending: Deferred[] = [];
+
+function installFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "hermes", edition: "hermes" }) };
+      }
+      // Scoped (?provider=) is the model hook, not the header seed.
+      if (url.includes("/setup-api/hermes/models?")) {
+        return {
+          ok: true,
+          json: async () => ({
+            provider: new URL(url, "http://localhost").searchParams.get("provider"),
+            authenticated: true,
+            models: [],
+            defaultModel: "",
+            current: "",
+            savedElsewhere: null,
+            source: "dashboard",
+            stale: false,
+          }),
+        };
+      }
+      if (url.includes("/setup-api/hermes/models")) {
+        const body = await new Promise<unknown>((resolve) => pending.push({ resolve }));
+        return { ok: true, json: async () => body };
+      }
+      if (url.includes("/setup-api/chat/model")) {
+        return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+}
+
+/** Answer the Nth still-unanswered seed request (0 = oldest). */
+async function settle(index: number, body: unknown) {
+  await act(async () => {
+    pending[index].resolve(body);
+    await Promise.resolve();
+  });
+}
+
+const providerPill = () => screen.getByRole("button", { name: /^Chat provider:/ });
+
+beforeEach(() => {
+  pending.length = 0;
+  resetHarnessCache();
+  window.localStorage.clear();
+  // jsdom ships no layout engine, so the message list's auto-scroll has nothing
+  // to call. Unrelated to what is under test here.
+  Element.prototype.scrollIntoView = vi.fn();
+  // Hermes mode opens no socket, but the component still references the global.
+  vi.stubGlobal(
+    "WebSocket",
+    class {
+      close() {}
+      send() {}
+      addEventListener() {}
+      removeEventListener() {}
+    },
+  );
+  installFetch();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetHarnessCache();
+});
+
+describe("overlapping Hermes header seeds", () => {
+  it("keeps the newest provider when an earlier seed resolves last", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    // Mount seed lands: the device is on OpenRouter.
+    await waitFor(() => expect(pending.length).toBe(1));
+    await settle(0, seedBody("openrouter", ["openrouter"]));
+    await waitFor(() => expect(providerPill()).toHaveAccessibleName("Chat provider: OpenRouter"));
+
+    // Two configures land back to back — two seeds now in flight.
+    await act(async () => {
+      window.dispatchEvent(new Event(HERMES_MODEL_STATE_EVENT));
+      window.dispatchEvent(new Event(HERMES_MODEL_STATE_EVENT));
+    });
+    await waitFor(() => expect(pending.length).toBe(3));
+
+    // The SECOND (newest) answers first: the device moved to Anthropic.
+    await settle(2, seedBody("anthropic", ["openrouter", "anthropic"]));
+    await waitFor(() => expect(providerPill()).toHaveAccessibleName("Chat provider: Claude"));
+
+    // Now the FIRST, slower seed finally answers with the pre-configure state.
+    // It is stale, so it must not be allowed to drag the header backwards.
+    await settle(1, seedBody("openrouter", ["openrouter"]));
+
+    await act(async () => { await Promise.resolve(); });
+    expect(providerPill()).toHaveAccessibleName("Chat provider: Claude");
+  });
+
+  it("keeps the newest provider LIST when an earlier seed resolves last", async () => {
+    // The list is what the dropdown offers: a stale seed winning here means a
+    // provider the user just connected disappears again from the picker.
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    await waitFor(() => expect(pending.length).toBe(1));
+    await settle(0, seedBody("openrouter", ["openrouter"]));
+    await waitFor(() => expect(providerPill()).toBeTruthy());
+
+    await act(async () => {
+      window.dispatchEvent(new Event(HERMES_MODEL_STATE_EVENT));
+      window.dispatchEvent(new Event(HERMES_MODEL_STATE_EVENT));
+    });
+    await waitFor(() => expect(pending.length).toBe(3));
+
+    await settle(2, seedBody("anthropic", ["openrouter", "anthropic", "deepseek"]));
+    await settle(1, seedBody("openrouter", ["openrouter"]));
+    await act(async () => { await Promise.resolve(); });
+
+    await act(async () => { providerPill().click(); });
+    // Both providers the newest seed reported are still on offer. (The selected
+    // row carries a trailing check glyph, hence the substring match.)
+    expect(screen.getByRole("option", { name: /Anthropic/ })).toBeTruthy();
+    expect(screen.getByRole("option", { name: /DeepSeek/ })).toBeTruthy();
+    expect(screen.getAllByRole("option")).toHaveLength(3);
+  });
+});

--- a/src/tests/components/hermes-provider-invalidation.test.tsx
+++ b/src/tests/components/hermes-provider-invalidation.test.tsx
@@ -1,0 +1,156 @@
+import fs from "fs";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import {
+  HERMES_MODEL_STATE_EVENT,
+  notifyHermesModelState,
+  useHermesModelOptions,
+} from "@/hooks/useHermesModelOptions";
+
+/**
+ * Adding or authenticating a provider has to show up in the chat's provider
+ * picker straight away — the device is configured, so a picker that still omits
+ * it is simply wrong until the page is reloaded.
+ *
+ * The server side was already correct (every write drops the model-options cache
+ * and the `hermes config get` memo keys on config.yaml's mtime); the gap was that
+ * nothing told the client to re-read. The fix is a signal, and its whole value is
+ * in being CHEAP: `refresh=1` re-enumerates every provider's live /v1/models,
+ * which is a device-wide sweep to answer "did the provider list change?".
+ */
+
+function scope(provider: string, models: string[]) {
+  return {
+    provider,
+    authenticated: true,
+    models: models.map((id) => ({ id })),
+    defaultModel: models[0] ?? "",
+    current: models[0] ?? "",
+    savedElsewhere: null,
+    source: "dashboard",
+    stale: false,
+  };
+}
+
+function Probe({ provider }: { provider: string }) {
+  const { scope: s, loading } = useHermesModelOptions(provider);
+  return <p data-testid="probe">{loading ? "loading" : s?.models.map((m) => m.id).join(",") || "none"}</p>;
+}
+
+const fetchMock = () => globalThis.fetch as unknown as ReturnType<typeof vi.fn>;
+const urls = () => fetchMock().mock.calls.map((c) => String(c[0]));
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("the chat/panel model scope across a provider configure", () => {
+  it("re-reads the provider's models when the signal fires", async () => {
+    let models = ["openai/gpt-5"];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => scope("openai", models) })),
+    );
+
+    render(<Probe provider="openai" />);
+    await waitFor(() => expect(screen.getByTestId("probe").textContent).toBe("openai/gpt-5"));
+
+    // A configure landed somewhere else in the UI.
+    models = ["openai/gpt-5", "openai/gpt-5-mini"];
+    await act(async () => {
+      notifyHermesModelState();
+    });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").textContent).toBe("openai/gpt-5,openai/gpt-5-mini"),
+    );
+  });
+
+  it("re-reads plainly — it never asks for the all-provider live sweep", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: true, json: async () => scope("openai", ["openai/gpt-5"]) })),
+    );
+
+    render(<Probe provider="openai" />);
+    await waitFor(() => expect(urls().length).toBe(1));
+
+    await act(async () => {
+      notifyHermesModelState();
+    });
+    await waitFor(() => expect(urls().length).toBe(2));
+
+    expect(urls().every((u) => !u.includes("refresh=1"))).toBe(true);
+  });
+
+  it("does not blank the scope while the re-read is in flight", async () => {
+    // The model pill holds its place off `loading`; an invalidation that flipped
+    // it would make the chat header jump on every provider someone adds.
+    let release: (() => void) | null = null;
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => {
+        calls += 1;
+        if (calls > 1) await new Promise<void>((r) => { release = r; });
+        return { ok: true, json: async () => scope("openai", ["openai/gpt-5"]) };
+      }),
+    );
+
+    render(<Probe provider="openai" />);
+    await waitFor(() => expect(screen.getByTestId("probe").textContent).toBe("openai/gpt-5"));
+
+    await act(async () => {
+      notifyHermesModelState();
+    });
+    // Still the previous answer for the SAME provider — never "loading".
+    expect(screen.getByTestId("probe").textContent).toBe("openai/gpt-5");
+
+    await act(async () => {
+      release?.();
+    });
+  });
+
+  it("keeps one event name for emitter and listeners", () => {
+    expect(HERMES_MODEL_STATE_EVENT).toBe("clawbox:hermes-model-state-changed");
+  });
+});
+
+// ── Wiring, asserted on source ───────────────────────────────────────────────
+// Rendering ChatPopup means standing up its whole websocket/gateway tree for one
+// listener; the same precedent as chat-model-pill-stability.test.tsx.
+const read = (...p: string[]) => fs.readFileSync(path.join(process.cwd(), ...p), "utf8");
+const CHAT = read("src", "components", "ChatPopup.tsx");
+const PANEL = read("src", "components", "HermesProviderConfig.tsx");
+const HOOK = read("src", "hooks", "useHermesModelOptions.ts");
+
+describe("who emits the signal and who listens", () => {
+  it("has the chat re-seed its provider list on the shared event", () => {
+    expect(CHAT).toMatch(/window\.addEventListener\(HERMES_MODEL_STATE_EVENT, onChanged\)/);
+    expect(CHAT).toMatch(/const onChanged = \(\) => \{ void seedHermesHeader\(controller\.signal\) \}/);
+  });
+
+  /** The source between two markers — line-ending agnostic, unlike a regex. */
+  function between(src: string, from: string, to: string): string {
+    const a = src.indexOf(from);
+    const b = src.indexOf(to, a + 1);
+    expect(a).toBeGreaterThan(-1);
+    expect(b).toBeGreaterThan(a);
+    return src.slice(a, b);
+  }
+
+  it("emits after the ClawBox AI device login configures the device", () => {
+    expect(between(PANEL, "onComplete: () => {", "onError:")).toContain("notifyChatHeader()");
+  });
+
+  it("emits when the user returns from Hermes' own sign-in page", () => {
+    expect(between(PANEL, "const onFocus = () => {", 'addEventListener("focus"')).toContain(
+      "notifyChatHeader()",
+    );
+  });
+
+  it("keeps the hook's listener off the expensive path", () => {
+    // Bumping the nonce re-asks; setting pendingRefreshRef would add `refresh=1`.
+    expect(HOOK).toMatch(/const onChanged = \(\) => setNonce\(\(n\) => n \+ 1\);/);
+    expect(HOOK).toMatch(/const fresh = provider && loaded\?\.provider === provider \? loaded : null/);
+  });
+});

--- a/src/tests/components/hermes-skills-warming.test.tsx
+++ b/src/tests/components/hermes-skills-warming.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import HermesSkillsStore from "@/components/HermesSkillsStore";
+
+/**
+ * A freshly flashed box has no offline skill index, so the first Browse is
+ * answered — not left pending — by a route that reports `origin: 'warming'`,
+ * `degraded: true` and zero results while a build runs behind it.
+ *
+ * The store used to gate its "building the catalogue" panel on `loading`, which
+ * is false for a request that COMPLETED, so it fell through to the generic
+ * empty state and told the user there was nothing in a catalogue of ~90 000
+ * skills. Worse, nothing re-asked: the skills only appeared after the window was
+ * reopened.
+ */
+
+const WARMING = {
+  skills: [],
+  page: 1,
+  pageSize: 24,
+  total: 0,
+  totalPages: 1,
+  hasMore: false,
+  facets: { sources: [], providers: [] },
+  catalog: { origin: "warming" },
+  degraded: true,
+};
+
+const READY = {
+  skills: [
+    { id: "official/pdf-tools", name: "PDF Tools", source: "official", trust: "official" },
+  ],
+  page: 1,
+  pageSize: 24,
+  total: 1,
+  totalPages: 1,
+  hasMore: false,
+  facets: { sources: [{ id: "official", label: "Official", count: 1 }], providers: [] },
+  catalog: { origin: "index", skillCount: 90_600, fetchedAt: new Date().toISOString(), stale: false },
+  degraded: false,
+};
+
+const INSTALLED = { skills: [], counts: { total: 0 }, categories: [] };
+
+/** Serves the installed list always, and the browse endpoint from a script. */
+function mockBrowse(pages: unknown[]) {
+  let call = 0;
+  const fetchMock = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/skills/browse")) {
+      const body = pages[Math.min(call, pages.length - 1)];
+      call += 1;
+      return { ok: true, json: async () => body };
+    }
+    return { ok: true, json: async () => INSTALLED };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { fetchMock, browseCalls: () => call };
+}
+
+async function openBrowseTab() {
+  render(<HermesSkillsStore />);
+  const tab = await screen.findByTestId("skill-tab-browse");
+  await act(async () => {
+    fireEvent.click(tab);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("Browse while the skill index is still building", () => {
+  it("says the catalogue is being prepared instead of that it is empty", async () => {
+    mockBrowse([WARMING]);
+    await openBrowseTab();
+
+    expect(await screen.findByText(/Building the skill catalogue/i)).toBeTruthy();
+    // The two strings the user actually saw on the device.
+    expect(screen.queryByText(/Nothing in .* yet/i)).toBeNull();
+    expect(screen.queryByText(/Try a different term/i)).toBeNull();
+  });
+
+  it("tells the user it will fill in on its own", async () => {
+    mockBrowse([WARMING]);
+    await openBrowseTab();
+
+    expect(await screen.findByText(/Skills will appear here as soon as it is ready/i)).toBeTruthy();
+  });
+
+  it("re-asks and shows the skills once the index is ready, with no user action", async () => {
+    const { browseCalls } = mockBrowse([WARMING, READY]);
+    await openBrowseTab();
+
+    await screen.findByText(/Building the skill catalogue/i);
+    const before = browseCalls();
+
+    // No click, no retyped search — only time passing.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+
+    await waitFor(() => expect(screen.getByText("PDF Tools")).toBeTruthy());
+    expect(browseCalls()).toBeGreaterThan(before);
+    expect(screen.queryByText(/Building the skill catalogue/i)).toBeNull();
+  });
+
+  it("stops polling once the catalogue answers", async () => {
+    mockBrowse([WARMING, READY]);
+    await openBrowseTab();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(6000);
+    });
+    await waitFor(() => expect(screen.getByText("PDF Tools")).toBeTruthy());
+    const calls = () => (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.length;
+    const settled = calls();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000);
+    });
+    expect(calls()).toBe(settled);
+  });
+
+  it("still reports a genuinely empty result once the device HAS a catalogue", async () => {
+    // origin 'index' with no matches is a real answer, not a warm-up.
+    mockBrowse([{ ...READY, skills: [], total: 0 }]);
+    await openBrowseTab();
+
+    expect(await screen.findByText(/Nothing in .* yet/i)).toBeTruthy();
+    expect(screen.queryByText(/Building the skill catalogue/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
Two UI fixes found while testing a Hermes device.

## A — Browse said the skill catalogue was empty while its index was still building

On a freshly flashed box, Skills → Browse showed "Nothing in All sources yet / Try a different term". Waiting and retrying made ~90k skills appear, so the catalogue was fine — the UI was describing a first-run state it could not recognise.

Two gaps, both fixed:

- `setup-api/hermes/skills/browse` read `isWarming()` *before* kicking the build, so the very first request — the one that starts it — reported itself as a plain CLI answer. It now kicks first and then reports, which is the only way that request can describe itself honestly.
- The store gated its "building the catalogue" panel on `loading`. That request **completes** while the index warms (it falls back to the CLI, which on a fresh device also has nothing), so `loading` is already false by the time anything renders and the generic empty state won. `useSkillCatalog` now exposes `preparing` — warming origin, zero results — which both shows the first-run panel and suppresses the "nothing here" copy. "Nothing here" is a claim about a catalogue the device does not have yet.

It also recovers on its own: while the answer stays `warming` the hook re-asks every 5 s and stops the moment the origin changes, so nobody has to reopen the window or retype a search. The panel now says so too.

## B — The chat provider dropdown did not update when a provider was added

Adding or authenticating a provider left the chat's dropdown on the old set until a full page reload.

The server side was already correct — every write drops the model-options cache, and the `hermes config get` memo keys on `config.yaml`'s mtime. The gap was that nothing told the client to re-read.

`clawbox:hermes-model-state-changed` already existed but was emitted from one path (the Save button) and listened to in one place. It is now a named export next to `useHermesModelOptions`, the hook subscribes to it, and the two remaining configure paths emit it: the ClawBox AI device login, and the return from Hermes' own sign-in page (exactly when a provider flips to authenticated).

Kept deliberately cheap, as the hook's own comment asks: the listener bumps the nonce rather than calling `refresh`, so the re-read is a plain scoped GET. `refresh` sets the explicit flag, which busts Hermes' per-provider disk cache and re-enumerates every provider's live `/v1/models` — a device-wide sweep to answer "is the list different?". It also leaves the loaded scope in place, so `loading` never flips and the model pill keeps its position (`chat-model-pill-stability` still passes unchanged).

## Tests

New: `hermes-skills-warming.test.tsx` (5) and `hermes-provider-invalidation.test.tsx` (8). The warming tests fail 4/5 against the previous code; the fifth pins that a genuinely empty result on a device that *has* a catalogue is still reported as empty.

- Unit: 2162 passed, 0 failed (+13 over the 2160 baseline).
- E2E: 41 passed / 2 skipped / 0 failed, including `chat-popup.spec.ts:204`.
- Build clean, lint clean on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Skill catalogues show a clear “building automatically” status while preparing.
  - Catalogues refresh automatically and display newly available skills without user action.
  - Hermes model options update automatically after provider or device configuration changes.
- **Bug Fixes**
  - Initial skill browsing correctly reports when index construction has started.
  - Improved synchronization of model and reasoning settings across open views.
  - Prevented outdated model requests from overwriting newer settings.
  - Preserved appropriate empty-state messaging for genuinely empty catalogues.
- **Tests**
  - Added coverage for catalog warming, automatic refresh, model invalidation, and cross-view updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->