### PR TITLE
The box says its context is 128K while holding 900K (TASK-393 follow-up)

### DIFF
--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -85,3 +85,21 @@ Edge cases:
 - **Overwrite on rename.** If they later say "actually, call me X instead", call `preferences_set` again with the new value.
 - **Clear on anonymity request.** If they ask not to be named, or want it reset, `preferences_set('{"ui_user_name": ""}')`.
 - **Don't echo back the stored name as confirmation** unless they explicitly ask. Silently doing the right thing is the vibe.
+
+---
+
+<!-- clawbox:ai-model-limits -->
+## What ClawBox AI can actually hold
+
+When you run on ClawBox AI (`deepseek-v4-flash` or `deepseek-v4-pro`), these are the real limits of the session you are in:
+
+- **Context window: 1,000,000 tokens.**
+- **Output: up to 393,216 tokens** in a single reply.
+- **Text in, text out.** Image attachments are rejected upstream.
+
+**Do not quote a smaller number if the user asks how much context you have.** The model weights were trained before this window existed, so asked cold you will tend to answer "128K" — that is a memory of an older DeepSeek, not a fact about this device. The numbers above are what the gateway configures and what the proxy enforces; verified on hardware with a 902,116-token prompt.
+
+Two things follow from a window this large:
+
+- **You rarely need to summarise to survive.** Reading a long file or a whole conversation in full is usually cheaper and more accurate than compacting it early.
+- **Keep the start of the context stable.** Upstream caches on prefix, so an unchanged opening is billed at roughly a tenth of the price and returns much faster — a 902K-token prompt drops from ~31s to ~6s on a cache hit. Reordering or rewriting early context throws that away for the entire remainder.

--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -103,3 +103,4 @@ Two things follow from a window this large:
 
 - **You rarely need to summarise to survive.** Reading a long file or a whole conversation in full is usually cheaper and more accurate than compacting it early.
 - **Keep the start of the context stable.** Upstream caches on prefix, so an unchanged opening is billed at roughly a tenth of the price and returns much faster — a 902K-token prompt drops from ~31s to ~6s on a cache hit. Reordering or rewriting early context throws that away for the entire remainder.
+<!-- /clawbox:ai-model-limits -->

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -964,6 +964,36 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # already mention CLAWBOX.md, so the agent loads our guide as part of
   # its session-start context without us having to overwrite AGENTS.md
   # (which the agent may have personalized).
+  # --- clawbox-md-ai-limits (extracted verbatim by tests) ---
+  # A CLAWBOX.md seeded before this section existed has no statement of what
+  # the ClawBox AI window actually is, and the model will not supply one: asked
+  # cold, V4 answers "128K" from its own training data, which is wrong by a
+  # factor of eight and reads to a customer like a spec sheet. Seeding is
+  # seed-if-missing, so those boxes would never get the correction. Append it
+  # to an existing file instead, guarded by the marker so a second gateway
+  # start is a no-op and anything the owner wrote is left where it is.
+  if [ -f "$CLAWBOX_GUIDE_DST" ] && ! grep -qF "clawbox:ai-model-limits" "$CLAWBOX_GUIDE_DST"; then
+    cat >> "$CLAWBOX_GUIDE_DST" <<'CLAWBOX_MD_AI_LIMITS'
+
+---
+
+<!-- clawbox:ai-model-limits -->
+## What ClawBox AI can actually hold
+
+When you run on ClawBox AI (`deepseek-v4-flash` or `deepseek-v4-pro`), these are the real limits of the session you are in:
+
+- **Context window: 1000000 tokens.**
+- **Output: up to 393216 tokens** in a single reply.
+- **Text in, text out.** Image attachments are rejected upstream.
+
+**Do not quote a smaller number if the user asks how much context you have.** The model weights were trained before this window existed, so asked cold you will tend to answer "128K" — that is a memory of an older DeepSeek, not a fact about this device.
+
+Keep the start of the context stable: upstream caches on prefix, so an unchanged opening is billed at roughly a tenth of the price and returns much faster. Rewriting early context throws that away for the entire remainder.
+CLAWBOX_MD_AI_LIMITS
+    echo "  Appended AI model limits to CLAWBOX.md"
+  fi
+  # --- end clawbox-md-ai-limits ---
+
   CLAWBOX_AGENTS_MD="$CLAWBOX_WORKSPACE/AGENTS.md"
   if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "CLAWBOX.md" "$CLAWBOX_AGENTS_MD"; then
     printf '\n\n## ClawBox integration\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, and how to install/uninstall skills through the App Store.\n' >> "$CLAWBOX_AGENTS_MD"

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -977,10 +977,14 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # the model picker came to claim 128K while the provider said something else.
   if [ -f "$CLAWBOX_GUIDE_DST" ] && [ -f "$CLAWBOX_GUIDE_SRC" ] \
      && ! grep -qF "clawbox:ai-model-limits" "$CLAWBOX_GUIDE_DST"; then
+    # Buffer and emit only once BOTH markers have been seen. Printing as we go
+    # would turn a template with an opening marker and no closing one into
+    # "everything from here to end of file", quietly appending unrelated
+    # sections to the customer's guide.
     CLAWBOX_AI_LIMITS_SECTION="$(awk '
       /<!-- clawbox:ai-model-limits -->/ { inside = 1 }
-      inside { print }
-      /<!-- \/clawbox:ai-model-limits -->/ { if (inside) exit }
+      inside { buf = buf $0 "\n" }
+      /<!-- \/clawbox:ai-model-limits -->/ { if (inside) { printf "%s", buf; exit } }
     ' "$CLAWBOX_GUIDE_SRC")"
     # An empty extraction means the markers moved. Append nothing rather than a
     # blank heading: a guide that says nothing about the window is the state we

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -965,32 +965,32 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # its session-start context without us having to overwrite AGENTS.md
   # (which the agent may have personalized).
   # --- clawbox-md-ai-limits (extracted verbatim by tests) ---
-  # A CLAWBOX.md seeded before this section existed has no statement of what
-  # the ClawBox AI window actually is, and the model will not supply one: asked
-  # cold, V4 answers "128K" from its own training data, which is wrong by a
-  # factor of eight and reads to a customer like a spec sheet. Seeding is
-  # seed-if-missing, so those boxes would never get the correction. Append it
-  # to an existing file instead, guarded by the marker so a second gateway
-  # start is a no-op and anything the owner wrote is left where it is.
-  if [ -f "$CLAWBOX_GUIDE_DST" ] && ! grep -qF "clawbox:ai-model-limits" "$CLAWBOX_GUIDE_DST"; then
-    cat >> "$CLAWBOX_GUIDE_DST" <<'CLAWBOX_MD_AI_LIMITS'
-
----
-
-<!-- clawbox:ai-model-limits -->
-## What ClawBox AI can actually hold
-
-When you run on ClawBox AI (`deepseek-v4-flash` or `deepseek-v4-pro`), these are the real limits of the session you are in:
-
-- **Context window: 1000000 tokens.**
-- **Output: up to 393216 tokens** in a single reply.
-- **Text in, text out.** Image attachments are rejected upstream.
-
-**Do not quote a smaller number if the user asks how much context you have.** The model weights were trained before this window existed, so asked cold you will tend to answer "128K" — that is a memory of an older DeepSeek, not a fact about this device.
-
-Keep the start of the context stable: upstream caches on prefix, so an unchanged opening is billed at roughly a tenth of the price and returns much faster. Rewriting early context throws that away for the entire remainder.
-CLAWBOX_MD_AI_LIMITS
-    echo "  Appended AI model limits to CLAWBOX.md"
+  # A CLAWBOX.md seeded before this section existed carries no statement of
+  # what the ClawBox AI window actually is, and the model will not supply one:
+  # asked cold, V4 answers "128K" from its own training data, wrong by a factor
+  # of eight and delivered in the product's voice. Seeding is seed-if-missing,
+  # so those boxes would never see a template change.
+  #
+  # The text is COPIED OUT OF THE SHIPPED TEMPLATE between its markers rather
+  # than restated here. A device upgraded in the field and a device flashed
+  # today then read the same words by construction — restating it inline is how
+  # the model picker came to claim 128K while the provider said something else.
+  if [ -f "$CLAWBOX_GUIDE_DST" ] && [ -f "$CLAWBOX_GUIDE_SRC" ] \
+     && ! grep -qF "clawbox:ai-model-limits" "$CLAWBOX_GUIDE_DST"; then
+    CLAWBOX_AI_LIMITS_SECTION="$(awk '
+      /<!-- clawbox:ai-model-limits -->/ { inside = 1 }
+      inside { print }
+      /<!-- \/clawbox:ai-model-limits -->/ { if (inside) exit }
+    ' "$CLAWBOX_GUIDE_SRC")"
+    # An empty extraction means the markers moved. Append nothing rather than a
+    # blank heading: a guide that says nothing about the window is the state we
+    # started from, while a truncated one is a new way to be wrong.
+    if [ -n "$CLAWBOX_AI_LIMITS_SECTION" ]; then
+      printf '\n---\n\n%s\n' "$CLAWBOX_AI_LIMITS_SECTION" >> "$CLAWBOX_GUIDE_DST"
+      echo "  Appended AI model limits to CLAWBOX.md"
+    else
+      echo "  WARNING: clawbox:ai-model-limits markers not found in template; CLAWBOX.md left as is" >&2
+    fi
   fi
   # --- end clawbox-md-ai-limits ---
 

--- a/src/tests/unit/gateway-pre-start-clawbox-md.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawbox-md.test.ts
@@ -122,6 +122,28 @@ describe.skipIf(!hasBash)("gateway-pre-start.sh CLAWBOX.md model limits", () => 
     expect(out).not.toContain(MARKER);
   });
 
+  it("appends nothing when the template opens the section but never closes it", () => {
+    // Printing as the section streams by would make a dangling opening marker
+    // mean "everything to end of file" — unrelated template content landing in
+    // the customer's guide, with a success exit code to hide it.
+    const dangling = path.join(dir, "template-unclosed.md");
+    writeFileSync(
+      dangling,
+      `# Guide\n\n<!-- ${MARKER} -->\n## Limits\n\nunrelated section that follows\n`,
+    );
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    const out = run(dangling);
+    expect(out).toBe("# ClawBox Integration Guide\n");
+    expect(out).not.toContain("unrelated section that follows");
+  });
+
+  it("ignores a closing marker that appears without an opening one", () => {
+    const orphanClose = path.join(dir, "template-orphan-close.md");
+    writeFileSync(orphanClose, `# Guide\n\nsome text\n<!-- /${MARKER} -->\n`);
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    expect(run(orphanClose)).toBe("# ClawBox Integration Guide\n");
+  });
+
   it("does nothing when the template is missing entirely", () => {
     writeFileSync(guide, "# ClawBox Integration Guide\n");
     const out = run(path.join(dir, "does-not-exist.md"));

--- a/src/tests/unit/gateway-pre-start-clawbox-md.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawbox-md.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Asked how much context it has, V4 answers "128K" — a memory of an older
+// DeepSeek, not a fact about this device, and eight times smaller than the
+// window the box actually configures. Observed on hardware on 2026-08-18: the
+// same box that had just answered a 902,116-token prompt said "128K tokens" in
+// the chat app. Nothing in the prompt told it otherwise, so CLAWBOX.md now
+// does — and because CLAWBOX.md is seeded only when absent, boxes already in
+// the field need the section appended rather than seeded.
+//
+// This runs the append block out of the shipped .sh, not a copy, so the test
+// fails if the real script drifts.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const GUIDE = path.resolve(process.cwd(), "config/clawbox-workspace-guide.md");
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+const MARKER = "clawbox:ai-model-limits";
+
+/** Pull the CLAWBOX.md append block out of the .sh verbatim. */
+function extractAppendBlock(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf("  # --- clawbox-md-ai-limits (extracted verbatim by tests) ---");
+  const end = src.indexOf("  # --- end clawbox-md-ai-limits ---", start);
+  if (start < 0 || end < 0) throw new Error("clawbox-md-ai-limits block not found");
+  return src.slice(start, end);
+}
+
+const BLOCK = hasBash ? extractAppendBlock() : "";
+
+let dir: string;
+let guide: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "clawbox-md-"));
+  guide = path.join(dir, "CLAWBOX.md");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+/** Run the extracted block against a CLAWBOX.md in a temp dir. */
+function run(): string {
+  const program = `set -eu\nCLAWBOX_GUIDE_DST="${guide}"\n${BLOCK}\n`;
+  execFileSync("bash", ["-c", program], { encoding: "utf-8" });
+  return existsSync(guide) ? readFileSync(guide, "utf-8") : "";
+}
+
+describe.skipIf(!hasBash)("gateway-pre-start.sh CLAWBOX.md model limits", () => {
+  it("appends the section to a guide that predates it", () => {
+    writeFileSync(guide, "# ClawBox Integration Guide\n\nolder content\n");
+    const out = run();
+    expect(out).toContain(MARKER);
+    expect(out).toContain("1000000");
+    expect(out).toContain("393216");
+  });
+
+  it("keeps what the owner already wrote", () => {
+    writeFileSync(guide, "# ClawBox Integration Guide\n\nmy own note about the office printer\n");
+    expect(run()).toContain("my own note about the office printer");
+  });
+
+  it("is idempotent — a second gateway start appends nothing", () => {
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    const once = run();
+    const twice = run();
+    expect(twice).toBe(once);
+    expect(twice.match(new RegExp(MARKER, "g"))).toHaveLength(1);
+  });
+
+  it("does not create the file when the box has no guide at all", () => {
+    // Seeding is the other half of the script's job and owns that case; this
+    // block must not conjure a CLAWBOX.md outside a workspace that exists.
+    expect(run()).toBe("");
+    expect(existsSync(guide)).toBe(false);
+  });
+
+  it("tells the agent not to repeat the 128K it will otherwise guess", () => {
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    expect(run()).toContain("128K");
+  });
+
+  it("states the same numbers the provider migration writes", () => {
+    // One drifting without the other is how the picker came to claim 128K in
+    // the first place: two places holding the same fact, only one maintained.
+    const src = readFileSync(SCRIPT, "utf-8");
+    expect(src).toContain('model["contextWindow"] = 1000000');
+    expect(src).toContain('model["maxTokens"] = 393216');
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    const out = run();
+    expect(out).toContain("1000000");
+    expect(out).toContain("393216");
+  });
+
+  it("ships the same section in the seeded template, so fresh boxes match upgraded ones", () => {
+    const template = readFileSync(GUIDE, "utf-8");
+    expect(template).toContain(MARKER);
+    expect(template).toContain("1,000,000");
+    expect(template).toContain("393,216");
+  });
+});

--- a/src/tests/unit/gateway-pre-start-clawbox-md.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawbox-md.test.ts
@@ -41,10 +41,20 @@ beforeEach(() => {
 afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
 /** Run the extracted block against a CLAWBOX.md in a temp dir. */
-function run(): string {
-  const program = `set -eu\nCLAWBOX_GUIDE_DST="${guide}"\n${BLOCK}\n`;
-  execFileSync("bash", ["-c", program], { encoding: "utf-8" });
+function run(templateSrc: string = GUIDE): string {
+  const program = `set -eu\nCLAWBOX_GUIDE_DST="${guide}"\nCLAWBOX_GUIDE_SRC="${templateSrc}"\n${BLOCK}\n`;
+  execFileSync("bash", ["-c", program], { encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] });
   return existsSync(guide) ? readFileSync(guide, "utf-8") : "";
+}
+
+/** The marked section of the shipped template, verbatim. */
+function templateSection(src: string = GUIDE): string {
+  const text = readFileSync(src, "utf-8");
+  const start = text.indexOf(`<!-- ${MARKER} -->`);
+  const endMarker = `<!-- /${MARKER} -->`;
+  const end = text.indexOf(endMarker, start);
+  if (start < 0 || end < 0) throw new Error("markers missing from template");
+  return text.slice(start, end + endMarker.length);
 }
 
 describe.skipIf(!hasBash)("gateway-pre-start.sh CLAWBOX.md model limits", () => {
@@ -52,8 +62,8 @@ describe.skipIf(!hasBash)("gateway-pre-start.sh CLAWBOX.md model limits", () => 
     writeFileSync(guide, "# ClawBox Integration Guide\n\nolder content\n");
     const out = run();
     expect(out).toContain(MARKER);
-    expect(out).toContain("1000000");
-    expect(out).toContain("393216");
+    expect(out).toContain("1,000,000");
+    expect(out).toContain("393,216");
   });
 
   it("keeps what the owner already wrote", () => {
@@ -66,7 +76,8 @@ describe.skipIf(!hasBash)("gateway-pre-start.sh CLAWBOX.md model limits", () => 
     const once = run();
     const twice = run();
     expect(twice).toBe(once);
-    expect(twice.match(new RegExp(MARKER, "g"))).toHaveLength(1);
+    // Count the opening marker only — the section carries a closing one too.
+    expect(twice.split(`<!-- ${MARKER} -->`)).toHaveLength(2);
   });
 
   it("does not create the file when the box has no guide at all", () => {
@@ -81,22 +92,39 @@ describe.skipIf(!hasBash)("gateway-pre-start.sh CLAWBOX.md model limits", () => 
     expect(run()).toContain("128K");
   });
 
+  it("appends the shipped section verbatim, so an upgraded box reads what a fresh one reads", () => {
+    // The whole point of copying out of the template: a device flashed today
+    // and a device upgraded in the field must not end up with two different
+    // explanations of the same limit.
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    expect(run()).toContain(templateSection());
+  });
+
   it("states the same numbers the provider migration writes", () => {
     // One drifting without the other is how the picker came to claim 128K in
     // the first place: two places holding the same fact, only one maintained.
     const src = readFileSync(SCRIPT, "utf-8");
     expect(src).toContain('model["contextWindow"] = 1000000');
     expect(src).toContain('model["maxTokens"] = 393216');
-    writeFileSync(guide, "# ClawBox Integration Guide\n");
-    const out = run();
-    expect(out).toContain("1000000");
-    expect(out).toContain("393216");
+    const section = templateSection();
+    expect(section).toContain("1,000,000");
+    expect(section).toContain("393,216");
   });
 
-  it("ships the same section in the seeded template, so fresh boxes match upgraded ones", () => {
-    const template = readFileSync(GUIDE, "utf-8");
-    expect(template).toContain(MARKER);
-    expect(template).toContain("1,000,000");
-    expect(template).toContain("393,216");
+  it("appends nothing when the template markers have moved", () => {
+    // A truncated section is a new way to be wrong; saying nothing is the
+    // state we started from. The script warns and leaves the guide alone.
+    const brokenTemplate = path.join(dir, "template-without-markers.md");
+    writeFileSync(brokenTemplate, "# ClawBox Integration Guide\n\nno markers here\n");
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    const out = run(brokenTemplate);
+    expect(out).toBe("# ClawBox Integration Guide\n");
+    expect(out).not.toContain(MARKER);
+  });
+
+  it("does nothing when the template is missing entirely", () => {
+    writeFileSync(guide, "# ClawBox Integration Guide\n");
+    const out = run(path.join(dir, "does-not-exist.md"));
+    expect(out).toBe("# ClawBox Integration Guide\n");
   });
 });


### PR DESCRIPTION
Follow-up to #391 / #392.

Observed on hardware on 18.08, box 192.168.50.66: minutes after answering a **902,116-token** prompt, the chat app was asked what model it was and what context window it had. It replied:

> I'm running deepseek/deepseek-v4-pro, and my context window is 128K tokens.

Checked before assuming: there is no live `128000` anywhere on the device, and the system prompt says nothing about context size. The model is answering from its own weights, which predate this window. A customer asking the obvious question gets a number **eight times too small**, stated confidently, by the product.

## Changes
- `config/clawbox-workspace-guide.md` — new marker-guarded section stating the real window (1,000,000), output cap (393,216) and text-only modality, plus why the model's own guess is wrong.
- `scripts/gateway-pre-start.sh` — appends that section to an existing `CLAWBOX.md`. Seeding is seed-if-missing by design (owners personalise the file), so a template change alone would never reach a box already in the field. The append is guarded by the `clawbox:ai-model-limits` marker: second gateway start is a no-op, owner edits untouched, and it will not create the file where none exists.

The section also tells the agent two things that follow from a 1M window: it rarely needs to compact early, and it should keep the prefix stable because upstream caches on it.

## Tests
New `src/tests/unit/gateway-pre-start-clawbox-md.test.ts`, 7 cases, running the append block extracted **verbatim from the shipped .sh** so the test fails if the script drifts: appends to an older guide · preserves owner content · idempotent (marker appears exactly once) · does not create a missing file · states the 128K warning · **asserts the numbers match the ones the provider migration writes in the same script** · asserts the shipped template carries the same section so fresh boxes match upgraded ones.

Full suite green locally: **203 files / 2585 tests**.

## Evidence for the numbers
Measured on this box, not quoted from a spec: 902,116-token prompt answered correctly on Flash, 462,116 on Pro; `max_tokens` 393,216 accepted and 400,000 rejected with `valid range is [1, 393216]`; cache hit 902,016/902,116 on repeat, 31.3s → 6.0s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance on ClawBox AI’s context window, maximum output, text-only input, context caching, and verified gateway and provider limits.
  - Documented the 128K correction and related model-limit details.

- **Improvements**
  - Existing `CLAWBOX.md` guides now receive model-limit guidance automatically while preserving user content.
  - Updates are applied only once and do not create guides when none exist.
  - Missing or incomplete template content is safely skipped with a warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->