### PR TITLE
fix: return tab order from focusableWithin, and stop over-filtering

### DIFF
--- a/src/hooks/useModalDialog.ts
+++ b/src/hooks/useModalDialog.ts
@@ -53,16 +53,23 @@ const FOCUSABLE_SELECTOR = [
  * `checkVisibility` is the one the component tests do not run in.
  */
 export function focusableWithin(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
-    // `:disabled` also catches a control disabled by an ancestor <fieldset>,
-    // which the attribute check alone misses.
-    if (el.hasAttribute("disabled") || el.matches(":disabled")) return false;
+  const candidates = Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((el) => {
+    // `:disabled` is the EFFECTIVE state — it covers a control disabled by an
+    // ancestor <fieldset>, and equally it does not fire for `<a href disabled>`
+    // or `<div tabindex="0" disabled>`, where HTML gives the attribute no
+    // meaning and the element stays focusable. Testing the raw attribute would
+    // wrongly drop those.
+    if (el.matches(":disabled")) return false;
     // Any negative tabindex is out of the tab order, not just -1.
     if (el.hasAttribute("tabindex") && el.tabIndex < 0) return false;
     // `contenteditable` is editable at "", "true" and "plaintext-only"; only an
     // explicit "false" opts out. Read from the attribute rather than
     // `isContentEditable`, which jsdom does not implement.
-    if (el.hasAttribute("contenteditable")) {
+    //
+    // "false" removes only the EDITING affordance, so it disqualifies an
+    // element that had nothing else going for it — never a button, link or
+    // anything explicitly tabbable, all of which report tabIndex >= 0.
+    if (el.hasAttribute("contenteditable") && el.tabIndex < 0) {
       const mode = (el.getAttribute("contenteditable") || "").toLowerCase();
       if (mode === "false") return false;
     }
@@ -83,6 +90,17 @@ export function focusableWithin(container: HTMLElement): HTMLElement[] {
       return false;
     }
     return true;
+  });
+
+  // Put the list in TAB order, which is not DOM order when a positive tabindex
+  // is present: those are visited first, ascending, before everything at 0.
+  // The trap treats the first and last entries as its wrap boundaries, so a
+  // DOM-ordered list would put the boundaries in the wrong place and let Tab
+  // walk straight out of the dialog. Sort is stable, so ties keep DOM order.
+  return candidates.sort((a, b) => {
+    const ai = a.tabIndex > 0 ? a.tabIndex : Number.MAX_SAFE_INTEGER;
+    const bi = b.tabIndex > 0 ? b.tabIndex : Number.MAX_SAFE_INTEGER;
+    return ai - bi;
   });
 }
 

--- a/src/tests/components/focusable-within.test.tsx
+++ b/src/tests/components/focusable-within.test.tsx
@@ -94,6 +94,41 @@ describe("focusableWithin", () => {
     expect(focusableWithin(host).map((el) => el.id)).toEqual(["empty", "true", "plaintext"]);
   });
 
+  it("keeps elements where `disabled` has no meaning in HTML", () => {
+    // `disabled` does nothing on a link or a plain div — both stay focusable,
+    // so dropping them would put the trap's wrap boundary in the wrong place.
+    const host = mount(`
+      <a id="link" href="#x" disabled>still focusable</a>
+      <div id="tabbable" tabindex="0" disabled>still focusable</div>
+      <button id="realControl" disabled>not focusable</button>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["link", "tabbable"]);
+  });
+
+  it("keeps a focusable control that merely turns editing off", () => {
+    // `contenteditable="false"` removes the editing affordance, not focus.
+    const host = mount(`
+      <button id="button" contenteditable="false">ok</button>
+      <div id="plainDiv" contenteditable="false">no</div>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["button"]);
+  });
+
+  it("returns tab order, not DOM order, when a positive tabindex is present", () => {
+    // Positive tabindex is visited first and ascending. The trap uses the
+    // first and last entries as its wrap boundaries, so a DOM-ordered list
+    // here would let Tab escape the dialog at the wrong end.
+    const host = mount(`
+      <button id="natural">natural</button>
+      <button id="second" tabindex="2">second</button>
+      <button id="first" tabindex="1">first</button>
+    `);
+
+    expect(focusableWithin(host).map((el) => el.id)).toEqual(["first", "second", "natural"]);
+  });
+
   it("skips anything inside an inert, hidden, or aria-hidden subtree", () => {
     const host = mount(`
       <button id="ok">ok</button>

--- a/src/tests/components/modal-dialog-inert.test.tsx
+++ b/src/tests/components/modal-dialog-inert.test.tsx
@@ -17,8 +17,8 @@ import { useModalDialog } from "@/hooks/useModalDialog";
  * nothing looking wrong.
  */
 
-function Harness({ open }: { open: boolean }) {
-  const panelRef = useModalDialog<HTMLDivElement>({ open, onClose: () => {} });
+function Harness({ open, onClose = () => {} }: { open: boolean; onClose?: () => void }) {
+  const panelRef = useModalDialog<HTMLDivElement>({ open, onClose });
   return (
     <div>
       <button type="button">background control</button>
@@ -41,7 +41,7 @@ function ToggleHarness() {
       <button type="button" onClick={() => setOpen(true)}>
         open it
       </button>
-      <Harness open={open} />
+      <Harness open={open} onClose={() => setOpen(false)} />
     </div>
   );
 }
@@ -70,7 +70,14 @@ describe("useModalDialog — background inerting", () => {
     expect(screen.queryByRole("button", { name: "background control" })).toBeNull();
     expect(document.querySelectorAll("[inert]").length).toBeGreaterThan(0);
 
+    // Escape really closes here — `onClose` flips the state — so this also
+    // asserts the marking is handed back rather than left on the page.
     fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+    expect(screen.getByRole("button", { name: "background control" })).toBeInTheDocument();
+    expect(document.querySelectorAll("[inert]")).toHaveLength(0);
+    expect(document.querySelectorAll('[aria-hidden="true"]')).toHaveLength(0);
   });
 
   it("never marks the dialog's own subtree", () => {


### PR DESCRIPTION
Follow-up to #371, which merged while this last review round was still in flight. Three focusability cases in the shared modal focus trap were wrong, all of which put the trap's Tab wrap boundaries on the wrong element.

Raised by CodeRabbit on #371 after the merge; each is confirmed and has a regression case.

## `disabled` was read as an attribute

HTML gives `disabled` no meaning on a link or a plain div, so `<a href disabled>` and `<div tabindex="0" disabled>` stay focusable — and were being dropped. `el.matches(":disabled")` is the **effective** state: it still catches a control disabled by an ancestor `<fieldset>`, and correctly ignores the attribute where the platform does.

## `contenteditable="false"` was treated as "not focusable"

It turns editing off, not focus. A `<button contenteditable="false">` is still perfectly reachable. The check now only disqualifies an element that had nothing else going for it (`tabIndex < 0`).

## The list was DOM order, but tab order is not DOM order

`querySelectorAll` returns DOM order. A positive `tabindex` is visited **first and ascending**, before everything at 0. The trap takes the first and last entries as its wrap boundaries, so with `tabindex="2"` appearing before `tabindex="1"` the boundaries invert and Tab can leave the dialog at the wrong end.

Sorted stably, so ties keep DOM order. No positive `tabindex` exists in the app today — verified by grep — so this is not a live bug; it keeps the helper honest for the next caller, since "first and last" is load-bearing.

## Test fix

`modal-dialog-inert.test.tsx` passed a no-op `onClose` to its harness, so the Escape at the end of the open/close test changed nothing and the test finished with the dialog still open — it never actually checked that `inert` and `aria-hidden` are handed back. `onClose` now flips the state, and the assertions for restoration are real.

## Testing

- Components: 24 files / 111 tests, all passing.
- Full suite: 191 files / 2256 tests. Same 29 pre-existing failures as `beta` on this Windows dev box (path separators and shell tooling); failure sets diffed identical, so no regressions.
- Lint and typecheck clean for every changed file.

Run locally on Windows. No Jetson involved — nothing here was verified on hardware, and this touches no device path (the change is confined to the focus-trap helper and its tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation to correctly identify focusable elements based on their effective disabled state.
  * Ensured focusable elements are ordered according to keyboard tab order.
  * Prevented improperly focusable editable elements from receiving focus.
  * Improved dialog closing behavior so background content becomes accessible again after pressing Escape.

* **Tests**
  * Added coverage for focusability and dialog accessibility restoration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->