### PR TITLE
Hermes sign-in works through tunnels: drive provider OAuth from the wizard instead of jumping to :8090

### DIFF
--- a/src/app/setup-api/hermes/oauth/cancel/route.ts
+++ b/src/app/setup-api/hermes/oauth/cancel/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
-import { dashboardUnreachable, hermesGate, isValidSessionId, relayJson } from "../shared";
+import { dashboardUnreachable, hermesGate, isValidSessionId, readJsonBody, relayJson } from "../shared";
 
 // Abandon an in-flight OAuth session (panel unmounted, user hit Start over).
 // Best-effort on the panel's side, but routed anyway so the dashboard doesn't
@@ -13,10 +13,8 @@ export async function DELETE(request: Request) {
   const gate = await hermesGate();
   if (gate) return gate;
 
-  let body: { sessionId?: unknown };
-  try {
-    body = await request.json();
-  } catch {
+  const body = await readJsonBody(request);
+  if (!body) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
   if (!isValidSessionId(body.sessionId)) {

--- a/src/app/setup-api/hermes/oauth/cancel/route.ts
+++ b/src/app/setup-api/hermes/oauth/cancel/route.ts
@@ -1,0 +1,34 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
+import { dashboardUnreachable, hermesGate, isValidSessionId, relayJson } from "../shared";
+
+// Abandon an in-flight OAuth session (panel unmounted, user hit Start over).
+// Best-effort on the panel's side, but routed anyway so the dashboard doesn't
+// accumulate half-open sessions until their expiry.
+const CANCEL_KEYS = ["ok", "status", "message"] as const;
+
+export async function DELETE(request: Request) {
+  const gate = await hermesGate();
+  if (gate) return gate;
+
+  let body: { sessionId?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!isValidSessionId(body.sessionId)) {
+    return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
+  }
+
+  try {
+    const res = await dashboardFetch(`/api/providers/oauth/sessions/${body.sessionId}`, {
+      method: "DELETE",
+    });
+    return await relayJson(res, CANCEL_KEYS);
+  } catch {
+    return dashboardUnreachable();
+  }
+}

--- a/src/app/setup-api/hermes/oauth/poll/route.ts
+++ b/src/app/setup-api/hermes/oauth/poll/route.ts
@@ -1,0 +1,32 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
+import { dashboardUnreachable, hermesGate, isValidProviderId, isValidSessionId, relayJson } from "../shared";
+
+// Poll a device-code session until the user approves it on the provider's
+// verification page. Terminal statuses: "approved" | "error" | "expired";
+// anything else means keep polling.
+const POLL_KEYS = ["session_id", "status", "error_message", "expires_at"] as const;
+
+export async function GET(request: Request) {
+  const gate = await hermesGate();
+  if (gate) return gate;
+
+  const params = new URL(request.url).searchParams;
+  const providerId = params.get("providerId");
+  const sessionId = params.get("sessionId");
+  if (!isValidProviderId(providerId)) {
+    return NextResponse.json({ error: "Invalid provider id" }, { status: 400 });
+  }
+  if (!isValidSessionId(sessionId)) {
+    return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
+  }
+
+  try {
+    const res = await dashboardFetch(`/api/providers/oauth/${providerId}/poll/${sessionId}`);
+    return await relayJson(res, POLL_KEYS);
+  } catch {
+    return dashboardUnreachable();
+  }
+}

--- a/src/app/setup-api/hermes/oauth/route.ts
+++ b/src/app/setup-api/hermes/oauth/route.ts
@@ -6,14 +6,17 @@ import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
 
 // Surface Hermes' native provider-OAuth catalog + connection status so the
 // AI-provider panel can offer "Sign in with Anthropic / OpenAI / …" and show
-// which are already connected. The actual OAuth (PKCE / device-code) is handled
-// by the Hermes dashboard's own /env page — we just read status here and the
-// panel deep-links users into that native flow.
+// which are already connected. The actual OAuth (PKCE / device-code) runs
+// inline in the panel through the start/submit/poll/cancel routes next to this
+// one — never by sending the browser to the dashboard's :8090 proxy, which a
+// tunnel does not forward. `cli_command` rides along for flow "external"
+// providers, whose only sign-in path is the Hermes CLI.
 interface RawOAuthProvider {
   id?: string;
   name?: string;
   flow?: string;
   docs_url?: string;
+  cli_command?: string;
   status?: { logged_in?: boolean };
 }
 
@@ -31,6 +34,7 @@ export async function GET() {
       flow: typeof p.flow === "string" ? p.flow : "",
       loggedIn: Boolean(p.status?.logged_in),
       docsUrl: typeof p.docs_url === "string" ? p.docs_url : undefined,
+      cliCommand: typeof p.cli_command === "string" ? p.cli_command : undefined,
     }));
     return NextResponse.json({ providers });
   } catch {

--- a/src/app/setup-api/hermes/oauth/shared.ts
+++ b/src/app/setup-api/hermes/oauth/shared.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { getActiveHarness } from "@/lib/harness";
+
+// Shared plumbing for the wizard-driven Hermes provider-OAuth routes
+// (start / submit / poll / cancel). These exist so the browser NEVER has to
+// reach the Hermes dashboard itself: the dashboard's auth proxy lives on :8090,
+// which a tunnel or reverse proxy (clawbox-tunnel on :80, Cloudflare quick
+// tunnel) does not forward — sending the user there worked only on the LAN.
+// Instead the wizard talks to these same-origin routes, and the server relays
+// to the dashboard API over dashboardFetch (127.0.0.2:9119, cookie-authed).
+
+// The wizard only ever sends ids it got from GET /setup-api/hermes/oauth, but
+// these values are spliced into a dashboard URL path, so they are charset-
+// guarded here too. Session ids are dashboard-minted opaque tokens
+// (UUID-shaped today); the guard is shape, not meaning.
+const PROVIDER_ID_RE = /^[a-z0-9_-]+$/;
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{8,128}$/;
+
+export function isValidProviderId(value: unknown): value is string {
+  return typeof value === "string" && value.length <= 64 && PROVIDER_ID_RE.test(value);
+}
+
+export function isValidSessionId(value: unknown): value is string {
+  return typeof value === "string" && SESSION_ID_RE.test(value);
+}
+
+/** 404 unless the device runs Hermes — same gate as ../route.ts. */
+export async function hermesGate(): Promise<NextResponse | null> {
+  if ((await getActiveHarness()) !== "hermes") {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+  return null;
+}
+
+/**
+ * Relay a dashboard response to the browser: same status, but only the listed
+ * keys. A whitelist rather than a blanket passthrough because the dashboard's
+ * responses are its own API surface — if it ever grows a field carrying
+ * credential material, that field must not fall out of this route by default.
+ * FastAPI signals errors as `detail`; surface that as `error` so the panel's
+ * existing error handling reads it.
+ */
+export async function relayJson(res: Response, keys: readonly string[]): Promise<NextResponse> {
+  let data: Record<string, unknown> = {};
+  try {
+    data = (await res.json()) as Record<string, unknown>;
+  } catch {
+    // Non-JSON body (dashboard mid-restart); relay the status alone.
+  }
+  const out: Record<string, unknown> = {};
+  for (const key of keys) {
+    if (data[key] !== undefined) out[key] = data[key];
+  }
+  if (!res.ok && typeof out.error !== "string") {
+    const detail = data.detail;
+    const message = data.message;
+    out.error =
+      typeof detail === "string" && detail
+        ? detail
+        : typeof message === "string" && message
+          ? message
+          : `Hermes dashboard error (HTTP ${res.status})`;
+  }
+  return NextResponse.json(out, { status: res.status });
+}
+
+export function dashboardUnreachable(): NextResponse {
+  return NextResponse.json({ error: "Hermes dashboard is unreachable" }, { status: 502 });
+}

--- a/src/app/setup-api/hermes/oauth/shared.ts
+++ b/src/app/setup-api/hermes/oauth/shared.ts
@@ -28,27 +28,45 @@ export function isValidSessionId(value: unknown): value is string {
 // body-size limit, and this server runs on a memory-constrained Jetson.
 // Anything the wizard legitimately sends is under a kilobyte.
 export const MAX_BODY_BYTES = 16 * 1024;
+// Whole-body deadline on top of the byte cap: Node's server-level
+// requestTimeout still allows five minutes of dribbled chunks, each arriving
+// just often enough to hold a handler open. A wizard POST that hasn't fully
+// arrived within this window is not a wizard POST.
+const BODY_READ_TIMEOUT_MS = 10_000;
 
-/** Parse a JSON object body, refusing oversized or malformed input with null. */
+/** Parse a JSON object body, refusing oversized, stalled or malformed input
+ *  with null. */
 export async function readJsonBody(request: Request): Promise<Record<string, unknown> | null> {
   const declared = Number(request.headers.get("content-length"));
   if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) return null;
   let text: string;
   if (request.body) {
-    // Read the stream with a running cap so a chunked body with no (or a lying)
-    // content-length can never be buffered past the limit.
+    // Read the stream with a running byte cap (a chunked body with no — or a
+    // lying — content-length can never be buffered past the limit) and a
+    // deadline (a read that stalls can never hold the handler open).
     const reader = request.body.getReader();
     const chunks: Uint8Array[] = [];
     let received = 0;
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      received += value.byteLength;
-      if (received > MAX_BODY_BYTES) {
-        await reader.cancel().catch(() => {});
-        return null;
+    const deadlineAt = Date.now() + BODY_READ_TIMEOUT_MS;
+    try {
+      for (;;) {
+        const remaining = deadlineAt - Date.now();
+        if (remaining <= 0) throw new Error("body read deadline");
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const step = await Promise.race([
+          reader.read(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error("body read deadline")), remaining);
+          }),
+        ]).finally(() => clearTimeout(timer));
+        if (step.done) break;
+        received += step.value.byteLength;
+        if (received > MAX_BODY_BYTES) throw new Error("body too large");
+        chunks.push(step.value);
       }
-      chunks.push(value);
+    } catch {
+      await reader.cancel().catch(() => {});
+      return null;
     }
     text = Buffer.concat(chunks).toString("utf8");
   } else {

--- a/src/app/setup-api/hermes/oauth/shared.ts
+++ b/src/app/setup-api/hermes/oauth/shared.ts
@@ -24,6 +24,47 @@ export function isValidSessionId(value: unknown): value is string {
   return typeof value === "string" && SESSION_ID_RE.test(value);
 }
 
+// Bound the request body BEFORE JSON.parse — Route Handlers have no built-in
+// body-size limit, and this server runs on a memory-constrained Jetson.
+// Anything the wizard legitimately sends is under a kilobyte.
+export const MAX_BODY_BYTES = 16 * 1024;
+
+/** Parse a JSON object body, refusing oversized or malformed input with null. */
+export async function readJsonBody(request: Request): Promise<Record<string, unknown> | null> {
+  const declared = Number(request.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) return null;
+  let text: string;
+  if (request.body) {
+    // Read the stream with a running cap so a chunked body with no (or a lying)
+    // content-length can never be buffered past the limit.
+    const reader = request.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let received = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > MAX_BODY_BYTES) {
+        await reader.cancel().catch(() => {});
+        return null;
+      }
+      chunks.push(value);
+    }
+    text = Buffer.concat(chunks).toString("utf8");
+  } else {
+    text = await request.text();
+    if (text.length > MAX_BODY_BYTES) return null;
+  }
+  try {
+    const value: unknown = JSON.parse(text);
+    return value && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /** 404 unless the device runs Hermes — same gate as ../route.ts. */
 export async function hermesGate(): Promise<NextResponse | null> {
   if ((await getActiveHarness()) !== "hermes") {

--- a/src/app/setup-api/hermes/oauth/start/route.ts
+++ b/src/app/setup-api/hermes/oauth/start/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
-import { dashboardUnreachable, hermesGate, isValidProviderId, relayJson } from "../shared";
+import { dashboardUnreachable, hermesGate, isValidProviderId, readJsonBody, relayJson } from "../shared";
 
 // Start a Hermes provider-OAuth session on behalf of the wizard. The dashboard
 // answers with the flow it runs for this provider:
@@ -26,10 +26,8 @@ export async function POST(request: Request) {
   const gate = await hermesGate();
   if (gate) return gate;
 
-  let body: { providerId?: unknown };
-  try {
-    body = await request.json();
-  } catch {
+  const body = await readJsonBody(request);
+  if (!body) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
   if (!isValidProviderId(body.providerId)) {

--- a/src/app/setup-api/hermes/oauth/start/route.ts
+++ b/src/app/setup-api/hermes/oauth/start/route.ts
@@ -1,0 +1,48 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
+import { dashboardUnreachable, hermesGate, isValidProviderId, relayJson } from "../shared";
+
+// Start a Hermes provider-OAuth session on behalf of the wizard. The dashboard
+// answers with the flow it runs for this provider:
+//   pkce        → { session_id, flow, auth_url, expires_in } — the panel opens
+//                 auth_url in a new tab and the user pastes the code back
+//   device_code → { session_id, flow, user_code, verification_url, expires_in,
+//                 poll_interval } — the panel shows the code and polls
+// A provider whose flow is "external" (CLI-only) gets a 400 from the dashboard,
+// relayed as-is; the panel never offers Sign in for those.
+const START_KEYS = [
+  "session_id",
+  "flow",
+  "auth_url",
+  "user_code",
+  "verification_url",
+  "expires_in",
+  "poll_interval",
+] as const;
+
+export async function POST(request: Request) {
+  const gate = await hermesGate();
+  if (gate) return gate;
+
+  let body: { providerId?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!isValidProviderId(body.providerId)) {
+    return NextResponse.json({ error: "Invalid provider id" }, { status: 400 });
+  }
+
+  try {
+    const res = await dashboardFetch(`/api/providers/oauth/${body.providerId}/start`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+    });
+    return await relayJson(res, START_KEYS);
+  } catch {
+    return dashboardUnreachable();
+  }
+}

--- a/src/app/setup-api/hermes/oauth/submit/route.ts
+++ b/src/app/setup-api/hermes/oauth/submit/route.ts
@@ -1,0 +1,50 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
+import { dashboardUnreachable, hermesGate, isValidProviderId, isValidSessionId, relayJson } from "../shared";
+
+// Complete a PKCE session with the code the user pasted from the provider's
+// consent page (Anthropic redirects to console.anthropic.com/oauth/code/callback
+// and shows the code there — which is exactly why this works through a tunnel:
+// nothing ever has to redirect back to the device). The dashboard reports
+// failure as { ok:false, status, message }; both shapes relay through.
+const SUBMIT_KEYS = ["ok", "status", "message"] as const;
+
+// The pasted authorization code. Printable ASCII only (Anthropic's includes a
+// "#" separator), bounded, and never a flag-looking value — same posture as
+// the provider-key route's API_KEY_RE.
+const CODE_RE = /^[!-~]{4,2048}$/;
+
+export async function POST(request: Request) {
+  const gate = await hermesGate();
+  if (gate) return gate;
+
+  let body: { providerId?: unknown; sessionId?: unknown; code?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+  if (!isValidProviderId(body.providerId)) {
+    return NextResponse.json({ error: "Invalid provider id" }, { status: 400 });
+  }
+  if (!isValidSessionId(body.sessionId)) {
+    return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
+  }
+  const code = typeof body.code === "string" ? body.code.trim() : "";
+  if (!CODE_RE.test(code)) {
+    return NextResponse.json({ error: "Invalid code" }, { status: 400 });
+  }
+
+  try {
+    const res = await dashboardFetch(`/api/providers/oauth/${body.providerId}/submit`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ session_id: body.sessionId, code }),
+    });
+    return await relayJson(res, SUBMIT_KEYS);
+  } catch {
+    return dashboardUnreachable();
+  }
+}

--- a/src/app/setup-api/hermes/oauth/submit/route.ts
+++ b/src/app/setup-api/hermes/oauth/submit/route.ts
@@ -2,7 +2,14 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
-import { dashboardUnreachable, hermesGate, isValidProviderId, isValidSessionId, relayJson } from "../shared";
+import {
+  dashboardUnreachable,
+  hermesGate,
+  isValidProviderId,
+  isValidSessionId,
+  readJsonBody,
+  relayJson,
+} from "../shared";
 
 // Complete a PKCE session with the code the user pasted from the provider's
 // consent page (Anthropic redirects to console.anthropic.com/oauth/code/callback
@@ -20,10 +27,8 @@ export async function POST(request: Request) {
   const gate = await hermesGate();
   if (gate) return gate;
 
-  let body: { providerId?: unknown; sessionId?: unknown; code?: unknown };
-  try {
-    body = await request.json();
-  } catch {
+  const body = await readJsonBody(request);
+  if (!body) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
   if (!isValidProviderId(body.providerId)) {

--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -45,6 +45,24 @@ interface ClawaiState {
 
 type Status = { kind: "ok" | "err"; msg: string } | null;
 
+// One in-flight provider sign-in, driven entirely from this panel through the
+// same-origin /setup-api/hermes/oauth/* routes. The Hermes dashboard's own
+// OAuth page sits behind the :8090 auth proxy, which remote access
+// (clawbox-tunnel on :80, Cloudflare quick tunnel) does not forward — sending
+// the browser there gave tunnel users a blank tab and no credentials.
+type OauthSignin =
+  | { stage: "starting"; providerId: string }
+  | { stage: "pkce"; providerId: string; sessionId: string; authUrl: string; error?: string }
+  | {
+      stage: "device";
+      providerId: string;
+      sessionId: string;
+      userCode: string;
+      verificationUrl: string;
+      pollMs: number;
+    }
+  | { stage: "failed"; providerId: string; message: string };
+
 interface Props {
   embedded?: boolean;
   onNext?: () => void;
@@ -145,12 +163,50 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
     notifyHermesModelState();
   }, []);
 
+  // ── Inline provider OAuth ──────────────────────────────────────────────────
+  //
+  // Held in a ref as well so unmount cleanup can abandon the dashboard-side
+  // session without the cleanup effect re-running on every state change.
+  const [signin, setSignin] = useState<OauthSignin | null>(null);
+  const signinRef = useRef<OauthSignin | null>(null);
+  useEffect(() => { signinRef.current = signin; }, [signin]);
+  const [oauthCode, setOauthCode] = useState("");
+  const [oauthBusy, setOauthBusy] = useState(false);
+  const [codeCopied, setCodeCopied] = useState(false);
+
+  const cancelOauthSession = useCallback((sessionId: string) => {
+    // Best-effort; keepalive lets the request outlive an unmounting page.
+    void fetch("/setup-api/hermes/oauth/cancel", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId }),
+      keepalive: true,
+    }).catch(() => {});
+  }, []);
+
+  const resetSignin = useCallback(() => {
+    const s = signinRef.current;
+    if (s && (s.stage === "pkce" || s.stage === "device")) cancelOauthSession(s.sessionId);
+    setSignin(null);
+    setOauthCode("");
+    setCodeCopied(false);
+  }, [cancelOauthSession]);
+
+  useEffect(() => () => {
+    // Panel going away mid-flow: don't leave a half-open session on the
+    // dashboard until its expiry.
+    const s = signinRef.current;
+    if (s && (s.stage === "pkce" || s.stage === "device")) cancelOauthSession(s.sessionId);
+  }, [cancelOauthSession]);
+
   const pickProvider = useCallback((id: string) => {
     userPickedProviderRef.current = true;
     setSelectedProvider(id);
     setPicked("");
     setSaveStatus(null);
-  }, []);
+    // A half-finished sign-in belongs to the row being left.
+    resetSignin();
+  }, [resetSignin]);
 
   const isClawaiSelected = selectedProvider === CLAWAI_PROVIDER;
 
@@ -167,7 +223,7 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
   const [loginBusy, setLoginBusy] = useState(false);
 
   // Hermes native provider-OAuth status (anthropic PKCE, openai-codex device-code, …).
-  const [oauth, setOauth] = useState<Record<string, { loggedIn: boolean; flow: string; docsUrl?: string }>>({});
+  const [oauth, setOauth] = useState<Record<string, { loggedIn: boolean; flow: string; docsUrl?: string; cliCommand?: string }>>({});
 
   // ClawBox AI has no model dropdown: its model is derived from the tier and
   // must stay a BARE id (a vendor-prefixed slug gets HTTP 400 "Model not
@@ -245,10 +301,11 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
       const res = await fetch("/setup-api/hermes/oauth", { cache: "no-store" });
       if (!res.ok) return;
       const d = (await res.json()) as {
-        providers?: { id: string; loggedIn: boolean; flow: string; docsUrl?: string }[];
+        providers?: { id: string; loggedIn: boolean; flow: string; docsUrl?: string; cliCommand?: string }[];
       };
-      const map: Record<string, { loggedIn: boolean; flow: string; docsUrl?: string }> = {};
-      for (const p of d.providers ?? []) map[p.id] = { loggedIn: p.loggedIn, flow: p.flow, docsUrl: p.docsUrl };
+      const map: Record<string, { loggedIn: boolean; flow: string; docsUrl?: string; cliCommand?: string }> = {};
+      for (const p of d.providers ?? [])
+        map[p.id] = { loggedIn: p.loggedIn, flow: p.flow, docsUrl: p.docsUrl, cliCommand: p.cliCommand };
       setOauth(map);
     } catch {
       /* OAuth affordances just won't show; non-fatal */
@@ -282,6 +339,145 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
     return () => window.removeEventListener("focus", onFocus);
   }, [loadOauth, refreshModels, notifyChatHeader]);
 
+  // A finished sign-in is a credential appearing server-side — the panel, the
+  // model cache and the chat header all have to re-read, same as the old
+  // return-from-dashboard-tab case. Flip the local flag first so Connected
+  // shows immediately instead of after the status round-trip.
+  const onOauthConnected = useCallback((providerId: string) => {
+    setSignin(null);
+    setOauthCode("");
+    setCodeCopied(false);
+    setOauth((m) => ({ ...m, [providerId]: { ...(m[providerId] ?? { flow: "" }), loggedIn: true } }));
+    void loadOauth();
+    refreshModels();
+    notifyChatHeader();
+  }, [loadOauth, refreshModels, notifyChatHeader]);
+
+  async function startOauth(providerId: string) {
+    resetSignin();
+    setSignin({ stage: "starting", providerId });
+    try {
+      const res = await fetch("/setup-api/hermes/oauth/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerId }),
+      });
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+      if (!res.ok) {
+        throw new Error(typeof data.error === "string" && data.error ? data.error : `HTTP ${res.status}`);
+      }
+      const sessionId = typeof data.session_id === "string" ? data.session_id : "";
+      if (data.flow === "pkce" && sessionId && typeof data.auth_url === "string") {
+        // The provider's consent page ends by SHOWING a code the user copies
+        // back here (Anthropic's redirect_uri is its own console) — nothing
+        // ever redirects back to this origin, which is why the flow survives
+        // any tunnel.
+        window.open(data.auth_url, "_blank", "noopener,noreferrer");
+        setSignin({ stage: "pkce", providerId, sessionId, authUrl: data.auth_url });
+      } else if (data.flow === "device_code" && sessionId) {
+        const interval =
+          typeof data.poll_interval === "number" && data.poll_interval > 0 ? data.poll_interval : 5;
+        setSignin({
+          stage: "device",
+          providerId,
+          sessionId,
+          userCode: typeof data.user_code === "string" ? data.user_code : "",
+          verificationUrl: typeof data.verification_url === "string" ? data.verification_url : "",
+          pollMs: Math.max(3, interval) * 1000,
+        });
+      } else {
+        throw new Error("Unexpected response from Hermes");
+      }
+    } catch (e) {
+      setSignin({
+        stage: "failed",
+        providerId,
+        message: e instanceof Error ? e.message : "Could not start sign-in",
+      });
+    }
+  }
+
+  async function submitOauthCode() {
+    const s = signin;
+    if (!s || s.stage !== "pkce") return;
+    const code = oauthCode.trim();
+    if (!code) return;
+    setOauthBusy(true);
+    try {
+      const res = await fetch("/setup-api/hermes/oauth/submit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ providerId: s.providerId, sessionId: s.sessionId, code }),
+      });
+      const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+      if (!res.ok || data.ok === false) {
+        const msg =
+          typeof data.message === "string" && data.message
+            ? data.message
+            : typeof data.error === "string" && data.error
+              ? data.error
+              : `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
+      onOauthConnected(s.providerId);
+    } catch (e) {
+      // Stay on the paste step: a mistyped code must not force a new session.
+      setSignin({ ...s, error: e instanceof Error ? e.message : "Code was not accepted" });
+    } finally {
+      setOauthBusy(false);
+    }
+  }
+
+  // Device-code sessions resolve out of band (the user approves on the
+  // provider's site), so poll until a terminal status. Recursive timeout, not
+  // an interval: a slow relay must never stack requests.
+  useEffect(() => {
+    if (!signin || signin.stage !== "device") return;
+    const { providerId, sessionId, pollMs } = signin;
+    let alive = true;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
+      let terminal = false;
+      try {
+        const res = await fetch(
+          `/setup-api/hermes/oauth/poll?providerId=${encodeURIComponent(providerId)}&sessionId=${encodeURIComponent(sessionId)}`,
+          { cache: "no-store" },
+        );
+        const data = (await res.json().catch(() => ({}))) as { status?: unknown; error_message?: unknown };
+        if (!alive) return;
+        const status = typeof data.status === "string" ? data.status : "";
+        if (status === "approved") {
+          terminal = true;
+          onOauthConnected(providerId);
+        } else if (status === "error" || status === "expired") {
+          terminal = true;
+          setSignin({
+            stage: "failed",
+            providerId,
+            message:
+              typeof data.error_message === "string" && data.error_message
+                ? data.error_message
+                : status === "expired"
+                  ? "The sign-in request expired. Try again."
+                  : "Sign-in failed. Try again.",
+          });
+        }
+      } catch {
+        // Transient relay error: keep polling until the session itself expires.
+      }
+      if (alive && !terminal) timer = setTimeout(tick, pollMs);
+    };
+    timer = setTimeout(tick, pollMs);
+    return () => { alive = false; clearTimeout(timer); };
+  }, [signin, onOauthConnected]);
+
+  function copyUserCode(code: string) {
+    void navigator.clipboard?.writeText(code).then(
+      () => setCodeCopied(true),
+      () => {},
+    );
+  }
+
   const changeUiTier = useCallback((tier: ClawaiTier) => {
     setUiTier(tier);
     setClawaiStatus(null);
@@ -314,8 +510,9 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
     onError: (msg) => setClawaiStatus({ kind: "err", msg }),
   });
 
-  // Open the Hermes dashboard's /env page (via the auth-gated proxy on :8090),
-  // where its native OAuth (PKCE / device-code) runs. Same host, dashboard port.
+  // ADVANCED FALLBACK ONLY: the Hermes dashboard's /env page via its auth-gated
+  // proxy on :8090. LAN-only — tunnels don't forward that port, which is
+  // exactly why the inline flow above exists; nothing depends on this link.
   // The flag is what the focus listener above keys on: we only re-check (and
   // pay for a live provider re-enumeration) when the user actually went off to
   // sign in, not on every incidental tab switch.
@@ -586,34 +783,166 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
           ) : (
             <div className="space-y-4">
               {selectedDef?.oauthId && (() => {
-                const st = oauth[selectedDef.oauthId];
+                const oauthId = selectedDef.oauthId;
+                const st = oauth[oauthId];
                 const connected = st?.loggedIn;
+                const external = st?.flow === "external";
+                const flow = signin && signin.providerId === oauthId ? signin : null;
+                const showSignInButton = !connected && !external && (!flow || flow.stage === "failed");
                 return (
                   <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--bg-deep)]/50 p-3">
                     <div className="flex items-center justify-between gap-3">
                       <div className="min-w-0">
                         <p className="text-sm font-medium text-gray-200">Sign in with {selectedDef.name}</p>
                         <p className="text-xs text-[var(--text-muted)]">
-                          {connected ? "Connected — OAuth credentials active." : "OAuth through Hermes (no API key needed)."}
+                          {connected
+                            ? "Connected. OAuth credentials active."
+                            : external
+                              ? "This provider signs in through the Hermes CLI."
+                              : "OAuth through Hermes (no API key needed)."}
                         </p>
                       </div>
-                      {connected ? (
+                      {connected && (
                         <span className="shrink-0 flex items-center gap-1 text-xs font-semibold text-emerald-400">
                           <span className="material-symbols-rounded" style={{ fontSize: 14 }}>check_circle</span>
                           Connected
                         </span>
-                      ) : (
+                      )}
+                      {showSignInButton && (
                         <button
                           type="button"
-                          onClick={openHermesOAuth}
+                          onClick={() => { void startOauth(oauthId); }}
                           className="shrink-0 rounded-lg bg-[var(--coral-bright)] px-3 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity"
                         >
-                          Sign in ↗
+                          {flow?.stage === "failed" ? "Try again" : "Sign in"}
                         </button>
                       )}
                     </div>
+                    {!connected && external && st?.cliCommand && (
+                      <div className="mt-3">
+                        <p className="text-xs text-[var(--text-muted)]">
+                          Run this in the device terminal, then reopen this panel:
+                        </p>
+                        <code className="mt-1.5 block rounded-lg bg-[var(--bg-deep)] border border-[var(--border-subtle)] px-3 py-2 text-xs font-mono text-[var(--text-primary)] overflow-x-auto">
+                          {st.cliCommand}
+                        </code>
+                      </div>
+                    )}
+                    {!connected && flow?.stage === "starting" && (
+                      <p className="mt-3 text-xs text-[var(--text-muted)]" role="status" aria-live="polite">
+                        Starting sign-in with {selectedDef.name}...
+                      </p>
+                    )}
+                    {!connected && flow?.stage === "pkce" && (
+                      <div className="mt-3 space-y-2">
+                        <p className="text-xs text-[var(--text-muted)]">
+                          A {selectedDef.name} sign-in tab has opened. Approve access there, copy the code it
+                          shows, and paste it here.{" "}
+                          <a
+                            href={flow.authUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline text-[var(--text-secondary)]"
+                          >
+                            Reopen the sign-in page
+                          </a>
+                        </p>
+                        <label className="sr-only" htmlFor={`${uid}-oauth-code`}>
+                          Paste the code from {selectedDef.name}
+                        </label>
+                        <input
+                          id={`${uid}-oauth-code`}
+                          type="text"
+                          className={selectCls}
+                          placeholder={`Paste the code from ${selectedDef.name}`}
+                          value={oauthCode}
+                          autoComplete="off"
+                          onChange={(e) => setOauthCode(e.target.value)}
+                        />
+                        <div className="flex items-center gap-3">
+                          <button
+                            type="button"
+                            onClick={() => { void submitOauthCode(); }}
+                            disabled={oauthBusy || !oauthCode.trim()}
+                            className="rounded-lg bg-[var(--coral-bright)] px-3 py-2 text-sm font-semibold text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+                          >
+                            {oauthBusy ? "Submitting..." : "Submit code"}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={resetSignin}
+                            className="text-xs text-[var(--text-muted)] underline hover:text-[var(--text-secondary)]"
+                          >
+                            Start over
+                          </button>
+                        </div>
+                        {flow.error && (
+                          <p role="alert" aria-live="polite" className="text-xs text-red-400">{flow.error}</p>
+                        )}
+                      </div>
+                    )}
+                    {!connected && flow?.stage === "device" && (
+                      <div className="mt-3 space-y-2">
+                        <p className="text-xs text-[var(--text-muted)]">
+                          Enter this code on the {selectedDef.name} verification page. This panel updates by
+                          itself once you approve.
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <span
+                            data-testid="hermes-oauth-user-code"
+                            className="rounded-lg bg-[var(--bg-deep)] border border-[var(--border-subtle)] px-3 py-2 text-base font-mono font-semibold tracking-widest text-[var(--text-primary)]"
+                          >
+                            {flow.userCode}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => copyUserCode(flow.userCode)}
+                            className="rounded-lg border border-[var(--border-subtle)] px-2.5 py-2 text-xs font-semibold text-[var(--text-secondary)] hover:bg-[var(--surface-card)] transition-colors"
+                          >
+                            {codeCopied ? "Copied" : "Copy code"}
+                          </button>
+                        </div>
+                        {flow.verificationUrl && (
+                          <a
+                            href={flow.verificationUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="inline-block text-xs font-semibold text-[var(--coral-bright)] underline"
+                          >
+                            Open the verification page
+                          </a>
+                        )}
+                        <div className="flex items-center gap-3">
+                          <p className="text-xs text-[var(--text-muted)]" role="status" aria-live="polite">
+                            Waiting for approval...
+                          </p>
+                          <button
+                            type="button"
+                            onClick={resetSignin}
+                            className="text-xs text-[var(--text-muted)] underline hover:text-[var(--text-secondary)]"
+                          >
+                            Start over
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                    {!connected && flow?.stage === "failed" && (
+                      <p role="alert" aria-live="polite" className="mt-2 text-xs text-red-400">{flow.message}</p>
+                    )}
                     {selectedDef.keyProvider && (
                       <p className="text-[11px] text-[var(--text-muted)] mt-2">…or paste an API key below instead.</p>
+                    )}
+                    {!connected && !external && (
+                      <p className="mt-2 text-[11px] text-[var(--text-muted)]">
+                        Advanced:{" "}
+                        <button
+                          type="button"
+                          onClick={openHermesOAuth}
+                          className="underline hover:text-[var(--text-secondary)]"
+                        >
+                          Hermes dashboard (LAN only)
+                        </button>
+                      </p>
                     )}
                   </div>
                 );

--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -6,6 +6,7 @@ import ClawboxAiProviderRow from "./ClawboxAiProviderRow";
 import ClawboxAiPlanPicker from "./ClawboxAiPlanPicker";
 import ClawboxAiDeviceLogin from "./ClawboxAiDeviceLogin";
 import { useClawaiDeviceLogin } from "@/hooks/useClawaiDeviceLogin";
+import { copyToClipboard } from "@/lib/clipboard";
 import { notifyHermesModelState, useHermesModelOptions } from "@/hooks/useHermesModelOptions";
 import {
   HERMES_PANEL_PROVIDERS,
@@ -472,10 +473,9 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
   }, [signin, onOauthConnected]);
 
   function copyUserCode(code: string) {
-    void navigator.clipboard?.writeText(code).then(
-      () => setCodeCopied(true),
-      () => {},
-    );
+    // copyToClipboard, not navigator.clipboard directly: the device is served
+    // over plain http on the LAN, where the async clipboard API doesn't exist.
+    void copyToClipboard(code).then((ok) => setCodeCopied(ok));
   }
 
   const changeUiTier = useCallback((tier: ClawaiTier) => {

--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -61,8 +61,23 @@ type OauthSignin =
       userCode: string;
       verificationUrl: string;
       pollMs: number;
+      /** Epoch ms; the poll loop's hard deadline, from the session's expires_in. */
+      expiresAt: number;
     }
   | { stage: "failed"; providerId: string; message: string };
+
+/** Only ever open or render a dashboard-supplied URL if it is plain http(s) —
+ *  anything else (javascript:, data:, a bare token) must not reach window.open
+ *  or an href. */
+function isHttpUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
 
 interface Props {
   embedded?: boolean;
@@ -174,6 +189,11 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
   const [oauthCode, setOauthCode] = useState("");
   const [oauthBusy, setOauthBusy] = useState(false);
   const [codeCopied, setCodeCopied] = useState(false);
+  // Bumped by every reset/unmount so a /start response that lands AFTER the
+  // user moved on (switched rows, hit Start over, left the panel) knows it was
+  // abandoned and hands its session straight back to the dashboard instead of
+  // resurrecting a flow nobody is looking at.
+  const signinGenRef = useRef(0);
 
   const cancelOauthSession = useCallback((sessionId: string) => {
     // Best-effort; keepalive lets the request outlive an unmounting page.
@@ -187,6 +207,7 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
 
   const resetSignin = useCallback(() => {
     const s = signinRef.current;
+    signinGenRef.current += 1;
     if (s && (s.stage === "pkce" || s.stage === "device")) cancelOauthSession(s.sessionId);
     setSignin(null);
     setOauthCode("");
@@ -197,6 +218,7 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
     // Panel going away mid-flow: don't leave a half-open session on the
     // dashboard until its expiry.
     const s = signinRef.current;
+    signinGenRef.current += 1;
     if (s && (s.stage === "pkce" || s.stage === "device")) cancelOauthSession(s.sessionId);
   }, [cancelOauthSession]);
 
@@ -356,6 +378,7 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
 
   async function startOauth(providerId: string) {
     resetSignin();
+    const gen = signinGenRef.current;
     setSignin({ stage: "starting", providerId });
     try {
       const res = await fetch("/setup-api/hermes/oauth/start", {
@@ -368,7 +391,12 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
         throw new Error(typeof data.error === "string" && data.error ? data.error : `HTTP ${res.status}`);
       }
       const sessionId = typeof data.session_id === "string" ? data.session_id : "";
-      if (data.flow === "pkce" && sessionId && typeof data.auth_url === "string") {
+      if (gen !== signinGenRef.current) {
+        // Abandoned mid-start: give the session back instead of leaking it.
+        if (sessionId) cancelOauthSession(sessionId);
+        return;
+      }
+      if (data.flow === "pkce" && sessionId && isHttpUrl(data.auth_url)) {
         // The provider's consent page ends by SHOWING a code the user copies
         // back here (Anthropic's redirect_uri is its own console) — nothing
         // ever redirects back to this origin, which is why the flow survives
@@ -378,18 +406,22 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
       } else if (data.flow === "device_code" && sessionId) {
         const interval =
           typeof data.poll_interval === "number" && data.poll_interval > 0 ? data.poll_interval : 5;
+        const expiresIn =
+          typeof data.expires_in === "number" && data.expires_in > 0 ? data.expires_in : 900;
         setSignin({
           stage: "device",
           providerId,
           sessionId,
           userCode: typeof data.user_code === "string" ? data.user_code : "",
-          verificationUrl: typeof data.verification_url === "string" ? data.verification_url : "",
+          verificationUrl: isHttpUrl(data.verification_url) ? data.verification_url : "",
           pollMs: Math.max(3, interval) * 1000,
+          expiresAt: Date.now() + expiresIn * 1000,
         });
       } else {
         throw new Error("Unexpected response from Hermes");
       }
     } catch (e) {
+      if (gen !== signinGenRef.current) return;
       setSignin({
         stage: "failed",
         providerId,
@@ -434,11 +466,22 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
   // an interval: a slow relay must never stack requests.
   useEffect(() => {
     if (!signin || signin.stage !== "device") return;
-    const { providerId, sessionId, pollMs } = signin;
+    const { providerId, sessionId, pollMs, expiresAt } = signin;
     let alive = true;
     let timer: ReturnType<typeof setTimeout>;
     const tick = async () => {
       let terminal = false;
+      // Hard deadline from the session's own expires_in: even if every poll
+      // errors (relay down, dashboard restarting), the loop cannot outlive the
+      // session it is polling for.
+      if (Date.now() >= expiresAt) {
+        setSignin({
+          stage: "failed",
+          providerId,
+          message: "The sign-in request expired. Try again.",
+        });
+        return;
+      }
       try {
         const res = await fetch(
           `/setup-api/hermes/oauth/poll?providerId=${encodeURIComponent(providerId)}&sessionId=${encodeURIComponent(sessionId)}`,

--- a/src/tests/components/hermes-oauth-inline.test.tsx
+++ b/src/tests/components/hermes-oauth-inline.test.tsx
@@ -205,6 +205,48 @@ describe("HermesProviderConfig inline OAuth", () => {
     expect(openMock).not.toHaveBeenCalled();
   });
 
+  it("cancels the dashboard session when the user starts over mid-flow", async () => {
+    const fetchMock = stubFetch();
+
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: /Anthropic/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Sign in$/ }));
+    await screen.findByPlaceholderText("Paste the code from Anthropic");
+
+    fireEvent.click(screen.getByRole("button", { name: /Start over/ }));
+
+    await waitFor(() => {
+      const cancelCall = fetchMock.mock.calls.find(([u]) => String(u) === "/setup-api/hermes/oauth/cancel");
+      expect(cancelCall).toBeTruthy();
+      expect(JSON.parse(String(cancelCall?.[1]?.body))).toEqual({ sessionId: "sess-anthropic-1" });
+    });
+    // Back to the idle state, ready to start a fresh session.
+    expect(await screen.findByRole("button", { name: /^Sign in$/ })).toBeInTheDocument();
+  });
+
+  it("copies the device code and confirms with Copied", async () => {
+    stubFetch();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: /OpenAI/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Sign in$/ }));
+    await screen.findByTestId("hermes-oauth-user-code");
+
+    fireEvent.click(screen.getByRole("button", { name: /Copy code/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Copied/ })).toBeInTheDocument();
+    });
+    expect(writeText).toHaveBeenCalledWith("ABCD-1234");
+  });
+
   it("shows the CLI command instead of a Sign in button for an external-flow provider", async () => {
     stubFetch();
 

--- a/src/tests/components/hermes-oauth-inline.test.tsx
+++ b/src/tests/components/hermes-oauth-inline.test.tsx
@@ -225,6 +225,73 @@ describe("HermesProviderConfig inline OAuth", () => {
     expect(await screen.findByRole("button", { name: /^Sign in$/ })).toBeInTheDocument();
   });
 
+  it("cancels a session minted by a /start that resolves after the user moved on", async () => {
+    // Own stub: /start must stay pending until after the user abandons the
+    // flow (switches rows — the only abandon affordance while stage is
+    // "starting"), so the generation-token branch is what handles the late
+    // session, not the normal reset path.
+    let resolveStart!: () => void;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? "GET";
+      if (url === "/setup-api/hermes/clawai") {
+        return {
+          ok: true,
+          json: async () => ({ hasToken: false, tier: "flash", tierStored: null, active: false, model: "" }),
+        } as Response;
+      }
+      if (url === "/setup-api/hermes/oauth") {
+        return {
+          ok: true,
+          json: async () => ({
+            providers: [{ id: "anthropic", name: "Anthropic", loggedIn: false, flow: "pkce" }],
+          }),
+        } as Response;
+      }
+      if (url === "/setup-api/hermes/oauth/start" && method === "POST") {
+        return new Promise<Response>((resolve) => {
+          resolveStart = () =>
+            resolve({
+              ok: true,
+              json: async () => ({
+                session_id: "sess-late-1",
+                flow: "pkce",
+                auth_url: "https://claude.ai/oauth/authorize?x=1",
+                expires_in: 600,
+              }),
+            } as Response);
+        });
+      }
+      if (url === "/setup-api/hermes/oauth/cancel") {
+        return { ok: true, json: async () => ({ ok: true }) } as Response;
+      }
+      if (url === "/setup-api/hermes/models") {
+        return { ok: true, json: async () => ({ provider: "openrouter" }) } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: /Anthropic/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Sign in$/ }));
+    await screen.findByText("Starting sign-in with Anthropic...");
+
+    // Abandon while /start is still in flight, then let it resolve late.
+    fireEvent.click(screen.getByRole("radio", { name: /OpenRouter/ }));
+    resolveStart();
+
+    await waitFor(() => {
+      const cancelCall = fetchMock.mock.calls.find(([u]) => String(u) === "/setup-api/hermes/oauth/cancel");
+      expect(cancelCall).toBeTruthy();
+      expect(JSON.parse(String(cancelCall?.[1]?.body))).toEqual({ sessionId: "sess-late-1" });
+    });
+    // The dead flow must not resurrect: no paste step, no consent tab.
+    expect(screen.queryByPlaceholderText("Paste the code from Anthropic")).not.toBeInTheDocument();
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
   it("copies the device code and confirms with Copied", async () => {
     stubFetch();
     const writeText = vi.fn().mockResolvedValue(undefined);

--- a/src/tests/components/hermes-oauth-inline.test.tsx
+++ b/src/tests/components/hermes-oauth-inline.test.tsx
@@ -1,0 +1,219 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import HermesProviderConfig from "@/components/HermesProviderConfig";
+
+// The inline provider sign-in that replaced the jump to the Hermes dashboard's
+// :8090 proxy (unreachable through clawbox-tunnel / Cloudflare tunnels). The
+// whole flow must run inside this panel against same-origin /setup-api routes:
+// pkce opens the provider's page and takes a pasted code; device_code shows the
+// user code and waits; external shows the CLI command instead of a button.
+
+vi.mock("@/lib/i18n", () => ({
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useT: () => ({ t: (key: string) => key, locale: "en", setLocale: vi.fn() }),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({ alt = "" }: { alt?: string }) => <img alt={alt} />,
+}));
+
+const refreshModels = vi.fn();
+
+vi.mock("@/hooks/useHermesModelOptions", () => ({
+  useHermesModelOptions: () => ({
+    scope: {
+      provider: "anthropic",
+      authenticated: true,
+      models: [{ id: "claude-opus-4-8", description: "" }],
+      defaultModel: "claude-opus-4-8",
+      current: "claude-opus-4-8",
+      savedElsewhere: null,
+      source: "dashboard",
+      stale: false,
+      fetchedAt: Date.now(),
+    },
+    loading: false,
+    refresh: refreshModels,
+  }),
+  notifyHermesModelState: vi.fn(),
+}));
+
+/** The panel's backing routes, including the new inline-OAuth relay. Tracks a
+ *  successful submit the way the dashboard would, so the status re-read after
+ *  connecting reports logged_in instead of clobbering the panel's flip. */
+function stubFetch({ submitOk = true }: { submitOk?: boolean } = {}) {
+  let anthropicLoggedIn = false;
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const method = init?.method ?? "GET";
+
+    if (url === "/setup-api/hermes/clawai") {
+      return {
+        ok: true,
+        json: async () => ({ hasToken: false, tier: "flash", tierStored: null, active: false, model: "" }),
+      } as Response;
+    }
+    if (url === "/setup-api/hermes/oauth") {
+      return {
+        ok: true,
+        json: async () => ({
+          providers: [
+            { id: "anthropic", name: "Anthropic", loggedIn: anthropicLoggedIn, flow: "pkce" },
+            { id: "openai-codex", name: "OpenAI", loggedIn: false, flow: "device_code" },
+            {
+              id: "copilot-acp",
+              name: "GitHub Copilot",
+              loggedIn: false,
+              flow: "external",
+              cliCommand: "hermes auth login copilot",
+            },
+          ],
+        }),
+      } as Response;
+    }
+    if (url === "/setup-api/hermes/oauth/start" && method === "POST") {
+      const { providerId } = JSON.parse(String(init?.body)) as { providerId: string };
+      if (providerId === "anthropic") {
+        return {
+          ok: true,
+          json: async () => ({
+            session_id: "sess-anthropic-1",
+            flow: "pkce",
+            auth_url: "https://claude.ai/oauth/authorize?x=1",
+            expires_in: 600,
+          }),
+        } as Response;
+      }
+      return {
+        ok: true,
+        json: async () => ({
+          session_id: "sess-codex-1",
+          flow: "device_code",
+          user_code: "ABCD-1234",
+          verification_url: "https://example.com/activate",
+          expires_in: 900,
+          poll_interval: 5,
+        }),
+      } as Response;
+    }
+    if (url === "/setup-api/hermes/oauth/submit" && method === "POST") {
+      if (submitOk) anthropicLoggedIn = true;
+      return submitOk
+        ? ({ ok: true, json: async () => ({ ok: true }) } as Response)
+        : ({
+            ok: false,
+            status: 400,
+            json: async () => ({ ok: false, status: "error", message: "Invalid authorization code" }),
+          } as Response);
+    }
+    if (url.startsWith("/setup-api/hermes/oauth/poll")) {
+      return { ok: true, json: async () => ({ status: "pending" }) } as Response;
+    }
+    if (url === "/setup-api/hermes/oauth/cancel") {
+      return { ok: true, json: async () => ({ ok: true }) } as Response;
+    }
+    if (url === "/setup-api/hermes/models") {
+      return { ok: true, json: async () => ({ provider: "openrouter" }) } as Response;
+    }
+
+    return { ok: true, json: async () => ({}) } as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("HermesProviderConfig inline OAuth", () => {
+  let openMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    refreshModels.mockClear();
+    openMock = vi.fn();
+    vi.stubGlobal("open", openMock);
+  });
+
+  it("runs the pkce flow inline: opens the provider page, takes a pasted code, shows Connected", async () => {
+    const fetchMock = stubFetch();
+
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: /Anthropic/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Sign in$/ }));
+
+    // The provider's consent page opens in a NEW tab; the panel itself never
+    // navigates anywhere (especially not to :8090).
+    const codeInput = await screen.findByPlaceholderText("Paste the code from Anthropic");
+    expect(openMock).toHaveBeenCalledWith(
+      "https://claude.ai/oauth/authorize?x=1",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    expect(openMock.mock.calls.every(([url]) => !String(url).includes(":8090"))).toBe(true);
+
+    fireEvent.change(codeInput, { target: { value: "authcode#state" } });
+    fireEvent.click(screen.getByRole("button", { name: /Submit code/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
+    const submitCall = fetchMock.mock.calls.find(([u]) => String(u) === "/setup-api/hermes/oauth/submit");
+    expect(submitCall).toBeTruthy();
+    expect(JSON.parse(String(submitCall?.[1]?.body))).toEqual({
+      providerId: "anthropic",
+      sessionId: "sess-anthropic-1",
+      code: "authcode#state",
+    });
+    expect(refreshModels).toHaveBeenCalled();
+  });
+
+  it("keeps the paste step visible with the dashboard's message when the code is rejected", async () => {
+    stubFetch({ submitOk: false });
+
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: /Anthropic/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Sign in$/ }));
+
+    const codeInput = await screen.findByPlaceholderText("Paste the code from Anthropic");
+    fireEvent.change(codeInput, { target: { value: "wrongcode" } });
+    fireEvent.click(screen.getByRole("button", { name: /Submit code/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Invalid authorization code");
+    });
+    // Still on the paste step: the user can correct the code without a new session.
+    expect(screen.getByPlaceholderText("Paste the code from Anthropic")).toBeInTheDocument();
+  });
+
+  it("runs the device_code flow inline: shows the user code, copy button and verification link", async () => {
+    stubFetch();
+
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: /OpenAI/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Sign in$/ }));
+
+    const code = await screen.findByTestId("hermes-oauth-user-code");
+    expect(code).toHaveTextContent("ABCD-1234");
+    expect(screen.getByRole("button", { name: /Copy code/ })).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /Open the verification page/ });
+    expect(link).toHaveAttribute("href", "https://example.com/activate");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(screen.getByText("Waiting for approval...")).toBeInTheDocument();
+    // Device-code never opens a tab by itself — the user may be on another machine.
+    expect(openMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the CLI command instead of a Sign in button for an external-flow provider", async () => {
+    stubFetch();
+
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+
+    fireEvent.click(await screen.findByRole("radio", { name: /GitHub Copilot/ }));
+
+    await screen.findByText("hermes auth login copilot");
+    expect(screen.getByText("This provider signs in through the Hermes CLI.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Sign in$/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/tests/routes/hermes/oauth-flows.test.ts
+++ b/src/tests/routes/hermes/oauth-flows.test.ts
@@ -1,0 +1,328 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The wizard-driven provider-OAuth relay: start / submit / poll / cancel under
+// /setup-api/hermes/oauth/. These exist so the browser never has to reach the
+// Hermes dashboard's :8090 proxy (unreachable through tunnels) — the routes
+// forward to the dashboard API via the server-side dashboardFetch. This suite
+// pins the three properties every route must hold: the hermes harness gate,
+// input validation before anything touches a dashboard URL, and a whitelisted
+// passthrough that can never leak credential material.
+
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: vi.fn(),
+}));
+
+vi.mock("@/lib/hermes-dashboard-auth", () => ({
+  dashboardFetch: vi.fn(),
+}));
+
+const SESSION_ID = "0f6c1c2e-1111-2222-3333-444455556666";
+
+function jsonRequest(path: string, method: string, body: unknown): Request {
+  return new Request(`http://localhost/setup-api/hermes/oauth/${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function dashboardResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("hermes provider-OAuth relay routes", () => {
+  let catalogGET: () => Promise<Response>;
+  let startPOST: (req: Request) => Promise<Response>;
+  let submitPOST: (req: Request) => Promise<Response>;
+  let pollGET: (req: Request) => Promise<Response>;
+  let cancelDELETE: (req: Request) => Promise<Response>;
+  let mockGetActiveHarness: ReturnType<typeof vi.fn>;
+  let mockDashboardFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+
+    const harness = await import("@/lib/harness");
+    mockGetActiveHarness = vi.mocked(harness.getActiveHarness) as unknown as ReturnType<typeof vi.fn>;
+    mockGetActiveHarness.mockResolvedValue("hermes");
+
+    const dash = await import("@/lib/hermes-dashboard-auth");
+    mockDashboardFetch = vi.mocked(dash.dashboardFetch) as unknown as ReturnType<typeof vi.fn>;
+
+    ({ GET: catalogGET } = await import("@/app/setup-api/hermes/oauth/route"));
+    ({ POST: startPOST } = await import("@/app/setup-api/hermes/oauth/start/route"));
+    ({ POST: submitPOST } = await import("@/app/setup-api/hermes/oauth/submit/route"));
+    ({ GET: pollGET } = await import("@/app/setup-api/hermes/oauth/poll/route"));
+    ({ DELETE: cancelDELETE } = await import("@/app/setup-api/hermes/oauth/cancel/route"));
+  });
+
+  it("404s every route when the active harness is not hermes", async () => {
+    mockGetActiveHarness.mockResolvedValue("openclaw");
+
+    const responses = await Promise.all([
+      catalogGET(),
+      startPOST(jsonRequest("start", "POST", { providerId: "anthropic" })),
+      submitPOST(jsonRequest("submit", "POST", { providerId: "anthropic", sessionId: SESSION_ID, code: "abc#def" })),
+      pollGET(new Request(`http://localhost/setup-api/hermes/oauth/poll?providerId=anthropic&sessionId=${SESSION_ID}`)),
+      cancelDELETE(jsonRequest("cancel", "DELETE", { sessionId: SESSION_ID })),
+    ]);
+
+    for (const res of responses) expect(res.status).toBe(404);
+    expect(mockDashboardFetch).not.toHaveBeenCalled();
+  });
+
+  describe("catalog (GET /setup-api/hermes/oauth)", () => {
+    it("maps the dashboard catalog, carrying cli_command for external-flow providers", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(200, {
+        providers: [
+          {
+            id: "anthropic",
+            name: "Anthropic",
+            flow: "pkce",
+            docs_url: "https://docs.example.com/anthropic",
+            status: { logged_in: true },
+          },
+          {
+            id: "copilot-acp",
+            name: "GitHub Copilot",
+            flow: "external",
+            cli_command: "hermes auth login copilot",
+            status: { logged_in: false },
+          },
+        ],
+      }));
+
+      const res = await catalogGET();
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.providers).toEqual([
+        {
+          id: "anthropic",
+          name: "Anthropic",
+          flow: "pkce",
+          loggedIn: true,
+          docsUrl: "https://docs.example.com/anthropic",
+        },
+        {
+          id: "copilot-acp",
+          name: "GitHub Copilot",
+          flow: "external",
+          loggedIn: false,
+          cliCommand: "hermes auth login copilot",
+        },
+      ]);
+    });
+
+    it("degrades to an empty catalog when the dashboard is down", async () => {
+      mockDashboardFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+      const res = await catalogGET();
+      const body = await res.json();
+      expect(res.status).toBe(200);
+      expect(body.providers).toEqual([]);
+    });
+  });
+
+  describe("start", () => {
+    it("rejects a provider id that could escape the dashboard URL path", async () => {
+      for (const providerId of ["../sessions", "anthropic/start", "Anthropic", "a b", "", 42, null]) {
+        const res = await startPOST(jsonRequest("start", "POST", { providerId }));
+        expect(res.status).toBe(400);
+      }
+      expect(mockDashboardFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects a non-JSON body", async () => {
+      const res = await startPOST(
+        new Request("http://localhost/setup-api/hermes/oauth/start", { method: "POST", body: "nope" }),
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("relays a pkce start whitelisted — never any credential material", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(200, {
+        session_id: SESSION_ID,
+        flow: "pkce",
+        auth_url: "https://claude.ai/oauth/authorize?x=1",
+        expires_in: 600,
+        access_token: "LEAKED",
+        code_verifier: "LEAKED-TOO",
+      }));
+
+      const res = await startPOST(jsonRequest("start", "POST", { providerId: "anthropic" }));
+      const body = await res.json();
+
+      expect(mockDashboardFetch).toHaveBeenCalledWith(
+        "/api/providers/oauth/anthropic/start",
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(res.status).toBe(200);
+      expect(body).toEqual({
+        session_id: SESSION_ID,
+        flow: "pkce",
+        auth_url: "https://claude.ai/oauth/authorize?x=1",
+        expires_in: 600,
+      });
+    });
+
+    it("relays a device_code start including the user code and poll interval", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(200, {
+        session_id: SESSION_ID,
+        flow: "device_code",
+        user_code: "ABCD-1234",
+        verification_url: "https://example.com/activate",
+        expires_in: 900,
+        poll_interval: 5,
+      }));
+
+      const res = await startPOST(jsonRequest("start", "POST", { providerId: "openai-codex" }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.user_code).toBe("ABCD-1234");
+      expect(body.verification_url).toBe("https://example.com/activate");
+      expect(body.poll_interval).toBe(5);
+    });
+
+    it("relays a dashboard refusal (flow external) with its status and detail", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(400, {
+        detail: "Provider uses an external flow",
+      }));
+
+      const res = await startPOST(jsonRequest("start", "POST", { providerId: "copilot-acp" }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.error).toBe("Provider uses an external flow");
+    });
+
+    it("502s when the dashboard is unreachable", async () => {
+      mockDashboardFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+      const res = await startPOST(jsonRequest("start", "POST", { providerId: "anthropic" }));
+      expect(res.status).toBe(502);
+    });
+  });
+
+  describe("submit", () => {
+    it("rejects bad session ids and codes before touching the dashboard", async () => {
+      const bad = [
+        { providerId: "anthropic", sessionId: "../sessions", code: "abc#def" },
+        { providerId: "anthropic", sessionId: "x", code: "abc#def" },
+        { providerId: "anthropic", sessionId: SESSION_ID, code: "has space" },
+        { providerId: "anthropic", sessionId: SESSION_ID, code: "" },
+        { providerId: "an/thropic", sessionId: SESSION_ID, code: "abc#def" },
+      ];
+      for (const body of bad) {
+        const res = await submitPOST(jsonRequest("submit", "POST", body));
+        expect(res.status).toBe(400);
+      }
+      expect(mockDashboardFetch).not.toHaveBeenCalled();
+    });
+
+    it("forwards the pasted code in the dashboard's body shape", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(200, { ok: true }));
+
+      const res = await submitPOST(jsonRequest("submit", "POST", {
+        providerId: "anthropic",
+        sessionId: SESSION_ID,
+        code: "  authcode#state  ",
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+      const [path, init] = mockDashboardFetch.mock.calls[0];
+      expect(path).toBe("/api/providers/oauth/anthropic/submit");
+      expect(JSON.parse(init.body)).toEqual({ session_id: SESSION_ID, code: "authcode#state" });
+    });
+
+    it("relays a code rejection so the panel can show the dashboard's message", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(400, {
+        ok: false,
+        status: "error",
+        message: "Invalid authorization code",
+      }));
+
+      const res = await submitPOST(jsonRequest("submit", "POST", {
+        providerId: "anthropic",
+        sessionId: SESSION_ID,
+        code: "wrongcode",
+      }));
+      const body = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(body.ok).toBe(false);
+      expect(body.message).toBe("Invalid authorization code");
+    });
+  });
+
+  describe("poll", () => {
+    it("validates the query parameters", async () => {
+      const urls = [
+        `http://localhost/setup-api/hermes/oauth/poll?providerId=anthropic`,
+        `http://localhost/setup-api/hermes/oauth/poll?sessionId=${SESSION_ID}`,
+        `http://localhost/setup-api/hermes/oauth/poll?providerId=..%2F..&sessionId=${SESSION_ID}`,
+        `http://localhost/setup-api/hermes/oauth/poll?providerId=anthropic&sessionId=..%2Fadmin`,
+      ];
+      for (const url of urls) {
+        const res = await pollGET(new Request(url));
+        expect(res.status).toBe(400);
+      }
+      expect(mockDashboardFetch).not.toHaveBeenCalled();
+    });
+
+    it("relays the session status from the dashboard's poll endpoint", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(200, {
+        session_id: SESSION_ID,
+        status: "approved",
+        error_message: null,
+        expires_at: "2026-08-21T12:00:00Z",
+      }));
+
+      const res = await pollGET(new Request(
+        `http://localhost/setup-api/hermes/oauth/poll?providerId=openai-codex&sessionId=${SESSION_ID}`,
+      ));
+      const body = await res.json();
+
+      expect(mockDashboardFetch).toHaveBeenCalledWith(
+        `/api/providers/oauth/openai-codex/poll/${SESSION_ID}`,
+      );
+      expect(res.status).toBe(200);
+      expect(body.status).toBe("approved");
+      expect(body.expires_at).toBe("2026-08-21T12:00:00Z");
+    });
+
+    it("502s when the dashboard is unreachable", async () => {
+      mockDashboardFetch.mockRejectedValue(new Error("timeout"));
+      const res = await pollGET(new Request(
+        `http://localhost/setup-api/hermes/oauth/poll?providerId=anthropic&sessionId=${SESSION_ID}`,
+      ));
+      expect(res.status).toBe(502);
+    });
+  });
+
+  describe("cancel", () => {
+    it("rejects a malformed session id", async () => {
+      const res = await cancelDELETE(jsonRequest("cancel", "DELETE", { sessionId: "../other" }));
+      expect(res.status).toBe(400);
+      expect(mockDashboardFetch).not.toHaveBeenCalled();
+    });
+
+    it("forwards the delete to the dashboard's sessions endpoint", async () => {
+      mockDashboardFetch.mockResolvedValue(dashboardResponse(200, { ok: true }));
+
+      const res = await cancelDELETE(jsonRequest("cancel", "DELETE", { sessionId: SESSION_ID }));
+      const body = await res.json();
+
+      expect(mockDashboardFetch).toHaveBeenCalledWith(
+        `/api/providers/oauth/sessions/${SESSION_ID}`,
+        expect.objectContaining({ method: "DELETE" }),
+      );
+      expect(res.status).toBe(200);
+      expect(body.ok).toBe(true);
+    });
+  });
+});

--- a/src/tests/routes/hermes/oauth-flows.test.ts
+++ b/src/tests/routes/hermes/oauth-flows.test.ts
@@ -135,6 +135,12 @@ describe("hermes provider-OAuth relay routes", () => {
       expect(mockDashboardFetch).not.toHaveBeenCalled();
     });
 
+    it("refuses an oversized body before parsing it", async () => {
+      const res = await startPOST(jsonRequest("start", "POST", { providerId: "a".repeat(32 * 1024) }));
+      expect(res.status).toBe(400);
+      expect(mockDashboardFetch).not.toHaveBeenCalled();
+    });
+
     it("rejects a non-JSON body", async () => {
       const res = await startPOST(
         new Request("http://localhost/setup-api/hermes/oauth/start", { method: "POST", body: "nope" }),


### PR DESCRIPTION
## Problem

In the setup wizard's Hermes models step, the OAuth "Sign in" button opened `<hostname>:8090/env` — the Hermes dashboard's auth-proxy port. On the LAN that works, but through any tunnel or reverse proxy (clawbox-tunnel remote access on :80, Cloudflare quick tunnel) only the web port is forwarded, so :8090 is unreachable: blank tab, user lands back on the same step. The dashboard can't be path-mounted on :80 (no base-path option — see the `scripts/hermes-dashboard-proxy.js` header). Reported and reproduced by Krasi on the Hermes-edition dev box, 2026-08-21.

## Fix

Run the whole OAuth flow inline in the wizard panel, against four new same-origin relay routes (`/setup-api/hermes/oauth/start|submit|poll|cancel`) that forward to the dashboard API (127.0.0.2:9119) via the server-side, cookie-authed `dashboardFetch`. The browser never needs a port other than the one the page is already on.

- **pkce** (Anthropic): Sign in opens the provider's consent page in a new tab; its redirect_uri is Anthropic's own console page that *shows* the code, the user pastes it back into the panel. Nothing redirects to the device, so the flow survives any tunnel.
- **device_code** (OpenAI Codex, Nous): the panel shows the user code with a copy button and a link to the verification page, then polls (min 3 s) until approved / error / expired.
- **external**: the panel shows the provider's CLI command instead of a Sign in button.
- The old :8090 dashboard link remains only as a tertiary "Advanced: Hermes dashboard (LAN only)" fallback.
- Every route 404s unless the active harness is Hermes, charset-validates provider/session ids before they touch a dashboard URL, and relays responses through a key whitelist so credential material can never fall through.
- Sessions are cancelled server-side on unmount / provider switch / Start over.

## Tests

- `src/tests/routes/hermes/oauth-flows.test.ts` — harness gate, id/code validation, whitelisted passthrough (incl. proving injected `access_token`-style fields are dropped), dashboard-down 502s, catalog mapping incl. `cli_command`.
- `src/tests/components/hermes-oauth-inline.test.tsx` — pkce (new-tab open, paste + submit, Connected; rejected-code stays on the paste step), device_code render state (user code, copy, verification link), external render state.
- Full suite: 3257 tests pass; coverage above the PR gate thresholds; no new type or lint errors (baseline unchanged).

## Manual test plan (Hermes box)

**LAN:**
1. Open the wizard's Hermes models step (or the same panel in Settings), select Anthropic, click Sign in.
2. A `claude.ai` consent tab opens; approve, copy the code from the Anthropic console page, paste it into the panel, Submit. Panel should flip to Connected without leaving the step, and the model dropdown should populate with live Anthropic ids.
3. Select OpenAI, click Sign in: a code like `ABCD-1234` appears with a copy button; open the verification link on your phone, approve, and watch the panel flip to Connected by itself.
4. Click Start over mid-flow and switch provider rows: no stuck state, Sign in works again.

**Through a tunnel (the actual bug):**
5. Reach the device via clawbox-tunnel remote access (or `cloudflared tunnel --url http://localhost:80`) and repeat steps 1-3. Everything must work identically — at no point should the browser be sent to `:8090`.
6. Confirm the "Advanced: Hermes dashboard (LAN only)" link is still there but clearly secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline Hermes sign-in for PKCE and device-code authentication.
  * Added authorization-code submission, status polling, and cancellation for in-progress sign-ins.
  * Added CLI command details for external provider authentication.
  * Provider selection now cleans up abandoned sessions and refreshes connection state after successful authentication.
  * Retained the dashboard sign-in link as an advanced LAN-only fallback.

* **Bug Fixes**
  * Improved handling and messaging for invalid requests, failed authentication, and unavailable services.

* **Tests**
  * Added coverage for inline sign-in flows, polling, cancellation, validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->