### PR TITLE
fix: make the in-app updater edition-aware

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1702,14 +1702,20 @@ step_post_update() {
   # clawbox-gateway as the active single source of truth.
   step_gateway_setup || echo "  Warning: gateway_setup step failed (non-fatal)"
   step_gateway_legacy_state_recovery || echo "  Warning: gateway_legacy_state_recovery step failed (non-fatal)"
-  # Re-provision the Hermes side (dashboard auth, units, shared identity) on the
-  # editions that run it. Without this an update could deliver a new proxy /
-  # dashboard unit but never restart or re-configure them, and a Hermes box
-  # whose auth provider had drifted stayed broken until a full reinstall.
-  # Runs after step_systemd_services so the unit files on disk are current.
-  if has_hermes_harness; then
-    step_hermes_edition || echo "  Warning: hermes_edition step failed (non-fatal)"
-  fi
+  # NOTE: Hermes re-provisioning is deliberately NOT called from here any more.
+  #
+  # It used to run as `step_hermes_edition || echo "Warning: … (non-fatal)"`,
+  # which meant a device that failed to provision the entire edition — no
+  # dashboard auth provider, no proxy, no MCP registration — still finished the
+  # update green, with the failure buried in a journal nobody reads.
+  #
+  # The in-app updater now dispatches `hermes_edition` as its own step, right
+  # after this one, so the work is visible while it happens and a failure is
+  # reported as a failure. Ordering is unchanged: it still lands after
+  # step_systemd_services has refreshed the unit files it reads.
+  #
+  # Fresh installs are unaffected — they call step_hermes_edition directly near
+  # the end of the full-install path, not through here.
   # Deliberately NO `systemctl restart clawbox-setup` here. The web server reads
   # the edition straight off /etc/clawbox/edition.env on demand
   # (src/lib/edition-source.ts stats the file per call and caches by mtime), so

--- a/install.sh
+++ b/install.sh
@@ -2276,6 +2276,17 @@ step_recover() {
 }
 
 step_gateway_setup() {
+  # DO NOT DELETE THIS GUARD AS "REDUNDANT" NOW THAT THE UPDATER FILTERS STEPS.
+  #
+  # The updater's `applies()` predicate drops the gateway_setup STEP on hermes,
+  # which looks like it makes this line dead. It does not: step_post_update has
+  # no such predicate — it runs on every SKU — and calls step_gateway_setup
+  # internally. This guard is the only thing standing between a Hermes box and
+  # an OpenClaw gateway being reinstalled and enabled halfway through its own
+  # update, on a SKU whose whole point is that the gateway is not there.
+  #
+  # The same applies to the guards in step_openclaw_install / step_openclaw_patch
+  # and to `install.sh --step <name>`, which can be run by hand on any edition.
   is_hermes_edition && { echo "  [hermes edition] skipping OpenClaw gateway setup"; return 0; }
   cp "$PROJECT_DIR/config/clawbox-gateway.service" /etc/systemd/system/
 

--- a/install.sh
+++ b/install.sh
@@ -1702,20 +1702,11 @@ step_post_update() {
   # clawbox-gateway as the active single source of truth.
   step_gateway_setup || echo "  Warning: gateway_setup step failed (non-fatal)"
   step_gateway_legacy_state_recovery || echo "  Warning: gateway_legacy_state_recovery step failed (non-fatal)"
-  # NOTE: Hermes re-provisioning is deliberately NOT called from here any more.
-  #
-  # It used to run as `step_hermes_edition || echo "Warning: … (non-fatal)"`,
-  # which meant a device that failed to provision the entire edition — no
-  # dashboard auth provider, no proxy, no MCP registration — still finished the
-  # update green, with the failure buried in a journal nobody reads.
-  #
-  # The in-app updater now dispatches `hermes_edition` as its own step, right
-  # after this one, so the work is visible while it happens and a failure is
-  # reported as a failure. Ordering is unchanged: it still lands after
-  # step_systemd_services has refreshed the unit files it reads.
-  #
-  # Fresh installs are unaffected — they call step_hermes_edition directly near
-  # the end of the full-install path, not through here.
+  # Hermes re-provisioning is deliberately NOT called here. The in-app updater
+  # dispatches `hermes_edition` as its own step immediately after this one, so a
+  # failure is reported instead of swallowed by `|| echo "(non-fatal)"`.
+  # Ordering is unchanged (still after step_systemd_services). Fresh installs
+  # call step_hermes_edition directly and are unaffected.
   # Deliberately NO `systemctl restart clawbox-setup` here. The web server reads
   # the edition straight off /etc/clawbox/edition.env on demand
   # (src/lib/edition-source.ts stats the file per call and caches by mtime), so

--- a/scripts/setup-hermes-edition.sh
+++ b/scripts/setup-hermes-edition.sh
@@ -63,9 +63,19 @@ fi
 
 # ── 2. Shared-identity bridge ───────────────────────────────────────────────
 # (canonical ~/.clawbox/agent-identity → both harnesses)
+# HOME is passed EXPLICITLY to every runuser call below, and must stay that way.
+# All three scripts resolve their state from `$HOME` (`${HOME:-/home/clawbox}`),
+# so the user they run as is not enough — the variable has to be right too.
+# `runuser` does reset HOME for the target user today, but that is a property of
+# util-linux we would be silently depending on: this script runs as root from
+# install.sh (HOME=/root), and if HOME ever survived, setup-hermes-dashboard-auth
+# would look for /root/.hermes/config.yaml, find no credentials to verify, and
+# mint a fresh password — desyncing it from the one the proxy already holds.
+# Passing HOME makes that impossible rather than merely unlikely.
 if [ -f "$PROJECT_DIR/scripts/setup-shared-identity.sh" ]; then
   log "seeding shared identity"
-  runuser -u "$CLAWBOX_USER" -- bash "$PROJECT_DIR/scripts/setup-shared-identity.sh" \
+  runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+    bash "$PROJECT_DIR/scripts/setup-shared-identity.sh" \
     || fail "shared-identity setup returned non-zero"
 fi
 
@@ -75,7 +85,7 @@ fi
 # proxy uses this password to sign the user in transparently.
 if [ -f "$PROJECT_DIR/scripts/setup-hermes-dashboard-auth.sh" ]; then
   log "configuring dashboard password auth"
-  runuser -u "$CLAWBOX_USER" -- env CLAWBOX_ROOT="$PROJECT_DIR" \
+  runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" CLAWBOX_ROOT="$PROJECT_DIR" \
     bash "$PROJECT_DIR/scripts/setup-hermes-dashboard-auth.sh" \
     || fail "dashboard auth setup returned non-zero — the dashboard will refuse to start without an auth provider"
 else
@@ -93,7 +103,8 @@ fi
 # Both paths are idempotent.
 if [ -f "$PROJECT_DIR/scripts/register-mcp.sh" ]; then
   log "registering the ClawBox MCP server with Hermes"
-  runuser -u "$CLAWBOX_USER" -- env CLAWBOX_ROOT="$PROJECT_DIR" CLAWBOX_EDITION="$EDITION" \
+  runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" CLAWBOX_ROOT="$PROJECT_DIR" \
+    CLAWBOX_EDITION="$EDITION" \
     bash "$PROJECT_DIR/scripts/register-mcp.sh" \
     || fail "MCP registration returned non-zero — the agent will have no device tools"
 else

--- a/src/lib/edition-source.ts
+++ b/src/lib/edition-source.ts
@@ -71,3 +71,20 @@ export function readEdition(): EditionName {
   }
   return normalizeEdition(process.env.CLAWBOX_EDITION) ?? "openclaw";
 }
+
+/**
+ * True when this device runs the Hermes harness — the `hermes` SKU (Hermes
+ * only) and the premium `dual` SKU (both harnesses).
+ *
+ * Mirrors install.sh's `has_hermes_harness()`, and must keep mirroring it: the
+ * updater uses this to decide whether to dispatch `install.sh --step
+ * hermes_edition`, so a device where the two disagree would either skip its own
+ * provisioning or run a step that immediately returns.
+ *
+ * Deliberately NOT the negation of `openclawIsAbsent()`: `dual` has both
+ * harnesses, so "runs Hermes" and "has no OpenClaw" are different questions.
+ */
+export function hasHermesHarness(): boolean {
+  const edition = readEdition();
+  return edition === "hermes" || edition === "dual";
+}

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -797,7 +797,7 @@ export async function setProviderPlugins(activeProvider: string): Promise<void> 
  * configured but gateway failed to restart. Try rebooting the device." on a
  * device where the configuration had in fact been written correctly.
  */
-function gatewayIsAbsent(): boolean {
+export function gatewayIsAbsent(): boolean {
   return readEdition() === "hermes";
 }
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -56,17 +56,11 @@ interface UpdateStepDef {
    * Whether this step applies to the device it is about to run on. Absent
    * means "always applies".
    *
-   * Editions differ in which harnesses they ship, so some steps have nothing
-   * to do on some SKUs. Expressing that as a predicate on the step — rather
-   * than an `if (edition === …)` inside each body — keeps the decision in one
-   * readable place and, crucially, lets the runner DROP the step from the list
-   * entirely. A dropped step never renders, so a Hermes owner is not shown
-   * OpenClaw work being "completed" on a box that has no OpenClaw.
-   *
-   * Each step names the helper matching its own reason for being skipped
-   * (binary absent vs gateway absent) rather than one blanket edition check:
-   * the two happen to coincide on today's SKUs, and a step that lies about why
-   * it was skipped is how they would silently diverge later.
+   * install.sh's step bodies already no-op per edition, but they cannot answer
+   * this question: by the time bash runs, the UI line exists and the step's
+   * timeout is already ticking. A predicate here lets the runner DROP the step
+   * from the list entirely, so a Hermes owner is never shown OpenClaw work
+   * being "completed" on a box that has no OpenClaw.
    */
   applies?: () => boolean;
 }
@@ -454,10 +448,8 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     label: "Updating OpenClaw",
     timeoutMs: OPENCLAW_INSTALL_TIMEOUT_MS,
     requiresRoot: true,
-    // No `openclaw` binary on this SKU to install. install.sh's counterpart
-    // already early-returns here, so the step reported "completed" — several
-    // minutes of budget and a line of UI spent announcing work that could not
-    // happen. Present on openclaw and dual.
+    // Keyed on the binary, not the edition: there is nothing to install where
+    // no `openclaw` ships. (Hermes today; the two predicates can diverge.)
     applies: () => !openclawIsAbsent(),
   },
   {
@@ -465,7 +457,6 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     label: "Patching OpenClaw gateway",
     timeoutMs: 30_000,
     requiresRoot: true,
-    // Nothing installed to patch. Same early-return as above.
     applies: () => !openclawIsAbsent(),
   },
   {
@@ -473,8 +464,8 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     label: "Configuring gateway service",
     timeoutMs: 30_000,
     requiresRoot: true,
-    // clawbox-gateway.service is deliberately removed and MASKED on this SKU
-    // (step_edition_gateway_state), so there is no unit to configure.
+    // Keyed on the unit, not the binary: clawbox-gateway.service is removed
+    // and masked by step_edition_gateway_state, so there is none to configure.
     applies: () => !gatewayIsAbsent(),
   },
   {
@@ -508,20 +499,16 @@ const UPDATE_STEPS: UpdateStepDef[] = [
   },
   {
     // Re-provision the Hermes side: dashboard + proxy units, dashboard auth,
-    // shared identity, MCP registration, gateway removal. Runs AFTER
-    // post_update so step_systemd_services has already refreshed the unit
-    // files this reads, and after the rebuild so it is the NEW install.sh.
+    // shared identity, MCP registration, gateway removal.
     //
-    // This work already happened — inside step_post_update, wrapped in
-    // `|| echo "Warning: … (non-fatal)"`. That made a total failure to
-    // provision the edition invisible: the update went green while the
-    // dashboard the customer actually uses could be unconfigured. It is the
-    // same work, hoisted to where it can be seen and can fail honestly.
+    // Ordering is load-bearing: AFTER post_update, so step_systemd_services has
+    // already refreshed the unit files this reinstalls and restarts, and after
+    // the rebuild, so it is the NEW install.sh being dispatched.
     id: "hermes_edition",
     label: "Provisioning Hermes edition",
     timeoutMs: 300_000,
     requiresRoot: true,
-    applies: hasHermesHarness,
+    applies: () => hasHermesHarness(),
   },
   {
     id: "gateway_verify",
@@ -538,20 +525,18 @@ const UPDATE_STEPS: UpdateStepDef[] = [
 ];
 
 /**
- * The steps that apply to THIS device, in order.
- *
  * Evaluated per run, never memoized: the edition is read from a root-owned
  * file that post_update itself can re-bake (step_edition_lock migrates a
  * pre-3.x box onto /etc/clawbox/edition.env), so a list frozen at module load
  * could describe the wrong SKU.
  *
- * The SAME array must feed both `state.steps` and the runner — `runUpdate`
- * addresses `state.steps[i]` by position, so two independently-filtered lists
- * would silently label every step after the first omission with its
- * neighbour's name.
+ * Callers must resolve this ONCE and feed the same array to both `state.steps`
+ * and the runner — `runUpdate` addresses `state.steps[i]` by position, so two
+ * independently-filtered lists would silently label every step after the first
+ * omission with its neighbour's name.
  */
-function applicableSteps(steps: UpdateStepDef[]): UpdateStepDef[] {
-  return steps.filter((step) => !step.applies || step.applies());
+function applicableSteps(): UpdateStepDef[] {
+  return UPDATE_STEPS.filter((step) => !step.applies || step.applies());
 }
 
 /**
@@ -798,7 +783,7 @@ function createStepStates(steps: UpdateStepDef[]): StepState[] {
   return steps.map((s) => ({ id: s.id, label: s.label, status: "pending" as const }));
 }
 
-function createInitialState(steps: UpdateStepDef[] = applicableSteps(UPDATE_STEPS)): UpdateState {
+function createInitialState(steps: UpdateStepDef[]): UpdateState {
   return {
     phase: "idle",
     steps: createStepStates(steps),
@@ -806,7 +791,7 @@ function createInitialState(steps: UpdateStepDef[] = applicableSteps(UPDATE_STEP
   };
 }
 
-let state: UpdateState = createInitialState();
+let state: UpdateState = createInitialState(applicableSteps());
 let running = false;
 
 export function getUpdateState(): UpdateState {
@@ -814,7 +799,7 @@ export function getUpdateState(): UpdateState {
 }
 
 export function resetUpdateState(): void {
-  state = createInitialState();
+  state = createInitialState(applicableSteps());
   running = false;
 }
 
@@ -857,7 +842,7 @@ export async function checkContinuation(): Promise<boolean> {
   // Resolve the list ONCE and reuse it for the state, the resume index and the
   // runner. The edition is stable across the reboot (post_update re-bakes the
   // same value), so this matches the list the pre-restart half ran.
-  const steps = applicableSteps(UPDATE_STEPS);
+  const steps = applicableSteps();
   const restartIndex = steps.findIndex((s) => s.id === RESTART_STEP_ID);
   const startFrom = restartIndex + 1;
 
@@ -906,7 +891,7 @@ export function startUpdate(): { started: boolean; error?: string } {
   }
 
   running = true;
-  const steps = applicableSteps(UPDATE_STEPS);
+  const steps = applicableSteps();
   state = createInitialState(steps);
   state.phase = "running";
   state.currentStepIndex = 0;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -3,7 +3,13 @@ import { promisify } from "util";
 import { readFile } from "fs/promises";
 import path from "path";
 import { get, set, setMany } from "./config-store";
-import { findOpenclawBin, restartGateway, openclawIsAbsent } from "./openclaw-config";
+import {
+  findOpenclawBin,
+  restartGateway,
+  openclawIsAbsent,
+  gatewayIsAbsent,
+} from "./openclaw-config";
+import { hasHermesHarness } from "./edition-source";
 import { isPortOpen } from "./port-probe";
 
 const PROJECT_DIR = "/home/clawbox/clawbox";
@@ -46,6 +52,23 @@ interface UpdateStepDef {
    * the unit finish in the background. Genuine unit failures still fail.
    */
   advisoryOnOverrun?: boolean;
+  /**
+   * Whether this step applies to the device it is about to run on. Absent
+   * means "always applies".
+   *
+   * Editions differ in which harnesses they ship, so some steps have nothing
+   * to do on some SKUs. Expressing that as a predicate on the step — rather
+   * than an `if (edition === …)` inside each body — keeps the decision in one
+   * readable place and, crucially, lets the runner DROP the step from the list
+   * entirely. A dropped step never renders, so a Hermes owner is not shown
+   * OpenClaw work being "completed" on a box that has no OpenClaw.
+   *
+   * Each step names the helper matching its own reason for being skipped
+   * (binary absent vs gateway absent) rather than one blanket edition check:
+   * the two happen to coincide on today's SKUs, and a step that lies about why
+   * it was skipped is how they would silently diverge later.
+   */
+  applies?: () => boolean;
 }
 
 /** Thrown by execAsRoot when OUR wait budget expired but the unit runs on. */
@@ -431,18 +454,28 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     label: "Updating OpenClaw",
     timeoutMs: OPENCLAW_INSTALL_TIMEOUT_MS,
     requiresRoot: true,
+    // No `openclaw` binary on this SKU to install. install.sh's counterpart
+    // already early-returns here, so the step reported "completed" — several
+    // minutes of budget and a line of UI spent announcing work that could not
+    // happen. Present on openclaw and dual.
+    applies: () => !openclawIsAbsent(),
   },
   {
     id: "openclaw_patch",
     label: "Patching OpenClaw gateway",
     timeoutMs: 30_000,
     requiresRoot: true,
+    // Nothing installed to patch. Same early-return as above.
+    applies: () => !openclawIsAbsent(),
   },
   {
     id: "gateway_setup",
     label: "Configuring gateway service",
     timeoutMs: 30_000,
     requiresRoot: true,
+    // clawbox-gateway.service is deliberately removed and MASKED on this SKU
+    // (step_edition_gateway_state), so there is no unit to configure.
+    applies: () => !gatewayIsAbsent(),
   },
   {
     id: RESTART_STEP_ID,
@@ -474,13 +507,52 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     advisoryOnOverrun: true,
   },
   {
+    // Re-provision the Hermes side: dashboard + proxy units, dashboard auth,
+    // shared identity, MCP registration, gateway removal. Runs AFTER
+    // post_update so step_systemd_services has already refreshed the unit
+    // files this reads, and after the rebuild so it is the NEW install.sh.
+    //
+    // This work already happened — inside step_post_update, wrapped in
+    // `|| echo "Warning: … (non-fatal)"`. That made a total failure to
+    // provision the edition invisible: the update went green while the
+    // dashboard the customer actually uses could be unconfigured. It is the
+    // same work, hoisted to where it can be seen and can fail honestly.
+    id: "hermes_edition",
+    label: "Provisioning Hermes edition",
+    timeoutMs: 300_000,
+    requiresRoot: true,
+    applies: hasHermesHarness,
+  },
+  {
     id: "gateway_verify",
     label: "Verifying gateway health",
     timeoutMs: 90_000,
     customRun: () => ensureGatewayHealthy(),
     failFast: true,
+    // The gateway is absent by design on this SKU — port 18789 is closed and
+    // the unit is masked — so this step could only ever throw. It also
+    // directly contradicted the step before it: post_update's smoke test
+    // fails the install if anything IS listening on 18789.
+    applies: () => !gatewayIsAbsent(),
   },
 ];
+
+/**
+ * The steps that apply to THIS device, in order.
+ *
+ * Evaluated per run, never memoized: the edition is read from a root-owned
+ * file that post_update itself can re-bake (step_edition_lock migrates a
+ * pre-3.x box onto /etc/clawbox/edition.env), so a list frozen at module load
+ * could describe the wrong SKU.
+ *
+ * The SAME array must feed both `state.steps` and the runner — `runUpdate`
+ * addresses `state.steps[i]` by position, so two independently-filtered lists
+ * would silently label every step after the first omission with its
+ * neighbour's name.
+ */
+function applicableSteps(steps: UpdateStepDef[]): UpdateStepDef[] {
+  return steps.filter((step) => !step.applies || step.applies());
+}
 
 /**
  * Runs a root-privileged step via the clawbox-root-update@ systemd template
@@ -726,10 +798,10 @@ function createStepStates(steps: UpdateStepDef[]): StepState[] {
   return steps.map((s) => ({ id: s.id, label: s.label, status: "pending" as const }));
 }
 
-function createInitialState(): UpdateState {
+function createInitialState(steps: UpdateStepDef[] = applicableSteps(UPDATE_STEPS)): UpdateState {
   return {
     phase: "idle",
-    steps: createStepStates(UPDATE_STEPS),
+    steps: createStepStates(steps),
     currentStepIndex: -1,
   };
 }
@@ -782,7 +854,11 @@ export async function checkContinuation(): Promise<boolean> {
 
   await set("update_needs_continuation", undefined);
 
-  const restartIndex = UPDATE_STEPS.findIndex((s) => s.id === RESTART_STEP_ID);
+  // Resolve the list ONCE and reuse it for the state, the resume index and the
+  // runner. The edition is stable across the reboot (post_update re-bakes the
+  // same value), so this matches the list the pre-restart half ran.
+  const steps = applicableSteps(UPDATE_STEPS);
+  const restartIndex = steps.findIndex((s) => s.id === RESTART_STEP_ID);
   const startFrom = restartIndex + 1;
 
   // The flag only proves the rebuild unit was STARTED, not that it rebuilt
@@ -801,7 +877,7 @@ export async function checkContinuation(): Promise<boolean> {
     const message = unitFailed
       ? (await readRootStepFailure(REBUILD_ROOT_STEP)) ?? "Rebuild failed before the restart"
       : "The device restarted without producing a new build — see clawbox-root-update@rebuild_reboot logs";
-    state = createInitialState();
+    state = createInitialState(steps);
     state.phase = "failed";
     for (let i = 0; i < restartIndex; i++) {
       state.steps[i].status = "completed";
@@ -813,14 +889,14 @@ export async function checkContinuation(): Promise<boolean> {
   }
 
   running = true;
-  state = createInitialState();
+  state = createInitialState(steps);
   state.phase = "running";
   for (let i = 0; i <= restartIndex; i++) {
     state.steps[i].status = "completed";
   }
   state.currentStepIndex = startFrom;
 
-  launchUpdate(UPDATE_STEPS, startFrom, { markCompleted: true });
+  launchUpdate(steps, startFrom, { markCompleted: true });
   return true;
 }
 
@@ -830,11 +906,12 @@ export function startUpdate(): { started: boolean; error?: string } {
   }
 
   running = true;
-  state = createInitialState();
+  const steps = applicableSteps(UPDATE_STEPS);
+  state = createInitialState(steps);
   state.phase = "running";
   state.currentStepIndex = 0;
 
-  launchUpdate(UPDATE_STEPS, 0, { markCompleted: true });
+  launchUpdate(steps, 0, { markCompleted: true });
   return { started: true };
 }
 
@@ -865,6 +942,14 @@ const OPENCLAW_UPDATE_STEPS: UpdateStepDef[] = [
 export function startOpenclawUpdate(): { started: boolean; error?: string } {
   if (running) {
     return { started: false, error: "Update already in progress" };
+  }
+  // Every step in this list is OpenClaw's, so there is no filtered version of
+  // it worth running — the whole flow is inapplicable. Refuse honestly instead
+  // of no-opping the two install steps and then failing on a gateway this SKU
+  // does not have. The UI never offers this on Hermes (getVersionInfo reports
+  // no OpenClaw update), but the endpoint is reachable regardless.
+  if (openclawIsAbsent()) {
+    return { started: false, error: "This edition does not ship OpenClaw." };
   }
 
   running = true;

--- a/src/tests/unit/hermes-dashboard-auth-yaml.test.ts
+++ b/src/tests/unit/hermes-dashboard-auth-yaml.test.ts
@@ -80,6 +80,29 @@ describe.runIf(RUNNABLE)("hermes dashboard auth block", () => {
     }
   });
 
+  it("does not re-mint when the stored hash already verifies the stored password", () => {
+    // The in-app updater now dispatches `hermes_edition` on every update, which
+    // runs this script every time. Re-minting a working box's credentials would
+    // rotate the password the auth proxy holds — a dashboard the customer can
+    // no longer be signed into, once per update.
+    const { root, configPath } = makeRoot();
+    const pwPath = path.join(root, "data", ".hermes-dashboard-pw");
+    expect(run(root, configPath, "clawbox").status).toBe(0);
+    const passwordBefore = fs.readFileSync(pwPath, "utf-8");
+    const hashBefore = /password_hash:\s*"([^"]+)"/.exec(
+      fs.readFileSync(configPath, "utf-8"),
+    )?.[1];
+
+    const second = run(root, configPath, "clawbox");
+
+    expect(second.status).toBe(0);
+    expect(second.stdout).toContain("already configured");
+    expect(fs.readFileSync(pwPath, "utf-8")).toBe(passwordBefore);
+    expect(
+      /password_hash:\s*"([^"]+)"/.exec(fs.readFileSync(configPath, "utf-8"))?.[1],
+    ).toBe(hashBefore);
+  });
+
   it("re-mints in place after the password file is lost, without a second block", () => {
     // The factory-reset shape: data/ is wiped, ~/.hermes/config.yaml survives.
     // A second top-level `dashboard:` key would be invalid YAML.

--- a/src/tests/unit/install-hermes-edition-step.test.ts
+++ b/src/tests/unit/install-hermes-edition-step.test.ts
@@ -31,16 +31,11 @@ function extractShellFunction(name: string): string {
   return INSTALL_SH.slice(start, end);
 }
 
-const DISPATCH_STEPS = INSTALL_SH.slice(
-  INSTALL_SH.indexOf("DISPATCH_STEPS=("),
-  INSTALL_SH.indexOf(")", INSTALL_SH.indexOf("DISPATCH_STEPS=(")),
-);
+// `hermes_edition` being in DISPATCH_STEPS is already pinned by
+// install-edition-lock.test.ts ("edition steps are dispatchable by the
+// updater") — not repeated here.
 
 describe("hermes_edition is the updater's own step", () => {
-  it("is dispatchable, so the updater can run it as a root step", () => {
-    expect(DISPATCH_STEPS).toContain("hermes_edition");
-  });
-
   it("the updater lists it", () => {
     expect(UPDATER_TS).toContain('id: "hermes_edition"');
   });
@@ -74,18 +69,33 @@ describe("provisioning stays safe to re-run on every update", () => {
     }
   });
 
-  it("verifies stored credentials before minting new ones", () => {
-    const auth = readFileSync(
-      path.join(REPO, "scripts/setup-hermes-dashboard-auth.sh"),
-      "utf-8",
+  // The "already-provisioned box is not re-minted on every update" property is
+  // tested behaviourally, by running the script twice, in
+  // hermes-dashboard-auth-yaml.test.ts — which owns that script.
+});
+
+/**
+ * src/lib/edition-source.ts's `hasHermesHarness()` states that it mirrors
+ * install.sh's `has_hermes_harness()`. The updater uses it to decide whether to
+ * dispatch `hermes_edition`, and the step itself re-checks the shell version —
+ * so if the two ever disagree, a device either skips its own provisioning or
+ * runs a step that immediately returns. Nothing else pins them together.
+ */
+describe("the TS and shell harness predicates agree", () => {
+  it("both treat hermes and dual as the Hermes-harness editions", () => {
+    expect(INSTALL_SH).toContain(
+      'has_hermes_harness() { [ "$CLAWBOX_EDITION" = "hermes" ] || [ "$CLAWBOX_EDITION" = "dual" ]; }',
     );
-    // The early exit must come before any generation, or a box that already
-    // works would get a fresh password on every single update.
-    const guard = auth.indexOf("if creds_are_consistent; then");
-    const mint = auth.indexOf("secrets.token_urlsafe(24)");
-    expect(guard).toBeGreaterThan(-1);
-    expect(mint).toBeGreaterThan(-1);
-    expect(guard).toBeLessThan(mint);
-    expect(auth.slice(guard, mint)).toContain("exit 0");
+    const ts = readFileSync(path.join(REPO, "src/lib/edition-source.ts"), "utf-8");
+    const body = ts.slice(ts.indexOf("export function hasHermesHarness()"));
+    expect(body).toContain('edition === "hermes" || edition === "dual"');
+  });
+
+  it("the provisioning step guards on the shell predicate too", () => {
+    // Belt and braces: the updater filters the step out, and dispatching it
+    // manually on an openclaw box still does nothing.
+    expect(extractShellFunction("step_hermes_edition")).toContain(
+      "has_hermes_harness || return 0",
+    );
   });
 });

--- a/src/tests/unit/install-hermes-edition-step.test.ts
+++ b/src/tests/unit/install-hermes-edition-step.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Hermes provisioning — dashboard + proxy units, dashboard auth, shared
+ * identity, MCP registration, gateway removal — used to run inside
+ * `step_post_update`, wrapped in `|| echo "Warning: … (non-fatal)"`. A device
+ * that failed to provision its entire edition still finished the update green,
+ * with the failure buried in the journal.
+ *
+ * The in-app updater now dispatches `hermes_edition` as its own visible step
+ * (see UPDATE_STEPS in src/lib/updater.ts), so it runs exactly once and a
+ * failure is reported as one. These tests pin both halves of that contract:
+ * the step must stay dispatchable, and post_update must not silently take the
+ * work back.
+ */
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const UPDATER_TS = readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8");
+const HERMES_SETUP = readFileSync(
+  path.join(REPO, "scripts/setup-hermes-edition.sh"),
+  "utf-8",
+);
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return INSTALL_SH.slice(start, end);
+}
+
+const DISPATCH_STEPS = INSTALL_SH.slice(
+  INSTALL_SH.indexOf("DISPATCH_STEPS=("),
+  INSTALL_SH.indexOf(")", INSTALL_SH.indexOf("DISPATCH_STEPS=(")),
+);
+
+describe("hermes_edition is the updater's own step", () => {
+  it("is dispatchable, so the updater can run it as a root step", () => {
+    expect(DISPATCH_STEPS).toContain("hermes_edition");
+  });
+
+  it("the updater lists it", () => {
+    expect(UPDATER_TS).toContain('id: "hermes_edition"');
+  });
+
+  it("post_update no longer calls it — that would run provisioning twice", () => {
+    // Two dashboard/proxy restarts per update, and the swallowed copy would
+    // still be the one that ran first.
+    expect(extractShellFunction("step_post_update")).not.toMatch(
+      /^\s*step_hermes_edition\b/m,
+    );
+  });
+
+  it("the full install still provisions directly, not via post_update", () => {
+    // step_post_update has only ever had one caller (the updater), so removing
+    // its call must not have cost fresh installs their provisioning.
+    const fullInstallTail = INSTALL_SH.slice(INSTALL_SH.indexOf("step_start_services\n"));
+    expect(fullInstallTail).toContain("step_hermes_edition");
+  });
+});
+
+describe("provisioning stays safe to re-run on every update", () => {
+  it("passes HOME explicitly to every runuser call", () => {
+    // All three scripts resolve their state from `${HOME:-/home/clawbox}`. This
+    // script runs as root (HOME=/root), so relying on runuser to reset HOME
+    // would make setup-hermes-dashboard-auth read the wrong config, find no
+    // credentials to verify, and mint a password the proxy does not have.
+    const runuserCalls = HERMES_SETUP.match(/runuser -u "\$CLAWBOX_USER" --[^\n]*(\n[^\n]*)?/g) ?? [];
+    expect(runuserCalls.length).toBeGreaterThan(0);
+    for (const call of runuserCalls) {
+      expect(call, `runuser call must pass HOME: ${call}`).toContain('HOME="$CLAWBOX_HOME"');
+    }
+  });
+
+  it("verifies stored credentials before minting new ones", () => {
+    const auth = readFileSync(
+      path.join(REPO, "scripts/setup-hermes-dashboard-auth.sh"),
+      "utf-8",
+    );
+    // The early exit must come before any generation, or a box that already
+    // works would get a fresh password on every single update.
+    const guard = auth.indexOf("if creds_are_consistent; then");
+    const mint = auth.indexOf("secrets.token_urlsafe(24)");
+    expect(guard).toBeGreaterThan(-1);
+    expect(mint).toBeGreaterThan(-1);
+    expect(guard).toBeLessThan(mint);
+    expect(auth.slice(guard, mint)).toContain("exit 0");
+  });
+});

--- a/src/tests/unit/install-hermes-edition-step.test.ts
+++ b/src/tests/unit/install-hermes-edition-step.test.ts
@@ -99,3 +99,31 @@ describe("the TS and shell harness predicates agree", () => {
     );
   });
 });
+
+/**
+ * The updater dropping a step is NOT a substitute for install.sh's own edition
+ * guards, and this is the trap: once `applies()` filters `gateway_setup` out on
+ * hermes, the `is_hermes_edition` guard inside step_gateway_setup looks dead and
+ * invites deletion. It is not dead. step_post_update has no `applies()` — it
+ * runs on every SKU — and calls step_gateway_setup itself, so deleting that
+ * guard would reinstall and enable an OpenClaw gateway on a Hermes box midway
+ * through its own update. `install.sh --step gateway_setup` by hand is the same
+ * hole. These pin both ends so the trap fails loudly instead of shipping.
+ */
+describe("install.sh keeps its own edition guards", () => {
+  it("post_update still calls gateway_setup on every edition", () => {
+    expect(extractShellFunction("step_post_update")).toContain("step_gateway_setup");
+  });
+
+  it("gateway_setup refuses on hermes regardless of how it was reached", () => {
+    expect(extractShellFunction("step_gateway_setup")).toContain("is_hermes_edition &&");
+  });
+
+  it("the OpenClaw steps refuse on hermes too", () => {
+    for (const step of ["step_openclaw_install", "step_openclaw_patch"]) {
+      expect(extractShellFunction(step), `${step} needs its own guard`).toContain(
+        "is_hermes_edition &&",
+      );
+    }
+  });
+});

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -136,6 +136,15 @@ describe("updater", () => {
     process.env.GATEWAY_HEALTH_WAIT_MS = "1";
     process.env.GATEWAY_RECOVERY_WAIT_MS = "1";
     process.env.GATEWAY_WAIT_INTERVAL_MS = "1";
+    // Pin the SKU. The step list is edition-dependent now, and these tests are
+    // routinely run ON A DEVICE — where /etc/clawbox/edition.env exists and is
+    // authoritative. Without this, the suite's result would depend on which box
+    // it happened to run on: on a Hermes device the OpenClaw and gateway steps
+    // are (correctly) filtered out, and every expectation below that looks for
+    // `gateway_verify` would fail for reasons that have nothing to do with the
+    // code under test. The nonexistent file forces the documented env fallback.
+    process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
+    process.env.CLAWBOX_EDITION = "openclaw";
 
     mockGet.mockResolvedValue(undefined);
     mockSet.mockResolvedValue();
@@ -163,6 +172,8 @@ describe("updater", () => {
     delete process.env.GATEWAY_HEALTH_WAIT_MS;
     delete process.env.GATEWAY_RECOVERY_WAIT_MS;
     delete process.env.GATEWAY_WAIT_INTERVAL_MS;
+    delete process.env.CLAWBOX_EDITION_FILE;
+    delete process.env.CLAWBOX_EDITION;
   });
 
   describe("getUpdateState", () => {
@@ -660,6 +671,175 @@ describe("updater", () => {
 
       expect(info.clawbox.updateAvailable).toBe(true);
       expect(info.clawbox.target).toBe("fix/qa-update@2222222");
+    });
+  });
+
+  /**
+   * An update on a Hermes box used to end red on `gateway_verify`: that step
+   * waits for the OpenClaw gateway on port 18789, which this SKU deliberately
+   * masks and closes. It could only ever throw, and because it is `failFast`
+   * the run stopped there — so `update_completed` was never persisted and the
+   * device kept presenting a finished update as unfinished.
+   *
+   * The same run also contradicted itself: post_update's smoke test FAILS the
+   * install if anything is listening on 18789, and the very next step demanded
+   * that something was.
+   */
+  describe("edition-aware step list", () => {
+    const OPENCLAW_ONLY = ["openclaw_install", "openclaw_patch"];
+    const GATEWAY_ONLY = ["gateway_setup", "gateway_verify"];
+
+    async function stepIdsFor(edition: string): Promise<string[]> {
+      vi.resetModules();
+      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
+      process.env.CLAWBOX_EDITION = edition;
+      const fresh = await import("@/lib/updater");
+      fresh.resetUpdateState();
+      return fresh.getUpdateState().steps.map((s) => s.id);
+    }
+
+    it("drops the OpenClaw and gateway steps on hermes", async () => {
+      const ids = await stepIdsFor("hermes");
+
+      for (const id of [...OPENCLAW_ONLY, ...GATEWAY_ONLY]) {
+        expect(ids, `${id} cannot apply on hermes`).not.toContain(id);
+      }
+    });
+
+    it("runs edition provisioning on hermes", async () => {
+      const ids = await stepIdsFor("hermes");
+
+      expect(ids).toContain("hermes_edition");
+      // After post_update: step_systemd_services has to have refreshed the unit
+      // files on disk before the provisioning step reinstalls and restarts them.
+      expect(ids.indexOf("hermes_edition")).toBeGreaterThan(ids.indexOf("post_update"));
+    });
+
+    it("still runs the shared steps on hermes", async () => {
+      const ids = await stepIdsFor("hermes");
+
+      expect(ids).toEqual([
+        "bootstrap_updater",
+        "apt_update",
+        "nvidia_jetpack",
+        "performance_mode",
+        "chromium_install",
+        "vnc_install",
+        "restart",
+        "post_update",
+        "hermes_edition",
+      ]);
+    });
+
+    it("leaves the openclaw edition unchanged apart from having no hermes step", async () => {
+      const ids = await stepIdsFor("openclaw");
+
+      expect(ids).toEqual([
+        "bootstrap_updater",
+        "apt_update",
+        "nvidia_jetpack",
+        "performance_mode",
+        "chromium_install",
+        "vnc_install",
+        "openclaw_install",
+        "openclaw_patch",
+        "gateway_setup",
+        "restart",
+        "post_update",
+        "gateway_verify",
+      ]);
+      expect(ids).not.toContain("hermes_edition");
+    });
+
+    it("runs everything on dual — it has both harnesses", async () => {
+      const ids = await stepIdsFor("dual");
+
+      for (const id of [...OPENCLAW_ONLY, ...GATEWAY_ONLY, "hermes_edition"]) {
+        expect(ids, `${id} applies on dual`).toContain(id);
+      }
+    });
+
+    it("defaults to the openclaw list when no edition is recorded", async () => {
+      vi.resetModules();
+      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
+      delete process.env.CLAWBOX_EDITION;
+      const fresh = await import("@/lib/updater");
+      fresh.resetUpdateState();
+      const ids = fresh.getUpdateState().steps.map((s) => s.id);
+
+      expect(ids).toContain("gateway_verify");
+      expect(ids).not.toContain("hermes_edition");
+    });
+
+    it("refuses the OpenClaw-only update on hermes instead of failing on the gateway", async () => {
+      vi.resetModules();
+      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
+      process.env.CLAWBOX_EDITION = "hermes";
+      const fresh = await import("@/lib/updater");
+      fresh.resetUpdateState();
+
+      const result = fresh.startOpenclawUpdate();
+
+      expect(result.started).toBe(false);
+      expect(result.error).toMatch(/does not ship OpenClaw/i);
+      // Nothing should have been kicked off.
+      expect(fresh.getUpdateState().phase).toBe("idle");
+    });
+
+    it("still allows the OpenClaw-only update on dual", async () => {
+      vi.resetModules();
+      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
+      process.env.CLAWBOX_EDITION = "dual";
+      const fresh = await import("@/lib/updater");
+      fresh.resetUpdateState();
+
+      expect(fresh.startOpenclawUpdate().started).toBe(true);
+      fresh.resetUpdateState();
+    });
+
+    it("completes a hermes update and records it as completed", async () => {
+      // The gateway is closed on this SKU — the old list could not get here.
+      mockIsPortOpen.mockResolvedValue(false);
+      setupExecFileMock({
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+      });
+
+      vi.resetModules();
+      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
+      process.env.CLAWBOX_EDITION = "hermes";
+      mockGet.mockResolvedValue(undefined);
+      mockSet.mockResolvedValue();
+      mockSetMany.mockResolvedValue();
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+      const fresh = await import("@/lib/updater");
+
+      fresh.resetUpdateState();
+      // Resume past `restart` so the test doesn't have to drive the rebuild
+      // hand-off, which never returns by design.
+      mockGet.mockResolvedValue("previous-build-id");
+      setupExecFileMock({
+        // Specific keys first — the mock returns on the first key that matches,
+        // and a bare "systemctl" would shadow this one.
+        "show clawbox-root-update@rebuild_reboot.service": { stdout: "success\n", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+      });
+      mockReadFile.mockImplementation(async (file) => {
+        if (String(file).endsWith("BUILD_ID")) return "new-build-id";
+        throw new Error("ENOENT");
+      });
+
+      expect(await fresh.checkContinuation()).toBe(true);
+      await vi.waitFor(() => {
+        expect(fresh.getUpdateState().phase).toBe("completed");
+      });
+
+      const state = fresh.getUpdateState();
+      expect(state.steps.every((s) => s.status === "completed")).toBe(true);
+      expect(mockSetMany).toHaveBeenCalledWith(
+        expect.objectContaining({ update_completed: true }),
+      );
     });
   });
 });

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -136,14 +136,11 @@ describe("updater", () => {
     process.env.GATEWAY_HEALTH_WAIT_MS = "1";
     process.env.GATEWAY_RECOVERY_WAIT_MS = "1";
     process.env.GATEWAY_WAIT_INTERVAL_MS = "1";
-    // Pin the SKU. The step list is edition-dependent now, and these tests are
-    // routinely run ON A DEVICE — where /etc/clawbox/edition.env exists and is
-    // authoritative. Without this, the suite's result would depend on which box
-    // it happened to run on: on a Hermes device the OpenClaw and gateway steps
-    // are (correctly) filtered out, and every expectation below that looks for
-    // `gateway_verify` would fail for reasons that have nothing to do with the
-    // code under test. The nonexistent file forces the documented env fallback.
-    process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
+    // Pin the SKU: the step list is edition-dependent, so without this the
+    // expectations below that look for `gateway_verify` would fail on a Hermes
+    // box, where it is (correctly) filtered out. Only the edition VALUE is set
+    // here — vitest.config.ts already points CLAWBOX_EDITION_FILE at a path
+    // that cannot exist, which is what makes process.env authoritative.
     process.env.CLAWBOX_EDITION = "openclaw";
 
     mockGet.mockResolvedValue(undefined);
@@ -172,7 +169,9 @@ describe("updater", () => {
     delete process.env.GATEWAY_HEALTH_WAIT_MS;
     delete process.env.GATEWAY_RECOVERY_WAIT_MS;
     delete process.env.GATEWAY_WAIT_INTERVAL_MS;
-    delete process.env.CLAWBOX_EDITION_FILE;
+    // NOT CLAWBOX_EDITION_FILE — that is a suite-wide guarantee from
+    // vitest.config.ts, and deleting it here would leave later files in this
+    // worker reading the real /etc/clawbox/edition.env.
     delete process.env.CLAWBOX_EDITION;
   });
 
@@ -686,36 +685,24 @@ describe("updater", () => {
    * that something was.
    */
   describe("edition-aware step list", () => {
-    const OPENCLAW_ONLY = ["openclaw_install", "openclaw_patch"];
-    const GATEWAY_ONLY = ["gateway_setup", "gateway_verify"];
-
-    async function stepIdsFor(edition: string): Promise<string[]> {
+    /** Same shape as loadHarness() in harness-edition.test.ts. */
+    async function loadUpdater(edition?: string) {
       vi.resetModules();
-      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
-      process.env.CLAWBOX_EDITION = edition;
+      if (edition === undefined) delete process.env.CLAWBOX_EDITION;
+      else process.env.CLAWBOX_EDITION = edition;
       const fresh = await import("@/lib/updater");
       fresh.resetUpdateState();
-      return fresh.getUpdateState().steps.map((s) => s.id);
+      return fresh;
     }
 
-    it("drops the OpenClaw and gateway steps on hermes", async () => {
-      const ids = await stepIdsFor("hermes");
+    const stepIdsFor = async (edition?: string): Promise<string[]> =>
+      (await loadUpdater(edition)).getUpdateState().steps.map((s) => s.id);
 
-      for (const id of [...OPENCLAW_ONLY, ...GATEWAY_ONLY]) {
-        expect(ids, `${id} cannot apply on hermes`).not.toContain(id);
-      }
-    });
-
-    it("runs edition provisioning on hermes", async () => {
-      const ids = await stepIdsFor("hermes");
-
-      expect(ids).toContain("hermes_edition");
-      // After post_update: step_systemd_services has to have refreshed the unit
-      // files on disk before the provisioning step reinstalls and restarts them.
-      expect(ids.indexOf("hermes_edition")).toBeGreaterThan(ids.indexOf("post_update"));
-    });
-
-    it("still runs the shared steps on hermes", async () => {
+    it("drops the OpenClaw and gateway steps on hermes, and provisions the edition", async () => {
+      // The exact list, so this fails loudly on any drift: openclaw_install,
+      // openclaw_patch, gateway_setup and gateway_verify are all absent, and
+      // hermes_edition lands AFTER post_update — step_systemd_services has to
+      // refresh the unit files before the provisioning step restarts them.
       const ids = await stepIdsFor("hermes");
 
       expect(ids).toEqual([
@@ -754,29 +741,26 @@ describe("updater", () => {
     it("runs everything on dual — it has both harnesses", async () => {
       const ids = await stepIdsFor("dual");
 
-      for (const id of [...OPENCLAW_ONLY, ...GATEWAY_ONLY, "hermes_edition"]) {
+      for (const id of [
+        "openclaw_install",
+        "openclaw_patch",
+        "gateway_setup",
+        "gateway_verify",
+        "hermes_edition",
+      ]) {
         expect(ids, `${id} applies on dual`).toContain(id);
       }
     });
 
     it("defaults to the openclaw list when no edition is recorded", async () => {
-      vi.resetModules();
-      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
-      delete process.env.CLAWBOX_EDITION;
-      const fresh = await import("@/lib/updater");
-      fresh.resetUpdateState();
-      const ids = fresh.getUpdateState().steps.map((s) => s.id);
+      const ids = await stepIdsFor();
 
       expect(ids).toContain("gateway_verify");
       expect(ids).not.toContain("hermes_edition");
     });
 
     it("refuses the OpenClaw-only update on hermes instead of failing on the gateway", async () => {
-      vi.resetModules();
-      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
-      process.env.CLAWBOX_EDITION = "hermes";
-      const fresh = await import("@/lib/updater");
-      fresh.resetUpdateState();
+      const fresh = await loadUpdater("hermes");
 
       const result = fresh.startOpenclawUpdate();
 
@@ -787,11 +771,7 @@ describe("updater", () => {
     });
 
     it("still allows the OpenClaw-only update on dual", async () => {
-      vi.resetModules();
-      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
-      process.env.CLAWBOX_EDITION = "dual";
-      const fresh = await import("@/lib/updater");
-      fresh.resetUpdateState();
+      const fresh = await loadUpdater("dual");
 
       expect(fresh.startOpenclawUpdate().started).toBe(true);
       fresh.resetUpdateState();
@@ -800,21 +780,8 @@ describe("updater", () => {
     it("completes a hermes update and records it as completed", async () => {
       // The gateway is closed on this SKU — the old list could not get here.
       mockIsPortOpen.mockResolvedValue(false);
-      setupExecFileMock({
-        ping: { stdout: "", stderr: "" },
-        systemctl: { stdout: "", stderr: "" },
-      });
+      const fresh = await loadUpdater("hermes");
 
-      vi.resetModules();
-      process.env.CLAWBOX_EDITION_FILE = "/nonexistent/edition.env";
-      process.env.CLAWBOX_EDITION = "hermes";
-      mockGet.mockResolvedValue(undefined);
-      mockSet.mockResolvedValue();
-      mockSetMany.mockResolvedValue();
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
-      const fresh = await import("@/lib/updater");
-
-      fresh.resetUpdateState();
       // Resume past `restart` so the test doesn't have to drive the rebuild
       // hand-off, which never returns by design.
       mockGet.mockResolvedValue("previous-build-id");


### PR DESCRIPTION
## The problem

An in-app update on a Hermes device ends red on `gateway_verify`. That step waits for the OpenClaw gateway on port 18789, which this edition deliberately masks and closes, so it can only ever throw — and because it is `failFast`, the run stops there.

The clearest way to see that this step was never meant to run on this SKU: **the run contradicts itself.** `post_update` calls `step_update_smoke`, which on hermes *fails the install if anything is listening on 18789*. The very next step demands that something is.

The user-visible damage is worse than a red row. `runUpdate` only persists `update_completed` when nothing failed, so a Hermes box never records a finished update. That flag gates `SetupWizard.tsx`'s resume step and the `/update/versions` route — the device keeps presenting a completed update as unfinished.

## What was already fine

Worth stating, because it narrowed the change considerably:

- `step_openclaw_install`, `step_openclaw_patch` and `step_gateway_setup` **already** early-return on hermes inside `install.sh`. They were never failures — they cost time and printed skip lines, but reported `completed`.
- Hermes provisioning was **already** re-applied on every update, from inside `step_post_update`. What was missing was not the work but its *visibility*: it was wrapped in `|| echo "Warning: … (non-fatal)"`, so a device that failed to provision its entire edition still finished the update green.

## The change

**Steps carry an applicability predicate, and inapplicable ones are dropped from the list.** A dropped step never renders, so it reads as absent rather than as a failure — no UI, `StepStatus` or translation change was needed, since `UpdateStep.tsx` renders `state.steps` verbatim and `Meter` derives its bounds from the array.

| step | openclaw | dual | hermes |
|---|---|---|---|
| `openclaw_install` / `openclaw_patch` | run | run | dropped (`openclawIsAbsent()`) |
| `gateway_setup` / `gateway_verify` | run | run | dropped (`gatewayIsAbsent()`) |
| `hermes_edition` *(new)* | dropped | run | run (`hasHermesHarness()`) |

Each step names the helper matching *its own* reason for being skipped rather than one blanket edition check. The two predicates are identical today; keeping them distinct means they can diverge without the filter quietly going wrong. `dual` ships both harnesses and is unchanged.

**Provisioning becomes its own visible step.** `hermes_edition` runs after `post_update` (so `step_systemd_services` has already refreshed the unit files it reinstalls) and is no longer called from inside `step_post_update`, so it runs exactly once and can fail honestly. Fresh installs are unaffected — they call `step_hermes_edition` directly.

**The scoped OpenClaw-only update refuses on an edition without OpenClaw** instead of no-opping two steps and then failing on the same absent gateway. `/setup-api/update/openclaw` was reachable and unguarded.

**`setup-hermes-edition.sh` passes `HOME` explicitly to every `runuser` call.** All three scripts it invokes resolve state from `${HOME:-/home/clawbox}` and it runs as root. `runuser` does reset `HOME` today — verified on hardware, util-linux 2.37.2 — but relying on that would let the dashboard-auth script read the wrong config, find no credentials to verify, and mint a password the proxy does not hold.

## Idempotency

`hermes_edition` now runs on every update, so re-running has to be free. Verified on a real Hermes box, in a throwaway root with overridden paths:

```
second-run said: [hermes-dash-auth] already configured (stored hash verifies the stored password) — skipping
password UNCHANGED: PASS
hash UNCHANGED: PASS
dashboard blocks in config: 1
```

`creds_are_consistent()` re-derives the scrypt hash from the stored plaintext and exits before any minting, so a working box is never rotated. This is now pinned by a behavioural test — run the script twice, assert password and hash unchanged — rather than a source-text scan.

## A guard that looks dead and is not

Once `applies()` drops `gateway_setup` on hermes, the `is_hermes_edition` guard *inside* `step_gateway_setup` reads as dead code. It is not. `step_post_update` has no predicate, runs on every SKU, and calls `step_gateway_setup` itself — deleting that guard would reinstall and enable an OpenClaw gateway on a Hermes box halfway through its own update, reintroducing this bug one layer down. `install.sh --step gateway_setup` by hand is the same hole. There is now a comment at the guard and tests pinning both ends of the argument.

## Testing

- Unit: edition-aware step lists for all three SKUs, the OpenClaw-only refusal, a full hermes update reaching `completed` with `update_completed` persisted, the no-re-mint behaviour, and a cross-layer pin that `hasHermesHarness()` and `has_hermes_harness()` agree.
- `e2e-install`'s `90-upgrade-main-to-beta.spec.ts` is unaffected: it asserts every step in `state.steps` completed without naming them, and the container resolves as `openclaw`, where the list is unchanged.

**A Hermes variant of the e2e-install upgrade spec is not feasible today**, and this is why rather than an excuse. `CLAWBOX_EDITION` is not plumbed through `docker-compose.test.yml` or `entrypoint.sh`. `step_hermes_install` has no test-mode guard and shells out to an unpinned third-party installer, degrading to a *warning* on failure — leaving no `hermes` binary, a crash-looping dashboard unit, and `step_validate_services` returning 1. That aborts `install.sh` under `set -e`, so `.needs-install` is never removed, the healthcheck never passes, and `global-setup.ts` burns its 40-minute timeout and fails **every** spec in the suite. The harness is also `workers: 1` against one hardcoded container, and the edition is baked at install time with the gateway deleted and masked, so the two editions cannot coexist. Doing it properly needs a second compose identity and a decision about what "Hermes installed" means in CI.

## Pre-flight before the manual upgrade test

The whole fix keys off `readEdition()`. **Run this on the older Hermes box first:**

```sh
cat /etc/clawbox/edition.env                     # expect CLAWBOX_EDITION=hermes
systemctl show clawbox-setup -p Environment      # expect CLAWBOX_EDITION=hermes
systemctl is-enabled clawbox-gateway.service     # expect: masked
```

If none of those carry the SKU, `readEdition()` falls back to `openclaw`, the box runs the OpenClaw steps, and it fails at `gateway_verify` exactly as before — **making a correct fix look broken.** Confirm the edition resolves before drawing any conclusion from the run.

Also set the update target, since a box with no `.update-branch` resolves via its current branch's upstream and can silently aim at `main`:

```sh
echo beta | sudo tee /home/clawbox/clawbox/.update-branch
```

Expected on hermes: `bootstrap_updater → apt_update → nvidia_jetpack → performance_mode → chromium_install → vnc_install → restart → post_update → hermes_edition`, ending `completed`, with no OpenClaw or gateway rows shown at all.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updates now adapt automatically to the device edition, running only applicable setup steps.
  * Hermes provisioning is handled as a distinct update step with independent status reporting.
  * Full installations support Hermes edition setup.

* **Bug Fixes**
  * Prevented gateway and OpenClaw setup from running on unsupported editions.
  * Preserved existing dashboard authentication credentials when setup is rerun.
  * Fixed credential lookup consistency during Hermes setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->