### PR TITLE
fix: factory reset no longer destroys the Hermes agent and offline model (hotfix to main)

### DIFF
--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -43,10 +43,11 @@ Everything ClawBox cares about lives under `/home/clawbox`. The app itself is a 
 | | System update | Factory reset |
 |---|---|---|
 | App code (`/home/clawbox/clawbox` tracked files) | **hard-reset to the release** | hard-reset + wiped state |
-| `data/` (settings, tokens, webapps) | ✅ kept | ❌ wiped (except `network.env`) |
+| `data/` (settings, tokens, webapps) | ✅ kept | ❌ wiped (except `network.env` and `llamacpp/models`) |
 | `.env` | ✅ kept | ✅ kept (gitignored, not in wipe list) |
 | `.update-branch` (channel pin) | ✅ kept | ✅ kept |
 | `~/.openclaw` (AI config, credentials, chats) | ✅ kept | ❌ wiped |
+| `~/.hermes` (Hermes config, chats, agent install) | ✅ kept | ❌ wiped, except `hermes-agent` (the agent install — can't be re-downloaded in AP mode) |
 | `~/.clawkeep` (backup pairing) | ✅ kept | ❌ wiped |
 | Ollama models | ✅ kept | ❌ deleted |
 | Saved Wi-Fi networks | ✅ kept | ❌ deleted (box returns to AP mode) |

--- a/install.sh
+++ b/install.sh
@@ -1133,41 +1133,35 @@ step_hermes_install() {
   local venv_python="$agent_dir/venv/bin/python"
   local installed=""
   # One constant so the reachability precheck and the install itself can never
-  # drift onto different hosts — a precheck against a URL we then do not use
-  # would be worse than no precheck.
+  # drift onto different hosts.
   local installer_url="https://hermes-agent.nousresearch.com/install.sh"
 
-  # `$shim` alone is NOT evidence of an install. It is a 4-line wrapper in
-  # ~/.local/bin that execs $venv_python; the agent it points at lives under
-  # ~/.hermes. A factory reset that removed ~/.hermes left the shim behind, so
-  # the old `[ -x "$shim" ]` guard reported "Hermes already installed ()" —
-  # with the version probe returning EMPTY into an echo nobody checked — and
-  # returned success without reinstalling anything. That is what turned a
-  # recoverable box into one that needed a reflash: every later repair attempt,
-  # including a full `install.sh` re-run, hit the same guard and did nothing.
+  # `$shim` alone is NOT evidence of an install: it is a 4-line wrapper in
+  # ~/.local/bin that execs $venv_python, and the agent it points at lives
+  # under ~/.hermes. A factory reset removed ~/.hermes and left the shim, so
+  # the old `[ -x "$shim" ]` guard printed "Hermes already installed ()" — an
+  # EMPTY version probe inside an echo nobody looked at — and returned success
+  # without reinstalling. Every later repair, a full install.sh re-run
+  # included, hit the same guard and did nothing: that is what turned a
+  # recoverable box into a reflash.
   #
   # So: require the interpreter to exist AND the agent to actually answer
-  # `--version`. Anything less is treated as "not installed" and reinstalled.
+  # `--version`. Anything less is treated as "not installed".
   if [ -x "$shim" ] && [ -x "$venv_python" ]; then
     # Probed AS THE CLAWBOX USER, deliberately. `hermes` is a Python entry
     # point and CPython writes __pycache__/*.pyc next to the sources it
-    # imports. install.sh runs as root, so probing here as root left ~13
-    # root-owned .pyc files (~165 after an agent version bump) inside a
-    # clawbox-owned tree — and the factory-reset route runs as clawbox, so its
-    # wipe hit EACCES on them and aborted MID-WIPE with the agent already half
-    # deleted. The probe is the only thing in this file that ever executed
-    # `hermes`, so running it under runuser removes the writer entirely.
-    # HOME is passed explicitly: hermes resolves ~/.hermes from $HOME, and this
+    # imports; probing as root left root-owned .pyc files inside a
+    # clawbox-owned tree, and the factory-reset route (which runs as clawbox)
+    # then hit EACCES and aborted MID-WIPE with the agent half deleted. HOME is
+    # passed explicitly: hermes resolves ~/.hermes from $HOME, and this
     # function's HOME is /root.
     #
-    # `|| installed=""` is NOT decoration. This file runs under `set -euo
-    # pipefail`, and a bare assignment takes the exit status of its command
-    # substitution — so a probe that exits non-zero (the exact false-negative
-    # case this step exists to survive) would kill install.sh right here,
-    # before the reachability check and before any repair, printing nothing.
-    # That would break both `install.sh --step hermes_install`, the repair
-    # command scripts/setup-hermes-edition.sh tells the operator to run, and
-    # the full install, which would skip every step after this one.
+    # `|| installed=""` is NOT decoration. Under `set -euo pipefail` an
+    # assignment takes the exit status of its command substitution, so the
+    # false-negative probe this step exists to survive would kill install.sh
+    # right here — before the reachability check, before any repair, printing
+    # nothing — taking `install.sh --step hermes_install` (the documented
+    # repair command) and every later step of a full install down with it.
     installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
       "$shim" --version 2>/dev/null | head -1) || installed=""
   fi
@@ -1178,17 +1172,10 @@ step_hermes_install() {
   fi
 
   # NOTHING above this line has modified the disk, and nothing below it does
-  # until the installer is known to be fetchable.
-  #
-  # This matters now in a way it did not before: step_post_update calls this
-  # step on EVERY update on EVERY hermes/dual box, not just on a broken one. So
-  # a false-negative probe — the venv busy, a transient fork failure, anything
-  # that makes `--version` come back empty on a device that is actually fine —
-  # used to reach a `rm -rf "$agent_dir"` and then depend on a network install
-  # that is explicitly non-fatal. On a box with no internet that sequence turns
-  # a healthy agent into no agent, which is the very outcome this file exists
-  # to prevent. Check reachability FIRST and leave the disk alone if the
-  # installer cannot be had.
+  # until the installer is known to be fetchable. step_post_update now calls
+  # this step on EVERY update on EVERY hermes/dual box, so a false-negative
+  # probe on a device with no internet must not be able to turn a healthy agent
+  # into no agent — the very outcome this file exists to prevent.
   if ! runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     curl -fsS --max-time 30 -o /dev/null "$installer_url"; then
     echo "  Warning: cannot reach the Hermes installer — leaving the existing agent untouched" >&2
@@ -1198,74 +1185,74 @@ step_hermes_install() {
   # The husk has to be out of the way before the reinstall: the upstream
   # installer refuses outright with "Directory exists but is not a git
   # repository" when $agent_dir survives as an empty shell — exactly what a
-  # factory reset leaves behind — so without this the reinstall fails and the
-  # box stays bricked.
+  # factory reset leaves behind — so without this the box stays bricked.
   #
-  # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
-  # box had, and this step is no longer only reached by a genuinely broken
-  # device; a rename is just as good for unblocking the installer and is
-  # recoverable when the diagnosis was wrong. A FIXED name rather than a
-  # timestamp keeps at most one husk on a device whose disk is not large — a
-  # per-run stamp would accumulate a git checkout plus a venv on every failed
-  # update. Renaming as ROOT is also required: the root-owned __pycache__
-  # described above is not movable by the clawbox user the installer runs as.
+  # MOVED ASIDE, never deleted, and only until the outcome is known: the
+  # install either succeeds (husk dropped below) or fails (husk moved back), so
+  # the device is never left with two copies and never with none, and a wrong
+  # diagnosis costs nothing. Renaming as ROOT is also required — the root-owned
+  # __pycache__ above is not movable by the clawbox user the installer runs as.
   if [ -e "$agent_dir" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    if [ -e "$agent_dir.broken" ]; then
-      # An earlier repair already saved the owner's checkout. Overwriting it
-      # here would replace it with the partial garbage the failed install left
-      # behind — on a persistently broken box, update #2 would destroy the only
-      # good copy. First husk wins.
-      echo "  Keeping the earlier $agent_dir.broken; discarding the unusable checkout"
-      rm -rf "$agent_dir"
-    elif mv "$agent_dir" "$agent_dir.broken"; then
-      # The husk MUST be deletable by the clawbox user. The factory-reset route
-      # runs as clawbox and keeps only the exact name "hermes-agent", so it
-      # tries to delete this directory — and a root-owned __pycache__ inside it
-      # (written by an older root-run probe) makes that unlink fail with EACCES.
-      # A reset that reports a failure aborts BEFORE the password/WiFi/hostname
-      # reset and the reboot, so the box would be stuck half-reset forever.
-      # install.sh is root here; the reset is not.
-      chown -R "$CLAWBOX_USER:" "$agent_dir.broken"
+    # Non-empty only if an earlier repair was interrupted between the move and
+    # the restore; without this `mv` would nest the new husk inside the old.
+    rm -rf "$agent_dir.broken"
+    if mv "$agent_dir" "$agent_dir.broken"; then
+      # The husk MUST be deletable by the clawbox user: the factory-reset route
+      # runs as clawbox and keeps only the exact name "hermes-agent", so a
+      # root-owned __pycache__ inside it fails the unlink with EACCES — and a
+      # reset that reports a failure aborts BEFORE the password/WiFi/hostname
+      # reset and the reboot. Non-fatal: errexit is live at this function's
+      # bare call sites and the agent is moved aside right now, so aborting
+      # here would leave the device with nothing installed at all.
+      chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$agent_dir.broken" \
+        || echo "  Warning: could not give $agent_dir.broken to $CLAWBOX_USER" >&2
       echo "  Moved the unusable agent to $agent_dir.broken"
     else
       echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
       return 0
     fi
   fi
-  # A no-op when the shim is absent; a stale shim must never outlive its agent.
-  rm -f "$shim"
 
   echo "  Installing Hermes agent (NousResearch)..."
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
-  # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
-  # The URL is passed as an argument rather than spliced into the -c string, so
-  # it stays a single source of truth without shell-quoting exposure.
-  runuser -u "$CLAWBOX_USER" -- bash -c \
-    'curl -fsSL "$1" | bash' _ "$installer_url" \
+  # the clawbox user so it lands in ~/.hermes and ~/.local/bin. The URL is
+  # passed as an argument rather than spliced into the -c string, so it stays a
+  # single source of truth without shell-quoting exposure. `-o pipefail`
+  # because `curl | bash` otherwise exits 0 when the fetch fails (bash just
+  # reads empty stdin) and the warning below could never fire; the timeouts
+  # because the caller is a systemd unit with TimeoutStartSec=7200.
+  runuser -u "$CLAWBOX_USER" -- bash -o pipefail -c \
+    'curl -fsSL --connect-timeout 15 --max-time 900 "$1" | bash' _ "$installer_url" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
   # non-fatal above, so a silent failure here would otherwise be discovered by
-  # the owner as a crash-looping dashboard.
-  # `|| installed=""` for the same errexit reason as the first probe: when the
-  # install laid down nothing, this runs a shim that does not exist and exits
-  # 127, which would abort the step before the warning below ever printed.
+  # the owner as a crash-looping dashboard. `|| installed=""` for the same
+  # errexit reason as the first probe: when the install laid down nothing, this
+  # runs a shim that does not exist and exits 127.
   installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     "$shim" --version 2>/dev/null | head -1) || installed=""
   if [ -n "$installed" ]; then
     echo "  Hermes installed ($installed)"
-    # The husk was insurance against a wrong diagnosis, and the new agent
-    # answers --version — so the insurance is over. It costs ~1.9 GB (checkout
-    # plus venv) on a device the comment above calls disk-constrained, and it
-    # is one more directory a later factory reset has to be able to delete.
+    # Diagnosis confirmed, so the insurance copy goes: it costs ~1.9 GB
+    # (checkout plus venv) on a disk-constrained device and is one more
+    # directory a later factory reset has to be able to delete.
     rm -rf "$agent_dir.broken"
   else
     echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
-    # Say where the previous install went, so a wrong diagnosis is reversible
-    # by hand instead of needing a reflash.
+    # The diagnosis may simply have been wrong — an empty probe on a loaded
+    # device is exactly the case above. Put the original back: whatever the
+    # failed install left behind is worth less than what was there before, and
+    # parking the only copy under another name would leave the owner with no
+    # working agent AND no automatic second chance on the next update.
     if [ -e "$agent_dir.broken" ]; then
-      echo "  The previous agent is preserved at $agent_dir.broken" >&2
+      rm -rf "$agent_dir"
+      if mv "$agent_dir.broken" "$agent_dir"; then
+        echo "  Restored the previous agent from $agent_dir.broken" >&2
+      else
+        echo "  Warning: the previous agent is at $agent_dir.broken — move it back by hand" >&2
+      fi
     fi
   fi
   # Explicit: the last command above is a test that is FALSE on the happy path,

--- a/install.sh
+++ b/install.sh
@@ -1194,24 +1194,33 @@ step_hermes_install() {
   # __pycache__ above is not movable by the clawbox user the installer runs as.
   if [ -e "$agent_dir" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    # Non-empty only if an earlier repair was interrupted between the move and
-    # the restore; without this `mv` would nest the new husk inside the old.
-    rm -rf "$agent_dir.broken"
-    if mv "$agent_dir" "$agent_dir.broken"; then
-      # The husk MUST be deletable by the clawbox user: the factory-reset route
-      # runs as clawbox and keeps only the exact name "hermes-agent", so a
-      # root-owned __pycache__ inside it fails the unlink with EACCES — and a
-      # reset that reports a failure aborts BEFORE the password/WiFi/hostname
-      # reset and the reboot. Non-fatal: errexit is live at this function's
-      # bare call sites and the agent is moved aside right now, so aborting
-      # here would leave the device with nothing installed at all.
-      chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$agent_dir.broken" \
-        || echo "  Warning: could not give $agent_dir.broken to $CLAWBOX_USER" >&2
+    if [ -e "$agent_dir.broken" ]; then
+      # An existing husk means an earlier repair was interrupted between the
+      # move and the restore: the husk is the owner's original checkout and
+      # $agent_dir is whatever the interrupted installer left behind. The
+      # original is the copy worth keeping; the partial tree is not. Deleting
+      # the husk here instead would destroy the last known-good agent.
+      if rm -rf "$agent_dir"; then
+        echo "  Kept the earlier husk at $agent_dir.broken and discarded the partial install"
+      else
+        echo "  Warning: could not clear the partial install at $agent_dir — leaving both in place" >&2
+        return 0
+      fi
+    elif mv "$agent_dir" "$agent_dir.broken"; then
       echo "  Moved the unusable agent to $agent_dir.broken"
     else
       echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
       return 0
     fi
+    # The husk MUST be deletable by the clawbox user: the factory-reset route
+    # runs as clawbox and keeps only the exact name "hermes-agent", so a
+    # root-owned __pycache__ inside it fails the unlink with EACCES — and a
+    # reset that reports a failure aborts BEFORE the password/WiFi/hostname
+    # reset and the reboot. Non-fatal: errexit is live at this function's
+    # bare call sites and the agent is moved aside right now, so aborting
+    # here would leave the device with nothing installed at all.
+    chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$agent_dir.broken" \
+      || echo "  Warning: could not give $agent_dir.broken to $CLAWBOX_USER" >&2
   fi
 
   echo "  Installing Hermes agent (NousResearch)..."
@@ -1223,7 +1232,7 @@ step_hermes_install() {
   # reads empty stdin) and the warning below could never fire; the timeouts
   # because the caller is a systemd unit with TimeoutStartSec=7200.
   runuser -u "$CLAWBOX_USER" -- bash -o pipefail -c \
-    'curl -fsSL --connect-timeout 15 --max-time 900 "$1" | bash' _ "$installer_url" \
+    'curl -fsSL --connect-timeout 15 --max-time 600 "$1" | bash' _ "$installer_url" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
@@ -1247,8 +1256,9 @@ step_hermes_install() {
     # parking the only copy under another name would leave the owner with no
     # working agent AND no automatic second chance on the next update.
     if [ -e "$agent_dir.broken" ]; then
-      rm -rf "$agent_dir"
-      if mv "$agent_dir.broken" "$agent_dir"; then
+      # Both steps guarded: a failed rm followed by mv would NEST the original
+      # inside the failed install and report success.
+      if rm -rf "$agent_dir" && mv "$agent_dir.broken" "$agent_dir"; then
         echo "  Restored the previous agent from $agent_dir.broken" >&2
       else
         echo "  Warning: the previous agent is at $agent_dir.broken — move it back by hand" >&2

--- a/install.sh
+++ b/install.sh
@@ -1128,16 +1128,97 @@ step_openclaw_setup() {
 # harness to switch to).
 step_hermes_install() {
   has_hermes_harness || return 0
-  if [ -x "$CLAWBOX_HOME/.local/bin/hermes" ]; then
-    echo "  Hermes already installed ($("$CLAWBOX_HOME/.local/bin/hermes" --version 2>/dev/null | head -1))"
+  local shim="$CLAWBOX_HOME/.local/bin/hermes"
+  local agent_dir="$CLAWBOX_HOME/.hermes/hermes-agent"
+  local venv_python="$agent_dir/venv/bin/python"
+  local installed=""
+
+  # `$shim` alone is NOT evidence of an install. It is a 4-line wrapper in
+  # ~/.local/bin that execs $venv_python; the agent it points at lives under
+  # ~/.hermes. A factory reset that removed ~/.hermes left the shim behind, so
+  # the old `[ -x "$shim" ]` guard reported "Hermes already installed ()" —
+  # with the version probe returning EMPTY into an echo nobody checked — and
+  # returned success without reinstalling anything. That is what turned a
+  # recoverable box into one that needed a reflash: every later repair attempt,
+  # including a full `install.sh` re-run, hit the same guard and did nothing.
+  #
+  # So: require the interpreter to exist AND the agent to actually answer
+  # `--version`. Anything less is treated as "not installed" and reinstalled.
+  if [ -x "$shim" ] && [ -x "$venv_python" ]; then
+    # Probed AS THE CLAWBOX USER, deliberately. `hermes` is a Python entry
+    # point and CPython writes __pycache__/*.pyc next to the sources it
+    # imports. install.sh runs as root, so probing here as root left ~13
+    # root-owned .pyc files (~165 after an agent version bump) inside a
+    # clawbox-owned tree — and the factory-reset route runs as clawbox, so its
+    # wipe hit EACCES on them and aborted MID-WIPE with the agent already half
+    # deleted. The probe is the only thing in this file that ever executed
+    # `hermes`, so running it under runuser removes the writer entirely.
+    # HOME is passed explicitly: hermes resolves ~/.hermes from $HOME, and this
+    # function's HOME is /root.
+    installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+      "$shim" --version 2>/dev/null | head -1)
+  fi
+
+  if [ -n "$installed" ]; then
+    echo "  Hermes already installed ($installed)"
     return 0
   fi
+
+  if [ -e "$agent_dir" ] || [ -e "$shim" ]; then
+    echo "  Hermes is present but not runnable — reinstalling the agent"
+    # The husk has to go before the reinstall. The upstream installer refuses
+    # outright with "Directory exists but is not a git repository" when
+    # $agent_dir survives as an empty shell — exactly what a factory reset
+    # leaves behind — so without this the reinstall fails and the box stays
+    # bricked. Removing it as ROOT is also required: the root-owned __pycache__
+    # described above is undeletable by the clawbox user the installer runs as.
+    rm -rf "$agent_dir"
+    rm -f "$shim"
+  fi
+
   echo "  Installing Hermes agent (NousResearch)..."
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
   # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
   runuser -u "$CLAWBOX_USER" -- bash -c \
     'curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash' \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
+
+  # Verify rather than assume. The installer is fetched over the network and is
+  # non-fatal above, so a silent failure here would otherwise be discovered by
+  # the owner as a crash-looping dashboard.
+  installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+    "$shim" --version 2>/dev/null | head -1)
+  if [ -n "$installed" ]; then
+    echo "  Hermes installed ($installed)"
+  else
+    echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
+  fi
+}
+
+# Re-cache ONLY the offline Gemma GGUF.
+#
+# Split out of step_llamacpp_install so the in-app updater can dispatch it:
+# that step also does apt work, a pip install and (worst case) a ~19-minute
+# native llama.cpp build, none of which an update needs. This one touches
+# nothing but the model file and is a fast no-op when it is already there,
+# which is what makes it safe to run on every update.
+#
+# Not gated on has_hermes_harness: the factory-reset route wipes data/ on EVERY
+# edition, so an openclaw box lost the same 3.2 GB model and needs the same
+# repair.
+step_llamacpp_model() {
+  if is_test_mode; then
+    echo "  CLAWBOX_TEST_MODE=1, skipping Gemma model re-cache"
+    return 0
+  fi
+  # `hf` is installed by step_llamacpp_install. If it was never run on this
+  # device there is no model to restore and nothing this step can do — say so
+  # instead of failing on a missing binary.
+  if ! as_clawbox_login "command -v hf" &>/dev/null; then
+    echo "  Hugging Face CLI not installed — skipping Gemma model re-cache"
+    return 0
+  fi
+  ensure_llamacpp_model_cached
 }
 
 # The OpenClaw gateway is an UNAUTHENTICATED agent control surface on
@@ -1982,6 +2063,25 @@ step_post_update() {
   # clawbox-gateway as the active single source of truth.
   step_gateway_setup || echo "  Warning: gateway_setup step failed (non-fatal)"
   step_gateway_legacy_state_recovery || echo "  Warning: gateway_legacy_state_recovery step failed (non-fatal)"
+  # Repair the two assets a factory reset performed by a pre-fix build deleted:
+  # the Hermes agent install (~/.hermes/hermes-agent) and the offline Gemma
+  # GGUF (data/llamacpp). Neither `git pull && build` nor any fixup above put
+  # them back, so before this an in-app UPDATE could not heal an
+  # already-bricked device — the owner needed SSH, which is not a support path
+  # for an appliance.
+  #
+  # Placed here, at the end of post_update, because both need the network the
+  # earlier steps have already brought back, and because the updater's
+  # `hermes_edition` step runs immediately AFTER this one and hard-fails when
+  # ~/.local/bin/hermes is not runnable — so the agent has to be repaired first
+  # or the repair and the provisioning would fight each other.
+  #
+  # Both are fast no-ops on a healthy box: step_hermes_install returns after a
+  # `--version` probe, step_llamacpp_model after a single `[ -f ]` test.
+  # step_hermes_install self-gates on has_hermes_harness; step_llamacpp_model
+  # deliberately does not (see its comment).
+  step_hermes_install || echo "  Warning: hermes_install step failed (non-fatal)"
+  step_llamacpp_model || echo "  Warning: llamacpp_model step failed (non-fatal)"
   # Hermes re-provisioning is deliberately NOT called here. The in-app updater
   # dispatches `hermes_edition` as its own step immediately after this one, so a
   # failure is reported instead of swallowed by `|| echo "(non-fatal)"`.
@@ -3193,7 +3293,7 @@ step_validate_services() {
 
 # Steps available for --step dispatch (must have a corresponding step_NAME function)
 DISPATCH_STEPS=(
-  bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install ollama_install llamacpp_install
+  bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install ollama_install llamacpp_install llamacpp_model
   chromium_install ai_tools_install vnc_install vnc_refresh
   openclaw_setup openclaw_install openclaw_patch openclaw_config openclaw_models
   # Edition steps must be dispatchable or no in-app update can ever re-bake the

--- a/install.sh
+++ b/install.sh
@@ -1132,6 +1132,10 @@ step_hermes_install() {
   local agent_dir="$CLAWBOX_HOME/.hermes/hermes-agent"
   local venv_python="$agent_dir/venv/bin/python"
   local installed=""
+  # One constant so the reachability precheck and the install itself can never
+  # drift onto different hosts — a precheck against a URL we then do not use
+  # would be worse than no precheck.
+  local installer_url="https://hermes-agent.nousresearch.com/install.sh"
 
   # `$shim` alone is NOT evidence of an install. It is a 4-line wrapper in
   # ~/.local/bin that execs $venv_python; the agent it points at lives under
@@ -1164,15 +1168,48 @@ step_hermes_install() {
     return 0
   fi
 
+  # NOTHING above this line has modified the disk, and nothing below it does
+  # until the installer is known to be fetchable.
+  #
+  # This matters now in a way it did not before: step_post_update calls this
+  # step on EVERY update on EVERY hermes/dual box, not just on a broken one. So
+  # a false-negative probe — the venv busy, a transient fork failure, anything
+  # that makes `--version` come back empty on a device that is actually fine —
+  # used to reach a `rm -rf "$agent_dir"` and then depend on a network install
+  # that is explicitly non-fatal. On a box with no internet that sequence turns
+  # a healthy agent into no agent, which is the very outcome this file exists
+  # to prevent. Check reachability FIRST and leave the disk alone if the
+  # installer cannot be had.
+  if ! runuser -u "$CLAWBOX_USER" -- \
+    curl -fsS --max-time 30 -o /dev/null "$installer_url"; then
+    echo "  Warning: cannot reach the Hermes installer — leaving the existing agent untouched" >&2
+    return 0
+  fi
+
   if [ -e "$agent_dir" ] || [ -e "$shim" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    # The husk has to go before the reinstall. The upstream installer refuses
-    # outright with "Directory exists but is not a git repository" when
-    # $agent_dir survives as an empty shell — exactly what a factory reset
-    # leaves behind — so without this the reinstall fails and the box stays
-    # bricked. Removing it as ROOT is also required: the root-owned __pycache__
-    # described above is undeletable by the clawbox user the installer runs as.
-    rm -rf "$agent_dir"
+    # The husk has to be out of the way before the reinstall: the upstream
+    # installer refuses outright with "Directory exists but is not a git
+    # repository" when $agent_dir survives as an empty shell — exactly what a
+    # factory reset leaves behind — so without this the reinstall fails and the
+    # box stays bricked.
+    #
+    # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
+    # box had, and this step is no longer only reached by a genuinely broken
+    # device; a rename is just as good for unblocking the installer and is
+    # recoverable when the diagnosis was wrong. A FIXED name rather than a
+    # timestamp keeps at most one husk on a device whose disk is not large — a
+    # per-run stamp would accumulate a git checkout plus a venv on every failed
+    # update. Renaming as ROOT is also required: the root-owned __pycache__
+    # described above is not movable by the clawbox user the installer runs as.
+    if [ -e "$agent_dir" ]; then
+      rm -rf "$agent_dir.broken"
+      if ! mv "$agent_dir" "$agent_dir.broken"; then
+        echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
+        return 0
+      fi
+      echo "  Moved the unusable agent to $agent_dir.broken"
+    fi
     rm -f "$shim"
   fi
 
@@ -1180,7 +1217,7 @@ step_hermes_install() {
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
   # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
   runuser -u "$CLAWBOX_USER" -- bash -c \
-    'curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash' \
+    "curl -fsSL '$installer_url' | bash" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
@@ -1192,7 +1229,15 @@ step_hermes_install() {
     echo "  Hermes installed ($installed)"
   else
     echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
+    # Say where the previous install went, so a wrong diagnosis is reversible
+    # by hand instead of needing a reflash.
+    if [ -e "$agent_dir.broken" ]; then
+      echo "  The previous agent is preserved at $agent_dir.broken" >&2
+    fi
   fi
+  # Explicit: the last command above is a test that is FALSE on the happy path,
+  # and step_post_update reports any non-zero return as a failed step.
+  return 0
 }
 
 # Re-cache ONLY the offline Gemma GGUF.

--- a/install.sh
+++ b/install.sh
@@ -1159,8 +1159,17 @@ step_hermes_install() {
     # `hermes`, so running it under runuser removes the writer entirely.
     # HOME is passed explicitly: hermes resolves ~/.hermes from $HOME, and this
     # function's HOME is /root.
+    #
+    # `|| installed=""` is NOT decoration. This file runs under `set -euo
+    # pipefail`, and a bare assignment takes the exit status of its command
+    # substitution — so a probe that exits non-zero (the exact false-negative
+    # case this step exists to survive) would kill install.sh right here,
+    # before the reachability check and before any repair, printing nothing.
+    # That would break both `install.sh --step hermes_install`, the repair
+    # command scripts/setup-hermes-edition.sh tells the operator to run, and
+    # the full install, which would skip every step after this one.
     installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
-      "$shim" --version 2>/dev/null | head -1)
+      "$shim" --version 2>/dev/null | head -1) || installed=""
   fi
 
   if [ -n "$installed" ]; then
@@ -1180,53 +1189,77 @@ step_hermes_install() {
   # a healthy agent into no agent, which is the very outcome this file exists
   # to prevent. Check reachability FIRST and leave the disk alone if the
   # installer cannot be had.
-  if ! runuser -u "$CLAWBOX_USER" -- \
+  if ! runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     curl -fsS --max-time 30 -o /dev/null "$installer_url"; then
     echo "  Warning: cannot reach the Hermes installer — leaving the existing agent untouched" >&2
     return 0
   fi
 
-  if [ -e "$agent_dir" ] || [ -e "$shim" ]; then
+  # The husk has to be out of the way before the reinstall: the upstream
+  # installer refuses outright with "Directory exists but is not a git
+  # repository" when $agent_dir survives as an empty shell — exactly what a
+  # factory reset leaves behind — so without this the reinstall fails and the
+  # box stays bricked.
+  #
+  # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
+  # box had, and this step is no longer only reached by a genuinely broken
+  # device; a rename is just as good for unblocking the installer and is
+  # recoverable when the diagnosis was wrong. A FIXED name rather than a
+  # timestamp keeps at most one husk on a device whose disk is not large — a
+  # per-run stamp would accumulate a git checkout plus a venv on every failed
+  # update. Renaming as ROOT is also required: the root-owned __pycache__
+  # described above is not movable by the clawbox user the installer runs as.
+  if [ -e "$agent_dir" ]; then
     echo "  Hermes is present but not runnable — reinstalling the agent"
-    # The husk has to be out of the way before the reinstall: the upstream
-    # installer refuses outright with "Directory exists but is not a git
-    # repository" when $agent_dir survives as an empty shell — exactly what a
-    # factory reset leaves behind — so without this the reinstall fails and the
-    # box stays bricked.
-    #
-    # MOVED ASIDE, not deleted. The husk is the only copy of whatever state the
-    # box had, and this step is no longer only reached by a genuinely broken
-    # device; a rename is just as good for unblocking the installer and is
-    # recoverable when the diagnosis was wrong. A FIXED name rather than a
-    # timestamp keeps at most one husk on a device whose disk is not large — a
-    # per-run stamp would accumulate a git checkout plus a venv on every failed
-    # update. Renaming as ROOT is also required: the root-owned __pycache__
-    # described above is not movable by the clawbox user the installer runs as.
-    if [ -e "$agent_dir" ]; then
-      rm -rf "$agent_dir.broken"
-      if ! mv "$agent_dir" "$agent_dir.broken"; then
-        echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
-        return 0
-      fi
+    if [ -e "$agent_dir.broken" ]; then
+      # An earlier repair already saved the owner's checkout. Overwriting it
+      # here would replace it with the partial garbage the failed install left
+      # behind — on a persistently broken box, update #2 would destroy the only
+      # good copy. First husk wins.
+      echo "  Keeping the earlier $agent_dir.broken; discarding the unusable checkout"
+      rm -rf "$agent_dir"
+    elif mv "$agent_dir" "$agent_dir.broken"; then
+      # The husk MUST be deletable by the clawbox user. The factory-reset route
+      # runs as clawbox and keeps only the exact name "hermes-agent", so it
+      # tries to delete this directory — and a root-owned __pycache__ inside it
+      # (written by an older root-run probe) makes that unlink fail with EACCES.
+      # A reset that reports a failure aborts BEFORE the password/WiFi/hostname
+      # reset and the reboot, so the box would be stuck half-reset forever.
+      # install.sh is root here; the reset is not.
+      chown -R "$CLAWBOX_USER:" "$agent_dir.broken"
       echo "  Moved the unusable agent to $agent_dir.broken"
+    else
+      echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
+      return 0
     fi
-    rm -f "$shim"
   fi
+  # A no-op when the shim is absent; a stale shim must never outlive its agent.
+  rm -f "$shim"
 
   echo "  Installing Hermes agent (NousResearch)..."
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
   # the clawbox user so it lands in ~/.hermes and ~/.local/bin.
+  # The URL is passed as an argument rather than spliced into the -c string, so
+  # it stays a single source of truth without shell-quoting exposure.
   runuser -u "$CLAWBOX_USER" -- bash -c \
-    "curl -fsSL '$installer_url' | bash" \
+    'curl -fsSL "$1" | bash' _ "$installer_url" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
   # non-fatal above, so a silent failure here would otherwise be discovered by
   # the owner as a crash-looping dashboard.
+  # `|| installed=""` for the same errexit reason as the first probe: when the
+  # install laid down nothing, this runs a shim that does not exist and exits
+  # 127, which would abort the step before the warning below ever printed.
   installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
-    "$shim" --version 2>/dev/null | head -1)
+    "$shim" --version 2>/dev/null | head -1) || installed=""
   if [ -n "$installed" ]; then
     echo "  Hermes installed ($installed)"
+    # The husk was insurance against a wrong diagnosis, and the new agent
+    # answers --version — so the insurance is over. It costs ~1.9 GB (checkout
+    # plus venv) on a device the comment above calls disk-constrained, and it
+    # is one more directory a later factory reset has to be able to delete.
+    rm -rf "$agent_dir.broken"
   else
     echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
     # Say where the previous install went, so a wrong diagnosis is reversible

--- a/scripts/setup-hermes-edition.sh
+++ b/scripts/setup-hermes-edition.sh
@@ -18,6 +18,7 @@ CLAWBOX_USER="${CLAWBOX_USER:-clawbox}"
 CLAWBOX_HOME="$(getent passwd "$CLAWBOX_USER" | cut -d: -f6)"
 CLAWBOX_HOME="${CLAWBOX_HOME:-/home/$CLAWBOX_USER}"
 HERMES_BIN="${HERMES_BIN:-$CLAWBOX_HOME/.local/bin/hermes}"
+HERMES_VENV_PYTHON="$CLAWBOX_HOME/.hermes/hermes-agent/venv/bin/python"
 EDITION_FILE="/etc/clawbox/edition.env"
 EDITION_DROPIN="/etc/systemd/system/clawbox-setup.service.d/edition.conf"
 
@@ -136,8 +137,14 @@ esac
 log "edition: $EDITION"
 
 # ── 1. Sanity: Hermes must be present (this edition runs on it). ────────────
-if [ ! -x "$HERMES_BIN" ]; then
-  fail "Hermes binary not found/executable at $HERMES_BIN — run: sudo bash $PROJECT_DIR/install.sh --step hermes_install"
+# BOTH halves, deliberately. $HERMES_BIN is a 4-line shim that execs
+# $HERMES_VENV_PYTHON, and it lives outside ~/.hermes — so a factory reset that
+# removed the agent left the shim executable and this check passing on a device
+# whose `hermes` command could not start. That is the same shim-only test that
+# made install.sh report "Hermes already installed ()"; fail loudly here instead
+# of continuing into a Hermes setup with no Hermes.
+if [ ! -x "$HERMES_BIN" ] || [ ! -x "$HERMES_VENV_PYTHON" ]; then
+  fail "Hermes agent not runnable ($HERMES_BIN -> $HERMES_VENV_PYTHON) — run: sudo bash $PROJECT_DIR/install.sh --step hermes_install"
 fi
 
 # ── 2. Shared-identity bridge ───────────────────────────────────────────────

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -42,6 +42,11 @@ const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
 // prompt text out of that log today; narrowing the keep to models/ is what
 // makes it stay true when the config changes, rather than something that has
 // to be re-verified every time llama.cpp is upgraded.
+//
+// Same KNOWN RESIDUAL as the ~/.hermes exception, for the same reasons and
+// with the same verdict — see the "KNOWN RESIDUAL" paragraph in
+// HOME_CONTENT_WIPE_KEEP below: a previous owner with a shell can plant a file
+// in a preserved directory and it survives the reset.
 const LLAMACPP_KEEP = new Set(["models"]);
 
 // Entries under ~/.hermes to preserve — see the .hermes entry in

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -20,13 +20,29 @@ const OPENCLAW_DIR = "/home/clawbox/.openclaw";
 //
 // network.env is hardware-specific and auto-generated.
 //
-// llamacpp/ holds the 3.2 GB offline Gemma GGUF — the same category as the
-// ~/.cache/huggingface voice models the home wipe deliberately keeps below:
-// a reset device reboots into AP mode with no internet, so a deleted model
-// cannot be re-downloaded and the box comes up with no on-device AI at all.
-// It is pure cache, not owner state — no tokens, no chats, no prompts — so
-// keeping it hands the next owner nothing.
+// llamacpp/ survives this top-level pass as a CONTAINER only — it is then
+// wiped entry-by-entry down to LLAMACPP_KEEP below. Spelling it here would
+// otherwise keep the whole subtree.
 const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
+
+// Entries under DATA_DIR/llamacpp to preserve: the models directory, nothing
+// else.
+//
+// models/ holds the 3.2 GB offline Gemma GGUF — the same category as the
+// ~/.cache/huggingface voice models the home wipe deliberately keeps below: a
+// reset device reboots into AP mode with no internet, so a deleted model
+// cannot be re-downloaded and the box comes up with no on-device AI at all.
+// Weights are pure cache, not owner state — no tokens, no chats, no prompts —
+// so keeping them hands the next owner nothing.
+//
+// Its siblings are a different matter. llamacpp/ is also llama-server's
+// runtime scratch (server.pid, server.log), and a log of a LOCAL MODEL is
+// owner-adjacent by nature — what the previous owner asked the offline model
+// is not something a resold box should carry. The shipped server config keeps
+// prompt text out of that log today; narrowing the keep to models/ is what
+// makes it stay true when the config changes, rather than something that has
+// to be re-verified every time llama.cpp is upgraded.
+const LLAMACPP_KEEP = new Set(["models"]);
 
 // Entries under ~/.hermes to preserve — see the .hermes entry in
 // HOME_CONTENT_WIPE_KEEP below for the full reasoning.
@@ -252,6 +268,28 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // on every box of this SKU. Everything Hermes writes about ITS OWNER lands
     // in the siblings above, which this wipe still removes.
     //
+    // KNOWN RESIDUAL, accepted deliberately: a previous owner with a shell
+    // could plant a file inside this one preserved directory and it would
+    // survive the reset. The obvious guard — assert `git status --porcelain`
+    // is empty and wipe the checkout when it is not — was tried and rejected,
+    // because both of its outcomes are worse than the hole:
+    //   * Wiping a "dirty" checkout recreates this very brick. A reset device
+    //     reboots into AP mode with no internet and nothing at boot reinstalls
+    //     the agent, so a false positive leaves the same crash-looping
+    //     dashboard — on every box of the SKU at once, the day upstream starts
+    //     writing into its own checkout. Whether it stays pristine is
+    //     NousResearch's choice, not ours.
+    //   * Reporting it as a failure instead is no better: a non-empty failure
+    //     list aborts the reset (500, no reboot), so the box could not be
+    //     factory reset at all until someone SSHed in.
+    // And it would not stop the attacker it is aimed at: the same shell can
+    // add the payload to .git/info/exclude, or drop it in venv/ — gitignored
+    // upstream, home to the interpreter, and invisible to --porcelain either
+    // way. A guard that a competent adversary steps over while a routine
+    // upstream commit bricks the fleet is a bad trade. Re-provisioning the
+    // agent from upstream after a reset is the real fix, and it needs network
+    // this device does not have at reset time.
+    //
     // Re-provisioning of the removed state is automatic: the dashboard unit
     // runs scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which
     // recreates config.yaml and a fresh password/hash/signing-secret on the
@@ -375,6 +413,13 @@ export async function POST() {
     } catch (err: unknown) {
       if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) throw err;
     }
+    // …then take llamacpp/ down to the weights alone. Kept as a whole subtree
+    // above only so this pass can decide what inside it survives.
+    dataFailures.push(
+      ...(await removeDirectoryContents(path.join(DATA_DIR, "llamacpp"), LLAMACPP_KEEP)).map(
+        (f) => `llamacpp/${f}`,
+      ),
+    );
 
     const openclawFailures = await removeDirectoryContents(OPENCLAW_DIR);
     // ClawKeep state (token, config, passphrase, schedule) lives in its own

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -16,8 +16,21 @@ const execFile = promisify(execFileCb);
 export const dynamic = "force-dynamic";
 const OPENCLAW_DIR = "/home/clawbox/.openclaw";
 
-// Files to preserve during factory reset (hardware-specific, auto-generated)
-const PRESERVE_FILES = new Set(["network.env"]);
+// Entries under DATA_DIR to preserve during factory reset.
+//
+// network.env is hardware-specific and auto-generated.
+//
+// llamacpp/ holds the 3.2 GB offline Gemma GGUF — the same category as the
+// ~/.cache/huggingface voice models the home wipe deliberately keeps below:
+// a reset device reboots into AP mode with no internet, so a deleted model
+// cannot be re-downloaded and the box comes up with no on-device AI at all.
+// It is pure cache, not owner state — no tokens, no chats, no prompts — so
+// keeping it hands the next owner nothing.
+const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
+
+// Entries under ~/.hermes to preserve — see the .hermes entry in
+// HOME_CONTENT_WIPE_KEEP below for the full reasoning.
+const HERMES_KEEP = new Set(["hermes-agent"]);
 
 /** Delete all Ollama models so a factory reset starts with a clean slate. */
 async function deleteOllamaModels(): Promise<void> {
@@ -96,13 +109,14 @@ async function deleteWifiConnections(): Promise<void> {
   }
 }
 
-async function removeDirectoryContents(dir: string): Promise<string[]> {
+async function removeDirectoryContents(dir: string, keep?: ReadonlySet<string>): Promise<string[]> {
   // Background processes (npm install, plugin runtimes) can recreate files
   // between readdir and rm; one retry catches that.
   for (let attempt = 0; attempt < 2; attempt++) {
     let entries: string[];
     try {
       entries = await fs.readdir(dir);
+      if (keep) entries = entries.filter((entry) => !keep.has(entry));
     } catch (err: unknown) {
       if (err && typeof err === "object" && "code" in err && err.code === "ENOENT") return [];
       throw err;
@@ -202,26 +216,55 @@ const HOME_REMOVE_PATHS = [
   ".cache/huggingface/stored_tokens",
   // VS Code server state/extensions from the VSCode app.
   ".local/share/code-server",
-  // Hermes edition state — the Hermes equivalent of ~/.openclaw, and the single
-  // biggest thing a resold box used to hand its next owner. It holds
-  // config.yaml (the providers.clawai billing token, the dashboard's session
-  // SIGNING SECRET and the scrypt password_hash, and a pointer to the chat DB),
-  // config.yaml.bak-* (full prior copies of the same), .env (~24 KB of provider
-  // keys), auth.json (OAuth tokens), plus memories/, logs/, cron/ and pairing/.
-  // The whole directory goes, not a per-file list: the .bak-* copies alone show
-  // how easily a surgical list misses a full duplicate of every secret.
-  //
-  // Nothing preserved. Re-provisioning is automatic — the dashboard unit runs
-  // scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which recreates
-  // config.yaml and a fresh password/hash/signing-secret on the next boot.
-  // (Before that ExecStartPre existed, wiping this would have left the
-  // dashboard with no auth provider on its non-loopback bind and crash-looped
-  // it forever, which is why the wipe had to land together with it.)
-  ".hermes",
 ];
 // User-visible folders the Files app exposes (and recreates empty on demand):
 // wipe the contents, keep the directories.
 const HOME_CONTENT_WIPE_DIRS = ["Documents", "Downloads", "Desktop"];
+
+// Directories wiped entry-by-entry with a NAMED exception list. Same
+// remove-everything default as HOME_REMOVE_PATHS — the exception is spelled
+// out and justified, and anything new that appears in the directory is
+// removed by default rather than kept by default.
+const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<string> }> = [
+  {
+    // Hermes edition state — the Hermes equivalent of ~/.openclaw, and the
+    // single biggest thing a resold box could hand its next owner. It holds
+    // config.yaml (the providers.clawai billing token, the dashboard's session
+    // SIGNING SECRET and the scrypt password_hash, and a pointer to the chat
+    // DB), config.yaml.bak-* (full prior copies of the same), .env (~24 KB of
+    // provider keys), auth.json (OAuth tokens), plus memories/, logs/, cron/,
+    // pairing/, sessions/, skills/ and the state/projects SQLite files. All of
+    // it still goes: this is a wipe with ONE exception, not a keep-list.
+    //
+    // That one exception is hermes-agent/ — and it is not owner state at all.
+    // It is the AGENT INSTALL: a git checkout of NousResearch/hermes-agent
+    // plus the Python venv that ~/.local/bin/hermes (a 4-line shim) execs.
+    // Deleting it was the factory-reset defect this exception fixes. The shim
+    // survives the wipe (it lives in ~/.local/bin), so a reset box was left
+    // with a `hermes` command whose interpreter no longer existed:
+    //   ~/.local/bin/hermes: line 4:
+    //   ~/.hermes/hermes-agent/venv/bin/python: No such file or directory
+    // …and clawbox-hermes-dashboard.service (Restart=always) crash-looping on
+    // status 127 forever. Nothing at boot reinstalls it, and a reset device is
+    // in AP mode with no internet to re-download it — a reflash.
+    //
+    // It carries no secrets to leak: upstream source and a venv, byte-identical
+    // on every box of this SKU. Everything Hermes writes about ITS OWNER lands
+    // in the siblings above, which this wipe still removes.
+    //
+    // Re-provisioning of the removed state is automatic: the dashboard unit
+    // runs scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which
+    // recreates config.yaml and a fresh password/hash/signing-secret on the
+    // next boot.
+    //
+    // Wiping entry-by-entry rather than `rm -rf ~/.hermes` also makes the reset
+    // survivable: each child is removed independently, so one undeletable entry
+    // is reported as a failure instead of aborting the whole subtree with the
+    // agent already half deleted.
+    rel: ".hermes",
+    keep: HERMES_KEEP,
+  },
+];
 
 /**
  * Wipe previous-owner state from the home directory so a factory-reset
@@ -240,6 +283,10 @@ async function wipeHomeUserState(): Promise<string[]> {
   );
   for (const rel of HOME_CONTENT_WIPE_DIRS) {
     const dirFailures = await removeDirectoryContents(path.join(HOME_DIR, rel));
+    failures.push(...dirFailures.map((f) => `${rel}/${f}`));
+  }
+  for (const { rel, keep } of HOME_CONTENT_WIPE_KEEP) {
+    const dirFailures = await removeDirectoryContents(path.join(HOME_DIR, rel), keep);
     failures.push(...dirFailures.map((f) => `${rel}/${f}`));
   }
   // Agent-scheduled cron jobs. `crontab -r` exits non-zero when there is no

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -16,41 +16,37 @@ const execFile = promisify(execFileCb);
 export const dynamic = "force-dynamic";
 const OPENCLAW_DIR = "/home/clawbox/.openclaw";
 
-// Entries under DATA_DIR to preserve during factory reset.
-//
-// network.env is hardware-specific and auto-generated.
-//
-// llamacpp/ survives this top-level pass as a CONTAINER only — it is then
-// wiped entry-by-entry down to LLAMACPP_KEEP below. Spelling it here would
-// otherwise keep the whole subtree.
-const PRESERVE_FILES = new Set(["network.env", "llamacpp"]);
+// Entries under DATA_DIR that survive a factory reset. A `keep` set means the
+// entry survives this top-level pass as a CONTAINER only and is then wiped
+// entry-by-entry down to those names; without one it is kept as it is.
+const DATA_KEEP: ReadonlyArray<{ rel: string; keep?: ReadonlySet<string> }> = [
+  // Hardware-specific and auto-generated.
+  { rel: "network.env" },
+  {
+    // models/ holds the 3.2 GB offline Gemma GGUF — the same category as the
+    // ~/.cache/huggingface voice models the home wipe keeps below: a reset
+    // device reboots into AP mode with no internet, so a deleted model cannot
+    // be re-downloaded and the box comes up with no on-device AI at all.
+    // Weights are pure cache, not owner state — no tokens, no chats, no
+    // prompts — so keeping them hands the next owner nothing. (It also carries
+    // ~24 KB of `hf` download bookkeeping; re-check that if huggingface_hub
+    // ever starts caching credentials under a --local-dir.)
+    //
+    // Its siblings are a different matter: llamacpp/ is also llama-server's
+    // runtime scratch (server.pid, server.log), and a log of a LOCAL MODEL is
+    // owner-adjacent by nature. The shipped server config keeps prompt text
+    // out of that log today; narrowing the keep to models/ is what makes that
+    // stay true when the config changes.
+    //
+    // Same KNOWN RESIDUAL as the ~/.hermes exception below, with the same
+    // verdict: a previous owner with a shell can plant a file in a preserved
+    // directory and it survives the reset.
+    rel: "llamacpp",
+    keep: new Set(["models"]),
+  },
+];
+const DATA_KEEP_NAMES = new Set(DATA_KEEP.map((entry) => entry.rel));
 
-// Entries under DATA_DIR/llamacpp to preserve: the models directory, nothing
-// else.
-//
-// models/ holds the 3.2 GB offline Gemma GGUF — the same category as the
-// ~/.cache/huggingface voice models the home wipe deliberately keeps below: a
-// reset device reboots into AP mode with no internet, so a deleted model
-// cannot be re-downloaded and the box comes up with no on-device AI at all.
-// Weights are pure cache, not owner state — no tokens, no chats, no prompts —
-// so keeping them hands the next owner nothing.
-//
-// Its siblings are a different matter. llamacpp/ is also llama-server's
-// runtime scratch (server.pid, server.log), and a log of a LOCAL MODEL is
-// owner-adjacent by nature — what the previous owner asked the offline model
-// is not something a resold box should carry. The shipped server config keeps
-// prompt text out of that log today; narrowing the keep to models/ is what
-// makes it stay true when the config changes, rather than something that has
-// to be re-verified every time llama.cpp is upgraded.
-//
-// Same KNOWN RESIDUAL as the ~/.hermes exception, for the same reasons and
-// with the same verdict — see the "KNOWN RESIDUAL" paragraph in
-// HOME_CONTENT_WIPE_KEEP below: a previous owner with a shell can plant a file
-// in a preserved directory and it survives the reset.
-const LLAMACPP_KEEP = new Set(["models"]);
-
-// Entries under ~/.hermes to preserve — see the .hermes entry in
-// HOME_CONTENT_WIPE_KEEP below for the full reasoning.
 const HERMES_KEEP = new Set(["hermes-agent"]);
 
 /** Delete all Ollama models so a factory reset starts with a clean slate. */
@@ -249,20 +245,19 @@ const HOME_CONTENT_WIPE_DIRS = ["Documents", "Downloads", "Desktop"];
 const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<string> }> = [
   {
     // Hermes edition state — the Hermes equivalent of ~/.openclaw, and the
-    // single biggest thing a resold box could hand its next owner. It holds
-    // config.yaml (the providers.clawai billing token, the dashboard's session
-    // SIGNING SECRET and the scrypt password_hash, and a pointer to the chat
-    // DB), config.yaml.bak-* (full prior copies of the same), .env (~24 KB of
-    // provider keys), auth.json (OAuth tokens), plus memories/, logs/, cron/,
-    // pairing/, sessions/, skills/ and the state/projects SQLite files. All of
-    // it still goes: this is a wipe with ONE exception, not a keep-list.
+    // single biggest thing a resold box could hand its next owner: config.yaml
+    // (billing token, the dashboard session SIGNING SECRET, the scrypt
+    // password_hash), config.yaml.bak-*, .env (~24 KB of provider keys),
+    // auth.json (OAuth tokens), memories/, logs/, cron/, pairing/, sessions/,
+    // skills/ and the state/projects SQLite files. All of it still goes: this
+    // is a wipe with ONE exception, not a keep-list.
     //
-    // That one exception is hermes-agent/ — and it is not owner state at all.
-    // It is the AGENT INSTALL: a git checkout of NousResearch/hermes-agent
-    // plus the Python venv that ~/.local/bin/hermes (a 4-line shim) execs.
-    // Deleting it was the factory-reset defect this exception fixes. The shim
-    // survives the wipe (it lives in ~/.local/bin), so a reset box was left
-    // with a `hermes` command whose interpreter no longer existed:
+    // That exception is hermes-agent/, and it is not owner state at all. It is
+    // the AGENT INSTALL — a git checkout of NousResearch/hermes-agent plus the
+    // Python venv that ~/.local/bin/hermes (a 4-line shim) execs. Deleting it
+    // was the factory-reset defect this exception fixes: the shim survives the
+    // wipe (it lives in ~/.local/bin), so a reset box was left with a `hermes`
+    // command whose interpreter no longer existed:
     //   ~/.local/bin/hermes: line 4:
     //   ~/.hermes/hermes-agent/venv/bin/python: No such file or directory
     // …and clawbox-hermes-dashboard.service (Restart=always) crash-looping on
@@ -270,30 +265,22 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // in AP mode with no internet to re-download it — a reflash.
     //
     // It carries no secrets to leak: upstream source and a venv, byte-identical
-    // on every box of this SKU. Everything Hermes writes about ITS OWNER lands
-    // in the siblings above, which this wipe still removes.
+    // on every box of this SKU.
     //
     // KNOWN RESIDUAL, accepted deliberately: a previous owner with a shell
     // could plant a file inside this one preserved directory and it would
-    // survive the reset. The obvious guard — assert `git status --porcelain`
-    // is empty and wipe the checkout when it is not — was tried and rejected,
-    // because both of its outcomes are worse than the hole:
-    //   * Wiping a "dirty" checkout recreates this very brick. A reset device
-    //     reboots into AP mode with no internet and nothing at boot reinstalls
-    //     the agent, so a false positive leaves the same crash-looping
-    //     dashboard — on every box of the SKU at once, the day upstream starts
-    //     writing into its own checkout. Whether it stays pristine is
-    //     NousResearch's choice, not ours.
-    //   * Reporting it as a failure instead is no better: a non-empty failure
-    //     list aborts the reset (500, no reboot), so the box could not be
-    //     factory reset at all until someone SSHed in.
-    // And it would not stop the attacker it is aimed at: the same shell can
-    // add the payload to .git/info/exclude, or drop it in venv/ — gitignored
-    // upstream, home to the interpreter, and invisible to --porcelain either
-    // way. A guard that a competent adversary steps over while a routine
-    // upstream commit bricks the fleet is a bad trade. Re-provisioning the
-    // agent from upstream after a reset is the real fix, and it needs network
-    // this device does not have at reset time.
+    // survive the reset. The obvious guard — wipe the checkout unless `git
+    // status --porcelain` is empty — was tried and rejected. Both of its
+    // outcomes are worse than the hole: wiping a "dirty" checkout recreates
+    // this very brick on every box of the SKU at once the day upstream starts
+    // writing into its own checkout (whether it stays pristine is
+    // NousResearch's choice, not ours), and reporting it as a failure instead
+    // aborts the reset (500, no reboot) so the box cannot be reset at all. It
+    // would not stop the attacker either: the same shell can add the payload
+    // to .git/info/exclude or drop it in venv/, gitignored upstream and
+    // invisible to --porcelain. Re-provisioning the agent from upstream after
+    // a reset is the real fix, and it needs network this device does not have
+    // at reset time.
     //
     // Re-provisioning of the removed state is automatic: the dashboard unit
     // runs scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which
@@ -409,7 +396,7 @@ export async function POST() {
       const entries = await fs.readdir(DATA_DIR);
       const results = await Promise.allSettled(
         entries
-          .filter(entry => !PRESERVE_FILES.has(entry))
+          .filter(entry => !DATA_KEEP_NAMES.has(entry))
           .map(entry => fs.rm(path.join(DATA_DIR, entry), { recursive: true, force: true }))
       );
       for (const r of results) {
@@ -418,13 +405,13 @@ export async function POST() {
     } catch (err: unknown) {
       if (!(err && typeof err === "object" && "code" in err && err.code === "ENOENT")) throw err;
     }
-    // …then take llamacpp/ down to the weights alone. Kept as a whole subtree
-    // above only so this pass can decide what inside it survives.
-    dataFailures.push(
-      ...(await removeDirectoryContents(path.join(DATA_DIR, "llamacpp"), LLAMACPP_KEEP)).map(
-        (f) => `llamacpp/${f}`,
-      ),
-    );
+    // …then take each container keep down to its exception list.
+    for (const { rel, keep } of DATA_KEEP) {
+      if (!keep) continue;
+      dataFailures.push(
+        ...(await removeDirectoryContents(path.join(DATA_DIR, rel), keep)).map((f) => `${rel}/${f}`),
+      );
+    }
 
     const openclawFailures = await removeDirectoryContents(OPENCLAW_DIR);
     // ClawKeep state (token, config, passphrase, schedule) lives in its own

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -491,9 +491,27 @@ const UPDATE_STEPS: UpdateStepDef[] = [
     // longer (wait_for_apt alone allows 900s), so an overrun past these 5
     // minutes is advisory: the unit finishes on its own (TimeoutStartSec is
     // 30 min) and everything inside it is non-fatal by design.
+    // 15 min, raised from 5. post_update now also REPAIRS a device that a
+    // pre-fix factory reset left without its Hermes agent install or its
+    // offline Gemma GGUF (step_hermes_install + step_llamacpp_model at the end
+    // of step_post_update). On a healthy box both are sub-second no-ops and
+    // nothing about the timing changes; on a broken one they are a git clone +
+    // venv build (~90s measured) and a 3.2 GB model download, on top of the
+    // fixups that already routinely outlive a minute.
+    //
+    // The raise is not cosmetic. `advisoryOnOverrun` does not pause the
+    // update: it marks the step completed and moves straight on to
+    // `hermes_edition`, which hard-fails when ~/.local/bin/hermes is not yet
+    // runnable. So an overrun DURING the repair would report the repair as
+    // fine and then fail the step after it. The budget has to cover the repair
+    // rather than lean on the advisory path.
+    //
+    // Still well inside the unit's own ceiling (TimeoutStartSec=7200 in
+    // config/clawbox-root-update@.service), and advisoryOnOverrun stays as the
+    // backstop for the genuinely pathological case.
     id: "post_update",
     label: "Applying system fixups",
-    timeoutMs: 300_000,
+    timeoutMs: 900_000,
     requiresRoot: true,
     advisoryOnOverrun: true,
   },

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -442,3 +442,169 @@ describe("POST /setup-api/setup/reset", () => {
     expect(unlinkInputCall).toBeDefined();
   });
 });
+
+/**
+ * A factory reset on a Hermes-edition device used to brick it.
+ *
+ * `.hermes` was in HOME_REMOVE_PATHS as a whole directory, on the (wrong)
+ * belief that it held only owner state. `~/.hermes/hermes-agent/` is the AGENT
+ * INSTALL — the upstream checkout plus the Python venv that the 4-line
+ * `~/.local/bin/hermes` shim execs. The shim lives outside the wipe and
+ * survived it, so the box came up with a `hermes` command whose interpreter was
+ * gone and clawbox-hermes-dashboard.service (Restart=always) crash-looping on
+ * exit 127 forever. The same reset emptied data/, taking the 3.2 GB offline
+ * Gemma GGUF with it — on a device that reboots into AP mode with no internet
+ * to re-download either.
+ *
+ * These tests pin both exceptions, and — just as importantly — pin that
+ * carving them out did not turn the wipe into a keep-list: every
+ * secret-bearing sibling under ~/.hermes must still be removed.
+ */
+describe("POST /setup-api/setup/reset — Hermes agent + offline model survive", () => {
+  let resetPost: () => Promise<Response>;
+  const HOME = process.env.HOME || "/home/clawbox";
+  const HERMES = `${HOME}/.hermes`;
+
+  // What a used Hermes box actually has under ~/.hermes.
+  const HERMES_ENTRIES = [
+    "hermes-agent",
+    "config.yaml",
+    "config.yaml.bak-20260813",
+    ".env",
+    "auth.json",
+    "memories",
+    "logs",
+    "cron",
+    "pairing",
+    "sessions",
+    "skills",
+    "state.db",
+    "projects.db",
+  ];
+  const SECRET_ENTRIES = HERMES_ENTRIES.filter((e) => e !== "hermes-agent");
+
+  const rmTargets = () =>
+    mockFs.rm.mock.calls.map(([p]) => p).filter((p): p is string => typeof p === "string");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: [] }),
+    }));
+    vi.stubGlobal("process", { ...process, getuid: () => 1000, getgid: () => 1000 });
+
+    mockFs.readdir.mockImplementation(((p: string) => {
+      if (p === HERMES) return Promise.resolve(HERMES_ENTRIES);
+      if (p === "/test/data") return Promise.resolve(["config.json", "network.env", "llamacpp", ".session-secret"]);
+      return Promise.resolve([]);
+    }) as unknown as typeof fs.readdir);
+    mockFs.rm.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.chown.mockResolvedValue();
+    mockFs.unlink.mockResolvedValue();
+    mockResetUpdateState.mockReturnValue();
+    setupExecFileMock({ nmcli: { stdout: "", stderr: "" }, systemctl: { stdout: "", stderr: "" } });
+
+    const mod = await import("@/app/setup-api/setup/reset/route");
+    resetPost = mod.POST;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("never removes ~/.hermes/hermes-agent, directly or via its parent", async () => {
+    await resetPost();
+    const targets = rmTargets();
+
+    // The agent install itself.
+    expect(targets).not.toContain(`${HERMES}/hermes-agent`);
+    // And not by taking the whole directory out from under it — the exact
+    // shape of the original defect.
+    expect(targets).not.toContain(HERMES);
+  });
+
+  it("still removes every secret-bearing entry under ~/.hermes", async () => {
+    await resetPost();
+    const targets = rmTargets();
+
+    for (const entry of SECRET_ENTRIES) {
+      expect(targets, `expected ~/.hermes/${entry} to be removed`).toContain(`${HERMES}/${entry}`);
+    }
+  });
+
+  it("removes unknown new entries under ~/.hermes by default", async () => {
+    // The exception is a named allow-list of one. Anything Hermes starts
+    // writing tomorrow must be wiped without a code change, or the fix quietly
+    // becomes a keep-list and the next secret leaks to the next owner.
+    mockFs.readdir.mockImplementation(((p: string) =>
+      Promise.resolve(p === HERMES ? ["hermes-agent", "some-future-token-store"] : [])
+    ) as unknown as typeof fs.readdir);
+
+    await resetPost();
+
+    expect(rmTargets()).toContain(`${HERMES}/some-future-token-store`);
+  });
+
+  it("keeps data/llamacpp (the offline GGUF) while wiping the rest of data/", async () => {
+    await resetPost();
+    const targets = rmTargets();
+
+    expect(targets).not.toContain("/test/data/llamacpp");
+    expect(targets).toContain("/test/data/config.json");
+    expect(targets).toContain("/test/data/.session-secret");
+    // network.env was already preserved; assert it stayed that way.
+    expect(targets).not.toContain("/test/data/network.env");
+  });
+
+  it("one undeletable entry under ~/.hermes does not stop the rest of the wipe", async () => {
+    // Root-owned __pycache__ under ~/.hermes (written by a root-run `hermes
+    // --version`) made `rm -rf ~/.hermes` fail as ONE call, aborting the whole
+    // subtree with the agent already half deleted. Per-entry removal means one
+    // EACCES is reported and the other entries still go.
+    mockFs.rm.mockImplementation(((p: unknown) =>
+      typeof p === "string" && p === `${HERMES}/auth.json`
+        ? Promise.reject(new Error("EACCES: permission denied"))
+        : Promise.resolve()) as unknown as typeof fs.rm);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    const body = await res.json();
+    warnSpy.mockRestore();
+
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(body.failures)).toContain("auth.json");
+    // Everything else still got removed.
+    const targets = rmTargets();
+    for (const entry of SECRET_ENTRIES.filter((e) => e !== "auth.json")) {
+      expect(targets, `expected ~/.hermes/${entry} to still be removed`).toContain(`${HERMES}/${entry}`);
+    }
+  });
+
+  it("a failed wipe leaves the owner able to get back in", async () => {
+    // The abort path does NOT reboot, and the AP only returns on reboot. So a
+    // reset that failed must not have already deleted the WiFi profiles or
+    // reset the login password — that would strand a WiFi-only device offline
+    // with credentials the owner does not have.
+    mockFs.rm.mockImplementation(((p: unknown) =>
+      typeof p === "string" && p.endsWith("auth.json")
+        ? Promise.reject(new Error("EACCES: permission denied"))
+        : Promise.resolve()) as unknown as typeof fs.rm);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const res = await resetPost();
+    warnSpy.mockRestore();
+
+    expect(res.status).toBe(500);
+    const calls = mockExecFile.mock.calls.map(([cmd, args]) => `${cmd} ${(args as string[])?.join(" ")}`);
+    expect(calls.some((c) => c.includes("connection delete"))).toBe(false);
+    expect(calls.some((c) => c.includes("clawbox-root-update@chpasswd"))).toBe(false);
+    expect(calls.some((c) => c.includes("systemctl reboot"))).toBe(false);
+  });
+});

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -499,6 +499,8 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     mockFs.readdir.mockImplementation(((p: string) => {
       if (p === HERMES) return Promise.resolve(HERMES_ENTRIES);
       if (p === "/test/data") return Promise.resolve(["config.json", "network.env", "llamacpp", ".session-secret"]);
+      // llama-server's runtime scratch sits beside the weights.
+      if (p === "/test/data/llamacpp") return Promise.resolve(["models", "server.pid", "server.log"]);
       return Promise.resolve([]);
     }) as unknown as typeof fs.readdir);
     mockFs.rm.mockResolvedValue();
@@ -561,6 +563,36 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     expect(targets).toContain("/test/data/.session-secret");
     // network.env was already preserved; assert it stayed that way.
     expect(targets).not.toContain("/test/data/network.env");
+  });
+
+  it("keeps only the weights inside data/llamacpp — runtime scratch still goes", async () => {
+    // The keep is for the 3.2 GB download a reset device cannot re-fetch, not
+    // for the directory it happens to live in. llamacpp/ is also llama-server's
+    // working directory: server.log is a log of what the previous owner asked
+    // the LOCAL model, which a resold box must not carry. Keeping models/
+    // rather than the subtree means that holds by construction instead of
+    // depending on the current llama-server logging config.
+    await resetPost();
+    const targets = rmTargets();
+
+    expect(targets).toContain("/test/data/llamacpp/server.pid");
+    expect(targets).toContain("/test/data/llamacpp/server.log");
+    expect(targets).not.toContain("/test/data/llamacpp/models");
+  });
+
+  it("removes anything new that appears next to the weights, by default", async () => {
+    // Same property as the ~/.hermes exception: a named allow-list of one, so
+    // whatever llama.cpp starts writing tomorrow is wiped without a code
+    // change rather than inherited by the next owner.
+    mockFs.readdir.mockImplementation(((p: string) => {
+      if (p === "/test/data") return Promise.resolve(["llamacpp"]);
+      if (p === "/test/data/llamacpp") return Promise.resolve(["models", "sessions.jsonl"]);
+      return Promise.resolve([]);
+    }) as unknown as typeof fs.readdir);
+
+    await resetPost();
+
+    expect(rmTargets()).toContain("/test/data/llamacpp/sessions.jsonl");
   });
 
   it("one undeletable entry under ~/.hermes does not stop the rest of the wipe", async () => {

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { readFileSync } from "node:fs";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import fs, { readFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 /**
@@ -31,7 +33,8 @@ import path from "node:path";
  *    repository" and the box stays broken.
  */
 const REPO = process.cwd();
-const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_SH_PATH = path.join(REPO, "install.sh");
+const INSTALL_SH = readFileSync(INSTALL_SH_PATH, "utf-8");
 const UPDATER_TS = readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8");
 
 const NL = String.fromCharCode(10);
@@ -93,14 +96,45 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     expect(alreadyLine).not.toContain("--version");
   });
 
-  it("clears the stale agent husk before reinstalling", () => {
-    expect(HERMES_CODE).toMatch(/rm -rf "\$agent_dir"/);
+  it("moves the stale agent husk aside rather than deleting it", () => {
+    // step_post_update now runs this step on EVERY update on EVERY hermes/dual
+    // box, so the destructive branch is no longer reached only by a device
+    // that is genuinely broken. `rm -rf "$agent_dir"` followed by a network
+    // install that is explicitly non-fatal is a one-way door: one
+    // false-negative probe on a box with no internet and a healthy agent
+    // becomes no agent at all.
+    expect(HERMES_CODE).not.toMatch(/rm -rf "\$agent_dir"\s*$/m);
+    expect(HERMES_CODE).toMatch(/mv "\$agent_dir" "\$agent_dir\.broken"/);
+  });
+
+  it("checks the installer is reachable BEFORE it touches the disk", () => {
+    // Ordering is the whole guarantee: a precheck after the husk is gone
+    // protects nothing.
+    const precheckIdx = HERMES_CODE.indexOf("$installer_url");
+    const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir"');
+    expect(precheckIdx).toBeGreaterThan(-1);
+    expect(mvIdx).toBeGreaterThan(precheckIdx);
+    // …and it must bail out rather than press on.
+    expect(HERMES_CODE).toMatch(/cannot reach the Hermes installer/);
+  });
+
+  it("prechecks and installs from the same URL", () => {
+    // A precheck against a host the install does not then use would be worse
+    // than no precheck — it would report reachable and still fail.
+    const urls = HERMES_CODE.match(/https:\/\/[^\s"']+/g) ?? [];
+    expect(urls.length).toBe(1);
+    expect(HERMES_CODE.match(/\$installer_url/g)?.length).toBe(2);
   });
 
   it("verifies the install afterwards instead of assuming it worked", () => {
     // The upstream installer is fetched over the network and its failure is
     // non-fatal, so the step has to check.
-    const afterInstall = HERMES_CODE.slice(HERMES_CODE.indexOf("hermes-agent.nousresearch.com"));
+    // Anchored on the install invocation itself, not on the URL — the URL now
+    // also appears in the `installer_url` declaration at the top of the
+    // function, which would make this assertion pass vacuously.
+    const installIdx = HERMES_CODE.indexOf("curl -fsSL");
+    expect(installIdx).toBeGreaterThan(-1);
+    const afterInstall = HERMES_CODE.slice(installIdx);
     expect(afterInstall).toContain("--version");
     expect(afterInstall).toMatch(/Warning: Hermes still does not run/);
   });
@@ -196,5 +230,201 @@ describe("llamacpp_model is a cheap, dispatchable step", () => {
     // The factory-reset route wipes data/ on all editions, so an openclaw box
     // needs exactly the same repair.
     expect(LLAMACPP_MODEL).not.toContain("has_hermes_harness");
+  });
+});
+
+/**
+ * Everything above reads install.sh as TEXT. That pins the shape of the code
+ * but not its behaviour: a regex cannot tell whether the branches actually go
+ * where the text suggests, and it is exactly the branch ordering — probe, then
+ * reachability, then move aside, then install — that decides whether a healthy
+ * box survives this step. So drive the real function, with a fake HOME and
+ * stubbed `runuser`/`curl`, and look at what it did to the filesystem.
+ *
+ * Same approach as install-llamacpp-prebuilt.test.ts: lift the one function
+ * out with sed, because sourcing install.sh would install a machine.
+ */
+describe("step_hermes_install — behaviour, driven against a fake HOME", () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-guard-"));
+    // Stands in for both the venv interpreter and the shim: all either has to
+    // do here is exist, be executable, and answer --version.
+    fs.writeFileSync(path.join(tmp, "fake-py"), "#!/bin/sh\necho 'Hermes 9.9.9'\n", { mode: 0o755 });
+  });
+  afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
+
+  const agentDir = () => path.join(tmp, ".hermes", "hermes-agent");
+  const shimPath = () => path.join(tmp, ".local", "bin", "hermes");
+  const exists = (p: string) => fs.existsSync(p);
+
+  /** The shim survives a factory reset — it lives outside ~/.hermes. */
+  function giveShim() {
+    fs.mkdirSync(path.dirname(shimPath()), { recursive: true });
+    fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
+    fs.chmodSync(shimPath(), 0o755);
+  }
+
+  /** An agent checkout, with or without the venv the shim execs. */
+  function giveAgent({ venv }: { venv: boolean }) {
+    fs.mkdirSync(agentDir(), { recursive: true });
+    // Marks THIS checkout, so we can tell "moved aside" from "recreated".
+    fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "original");
+    if (venv) {
+      const binDir = path.join(agentDir(), "venv", "bin");
+      fs.mkdirSync(binDir, { recursive: true });
+      fs.copyFileSync(path.join(tmp, "fake-py"), path.join(binDir, "python"));
+      fs.chmodSync(path.join(binDir, "python"), 0o755);
+    }
+  }
+
+  /**
+   * `reachable` decides what the reachability precheck sees; `installOk`
+   * whether the stubbed installer actually lays down a working agent. The stub
+   * records that it ran, so "did the network install happen at all" is
+   * directly observable.
+   */
+  function run({ reachable = true, installOk = true } = {}) {
+    const script = [
+      "set -u",
+      'CLAWBOX_HOME="$1"',
+      'CLAWBOX_USER="$(id -un)"',
+      'export MARKER="$1/installer-ran"',
+      'export AGENT_DIR="$1/.hermes/hermes-agent"',
+      'export SHIM="$1/.local/bin/hermes"',
+      'export FAKE_PY="$1/fake-py"',
+      'export PRECHECK_RC="$2"',
+      'export INSTALL_OK="$3"',
+      "has_hermes_harness() { return 0; }",
+      // Run the command as this user instead of switching: `runuser -u X -- cmd`.
+      'runuser() { shift 2; [ "$1" = "--" ] && shift; "$@"; }',
+      "curl() {",
+      //  The reachability precheck is the `-o /dev/null` call; anything else is
+      //  the real installer being piped into bash.
+      '  case " $* " in *" -o /dev/null "*) return "$PRECHECK_RC" ;; esac',
+      '  echo ran >> "$MARKER"',
+      '  if [ "$INSTALL_OK" = "1" ]; then',
+      '    mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
+      '    cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
+      '    cp "$FAKE_PY" "$SHIM"',
+      "  fi",
+      '  echo ":"',
+      "}",
+      "export -f curl",
+      "sed -n '/^step_hermes_install() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
+      '. "$1/fn.sh"',
+      // Merged, because the warnings that matter here are all on stderr.
+      "step_hermes_install 2>&1",
+    ].join(NL);
+    try {
+      const out = execFileSync(
+        "bash",
+        ["-c", script, "bash", tmp, reachable ? "0" : "1", installOk ? "1" : "0", INSTALL_SH_PATH],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+      );
+      return { code: 0, out, installerRan: exists(path.join(tmp, "installer-ran")) };
+    } catch (e: unknown) {
+      const err = e as { status?: number; stdout?: string; stderr?: string };
+      return {
+        code: err.status ?? 1,
+        out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
+        installerRan: exists(path.join(tmp, "installer-ran")),
+      };
+    }
+  }
+
+  it("a healthy install is a no-op — nothing touched, nothing fetched", () => {
+    giveShim();
+    giveAgent({ venv: true });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/already installed \(Hermes 9\.9\.9\)/);
+    // Why the reachability precheck sits AFTER the probe: a healthy box makes
+    // no network call at all, on every single update.
+    expect(r.installerRan).toBe(false);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+  });
+
+  it("a shim with no venv is reinstalled — the factory-reset husk case", () => {
+    // What the bench box actually looked like: the shim survived in
+    // ~/.local/bin and ~/.hermes/hermes-agent was a shell with no venv.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.out).not.toMatch(/already installed/);
+    expect(r.installerRan).toBe(true);
+    // Moved aside, not deleted — the old checkout is still recoverable.
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
+    // …and a working agent is in its place.
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\)/);
+  });
+
+  it("a shim with no agent directory reinstalls without inventing a husk", () => {
+    giveShim();
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.installerRan).toBe(true);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+  });
+
+  it("an unreachable installer leaves the existing agent exactly where it is", () => {
+    // The regression this guards: post_update runs this step on every update on
+    // every hermes box, so a probe that comes back empty on a device with no
+    // internet must not be able to destroy a recoverable install.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run({ reachable: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/cannot reach the Hermes installer/);
+    expect(r.installerRan).toBe(false);
+    // Untouched: not moved aside, not deleted, shim still present.
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+    expect(exists(shimPath())).toBe(true);
+  });
+
+  it("a failed install still succeeds as a step, and says where the old agent went", () => {
+    // Non-fatal by design — but it must not go quiet, and the husk it left
+    // behind is the difference between a hand repair and a reflash.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run({ installOk: false });
+
+    // step_post_update's `|| echo` depends on this not being a hard failure,
+    // and the trailing `[ -e ... ]` test must not leak a non-zero status.
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Warning: Hermes still does not run/);
+    expect(r.out).toMatch(/preserved at .*hermes-agent\.broken/);
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
+  });
+
+  it("only ever keeps one husk, so repeated failures cannot fill the disk", () => {
+    giveShim();
+    giveAgent({ venv: false });
+    run({ installOk: false });
+    // Second round: a new husk replaces the first rather than accumulating.
+    giveAgent({ venv: false });
+    fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "second");
+
+    run({ installOk: false });
+
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("second");
+    expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual([
+      "hermes-agent.broken",
+    ]);
   });
 });

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -96,34 +96,40 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     expect(alreadyLine).not.toContain("--version");
   });
 
-  it("moves the stale agent husk aside rather than deleting it", () => {
-    // step_post_update now runs this step on EVERY update on EVERY hermes/dual
-    // box, so the destructive branch is no longer reached only by a device
-    // that is genuinely broken. `rm -rf "$agent_dir"` followed by a network
-    // install that is explicitly non-fatal is a one-way door: one
-    // false-negative probe on a box with no internet and a healthy agent
-    // becomes no agent at all.
-    expect(HERMES_CODE).not.toMatch(/rm -rf "\$agent_dir"\s*$/m);
-    expect(HERMES_CODE).toMatch(/mv "\$agent_dir" "\$agent_dir\.broken"/);
-  });
-
-  it("checks the installer is reachable BEFORE it touches the disk", () => {
-    // Ordering is the whole guarantee: a precheck after the husk is gone
-    // protects nothing.
-    const precheckIdx = HERMES_CODE.indexOf("$installer_url");
-    const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir"');
-    expect(precheckIdx).toBeGreaterThan(-1);
-    expect(mvIdx).toBeGreaterThan(precheckIdx);
-    // …and it must bail out rather than press on.
-    expect(HERMES_CODE).toMatch(/cannot reach the Hermes installer/);
-  });
+  // "moves the husk aside" and "reachability before the husk moves" used to be
+  // asserted here as regexes over the shell text. They are now driven for real
+  // against a fake HOME at the bottom of this file, which is stronger evidence
+  // and does not have to be rewritten every time the branch is reshaped.
 
   it("prechecks and installs from the same URL", () => {
     // A precheck against a host the install does not then use would be worse
-    // than no precheck — it would report reachable and still fail.
-    const urls = HERMES_CODE.match(/https:\/\/[^\s"']+/g) ?? [];
-    expect(urls.length).toBe(1);
-    expect(HERMES_CODE.match(/\$installer_url/g)?.length).toBe(2);
+    // than no precheck — it would report reachable and still fail. Expressed
+    // as: every curl call goes through the one variable, none carries a
+    // literal URL of its own.
+    const curlLines = HERMES_CODE.split(NL).filter((l) => l.includes("curl "));
+    expect(curlLines.length).toBe(2);
+    for (const line of curlLines) {
+      expect(line, `curl must use $installer_url: ${line}`).toContain("$installer_url");
+      expect(line, `curl must not carry its own URL: ${line}`).not.toContain("https://");
+      // …and the URL reaches the install as an ARGUMENT, never spliced into a
+      // `bash -c` string. Harmless while it is a local literal; free to keep
+      // safe if it is ever made configurable.
+      expect(line, `URL must not be interpolated into a shell string: ${line}`).not.toContain(
+        "'$installer_url'",
+      );
+    }
+  });
+
+  it("hands the husk to the clawbox user so a later factory reset can delete it", () => {
+    // Not reachable behaviourally — it needs root and a root-owned file. The
+    // failure it prevents was reproduced on hardware: the husk is a verbatim
+    // `mv` of a tree an older root-run probe wrote __pycache__ into, the reset
+    // route runs as clawbox and does NOT spare a `.broken` name, so the unlink
+    // fails with EACCES, the reset aborts at its failure gate — before the
+    // password/WiFi/hostname reset and the reboot — and returns 500 every time.
+    const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir" "$agent_dir.broken"');
+    expect(mvIdx).toBeGreaterThan(-1);
+    expect(HERMES_CODE.slice(mvIdx)).toMatch(/chown -R "\$CLAWBOX_USER:" "\$agent_dir\.broken"/);
   });
 
   it("verifies the install afterwards instead of assuming it worked", () => {
@@ -157,9 +163,15 @@ describe("step_hermes_install never runs hermes as root", () => {
     // install.sh runs as root (HOME=/root); relying on runuser to reset HOME
     // would point the probe at /root/.hermes.
     const runuserLines = HERMES_CODE.split(NL).filter((l) => l.includes("runuser -u"));
-    expect(runuserLines.length).toBeGreaterThan(0);
+    // Two probes, the reachability precheck, and the installer itself.
+    expect(runuserLines.length).toBe(4);
     for (const line of runuserLines) {
-      if (!line.includes("$shim")) continue;
+      // The upstream installer is the one exception: it is handed to `bash -c`
+      // and resolves the home directory for itself.
+      if (line.includes("bash -c")) continue;
+      // Everything else — the two probes and the reachability precheck — runs
+      // with the same environment, so none of them can quietly read /root's
+      // dotfiles instead of the owner's.
       expect(line, `runuser call must pass HOME: ${line}`).toContain('HOME="$CLAWBOX_HOME"');
     }
   });
@@ -259,10 +271,15 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
   const shimPath = () => path.join(tmp, ".local", "bin", "hermes");
   const exists = (p: string) => fs.existsSync(p);
 
-  /** The shim survives a factory reset — it lives outside ~/.hermes. */
-  function giveShim() {
+  /**
+   * The shim survives a factory reset — it lives outside ~/.hermes.
+   * `answers: false` gives a shim that is present and executable but exits
+   * non-zero, which is what a false-negative probe looks like from here.
+   */
+  function giveShim({ answers = true } = {}) {
     fs.mkdirSync(path.dirname(shimPath()), { recursive: true });
-    fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
+    if (answers) fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
+    else fs.writeFileSync(shimPath(), "#!/bin/sh\nexit 1\n");
     fs.chmodSync(shimPath(), 0o755);
   }
 
@@ -286,8 +303,31 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    * directly observable.
    */
   function run({ reachable = true, installOk = true } = {}) {
+    // The reachability precheck is the `-o /dev/null` call; anything else is
+    // the real installer being fetched to be piped into bash.
+    fs.mkdirSync(path.join(tmp, "bin"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmp, "bin", "curl"),
+      [
+        "#!/bin/sh",
+        'case " $* " in *" -o /dev/null "*) exit "$PRECHECK_RC" ;; esac',
+        'echo ran >> "$MARKER"',
+        'if [ "$INSTALL_OK" = "1" ]; then',
+        '  mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
+        '  cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
+        '  cp "$FAKE_PY" "$SHIM"',
+        "fi",
+        'echo ":"',
+        "",
+      ].join(NL),
+      { mode: 0o755 },
+    );
     const script = [
-      "set -u",
+      // install.sh's OWN options, not a laxer subset. Under `set -e` a probe
+      // assignment that inherits a non-zero status aborts the whole script, so
+      // a harness running with plain `set -u` certifies paths the shipped
+      // script does not actually have.
+      "set -euo pipefail",
       'CLAWBOX_HOME="$1"',
       'CLAWBOX_USER="$(id -un)"',
       'export MARKER="$1/installer-ran"',
@@ -298,20 +338,12 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       'export INSTALL_OK="$3"',
       "has_hermes_harness() { return 0; }",
       // Run the command as this user instead of switching: `runuser -u X -- cmd`.
-      'runuser() { shift 2; [ "$1" = "--" ] && shift; "$@"; }',
-      "curl() {",
-      //  The reachability precheck is the `-o /dev/null` call; anything else is
-      //  the real installer being piped into bash.
-      '  case " $* " in *" -o /dev/null "*) return "$PRECHECK_RC" ;; esac',
-      '  echo ran >> "$MARKER"',
-      '  if [ "$INSTALL_OK" = "1" ]; then',
-      '    mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
-      '    cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
-      '    cp "$FAKE_PY" "$SHIM"',
-      "  fi",
-      '  echo ":"',
-      "}",
-      "export -f curl",
+      'runuser() { shift 2; if [ "$1" = "--" ]; then shift; fi; "$@"; }',
+      // curl is stubbed as a real executable on PATH, not as a shell function:
+      // the reachability precheck runs it through `env`, which does a PATH
+      // lookup and never sees a function. A function stub therefore let the
+      // precheck reach the real network — the test passed for the wrong reason.
+      'export PATH="$1/bin:$PATH"',
       "sed -n '/^step_hermes_install() {/,/^}/p' \"$4\" > \"$1/fn.sh\"",
       '. "$1/fn.sh"',
       // Merged, because the warnings that matter here are all on stderr.
@@ -360,10 +392,30 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(r.code).toBe(0);
     expect(r.out).not.toMatch(/already installed/);
     expect(r.installerRan).toBe(true);
-    // Moved aside, not deleted — the old checkout is still recoverable.
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
-    // …and a working agent is in its place.
+    expect(r.out).toMatch(/Moved the unusable agent to .*hermes-agent\.broken/);
+    // A working agent is in its place…
     expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\)/);
+    // …so the husk has done its job and is gone. It is ~1.9 GB on a
+    // disk-constrained device, and while it exists a factory reset has to be
+    // able to delete it — the reset keeps only the exact name "hermes-agent".
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("a probe that exits non-zero reinstalls instead of killing install.sh", () => {
+    // The false-negative case the whole step is built around, and the one that
+    // errexit turns into a silent death: `installed=$(… | head -1)` inherits
+    // the probe's status, so without `|| installed=""` bash exits right there —
+    // no output, nothing repaired. It takes down `install.sh --step
+    // hermes_install` (the documented repair command) and, in a full install,
+    // every step that follows this one.
+    giveShim({ answers: false });
+    giveAgent({ venv: true });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.installerRan).toBe(true);
     expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\)/);
   });
 
@@ -412,17 +464,21 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
   });
 
-  it("only ever keeps one husk, so repeated failures cannot fill the disk", () => {
+  it("keeps the FIRST husk, so a second failed repair cannot destroy it", () => {
+    // step_post_update runs this on every update, so a persistently broken box
+    // reaches the husk branch again and again. Round 2 must not overwrite the
+    // owner's original checkout with the garbage round 1's failed install left
+    // behind — and one fixed name still bounds the disk cost at a single husk.
     giveShim();
     giveAgent({ venv: false });
     run({ installOk: false });
-    // Second round: a new husk replaces the first rather than accumulating.
+
     giveAgent({ venv: false });
     fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "second");
+    const r = run({ installOk: false });
 
-    run({ installOk: false });
-
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("second");
+    expect(r.out).toMatch(/Keeping the earlier .*hermes-agent\.broken/);
+    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
     expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual([
       "hermes-agent.broken",
     ]);

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * `step_hermes_install` decides whether a device already has a working Hermes
+ * agent. It used to decide it from the wrong file:
+ *
+ *   if [ -x "$CLAWBOX_HOME/.local/bin/hermes" ]; then
+ *     echo "  Hermes already installed ($(… --version 2>/dev/null | head -1))"
+ *     return 0
+ *
+ * `~/.local/bin/hermes` is a 4-line shim that execs
+ * `~/.hermes/hermes-agent/venv/bin/python`. A factory reset removed ~/.hermes
+ * and left the shim, so the guard matched, the `--version` probe returned
+ * EMPTY into an echo whose value nobody looked at, and the step returned
+ * success without reinstalling. Observed verbatim on the bench box:
+ *
+ *   Hermes already installed ()
+ *
+ * That is what made the brick unrecoverable: a full `install.sh` re-run hit the
+ * same guard and did nothing, so the only remaining repair was a reflash.
+ *
+ * Two further properties are pinned here because both were load-bearing on
+ * hardware:
+ *  - the probe must run as the clawbox user (a root-run `hermes --version`
+ *    writes root-owned __pycache__ into a clawbox-owned tree, and the
+ *    factory-reset route — which runs as clawbox — then aborts on EACCES);
+ *  - the reinstall must clear the stale ~/.hermes/hermes-agent husk first, or
+ *    the upstream installer refuses with "Directory exists but is not a git
+ *    repository" and the box stays broken.
+ */
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const UPDATER_TS = readFileSync(path.join(REPO, "src/lib/updater.ts"), "utf-8");
+
+const NL = String.fromCharCode(10);
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf(`${NL}}`, start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return INSTALL_SH.slice(start, end);
+}
+
+/**
+ * The comments inside step_hermes_install quote the OLD buggy code verbatim —
+ * that is the point of them — so an assertion run over the raw text would
+ * match the very thing it is meant to forbid. Strip comment lines, and join
+ * shell line-continuations so a statement split across lines is matched as
+ * the single statement it is.
+ */
+function shellCode(fn: string): string {
+  return fn
+    .split(NL)
+    .filter((line) => !line.trim().startsWith("#"))
+    .join(NL)
+    .replace(new RegExp("\\\\" + NL + "\\s*", "g"), " ");
+}
+
+const HERMES_INSTALL = extractShellFunction("step_hermes_install");
+const HERMES_CODE = shellCode(HERMES_INSTALL);
+
+describe("step_hermes_install treats a shim without an agent as NOT installed", () => {
+  it("does not decide from the shim alone", () => {
+    // The exact shape of the defect: a bare `[ -x .local/bin/hermes ]` test
+    // whose success arm returns 0.
+    expect(HERMES_CODE).not.toMatch(
+      /if\s+\[\s+-x\s+"\$CLAWBOX_HOME\/\.local\/bin\/hermes"\s+\]\s*;\s*then/,
+    );
+  });
+
+  it("requires the venv interpreter the shim execs", () => {
+    // The shim's line 4 execs this path; its absence is the whole failure mode.
+    expect(HERMES_CODE).toContain("$CLAWBOX_HOME/.hermes/hermes-agent");
+    expect(HERMES_CODE).toMatch(/venv_python="\$agent_dir\/venv\/bin\/python"/);
+    expect(HERMES_CODE).toMatch(/\[\s+-x\s+"\$venv_python"\s+\]/);
+  });
+
+  it("requires the --version probe to return something", () => {
+    // `-n "$installed"` is the whole point: an EMPTY probe result must fall
+    // through to the reinstall, not print "already installed ()".
+    expect(HERMES_CODE).toMatch(/if\s+\[\s+-n\s+"\$installed"\s+\]/);
+  });
+
+  it("only says 'already installed' when it has a version to show", () => {
+    const alreadyLine = HERMES_CODE.split(NL).find((l) => l.includes("Hermes already installed"));
+    expect(alreadyLine).toBeDefined();
+    // Interpolates the captured variable, never a bare inline command
+    // substitution whose emptiness goes unchecked.
+    expect(alreadyLine).toContain("$installed");
+    expect(alreadyLine).not.toContain("--version");
+  });
+
+  it("clears the stale agent husk before reinstalling", () => {
+    expect(HERMES_CODE).toMatch(/rm -rf "\$agent_dir"/);
+  });
+
+  it("verifies the install afterwards instead of assuming it worked", () => {
+    // The upstream installer is fetched over the network and its failure is
+    // non-fatal, so the step has to check.
+    const afterInstall = HERMES_CODE.slice(HERMES_CODE.indexOf("hermes-agent.nousresearch.com"));
+    expect(afterInstall).toContain("--version");
+    expect(afterInstall).toMatch(/Warning: Hermes still does not run/);
+  });
+});
+
+describe("step_hermes_install never runs hermes as root", () => {
+  it("every hermes invocation goes through runuser as the clawbox user", () => {
+    const invocations = HERMES_CODE.split(NL).filter(
+      (line) => line.includes("--version") && line.includes("$shim"),
+    );
+    expect(invocations.length).toBeGreaterThan(0);
+    for (const line of invocations) {
+      expect(line, `hermes must not be executed as root: ${line}`).toContain(
+        'runuser -u "$CLAWBOX_USER"',
+      );
+    }
+  });
+
+  it("passes HOME explicitly — hermes resolves ~/.hermes from $HOME", () => {
+    // install.sh runs as root (HOME=/root); relying on runuser to reset HOME
+    // would point the probe at /root/.hermes.
+    const runuserLines = HERMES_CODE.split(NL).filter((l) => l.includes("runuser -u"));
+    expect(runuserLines.length).toBeGreaterThan(0);
+    for (const line of runuserLines) {
+      if (!line.includes("$shim")) continue;
+      expect(line, `runuser call must pass HOME: ${line}`).toContain('HOME="$CLAWBOX_HOME"');
+    }
+  });
+});
+
+describe("an in-app update can heal a device a factory reset broke", () => {
+  const POST_UPDATE = shellCode(extractShellFunction("step_post_update"));
+
+  it("post_update reinstalls the Hermes agent", () => {
+    // Without this the ONLY repair path was SSH. The in-app updater runs
+    // post_update and rebuild_reboot; neither reached step_hermes_install, so
+    // clicking UPDATE on a bricked box did nothing for it.
+    expect(POST_UPDATE).toMatch(/^\s*step_hermes_install\b/m);
+  });
+
+  it("post_update re-caches the offline model", () => {
+    expect(POST_UPDATE).toMatch(/^\s*step_llamacpp_model\b/m);
+  });
+
+  it("both are non-fatal, in the surrounding style", () => {
+    for (const step of ["step_hermes_install", "step_llamacpp_model"]) {
+      const line = POST_UPDATE.split(NL).find((l) => l.trim().startsWith(step));
+      expect(line, `${step} must be called in post_update`).toBeDefined();
+      expect(line, `${step} must not be able to fail the update`).toContain("|| echo");
+    }
+  });
+
+  it("repairs the agent BEFORE the updater's hermes_edition step runs", () => {
+    // setup-hermes-edition.sh hard-fails when ~/.local/bin/hermes is not
+    // executable, and UPDATE_STEPS puts hermes_edition immediately after
+    // post_update — so the repair has to be inside post_update, not after it.
+    const postUpdateIdx = UPDATER_TS.indexOf('id: "post_update"');
+    const hermesEditionIdx = UPDATER_TS.indexOf('id: "hermes_edition"');
+    expect(postUpdateIdx).toBeGreaterThan(-1);
+    expect(hermesEditionIdx).toBeGreaterThan(postUpdateIdx);
+  });
+
+  it("post_update's budget covers the repair rather than leaning on the advisory path", () => {
+    // advisoryOnOverrun does not pause the update — it marks the step complete
+    // and moves on to hermes_edition, which would then fail because the agent
+    // is still mid-install. Measured on hardware: ~90s for the agent, plus a
+    // 3.2 GB model download.
+    const start = UPDATER_TS.indexOf('id: "post_update"');
+    const block = UPDATER_TS.slice(start, start + 400);
+    const match = block.match(/timeoutMs:\s*([\d_]+)/);
+    expect(match).not.toBeNull();
+    const budgetMs = Number(match![1].replace(/_/g, ""));
+    expect(budgetMs).toBeGreaterThanOrEqual(900_000);
+  });
+});
+
+describe("llamacpp_model is a cheap, dispatchable step", () => {
+  const LLAMACPP_MODEL = shellCode(extractShellFunction("step_llamacpp_model"));
+
+  it("is dispatchable by the updater", () => {
+    const open = INSTALL_SH.indexOf("DISPATCH_STEPS=(");
+    const dispatch = INSTALL_SH.slice(open, INSTALL_SH.indexOf(")", open));
+    expect(dispatch).toContain("llamacpp_model");
+  });
+
+  it("does not drag in the ~19-minute native llama.cpp build", () => {
+    expect(LLAMACPP_MODEL).not.toContain("cmake");
+    expect(LLAMACPP_MODEL).not.toContain("llama-server");
+    expect(LLAMACPP_MODEL).toContain("ensure_llamacpp_model_cached");
+  });
+
+  it("is not gated on the Hermes harness — every edition loses the model", () => {
+    // The factory-reset route wipes data/ on all editions, so an openclaw box
+    // needs exactly the same repair.
+    expect(LLAMACPP_MODEL).not.toContain("has_hermes_harness");
+  });
+});

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -412,6 +412,31 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
   });
 
+  it("an interrupted earlier repair left a husk — the husk (the original) wins, the partial tree goes", () => {
+    // State after a power cut or unit timeout between the move and the restore:
+    // ~/.hermes/hermes-agent holds whatever the interrupted installer managed
+    // to write (no venv), and ~/.hermes/hermes-agent.broken is the owner's
+    // original, working checkout.
+    giveShim({ answers: false });
+    giveAgent({ venv: false });
+    const husk = `${agentDir()}.broken`;
+    fs.mkdirSync(path.join(husk, "venv", "bin"), { recursive: true });
+    fs.writeFileSync(path.join(husk, "SENTINEL"), "husk-original");
+    fs.copyFileSync(path.join(tmp, "fake-py"), path.join(husk, "venv", "bin", "python"));
+    fs.chmodSync(path.join(husk, "venv", "bin", "python"), 0o755);
+
+    // The reinstall fails too — so the restore must bring back the HUSK, not
+    // the partial tree. (The old code deleted the husk first and restored the
+    // partial tree: the original was gone for good.)
+    const r = run({ installOk: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Kept the earlier husk/);
+    expect(r.out).toMatch(/Restored the previous agent/);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("husk-original");
+    expect(exists(husk)).toBe(false);
+  });
+
   it("a shim with no venv is reinstalled — the factory-reset husk case", () => {
     // What the bench box actually looked like: the shim survived in
     // ~/.local/bin and ~/.hermes/hermes-agent was a shell with no venv.

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -107,7 +107,7 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     // as: every curl call goes through the one variable, none carries a
     // literal URL of its own.
     const curlLines = HERMES_CODE.split(NL).filter((l) => l.includes("curl "));
-    expect(curlLines.length).toBe(2);
+    expect(curlLines.length).toBeGreaterThan(0);
     for (const line of curlLines) {
       expect(line, `curl must use $installer_url: ${line}`).toContain("$installer_url");
       expect(line, `curl must not carry its own URL: ${line}`).not.toContain("https://");
@@ -129,7 +129,20 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     // password/WiFi/hostname reset and the reboot — and returns 500 every time.
     const mvIdx = HERMES_CODE.indexOf('mv "$agent_dir" "$agent_dir.broken"');
     expect(mvIdx).toBeGreaterThan(-1);
-    expect(HERMES_CODE.slice(mvIdx)).toMatch(/chown -R "\$CLAWBOX_USER:" "\$agent_dir\.broken"/);
+    expect(HERMES_CODE.slice(mvIdx)).toMatch(
+      /chown -R "\$CLAWBOX_USER:\$CLAWBOX_USER" "\$agent_dir\.broken"/,
+    );
+    // …and it must not be able to abort the step: errexit is live at this
+    // function's bare call sites, and the agent is moved aside at this exact
+    // moment, so a chown failure would leave the device with nothing.
+    expect(HERMES_CODE.slice(mvIdx)).toMatch(/chown -R[\s\S]{0,120}\|\| echo/);
+  });
+
+  it("never deletes the shim", () => {
+    // Deleting it on the failure path left the operator with no `hermes`
+    // command at all, and moving the husk back by hand did not bring it back.
+    // On the success path the installer rewrites it anyway.
+    expect(HERMES_CODE).not.toMatch(/rm -f "\$shim"/);
   });
 
   it("verifies the install afterwards instead of assuming it worked", () => {
@@ -163,12 +176,11 @@ describe("step_hermes_install never runs hermes as root", () => {
     // install.sh runs as root (HOME=/root); relying on runuser to reset HOME
     // would point the probe at /root/.hermes.
     const runuserLines = HERMES_CODE.split(NL).filter((l) => l.includes("runuser -u"));
-    // Two probes, the reachability precheck, and the installer itself.
-    expect(runuserLines.length).toBe(4);
+    expect(runuserLines.length).toBeGreaterThan(0);
     for (const line of runuserLines) {
-      // The upstream installer is the one exception: it is handed to `bash -c`
-      // and resolves the home directory for itself.
-      if (line.includes("bash -c")) continue;
+      // The upstream installer is the one exception: it is piped into `bash`,
+      // which resolves the home directory for itself.
+      if (line.includes("| bash")) continue;
       // Everything else — the two probes and the reachability precheck — runs
       // with the same environment, so none of them can quietly read /root's
       // dotfiles instead of the owner's.
@@ -261,8 +273,8 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
   beforeEach(() => {
     tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hermes-guard-"));
-    // Stands in for both the venv interpreter and the shim: all either has to
-    // do here is exist, be executable, and answer --version.
+    // Stands in for the venv interpreter: all it has to do here is exist, be
+    // executable, and answer --version.
     fs.writeFileSync(path.join(tmp, "fake-py"), "#!/bin/sh\necho 'Hermes 9.9.9'\n", { mode: 0o755 });
   });
   afterEach(() => fs.rmSync(tmp, { recursive: true, force: true }));
@@ -278,8 +290,14 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    */
   function giveShim({ answers = true } = {}) {
     fs.mkdirSync(path.dirname(shimPath()), { recursive: true });
-    if (answers) fs.copyFileSync(path.join(tmp, "fake-py"), shimPath());
-    else fs.writeFileSync(shimPath(), "#!/bin/sh\nexit 1\n");
+    // The real shim is 4 lines that exec the venv interpreter, so it answers
+    // only while the agent behind it exists — the property the step now
+    // depends on twice, since it no longer deletes the shim before installing.
+    const venvPython = path.join(agentDir(), "venv", "bin", "python");
+    fs.writeFileSync(
+      shimPath(),
+      answers ? `#!/bin/sh${NL}exec "${venvPython}" "$@"${NL}` : `#!/bin/sh${NL}exit 1${NL}`,
+    );
     fs.chmodSync(shimPath(), 0o755);
   }
 
@@ -302,7 +320,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    * records that it ran, so "did the network install happen at all" is
    * directly observable.
    */
-  function run({ reachable = true, installOk = true } = {}) {
+  function run({ reachable = true, installOk = true, fetchOk = true } = {}) {
     // The reachability precheck is the `-o /dev/null` call; anything else is
     // the real installer being fetched to be piped into bash.
     fs.mkdirSync(path.join(tmp, "bin"), { recursive: true });
@@ -312,6 +330,9 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
         "#!/bin/sh",
         'case " $* " in *" -o /dev/null "*) exit "$PRECHECK_RC" ;; esac',
         'echo ran >> "$MARKER"',
+        // A fetch that fails after the precheck said the host was up: the CDN
+        // answering is not the same as the install succeeding.
+        'if [ "$FETCH_OK" = "0" ]; then exit 22; fi',
         'if [ "$INSTALL_OK" = "1" ]; then',
         '  mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
         '  cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
@@ -336,6 +357,7 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       'export FAKE_PY="$1/fake-py"',
       'export PRECHECK_RC="$2"',
       'export INSTALL_OK="$3"',
+      'export FETCH_OK="$5"',
       "has_hermes_harness() { return 0; }",
       // Run the command as this user instead of switching: `runuser -u X -- cmd`.
       'runuser() { shift 2; if [ "$1" = "--" ]; then shift; fi; "$@"; }',
@@ -352,7 +374,16 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     try {
       const out = execFileSync(
         "bash",
-        ["-c", script, "bash", tmp, reachable ? "0" : "1", installOk ? "1" : "0", INSTALL_SH_PATH],
+        [
+          "-c",
+          script,
+          "bash",
+          tmp,
+          reachable ? "0" : "1",
+          installOk ? "1" : "0",
+          INSTALL_SH_PATH,
+          fetchOk ? "1" : "0",
+        ],
         { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
       );
       return { code: 0, out, installerRan: exists(path.join(tmp, "installer-ran")) };
@@ -448,39 +479,91 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(exists(shimPath())).toBe(true);
   });
 
-  it("a failed install still succeeds as a step, and says where the old agent went", () => {
-    // Non-fatal by design — but it must not go quiet, and the husk it left
-    // behind is the difference between a hand repair and a reflash.
+  it("a failed install puts the previous agent back", () => {
+    // Non-fatal by design — but it must not be one-way. The husk is insurance
+    // against a WRONG diagnosis, so the step has to be able to undo itself.
     giveShim();
     giveAgent({ venv: false });
 
     const r = run({ installOk: false });
 
-    // step_post_update's `|| echo` depends on this not being a hard failure,
-    // and the trailing `[ -e ... ]` test must not leak a non-zero status.
+    // step_post_update's `|| echo` depends on this not being a hard failure.
     expect(r.code).toBe(0);
     expect(r.out).toMatch(/Warning: Hermes still does not run/);
-    expect(r.out).toMatch(/preserved at .*hermes-agent\.broken/);
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
+    expect(r.out).toMatch(/Restored the previous agent/);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    // Nothing parked under another name for an operator to find and move back.
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
   });
 
-  it("keeps the FIRST husk, so a second failed repair cannot destroy it", () => {
-    // step_post_update runs this on every update, so a persistently broken box
-    // reaches the husk branch again and again. Round 2 must not overwrite the
-    // owner's original checkout with the garbage round 1's failed install left
-    // behind — and one fixed name still bounds the disk cost at a single husk.
-    giveShim();
-    giveAgent({ venv: false });
-    run({ installOk: false });
+  it("a healthy agent survives a lying probe plus a failed install", () => {
+    // The worst realistic case, and the reason the restore exists: a box whose
+    // agent works, a probe that comes back non-zero anyway (a fork failure on
+    // an 8 GB device mid-update), a reachable CDN, and an upstream install that
+    // then fails — clone or venv build, neither of which the precheck sees.
+    // step_post_update drives this on EVERY update on EVERY hermes/dual box,
+    // so this path has to leave the device exactly as it found it.
+    giveShim({ answers: false });
+    giveAgent({ venv: true });
 
-    giveAgent({ venv: false });
-    fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "second");
     const r = run({ installOk: false });
 
-    expect(r.out).toMatch(/Keeping the earlier .*hermes-agent\.broken/);
-    expect(fs.readFileSync(path.join(`${agentDir()}.broken`, "SENTINEL"), "utf8")).toBe("original");
-    expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual([
-      "hermes-agent.broken",
-    ]);
+    expect(r.code).toBe(0);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    // The shim has to survive too: without it there is no `hermes` command,
+    // and the next run would find no shim, skip the probe and move the healthy
+    // agent aside all over again.
+    expect(exists(shimPath())).toBe(true);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("repeated failed repairs neither accumulate husks nor lose the original", () => {
+    // step_post_update runs this on every update, so a persistently broken box
+    // reaches this branch again and again. Round 2 must still find the owner's
+    // original checkout, not round 1's leftovers.
+    giveShim();
+    giveAgent({ venv: false });
+
+    run({ installOk: false });
+    const r = run({ installOk: false });
+
+    expect(r.code).toBe(0);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual(
+      [],
+    );
+  });
+
+  it("a fetch failure is reported, not swallowed by the pipe", () => {
+    // `curl … | bash` exits 0 when curl fails — bash just reads empty stdin —
+    // so without `-o pipefail` this warning could never fire and a download
+    // failure looked identical to a successful install.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run({ fetchOk: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Hermes install failed \(non-fatal\)/);
+    // …and the box is still whole.
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+  });
+});
+
+describe("setup-hermes-edition.sh does not repeat the shim-only check", () => {
+  const SETUP_HERMES = readFileSync(path.join(REPO, "scripts/setup-hermes-edition.sh"), "utf-8");
+
+  it("requires the venv interpreter, not just the shim", () => {
+    // This script hard-fails when Hermes is missing — but it tested exactly
+    // the file install.sh's old guard tested. On a factory-reset box the shim
+    // was present and executable, so this check passed and the edition setup
+    // continued on a device with no agent behind it.
+    expect(SETUP_HERMES).toContain(
+      'HERMES_VENV_PYTHON="$CLAWBOX_HOME/.hermes/hermes-agent/venv/bin/python"',
+    );
+    const guard = SETUP_HERMES.split(NL).find((l) => l.includes('[ ! -x "$HERMES_BIN" ]'));
+    expect(guard).toBeDefined();
+    expect(guard).toContain('[ ! -x "$HERMES_VENV_PYTHON" ]');
   });
 });


### PR DESCRIPTION
Hotfix to `main`: cherry-pick of the four commits in #412 (`fix/hermes-factory-reset-brick` → beta), applied cleanly on top of `c35b13a`. The fix patch is byte-identical to the one verified on hardware; the only delta vs #412 is beta-only drift outside the fix (`OPENCLAW_VERSION`).

## Why main, and why now

A factory reset on a Hermes-edition box leaves it non-functional: `~/.hermes` was removed wholesale (the agent install lives in `~/.hermes/hermes-agent`), `data/llamacpp` (the offline model) was removed, and `install.sh`'s `step_hermes_install` guard only tested the `~/.local/bin/hermes` shim — which survives — so a re-run printed `Hermes already installed ()` and repaired nothing. The guard also ran `hermes --version` as root, leaving root-owned `__pycache__` that made the *next* reset abort with EACCES (HTTP 500) after the wipe had already destroyed the agent.

Field boxes pin `.update-branch=main`, and a factory reset dispatches `install.sh` whose bootstrap does `git reset --hard origin/main` — so landing this on beta alone changes nothing for a device in the field. It has to be on main.

## What changes

- **Reset route** — `~/.hermes` is wiped entry-by-entry with one exception (`hermes-agent`); `data/llamacpp/models` is kept (same reasoning the file already applies to the HF voice models: not re-downloadable from AP mode). Every secret-bearing item still goes: `config.yaml`, `config.yaml.bak-*`, `.env`, `auth.json`, `memories/`, `logs/`, `cron/`, `pairing/`, `sessions/`, `skills/`, the SQLite files, `~/.ssh`, `data/config.json`, the login password.
- **`install.sh` `step_hermes_install`** — "installed" now requires the venv interpreter AND a non-empty `--version`, probed under `runuser` as the clawbox user (no more root-owned cache files). Repair is reversible: a broken agent is moved aside, the installer host is checked for reachability first, and on any failure the original agent and the shim are restored untouched. Healthy agents are a 2 s no-op.
- **`step_llamacpp_model`** (new) + **`step_post_update`** now runs `step_hermes_install` and `step_llamacpp_model` (`|| warn`), so the in-app Update heals an already-broken box. Runs on every update on every edition; both are fast no-ops when healthy. If the pinned GGUF is absent it re-downloads 3.2 GB (inside the raised budget).
- **`updater.ts`** — `post_update` budget 300 s → 900 s (the agent install + model re-cache fit inside it; an overrun would have marked the step done and started `hermes_edition`, which hard-fails without the agent).
- **Tests** — 6 reset-route tests + a 16-case behavioural harness that lifts `step_hermes_install` and runs it under install.sh's own `set -euo pipefail`. All proven red on the parent commit.

## Verification (Hermes bench box, serial redacted, JetPack 6.2.2)

Three independent verification rounds; the final round on `e0ab6fd` passed both an adversarial code review and a full hardware pass, every artefact regenerated:

- **Reproduced on released code** (`c35b13a`): reset → HTTP 500 EACCES, shim present, venv gone, `hermes --version` verbatim error, model gone, dashboard crash-looping (`status=127`), `--step hermes_install` a no-op.
- **Healthy agent untouched** by the new update-path step: agent inode/mtime/file count and shim md5 identical before/after.
- **Installer unreachable**: healthy agent untouched; broken agent left in place with a warning, shim not deleted.
- **Healthy agent + false-negative probe + failing upstream install**: original agent restored, shim intact (the round-2 finding, now closed).
- **One-command heal** of a fully bricked box: `sudo bash ~/clawbox/install.sh` → agent reinstalled, model re-cached, `[provision-status] OK`, 0 failed units (255 s).
- **In-app Update heals** a bricked box from wizard steps 1–2 (all 9 update steps green, 156 s post_update). Not reachable from the AI-provider step — the wizard has no back navigation; documented, out of scope.
- **Reset no longer bricks**: with planted secrets, reset → `{"success":true}` HTTP 200 → reboot → factory password, agent preserved in place (same inode), model byte-identical (md5), dashboard up, wizard fresh, every planted secret gone, `data/llamacpp` reduced to `models/` only, 0 root-owned files under `~/.hermes`.

## Known non-blocking follow-ups (separate PR to beta)

- `timeout` on the two `--version` probes (a blocking shim would stall the update path until the 900 s/7200 s backstops).
- Guard the two `rm -rf` calls for the rare read-only/immutable case so a failure cannot nest directories.
- Single-fetch the installer (reachability check and execution currently fetch it twice).
- Retire the remaining regex-over-shell-text assertions in favour of the behavioural harness.
- Note for reviewers: the update path now runs the vendor's `curl … | bash` installer whenever the probe reports the agent unusable — previously only at install time. Same TLS-protected documented path; timing of execution is what changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic recovery for unavailable Hermes installations.
  * Added offline Gemma model re-caching during updates when needed.
  * Extended update timeouts to support repair and model download operations.

* **Bug Fixes**
  * Factory reset now preserves Wi-Fi settings, the Hermes agent installation, and cached models while removing other runtime data.
  * Reset cleanup continues safely after individual errors and reports failures appropriately.

* **Documentation**
  * Updated factory-reset documentation to reflect preserved data and installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->