### PR TITLE
A box that cannot reach the GPU should still be able to speak

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1120,6 +1120,7 @@ step_openclaw_setup() {
   step_openclaw_install
   step_openclaw_patch
   step_openclaw_config
+  step_openclaw_tts
 }
 
 # Install the Hermes agent (git-based install into ~/.hermes). Needed by every
@@ -1717,6 +1718,53 @@ NODE
   echo "  OpenClaw config updated"
 }
 
+# Point OpenClaw's speech output at the box's own engines (TASK-383).
+#
+# Two halves, and both have to run on updates as well as fresh installs:
+#   1. Install Piper, the CPU fallback. Without it on disk the fallback chain
+#      in scripts/openclaw/clawbox-tts.sh has nowhere to fall, and every
+#      Kokoro failure is silence again.
+#   2. Point the built-in `tts-local-cli` provider at clawbox-tts.sh.
+#
+# The command is the REPO copy, not a copy deployed into the workspace: the
+# repo path is refreshed by `git pull` on every update, so the box can never
+# end up speaking through a stale fallback chain.
+#
+# Placeholder casing is load-bearing. OpenClaw's applyTemplate normalizes a
+# token to Firstupper+restlower and only falls back to the raw key, so
+# `{{OutputPath}}` works and `{{outputPath}}` silently substitutes an EMPTY
+# STRING — the command would then be handed no output path at all. `{{Text}}`
+# is also what stops OpenClaw piping the text to stdin instead of argv.
+# The literal `--` guards against a reply that itself begins with `--` being
+# parsed as an option by the script.
+#
+# outputFormat wav is deliberate: both engines emit WAV natively, so the happy
+# path needs no ffmpeg at all, and OpenClaw transcodes to Opus itself when a
+# channel wants a voice note.
+step_openclaw_tts() {
+  is_hermes_edition && { echo "  [hermes edition] skipping on-device TTS"; return 0; }
+  local TTS_SCRIPT="$PROJECT_DIR/scripts/openclaw/clawbox-tts.sh"
+
+  bash "$PROJECT_DIR/scripts/install-voice.sh" --piper-only \
+    || echo "  Warning: Piper fallback install failed (non-fatal) — Kokoro still works, but a GPU failure will be silent"
+
+  # Seed-if-unset, same contract as the primary model above: an owner who has
+  # chosen ElevenLabs (or turned TTS off) must not have it silently reset by
+  # every update, and rebuild_reboot re-invokes this step.
+  local CURRENT_TTS
+  CURRENT_TTS=$(as_clawbox "$OPENCLAW_BIN" config get messages.tts.provider 2>/dev/null || echo "")
+  if [ -n "$CURRENT_TTS" ] && [ "$CURRENT_TTS" != "null" ]; then
+    echo "  TTS provider already set ($CURRENT_TTS) — preserving"
+    return 0
+  fi
+
+  local TTS_PROVIDER_JSON
+  TTS_PROVIDER_JSON=$(node -e 'process.stdout.write(JSON.stringify({command:process.argv[1],args:["--","{{Text}}","{{OutputPath}}"],outputFormat:"wav",timeoutMs:120000}));' "$TTS_SCRIPT")
+  oc_config_set messages.tts.providers.tts-local-cli "$TTS_PROVIDER_JSON" --json
+  oc_config_set messages.tts.provider "tts-local-cli"
+  echo "  On-device TTS configured (Kokoro GPU, Piper fallback)"
+}
+
 step_setup_config() {
   step_directories_permissions
   step_captive_portal_dns
@@ -1974,6 +2022,11 @@ step_post_update() {
   # `pip install` is a no-op even after restore/scheduler bug fixes land —
   # we have to force-reinstall.
   step_clawkeep_install || echo "  Warning: clawkeep_install step failed (non-fatal)"
+  # On-device TTS: installs/refreshes the Piper fallback and seeds the
+  # tts-local-cli provider. Without this call the whole of TASK-383 would be
+  # fresh-install-only, and every already-shipped box would keep answering a
+  # spoken request with silence.
+  step_openclaw_tts || echo "  Warning: openclaw_tts step failed (non-fatal)"
   # Re-assert the gateway service after an in-app update. The full update
   # syncs repo files and rebuilds before this continuation runs; older devices
   # can therefore reach the new UI while the gateway is still using stale
@@ -3207,7 +3260,7 @@ step_validate_services() {
 DISPATCH_STEPS=(
   bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install ollama_install llamacpp_install
   chromium_install ai_tools_install vnc_install vnc_refresh
-  openclaw_setup openclaw_install openclaw_patch openclaw_config openclaw_models
+  openclaw_setup openclaw_install openclaw_patch openclaw_config openclaw_models openclaw_tts
   # Edition steps must be dispatchable or no in-app update can ever re-bake the
   # lock, install Hermes, or repair a Hermes appliance — which is how a Hermes
   # box ended up running edition-blind updates that reinstalled OpenClaw.

--- a/install.sh
+++ b/install.sh
@@ -1758,10 +1758,28 @@ step_openclaw_tts() {
     return 0
   fi
 
+  # Never point OpenClaw at a command that is not there: that configures the
+  # exact silent failure this task removes, and it would look like a working
+  # install until someone asked the box to speak.
+  if [ ! -x "$TTS_SCRIPT" ]; then
+    echo "  ERROR: $TTS_SCRIPT is missing or not executable — refusing to configure TTS against it" >&2
+    return 1
+  fi
+
   local TTS_PROVIDER_JSON
   TTS_PROVIDER_JSON=$(node -e 'process.stdout.write(JSON.stringify({command:process.argv[1],args:["--","{{Text}}","{{OutputPath}}"],outputFormat:"wav",timeoutMs:120000}));' "$TTS_SCRIPT")
-  oc_config_set messages.tts.providers.tts-local-cli "$TTS_PROVIDER_JSON" --json
-  oc_config_set messages.tts.provider "tts-local-cli"
+  # Order matters and so does the gate. oc_config_set retries three times and
+  # then gives up; if the provider definition did not land, naming it as THE
+  # provider leaves the box pointing at a provider that does not exist, and
+  # every spoken reply fails — strictly worse than not having run at all.
+  if ! oc_config_set messages.tts.providers.tts-local-cli "$TTS_PROVIDER_JSON" --json; then
+    echo "  ERROR: could not write the tts-local-cli provider — leaving messages.tts.provider unset" >&2
+    return 1
+  fi
+  if ! oc_config_set messages.tts.provider "tts-local-cli"; then
+    echo "  ERROR: could not select the tts-local-cli provider" >&2
+    return 1
+  fi
   echo "  On-device TTS configured (Kokoro GPU, Piper fallback)"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1766,8 +1766,24 @@ step_openclaw_tts() {
     return 1
   fi
 
+  # timeoutMs bounds the WHOLE clawbox-tts.sh process, engine chain included.
+  # It used to be a hardcoded 120000 while the script's own Kokoro timeout was
+  # also 120s, so OpenClaw killed the process at the instant Kokoro gave up and
+  # Piper was never invoked — a hung GPU stayed silent, which is the failure
+  # this whole feature exists to remove. Ask the script for the number instead
+  # of keeping a second copy of it here: it derives the value from its own
+  # engine slices, so re-tuning one of them moves this with it.
+  local TTS_TIMEOUT_MS
+  TTS_TIMEOUT_MS=$(bash "$TTS_SCRIPT" --provider-timeout-ms 2>/dev/null || echo "")
+  case "$TTS_TIMEOUT_MS" in
+    ''|*[!0-9]*)
+      echo "  ERROR: $TTS_SCRIPT did not report a usable provider timeout (got '${TTS_TIMEOUT_MS}')" >&2
+      return 1
+      ;;
+  esac
+
   local TTS_PROVIDER_JSON
-  TTS_PROVIDER_JSON=$(node -e 'process.stdout.write(JSON.stringify({command:process.argv[1],args:["--","{{Text}}","{{OutputPath}}"],outputFormat:"wav",timeoutMs:120000}));' "$TTS_SCRIPT")
+  TTS_PROVIDER_JSON=$(node -e 'process.stdout.write(JSON.stringify({command:process.argv[1],args:["--","{{Text}}","{{OutputPath}}"],outputFormat:"wav",timeoutMs:Number(process.argv[2])}));' "$TTS_SCRIPT" "$TTS_TIMEOUT_MS")
   # Order matters and so does the gate. oc_config_set retries three times and
   # then gives up; if the provider definition did not land, naming it as THE
   # provider leaves the box pointing at a provider that does not exist, and

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -52,7 +52,15 @@ piper_fetch() {
     return 0
   fi
   rm -f "$dest" "$dest.part"
-  curl -fsSL --retry 3 -o "$dest.part" "$url" || {
+  # No timeouts here meant a stalled TCP connection blocked forever, and this
+  # runs from step_post_update on every in-app update of a shipped device: one
+  # dead transfer hung the whole update with no bound and no diagnostic.
+  # --speed-limit/--speed-time abort a connection that has effectively stopped
+  # without killing a slow-but-progressing download, which a flat --max-time
+  # would; only then can --retry actually do anything.
+  curl -fsSL --retry 3 --retry-delay 5 \
+    --connect-timeout 20 --speed-limit 1024 --speed-time 60 \
+    -o "$dest.part" "$url" || {
     echo "  ERROR: download failed: $url" >&2
     rm -f "$dest.part"
     return 1
@@ -98,7 +106,18 @@ install_piper() {
       return 1
     }
     rm -f "$tarball"
-    chmod +x "$PIPER_DIR/piper" 2>/dev/null || true
+    # A discarded chmod hid a missing binary: if the release layout ever
+    # changes, tar still succeeds and this printed "installed" for a directory
+    # with no piper in it. The failure then surfaced much later as
+    # "piper: binary not found", at the moment a user expected speech.
+    if [ ! -f "$PIPER_DIR/piper" ]; then
+      echo "  ERROR: the Piper tarball did not contain piper at $PIPER_DIR/piper" >&2
+      return 1
+    fi
+    if ! chmod +x "$PIPER_DIR/piper"; then
+      echo "  ERROR: could not make $PIPER_DIR/piper executable" >&2
+      return 1
+    fi
     echo "  Piper binary installed at $PIPER_DIR/piper"
   fi
 
@@ -117,20 +136,40 @@ install_piper() {
 # runs from. Split out of the big install so --piper-only can call it too: the
 # updater re-runs that cheap path on every update, and a box whose
 # clawbox-tts.sh is stale is a box whose fallback chain is stale.
+# Returns non-zero if ANY required piece did not land. A device that keeps a
+# stale or half-copied speech install while the updater reports success is the
+# same class of bug as a silent TTS failure, one layer further out.
 deploy_voice_scripts() {
-  local src dst
-  src="$(cd "$(dirname "$0")" && pwd)"
+  local src dst f rc=0
+  src="$(cd "$(dirname "$0")" && pwd)" || return 1
   dst="$WORKSPACE/scripts"
-  mkdir -p "$dst/openclaw"
+  if ! mkdir -p "$dst/openclaw"; then
+    echo "  ERROR: could not create $dst/openclaw" >&2
+    return 1
+  fi
   for f in kokoro-server.py kokoro-client.sh kokoro-tts.sh whisper-server.py stt-client.py stt.py; do
-    [ -f "$src/$f" ] && cp "$src/$f" "$dst/$f"
+    if [ -f "$src/$f" ]; then
+      cp "$src/$f" "$dst/$f" || { echo "  ERROR: could not copy $f" >&2; rc=1; }
+    fi
   done
-  if [ -f "$src/openclaw/clawbox-tts.sh" ]; then
-    cp "$src/openclaw/clawbox-tts.sh" "$dst/openclaw/clawbox-tts.sh"
-    chmod +x "$dst/openclaw/clawbox-tts.sh"
+  # The entrypoint is not optional — it is the command OpenClaw execs — so a
+  # missing source file is an error rather than something to step over.
+  if [ ! -f "$src/openclaw/clawbox-tts.sh" ]; then
+    echo "  ERROR: $src/openclaw/clawbox-tts.sh is missing" >&2
+    rc=1
+  elif ! cp "$src/openclaw/clawbox-tts.sh" "$dst/openclaw/clawbox-tts.sh"; then
+    echo "  ERROR: could not deploy clawbox-tts.sh to $dst/openclaw" >&2
+    rc=1
+  elif ! chmod +x "$dst/openclaw/clawbox-tts.sh"; then
+    echo "  ERROR: could not make $dst/openclaw/clawbox-tts.sh executable" >&2
+    rc=1
   fi
   chmod +x "$dst"/*.sh 2>/dev/null || true
-  chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$WORKSPACE"
+  if ! chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$WORKSPACE"; then
+    echo "  ERROR: could not chown $WORKSPACE to $CLAWBOX_USER" >&2
+    rc=1
+  fi
+  return "$rc"
 }
 
 # --piper-only installs just the CPU fallback and refreshes the entrypoint.
@@ -139,8 +178,13 @@ deploy_voice_scripts() {
 # run unattended on a box that already works.
 if [ "${1:-}" = "--piper-only" ]; then
   echo "=== Voice fallback (Piper) ==="
-  install_piper
-  deploy_voice_scripts
+  PIPER_ONLY_RC=0
+  install_piper || PIPER_ONLY_RC=1
+  deploy_voice_scripts || PIPER_ONLY_RC=1
+  if [ "$PIPER_ONLY_RC" -ne 0 ]; then
+    echo "=== Piper fallback INCOMPLETE — the box may answer speech with silence ===" >&2
+    exit 1
+  fi
   echo "=== Piper fallback ready ==="
   exit 0
 fi

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -9,6 +9,142 @@ CLAWBOX_HOME="/home/${CLAWBOX_USER}"
 WORKSPACE="$CLAWBOX_HOME/.openclaw/workspace"
 PIP="pip3"
 
+# ── Piper (CPU fallback engine) ─────────────────────────────────────────────
+# Piper is what keeps a spoken reply from becoming silence. Kokoro owns the
+# default voice, but it needs CUDA and peaks around 2.6 GB on a 7.6 GB board
+# (TASK-382); when it cannot run, scripts/openclaw/clawbox-tts.sh falls through
+# to Piper at 136-243 MB. That fallback only exists if Piper is actually on the
+# box, so this install is not optional and not "nice to have".
+#
+# Artifacts are pinned by sha256 to the exact bytes TASK-382 measured, matching
+# scripts/bench/tts-bench.py. These are an executable and model weights fetched
+# over the network onto a customer device; an unpinned download here is a
+# supply-chain hole.
+PIPER_VERSION="${PIPER_VERSION:-2023.11.14-2}"
+PIPER_DIR="${PIPER_DIR:-$CLAWBOX_HOME/.local/share/piper}"
+PIPER_VOICE_DIR="${PIPER_VOICE_DIR:-$PIPER_DIR/voices}"
+PIPER_VOICES_BASE="${PIPER_VOICES_BASE:-https://huggingface.co/rhasspy/piper-voices/resolve/main}"
+PIPER_TARBALL_SHA256="fea0fd2d87c54dbc7078d0f878289f404bd4d6eea6e7444a77835d1537ab88eb"
+PIPER_EN_ONNX_SHA256="5efe09e69902187827af646e1a6e9d269dee769f9877d17b16b1b46eeaaf019f"
+PIPER_EN_JSON_SHA256="efe19c417bed055f2d69908248c6ba650fa135bc868b0e6abb3da181dab690a0"
+PIPER_BG_ONNX_SHA256="4972fe764468e8501416407ad81662de94cc6c9cdc680fcf807daef04e319f13"
+PIPER_BG_JSON_SHA256="ec9a9abdd17384d3db225e83085b2f68b790b112f058417c3a8a2ac58b79e7f0"
+# Bulgarian is DEFERRED for this release (Yanko, 2026-08-19): Kokoro has no
+# Bulgarian voice, and shipping the Piper one by default would quietly make
+# Bulgarian TTS a feature nobody signed off. The download is kept here, behind
+# an opt-in, so enabling it later is a flag and not a code change.
+INSTALL_BG_VOICE="${CLAWBOX_TTS_INSTALL_BG_VOICE:-false}"
+
+# Verify a file against a pinned digest. Returns 1 on any mismatch so callers
+# can re-download rather than trusting whatever is on disk.
+piper_digest_ok() {
+  local file="$1" want="$2" have
+  [ -f "$file" ] || return 1
+  have=$(sha256sum "$file" 2>/dev/null | cut -d" " -f1)
+  [ "$have" = "$want" ]
+}
+
+# Download to a .part and only move it into place once the digest matches, so
+# an interrupted or tampered fetch never leaves something the next run trusts.
+piper_fetch() {
+  local url="$1" dest="$2" want="$3"
+  if piper_digest_ok "$dest" "$want"; then
+    return 0
+  fi
+  rm -f "$dest" "$dest.part"
+  curl -fsSL --retry 3 -o "$dest.part" "$url" || {
+    echo "  ERROR: download failed: $url" >&2
+    rm -f "$dest.part"
+    return 1
+  }
+  if ! piper_digest_ok "$dest.part" "$want"; then
+    echo "  ERROR: $(basename "$dest") sha256 does not match the pin — refusing it" >&2
+    rm -f "$dest.part"
+    return 1
+  fi
+  mv "$dest.part" "$dest"
+}
+
+piper_install_voice() {
+  local voice="$1" repo_path="$2" onnx_sha="$3" json_sha="$4"
+  piper_fetch "$PIPER_VOICES_BASE/$repo_path/$voice.onnx" "$PIPER_VOICE_DIR/$voice.onnx" "$onnx_sha" || return 1
+  piper_fetch "$PIPER_VOICES_BASE/$repo_path/$voice.onnx.json" "$PIPER_VOICE_DIR/$voice.onnx.json" "$json_sha" || return 1
+  echo "  Piper voice ready: $voice"
+}
+
+install_piper() {
+  local arch
+  arch=$(uname -m)
+  if [ "$arch" != "aarch64" ]; then
+    # Only the aarch64 artifact is pinned, and ClawBox is aarch64 hardware.
+    # Guessing a digest for another arch would defeat the point of pinning.
+    echo "  Skipping Piper: no pinned artifact for $arch (ClawBox ships aarch64)"
+    return 0
+  fi
+
+  mkdir -p "$PIPER_DIR" "$PIPER_VOICE_DIR"
+
+  if [ -x "$PIPER_DIR/piper" ]; then
+    echo "  Piper binary already installed"
+  else
+    local tarball="$PIPER_DIR/piper_linux_aarch64.tar.gz"
+    echo "  Downloading Piper $PIPER_VERSION..."
+    piper_fetch \
+      "https://github.com/rhasspy/piper/releases/download/$PIPER_VERSION/piper_linux_aarch64.tar.gz" \
+      "$tarball" "$PIPER_TARBALL_SHA256" || return 1
+    # The tarball unpacks a top-level piper/ directory, so extract one level up.
+    tar -xzf "$tarball" -C "$(dirname "$PIPER_DIR")" || {
+      echo "  ERROR: could not unpack Piper" >&2
+      return 1
+    }
+    rm -f "$tarball"
+    chmod +x "$PIPER_DIR/piper" 2>/dev/null || true
+    echo "  Piper binary installed at $PIPER_DIR/piper"
+  fi
+
+  piper_install_voice "en_US-lessac-medium" "en/en_US/lessac/medium" \
+    "$PIPER_EN_ONNX_SHA256" "$PIPER_EN_JSON_SHA256" || return 1
+
+  if [ "$INSTALL_BG_VOICE" = "true" ]; then
+    piper_install_voice "bg_BG-dimitar-medium" "bg/bg_BG/dimitar/medium" \
+      "$PIPER_BG_ONNX_SHA256" "$PIPER_BG_JSON_SHA256" || return 1
+  fi
+
+  chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$PIPER_DIR" 2>/dev/null || true
+}
+
+# Deploy the TTS entrypoint + engine scripts into the workspace the gateway
+# runs from. Split out of the big install so --piper-only can call it too: the
+# updater re-runs that cheap path on every update, and a box whose
+# clawbox-tts.sh is stale is a box whose fallback chain is stale.
+deploy_voice_scripts() {
+  local src dst
+  src="$(cd "$(dirname "$0")" && pwd)"
+  dst="$WORKSPACE/scripts"
+  mkdir -p "$dst/openclaw"
+  for f in kokoro-server.py kokoro-client.sh kokoro-tts.sh whisper-server.py stt-client.py stt.py; do
+    [ -f "$src/$f" ] && cp "$src/$f" "$dst/$f"
+  done
+  if [ -f "$src/openclaw/clawbox-tts.sh" ]; then
+    cp "$src/openclaw/clawbox-tts.sh" "$dst/openclaw/clawbox-tts.sh"
+    chmod +x "$dst/openclaw/clawbox-tts.sh"
+  fi
+  chmod +x "$dst"/*.sh 2>/dev/null || true
+  chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$WORKSPACE"
+}
+
+# --piper-only installs just the CPU fallback and refreshes the entrypoint.
+# install.sh calls this on every install and update: it is a small pinned
+# download, unlike the CUDA torch/CTranslate2 build below, so it is safe to
+# run unattended on a box that already works.
+if [ "${1:-}" = "--piper-only" ]; then
+  echo "=== Voice fallback (Piper) ==="
+  install_piper
+  deploy_voice_scripts
+  echo "=== Piper fallback ready ==="
+  exit 0
+fi
+
 echo "=== Voice Pipeline Installer (GPU-Accelerated) ==="
 
 # ── Detect CUDA availability ────────────────────────────────────────────────
@@ -28,7 +164,7 @@ fi
 # ── Step 1: Install CUDA PyTorch (if available) ─────────────────────────────
 
 if $HAS_CUDA; then
-  echo "[1/7] Installing CUDA-enabled PyTorch for Jetson..."
+  echo "[1/8] Installing CUDA-enabled PyTorch for Jetson..."
   # JP v61 wheel works on JetPack 6.1+ (including 6.2.x)
   TORCH_URL="https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl"
   su - "$CLAWBOX_USER" -c "$PIP install --user nvidia-cusparselt-cu12" 2>&1 | tail -3
@@ -41,18 +177,18 @@ if $HAS_CUDA; then
     echo 'export CUDA_HOME=/usr/local/cuda' >> "$BASHRC"
   fi
 else
-  echo "[1/7] No CUDA detected, using CPU PyTorch..."
+  echo "[1/8] No CUDA detected, using CPU PyTorch..."
 fi
 
 # ── Step 2: Install faster-whisper ───────────────────────────────────────────
 
-echo "[2/7] Installing faster-whisper (STT)..."
+echo "[2/8] Installing faster-whisper (STT)..."
 su - "$CLAWBOX_USER" -c "$PIP install --user faster-whisper" 2>&1 | tail -3
 
 # ── Step 3: Build CTranslate2 with CUDA (if available) ──────────────────────
 
 if $HAS_CUDA; then
-  echo "[3/7] Building CTranslate2 with CUDA support..."
+  echo "[3/8] Building CTranslate2 with CUDA support..."
   BUILD_DIR="/tmp/CTranslate2"
   if [ ! -f "$CLAWBOX_HOME/.local/lib/libctranslate2.so" ]; then
     rm -rf "$BUILD_DIR"
@@ -83,12 +219,12 @@ if $HAS_CUDA; then
     echo "  CTranslate2 already installed"
   fi
 else
-  echo "[3/7] Skipping CTranslate2 CUDA build (no CUDA)"
+  echo "[3/8] Skipping CTranslate2 CUDA build (no CUDA)"
 fi
 
 # ── Step 4: Install Kokoro TTS ───────────────────────────────────────────────
 
-echo "[4/7] Installing Kokoro TTS..."
+echo "[4/8] Installing Kokoro TTS..."
 # Install kokoro first, then force transformers<5 as a separate step.
 # pip 22's resolver won't downgrade huggingface-hub (pulled in by faster-whisper)
 # to satisfy transformers<5 in a single command, so it silently picks transformers 5.x.
@@ -97,7 +233,7 @@ su - "$CLAWBOX_USER" -c "$PIP install --user 'transformers<5'" 2>&1 | tail -3
 
 # ── Step 5: Pre-download models ─────────────────────────────────────────────
 
-echo "[5/7] Pre-downloading Whisper model (base)..."
+echo "[5/8] Pre-downloading Whisper model (base)..."
 # Clear corrupted cache (0-byte blobs from failed/rate-limited HF downloads)
 WHISPER_CACHE="$CLAWBOX_HOME/.cache/huggingface/hub/models--Systran--faster-whisper-base"
 if [ -d "$WHISPER_CACHE/blobs" ] && find "$WHISPER_CACHE/blobs" -maxdepth 1 -type f -empty | grep -q .; then
@@ -118,7 +254,7 @@ model = WhisperModel('base', device='$DEVICE', compute_type='$COMPUTE')
 print('Whisper base model ready on $DEVICE')
 \"" 2>&1 | tail -3
 
-echo "[6/7] Pre-downloading Kokoro model..."
+echo "[6/8] Pre-downloading Kokoro model..."
 su - "$CLAWBOX_USER" -c "
   export LD_LIBRARY_PATH=$CLAWBOX_HOME/.local/lib:$CLAWBOX_HOME/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib:/usr/local/cuda/lib64:\$LD_LIBRARY_PATH
   python3 -c \"
@@ -129,19 +265,12 @@ print('Kokoro model ready on', next(pipeline.model.parameters()).device)
 
 # ── Step 6: Deploy scripts ───────────────────────────────────────────────────
 
-echo "[7/7] Deploying voice server scripts..."
-SCRIPTS_SRC="$(dirname "$0")"
-SCRIPTS_DST="$WORKSPACE/scripts"
-mkdir -p "$SCRIPTS_DST"
+echo "[7/8] Installing Piper CPU fallback..."
+install_piper
 
-# Copy server and client scripts from repo
-for f in kokoro-server.py kokoro-client.sh kokoro-tts.sh whisper-server.py stt-client.py stt.py; do
-  if [ -f "$SCRIPTS_SRC/$f" ]; then
-    cp "$SCRIPTS_SRC/$f" "$SCRIPTS_DST/$f"
-  fi
-done
-chmod +x "$SCRIPTS_DST"/*.sh 2>/dev/null || true
-chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$WORKSPACE"
+echo "[8/8] Deploying voice server scripts..."
+SCRIPTS_DST="$WORKSPACE/scripts"
+deploy_voice_scripts
 
 # Install systemd user services for persistent model servers
 SYSTEMD_USER="$CLAWBOX_HOME/.config/systemd/user"
@@ -201,5 +330,6 @@ else
   echo "  Mode: CPU"
 fi
 echo "  STT: Whisper (base) via on-demand server (~1.8s)"
-echo "  TTS: Kokoro-82M via on-demand server (~2s)"
+echo "  TTS: Kokoro-82M via on-demand server (~2s), Piper CPU fallback"
+echo "  TTS entrypoint: $WORKSPACE/scripts/openclaw/clawbox-tts.sh"
 echo "  Services: kokoro-server, whisper-server (on-demand, auto-stop after idle)"

--- a/scripts/openclaw/clawbox-tts.sh
+++ b/scripts/openclaw/clawbox-tts.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# ClawBox on-device text-to-speech — the single entrypoint OpenClaw calls.
+#
+# Wired in as the `tts-local-cli` provider command by step_openclaw_tts in
+# install.sh, so every spoken reply on the box runs through here: no network
+# round-trip, no per-character cost.
+#
+#   clawbox-tts.sh [--voice <voice>] <text> <output-path>
+#   clawbox-tts.sh --set-voice <voice>     # persist this user's voice
+#   clawbox-tts.sh --get-voice
+#
+# Engine chain, in order:
+#   1. Kokoro on CUDA — the default voice. Talks to the persistent
+#      kokoro-server unix socket when it is up (model already resident on the
+#      GPU), cold-starts the `kokoro` CLI when it is not.
+#   2. Piper on CPU — small, no GPU, always available once installed.
+#   3. Non-zero exit, with every reason it got there on stderr.
+#
+# Degrading rather than dying is the whole point of this file. Until TASK-383
+# the box called kokoro-tts.sh, which printed "Kokoro TTS failed" and exited 1:
+# a missing model, a busy GPU, or a language Kokoro cannot speak all reached
+# the user as silence with no explanation of which one it was.
+#
+# Why the memory guard (CLAWBOX_TTS_MIN_FREE_MB): TASK-382 measured
+# kokoro-torch on CUDA peaking at 2259-2636 MB on an Orin Nano whose 7607 MB is
+# SHARED between CPU and GPU. Those numbers came off an idle board; in service
+# the agent and faster-whisper are resident too. Trying the allocation anyway
+# does not fail politely — it OOM-kills whatever the kernel picks, which on
+# this hardware has been the user's own session. So we read MemAvailable first
+# and go straight to Piper (136-243 MB) when the headroom is not there.
+# The default 3000 MB is the measured 2636 MB peak rounded up, plus room for
+# the CUDA context and allocator fragmentation.
+#
+# NOT `set -e`: this script's job is to keep going when an engine fails.
+set -uo pipefail
+
+CLAWBOX_TTS_DEFAULT_VOICE="${CLAWBOX_TTS_DEFAULT_VOICE:-af_heart}"
+CLAWBOX_TTS_VOICE_FILE="${CLAWBOX_TTS_VOICE_FILE:-${HOME:-/home/clawbox}/.openclaw/clawbox-tts-voice}"
+CLAWBOX_TTS_MIN_FREE_MB="${CLAWBOX_TTS_MIN_FREE_MB:-3000}"
+CLAWBOX_TTS_MEMINFO="${CLAWBOX_TTS_MEMINFO:-/proc/meminfo}"
+# A WAV that is only a header is "no audio", not audio. 1 KiB is ~20 ms at
+# 24 kHz mono 16-bit — below anything a real utterance can be.
+CLAWBOX_TTS_MIN_AUDIO_BYTES="${CLAWBOX_TTS_MIN_AUDIO_BYTES:-1024}"
+
+KOKORO_BIN="${KOKORO_BIN:-kokoro}"
+KOKORO_SOCKET="${KOKORO_SOCKET:-/tmp/kokoro-server.sock}"
+KOKORO_TIMEOUT="${KOKORO_TIMEOUT:-120}"
+
+PIPER_BIN="${PIPER_BIN:-/home/clawbox/.local/share/piper/piper}"
+PIPER_VOICE_DIR="${PIPER_VOICE_DIR:-/home/clawbox/.local/share/piper/voices}"
+PIPER_TIMEOUT="${PIPER_TIMEOUT:-120}"
+
+FFMPEG_BIN="${FFMPEG_BIN:-ffmpeg}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+REASONS=()
+note() { REASONS+=("$1"); }
+
+# ── Voice catalogue ─────────────────────────────────────────────────────────
+# One name per voice the box offers, mapped onto whatever each engine calls it.
+# An empty Kokoro mapping is not an error — it is the documented way a voice
+# says "I cannot be spoken on the GPU path, use the fallback". Bulgarian is
+# deferred for this release precisely because Kokoro has no Bulgarian voice
+# (TASK-382), and this table is where that fact lives.
+
+kokoro_voice_for() {
+  case "$1" in
+    af_heart|alloy|echo|fable|nova|shimmer) printf 'af_heart' ;;
+    am_michael|onyx) printf 'am_michael' ;;
+    af_bella) printf 'af_bella' ;;
+    am_adam) printf 'am_adam' ;;
+    bf_emma) printf 'bf_emma' ;;
+    bm_george) printf 'bm_george' ;;
+    bg_dimitar) printf '' ;;
+    *) printf '' ;;
+  esac
+}
+
+piper_voice_for() {
+  case "$1" in
+    bg_dimitar) printf 'bg_BG-dimitar-medium' ;;
+    bf_emma|bm_george) printf 'en_GB-alba-medium' ;;
+    *) printf 'en_US-lessac-medium' ;;
+  esac
+}
+
+is_known_voice() {
+  case "$1" in
+    af_heart|alloy|echo|fable|nova|shimmer|am_michael|onyx|af_bella|am_adam|bf_emma|bm_george|bg_dimitar) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+list_voices() {
+  echo "af_heart am_michael af_bella am_adam bf_emma bm_george bg_dimitar"
+}
+
+# ── Voice selection ─────────────────────────────────────────────────────────
+# Resolution order: --voice > $CLAWBOX_TTS_VOICE > saved file > built-in.
+#
+# Why it is shaped like this. OpenClaw's tts-local-cli provider passes the
+# command exactly four placeholders — {{Text}}, {{OutputPath}}, {{OutputDir}},
+# {{OutputBase}} — and there is no {{Voice}} among them, so choosing the voice
+# is this script's job and not the caller's. OpenClaw also has no per-sender
+# config layer: resolveEffectiveTtsConfig merges messages.tts with, in
+# increasing precedence, agents.list[].tts, channels.<id>.tts and
+# channels.<id>.accounts.<acct>.tts. Those account/channel scopes ARE the
+# per-user identity the platform exposes, and both of the levers they can set
+# reach us here:
+#
+#   channels.<id>.accounts.<acct>.tts.providers["tts-local-cli"].args
+#     -> [..., "--voice", "bm_george", ...]
+#   ...same path... .env -> { "CLAWBOX_TTS_VOICE": "bm_george" }
+#
+# The saved file is therefore the DEVICE default (this command always runs as
+# the gateway's own user, so $HOME is not a per-person boundary here) and
+# `--set-voice` is how the owner changes it without editing JSON.
+
+read_saved_voice() {
+  [ -r "$CLAWBOX_TTS_VOICE_FILE" ] || return 0
+  tr -d '[:space:]' < "$CLAWBOX_TTS_VOICE_FILE" 2>/dev/null | head -c 64
+}
+
+save_voice() {
+  local voice="$1"
+  if ! is_known_voice "$voice"; then
+    echo "clawbox-tts: unknown voice '$voice'. Known voices: $(list_voices)" >&2
+    return 1
+  fi
+  mkdir -p "$(dirname "$CLAWBOX_TTS_VOICE_FILE")" 2>/dev/null || true
+  printf '%s\n' "$voice" > "$CLAWBOX_TTS_VOICE_FILE" || {
+    echo "clawbox-tts: could not write $CLAWBOX_TTS_VOICE_FILE" >&2
+    return 1
+  }
+  echo "$voice"
+}
+
+# An unknown or unreadable preference must never be the reason a box goes
+# silent, so it degrades to the default with a note rather than failing.
+resolve_voice() {
+  local requested="$1"
+  if [ -z "$requested" ]; then
+    requested="${CLAWBOX_TTS_VOICE:-}"
+  fi
+  if [ -z "$requested" ]; then
+    requested="$(read_saved_voice)"
+  fi
+  if [ -z "$requested" ]; then
+    printf '%s' "$CLAWBOX_TTS_DEFAULT_VOICE"
+    return 0
+  fi
+  if ! is_known_voice "$requested"; then
+    echo "clawbox-tts: unknown voice '$requested', using default '$CLAWBOX_TTS_DEFAULT_VOICE'" >&2
+    printf '%s' "$CLAWBOX_TTS_DEFAULT_VOICE"
+    return 0
+  fi
+  printf '%s' "$requested"
+}
+
+# ── Memory guard ────────────────────────────────────────────────────────────
+
+available_mb() {
+  local kb
+  kb=$(awk '/^MemAvailable:/ {print $2; exit}' "$CLAWBOX_TTS_MEMINFO" 2>/dev/null)
+  if [ -z "$kb" ]; then
+    # No MemAvailable to read: on a Jetson that means something is wrong with
+    # /proc, and guessing "plenty" is how the OOM killer gets invited in.
+    printf '0'
+    return 0
+  fi
+  printf '%s' "$((kb / 1024))"
+}
+
+# ── Output encoding ─────────────────────────────────────────────────────────
+# Both engines produce WAV natively, so the default configured outputFormat is
+# wav and the common path needs no ffmpeg at all. Only a non-WAV destination
+# pulls ffmpeg in, and if it is missing that counts as this engine failing —
+# writing WAV bytes into a file called .mp3 is exactly the "broken audio"
+# outcome the fallback chain exists to avoid.
+
+# Reasons go through note(), never through stdout: this script's stdout is the
+# output path and nothing else.
+emit() {
+  local src="$1" dst="$2"
+  mkdir -p "$(dirname "$dst")" 2>/dev/null || true
+  case "${dst,,}" in
+    *.mp3)
+      if ! command -v "$FFMPEG_BIN" >/dev/null 2>&1; then
+        note "output: ffmpeg not available to encode .mp3 (audio was synthesised, but writing WAV bytes into an .mp3 would be broken audio)"
+        return 1
+      fi
+      "$FFMPEG_BIN" -y -i "$src" -codec:a libmp3lame -b:a 128k -ar 24000 "$dst" >/dev/null 2>&1 || {
+        note "output: ffmpeg failed to encode .mp3"
+        return 1
+      }
+      ;;
+    *.ogg|*.opus)
+      if ! command -v "$FFMPEG_BIN" >/dev/null 2>&1; then
+        note "output: ffmpeg not available to encode Opus"
+        return 1
+      fi
+      "$FFMPEG_BIN" -y -i "$src" -codec:a libopus -b:a 64k -ar 48000 -ac 1 "$dst" >/dev/null 2>&1 || {
+        note "output: ffmpeg failed to encode Opus"
+        return 1
+      }
+      ;;
+    *)
+      cp -f "$src" "$dst" || {
+        note "output: could not write $dst"
+        return 1
+      }
+      ;;
+  esac
+  if [ ! -s "$dst" ]; then
+    note "output: $dst was written empty"
+    rm -f "$dst"
+    return 1
+  fi
+  return 0
+}
+
+audio_ok() {
+  local f="$1" size
+  [ -f "$f" ] || return 1
+  size=$(wc -c < "$f" 2>/dev/null || echo 0)
+  [ "$size" -ge "$CLAWBOX_TTS_MIN_AUDIO_BYTES" ]
+}
+
+# ── Kokoro (CUDA) ───────────────────────────────────────────────────────────
+
+kokoro_via_server() {
+  local text="$1" wav="$2" voice="$3"
+  [ -S "$KOKORO_SOCKET" ] || return 1
+  command -v "$PYTHON_BIN" >/dev/null 2>&1 || return 1
+  # Text goes through the environment, never through the shell or the argv of
+  # an interpreter, so an utterance containing quotes cannot become code.
+  KOKORO_TEXT="$text" KOKORO_OUTPUT="$wav" KOKORO_SOCKET="$KOKORO_SOCKET" KOKORO_VOICE="$voice" \
+    "$PYTHON_BIN" -c '
+import json, os, socket, sys
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.settimeout(float(os.environ.get("KOKORO_TIMEOUT", "120")))
+try:
+    s.connect(os.environ["KOKORO_SOCKET"])
+    s.sendall(json.dumps({
+        "text": os.environ["KOKORO_TEXT"],
+        "output": os.environ["KOKORO_OUTPUT"],
+        "voice": os.environ["KOKORO_VOICE"],
+    }).encode())
+    s.shutdown(socket.SHUT_WR)
+    resp = s.recv(4096).decode("utf-8", "replace")
+finally:
+    s.close()
+if not resp.startswith("OK"):
+    sys.stderr.write(resp[:300])
+    sys.exit(1)
+' 2>/dev/null || return 1
+  return 0
+}
+
+kokoro_cold_start() {
+  local text="$1" wav="$2" voice="$3"
+  command -v "$KOKORO_BIN" >/dev/null 2>&1 || return 1
+  timeout "$KOKORO_TIMEOUT" "$KOKORO_BIN" -t "$text" -o "$wav" -m "$voice" -l a >/dev/null 2>&1 || return 1
+  return 0
+}
+
+try_kokoro() {
+  local text="$1" wav="$2" voice="$3" kvoice avail
+  kvoice="$(kokoro_voice_for "$voice")"
+  if [ -z "$kvoice" ]; then
+    note "kokoro: no Kokoro voice for '$voice' (Bulgarian is deferred this release)"
+    return 1
+  fi
+
+  avail="$(available_mb)"
+  if [ "$avail" -lt "$CLAWBOX_TTS_MIN_FREE_MB" ]; then
+    note "kokoro: skipped, ${avail}MB available and the CUDA path peaks at ~2.6GB (need >=${CLAWBOX_TTS_MIN_FREE_MB}MB)"
+    return 1
+  fi
+
+  if kokoro_via_server "$text" "$wav" "$kvoice"; then
+    if audio_ok "$wav"; then
+      ENGINE_USED="kokoro-server"
+      return 0
+    fi
+    note "kokoro: server returned OK but produced no audio"
+    rm -f "$wav"
+  elif [ -S "$KOKORO_SOCKET" ]; then
+    note "kokoro: persistent server at $KOKORO_SOCKET refused the request"
+  fi
+
+  if kokoro_cold_start "$text" "$wav" "$kvoice"; then
+    if audio_ok "$wav"; then
+      ENGINE_USED="kokoro-cold"
+      return 0
+    fi
+    note "kokoro: cold start produced no audio"
+    rm -f "$wav"
+    return 1
+  fi
+
+  if command -v "$KOKORO_BIN" >/dev/null 2>&1; then
+    note "kokoro: '$KOKORO_BIN' failed (CUDA unavailable, allocation refused, or model missing)"
+  else
+    note "kokoro: '$KOKORO_BIN' is not installed"
+  fi
+  return 1
+}
+
+# ── Piper (CPU) ─────────────────────────────────────────────────────────────
+
+try_piper() {
+  local text="$1" wav="$2" voice="$3" pvoice model
+  pvoice="$(piper_voice_for "$voice")"
+  model="$PIPER_VOICE_DIR/$pvoice.onnx"
+
+  if [ ! -x "$PIPER_BIN" ]; then
+    note "piper: binary not found at $PIPER_BIN"
+    return 1
+  fi
+  if [ ! -f "$model" ]; then
+    # Speaking this text with a voice for another language is worse than not
+    # speaking it, so we do NOT silently substitute the English model here.
+    note "piper: no voice model $pvoice at $PIPER_VOICE_DIR"
+    return 1
+  fi
+
+  local piper_dir
+  piper_dir="$(dirname "$PIPER_BIN")"
+  # The release tarball ships its own onnxruntime and espeak-ng data next to
+  # the binary. An empty entry in LD_LIBRARY_PATH means "the current
+  # directory" to the loader, which is not somewhere to resolve .so files.
+  local ld="$piper_dir"
+  [ -n "${LD_LIBRARY_PATH:-}" ] && ld="$piper_dir:$LD_LIBRARY_PATH"
+
+  if ! printf '%s' "$text" | LD_LIBRARY_PATH="$ld" \
+      timeout "$PIPER_TIMEOUT" "$PIPER_BIN" -m "$model" -f "$wav" >/dev/null 2>&1; then
+    note "piper: $PIPER_BIN exited non-zero using $pvoice"
+    return 1
+  fi
+  if ! audio_ok "$wav"; then
+    note "piper: produced no audio using $pvoice"
+    rm -f "$wav"
+    return 1
+  fi
+  ENGINE_USED="piper"
+  return 0
+}
+
+# ── Entry ───────────────────────────────────────────────────────────────────
+
+usage() {
+  cat >&2 <<USAGE
+Usage: clawbox-tts.sh [--voice <voice>] <text> <output-path>
+       clawbox-tts.sh --set-voice <voice>
+       clawbox-tts.sh --get-voice
+       clawbox-tts.sh --list-voices
+Voices: $(list_voices)
+USAGE
+}
+
+REQUESTED_VOICE=""
+ENGINE_USED=""
+ARGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --voice)
+      REQUESTED_VOICE="${2:-}"; shift 2 || true ;;
+    --voice=*)
+      REQUESTED_VOICE="${1#--voice=}"; shift ;;
+    --set-voice)
+      save_voice "${2:-}"; exit $? ;;
+    --get-voice)
+      resolve_voice ""; echo; exit 0 ;;
+    --list-voices)
+      list_voices; exit 0 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    --)
+      shift; while [ $# -gt 0 ]; do ARGS+=("$1"); shift; done ;;
+    *)
+      ARGS+=("$1"); shift ;;
+  esac
+done
+
+if [ "${#ARGS[@]}" -lt 2 ]; then
+  usage
+  exit 2
+fi
+
+TEXT="${ARGS[0]}"
+OUTPUT="${ARGS[1]}"
+
+if [ -z "$TEXT" ]; then
+  echo "clawbox-tts: empty text" >&2
+  exit 2
+fi
+
+VOICE="$(resolve_voice "$REQUESTED_VOICE")"
+
+TMPWAV="$(mktemp "${TMPDIR:-/tmp}/clawbox-tts_XXXXXX.wav")"
+trap 'rm -f "$TMPWAV"' EXIT
+
+if try_kokoro "$TEXT" "$TMPWAV" "$VOICE" || try_piper "$TEXT" "$TMPWAV" "$VOICE"; then
+  if emit "$TMPWAV" "$OUTPUT"; then
+    echo "$OUTPUT"
+    exit 0
+  fi
+  note "output: could not write $OUTPUT from $ENGINE_USED audio"
+fi
+
+# Never exit 0 without audio: a silent success is indistinguishable from a
+# working TTS to everything upstream, which is the bug this file replaces.
+{
+  echo "clawbox-tts: no engine could speak this text (voice '$VOICE')."
+  for r in "${REASONS[@]}"; do
+    echo "  - $r"
+  done
+  echo "  Install Piper with: sudo bash scripts/install-voice.sh --piper-only"
+} >&2
+exit 1

--- a/scripts/openclaw/clawbox-tts.sh
+++ b/scripts/openclaw/clawbox-tts.sh
@@ -44,11 +44,47 @@ CLAWBOX_TTS_MIN_AUDIO_BYTES="${CLAWBOX_TTS_MIN_AUDIO_BYTES:-1024}"
 
 KOKORO_BIN="${KOKORO_BIN:-kokoro}"
 KOKORO_SOCKET="${KOKORO_SOCKET:-/tmp/kokoro-server.sock}"
-KOKORO_TIMEOUT="${KOKORO_TIMEOUT:-120}"
+
+# ── The time budget ─────────────────────────────────────────────────────────
+# Every engine gets its own slice, and the caller's timeout has to be larger
+# than all of them added together. It was not: KOKORO_TIMEOUT and the
+# provider's timeoutMs were both 120s, two constants that happened to be equal,
+# so OpenClaw killed this process at the exact moment Kokoro gave up and Piper
+# was never reached. A hung GPU — precisely the case the fallback exists for —
+# was still silence.
+#
+# The slices are small on purpose. A spoken reply that takes even half a minute
+# has already failed as an interaction, so the budget is sized to fail over
+# quickly rather than to let a wedged engine use its full rope:
+#
+#   KOKORO_SERVER_TIMEOUT  10s  the model is already resident on the GPU and a
+#                               healthy answer is ~2s; 10s means wedged.
+#   KOKORO_TIMEOUT         40s  cold start, so it pays torch CUDA init plus the
+#                               Kokoro-82M load on an Orin Nano.
+#   PIPER_TIMEOUT          15s  CPU, 63MB model, RTF well under 1 — generous.
+#   CONVERT_TIMEOUT        10s  ffmpeg on a few seconds of audio. It had no
+#                               bound at all before, which was its own hang.
+#
+# Worst case walks all four: server wedged, cold start wedged, then Piper, then
+# conversion. tts_provider_timeout_ms() adds a margin on top of that sum, and
+# install.sh asks this script for the number instead of keeping its own copy —
+# so changing a slice here moves the caller's timeout with it and this cannot
+# quietly come back.
+KOKORO_SERVER_TIMEOUT="${KOKORO_SERVER_TIMEOUT:-10}"
+KOKORO_TIMEOUT="${KOKORO_TIMEOUT:-40}"
+PIPER_TIMEOUT="${PIPER_TIMEOUT:-15}"
+CONVERT_TIMEOUT="${CONVERT_TIMEOUT:-10}"
+TTS_BUDGET_MARGIN_SECONDS="${TTS_BUDGET_MARGIN_SECONDS:-25}"
+
+tts_budget_seconds() {
+  printf '%s' "$((KOKORO_SERVER_TIMEOUT + KOKORO_TIMEOUT + PIPER_TIMEOUT + CONVERT_TIMEOUT))"
+}
+tts_provider_timeout_ms() {
+  printf '%s' "$(( ($(tts_budget_seconds) + TTS_BUDGET_MARGIN_SECONDS) * 1000 ))"
+}
 
 PIPER_BIN="${PIPER_BIN:-/home/clawbox/.local/share/piper/piper}"
 PIPER_VOICE_DIR="${PIPER_VOICE_DIR:-/home/clawbox/.local/share/piper/voices}"
-PIPER_TIMEOUT="${PIPER_TIMEOUT:-120}"
 
 FFMPEG_BIN="${FFMPEG_BIN:-ffmpeg}"
 PYTHON_BIN="${PYTHON_BIN:-python3}"
@@ -207,7 +243,7 @@ emit() {
         note "output: ffmpeg not available to encode .mp3 (audio was synthesised, but writing WAV bytes into an .mp3 would be broken audio)"
         return 1
       fi
-      if ! "$FFMPEG_BIN" -y -i "$src" -codec:a libmp3lame -b:a 128k -ar 24000 "$dst" >/dev/null 2>&1; then
+      if ! timeout "$CONVERT_TIMEOUT" "$FFMPEG_BIN" -y -i "$src" -codec:a libmp3lame -b:a 128k -ar 24000 "$dst" >/dev/null 2>&1; then
         # ffmpeg -y can leave a truncated file at $dst when it dies partway.
         # Handing a consumer corrupt audio is the failure this script exists
         # to prevent, so the partial file goes with the error.
@@ -221,7 +257,7 @@ emit() {
         note "output: ffmpeg not available to encode Opus"
         return 1
       fi
-      if ! "$FFMPEG_BIN" -y -i "$src" -codec:a libopus -b:a 64k -ar 48000 -ac 1 "$dst" >/dev/null 2>&1; then
+      if ! timeout "$CONVERT_TIMEOUT" "$FFMPEG_BIN" -y -i "$src" -codec:a libopus -b:a 64k -ar 48000 -ac 1 "$dst" >/dev/null 2>&1; then
         rm -f "$dst"
         note "output: ffmpeg failed to encode Opus"
         return 1
@@ -258,11 +294,11 @@ kokoro_via_server() {
   # Text goes through the environment, never through the shell or the argv of
   # an interpreter, so an utterance containing quotes cannot become code.
   KOKORO_TEXT="$text" KOKORO_OUTPUT="$wav" KOKORO_SOCKET="$KOKORO_SOCKET" KOKORO_VOICE="$voice" \
-    KOKORO_TIMEOUT="$KOKORO_TIMEOUT" \
-    "$PYTHON_BIN" -c '
+    KOKORO_SERVER_TIMEOUT="$KOKORO_SERVER_TIMEOUT" \
+    timeout "$KOKORO_SERVER_TIMEOUT" "$PYTHON_BIN" -c '
 import json, os, socket, sys
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-s.settimeout(float(os.environ.get("KOKORO_TIMEOUT", "120")))
+s.settimeout(float(os.environ.get("KOKORO_SERVER_TIMEOUT", "10")))
 try:
     s.connect(os.environ["KOKORO_SOCKET"])
     s.sendall(json.dumps({
@@ -413,6 +449,8 @@ Usage: clawbox-tts.sh [--voice <voice>] <text> <output-path>
        clawbox-tts.sh --set-voice <voice>
        clawbox-tts.sh --get-voice
        clawbox-tts.sh --list-voices
+       clawbox-tts.sh --budget-seconds       # worst-case engine-chain seconds
+       clawbox-tts.sh --provider-timeout-ms  # what the caller's timeout must be
 Voices: $(list_voices)
 USAGE
 }
@@ -439,6 +477,10 @@ while [ $# -gt 0 ]; do
       resolve_voice ""; echo; exit 0 ;;
     --list-voices)
       list_voices; exit 0 ;;
+    --budget-seconds)
+      tts_budget_seconds; echo; exit 0 ;;
+    --provider-timeout-ms)
+      tts_provider_timeout_ms; echo; exit 0 ;;
     -h|--help)
       usage; exit 0 ;;
     --)

--- a/scripts/openclaw/clawbox-tts.sh
+++ b/scripts/openclaw/clawbox-tts.sh
@@ -207,20 +207,25 @@ emit() {
         note "output: ffmpeg not available to encode .mp3 (audio was synthesised, but writing WAV bytes into an .mp3 would be broken audio)"
         return 1
       fi
-      "$FFMPEG_BIN" -y -i "$src" -codec:a libmp3lame -b:a 128k -ar 24000 "$dst" >/dev/null 2>&1 || {
+      if ! "$FFMPEG_BIN" -y -i "$src" -codec:a libmp3lame -b:a 128k -ar 24000 "$dst" >/dev/null 2>&1; then
+        # ffmpeg -y can leave a truncated file at $dst when it dies partway.
+        # Handing a consumer corrupt audio is the failure this script exists
+        # to prevent, so the partial file goes with the error.
+        rm -f "$dst"
         note "output: ffmpeg failed to encode .mp3"
         return 1
-      }
+      fi
       ;;
     *.ogg|*.opus)
       if ! command -v "$FFMPEG_BIN" >/dev/null 2>&1; then
         note "output: ffmpeg not available to encode Opus"
         return 1
       fi
-      "$FFMPEG_BIN" -y -i "$src" -codec:a libopus -b:a 64k -ar 48000 -ac 1 "$dst" >/dev/null 2>&1 || {
+      if ! "$FFMPEG_BIN" -y -i "$src" -codec:a libopus -b:a 64k -ar 48000 -ac 1 "$dst" >/dev/null 2>&1; then
+        rm -f "$dst"
         note "output: ffmpeg failed to encode Opus"
         return 1
-      }
+      fi
       ;;
     *)
       cp -f "$src" "$dst" || {
@@ -253,6 +258,7 @@ kokoro_via_server() {
   # Text goes through the environment, never through the shell or the argv of
   # an interpreter, so an utterance containing quotes cannot become code.
   KOKORO_TEXT="$text" KOKORO_OUTPUT="$wav" KOKORO_SOCKET="$KOKORO_SOCKET" KOKORO_VOICE="$voice" \
+    KOKORO_TIMEOUT="$KOKORO_TIMEOUT" \
     "$PYTHON_BIN" -c '
 import json, os, socket, sys
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -275,10 +281,19 @@ if not resp.startswith("OK"):
   return 0
 }
 
+# Kokoro voice ids are <lang><gender>_<name>: af_heart and am_michael are
+# American ("a"), bf_emma and bm_george are British ("b"). Passing -l a for a
+# British voice does not fail — kokoro warns "Language mismatch, loading
+# <voice> into <language> pipeline" and carries on — so the only symptom is
+# the wrong G2P and mispronounced output. Derive it instead of hardcoding it,
+# so a voice added to the table above cannot silently inherit "a".
+kokoro_lang_of() { printf '%s' "${1:0:1}"; }
+
 kokoro_cold_start() {
-  local text="$1" wav="$2" voice="$3"
+  local text="$1" wav="$2" voice="$3" lang
   command -v "$KOKORO_BIN" >/dev/null 2>&1 || return 1
-  timeout "$KOKORO_TIMEOUT" "$KOKORO_BIN" -t "$text" -o "$wav" -m "$voice" -l a >/dev/null 2>&1 || return 1
+  lang="$(kokoro_lang_of "$voice")"
+  timeout "$KOKORO_TIMEOUT" "$KOKORO_BIN" -t "$text" -o "$wav" -m "$voice" -l "$lang" >/dev/null 2>&1 || return 1
   return 0
 }
 
@@ -383,6 +398,15 @@ try_piper() {
 
 # ── Entry ───────────────────────────────────────────────────────────────────
 
+# Refuse an option that was handed no value, rather than looping on it.
+need_value() {
+  if [ "$2" -lt 2 ]; then
+    echo "clawbox-tts: $1 requires a value" >&2
+    usage
+    exit 2
+  fi
+}
+
 usage() {
   cat >&2 <<USAGE
 Usage: clawbox-tts.sh [--voice <voice>] <text> <output-path>
@@ -400,11 +424,17 @@ ARGS=()
 while [ $# -gt 0 ]; do
   case "$1" in
     --voice)
-      REQUESTED_VOICE="${2:-}"; shift 2 || true ;;
+      # `shift 2` with only one argument left does NOT shift — it returns
+      # non-zero and leaves $@ untouched. Swallowing that with `|| true` left
+      # $1 as --voice forever and span this loop on a core until the caller's
+      # timeout killed it. Every option that takes a value checks for it.
+      need_value "--voice" "$#"
+      REQUESTED_VOICE="$2"; shift 2 ;;
     --voice=*)
       REQUESTED_VOICE="${1#--voice=}"; shift ;;
     --set-voice)
-      save_voice "${2:-}"; exit $? ;;
+      need_value "--set-voice" "$#"
+      save_voice "$2"; exit $? ;;
     --get-voice)
       resolve_voice ""; echo; exit 0 ;;
     --list-voices)
@@ -438,6 +468,12 @@ trap 'rm -f "$TMPWAV"' EXIT
 
 if try_kokoro "$TEXT" "$TMPWAV" "$VOICE" || try_piper "$TEXT" "$TMPWAV" "$VOICE"; then
   if emit "$TMPWAV" "$OUTPUT"; then
+    # A fallback that leaves no trace is indistinguishable from a healthy GPU
+    # path. Say so once, on stderr, so a box quietly living on the CPU engine
+    # is visible in the gateway log instead of only in the audio.
+    if [ "$ENGINE_USED" = "piper" ] && [ "${#REASONS[@]}" -gt 0 ]; then
+      echo "clawbox-tts: fell back to Piper — ${REASONS[*]}" >&2
+    fi
     echo "$OUTPUT"
     exit 0
   fi

--- a/scripts/openclaw/clawbox-tts.sh
+++ b/scripts/openclaw/clawbox-tts.sh
@@ -84,6 +84,24 @@ piper_voice_for() {
   esac
 }
 
+# Piper model ids are <lang>_<REGION>-<name>-<quality>, so the language falls
+# out of the id and no second table has to be kept in sync with the first. A
+# voice added to piper_voice_for above inherits the substitution behaviour
+# below for free.
+piper_language_of() { printf '%s' "${1%%_*}"; }
+
+# Any installed model for this language, in a deterministic order. Used only
+# when the voice's own model is absent.
+piper_model_for_language() {
+  local lang="$1" f
+  for f in "$PIPER_VOICE_DIR/${lang}_"*.onnx; do
+    [ -f "$f" ] || continue
+    basename "$f" .onnx
+    return 0
+  done
+  return 1
+}
+
 is_known_voice() {
   case "$1" in
     af_heart|alloy|echo|fable|nova|shimmer|am_michael|onyx|af_bella|am_adam|bf_emma|bm_george|bg_dimitar) return 0 ;;
@@ -318,11 +336,27 @@ try_piper() {
     note "piper: binary not found at $PIPER_BIN"
     return 1
   fi
+  # A voice whose own model is not on disk must not become silence — that is
+  # the bug this whole file exists to fix, and it would come back through the
+  # voice table rather than through the engines. Two different substitutions,
+  # and the difference between them is the whole point:
+  #
+  #   same language  -> acceptable. en_GB-alba-medium missing, en_US-lessac
+  #                     installed: the user hears the right words in a
+  #                     slightly different accent, and is told so.
+  #   cross language -> refused. Bulgarian read aloud by an English model is
+  #                     broken audio, which is worse than no audio.
   if [ ! -f "$model" ]; then
-    # Speaking this text with a voice for another language is worse than not
-    # speaking it, so we do NOT silently substitute the English model here.
-    note "piper: no voice model $pvoice at $PIPER_VOICE_DIR"
-    return 1
+    local lang substitute
+    lang="$(piper_language_of "$pvoice")"
+    substitute="$(piper_model_for_language "$lang")"
+    if [ -z "$substitute" ]; then
+      note "piper: no voice model for language '$lang' at $PIPER_VOICE_DIR (wanted $pvoice)"
+      return 1
+    fi
+    echo "clawbox-tts: voice model $pvoice is not installed, speaking '$voice' with $substitute instead" >&2
+    pvoice="$substitute"
+    model="$PIPER_VOICE_DIR/$pvoice.onnx"
   fi
 
   local piper_dir

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync, chmodSync } from "node:fs";
 import { spawnSync, spawn, type ChildProcess } from "node:child_process";
+import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -802,9 +803,13 @@ describe("install-voice.sh installs the fallback engine", () => {
 
     const BODY = "piper-artifact-bytes";
     // sha256 of BODY, computed here so the fixture cannot drift from it.
-    const SHA = spawnSync("bash", ["-c", `printf %s '${BODY}' | sha256sum | cut -d' ' -f1`], {
-      encoding: "utf8",
-    }).stdout.trim();
+    //
+    // In Node, not by shelling out to sha256sum: describe.skipIf still runs
+    // this factory to COLLECT the tests even when canRun is false, and
+    // spawnSync on a missing binary returns stdout undefined, so .trim() threw
+    // a TypeError and took the whole FILE down instead of skipping it
+    // cleanly. Anything evaluated out here has to survive a box with no bash.
+    const SHA = createHash("sha256").update(BODY).digest("hex");
 
     it("passes the timeout bounds on the actual call", () => {
       const { r, recorded, cleanup } = runFetch(BODY, SHA);

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -20,6 +20,32 @@ const SCRIPT = path.resolve(process.cwd(), "scripts/openclaw/clawbox-tts.sh");
 const INSTALL_SH = readFileSync(path.resolve(process.cwd(), "install.sh"), "utf-8");
 const INSTALL_VOICE_SH = readFileSync(path.resolve(process.cwd(), "scripts/install-voice.sh"), "utf-8");
 
+/** Pull a shell function body out of a script, for asserting on its shape. */
+function extractShellFn(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end + 2);
+}
+
+/** Every curl command in a script, line continuations folded in. */
+function curlInvocations(source: string): string[] {
+  const lines = source.split("\n");
+  const found: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!/(^|[\s;(&|])curl\s/.test(lines[i])) continue;
+    let cmd = lines[i];
+    let j = i;
+    while (/\\\s*$/.test(lines[j]) && j + 1 < lines.length) {
+      j += 1;
+      cmd += " " + lines[j];
+    }
+    found.push(cmd);
+  }
+  return found;
+}
+
 const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
 const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
 const canRun = hasBash && hasPython3;
@@ -529,6 +555,61 @@ describe.skipIf(!canRun)("scripts/openclaw/clawbox-tts.sh", () => {
     expect(calls()).not.toContain("lang=a");
   });
 
+  it("still reaches Piper when Kokoro hangs rather than fails", () => {
+    // The scenario the budget exists for, end to end: kokoro never returns.
+    // With timeoutMs equal to KOKORO_TIMEOUT, OpenClaw killed this process at
+    // the moment kokoro was given up on, so Piper never ran and a wedged GPU
+    // was still silence. Timeouts are shrunk here so the test is quick; the
+    // relationship under test is the ordering, not the numbers.
+    writeStub("kokoro", ['echo "kokoro $*" >> "$CALLS_LOG"', "sleep 30"].join("\n"));
+    stubPiper();
+    const started = Date.now();
+    const r = synth([], { KOKORO_TIMEOUT: "2", KOKORO_SERVER_TIMEOUT: "1", PIPER_TIMEOUT: "10" });
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("kokoro ");
+    expect(calls()).toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+    // It gave up on kokoro and moved on, rather than waiting out the sleep.
+    expect(Date.now() - started).toBeLessThan(20_000);
+  }, 30_000);
+
+  it("leaves room for the whole chain inside the caller's timeout", () => {
+    // The regression this pins: timeoutMs and KOKORO_TIMEOUT were both 120s,
+    // so OpenClaw killed the process at the moment Kokoro gave up and Piper
+    // never ran. A hung GPU stayed silent — the exact bug this PR fixes.
+    const budget = Number(spawnSync("bash", [SCRIPT, "--budget-seconds"], { encoding: "utf8" }).stdout.trim());
+    const providerMs = Number(spawnSync("bash", [SCRIPT, "--provider-timeout-ms"], { encoding: "utf8" }).stdout.trim());
+    expect(Number.isFinite(budget)).toBe(true);
+    expect(budget).toBeGreaterThan(0);
+    expect(providerMs).toBeGreaterThan(budget * 1000);
+  });
+
+  it("reports a budget that is really the sum of its engine timeouts", () => {
+    // Stops the budget from being a decorative number that drifts away from
+    // the timeouts actually handed to `timeout`.
+    const src = readFileSync(SCRIPT, "utf8");
+    const slice = (name: string): number => {
+      const m = src.match(new RegExp(`^${name}="\\$\\{${name}:-(\\d+)\\}"`, "m"));
+      if (!m) throw new Error(`${name} default not found`);
+      return Number(m[1]);
+    };
+    const parts = ["KOKORO_SERVER_TIMEOUT", "KOKORO_TIMEOUT", "PIPER_TIMEOUT", "CONVERT_TIMEOUT"];
+    const sum = parts.reduce((acc, n) => acc + slice(n), 0);
+    const budget = Number(spawnSync("bash", [SCRIPT, "--budget-seconds"], { encoding: "utf8" }).stdout.trim());
+    expect(budget).toBe(sum);
+    // And each slice is actually enforced, not just declared.
+    for (const name of parts) {
+      expect(src).toMatch(new RegExp(`timeout "\\$${name}"`));
+    }
+  });
+
+  it("keeps every engine slice short enough to fail over usefully", () => {
+    // A spoken reply that takes even half a minute has already failed as an
+    // interaction; the point of the budget is fast failover, not long rope.
+    const budget = Number(spawnSync("bash", [SCRIPT, "--budget-seconds"], { encoding: "utf8" }).stdout.trim());
+    expect(budget).toBeLessThanOrEqual(120);
+  });
+
   it("does not mistake reply text starting with -- for its own options", () => {
     stubKokoro();
     stubPiper();
@@ -578,6 +659,18 @@ describe("install.sh wires TTS to the on-device chain", () => {
     const checkIndex = step.indexOf('[ ! -x "$TTS_SCRIPT" ]');
     const setIndex = step.indexOf("oc_config_set messages.tts.providers");
     expect(checkIndex).toBeLessThan(setIndex);
+  });
+
+  it("takes the provider timeout from the script instead of hardcoding one", () => {
+    expect(step).toContain("--provider-timeout-ms");
+    expect(step).toContain("timeoutMs:Number(process.argv[2])");
+    // The old hardcoded value, and any other literal, must be gone: a second
+    // copy of this number is how it drifted into equalling KOKORO_TIMEOUT.
+    expect(step).not.toMatch(/timeoutMs:\s*\d+/);
+  });
+
+  it("refuses a provider timeout it cannot parse", () => {
+    expect(step).toContain("did not report a usable provider timeout");
   });
 
   it("writes config through the retrying helper, not a raw config set", () => {
@@ -649,12 +742,107 @@ describe("install-voice.sh installs the fallback engine", () => {
     expect(INSTALL_VOICE_SH).toContain("Piper binary already installed");
   });
 
-  it("bounds a stalled download so an update cannot hang forever", () => {
-    // This runs from step_post_update on every in-app update of a shipped
-    // device; an unbounded curl there hangs the whole update.
-    expect(INSTALL_VOICE_SH).toContain("--connect-timeout");
-    expect(INSTALL_VOICE_SH).toContain("--speed-limit");
-    expect(INSTALL_VOICE_SH).toContain("--speed-time");
+  it("bounds EVERY download, not just one of them", () => {
+    // Asserting the flags appear somewhere in the file would be satisfied by a
+    // single bounded curl while an unbounded one was added elsewhere. This
+    // runs from step_post_update on every in-app update of a shipped device,
+    // so any unbounded transfer hangs the whole update.
+    const invocations = curlInvocations(INSTALL_VOICE_SH);
+    expect(invocations.length).toBeGreaterThan(0);
+    for (const cmd of invocations) {
+      expect(cmd).toContain("--connect-timeout");
+      expect(cmd).toContain("--speed-limit");
+      expect(cmd).toContain("--speed-time");
+    }
+  });
+
+  describe.skipIf(!canRun)("piper_fetch against a recording curl", () => {
+    // Runs the real function out of the shipped script with a stub curl on
+    // PATH that records the argv it was handed, so the bound is checked on the
+    // call as it is actually made rather than on the file's text.
+    function runFetch(body: string, wantSha: string, times = 1) {
+      const fetchDir = mkdtempSync(path.join(tmpdir(), "piper-fetch-"));
+      const fetchBin = path.join(fetchDir, "bin");
+      mkdirSync(fetchBin, { recursive: true });
+      const curlArgs = path.join(fetchDir, "curl-args.log");
+      const curl = path.join(fetchBin, "curl");
+      writeFileSync(
+        curl,
+        [
+          "#!/usr/bin/env bash",
+          'printf "%s\n" "$*" >> "$CURL_ARGS"',
+          'out=""',
+          'while [ $# -gt 0 ]; do case "$1" in -o) out="$2"; shift 2;; *) shift;; esac; done',
+          'printf "%s" "$CURL_BODY" > "$out"',
+        ].join("\n"),
+      );
+      chmodSync(curl, 0o755);
+      const dest = path.join(fetchDir, "artifact.bin");
+      const harness = path.join(fetchDir, "harness.sh");
+      writeFileSync(
+        harness,
+        [
+          "set -uo pipefail",
+          extractShellFn(INSTALL_VOICE_SH, "piper_digest_ok"),
+          extractShellFn(INSTALL_VOICE_SH, "piper_fetch"),
+          ...Array.from(
+            { length: times },
+            () => `piper_fetch "https://example.invalid/artifact.bin" "${dest}" "${wantSha}"`,
+          ),
+        ].join("\n"),
+      );
+      const r = spawnSync("bash", [harness], {
+        encoding: "utf8",
+        env: { PATH: `${fetchBin}:/usr/bin:/bin`, CURL_ARGS: curlArgs, CURL_BODY: body },
+        timeout: 30_000,
+      });
+      const recorded = existsSync(curlArgs) ? readFileSync(curlArgs, "utf8") : "";
+      return { r, recorded, dest, cleanup: () => rmSync(fetchDir, { recursive: true, force: true }) };
+    }
+
+    const BODY = "piper-artifact-bytes";
+    // sha256 of BODY, computed here so the fixture cannot drift from it.
+    const SHA = spawnSync("bash", ["-c", `printf %s '${BODY}' | sha256sum | cut -d' ' -f1`], {
+      encoding: "utf8",
+    }).stdout.trim();
+
+    it("passes the timeout bounds on the actual call", () => {
+      const { r, recorded, cleanup } = runFetch(BODY, SHA);
+      try {
+        expect(r.status).toBe(0);
+        expect(recorded).toContain("--connect-timeout");
+        expect(recorded).toContain("--speed-limit");
+        expect(recorded).toContain("--speed-time");
+        expect(recorded).toContain("--retry");
+      } finally {
+        cleanup();
+      }
+    });
+
+    it("refuses bytes whose digest does not match the pin", () => {
+      const { r, dest, cleanup } = runFetch(BODY, "deadbeef");
+      try {
+        expect(r.status).not.toBe(0);
+        expect(r.stderr).toContain("does not match the pin");
+        // Nothing half-written is left for the next run to trust.
+        expect(existsSync(dest)).toBe(false);
+        expect(existsSync(`${dest}.part`)).toBe(false);
+      } finally {
+        cleanup();
+      }
+    });
+
+    it("does not re-download an artifact that is already correct", () => {
+      // Called twice; the second call must be satisfied by the digest already
+      // on disk. The updater re-runs this on every update of every device.
+      const { r, recorded, cleanup } = runFetch(BODY, SHA, 2);
+      try {
+        expect(r.status).toBe(0);
+        expect(recorded.trim().split("\n")).toHaveLength(1);
+      } finally {
+        cleanup();
+      }
+    });
   });
 
   it("proves the binary exists rather than discarding the chmod", () => {

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -264,6 +264,52 @@ describe.skipIf(!canRun)("scripts/openclaw/clawbox-tts.sh", () => {
     expect(outputBytes()).toBeGreaterThan(1024);
   });
 
+  it("substitutes a same-language voice rather than going silent", () => {
+    // bm_george maps to en_GB-alba-medium, which the installer does not ship.
+    // On a box where Kokoro cannot run — the low-memory case the guard exists
+    // for — refusing here would be exactly the silence this task is about.
+    stubKokoro();
+    stubPiper();
+    writeMeminfo(900);
+    const r = synth(["--voice", "bm_george"]);
+    expect(r.status).toBe(0);
+    expect(calls()).not.toContain("kokoro ");
+    expect(calls()).toContain("en_US-lessac-medium.onnx");
+    expect(outputBytes()).toBeGreaterThan(1024);
+    // The user is told the accent is not the one they picked.
+    expect(r.stderr).toContain("en_GB-alba-medium");
+    expect(r.stderr).toContain("en_US-lessac-medium");
+    expect(r.stderr).toContain("bm_george");
+  });
+
+  it("prefers the voice's own model when it is installed", () => {
+    // Guards the substitution against becoming a permanent downgrade.
+    stubKokoro();
+    stubPiper();
+    installPiperVoice("en_GB-alba-medium");
+    writeMeminfo(900);
+    const r = synth(["--voice", "bm_george"]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("en_GB-alba-medium.onnx");
+    expect(calls()).not.toContain("en_US-lessac-medium.onnx");
+    expect(r.stderr).not.toContain("instead");
+  });
+
+  it("still refuses to cross languages when only English is installed", () => {
+    // Same-language substitution must not weaken this: an English model
+    // reading Bulgarian is broken audio, which is worse than no audio.
+    stubKokoro();
+    stubPiper();
+    writeMeminfo(900);
+    const r = synth(["--voice", "bg_dimitar"]);
+    expect(r.status).not.toBe(0);
+    // Assert on what the engine was actually asked to load, not just the code.
+    expect(calls()).not.toContain("en_US-lessac-medium.onnx");
+    expect(calls()).not.toContain("piper ");
+    expect(r.stderr).toContain("no voice model for language 'bg'");
+    expect(existsSync(outPath)).toBe(false);
+  });
+
   it("refuses to speak a missing-voice language in the wrong voice", () => {
     // With no Bulgarian model installed the honest answer is no audio and a
     // reason — NOT Bulgarian text read out by the English voice.

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -60,7 +60,8 @@ function stubKokoro() {
       '  case "$1" in',
       '    -o) out="$2"; shift 2;;',
       '    -m) voice="$2"; shift 2;;',
-      '    -t|-l) shift 2;;',
+      '    -t) shift 2;;',
+      '    -l) echo "lang=$2" >> "$CALLS_LOG"; shift 2;;',
       "    *) shift;;",
       "  esac",
       "done",
@@ -189,8 +190,10 @@ describe.skipIf(!canRun)("scripts/openclaw/clawbox-tts.sh", () => {
     expect(r.status).toBe(0);
     expect(calls()).toContain("piper ");
     expect(outputBytes()).toBeGreaterThan(1024);
-    // The reason has to be visible; a silent fallback hides a broken GPU box.
-    expect(r.stderr === "" || r.stderr.length >= 0).toBe(true);
+    // The reason has to be visible; a silent fallback hides a broken GPU box
+    // that is quietly living on the CPU engine.
+    expect(r.stderr).toContain("fell back to Piper");
+    expect(r.stderr).toContain("is not installed");
   });
 
   it("falls back to Piper when kokoro fails, instead of exiting 1", () => {
@@ -479,6 +482,53 @@ describe.skipIf(!canRun)("scripts/openclaw/clawbox-tts.sh", () => {
     expect(existsSync(mp3)).toBe(false);
   });
 
+  it("rejects --voice with no value instead of spinning on it", () => {
+    // `shift 2` with one argument left does not shift and returns non-zero;
+    // swallowing that left $1 as --voice and span the parse loop on a core
+    // until the caller's timeout killed it. The `timeout` wrapper means a
+    // regression fails this test in 5s rather than hanging the suite.
+    const r = spawnSync("timeout", ["5", "bash", SCRIPT, "--voice"], {
+      encoding: "utf8",
+      env: baseEnv(),
+      timeout: 30_000,
+    });
+    expect(r.status).not.toBe(124); // 124 == killed by timeout, i.e. it hung
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("--voice requires a value");
+  });
+
+  it("rejects --set-voice with no value", () => {
+    const r = spawnSync("timeout", ["5", "bash", SCRIPT, "--set-voice"], {
+      encoding: "utf8",
+      env: baseEnv(),
+      timeout: 30_000,
+    });
+    expect(r.status).not.toBe(124);
+    expect(r.status).toBe(2);
+    expect(r.stderr).toContain("--set-voice requires a value");
+  });
+
+  it("tells Kokoro the American language code for an American voice", () => {
+    stubKokoro();
+    stubPiper();
+    const r = synth(["--voice", "af_heart"]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("lang=a");
+  });
+
+  it("tells Kokoro the British language code for a British voice", () => {
+    // kokoro does not fail on a mismatch — it warns "Language mismatch,
+    // loading <voice> into <language> pipeline" and synthesises anyway, so
+    // hardcoding -l a degraded pronunciation instead of erroring.
+    stubKokoro();
+    stubPiper();
+    const r = synth(["--voice", "bm_george"]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("voice=bm_george");
+    expect(calls()).toContain("lang=b");
+    expect(calls()).not.toContain("lang=a");
+  });
+
   it("does not mistake reply text starting with -- for its own options", () => {
     stubKokoro();
     stubPiper();
@@ -505,10 +555,29 @@ describe("install.sh wires TTS to the on-device chain", () => {
     expect(step).toContain("config get messages.tts.provider");
     expect(step).toMatch(/CURRENT_TTS.*!=.*"null"|"\$CURRENT_TTS" != "null"/);
     expect(step).toContain("preserving");
+    // The preserve branch must return BEFORE anything is written, otherwise
+    // "seed-if-unset" is just "set".
     const guardIndex = step.indexOf("preserving");
     const setIndex = step.indexOf("oc_config_set messages.tts.provider");
-    expect(guardIndex).toBeGreaterThan(-1);
+    expect(step.slice(guardIndex, setIndex)).toContain("return 0");
     expect(setIndex).toBeGreaterThan(guardIndex);
+  });
+
+  it("does not select a provider it failed to define", () => {
+    // oc_config_set retries 3x then returns 1. Naming tts-local-cli as THE
+    // provider after its definition failed to land points the box at a
+    // provider that does not exist and breaks every spoken reply.
+    expect(step).toContain("if ! oc_config_set messages.tts.providers.tts-local-cli");
+    const defineIndex = step.indexOf("oc_config_set messages.tts.providers.tts-local-cli");
+    const selectIndex = step.indexOf("oc_config_set messages.tts.provider ");
+    expect(step.slice(defineIndex, selectIndex)).toContain("return 1");
+  });
+
+  it("refuses to wire the provider to a command that is not there", () => {
+    expect(step).toContain('[ ! -x "$TTS_SCRIPT" ]');
+    const checkIndex = step.indexOf('[ ! -x "$TTS_SCRIPT" ]');
+    const setIndex = step.indexOf("oc_config_set messages.tts.providers");
+    expect(checkIndex).toBeLessThan(setIndex);
   });
 
   it("writes config through the retrying helper, not a raw config set", () => {
@@ -522,8 +591,12 @@ describe("install.sh wires TTS to the on-device chain", () => {
     // the script would be handed no destination at all.
     expect(step).toContain("{{OutputPath}}");
     expect(step).toContain("{{Text}}");
+    // All three invalid spellings, written out literally. The previous version
+    // of this test excluded "{{outputpath }}" — with a trailing space — which
+    // no regression would ever produce, so it guarded nothing.
     expect(step).not.toContain("{{outputPath}}");
-    expect(step).not.toContain("{{OutputPath }}".replace("OutputPath", "outputpath"));
+    expect(step).not.toContain("{{outputpath}}");
+    expect(step).not.toContain("{{OUTPUTPATH}}");
   });
 
   it("points the provider at the shipped entrypoint", () => {
@@ -574,6 +647,38 @@ describe("install-voice.sh installs the fallback engine", () => {
   it("is idempotent: a matching digest on disk is not re-downloaded", () => {
     expect(INSTALL_VOICE_SH).toMatch(/piper_digest_ok "\$dest" "\$want"[\s\S]{0,60}return 0/);
     expect(INSTALL_VOICE_SH).toContain("Piper binary already installed");
+  });
+
+  it("bounds a stalled download so an update cannot hang forever", () => {
+    // This runs from step_post_update on every in-app update of a shipped
+    // device; an unbounded curl there hangs the whole update.
+    expect(INSTALL_VOICE_SH).toContain("--connect-timeout");
+    expect(INSTALL_VOICE_SH).toContain("--speed-limit");
+    expect(INSTALL_VOICE_SH).toContain("--speed-time");
+  });
+
+  it("proves the binary exists rather than discarding the chmod", () => {
+    expect(INSTALL_VOICE_SH).toContain("the Piper tarball did not contain piper");
+    expect(INSTALL_VOICE_SH).not.toMatch(/chmod \+x "\$PIPER_DIR\/piper" 2>\/dev\/null \|\| true/);
+  });
+
+  it("reports piper-only failure instead of exiting 0 regardless", () => {
+    const branch = INSTALL_VOICE_SH.slice(
+      INSTALL_VOICE_SH.indexOf('"${1:-}" = "--piper-only"'),
+      INSTALL_VOICE_SH.indexOf("Piper fallback ready"),
+    );
+    expect(branch).toContain("install_piper || PIPER_ONLY_RC=1");
+    expect(branch).toContain("deploy_voice_scripts || PIPER_ONLY_RC=1");
+    expect(branch).toContain("exit 1");
+  });
+
+  it("treats a missing TTS entrypoint as a deploy failure", () => {
+    const fn = INSTALL_VOICE_SH.slice(
+      INSTALL_VOICE_SH.indexOf("deploy_voice_scripts() {"),
+      INSTALL_VOICE_SH.indexOf("\n}", INSTALL_VOICE_SH.indexOf("deploy_voice_scripts() {")),
+    );
+    expect(fn).toContain("clawbox-tts.sh is missing");
+    expect(fn).toContain('return "$rc"');
   });
 
   it("offers a cheap piper-only path for the updater", () => {

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -1,0 +1,543 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync, chmodSync } from "node:fs";
+import { spawnSync, spawn, type ChildProcess } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// These run the shipped scripts/openclaw/clawbox-tts.sh itself against stub
+// `kokoro` and `piper` executables on PATH — not a reimplementation of its
+// fallback chain in TypeScript. The engines are the part that breaks, so the
+// stubs are scripted to break the way the real ones do: a kokoro that is not
+// installed, one that exits non-zero when CUDA will not allocate, one that
+// returns a WAV header with no samples in it, and a board with no memory left.
+//
+// The bug being fixed is silence. Until TASK-383 the box called kokoro-tts.sh,
+// which printed "Kokoro TTS failed" and exited 1 for every one of those cases,
+// so each test below asserts BOTH that the right engine ran and that audio
+// came out — an exit code alone would have passed against the old script too.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/openclaw/clawbox-tts.sh");
+const INSTALL_SH = readFileSync(path.resolve(process.cwd(), "install.sh"), "utf-8");
+const INSTALL_VOICE_SH = readFileSync(path.resolve(process.cwd(), "scripts/install-voice.sh"), "utf-8");
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+const canRun = hasBash && hasPython3;
+
+let dir: string;
+let binDir: string;
+let voiceDir: string;
+let callsLog: string;
+let meminfo: string;
+let voiceFile: string;
+let wavWriter: string;
+let outPath: string;
+let servers: ChildProcess[] = [];
+
+/** MemAvailable in MB, in the shape awk reads out of /proc/meminfo. */
+function writeMeminfo(availableMb: number) {
+  writeFileSync(
+    meminfo,
+    ["MemTotal:        7607000 kB", `MemAvailable:    ${availableMb * 1024} kB`, "SwapFree:              0 kB"].join("\n"),
+  );
+}
+
+function writeStub(name: string, body: string) {
+  const p = path.join(binDir, name);
+  writeFileSync(p, `#!/usr/bin/env bash\n${body}\n`);
+  chmodSync(p, 0o755);
+  return p;
+}
+
+/** A kokoro CLI that honours -o/-m and can be told to fail or fall silent. */
+function stubKokoro() {
+  return writeStub(
+    "kokoro",
+    [
+      'echo "kokoro $*" >> "$CALLS_LOG"',
+      'out=""; voice=""',
+      "while [ $# -gt 0 ]; do",
+      '  case "$1" in',
+      '    -o) out="$2"; shift 2;;',
+      '    -m) voice="$2"; shift 2;;',
+      '    -t|-l) shift 2;;',
+      "    *) shift;;",
+      "  esac",
+      "done",
+      'echo "voice=$voice" >> "$CALLS_LOG"',
+      'if [ "${KOKORO_FAIL:-0}" != "0" ]; then echo "CUDA out of memory" >&2; exit 1; fi',
+      'python3 "$WAV_WRITER" "$out" "${KOKORO_SECONDS:-1}"',
+    ].join("\n"),
+  );
+}
+
+/** A piper CLI that reads text on stdin and honours -m/-f, like the real one. */
+function stubPiper() {
+  return writeStub(
+    "piper",
+    [
+      'echo "piper $*" >> "$CALLS_LOG"',
+      "cat > /dev/null",
+      'out=""; model=""',
+      "while [ $# -gt 0 ]; do",
+      '  case "$1" in',
+      '    -f) out="$2"; shift 2;;',
+      '    -m) model="$2"; shift 2;;',
+      "    *) shift;;",
+      "  esac",
+      "done",
+      'if [ "${PIPER_FAIL:-0}" != "0" ]; then exit 1; fi',
+      'python3 "$WAV_WRITER" "$out" 1',
+    ].join("\n"),
+  );
+}
+
+function installPiperVoice(voice: string) {
+  writeFileSync(path.join(voiceDir, `${voice}.onnx`), "stub-model");
+  writeFileSync(path.join(voiceDir, `${voice}.onnx.json`), "{}");
+}
+
+function baseEnv(extra: Record<string, string> = {}): Record<string, string> {
+  return {
+    PATH: `${binDir}:/usr/bin:/bin`,
+    HOME: dir,
+    CALLS_LOG: callsLog,
+    WAV_WRITER: wavWriter,
+    CLAWBOX_TTS_MEMINFO: meminfo,
+    CLAWBOX_TTS_VOICE_FILE: voiceFile,
+    PIPER_BIN: path.join(binDir, "piper"),
+    PIPER_VOICE_DIR: voiceDir,
+    // A path that cannot be a socket, so the cold-start branch is what runs
+    // unless a test deliberately stands a server up.
+    KOKORO_SOCKET: path.join(dir, "no-such.sock"),
+    ...extra,
+  };
+}
+
+function run(args: string[], extraEnv: Record<string, string> = {}) {
+  return spawnSync("bash", [SCRIPT, ...args], {
+    encoding: "utf8",
+    env: baseEnv(extraEnv),
+    timeout: 60_000,
+  });
+}
+
+function synth(args: string[], extraEnv: Record<string, string> = {}) {
+  return run([...args, "--", "Your ClawBox is ready.", outPath], extraEnv);
+}
+
+function calls(): string {
+  return existsSync(callsLog) ? readFileSync(callsLog, "utf8") : "";
+}
+
+function outputBytes(): number {
+  return existsSync(outPath) ? readFileSync(outPath).length : 0;
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "clawbox-tts-"));
+  binDir = path.join(dir, "bin");
+  voiceDir = path.join(dir, "voices");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(voiceDir, { recursive: true });
+  callsLog = path.join(dir, "calls.log");
+  meminfo = path.join(dir, "meminfo");
+  voiceFile = path.join(dir, "tts-voice");
+  outPath = path.join(dir, "out", "speech.wav");
+  wavWriter = path.join(dir, "write_wav.py");
+  writeFileSync(
+    wavWriter,
+    [
+      "import sys, wave",
+      "w = wave.open(sys.argv[1], 'wb')",
+      "w.setnchannels(1); w.setsampwidth(2); w.setframerate(24000)",
+      "w.writeframes(b'\\x00\\x00' * int(24000 * float(sys.argv[2])))",
+      "w.close()",
+    ].join("\n"),
+  );
+  writeMeminfo(6000);
+  installPiperVoice("en_US-lessac-medium");
+});
+
+afterEach(() => {
+  for (const s of servers) {
+    try {
+      s.kill("SIGKILL");
+    } catch {
+      // already gone
+    }
+  }
+  servers = [];
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe.skipIf(!canRun)("scripts/openclaw/clawbox-tts.sh", () => {
+  it("speaks through Kokoro when the GPU path is available", () => {
+    stubKokoro();
+    stubPiper();
+    const r = synth([]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("kokoro ");
+    // Kokoro succeeded, so the CPU engine must not have been touched at all.
+    expect(calls()).not.toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("falls back to Piper when kokoro is not installed at all", () => {
+    stubPiper();
+    const r = synth([]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+    // The reason has to be visible; a silent fallback hides a broken GPU box.
+    expect(r.stderr === "" || r.stderr.length >= 0).toBe(true);
+  });
+
+  it("falls back to Piper when kokoro fails, instead of exiting 1", () => {
+    // This is the old behaviour, exactly: kokoro-tts.sh printed
+    // "Kokoro TTS failed" and exited 1, and the user heard nothing.
+    stubKokoro();
+    stubPiper();
+    const r = synth([], { KOKORO_FAIL: "1" });
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("kokoro ");
+    expect(calls()).toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("treats a WAV with no samples in it as a failure and falls back", () => {
+    // A header-only WAV is the shape "success" takes when the model loaded but
+    // synthesised nothing — exit code 0, file exists, no audio.
+    stubKokoro();
+    stubPiper();
+    const r = synth([], { KOKORO_SECONDS: "0" });
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("skips the GPU entirely when the board has no memory headroom", () => {
+    // kokoro-torch peaks at 2259-2636 MB (TASK-382) on a board whose 7607 MB
+    // is shared with the GPU. Attempting it at 900 MB free does not fail
+    // politely, it OOM-kills something else — so kokoro must never be invoked.
+    stubKokoro();
+    stubPiper();
+    writeMeminfo(900);
+    const r = synth([]);
+    expect(r.status).toBe(0);
+    expect(calls()).not.toContain("kokoro ");
+    expect(calls()).toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("uses the GPU again once the headroom is back", () => {
+    // Guards against a threshold that is simply always tripped.
+    stubKokoro();
+    stubPiper();
+    writeMeminfo(3200);
+    const r = synth([]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("kokoro ");
+  });
+
+  it("honours an overridden memory threshold", () => {
+    stubKokoro();
+    stubPiper();
+    writeMeminfo(3200);
+    const r = synth([], { CLAWBOX_TTS_MIN_FREE_MB: "5000" });
+    expect(r.status).toBe(0);
+    expect(calls()).not.toContain("kokoro ");
+    expect(calls()).toContain("piper ");
+  });
+
+  it("routes a voice Kokoro cannot speak to Piper's own voice for it", () => {
+    // Bulgarian is deferred because Kokoro has no Bulgarian voice. The failure
+    // to avoid is Kokoro speaking Bulgarian text in an English voice.
+    stubKokoro();
+    stubPiper();
+    installPiperVoice("bg_BG-dimitar-medium");
+    const r = synth(["--voice", "bg_dimitar"]);
+    expect(r.status).toBe(0);
+    expect(calls()).not.toContain("kokoro ");
+    expect(calls()).toContain("bg_BG-dimitar-medium.onnx");
+    expect(calls()).not.toContain("en_US-lessac-medium.onnx");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("refuses to speak a missing-voice language in the wrong voice", () => {
+    // With no Bulgarian model installed the honest answer is no audio and a
+    // reason — NOT Bulgarian text read out by the English voice.
+    stubKokoro();
+    stubPiper();
+    const r = synth(["--voice", "bg_dimitar"]);
+    expect(r.status).not.toBe(0);
+    expect(calls()).not.toContain("en_US-lessac-medium.onnx");
+    expect(r.stderr).toContain("bg_dimitar");
+    expect(r.stderr).toContain("bg_BG-dimitar-medium");
+    expect(existsSync(outPath)).toBe(false);
+  });
+
+  it("exits non-zero with a diagnostic when no engine can run", () => {
+    // Silence is the bug. Whatever else happens, the reason must reach stderr,
+    // where OpenClaw surfaces it as `CLI TTS exit 1: <stderr>`.
+    const r = synth([]);
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("no engine could speak");
+    expect(r.stderr).toMatch(/kokoro/);
+    expect(r.stderr).toMatch(/piper/);
+    expect(existsSync(outPath)).toBe(false);
+  });
+
+  it("names both engines' reasons rather than just the last one", () => {
+    stubKokoro();
+    const r = synth([], { KOKORO_FAIL: "1" });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("kokoro:");
+    expect(r.stderr).toContain("piper: binary not found");
+  });
+
+  it("passes the selected voice through to Kokoro", () => {
+    stubKokoro();
+    stubPiper();
+    const r = synth(["--voice", "am_michael"]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("voice=am_michael");
+  });
+
+  it("maps an OpenAI-style voice alias onto its Kokoro voice", () => {
+    stubKokoro();
+    stubPiper();
+    const r = synth(["--voice", "onyx"]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("voice=am_michael");
+  });
+
+  it("degrades an unknown voice to the default instead of erroring", () => {
+    stubKokoro();
+    stubPiper();
+    const r = synth(["--voice", "definitely-not-a-voice"]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("voice=af_heart");
+    expect(r.stderr).toContain("unknown voice");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("persists a chosen voice and uses it on later runs", () => {
+    stubKokoro();
+    stubPiper();
+    const set = run(["--set-voice", "bf_emma"]);
+    expect(set.status).toBe(0);
+    expect(readFileSync(voiceFile, "utf8").trim()).toBe("bf_emma");
+    const r = synth([]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("voice=bf_emma");
+  });
+
+  it("refuses to persist a voice the box cannot speak", () => {
+    const set = run(["--set-voice", "nonsense"]);
+    expect(set.status).not.toBe(0);
+    expect(set.stderr).toContain("unknown voice");
+    expect(existsSync(voiceFile)).toBe(false);
+  });
+
+  it("lets a per-scope override outrank the saved default", () => {
+    // OpenClaw has no per-sender config layer; per-user selection rides on the
+    // agent/channel/account overrides of the provider's `args` and `env`, so
+    // both of those levers have to beat the device-wide saved voice.
+    stubKokoro();
+    stubPiper();
+    writeFileSync(voiceFile, "bf_emma\n");
+
+    const viaEnv = synth([], { CLAWBOX_TTS_VOICE: "am_adam" });
+    expect(viaEnv.status).toBe(0);
+    expect(calls()).toContain("voice=am_adam");
+
+    rmSync(callsLog, { force: true });
+    const viaArg = synth(["--voice", "af_bella"], { CLAWBOX_TTS_VOICE: "am_adam" });
+    expect(viaArg.status).toBe(0);
+    expect(calls()).toContain("voice=af_bella");
+  });
+
+  it("reports the voice it would use", () => {
+    writeFileSync(voiceFile, "am_michael\n");
+    const r = run(["--get-voice"]);
+    expect(r.status).toBe(0);
+    expect(r.stdout.trim()).toBe("am_michael");
+  });
+
+  it("prefers the resident model server over a cold start", () => {
+    // The persistent kokoro-server keeps the model on the GPU; cold-starting
+    // the CLI instead is the difference between ~2s and a full model load.
+    const sock = path.join(dir, "kokoro.sock");
+    const server = path.join(dir, "server.py");
+    writeFileSync(
+      server,
+      [
+        "import json, os, socket, sys, wave",
+        "s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)",
+        "s.bind(sys.argv[1]); s.listen(1)",
+        "open(sys.argv[1] + '.ready', 'w').close()",
+        "conn, _ = s.accept()",
+        "data = b''",
+        "while True:",
+        "    chunk = conn.recv(4096)",
+        "    if not chunk: break",
+        "    data += chunk",
+        "req = json.loads(data.decode())",
+        "open(os.environ['CALLS_LOG'], 'a').write('server voice=' + req.get('voice', '') + '\\n')",
+        "w = wave.open(req['output'], 'wb')",
+        "w.setnchannels(1); w.setsampwidth(2); w.setframerate(24000)",
+        "w.writeframes(b'\\x00\\x00' * 24000)",
+        "w.close()",
+        "conn.sendall(b'OK')",
+        "conn.close()",
+      ].join("\n"),
+    );
+    const proc = spawn("python3", [server, sock], { env: { ...process.env, CALLS_LOG: callsLog }, stdio: "ignore" });
+    servers.push(proc);
+    const deadline = Date.now() + 15_000;
+    while (!existsSync(`${sock}.ready`) && Date.now() < deadline) {
+      spawnSync("sleep", ["0.05"]);
+    }
+    expect(existsSync(`${sock}.ready`)).toBe(true);
+
+    stubKokoro();
+    stubPiper();
+    const r = synth([], { KOKORO_SOCKET: sock });
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("server voice=af_heart");
+    // The whole point of the socket is not paying for a model load.
+    expect(calls()).not.toContain("kokoro ");
+    expect(calls()).not.toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("cold-starts when the server socket is gone", () => {
+    stubKokoro();
+    stubPiper();
+    const r = synth([], { KOKORO_SOCKET: path.join(dir, "absent.sock") });
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("kokoro ");
+  });
+
+  it("never writes WAV bytes into a file claiming to be something else", () => {
+    // OpenClaw picks the extension from outputFormat. If a deployment asks for
+    // mp3 on a box with no ffmpeg, handing back a mislabelled WAV is broken
+    // audio; failing with a reason is not.
+    stubKokoro();
+    stubPiper();
+    const mp3 = path.join(dir, "out", "speech.mp3");
+    const r = run(["--", "Your ClawBox is ready.", mp3], { FFMPEG_BIN: path.join(dir, "no-ffmpeg") });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("ffmpeg");
+    expect(existsSync(mp3)).toBe(false);
+  });
+
+  it("does not mistake reply text starting with -- for its own options", () => {
+    stubKokoro();
+    stubPiper();
+    const r = run(["--", "--voice is a strange thing to say", outPath]);
+    expect(r.status).toBe(0);
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+});
+
+describe("install.sh wires TTS to the on-device chain", () => {
+  function extractShellFunction(source: string, name: string): string {
+    const start = source.indexOf(`${name}() {`);
+    if (start < 0) throw new Error(`${name} not found`);
+    const end = source.indexOf("\n}", start);
+    if (end < 0) throw new Error(`${name} has no closing brace`);
+    return source.slice(start, end);
+  }
+
+  const step = extractShellFunction(INSTALL_SH, "step_openclaw_tts");
+
+  it("seeds the provider only when the owner has not chosen one", () => {
+    // Same contract as agents.defaults.model.primary: an owner who switched to
+    // ElevenLabs must not be reset to the local CLI by every update.
+    expect(step).toContain("config get messages.tts.provider");
+    expect(step).toMatch(/CURRENT_TTS.*!=.*"null"|"\$CURRENT_TTS" != "null"/);
+    expect(step).toContain("preserving");
+    const guardIndex = step.indexOf("preserving");
+    const setIndex = step.indexOf("oc_config_set messages.tts.provider");
+    expect(guardIndex).toBeGreaterThan(-1);
+    expect(setIndex).toBeGreaterThan(guardIndex);
+  });
+
+  it("writes config through the retrying helper, not a raw config set", () => {
+    expect(step).toContain("oc_config_set messages.tts.providers.tts-local-cli");
+    expect(step).not.toMatch(/^\s*as_clawbox "\$OPENCLAW_BIN" config set/m);
+  });
+
+  it("uses the exact placeholder casing OpenClaw substitutes", () => {
+    // applyTemplate normalizes to Firstupper+restlower and only then falls back
+    // to the raw key, so {{outputPath}} silently becomes an empty string and
+    // the script would be handed no destination at all.
+    expect(step).toContain("{{OutputPath}}");
+    expect(step).toContain("{{Text}}");
+    expect(step).not.toContain("{{outputPath}}");
+    expect(step).not.toContain("{{OutputPath }}".replace("OutputPath", "outputpath"));
+  });
+
+  it("points the provider at the shipped entrypoint", () => {
+    expect(step).toContain("scripts/openclaw/clawbox-tts.sh");
+    expect(step).toContain('outputFormat:"wav"');
+  });
+
+  it("installs the Piper fallback as part of the same step", () => {
+    expect(step).toContain("install-voice.sh");
+    expect(step).toContain("--piper-only");
+  });
+
+  it("runs on updated boxes and not just fresh installs", () => {
+    // Without this the entire feature would be fresh-install-only and every
+    // already-shipped box would keep answering a spoken request with silence.
+    expect(extractShellFunction(INSTALL_SH, "step_post_update")).toContain("step_openclaw_tts");
+    expect(extractShellFunction(INSTALL_SH, "step_openclaw_setup")).toContain("step_openclaw_tts");
+  });
+
+  it("is dispatchable by the in-app updater", () => {
+    const dispatch = INSTALL_SH.slice(
+      INSTALL_SH.indexOf("DISPATCH_STEPS=("),
+      INSTALL_SH.indexOf(")", INSTALL_SH.indexOf("DISPATCH_STEPS=(")),
+    );
+    expect(dispatch).toContain("openclaw_tts");
+  });
+});
+
+describe("install-voice.sh installs the fallback engine", () => {
+  it("pins every downloaded artifact by sha256", () => {
+    // An executable and model weights fetched onto a customer device.
+    expect(INSTALL_VOICE_SH).toContain("PIPER_TARBALL_SHA256=");
+    expect(INSTALL_VOICE_SH).toContain("PIPER_EN_ONNX_SHA256=");
+    expect(INSTALL_VOICE_SH).toMatch(/piper_digest_ok "\$dest\.part" "\$want"/);
+  });
+
+  it("uses the same pinned bytes the benchmark measured", () => {
+    const bench = readFileSync(path.resolve(process.cwd(), "scripts/bench/tts-bench.py"), "utf-8");
+    for (const key of [
+      "fea0fd2d87c54dbc7078d0f878289f404bd4d6eea6e7444a77835d1537ab88eb",
+      "5efe09e69902187827af646e1a6e9d269dee769f9877d17b16b1b46eeaaf019f",
+    ]) {
+      expect(bench).toContain(key);
+      expect(INSTALL_VOICE_SH).toContain(key);
+    }
+  });
+
+  it("is idempotent: a matching digest on disk is not re-downloaded", () => {
+    expect(INSTALL_VOICE_SH).toMatch(/piper_digest_ok "\$dest" "\$want"[\s\S]{0,60}return 0/);
+    expect(INSTALL_VOICE_SH).toContain("Piper binary already installed");
+  });
+
+  it("offers a cheap piper-only path for the updater", () => {
+    expect(INSTALL_VOICE_SH).toContain('"${1:-}" = "--piper-only"');
+  });
+
+  it("ships an English voice by default and keeps Bulgarian opt-in", () => {
+    // Bulgarian is deferred this release; the download stays behind a flag so
+    // enabling it later is config, not a code change.
+    expect(INSTALL_VOICE_SH).toContain("en_US-lessac-medium");
+    expect(INSTALL_VOICE_SH).toContain('INSTALL_BG_VOICE="${CLAWBOX_TTS_INSTALL_BG_VOICE:-false}"');
+  });
+});


### PR DESCRIPTION
Closes TASK-383 (part of the TASK-379 v4 multimodal epic).

A ClawBox that cannot run Kokoro currently says nothing at all. `kokoro-tts.sh`
prints `Kokoro TTS failed` and exits 1, and there is no second engine anywhere
on the box. This ships the fallback chain and points OpenClaw's speech output
at it.

Follows Yanko's decision on the task: Kokoro on GPU is the default voice,
Bulgarian is deferred for this release, and the ship must degrade rather than
OOM — TASK-382 measured kokoro-torch CUDA at 2259-2636 MB on a board with
7607 MB shared between CPU and GPU, which is fine idle and unproven with the
agent plus STT resident.

## What is in here

- **`scripts/openclaw/clawbox-tts.sh`** (new) — the single on-device synthesis
  entrypoint. Resolves the voice, guards memory, runs the engine chain.
- **`scripts/install-voice.sh`** — sha256-pinned, idempotent Piper install,
  a `--piper-only` mode, and `deploy_voice_scripts`.
- **`install.sh`** — `step_openclaw_tts`: installs the Piper fallback and
  seeds `messages.tts` at the built-in `tts-local-cli` provider. Wired into
  `step_openclaw_setup`, `step_post_update` and `DISPATCH_STEPS`, so already
  shipped boxes get it on update and not only fresh installs.
- **`src/tests/unit/clawbox-tts.test.ts`** (new) — 37 tests that drive the
  shipped script against stub engines.

## Engine selection

1. Voice: `--voice` > `$CLAWBOX_TTS_VOICE` > saved file > `af_heart`. An
   unknown voice degrades to the default rather than erroring.
2. Kokoro is skipped outright when the voice has no Kokoro mapping (the
   deferred-Bulgarian case) or when `MemAvailable` is below
   `CLAWBOX_TTS_MIN_FREE_MB` (default 3000 — TASK-382's 2636 MB peak rounded
   up, plus CUDA context room). In that case Kokoro is never invoked at all.
3. Otherwise Kokoro tries the resident server socket, then a cold start.
4. Not installed / non-zero exit / header-only WAV / socket gone and cold start
   failed all fall through to Piper.
5. Nothing produced audio → exit 1 with every collected reason on stderr, which
   OpenClaw surfaces as `CLI TTS exit 1: <stderr>`.

## Two substitution rules, and the difference is the point

Piper degrades **within** a language before it gives up: if a voice's own model
is not on disk, any installed model for the same language is used and the
substitution is named on stderr. `bm_george` on a box with only
`en_US-lessac-medium` gets the right words in a different accent.

It never crosses languages. `bg_dimitar` with only English installed still
exits non-zero and the English model is never loaded — Bulgarian read aloud by
an English model is broken audio, which is worse than no audio. That is also
what keeps deferred Bulgarian from shipping as garbage instead of a clean
error. The test asserts on the arguments the stub engine was invoked with, not
just on the exit code.

The language is derived from the Piper model id (`<lang>_<REGION>-...`) rather
than from a second table, so a voice added to `piper_voice_for` later inherits
this instead of silently regressing to the bug above.

## Notes for review

- `messages.tts.provider` is seeded **if unset only**, same contract as the
  primary model, so an owner who chose ElevenLabs or turned TTS off does not
  get reset on every update.
- `messages.tts.auto` is deliberately **not** set. Yanko's decision names
  Kokoro the default *voice*; `auto: "always"` would make the box speak every
  reply, which is a separate product change. On-device is the engine whenever
  TTS is used; auto-speech stays a one-command opt-in.
- Placeholder casing is load-bearing and was checked against the provider
  source, not the docs: `tts-local-cli` exposes exactly `{{Text}}`,
  `{{OutputPath}}`, `{{OutputDir}}`, `{{OutputBase}}` — there is no
  `{{Voice}}`, and `{{outputPath}}` silently substitutes an empty string.

## Testing

`npx vitest run` — 205 files, 2655 tests, all passing. `bash -n` clean on all
three shell scripts.

Every engine in the test suite is a stub, so the following still need proving
on a real Orin Nano and are **not** covered here: the real Kokoro/Piper
invocation contracts, the 3000 MB threshold against a live agent plus
faster-whisper resident, the aarch64 Piper download and tarball layout, and
end-to-end synthesis through the gateway including the voice-note transcode.
Both test boxes (192.168.50.66 and .69) were powered down during this run, so
that proof is outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-device text-to-speech with Kokoro and Piper CPU fallback.
  * Added persistent voice selection, voice cataloging, and optional Bulgarian voice support.
  * Added WAV conversion, audio validation, timeout reporting, and voice management commands.
  * Added automatic TTS setup during installation and updates.
* **Bug Fixes**
  * Improved fallback behavior, validation, and diagnostics when synthesis or configuration fails.
* **Tests**
  * Expanded coverage for synthesis, installation, fallback, voice management, and update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->