### PR TITLE
docs: feature the Bootable USBs review video on the docs homepage

### DIFF
--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -10,10 +10,7 @@ summary: "ClawBox is pre-configured AI hardware that runs OpenClaw or Hermes Age
 </p>
 
 <Tip>
-  📺 **Hands-on walkthrough (English voice-over)** — *"ClawBox: A Ferramenta que Muda Como Você Trabalha,"* including a manual ClawBox install via `installer.sh` → [watch on YouTube](https://youtu.be/KMDTF7N8uzU).
-
-  📺 **Watch an independent review** — maker Kevin McAleer breaks down *"What is ClawBox, and who is it for?"* → [watch on YouTube](https://www.youtube.com/live/rOkt0Ev-dQ0).
-
+  📺 **Watch an independent review** — *"I Tested ClawBox — Is This the Future of Personal AI?"* by Bootable USBs → [watch on YouTube](https://www.youtube.com/watch?v=1cekuQjVikU).
 </Tip>
 
 <Columns cols={2}>

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -11,6 +11,9 @@ summary: "ClawBox is pre-configured AI hardware that runs OpenClaw or Hermes Age
 
 <Tip>
   📺 **Watch an independent review** — *"I Tested ClawBox — Is This the Future of Personal AI?"* by Bootable USBs → [watch on YouTube](https://www.youtube.com/watch?v=1cekuQjVikU).
+
+  📺 **Hands-on walkthrough (English voice-over)** — *"ClawBox: A Ferramenta que Muda Como Você Trabalha,"* including a manual ClawBox install via `installer.sh` → [watch on YouTube](https://youtu.be/KMDTF7N8uzU).
+
 </Tip>
 
 <Columns cols={2}>


### PR DESCRIPTION
Features the new reference video on the docs homepage: ["I Tested ClawBox — Is This the Future of Personal AI?" by Bootable USBs](https://www.youtube.com/watch?v=1cekuQjVikU), listed first.

Keeps Caio Delgado's hands-on walkthrough; removes the Kevin McAleer review link (per Krasi's call).

Content-only change; docs.clawbox.com picks it up on the next docs deploy after this reaches main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the homepage tip to link to an independent Bootable USBs review.
  - Preserved the existing hands-on walkthrough.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->