### PR TITLE
See what is really running on your box (TASK-435)

### DIFF
--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -63,6 +63,16 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl enable  clawbox-tunnel
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl disable clawbox-tunnel.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl disable clawbox-tunnel
 
+# Ollama, for Settings -> Local Models. Ollama is a system unit and it holds
+# real RAM on an 8 GB box, so the owner has to be able to stop it and have it
+# stay stopped; until this grant existed nothing in the UI could. `--now` is
+# part of the command string because sudoers matches the argument list exactly
+# and the UI always issues enable/disable together with it, so a grant without
+# --now would never match and the toggle would fail closed on a password
+# prompt no one can answer.
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl enable  --now ollama.service
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl disable --now ollama.service
+
 # Update / power / install paths.
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reset-failed *
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block *

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -1117,6 +1117,32 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
       return;
     }
 
+    // Settings -> Local Models. A realistic inventory rather than an empty
+    // one: the tab's whole point is telling "installed and stopped" apart from
+    // "not installed", so the mock has to contain both or the spec proves
+    // nothing. Without this handler the fallthrough below answers `{}` and the
+    // panel correctly refuses to adopt it, leaving the tab on its skeleton.
+    if (path === "/setup-api/local-models") {
+      await fulfillJson(route, {
+        models: [
+          {
+            id: "ollama", name: "Ollama", kind: "llm", runtime: "System service",
+            installed: true, enabled: true, running: "running",
+            diskBytes: 639_000_000, memoryBytes: 1_073_741_824,
+            control: "system-unit", detail: "Serving 1 model: qwen3-embedding:0.6b.",
+          },
+          {
+            id: "kokoro", name: "Kokoro", kind: "tts", runtime: "systemd user service",
+            installed: false, enabled: null, running: "not-installed",
+            diskBytes: null, memoryBytes: null, control: "none",
+            detail: "Not installed on this box. Speech falls back to Piper.",
+          },
+        ],
+        unavailable: [],
+      });
+      return;
+    }
+
     await fulfillJson(route, {});
   });
 }

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -65,6 +65,19 @@ test("settings covers appearance, network, local AI, telegram, system, and about
   await expect(localProviderGroup.getByText("Ollama")).toHaveCount(0);
   await expect(localProviderGroup.getByText("ClawBox AI")).toHaveCount(0);
 
+  // Local Models: the inventory behind the Local AI selector. The assertion
+  // that matters is the NEGATIVE one — an engine the box does not have must
+  // read as absent and must not come with a switch, because offering a control
+  // that cannot work is the drift this tab was built to end.
+  await settingsWindow.getByRole("button", { name: "Local Models" }).click();
+  const ollamaRow = settingsWindow.getByTestId("local-model-ollama");
+  await expect(ollamaRow.getByText("Running", { exact: true })).toBeVisible();
+  await expect(ollamaRow.getByText(/Disk 609 MB/)).toBeVisible();
+  await expect(ollamaRow.getByRole("switch", { name: /Ollama enabled/i })).toBeVisible();
+  const kokoroRow = settingsWindow.getByTestId("local-model-kokoro");
+  await expect(kokoroRow.getByText("Not installed", { exact: true })).toBeVisible();
+  await expect(kokoroRow.getByRole("switch")).toHaveCount(0);
+
   await settingsWindow.getByRole("button", { name: "Telegram" }).click();
   await settingsWindow.locator("#settings-tg-token").fill("123456789:ABCdefGHI");
   await settingsWindow.getByRole("button", { name: /Connect$/ }).click();

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -7,7 +7,7 @@ import { installClawboxMocks } from "./helpers/clawbox";
 // and the dialog-driven assertions in the original test went stale.
 // A focused AI-Provider test belongs in its own spec; until then this
 // test still gives us the bulk of SettingsApp's render coverage.
-test("settings covers appearance, network, local AI, telegram, system, and about flows", async ({ page }) => {
+test("settings covers appearance, network, local AI, local models, telegram, system, and about flows", async ({ page }) => {
   await installClawboxMocks(page, {
     initialSetup: {
       setup_complete: true,

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -73,7 +73,9 @@ test("settings covers appearance, network, local AI, local models, telegram, sys
   const ollamaRow = settingsWindow.getByTestId("local-model-ollama");
   await expect(ollamaRow.getByText("Running", { exact: true })).toBeVisible();
   await expect(ollamaRow.getByText(/Disk 609 MB/)).toBeVisible();
-  await expect(ollamaRow.getByRole("switch", { name: /Ollama enabled/i })).toBeVisible();
+  // aria-checked, not just visible: the fixture has Ollama enabled, so a switch
+  // that rendered stuck-off would still pass a visibility-only assertion.
+  await expect(ollamaRow.getByRole("switch", { name: /Ollama enabled/i })).toHaveAttribute("aria-checked", "true");
   const kokoroRow = settingsWindow.getByTestId("local-model-kokoro");
   await expect(kokoroRow.getByText("Not installed", { exact: true })).toBeVisible();
   await expect(kokoroRow.getByRole("switch")).toHaveCount(0);

--- a/src/app/setup-api/local-models/route.ts
+++ b/src/app/setup-api/local-models/route.ts
@@ -1,0 +1,96 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import {
+  buildLocalModelInventory,
+  setEngineEnabled,
+  unitForEngine,
+  type InventoryProbes,
+} from "@/lib/local-models";
+import { getDefaultLlamaCppModel, getLlamaCppBaseUrl } from "@/lib/llamacpp";
+import { getLlamaCppProvisioningStatus } from "@/lib/llamacpp-server";
+import { getOllamaBaseUrl } from "@/lib/local-ai-runtime";
+import { getMemoryStatus } from "@/lib/clawkeep-memory";
+
+/** Is llama.cpp answering right now? Same probe the llamacpp status route uses. */
+async function llamaCppRunning(baseUrl: string): Promise<string | null> {
+  try {
+    const res = await fetch(`${baseUrl}/models`, { signal: AbortSignal.timeout(4000) });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const first = Array.isArray(data?.data) ? data.data[0] : null;
+    return typeof first?.id === "string" ? first.id : "";
+  } catch {
+    return null;
+  }
+}
+
+async function probes(): Promise<InventoryProbes> {
+  const llamaBase = getLlamaCppBaseUrl();
+  const alias = getDefaultLlamaCppModel();
+  // Each probe is independently guarded: an engine that cannot be reached must
+  // cost only its own row, never the whole inventory.
+  const [provisioning, servedModel, memory] = await Promise.all([
+    getLlamaCppProvisioningStatus(alias).catch(() => null),
+    llamaCppRunning(llamaBase),
+    getMemoryStatus().catch(() => null),
+  ]);
+  return {
+    ollamaBaseUrl: getOllamaBaseUrl(),
+    llamacpp: {
+      installed: !!provisioning?.installed,
+      running: servedModel !== null,
+      model: servedModel || alias || null,
+    },
+    embeddings: {
+      available: !!memory?.available,
+      provider: memory?.provider || null,
+      model: memory?.model || null,
+      local: memory?.location === "local",
+    },
+  };
+}
+
+export async function GET() {
+  const snapshot = await buildLocalModelInventory(await probes());
+  return NextResponse.json(snapshot, { headers: { "Cache-Control": "no-store" } });
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  const id = (body as { id?: unknown })?.id;
+  const enabled = (body as { enabled?: unknown })?.enabled;
+  if (typeof id !== "string" || typeof enabled !== "boolean") {
+    return NextResponse.json({ error: "Expected an engine id and an enabled flag." }, { status: 400 });
+  }
+
+  const target = unitForEngine(id);
+  if (!target) {
+    return NextResponse.json({ error: "That model cannot be turned on or off here." }, { status: 400 });
+  }
+
+  // Refuse to act on an engine that is not installed rather than creating an
+  // enabled-but-absent unit: the acceptance line is that a missing model reads
+  // as missing, not as an option.
+  const before = await buildLocalModelInventory(await probes());
+  const entry = before.models.find(m => m.id === id);
+  if (!entry || !entry.installed) {
+    return NextResponse.json({ error: "That model is not installed on this box." }, { status: 409 });
+  }
+
+  const result = await setEngineEnabled(target.unit, target.scope, enabled);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error ?? "Could not change the service." }, { status: 500 });
+  }
+
+  const after = await buildLocalModelInventory(await probes());
+  return NextResponse.json(
+    { ok: true, models: after.models, unavailable: after.unavailable },
+    { headers: { "Cache-Control": "no-store" } },
+  );
+}

--- a/src/components/LocalModelsPanel.tsx
+++ b/src/components/LocalModelsPanel.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { LocalModelEntry, LocalModelsSnapshot, RunState } from "@/lib/local-models";
+
+const KIND_LABEL: Record<LocalModelEntry["kind"], string> = {
+  llm: "Language",
+  tts: "Speech out",
+  stt: "Speech in",
+  embedding: "Memory",
+};
+
+const KIND_ICON: Record<LocalModelEntry["kind"], string> = {
+  llm: "smart_toy",
+  tts: "record_voice_over",
+  stt: "mic",
+  embedding: "database",
+};
+
+/**
+ * Four states, four different sentences. Collapsing "not installed" into "off"
+ * is the exact drift this panel exists to make visible (TASK-420: the installer
+ * announced Kokoro on boxes that had never had it).
+ */
+const RUN_LABEL: Record<RunState, string> = {
+  running: "Running",
+  idle: "Stopped",
+  "on-demand": "On demand",
+  "not-installed": "Not installed",
+};
+
+const RUN_TONE: Record<RunState, string> = {
+  running: "bg-cyan-500/10 text-cyan-300 border-cyan-400/20",
+  idle: "bg-white/[0.06] text-[var(--text-secondary)] border-white/10",
+  "on-demand": "bg-white/[0.06] text-[var(--text-secondary)] border-white/10",
+  "not-installed": "bg-amber-500/10 text-amber-300 border-amber-400/20",
+};
+
+/**
+ * Deliberately the same arithmetic and the same rounding rule as ClawKeep's
+ * formatBytes: the two panels can end up quoting the same number (the memory
+ * index, the embedding model) and must not disagree about it. Returns null
+ * rather than "0 B" so an unknown figure is omitted instead of asserted.
+ */
+export function formatBytes(bytes: number | null): string | null {
+  if (bytes === null || !Number.isFinite(bytes) || bytes <= 0) return null;
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unit = 0;
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024;
+    unit += 1;
+  }
+  return `${value.toFixed(value >= 100 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+/** A payload is only adopted when it is really an inventory. */
+function isSnapshot(value: unknown): value is LocalModelsSnapshot {
+  if (!value || typeof value !== "object") return false;
+  const models = (value as { models?: unknown }).models;
+  if (!Array.isArray(models)) return false;
+  return models.every(m =>
+    !!m && typeof m === "object"
+    && typeof (m as LocalModelEntry).id === "string"
+    && typeof (m as LocalModelEntry).running === "string");
+}
+
+export default function LocalModelsPanel({ active }: { active: boolean }) {
+  const [snapshot, setSnapshot] = useState<LocalModelsSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  // A toggle takes seconds; without this the poll below would overwrite the
+  // optimistic row with the pre-toggle reading mid-flight.
+  const pendingRef = useRef<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (pendingRef.current) return;
+    try {
+      const res = await fetch("/setup-api/local-models", { cache: "no-store" });
+      const data = await res.json();
+      if (!isSnapshot(data)) return;
+      setSnapshot(data);
+    } catch {
+      /* keep the last good reading rather than blanking the tab */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    refresh();
+    const t = setInterval(() => { refresh().catch(() => {}); }, 5000);
+    return () => clearInterval(t);
+  }, [active, refresh]);
+
+  const toggle = useCallback(async (entry: LocalModelEntry, next: boolean) => {
+    pendingRef.current = entry.id;
+    setPendingId(entry.id);
+    setError(null);
+    try {
+      const res = await fetch("/setup-api/local-models", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: entry.id, enabled: next }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data?.error === "string" ? data.error : "Could not change that model.");
+        return;
+      }
+      if (isSnapshot(data)) setSnapshot(data);
+    } catch {
+      setError("Could not reach the box to change that model.");
+    } finally {
+      pendingRef.current = null;
+      setPendingId(null);
+    }
+  }, []);
+
+  if (!snapshot) {
+    return (
+      <div className="max-w-2xl space-y-3" data-testid="local-models-loading">
+        {[0, 1, 2].map(i => (
+          <div key={i} className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5 animate-pulse">
+            <div className="h-3 w-40 rounded bg-white/[0.08]" />
+            <div className="h-2 w-64 rounded bg-white/[0.06] mt-3" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <p className="text-sm text-[var(--text-secondary)]">
+        Everything that can run on the box itself, and what it is doing right now. Anything shown as
+        not installed is genuinely absent — it is not a setting you can switch on here.
+      </p>
+
+      {error && (
+        <div role="alert" className="rounded-xl border border-red-500/20 bg-red-500/[0.06] px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {snapshot.unavailable.length > 0 && (
+        <div className="rounded-xl border border-amber-500/20 bg-amber-500/[0.06] px-4 py-3 text-sm text-amber-200">
+          Could not read the state of: {snapshot.unavailable.join(", ")}.
+        </div>
+      )}
+
+      {snapshot.models.map(entry => {
+        const disk = formatBytes(entry.diskBytes);
+        const memory = formatBytes(entry.memoryBytes);
+        const busy = pendingId === entry.id;
+        return (
+          <div
+            key={entry.id}
+            data-testid={`local-model-${entry.id}`}
+            className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5"
+          >
+            <div className="flex items-start gap-4">
+              <span className="flex items-center justify-center w-10 h-10 rounded-xl bg-white/[0.06] shrink-0">
+                <span className="material-symbols-rounded text-[var(--text-muted)]" style={{ fontSize: 20 }} aria-hidden="true">
+                  {KIND_ICON[entry.kind]}
+                </span>
+              </span>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span className="text-sm font-semibold text-[var(--text-primary)]">{entry.name}</span>
+                  <span className={`text-[11px] px-2 py-0.5 rounded-full border ${RUN_TONE[entry.running]}`}>
+                    {RUN_LABEL[entry.running]}
+                  </span>
+                </div>
+                <div className="text-xs text-[var(--text-muted)] mt-0.5">
+                  {KIND_LABEL[entry.kind]} · {entry.runtime}
+                </div>
+                <p className="text-sm text-[var(--text-secondary)] mt-2">{entry.detail}</p>
+                {(disk || memory) && (
+                  <div className="flex gap-4 mt-2 text-xs text-[var(--text-muted)]">
+                    {disk && <span>Disk {disk}</span>}
+                    {memory && <span>Memory in use {memory}</span>}
+                  </div>
+                )}
+                {entry.managedBy === "clawkeep" && (
+                  <p className="text-xs text-[var(--text-muted)] mt-2">Managed in ClawKeep.</p>
+                )}
+                {entry.managedBy === "localAi" && (
+                  <p className="text-xs text-[var(--text-muted)] mt-2">Managed in Settings → Local AI.</p>
+                )}
+              </div>
+              {entry.control !== "none" && entry.enabled !== null && (
+                <div className="flex items-center gap-2 shrink-0">
+                  {busy && (
+                    <span className="material-symbols-rounded animate-spin text-[var(--text-muted)]" style={{ fontSize: 18 }} aria-hidden="true">
+                      progress_activity
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-label={`${entry.name} enabled`}
+                    aria-checked={entry.enabled}
+                    aria-busy={busy}
+                    disabled={busy}
+                    onClick={() => toggle(entry, !entry.enabled)}
+                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 ${
+                      entry.enabled ? "bg-[var(--coral-bright)]" : "bg-gray-600"
+                    }`}
+                  >
+                    <span className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${entry.enabled ? "translate-x-6" : "translate-x-1"}`} />
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+
+      <p className="text-xs text-[var(--text-muted)]">
+        Turning a model off stops it now and keeps it off after a reboot.
+      </p>
+    </div>
+  );
+}

--- a/src/components/LocalModelsPanel.tsx
+++ b/src/components/LocalModelsPanel.tsx
@@ -54,11 +54,19 @@ export function formatBytes(bytes: number | null): string | null {
   return `${value.toFixed(value >= 100 || unit === 0 ? 0 : 1)} ${units[unit]}`;
 }
 
-/** A payload is only adopted when it is really an inventory. */
+/**
+ * A payload is only adopted when it is really an inventory — EVERY field the
+ * render reads, not just the one it reads first. `{ "models": [] }` used to
+ * pass here and then threw on `snapshot.unavailable.length` a few lines later,
+ * which is the same "guard the shape, then read an ungarded sibling" mistake
+ * that took the whole ClawKeep window down on TASK-398.
+ */
 function isSnapshot(value: unknown): value is LocalModelsSnapshot {
   if (!value || typeof value !== "object") return false;
   const models = (value as { models?: unknown }).models;
-  if (!Array.isArray(models)) return false;
+  const unavailable = (value as { unavailable?: unknown }).unavailable;
+  if (!Array.isArray(models) || !Array.isArray(unavailable)) return false;
+  if (!unavailable.every(u => typeof u === "string")) return false;
   return models.every(m =>
     !!m && typeof m === "object"
     && typeof (m as LocalModelEntry).id === "string"

--- a/src/components/LocalModelsPanel.tsx
+++ b/src/components/LocalModelsPanel.tsx
@@ -54,23 +54,44 @@ export function formatBytes(bytes: number | null): string | null {
   return `${value.toFixed(value >= 100 || unit === 0 ? 0 : 1)} ${units[unit]}`;
 }
 
+const RUN_STATES = Object.keys(RUN_LABEL) as RunState[];
+const KINDS = Object.keys(KIND_LABEL) as LocalModelEntry["kind"][];
+const CONTROLS = ["none", "user-unit", "system-unit"];
+
 /**
  * A payload is only adopted when it is really an inventory — EVERY field the
  * render reads, not just the one it reads first. `{ "models": [] }` used to
  * pass here and then threw on `snapshot.unavailable.length` a few lines later,
- * which is the same "guard the shape, then read an ungarded sibling" mistake
+ * which is the same "guard the shape, then read an unguarded sibling" mistake
  * that took the whole ClawKeep window down on TASK-398.
+ *
+ * The enums are checked against the lookup tables themselves rather than a
+ * hand-written list, so a state added to the model but not to the copy is
+ * rejected here instead of rendering as a blank pill.
  */
+function isEntry(value: unknown): value is LocalModelEntry {
+  if (!value || typeof value !== "object") return false;
+  const m = value as Record<string, unknown>;
+  for (const key of ["id", "name", "runtime", "detail"]) {
+    if (typeof m[key] !== "string") return false;
+  }
+  if (typeof m.installed !== "boolean") return false;
+  if (m.enabled !== null && typeof m.enabled !== "boolean") return false;
+  for (const key of ["diskBytes", "memoryBytes"]) {
+    if (m[key] !== null && typeof m[key] !== "number") return false;
+  }
+  return KINDS.includes(m.kind as LocalModelEntry["kind"])
+    && RUN_STATES.includes(m.running as RunState)
+    && CONTROLS.includes(m.control as string);
+}
+
 function isSnapshot(value: unknown): value is LocalModelsSnapshot {
   if (!value || typeof value !== "object") return false;
   const models = (value as { models?: unknown }).models;
   const unavailable = (value as { unavailable?: unknown }).unavailable;
   if (!Array.isArray(models) || !Array.isArray(unavailable)) return false;
   if (!unavailable.every(u => typeof u === "string")) return false;
-  return models.every(m =>
-    !!m && typeof m === "object"
-    && typeof (m as LocalModelEntry).id === "string"
-    && typeof (m as LocalModelEntry).running === "string");
+  return models.every(isEntry);
 }
 
 export default function LocalModelsPanel({ active }: { active: boolean }) {

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -13,6 +13,7 @@ import { dispatchOpenApp } from "@/lib/ui-events";
 import AIModelsStep from "./AIModelsStep";
 import TelegramConfiguringOverlay from "./TelegramConfiguringOverlay";
 import RemoteControlPanel from "./RemoteControlPanel";
+import LocalModelsPanel from "./LocalModelsPanel";
 import FreeTierUpgradeCard from "./FreeTierUpgradeCard";
 import { copyToClipboard } from "@/lib/clipboard";
 import ClawBoxLoginModal, { type ClawBoxLoginFeature } from "./ClawBoxLoginModal";
@@ -70,7 +71,7 @@ interface SystemStats {
 }
 
 
-const SECTIONS = ["appearance", "wifi", "ai", "localAi", "telegram", "remote", "system", "about"] as const;
+const SECTIONS = ["appearance", "wifi", "ai", "localAi", "localModels", "telegram", "remote", "system", "about"] as const;
 
 const REBOOT_PROBE_GRACE_MS = 8_000;
 const REBOOT_PROBE_INTERVAL_MS = 3_000;
@@ -84,6 +85,7 @@ const NAV_ITEMS: { id: Section; icon: string; labelKey?: string; label?: string 
   { id: "wifi", icon: "wifi", labelKey: "settings.network" },
   { id: "ai", icon: "smart_toy", labelKey: "settings.aiProvider" },
   { id: "localAi", icon: "memory", label: "Local AI" },
+  { id: "localModels", icon: "deployed_code", label: "Local Models" },
   { id: "telegram", icon: "send", labelKey: "settings.telegram" },
   { id: "remote", icon: "cloud_sync", labelKey: "settings.remote" },
   { id: "system", icon: "monitor_heart", labelKey: "settings.system" },
@@ -2428,6 +2430,11 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               }}
             /></I18nProvider>
           </div>
+        )}
+
+        {/* ─── Local Models ─── */}
+        {activeSection === "localModels" && (
+          <LocalModelsPanel active={activeSection === "localModels"} />
         )}
 
         {/* ─── Telegram ─── */}

--- a/src/lib/local-models.ts
+++ b/src/lib/local-models.ts
@@ -370,7 +370,26 @@ interface EmbeddingProbe {
   local: boolean;
 }
 
-function embeddingEntry(probe: EmbeddingProbe): LocalModelEntry {
+/**
+ * `engines` are the rows already built, so the embedding row can be checked
+ * against the thing that actually serves it.
+ *
+ * This matters: ClawKeep's memory status answers `available: true, health:
+ * healthy` from the index and the configured provider, NOT from a live embed
+ * call — verified on a box where Ollama had been stopped and it still said
+ * healthy. Passing that straight through would put "Embedding your memory on
+ * the box" one row below "Ollama — Stopped", which is precisely the
+ * "must not read as available" case this tab exists to remove.
+ */
+function embeddingEntry(probe: EmbeddingProbe, engines: LocalModelEntry[]): LocalModelEntry {
+  const providerId = probe.provider ? probe.provider.toLowerCase() : null;
+  const host = providerId ? engines.find(e => e.id === providerId) : undefined;
+  const hostStopped = !!host && host.running !== "running" && host.running !== "on-demand";
+  const running: RunState = !probe.available
+    ? "not-installed"
+    : hostStopped
+      ? "idle"
+      : probe.local ? "running" : "on-demand";
   return {
     id: "embeddings",
     name: probe.model ? `Memory embeddings (${probe.model})` : "Memory embeddings",
@@ -378,16 +397,18 @@ function embeddingEntry(probe: EmbeddingProbe): LocalModelEntry {
     runtime: probe.provider ?? "unknown",
     installed: probe.available,
     enabled: null,
-    running: probe.available ? (probe.local ? "running" : "on-demand") : "not-installed",
+    running,
     diskBytes: null,
     memoryBytes: null,
     control: "none",
     managedBy: "clawkeep",
     detail: !probe.available
       ? "No embedding model is answering, so memory search cannot run."
-      : probe.local
-        ? "Embedding your memory on the box. Manage it in ClawKeep."
-        : "Embedding your memory in the cloud. Manage it in ClawKeep.",
+      : hostStopped
+        ? `${host?.name ?? "Its engine"} is stopped, so memory cannot be embedded until you turn it back on.`
+        : probe.local
+          ? "Embedding your memory on the box. Manage it in ClawKeep."
+          : "Embedding your memory in the cloud. Manage it in ClawKeep.",
   };
 }
 
@@ -403,19 +424,21 @@ export interface InventoryProbes {
  * a subordinate panel caused in ClawKeep on TASK-398.
  */
 export async function buildLocalModelInventory(probes: InventoryProbes): Promise<LocalModelsSnapshot> {
-  const builders: [string, () => Promise<LocalModelEntry>][] = [
+  // Order matters for one reason only: the embedding row is checked against the
+  // engine that serves it, so that engine's row has to exist by then.
+  const builders: [string, (built: LocalModelEntry[]) => Promise<LocalModelEntry>][] = [
     ["llamacpp", () => llamaCppEntry(probes.llamacpp)],
     ["ollama", () => ollamaEntry(probes.ollamaBaseUrl)],
     ["kokoro", kokoroEntry],
     ["piper", piperEntry],
     ["whisper", whisperEntry],
-    ["embeddings", async () => embeddingEntry(probes.embeddings)],
+    ["embeddings", async built => embeddingEntry(probes.embeddings, built)],
   ];
   const models: LocalModelEntry[] = [];
   const unavailable: string[] = [];
   for (const [id, build] of builders) {
     try {
-      models.push(await build());
+      models.push(await build(models));
     } catch {
       unavailable.push(id);
     }

--- a/src/lib/local-models.ts
+++ b/src/lib/local-models.ts
@@ -1,0 +1,479 @@
+/**
+ * The local-model inventory behind Settings → Local Models.
+ *
+ * Everything here is a MEASUREMENT of the device, never a claim from a config
+ * file. That is the whole point of the tab: `install.sh` printed "On-device TTS
+ * configured (Kokoro GPU, Piper fallback)" on boxes where Kokoro had never been
+ * installed, and nothing in the UI could contradict it (TASK-420). So an engine
+ * is "installed" only when the artefact it needs is on disk, and "running" only
+ * when systemd or the process table says so.
+ *
+ * The paths and unit names below are the ones `scripts/install-voice.sh`
+ * actually writes; `src/tests/unit/local-models-installer-contract.test.ts`
+ * reads that script and fails if they drift apart.
+ */
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
+const execFileAsync = promisify(execFile);
+
+export type ModelKind = "llm" | "tts" | "stt" | "embedding";
+
+/**
+ * How a customer may act on the engine.
+ *  - "user-unit"   : a systemd --user unit; the web server can toggle it itself
+ *  - "system-unit" : a system unit reachable through the scoped sudoers grants
+ *  - "none"        : nothing to toggle (on-demand binaries, or not installed)
+ */
+export type ControlKind = "none" | "user-unit" | "system-unit";
+
+/**
+ * Deliberately NOT a boolean. "Not installed" and "installed but idle" are
+ * different facts and the tab must not collapse them — a crashed or absent
+ * model reading as merely "off" is the failure this task exists to remove.
+ */
+export type RunState = "running" | "idle" | "on-demand" | "not-installed";
+
+export interface LocalModelEntry {
+  id: string;
+  name: string;
+  kind: ModelKind;
+  /** What supplies it, shown as the subtitle: "systemd user service", "Ollama"… */
+  runtime: string;
+  installed: boolean;
+  /** null when the engine has no unit, so "enabled" is not a meaningful question. */
+  enabled: boolean | null;
+  running: RunState;
+  /** Bytes on disk for the model artefacts, or null when nothing was found. */
+  diskBytes: number | null;
+  /** Resident bytes of the engine's processes right now, null when not running. */
+  memoryBytes: number | null;
+  control: ControlKind;
+  /** One line the customer can act on. Never a command line, never a path. */
+  detail: string;
+  /** Settings section or app that owns this engine's deeper controls. */
+  managedBy?: "clawkeep" | "localAi";
+}
+
+export interface LocalModelsSnapshot {
+  models: LocalModelEntry[];
+  /** Engines whose state could not be read at all, by id. */
+  unavailable: string[];
+}
+
+const HOME = process.env.CLAWBOX_HOME || os.homedir() || "/home/clawbox";
+
+/** Paths written by scripts/install-voice.sh — see the contract test. */
+export const PIPER_DIR = path.join(HOME, ".local/share/piper");
+export const PIPER_BINARY = path.join(PIPER_DIR, "piper");
+export const PIPER_VOICE_DIR = path.join(PIPER_DIR, "voices");
+export const KOKORO_STAMP = path.join(HOME, ".cache/clawbox/kokoro-installed");
+export const SYSTEMD_USER_DIR = path.join(HOME, ".config/systemd/user");
+export const KOKORO_UNIT = "kokoro-server.service";
+export const WHISPER_UNIT = "whisper-server.service";
+export const OLLAMA_UNIT = "ollama.service";
+
+/** Units this module is ever allowed to name to systemctl. */
+const USER_UNITS = new Set([KOKORO_UNIT, WHISPER_UNIT]);
+const SYSTEM_UNITS = new Set([OLLAMA_UNIT]);
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function dirBytes(dir: string): Promise<number | null> {
+  let total = 0;
+  let sawAnything = false;
+  const walk = async (d: string, depth: number): Promise<void> => {
+    if (depth > 4) return;
+    let entries;
+    try {
+      entries = await fs.readdir(d, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const full = path.join(d, e.name);
+      if (e.isDirectory()) {
+        await walk(full, depth + 1);
+      } else if (e.isFile()) {
+        try {
+          const st = await fs.stat(full);
+          total += st.size;
+          sawAnything = true;
+        } catch {
+          /* a file that vanished mid-scan is not a failure */
+        }
+      }
+    }
+  };
+  await walk(dir, 0);
+  return sawAnything ? total : null;
+}
+
+async function run(cmd: string, args: string[], timeout = 5000): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(cmd, args, { timeout });
+    return stdout;
+  } catch (err) {
+    // systemctl exits non-zero for "inactive"/"disabled" and still prints the
+    // word we want, so a failure with usable stdout is a real answer.
+    const out = (err as { stdout?: string })?.stdout;
+    return typeof out === "string" && out.trim() ? out : null;
+  }
+}
+
+function userSystemctlEnv(): NodeJS.ProcessEnv {
+  // A `--user` call from a system service has no bus address unless we point it
+  // at the user's runtime dir; without this every answer is "Failed to connect".
+  return {
+    ...process.env,
+    XDG_RUNTIME_DIR: process.env.XDG_RUNTIME_DIR || `/run/user/${process.getuid?.() ?? 1000}`,
+  };
+}
+
+async function runUserSystemctl(args: string[]): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync("/usr/bin/systemctl", ["--user", ...args], {
+      timeout: 5000,
+      env: userSystemctlEnv(),
+    });
+    return stdout;
+  } catch (err) {
+    const out = (err as { stdout?: string })?.stdout;
+    return typeof out === "string" && out.trim() ? out : null;
+  }
+}
+
+export interface UnitState {
+  /** The unit file exists at all. */
+  present: boolean;
+  active: boolean;
+  enabled: boolean;
+}
+
+export async function readUnitState(unit: string, scope: "user" | "system"): Promise<UnitState> {
+  const isActive = scope === "user"
+    ? await runUserSystemctl(["is-active", unit])
+    : await run("/usr/bin/systemctl", ["is-active", unit]);
+  const isEnabled = scope === "user"
+    ? await runUserSystemctl(["is-enabled", unit])
+    : await run("/usr/bin/systemctl", ["is-enabled", unit]);
+  const enabledWord = (isEnabled ?? "").trim();
+  // `is-enabled` answers with an error string, not a state, when the unit file
+  // is missing — that is how "absent" is told apart from "installed but off".
+  const present = enabledWord !== "" && !enabledWord.toLowerCase().includes("no such file");
+  return {
+    present,
+    active: (isActive ?? "").trim() === "active",
+    enabled: ["enabled", "enabled-runtime", "static", "alias", "indirect"].includes(enabledWord),
+  };
+}
+
+/** Resident bytes of every process whose command line matches `pattern`. */
+export async function processMemoryBytes(pattern: string): Promise<number | null> {
+  const out = await run("/usr/bin/pgrep", ["-f", pattern]);
+  const pids = (out ?? "").split("\n").map(s => s.trim()).filter(Boolean);
+  if (!pids.length) return null;
+  let total = 0;
+  let sawAny = false;
+  for (const pid of pids) {
+    if (!/^\d+$/.test(pid)) continue;
+    try {
+      const status = await fs.readFile(`/proc/${pid}/status`, "utf8");
+      const m = status.match(/^VmRSS:\s+(\d+) kB$/m);
+      if (m) {
+        total += Number(m[1]) * 1024;
+        sawAny = true;
+      }
+    } catch {
+      /* the process exited between pgrep and the read */
+    }
+  }
+  return sawAny ? total : null;
+}
+
+async function ollamaModels(baseUrl: string): Promise<{ name: string; size: number }[] | null> {
+  try {
+    const res = await fetch(`${baseUrl}/api/tags`, { signal: AbortSignal.timeout(4000) });
+    if (!res.ok) return null;
+    const data = await res.json();
+    const list = Array.isArray(data?.models) ? data.models : [];
+    return list
+      .filter((m: unknown): m is { name: string; size: number } =>
+        !!m && typeof (m as { name?: unknown }).name === "string")
+      .map((m: { name: string; size?: number }) => ({ name: m.name, size: Number(m.size) || 0 }));
+  } catch {
+    return null;
+  }
+}
+
+function shortModelName(name: string): string {
+  return name.replace(/:latest$/, "");
+}
+
+async function piperEntry(): Promise<LocalModelEntry> {
+  const [binary, voiceBytes] = await Promise.all([exists(PIPER_BINARY), dirBytes(PIPER_VOICE_DIR)]);
+  const voices = await listVoices();
+  // Piper is a binary invoked per utterance, not a server. "idle" would imply
+  // something that could be running and isn't; on-demand is the truth.
+  const installed = binary && voices.length > 0;
+  return {
+    id: "piper",
+    name: "Piper",
+    kind: "tts",
+    runtime: "On-demand binary",
+    installed,
+    enabled: null,
+    running: installed ? "on-demand" : "not-installed",
+    diskBytes: voiceBytes,
+    memoryBytes: null,
+    control: "none",
+    detail: installed
+      ? `Speaks on demand. ${voices.length} voice${voices.length === 1 ? "" : "s"} installed: ${voices.join(", ")}.`
+      : binary
+        ? "The Piper program is installed but no voice is, so it cannot speak yet."
+        : "Not installed on this box.",
+  };
+}
+
+async function listVoices(): Promise<string[]> {
+  try {
+    const entries = await fs.readdir(PIPER_VOICE_DIR);
+    return entries.filter(f => f.endsWith(".onnx")).map(f => f.replace(/\.onnx$/, "")).sort();
+  } catch {
+    return [];
+  }
+}
+
+async function kokoroEntry(): Promise<LocalModelEntry> {
+  const [stamped, unit] = await Promise.all([
+    exists(KOKORO_STAMP),
+    readUnitState(KOKORO_UNIT, "user"),
+  ]);
+  // BOTH have to be true. The weights alone are not an installation: on the
+  // loop's own test box the 82M Kokoro weights sit in the HuggingFace cache
+  // from a run that failed afterwards, with no unit and no stamp. Reporting
+  // that as installed is precisely the lie this tab removes.
+  const installed = stamped && unit.present;
+  const memoryBytes = unit.active ? await processMemoryBytes("kokoro-server.py") : null;
+  return {
+    id: "kokoro",
+    name: "Kokoro",
+    kind: "tts",
+    runtime: "systemd user service",
+    installed,
+    enabled: installed ? unit.enabled : null,
+    running: !installed ? "not-installed" : unit.active ? "running" : "idle",
+    diskBytes: null,
+    memoryBytes,
+    control: installed ? "user-unit" : "none",
+    detail: installed
+      ? unit.active
+        ? "Running as the GPU voice."
+        : "Installed and stopped."
+      : stamped
+        ? "Marked as installed but its service is missing, so it cannot speak."
+        : "Not installed on this box. Speech falls back to Piper.",
+  };
+}
+
+async function whisperEntry(): Promise<LocalModelEntry> {
+  const unit = await readUnitState(WHISPER_UNIT, "user");
+  const memoryBytes = unit.active ? await processMemoryBytes("whisper-server.py") : null;
+  return {
+    id: "whisper",
+    name: "Whisper",
+    kind: "stt",
+    runtime: "systemd user service",
+    installed: unit.present,
+    enabled: unit.present ? unit.enabled : null,
+    running: !unit.present ? "not-installed" : unit.active ? "running" : "idle",
+    diskBytes: null,
+    memoryBytes,
+    control: unit.present ? "user-unit" : "none",
+    detail: unit.present
+      ? unit.active
+        ? "Running and ready to transcribe."
+        : "Installed and stopped. It starts on demand when you speak."
+      : "Not installed on this box. Speech is transcribed in the cloud.",
+  };
+}
+
+async function ollamaEntry(baseUrl: string): Promise<LocalModelEntry> {
+  const unit = await readUnitState(OLLAMA_UNIT, "system");
+  const models = unit.active ? await ollamaModels(baseUrl) : null;
+  const memoryBytes = unit.active ? await processMemoryBytes("ollama") : null;
+  const diskBytes = models?.length ? models.reduce((sum, m) => sum + m.size, 0) : null;
+  const names = (models ?? []).map(m => shortModelName(m.name));
+  return {
+    id: "ollama",
+    name: "Ollama",
+    kind: "llm",
+    runtime: "System service",
+    installed: unit.present,
+    enabled: unit.present ? unit.enabled : null,
+    running: !unit.present ? "not-installed" : unit.active ? "running" : "idle",
+    diskBytes,
+    memoryBytes,
+    control: unit.present ? "system-unit" : "none",
+    detail: !unit.present
+      ? "Not installed on this box."
+      : !unit.active
+        ? "Installed and stopped."
+        : names.length
+          ? `Serving ${names.length} model${names.length === 1 ? "" : "s"}: ${names.join(", ")}.`
+          : "Running with no models pulled yet.",
+  };
+}
+
+interface LlamaCppProbe {
+  installed: boolean;
+  running: boolean;
+  model: string | null;
+}
+
+async function llamaCppEntry(probe: LlamaCppProbe): Promise<LocalModelEntry> {
+  const memoryBytes = probe.running ? await processMemoryBytes("llama-server") : null;
+  return {
+    id: "llamacpp",
+    name: probe.model ? `Local LLM (${probe.model})` : "Local LLM",
+    kind: "llm",
+    runtime: "llama.cpp",
+    installed: probe.installed,
+    enabled: null,
+    running: !probe.installed ? "not-installed" : probe.running ? "running" : "idle",
+    diskBytes: null,
+    memoryBytes,
+    control: "none",
+    managedBy: "localAi",
+    detail: !probe.installed
+      ? "Not installed on this box."
+      : probe.running
+        ? "Answering on the box right now."
+        : "Installed and in standby to free memory until it is needed.",
+  };
+}
+
+interface EmbeddingProbe {
+  available: boolean;
+  provider: string | null;
+  model: string | null;
+  local: boolean;
+}
+
+function embeddingEntry(probe: EmbeddingProbe): LocalModelEntry {
+  return {
+    id: "embeddings",
+    name: probe.model ? `Memory embeddings (${probe.model})` : "Memory embeddings",
+    kind: "embedding",
+    runtime: probe.provider ?? "unknown",
+    installed: probe.available,
+    enabled: null,
+    running: probe.available ? (probe.local ? "running" : "on-demand") : "not-installed",
+    diskBytes: null,
+    memoryBytes: null,
+    control: "none",
+    managedBy: "clawkeep",
+    detail: !probe.available
+      ? "No embedding model is answering, so memory search cannot run."
+      : probe.local
+        ? "Embedding your memory on the box. Manage it in ClawKeep."
+        : "Embedding your memory in the cloud. Manage it in ClawKeep.",
+  };
+}
+
+export interface InventoryProbes {
+  ollamaBaseUrl: string;
+  llamacpp: LlamaCppProbe;
+  embeddings: EmbeddingProbe;
+}
+
+/**
+ * Build the inventory. Every entry is produced independently so one engine that
+ * cannot be read never costs the customer the whole tab — the same failure mode
+ * a subordinate panel caused in ClawKeep on TASK-398.
+ */
+export async function buildLocalModelInventory(probes: InventoryProbes): Promise<LocalModelsSnapshot> {
+  const builders: [string, () => Promise<LocalModelEntry>][] = [
+    ["llamacpp", () => llamaCppEntry(probes.llamacpp)],
+    ["ollama", () => ollamaEntry(probes.ollamaBaseUrl)],
+    ["kokoro", kokoroEntry],
+    ["piper", piperEntry],
+    ["whisper", whisperEntry],
+    ["embeddings", async () => embeddingEntry(probes.embeddings)],
+  ];
+  const models: LocalModelEntry[] = [];
+  const unavailable: string[] = [];
+  for (const [id, build] of builders) {
+    try {
+      models.push(await build());
+    } catch {
+      unavailable.push(id);
+    }
+  }
+  return { models, unavailable };
+}
+
+export interface ToggleResult {
+  ok: boolean;
+  error?: string;
+}
+
+/**
+ * Turn an engine on or off for good: `--now` so the change takes effect
+ * immediately, and enable/disable so it survives a reboot. TASK-435 asked
+ * whether "disable" should mean stop now or stop at next boot; doing both is
+ * the only answer under which neither reading is violated.
+ */
+export async function setEngineEnabled(
+  unit: string,
+  scope: "user" | "system",
+  enabled: boolean,
+): Promise<ToggleResult> {
+  const allowed = scope === "user" ? USER_UNITS : SYSTEM_UNITS;
+  if (!allowed.has(unit)) return { ok: false, error: "Unknown service." };
+  const verb = enabled ? "enable" : "disable";
+  try {
+    if (scope === "user") {
+      await execFileAsync("/usr/bin/systemctl", ["--user", verb, "--now", unit], {
+        timeout: 30_000,
+        env: userSystemctlEnv(),
+      });
+    } else {
+      // sudo is scoped per exact argument list in config/clawbox-sudoers, so the
+      // verb and the unit are literals here, never interpolated user input.
+      await execFileAsync("/usr/bin/sudo", ["/usr/bin/systemctl", verb, "--now", unit], {
+        timeout: 30_000,
+      });
+    }
+    return { ok: true };
+  } catch (err) {
+    // Never surface the command line: it carries absolute paths, and scope 10
+    // of the parent epic forbids that reaching the customer.
+    const raw = err instanceof Error ? err.message : "";
+    const denied = /sudo|password|not allowed|permission/i.test(raw);
+    return {
+      ok: false,
+      error: denied
+        ? "This box does not allow the web interface to change that service."
+        : `Could not ${verb} the service.`,
+    };
+  }
+}
+
+/** The unit and scope a toggleable engine maps to, or null when it has none. */
+export function unitForEngine(id: string): { unit: string; scope: "user" | "system" } | null {
+  if (id === "kokoro") return { unit: KOKORO_UNIT, scope: "user" };
+  if (id === "whisper") return { unit: WHISPER_UNIT, scope: "user" };
+  if (id === "ollama") return { unit: OLLAMA_UNIT, scope: "system" };
+  return null;
+}

--- a/src/lib/local-models.ts
+++ b/src/lib/local-models.ts
@@ -221,8 +221,11 @@ function shortModelName(name: string): string {
 }
 
 async function piperEntry(): Promise<LocalModelEntry> {
-  const [binary, voiceBytes] = await Promise.all([exists(PIPER_BINARY), dirBytes(PIPER_VOICE_DIR)]);
-  const voices = await listVoices();
+  const [binary, voiceBytes, voices] = await Promise.all([
+    exists(PIPER_BINARY),
+    dirBytes(PIPER_VOICE_DIR),
+    listVoices(),
+  ]);
   // Piper is a binary invoked per utterance, not a server. "idle" would imply
   // something that could be running and isn't; on-demand is the truth.
   const installed = binary && voices.length > 0;
@@ -424,24 +427,31 @@ export interface InventoryProbes {
  * a subordinate panel caused in ClawKeep on TASK-398.
  */
 export async function buildLocalModelInventory(probes: InventoryProbes): Promise<LocalModelsSnapshot> {
-  // Order matters for one reason only: the embedding row is checked against the
-  // engine that serves it, so that engine's row has to exist by then.
-  const builders: [string, (built: LocalModelEntry[]) => Promise<LocalModelEntry>][] = [
+  // Concurrent, not sequential: every engine costs at least two systemctl
+  // round-trips and some cost an HTTP probe, and on a Jetson a serial pass adds
+  // up to seconds on a panel that refreshes every five. The engines do not
+  // depend on each other, so nothing is gained by waiting.
+  const builders: [string, () => Promise<LocalModelEntry>][] = [
     ["llamacpp", () => llamaCppEntry(probes.llamacpp)],
     ["ollama", () => ollamaEntry(probes.ollamaBaseUrl)],
     ["kokoro", kokoroEntry],
     ["piper", piperEntry],
     ["whisper", whisperEntry],
-    ["embeddings", async built => embeddingEntry(probes.embeddings, built)],
   ];
-  const models: LocalModelEntry[] = [];
-  const unavailable: string[] = [];
-  for (const [id, build] of builders) {
+  const settled = await Promise.all(builders.map(async ([id, build]) => {
     try {
-      models.push(await build(models));
+      return { id, entry: await build() };
     } catch {
-      unavailable.push(id);
+      return { id, entry: null };
     }
+  }));
+  const models = settled.map(r => r.entry).filter((e): e is LocalModelEntry => e !== null);
+  const unavailable = settled.filter(r => r.entry === null).map(r => r.id);
+  // Embeddings last and alone: it is the only row read against another row.
+  try {
+    models.push(embeddingEntry(probes.embeddings, models));
+  } catch {
+    unavailable.push("embeddings");
   }
   return { models, unavailable };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -143,6 +143,7 @@ const PRE_AUTH_SENSITIVE_PREFIXES = [
   "/setup-api/apps/settings",  // privileged `openclaw config set skills.*` + credential writes
   "/setup-api/gateway/ws-config", // hands back the live gateway auth token
   "/setup-api/chat",        // reads generated media out of the harness media tree
+  "/setup-api/local-models", // POST enables/disables real systemd units through sudo
   // Hermes edition. During setup the device broadcasts an OPEN `ClawBox-Setup`
   // AP, so anything left pre-auth is reachable by anyone in radio range.
   //   - /hermes/chat runs a full agent turn with shell/tool access, unlimited.

--- a/src/tests/components/local-models-panel.test.tsx
+++ b/src/tests/components/local-models-panel.test.tsx
@@ -102,6 +102,22 @@ describe("Local Models panel", () => {
     await expectSecondPollIgnored({});
   });
 
+  it("refuses an entry that is missing fields the render reads", async () => {
+    // A well-formed envelope is not a well-formed entry. This one has a valid
+    // `unavailable` array and an entry with an id, so a guard that stops at the
+    // envelope accepts it — and then `KIND_ICON[undefined]` and
+    // `RUN_TONE[undefined]` render an unlabelled, untoned row that looks like
+    // a real reading of the box.
+    await expectSecondPollIgnored({ models: [{ id: "ollama", running: "running" }], unavailable: [] });
+  });
+
+  it("refuses an entry whose state is not one the copy knows", async () => {
+    await expectSecondPollIgnored({
+      models: [{ ...model(), running: "warming-up" }],
+      unavailable: [],
+    });
+  });
+
   it("refuses a payload that has models but no unavailable list", async () => {
     // Narrower than the case above and worth its own test: `{ models: [] }`
     // satisfies a guard that only checks `models`, is then stored, and the very

--- a/src/tests/components/local-models-panel.test.tsx
+++ b/src/tests/components/local-models-panel.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
+import { act, fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
 import LocalModelsPanel from "@/components/LocalModelsPanel";
 
 /**
@@ -28,7 +28,7 @@ function mockFetch(payloads: unknown[]) {
 }
 
 beforeEach(() => { vi.useRealTimers(); });
-afterEach(() => { vi.unstubAllGlobals(); });
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); });
 
 describe("Local Models panel", () => {
   it("shows a running engine with its footprint", async () => {
@@ -99,17 +99,41 @@ describe("Local Models panel", () => {
     // front of an older build. Adopting that as state read `.models` off
     // nothing on the next render and took the WHOLE window down, backups and
     // all. This drives a real second poll rather than trusting the first one.
-    const fn = vi.fn()
-      .mockResolvedValueOnce({ ok: true, json: async () => ({ models: [model()], unavailable: [] }) })
-      .mockResolvedValue({ ok: true, json: async () => ({}) });
-    vi.stubGlobal("fetch", fn);
-    render(<LocalModelsPanel active />);
-    const row = await screen.findByTestId("local-model-ollama");
-    expect(within(row).getByText("Running")).toBeTruthy();
+    await expectSecondPollIgnored({});
+  });
 
-    await waitFor(() => expect(fn.mock.calls.length).toBeGreaterThan(1), { timeout: 8000 });
-    // Still the engine from the good payload, and the panel is still standing.
-    const after = await screen.findByTestId("local-model-ollama");
-    expect(within(after).getByText("Running")).toBeTruthy();
-  }, 15000);
+  it("refuses a payload that has models but no unavailable list", async () => {
+    // Narrower than the case above and worth its own test: `{ models: [] }`
+    // satisfies a guard that only checks `models`, is then stored, and the very
+    // next render reads `.unavailable.length` off nothing. Guarding the field
+    // you read first is not the same as guarding the shape you rely on.
+    await expectSecondPollIgnored({ models: [] });
+  });
 });
+
+/**
+ * Render with a good inventory, let one more poll return `bad`, and assert the
+ * panel is still showing the good reading afterwards.
+ */
+async function expectSecondPollIgnored(bad: unknown) {
+  const fn = vi.fn()
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ models: [model()], unavailable: [] }) })
+    .mockResolvedValue({ ok: true, json: async () => bad });
+  vi.stubGlobal("fetch", fn);
+
+  // Fake timers BEFORE the render, because the poll's setInterval is created
+  // during it - installed afterwards they would not own that timer and
+  // advancing them would do nothing. shouldAdvanceTime keeps Testing Library's
+  // own async plumbing working.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  render(<LocalModelsPanel active />);
+  const row = await screen.findByTestId("local-model-ollama");
+  expect(within(row).getByText("Running")).toBeTruthy();
+
+  await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+  expect(fn.mock.calls.length).toBeGreaterThan(1);
+
+  // Still the engine from the good payload, and the panel is still standing.
+  const after = screen.getByTestId("local-model-ollama");
+  expect(within(after).getByText("Running")).toBeTruthy();
+}

--- a/src/tests/components/local-models-panel.test.tsx
+++ b/src/tests/components/local-models-panel.test.tsx
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
+import LocalModelsPanel from "@/components/LocalModelsPanel";
+
+/**
+ * TASK-435 — what the customer is actually told.
+ *
+ * The acceptance line is that a not-installed model reads as not-installed
+ * "rather than as an option", so the assertions here are about the ABSENCE of
+ * a control as much as the presence of a label.
+ */
+
+function model(over: Record<string, unknown> = {}) {
+  return {
+    id: "ollama", name: "Ollama", kind: "llm", runtime: "System service",
+    installed: true, enabled: true, running: "running", diskBytes: 639_000_000,
+    memoryBytes: 1_073_741_824, control: "system-unit", detail: "Serving 1 model: qwen3-embedding:0.6b.",
+    ...over,
+  };
+}
+
+function mockFetch(payloads: unknown[]) {
+  const fn = vi.fn();
+  for (const p of payloads) fn.mockResolvedValueOnce({ ok: true, json: async () => p });
+  fn.mockResolvedValue({ ok: true, json: async () => payloads.at(-1) });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+beforeEach(() => { vi.useRealTimers(); });
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe("Local Models panel", () => {
+  it("shows a running engine with its footprint", async () => {
+    mockFetch([{ models: [model()], unavailable: [] }]);
+    render(<LocalModelsPanel active />);
+    const row = await screen.findByTestId("local-model-ollama");
+    expect(within(row).getByText("Running")).toBeTruthy();
+    expect(within(row).getByText(/Disk 609 MB/)).toBeTruthy();
+    expect(within(row).getByText(/Memory in use 1.0 GB/)).toBeTruthy();
+    expect(within(row).getByRole("switch", { name: /Ollama enabled/i })).toBeTruthy();
+  });
+
+  it("offers no switch for an engine that is not installed", async () => {
+    mockFetch([{
+      models: [model({ id: "kokoro", name: "Kokoro", kind: "tts", installed: false, enabled: null, running: "not-installed", control: "none", detail: "Not installed on this box. Speech falls back to Piper." })],
+      unavailable: [],
+    }]);
+    render(<LocalModelsPanel active />);
+    const row = await screen.findByTestId("local-model-kokoro");
+    expect(within(row).getByText("Not installed")).toBeTruthy();
+    expect(within(row).queryByRole("switch")).toBeNull();
+  });
+
+  it("does not call an on-demand engine stopped", async () => {
+    mockFetch([{
+      models: [model({ id: "piper", name: "Piper", kind: "tts", enabled: null, running: "on-demand", control: "none", diskBytes: null, memoryBytes: null, detail: "Speaks on demand." })],
+      unavailable: [],
+    }]);
+    render(<LocalModelsPanel active />);
+    const row = await screen.findByTestId("local-model-piper");
+    expect(within(row).getByText("On demand")).toBeTruthy();
+    expect(within(row).queryByText("Stopped")).toBeNull();
+  });
+
+  it("adopts the state the toggle came back with", async () => {
+    const fetchMock = mockFetch([
+      { models: [model({ enabled: true, running: "running" })], unavailable: [] },
+      { ok: true, models: [model({ enabled: false, running: "idle", detail: "Installed and stopped." })], unavailable: [] },
+    ]);
+    render(<LocalModelsPanel active />);
+    const sw = await screen.findByRole("switch", { name: /Ollama enabled/i });
+    expect(sw.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(sw);
+    await waitFor(() => {
+      expect(screen.getByRole("switch", { name: /Ollama enabled/i }).getAttribute("aria-checked")).toBe("false");
+    });
+    const post = fetchMock.mock.calls.find(c => (c[1] as { method?: string })?.method === "POST");
+    expect(JSON.parse((post?.[1] as { body: string }).body)).toEqual({ id: "ollama", enabled: false });
+  });
+
+  it("reports a refusal instead of pretending the switch worked", async () => {
+    const fn = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ models: [model()], unavailable: [] }) })
+      .mockResolvedValueOnce({ ok: false, json: async () => ({ error: "This box does not allow the web interface to change that service." }) })
+      .mockResolvedValue({ ok: true, json: async () => ({ models: [model()], unavailable: [] }) });
+    vi.stubGlobal("fetch", fn);
+    render(<LocalModelsPanel active />);
+    const sw = await screen.findByRole("switch", { name: /Ollama enabled/i });
+    fireEvent.click(sw);
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/does not allow/i);
+    expect(screen.getByRole("switch", { name: /Ollama enabled/i }).getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("keeps its last good reading when a later poll is not an inventory", async () => {
+    // The ClawKeep lesson from TASK-398: the shared e2e mock answers any
+    // unknown /setup-api/* path with `{}` and HTTP 200, and so does a proxy in
+    // front of an older build. Adopting that as state read `.models` off
+    // nothing on the next render and took the WHOLE window down, backups and
+    // all. This drives a real second poll rather than trusting the first one.
+    const fn = vi.fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ models: [model()], unavailable: [] }) })
+      .mockResolvedValue({ ok: true, json: async () => ({}) });
+    vi.stubGlobal("fetch", fn);
+    render(<LocalModelsPanel active />);
+    const row = await screen.findByTestId("local-model-ollama");
+    expect(within(row).getByText("Running")).toBeTruthy();
+
+    await waitFor(() => expect(fn.mock.calls.length).toBeGreaterThan(1), { timeout: 8000 });
+    // Still the engine from the good payload, and the panel is still standing.
+    const after = await screen.findByTestId("local-model-ollama");
+    expect(within(after).getByText("Running")).toBeTruthy();
+  }, 15000);
+});

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -480,6 +480,10 @@ describe("middleware", () => {
       "/setup-api/gateway/ws-config",
       // Reads generated images straight off the harness media tree.
       "/setup-api/chat/media",
+      // POST turns real systemd units on and off through sudo, and has no part
+      // in onboarding — during the setup window the device is broadcasting an
+      // OPEN AP, so anyone in radio range would otherwise reach it.
+      "/setup-api/local-models",
       "/setup-api/gateway",
       "/setup-api/gateway/", // trailing slash must not dodge the exact match
     ])("gates sensitive %s during the setup window", async (p) => {

--- a/src/tests/routes/local-models.test.ts
+++ b/src/tests/routes/local-models.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-435 — /setup-api/local-models.
+ *
+ * The route's job beyond reporting is to REFUSE: it must never offer to switch
+ * something that has no service, and never act on an engine that is not on the
+ * box. "A not-installed model is shown as not-installed rather than as an
+ * option" has to hold at the API too, or the UI is the only thing enforcing it.
+ */
+
+const inventory = vi.fn();
+const setEnabled = vi.fn();
+
+vi.mock("@/lib/local-models", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/local-models")>();
+  return {
+    ...actual,
+    buildLocalModelInventory: (...args: unknown[]) => inventory(...args),
+    setEngineEnabled: (...args: unknown[]) => setEnabled(...args),
+  };
+});
+
+vi.mock("@/lib/llamacpp", () => ({
+  getLlamaCppBaseUrl: () => "http://127.0.0.1:8081/v1",
+  getDefaultLlamaCppModel: () => "gemma",
+}));
+vi.mock("@/lib/llamacpp-server", () => ({
+  getLlamaCppProvisioningStatus: async () => ({ installed: false }),
+}));
+vi.mock("@/lib/local-ai-runtime", () => ({
+  getOllamaBaseUrl: () => "http://127.0.0.1:11434",
+}));
+vi.mock("@/lib/clawkeep-memory", () => ({
+  getMemoryStatus: async () => ({ available: true, provider: "ollama", model: "qwen3-embedding:0.6b", location: "local" }),
+}));
+
+function snapshot(over: Partial<{ id: string; installed: boolean }> = {}) {
+  return {
+    models: [{
+      id: "ollama", name: "Ollama", kind: "llm", runtime: "System service",
+      installed: true, enabled: false, running: "idle", diskBytes: null,
+      memoryBytes: null, control: "system-unit", detail: "Installed and stopped.",
+      ...over,
+    }],
+    unavailable: [],
+  };
+}
+
+async function route() {
+  return await import("@/app/setup-api/local-models/route");
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  inventory.mockReset();
+  setEnabled.mockReset();
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+});
+
+describe("GET /setup-api/local-models", () => {
+  it("returns the inventory and never caches it", async () => {
+    inventory.mockResolvedValue(snapshot());
+    const { GET } = await route();
+    const res = await GET();
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = await res.json();
+    expect(body.models[0].id).toBe("ollama");
+  });
+});
+
+describe("POST /setup-api/local-models", () => {
+  it("rejects a body that is not an id plus a flag", async () => {
+    const { POST } = await route();
+    const res = await POST(new Request("http://box/setup-api/local-models", {
+      method: "POST", body: JSON.stringify({ id: "ollama" }),
+    }));
+    expect(res.status).toBe(400);
+    expect(setEnabled).not.toHaveBeenCalled();
+  });
+
+  it("refuses an engine that has no service to toggle", async () => {
+    const { POST } = await route();
+    const res = await POST(new Request("http://box/setup-api/local-models", {
+      method: "POST", body: JSON.stringify({ id: "piper", enabled: false }),
+    }));
+    expect(res.status).toBe(400);
+    expect(setEnabled).not.toHaveBeenCalled();
+  });
+
+  it("refuses to enable a model that is not installed", async () => {
+    inventory.mockResolvedValue(snapshot({ installed: false }));
+    const { POST } = await route();
+    const res = await POST(new Request("http://box/setup-api/local-models", {
+      method: "POST", body: JSON.stringify({ id: "ollama", enabled: true }),
+    }));
+    expect(res.status).toBe(409);
+    expect(setEnabled).not.toHaveBeenCalled();
+  });
+
+  it("toggles an installed engine and answers with the state that followed", async () => {
+    inventory
+      .mockResolvedValueOnce(snapshot())
+      .mockResolvedValueOnce({ models: [{ ...snapshot().models[0], enabled: true, running: "running" }], unavailable: [] });
+    setEnabled.mockResolvedValue({ ok: true });
+    const { POST } = await route();
+    const res = await POST(new Request("http://box/setup-api/local-models", {
+      method: "POST", body: JSON.stringify({ id: "ollama", enabled: true }),
+    }));
+    expect(res.status).toBe(200);
+    expect(setEnabled).toHaveBeenCalledWith("ollama.service", "system", true);
+    const body = await res.json();
+    // Answering with the post-toggle reading is what stops the UI showing the
+    // old state until its next poll.
+    expect(body.models[0].running).toBe("running");
+  });
+
+  it("passes a refusal through without the command line", async () => {
+    inventory.mockResolvedValue(snapshot());
+    setEnabled.mockResolvedValue({ ok: false, error: "This box does not allow the web interface to change that service." });
+    const { POST } = await route();
+    const res = await POST(new Request("http://box/setup-api/local-models", {
+      method: "POST", body: JSON.stringify({ id: "ollama", enabled: false }),
+    }));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).not.toMatch(/usr\/bin|sudo/);
+  });
+});

--- a/src/tests/unit/local-models-installer-contract.test.ts
+++ b/src/tests/unit/local-models-installer-contract.test.ts
@@ -64,7 +64,7 @@ describe("local-models agrees with the sudoers grants", () => {
         .split("\n")
         .some(line => line.trim().startsWith("clawbox ")
           && /\/usr\/bin\/systemctl/.test(line)
-          && new RegExp(`\\b${verb}\\s+--now\\s+${OLLAMA_UNIT.replace(".", "\\.")}\\s*$`).test(line));
+          && new RegExp(`\\b${verb}\\s+--now\\s+${OLLAMA_UNIT.replace(/[.]/g, "\\.")}\\s*$`).test(line));
       expect(granted, `no NOPASSWD grant for systemctl ${verb} --now ${OLLAMA_UNIT}`).toBe(true);
     }
   });

--- a/src/tests/unit/local-models-installer-contract.test.ts
+++ b/src/tests/unit/local-models-installer-contract.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+
+/**
+ * The Local Models tab reads the device by looking for the exact artefacts
+ * `scripts/install-voice.sh` writes. If the installer ever moves a unit name,
+ * the stamp or the Piper directory, the tab would quietly report every voice
+ * engine as missing — the same class of silent drift the tab was built to end.
+ *
+ * So this asserts against the SHIPPED SCRIPT, not against a copy of its values:
+ * change the installer without changing the library and this test fails.
+ */
+
+const INSTALLER = new URL("../../../scripts/install-voice.sh", import.meta.url);
+
+async function installer(): Promise<string> {
+  return await fs.readFile(INSTALLER, "utf8");
+}
+
+describe("local-models agrees with the voice installer", () => {
+  it("watches for the unit files the installer actually writes", async () => {
+    const script = await installer();
+    const { KOKORO_UNIT, WHISPER_UNIT } = await import("@/lib/local-models");
+    expect(script).toContain(`$SYSTEMD_USER/${KOKORO_UNIT}`);
+    expect(script).toContain(`$SYSTEMD_USER/${WHISPER_UNIT}`);
+  });
+
+  it("looks for the units in the directory the installer writes them to", async () => {
+    const script = await installer();
+    const { SYSTEMD_USER_DIR } = await import("@/lib/local-models");
+    expect(script).toContain('SYSTEMD_USER="$CLAWBOX_HOME/.config/systemd/user"');
+    expect(SYSTEMD_USER_DIR.endsWith("/.config/systemd/user")).toBe(true);
+  });
+
+  it("looks for the Kokoro stamp at the installer's path", async () => {
+    const script = await installer();
+    const { KOKORO_STAMP } = await import("@/lib/local-models");
+    expect(script).toContain('KOKORO_STAMP="$CLAWBOX_HOME/.cache/clawbox/kokoro-installed"');
+    expect(KOKORO_STAMP.endsWith("/.cache/clawbox/kokoro-installed")).toBe(true);
+  });
+
+  it("looks for Piper where the installer puts it", async () => {
+    const script = await installer();
+    const { PIPER_DIR, PIPER_BINARY, PIPER_VOICE_DIR } = await import("@/lib/local-models");
+    expect(script).toContain('PIPER_DIR="${PIPER_DIR:-$CLAWBOX_HOME/.local/share/piper}"');
+    expect(script).toContain('PIPER_VOICE_DIR="${PIPER_VOICE_DIR:-$PIPER_DIR/voices}"');
+    expect(script).toContain('"$PIPER_DIR/piper"');
+    expect(PIPER_DIR.endsWith("/.local/share/piper")).toBe(true);
+    expect(PIPER_BINARY.endsWith("/.local/share/piper/piper")).toBe(true);
+    expect(PIPER_VOICE_DIR.endsWith("/.local/share/piper/voices")).toBe(true);
+  });
+});
+
+describe("local-models agrees with the sudoers grants", () => {
+  it("issues exactly the ollama command the sudoers file allows", async () => {
+    // sudoers Cmnd_Spec matching is argument-exact. A grant for
+    // `systemctl disable ollama.service` does NOT authorise
+    // `systemctl disable --now ollama.service`; getting this wrong means the
+    // toggle hangs on a password prompt no web request can answer.
+    const sudoers = await fs.readFile(new URL("../../../config/clawbox-sudoers", import.meta.url), "utf8");
+    const { OLLAMA_UNIT } = await import("@/lib/local-models");
+    for (const verb of ["enable", "disable"]) {
+      const granted = sudoers
+        .split("\n")
+        .some(line => line.trim().startsWith("clawbox ")
+          && /\/usr\/bin\/systemctl/.test(line)
+          && new RegExp(`\\b${verb}\\s+--now\\s+${OLLAMA_UNIT.replace(".", "\\.")}\\s*$`).test(line));
+      expect(granted, `no NOPASSWD grant for systemctl ${verb} --now ${OLLAMA_UNIT}`).toBe(true);
+    }
+  });
+});

--- a/src/tests/unit/local-models.test.ts
+++ b/src/tests/unit/local-models.test.ts
@@ -263,3 +263,41 @@ describe("unit lookup", () => {
     expect(unitForEngine("llamacpp")).toBeNull();
   });
 });
+
+describe("embeddings are checked against the engine that serves them", () => {
+  it("does not call memory embedding healthy while its engine is stopped", async () => {
+    // Found by driving a real box, not by reading the code: ClawKeep's memory
+    // status answers available/healthy from the index and the CONFIGURED
+    // provider, never from a live embed call. With Ollama stopped it still
+    // said healthy, so the tab printed "Embedding your memory on the box" one
+    // row under "Ollama — Stopped". Acceptance 4 of this task forbids exactly
+    // that: a model that is not actually able to run must not read as available.
+    responses.push({ match: /is-enabled ollama/, stdout: "disabled\n" });
+    responses.push({ match: /is-active ollama/, fail: "exit 3", stdout: "inactive\n" });
+    bareBox();
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory({
+      ...PROBES,
+      embeddings: { available: true, provider: "ollama", model: "qwen3-embedding:0.6b", local: true },
+    });
+    const emb = entry(models, "embeddings") as unknown as { running: string; detail: string };
+    expect(emb.running).toBe("idle");
+    expect(emb.detail).toMatch(/Ollama is stopped/i);
+  });
+
+  it("still reports embedding as running when its engine is up", async () => {
+    responses.push({ match: /is-enabled ollama/, stdout: "enabled\n" });
+    responses.push({ match: /is-active ollama/, stdout: "active\n" });
+    bareBox();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, json: async () => ({ models: [] }) }));
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory({
+      ...PROBES,
+      embeddings: { available: true, provider: "ollama", model: "qwen3-embedding:0.6b", local: true },
+    });
+    const emb = entry(models, "embeddings") as unknown as { running: string; detail: string };
+    expect(emb.running).toBe("running");
+    expect(emb.detail).toMatch(/on the box/i);
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/tests/unit/local-models.test.ts
+++ b/src/tests/unit/local-models.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * TASK-435 — Settings → Local Models.
+ *
+ * The tab exists because `install.sh` announced "On-device TTS configured
+ * (Kokoro GPU, Piper fallback)" on boxes where Kokoro had never been installed,
+ * and nothing in the UI could contradict it. So the cases that matter here are
+ * the ones where the box LOOKS equipped and is not: weights on disk with no
+ * runtime, a stamp with no service, a binary with no voice.
+ */
+
+type ExecCall = { cmd: string; args: string[] };
+
+let calls: ExecCall[] = [];
+let responses: { match: RegExp; stdout?: string; fail?: string }[] = [];
+let tmpHome = "";
+
+vi.mock("child_process", () => ({
+  execFile: (
+    cmd: string,
+    args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, res: { stdout: string; stderr: string }) => void,
+  ) => {
+    calls.push({ cmd, args });
+    const line = `${cmd} ${args.join(" ")}`;
+    const hit = responses.find(r => r.match.test(line));
+    if (!hit) {
+      const err = new Error(`Command failed: ${line}`) as Error & { stdout: string };
+      err.stdout = "";
+      cb(err, { stdout: "", stderr: "" });
+      return;
+    }
+    if (hit.fail) {
+      const err = new Error(hit.fail) as Error & { stdout: string };
+      err.stdout = hit.stdout ?? "";
+      cb(err, { stdout: hit.stdout ?? "", stderr: "" });
+      return;
+    }
+    cb(null, { stdout: hit.stdout ?? "", stderr: "" });
+  },
+}));
+
+beforeEach(async () => {
+  calls = [];
+  responses = [];
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "local-models-"));
+  process.env.CLAWBOX_HOME = tmpHome;
+  // CLAWBOX_HOME is read once at module load, so every test needs a fresh graph.
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  delete process.env.CLAWBOX_HOME;
+  await fs.rm(tmpHome, { recursive: true, force: true });
+});
+
+async function lib() {
+  return await import("@/lib/local-models");
+}
+
+const NO_UNIT = "Failed to get unit file state for x.service: No such file or directory";
+
+/** systemctl answers used by a box where nothing local is installed. */
+function bareBox() {
+  responses.push({ match: /is-enabled/, fail: "exit 1", stdout: NO_UNIT });
+  responses.push({ match: /is-active/, fail: "exit 3", stdout: "inactive" });
+  responses.push({ match: /pgrep/, fail: "no match", stdout: "" });
+}
+
+const PROBES = {
+  ollamaBaseUrl: "http://127.0.0.1:11434",
+  llamacpp: { installed: false, running: false, model: null },
+  embeddings: { available: false, provider: null, model: null, local: false },
+};
+
+function entry(models: { id: string }[], id: string) {
+  const found = models.find(m => m.id === id);
+  if (!found) throw new Error(`no entry ${id}`);
+  return found as never;
+}
+
+describe("local model inventory", () => {
+  it("calls Kokoro not installed when only its weights are on disk", async () => {
+    // The exact state of the loop's test box: the 82M weights sit in the
+    // HuggingFace cache from an install that failed afterwards, with no stamp
+    // and no unit. Reporting that as installed is the lie this tab removes.
+    await fs.mkdir(path.join(tmpHome, ".cache/huggingface/hub/models--hexgrad--Kokoro-82M"), { recursive: true });
+    bareBox();
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory(PROBES);
+    const kokoro = entry(models, "kokoro") as unknown as { installed: boolean; running: string; control: string; enabled: unknown; detail: string };
+    expect(kokoro.installed).toBe(false);
+    expect(kokoro.running).toBe("not-installed");
+    expect(kokoro.control).toBe("none");
+    expect(kokoro.enabled).toBeNull();
+    expect(kokoro.detail).toMatch(/falls back to Piper/i);
+  });
+
+  it("calls Kokoro not installed when it is stamped but its service is gone", async () => {
+    await fs.mkdir(path.join(tmpHome, ".cache/clawbox"), { recursive: true });
+    await fs.writeFile(path.join(tmpHome, ".cache/clawbox/kokoro-installed"), "2\n");
+    bareBox();
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory(PROBES);
+    const kokoro = entry(models, "kokoro") as unknown as { installed: boolean; detail: string };
+    expect(kokoro.installed).toBe(false);
+    expect(kokoro.detail).toMatch(/cannot speak/i);
+  });
+
+  it("reports Kokoro as running when both the stamp and an active unit exist", async () => {
+    await fs.mkdir(path.join(tmpHome, ".cache/clawbox"), { recursive: true });
+    await fs.writeFile(path.join(tmpHome, ".cache/clawbox/kokoro-installed"), "2\n");
+    responses.push({ match: /--user is-enabled kokoro-server/, stdout: "enabled\n" });
+    responses.push({ match: /--user is-active kokoro-server/, stdout: "active\n" });
+    responses.push({ match: /pgrep/, fail: "no match", stdout: "" });
+    bareBox();
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory(PROBES);
+    const kokoro = entry(models, "kokoro") as unknown as { installed: boolean; running: string; enabled: boolean; control: string };
+    expect(kokoro.installed).toBe(true);
+    expect(kokoro.running).toBe("running");
+    expect(kokoro.enabled).toBe(true);
+    expect(kokoro.control).toBe("user-unit");
+  });
+
+  it("separates an installed-but-stopped engine from a missing one", async () => {
+    responses.push({ match: /--user is-enabled whisper-server/, stdout: "disabled\n" });
+    responses.push({ match: /--user is-active whisper-server/, fail: "exit 3", stdout: "inactive\n" });
+    bareBox();
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory(PROBES);
+    const whisper = entry(models, "whisper") as unknown as { installed: boolean; running: string; enabled: boolean; control: string };
+    // "disabled" is a unit-file state, so the unit exists — installed and off.
+    expect(whisper.installed).toBe(true);
+    expect(whisper.running).toBe("idle");
+    expect(whisper.enabled).toBe(false);
+    expect(whisper.control).toBe("user-unit");
+  });
+
+  it("does not call Piper installed when the binary has no voice", async () => {
+    const piper = path.join(tmpHome, ".local/share/piper");
+    await fs.mkdir(piper, { recursive: true });
+    await fs.writeFile(path.join(piper, "piper"), "#!/bin/sh\n");
+    bareBox();
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory(PROBES);
+    const entryPiper = entry(models, "piper") as unknown as { installed: boolean; detail: string };
+    expect(entryPiper.installed).toBe(false);
+    expect(entryPiper.detail).toMatch(/no voice/i);
+  });
+
+  it("names the installed Piper voices and reports it as on demand, not idle", async () => {
+    const piper = path.join(tmpHome, ".local/share/piper");
+    await fs.mkdir(path.join(piper, "voices"), { recursive: true });
+    await fs.writeFile(path.join(piper, "piper"), "#!/bin/sh\n");
+    await fs.writeFile(path.join(piper, "voices/en_US-lessac-medium.onnx"), "x".repeat(1024));
+    await fs.writeFile(path.join(piper, "voices/en_US-lessac-medium.onnx.json"), "{}");
+    bareBox();
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory(PROBES);
+    const entryPiper = entry(models, "piper") as unknown as { installed: boolean; running: string; detail: string; diskBytes: number };
+    expect(entryPiper.installed).toBe(true);
+    // A per-utterance binary is never "stopped"; calling it idle would invite
+    // the customer to look for a switch that does not exist.
+    expect(entryPiper.running).toBe("on-demand");
+    expect(entryPiper.detail).toContain("en_US-lessac-medium");
+    expect(entryPiper.diskBytes).toBeGreaterThan(1000);
+  });
+
+  it("keeps the rest of the inventory when one engine cannot be read", async () => {
+    // A subordinate row must not cost the customer the tab — the failure mode
+    // a bad payload caused in the whole ClawKeep window on TASK-398.
+    bareBox();
+    const mod = await lib();
+    const broken = {
+      ...PROBES,
+      embeddings: {
+        get available(): boolean { throw new Error("probe exploded"); },
+        provider: null, model: null, local: false,
+      },
+    } as unknown as Parameters<typeof mod.buildLocalModelInventory>[0];
+    const { models, unavailable } = await mod.buildLocalModelInventory(broken);
+    expect(unavailable).toContain("embeddings");
+    expect(models.map(m => m.id)).toEqual(expect.arrayContaining(["piper", "kokoro", "whisper", "ollama"]));
+  });
+
+  it("sums the pulled Ollama models into a disk figure", async () => {
+    responses.push({ match: /is-enabled ollama/, stdout: "enabled\n" });
+    responses.push({ match: /is-active ollama/, stdout: "active\n" });
+    responses.push({ match: /pgrep/, fail: "no match", stdout: "" });
+    bareBox();
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ models: [{ name: "qwen3-embedding:0.6b", size: 639_000_000 }] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { buildLocalModelInventory } = await lib();
+    const { models } = await buildLocalModelInventory(PROBES);
+    const ollama = entry(models, "ollama") as unknown as { running: string; diskBytes: number; detail: string; control: string };
+    expect(ollama.running).toBe("running");
+    expect(ollama.diskBytes).toBe(639_000_000);
+    expect(ollama.detail).toContain("qwen3-embedding:0.6b");
+    expect(ollama.control).toBe("system-unit");
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("turning an engine on and off", () => {
+  it("stops it now AND keeps it off after a reboot", async () => {
+    // TASK-435 asked whether disable means "stop now" or "do not start next
+    // boot". `disable --now` is both, so neither reading is violated.
+    responses.push({ match: /systemctl/, stdout: "" });
+    const { setEngineEnabled } = await lib();
+    const res = await setEngineEnabled("kokoro-server.service", "user", false);
+    expect(res.ok).toBe(true);
+    const call = calls.find(c => c.args.includes("disable"));
+    expect(call?.args).toEqual(["--user", "disable", "--now", "kokoro-server.service"]);
+  });
+
+  it("drives a system unit through sudo with the exact granted argument list", async () => {
+    // sudoers matches argument-for-argument; a reordered or extra argument
+    // falls through to a password prompt nobody can answer.
+    responses.push({ match: /sudo/, stdout: "" });
+    const { setEngineEnabled } = await lib();
+    const res = await setEngineEnabled("ollama.service", "system", true);
+    expect(res.ok).toBe(true);
+    expect(calls.at(-1)).toEqual({
+      cmd: "/usr/bin/sudo",
+      args: ["/usr/bin/systemctl", "enable", "--now", "ollama.service"],
+    });
+  });
+
+  it("refuses a unit it was never meant to touch", async () => {
+    const { setEngineEnabled } = await lib();
+    const res = await setEngineEnabled("clawbox-gateway.service", "system", false);
+    expect(res.ok).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("never leaks the command line when sudo refuses", async () => {
+    responses.push({ match: /sudo/, fail: "Command failed: /usr/bin/sudo /usr/bin/systemctl disable --now ollama.service\nsudo: a password is required" });
+    const { setEngineEnabled } = await lib();
+    const res = await setEngineEnabled("ollama.service", "system", false);
+    expect(res.ok).toBe(false);
+    expect(res.error).not.toContain("/usr/bin");
+    expect(res.error).toMatch(/does not allow/i);
+  });
+});
+
+describe("unit lookup", () => {
+  it("maps only the engines that really have a service", async () => {
+    const { unitForEngine } = await lib();
+    expect(unitForEngine("ollama")).toEqual({ unit: "ollama.service", scope: "system" });
+    expect(unitForEngine("kokoro")).toEqual({ unit: "kokoro-server.service", scope: "user" });
+    expect(unitForEngine("whisper")).toEqual({ unit: "whisper-server.service", scope: "user" });
+    // Piper is a binary and llama.cpp is owned by Settings → Local AI.
+    expect(unitForEngine("piper")).toBeNull();
+    expect(unitForEngine("llamacpp")).toBeNull();
+  });
+});

--- a/src/tests/unit/local-models.test.ts
+++ b/src/tests/unit/local-models.test.ts
@@ -55,6 +55,10 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // In afterEach rather than inline at the end of a test: an inline call is
+  // skipped when an assertion above it fails, and the stubbed fetch then leaks
+  // into the next test, turning one failure into several.
+  vi.unstubAllGlobals();
   delete process.env.CLAWBOX_HOME;
   await fs.rm(tmpHome, { recursive: true, force: true });
 });
@@ -206,7 +210,6 @@ describe("local model inventory", () => {
     expect(ollama.diskBytes).toBe(639_000_000);
     expect(ollama.detail).toContain("qwen3-embedding:0.6b");
     expect(ollama.control).toBe("system-unit");
-    vi.unstubAllGlobals();
   });
 });
 
@@ -298,6 +301,5 @@ describe("embeddings are checked against the engine that serves them", () => {
     const emb = entry(models, "embeddings") as unknown as { running: string; detail: string };
     expect(emb.running).toBe("running");
     expect(emb.detail).toMatch(/on the box/i);
-    vi.unstubAllGlobals();
   });
 });


### PR DESCRIPTION
Settings gains a **Local Models** tab: every engine that can run on the box, what it is doing right now, what it costs in disk and memory, and a switch only where a switch can actually work.

## Why

The box could lie. `install.sh` printed *"On-device TTS configured (Kokoro GPU, Piper fallback)"* on machines where Kokoro had never been installed — every one of them quietly speaking through Piper — and nothing in the UI could contradict it (TASK-420). Nobody could see that drift until an acceptance run tripped over it.

So no row here is read from a config file recording an *intention*. Each one is a measurement: the unit file, the process table, the artefact on disk.

## What that changes in practice

Read off `.177` before a line of this was written, and now visible in the UI:

| engine | what the box says today |
|---|---|
| Ollama | running, one model, ~610 MB, ~1 GB resident — and nothing could stop it |
| Kokoro | **not installed** — its 82M weights are in the HF cache from an install that failed afterwards |
| Whisper | **not installed** — no `whisper-server.service` at all |
| Piper | on demand, `en_US-lessac-medium` |
| llama.cpp | not installed → links to Settings → Local AI |
| Embeddings | `qwen3-embedding:0.6b`, on device → links to ClawKeep |

## Design decisions worth reviewing

- **Four states, not a boolean.** `Not installed` / `Stopped` / `Running` / `On demand` are different facts. Piper is a per-utterance binary, so calling it "stopped" would send the owner hunting for a switch that does not exist. Kokoro absent is not Kokoro off.
- **Kokoro is installed only with BOTH stamp and unit.** Weights on disk are not an installation.
- **Piper is installed only with binary AND voice.** A voiceless binary cannot speak, and says so.
- **No service, no switch.** The tab can never offer a control that silently does nothing, and the route enforces it too (400 for an engine with no unit, 409 for one that is not installed) rather than leaving the UI as the only guard.
- **Disable means `disable --now`.** The task asked whether "disable" should stop the service now or only at next boot. Doing both is the only answer that satisfies either reading of its own acceptance line, "enable/disable survives reboot".
- **Ollama needed a sudoers grant.** It is a system unit, and until now nothing in the UI could stop the single biggest RAM consumer on an 8 GB box. The grant is argument-exact including `--now`, because sudoers matches the argument list literally and a near-miss falls through to a password prompt no web request can answer. `step_systemd_services` reinstalls the sudoers file on every update, so this reaches existing boxes.
- **No duplicated controls.** Embeddings and llama.cpp are listed but link to ClawKeep and Local AI, per the task's own "do not duplicate".
- **The panel refuses a payload that is not an inventory.** The shared e2e mock answers unknown `/setup-api/*` paths with `{}` and HTTP 200 — the exact thing that took the whole ClawKeep window down on TASK-398.

## Tests

**30 new** (254 files / 3438 tests → 258 / 3468, all green), plus one e2e leg through the real Settings window.

The unit cases are the *lying-box* cases, and three targeted mutations were run to prove they bite:

| mutation | result |
|---|---|
| Kokoro `installed = stamp \|\| unit` instead of `&&` | 1 failed |
| the two `--now` sudoers grants deleted | 1 failed |
| the panel's payload guard removed | 1 failed |

The sudoers contract is asserted against `config/clawbox-sudoers` and the voice paths against `scripts/install-voice.sh`, so drift in either breaks the build rather than the tab.

## Scope not taken

Installing or removing models. The acceptance line only requires that a not-installed model reads as not-installed rather than as an option; pulling models onto the box is a separate, much larger task.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Local Models section to Settings.
  * View installation status, runtime state, model type, disk and memory usage, and availability for supported local models.
  * Enable or disable eligible model services directly from Settings.
  * Added automatic status refresh while the panel is active, with clear warnings and error handling.

* **Bug Fixes**
  * Preserves the last valid model status when a later refresh returns invalid data.
  * Protects local-model controls during setup.

* **Tests**
  * Added comprehensive coverage for inventory, availability, service controls, and UI workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->