### PR TITLE
A ClawBox can finally see the image you attach to it

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -490,7 +490,11 @@ if isinstance(deepseek_provider, dict) and deepseek_provider.get("baseUrl") in (
 # max_tokens 128000 is accepted and 200000 (the generic default an entry falls
 # through to when the field is absent) comes back 400 "supports at most 128000
 # completion tokens".
-CLAWBOX_VISION_MODEL_ID = "gpt-5.6-luna"
+# Honour the same env override CLAWBOX_AI_VISION_MODEL_ID gives the route, so a
+# box provisioned against a staging proxy with a different alias map is not
+# dragged back to the production slug at the next boot. Unset (the normal case)
+# means the shipped default, which the unit test pins to the TS constant.
+CLAWBOX_VISION_MODEL_ID = (os.environ.get("CLAWBOX_AI_VISION_MODEL_ID") or "").strip() or "gpt-5.6-luna"
 CLAWBOX_VISION_MODEL_NAME = "ClawBox AI Vision"
 CLAWBOX_VISION_MODEL_REF = "deepseek/" + CLAWBOX_VISION_MODEL_ID
 CLAWBOX_VISION_MAX_TOKENS = 128000

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -460,6 +460,99 @@ if isinstance(deepseek_provider, dict) and deepseek_provider.get("baseUrl") in (
     deepseek_provider["baseUrl"] = "https://clawbox.com/api/ai"
     changed = True
 
+# Migration: ClawBox AI vision (image understanding).
+#
+# A ClawBox accepts an image attachment in chat and then cannot look at it.
+# Both ClawBox AI chat models are `input: ["text"]`, so OpenClaw does not
+# inline image parts; it hands the turn a media path and expects the `image`
+# tool to describe it. That tool resolves its model from
+# `agents.defaults.imageModel`, which ClawBox provisioning never wrote, so
+# runWithImageModelFallback throws "No image model configured"
+# (dist/model-fallback-CvSRhgYr.js on 2026.7.1). Reproduced on a real box on
+# 2026-08-21; see TASK-417.
+#
+# Boxes already in the field never re-run the configure route, so the repair
+# has to happen here. Mirrors buildClawboxAiProviderDefinition() and the
+# imageModel write in src/app/setup-api/ai-models/configure/route.ts; the two
+# must stay in step, and src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+# runs these exact bytes out of the shipped .sh.
+#
+# Registered under the `deepseek` provider even though the id is an OpenAI one:
+# that entry IS the ClawBox AI proxy, already carrying api=openai-completions,
+# the proxy baseUrl and the claw_ token. OpenClaw's `openai` provider defaults
+# to openai-responses, which the proxy does not speak. It cannot show up in the
+# chat model picker — the clawai catalogue is the hardcoded CLAWAI_STATIC_MODELS
+# list, not a read of this array.
+#
+# The model id and the ceiling are duplicated from CLAWBOX_AI_VISION_* in
+# src/lib/clawbox-ai-models.ts because a shell migration cannot import them.
+# 128000 is measured, not guessed: against the live proxy on 2026-08-21,
+# max_tokens 128000 is accepted and 200000 (the generic default an entry falls
+# through to when the field is absent) comes back 400 "supports at most 128000
+# completion tokens".
+CLAWBOX_VISION_MODEL_ID = "gpt-5.6-luna"
+CLAWBOX_VISION_MODEL_NAME = "ClawBox AI Vision"
+CLAWBOX_VISION_MODEL_REF = "deepseek/" + CLAWBOX_VISION_MODEL_ID
+CLAWBOX_VISION_MAX_TOKENS = 128000
+
+# The token is the entitlement, exactly as for images: only a box that actually
+# has ClawBox AI gets a vision model pointed at the ClawBox AI proxy. Read here
+# rather than borrowing the image migration's `_clawai_token`, so this block
+# stays a self-contained slice its unit test can run out of the shipped .sh.
+_vision_models = deepseek_provider.get("models") if isinstance(deepseek_provider, dict) else None
+_vision_token = deepseek_provider.get("apiKey") if isinstance(deepseek_provider, dict) else None
+if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _vision_token.startswith("claw_"):
+    _vision_entry = next(
+        (m for m in _vision_models if isinstance(m, dict) and m.get("id") == CLAWBOX_VISION_MODEL_ID),
+        None,
+    )
+    if _vision_entry is None:
+        _vision_models.append({
+            "id": CLAWBOX_VISION_MODEL_ID,
+            "name": CLAWBOX_VISION_MODEL_NAME,
+            "input": ["text", "image"],
+            "maxTokens": CLAWBOX_VISION_MAX_TOKENS,
+            "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+        })
+        changed = True
+    else:
+        # Repair only what makes the entry unusable, in the same order the
+        # route builds it. `name` first: OpenClaw's schema rejects a models[]
+        # row without one and the gateway then refuses to start.
+        if not isinstance(_vision_entry.get("name"), str) or not _vision_entry.get("name").strip():
+            _vision_entry["name"] = CLAWBOX_VISION_MODEL_NAME
+            changed = True
+        # Without "image" in `input`, resolveImageRuntime refuses the model
+        # outright ("Model does not support images"), which is the whole
+        # failure this migration exists to fix.
+        _vision_input = _vision_entry.get("input")
+        if not isinstance(_vision_input, list) or "image" not in _vision_input:
+            _vision_entry["input"] = ["text", "image"]
+            changed = True
+        # Only fill an absent ceiling. A number someone else chose is theirs.
+        if _vision_entry.get("maxTokens") is None:
+            _vision_entry["maxTokens"] = CLAWBOX_VISION_MAX_TOKENS
+            changed = True
+
+    # Claim agents.defaults.imageModel only when it is empty, where "empty"
+    # means what OpenClaw's hasToolModelConfig means: neither a primary nor a
+    # usable fallback. A fallbacks-only entry is a working, deliberate
+    # configuration, and the write below replaces the whole object.
+    _vision_model_cfg = agents_defaults.get("imageModel")
+    _vision_fallbacks = (
+        _vision_model_cfg.get("fallbacks") if isinstance(_vision_model_cfg, dict) else None
+    )
+    _has_vision_model = isinstance(_vision_model_cfg, dict) and bool(
+        (isinstance(_vision_model_cfg.get("primary"), str) and _vision_model_cfg.get("primary").strip())
+        or (
+            isinstance(_vision_fallbacks, list)
+            and any(isinstance(ref, str) and ref.strip() for ref in _vision_fallbacks)
+        )
+    )
+    if not _has_vision_model:
+        agents_defaults["imageModel"] = {"primary": CLAWBOX_VISION_MODEL_REF}
+        changed = True
+
 # Migration: ClawBox AI image generation.
 #
 # OpenClaw only registers its `image_generate` tool when an image-generation

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -44,6 +44,11 @@ import {
   CLAWBOX_AI_IMAGE_MODEL,
   CLAWBOX_AI_IMAGE_MODEL_ID,
   CLAWBOX_AI_IMAGE_MODEL_LABEL,
+  CLAWBOX_AI_VISION_MODEL,
+  CLAWBOX_AI_VISION_MODEL_ID,
+  CLAWBOX_AI_VISION_MODEL_LABEL,
+  CLAWBOX_AI_VISION_INPUT_MODALITIES,
+  CLAWBOX_AI_VISION_MAX_TOKENS,
   normalizeClawboxAiTier,
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
@@ -321,6 +326,22 @@ function buildClawboxAiProviderDefinition(apiKey: string) {
           supportedReasoningEfforts: ["off", "high", "xhigh"],
         },
       },
+      // Image understanding. Not a chat tier and never selectable as one —
+      // the device model picker reads CLAWAI_STATIC_MODELS, not this array —
+      // it exists so `agents.defaults.imageModel` has something to resolve to
+      // when the user attaches a picture and the text-only session model
+      // cannot look at it. See the CLAWBOX_AI_VISION_* block in
+      // src/lib/clawbox-ai-models.ts for why it lives under this provider.
+      //
+      // No `reasoning`/`compat`: the media-understanding path issues a
+      // one-shot describe and never negotiates a thinking level.
+      {
+        id: CLAWBOX_AI_VISION_MODEL_ID,
+        name: CLAWBOX_AI_VISION_MODEL_LABEL,
+        input: [...CLAWBOX_AI_VISION_INPUT_MODALITIES],
+        maxTokens: CLAWBOX_AI_VISION_MAX_TOKENS,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      },
     ],
   });
 }
@@ -522,7 +543,7 @@ function foreignOpenAiRoute(provider: OpenAiProviderConfig | undefined): string 
 }
 
 /**
- * True when `agents.defaults.imageGenerationModel` already names a model.
+ * True when an `agents.defaults.<tool>Model` slot already names a model.
  *
  * Byte-for-byte the same test OpenClaw applies in `hasToolModelConfig`
  * (`dist/model-config.helpers-BS3FWcoO.js:25` on 2026.7.1-2):
@@ -538,8 +559,12 @@ function foreignOpenAiRoute(provider: OpenAiProviderConfig | undefined): string 
  * only the fallback. Claiming an occupied slot there would silently overrule a
  * choice the user made elsewhere, so we claim only what is empty. Mirrors the
  * same guard in the boot migration in scripts/gateway-pre-start.sh.
+ *
+ * Shared by `imageGenerationModel` (where images come from) and `imageModel`
+ * (what looks at an image the user sent). Different slots, identical
+ * don't-clobber rule, and OpenClaw reads both through the same helper.
  */
-function hasImageGenerationModel(existing: unknown): boolean {
+function hasToolModelConfig(existing: unknown): boolean {
   if (typeof existing !== "object" || existing === null) return false;
   const cfg = existing as { primary?: unknown; fallbacks?: unknown };
   if (typeof cfg.primary === "string" && cfg.primary.trim()) return true;
@@ -567,7 +592,7 @@ function hasImageGenerationModel(existing: unknown): boolean {
  * So a box with only the provider block would satisfy gate 2, fail gate 1, and
  * never see the tool. Naming a model in `imageGenerationModel` is the
  * deterministic path — hence the write below on every box that does not
- * already name one (see `hasImageGenerationModel` for why "already" includes
+ * already name one (see `hasToolModelConfig` for why "already" includes
  * fallbacks).
  *
  * Note the key name: `imageGenerationModel`, *not* `imageModel`. They are two
@@ -621,7 +646,7 @@ async function configureClawboxAiImages(clawboxAiToken: string): Promise<boolean
     buildClawboxAiImageProviderModels(existingOpenAiProvider?.models),
     "--json",
   ]);
-  if (hasImageGenerationModel(existingImageModel)) {
+  if (hasToolModelConfig(existingImageModel)) {
     console.log(
       "[AI Config] Left agents.defaults.imageGenerationModel alone: it already names an image model",
     );
@@ -665,6 +690,51 @@ async function configureClawboxAi(setFallback: boolean, preferredToken?: string)
     buildClawboxAiProviderDefinition(clawboxAiToken),
     "--json",
   ]);
+
+  // Point image *understanding* at the vision entry the provider definition
+  // above just wrote. Without this the device accepts an attached picture and
+  // then cannot look at it: the ClawBox AI chat models are `input: ["text"]`,
+  // so OpenClaw hands the turn a media path instead of inline image parts, and
+  // the `image` tool that would read that path resolves its model through
+  // `agents.defaults.imageModel` — which ClawBox provisioning never set, making
+  // `runWithImageModelFallback` throw "No image model configured"
+  // (`dist/model-fallback-CvSRhgYr.js` on 2026.7.1). Reproduced on a real box
+  // on 2026-08-21; see TASK-417.
+  //
+  // Same don't-clobber rule as image generation, for the same reason: this
+  // function also runs when ClawBox AI is merely being added as a *fallback*
+  // for some other provider, and a slot the owner filled is their choice.
+  // Non-fatal for the same reason too.
+  try {
+    let existingVisionModel: unknown;
+    try {
+      existingVisionModel = (await readOpenClawConfig()).agents?.defaults?.imageModel;
+    } catch {
+      // No readable config yet (fresh box) — nothing to preserve.
+      existingVisionModel = undefined;
+    }
+    if (hasToolModelConfig(existingVisionModel)) {
+      console.log(
+        "[AI Config] Left agents.defaults.imageModel alone: it already names a vision model",
+      );
+    } else {
+      await runCommand(OPENCLAW_BIN, [
+        "config",
+        "set",
+        "agents.defaults.imageModel",
+        JSON.stringify({ primary: CLAWBOX_AI_VISION_MODEL }),
+        "--json",
+      ]);
+      console.log(
+        `[AI Config] Set ClawBox AI vision model ${CLAWBOX_AI_VISION_MODEL} via proxy ${CLAWBOX_AI_PROXY_URL}`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      "[AI Config] Failed to configure ClawBox AI vision model:",
+      err instanceof Error ? logSafe(err.message) : err,
+    );
+  }
 
   // Images ride on the same token and the same proxy, so they are provisioned
   // here rather than behind a separate opt-in — a box that has ClawBox AI has

--- a/src/app/setup-api/chat/attachments/route.ts
+++ b/src/app/setup-api/chat/attachments/route.ts
@@ -110,6 +110,12 @@ export async function POST(req: NextRequest) {
   if (!contentType.includes("multipart/form-data")) {
     return NextResponse.json({ error: "Expected multipart/form-data" }, { status: 400 });
   }
+  // A multipart type with no boundary is malformed input, not a server fault:
+  // busboy's constructor throws on it, and that throw would otherwise surface
+  // as a 500 for a request the caller can fix.
+  if (!/;\s*boundary=/i.test(contentType)) {
+    return NextResponse.json({ error: "Expected multipart/form-data with a boundary" }, { status: 400 });
+  }
   if (!req.body) return NextResponse.json({ error: "No body" }, { status: 400 });
 
   // Preparing the staging directory is our side of the contract, not the
@@ -151,6 +157,9 @@ export async function POST(req: NextRequest) {
       let destPath = "";
       let sawFile = false;
       const writes: Promise<void>[] = [];
+      // The file stream currently being written, so an abort can stop it at the
+      // source rather than wait for bytes nobody wants any more.
+      let activeFileStream: Readable | null = null;
 
       const rejectOnce = (error: unknown) => {
         if (settled) return;
@@ -190,6 +199,7 @@ export async function POST(req: NextRequest) {
         written = dest;
         // busboy raises `limit` and then ends the stream, so the pipeline would
         // otherwise resolve on a truncated file and hand back a path to it.
+        activeFileStream = fileStream as unknown as Readable;
         fileStream.on("limit", () => rejectOnce(new BadUpload("File exceeds the size limit", 413)));
         // "wx": never clobber. A path we just generated should not exist, and
         // if it does, something is wrong enough that overwriting is the worst
@@ -222,9 +232,15 @@ export async function POST(req: NextRequest) {
       nodeStream.on("data", (chunk: Buffer) => {
         receivedBytes += chunk.length;
         if (receivedBytes > MAX_REQUEST_BYTES) {
+          // Tear down every stage, not just the source. Leaving busboy or the
+          // file stream alive means the pipeline never settles and the awaited
+          // cleanup below hangs instead of answering 413.
           nodeStream.unpipe(busboy);
           nodeStream.destroy();
-          rejectOnce(new BadUpload("Request exceeds the size limit", 413));
+          const aborted = new BadUpload("Request exceeds the size limit", 413);
+          activeFileStream?.destroy(aborted);
+          busboy.destroy();
+          rejectOnce(aborted);
         }
       });
       nodeStream.on("error", rejectOnce);

--- a/src/app/setup-api/chat/attachments/route.ts
+++ b/src/app/setup-api/chat/attachments/route.ts
@@ -55,11 +55,102 @@ const MAX_FIELDS = 8;
 const MAX_FIELD_BYTES = 4096;
 const MAX_PARTS = 12;
 
+// -- Retention --------------------------------------------------------------
+//
+// Every accepted upload stays here for as long as the chat message that names
+// it is useful, and nothing else ever removes one. Per-request limits bound a
+// single upload; they say nothing about the total. On a Jetson this directory
+// shares a disk with openclaw.json, the identity keys and every transcript, so
+// left alone it is a slow way to fill the box.
+//
+// Age first, then a total-size cap on what age left behind. Both are swept
+// before a new file is staged, best effort: a failed sweep must never turn a
+// good upload into an error.
+const RETENTION_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const RETENTION_MAX_BYTES = 500 * 1024 * 1024;
+// Nothing this young is ever removed, whatever the totals say. A file being
+// written by a concurrent request is the newest thing in the directory, and
+// deleting it out from under an in-flight upload would hand the composer back
+// a path with nothing at it.
+const RETENTION_MIN_AGE_MS = 60 * 1000;
+
 /** Raised for input the client got wrong (400) as opposed to a failure of ours (500). */
 class BadUpload extends Error {
   constructor(message: string, readonly status = 400) {
     super(message);
     this.name = "BadUpload";
+  }
+}
+
+/**
+ * The errors busboy 1.6.0's multipart parser raises for input it cannot read.
+ *
+ * Verified against busboy 1.6.0 rather than taken from the docs, because where
+ * they surface is not obvious: with no file part open both arrive on the Busboy
+ * instance, but a body truncated *while a file part is open* is emitted on that
+ * file's stream instead. So the same client mistake reaches this route by two
+ * different paths and has to be classified in both.
+ */
+const PARSER_FAULTS = new Set(["Malformed part header", "Unexpected end of form"]);
+
+/**
+ * Re-label a parser fault as client input; leave everything else alone.
+ *
+ * A malformed or truncated multipart body is something the caller can fix, so
+ * it is a 400. Anything else reaching the same handlers -- a write failure, a
+ * dead socket, a bug of ours -- keeps its identity and is reported as a 500,
+ * because telling the user to fix a request that was fine sends them nowhere.
+ */
+function asBadUpload(err: unknown): unknown {
+  if (err instanceof BadUpload) return err;
+  if (err instanceof Error && PARSER_FAULTS.has(err.message)) return new BadUpload(err.message);
+  return err;
+}
+
+/**
+ * Drop staged files that are old, then oldest-first until the directory fits.
+ *
+ * Best effort by construction: it is called for its side effect before a new
+ * upload is staged, and every failure -- an unreadable entry, a file that
+ * vanished under a concurrent sweep, a stat that races an unlink -- is skipped
+ * rather than raised. Directories and anything else that is not a regular file
+ * are left untouched.
+ */
+async function pruneStagingDir(dirReal: string): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await fsp.readdir(dirReal);
+  } catch {
+    return;
+  }
+  const now = Date.now();
+  const kept: { path: string; mtimeMs: number; size: number }[] = [];
+  for (const name of entries) {
+    const full = path.join(dirReal, name);
+    let stat;
+    try {
+      stat = await fsp.lstat(full);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    const age = now - stat.mtimeMs;
+    if (age < RETENTION_MIN_AGE_MS) continue;
+    if (age > RETENTION_MAX_AGE_MS) {
+      try { await fsp.unlink(full); } catch { /* raced another sweep */ }
+      continue;
+    }
+    kept.push({ path: full, mtimeMs: stat.mtimeMs, size: stat.size });
+  }
+  let total = kept.reduce((sum, f) => sum + f.size, 0);
+  if (total <= RETENTION_MAX_BYTES) return;
+  kept.sort((a, b) => a.mtimeMs - b.mtimeMs);
+  for (const f of kept) {
+    if (total <= RETENTION_MAX_BYTES) break;
+    try {
+      await fsp.unlink(f.path);
+      total -= f.size;
+    } catch { /* raced another sweep */ }
   }
 }
 
@@ -134,6 +225,11 @@ export async function POST(req: NextRequest) {
       { status: 500 },
     );
   }
+
+  // Before staging anything new, not after: the point is to make room, and a
+  // sweep that only ran on the way out would leave the last upload of a session
+  // sitting on the disk until the next one arrived.
+  await pruneStagingDir(dirReal);
 
   let written: string | null = null;
   // Hoisted so the cleanup below can wait for the write to stop before
@@ -212,7 +308,9 @@ export async function POST(req: NextRequest) {
         // Registered before the first thing that can reject, so an abort on
         // this part stops it at the source instead of leaving it draining.
         activeFileStream = fileStream as unknown as Readable;
-        fileStream.on("error", fail);
+        // A body truncated while this part is open surfaces here rather than on
+        // busboy, so the classifier has to run on this path too.
+        fileStream.on("error", (err) => fail(asBadUpload(err)));
         const leaf = safeLeafName(info.filename);
         if (!leaf) {
           fail(new BadUpload("Invalid filename"));
@@ -258,7 +356,10 @@ export async function POST(req: NextRequest) {
           })
           .catch(fail);
       });
-      busboy.on("error", fail);
+      // Malformed headers and a body that ends early are the caller's mistake,
+      // not ours; unclassified they left this route answering 500 for a request
+      // no server change could ever make work.
+      busboy.on("error", (err) => fail(asBadUpload(err)));
 
       const source = Readable.fromWeb(req.body as unknown as import("stream/web").ReadableStream);
       nodeStream = source;

--- a/src/app/setup-api/chat/attachments/route.ts
+++ b/src/app/setup-api/chat/attachments/route.ts
@@ -160,25 +160,62 @@ export async function POST(req: NextRequest) {
       // The file stream currently being written, so an abort can stop it at the
       // source rather than wait for bytes nobody wants any more.
       let activeFileStream: Readable | null = null;
+      // Assigned once the request body is adapted, below. Hoisted so the abort
+      // helper can reach it: nothing can emit before `pipe`, so it is never
+      // still null by the time an abort can fire.
+      let nodeStream: Readable | null = null;
 
-      const rejectOnce = (error: unknown) => {
+      /**
+       * The single way this upload fails.
+       *
+       * Rejecting on its own is not enough, because rejecting stops nothing.
+       * Two failures were reproduced against the previous reject-and-hope
+       * version:
+       *
+       *  - `fieldsLimit` ends `field` events but not `file` ones. With the body
+       *    split across chunks the way a real connection delivers it, the route
+       *    answered 400 and busboy then handed over the file part anyway,
+       *    staging a file on the customer's disk that nothing would ever come
+       *    back for. It only looked clean under test because a single-chunk
+       *    body let the `file` event land before the catch read `written`.
+       *  - a source error mid-file (client hung up) left busboy and the file
+       *    stream alive, so the write never settled, the awaited cleanup never
+       *    returned, and the route answered *nothing at all* — not a slow 500,
+       *    a permanent hang.
+       *
+       * So every limit, parser, file, write and source error comes through
+       * here, and it tears down all three stages before rejecting. Destroying
+       * the file stream with the error is what makes an in-flight write settle,
+       * which is what lets the cleanup unlink the partial file rather than wait
+       * on it forever. Idempotent, because the teardown makes other handlers
+       * fire in turn.
+       */
+      const fail = (error: unknown) => {
         if (settled) return;
         settled = true;
+        const cause = error instanceof Error ? error : new Error(String(error));
+        nodeStream?.unpipe(busboy);
+        nodeStream?.destroy();
+        activeFileStream?.destroy(cause);
+        busboy.destroy();
         reject(error);
       };
 
       // busboy stops emitting past a limit rather than failing, so a request
       // that trips one would otherwise look like a well-formed short upload.
-      busboy.on("filesLimit", () => rejectOnce(new BadUpload("Only one file per request")));
-      busboy.on("partsLimit", () => rejectOnce(new BadUpload("Too many multipart parts")));
-      busboy.on("fieldsLimit", () => rejectOnce(new BadUpload("Too many form fields")));
+      busboy.on("filesLimit", () => fail(new BadUpload("Only one file per request")));
+      busboy.on("partsLimit", () => fail(new BadUpload("Too many multipart parts")));
+      busboy.on("fieldsLimit", () => fail(new BadUpload("Too many form fields")));
 
       busboy.on("file", (_field, fileStream, info) => {
         sawFile = true;
+        // Registered before the first thing that can reject, so an abort on
+        // this part stops it at the source instead of leaving it draining.
+        activeFileStream = fileStream as unknown as Readable;
+        fileStream.on("error", fail);
         const leaf = safeLeafName(info.filename);
         if (!leaf) {
-          fileStream.resume();
-          rejectOnce(new BadUpload("Invalid filename"));
+          fail(new BadUpload("Invalid filename"));
           return;
         }
         // Storage name is ours, display name is theirs. Deriving the path from
@@ -190,8 +227,7 @@ export async function POST(req: NextRequest) {
         const storageName = `${randomUUID()}-${leaf}`;
         const dest = resolveDest(dirReal, storageName);
         if (!dest) {
-          fileStream.resume();
-          rejectOnce(new BadUpload("Invalid destination"));
+          fail(new BadUpload("Invalid destination"));
           return;
         }
         fileName = leaf;
@@ -199,20 +235,19 @@ export async function POST(req: NextRequest) {
         written = dest;
         // busboy raises `limit` and then ends the stream, so the pipeline would
         // otherwise resolve on a truncated file and hand back a path to it.
-        activeFileStream = fileStream as unknown as Readable;
-        fileStream.on("limit", () => rejectOnce(new BadUpload("File exceeds the size limit", 413)));
+        fileStream.on("limit", () => fail(new BadUpload("File exceeds the size limit", 413)));
         // "wx": never clobber. A path we just generated should not exist, and
         // if it does, something is wrong enough that overwriting is the worst
         // available answer.
         const write = pipeline(fileStream, fs.createWriteStream(dest, { flags: "wx" })).then(() => {});
         writes.push(write);
         pendingWrites.push(write);
-        write.catch(rejectOnce);
+        write.catch(fail);
       });
 
       busboy.on("finish", () => {
         if (!sawFile) {
-          rejectOnce(new BadUpload("No file part"));
+          fail(new BadUpload("No file part"));
           return;
         }
         void Promise.all(writes)
@@ -221,30 +256,23 @@ export async function POST(req: NextRequest) {
             settled = true;
             resolve({ name: fileName, path: destPath });
           })
-          .catch(rejectOnce);
+          .catch(fail);
       });
-      busboy.on("error", rejectOnce);
+      busboy.on("error", fail);
 
-      const nodeStream = Readable.fromWeb(req.body as unknown as import("stream/web").ReadableStream);
+      const source = Readable.fromWeb(req.body as unknown as import("stream/web").ReadableStream);
+      nodeStream = source;
       // Total-request guard. Per-file and per-field limits leave the sum
       // unbounded, so count what actually arrives and cut the stream off.
       let receivedBytes = 0;
-      nodeStream.on("data", (chunk: Buffer) => {
+      source.on("data", (chunk: Buffer) => {
         receivedBytes += chunk.length;
         if (receivedBytes > MAX_REQUEST_BYTES) {
-          // Tear down every stage, not just the source. Leaving busboy or the
-          // file stream alive means the pipeline never settles and the awaited
-          // cleanup below hangs instead of answering 413.
-          nodeStream.unpipe(busboy);
-          nodeStream.destroy();
-          const aborted = new BadUpload("Request exceeds the size limit", 413);
-          activeFileStream?.destroy(aborted);
-          busboy.destroy();
-          rejectOnce(aborted);
+          fail(new BadUpload("Request exceeds the size limit", 413));
         }
       });
-      nodeStream.on("error", rejectOnce);
-      nodeStream.pipe(busboy);
+      source.on("error", fail);
+      source.pipe(busboy);
     });
     return NextResponse.json({ ok: true, name: result.name, path: result.path });
   } catch (err) {

--- a/src/app/setup-api/chat/attachments/route.ts
+++ b/src/app/setup-api/chat/attachments/route.ts
@@ -1,0 +1,176 @@
+import { NextRequest, NextResponse } from "next/server";
+import fs from "fs";
+import fsp from "fs/promises";
+import path from "path";
+import { Readable } from "stream";
+import { pipeline } from "stream/promises";
+import Busboy from "busboy";
+import { OPENCLAW_HOME } from "@/lib/openclaw-config";
+
+export const dynamic = "force-dynamic";
+
+// -- Chat attachment staging ------------------------------------------------
+//
+// Where a file the user attaches in device chat is written so the agent can
+// actually open it.
+//
+// The chat composer uploads the file and then names its absolute path in the
+// message (`[Attached file: /abs/path]`), so the path has to be one OpenClaw
+// will read. It maintains a fixed allowlist of media roots --
+// `buildMediaLocalRoots` in `dist/local-roots-CAoJyC6u.js` on 2026.7.1: the
+// openclaw tmp dir, `<configDir>/media`, and
+// `<stateDir>/{media,canvas,workspace,sandboxes}`, plus the agent workspace.
+// `$HOME/uploads`, which is where `/setup-api/files?dir=uploads` puts it, is on
+// none of them, so the `image` tool answers "Local media path is not under an
+// allowed directory" and the assistant tells the user it cannot see the
+// picture. Reproduced on a real box on 2026-08-21 with the exact path the
+// composer produces; see TASK-417.
+//
+// `<stateDir>/media` is the allowlisted root that is also where OpenClaw keeps
+// inbound media of its own, so a subdirectory of it is the natural home. The
+// Files API cannot be used for this: file-guard.ts refuses the whole of
+// ~/.openclaw there -- correctly, since that tree also holds openclaw.json, the
+// identity keys and every transcript -- and relaxing that guard to land one
+// attachment would expose the credentials with it. Same reasoning, and the same
+// OPENCLAW_HOME rooting, as the sibling media reader in ../media/route.ts.
+//
+// Session-gated by middleware, which lists /setup-api/chat among the surfaces
+// that stay closed even during the pre-setup AP window.
+const ATTACHMENT_DIR = path.join(OPENCLAW_HOME, "media", "chat-attachments");
+
+// OpenClaw refuses an inline chat image over 6 MB
+// (`attachment-normalize-CpH9LzfB.js`), but this path is not the inline one --
+// it stages a file the agent opens by path, and the composer also accepts PDFs
+// and text. 25 MB matches the ceiling the sibling media reader uses.
+const MAX_BYTES = 25 * 1024 * 1024;
+
+/**
+ * A filesystem-safe leaf name for an uploaded file.
+ *
+ * The name arrives from a browser file picker or a clipboard paste, so it is
+ * attacker-influenced in the same way any upload name is. `path.basename`
+ * drops any directory part, the character class removes separators and control
+ * bytes that survive it on some platforms, and leading dots are stripped so an
+ * upload cannot land as a dotfile. Returns null when nothing usable is left --
+ * the caller rejects rather than inventing a name, so the client never gets
+ * back a path it did not send a file for.
+ *
+ * Containment is still re-checked against the resolved directory after the
+ * join; this is the first of two gates, not the only one.
+ */
+function safeLeafName(raw: string): string | null {
+  const base = path.basename(String(raw ?? "").trim());
+  const cleaned = base
+    .replace(/[\u0000-\u001f\u007f/\\]/g, "")
+    .replace(/^\.+/, "")
+    .slice(0, 120)
+    .trim();
+  if (!cleaned || cleaned === "." || cleaned === "..") return null;
+  return cleaned;
+}
+
+/**
+ * `<dir>/<name>`, or null when the join escapes `dir`.
+ *
+ * Belt and braces over `safeLeafName`. An exact-match check is not enough on
+ * its own: without the separator a sibling like `.../chat-attachments-evil`
+ * would pass a bare `startsWith`.
+ */
+function resolveDest(dirReal: string, name: string): string | null {
+  const dest = path.resolve(dirReal, name);
+  if (dest !== dirReal && !dest.startsWith(dirReal + path.sep)) return null;
+  return dest;
+}
+
+// POST /setup-api/chat/attachments
+// Body: multipart/form-data with one `file` part.
+// Returns { ok, name, path } -- the same shape the composer already reads back
+// from the Files API, so only the URL changes on the client.
+export async function POST(req: NextRequest) {
+  const contentType = req.headers.get("content-type") ?? "";
+  if (!contentType.includes("multipart/form-data")) {
+    return NextResponse.json({ error: "Expected multipart/form-data" }, { status: 400 });
+  }
+  if (!req.body) return NextResponse.json({ error: "No body" }, { status: 400 });
+
+  await fsp.mkdir(ATTACHMENT_DIR, { recursive: true });
+  // Resolve AFTER mkdir: realpath on a directory that does not exist yet
+  // throws, and ~/.openclaw is a symlink on shared-identity installs.
+  const dirReal = await fsp.realpath(ATTACHMENT_DIR);
+
+  let written: string | null = null;
+  try {
+    const result = await new Promise<{ name: string; path: string }>((resolve, reject) => {
+      const busboy = Busboy({
+        headers: { "content-type": contentType },
+        limits: { files: 1, fileSize: MAX_BYTES },
+      });
+      let settled = false;
+      let fileName = "";
+      let destPath = "";
+      let sawFile = false;
+      const writes: Promise<void>[] = [];
+
+      const rejectOnce = (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+
+      busboy.on("file", (_field, fileStream, info) => {
+        sawFile = true;
+        const leaf = safeLeafName(info.filename);
+        if (!leaf) {
+          fileStream.resume();
+          rejectOnce(new Error("Invalid filename"));
+          return;
+        }
+        const dest = resolveDest(dirReal, leaf);
+        if (!dest) {
+          fileStream.resume();
+          rejectOnce(new Error("Invalid destination"));
+          return;
+        }
+        fileName = leaf;
+        destPath = dest;
+        written = dest;
+        // busboy raises `limit` and then ends the stream, so the pipeline would
+        // otherwise resolve on a truncated file and hand back a path to it.
+        fileStream.on("limit", () => rejectOnce(new Error("File exceeds the size limit")));
+        const write = pipeline(fileStream, fs.createWriteStream(dest)).then(() => {});
+        writes.push(write);
+        write.catch(rejectOnce);
+      });
+
+      busboy.on("finish", () => {
+        if (!sawFile) {
+          rejectOnce(new Error("No file part"));
+          return;
+        }
+        void Promise.all(writes)
+          .then(() => {
+            if (settled) return;
+            settled = true;
+            resolve({ name: fileName, path: destPath });
+          })
+          .catch(rejectOnce);
+      });
+      busboy.on("error", rejectOnce);
+
+      const nodeStream = Readable.fromWeb(req.body as unknown as import("stream/web").ReadableStream);
+      nodeStream.pipe(busboy);
+    });
+    return NextResponse.json({ ok: true, name: result.name, path: result.path });
+  } catch (err) {
+    // A rejected upload must not leave a partial file behind: the composer
+    // would be told nothing, but a later request reusing the name would
+    // silently inherit whatever bytes did land.
+    if (written) {
+      try { await fsp.unlink(written); } catch { /* best effort */ }
+    }
+    return NextResponse.json(
+      { error: `Upload failed: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 400 },
+    );
+  }
+}

--- a/src/app/setup-api/chat/attachments/route.ts
+++ b/src/app/setup-api/chat/attachments/route.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import Busboy from "busboy";
+import { randomUUID } from "crypto";
 import { OPENCLAW_HOME } from "@/lib/openclaw-config";
 
 export const dynamic = "force-dynamic";
@@ -43,6 +44,24 @@ const ATTACHMENT_DIR = path.join(OPENCLAW_HOME, "media", "chat-attachments");
 // it stages a file the agent opens by path, and the composer also accepts PDFs
 // and text. 25 MB matches the ceiling the sibling media reader uses.
 const MAX_BYTES = 25 * 1024 * 1024;
+
+// `limits.fileSize` bounds each file, not the request. Without a total-bytes
+// guard a caller can stream unbounded data at the disk under one part, or pile
+// on parts and fields that never hit the file limit at all. This route is
+// session-gated, so this is a resource guard rather than a perimeter, but the
+// disk it fills is the customer's.
+const MAX_REQUEST_BYTES = MAX_BYTES + 1024 * 1024;
+const MAX_FIELDS = 8;
+const MAX_FIELD_BYTES = 4096;
+const MAX_PARTS = 12;
+
+/** Raised for input the client got wrong (400) as opposed to a failure of ours (500). */
+class BadUpload extends Error {
+  constructor(message: string, readonly status = 400) {
+    super(message);
+    this.name = "BadUpload";
+  }
+}
 
 /**
  * A filesystem-safe leaf name for an uploaded file.
@@ -93,17 +112,39 @@ export async function POST(req: NextRequest) {
   }
   if (!req.body) return NextResponse.json({ error: "No body" }, { status: 400 });
 
-  await fsp.mkdir(ATTACHMENT_DIR, { recursive: true });
-  // Resolve AFTER mkdir: realpath on a directory that does not exist yet
-  // throws, and ~/.openclaw is a symlink on shared-identity installs.
-  const dirReal = await fsp.realpath(ATTACHMENT_DIR);
+  // Preparing the staging directory is our side of the contract, not the
+  // caller's: a read-only filesystem or a bad permission here is a 500, and it
+  // has to be caught, or the rejection escapes the route with no JSON body at
+  // all.
+  let dirReal: string;
+  try {
+    await fsp.mkdir(ATTACHMENT_DIR, { recursive: true });
+    // Resolve AFTER mkdir: realpath on a directory that does not exist yet
+    // throws, and ~/.openclaw is a symlink on shared-identity installs.
+    dirReal = await fsp.realpath(ATTACHMENT_DIR);
+  } catch (err) {
+    return NextResponse.json(
+      { error: `Could not prepare the attachment directory: ${err instanceof Error ? err.message : String(err)}` },
+      { status: 500 },
+    );
+  }
 
   let written: string | null = null;
+  // Hoisted so the cleanup below can wait for the write to stop before
+  // unlinking. Rejecting on a limit does not halt the pipeline synchronously,
+  // and an unlink that races it just gets the bytes written back underneath it.
+  const pendingWrites: Promise<unknown>[] = [];
   try {
     const result = await new Promise<{ name: string; path: string }>((resolve, reject) => {
       const busboy = Busboy({
         headers: { "content-type": contentType },
-        limits: { files: 1, fileSize: MAX_BYTES },
+        limits: {
+          files: 1,
+          fileSize: MAX_BYTES,
+          fields: MAX_FIELDS,
+          fieldSize: MAX_FIELD_BYTES,
+          parts: MAX_PARTS,
+        },
       });
       let settled = false;
       let fileName = "";
@@ -117,18 +158,31 @@ export async function POST(req: NextRequest) {
         reject(error);
       };
 
+      // busboy stops emitting past a limit rather than failing, so a request
+      // that trips one would otherwise look like a well-formed short upload.
+      busboy.on("filesLimit", () => rejectOnce(new BadUpload("Only one file per request")));
+      busboy.on("partsLimit", () => rejectOnce(new BadUpload("Too many multipart parts")));
+      busboy.on("fieldsLimit", () => rejectOnce(new BadUpload("Too many form fields")));
+
       busboy.on("file", (_field, fileStream, info) => {
         sawFile = true;
         const leaf = safeLeafName(info.filename);
         if (!leaf) {
           fileStream.resume();
-          rejectOnce(new Error("Invalid filename"));
+          rejectOnce(new BadUpload("Invalid filename"));
           return;
         }
-        const dest = resolveDest(dirReal, leaf);
+        // Storage name is ours, display name is theirs. Deriving the path from
+        // the client filename alone means two uploads called screenshot.png
+        // land on the same file, and the second silently rewrites the bytes an
+        // earlier chat message already points at — `createWriteStream` opens
+        // "w", which truncates. The uuid prefix also makes the exclusive open
+        // below a genuine collision check rather than a formality.
+        const storageName = `${randomUUID()}-${leaf}`;
+        const dest = resolveDest(dirReal, storageName);
         if (!dest) {
           fileStream.resume();
-          rejectOnce(new Error("Invalid destination"));
+          rejectOnce(new BadUpload("Invalid destination"));
           return;
         }
         fileName = leaf;
@@ -136,15 +190,19 @@ export async function POST(req: NextRequest) {
         written = dest;
         // busboy raises `limit` and then ends the stream, so the pipeline would
         // otherwise resolve on a truncated file and hand back a path to it.
-        fileStream.on("limit", () => rejectOnce(new Error("File exceeds the size limit")));
-        const write = pipeline(fileStream, fs.createWriteStream(dest)).then(() => {});
+        fileStream.on("limit", () => rejectOnce(new BadUpload("File exceeds the size limit", 413)));
+        // "wx": never clobber. A path we just generated should not exist, and
+        // if it does, something is wrong enough that overwriting is the worst
+        // available answer.
+        const write = pipeline(fileStream, fs.createWriteStream(dest, { flags: "wx" })).then(() => {});
         writes.push(write);
+        pendingWrites.push(write);
         write.catch(rejectOnce);
       });
 
       busboy.on("finish", () => {
         if (!sawFile) {
-          rejectOnce(new Error("No file part"));
+          rejectOnce(new BadUpload("No file part"));
           return;
         }
         void Promise.all(writes)
@@ -158,6 +216,18 @@ export async function POST(req: NextRequest) {
       busboy.on("error", rejectOnce);
 
       const nodeStream = Readable.fromWeb(req.body as unknown as import("stream/web").ReadableStream);
+      // Total-request guard. Per-file and per-field limits leave the sum
+      // unbounded, so count what actually arrives and cut the stream off.
+      let receivedBytes = 0;
+      nodeStream.on("data", (chunk: Buffer) => {
+        receivedBytes += chunk.length;
+        if (receivedBytes > MAX_REQUEST_BYTES) {
+          nodeStream.unpipe(busboy);
+          nodeStream.destroy();
+          rejectOnce(new BadUpload("Request exceeds the size limit", 413));
+        }
+      });
+      nodeStream.on("error", rejectOnce);
       nodeStream.pipe(busboy);
     });
     return NextResponse.json({ ok: true, name: result.name, path: result.path });
@@ -166,11 +236,16 @@ export async function POST(req: NextRequest) {
     // would be told nothing, but a later request reusing the name would
     // silently inherit whatever bytes did land.
     if (written) {
+      await Promise.allSettled(pendingWrites);
       try { await fsp.unlink(written); } catch { /* best effort */ }
     }
+    // 400/413 only for input the caller can fix. Anything else is ours —
+    // a full disk, a permission problem — and reporting it as a client error
+    // sends the user off debugging a request that was fine.
+    const status = err instanceof BadUpload ? err.status : 500;
     return NextResponse.json(
       { error: `Upload failed: ${err instanceof Error ? err.message : String(err)}` },
-      { status: 400 },
+      { status },
     );
   }
 }

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -1492,9 +1492,17 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     return () => window.clearInterval(timer)
   }, [generatingImage, status, reconcileTranscript, endImageWait])
 
-  // Upload one or more files to the server's /uploads dir and add them to
-  // the chat attachment list. Shared by the file-input change handler and
-  // by the textarea paste handler (Ctrl+V on a clipboard image).
+  // Stage one or more files for the agent and add them to the chat attachment
+  // list. Shared by the file-input change handler and by the textarea paste
+  // handler (Ctrl+V on a clipboard image).
+  //
+  // Deliberately NOT the Files API. dispatchSend puts the returned absolute
+  // path in the message, and OpenClaw only reads media from a fixed allowlist
+  // of roots; $HOME/uploads, where `/setup-api/files?dir=uploads` writes, is
+  // not one of them, so the agent got "Local media path is not under an
+  // allowed directory" and told the user it could not see the picture
+  // (TASK-417). /setup-api/chat/attachments writes under <stateDir>/media,
+  // which is on that allowlist. Same { name, path } response shape.
   const uploadFiles = useCallback((files: File[]) => {
     if (files.length === 0) return
     const stampBase = Date.now()
@@ -1509,7 +1517,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       const formData = new FormData()
       formData.append('file', rawFile, filename)
       try {
-        const res = await fetch('/setup-api/files?dir=uploads', { method: 'POST', body: formData })
+        const res = await fetch('/setup-api/chat/attachments', { method: 'POST', body: formData })
         if (!res.ok) return
         const json = await res.json().catch(() => ({} as { name?: string; path?: string }))
         const name = json.name || filename

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -171,3 +171,61 @@ export function normalizeClawboxAiPlan(value: unknown): ClawboxAiPlan | null {
 export function monthlyImageLimitForPlan(plan: ClawboxAiPlan | null): number | null {
   return plan ? CLAWBOX_AI_MONTHLY_IMAGE_LIMITS[plan] : null;
 }
+
+/* ---------------------------------------------------------------------------
+ * ClawBox AI vision (image understanding)
+ * ------------------------------------------------------------------------ */
+
+/**
+ * Model the device uses to *look at* an image the user attached in chat.
+ *
+ * Registered under `CLAWBOX_AI_PROVIDER` (`deepseek`) rather than `openai`,
+ * even though the id is an OpenAI one, because that provider entry is really
+ * "the ClawBox AI proxy": it already carries `api: "openai-completions"`, the
+ * proxy `baseUrl` and the `claw_` subscription token, which is exactly the
+ * transport a vision request needs. OpenClaw's `openai` provider defaults to
+ * `openai-responses` (`dist/model-C3gzf-T3.js` on 2026.7.1), an API the proxy
+ * does not speak, so an entry there would have to re-declare the api, the
+ * baseUrl and the auth to end up in the same place.
+ *
+ * It cannot leak into the chat model picker: the device catalogue for
+ * `clawai` is the hardcoded two-entry `CLAWAI_STATIC_MODELS` in
+ * src/app/setup-api/ai-models/catalog/route.ts, not a read of
+ * `models.providers.deepseek.models`.
+ *
+ * Env-overridable for the same reason the chat and image slugs are — the proxy
+ * matches the BARE id against its allowlist, so this value must always name
+ * something production already allows.
+ */
+export const CLAWBOX_AI_VISION_MODEL_ID =
+  process.env.CLAWBOX_AI_VISION_MODEL_ID?.trim() || "gpt-5.6-luna";
+
+/** `name` on the model entry. Required by OpenClaw's schema — see the image label. */
+export const CLAWBOX_AI_VISION_MODEL_LABEL = "ClawBox AI Vision";
+
+/** Fully-qualified ref written to `agents.defaults.imageModel.primary`. */
+export const CLAWBOX_AI_VISION_MODEL = `${CLAWBOX_AI_PROVIDER}/${CLAWBOX_AI_VISION_MODEL_ID}`;
+
+/**
+ * Input modalities. `image` is the whole point of the entry: OpenClaw's
+ * `resolveImageRuntime` (`dist/image-Bg-2ezSd.js:99` on 2026.7.1) refuses a
+ * media-understanding model whose catalog entry does not advertise it, with
+ * "Model does not support images".
+ */
+export const CLAWBOX_AI_VISION_INPUT_MODALITIES = ["text", "image"] as const;
+
+/**
+ * Completion-token ceiling the upstream actually enforces, measured against the
+ * live proxy from a device on 2026-08-21: `max_tokens: 128000` is accepted,
+ * `200000` and `400000` both come back 400 "max_tokens is too large … This
+ * model supports at most 128000 completion tokens".
+ *
+ * 200,000 is not an arbitrary counter-example: it is the generic default a
+ * configured provider entry falls through to when it omits the field, because
+ * an entry in `models.providers` overrides OpenClaw's bundled catalog outright.
+ * The media-understanding path in 2026.7.1 happens not to send `max_tokens` at
+ * all — verified on a real box, the describe call succeeds with this field
+ * removed — so this is a guard against any caller that does start sending it,
+ * not the thing that makes vision work today.
+ */
+export const CLAWBOX_AI_VISION_MAX_TOKENS = 128_000;

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -500,6 +500,11 @@ export interface OpenClawConfig {
       // `model`, entirely separate key — and distinct again from `imageModel`,
       // which selects the vision (image *understanding*) model.
       imageGenerationModel?: { primary?: string; fallbacks?: string[] };
+      // Which model *looks at* an image — the vision model OpenClaw resolves
+      // when a text-only session model is handed a picture and the `image`
+      // tool has to describe it. Same shape, separate key from
+      // `imageGenerationModel`; nothing aliases the two.
+      imageModel?: { primary?: string; fallbacks?: string[] };
       workspace?: string;
       compaction?: { reserveTokensFloor?: number };
     };

--- a/src/tests/components/chat-attachment-staging.test.tsx
+++ b/src/tests/components/chat-attachment-staging.test.tsx
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * TASK-417: the device accepted an attached image and then answered that it
+ * could not see it.
+ *
+ * Half of that was a missing vision model (covered by the configure-route and
+ * gateway-pre-start tests). The other half is here: the composer uploaded to
+ * the Files API, which writes to `$HOME/uploads`, and then named that absolute
+ * path in the message. OpenClaw reads media only from a fixed root allowlist
+ * (`buildMediaLocalRoots`), and `$HOME/uploads` is not on it, so the `image`
+ * tool answered "Local media path is not under an allowed directory" — proven
+ * on box 192.168.50.65 on 2026-08-21 with the exact path the composer produces.
+ *
+ * Asserting on the component rather than on source text: the upload URL and the
+ * `[Attached file: …]` line are two different callbacks that have to agree, and
+ * what matters to a customer is that the path the agent is handed is one it can
+ * open.
+ */
+
+const STAGED_PATH = "/home/clawbox/.openclaw/media/chat-attachments/paste-1.png";
+
+type Frame = Record<string, unknown>;
+
+const instances: FakeGatewayWs[] = [];
+const sentFrames: Frame[] = [];
+
+class FakeGatewayWs {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readyState = FakeGatewayWs.OPEN;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onopen: (() => void) | null = null;
+
+  constructor(public url: string) {
+    instances.push(this);
+    setTimeout(() => this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "test-nonce" } }), 0);
+  }
+
+  send(raw: string) {
+    let frame: Frame;
+    try {
+      frame = JSON.parse(raw) as Frame;
+    } catch {
+      return;
+    }
+    if (frame.type !== "req") return;
+    sentFrames.push(frame);
+    const id = frame.id as string;
+    if (frame.method === "connect") {
+      this.respond(id, { snapshot: { sessionDefaults: { mainSessionKey: "agent:main:main" } } });
+      return;
+    }
+    if (frame.method === "chat.history") {
+      this.respond(id, { messages: [] });
+      return;
+    }
+    // Any other request is a turn. Ack it and then close it out: the surface
+    // opens with an automatic greeting, and a run that never finishes leaves
+    // `sending` true, which queues the turn under test instead of sending it.
+    const runId = `run-${sentFrames.length}`;
+    this.respond(id, { runId, status: "started" });
+    setTimeout(() => this.emit({
+      type: "event",
+      event: "chat",
+      payload: {
+        runId,
+        sessionKey: "agent:main:main",
+        state: "final",
+        stopReason: "stop",
+        message: { role: "assistant", content: [{ type: "text", text: "ok" }], timestamp: 1787260000000 },
+      },
+    }), 1);
+  }
+
+  close() { this.readyState = FakeGatewayWs.CLOSED; }
+  addEventListener() {}
+  removeEventListener() {}
+
+  private respond(id: string, payload: unknown) {
+    setTimeout(() => this.emit({ type: "res", id, ok: true, payload }), 0);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+/** Every URL the component fetched, in order. */
+const fetchedUrls: string[] = [];
+
+function installFetch() {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      fetchedUrls.push(url);
+      if (url.includes("/setup-api/gateway/ws-config")) {
+        return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+      }
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+      }
+      if (url.includes("/setup-api/chat/model")) {
+        return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+      }
+      if (url.includes("/setup-api/chat/attachments")) {
+        return { ok: true, json: async () => ({ ok: true, name: "paste-1.png", path: STAGED_PATH }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+}
+
+/**
+ * Wait until the composer is live.
+ *
+ * The paste handler is a no-op until the socket says `connected` — pasting
+ * before the handshake lands makes this test silently assert nothing.
+ */
+async function connected() {
+  await waitFor(() => {
+    expect(sentFrames.some((f) => f.method === "chat.history")).toBe(true);
+  });
+}
+
+/** Paste one PNG into the composer, the way Ctrl+V on a screenshot does. */
+function pasteImage(textarea: HTMLElement) {
+  const file = new File([new Uint8Array([1, 2, 3])], "image.png", { type: "image/png" });
+  fireEvent.paste(textarea, {
+    clipboardData: {
+      items: [{ kind: "file", type: "image/png", getAsFile: () => file }],
+    },
+  });
+}
+
+describe("device chat attachment staging", () => {
+  beforeEach(() => {
+    instances.length = 0;
+    sentFrames.length = 0;
+    fetchedUrls.length = 0;
+    resetHarnessCache();
+    window.localStorage.clear();
+    // jsdom has no layout engine, so the transcript's auto-scroll has nothing
+    // to call. Unrelated to what is under test.
+    Element.prototype.scrollIntoView = vi.fn();
+    installFetch();
+    vi.stubGlobal("WebSocket", FakeGatewayWs as unknown as typeof WebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetHarnessCache();
+  });
+
+  it("uploads a pasted image to the staging route, not the Files API", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    const textarea = await screen.findByRole("textbox");
+    await connected();
+
+    pasteImage(textarea);
+
+    await waitFor(() => {
+      expect(fetchedUrls.some((u) => u.includes("/setup-api/chat/attachments"))).toBe(true);
+    });
+    // $HOME/uploads is outside OpenClaw's media allowlist — going back to it
+    // is the regression this test exists to catch.
+    expect(fetchedUrls.some((u) => u.includes("/setup-api/files"))).toBe(false);
+  });
+
+  it("hands the agent the staged path, inside an allowed media root", async () => {
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    const textarea = await screen.findByRole("textbox");
+    await connected();
+
+    pasteImage(textarea);
+    await waitFor(() => expect(document.body.textContent).toContain("paste-1.png"));
+
+    fireEvent.change(textarea, { target: { value: "what is in this picture?" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+    // The turn we typed, not whatever else the surface sends on open.
+    const message = await waitFor(() => {
+      const text = sentFrames
+        .filter((f) => f.method === "chat.send")
+        .map((f) => String((f.params as { message?: unknown }).message ?? ""))
+        .find((m) => m.includes("what is in this picture?"));
+      expect(text).toBeDefined();
+      return text as string;
+    });
+
+    expect(message).toContain(`[Attached file: ${STAGED_PATH}]`);
+    expect(message).not.toContain("/uploads/");
+  });
+});

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -244,7 +244,11 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
       const call = callFor("agents.defaults.imageGenerationModel");
       expect(call?.[2]).toBe("--json");
       expect(JSON.parse(call?.[1] ?? "null")).toEqual({ primary: CLAWBOX_AI_IMAGE_MODEL });
-      expect(callFor("agents.defaults.imageModel")).toBeUndefined();
+      // The route also writes `imageModel` — the vision key, from a different
+      // function (TASK-417). What must never happen is the two aliasing: the
+      // image-generation slot has to name the image model and nothing else.
+      const visionCall = callFor("agents.defaults.imageModel");
+      expect(JSON.parse(visionCall?.[1] ?? "null")).not.toEqual({ primary: CLAWBOX_AI_IMAGE_MODEL });
     });
 
     it("names the same model the boot migration writes", async () => {

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import fsp from "fs/promises";
+import type { ChildProcess } from "child_process";
+import { EventEmitter } from "events";
+import {
+  CLAWBOX_AI_VISION_MODEL,
+  CLAWBOX_AI_VISION_MODEL_ID,
+  CLAWBOX_AI_VISION_MODEL_LABEL,
+  CLAWBOX_AI_VISION_MAX_TOKENS,
+} from "@/lib/clawbox-ai-models";
+
+// The ClawBox AI vision half of POST /setup-api/ai-models/configure
+// (TASK-417). Without it a provisioned box accepts an image attachment and then
+// answers that it cannot see it: both chat tiers are text-only, so OpenClaw
+// hands the turn a media path, and the `image` tool that would read it resolves
+// its model from `agents.defaults.imageModel` — which provisioning never wrote,
+// so runWithImageModelFallback throws "No image model configured".
+//
+// Mocks are the same set configure-images.test.ts uses — the route's
+// collaborators, with `runOpenclawConfigSet` as the boundary every
+// `openclaw config set` goes through, so the assertions below are about the
+// exact commands the route runs.
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    rename: vi.fn(),
+    chown: vi.fn(),
+    mkdir: vi.fn(),
+    rm: vi.fn(),
+    unlink: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/home/clawbox/clawbox/data",
+  getAll: vi.fn(),
+  setMany: vi.fn(),
+}));
+
+vi.mock("@/lib/clawkeep", () => ({
+  unpairLocal: vi.fn(),
+}));
+
+// Out-of-band catalog refresh the route deliberately does not await; stubbing
+// it stops its late console write from racing worker teardown. See the long
+// note in configure.test.ts.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  refreshInBackground: vi.fn(),
+}));
+
+const { parseFullyQualifiedModelImpl, LLAMACPP_PROXY_BASE_URL } = vi.hoisted(() => ({
+  parseFullyQualifiedModelImpl(fq: string) {
+    const idx = fq.indexOf("/");
+    if (idx <= 0 || idx === fq.length - 1) return null;
+    return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+  },
+  LLAMACPP_PROXY_BASE_URL: "http://127.0.0.1/setup-api/local-ai/llamacpp/v1",
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR: 24000,
+  compactionReserveFloorForContext: (contextWindow: number) =>
+    Number.isFinite(contextWindow) && contextWindow > 0
+      ? Math.min(24000, Math.max(4096, Math.round(contextWindow / 4)))
+      : 24000,
+  restartGateway: vi.fn(),
+  findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
+  readConfig: vi.fn(),
+  inferConfiguredLocalModel: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
+  applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
+  parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
+  setProviderPlugins: vi.fn().mockResolvedValue(undefined),
+  openclawIsAbsent: vi.fn().mockReturnValue(false),
+  OpenclawUnavailableError: class OpenclawUnavailableError extends Error {},
+}));
+
+vi.mock("@/lib/llamacpp", () => ({
+  getDefaultLlamaCppModel: vi.fn().mockReturnValue("gemma4-e2b-it-q4_0"),
+  getLlamaCppContextWindow: vi.fn().mockReturnValue(131072),
+  getLlamaCppMaxTokens: vi.fn().mockReturnValue(131072),
+  getLlamaCppProxyBaseUrl: vi.fn().mockReturnValue(LLAMACPP_PROXY_BASE_URL),
+}));
+
+vi.mock("@/lib/local-ai-runtime", () => ({
+  getLocalAiProxyBaseUrl: vi.fn((provider: string) =>
+    provider === "llamacpp"
+      ? LLAMACPP_PROXY_BASE_URL
+      : `http://127.0.0.1/setup-api/local-ai/${provider}`,
+  ),
+}));
+
+vi.mock("@/lib/local-ai-token", () => ({
+  getLocalAiToken: vi.fn().mockReturnValue("a".repeat(64)),
+  verifyLocalAiBearer: vi.fn().mockReturnValue(true),
+  markLocalAiTokenMigrated: vi.fn(),
+}));
+
+import { getAll, setMany } from "@/lib/config-store";
+import { unpairLocal } from "@/lib/clawkeep";
+import {
+  inferConfiguredLocalModel,
+  readConfig,
+  restartGateway,
+  runOpenclawConfigSet,
+  applyModelOverrideToAllAgentSessions,
+  parseFullyQualifiedModel,
+} from "@/lib/openclaw-config";
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const mockGetAll = vi.mocked(getAll);
+const mockSetMany = vi.mocked(setMany);
+const mockReadConfig = vi.mocked(readConfig);
+const mockRunOpenclawConfigSet = vi.mocked(runOpenclawConfigSet);
+const mockFs = vi.mocked(fsp);
+
+function createSuccessfulChildProcess(): ChildProcess {
+  const emitter = new EventEmitter() as ChildProcess;
+  emitter.stdin = { end: vi.fn() } as unknown as ChildProcess["stdin"];
+  emitter.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
+  emitter.stderr = new EventEmitter() as unknown as ChildProcess["stderr"];
+  emitter.kill = vi.fn();
+  queueMicrotask(() => emitter.emit("close", 0));
+  return emitter;
+}
+
+const CLAWAI_TOKEN = "claw_token123";
+const PROXY_URL = "https://clawbox.com/api/ai";
+
+type ModelEntry = {
+  id?: string;
+  name?: string;
+  input?: unknown;
+  maxTokens?: unknown;
+  reasoning?: unknown;
+  compat?: unknown;
+  [key: string]: unknown;
+};
+
+describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () => {
+  let configurePost: (req: Request) => Promise<Response>;
+
+  function jsonRequest(body: unknown): Request {
+    return new Request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function configSetCalls(): string[][] {
+    return mockRunOpenclawConfigSet.mock.calls.map((call) => call[0] as string[]);
+  }
+
+  function callFor(path: string): string[] | undefined {
+    return configSetCalls().find((args) => args[0] === path);
+  }
+
+  /** The models[] the route wrote for the ClawBox AI (deepseek) provider. */
+  function deepseekModels(): ModelEntry[] {
+    const call = callFor("models.providers.deepseek");
+    const provider = JSON.parse(call?.[1] ?? "null") as { models?: ModelEntry[] } | null;
+    return provider?.models ?? [];
+  }
+
+  function visionEntry(): ModelEntry | undefined {
+    return deepseekModels().find((m) => m.id === CLAWBOX_AI_VISION_MODEL_ID);
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.rename.mockResolvedValue();
+    mockFs.chown.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.rm.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
+    mockGetAll.mockResolvedValue({});
+    mockReadConfig.mockResolvedValue({});
+    vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
+    mockSetMany.mockResolvedValue();
+    vi.mocked(restartGateway).mockResolvedValue();
+    mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
+    mockRunOpenclawConfigSet.mockResolvedValue(undefined);
+    vi.mocked(unpairLocal).mockResolvedValue(undefined);
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(parseFullyQualifiedModel).mockImplementation(parseFullyQualifiedModelImpl);
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
+
+    const mod = await import("@/app/setup-api/ai-models/configure/route");
+    configurePost = mod.POST;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  async function connectClawai(token = CLAWAI_TOKEN) {
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: token }));
+    expect(res.status).toBe(200);
+    return res;
+  }
+
+  it("registers a vision entry that advertises image input", async () => {
+    await connectClawai();
+
+    // `input: ["text", "image"]` is the load-bearing part: resolveImageRuntime
+    // refuses a media-understanding model whose catalog entry does not
+    // advertise image input.
+    expect(visionEntry()).toEqual({
+      id: CLAWBOX_AI_VISION_MODEL_ID,
+      name: CLAWBOX_AI_VISION_MODEL_LABEL,
+      input: ["text", "image"],
+      maxTokens: CLAWBOX_AI_VISION_MAX_TOKENS,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+  });
+
+  it("registers it on the ClawBox AI proxy provider, not on openai", async () => {
+    await connectClawai();
+
+    // The deepseek entry IS the proxy: it already carries
+    // api=openai-completions, the proxy baseUrl and the claw_ token. OpenClaw's
+    // `openai` provider defaults to openai-responses, which the proxy does not
+    // speak.
+    const provider = JSON.parse(callFor("models.providers.deepseek")?.[1] ?? "null");
+    expect(provider.baseUrl).toBe(PROXY_URL);
+    expect(provider.api).toBe("openai-completions");
+
+    const openaiModels = JSON.parse(callFor("models.providers.openai.models")?.[1] ?? "[]") as ModelEntry[];
+    expect(openaiModels.some((m) => m.id === CLAWBOX_AI_VISION_MODEL_ID)).toBe(false);
+  });
+
+  it("points agents.defaults.imageModel at it", async () => {
+    await connectClawai();
+
+    const call = callFor("agents.defaults.imageModel");
+    expect(call?.[2]).toBe("--json");
+    expect(JSON.parse(call?.[1] ?? "null")).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
+  it("leaves the two chat tiers text-only and non-reasoning-free", async () => {
+    await connectClawai();
+
+    const chat = deepseekModels().filter((m) => m.id !== CLAWBOX_AI_VISION_MODEL_ID);
+    expect(chat).toHaveLength(2);
+    for (const entry of chat) {
+      expect(entry.input).toEqual(["text"]);
+      expect(entry.reasoning).toBe(true);
+    }
+    // The vision entry is a one-shot describe and never negotiates thinking.
+    expect(visionEntry()?.reasoning).toBeUndefined();
+    expect(visionEntry()?.compat).toBeUndefined();
+  });
+
+  it("does not touch imageGenerationModel", async () => {
+    await connectClawai();
+
+    // Two independent config keys with no aliasing. imageGenerationModel says
+    // where pictures come from; imageModel says what looks at one.
+    expect(JSON.parse(callFor("agents.defaults.imageGenerationModel")?.[1] ?? "null"))
+      .toEqual({ primary: "openai/gpt-image-1-mini" });
+    expect(JSON.parse(callFor("agents.defaults.imageModel")?.[1] ?? "null"))
+      .toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
+  it("keeps a vision model the owner already chose", async () => {
+    // configureClawboxAi also runs when ClawBox AI is merely being added as a
+    // fallback for some other provider, so an occupied slot is a decision made
+    // elsewhere.
+    mockReadConfig.mockResolvedValue({
+      agents: { defaults: { imageModel: { primary: "google/gemini-2.5-flash" } } },
+    });
+
+    await connectClawai();
+
+    expect(callFor("agents.defaults.imageModel")).toBeUndefined();
+    // The entry is still registered — availability is not the same as default.
+    expect(visionEntry()).toBeDefined();
+  });
+
+  it("treats a fallbacks-only imageModel as already configured", async () => {
+    // The write replaces the whole object, so claiming the slot here would
+    // delete the owner's fallbacks. Same rule OpenClaw's hasToolModelConfig
+    // applies.
+    mockReadConfig.mockResolvedValue({
+      agents: { defaults: { imageModel: { fallbacks: ["google/gemini-2.5-flash"] } } },
+    });
+
+    await connectClawai();
+
+    expect(callFor("agents.defaults.imageModel")).toBeUndefined();
+  });
+
+  it("claims an imageModel that is empty in OpenClaw's sense", async () => {
+    mockReadConfig.mockResolvedValue({
+      agents: { defaults: { imageModel: { primary: "  ", fallbacks: ["", " "] } } },
+    });
+
+    await connectClawai();
+
+    expect(JSON.parse(callFor("agents.defaults.imageModel")?.[1] ?? "null"))
+      .toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
+  it("still configures chat when the vision write fails", async () => {
+    // Non-fatal by design: a chat provider that works is worth more than a
+    // vision model, so this must not fail the whole Connect ClawBox AI flow.
+    mockRunOpenclawConfigSet.mockImplementation(async (args: string[]) => {
+      if (args[0] === "agents.defaults.imageModel") throw new Error("config set exploded");
+    });
+
+    const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
+
+    expect(res.status).toBe(200);
+    expect(callFor("models.providers.deepseek")).toBeDefined();
+  });
+});

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -348,10 +348,19 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(providerDef.models[1].compat.supportedReasoningEfforts).toEqual(["off", "high", "xhigh"]);
 
     // A configured provider overrides OpenClaw's bundled catalog, so these
-    // three fields have to be stated on every model. Omit contextWindow and
-    // the gateway falls back to a generic 200,000 rather than V4's real 1M —
-    // reproduced on a device running 2026.7.1 on 2026-08-17.
-    for (const model of providerDef.models) {
+    // three fields have to be stated on every CHAT model. Omit contextWindow
+    // and the gateway falls back to a generic 200,000 rather than V4's real 1M
+    // — reproduced on a device running 2026.7.1 on 2026-08-17.
+    //
+    // Scoped to the two V4 tiers on purpose: the same provider also carries the
+    // vision entry (TASK-417), which is deliberately text+image with its own
+    // measured ceiling and is never a session model. Asserting over every row
+    // would make this test fail on a correct config.
+    const chatTiers = providerDef.models.filter(
+      (m: { id: string }) => m.id === "deepseek-v4-flash" || m.id === "deepseek-v4-pro",
+    );
+    expect(chatTiers).toHaveLength(2);
+    for (const model of chatTiers) {
       expect(model.contextWindow).toBe(1_000_000);
       expect(model.maxTokens).toBe(393_216);
       expect(model.input).toEqual(["text"]);

--- a/src/tests/routes/chat-attachments.test.ts
+++ b/src/tests/routes/chat-attachments.test.ts
@@ -102,6 +102,56 @@ function stagingDir(): string {
   return path.join(openclawHome, "media", "chat-attachments");
 }
 
+/** What is staged right now, or `[]` when nothing ever created the directory. */
+function staged(): string[] {
+  return fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
+}
+
+/**
+ * Wait until the staging directory is empty, or fail once the deadline passes.
+ *
+ * Cleanup finishes after the response, so these assertions need to wait for
+ * something. A fixed sleep is the wrong instrument twice over: too short and it
+ * flakes on a loaded CI box, too long and every run pays for it. Polling
+ * returns as soon as the directory is actually clean, and a real leak still
+ * fails -- one `expect` on the last read, either way.
+ */
+async function expectStagingDrains(timeoutMs = 5000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let listed = staged();
+  while (listed.length && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    listed = staged();
+  }
+  expect(listed).toEqual([]);
+}
+
+/** `n` file parts, so a request can trip the one-file limit. */
+function fileParts(n: number, content: Buffer): Buffer {
+  const parts: Buffer[] = [];
+  for (let i = 0; i < n; i++) {
+    parts.push(Buffer.concat([
+      Buffer.from(
+        `--${BOUNDARY}\r\nContent-Disposition: form-data; name="file"; filename="f${i}.png"\r\n`
+          + "Content-Type: application/octet-stream\r\n\r\n",
+      ),
+      content,
+      Buffer.from("\r\n"),
+    ]));
+  }
+  return Buffer.concat(parts);
+}
+
+/** Write a staged file directly and backdate it, to set up a retention sweep. */
+function seedStaged(name: string, bytes: Buffer, ageMs: number): string {
+  fs.mkdirSync(stagingDir(), { recursive: true });
+  const full = path.join(stagingDir(), name);
+  fs.writeFileSync(full, bytes);
+  const when = new Date(Date.now() - ageMs);
+  fs.utimesSync(full, when, when);
+  return full;
+}
+
 describe("/setup-api/chat/attachments", () => {
   beforeEach(async () => {
     originalHome = process.env.HOME;
@@ -220,8 +270,7 @@ describe("/setup-api/chat/attachments", () => {
     const huge = Buffer.alloc(27 * 1024 * 1024, 0x41);
     const res = await POST(request(multipart("huge.bin", huge)));
     expect(res.status).toBe(413);
-    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
-    expect(listed).toEqual([]);
+    expect(staged()).toEqual([]);
   });
 
   it("reports a broken staging directory as a server error, not a client one", async () => {
@@ -236,8 +285,7 @@ describe("/setup-api/chat/attachments", () => {
   it("leaves no partial file behind when the upload is rejected", async () => {
     await POST(request(multipart("...", PNG)));
     // The name never resolved, so nothing should have been created at all.
-    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
-    expect(listed).toEqual([]);
+    expect(staged()).toEqual([]);
   });
 
   it("stages nothing after a rejection that arrives before the file does", async () => {
@@ -251,9 +299,161 @@ describe("/setup-api/chat/attachments", () => {
 
     expect(res.status).toBe(400);
     expect((await res.json()).error).toContain("Too many form fields");
-    await new Promise((resolve) => setTimeout(resolve, 300));
-    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
-    expect(listed).toEqual([]);
+    await expectStagingDrains();
+  });
+
+  it("refuses a second file part rather than staging one of them", async () => {
+    // busboy caps files at 1 by going quiet, so without the filesLimit handler
+    // a two-file request looked like a perfectly ordinary one-file upload.
+    const res = await POST(chunkedRequest([
+      fileParts(2, PNG),
+      Buffer.from(`--${BOUNDARY}--\r\n`),
+    ]));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("Only one file per request");
+    await expectStagingDrains();
+  });
+
+  it("refuses a request with more parts than the limit", async () => {
+    // Parts are the cheapest thing to pile on: each one costs the sender almost
+    // nothing and costs the parser real work.
+    const res = await POST(chunkedRequest([
+      fieldParts(20),
+      filePart("late.png", PNG),
+    ]));
+
+    expect(res.status).toBe(400);
+    // Fields and parts are both exceeded here; either rejection is the right
+    // answer, and both have to leave the disk clean.
+    expect((await res.json()).error).toMatch(/Too many (multipart parts|form fields)/);
+    await expectStagingDrains();
+  });
+
+  it("reports a malformed part header as client input, not a server fault", async () => {
+    // busboy raises "Malformed part header" on itself. Unclassified it reached
+    // the catch as a plain Error and the caller was told 500 -- go and debug the
+    // server -- for a request only they could fix.
+    const body = Buffer.concat([
+      Buffer.from(
+        `--${BOUNDARY}\r\n`
+          + `Content-Disposition form-data; name="file"; filename="broken.png"\r\n\r\n`,
+      ),
+      PNG,
+      Buffer.from(`\r\n--${BOUNDARY}--\r\n`),
+    ]);
+    const res = await POST(request(body));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("Malformed part header");
+    await expectStagingDrains();
+  });
+
+  it("reports a body that ends early as client input, in both places busboy raises it", async () => {
+    // The same client mistake surfaces on two different objects: with no file
+    // part open busboy emits it, and mid-file the file's own stream does. Both
+    // have to answer 400, so both paths are asserted here.
+    const beforeFile = await POST(request(Buffer.from(
+      `--${BOUNDARY}\r\nContent-Disposition: form-data; name="note"\r\n\r\nhal`,
+    )));
+    expect(beforeFile.status).toBe(400);
+    expect((await beforeFile.json()).error).toContain("Unexpected end of form");
+
+    const midFile = await POST(request(Buffer.concat([
+      Buffer.from(
+        `--${BOUNDARY}\r\nContent-Disposition: form-data; name="file"; filename="half.png"\r\n`
+          + "Content-Type: application/octet-stream\r\n\r\n",
+      ),
+      PNG,
+    ])));
+    expect(midFile.status).toBe(400);
+    expect((await midFile.json()).error).toContain("Unexpected end of form");
+    await expectStagingDrains();
+  });
+
+  it("keeps a genuine server fault a 500 while parser faults become 400", async () => {
+    // The classifier must not swallow everything: a dead connection is ours to
+    // report, and the two cases arrive through the very same handlers.
+    const body = new ReadableStream({
+      async start(controller) {
+        controller.enqueue(new Uint8Array(Buffer.from(
+          `--${BOUNDARY}\r\nContent-Disposition: form-data; name="file"; filename="gone.bin"\r\n`
+            + "Content-Type: application/octet-stream\r\n\r\n",
+        )));
+        controller.enqueue(new Uint8Array(Buffer.alloc(512, 3)));
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        controller.error(new Error("client went away"));
+      },
+    });
+    const res = await POST(new NextRequest("http://localhost/setup-api/chat/attachments", {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${BOUNDARY}` },
+      body,
+      duplex: "half",
+    } as unknown as ConstructorParameters<typeof NextRequest>[1]));
+
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toContain("client went away");
+  }, 10000);
+
+  it("drops staged files past the retention age when the next upload arrives", async () => {
+    // Nothing else ever removes one of these, so without a sweep the directory
+    // only grows -- on a box whose disk also holds openclaw.json and the keys.
+    const stale = seedStaged("stale.png", PNG, 8 * 24 * 60 * 60 * 1000);
+    const fresh = seedStaged("fresh.png", PNG, 2 * 60 * 1000);
+
+    const res = await POST(request(multipart("new.png", PNG)));
+    expect(res.status).toBe(200);
+
+    expect(fs.existsSync(stale)).toBe(false);
+    // Inside the window: a week-old file goes, yesterday's stays.
+    expect(fs.existsSync(fresh)).toBe(true);
+    expect(fs.existsSync((await res.json()).path)).toBe(true);
+  });
+
+  it("evicts the oldest staged files once the directory is over its size cap", async () => {
+    // 500 MB of real bytes would make the suite unusable, so the cap is reached
+    // with sparse files: the size the sweep reads is the apparent one.
+    const big = (name: string, ageMs: number) => {
+      const full = seedStaged(name, Buffer.alloc(0), ageMs);
+      fs.truncateSync(full, 200 * 1024 * 1024);
+      const when = new Date(Date.now() - ageMs);
+      fs.utimesSync(full, when, when);
+      return full;
+    };
+    const oldest = big("oldest.bin", 6 * 60 * 60 * 1000);
+    const middle = big("middle.bin", 3 * 60 * 60 * 1000);
+    const newest = big("newest.bin", 2 * 60 * 60 * 1000);
+
+    const res = await POST(request(multipart("new.png", PNG)));
+    expect(res.status).toBe(200);
+
+    // 600 MB against a 500 MB cap: exactly one eviction, and it is the oldest.
+    expect(fs.existsSync(oldest)).toBe(false);
+    expect(fs.existsSync(middle)).toBe(true);
+    expect(fs.existsSync(newest)).toBe(true);
+  });
+
+  it("never sweeps a file young enough to still be arriving", async () => {
+    // A concurrent upload's file is the newest thing in the directory and, once
+    // the cap is exceeded, deleting it would hand that request's composer back
+    // a path with nothing at it.
+    const inFlight = seedStaged("in-flight.bin", Buffer.alloc(0), 0);
+    fs.truncateSync(inFlight, 600 * 1024 * 1024);
+
+    const res = await POST(request(multipart("new.png", PNG)));
+    expect(res.status).toBe(200);
+    expect(fs.existsSync(inFlight)).toBe(true);
+  });
+
+  it("stages the upload even when the retention sweep cannot read the directory", async () => {
+    // Retention is a housekeeping side effect. If it ever became load-bearing,
+    // a permission problem in it would start failing good uploads.
+    const spy = vi.spyOn(fs.promises, "readdir").mockRejectedValueOnce(new Error("EACCES"));
+    const res = await POST(request(multipart("shapes.png", PNG)));
+    expect(res.status).toBe(200);
+    expect(fs.existsSync((await res.json()).path)).toBe(true);
+    spy.mockRestore();
   });
 
   it("answers, and cleans up, when the connection dies mid-file", async () => {
@@ -287,8 +487,6 @@ describe("/setup-api/chat/attachments", () => {
 
     // Their connection broke, not their request: this is ours to report as 500.
     expect(res.status).toBe(500);
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
-    expect(listed).toEqual([]);
+    await expectStagingDrains();
   }, 10000);
 });

--- a/src/tests/routes/chat-attachments.test.ts
+++ b/src/tests/routes/chat-attachments.test.ts
@@ -129,6 +129,14 @@ describe("/setup-api/chat/attachments", () => {
     expect(path.basename(body.path)).toMatch(/-bashrc$/);
   });
 
+  it("rejects a multipart content-type with no boundary as client input", async () => {
+    // busboy's constructor throws on it; unguarded that surfaces as a 500 for a
+    // request the caller can fix.
+    const res = await POST(request(multipart("shapes.png", PNG), "multipart/form-data"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("boundary");
+  });
+
   it("rejects a non-multipart body", async () => {
     const res = await POST(request(Buffer.from("{}"), "application/json"));
     expect(res.status).toBe(400);

--- a/src/tests/routes/chat-attachments.test.ts
+++ b/src/tests/routes/chat-attachments.test.ts
@@ -108,20 +108,33 @@ function staged(): string[] {
 }
 
 /**
- * Wait until the staging directory is empty, or fail once the deadline passes.
+ * Require the staging directory to be empty and to STAY empty for a window.
  *
- * Cleanup finishes after the response, so these assertions need to wait for
+ * Cleanup finishes after the response, so these assertions have to wait for
  * something. A fixed sleep is the wrong instrument twice over: too short and it
- * flakes on a loaded CI box, too long and every run pays for it. Polling
- * returns as soon as the directory is actually clean, and a real leak still
- * fails -- one `expect` on the last read, either way.
+ * flakes on a loaded CI box, too long and every run pays for it.
+ *
+ * But "poll until empty" is worse than the sleep it replaces, because the
+ * regressions these tests exist for stage the orphan file *after* the response
+ * resolves -- so the first read is empty, a stop-on-empty poll returns
+ * immediately, and the test passes while the orphan lands a moment later. It
+ * would have gone green on the very bug it was written to catch.
+ *
+ * So: empty is necessary but not sufficient. The directory has to read empty
+ * continuously for `settleMs`, and any file appearing inside that window resets
+ * it. Clean runs still finish in about the settle time rather than the timeout.
  */
-async function expectStagingDrains(timeoutMs = 5000): Promise<void> {
+async function expectStagingDrains(timeoutMs = 5000, settleMs = 300): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   let listed = staged();
-  while (listed.length && Date.now() < deadline) {
+  let emptySince = listed.length ? null : Date.now();
+  while (Date.now() < deadline) {
+    if (emptySince !== null && Date.now() - emptySince >= settleMs) break;
     await new Promise((resolve) => setTimeout(resolve, 20));
     listed = staged();
+    // A file appearing after an empty read is exactly the leak under test:
+    // restart the window rather than accept the earlier reading.
+    emptySince = listed.length ? null : (emptySince ?? Date.now());
   }
   expect(listed).toEqual([]);
 }
@@ -452,6 +465,9 @@ describe("/setup-api/chat/attachments", () => {
     const spy = vi.spyOn(fs.promises, "readdir").mockRejectedValueOnce(new Error("EACCES"));
     const res = await POST(request(multipart("shapes.png", PNG)));
     expect(res.status).toBe(200);
+    // Without this the test would still pass if the sweep stopped running at
+    // all: a route that never reads the directory cannot fail on a read.
+    expect(spy).toHaveBeenCalled();
     expect(fs.existsSync((await res.json()).path)).toBe(true);
     spy.mockRestore();
   });

--- a/src/tests/routes/chat-attachments.test.ts
+++ b/src/tests/routes/chat-attachments.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// POST /setup-api/chat/attachments — where a file attached in device chat is
+// staged so the agent can open it.
+//
+// The composer names the returned absolute path in the message, and OpenClaw
+// only reads media from a fixed root allowlist. $HOME/uploads (where the Files
+// API writes) is not on it, so the `image` tool answered "Local media path is
+// not under an allowed directory" and the assistant told the user it could not
+// see the picture. TASK-417. `<stateDir>/media` IS on that allowlist, and this
+// route is what puts the file there.
+
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+let tmpHome: string;
+let openclawHome: string;
+let originalHome: string | undefined;
+let originalOpenclawHome: string | undefined;
+let POST: (req: NextRequest) => Promise<Response>;
+
+const BOUNDARY = "----clawboxtestboundary";
+
+/** A multipart body with one `file` part, built by hand so the bytes are exact. */
+function multipart(filename: string, content: Buffer): Buffer {
+  const head = Buffer.from(
+    `--${BOUNDARY}\r\n`
+      + `Content-Disposition: form-data; name="file"; filename="${filename}"\r\n`
+      + "Content-Type: application/octet-stream\r\n\r\n",
+  );
+  const tail = Buffer.from(`\r\n--${BOUNDARY}--\r\n`);
+  return Buffer.concat([head, content, tail]);
+}
+
+function request(body: Buffer, contentType = `multipart/form-data; boundary=${BOUNDARY}`): NextRequest {
+  return new NextRequest("http://localhost/setup-api/chat/attachments", {
+    method: "POST",
+    headers: { "content-type": contentType },
+    body: new Uint8Array(body),
+    // Node's fetch Request requires `duplex` for a body stream; it is not in
+    // the DOM RequestInit type, hence the cast.
+    duplex: "half",
+  } as unknown as ConstructorParameters<typeof NextRequest>[1]);
+}
+
+/** The directory OpenClaw's allowlist covers: `<stateDir>/media`. */
+function stagingDir(): string {
+  return path.join(openclawHome, "media", "chat-attachments");
+}
+
+describe("/setup-api/chat/attachments", () => {
+  beforeEach(async () => {
+    originalHome = process.env.HOME;
+    originalOpenclawHome = process.env.OPENCLAW_HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-attach-"));
+    openclawHome = path.join(tmpHome, ".openclaw");
+    fs.mkdirSync(openclawHome, { recursive: true });
+    // The route roots on OPENCLAW_HOME, read at module load — set it first.
+    process.env.HOME = tmpHome;
+    process.env.OPENCLAW_HOME = openclawHome;
+    vi.resetModules();
+    POST = (await import("@/app/setup-api/chat/attachments/route")).POST;
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalOpenclawHome === undefined) delete process.env.OPENCLAW_HOME;
+    else process.env.OPENCLAW_HOME = originalOpenclawHome;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("writes the file under <stateDir>/media, which OpenClaw will read", async () => {
+    const res = await POST(request(multipart("shapes.png", PNG)));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.name).toBe("shapes.png");
+    // The assertion that matters: the path handed to the agent is inside the
+    // media root, not $HOME/uploads.
+    expect(body.path).toBe(path.join(stagingDir(), "shapes.png"));
+    expect(path.resolve(body.path).startsWith(path.join(openclawHome, "media") + path.sep)).toBe(true);
+    expect(fs.readFileSync(body.path)).toEqual(PNG);
+  });
+
+  it("creates the staging directory on a box that has never used it", async () => {
+    expect(fs.existsSync(stagingDir())).toBe(false);
+    const res = await POST(request(multipart("first.png", PNG)));
+    expect(res.status).toBe(200);
+    expect(fs.existsSync(stagingDir())).toBe(true);
+  });
+
+  it("keeps a traversal filename inside the staging directory", async () => {
+    const res = await POST(request(multipart("../../../etc/evil.png", PNG)));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.path).toBe(path.join(stagingDir(), "evil.png"));
+    expect(fs.existsSync(path.join(tmpHome, "evil.png"))).toBe(false);
+  });
+
+  it("strips separators that survive basename, and refuses what is left of a dotfile", async () => {
+    const ok = await POST(request(multipart("a/b\\c.png", PNG)));
+    const okBody = await ok.json();
+    expect(path.dirname(okBody.path)).toBe(stagingDir());
+    expect(okBody.name).not.toContain("/");
+    expect(okBody.name).not.toContain("\\");
+
+    // "..." reduces to nothing once leading dots go — the route must reject
+    // rather than invent a name for a file the client did not name.
+    const bad = await POST(request(multipart("...", PNG)));
+    expect(bad.status).toBe(400);
+  });
+
+  it("does not land an upload as a dotfile", async () => {
+    const res = await POST(request(multipart(".bashrc", PNG)));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(path.basename(body.path)).toBe("bashrc");
+  });
+
+  it("rejects a non-multipart body", async () => {
+    const res = await POST(request(Buffer.from("{}"), "application/json"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("multipart");
+  });
+
+  it("rejects a multipart body with no file part", async () => {
+    const body = Buffer.from(
+      `--${BOUNDARY}\r\nContent-Disposition: form-data; name="note"\r\n\r\nhello\r\n--${BOUNDARY}--\r\n`,
+    );
+    const res = await POST(request(body));
+    expect(res.status).toBe(400);
+  });
+
+  it("leaves no partial file behind when the upload is rejected", async () => {
+    await POST(request(multipart("...", PNG)));
+    // The name never resolved, so nothing should have been created at all.
+    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
+    expect(listed).toEqual([]);
+  });
+});

--- a/src/tests/routes/chat-attachments.test.ts
+++ b/src/tests/routes/chat-attachments.test.ts
@@ -85,8 +85,10 @@ describe("/setup-api/chat/attachments", () => {
     expect(body.name).toBe("shapes.png");
     // The assertion that matters: the path handed to the agent is inside the
     // media root, not $HOME/uploads.
-    expect(body.path).toBe(path.join(stagingDir(), "shapes.png"));
+    expect(path.dirname(body.path)).toBe(stagingDir());
     expect(path.resolve(body.path).startsWith(path.join(openclawHome, "media") + path.sep)).toBe(true);
+    // Storage name is server-generated; the client name survives as the label.
+    expect(path.basename(body.path)).toMatch(/^[0-9a-f-]{36}-shapes\.png$/);
     expect(fs.readFileSync(body.path)).toEqual(PNG);
   });
 
@@ -101,7 +103,8 @@ describe("/setup-api/chat/attachments", () => {
     const res = await POST(request(multipart("../../../etc/evil.png", PNG)));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.path).toBe(path.join(stagingDir(), "evil.png"));
+    expect(path.dirname(body.path)).toBe(stagingDir());
+    expect(path.basename(body.path)).toMatch(/-evil\.png$/);
     expect(fs.existsSync(path.join(tmpHome, "evil.png"))).toBe(false);
   });
 
@@ -122,7 +125,8 @@ describe("/setup-api/chat/attachments", () => {
     const res = await POST(request(multipart(".bashrc", PNG)));
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(path.basename(body.path)).toBe("bashrc");
+    expect(body.name).toBe("bashrc");
+    expect(path.basename(body.path)).toMatch(/-bashrc$/);
   });
 
   it("rejects a non-multipart body", async () => {
@@ -137,6 +141,40 @@ describe("/setup-api/chat/attachments", () => {
     );
     const res = await POST(request(body));
     expect(res.status).toBe(400);
+  });
+
+  it("never lets a second upload overwrite the first one's bytes", async () => {
+    // Two screenshots both called screenshot.png. Deriving the path from the
+    // client name alone would truncate the first, and an earlier chat message
+    // still points at it.
+    const first = await (await POST(request(multipart("screenshot.png", PNG)))).json();
+    const other = Buffer.concat([PNG, Buffer.from("second")]);
+    const second = await (await POST(request(multipart("screenshot.png", other)))).json();
+
+    expect(first.path).not.toBe(second.path);
+    expect(first.name).toBe("screenshot.png");
+    expect(second.name).toBe("screenshot.png");
+    expect(fs.readFileSync(first.path)).toEqual(PNG);
+    expect(fs.readFileSync(second.path)).toEqual(other);
+  });
+
+  it("refuses a request larger than the total limit with 413", async () => {
+    // Per-file and per-field limits leave the SUM unbounded; this is the guard
+    // on what actually arrives.
+    const huge = Buffer.alloc(27 * 1024 * 1024, 0x41);
+    const res = await POST(request(multipart("huge.bin", huge)));
+    expect(res.status).toBe(413);
+    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
+    expect(listed).toEqual([]);
+  });
+
+  it("reports a broken staging directory as a server error, not a client one", async () => {
+    // A read-only filesystem is our problem, and it happens before the try
+    // block that used to be the only error path.
+    fs.writeFileSync(path.join(openclawHome, "media"), "not a directory");
+    const res = await POST(request(multipart("shapes.png", PNG)));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toContain("attachment directory");
   });
 
   it("leaves no partial file behind when the upload is rejected", async () => {

--- a/src/tests/routes/chat-attachments.test.ts
+++ b/src/tests/routes/chat-attachments.test.ts
@@ -38,6 +38,54 @@ function multipart(filename: string, content: Buffer): Buffer {
   return Buffer.concat([head, content, tail]);
 }
 
+/**
+ * The same body, but delivered in separate chunks with a gap between them.
+ *
+ * A single-buffer body hands busboy everything at once, which hides the
+ * ordering that matters here: a real connection delivers a multipart request
+ * over several reads, so a rejection can land while parts are still arriving.
+ */
+function chunkedRequest(chunks: Buffer[]): NextRequest {
+  const body = new ReadableStream({
+    async start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(new Uint8Array(chunk));
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      controller.close();
+    },
+  });
+  return new NextRequest("http://localhost/setup-api/chat/attachments", {
+    method: "POST",
+    headers: { "content-type": `multipart/form-data; boundary=${BOUNDARY}` },
+    body,
+    duplex: "half",
+  } as unknown as ConstructorParameters<typeof NextRequest>[1]);
+}
+
+/** `n` form fields, as their own chunk. */
+function fieldParts(n: number): Buffer {
+  const parts: Buffer[] = [];
+  for (let i = 0; i < n; i++) {
+    parts.push(Buffer.from(
+      `--${BOUNDARY}\r\nContent-Disposition: form-data; name="f${i}"\r\n\r\nv${i}\r\n`,
+    ));
+  }
+  return Buffer.concat(parts);
+}
+
+/** A trailing file part plus the closing boundary, as its own chunk. */
+function filePart(filename: string, content: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from(
+      `--${BOUNDARY}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\n`
+        + "Content-Type: application/octet-stream\r\n\r\n",
+    ),
+    content,
+    Buffer.from(`\r\n--${BOUNDARY}--\r\n`),
+  ]);
+}
+
 function request(body: Buffer, contentType = `multipart/form-data; boundary=${BOUNDARY}`): NextRequest {
   return new NextRequest("http://localhost/setup-api/chat/attachments", {
     method: "POST",
@@ -191,4 +239,56 @@ describe("/setup-api/chat/attachments", () => {
     const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
     expect(listed).toEqual([]);
   });
+
+  it("stages nothing after a rejection that arrives before the file does", async () => {
+    // busboy's fields limit ends `field` events but not `file` ones. Rejecting
+    // without tearing the parser down let the route answer 400 and then accept
+    // the file anyway, leaving a staged file on the customer's disk that no
+    // response ever named and nothing would come back for. Only reproducible
+    // with a chunked body: in one buffer the `file` event lands early enough
+    // for the catch to still see the path and clean up by luck.
+    const res = await POST(chunkedRequest([fieldParts(9), filePart("orphan.png", PNG)]));
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("Too many form fields");
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
+    expect(listed).toEqual([]);
+  });
+
+  it("answers, and cleans up, when the connection dies mid-file", async () => {
+    // A source error used to leave busboy and the file stream alive, so the
+    // write never settled and the awaited cleanup never returned: the route
+    // produced no response at all. The race below fails the test rather than
+    // hanging the suite.
+    const body = new ReadableStream({
+      async start(controller) {
+        controller.enqueue(new Uint8Array(Buffer.from(
+          `--${BOUNDARY}\r\nContent-Disposition: form-data; name="file"; filename="half.bin"\r\n`
+            + "Content-Type: application/octet-stream\r\n\r\n",
+        )));
+        controller.enqueue(new Uint8Array(Buffer.alloc(1024, 7)));
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        controller.error(new Error("client went away"));
+      },
+    });
+    const req = new NextRequest("http://localhost/setup-api/chat/attachments", {
+      method: "POST",
+      headers: { "content-type": `multipart/form-data; boundary=${BOUNDARY}` },
+      body,
+      duplex: "half",
+    } as unknown as ConstructorParameters<typeof NextRequest>[1]);
+
+    const res = await Promise.race([
+      POST(req),
+      new Promise<Response>((_, reject) =>
+        setTimeout(() => reject(new Error("route never answered")), 4000)),
+    ]);
+
+    // Their connection broke, not their request: this is ours to report as 500.
+    expect(res.status).toBe(500);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    const listed = fs.existsSync(stagingDir()) ? fs.readdirSync(stagingDir()) : [];
+    expect(listed).toEqual([]);
+  }, 10000);
 });

--- a/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Same env-override dance as gateway-pre-start-clawai-images.test.ts:
+// `CLAWBOX_AI_VISION_MODEL_ID` resolves an env var at module load and the .sh
+// hardcodes the default, so a developer who happens to export that variable
+// would fail this file while both sides are perfectly correct. What the
+// migration must match is the documented default.
+const {
+  CLAWBOX_AI_VISION_MODEL,
+  CLAWBOX_AI_VISION_MODEL_ID,
+  CLAWBOX_AI_VISION_MODEL_LABEL,
+  CLAWBOX_AI_VISION_MAX_TOKENS,
+} = await (async () => {
+  const override = process.env.CLAWBOX_AI_VISION_MODEL_ID;
+  delete process.env.CLAWBOX_AI_VISION_MODEL_ID;
+  vi.resetModules();
+  try {
+    return await import("@/lib/clawbox-ai-models");
+  } finally {
+    if (override !== undefined) process.env.CLAWBOX_AI_VISION_MODEL_ID = override;
+    vi.resetModules();
+  }
+})();
+
+// A ClawBox accepts an image attachment and then answers that it cannot see it:
+// both ClawBox AI chat models are text-only, so OpenClaw hands the turn a media
+// path and the `image` tool has to describe it — and that tool resolves its
+// model from `agents.defaults.imageModel`, which provisioning never wrote.
+// Boxes in the field never re-run the configure route, so gateway-pre-start.sh
+// repairs them at boot (TASK-417).
+//
+// These run the migration block out of the shipped .sh, not a copy of it, so
+// the test fails if the real script drifts.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+/** Pull the ClawBox AI vision migration out of the .sh verbatim. */
+function extractPolicy(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf("# Migration: ClawBox AI vision (image understanding).");
+  const end = src.indexOf("# Migration: ClawBox AI image generation.", start);
+  if (start < 0 || end < 0) throw new Error("clawai vision migration block not found");
+  return src.slice(start, end);
+}
+
+const POLICY = hasPython3 ? extractPolicy() : "";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "clawai-vision-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+type Config = Record<string, unknown>;
+type ModelEntry = { id?: string; name?: string; input?: unknown; maxTokens?: unknown; [key: string]: unknown };
+
+/**
+ * Run the extracted block over a whole openclaw.json.
+ *
+ * The preamble reproduces only the names the block reads from its surrounding
+ * scope, exactly as the real script binds them upstream of this point
+ * (`deepseek_provider`, `agents_defaults`, `changed`) — mock at that boundary
+ * and nothing else, so the logic under test is 100% shipped bytes.
+ */
+function migrate(cfg: Config): { cfg: Config; changed: boolean } {
+  const file = path.join(dir, "config.json");
+  writeFileSync(file, JSON.stringify(cfg));
+  const program = [
+    "import json, sys",
+    "cfg = json.load(open(sys.argv[1]))",
+    'models_providers = cfg.setdefault("models", {}).setdefault("providers", {})',
+    'agents_defaults = cfg.setdefault("agents", {}).setdefault("defaults", {})',
+    'deepseek_provider = models_providers.get("deepseek")',
+    "changed = False",
+    POLICY,
+    "print(json.dumps({'cfg': cfg, 'changed': changed}))",
+  ].join("\n");
+  const out = execFileSync("python3", ["-c", program, file], { encoding: "utf-8" }).trim().split("\n");
+  return JSON.parse(out[out.length - 1]);
+}
+
+/** A box provisioned with ClawBox AI: portal token, proxy, the two chat tiers. */
+function pairedBox(overrides: { models?: ModelEntry[]; defaults?: Config; apiKey?: string } = {}): Config {
+  return {
+    models: {
+      providers: {
+        deepseek: {
+          apiKey: overrides.apiKey ?? "claw_token123",
+          baseUrl: "https://clawbox.com/api/ai",
+          models: overrides.models ?? [
+            { id: "deepseek-v4-flash", name: "ClawBox AI Flash", input: ["text"] },
+            { id: "deepseek-v4-pro", name: "ClawBox AI Pro", input: ["text"] },
+          ],
+        },
+      },
+    },
+    agents: { defaults: overrides.defaults ?? {} },
+  };
+}
+
+function dsModels(cfg: Config): ModelEntry[] {
+  const models = (cfg.models ?? {}) as { providers?: Record<string, Record<string, unknown>> };
+  return (models.providers?.deepseek?.models ?? []) as ModelEntry[];
+}
+
+function visionEntry(cfg: Config): ModelEntry | undefined {
+  return dsModels(cfg).find((m) => m.id === CLAWBOX_AI_VISION_MODEL_ID);
+}
+
+function imageModel(cfg: Config): unknown {
+  const agents = (cfg.agents ?? {}) as { defaults?: Record<string, unknown> };
+  return agents.defaults?.imageModel;
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI vision migration", () => {
+  it("adds the vision entry and claims imageModel on a paired box", () => {
+    const { cfg, changed } = migrate(pairedBox());
+
+    expect(changed).toBe(true);
+    expect(visionEntry(cfg)).toEqual({
+      id: CLAWBOX_AI_VISION_MODEL_ID,
+      name: CLAWBOX_AI_VISION_MODEL_LABEL,
+      input: ["text", "image"],
+      maxTokens: CLAWBOX_AI_VISION_MAX_TOKENS,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+    expect(imageModel(cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
+  it("leaves the two chat tiers untouched", () => {
+    const { cfg } = migrate(pairedBox());
+    const chat = dsModels(cfg).filter((m) => m.id !== CLAWBOX_AI_VISION_MODEL_ID);
+    expect(chat).toEqual([
+      { id: "deepseek-v4-flash", name: "ClawBox AI Flash", input: ["text"] },
+      { id: "deepseek-v4-pro", name: "ClawBox AI Pro", input: ["text"] },
+    ]);
+  });
+
+  it("does not touch imageGenerationModel", () => {
+    // Two independent keys. Images-out is provisioned by its own migration and
+    // a vision repair must not disturb it.
+    const { cfg } = migrate(pairedBox({ defaults: { imageGenerationModel: { primary: "openai/gpt-image-1-mini" } } }));
+    const defaults = (cfg.agents as { defaults: Record<string, unknown> }).defaults;
+    expect(defaults.imageGenerationModel).toEqual({ primary: "openai/gpt-image-1-mini" });
+    expect(defaults.imageModel).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
+  it("is idempotent — a second boot changes nothing", () => {
+    const first = migrate(pairedBox());
+    const second = migrate(first.cfg);
+    expect(second.changed).toBe(false);
+    expect(second.cfg).toEqual(first.cfg);
+  });
+
+  it("skips a box with no ClawBox AI token", () => {
+    // The token is the entitlement: an unpaired box gets no proxy-backed model.
+    const { cfg, changed } = migrate(pairedBox({ apiKey: "" }));
+    expect(changed).toBe(false);
+    expect(visionEntry(cfg)).toBeUndefined();
+    expect(imageModel(cfg)).toBeUndefined();
+  });
+
+  it("skips a box whose deepseek key is somebody else's, not a claw_ token", () => {
+    const { cfg, changed } = migrate(pairedBox({ apiKey: "sk-someone-elses-deepseek-key" }));
+    expect(changed).toBe(false);
+    expect(visionEntry(cfg)).toBeUndefined();
+  });
+
+  it("keeps an imageModel the owner already chose", () => {
+    const { cfg, changed } = migrate(pairedBox({ defaults: { imageModel: { primary: "google/gemini-2.5-flash" } } }));
+    expect(imageModel(cfg)).toEqual({ primary: "google/gemini-2.5-flash" });
+    // The entry is still added — having the model available is not the same as
+    // making it the default — so this boot is still a change.
+    expect(changed).toBe(true);
+    expect(visionEntry(cfg)).toBeDefined();
+  });
+
+  it("treats a fallbacks-only imageModel as already configured", () => {
+    // hasToolModelConfig counts fallbacks, and the write replaces the whole
+    // object — claiming the slot here would delete the owner's fallbacks.
+    const owner = { fallbacks: ["google/gemini-2.5-flash"] };
+    const { cfg } = migrate(pairedBox({ defaults: { imageModel: owner } }));
+    expect(imageModel(cfg)).toEqual(owner);
+  });
+
+  it("ignores an imageModel that is empty in OpenClaw's sense", () => {
+    const { cfg } = migrate(pairedBox({ defaults: { imageModel: { primary: "   ", fallbacks: ["", "  "] } } }));
+    expect(imageModel(cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
+  it("repairs an existing entry that cannot accept images", () => {
+    // The failure this migration exists to fix: without "image" in `input`,
+    // resolveImageRuntime refuses the model outright.
+    const { cfg, changed } = migrate(pairedBox({
+      models: [
+        { id: "deepseek-v4-flash", name: "ClawBox AI Flash", input: ["text"] },
+        { id: CLAWBOX_AI_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text"], maxTokens: 128000 },
+      ],
+    }));
+    expect(changed).toBe(true);
+    expect(visionEntry(cfg)?.input).toEqual(["text", "image"]);
+  });
+
+  it("repairs a missing name, which would stop the gateway booting", () => {
+    const { cfg, changed } = migrate(pairedBox({
+      models: [{ id: CLAWBOX_AI_VISION_MODEL_ID, name: "  ", input: ["text", "image"], maxTokens: 128000 }],
+    }));
+    expect(changed).toBe(true);
+    expect(visionEntry(cfg)?.name).toBe(CLAWBOX_AI_VISION_MODEL_LABEL);
+  });
+
+  it("fills an absent maxTokens but keeps a number someone else chose", () => {
+    const filled = migrate(pairedBox({
+      models: [{ id: CLAWBOX_AI_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text", "image"] }],
+    }));
+    expect(visionEntry(filled.cfg)?.maxTokens).toBe(CLAWBOX_AI_VISION_MAX_TOKENS);
+
+    const chosen = migrate(pairedBox({
+      models: [{ id: CLAWBOX_AI_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text", "image"], maxTokens: 4096 }],
+    }));
+    expect(visionEntry(chosen.cfg)?.maxTokens).toBe(4096);
+  });
+
+  it("keeps the model id, label and ceiling in step with the TS constants", () => {
+    // The .sh hardcodes them because a shell migration cannot import a TS
+    // constant. The proxy matches the BARE id against its allowlist, so a drift
+    // here silently breaks every vision request.
+    expect(POLICY).toContain(`CLAWBOX_VISION_MODEL_ID = "${CLAWBOX_AI_VISION_MODEL_ID}"`);
+    expect(POLICY).toContain(`CLAWBOX_VISION_MODEL_NAME = "${CLAWBOX_AI_VISION_MODEL_LABEL}"`);
+    expect(POLICY).toContain(`CLAWBOX_VISION_MAX_TOKENS = ${CLAWBOX_AI_VISION_MAX_TOKENS}`);
+    expect(CLAWBOX_AI_VISION_MODEL).toBe(`deepseek/${CLAWBOX_AI_VISION_MODEL_ID}`);
+  });
+});

--- a/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
@@ -65,11 +65,11 @@ type ModelEntry = { id?: string; name?: string; input?: unknown; maxTokens?: unk
  * (`deepseek_provider`, `agents_defaults`, `changed`) — mock at that boundary
  * and nothing else, so the logic under test is 100% shipped bytes.
  */
-function migrate(cfg: Config): { cfg: Config; changed: boolean } {
+function migrate(cfg: Config, env: Record<string, string> = {}): { cfg: Config; changed: boolean } {
   const file = path.join(dir, "config.json");
   writeFileSync(file, JSON.stringify(cfg));
   const program = [
-    "import json, sys",
+    "import json, os, sys",
     "cfg = json.load(open(sys.argv[1]))",
     'models_providers = cfg.setdefault("models", {}).setdefault("providers", {})',
     'agents_defaults = cfg.setdefault("agents", {}).setdefault("defaults", {})',
@@ -78,7 +78,10 @@ function migrate(cfg: Config): { cfg: Config; changed: boolean } {
     POLICY,
     "print(json.dumps({'cfg': cfg, 'changed': changed}))",
   ].join("\n");
-  const out = execFileSync("python3", ["-c", program, file], { encoding: "utf-8" }).trim().split("\n");
+  const out = execFileSync("python3", ["-c", program, file], {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+  }).trim().split("\n");
   return JSON.parse(out[out.length - 1]);
 }
 
@@ -224,11 +227,20 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI vision migration",
     expect(visionEntry(chosen.cfg)?.maxTokens).toBe(4096);
   });
 
+  it("follows CLAWBOX_AI_VISION_MODEL_ID when a staging proxy sets it", () => {
+    // The route resolves the slug from the environment; a migration that always
+    // wrote the production default would drag a staging box back to a model its
+    // proxy may not allow at the next boot.
+    const { cfg } = migrate(pairedBox(), { CLAWBOX_AI_VISION_MODEL_ID: "vision-staging-1" });
+    expect(dsModels(cfg).some((m) => m.id === "vision-staging-1")).toBe(true);
+    expect(imageModel(cfg)).toEqual({ primary: "deepseek/vision-staging-1" });
+  });
+
   it("keeps the model id, label and ceiling in step with the TS constants", () => {
     // The .sh hardcodes them because a shell migration cannot import a TS
     // constant. The proxy matches the BARE id against its allowlist, so a drift
     // here silently breaks every vision request.
-    expect(POLICY).toContain(`CLAWBOX_VISION_MODEL_ID = "${CLAWBOX_AI_VISION_MODEL_ID}"`);
+    expect(POLICY).toContain(`or "${CLAWBOX_AI_VISION_MODEL_ID}"`);
     expect(POLICY).toContain(`CLAWBOX_VISION_MODEL_NAME = "${CLAWBOX_AI_VISION_MODEL_LABEL}"`);
     expect(POLICY).toContain(`CLAWBOX_VISION_MAX_TOKENS = ${CLAWBOX_AI_VISION_MAX_TOKENS}`);
     expect(CLAWBOX_AI_VISION_MODEL).toBe(`deepseek/${CLAWBOX_AI_VISION_MODEL_ID}`);


### PR DESCRIPTION
Fixes TASK-417: attaching an image in device chat was accepted, and then the assistant answered that it could not see it.

Two independent defects, both reproduced on test box `192.168.50.65` before any code was written, and both of which have to go before the customer-visible behaviour changes.

### 1. No vision model was registered

Both ClawBox AI chat tiers are `input: ["text"]`, so OpenClaw does not inline image parts — it hands the turn a media path and expects the `image` tool to describe it. That tool resolves its model from `agents.defaults.imageModel`, a key ClawBox provisioning never wrote, so `runWithImageModelFallback` throws *"No image model configured"* (`dist/model-fallback-CvSRhgYr.js`, 2026.7.1).

A vision entry (`gpt-5.6-luna`, `input: ["text","image"]`) now rides on the ClawBox AI provider, and `agents.defaults.imageModel` points at it.

**Why the `deepseek` provider and not `openai`:** that entry *is* the ClawBox AI proxy — it already carries `api: "openai-completions"`, the proxy `baseUrl` and the `claw_` token, which is exactly the transport a vision request needs. OpenClaw's `openai` provider defaults to `openai-responses`, which the proxy does not speak. It cannot leak into the chat model picker: the device catalogue for `clawai` is the hardcoded two-entry `CLAWAI_STATIC_MODELS`, not a read of `models.providers.deepseek.models`.

Written in **both** places, because a box already in the field never re-runs the configure route: the provisioning route for new boxes, `scripts/gateway-pre-start.sh` for the ones already shipped. Same don't-clobber rule as image generation (an owner-chosen slot, including a fallbacks-only one, is left alone), and non-fatal for the same reason — a chat provider that works is worth more than a vision model.

### 2. The attachment landed where OpenClaw will not read it

The composer uploaded to `/setup-api/files?dir=uploads`, which writes to `$HOME/uploads`, then named that absolute path in the message. OpenClaw reads local media only from a fixed root allowlist (`buildMediaLocalRoots`: the openclaw tmp dir, `<configDir>/media`, `<stateDir>/{media,canvas,workspace,sandboxes}`, plus the agent workspace). `$HOME/uploads` is on none of them, so the `image` tool answered *"Local media path is not under an allowed directory"*.

Chat attachments now stage under `<stateDir>/media/chat-attachments`, which is on that allowlist, through `POST /setup-api/chat/attachments`. Deliberately a route of its own rather than loosening `file-guard.ts` over `~/.openclaw` — that tree also holds `openclaw.json`, the identity keys and every transcript. It inherits the existing `/setup-api/chat` middleware gating, including the pre-setup AP window, and returns the same `{ ok, name, path }` shape, so only the URL changed on the client.

### Measured, not guessed

Against the live proxy from a device on 2026-08-21: `max_tokens: 128000` is accepted for the vision model; `200000` (the generic default an entry falls through to when the field is absent, since a configured provider overrides the bundled catalog) comes back `400 "max_tokens is too large … supports at most 128000 completion tokens"`. The media-understanding path in 2026.7.1 happens not to send `max_tokens` at all — verified on a real box, the describe call succeeds with the field removed — so `maxTokens` here is a guard against a caller that starts sending it, not the thing that makes vision work today.

### Tests

32 new tests across four files, every one verified to fail without the change:

- `src/tests/unit/gateway-pre-start-clawai-vision.test.ts` (13) — runs the migration block **out of the shipped `.sh`**, mocking only the four names it reads from its surrounding scope. Covers idempotence, the token entitlement gate, the don't-clobber rule including fallbacks-only, and each individual repair.
- `src/tests/routes/ai-models/configure-vision.test.ts` (9) — the exact `openclaw config set` commands the provisioning route runs.
- `src/tests/routes/chat-attachments.test.ts` (8) — the staging route against a real temp filesystem, including traversal names, dotfiles, and no-partial-file-on-reject.
- `src/tests/components/chat-attachment-staging.test.tsx` (2) — drives `ChatPopup` through a scripted gateway socket: a pasted image goes to the staging route and never to the Files API, and the path the agent is handed is the staged one.

Two existing assertions were narrowed rather than deleted, because the invariant they stated genuinely changed: `configure.test.ts` asserted every `models[]` row is a 1M/text V4 chat tier (now scoped to the two tiers), and `configure-images.test.ts` asserted `imageModel` is never written (now asserts the two keys do not alias).

Local gate: **228 files / 3049 tests green**, baseline 224 / 3017.

### Behaviour on a real box

Before: the `image` tool call is rejected on the path, and the model flails through `read` / `clawbox__read_file` / `exec` workarounds — it happened to reach a correct answer by measuring pixels with Python, which is not a feature.

After: **one** `image` tool call, first try, `"model": "deepseek/gpt-5.6-luna"`, correct description of the actual picture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ClawBox AI vision-model support for image understanding with text and image inputs.
  * Added secure chat attachment uploads with validation, size limits, cleanup, and media-directory storage.
  * Updated chat attachments to use the supported media location.

* **Bug Fixes**
  * Preserved existing image and vision-model selections during setup.
  * Improved recovery of incomplete vision-model settings.
  * Made vision-model setup failures non-blocking for chat setup.

* **Tests**
  * Added coverage for vision configuration, attachment uploads, validation, migration, and configuration preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->