### PR TITLE
Make the agent verify model limits instead of guessing

### DIFF
--- a/docs-site/technical/agent-interface.mdx
+++ b/docs-site/technical/agent-interface.mdx
@@ -32,7 +32,7 @@ startup from the device's edition lock.
 ### Orientation — the agent calls these first
 | Tool | Purpose |
 |---|---|
-| `device_status` | Edition, agent, AI provider/model/thinking level, free disk, update waiting — in one call |
+| `device_status` | Edition, agent, AI provider/model, configured context/output limits, thinking level, free disk, update waiting — in one call |
 | `clawbox_health` | Is the device API reachable, and is our token accepted — separates auth from connectivity |
 | `clawbox_context` | The on-device field guide plus the webapp storage/styling rules |
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,7 +73,7 @@ chronically-failing tool takes *every* ClawBox tool offline for the agent.
 ### Orientation — call these first
 | Tool | What it does |
 |---|---|
-| `device_status` | Edition, agent, AI provider/model/thinking level, free disk, update waiting. One call, independent timeouts, dead legs report `"unknown"`. |
+| `device_status` | Edition, agent, AI provider/model, configured context/output limits, thinking level, free disk, update waiting. One call, independent timeouts, dead legs report `"unknown"`. |
 | `clawbox_health` | Is the device API reachable and is our token accepted. Separates auth from connectivity. |
 | `clawbox_context` | The device field guide plus the webapp storage/styling rules. |
 

--- a/mcp/clawbox-mcp.ts
+++ b/mcp/clawbox-mcp.ts
@@ -53,6 +53,7 @@ function instructionsFor(edition: Ed): string {
   return [
     `You are the AI inside a ClawBox — ${product} The desktop has a sarcastic crab mascot.`,
     "Call `clawbox_context` once at the start of a session for the full field guide, and `device_status` before answering anything about the device itself.",
+    "Before stating a context-window or output-token limit, call `device_status` and use `ai.limits`, which is read from the live runtime configuration. If a limit is unknown, say so; never infer it from the model name or training memory.",
     "For web browsing use `browser_open` and `browser_navigate`, which drive the real Chromium window on the desktop. Do not open the \"browser\" desktop app for browsing — it is only the integration settings panel.",
     // The harness ships its OWN browser tool, and on a ClawBox it is the wrong
     // one twice over: it drives a separate headless browser the user cannot

--- a/mcp/tools/orientation.ts
+++ b/mcp/tools/orientation.ts
@@ -66,6 +66,53 @@ interface ChatModelPayload {
   current?: string | null;
 }
 
+interface ConfiguredModelLimits {
+  model: string;
+  context_window_tokens: number | "unknown";
+  max_output_tokens: number | "unknown";
+  source: "openclaw_config";
+}
+
+/** Keep only positive whole-token counts; invalid config stays visibly unknown. */
+function positiveInteger(value: unknown): number | "unknown" {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : "unknown";
+}
+
+/** Read the active model's declared limits from the config the gateway uses. */
+export function readConfiguredModelLimits(
+  configPath = process.env.OPENCLAW_CONFIG
+    ?? join(process.env.HOME ?? "/home/clawbox", ".openclaw", "openclaw.json"),
+): ConfiguredModelLimits | "unknown" {
+  try {
+    const config = JSON.parse(readFileSync(configPath, "utf8")) as {
+      agents?: { defaults?: { model?: { primary?: unknown } } };
+      models?: { providers?: Record<string, { models?: unknown[] }> };
+    };
+    const primary = config.agents?.defaults?.model?.primary;
+    if (typeof primary !== "string") return "unknown";
+    const slash = primary.indexOf("/");
+    if (slash <= 0 || slash === primary.length - 1) return "unknown";
+    const provider = primary.slice(0, slash);
+    const modelId = primary.slice(slash + 1);
+    const models = config.models?.providers?.[provider]?.models;
+    if (!Array.isArray(models)) return "unknown";
+    const model = models.find((entry): entry is Record<string, unknown> =>
+      !!entry && typeof entry === "object" && (entry as { id?: unknown }).id === modelId
+    );
+    if (!model) return "unknown";
+    return {
+      model: primary,
+      context_window_tokens: positiveInteger(model.contextWindow),
+      max_output_tokens: positiveInteger(model.maxTokens),
+      source: "openclaw_config",
+    };
+  } catch {
+    return "unknown";
+  }
+}
+
 /** The root mount is what "free disk" means to a customer. */
 function rootDisk(stats: StatsPayload | null) {
   if (!stats?.storage?.length) return "unknown";
@@ -76,7 +123,7 @@ function rootDisk(stats: StatsPayload | null) {
 export function registerOrientationTools(reg: Registrar, ctx: McpContext): void {
   reg.tool(
     "device_status",
-    "Report what this ClawBox is: edition, active agent, AI provider and model, thinking level, free disk space, and whether a software update is waiting. Call this before answering any question about the device itself, and before choosing between tools that exist on only one edition. Any part that cannot be read reports \"unknown\" instead of failing the whole call.",
+    "Report what this ClawBox is: edition, active agent, AI provider and model, the active model's configured context/output limits, thinking level, free disk space, and whether a software update is waiting. Call this before answering any question about the device itself or its model limits. Any part that cannot be read reports \"unknown\" instead of failing the whole call.",
     {},
     { editions: ["openclaw", "hermes"], readOnly: true, profile: "core" },
     async () => {
@@ -112,6 +159,7 @@ export function registerOrientationTools(reg: Registrar, ctx: McpContext): void 
           : {
               provider: chatModel?.selected?.provider ?? "unknown",
               model: chatModel?.selected?.model ?? chatModel?.current ?? "unknown",
+              limits: readConfiguredModelLimits(),
               thinking: "unknown",
             };
 

--- a/src/tests/unit/mcp-model-limits.test.ts
+++ b/src/tests/unit/mcp-model-limits.test.ts
@@ -1,0 +1,72 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterAll, describe, expect, it } from "vitest";
+import { readConfiguredModelLimits } from "../../../mcp/tools/orientation";
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-model-limits-"));
+
+function configFile(name: string, config: unknown): string {
+  const file = path.join(tempDir, name);
+  fs.writeFileSync(file, JSON.stringify(config));
+  return file;
+}
+
+afterAll(() => fs.rmSync(tempDir, { recursive: true, force: true }));
+
+describe("managed model-limit guidance", () => {
+  it("requires a live check without supplying a memorized answer", () => {
+    const instructions = fs.readFileSync(
+      path.join(process.cwd(), "mcp", "clawbox-mcp.ts"),
+      "utf8",
+    );
+    expect(instructions).toContain("call `device_status`");
+    expect(instructions).toContain("use `ai.limits`");
+    expect(instructions).toMatch(/never infer/i);
+    expect(instructions).not.toMatch(/128(?:,?000|K)|1(?:,?000,?000|M)|393(?:,?216|K)/i);
+  });
+});
+
+describe("readConfiguredModelLimits", () => {
+  it("reads the active model rather than guessing from its id", () => {
+    const file = configFile("valid.json", {
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+      models: {
+        providers: {
+          deepseek: {
+            models: [
+              { id: "deepseek-v4-flash", contextWindow: 111, maxTokens: 222 },
+              { id: "deepseek-v4-pro", contextWindow: 1_000_000, maxTokens: 393_216 },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(readConfiguredModelLimits(file)).toEqual({
+      model: "deepseek/deepseek-v4-pro",
+      context_window_tokens: 1_000_000,
+      max_output_tokens: 393_216,
+      source: "openclaw_config",
+    });
+  });
+
+  it("reports unknown instead of inventing unavailable limits", () => {
+    expect(readConfiguredModelLimits("/does/not/exist")).toBe("unknown");
+    const file = configFile("invalid-limits.json", {
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+      models: {
+        providers: {
+          deepseek: { models: [{ id: "deepseek-v4-pro", contextWindow: -1 }] },
+        },
+      },
+    });
+
+    expect(readConfiguredModelLimits(file)).toEqual({
+      model: "deepseek/deepseek-v4-pro",
+      context_window_tokens: "unknown",
+      max_output_tokens: "unknown",
+      source: "openclaw_config",
+    });
+  });
+});


### PR DESCRIPTION
TASK-393 follow-up, replacing the reverted #393 with a managed runtime check.

What changed:
- one MCP instruction tells the model to call device_status before stating context/output limits
- device_status reads the active model entry from the live OpenClaw config and returns ai.limits
- missing or invalid values return unknown; the prompt contains no context-size answer
- no shell/awk migration and no customer-owned workspace files are touched

Verification:
- 3 focused tests
- full suite: 203 files / 2585 tests pass
- MCP TypeScript check passes
- MCP tool-contract check passes
- changed-file ESLint passes

Repository-wide ESLint still has pre-existing failures in unrelated files; this diff introduces none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device status now reports configured context-window and output-token limits alongside thinking level.
  * Model limits are read from the active configuration and shown as unknown when unavailable.

* **Bug Fixes**
  * Improved guidance prevents reporting unverified or inferred model limits.

* **Documentation**
  * Updated technical and MCP documentation to describe the expanded device status information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->