### PR TITLE
Configuring a voice provider is not the same as having one

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1792,6 +1792,41 @@ step_openclaw_tts() {
     echo "  ERROR: could not write the tts-local-cli provider — leaving messages.tts.provider unset" >&2
     return 1
   fi
+
+  # Configuring the provider is not the same as OpenClaw HAVING it, and the
+  # gap between those two is silent. `tts-local-cli` ships inside OpenClaw as a
+  # bundled extension, but the gateway resolves plugins through a PERSISTED
+  # registry rather than by scanning dist/extensions, and that index goes stale
+  # whenever the extension set on disk changes — `openclaw plugins registry`
+  # calls the reason `source-changed`, which is every OpenClaw upgrade. A stale
+  # index simply does not contain tts-local-cli: the gateway comes up without
+  # it and every spoken reply dies with
+  #     TTS conversion failed: tts-local-cli: no provider registered
+  # while this step, openclaw.json and `capability tts status` all still say
+  # the box is configured correctly.
+  #
+  # Measured on the freshly flashed Orin used for the TASK-383 hardware proof
+  # (2026-08-19): persisted 32/33 plugins against 49/67 current, the gateway
+  # loading only memory-core and ollama, and no on-device speech at all —
+  # `plugins doctor` reported no issues and `plugins enable tts-local-cli`
+  # answered "Plugin not found". Rebuilding the index was the whole fix.
+  if ! as_clawbox "$OPENCLAW_BIN" plugins registry --refresh >/dev/null 2>&1; then
+    echo "  Warning: could not refresh the plugin registry — the provider may not be visible to the gateway" >&2
+  fi
+
+  # Then verify, and refuse to select a provider that is not there. This is the
+  # same rule already applied to the script path above: never leave the box
+  # configured to speak through something that does not exist, because that
+  # configures exactly the silent failure this task removes. Leaving
+  # messages.tts.provider unset is the better outcome — OpenClaw then reports
+  # TTS as unconfigured instead of pretending it is ready.
+  if ! as_clawbox "$OPENCLAW_BIN" plugins info tts-local-cli >/dev/null 2>&1; then
+    echo "  ERROR: the tts-local-cli plugin is not registered even after refreshing the registry." >&2
+    echo "         Leaving messages.tts.provider unset rather than pointing the box at a provider" >&2
+    echo "         that cannot answer. Diagnose with: openclaw plugins registry; openclaw plugins doctor" >&2
+    return 1
+  fi
+
   if ! oc_config_set messages.tts.provider "tts-local-cli"; then
     echo "  ERROR: could not select the tts-local-cli provider" >&2
     return 1

--- a/install.sh
+++ b/install.sh
@@ -1741,6 +1741,34 @@ NODE
 # outputFormat wav is deliberate: both engines emit WAV natively, so the happy
 # path needs no ffmpeg at all, and OpenClaw transcodes to Opus itself when a
 # channel wants a voice note.
+# Configuring the provider is not the same as OpenClaw HAVING it, and the gap
+# between those two is silent. `tts-local-cli` ships inside OpenClaw as a
+# bundled extension, but the gateway resolves plugins through a PERSISTED
+# registry rather than by scanning dist/extensions, and that index goes stale
+# whenever the extension set on disk changes — `openclaw plugins registry`
+# calls the reason `source-changed`, which is every OpenClaw upgrade. A stale
+# index simply does not contain tts-local-cli: the gateway comes up without it
+# and every spoken reply dies with
+#     TTS conversion failed: tts-local-cli: no provider registered
+# while this step, openclaw.json and `capability tts status` all still say the
+# box is configured correctly.
+#
+# Measured on the freshly flashed Orin used for the TASK-383 hardware proof
+# (2026-08-19): persisted 32/33 plugins against 49/67 current, the gateway
+# loading only memory-core and ollama, and no on-device speech at all —
+# `plugins doctor` reported no issues and `plugins enable tts-local-cli`
+# answered "Plugin not found". Rebuilding the index was the whole fix.
+#
+# A failed refresh is only a warning: what decides the outcome is whether the
+# provider resolves, not how it got there, so an OpenClaw without the
+# subcommand must not cost a box its voice.
+tts_ensure_provider_registered() {
+  if ! as_clawbox "$OPENCLAW_BIN" plugins registry --refresh >/dev/null 2>&1; then
+    echo "  Warning: could not refresh the plugin registry — the provider may not be visible to the gateway" >&2
+  fi
+  as_clawbox "$OPENCLAW_BIN" plugins info tts-local-cli >/dev/null 2>&1
+}
+
 step_openclaw_tts() {
   is_hermes_edition && { echo "  [hermes edition] skipping on-device TTS"; return 0; }
   local TTS_SCRIPT="$PROJECT_DIR/scripts/openclaw/clawbox-tts.sh"
@@ -1754,6 +1782,23 @@ step_openclaw_tts() {
   local CURRENT_TTS
   CURRENT_TTS=$(as_clawbox "$OPENCLAW_BIN" config get messages.tts.provider 2>/dev/null || echo "")
   if [ -n "$CURRENT_TTS" ] && [ "$CURRENT_TTS" != "null" ]; then
+    # An owner who chose ElevenLabs keeps it. But when the box is already on
+    # OUR provider, preserving the selection is not enough: the update that
+    # just replaced OpenClaw is the very thing that invalidates the plugin
+    # registry (`source-changed`), so returning here is how an ALREADY-SHIPPED
+    # box keeps a provider selected that its gateway can no longer resolve.
+    # That is the population this step is in step_post_update for, so the
+    # verification has to happen on this path too, not only on first setup.
+    if [ "$CURRENT_TTS" = "tts-local-cli" ]; then
+      if ! tts_ensure_provider_registered; then
+        echo "  ERROR: messages.tts.provider is tts-local-cli but the plugin does not resolve," >&2
+        echo "         even after refreshing the registry. The box cannot speak until it does." >&2
+        echo "         Diagnose with: openclaw plugins registry; openclaw plugins doctor" >&2
+        return 1
+      fi
+      echo "  TTS provider already set (tts-local-cli) — preserved, plugin registry verified"
+      return 0
+    fi
     echo "  TTS provider already set ($CURRENT_TTS) — preserving"
     return 0
   fi
@@ -1793,34 +1838,13 @@ step_openclaw_tts() {
     return 1
   fi
 
-  # Configuring the provider is not the same as OpenClaw HAVING it, and the
-  # gap between those two is silent. `tts-local-cli` ships inside OpenClaw as a
-  # bundled extension, but the gateway resolves plugins through a PERSISTED
-  # registry rather than by scanning dist/extensions, and that index goes stale
-  # whenever the extension set on disk changes — `openclaw plugins registry`
-  # calls the reason `source-changed`, which is every OpenClaw upgrade. A stale
-  # index simply does not contain tts-local-cli: the gateway comes up without
-  # it and every spoken reply dies with
-  #     TTS conversion failed: tts-local-cli: no provider registered
-  # while this step, openclaw.json and `capability tts status` all still say
-  # the box is configured correctly.
-  #
-  # Measured on the freshly flashed Orin used for the TASK-383 hardware proof
-  # (2026-08-19): persisted 32/33 plugins against 49/67 current, the gateway
-  # loading only memory-core and ollama, and no on-device speech at all —
-  # `plugins doctor` reported no issues and `plugins enable tts-local-cli`
-  # answered "Plugin not found". Rebuilding the index was the whole fix.
-  if ! as_clawbox "$OPENCLAW_BIN" plugins registry --refresh >/dev/null 2>&1; then
-    echo "  Warning: could not refresh the plugin registry — the provider may not be visible to the gateway" >&2
-  fi
-
-  # Then verify, and refuse to select a provider that is not there. This is the
-  # same rule already applied to the script path above: never leave the box
-  # configured to speak through something that does not exist, because that
-  # configures exactly the silent failure this task removes. Leaving
-  # messages.tts.provider unset is the better outcome — OpenClaw then reports
-  # TTS as unconfigured instead of pretending it is ready.
-  if ! as_clawbox "$OPENCLAW_BIN" plugins info tts-local-cli >/dev/null 2>&1; then
+  # Refuse to select a provider that is not there. Same rule already applied to
+  # the script path above: never leave the box configured to speak through
+  # something that does not exist, because that configures exactly the silent
+  # failure this task removes. Leaving messages.tts.provider unset is the
+  # better outcome — OpenClaw then reports TTS as unconfigured instead of
+  # accepting spoken requests it cannot answer.
+  if ! tts_ensure_provider_registered; then
     echo "  ERROR: the tts-local-cli plugin is not registered even after refreshing the registry." >&2
     echo "         Leaving messages.tts.provider unset rather than pointing the box at a provider" >&2
     echo "         that cannot answer. Diagnose with: openclaw plugins registry; openclaw plugins doctor" >&2

--- a/src/tests/unit/install-tts-provider-registry.test.ts
+++ b/src/tests/unit/install-tts-provider-registry.test.ts
@@ -65,9 +65,12 @@ case "$1 $2" in
 esac
 case "$1" in
   config)
-    # \`config get messages.tts.provider\` must come back empty so the step does
-    # not take its "already configured — preserving" early return.
-    [ "$2" = "get" ] && exit 0
+    # \`config get messages.tts.provider\` decides whether the step takes its
+    # "already configured — preserving" path. Empty by default.
+    if [ "$2" = "get" ]; then
+      [ "$3" = "messages.tts.provider" ] && printf '%s' "\${CURRENT_TTS_PROVIDER:-}"
+      exit 0
+    fi
     exit 0 ;;
 esac
 exit 0
@@ -88,6 +91,7 @@ function runStep(env: Record<string, string> = {}) {
     "as_clawbox() { env \"$@\"; }",
     "is_hermes_edition() { return 1; }",
     extractShellFn(INSTALL_SH, "oc_config_set"),
+    extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
     "step_openclaw_tts",
   ].join("\n");
@@ -138,10 +142,18 @@ describe.skipIf(!hasBash)("step_openclaw_tts registers the provider before selec
     expect(refreshed).toBeLessThan(selected);
   });
 
-  it("verifies the plugin actually registered", () => {
+  it("verifies the plugin actually registered, before selecting it", () => {
     const res = runStep();
-    expect(calls()).toContain("plugins info tts-local-cli");
     expect(res.status).toBe(0);
+
+    const log = calls();
+    const verified = log.findIndex((c) => c === "plugins info tts-local-cli");
+    const selected = log.findIndex((c) => c === "config set messages.tts.provider tts-local-cli");
+
+    expect(verified, "the plugin is never verified").toBeGreaterThanOrEqual(0);
+    // Verifying after the selection would prove nothing: the box would already
+    // be pointing at the provider by the time we found out it is missing.
+    expect(verified).toBeLessThan(selected);
   });
 
   it("refuses to select a provider that is still not registered", () => {
@@ -168,5 +180,59 @@ describe.skipIf(!hasBash)("step_openclaw_tts registers the provider before selec
     const res = runStep({ REFRESH_EXIT: "1" });
     expect(res.status).toBe(0);
     expect(calls()).toContain("config set messages.tts.provider tts-local-cli");
+    // Silently swallowing it would hide the one clue for the next person
+    // debugging a box that went quiet.
+    expect(res.stderr).toMatch(/could not refresh the plugin registry/i);
+  });
+});
+
+/**
+ * The boxes that need this most are the ones that already ran the old step:
+ * they have `messages.tts.provider = tts-local-cli` saved, and the OpenClaw
+ * upgrade they just took is exactly what invalidated the registry. The
+ * seed-if-unset guard returns early for them, so the verification has to live
+ * on that path too — otherwise the fix reaches only fresh installs, and
+ * step_openclaw_tts is in step_post_update precisely for the others.
+ */
+describe.skipIf(!hasBash)("an already-configured box is re-verified, not just preserved", () => {
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "tts-registry-upgrade-"));
+    projectDir = path.join(dir, "project");
+    callsLog = path.join(dir, "calls.log");
+    mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+    writeFileSync(
+      path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+      "#!/usr/bin/env bash\n[ \"${1:-}\" = \"--provider-timeout-ms\" ] && echo 100000\nexit 0\n",
+      { mode: 0o755 },
+    );
+    writeFileSync(path.join(projectDir, "scripts", "install-voice.sh"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+    writeOpenclawStub();
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("refreshes the registry when tts-local-cli is already selected", () => {
+    const res = runStep({ CURRENT_TTS_PROVIDER: "tts-local-cli" });
+    expect(res.status).toBe(0);
+    expect(calls()).toContain("plugins registry --refresh");
+    expect(calls()).toContain("plugins info tts-local-cli");
+  });
+
+  it("fails loudly when the already-selected provider still does not resolve", () => {
+    const res = runStep({ CURRENT_TTS_PROVIDER: "tts-local-cli", INFO_EXIT: "1" });
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/does not resolve/i);
+  });
+
+  it("leaves a different provider alone entirely", () => {
+    // An owner on ElevenLabs must not have their choice touched, and must not
+    // pay for a registry rebuild on every update either.
+    const res = runStep({ CURRENT_TTS_PROVIDER: "elevenlabs" });
+    expect(res.status).toBe(0);
+    expect(calls()).not.toContain("plugins registry --refresh");
+    expect(calls()).not.toContain("config set messages.tts.provider tts-local-cli");
+    expect(res.stdout).toMatch(/preserving/i);
   });
 });

--- a/src/tests/unit/install-tts-provider-registry.test.ts
+++ b/src/tests/unit/install-tts-provider-registry.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * step_openclaw_tts used to write `messages.tts.provider = tts-local-cli` and
+ * stop there. That is not enough to make a box speak, and the way it fails is
+ * silent.
+ *
+ * `tts-local-cli` is a bundled OpenClaw extension, but the gateway resolves
+ * plugins through a PERSISTED registry instead of scanning dist/extensions,
+ * and that registry goes stale whenever the extension set on disk changes
+ * (`openclaw plugins registry` calls the reason `source-changed` — i.e. every
+ * OpenClaw upgrade). A stale index does not contain the plugin, so the gateway
+ * starts without it and every spoken reply fails with
+ *
+ *     TTS conversion failed: tts-local-cli: no provider registered
+ *
+ * while openclaw.json, this install step, and `capability tts status` all keep
+ * insisting the box is configured. Found on the TASK-383 hardware proof
+ * (2026-08-19, freshly flashed Orin): persisted 32/33 plugins against 49/67
+ * current, gateway loading only memory-core and ollama, zero on-device speech
+ * until the index was rebuilt.
+ *
+ * These tests EXECUTE the real step out of install.sh against a stub
+ * `openclaw`, rather than grepping it, so they fail if the refresh or the
+ * verification is dropped — and so they cannot pass against a rewrite that
+ * merely keeps the words.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+function extractShellFn(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end + 2);
+}
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+let dir: string;
+let projectDir: string;
+let callsLog: string;
+
+/**
+ * A stub `openclaw` that logs every invocation and whose two interesting
+ * subcommands are scripted per test:
+ *   plugins registry --refresh  -> exit $REFRESH_EXIT
+ *   plugins info tts-local-cli  -> exit $INFO_EXIT   (1 == "Plugin not found")
+ */
+function writeOpenclawStub(): string {
+  const bin = path.join(dir, "openclaw");
+  writeFileSync(
+    bin,
+    `#!/usr/bin/env bash
+echo "$*" >> "${callsLog}"
+case "$1 $2" in
+  "plugins registry") exit \${REFRESH_EXIT:-0} ;;
+  "plugins info")     exit \${INFO_EXIT:-0} ;;
+esac
+case "$1" in
+  config)
+    # \`config get messages.tts.provider\` must come back empty so the step does
+    # not take its "already configured — preserving" early return.
+    [ "$2" = "get" ] && exit 0
+    exit 0 ;;
+esac
+exit 0
+`,
+    { mode: 0o755 },
+  );
+  return bin;
+}
+
+/** Run the real step_openclaw_tts with install.sh's real oc_config_set. */
+function runStep(env: Record<string, string> = {}) {
+  const program = [
+    "set -uo pipefail",
+    `PROJECT_DIR="${projectDir}"`,
+    `OPENCLAW_BIN="${path.join(dir, "openclaw")}"`,
+    "CLAWBOX_USER=clawbox",
+    // as_clawbox drops privileges on a device; here it just runs the command.
+    "as_clawbox() { env \"$@\"; }",
+    "is_hermes_edition() { return 1; }",
+    extractShellFn(INSTALL_SH, "oc_config_set"),
+    extractShellFn(INSTALL_SH, "step_openclaw_tts"),
+    "step_openclaw_tts",
+  ].join("\n");
+
+  return spawnSync("bash", ["-c", program], {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  });
+}
+
+const calls = () =>
+  existsSync(callsLog) ? readFileSync(callsLog, "utf-8").trim().split("\n").filter(Boolean) : [];
+
+describe.skipIf(!hasBash)("step_openclaw_tts registers the provider before selecting it", () => {
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "tts-registry-"));
+    projectDir = path.join(dir, "project");
+    callsLog = path.join(dir, "calls.log");
+    mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+    // The step refuses to configure TTS against a script that is not
+    // executable, and asks that script for the provider timeout.
+    writeFileSync(
+      path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+      "#!/usr/bin/env bash\n[ \"${1:-}\" = \"--provider-timeout-ms\" ] && echo 100000\nexit 0\n",
+      { mode: 0o755 },
+    );
+    // Piper install is exercised by its own tests; here it must not run.
+    writeFileSync(path.join(projectDir, "scripts", "install-voice.sh"), "#!/usr/bin/env bash\nexit 0\n", {
+      mode: 0o755,
+    });
+    writeOpenclawStub();
+  });
+
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  it("refreshes the plugin registry and selects the provider", () => {
+    const res = runStep();
+    expect(res.status).toBe(0);
+
+    const log = calls();
+    const refreshed = log.findIndex((c) => c.startsWith("plugins registry --refresh"));
+    const selected = log.findIndex((c) => c === "config set messages.tts.provider tts-local-cli");
+
+    expect(refreshed, "the registry is never rebuilt").toBeGreaterThanOrEqual(0);
+    expect(selected, "the provider is never selected").toBeGreaterThanOrEqual(0);
+    // Ordering is the point: refreshing after selection would leave the box
+    // pointing at an unregistered provider until something restarted it.
+    expect(refreshed).toBeLessThan(selected);
+  });
+
+  it("verifies the plugin actually registered", () => {
+    const res = runStep();
+    expect(calls()).toContain("plugins info tts-local-cli");
+    expect(res.status).toBe(0);
+  });
+
+  it("refuses to select a provider that is still not registered", () => {
+    // The failure this whole change exists to stop: config written, provider
+    // named, nothing able to answer.
+    const res = runStep({ INFO_EXIT: "1" });
+
+    expect(res.status, "an unregistered provider must fail the step").not.toBe(0);
+    expect(calls()).not.toContain("config set messages.tts.provider tts-local-cli");
+    expect(res.stderr).toMatch(/not registered/i);
+  });
+
+  it("still writes the provider definition when registration fails", () => {
+    // Only the *selection* is gated. The definition is harmless on its own and
+    // keeping it means a later refresh + re-run has nothing left to redo.
+    runStep({ INFO_EXIT: "1" });
+    expect(calls().some((c) => c.startsWith("config set messages.tts.providers.tts-local-cli"))).toBe(true);
+  });
+
+  it("treats a failed refresh as a warning, not a failure, when the plugin is there anyway", () => {
+    // An older OpenClaw without `plugins registry` must not cost a box its
+    // voice — what matters is whether the provider resolves, not how it got
+    // there.
+    const res = runStep({ REFRESH_EXIT: "1" });
+    expect(res.status).toBe(0);
+    expect(calls()).toContain("config set messages.tts.provider tts-local-cli");
+  });
+});


### PR DESCRIPTION
Follow-up to #398, found by running that PR's Step 5 hardware proof on a real Orin Nano (192.168.50.102) after it merged.

## What was broken

#398 configures `messages.tts.provider = tts-local-cli`. On the box, that was necessary and not sufficient — every spoken reply failed:

```
TTS conversion failed: tts-local-cli: no provider registered; openai: not configured; ...
```

Gateway log: `[ws] ⇄ res ✗ tts.convert errorCode=UNAVAILABLE`. Meanwhile `openclaw.json`, `capability tts status` and the install log all agreed the box was configured, and `clawbox-tts.sh` produced perfect audio when called directly. That is the same silent-failure class TASK-383 set out to remove, moved one layer up.

## Root cause

`tts-local-cli` is a bundled extension, but the gateway resolves plugins through a **persisted registry** rather than scanning `dist/extensions`, and that index goes stale whenever the extension set changes on disk — `openclaw plugins registry` names the reason `source-changed`, which is every OpenClaw upgrade.

On the proof box:

```
State: stale
Current:   49/67 enabled plugins
Persisted: 32/33 enabled plugins
Refresh reasons: source-changed
```

The gateway came up with only `memory-core, ollama`. `plugins doctor` reported no issues, and `plugins enable tts-local-cli` answered `Plugin not found`. Rebuilding the index was the entire fix:

```
openclaw plugins registry --refresh     # 49/67 indexed, tts-local-cli Status: loaded
systemctl restart clawbox-gateway.service
openclaw capability tts convert --gateway ...   # provider: tts-local-cli, 187552 bytes
```

whisper transcript of that gateway-produced file: *"The clawbox is speaking through open claw with no cloud and no GPU."*

Because the trigger is `source-changed`, this is not a freshly-flashed-box quirk — any device that updates OpenClaw can land in it.

## The change

`step_openclaw_tts` now refreshes the registry and then **verifies the plugin resolved**, and refuses to name a provider that did not. That is the rule the step already applied to the script path — never leave the box configured to speak through something that does not exist — applied to the provider too. Leaving `messages.tts.provider` unset is the better failure: OpenClaw reports TTS as unconfigured instead of accepting spoken requests it cannot answer.

A failed *refresh* stays a warning; what matters is whether the provider resolves, not how it got there, so an OpenClaw without the subcommand does not cost a box its voice.

Ordering matters and is pinned: refresh/verify happen **before** the provider is selected. On the update path `step_gateway_setup` restarts the gateway right after this step, so the rebuilt index takes effect within the same update.

## Tests

`src/tests/unit/install-tts-provider-registry.test.ts` executes the real `step_openclaw_tts` extracted from `install.sh` against a stub `openclaw`, so it fails if either half is dropped rather than passing against a rewrite that keeps the words. Verified both ways: 5/5 pass with the change, and the 3 load-bearing cases fail without it.

Full suite: 206 files / 2679 tests green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech provider setup by refreshing and verifying availability before activation.
  * Prevented unavailable providers from being selected and clearly reported setup failures.
  * Preserved existing provider configuration when activation is blocked.
  * Allowed setup to continue when availability checks cannot refresh, provided the provider remains available.
  * Revalidated previously selected providers while preserving unrelated provider selections.

* **Tests**
  * Added coverage for provider availability, selection, failure handling, configuration preservation, and setup ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->