### PR TITLE
Install the Kokoro GPU engine the installer already claimed to configure (TASK-420)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1786,8 +1786,42 @@ step_openclaw_tts() {
   is_hermes_edition && { echo "  [hermes edition] skipping on-device TTS"; return 0; }
   local TTS_SCRIPT="$PROJECT_DIR/scripts/openclaw/clawbox-tts.sh"
 
-  bash "$PROJECT_DIR/scripts/install-voice.sh" --piper-only \
-    || echo "  Warning: Piper fallback install failed (non-fatal) — Kokoro still works, but a GPU failure will be silent"
+  # --tts-only, NOT --piper-only. --piper-only installs the CPU fallback and
+  # nothing else, so every box we shipped ran on Piper while this step printed
+  # "Kokoro GPU" — on freshly flashed hardware neither `import kokoro` nor
+  # `import torch` resolved and no kokoro-server unit existed (TASK-420).
+  # --tts-only installs the CUDA Kokoro stack too, and deliberately not the STT
+  # half of that script (faster-whisper + the CTranslate2 source build, about
+  # an hour on an Orin) because this step also runs from step_post_update on
+  # every in-app update.
+  #
+  # Its exit code is the contract: it never fails the install over the GPU
+  # path, it reports whether Kokoro is actually there so the summary below can
+  # tell the truth instead of asserting it.
+  local VOICE_RC=0
+  bash "$PROJECT_DIR/scripts/install-voice.sh" --tts-only || VOICE_RC=$?
+  local KOKORO_READY=false KOKORO_REASON=""
+  case "$VOICE_RC" in
+    0)  KOKORO_READY=true ;;
+    10) KOKORO_REASON="no CUDA toolkit on this board" ;;
+    11) KOKORO_REASON="no Jetson CUDA build for this CPU architecture" ;;
+    12) KOKORO_REASON="the Kokoro GPU install failed, see the log above" ;;
+    1)  KOKORO_REASON="the voice install did not complete"
+        # Reworded for TASK-420: this used to say "Kokoro still works, but a
+        # GPU failure will be silent", which was written when Kokoro was
+        # assumed present. Losing Piper is only survivable while Kokoro works.
+        echo "  Warning: the Piper CPU fallback did not install (non-fatal) — if Kokoro is unavailable or its GPU path fails, the box answers speech with silence" >&2
+        ;;
+    *)  KOKORO_REASON="install-voice.sh exited $VOICE_RC" ;;
+  esac
+  if [ "$KOKORO_READY" = true ]; then
+    echo "  Kokoro GPU TTS installed (Piper CPU fallback behind it)"
+  else
+    # No engine claim here: on VOICE_RC=1 the Piper half is the thing that
+    # failed, so "Piper is the active engine" would be its own small lie. The
+    # summary at the end of the step names the engine.
+    echo "  Kokoro GPU TTS NOT installed: $KOKORO_REASON"
+  fi
 
   # Seed-if-unset, same contract as the primary model above: an owner who has
   # chosen ElevenLabs (or turned TTS off) must not have it silently reset by
@@ -1868,7 +1902,16 @@ step_openclaw_tts() {
     echo "  ERROR: could not select the tts-local-cli provider" >&2
     return 1
   fi
-  echo "  On-device TTS configured (Kokoro GPU, Piper fallback)"
+  # Only claim Kokoro when Kokoro is genuinely there. This line asserting
+  # "Kokoro GPU" unconditionally is what kept TASK-420 invisible: three
+  # freshly flashed boxes printed it while running entirely on Piper.
+  if [ "$KOKORO_READY" = true ]; then
+    echo "  On-device TTS configured (Kokoro GPU, Piper fallback)"
+  elif [ "$VOICE_RC" -eq 1 ]; then
+    echo "  On-device TTS configured, but NO engine is confirmed installed ($KOKORO_REASON)"
+  else
+    echo "  On-device TTS configured (Piper CPU only — $KOKORO_REASON)"
+  fi
 }
 
 step_setup_config() {

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -20,10 +20,6 @@ PIP="pip3"
 
 # JP v61 wheel works on JetPack 6.1+ (including 6.2.x).
 JETSON_TORCH_URL="https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl"
-# libcusparseLt (shipped by the nvidia-cusparselt-cu12 wheel) is not on the
-# default loader path, so `import torch` fails without this. The systemd user
-# units and every python invocation below need it.
-KOKORO_LD_PATH="/home/clawbox/.local/lib:/home/clawbox/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib:/usr/local/cuda/lib64"
 SYSTEMD_USER="$CLAWBOX_HOME/.config/systemd/user"
 CUDA_HOME_DIR="${CLAWBOX_CUDA_HOME:-/usr/local/cuda}"
 # Written only after a COMPLETE Kokoro install, and read as the idempotence
@@ -36,7 +32,84 @@ CUDA_HOME_DIR="${CLAWBOX_CUDA_HOME:-/usr/local/cuda}"
 # repeated install, never correctness.
 KOKORO_STAMP="$CLAWBOX_HOME/.cache/clawbox/kokoro-installed"
 # Bump when a step below changes in a way an already-stamped box must redo.
-KOKORO_STAMP_VERSION="1"
+# 2: the numpy floor. A box stamped "1" installed `numpy<2`, which was a no-op
+#    against the board's apt numpy 1.21.5 — and it passes BOTH halves of the
+#    gate below, because `import kokoro, torch` succeeds on such a box (torch
+#    only raises "Numpy is not available" later, at the tensor conversion). So
+#    without this bump the fix reaches every box except the ones that have the
+#    defect. The cost of the bump is one repeat of a ~4 minute install.
+KOKORO_STAMP_VERSION="2"
+
+# ── The CUDA loader path ────────────────────────────────────────────────────
+# libcusparseLt.so.0 ships INSIDE the nvidia-cusparselt-cu12 wheel, under the
+# clawbox user's site-packages, where no loader looks by default, so without
+# these directories `import torch` dies with
+#   ImportError: libcusparseLt.so.0: cannot open shared object file
+# which is the exact failure TASK-420 exists to remove. The systemd user units,
+# the ~/.bashrc export and every python invocation below need them.
+#
+# DERIVED from $CLAWBOX_HOME and $CUDA_HOME_DIR, never pinned. The literal this
+# replaced said /home/clawbox and python3.10, and it was baked verbatim into
+# kokoro-server.service; a box with another CLAWBOX_HOME, or the same Jetson
+# after a python minor-version bump, got a unit and a clawbox_python pointing
+# at a directory that does not exist — that ImportError again, with the install
+# still reporting success. scripts/openclaw/clawbox-tts.sh resolves the same
+# three directories the same way in its own kokoro_ld_path(); this is
+# deliberately the same shape rather than a third spelling of it.
+#
+# The callers need DIFFERENT semantics, so the mode is explicit:
+#
+#   present   keep only directories that are on disk right now. For commands
+#             this script runs itself, where naming a directory that does not
+#             exist yet adds nothing. It is what clawbox-tts.sh does, because
+#             it runs at speech time when the wheels are installed by
+#             definition.
+#
+#   expected  keep the site-packages entry even when nothing is unpacked there
+#             yet, resolving the python version from the interpreter that will
+#             run pip. The unit and ~/.bashrc are written ONCE and then read
+#             for the LIFE of the box, and they are written before (or despite)
+#             a failed wheel install — so a strict "skip what is missing"
+#             filter there would silently produce a unit with no cusparselt
+#             entry at all, which is the same broken import arrived at more
+#             quietly.
+#
+# Both modes join with ${out:+$out:} because an EMPTY entry in LD_LIBRARY_PATH
+# means "the current directory" to the loader, which is not somewhere to
+# resolve .so files from.
+kokoro_ld_path() {
+  local mode="${1:-present}" out="" d cusparselt=""
+  # A python* glob, not a pinned python3.10: the minor version is a property of
+  # the box. A directory that really exists always outranks a predicted one.
+  for d in "$CLAWBOX_HOME"/.local/lib/python*/site-packages/nvidia/cusparselt/lib; do
+    if [ -d "$d" ]; then cusparselt="$d"; fi
+  done
+  if [ -z "$cusparselt" ] && [ "$mode" = "expected" ]; then
+    cusparselt=$(kokoro_expected_cusparselt_dir)
+  fi
+  local dirs=("$CLAWBOX_HOME/.local/lib")
+  if [ -n "$cusparselt" ]; then dirs+=("$cusparselt"); fi
+  dirs+=("$CUDA_HOME_DIR/lib64")
+  for d in "${dirs[@]}"; do
+    if [ "$mode" = "present" ] && [ ! -d "$d" ]; then continue; fi
+    out="${out:+$out:}$d"
+  done
+  printf '%s' "$out"
+}
+
+# Where pip --user is going to unpack that wheel on THIS box. Asked of the
+# interpreter that will run pip, so the answer carries the python minor version
+# the box actually has instead of the one this file was written against. Prints
+# nothing if the interpreter cannot be reached or answers something
+# unrecognisable — leaving the entry out is honest, inventing a version is not.
+kokoro_expected_cusparselt_dir() {
+  local ver
+  ver=$(su - "$CLAWBOX_USER" -c \
+    'python3 -c "import sys; print(\"python%d.%d\" % sys.version_info[:2])"' 2>/dev/null | tail -1) || ver=""
+  case "$ver" in
+    python[0-9]*.[0-9]*) printf '%s' "$CLAWBOX_HOME/.local/lib/$ver/site-packages/nvidia/cusparselt/lib" ;;
+  esac
+}
 
 # ── Piper (CPU fallback engine) ─────────────────────────────────────────────
 # Piper is what keeps a spoken reply from becoming silence. Kokoro owns the
@@ -234,9 +307,14 @@ pip_as_clawbox() {
 }
 
 # Run a python3 snippet as the clawbox user with the CUDA library path set.
+# "present": these commands run here and now. The export is skipped entirely
+# when nothing resolved, because `LD_LIBRARY_PATH=:$LD_LIBRARY_PATH` hands the
+# loader an empty leading entry — the current directory.
 clawbox_python() {
+  local ld
+  ld=$(kokoro_ld_path present)
   su - "$CLAWBOX_USER" -c "
-    export LD_LIBRARY_PATH=$KOKORO_LD_PATH:\$LD_LIBRARY_PATH
+    ${ld:+export LD_LIBRARY_PATH=\"$ld\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\"}
     python3 -c \"$1\""
 }
 
@@ -244,11 +322,19 @@ install_cuda_torch() {
   echo "  Installing CUDA-enabled PyTorch for Jetson (~300 MB)..."
   pip_as_clawbox "nvidia-cusparselt-cu12" || return 1
   pip_as_clawbox "--no-cache-dir '$JETSON_TORCH_URL'" || return 1
-  # Interactive shells need the same loader path the units get.
-  local bashrc="$CLAWBOX_HOME/.bashrc"
+  # Interactive shells need the same loader path the units get. "expected":
+  # this line is appended once and sourced for the life of the box.
+  local bashrc="$CLAWBOX_HOME/.bashrc" ld
+  ld=$(kokoro_ld_path expected)
   if ! grep -q "cusparselt" "$bashrc" 2>/dev/null; then
-    echo "export LD_LIBRARY_PATH=$KOKORO_LD_PATH:\${LD_LIBRARY_PATH}" >> "$bashrc"
+    echo "export LD_LIBRARY_PATH=$ld\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}" >> "$bashrc"
     echo "export CUDA_HOME=$CUDA_HOME_DIR" >> "$bashrc"
+    # `>>` CREATES the file when it is missing, and this runs as root: a box
+    # whose clawbox user had no .bashrc would get a root-owned one it can never
+    # edit again. Best-effort, like every other chown here — the exports still
+    # work if it fails, and failing the GPU install over file ownership would
+    # cost the box its voice for nothing.
+    chown "$CLAWBOX_USER:$CLAWBOX_USER" "$bashrc" 2>/dev/null || true
   fi
 }
 
@@ -320,6 +406,10 @@ kokoro_mark_installed() {
 # The kokoro-server.service heredoc lives here, once, so the full path and
 # --tts-only cannot ship two different units.
 write_kokoro_unit() {
+  local ld
+  # "expected": this file is written once and read for the life of the box, and
+  # it is refreshed even on a run whose wheel install failed.
+  ld=$(kokoro_ld_path expected)
   mkdir -p "$SYSTEMD_USER" || return 1
   cat > "$SYSTEMD_USER/kokoro-server.service" << EOF
 [Unit]
@@ -328,7 +418,7 @@ After=default.target
 
 [Service]
 Type=simple
-Environment=LD_LIBRARY_PATH=$KOKORO_LD_PATH
+Environment=LD_LIBRARY_PATH=$ld
 ExecStart=/usr/bin/python3 $WORKSPACE/scripts/kokoro-server.py
 Restart=no
 
@@ -551,13 +641,14 @@ if $HAS_CUDA; then
   DEVICE="cuda"
   COMPUTE="float16"
 fi
-su - "$CLAWBOX_USER" -c "
-  export LD_LIBRARY_PATH=$CLAWBOX_HOME/.local/lib:$CLAWBOX_HOME/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib:/usr/local/cuda/lib64:\$LD_LIBRARY_PATH
-  python3 -c \"
+# Through the shared helper: this was the third copy of the same pinned
+# python3.10 path, and STT needs that loader path for exactly the reason TTS
+# does — the CUDA libraries live under user-site.
+clawbox_python "
 from faster_whisper import WhisperModel
 model = WhisperModel('base', device='$DEVICE', compute_type='$COMPUTE')
 print('Whisper base model ready on $DEVICE')
-\"" 2>&1 | tail -3
+" 2>&1 | tail -3
 
 echo "[6/8] Pre-downloading Kokoro model..."
 if kokoro_predownload_model; then
@@ -589,7 +680,7 @@ After=default.target
 
 [Service]
 Type=simple
-Environment=LD_LIBRARY_PATH=$KOKORO_LD_PATH
+Environment=LD_LIBRARY_PATH=$(kokoro_ld_path expected)
 Environment=WHISPER_MODEL=base
 ExecStart=/usr/bin/python3 $SCRIPTS_DST/whisper-server.py
 Restart=no

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -258,7 +258,19 @@ install_kokoro_packages() {
   # pip 22's resolver won't downgrade huggingface-hub (pulled in by
   # faster-whisper) to satisfy transformers<5 in a single command, so it
   # silently picks transformers 5.x. Keep these two as two pip invocations.
-  pip_as_clawbox "'numpy<2' kokoro soundfile 'Pillow>=10'" || return 1
+  #
+  # The numpy FLOOR is what makes this pip step do anything at all. JetPack
+  # ships numpy 1.21.5 as an apt package in /usr/lib/python3/dist-packages,
+  # which already satisfies a bare `numpy<2` — so pip installed nothing, and
+  # the Jetson torch wheel could not use 1.21.5:
+  #   $ kokoro -t "..." -o /tmp/k1.wav -m af_heart -l a
+  #   RuntimeError: Numpy is not available          (a 44-byte output file)
+  # With `numpy>=1.24,<2`, 1.26.4 lands in user-site and the same command
+  # produced 105,644 bytes of audio in 12.2 s (measured on a JetPack 6.2 Orin).
+  # The <2 ceiling stays: torch 2.5.0a0+872d972e41.nv24.8 is a numpy-1.x build.
+  # This defect was inherited from the pre-existing full path, which calls this
+  # same function, so both paths are fixed here.
+  pip_as_clawbox "'numpy>=1.24,<2' kokoro soundfile 'Pillow>=10'" || return 1
   pip_as_clawbox "'transformers<5'" || return 1
 }
 

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -4,10 +4,39 @@
 # Runs as clawbox user. Requires espeak-ng to be installed (system package).
 set -euo pipefail
 
-CLAWBOX_USER="clawbox"
-CLAWBOX_HOME="/home/${CLAWBOX_USER}"
+# Overridable for the same reason PIPER_DIR is: the tests run the real script
+# end-to-end so they fail when the shipped artifact drifts, and they cannot
+# write into a real /home/clawbox. install.sh does not export either name, so a
+# device always takes these defaults.
+CLAWBOX_USER="${CLAWBOX_USER:-clawbox}"
+CLAWBOX_HOME="${CLAWBOX_HOME:-/home/${CLAWBOX_USER}}"
 WORKSPACE="$CLAWBOX_HOME/.openclaw/workspace"
 PIP="pip3"
+
+# ── Shared Kokoro (GPU TTS) constants ───────────────────────────────────────
+# Named once because two paths through this file install Kokoro — the full
+# voice-pipeline run at the bottom and the --tts-only run install.sh uses — and
+# a second copy of any of these is a drift waiting to happen.
+
+# JP v61 wheel works on JetPack 6.1+ (including 6.2.x).
+JETSON_TORCH_URL="https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl"
+# libcusparseLt (shipped by the nvidia-cusparselt-cu12 wheel) is not on the
+# default loader path, so `import torch` fails without this. The systemd user
+# units and every python invocation below need it.
+KOKORO_LD_PATH="/home/clawbox/.local/lib:/home/clawbox/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib:/usr/local/cuda/lib64"
+SYSTEMD_USER="$CLAWBOX_HOME/.config/systemd/user"
+CUDA_HOME_DIR="${CLAWBOX_CUDA_HOME:-/usr/local/cuda}"
+# Written only after a COMPLETE Kokoro install, and read as the idempotence
+# gate. Importability alone must not be the gate: the packages land before the
+# transformers pin and before the model download, so a run that failed at
+# either leaves `import kokoro` working with the job half done — and gating on
+# the import would latch that half-done box in as "ready" on every subsequent
+# update, while the first spoken reply still paid for the 300 MB the warm-up
+# was supposed to have fetched. Derived state under .cache: losing it costs one
+# repeated install, never correctness.
+KOKORO_STAMP="$CLAWBOX_HOME/.cache/clawbox/kokoro-installed"
+# Bump when a step below changes in a way an already-stamped box must redo.
+KOKORO_STAMP_VERSION="1"
 
 # ── Piper (CPU fallback engine) ─────────────────────────────────────────────
 # Piper is what keeps a spoken reply from becoming silence. Kokoro owns the
@@ -172,10 +201,244 @@ deploy_voice_scripts() {
   return "$rc"
 }
 
-# --piper-only installs just the CPU fallback and refreshes the entrypoint.
-# install.sh calls this on every install and update: it is a small pinned
-# download, unlike the CUDA torch/CTranslate2 build below, so it is safe to
-# run unattended on a box that already works.
+# ── Kokoro (GPU TTS) ────────────────────────────────────────────────────────
+# Kokoro is the DEFAULT voice (TASK-382 benchmarked it on real Orin hardware,
+# TASK-383 shipped it), but until TASK-420 nothing on the install path actually
+# installed it: install.sh called this script with --piper-only and then printed
+# "Kokoro GPU, Piper fallback". Every shipped box spoke through the CPU
+# fallback. The pieces below are functions, not inline steps, because both the
+# full pipeline install and --tts-only run them and neither may drift.
+
+# CUDA detection: nvcc on PATH, else the standard Jetson location (exported so
+# later steps find it). Returns 0 only when CUDA is genuinely usable — the
+# torch wheel and the whole Kokoro stack are pointless without it.
+NVCC=""
+detect_cuda() {
+  NVCC=$(command -v nvcc 2>/dev/null || echo "")
+  if [ -z "$NVCC" ] && [ -x "$CUDA_HOME_DIR/bin/nvcc" ]; then
+    export PATH="$CUDA_HOME_DIR/bin:$PATH"
+    NVCC="$CUDA_HOME_DIR/bin/nvcc"
+  fi
+  [ -n "$NVCC" ]
+}
+
+# pip as the clawbox user. The `| tail -3` the inline steps used swallowed the
+# exit status (pipefail reports the RIGHTMOST failure, and tail always
+# succeeds), which is how a failed install could still look like one that
+# worked. Capture, trim for the log, and return the real status.
+pip_as_clawbox() {
+  local out rc=0
+  out=$(su - "$CLAWBOX_USER" -c "$PIP install --user $1" 2>&1) || rc=$?
+  printf '%s\n' "$out" | tail -3
+  return "$rc"
+}
+
+# Run a python3 snippet as the clawbox user with the CUDA library path set.
+clawbox_python() {
+  su - "$CLAWBOX_USER" -c "
+    export LD_LIBRARY_PATH=$KOKORO_LD_PATH:\$LD_LIBRARY_PATH
+    python3 -c \"$1\""
+}
+
+install_cuda_torch() {
+  echo "  Installing CUDA-enabled PyTorch for Jetson (~300 MB)..."
+  pip_as_clawbox "nvidia-cusparselt-cu12" || return 1
+  pip_as_clawbox "--no-cache-dir '$JETSON_TORCH_URL'" || return 1
+  # Interactive shells need the same loader path the units get.
+  local bashrc="$CLAWBOX_HOME/.bashrc"
+  if ! grep -q "cusparselt" "$bashrc" 2>/dev/null; then
+    echo "export LD_LIBRARY_PATH=$KOKORO_LD_PATH:\${LD_LIBRARY_PATH}" >> "$bashrc"
+    echo "export CUDA_HOME=$CUDA_HOME_DIR" >> "$bashrc"
+  fi
+}
+
+install_kokoro_packages() {
+  echo "  Installing Kokoro TTS..."
+  # Install kokoro first, then force transformers<5 as a separate step.
+  # pip 22's resolver won't downgrade huggingface-hub (pulled in by
+  # faster-whisper) to satisfy transformers<5 in a single command, so it
+  # silently picks transformers 5.x. Keep these two as two pip invocations.
+  pip_as_clawbox "'numpy<2' kokoro soundfile 'Pillow>=10'" || return 1
+  pip_as_clawbox "'transformers<5'" || return 1
+}
+
+# Warm the model cache so the FIRST spoken reply is not a 300 MB download the
+# user waits through with no explanation.
+kokoro_predownload_model() {
+  local out rc=0
+  echo "  Pre-downloading Kokoro model..."
+  out=$(clawbox_python "
+from kokoro import KPipeline
+pipeline = KPipeline(lang_code='a')
+print('Kokoro model ready on', next(pipeline.model.parameters()).device)
+" 2>&1) || rc=$?
+  printf '%s\n' "$out" | tail -5
+  return "$rc"
+}
+
+# Does the box already have a COMPLETE Kokoro stack? This is the idempotence
+# gate: --tts-only runs on EVERY in-app update of a shipped device, and
+# re-fetching the torch wheel each time would make every update a ~300 MB
+# download for nothing.
+#
+# Both halves are load-bearing. The stamp says "a previous run of this script
+# finished every step"; the import says "and it is still true" (a pip
+# uninstall, a python upgrade or a wiped ~/.local invalidates it). Gating on
+# the import alone would report a box that died at the model download as ready
+# forever — see $KOKORO_STAMP above.
+kokoro_stack_present() {
+  [ "$(cat "$KOKORO_STAMP" 2>/dev/null || true)" = "$KOKORO_STAMP_VERSION" ] || return 1
+  clawbox_python "import kokoro, torch" >/dev/null 2>&1
+}
+
+# Record a finished install. Best-effort: if the stamp cannot be written the
+# only cost is redoing this work on the next update, so it must not fail the
+# install — but it is said out loud, because silently paying for a 300 MB
+# download on every update is exactly the kind of thing nobody notices.
+kokoro_mark_installed() {
+  local dir
+  dir=$(dirname "$KOKORO_STAMP")
+  if ! (mkdir -p "$dir" && printf '%s\n' "$KOKORO_STAMP_VERSION" > "$KOKORO_STAMP"); then
+    echo "  Warning: could not write $KOKORO_STAMP — the next update will reinstall Kokoro" >&2
+    return 0
+  fi
+  chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$dir" 2>/dev/null || true
+}
+
+# The kokoro-server.service heredoc lives here, once, so the full path and
+# --tts-only cannot ship two different units.
+write_kokoro_unit() {
+  mkdir -p "$SYSTEMD_USER" || return 1
+  cat > "$SYSTEMD_USER/kokoro-server.service" << EOF
+[Unit]
+Description=Kokoro TTS Server (GPU)
+After=default.target
+
+[Service]
+Type=simple
+Environment=LD_LIBRARY_PATH=$KOKORO_LD_PATH
+ExecStart=/usr/bin/python3 $WORKSPACE/scripts/kokoro-server.py
+Restart=no
+
+[Install]
+WantedBy=default.target
+EOF
+}
+
+# Make freshly written user units usable: owned by the user that runs them,
+# lingering enabled so they can start without a login session, and reloaded.
+# All three are best-effort — none of them can cost the box its voice, because
+# clawbox-tts.sh starts the server on demand if the unit is not running.
+activate_user_units() {
+  chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$SYSTEMD_USER" 2>/dev/null || true
+  loginctl enable-linger "$CLAWBOX_USER" 2>/dev/null || true
+  su - "$CLAWBOX_USER" -c "
+    export XDG_RUNTIME_DIR=/run/user/\$(id -u)
+    systemctl --user daemon-reload
+  " 2>/dev/null || true
+}
+
+# Install the GPU Kokoro stack. NEVER fatal: every exit path leaves Piper and
+# the deployed scripts untouched, because a box that lost its voice to a failed
+# GPU install is strictly worse than a box on the CPU fallback. The return code
+# is the contract with install.sh's step_openclaw_tts, which uses it to decide
+# whether it may claim Kokoro in its summary:
+#   0   Kokoro ready
+#   10  skipped, no CUDA toolkit
+#   11  skipped, no Jetson build for this architecture
+#   12  attempted and failed
+install_kokoro_tts() {
+  local arch
+  arch=$(uname -m)
+  if [ "$arch" != "aarch64" ]; then
+    # $JETSON_TORCH_URL is an aarch64 wheel and install_piper already refuses
+    # to guess for other arches. Installing "something" here and reporting
+    # Kokoro is the exact lie TASK-420 removes.
+    echo "  Skipping Kokoro: no Jetson CUDA build for $arch (ClawBox ships aarch64)"
+    echo "CLAWBOX_TTS_KOKORO=skipped:arch-$arch"
+    return 11
+  fi
+  if ! detect_cuda; then
+    echo "  Skipping Kokoro: no CUDA toolkit (no nvcc on PATH, none at $CUDA_HOME_DIR/bin/nvcc)"
+    echo "CLAWBOX_TTS_KOKORO=skipped:no-cuda"
+    return 10
+  fi
+  echo "  CUDA detected: $("$NVCC" --version 2>/dev/null | tail -1)"
+
+  if kokoro_stack_present; then
+    echo "  Kokoro already installed by a previous run — skipping the GPU install"
+  else
+    if ! install_cuda_torch; then
+      echo "  ERROR: CUDA PyTorch install failed — leaving TTS on the Piper fallback" >&2
+      echo "CLAWBOX_TTS_KOKORO=failed:torch"
+      return 12
+    fi
+    if ! install_kokoro_packages; then
+      echo "  ERROR: Kokoro package install failed — leaving TTS on the Piper fallback" >&2
+      echo "CLAWBOX_TTS_KOKORO=failed:packages"
+      return 12
+    fi
+    if ! kokoro_predownload_model; then
+      echo "  ERROR: Kokoro model pre-download failed — leaving TTS on the Piper fallback" >&2
+      echo "CLAWBOX_TTS_KOKORO=failed:model"
+      return 12
+    fi
+    # Only now: every step above landed. Stamping earlier is what would turn a
+    # partial install into a permanent false "ready".
+    kokoro_mark_installed
+  fi
+
+  # Refreshed on every run, present or not: the unit points at a script
+  # deploy_voice_scripts just re-copied, and a stale unit is how a working box
+  # stops working after an update.
+  if ! write_kokoro_unit; then
+    echo "  ERROR: could not write $SYSTEMD_USER/kokoro-server.service" >&2
+    echo "CLAWBOX_TTS_KOKORO=failed:unit"
+    return 12
+  fi
+  activate_user_units
+  echo "CLAWBOX_TTS_KOKORO=ready"
+}
+
+# --tts-only installs exactly what on-device TTS needs: the Piper CPU fallback,
+# the workspace scripts OpenClaw execs, and the CUDA Kokoro stack with its
+# on-demand server unit.
+#
+# It deliberately does NOT run the STT half of this file — faster-whisper, the
+# CTranslate2 CUDA source build, the Whisper model download — which is roughly
+# an hour on an Orin. install.sh runs this from step_openclaw_tts on every
+# install AND every in-app update; an hour of source builds per update is not
+# something a shipped device can absorb.
+#
+# Piper goes first so a Kokoro failure can never take the fallback with it.
+if [ "${1:-}" = "--tts-only" ]; then
+  echo "=== On-device TTS (Kokoro GPU + Piper fallback) ==="
+  TTS_ONLY_RC=0
+  install_piper || TTS_ONLY_RC=1
+  deploy_voice_scripts || TTS_ONLY_RC=1
+
+  KOKORO_RC=0
+  install_kokoro_tts || KOKORO_RC=$?
+
+  if [ "$TTS_ONLY_RC" -ne 0 ]; then
+    # The loud one: without Piper AND without Kokoro the box answers speech
+    # with silence, so this outranks whatever the GPU path reported.
+    echo "=== Piper fallback INCOMPLETE — the box may answer speech with silence ===" >&2
+    exit 1
+  fi
+  if [ "$KOKORO_RC" -eq 0 ]; then
+    echo "=== On-device TTS ready (Kokoro GPU, Piper fallback) ==="
+  else
+    echo "=== On-device TTS ready on Piper CPU only (Kokoro unavailable) ==="
+  fi
+  exit "$KOKORO_RC"
+fi
+
+# --piper-only installs just the CPU fallback and refreshes the entrypoint. It
+# is a small pinned download, unlike the CUDA torch/CTranslate2 build below, so
+# it is safe to run unattended on a box that already works. install.sh moved to
+# --tts-only above, but this stays: clawbox-tts.sh names it in its
+# "Piper not installed" hint, and older devices' scripts call it.
 if [ "${1:-}" = "--piper-only" ]; then
   echo "=== Voice fallback (Piper) ==="
   PIPER_ONLY_RC=0
@@ -194,32 +457,22 @@ echo "=== Voice Pipeline Installer (GPU-Accelerated) ==="
 # ── Detect CUDA availability ────────────────────────────────────────────────
 
 HAS_CUDA=false
-# Check PATH first, then the standard Jetson CUDA location
-NVCC=$(command -v nvcc 2>/dev/null || echo "")
-if [ -z "$NVCC" ] && [ -x /usr/local/cuda/bin/nvcc ]; then
-  export PATH="/usr/local/cuda/bin:$PATH"
-  NVCC=/usr/local/cuda/bin/nvcc
-fi
-if [ -n "$NVCC" ]; then
+if detect_cuda; then
   HAS_CUDA=true
-  echo "  CUDA detected: $($NVCC --version | tail -1)"
+  echo "  CUDA detected: $("$NVCC" --version | tail -1)"
 fi
 
 # ── Step 1: Install CUDA PyTorch (if available) ─────────────────────────────
 
+# Tracked across the Kokoro steps so this path can write the same completion
+# stamp --tts-only reads, and write it only when every one of them worked. A
+# box installed the long way must not then redo the whole GPU stack on its
+# first in-app update — nor be stamped as complete when it is not.
+KOKORO_FULL_OK=$HAS_CUDA
+
 if $HAS_CUDA; then
   echo "[1/8] Installing CUDA-enabled PyTorch for Jetson..."
-  # JP v61 wheel works on JetPack 6.1+ (including 6.2.x)
-  TORCH_URL="https://developer.download.nvidia.com/compute/redist/jp/v61/pytorch/torch-2.5.0a0+872d972e41.nv24.08.17622132-cp310-cp310-linux_aarch64.whl"
-  su - "$CLAWBOX_USER" -c "$PIP install --user nvidia-cusparselt-cu12" 2>&1 | tail -3
-  su - "$CLAWBOX_USER" -c "$PIP install --user --no-cache-dir '$TORCH_URL'" 2>&1 | tail -3
-
-  # Set up LD_LIBRARY_PATH in .bashrc if not already there
-  BASHRC="$CLAWBOX_HOME/.bashrc"
-  if ! grep -q "cusparselt" "$BASHRC" 2>/dev/null; then
-    echo 'export LD_LIBRARY_PATH=/home/clawbox/.local/lib:/home/clawbox/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}' >> "$BASHRC"
-    echo 'export CUDA_HOME=/usr/local/cuda' >> "$BASHRC"
-  fi
+  install_cuda_torch || { KOKORO_FULL_OK=false; echo "  Warning: CUDA PyTorch install reported an error"; }
 else
   echo "[1/8] No CUDA detected, using CPU PyTorch..."
 fi
@@ -269,11 +522,7 @@ fi
 # ── Step 4: Install Kokoro TTS ───────────────────────────────────────────────
 
 echo "[4/8] Installing Kokoro TTS..."
-# Install kokoro first, then force transformers<5 as a separate step.
-# pip 22's resolver won't downgrade huggingface-hub (pulled in by faster-whisper)
-# to satisfy transformers<5 in a single command, so it silently picks transformers 5.x.
-su - "$CLAWBOX_USER" -c "$PIP install --user 'numpy<2' kokoro soundfile 'Pillow>=10'" 2>&1 | tail -3
-su - "$CLAWBOX_USER" -c "$PIP install --user 'transformers<5'" 2>&1 | tail -3
+install_kokoro_packages || { KOKORO_FULL_OK=false; echo "  Warning: Kokoro package install reported an error"; }
 
 # ── Step 5: Pre-download models ─────────────────────────────────────────────
 
@@ -299,13 +548,13 @@ print('Whisper base model ready on $DEVICE')
 \"" 2>&1 | tail -3
 
 echo "[6/8] Pre-downloading Kokoro model..."
-su - "$CLAWBOX_USER" -c "
-  export LD_LIBRARY_PATH=$CLAWBOX_HOME/.local/lib:$CLAWBOX_HOME/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib:/usr/local/cuda/lib64:\$LD_LIBRARY_PATH
-  python3 -c \"
-from kokoro import KPipeline
-pipeline = KPipeline(lang_code='a')
-print('Kokoro model ready on', next(pipeline.model.parameters()).device)
-\"" 2>&1 | tail -5
+if kokoro_predownload_model; then
+  if $KOKORO_FULL_OK; then
+    kokoro_mark_installed
+  fi
+else
+  echo "  Warning: Kokoro model pre-download reported an error"
+fi
 
 # ── Step 6: Deploy scripts ───────────────────────────────────────────────────
 
@@ -316,26 +565,10 @@ echo "[8/8] Deploying voice server scripts..."
 SCRIPTS_DST="$WORKSPACE/scripts"
 deploy_voice_scripts
 
-# Install systemd user services for persistent model servers
-SYSTEMD_USER="$CLAWBOX_HOME/.config/systemd/user"
-mkdir -p "$SYSTEMD_USER"
-
-LD_PATH="/home/clawbox/.local/lib:/home/clawbox/.local/lib/python3.10/site-packages/nvidia/cusparselt/lib:/usr/local/cuda/lib64"
-
-cat > "$SYSTEMD_USER/kokoro-server.service" << EOF
-[Unit]
-Description=Kokoro TTS Server (GPU)
-After=default.target
-
-[Service]
-Type=simple
-Environment=LD_LIBRARY_PATH=$LD_PATH
-ExecStart=/usr/bin/python3 $SCRIPTS_DST/kokoro-server.py
-Restart=no
-
-[Install]
-WantedBy=default.target
-EOF
+# Install systemd user services for persistent model servers. The Kokoro unit
+# comes from the shared writer so this path and --tts-only cannot disagree
+# about it; the Whisper unit is STT and only exists on this path.
+write_kokoro_unit
 
 cat > "$SYSTEMD_USER/whisper-server.service" << EOF
 [Unit]
@@ -344,7 +577,7 @@ After=default.target
 
 [Service]
 Type=simple
-Environment=LD_LIBRARY_PATH=$LD_PATH
+Environment=LD_LIBRARY_PATH=$KOKORO_LD_PATH
 Environment=WHISPER_MODEL=base
 ExecStart=/usr/bin/python3 $SCRIPTS_DST/whisper-server.py
 Restart=no
@@ -353,16 +586,8 @@ Restart=no
 WantedBy=default.target
 EOF
 
-chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$SYSTEMD_USER"
-
-# Enable lingering so user services start on boot without login
-loginctl enable-linger "$CLAWBOX_USER" 2>/dev/null || true
-
-# Reload service files (servers start on demand via stt-client.py)
-su - "$CLAWBOX_USER" -c "
-  export XDG_RUNTIME_DIR=/run/user/\$(id -u)
-  systemctl --user daemon-reload
-" 2>/dev/null || true
+# Owner, lingering and daemon-reload (servers start on demand via stt-client.py)
+activate_user_units
 
 echo ""
 echo "=== Voice Pipeline Installed ==="

--- a/scripts/openclaw/clawbox-tts.sh
+++ b/scripts/openclaw/clawbox-tts.sh
@@ -42,8 +42,67 @@ CLAWBOX_TTS_MEMINFO="${CLAWBOX_TTS_MEMINFO:-/proc/meminfo}"
 # 24 kHz mono 16-bit — below anything a real utterance can be.
 CLAWBOX_TTS_MIN_AUDIO_BYTES="${CLAWBOX_TTS_MIN_AUDIO_BYTES:-1024}"
 
-KOKORO_BIN="${KOKORO_BIN:-kokoro}"
 KOKORO_SOCKET="${KOKORO_SOCKET:-/tmp/kokoro-server.sock}"
+
+# ── Finding the Kokoro CLI ──────────────────────────────────────────────────
+# `pip install --user kokoro` puts the CLI at ~/.local/bin/kokoro, and that
+# directory is not on the PATH a non-interactive exec inherits — on a shipped
+# box that is /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin and
+# nothing else. OpenClaw execs this script directly, with no login shell and no
+# profile, so `command -v kokoro` failed on a box where Kokoro was fully
+# installed and spoke correctly from an interactive shell: every reply came out
+# of Piper with "kokoro: 'kokoro' is not installed" (TASK-420, measured on a
+# real Orin). Installing the engine was not enough; it also has to be findable
+# from the environment the gateway hands us.
+#
+# An explicit KOKORO_BIN still wins. It is how a per-channel provider `env` can
+# point at another build, and how the tests aim this at a stub.
+KOKORO_USER_BIN="${KOKORO_USER_BIN:-${HOME:-/home/clawbox}/.local/bin/kokoro}"
+KOKORO_UNRESOLVED=""
+resolve_kokoro_bin() {
+  [ -n "${KOKORO_BIN:-}" ] && return 0
+  if command -v kokoro >/dev/null 2>&1; then
+    KOKORO_BIN="kokoro"
+    return 0
+  fi
+  if [ -x "$KOKORO_USER_BIN" ]; then
+    KOKORO_BIN="$KOKORO_USER_BIN"
+    return 0
+  fi
+  # Nothing to run. The diagnostic keeps the name a person would type, and
+  # remembers that both places were searched so it can say where it looked.
+  KOKORO_BIN="kokoro"
+  KOKORO_UNRESOLVED=1
+}
+resolve_kokoro_bin
+
+# ── The CUDA loader path ────────────────────────────────────────────────────
+# Without it torch cannot be imported at all:
+#   ImportError: libcusparseLt.so.0: cannot open shared object file
+# That library ships inside the nvidia-cusparselt-cu12 wheel, under user-site,
+# where no loader looks by default. install-voice.sh appends the export to
+# ~/.bashrc and writes it into kokoro-server.service — neither of which reaches
+# here, for the same reason the PATH above does not. And because the engines'
+# own output is discarded, that ImportError arrived as nothing more than
+# "kokoro failed", with Piper quietly taking over.
+#
+# Derived from $HOME and whichever python user-site is actually on the box
+# rather than pinned to /home/clawbox and python3.10, and only directories that
+# exist are added: an EMPTY entry means "the current directory" to the loader,
+# which is not somewhere to resolve .so files from. Whatever the caller already
+# set is appended to, never replaced.
+kokoro_ld_path() {
+  local out="" d
+  for d in "${HOME:-/home/clawbox}/.local/lib" \
+           "${HOME:-/home/clawbox}"/.local/lib/python*/site-packages/nvidia/cusparselt/lib \
+           "${KOKORO_CUDA_LIB_DIR:-/usr/local/cuda/lib64}"; do
+    [ -d "$d" ] || continue
+    out="${out:+$out:}$d"
+  done
+  [ -n "${LD_LIBRARY_PATH:-}" ] && out="${out:+$out:}$LD_LIBRARY_PATH"
+  printf '%s' "$out"
+}
+KOKORO_LD_PATH="${KOKORO_LD_PATH:-$(kokoro_ld_path)}"
 
 # ── The time budget ─────────────────────────────────────────────────────────
 # Every engine gets its own slice, and the caller's timeout has to be larger
@@ -294,7 +353,7 @@ kokoro_via_server() {
   # Text goes through the environment, never through the shell or the argv of
   # an interpreter, so an utterance containing quotes cannot become code.
   KOKORO_TEXT="$text" KOKORO_OUTPUT="$wav" KOKORO_SOCKET="$KOKORO_SOCKET" KOKORO_VOICE="$voice" \
-    KOKORO_SERVER_TIMEOUT="$KOKORO_SERVER_TIMEOUT" \
+    KOKORO_SERVER_TIMEOUT="$KOKORO_SERVER_TIMEOUT" LD_LIBRARY_PATH="$KOKORO_LD_PATH" \
     timeout "$KOKORO_SERVER_TIMEOUT" "$PYTHON_BIN" -c '
 import json, os, socket, sys
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -329,7 +388,8 @@ kokoro_cold_start() {
   local text="$1" wav="$2" voice="$3" lang
   command -v "$KOKORO_BIN" >/dev/null 2>&1 || return 1
   lang="$(kokoro_lang_of "$voice")"
-  timeout "$KOKORO_TIMEOUT" "$KOKORO_BIN" -t "$text" -o "$wav" -m "$voice" -l "$lang" >/dev/null 2>&1 || return 1
+  LD_LIBRARY_PATH="$KOKORO_LD_PATH" \
+    timeout "$KOKORO_TIMEOUT" "$KOKORO_BIN" -t "$text" -o "$wav" -m "$voice" -l "$lang" >/dev/null 2>&1 || return 1
   return 0
 }
 
@@ -370,6 +430,10 @@ try_kokoro() {
 
   if command -v "$KOKORO_BIN" >/dev/null 2>&1; then
     note "kokoro: '$KOKORO_BIN' failed (CUDA unavailable, allocation refused, or model missing)"
+  elif [ -n "$KOKORO_UNRESOLVED" ]; then
+    # Says where it looked, because "not installed" was the message a box
+    # printed while the engine was installed and working two directories away.
+    note "kokoro: '$KOKORO_BIN' is not installed (not on PATH, and nothing executable at $KOKORO_USER_BIN)"
   else
     note "kokoro: '$KOKORO_BIN' is not installed"
   fi

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -69,19 +69,26 @@ function writeMeminfo(availableMb: number) {
   );
 }
 
-function writeStub(name: string, body: string) {
-  const p = path.join(binDir, name);
+function writeStub(name: string, body: string, atDir = binDir) {
+  const p = path.join(atDir, name);
   writeFileSync(p, `#!/usr/bin/env bash\n${body}\n`);
   chmodSync(p, 0o755);
   return p;
 }
 
-/** A kokoro CLI that honours -o/-m and can be told to fail or fall silent. */
-function stubKokoro() {
+/**
+ * A kokoro CLI that honours -o/-m and can be told to fail or fall silent.
+ * `atDir` is a parameter because WHERE the CLI is is itself under test: pip
+ * --user puts it somewhere the exec PATH does not include.
+ */
+function stubKokoro(atDir = binDir, name = "kokoro") {
   return writeStub(
-    "kokoro",
+    name,
     [
       'echo "kokoro $*" >> "$CALLS_LOG"',
+      // The loader path the engine was actually handed. torch does not import
+      // without it, and the stub is the only place a test can observe it.
+      'echo "ld=${LD_LIBRARY_PATH:-}" >> "$CALLS_LOG"',
       'out=""; voice=""',
       "while [ $# -gt 0 ]; do",
       '  case "$1" in',
@@ -221,6 +228,88 @@ describe.skipIf(!canRun)("scripts/openclaw/clawbox-tts.sh", () => {
     // that is quietly living on the CPU engine.
     expect(r.stderr).toContain("fell back to Piper");
     expect(r.stderr).toContain("is not installed");
+  });
+
+  // ── Where the engine is, and what it can load ─────────────────────────────
+  // Installing Kokoro was not enough. With the whole package set on disk and
+  // `kokoro -t ... -o ...` producing 105 KB of audio from an interactive
+  // shell, a real Orin still spoke through Piper: the CLI lives at
+  // ~/.local/bin, which is not on the PATH OpenClaw execs this script with,
+  // and torch cannot import libcusparseLt.so.0 without a loader path that
+  // only ~/.bashrc and the systemd unit carried (TASK-420).
+
+  it("finds the CLI pip --user installed, which the exec PATH does not include", () => {
+    const userBin = path.join(dir, ".local", "bin");
+    mkdirSync(userBin, { recursive: true });
+    stubKokoro(userBin);
+    stubPiper();
+    const r = synth([]);
+    expect(r.status).toBe(0);
+    // Kokoro is the engine that spoke — not Piper, and not "Piper with a note".
+    expect(calls()).toContain("kokoro ");
+    expect(calls()).not.toContain("piper ");
+    expect(r.stderr).not.toContain("fell back to Piper");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("says where it looked when the CLI is in neither place", () => {
+    stubPiper();
+    const r = synth([]);
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("piper ");
+    expect(r.stderr).toContain("is not installed");
+    // "not installed" is what a box printed while Kokoro was installed and
+    // working at exactly this path, so the note has to name the path it
+    // checked rather than leave that as the reader's guess.
+    expect(r.stderr).toContain(path.join(dir, ".local/bin/kokoro"));
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("lets an explicit KOKORO_BIN outrank both PATH and ~/.local/bin", () => {
+    // The per-channel provider `env` sets it, and this suite drives the script
+    // through it, so resolution must not quietly take the choice away.
+    const userBin = path.join(dir, ".local", "bin");
+    mkdirSync(userBin, { recursive: true });
+    writeStub("kokoro", 'echo "wrong-kokoro-from-PATH $*" >> "$CALLS_LOG"; exit 1');
+    writeStub("kokoro", 'echo "wrong-kokoro-from-user-site $*" >> "$CALLS_LOG"; exit 1', userBin);
+    const explicit = stubKokoro(binDir, "kokoro-explicit");
+    stubPiper();
+    const r = synth([], { KOKORO_BIN: explicit });
+    expect(r.status).toBe(0);
+    expect(calls()).toContain("kokoro ");
+    expect(calls()).not.toContain("wrong-kokoro");
+    expect(calls()).not.toContain("piper ");
+    expect(outputBytes()).toBeGreaterThan(1024);
+  });
+
+  it("hands Kokoro the CUDA loader path, appended to whatever was already set", () => {
+    const cusparse = path.join(dir, ".local/lib/python3.10/site-packages/nvidia/cusparselt/lib");
+    mkdirSync(cusparse, { recursive: true });
+    stubKokoro();
+    stubPiper();
+    const r = synth([], { LD_LIBRARY_PATH: "/opt/already-here" });
+    expect(r.status).toBe(0);
+    const observed = calls().split("\n").find((l) => l.startsWith("ld=")) ?? "";
+    expect(observed, "the engine was invoked without the cusparselt path").toContain(cusparse);
+    expect(observed).toContain(path.join(dir, ".local/lib"));
+    // Appended, never replaced — and ours first, so it is not shadowed.
+    expect(observed).toContain("/opt/already-here");
+    expect(observed.indexOf(cusparse)).toBeLessThan(observed.indexOf("/opt/already-here"));
+    // An empty entry means "the current directory" to the loader, which is not
+    // somewhere to resolve .so files from.
+    expect(observed).not.toContain("::");
+    expect(observed).not.toMatch(/^ld=:|:$/);
+  });
+
+  it("leaves Piper's own library path alone", () => {
+    // Piper ships its own onnxruntime next to the binary; putting user-site
+    // CUDA directories in front of that is not this change's business.
+    writeStub("piper", ['echo "piper-ld=${LD_LIBRARY_PATH:-}" >> "$CALLS_LOG"', "cat > /dev/null", "exit 1"].join("\n"));
+    mkdirSync(path.join(dir, ".local/lib/python3.10/site-packages/nvidia/cusparselt/lib"), { recursive: true });
+    synth([]);
+    const observed = calls().split("\n").find((l) => l.startsWith("piper-ld=")) ?? "";
+    expect(observed).toContain(binDir);
+    expect(observed).not.toContain("cusparselt");
   });
 
   it("falls back to Piper when kokoro fails, instead of exiting 1", () => {

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -103,6 +103,7 @@ function stubKokoro(atDir = binDir, name = "kokoro") {
       'if [ "${KOKORO_FAIL:-0}" != "0" ]; then echo "CUDA out of memory" >&2; exit 1; fi',
       'python3 "$WAV_WRITER" "$out" "${KOKORO_SECONDS:-1}"',
     ].join("\n"),
+    atDir,
   );
 }
 
@@ -290,15 +291,19 @@ describe.skipIf(!canRun)("scripts/openclaw/clawbox-tts.sh", () => {
     const r = synth([], { LD_LIBRARY_PATH: "/opt/already-here" });
     expect(r.status).toBe(0);
     const observed = calls().split("\n").find((l) => l.startsWith("ld=")) ?? "";
-    expect(observed, "the engine was invoked without the cusparselt path").toContain(cusparse);
-    expect(observed).toContain(path.join(dir, ".local/lib"));
+    // Split into entries rather than substring-matching the whole string:
+    // $HOME/.local/lib is a PREFIX of the cusparselt path, so a toContain on
+    // the joined value would be satisfied by the cusparselt entry alone and
+    // would not notice $HOME/.local/lib going missing.
+    const entries = observed.replace(/^ld=/, "").split(":");
+    expect(entries, "the engine was invoked without the cusparselt path").toContain(cusparse);
+    expect(entries, "the engine was invoked without the user-site lib dir").toContain(path.join(dir, ".local/lib"));
     // Appended, never replaced — and ours first, so it is not shadowed.
-    expect(observed).toContain("/opt/already-here");
-    expect(observed.indexOf(cusparse)).toBeLessThan(observed.indexOf("/opt/already-here"));
+    expect(entries).toContain("/opt/already-here");
+    expect(entries.indexOf(cusparse)).toBeLessThan(entries.indexOf("/opt/already-here"));
     // An empty entry means "the current directory" to the loader, which is not
     // somewhere to resolve .so files from.
-    expect(observed).not.toContain("::");
-    expect(observed).not.toMatch(/^ld=:|:$/);
+    expect(entries.filter((e) => e === "")).toEqual([]);
   });
 
   it("leaves Piper's own library path alone", () => {

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -698,9 +698,12 @@ describe("install.sh wires TTS to the on-device chain", () => {
     expect(step).toContain('outputFormat:"wav"');
   });
 
-  it("installs the Piper fallback as part of the same step", () => {
+  it("installs both engines as part of the same step", () => {
     expect(step).toContain("install-voice.sh");
-    expect(step).toContain("--piper-only");
+    // --piper-only until TASK-420, which installed the fallback and nothing
+    // else while this step claimed Kokoro GPU. --tts-only installs both.
+    // Behaviour is covered by install-kokoro-tts.test.ts, which executes it.
+    expect(step).toMatch(/install-voice\.sh" --tts-only/);
   });
 
   it("runs on updated boxes and not just fresh installs", () => {

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -284,6 +284,34 @@ describe.skipIf(!hasBash)("install-voice.sh --tts-only on a fresh CUDA box", () 
     expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=ready");
   });
 
+  it("asks for a numpy the Jetson torch wheel can actually use", () => {
+    // `numpy<2` on its own is a NO-OP on this hardware: JetPack ships numpy
+    // 1.21.5 as an apt package in /usr/lib/python3/dist-packages, which
+    // already satisfies it, so pip installed nothing and the torch wheel could
+    // not use what was there —
+    //   $ kokoro -t "..." -o /tmp/k1.wav -m af_heart -l a
+    //   RuntimeError: Numpy is not available        (a 44-byte output file)
+    // With the floor, 1.26.4 lands in user-site and the same command produced
+    // 105,644 bytes of audio. A test that only checked the ceiling is what let
+    // that ship, so this one reads the floor and refuses a missing one.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    const step = res.su.filter((c) => c.includes("pip3 install")).find((c) => c.includes("kokoro"));
+    expect(step, "no pip step installs kokoro at all").toBeDefined();
+
+    const pin = /numpy>=(\d+)\.(\d+)[^'"]*,\s*<2/.exec(step!);
+    expect(
+      pin,
+      `numpy is pinned without a usable floor: ${step} — the board's apt numpy already satisfies <2`,
+    ).not.toBeNull();
+    // >= 1.24. The measured-good version is 1.26.4; 1.21.5 is the one that
+    // makes torch raise, and anything below 1.24 has no numpy-1.x guarantee
+    // for this wheel.
+    expect(Number(pin![1]) * 100 + Number(pin![2])).toBeGreaterThanOrEqual(124);
+    // And the ceiling stays: torch 2.5.0a0+872d972e41.nv24.8 is a numpy-1.x
+    // build, so an unbounded numpy would break it the other way.
+    expect(step).toContain("<2");
+  });
+
   it("writes the kokoro-server user unit and enables lingering", () => {
     const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
     const unit = path.join(res.home, ".config/systemd/user/kokoro-server.service");

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -47,6 +47,13 @@ function writeExec(file: string, body: string) {
   writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
 }
 
+/** The value of the generated unit's `Environment=LD_LIBRARY_PATH=` line. */
+function unitLdPath(unit: string): string {
+  const m = /^Environment=LD_LIBRARY_PATH=(.*)$/m.exec(unit);
+  expect(m, `the unit sets no LD_LIBRARY_PATH:\n${unit}`).not.toBeNull();
+  return m![1];
+}
+
 // ── The --tts-only harness ──────────────────────────────────────────────────
 
 interface VoiceRun {
@@ -56,6 +63,8 @@ interface VoiceRun {
   /** Every command string handed to `su - clawbox -c`, one per line. */
   su: string[];
   curl: string[];
+  /** Every `chown` argument list, one per line. */
+  chown: string[];
   home: string;
 }
 
@@ -72,18 +81,22 @@ let root: string;
  *   FAKE_ARCH           what `uname -m` reports
  *   WITH_CUDA           "1" puts an nvcc stub on PATH
  *
- * `stamped` pre-writes the completion stamp a previous successful run leaves.
+ * `stamped` pre-writes the completion stamp a previous successful run leaves —
+ * `true` for the current version, or a literal string for a stamp an older
+ * release wrote.
  */
-function runTtsOnly(env: Record<string, string> = {}, stamped = false): VoiceRun {
+function runTtsOnly(env: Record<string, string> = {}, stamped: boolean | string = false): VoiceRun {
   const home = path.join(root, "home", "clawbox");
   const bin = path.join(root, "bin");
   const suLog = path.join(root, "su.log");
   const curlLog = path.join(root, "curl.log");
+  const chownLog = path.join(root, "chown.log");
   mkdirSync(bin, { recursive: true });
   mkdirSync(home, { recursive: true });
   if (stamped) {
     mkdirSync(path.join(home, ".cache", "clawbox"), { recursive: true });
-    writeFileSync(path.join(home, ".cache", "clawbox", "kokoro-installed"), `${shellConst("KOKORO_STAMP_VERSION")}\n`);
+    const version = typeof stamped === "string" ? stamped : shellConst("KOKORO_STAMP_VERSION");
+    writeFileSync(path.join(home, ".cache", "clawbox", "kokoro-installed"), `${version}\n`);
   }
 
   // `su - clawbox -c "<cmd>"` is how every pip/python step runs, so this stub
@@ -95,6 +108,11 @@ function runTtsOnly(env: Record<string, string> = {}, stamped = false): VoiceRun
       'while [ $# -gt 0 ]; do case "$1" in -c) cmd="$2"; shift 2;; *) shift;; esac; done',
       `printf '%s\\n---\\n' "$cmd" >> "${suLog}"`,
       'case "$cmd" in',
+      // How the script asks the box which python pip --user will unpack the
+      // cusparselt wheel under, instead of pinning the version it was written
+      // against. A device answers "python3.10" (JetPack 6.2); the test host's
+      // own python is irrelevant, so it is scripted here.
+      '  *"sys.version_info"*) echo "${FAKE_PY_VERSION:-python3.10}"; exit 0 ;;',
       '  *"import kokoro, torch"*) exit "${KOKORO_IMPORT_EXIT:-1}" ;;',
       '  *"from kokoro import KPipeline"*) echo "Kokoro model ready on cuda"; exit "${WARMUP_EXIT:-0}" ;;',
       '  *"pip3 install"*) echo "Successfully installed"; exit "${PIP_EXIT:-0}" ;;',
@@ -113,7 +131,9 @@ function runTtsOnly(env: Record<string, string> = {}, stamped = false): VoiceRun
   writeExec(path.join(bin, "curl"), [`printf '%s\\n' "$*" >> "${curlLog}"`, "exit 1"].join("\n"));
   // chown to a user that does not exist on the test host would otherwise fail
   // deploy_voice_scripts for a reason that has nothing to do with the code.
-  writeExec(path.join(bin, "chown"), "exit 0");
+  // Logged as well as stubbed: this script runs as root in files the clawbox
+  // user has to keep owning.
+  writeExec(path.join(bin, "chown"), [`printf '%s\\n' "$*" >> "${chownLog}"`, "exit 0"].join("\n"));
   writeExec(path.join(bin, "loginctl"), "exit 0");
   if (env.WITH_CUDA === "1") {
     writeExec(path.join(bin, "nvcc"), 'echo "Cuda compilation tools, release 12.6, V12.6.68"');
@@ -155,6 +175,7 @@ function runTtsOnly(env: Record<string, string> = {}, stamped = false): VoiceRun
     stderr: res.stderr ?? "",
     su: read(suLog).split("\n---\n").filter(Boolean),
     curl: read(curlLog).trim().split("\n").filter(Boolean),
+    chown: read(chownLog).trim().split("\n").filter(Boolean),
     home,
   };
 }
@@ -298,18 +319,37 @@ describe.skipIf(!hasBash)("install-voice.sh --tts-only on a fresh CUDA box", () 
     const step = res.su.filter((c) => c.includes("pip3 install")).find((c) => c.includes("kokoro"));
     expect(step, "no pip step installs kokoro at all").toBeDefined();
 
-    const pin = /numpy>=(\d+)\.(\d+)[^'"]*,\s*<2/.exec(step!);
+    // Read the requirement and its constraints rather than pattern-matching
+    // the line. A regex that just looked for "<2" was satisfied by "<2.5" and
+    // by "<20" — it matched the prefix and let the rest fall outside — which
+    // is the numpy-2.x breakage the ceiling is here to prevent, passing CI.
+    // The quotes are part of the requirement: `<` unquoted is a redirection.
+    const req = /'(numpy[^']*)'/.exec(step!)?.[1];
+    expect(req, `no quoted numpy requirement in: ${step}`).toBeDefined();
+    const constraints = req!.slice("numpy".length).split(",").map((c) => c.trim());
+    const version = (v: string) => {
+      const [maj = 0, min = 0, patch = 0] = v.split(".").map(Number);
+      return maj * 1_000_000 + min * 1_000 + patch;
+    };
+    const floor = constraints.find((c) => c.startsWith(">="));
+    const ceiling = constraints.find((c) => /^<[^=]/.test(c));
+
     expect(
-      pin,
-      `numpy is pinned without a usable floor: ${step} — the board's apt numpy already satisfies <2`,
-    ).not.toBeNull();
-    // >= 1.24. The measured-good version is 1.26.4; 1.21.5 is the one that
-    // makes torch raise, and anything below 1.24 has no numpy-1.x guarantee
-    // for this wheel.
-    expect(Number(pin![1]) * 100 + Number(pin![2])).toBeGreaterThanOrEqual(124);
+      floor,
+      `numpy is pinned without a floor (${req}) — the board's apt numpy 1.21.5 already satisfies <2, so pip installs nothing`,
+    ).toBeDefined();
+    // The measured-good version is 1.26.4; 1.21.5 is the one that makes torch
+    // raise "Numpy is not available".
+    expect(version(floor!.slice(2)), `the numpy floor ${floor} is below 1.24`).toBeGreaterThanOrEqual(version("1.24"));
     // And the ceiling stays: torch 2.5.0a0+872d972e41.nv24.8 is a numpy-1.x
-    // build, so an unbounded numpy would break it the other way.
-    expect(step).toContain("<2");
+    // build, so an unbounded numpy breaks it the other way.
+    expect(ceiling, `numpy is pinned without a ceiling (${req})`).toBeDefined();
+    expect(version(ceiling!.slice(1)), `the numpy ceiling ${ceiling} admits numpy 2.x`).toBeLessThanOrEqual(
+      version("2"),
+    );
+    // A floor at or above the ceiling is unsatisfiable — pip only says so at
+    // install time, on the device, an hour into an update.
+    expect(version(floor!.slice(2))).toBeLessThan(version(ceiling!.slice(1)));
   });
 
   it("writes the kokoro-server user unit and enables lingering", () => {
@@ -319,8 +359,59 @@ describe.skipIf(!hasBash)("install-voice.sh --tts-only on a fresh CUDA box", () 
     const body = readFileSync(unit, "utf-8");
     expect(body).toContain("ExecStart=/usr/bin/python3");
     expect(body).toContain("kokoro-server.py");
-    expect(body).toContain("cusparselt");
+    // The loader path has to name THIS box's home, not the one the script was
+    // written against. Asserting only /cusparselt/ is what a hardcoded
+    // /home/clawbox/.local/lib/python3.10/... satisfies just as happily.
+    expect(unitLdPath(body), "the unit's LD_LIBRARY_PATH is not derived from CLAWBOX_HOME").toContain(
+      `${res.home}/.local/lib`,
+    );
+    expect(unitLdPath(body)).toContain("cusparselt");
     expect(res.su.some((c) => c.includes("systemctl --user daemon-reload"))).toBe(true);
+  });
+
+  it("points the unit at the python that is on the box, not a pinned version", () => {
+    // A wheel already unpacked under some python version is the authoritative
+    // answer, and it is found with a python* glob — a unit pinned to
+    // python3.10 would send this box's `import torch` at a directory that does
+    // not exist, which is the ImportError this whole task exists to remove.
+    const cusparselt = path.join(root, "home/clawbox/.local/lib/python3.13/site-packages/nvidia/cusparselt/lib");
+    mkdirSync(cusparselt, { recursive: true });
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1", FAKE_PY_VERSION: "python3.9" });
+    const ld = unitLdPath(readFileSync(path.join(res.home, ".config/systemd/user/kokoro-server.service"), "utf-8"));
+    expect(ld, "the real site-packages directory was not the one written").toContain(cusparselt);
+    expect(ld).not.toContain("python3.10");
+    expect(ld).not.toContain("python3.9");
+  });
+
+  it("still names the cusparselt directory when the wheels are not unpacked yet", () => {
+    // The deliberate difference from clawbox-tts.sh, which runs at speech time
+    // and can drop what is missing: this unit is written BEFORE the wheel is
+    // installed and is then read for the life of the box. Filtering on
+    // existence here would ship a unit with no cusparselt entry at all — the
+    // same broken import, arrived at more quietly.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1", FAKE_PY_VERSION: "python3.11" });
+    const ld = unitLdPath(readFileSync(path.join(res.home, ".config/systemd/user/kokoro-server.service"), "utf-8"));
+    expect(ld, "a missing directory was silently dropped from the unit").toContain(
+      `${res.home}/.local/lib/python3.11/site-packages/nvidia/cusparselt/lib`,
+    );
+    // An empty entry means "the current directory" to the loader.
+    expect(ld).not.toContain("::");
+    expect(ld.startsWith(":") || ld.endsWith(":")).toBe(false);
+  });
+
+  it("leaves the .bashrc it appends to owned by the clawbox user", () => {
+    // install_cuda_torch runs as ROOT and appends with `>>`, which creates the
+    // file when it is missing — a box whose clawbox user had no .bashrc would
+    // get a root-owned one it can never edit again. The exports still load,
+    // so nothing here fails loudly; the user just loses their own file.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    const bashrc = path.join(res.home, ".bashrc");
+    const body = readFileSync(bashrc, "utf-8");
+    expect(body, "the loader path is not exported for interactive shells").toContain("cusparselt");
+    // Derived here too: this line is appended once and sourced for the life of
+    // the box, so a pinned /home/clawbox would outlive the run that wrote it.
+    expect(body).toContain(`${res.home}/.local/lib`);
+    expect(res.chown.some((c) => c.includes("clawbox:clawbox") && c.includes(bashrc)), "the .bashrc was never chowned back to the user").toBe(true);
   });
 
   it("still deploys Piper and the TTS entrypoint alongside it", () => {
@@ -362,6 +453,23 @@ describe.skipIf(!hasBash)("install-voice.sh --tts-only is cheap on re-run", () =
     const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "0" }, true);
     expect(existsSync(path.join(res.home, ".config/systemd/user/kokoro-server.service"))).toBe(true);
     expect(existsSync(path.join(res.home, ".openclaw/workspace/scripts/kokoro-server.py"))).toBe(true);
+  });
+
+  it("redoes the install on a box stamped by the release that got numpy wrong", () => {
+    // The stamp makes an update cheap, and it is also how a fix to the pip
+    // steps can miss exactly the boxes that need it. A box that installed
+    // `numpy<2` — a no-op against the board's apt 1.21.5 — passes BOTH halves
+    // of kokoro_stack_present(): the stamp is there, and `import kokoro,
+    // torch` succeeds, because torch imports fine and only raises "Numpy is
+    // not available" later at the tensor conversion. Bumping the version is
+    // what makes such a box redo the pip steps.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "0" }, "1");
+    expect(res.status, res.stderr).toBe(0);
+    expect(
+      res.su.some((c) => c.includes("pip3 install") && c.includes("numpy")),
+      "a box stamped by the old version never redid the numpy step",
+    ).toBe(true);
+    expect(shellConst("KOKORO_STAMP_VERSION"), "the numpy fix shipped without bumping the stamp").not.toBe("1");
   });
 
   // One run per test: runTtsOnly reuses the per-test temp root, so a second

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -1,0 +1,418 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * install.sh advertised "On-device TTS configured (Kokoro GPU, Piper fallback)"
+ * while calling `install-voice.sh --piper-only`, which installs the CPU
+ * fallback and nothing else. Kokoro was only ever installed by the full,
+ * no-flag path of that script, and install.sh never invoked it — so on three
+ * freshly flashed boxes (beta e4f11e1, 2026-08-20) `import kokoro` and
+ * `import torch` both raised ModuleNotFoundError, `systemctl --user
+ * list-unit-files` had no kokoro-server unit, and Piper was the only engine
+ * present. Neither the flash path nor the remote-update path shipped the
+ * engine TASK-382 benchmarked and TASK-383 made the default.
+ *
+ * These tests EXECUTE the shipped artifacts — the real `--tts-only` dispatch
+ * out of scripts/install-voice.sh, and the real step_openclaw_tts out of
+ * install.sh — against stubs for su/pip/uname/nvcc, rather than grepping their
+ * text. A rewrite that keeps the words but drops the install fails them.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_VOICE = path.join(REPO, "scripts", "install-voice.sh");
+const INSTALL_VOICE_SH = readFileSync(INSTALL_VOICE, "utf-8");
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+function extractShellFn(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end + 2);
+}
+
+/** Read a pinned constant (e.g. PIPER_EN_ONNX_SHA256) out of the real script. */
+function shellConst(name: string): string {
+  const m = new RegExp(`^${name}="([^"]+)"`, "m").exec(INSTALL_VOICE_SH);
+  if (!m) throw new Error(`${name} not found in install-voice.sh`);
+  return m[1];
+}
+
+function writeExec(file: string, body: string) {
+  writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+}
+
+// ── The --tts-only harness ──────────────────────────────────────────────────
+
+interface VoiceRun {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  /** Every command string handed to `su - clawbox -c`, one per line. */
+  su: string[];
+  curl: string[];
+  home: string;
+}
+
+let root: string;
+
+/**
+ * Build a fake device root and a PATH of stubs, then run the REAL
+ * `install-voice.sh --tts-only`.
+ *
+ * Scripted via env:
+ *   KOKORO_IMPORT_EXIT  `import kokoro, torch` status (0 = packages on disk)
+ *   PIP_EXIT            every `pip3 install` status
+ *   WARMUP_EXIT         the KPipeline pre-download status
+ *   FAKE_ARCH           what `uname -m` reports
+ *   WITH_CUDA           "1" puts an nvcc stub on PATH
+ *
+ * `stamped` pre-writes the completion stamp a previous successful run leaves.
+ */
+function runTtsOnly(env: Record<string, string> = {}, stamped = false): VoiceRun {
+  const home = path.join(root, "home", "clawbox");
+  const bin = path.join(root, "bin");
+  const suLog = path.join(root, "su.log");
+  const curlLog = path.join(root, "curl.log");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  if (stamped) {
+    mkdirSync(path.join(home, ".cache", "clawbox"), { recursive: true });
+    writeFileSync(path.join(home, ".cache", "clawbox", "kokoro-installed"), `${shellConst("KOKORO_STAMP_VERSION")}\n`);
+  }
+
+  // `su - clawbox -c "<cmd>"` is how every pip/python step runs, so this stub
+  // IS the pip call log the idempotence and no-STT assertions read.
+  writeExec(
+    path.join(bin, "su"),
+    [
+      'cmd=""',
+      'while [ $# -gt 0 ]; do case "$1" in -c) cmd="$2"; shift 2;; *) shift;; esac; done',
+      `printf '%s\\n---\\n' "$cmd" >> "${suLog}"`,
+      'case "$cmd" in',
+      '  *"import kokoro, torch"*) exit "${KOKORO_IMPORT_EXIT:-1}" ;;',
+      '  *"from kokoro import KPipeline"*) echo "Kokoro model ready on cuda"; exit "${WARMUP_EXIT:-0}" ;;',
+      '  *"pip3 install"*) echo "Successfully installed"; exit "${PIP_EXIT:-0}" ;;',
+      "esac",
+      "exit 0",
+    ].join("\n"),
+  );
+  writeExec(
+    path.join(bin, "uname"),
+    [`[ "\${1:-}" = "-m" ] && { echo "\${FAKE_ARCH:-aarch64}"; exit 0; }`, 'exec /usr/bin/uname "$@"'].join(
+      "\n",
+    ),
+  );
+  // No network in a unit test: any download is a bug, and failing loudly here
+  // makes it one the assertions can see.
+  writeExec(path.join(bin, "curl"), [`printf '%s\\n' "$*" >> "${curlLog}"`, "exit 1"].join("\n"));
+  // chown to a user that does not exist on the test host would otherwise fail
+  // deploy_voice_scripts for a reason that has nothing to do with the code.
+  writeExec(path.join(bin, "chown"), "exit 0");
+  writeExec(path.join(bin, "loginctl"), "exit 0");
+  if (env.WITH_CUDA === "1") {
+    writeExec(path.join(bin, "nvcc"), 'echo "Cuda compilation tools, release 12.6, V12.6.68"');
+  }
+
+  // Piper: pre-installed, so nothing here needs the network. sha256sum is
+  // stubbed to report a file's own contents as its digest, which lets the
+  // fixtures carry the real pinned values without shipping the real weights.
+  const piperDir = path.join(root, "piper");
+  mkdirSync(path.join(piperDir, "voices"), { recursive: true });
+  writeExec(path.join(piperDir, "piper"), "exit 0");
+  writeFileSync(path.join(piperDir, "voices", "en_US-lessac-medium.onnx"), shellConst("PIPER_EN_ONNX_SHA256"));
+  writeFileSync(
+    path.join(piperDir, "voices", "en_US-lessac-medium.onnx.json"),
+    shellConst("PIPER_EN_JSON_SHA256"),
+  );
+  writeExec(path.join(bin, "sha256sum"), ['printf "%s  %s\\n" "$(head -c 64 "$1")" "$1"'].join("\n"));
+
+  const res = spawnSync("bash", [INSTALL_VOICE, "--tts-only"], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: {
+      PATH: `${bin}:/usr/bin:/bin`,
+      HOME: home,
+      CLAWBOX_USER: "clawbox",
+      CLAWBOX_HOME: home,
+      PIPER_DIR: piperDir,
+      // Point the /usr/local/cuda probe at nothing so a dev box or CI runner
+      // that happens to have CUDA cannot turn the no-CUDA test green.
+      CLAWBOX_CUDA_HOME: path.join(root, "no-such-cuda"),
+      ...env,
+    },
+  });
+
+  const read = (f: string) => (existsSync(f) ? readFileSync(f, "utf-8") : "");
+  return {
+    status: res.status,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    su: read(suLog).split("\n---\n").filter(Boolean),
+    curl: read(curlLog).trim().split("\n").filter(Boolean),
+    home,
+  };
+}
+
+// ── The step_openclaw_tts harness ───────────────────────────────────────────
+
+/**
+ * Run the real step_openclaw_tts against a stub `openclaw` and a stub
+ * install-voice.sh whose exit code the test picks.
+ */
+function runStep(voiceExit: number) {
+  const projectDir = path.join(root, "project");
+  const callsLog = path.join(root, "openclaw.log");
+  const voiceArgs = path.join(root, "voice-args.log");
+  mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+  writeExec(
+    path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+    '[ "${1:-}" = "--provider-timeout-ms" ] && echo 100000\nexit 0',
+  );
+  writeExec(
+    path.join(projectDir, "scripts", "install-voice.sh"),
+    [`printf '%s\\n' "$*" >> "${voiceArgs}"`, `exit ${voiceExit}`].join("\n"),
+  );
+  const openclaw = path.join(root, "openclaw");
+  writeExec(
+    openclaw,
+    [
+      `echo "$*" >> "${callsLog}"`,
+      'if [ "$1" = "config" ] && [ "$2" = "get" ]; then exit 0; fi',
+      "exit 0",
+    ].join("\n"),
+  );
+
+  const program = [
+    "set -uo pipefail",
+    `PROJECT_DIR="${projectDir}"`,
+    `OPENCLAW_BIN="${openclaw}"`,
+    "CLAWBOX_USER=clawbox",
+    'as_clawbox() { env "$@"; }',
+    "is_hermes_edition() { return 1; }",
+    extractShellFn(INSTALL_SH, "oc_config_set"),
+    extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
+    extractShellFn(INSTALL_SH, "step_openclaw_tts"),
+    "step_openclaw_tts",
+  ].join("\n");
+
+  const res = spawnSync("bash", ["-c", program], { encoding: "utf-8", timeout: 60_000 });
+  const read = (f: string) => (existsSync(f) ? readFileSync(f, "utf-8").trim().split("\n").filter(Boolean) : []);
+  return {
+    status: res.status,
+    stdout: res.stdout ?? "",
+    stderr: res.stderr ?? "",
+    voiceArgs: read(voiceArgs),
+    openclaw: read(callsLog),
+  };
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "kokoro-install-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises", () => {
+  it("calls the Kokoro-capable mode, not --piper-only", () => {
+    // The whole defect in one assertion: --piper-only cannot install Kokoro,
+    // so a step that calls it can never make its own summary line true.
+    const res = runStep(0);
+    expect(res.status).toBe(0);
+    expect(res.voiceArgs).toContain("--tts-only");
+    expect(res.voiceArgs).not.toContain("--piper-only");
+  });
+
+  it("claims Kokoro only when install-voice.sh reports it ready", () => {
+    const res = runStep(0);
+    expect(res.stdout).toContain("On-device TTS configured (Kokoro GPU, Piper fallback)");
+  });
+
+  it.each([
+    [10, /no CUDA toolkit/],
+    [11, /CPU architecture/],
+    [12, /Kokoro GPU install failed/],
+  ])("stays non-fatal and tells the truth when the voice install exits %i", (code, reason) => {
+    const res = runStep(code as number);
+    // Non-fatal: a box must never lose its voice, or its install, to the GPU
+    // path. TTS is still configured — through Piper.
+    expect(res.status).toBe(0);
+    expect(res.openclaw).toContain("config set messages.tts.provider tts-local-cli");
+    // And the summary must not repeat the lie that hid this bug for a release.
+    expect(res.stdout).not.toContain("Kokoro GPU, Piper fallback");
+    expect(res.stdout).toContain("Piper CPU only");
+    expect(res.stdout).toMatch(reason as RegExp);
+  });
+
+  it("warns about the fallback in terms of the fallback, not of Kokoro", () => {
+    // The old wording said "Kokoro still works, but a GPU failure will be
+    // silent" — written when Kokoro was assumed present, which it never was.
+    const res = runStep(1);
+    expect(res.status).toBe(0);
+    expect(res.stderr).toMatch(/Piper CPU fallback did not install/);
+    expect(res.stderr).not.toMatch(/Kokoro still works/);
+    // Exit 1 is the Piper half failing, so claiming Piper is the active engine
+    // would just be a smaller version of the same lie.
+    expect(res.stdout).toContain("NO engine is confirmed installed");
+    expect(res.stdout).not.toContain("Piper CPU only");
+    expect(res.stdout).not.toContain("Kokoro GPU, Piper fallback");
+  });
+});
+
+describe.skipIf(!hasBash)("install-voice.sh --tts-only on a fresh CUDA box", () => {
+  it("installs the Jetson torch wheel, kokoro, and the model, then reports ready", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    expect(res.status, res.stderr).toBe(0);
+
+    const pip = res.su.filter((c) => c.includes("pip3 install"));
+    const torchUrl = shellConst("JETSON_TORCH_URL");
+    expect(pip.some((c) => c.includes(torchUrl)), "the Jetson CUDA torch wheel is never installed").toBe(true);
+    expect(pip.some((c) => c.includes("nvidia-cusparselt-cu12"))).toBe(true);
+    expect(pip.some((c) => c.includes("kokoro"))).toBe(true);
+    // transformers<5 must stay its OWN pip step: pip 22's resolver will not
+    // downgrade huggingface-hub inside a single command and silently picks 5.x.
+    const combined = pip.find((c) => c.includes("kokoro"));
+    expect(combined).not.toContain("transformers<5");
+    expect(pip.some((c) => c.includes("transformers<5"))).toBe(true);
+
+    // Warm the cache here, or the first spoken reply is a 300 MB download.
+    expect(res.su.some((c) => c.includes("from kokoro import KPipeline"))).toBe(true);
+    expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=ready");
+  });
+
+  it("writes the kokoro-server user unit and enables lingering", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    const unit = path.join(res.home, ".config/systemd/user/kokoro-server.service");
+    expect(existsSync(unit), "no kokoro-server unit was installed").toBe(true);
+    const body = readFileSync(unit, "utf-8");
+    expect(body).toContain("ExecStart=/usr/bin/python3");
+    expect(body).toContain("kokoro-server.py");
+    expect(body).toContain("cusparselt");
+    expect(res.su.some((c) => c.includes("systemctl --user daemon-reload"))).toBe(true);
+  });
+
+  it("still deploys Piper and the TTS entrypoint alongside it", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    expect(res.stdout).toMatch(/Piper voice ready/);
+    const entrypoint = path.join(res.home, ".openclaw/workspace/scripts/openclaw/clawbox-tts.sh");
+    expect(existsSync(entrypoint)).toBe(true);
+    expect(existsSync(path.join(res.home, ".openclaw/workspace/scripts/kokoro-server.py"))).toBe(true);
+  });
+
+  it("never runs the STT half — it would add about an hour to every update", () => {
+    // This path runs from step_post_update on EVERY in-app update. Pulling
+    // faster-whisper, building CTranslate2 from source with CUDA, and
+    // downloading the Whisper weights is roughly an hour on an Orin.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    const all = res.su.join("\n");
+    for (const forbidden of ["faster-whisper", "CTranslate2", "WhisperModel", "cmake", "git clone"]) {
+      expect(all, `--tts-only ran the STT step: ${forbidden}`).not.toContain(forbidden);
+    }
+  });
+});
+
+describe.skipIf(!hasBash)("install-voice.sh --tts-only is cheap on re-run", () => {
+  it("downloads nothing when a previous run already finished the install", () => {
+    // The update path. Re-fetching a ~300 MB wheel on a box that already works
+    // is how a five-minute update becomes a twenty-minute one.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "0" }, true);
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.su.filter((c) => c.includes("pip3 install")), "the heavy pip work ran again").toEqual([]);
+    expect(res.su.filter((c) => c.includes("KPipeline")), "the warm-up ran again").toEqual([]);
+    expect(res.curl, "something was downloaded on a no-op run").toEqual([]);
+    expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=ready");
+  });
+
+  it("still refreshes the scripts and the unit on that cheap run", () => {
+    // Skipping the download must not skip the delivery: a box whose
+    // kokoro-server.py or unit is stale after an update is a box that stops
+    // speaking for a reason nobody changed.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "0" }, true);
+    expect(existsSync(path.join(res.home, ".config/systemd/user/kokoro-server.service"))).toBe(true);
+    expect(existsSync(path.join(res.home, ".openclaw/workspace/scripts/kokoro-server.py"))).toBe(true);
+  });
+
+  // One run per test: runTtsOnly reuses the per-test temp root, so a second
+  // call in the same test would inherit the first one's stamp.
+  it("records the completion stamp once every step has landed", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    expect(existsSync(path.join(res.home, ".cache/clawbox/kokoro-installed"))).toBe(true);
+  });
+
+  it("does not stamp an install that failed part-way", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1", WARMUP_EXIT: "1" });
+    expect(res.status).toBe(12);
+    expect(
+      existsSync(path.join(res.home, ".cache/clawbox/kokoro-installed")),
+      "a failed install was stamped as complete",
+    ).toBe(false);
+  });
+
+  it("redoes a half-finished install instead of latching it in as ready", () => {
+    // The trap this gate has to avoid. The packages land BEFORE the
+    // transformers pin and BEFORE the model download, so a run that died at
+    // either leaves `import kokoro, torch` working with the job half done.
+    // Gating on importability alone would report that box ready on every
+    // update from then on, while its first spoken reply still paid for the
+    // 300 MB the warm-up was supposed to have fetched — the same over-claim
+    // TASK-420 exists to remove, one layer deeper.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "0" }); // imports, but never stamped
+    expect(res.status, res.stderr).toBe(0);
+    expect(res.su.some((c) => c.includes("from kokoro import KPipeline")), "the model was never fetched").toBe(
+      true,
+    );
+    expect(res.su.some((c) => c.includes("transformers<5")), "the transformers pin was never redone").toBe(true);
+    expect(existsSync(path.join(res.home, ".cache/clawbox/kokoro-installed"))).toBe(true);
+  });
+});
+
+describe.skipIf(!hasBash)("install-voice.sh --tts-only never costs the box its voice", () => {
+  it("survives a failed pip: exit 12, Piper intact, no claim of Kokoro", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1", PIP_EXIT: "1" });
+    expect(res.status, "a GPU failure must be reported, not fatal").toBe(12);
+    expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=failed:torch");
+    expect(res.stdout).not.toContain("CLAWBOX_TTS_KOKORO=ready");
+    // Piper and the entrypoint are installed BEFORE Kokoro is attempted
+    // precisely so this is true.
+    expect(res.stdout).toMatch(/Piper voice ready/);
+    expect(existsSync(path.join(res.home, ".openclaw/workspace/scripts/openclaw/clawbox-tts.sh"))).toBe(true);
+  });
+
+  it("survives a failed model pre-download the same way", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1", WARMUP_EXIT: "1" });
+    expect(res.status).toBe(12);
+    expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=failed:model");
+  });
+
+  it("skips Kokoro with a stated reason when there is no CUDA", () => {
+    const res = runTtsOnly({ KOKORO_IMPORT_EXIT: "1" });
+    expect(res.status).toBe(10);
+    expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=skipped:no-cuda");
+    expect(res.stdout).toMatch(/no CUDA toolkit/);
+    // Skipping means skipping: no wheel, no packages, no pretending.
+    expect(res.su.filter((c) => c.includes("pip3 install"))).toEqual([]);
+    expect(res.stdout).toMatch(/Piper voice ready/);
+  });
+
+  it("skips Kokoro on an architecture with no Jetson build", () => {
+    // install_piper already refuses to guess a digest off aarch64; the CUDA
+    // torch wheel is just as aarch64-only.
+    const res = runTtsOnly({ FAKE_ARCH: "x86_64", WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    expect(res.status).toBe(11);
+    expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=skipped:arch-x86_64");
+    expect(res.su.filter((c) => c.includes("pip3 install"))).toEqual([]);
+  });
+});
+
+describe.skipIf(!hasBash)("the older --piper-only entry point still works", () => {
+  it("is kept: clawbox-tts.sh names it and older devices' scripts call it", () => {
+    // Removing it would break the hint a box prints when Piper is missing.
+    const tts = readFileSync(path.join(REPO, "scripts/openclaw/clawbox-tts.sh"), "utf-8");
+    expect(tts).toContain("--piper-only");
+    expect(INSTALL_VOICE_SH).toContain('if [ "${1:-}" = "--piper-only" ]; then');
+  });
+});


### PR DESCRIPTION
Every ClawBox in the field speaks through the CPU fallback while the installer prints `On-device TTS configured (Kokoro GPU, Piper fallback)`.

`step_openclaw_tts` called `install-voice.sh --piper-only` — which installs Piper and nothing else — and then asserted the outcome instead of reporting it. Kokoro was only ever installed by the full, no-flag path of that script, and `install.sh` never invoked it. TASK-382 benchmarked Kokoro on real Orin hardware specifically to choose it; TASK-383 shipped it as "the ClawBox default"; nobody got it.

Verified today on three freshly **flashed** test boxes (beta `e4f11e1`), which rules out the "maybe only the update path is affected" caveat on the task: `import kokoro` and `import torch` both `ModuleNotFoundError`, no `kokoro-server` unit, Piper the only engine present.

## Installing Kokoro was not enough — three runtime gaps behind it

Measured on a real Orin (192.168.50.71, JetPack 6.2 / CUDA 12.6, Python 3.10.12) by running the exact pip sequence the full path uses and then trying to speak. With the whole stack installed, the box **still** answered through Piper.

**1. `'numpy<2'` was a no-op that broke torch.** JetPack ships numpy 1.21.5 as an apt package in `dist-packages`, which already satisfies a bare `numpy<2`, so pip installed nothing and torch could not use it:

```
$ kokoro -t "..." -o /tmp/k1.wav -m af_heart -l a
RuntimeError: Numpy is not available          # 44-byte output file
```

With `numpy>=1.24,<2`, 1.26.4 lands in user-site and the same command produces 105,644 bytes of audio in 12.2 s. The `<2` ceiling stays — that wheel is a numpy-1.x build. This defect is inherited from the pre-existing full path, so the shared function fixes both.

**2. torch does not import without `LD_LIBRARY_PATH`.** `libcusparseLt.so.0` ships inside the `nvidia-cusparselt-cu12` wheel under user-site, where no loader looks. `install-voice.sh` appended the export to `~/.bashrc` and wrote it into the systemd unit — neither reaches `clawbox-tts.sh`, which OpenClaw execs directly.

**3. The `kokoro` CLI is not on PATH.** pip `--user` puts it in `~/.local/bin`; the box's non-interactive PATH does not include it. The symptom, with Kokoro installed and working from an interactive shell:

```
$ clawbox-tts.sh -- "..." /tmp/x.wav
clawbox-tts: fell back to Piper — kokoro: 'kokoro' is not installed
```

And because the engines' own output is discarded, an `ImportError` arrived as nothing more than "kokoro failed", with Piper quietly taking over — which is how all three stayed invisible.

The path that actually runs on a box is the CLI cold start: `kokoro-server.service` is `Restart=no` + `WantedBy=default.target`, `kokoro-server.py` exits after 300 s idle, and nothing socket-activates it. Cold start measures 12.2 s against the 40 s `KOKORO_TIMEOUT`.

## The change

`install-voice.sh` gains `--tts-only`: Piper first, the workspace scripts, then the CUDA Kokoro stack (Jetson torch wheel, `numpy>=1.24,<2 kokoro soundfile Pillow>=10`, `transformers<5` as its own pip step, the `KPipeline` warm-up) and the `kokoro-server` user unit. It deliberately omits the STT half of that file — faster-whisper, the CTranslate2 CUDA source build, the Whisper download — which is about an hour on an Orin. `step_openclaw_tts` also runs from `step_post_update`, so this executes on **every** in-app update and cannot carry that. Whole Kokoro install measures ~4 minutes on real hardware (cusparselt 25 s, torch 1m46s, kokoro+deps ~1m, transformers 14 s, warm-up 45 s).

Piper installs first and every Kokoro failure returns rather than exits, so a box can never lose its voice to the GPU path. The exit code is the contract with `install.sh`: `0` ready, `10` no CUDA, `11` wrong arch, `12` attempted and failed, `1` the Piper half did not land. `install.sh` maps those to a summary that can only say "Kokoro GPU, Piper fallback" when Kokoro is genuinely there, names the reason otherwise, and on `rc=1` claims no engine at all.

Idempotence is gated on a completion stamp **and** a live import, not importability alone: the packages land before the transformers pin and before the model download, so a run that died at either leaves `import kokoro, torch` working with the job half done — an import-only gate would call that box ready on every update forever, which is the same over-claim this task removes.

`clawbox-tts.sh` resolves `KOKORO_BIN` (explicit override, then PATH, then `$HOME/.local/bin/kokoro`) and gives the Kokoro invocations the CUDA loader path, derived from `$HOME` and whichever python user-site exists rather than pinned to `/home/clawbox` and `python3.10`, skipping directories that do not exist (an empty entry means "current directory" to the loader) and appending to whatever the caller already set. Piper's environment is untouched.

The systemd unit heredoc, CUDA detection, torch URL, loader path and pip steps are now single functions the full path calls too, so the two cannot drift into installing different things. pip status is no longer swallowed by `| tail -3` (pipefail reports the rightmost failure and `tail` always succeeds), which is how a failed install could look like one that worked. `--piper-only` is untouched — `clawbox-tts.sh` names it in its "Piper not installed" hint and older devices' scripts call it.

## Tests

`src/tests/unit/install-kokoro-tts.test.ts` (new) executes the shipped artifacts — the real `--tts-only` dispatch and the real `step_openclaw_tts` — against stubbed `su`/`pip`/`uname`/`nvcc`, so it fails when either drifts rather than when the wording changes. `clawbox-tts.test.ts` gains the runtime-resolution cases: CLI only in `~/.local/bin` still selects Kokoro, neither present falls back with the honest note, an explicit override wins, and the loader path reaches the invocation without clobbering an existing `LD_LIBRARY_PATH`.

Local gate: **218 files / 2938 tests green** (baseline 217 / 2912).

Closes TASK-420.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing both Kokoro GPU and Piper TTS engines.
  - Added automatic CUDA detection, model setup, and configurable installation paths.
  - Improved Kokoro executable discovery and diagnostic messages.
  - Added fallback reporting when Kokoro is unavailable.

- **Bug Fixes**
  - Installation status now accurately identifies available voice engines.
  - Preserved Piper functionality and library configuration during Kokoro setup.

- **Tests**
  - Expanded coverage for installation flows, fallback behavior, CUDA support, discovery, and repeat installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->