### PR TITLE
fix: bring the other edition's harness down instead of only reporting it

### DIFF
--- a/docs-site/editions/overview.mdx
+++ b/docs-site/editions/overview.mdx
@@ -93,12 +93,24 @@ Re-running the installer with the edition the device already is — or with no
 re-install and update path and is unaffected. `dual` counts as its own edition
 here, so moving to or from it is a change like any other.
 
-The installer does not migrate an edition. It has no step that removes the
-harness the device would be leaving, and each harness keeps its AI provider
-sign-in in its own configuration file, so signing in does not carry across. A
-device installed over the top of another edition ends up running two agents with
-no usable model — which is why the transition is refused rather than half
-performed. Changing a device's edition is a reflash.
+The installer does not migrate an edition. It will stop and disable the harness
+the device is leaving — two agents on one box conflict over shared resources such
+as the Telegram bot token, so that half is not left to chance — but each harness
+keeps its AI provider sign-in in its own configuration file, and signing in does
+not carry across. A device installed over the top of another edition ends up with
+no usable model while still reporting that setup is complete, which is why the
+transition is refused rather than half performed. Changing a device's edition is
+a reflash.
+
+If an edition's units are ever found running on a device that does not belong to
+that edition, the installer reports them and brings them down. To keep them
+exactly as they are — while diagnosing, for instance — run the installer with
+`CLAWBOX_KEEP_FOREIGN_UNITS=1`; the check still reports them, it just does not
+act. To bring them down on demand:
+
+```bash
+sudo bash /home/clawbox/clawbox/install.sh --step edition_foreign_teardown
+```
 
 ## Which edition am I on?
 

--- a/install.sh
+++ b/install.sh
@@ -163,14 +163,18 @@ esac
 
 # ── Refuse to change the edition of an already-provisioned device ────────────
 #
-# install.sh can INSTALL an edition. It cannot MIGRATE one, and it never
-# pretended to: nothing here stops, disables or masks the harness a device would
-# be LEAVING, and each harness keeps its provider credentials in its own file
-# (~/.hermes/config.yaml vs ~/.openclaw/openclaw.json), so a sign-in does not
-# move. The message below spells out what that costs an operator; the same
-# reasoning is in docs-site/editions/overview.mdx. Changing edition is a
-# reflash. scripts/setup-hermes-edition.sh is the other writer of the lock and
-# carries the same refusal — both writers have to, or neither means anything.
+# install.sh can INSTALL an edition. It cannot MIGRATE one. Two harnesses on one
+# box is only the most visible half of that, and step_edition_foreign_teardown
+# now handles that half — it stops and disables the harness a device is leaving.
+# What it cannot do is move the sign-in: each harness keeps its provider
+# credentials in its own file (~/.hermes/config.yaml vs ~/.openclaw/openclaw.json),
+# and setup_complete carries over, so the wizard step that would populate the
+# incoming harness never runs again. The device comes up quiet instead of
+# conflicted, and still has no usable model. The message below spells out what
+# that costs an operator; the same reasoning is in
+# docs-site/editions/overview.mdx. Changing edition is a reflash.
+# scripts/setup-hermes-edition.sh is the other writer of the lock and carries the
+# same refusal — both writers have to, or neither means anything.
 #
 # ORDERING is load-bearing: this is the first thing after the edition resolves,
 # so it runs before the lock and drop-in are rewritten, before
@@ -199,8 +203,10 @@ if [ -n "$CLAWBOX_RECORDED_EDITION" ] && [ "$CLAWBOX_RECORDED_EDITION" != "$CLAW
 
 WARNING: CLAWBOX_ALLOW_EDITION_CHANGE=1 — installing '$CLAWBOX_EDITION' over
          '$CLAWBOX_RECORDED_EDITION' on a device that is already provisioned.
-         The installer does NOT migrate an edition: the '$CLAWBOX_RECORDED_EDITION' harness is
-         left running, and the AI provider sign-in is not carried across.
+         The installer does NOT migrate an edition. The '$CLAWBOX_RECORDED_EDITION' harness
+         will be stopped and disabled so two agents do not run at once, but
+         the AI provider sign-in is not carried across and setup still reads
+         as complete — so the device will come up with no usable model.
          You are expected to finish the transition by hand.
 
 EOF
@@ -212,11 +218,11 @@ ERROR: this device is already installed as the '$CLAWBOX_RECORDED_EDITION' editi
          Recorded edition:  $CLAWBOX_RECORDED_EDITION   ($CLAWBOX_EDITION_FILE)
          Requested edition: $CLAWBOX_EDITION
 
-       The installer installs an edition; it does not migrate one. It has no
-       step that removes the harness a device is leaving, and the AI provider
-       sign-in lives in each harness's own config, so it does not move. A
-       device installed this way comes up with two harnesses running and no
-       usable model, while still reporting that setup is complete.
+       The installer installs an edition; it does not migrate one. It will
+       stop and disable the harness a device is leaving, but the AI provider
+       sign-in lives in each harness's own config and does not move with it.
+       A device installed this way comes up with no usable model, while
+       still reporting that setup is complete.
 
        Changing a device's edition requires a REFLASH.
        See https://docs.clawbox.com/editions/overview
@@ -339,10 +345,16 @@ fi
 # EXPECTED_ACTIVE_SERVICES only ever describes what should be UP, which left
 # step_validate_services blind in one direction: it appends the Hermes units
 # inside `if has_hermes_harness`, so on the openclaw edition a fully running
-# Hermes stack was not merely tolerated, it was invisible. Nothing in install.sh
-# brings these down, so anything found here is a device that used to be another
-# edition. Both predicates are negated, so `dual` — the edition that legitimately
-# runs both — accumulates nothing and needs no special case.
+# Hermes stack was not merely tolerated, it was invisible. Anything found here is
+# a device that used to be another edition. Both predicates are negated, so
+# `dual` — the edition that legitimately runs both — accumulates nothing and
+# needs no special case.
+#
+# ONE list, TWO consumers, in this order: step_edition_foreign_teardown stops and
+# disables everything in it early in the run, and step_validate_services asserts
+# at the end that none of it is back. So a unit still reported here is one that
+# returned under its own Restart=, or one the operator kept with
+# CLAWBOX_KEEP_FOREIGN_UNITS=1 — not simply one nobody ever touched.
 FOREIGN_EDITION_UNITS=()
 if ! has_hermes_harness; then
   # The Hermes harness: the two ClawBox-managed dashboard units, plus the
@@ -1137,6 +1149,100 @@ step_edition_gateway_state() {
   return 0
 }
 
+# Bring down the harness this edition does not run.
+#
+# step_edition_gateway_state above already does exactly this, but in ONE
+# direction only: on hermes it stops, disables, removes and masks
+# clawbox-gateway.service. The openclaw/dual direction was never written, so a
+# device that used to be hermes kept its entire Hermes stack —
+# clawbox-hermes-dashboard, its auth proxy, and the hermes-gateway unit the
+# upstream Hermes installer writes. That unit holds the Telegram bot token, so
+# both harnesses then long-poll getUpdates on the same token and terminate each
+# other's request ("Conflict: terminated by other getUpdates request",
+# followed by a stall-detected restart loop): neither side receives a message,
+# indefinitely.
+#
+# step_validate_services REPORTS that state, and reporting is not fixing. An
+# appliance whose install finishes loudly broken still has to be repaired by an
+# operator who knows which units to name, so the installer names them itself.
+#
+# Deliberately conservative:
+#   - stop + disable ONLY. Nothing is masked, no unit file is removed, so every
+#     unit here returns with one `systemctl enable --now`. The mask in
+#     step_edition_gateway_state is NOT copied over: it is there because
+#     config/clawbox-sudoers grants the clawbox user NOPASSWD `systemctl start
+#     clawbox-gateway`, which undoes a plain disable from the in-UI terminal.
+#     No Hermes unit has an equivalent grant, so a mask would buy nothing and
+#     cost reversibility. hermes-gateway.service is not written by this repo
+#     either, so deleting its unit file is not ours to do.
+#   - only FOREIGN_EDITION_UNITS, which is built by negating BOTH harness
+#     predicates. `dual` satisfies both, so its list is empty and this loop has
+#     no body — the edition that legitimately runs both is untouched by
+#     construction rather than by a special case that could rot.
+#   - never silent: every unit is named with the state it was in and the
+#     command that puts it back.
+#   - CLAWBOX_KEEP_FOREIGN_UNITS=1 skips the teardown entirely, for an operator
+#     who is mid-diagnosis and wants the box left exactly as found. Detection is
+#     unaffected either way: step_validate_services still fails the install.
+step_edition_foreign_teardown() {
+  if [ "${#FOREIGN_EDITION_UNITS[@]}" -eq 0 ]; then
+    return 0   # dual — both harnesses belong here
+  fi
+
+  local funit f_active f_enabled needs_stop needs_disable
+  local -a brought_down=()
+
+  for funit in "${FOREIGN_EDITION_UNITS[@]}"; do
+    f_active=$(systemctl is-active "$funit" 2>/dev/null || true)
+    f_enabled=$(systemctl is-enabled "$funit" 2>/dev/null || true)
+
+    # An absent unit answers `inactive`, a masked one answers `masked`, and a
+    # unit already stopped and disabled matches neither arm — so all three cost
+    # nothing and need no `systemctl cat` guard. `enabled but inactive` is still
+    # torn down: it is one reboot away from being the second poller.
+    needs_stop=false
+    needs_disable=false
+    case "$f_active" in
+      active|activating|reloading) needs_stop=true ;;
+    esac
+    case "$f_enabled" in
+      enabled|enabled-runtime) needs_disable=true ;;
+    esac
+    if [ "$needs_stop" = false ] && [ "$needs_disable" = false ]; then
+      continue
+    fi
+
+    if [ "${CLAWBOX_KEEP_FOREIGN_UNITS:-0}" = "1" ]; then
+      echo "  [edition] $funit belongs to another edition (active=$f_active enabled=$f_enabled) — left as-is: CLAWBOX_KEEP_FOREIGN_UNITS=1"
+      continue
+    fi
+
+    if [ "$needs_stop" = true ]; then
+      systemctl stop "$funit" >/dev/null 2>&1 || true
+    fi
+    if [ "$needs_disable" = true ]; then
+      systemctl disable "$funit" >/dev/null 2>&1 || true
+    fi
+    brought_down+=("$funit (was active=$f_active enabled=$f_enabled)")
+  done
+
+  if [ "${#brought_down[@]}" -eq 0 ]; then
+    return 0
+  fi
+
+  echo "  Brought down units belonging to another edition (this device is '$CLAWBOX_EDITION'):"
+  local entry
+  for entry in "${brought_down[@]}"; do
+    echo "    - $entry"
+  done
+  echo "    Reason: both harnesses poll the same Telegram bot token, so running"
+  echo "    them together leaves neither able to receive a message."
+  echo "    Stopped and disabled only — nothing was masked and no unit file was"
+  echo "    removed. To put one back:  sudo systemctl enable --now <unit>"
+  echo "    To leave them alone next time: CLAWBOX_KEEP_FOREIGN_UNITS=1"
+  return 0
+}
+
 # Bake the edition lock so a customer can't flip the harness.
 #
 # The record is a ROOT-OWNED file, /etc/clawbox/edition.env. The old drop-in
@@ -1168,6 +1274,13 @@ step_edition_lock() {
   systemctl daemon-reload 2>/dev/null || true
 
   step_edition_gateway_state
+  # After the gateway state, not before: on hermes the step above has already
+  # stopped and masked clawbox-gateway (the only foreign unit on that edition),
+  # so the teardown finds nothing to do and says nothing. On openclaw/dual it is
+  # the step that actually brings the other harness down. Both run inside
+  # step_edition_lock, so both reach the full-install path AND the in-app
+  # updater, which dispatches `--step edition_lock` from step_post_update.
+  step_edition_foreign_teardown
 
   echo "  Baked edition lock: CLAWBOX_EDITION=$CLAWBOX_EDITION ($CLAWBOX_EDITION_FILE)"
 }
@@ -2954,13 +3067,13 @@ step_validate_services() {
       f_enabled=$(systemctl is-enabled "$funit" 2>/dev/null || true)
       case "$f_active" in
         active|activating|reloading)
-          failed_probe+=("Edition: $funit is $f_active but belongs to another edition (this device is '$CLAWBOX_EDITION') — two agent harnesses are running on one box")
+          failed_probe+=("Edition: $funit is $f_active but belongs to another edition (this device is '$CLAWBOX_EDITION') — two agent harnesses are running on one box. Fix: sudo systemctl disable --now $funit")
           continue
           ;;
       esac
       case "$f_enabled" in
         enabled|enabled-runtime)
-          failed_probe+=("Edition: $funit is enabled but belongs to another edition (this device is '$CLAWBOX_EDITION') — it starts again on the next boot")
+          failed_probe+=("Edition: $funit is enabled but belongs to another edition (this device is '$CLAWBOX_EDITION') — it starts again on the next boot. Fix: sudo systemctl disable $funit")
           ;;
       esac
     done
@@ -2994,9 +3107,18 @@ step_validate_services() {
     systemctl status "$unit_name" --no-pager -n 5 2>&1 | sed 's/^/        /' || true
     echo
   done
+  local had_edition_failure=false
   for entry in "${failed_probe[@]}"; do
     echo "    - $entry"
+    case "$entry" in Edition:*) had_edition_failure=true ;; esac
   done
+  # A foreign unit reaching this point means the teardown was skipped or the
+  # unit came back. Name the one command that redoes it rather than leaving the
+  # operator to reconstruct the unit list from the lines above.
+  if [ "$had_edition_failure" = true ]; then
+    echo "    To bring every foreign-edition unit down again, in one command:"
+    echo "      sudo bash $PROJECT_DIR/install.sh --step edition_foreign_teardown"
+  fi
   return 1
 }
 
@@ -3010,7 +3132,7 @@ DISPATCH_STEPS=(
   # Edition steps must be dispatchable or no in-app update can ever re-bake the
   # lock, install Hermes, or repair a Hermes appliance — which is how a Hermes
   # box ended up running edition-blind updates that reinstalled OpenClaw.
-  edition_lock hermes_install hermes_edition
+  edition_lock edition_foreign_teardown hermes_install hermes_edition
   network_setup set_hostname setup_config system_config
   git_pull build rebuild rebuild_reboot restart restart_ap recover
   chpasswd gateway_setup ffmpeg_install polkit_rules systemd_services

--- a/scripts/setup-hermes-edition.sh
+++ b/scripts/setup-hermes-edition.sh
@@ -96,7 +96,8 @@ if [ -n "$RECORDED_EDITION" ] && [ -n "$REQUESTED_EDITION" ] \
    && [ "$RECORDED_EDITION" != "$REQUESTED_EDITION" ]; then
   if [ "${CLAWBOX_ALLOW_EDITION_CHANGE:-0}" = "1" ]; then
     log "WARNING: CLAWBOX_ALLOW_EDITION_CHANGE=1 — provisioning '$REQUESTED_EDITION' over '$RECORDED_EDITION'."
-    log "         The '$RECORDED_EDITION' harness is NOT torn down and credentials are not migrated."
+    log "         This script does not tear the '$RECORDED_EDITION' harness down (install.sh's"
+    log "         edition_foreign_teardown step does), and credentials are not migrated."
   else
     cat >&2 <<EOF
 [hermes-edition] ERROR: this device is already installed as the '$RECORDED_EDITION' edition.
@@ -105,8 +106,9 @@ if [ -n "$RECORDED_EDITION" ] && [ -n "$REQUESTED_EDITION" ] \
          Requested edition: $REQUESTED_EDITION
 
        Provisioning would rewrite the edition lock, and neither this script nor
-       install.sh migrates a device between editions — the harness being left
-       behind keeps running and the AI provider sign-in does not move with it.
+       install.sh migrates a device between editions — the AI provider sign-in
+       lives in each harness's own config and does not move with it, so the
+       device would come up with no usable model.
        Changing a device's edition requires a reflash.
        See https://docs.clawbox.com/editions/overview
 

--- a/src/tests/unit/install-foreign-edition-teardown.test.ts
+++ b/src/tests/unit/install-foreign-edition-teardown.test.ts
@@ -1,0 +1,490 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// A device converted in place from hermes to openclaw came up with the OpenClaw
+// gateway healthy AND the whole Hermes stack still running — clawbox-gateway,
+// clawbox-hermes-dashboard, clawbox-hermes-dashboard-proxy and hermes-gateway
+// all active at once. Both harnesses long-poll getUpdates on the same Telegram
+// bot token, so each terminated the other's request ("Conflict: terminated by
+// other getUpdates request", then "Polling stall detected … forcing restart"),
+// and the box could not receive a message for hours.
+//
+// install.sh could already SEE that state (FOREIGN_EDITION_UNITS, pinned in
+// install-edition-switch-refusal.test.ts) but did nothing about it, so the
+// install finished loudly broken and waited for an operator who knew which
+// units to name. step_edition_foreign_teardown closes that: it brings the other
+// harness down, conservatively and out loud.
+//
+// The mechanism is not new — step_edition_gateway_state has always stopped,
+// disabled, removed and masked clawbox-gateway on hermes. Only the
+// openclaw/dual direction was missing.
+
+const REPO = path.resolve(__dirname, "../../..");
+const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const SUDOERS = fs.readFileSync(path.join(REPO, "config/clawbox-sudoers"), "utf-8");
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+/** Source text between two literal markers, `end` exclusive. */
+function slice(startMarker: string, endMarker: string): string {
+  const start = INSTALL_SH.indexOf(startMarker);
+  if (start < 0) throw new Error(`marker not found: ${startMarker}`);
+  const end = INSTALL_SH.indexOf(endMarker, start);
+  if (end < 0) throw new Error(`marker not found: ${endMarker}`);
+  return INSTALL_SH.slice(start, end);
+}
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return `${INSTALL_SH.slice(start, end)}\n}`;
+}
+
+// The edition predicates through the service registry — the block that builds
+// FOREIGN_EDITION_UNITS. Sourced verbatim so the list under test is the list
+// that ships, not a copy of it.
+const SERVICE_REGISTRY = slice(
+  "# The Hermes SKU: Hermes is the ONLY harness",
+  "# Load persisted WiFi interface if available",
+);
+
+const TEARDOWN_FN = extractShellFunction("step_edition_foreign_teardown");
+const VALIDATE_FN = extractShellFunction("step_validate_services");
+
+let tmp: string;
+let actionsLog: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-teardown-"));
+  actionsLog = path.join(tmp, "systemctl-calls");
+  fs.writeFileSync(actionsLog, "");
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/**
+ * A fake `systemctl` over a table of `unit -> "<enabled>:<active>"`, which
+ * APPENDS every state-changing verb to a file. install.sh sends those calls to
+ * /dev/null, so a file is the only way to observe that stop/disable were the
+ * only things done — and, just as importantly, that mask and rm were not.
+ */
+function systemctlStub(units: Record<string, string>): string {
+  const arms = Object.entries(units)
+    .map(([unit, state]) => `    ${unit}) printf '%s' '${state}' ;;`)
+    .join("\n");
+  return `
+_unit_state() {
+  case "$1" in
+${arms}
+    *) return 1 ;;
+  esac
+}
+systemctl() {
+  local verb="$1"; shift
+  local unit="\${1:-}"
+  local st
+  case "$verb" in
+    cat) _unit_state "$unit" >/dev/null 2>&1 || return 1 ;;
+    is-enabled) st="$(_unit_state "$unit")" || return 1; printf '%s' "\${st%%:*}" ;;
+    is-active) st="$(_unit_state "$unit")" || { printf 'inactive'; return 1; }; printf '%s' "\${st##*:}" ;;
+    status) printf 'stub status for %s\\n' "$unit" ;;
+    *) printf '%s %s\\n' "$verb" "$unit" >> ${JSON.stringify(actionsLog)} ;;
+  esac
+  return 0
+}
+`;
+}
+
+function runTeardown(
+  edition: string,
+  units: Record<string, string>,
+  env: Record<string, string> = {},
+): { status: number; stdout: string; calls: string[] } {
+  const script = [
+    "set -euo pipefail",
+    `CLAWBOX_EDITION=${edition}`,
+    "CLAWBOX_TEST_MODE=1",
+    "PROJECT_DIR=/nonexistent",
+    "CLAWBOX_HOME=/nonexistent",
+    'IFACE_ENV="/nonexistent/network.env"',
+    SERVICE_REGISTRY,
+    systemctlStub(units),
+    TEARDOWN_FN,
+    "step_edition_foreign_teardown",
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    // Deliberately NOT inheriting process.env: a CLAWBOX_EDITION or
+    // CLAWBOX_KEEP_FOREIGN_UNITS already exported in the developer's shell
+    // would silently rewrite what these cases are asking.
+    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV, ...env },
+  });
+  const calls = fs
+    .readFileSync(actionsLog, "utf-8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return { status: r.status ?? -1, stdout: `${r.stdout ?? ""}${r.stderr ?? ""}`, calls };
+}
+
+/** The exact device state that was observed: openclaw box, Hermes stack up. */
+function hermesStackUp(): Record<string, string> {
+  return {
+    "clawbox-hermes-dashboard.service": "enabled:active",
+    "clawbox-hermes-dashboard-proxy.service": "enabled:active",
+    "hermes-gateway.service": "enabled:active",
+  };
+}
+
+d("step_edition_foreign_teardown brings the other harness down", () => {
+  it("stops and disables the whole Hermes stack on an openclaw device", () => {
+    const r = runTeardown("openclaw", hermesStackUp());
+
+    expect(r.status).toBe(0);
+    expect(r.calls).toEqual([
+      "stop clawbox-hermes-dashboard.service",
+      "disable clawbox-hermes-dashboard.service",
+      "stop clawbox-hermes-dashboard-proxy.service",
+      "disable clawbox-hermes-dashboard-proxy.service",
+      // The unit holding the Telegram bot token, hence the conflict loop.
+      "stop hermes-gateway.service",
+      "disable hermes-gateway.service",
+    ]);
+  });
+
+  it("does not mask, unmask, or remove anything", () => {
+    // The whole point of preferring stop+disable: every unit here comes back
+    // with one command. A mask (or a deleted unit file) is a different, much
+    // less reversible decision, and it is not this step's to make.
+    const r = runTeardown("openclaw", hermesStackUp());
+    for (const verb of ["mask", "unmask", "daemon-reload"]) {
+      expect(r.calls.join("\n")).not.toContain(verb);
+    }
+    expect(TEARDOWN_FN).not.toMatch(/systemctl\s+(--runtime\s+)?u?n?mask/);
+    expect(TEARDOWN_FN).not.toMatch(/\brm\b/);
+  });
+
+  it("names every unit it brought down, with the state it was in", () => {
+    // Silently stopping a service an operator may be watching is the hazard
+    // this step has to answer for. It answers by narrating.
+    const r = runTeardown("openclaw", hermesStackUp());
+    for (const unit of Object.keys(hermesStackUp())) {
+      expect(r.stdout).toContain(unit);
+    }
+    expect(r.stdout).toContain("another edition");
+    expect(r.stdout).toContain("this device is 'openclaw'");
+    expect(r.stdout).toMatch(/was active=active enabled=enabled/);
+  });
+
+  it("prints the command that puts a unit back", () => {
+    const r = runTeardown("openclaw", hermesStackUp());
+    expect(r.stdout).toContain("systemctl enable --now");
+    expect(r.stdout).toContain("CLAWBOX_KEEP_FOREIGN_UNITS=1");
+  });
+
+  it("says why, so the teardown is not just an assertion of authority", () => {
+    const r = runTeardown("openclaw", hermesStackUp());
+    expect(r.stdout).toContain("Telegram");
+  });
+});
+
+d("it touches nothing it does not have to", () => {
+  it("leaves dual completely alone — that edition runs both harnesses", () => {
+    // Not a special case in the step: FOREIGN_EDITION_UNITS is built by negating
+    // BOTH has_*_harness predicates, and dual satisfies both, so the list is
+    // empty and the loop has no body. This is the test that must never go red.
+    const r = runTeardown("dual", {
+      ...hermesStackUp(),
+      "clawbox-gateway.service": "enabled:active",
+    });
+    expect(r.status).toBe(0);
+    expect(r.calls).toEqual([]);
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("does nothing when the other harness was never installed", () => {
+    const r = runTeardown("openclaw", {});
+    expect(r.status).toBe(0);
+    expect(r.calls).toEqual([]);
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("does nothing to a foreign unit already stopped and disabled", () => {
+    const r = runTeardown("openclaw", {
+      "clawbox-hermes-dashboard.service": "disabled:inactive",
+      "hermes-gateway.service": "disabled:inactive",
+    });
+    expect(r.calls).toEqual([]);
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("is idempotent — the second run over its own result is a no-op", () => {
+    runTeardown("openclaw", hermesStackUp());
+    fs.writeFileSync(actionsLog, "");
+    const again = runTeardown("openclaw", {
+      "clawbox-hermes-dashboard.service": "disabled:inactive",
+      "clawbox-hermes-dashboard-proxy.service": "disabled:inactive",
+      "hermes-gateway.service": "disabled:inactive",
+    });
+    expect(again.calls).toEqual([]);
+  });
+
+  it("says nothing on hermes, where step_edition_gateway_state already acted", () => {
+    // step_edition_lock runs the gateway state FIRST, so by the time the
+    // teardown looks, clawbox-gateway is stopped and masked. Reporting it a
+    // second time would be noise about work already done.
+    const r = runTeardown("hermes", { "clawbox-gateway.service": "masked:inactive" });
+    expect(r.calls).toEqual([]);
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  it("still backstops hermes if the gateway somehow survived that step", () => {
+    const r = runTeardown("hermes", { "clawbox-gateway.service": "enabled:active" });
+    expect(r.calls).toEqual([
+      "stop clawbox-gateway.service",
+      "disable clawbox-gateway.service",
+    ]);
+  });
+});
+
+d("the states that are easy to miss", () => {
+  it("disables a foreign unit that is enabled but not yet running", () => {
+    // One reboot from being the second poller. Not stopped — it isn't running.
+    const r = runTeardown("openclaw", { "hermes-gateway.service": "enabled:inactive" });
+    expect(r.calls).toEqual(["disable hermes-gateway.service"]);
+    expect(r.stdout).toContain("hermes-gateway.service");
+  });
+
+  it("stops a foreign unit that is masked but still running", () => {
+    // Masking does not stop a running unit. `is-enabled` says masked, so there
+    // is nothing to disable — but the process is still on the token.
+    const r = runTeardown("openclaw", { "hermes-gateway.service": "masked:active" });
+    expect(r.calls).toEqual(["stop hermes-gateway.service"]);
+  });
+
+  it("treats activating and reloading as running", () => {
+    // A unit caught mid-start or mid-reload is on its way to holding the token.
+    for (const state of ["activating", "reloading"]) {
+      fs.writeFileSync(actionsLog, "");
+      const r = runTeardown("openclaw", { "hermes-gateway.service": `disabled:${state}` });
+      expect(r.calls, state).toEqual(["stop hermes-gateway.service"]);
+    }
+  });
+});
+
+d("CLAWBOX_KEEP_FOREIGN_UNITS is the way out", () => {
+  it("leaves everything running when set to 1, and says so per unit", () => {
+    const r = runTeardown("openclaw", hermesStackUp(), {
+      CLAWBOX_KEEP_FOREIGN_UNITS: "1",
+    });
+    expect(r.status).toBe(0);
+    expect(r.calls).toEqual([]);
+    expect(r.stdout).toContain("CLAWBOX_KEEP_FOREIGN_UNITS=1");
+    expect(r.stdout).toContain("left as-is");
+    for (const unit of Object.keys(hermesStackUp())) {
+      expect(r.stdout).toContain(unit);
+    }
+  });
+
+  it("takes only an explicit 1 — not 'true', 'yes' or 0", () => {
+    for (const value of ["0", "true", "yes", ""]) {
+      fs.writeFileSync(actionsLog, "");
+      const r = runTeardown("openclaw", hermesStackUp(), {
+        CLAWBOX_KEEP_FOREIGN_UNITS: value,
+      });
+      expect(r.calls.length, `CLAWBOX_KEEP_FOREIGN_UNITS=${value}`).toBe(6);
+    }
+  });
+});
+
+// ── Wiring ──────────────────────────────────────────────────────────────────
+// A teardown nothing calls is a teardown that does not exist.
+
+describe("the teardown is wired into both entry paths", () => {
+  it("runs from step_edition_lock, after the gateway state", () => {
+    const lock = extractShellFunction("step_edition_lock");
+    expect(lock).toContain("step_edition_foreign_teardown");
+    expect(lock.indexOf("step_edition_gateway_state")).toBeLessThan(
+      lock.indexOf("step_edition_foreign_teardown"),
+    );
+  });
+
+  it("reaches the in-app updater, which dispatches edition_lock", () => {
+    const postUpdate = extractShellFunction("step_post_update");
+    expect(postUpdate).toContain("step_edition_lock");
+  });
+
+  it("is dispatchable on its own, so the printed repair command is real", () => {
+    const dispatch = slice("DISPATCH_STEPS=(", "\n)");
+    expect(dispatch).toContain("edition_foreign_teardown");
+    expect(INSTALL_SH).toContain("step_edition_foreign_teardown() {");
+    expect(INSTALL_SH).toContain(
+      "install.sh --step edition_foreign_teardown",
+    );
+  });
+
+  it("runs before any unit of this edition is installed or started", () => {
+    // step_edition_lock is called before step_system_config and
+    // step_start_services, so the other harness is down before ours comes up.
+    const mainFlow = INSTALL_SH.slice(INSTALL_SH.indexOf('log "Installing NVIDIA JetPack'));
+    expect(mainFlow.indexOf("step_edition_lock")).toBeLessThan(
+      mainFlow.indexOf("step_system_config"),
+    );
+    expect(mainFlow.indexOf("step_edition_lock")).toBeLessThan(
+      mainFlow.indexOf("step_start_services"),
+    );
+  });
+
+  it("cannot run on a refused edition change — the refusal exits first", () => {
+    // #377's refusal is a top-level `exit 1` during constant parsing, so a
+    // device whose transition is refused never reaches any step function at
+    // all. "Nothing has been changed" has to stay literally true.
+    expect(INSTALL_SH.indexOf("ERROR: this device is already installed as the")).toBeLessThan(
+      INSTALL_SH.indexOf("step_edition_foreign_teardown() {"),
+    );
+    expect(INSTALL_SH).toContain(
+      "Nothing has been changed. No unit was stopped, started or masked",
+    );
+  });
+
+  it("drives the shipped registry, not a second copy of the unit list", () => {
+    // Two lists would drift, and the drift would be invisible: the validator
+    // would keep reporting a unit the teardown had stopped listing.
+    expect(TEARDOWN_FN).toContain('"${FOREIGN_EDITION_UNITS[@]}"');
+    expect(TEARDOWN_FN).not.toContain("hermes-gateway.service");
+    expect(TEARDOWN_FN).not.toContain("clawbox-hermes-dashboard");
+  });
+});
+
+describe("stop+disable is the right amount of force", () => {
+  it("the gateway's mask is justified by a sudoers grant no Hermes unit has", () => {
+    // step_edition_gateway_state masks clawbox-gateway because a plain disable
+    // is undone from the in-UI terminal. If an equivalent grant ever appears
+    // for a Hermes unit, this test fails and the teardown needs revisiting.
+    const grants = SUDOERS.split("\n").filter(
+      (l) => l.startsWith("clawbox ") && l.includes("systemctl"),
+    );
+    expect(grants.some((l) => /\bstart\s+clawbox-gateway/.test(l))).toBe(true);
+    for (const unit of ["hermes-dashboard", "hermes-gateway"]) {
+      expect(grants.some((l) => l.includes(unit))).toBe(false);
+    }
+  });
+
+  it("hermes-gateway.service is not ours to delete", () => {
+    // Written by the upstream Hermes installer; nothing in config/ ships it, so
+    // removing the file would make a deliberate return to hermes a reinstall.
+    expect(fs.existsSync(path.join(REPO, "config/hermes-gateway.service"))).toBe(false);
+  });
+});
+
+// ── Detection stays, and now tells the operator what to run ─────────────────
+// Bringing the units down does not replace the check: a unit can come back
+// under its own Restart=, and CLAWBOX_KEEP_FOREIGN_UNITS=1 skips the teardown
+// entirely. Both leave the validator as the last line of defence.
+
+function runValidator(
+  edition: string,
+  units: Record<string, string>,
+): { status: number; stdout: string } {
+  const script = [
+    "set -uo pipefail",
+    `CLAWBOX_EDITION=${edition}`,
+    "CLAWBOX_TEST_MODE=1",
+    "PROJECT_DIR=/home/clawbox/clawbox",
+    "CLAWBOX_HOME=/nonexistent",
+    'IFACE_ENV="/nonexistent/network.env"',
+    SERVICE_REGISTRY,
+    // The poll loop reads `date +%s` twice per pass and gives up after 30s. A
+    // file-backed clock that jumps 100s per read makes a failing run break
+    // after one pass instead of polling for half a minute.
+    `_CLOCK=${JSON.stringify(path.join(tmp, "clock"))}`,
+    'echo 1000 > "$_CLOCK"',
+    'date() { local n; n=$(( $(cat "$_CLOCK") + 100 )); echo "$n" > "$_CLOCK"; printf \'%s\' "$n"; }',
+    "sleep() { :; }",
+    "curl() { printf '200'; }",
+    "gateway_port_listening() { return 1; }",
+    systemctlStub(units),
+    VALIDATE_FN,
+    "step_validate_services",
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV },
+  });
+  return { status: r.status ?? -1, stdout: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+function healthyOpenclaw(): Record<string, string> {
+  return {
+    "clawbox-setup.service": "enabled:active",
+    "clawbox-gateway.service": "enabled:active",
+    "clawbox-heartbeat.timer": "enabled:active",
+    "clawbox-ap-watchdog.timer": "enabled:active",
+    "clawbox-codex-auth-sync.timer": "enabled:active",
+    "clawbox-heartbeat.service": "static:inactive",
+    "clawbox-browser.service": "disabled:inactive",
+    "clawbox-tunnel.service": "disabled:inactive",
+    "clawbox-root-update@.service": "static:inactive",
+    "clawbox-ap-watchdog.service": "static:inactive",
+    "clawbox-codex-auth-sync.service": "static:inactive",
+  };
+}
+
+d("the validator now says what to run, not just what is wrong", () => {
+  it("names the per-unit fix on a foreign unit that is running", () => {
+    const r = runValidator("openclaw", {
+      ...healthyOpenclaw(),
+      "hermes-gateway.service": "enabled:active",
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain("sudo systemctl disable --now hermes-gateway.service");
+  });
+
+  it("names the per-unit fix on a foreign unit that is merely enabled", () => {
+    const r = runValidator("openclaw", {
+      ...healthyOpenclaw(),
+      "hermes-gateway.service": "enabled:inactive",
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout).toContain("sudo systemctl disable hermes-gateway.service");
+  });
+
+  it("offers the one command that redoes the whole teardown", () => {
+    const r = runValidator("openclaw", {
+      ...healthyOpenclaw(),
+      "clawbox-hermes-dashboard.service": "enabled:active",
+      "hermes-gateway.service": "enabled:active",
+    });
+    expect(r.stdout).toContain(
+      "sudo bash /home/clawbox/clawbox/install.sh --step edition_foreign_teardown",
+    );
+  });
+
+  it("does not offer it for failures that have nothing to do with editions", () => {
+    const r = runValidator("openclaw", {
+      ...healthyOpenclaw(),
+      "clawbox-gateway.service": "enabled:failed",
+    });
+    expect(r.status).toBe(1);
+    expect(r.stdout).not.toContain("--step edition_foreign_teardown");
+  });
+
+  it("still passes a clean openclaw device, with the count unchanged", () => {
+    // The teardown adds no checks — the healthy line must not move.
+    const r = runValidator("openclaw", healthyOpenclaw());
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/All 15 checks healthy/);
+  });
+});


### PR DESCRIPTION
## What happened on a device

A box was converted in place from the `hermes` edition to `openclaw` by re-running `install.sh`. The OpenClaw gateway came up healthy — and the Hermes stack was still running alongside it:

```
clawbox-gateway                  active
clawbox-hermes-dashboard         active
clawbox-hermes-dashboard-proxy   active
hermes-gateway                   active
```

Two harnesses long-polling `getUpdates` on one Telegram bot token, each knocking the other off:

```
[Telegram] polling conflict — Conflict: terminated by other getUpdates request
[telegram] Polling stall detected (no completed getUpdates for 145.06s); forcing restart
```

Telegram was dead on that box for hours.

## The decision: act, don't just report

`FOREIGN_EDITION_UNITS` already **saw** this — `step_validate_services` failed the install over it. But nothing acted on it, so the appliance finished loudly broken and waited for an operator who knew which units to name.

Three things decided it:

**1. The repo already accepts this mechanism — it was only written in one direction.** `step_edition_gateway_state` stops, disables, removes *and masks* `clawbox-gateway` on `hermes`. "install.sh brings a foreign harness down" is shipped behaviour; the openclaw/dual half was simply missing. The old comment "Nothing in install.sh brings these down" described the Hermes-side units, not the mechanism.

**2. #377's refusal does not cover every route into this state.** It fires only when a recorded edition exists *and* differs. Two gaps remain:
   - `CLAWBOX_ALLOW_EDITION_CHANGE=1` is a documented escape hatch whose own warning text promised the old harness would be left running — that is this state, by design.
   - If `/etc/clawbox/edition.env` and the legacy drop-in are both absent (wiped, restored from backup, provisioned by a route that never wrote them), the refusal is skipped entirely and no flag is needed.

**3. It is a shared exclusive resource, not a preference.** One bot token, one long-poll. Two pollers is not "degraded" — neither side wins.

**Rejected: leave it at detection.** The argument against acting is that stopping services an operator may be mid-diagnosis on is its own hazard. That is answered rather than dismissed — the teardown is never silent, is reversible with one command, and `CLAWBOX_KEEP_FOREIGN_UNITS=1` opts out entirely while leaving detection untouched. Detection alone leaves an appliance broken at the end of a run the operator started.

**Rejected: mask the Hermes units the way the gateway is masked.** The gateway's mask is justified by a specific fact — `config/clawbox-sudoers` grants the clawbox user NOPASSWD `systemctl start clawbox-gateway`, so a plain disable is undone from the in-UI terminal. No Hermes unit has an equivalent grant, so a mask would only cost reversibility. `hermes-gateway.service` is written by the upstream Hermes installer, so deleting its unit file is not ours to do either. A test reads the sudoers file and fails if that ever stops being true.

## What this adds

`step_edition_foreign_teardown`, driven by the same `FOREIGN_EDITION_UNITS` list the validator uses so the two cannot drift. Called from `step_edition_lock` *after* `step_edition_gateway_state`, so it reaches the full install and the in-app updater's `--step` dispatch alike, and runs before any unit of this edition starts.

- **stop + disable only** — no mask, no file removed; everything returns with one `systemctl enable --now`.
- **`dual` untouched by construction** — its foreign list is empty because both harness predicates are negated. Zero systemctl calls, no output.
- **never silent** — every unit named with the state it was in, why, and how to restore it.
- **`CLAWBOX_KEEP_FOREIGN_UNITS=1`** skips it; detection still fails the install.
- **dispatchable** — `sudo bash install.sh --step edition_foreign_teardown`.

Detection stays as the last line of defence (a unit can return under its own `Restart=`, and the opt-out skips the teardown). Its messages now carry the exact command per unit, and the failure list ends with the one command that redoes the whole teardown.

The refusal from #377 still precedes all of it — a top-level exit during constant parsing, so a refused transition reaches no step function and *"nothing has been changed"* stays literally true.

## Corrected claims

Three places promised the old harness would be left running and no longer can: install.sh's escape-hatch warning and refusal text, the same passage in `docs-site/editions/overview.mdx`, and the note in `scripts/setup-hermes-edition.sh`. What *is* still true — and what the refusal now rests on — is that the **sign-in does not move**: each harness keeps its credentials in its own config and `setup_complete` carries over, so a converted device comes up quiet rather than conflicted and still has no usable model. Changing edition is still a reflash.

## Tests

`src/tests/unit/install-foreign-edition-teardown.test.ts` (29 tests), following `install-edition-switch-refusal.test.ts`: the real shell function is extracted from `install.sh` and run against a stubbed `systemctl` that records every state-changing verb to a file — install.sh sends those calls to `/dev/null`, so a file is the only way to assert stop and disable were the only things done, and mask/unmask/rm were not.

Covered: the exact observed device state; `dual` with zero calls; `hermes` silent after the gateway state already masked, and still backstopping if it did not; enabled-but-inactive; masked-but-running; activating/reloading; idempotence; the opt-out taking only an explicit `1`; the wiring and ordering; and the new validator hints.

```
Test Files  2 passed (2)
     Tests  76 passed (76)
```
(new file + `install-edition-switch-refusal.test.ts`, run on Linux — the bash-backed suites skip on win32)

Full unit project: **174 files / 2406 tests passed**. ESLint and `tsc --noEmit` clean; `bash -n` clean on both scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edition transitions now detect and report services from other editions.
  * Foreign-edition services are stopped and disabled automatically, with an option to preserve them using `CLAWBOX_KEEP_FOREIGN_UNITS=1`.
  * Added a manual command for tearing down foreign-edition services.
* **Bug Fixes**
  * Improved migration warnings and refusal messages, including clearer guidance about service cleanup and provider credentials.
  * Added actionable repair instructions when service validation detects conflicts.
* **Tests**
  * Expanded coverage for cleanup, validation, opt-out behavior, and safe repeated execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->