### PR TITLE
ci: accelerate full install e2e

### DIFF
--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -125,10 +125,10 @@ jobs:
           bun-version: "1.2.10"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build e2e-install image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: e2e-install/Dockerfile

--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -68,16 +68,19 @@ jobs:
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
-          fetch-depth: 0
+          # The updater fetches its target branch explicitly. Keeping only the
+          # exact PR head avoids copying the repository's full object history
+          # into the Docker image while preserving a real, fetchable .git repo.
+          fetch-depth: 1
 
       - name: Checkout repository
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/checkout@v7
         with:
-          # We need the target branch reachable from the working tree so the
-          # updater can `git fetch origin <branch>`. Fetch tags too since the
-          # version check polls `git ls-remote --tags`.
-          fetch-depth: 0
+          # Scheduled/dispatch runs update the checked-out branch. The updater
+          # performs its own `git fetch origin <branch>`, and version checks use
+          # `git ls-remote --tags`, so local history and tags are unnecessary.
+          fetch-depth: 1
 
       - name: Show Docker + runner info
         run: |

--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Checkout PR head
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -72,15 +72,17 @@ jobs:
           # exact PR head avoids copying the repository's full object history
           # into the Docker image while preserving a real, fetchable .git repo.
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Checkout repository
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Scheduled/dispatch runs update the checked-out branch. The updater
           # performs its own `git fetch origin <branch>`, and version checks use
           # `git ls-remote --tags`, so local history and tags are unnecessary.
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Show Docker + runner info
         run: |

--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -124,6 +124,19 @@ jobs:
         with:
           bun-version: "1.2.10"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build e2e-install image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: e2e-install/Dockerfile
+          load: true
+          tags: clawbox-e2e:latest
+          cache-from: type=gha,scope=e2e-install-${{ runner.arch }}
+          cache-to: type=gha,mode=min,scope=e2e-install-${{ runner.arch }}
+
       # Only install the host-side bits we need to *drive* the tests: the
       # Playwright runner + its system libs for the chat UI spec. The
       # container inside Docker has its own separate Playwright install.
@@ -140,13 +153,10 @@ jobs:
           GREP_FILTER: ${{ inputs.grep_filter }}
           # Let global-setup.ts handle image build + container boot +
           # waitForInstallComplete. It already does all three with one
-          # consistent error path; running a separate "boot" step here and
-          # then SKIP_SETUP=1 would race against install.sh still running.
-          DOCKER_BUILDKIT: "1"
-          # Force the image to build fresh each CI run — caching layers
-          # across runs makes failures hard to reproduce and the runner
-          # disk is throwaway anyway.
-          CLAWBOX_E2E_REBUILD: "1"
+          # consistent error path. The image itself was built immediately
+          # above from this exact checkout; content-addressed BuildKit layers
+          # only avoid re-downloading unchanged base packages on cold runners.
+          CLAWBOX_E2E_REBUILD: "0"
         run: |
           set -o pipefail
           args=()

--- a/e2e-install/entrypoint.sh
+++ b/e2e-install/entrypoint.sh
@@ -40,5 +40,32 @@ CLAWBOX_TEST_MODE=1
 NETWORK_INTERFACE=${NETWORK_INTERFACE:-eth0}
 EOF
 
+# The full installer still deploys clawbox-ap.service so upgrade paths can
+# verify its unit file, but this container has no WiFi radio and the install
+# harness intentionally excludes the service from active-service validation.
+# Keep the real root-update/systemd restart path while replacing only the
+# impossible hardware boundary; otherwise each settings write waits ~34s for
+# start-ap.sh retries that cannot succeed and whose failure is already ignored.
+mkdir -p /etc/systemd/system/clawbox-ap.service.d
+cat > /etc/systemd/system/clawbox-ap.service.d/e2e-no-radio.conf <<EOF
+[Service]
+ExecStart=
+ExecStart=/bin/true
+ExecStop=
+ExecStop=/bin/true
+EOF
+
+# Docker networking is already configured before PID 1 starts. Ubuntu's
+# NetworkManager-wait-online helper cannot classify the synthetic eth0 link
+# and burns its full 60-second timeout on every tested reboot before allowing
+# clawbox-setup.service to start. Preserve the network-online dependency graph
+# but satisfy the impossible hardware probe immediately in this container.
+mkdir -p /etc/systemd/system/NetworkManager-wait-online.service.d
+cat > /etc/systemd/system/NetworkManager-wait-online.service.d/e2e-docker-network.conf <<EOF
+[Service]
+ExecStart=
+ExecStart=/bin/true
+EOF
+
 # Hand off to systemd.
 exec "$@"


### PR DESCRIPTION
## Summary

- build the full-install Docker image with BuildKit and a content-addressed GitHub Actions cache, then load that exact checkout for the suite
- replace only the unavailable WiFi-radio boundary inside the e2e container while retaining the real API → privileged root-update → systemd restart path
- satisfy Docker's already-configured network-online boundary immediately instead of waiting 60 seconds for `NetworkManager-wait-online` to time out after every tested reboot

## Coverage and safety

- no tests, assertions, specs, update steps, or reboot checks were removed or weakened
- production units and production networking are unchanged; both systemd overrides exist only inside `e2e-install/entrypoint.sh`
- the image is still rebuilt from the exact PR checkout; only unchanged content-addressed Docker layers are restored

## Performance evidence

### Local comparable full runs (standalone clones, clean volume)

- before: **538.35s** (`CLAWBOX_E2E_REBUILD=1`, clean image)
- after: **286.07s** total = **7.80s** restored-cache image build + **278.27s** full suite
- improvement: **252.28s / 46.9% faster**
- outcomes preserved: **76 passed, 11 intentionally skipped, 0 failed** in both runs
- hotspot settings spec: **72.25s → 4.49s file total** (the rename itself: ~68s → 1.9s)
- power/reboot spec: **65.94s → 5.36s**

### GitHub Actions cold-run comparison

Both jobs ran on distinct fresh GitHub-hosted ARM64 runners. The improved job restored the content-addressed Docker cache populated by the preceding PR run; the runner itself was fresh.

- current `beta` baseline SHA `0d938249`: **12m11s / 731s** — run `32410047327`, runner `1000009932`
- final improved PR SHA `68ecee04`: **8m13s / 493s** — run `32413266546`, runner `1000009960`
- improvement: **238s / 32.6% lower wall-clock time**
- suite step: **11m33s / 693s → 6m51s / 411s** (**40.7% faster**)
- final report: **79 passed, 8 intentionally skipped, 0 failed**, matching the baseline report
- warmed image build: **34s**; host Playwright install: **26s**

## Validation

- full local `e2e-install` suite
- `bash -n e2e-install/entrypoint.sh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end installation test reliability by prebuilding and reusing the test container image.
  - Added cached image layers and shallow source checkouts to reduce setup time and resource usage.
  - Added test-environment service overrides to prevent unnecessary application and network startup during installation tests.
  - Streamlined test execution by disabling redundant image rebuilding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
