### PR TITLE
fix: narrow when the OAuth handoff file is cleared, and check its timestamp

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -529,9 +529,12 @@ export async function POST(request: Request) {
       // shape means the file is not one of ours to use, so it goes down the
       // same path rather than being spliced into the body for a later check to
       // reject — which would leave it on disk for every retry to trip over.
+      // Trimmed, because the token is trimmed before it is used: a blank string
+      // is as unusable as a missing one, and would otherwise be refused further
+      // down with the file still on disk.
       const wellFormed =
         typeof handoff.access_token === "string" &&
-        handoff.access_token.length > 0 &&
+        handoff.access_token.trim().length > 0 &&
         (handoff.provider === undefined || typeof handoff.provider === "string");
       if (
         !wellFormed ||

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -515,18 +515,26 @@ export async function POST(request: Request) {
         );
       }
       // Age the file by its own timestamp, and only when that timestamp is one
-      // we can actually compare: a missing, non-numeric or future `createdAt`
-      // yields no age, so the file cannot be shown to be inside the TTL and is
-      // treated exactly like one past it. (A bare `Date.now() - createdAt`
-      // comparison would pass for both — NaN and a negative age each fail a
-      // `> TTL` test.)
+      // we can actually compare: a missing, non-numeric, non-finite or future
+      // `createdAt` yields no age, so the file cannot be shown to be inside the
+      // TTL and is treated exactly like one past it. (A bare
+      // `Date.now() - createdAt` comparison would pass for all of them — NaN
+      // and a negative age each fail a `> TTL` test.)
       const createdAt = handoff.createdAt;
       const ageMs =
         typeof createdAt === "number" && Number.isFinite(createdAt)
           ? Date.now() - createdAt
           : null;
+      // These routes write the file, and they write strings. A field of another
+      // shape means the file is not one of ours to use, so it goes down the
+      // same path rather than being spliced into the body for a later check to
+      // reject — which would leave it on disk for every retry to trip over.
+      const wellFormed =
+        typeof handoff.access_token === "string" &&
+        handoff.access_token.length > 0 &&
+        (handoff.provider === undefined || typeof handoff.provider === "string");
       if (
-        !handoff.access_token ||
+        !wellFormed ||
         ageMs === null ||
         ageMs < 0 ||
         ageMs > HANDOFF_TTL_MS

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -492,20 +492,44 @@ export async function POST(request: Request) {
         expires_in?: number;
         createdAt?: number;
       };
+      let rawHandoff: string;
       try {
-        handoff = JSON.parse(await fs.readFile(HANDOFF_TOKENS_PATH, "utf-8"));
+        rawHandoff = await fs.readFile(HANDOFF_TOKENS_PATH, "utf-8");
       } catch {
         return NextResponse.json(
           { error: "No pending OAuth tokens. Restart the sign-in flow." },
           { status: 400 },
         );
       }
-      // A file with no `createdAt` has no age we can check, so it cannot be
-      // shown to be inside the TTL — treat it the same as one that is past it.
+      try {
+        const parsed = JSON.parse(rawHandoff);
+        if (!parsed || typeof parsed !== "object") throw new Error("not an object");
+        handoff = parsed;
+      } catch {
+        // Content a retry cannot fix. Remove it rather than leave every later
+        // attempt to fail on the same file until something else clears it.
+        await fs.unlink(HANDOFF_TOKENS_PATH).catch(() => {});
+        return NextResponse.json(
+          { error: "No pending OAuth tokens. Restart the sign-in flow." },
+          { status: 400 },
+        );
+      }
+      // Age the file by its own timestamp, and only when that timestamp is one
+      // we can actually compare: a missing, non-numeric or future `createdAt`
+      // yields no age, so the file cannot be shown to be inside the TTL and is
+      // treated exactly like one past it. (A bare `Date.now() - createdAt`
+      // comparison would pass for both — NaN and a negative age each fail a
+      // `> TTL` test.)
+      const createdAt = handoff.createdAt;
+      const ageMs =
+        typeof createdAt === "number" && Number.isFinite(createdAt)
+          ? Date.now() - createdAt
+          : null;
       if (
         !handoff.access_token ||
-        !handoff.createdAt ||
-        Date.now() - handoff.createdAt > HANDOFF_TTL_MS
+        ageMs === null ||
+        ageMs < 0 ||
+        ageMs > HANDOFF_TTL_MS
       ) {
         // Stale/invalid credential material — consume it so it can't linger.
         await fs.unlink(HANDOFF_TOKENS_PATH).catch(() => {});

--- a/src/app/setup-api/ai-models/oauth/device-poll/route.ts
+++ b/src/app/setup-api/ai-models/oauth/device-poll/route.ts
@@ -6,7 +6,6 @@ import { DATA_DIR } from "@/lib/config-store";
 import {
   HANDOFF_TOKENS_PATH,
   HANDOFF_TTL_MS,
-  clearHandoffTokens,
   sweepStaleHandoffTokens,
 } from "@/lib/oauth-handoff";
 import {
@@ -21,19 +20,17 @@ export const dynamic = "force-dynamic";
 const STATE_PATH = path.join(DATA_DIR, "oauth-device-state.json");
 
 /**
- * Drop both halves of a sign-in the provider ended without completing: the
- * in-flight state, and any handoff tokens an earlier attempt left behind.
+ * Drop the in-flight state of a sign-in the provider ended without completing.
  *
- * Used on the provider-failure branches only. The expiry branch in POST drops
- * the state alone, because a device-code state can be expired while the handoff
- * file holds fresh tokens from the *other* (authorization-code) flow; those are
- * left for the age sweep to judge on their own timestamp.
+ * Deliberately does NOT touch the handoff file. Tokens are only ever written
+ * after this route has removed the state, so no branch that reaches here has
+ * written any — whatever handoff exists at this moment belongs to some other
+ * flow, quite possibly a finished authorization-code one still waiting for
+ * /configure. Clearing it here would end that sign-in too. Handoff material is
+ * cleared where a flow starts, and swept by age in POST below.
  */
 async function discardFlow(): Promise<void> {
-  await Promise.all([
-    fs.unlink(STATE_PATH).catch(() => {}),
-    clearHandoffTokens(),
-  ]);
+  await fs.unlink(STATE_PATH).catch(() => {});
 }
 
 interface DeviceTokens {

--- a/src/app/setup-api/ai-models/oauth/device-start/route.ts
+++ b/src/app/setup-api/ai-models/oauth/device-start/route.ts
@@ -12,11 +12,6 @@ const STATE_PATH = path.join(DATA_DIR, "oauth-device-state.json");
 
 export async function POST(request: Request) {
   try {
-    // A new sign-in flow supersedes any prior one. Best-effort clear a stale
-    // token-handoff file left behind by an abandoned earlier flow so it can
-    // never be consumed by a later configure call.
-    await clearHandoffTokens();
-
     let body: { provider?: string } = {};
     try {
       body = await request.json();
@@ -95,6 +90,12 @@ export async function POST(request: Request) {
       { mode: 0o600 }
     );
     await fs.rename(tmpPath, STATE_PATH);
+
+    // This flow supersedes any prior one, so drop a handoff file an abandoned
+    // earlier sign-in left behind. Only now that the replacement state is on
+    // disk: a bad provider or an upstream failure returns above, and those must
+    // not end a sign-in that is still waiting to be consumed by configure.
+    await clearHandoffTokens();
 
     return NextResponse.json({
       verification_url: verificationUrl,

--- a/src/app/setup-api/ai-models/oauth/start/route.ts
+++ b/src/app/setup-api/ai-models/oauth/start/route.ts
@@ -16,11 +16,6 @@ function base64url(buf: Buffer): string {
 
 export async function POST(request: Request) {
   try {
-    // A new sign-in supersedes any prior one — same rule the device-code entry
-    // point applies, so the handoff file always belongs to the flow in progress
-    // rather than to whichever one was abandoned last.
-    await clearHandoffTokens();
-
     let body: { provider?: string } = {};
     try {
       body = await request.json();
@@ -62,6 +57,12 @@ export async function POST(request: Request) {
       { mode: 0o600 }
     );
     await fs.rename(tmpPath, STATE_PATH);
+
+    // Same rule the device-code entry point applies: this flow supersedes any
+    // prior one, so drop a handoff an abandoned sign-in left behind — but only
+    // now that the replacement state exists, since the validation failures
+    // above return without starting anything.
+    await clearHandoffTokens();
 
     // For OpenAI: check if a previous attempt saved an organization_id.
     // Including `organization` in the authorize URL causes Auth0 to embed

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1133,21 +1133,26 @@ describe("POST /setup-api/ai-models/configure", () => {
     );
   });
 
+  // Written as raw documents rather than through JSON.stringify: it serialises
+  // NaN and Infinity as `null`, which would quietly turn the non-finite case
+  // into the missing-createdAt case already covered below. `1e999` parses to
+  // Infinity, which is what the route's Number.isFinite check is there for.
+  const handoffDoc = (fields: string) =>
+    `{"provider":"openai","access_token":"access.token.jwt","id_token":"id.token.jwt",${fields}}`;
+
   it.each([
-    ["a non-numeric createdAt", "not-a-timestamp"],
-    ["a NaN createdAt", Number.NaN],
-    ["a createdAt in the future", Date.now() + 60 * 60 * 1000],
-  ])("rejects and removes a handoff file with %s", async (_label, createdAt) => {
-    // None of these yields an age that can be compared against the TTL, and a
-    // bare `now - createdAt > TTL` test passes for all three.
+    ["a non-numeric createdAt", handoffDoc(`"createdAt":"not-a-timestamp"`)],
+    ["a non-finite createdAt", handoffDoc(`"createdAt":1e999`)],
+    ["a createdAt in the future", handoffDoc(`"createdAt":${Date.now() + 60 * 60 * 1000}`)],
+    // A field of the wrong shape means the file is not one this device wrote.
+    ["a non-string access_token", `{"provider":"openai","access_token":{},"createdAt":${Date.now()}}`],
+    ["a non-string provider", `{"provider":{},"access_token":"a.b.c","createdAt":${Date.now()}}`],
+  ])("rejects and removes a handoff file with %s", async (_label, doc) => {
+    // None of these yields something the route can use, and a bare
+    // `now - createdAt > TTL` truthiness test passes for every one of them.
     mockFs.readFile.mockImplementation(async (file) =>
       String(file).endsWith("oauth-device-tokens.json")
-        ? JSON.stringify({
-            provider: "openai",
-            access_token: "access.token.jwt",
-            id_token: "id.token.jwt",
-            createdAt,
-          })
+        ? doc
         : JSON.stringify({ version: 1, profiles: {} }),
     );
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1147,6 +1147,8 @@ describe("POST /setup-api/ai-models/configure", () => {
     // A field of the wrong shape means the file is not one this device wrote.
     ["a non-string access_token", `{"provider":"openai","access_token":{},"createdAt":${Date.now()}}`],
     ["a non-string provider", `{"provider":{},"access_token":"a.b.c","createdAt":${Date.now()}}`],
+    // Trims to nothing where it is used, so it is as unusable as a missing one.
+    ["a blank access_token", `{"provider":"openai","access_token":"   ","createdAt":${Date.now()}}`],
   ])("rejects and removes a handoff file with %s", async (_label, doc) => {
     // None of these yields something the route can use, and a bare
     // `now - createdAt > TTL` truthiness test passes for every one of them.

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1112,6 +1112,59 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(body.error).toContain("expired");
   });
 
+  it("rejects and removes a handoff file whose contents cannot be parsed", async () => {
+    // A retry cannot fix this file, so leaving it would make every later
+    // attempt fail on the same content.
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("oauth-device-tokens.json")
+        ? "{not json"
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+
+    expect(res.status).toBe(400);
+    expect(mockFs.unlink).toHaveBeenCalledWith(
+      expect.stringContaining("oauth-device-tokens.json"),
+    );
+  });
+
+  it.each([
+    ["a non-numeric createdAt", "not-a-timestamp"],
+    ["a NaN createdAt", Number.NaN],
+    ["a createdAt in the future", Date.now() + 60 * 60 * 1000],
+  ])("rejects and removes a handoff file with %s", async (_label, createdAt) => {
+    // None of these yields an age that can be compared against the TTL, and a
+    // bare `now - createdAt > TTL` test passes for all three.
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("oauth-device-tokens.json")
+        ? JSON.stringify({
+            provider: "openai",
+            access_token: "access.token.jwt",
+            id_token: "id.token.jwt",
+            createdAt,
+          })
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.error).toContain("expired");
+    expect(mockFs.unlink).toHaveBeenCalledWith(
+      expect.stringContaining("oauth-device-tokens.json"),
+    );
+  });
+
   it("rejects and removes a handoff file that carries no createdAt", async () => {
     // Without a timestamp the file's age is unknown, so it cannot be shown to
     // be inside the TTL — it is refused like an expired one, and removed rather

--- a/src/tests/routes/ai-models/device-poll.test.ts
+++ b/src/tests/routes/ai-models/device-poll.test.ts
@@ -316,10 +316,12 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
     expect(body.status).toBe("pending");
   });
 
-  // A flow that ends without completing should leave nothing behind: the state
-  // file and the token handoff file are two halves of the same flow, so both go.
+  // A flow the provider ends without completing drops its own state. It must
+  // NOT drop the handoff file: no branch that fails here has written tokens, so
+  // whatever is there belongs to another flow — possibly a finished
+  // authorization-code one still waiting for /configure.
   describe("interrupted flow cleanup", () => {
-    it("removes the handoff tokens when the token exchange fails", async () => {
+    it("keeps the handoff tokens when the token exchange fails", async () => {
       vi.stubGlobal("fetch", vi.fn()
         .mockResolvedValueOnce({
           ok: true,
@@ -337,11 +339,11 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
       const res = await devicePollPost();
 
       expect(res.status).toBe(502);
-      expect(mockFs.unlink).toHaveBeenCalledWith(TOKENS_PATH);
       expect(mockFs.unlink).toHaveBeenCalledWith(STATE_PATH);
+      expect(mockFs.unlink).not.toHaveBeenCalledWith(TOKENS_PATH);
     });
 
-    it("removes the handoff tokens when the provider returns no code_verifier", async () => {
+    it("keeps the handoff tokens when the provider returns no code_verifier", async () => {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ authorization_code: "test-auth-code" }),
@@ -350,8 +352,8 @@ describe("POST /setup-api/ai-models/oauth/device-poll", () => {
       const res = await devicePollPost();
 
       expect(res.status).toBe(502);
-      expect(mockFs.unlink).toHaveBeenCalledWith(TOKENS_PATH);
       expect(mockFs.unlink).toHaveBeenCalledWith(STATE_PATH);
+      expect(mockFs.unlink).not.toHaveBeenCalledWith(TOKENS_PATH);
     });
 
     it("sweeps a handoff file that is past the TTL", async () => {


### PR DESCRIPTION
Follow-up to #372, which auto-merged while its review comments were being worked through — these fixes were pushed a few minutes too late to be included in it. Same branch content, carried forward.

Three corrections, one of which reverses something #372 did.

## `device-poll` no longer clears the handoff file on its failure branches

The premise in #372 was that a failed exchange leaves its own tokens behind. That is not what happens. Tokens are only written *after* the route has removed the flow state, so no branch that reaches that cleanup has written any:

- a poll that returns tokens removes the state, persists, and returns — no failure branch follows it
- a later poll therefore 400s on the missing state before it can reach the cleanup at all

Whatever handoff exists at that moment belongs to some other flow, quite possibly a finished authorization-code one still waiting for `/configure`, and clearing it would end that sign-in too. The abandoned-file case is covered by the clear-on-start in both entry points and by the age sweep, which is a tighter bound anyway.

## Both entry points clear the superseded handoff only after the replacement state exists

Clearing first meant an invalid request, an unsupported provider or an upstream failure ended an existing sign-in without starting one to take its place. `device-start` had this ordering before #372; it is corrected here alongside the new call in `start` rather than left inconsistent.

## `configure` requires a timestamp it can actually compare

`createdAt` must now be a finite number and not in the future. A non-numeric value made the subtraction `NaN`; a future one made the age negative. Neither is `> TTL`, so a file carrying either was accepted however old it was — a presence check alone would not have covered it.

The read is also separated from the parse, and content that will not parse is removed rather than left for every later attempt to fail on. A parse yielding a non-object takes the same path instead of reaching a property access on it.

## Testing

- `bun run test`: 2265 passing. The 29 failures are pre-existing on the dev machine (Windows `chmod`/symlink/spawn-env semantics); the failing set is byte-for-byte identical before and after this branch.
- New tests: exchange failure keeps the handoff and drops only the state; malformed JSON is removed; non-numeric, `NaN` and future timestamps are each rejected and removed.
- `tsc --noEmit` and `eslint` clean on the changed files.
- **Hardware verification was not done** — no Jetson available. CI's `e2e` and `e2e-install` cover these routes.

Credit to the review on #372 for the first and second items.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OAuth setup recovery for missing, unreadable, malformed, invalid, expired, or future-dated handoff data.
  - Invalid credentials are now rejected cleanly, with prompts to restart setup when necessary.
  - Interrupted device authorization flows no longer remove valid handoff information needed by other OAuth flows.
  - Existing handoffs are preserved when a new authorization attempt fails before successfully starting.
  - Invalid handoff data is automatically removed to prevent repeated setup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->