### PR TITLE
V4 output cap: use the 393,216 the proxy enforces, not the 384,000 we rounded to (TASK-393)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -491,11 +491,14 @@ if isinstance(ds_models, list):
         if model.get("contextWindow") in (None, 128000, 131072, 200000):
             model["contextWindow"] = 1000000
             changed = True
-        # maxTokens is only filled in when absent. Unlike contextWindow there
-        # is no wrong-value set to recognise here, and a number someone chose
-        # is a choice — a box told to cap output at 8K meant it.
-        if model.get("maxTokens") is None:
-            model["maxTokens"] = 384000
+        # maxTokens: filled in when absent, and corrected when it holds a
+        # number this migration itself put there. 384000 shipped first and is
+        # 9,216 short of the ceiling the upstream enforces (393216 = 384*1024,
+        # measured against the live proxy), so a box carrying it is carrying
+        # our rounding, not its owner's decision. Any other value is left
+        # alone — a box told to cap output at 8K meant it.
+        if model.get("maxTokens") in (None, 384000):
+            model["maxTokens"] = 393216
             changed = True
         if not isinstance(model.get("input"), list) or not model.get("input"):
             model["input"] = ["text"]

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -254,7 +254,12 @@ async function getConfiguredClawboxAiToken(preferredToken?: string) {
 // 2026.7.1 (2026-08-17): with these fields absent, `openclaw models list`
 // resolved both V4 models to 200K; with them present it reports 1M.
 const CLAWBOX_AI_CONTEXT_WINDOW = 1_000_000;
-const CLAWBOX_AI_MAX_TOKENS = 384_000;
+// 393,216 (384 x 1024) is the ceiling the upstream actually enforces, measured
+// against the live proxy on 2026-08-18: max_tokens=393216 is accepted, 400000
+// comes back 400 "the valid range of max_tokens is [1, 393216]". The previous
+// 384,000 was a round number that left 9,216 tokens of output unusable for no
+// reason.
+const CLAWBOX_AI_MAX_TOKENS = 393_216;
 // V4 is text-in/text-out upstream. Stated rather than inferred so the picker
 // never offers image attachments the proxy would reject.
 const CLAWBOX_AI_INPUT_MODALITIES = ["text"] as const;

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -353,7 +353,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     // reproduced on a device running 2026.7.1 on 2026-08-17.
     for (const model of providerDef.models) {
       expect(model.contextWindow).toBe(1_000_000);
-      expect(model.maxTokens).toBe(384_000);
+      expect(model.maxTokens).toBe(393_216);
       expect(model.input).toEqual(["text"]);
     }
 

--- a/src/tests/unit/gateway-pre-start-v4-context.test.ts
+++ b/src/tests/unit/gateway-pre-start-v4-context.test.ts
@@ -77,13 +77,21 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh V4 context migration", () => 
   it.each(V4_IDS)("fills an absent contextWindow with 1M on %s", (id) => {
     const [m] = migrate([{ id, name: "ClawBox AI" }]);
     expect(m.contextWindow).toBe(1_000_000);
-    expect(m.maxTokens).toBe(384_000);
+    expect(m.maxTokens).toBe(393_216);
     expect(m.input).toEqual(["text"]);
   });
 
   it.each(V4_IDS)("replaces the old explicit 128K on %s", (id) => {
     const [m] = migrate([{ id, contextWindow: 128000 }]);
     expect(m.contextWindow).toBe(1_000_000);
+  });
+
+  it.each(V4_IDS)("raises the 384K output cap an earlier run wrote to the enforced 393,216 on %s", (id) => {
+    // The first version of this migration shipped 384000. It is under the real
+    // upstream ceiling, so boxes that already took it would keep a cap we chose
+    // by rounding rather than by measuring.
+    const [m] = migrate([{ id, maxTokens: 384000 }]);
+    expect(m.maxTokens).toBe(393_216);
   });
 
   it.each(V4_IDS)("replaces the 200K fallback written back by an earlier run on %s", (id) => {


### PR DESCRIPTION
Follow-up to #391.

#391 declared `maxTokens: 384000` on both V4 tiers. That number was a round "384K", not a measured one. Probing the live proxy on 18.08 with a real Max-tier token:

- `max_tokens=384000` → HTTP 200
- `max_tokens=393216` → HTTP 200
- `max_tokens=400000` → HTTP 400, `Invalid max_tokens value, the valid range of max_tokens is [1, 393216]`

393,216 is 384 x 1024 — the real enforced ceiling. Every V4 session has been leaving 9,216 tokens of output unusable.

## Changes
- `CLAWBOX_AI_MAX_TOKENS` 384,000 → 393,216 in the provider definition written to `openclaw.json`.
- Migration in `gateway-pre-start.sh` now corrects `maxTokens: 384000` as well as filling an absent one. 384000 can only have come from the first version of this migration, so a box carrying it is carrying our rounding — not an operator decision. Any other value is still left alone, same as before.
- Tests updated, plus a new case per tier covering the 384000 → 393216 correction.

## Verification
72 tests pass across the three affected files (`gateway-pre-start-v4-context`, `configure`, `catalog-clawai`). The migration tests run the block extracted from the shipped `gateway-pre-start.sh`, so they fail if it drifts.

The merged #391 was validated end to end on a real Orin Nano earlier today (bug reproduced at 200K, fixed via the gateway restart path, idempotent, live Flash + Pro traffic, session reporting `contextTokens=1000000`). This PR gets the same treatment on a clean box after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the DeepSeek V4 maximum output-token limit from 384,000 to 393,216.
  * Existing custom token limits remain unchanged.
  * Models using the previous 384,000 limit are automatically updated to the new ceiling.

* **Tests**
  * Updated coverage to verify the new limit and migration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->