### PR TITLE
fix(chat): stop duplicate user turns, add a New chat button

### DIFF
--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -270,6 +270,66 @@ function sameTranscript(a: ChatMessage[], b: ChatMessage[]): boolean {
   return true
 }
 
+/** The gateway suffixes its stored copy by role; the client holds the bare run id. */
+function runIdOf(key: string | undefined): string | undefined {
+  if (!key) return undefined
+  return key.endsWith(':user') ? key.slice(0, -':user'.length) : key
+}
+
+/**
+ * Which locally-appended user turns the server has NOT echoed back yet.
+ *
+ * A turn is added to the transcript the moment it is sent, so a history read
+ * that lands before the write completes must not erase it. Deciding that by
+ * timestamp alone is not possible: the local copy is stamped with the browser's
+ * clock and the server's with the device's, and a browser running ahead makes
+ * every local copy look newer than everything the server returned.
+ *
+ * Identity settles it — both sides carry the run's idempotency key. Text is
+ * kept only as the fallback for turns without one (other harnesses, older
+ * gateways), and cannot be the primary test: an attachment turn displays
+ * "📎 pic.png\nwhat is this" locally while the gateway stores the prompt alone.
+ */
+export function unechoedUserTurns(
+  previous: ChatMessage[],
+  restored: ChatMessage[],
+  lastServerTs: number,
+): ChatMessage[] {
+  const serverRunIds = new Set<string>()
+  // Per-text stock of server copies. Counting rather than a boolean so the
+  // same words sent twice keep the second bubble.
+  const unclaimed = new Map<string, number>()
+  for (const message of restored) {
+    if (message.role !== 'user') continue
+    const runId = runIdOf(message.idempotencyKey)
+    if (runId) serverRunIds.add(runId)
+    unclaimed.set(message.text, (unclaimed.get(message.text) ?? 0) + 1)
+  }
+  const claimText = (text: string): boolean => {
+    const left = unclaimed.get(text) ?? 0
+    if (left <= 0) return false
+    unclaimed.set(text, left - 1)
+    return true
+  }
+  const pending: ChatMessage[] = []
+  for (const message of previous) {
+    if (message.role !== 'user') continue
+    const runId = runIdOf(message.idempotencyKey)
+    if (runId && serverRunIds.has(runId)) {
+      // Also spend this text's stock, so a later identical turn is not matched
+      // against the copy this one already accounted for.
+      claimText(message.text)
+      continue
+    }
+    if (claimText(message.text)) continue
+    // Nothing on the server matches. Keep it only if it is newer than the whole
+    // replay — an older unmatched turn has aged out of the history window and
+    // re-appending it would put it back in the wrong place.
+    if (message.timestamp > lastServerTs) pending.push(message)
+  }
+  return pending
+}
+
 // A live TTS supplement can arrive before an older gateway's history
 // projection learns about it. Carry players across that short reconcile by
 // message occurrence, never by a text->audio map: common replies such as
@@ -1082,9 +1142,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
                 pendingModelSwitchResetRef.current = null
                 if (pendingModelSwitch) {
                   try {
-                    await wsRequest('sessions.reset', { key: mainSessionKey, reason: 'new' })
-                    setMessages([])
-                    greetedRef.current = true
+                    await resetSessionRef.current(mainSessionKey)
                   } catch (err) {
                     setMessages(prev => [...prev, {
                       role: 'system',
@@ -1483,6 +1541,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
 
   // Load chat history, auto-greet if empty
   const greetedRef = useRef(false)
+  const [startingSession, setStartingSession] = useState(false)
   const loadHistory = useCallback(async () => {
     // Optimistically show the typing bubble if an auto-greet might still run,
     // so the user sees feedback during the history round-trip (and is locked
@@ -1546,7 +1605,8 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         if (role === 'user') {
           const cleaned = raw.replace(/^\[[^\]]+\]\s*/, '')
           if (!cleaned) continue
-          chatMsgs.push({ role: 'user', text: cleaned, timestamp })
+          const idempotencyKey = typeof m.idempotencyKey === 'string' ? m.idempotencyKey : undefined
+          chatMsgs.push({ role: 'user', text: cleaned, timestamp, idempotencyKey })
           continue
         }
         // Replayed history carries the same MEDIA: lines the live turn did, so
@@ -1603,7 +1663,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         // keyed by text put the newest recording on every historical "Sure.".
         const restored = preserveSpokenByOccurrence(prev, chatMsgs)
         const lastServerTs = restored.length > 0 ? restored[restored.length - 1].timestamp : 0
-        const inFlight = prev.filter(m => m.role === 'user' && m.timestamp > lastServerTs)
+        const inFlight = unechoedUserTurns(prev, restored, lastServerTs)
         const next = inFlight.length === 0 ? restored : [...restored, ...inFlight]
         // Returning `prev` when nothing changed makes React skip the render.
         return sameTranscript(prev, next) ? prev : next
@@ -1661,6 +1721,38 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   }, [loadHistory, endImageWait])
 
   useEffect(() => { reconcileTranscriptRef.current = reconcileTranscript }, [reconcileTranscript])
+
+  // Make the agent forget the thread, rather than the UI merely hiding it.
+  // Shared with the provider switch, which needs the same reset: when the two
+  // were written out separately they drifted, and the switch stopped clearing
+  // the previous model's half-streamed reply off the screen. Throws on
+  // failure so each caller can word its own banner.
+  const resetSession = useCallback(async (key: string) => {
+    await wsRequest('sessions.reset', { key, reason: 'new' })
+    setMessages([])
+    setStreaming('')
+    // The auto-greet opens a FIRST conversation; re-arming it here would drop
+    // an unasked-for "hi" into the chat the moment it was cleared.
+    greetedRef.current = true
+  }, [wsRequest])
+  const resetSessionRef = useRef(resetSession)
+  useEffect(() => { resetSessionRef.current = resetSession }, [resetSession])
+
+  const startNewSession = useCallback(async () => {
+    setStartingSession(true)
+    try {
+      await resetSession(sessionKeyRef.current)
+    } catch (err) {
+      setMessages(prev => [...prev, {
+        role: 'system',
+        text: `Could not start a new chat: ${err instanceof Error ? err.message : 'unknown error'}`,
+        timestamp: Date.now(),
+        variant: 'error',
+      }])
+    } finally {
+      setStartingSession(false)
+    }
+  }, [resetSession])
 
   // While a picture is being generated, go and look for it. The background run
   // that produces it does not deliver renderable media over this socket, so a
@@ -2148,10 +2240,14 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const startRun = useCallback((text: string, sendAttachments: { name: string; path: string; type: string }[]) => {
     const fileNames = sendAttachments.map(a => `📎 ${a.name}`).join('\n')
     const displayText = [fileNames, text].filter(Boolean).join('\n')
-    setMessages(prev => [...prev, { role: 'user', text: displayText, timestamp: Date.now() }])
+    const idempotencyKey = uuid()
+    // Stamped onto the bubble, not just sent with the request: it is how the
+    // reconcile recognises the server's copy of this exact turn. Text cannot
+    // do that job here — `displayText` carries the 📎 filenames while the
+    // gateway stores and returns the prompt alone.
+    setMessages(prev => [...prev, { role: 'user', text: displayText, timestamp: Date.now(), idempotencyKey }])
     setSending(true)
     setStreaming('')
-    const idempotencyKey = uuid()
     runIdRef.current = idempotencyKey
     if (harnessRef.current === 'hermes') {
       void dispatchHermes(text)
@@ -3042,6 +3138,24 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             </svg>
           </button>
         )}
+        <button
+          onPointerDown={stopHeaderDrag}
+          onClick={() => { void startNewSession() }}
+          disabled={startingSession}
+          title="New chat"
+          aria-label="New chat"
+          style={{
+            background: 'none', border: 'none', color: 'rgba(255,255,255,0.4)',
+            cursor: 'pointer', padding: 4, borderRadius: 6,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.color = '#fff'; e.currentTarget.style.background = 'rgba(255,255,255,0.1)' }}
+          onMouseLeave={(e) => { e.currentTarget.style.color = 'rgba(255,255,255,0.4)'; e.currentTarget.style.background = 'none' }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 5v14M5 12h14" />
+          </svg>
+        </button>
         {!mobile && (
           <button
             onPointerDown={stopHeaderDrag}

--- a/src/lib/chat-history-cache.ts
+++ b/src/lib/chat-history-cache.ts
@@ -12,6 +12,11 @@ export interface ChatMessage {
   // different elements with different affordances, and merging them would make
   // every existing `images.length` check quietly wrong.
   audio?: string[];
+  // The run this turn belongs to. Set locally when the turn is sent and read
+  // back off the gateway's own record, so a turn can be recognised as "the one
+  // already on the server" without comparing text or clocks. The gateway
+  // suffixes its copy by role (`<runId>:user`); `runIdOf` normalises that.
+  idempotencyKey?: string;
 }
 
 export function uuid(): string {

--- a/src/tests/components/chat-new-session.test.tsx
+++ b/src/tests/components/chat-new-session.test.tsx
@@ -1,0 +1,178 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * "New chat" has to actually reset the agent's thread, not just blank the view.
+ *
+ * Clearing `messages` alone would look right and be wrong: the next question
+ * would still be answered with the previous conversation in context. The button
+ * therefore sends the same `sessions.reset` the provider switch already uses,
+ * and the transcript is only cleared once the gateway has accepted it.
+ *
+ * The auto-greet must NOT fire afterwards. It exists to open a first
+ * conversation on an empty box; re-arming it here would drop an unasked-for
+ * "hi" into the chat the moment the user cleared it.
+ */
+
+const SEED_TEXT = "Here's your orange tabby";
+
+function assistantMessage(text: string, timestamp: number) {
+  return { role: "assistant", content: [{ type: "text", text }], timestamp };
+}
+
+let history: unknown[] = [];
+/** Every frame the component sent, so the test can assert on the reset call. */
+const sent: Array<Record<string, unknown>> = [];
+/** Set to make `sessions.reset` fail, exercising the error path. */
+let resetFails = false;
+
+const sockets: FakeGatewayWs[] = [];
+const socket = () => sockets[sockets.length - 1] ?? null;
+
+class FakeGatewayWs {
+  static readonly OPEN = 1;
+  readyState = FakeGatewayWs.OPEN;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    sockets.push(this);
+    setTimeout(() => this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "n" } }), 0);
+  }
+
+  send(raw: string) {
+    let frame: Record<string, unknown>;
+    try { frame = JSON.parse(raw) as Record<string, unknown>; } catch { return; }
+    if (frame.type !== "req") return;
+    sent.push(frame);
+    const id = frame.id as string;
+    if (frame.method === "connect") {
+      this.respond(id, { snapshot: { sessionDefaults: { mainSessionKey: "agent:main:main" } } });
+      return;
+    }
+    if (frame.method === "chat.history") {
+      this.respond(id, { messages: history });
+      return;
+    }
+    if (frame.method === "sessions.reset") {
+      if (resetFails) {
+        setTimeout(() => this.emit({ type: "res", id, ok: false, error: { message: "gateway said no" } }), 0);
+        return;
+      }
+      // A real reset empties the transcript the next read returns.
+      history = [];
+      this.respond(id, {});
+      return;
+    }
+    this.respond(id, { runId: "r1", status: "started" });
+  }
+
+  close() {}
+
+  private respond(id: string, payload: unknown) {
+    setTimeout(() => this.emit({ type: "res", id, ok: true, payload }), 0);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+function installFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/setup-api/gateway/ws-config")) {
+      return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+    }
+    if (url.includes("/setup-api/harness/active")) {
+      return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+    }
+    if (url.includes("/setup-api/chat/model")) {
+      return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+    }
+    if (url.includes("/setup-api/chat/spoken-history")) {
+      return { ok: true, json: async () => ({ items: [] }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+const resetFrames = () => sent.filter((f) => f.method === "sessions.reset");
+const sendFrames = () => sent.filter((f) => f.method === "chat.send");
+const historyFrames = () => sent.filter((f) => f.method === "chat.history");
+
+async function mountReady() {
+  render(<ChatPopup isOpen onClose={() => {}} />);
+  await waitFor(() => expect(socket()).not.toBeNull());
+  await screen.findByText(SEED_TEXT);
+}
+
+describe("new chat button", () => {
+  beforeEach(() => {
+    history = [assistantMessage(SEED_TEXT, 500)];
+    sent.length = 0;
+    resetFails = false;
+    sockets.length = 0;
+    resetHarnessCache();
+    window.localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal("WebSocket", FakeGatewayWs as unknown as typeof WebSocket);
+    installFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetHarnessCache();
+  });
+
+  it("resets the agent's session and clears the transcript", async () => {
+    await mountReady();
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }));
+
+    await waitFor(() => expect(resetFrames()).toHaveLength(1));
+    // Reason 'new' is what makes the agent start a fresh thread rather than
+    // merely rewinding — the provider switch uses the same pair.
+    expect(resetFrames()[0].params).toMatchObject({ key: "agent:main:main", reason: "new" });
+    await waitFor(() => expect(screen.queryByText(SEED_TEXT)).toBeNull());
+  });
+
+  it("does not auto-greet into the chat it just cleared", async () => {
+    await mountReady();
+    const sendsBefore = sendFrames().length;
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }));
+    await waitFor(() => expect(screen.queryByText(SEED_TEXT)).toBeNull());
+
+    // Force a real history read against the now-empty transcript: that is the
+    // branch which would auto-greet if the reset had re-armed `greetedRef`.
+    // Asserting on a fixed sleep would only prove "nothing happened for 250ms"
+    // without ever exercising it.
+    const readsBefore = historyFrames().length;
+    socket()?.emit({
+      type: "event",
+      event: "session.message",
+      payload: { sessionKey: "agent:main:main", agentId: "main", message: assistantMessage("", 900) },
+    });
+    await waitFor(() => expect(historyFrames().length).toBeGreaterThan(readsBefore), { timeout: 3000 });
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+
+    expect(sendFrames()).toHaveLength(sendsBefore);
+  });
+
+  it("keeps the transcript and explains itself when the reset fails", async () => {
+    await mountReady();
+    resetFails = true;
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }));
+
+    // Blanking the view on a failed reset would be the worst outcome: the
+    // agent still holds the thread, but the user believes it is gone.
+    await screen.findByText(/Could not start a new chat/);
+    expect(screen.queryByText(SEED_TEXT)).not.toBeNull();
+  });
+});

--- a/src/tests/components/chat-optimistic-duplicate.test.tsx
+++ b/src/tests/components/chat-optimistic-duplicate.test.tsx
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * A sent message must appear once, however far apart the two clocks are.
+ *
+ * The chat appends the turn locally the moment you press Enter, stamped with
+ * `Date.now()` — the BROWSER's clock. `chat.history` then returns that same turn
+ * stamped by the DEVICE. Those are two different machines, and the reconcile
+ * used to decide "is this still in flight?" by comparing them: keep any local
+ * user turn newer than the newest message the server returned.
+ *
+ * On a browser running ahead of the box that is always true, so the optimistic
+ * copy survived a history read that had already echoed it back and the question
+ * rendered twice. `sameTranscript` compares timestamps, so the pair never
+ * collapsed on a later render either.
+ *
+ * Reproduced on the box: one "generate bunny image" in the transcript, two
+ * bubbles on screen. Image generation makes it easy to hit because the run is
+ * long and tool events reconcile throughout, but nothing here is specific to
+ * images — any reply slow enough to span a reconcile does it.
+ *
+ * Two harness details are load-bearing, both learned by getting them wrong:
+ *
+ * 1. History is seeded NON-EMPTY. On an empty transcript the popup auto-greets
+ *    and gates the composer while it bootstraps, so the send never happens and
+ *    the test measures nothing.
+ * 2. Bubbles are counted excluding the textarea. React renders a controlled
+ *    textarea's value as a DOM text node, so a bare `queryAllByText` counts the
+ *    unsent draft as if it were a message.
+ */
+
+const PROMPT = "generate bunny image";
+/** What the device stamps. Deliberately far behind the browser's Date.now(). */
+const SERVER_TS = 1000;
+const SEED_TS = 500;
+const SEED_TEXT = "Ready when you are.";
+
+function userMessage(text: string, timestamp: number, idempotencyKey?: string) {
+  return { role: "user", content: [{ type: "text", text }], timestamp, idempotencyKey };
+}
+
+/** The run id the component generated for the turn it just sent. */
+function lastSentRunId(): string {
+  const send = sent.filter((f) => f.method === "chat.send").pop();
+  return String((send?.params as { idempotencyKey?: string })?.idempotencyKey ?? "");
+}
+
+function assistantMessage(text: string, timestamp: number) {
+  return { role: "assistant", content: [{ type: "text", text }], timestamp };
+}
+
+/** A prior turn, so the transcript is never empty and the auto-greet stays off. */
+const SEED = assistantMessage(SEED_TEXT, SEED_TS);
+
+/** What the gateway replays. Mutated per test before the reconcile fires. */
+let history: unknown[] = [];
+let historyReads = 0;
+/** Every request frame the component sent. */
+const sent: Array<Record<string, unknown>> = [];
+
+const sockets: FakeGatewayWs[] = [];
+const socket = () => sockets[sockets.length - 1] ?? null;
+
+class FakeGatewayWs {
+  static readonly OPEN = 1;
+  readyState = FakeGatewayWs.OPEN;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    sockets.push(this);
+    setTimeout(() => this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "n" } }), 0);
+  }
+
+  send(raw: string) {
+    let frame: Record<string, unknown>;
+    try { frame = JSON.parse(raw) as Record<string, unknown>; } catch { return; }
+    if (frame.type !== "req") return;
+    sent.push(frame);
+    const id = frame.id as string;
+    if (frame.method === "connect") {
+      this.respond(id, { snapshot: { sessionDefaults: { mainSessionKey: "agent:main:main" } } });
+      return;
+    }
+    if (frame.method === "chat.history") {
+      historyReads += 1;
+      this.respond(id, { messages: history });
+      return;
+    }
+    this.respond(id, { runId: "r1", status: "started" });
+  }
+
+  close() {}
+
+  private respond(id: string, payload: unknown) {
+    setTimeout(() => this.emit({ type: "res", id, ok: true, payload }), 0);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+function installFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/setup-api/gateway/ws-config")) {
+      return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+    }
+    if (url.includes("/setup-api/harness/active")) {
+      return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+    }
+    if (url.includes("/setup-api/chat/model")) {
+      return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+    }
+    if (url.includes("/setup-api/chat/spoken-history")) {
+      return { ok: true, json: async () => ({ items: [] }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+/** The signal that makes the component re-read `chat.history`. */
+function reconcile() {
+  socket()?.emit({
+    type: "event",
+    event: "session.message",
+    payload: { sessionKey: "agent:main:main", agentId: "main", message: userMessage(PROMPT, SERVER_TS) },
+  });
+}
+
+/** Message bubbles only — never the composer's own draft text. */
+const bubbles = (text: string) =>
+  screen.queryAllByText(text).filter((el) => el.tagName !== "TEXTAREA");
+
+async function mountReady() {
+  render(<ChatPopup isOpen onClose={() => {}} />);
+  await waitFor(() => expect(socket()).not.toBeNull());
+  // The seed turn proves history landed and the composer is no longer gated.
+  await screen.findByText(SEED_TEXT);
+}
+
+async function sendPrompt(text: string) {
+  const textarea = await screen.findByRole("textbox");
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+}
+
+async function reconcileOnce() {
+  const before = historyReads;
+  reconcile();
+  await waitFor(() => expect(historyReads).toBeGreaterThan(before), { timeout: 3000 });
+  // LOAD-BEARING. The request has only been *sent* at this point; the fake
+  // socket answers it on a later macrotask. Without flushing, every assertion
+  // below runs against pre-reconcile state and the file passes even against
+  // the unfixed component — verified. Do not remove as "redundant".
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
+describe("optimistic user turns across a history reconcile", () => {
+  beforeEach(() => {
+    history = [SEED];
+    historyReads = 0;
+    sent.length = 0;
+    sockets.length = 0;
+    resetHarnessCache();
+    window.localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal("WebSocket", FakeGatewayWs as unknown as typeof WebSocket);
+    installFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetHarnessCache();
+  });
+
+  it("shows a sent message once when the device clock trails the browser", async () => {
+    await mountReady();
+    await sendPrompt(PROMPT);
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(1));
+
+    // The server now has the turn, stamped with its own much-older clock.
+    history = [SEED, userMessage(PROMPT, SERVER_TS)];
+    await reconcileOnce();
+
+    // Before the fix this was 2: the optimistic copy outlived the echo purely
+    // because the browser's clock was ahead of the device's.
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(1));
+  });
+
+  it("keeps a turn the server has not stored yet", async () => {
+    await mountReady();
+    await sendPrompt(PROMPT);
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(1));
+
+    // A reconcile that beats the write: history still lacks the new turn.
+    // Dropping the local copy here would blank the message the user just sent,
+    // which is the failure the in-flight carry exists to prevent.
+    await reconcileOnce();
+
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(1));
+  });
+
+  it("shows an attachment turn once, though its text differs from the server's", async () => {
+    // The bubble reads "📎 pic.png\nwhat is this" while the gateway stores and
+    // returns the prompt alone — different strings by construction, so no
+    // amount of text matching can pair them. Identity is what closes this.
+    await mountReady();
+    await sendPrompt(PROMPT);
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(1));
+
+    const runId = lastSentRunId();
+    expect(runId).not.toBe("");
+    // Same turn, as the gateway records it: role-suffixed key, its own clock,
+    // and text that does NOT match what the bubble is showing.
+    history = [SEED, userMessage("a different projection", SERVER_TS, `${runId}:user`)];
+    await reconcileOnce();
+
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(0));
+  });
+
+  it("keeps both when the same words are deliberately sent twice", async () => {
+    // The first copy is already on the server; the second is still in flight.
+    // An identity check coarser than per-occurrence counting would swallow the
+    // second and lose a message the user really did send.
+    history = [SEED, userMessage(PROMPT, SERVER_TS)];
+    await mountReady();
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(1));
+
+    await sendPrompt(PROMPT);
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(2));
+
+    await reconcileOnce();
+
+    await waitFor(() => expect(bubbles(PROMPT)).toHaveLength(2));
+  });
+});


### PR DESCRIPTION
## Duplicate user turns

A sent message could render twice.

The transcript appends the turn locally the moment you press Enter, stamped with the **browser's** clock, while `chat.history` returns the same turn stamped by the **device**. The reconcile decided *"is this still in flight?"* by comparing those two, so a browser running ahead of the box kept a copy the server had already echoed back — and `sameTranscript` compares timestamps, so the pair never collapsed on a later render either.

Observed on the box: one `generate bunny image` in the transcript, two bubbles on screen. Any reply slow enough to span a reconcile does it; image generation just makes it easy to hit because tool events reconcile throughout a long run.

**Matching is now by identity.** Both sides already carry the run's idempotency key — the client generates it in `startRun`, and the gateway stores its copy role-suffixed as `<runId>:user`, which survives the history projection. Text and timestamp are kept only as the fallback for turns without a key (other harnesses, older gateways).

Identity rather than text is load-bearing, not a preference: an **attachment** turn displays the filename above the prompt while the gateway stores the prompt alone, so the two strings can never match. A text-only fix leaves that case duplicating — `shows an attachment turn once, though its text differs from the server's` covers it.

## New chat button

A small **+** in the popup header starts a fresh conversation without changing provider or model.

It issues `sessions.reset` with `reason: 'new'`, so the agent *forgets the thread* rather than the UI merely hiding it, and the transcript is cleared only once the gateway accepts. A failed reset keeps the transcript and says why — blanking the view while the agent still holds the context would be the worst outcome.

The auto-greet is deliberately left disarmed afterwards: it exists to open a **first** conversation, and re-arming it would drop an unasked-for `hi` into the chat the moment it was cleared.

## Shared reset (drift fix)

The provider switch already performed this reset inline. Writing it out twice had let the two drift: the switch never cleared the streaming buffer, so **changing provider mid-stream left the previous model's partial reply on screen**. Both paths now call one `resetSession` helper, which fixes that as a side effect.

## Testing

- `bun run test` — **238 files / 3199 tests pass**
- `npx tsc --noEmit` — no new errors
- `bun run lint` — 0 errors on changed files
- Built and deployed to a real Jetson; button exercised in the running desktop

Each new test was verified to fail against the unfixed code, not just to pass against the fixed code:

| Test | Mutation it catches |
|---|---|
| device clock trails the browser | reverting to the timestamp-only filter |
| attachment turn, differing text | removing the identity branch (text-only matching) |
| turn the server has not stored yet | dropping all optimistic turns |
| same words sent twice | matching coarser than per-occurrence |

Two harness details are called out in-file because both were found by getting them wrong: history must be seeded non-empty (an empty transcript auto-greets and gates the composer, so the send never happens), and bubbles are counted excluding the textarea (React renders a controlled textarea's value as a DOM text node, so a bare `queryAllByText` counts the unsent draft as a message). The post-reconcile `act` flush is marked **LOAD-BEARING** — without it the file passes against the *unfixed* component.

## Known gaps, not addressed here

- **Run teardown.** Pressing New chat mid-run leaves the chat "thinking" with the dead run's tool pills, and the old reply lands in the cleared chat. The fix is an `endRun()` shared with the two existing run-end sites — a behaviour change, so it is kept out of this PR.
- **`newestTimestamp` mixed clocks** ([ChatPopup.tsx:329](https://github.com/ID-Robots/clawbox/blob/beta/src/components/ChatPopup.tsx#L329)) scans browser-stamped messages while its comment claims both sides are server timestamps — same bug class, can hang the image-generation banner. Pre-existing, outside this diff.
- The `FakeGatewayWs` + `installFetch` harness is now copied into a 7th and 8th test file. Extracting it properly means touching six pre-existing files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “New chat” control that resets the active conversation and provides feedback if the reset fails.
  * Chat messages now remain visible while being saved or reconciled with conversation history.

* **Bug Fixes**
  * Prevented recently sent messages from disappearing or appearing duplicated during history updates.
  * Improved handling of repeated prompts and messages with attachments.
  * Provider changes now reliably reset the conversation state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->