### PR TITLE
chore: stop the weekly novnc bump and report coverage on a red build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,16 @@ updates:
       # Majors are opt-in — do them by hand, not on Dependabot's schedule.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # @novnc/novnc 1.7.0 is a breaking change wearing a minor version number:
+      # it drops lib/ for core/ and declares `"exports": "./core/rfb.js"` as a
+      # bare string, so EVERY subpath import is refused — including the
+      # keysymdef one src/lib/vnc-keys.ts needs. There is no drop-in rewrite,
+      # so the manifest pins 1.6.0 exactly (src/tests/unit/novnc-pin.test.ts
+      # guards it). Without this rule the weekly run rewrites that pin and
+      # opens a PR that can only ever fail. Remove this when upstream restores
+      # subpath exports — then take the bump by hand.
+      - dependency-name: "@novnc/novnc"
+        update-types: ["version-update:semver-minor"]
 
   # npm entry exists ONLY for security-update PRs (the bun ecosystem doesn't
   # support them; package-lock.json is kept in sync for this + the dependency

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,6 +42,13 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary", "html", "clover"],
+      // Write the summary even when a test failed. Without this the reports are
+      // skipped on a failing run, so pr-tests-coverage.yml's "Parse coverage"
+      // step — which runs `if: always()` precisely so the PR comment can show
+      // numbers on a red build — never found the file and silently reported
+      // nothing. It does not affect the gate: a failing test fails the job
+      // either way.
+      reportOnFailure: true,
       include: ["src/**/*.ts", "src/**/*.tsx"],
       exclude: [
         "src/**/*.test.ts",


### PR DESCRIPTION
Two small maintenance fixes, both found while verifying that earlier work actually holds.

**The novnc pin was being rewritten every week.** The manifest pins `@novnc/novnc` exactly, because 1.7.0 removes the subpath imports this codebase relies on. But that release is a *minor*, and the bun group only ignores majors — so the weekly run kept rewriting the pin and opening a PR that could never pass. Now that one bump, for that one package, is ignored. The comment says when to remove the rule.

**Coverage numbers never appeared on a failing build.** `pr-tests-coverage.yml` runs its parse step `if: always()`, with a comment saying that is precisely so the PR comment can show numbers even on failure — but Vitest does not write the summary when a test fails, so the step always took the not-found path. `reportOnFailure: true` makes the workflow do what it already claimed to do. The gate is unchanged: a failing test still fails the job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Coverage reports are now generated even when test runs include failures.

* **Chores**
  * Preserved compatibility with the current noVNC version by preventing unsupported minor updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->