### PR TITLE
docs: record why the data dir needs containment rather than name matching

### DIFF
--- a/src/lib/file-guard.ts
+++ b/src/lib/file-guard.ts
@@ -58,7 +58,15 @@ const PROTECTED_FILE_RES: RegExp[] = [
 // this directory even in principle: an atomic write stages `<name>.tmp.<hex>`
 // beside its target, so some of what lands here is named at runtime. A
 // hand-maintained list also only describes the code as it was when the list was
-// last edited.
+// last edited — the one this replaced had fallen behind the OAuth flow files,
+// the login and credentials-change state, the tunnel state and cloudflared/.
+//
+// The name-shaped rules above cannot stand in for it either. Each matches the
+// names it was written for, and this directory is full of names just outside
+// them: it holds `network.env`, `hotspot.env`, `ap-runtime.env` and
+// `hostname.env`, which END in `.env`, while the dotenv rule in mcp/lib/guard.ts
+// matches names that BEGIN with it. Neither rule is wrong; they describe
+// different things. Only the directory describes the directory.
 //
 // DATA_DIR *itself* is deliberately not protected. The Files API filters a
 // directory listing entry by entry, so keeping the directory openable is what


### PR DESCRIPTION
Comment-only follow-up to #372. No behaviour change; the tests that back both claims already landed with that PR.

Two arguments came out of building the data-dir inventory while verifying the public-subtree list, and neither made it into the code.

**The list had fallen behind, and by how much is worth naming.** The comment claimed a hand-maintained list "only describes the code as it was when the list was last edited". True, but it reads as an abstraction. It had actually fallen behind the OAuth flow files, the login and credentials-change state, the tunnel state and `cloudflared/` — so the next person can see the failure mode instead of taking the claim on trust.

**Name-shaped rules cannot stand in for containment.** This is the sharper argument and it was missing entirely. The data dir holds `network.env`, `hotspot.env`, `ap-runtime.env` and `hostname.env` — names that *end* in `.env` — while the dotenv rule in `mcp/lib/guard.ts` matches names that *begin* with it. Neither rule is wrong about its own subject, and that is exactly the point: a name rule describes the names it was written for, so no name rule generalises to a directory whose contents it did not anticipate.

All four `*.env` files are already in the inventory `it.each` in `src/tests/unit/file-guard.test.ts`, so the behaviour this describes is pinned; this only writes down why.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the scope of data directory protection, including authentication, OAuth, tunnel, cloud connectivity, and environment configuration state.
  * Improved guidance explaining why comprehensive directory containment is needed to protect application data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->