### PR TITLE
test: fix the three E2E Install failures

### DIFF
--- a/e2e-install/15-login-relogin.spec.ts
+++ b/e2e-install/15-login-relogin.spec.ts
@@ -11,10 +11,9 @@
  */
 import { test, expect } from "@playwright/test";
 import { BASE_URL } from "./helpers/container";
-import { getStatus } from "./helpers/setup-api";
-
-// Same password the wizard sets in 10-setup-wizard.spec.ts.
-const SETUP_PASSWORD = "clawbox-e2e-pass";
+// SETUP_PASSWORD is the password the wizard sets in 10-setup-wizard.spec.ts,
+// shared from the helper so the specs that need it can't drift apart.
+import { getStatus, SETUP_PASSWORD } from "./helpers/setup-api";
 
 test.describe("login round-trip", () => {
   test.beforeAll(async () => {

--- a/e2e-install/35-mcp.spec.ts
+++ b/e2e-install/35-mcp.spec.ts
@@ -34,16 +34,50 @@ test.describe("clawbox-cli (MCP user-space wrapper)", () => {
     expect(parsed.hostname.length).toBeGreaterThan(0);
   });
 
-  test("app list prints the built-in app names", async () => {
-    // CLI prints a header then one app name per line — not JSON.
+  test("app list prints the built-in apps for this edition", async () => {
+    // The CLI prints an edition-tagged header, then one `<id> — <name>` line
+    // per app — not JSON. The set is edition-dependent (see `builtInApps` in
+    // mcp/lib/context.ts): every edition gets the common apps, and each
+    // harness adds its own on top. Asking the CLI which edition it is keeps
+    // this assertion true on an OpenClaw box and on a Hermes box, instead of
+    // pinning it to whichever one CI happens to install.
+    const edition = (
+      await dockerExec(cli("edition"), { user: "clawbox", timeoutMs: 30_000 })
+    ).trim();
+    expect(edition, "`clawbox edition` should name a known edition").toMatch(
+      /^(openclaw|hermes|dual)$/,
+    );
+
     const out = await dockerExec(cli("app", "list"), {
       user: "clawbox",
       timeoutMs: 30_000,
     });
-    expect(out).toMatch(/Built-in apps:/i);
-    expect(out).toMatch(/\bsettings\b/);
-    expect(out).toMatch(/\bfiles\b/);
-    expect(out).toMatch(/\bterminal\b/);
+
+    // Header carries the edition, so a reader knows which app set this is.
+    expect(out).toMatch(
+      new RegExp(`^Built-in apps \\(${edition} edition\\):`, "im"),
+    );
+
+    // Common apps — listed on every edition.
+    for (const id of ["settings", "terminal", "files", "browser", "vnc"]) {
+      expect(out, `built-in app '${id}' should be listed`).toMatch(
+        new RegExp(`^\\s+${id} — `, "m"),
+      );
+    }
+
+    // Harness-specific apps. A Hermes box has the skills app and neither the
+    // OpenClaw chat app nor the store; listing an app whose backend isn't
+    // installed would point the agent at a window that cannot open. The
+    // premium `dual` edition resolves to the OpenClaw set.
+    if (edition === "hermes") {
+      expect(out).toMatch(/^\s+hermes-skills — /m);
+      expect(out).not.toMatch(/^\s+openclaw — /m);
+      expect(out).not.toMatch(/^\s+store — /m);
+    } else {
+      expect(out).toMatch(/^\s+openclaw — /m);
+      expect(out).toMatch(/^\s+store — /m);
+      expect(out).not.toMatch(/^\s+hermes-skills — /m);
+    }
   });
 
   test("notify writes a ui:pending-action with the message into kv.json", async () => {

--- a/e2e-install/40-terminal.spec.ts
+++ b/e2e-install/40-terminal.spec.ts
@@ -5,16 +5,40 @@
  *
  * This exercises:
  *   - node-pty native rebuild (install.sh's ensure_node_pty)
- *   - production-server.js WebSocket upgrade routing
+ *   - production-server.js WebSocket upgrade routing, including the session
+ *     check it applies to the single-service sockets
  *   - the standalone terminal-server.ts on port 3006 inside the container
+ *
+ * The upgrade carries a `clawbox_session` cookie because that is what the
+ * desktop's Terminal app sends. A WebSocket upgrade never passes through the
+ * Next.js middleware that gates ordinary requests, so production-server.js
+ * checks the cookie itself and the client has to supply it — the browser does
+ * so automatically from the document's cookie jar, and a raw socket must set
+ * the header by hand.
  */
 import { test, expect } from "@playwright/test";
 import WebSocket from "ws";
 import { CLAWBOX_PORT } from "./helpers/container";
+import { getStatus, loginSessionCookie } from "./helpers/setup-api";
+
+const TERMINAL_WS_URL = `ws://localhost:${CLAWBOX_PORT}/terminal-ws`;
 
 test.describe("terminal app happy path", () => {
+  let sessionCookie = "";
+
+  test.beforeAll(async () => {
+    const status = await getStatus();
+    test.skip(
+      !status.setup_complete,
+      "setup did not complete — no password to log in with yet",
+    );
+    sessionCookie = await loginSessionCookie();
+  });
+
   test("echo round-trip via /terminal-ws", async () => {
-    const ws = new WebSocket(`ws://localhost:${CLAWBOX_PORT}/terminal-ws`);
+    const ws = new WebSocket(TERMINAL_WS_URL, {
+      headers: { cookie: sessionCookie },
+    });
 
     const output: string[] = [];
     let opened = false;
@@ -59,5 +83,31 @@ test.describe("terminal app happy path", () => {
 
     expect(result).toMatch(/\bLinux\b/);
     expect(result).toMatch(/aarch64|x86_64|armv/);
+  });
+
+  test("/terminal-ws upgrade without a session does not open", async () => {
+    // The PTY backend listens on loopback with no auth of its own, so the
+    // session check on the upgrade is the only thing standing between a
+    // caller and a shell. Assert it is actually applied — otherwise the test
+    // above would keep passing if the cookie stopped being required.
+    const ws = new WebSocket(TERMINAL_WS_URL);
+
+    const outcome = await new Promise<string>((resolve) => {
+      const timer = setTimeout(() => resolve("timed-out"), 15_000);
+      ws.on("open", () => {
+        clearTimeout(timer);
+        ws.close();
+        resolve("opened");
+      });
+      ws.on("error", (err) => {
+        clearTimeout(timer);
+        resolve(String(err instanceof Error ? err.message : err));
+      });
+    });
+
+    expect(outcome, "an anonymous upgrade should not reach the PTY").not.toBe(
+      "opened",
+    );
+    expect(outcome).toMatch(/401/);
   });
 });

--- a/e2e-install/45-vnc.spec.ts
+++ b/e2e-install/45-vnc.spec.ts
@@ -4,17 +4,26 @@
  * spec verifies the public-facing surface:
  *
  *   - GET /setup-api/vnc returns a structured status payload
- *   - websockify on port 6080 accepts an HTTP GET (noVNC over websocket
- *     transport upgrades from HTTP, so a plain GET responds with 4xx /
- *     a noVNC welcome page; either is fine — what we DON'T want is
- *     ECONNREFUSED).
+ *   - websockify is up and answering on the address it binds (noVNC over
+ *     websocket transport upgrades from HTTP, so a plain GET responds with
+ *     a 4xx / a noVNC welcome page; either is fine — what we DON'T want is
+ *     nothing listening)
+ *   - the route the desktop actually uses, /novnc-ws on the app port,
+ *     carries the same session requirement as the rest of the desktop
  *
  * Runs at NN=45 between terminal (40) and webapps (50).
  */
 import { test, expect } from "@playwright/test";
+import WebSocket from "ws";
+import { CLAWBOX_PORT, dockerExec } from "./helpers/container";
 import { getVncStatus } from "./helpers/setup-api";
 
-const VNC_PORT = process.env.CLAWBOX_VNC_PORT ?? "6080";
+// The port websockify binds inside the container. install.sh binds it on
+// loopback rather than the wildcard: x11vnc runs `-nopw -localhost`, so the
+// desktop has no password of its own and the intended route to it is
+// production-server.js's /novnc-ws upgrade, which is session-gated (and which
+// VNCApp already uses — same-origin, so HTTPS and the tunnel work too).
+const VNC_WS_PORT = process.env.VNC_WS_PORT ?? "6080";
 
 test.describe("vnc happy path", () => {
   test("GET /setup-api/vnc returns a status payload", async () => {
@@ -31,16 +40,51 @@ test.describe("vnc happy path", () => {
     }
   });
 
-  test("websockify port responds (no ECONNREFUSED)", async ({ request }) => {
-    // noVNC's websockify accepts plain HTTP GET on the wsPort and serves
-    // a tiny welcome page or a 4xx "websocket only" — both prove it's
-    // listening.
-    const res = await request.get(`http://localhost:${VNC_PORT}/`, {
-      failOnStatusCode: false,
-      timeout: 5_000,
-    });
-    expect(res.status(), "websockify should respond on port 6080").toBeLessThan(
-      500,
+  test("websockify answers on its loopback bind", async () => {
+    // Probe websockify where it actually listens — inside the container — so
+    // this still proves "websockify is up and answering" rather than "the
+    // port is reachable from off-box", which it deliberately is not.
+    // `%{http_code}` is `000` when curl never got an HTTP response at all,
+    // which is the case this test exists to catch.
+    const out = await dockerExec(
+      [
+        "bash",
+        "-lc",
+        `curl -s -o /dev/null -w '%{http_code}' --max-time 5 http://127.0.0.1:${VNC_WS_PORT}/ || true`,
+      ],
+      { user: "clawbox", timeoutMs: 30_000 },
     );
+    const code = out.trim();
+    expect(
+      code,
+      `nothing answered on 127.0.0.1:${VNC_WS_PORT} — websockify is not listening`,
+    ).not.toBe("000");
+    expect(Number(code), `unexpected websockify status ${code}`).toBeLessThan(500);
+  });
+
+  test("/novnc-ws upgrade without a session does not open", async () => {
+    // The desktop reaches the remote desktop through this same-origin route,
+    // and it is the only route in from off-box. Assert the session
+    // requirement is applied on the upgrade, since websockify itself has no
+    // auth of its own to fall back on.
+    const ws = new WebSocket(`ws://localhost:${CLAWBOX_PORT}/novnc-ws`);
+
+    const outcome = await new Promise<string>((resolve) => {
+      const timer = setTimeout(() => resolve("timed-out"), 15_000);
+      ws.on("open", () => {
+        clearTimeout(timer);
+        ws.close();
+        resolve("opened");
+      });
+      ws.on("error", (err) => {
+        clearTimeout(timer);
+        resolve(String(err instanceof Error ? err.message : err));
+      });
+    });
+
+    expect(outcome, "an anonymous upgrade should not reach websockify").not.toBe(
+      "opened",
+    );
+    expect(outcome).toMatch(/401/);
   });
 });

--- a/e2e-install/README.md
+++ b/e2e-install/README.md
@@ -42,8 +42,10 @@ Paths guarded by `CLAWBOX_TEST_MODE=1` because they need real hardware:
 
 VNC (`x11vnc` + `Xvfb` + `websockify`) **is** installed in test mode — it
 runs fine in a `--privileged` container and is needed for browser automation
-tests. Point a VNC/noVNC client at `localhost:6080` while tests run to watch
-the container's virtual desktop.
+tests. websockify binds loopback inside the container (same as a real
+device), so port 6080 is not published and cannot be reached from the host.
+To watch the container's virtual desktop while tests run, go in on the
+published web port: log in, then open the Remote Desktop app.
 
 Everything else runs for real: apt packages, git clone, bun install, next
 build, OpenClaw npm install + patches, systemd service install, polkit, the

--- a/e2e-install/docker-compose.test.yml
+++ b/e2e-install/docker-compose.test.yml
@@ -49,10 +49,12 @@ services:
       CLAWBOX_BRANCH: ${CLAWBOX_BRANCH:-main}
     ports:
       - "${CLAWBOX_PORT:-8080}:80"
-      # Expose noVNC websockify so developers can view the Xvfb desktop
-      # during browser/VNC tests. CLAWBOX_VNC_PORT defaults to 6080 — the
-      # same port a real device exposes.
-      - "${CLAWBOX_VNC_PORT:-6080}:6080"
+      # websockify (6080) is deliberately NOT published. It binds loopback
+      # inside the container, matching a real device — see install.sh's
+      # clawbox-websockify.service — so a host-side mapping would forward to
+      # an address nothing is listening on. To watch the Xvfb desktop during
+      # browser/VNC tests, go in the front door on the published port above:
+      # log in, then open the Remote Desktop app (or /novnc-ws directly).
     # Health check polls the setup API so Playwright can `wait-for-healthy`
     # instead of blind sleeping.
     healthcheck:

--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -22,6 +22,53 @@ async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
   return body as T;
 }
 
+// ── Session ───────────────────────────────────────────────────────────────
+
+/** The password `10-setup-wizard.spec.ts` sets while running the wizard. */
+export const SETUP_PASSWORD = "clawbox-e2e-pass";
+
+/** One of the durations `/login-api` accepts, in seconds. */
+const SESSION_DURATION_SECONDS = 21_600;
+
+/**
+ * Log in and return the `clawbox_session` cookie as a ready-to-send
+ * `name=value` pair.
+ *
+ * Browser-driven specs get this cookie for free from the Playwright context.
+ * Specs that open a raw socket do not: a WebSocket upgrade is served by
+ * `production-server.js` and never passes through the Next.js request
+ * pipeline, so those specs have to carry the session on the upgrade request
+ * themselves — exactly as the desktop UI does.
+ */
+export async function loginSessionCookie(
+  password: string = SETUP_PASSWORD,
+): Promise<string> {
+  const res = await fetch(`${BASE_URL}/login-api`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ password, duration: SESSION_DURATION_SECONDS }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `POST /login-api → ${res.status} ${res.statusText}: ${await res.text()}`,
+    );
+  }
+  // `getSetCookie()` keeps multiple Set-Cookie headers separate; the single
+  // -header fallback keeps this working on any runtime that lacks it.
+  const headers = res.headers as Headers & { getSetCookie?: () => string[] };
+  const cookies =
+    typeof headers.getSetCookie === "function"
+      ? headers.getSetCookie()
+      : [res.headers.get("set-cookie") ?? ""];
+  for (const raw of cookies) {
+    const match = /(?:^|,\s*)(clawbox_session=[^;,]+)/.exec(raw);
+    if (match) return match[1];
+  }
+  throw new Error(
+    `/login-api returned 200 but set no clawbox_session cookie: ${cookies.join(" | ")}`,
+  );
+}
+
 export interface SetupStatus {
   setup_complete: boolean;
   wifi_configured: boolean;


### PR DESCRIPTION
Makes the `E2E Install` job green again. Three specs were failing on the open PRs; one of them was already failing on `beta` before the edition work landed.

## 1. `35-mcp.spec.ts` — app list header (new, from the edition work)

`clawbox app list` now tags its header with the edition and prints an edition-dependent app set:

```
Built-in apps (openclaw edition):
  settings — Settings
  ...
```

The output change is intentional; the assertion (`/Built-in apps:/i`) was stale. The spec now asks `clawbox edition` first and checks the app set that edition is supposed to have, so it holds on an OpenClaw box, a Hermes box (skills app, no OpenClaw app, no store) and a `dual` box — rather than on whichever one CI happens to install.

## 2. `45-vnc.spec.ts` — websockify probe (new, from the edition work)

`clawbox-websockify.service` moved from `websockify 6080 ...` to `websockify 127.0.0.1:6080 ...`, so it no longer answers on the container's published port. The service itself is fine — `70-browser.spec.ts` asserts it is `active` and passed in the same run. Only the test's address was wrong.

The probe now runs inside the container against the address websockify binds, which keeps the original intent ("it is up and answering", not "the port is open off-box"). The compose mapping that can no longer reach it is dropped, and a case is added for `/novnc-ws`, the same-origin route the desktop actually uses.

## 3. `40-terminal.spec.ts` — 401 on the upgrade (pre-existing)

This one failed on `beta` before the merge too. `/terminal-ws` upgrades have required a `clawbox_session` cookie since the proxy started checking them; the spec dates from before that and still opened the socket anonymously, so it got a 401 rather than a PTY.

The server is behaving correctly, so the spec is what changes: it logs in and sends the cookie the desktop's Terminal app sends. To keep "the test wasn't sending credentials" and "the server stopped accepting them" distinguishable in future, a companion case asserts an anonymous upgrade still does not open — so the happy path cannot start passing for the wrong reason. Nothing on the server side was relaxed.

## Also checked

`ap-watchdog.sh` retrying against an unmanaged device, and `clawbox-ap-watchdog.service` exiting 1, are container artefacts — there is no wifi device, and the watchdog is a no-op once setup completes. Both the watchdog and the stub-interface path predate the merge, and the pre-merge run had only the terminal failure, so they are not contributing. Left alone.

No test was skipped, deleted or loosened.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of edition-specific app listings and CLI information.
  * Secured terminal and desktop connections by requiring an authenticated session.
  * Confirmed unauthorized connection attempts are rejected instead of opening a session.
  * Improved reliability of setup login handling and session management.

* **Documentation**
  * Updated desktop access instructions to use the published web interface and Remote Desktop app.

* **Chores**
  * Updated installation testing to reflect the revised desktop access flow and configurable connection settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->