### PR TITLE
A screen reader hears the answer, not its markdown (TASK-381)

### DIFF
--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -154,13 +154,27 @@ const PROVIDER_PILL_LABEL: Record<string, string> = {
   'Ollama Local': 'Ollama',
   'Gemma 4 Local': 'Gemma 4',
 }
+
+/**
+ * Accessible name for a spoken reply's player.
+ *
+ * The message body is already on screen and already read by the message
+ * itself, so this is a short identifying fragment, not a second copy — but it
+ * has to be there: a transcript can hold several players, and "audio" three
+ * times over tells a screen-reader user nothing about which is which.
+ */
+function audioLabel(text: string | undefined, prefix: string): string {
+  const spoken = text ? plainTextForLabel(text, 100) : "";
+  return spoken ? `${prefix}: ${spoken}` : prefix;
+}
+
 function getProviderPillText(option: ChatModelState['options'][number]): string {
   const full = getChatModelOptionText(option)
   if (!option.available) return full
   return PROVIDER_PILL_LABEL[option.label ?? ''] ?? full
 }
 
-import { renderText } from '@/lib/chat-markdown'
+import { renderText, plainTextForLabel } from '@/lib/chat-markdown'
 import { extractImageFilesFromClipboard } from '@/lib/clipboard'
 import {
   type ChatAttachment,
@@ -3459,9 +3473,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
                       <audio
                         key={src}
                         data-testid="chat-audio"
-                        aria-label={msg.text
-                          ? `${t("chat.audioReply")}: ${msg.text.slice(0, 100)}`
-                          : t("chat.audioReply")}
+                        // Markdown source must not reach an accessible name —
+                        // it is read out character for character. See
+                        // plainTextForLabel.
+                        aria-label={audioLabel(msg.text, t("chat.audioReply"))}
                         controls
                         preload="metadata"
                         src={src}

--- a/src/lib/chat-markdown.tsx
+++ b/src/lib/chat-markdown.tsx
@@ -65,3 +65,46 @@ export function renderText(text: string) {
     );
   });
 }
+
+/**
+ * The same message as plain speech, for an accessible name.
+ *
+ * A control's accessible name is read aloud verbatim, so the markdown source
+ * cannot go in it: `*"seventeen copper bells"*` is announced as "asterisk
+ * quote seventeen copper bells quote asterisk", and a fenced block reads its
+ * backticks out one by one. The audio player's label was the raw `msg.text`,
+ * so every emphasis mark, link URL and heading hash in a spoken reply landed
+ * in the screen reader.
+ *
+ * Deliberately in this file and not next to the player: it strips the same
+ * markers `renderInline`/`renderText` consume, so the two cannot drift into
+ * disagreeing about what counts as markup. Where it differs it strips MORE,
+ * never less: `renderText` only promotes `##`/`###` to headings and only
+ * bullets a paragraph made entirely of them, while this drops any leading
+ * `#`s and any leading bullet. That asymmetry is the safe one — a stray `#`
+ * that stays on screen costs nothing, but spoken aloud it is just noise.
+ *
+ * `max` is a budget for the SPOKEN name, so it cuts on a word boundary — the
+ * previous `slice(0, 100)` could stop mid-word, and mid-token, which is worse
+ * out loud than it looks on screen.
+ */
+export function plainTextForLabel(text: string, max = 100): string {
+  const flat = text
+    // Fenced blocks first: their content may contain any other marker.
+    .replace(/```[\s\S]*?```/g, (seg) => seg.slice(3, -3).replace(/^\w*\n/, ""))
+    .replace(/`([^`\n]+)`/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    // Headings and list bullets are line-leading, so anchor them per line.
+    .replace(/^\s{0,3}#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*]\s+/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (flat.length <= max) return flat;
+  const cut = flat.slice(0, max);
+  const lastSpace = cut.lastIndexOf(" ");
+  // Only honour the word boundary if one exists late enough to leave a useful
+  // label; a single very long token still gets truncated rather than dropped.
+  return `${(lastSpace > max * 0.5 ? cut.slice(0, lastSpace) : cut).trimEnd()}…`;
+}

--- a/src/tests/components/chat-spoken-reply.test.tsx
+++ b/src/tests/components/chat-spoken-reply.test.tsx
@@ -209,6 +209,31 @@ describe("spoken replies in the mascot chat", () => {
     expect(player).toHaveAccessibleName(`chat.audioReply: ${SPOKEN_TEXT}`);
   });
 
+  it("labels the player with speakable text, not the markdown the model wrote", async () => {
+    // Observed live on .177 at beta 084e3f7: the model answered
+    // `Sent — *"Seventeen copper bells."*` and the player's accessible name was
+    // that string verbatim, so a screen reader announced the asterisks. It also
+    // carried the whole message body, including a paragraph about how MEDIA is
+    // delivered — internal wording, read out as the control's name.
+    const MARKDOWN = 'Sent — *"Seventeen copper bells."*\n\nSee [the docs](https://clawbox.com/docs/tts) or run `openclaw health`.';
+    render(<ChatPopup isOpen onClose={() => {}} />);
+    await waitFor(() => expect(socket()).not.toBeNull());
+    await screen.findByRole("textbox");
+
+    deliver(assistantMessage(MARKDOWN, 1787291821899));
+    deliverSessionMessage(assistantMessage(MARKDOWN, 1787291825743, VOICE));
+    await waitFor(() => expect(players()).toHaveLength(1));
+
+    const name = players()[0].getAttribute("aria-label") ?? "";
+    expect(name.startsWith("chat.audioReply: ")).toBe(true);
+    for (const marker of ["*", "`", "](", "https://"]) {
+      expect(name).not.toContain(marker);
+    }
+    // The words survive; only the syntax is gone.
+    expect(name).toContain("Seventeen copper bells.");
+    expect(name).toContain("the docs");
+  });
+
   it("does not show the answer twice when its spoken half arrives", async () => {
     render(<ChatPopup isOpen onClose={() => {}} />);
     await waitFor(() => expect(socket()).not.toBeNull());

--- a/src/tests/unit/chat-audio-label.test.ts
+++ b/src/tests/unit/chat-audio-label.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { plainTextForLabel } from "@/lib/chat-markdown";
+
+/**
+ * An accessible name is SPOKEN, so it cannot carry markdown source.
+ *
+ * The audio player under a spoken reply used to be labelled with the raw
+ * `msg.text`, so a reply the model wrote as `*"seventeen copper bells"*` was
+ * announced as "asterisk quote seventeen copper bells quote asterisk", and a
+ * reply containing a link read the whole URL out. Observed live on box .177 on
+ * beta 084e3f7 before this change.
+ *
+ * The contract this file locks down: whatever `renderInline`/`renderText`
+ * treat as markup, this strips — the two must not drift into disagreeing about
+ * what counts as syntax.
+ */
+describe("plainTextForLabel", () => {
+  it("drops emphasis markers but keeps the words", () => {
+    expect(plainTextForLabel('Sent — *"Seventeen copper bells."*')).toBe('Sent — "Seventeen copper bells."');
+    expect(plainTextForLabel("that is **very** important")).toBe("that is very important");
+  });
+
+  it("keeps a link's text and drops its URL", () => {
+    // The URL is the part that is unbearable out loud, and it is never the
+    // information the listener wanted.
+    expect(plainTextForLabel("see [the docs](https://clawbox.com/docs/a/b/c) for more"))
+      .toBe("see the docs for more");
+  });
+
+  it("unwraps inline and fenced code instead of reading backticks", () => {
+    expect(plainTextForLabel("run `openclaw health` now")).toBe("run openclaw health now");
+    expect(plainTextForLabel("before\n```bash\nls -la\n```\nafter")).toBe("before ls -la after");
+  });
+
+  it("removes heading hashes and list bullets", () => {
+    expect(plainTextForLabel("## Result\n- first\n- second")).toBe("Result first second");
+  });
+
+  it("strips more than renderText renders, never less", () => {
+    // renderText only promotes ## and ### to headings, and only bullets a
+    // paragraph made entirely of them. This deliberately drops a lone # and a
+    // stray bullet too: on screen a leftover marker is invisible noise, spoken
+    // aloud it is a word the listener has to discard.
+    expect(plainTextForLabel("# Title")).toBe("Title");
+    expect(plainTextForLabel("#### Deep")).toBe("Deep");
+    expect(plainTextForLabel("intro\n- lone bullet")).toBe("intro lone bullet");
+  });
+
+  it("collapses newlines so the name is one utterance", () => {
+    expect(plainTextForLabel("one\n\n\ntwo\n   three")).toBe("one two three");
+  });
+
+  it("truncates on a word boundary rather than mid-word", () => {
+    const out = plainTextForLabel("the harbour lantern turns amber at quarter past four", 20);
+    expect(out).toBe("the harbour lantern…");
+    // The old behaviour — a bare slice — would have said "the harbour lanter".
+    expect(out).not.toContain("lanter…");
+  });
+
+  it("still truncates a single unbroken token", () => {
+    // No word boundary to honour: cutting is better than an unbounded name.
+    const out = plainTextForLabel("x".repeat(60), 20);
+    expect(out).toBe("x".repeat(20) + "…");
+  });
+
+  it("leaves a short plain message exactly as it is", () => {
+    expect(plainTextForLabel("The lantern is green.")).toBe("The lantern is green.");
+  });
+
+  it("returns an empty string for whitespace-only text", () => {
+    // The caller falls back to the bare "Audio reply" label on empty output,
+    // so this must not produce a stray separator.
+    expect(plainTextForLabel("   \n\n  ")).toBe("");
+  });
+});


### PR DESCRIPTION
## What was wrong

The `<audio>` element under a spoken reply in the mascot chat was labelled with the **raw message source**:

```tsx
aria-label={msg.text ? `${t("chat.audioReply")}: ${msg.text.slice(0, 100)}` : t("chat.audioReply")}
```

An accessible name is announced **verbatim**, so every marker the renderer exists to consume went straight to speech.

Observed live on box `.177` at beta `084e3f7`. The model answered:

```
Sent — *"Seventeen copper bells."*

See [the docs](https://clawbox.com/docs/tts) or run `openclaw health`.
```

and the player's accessible name was that string, character for character — asterisks and quotes spoken as words, the whole URL read out, backticks announced one at a time. The bare `slice(0, 100)` also cut mid-word: the live name ended `openclaw he`.

## The fix

`plainTextForLabel` in `src/lib/chat-markdown.tsx` — deliberately beside `renderInline`/`renderText` so the two cannot drift about what counts as markup. It strips the markers those renderers consume (fenced and inline code, links keeping their text, bold/italic, heading hashes, list bullets), collapses the message to one utterance, and truncates on a word boundary.

Where it differs from the renderers it strips **more, never less**: `renderText` only promotes `##`/`###` and only bullets a paragraph made entirely of them, while this drops a lone `#` and a stray bullet too. A leftover marker on screen costs nothing; spoken aloud it is a word the listener has to discard. That asymmetry is pinned by a test rather than left to chance.

## Tests

- **10 unit tests** on the helper — each one **verified to fail against unmodified beta** (stripped the source change, re-ran: 10 failed / 10).
- **1 component test** through the real `ChatPopup`, asserting no `*`, `` ` ``, `](` or `https://` survives into the accessible name while the words do. Also verified failing first — it reported the defect verbatim.

Local gate: **242 files / 3275 tests green** (baseline 241 / 3264). Changed-file ESLint: 0 errors.

## Not in this PR

`FilesApp.tsx:1296` renders `<audio src controls />` with no accessible name at all. Different surface, pre-existing, and its context is a filename rather than a message — it needs its own task, not a widened diff here.

TASK-381 acceptance 4 and 6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved audio-player labels for spoken replies by removing Markdown formatting and link URLs.
  * Labels now use concise, readable reply text with normalized whitespace and sensible truncation.

* **Tests**
  * Added coverage for formatted text, links, code, headings, lists, whitespace, and long replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->