### PR TITLE
fix: route every direct preference write through one checked door

### DIFF
--- a/scripts/hermes-dashboard-proxy.js
+++ b/scripts/hermes-dashboard-proxy.js
@@ -109,13 +109,14 @@ const HEADER_TERMINATOR = "\r\n\r\n";
 // rather than stripped, so two values differing only in control characters do
 // not collapse into the same line. U+FFFD is the conventional stand-in.
 const LOG_CONTROL_CHARACTERS = /\p{Cc}/gu;
-const LOG_FIELD_MAX_LENGTH = 200;
-function logSafe(value, maxLength = LOG_FIELD_MAX_LENGTH) {
-  const s = String(value);
-  if (s.length <= maxLength) return s.replace(LOG_CONTROL_CHARACTERS, "�");
+// U+FFFD REPLACEMENT CHARACTER, written by code point rather than as a literal
+// so the glyph does not read as mojibake in an editor — as in log-safe.ts.
+const LOG_REPLACEMENT = String.fromCharCode(0xfffd);
+function logSafe(s, maxLength) {
+  if (s.length <= maxLength) return s.replace(LOG_CONTROL_CHARACTERS, LOG_REPLACEMENT);
   // Cut first, then sanitise the head only: every character the pattern matches
   // is one UTF-16 code unit replaced by one, so no match can straddle the cut.
-  const head = s.slice(0, maxLength).replace(LOG_CONTROL_CHARACTERS, "�");
+  const head = s.slice(0, maxLength).replace(LOG_CONTROL_CHARACTERS, LOG_REPLACEMENT);
   return `${head}...[+${s.length - maxLength} chars]`;
 }
 

--- a/src/app/setup-api/apps/install/route.ts
+++ b/src/app/setup-api/apps/install/route.ts
@@ -4,10 +4,11 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
-import { DATA_DIR, getAll as configGetAll, setMany as configSetMany } from "@/lib/config-store";
+import { DATA_DIR, getAll as configGetAll } from "@/lib/config-store";
 import { getSkillsDir, findOpenclawBin } from "@/lib/openclaw-config";
 import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR, type InstalledMeta } from "@/lib/store-categories";
-import { boundPreferenceText, sanitizePreferenceWrites } from "@/lib/preference-schema";
+import { boundPreferenceText } from "@/lib/preference-schema";
+import { setPreferences } from "@/lib/preference-store";
 
 const STORE_SEARCH_API = "https://openclawhardware.dev/api/store/apps";
 const STORE_ICONS_BASE = "https://openclawhardware.dev/store/icons";
@@ -171,14 +172,10 @@ async function syncInstalledPreferences(appId: string): Promise<string | undefin
     if (!alreadyListed) {
       nextUpdates["pref:installed_apps"] = [...list, appId];
     }
-    // This writes to the config store directly rather than through
-    // POST /setup-api/preferences, so the preference rules are applied here.
-    // The check covers the entries carried over from the read above as well as
-    // the one being added. See src/lib/preference-schema.ts.
-    const checkedUpdates = sanitizePreferenceWrites(nextUpdates);
-    if (Object.keys(checkedUpdates).length > 0) {
-      await configSetMany(checkedUpdates);
-    }
+    // setPreferences applies the preference rules — this does not go through
+    // POST /setup-api/preferences, and the update carries over every entry read
+    // above alongside the one being added.
+    await setPreferences(nextUpdates);
     return undefined;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/app/setup-api/apps/uninstall/route.ts
+++ b/src/app/setup-api/apps/uninstall/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
-import { DATA_DIR, getAll as configGetAll, setMany as configSetMany } from "@/lib/config-store";
+import { DATA_DIR, getAll as configGetAll } from "@/lib/config-store";
+import { setPreferences } from "@/lib/preference-store";
 import { getSkillsDir } from "@/lib/openclaw-config";
 
 export const dynamic = "force-dynamic";
@@ -48,9 +49,10 @@ export async function POST(req: Request) {
         delete metaMap[appId];
         updates["pref:installed_meta"] = metaMap;
       }
-      if (Object.keys(updates).length > 0) {
-        await configSetMany(updates);
-      }
+      // setPreferences applies the preference rules — this does not go through
+      // POST /setup-api/preferences, and removing one entry writes the rest of
+      // the collection back out with it.
+      await setPreferences(updates);
     } catch (err) {
       console.warn("[uninstall] Failed to update installed_apps/meta preferences:", err instanceof Error ? err.message : err);
     }

--- a/src/app/setup-api/code/route.ts
+++ b/src/app/setup-api/code/route.ts
@@ -52,9 +52,7 @@ export async function POST(request: NextRequest) {
         const { projectId, name, color, description, template } = body;
         if (!projectId || !validateProjectId(projectId)) return err("Invalid project ID");
         if (!name) return err("Project name required");
-        // Shape and length are checked inside initProject too, before it creates
-        // anything, so the MCP door gets the same rules; a ValidationError from
-        // there is answered as a 400 below.
+        // Also checked in initProject, before anything is written.
         const meta = await initProject(projectId, name, { color, description, template });
         return ok({ success: true, project: meta });
       }

--- a/src/app/setup-api/preferences/route.ts
+++ b/src/app/setup-api/preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import * as config from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
-import { sanitizePreferences, validatePreference } from "@/lib/preference-schema";
+import { PREFERENCE_KEY_PREFIX, sanitizePreferences, validatePreference } from "@/lib/preference-schema";
 import { personaFilesFor, writeLanguagePersona } from "@/lib/language-persona";
 import { logSafe } from "@/lib/log-safe";
 
@@ -14,10 +14,14 @@ function isAllowed(key: string) {
   return ALLOWED_PREFIXES.some((p) => key.startsWith(p));
 }
 
-// Most keys one read may name. Every caller in the app asks for a single key
-// (see SettingsApp, i18n, mascot-client); the whole set is fetched with `all=1`
-// instead. Bound it so the size of a response follows the store rather than the
-// request.
+// Most keys one read may name, so the work and the response a request can ask
+// for do not follow the length of its query string.
+//
+// The largest caller is the `preferences_get` MCP tool, which sends its whole
+// readable-prefs allowlist in one request — 9 keys today (READABLE_PREFS in
+// mcp/tools/system.ts). The in-app callers ask for one (SettingsApp, i18n,
+// mascot-client) or use `all=1`. Headroom is deliberate: if that allowlist ever
+// grows past this cap the tool starts getting a 400, so raise this with it.
 const MAX_KEYS_PER_READ = 32;
 
 // GET /setup-api/preferences?keys=wp_opacity,wp_bg_color
@@ -40,8 +44,8 @@ export async function GET(req: Request) {
     // sanitizePreferences, which is where these objects end up.
     const result: Record<string, unknown> = Object.create(null);
     for (const [key, value] of Object.entries(allConfig)) {
-      if (key.startsWith("pref:")) {
-        result[key.slice(5)] = value;
+      if (key.startsWith(PREFERENCE_KEY_PREFIX)) {
+        result[key.slice(PREFERENCE_KEY_PREFIX.length)] = value;
       }
     }
     return NextResponse.json(sanitizePreferences(result));
@@ -51,20 +55,23 @@ export async function GET(req: Request) {
   if (!keysParam) {
     return NextResponse.json({ error: "keys or all param required" }, { status: 400 });
   }
-  const keys = keysParam.split(",").filter(isAllowed);
-  if (keys.length > MAX_KEYS_PER_READ) {
+  // Counted before the allowlist filter, so the bound is on what the request
+  // names rather than on what survives it.
+  const named = keysParam.split(",");
+  if (named.length > MAX_KEYS_PER_READ) {
     return NextResponse.json(
       { error: `at most ${MAX_KEYS_PER_READ} keys per request` },
       { status: 400 },
     );
   }
+  const keys = named.filter(isAllowed);
   // One read of the store rather than one per key: config.get() re-reads and
   // re-parses the whole file synchronously on every call, so the work of a
   // request would otherwise follow the length of its `keys` parameter.
   const allConfig = await config.getAll();
   const result: Record<string, unknown> = Object.create(null);
   for (const key of keys) {
-    result[key] = allConfig[`pref:${key}`];
+    result[key] = allConfig[`${PREFERENCE_KEY_PREFIX}${key}`];
   }
   return NextResponse.json(sanitizePreferences(result));
 }
@@ -88,7 +95,7 @@ export async function POST(req: Request) {
         console.error(`[preferences] Rejected write: ${logSafe(check.reason ?? "")}`);
         return NextResponse.json({ error: check.reason ?? "Invalid preference value" }, { status: 400 });
       }
-      entries[`pref:${key}`] = value;
+      entries[`${PREFERENCE_KEY_PREFIX}${key}`] = value;
     }
     if (Object.keys(entries).length > 0) {
       await config.setMany(entries);

--- a/src/app/setup-api/webapps/route.ts
+++ b/src/app/setup-api/webapps/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextRequest, NextResponse } from "next/server";
 import fs from "fs/promises";
 import path from "path";
-import { WEBAPPS_DIR, APP_ID_RE, deployWebapp, writeWebappIndex } from "@/lib/code-projects";
+import { WEBAPPS_DIR, APP_ID_RE, ValidationError, deployWebapp, writeWebappIndex } from "@/lib/code-projects";
 
 const MIME_TYPES: Record<string, string> = {
   ".html": "text/html; charset=utf-8",
@@ -107,6 +107,11 @@ export async function POST(request: NextRequest) {
       url: `/setup-api/webapps?app=${appId}`,
     });
   } catch (err) {
+    // A rejected field is the caller's to fix, so answer 400 rather than
+    // reporting it as a server failure.
+    if (err instanceof ValidationError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to create webapp" },
       { status: 500 }

--- a/src/lib/code-projects.ts
+++ b/src/lib/code-projects.ts
@@ -80,16 +80,18 @@ export function validateProjectId(id: string): boolean {
 export const MAX_PROJECT_NAME_LENGTH = 60;
 
 /**
- * The name a project may be created with, or a ValidationError.
+ * The name a project may be created with, trimmed — or a ValidationError.
  *
- * Checked here rather than at each caller because initProject writes the
- * directory and project.json before the name reaches the templates: a name the
- * templates cannot render has to be refused while nothing has been created yet,
- * so a rejected request leaves no project behind for the next attempt to
- * collide with. The MCP door declares the same limit (`zText(60)` in
- * mcp/tools/desktop.ts); this is where it is enforced.
+ * Checked in the library rather than at each route because initProject writes
+ * the directory and project.json before the name reaches the templates: a name
+ * the templates cannot render has to be refused while nothing has been created
+ * yet, so a rejected request leaves no project behind for the next attempt to
+ * collide with. deployWebapp applies it for the same reason — it is the
+ * chokepoint the webapps route and buildProject share. The MCP door declares
+ * the same limit (`zText(60)` in mcp/tools/desktop.ts); this is where it is
+ * enforced.
  */
-export function validateProjectName(name: unknown): string {
+function assertProjectName(name: unknown): string {
   if (typeof name !== "string") throw new ValidationError("Project name must be a string");
   const trimmed = name.trim();
   if (!trimmed) throw new ValidationError("Project name required");
@@ -142,8 +144,8 @@ export async function initProject(
   opts?: { color?: string; description?: string; template?: "blank" | "app" }
 ): Promise<ProjectMeta> {
   if (!validateProjectId(projectId)) throw new ValidationError("Invalid project ID");
-  // Before anything is created on disk — see validateProjectName.
-  const projectName = validateProjectName(name);
+  // Before anything is created on disk — see assertProjectName.
+  const projectName = assertProjectName(name);
 
   const dir = projectDir(projectId);
   const exists = await fs.stat(dir).catch(() => null);
@@ -581,13 +583,16 @@ export async function deployWebapp(
   html: string,
   meta: { name: string; color?: string; icon?: string },
 ): Promise<void> {
+  // Same rule and same reason as initProject: the name reaches meta.json and
+  // the desktop label, so bound it before any of that is written.
+  const name = assertProjectName(meta.name);
   await writeWebappIndex(appId, html);
   await fs.writeFile(
     path.join(WEBAPPS_DIR, appId, "meta.json"),
-    JSON.stringify({ name: meta.name, color: meta.color || "#f97316", icon: meta.icon || "" }),
+    JSON.stringify({ name, color: meta.color || "#f97316", icon: meta.icon || "" }),
     "utf-8",
   );
-  await registerWebappInPreferences(appId, meta.name, {
+  await registerWebappInPreferences(appId, name, {
     color: meta.color,
     iconUrl: meta.icon,
     webappUrl: `/setup-api/webapps?app=${appId}`,

--- a/src/lib/hermes-dashboard-auth.ts
+++ b/src/lib/hermes-dashboard-auth.ts
@@ -38,7 +38,7 @@ const REQUEST_TIMEOUT_MS = 8_000;
 // the dashboard means the request did not reach the API, which is what the
 // callers below already treat as "not signed in". Same rule and same reason as
 // mcp/lib/api.ts.
-const REDIRECT_POLICY = "manual" as const;
+const REDIRECT_POLICY = "manual";
 
 async function readPassword(): Promise<string> {
   try {

--- a/src/lib/preference-schema.ts
+++ b/src/lib/preference-schema.ts
@@ -35,10 +35,17 @@
 // On read the rules are applied PER ENTRY. Several preferences hold a
 // collection — installed-app metadata, an icon grid, a list of open windows —
 // where each member is independent of the others. A member that does not pass
-// costs only itself; the rest of the collection is still served. Anything that
-// writes straight to the config store rather than through
-// POST /setup-api/preferences applies the same rules with
-// `sanitizePreferenceWrites`, so every door agrees on what may be stored.
+// costs only itself; the rest of the collection is still served.
+//
+// The doors do not all answer a bad value the same way, on purpose:
+//
+//   - The user door (POST /setup-api/preferences) REJECTS the request, so a
+//     caller that sent an impossible value learns that.
+//   - The machine doors — app install/uninstall, the webapp registry — write
+//     on someone else's behalf and have no one to report a 400 to. They COERCE
+//     the label fields they control (`boundPreferenceText`) and DROP entries
+//     that still do not pass (`setPreferences` in src/lib/preference-store.ts),
+//     so a stray character in an app-store listing cannot fail an install.
 
 export const PREFERENCE_LANGUAGES = [
   "en",
@@ -78,21 +85,13 @@ const CONTROL_CHARACTERS_GLOBAL = new RegExp(CONTROL_CHARACTERS.source, "g");
 /** How a preference is spelled in the config store. */
 export const PREFERENCE_KEY_PREFIX = "pref:";
 
-const CLOSED_DOMAINS: Record<string, readonly string[]> = {
-  ui_language: PREFERENCE_LANGUAGES,
-  wp_fit: WALLPAPER_FITS,
-};
-
-/**
- * The domain for a key, if it has one. Own properties only: the table is a
- * plain object literal, so a name such as `constructor` would otherwise resolve
- * to an inherited value that is not a list of legal strings.
- */
-function closedDomainFor(key: string): readonly string[] | undefined {
-  return Object.prototype.hasOwnProperty.call(CLOSED_DOMAINS, key)
-    ? CLOSED_DOMAINS[key]
-    : undefined;
-}
+// A Map rather than an object literal: lookup is by own entry only, so a key
+// named after something on Object.prototype (`constructor`, `toString`) reads
+// as "no domain" instead of resolving to a value that is not a list.
+const CLOSED_DOMAINS = new Map<string, readonly string[]>([
+  ["ui_language", PREFERENCE_LANGUAGES],
+  ["wp_fit", WALLPAPER_FITS],
+]);
 
 export function isPreferenceLanguage(value: unknown): value is PreferenceLanguage {
   return typeof value === "string" && (PREFERENCE_LANGUAGES as readonly string[]).includes(value);
@@ -144,7 +143,7 @@ function checkShape(value: unknown, depth: number): string | null {
  * cannot be stored) and on read (so junk stored earlier is not served).
  */
 export function validatePreference(key: string, value: unknown): PreferenceCheck {
-  const domain = closedDomainFor(key);
+  const domain = CLOSED_DOMAINS.get(key);
   if (domain) {
     if (typeof value === "string" && domain.includes(value)) return { ok: true };
     return { ok: false, reason: `${key} must be one of: ${domain.join(", ")}` };
@@ -173,7 +172,9 @@ export function validatePreference(key: string, value: unknown): PreferenceCheck
  * reaches them at when it walks the value whole — so they are checked at that
  * same depth here and the two agree on what passes.
  */
-function keepPassingMembers(value: unknown): unknown | undefined {
+function keepPassingMembers(
+  value: unknown,
+): Record<string, unknown> | unknown[] | undefined {
   if (Array.isArray(value)) {
     return value.filter((item) => checkShape(item, 1) === null);
   }
@@ -210,11 +211,20 @@ export type PreferenceOutcome = { ok: true; value: unknown } | { ok: false };
  */
 export function sanitizePreferenceValue(key: string, value: unknown): PreferenceOutcome {
   if (validatePreference(key, value).ok) return { ok: true, value };
-  if (closedDomainFor(key)) return { ok: false };
 
   const pruned = keepPassingMembers(value);
   if (pruned === undefined) return { ok: false };
+  // A prune that dropped nothing cannot change the verdict, so don't pay for a
+  // second walk to reach the answer the first one already gave. This is the
+  // case where the value failed on a whole-value cap rather than on a member.
+  if (memberCount(pruned) === memberCount(value)) return { ok: false };
   return validatePreference(key, pruned).ok ? { ok: true, value: pruned } : { ok: false };
+}
+
+/** How many members a collection holds. */
+function memberCount(value: unknown): number {
+  if (Array.isArray(value)) return value.length;
+  return Object.keys(value as Record<string, unknown>).length;
 }
 
 /**
@@ -248,10 +258,14 @@ export function sanitizePreferenceWrites(
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   for (const [storeKey, value] of Object.entries(updates)) {
-    const key = storeKey.startsWith(PREFERENCE_KEY_PREFIX)
-      ? storeKey.slice(PREFERENCE_KEY_PREFIX.length)
-      : storeKey;
-    const kept = sanitizePreferenceValue(key, value);
+    // Only `pref:*` keys are preferences. The config store holds other things
+    // in the same namespace — tokens, setup flags, updater state — and the
+    // rules below would be wrong for those, so they pass through untouched.
+    if (!storeKey.startsWith(PREFERENCE_KEY_PREFIX)) {
+      out[storeKey] = value;
+      continue;
+    }
+    const kept = sanitizePreferenceValue(storeKey.slice(PREFERENCE_KEY_PREFIX.length), value);
     if (kept.ok) out[storeKey] = kept.value;
   }
   return out;

--- a/src/lib/preference-store.ts
+++ b/src/lib/preference-store.ts
@@ -1,0 +1,25 @@
+import { setMany } from "@/lib/config-store";
+import { sanitizePreferenceWrites } from "@/lib/preference-schema";
+
+/**
+ * Write `pref:*` entries to the config store, applying the preference rules
+ * first.
+ *
+ * The one door for code that stores preferences without going through
+ * POST /setup-api/preferences — the app install and uninstall routes, and the
+ * webapp registry. All three read the current value, change one entry and write
+ * the whole thing back, so the rules have to cover the entries they carry over
+ * as well as the one they are changing.
+ *
+ * Deliberately NOT folded into `config-store.setMany`: most of what that writes
+ * is not a preference at all (provider tokens, setup flags, updater state), and
+ * the preference rules — a length cap, no control characters — would be wrong
+ * for an opaque secret.
+ */
+export async function setPreferences(updates: Record<string, unknown>): Promise<void> {
+  const checked = sanitizePreferenceWrites(updates);
+  // Every entry can be dropped, and an empty write would still cost a full
+  // read-modify-rewrite of config.json.
+  if (Object.keys(checked).length === 0) return;
+  await setMany(checked);
+}

--- a/src/lib/webapp-registry.ts
+++ b/src/lib/webapp-registry.ts
@@ -1,5 +1,6 @@
-import { getAll, setMany } from "@/lib/config-store";
-import { boundPreferenceText, sanitizePreferenceWrites } from "@/lib/preference-schema";
+import { getAll } from "@/lib/config-store";
+import { boundPreferenceText } from "@/lib/preference-schema";
+import { setPreferences } from "@/lib/preference-store";
 
 interface InstalledMeta {
   name: string;
@@ -34,12 +35,10 @@ export async function registerWebappInPreferences(
   const installedMeta = (prefs["pref:installed_meta"] as Record<string, InstalledMeta> | undefined) ?? {};
   const hiddenInstalled = (prefs["pref:hidden_installed"] as string[] | undefined) ?? [];
 
-  // This writes to the config store directly rather than through
-  // POST /setup-api/preferences, so the preference rules are applied here: the
-  // label is bounded before it goes in, and the whole update — including the
-  // entries carried over from the read above — goes through the same check the
-  // route applies. See src/lib/preference-schema.ts.
-  const updates = sanitizePreferenceWrites({
+  // setPreferences applies the preference rules — this does not go through
+  // POST /setup-api/preferences, and the update carries over every entry read
+  // above alongside the one being added.
+  await setPreferences({
     "pref:installed_apps": installedApps.includes(appId) ? installedApps : [...installedApps, appId],
     "pref:installed_meta": {
       ...installedMeta,
@@ -53,5 +52,4 @@ export async function registerWebappInPreferences(
     // A freshly (re)created app shouldn't stay hidden.
     "pref:hidden_installed": hiddenInstalled.filter((id) => id !== appId),
   });
-  if (Object.keys(updates).length > 0) await setMany(updates);
 }

--- a/src/tests/routes/preferences-language.test.ts
+++ b/src/tests/routes/preferences-language.test.ts
@@ -31,7 +31,6 @@ vi.mock("fs/promises", () => ({
 import * as config from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
 
-const mockGet = vi.mocked(config.get);
 const mockGetAll = vi.mocked(config.getAll);
 const mockSetMany = vi.mocked(config.setMany);
 const mockActiveHarness = vi.mocked(getActiveHarness);
@@ -69,7 +68,6 @@ describe("/setup-api/preferences — language", () => {
     process.env.HOME = "/home/clawbox";
     delete process.env.HERMES_HOME;
     mockGetAll.mockResolvedValue({});
-    mockGet.mockResolvedValue(undefined as never);
     mockSetMany.mockResolvedValue(undefined);
     mockActiveHarness.mockResolvedValue("openclaw");
     const fsMod = (await import("fs/promises")).default;

--- a/src/tests/routes/preferences.test.ts
+++ b/src/tests/routes/preferences.test.ts
@@ -17,7 +17,6 @@ vi.mock("fs/promises", () => ({
 
 import * as config from "@/lib/config-store";
 
-const mockGet = vi.mocked(config.get);
 const mockGetAll = vi.mocked(config.getAll);
 const mockSetMany = vi.mocked(config.setMany);
 
@@ -29,7 +28,6 @@ describe("/setup-api/preferences", () => {
     vi.resetModules();
     vi.clearAllMocks();
     mockGetAll.mockResolvedValue({});
-    mockGet.mockResolvedValue(undefined as never);
     mockSetMany.mockResolvedValue(undefined);
     const fsMod = (await import("fs/promises")).default;
     vi.mocked(fsMod.mkdir).mockResolvedValue(undefined as never);

--- a/src/tests/routes/webapps.test.ts
+++ b/src/tests/routes/webapps.test.ts
@@ -19,6 +19,13 @@ vi.mock("@/lib/code-projects", () => ({
   deployWebapp: vi.fn().mockResolvedValue(undefined),
   // The update path refreshes only index.html via this helper.
   writeWebappIndex: vi.fn().mockResolvedValue(undefined),
+  // The route maps this to a 400; deployWebapp throws it for a name it refuses.
+  ValidationError: class ValidationError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = "ValidationError";
+    }
+  },
 }));
 
 import fs from "fs/promises";

--- a/src/tests/unit/edition-license.test.ts
+++ b/src/tests/unit/edition-license.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
@@ -17,25 +17,32 @@ import { verifyDualLicense } from "@/lib/edition-license";
  * these hold that shape from coming back.
  *
  * Each case signs a licence with a key of its own and offers the matching
- * public key through every environment name the module has ever read, plus the
- * shapes that made the old expression fall through to a blank key.
+ * public key through `CLAWBOX_LICENSE_PUBKEY` — the name the old expression
+ * read — plus the shapes that made it fall through to a blank key.
  */
 
-const ENV_KEYS = [
-  "CLAWBOX_LICENSE_PUBKEY",
-  "CLAWBOX_DUAL_LICENSE_PUBKEY",
-  "CLAWBOX_LICENSE_PUBLIC_KEY",
-];
-const TOUCHED = [...ENV_KEYS, "CLAWBOX_DUAL_LICENSE", "CLAWBOX_ROOT", "CLAWBOX_DEVICE_ID"];
+const PUBKEY_ENV = "CLAWBOX_LICENSE_PUBKEY";
+const TOUCHED = [PUBKEY_ENV, "CLAWBOX_DUAL_LICENSE", "CLAWBOX_ROOT", "CLAWBOX_DEVICE_ID"];
 
 const saved = new Map<string, string | undefined>();
 for (const name of TOUCHED) saved.set(name, process.env[name]);
+
+const tempRoots: string[] = [];
+function tempRoot(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-licence-"));
+  tempRoots.push(dir);
+  return dir;
+}
 
 afterEach(() => {
   for (const [name, value] of saved) {
     if (value === undefined) delete process.env[name];
     else process.env[name] = value;
   }
+});
+
+afterAll(() => {
+  for (const dir of tempRoots) fs.rmSync(dir, { recursive: true, force: true });
 });
 
 /** A licence in the module's format, signed by a freshly minted keypair. */
@@ -57,48 +64,58 @@ describe("verifyDualLicense", () => {
   it("does not accept a licence signed by a key named in the environment", () => {
     const { licence, publicKeyPem } = perpetualDualLicence();
     process.env.CLAWBOX_DUAL_LICENSE = licence;
-    for (const name of ENV_KEYS) process.env[name] = publicKeyPem;
+    process.env[PUBKEY_ENV] = publicKeyPem;
 
     expect(verifyDualLicense()).toBe(false);
   });
 
-  it("does not accept a licence when the environment offers a blank key", () => {
-    // The shapes that used to win a `||` and then reduce to an empty string,
-    // which read as "nothing to verify against".
+  // The shapes that used to win a `||` and then reduce to an empty string,
+  // which read as "nothing to verify against".
+  it.each([
+    ["a single space", " "],
+    ["a tab", "\t"],
+    ["a newline", "\n"],
+    ["mixed whitespace", "   \r\n  "],
+    ["an empty string", ""],
+  ])("does not accept a licence when the environment offers %s as the key", (_label, blank) => {
     const { licence } = perpetualDualLicence();
     process.env.CLAWBOX_DUAL_LICENSE = licence;
+    process.env[PUBKEY_ENV] = blank;
 
-    for (const blank of [" ", "\t", "\n", "   \r\n  ", ""]) {
-      for (const name of ENV_KEYS) process.env[name] = blank;
-      expect(verifyDualLicense()).toBe(false);
-    }
+    expect(verifyDualLicense()).toBe(false);
   });
 
   it("does not accept a licence read from disk and signed by an environment key", () => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-licence-"));
+    const root = tempRoot();
     fs.mkdirSync(path.join(root, "data"), { recursive: true });
     const { licence, publicKeyPem } = perpetualDualLicence();
     fs.writeFileSync(path.join(root, "data", "dual-license.txt"), licence);
 
     delete process.env.CLAWBOX_DUAL_LICENSE;
     process.env.CLAWBOX_ROOT = root;
-    for (const name of ENV_KEYS) process.env[name] = publicKeyPem;
+    process.env[PUBKEY_ENV] = publicKeyPem;
 
     expect(verifyDualLicense()).toBe(false);
   });
 
   it("answers false when there is no licence at all", () => {
     delete process.env.CLAWBOX_DUAL_LICENSE;
-    process.env.CLAWBOX_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-licence-"));
+    process.env.CLAWBOX_ROOT = tempRoot();
 
     expect(verifyDualLicense()).toBe(false);
   });
 
-  it("answers false for a licence that is not in the expected format", () => {
-    process.env.CLAWBOX_ROOT = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-licence-"));
-    for (const bad of ["", ".", "no-dot", ".leading", "trailing.", "a.b"]) {
-      process.env.CLAWBOX_DUAL_LICENSE = bad;
-      expect(verifyDualLicense()).toBe(false);
-    }
+  it.each([
+    ["an empty string", ""],
+    ["a bare separator", "."],
+    ["no separator", "no-dot"],
+    ["nothing before the separator", ".leading"],
+    ["nothing after the separator", "trailing."],
+    ["two parts that are not a signed payload", "a.b"],
+  ])("answers false for a licence that is %s", (_label, bad) => {
+    process.env.CLAWBOX_ROOT = tempRoot();
+    process.env.CLAWBOX_DUAL_LICENSE = bad;
+
+    expect(verifyDualLicense()).toBe(false);
   });
 });

--- a/src/tests/unit/preference-schema.test.ts
+++ b/src/tests/unit/preference-schema.test.ts
@@ -138,11 +138,12 @@ describe("preference-schema", () => {
     };
 
     it("keeps other entries when one is malformed", () => {
-      const kept = sanitizePreferenceValue("installed_meta", installedMeta);
-      expect(kept.ok).toBe(true);
-      expect(kept.ok && kept.value).toEqual({
-        notes: { name: "Notes", color: "#f97316", iconUrl: "" },
-        radio: { name: "Radio", color: "#22d3ee", iconUrl: "" },
+      expect(sanitizePreferenceValue("installed_meta", installedMeta)).toEqual({
+        ok: true,
+        value: {
+          notes: { name: "Notes", color: "#f97316", iconUrl: "" },
+          radio: { name: "Radio", color: "#22d3ee", iconUrl: "" },
+        },
       });
     });
 
@@ -153,13 +154,16 @@ describe("preference-schema", () => {
     });
 
     it("keeps the good members of a list", () => {
-      const kept = sanitizePreferenceValue("installed_apps", ["notes", `ti${CONTROL}mer`, "radio"]);
-      expect(kept.ok && kept.value).toEqual(["notes", "radio"]);
+      expect(
+        sanitizePreferenceValue("installed_apps", ["notes", `ti${CONTROL}mer`, "radio"]),
+      ).toEqual({ ok: true, value: ["notes", "radio"] });
     });
 
     it("keeps a whole value that already passes", () => {
       const value = { notes: { name: "Notes" } };
       const kept = sanitizePreferenceValue("installed_meta", value);
+      expect(kept).toMatchObject({ ok: true });
+      // The same object, not a rebuilt copy.
       expect(kept.ok && kept.value).toBe(value);
     });
 
@@ -185,6 +189,16 @@ describe("preference-schema", () => {
       expect(sanitizePreferenceWrites({ "pref:ui_language": "bg" })).toEqual({
         "pref:ui_language": "bg",
       });
+    });
+
+    it("leaves keys outside the preference namespace alone", () => {
+      // The config store holds tokens and setup flags under the same roof, and
+      // the preference rules would be wrong for those.
+      const out = sanitizePreferenceWrites({
+        clawai_token: `tok${CONTROL}en`,
+        ai_model_configured: true,
+      });
+      expect(out).toEqual({ clawai_token: `tok${CONTROL}en`, ai_model_configured: true });
     });
   });
 


### PR DESCRIPTION
Follow-up to #378, from reviewing that diff. One real gap, one inconsistency, and three tidy-ups.

## The gap: a third direct writer

#378 applied the preference rules at two writers that reach the config store without going through `POST /setup-api/preferences`. There is a **third** — `src/app/setup-api/apps/uninstall/route.ts`. It reads `installed_apps` and `installed_meta`, drops one entry and writes the rest back, so it carries whatever it read straight out again. That is exactly the case the other two were fixed for, and the docstring #378 added claimed every door was covered. It wasn't.

Rather than restate the same three lines at a third call site, this adds `setPreferences()` (`src/lib/preference-store.ts`) and points all three at it.

**Not** folded into `config-store.setMany`, deliberately: of its 17 call sites, 13 write things that are not preferences at all — provider tokens, `wifi_configured`, `ai_model_configured`, updater state. A 4096-character cap and a ban on control characters would be wrong for an opaque secret, so `setMany` stays a general config writer and the preference rules sit in front of it.

Related: `sanitizePreferenceWrites` now leaves keys outside the `pref:` namespace alone. It previously fell through and validated them as preferences, which is a contract its name does not promise — and is what made the deeper placement unsafe.

## The inconsistency: one label, two limits

#378 checked the project name in `initProject`. The same user-facing label also arrives through `webapp create` and `code build`, which reach `deployWebapp` — documented in that file as the chokepoint those two share. Net effect was one label capped at 60 through one door and unbounded through the others, while the MCP schema already declares `zText(60)` for both.

The rule now applies at `deployWebapp` too. The webapps route mapped every thrown error to a 500; a refused field is the caller's to fix, so `ValidationError` answers 400 there as it already did on the code route.

Renamed `validateProjectName` → `assertProjectName`, matching `assertMutableTarget` in the same file — `validateProjectId` sits ten lines away and returns a boolean, so the two contracts should not share a prefix.

## Tidy-ups

- `PREFERENCE_KEY_PREFIX` was introduced in #378 and then not used where the prefix is actually taken apart, leaving a bare `slice(5)` tied to its length by nothing.
- The key-cap comment was wrong. It said every caller asks for a single key; the largest is the `preferences_get` MCP tool, which sends its whole readable-prefs allowlist in one request (9 keys today). Corrected, with the headroom stated. The cap is now counted before the allowlist filter, so it bounds what a request names rather than what survives it.
- `sanitizePreferenceValue` skipped a second walk that could only reach the answer the first one gave — a prune that dropped nothing cannot change the verdict.
- `CLOSED_DOMAINS` is a `Map`, so a key named after something on `Object.prototype` reads as "no domain" by construction and the `hasOwnProperty` helper goes away.
- The proxy copy of `logSafe` had drifted from the module it restates on the two points that module documents: it wrote U+FFFD as a literal glyph and accepted a non-string. Matched to the source; unused default and constant dropped.
- Tests assert the whole outcome instead of short-circuiting through `.ok`, so a failure shows what was dropped rather than a boolean. The looped licence cases are split into named ones, their temp directories are cleaned up, and two environment names that never existed are gone.

## Verification

Full unit suite: the same 29 pre-existing failures as `beta` (Windows-only — path separators, `0600` modes, symlinks, exec bits), 2392 passing. `eslint` unchanged at 92 problems / 22 errors. Typecheck shows the same two pre-existing errors in files this branch does not touch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved preference validation and synchronization during app installation, removal, and updates.
  - Preference requests now enforce key limits consistently and preserve unrelated settings.
  - Invalid webapp submissions now return a clear 400 error instead of a server error.
  - Project and webapp names are validated consistently before changes are saved.
- **Tests**
  - Expanded coverage for preference filtering, invalid licenses, project validation, and webapp error handling.
  - Improved test cleanup and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->