### PR TITLE
docs: record why three CodeQL refutations hold

### DIFF
--- a/mcp/lib/edition.ts
+++ b/mcp/lib/edition.ts
@@ -20,6 +20,10 @@ const HARNESS_TIMEOUT_MS = 3_000;
 
 // Same path src/lib/edition-source.ts reads; re-stated (not exported from there)
 // only to tell "the lock is absent" apart from "the lock is unreadable".
+// Not an edition-lock bypass — see the note on the same constant in
+// src/lib/edition-source.ts. What it can influence HERE is the tool set, and the
+// env supplying it is the one that launches this server, so anyone able to set it
+// already has the clawbox shell that the smaller set withholds.
 const EDITION_FILE = process.env.CLAWBOX_EDITION_FILE || "/etc/clawbox/edition.env";
 
 /**

--- a/src/lib/code-projects.ts
+++ b/src/lib/code-projects.ts
@@ -409,6 +409,10 @@ export async function searchFiles(
     // No global flag: only test() is used, and the 'g' flag makes test()
     // stateful (persisting lastIndex), which silently skips alternating matches.
     const flags = opts.caseSensitive ? "" : "i";
+    // Flagged by CodeQL js/regex-injection: the pattern is a search FILTER, not
+    // a guard. It decides no path, permission or sanitisation outcome — only
+    // which lines of this device's own project files come back to the caller
+    // that asked. /setup-api/code sits behind the session / MCP-bearer gate.
     let re: RegExp;
     try {
       re = new RegExp(pattern, flags);

--- a/src/lib/edition-source.ts
+++ b/src/lib/edition-source.ts
@@ -21,6 +21,10 @@ import fs from "fs";
 export type EditionName = "openclaw" | "hermes" | "dual";
 
 // Overridable for tests only; production always reads the root-owned path.
+// Redirecting it is not an edition-lock bypass: no request data flows into it,
+// and "dual" additionally has to clear verifyDualLicense() against a key constant
+// that is deliberately not env-overridable (see edition-license.ts) — so a
+// redirected path can change the edition LABEL, never unlock the premium switcher.
 const EDITION_FILE = process.env.CLAWBOX_EDITION_FILE || "/etc/clawbox/edition.env";
 
 let cache: { mtimeMs: number; edition: EditionName } | null = null;


### PR DESCRIPTION
Closes out the CodeQL triage. Comment-only change (12 lines, no behaviour).

An adversarial pass over the open alerts concluded that most are false positives. This records the reasoning for three of them at the site, so the next reader — human or tool — does not re-derive it, and pairs with per-alert dismissals in the Security tab, the mechanism `.github/codeql/codeql-config.yml` already nominates.

### The three notes

- **`src/lib/edition-source.ts`** — why the `CLAWBOX_EDITION_FILE` override is not an edition-lock bypass: no request data flows into it, and `dual` must additionally clear `verifyDualLicense()` against a key constant that is deliberately not env-overridable. A redirected path can change the edition *label*, never unlock the premium switcher.
- **`mcp/lib/edition.ts`** — same constant, but the stake here is the *tool set*, not the licence. The env supplying the path is the one that launches this server, so anyone able to set it already has the shell the smaller set withholds.
- **`src/lib/code-projects.ts`** — why the constructed `RegExp` is not a defect: it is a search filter, deciding no path, permission or sanitisation outcome.

### Triage outcome

The false-positive alerts are dismissed individually in the Security tab, each with the specific guard named.

A small number did not survive verification and are **not** dismissed. They are tracked privately and handled separately from this PR, which is comment-only.
