### PR TITLE
fix: persist the installer's branch so a device remembers what it was built with

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,11 @@ next-env.d.ts
 !.env.template
 !.env.test.example
 .update-branch
-# install.sh writes the pin through this temp file and renames it into place, so
-# the rename cannot follow a symlink. It exists for microseconds, but a failed
-# run must not leave the device's working tree dirty forever.
-.update-branch.tmp
+# install.sh writes the pin through an mktemp file alongside it and renames it
+# into place, so the write cannot follow a symlink. It exists for microseconds
+# and is removed if any step fails, but a run killed mid-write must not leave
+# the device's working tree dirty forever.
+.update-branch.*
 claude-code-source-code/
 code-source-code/
 .omx/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@ next-env.d.ts
 !.env.template
 !.env.test.example
 .update-branch
+# install.sh writes the pin through this temp file and renames it into place, so
+# the rename cannot follow a symlink. It exists for microseconds, but a failed
+# run must not leave the device's working tree dirty forever.
+.update-branch.tmp
 claude-code-source-code/
 code-source-code/
 .omx/

--- a/install.sh
+++ b/install.sh
@@ -967,6 +967,19 @@ step_set_hostname() {
 is_safe_git_ref() {
   local ref="${1:-}"
   [ -n "$ref" ] || return 1
+  # Two gates, and both are load-bearing.
+  #
+  # The character class mirrors src/lib/update-branch.ts. It is not redundant
+  # with git's check below: git happily accepts `feat/a+b`, the runtime updater
+  # refuses it, and a pin the updater refuses does not fail the update — it
+  # falls through to `main`. So install.sh must never write a ref the runtime
+  # would reject, or the device drifts while its pin still reads correct.
+  #
+  # git's own grammar check then rejects the names that are spelled with legal
+  # characters but are not branches: `HEAD`, `a..b`, `x/`, `a.lock`.
+  case "$ref" in
+    -*|/*|*[!A-Za-z0-9._/-]*) return 1 ;;
+  esac
   git check-ref-format --branch "$ref" >/dev/null 2>&1
 }
 
@@ -1002,61 +1015,126 @@ resolve_update_branch() {
   fi
 }
 
-# Record the branch this device was built with, so its own pin matches.
+# The branch this checkout is already sitting on, when that is worth recording.
+# Prints nothing (and succeeds) when it is not.
+#
+# Deliberately narrow, because this runs without anyone having asked for a
+# branch. Every condition below is a case where writing a pin would be a guess
+# rather than a record:
+#   - not a repo, or HEAD is detached → there is no branch name to record. A
+#     detached device still falls through to `main`; see step_git_pull.
+#   - `main` → rule 3's fallback is already main, so a pin changes nothing today
+#     and would only freeze a device an operator later moves by hand.
+#   - not a ref both resolvers accept → a pin the updater refuses resolves to
+#     `main`, which is the very drift this function exists to prevent.
+#   - origin does not carry the branch → today such a device falls back to main
+#     and keeps updating. Pinning it would turn that into a hard failure at
+#     `reset --hard origin/<branch>` on every future update.
+adoptable_checkout_branch() {
+  [ -d "$PROJECT_DIR/.git" ] || return 0
+  local git_cmd current
+  git_cmd="git -c safe.directory=$PROJECT_DIR -C $PROJECT_DIR"
+  current=$($git_cmd symbolic-ref --short HEAD 2>/dev/null || true)
+  [ -n "$current" ] || return 0
+  [ "$current" != "main" ] || return 0
+  is_safe_git_ref "$current" || return 0
+  $git_cmd rev-parse --verify --quiet "refs/remotes/origin/$current" >/dev/null 2>&1 || return 0
+  printf '%s\n' "$current"
+}
+
+# Record the branch this device updates from, so the answer survives.
 #
 # resolve_update_branch() has always READ $PROJECT_DIR/.update-branch and never
 # written it, so the pin existed only if a human created it. Without one, a box
 # falls through to rule 2 — the current branch, and only if that branch tracks a
-# remote. That upstream link does not survive a re-clone, so a device flashed
-# with CLAWBOX_BRANCH=<x> could later resolve to `main` and update itself onto a
-# branch it was never built for. Two freshly provisioned devices reached an
-# operator with no pin at all.
+# remote. That upstream *link* does not survive a re-clone even though the
+# branch does, so a device built from CLAWBOX_BRANCH=<x> could later resolve to
+# `main` and update itself onto a branch it was never built for. Two freshly
+# provisioned devices reached an operator with no pin at all.
 #
-# Written ONLY for an explicit CLAWBOX_BRANCH, and both directions matter:
+# Three cases, in precedence order:
 #   - explicit CLAWBOX_BRANCH → write the pin, including OVER a different
 #     existing one. This is the precedence already documented in
 #     resolve_update_branch (CLAWBOX_BRANCH > .update-branch > current > main),
-#     and by the time we get here the repo has been hard-reset onto that branch;
-#     a pin still naming the old branch would make the very next unattended
-#     update pull the device straight back off it.
-#   - no CLAWBOX_BRANCH → never write and never delete. A bare
-#     `sudo bash install.sh`, or an updater-triggered `--step`, must not
-#     silently repin a device the operator did not ask to move.
+#     and the repo is about to be hard-reset onto that branch; a pin still
+#     naming the old branch would make the very next unattended update pull the
+#     device straight back off it.
+#   - no CLAWBOX_BRANCH and NO pin at all → adopt the checked-out branch, if
+#     adoptable_checkout_branch vouches for it. This does not move the device;
+#     it records where it already is, before sync_repo_to_update_target
+#     overwrites the only evidence. It also settles a disagreement inside a
+#     single install run: the bootstrap block at the top of this file follows
+#     the checked-out branch with no upstream requirement and resets to it,
+#     while resolve_update_branch's rule 2 would then send the same box to main.
+#   - no CLAWBOX_BRANCH and a pin already present → never rewrite, never delete.
+#     An existing pin is somebody's explicit choice (operator, Settings UI, an
+#     earlier flash); a bare `sudo bash install.sh` and every updater-triggered
+#     `--step` must leave it exactly as found.
 persist_update_branch_pin() {
-  local branch="${CLAWBOX_BRANCH:-}"
-  [ -n "$branch" ] || return 0
   [ -d "$PROJECT_DIR" ] || return 0
-  if ! is_safe_git_ref "$branch"; then
-    echo "  WARN: not pinning update branch — '$branch' is not a valid git ref" >&2
+
+  local pin_file="$PROJECT_DIR/.update-branch"
+
+  # $PROJECT_DIR belongs to $CLAWBOX_USER and this function runs as root, so the
+  # pin path is writable by an account the writer outranks. A symlink left here
+  # would redirect the write, the chown and the chmod onto whatever it points
+  # at. Refuse rather than follow it; the write itself then goes through a temp
+  # file and `mv`, which replaces the directory entry instead of following it.
+  if [ -L "$pin_file" ]; then
+    echo "  WARN: not pinning update branch — $pin_file is a symlink" >&2
     return 0
   fi
 
-  local pin_file="$PROJECT_DIR/.update-branch"
   local existing=""
   if [ -f "$pin_file" ]; then
     existing=$(head -n 1 "$pin_file" | tr -d '[:space:]')
   fi
 
-  if [ "$existing" = "$branch" ]; then
-    echo "  Update branch already pinned to '$branch'"
-  else
+  local branch="${CLAWBOX_BRANCH:-}"
+  local pin_source="explicit CLAWBOX_BRANCH"
+  if [ -n "$branch" ]; then
+    if ! is_safe_git_ref "$branch"; then
+      echo "  WARN: not pinning update branch — '$branch' is not a valid git ref" >&2
+      branch=""
+    fi
+  elif [ -z "$existing" ]; then
+    branch="$(adoptable_checkout_branch)"
+    pin_source="the branch this checkout is on"
+  fi
+
+  if [ -n "$branch" ] && [ "$branch" != "$existing" ]; then
     if [ -n "$existing" ]; then
       # Repinning a device is never silent — an operator watching this run has
       # to be able to see the branch it will follow from here on.
-      echo "  Re-pinning update branch '$existing' -> '$branch' (explicit CLAWBOX_BRANCH)"
+      echo "  Re-pinning update branch '$existing' -> '$branch' ($pin_source)"
     else
-      echo "  Pinning update branch to '$branch'"
+      echo "  Pinning update branch to '$branch' ($pin_source)"
     fi
-    printf '%s\n' "$branch" > "$pin_file"
+    # Own and mode the temp file before it becomes the pin, so the pin is never
+    # momentarily readable-but-root-owned, and so neither call can be aimed at a
+    # symlink target planted between the check above and the write.
+    printf '%s\n' "$branch" > "$pin_file.tmp"
+    chown "$CLAWBOX_USER:$CLAWBOX_USER" "$pin_file.tmp"
+    chmod 644 "$pin_file.tmp"
+    mv -f "$pin_file.tmp" "$pin_file"
+    return 0
   fi
 
-  # The web app runs as $CLAWBOX_USER and rewrites this file itself, through
-  # /setup-api/system/update-branch (Settings → Update branch). A root-owned pin
-  # would make that POST fail with EACCES — the same class of bug a root-owned
-  # data/ caused in the config store. Re-assert owner and mode on every run so a
-  # pin left root-owned by a hand-written `sudo` redirect is repaired too. 0644,
-  # not 0600: this is a build record, not a secret, and root reads it during the
+  # Nothing to write. Still re-assert owner and mode on an existing pin, and do
+  # it whether or not a branch was given: the web app runs as $CLAWBOX_USER and
+  # rewrites this file itself through /setup-api/system/update-branch, so a
+  # root-owned pin turns that POST into an EACCES — the same class of bug a
+  # root-owned data/ caused in the config store. Worse, a pin the app user
+  # cannot READ is invisible to the updater, which then resolves to `main` while
+  # this script (running as root) still reads the pin and disagrees. Repairing
+  # it unconditionally is what makes a pin left behind by a hand-written
+  # `sudo sh -c 'echo beta > .update-branch'` heal on the next run. 0644, not
+  # 0600: this is a build record, not a secret, and root reads it during the
   # bootstrap re-exec before it drops to $CLAWBOX_USER.
+  [ -n "$existing" ] || return 0
+  if [ -n "$branch" ]; then
+    echo "  Update branch already pinned to '$branch'"
+  fi
   chown "$CLAWBOX_USER:$CLAWBOX_USER" "$pin_file"
   chmod 644 "$pin_file"
 }
@@ -1098,26 +1176,35 @@ step_bootstrap_updater() {
 }
 
 step_git_pull() {
+  local fresh_clone=0
   if [ ! -d "$PROJECT_DIR/.git" ]; then
     echo "  Cloning from $REPO_URL (branch: $REPO_BRANCH)..."
     git clone --branch "$REPO_BRANCH" "$REPO_URL" "$PROJECT_DIR"
     chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$PROJECT_DIR"
-  else
-    # Hard-sync to the resolved update branch (CLAWBOX_BRANCH > .update-branch >
-    # current branch > main) instead of a fast-forward-only merge. The old
-    # `merge --ff-only ... || echo continuing` silently kept stale code whenever
-    # the box had any local divergence, which then pinned config/openclaw-target.txt,
-    # OpenClaw, and the gateway to the old version (issue #202). Reuse the same
-    # robust path the in-app updater takes: fetch, drop local changes, checkout,
-    # and reset --hard to the upstream. sync_repo_to_update_target chowns too.
-    resolve_update_branch
-    echo "  Repository exists, hard-syncing to '$UPDATE_TARGET_LOCAL'..."
-    sync_repo_to_update_target "$UPDATE_TARGET_LOCAL" "$UPDATE_TARGET_UPSTREAM"
+    fresh_clone=1
   fi
-  # Both arms above put the repo on a branch; record it while PROJECT_DIR is
-  # known-good, and before any later step can fail the install. No-op unless
-  # CLAWBOX_BRANCH was given explicitly — see persist_update_branch_pin.
+
+  # Record the pin BEFORE anything moves the repo. sync_repo_to_update_target
+  # below checks out and hard-resets, so on an unpinned device the checked-out
+  # branch — the only surviving record of what this unit was built from — is
+  # gone by the time it returns. Writing the pin here also feeds
+  # resolve_update_branch's rule 1 on this very run, so the branch the device
+  # keeps is the branch this run installs. Early enough, too, that a later
+  # failed step still leaves a correctly pinned device.
   persist_update_branch_pin
+
+  [ "$fresh_clone" -eq 0 ] || return 0
+
+  # Hard-sync to the resolved update branch (CLAWBOX_BRANCH > .update-branch >
+  # current branch > main) instead of a fast-forward-only merge. The old
+  # `merge --ff-only ... || echo continuing` silently kept stale code whenever
+  # the box had any local divergence, which then pinned config/openclaw-target.txt,
+  # OpenClaw, and the gateway to the old version (issue #202). Reuse the same
+  # robust path the in-app updater takes: fetch, drop local changes, checkout,
+  # and reset --hard to the upstream. sync_repo_to_update_target chowns too.
+  resolve_update_branch
+  echo "  Repository exists, hard-syncing to '$UPDATE_TARGET_LOCAL'..."
+  sync_repo_to_update_target "$UPDATE_TARGET_LOCAL" "$UPDATE_TARGET_UPSTREAM"
 }
 
 step_install_bun() {

--- a/install.sh
+++ b/install.sh
@@ -1039,11 +1039,14 @@ persist_update_branch_pin() {
 
   if [ "$existing" = "$branch" ]; then
     echo "  Update branch already pinned to '$branch'"
-  elif [ -n "$existing" ]; then
-    echo "  Re-pinning update branch '$existing' -> '$branch' (explicit CLAWBOX_BRANCH)"
-    printf '%s\n' "$branch" > "$pin_file"
   else
-    echo "  Pinning update branch to '$branch'"
+    if [ -n "$existing" ]; then
+      # Repinning a device is never silent — an operator watching this run has
+      # to be able to see the branch it will follow from here on.
+      echo "  Re-pinning update branch '$existing' -> '$branch' (explicit CLAWBOX_BRANCH)"
+    else
+      echo "  Pinning update branch to '$branch'"
+    fi
     printf '%s\n' "$branch" > "$pin_file"
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -980,7 +980,14 @@ is_safe_git_ref() {
   case "$ref" in
     -*|/*|*[!A-Za-z0-9._/-]*) return 1 ;;
   esac
-  git check-ref-format --branch "$ref" >/dev/null 2>&1
+  # `-C /` so the answer depends on the ref and nothing else. check-ref-format
+  # needs no repository, but git still runs repository discovery from the
+  # working directory first, and a broken .git there (a moved worktree, a
+  # half-restored backup) makes it exit 128 for EVERY ref — which would look
+  # exactly like "no valid branch": no pin written, and the device falls back to
+  # main. install.sh is run from whatever directory the operator happened to be
+  # in, so that must not be able to decide this.
+  git -C / check-ref-format --branch "$ref" >/dev/null 2>&1
 }
 
 resolve_update_branch() {
@@ -1075,11 +1082,12 @@ persist_update_branch_pin() {
 
   local pin_file="$PROJECT_DIR/.update-branch"
 
-  # $PROJECT_DIR belongs to $CLAWBOX_USER and this function runs as root, so the
-  # pin path is writable by an account the writer outranks. A symlink left here
-  # would redirect the write, the chown and the chmod onto whatever it points
-  # at. Refuse rather than follow it; the write itself then goes through a temp
-  # file and `mv`, which replaces the directory entry instead of following it.
+  # $PROJECT_DIR belongs to $CLAWBOX_USER and this function runs as root, so
+  # every path under it is writable by an account the writer outranks. A symlink
+  # left at the pin path would redirect the write, the chown and the chmod onto
+  # whatever it points at, and `[ -f ]` follows one. Refuse instead. The write
+  # goes through a temp file whose name mktemp chooses (see below), and `mv`
+  # replaces the pin's directory entry rather than following it.
   if [ -L "$pin_file" ]; then
     echo "  WARN: not pinning update branch — $pin_file is a symlink" >&2
     return 0
@@ -1110,13 +1118,26 @@ persist_update_branch_pin() {
     else
       echo "  Pinning update branch to '$branch' ($pin_source)"
     fi
-    # Own and mode the temp file before it becomes the pin, so the pin is never
-    # momentarily readable-but-root-owned, and so neither call can be aimed at a
-    # symlink target planted between the check above and the write.
-    printf '%s\n' "$branch" > "$pin_file.tmp"
-    chown "$CLAWBOX_USER:$CLAWBOX_USER" "$pin_file.tmp"
-    chmod 644 "$pin_file.tmp"
-    mv -f "$pin_file.tmp" "$pin_file"
+    # mktemp, not a fixed "$pin_file.tmp": it creates the file itself with
+    # O_EXCL and a name nobody can predict, so — unlike a fixed name, which the
+    # app user could pre-create as a symlink — the write, the chown and the
+    # chmod are guaranteed to land on a file this function just made. Owning and
+    # moding it before the rename also means the pin is never briefly live while
+    # still root-owned. Same shape as write_env_file above.
+    local tmp_pin
+    tmp_pin=$(mktemp "$pin_file.XXXXXX") || {
+      echo "  WARN: could not create a temp file to write the update-branch pin" >&2
+      return 0
+    }
+    if printf '%s\n' "$branch" > "$tmp_pin" \
+      && chown "$CLAWBOX_USER:$CLAWBOX_USER" "$tmp_pin" \
+      && chmod 644 "$tmp_pin" \
+      && mv -f "$tmp_pin" "$pin_file"; then
+      return 0
+    fi
+    # Never leave the device's working tree holding a stray temp file.
+    rm -f "$tmp_pin"
+    echo "  WARN: failed to write the update-branch pin" >&2
     return 0
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,10 @@
 #   sudo bash install.sh --step NAME  — run a single step (used by systemd)
 #
 # Environment variables:
-#   CLAWBOX_BRANCH       — git branch to clone/checkout (default: main)
+#   CLAWBOX_BRANCH       — git branch to clone/checkout (default: main). When
+#                          set explicitly it is also persisted to
+#                          $PROJECT_DIR/.update-branch, so the device keeps
+#                          updating on the branch it was built with.
 #   NETWORK_INTERFACE    — WiFi interface override (default: auto-detect)
 set -euo pipefail
 
@@ -999,6 +1002,62 @@ resolve_update_branch() {
   fi
 }
 
+# Record the branch this device was built with, so its own pin matches.
+#
+# resolve_update_branch() has always READ $PROJECT_DIR/.update-branch and never
+# written it, so the pin existed only if a human created it. Without one, a box
+# falls through to rule 2 — the current branch, and only if that branch tracks a
+# remote. That upstream link does not survive a re-clone, so a device flashed
+# with CLAWBOX_BRANCH=<x> could later resolve to `main` and update itself onto a
+# branch it was never built for. Two freshly provisioned devices reached an
+# operator with no pin at all.
+#
+# Written ONLY for an explicit CLAWBOX_BRANCH, and both directions matter:
+#   - explicit CLAWBOX_BRANCH → write the pin, including OVER a different
+#     existing one. This is the precedence already documented in
+#     resolve_update_branch (CLAWBOX_BRANCH > .update-branch > current > main),
+#     and by the time we get here the repo has been hard-reset onto that branch;
+#     a pin still naming the old branch would make the very next unattended
+#     update pull the device straight back off it.
+#   - no CLAWBOX_BRANCH → never write and never delete. A bare
+#     `sudo bash install.sh`, or an updater-triggered `--step`, must not
+#     silently repin a device the operator did not ask to move.
+persist_update_branch_pin() {
+  local branch="${CLAWBOX_BRANCH:-}"
+  [ -n "$branch" ] || return 0
+  [ -d "$PROJECT_DIR" ] || return 0
+  if ! is_safe_git_ref "$branch"; then
+    echo "  WARN: not pinning update branch — '$branch' is not a valid git ref" >&2
+    return 0
+  fi
+
+  local pin_file="$PROJECT_DIR/.update-branch"
+  local existing=""
+  if [ -f "$pin_file" ]; then
+    existing=$(head -n 1 "$pin_file" | tr -d '[:space:]')
+  fi
+
+  if [ "$existing" = "$branch" ]; then
+    echo "  Update branch already pinned to '$branch'"
+  elif [ -n "$existing" ]; then
+    echo "  Re-pinning update branch '$existing' -> '$branch' (explicit CLAWBOX_BRANCH)"
+    printf '%s\n' "$branch" > "$pin_file"
+  else
+    echo "  Pinning update branch to '$branch'"
+    printf '%s\n' "$branch" > "$pin_file"
+  fi
+
+  # The web app runs as $CLAWBOX_USER and rewrites this file itself, through
+  # /setup-api/system/update-branch (Settings → Update branch). A root-owned pin
+  # would make that POST fail with EACCES — the same class of bug a root-owned
+  # data/ caused in the config store. Re-assert owner and mode on every run so a
+  # pin left root-owned by a hand-written `sudo` redirect is repaired too. 0644,
+  # not 0600: this is a build record, not a secret, and root reads it during the
+  # bootstrap re-exec before it drops to $CLAWBOX_USER.
+  chown "$CLAWBOX_USER:$CLAWBOX_USER" "$pin_file"
+  chmod 644 "$pin_file"
+}
+
 sync_repo_to_update_target() {
   local target_branch="$1"
   local upstream_branch="$2"
@@ -1052,6 +1111,10 @@ step_git_pull() {
     echo "  Repository exists, hard-syncing to '$UPDATE_TARGET_LOCAL'..."
     sync_repo_to_update_target "$UPDATE_TARGET_LOCAL" "$UPDATE_TARGET_UPSTREAM"
   fi
+  # Both arms above put the repo on a branch; record it while PROJECT_DIR is
+  # known-good, and before any later step can fail the install. No-op unless
+  # CLAWBOX_BRANCH was given explicitly — see persist_update_branch_pin.
+  persist_update_branch_pin
 }
 
 step_install_bun() {

--- a/install.sh
+++ b/install.sh
@@ -1032,13 +1032,13 @@ resolve_update_branch() {
 #     `reset --hard origin/<branch>` on every future update.
 adoptable_checkout_branch() {
   [ -d "$PROJECT_DIR/.git" ] || return 0
-  local git_cmd current
-  git_cmd="git -c safe.directory=$PROJECT_DIR -C $PROJECT_DIR"
-  current=$($git_cmd symbolic-ref --short HEAD 2>/dev/null || true)
+  local current
+  current=$(git -c safe.directory="$PROJECT_DIR" -C "$PROJECT_DIR" symbolic-ref --short HEAD 2>/dev/null || true)
   [ -n "$current" ] || return 0
   [ "$current" != "main" ] || return 0
   is_safe_git_ref "$current" || return 0
-  $git_cmd rev-parse --verify --quiet "refs/remotes/origin/$current" >/dev/null 2>&1 || return 0
+  git -c safe.directory="$PROJECT_DIR" -C "$PROJECT_DIR" \
+    rev-parse --verify --quiet "refs/remotes/origin/$current" >/dev/null 2>&1 || return 0
   printf '%s\n' "$current"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1118,24 +1118,28 @@ persist_update_branch_pin() {
     else
       echo "  Pinning update branch to '$branch' ($pin_source)"
     fi
-    # Stage the write inside a directory only root can touch.
+    # Stage the write in a directory of our own rather than beside the pin.
     #
-    # A temp file placed directly in $PROJECT_DIR is not enough, even with an
-    # unpredictable name: $PROJECT_DIR is writable by $CLAWBOX_USER, so that
-    # account can watch the directory, see the name appear, unlink it and leave
-    # a symlink in its place before the printf/chown/chmod land. That would aim
-    # root's chown at a path of its choosing, which is an escalation primitive
-    # rather than a pin problem. A 0700 root-owned directory removes the
-    # opportunity outright — nothing but root can create or unlink inside it —
-    # and keeps the staging file on the same filesystem, so the final step is
-    # still a rename. `mv` replaces the pin's directory entry and never follows
-    # a symlink sitting at it.
+    # A temp file placed directly in $PROJECT_DIR can be swapped for a symlink
+    # before the printf/chown/chmod land, because $PROJECT_DIR is writable by
+    # $CLAWBOX_USER. With a fixed name that needs no timing at all; the staging
+    # directory means an attacker must instead win a race on the directory
+    # entry between the mkdir and the write. The final step is a rename, which
+    # replaces the pin's directory entry and never follows a symlink left at it.
     #
-    # Losing the race for $stage itself only costs us the write: mkdir fails on
-    # an existing path, and we warn and leave the pin alone. Nothing is
-    # redirected. An account that can do that can already write the pin file
-    # directly — the Settings route does exactly that — so pin *contents* were
-    # never protected from it. Root's authority is what has to be.
+    # It does NOT close that race, and 0700 is not what stops it: unlinking an
+    # entry is governed by the parent's write bit, which $CLAWBOX_USER has, so
+    # $stage can still be rmdir'd and replaced between the two lines below.
+    # Closing it needs descriptor-bound openat/renameat with no-follow
+    # semantics, which POSIX shell cannot express.
+    #
+    # That residual is accepted deliberately, and the reason is three lines
+    # further down: sync_repo_to_update_target runs `git reset --hard` as root
+    # inside this same app-writable tree and then `chown -R` over all of it.
+    # Whoever can win the race below already has a far larger version of the
+    # same primitive in the same step. Hardening the pin write past this point
+    # while that stands would be motion, not progress — if this class is worth
+    # closing it has to be closed for the tree, not for one file in it.
     local stage="$PROJECT_DIR/.update-branch.stage" tmp_pin
     rm -rf "$stage"
     if ! (umask 077 && mkdir "$stage"); then

--- a/install.sh
+++ b/install.sh
@@ -1118,25 +1118,40 @@ persist_update_branch_pin() {
     else
       echo "  Pinning update branch to '$branch' ($pin_source)"
     fi
-    # mktemp, not a fixed "$pin_file.tmp": it creates the file itself with
-    # O_EXCL and a name nobody can predict, so — unlike a fixed name, which the
-    # app user could pre-create as a symlink — the write, the chown and the
-    # chmod are guaranteed to land on a file this function just made. Owning and
-    # moding it before the rename also means the pin is never briefly live while
-    # still root-owned. Same shape as write_env_file above.
-    local tmp_pin
-    tmp_pin=$(mktemp "$pin_file.XXXXXX") || {
-      echo "  WARN: could not create a temp file to write the update-branch pin" >&2
+    # Stage the write inside a directory only root can touch.
+    #
+    # A temp file placed directly in $PROJECT_DIR is not enough, even with an
+    # unpredictable name: $PROJECT_DIR is writable by $CLAWBOX_USER, so that
+    # account can watch the directory, see the name appear, unlink it and leave
+    # a symlink in its place before the printf/chown/chmod land. That would aim
+    # root's chown at a path of its choosing, which is an escalation primitive
+    # rather than a pin problem. A 0700 root-owned directory removes the
+    # opportunity outright — nothing but root can create or unlink inside it —
+    # and keeps the staging file on the same filesystem, so the final step is
+    # still a rename. `mv` replaces the pin's directory entry and never follows
+    # a symlink sitting at it.
+    #
+    # Losing the race for $stage itself only costs us the write: mkdir fails on
+    # an existing path, and we warn and leave the pin alone. Nothing is
+    # redirected. An account that can do that can already write the pin file
+    # directly — the Settings route does exactly that — so pin *contents* were
+    # never protected from it. Root's authority is what has to be.
+    local stage="$PROJECT_DIR/.update-branch.stage" tmp_pin
+    rm -rf "$stage"
+    if ! (umask 077 && mkdir "$stage"); then
+      echo "  WARN: could not stage the update-branch pin write" >&2
       return 0
-    }
+    fi
+    tmp_pin="$stage/pin"
     if printf '%s\n' "$branch" > "$tmp_pin" \
       && chown "$CLAWBOX_USER:$CLAWBOX_USER" "$tmp_pin" \
       && chmod 644 "$tmp_pin" \
       && mv -f "$tmp_pin" "$pin_file"; then
+      rm -rf "$stage"
       return 0
     fi
-    # Never leave the device's working tree holding a stray temp file.
-    rm -f "$tmp_pin"
+    # Never leave the device's working tree holding staging litter.
+    rm -rf "$stage"
     echo "  WARN: failed to write the update-branch pin" >&2
     return 0
   fi

--- a/src/app/setup-api/system/update-branch/route.ts
+++ b/src/app/setup-api/system/update-branch/route.ts
@@ -1,15 +1,12 @@
 import { NextResponse } from "next/server";
 import { readFile, writeFile, unlink } from "fs/promises";
 import path from "path";
+import { isSafeBranch } from "@/lib/update-branch";
 
 export const dynamic = "force-dynamic";
 
 const PROJECT_DIR = "/home/clawbox/clawbox";
 const UPDATE_BRANCH_FILE = path.join(PROJECT_DIR, ".update-branch");
-// Reject a leading '-' (or '/') so an attacker-chosen branch can't smuggle a
-// git option flag (e.g. "-D"/"--all") into the updater's checkout/fetch and
-// brick it. Mirrors SAFE_BRANCH in src/lib/updater.ts.
-const SAFE_BRANCH = /^(?![-/])[A-Za-z0-9._\-/]+$/;
 
 function isEnoent(err: unknown): boolean {
   return !!(err && typeof err === "object" && "code" in err && err.code === "ENOENT");
@@ -42,7 +39,9 @@ export async function POST(request: Request) {
       return NextResponse.json({ success: true, branch: null });
     }
 
-    if (typeof branch !== "string" || !SAFE_BRANCH.test(branch)) {
+    // Shared with the updater and mirrored by install.sh — a value accepted
+    // here but refused there does not error, it silently resolves to `main`.
+    if (typeof branch !== "string" || !isSafeBranch(branch)) {
       return NextResponse.json({ error: "Invalid branch name" }, { status: 400 });
     }
 

--- a/src/lib/update-branch.ts
+++ b/src/lib/update-branch.ts
@@ -1,0 +1,53 @@
+/**
+ * What counts as a pinnable update branch.
+ *
+ * One definition, three consumers: the updater (src/lib/updater.ts), the
+ * Settings route (setup-api/system/update-branch) and install.sh's
+ * `is_safe_git_ref`, which applies the same character class before handing the
+ * value to `git check-ref-format --branch`.
+ *
+ * Any disagreement between those validators is silent branch drift. A value one
+ * side writes and another side refuses does not fail — it falls through to
+ * `main`, and the device updates onto software it was never built for while its
+ * pin still reads as a deliberate choice. That is why the character class and
+ * the grammar rules live here rather than being restated per call site;
+ * src/tests/unit/update-branch-validator.test.ts holds install.sh and this file
+ * to the same answers.
+ */
+
+/**
+ * Characters. The negative lookahead rejects a leading '-' (or '/'): a branch
+ * token that starts with '-' is parsed by git as an option flag (e.g. "-D",
+ * "--all") rather than a ref, which smuggles switches into the checkout/fetch
+ * commands and bricks the updater. Real branch names never start with '-' or '/'.
+ */
+const SAFE_BRANCH_CHARS = /^(?![-/])[A-Za-z0-9._\-/]+$/;
+
+/**
+ * Grammar. `git check-ref-format --branch` rejects each of these, the character
+ * class alone does not, and every one of them resolves somewhere unintended:
+ *
+ *   "HEAD"    `git reset --hard origin/HEAD` follows origin's *default* branch
+ *             — i.e. main — so a device pinned to "HEAD" silently tracks main.
+ *   "a..b"    a revision range, not a ref.
+ *   "x/"      not a ref; git refuses the checkout and the update fails.
+ *
+ * Only an exact "HEAD" is reserved: "feature/HEAD" and "HEAD/x" are branches git
+ * accepts, and rejecting them here would put this file back out of step with
+ * install.sh in the other direction.
+ */
+const INVALID_BRANCH = [
+  /^HEAD$/,
+  /\.\./, // ".." anywhere — a range, and git forbids it in a ref
+  /\/\//, // empty path component
+  /\/$/, // trailing slash
+  /(^|\/)\./, // a path component starting with "."
+  /\.($|\/)/, // a path component ending with "."
+  /\.lock($|\/)/, // git's reserved lock-file suffix
+];
+
+/** True when `branch` is safe to interpolate into `origin/<branch>` and to check out. */
+export function isSafeBranch(branch: string): boolean {
+  if (!SAFE_BRANCH_CHARS.test(branch)) return false;
+  return !INVALID_BRANCH.some((re) => re.test(branch));
+}

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -11,6 +11,7 @@ import {
 } from "./openclaw-config";
 import { hasHermesHarness } from "./edition-source";
 import { isPortOpen } from "./port-probe";
+import { isSafeBranch } from "./update-branch";
 
 const PROJECT_DIR = "/home/clawbox/clawbox";
 const UPDATE_BRANCH_FILE = path.join(PROJECT_DIR, ".update-branch");
@@ -195,13 +196,6 @@ async function startRootServiceFireAndForget(stepId: string): Promise<void> {
   });
 }
 
-/** Validate branch name — only safe git ref characters allowed (prevents shell injection). */
-// The negative lookahead rejects a leading '-' (or '/'): a branch token that
-// starts with '-' is parsed by git as an option flag (e.g. "-D", "--all")
-// rather than a ref, which smuggles switches into the checkout/fetch commands
-// and bricks the updater. Real branch names never start with '-' or '/'.
-const SAFE_BRANCH = /^(?![-/])[A-Za-z0-9._\-/]+$/;
-
 /**
  * Determine which branch to update to, in priority order:
  * 1. `.update-branch` file in project root (survives factory reset + git reset)
@@ -213,12 +207,17 @@ const SAFE_BRANCH = /^(?![-/])[A-Za-z0-9._\-/]+$/;
  * root itself — and survives `git reset --hard` because the file is gitignored.
  * Both are pinned by src/tests/unit/install-update-branch-pin.test.ts.
  *
- * The pin is written by install.sh (persist_update_branch_pin, whenever the
- * installer is given an explicit CLAWBOX_BRANCH — i.e. every flashed device
- * records the branch it was built with) and by the operator through
- * /setup-api/system/update-branch. Rule 2 is only a fallback: a branch's
- * upstream link does not survive a re-clone, so an unpinned device can silently
- * fall through to `main`.
+ * The pin is written by install.sh (persist_update_branch_pin) and by the
+ * operator through /setup-api/system/update-branch. install.sh writes it for an
+ * explicit CLAWBOX_BRANCH, and — when the device carries no pin at all — adopts
+ * the branch the checkout is already sitting on, because rule 2 is weak: a
+ * branch's upstream *link* does not survive a re-clone even though the branch
+ * does, and an unpinned device then falls silently through to `main`.
+ *
+ * Rules 2 and 3 are why a rejected pin is worse than no pin: an unreadable or
+ * malformed value does not fail the update, it quietly becomes `main`. The
+ * validator is therefore shared with the Settings route and mirrored by
+ * install.sh's `is_safe_git_ref` — see src/lib/update-branch.ts.
  */
 interface ResolvedBranch {
   /** Local branch to checkout */
@@ -233,7 +232,7 @@ async function resolveUpdateBranch(gitCmd: string): Promise<ResolvedBranch> {
   // 1. Check .update-branch file
   try {
     const pinned = (await readFile(UPDATE_BRANCH_FILE, "utf-8")).trim();
-    if (pinned && SAFE_BRANCH.test(pinned)) {
+    if (pinned && isSafeBranch(pinned)) {
       return { local: pinned, upstream: `origin/${pinned}` };
     }
   } catch { /* file doesn't exist */ }
@@ -245,14 +244,14 @@ async function resolveUpdateBranch(gitCmd: string): Promise<ResolvedBranch> {
       { timeout: 10_000 },
     );
     const current = branchOut.trim();
-    if (!current || current === "main" || !SAFE_BRANCH.test(current)) return main;
+    if (!current || current === "main" || !isSafeBranch(current)) return main;
 
     const { stdout: upstreamOut } = await execShell(
       `${gitCmd} rev-parse --abbrev-ref ${current}@{u}`,
       { timeout: 10_000 },
     );
     const upstream = upstreamOut.trim();
-    if (upstream && SAFE_BRANCH.test(upstream)) {
+    if (upstream && isSafeBranch(upstream)) {
       return { local: current, upstream };
     }
   } catch {
@@ -672,7 +671,7 @@ async function getPinnedBranchTarget(gitCmd: string): Promise<{
   } catch {
     return null;
   }
-  if (!branch || !SAFE_BRANCH.test(branch)) return null;
+  if (!branch || !isSafeBranch(branch)) return null;
 
   try {
     await execShell(`${gitCmd} fetch --quiet origin ${branch}`, { timeout: 20_000 }).catch(() => {});

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -207,6 +207,18 @@ const SAFE_BRANCH = /^(?![-/])[A-Za-z0-9._\-/]+$/;
  * 1. `.update-branch` file in project root (survives factory reset + git reset)
  * 2. Current branch if it tracks a remote
  * 3. "main" as the default fallback
+ *
+ * Rule 1 survives a factory reset because the reset route wipes `data/`,
+ * `~/.openclaw`, `~/.clawkeep` and a list of home dotfiles — never the project
+ * root itself — and survives `git reset --hard` because the file is gitignored.
+ * Both are pinned by src/tests/unit/install-update-branch-pin.test.ts.
+ *
+ * The pin is written by install.sh (persist_update_branch_pin, whenever the
+ * installer is given an explicit CLAWBOX_BRANCH — i.e. every flashed device
+ * records the branch it was built with) and by the operator through
+ * /setup-api/system/update-branch. Rule 2 is only a fallback: a branch's
+ * upstream link does not survive a re-clone, so an unpinned device can silently
+ * fall through to `main`.
  */
 interface ResolvedBranch {
   /** Local branch to checkout */

--- a/src/tests/unit/install-update-branch-pin.test.ts
+++ b/src/tests/unit/install-update-branch-pin.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// A device is flashed with CLAWBOX_VERSION=<branch>, which flash.sh hands to
+// install.sh as CLAWBOX_BRANCH. What the device later UPDATES to is decided
+// separately, by resolve_update_branch (install.sh) and resolveUpdateBranch
+// (src/lib/updater.ts): the `.update-branch` pin, else the current branch if it
+// tracks a remote, else `main`.
+//
+// install.sh read that pin and never wrote it, so it existed only when a human
+// created it — two freshly provisioned devices arrived with none. Rule 2 caught
+// those, but a branch's upstream link does not survive a re-clone, so an
+// unpinned unit can silently resolve to `main` and update itself onto a branch
+// it was never built for. On customer units that reaches the customer before it
+// reaches us.
+//
+// persist_update_branch_pin closes the gap: an explicit CLAWBOX_BRANCH is
+// recorded on disk, owned by the app user so the Settings UI can still rewrite
+// it, and an installer run WITHOUT the env var leaves an existing pin alone.
+
+const REPO = path.resolve(__dirname, "../../..");
+const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const GITIGNORE = fs.readFileSync(path.join(REPO, ".gitignore"), "utf-8");
+const RESET_ROUTE = fs.readFileSync(
+  path.join(REPO, "src/app/setup-api/setup/reset/route.ts"),
+  "utf-8",
+);
+const UPDATER_TS = fs.readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8");
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return `${INSTALL_SH.slice(start, end)}\n}`;
+}
+
+// Sourced verbatim so the tests exercise the code that ships, not a copy.
+const PERSIST_FN = extractShellFunction("persist_update_branch_pin");
+const IS_SAFE_REF_FN = extractShellFunction("is_safe_git_ref");
+
+let tmp: string;
+let projectDir: string;
+let pinFile: string;
+let chownLog: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-pin-"));
+  projectDir = path.join(tmp, "clawbox");
+  fs.mkdirSync(projectDir);
+  pinFile = path.join(projectDir, ".update-branch");
+  chownLog = path.join(tmp, "chown-calls");
+  fs.writeFileSync(chownLog, "");
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+/**
+ * Run persist_update_branch_pin against a throwaway project dir.
+ *
+ * `chown` is stubbed — the test host is not root and has no `clawbox` user —
+ * but every call is logged so the ownership contract is still observable.
+ * `chmod` is left REAL so the resulting mode can be read off the filesystem.
+ */
+function runPersist(env: Record<string, string> = {}): {
+  status: number;
+  stdout: string;
+  chowns: string[];
+} {
+  const script = [
+    "set -euo pipefail",
+    `PROJECT_DIR=${JSON.stringify(projectDir)}`,
+    "CLAWBOX_USER=clawbox",
+    `chown() { printf '%s\\n' "$*" >> ${JSON.stringify(chownLog)}; }`,
+    IS_SAFE_REF_FN,
+    PERSIST_FN,
+    "persist_update_branch_pin",
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", script], {
+    encoding: "utf-8",
+    // Deliberately NOT inheriting process.env: a CLAWBOX_BRANCH exported in a
+    // developer's shell would rewrite what each case is asking.
+    env: { PATH: process.env.PATH ?? "", ...env },
+  });
+  const chowns = fs
+    .readFileSync(chownLog, "utf-8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return { status: r.status ?? -1, stdout: `${r.stdout ?? ""}${r.stderr ?? ""}`, chowns };
+}
+
+d("persist_update_branch_pin records the branch the device was built with", () => {
+  it("writes the pin when the installer is given an explicit branch", () => {
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    expect(r.stdout).toContain("Pinning update branch to 'beta'");
+  });
+
+  it("writes a branch containing slashes verbatim", () => {
+    // Feature branches are the common QA case and the one most likely to be
+    // mangled by a sloppy write.
+    const r = runPersist({ CLAWBOX_BRANCH: "fix/persist-update-branch" });
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("fix/persist-update-branch\n");
+  });
+
+  it("leaves the pin owned by the app user, not root", () => {
+    // install.sh runs as root. The web app runs as the clawbox user and
+    // rewrites this file itself via /setup-api/system/update-branch, so a
+    // root-owned pin turns that POST into an EACCES — the same failure a
+    // root-owned data/ produced in the config store.
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(r.chowns).toEqual(["clawbox:clawbox " + pinFile]);
+    expect(fs.statSync(pinFile).mode & 0o777).toBe(0o644);
+  });
+
+  it("repairs ownership of a pin that already names the right branch", () => {
+    // A hand-written `sudo sh -c 'echo beta > .update-branch'` leaves a
+    // root-owned file with the correct contents. Re-asserting owner and mode on
+    // the no-write path is what makes the installer able to heal that.
+    fs.writeFileSync(pinFile, "beta\n");
+    fs.chmodSync(pinFile, 0o600);
+
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("already pinned to 'beta'");
+    expect(r.chowns).toEqual(["clawbox:clawbox " + pinFile]);
+    expect(fs.statSync(pinFile).mode & 0o777).toBe(0o644);
+  });
+
+  it("overwrites a stale pin that names a different branch", () => {
+    // Documented precedence: CLAWBOX_BRANCH > .update-branch > current > main.
+    // The repo has just been hard-reset onto CLAWBOX_BRANCH, so a pin still
+    // naming the old branch would make the next unattended update pull the
+    // device straight back off the branch it was built with.
+    fs.writeFileSync(pinFile, "main\n");
+
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    // Repinning a device is not a silent act.
+    expect(r.stdout).toContain("Re-pinning update branch 'main' -> 'beta'");
+  });
+
+  it("does not clobber an existing pin when no branch is given", () => {
+    // The other direction: an operator re-running the installer bare, and every
+    // updater-triggered `install.sh --step`, must leave the device where it is.
+    fs.writeFileSync(pinFile, "beta\n");
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    expect(r.chowns).toEqual([]);
+  });
+
+  it("does not invent a pin when no branch is given", () => {
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(pinFile)).toBe(false);
+  });
+
+  it("does not delete an existing pin when no branch is given", () => {
+    fs.writeFileSync(pinFile, "beta\n");
+    runPersist();
+    expect(fs.existsSync(pinFile)).toBe(true);
+  });
+
+  it("refuses to write a value that is not a valid git ref", () => {
+    // The pin is interpolated into `origin/<ref>` by both resolvers. Writing
+    // junk here would only move the failure to update time.
+    fs.writeFileSync(pinFile, "beta\n");
+
+    const r = runPersist({ CLAWBOX_BRANCH: "beta; rm -rf /" });
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    expect(r.stdout).toContain("not a valid git ref");
+  });
+
+  it("survives a missing project dir instead of failing the install", () => {
+    fs.rmSync(projectDir, { recursive: true, force: true });
+
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    // `set -euo pipefail` is active: a non-zero return here aborts the step.
+    expect(r.status).toBe(0);
+  });
+});
+
+describe("the pin is wired into the install", () => {
+  it("step_git_pull persists the pin", () => {
+    // Without this call site the function is dead code. git_pull is the step
+    // that puts the repo on a branch, and it runs early enough that a later
+    // failed step still leaves a correctly pinned device.
+    expect(extractShellFunction("step_git_pull")).toContain("persist_update_branch_pin");
+  });
+
+  it("git_pull is dispatchable, so the pin can be repaired without a full install", () => {
+    const dispatch = INSTALL_SH.slice(
+      INSTALL_SH.indexOf("DISPATCH_STEPS=("),
+      INSTALL_SH.indexOf(")", INSTALL_SH.indexOf("DISPATCH_STEPS=(")),
+    );
+    expect(dispatch).toContain("git_pull");
+  });
+
+  it("the pin never dirties the git tree", () => {
+    // install.sh writes this file into the repo working tree. If it were
+    // tracked, sync_repo_to_update_target's `git reset --hard` would fight it
+    // and `git status` would be permanently dirty on every device.
+    expect(GITIGNORE.split("\n").map((l) => l.trim())).toContain(".update-branch");
+  });
+});
+
+describe("the pin outlives the things updater.ts says it outlives", () => {
+  // resolveUpdateBranch's docstring claims rule 1 "survives factory reset +
+  // git reset". Both halves are load-bearing for a shipped unit, and neither is
+  // enforced by anything else.
+
+  it("factory reset never targets the pin", () => {
+    expect(RESET_ROUTE).not.toContain(".update-branch");
+  });
+
+  it("factory reset wipes data/, not the project root that holds the pin", () => {
+    // DATA_DIR is CONFIG_ROOT + "/data"; the pin sits in CONFIG_ROOT itself.
+    // A reset that ever wiped the project root instead would silently unpin
+    // every device it touched.
+    expect(RESET_ROUTE).toContain("removeDirectoryContents(OPENCLAW_DIR)");
+    expect(RESET_ROUTE).toContain("fs.readdir(DATA_DIR)");
+    expect(RESET_ROUTE).not.toMatch(/readdir\(\s*PROJECT_DIR/);
+    expect(RESET_ROUTE).not.toMatch(/removeDirectoryContents\(\s*PROJECT_DIR/);
+  });
+
+  it("the home-dir wipe list does not reach into the project dir", () => {
+    // HOME_REMOVE_PATHS and HOME_CONTENT_WIPE_DIRS are joined onto HOME_DIR,
+    // and the project dir is HOME_DIR/clawbox — one entry of "clawbox" here
+    // would take the pin (and the checkout) with it.
+    const listBlock = RESET_ROUTE.slice(
+      RESET_ROUTE.indexOf("const HOME_REMOVE_PATHS"),
+      RESET_ROUTE.indexOf("async function wipeHomeUserState"),
+    );
+    expect(listBlock.length).toBeGreaterThan(0);
+    expect(listBlock).not.toMatch(/["']clawbox\/?["']/);
+  });
+
+  it("the pin file is the same path on both sides of the read", () => {
+    // install.sh writes $PROJECT_DIR/.update-branch; updater.ts and the
+    // Settings route read PROJECT_DIR + ".update-branch". A drift between them
+    // would leave a device pinned in a file nothing consults.
+    expect(UPDATER_TS).toContain('const PROJECT_DIR = "/home/clawbox/clawbox"');
+    expect(UPDATER_TS).toContain('path.join(PROJECT_DIR, ".update-branch")');
+    expect(INSTALL_SH).toContain('PROJECT_DIR="/home/clawbox/clawbox"');
+    expect(PERSIST_FN).toContain('"$PROJECT_DIR/.update-branch"');
+  });
+});

--- a/src/tests/unit/install-update-branch-pin.test.ts
+++ b/src/tests/unit/install-update-branch-pin.test.ts
@@ -153,12 +153,13 @@ d("persist_update_branch_pin records the branch the device was built with", () =
     expect(fs.statSync(pinFile).mode & 0o777).toBe(0o644);
   });
 
-  it("stages the write in a directory the app user cannot write", () => {
-    // The staging directory is what closes the race: a temp file sitting
-    // directly in the project dir can be unlinked and replaced with a symlink
-    // between its creation and the chown, however unpredictable its name — and
-    // the project dir belongs to the app user. 0700 leaves nobody but root able
-    // to create or unlink inside it.
+  it("stages the write in its own directory and renames the result", () => {
+    // Staging narrows the exposure — a temp file sitting directly beside the
+    // pin, under a name that never changes, can be swapped for a symlink with
+    // no timing at all. It does not eliminate it: unlinking an entry is
+    // governed by the parent directory's write bit, which the app user has.
+    // See the comment on this block for why the residual is accepted rather
+    // than chased further in shell.
     const persistFn = extractShellFunction("persist_update_branch_pin");
 
     expect(persistFn).toContain("umask 077");
@@ -195,13 +196,9 @@ d("persist_update_branch_pin records the branch the device was built with", () =
   it("clears a symlink planted at the staging path instead of following it", () => {
     // `rm -rf` on a symlink removes the link, never the thing it points at, so
     // a pre-planted decoy neither redirects the write nor blocks it: the
-    // staging directory is created fresh and the pin lands normally.
-    //
-    // Only a genuine race — creating the path between that `rm` and the `mkdir`
-    // — can interfere, and then `mkdir` simply fails and the pin is left as
-    // found. Nothing is redirected either way, which is the property that
-    // matters: root's chown must never be steerable onto a path of someone
-    // else's choosing.
+    // staging directory is created fresh and the pin lands normally. This is
+    // the case that needed no timing at all when the staging path was a fixed
+    // name, and it is the one this pins shut.
     const decoy = path.join(tmp, "decoy");
     fs.writeFileSync(decoy, "untouched\n");
     fs.symlinkSync(decoy, `${pinFile}.stage`);

--- a/src/tests/unit/install-update-branch-pin.test.ts
+++ b/src/tests/unit/install-update-branch-pin.test.ts
@@ -144,17 +144,28 @@ d("persist_update_branch_pin records the branch the device was built with", () =
     // root-owned pin turns that POST into an EACCES — the same failure a
     // root-owned data/ produced in the config store.
     //
-    // Owner and mode are applied to the mktemp file, which is then renamed into
-    // place: the pin is never momentarily live while still root-owned, and
-    // neither call can be aimed at a path someone else chose. The temp name is
-    // unpredictable by design, so match its shape rather than a literal.
+    // Owner and mode are applied to the staged file, which is then renamed into
+    // place: the pin is never momentarily live while still root-owned, and the
+    // chown can only ever name a path inside the root-owned staging directory.
     const r = runPersist({ CLAWBOX_BRANCH: "beta" });
 
-    expect(r.chowns).toHaveLength(1);
-    expect(r.chowns[0]).toMatch(
-      new RegExp(`^clawbox:clawbox ${pinFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.\\w{6}$`),
-    );
+    expect(r.chowns).toEqual([`clawbox:clawbox ${pinFile}.stage/pin`]);
     expect(fs.statSync(pinFile).mode & 0o777).toBe(0o644);
+  });
+
+  it("stages the write in a directory the app user cannot write", () => {
+    // The staging directory is what closes the race: a temp file sitting
+    // directly in the project dir can be unlinked and replaced with a symlink
+    // between its creation and the chown, however unpredictable its name — and
+    // the project dir belongs to the app user. 0700 leaves nobody but root able
+    // to create or unlink inside it.
+    const persistFn = extractShellFunction("persist_update_branch_pin");
+
+    expect(persistFn).toContain("umask 077");
+    expect(persistFn).toMatch(/mkdir "\$stage"/);
+    // The staged file must be renamed, not copied: rename replaces the pin's
+    // directory entry instead of following a symlink left at it.
+    expect(persistFn).toMatch(/mv -f "\$tmp_pin" "\$pin_file"/);
   });
 
   it("leaves no temp file behind in the working tree", () => {
@@ -166,12 +177,9 @@ d("persist_update_branch_pin records the branch the device was built with", () =
   });
 
   it("does not write through a symlink planted at a guessable temp path", () => {
-    // The pin path itself is guarded, but the temp file the write is staged
-    // through lives in the same app-user-writable directory. A fixed name like
-    // `.update-branch.tmp` could be pre-created as a symlink, which would move
-    // the whole problem one path across — `printf >` follows an existing link.
-    // mktemp picks the name and creates the file with O_EXCL, so a decoy at any
-    // guessable path is simply not the file that gets written.
+    // Guarding only the pin path moved the problem one path across: the file
+    // the write is staged through lives in the same app-user-writable
+    // directory, and `printf >` follows an existing link there too.
     const decoy = path.join(tmp, "decoy");
     fs.writeFileSync(decoy, "untouched\n");
     fs.symlinkSync(decoy, `${pinFile}.tmp`);
@@ -181,8 +189,30 @@ d("persist_update_branch_pin records the branch the device was built with", () =
     expect(r.status).toBe(0);
     expect(fs.readFileSync(decoy, "utf-8")).toBe("untouched\n");
     expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
-    // The chown must have gone to the mktemp file, never to the planted path.
     expect(r.chowns).not.toContain(`clawbox:clawbox ${pinFile}.tmp`);
+  });
+
+  it("clears a symlink planted at the staging path instead of following it", () => {
+    // `rm -rf` on a symlink removes the link, never the thing it points at, so
+    // a pre-planted decoy neither redirects the write nor blocks it: the
+    // staging directory is created fresh and the pin lands normally.
+    //
+    // Only a genuine race — creating the path between that `rm` and the `mkdir`
+    // — can interfere, and then `mkdir` simply fails and the pin is left as
+    // found. Nothing is redirected either way, which is the property that
+    // matters: root's chown must never be steerable onto a path of someone
+    // else's choosing.
+    const decoy = path.join(tmp, "decoy");
+    fs.writeFileSync(decoy, "untouched\n");
+    fs.symlinkSync(decoy, `${pinFile}.stage`);
+
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(decoy, "utf-8")).toBe("untouched\n");
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    expect(r.chowns).toEqual([`clawbox:clawbox ${pinFile}.stage/pin`]);
+    expect(strayTempFiles()).toEqual([]);
   });
 
   it("refuses to write through a symlink left in the pin's place", () => {

--- a/src/tests/unit/install-update-branch-pin.test.ts
+++ b/src/tests/unit/install-update-branch-pin.test.ts
@@ -113,6 +113,13 @@ function runPersist(env: Record<string, string> = {}): {
   return { status: r.status ?? -1, stdout: `${r.stdout ?? ""}${r.stderr ?? ""}`, chowns };
 }
 
+/** Temp files left next to the pin — on a device these dirty `git status`. */
+function strayTempFiles(): string[] {
+  return fs
+    .readdirSync(projectDir)
+    .filter((name) => name.startsWith(".update-branch."));
+}
+
 d("persist_update_branch_pin records the branch the device was built with", () => {
   it("writes the pin when the installer is given an explicit branch", () => {
     const r = runPersist({ CLAWBOX_BRANCH: "beta" });
@@ -137,21 +144,45 @@ d("persist_update_branch_pin records the branch the device was built with", () =
     // root-owned pin turns that POST into an EACCES — the same failure a
     // root-owned data/ produced in the config store.
     //
-    // Owner and mode are applied to the temp file, which is then renamed into
+    // Owner and mode are applied to the mktemp file, which is then renamed into
     // place: the pin is never momentarily live while still root-owned, and
-    // neither call can be aimed at a symlink target.
+    // neither call can be aimed at a path someone else chose. The temp name is
+    // unpredictable by design, so match its shape rather than a literal.
     const r = runPersist({ CLAWBOX_BRANCH: "beta" });
 
-    expect(r.chowns).toEqual([`clawbox:clawbox ${pinFile}.tmp`]);
+    expect(r.chowns).toHaveLength(1);
+    expect(r.chowns[0]).toMatch(
+      new RegExp(`^clawbox:clawbox ${pinFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.\\w{6}$`),
+    );
     expect(fs.statSync(pinFile).mode & 0o777).toBe(0o644);
   });
 
   it("leaves no temp file behind in the working tree", () => {
-    // The pin is gitignored; a stranded `.update-branch.tmp` next to it would
-    // show up in `git status` on the device forever.
+    // The pin is gitignored; a stranded temp file next to it would show up in
+    // `git status` on the device forever.
     runPersist({ CLAWBOX_BRANCH: "beta" });
 
-    expect(fs.existsSync(`${pinFile}.tmp`)).toBe(false);
+    expect(strayTempFiles()).toEqual([]);
+  });
+
+  it("does not write through a symlink planted at a guessable temp path", () => {
+    // The pin path itself is guarded, but the temp file the write is staged
+    // through lives in the same app-user-writable directory. A fixed name like
+    // `.update-branch.tmp` could be pre-created as a symlink, which would move
+    // the whole problem one path across — `printf >` follows an existing link.
+    // mktemp picks the name and creates the file with O_EXCL, so a decoy at any
+    // guessable path is simply not the file that gets written.
+    const decoy = path.join(tmp, "decoy");
+    fs.writeFileSync(decoy, "untouched\n");
+    fs.symlinkSync(decoy, `${pinFile}.tmp`);
+
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(decoy, "utf-8")).toBe("untouched\n");
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    // The chown must have gone to the mktemp file, never to the planted path.
+    expect(r.chowns).not.toContain(`clawbox:clawbox ${pinFile}.tmp`);
   });
 
   it("refuses to write through a symlink left in the pin's place", () => {
@@ -437,7 +468,7 @@ describe("the pin is wired into the install", () => {
     // otherwise leave the device dirty forever.
     const lines = GITIGNORE.split("\n").map((l) => l.trim());
     expect(lines).toContain(".update-branch");
-    expect(lines).toContain(".update-branch.tmp");
+    expect(lines).toContain(".update-branch.*");
   });
 });
 

--- a/src/tests/unit/install-update-branch-pin.test.ts
+++ b/src/tests/unit/install-update-branch-pin.test.ts
@@ -20,6 +20,14 @@ import path from "path";
 // persist_update_branch_pin closes the gap: an explicit CLAWBOX_BRANCH is
 // recorded on disk, owned by the app user so the Settings UI can still rewrite
 // it, and an installer run WITHOUT the env var leaves an existing pin alone.
+//
+// A device carrying NO pin is the remaining hole, and the branch it is checked
+// out on is the only record of what it was built from — a record
+// sync_repo_to_update_target destroys moments later. So an unpinned device
+// adopts that branch, under the narrow conditions adoptable_checkout_branch
+// enforces. A device on `main` is unaffected either way: rule 2 returns main
+// when the current branch is main, and rule 3's fallback IS main, so main-built
+// units resolve to main through every path with or without a pin.
 
 const REPO = path.resolve(__dirname, "../../..");
 const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
@@ -33,7 +41,9 @@ const UPDATER_TS = fs.readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8
 const CAN_RUN =
   process.platform !== "win32"
   && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const HAS_GIT = spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
 const d = CAN_RUN ? describe : describe.skip;
+const dg = CAN_RUN && HAS_GIT ? describe : describe.skip;
 
 function extractShellFunction(name: string): string {
   const start = INSTALL_SH.indexOf(`${name}() {`);
@@ -46,6 +56,7 @@ function extractShellFunction(name: string): string {
 // Sourced verbatim so the tests exercise the code that ships, not a copy.
 const PERSIST_FN = extractShellFunction("persist_update_branch_pin");
 const IS_SAFE_REF_FN = extractShellFunction("is_safe_git_ref");
+const ADOPT_FN = extractShellFunction("adoptable_checkout_branch");
 
 let tmp: string;
 let projectDir: string;
@@ -83,6 +94,7 @@ function runPersist(env: Record<string, string> = {}): {
     "CLAWBOX_USER=clawbox",
     `chown() { printf '%s\\n' "$*" >> ${JSON.stringify(chownLog)}; }`,
     IS_SAFE_REF_FN,
+    ADOPT_FN,
     PERSIST_FN,
     "persist_update_branch_pin",
   ].join("\n");
@@ -124,10 +136,39 @@ d("persist_update_branch_pin records the branch the device was built with", () =
     // rewrites this file itself via /setup-api/system/update-branch, so a
     // root-owned pin turns that POST into an EACCES — the same failure a
     // root-owned data/ produced in the config store.
+    //
+    // Owner and mode are applied to the temp file, which is then renamed into
+    // place: the pin is never momentarily live while still root-owned, and
+    // neither call can be aimed at a symlink target.
     const r = runPersist({ CLAWBOX_BRANCH: "beta" });
 
-    expect(r.chowns).toEqual(["clawbox:clawbox " + pinFile]);
+    expect(r.chowns).toEqual([`clawbox:clawbox ${pinFile}.tmp`]);
     expect(fs.statSync(pinFile).mode & 0o777).toBe(0o644);
+  });
+
+  it("leaves no temp file behind in the working tree", () => {
+    // The pin is gitignored; a stranded `.update-branch.tmp` next to it would
+    // show up in `git status` on the device forever.
+    runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(fs.existsSync(`${pinFile}.tmp`)).toBe(false);
+  });
+
+  it("refuses to write through a symlink left in the pin's place", () => {
+    // The project dir belongs to the app user; install.sh runs as root. A
+    // symlink planted here would redirect the write, the chown and the chmod
+    // onto its target. `[ -f ]` alone follows it, so the check has to be -L.
+    const decoy = path.join(tmp, "decoy");
+    fs.writeFileSync(decoy, "untouched\n");
+    fs.symlinkSync(decoy, pinFile);
+
+    const r = runPersist({ CLAWBOX_BRANCH: "beta" });
+
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("is a symlink");
+    expect(fs.readFileSync(decoy, "utf-8")).toBe("untouched\n");
+    expect(r.chowns).toEqual([]);
+    expect(fs.lstatSync(pinFile).isSymbolicLink()).toBe(true);
   });
 
   it("repairs ownership of a pin that already names the right branch", () => {
@@ -169,7 +210,26 @@ d("persist_update_branch_pin records the branch the device was built with", () =
 
     expect(r.status).toBe(0);
     expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
-    expect(r.chowns).toEqual([]);
+    // Contents untouched, but the pin is NOT left as found: see below.
+  });
+
+  it("repairs an unreadable pin even with no branch given", () => {
+    // A pin the app user cannot read is worse than no pin. The updater runs as
+    // the app user, so rule 1 is swallowed and it resolves `main`, while
+    // install.sh — running as root — still reads the pin and disagrees. The
+    // device then updates to a branch its own pin denies.
+    //
+    // The repair therefore cannot sit behind an explicit CLAWBOX_BRANCH: the
+    // run that has to heal this is precisely the bare one.
+    fs.writeFileSync(pinFile, "beta\n");
+    fs.chmodSync(pinFile, 0o600);
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    expect(r.chowns).toEqual([`clawbox:clawbox ${pinFile}`]);
+    expect(fs.statSync(pinFile).mode & 0o777).toBe(0o644);
   });
 
   it("does not invent a pin when no branch is given", () => {
@@ -207,12 +267,157 @@ d("persist_update_branch_pin records the branch the device was built with", () =
   });
 });
 
+function git(cwd: string, ...args: string[]): string {
+  const r = spawnSync("git", args, { cwd, encoding: "utf-8" });
+  if (r.status !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  return (r.stdout ?? "").trim();
+}
+
+/**
+ * Make `projectDir` a clone of a throwaway origin that carries `main` and
+ * `beta`, checked out on `branch`. A real clone, not a fixture: what
+ * adoptable_checkout_branch inspects is remote-tracking refs and HEAD, and a
+ * hand-built .git would let the test pass while the device failed.
+ */
+function makeRepo(branch: string): void {
+  const seed = path.join(tmp, "seed");
+  const origin = path.join(tmp, "origin.git");
+  fs.mkdirSync(seed);
+  git(seed, "init", "--quiet");
+  // Not `init -b main`: that flag postdates git 2.28 and this has to run on
+  // whatever the CI image ships.
+  git(seed, "symbolic-ref", "HEAD", "refs/heads/main");
+  git(seed, "config", "user.email", "test@example.com");
+  git(seed, "config", "user.name", "test");
+  fs.writeFileSync(path.join(seed, "f"), "x\n");
+  git(seed, "add", "f");
+  git(seed, "commit", "--quiet", "-m", "seed");
+  git(seed, "branch", "beta");
+  git(tmp, "clone", "--quiet", "--bare", seed, origin);
+  fs.rmSync(projectDir, { recursive: true, force: true });
+  git(tmp, "clone", "--quiet", origin, projectDir);
+  if (branch !== "main") git(projectDir, "checkout", "--quiet", branch);
+}
+
+dg("an unpinned device adopts the branch it is checked out on", () => {
+  it("records the checked-out branch", () => {
+    makeRepo("beta");
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+    expect(r.stdout).toContain("Pinning update branch to 'beta'");
+    // Adoption is not a silent act either — the log says where the value came
+    // from, so an operator can tell it apart from a flash-time choice.
+    expect(r.stdout).toContain("the branch this checkout is on");
+  });
+
+  it("records a branch whose upstream link is gone — the case rule 2 misses", () => {
+    // This is the whole bug. `git clone` sets the upstream link; a re-clone or
+    // a hand-rebuilt checkout does not, and rule 2 requires it. Measured on a
+    // device: an unpinned box on beta with no upstream resolves `main` in both
+    // resolvers, even though install.sh's own bootstrap block reset it to
+    // origin/beta minutes earlier in the same run.
+    makeRepo("beta");
+    git(projectDir, "branch", "--unset-upstream", "beta");
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("beta\n");
+  });
+
+  it("does not adopt main", () => {
+    // Rule 2 returns main when the current branch is main, and rule 3's
+    // fallback IS main, so a main device already resolves to main through every
+    // path. Writing the pin anyway would gain nothing and would freeze a box an
+    // operator later moves by hand.
+    makeRepo("main");
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(pinFile)).toBe(false);
+  });
+
+  it("does not adopt a detached HEAD", () => {
+    // Deliberately NOT closed: a detached HEAD has no branch name to record.
+    // Inferring one from the commit is a guess — on the real repo main and beta
+    // sit on the same commit, so `--points-at HEAD` is ambiguous exactly when
+    // it would matter. Such a device still falls through to main; the fix is
+    // for the flasher to pass CLAWBOX_BRANCH.
+    makeRepo("beta");
+    git(projectDir, "checkout", "--quiet", "--detach", "HEAD");
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(pinFile)).toBe(false);
+  });
+
+  it("does not adopt a branch origin does not carry", () => {
+    // Without this guard a pin would be written for a branch that cannot be
+    // fetched, turning today's silent fallback to main into a hard failure at
+    // `reset --hard origin/<branch>` on every future update.
+    makeRepo("beta");
+    git(projectDir, "checkout", "--quiet", "-b", "local-only");
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(pinFile)).toBe(false);
+  });
+
+  it("leaves an existing pin alone rather than adopting over it", () => {
+    // An existing pin is somebody's explicit choice — the Settings UI, an
+    // earlier flash, an operator. Adoption only fills a vacuum.
+    makeRepo("beta");
+    fs.writeFileSync(pinFile, "main\n");
+
+    const r = runPersist();
+
+    expect(r.status).toBe(0);
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("main\n");
+  });
+
+  it("still lets an explicit branch win over the checkout", () => {
+    makeRepo("beta");
+
+    const r = runPersist({ CLAWBOX_BRANCH: "fix/qa-build" });
+
+    expect(fs.readFileSync(pinFile, "utf-8")).toBe("fix/qa-build\n");
+    expect(r.stdout).toContain("explicit CLAWBOX_BRANCH");
+  });
+});
+
 describe("the pin is wired into the install", () => {
   it("step_git_pull persists the pin", () => {
     // Without this call site the function is dead code. git_pull is the step
     // that puts the repo on a branch, and it runs early enough that a later
     // failed step still leaves a correctly pinned device.
     expect(extractShellFunction("step_git_pull")).toContain("persist_update_branch_pin");
+  });
+
+  it("step_git_pull pins BEFORE it syncs", () => {
+    // Order is the whole of the adoption fix. sync_repo_to_update_target checks
+    // out and hard-resets, so the checked-out branch — the only record of what
+    // an unpinned device was built from — is gone once it returns. Pinning
+    // first also feeds resolve_update_branch's rule 1 on this same run, so the
+    // branch the device keeps is the branch this run installs.
+    // Comment lines are stripped first: the comment explaining the ordering
+    // names both functions, so matching raw text would assert on prose.
+    const step = extractShellFunction("step_git_pull")
+      .split("\n")
+      .filter((line) => !line.trim().startsWith("#"))
+      .join("\n");
+    const pinAt = step.indexOf("persist_update_branch_pin");
+    const resolveAt = step.indexOf("resolve_update_branch");
+    const syncAt = step.indexOf("sync_repo_to_update_target");
+
+    expect(pinAt).toBeGreaterThan(-1);
+    expect(resolveAt).toBeGreaterThan(pinAt);
+    expect(syncAt).toBeGreaterThan(pinAt);
   });
 
   it("git_pull is dispatchable, so the pin can be repaired without a full install", () => {
@@ -226,8 +431,13 @@ describe("the pin is wired into the install", () => {
   it("the pin never dirties the git tree", () => {
     // install.sh writes this file into the repo working tree. If it were
     // tracked, sync_repo_to_update_target's `git reset --hard` would fight it
-    // and `git status` would be permanently dirty on every device.
-    expect(GITIGNORE.split("\n").map((l) => l.trim())).toContain(".update-branch");
+    // and `git status` would be permanently dirty on every device. The temp
+    // file the write is staged through needs the same treatment: it is renamed
+    // into place immediately, but a run that dies between the two would
+    // otherwise leave the device dirty forever.
+    const lines = GITIGNORE.split("\n").map((l) => l.trim());
+    expect(lines).toContain(".update-branch");
+    expect(lines).toContain(".update-branch.tmp");
   });
 });
 

--- a/src/tests/unit/update-branch-validator.test.ts
+++ b/src/tests/unit/update-branch-validator.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { isSafeBranch } from "@/lib/update-branch";
+
+// Two validators decide what may sit in `.update-branch`: is_safe_git_ref in
+// install.sh (which WRITES the pin) and isSafeBranch in src/lib/update-branch.ts
+// (which the updater and the Settings route READ it with).
+//
+// A disagreement between them is not a validation error, it is branch drift.
+// resolveUpdateBranch does not fail on a pin it refuses — it falls through to
+// rule 2, then to `main`. So a value install.sh accepts and the updater rejects
+// produces a device whose pin says `feat/a+b` and whose updater installs `main`,
+// with nothing in the logs. That is the failure this file exists to prevent, so
+// the invariant is asserted directly rather than restated as two lists.
+
+const REPO = path.resolve(__dirname, "../../..");
+const INSTALL_SH = fs.readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0
+  && spawnSync("git", ["--version"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return `${INSTALL_SH.slice(start, end)}\n}`;
+}
+
+/** Run install.sh's real is_safe_git_ref against a candidate ref. */
+function installShAccepts(ref: string): boolean {
+  const script = [
+    "set -uo pipefail",
+    extractShellFunction("is_safe_git_ref"),
+    `is_safe_git_ref ${JSON.stringify(ref)}`,
+  ].join("\n");
+  // cwd is deliberately outside any git repo: install.sh runs from wherever the
+  // operator invoked it, so the answer must not depend on being inside one.
+  return spawnSync("bash", ["-c", script], { cwd: path.parse(REPO).root }).status === 0;
+}
+
+// Real branch names, near-misses, and the values that historically resolved
+// somewhere unintended. Anything added here is checked against BOTH validators.
+const CORPUS = [
+  "main",
+  "beta",
+  "fix/persist-update-branch",
+  "origin/beta",
+  "release/v1.0.0",
+  "fix_something",
+  "feature/branch.name",
+  "feature/HEAD",
+  "HEAD/x",
+  "refs/heads/x",
+  "v1.0",
+  "a_b",
+  // near-misses / hostile
+  "feat/a+b",
+  "feat/a~b",
+  "feat/a^b",
+  "feat/a:b",
+  "-D",
+  "--all",
+  "/lead",
+  "HEAD",
+  "a..b",
+  "a...b",
+  "x/",
+  "x//y",
+  ".hidden",
+  "a.",
+  "a.lock",
+  "a.lock/b",
+  "a@{1}",
+  "@",
+  "a@b",
+  "branch with spaces",
+  "branch!special",
+  "branch\nnewline",
+  "ünïcode",
+  "beta; rm -rf /",
+  "$(id)",
+  "",
+];
+
+d("install.sh and update-branch.ts agree on what a branch is", () => {
+  it("never lets install.sh write a pin the updater would refuse", () => {
+    // The safety-critical direction. install.sh must be a SUBSET: every value it
+    // is willing to persist has to be one the runtime will honour, because the
+    // penalty for a refused pin is a silent fall-through to `main`.
+    const writtenButRefused = CORPUS.filter(
+      (ref) => installShAccepts(ref) && !isSafeBranch(ref),
+    );
+
+    expect(writtenButRefused).toEqual([]);
+  });
+
+  it("agrees in both directions across the corpus", () => {
+    const disagreements = CORPUS.filter((ref) => installShAccepts(ref) !== isSafeBranch(ref));
+
+    expect(disagreements).toEqual([]);
+  });
+
+  it("accepts the branches devices are actually built from", () => {
+    for (const ref of ["main", "beta", "fix/persist-update-branch", "release/v1.0.0"]) {
+      expect(isSafeBranch(ref), ref).toBe(true);
+      expect(installShAccepts(ref), ref).toBe(true);
+    }
+  });
+});
+
+describe("values that resolve somewhere other than where they read", () => {
+  it('rejects "HEAD", which git resolves to origin\'s default branch', () => {
+    // `git reset --hard origin/HEAD` follows origin's default branch — main —
+    // so a device pinned to HEAD tracks main while its pin reads as a choice.
+    // The Settings route used to return 200 for this.
+    expect(isSafeBranch("HEAD")).toBe(false);
+  });
+
+  it("rejects revision ranges and empty path components", () => {
+    for (const ref of ["a..b", "a...b", "x/", "x//y"]) {
+      expect(isSafeBranch(ref), ref).toBe(false);
+    }
+  });
+
+  it("rejects git's reserved spellings", () => {
+    for (const ref of [".hidden", "a.", "a.lock", "a.lock/b"]) {
+      expect(isSafeBranch(ref), ref).toBe(false);
+    }
+  });
+
+  it("still rejects the flag-injection shapes", () => {
+    // A ref starting with '-' is parsed by git as an option, not a ref.
+    for (const ref of ["-D", "--all", "/lead"]) {
+      expect(isSafeBranch(ref), ref).toBe(false);
+    }
+  });
+
+  it("keeps accepting the legal names that merely look reserved", () => {
+    // Over-tightening is drift too, in the other direction: install.sh accepts
+    // these, so the runtime must as well.
+    for (const ref of ["feature/HEAD", "HEAD/x", "feature/branch.name", "v1.0"]) {
+      expect(isSafeBranch(ref), ref).toBe(true);
+    }
+  });
+});

--- a/src/tests/unit/update-branch-validator.test.ts
+++ b/src/tests/unit/update-branch-validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "child_process";
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { isSafeBranch } from "@/lib/update-branch";
 
@@ -32,8 +33,8 @@ function extractShellFunction(name: string): string {
   return `${INSTALL_SH.slice(start, end)}\n}`;
 }
 
-/** Run install.sh's real is_safe_git_ref against a candidate ref. */
-function installShAccepts(ref: string): boolean {
+/** Run install.sh's real is_safe_git_ref against a candidate ref, from `cwd`. */
+function installShAccepts(ref: string, cwd: string = path.parse(REPO).root): boolean {
   const script = [
     "set -uo pipefail",
     extractShellFunction("is_safe_git_ref"),
@@ -46,13 +47,9 @@ function installShAccepts(ref: string): boolean {
     // the bug hides as a passing test.
     'is_safe_git_ref "$1"',
   ].join("\n");
-  // cwd is deliberately outside any git repo: install.sh runs from wherever the
+  // cwd defaults outside any git repo: install.sh runs from wherever the
   // operator invoked it, so the answer must not depend on being inside one.
-  return (
-    spawnSync("bash", ["-c", script, "is_safe_git_ref", ref], {
-      cwd: path.parse(REPO).root,
-    }).status === 0
-  );
+  return spawnSync("bash", ["-c", script, "is_safe_git_ref", ref], { cwd }).status === 0;
 }
 
 // Real branch names, near-misses, and the values that historically resolved
@@ -129,6 +126,30 @@ d("install.sh and update-branch.ts agree on what a branch is", () => {
     for (const ref of ["main", "beta", "fix/persist-update-branch", "release/v1.0.0"]) {
       expect(isSafeBranch(ref), ref).toBe(true);
       expect(installShAccepts(ref), ref).toBe(true);
+    }
+  });
+
+  it("gives the same answer from a directory holding a broken .git", () => {
+    // `git check-ref-format` needs no repository, but git still runs repository
+    // discovery from the working directory first, and a broken .git there makes
+    // it exit 128 for EVERY ref. That reads as "no valid branch": no pin gets
+    // written and the device falls back to main — this PR's failure mode,
+    // triggered by nothing but the directory the operator happened to be in.
+    // install.sh pins this by calling `git -C /`.
+    const broken = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-brokengit-"));
+    try {
+      fs.writeFileSync(
+        path.join(broken, ".git"),
+        "gitdir: /nonexistent/path/worktrees/gone\n",
+      );
+
+      expect(installShAccepts("beta", broken)).toBe(true);
+      expect(installShAccepts("fix/persist-update-branch", broken)).toBe(true);
+      // and still rejects, rather than passing everything for the same reason
+      expect(installShAccepts("HEAD", broken)).toBe(false);
+      expect(installShAccepts("a..b", broken)).toBe(false);
+    } finally {
+      fs.rmSync(broken, { recursive: true, force: true });
     }
   });
 });

--- a/src/tests/unit/update-branch-validator.test.ts
+++ b/src/tests/unit/update-branch-validator.test.ts
@@ -37,11 +37,22 @@ function installShAccepts(ref: string): boolean {
   const script = [
     "set -uo pipefail",
     extractShellFunction("is_safe_git_ref"),
-    `is_safe_git_ref ${JSON.stringify(ref)}`,
+    // The ref arrives as $1, never interpolated into the script text. Embedding
+    // it would quote for JavaScript rather than for bash, and the two entries
+    // that matter most would be compared as different strings: a real newline
+    // becomes a literal backslash-n inside bash double quotes, and `$(id)` gets
+    // command-substituted, so the shell would be validating the output of `id`
+    // while isSafeBranch validated the literal. Both still return "reject", so
+    // the bug hides as a passing test.
+    'is_safe_git_ref "$1"',
   ].join("\n");
   // cwd is deliberately outside any git repo: install.sh runs from wherever the
   // operator invoked it, so the answer must not depend on being inside one.
-  return spawnSync("bash", ["-c", script], { cwd: path.parse(REPO).root }).status === 0;
+  return (
+    spawnSync("bash", ["-c", script, "is_safe_git_ref", ref], {
+      cwd: path.parse(REPO).root,
+    }).status === 0
+  );
 }
 
 // Real branch names, near-misses, and the values that historically resolved
@@ -85,6 +96,14 @@ const CORPUS = [
   "ünïcode",
   "beta; rm -rf /",
   "$(id)",
+  // Canaries for the harness rather than for the validators. Both sides must
+  // reject these literally. If the ref were ever interpolated into the shell
+  // script instead of passed as an argument, bash would substitute them to
+  // "main" and accept, while isSafeBranch kept rejecting the literal — so the
+  // agreement assertion below fails loudly instead of passing on two different
+  // strings.
+  "$(echo main)",
+  "`echo main`",
   "",
 ];
 


### PR DESCRIPTION
## The gap

A device flashed with an explicit branch gets it as `CLAWBOX_BRANCH`. What it later *updates* to is decided separately, by `resolve_update_branch` (install.sh) and `resolveUpdateBranch` (`src/lib/updater.ts`):

1. the `.update-branch` pin in the project root
2. the current branch, **if it tracks a remote**
3. `main`

`install.sh` has always *read* that pin and never written it, so it only existed where a human had created one. Two freshly provisioned devices turned up with no pin at all. Rule 2 covered them — but a branch's upstream *link* does not survive a re-clone even though the branch does, so an unpinned unit can fall through to `main` and update itself onto a branch it was never built for.

That matters because units flashed from a given branch are shipped relying on the in-app updater to bring them current in transit.

## The thing that makes all of this sharp

**A pin the runtime refuses is not an error.** `resolveUpdateBranch` does not fail on a value it rejects — it falls through to rule 2, then to `main`. So every disagreement between the thing that *writes* `.update-branch` and the things that *read* it is silent branch drift, with a pin that still reads as a deliberate choice.

That is why this PR is larger than "write the file".

## Scope

Deliberately bounded. **A device on `main` resolves to main through every path** — pinned, unpinned, upstream lost, detached HEAD — because rule 2 returns main when the current branch is main and rule 3's fallback *is* main. So none of this is load-bearing for main-flashed units. It matters for beta and feature-branch flashes, and for a support engineer who later runs the installer with an explicit branch.

## Measured, per scenario

`install.sh` resolve / `updater.ts` resolve, after one installer run:

| device state before the installer runs | before | after |
|---|---|---|
| no pin, on beta, upstream OK | `beta/beta` | `beta/beta` |
| **no pin, on beta, upstream LOST** | `main/main` | **`beta/beta`** |
| **pin=`feat/a+b`, upstream OK** | `feat/a+b/beta` | **`beta/beta`** |
| **pin=`feat/a+b`, upstream LOST** | `feat/a+b/main` | **`main/main`** |
| **pin=`HEAD`** | `beta/HEAD` | **`beta/beta`** |
| no pin, detached HEAD (was beta) | `main/main` | `main/main` — *not closed, see below* |
| no pin, on main — upstream OK / lost / detached | `main/main` | `main/main` |
| `CLAWBOX_BRANCH=beta`, on main, no pin | `beta/beta` | `beta/beta` |

The `feat/a+b` rows are the interesting ones: the installer and the updater were resolving to **different branches on the same device**.

And on the writer side — what `install.sh` actually persists:

| `CLAWBOX_BRANCH=` | before | after |
|---|---|---|
| `beta` | `beta` | `beta` |
| `feat/a+b` | `feat/a+b` | *(refused)* |
| `ünïcode` | `ünïcode` | *(refused)* |
| `HEAD`, `a..b`, `x/`, `-D` | *(refused)* | *(refused)* |

## One validator, three consumers

`is_safe_git_ref` used only `git check-ref-format --branch`, which accepts `feat/a+b` and `ünïcode` — refs `updater.ts` refused. The installer wrote pins that read correct and resolved to `main`.

The character class now lives in `src/lib/update-branch.ts`, shared by the updater and the Settings route (it was duplicated between them). `install.sh` applies the same class *before* git's grammar check.

Git's grammar check is the half `updater.ts` was missing. `HEAD` passes the regex, and `git reset --hard origin/HEAD` follows origin's *default* branch — so a device pinned to `HEAD` tracked `main`, and `POST /setup-api/system/update-branch {"branch":"HEAD"}` returned 200. Same for `a..b`, `x/`, `a.lock`.

`src/tests/unit/update-branch-validator.test.ts` runs both validators over one shared corpus and asserts the safety-critical direction: **install.sh can never write a value the runtime would refuse.**

## An unpinned device adopts the branch it is on

Only when there is no pin at all, and only via `adoptable_checkout_branch`, which refuses to guess:

- **detached HEAD** — no branch name to record
- **`main`** — rule 3's fallback is already main; a pin would only freeze a box an operator later moves by hand
- **a ref the updater would refuse** — that is the drift being prevented
- **a branch origin does not carry** — pinning it would turn today's fallback into a failing `reset --hard origin/<branch>` on every future update

This does not move the device; it records where it already is. The call site moves ahead of resolve/sync in `step_git_pull`, because `sync_repo_to_update_target` destroys the evidence, and because pinning first stops the bootstrap block (which follows the checked-out branch with no upstream requirement) and `step_git_pull` (rule 2, which requires one) disagreeing inside a single run.

## Ownership

Re-asserting owner and mode now runs **whether or not `CLAWBOX_BRANCH` was given**. It previously returned before that on a bare run, so the claim that it healed a root-owned pin was not true for the only run that had to do it. This matters beyond the Settings POST: a pin the app user cannot *read* is invisible to the updater, which resolves `main`, while `install.sh` as root still reads it and disagrees.

`0644`, not `0600`: a build record, not a secret, and root reads it during the bootstrap re-exec.

## Writing the pin

The pin path is refused outright if it is a symlink — `[ -f ]` alone follows one, and the project dir belongs to the app user while this code runs as root. Measured against the pre-fix revision: a root-owned decoy went from `600` / `ORIGINAL-ROOT-CONTENT` to `644` / `beta`.

Guarding only the pin path moved the problem one path across, though: the file the write staged through lived in the same app-user-writable directory, so it could be unlinked and replaced with a symlink — as a fixed `.update-branch.tmp` with no timing needed at all, or, once the name was randomised, by watching the directory and winning a race. What that buys is not a wrong pin but root's `chown` aimed at a path of someone else's choosing.

The write is now staged inside a `0700` directory the function creates, so nothing but root can create or unlink the file being chowned. It stays inside `$PROJECT_DIR`, so the final step is still a rename — and `rename(2)` replaces the pin's directory entry rather than following a symlink left at it. `.gitignore` covers `.update-branch.*`.

Measured, planting a decoy symlink at the temp/staging path (`parent-dir` = mode of the directory holding the chown target):

| | decoy after the run | chown target | parent-dir |
|---|---|---|---|
| before, planted at `.tmp` | `beta`, mode `644` — **clobbered** | `.update-branch.tmp` | `755` |
| after, planted at `.tmp` | untouched, mode `600` | `.update-branch.stage/pin` | `700` |
| after, planted at `.stage` | untouched, mode `600` | `.update-branch.stage/pin` | `700` |

What staging does **not** do is close the race behind it, and the `0700` is not what would: unlinking a directory entry is governed by the parent's write bit, which the app user has on `$PROJECT_DIR`, so the staging directory can still be replaced between the `mkdir` and the write. Closing that needs descriptor-bound `openat`/`renameat` with no-follow semantics, which POSIX shell cannot express.

That residual is accepted deliberately, and the reason is three lines further down the same function: `sync_repo_to_update_target` runs `git reset --hard` as root inside this same app-writable tree and then `chown -R` over all of it — recursive, hundreds of paths, in the same step. Anyone who can win the race on the pin already has a far larger version of the same primitive on the same run. Hardening one file past this point while that stands would be motion rather than progress; if the class is worth closing it has to be closed for the tree, and that is a different change with a different blast radius than "persist the installer's branch".

## The validator must not depend on where you ran the installer

`git check-ref-format` needs no repository, but git runs repository discovery from the working directory first. A broken `.git` there — a moved worktree, a half-restored backup — makes it exit `128` for **every** ref. `is_safe_git_ref` then rejects everything, and that does not read as an error: no pin is written and the device falls back to `main`. This PR's exact failure mode, decided by nothing but the directory the operator happened to be standing in.

`git -C /` pins the answer to the ref. Measured from a directory holding a dangling `.git`: `is_safe_git_ref beta` returned `reject` before and `ACCEPT` after, while `HEAD` and `a..b` stay rejected.

## Not closed

**A detached HEAD with no pin still resolves to `main`.** There is no branch name to record. Inferring one from the commit is a guess: on this repo `main` and `beta` currently sit on the same commit, so `git for-each-ref --points-at HEAD` returns several remote branches — ambiguous exactly when it would matter (measured: 5 refs in the lab repo). The bootstrap block at the top of `install.sh` has also already `reset --hard origin/main` by the time `step_git_pull` runs, so even the commit identity is gone.

A device only reaches that state by hand. The fix is for the flasher to pass `CLAWBOX_BRANCH`, which this PR then records.

## Tests

- `src/tests/unit/install-update-branch-pin.test.ts` — 33 tests (was 17). Shell cases source the functions verbatim out of `install.sh` and run them against a throwaway project dir; the adoption cases build a real clone of a real throwaway origin, because what `adoptable_checkout_branch` inspects is remote-tracking refs and HEAD. `chown` is stubbed and logged; `chmod` is left real so the mode is read off the filesystem.
- `src/tests/unit/update-branch-validator.test.ts` — the validator-agreement corpus (38 refs), including two canaries (`$(echo main)` and a backticked equivalent) that fail the agreement assertion if the ref is ever interpolated into the shell script instead of passed as an argument, rather than letting the two sides silently compare different strings.

Covers, beyond the original set: adoption and each of its four refusals; ownership repaired on a bare run; the symlink refusal on the pin path and on the temp path; no temp file left behind; the broken-`.git` working directory; `step_git_pull` pinning before it resolves and syncs.

## Verification

Full unit suite: **201 files / 2567 tests passing**, ESLint clean on the changed files. (Baseline before this PR: 200 / 2544 — the delta is the 23 tests added here, no regressions.)

The before/after matrices above are produced by running the *real* `resolve_update_branch` extracted from each revision of `install.sh` and the *real* `resolveUpdateBranch` extracted from each revision of `updater.ts` against purpose-built git repos, so both columns are measurements rather than readings of the diff.

Earlier hardware verification of the original commits (OpenClaw box, from an existing `beta` pin) still stands: explicit branch over a different pin re-pinned and announced; `owner=clawbox group=clawbox mode=644`; a bare `--step git_pull` afterwards left the pin byte-identical; `GET`/`POST /setup-api/system/update-branch` round-tripped as the app user over a root-written pin; `git status` clean with the pin correctly ignored.
