### PR TITLE
Warn when voice can leave the box (TASK-409)

### DIFF
--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -15,6 +15,7 @@ import { extractImageFilesFromClipboard } from '@/lib/clipboard'
 import { useT } from '@/lib/i18n'
 import { useChatToolCalls, ToolCallPills } from '@/lib/chat-tool-events'
 import { prettifyAssistantText, isSentinel } from '@/lib/chat-sentinels'
+import { CloudTtsWarning } from '@/components/CloudTtsWarning'
 
 
 function extractText(msg: unknown): string {
@@ -566,6 +567,8 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
         scrollbarColor: 'rgba(255,255,255,0.1) transparent',
       }}>
         <style>{`@keyframes chatapp-spin { to { transform: rotate(360deg) } } @keyframes chatapp-blink { 50% { opacity: 0 } } @keyframes chatapp-bounce-dot { 0%, 80%, 100% { transform: translateY(0) } 40% { transform: translateY(-5px) } }`}</style>
+
+        <CloudTtsWarning connected={status === 'connected'} request={wsRequest} />
 
         {status === 'connecting' && messages.length === 0 && (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, gap: 12, color: 'rgba(255,255,255,0.4)', fontSize: 13 }}>

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -175,6 +175,7 @@ import { useClawboxLogin } from '@/lib/use-clawbox-login'
 import { isClawboxAiProModel, CLAWBOX_AI_MODEL_BY_TIER } from '@/lib/clawbox-ai-models'
 import { PORTAL_DASHBOARD_URL } from '@/lib/max-subscription'
 import { HeaderDropdown } from '@/components/HeaderDropdown'
+import { CloudTtsWarning } from '@/components/CloudTtsWarning'
 import { fetchHarness } from '@/lib/client-harness'
 import { shortModelPillLabel, REASONING_PILL_ICON } from '@/lib/chat-header-pills'
 
@@ -2273,6 +2274,8 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         scrollbarWidth: 'thin',
         scrollbarColor: 'rgba(255,255,255,0.1) transparent',
       }}>
+        <CloudTtsWarning connected={status === 'connected'} request={wsRequest} />
+
         {(status === 'connecting' || reloadingSkill) && (reloadingSkill || messages.length === 0) && (
           <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', flex: 1, gap: 14, color: 'rgba(255,255,255,0.5)', fontSize: 13 }}>
             <style>{`@keyframes spin { to { transform: rotate(360deg) } } @keyframes dots { 0%,20% { content: '' } 40% { content: '.' } 60% { content: '..' } 80%,100% { content: '...' } } @keyframes clawReloadFill { from { transform: scaleX(0.04) } to { transform: scaleX(0.9) } }`}</style>

--- a/src/components/CloudTtsWarning.tsx
+++ b/src/components/CloudTtsWarning.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { buildCloudTtsWarning } from '@/lib/tts-cloud-warning'
+
+interface CloudTtsWarningProps {
+  connected: boolean
+  request: (method: string, params: unknown) => Promise<unknown>
+}
+
+/**
+ * A live privacy notice for the gateway's actual TTS provider chain.
+ *
+ * This is intentionally a chat banner, not a persisted transcript message:
+ * it describes runtime configuration, can change after a gateway restart,
+ * and must not be copied into the agent's conversation context. Both ClawBox
+ * chat surfaces use this component so the compact popup cannot hide a warning
+ * that the full chat shows (or vice versa).
+ */
+export function CloudTtsWarning({ connected, request }: CloudTtsWarningProps) {
+  const [warning, setWarning] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!connected) {
+      return () => { cancelled = true }
+    }
+
+    void request('tts.status', {})
+      .then((payload) => {
+        if (!cancelled) setWarning(buildCloudTtsWarning(payload))
+      })
+      .catch(() => {
+        // Older gateways may not expose tts.status. Chat must remain usable;
+        // the next successful reconnect will try again after an update.
+        if (!cancelled) setWarning(null)
+      })
+
+    return () => { cancelled = true }
+  }, [connected, request])
+
+  if (!connected || !warning) return null
+
+  return (
+    <div
+      role="alert"
+      aria-live="polite"
+      style={{
+        padding: '8px 12px',
+        borderRadius: 10,
+        background: 'rgba(245,158,11,0.12)',
+        border: '1px solid rgba(245,158,11,0.35)',
+        color: '#fbbf24',
+        fontSize: 12,
+        lineHeight: 1.45,
+      }}
+    >
+      ⚠️ {warning}
+    </div>
+  )
+}

--- a/src/components/CloudTtsWarning.tsx
+++ b/src/components/CloudTtsWarning.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useState } from 'react'
 import { buildCloudTtsWarning } from '@/lib/tts-cloud-warning'
 
+const TTS_STATUS_REFRESH_MS = 60_000
+
 interface CloudTtsWarningProps {
   connected: boolean
   request: (method: string, params: unknown) => Promise<unknown>
@@ -27,17 +29,34 @@ export function CloudTtsWarning({ connected, request }: CloudTtsWarningProps) {
       return () => { cancelled = true }
     }
 
-    void request('tts.status', {})
-      .then((payload) => {
+    let refreshTimer: number | null = null
+    const refreshWarning = async () => {
+      try {
+        const payload = await request('tts.status', {})
         if (!cancelled) setWarning(buildCloudTtsWarning(payload))
-      })
-      .catch(() => {
+      } catch {
         // Older gateways may not expose tts.status. Chat must remain usable;
-        // the next successful reconnect will try again after an update.
+        // a later refresh or reconnect can recover after an update or a
+        // transient gateway error.
         if (!cancelled) setWarning(null)
-      })
+      } finally {
+        // Schedule only after the previous request settles. The gateway can be
+        // busy with an agent turn for longer than the refresh interval, so a
+        // fixed interval would accumulate overlapping status calls.
+        if (!cancelled) {
+          refreshTimer = window.setTimeout(refreshWarning, TTS_STATUS_REFRESH_MS)
+        }
+      }
+    }
 
-    return () => { cancelled = true }
+    void refreshWarning()
+    // messages.tts preferences can hot-reload without dropping the chat WebSocket.
+    // Refresh periodically so a newly enabled cloud provider cannot leave a stale
+    // local-only state on screen until the user reconnects.
+    return () => {
+      cancelled = true
+      if (refreshTimer !== null) window.clearTimeout(refreshTimer)
+    }
   }, [connected, request])
 
   if (!connected || !warning) return null

--- a/src/lib/tts-cloud-warning.ts
+++ b/src/lib/tts-cloud-warning.ts
@@ -1,0 +1,112 @@
+export interface TtsProviderState {
+  id?: unknown
+  label?: unknown
+  configured?: unknown
+}
+
+export interface TtsStatusPayload {
+  enabled?: unknown
+  provider?: unknown
+  fallbackProviders?: unknown
+  providerStates?: unknown
+}
+
+const LOCAL_PROVIDER_IDS = new Set([
+  'tts-local-cli',
+])
+
+function asProviderId(value: unknown): string | null {
+  if (typeof value !== 'string') return null
+  const id = value.trim().toLowerCase()
+  return id || null
+}
+
+function isLocalProvider(id: string): boolean {
+  if (LOCAL_PROVIDER_IDS.has(id)) return true
+
+  // Third-party local providers are allowed. Treat an explicitly local/CLI
+  // provider as local even when it was registered after this ClawBox build;
+  // everything else is conservatively remote because the privacy-safe error
+  // is to warn about an unknown provider, not to silently call it local.
+  return /(?:^|[-_.])(local|cli|piper|kokoro)(?:$|[-_.])/.test(id)
+}
+
+interface ProviderIndex {
+  labels: Map<string, string>
+  configured: Set<string>
+  hasStates: boolean
+}
+
+function providerIndex(payload: TtsStatusPayload): ProviderIndex {
+  const labels = new Map<string, string>()
+  const configured = new Set<string>()
+  if (!Array.isArray(payload.providerStates)) {
+    return { labels, configured, hasStates: false }
+  }
+
+  for (const raw of payload.providerStates as TtsProviderState[]) {
+    if (!raw || typeof raw !== 'object') continue
+    const id = asProviderId(raw.id)
+    if (!id) continue
+    const label = typeof raw.label === 'string' && raw.label.trim()
+      ? raw.label.trim()
+      : id
+    labels.set(id, label)
+    if (raw.configured === true) configured.add(id)
+  }
+  return { labels, configured, hasStates: true }
+}
+
+function readableList(values: string[]): string {
+  if (values.length <= 1) return values[0] ?? ''
+  if (values.length === 2) return `${values[0]} and ${values[1]}`
+  return `${values.slice(0, -1).join(', ')}, and ${values.at(-1)}`
+}
+
+/**
+ * Build the privacy notice shown in ClawBox chat from OpenClaw's live
+ * `tts.status` response.
+ *
+ * The status call already filters fallbackProviders to providers that are
+ * configured. We deliberately do not infer from static ClawBox config: the
+ * warning must follow the gateway's current runtime chain after upgrades and
+ * plugin-registry refreshes.
+ */
+export function buildCloudTtsWarning(rawPayload: unknown): string | null {
+  if (!rawPayload || typeof rawPayload !== 'object' || Array.isArray(rawPayload)) return null
+  const payload = rawPayload as TtsStatusPayload
+  if (payload.enabled !== true) return null
+
+  const primary = asProviderId(payload.provider)
+  const index = providerIndex(payload)
+  const fallbacks = Array.isArray(payload.fallbackProviders)
+    ? payload.fallbackProviders
+        .map(asProviderId)
+        .filter((id): id is string => Boolean(id))
+    : []
+
+  // `provider` is the selected preference even when it is unavailable. Do not
+  // say an unconfigured cloud primary "uses" the cloud; in that case only the
+  // configured fallbackProviders are candidates. Older gateways without
+  // providerStates keep the conservative warning.
+  const effectivePrimary = primary && (!index.hasStates || index.configured.has(primary))
+    ? primary
+    : null
+  const providerChain = [effectivePrimary, ...fallbacks]
+    .filter((id): id is string => Boolean(id))
+  const remoteProviders = [...new Set(providerChain.filter(id => !isLocalProvider(id)))]
+
+  if (remoteProviders.length === 0) return null
+
+  const providerNames = readableList(remoteProviders.map(id => index.labels.get(id) ?? id))
+  const primaryIsRemote = effectivePrimary ? remoteProviders.includes(effectivePrimary) : false
+
+  if (primaryIsRemote) {
+    return `Privacy notice: Voice uses ${providerNames} cloud TTS. Text sent for speech leaves this ClawBox.`
+  }
+
+  const unavailableProvider = primary && isLocalProvider(primary)
+    ? 'local speech'
+    : 'the selected voice provider'
+  return `Privacy notice: If ${unavailableProvider} is unavailable, voice may use ${providerNames} cloud TTS. Text sent for speech may leave this ClawBox.`
+}

--- a/src/tests/components/cloud-tts-warning.test.tsx
+++ b/src/tests/components/cloud-tts-warning.test.tsx
@@ -1,8 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render, waitFor } from '@/tests/helpers/test-utils'
 import { CloudTtsWarning } from '@/components/CloudTtsWarning'
 
 describe('CloudTtsWarning', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('reads the live gateway TTS chain and shows the privacy notice', async () => {
     const request = vi.fn().mockResolvedValue({
       enabled: true,
@@ -39,5 +43,43 @@ describe('CloudTtsWarning', () => {
 
     await waitFor(() => expect(request).toHaveBeenCalledOnce())
     expect(queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('refreshes the warning when TTS configuration hot-reloads', async () => {
+    vi.useFakeTimers()
+    const request = vi.fn()
+      .mockResolvedValueOnce({
+        enabled: true,
+        provider: 'tts-local-cli',
+        fallbackProviders: [],
+        providerStates: [
+          { id: 'tts-local-cli', label: 'Local CLI', configured: true },
+        ],
+      })
+      .mockResolvedValueOnce({
+        enabled: true,
+        provider: 'tts-local-cli',
+        fallbackProviders: ['openai'],
+        providerStates: [
+          { id: 'tts-local-cli', label: 'Local CLI', configured: true },
+          { id: 'openai', label: 'OpenAI', configured: true },
+        ],
+      })
+
+    const { queryByRole, getByRole } = render(
+      <CloudTtsWarning connected request={request} />,
+    )
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+    expect(queryByRole('alert')).not.toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    await vi.waitFor(() => {
+      expect(getByRole('alert')).toHaveTextContent(
+        'voice may use OpenAI cloud TTS',
+      )
+    })
+    expect(request).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/tests/components/cloud-tts-warning.test.tsx
+++ b/src/tests/components/cloud-tts-warning.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from '@/tests/helpers/test-utils'
+import { CloudTtsWarning } from '@/components/CloudTtsWarning'
+
+describe('CloudTtsWarning', () => {
+  it('reads the live gateway TTS chain and shows the privacy notice', async () => {
+    const request = vi.fn().mockResolvedValue({
+      enabled: true,
+      provider: 'tts-local-cli',
+      fallbackProviders: ['microsoft'],
+      providerStates: [
+        { id: 'tts-local-cli', label: 'Local CLI', configured: true },
+        { id: 'microsoft', label: 'Microsoft', configured: true },
+      ],
+    })
+
+    const { getByRole } = render(<CloudTtsWarning connected request={request} />)
+
+    await waitFor(() => {
+      expect(getByRole('alert')).toHaveTextContent(
+        'If local speech is unavailable, voice may use Microsoft cloud TTS',
+      )
+    })
+    expect(request).toHaveBeenCalledOnce()
+    expect(request).toHaveBeenCalledWith('tts.status', {})
+  })
+
+  it('does not query the gateway before chat connects', () => {
+    const request = vi.fn()
+    const { queryByRole } = render(<CloudTtsWarning connected={false} request={request} />)
+
+    expect(request).not.toHaveBeenCalled()
+    expect(queryByRole('alert')).not.toBeInTheDocument()
+  })
+
+  it('keeps chat usable when an older gateway has no tts.status method', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('Method not found'))
+    const { queryByRole } = render(<CloudTtsWarning connected request={request} />)
+
+    await waitFor(() => expect(request).toHaveBeenCalledOnce())
+    expect(queryByRole('alert')).not.toBeInTheDocument()
+  })
+})

--- a/src/tests/unit/tts-cloud-warning.test.ts
+++ b/src/tests/unit/tts-cloud-warning.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { buildCloudTtsWarning } from '@/lib/tts-cloud-warning'
+
+const states = [
+  { id: 'tts-local-cli', label: 'Local CLI', configured: true },
+  { id: 'microsoft', label: 'Microsoft', configured: true },
+  { id: 'openai', label: 'OpenAI', configured: true },
+]
+
+describe('buildCloudTtsWarning', () => {
+  it('warns when local TTS can fall back to a configured cloud provider', () => {
+    expect(buildCloudTtsWarning({
+      enabled: true,
+      provider: 'tts-local-cli',
+      fallbackProviders: ['microsoft'],
+      providerStates: states,
+    })).toBe(
+      'Privacy notice: If local speech is unavailable, voice may use Microsoft cloud TTS. Text sent for speech may leave this ClawBox.',
+    )
+  })
+
+  it('warns directly when the selected provider is cloud TTS', () => {
+    expect(buildCloudTtsWarning({
+      enabled: true,
+      provider: 'openai',
+      fallbackProviders: ['microsoft'],
+      providerStates: states,
+    })).toBe(
+      'Privacy notice: Voice uses OpenAI and Microsoft cloud TTS. Text sent for speech leaves this ClawBox.',
+    )
+  })
+
+  it('does not claim an unconfigured cloud preference is active', () => {
+    expect(buildCloudTtsWarning({
+      enabled: true,
+      provider: 'openai',
+      fallbackProviders: ['microsoft'],
+      providerStates: states.map(state => (
+        state.id === 'openai' ? { ...state, configured: false } : state
+      )),
+    })).toBe(
+      'Privacy notice: If the selected voice provider is unavailable, voice may use Microsoft cloud TTS. Text sent for speech may leave this ClawBox.',
+    )
+  })
+
+  it('does not warn when automatic TTS is disabled', () => {
+    expect(buildCloudTtsWarning({
+      enabled: false,
+      provider: 'tts-local-cli',
+      fallbackProviders: ['microsoft'],
+      providerStates: states,
+    })).toBeNull()
+  })
+
+  it('does not warn for an entirely local provider chain', () => {
+    expect(buildCloudTtsWarning({
+      enabled: true,
+      provider: 'tts-local-cli',
+      fallbackProviders: ['custom-piper-local'],
+      providerStates: states,
+    })).toBeNull()
+  })
+
+  it('handles malformed status payloads without inventing a warning', () => {
+    expect(buildCloudTtsWarning({ enabled: true, provider: null, fallbackProviders: 'microsoft' })).toBeNull()
+    expect(buildCloudTtsWarning(null)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- keep OpenClaw's cloud TTS fallback enabled, per the TASK-409 product decision
- show a live privacy warning in both the full ClawBox chat and compact chat popup whenever the enabled TTS provider chain includes a cloud provider
- derive the warning from `tts.status`, so it follows the gateway's configured runtime providers after upgrades
- keep older gateways usable when `tts.status` is unavailable

## Verification

- `bun run test` — 2,691 passed
- focused warning tests — 9 passed
- `bun run build` — successful
- ESLint on all new files — clean

TASK-409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added privacy warnings when text-to-speech uses a cloud provider.
  * Warnings appear in both the main chat and chat popup.
  * Alerts identify cloud-based fallback providers when applicable.
  * Local-only, disabled, or unavailable text-to-speech configurations remain warning-free.
  * Status checks occur only while connected and handle unsupported gateways gracefully.
  * Warnings refresh automatically when text-to-speech settings change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->