### PR TITLE
fix: refuse an unsupported edition transition and make validation honest

### DIFF
--- a/docs-site/editions/overview.mdx
+++ b/docs-site/editions/overview.mdx
@@ -77,6 +77,29 @@ sudo CLAWBOX_EDITION=hermes bash install.sh
 Valid values are `openclaw`, `hermes` and `dual`. An unrecognised value prints a
 warning and installs as `openclaw`.
 
+That variable chooses the edition on a **first** install. On a device that has
+already been installed, the installer compares it against the recorded edition
+and stops if they differ, before it changes anything:
+
+```text
+ERROR: this device is already installed as the 'hermes' edition.
+
+         Recorded edition:  hermes   (/etc/clawbox/edition.env)
+         Requested edition: openclaw
+```
+
+Re-running the installer with the edition the device already is — or with no
+`CLAWBOX_EDITION` at all, which reads the recorded value — is the normal
+re-install and update path and is unaffected. `dual` counts as its own edition
+here, so moving to or from it is a change like any other.
+
+The installer does not migrate an edition. It has no step that removes the
+harness the device would be leaving, and each harness keeps its AI provider
+sign-in in its own configuration file, so signing in does not carry across. A
+device installed over the top of another edition ends up running two agents with
+no usable model — which is why the transition is refused rather than half
+performed. Changing a device's edition is a reflash.
+
 ## Which edition am I on?
 
 Over SSH or in the Terminal app:

--- a/install.sh
+++ b/install.sh
@@ -106,12 +106,34 @@ _read_edition_from_file() {
   printf '%s' "$v"
 }
 
+# The edition RECORDED on this device, from the root-owned records only and in
+# authority order. Deliberately excludes config/edition.txt: that is a
+# first-flash seed in a tree the customer owns, so it is a source for resolution
+# (below) but never evidence of what the device already IS.
+_read_recorded_edition() {
+  local v
+  v="$(_read_edition_from_file "$CLAWBOX_EDITION_FILE" || true)"
+  [ -n "$v" ] || v="$(_read_edition_from_file "$LEGACY_EDITION_DROPIN" || true)"
+  printf '%s' "$v"
+}
+
+# Lower-case and map anything unrecognised onto openclaw — the same rule the
+# resolution `case` below applies, minus the warning. Empty stays empty so
+# "no edition recorded" is distinguishable from "recorded as openclaw".
+_normalise_edition() {
+  local v
+  v="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  case "$v" in
+    openclaw|hermes|dual|"") printf '%s' "$v" ;;
+    *) printf 'openclaw' ;;
+  esac
+}
+
+CLAWBOX_RECORDED_EDITION_RAW="$(_read_recorded_edition)"
+
 CLAWBOX_EDITION_RAW="${CLAWBOX_EDITION:-}"
 if [ -z "$CLAWBOX_EDITION_RAW" ]; then
-  CLAWBOX_EDITION_RAW="$(_read_edition_from_file "$CLAWBOX_EDITION_FILE" || true)"
-fi
-if [ -z "$CLAWBOX_EDITION_RAW" ]; then
-  CLAWBOX_EDITION_RAW="$(_read_edition_from_file "$LEGACY_EDITION_DROPIN" || true)"
+  CLAWBOX_EDITION_RAW="$CLAWBOX_RECORDED_EDITION_RAW"
 fi
 if [ -z "$CLAWBOX_EDITION_RAW" ] && [ -f "$PROJECT_DIR/config/edition.txt" ]; then
   CLAWBOX_EDITION_RAW="$(tr -d '[:space:]' < "$PROJECT_DIR/config/edition.txt" 2>/dev/null || true)"
@@ -131,6 +153,82 @@ case "$CLAWBOX_EDITION" in
     CLAWBOX_EDITION="openclaw"
     ;;
 esac
+
+# ── Refuse to change the edition of an already-provisioned device ────────────
+#
+# install.sh can INSTALL an edition. It cannot MIGRATE one, and it never
+# pretended to: nothing here stops, disables or masks the harness a device would
+# be LEAVING, and each harness keeps its provider credentials in its own file
+# (~/.hermes/config.yaml vs ~/.openclaw/openclaw.json), so a sign-in does not
+# move. The message below spells out what that costs an operator; the same
+# reasoning is in docs-site/editions/overview.mdx. Changing edition is a
+# reflash. scripts/setup-hermes-edition.sh is the other writer of the lock and
+# carries the same refusal — both writers have to, or neither means anything.
+#
+# ORDERING is load-bearing: this is the first thing after the edition resolves,
+# so it runs before the lock and drop-in are rewritten, before
+# step_edition_gateway_state masks or unmasks anything, and before any unit is
+# copied, enabled or started — on the full-install path AND on the `--step`
+# dispatch path the in-app updater uses, since both reach this point during
+# constant parsing. A refusal that fires after the gateway has been unmasked is
+# not a refusal.
+#
+# EVERY recorded-vs-requested difference counts, including openclaw -> dual and
+# hermes -> dual. `dual` is a distinct SKU (both harnesses plus a licence-gated
+# runtime switcher), and the additive direction fails the same way as the
+# destructive one: the harness being ADDED comes up with an empty provider
+# registry and no credentials, and setup_complete suppresses the step that would
+# populate them. The lock exists precisely so the SKU cannot be flipped from the
+# environment, so "upgrading" to premium by exporting a variable is exactly what
+# it must refuse.
+CLAWBOX_ALLOW_EDITION_CHANGE="${CLAWBOX_ALLOW_EDITION_CHANGE:-0}"
+CLAWBOX_RECORDED_EDITION="$(_normalise_edition "$CLAWBOX_RECORDED_EDITION_RAW")"
+
+# Empty means no lock has ever been written: a fresh install, which is exactly
+# how an edition is legitimately chosen. Untouched.
+if [ -n "$CLAWBOX_RECORDED_EDITION" ] && [ "$CLAWBOX_RECORDED_EDITION" != "$CLAWBOX_EDITION" ]; then
+  if [ "$CLAWBOX_ALLOW_EDITION_CHANGE" = "1" ]; then
+    cat >&2 <<EOF
+
+WARNING: CLAWBOX_ALLOW_EDITION_CHANGE=1 — installing '$CLAWBOX_EDITION' over
+         '$CLAWBOX_RECORDED_EDITION' on a device that is already provisioned.
+         The installer does NOT migrate an edition: the '$CLAWBOX_RECORDED_EDITION' harness is
+         left running, and the AI provider sign-in is not carried across.
+         You are expected to finish the transition by hand.
+
+EOF
+  else
+    cat >&2 <<EOF
+
+ERROR: this device is already installed as the '$CLAWBOX_RECORDED_EDITION' edition.
+
+         Recorded edition:  $CLAWBOX_RECORDED_EDITION   ($CLAWBOX_EDITION_FILE)
+         Requested edition: $CLAWBOX_EDITION
+
+       The installer installs an edition; it does not migrate one. It has no
+       step that removes the harness a device is leaving, and the AI provider
+       sign-in lives in each harness's own config, so it does not move. A
+       device installed this way comes up with two harnesses running and no
+       usable model, while still reporting that setup is complete.
+
+       Changing a device's edition requires a REFLASH.
+       See https://docs.clawbox.com/editions/overview
+
+       Nothing has been changed. No unit was stopped, started or masked, and
+       the edition lock still reads '$CLAWBOX_RECORDED_EDITION'.
+
+       To re-install this device as the edition it already is, drop
+       CLAWBOX_EDITION from the command (the recorded value is used
+       automatically) or pass CLAWBOX_EDITION=$CLAWBOX_RECORDED_EDITION.
+
+       If you genuinely intend to overwrite the edition and will finish the
+       transition yourself, re-run with CLAWBOX_ALLOW_EDITION_CHANGE=1.
+
+EOF
+    exit 1
+  fi
+fi
+
 # The Hermes SKU: Hermes is the ONLY harness, the OpenClaw gateway is removed.
 is_hermes_edition() { [ "$CLAWBOX_EDITION" = "hermes" ]; }
 # Editions that ship the Hermes harness + dashboard (hermes AND the premium
@@ -227,6 +325,37 @@ if is_hermes_edition; then
     [ "$_s" = "clawbox-gateway.service" ] || _active_svcs+=("$_s")
   done
   EXPECTED_ACTIVE_SERVICES=("${_active_svcs[@]}")
+fi
+
+# Units belonging to a harness THIS edition does not run.
+#
+# EXPECTED_ACTIVE_SERVICES only ever describes what should be UP, which left
+# step_validate_services blind in one direction: it appends the Hermes units
+# inside `if has_hermes_harness`, so on the openclaw edition a fully running
+# Hermes stack was not merely tolerated, it was invisible. Nothing in install.sh
+# brings these down, so anything found here is a device that used to be another
+# edition. Both predicates are negated, so `dual` — the edition that legitimately
+# runs both — accumulates nothing and needs no special case.
+FOREIGN_EDITION_UNITS=()
+if ! has_hermes_harness; then
+  # The Hermes harness: the two ClawBox-managed dashboard units, plus the
+  # gateway unit the upstream Hermes installer writes. The latter is the one
+  # that holds the Telegram bot token, so leaving it running next to the
+  # OpenClaw gateway puts two pollers on one token — a permanent conflict loop.
+  FOREIGN_EDITION_UNITS+=(
+    clawbox-hermes-dashboard.service
+    clawbox-hermes-dashboard-proxy.service
+    hermes-gateway.service
+  )
+fi
+if ! has_openclaw_harness; then
+  # hermes: the OpenClaw gateway. The hermes-only probe in
+  # step_validate_services also names this unit — it is an unauthenticated agent
+  # surface on :18789 and earns its own message — but that probe only tests
+  # `is-active`. Listing it here keeps the mechanism symmetric and adds the
+  # `enabled but inactive` case. A masked gateway matches neither, so a
+  # correctly provisioned Hermes box reports nothing twice.
+  FOREIGN_EDITION_UNITS+=(clawbox-gateway.service)
 fi
 
 # Load persisted WiFi interface if available
@@ -2801,6 +2930,34 @@ step_validate_services() {
       esac
     fi
 
+    # Probe: no unit belonging to ANOTHER edition is running here.
+    #
+    # Every check above asks whether this edition's own units are UP, so a
+    # second harness left over from a previous edition scored zero failures and
+    # went unseen. Absence has to be asserted too, or "All N checks healthy" is
+    # printable on a box running two agents and two Telegram pollers.
+    #
+    # An absent unit answers `inactive` and a masked one answers `masked`, so
+    # neither arm matches and no `systemctl cat` guard is needed — which also
+    # means a unit that was masked while still running is still caught.
+    # `enabled but inactive` fails too: it is one reboot away from active.
+    local funit f_active f_enabled
+    for funit in "${FOREIGN_EDITION_UNITS[@]}"; do
+      f_active=$(systemctl is-active "$funit" 2>/dev/null || true)
+      f_enabled=$(systemctl is-enabled "$funit" 2>/dev/null || true)
+      case "$f_active" in
+        active|activating|reloading)
+          failed_probe+=("Edition: $funit is $f_active but belongs to another edition (this device is '$CLAWBOX_EDITION') — two agent harnesses are running on one box")
+          continue
+          ;;
+      esac
+      case "$f_enabled" in
+        enabled|enabled-runtime)
+          failed_probe+=("Edition: $funit is enabled but belongs to another edition (this device is '$CLAWBOX_EDITION') — it starts again on the next boot")
+          ;;
+      esac
+    done
+
     [ ${#failed_active[@]} -eq 0 ] && [ ${#failed_installed[@]} -eq 0 ] && [ ${#failed_probe[@]} -eq 0 ] && break
     [ "$(date +%s)" -ge "$deadline" ] && break
     sleep 2
@@ -2810,6 +2967,11 @@ step_validate_services() {
   if is_test_mode; then probe_count=1; fi
   # +3: gateway-inactive, gateway-port-silent, dashboard-proxy-answers.
   if is_hermes_edition; then probe_count=$(( probe_count + 3 )); fi
+  # One per foreign unit. Counted even when the unit is absent: "the other
+  # harness is not here" is a check that ran and passed, and folding it into the
+  # total is what stops the healthy line from being printable on a box that is
+  # running two of them.
+  probe_count=$(( probe_count + ${#FOREIGN_EDITION_UNITS[@]} ))
   local total=$(( ${#active_services[@]} + ${#EXPECTED_INSTALLED_SERVICES[@]} + probe_count ))
   local fails=$(( ${#failed_active[@]} + ${#failed_installed[@]} + ${#failed_probe[@]} ))
   if [ "$fails" -eq 0 ]; then

--- a/install.sh
+++ b/install.sh
@@ -141,7 +141,14 @@ fi
 # Lower-case to match the TypeScript side (src/lib/edition-source.ts), which has
 # always normalised case — otherwise "Hermes" in edition.txt silently installs
 # an OpenClaw box.
-CLAWBOX_EDITION="$(printf '%s' "$CLAWBOX_EDITION_RAW" | tr '[:upper:]' '[:lower:]')"
+#
+# Whitespace is stripped for the same reason, and so that this rule is IDENTICAL
+# to _normalise_edition above. When only one of the two stripped whitespace, a
+# padded `CLAWBOX_EDITION=" hermes "` resolved to openclaw (unrecognised → warn →
+# openclaw) while the lock still read hermes, and the refusal below fired on a
+# device nobody was trying to change — reporting "Requested edition: openclaw"
+# at an operator who had typed hermes.
+CLAWBOX_EDITION="$(printf '%s' "$CLAWBOX_EDITION_RAW" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
 case "$CLAWBOX_EDITION" in
   openclaw|hermes|dual) ;;
   "") CLAWBOX_EDITION="openclaw" ;;

--- a/scripts/setup-hermes-edition.sh
+++ b/scripts/setup-hermes-edition.sh
@@ -42,11 +42,61 @@ fi
 # install.sh) is honoured for the first-flash case where the file doesn't exist
 # yet. Standalone runs with neither default to `hermes`, which is what this
 # script has always been used for.
-EDITION="${CLAWBOX_EDITION:-}"
-if [ -z "$EDITION" ] && [ -f "$EDITION_FILE" ]; then
-  EDITION="$(sed -n 's/^[[:space:]]*CLAWBOX_EDITION[[:space:]]*=[[:space:]]*//p' "$EDITION_FILE" 2>/dev/null | tail -n 1 | tr -d '"'\'' ')"
+# Lower-case, and strip the quotes and whitespace an EnvironmentFile value may
+# carry, so a lock reading `CLAWBOX_EDITION="Hermes"` compares equal to `hermes`.
+_norm() { printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d "[:space:]\"'"; }
+
+RECORDED_EDITION=""
+if [ -f "$EDITION_FILE" ]; then
+  RECORDED_EDITION="$(_norm "$(sed -n 's/^[[:space:]]*CLAWBOX_EDITION[[:space:]]*=[[:space:]]*//p' "$EDITION_FILE" 2>/dev/null | tail -n 1)")"
 fi
-EDITION="$(printf '%s' "${EDITION:-hermes}" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+REQUESTED_EDITION="$(_norm "${CLAWBOX_EDITION:-}")"
+
+# This script is the OTHER writer of the edition lock (§4 below rewrites both
+# /etc/clawbox/edition.env and the legacy drop-in). install.sh refuses to change
+# a provisioned device's edition; without the same refusal here, `sudo
+# CLAWBOX_EDITION=dual bash scripts/setup-hermes-edition.sh` would rewrite the
+# lock on a hermes box and a later plain `install.sh` would then see recorded ==
+# requested, find no mismatch, and unmask and start the OpenClaw gateway on what
+# the customer bought as a Hermes appliance. Refusing at BOTH writers is what
+# makes the lock mean anything.
+#
+# Only a genuine disagreement is refused: no lock yet (first flash) or no
+# CLAWBOX_EDITION passed (the normal standalone repair run) are untouched, and
+# so is install.sh's own call — it runs step_edition_lock before
+# step_hermes_edition, so the two always agree by then.
+if [ -n "$RECORDED_EDITION" ] && [ -n "$REQUESTED_EDITION" ] \
+   && [ "$RECORDED_EDITION" != "$REQUESTED_EDITION" ]; then
+  if [ "${CLAWBOX_ALLOW_EDITION_CHANGE:-0}" = "1" ]; then
+    log "WARNING: CLAWBOX_ALLOW_EDITION_CHANGE=1 — provisioning '$REQUESTED_EDITION' over '$RECORDED_EDITION'."
+    log "         The '$RECORDED_EDITION' harness is NOT torn down and credentials are not migrated."
+  else
+    cat >&2 <<EOF
+[hermes-edition] ERROR: this device is already installed as the '$RECORDED_EDITION' edition.
+
+         Recorded edition:  $RECORDED_EDITION   ($EDITION_FILE)
+         Requested edition: $REQUESTED_EDITION
+
+       Provisioning would rewrite the edition lock, and neither this script nor
+       install.sh migrates a device between editions — the harness being left
+       behind keeps running and the AI provider sign-in does not move with it.
+       Changing a device's edition requires a reflash.
+       See https://docs.clawbox.com/editions/overview
+
+       Nothing has been changed. Drop CLAWBOX_EDITION to provision the edition
+       this device already is, or pass CLAWBOX_EDITION=$RECORDED_EDITION.
+       To overwrite it anyway, re-run with CLAWBOX_ALLOW_EDITION_CHANGE=1.
+EOF
+    exit 1
+  fi
+fi
+
+# An explicit request wins once it agrees with the lock (or the escape hatch was
+# used); otherwise fall back to the lock, then to this script's historical
+# default.
+EDITION="$REQUESTED_EDITION"
+[ -n "$EDITION" ] || EDITION="$RECORDED_EDITION"
+[ -n "$EDITION" ] || EDITION="hermes"
 case "$EDITION" in
   hermes|dual) ;;
   *)

--- a/scripts/setup-hermes-edition.sh
+++ b/scripts/setup-hermes-edition.sh
@@ -46,10 +46,37 @@ fi
 # carry, so a lock reading `CLAWBOX_EDITION="Hermes"` compares equal to `hermes`.
 _norm() { printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | tr -d "[:space:]\"'"; }
 
-RECORDED_EDITION=""
-if [ -f "$EDITION_FILE" ]; then
-  RECORDED_EDITION="$(_norm "$(sed -n 's/^[[:space:]]*CLAWBOX_EDITION[[:space:]]*=[[:space:]]*//p' "$EDITION_FILE" 2>/dev/null | tail -n 1)")"
+# An unrecognised RECORDED value describes an openclaw device everywhere else
+# (install.sh's _normalise_edition applies exactly this rule), so map it the same
+# way. Treating it as *absent* instead would be the dangerous reading: it would
+# clear the refusal and let a typo'd lock be provisioned straight over.
+_norm_recorded() {
+  local v
+  v="$(_norm "${1:-}")"
+  case "$v" in
+    openclaw|hermes|dual|"") printf '%s' "$v" ;;
+    *) printf 'openclaw' ;;
+  esac
+}
+
+# Read `CLAWBOX_EDITION=x` from an EnvironmentFile or `Environment=CLAWBOX_EDITION=x`
+# from a systemd drop-in — same two shapes install.sh's _read_edition_from_file
+# accepts.
+_read_edition_file() {
+  [ -f "$1" ] || return 0
+  sed -n 's/^[[:space:]]*\(export[[:space:]][[:space:]]*\)\{0,1\}\(Environment=\)\{0,1\}"\{0,1\}CLAWBOX_EDITION[[:space:]]*=[[:space:]]*//p' \
+    "$1" 2>/dev/null | tail -n 1
+}
+
+# Root-owned records, in authority order. The legacy drop-in matters: on a device
+# provisioned before /etc/clawbox/edition.env existed it is the ONLY durable
+# record, so reading just the new file would leave that whole part of the fleet
+# able to bypass the refusal below.
+_recorded_raw="$(_read_edition_file "$EDITION_FILE")"
+if [ -z "$_recorded_raw" ]; then
+  _recorded_raw="$(_read_edition_file "$EDITION_DROPIN")"
 fi
+RECORDED_EDITION="$(_norm_recorded "$_recorded_raw")"
 REQUESTED_EDITION="$(_norm "${CLAWBOX_EDITION:-}")"
 
 # This script is the OTHER writer of the edition lock (§4 below rewrites both

--- a/src/tests/unit/install-edition-switch-refusal.test.ts
+++ b/src/tests/unit/install-edition-switch-refusal.test.ts
@@ -1,0 +1,657 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// A device installed as one edition and then re-installed as another completed
+// all 26 steps and printed "All N checks healthy" — on a box that was broken.
+// install.sh installs an edition; it has never migrated one. It has no step
+// that stops, disables or masks the harness a device is LEAVING, and the AI
+// provider sign-in lives in each harness's own config file, so it does not move
+// across. The result was two harnesses running at once (duplicate Telegram
+// pollers on one bot token, both dashboards bound), an incoming harness with an
+// empty provider registry so every chat turn failed to resolve its model, and
+// setup_complete carried over so the wizard step that would have repaired it
+// never ran again.
+//
+// Two fixes are pinned here:
+//   1. install.sh REFUSES the transition, before it changes anything.
+//   2. step_validate_services can see units belonging to another edition, so
+//      "All N checks healthy" is no longer printable on a two-harness box.
+//
+// Making the switch actually work is a separate feature and deliberately not
+// attempted — changing edition is a reflash.
+
+const REPO = path.resolve(__dirname, "../../..");
+const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const HERMES_EDITION_SH = fs.readFileSync(
+  path.join(REPO, "scripts/setup-hermes-edition.sh"),
+  "utf-8",
+);
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+/** Source text between two literal markers, `end` exclusive. */
+function sliceOf(source: string, startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  if (start < 0) throw new Error(`marker not found: ${startMarker}`);
+  const end = source.indexOf(endMarker, start);
+  if (end < 0) throw new Error(`marker not found: ${endMarker}`);
+  return source.slice(start, end);
+}
+
+const slice = (startMarker: string, endMarker: string) =>
+  sliceOf(INSTALL_SH, startMarker, endMarker);
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return `${INSTALL_SH.slice(start, end)}\n}`;
+}
+
+// ── The edition-resolution + refusal block, run for real ─────────────────────
+// Everything from the lock-file constants down to (not including) the edition
+// predicates: the resolution chain, the normalisation, and the refusal. The two
+// absolute paths are rewritten to a temp dir so the real code can be executed
+// unprivileged; nothing else is altered, so this exercises the shipped text.
+
+const REFUSAL_BLOCK = slice(
+  'CLAWBOX_EDITION_FILE="/etc/clawbox/edition.env"',
+  "# The Hermes SKU: Hermes is the ONLY harness",
+);
+
+/** Just the refusal, without the resolution chain that precedes it. */
+const REFUSAL_ONLY = slice(
+  "# ── Refuse to change the edition of an already-provisioned device",
+  "# The Hermes SKU: Hermes is the ONLY harness",
+);
+
+let tmp: string;
+let lockPath: string;
+let dropinPath: string;
+let projectDir: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-edition-"));
+  lockPath = path.join(tmp, "edition.env");
+  dropinPath = path.join(tmp, "edition.conf");
+  projectDir = path.join(tmp, "project");
+  fs.mkdirSync(path.join(projectDir, "config"), { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/** Write the root-owned lock the way step_edition_lock does. */
+function writeLock(edition: string): void {
+  fs.writeFileSync(
+    lockPath,
+    `# ClawBox edition lock — written by install.sh (step_edition_lock).\nCLAWBOX_EDITION=${edition}\n`,
+  );
+}
+
+/** Write the legacy systemd drop-in — the only record on pre-edition.env boxes. */
+function writeLegacyDropin(edition: string): void {
+  fs.writeFileSync(dropinPath, `[Service]\nEnvironment=CLAWBOX_EDITION=${edition}\n`);
+}
+
+function runRefusal(env: Record<string, string> = {}): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const script = [
+    "set -euo pipefail",
+    `PROJECT_DIR=${JSON.stringify(projectDir)}`,
+    REFUSAL_BLOCK.replace('"/etc/clawbox/edition.env"', JSON.stringify(lockPath)).replace(
+      '"/etc/systemd/system/clawbox-setup.service.d/edition.conf"',
+      JSON.stringify(dropinPath),
+    ),
+    'printf "RESOLVED=%s\\n" "$CLAWBOX_EDITION"',
+  ].join("\n");
+
+  // Deliberately NOT inheriting process.env: a CLAWBOX_EDITION already exported
+  // in the developer's shell would silently rewrite what these cases are asking.
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV, ...env },
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+d("install.sh refuses to change a provisioned device's edition", () => {
+  it("refuses when the lock says one edition and the environment asks for another", () => {
+    writeLock("hermes");
+    const r = runRefusal({ CLAWBOX_EDITION: "openclaw" });
+
+    expect(r.status).toBe(1);
+    expect(r.stdout).not.toContain("RESOLVED=");
+    // The operator must be told what the device IS, what was ASKED for, and
+    // that the supported route is a reflash. A bare "refused" sends them
+    // straight to the escape hatch.
+    expect(r.stderr).toContain("already installed as the 'hermes' edition");
+    expect(r.stderr).toMatch(/Recorded edition:\s+hermes/);
+    expect(r.stderr).toMatch(/Requested edition:\s+openclaw/);
+    expect(r.stderr).toMatch(/REFLASH/i);
+    // The escape hatch has to be named, or the message is a dead end...
+    expect(r.stderr).toContain("CLAWBOX_ALLOW_EDITION_CHANGE=1");
+    // ...as does the way back to a normal re-install of what it already is.
+    expect(r.stderr).toContain("CLAWBOX_EDITION=hermes");
+  });
+
+  it("changes nothing on the way out", () => {
+    writeLock("hermes");
+    const before = fs.readFileSync(lockPath, "utf-8");
+    const filesBefore = fs.readdirSync(tmp).sort();
+
+    const r = runRefusal({ CLAWBOX_EDITION: "openclaw" });
+
+    expect(r.status).toBe(1);
+    // The refusal is worthless if it fires after the lock has been rewritten or
+    // the gateway unmasked, so it must reach the exit having written nothing.
+    expect(fs.readFileSync(lockPath, "utf-8")).toBe(before);
+    expect(fs.existsSync(dropinPath)).toBe(false);
+    expect(fs.readdirSync(tmp).sort()).toEqual(filesBefore);
+    expect(r.stderr).toContain("Nothing has been changed");
+  });
+
+  it("refuses on the legacy drop-in too — that is the only record on older boxes", () => {
+    // Boxes provisioned before /etc/clawbox/edition.env existed carry the SKU
+    // only in the systemd drop-in. Reading just the new file would leave that
+    // whole part of the fleet switchable.
+    writeLegacyDropin("hermes");
+    const r = runRefusal({ CLAWBOX_EDITION: "openclaw" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("already installed as the 'hermes' edition");
+  });
+
+  it("permits the switch with the explicit escape hatch", () => {
+    writeLock("hermes");
+    const r = runRefusal({ CLAWBOX_EDITION: "openclaw", CLAWBOX_ALLOW_EDITION_CHANGE: "1" });
+
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=openclaw");
+    // Permitted, but never quiet: the operator owns the teardown and the
+    // credentials that the installer will not move for them.
+    expect(r.stderr).toContain("WARNING");
+    expect(r.stderr).toContain("CLAWBOX_ALLOW_EDITION_CHANGE=1");
+  });
+
+  it("takes only an explicit 1 as the escape hatch", () => {
+    // A truthy-looking value must not open the gate by accident.
+    writeLock("hermes");
+    for (const value of ["0", "yes", "true", "", "2"]) {
+      const r = runRefusal({ CLAWBOX_EDITION: "openclaw", CLAWBOX_ALLOW_EDITION_CHANGE: value });
+      expect(r.status, `CLAWBOX_ALLOW_EDITION_CHANGE=${value}`).toBe(1);
+    }
+  });
+});
+
+d("the paths that must stay unaffected", () => {
+  it("a fresh install with no lock installs whatever was asked for", () => {
+    const r = runRefusal({ CLAWBOX_EDITION: "hermes" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=hermes");
+    expect(r.stderr).toBe("");
+  });
+
+  it("a same-edition re-install is untouched", () => {
+    writeLock("hermes");
+    const r = runRefusal({ CLAWBOX_EDITION: "hermes" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=hermes");
+    expect(r.stderr).toBe("");
+  });
+
+  it("the updater's path is untouched — no env var, edition read from the lock", () => {
+    // post_update re-runs provisioning on EVERY update via
+    // `install.sh --step`, whose unit exports CLAWBOX_EDITION from the lock
+    // file. Requested and recorded are the same value by construction, so the
+    // refusal must never fire on an update.
+    writeLock("hermes");
+    const r = runRefusal();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=hermes");
+    expect(r.stderr).toBe("");
+  });
+
+  it("matches case-insensitively, like every other edition consumer", () => {
+    // src/lib/edition-source.ts lower-cases; a lock reading "Hermes" is the
+    // same device, not a switch.
+    writeLock("Hermes");
+    const r = runRefusal({ CLAWBOX_EDITION: "hermes" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=hermes");
+  });
+
+  it("does not refuse over an unrecognised recorded value", () => {
+    // An unrecognised edition resolves to openclaw everywhere else, so a typo'd
+    // lock describes an openclaw box. Refusing here would brick its updates.
+    writeLock("openclw");
+    const r = runRefusal({ CLAWBOX_EDITION: "openclaw" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=openclaw");
+  });
+
+  it("does not treat config/edition.txt as a record", () => {
+    // edition.txt is a first-flash seed in a tree the customer owns. Reading it
+    // as a lock would let anyone with write access to $PROJECT_DIR manufacture
+    // a refusal — and would refuse genuine first installs.
+    fs.writeFileSync(path.join(projectDir, "config", "edition.txt"), "hermes\n");
+    const r = runRefusal({ CLAWBOX_EDITION: "openclaw" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=openclaw");
+  });
+});
+
+d("dual is a distinct edition, in both directions", () => {
+  // Both directions into and out of dual are switches. dual is its own SKU
+  // (both harnesses plus a licence-gated runtime switcher), and the ADDITIVE
+  // direction fails exactly like the destructive one: the harness being added
+  // comes up with an empty provider registry and no credentials, while
+  // setup_complete suppresses the wizard step that would supply them. The lock
+  // exists so the SKU cannot be flipped from the environment, so "upgrading" to
+  // premium by exporting a variable is precisely what it has to refuse.
+  const pairs: Array<[string, string]> = [
+    ["openclaw", "dual"],
+    ["hermes", "dual"],
+    ["dual", "openclaw"],
+    ["dual", "hermes"],
+    ["openclaw", "hermes"],
+    ["hermes", "openclaw"],
+  ];
+
+  for (const [recorded, requested] of pairs) {
+    it(`refuses ${recorded} -> ${requested}`, () => {
+      writeLock(recorded);
+      const r = runRefusal({ CLAWBOX_EDITION: requested });
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain(`already installed as the '${recorded}' edition`);
+    });
+  }
+
+  for (const edition of ["openclaw", "hermes", "dual"]) {
+    it(`allows a plain ${edition} re-install`, () => {
+      writeLock(edition);
+      const r = runRefusal({ CLAWBOX_EDITION: edition });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain(`RESOLVED=${edition}`);
+    });
+  }
+});
+
+describe("the refusal runs before anything can be changed", () => {
+  it("sits at the top level, before any step function is even defined", () => {
+    // Placement is the whole fix. It has to precede step_edition_lock (which
+    // rewrites the lock and the drop-in) and step_edition_gateway_state (which
+    // unmasks the gateway). Being ahead of the FIRST step definition is the
+    // strong form of that: no step exists yet, on any entry path.
+    const refusal = INSTALL_SH.indexOf("already installed as the");
+    expect(refusal).toBeGreaterThan(0);
+    const firstStepDefinition = INSTALL_SH.search(/^step_[a-z_]+\(\) \{/m);
+    expect(firstStepDefinition).toBeGreaterThan(0);
+    expect(refusal).toBeLessThan(firstStepDefinition);
+  });
+
+  it("precedes both entry paths — full install and --step dispatch", () => {
+    const refusal = INSTALL_SH.indexOf("already installed as the");
+    expect(refusal).toBeLessThan(INSTALL_SH.indexOf("DISPATCH_STEPS=("));
+    expect(refusal).toBeLessThan(INSTALL_SH.indexOf('echo "=== ClawBox Installer ==="'));
+  });
+
+  it("is a hard exit, not a warning", () => {
+    expect(REFUSAL_ONLY).toContain("exit 1");
+    expect(REFUSAL_ONLY).toContain(
+      'CLAWBOX_ALLOW_EDITION_CHANGE="${CLAWBOX_ALLOW_EDITION_CHANGE:-0}"',
+    );
+  });
+
+  it("does not implement edition switching", () => {
+    // Explicitly out of scope: migrating credentials, tearing down the other
+    // harness and re-running the AI step is a feature, not a bug fix. If a
+    // teardown ever appears, this test should be deleted along with the
+    // refusal — not silently left passing next to a half-migration.
+    expect(REFUSAL_ONLY).not.toMatch(/systemctl\s+(stop|disable|mask|unmask)/);
+    expect(REFUSAL_ONLY).not.toMatch(/\brm\s+-[rf]/);
+  });
+});
+
+// ── The validator's blind spot ──────────────────────────────────────────────
+// step_validate_services only ever appended the Hermes units to
+// EXPECTED_ACTIVE_SERVICES inside `if has_hermes_harness`, so on the openclaw
+// edition a fully running Hermes stack was not merely tolerated — it was
+// invisible, and the installer printed a clean bill of health for a device
+// running two agent harnesses.
+
+const SERVICE_REGISTRY = slice(
+  "# The Hermes SKU: Hermes is the ONLY harness",
+  "# Load persisted WiFi interface if available",
+);
+
+/** Just the FOREIGN_EDITION_UNITS construction, out of the registry above. */
+const FOREIGN_REGISTRY = SERVICE_REGISTRY.slice(
+  SERVICE_REGISTRY.indexOf("FOREIGN_EDITION_UNITS=()"),
+);
+
+/** A fake `systemctl` over a table of `unit -> "<enabled>:<active>"`. */
+function systemctlStub(units: Record<string, string>): string {
+  const arms = Object.entries(units)
+    .map(([unit, state]) => `    ${unit}) printf '%s' '${state}' ;;`)
+    .join("\n");
+  return `
+_unit_state() {
+  case "$1" in
+${arms}
+    *) return 1 ;;
+  esac
+}
+systemctl() {
+  local verb="$1"; shift
+  local unit="\${1:-}"
+  local st
+  case "$verb" in
+    cat) _unit_state "$unit" >/dev/null 2>&1 || return 1 ;;
+    is-enabled) st="$(_unit_state "$unit")" || return 1; printf '%s' "\${st%%:*}" ;;
+    is-active) st="$(_unit_state "$unit")" || { printf 'inactive'; return 1; }; printf '%s' "\${st##*:}" ;;
+    status) printf 'stub status for %s\\n' "$unit" ;;
+    *) : ;;
+  esac
+  return 0
+}
+`;
+}
+
+function runValidator(
+  edition: string,
+  units: Record<string, string>,
+): { status: number; stdout: string } {
+  const script = [
+    "set -uo pipefail",
+    `CLAWBOX_EDITION=${edition}`,
+    "CLAWBOX_TEST_MODE=1",
+    "PROJECT_DIR=/nonexistent",
+    "CLAWBOX_HOME=/nonexistent",
+    'IFACE_ENV="/nonexistent/network.env"',
+    SERVICE_REGISTRY,
+    // The poll loop reads `date +%s` twice per pass and gives up after 30s. A
+    // clock that jumps 100s per read makes a failing run break after ONE pass
+    // instead of polling for half a minute. It has to be file-backed: `date` is
+    // called inside command substitution, so a shell variable would be
+    // incremented in a subshell and the parent would never see the deadline
+    // pass — an infinite loop, not a slow test.
+    `_CLOCK=${JSON.stringify(path.join(tmp, "clock"))}`,
+    'echo 1000 > "$_CLOCK"',
+    'date() { local n; n=$(( $(cat "$_CLOCK") + 100 )); echo "$n" > "$_CLOCK"; printf \'%s\' "$n"; }',
+    "sleep() { :; }",
+    "curl() { printf '200'; }",
+    "gateway_port_listening() { return 1; }",
+    systemctlStub(units),
+    extractShellFunction("step_validate_services"),
+    "step_validate_services",
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    // NODE_ENV is not read by any shell here; it is carried only because this
+    // repo's ProcessEnv typing makes it required on an env literal.
+    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV },
+  });
+  return { status: r.status ?? -1, stdout: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+/** Every unit an openclaw device is supposed to have, all healthy. */
+function healthyOpenclaw(): Record<string, string> {
+  return {
+    "clawbox-setup.service": "enabled:active",
+    "clawbox-gateway.service": "enabled:active",
+    "clawbox-heartbeat.timer": "enabled:active",
+    "clawbox-ap-watchdog.timer": "enabled:active",
+    "clawbox-codex-auth-sync.timer": "enabled:active",
+    "clawbox-heartbeat.service": "static:inactive",
+    "clawbox-browser.service": "disabled:inactive",
+    "clawbox-tunnel.service": "disabled:inactive",
+    "clawbox-root-update@.service": "static:inactive",
+    "clawbox-ap-watchdog.service": "static:inactive",
+    "clawbox-codex-auth-sync.service": "static:inactive",
+  };
+}
+
+d("step_validate_services sees units belonging to another edition", () => {
+  it("still passes a clean openclaw device", () => {
+    const r = runValidator("openclaw", healthyOpenclaw());
+    expect(r.stdout).toContain("checks healthy");
+    expect(r.status).toBe(0);
+  });
+
+  it("fails an openclaw device that is still running the Hermes stack", () => {
+    // The exact device state that reported "All 15 checks healthy": every
+    // openclaw unit up, and every Hermes unit left active and enabled.
+    const r = runValidator("openclaw", {
+      ...healthyOpenclaw(),
+      "clawbox-hermes-dashboard.service": "enabled:active",
+      "clawbox-hermes-dashboard-proxy.service": "enabled:active",
+      "hermes-gateway.service": "enabled:active",
+    });
+
+    expect(r.status).toBe(1);
+    expect(r.stdout).not.toContain("checks healthy");
+    expect(r.stdout).toContain("clawbox-hermes-dashboard.service");
+    expect(r.stdout).toContain("clawbox-hermes-dashboard-proxy.service");
+    // The unit holding the Telegram bot token, hence the conflict loop.
+    expect(r.stdout).toContain("hermes-gateway.service");
+    expect(r.stdout).toContain("another edition");
+  });
+
+  it("fails on a foreign unit that is merely enabled — one reboot from active", () => {
+    const r = runValidator("openclaw", {
+      ...healthyOpenclaw(),
+      "hermes-gateway.service": "enabled:inactive",
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toMatch(/hermes-gateway\.service is enabled/);
+  });
+
+  it("ignores a foreign unit that is installed but disabled and stopped", () => {
+    const r = runValidator("openclaw", {
+      ...healthyOpenclaw(),
+      "hermes-gateway.service": "disabled:inactive",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("checks healthy");
+  });
+
+  it("fails a hermes device that is still running the OpenClaw gateway", () => {
+    const hermes: Record<string, string> = {
+      "clawbox-setup.service": "enabled:active",
+      "clawbox-heartbeat.timer": "enabled:active",
+      "clawbox-ap-watchdog.timer": "enabled:active",
+      "clawbox-codex-auth-sync.timer": "enabled:active",
+      "clawbox-hermes-dashboard.service": "enabled:active",
+      "clawbox-hermes-dashboard-proxy.service": "enabled:active",
+      "clawbox-heartbeat.service": "static:inactive",
+      "clawbox-browser.service": "disabled:inactive",
+      "clawbox-tunnel.service": "disabled:inactive",
+      "clawbox-root-update@.service": "static:inactive",
+      "clawbox-ap-watchdog.service": "static:inactive",
+      "clawbox-codex-auth-sync.service": "static:inactive",
+      "clawbox-gateway.service": "enabled:active",
+    };
+    const r = runValidator("hermes", hermes);
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain("clawbox-gateway.service");
+  });
+
+  it("counts the foreign checks in the total, so the healthy line moves with them", () => {
+    // Reporting "All N healthy" while silently not running some of the checks
+    // is how the blind spot read as health in the first place.
+    const withoutHermes = runValidator("openclaw", healthyOpenclaw());
+    const total = /All (\d+) checks healthy/.exec(withoutHermes.stdout)?.[1];
+    expect(total).toBeDefined();
+    // 5 active (test mode drops clawbox-ap + clawbox-performance) + 6 installed
+    // + 1 probe (test mode drops the WiFi probe) + 3 foreign-unit checks.
+    expect(Number(total)).toBe(15);
+  });
+});
+
+// ── The second writer of the lock ───────────────────────────────────────────
+// scripts/setup-hermes-edition.sh also rewrites /etc/clawbox/edition.env (and
+// the legacy drop-in). Guarding only install.sh would leave a documented
+// standalone command that flips the lock — and worse, LAUNDERS the change: once
+// the lock reads the new edition, a later plain install.sh sees recorded ==
+// requested, finds no mismatch, and provisions the new harness on top.
+
+const HERMES_EDITION_STEP_0 = sliceOf(
+  HERMES_EDITION_SH,
+  "# ── 0. Which edition are we?",
+  "# ── 1. Sanity: Hermes must be present",
+);
+
+function runHermesEditionStep0(env: Record<string, string> = {}): {
+  status: number;
+  stdout: string;
+  stderr: string;
+} {
+  const script = [
+    "set -euo pipefail",
+    `EDITION_FILE=${JSON.stringify(lockPath)}`,
+    'log() { echo "[hermes-edition] $*"; }',
+    HERMES_EDITION_STEP_0,
+    'printf "EDITION=%s\\n" "$EDITION"',
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV, ...env },
+  });
+  return { status: r.status ?? -1, stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}
+
+d("scripts/setup-hermes-edition.sh refuses the same transition", () => {
+  it("refuses when the environment disagrees with the recorded lock", () => {
+    writeLock("hermes");
+    const r = runHermesEditionStep0({ CLAWBOX_EDITION: "dual" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("already installed as the 'hermes' edition");
+    expect(r.stderr).toContain("CLAWBOX_ALLOW_EDITION_CHANGE=1");
+    // Must not reach the provisioning that rewrites the lock.
+    expect(r.stdout).not.toContain("EDITION=");
+    expect(fs.readFileSync(lockPath, "utf-8")).toContain("CLAWBOX_EDITION=hermes");
+  });
+
+  it("refuses the hermes -> openclaw direction by simply having nothing to do", () => {
+    // openclaw never reaches the lock-writing code at all: the SKU gate exits 0.
+    writeLock("hermes");
+    const r = runHermesEditionStep0({ CLAWBOX_EDITION: "openclaw" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("already installed as the 'hermes' edition");
+  });
+
+  it("permits the switch with the same escape hatch", () => {
+    writeLock("hermes");
+    const r = runHermesEditionStep0({
+      CLAWBOX_EDITION: "dual",
+      CLAWBOX_ALLOW_EDITION_CHANGE: "1",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("EDITION=dual");
+    expect(r.stdout).toContain("WARNING");
+  });
+
+  it("leaves install.sh's own call untouched", () => {
+    // step_edition_lock runs before step_hermes_edition, so by the time this
+    // script is invoked the lock and $CLAWBOX_EDITION always agree.
+    for (const edition of ["hermes", "dual"]) {
+      writeLock(edition);
+      const r = runHermesEditionStep0({ CLAWBOX_EDITION: edition });
+      expect(r.status, edition).toBe(0);
+      expect(r.stdout).toContain(`EDITION=${edition}`);
+    }
+  });
+
+  it("leaves a standalone repair run untouched — lock, no environment", () => {
+    writeLock("hermes");
+    const r = runHermesEditionStep0();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("EDITION=hermes");
+  });
+
+  it("leaves a first flash untouched — environment, no lock yet", () => {
+    const r = runHermesEditionStep0({ CLAWBOX_EDITION: "dual" });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("EDITION=dual");
+  });
+
+  it("keeps the historical default when neither is present", () => {
+    const r = runHermesEditionStep0();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("EDITION=hermes");
+  });
+
+  it("still does nothing at all on an openclaw device", () => {
+    writeLock("openclaw");
+    const r = runHermesEditionStep0();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("nothing to do");
+    expect(r.stdout).not.toContain("EDITION=openclaw");
+  });
+
+  it("reads the lock before the environment, like every other consumer", () => {
+    // The old order was env-first, which made this the one place where an
+    // environment variable outranked the root-owned lock — and the one place
+    // that then rewrote it.
+    expect(HERMES_EDITION_STEP_0.indexOf("RECORDED_EDITION=")).toBeLessThan(
+      HERMES_EDITION_STEP_0.indexOf("REQUESTED_EDITION="),
+    );
+    expect(HERMES_EDITION_STEP_0).toContain("exit 1");
+  });
+});
+
+describe("the foreign-unit registry", () => {
+  it("covers the whole Hermes harness on editions that do not run it", () => {
+    expect(FOREIGN_REGISTRY).toContain("if ! has_hermes_harness; then");
+    for (const unit of [
+      "clawbox-hermes-dashboard.service",
+      "clawbox-hermes-dashboard-proxy.service",
+      // Written by the upstream Hermes installer, not by config/. No ClawBox
+      // code path stops it, and it is the one holding the Telegram bot token.
+      "hermes-gateway.service",
+    ]) {
+      expect(FOREIGN_REGISTRY).toContain(unit);
+    }
+  });
+
+  it("covers the OpenClaw gateway on editions that do not run it", () => {
+    expect(FOREIGN_REGISTRY).toContain("if ! has_openclaw_harness; then");
+    expect(FOREIGN_REGISTRY).toContain("FOREIGN_EDITION_UNITS+=(clawbox-gateway.service)");
+  });
+
+  it("leaves dual alone — it is the edition that legitimately runs both", () => {
+    // Both guards are negations of the has_*_harness predicates, and dual
+    // satisfies both, so dual accumulates nothing.
+    expect(FOREIGN_REGISTRY).not.toContain("is_hermes_edition");
+    expect(INSTALL_SH).toContain('has_hermes_harness() { [ "$CLAWBOX_EDITION" = "hermes" ] || [ "$CLAWBOX_EDITION" = "dual" ]; }');
+    expect(INSTALL_SH).toContain('has_openclaw_harness() { [ "$CLAWBOX_EDITION" != "hermes" ]; }');
+  });
+
+  it("every ClawBox-shipped harness unit is claimed by exactly one edition", () => {
+    // EDITION_SCOPED_UNITS lists the units that exist in config/ but are only
+    // installed on some SKUs. Each of them must also be recognisable as foreign
+    // somewhere, or the validator keeps a blind spot for it.
+    const scoped = slice("EDITION_SCOPED_UNITS=(", "\n)")
+      .split("\n")
+      .slice(1)
+      // Strip trailing comments, then the quotes some entries carry
+      // (`"clawbox-root-update@.service"` in the sibling arrays).
+      .map((l) => l.replace(/#.*$/, "").trim().replace(/^"|"$/g, ""))
+      .filter(Boolean);
+    expect(scoped.length).toBeGreaterThan(0);
+    for (const unit of scoped) expect(FOREIGN_REGISTRY).toContain(unit);
+  });
+});

--- a/src/tests/unit/install-edition-switch-refusal.test.ts
+++ b/src/tests/unit/install-edition-switch-refusal.test.ts
@@ -231,6 +231,27 @@ d("the paths that must stay unaffected", () => {
     expect(r.stdout).toContain("RESOLVED=hermes");
   });
 
+  it("normalises whitespace the same way on both sides of the comparison", () => {
+    // The recorded value is whitespace-stripped by _normalise_edition. If the
+    // resolution rule did not strip it too, a padded CLAWBOX_EDITION resolved to
+    // openclaw (unrecognised → warn → openclaw) while the lock still read
+    // hermes — a refusal on a device nobody was trying to change, reporting a
+    // requested edition the operator never typed.
+    writeLock("hermes");
+    const r = runRefusal({ CLAWBOX_EDITION: "  hermes  " });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("RESOLVED=hermes");
+    expect(r.stderr).toBe("");
+  });
+
+  it("still refuses a padded value that IS a different edition", () => {
+    // Whitespace tolerance must not blunt the check itself.
+    writeLock("hermes");
+    const r = runRefusal({ CLAWBOX_EDITION: " openclaw " });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/Requested edition:\s+openclaw/);
+  });
+
   it("does not refuse over an unrecognised recorded value", () => {
     // An unrecognised edition resolves to openclaw everywhere else, so a typo'd
     // lock describes an openclaw box. Refusing here would brick its updates.
@@ -521,6 +542,7 @@ function runHermesEditionStep0(env: Record<string, string> = {}): {
   const script = [
     "set -euo pipefail",
     `EDITION_FILE=${JSON.stringify(lockPath)}`,
+    `EDITION_DROPIN=${JSON.stringify(dropinPath)}`,
     'log() { echo "[hermes-edition] $*"; }',
     HERMES_EDITION_STEP_0,
     'printf "EDITION=%s\\n" "$EDITION"',
@@ -551,6 +573,30 @@ d("scripts/setup-hermes-edition.sh refuses the same transition", () => {
     const r = runHermesEditionStep0({ CLAWBOX_EDITION: "openclaw" });
     expect(r.status).toBe(1);
     expect(r.stderr).toContain("already installed as the 'hermes' edition");
+  });
+
+  it("refuses on the legacy drop-in too", () => {
+    // Reading only /etc/clawbox/edition.env left every device provisioned before
+    // that file existed able to walk straight past the refusal — the drop-in is
+    // their only durable record.
+    writeLegacyDropin("hermes");
+    const r = runHermesEditionStep0({ CLAWBOX_EDITION: "dual" });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain("already installed as the 'hermes' edition");
+  });
+
+  it("treats an unrecognised recorded value as openclaw, not as absent", () => {
+    // Matching install.sh's rule. Reading it as "absent" would clear the
+    // refusal and let a typo'd lock be provisioned straight over.
+    writeLock("openclw");
+    const refused = runHermesEditionStep0({ CLAWBOX_EDITION: "hermes" });
+    expect(refused.status).toBe(1);
+    expect(refused.stderr).toContain("already installed as the 'openclaw' edition");
+
+    // ...and with no request it is simply an openclaw box: nothing to do.
+    const bare = runHermesEditionStep0();
+    expect(bare.status).toBe(0);
+    expect(bare.stdout).toContain("nothing to do");
   });
 
   it("permits the switch with the same escape hatch", () => {


### PR DESCRIPTION
## Problem

Re-running the installer with a different `CLAWBOX_EDITION` on a device that is already provisioned completed all 26 steps and printed a healthy summary — for a device left in a state it cannot recover from on its own.

The installer installs an edition; it does not migrate one. There is no step that stops, disables or masks the harness a device is leaving, and each harness keeps its AI provider credentials in its own config file, so a sign-in does not move across. What you get is:

- both harnesses running at once — two agents, two dashboards, and two pollers on one Telegram bot token;
- the incoming harness with an empty provider registry, so no model resolves and every chat turn fails;
- a previously signed-in device reading as signed out;
- `setup_complete` carried over, so the wizard step that would repair all of it never runs again.

`docs-site/editions/overview.mdx` already documented edition changes as reflash-only. The installer just did not enforce it.

## What this changes

**1. The installer refuses the transition.** `install.sh` compares the requested edition against the root-owned lock — with the legacy systemd drop-in as the fallback, so boxes provisioned before `edition.env` existed are covered too — and stops before anything is changed. The message states what the device currently is, what was requested, that changing edition requires a reflash, and names the single override.

The check sits immediately after the edition resolves, during constant parsing. That is ahead of the lock and drop-in rewrite, ahead of any mask/unmask, and ahead of any unit being copied, enabled or started — on the full-install path **and** on the `--step` dispatch path the in-app updater uses, since both reach that point before any step function is even defined. A refusal that fires after the gateway has been unmasked would not be a refusal.

`CLAWBOX_ALLOW_EDITION_CHANGE=1` is the one explicit escape hatch. It is named in the refusal and left out of the customer-facing docs on purpose.

**2. The other writer of the lock carries the same refusal.** `scripts/setup-hermes-edition.sh` also rewrites `/etc/clawbox/edition.env` and the legacy drop-in, and it read `$CLAWBOX_EDITION` ahead of the lock — the one place where the environment outranked the root-owned file, and the place that then rewrote it. Guarding only `install.sh` would have left that path open, and worse, it launders the change: once the lock reads the new edition, a later plain `install.sh` sees no mismatch and provisions on top. Both writers now refuse, and this one reads the lock first like every other consumer.

**3. `dual` is a distinct edition in both directions.** `openclaw → dual` and `hermes → dual` are refused too. The additive direction fails the same way as the destructive one — the harness being *added* comes up with no provider registry and no credentials, and `setup_complete` suppresses the step that would populate them — and the lock exists precisely so the SKU cannot be selected from the environment.

**4. Validation is honest about foreign units.** `step_validate_services` only ever asserted that *this* edition's units are up; it appends the Hermes units inside `if has_hermes_harness`, so on `openclaw` a fully running Hermes stack was not merely tolerated, it was invisible. A new `FOREIGN_EDITION_UNITS` registry — built from the existing `has_hermes_harness` / `has_openclaw_harness` predicates, so `dual` accumulates nothing and needs no special case — is now checked, and any foreign unit that is active *or* merely enabled fails the run. That is what stops the healthy summary being printable on a device running two harnesses.

Edition migration is deliberately **not** implemented. Doing it properly means migrating credentials, tearing down the other harness and re-running the AI step; that is a feature, not this fix.

## Unaffected

- **Fresh installs** — no lock yet, so nothing to disagree with.
- **Same-edition re-installs** — recorded equals requested.
- **`post_update` / the in-app updater** — `clawbox-root-update@.service` exports `CLAWBOX_EDITION` from the lock, so requested and recorded are equal by construction on every step it dispatches.
- **`config/edition.txt`** is still a resolution source but is never treated as a *record*; it lives in a customer-writable tree.
- An unrecognised recorded value normalises to `openclaw` before comparing, so a typo'd lock cannot brick a device's updates.

## Tests

`src/tests/unit/install-edition-switch-refusal.test.ts` (43 tests). Following the conventions in `install-edition-lock.test.ts` and `register-mcp-hermes.test.ts`, these **execute the shipped shell text** rather than string-matching it: the edition-resolution/refusal region and `step_validate_services` are extracted from `install.sh` and run against a temp lock file and a fake `systemd`.

- Refusal fires on lock/env disagreement, and the lock file is byte-identical afterwards with no drop-in created.
- The escape hatch permits it; only a literal `1` opens it (`yes`, `true`, `2`, `0` all still refuse).
- Fresh install, same-edition re-install, updater path (no env var), case-insensitive lock, and unrecognised lock values are all unaffected.
- All six recorded→requested transitions refuse; all three same-edition re-installs pass.
- Ordering is pinned structurally: the refusal precedes the first `step_*` definition, `DISPATCH_STEPS`, and the installer banner.
- A test asserts the refusal block contains no `systemctl stop|disable|mask|unmask` and no `rm -rf`, holding the "no migration" scope boundary.
- Validator: a clean `openclaw` box passes; the same box with the Hermes stack alive fails 3 of 15; enabled-but-inactive fails; installed-but-disabled passes; `hermes` still running the gateway fails; `dual` running both is healthy.

Full suite green — 197 files, 2458 tests. `eslint` clean on the changed files, `shellcheck -S warning` clean on both scripts, no new `tsc` errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installation now records and validates the selected edition.
  * Reinstallations reuse the recorded edition by default and prevent incompatible edition changes.
  * Edition changes can be explicitly overridden when required.
  * Installation checks now detect active or enabled services from other editions.

* **Documentation**
  * Added guidance on first-install edition selection, reinstallations, overrides, and reflashing requirements.

* **Bug Fixes**
  * Improved handling of invalid, legacy, missing, and case-variant edition values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->