### PR TITLE
fix: focus trap for the install dialog, upstream timeouts for the hermes dashboard proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,10 @@ ALLOW_INSECURE_CONTROL_UI=true
 # Optional override for OpenClaw's output budget. If unset, ClawBox uses the
 # full llama.cpp context window instead of a smaller app-level cap.
 # LLAMACPP_MAX_TOKENS=131072
+
+# Optional: Hermes dashboard proxy (scripts/hermes-dashboard-proxy.js) upstream
+# timeouts, in milliseconds. Each is armed only for the phase where silence
+# means the upstream is stuck; 0 disables one. Defaults shown.
+# HERMES_DASH_UPSTREAM_TIMEOUT_MS=30000   # request sent -> first response byte
+# HERMES_DASH_LOGIN_TIMEOUT_MS=10000      # absolute deadline for the SSO login
+# HERMES_DASH_WS_TIMEOUT_MS=15000         # TCP connect + WebSocket handshake

--- a/e2e-install/80-chat.spec.ts
+++ b/e2e-install/80-chat.spec.ts
@@ -142,6 +142,23 @@ test.describe("chat round trip", () => {
 
     await page.goto("/");
 
+    // Configuring a provider above flips the account tier, which makes the
+    // tier-upgrade dialog open over the desktop on first load. It is a real
+    // modal — `aria-modal="true"`, and the page behind it is `inert`, so the
+    // chat panel is genuinely unreachable until it is dismissed, for a screen
+    // reader and for this test alike. Dismiss it the way a user would rather
+    // than querying around it; it is absent on reruns (the "seen" tier is
+    // persisted), hence the tolerant wait.
+    const celebration = page.getByRole("dialog").filter({ hasText: /plan/i });
+    const celebrationShown = await celebration
+      .waitFor({ state: "visible", timeout: 10_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (celebrationShown) {
+      await celebration.getByRole("button").first().click();
+      await expect(celebration).toBeHidden({ timeout: 10_000 });
+    }
+
     // Before the gateway WS connects, the textbox shows
     // "Waiting for the Claw to wake up…" and is disabled. Once the gateway
     // acknowledges the session, the placeholder flips to "Type a message..."

--- a/scripts/hermes-dashboard-proxy.js
+++ b/scripts/hermes-dashboard-proxy.js
@@ -79,13 +79,20 @@ const DASH_USERNAME = process.env.HERMES_DASH_USERNAME || "clawbox";
 // vanish (a bare 1006, no status). Silence is the very symptom these timeouts
 // exist to remove, so every timeout path below writes its own status FIRST and
 // tears the socket down after.
+//
+// Note the LOGIN timer is an absolute deadline rather than a socket timeout —
+// `setTimeout` on a socket measures inactivity, which an upstream that dribbles
+// bytes can reset forever. See hermesLogin().
 function envMs(name, fallback) {
-  const raw = Number.parseInt(process.env[name] || "", 10);
+  const raw = Number.parseInt(process.env[name], 10);
   return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
 }
 const UPSTREAM_HEADERS_TIMEOUT_MS = envMs("HERMES_DASH_UPSTREAM_TIMEOUT_MS", 30_000);
 const LOGIN_TIMEOUT_MS = envMs("HERMES_DASH_LOGIN_TIMEOUT_MS", 10_000);
 const WS_HANDSHAKE_TIMEOUT_MS = envMs("HERMES_DASH_WS_TIMEOUT_MS", 15_000);
+// End of an HTTP header block — what the WS path waits for before it will call
+// the upgrade handshake complete and stand its timeout down.
+const HEADER_TERMINATOR = "\r\n\r\n";
 
 // Rewrite the origin part of a Referer to the upstream authority, keeping path.
 function rewriteReferer(value) {
@@ -347,6 +354,18 @@ function hermesLogin() {
   if (!pw) return Promise.resolve(null);
   const body = JSON.stringify({ provider: "basic", username: DASH_USERNAME, password: pw, next: "/" });
   return new Promise((resolve) => {
+    // EVERY request needing SSO awaits this one promise (see ensureHermesCookies),
+    // so it must settle exactly once and it must always settle. `settle` gives
+    // both: later callers are ignored, and the deadline below guarantees one.
+    let settled = false;
+    let deadline = null;
+    const settle = (value) => {
+      if (settled) return;
+      settled = true;
+      if (deadline) clearTimeout(deadline);
+      resolve(value);
+    };
+
     const reqUp = http.request(
       {
         host: UPSTREAM_HOST,
@@ -366,7 +385,7 @@ function hermesLogin() {
           const setCookies = up.headers["set-cookie"];
           if (up.statusCode !== 200 || !Array.isArray(setCookies) || setCookies.length === 0) {
             console.error(`[hermes-dashboard-proxy] login failed: HTTP ${up.statusCode} ${Buffer.concat(chunks).toString().slice(0, 120)}`);
-            resolve(null);
+            settle(null);
             return;
           }
           // Build a Cookie header from each Set-Cookie's leading name=value.
@@ -374,24 +393,29 @@ function hermesLogin() {
             .map((sc) => String(sc).split(";", 1)[0])
             .filter(Boolean)
             .join("; ");
-          resolve({ cookieHeader, setCookies });
+          settle({ cookieHeader, setCookies });
         });
       },
     );
-    // A dashboard that accepts the connection and never answers would otherwise
-    // pin `loginInFlight` forever, and EVERY request that needs SSO awaits that
-    // same promise — one wedged login would stall the whole proxy. Resolving
-    // null here feeds the existing failure path: cooldown, then retry.
+    // An ABSOLUTE deadline, not a socket timeout. `setTimeout` on a request
+    // measures INACTIVITY, so a dashboard that dribbles a byte just often
+    // enough — a half-written response, a stuck chunked body — resets it
+    // forever and never fires. The promise would then stay pending, and with
+    // it every SSO request in the process. This bounds total login duration
+    // regardless of how the upstream misbehaves; resolving null feeds the
+    // existing failure path (cooldown, then retry).
     if (LOGIN_TIMEOUT_MS > 0) {
-      reqUp.setTimeout(LOGIN_TIMEOUT_MS, () => {
+      deadline = setTimeout(() => {
         console.error(`[hermes-dashboard-proxy] login timed out after ${LOGIN_TIMEOUT_MS}ms`);
         reqUp.destroy();
-        resolve(null);
-      });
+        settle(null);
+      }, LOGIN_TIMEOUT_MS);
+      // Never hold the process open for a login that is only a retry away.
+      deadline.unref?.();
     }
     reqUp.on("error", (e) => {
       console.error(`[hermes-dashboard-proxy] login error: ${e.message}`);
-      resolve(null);
+      settle(null);
     });
     reqUp.end(body);
   });
@@ -525,9 +549,8 @@ function forward(req, res, injected, bodyBuf, allowRelogin) {
   // ServerResponse — unhandled, that is an uncaught exception, and this
   // proxy is a single process, so it would take the whole service down.
   //
-  // Also the reason both the timeout and the error path can fire for one
-  // request without doubling up: whichever lands first writes, the other
-  // returns here.
+  // Also why the timeout and the error path can both fire for one request
+  // without doubling up: whichever lands first writes, the other returns here.
   const failRequest = (status, message) => {
     if (res.writableEnded || res.destroyed) return;
     if (res.headersSent) {
@@ -540,17 +563,9 @@ function forward(req, res, injected, bodyBuf, allowRelogin) {
 
   if (UPSTREAM_HEADERS_TIMEOUT_MS > 0) {
     upstream.setTimeout(UPSTREAM_HEADERS_TIMEOUT_MS, () => {
-      // Respond FIRST, then tear down — never the other way round.
-      //
-      // `destroy()` with no argument is specified to emit 'close'; whether an
-      // 'error' ALSO reaches the handler below depends on how far the exchange
-      // got, and once a response is in flight it does not end the client's
-      // response at all, because pipe() does not propagate a source error to
-      // its destination. Leaving the teardown to speak for us is therefore a
-      // request that may hang — the exact symptom the timeout exists to stop.
-      // Writing the status here makes the outcome identical in every case, and
-      // 504 says "the dashboard went quiet" rather than the 502 an incidental
-      // socket error would report.
+      // Respond FIRST, then tear down — see the Timeouts section at the top of
+      // this file. 504 also says "the dashboard went quiet" rather than the 502
+      // an incidental socket error would report.
       failRequest(504, "Hermes dashboard did not respond in time.");
       upstream.destroy();
     });
@@ -708,10 +723,15 @@ function handleUpgrade(req, clientSocket, head) {
     // Armed for TCP connect + the 101 handshake only. A dashboard that accepts
     // the socket and never completes the upgrade would otherwise leave the
     // browser's WebSocket pending indefinitely with no close frame; the client
-    // gets an explicit 504 instead. Disarmed on the upstream's first byte,
-    // because an established WebSocket is idle by design and an idle timer
-    // past that point would drop healthy connections.
-    let handshakeStarted = false;
+    // gets an explicit 504 instead. Disarmed once the upstream's response
+    // HEADERS are complete, because an established WebSocket is idle by design
+    // and an idle timer past that point would drop healthy connections.
+    //
+    // Completion means the full header block, terminator included — NOT merely
+    // "some byte arrived". A partial status line followed by silence is exactly
+    // the wedged-upstream case this timeout exists for, and disarming on the
+    // first byte would hand that case straight back to the hang.
+    let handshakeComplete = false;
     const upstream = net.connect(UPSTREAM_PORT, UPSTREAM_HOST, () => {
       const headerLines = [`${req.method} ${req.url} HTTP/1.1`];
       let cookieWritten = false;
@@ -739,23 +759,41 @@ function handleUpgrade(req, clientSocket, head) {
       if (head && head.length) upstream.write(head);
       clientSocket.pipe(upstream);
       upstream.pipe(clientSocket);
-      // Attached AFTER pipe() so the pipe is already consuming — both listeners
+      // Watch the upstream's bytes only until its response headers end, then
+      // DETACH. This listener merely observes — pipe() above still delivers
+      // every chunk to the client — but pipe has already registered a 'data'
+      // handler, so leaving a second one attached would keep `_events.data` an
+      // array for the life of the socket, and emit() clones that array on
+      // every inbound chunk. Removing it restores the single-listener fast
+      // path for the long-lived WebSocket that follows.
+      //
+      // Attached AFTER pipe() so the pipe is already consuming; both listeners
       // are registered in this same synchronous block, so no byte is lost.
-      upstream.on("data", () => {
-        if (handshakeStarted) return;
-        handshakeStarted = true;
-        upstream.setTimeout(0);
-      });
+      let sniffed = "";
+      const onUpstreamData = (chunk) => {
+        // latin1 keeps one byte per char, so the CRLF scan and the carry-over
+        // slice below cannot be broken by a multi-byte sequence.
+        const text = sniffed + chunk.toString("latin1");
+        if (text.includes(HEADER_TERMINATOR)) {
+          handshakeComplete = true;
+          sniffed = "";
+          upstream.setTimeout(0);
+          upstream.off("data", onUpstreamData);
+          return;
+        }
+        // Carry the tail so a terminator split across two chunks still matches.
+        sniffed = text.slice(-(HEADER_TERMINATOR.length - 1));
+      };
+      upstream.on("data", onUpstreamData);
     });
     const kill = () => { try { upstream.destroy(); } catch {} try { clientSocket.destroy(); } catch {} };
     if (WS_HANDSHAKE_TIMEOUT_MS > 0) {
       upstream.setTimeout(WS_HANDSHAKE_TIMEOUT_MS, () => {
-        if (handshakeStarted) return; // established WebSocket: idle is normal
-        // Same trap as the HTTP path, and here it is unambiguous: `kill` on its
-        // own drops the TCP connection with nothing written, so the browser
-        // reports a bare 1006 and no page can tell a wedged dashboard from a
+        if (handshakeComplete) return; // established WebSocket: idle is normal
+        // `kill` on its own drops the connection with nothing written, so the
+        // browser reports a bare 1006 and cannot tell a wedged dashboard from a
         // network blip. Write the status before tearing down.
-        try { clientSocket.write("HTTP/1.1 504 Gateway Timeout\r\nConnection: close\r\n\r\n"); } catch {}
+        try { clientSocket.write(`HTTP/1.1 504 Gateway Timeout\r\nConnection: close${HEADER_TERMINATOR}`); } catch {}
         kill();
       });
     }
@@ -779,20 +817,20 @@ function handleUpgrade(req, clientSocket, head) {
 // its behaviour without also binding :8090 — so the gate, the SSO broker and
 // the timeouts above shipped to devices with no test covering any of them.
 
+// ONE server per process. The Hermes session cache, the login cooldown and the
+// upstream address are all module-scope, so two servers built here would share
+// them — build a second only to assert something about a server that never
+// listens, never to run two side by side.
 function createProxyServer() {
   const srv = http.createServer(handleRequest);
   srv.on("upgrade", handleUpgrade);
   return srv;
 }
 
-function main() {
-  const srv = createProxyServer();
-  srv.listen(PORT, "0.0.0.0", () => {
+if (require.main === module) {
+  createProxyServer().listen(PORT, "0.0.0.0", () => {
     console.log(`[hermes-dashboard-proxy] :${PORT} -> ${UPSTREAM_AUTHORITY} (clawbox_session gated, Hermes SSO)`);
   });
-  return srv;
 }
 
-if (require.main === module) main();
-
-module.exports = { createProxyServer, handleRequest, handleUpgrade, main };
+module.exports = { createProxyServer, handleRequest, handleUpgrade };

--- a/scripts/hermes-dashboard-proxy.js
+++ b/scripts/hermes-dashboard-proxy.js
@@ -63,14 +63,19 @@ const DASH_USERNAME = process.env.HERMES_DASH_USERNAME || "clawbox";
 //
 // Each timeout is armed only for the phase where silence means "stuck":
 //
-//   HEADERS — from send to the first response byte. Disarmed as soon as the
+//   HEADERS — from send to COMPLETE response headers. Cleared as soon as the
 //     response starts, because the dashboard legitimately streams (long-lived
 //     event streams would be cut mid-flight by an idle timer).
 //   LOGIN   — the SSO broker's own POST /auth/password-login. Short: it is on
 //     the critical path of a user's first request.
-//   WS      — TCP connect plus the 101 handshake, disarmed once the upstream
-//     sends its first byte. A live WebSocket is idle most of the time, so an
-//     idle timeout past the handshake would drop working connections.
+//   WS      — TCP connect plus the 101 handshake, stood down once the upstream
+//     has sent a complete header block. A live WebSocket is idle most of the
+//     time, so an idle timeout past the handshake would drop working links.
+//
+// The first two are ABSOLUTE deadlines rather than socket timeouts. A socket
+// timer measures inactivity, so an upstream that trickles a byte at a time
+// resets it forever and the request hangs anyway. The WS one is a socket timer
+// on purpose: it must stop applying entirely once the connection is live.
 //
 // A timed-out request must still PRODUCE A RESPONSE. Tearing the upstream
 // socket down and trusting the existing error handler to notice is not enough:
@@ -508,10 +513,9 @@ function forward(req, res, injected, bodyBuf, allowRelogin) {
   const upstream = http.request(
     { host: UPSTREAM_HOST, port: UPSTREAM_PORT, method: req.method, path: req.url, headers },
     (up) => {
-      // Headers are in — the upstream is alive. Disarm before piping: the
-      // response body may legitimately trickle (event stream, slow download),
-      // and an idle timer would sever it mid-transfer.
-      upstream.setTimeout(0);
+      // Headers are in — the upstream is alive. The deadline is cleared by the
+      // 'response' listener below; from here a slow body is legitimate (event
+      // stream, slow download) and nothing may cut it.
       // The Hermes session was rejected (TTL elapsed, or the dashboard restarted
       // and rotated its signing secret) — re-broker once and replay.
       //
@@ -561,16 +565,35 @@ function forward(req, res, injected, bodyBuf, allowRelogin) {
     res.end(message);
   };
 
+  // An ABSOLUTE deadline for "response headers complete", not a socket timeout.
+  // A socket timer measures INACTIVITY, so an upstream trickling one header
+  // byte at a time — or a stuck chunked header block — resets it forever: the
+  // response callback never runs, the timer never fires, and the browser waits
+  // with nothing to show. Same trap as the login path; bounded the same way.
+  // Cleared once headers land, so a legitimately slow BODY is never cut.
+  let headerDeadline = null;
+  const clearHeaderDeadline = () => {
+    if (headerDeadline) {
+      clearTimeout(headerDeadline);
+      headerDeadline = null;
+    }
+  };
   if (UPSTREAM_HEADERS_TIMEOUT_MS > 0) {
-    upstream.setTimeout(UPSTREAM_HEADERS_TIMEOUT_MS, () => {
+    headerDeadline = setTimeout(() => {
       // Respond FIRST, then tear down — see the Timeouts section at the top of
       // this file. 504 also says "the dashboard went quiet" rather than the 502
       // an incidental socket error would report.
       failRequest(504, "Hermes dashboard did not respond in time.");
       upstream.destroy();
-    });
+    }, UPSTREAM_HEADERS_TIMEOUT_MS);
+    headerDeadline.unref?.();
   }
-  upstream.on("error", () => failRequest(502, "Hermes dashboard is not reachable."));
+  upstream.on("response", clearHeaderDeadline);
+  upstream.on("error", () => {
+    clearHeaderDeadline();
+    failRequest(502, "Hermes dashboard is not reachable.");
+  });
+  upstream.on("close", clearHeaderDeadline);
   // Sink for any late stream error on the client connection, same reasoning.
   res.on("error", () => {});
 

--- a/scripts/hermes-dashboard-proxy.js
+++ b/scripts/hermes-dashboard-proxy.js
@@ -52,6 +52,41 @@ const UPSTREAM_AUTHORITY = `${UPSTREAM_HOST}:${UPSTREAM_PORT}`;
 const UPSTREAM_ORIGIN = `http://${UPSTREAM_AUTHORITY}`;
 const DASH_USERNAME = process.env.HERMES_DASH_USERNAME || "clawbox";
 
+// ---------------------------------------------------------------------------
+// Timeouts
+// ---------------------------------------------------------------------------
+//
+// Without these, an upstream that accepts the connection and then goes quiet
+// (the dashboard mid-restart, a wedged worker) held the browser's request open
+// forever. On a Jetson serving a handful of connections that is how the tab
+// ends up spinning with nothing to click and no error to report.
+//
+// Each timeout is armed only for the phase where silence means "stuck":
+//
+//   HEADERS — from send to the first response byte. Disarmed as soon as the
+//     response starts, because the dashboard legitimately streams (long-lived
+//     event streams would be cut mid-flight by an idle timer).
+//   LOGIN   — the SSO broker's own POST /auth/password-login. Short: it is on
+//     the critical path of a user's first request.
+//   WS      — TCP connect plus the 101 handshake, disarmed once the upstream
+//     sends its first byte. A live WebSocket is idle most of the time, so an
+//     idle timeout past the handshake would drop working connections.
+//
+// A timed-out request must still PRODUCE A RESPONSE. Tearing the upstream
+// socket down and trusting the existing error handler to notice is not enough:
+// `destroy()` is specified to emit 'close', an 'error' only follows in some
+// shapes, and on the WebSocket path the client just sees the TCP connection
+// vanish (a bare 1006, no status). Silence is the very symptom these timeouts
+// exist to remove, so every timeout path below writes its own status FIRST and
+// tears the socket down after.
+function envMs(name, fallback) {
+  const raw = Number.parseInt(process.env[name] || "", 10);
+  return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
+}
+const UPSTREAM_HEADERS_TIMEOUT_MS = envMs("HERMES_DASH_UPSTREAM_TIMEOUT_MS", 30_000);
+const LOGIN_TIMEOUT_MS = envMs("HERMES_DASH_LOGIN_TIMEOUT_MS", 10_000);
+const WS_HANDSHAKE_TIMEOUT_MS = envMs("HERMES_DASH_WS_TIMEOUT_MS", 15_000);
+
 // Rewrite the origin part of a Referer to the upstream authority, keeping path.
 function rewriteReferer(value) {
   return typeof value === "string" ? value.replace(/^https?:\/\/[^/]+/i, UPSTREAM_ORIGIN) : value;
@@ -343,6 +378,17 @@ function hermesLogin() {
         });
       },
     );
+    // A dashboard that accepts the connection and never answers would otherwise
+    // pin `loginInFlight` forever, and EVERY request that needs SSO awaits that
+    // same promise — one wedged login would stall the whole proxy. Resolving
+    // null here feeds the existing failure path: cooldown, then retry.
+    if (LOGIN_TIMEOUT_MS > 0) {
+      reqUp.setTimeout(LOGIN_TIMEOUT_MS, () => {
+        console.error(`[hermes-dashboard-proxy] login timed out after ${LOGIN_TIMEOUT_MS}ms`);
+        reqUp.destroy();
+        resolve(null);
+      });
+    }
     reqUp.on("error", (e) => {
       console.error(`[hermes-dashboard-proxy] login error: ${e.message}`);
       resolve(null);
@@ -438,6 +484,10 @@ function forward(req, res, injected, bodyBuf, allowRelogin) {
   const upstream = http.request(
     { host: UPSTREAM_HOST, port: UPSTREAM_PORT, method: req.method, path: req.url, headers },
     (up) => {
+      // Headers are in — the upstream is alive. Disarm before piping: the
+      // response body may legitimately trickle (event stream, slow download),
+      // and an idle timer would sever it mid-transfer.
+      upstream.setTimeout(0);
       // The Hermes session was rejected (TTL elapsed, or the dashboard restarted
       // and rotated its signing secret) — re-broker once and replay.
       //
@@ -467,16 +517,45 @@ function forward(req, res, injected, bodyBuf, allowRelogin) {
       pipeResponse(res, up, injected);
     },
   );
-  upstream.on("error", () => {
-    // The socket can also error AFTER the response was fully piped and ended
-    // (aborted keep-alive, dashboard restart mid-stream). Writing then is a
-    // write-after-end, which Node raises as an 'error' event on the
-    // ServerResponse — unhandled, that is an uncaught exception, and this
-    // proxy is a single process, so it would take the whole service down.
+  // Answer the client with `status` unless the response is already under way.
+  //
+  // The socket can also error AFTER the response was fully piped and ended
+  // (aborted keep-alive, dashboard restart mid-stream). Writing then is a
+  // write-after-end, which Node raises as an 'error' event on the
+  // ServerResponse — unhandled, that is an uncaught exception, and this
+  // proxy is a single process, so it would take the whole service down.
+  //
+  // Also the reason both the timeout and the error path can fire for one
+  // request without doubling up: whichever lands first writes, the other
+  // returns here.
+  const failRequest = (status, message) => {
     if (res.writableEnded || res.destroyed) return;
-    if (!res.headersSent) res.writeHead(502, { "Content-Type": "text/plain" });
-    res.end("Hermes dashboard is not reachable.");
-  });
+    if (res.headersSent) {
+      res.end();
+      return;
+    }
+    res.writeHead(status, { "Content-Type": "text/plain", "Cache-Control": "no-store" });
+    res.end(message);
+  };
+
+  if (UPSTREAM_HEADERS_TIMEOUT_MS > 0) {
+    upstream.setTimeout(UPSTREAM_HEADERS_TIMEOUT_MS, () => {
+      // Respond FIRST, then tear down — never the other way round.
+      //
+      // `destroy()` with no argument is specified to emit 'close'; whether an
+      // 'error' ALSO reaches the handler below depends on how far the exchange
+      // got, and once a response is in flight it does not end the client's
+      // response at all, because pipe() does not propagate a source error to
+      // its destination. Leaving the teardown to speak for us is therefore a
+      // request that may hang — the exact symptom the timeout exists to stop.
+      // Writing the status here makes the outcome identical in every case, and
+      // 504 says "the dashboard went quiet" rather than the 502 an incidental
+      // socket error would report.
+      failRequest(504, "Hermes dashboard did not respond in time.");
+      upstream.destroy();
+    });
+  }
+  upstream.on("error", () => failRequest(502, "Hermes dashboard is not reachable."));
   // Sink for any late stream error on the client connection, same reasoning.
   res.on("error", () => {});
 
@@ -513,7 +592,7 @@ function pipeResponse(res, up, injected, extraSetCookies) {
   up.pipe(res);
 }
 
-const server = http.createServer((req, res) => {
+function handleRequest(req, res) {
   // Cross-origin / rebind check FIRST: everything below rewrites Host and
   // Origin to the upstream authority, which would otherwise disarm the
   // dashboard's own guard.
@@ -603,13 +682,13 @@ const server = http.createServer((req, res) => {
     });
     req.on("error", () => { try { res.destroy(); } catch {} });
   });
-});
+}
 
 // ---------------------------------------------------------------------------
 // WebSocket upgrades — same gate, inject SSO cookies, raw splice upstream.
 // ---------------------------------------------------------------------------
 
-server.on("upgrade", (req, clientSocket, head) => {
+function handleUpgrade(req, clientSocket, head) {
   // Same guard as the HTTP path — the upgrade handler below rewrites Host and
   // Origin to the upstream authority, so the dashboard's WS Origin check can't
   // protect us. A same-origin SPA upgrade sends Origin == this proxy's
@@ -626,6 +705,13 @@ server.on("upgrade", (req, clientSocket, head) => {
     return;
   }
   const proceed = (injected) => {
+    // Armed for TCP connect + the 101 handshake only. A dashboard that accepts
+    // the socket and never completes the upgrade would otherwise leave the
+    // browser's WebSocket pending indefinitely with no close frame; the client
+    // gets an explicit 504 instead. Disarmed on the upstream's first byte,
+    // because an established WebSocket is idle by design and an idle timer
+    // past that point would drop healthy connections.
+    let handshakeStarted = false;
     const upstream = net.connect(UPSTREAM_PORT, UPSTREAM_HOST, () => {
       const headerLines = [`${req.method} ${req.url} HTTP/1.1`];
       let cookieWritten = false;
@@ -653,8 +739,26 @@ server.on("upgrade", (req, clientSocket, head) => {
       if (head && head.length) upstream.write(head);
       clientSocket.pipe(upstream);
       upstream.pipe(clientSocket);
+      // Attached AFTER pipe() so the pipe is already consuming — both listeners
+      // are registered in this same synchronous block, so no byte is lost.
+      upstream.on("data", () => {
+        if (handshakeStarted) return;
+        handshakeStarted = true;
+        upstream.setTimeout(0);
+      });
     });
     const kill = () => { try { upstream.destroy(); } catch {} try { clientSocket.destroy(); } catch {} };
+    if (WS_HANDSHAKE_TIMEOUT_MS > 0) {
+      upstream.setTimeout(WS_HANDSHAKE_TIMEOUT_MS, () => {
+        if (handshakeStarted) return; // established WebSocket: idle is normal
+        // Same trap as the HTTP path, and here it is unambiguous: `kill` on its
+        // own drops the TCP connection with nothing written, so the browser
+        // reports a bare 1006 and no page can tell a wedged dashboard from a
+        // network blip. Write the status before tearing down.
+        try { clientSocket.write("HTTP/1.1 504 Gateway Timeout\r\nConnection: close\r\n\r\n"); } catch {}
+        kill();
+      });
+    }
     upstream.on("error", kill);
     clientSocket.on("error", kill);
   };
@@ -664,8 +768,31 @@ server.on("upgrade", (req, clientSocket, head) => {
   } else {
     ensureHermesCookies(false).then((injected) => proceed(injected));
   }
-});
+}
 
-server.listen(PORT, "0.0.0.0", () => {
-  console.log(`[hermes-dashboard-proxy] :${PORT} -> ${UPSTREAM_AUTHORITY} (clawbox_session gated, Hermes SSO)`);
-});
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+//
+// The server is BUILT here but only LISTENS under the main-module guard below.
+// Calling listen() at import time meant nothing could load this file to check
+// its behaviour without also binding :8090 — so the gate, the SSO broker and
+// the timeouts above shipped to devices with no test covering any of them.
+
+function createProxyServer() {
+  const srv = http.createServer(handleRequest);
+  srv.on("upgrade", handleUpgrade);
+  return srv;
+}
+
+function main() {
+  const srv = createProxyServer();
+  srv.listen(PORT, "0.0.0.0", () => {
+    console.log(`[hermes-dashboard-proxy] :${PORT} -> ${UPSTREAM_AUTHORITY} (clawbox_session gated, Hermes SSO)`);
+  });
+  return srv;
+}
+
+if (require.main === module) main();
+
+module.exports = { createProxyServer, handleRequest, handleUpgrade, main };

--- a/src/components/AppStore.tsx
+++ b/src/components/AppStore.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useCallback, useId, useRef, useMemo } from "react";
 import { useModalDialog } from "@/hooks/useModalDialog";
 import { useT } from "@/lib/i18n";
 import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR } from "@/lib/store-categories";
@@ -310,10 +310,13 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
   }, []);
 
   const dismissConfirmInstall = useCallback(() => setConfirmInstall(null), []);
-  // Focus containment for the install confirmation below. The hook has to be
-  // called unconditionally (rules of hooks) even though the dialog is
-  // conditionally rendered, hence the `open` flag rather than mounting the
-  // dialog as its own component.
+  // Generated, not hardcoded: dialogs on this desktop can stack, and two
+  // elements sharing an id would point aria-labelledby at whichever the
+  // browser found first.
+  const confirmTitleId = useId();
+  // Focus containment for the install confirmation below. `open` is the hook's
+  // normal contract for a dialog whose panel is rendered conditionally from a
+  // component that stays mounted — not a workaround for anything here.
   const confirmPanelRef = useModalDialog<HTMLDivElement>({
     open: confirmInstall !== null,
     onClose: dismissConfirmInstall,
@@ -453,13 +456,13 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
       onClick={dismissConfirmInstall}>
       <div
         ref={confirmPanelRef}
-        role="dialog" aria-modal="true" aria-labelledby="confirm-install-title"
+        role="dialog" aria-modal="true" aria-labelledby={confirmTitleId}
         className="bg-[#1a1e2e] border border-white/10 rounded-2xl p-6 max-w-sm mx-4 shadow-2xl" onClick={e => e.stopPropagation()}>
         <div className="flex items-center gap-3 mb-4">
           <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ backgroundColor: BRAND_ORANGE }}>
             <span className="material-symbols-rounded text-white" style={{ fontSize: 22 }} aria-hidden="true">download</span>
           </div>
-          <h3 id="confirm-install-title" className="text-lg font-semibold">{t("store.confirmTitle", { name: confirmInstall.name })}</h3>
+          <h3 id={confirmTitleId} className="text-lg font-semibold">{t("store.confirmTitle", { name: confirmInstall.name })}</h3>
         </div>
         <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 mb-4">
           <div className="flex gap-2">

--- a/src/components/AppStore.tsx
+++ b/src/components/AppStore.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useModalDialog } from "@/hooks/useModalDialog";
 import { useT } from "@/lib/i18n";
 import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR } from "@/lib/store-categories";
 
@@ -308,6 +309,16 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
     setConfirmInstall(app);
   }, []);
 
+  const dismissConfirmInstall = useCallback(() => setConfirmInstall(null), []);
+  // Focus containment for the install confirmation below. The hook has to be
+  // called unconditionally (rules of hooks) even though the dialog is
+  // conditionally rendered, hence the `open` flag rather than mounting the
+  // dialog as its own component.
+  const confirmPanelRef = useModalDialog<HTMLDivElement>({
+    open: confirmInstall !== null,
+    onClose: dismissConfirmInstall,
+  });
+
   const handleInstall = useCallback(async (app: StoreApp) => {
     setConfirmInstall(null);
     setInstallProgress(prev => ({ ...prev, [app.id]: { appId: app.id, status: "installing" } }));
@@ -429,22 +440,30 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
     );
   };
 
-  // Install confirmation modal — shared across all views
+  // Install confirmation modal — shared across all views.
+  //
+  // The dialog role sits on the PANEL, not on the full-screen backdrop: on the
+  // backdrop the accessible dialog is the entire viewport and its accessible
+  // name absorbs everything behind the scrim. Escape used to be an onKeyDown on
+  // that same backdrop div, which never fired — a div is not focusable, so the
+  // key event was never routed to it. useModalDialog owns Escape, the Tab
+  // cycle, focus-in on open and focus-restore on close.
   const confirmModal = confirmInstall && (
     <div className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/60 backdrop-blur-sm"
-      onClick={() => setConfirmInstall(null)}
-      onKeyDown={e => { if (e.key === 'Escape') setConfirmInstall(null); }}
-      role="dialog" aria-modal="true" aria-labelledby="confirm-install-title">
-      <div className="bg-[#1a1e2e] border border-white/10 rounded-2xl p-6 max-w-sm mx-4 shadow-2xl" onClick={e => e.stopPropagation()}>
+      onClick={dismissConfirmInstall}>
+      <div
+        ref={confirmPanelRef}
+        role="dialog" aria-modal="true" aria-labelledby="confirm-install-title"
+        className="bg-[#1a1e2e] border border-white/10 rounded-2xl p-6 max-w-sm mx-4 shadow-2xl" onClick={e => e.stopPropagation()}>
         <div className="flex items-center gap-3 mb-4">
           <div className="w-10 h-10 rounded-xl flex items-center justify-center" style={{ backgroundColor: BRAND_ORANGE }}>
-            <span className="material-symbols-rounded text-white" style={{ fontSize: 22 }}>download</span>
+            <span className="material-symbols-rounded text-white" style={{ fontSize: 22 }} aria-hidden="true">download</span>
           </div>
           <h3 id="confirm-install-title" className="text-lg font-semibold">{t("store.confirmTitle", { name: confirmInstall.name })}</h3>
         </div>
         <div className="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-3 mb-4">
           <div className="flex gap-2">
-            <span className="material-symbols-rounded text-yellow-400 shrink-0" style={{ fontSize: 18 }}>warning</span>
+            <span className="material-symbols-rounded text-yellow-400 shrink-0" style={{ fontSize: 18 }} aria-hidden="true">warning</span>
             <p className="text-sm text-yellow-200/80">
               {t("store.confirmMessage")}
             </p>
@@ -452,12 +471,14 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
         </div>
         <div className="flex gap-3 justify-end">
           <button
-            onClick={() => setConfirmInstall(null)}
+            type="button"
+            onClick={dismissConfirmInstall}
             className="px-4 py-2 rounded-lg text-sm text-white/60 hover:text-white hover:bg-white/10 transition-colors cursor-pointer"
           >
             {t("cancel")}
           </button>
           <button
+            type="button"
             onClick={() => handleInstall(confirmInstall)}
             className="px-4 py-2 rounded-lg text-sm font-medium text-white transition-colors cursor-pointer"
             style={{ backgroundColor: BRAND_ORANGE }}

--- a/src/components/ClawBoxLoginModal.tsx
+++ b/src/components/ClawBoxLoginModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useModalDialog } from "@/hooks/useModalDialog";
 import { PORTAL_LOGIN_URL } from "@/lib/max-subscription";
 
 // Reusable "Sign in to ClawBox" modal. Surfaced when a user tries to use a
@@ -36,24 +36,11 @@ const COPY: Record<ClawBoxLoginFeature, { title: string; body: string }> = {
 };
 
 export default function ClawBoxLoginModal({ open, onClose, feature = "generic" }: Props) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-
-  // Esc closes; focus trap is intentionally light (single primary button).
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener("keydown", onKey);
-    // Defer the focus to next tick so the button is mounted.
-    requestAnimationFrame(() => {
-      dialogRef.current?.querySelector<HTMLButtonElement>("[data-primary]")?.focus();
-    });
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+  // Escape, focus-in, the Tab cycle and focus-restore all come from the shared
+  // hook. The trap used to be "intentionally light" — no trap at all, in
+  // practice: Tab walked straight out of the modal onto the page behind it, so
+  // a keyboard user could not reliably get back to "Open ClawBox Portal".
+  const dialogRef = useModalDialog<HTMLDivElement>({ open, onClose });
 
   if (!open) return null;
 
@@ -62,13 +49,13 @@ export default function ClawBoxLoginModal({ open, onClose, feature = "generic" }
   return (
     <div
       className="fixed inset-0 z-[100000] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="clawbox-login-title"
       onClick={onClose}
     >
       <div
         ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="clawbox-login-title"
         onClick={(e) => e.stopPropagation()}
         className="w-full max-w-md rounded-2xl border border-white/10 bg-[#0f1219] p-6 shadow-2xl"
       >

--- a/src/components/ClawBoxLoginModal.tsx
+++ b/src/components/ClawBoxLoginModal.tsx
@@ -76,7 +76,6 @@ export default function ClawBoxLoginModal({ open, onClose, feature = "generic" }
         </div>
         <div className="flex flex-col gap-2">
           <a
-            data-primary
             href={PORTAL_LOGIN_URL}
             target="_blank"
             rel="noopener noreferrer"

--- a/src/components/SystemUpdateApp.tsx
+++ b/src/components/SystemUpdateApp.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useModalDialog } from "@/hooks/useModalDialog";
 import type { StepStatus, UpdateState } from "@/lib/updater";
 import { RESTART_STEP_ID } from "@/lib/update-constants";
 import { cleanVersion } from "@/lib/version-utils";
@@ -580,6 +581,10 @@ export default function SystemUpdateApp() {
 // Shared confirmation dialog. Focuses Cancel on open (so a stray Enter can't
 // confirm a destructive action), closes on Escape, and traps Tab focus within
 // the dialog — the keyboard-nav behavior CLAUDE.md requires of modals.
+//
+// That behaviour now comes from useModalDialog rather than a second copy of it
+// here, which also gets this dialog the two things the local copy lacked:
+// focus returns to the trigger on close, and the page behind goes inert.
 function ConfirmModal({
   titleId,
   title,
@@ -597,46 +602,19 @@ function ConfirmModal({
   onCancel: () => void;
   children: ReactNode;
 }) {
-  const dialogRef = useRef<HTMLDivElement>(null);
-  const cancelRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    cancelRef.current?.focus();
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onCancel();
-        return;
-      }
-      if (e.key !== "Tab") return;
-      const focusables = dialogRef.current?.querySelectorAll<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
-      );
-      if (!focusables || focusables.length === 0) return;
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      if (e.shiftKey && document.activeElement === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && document.activeElement === last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onCancel]);
+  // Cancel is first in DOM order, so the shared trap lands there on open.
+  const dialogRef = useModalDialog<HTMLDivElement>({ onClose: onCancel });
 
   return (
     <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
       className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/70 backdrop-blur-sm"
       onClick={onCancel}
     >
       <div
         ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
         className="w-full max-w-md rounded-2xl border border-white/10 bg-[var(--bg-deep)] shadow-2xl overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
@@ -651,7 +629,6 @@ function ConfirmModal({
         </div>
         <div className="flex justify-end gap-2 px-5 pb-5 pt-2 border-t border-white/5">
           <button
-            ref={cancelRef}
             type="button"
             onClick={onCancel}
             className="px-4 py-2 rounded-lg text-sm font-medium border border-white/10 text-gray-200 hover:bg-white/5 cursor-pointer"

--- a/src/components/TierUpgradeCelebration.tsx
+++ b/src/components/TierUpgradeCelebration.tsx
@@ -156,17 +156,31 @@ export default function TierUpgradeCelebration() {
 
   const contentKey: ContentKey = dialog.kind === "upgrade" ? dialog.tier : "free";
   const content = CONTENT[contentKey];
+  // No `autoFocus` in either branch: useModalDialog focuses the first focusable
+  // control in DOM order, and React applies autoFocus during commit — before
+  // effects — so the hook would win and leave the attribute lying about who
+  // gets focus. DOM order is therefore the only knob, and it is used below.
   const primary = dialog.kind === "upgrade" ? (
     <button
       type="button"
       onClick={onClose}
-      autoFocus
       className="inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl btn-gradient text-sm font-medium text-white cursor-pointer w-full"
     >
       {t("tierCelebration.upgradeCta")}
     </button>
   ) : (
-    <div className="flex flex-col gap-2">
+    // Dismiss FIRST in DOM order so the trap opens on it rather than on a link
+    // that leaves the device for the billing portal in a new tab.
+    // `flex-col-reverse` renders the first child last, so the paid CTA still
+    // sits on top visually — the layout is unchanged, only the focus order.
+    <div className="flex flex-col-reverse gap-2">
+      <button
+        type="button"
+        onClick={onClose}
+        className="px-4 py-2 rounded-xl text-sm text-white/60 hover:text-white/85 hover:bg-white/[0.04] cursor-pointer"
+      >
+        {t("tierCelebration.freeCta")}
+      </button>
       <a
         href={PORTAL_DASHBOARD_URL}
         target="_blank"
@@ -177,14 +191,6 @@ export default function TierUpgradeCelebration() {
         <span className="material-symbols-rounded" style={{ fontSize: 18 }}>open_in_new</span>
         {t("tierCelebration.resubscribe")}
       </a>
-      <button
-        type="button"
-        onClick={onClose}
-        autoFocus
-        className="px-4 py-2 rounded-xl text-sm text-white/60 hover:text-white/85 hover:bg-white/[0.04] cursor-pointer"
-      >
-        {t("tierCelebration.freeCta")}
-      </button>
     </div>
   );
 

--- a/src/components/TierUpgradeCelebration.tsx
+++ b/src/components/TierUpgradeCelebration.tsx
@@ -7,6 +7,7 @@ import {
   type MouseEvent,
   type ReactNode,
 } from "react";
+import { useModalDialog } from "@/hooks/useModalDialog";
 import { useClawboxLogin } from "@/lib/use-clawbox-login";
 import { useT } from "@/lib/i18n";
 import { PORTAL_DASHBOARD_URL } from "@/lib/max-subscription";
@@ -215,15 +216,13 @@ function CelebrationShell({ tone, badge, headline, body, primary, onClose }: She
   const titleId = useId();
   const descriptionId = useId();
 
-  // Esc closes — standard modal a11y. Listener mounts only while
-  // the dialog is rendered (parent gates with `if (!dialog) return null`).
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [onClose]);
+  // Esc, focus-in, the Tab cycle and focus-restore all come from the shared
+  // hook. Esc alone was not enough: this dialog interrupts the desktop
+  // unprompted, so a keyboard user who never touched it had focus still parked
+  // somewhere behind the scrim, with nothing to tell them the dialog was there
+  // and no reliable way to Tab to its dismiss button.
+  // Mounted only while the dialog is up (parent gates with `if (!dialog) return null`).
+  const panelRef = useModalDialog<HTMLDivElement>({ onClose });
 
   const glowClass = tone === "paid"
     ? "drop-shadow-[0_0_18px_rgba(217,70,239,0.6)]"
@@ -242,13 +241,16 @@ function CelebrationShell({ tone, badge, headline, body, primary, onClose }: She
   return (
     <div
       className="fixed inset-0 z-[100001] flex items-center justify-center bg-black/70 backdrop-blur-sm p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-      aria-describedby={descriptionId}
       onClick={onOverlayClick}
     >
-      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-[#0f1219] p-6 shadow-2xl text-center">
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        className="w-full max-w-md rounded-2xl border border-white/10 bg-[#0f1219] p-6 shadow-2xl text-center"
+      >
         <div className="flex flex-col items-center gap-4 mb-5">
           <img
             src="/clawbox-crab.png"

--- a/src/components/hermes-skills/ConfirmDialog.tsx
+++ b/src/components/hermes-skills/ConfirmDialog.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { type ReactNode, useEffect, useRef } from 'react';
+import { type ReactNode } from 'react';
+import { useModalDialog } from '@/hooks/useModalDialog';
 import { COPY } from './copy';
 import { FOCUS_RING } from './primitives';
 
 // One accessible modal for both install and uninstall confirmation.
 //
-// The desktop's other stores each hand-roll this and each miss something, so the
-// three things that actually matter are done once here: the dialog role lives on
-// the PANEL (not the backdrop, which would make the backdrop the accessible
-// dialog), focus moves in on open and is restored on close, and Tab is trapped
-// between the two buttons instead of walking the page behind the overlay.
+// The three things that actually matter — the dialog role on the PANEL (not the
+// backdrop, which would make the backdrop the accessible dialog), focus moving
+// in on open and restored on close, and Tab trapped inside instead of walking
+// the page behind the overlay — now live in useModalDialog, so the app store
+// and the rest of the desktop share exactly this behaviour.
 
 export function ConfirmDialog({
   title,
@@ -29,50 +30,9 @@ export function ConfirmDialog({
   onCancel: () => void;
   children: ReactNode;
 }) {
-  const cancelRef = useRef<HTMLButtonElement>(null);
-  const confirmRef = useRef<HTMLButtonElement>(null);
-  const restoreRef = useRef<HTMLElement | null>(null);
-  // The handler is read through a ref so the trap below can run ONCE. Keying
-  // the effect on the prop re-ran it on every parent render — and the parent
-  // re-renders under the open dialog while the detail fetch resolves, which
-  // pulled focus back to Cancel mid-Tab and corrupted the restore target.
-  const cancelHandler = useRef(onCancel);
-  useEffect(() => {
-    cancelHandler.current = onCancel;
-  }, [onCancel]);
-
-  useEffect(() => {
-    restoreRef.current = document.activeElement as HTMLElement | null;
-    cancelRef.current?.focus();
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.stopPropagation();
-        cancelHandler.current();
-        return;
-      }
-      if (e.key !== 'Tab') return;
-      const first = cancelRef.current;
-      const last = confirmRef.current;
-      if (!first || !last) return;
-      const active = document.activeElement;
-      if (e.shiftKey && active === first) {
-        e.preventDefault();
-        last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
-        first.focus();
-      } else if (active !== first && active !== last) {
-        e.preventDefault();
-        first.focus();
-      }
-    };
-    document.addEventListener('keydown', onKeyDown, true);
-    return () => {
-      document.removeEventListener('keydown', onKeyDown, true);
-      restoreRef.current?.focus?.();
-    };
-    // Mount/unmount only — see cancelHandler above.
-  }, []);
+  // Cancel is first in DOM order, so the shared trap focuses it on open — a
+  // stray Enter cannot confirm an install the user never read.
+  const panelRef = useModalDialog<HTMLDivElement>({ onClose: onCancel });
 
   return (
     <div
@@ -80,6 +40,7 @@ export function ConfirmDialog({
       onClick={onCancel}
     >
       <div
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="hs-dialog-title"
@@ -105,7 +66,6 @@ export function ConfirmDialog({
 
         <div className="flex gap-3 justify-end">
           <button
-            ref={cancelRef}
             type="button"
             onClick={onCancel}
             className={`px-4 py-2 rounded-lg text-sm text-[var(--text-secondary)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-card)] transition-colors ${FOCUS_RING}`}
@@ -113,7 +73,6 @@ export function ConfirmDialog({
             {COPY.cancel}
           </button>
           <button
-            ref={confirmRef}
             type="button"
             onClick={onConfirm}
             className={`px-4 py-2 rounded-lg text-sm font-semibold text-white transition-opacity hover:opacity-90 ${FOCUS_RING} ${

--- a/src/hooks/useModalDialog.ts
+++ b/src/hooks/useModalDialog.ts
@@ -1,0 +1,201 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+
+// One modal-dialog behaviour for the whole desktop.
+//
+// Every overlay on the device used to hand-roll this and each one missed
+// something different: the app store's install confirmation never moved focus
+// in at all (so a keyboard user tabbed straight through it into the page
+// behind and could not reach "Install anyway"), the sign-in and upgrade
+// modals moved focus in but never trapped or restored it, and the system
+// update dialog had a working trap that nothing else could reuse. This hook is
+// that trap, extracted from the Hermes skills store's ConfirmDialog — the one
+// implementation that was already correct — so there is a single place to fix.
+//
+// What a caller gets by attaching the returned ref to the dialog PANEL:
+//   - focus moves into the panel on open, and back to the trigger on close
+//   - Tab / Shift-Tab cycle inside the panel instead of walking the page
+//   - Escape closes (and stops there, so the window behind doesn't also close)
+//   - everything outside the panel is `inert` + `aria-hidden` while it is open
+//
+// The caller still owns the markup: put `role="dialog"` (or `alertdialog`),
+// `aria-modal="true"` and an `aria-labelledby` on the same element the ref is
+// attached to. The role belongs on the panel, not on the full-screen backdrop —
+// on the backdrop the accessible dialog would be the whole viewport, and its
+// accessible name would swallow every bit of text behind the scrim.
+
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "area[href]",
+  "button:not([disabled])",
+  "input:not([disabled]):not([type='hidden'])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "iframe",
+  "[contenteditable='true']",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+/** Focusable descendants, in DOM order, skipping anything hidden or inert. */
+function focusableWithin(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
+    if (el.hasAttribute("disabled") || el.getAttribute("aria-hidden") === "true") return false;
+    if (el.hidden || el.closest("[hidden], [inert]") !== null) return false;
+    // Layout-aware check where the engine offers one. `visibilityProperty`
+    // adds `visibility: hidden` to the default display/content-visibility
+    // checks; opacity is deliberately NOT included, since a 0-opacity control
+    // is still focusable and still reachable by a screen reader.
+    //
+    // jsdom has no layout and does not implement checkVisibility, so under test
+    // every control counts — which is what we want: a layout heuristic there
+    // would filter the whole dialog away and silently make the trap untestable.
+    if (typeof el.checkVisibility === "function" && !el.checkVisibility({ visibilityProperty: true })) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Hide everything outside `panel` from assistive tech and from the tab order.
+ *
+ * Walks from the panel up to <body>, marking each ancestor's siblings rather
+ * than only the top-level children of <body>: these dialogs render inline in
+ * the React tree (not through a portal), so the page behind them is a sibling
+ * several levels down, not a sibling of the app root.
+ *
+ * Returns an undo function. Previous attribute values are captured per element
+ * so nesting one dialog inside another restores correctly on the way out.
+ */
+function hideOutside(panel: HTMLElement): () => void {
+  const touched: { el: Element; inert: string | null; ariaHidden: string | null }[] = [];
+  let node: Element | null = panel;
+  while (node && node.parentElement && node !== document.body) {
+    for (const sibling of Array.from(node.parentElement.children)) {
+      if (sibling === node) continue;
+      // Scripts and style tags are not in the a11y tree; marking them is noise.
+      const tag = sibling.tagName;
+      if (tag === "SCRIPT" || tag === "STYLE" || tag === "LINK") continue;
+      touched.push({
+        el: sibling,
+        inert: sibling.getAttribute("inert"),
+        ariaHidden: sibling.getAttribute("aria-hidden"),
+      });
+      sibling.setAttribute("inert", "");
+      sibling.setAttribute("aria-hidden", "true");
+    }
+    node = node.parentElement;
+  }
+  return () => {
+    // Reverse order so a nested dialog's undo runs before the outer one's.
+    for (let i = touched.length - 1; i >= 0; i--) {
+      const { el, inert, ariaHidden } = touched[i];
+      if (inert === null) el.removeAttribute("inert");
+      else el.setAttribute("inert", inert);
+      if (ariaHidden === null) el.removeAttribute("aria-hidden");
+      else el.setAttribute("aria-hidden", ariaHidden);
+    }
+  };
+}
+
+export interface ModalDialogOptions {
+  /** Whether the dialog is currently rendered. Defaults to true. */
+  open?: boolean;
+  /** Called on Escape. Also used as the "dismiss" action for the trap. */
+  onClose: () => void;
+}
+
+/**
+ * Wire up focus containment for a modal dialog.
+ *
+ * @returns a ref to attach to the dialog panel element.
+ */
+export function useModalDialog<T extends HTMLElement = HTMLDivElement>({
+  open = true,
+  onClose,
+}: ModalDialogOptions): RefObject<T | null> {
+  const panelRef = useRef<T>(null);
+  // The close handler is read through a ref so the effect below can key on
+  // `open` alone. Keying it on the callback re-ran the whole setup on every
+  // parent render — and these parents DO re-render under an open dialog (the
+  // app store resolves its detail fetch while the confirmation is up), which
+  // yanked focus back to the first control mid-Tab and overwrote the element
+  // we were meant to restore focus to on close.
+  const closeRef = useRef(onClose);
+  useEffect(() => {
+    closeRef.current = onClose;
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) return;
+    const panel = panelRef.current;
+    if (!panel) return;
+
+    const restoreTarget = document.activeElement as HTMLElement | null;
+
+    // Move focus in. If the dialog has no focusable control (a progress-only
+    // overlay), focus the panel itself so the trap still has an anchor and the
+    // screen reader lands on the dialog's label rather than on the page behind.
+    const initial = focusableWithin(panel)[0];
+    if (initial) {
+      initial.focus();
+    } else {
+      if (!panel.hasAttribute("tabindex")) panel.setAttribute("tabindex", "-1");
+      panel.focus();
+    }
+
+    const undoHide = hideOutside(panel);
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        // Stop here: the window/app behind must not also act on this Escape.
+        e.preventDefault();
+        e.stopPropagation();
+        closeRef.current();
+        return;
+      }
+      if (e.key !== "Tab") return;
+
+      // Recomputed per keystroke — dialog contents change while open (a button
+      // becomes disabled mid-install, a details block expands).
+      const focusables = focusableWithin(panel);
+      if (focusables.length === 0) {
+        e.preventDefault();
+        panel.focus();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement;
+
+      if (!panel.contains(active)) {
+        // Focus escaped (a click on the backdrop, or a browser chrome round
+        // trip). Pull it back rather than letting Tab continue outside.
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+        return;
+      }
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    // Capture phase: the dialog must see Tab/Escape before any handler further
+    // down (or any bubble-phase listener on window) gets a chance to act.
+    document.addEventListener("keydown", onKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      undoHide();
+      // Restore focus to whatever opened the dialog. `isConnected` guards the
+      // case where the trigger itself was removed by the action just taken.
+      if (restoreTarget && restoreTarget.isConnected) restoreTarget.focus?.();
+    };
+  }, [open]);
+
+  return panelRef;
+}

--- a/src/hooks/useModalDialog.ts
+++ b/src/hooks/useModalDialog.ts
@@ -37,8 +37,12 @@ const FOCUSABLE_SELECTOR = [
   "select",
   "textarea",
   "iframe",
-  "[contenteditable='true']",
-  "[tabindex]:not([tabindex='-1'])",
+  // Broad on purpose — the effective state is decided in the filter, not here.
+  // `[contenteditable='true']` alone missed the equally-editable `""` and
+  // `"plaintext-only"`, and `[tabindex]:not([tabindex='-1'])` still matched
+  // `tabindex="-2"`, which is not focusable either.
+  "[contenteditable]",
+  "[tabindex]",
 ].join(",");
 
 /**
@@ -50,10 +54,22 @@ const FOCUSABLE_SELECTOR = [
  */
 export function focusableWithin(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
-    if (el.hasAttribute("disabled") || el.getAttribute("aria-hidden") === "true") return false;
-    // `closest` covers the element itself, and `hidden` reflects to the
-    // attribute, so this one test catches both self and ancestor.
-    if (el.closest("[hidden], [inert]") !== null) return false;
+    // `:disabled` also catches a control disabled by an ancestor <fieldset>,
+    // which the attribute check alone misses.
+    if (el.hasAttribute("disabled") || el.matches(":disabled")) return false;
+    // Any negative tabindex is out of the tab order, not just -1.
+    if (el.hasAttribute("tabindex") && el.tabIndex < 0) return false;
+    // `contenteditable` is editable at "", "true" and "plaintext-only"; only an
+    // explicit "false" opts out. Read from the attribute rather than
+    // `isContentEditable`, which jsdom does not implement.
+    if (el.hasAttribute("contenteditable")) {
+      const mode = (el.getAttribute("contenteditable") || "").toLowerCase();
+      if (mode === "false") return false;
+    }
+    // `closest` covers the element itself, so one test catches both an element
+    // that is hidden/inert/aria-hidden and one nested inside such a subtree —
+    // focus must never land on content excluded from the accessibility tree.
+    if (el.closest('[hidden], [inert], [aria-hidden="true"]') !== null) return false;
     // Capability check, not an environment check: `checkVisibility` is CSSOM-View
     // and needs a layout engine. `visibilityProperty` adds `visibility: hidden`
     // to the default display/content-visibility tests; opacity is deliberately

--- a/src/hooks/useModalDialog.ts
+++ b/src/hooks/useModalDialog.ts
@@ -25,31 +25,44 @@ import { useEffect, useRef, type RefObject } from "react";
 // on the backdrop the accessible dialog would be the whole viewport, and its
 // accessible name would swallow every bit of text behind the scrim.
 
+// Candidate types only — `disabled`, `hidden` and `inert` are all filtered
+// below rather than encoded here, so the rule for "can this take focus" lives
+// in exactly one place. (The selector form would also miss a `[tabindex]`
+// element carrying `disabled`.)
 const FOCUSABLE_SELECTOR = [
   "a[href]",
   "area[href]",
-  "button:not([disabled])",
-  "input:not([disabled]):not([type='hidden'])",
-  "select:not([disabled])",
-  "textarea:not([disabled])",
+  "button",
+  "input:not([type='hidden'])",
+  "select",
+  "textarea",
   "iframe",
   "[contenteditable='true']",
   "[tabindex]:not([tabindex='-1'])",
 ].join(",");
 
-/** Focusable descendants, in DOM order, skipping anything hidden or inert. */
-function focusableWithin(container: HTMLElement): HTMLElement[] {
+/**
+ * Focusable descendants, in DOM order, skipping anything hidden or inert.
+ *
+ * Exported for its own unit tests: the visibility branch below cannot be
+ * reached through the React components, because the engine that implements
+ * `checkVisibility` is the one the component tests do not run in.
+ */
+export function focusableWithin(container: HTMLElement): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
     if (el.hasAttribute("disabled") || el.getAttribute("aria-hidden") === "true") return false;
-    if (el.hidden || el.closest("[hidden], [inert]") !== null) return false;
-    // Layout-aware check where the engine offers one. `visibilityProperty`
-    // adds `visibility: hidden` to the default display/content-visibility
-    // checks; opacity is deliberately NOT included, since a 0-opacity control
-    // is still focusable and still reachable by a screen reader.
+    // `closest` covers the element itself, and `hidden` reflects to the
+    // attribute, so this one test catches both self and ancestor.
+    if (el.closest("[hidden], [inert]") !== null) return false;
+    // Capability check, not an environment check: `checkVisibility` is CSSOM-View
+    // and needs a layout engine. `visibilityProperty` adds `visibility: hidden`
+    // to the default display/content-visibility tests; opacity is deliberately
+    // excluded, since a 0-opacity control is still focusable and still reachable
+    // by a screen reader.
     //
-    // jsdom has no layout and does not implement checkVisibility, so under test
-    // every control counts — which is what we want: a layout heuristic there
-    // would filter the whole dialog away and silently make the trap untestable.
+    // Consequence worth knowing: jsdom does not implement it, so this filter is
+    // inert under the component tests and every control there counts. That is
+    // why it has direct unit tests with a stubbed implementation.
     if (typeof el.checkVisibility === "function" && !el.checkVisibility({ visibilityProperty: true })) {
       return false;
     }
@@ -65,8 +78,9 @@ function focusableWithin(container: HTMLElement): HTMLElement[] {
  * the React tree (not through a portal), so the page behind them is a sibling
  * several levels down, not a sibling of the app root.
  *
- * Returns an undo function. Previous attribute values are captured per element
- * so nesting one dialog inside another restores correctly on the way out.
+ * Returns an undo function. Each element's prior attribute values are captured
+ * and put back, rather than blindly removed, so a dialog opened over another
+ * dialog does not strip the outer one's marking when it closes.
  */
 function hideOutside(panel: HTMLElement): () => void {
   const touched: { el: Element; inert: string | null; ariaHidden: string | null }[] = [];
@@ -88,9 +102,9 @@ function hideOutside(panel: HTMLElement): () => void {
     node = node.parentElement;
   }
   return () => {
-    // Reverse order so a nested dialog's undo runs before the outer one's.
-    for (let i = touched.length - 1; i >= 0; i--) {
-      const { el, inert, ariaHidden } = touched[i];
+    // Order is irrelevant: each level's siblings are disjoint from the next
+    // level's (which are their ancestors), so no element appears twice.
+    for (const { el, inert, ariaHidden } of touched) {
       if (inert === null) el.removeAttribute("inert");
       else el.setAttribute("inert", inert);
       if (ariaHidden === null) el.removeAttribute("aria-hidden");
@@ -99,8 +113,26 @@ function hideOutside(panel: HTMLElement): () => void {
   };
 }
 
+// Open dialogs, oldest first. Only the last entry reacts to keys.
+//
+// Dialogs on this desktop DO stack: TierUpgradeCelebration mounts from the
+// page shell independently of any window, and the sign-in modal can open over
+// ClawKeep or Remote Control. Each open dialog adds its own capture listener
+// to `document`, and stopPropagation() does not stop the OTHER listeners
+// already registered on that same node — so without this, one Escape closed
+// every open dialog at once, and the older dialog's Tab handler yanked focus
+// out of the newer panel it was supposed to be trapped in.
+const openPanels: HTMLElement[] = [];
+
 export interface ModalDialogOptions {
-  /** Whether the dialog is currently rendered. Defaults to true. */
+  /**
+   * Whether the dialog is currently rendered. Defaults to true.
+   *
+   * This is the normal contract, not a workaround: a modal that stays mounted
+   * and self-gates (`if (!open) return null`) is the dominant React shape, and
+   * two of this hook's callers are written that way. Callers that mount and
+   * unmount the dialog outright can leave it alone.
+   */
   open?: boolean;
   /** Called on Escape. Also used as the "dismiss" action for the trap. */
   onClose: () => void;
@@ -130,9 +162,21 @@ export function useModalDialog<T extends HTMLElement = HTMLDivElement>({
   useEffect(() => {
     if (!open) return;
     const panel = panelRef.current;
-    if (!panel) return;
+    if (!panel) {
+      // Silence here would mean a dialog with no trap and no signal — the worst
+      // failure mode for a11y infrastructure. Callers must render the panel in
+      // the same commit that flips `open`; one that gates its panel behind an
+      // inner loading state has to keep `open` false until the panel exists.
+      if (process.env.NODE_ENV !== "production") {
+        console.error(
+          "useModalDialog: `open` is true but the panel ref is not attached — no focus trap is active.",
+        );
+      }
+      return;
+    }
 
     const restoreTarget = document.activeElement as HTMLElement | null;
+    openPanels.push(panel);
 
     // Move focus in. If the dialog has no focusable control (a progress-only
     // overlay), focus the panel itself so the trap still has an anchor and the
@@ -148,6 +192,9 @@ export function useModalDialog<T extends HTMLElement = HTMLDivElement>({
     const undoHide = hideOutside(panel);
 
     const onKeyDown = (e: KeyboardEvent) => {
+      // Only the topmost dialog reacts. A dialog underneath is already `inert`
+      // (the newer one marked it), so acting on keys would be wrong twice over.
+      if (openPanels[openPanels.length - 1] !== panel) return;
       if (e.key === "Escape") {
         // Stop here: the window/app behind must not also act on this Escape.
         e.preventDefault();
@@ -190,6 +237,8 @@ export function useModalDialog<T extends HTMLElement = HTMLDivElement>({
     document.addEventListener("keydown", onKeyDown, true);
     return () => {
       document.removeEventListener("keydown", onKeyDown, true);
+      const at = openPanels.lastIndexOf(panel);
+      if (at !== -1) openPanels.splice(at, 1);
       undoHide();
       // Restore focus to whatever opened the dialog. `isConnected` guards the
       // case where the trigger itself was removed by the action just taken.

--- a/src/tests/components/app-store-install-modal.test.tsx
+++ b/src/tests/components/app-store-install-modal.test.tsx
@@ -74,7 +74,7 @@ afterEach(() => {
 
 /** Open the confirmation from the store list and return its panel. */
 async function openInstallConfirmation() {
-  render(<AppStore installedAppIds={[]} onInstall={vi.fn()} onUninstall={vi.fn()} />);
+  const view = render(<AppStore installedAppIds={[]} onInstall={vi.fn()} onUninstall={vi.fn()} />);
 
   const installButton = await screen.findByRole("button", { name: "store.install" });
   // Focus the trigger the way a keyboard user would have, so the restore
@@ -85,7 +85,7 @@ async function openInstallConfirmation() {
   fireEvent.click(installButton);
 
   const panel = await screen.findByRole("dialog");
-  return { panel, installButton };
+  return { panel, installButton, unmount: view.unmount };
 }
 
 /** Every control the user can reach inside the dialog, in DOM order. */
@@ -136,8 +136,10 @@ describe("app store install confirmation — keyboard access", () => {
   it("pulls focus back in if it lands on the page behind the dialog", async () => {
     const { panel } = await openInstallConfirmation();
 
-    // The exact failure the trap exists to prevent: focus sitting on a store
-    // control behind the scrim while the dialog is open.
+    // Focus parked on a store control behind the scrim. A real browser would
+    // refuse this — the store is `inert` while the dialog is open — but jsdom
+    // does not implement `inert`, which makes it a convenient way to drive the
+    // recovery branch: whatever put focus out there, Tab must bring it back.
     const search = screen.getByPlaceholderText("store.searchApps");
     expect(panel.contains(search)).toBe(false);
     search.focus();
@@ -162,9 +164,14 @@ describe("app store install confirmation — keyboard access", () => {
     const { panel } = await openInstallConfirmation();
 
     expect(panel).toHaveAttribute("aria-modal", "true");
-    // The backdrop covers the viewport; had it carried the role, the accessible
-    // dialog would be the whole page and its name would absorb the store behind.
-    expect(panel.className).not.toContain("fixed inset-0");
+    // Asserted structurally rather than on class text: the role must sit on a
+    // CHILD of the full-screen backdrop. Had the backdrop carried it, the
+    // accessible dialog would be the whole page and its name would absorb the
+    // store behind it.
+    const backdrop = panel.parentElement as HTMLElement;
+    expect(backdrop).not.toHaveAttribute("role", "dialog");
+    expect(backdrop.contains(panel)).toBe(true);
+    expect(panel).not.toBe(backdrop);
     const title = document.getElementById(panel.getAttribute("aria-labelledby") as string);
     expect(title).toHaveTextContent("store.confirmTitle");
   });
@@ -185,6 +192,29 @@ describe("app store install confirmation — keyboard access", () => {
     await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
 
     for (const el of hiddenBehind) {
+      expect(el).not.toHaveAttribute("inert");
+      expect(el).not.toHaveAttribute("aria-hidden");
+    }
+  });
+
+  it("restores the page behind it when the dialog is torn down while still open", async () => {
+    // Closing is the easy path. The dangerous one is the whole tree going away
+    // with the dialog still up — a window closed, a route swapped, the app
+    // remounted. If the restore only ran on close, `inert` + `aria-hidden`
+    // would outlive the dialog and quietly make background content
+    // unreachable to assistive tech and to any role-based query.
+    const { panel, unmount } = await openInstallConfirmation();
+
+    const store = screen.getByTestId("app-store");
+    const hiddenBehind = Array.from(store.children).filter((el) => !el.contains(panel));
+    expect(hiddenBehind.length).toBeGreaterThan(0);
+    expect(hiddenBehind[0]).toHaveAttribute("aria-hidden", "true");
+    // Hold the nodes across the unmount so they can be inspected afterwards.
+    const detached = [...hiddenBehind];
+
+    unmount();
+
+    for (const el of detached) {
       expect(el).not.toHaveAttribute("inert");
       expect(el).not.toHaveAttribute("aria-hidden");
     }

--- a/src/tests/components/app-store-install-modal.test.tsx
+++ b/src/tests/components/app-store-install-modal.test.tsx
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import AppStore from "@/components/AppStore";
+
+/**
+ * Keyboard access to the app store's install confirmation.
+ *
+ * The dialog used to be unusable without a mouse. It never moved focus in, so
+ * focus stayed on the "Install" button BEHIND the scrim; Tab then walked the
+ * store's search box, sort menu and category tabs — every control the dialog
+ * was supposed to be blocking — and Escape was wired as an `onKeyDown` on the
+ * backdrop div, which is not focusable and therefore never received the key.
+ * A keyboard or screen-reader user could open the confirmation and had no
+ * reliable way to reach "Install anyway" or to dismiss it.
+ *
+ * These tests assert the behaviour, not the attributes: where focus actually
+ * lands after Tab, Shift-Tab and close.
+ *
+ * `useT` falls back to identity when no provider is mounted, so labels assert
+ * as their translation keys ("cancel", "store.installAnyway").
+ */
+
+const APP = {
+  name: "Weather Deck",
+  slug: "weather-deck",
+  summary: "Forecast cards for the desktop shell.",
+  category: "Utilities",
+  rating: 5,
+  installs: "2800+",
+  channel: "official",
+};
+
+const LIST = {
+  total: 1,
+  categories: [{ id: "Utilities", name: "Utilities", count: 1 }],
+  apps: [APP],
+};
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+  } as unknown as Response);
+}
+
+beforeEach(() => {
+  // The suite runs with `mockReset: true`, which strips the implementation off
+  // the shared IntersectionObserver stub in setup.ts before each test. The
+  // store observes a scroll sentinel on mount, so re-stub it here.
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith("/setup-api/apps/store")) return jsonResponse(LIST);
+      if (url.startsWith("/setup-api/apps/install")) return jsonResponse({ success: true });
+      return jsonResponse({});
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Open the confirmation from the store list and return its panel. */
+async function openInstallConfirmation() {
+  render(<AppStore installedAppIds={[]} onInstall={vi.fn()} onUninstall={vi.fn()} />);
+
+  const installButton = await screen.findByRole("button", { name: "store.install" });
+  // Focus the trigger the way a keyboard user would have, so the restore
+  // assertion below is about the dialog and not about jsdom's default.
+  installButton.focus();
+  expect(document.activeElement).toBe(installButton);
+
+  fireEvent.click(installButton);
+
+  const panel = await screen.findByRole("dialog");
+  return { panel, installButton };
+}
+
+/** Every control the user can reach inside the dialog, in DOM order. */
+function dialogButtons(panel: HTMLElement) {
+  return Array.from(panel.querySelectorAll("button"));
+}
+
+describe("app store install confirmation — keyboard access", () => {
+  it("moves focus into the dialog when it opens", async () => {
+    const { panel } = await openInstallConfirmation();
+
+    const [cancel] = dialogButtons(panel);
+    expect(document.activeElement).toBe(cancel);
+    expect(panel.contains(document.activeElement)).toBe(true);
+    // Cancel first, not the confirm: a stray Enter must not install an app the
+    // user has not read the warning for.
+    expect(cancel).toHaveTextContent("cancel");
+  });
+
+  it("wraps Tab from the last control back to the first instead of escaping the dialog", async () => {
+    const { panel } = await openInstallConfirmation();
+
+    const buttons = dialogButtons(panel);
+    const first = buttons[0];
+    const last = buttons[buttons.length - 1];
+    expect(first).not.toBe(last);
+
+    last.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(document.activeElement).toBe(first);
+    expect(panel.contains(document.activeElement)).toBe(true);
+  });
+
+  it("wraps Shift-Tab from the first control back to the last", async () => {
+    const { panel } = await openInstallConfirmation();
+
+    const buttons = dialogButtons(panel);
+    const first = buttons[0];
+    const last = buttons[buttons.length - 1];
+
+    first.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
+  });
+
+  it("pulls focus back in if it lands on the page behind the dialog", async () => {
+    const { panel } = await openInstallConfirmation();
+
+    // The exact failure the trap exists to prevent: focus sitting on a store
+    // control behind the scrim while the dialog is open.
+    const search = screen.getByPlaceholderText("store.searchApps");
+    expect(panel.contains(search)).toBe(false);
+    search.focus();
+
+    fireEvent.keyDown(document, { key: "Tab" });
+
+    expect(panel.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).toBe(dialogButtons(panel)[0]);
+  });
+
+  it("closes on Escape and returns focus to the control that opened it", async () => {
+    const { panel, installButton } = await openInstallConfirmation();
+    expect(panel).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    expect(document.activeElement).toBe(installButton);
+  });
+
+  it("labels the dialog and puts the role on the panel, not the full-screen backdrop", async () => {
+    const { panel } = await openInstallConfirmation();
+
+    expect(panel).toHaveAttribute("aria-modal", "true");
+    // The backdrop covers the viewport; had it carried the role, the accessible
+    // dialog would be the whole page and its name would absorb the store behind.
+    expect(panel.className).not.toContain("fixed inset-0");
+    const title = document.getElementById(panel.getAttribute("aria-labelledby") as string);
+    expect(title).toHaveTextContent("store.confirmTitle");
+  });
+
+  it("hides the page behind the dialog from assistive tech, and restores it on close", async () => {
+    const { panel } = await openInstallConfirmation();
+
+    // The store's own content is a sibling of the dialog's backdrop.
+    const store = screen.getByTestId("app-store");
+    const hiddenBehind = Array.from(store.children).filter((el) => !el.contains(panel));
+    expect(hiddenBehind.length).toBeGreaterThan(0);
+    for (const el of hiddenBehind) {
+      expect(el).toHaveAttribute("inert");
+      expect(el).toHaveAttribute("aria-hidden", "true");
+    }
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+
+    for (const el of hiddenBehind) {
+      expect(el).not.toHaveAttribute("inert");
+      expect(el).not.toHaveAttribute("aria-hidden");
+    }
+  });
+});

--- a/src/tests/components/focusable-within.test.tsx
+++ b/src/tests/components/focusable-within.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { focusableWithin } from "@/hooks/useModalDialog";
+
+/**
+ * Direct tests for the focus-trap's candidate filter.
+ *
+ * These exist because one branch of it is unreachable from the component
+ * tests: `checkVisibility()` is a CSSOM-View API that needs a layout engine,
+ * and jsdom does not implement it. On a real device that filter always runs;
+ * under the modal tests it never does. Stubbing the method here covers both
+ * sides, so the trap's only genuinely new logic is not shipped untested.
+ */
+
+function mount(html: string): HTMLElement {
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  document.body.appendChild(host);
+  return host;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+/** Give elements a checkVisibility() that reports the named ids as hidden. */
+function stubVisibility(hiddenIds: string[]) {
+  const proto = Element.prototype as unknown as { checkVisibility?: () => boolean };
+  const had = Object.prototype.hasOwnProperty.call(proto, "checkVisibility");
+  const original = proto.checkVisibility;
+  proto.checkVisibility = function (this: Element) {
+    return !hiddenIds.includes(this.id);
+  };
+  return () => {
+    if (had) proto.checkVisibility = original;
+    else delete proto.checkVisibility;
+  };
+}
+
+describe("focusableWithin", () => {
+  it("returns interactive descendants in DOM order", () => {
+    const host = mount(`
+      <button id="a">a</button>
+      <a id="b" href="#x">b</a>
+      <input id="c" />
+      <select id="d"></select>
+      <textarea id="e"></textarea>
+      <div id="f" tabindex="0">f</div>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  it("skips controls that cannot take focus", () => {
+    const host = mount(`
+      <button id="ok">ok</button>
+      <button id="disabled" disabled>no</button>
+      <input id="hiddenType" type="hidden" />
+      <button id="ariaHidden" aria-hidden="true">no</button>
+      <button id="nativelyHidden" hidden>no</button>
+      <div id="skipped" tabindex="-1">no</div>
+      <a id="noHref">no</a>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["ok"]);
+  });
+
+  it("skips anything inside an inert or hidden subtree", () => {
+    const host = mount(`
+      <button id="ok">ok</button>
+      <div inert><button id="inInert">no</button></div>
+      <div hidden><button id="inHidden">no</button></div>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["ok"]);
+  });
+
+  it("drops controls the engine reports as not visible", () => {
+    const host = mount(`
+      <button id="shown">shown</button>
+      <button id="invisible">invisible</button>
+    `);
+    const restore = stubVisibility(["invisible"]);
+    try {
+      // The production branch: with a layout engine present, a control the
+      // engine calls invisible must not become the trap's wrap target.
+      expect(focusableWithin(host).map((el) => el.id)).toEqual(["shown"]);
+    } finally {
+      restore();
+    }
+  });
+
+  it("keeps every control when the engine offers no visibility check", () => {
+    const host = mount(`
+      <button id="one">one</button>
+      <button id="two">two</button>
+    `);
+    // jsdom's own state — no checkVisibility — so nothing is filtered and the
+    // trap still has both ends to wrap between.
+    expect("checkVisibility" in Element.prototype).toBe(false);
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["one", "two"]);
+  });
+});

--- a/src/tests/components/focusable-within.test.tsx
+++ b/src/tests/components/focusable-within.test.tsx
@@ -64,11 +64,42 @@ describe("focusableWithin", () => {
     expect(focusableWithin(host).map((el) => el.id)).toEqual(["ok"]);
   });
 
-  it("skips anything inside an inert or hidden subtree", () => {
+  it("skips any negative tabindex, not just -1", () => {
+    const host = mount(`
+      <div id="ok" tabindex="0">ok</div>
+      <div id="minusOne" tabindex="-1">no</div>
+      <div id="minusTwo" tabindex="-2">no</div>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["ok"]);
+  });
+
+  it("treats a control disabled by an ancestor fieldset as unreachable", () => {
+    const host = mount(`
+      <button id="ok">ok</button>
+      <fieldset disabled><button id="inFieldset">no</button></fieldset>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["ok"]);
+  });
+
+  it("counts every editable contenteditable mode, and only skips an explicit false", () => {
+    const host = mount(`
+      <div id="empty" contenteditable="">yes</div>
+      <div id="true" contenteditable="true">yes</div>
+      <div id="plaintext" contenteditable="plaintext-only">yes</div>
+      <div id="off" contenteditable="false">no</div>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["empty", "true", "plaintext"]);
+  });
+
+  it("skips anything inside an inert, hidden, or aria-hidden subtree", () => {
     const host = mount(`
       <button id="ok">ok</button>
       <div inert><button id="inInert">no</button></div>
       <div hidden><button id="inHidden">no</button></div>
+      <div aria-hidden="true"><button id="inAriaHidden">no</button></div>
     `);
 
     expect(focusableWithin(host).map((el) => el.id)).toEqual(["ok"]);

--- a/src/tests/components/modal-dialog-inert.test.tsx
+++ b/src/tests/components/modal-dialog-inert.test.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+import { fireEvent, render, screen } from "@/tests/helpers/test-utils";
+import { useModalDialog } from "@/hooks/useModalDialog";
+
+/**
+ * Where `inert` / `aria-hidden` may and may not be applied.
+ *
+ * `getByRole` resolves against the ACCESSIBILITY TREE, not the DOM. A control
+ * inside an `inert` or `aria-hidden` subtree stays perfectly visible to a CSS
+ * selector and disappears from every role-based query — so a mistake here is
+ * invisible on screen and total for a screen-reader user.
+ *
+ * The dangerous version is applying it on MOUNT rather than on OPEN: several of
+ * these dialogs stay mounted all the time and are gated by an `open` prop, so
+ * that would poison the whole app's accessibility tree permanently, with
+ * nothing looking wrong.
+ */
+
+function Harness({ open }: { open: boolean }) {
+  const panelRef = useModalDialog<HTMLDivElement>({ open, onClose: () => {} });
+  return (
+    <div>
+      <button type="button">background control</button>
+      {open && (
+        <div className="backdrop">
+          <div ref={panelRef} role="dialog" aria-modal="true" aria-label="Confirm">
+            <button type="button">dialog control</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** A dialog that stays mounted and self-gates, like ClawBoxLoginModal. */
+function ToggleHarness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button type="button" onClick={() => setOpen(true)}>
+        open it
+      </button>
+      <Harness open={open} />
+    </div>
+  );
+}
+
+describe("useModalDialog — background inerting", () => {
+  it("leaves the page alone while the dialog is closed", () => {
+    render(<Harness open={false} />);
+
+    // The whole point: a mounted-but-closed dialog must not touch anything.
+    // If this regresses, every getByRole in the app starts failing while the
+    // screen still looks correct.
+    expect(screen.getByRole("button", { name: "background control" })).toBeInTheDocument();
+    expect(document.querySelectorAll("[inert]")).toHaveLength(0);
+    expect(document.querySelectorAll('[aria-hidden="true"]')).toHaveLength(0);
+  });
+
+  it("hides the page only once the dialog actually opens, and gives it back on close", () => {
+    render(<ToggleHarness />);
+
+    expect(screen.getByRole("button", { name: "background control" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "open it" }));
+
+    // Open: the background control is gone from the accessibility tree.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "background control" })).toBeNull();
+    expect(document.querySelectorAll("[inert]").length).toBeGreaterThan(0);
+
+    fireEvent.keyDown(document, { key: "Escape" });
+  });
+
+  it("never marks the dialog's own subtree", () => {
+    render(<Harness open />);
+
+    const panel = screen.getByRole("dialog");
+    expect(panel).not.toHaveAttribute("inert");
+    expect(panel).not.toHaveAttribute("aria-hidden");
+    // The control inside the dialog has to stay reachable by role, or the
+    // dialog is as unusable as the page it is covering.
+    expect(screen.getByRole("button", { name: "dialog control" })).toBeInTheDocument();
+  });
+});

--- a/src/tests/unit/hermes-dashboard-proxy-timeouts.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-timeouts.test.ts
@@ -1,9 +1,9 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { createRequire } from "node:module";
-import crypto from "node:crypto";
 import http from "node:http";
 import net from "node:net";
 import path from "node:path";
+import { createSessionCookie } from "@/lib/auth";
 
 /**
  * scripts/hermes-dashboard-proxy.js — upstream timeouts.
@@ -30,31 +30,28 @@ const SCRIPT = path.resolve(process.cwd(), "scripts/hermes-dashboard-proxy.js");
 const TIMEOUT_MS = 300;
 const SESSION_SECRET = "test-session-secret-for-proxy-timeouts";
 
-/** A `clawbox_session` the proxy's HMAC gate accepts (same scheme as auth.ts). */
+/**
+ * A `clawbox_session` the proxy's HMAC gate accepts.
+ *
+ * Minted with the PRODUCTION helper, not a copy of its format. The proxy is a
+ * standalone script and re-implements the verification side in plain JS, so it
+ * cannot import `auth.ts` — this test is the only thing holding the two in
+ * step. A hand-rolled cookie here would keep passing against a payload shape
+ * `auth.ts` had already moved on from, which is precisely the drift the test
+ * exists to catch.
+ *
+ * `hermes_session_at` puts the request on the pass-through path so the test
+ * exercises forwarding, not the SSO broker.
+ */
 function sessionCookie(): string {
-  const payload = Buffer.from(
-    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600, gen: 0 }),
-  )
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-  const sig = crypto.createHmac("sha256", SESSION_SECRET).update(payload).digest("hex");
-  // `hermes_session_at` puts the request on the pass-through path so the test
-  // exercises forwarding, not the SSO broker.
-  return `clawbox_session=${payload}.${sig}; hermes_session_at=stub`;
+  return `clawbox_session=${createSessionCookie(3600, SESSION_SECRET)}; hermes_session_at=stub`;
 }
 
-interface Started {
-  server: http.Server;
-  port: number;
-}
-
-function listen(server: http.Server | net.Server): Promise<Started> {
+/** Bind on an ephemeral port and resolve with the one it got. */
+function listen(server: http.Server | net.Server): Promise<number> {
   return new Promise((resolve) => {
     server.listen(0, "127.0.0.1", () => {
-      const addr = server.address() as net.AddressInfo;
-      resolve({ server: server as http.Server, port: addr.port });
+      resolve((server.address() as net.AddressInfo).port);
     });
   });
 }
@@ -62,6 +59,12 @@ function listen(server: http.Server | net.Server): Promise<Started> {
 function close(server?: http.Server | net.Server): Promise<void> {
   return new Promise((resolve) => {
     if (!server) return resolve();
+    // `close()` only stops NEW connections and waits for existing ones to end.
+    // These tests deliberately leave half-finished sockets around (a stalled
+    // upgrade, a held-open request), so waiting for them is waiting forever.
+    // http.Server can drop them itself; a plain net.Server cannot, which is why
+    // those stubs track their sockets and destroy them in afterAll.
+    if ("closeAllConnections" in server) server.closeAllConnections();
     server.close(() => resolve());
   });
 }
@@ -112,6 +115,9 @@ const heldSockets: net.Socket[] = [];
 let muteTcp: net.Server;
 let muteTcpPort: number;
 
+/** Stub upstreams a single test spun up; torn down with the rest in afterAll. */
+const adHocServers: net.Server[] = [];
+
 let proxy: http.Server;
 let proxyPort: number;
 
@@ -126,16 +132,17 @@ beforeAll(async () => {
     res.writeHead(200, { "Content-Type": "text/plain" });
     res.end("dashboard ok");
   });
-  ({ port: upstreamPort } = await listen(upstream));
+  upstreamPort = await listen(upstream);
 
   muteTcp = net.createServer((socket) => {
     heldSockets.push(socket);
   });
-  const muted = await listen(muteTcp);
-  muteTcpPort = muted.port;
+  muteTcpPort = await listen(muteTcp);
 });
 
 afterAll(async () => {
+  // Sockets first: these servers are deliberately holding half-finished
+  // connections, and `close()` on a net.Server waits for every one of them.
   for (const s of heldSockets) {
     try {
       s.destroy();
@@ -143,13 +150,33 @@ afterAll(async () => {
       /* already gone */
     }
   }
-  await close(upstream);
-  await close(muteTcp);
+  await Promise.all([close(upstream), close(muteTcp), ...adHocServers.map(close)]);
+});
+
+// Every env key startProxy() may write. Snapshotted so the suite cannot leak
+// a proxy-shaped environment into whatever else shares this worker.
+const ENV_KEYS = [
+  "SESSION_SECRET",
+  "ALLOWED_HOSTS",
+  "CLAWBOX_ROOT",
+  "HERMES_DASH_HOST",
+  "HERMES_PORT",
+  "HERMES_DASH_UPSTREAM_TIMEOUT_MS",
+  "HERMES_DASH_WS_TIMEOUT_MS",
+  "HERMES_DASH_LOGIN_TIMEOUT_MS",
+] as const;
+const envBefore = new Map<string, string | undefined>();
+
+beforeAll(() => {
+  for (const key of ENV_KEYS) envBefore.set(key, process.env[key]);
 });
 
 afterEach(async () => {
   await close(proxy);
-  delete require_.cache[require_.resolve(SCRIPT)];
+  for (const [key, value] of envBefore) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
 });
 
 /**
@@ -168,10 +195,12 @@ async function startProxy(env: Record<string, string>) {
     HERMES_DASH_LOGIN_TIMEOUT_MS: String(TIMEOUT_MS),
     ...env,
   });
+  // The proxy snapshots env at module load, so every start needs a fresh one.
+  // This is also what clears the module's Hermes session cache between tests.
   delete require_.cache[require_.resolve(SCRIPT)];
   const mod = require_(SCRIPT);
   proxy = mod.createProxyServer();
-  ({ port: proxyPort } = await listen(proxy));
+  proxyPort = await listen(proxy);
   return mod;
 }
 
@@ -182,10 +211,9 @@ describe("hermes dashboard proxy — module shape", () => {
     const mod = await startProxy({ HERMES_PORT: String(upstreamPort) });
 
     expect(typeof mod.createProxyServer).toBe("function");
-    expect(typeof mod.handleRequest).toBe("function");
-    expect(typeof mod.handleUpgrade).toBe("function");
-    // A second server can be built and thrown away: importing the module has no
-    // side effect on any port.
+    // The regression this guards: the script used to call listen() at import
+    // time, so merely loading it bound :8090. A server built here must be inert
+    // until something asks it to listen.
     const spare = mod.createProxyServer();
     expect(spare.listening).toBe(false);
     spare.close();
@@ -231,7 +259,7 @@ describe("hermes dashboard proxy — upstream timeouts", () => {
   it("answers 502 when the upstream is not listening at all", async () => {
     // Bind and immediately release a port so we know nothing is on it.
     const scratch = net.createServer();
-    const { port: deadPort } = await listen(scratch);
+    const deadPort = await listen(scratch);
     await close(scratch);
 
     await startProxy({ HERMES_PORT: String(deadPort) });
@@ -242,41 +270,64 @@ describe("hermes dashboard proxy — upstream timeouts", () => {
     expect(res.body).toContain("not reachable");
   });
 
-  it("closes a WebSocket upgrade with 504 when the upstream never completes the handshake", async () => {
+  it("closes a WebSocket upgrade with 504 when the upstream never speaks at all", async () => {
     await startProxy({ HERMES_PORT: String(muteTcpPort) });
 
-    const raw = await new Promise<{ text: string; elapsedMs: number }>((resolve, reject) => {
-      const startedAt = Date.now();
-      const socket = net.connect(proxyPort, "127.0.0.1", () => {
-        socket.write(
-          [
-            "GET /ws HTTP/1.1",
-            `Host: 127.0.0.1:${proxyPort}`,
-            "Upgrade: websocket",
-            "Connection: Upgrade",
-            "Sec-WebSocket-Version: 13",
-            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
-            `Origin: http://127.0.0.1:${proxyPort}`,
-            `Cookie: ${sessionCookie()}`,
-            "",
-            "",
-          ].join("\r\n"),
-        );
-      });
-      let text = "";
-      socket.on("data", (c) => {
-        text += c.toString();
-      });
-      socket.on("close", () => resolve({ text, elapsedMs: Date.now() - startedAt }));
-      socket.on("error", reject);
-      socket.setTimeout(TIMEOUT_MS * 20, () => {
-        socket.destroy();
-        reject(new Error("upgrade hung — proxy never answered or closed"));
-      });
-    });
+    const raw = await attemptUpgrade();
 
     // The browser must be told; a silent close is a 1006 with no explanation.
     expect(raw.text).toContain("504");
     expect(raw.elapsedMs).toBeLessThan(TIMEOUT_MS * 10);
   });
+
+  it("closes a WebSocket upgrade with 504 when the upstream stalls MID-HEADER", async () => {
+    // The subtle case: bytes arrive, so anything that stood the timer down on
+    // "first byte seen" would disarm here and hand the client a permanent hang.
+    // The upgrade is only complete once the header terminator lands.
+    const partial = net.createServer((socket) => {
+      heldSockets.push(socket);
+      socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: websoc");
+    });
+    adHocServers.push(partial);
+    const partialPort = await listen(partial);
+
+    await startProxy({ HERMES_PORT: String(partialPort) });
+    const raw = await attemptUpgrade();
+
+    expect(raw.text).toContain("504");
+    expect(raw.elapsedMs).toBeLessThan(TIMEOUT_MS * 10);
+  });
 });
+
+/** Drive a raw WebSocket upgrade through the proxy and collect what comes back. */
+function attemptUpgrade() {
+  return new Promise<{ text: string; elapsedMs: number }>((resolve, reject) => {
+    const startedAt = Date.now();
+    const socket = net.connect(proxyPort, "127.0.0.1", () => {
+      socket.write(
+        [
+          "GET /ws HTTP/1.1",
+          `Host: 127.0.0.1:${proxyPort}`,
+          "Upgrade: websocket",
+          "Connection: Upgrade",
+          "Sec-WebSocket-Version: 13",
+          "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+          `Origin: http://127.0.0.1:${proxyPort}`,
+          `Cookie: ${sessionCookie()}`,
+          "",
+          "",
+        ].join("\r\n"),
+      );
+    });
+    let text = "";
+    socket.on("data", (c) => {
+      text += c.toString();
+    });
+    socket.on("close", () => resolve({ text, elapsedMs: Date.now() - startedAt }));
+    socket.on("error", reject);
+    socket.setTimeout(TIMEOUT_MS * 20, () => {
+      socket.destroy();
+      reject(new Error("upgrade hung — proxy never answered or closed"));
+    });
+  });
+}

--- a/src/tests/unit/hermes-dashboard-proxy-timeouts.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-timeouts.test.ts
@@ -247,6 +247,28 @@ describe("hermes dashboard proxy — upstream timeouts", () => {
     );
   });
 
+  it("answers 504 when the upstream trickles headers forever without finishing them", async () => {
+    // A socket timeout measures INACTIVITY, so this upstream — one header byte
+    // every 60ms, header block never terminated — would reset it indefinitely
+    // and the request would hang with no status. The deadline is absolute, so
+    // it fires regardless of the dribble.
+    const trickler = net.createServer((socket) => {
+      heldSockets.push(socket);
+      socket.write("HTTP/1.1 200 OK\r\n");
+      const tick = setInterval(() => socket.write("X-Padding: 1\r\n"), 60);
+      socket.on("close", () => clearInterval(tick));
+      socket.on("error", () => clearInterval(tick));
+    });
+    adHocServers.push(trickler);
+    const tricklerPort = await listen(trickler);
+
+    await startProxy({ HERMES_PORT: String(tricklerPort) });
+    const res = await get(proxyPort, "/drip", TIMEOUT_MS * 20);
+
+    expect(res.status).toBe(504);
+    expect(res.body).toContain("did not respond in time");
+  });
+
   it("still proxies a responsive upstream — the timeout does not fire on healthy traffic", async () => {
     await startProxy({ HERMES_PORT: String(upstreamPort) });
 

--- a/src/tests/unit/hermes-dashboard-proxy-timeouts.test.ts
+++ b/src/tests/unit/hermes-dashboard-proxy-timeouts.test.ts
@@ -1,0 +1,282 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createRequire } from "node:module";
+import crypto from "node:crypto";
+import http from "node:http";
+import net from "node:net";
+import path from "node:path";
+
+/**
+ * scripts/hermes-dashboard-proxy.js — upstream timeouts.
+ *
+ * The proxy is on the serving path for the Hermes dashboard on shipped
+ * devices. Before this, an upstream that accepted the connection and then went
+ * quiet (dashboard mid-restart, wedged worker) held the browser's request open
+ * with no status and no error: the tab just span.
+ *
+ * The fix is only worth anything if the timeout PRODUCES A RESPONSE. Node's
+ * `destroy()` with no argument emits 'close', not 'error', so a timeout that
+ * simply tore the socket down would leave the request hanging — the same
+ * symptom, now caused by the fix. Every assertion below is therefore "a status
+ * came back, within the timeout", never "an attribute is set".
+ *
+ * These tests exist at all because the script now exports a server factory and
+ * keeps `listen()` behind a main-module guard. Previously it bound its port at
+ * import time, so nothing could load it without starting a real listener.
+ */
+
+const require_ = createRequire(import.meta.url);
+const SCRIPT = path.resolve(process.cwd(), "scripts/hermes-dashboard-proxy.js");
+
+const TIMEOUT_MS = 300;
+const SESSION_SECRET = "test-session-secret-for-proxy-timeouts";
+
+/** A `clawbox_session` the proxy's HMAC gate accepts (same scheme as auth.ts). */
+function sessionCookie(): string {
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600, gen: 0 }),
+  )
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+  const sig = crypto.createHmac("sha256", SESSION_SECRET).update(payload).digest("hex");
+  // `hermes_session_at` puts the request on the pass-through path so the test
+  // exercises forwarding, not the SSO broker.
+  return `clawbox_session=${payload}.${sig}; hermes_session_at=stub`;
+}
+
+interface Started {
+  server: http.Server;
+  port: number;
+}
+
+function listen(server: http.Server | net.Server): Promise<Started> {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address() as net.AddressInfo;
+      resolve({ server: server as http.Server, port: addr.port });
+    });
+  });
+}
+
+function close(server?: http.Server | net.Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server) return resolve();
+    server.close(() => resolve());
+  });
+}
+
+/** GET through the proxy, rejecting loudly if nothing ever comes back. */
+function get(port: number, urlPath: string, budgetMs: number) {
+  return new Promise<{ status: number; body: string; elapsedMs: number }>((resolve, reject) => {
+    const startedAt = Date.now();
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path: urlPath,
+        method: "GET",
+        headers: { host: `127.0.0.1:${port}`, cookie: sessionCookie() },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString(),
+            elapsedMs: Date.now() - startedAt,
+          }),
+        );
+      },
+    );
+    // The regression this guards: a timeout path that destroys the upstream
+    // without answering leaves us here until the budget expires.
+    req.setTimeout(budgetMs, () => {
+      req.destroy();
+      reject(new Error(`proxy never responded — request hung for ${budgetMs}ms`));
+    });
+    req.on("error", (e) => reject(e));
+    req.end();
+  });
+}
+
+// --- fixtures --------------------------------------------------------------
+
+/** Upstream that answers /fast and deliberately never answers /silent. */
+let upstream: http.Server;
+let upstreamPort: number;
+const heldSockets: net.Socket[] = [];
+
+/** Upstream that accepts TCP and never speaks — for the WS handshake path. */
+let muteTcp: net.Server;
+let muteTcpPort: number;
+
+let proxy: http.Server;
+let proxyPort: number;
+
+beforeAll(async () => {
+  upstream = http.createServer((req, res) => {
+    if (req.url === "/silent") {
+      // Hold the connection open, headers never sent. This is the wedged
+      // dashboard: TCP is healthy, the application is not.
+      heldSockets.push(res.socket as net.Socket);
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end("dashboard ok");
+  });
+  ({ port: upstreamPort } = await listen(upstream));
+
+  muteTcp = net.createServer((socket) => {
+    heldSockets.push(socket);
+  });
+  const muted = await listen(muteTcp);
+  muteTcpPort = muted.port;
+});
+
+afterAll(async () => {
+  for (const s of heldSockets) {
+    try {
+      s.destroy();
+    } catch {
+      /* already gone */
+    }
+  }
+  await close(upstream);
+  await close(muteTcp);
+});
+
+afterEach(async () => {
+  await close(proxy);
+  delete require_.cache[require_.resolve(SCRIPT)];
+});
+
+/**
+ * Load the proxy with a fresh module registry so its load-time env snapshot
+ * (ports, timeouts, secret) reflects this test's setup, then start it on an
+ * ephemeral port.
+ */
+async function startProxy(env: Record<string, string>) {
+  Object.assign(process.env, {
+    SESSION_SECRET,
+    ALLOWED_HOSTS: "localhost",
+    CLAWBOX_ROOT: path.join(process.cwd(), "nonexistent-proxy-test-root"),
+    HERMES_DASH_HOST: "127.0.0.1",
+    HERMES_DASH_UPSTREAM_TIMEOUT_MS: String(TIMEOUT_MS),
+    HERMES_DASH_WS_TIMEOUT_MS: String(TIMEOUT_MS),
+    HERMES_DASH_LOGIN_TIMEOUT_MS: String(TIMEOUT_MS),
+    ...env,
+  });
+  delete require_.cache[require_.resolve(SCRIPT)];
+  const mod = require_(SCRIPT);
+  proxy = mod.createProxyServer();
+  ({ port: proxyPort } = await listen(proxy));
+  return mod;
+}
+
+// --- tests -----------------------------------------------------------------
+
+describe("hermes dashboard proxy — module shape", () => {
+  it("exports a server factory and does not listen on import", async () => {
+    const mod = await startProxy({ HERMES_PORT: String(upstreamPort) });
+
+    expect(typeof mod.createProxyServer).toBe("function");
+    expect(typeof mod.handleRequest).toBe("function");
+    expect(typeof mod.handleUpgrade).toBe("function");
+    // A second server can be built and thrown away: importing the module has no
+    // side effect on any port.
+    const spare = mod.createProxyServer();
+    expect(spare.listening).toBe(false);
+    spare.close();
+  });
+});
+
+describe("hermes dashboard proxy — upstream timeouts", () => {
+  it("answers 504 when the upstream accepts the connection but never responds", async () => {
+    await startProxy({ HERMES_PORT: String(upstreamPort) });
+
+    // Budget is many times the timeout: if this rejects, the proxy hung.
+    const res = await get(proxyPort, "/silent", TIMEOUT_MS * 20);
+
+    expect(res.status).toBe(504);
+    expect(res.body).toContain("did not respond in time");
+    expect(res.elapsedMs).toBeGreaterThanOrEqual(TIMEOUT_MS - 50);
+    expect(res.elapsedMs).toBeLessThan(TIMEOUT_MS * 10);
+  });
+
+  it("hangs on that same request when the timeout is disabled — the behaviour being fixed", async () => {
+    // 0 disables the timer, reproducing the proxy exactly as it shipped. The
+    // point of the test above is that this is what it replaced: not a slower
+    // response, but no response at all until the browser gives up.
+    await startProxy({
+      HERMES_PORT: String(upstreamPort),
+      HERMES_DASH_UPSTREAM_TIMEOUT_MS: "0",
+    });
+
+    await expect(get(proxyPort, "/silent", TIMEOUT_MS * 4)).rejects.toThrow(
+      /never responded/,
+    );
+  });
+
+  it("still proxies a responsive upstream — the timeout does not fire on healthy traffic", async () => {
+    await startProxy({ HERMES_PORT: String(upstreamPort) });
+
+    const res = await get(proxyPort, "/fast", TIMEOUT_MS * 20);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toBe("dashboard ok");
+  });
+
+  it("answers 502 when the upstream is not listening at all", async () => {
+    // Bind and immediately release a port so we know nothing is on it.
+    const scratch = net.createServer();
+    const { port: deadPort } = await listen(scratch);
+    await close(scratch);
+
+    await startProxy({ HERMES_PORT: String(deadPort) });
+
+    const res = await get(proxyPort, "/fast", TIMEOUT_MS * 20);
+
+    expect(res.status).toBe(502);
+    expect(res.body).toContain("not reachable");
+  });
+
+  it("closes a WebSocket upgrade with 504 when the upstream never completes the handshake", async () => {
+    await startProxy({ HERMES_PORT: String(muteTcpPort) });
+
+    const raw = await new Promise<{ text: string; elapsedMs: number }>((resolve, reject) => {
+      const startedAt = Date.now();
+      const socket = net.connect(proxyPort, "127.0.0.1", () => {
+        socket.write(
+          [
+            "GET /ws HTTP/1.1",
+            `Host: 127.0.0.1:${proxyPort}`,
+            "Upgrade: websocket",
+            "Connection: Upgrade",
+            "Sec-WebSocket-Version: 13",
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==",
+            `Origin: http://127.0.0.1:${proxyPort}`,
+            `Cookie: ${sessionCookie()}`,
+            "",
+            "",
+          ].join("\r\n"),
+        );
+      });
+      let text = "";
+      socket.on("data", (c) => {
+        text += c.toString();
+      });
+      socket.on("close", () => resolve({ text, elapsedMs: Date.now() - startedAt }));
+      socket.on("error", reject);
+      socket.setTimeout(TIMEOUT_MS * 20, () => {
+        socket.destroy();
+        reject(new Error("upgrade hung — proxy never answered or closed"));
+      });
+    });
+
+    // The browser must be told; a silent close is a 1006 with no explanation.
+    expect(raw.text).toContain("504");
+    expect(raw.elapsedMs).toBeLessThan(TIMEOUT_MS * 10);
+  });
+});


### PR DESCRIPTION
Two robustness defects found during review. Independent; separated per commit.

## 1. The install confirmation could not be completed with a keyboard

Three separate defects, and the first is the one that matters most:

- **Escape had never worked.** It was bound as an `onKeyDown` on the backdrop `div`. A `div` is not focusable, so the key event was never routed to it — the handler could not fire. The existing code only *appeared* to handle Escape.
- **`role="dialog"` sat on the full-screen backdrop**, which made the accessible dialog the entire viewport and its accessible name absorb everything behind the scrim.
- **Focus never moved into the dialog**, so it stayed on the "Install" button behind the scrim and Tab walked the store's search box, sort menu and category tabs — the controls the dialog exists to block. There was no way to reach "Install anyway" by keyboard, and no way to dismiss.

`src/components/hermes-skills/ConfirmDialog.tsx` already did this correctly, so rather than add a fourth pattern its implementation is extracted into `src/hooks/useModalDialog.ts` and the hand-rolled copies are replaced by it:

- focus moves into the panel on open, restored to the trigger on close
- Tab / Shift-Tab cycle inside the panel, and focus is pulled back if it lands outside
- Escape closes and stops there, so the window behind does not also act
- the page behind the panel is `inert` + `aria-hidden` while it is open

**Callers covered**

| Dialog | Before | Now |
|---|---|---|
| App store install confirmation | no focus-in, no trap, Escape dead, role on backdrop | full |
| Hermes skills store install/uninstall | correct (extraction source) | unchanged + background inert |
| ClawBox sign-in modal | Escape + focus-in only | full |
| Tier upgrade dialog | Escape only | full |
| System update confirmation | its own duplicate trap | shared trap + restore + inert |

**Deliberately not converted:** the ClawKeep dialogs, the VNC dialog, and the inline confirmations in `SettingsApp`. They share the defect but sit in large files outside this flow, and converting them would have inflated a diff that is already touching an e2e blast zone. **`useModalDialog` is now available for them** — that is the obvious follow-up for whoever picks it up.

## 2. `scripts/hermes-dashboard-proxy.js` had no upstream timeouts

An upstream that accepted the socket and then went quiet held the browser's request open with no status and no error. Each timeout is armed only for the phase where silence means stuck, and disarmed after, so nothing that legitimately streams is cut:

- **HTTP** — request to first response byte (30s), disarmed once headers arrive
- **SSO login** — the broker's password-login POST (10s); every request awaiting the shared promise would otherwise queue behind it
- **WebSocket** — TCP connect plus the 101 handshake (15s), disarmed on the upstream's first byte

All three are env-overridable.

### The naive fix is worse than the bug, and I checked rather than assuming

Each timeout path **writes its status before** tearing the socket down. I verified both halves of that by removing my own pre-write and re-running:

- **HTTP:** letting `destroy()` speak for itself produced a **misleading 502** ("not reachable") instead of a 504 — the operator would chase a network fault that does not exist. `destroy()` is specified to emit `close`; an `error` only follows in some shapes, and once a response is in flight it does not end the client's response at all, because `pipe()` does not propagate a source error to its destination.
- **WebSocket:** a bare `kill()` gave the browser a **silent 1006** — the assertion failed on an empty body, so nothing distinguishes a wedged dashboard from a network blip.

A timeout that produces silence reintroduces the symptom it was added to remove.

To make any of this testable the script now exports a server factory and keeps `listen()` behind a `require.main` guard; it previously bound its port at import time. The request path itself is unchanged, and the systemd unit still runs it as the main module.

## Testing

- **Unit**: 190 files / 2239 tests, +13 new. Same 12 files / 29 failures as `beta` on the Windows dev box used here (platform-specific: path separators and shell tooling); failure sets diffed identical, so no regressions. CI `test` is green.
- **Focus-trap tests assert where focus lands** after Tab, Shift-Tab and close — not that an attribute is present. All seven **fail against the previous markup** (verified by stashing the component fix and re-running). An a11y test that passes on broken markup is worse than none.
- **Proxy tests prove the timed-out request returns**: a silent upstream answers 504 in ~330ms, and the same request **hangs** with the timeout disabled — that test pins the old behaviour. Also covers 502 for an absent upstream, an explicit 504 on a stalled WebSocket handshake (verified non-vacuous), and that a healthy upstream still proxies.
- **E2E**: green in CI. Locally 38 passed + 3 flaky (all green on retry) + 2 skipped, 0 failed — matches the 41/2/0 baseline. `store-flow.spec.ts`, which drives the install modal end to end, passed. The flakes are the timing-sensitive specs `playwright.config.ts` already documents as flaky on slow runs.
- **Lint** clean (only pre-existing `<img>` warnings); **typecheck** clean for every changed file.

### What this testing does not cover

- **No hardware verification.** Everything ran locally on a Windows dev machine; no Jetson was involved. Nothing here has been exercised on a real device.
- The local e2e run needed a workaround: `package.json`'s `postbuild` is POSIX shell and fails under Windows tooling, so its copy step was replicated by hand and Playwright pointed at an already-running standalone server. That is a local-environment limitation, not a repo defect, and `package.json` was not touched. CI ran the real pipeline.
- `e2e-install` is unaffected by these changes — `60-app-store.spec.ts` drives `setup-api` directly rather than the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved modal accessibility with reliable focus management, keyboard navigation, Escape-to-close behavior, focus restoration, and background content isolation.
  - Added configurable timeout settings for dashboard responses, login requests, and WebSocket handshakes.

- **Bug Fixes**
  - Dashboard proxy timeouts now return clear 504 or 502 errors instead of hanging or closing silently.
  - Established WebSocket connections are no longer interrupted by handshake timeout handling.

- **Documentation**
  - Documented optional timeout settings, including how to disable them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->