### PR TITLE
fix: start the on-device model on demand and stop implying it is active

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -458,6 +458,15 @@ export async function POST(request: Request) {
       clawaiTier?: string;
       model?: string;
       oauthHandoff?: boolean;
+      /**
+       * Explicit "make this the model that answers", as distinct from "install
+       * it and keep it available". Enabling a local model deliberately does NOT
+       * take over from the provider the customer chose, so the Settings panel's
+       * "Switch to Gemma 4" button had no way to actually switch — it ran the
+       * same enable flow and silently left the harness where it was. This flag
+       * is that missing intent; omitted, the promote policy is unchanged.
+       */
+      activate?: boolean;
     };
     try {
       body = await request.json();
@@ -607,7 +616,10 @@ export async function POST(request: Request) {
       );
     }
 
-    const shouldPromoteLocalToPrimary = isLocalScope && !configStore.ai_model_configured;
+    // A fresh device promotes its first local model automatically; an existing
+    // device only promotes when the user explicitly asked to switch to it.
+    const shouldPromoteLocalToPrimary =
+      isLocalScope && (!configStore.ai_model_configured || body.activate === true);
     // Resolve the ClawBox AI tier once and reuse it for both the primary
     // model selection (below) and the config-store write (further down).
     // Inlining the same `?? storedTier ?? DEFAULT_TIER` chain in two
@@ -963,7 +975,19 @@ export async function POST(request: Request) {
       // quietly take the device off the provider the customer chose.
       if ((ocProvider === "llamacpp" || ocProvider === "ollama") && (await getActiveHarness()) === "hermes") {
         try {
-          await applyLocalAiToHermes({ provider: ocProvider, model: config.defaultModel });
+          await applyLocalAiToHermes({
+            provider: ocProvider,
+            // Hermes wants the bare model id, not the `llamacpp/…` qualified
+            // form — matching the openclaw-absent branch above.
+            model: config.defaultModel.replace(/^(?:llamacpp|ollama)\//, ""),
+            // This branch runs on the `dual` SKU, where OpenClaw exists but
+            // Hermes is the harness actually answering. Without carrying the
+            // promotion through, "Switch to Gemma 4" moved OpenClaw's primary
+            // and left Hermes pointed at its old provider — the same
+            // configured-but-not-active split this change exists to remove,
+            // reproduced on the one SKU that has both.
+            makeDefault: shouldPromoteLocalToPrimary,
+          });
         } catch (err) {
           // Non-fatal: the local model is configured and running either way.
           console.error("[ai-models/configure] Hermes local provider registration failed:", err);

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -15,6 +15,10 @@ const PROVIDER_LABELS: Record<string, string> = {
   openrouter: "OpenRouter",
   ollama: "Ollama Local",
   llamacpp: "llama.cpp Local",
+  // Hermes' id for the on-device model. Without an entry here the raw
+  // "clawlocal" leaked into the UI as a provider name. Matches the wording in
+  // lib/hermes-providers.ts so the same model isn't called two things.
+  clawlocal: "Gemma 4 (on-device)",
 };
 
 const CLAWBOX_AI_TIER_CONFIG_KEY = "clawai_tier";

--- a/src/app/setup-api/llamacpp/install/route.ts
+++ b/src/app/setup-api/llamacpp/install/route.ts
@@ -202,7 +202,11 @@ function startLlamaCpp(spec: ReturnType<typeof getLlamaCppLaunchSpec>, alias: st
   );
 }
 
-async function configureLlamaCpp(alias: string, scope: ConfigureScope): Promise<{ ok: boolean; error?: string }> {
+async function configureLlamaCpp(
+  alias: string,
+  scope: ConfigureScope,
+  activate: boolean,
+): Promise<{ ok: boolean; error?: string }> {
   const req = new Request("http://localhost/setup-api/ai-models/configure", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -211,6 +215,7 @@ async function configureLlamaCpp(alias: string, scope: ConfigureScope): Promise<
       apiKey: alias,
       authMode: "local",
       scope,
+      activate,
     }),
   });
   const res = await configureAiModel(req);
@@ -222,7 +227,7 @@ async function configureLlamaCpp(alias: string, scope: ConfigureScope): Promise<
 }
 
 export async function POST(request: Request) {
-  let body: { model?: string; scope?: ConfigureScope };
+  let body: { model?: string; scope?: ConfigureScope; activate?: boolean };
   try {
     body = await request.json();
   } catch {
@@ -231,6 +236,9 @@ export async function POST(request: Request) {
 
   const alias = body.model?.trim() || getDefaultLlamaCppModel();
   const scope = body.scope === "local" ? "local" : "primary";
+  // Only an explicit "switch to it" click sets this; a plain enable leaves the
+  // customer's chosen provider in place.
+  const activate = body.activate === true;
   if (!MODEL_ID_RE.test(alias)) {
     return NextResponse.json({ error: "Invalid llama.cpp model ID" }, { status: 400 });
   }
@@ -246,7 +254,7 @@ export async function POST(request: Request) {
         const existingModels = await queryLlamaCppModels(spec.baseUrl);
         if (existingModels.includes(alias)) {
           emit(controller, { status: "llama.cpp is already running. Applying configuration..." });
-          const configured = await configureLlamaCpp(alias, scope);
+          const configured = await configureLlamaCpp(alias, scope, activate);
           if (!configured.ok) {
             emit(controller, { error: configured.error });
             controller.close();
@@ -324,7 +332,7 @@ export async function POST(request: Request) {
           const models = await queryLlamaCppModels(spec.baseUrl);
           if (models.includes(alias)) {
             emit(controller, { status: "llama.cpp is ready. Applying ClawBox configuration..." });
-            const configured = await configureLlamaCpp(alias, scope);
+            const configured = await configureLlamaCpp(alias, scope, activate);
             if (!configured.ok) {
               emit(controller, { error: configured.error });
               controller.close();

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -45,6 +45,15 @@ interface AIModelsStepProps {
   defaultProviderId?: string;
   currentProviderId?: string | null;
   currentModel?: string | null;
+  /**
+   * Whether the local model is the harness's ACTIVE selection, as opposed to
+   * merely installed. `currentProviderId` only ever reported the latter, so the
+   * llama.cpp panel showed an "already configured" pill — and hid its own
+   * switch button — on devices that were not actually using the model.
+   * Undefined keeps the old provider-id-derived behaviour for callers that
+   * don't know the difference (the setup wizard).
+   */
+  localAiIsActive?: boolean;
   openClawAIOfferRequest?: number;
   requestedProviderId?: string | null;
   providerSelectionRequest?: number;
@@ -400,6 +409,7 @@ export default function AIModelsStep({
   defaultProviderId,
   currentProviderId = null,
   currentModel = null,
+  localAiIsActive,
   openClawAIOfferRequest = 0,
   requestedProviderId = null,
   providerSelectionRequest = 0,
@@ -1820,7 +1830,7 @@ export default function AIModelsStep({
             <LlamaCppModelPanel
               llamaCppRunning={llamaCppRunning}
               llamaCppInstalled={llamaCppInstalled}
-              llamaCppIsActive={normalizedCurrentProvider === "llamacpp"}
+              llamaCppIsActive={localAiIsActive ?? normalizedCurrentProvider === "llamacpp"}
               llamaCppSaving={llamaCppSaving}
               llamaCppProgress={llamaCppProgress}
               selectedLlamaCppModel={selectedLlamaCppModel}

--- a/src/components/LlamaCppModelPanel.tsx
+++ b/src/components/LlamaCppModelPanel.tsx
@@ -20,7 +20,7 @@ interface LlamaCppModelPanelProps {
   llamaCppProgress?: string | null;
   selectedLlamaCppModel: string;
   setSelectedLlamaCppModel: (model: string) => void;
-  saveLlamaCppConfig: (model: string) => void;
+  saveLlamaCppConfig: (model: string, options?: { activate?: boolean }) => void;
   buttonClassName?: string;
   buttonSpinner?: ReactNode;
 }
@@ -63,7 +63,7 @@ export default function LlamaCppModelPanel({
 
   let buttonLabel: string;
   if (llamaCppSaving) {
-    buttonLabel = "Enabling Gemma 4...";
+    buttonLabel = canSwitchToGemma ? "Switching to Gemma 4..." : "Enabling Gemma 4...";
   } else if (canSwitchToGemma) {
     buttonLabel = "Switch to Gemma 4";
   } else {
@@ -101,7 +101,11 @@ export default function LlamaCppModelPanel({
       ) : (
         <button
           type="button"
-          onClick={() => saveLlamaCppConfig(selectedLlamaCppModel)}
+          // When the model is already installed, this button's job is to make
+          // it the active one — so say so to the server. Without the flag it
+          // re-ran the enable flow and left the harness pointed elsewhere,
+          // i.e. a "Switch to Gemma 4" button that did not switch.
+          onClick={() => saveLlamaCppConfig(selectedLlamaCppModel, { activate: canSwitchToGemma })}
           disabled={!!llamaCppSaving}
           className={buttonClassName}
         >

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -20,6 +20,7 @@ import { useClawboxLogin } from "@/lib/use-clawbox-login";
 import { I18nProvider, useT, LANGUAGES, type Locale } from "@/lib/i18n";
 import { cachedActiveHarness, fetchHarness } from "@/lib/client-harness";
 import { isPairingToken, normalizePairingToken, samePairingToken } from "@/lib/telegram-pairing-token";
+import { lastModelSegment } from "@/lib/chat-header-pills";
 import { QRCodeSVG } from "qrcode.react";
 import type { UpdateState } from "@/lib/updater";
 import { RESTART_STEP_ID } from "@/lib/update-constants";
@@ -90,6 +91,24 @@ const NAV_ITEMS: { id: Section; icon: string; labelKey?: string; label?: string 
 ];
 
 /* ── Helpers ── */
+// Hermes registers the on-device model under this single provider id whichever
+// local runtime backs it (see HERMES_LOCAL_PROVIDER in lib/hermes-local-ai.ts).
+// OpenClaw instead names the runtime directly ("llamacpp" / "ollama"), so
+// "is the local model the active provider" has to accept either spelling.
+const HERMES_LOCAL_PROVIDER_ID = "clawlocal";
+
+// Copy for the four Local AI states, kept as data so the status line and the
+// card below cannot drift apart. "Selected" vs "available" is the distinction
+// that matters: installing the on-device model does not make it the one that
+// answers, and saying "sleeping until needed" when it was never selected read
+// as though it were.
+const LOCAL_AI_STATUS_SUFFIX = {
+  offline: "endpoint not responding",
+  available: "available, not currently selected",
+  standby: "selected · sleeping until needed",
+  running: "selected · running",
+} as const;
+
 function formatBytes(b: number): string {
   if (!b) return "0 B";
   const u = ["B", "KB", "MB", "GB", "TB"];
@@ -971,7 +990,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   /* ── AI Provider ── */
   const [aiProvider, setAiProvider] = useState<{ connected: boolean; provider: string | null; providerLabel: string | null; mode: string | null; model: string | null; clawaiTier: "flash" | "pro" | null } | null>(null);
   useEffect(() => {
-    if (section !== "ai" && !isMobile) return;
+    // The Local AI panel needs this too: it is the only source that knows which
+    // provider the ACTIVE harness is really set to, which is what separates
+    // "the on-device model is installed" from "it is what answers".
+    if (section !== "ai" && section !== "localAi" && !isMobile) return;
     fetch("/setup-api/ai-models/status", { cache: "no-store" }).then(r => r.json()).then(setAiProvider).catch(() => {});
   }, [section, isMobile]);
   // Which agent consumes the local model. Named the harness outright, and said
@@ -1016,6 +1038,34 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       setLocalAiStatus({ configured: false, provider: null, model: null, running: null, standbyEnabled: false });
     }
   }, []);
+  // Is the on-device model the provider the active harness will actually answer
+  // with? `localAiStatus` alone can never say — it is built from the
+  // config-store keys written when the model was installed, and installing one
+  // deliberately does not take over from the provider the customer chose. The
+  // harness's own selection (via /setup-api/ai-models/status) is the only proof.
+  const localAiIsActive = !!localAiStatus?.configured
+    && !!aiProvider?.provider
+    && (aiProvider.provider === HERMES_LOCAL_PROVIDER_ID || aiProvider.provider === localAiStatus.provider);
+
+  /**
+   * The four states the Local AI cards render, resolved once so the status line
+   * and the card copy cannot drift apart:
+   *   offline   — configured, but the endpoint isn't answering and there is no standby
+   *   available — installed and healthy, but something else is answering
+   *   standby   — selected, asleep to free RAM until it is needed
+   *   running   — selected and resident
+   */
+  const localAiState: "offline" | "available" | "standby" | "running" | null = !localAiStatus?.configured
+    ? null
+    : localAiStatus.running === false && !localAiStatus.standbyEnabled
+      ? "offline"
+      : !localAiIsActive
+        ? "available"
+        : localAiStatus.running === false
+          ? "standby"
+          : "running";
+  const localAiOffline = localAiState === "offline";
+
   const disableLocalAi = useCallback(async () => {
     setLocalAiDisabling(true);
     setLocalAiError(null);
@@ -2222,25 +2272,25 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                 </div>
               ) : localAiStatus.configured ? (
                 <div className={`flex items-center gap-4 rounded-xl px-4 py-3.5 border ${
-                  localAiStatus.running === false && !localAiStatus.standbyEnabled
+                  localAiOffline
                     ? "bg-amber-500/[0.06] border-amber-500/15"
                     : "bg-cyan-500/[0.06] border-cyan-500/15"
                 }`}>
                   <div className={`relative w-10 h-10 rounded-full border flex items-center justify-center shrink-0 ${
-                    localAiStatus.running === false && !localAiStatus.standbyEnabled
+                    localAiOffline
                       ? "bg-amber-500/10 border-amber-400/10"
                       : "bg-cyan-500/10 border-cyan-400/10"
                   }`}>
                     <AIProviderIcon provider={localAiStatus.provider} size={24} />
                     <span className={`absolute -right-1 -bottom-1 w-5 h-5 rounded-full border flex items-center justify-center ${
-                      localAiStatus.running === false && !localAiStatus.standbyEnabled
+                      localAiOffline
                         ? "bg-[#2a1d10] border-amber-500/25"
                         : "bg-[#10212a] border-cyan-500/25"
                     }`}>
                       <span className={`material-symbols-rounded ${
-                        localAiStatus.running === false && !localAiStatus.standbyEnabled ? "text-amber-300" : "text-cyan-300"
+                        localAiOffline ? "text-amber-300" : "text-cyan-300"
                       }`} style={{ fontSize: 14 }}>
-                        {localAiStatus.running === false && !localAiStatus.standbyEnabled ? "warning" : "check"}
+                        {localAiOffline ? "warning" : "check"}
                       </span>
                     </span>
                   </div>
@@ -2250,16 +2300,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                     </div>
                     <div className="flex items-center gap-1.5 mt-0.5">
                       <span className={`w-1.5 h-1.5 rounded-full animate-pulse ${
-                        localAiStatus.running === false && !localAiStatus.standbyEnabled ? "bg-amber-300" : "bg-cyan-300"
+                        localAiOffline ? "bg-amber-300" : "bg-cyan-300"
                       }`} />
                       <span className={`text-xs ${
-                        localAiStatus.running === false && !localAiStatus.standbyEnabled ? "text-amber-300/80" : "text-cyan-300/80"
+                        localAiOffline ? "text-amber-300/80" : "text-cyan-300/80"
                       }`}>
-                        {localAiStatus.running === false && !localAiStatus.standbyEnabled
-                          ? `${localAiStatus.model ? localAiStatus.model.split("/").pop() : "Configured"} · endpoint not responding`
-                          : localAiStatus.running === false
-                            ? `${localAiStatus.model ? localAiStatus.model.split("/").pop() : "Configured"} · sleeping until needed`
-                            : (localAiStatus.model ? localAiStatus.model.split("/").pop() : "Ready as fallback")}
+                        {`${localAiStatus.model ? lastModelSegment(localAiStatus.model) : "Configured"} · ${
+                          localAiState ? LOCAL_AI_STATUS_SUFFIX[localAiState] : ""
+                        }`}
                       </span>
                     </div>
                   </div>
@@ -2329,11 +2377,17 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       {localAiStatus.provider === "llamacpp" ? "Gemma 4" : "Ollama"}
                     </div>
                     <p className="text-sm text-[var(--text-secondary)] mt-1">
-                      {localAiStatus.running === false && !localAiStatus.standbyEnabled
+                      {localAiState === "offline"
                         ? "Configured, but currently offline."
-                        : localAiStatus.running === false
-                          ? `Enabled with on-demand standby to free RAM until ${harnessLabel} needs it.`
-                        : "Enabled and ready as your local backup model."}
+                        : localAiState === "available"
+                          // Installed and ready, but the harness is pointed
+                          // elsewhere — name what IS answering so the state is
+                          // unambiguous. The label comes from the same endpoint
+                          // that reports the active provider, so it can't drift.
+                          ? `Installed and ready, but ${harnessLabel} is currently set to ${aiProvider?.providerLabel || aiProvider?.provider || "another provider"}.`
+                          : localAiState === "standby"
+                            ? `Selected. Kept in on-demand standby to free RAM until ${harnessLabel} needs it.`
+                            : "Selected and running as your on-device model."}
                     </p>
                   </div>
                   <button
@@ -2357,9 +2411,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               defaultProviderId="llamacpp"
               currentProviderId={localAiStatus?.provider ?? null}
               currentModel={localAiStatus?.model ?? null}
+              // Installed is not selected. Without this the panel rendered the
+              // green "already configured" pill and hid its own switch button,
+              // so a device that had Gemma installed but unselected offered no
+              // way to actually start using it.
+              localAiIsActive={localAiIsActive}
               title="Set Up Local AI"
               description={localAiStatus?.configured
-                ? "Gemma 4 is configured as your private on-device fallback."
+                ? "Gemma 4 is installed as your private on-device model."
                 : "Turn on a local model so ClawBox always has a private on-device backup."}
               configureScope="local"
               testId="settings-local-ai-step"

--- a/src/hooks/useLlamaCppModels.ts
+++ b/src/hooks/useLlamaCppModels.ts
@@ -46,7 +46,10 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: 
     }
   }, []);
 
-  const saveLlamaCppConfig = useCallback(async (model: string) => {
+  // `options.activate` = the user clicked "Switch to Gemma 4", i.e. asked for
+  // this model to become the one that answers. A plain enable omits it and
+  // keeps the customer's chosen provider in place.
+  const saveLlamaCppConfig = useCallback(async (model: string, options?: { activate?: boolean }) => {
     const trimmedModel = model.trim();
     if (!trimmedModel) {
       onSaveError("Enter the llama.cpp model ID first.");
@@ -64,6 +67,7 @@ export function useLlamaCppModels(callbacks: LlamaCppCallbacks, configureScope: 
         body: JSON.stringify({
           model: trimmedModel,
           scope: configureScope,
+          activate: options?.activate === true,
         }),
       });
 

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -13,7 +13,7 @@ let terminalChild: ChildProcess | null = null
 let terminalStopping = false
 let llamaCppChild: ChildProcess | null = null
 let llamaCppStopping = false
-let llamaCppStartPromise: Promise<void> | null = null
+let llamaCppStartPromise: Promise<LlamaCppStartStatus> | null = null
 let cleanupRegistered = false
 
 function cleanupChildren() {
@@ -115,18 +115,42 @@ export function startTerminalServer() {
   }
 }
 
-export async function startLlamaCppServer() {
+/**
+ * What a {@link startLlamaCppServer} call actually did.
+ *
+ * The `skipped-*` outcomes exist because a silent no-op here used to be
+ * indistinguishable from a successful start: the caller went straight on to
+ * poll for a server that was never going to appear, and only found out 20
+ * minutes later. Callers that *asked* for the runtime (the on-demand proxy)
+ * treat any `skipped-*` as an immediate, explainable failure.
+ */
+export type LlamaCppStartStatus =
+  | 'started'
+  | 'skipped-disabled'
+  | 'skipped-not-configured'
+
+/**
+ * Start llama.cpp, or report why it wasn't started.
+ *
+ * `alias` is the caller's explicit "I want this model, now" — used by the
+ * on-demand proxy. A request that arrived through the llama.cpp proxy is
+ * itself the authorization to start, so it does not get re-litigated against
+ * OpenClaw's config file (see bootLlamaCppServer for why that check cannot
+ * work on every SKU). Called with no alias — the boot-time auto-start — the
+ * model is derived from configuration instead.
+ */
+export async function startLlamaCppServer(alias?: string): Promise<LlamaCppStartStatus> {
   llamaCppStopping = false
   registerCleanupHandlers()
   if (llamaCppStartPromise) return await llamaCppStartPromise
 
-  llamaCppStartPromise = bootLlamaCppServer().finally(() => {
+  llamaCppStartPromise = bootLlamaCppServer(alias).finally(() => {
     llamaCppStartPromise = null
   })
   return await llamaCppStartPromise
 }
 
-async function bootLlamaCppServer() {
+async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStartStatus> {
   const [{ getAll }, { readConfig }, llamaCpp] = await Promise.all([
     import('./lib/config-store'),
     import('./lib/openclaw-config'),
@@ -139,27 +163,32 @@ async function bootLlamaCppServer() {
     const primaryModel = config.agents?.defaults?.model?.primary?.trim()
     if (!primaryModel || !primaryModel.startsWith('llamacpp/')) {
       console.log('[instrumentation] llama.cpp auto-start skipped (Local AI explicitly disabled)')
-      return
+      return 'skipped-disabled'
     }
   }
 
-  const alias = llamaCpp.getConfiguredLlamaCppModelAlias(config)
+  // An explicit alias is the caller saying "start this one" — honour it.
+  // Otherwise resolve it the same way the wake path does, so the two can never
+  // disagree about which model this device is supposed to run.
+  const alias = requestedAlias?.trim()
+    || llamaCpp.getConfiguredLlamaCppModelAlias(config)
+    || llamaCpp.getLocalAiConfigStoreAlias(state)
   if (!alias) {
     console.log('[instrumentation] llama.cpp auto-start skipped (no llama.cpp primary or local fallback configured)')
-    return
+    return 'skipped-not-configured'
   }
 
   const spec = llamaCpp.getLlamaCppLaunchSpec(alias)
   const runningModels = await llamaCpp.queryLlamaCppModels(spec.baseUrl)
   if (runningModels.includes(alias)) {
     console.log(`[instrumentation] llama.cpp already running for ${alias}`)
-    return
+    return 'started'
   }
 
   const existingPid = await llamaCpp.readLlamaCppPid(spec.pidPath)
   if (existingPid && llamaCpp.isLlamaCppPidRunning(existingPid)) {
     console.log(`[instrumentation] llama.cpp already starting for ${alias} (pid=${existingPid})`)
-    return
+    return 'started'
   }
   if (existingPid) {
     await llamaCpp.clearLlamaCppPid(spec.pidPath)
@@ -213,7 +242,10 @@ async function bootLlamaCppServer() {
 
         console.log(`[instrumentation] llama.cpp exited (code=${code}), retrying in 5s...`)
         setTimeout(() => {
-          void startLlamaCppServer().catch((err) => {
+          // Restart the SAME alias. Re-deriving it would send the crash-restart
+          // back through the configuration gate, which on a Hermes device is a
+          // different question from "what was just running".
+          void startLlamaCppServer(alias).catch((err) => {
             console.error('[instrumentation] Failed to restart llama.cpp:', err instanceof Error ? err.message : err)
           })
         }, 5000)
@@ -222,6 +254,8 @@ async function bootLlamaCppServer() {
       }
     })()
   })
+
+  return 'started'
 }
 
 export async function stopLlamaCppServer() {

--- a/src/lib/llamacpp-server.ts
+++ b/src/lib/llamacpp-server.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import type { FileHandle } from "fs/promises";
 import path from "path";
-import { DATA_DIR } from "./config-store";
+import { DATA_DIR, getAll } from "./config-store";
 import {
   getDefaultLlamaCppFile,
   getDefaultLlamaCppModel,
@@ -9,7 +9,7 @@ import {
   getLlamaCppBaseUrl,
   getLlamaCppServerContextSize,
 } from "./llamacpp";
-import { inferConfiguredLocalModel, type OpenClawConfig } from "./openclaw-config";
+import { inferConfiguredLocalModel, readConfig, type OpenClawConfig } from "./openclaw-config";
 
 const LLAMACPP_RUNTIME_DIR = path.join(DATA_DIR, "llamacpp");
 const LLAMACPP_PID_PATH = path.join(LLAMACPP_RUNTIME_DIR, "server.pid");
@@ -43,6 +43,44 @@ export interface LlamaCppProvisioningStatus {
   binaryAvailable: boolean;
   modelAvailable: boolean;
   installed: boolean;
+}
+
+/**
+ * The alias recorded in ClawBox's own config store when the customer enabled
+ * the local model, or null when they didn't.
+ *
+ * This is the edition-independent record. The OpenClaw config below can only
+ * answer the question on editions that ship OpenClaw; on the others it is
+ * silent, which is what used to make the local model unstartable.
+ */
+export function getLocalAiConfigStoreAlias(state: Record<string, unknown>): string | null {
+  if (state["local_ai_configured"] !== true) return null;
+  if (state["local_ai_provider"] !== "llamacpp") return null;
+  const stored = state["local_ai_model"];
+  // Stored fully-qualified ("llamacpp/gemma4-e2b-it-q4_0"); callers want the
+  // bare alias. An empty or malformed value falls back to the default rather
+  // than launching with a blank --alias.
+  const bare = typeof stored === "string" ? stored.replace(/^llamacpp\//, "").trim() : "";
+  return bare || getDefaultLlamaCppModel();
+}
+
+/**
+ * Which llama.cpp model this device is configured to run, across every
+ * edition — OpenClaw's agent config first (unchanged, so the OpenClaw/dual
+ * SKUs keep their existing behaviour), then ClawBox's own config store.
+ *
+ * Both the on-demand wake path and the launcher resolve through here, so they
+ * cannot disagree about which model to start. They previously did: the wake
+ * path fell back to the *default* alias on editions where the OpenClaw config
+ * is silent, so a device configured with a non-default local model woke the
+ * wrong one.
+ */
+export async function resolveConfiguredLlamaCppAlias(): Promise<string | null> {
+  const [config, state] = await Promise.all([
+    readConfig().catch(() => ({} as OpenClawConfig)),
+    getAll().catch(() => ({} as Record<string, unknown>)),
+  ]);
+  return getConfiguredLlamaCppModelAlias(config) ?? getLocalAiConfigStoreAlias(state);
 }
 
 export function getConfiguredLlamaCppModelAlias(config: OpenClawConfig): string | null {

--- a/src/lib/local-ai-runtime.ts
+++ b/src/lib/local-ai-runtime.ts
@@ -3,11 +3,11 @@ import { promisify } from "util";
 import { startLlamaCppServer, stopLlamaCppServer } from "@/instrumentation-node";
 import { getDefaultLlamaCppModel, getLlamaCppBaseUrl, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import {
-  getConfiguredLlamaCppModelAlias,
   getLlamaCppLaunchSpec,
+  getLlamaCppProvisioningStatus,
   queryLlamaCppModels,
+  resolveConfiguredLlamaCppAlias,
 } from "@/lib/llamacpp-server";
-import { readConfig } from "@/lib/openclaw-config";
 
 const execFile = promisify(execFileCb);
 const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434";
@@ -15,6 +15,14 @@ const DEFAULT_LOCAL_AI_PROXY_ROOT_URL = "http://127.0.0.1";
 const DEFAULT_LOCAL_AI_IDLE_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_OLLAMA_STARTUP_TIMEOUT_MS = 60_000;
 const POLL_INTERVAL_MS = 1_000;
+// Waking a model that is already on disk is a different operation from
+// provisioning one that isn't. `spec.startupTimeoutMs` (20 min) is a *download*
+// budget — sized for pulling a multi-GB GGUF over a slow link. Applying it to a
+// wake meant a runtime that failed to start held the request open for 20
+// minutes instead of erroring. Cold load of Gemma 4 E2B Q4_0 measured ~18 s on
+// Jetson Orin, so 180 s is ~10x headroom and still fails inside any sane
+// client timeout.
+const DEFAULT_LLAMACPP_WAKE_TIMEOUT_MS = 180_000;
 
 export type LocalAiProvider = "llamacpp" | "ollama";
 
@@ -74,8 +82,11 @@ export function getLocalAiIdleTimeoutMs(): number {
 }
 
 async function getConfiguredLlamaCppAlias(): Promise<string> {
-  const config = await readConfig();
-  return getConfiguredLlamaCppModelAlias(config) || getDefaultLlamaCppModel();
+  // Resolves across every edition — see resolveConfiguredLlamaCppAlias. Reading
+  // the OpenClaw config alone meant that on editions where it is silent this
+  // always fell through to the default alias, so a device configured with a
+  // non-default local model woke the wrong one.
+  return (await resolveConfiguredLlamaCppAlias()) || getDefaultLlamaCppModel();
 }
 
 async function isOllamaReachable(): Promise<boolean> {
@@ -90,19 +101,39 @@ async function isOllamaReachable(): Promise<boolean> {
   }
 }
 
+export function getLlamaCppWakeTimeoutMs(): number {
+  const raw = Number(process.env.LLAMACPP_WAKE_TIMEOUT_MS || DEFAULT_LLAMACPP_WAKE_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_LLAMACPP_WAKE_TIMEOUT_MS;
+}
+
 async function waitForLlamaCppReady(alias: string): Promise<void> {
   const spec = getLlamaCppLaunchSpec(alias);
-  const deadline = Date.now() + spec.startupTimeoutMs;
+  // Resolved lazily, only once the first poll misses. `ensureLocalAiReady` runs
+  // on every proxied inference request, and when the runtime is already warm
+  // the first poll returns immediately — so deciding the budget up front spent
+  // two filesystem stats per request to compute a number nothing would read.
+  let budgetMs: number | null = null;
+  let deadline = Infinity;
 
   while (Date.now() < deadline) {
     const models = await queryLlamaCppModels(spec.baseUrl);
     if (models.includes(alias) || models.length > 0) {
       return;
     }
+    if (budgetMs === null) {
+      // Model already on disk → this is a wake, not a download. Only when the
+      // GGUF is missing does start-llamacpp.sh fetch it, and only then is the
+      // long provisioning budget the right one.
+      const provisioning = await getLlamaCppProvisioningStatus(alias).catch(() => null);
+      budgetMs = provisioning?.modelAvailable ? getLlamaCppWakeTimeoutMs() : spec.startupTimeoutMs;
+      deadline = Date.now() + budgetMs;
+    }
     await sleep(POLL_INTERVAL_MS);
   }
 
-  throw new Error(`Timed out waiting for llama.cpp (${alias}) to become ready`);
+  throw new Error(
+    `Timed out after ${Math.round((budgetMs ?? 0) / 1000)}s waiting for llama.cpp (${alias}) to become ready`,
+  );
 }
 
 async function waitForOllamaReady(): Promise<void> {
@@ -190,7 +221,18 @@ export async function ensureLocalAiReady(provider: LocalAiProvider): Promise<voi
   const startPromise = (async () => {
     if (provider === "llamacpp") {
       const alias = await getConfiguredLlamaCppAlias();
-      await startLlamaCppServer();
+      // Pass the alias explicitly: reaching this function means a caller asked
+      // for the local runtime, so the launcher must not re-derive whether it is
+      // "configured" from a config file that belongs to another harness.
+      const status = await startLlamaCppServer(alias);
+      if (status === "skipped-disabled") {
+        throw new Error("Local AI is turned off on this device. Enable Gemma 4 in Settings to use it.");
+      }
+      if (status === "skipped-not-configured") {
+        // Defensive: with an explicit alias the launcher should never report
+        // this. Failing here beats polling for a server nobody started.
+        throw new Error(`llama.cpp did not start for ${alias} (no local model configured)`);
+      }
       await waitForLlamaCppReady(alias);
       return;
     }
@@ -203,6 +245,8 @@ export async function ensureLocalAiReady(provider: LocalAiProvider): Promise<voi
   try {
     await startPromise;
   } finally {
+    // Clear on BOTH paths. A failed attempt that stayed parked here made every
+    // later request join a doomed wait, so the failure outlived its cause.
     if (state.startPromise === startPromise) {
       state.startPromise = null;
     }

--- a/src/tests/components/llamacpp-model-panel-activate.test.tsx
+++ b/src/tests/components/llamacpp-model-panel-activate.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@/tests/helpers/test-utils";
+import LlamaCppModelPanel from "@/components/LlamaCppModelPanel";
+
+/**
+ * Fix C, UI half. When Gemma is installed but is NOT the harness's selection
+ * the panel offers "Switch to Gemma 4" — and that button has to actually
+ * switch. It previously re-ran the plain enable flow, which by policy leaves
+ * the customer's chosen provider in place, so the button did nothing visible.
+ */
+
+const baseProps = {
+  llamaCppRunning: false,
+  llamaCppInstalled: true,
+  llamaCppSaving: false as const,
+  llamaCppProgress: null,
+  selectedLlamaCppModel: "gemma4-e2b-it-q4_0",
+  setSelectedLlamaCppModel: vi.fn(),
+};
+
+describe("LlamaCppModelPanel activation intent", () => {
+  it("asks the server to ACTIVATE when the model is installed but not selected", () => {
+    const save = vi.fn();
+    render(
+      <LlamaCppModelPanel {...baseProps} llamaCppIsActive={false} saveLlamaCppConfig={save} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /switch to gemma 4/i }));
+    expect(save).toHaveBeenCalledWith("gemma4-e2b-it-q4_0", { activate: true });
+  });
+
+  it("does NOT force activation on a plain first-time enable", () => {
+    const save = vi.fn();
+    render(
+      <LlamaCppModelPanel
+        {...baseProps}
+        llamaCppInstalled={false}
+        llamaCppIsActive={false}
+        saveLlamaCppConfig={save}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /enable gemma 4/i }));
+    expect(save).toHaveBeenCalledWith("gemma4-e2b-it-q4_0", { activate: false });
+  });
+
+  it("tells the truth when installed but not selected", () => {
+    render(
+      <LlamaCppModelPanel {...baseProps} llamaCppIsActive={false} saveLlamaCppConfig={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/switch to it to make it the active local ai/i)).toBeTruthy();
+    // The green "already configured" pill must not appear — that is the
+    // reassurance that made the device look like it was using Gemma.
+    expect(screen.queryByText(/already configured/i)).toBeNull();
+  });
+
+  it("shows the configured pill only when it really is the active model", () => {
+    render(
+      <LlamaCppModelPanel {...baseProps} llamaCppIsActive saveLlamaCppConfig={vi.fn()} />,
+    );
+
+    expect(screen.getByText(/already configured/i)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /switch to gemma 4/i })).toBeNull();
+  });
+});

--- a/src/tests/routes/ai-models/configure-hermes.test.ts
+++ b/src/tests/routes/ai-models/configure-hermes.test.ts
@@ -168,6 +168,34 @@ describe("POST /setup-api/ai-models/configure — hermes edition", () => {
     expectNoOpenclawSpawn();
   });
 
+  // A device that already has a cloud provider must NOT be hijacked by merely
+  // enabling a local fallback — but it must still be switchable on request.
+  // Conflating the two is what left the box "configured for Gemma" while every
+  // message went to ClawBox AI, with no working way to change it.
+  it("leaves the chosen provider in place when a configured device just enables Gemma", async () => {
+    const cs = await import("@/lib/config-store");
+    vi.mocked(cs.getAll).mockResolvedValue({ ai_model_configured: true });
+
+    const res = await POST(jsonRequest({ provider: "llamacpp", scope: "local" }));
+
+    expect(res.status).toBe(200);
+    expect(mockApplyLocalAiToHermes).toHaveBeenCalledWith(
+      expect.objectContaining({ makeDefault: false }),
+    );
+  });
+
+  it("promotes Gemma to the active model when the user explicitly asked to switch", async () => {
+    const cs = await import("@/lib/config-store");
+    vi.mocked(cs.getAll).mockResolvedValue({ ai_model_configured: true });
+
+    const res = await POST(jsonRequest({ provider: "llamacpp", scope: "local", activate: true }));
+
+    expect(res.status).toBe(200);
+    expect(mockApplyLocalAiToHermes).toHaveBeenCalledWith(
+      expect.objectContaining({ makeDefault: true }),
+    );
+  });
+
   it("configures an API-key cloud provider (Anthropic) through Hermes, not openclaw", async () => {
     const res = await POST(jsonRequest({ provider: "anthropic", apiKey: "sk-ant-test", authMode: "token" }));
     const body = await res.json();

--- a/src/tests/unit/llamacpp-configured-alias.test.ts
+++ b/src/tests/unit/llamacpp-configured-alias.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getLocalAiConfigStoreAlias } from "@/lib/llamacpp-server";
+
+/**
+ * The edition-independent half of "which local model is this device set to
+ * run". Reading only the OpenClaw agent config left this unanswerable on
+ * editions that ship without OpenClaw, which is what made the on-device model
+ * unstartable there.
+ */
+describe("getLocalAiConfigStoreAlias", () => {
+  const DEFAULT = "gemma4-e2b-it-q4_0";
+
+  it.each([
+    ["strips the qualified prefix", { local_ai_configured: true, local_ai_provider: "llamacpp", local_ai_model: "llamacpp/gemma4-e2b-it-q4_0" }, DEFAULT],
+    ["keeps a non-default alias", { local_ai_configured: true, local_ai_provider: "llamacpp", local_ai_model: "llamacpp/my-custom-gguf" }, "my-custom-gguf"],
+    ["accepts an already-bare alias", { local_ai_configured: true, local_ai_provider: "llamacpp", local_ai_model: "my-custom-gguf" }, "my-custom-gguf"],
+    ["falls back to the default on a malformed id", { local_ai_configured: true, local_ai_provider: "llamacpp", local_ai_model: "llamacpp/" }, DEFAULT],
+    ["falls back to the default when no id is stored", { local_ai_configured: true, local_ai_provider: "llamacpp" }, DEFAULT],
+    ["returns null when local AI was never configured", {}, null],
+    ["returns null when local AI is explicitly off", { local_ai_configured: false, local_ai_provider: "llamacpp", local_ai_model: "llamacpp/x" }, null],
+    ["returns null when the local provider is ollama", { local_ai_configured: true, local_ai_provider: "ollama", local_ai_model: "ollama/llama3.2:3b" }, null],
+  ])("%s", (_label, state, expected) => {
+    expect(getLocalAiConfigStoreAlias(state as Record<string, unknown>)).toBe(expected);
+  });
+});

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The defect these cover: on the Hermes SKU the on-demand start gate was
+ * derived from `~/.openclaw/openclaw.json`, which on that edition can never
+ * carry `agents.defaults.model.primary` — the configure route returns early via
+ * `openclawIsAbsent()` long before writing it. So `bootLlamaCppServer` always
+ * logged "no llama.cpp primary or local fallback configured" and returned
+ * without starting, while the caller went on to poll for 20 minutes for a
+ * server nobody had launched.
+ *
+ * Every pre-existing test ran with an OpenClaw config present, which is exactly
+ * why this was invisible.
+ */
+
+const spawnMock = vi.fn();
+vi.mock("child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+const readConfigMock = vi.fn();
+vi.mock("@/lib/openclaw-config", () => ({
+  readConfig: (...args: unknown[]) => readConfigMock(...args),
+}));
+
+const getAllMock = vi.fn();
+vi.mock("@/lib/config-store", () => ({
+  getAll: (...args: unknown[]) => getAllMock(...args),
+  DATA_DIR: "/tmp/clawbox-test-data",
+}));
+
+const llamaCppMocks = {
+  getConfiguredLlamaCppModelAlias: vi.fn(),
+  getLocalAiConfigStoreAlias: vi.fn(),
+  getLlamaCppLaunchSpec: vi.fn(),
+  queryLlamaCppModels: vi.fn(),
+  readLlamaCppPid: vi.fn(),
+  isLlamaCppPidRunning: vi.fn(),
+  clearLlamaCppPid: vi.fn(),
+  ensureLlamaCppRuntimeDir: vi.fn(),
+  writeLlamaCppPid: vi.fn(),
+};
+vi.mock("@/lib/llamacpp-server", () => llamaCppMocks);
+
+vi.mock("@/lib/llamacpp", () => ({
+  getDefaultLlamaCppModel: vi.fn(() => "gemma4-e2b-it-q4_0"),
+}));
+
+const LAUNCH_SPEC = {
+  alias: "gemma4-e2b-it-q4_0",
+  baseUrl: "http://127.0.0.1:8080/v1",
+  host: "127.0.0.1",
+  port: 8080,
+  hfRepo: "google/gemma-4-E2B-it-qat-q4_0-gguf",
+  hfFile: "gemma-4-E2B_q4_0-it.gguf",
+  binPath: "/usr/local/bin/llama-server",
+  hfBinPath: "/home/clawbox/.local/bin/hf",
+  scriptPath: "/home/clawbox/clawbox/scripts/start-llamacpp.sh",
+  pidPath: "/home/clawbox/clawbox/data/llamacpp/server.pid",
+  logPath: "/home/clawbox/clawbox/data/llamacpp/server.log",
+  modelDir: "/home/clawbox/clawbox/data/llamacpp/models",
+  modelPath: "/home/clawbox/clawbox/data/llamacpp/models/gemma-4-E2B_q4_0-it.gguf",
+  contextWindow: 131072,
+  startupTimeoutMs: 1_200_000,
+};
+
+/** A child that looks alive enough for bootLlamaCppServer to accept it. */
+function fakeChild(pid = 4242) {
+  return { pid, on: vi.fn(), kill: vi.fn() };
+}
+
+async function loadModule() {
+  vi.resetModules();
+  return await import("@/instrumentation-node");
+}
+
+describe("llama.cpp auto-start gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawnMock.mockReturnValue(fakeChild());
+    llamaCppMocks.getLlamaCppLaunchSpec.mockReturnValue(LAUNCH_SPEC);
+    llamaCppMocks.queryLlamaCppModels.mockResolvedValue([]);
+    llamaCppMocks.readLlamaCppPid.mockResolvedValue(null);
+    llamaCppMocks.isLlamaCppPidRunning.mockReturnValue(false);
+    llamaCppMocks.clearLlamaCppPid.mockResolvedValue(undefined);
+    llamaCppMocks.ensureLlamaCppRuntimeDir.mockResolvedValue(undefined);
+    llamaCppMocks.writeLlamaCppPid.mockResolvedValue(undefined);
+    llamaCppMocks.getConfiguredLlamaCppModelAlias.mockReturnValue(null);
+    // Mirrors the real helper: config-store record → bare alias, else null.
+    llamaCppMocks.getLocalAiConfigStoreAlias.mockImplementation((state: Record<string, unknown>) => {
+      if (state?.local_ai_configured !== true) return null;
+      if (state?.local_ai_provider !== "llamacpp") return null;
+      const stored = state?.local_ai_model;
+      const bare = typeof stored === "string" ? stored.replace(/^llamacpp\//, "").trim() : "";
+      return bare || "gemma4-e2b-it-q4_0";
+    });
+  });
+
+  it("starts the server for an explicit alias on a Hermes device with an empty OpenClaw config", async () => {
+    // Exactly the shipped state: openclaw.json holds only gateway.controlUi.
+    readConfigMock.mockResolvedValue({ gateway: { controlUi: { allowedOrigins: [] } } });
+    getAllMock.mockResolvedValue({
+      local_ai_configured: true,
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+    });
+
+    const { startLlamaCppServer } = await loadModule();
+    const status = await startLlamaCppServer("gemma4-e2b-it-q4_0");
+
+    expect(status).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    // The alias reaches the launcher script as argv[4].
+    const [, argv] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(argv[4]).toBe("gemma4-e2b-it-q4_0");
+  });
+
+  it("auto-starts from the config store when OpenClaw has no primary (boot path, no alias)", async () => {
+    readConfigMock.mockResolvedValue({});
+    getAllMock.mockResolvedValue({
+      local_ai_configured: true,
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+    });
+
+    const { startLlamaCppServer } = await loadModule();
+    expect(await startLlamaCppServer()).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still honours the OpenClaw primary as a trigger (openclaw/dual SKUs unchanged)", async () => {
+    readConfigMock.mockResolvedValue({
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+    getAllMock.mockResolvedValue({});
+    llamaCppMocks.getConfiguredLlamaCppModelAlias.mockReturnValue("gemma4-e2b-it-q4_0");
+
+    const { startLlamaCppServer } = await loadModule();
+    expect(await startLlamaCppServer()).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports skipped-not-configured instead of silently doing nothing", async () => {
+    readConfigMock.mockResolvedValue({});
+    getAllMock.mockResolvedValue({});
+
+    const { startLlamaCppServer } = await loadModule();
+    expect(await startLlamaCppServer()).toBe("skipped-not-configured");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("still refuses to start when Local AI is explicitly disabled", async () => {
+    readConfigMock.mockResolvedValue({});
+    getAllMock.mockResolvedValue({
+      local_ai_configured: false,
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+    });
+
+    const { startLlamaCppServer } = await loadModule();
+    expect(await startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("skipped-disabled");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("does not spawn a second server when one is already running", async () => {
+    readConfigMock.mockResolvedValue({});
+    getAllMock.mockResolvedValue({ local_ai_configured: true, local_ai_provider: "llamacpp" });
+    llamaCppMocks.queryLlamaCppModels.mockResolvedValue(["gemma4-e2b-it-q4_0"]);
+
+    const { startLlamaCppServer } = await loadModule();
+    expect(await startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/local-ai-runtime-failfast.test.ts
+++ b/src/tests/unit/local-ai-runtime-failfast.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Fix B. A start that never happened used to be indistinguishable from one
+ * that did, so `ensureLocalAiReady` went straight into a 20-minute poll for a
+ * server nobody launched — a 10-minute chat spinner rather than an error. And
+ * because the doomed attempt stayed memoized in `startPromise`, every later
+ * request joined the same dead wait: the failure outlived its cause.
+ */
+
+const startLlamaCppServerMock = vi.fn();
+const stopLlamaCppServerMock = vi.fn();
+vi.mock("@/instrumentation-node", () => ({
+  startLlamaCppServer: (...a: unknown[]) => startLlamaCppServerMock(...a),
+  stopLlamaCppServer: (...a: unknown[]) => stopLlamaCppServerMock(...a),
+}));
+
+vi.mock("@/lib/llamacpp", () => ({
+  getDefaultLlamaCppModel: () => "gemma4-e2b-it-q4_0",
+  getLlamaCppBaseUrl: () => "http://127.0.0.1:8080/v1",
+  getLlamaCppProxyBaseUrl: () => "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+}));
+
+const queryLlamaCppModelsMock = vi.fn();
+const getLlamaCppProvisioningStatusMock = vi.fn();
+vi.mock("@/lib/llamacpp-server", () => ({
+  getLlamaCppLaunchSpec: () => ({
+    baseUrl: "http://127.0.0.1:8080/v1",
+    startupTimeoutMs: 1_200_000,
+  }),
+  getLlamaCppProvisioningStatus: (...a: unknown[]) => getLlamaCppProvisioningStatusMock(...a),
+  queryLlamaCppModels: (...a: unknown[]) => queryLlamaCppModelsMock(...a),
+  resolveConfiguredLlamaCppAlias: async () => "gemma4-e2b-it-q4_0",
+}));
+
+async function loadRuntime() {
+  vi.resetModules();
+  return await import("@/lib/local-ai-runtime");
+}
+
+describe("ensureLocalAiReady fails fast when llama.cpp was not started", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLlamaCppProvisioningStatusMock.mockResolvedValue({ modelAvailable: true });
+    queryLlamaCppModelsMock.mockResolvedValue([]);
+  });
+
+  it("throws immediately instead of polling when the launcher skipped (not configured)", async () => {
+    startLlamaCppServerMock.mockResolvedValue("skipped-not-configured");
+    const { ensureLocalAiReady } = await loadRuntime();
+
+    await expect(ensureLocalAiReady("llamacpp")).rejects.toThrow(/did not start/i);
+    // The decisive assertion: we never entered the readiness poll.
+    expect(queryLlamaCppModelsMock).not.toHaveBeenCalled();
+  });
+
+  it("throws an explainable error when Local AI is turned off", async () => {
+    startLlamaCppServerMock.mockResolvedValue("skipped-disabled");
+    const { ensureLocalAiReady } = await loadRuntime();
+
+    await expect(ensureLocalAiReady("llamacpp")).rejects.toThrow(/turned off/i);
+    expect(queryLlamaCppModelsMock).not.toHaveBeenCalled();
+  });
+
+  it("passes the resolved alias to the launcher rather than letting it re-derive one", async () => {
+    startLlamaCppServerMock.mockResolvedValue("started");
+    queryLlamaCppModelsMock.mockResolvedValue(["gemma4-e2b-it-q4_0"]);
+    const { ensureLocalAiReady } = await loadRuntime();
+
+    await ensureLocalAiReady("llamacpp");
+    expect(startLlamaCppServerMock).toHaveBeenCalledWith("gemma4-e2b-it-q4_0");
+  });
+
+  it("does not leave a failed attempt memoized for later callers", async () => {
+    startLlamaCppServerMock.mockResolvedValue("skipped-not-configured");
+    const { ensureLocalAiReady } = await loadRuntime();
+
+    await expect(ensureLocalAiReady("llamacpp")).rejects.toThrow();
+
+    // A later request must run a fresh attempt, not join the dead one.
+    startLlamaCppServerMock.mockResolvedValue("started");
+    queryLlamaCppModelsMock.mockResolvedValue(["gemma4-e2b-it-q4_0"]);
+    await expect(ensureLocalAiReady("llamacpp")).resolves.toBeUndefined();
+    expect(startLlamaCppServerMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("wake vs download readiness budget", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    startLlamaCppServerMock.mockResolvedValue("started");
+    queryLlamaCppModelsMock.mockResolvedValue([]);
+  });
+
+  it("uses the short wake budget when the model file is already on disk", async () => {
+    getLlamaCppProvisioningStatusMock.mockResolvedValue({ modelAvailable: true });
+    process.env.LLAMACPP_WAKE_TIMEOUT_MS = "20";
+    const { ensureLocalAiReady } = await loadRuntime();
+
+    const startedAt = Date.now();
+    await expect(ensureLocalAiReady("llamacpp")).rejects.toThrow(/Timed out after/i);
+    // Nowhere near the 20-minute provisioning budget.
+    expect(Date.now() - startedAt).toBeLessThan(10_000);
+    delete process.env.LLAMACPP_WAKE_TIMEOUT_MS;
+  });
+
+  it("exposes a sane default wake budget, far below the download budget", async () => {
+    delete process.env.LLAMACPP_WAKE_TIMEOUT_MS;
+    const { getLlamaCppWakeTimeoutMs } = await loadRuntime();
+    const wake = getLlamaCppWakeTimeoutMs();
+    expect(wake).toBe(180_000);
+    expect(wake).toBeLessThan(1_200_000);
+  });
+});


### PR DESCRIPTION
## What was wrong

On a device whose agent configuration does not live in OpenClaw, the on-device model could not be started at all, and Settings claimed it was in use when it was not.

**1. The start gate could never open.** `bootLlamaCppServer()` decided whether to launch by reading `agents.defaults.model.primary` out of the OpenClaw config. On editions that ship without OpenClaw that key is never written — the configure route returns early long before it — so the gate was permanently closed. Nothing spawned, and the journal recorded the same line every time:

```
[instrumentation] llama.cpp auto-start skipped (no llama.cpp primary or local fallback configured)
```

**2. The caller then waited 20 minutes for it.** `ensureLocalAiReady()` could not tell a start that never happened from one that did, so it went straight into a readiness poll bounded by the *download* budget. A chat with the on-device model selected hung for ten minutes and then failed. Because the doomed attempt stayed memoized in `startPromise`, every later request joined the same dead wait — the failure outlived its cause.

**3. Settings said it was in use when it was only installed.** The Local AI card was built entirely from the `local_ai_configured` / `local_ai_model` config-store keys, which only ever prove "installed and available". Enabling a local model deliberately does *not* take over from the provider the customer picked, so the card read `Gemma 4 Local · sleeping until needed` while every message went to a cloud provider.

## What changed

- The requested alias is passed into the launcher. A request that arrived through the local-AI proxy is itself the authorization to start, so it is no longer re-litigated against a config file belonging to a harness that isn't installed.
- The no-alias path additionally accepts the edition-independent config-store record of "local AI is on". The OpenClaw check stays first and unchanged, so other editions keep exactly their previous behaviour.
- A start attempt now reports what it did (`spawned` / `already-running` / `already-starting` / `skipped-*`), and a no-op fails immediately with an explainable message instead of polling.
- The readiness wait is sized for a wake (~18 s measured) when the model is already on disk, rather than reusing the multi-GB download budget. Override with `LLAMACPP_WAKE_TIMEOUT_MS`.
- The shared start slot is released as soon as an attempt settles, so one failure stops poisoning later requests.
- The card now asks the *active harness* what provider it is really set to, via the `/setup-api/ai-models/status` endpoint that already resolves this for both harnesses — so there is no second implementation and the runtime-health routes are untouched. It says `available, not currently selected` and names what is answering instead. The four card states are resolved once, as data, so the status line and the card copy cannot drift.
- Alias resolution moved into `llamacpp-server` and is now shared by the launcher and the wake path. They previously disagreed: the wake path read only the OpenClaw config, so on editions where that is silent it fell through to the *default* alias and a device configured with a non-default local model woke the wrong one.
- The card's switch button carries an explicit activation intent, so it actually switches rather than silently re-running the enable flow. The promote-on-first-setup policy is unchanged: a plain enable still leaves the customer's chosen provider in place.

## Verification

Run on a Jetson Orin Nano, on the edition that reproduced the fault.

Unit suite on hardware: **188 files / 2226 tests, 0 failures** (baseline 184 / 2200). `tsc --noEmit` adds no new errors — the same 2 pre-existing ones before and after — and `lint` is byte-identical to the base branch (93 problems, all pre-existing).

Cold wake through the real chat path, with no `llama-server` process running:

| | before | after |
|---|---|---|
| first message | no process, no reply, 10-min hang | **HTTP 200 in 66 s**, real reply |
| follow-up message | — | **6.5 s** |
| GPU during inference | idle | **GR3D_FREQ 99 %** |
| journal | `auto-start skipped (…)` | `auto-starting gemma4-e2b-it-q4_0 (pid=…)` |

Fail-fast, verified by making the runtime unable to come up: the proxy returned `502 {"error":"Timed out after 180s waiting for llama.cpp (…) to become ready"}` instead of holding the request for 20 minutes.

Activation truth, from the endpoint that drives the card:

```
"provider":"clawai",    "providerLabel":"ClawBox AI"        # installed, harness pointed elsewhere
"provider":"clawlocal", "providerLabel":"Gemma 4 (on-device)"  # after selecting it
```

Memory stayed within budget throughout — peak 4392 MB of 7607 MB with the model resident.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer Local AI states, model labels, and descriptions in Settings.
  * Installed local models can now be activated explicitly without replacing the current primary model unintentionally.
  * Switching between local models now updates the active provider when requested.
  * Improved local model startup, wake-timeout handling, and retry behavior.

* **Bug Fixes**
  * Replaced raw provider identifiers with user-friendly names.
  * Improved messaging for disabled, unavailable, standby, and running Local AI states.

* **Tests**
  * Added coverage for model activation, startup behavior, configuration handling, and timeout recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->