### PR TITLE
fix: keep the Hermes agent and offline model through a factory reset

### DIFF
--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -43,10 +43,11 @@ Everything ClawBox cares about lives under `/home/clawbox`. The app itself is a 
 | | System update | Factory reset |
 |---|---|---|
 | App code (`/home/clawbox/clawbox` tracked files) | **hard-reset to the release** | hard-reset + wiped state |
-| `data/` (settings, tokens, webapps) | ✅ kept | ❌ wiped (except `network.env`) |
+| `data/` (settings, tokens, webapps) | ✅ kept | ❌ wiped (except `network.env` and `llamacpp/models`) |
 | `.env` | ✅ kept | ✅ kept (gitignored, not in wipe list) |
 | `.update-branch` (channel pin) | ✅ kept | ✅ kept |
 | `~/.openclaw` (AI config, credentials, chats) | ✅ kept | ❌ wiped |
+| `~/.hermes` (Hermes config, chats, agent install) | ✅ kept | ❌ wiped, except `hermes-agent` (the agent install — can't be re-downloaded in AP mode) |
 | `~/.clawkeep` (backup pairing) | ✅ kept | ❌ wiped |
 | Ollama models | ✅ kept | ❌ deleted |
 | Saved Wi-Fi networks | ✅ kept | ❌ deleted (box returns to AP mode) |

--- a/install.sh
+++ b/install.sh
@@ -1129,16 +1129,97 @@ step_openclaw_setup() {
 # harness to switch to).
 step_hermes_install() {
   has_hermes_harness || return 0
-  if [ -x "$CLAWBOX_HOME/.local/bin/hermes" ]; then
-    echo "  Hermes already installed ($("$CLAWBOX_HOME/.local/bin/hermes" --version 2>/dev/null | head -1))"
+  local shim="$CLAWBOX_HOME/.local/bin/hermes"
+  local agent_dir="$CLAWBOX_HOME/.hermes/hermes-agent"
+  local venv_python="$agent_dir/venv/bin/python"
+  local installed=""
+
+  # `$shim` alone is NOT evidence of an install. It is a 4-line wrapper in
+  # ~/.local/bin that execs $venv_python; the agent it points at lives under
+  # ~/.hermes. A factory reset that removed ~/.hermes left the shim behind, so
+  # the old `[ -x "$shim" ]` guard reported "Hermes already installed ()" —
+  # with the version probe returning EMPTY into an echo nobody checked — and
+  # returned success without reinstalling anything. That is what turned a
+  # recoverable box into one that needed a reflash: every later repair attempt,
+  # including a full `install.sh` re-run, hit the same guard and did nothing.
+  #
+  # So: require the interpreter to exist AND the agent to actually answer
+  # `--version`. Anything less is treated as "not installed" and reinstalled.
+  if [ -x "$shim" ] && [ -x "$venv_python" ]; then
+    # Probed AS THE CLAWBOX USER, deliberately. `hermes` is a Python entry
+    # point and CPython writes __pycache__/*.pyc next to the sources it
+    # imports. install.sh runs as root, so probing here as root left ~13
+    # root-owned .pyc files (~165 after an agent version bump) inside a
+    # clawbox-owned tree — and the factory-reset route runs as clawbox, so its
+    # wipe hit EACCES on them and aborted MID-WIPE with the agent already half
+    # deleted. The probe is the only thing in this file that ever executed
+    # `hermes`, so running it under runuser removes the writer entirely.
+    # HOME is passed explicitly: hermes resolves ~/.hermes from $HOME, and this
+    # function's HOME is /root.
+    installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+      "$shim" --version 2>/dev/null | head -1)
+  fi
+
+  if [ -n "$installed" ]; then
+    echo "  Hermes already installed ($installed)"
     return 0
   fi
+
+  if [ -e "$agent_dir" ] || [ -e "$shim" ]; then
+    echo "  Hermes is present but not runnable — reinstalling the agent"
+    # The husk has to go before the reinstall. The upstream installer refuses
+    # outright with "Directory exists but is not a git repository" when
+    # $agent_dir survives as an empty shell — exactly what a factory reset
+    # leaves behind — so without this the reinstall fails and the box stays
+    # bricked. Removing it as ROOT is also required: the root-owned __pycache__
+    # described above is undeletable by the clawbox user the installer runs as.
+    rm -rf "$agent_dir"
+    rm -f "$shim"
+  fi
+
   echo "  Installing Hermes agent (NousResearch)..."
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
   # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
   runuser -u "$CLAWBOX_USER" -- bash -c \
     'curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash' \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
+
+  # Verify rather than assume. The installer is fetched over the network and is
+  # non-fatal above, so a silent failure here would otherwise be discovered by
+  # the owner as a crash-looping dashboard.
+  installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+    "$shim" --version 2>/dev/null | head -1)
+  if [ -n "$installed" ]; then
+    echo "  Hermes installed ($installed)"
+  else
+    echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
+  fi
+}
+
+# Re-cache ONLY the offline Gemma GGUF.
+#
+# Split out of step_llamacpp_install so the in-app updater can dispatch it:
+# that step also does apt work, a pip install and (worst case) a ~19-minute
+# native llama.cpp build, none of which an update needs. This one touches
+# nothing but the model file and is a fast no-op when it is already there,
+# which is what makes it safe to run on every update.
+#
+# Not gated on has_hermes_harness: the factory-reset route wipes data/ on EVERY
+# edition, so an openclaw box lost the same 3.2 GB model and needs the same
+# repair.
+step_llamacpp_model() {
+  if is_test_mode; then
+    echo "  CLAWBOX_TEST_MODE=1, skipping Gemma model re-cache"
+    return 0
+  fi
+  # `hf` is installed by step_llamacpp_install. If it was never run on this
+  # device there is no model to restore and nothing this step can do — say so
+  # instead of failing on a missing binary.
+  if ! as_clawbox_login "command -v hf" &>/dev/null; then
+    echo "  Hugging Face CLI not installed — skipping Gemma model re-cache"
+    return 0
+  fi
+  ensure_llamacpp_model_cached
 }
 
 # The OpenClaw gateway is an UNAUTHENTICATED agent control surface on
@@ -2184,6 +2265,25 @@ step_post_update() {
   # clawbox-gateway as the active single source of truth.
   step_gateway_setup || echo "  Warning: gateway_setup step failed (non-fatal)"
   step_gateway_legacy_state_recovery || echo "  Warning: gateway_legacy_state_recovery step failed (non-fatal)"
+  # Repair the two assets a factory reset performed by a pre-fix build deleted:
+  # the Hermes agent install (~/.hermes/hermes-agent) and the offline Gemma
+  # GGUF (data/llamacpp). Neither `git pull && build` nor any fixup above put
+  # them back, so before this an in-app UPDATE could not heal an
+  # already-bricked device — the owner needed SSH, which is not a support path
+  # for an appliance.
+  #
+  # Placed here, at the end of post_update, because both need the network the
+  # earlier steps have already brought back, and because the updater's
+  # `hermes_edition` step runs immediately AFTER this one and hard-fails when
+  # ~/.local/bin/hermes is not runnable — so the agent has to be repaired first
+  # or the repair and the provisioning would fight each other.
+  #
+  # Both are fast no-ops on a healthy box: step_hermes_install returns after a
+  # `--version` probe, step_llamacpp_model after a single `[ -f ]` test.
+  # step_hermes_install self-gates on has_hermes_harness; step_llamacpp_model
+  # deliberately does not (see its comment).
+  step_hermes_install || echo "  Warning: hermes_install step failed (non-fatal)"
+  step_llamacpp_model || echo "  Warning: llamacpp_model step failed (non-fatal)"
   # Hermes re-provisioning is deliberately NOT called here. The in-app updater
   # dispatches `hermes_edition` as its own step immediately after this one, so a
   # failure is reported instead of swallowed by `|| echo "(non-fatal)"`.
@@ -3407,7 +3507,7 @@ step_validate_services() {
 
 # Steps available for --step dispatch (must have a corresponding step_NAME function)
 DISPATCH_STEPS=(
-  bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install ollama_install llamacpp_install
+  bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install ollama_install llamacpp_install llamacpp_model
   chromium_install ai_tools_install vnc_install vnc_refresh
   openclaw_setup openclaw_install openclaw_patch openclaw_config openclaw_models openclaw_tts
   # Edition steps must be dispatchable or no in-app update can ever re-bake the

--- a/install.sh
+++ b/install.sh
@@ -1133,6 +1133,10 @@ step_hermes_install() {
   local agent_dir="$CLAWBOX_HOME/.hermes/hermes-agent"
   local venv_python="$agent_dir/venv/bin/python"
   local installed=""
+  # One constant so the reachability precheck and the install itself can never
+  # drift onto different hosts — a precheck against a URL we then do not use
+  # would be worse than no precheck.
+  local installer_url="https://hermes-agent.nousresearch.com/install.sh"
 
   # `$shim` alone is NOT evidence of an install. It is a 4-line wrapper in
   # ~/.local/bin that execs $venv_python; the agent it points at lives under
@@ -1165,15 +1169,48 @@ step_hermes_install() {
     return 0
   fi
 
+  # NOTHING above this line has modified the disk, and nothing below it does
+  # until the installer is known to be fetchable.
+  #
+  # This matters now in a way it did not before: step_post_update calls this
+  # step on EVERY update on EVERY hermes/dual box, not just on a broken one. So
+  # a false-negative probe — the venv busy, a transient fork failure, anything
+  # that makes `--version` come back empty on a device that is actually fine —
+  # used to reach a `rm -rf "$agent_dir"` and then depend on a network install
+  # that is explicitly non-fatal. On a box with no internet that sequence turns
+  # a healthy agent into no agent, which is the very outcome this file exists
+  # to prevent. Check reachability FIRST and leave the disk alone if the
+  # installer cannot be had.
+  if ! runuser -u "$CLAWBOX_USER" -- \
+    curl -fsS --max-time 30 -o /dev/null "$installer_url"; then
+    echo "  Warning: cannot reach the Hermes installer — leaving the existing agent untouched" >&2
+    return 0
+  fi
+
   if [ -e "$agent_dir" ] || [ -e "$shim" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    # The husk has to go before the reinstall. The upstream installer refuses
-    # outright with "Directory exists but is not a git repository" when
-    # $agent_dir survives as an empty shell — exactly what a factory reset
-    # leaves behind — so without this the reinstall fails and the box stays
-    # bricked. Removing it as ROOT is also required: the root-owned __pycache__
-    # described above is undeletable by the clawbox user the installer runs as.
-    rm -rf "$agent_dir"
+    # The husk has to be out of the way before the reinstall: the upstream
+    # installer refuses outright with "Directory exists but is not a git
+    # repository" when $agent_dir survives as an empty shell — exactly what a
+    # factory reset leaves behind — so without this the reinstall fails and the
+    # box stays bricked.
+    #
+    # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
+    # box had, and this step is no longer only reached by a genuinely broken
+    # device; a rename is just as good for unblocking the installer and is
+    # recoverable when the diagnosis was wrong. A FIXED name rather than a
+    # timestamp keeps at most one husk on a device whose disk is not large — a
+    # per-run stamp would accumulate a git checkout plus a venv on every failed
+    # update. Renaming as ROOT is also required: the root-owned __pycache__
+    # described above is not movable by the clawbox user the installer runs as.
+    if [ -e "$agent_dir" ]; then
+      rm -rf "$agent_dir.broken"
+      if ! mv "$agent_dir" "$agent_dir.broken"; then
+        echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
+        return 0
+      fi
+      echo "  Moved the unusable agent to $agent_dir.broken"
+    fi
     rm -f "$shim"
   fi
 
@@ -1181,7 +1218,7 @@ step_hermes_install() {
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
   # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
   runuser -u "$CLAWBOX_USER" -- bash -c \
-    'curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash' \
+    "curl -fsSL '$installer_url' | bash" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
@@ -1193,7 +1230,15 @@ step_hermes_install() {
     echo "  Hermes installed ($installed)"
   else
     echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
+    # Say where the previous install went, so a wrong diagnosis is reversible
+    # by hand instead of needing a reflash.
+    if [ -e "$agent_dir.broken" ]; then
+      echo "  The previous agent is preserved at $agent_dir.broken" >&2
+    fi
   fi
+  # Explicit: the last command above is a test that is FALSE on the happy path,
+  # and step_post_update reports any non-zero return as a failed step.
+  return 0
 }
 
 # Re-cache ONLY the offline Gemma GGUF.

--- a/install.sh
+++ b/install.sh
@@ -1134,41 +1134,35 @@ step_hermes_install() {
   local venv_python="$agent_dir/venv/bin/python"
   local installed=""
   # One constant so the reachability precheck and the install itself can never
-  # drift onto different hosts — a precheck against a URL we then do not use
-  # would be worse than no precheck.
+  # drift onto different hosts.
   local installer_url="https://hermes-agent.nousresearch.com/install.sh"
 
-  # `$shim` alone is NOT evidence of an install. It is a 4-line wrapper in
-  # ~/.local/bin that execs $venv_python; the agent it points at lives under
-  # ~/.hermes. A factory reset that removed ~/.hermes left the shim behind, so
-  # the old `[ -x "$shim" ]` guard reported "Hermes already installed ()" —
-  # with the version probe returning EMPTY into an echo nobody checked — and
-  # returned success without reinstalling anything. That is what turned a
-  # recoverable box into one that needed a reflash: every later repair attempt,
-  # including a full `install.sh` re-run, hit the same guard and did nothing.
+  # `$shim` alone is NOT evidence of an install: it is a 4-line wrapper in
+  # ~/.local/bin that execs $venv_python, and the agent it points at lives
+  # under ~/.hermes. A factory reset removed ~/.hermes and left the shim, so
+  # the old `[ -x "$shim" ]` guard printed "Hermes already installed ()" — an
+  # EMPTY version probe inside an echo nobody looked at — and returned success
+  # without reinstalling. Every later repair, a full install.sh re-run
+  # included, hit the same guard and did nothing: that is what turned a
+  # recoverable box into a reflash.
   #
   # So: require the interpreter to exist AND the agent to actually answer
-  # `--version`. Anything less is treated as "not installed" and reinstalled.
+  # `--version`. Anything less is treated as "not installed".
   if [ -x "$shim" ] && [ -x "$venv_python" ]; then
     # Probed AS THE CLAWBOX USER, deliberately. `hermes` is a Python entry
     # point and CPython writes __pycache__/*.pyc next to the sources it
-    # imports. install.sh runs as root, so probing here as root left ~13
-    # root-owned .pyc files (~165 after an agent version bump) inside a
-    # clawbox-owned tree — and the factory-reset route runs as clawbox, so its
-    # wipe hit EACCES on them and aborted MID-WIPE with the agent already half
-    # deleted. The probe is the only thing in this file that ever executed
-    # `hermes`, so running it under runuser removes the writer entirely.
-    # HOME is passed explicitly: hermes resolves ~/.hermes from $HOME, and this
+    # imports; probing as root left root-owned .pyc files inside a
+    # clawbox-owned tree, and the factory-reset route (which runs as clawbox)
+    # then hit EACCES and aborted MID-WIPE with the agent half deleted. HOME is
+    # passed explicitly: hermes resolves ~/.hermes from $HOME, and this
     # function's HOME is /root.
     #
-    # `|| installed=""` is NOT decoration. This file runs under `set -euo
-    # pipefail`, and a bare assignment takes the exit status of its command
-    # substitution — so a probe that exits non-zero (the exact false-negative
-    # case this step exists to survive) would kill install.sh right here,
-    # before the reachability check and before any repair, printing nothing.
-    # That would break both `install.sh --step hermes_install`, the repair
-    # command scripts/setup-hermes-edition.sh tells the operator to run, and
-    # the full install, which would skip every step after this one.
+    # `|| installed=""` is NOT decoration. Under `set -euo pipefail` an
+    # assignment takes the exit status of its command substitution, so the
+    # false-negative probe this step exists to survive would kill install.sh
+    # right here — before the reachability check, before any repair, printing
+    # nothing — taking `install.sh --step hermes_install` (the documented
+    # repair command) and every later step of a full install down with it.
     installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
       "$shim" --version 2>/dev/null | head -1) || installed=""
   fi
@@ -1179,17 +1173,10 @@ step_hermes_install() {
   fi
 
   # NOTHING above this line has modified the disk, and nothing below it does
-  # until the installer is known to be fetchable.
-  #
-  # This matters now in a way it did not before: step_post_update calls this
-  # step on EVERY update on EVERY hermes/dual box, not just on a broken one. So
-  # a false-negative probe — the venv busy, a transient fork failure, anything
-  # that makes `--version` come back empty on a device that is actually fine —
-  # used to reach a `rm -rf "$agent_dir"` and then depend on a network install
-  # that is explicitly non-fatal. On a box with no internet that sequence turns
-  # a healthy agent into no agent, which is the very outcome this file exists
-  # to prevent. Check reachability FIRST and leave the disk alone if the
-  # installer cannot be had.
+  # until the installer is known to be fetchable. step_post_update now calls
+  # this step on EVERY update on EVERY hermes/dual box, so a false-negative
+  # probe on a device with no internet must not be able to turn a healthy agent
+  # into no agent — the very outcome this file exists to prevent.
   if ! runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     curl -fsS --max-time 30 -o /dev/null "$installer_url"; then
     echo "  Warning: cannot reach the Hermes installer — leaving the existing agent untouched" >&2
@@ -1199,74 +1186,74 @@ step_hermes_install() {
   # The husk has to be out of the way before the reinstall: the upstream
   # installer refuses outright with "Directory exists but is not a git
   # repository" when $agent_dir survives as an empty shell — exactly what a
-  # factory reset leaves behind — so without this the reinstall fails and the
-  # box stays bricked.
+  # factory reset leaves behind — so without this the box stays bricked.
   #
-  # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
-  # box had, and this step is no longer only reached by a genuinely broken
-  # device; a rename is just as good for unblocking the installer and is
-  # recoverable when the diagnosis was wrong. A FIXED name rather than a
-  # timestamp keeps at most one husk on a device whose disk is not large — a
-  # per-run stamp would accumulate a git checkout plus a venv on every failed
-  # update. Renaming as ROOT is also required: the root-owned __pycache__
-  # described above is not movable by the clawbox user the installer runs as.
+  # MOVED ASIDE, never deleted, and only until the outcome is known: the
+  # install either succeeds (husk dropped below) or fails (husk moved back), so
+  # the device is never left with two copies and never with none, and a wrong
+  # diagnosis costs nothing. Renaming as ROOT is also required — the root-owned
+  # __pycache__ above is not movable by the clawbox user the installer runs as.
   if [ -e "$agent_dir" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    if [ -e "$agent_dir.broken" ]; then
-      # An earlier repair already saved the owner's checkout. Overwriting it
-      # here would replace it with the partial garbage the failed install left
-      # behind — on a persistently broken box, update #2 would destroy the only
-      # good copy. First husk wins.
-      echo "  Keeping the earlier $agent_dir.broken; discarding the unusable checkout"
-      rm -rf "$agent_dir"
-    elif mv "$agent_dir" "$agent_dir.broken"; then
-      # The husk MUST be deletable by the clawbox user. The factory-reset route
-      # runs as clawbox and keeps only the exact name "hermes-agent", so it
-      # tries to delete this directory — and a root-owned __pycache__ inside it
-      # (written by an older root-run probe) makes that unlink fail with EACCES.
-      # A reset that reports a failure aborts BEFORE the password/WiFi/hostname
-      # reset and the reboot, so the box would be stuck half-reset forever.
-      # install.sh is root here; the reset is not.
-      chown -R "$CLAWBOX_USER:" "$agent_dir.broken"
+    # Non-empty only if an earlier repair was interrupted between the move and
+    # the restore; without this `mv` would nest the new husk inside the old.
+    rm -rf "$agent_dir.broken"
+    if mv "$agent_dir" "$agent_dir.broken"; then
+      # The husk MUST be deletable by the clawbox user: the factory-reset route
+      # runs as clawbox and keeps only the exact name "hermes-agent", so a
+      # root-owned __pycache__ inside it fails the unlink with EACCES — and a
+      # reset that reports a failure aborts BEFORE the password/WiFi/hostname
+      # reset and the reboot. Non-fatal: errexit is live at this function's
+      # bare call sites and the agent is moved aside right now, so aborting
+      # here would leave the device with nothing installed at all.
+      chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$agent_dir.broken" \
+        || echo "  Warning: could not give $agent_dir.broken to $CLAWBOX_USER" >&2
       echo "  Moved the unusable agent to $agent_dir.broken"
     else
       echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
       return 0
     fi
   fi
-  # A no-op when the shim is absent; a stale shim must never outlive its agent.
-  rm -f "$shim"
 
   echo "  Installing Hermes agent (NousResearch)..."
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
-  # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
-  # The URL is passed as an argument rather than spliced into the -c string, so
-  # it stays a single source of truth without shell-quoting exposure.
-  runuser -u "$CLAWBOX_USER" -- bash -c \
-    'curl -fsSL "$1" | bash' _ "$installer_url" \
+  # the clawbox user so it lands in ~/.hermes and ~/.local/bin. The URL is
+  # passed as an argument rather than spliced into the -c string, so it stays a
+  # single source of truth without shell-quoting exposure. `-o pipefail`
+  # because `curl | bash` otherwise exits 0 when the fetch fails (bash just
+  # reads empty stdin) and the warning below could never fire; the timeouts
+  # because the caller is a systemd unit with TimeoutStartSec=7200.
+  runuser -u "$CLAWBOX_USER" -- bash -o pipefail -c \
+    'curl -fsSL --connect-timeout 15 --max-time 900 "$1" | bash' _ "$installer_url" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
   # non-fatal above, so a silent failure here would otherwise be discovered by
-  # the owner as a crash-looping dashboard.
-  # `|| installed=""` for the same errexit reason as the first probe: when the
-  # install laid down nothing, this runs a shim that does not exist and exits
-  # 127, which would abort the step before the warning below ever printed.
+  # the owner as a crash-looping dashboard. `|| installed=""` for the same
+  # errexit reason as the first probe: when the install laid down nothing, this
+  # runs a shim that does not exist and exits 127.
   installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     "$shim" --version 2>/dev/null | head -1) || installed=""
   if [ -n "$installed" ]; then
     echo "  Hermes installed ($installed)"
-    # The husk was insurance against a wrong diagnosis, and the new agent
-    # answers --version — so the insurance is over. It costs ~1.9 GB (checkout
-    # plus venv) on a device the comment above calls disk-constrained, and it
-    # is one more directory a later factory reset has to be able to delete.
+    # Diagnosis confirmed, so the insurance copy goes: it costs ~1.9 GB
+    # (checkout plus venv) on a disk-constrained device and is one more
+    # directory a later factory reset has to be able to delete.
     rm -rf "$agent_dir.broken"
   else
     echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
-    # Say where the previous install went, so a wrong diagnosis is reversible
-    # by hand instead of needing a reflash.
+    # The diagnosis may simply have been wrong — an empty probe on a loaded
+    # device is exactly the case above. Put the original back: whatever the
+    # failed install left behind is worth less than what was there before, and
+    # parking the only copy under another name would leave the owner with no
+    # working agent AND no automatic second chance on the next update.
     if [ -e "$agent_dir.broken" ]; then
-      echo "  The previous agent is preserved at $agent_dir.broken" >&2
+      rm -rf "$agent_dir"
+      if mv "$agent_dir.broken" "$agent_dir"; then
+        echo "  Restored the previous agent from $agent_dir.broken" >&2
+      else
+        echo "  Warning: the previous agent is at $agent_dir.broken — move it back by hand" >&2
+      fi
     fi
   fi
   # Explicit: the last command above is a test that is FALSE on the happy path,

--- a/install.sh
+++ b/install.sh
@@ -1195,24 +1195,33 @@ step_hermes_install() {
   # __pycache__ above is not movable by the clawbox user the installer runs as.
   if [ -e "$agent_dir" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    # Non-empty only if an earlier repair was interrupted between the move and
-    # the restore; without this `mv` would nest the new husk inside the old.
-    rm -rf "$agent_dir.broken"
-    if mv "$agent_dir" "$agent_dir.broken"; then
-      # The husk MUST be deletable by the clawbox user: the factory-reset route
-      # runs as clawbox and keeps only the exact name "hermes-agent", so a
-      # root-owned __pycache__ inside it fails the unlink with EACCES — and a
-      # reset that reports a failure aborts BEFORE the password/WiFi/hostname
-      # reset and the reboot. Non-fatal: errexit is live at this function's
-      # bare call sites and the agent is moved aside right now, so aborting
-      # here would leave the device with nothing installed at all.
-      chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$agent_dir.broken" \
-        || echo "  Warning: could not give $agent_dir.broken to $CLAWBOX_USER" >&2
+    if [ -e "$agent_dir.broken" ]; then
+      # An existing husk means an earlier repair was interrupted between the
+      # move and the restore: the husk is the owner's original checkout and
+      # $agent_dir is whatever the interrupted installer left behind. The
+      # original is the copy worth keeping; the partial tree is not. Deleting
+      # the husk here instead would destroy the last known-good agent.
+      if rm -rf "$agent_dir"; then
+        echo "  Kept the earlier husk at $agent_dir.broken and discarded the partial install"
+      else
+        echo "  Warning: could not clear the partial install at $agent_dir — leaving both in place" >&2
+        return 0
+      fi
+    elif mv "$agent_dir" "$agent_dir.broken"; then
       echo "  Moved the unusable agent to $agent_dir.broken"
     else
       echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
       return 0
     fi
+    # The husk MUST be deletable by the clawbox user: the factory-reset route
+    # runs as clawbox and keeps only the exact name "hermes-agent", so a
+    # root-owned __pycache__ inside it fails the unlink with EACCES — and a
+    # reset that reports a failure aborts BEFORE the password/WiFi/hostname
+    # reset and the reboot. Non-fatal: errexit is live at this function's
+    # bare call sites and the agent is moved aside right now, so aborting
+    # here would leave the device with nothing installed at all.
+    chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$agent_dir.broken" \
+      || echo "  Warning: could not give $agent_dir.broken to $CLAWBOX_USER" >&2
   fi
 
   echo "  Installing Hermes agent (NousResearch)..."
@@ -1224,7 +1233,7 @@ step_hermes_install() {
   # reads empty stdin) and the warning below could never fire; the timeouts
   # because the caller is a systemd unit with TimeoutStartSec=7200.
   runuser -u "$CLAWBOX_USER" -- bash -o pipefail -c \
-    'curl -fsSL --connect-timeout 15 --max-time 900 "$1" | bash' _ "$installer_url" \
+    'curl -fsSL --connect-timeout 15 --max-time 600 "$1" | bash' _ "$installer_url" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
@@ -1248,8 +1257,9 @@ step_hermes_install() {
     # parking the only copy under another name would leave the owner with no
     # working agent AND no automatic second chance on the next update.
     if [ -e "$agent_dir.broken" ]; then
-      rm -rf "$agent_dir"
-      if mv "$agent_dir.broken" "$agent_dir"; then
+      # Both steps guarded: a failed rm followed by mv would NEST the original
+      # inside the failed install and report success.
+      if rm -rf "$agent_dir" && mv "$agent_dir.broken" "$agent_dir"; then
         echo "  Restored the previous agent from $agent_dir.broken" >&2
       else
         echo "  Warning: the previous agent is at $agent_dir.broken — move it back by hand" >&2

--- a/install.sh
+++ b/install.sh
@@ -1160,8 +1160,17 @@ step_hermes_install() {
     # `hermes`, so running it under runuser removes the writer entirely.
     # HOME is passed explicitly: hermes resolves ~/.hermes from $HOME, and this
     # function's HOME is /root.
+    #
+    # `|| installed=""` is NOT decoration. This file runs under `set -euo
+    # pipefail`, and a bare assignment takes the exit status of its command
+    # substitution — so a probe that exits non-zero (the exact false-negative
+    # case this step exists to survive) would kill install.sh right here,
+    # before the reachability check and before any repair, printing nothing.
+    # That would break both `install.sh --step hermes_install`, the repair
+    # command scripts/setup-hermes-edition.sh tells the operator to run, and
+    # the full install, which would skip every step after this one.
     installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
-      "$shim" --version 2>/dev/null | head -1)
+      "$shim" --version 2>/dev/null | head -1) || installed=""
   fi
 
   if [ -n "$installed" ]; then
@@ -1181,53 +1190,77 @@ step_hermes_install() {
   # a healthy agent into no agent, which is the very outcome this file exists
   # to prevent. Check reachability FIRST and leave the disk alone if the
   # installer cannot be had.
-  if ! runuser -u "$CLAWBOX_USER" -- \
+  if ! runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     curl -fsS --max-time 30 -o /dev/null "$installer_url"; then
     echo "  Warning: cannot reach the Hermes installer — leaving the existing agent untouched" >&2
     return 0
   fi
 
-  if [ -e "$agent_dir" ] || [ -e "$shim" ]; then
+  # The husk has to be out of the way before the reinstall: the upstream
+  # installer refuses outright with "Directory exists but is not a git
+  # repository" when $agent_dir survives as an empty shell — exactly what a
+  # factory reset leaves behind — so without this the reinstall fails and the
+  # box stays bricked.
+  #
+  # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
+  # box had, and this step is no longer only reached by a genuinely broken
+  # device; a rename is just as good for unblocking the installer and is
+  # recoverable when the diagnosis was wrong. A FIXED name rather than a
+  # timestamp keeps at most one husk on a device whose disk is not large — a
+  # per-run stamp would accumulate a git checkout plus a venv on every failed
+  # update. Renaming as ROOT is also required: the root-owned __pycache__
+  # described above is not movable by the clawbox user the installer runs as.
+  if [ -e "$agent_dir" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    # The husk has to be out of the way before the reinstall: the upstream
-    # installer refuses outright with "Directory exists but is not a git
-    # repository" when $agent_dir survives as an empty shell — exactly what a
-    # factory reset leaves behind — so without this the reinstall fails and the
-    # box stays bricked.
-    #
-    # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
-    # box had, and this step is no longer only reached by a genuinely broken
-    # device; a rename is just as good for unblocking the installer and is
-    # recoverable when the diagnosis was wrong. A FIXED name rather than a
-    # timestamp keeps at most one husk on a device whose disk is not large — a
-    # per-run stamp would accumulate a git checkout plus a venv on every failed
-    # update. Renaming as ROOT is also required: the root-owned __pycache__
-    # described above is not movable by the clawbox user the installer runs as.
-    if [ -e "$agent_dir" ]; then
-      rm -rf "$agent_dir.broken"
-      if ! mv "$agent_dir" "$agent_dir.broken"; then
-        echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
-        return 0
-      fi
+    if [ -e "$agent_dir.broken" ]; then
+      # An earlier repair already saved the owner's checkout. Overwriting it
+      # here would replace it with the partial garbage the failed install left
+      # behind — on a persistently broken box, update #2 would destroy the only
+      # good copy. First husk wins.
+      echo "  Keeping the earlier $agent_dir.broken; discarding the unusable checkout"
+      rm -rf "$agent_dir"
+    elif mv "$agent_dir" "$agent_dir.broken"; then
+      # The husk MUST be deletable by the clawbox user. The factory-reset route
+      # runs as clawbox and keeps only the exact name "hermes-agent", so it
+      # tries to delete this directory — and a root-owned __pycache__ inside it
+      # (written by an older root-run probe) makes that unlink fail with EACCES.
+      # A reset that reports a failure aborts BEFORE the password/WiFi/hostname
+      # reset and the reboot, so the box would be stuck half-reset forever.
+      # install.sh is root here; the reset is not.
+      chown -R "$CLAWBOX_USER:" "$agent_dir.broken"
       echo "  Moved the unusable agent to $agent_dir.broken"
+    else
+      echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
+      return 0
     fi
-    rm -f "$shim"
   fi
+  # A no-op when the shim is absent; a stale shim must never outlive its agent.
+  rm -f "$shim"
 
   echo "  Installing Hermes agent (NousResearch)..."
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
   # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
+  # The URL is passed as an argument rather than spliced into the -c string, so
+  # it stays a single source of truth without shell-quoting exposure.
   runuser -u "$CLAWBOX_USER" -- bash -c \
-    "curl -fsSL '$installer_url' | bash" \
+    'curl -fsSL "$1" | bash' _ "$installer_url" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
   # non-fatal above, so a silent failure here would otherwise be discovered by
   # the owner as a crash-looping dashboard.
+  # `|| installed=""` for the same errexit reason as the first probe: when the
+  # install laid down nothing, this runs a shim that does not exist and exits
+  # 127, which would abort the step before the warning below ever printed.
   installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
-    "$shim" --version 2>/dev/null | head -1)
+    "$shim" --version 2>/dev/null | head -1) || installed=""
   if [ -n "$installed" ]; then
     echo "  Hermes installed ($installed)"
+    # The husk was insurance against a wrong diagnosis, and the new agent
+    # answers --version — so the insurance is over. It costs ~1.9 GB (checkout
+    # plus venv) on a device the comment above calls disk-constrained, and it
+    # is one more directory a later factory reset has to be able to delete.
+    rm -rf "$agent_dir.broken"
   else
     echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
     # Say where the previous install went, so a wrong diagnosis is reversible

--- a/scripts/setup-hermes-edition.sh
+++ b/scripts/setup-hermes-edition.sh
@@ -18,6 +18,7 @@ CLAWBOX_USER="${CLAWBOX_USER:-clawbox}"
 CLAWBOX_HOME="$(getent passwd "$CLAWBOX_USER" | cut -d: -f6)"
 CLAWBOX_HOME="${CLAWBOX_HOME:-/home/$CLAWBOX_USER}"
 HERMES_BIN="${HERMES_BIN:-$CLAWBOX_HOME/.local/bin/hermes}"
+HERMES_VENV_PYTHON="$CLAWBOX_HOME/.hermes/hermes-agent/venv/bin/python"
 EDITION_FILE="/etc/clawbox/edition.env"
 EDITION_DROPIN="/etc/systemd/system/clawbox-setup.service.d/edition.conf"
 
@@ -136,8 +137,14 @@ esac
 log "edition: $EDITION"
 
 # ── 1. Sanity: Hermes must be present (this edition runs on it). ────────────
-if [ ! -x "$HERMES_BIN" ]; then
-  fail "Hermes binary not found/executable at $HERMES_BIN — run: sudo bash $PROJECT_DIR/install.sh --step hermes_install"
+# BOTH halves, deliberately. $HERMES_BIN is a 4-line shim that execs
+# $HERMES_VENV_PYTHON, and it lives outside ~/.hermes — so a factory reset that
+# removed the agent left the shim executable and this check passing on a device
+# whose `hermes` command could not start. That is the same shim-only test that
+# made install.sh report "Hermes already installed ()"; fail loudly here instead
+# of continuing into a Hermes setup with no Hermes.
+if [ ! -x "$HERMES_BIN" ] || [ ! -x "$HERMES_VENV_PYTHON" ]; then
+  fail "Hermes agent not runnable ($HERMES_BIN -> $HERMES_VENV_PYTHON) — run: sudo bash $PROJECT_DIR/install.sh --step hermes_install"
 fi
 
 # ── 2. Shared-identity bridge ───────────────────────────────────────────────

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -42,6 +42,11 @@ const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
 // prompt text out of that log today; narrowing the keep to models/ is what
 // makes it stay true when the config changes, rather than something that has
 // to be re-verified every time llama.cpp is upgraded.
+//
+// Same KNOWN RESIDUAL as the ~/.hermes exception, for the same reasons and
+// with the same verdict — see the "KNOWN RESIDUAL" paragraph in
+// HOME_CONTENT_WIPE_KEEP below: a previous owner with a shell can plant a file
+// in a preserved directory and it survives the reset.
 const LLAMACPP_KEEP = new Set(["models"]);
 
 // Entries under ~/.hermes to preserve — see the .hermes entry in

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -20,13 +20,29 @@ const OPENCLAW_DIR = "/home/clawbox/.openclaw";
 //
 // network.env is hardware-specific and auto-generated.
 //
-// llamacpp/ holds the 3.2 GB offline Gemma GGUF — the same category as the
-// ~/.cache/huggingface voice models the home wipe deliberately keeps below:
-// a reset device reboots into AP mode with no internet, so a deleted model
-// cannot be re-downloaded and the box comes up with no on-device AI at all.
-// It is pure cache, not owner state — no tokens, no chats, no prompts — so
-// keeping it hands the next owner nothing.
+// llamacpp/ survives this top-level pass as a CONTAINER only — it is then
+// wiped entry-by-entry down to LLAMACPP_KEEP below. Spelling it here would
+// otherwise keep the whole subtree.
 const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
+
+// Entries under DATA_DIR/llamacpp to preserve: the models directory, nothing
+// else.
+//
+// models/ holds the 3.2 GB offline Gemma GGUF — the same category as the
+// ~/.cache/huggingface voice models the home wipe deliberately keeps below: a
+// reset device reboots into AP mode with no internet, so a deleted model
+// cannot be re-downloaded and the box comes up with no on-device AI at all.
+// Weights are pure cache, not owner state — no tokens, no chats, no prompts —
+// so keeping them hands the next owner nothing.
+//
+// Its siblings are a different matter. llamacpp/ is also llama-server's
+// runtime scratch (server.pid, server.log), and a log of a LOCAL MODEL is
+// owner-adjacent by nature — what the previous owner asked the offline model
+// is not something a resold box should carry. The shipped server config keeps
+// prompt text out of that log today; narrowing the keep to models/ is what
+// makes it stay true when the config changes, rather than something that has
+// to be re-verified every time llama.cpp is upgraded.
+const LLAMACPP_KEEP = new Set(["models"]);
 
 // Entries under ~/.hermes to preserve — see the .hermes entry in
 // HOME_CONTENT_WIPE_KEEP below for the full reasoning.
@@ -252,6 +268,28 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // on every box of this SKU. Everything Hermes writes about ITS OWNER lands
     // in the siblings above, which this wipe still removes.
     //
+    // KNOWN RESIDUAL, accepted deliberately: a previous owner with a shell
+    // could plant a file inside this one preserved directory and it would
+    // survive the reset. The obvious guard — assert `git status --porcelain`
+    // is empty and wipe the checkout when it is not — was tried and rejected,
+    // because both of its outcomes are worse than the hole:
+    //   * Wiping a "dirty" checkout recreates this very brick. A reset device
+    //     reboots into AP mode with no internet and nothing at boot reinstalls
+    //     the agent, so a false positive leaves the same crash-looping
+    //     dashboard — on every box of the SKU at once, the day upstream starts
+    //     writing into its own checkout. Whether it stays pristine is
+    //     NousResearch's choice, not ours.
+    //   * Reporting it as a failure instead is no better: a non-empty failure
+    //     list aborts the reset (500, no reboot), so the box could not be
+    //     factory reset at all until someone SSHed in.
+    // And it would not stop the attacker it is aimed at: the same shell can
+    // add the payload to .git/info/exclude, or drop it in venv/ — gitignored
+    // upstream, home to the interpreter, and invisible to --porcelain either
+    // way. A guard that a competent adversary steps over while a routine
+    // upstream commit bricks the fleet is a bad trade. Re-provisioning the
+    // agent from upstream after a reset is the real fix, and it needs network
+    // this device does not have at reset time.
+    //
     // Re-provisioning of the removed state is automatic: the dashboard unit
     // runs scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which
     // recreates config.yaml and a fresh password/hash/signing-secret on the
@@ -375,6 +413,13 @@ export async function POST() {
     } catch (err: unknown) {
       if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) throw err;
     }
+    // …then take llamacpp/ down to the weights alone. Kept as a whole subtree
+    // above only so this pass can decide what inside it survives.
+    dataFailures.push(
+      ...(await removeDirectoryContents(path.join(DATA_DIR, "llamacpp"), LLAMACPP_KEEP)).map(
+        (f) => `llamacpp/${f}`,
+      ),
+    );
 
     const openclawFailures = await removeDirectoryContents(OPENCLAW_DIR);
     // ClawKeep state (token, config, passphrase, schedule) lives in its own

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -16,8 +16,21 @@ const execFile = promisify(execFileCb);
 export const dynamic = "force-dynamic";
 const OPENCLAW_DIR = "/home/clawbox/.openclaw";
 
-// Files to preserve during factory reset (hardware-specific, auto-generated)
-const PRESERVE_FILES = new Set(["network.env"]);
+// Entries under DATA_DIR to preserve during factory reset.
+//
+// network.env is hardware-specific and auto-generated.
+//
+// llamacpp/ holds the 3.2 GB offline Gemma GGUF — the same category as the
+// ~/.cache/huggingface voice models the home wipe deliberately keeps below:
+// a reset device reboots into AP mode with no internet, so a deleted model
+// cannot be re-downloaded and the box comes up with no on-device AI at all.
+// It is pure cache, not owner state — no tokens, no chats, no prompts — so
+// keeping it hands the next owner nothing.
+const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
+
+// Entries under ~/.hermes to preserve — see the .hermes entry in
+// HOME_CONTENT_WIPE_KEEP below for the full reasoning.
+const HERMES_KEEP = new Set(["hermes-agent"]);
 
 /** Delete all Ollama models so a factory reset starts with a clean slate. */
 async function deleteOllamaModels(): Promise<void> {
@@ -96,13 +109,14 @@ async function deleteWifiConnections(): Promise<void> {
   }
 }
 
-async function removeDirectoryContents(dir: string): Promise<string[]> {
+async function removeDirectoryContents(dir: string, keep?: ReadonlySet<string>): Promise<string[]> {
   // Background processes (npm install, plugin runtimes) can recreate files
   // between readdir and rm; one retry catches that.
   for (let attempt = 0; attempt < 2; attempt++) {
     let entries: string[];
     try {
       entries = await fs.readdir(dir);
+      if (keep) entries = entries.filter((entry) => !keep.has(entry));
     } catch (err: unknown) {
       if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return [];
       throw err;
@@ -202,26 +216,55 @@ const HOME_REMOVE_PATHS = [
   ".cache/huggingface/stored_tokens",
   // VS Code server state/extensions from the VSCode app.
   ".local/share/code-server",
-  // Hermes edition state — the Hermes equivalent of ~/.openclaw, and the single
-  // biggest thing a resold box used to hand its next owner. It holds
-  // config.yaml (the providers.clawai billing token, the dashboard's session
-  // SIGNING SECRET and the scrypt password_hash, and a pointer to the chat DB),
-  // config.yaml.bak-* (full prior copies of the same), .env (~24 KB of provider
-  // keys), auth.json (OAuth tokens), plus memories/, logs/, cron/ and pairing/.
-  // The whole directory goes, not a per-file list: the .bak-* copies alone show
-  // how easily a surgical list misses a full duplicate of every secret.
-  //
-  // Nothing preserved. Re-provisioning is automatic — the dashboard unit runs
-  // scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which recreates
-  // config.yaml and a fresh password/hash/signing-secret on the next boot.
-  // (Before that ExecStartPre existed, wiping this would have left the
-  // dashboard with no auth provider on its non-loopback bind and crash-looped
-  // it forever, which is why the wipe had to land together with it.)
-  ".hermes",
 ];
 // User-visible folders the Files app exposes (and recreates empty on demand):
 // wipe the contents, keep the directories.
 const HOME_CONTENT_WIPE_DIRS = ["Documents", "Downloads", "Desktop"];
+
+// Directories wiped entry-by-entry with a NAMED exception list. Same
+// remove-everything default as HOME_REMOVE_PATHS — the exception is spelled
+// out and justified, and anything new that appears in the directory is
+// removed by default rather than kept by default.
+const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<string> }> = [
+  {
+    // Hermes edition state — the Hermes equivalent of ~/.openclaw, and the
+    // single biggest thing a resold box could hand its next owner. It holds
+    // config.yaml (the providers.clawai billing token, the dashboard's session
+    // SIGNING SECRET and the scrypt password_hash, and a pointer to the chat
+    // DB), config.yaml.bak-* (full prior copies of the same), .env (~24 KB of
+    // provider keys), auth.json (OAuth tokens), plus memories/, logs/, cron/,
+    // pairing/, sessions/, skills/ and the state/projects SQLite files. All of
+    // it still goes: this is a wipe with ONE exception, not a keep-list.
+    //
+    // That one exception is hermes-agent/ — and it is not owner state at all.
+    // It is the AGENT INSTALL: a git checkout of NousResearch/hermes-agent
+    // plus the Python venv that ~/.local/bin/hermes (a 4-line shim) execs.
+    // Deleting it was the factory-reset defect this exception fixes. The shim
+    // survives the wipe (it lives in ~/.local/bin), so a reset box was left
+    // with a `hermes` command whose interpreter no longer existed:
+    //   ~/.local/bin/hermes: line 4:
+    //   ~/.hermes/hermes-agent/venv/bin/python: No such file or directory
+    // …and clawbox-hermes-dashboard.service (Restart=always) crash-looping on
+    // status 127 forever. Nothing at boot reinstalls it, and a reset device is
+    // in AP mode with no internet to re-download it — a reflash.
+    //
+    // It carries no secrets to leak: upstream source and a venv, byte-identical
+    // on every box of this SKU. Everything Hermes writes about ITS OWNER lands
+    // in the siblings above, which this wipe still removes.
+    //
+    // Re-provisioning of the removed state is automatic: the dashboard unit
+    // runs scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which
+    // recreates config.yaml and a fresh password/hash/signing-secret on the
+    // next boot.
+    //
+    // Wiping entry-by-entry rather than `rm -rf ~/.hermes` also makes the reset
+    // survivable: each child is removed independently, so one undeletable entry
+    // is reported as a failure instead of aborting the whole subtree with the
+    // agent already half deleted.
+    rel: ".hermes",
+    keep: HERMES_KEEP,
+  },
+];
 
 /**
  * Wipe previous-owner state from the home directory so a factory-reset
@@ -240,6 +283,10 @@ async function wipeHomeUserState(): Promise<string[]> {
   );
   for (const rel of HOME_CONTENT_WIPE_DIRS) {
     const dirFailures = await removeDirectoryContents(path.join(HOME_DIR, rel));
+    failures.push(...dirFailures.map((f) => `${rel}/${f}`));
+  }
+  for (const { rel, keep } of HOME_CONTENT_WIPE_KEEP) {
+    const dirFailures = await removeDirectoryContents(path.join(HOME_DIR, rel), keep);
     failures.push(...dirFailures.map((f) => `${rel}/${f}`));
   }
   // Agent-scheduled cron jobs. `crontab -r` exits non-zero when there is no

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -16,41 +16,37 @@ const execFile = promisify(execFileCb);
 export const dynamic = "force-dynamic";
 const OPENCLAW_DIR = "/home/clawbox/.openclaw";
 
-// Entries under DATA_DIR to preserve during factory reset.
-//
-// network.env is hardware-specific and auto-generated.
-//
-// llamacpp/ survives this top-level pass as a CONTAINER only — it is then
-// wiped entry-by-entry down to LLAMACPP_KEEP below. Spelling it here would
-// otherwise keep the whole subtree.
-const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
+// Entries under DATA_DIR that survive a factory reset. A `keep` set means the
+// entry survives this top-level pass as a CONTAINER only and is then wiped
+// entry-by-entry down to those names; without one it is kept as it is.
+const DATA_KEEP: ReadonlyArray<{ rel: string; keep?: ReadonlySet<string> }> = [
+  // Hardware-specific and auto-generated.
+  { rel: "network.env" },
+  {
+    // models/ holds the 3.2 GB offline Gemma GGUF — the same category as the
+    // ~/.cache/huggingface voice models the home wipe keeps below: a reset
+    // device reboots into AP mode with no internet, so a deleted model cannot
+    // be re-downloaded and the box comes up with no on-device AI at all.
+    // Weights are pure cache, not owner state — no tokens, no chats, no
+    // prompts — so keeping them hands the next owner nothing. (It also carries
+    // ~24 KB of `hf` download bookkeeping; re-check that if huggingface_hub
+    // ever starts caching credentials under a --local-dir.)
+    //
+    // Its siblings are a different matter: llamacpp/ is also llama-server's
+    // runtime scratch (server.pid, server.log), and a log of a LOCAL MODEL is
+    // owner-adjacent by nature. The shipped server config keeps prompt text
+    // out of that log today; narrowing the keep to models/ is what makes that
+    // stay true when the config changes.
+    //
+    // Same KNOWN RESIDUAL as the ~/.hermes exception below, with the same
+    // verdict: a previous owner with a shell can plant a file in a preserved
+    // directory and it survives the reset.
+    rel: "llamacpp",
+    keep: new Set(["models"]),
+  },
+];
+const DATA_KEEP_NAMES = new Set(DATA_KEEP.map((entry) => entry.rel));
 
-// Entries under DATA_DIR/llamacpp to preserve: the models directory, nothing
-// else.
-//
-// models/ holds the 3.2 GB offline Gemma GGUF — the same category as the
-// ~/.cache/huggingface voice models the home wipe deliberately keeps below: a
-// reset device reboots into AP mode with no internet, so a deleted model
-// cannot be re-downloaded and the box comes up with no on-device AI at all.
-// Weights are pure cache, not owner state — no tokens, no chats, no prompts —
-// so keeping them hands the next owner nothing.
-//
-// Its siblings are a different matter. llamacpp/ is also llama-server's
-// runtime scratch (server.pid, server.log), and a log of a LOCAL MODEL is
-// owner-adjacent by nature — what the previous owner asked the offline model
-// is not something a resold box should carry. The shipped server config keeps
-// prompt text out of that log today; narrowing the keep to models/ is what
-// makes it stay true when the config changes, rather than something that has
-// to be re-verified every time llama.cpp is upgraded.
-//
-// Same KNOWN RESIDUAL as the ~/.hermes exception, for the same reasons and
-// with the same verdict — see the "KNOWN RESIDUAL" paragraph in
-// HOME_CONTENT_WIPE_KEEP below: a previous owner with a shell can plant a file
-// in a preserved directory and it survives the reset.
-const LLAMACPP_KEEP = new Set(["models"]);
-
-// Entries under ~/.hermes to preserve — see the .hermes entry in
-// HOME_CONTENT_WIPE_KEEP below for the full reasoning.
 const HERMES_KEEP = new Set(["hermes-agent"]);
 
 /** Delete all Ollama models so a factory reset starts with a clean slate. */
@@ -249,20 +245,19 @@ const HOME_CONTENT_WIPE_DIRS = ["Documents", "Downloads", "Desktop"];
 const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<string> }> = [
   {
     // Hermes edition state — the Hermes equivalent of ~/.openclaw, and the
-    // single biggest thing a resold box could hand its next owner. It holds
-    // config.yaml (the providers.clawai billing token, the dashboard's session
-    // SIGNING SECRET and the scrypt password_hash, and a pointer to the chat
-    // DB), config.yaml.bak-* (full prior copies of the same), .env (~24 KB of
-    // provider keys), auth.json (OAuth tokens), plus memories/, logs/, cron/,
-    // pairing/, sessions/, skills/ and the state/projects SQLite files. All of
-    // it still goes: this is a wipe with ONE exception, not a keep-list.
+    // single biggest thing a resold box could hand its next owner: config.yaml
+    // (billing token, the dashboard session SIGNING SECRET, the scrypt
+    // password_hash), config.yaml.bak-*, .env (~24 KB of provider keys),
+    // auth.json (OAuth tokens), memories/, logs/, cron/, pairing/, sessions/,
+    // skills/ and the state/projects SQLite files. All of it still goes: this
+    // is a wipe with ONE exception, not a keep-list.
     //
-    // That one exception is hermes-agent/ — and it is not owner state at all.
-    // It is the AGENT INSTALL: a git checkout of NousResearch/hermes-agent
-    // plus the Python venv that ~/.local/bin/hermes (a 4-line shim) execs.
-    // Deleting it was the factory-reset defect this exception fixes. The shim
-    // survives the wipe (it lives in ~/.local/bin), so a reset box was left
-    // with a `hermes` command whose interpreter no longer existed:
+    // That exception is hermes-agent/, and it is not owner state at all. It is
+    // the AGENT INSTALL — a git checkout of NousResearch/hermes-agent plus the
+    // Python venv that ~/.local/bin/hermes (a 4-line shim) execs. Deleting it
+    // was the factory-reset defect this exception fixes: the shim survives the
+    // wipe (it lives in ~/.local/bin), so a reset box was left with a `hermes`
+    // command whose interpreter no longer existed:
     //   ~/.local/bin/hermes: line 4:
     //   ~/.hermes/hermes-agent/venv/bin/python: No such file or directory
     // …and clawbox-hermes-dashboard.service (Restart=always) crash-looping on
@@ -270,30 +265,22 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // in AP mode with no internet to re-download it — a reflash.
     //
     // It carries no secrets to leak: upstream source and a venv, byte-identical
-    // on every box of this SKU. Everything Hermes writes about ITS OWNER lands
-    // in the siblings above, which this wipe still removes.
+    // on every box of this SKU.
     //
     // KNOWN RESIDUAL, accepted deliberately: a previous owner with a shell
     // could plant a file inside this one preserved directory and it would
-    // survive the reset. The obvious guard — assert `git status --porcelain`
-    // is empty and wipe the checkout when it is not — was tried and rejected,
-    // because both of its outcomes are worse than the hole:
-    //   * Wiping a "dirty" checkout recreates this very brick. A reset device
-    //     reboots into AP mode with no internet and nothing at boot reinstalls
-    //     the agent, so a false positive leaves the same crash-looping
-    //     dashboard — on every box of the SKU at once, the day upstream starts
-    //     writing into its own checkout. Whether it stays pristine is
-    //     NousResearch's choice, not ours.
-    //   * Reporting it as a failure instead is no better: a non-empty failure
-    //     list aborts the reset (500, no reboot), so the box could not be
-    //     factory reset at all until someone SSHed in.
-    // And it would not stop the attacker it is aimed at: the same shell can
-    // add the payload to .git/info/exclude, or drop it in venv/ — gitignored
-    // upstream, home to the interpreter, and invisible to --porcelain either
-    // way. A guard that a competent adversary steps over while a routine
-    // upstream commit bricks the fleet is a bad trade. Re-provisioning the
-    // agent from upstream after a reset is the real fix, and it needs network
-    // this device does not have at reset time.
+    // survive the reset. The obvious guard — wipe the checkout unless `git
+    // status --porcelain` is empty — was tried and rejected. Both of its
+    // outcomes are worse than the hole: wiping a "dirty" checkout recreates
+    // this very brick on every box of the SKU at once the day upstream starts
+    // writing into its own checkout (whether it stays pristine is
+    // NousResearch's choice, not ours), and reporting it as a failure instead
+    // aborts the reset (500, no reboot) so the box cannot be reset at all. It
+    // would not stop the attacker either: the same shell can add the payload
+    // to .git/info/exclude or drop it in venv/, gitignored upstream and
+    // invisible to --porcelain. Re-provisioning the agent from upstream after
+    // a reset is the real fix, and it needs network this device does not have
+    // at reset time.
     //
     // Re-provisioning of the removed state is automatic: the dashboard unit
     // runs scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which
@@ -409,7 +396,7 @@ export async function POST() {
       const entries = await fs.readdir(DATA_DIR);
       const results = await Promise.allSettled(
         entries
-          .filter(entry => !PRESERVE_FILES.has(entry))
+          .filter(entry => !DATA_KEEP_NAMES.has(entry))
           .map(entry => fs.rm(path.join(DATA_DIR, entry), { recursive: true, force: true }))
       );
       for (const r of results) {
@@ -418,13 +405,13 @@ export async function POST() {
     } catch (err: unknown) {
       if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) throw err;
     }
-    // …then take llamacpp/ down to the weights alone. Kept as a whole subtree
-    // above only so this pass can decide what inside it survives.
-    dataFailures.push(
-      ...(await removeDirectoryContents(path.join(DATA_DIR, "llamacpp"), LLAMACPP_KEEP)).map(
-        (f) => `llamacpp/${f}`,
-      ),
-    );
+    // …then take each container keep down to its exception list.
+    for (const { rel, keep } of DATA_KEEP) {
+      if (!keep) continue;
+      dataFailures.push(
+        ...(await removeDirectoryContents(path.join(DATA_DIR, rel), keep)).map((f) => `${rel}/${f}`),
+      );
+    }
 
     const openclawFailures = await removeDirectoryContents(OPENCLAW_DIR);
     // ClawKeep state (token, config, passphrase, schedule) lives in its own

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -491,9 +491,27 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     // longer (wait_for_apt alone allows 900s), so an overrun past these 5
     // minutes is advisory: the unit finishes on its own (TimeoutStartSec is
     // 30 min) and everything inside it is non-fatal by design.
+    // 15 min, raised from 5. post_update now also REPAIRS a device that a
+    // pre-fix factory reset left without its Hermes agent install or its
+    // offline Gemma GGUF (step_hermes_install + step_llamacpp_model at the end
+    // of step_post_update). On a healthy box both are sub-second no-ops and
+    // nothing about the timing changes; on a broken one they are a git clone +
+    // venv build (~90s measured) and a 3.2 GB model download, on top of the
+    // fixups that already routinely outlive a minute.
+    //
+    // The raise is not cosmetic. `advisoryOnOverrun` does not pause the
+    // update: it marks the step completed and moves straight on to
+    // `hermes_edition`, which hard-fails when ~/.local/bin/hermes is not yet
+    // runnable. So an overrun DURING the repair would report the repair as
+    // fine and then fail the step after it. The budget has to cover the repair
+    // rather than lean on the advisory path.
+    //
+    // Still well inside the unit's own ceiling (TimeoutStartSec=7200 in
+    // config/clawbox-root-update@.service), and advisoryOnOverrun stays as the
+    // backstop for the genuinely pathological case.
     id: "post_update",
     label: "Applying system fixups",
-    timeoutMs: 300_000,
+    timeoutMs: 900_000,
     requiresRoot: true,
     advisoryOnOverrun: true,
   },

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -442,3 +442,169 @@ describe("POST /setup-api/setup/reset", () => {
     expect(unlinkInputCall).toBeDefined();
   });
 });
+
+/**
+ * A factory reset on a Hermes-edition device used to brick it.
+ *
+ * `.hermes` was in HOME_REMOVE_PATHS as a whole directory, on the (wrong)
+ * belief that it held only owner state. `~/.hermes/hermes-agent/` is the AGENT
+ * INSTALL — the upstream checkout plus the Python venv that the 4-line
+ * `~/.local/bin/hermes` shim execs. The shim lives outside the wipe and
+ * survived it, so the box came up with a `hermes` command whose interpreter was
+ * gone and clawbox-hermes-dashboard.service (Restart=always) crash-looping on
+ * exit 127 forever. The same reset emptied data/, taking the 3.2 GB offline
+ * Gemma GGUF with it — on a device that reboots into AP mode with no internet
+ * to re-download either.
+ *
+ * These tests pin both exceptions, and — just as importantly — pin that
+ * carving them out did not turn the wipe into a keep-list: every
+ * secret-bearing sibling under ~/.hermes must still be removed.
+ */
+describe("POST /setup-api/setup/reset — Hermes agent + offline model survive", () => {
+  let resetPost: () => Promise<Response>;
+  const HOME = process.env.HOME || "/home/clawbox";
+  const HERMES = `${HOME}/.hermes`;
+
+  // What a used Hermes box actually has under ~/.hermes.
+  const HERMES_ENTRIES = [
+    "hermes-agent",
+    "config.yaml",
+    "config.yaml.bak-20260813",
+    ".env",
+    "auth.json",
+    "memories",
+    "logs",
+    "cron",
+    "pairing",
+    "sessions",
+    "skills",
+    "state.db",
+    "projects.db",
+  ];
+  const SECRET_ENTRIES = HERMES_ENTRIES.filter((e) => e !== "hermes-agent");
+
+  const rmTargets = () =>
+    mockFs.rm.mock.calls.map(([p]) => p).filter((p): p is string => typeof p === "string");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: [] }),
+    }));
+    vi.stubGlobal("process", { ...process, getuid: () => 1000, getgid: () => 1000 });
+
+    mockFs.readdir.mockImplementation(((p: string) => {
+      if (p === HERMES) return Promise.resolve(HERMES_ENTRIES);
+      if (p === "/test/data") return Promise.resolve(["config.json", "network.env", "llamacpp", ".session-secret"]);
+      return Promise.resolve([]);
+    }) as unknown as typeof fs.readdir);
+    mockFs.rm.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.chown.mockResolvedValue();
+    mockFs.unlink.mockResolvedValue();
+    mockResetUpdateState.mockReturnValue();
+    setupExecFileMock({ nmcli: { stdout: "", stderr: "" }, systemctl: { stdout: "", stderr: "" } });
+
+    const mod = await import("@/app/setup-api/setup/reset/route");
+    resetPost = mod.POST;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("never removes ~/.hermes/hermes-agent, directly or via its parent", async () => {
+    await resetPost();
+    const targets = rmTargets();
+
+    // The agent install itself.
+    expect(targets).not.toContain(`${HERMES}/hermes-agent`);
+    // And not by taking the whole directory out from under it — the exact
+    // shape of the original defect.
+    expect(targets).not.toContain(HERMES);
+  });
+
+  it("still removes every secret-bearing entry under ~/.hermes", async () => {
+    await resetPost();
+    const targets = rmTargets();
+
+    for (const entry of SECRET_ENTRIES) {
+      expect(targets, `expected ~/.hermes/${entry} to be removed`).toContain(`${HERMES}/${entry}`);
+    }
+  });
+
+  it("removes unknown new entries under ~/.hermes by default", async () => {
+    // The exception is a named allow-list of one. Anything Hermes starts
+    // writing tomorrow must be wiped without a code change, or the fix quietly
+    // becomes a keep-list and the next secret leaks to the next owner.
+    mockFs.readdir.mockImplementation(((p: string) =>
+      Promise.resolve(p === HERMES ? ["hermes-agent", "some-future-token-store"] : [])
+    ) as unknown as typeof fs.readdir);
+
+    await resetPost();
+
+    expect(rmTargets()).toContain(`${HERMES}/some-future-token-store`);
+  });
+
+  it("keeps data/llamacpp (the offline GGUF) while wiping the rest of data/", async () => {
+    await resetPost();
+    const targets = rmTargets();
+
+    expect(targets).not.toContain("/test/data/llamacpp");
+    expect(targets).toContain("/test/data/config.json");
+    expect(targets).toContain("/test/data/.session-secret");
+    // network.env was already preserved; assert it stayed that way.
+    expect(targets).not.toContain("/test/data/network.env");
+  });
+
+  it("one undeletable entry under ~/.hermes does not stop the rest of the wipe", async () => {
+    // Root-owned __pycache__ under ~/.hermes (written by a root-run `hermes
+    // --version`) made `rm -rf ~/.hermes` fail as ONE call, aborting the whole
+    // subtree with the agent already half deleted. Per-entry removal means one
+    // EACCES is reported and the other entries still go.
+    mockFs.rm.mockImplementation(((p: unknown) =>
+      typeof p === "string" && p === `${HERMES}/auth.json`
+        ? Promise.reject(new Error("EACCES: permission denied"))
+        : Promise.resolve()) as unknown as typeof fs.rm);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    const body = await res.json();
+    warnSpy.mockRestore();
+
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(body.failures)).toContain("auth.json");
+    // Everything else still got removed.
+    const targets = rmTargets();
+    for (const entry of SECRET_ENTRIES.filter((e) => e !== "auth.json")) {
+      expect(targets, `expected ~/.hermes/${entry} to still be removed`).toContain(`${HERMES}/${entry}`);
+    }
+  });
+
+  it("a failed wipe leaves the owner able to get back in", async () => {
+    // The abort path does NOT reboot, and the AP only returns on reboot. So a
+    // reset that failed must not have already deleted the WiFi profiles or
+    // reset the login password — that would strand a WiFi-only device offline
+    // with credentials the owner does not have.
+    mockFs.rm.mockImplementation(((p: unknown) =>
+      typeof p === "string" && p.endsWith("auth.json")
+        ? Promise.reject(new Error("EACCES: permission denied"))
+        : Promise.resolve()) as unknown as typeof fs.rm);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    warnSpy.mockRestore();
+
+    expect(res.status).toBe(500);
+    const calls = mockExecFile.mock.calls.map(([cmd, args]) => `${cmd} ${(args as string[])?.join(" ")}`);
+    expect(calls.some((c) => c.includes("connection delete"))).toBe(false);
+    expect(calls.some((c) => c.includes("clawbox-root-update@chpasswd"))).toBe(false);
+    expect(calls.some((c) => c.includes("systemctl reboot"))).toBe(false);
+  });
+});

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -499,6 +499,8 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     mockFs.readdir.mockImplementation(((p: string) => {
       if (p === HERMES) return Promise.resolve(HERMES_ENTRIES);
       if (p === "/test/data") return Promise.resolve(["config.json", "network.env", "llamacpp", ".session-secret"]);
+      // llama-server's runtime scratch sits beside the weights.
+      if (p === "/test/data/llamacpp") return Promise.resolve(["models", "server.pid", "server.log"]);
       return Promise.resolve([]);
     }) as unknown as typeof fs.readdir);
     mockFs.rm.mockResolvedValue();
@@ -561,6 +563,36 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     expect(targets).toContain("/test/data/.session-secret");
     // network.env was already preserved; assert it stayed that way.
     expect(targets).not.toContain("/test/data/network.env");
+  });
+
+  it("keeps only the weights inside data/llamacpp — runtime scratch still goes", async () => {
+    // The keep is for the 3.2 GB download a reset device cannot re-fetch, not
+    // for the directory it happens to live in. llamacpp/ is also llama-server's
+    // working directory: server.log is a log of what the previous owner asked
+    // the LOCAL model, which a resold box must not carry. Keeping models/
+    // rather than the subtree means that holds by construction instead of
+    // depending on the current llama-server logging config.
+    await resetPost();
+    const targets = rmTargets();
+
+    expect(targets).toContain("/test/data/llamacpp/server.pid");
+    expect(targets).toContain("/test/data/llamacpp/server.log");
+    expect(targets).not.toContain("/test/data/llamacpp/models");
+  });
+
+  it("removes anything new that appears next to the weights, by default", async () => {
+    // Same property as the ~/.hermes exception: a named allow-list of one, so
+    // whatever llama.cpp starts writing tomorrow is wiped without a code
+    // change rather than inherited by the next owner.
+    mockFs.readdir.mockImplementation(((p: string) => {
+      if (p === "/test/data") return Promise.resolve(["llamacpp"]);
+      if (p === "/test/data/llamacpp") return Promise.resolve(["models", "sessions.jsonl"]);
+      return Promise.resolve([]);
+    }) as unknown as typeof fs.readdir);
+
+    await resetPost();
+
+    expect(rmTargets()).toContain("/test/data/llamacpp/sessions.jsonl");
   });
 
   it("one undeletable entry under ~/.hermes does not stop the rest of the wipe", async () => {

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs, { readFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 /**
@@ -31,7 +33,8 @@ import path from "node:path";
  *    repository" and the box stays broken.
  */
 const REPO = process.cwd();
-const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_SH_PATH = path.join(REPO, "install.sh");
+const INSTALL_SH = readFileSync(INSTALL_SH_PATH, "utf-8");
 const UPDATER_TS = readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8");
 
 const NL = String.fromCharCode(10);
@@ -93,14 +96,45 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     expect(alreadyLine).not.toContain("--version");
   });
 
-  it("clears the stale agent husk before reinstalling", () => {
-    expect(HERMES_CODE).toMatch(/rm -rf "\$agent_dir"/);
+  it("moves the stale agent husk aside rather than deleting it", () => {
+    // step_post_update now runs this step on EVERY update on EVERY hermes/dual
+    // box, so the destructive branch is no longer reached only by a device
+    // that is genuinely broken. `rm -rf "$agent_dir"` followed by a network
+    // install that is explicitly non-fatal is a one-way door: one
+    // false-negative probe on a box with no internet and a healthy agent
+    // becomes no agent at all.
+    expect(HERMES_CODE).not.toMatch(/rm -rf "\$agent_dir"\s*$/m);
+    expect(HERMES_CODE).toMatch(/mv "\$agent_dir" "\$agent_dir\.broken"/);
+  });
+
+  it("checks the installer is reachable BEFORE it touches the disk", () => {
+    // Ordering is the whole guarantee: a precheck after the husk is gone
+    // protects nothing.
+    const precheckIdx = HERMES_CODE.indexOf("$installer_url");
+    const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir"');
+    expect(precheckIdx).toBeGreaterThan(-1);
+    expect(mvIdx).toBeGreaterThan(precheckIdx);
+    // …and it must bail out rather than press on.
+    expect(HERMES_CODE).toMatch(/cannot reach the Hermes installer/);
+  });
+
+  it("prechecks and installs from the same URL", () => {
+    // A precheck against a host the install does not then use would be worse
+    // than no precheck — it would report reachable and still fail.
+    const urls = HERMES_CODE.match(/https:\/\/[^\s"']+/g) ?? [];
+    expect(urls.length).toBe(1);
+    expect(HERMES_CODE.match(/\$installer_url/g)?.length).toBe(2);
   });
 
   it("verifies the install afterwards instead of assuming it worked", () => {
     // The upstream installer is fetched over the network and its failure is
     // non-fatal, so the step has to check.
-    const afterInstall = HERMES_CODE.slice(HERMES_CODE.indexOf("hermes-agent.nousresearch.com"));
+    // Anchored on the install invocation itself, not on the URL — the URL now
+    // also appears in the `installer_url` declaration at the top of the
+    // function, which would make this assertion pass vacuously.
+    const installIdx = HERMES_CODE.indexOf("curl -fsSL");
+    expect(installIdx).toBeGreaterThan(-1);
+    const afterInstall = HERMES_CODE.slice(installIdx);
     expect(afterInstall).toContain("--version");
     expect(afterInstall).toMatch(/Warning: Hermes still does not run/);
   });
@@ -196,5 +230,201 @@ describe("llamacpp_model is a cheap, dispatchable step", () => {
     // The factory-reset route wipes data/ on all editions, so an openclaw box
     // needs exactly the same repair.
     expect(LLAMACPP_MODEL).not.toContain("has_hermes_harness");
+  });
+});
+
+/**
+ * Everything above reads install.sh as TEXT. That pins the shape of the code
+ * but not its behaviour: a regex cannot tell whether the branches actually go
+ * where the text suggests, and it is exactly the branch ordering — probe, then
+ * reachability, then move aside, then install — that decides whether a healthy
+ * box survives this step. So drive the real function, with a fake HOME and
+ * stubbed `runuser`/`curl`, and look at what it did to the filesystem.
+ *
+ * Same approach as install-llamacpp-prebuilt.test.ts: lift the one function
+ * out with sed, because sourcing install.sh would install a machine.
+ */
+describe("step_hermes_install — behaviour, driven against a fake HOME", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-guard-"));
+    // Stands in for both the venv interpreter and the shim: all either has to
+    // do here is exist, be executable, and answer --version.
+    fs.writeFileSync(path.join(tmp, "fake-py"), "#!/bin/sh\necho 'Hermes 9.9.9'\n", { mode: 0o755 });
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  const agentDir = () => path.join(tmp, ".hermes", "hermes-agent");
+  const shimPath = () => path.join(tmp, ".local", "bin", "hermes");
+  const exists = (p: string) => fs.existsSync(p);
+
+  /** The shim survives a factory reset — it lives outside ~/.hermes. */
+  function giveShim() {
+    fs.mkdirSync(path.dirname(shimPath()), { recursive: true });
+    fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
+    fs.chmodSync(shimPath(), 0o755);
+  }
+
+  /** An agent checkout, with or without the venv the shim execs. */
+  function giveAgent({ venv }: { venv: boolean }) {
+    fs.mkdirSync(agentDir(), { recursive: true });
+    // Marks THIS checkout, so we can tell "moved aside" from "recreated".
+    fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "original");
+    if (venv) {
+      const binDir = path.join(agentDir(), "venv", "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.copyFileSync(path.join(tmp, "fake-py"), path.join(binDir, "python"));
+      fs.chmodSync(path.join(binDir, "python"), 0o755);
+    }
+  }
+
+  /**
+   * `reachable` decides what the reachability precheck sees; `installOk`
+   * whether the stubbed installer actually lays down a working agent. The stub
+   * records that it ran, so "did the network install happen at all" is
+   * directly observable.
+   */
+  function run({ reachable = true, installOk = true } = {}) {
+    const script = [
+      "set -u",
+      'CLAWBOX_HOME="$1"',
+      'CLAWBOX_USER="$(id -un)"',
+      'export MARKER="$1/installer-ran"',
+      'export AGENT_DIR="$1/.hermes/hermes-agent"',
+      'export SHIM="$1/.local/bin/hermes"',
+      'export FAKE_PY="$1/fake-py"',
+      'export PRECHECK_RC="$2"',
+      'export INSTALL_OK="$3"',
+      "has_hermes_harness() { return 0; }",
+      // Run the command as this user instead of switching: `runuser -u X -- cmd`.
+      'runuser() { shift 2; [ "$1" = "--" ] && shift; "$@"; }',
+      "curl() {",
+      //  The reachability precheck is the `-o /dev/null` call; anything else is
+      //  the real installer being piped into bash.
+      '  case " $* " in *" -o /dev/null "*) return "$PRECHECK_RC" ;; esac',
+      '  echo ran >> "$MARKER"',
+      '  if [ "$INSTALL_OK" = "1" ]; then',
+      '    mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
+      '    cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
+      '    cp "$FAKE_PY" "$SHIM"',
+      "  fi",
+      '  echo ":"',
+      "}",
+      "export -f curl",
+      "sed -n '/^step_hermes_install() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
+      '. "$1/fn.sh"',
+      // Merged, because the warnings that matter here are all on stderr.
+      "step_hermes_install 2>&1",
+    ].join(NL);
+    try {
+      const out = execFileSync(
+        "bash",
+        ["-c", script, "bash", tmp, reachable ? "0" : "1", installOk ? "1" : "0", INSTALL_SH_PATH],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      );
+      return { code: 0, out, installerRan: exists(path.join(tmp, "installer-ran")) };
+    } catch (e: unknown) {
+      const err = e as { status?: number; stdout?: string; stderr?: string };
+      return {
+        code: err.status ?? 1,
+        out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+        installerRan: exists(path.join(tmp, "installer-ran")),
+      };
+    }
+  }
+
+  it("a healthy install is a no-op — nothing touched, nothing fetched", () => {
+    giveShim();
+    giveAgent({ venv: true });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/already installed \(Hermes 9\.9\.9\)/);
+    // Why the reachability precheck sits AFTER the probe: a healthy box makes
+    // no network call at all, on every single update.
+    expect(r.installerRan).toBe(false);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+  });
+
+  it("a shim with no venv is reinstalled — the factory-reset husk case", () => {
+    // What the bench box actually looked like: the shim survived in
+    // ~/.local/bin and ~/.hermes/hermes-agent was a shell with no venv.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(/already installed/);
+    expect(r.installerRan).toBe(true);
+    // Moved aside, not deleted — the old checkout is still recoverable.
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
+    // …and a working agent is in its place.
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\)/);
+  });
+
+  it("a shim with no agent directory reinstalls without inventing a husk", () => {
+    giveShim();
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.installerRan).toBe(true);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+  });
+
+  it("an unreachable installer leaves the existing agent exactly where it is", () => {
+    // The regression this guards: post_update runs this step on every update on
+    // every hermes box, so a probe that comes back empty on a device with no
+    // internet must not be able to destroy a recoverable install.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run({ reachable: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/cannot reach the Hermes installer/);
+    expect(r.installerRan).toBe(false);
+    // Untouched: not moved aside, not deleted, shim still present.
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+    expect(exists(shimPath())).toBe(true);
+  });
+
+  it("a failed install still succeeds as a step, and says where the old agent went", () => {
+    // Non-fatal by design — but it must not go quiet, and the husk it left
+    // behind is the difference between a hand repair and a reflash.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run({ installOk: false });
+
+    // step_post_update's `|| echo` depends on this not being a hard failure,
+    // and the trailing `[ -e ... ]` test must not leak a non-zero status.
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Warning: Hermes still does not run/);
+    expect(r.out).toMatch(/preserved at .*hermes-agent\.broken/);
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
+  });
+
+  it("only ever keeps one husk, so repeated failures cannot fill the disk", () => {
+    giveShim();
+    giveAgent({ venv: false });
+    run({ installOk: false });
+    // Second round: a new husk replaces the first rather than accumulating.
+    giveAgent({ venv: false });
+    fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "second");
+
+    run({ installOk: false });
+
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("second");
+    expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual([
+      "hermes-agent.broken",
+    ]);
   });
 });

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -96,34 +96,40 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     expect(alreadyLine).not.toContain("--version");
   });
 
-  it("moves the stale agent husk aside rather than deleting it", () => {
-    // step_post_update now runs this step on EVERY update on EVERY hermes/dual
-    // box, so the destructive branch is no longer reached only by a device
-    // that is genuinely broken. `rm -rf "$agent_dir"` followed by a network
-    // install that is explicitly non-fatal is a one-way door: one
-    // false-negative probe on a box with no internet and a healthy agent
-    // becomes no agent at all.
-    expect(HERMES_CODE).not.toMatch(/rm -rf "\$agent_dir"\s*$/m);
-    expect(HERMES_CODE).toMatch(/mv "\$agent_dir" "\$agent_dir\.broken"/);
-  });
-
-  it("checks the installer is reachable BEFORE it touches the disk", () => {
-    // Ordering is the whole guarantee: a precheck after the husk is gone
-    // protects nothing.
-    const precheckIdx = HERMES_CODE.indexOf("$installer_url");
-    const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir"');
-    expect(precheckIdx).toBeGreaterThan(-1);
-    expect(mvIdx).toBeGreaterThan(precheckIdx);
-    // …and it must bail out rather than press on.
-    expect(HERMES_CODE).toMatch(/cannot reach the Hermes installer/);
-  });
+  // "moves the husk aside" and "reachability before the husk moves" used to be
+  // asserted here as regexes over the shell text. They are now driven for real
+  // against a fake HOME at the bottom of this file, which is stronger evidence
+  // and does not have to be rewritten every time the branch is reshaped.
 
   it("prechecks and installs from the same URL", () => {
     // A precheck against a host the install does not then use would be worse
-    // than no precheck — it would report reachable and still fail.
-    const urls = HERMES_CODE.match(/https:\/\/[^\s"']+/g) ?? [];
-    expect(urls.length).toBe(1);
-    expect(HERMES_CODE.match(/\$installer_url/g)?.length).toBe(2);
+    // than no precheck — it would report reachable and still fail. Expressed
+    // as: every curl call goes through the one variable, none carries a
+    // literal URL of its own.
+    const curlLines = HERMES_CODE.split(NL).filter((l) => l.includes("curl "));
+    expect(curlLines.length).toBe(2);
+    for (const line of curlLines) {
+      expect(line, `curl must use $installer_url: ${line}`).toContain("$installer_url");
+      expect(line, `curl must not carry its own URL: ${line}`).not.toContain("https://");
+      // …and the URL reaches the install as an ARGUMENT, never spliced into a
+      // `bash -c` string. Harmless while it is a local literal; free to keep
+      // safe if it is ever made configurable.
+      expect(line, `URL must not be interpolated into a shell string: ${line}`).not.toContain(
+        "'$installer_url'",
+      );
+    }
+  });
+
+  it("hands the husk to the clawbox user so a later factory reset can delete it", () => {
+    // Not reachable behaviourally — it needs root and a root-owned file. The
+    // failure it prevents was reproduced on hardware: the husk is a verbatim
+    // `mv` of a tree an older root-run probe wrote __pycache__ into, the reset
+    // route runs as clawbox and does NOT spare a `.broken` name, so the unlink
+    // fails with EACCES, the reset aborts at its failure gate — before the
+    // password/WiFi/hostname reset and the reboot — and returns 500 every time.
+    const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir" "$agent_dir.broken"');
+    expect(mvIdx).toBeGreaterThan(-1);
+    expect(HERMES_CODE.slice(mvIdx)).toMatch(/chown -R "\$CLAWBOX_USER:" "\$agent_dir\.broken"/);
   });
 
   it("verifies the install afterwards instead of assuming it worked", () => {
@@ -157,9 +163,15 @@ describe("step_hermes_install never runs hermes as root", () => {
     // install.sh runs as root (HOME=/root); relying on runuser to reset HOME
     // would point the probe at /root/.hermes.
     const runuserLines = HERMES_CODE.split(NL).filter((l) => l.includes("runuser -u"));
-    expect(runuserLines.length).toBeGreaterThan(0);
+    // Two probes, the reachability precheck, and the installer itself.
+    expect(runuserLines.length).toBe(4);
     for (const line of runuserLines) {
-      if (!line.includes("$shim")) continue;
+      // The upstream installer is the one exception: it is handed to `bash -c`
+      // and resolves the home directory for itself.
+      if (line.includes("bash -c")) continue;
+      // Everything else — the two probes and the reachability precheck — runs
+      // with the same environment, so none of them can quietly read /root's
+      // dotfiles instead of the owner's.
       expect(line, `runuser call must pass HOME: ${line}`).toContain('HOME="$CLAWBOX_HOME"');
     }
   });
@@ -259,10 +271,15 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
   const shimPath = () => path.join(tmp, ".local", "bin", "hermes");
   const exists = (p: string) => fs.existsSync(p);
 
-  /** The shim survives a factory reset — it lives outside ~/.hermes. */
-  function giveShim() {
+  /**
+   * The shim survives a factory reset — it lives outside ~/.hermes.
+   * `answers: false` gives a shim that is present and executable but exits
+   * non-zero, which is what a false-negative probe looks like from here.
+   */
+  function giveShim({ answers = true } = {}) {
     fs.mkdirSync(path.dirname(shimPath()), { recursive: true });
-    fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
+    if (answers) fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
+    else fs.writeFileSync(shimPath(), "#!/bin/sh\nexit 1\n");
     fs.chmodSync(shimPath(), 0o755);
   }
 
@@ -286,8 +303,31 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    * directly observable.
    */
   function run({ reachable = true, installOk = true } = {}) {
+    // The reachability precheck is the `-o /dev/null` call; anything else is
+    // the real installer being fetched to be piped into bash.
+    fs.mkdirSync(path.join(tmp, "bin"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, "bin", "curl"),
+      [
+        "#!/bin/sh",
+        'case " $* " in *" -o /dev/null "*) exit "$PRECHECK_RC" ;; esac',
+        'echo ran >> "$MARKER"',
+        'if [ "$INSTALL_OK" = "1" ]; then',
+        '  mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
+        '  cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
+        '  cp "$FAKE_PY" "$SHIM"',
+        "fi",
+        'echo ":"',
+        "",
+      ].join(NL),
+      { mode: 0o755 },
+    );
     const script = [
-      "set -u",
+      // install.sh's OWN options, not a laxer subset. Under `set -e` a probe
+      // assignment that inherits a non-zero status aborts the whole script, so
+      // a harness running with plain `set -u` certifies paths the shipped
+      // script does not actually have.
+      "set -euo pipefail",
       'CLAWBOX_HOME="$1"',
       'CLAWBOX_USER="$(id -un)"',
       'export MARKER="$1/installer-ran"',
@@ -298,20 +338,12 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       'export INSTALL_OK="$3"',
       "has_hermes_harness() { return 0; }",
       // Run the command as this user instead of switching: `runuser -u X -- cmd`.
-      'runuser() { shift 2; [ "$1" = "--" ] && shift; "$@"; }',
-      "curl() {",
-      //  The reachability precheck is the `-o /dev/null` call; anything else is
-      //  the real installer being piped into bash.
-      '  case " $* " in *" -o /dev/null "*) return "$PRECHECK_RC" ;; esac',
-      '  echo ran >> "$MARKER"',
-      '  if [ "$INSTALL_OK" = "1" ]; then',
-      '    mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
-      '    cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
-      '    cp "$FAKE_PY" "$SHIM"',
-      "  fi",
-      '  echo ":"',
-      "}",
-      "export -f curl",
+      'runuser() { shift 2; if [ "$1" = "--" ]; then shift; fi; "$@"; }',
+      // curl is stubbed as a real executable on PATH, not as a shell function:
+      // the reachability precheck runs it through `env`, which does a PATH
+      // lookup and never sees a function. A function stub therefore let the
+      // precheck reach the real network — the test passed for the wrong reason.
+      'export PATH="$1/bin:$PATH"',
       "sed -n '/^step_hermes_install() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
       '. "$1/fn.sh"',
       // Merged, because the warnings that matter here are all on stderr.
@@ -360,10 +392,30 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(r.code).toBe(0);
     expect(r.out).not.toMatch(/already installed/);
     expect(r.installerRan).toBe(true);
-    // Moved aside, not deleted — the old checkout is still recoverable.
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
-    // …and a working agent is in its place.
+    expect(r.out).toMatch(/Moved the unusable agent to .*hermes-agent\.broken/);
+    // A working agent is in its place…
     expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\)/);
+    // …so the husk has done its job and is gone. It is ~1.9 GB on a
+    // disk-constrained device, and while it exists a factory reset has to be
+    // able to delete it — the reset keeps only the exact name "hermes-agent".
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("a probe that exits non-zero reinstalls instead of killing install.sh", () => {
+    // The false-negative case the whole step is built around, and the one that
+    // errexit turns into a silent death: `installed=$(… | head -1)` inherits
+    // the probe's status, so without `|| installed=""` bash exits right there —
+    // no output, nothing repaired. It takes down `install.sh --step
+    // hermes_install` (the documented repair command) and, in a full install,
+    // every step that follows this one.
+    giveShim({ answers: false });
+    giveAgent({ venv: true });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.installerRan).toBe(true);
     expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\)/);
   });
 
@@ -412,17 +464,21 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
   });
 
-  it("only ever keeps one husk, so repeated failures cannot fill the disk", () => {
+  it("keeps the FIRST husk, so a second failed repair cannot destroy it", () => {
+    // step_post_update runs this on every update, so a persistently broken box
+    // reaches the husk branch again and again. Round 2 must not overwrite the
+    // owner's original checkout with the garbage round 1's failed install left
+    // behind — and one fixed name still bounds the disk cost at a single husk.
     giveShim();
     giveAgent({ venv: false });
     run({ installOk: false });
-    // Second round: a new husk replaces the first rather than accumulating.
+
     giveAgent({ venv: false });
     fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "second");
+    const r = run({ installOk: false });
 
-    run({ installOk: false });
-
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("second");
+    expect(r.out).toMatch(/Keeping the earlier .*hermes-agent\.broken/);
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
     expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual([
       "hermes-agent.broken",
     ]);

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * `step_hermes_install` decides whether a device already has a working Hermes
+ * agent. It used to decide it from the wrong file:
+ *
+ *   if [ -x "$CLAWBOX_HOME/.local/bin/hermes" ]; then
+ *     echo "  Hermes already installed ($(… --version 2>/dev/null | head -1))"
+ *     return 0
+ *
+ * `~/.local/bin/hermes` is a 4-line shim that execs
+ * `~/.hermes/hermes-agent/venv/bin/python`. A factory reset removed ~/.hermes
+ * and left the shim, so the guard matched, the `--version` probe returned
+ * EMPTY into an echo whose value nobody looked at, and the step returned
+ * success without reinstalling. Observed verbatim on the bench box:
+ *
+ *   Hermes already installed ()
+ *
+ * That is what made the brick unrecoverable: a full `install.sh` re-run hit the
+ * same guard and did nothing, so the only remaining repair was a reflash.
+ *
+ * Two further properties are pinned here because both were load-bearing on
+ * hardware:
+ *  - the probe must run as the clawbox user (a root-run `hermes --version`
+ *    writes root-owned __pycache__ into a clawbox-owned tree, and the
+ *    factory-reset route — which runs as clawbox — then aborts on EACCES);
+ *  - the reinstall must clear the stale ~/.hermes/hermes-agent husk first, or
+ *    the upstream installer refuses with "Directory exists but is not a git
+ *    repository" and the box stays broken.
+ */
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const UPDATER_TS = readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8");
+
+const NL = String.fromCharCode(10);
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf(`${NL}}`, start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return INSTALL_SH.slice(start, end);
+}
+
+/**
+ * The comments inside step_hermes_install quote the OLD buggy code verbatim —
+ * that is the point of them — so an assertion run over the raw text would
+ * match the very thing it is meant to forbid. Strip comment lines, and join
+ * shell line-continuations so a statement split across lines is matched as
+ * the single statement it is.
+ */
+function shellCode(fn: string): string {
+  return fn
+    .split(NL)
+    .filter((line) => !line.trim().startsWith("#"))
+    .join(NL)
+    .replace(new RegExp("\\\\" + NL + "\\s*", "g"), " ");
+}
+
+const HERMES_INSTALL = extractShellFunction("step_hermes_install");
+const HERMES_CODE = shellCode(HERMES_INSTALL);
+
+describe("step_hermes_install treats a shim without an agent as NOT installed", () => {
+  it("does not decide from the shim alone", () => {
+    // The exact shape of the defect: a bare `[ -x .local/bin/hermes ]` test
+    // whose success arm returns 0.
+    expect(HERMES_CODE).not.toMatch(
+      /if\s+\[\s+-x\s+"\$CLAWBOX_HOME\/\.local\/bin\/hermes"\s+\]\s*;\s*then/,
+    );
+  });
+
+  it("requires the venv interpreter the shim execs", () => {
+    // The shim's line 4 execs this path; its absence is the whole failure mode.
+    expect(HERMES_CODE).toContain("$CLAWBOX_HOME/.hermes/hermes-agent");
+    expect(HERMES_CODE).toMatch(/venv_python="\$agent_dir\/venv\/bin\/python"/);
+    expect(HERMES_CODE).toMatch(/\[\s+-x\s+"\$venv_python"\s+\]/);
+  });
+
+  it("requires the --version probe to return something", () => {
+    // `-n "$installed"` is the whole point: an EMPTY probe result must fall
+    // through to the reinstall, not print "already installed ()".
+    expect(HERMES_CODE).toMatch(/if\s+\[\s+-n\s+"\$installed"\s+\]/);
+  });
+
+  it("only says 'already installed' when it has a version to show", () => {
+    const alreadyLine = HERMES_CODE.split(NL).find((l) => l.includes("Hermes already installed"));
+    expect(alreadyLine).toBeDefined();
+    // Interpolates the captured variable, never a bare inline command
+    // substitution whose emptiness goes unchecked.
+    expect(alreadyLine).toContain("$installed");
+    expect(alreadyLine).not.toContain("--version");
+  });
+
+  it("clears the stale agent husk before reinstalling", () => {
+    expect(HERMES_CODE).toMatch(/rm -rf "\$agent_dir"/);
+  });
+
+  it("verifies the install afterwards instead of assuming it worked", () => {
+    // The upstream installer is fetched over the network and its failure is
+    // non-fatal, so the step has to check.
+    const afterInstall = HERMES_CODE.slice(HERMES_CODE.indexOf("hermes-agent.nousresearch.com"));
+    expect(afterInstall).toContain("--version");
+    expect(afterInstall).toMatch(/Warning: Hermes still does not run/);
+  });
+});
+
+describe("step_hermes_install never runs hermes as root", () => {
+  it("every hermes invocation goes through runuser as the clawbox user", () => {
+    const invocations = HERMES_CODE.split(NL).filter(
+      (line) => line.includes("--version") && line.includes("$shim"),
+    );
+    expect(invocations.length).toBeGreaterThan(0);
+    for (const line of invocations) {
+      expect(line, `hermes must not be executed as root: ${line}`).toContain(
+        'runuser -u "$CLAWBOX_USER"',
+      );
+    }
+  });
+
+  it("passes HOME explicitly — hermes resolves ~/.hermes from $HOME", () => {
+    // install.sh runs as root (HOME=/root); relying on runuser to reset HOME
+    // would point the probe at /root/.hermes.
+    const runuserLines = HERMES_CODE.split(NL).filter((l) => l.includes("runuser -u"));
+    expect(runuserLines.length).toBeGreaterThan(0);
+    for (const line of runuserLines) {
+      if (!line.includes("$shim")) continue;
+      expect(line, `runuser call must pass HOME: ${line}`).toContain('HOME="$CLAWBOX_HOME"');
+    }
+  });
+});
+
+describe("an in-app update can heal a device a factory reset broke", () => {
+  const POST_UPDATE = shellCode(extractShellFunction("step_post_update"));
+
+  it("post_update reinstalls the Hermes agent", () => {
+    // Without this the ONLY repair path was SSH. The in-app updater runs
+    // post_update and rebuild_reboot; neither reached step_hermes_install, so
+    // clicking UPDATE on a bricked box did nothing for it.
+    expect(POST_UPDATE).toMatch(/^\s*step_hermes_install\b/m);
+  });
+
+  it("post_update re-caches the offline model", () => {
+    expect(POST_UPDATE).toMatch(/^\s*step_llamacpp_model\b/m);
+  });
+
+  it("both are non-fatal, in the surrounding style", () => {
+    for (const step of ["step_hermes_install", "step_llamacpp_model"]) {
+      const line = POST_UPDATE.split(NL).find((l) => l.trim().startsWith(step));
+      expect(line, `${step} must be called in post_update`).toBeDefined();
+      expect(line, `${step} must not be able to fail the update`).toContain("|| echo");
+    }
+  });
+
+  it("repairs the agent BEFORE the updater's hermes_edition step runs", () => {
+    // setup-hermes-edition.sh hard-fails when ~/.local/bin/hermes is not
+    // executable, and UPDATE_STEPS puts hermes_edition immediately after
+    // post_update — so the repair has to be inside post_update, not after it.
+    const postUpdateIdx = UPDATER_TS.indexOf('id: "post_update"');
+    const hermesEditionIdx = UPDATER_TS.indexOf('id: "hermes_edition"');
+    expect(postUpdateIdx).toBeGreaterThan(-1);
+    expect(hermesEditionIdx).toBeGreaterThan(postUpdateIdx);
+  });
+
+  it("post_update's budget covers the repair rather than leaning on the advisory path", () => {
+    // advisoryOnOverrun does not pause the update — it marks the step complete
+    // and moves on to hermes_edition, which would then fail because the agent
+    // is still mid-install. Measured on hardware: ~90s for the agent, plus a
+    // 3.2 GB model download.
+    const start = UPDATER_TS.indexOf('id: "post_update"');
+    const block = UPDATER_TS.slice(start, start + 400);
+    const match = block.match(/timeoutMs:\s*([\d_]+)/);
+    expect(match).not.toBeNull();
+    const budgetMs = Number(match![1].replace(/_/g, ""));
+    expect(budgetMs).toBeGreaterThanOrEqual(900_000);
+  });
+});
+
+describe("llamacpp_model is a cheap, dispatchable step", () => {
+  const LLAMACPP_MODEL = shellCode(extractShellFunction("step_llamacpp_model"));
+
+  it("is dispatchable by the updater", () => {
+    const open = INSTALL_SH.indexOf("DISPATCH_STEPS=(");
+    const dispatch = INSTALL_SH.slice(open, INSTALL_SH.indexOf(")", open));
+    expect(dispatch).toContain("llamacpp_model");
+  });
+
+  it("does not drag in the ~19-minute native llama.cpp build", () => {
+    expect(LLAMACPP_MODEL).not.toContain("cmake");
+    expect(LLAMACPP_MODEL).not.toContain("llama-server");
+    expect(LLAMACPP_MODEL).toContain("ensure_llamacpp_model_cached");
+  });
+
+  it("is not gated on the Hermes harness — every edition loses the model", () => {
+    // The factory-reset route wipes data/ on all editions, so an openclaw box
+    // needs exactly the same repair.
+    expect(LLAMACPP_MODEL).not.toContain("has_hermes_harness");
+  });
+});

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -412,6 +412,31 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
   });
 
+  it("an interrupted earlier repair left a husk — the husk (the original) wins, the partial tree goes", () => {
+    // State after a power cut or unit timeout between the move and the restore:
+    // ~/.hermes/hermes-agent holds whatever the interrupted installer managed
+    // to write (no venv), and ~/.hermes/hermes-agent.broken is the owner's
+    // original, working checkout.
+    giveShim({ answers: false });
+    giveAgent({ venv: false });
+    const husk = `${agentDir()}.broken`;
+    fs.mkdirSync(path.join(husk, "venv", "bin"), { recursive: true });
+    fs.writeFileSync(path.join(husk, "SENTINEL"), "husk-original");
+    fs.copyFileSync(path.join(tmp, "fake-py"), path.join(husk, "venv", "bin", "python"));
+    fs.chmodSync(path.join(husk, "venv", "bin", "python"), 0o755);
+
+    // The reinstall fails too — so the restore must bring back the HUSK, not
+    // the partial tree. (The old code deleted the husk first and restored the
+    // partial tree: the original was gone for good.)
+    const r = run({ installOk: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Kept the earlier husk/);
+    expect(r.out).toMatch(/Restored the previous agent/);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("husk-original");
+    expect(exists(husk)).toBe(false);
+  });
+
   it("a shim with no venv is reinstalled — the factory-reset husk case", () => {
     // What the bench box actually looked like: the shim survived in
     // ~/.local/bin and ~/.hermes/hermes-agent was a shell with no venv.

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -107,7 +107,7 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     // as: every curl call goes through the one variable, none carries a
     // literal URL of its own.
     const curlLines = HERMES_CODE.split(NL).filter((l) => l.includes("curl "));
-    expect(curlLines.length).toBe(2);
+    expect(curlLines.length).toBeGreaterThan(0);
     for (const line of curlLines) {
       expect(line, `curl must use $installer_url: ${line}`).toContain("$installer_url");
       expect(line, `curl must not carry its own URL: ${line}`).not.toContain("https://");
@@ -129,7 +129,20 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     // password/WiFi/hostname reset and the reboot — and returns 500 every time.
     const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir" "$agent_dir.broken"');
     expect(mvIdx).toBeGreaterThan(-1);
-    expect(HERMES_CODE.slice(mvIdx)).toMatch(/chown -R "\$CLAWBOX_USER:" "\$agent_dir\.broken"/);
+    expect(HERMES_CODE.slice(mvIdx)).toMatch(
+      /chown -R "\$CLAWBOX_USER:\$CLAWBOX_USER" "\$agent_dir\.broken"/,
+    );
+    // …and it must not be able to abort the step: errexit is live at this
+    // function's bare call sites, and the agent is moved aside at this exact
+    // moment, so a chown failure would leave the device with nothing.
+    expect(HERMES_CODE.slice(mvIdx)).toMatch(/chown -R[\s\S]{0,120}\|\| echo/);
+  });
+
+  it("never deletes the shim", () => {
+    // Deleting it on the failure path left the operator with no `hermes`
+    // command at all, and moving the husk back by hand did not bring it back.
+    // On the success path the installer rewrites it anyway.
+    expect(HERMES_CODE).not.toMatch(/rm -f "\$shim"/);
   });
 
   it("verifies the install afterwards instead of assuming it worked", () => {
@@ -163,12 +176,11 @@ describe("step_hermes_install never runs hermes as root", () => {
     // install.sh runs as root (HOME=/root); relying on runuser to reset HOME
     // would point the probe at /root/.hermes.
     const runuserLines = HERMES_CODE.split(NL).filter((l) => l.includes("runuser -u"));
-    // Two probes, the reachability precheck, and the installer itself.
-    expect(runuserLines.length).toBe(4);
+    expect(runuserLines.length).toBeGreaterThan(0);
     for (const line of runuserLines) {
-      // The upstream installer is the one exception: it is handed to `bash -c`
-      // and resolves the home directory for itself.
-      if (line.includes("bash -c")) continue;
+      // The upstream installer is the one exception: it is piped into `bash`,
+      // which resolves the home directory for itself.
+      if (line.includes("| bash")) continue;
       // Everything else — the two probes and the reachability precheck — runs
       // with the same environment, so none of them can quietly read /root's
       // dotfiles instead of the owner's.
@@ -261,8 +273,8 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
   beforeEach(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-guard-"));
-    // Stands in for both the venv interpreter and the shim: all either has to
-    // do here is exist, be executable, and answer --version.
+    // Stands in for the venv interpreter: all it has to do here is exist, be
+    // executable, and answer --version.
     fs.writeFileSync(path.join(tmp, "fake-py"), "#!/bin/sh\necho 'Hermes 9.9.9'\n", { mode: 0o755 });
   });
   afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
@@ -278,8 +290,14 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    */
   function giveShim({ answers = true } = {}) {
     fs.mkdirSync(path.dirname(shimPath()), { recursive: true });
-    if (answers) fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
-    else fs.writeFileSync(shimPath(), "#!/bin/sh\nexit 1\n");
+    // The real shim is 4 lines that exec the venv interpreter, so it answers
+    // only while the agent behind it exists — the property the step now
+    // depends on twice, since it no longer deletes the shim before installing.
+    const venvPython = path.join(agentDir(), "venv", "bin", "python");
+    fs.writeFileSync(
+      shimPath(),
+      answers ? `#!/bin/sh${NL}exec "${venvPython}" "$@"${NL}` : `#!/bin/sh${NL}exit 1${NL}`,
+    );
     fs.chmodSync(shimPath(), 0o755);
   }
 
@@ -302,7 +320,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    * records that it ran, so "did the network install happen at all" is
    * directly observable.
    */
-  function run({ reachable = true, installOk = true } = {}) {
+  function run({ reachable = true, installOk = true, fetchOk = true } = {}) {
     // The reachability precheck is the `-o /dev/null` call; anything else is
     // the real installer being fetched to be piped into bash.
     fs.mkdirSync(path.join(tmp, "bin"), { recursive: true });
@@ -312,6 +330,9 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
         "#!/bin/sh",
         'case " $* " in *" -o /dev/null "*) exit "$PRECHECK_RC" ;; esac',
         'echo ran >> "$MARKER"',
+        // A fetch that fails after the precheck said the host was up: the CDN
+        // answering is not the same as the install succeeding.
+        'if [ "$FETCH_OK" = "0" ]; then exit 22; fi',
         'if [ "$INSTALL_OK" = "1" ]; then',
         '  mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
         '  cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
@@ -336,6 +357,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       'export FAKE_PY="$1/fake-py"',
       'export PRECHECK_RC="$2"',
       'export INSTALL_OK="$3"',
+      'export FETCH_OK="$5"',
       "has_hermes_harness() { return 0; }",
       // Run the command as this user instead of switching: `runuser -u X -- cmd`.
       'runuser() { shift 2; if [ "$1" = "--" ]; then shift; fi; "$@"; }',
@@ -352,7 +374,16 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     try {
       const out = execFileSync(
         "bash",
-        ["-c", script, "bash", tmp, reachable ? "0" : "1", installOk ? "1" : "0", INSTALL_SH_PATH],
+        [
+          "-c",
+          script,
+          "bash",
+          tmp,
+          reachable ? "0" : "1",
+          installOk ? "1" : "0",
+          INSTALL_SH_PATH,
+          fetchOk ? "1" : "0",
+        ],
         { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
       );
       return { code: 0, out, installerRan: exists(path.join(tmp, "installer-ran")) };
@@ -448,39 +479,91 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(exists(shimPath())).toBe(true);
   });
 
-  it("a failed install still succeeds as a step, and says where the old agent went", () => {
-    // Non-fatal by design — but it must not go quiet, and the husk it left
-    // behind is the difference between a hand repair and a reflash.
+  it("a failed install puts the previous agent back", () => {
+    // Non-fatal by design — but it must not be one-way. The husk is insurance
+    // against a WRONG diagnosis, so the step has to be able to undo itself.
     giveShim();
     giveAgent({ venv: false });
 
     const r = run({ installOk: false });
 
-    // step_post_update's `|| echo` depends on this not being a hard failure,
-    // and the trailing `[ -e ... ]` test must not leak a non-zero status.
+    // step_post_update's `|| echo` depends on this not being a hard failure.
     expect(r.code).toBe(0);
     expect(r.out).toMatch(/Warning: Hermes still does not run/);
-    expect(r.out).toMatch(/preserved at .*hermes-agent\.broken/);
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
+    expect(r.out).toMatch(/Restored the previous agent/);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    // Nothing parked under another name for an operator to find and move back.
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
   });
 
-  it("keeps the FIRST husk, so a second failed repair cannot destroy it", () => {
-    // step_post_update runs this on every update, so a persistently broken box
-    // reaches the husk branch again and again. Round 2 must not overwrite the
-    // owner's original checkout with the garbage round 1's failed install left
-    // behind — and one fixed name still bounds the disk cost at a single husk.
-    giveShim();
-    giveAgent({ venv: false });
-    run({ installOk: false });
+  it("a healthy agent survives a lying probe plus a failed install", () => {
+    // The worst realistic case, and the reason the restore exists: a box whose
+    // agent works, a probe that comes back non-zero anyway (a fork failure on
+    // an 8 GB device mid-update), a reachable CDN, and an upstream install that
+    // then fails — clone or venv build, neither of which the precheck sees.
+    // step_post_update drives this on EVERY update on EVERY hermes/dual box,
+    // so this path has to leave the device exactly as it found it.
+    giveShim({ answers: false });
+    giveAgent({ venv: true });
 
-    giveAgent({ venv: false });
-    fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "second");
     const r = run({ installOk: false });
 
-    expect(r.out).toMatch(/Keeping the earlier .*hermes-agent\.broken/);
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
-    expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual([
-      "hermes-agent.broken",
-    ]);
+    expect(r.code).toBe(0);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    // The shim has to survive too: without it there is no `hermes` command,
+    // and the next run would find no shim, skip the probe and move the healthy
+    // agent aside all over again.
+    expect(exists(shimPath())).toBe(true);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("repeated failed repairs neither accumulate husks nor lose the original", () => {
+    // step_post_update runs this on every update, so a persistently broken box
+    // reaches this branch again and again. Round 2 must still find the owner's
+    // original checkout, not round 1's leftovers.
+    giveShim();
+    giveAgent({ venv: false });
+
+    run({ installOk: false });
+    const r = run({ installOk: false });
+
+    expect(r.code).toBe(0);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual(
+      [],
+    );
+  });
+
+  it("a fetch failure is reported, not swallowed by the pipe", () => {
+    // `curl … | bash` exits 0 when curl fails — bash just reads empty stdin —
+    // so without `-o pipefail` this warning could never fire and a download
+    // failure looked identical to a successful install.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run({ fetchOk: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Hermes install failed \(non-fatal\)/);
+    // …and the box is still whole.
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+  });
+});
+
+describe("setup-hermes-edition.sh does not repeat the shim-only check", () => {
+  const SETUP_HERMES = readFileSync(path.join(REPO, "scripts/setup-hermes-edition.sh"), "utf-8");
+
+  it("requires the venv interpreter, not just the shim", () => {
+    // This script hard-fails when Hermes is missing — but it tested exactly
+    // the file install.sh's old guard tested. On a factory-reset box the shim
+    // was present and executable, so this check passed and the edition setup
+    // continued on a device with no agent behind it.
+    expect(SETUP_HERMES).toContain(
+      'HERMES_VENV_PYTHON="$CLAWBOX_HOME/.hermes/hermes-agent/venv/bin/python"',
+    );
+    const guard = SETUP_HERMES.split(NL).find((l) => l.includes('[ ! -x "$HERMES_BIN" ]'));
+    expect(guard).toBeDefined();
+    expect(guard).toContain('[ ! -x "$HERMES_VENV_PYTHON" ]');
   });
 });


### PR DESCRIPTION
## A factory reset bricks a Hermes-edition box, and no update could heal it

Reproduced end-to-end on a Hermes bench device, repaired, fixed, and re-proven
through the real in-app update path.

### What the owner sees

```
/home/clawbox/.local/bin/hermes: line 4:
/home/clawbox/.hermes/hermes-agent/venv/bin/python: No such file or directory
```

`clawbox-hermes-dashboard.service` (`Restart=always`) then crash-loops on exit
127 — **11 restarts in 60 s, measured** — the Hermes dashboard is unreachable,
and the on-device Gemma model is gone. Until this PR the only repair was SSH,
and on a device with the old `install.sh` guard even a full `install.sh` re-run
did nothing (see defect 3), which made it a reflash.

---

## The three defects

### 1. `~/.hermes` was wiped whole — including the agent install

`src/app/setup-api/setup/reset/route.ts` listed `.hermes` in
`HOME_REMOVE_PATHS`. The intent (resale security) was right: `config.yaml`
carries the billing token, the dashboard session **signing secret** and the
scrypt `password_hash`; `config.yaml.bak-*` duplicates all of it; `.env` is
~24 KB of provider keys; plus `auth.json`, `memories/`, `logs/`, `cron/`,
`pairing/`. All of that must go.

What the author did not know is that `~/.hermes/hermes-agent/` in the same
directory is **not owner state at all** — it is the *agent install*: the
upstream checkout plus the Python venv. `~/.local/bin/hermes` is a 4-line shim
that execs `…/hermes-agent/venv/bin/python`, and the shim lives outside the
wipe, so it survives and points at nothing.

**Fix:** `.hermes` moves from a whole-directory `rm` to an entry-by-entry wipe
with **one named exception**, `hermes-agent`. Every secret-bearing sibling still
goes, and anything new that appears in the directory tomorrow is removed by
default — it is a wipe with an exception, not a keep-list. `hermes-agent`
carries nothing to leak: upstream source and a venv, byte-identical on every box
of this SKU (verified by listing it on hardware after a clean install).

### 2. The `data/` wipe took the 3.2 GB offline model

`PRESERVE_FILES` was `{network.env}`, so `data/llamacpp/` — the Gemma GGUF —
went with everything else. The same file already preserves the
`~/.cache/huggingface` voice models, with the reasoning written out: *a reset
device reboots into AP mode with no internet, so anything deleted that cannot be
re-downloaded means a reflash.* The llama.cpp model is exactly that category.

**Fix:** the `data/` wipe now keeps `llamacpp/models/` — and only that. The
weights are pure cache (no tokens, no chats, no prompts), so keeping them hands
the next owner nothing. The rest of `llamacpp/` is llama-server runtime scratch
and still goes; see "Review hardening" below.

### 3. `step_hermes_install` refused to reinstall, and this is what made it unrecoverable

```sh
if [ -x "$CLAWBOX_HOME/.local/bin/hermes" ]; then
  echo "  Hermes already installed ($("…/hermes" --version 2>/dev/null | head -1))"
  return 0
fi
```

The shim survives the wipe, so the guard matched. The `--version` probe returned
**empty**, and its value was echoed into a string nobody checked. Verbatim from
the bench box, on a device with no agent at all:

```
  Hermes already installed ()
```

**Fix:** require the venv interpreter to exist *and* the agent to actually answer
`--version` before declaring it installed; anything less is reinstalled. The
step also now moves the stale `hermes-agent` husk aside first (see "what the
documented repair got wrong" below), prechecks that the installer host is
actually reachable before touching anything, and verifies the result instead of
assuming the network install worked.

### …and the root-owned `__pycache__` that made the reset abort halfway

The guard above executed `hermes` **as root** — `install.sh` runs as root, and
that line was the only place in the file that ever executed the agent. `hermes`
is a Python entry point, and CPython writes `__pycache__/*.pyc` next to the
sources it imports. So a root-run probe leaves root-owned files inside a
clawbox-owned tree.

Proven directly, from a clean state:

| | root-owned files under `~/.hermes` |
|---|---|
| before | `0` |
| after **one** `sudo install.sh --step hermes_install` | `13` |
| after the same run once the agent had been updated | **`137`** |

The reset route runs as the `clawbox` user, so `rm -rf ~/.hermes` hits `EACCES`
on those files. The whole subtree fails as one call — **with the agent already
half deleted** — and the reset aborts:

```json
{"error":"Factory reset incomplete: 1 file deletion(s) failed",
 "failures":[".hermes: Error: EACCES: permission denied, unlink
 '/home/clawbox/.hermes/hermes-agent/__pycache__/hermes_bootstrap.cpython-311.pyc'"]}
```

**Fix (the writer):** the probe now runs under `runuser` as the clawbox user,
with `HOME` passed explicitly. **Fix (the wipe):** entry-by-entry removal means
one undeletable entry is collected and reported while the rest still go —
and because `hermes-agent` is now preserved, the reset no longer touches those
files at all.

**On the password:** the reported ordering bug is already fixed on `beta` — the
failure gate sits *before* `resetSystemPasswordToDefault()` and before the WiFi
deletion, so an aborted reset leaves the owner able to log back in. Verified on
hardware (SSH kept working with the owner's password through two aborted resets)
and now pinned by a test, so it cannot regress.

---

## Making UPDATE the repair path

Before this PR the in-app updater ran `post_update` (edition_lock, set_hostname,
nm_dispatcher, sysctl_linkdown, vnc_refresh, systemd_services, clawkeep,
gateway_setup) and `rebuild_reboot`. **Neither reached `step_hermes_install`,
and nothing re-cached the model** — so clicking UPDATE on a bricked box did
nothing for it even with the guard fixed.

- `step_post_update` now ends with `step_hermes_install` and a new
  `step_llamacpp_model`, both `|| echo "Warning: … (non-fatal)"` in the
  surrounding style. Both are sub-second no-ops on a healthy box.
- `step_llamacpp_model` is new and dispatchable: it calls
  `ensure_llamacpp_model_cached` and nothing else, so it skips the ~19-minute
  native llama.cpp build that `step_llamacpp_install` would drag in.
- **Ordering is load-bearing.** The repair sits *inside* `post_update`, because
  the updater's next step is `hermes_edition`, and `setup-hermes-edition.sh`
  hard-fails when `~/.local/bin/hermes` is not runnable.
- **`post_update`'s budget: 5 min → 15 min.** Not cosmetic: `advisoryOnOverrun`
  does **not** pause the update — it marks the step completed and moves straight
  on to `hermes_edition`, which would then fail while the agent was still
  installing. Measured: ~90 s for the agent install, plus the model download.
  Still far inside the unit's own `TimeoutStartSec=7200`, and
  `advisoryOnOverrun` stays as the backstop.

### One deliberate deviation

`step_llamacpp_model` is **not** gated on `has_hermes_harness`, unlike
`step_hermes_install`. The `data/` wipe removes `data/llamacpp` on *every*
edition, so an openclaw box loses the same 3.2 GB model and needs the same
repair; gating it would leave those boxes unhealable. Pinned by a test.

---

## Review hardening

Four things the first round got wrong or left unstated. All four are covered by
tests that fail without them.

### The preserved model cache is narrowed to the weights

The first version kept `data/llamacpp/` whole. That directory is also
llama-server's working directory: `server.pid` and `server.log` live beside the
GGUF. A log of what the previous owner asked the **local** model is
owner-adjacent by nature, and a resold box should not carry it.

The keep is now `data/llamacpp/models/` and nothing else; `llamacpp/` itself
survives the top-level pass only as a container and is then wiped entry-by-entry
down to `models/`. At the shipped llama-server config that log holds no prompt
text — this narrowing is what keeps that true **by construction** instead of
something to re-verify on every llama.cpp upgrade. Same property as the
`~/.hermes` exception: a named allow-list of one, so anything llama.cpp starts
writing tomorrow is removed by default rather than inherited.

### The reinstall no longer destroys before it verifies

The first version did `rm -rf "$agent_dir"` on a failed probe and then leaned on
a `curl | bash` that is explicitly non-fatal. That was tolerable while the step
only ran on a box someone had already diagnosed as broken. It is **not**
tolerable now that `step_post_update` runs it on every update on every
hermes/dual box: one false-negative probe — a busy venv, a transient fork
failure, anything that makes `--version` come back empty — on a device with no
internet would turn a healthy agent into no agent at all. That is the exact
outcome this PR exists to prevent, re-introduced through the repair path.

Two changes, both minimal:

- **Reachability precheck.** Nothing touches the disk until a
  `curl -fsS --max-time 30 -o /dev/null` against the installer URL succeeds. If
  it cannot be reached the step warns and returns, leaving whatever is on disk
  exactly where it is. Precheck and install share one `installer_url` variable,
  so they cannot drift onto different hosts.
- **The husk is moved aside, not deleted.** `hermes-agent` ->
  `hermes-agent.broken`, which is all the upstream installer needs to stop
  refusing with *"Directory exists but is not a git repository"*, and is
  recoverable when the diagnosis was wrong. A **fixed** name rather than a
  timestamp, so it cannot accumulate a checkout plus a venv on every failed
  update. Its full lifecycle - who owns it, and when it goes - is in the round-2
  and round-3 sections below: as of round 3 it is deleted on success and **moved
  back** on failure, so it never outlives the repair that created it.

A healthy box still makes **no network call at all**: the reachability check
sits after the `--version` probe, so the common path is unchanged.

### `step_llamacpp_model` runs on every update, on every edition — and can pull 3.2 GB

Stated plainly, because it is a real cost that is being accepted rather than
avoided. Precisely, in three cases:

- **The model is already there** (every healthy box): a single `[ -f ]` test,
  back in milliseconds. This is the overwhelmingly common path.
- **The box never provisioned llama.cpp at all**: a **no-op**, not a download.
  The step needs the Hugging Face CLI, which only `step_llamacpp_install` puts
  on the clawbox login PATH, so it returns early with *"Hugging Face CLI not
  installed — skipping Gemma model re-cache"*. `CLAWBOX_TEST_MODE=1`
  short-circuits it too.
- **The box had the model and lost it** — bricked by a pre-fix reset, or the
  file removed by hand: it begins a **~3.2 GB download as part of an ordinary
  update**, without the owner having asked for a model download specifically. On
  a slow or metered link that is a surprise, and it is the case being accepted.

It is deliberate: re-caching the model is the entire repair for defect 2, and a
reset box cannot do it later on its own. It is not gated on edition, for the
reason in the deliberate deviation above.

**The related timing risk, stated with it.** 3.2 GB inside the new 900 s budget
needs ~28 Mbit/s sustained, so on a slow link an **overrun is likely — on exactly
the population this PR rescues**. What an overrun does: `advisoryOnOverrun` only
abandons the *wait* (`src/lib/updater.ts`), it does not stop anything. The root
unit keeps running to its own `TimeoutStartSec=7200`, while the updater marks the
step complete and starts `hermes_edition` — so `hf download` continues as root
alongside the next step. In practice that is harmless, and the reasons are worth
stating rather than assuming: the Hermes repair runs **before** the model
re-cache inside `post_update`, so `hermes_edition` finds a runnable agent either
way; `hf` downloads resume where they left off if interrupted; and no step in
`UPDATE_STEPS` after this point reboots the device. Removing the overlap means
making `advisoryOnOverrun` wait, which changes the updater's contract for every
step — out of scope here.

**And the exposure it widens, named:** `step_post_update` now reaches an unpinned
`curl … | bash` from the upstream installer host on every update on every
hermes/dual box whenever the probe comes back empty — previously only at install
time or on an explicit dispatch. There is no checksum or signature pinning, which
is consistent with every other third-party installer in `install.sh` (bun,
Hugging Face, and the rest), but the *frequency* is new. The reachability
precheck and the `-o pipefail` install pipeline are about failure modes, not
about trusting that host any less.

### Why the preserved `hermes-agent/` has no integrity guard

A previous owner with a shell could plant a file inside the one directory this
reset spares, and it would survive. The obvious guard — assert
`git status --porcelain` is empty and wipe the checkout when it is not — was
implemented, tested against a real box (a healthy checkout does report exactly
zero lines, because upstream's `.gitignore` already covers `/venv/`,
`__pycache__/` and `*.pyc*`), and then **removed**. Both of its outcomes are
worse than the hole:

- **Wiping a "dirty" checkout recreates this very brick.** A reset device reboots
  into AP mode with no internet, nothing at boot reinstalls the agent, and every
  reinstall path needs the network. A false positive leaves the same
  crash-looping dashboard — on every box of the SKU at once, the day upstream
  starts writing into its own checkout. Whether it stays pristine is
  NousResearch's call, not ours.
- **Reporting it as a failure is no better.** A non-empty failure list aborts the
  reset (HTTP 500, no reboot), so the box could not be factory reset at all
  until someone SSHed in.

And it would not stop the attacker it is aimed at: the same shell can add the
payload to `.git/info/exclude`, or drop it in `venv/` — gitignored upstream, home
to the interpreter, and invisible to `--porcelain` either way. A guard a
competent adversary steps over while a routine upstream commit bricks the fleet
is a bad trade. Re-provisioning the agent from upstream after a reset is the real
fix and it needs network the device does not have at reset time. The reasoning
is recorded in the code next to the exception so it is not silently re-litigated.

**The residual is real, and was demonstrated.** A file planted inside
`hermes-agent/` before a factory reset survives it, while every other canary is
destroyed. Two measurements that bound the trade: on this bench device
`git status --porcelain` inside the agent checkout returns **0 lines** (pristine
at the shipped upstream commit), so the rejected guard *would* have caught the
planted file cleanly today — the rejection rests on the forward-looking risk of
false positives bricking the SKU, not on observed dirtiness. It is a judgement
call, and it is recorded as one.

### Behavioural tests for the shell

The guard tests were entirely regex-over-shell-text, which pins the shape of the
code but not where its branches actually go — and the branch **ordering** (probe
→ reachability → move aside → install) is the whole guarantee. The step is now
also driven for real, with a fake `HOME` and stubbed `runuser`/`curl`, following
the existing `install-llamacpp-prebuilt.test.ts` pattern of lifting one function
out with `sed`. Nine cases: healthy no-op (nothing touched, nothing fetched),
shim-without-venv (the factory-reset husk case), a probe that exits non-zero,
shim with no agent directory, unreachable installer, a failed install (agent
restored), a healthy agent behind a lying probe plus a failed install, repeated
failed repairs, and a fetch failure that must not be swallowed by the pipe.

The harness runs the lifted function under **install.sh's own
`set -euo pipefail`**, not a laxer subset — see round 2 below for why that
distinction turned out to matter more than anything else in this file. Two regex
cases that the behavioural ones fully supersede were deleted rather than kept in
parallel.

---

## Round 2: the repair step could not survive its own `set -e`

An adversarial pass over the round-1 code found two defects that cancelled much
of it. Both are fixed here, both reproduced on hardware before and after.

### The probes killed `install.sh` outright

`install.sh` runs under `set -euo pipefail` (line 12). Both `--version` probes
assigned a pipeline straight to a variable:

```sh
installed=$(runuser … "$shim" --version 2>/dev/null | head -1)
```

A plain assignment takes the exit status of its command substitution, so under
errexit a probe that exits non-zero **kills the script at that line** — before
the reachability check, before any repair, before the `|| echo "… (non-fatal)"`
two lines further down that was supposed to make this step harmless. And that is
precisely the false-negative case the round-1 work existed to survive.

**Attribution, corrected in round 3.** Released `main` is **not** affected by
this. There the probe sits inside an `echo` *argument* —
`echo "  Hermes already installed ($(… --version …))"` — and a failing command
substitution in argument position does not trip errexit: on a fully bricked box
the released code prints `Hermes already installed ()` and returns 0 (checked on
hardware). The errexit kill was introduced by **this branch's own commit
`2453830`** and fixed by `1353d7a` before merge, so no device outside the bench
ever ran it. The measurement below was taken against **that previous commit on
this branch**, not against released code.

With a shim that is present and executable but exits 1:

```
$ sudo install.sh --step hermes_install
$ echo $?
1
```

Zero bytes of output. The command `scripts/setup-hermes-edition.sh` tells the
operator to run repaired nothing and said nothing. In full-install mode the same
abort skips every step after it — `clawkeep_install`, `setup_config`,
`edition_lock`, `system_config`, `jtop`, `ollama`, `llamacpp`, `chromium`,
`cloudflared`, `ai_tools`, `vnc`, `desktop_theme`.

**Fix:** `|| installed=""` on both assignments. Nothing else changes. Same box,
same broken shim, this branch:

```
  Hermes is present but not runnable — reinstalling the agent
  Moved the unusable agent to /home/clawbox/.hermes/hermes-agent.broken
  Installing Hermes agent (NousResearch)...
  Hermes installed (Hermes Agent v0.20.4 · upstream fb27614a)
  rc=0
```

The second probe had the same defect for the same reason: after a failed install
the shim is gone, so it exits 127 and the step died before printing either
*"Hermes still does not run"* or the line that names where the old agent went —
the two messages that make a hand repair possible instead of a reflash.

**Why the tests had not caught it:** the behavioural harness ran the lifted
function under `set -u`. Side by side on the same fixture: `set -u` → full repair
output, rc 0; `set -euo pipefail` → no output, exit 1. The harness now uses
install.sh's own options, which is what makes those cases evidence about the
shipped script. It also exposed a second harness bug — the `curl` stub was a
shell function, but the reachability precheck reaches curl through `env`, which
does a PATH lookup and never sees a function, so the "unreachable installer" case
was quietly calling the real network. The stub is now a real executable on PATH.

### The husk itself became the next brick

Moving the broken agent aside instead of deleting it is right, but
`hermes-agent.broken` is not an exact match for `hermes-agent`, so the factory
reset does not spare it — it tries to **delete** it, as the `clawbox` user. The
husk is a verbatim `mv` of a tree an older root-run probe wrote `__pycache__`
into. Result, reproduced on hardware at the round-1 head: `EACCES`, a non-empty
failure list, **HTTP 500 on every retry, forever**.

That is worse than a plain error. The failure gate sits *before*
`deleteWifiConnections()`, `resetSystemPasswordToDefault()`, the hostname reset
and the reboot — so the box is left **half-reset**: `~/.ssh`, `~/.clawkeep` and
`data/config.json` already destroyed (the wizard therefore reports
`setup_complete:false` and *looks* factory-fresh), while the previous owner's
login password and saved WiFi profiles are still live. And it landed on exactly
the population this PR rescues, because a successful update-heal always left a
husk behind.

Three small changes give the husk a complete lifecycle:

- **Chowned to the clawbox user immediately after the `mv`.** `install.sh` is
  root here and the reset is not. Demonstrated on the box: a root-owned file
  inside a directory makes the clawbox-run `rm -rf` fail with *permission
  denied* and the directory survives; after `chown -R clawbox:` the identical
  `rm -rf` removes it.
- **Deleted once the post-install probe verifies the new agent.** The husk is
  insurance against a wrong diagnosis; when the replacement answers `--version`
  the insurance is over. This reclaims ~1.9 GB (measured) on a disk-constrained
  device and means the common heal path leaves **nothing** for a later reset to
  trip over. Verified on hardware: after the repair run above,
  `ls ~/.hermes/hermes-agent*` shows only `hermes-agent`.
- **The first husk wins.** *(Superseded in round 3 — this branch of the code no
  longer exists.)* A persistently broken box reaches this branch on every update,
  and round 1 let update #2 overwrite the owner's original checkout with the
  garbage update #1 left behind. Round 3 makes the husk **always transient** (a
  failed install moves the original back), so there is never a second husk to
  arbitrate between.

Note this also re-establishes the reasoning for **not** adding an integrity guard
to the preserved `hermes-agent/` (below). That rejection rests on "a failure list
aborts the reset entirely" being an unacceptable outcome — which the husk was
quietly causing through a different door until now.

### Three smaller items in the same function

- The reachability precheck was the only one of the `runuser` calls that did not
  pass `env HOME="$CLAWBOX_HOME"`, so curl ran as clawbox with `HOME=/root` and
  would read root's `.curlrc`. Harmless at the current flags; all the calls that
  are not `bash -c` now look identical.
- The installer URL reaches `bash -c` as a positional argument instead of being
  spliced into the command string. Safe today because it is a local literal;
  this keeps it safe if the constant is ever made configurable.
- One level of `if` nesting removed around `rm -f "$shim"`. *(Round 3 deletes
  that line outright — see below; deleting the shim on the failure path was the
  other half of the one-way repair.)*

### Docs

`docs-site/technical/filesystem.mdx`'s "what survives what" table is a statement
about what a resold box retains, and it was wrong after this PR. It now says
`data/` is wiped *except `network.env` and `llamacpp/models`*, and has a row for
`~/.hermes` — wiped except `hermes-agent`.

---

## Can a field-bricked box heal itself? — **(b), and here is the boundary**

The honest answer, established on hardware:

> **Update heals it fully — from the wizard, at the Update step (step 2), or
> from Settings once setup is complete. It does NOT heal a box parked at the
> wizard's AI-provider step, because the wizard cannot navigate backwards.**

Why:

- The wizard is **WiFi(1) → Update(2) → Credentials(3) → AI models(4) →
  Telegram(5)**. `goToStep` is only ever called from an `onNext` handler, and
  `ProgressBar` has no click handler at all — there is **no back navigation**.
- A reset clears `data/config.json`, so `update_completed` is false and the
  wizard resumes at step 1. The owner reaches the Update step **before** the AI
  step, and the repair lands there. This is the common path, and it works.
- If the owner is already **past** step 2 — sitting at the AI-provider step,
  which is where a bricked Hermes box strands them because the harness the step
  talks to is dead — the wizard cannot go back, and Settings' update button is
  on the desktop, which requires `setup_complete`. **That state needs SSH**, or
  a page reload after clearing `update_completed`.
- Auth is not the obstacle. While `setup_complete` is false the middleware lets
  the wizard reach `/setup-api/*` without a session, and `/setup-api/update/*`
  is not on the sensitive list. Confirmed on the device:
  `update/status` → `200` and `update/versions` → `200` with **no cookie**,
  while `/setup-api/gateway` → `401`.

Making step 2 reachable from later steps is a UI change and is deliberately out
of scope for this fix; it is the obvious follow-up.

---

## What the documented repair procedure got wrong

The repair recipe carried over from the first incident **does not work as
written**. Both failures were reproduced:

1. `sudo bash install.sh --step hermes_install` → `Hermes already installed ()`,
   no reinstall (defect 3).
2. After moving the shim aside, the upstream installer refuses outright:
   ```
   ✗ Directory exists but is not a git repository: /home/clawbox/.hermes/hermes-agent
   ```
   because the aborted wipe leaves the husk behind — and the husk cannot be
   removed by the `clawbox` user, since the root-owned `__pycache__` is inside
   it. `sudo rm -rf ~/.hermes/hermes-agent` is a **required** step that the
   recipe never had.

The corrected procedure is in the PR discussion. `step_hermes_install` now does
both of those things itself, so the SSH path collapses to a single command.

---

## Evidence

**Reproduced** (released code, Hermes bench box): shim present (161 B), venv
python gone, `hermes --version` → the verbatim error, `data/llamacpp/models`
gone, `data/config.json` gone, dashboard `NRestarts` 0 → 11 in 60 s, `:9119`
dead, reset returned HTTP 500 with the `EACCES` failure and correctly did not
reboot.

**Repaired** (timed, for the support runbook): agent reinstall 86 s, full
`install.sh` 228 s including a 3.2 GB model re-download. End state:
`hermes --version` OK, dashboard `active` / `NRestarts=0`, `:9119` → 302,
`:8090` → 302, model 3.2 G, `provision-status STATUS=ok`, **0 failed units**.

**Tests.** `src/tests/routes/setup/reset.test.ts` plus a new
`src/tests/unit/install-hermes-install-guard.test.ts` — **60/60 green** across
the two files, run on the device.

Verified red at every step. Against `origin/beta`: all six original reset cases
fail and the install-guard file does not even load
(`step_llamacpp_model not found in install.sh`). Against this branch's own
previous heads: 9 failures for the review-hardening round, and for round 2
**exactly 7 failures, one per change** — the two errexit probes, the husk chown,
the husk deletion on success, first-husk-wins, `HOME` on the precheck, and the
URL passed as an argument. Nothing in this round is unproven by a test that goes
red without it.

**Hardware, round 2** (same bench box, Hermes edition): the released repair
command reproduced as `rc=1` with **0 bytes of output** against a non-zero probe;
the same fixture on this branch repaired the agent and exited 0. Both husk
branches driven for real — *"Moved the unusable agent to …"* on a first failure,
*"Keeping the earlier …"* when one was already there — each followed by a
verified `hermes --version` and **no husk left on disk**. The chown remedy shown
directly: a root-owned file makes the clawbox-run `rm -rf` fail with permission
denied, and succeed after `chown -R clawbox:`. Box restored afterwards: clean
checkout, `hermes_edition` step green, all units active.

`eslint` clean, `tsc` clean on the changed files (13 pre-existing errors
elsewhere in the repo, untouched), `bash -n install.sh` clean, `bun run build`
green — all run on the device.

### Field-heal path, proven end to end on hardware

The device was put back on released code, walked through the wizard, and
re-broken through the **real Settings factory reset** — 137 root-owned
`__pycache__` files, HTTP 500 abort, agent gone, model gone, dashboard
crash-looping. Then `.update-branch` was pointed at this branch and UPDATE was
triggered through the real route **with no session cookie** — the wizard's own
call — and left alone.

From the `post_update` journal, unedited:

```
[hermes edition] skipping gateway recovery
Hermes is present but not runnable — reinstalling the agent
Installing Hermes agent (NousResearch)...
…
Hermes installed (Hermes Agent v0.20.4 (2026.8.18) · upstream fc9cbc87)
Downloading Gemma 4 GGUF for offline use...
Gemma 4 model cached for offline startup
```

Agent reinstall **61 s**, model re-download **38 s** — ~99 s of repair inside
`post_update`. Every updater step finished green, **including `hermes_edition`**,
which is the step that would have hard-failed on a device with no runnable
agent.

### Then: a factory reset on the fixed code

Owner canaries were planted in `~/.hermes/.env`, `auth.json`,
`memories/canary.md`, `config.yaml.bak-canary` and `~/.ssh/authorized_keys`,
plus one marker file *inside* `hermes-agent/` to prove the exception is scoped.
Factory reset run from the Settings UI path.

The reset returned **`{"success":true}` / HTTP 200** — it completed instead of
aborting, and rebooted. After the reboot, logging in with the **factory
password** (`clawbox`):

| | |
|---|---|
| `hermes --version` | **works** — v0.20.4, venv python intact |
| marker inside `hermes-agent/` | **survived** — the exception is scoped exactly |
| offline model | **3.2 G present** |
| dashboard | `active`, **`NRestarts=0`**, `:9119` → 302 (after its ~60 s web-dist build), proxy `:8090` → 302 |
| failed units | **0** |
| wizard | **fresh** — no `data/config.json`, `setup_complete:false` |
| login password | **back to factory** |
| `data/` | only `network.env` + the preserved `llamacpp/` + freshly minted runtime secrets |
| owner canaries anywhere | **0** |
| `~/.ssh` | gone |
| `config.yaml.bak-*`, `auth.json`, `.env`, `projects.db` | gone |
| `config.yaml`, `memories/`, `cron/`, `pairing/`, `sessions/`, `state.db` | re-created *after* the reset (mtimes 09:53:16+, reset ran 09:53:13) |
| root-owned files under `~/.hermes` | **0** — the writer is gone |


---

## Round 3: the repair had to be able to undo itself

A second adversarial pass found the round-2 husk work was still **one-way** on
the failure path, and that the recovery message it printed did not work. The
case the suite did not cover: a **healthy** agent, a probe that exits non-zero
anyway, a reachable installer host, and an upstream install that then fails. The
old code left `$agent_dir` gone, the working venv parked in
`hermes-agent.broken`, and `~/.local/bin/hermes` **deleted** — so an operator who
followed the printed advice and moved the husk back still had no `hermes`
command, and re-running the step just moved it aside again (no shim → no probe →
straight back to the husk branch). Both halves of that scenario are plausible on
this fleet: the precheck only proves the CDN answers, while the upstream
installer additionally clones GitHub and builds a venv; and a false-negative
probe on an 8 GB Jetson mid-update is the same fork/OOM class this PR argues for
elsewhere. `step_post_update` drives it on every update on every hermes/dual box.

The fix removes more code than it adds:

- **The shim is never deleted.** The installer rewrites it on success, and on
  failure deleting it changed nothing that mattered — `setup-hermes-edition.sh`
  gates on the same file either way — while costing the owner the one command
  they had.
- **A failed install moves the original back.** `rm -rf "$agent_dir"; mv
  "$agent_dir.broken" "$agent_dir"`, and it says so. The husk is therefore
  **always transient**: deleted on success, restored on failure, never parked.
  That deletes the first-husk-wins branch, all husk disk growth, and the
  "preserved at …" message that was advice nobody could act on.
- **The install pipeline fails loudly.** `bash -c 'curl … | bash'` exits 0 when
  `curl` fails — bash simply reads empty stdin — so the `|| echo "… (non-fatal)"`
  warning could never fire for a fetch failure. Now `bash -o pipefail -c`, the
  file's own idiom elsewhere, plus `--connect-timeout 15 --max-time 900` so a
  hung fetch cannot ride the unit's `TimeoutStartSec=7200`.
- **The husk `chown` can no longer abort the step.** It sat in the one window the
  function's own invariant says must not abort (agent moved aside, nothing
  reinstalled) while errexit is live at the two bare call sites. Now
  `|| echo "  Warning: …" >&2`, and it uses the file's `user:group` idiom.
- **The sibling script stops repeating the original defect.**
  `scripts/setup-hermes-edition.sh` hard-failed on `[ -x "$HERMES_BIN" ]` — the
  exact shim-only test this PR proves wrong — so on a reset box it passed and
  carried on provisioning a Hermes edition with no Hermes behind it. It now also
  requires `~/.hermes/hermes-agent/venv/bin/python`.

Two tidy-ups in the same pass:

- The `data/` wipe keeps **one list with one meaning**. `PRESERVE_FILES`
  conflated "keep this" (`network.env`) with "defer to a second pass"
  (`llamacpp`); it is now a single `{ rel, keep? }` list, the same shape the home
  wipe already uses. Pure refactor, no behaviour change. The `models/` keep also
  gained a line noting what it carries today (~24 KB of `hf` download
  bookkeeping, no credentials) and what to re-check if `huggingface_hub` ever
  starts caching tokens under a `--local-dir`.
- **Comment volume trimmed.** `step_hermes_install` was ~145 lines of which ~95
  were comment, with several paragraphs restating each other, and the `.hermes`
  keep block cross-referenced its own argument three times. The incident
  narrative earns its place; the repetition does not, particularly in a public
  repo.

Two brittle test assertions went with it: `expect(curlLines.length).toBe(2)` and
`expect(runuserLines.length).toBe(4)` went red on benign additions, and the
property assertions around them (every `curl` goes through `$installer_url`,
none carries a literal URL, every `runuser` passes `HOME`) already carried the
value.

**Round-3 evidence.** 60/60 green on the two test files, run on the device.
Verified red against this branch's previous head: **7 failures, one per change**
— the husk `chown` idiom and its non-fatal form, the shim deletion, the restore
on a failed install, the healthy-agent-plus-lying-probe case, repeated failed
repairs leaving no husk, the swallowed fetch failure, and the sibling script's
shim-only guard. The real `install.sh --step hermes_install` was then run as root
on the bench box against this branch's code (the bootstrap re-exec bypassed, or
it would have run `main`): `Hermes already installed (Hermes Agent v0.20.5
(2026.8.19) · upstream fcbd1076)`, no husk created, shim intact, **0 root-owned
files** in the agent tree. `scripts/setup-hermes-edition.sh` was run for real on
the same healthy box and finished green, which is the non-regression check for
its tightened guard. `bun run build`, `eslint` and `tsc` on the changed files all
clean on the device (13 pre-existing `tsc` errors elsewhere in the repo,
untouched). The box was restored to `origin/main` afterwards.

The version strings in the older evidence above read `v0.20.4`; the device
reports **v0.20.5 (upstream `fcbd1076`)** today. That is upstream drift between
rounds, not a change here.

## Not verified

- Only the **hermes** edition was exercised. `dual` and `openclaw` are covered
  by tests and by reading, not by hardware.
- Not tested with the device actually **in AP mode with no internet**; the
  repair steps need the network, so on a truly offline box they warn and skip
  (by design — the preserved model and agent are what make that survivable in
  the first place).
- Rounds 2 and 3 did **not** re-run a live factory reset. Round 2 changed no
  reset-route code, and round 3's change to it is a pure refactor of the keep
  list (same names, same order of operations) covered by the existing route
  tests. The husk input that used to break a reset is gone at the source: it is
  now always transient.
- Round 3's failure paths are proven by the behavioural harness — which runs on
  the device, against the real `mv`/`chown`/`rm` — and by the red run against the
  previous head, not by breaking a real agent on hardware. The healthy no-op path
  *was* exercised for real, as root, on the bench box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added automatic recovery and verification for incomplete or outdated Hermes installations.
- Added offline Gemma model caching and recovery support.
- Factory reset now preserves the offline model and essential Hermes agent installation.

## Bug Fixes
- Improved detection and cleanup of stale or invalid installation files.
- Reset failures now report detailed errors, continue safe cleanup, and prevent unsafe follow-up actions.
- Extended update time to support Hermes installation and model recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


