### PR TITLE
Choose which voice speaks, and see which one actually did (TASK-434)

### DIFF
--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -1143,6 +1143,40 @@ export async function installClawboxMocks(page: Page, options: MockOptions = {})
       return;
     }
 
+    // Settings -> Voice. Deliberately the real-box shape: the on-device voice
+    // works and the cloud one is present but unusable, because the assertion
+    // that matters is the negative one — a voice the box cannot use must read
+    // as unavailable rather than as a choice that quietly does something else.
+    if (path === "/setup-api/tts") {
+      await fulfillJson(route, {
+        choice: "auto",
+        activeProviderId: "tts-local-cli",
+        activeEngine: "local",
+        preferredEngine: "local",
+        drifted: false,
+        engines: [
+          {
+            id: "local", providerId: "tts-local-cli", label: "On this box",
+            configured: true, proven: true, usable: true,
+            detail: "Speaks on the box itself. Nothing leaves it. Installed: Piper.",
+          },
+          {
+            id: "cloud", providerId: "openai", label: "ClawBox cloud",
+            configured: false, proven: false, usable: false,
+            detail: "ClawBox AI does not serve the voice yet, so this box has no cloud voice to call.",
+          },
+        ],
+        lastCheck: {
+          at: 1787000000000, ok: true,
+          servedByProviderId: "tts-local-cli", servedEngine: "local",
+          attempts: [{ providerId: "tts-local-cli", engine: "local", ok: true, message: null, latencyMs: 14893 }],
+          message: null,
+        },
+        warning: null,
+      });
+      return;
+    }
+
     await fulfillJson(route, {});
   });
 }

--- a/e2e/settings-workflow.spec.ts
+++ b/e2e/settings-workflow.spec.ts
@@ -80,6 +80,18 @@ test("settings covers appearance, network, local AI, local models, telegram, sys
   await expect(kokoroRow.getByText("Not installed", { exact: true })).toBeVisible();
   await expect(kokoroRow.getByRole("switch")).toHaveCount(0);
 
+  // Voice: which engine speaks, and which one actually did. Same negative
+  // assertion as Local Models — a cloud voice this box cannot call must read as
+  // unavailable, because "chosen quietly becoming something else" is the exact
+  // failure this section exists to prevent.
+  await settingsWindow.getByRole("button", { name: "Voice" }).click();
+  await expect(settingsWindow.getByTestId("voice-speaking-now")).toContainText("On this box");
+  await expect(settingsWindow.getByTestId("voice-choice-auto")).toHaveAttribute("aria-checked", "true");
+  const cloudChoice = settingsWindow.getByTestId("voice-choice-cloud");
+  await expect(cloudChoice.getByText("Not available")).toBeVisible();
+  await expect(cloudChoice).toHaveAttribute("aria-disabled", "true");
+  await expect(settingsWindow.getByTestId("voice-last-check")).toContainText("On this box spoke in 14.9s.");
+
   await settingsWindow.getByRole("button", { name: "Telegram" }).click();
   await settingsWindow.locator("#settings-tg-token").fill("123456789:ABCdefGHI");
   await settingsWindow.getByRole("button", { name: /Connect$/ }).click();

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -22,7 +22,7 @@ import {
 import {
   applyCheck,
   buildVoiceOutputStatus,
-  engineSignatures,
+  forgetEngineCheck,
   failedVoiceCheck,
   isVoiceChoice,
   localCommandPath,
@@ -30,6 +30,7 @@ import {
   providerIdForChoice,
   selectionError,
   type LocalVoiceProbe,
+  type VoiceChoice,
   type VoiceOutputStatus,
 } from "@/lib/voice-output";
 import { readVoiceState, writeVoiceState } from "@/lib/voice-output-store";
@@ -183,36 +184,26 @@ function currentCheck() {
   return checkInFlight;
 }
 
-export async function POST(req: Request) {
-  let body: unknown;
-  try {
-    body = await req.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
-  }
-  const action = (body as { action?: unknown })?.action;
+async function handleCheck() {
+  const check = await currentCheck();
+  // Read the state AFTER the run, not before it. A check holds no snapshot
+  // across its own 90 seconds: a customer who changes the voice while it is
+  // running would otherwise have that choice overwritten by the stale copy this
+  // handler started with. The box is probed once and reused, rather than read a
+  // third time for a status this function can already assemble.
+  const [state, { config, probe }] = await Promise.all([readVoiceState(), probeBox()]);
+  const next = applyCheck(state, check);
+  await writeVoiceState(next);
+  return NextResponse.json(buildVoiceOutputStatus(config, probe, next), {
+    headers: { "Cache-Control": "no-store" },
+  });
+}
 
-  if (action === "check") {
-    const check = await currentCheck();
-    // Read the state AFTER the run, not before it. A check holds no snapshot
-    // across its own 90 seconds: a customer who changes the voice while it is
-    // running would otherwise have that choice overwritten by the stale copy
-    // this handler started with.
-    const [state, { config, probe }] = await Promise.all([readVoiceState(), probeBox()]);
-    await writeVoiceState(applyCheck(state, check, engineSignatures(config, probe)));
-    return NextResponse.json(await status(), { headers: { "Cache-Control": "no-store" } });
-  }
+async function handleSelect(choice: VoiceChoice) {
+  const { config, probe } = await probeBox();
+  const state = await readVoiceState();
+  const before = buildVoiceOutputStatus(config, probe, state);
 
-  if (action !== "select") {
-    return NextResponse.json({ error: "Unknown action." }, { status: 400 });
-  }
-
-  const choice = (body as { choice?: unknown })?.choice;
-  if (!isVoiceChoice(choice)) {
-    return NextResponse.json({ error: "Pick Auto, this box, or ClawBox cloud." }, { status: 400 });
-  }
-
-  const before = await status();
   // Refuse rather than write a primary the box cannot honour, and refuse rather
   // than quietly substitute the other engine: an engine that is not installed
   // must read as not installed, not as a selected option that never speaks.
@@ -232,15 +223,43 @@ export async function POST(req: Request) {
     if (openclawIsAbsent()) {
       return NextResponse.json({ error: "This box cannot change the voice." }, { status: 409 });
     }
-    try {
-      await runOpenclawConfigSet(["messages.tts.provider", providerId]);
-    } catch (err) {
-      console.warn("[setup-api/tts] could not set the speech provider:", err);
-      return NextResponse.json({ error: "Could not change the voice on this box." }, { status: 500 });
-    }
+    await runOpenclawConfigSet(["messages.tts.provider", providerId]);
   }
 
-  const state = await readVoiceState();
-  await writeVoiceState({ ...state, choice });
+  // Picking an engine again is a request to retry it, so this box stops
+  // reporting what it observed last time until the next check says otherwise.
+  const next = choice === "auto"
+    ? { ...state, choice }
+    : { ...forgetEngineCheck(state, choice), choice };
+  await writeVoiceState(next);
   return NextResponse.json(await status(), { headers: { "Cache-Control": "no-store" } });
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  const action = (body as { action?: unknown })?.action;
+  const choice = (body as { choice?: unknown })?.choice;
+
+  if (action !== "check" && action !== "select") {
+    return NextResponse.json({ error: "Unknown action." }, { status: 400 });
+  }
+  if (action === "select" && !isVoiceChoice(choice)) {
+    return NextResponse.json({ error: "Pick Auto, this box, or ClawBox cloud." }, { status: 400 });
+  }
+
+  // One boundary for both branches. Every step here is filesystem work or a
+  // spawn: a full disk, a read-only data dir or a missing CLI must come back as
+  // a message the panel can show, not as a framework error page that leaves the
+  // box with nothing in its log.
+  try {
+    return action === "check" ? await handleCheck() : await handleSelect(choice as VoiceChoice);
+  } catch (err) {
+    console.warn(`[setup-api/tts] ${action} failed:`, err);
+    return NextResponse.json({ error: "Could not change the voice on this box." }, { status: 500 });
+  }
 }

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -1,0 +1,219 @@
+export const dynamic = "force-dynamic";
+
+import { NextResponse } from "next/server";
+import { spawn } from "child_process";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+import crypto from "crypto";
+import {
+  buildTtsInventory,
+  KOKORO_STAMP,
+  PIPER_BINARY,
+  type LocalModelEntry,
+} from "@/lib/local-models";
+import {
+  findOpenclawBin,
+  openclawIsAbsent,
+  readConfig,
+  runOpenclawConfigSet,
+  type OpenClawConfig,
+} from "@/lib/openclaw-config";
+import {
+  applyCheck,
+  buildVoiceOutputStatus,
+  failedVoiceCheck,
+  isVoiceChoice,
+  localCommandPath,
+  parseVoiceCheck,
+  providerIdForChoice,
+  selectionError,
+  type LocalVoiceProbe,
+  type VoiceOutputStatus,
+} from "@/lib/voice-output";
+import { readVoiceState, writeVoiceState } from "@/lib/voice-output-store";
+
+/**
+ * GET  /setup-api/tts            → who speaks for this box, and who actually did
+ * POST /setup-api/tts {select}   → pick Auto / On this box / ClawBox cloud
+ * POST /setup-api/tts {check}    → synthesise a real phrase and record the result
+ *
+ * GET touches only the filesystem. The openclaw CLI costs 8-12 s of cold start
+ * on an Orin Nano (see runOpenclawConfigSet's note), which is fine for an
+ * explicit button and completely wrong for a panel the customer just opened.
+ */
+
+const CHECK_PHRASE = "ClawBox voice check.";
+// The on-device chain alone measured 14.9 s on a Nano, and a cloud attempt in
+// front of it adds a round trip before it fails over. 30 s would time out a
+// working box and report it as broken.
+const CHECK_TIMEOUT_MS = 120_000;
+
+function localProbeFrom(config: OpenClawConfig, models: LocalModelEntry[], commandPresent: boolean): LocalVoiceProbe {
+  const installedTts = models.filter(m => m.kind === "tts" && m.installed);
+  return {
+    providerConfigured: Boolean(localCommandPath(config)),
+    commandPresent,
+    engineInstalled: installedTts.length > 0,
+    engineNames: installedTts.map(m => m.name),
+  };
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function status(): Promise<VoiceOutputStatus> {
+  const [config, state] = await Promise.all([readConfig(), readVoiceState()]);
+  const models = await buildTtsInventory();
+  const command = localCommandPath(config);
+  // The provider entry names a script; if that script is gone the box cannot
+  // speak locally however healthy the voices look. Fall back to the installer's
+  // own artefacts when no command is configured at all.
+  const commandPresent = command
+    ? await exists(command)
+    : (await exists(PIPER_BINARY)) || (await exists(KOKORO_STAMP));
+  return buildVoiceOutputStatus(config, localProbeFrom(config, models, commandPresent), state);
+}
+
+export async function GET() {
+  try {
+    return NextResponse.json(await status(), { headers: { "Cache-Control": "no-store" } });
+  } catch (err) {
+    console.warn("[setup-api/tts] could not read voice status:", err);
+    return NextResponse.json({ error: "Could not read the voice settings." }, { status: 500 });
+  }
+}
+
+function runVoiceConvert(outputPath: string): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  const bin = findOpenclawBin();
+  return new Promise((resolve, reject) => {
+    const child = spawn(bin, [
+      "capability", "tts", "convert",
+      "--text", CHECK_PHRASE,
+      "--output", outputPath,
+      "--json",
+    ], {
+      stdio: ["ignore", "pipe", "pipe"],
+      cwd: process.env.HOME ?? "/home/clawbox",
+      env: { HOME: "/home/clawbox", ...process.env },
+    });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    child.stdout?.on("data", (c: Buffer) => { stdout += c.toString(); });
+    child.stderr?.on("data", (c: Buffer) => { stderr += c.toString(); });
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error("The voice check took too long and was stopped."));
+    }, CHECK_TIMEOUT_MS);
+    child.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ ok: code === 0, stdout, stderr });
+    });
+  });
+}
+
+/**
+ * Speak a short phrase through the real chain and record what happened.
+ *
+ * Deliberately not pinned to one provider: the question the customer is asking
+ * is "what happens when my box talks", and the answer includes the fallback.
+ * The CLI reports every provider it tried in order, so a cloud primary that
+ * fails and an on-device voice that then speaks are both in the record.
+ */
+async function runCheck() {
+  const outputPath = path.join(os.tmpdir(), `clawbox-voice-check-${crypto.randomBytes(6).toString("hex")}.wav`);
+  const at = Date.now();
+  try {
+    const result = await runVoiceConvert(outputPath);
+    let parsed: unknown = null;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      parsed = null;
+    }
+    if (parsed) return parseVoiceCheck(parsed, at);
+    return failedVoiceCheck(result.stderr.trim() || result.stdout.trim(), at);
+  } catch (err) {
+    return failedVoiceCheck(err instanceof Error ? err.message : null, at);
+  } finally {
+    // The audio itself is worthless — it exists only to prove a provider
+    // produced bytes — and a box that leaves one behind per check fills its
+    // own disk.
+    await fs.unlink(outputPath).catch(() => {});
+  }
+}
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+  const action = (body as { action?: unknown })?.action;
+
+  if (action === "check") {
+    const state = await readVoiceState();
+    const check = await runCheck();
+    await writeVoiceState(applyCheck(state, check));
+    return NextResponse.json(await status(), { headers: { "Cache-Control": "no-store" } });
+  }
+
+  if (action !== "select") {
+    return NextResponse.json({ error: "Unknown action." }, { status: 400 });
+  }
+
+  const choice = (body as { choice?: unknown })?.choice;
+  if (!isVoiceChoice(choice)) {
+    return NextResponse.json({ error: "Pick Auto, this box, or ClawBox cloud." }, { status: 400 });
+  }
+
+  const before = await status();
+  // Refuse rather than write a primary the box cannot honour, and refuse rather
+  // than quietly substitute the other engine: an engine that is not installed
+  // must read as not installed, not as a selected option that never speaks.
+  const refusal = selectionError(choice, before.engines);
+  if (refusal) {
+    return NextResponse.json({ error: refusal }, { status: 409 });
+  }
+  const providerId = providerIdForChoice(choice, before.engines);
+  if (!providerId) {
+    return NextResponse.json(
+      { error: "That voice is not available on this box." },
+      { status: 409 },
+    );
+  }
+
+  if (providerId !== before.activeProviderId) {
+    if (openclawIsAbsent()) {
+      return NextResponse.json({ error: "This box cannot change the voice." }, { status: 409 });
+    }
+    try {
+      await runOpenclawConfigSet(["messages.tts.provider", providerId]);
+    } catch (err) {
+      console.warn("[setup-api/tts] could not set the speech provider:", err);
+      return NextResponse.json({ error: "Could not change the voice on this box." }, { status: 500 });
+    }
+  }
+
+  const state = await readVoiceState();
+  await writeVoiceState({ ...state, choice });
+  return NextResponse.json(await status(), { headers: { "Cache-Control": "no-store" } });
+}

--- a/src/app/setup-api/tts/route.ts
+++ b/src/app/setup-api/tts/route.ts
@@ -22,6 +22,7 @@ import {
 import {
   applyCheck,
   buildVoiceOutputStatus,
+  engineSignatures,
   failedVoiceCheck,
   isVoiceChoice,
   localCommandPath,
@@ -68,9 +69,8 @@ async function exists(p: string): Promise<boolean> {
   }
 }
 
-async function status(): Promise<VoiceOutputStatus> {
-  const [config, state] = await Promise.all([readConfig(), readVoiceState()]);
-  const models = await buildTtsInventory();
+async function probeBox() {
+  const [config, models] = await Promise.all([readConfig(), buildTtsInventory()]);
   const command = localCommandPath(config);
   // The provider entry names a script; if that script is gone the box cannot
   // speak locally however healthy the voices look. Fall back to the installer's
@@ -78,7 +78,12 @@ async function status(): Promise<VoiceOutputStatus> {
   const commandPresent = command
     ? await exists(command)
     : (await exists(PIPER_BINARY)) || (await exists(KOKORO_STAMP));
-  return buildVoiceOutputStatus(config, localProbeFrom(config, models, commandPresent), state);
+  return { config, probe: localProbeFrom(config, models, commandPresent) };
+}
+
+async function status(): Promise<VoiceOutputStatus> {
+  const [{ config, probe }, state] = await Promise.all([probeBox(), readVoiceState()]);
+  return buildVoiceOutputStatus(config, probe, state);
 }
 
 export async function GET() {
@@ -160,6 +165,24 @@ async function runCheck() {
   }
 }
 
+/**
+ * One check at a time, per box.
+ *
+ * A check spawns a real synthesis that can run for a minute and a half on an
+ * Orin. Two of them at once means two engines competing for the same GPU on an
+ * 8 GB board, and the client-side busy flag cannot prevent it — a second tab,
+ * a reload mid-check or a stray retry all bypass it. Callers join the run in
+ * flight instead of starting another.
+ */
+let checkInFlight: Promise<Awaited<ReturnType<typeof runCheck>>> | null = null;
+
+function currentCheck() {
+  if (!checkInFlight) {
+    checkInFlight = runCheck().finally(() => { checkInFlight = null; });
+  }
+  return checkInFlight;
+}
+
 export async function POST(req: Request) {
   let body: unknown;
   try {
@@ -170,9 +193,13 @@ export async function POST(req: Request) {
   const action = (body as { action?: unknown })?.action;
 
   if (action === "check") {
-    const state = await readVoiceState();
-    const check = await runCheck();
-    await writeVoiceState(applyCheck(state, check));
+    const check = await currentCheck();
+    // Read the state AFTER the run, not before it. A check holds no snapshot
+    // across its own 90 seconds: a customer who changes the voice while it is
+    // running would otherwise have that choice overwritten by the stale copy
+    // this handler started with.
+    const [state, { config, probe }] = await Promise.all([readVoiceState(), probeBox()]);
+    await writeVoiceState(applyCheck(state, check, engineSignatures(config, probe)));
     return NextResponse.json(await status(), { headers: { "Cache-Control": "no-store" } });
   }
 

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -14,6 +14,7 @@ import AIModelsStep from "./AIModelsStep";
 import TelegramConfiguringOverlay from "./TelegramConfiguringOverlay";
 import RemoteControlPanel from "./RemoteControlPanel";
 import LocalModelsPanel from "./LocalModelsPanel";
+import VoiceOutputPanel from "./VoiceOutputPanel";
 import FreeTierUpgradeCard from "./FreeTierUpgradeCard";
 import { copyToClipboard } from "@/lib/clipboard";
 import ClawBoxLoginModal, { type ClawBoxLoginFeature } from "./ClawBoxLoginModal";
@@ -71,7 +72,7 @@ interface SystemStats {
 }
 
 
-const SECTIONS = ["appearance", "wifi", "ai", "localAi", "localModels", "telegram", "remote", "system", "about"] as const;
+const SECTIONS = ["appearance", "wifi", "ai", "localAi", "localModels", "voice", "telegram", "remote", "system", "about"] as const;
 
 const REBOOT_PROBE_GRACE_MS = 8_000;
 const REBOOT_PROBE_INTERVAL_MS = 3_000;
@@ -86,6 +87,7 @@ const NAV_ITEMS: { id: Section; icon: string; labelKey?: string; label?: string 
   { id: "ai", icon: "smart_toy", labelKey: "settings.aiProvider" },
   { id: "localAi", icon: "memory", label: "Local AI" },
   { id: "localModels", icon: "deployed_code", label: "Local Models" },
+  { id: "voice", icon: "record_voice_over", label: "Voice" },
   { id: "telegram", icon: "send", labelKey: "settings.telegram" },
   { id: "remote", icon: "cloud_sync", labelKey: "settings.remote" },
   { id: "system", icon: "monitor_heart", labelKey: "settings.system" },
@@ -2433,6 +2435,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         )}
 
         {/* ─── Local Models ─── */}
+        {activeSection === "voice" && (
+          <VoiceOutputPanel active={activeSection === "voice"} />
+        )}
+
         {activeSection === "localModels" && (
           <LocalModelsPanel active={activeSection === "localModels"} />
         )}

--- a/src/components/VoiceOutputPanel.tsx
+++ b/src/components/VoiceOutputPanel.tsx
@@ -225,7 +225,12 @@ export default function VoiceOutputPanel({ active }: { active: boolean }) {
         {CHOICES.map(choice => {
           const selected = status.choice === choice.id;
           const engine = choice.id === "auto" ? null : engineById(choice.id as VoiceEngineId);
-          const unavailable = engine !== null && !engine.usable;
+          // Absent and broken are different answers, and only one of them
+          // means "you cannot pick this". A voice whose last check failed is
+          // still offered — refusing it would make the failure permanent,
+          // because nothing else would ever route a check through it again.
+          const unavailable = engine !== null && !engine.configured;
+          const failing = engine !== null && engine.configured && !engine.usable;
           return (
             <button
               key={choice.id}
@@ -252,6 +257,11 @@ export default function VoiceOutputPanel({ active }: { active: boolean }) {
                 {unavailable && (
                   <span className="text-[11px] px-2 py-0.5 rounded-full border bg-amber-500/10 text-amber-300 border-amber-400/20">
                     Not available
+                  </span>
+                )}
+                {failing && (
+                  <span className="text-[11px] px-2 py-0.5 rounded-full border bg-amber-500/10 text-amber-300 border-amber-400/20">
+                    Last check failed
                   </span>
                 )}
                 {engine?.proven && (

--- a/src/components/VoiceOutputPanel.tsx
+++ b/src/components/VoiceOutputPanel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   VoiceChoice,
   VoiceEngine,
@@ -123,6 +123,7 @@ export default function VoiceOutputPanel({ active }: { active: boolean }) {
     load();
   }, [active, load]);
 
+
   const post = useCallback(async (body: Record<string, unknown>, kind: "select" | "check") => {
     setBusy(kind);
     setError(null);
@@ -145,6 +146,20 @@ export default function VoiceOutputPanel({ active }: { active: boolean }) {
     }
   }, []);
 
+  // Auto is a standing instruction, not a one-off write: if the engine it
+  // resolves to is not the one the box is configured for — because a cloud
+  // voice appeared, or the one in use stopped working — move the box rather
+  // than telling the customer to click their own choice again. Once per mount,
+  // so a write that does not clear the drift cannot become a loop.
+  const reconciled = useRef(false);
+  useEffect(() => {
+    if (!active || !status || busy) return;
+    if (status.choice !== "auto" || !status.drifted) return;
+    if (reconciled.current) return;
+    reconciled.current = true;
+    void post({ action: "select", choice: "auto" }, "select");
+  }, [active, status, busy, post]);
+
   if (!status) {
     return (
       <div className="max-w-2xl space-y-3" data-testid="voice-output-loading">
@@ -160,8 +175,13 @@ export default function VoiceOutputPanel({ active }: { active: boolean }) {
 
   const engineById = (id: VoiceEngineId | null) =>
     id ? status.engines.find(e => e.id === id) ?? null : null;
-  const speaking = engineById(status.activeEngine);
-  const preferred = engineById(status.preferredEngine);
+  // What will ACTUALLY speak, not what is written in the config. When a chosen
+  // engine stops working the gateway falls back at request time, so naming the
+  // configured primary here would tell the customer the one thing this panel
+  // exists to stop them believing.
+  const speaking = engineById(status.preferredEngine) ?? engineById(status.activeEngine);
+  const chosen = status.choice === "auto" ? null : engineById(status.choice as VoiceEngineId);
+  const fellBack = chosen !== null && speaking !== null && chosen.id !== speaking.id;
   const last = status.lastCheck;
   const servedEngine = engineById(last?.servedEngine ?? null);
   const warning = status.warning;
@@ -188,9 +208,10 @@ export default function VoiceOutputPanel({ active }: { active: boolean }) {
         <div className="text-sm font-semibold text-[var(--text-primary)] mt-1">
           {speaking ? speaking.label : "No voice is selected on this box."}
         </div>
-        {status.drifted && preferred && (
+        {fellBack && (
           <p className="text-sm text-amber-200 mt-2" data-testid="voice-drift">
-            Your choice would use {preferred.label}. Pick it again to move this box over.
+            You chose {chosen.label}, but it cannot speak right now, so {speaking.label} answers
+            instead.
           </p>
         )}
         {warning && (

--- a/src/components/VoiceOutputPanel.tsx
+++ b/src/components/VoiceOutputPanel.tsx
@@ -40,6 +40,22 @@ function isEngine(value: unknown): value is VoiceEngine {
 }
 
 /**
+ * An attempt is only adopted when every field the list below reads is really
+ * there. `attempts: [null]` used to pass the array check and then throw on
+ * `attempt.engine` one render later — the same guard-the-envelope-then-read-a-
+ * sibling mistake this validator exists to prevent.
+ */
+function isAttempt(value: unknown): boolean {
+  if (!value || typeof value !== "object") return false;
+  const a = value as Record<string, unknown>;
+  if (typeof a.providerId !== "string") return false;
+  if (a.engine !== null && !ENGINE_ORDER.includes(a.engine as VoiceEngineId)) return false;
+  if (typeof a.ok !== "boolean") return false;
+  if (a.message !== null && typeof a.message !== "string") return false;
+  return a.latencyMs === null || typeof a.latencyMs === "number";
+}
+
+/**
  * Validate every field the render reads, not just the first one.
  *
  * `{ engines: [] }` passing here and throwing one render later on
@@ -63,7 +79,12 @@ export function isVoiceStatus(value: unknown): value is VoiceOutputStatus {
     if (!last || typeof last !== "object") return false;
     const c = last as Record<string, unknown>;
     if (typeof c.at !== "number" || typeof c.ok !== "boolean") return false;
-    if (!Array.isArray(c.attempts)) return false;
+    if (!Array.isArray(c.attempts) || !c.attempts.every(isAttempt)) return false;
+    // Rendered directly when no engine matched, so an unvalidated value shows
+    // the customer the literal word "undefined".
+    if (c.servedByProviderId !== null && typeof c.servedByProviderId !== "string") return false;
+    if (c.servedEngine !== null && !ENGINE_ORDER.includes(c.servedEngine as VoiceEngineId)) return false;
+    if (c.message !== null && typeof c.message !== "string") return false;
   }
   return true;
 }

--- a/src/components/VoiceOutputPanel.tsx
+++ b/src/components/VoiceOutputPanel.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import type {
+  VoiceChoice,
+  VoiceEngine,
+  VoiceEngineId,
+  VoiceOutputStatus,
+} from "@/lib/voice-output";
+
+const CHOICES: { id: VoiceChoice; title: string; blurb: string }[] = [
+  {
+    id: "auto",
+    title: "Auto",
+    blurb: "Let ClawBox choose. It prefers the cloud voice and speaks on the box when the cloud cannot.",
+  },
+  {
+    id: "local",
+    title: "On this box",
+    blurb: "Speak with the on-device voice. Nothing to be spoken leaves the box unless it cannot speak at all.",
+  },
+  {
+    id: "cloud",
+    title: "ClawBox cloud",
+    blurb: "Speak with the cloud voice. The words to be spoken leave this box.",
+  },
+];
+
+const ENGINE_ORDER: VoiceEngineId[] = ["local", "cloud"];
+
+function isEngine(value: unknown): value is VoiceEngine {
+  if (!value || typeof value !== "object") return false;
+  const e = value as Record<string, unknown>;
+  if (!ENGINE_ORDER.includes(e.id as VoiceEngineId)) return false;
+  if (typeof e.label !== "string" || typeof e.detail !== "string") return false;
+  if (e.providerId !== null && typeof e.providerId !== "string") return false;
+  return typeof e.configured === "boolean"
+    && typeof e.proven === "boolean"
+    && typeof e.usable === "boolean";
+}
+
+/**
+ * Validate every field the render reads, not just the first one.
+ *
+ * `{ engines: [] }` passing here and throwing one render later on
+ * `status.choice` is the same mistake that took the whole ClawKeep window down
+ * on TASK-398 and that CodeRabbit caught again on the Local Models tab: a panel
+ * that cannot read the box must keep its last good reading, never take the
+ * window with it.
+ */
+export function isVoiceStatus(value: unknown): value is VoiceOutputStatus {
+  if (!value || typeof value !== "object") return false;
+  const s = value as Record<string, unknown>;
+  if (!["auto", "local", "cloud"].includes(s.choice as string)) return false;
+  if (!Array.isArray(s.engines) || !s.engines.every(isEngine)) return false;
+  if (s.activeProviderId !== null && typeof s.activeProviderId !== "string") return false;
+  if (s.activeEngine !== null && !ENGINE_ORDER.includes(s.activeEngine as VoiceEngineId)) return false;
+  if (s.preferredEngine !== null && !ENGINE_ORDER.includes(s.preferredEngine as VoiceEngineId)) return false;
+  if (typeof s.drifted !== "boolean") return false;
+  if (s.warning !== null && typeof s.warning !== "string") return false;
+  const last = s.lastCheck;
+  if (last !== null) {
+    if (!last || typeof last !== "object") return false;
+    const c = last as Record<string, unknown>;
+    if (typeof c.at !== "number" || typeof c.ok !== "boolean") return false;
+    if (!Array.isArray(c.attempts)) return false;
+  }
+  return true;
+}
+
+function checkedAt(at: number): string {
+  try {
+    return new Date(at).toLocaleString();
+  } catch {
+    return "";
+  }
+}
+
+function seconds(ms: number | null): string {
+  if (ms === null || !Number.isFinite(ms) || ms <= 0) return "";
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+export default function VoiceOutputPanel({ active }: { active: boolean }) {
+  const [status, setStatus] = useState<VoiceOutputStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<"select" | "check" | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetch("/setup-api/tts", { cache: "no-store" });
+      const data = await res.json();
+      if (!isVoiceStatus(data)) return;
+      setStatus(data);
+    } catch {
+      /* keep the last good reading rather than blanking the panel */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    load();
+  }, [active, load]);
+
+  const post = useCallback(async (body: Record<string, unknown>, kind: "select" | "check") => {
+    setBusy(kind);
+    setError(null);
+    try {
+      const res = await fetch("/setup-api/tts", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError(typeof data?.error === "string" ? data.error : "Could not change the voice.");
+        return;
+      }
+      if (isVoiceStatus(data)) setStatus(data);
+    } catch {
+      setError("Could not reach the box.");
+    } finally {
+      setBusy(null);
+    }
+  }, []);
+
+  if (!status) {
+    return (
+      <div className="max-w-2xl space-y-3" data-testid="voice-output-loading">
+        {[0, 1, 2].map(i => (
+          <div key={i} className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5 animate-pulse">
+            <div className="h-3 w-40 rounded bg-white/[0.08]" />
+            <div className="h-2 w-64 rounded bg-white/[0.06] mt-3" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const engineById = (id: VoiceEngineId | null) =>
+    id ? status.engines.find(e => e.id === id) ?? null : null;
+  const speaking = engineById(status.activeEngine);
+  const preferred = engineById(status.preferredEngine);
+  const last = status.lastCheck;
+  const servedEngine = engineById(last?.servedEngine ?? null);
+  const warning = status.warning;
+
+  return (
+    <div className="max-w-2xl space-y-4">
+      <p className="text-sm text-[var(--text-secondary)]">
+        Who speaks when your ClawBox talks back. Whatever you pick here, the box tells you which
+        voice actually answered — a choice that quietly does something else is the thing this
+        setting exists to prevent.
+      </p>
+
+      {error && (
+        <div role="alert" className="rounded-xl border border-red-500/20 bg-red-500/[0.06] px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div
+        data-testid="voice-speaking-now"
+        className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5"
+      >
+        <div className="text-xs uppercase tracking-wide text-[var(--text-muted)]">Speaking now</div>
+        <div className="text-sm font-semibold text-[var(--text-primary)] mt-1">
+          {speaking ? speaking.label : "No voice is selected on this box."}
+        </div>
+        {status.drifted && preferred && (
+          <p className="text-sm text-amber-200 mt-2" data-testid="voice-drift">
+            Your choice would use {preferred.label}. Pick it again to move this box over.
+          </p>
+        )}
+        {warning && (
+          <p role="alert" className="text-sm text-amber-200 mt-2" data-testid="voice-cloud-warning">
+            ⚠️ {warning}
+          </p>
+        )}
+      </div>
+
+      <div role="radiogroup" aria-label="Voice output" className="space-y-3">
+        {CHOICES.map(choice => {
+          const selected = status.choice === choice.id;
+          const engine = choice.id === "auto" ? null : engineById(choice.id as VoiceEngineId);
+          const unavailable = engine !== null && !engine.usable;
+          return (
+            <button
+              key={choice.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-disabled={unavailable || busy !== null}
+              disabled={busy !== null}
+              data-testid={`voice-choice-${choice.id}`}
+              onClick={() => post({ action: "select", choice: choice.id }, "select")}
+              className={`w-full text-left rounded-2xl border p-5 transition-colors cursor-pointer disabled:opacity-60 ${
+                selected
+                  ? "border-[var(--coral-bright)] bg-[var(--coral-bright)]/[0.08]"
+                  : "border-[var(--border-subtle)] bg-[var(--surface-card)]"
+              }`}
+            >
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="text-sm font-semibold text-[var(--text-primary)]">{choice.title}</span>
+                {selected && (
+                  <span className="text-[11px] px-2 py-0.5 rounded-full border bg-cyan-500/10 text-cyan-300 border-cyan-400/20">
+                    Chosen
+                  </span>
+                )}
+                {unavailable && (
+                  <span className="text-[11px] px-2 py-0.5 rounded-full border bg-amber-500/10 text-amber-300 border-amber-400/20">
+                    Not available
+                  </span>
+                )}
+                {engine?.proven && (
+                  <span className="text-[11px] px-2 py-0.5 rounded-full border bg-white/[0.06] text-[var(--text-secondary)] border-white/10">
+                    Proven on this box
+                  </span>
+                )}
+              </div>
+              <p className="text-sm text-[var(--text-secondary)] mt-2">{choice.blurb}</p>
+              {engine && (
+                <p className="text-xs text-[var(--text-muted)] mt-2">{engine.detail}</p>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <div className="text-sm font-semibold text-[var(--text-primary)]">Voice check</div>
+            <p className="text-sm text-[var(--text-secondary)] mt-1">
+              Speaks one short phrase for real and reports which voice produced it.
+            </p>
+          </div>
+          <button
+            type="button"
+            data-testid="voice-check"
+            disabled={busy !== null}
+            aria-busy={busy === "check"}
+            onClick={() => post({ action: "check" }, "check")}
+            className="rounded-xl border border-[var(--border-subtle)] px-4 py-2 text-sm text-[var(--text-primary)] cursor-pointer disabled:opacity-50 shrink-0"
+          >
+            {busy === "check" ? "Checking…" : "Check voice"}
+          </button>
+        </div>
+
+        {last && (
+          <div className="mt-4 space-y-2" data-testid="voice-last-check">
+            <div className="text-xs text-[var(--text-muted)]">Last checked {checkedAt(last.at)}</div>
+            <div className={`text-sm ${last.ok ? "text-[var(--text-primary)]" : "text-red-300"}`}>
+              {last.ok
+                ? `${servedEngine?.label ?? last.servedByProviderId ?? "A voice"} spoke.`
+                : last.message
+                  ? `No voice could speak: ${last.message}`
+                  : "No voice could speak."}
+            </div>
+            {last.attempts.length > 0 && (
+              <ul className="text-xs text-[var(--text-muted)] space-y-1">
+                {last.attempts.map((attempt, i) => {
+                  const label = engineById(attempt.engine)?.label ?? attempt.providerId;
+                  const took = seconds(attempt.latencyMs);
+                  return (
+                    <li key={`${attempt.providerId}-${i}`}>
+                      {attempt.ok
+                        ? `${label} spoke${took ? ` in ${took}` : ""}.`
+                        : `${label} could not speak${attempt.message ? `: ${attempt.message}` : "."}`}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-[var(--text-muted)]">
+        A voice shown as not available is genuinely missing from this box — it is not a switch that
+        can be turned on here.
+      </p>
+    </div>
+  );
+}

--- a/src/lib/local-models.ts
+++ b/src/lib/local-models.ts
@@ -415,6 +415,28 @@ function embeddingEntry(probe: EmbeddingProbe, engines: LocalModelEntry[]): Loca
   };
 }
 
+/**
+ * Just the speech-out rows.
+ *
+ * The Voice panel (TASK-434) needs one fact — is there a voice on this box —
+ * and it must be the SAME fact the Local Models tab shows, or the two would
+ * eventually disagree about whether Kokoro is installed. Building the whole
+ * inventory for it would cost an Ollama HTTP probe, a llama.cpp probe and two
+ * more systemctl round trips that cannot change the answer.
+ */
+export async function buildTtsInventory(): Promise<LocalModelEntry[]> {
+  const settled = await Promise.all([kokoroEntry, piperEntry].map(async build => {
+    try {
+      return await build();
+    } catch {
+      // One unreadable engine must not hide the other: a box with Piper
+      // installed can still speak while Kokoro's unit refuses to answer.
+      return null;
+    }
+  }));
+  return settled.filter((e): e is LocalModelEntry => e !== null);
+}
+
 export interface InventoryProbes {
   ollamaBaseUrl: string;
   llamacpp: LlamaCppProbe;

--- a/src/lib/voice-output-store.ts
+++ b/src/lib/voice-output-store.ts
@@ -1,0 +1,121 @@
+/**
+ * Where the voice-output selection lives.
+ *
+ * `messages.tts.provider` records which engine speaks, but it cannot record
+ * that the customer asked for "Auto": Auto and an explicit pick can resolve to
+ * the same provider, and only one of them should move when the box changes. So
+ * the choice is kept beside the setup app's own state, and openclaw.json stays
+ * the single truth for what is actually configured.
+ *
+ * The per-engine check memory rides along in the same file: it is a record of
+ * what this box observed, not configuration, and losing it costs nothing worse
+ * than an "unproven" badge until the next check.
+ */
+import { promises as fs } from "fs";
+import path from "path";
+import crypto from "crypto";
+import { DATA_DIR } from "@/lib/config-store";
+import {
+  DEFAULT_VOICE_STATE,
+  isVoiceChoice,
+  normalizeProviderId,
+  type VoiceAttempt,
+  type VoiceCheck,
+  type VoiceEngineId,
+  type VoiceOutputState,
+} from "@/lib/voice-output";
+
+export const VOICE_STATE_PATH = path.join(DATA_DIR, "voice-output.json");
+
+const ENGINE_IDS: VoiceEngineId[] = ["local", "cloud"];
+
+function readAttempt(value: unknown): VoiceAttempt | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const providerId = normalizeProviderId(raw.providerId);
+  if (!providerId) return null;
+  const engine = ENGINE_IDS.includes(raw.engine as VoiceEngineId)
+    ? raw.engine as VoiceEngineId
+    : null;
+  return {
+    providerId,
+    engine,
+    ok: raw.ok === true,
+    message: typeof raw.message === "string" ? raw.message : null,
+    latencyMs: typeof raw.latencyMs === "number" && Number.isFinite(raw.latencyMs)
+      ? raw.latencyMs
+      : null,
+  };
+}
+
+function readCheck(value: unknown): VoiceCheck | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const at = typeof raw.at === "number" && Number.isFinite(raw.at) ? raw.at : null;
+  if (at === null) return null;
+  const attempts = Array.isArray(raw.attempts)
+    ? raw.attempts.map(readAttempt).filter((a): a is VoiceAttempt => a !== null)
+    : [];
+  return {
+    at,
+    ok: raw.ok === true,
+    servedByProviderId: normalizeProviderId(raw.servedByProviderId),
+    servedEngine: ENGINE_IDS.includes(raw.servedEngine as VoiceEngineId)
+      ? raw.servedEngine as VoiceEngineId
+      : null,
+    attempts,
+    message: typeof raw.message === "string" ? raw.message : null,
+  };
+}
+
+/**
+ * Never throws and never returns a half-read shape: a corrupt or truncated
+ * state file must cost the customer an "unproven" badge, not the Voice panel.
+ * Every field is validated the way it will be read, because a guard that
+ * checks the envelope and lets an entry through is the mistake that took the
+ * whole ClawKeep window down on TASK-398.
+ */
+export async function readVoiceState(): Promise<VoiceOutputState> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await fs.readFile(VOICE_STATE_PATH, "utf8"));
+  } catch {
+    return { ...DEFAULT_VOICE_STATE, engineChecks: {} };
+  }
+  if (!parsed || typeof parsed !== "object") {
+    return { ...DEFAULT_VOICE_STATE, engineChecks: {} };
+  }
+  const raw = parsed as Record<string, unknown>;
+  const engineChecks: VoiceOutputState["engineChecks"] = {};
+  const rawChecks = raw.engineChecks;
+  if (rawChecks && typeof rawChecks === "object") {
+    for (const engine of ENGINE_IDS) {
+      const entry = (rawChecks as Record<string, unknown>)[engine];
+      const attempt = readAttempt(entry);
+      const at = (entry as { at?: unknown })?.at;
+      if (attempt && typeof at === "number" && Number.isFinite(at)) {
+        engineChecks[engine] = { ...attempt, at };
+      }
+    }
+  }
+  return {
+    choice: isVoiceChoice(raw.choice) ? raw.choice : DEFAULT_VOICE_STATE.choice,
+    engineChecks,
+    lastCheck: readCheck(raw.lastCheck),
+  };
+}
+
+export async function writeVoiceState(state: VoiceOutputState): Promise<void> {
+  await fs.mkdir(DATA_DIR, { recursive: true });
+  // Atomic, like every other state file in data/: a half-written selection read
+  // by the next request would look like a corrupt file and silently reset the
+  // customer's choice to Auto.
+  const tmp = `${VOICE_STATE_PATH}.tmp.${crypto.randomBytes(4).toString("hex")}`;
+  try {
+    await fs.writeFile(tmp, JSON.stringify(state, null, 2), { mode: 0o600 });
+    await fs.rename(tmp, VOICE_STATE_PATH);
+  } catch (err) {
+    await fs.unlink(tmp).catch(() => {});
+    throw err;
+  }
+}

--- a/src/lib/voice-output-store.ts
+++ b/src/lib/voice-output-store.ts
@@ -21,13 +21,14 @@ import {
   normalizeProviderId,
   type VoiceAttempt,
   type VoiceCheck,
+  VOICE_ENGINE_IDS,
   type VoiceEngineId,
   type VoiceOutputState,
 } from "@/lib/voice-output";
 
 export const VOICE_STATE_PATH = path.join(DATA_DIR, "voice-output.json");
 
-const ENGINE_IDS: VoiceEngineId[] = ["local", "cloud"];
+const ENGINE_IDS = VOICE_ENGINE_IDS;
 
 function readAttempt(value: unknown): VoiceAttempt | null {
   if (!value || typeof value !== "object") return null;

--- a/src/lib/voice-output-store.ts
+++ b/src/lib/voice-output-store.ts
@@ -93,13 +93,8 @@ export async function readVoiceState(): Promise<VoiceOutputState> {
       const entry = (rawChecks as Record<string, unknown>)[engine];
       const attempt = readAttempt(entry);
       const at = (entry as { at?: unknown })?.at;
-      const signature = (entry as { signature?: unknown })?.signature;
       if (attempt && typeof at === "number" && Number.isFinite(at)) {
-        engineChecks[engine] = {
-          ...attempt,
-          at,
-          ...(typeof signature === "string" ? { signature } : {}),
-        };
+        engineChecks[engine] = { ...attempt, at };
       }
     }
   }

--- a/src/lib/voice-output-store.ts
+++ b/src/lib/voice-output-store.ts
@@ -93,8 +93,13 @@ export async function readVoiceState(): Promise<VoiceOutputState> {
       const entry = (rawChecks as Record<string, unknown>)[engine];
       const attempt = readAttempt(entry);
       const at = (entry as { at?: unknown })?.at;
+      const signature = (entry as { signature?: unknown })?.signature;
       if (attempt && typeof at === "number" && Number.isFinite(at)) {
-        engineChecks[engine] = { ...attempt, at };
+        engineChecks[engine] = {
+          ...attempt,
+          at,
+          ...(typeof signature === "string" ? { signature } : {}),
+        };
       }
     }
   }
@@ -112,7 +117,18 @@ export async function writeVoiceState(state: VoiceOutputState): Promise<void> {
   // customer's choice to Auto.
   const tmp = `${VOICE_STATE_PATH}.tmp.${crypto.randomBytes(4).toString("hex")}`;
   try {
-    await fs.writeFile(tmp, JSON.stringify(state, null, 2), { mode: 0o600 });
+    // rename() makes the swap atomic against a reader; it does not make the new
+    // bytes durable. This runs on a Jetson that gets unplugged, and a rename
+    // that outlives its own contents leaves a truncated file — which reads as
+    // corrupt and silently resets the customer's choice to Auto, exactly the
+    // loss the atomic write is here to prevent. So sync before swapping.
+    const handle = await fs.open(tmp, "w", 0o600);
+    try {
+      await handle.writeFile(JSON.stringify(state, null, 2));
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
     await fs.rename(tmp, VOICE_STATE_PATH);
   } catch (err) {
     await fs.unlink(tmp).catch(() => {});

--- a/src/lib/voice-output.ts
+++ b/src/lib/voice-output.ts
@@ -1,0 +1,510 @@
+/**
+ * Voice output: which engine speaks for this box, and which one actually did.
+ *
+ * TASK-434 asked for a per-capability Local/ClawBox/Auto picker across the whole
+ * multimodal stack. Yanko cut it to TTS on 2026-08-22 for a measured reason: of
+ * the five capabilities in the original scope, TTS is the only one with both an
+ * on-device and a cloud implementation on a ClawBox. The other four would have
+ * shipped a "Local" option nothing could ever select.
+ *
+ * Two facts about the device shape everything below, and both were read off a
+ * real box before any of this was written:
+ *
+ *  1. THE GATEWAY ALREADY OWNS THE FALLBACK. `messages.tts` has no
+ *     `fallbackProviders` key; `resolveTtsProviderOrder()` builds the chain from
+ *     the primary plus every other configured speech provider. So a selector's
+ *     whole job is to set the primary honestly and then report what actually
+ *     served — inventing a second chain here would just be a chain that can
+ *     disagree with the one that runs.
+ *
+ *  2. A CONFIGURED CLOUD VOICE IS NOT A WORKING ONE. The `openai` provider on a
+ *     ClawBox carries the ClawBox AI portal token (`claw_…`) and no
+ *     provider-level baseUrl, so a speech call goes to api.openai.com and comes
+ *     back 401 (`openclaw capability tts convert --model openai/gpt-4o-mini-tts`
+ *     on .177, 2026-08-22). The ClawBox AI proxy has no speech endpoint at all.
+ *     An option that is present in a registry is therefore not evidence that the
+ *     box can speak with it.
+ *
+ * So availability here is a MEASUREMENT, in the same spirit as the Local Models
+ * tab (TASK-435): an engine is usable when the box has what it needs AND the
+ * last real attempt through it did not fail. `runVoiceCheck` is that attempt —
+ * it synthesises a real phrase through the real chain and records which provider
+ * produced the audio, which is what makes "chosen vs actually used" a fact
+ * rather than a label.
+ */
+import { sanitizeErrorMessage } from "@/lib/safe-error-text";
+import { buildCloudTtsWarning } from "@/lib/tts-cloud-warning";
+
+/**
+ * The slice of openclaw.json this module reads.
+ *
+ * Declared here rather than importing OpenClawConfig so the rules below can be
+ * exercised against a literal in a test without dragging the CLI-spawning
+ * module in, and so it is obvious at a glance how little of the config a voice
+ * decision is allowed to depend on. `OpenClawConfig` is structurally assignable
+ * to it.
+ */
+export interface VoiceConfigView {
+  messages?: {
+    tts?: {
+      provider?: unknown;
+      providers?: unknown;
+    };
+  };
+  models?: {
+    providers?: Record<string, { apiKey?: unknown; baseUrl?: unknown } | undefined>;
+  };
+}
+
+/** The provider id install.sh writes for the on-device voice. */
+export const LOCAL_TTS_PROVIDER_ID = "tts-local-cli";
+
+/** The cloud speech provider a ClawBox would use if it had a key for one. */
+export const DEFAULT_CLOUD_TTS_PROVIDER_ID = "openai";
+
+/**
+ * What the privacy notice calls the cloud voice. The customer bought ClawBox AI,
+ * not a provider id, and the sentence reads "Voice uses <this> cloud TTS".
+ */
+export const CLOUD_DISCLOSURE_LABEL = "ClawBox AI";
+
+/**
+ * The standing V4 product decision (Yanko, 2026-08-20): cloud TTS first, local
+ * as the fallback. "Auto" follows this rather than pinning it, so a box whose
+ * cloud voice is unusable still speaks instead of going silent.
+ */
+export const RECOMMENDED_ENGINE: VoiceEngineId = "cloud";
+
+export type VoiceChoice = "auto" | "local" | "cloud";
+export type VoiceEngineId = "local" | "cloud";
+
+export const VOICE_CHOICES: readonly VoiceChoice[] = ["auto", "local", "cloud"];
+
+export function isVoiceChoice(value: unknown): value is VoiceChoice {
+  return typeof value === "string" && (VOICE_CHOICES as readonly string[]).includes(value);
+}
+
+export interface VoiceAttempt {
+  providerId: string;
+  engine: VoiceEngineId | null;
+  ok: boolean;
+  /** Customer-safe, or null when the raw reason could not be shown. */
+  message: string | null;
+  latencyMs: number | null;
+}
+
+export interface VoiceCheck {
+  at: number;
+  ok: boolean;
+  /** The provider that actually produced audio, when one did. */
+  servedByProviderId: string | null;
+  servedEngine: VoiceEngineId | null;
+  attempts: VoiceAttempt[];
+  message: string | null;
+}
+
+export interface VoiceEngine {
+  id: VoiceEngineId;
+  providerId: string | null;
+  label: string;
+  /** Everything this engine needs is present on the box. */
+  configured: boolean;
+  /** A real conversion has gone through this engine on this box. */
+  proven: boolean;
+  /** The box can use it: configured, and the last real attempt did not fail. */
+  usable: boolean;
+  /** One line the customer can act on. Never a path, a URL or a credential. */
+  detail: string;
+}
+
+export interface VoiceOutputStatus {
+  choice: VoiceChoice;
+  /** `messages.tts.provider` exactly as it stands in openclaw.json. */
+  activeProviderId: string | null;
+  /** Which of our two engines that provider is, or null when it is neither. */
+  activeEngine: VoiceEngineId | null;
+  /** What `choice` resolves to given today's measurements. */
+  preferredEngine: VoiceEngineId | null;
+  /** The selection and the box disagree — Auto has somewhere to move to. */
+  drifted: boolean;
+  engines: VoiceEngine[];
+  lastCheck: VoiceCheck | null;
+  /**
+   * The TASK-409 privacy notice, built by the same function the chat banner
+   * uses, so the two surfaces cannot word the same fact differently.
+   */
+  warning: string | null;
+}
+
+/** Persisted in the setup app's own data dir; see voice-output-store.ts. */
+export interface VoiceOutputState {
+  choice: VoiceChoice;
+  /** The most recent real attempt through each engine, by engine id. */
+  engineChecks: Partial<Record<VoiceEngineId, VoiceAttempt & { at: number }>>;
+  lastCheck: VoiceCheck | null;
+}
+
+export const DEFAULT_VOICE_STATE: VoiceOutputState = {
+  choice: "auto",
+  engineChecks: {},
+  lastCheck: null,
+};
+
+export function normalizeProviderId(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const id = value.trim().toLowerCase();
+  return id || null;
+}
+
+/**
+ * Local means "speaks without leaving the box". Kept deliberately in step with
+ * `isLocalProvider` in tts-cloud-warning.ts: the privacy banner and this
+ * selector must never disagree about whether an engine is on-device, or the box
+ * would show "on this box" beside a cloud warning. The contract test
+ * voice-output-warning-agreement asserts they agree on every id either sees.
+ */
+export function isLocalProviderId(id: string): boolean {
+  if (id === LOCAL_TTS_PROVIDER_ID) return true;
+  return /(?:^|[-_.])(local|cli|piper|kokoro)(?:$|[-_.])/.test(id);
+}
+
+export function engineForProviderId(id: string | null): VoiceEngineId | null {
+  if (!id) return null;
+  return isLocalProviderId(id) ? "local" : "cloud";
+}
+
+interface TtsProviderEntry {
+  command?: unknown;
+  apiKey?: unknown;
+  baseUrl?: unknown;
+}
+
+function ttsProviders(config: VoiceConfigView): Record<string, TtsProviderEntry> {
+  const providers = config.messages?.tts?.providers;
+  if (!providers || typeof providers !== "object" || Array.isArray(providers)) return {};
+  return providers as Record<string, TtsProviderEntry>;
+}
+
+export function configuredTtsProviderId(config: VoiceConfigView): string | null {
+  return normalizeProviderId(config.messages?.tts?.provider);
+}
+
+/**
+ * Which provider a cloud pick would write. Prefer an explicit `messages.tts`
+ * entry — someone who configured their own cloud voice means that one — and
+ * fall back to the OpenAI-compatible provider the ClawBox image ships.
+ */
+export function cloudProviderIdFor(config: VoiceConfigView): string | null {
+  for (const id of Object.keys(ttsProviders(config))) {
+    const normalized = normalizeProviderId(id);
+    if (normalized && !isLocalProviderId(normalized)) return normalized;
+  }
+  const models = config.models?.providers ?? {};
+  if (models[DEFAULT_CLOUD_TTS_PROVIDER_ID]) return DEFAULT_CLOUD_TTS_PROVIDER_ID;
+  return null;
+}
+
+function credentialFor(config: VoiceConfigView, providerId: string): string | null {
+  const direct = ttsProviders(config)[providerId]?.apiKey;
+  if (typeof direct === "string" && direct.trim()) return direct.trim();
+  const model = config.models?.providers?.[providerId]?.apiKey;
+  return typeof model === "string" && model.trim() ? model.trim() : null;
+}
+
+function cloudEndpointConfigured(config: VoiceConfigView, providerId: string): boolean {
+  const entry = ttsProviders(config)[providerId];
+  if (typeof entry?.baseUrl === "string" && entry.baseUrl.trim()) return true;
+  const provider = config.models?.providers?.[providerId];
+  return typeof provider?.baseUrl === "string" && Boolean(provider.baseUrl.trim());
+}
+
+/**
+ * A ClawBox AI portal token is not an OpenAI key. Sent to api.openai.com it
+ * comes back 401 — proven on .177 — and ClawBox AI itself serves chat,
+ * transcription and images but no speech, so there is nothing to point it at.
+ * Saying so before the customer spends a check on it is the difference between
+ * a selector that reports the box and one that repeats a registry.
+ */
+export function cloudCredentialIsUnusable(config: VoiceConfigView, providerId: string): boolean {
+  const key = credentialFor(config, providerId);
+  if (!key) return false;
+  return key.startsWith("claw_") && !cloudEndpointConfigured(config, providerId);
+}
+
+export interface LocalVoiceProbe {
+  /** `messages.tts.providers["tts-local-cli"]` names a command. */
+  providerConfigured: boolean;
+  /** That command is really on disk. */
+  commandPresent: boolean;
+  /** A TTS engine (Piper or Kokoro) is genuinely installed. */
+  engineInstalled: boolean;
+  /** Names of the installed on-device voices, for the detail line. */
+  engineNames: string[];
+}
+
+export function localCommandPath(config: VoiceConfigView): string | null {
+  const command = ttsProviders(config)[LOCAL_TTS_PROVIDER_ID]?.command;
+  return typeof command === "string" && command.trim() ? command.trim() : null;
+}
+
+function lastFailure(state: VoiceOutputState, engine: VoiceEngineId): string | null {
+  const attempt = state.engineChecks[engine];
+  if (!attempt || attempt.ok) return null;
+  return attempt.message ?? "The last voice check through it did not produce audio.";
+}
+
+function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState): VoiceEngine {
+  const configured = probe.providerConfigured && probe.commandPresent && probe.engineInstalled;
+  const failure = lastFailure(state, "local");
+  const proven = state.engineChecks.local?.ok === true;
+  const voices = probe.engineNames.join(", ");
+  let detail: string;
+  if (!probe.engineInstalled) {
+    detail = "No on-device voice is installed, so this box cannot speak by itself yet.";
+  } else if (!probe.providerConfigured || !probe.commandPresent) {
+    detail = "A voice is installed but the box is not wired to use it. Re-running the update repairs this.";
+  } else if (failure) {
+    detail = `The last voice check failed: ${failure}`;
+  } else if (proven) {
+    detail = voices
+      ? `Speaks on the box itself. Nothing leaves it. Installed: ${voices}.`
+      : "Speaks on the box itself. Nothing leaves it.";
+  } else {
+    detail = voices
+      ? `Speaks on the box itself. Nothing leaves it. Installed: ${voices}.`
+      : "Speaks on the box itself. Nothing leaves it.";
+  }
+  return {
+    id: "local",
+    providerId: LOCAL_TTS_PROVIDER_ID,
+    label: "On this box",
+    configured,
+    proven,
+    usable: configured && !failure,
+    detail,
+  };
+}
+
+function cloudEngine(config: VoiceConfigView, state: VoiceOutputState): VoiceEngine {
+  const providerId = cloudProviderIdFor(config);
+  const hasKey = providerId ? Boolean(credentialFor(config, providerId)) : false;
+  const unusableKey = providerId ? cloudCredentialIsUnusable(config, providerId) : false;
+  const failure = lastFailure(state, "cloud");
+  const proven = state.engineChecks.cloud?.ok === true;
+  const configured = Boolean(providerId) && hasKey && !unusableKey;
+
+  let detail: string;
+  if (!providerId || !hasKey) {
+    detail = "No cloud voice is set up on this box.";
+  } else if (unusableKey) {
+    detail = "ClawBox AI does not serve the voice yet, so this box has no cloud voice to call.";
+  } else if (failure) {
+    detail = `The last voice check failed: ${failure}`;
+  } else if (proven) {
+    detail = "Speaks in the cloud. The words to be spoken leave this box.";
+  } else {
+    detail = "Set up but not proven on this box yet. Run a voice check to find out.";
+  }
+
+  return {
+    id: "cloud",
+    providerId,
+    label: "ClawBox cloud",
+    configured,
+    proven,
+    usable: configured && !failure,
+    detail,
+  };
+}
+
+/**
+ * What the selection resolves to right now.
+ *
+ * Auto follows the standing recommendation but will not pin an engine the box
+ * cannot use; an explicit pick is honoured whenever it is usable, and only
+ * steps aside when it is not, because a silent box is worse than a box that
+ * says which engine it fell back to.
+ */
+export function resolvePreferredEngine(
+  choice: VoiceChoice,
+  engines: VoiceEngine[],
+): VoiceEngineId | null {
+  const usable = (id: VoiceEngineId) => engines.find(e => e.id === id)?.usable === true;
+  const order: VoiceEngineId[] = choice === "local"
+    ? ["local", "cloud"]
+    : choice === "cloud"
+      ? ["cloud", "local"]
+      : RECOMMENDED_ENGINE === "cloud" ? ["cloud", "local"] : ["local", "cloud"];
+  return order.find(usable) ?? null;
+}
+
+/**
+ * Reuse the chat disclosure rather than write a second one (PR #401, TASK-409).
+ *
+ * The payload is the shape `tts.status` returns, assembled from what this panel
+ * already measured: the primary is the provider actually configured, and the
+ * other engine is a fallback only when the box could really use it — which is
+ * exactly how the gateway derives its own chain. `enabled` is passed as true
+ * because the question here is "who would speak", not "is speech switched on":
+ * a customer choosing a cloud voice must see the notice at the moment they
+ * choose it, not only once the box has spoken.
+ */
+export function buildVoiceDisclosure(
+  activeProviderId: string | null,
+  engines: VoiceEngine[],
+): string | null {
+  const providerStates = engines
+    .filter(engine => engine.providerId)
+    .map(engine => ({
+      id: engine.providerId as string,
+      label: engine.id === "cloud" ? CLOUD_DISCLOSURE_LABEL : engine.label,
+      configured: engine.usable,
+    }));
+  const fallbackProviders = engines
+    .filter(engine => engine.usable && engine.providerId && engine.providerId !== activeProviderId)
+    .map(engine => engine.providerId as string);
+  return buildCloudTtsWarning({
+    enabled: true,
+    provider: activeProviderId ?? undefined,
+    fallbackProviders,
+    providerStates,
+  });
+}
+
+export function buildVoiceOutputStatus(
+  config: VoiceConfigView,
+  probe: LocalVoiceProbe,
+  state: VoiceOutputState,
+): VoiceOutputStatus {
+  const engines = [localEngine(probe, state), cloudEngine(config, state)];
+  const activeProviderId = configuredTtsProviderId(config);
+  const preferredEngine = resolvePreferredEngine(state.choice, engines);
+  const preferredProviderId = preferredEngine
+    ? engines.find(e => e.id === preferredEngine)?.providerId ?? null
+    : null;
+  return {
+    choice: state.choice,
+    activeProviderId,
+    activeEngine: engineForProviderId(activeProviderId),
+    preferredEngine,
+    drifted: Boolean(preferredProviderId) && preferredProviderId !== activeProviderId,
+    engines,
+    lastCheck: state.lastCheck,
+    warning: buildVoiceDisclosure(activeProviderId, engines),
+  };
+}
+
+/**
+ * Why an explicit pick cannot be honoured, or null when it can.
+ *
+ * Auto is always selectable — resolving to whatever works IS what it means.
+ * An explicit pick is not: scope line 3 of this task says "selecting Local and
+ * silently getting cloud is the failure mode to avoid", and the mirror is just
+ * as bad, so a named engine the box cannot use has to be refused out loud
+ * rather than quietly turned into the other one.
+ *
+ * Note this is about the moment of CHOOSING. Once chosen, the gateway still
+ * falls back if the picked engine fails mid-request — which is why the panel
+ * separately reports the engine that actually spoke.
+ */
+export function selectionError(choice: VoiceChoice, engines: VoiceEngine[]): string | null {
+  if (choice === "auto") {
+    return engines.some(e => e.usable) ? null : "This box has no voice it can use.";
+  }
+  const engine = engines.find(e => e.id === choice);
+  if (!engine) return "That voice is not available on this box.";
+  return engine.usable ? null : "That voice is not available on this box.";
+}
+
+/** The provider id a choice should write, or null when nothing is usable. */
+export function providerIdForChoice(
+  choice: VoiceChoice,
+  engines: VoiceEngine[],
+): string | null {
+  const engine = resolvePreferredEngine(choice, engines);
+  if (!engine) return null;
+  return engines.find(e => e.id === engine)?.providerId ?? null;
+}
+
+interface RawAttempt {
+  provider?: unknown;
+  outcome?: unknown;
+  reasonCode?: unknown;
+  error?: unknown;
+  message?: unknown;
+  latencyMs?: unknown;
+}
+
+function attemptMessage(raw: RawAttempt): string | null {
+  for (const candidate of [raw.error, raw.message, raw.reasonCode]) {
+    const safe = sanitizeErrorMessage(typeof candidate === "string" ? candidate : null);
+    if (safe && safe !== "success") return safe;
+  }
+  return null;
+}
+
+/**
+ * Turn `openclaw capability tts convert --json` into the per-engine record.
+ *
+ * The CLI reports every provider it tried, in order, with an outcome each — so
+ * a run where the cloud primary failed and the on-device voice spoke instead is
+ * visible as two attempts, which is the fallback made observable rather than
+ * asserted.
+ */
+export function parseVoiceCheck(rawOutput: unknown, at: number): VoiceCheck {
+  const payload = (rawOutput && typeof rawOutput === "object" && !Array.isArray(rawOutput))
+    ? rawOutput as Record<string, unknown>
+    : {};
+  const rawAttempts = Array.isArray(payload.attempts) ? payload.attempts as RawAttempt[] : [];
+  const attempts: VoiceAttempt[] = [];
+  for (const raw of rawAttempts) {
+    const providerId = normalizeProviderId(raw?.provider);
+    if (!providerId) continue;
+    const ok = raw.outcome === "success";
+    const latency = typeof raw.latencyMs === "number" && Number.isFinite(raw.latencyMs)
+      ? raw.latencyMs
+      : null;
+    attempts.push({
+      providerId,
+      engine: engineForProviderId(providerId),
+      ok,
+      message: ok ? null : attemptMessage(raw),
+      latencyMs: latency,
+    });
+  }
+  const served = attempts.find(a => a.ok) ?? null;
+  const ok = payload.ok === true && served !== null;
+  return {
+    at,
+    ok,
+    servedByProviderId: served?.providerId ?? null,
+    servedEngine: served?.engine ?? null,
+    attempts,
+    message: ok ? null : (attempts.find(a => !a.ok)?.message ?? null),
+  };
+}
+
+/**
+ * A failed run that never reached a provider still has to be recorded, or the
+ * panel would show the previous success and read as though nothing happened.
+ */
+export function failedVoiceCheck(rawMessage: unknown, at: number): VoiceCheck {
+  return {
+    at,
+    ok: false,
+    servedByProviderId: null,
+    servedEngine: null,
+    attempts: [],
+    message: sanitizeErrorMessage(rawMessage),
+  };
+}
+
+/** Fold a check's attempts into the per-engine memory the status reads. */
+export function applyCheck(state: VoiceOutputState, check: VoiceCheck): VoiceOutputState {
+  const engineChecks = { ...state.engineChecks };
+  for (const attempt of check.attempts) {
+    if (!attempt.engine) continue;
+    engineChecks[attempt.engine] = { ...attempt, at: check.at };
+  }
+  return { ...state, engineChecks, lastCheck: check };
+}

--- a/src/lib/voice-output.ts
+++ b/src/lib/voice-output.ts
@@ -79,6 +79,7 @@ export type VoiceChoice = "auto" | "local" | "cloud";
 export type VoiceEngineId = "local" | "cloud";
 
 export const VOICE_CHOICES: readonly VoiceChoice[] = ["auto", "local", "cloud"];
+export const VOICE_ENGINE_IDS: readonly VoiceEngineId[] = ["local", "cloud"];
 
 export function isVoiceChoice(value: unknown): value is VoiceChoice {
   return typeof value === "string" && (VOICE_CHOICES as readonly string[]).includes(value);
@@ -458,8 +459,17 @@ export function providerIdForChoice(
  */
 export function forgetEngineCheck(state: VoiceOutputState, engine: VoiceEngineId): VoiceOutputState {
   if (!state.engineChecks[engine]) return state;
-  const engineChecks = { ...state.engineChecks };
-  delete engineChecks[engine];
+  // Rebuilt from the fixed list of engine ids rather than spread-and-delete.
+  // `engine` reaches here from a request body — validated, but the shape that
+  // makes that safe is not visible to a static analyser, and writing a key
+  // derived from a request is worth avoiding on principle rather than
+  // defending. Every key written below is a literal from a constant.
+  const engineChecks: VoiceOutputState["engineChecks"] = {};
+  for (const id of VOICE_ENGINE_IDS) {
+    if (id === engine) continue;
+    const entry = state.engineChecks[id];
+    if (entry) engineChecks[id] = entry;
+  }
   return { ...state, engineChecks };
 }
 

--- a/src/lib/voice-output.ts
+++ b/src/lib/voice-output.ts
@@ -344,11 +344,19 @@ export function resolvePreferredEngine(
  *
  * The payload is the shape `tts.status` returns, assembled from what this panel
  * already measured: the primary is the provider actually configured, and the
- * other engine is a fallback only when the box could really use it — which is
- * exactly how the gateway derives its own chain. `enabled` is passed as true
- * because the question here is "who would speak", not "is speech switched on":
- * a customer choosing a cloud voice must see the notice at the moment they
- * choose it, not only once the box has spoken.
+ * other engine is a fallback when the box HAS it — which is exactly how the
+ * gateway derives its own chain.
+ *
+ * `configured`, not `usable`, and that distinction is the whole point of a
+ * privacy notice. A cloud voice whose last check failed is still in the chain:
+ * the gateway sends it the text, it fails, and only then does the on-device
+ * voice speak. The words left the box either way. Found on .177 with a failing
+ * cloud primary, where filtering by `usable` silently dropped the notice while
+ * every spoken reply was still being posted to the cloud first.
+ *
+ * `enabled` is passed as true because the question here is "who would speak",
+ * not "is speech switched on": a customer choosing a cloud voice must see the
+ * notice at the moment they choose it, not only once the box has spoken.
  */
 export function buildVoiceDisclosure(
   activeProviderId: string | null,
@@ -359,10 +367,10 @@ export function buildVoiceDisclosure(
     .map(engine => ({
       id: engine.providerId as string,
       label: engine.id === "cloud" ? CLOUD_DISCLOSURE_LABEL : engine.label,
-      configured: engine.usable,
+      configured: engine.configured,
     }));
   const fallbackProviders = engines
-    .filter(engine => engine.usable && engine.providerId && engine.providerId !== activeProviderId)
+    .filter(engine => engine.configured && engine.providerId && engine.providerId !== activeProviderId)
     .map(engine => engine.providerId as string);
   return buildCloudTtsWarning({
     enabled: true,

--- a/src/lib/voice-output.ts
+++ b/src/lib/voice-output.ts
@@ -32,7 +32,6 @@
  * produced the audio, which is what makes "chosen vs actually used" a fact
  * rather than a label.
  */
-import { createHash } from "crypto";
 import { sanitizeErrorMessage } from "@/lib/safe-error-text";
 import { buildCloudTtsWarning } from "@/lib/tts-cloud-warning";
 
@@ -85,19 +84,6 @@ export function isVoiceChoice(value: unknown): value is VoiceChoice {
   return typeof value === "string" && (VOICE_CHOICES as readonly string[]).includes(value);
 }
 
-/**
- * What a recorded attempt was an attempt AT.
- *
- * Without this, a failure is permanent by construction: once the cloud voice is
- * marked unusable, Auto stops choosing it, so no later check routes through it,
- * so nothing can ever clear the failure — and a customer who fixes the cause by
- * adding a real key would still be told the voice is unavailable. Tying the
- * record to the configuration it describes makes a fix take effect, and keeps a
- * "proven" badge from surviving a swapped credential it says nothing about.
- *
- * Deliberately shape, never secret: whether a key is present and which family
- * it belongs to, not the key.
- */
 export interface VoiceAttempt {
   providerId: string;
   engine: VoiceEngineId | null;
@@ -105,11 +91,6 @@ export interface VoiceAttempt {
   /** Customer-safe, or null when the raw reason could not be shown. */
   message: string | null;
   latencyMs: number | null;
-}
-
-export interface EngineSignatures {
-  local: string;
-  cloud: string;
 }
 
 export interface VoiceCheck {
@@ -159,7 +140,7 @@ export interface VoiceOutputStatus {
 export interface VoiceOutputState {
   choice: VoiceChoice;
   /** The most recent real attempt through each engine, by engine id. */
-  engineChecks: Partial<Record<VoiceEngineId, VoiceAttempt & { at: number; signature?: string }>>;
+  engineChecks: Partial<Record<VoiceEngineId, VoiceAttempt & { at: number }>>;
   lastCheck: VoiceCheck | null;
 }
 
@@ -266,57 +247,16 @@ export function localCommandPath(config: VoiceConfigView): string | null {
   return typeof command === "string" && command.trim() ? command.trim() : null;
 }
 
-/**
- * Identify a credential without recording it.
- *
- * The family alone is not enough: swapping a rejected OpenAI key for a working
- * one leaves both as "sk", the old failure would keep applying, and the
- * customer who just fixed the problem would still be told the voice is
- * unavailable. So the signature also carries a short SHA-256 prefix — enough to
- * notice the key changed, not enough to be a copy of it, and it lives in the
- * same 0600 file as the rest of this state.
- */
-function keyFingerprint(key: string | null): string {
-  if (!key) return "none";
-  const family = key.startsWith("claw_") ? "claw" : key.startsWith("sk-") ? "sk" : "other";
-  return `${family}:${createHash("sha256").update(key).digest("hex").slice(0, 12)}`;
-}
-
-export function engineSignatures(config: VoiceConfigView, probe: LocalVoiceProbe): EngineSignatures {
-  const cloudId = cloudProviderIdFor(config);
-  const cloudKey = cloudId ? credentialFor(config, cloudId) : null;
-  return {
-    local: [
-      LOCAL_TTS_PROVIDER_ID,
-      probe.providerConfigured ? "wired" : "unwired",
-      probe.commandPresent ? "present" : "absent",
-      [...probe.engineNames].sort().join(","),
-    ].join("|"),
-    cloud: [
-      cloudId ?? "none",
-      keyFingerprint(cloudKey),
-      cloudId && cloudEndpointConfigured(config, cloudId) ? "endpoint" : "no-endpoint",
-    ].join("|"),
-  };
-}
-
-/** The stored attempt, but only while it still describes today's configuration. */
-function currentAttempt(state: VoiceOutputState, engine: VoiceEngineId, signature: string) {
+function lastFailure(state: VoiceOutputState, engine: VoiceEngineId): string | null {
   const attempt = state.engineChecks[engine];
-  if (!attempt) return null;
-  return attempt.signature === signature ? attempt : null;
-}
-
-function lastFailure(state: VoiceOutputState, engine: VoiceEngineId, signature: string): string | null {
-  const attempt = currentAttempt(state, engine, signature);
   if (!attempt || attempt.ok) return null;
   return attempt.message ?? "The last voice check through it did not produce audio.";
 }
 
-function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState, signature: string): VoiceEngine {
+function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState): VoiceEngine {
   const configured = probe.providerConfigured && probe.commandPresent && probe.engineInstalled;
-  const failure = lastFailure(state, "local", signature);
-  const proven = currentAttempt(state, "local", signature)?.ok === true;
+  const failure = lastFailure(state, "local");
+  const proven = state.engineChecks.local?.ok === true;
   const voices = probe.engineNames.join(", ");
   let detail: string;
   if (!probe.engineInstalled) {
@@ -346,12 +286,12 @@ function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState, signature:
   };
 }
 
-function cloudEngine(config: VoiceConfigView, state: VoiceOutputState, signature: string): VoiceEngine {
+function cloudEngine(config: VoiceConfigView, state: VoiceOutputState): VoiceEngine {
   const providerId = cloudProviderIdFor(config);
   const hasKey = providerId ? Boolean(credentialFor(config, providerId)) : false;
   const unusableKey = providerId ? cloudCredentialIsUnusable(config, providerId) : false;
-  const failure = lastFailure(state, "cloud", signature);
-  const proven = currentAttempt(state, "cloud", signature)?.ok === true;
+  const failure = lastFailure(state, "cloud");
+  const proven = state.engineChecks.cloud?.ok === true;
   const configured = Boolean(providerId) && hasKey && !unusableKey;
 
   let detail: string;
@@ -437,11 +377,7 @@ export function buildVoiceOutputStatus(
   probe: LocalVoiceProbe,
   state: VoiceOutputState,
 ): VoiceOutputStatus {
-  const signatures = engineSignatures(config, probe);
-  const engines = [
-    localEngine(probe, state, signatures.local),
-    cloudEngine(config, state, signatures.cloud),
-  ];
+  const engines = [localEngine(probe, state), cloudEngine(config, state)];
   const activeProviderId = configuredTtsProviderId(config);
   const preferredEngine = resolvePreferredEngine(state.choice, engines);
   const preferredProviderId = preferredEngine
@@ -462,33 +398,61 @@ export function buildVoiceOutputStatus(
 /**
  * Why an explicit pick cannot be honoured, or null when it can.
  *
- * Auto is always selectable — resolving to whatever works IS what it means.
- * An explicit pick is not: scope line 3 of this task says "selecting Local and
- * silently getting cloud is the failure mode to avoid", and the mirror is just
- * as bad, so a named engine the box cannot use has to be refused out loud
- * rather than quietly turned into the other one.
+ * The gate is CONFIGURED, not usable, and the difference is the whole point. An
+ * engine the box does not have is refused out loud rather than quietly turned
+ * into the other one — scope line 3 of this task says a choice that silently
+ * becomes something else is the failure to avoid, and the mirror is just as
+ * bad. But an engine that merely FAILED its last check is still offered: a
+ * failure that also removed the customer's ability to retry would be permanent
+ * by construction, since Auto stops choosing a failed engine, so no later check
+ * would ever route through it and nothing could clear the record.
  *
- * Note this is about the moment of CHOOSING. Once chosen, the gateway still
- * falls back if the picked engine fails mid-request — which is why the panel
+ * This is about the moment of choosing. Once chosen, the gateway still falls
+ * back if the picked engine fails mid-request — which is why the panel
  * separately reports the engine that actually spoke.
  */
 export function selectionError(choice: VoiceChoice, engines: VoiceEngine[]): string | null {
   if (choice === "auto") {
-    return engines.some(e => e.usable) ? null : "This box has no voice it can use.";
+    return engines.some(e => e.configured) ? null : "This box has no voice it can use.";
   }
   const engine = engines.find(e => e.id === choice);
-  if (!engine) return "That voice is not available on this box.";
-  return engine.usable ? null : "That voice is not available on this box.";
+  if (!engine || !engine.configured) return "That voice is not available on this box.";
+  return null;
 }
 
-/** The provider id a choice should write, or null when nothing is usable. */
+/**
+ * The provider id a choice should write, or null when nothing can be written.
+ *
+ * An explicit pick writes THAT engine, even if its last check failed — the
+ * customer asked for it, and the alternative is a selector that reads back
+ * something the customer did not choose. Auto instead resolves to whatever can
+ * actually speak.
+ */
 export function providerIdForChoice(
   choice: VoiceChoice,
   engines: VoiceEngine[],
 ): string | null {
-  const engine = resolvePreferredEngine(choice, engines);
-  if (!engine) return null;
-  return engines.find(e => e.id === engine)?.providerId ?? null;
+  if (choice !== "auto") {
+    const engine = engines.find(e => e.id === choice);
+    return engine?.configured ? engine.providerId : null;
+  }
+  const preferred = resolvePreferredEngine("auto", engines);
+  return preferred ? engines.find(e => e.id === preferred)?.providerId ?? null : null;
+}
+
+/**
+ * Drop what this box observed about one engine.
+ *
+ * Called when the customer deliberately picks an engine again: they are asking
+ * for a retry, and continuing to say "the last check failed" about a choice
+ * they have just re-made would be reporting history as if it were the present.
+ * The next check writes a fresh record either way.
+ */
+export function forgetEngineCheck(state: VoiceOutputState, engine: VoiceEngineId): VoiceOutputState {
+  if (!state.engineChecks[engine]) return state;
+  const engineChecks = { ...state.engineChecks };
+  delete engineChecks[engine];
+  return { ...state, engineChecks };
 }
 
 interface RawAttempt {
@@ -568,20 +532,16 @@ export function failedVoiceCheck(rawMessage: unknown, at: number): VoiceCheck {
  * Fold a check's attempts into the per-engine memory the status reads.
  *
  * An engine this check did not attempt keeps its previous record: clearing it
- * would let a known-bad engine drift back to "unproven" every time the other
- * one is checked, and Auto would keep choosing it. The record ages out by
- * SIGNATURE instead — it stops applying the moment the configuration it
- * describes changes, which is the only event that can actually have fixed it.
+ * would let a known-bad engine read as merely unproven every time the other one
+ * is checked, and Auto would keep choosing it. The record is cleared by
+ * {@link forgetEngineCheck} instead, when the customer deliberately asks for
+ * that engine again.
  */
-export function applyCheck(
-  state: VoiceOutputState,
-  check: VoiceCheck,
-  signatures: EngineSignatures,
-): VoiceOutputState {
+export function applyCheck(state: VoiceOutputState, check: VoiceCheck): VoiceOutputState {
   const engineChecks = { ...state.engineChecks };
   for (const attempt of check.attempts) {
     if (!attempt.engine) continue;
-    engineChecks[attempt.engine] = { ...attempt, at: check.at, signature: signatures[attempt.engine] };
+    engineChecks[attempt.engine] = { ...attempt, at: check.at };
   }
   return { ...state, engineChecks, lastCheck: check };
 }

--- a/src/lib/voice-output.ts
+++ b/src/lib/voice-output.ts
@@ -32,6 +32,7 @@
  * produced the audio, which is what makes "chosen vs actually used" a fact
  * rather than a label.
  */
+import { createHash } from "crypto";
 import { sanitizeErrorMessage } from "@/lib/safe-error-text";
 import { buildCloudTtsWarning } from "@/lib/tts-cloud-warning";
 
@@ -84,6 +85,19 @@ export function isVoiceChoice(value: unknown): value is VoiceChoice {
   return typeof value === "string" && (VOICE_CHOICES as readonly string[]).includes(value);
 }
 
+/**
+ * What a recorded attempt was an attempt AT.
+ *
+ * Without this, a failure is permanent by construction: once the cloud voice is
+ * marked unusable, Auto stops choosing it, so no later check routes through it,
+ * so nothing can ever clear the failure — and a customer who fixes the cause by
+ * adding a real key would still be told the voice is unavailable. Tying the
+ * record to the configuration it describes makes a fix take effect, and keeps a
+ * "proven" badge from surviving a swapped credential it says nothing about.
+ *
+ * Deliberately shape, never secret: whether a key is present and which family
+ * it belongs to, not the key.
+ */
 export interface VoiceAttempt {
   providerId: string;
   engine: VoiceEngineId | null;
@@ -91,6 +105,11 @@ export interface VoiceAttempt {
   /** Customer-safe, or null when the raw reason could not be shown. */
   message: string | null;
   latencyMs: number | null;
+}
+
+export interface EngineSignatures {
+  local: string;
+  cloud: string;
 }
 
 export interface VoiceCheck {
@@ -140,7 +159,7 @@ export interface VoiceOutputStatus {
 export interface VoiceOutputState {
   choice: VoiceChoice;
   /** The most recent real attempt through each engine, by engine id. */
-  engineChecks: Partial<Record<VoiceEngineId, VoiceAttempt & { at: number }>>;
+  engineChecks: Partial<Record<VoiceEngineId, VoiceAttempt & { at: number; signature?: string }>>;
   lastCheck: VoiceCheck | null;
 }
 
@@ -247,16 +266,57 @@ export function localCommandPath(config: VoiceConfigView): string | null {
   return typeof command === "string" && command.trim() ? command.trim() : null;
 }
 
-function lastFailure(state: VoiceOutputState, engine: VoiceEngineId): string | null {
+/**
+ * Identify a credential without recording it.
+ *
+ * The family alone is not enough: swapping a rejected OpenAI key for a working
+ * one leaves both as "sk", the old failure would keep applying, and the
+ * customer who just fixed the problem would still be told the voice is
+ * unavailable. So the signature also carries a short SHA-256 prefix — enough to
+ * notice the key changed, not enough to be a copy of it, and it lives in the
+ * same 0600 file as the rest of this state.
+ */
+function keyFingerprint(key: string | null): string {
+  if (!key) return "none";
+  const family = key.startsWith("claw_") ? "claw" : key.startsWith("sk-") ? "sk" : "other";
+  return `${family}:${createHash("sha256").update(key).digest("hex").slice(0, 12)}`;
+}
+
+export function engineSignatures(config: VoiceConfigView, probe: LocalVoiceProbe): EngineSignatures {
+  const cloudId = cloudProviderIdFor(config);
+  const cloudKey = cloudId ? credentialFor(config, cloudId) : null;
+  return {
+    local: [
+      LOCAL_TTS_PROVIDER_ID,
+      probe.providerConfigured ? "wired" : "unwired",
+      probe.commandPresent ? "present" : "absent",
+      [...probe.engineNames].sort().join(","),
+    ].join("|"),
+    cloud: [
+      cloudId ?? "none",
+      keyFingerprint(cloudKey),
+      cloudId && cloudEndpointConfigured(config, cloudId) ? "endpoint" : "no-endpoint",
+    ].join("|"),
+  };
+}
+
+/** The stored attempt, but only while it still describes today's configuration. */
+function currentAttempt(state: VoiceOutputState, engine: VoiceEngineId, signature: string) {
   const attempt = state.engineChecks[engine];
+  if (!attempt) return null;
+  return attempt.signature === signature ? attempt : null;
+}
+
+function lastFailure(state: VoiceOutputState, engine: VoiceEngineId, signature: string): string | null {
+  const attempt = currentAttempt(state, engine, signature);
   if (!attempt || attempt.ok) return null;
   return attempt.message ?? "The last voice check through it did not produce audio.";
 }
 
-function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState): VoiceEngine {
+function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState, signature: string): VoiceEngine {
   const configured = probe.providerConfigured && probe.commandPresent && probe.engineInstalled;
-  const failure = lastFailure(state, "local");
-  const proven = state.engineChecks.local?.ok === true;
+  const failure = lastFailure(state, "local", signature);
+  const proven = currentAttempt(state, "local", signature)?.ok === true;
   const voices = probe.engineNames.join(", ");
   let detail: string;
   if (!probe.engineInstalled) {
@@ -265,11 +325,12 @@ function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState): VoiceEngi
     detail = "A voice is installed but the box is not wired to use it. Re-running the update repairs this.";
   } else if (failure) {
     detail = `The last voice check failed: ${failure}`;
-  } else if (proven) {
-    detail = voices
-      ? `Speaks on the box itself. Nothing leaves it. Installed: ${voices}.`
-      : "Speaks on the box itself. Nothing leaves it.";
   } else {
+    // No "set up but unproven" line here, unlike the cloud engine, and that
+    // asymmetry is the point: the on-device voice is judged by artefacts read
+    // off this disk, so naming the installed voice IS the evidence. A cloud key
+    // can only be tested by using it, so until a check succeeds the honest
+    // thing to say about it is that nobody has tried.
     detail = voices
       ? `Speaks on the box itself. Nothing leaves it. Installed: ${voices}.`
       : "Speaks on the box itself. Nothing leaves it.";
@@ -285,12 +346,12 @@ function localEngine(probe: LocalVoiceProbe, state: VoiceOutputState): VoiceEngi
   };
 }
 
-function cloudEngine(config: VoiceConfigView, state: VoiceOutputState): VoiceEngine {
+function cloudEngine(config: VoiceConfigView, state: VoiceOutputState, signature: string): VoiceEngine {
   const providerId = cloudProviderIdFor(config);
   const hasKey = providerId ? Boolean(credentialFor(config, providerId)) : false;
   const unusableKey = providerId ? cloudCredentialIsUnusable(config, providerId) : false;
-  const failure = lastFailure(state, "cloud");
-  const proven = state.engineChecks.cloud?.ok === true;
+  const failure = lastFailure(state, "cloud", signature);
+  const proven = currentAttempt(state, "cloud", signature)?.ok === true;
   const configured = Boolean(providerId) && hasKey && !unusableKey;
 
   let detail: string;
@@ -376,7 +437,11 @@ export function buildVoiceOutputStatus(
   probe: LocalVoiceProbe,
   state: VoiceOutputState,
 ): VoiceOutputStatus {
-  const engines = [localEngine(probe, state), cloudEngine(config, state)];
+  const signatures = engineSignatures(config, probe);
+  const engines = [
+    localEngine(probe, state, signatures.local),
+    cloudEngine(config, state, signatures.cloud),
+  ];
   const activeProviderId = configuredTtsProviderId(config);
   const preferredEngine = resolvePreferredEngine(state.choice, engines);
   const preferredProviderId = preferredEngine
@@ -499,12 +564,24 @@ export function failedVoiceCheck(rawMessage: unknown, at: number): VoiceCheck {
   };
 }
 
-/** Fold a check's attempts into the per-engine memory the status reads. */
-export function applyCheck(state: VoiceOutputState, check: VoiceCheck): VoiceOutputState {
+/**
+ * Fold a check's attempts into the per-engine memory the status reads.
+ *
+ * An engine this check did not attempt keeps its previous record: clearing it
+ * would let a known-bad engine drift back to "unproven" every time the other
+ * one is checked, and Auto would keep choosing it. The record ages out by
+ * SIGNATURE instead — it stops applying the moment the configuration it
+ * describes changes, which is the only event that can actually have fixed it.
+ */
+export function applyCheck(
+  state: VoiceOutputState,
+  check: VoiceCheck,
+  signatures: EngineSignatures,
+): VoiceOutputState {
   const engineChecks = { ...state.engineChecks };
   for (const attempt of check.attempts) {
     if (!attempt.engine) continue;
-    engineChecks[attempt.engine] = { ...attempt, at: check.at };
+    engineChecks[attempt.engine] = { ...attempt, at: check.at, signature: signatures[attempt.engine] };
   }
   return { ...state, engineChecks, lastCheck: check };
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -144,6 +144,7 @@ const PRE_AUTH_SENSITIVE_PREFIXES = [
   "/setup-api/gateway/ws-config", // hands back the live gateway auth token
   "/setup-api/chat",        // reads generated media out of the harness media tree
   "/setup-api/local-models", // POST enables/disables real systemd units through sudo
+  "/setup-api/tts",         // POST rewrites messages.tts.provider and spawns the openclaw CLI
   // Hermes edition. During setup the device broadcasts an OPEN `ClawBox-Setup`
   // AP, so anything left pre-auth is reachable by anyone in radio range.
   //   - /hermes/chat runs a full agent turn with shell/tool access, unlimited.

--- a/src/tests/components/voice-output-panel.test.tsx
+++ b/src/tests/components/voice-output-panel.test.tsx
@@ -167,6 +167,25 @@ describe("status validation", () => {
 
   it("rejects a last check that is missing the fields the render reads", () => {
     expect(isVoiceStatus({ ...status(), lastCheck: { ok: true } })).toBe(false);
-    expect(isVoiceStatus({ ...status(), lastCheck: { at: 1, ok: true, attempts: [] } })).toBe(true);
+    expect(isVoiceStatus({ ...status(), lastCheck: { at: 1, ok: true, attempts: [], servedByProviderId: null, servedEngine: null, message: null } })).toBe(true);
+  });
+});
+
+describe("a damaged check record cannot take the window down", () => {
+  const withCheck = (attempts: unknown[], over: Record<string, unknown> = {}) => ({
+    ...status(),
+    lastCheck: { at: 1, ok: true, servedByProviderId: "tts-local-cli", servedEngine: "local", attempts, message: null, ...over },
+  });
+
+  it("rejects a check whose attempts are not attempts", () => {
+    expect(isVoiceStatus(withCheck([null]))).toBe(false);
+    expect(isVoiceStatus(withCheck([{ providerId: "openai" }]))).toBe(false);
+    expect(isVoiceStatus(withCheck([{ providerId: "openai", engine: "cloud", ok: false, message: null, latencyMs: null }]))).toBe(true);
+  });
+
+  it("rejects a served provider the panel would print as `undefined`", () => {
+    expect(isVoiceStatus(withCheck([], { servedByProviderId: 7 }))).toBe(false);
+    expect(isVoiceStatus(withCheck([], { servedEngine: "quantum" }))).toBe(false);
+    expect(isVoiceStatus(withCheck([], { message: 7 }))).toBe(false);
   });
 });

--- a/src/tests/components/voice-output-panel.test.tsx
+++ b/src/tests/components/voice-output-panel.test.tsx
@@ -234,3 +234,30 @@ describe("a damaged check record cannot take the window down", () => {
     expect(isVoiceStatus(withCheck([], { message: 7 }))).toBe(false);
   });
 });
+
+describe("absent and broken are different answers", () => {
+  it("offers a voice whose last check failed, and says so", async () => {
+    mockFetch([status({
+      engines: [
+        engine(),
+        engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud", configured: true, usable: false, detail: "The last voice check failed: provider_error" }),
+      ],
+    })]);
+    render(<VoiceOutputPanel active />);
+    const cloud = await screen.findByTestId("voice-choice-cloud");
+    expect(within(cloud).getByText("Last check failed")).toBeTruthy();
+    expect(within(cloud).queryByText("Not available")).toBeNull();
+    // Still pickable: refusing it would make the failure permanent, since
+    // nothing else would ever route a check through it again.
+    expect(cloud.getAttribute("aria-disabled")).toBe("false");
+  });
+
+  it("does not offer a voice the box does not have", async () => {
+    mockFetch([status()]);
+    render(<VoiceOutputPanel active />);
+    const cloud = await screen.findByTestId("voice-choice-cloud");
+    expect(within(cloud).getByText("Not available")).toBeTruthy();
+    expect(within(cloud).queryByText("Last check failed")).toBeNull();
+    expect(cloud.getAttribute("aria-disabled")).toBe("true");
+  });
+});

--- a/src/tests/components/voice-output-panel.test.tsx
+++ b/src/tests/components/voice-output-panel.test.tsx
@@ -137,10 +137,55 @@ describe("Voice panel", () => {
     expect(screen.queryByTestId("voice-cloud-warning")).toBeNull();
   });
 
-  it("tells the customer their choice has somewhere to move to", async () => {
-    mockFetch([status({ preferredEngine: "cloud", drifted: true, engines: [engine(), engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud" })] })]);
+  it("names the engine that will actually speak, not the one in the config", async () => {
+    // The chosen cloud voice broke, so the gateway will fall back at request
+    // time. Naming the configured primary here would tell the customer the one
+    // thing this panel exists to stop them believing.
+    mockFetch([status({
+      choice: "cloud",
+      activeProviderId: "openai",
+      activeEngine: "cloud",
+      preferredEngine: "local",
+      drifted: true,
+    })]);
     render(<VoiceOutputPanel active />);
-    expect(await screen.findByTestId("voice-drift")).toHaveTextContent(/ClawBox cloud/);
+    const speaking = await screen.findByTestId("voice-speaking-now");
+    expect(within(speaking).getByText("On this box")).toBeTruthy();
+    expect(await screen.findByTestId("voice-drift"))
+      .toHaveTextContent(/You chose ClawBox cloud, but it cannot speak right now, so On this box answers instead/);
+  });
+
+  it("says nothing about a fallback when the chosen voice is the one speaking", async () => {
+    mockFetch([status({ choice: "local", preferredEngine: "local" })]);
+    render(<VoiceOutputPanel active />);
+    await screen.findByTestId("voice-speaking-now");
+    expect(screen.queryByTestId("voice-drift")).toBeNull();
+  });
+
+  it("moves the box itself when Auto resolves somewhere else, instead of asking the customer to re-pick", async () => {
+    const both = [engine(), engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud" })];
+    const fn = mockFetch([status({ preferredEngine: "cloud", drifted: true, engines: both })]);
+    fn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => status({ activeProviderId: "openai", activeEngine: "cloud", preferredEngine: "cloud", drifted: false, engines: both }),
+    });
+    render(<VoiceOutputPanel active />);
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+    expect(JSON.parse((fn.mock.calls[1][1] as { body: string }).body)).toEqual({ action: "select", choice: "auto" });
+    const speaking = await screen.findByTestId("voice-speaking-now");
+    expect(within(speaking).getByText("ClawBox cloud")).toBeTruthy();
+  });
+
+  it("does not keep rewriting the box when the drift will not clear", async () => {
+    // A write that does not resolve the drift must not become a loop.
+    const both = [engine(), engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud" })];
+    const drifting = status({ preferredEngine: "cloud", drifted: true, engines: both });
+    const fn = mockFetch([drifting]);
+    fn.mockResolvedValue({ ok: true, json: async () => drifting });
+    render(<VoiceOutputPanel active />);
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+    await new Promise(r => setTimeout(r, 300));
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 
   it("keeps its last good reading when the box answers something that is not a status", async () => {

--- a/src/tests/components/voice-output-panel.test.tsx
+++ b/src/tests/components/voice-output-panel.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
+import VoiceOutputPanel, { isVoiceStatus } from "@/components/VoiceOutputPanel";
+
+/**
+ * TASK-434 — what the customer is actually told.
+ *
+ * The acceptance line this panel exists for is "the chosen and the actually-used
+ * engine must both be visible", so the assertions are about both being on
+ * screen at once, and about a voice the box cannot use reading as unavailable
+ * rather than as a choice that silently does something else.
+ */
+
+function engine(over: Record<string, unknown> = {}) {
+  return {
+    id: "local", providerId: "tts-local-cli", label: "On this box",
+    configured: true, proven: false, usable: true, detail: "Speaks on the box itself.",
+    ...over,
+  };
+}
+
+function status(over: Record<string, unknown> = {}) {
+  return {
+    choice: "auto",
+    activeProviderId: "tts-local-cli",
+    activeEngine: "local",
+    preferredEngine: "local",
+    drifted: false,
+    engines: [
+      engine(),
+      engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud", usable: false, configured: false, detail: "ClawBox AI does not serve the voice yet, so this box has no cloud voice to call." }),
+    ],
+    lastCheck: null,
+    warning: null,
+    ...over,
+  };
+}
+
+function mockFetch(payloads: unknown[]) {
+  const fn = vi.fn();
+  for (const p of payloads) fn.mockResolvedValueOnce({ ok: true, json: async () => p });
+  fn.mockResolvedValue({ ok: true, json: async () => payloads.at(-1) });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe("Voice panel", () => {
+  it("shows which voice is speaking and which one is chosen, together", async () => {
+    mockFetch([status()]);
+    render(<VoiceOutputPanel active />);
+    const speaking = await screen.findByTestId("voice-speaking-now");
+    expect(within(speaking).getByText("On this box")).toBeTruthy();
+    expect(screen.getByTestId("voice-choice-auto").getAttribute("aria-checked")).toBe("true");
+    expect(screen.getByTestId("voice-choice-local").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("reads a voice the box cannot use as unavailable, with the reason", async () => {
+    mockFetch([status()]);
+    render(<VoiceOutputPanel active />);
+    const cloud = await screen.findByTestId("voice-choice-cloud");
+    expect(within(cloud).getByText("Not available")).toBeTruthy();
+    expect(within(cloud).getByText(/does not serve the voice yet/)).toBeTruthy();
+    expect(cloud.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("surfaces the box's refusal rather than pretending the pick worked", async () => {
+    const fn = mockFetch([status()]);
+    fn.mockResolvedValueOnce({ ok: false, json: async () => ({ error: "That voice is not available on this box." }) });
+    render(<VoiceOutputPanel active />);
+    fireEvent.click(await screen.findByTestId("voice-choice-cloud"));
+    expect(await screen.findByRole("alert")).toHaveTextContent("That voice is not available on this box.");
+    // The panel must not paint the refused choice as chosen.
+    expect(screen.getByTestId("voice-choice-cloud").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("sends the choice and adopts the box's answer", async () => {
+    const fn = mockFetch([status()]);
+    fn.mockResolvedValueOnce({
+      ok: true,
+      json: async () => status({ choice: "local", activeEngine: "local" }),
+    });
+    render(<VoiceOutputPanel active />);
+    fireEvent.click(await screen.findByTestId("voice-choice-local"));
+    await waitFor(() => {
+      expect(screen.getByTestId("voice-choice-local").getAttribute("aria-checked")).toBe("true");
+    });
+    const body = JSON.parse((fn.mock.calls[1][1] as { body: string }).body);
+    expect(body).toEqual({ action: "select", choice: "local" });
+  });
+
+  it("says which voice actually spoke, and names the one that failed before it", async () => {
+    mockFetch([status({
+      lastCheck: {
+        at: 1_787_000_000_000,
+        ok: true,
+        servedByProviderId: "tts-local-cli",
+        servedEngine: "local",
+        attempts: [
+          { providerId: "openai", engine: "cloud", ok: false, message: "rejected by the voice service", latencyMs: null },
+          { providerId: "tts-local-cli", engine: "local", ok: true, message: null, latencyMs: 14893 },
+        ],
+        message: null,
+      },
+    })]);
+    render(<VoiceOutputPanel active />);
+    const last = await screen.findByTestId("voice-last-check");
+    expect(within(last).getByText(/On this box spoke\./)).toBeTruthy();
+    expect(within(last).getByText(/ClawBox cloud could not speak: rejected by the voice service/)).toBeTruthy();
+    expect(within(last).getByText(/On this box spoke in 14\.9s\./)).toBeTruthy();
+  });
+
+  it("runs a real check when asked", async () => {
+    const fn = mockFetch([status()]);
+    fn.mockResolvedValueOnce({ ok: true, json: async () => status() });
+    render(<VoiceOutputPanel active />);
+    fireEvent.click(await screen.findByTestId("voice-check"));
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+    expect(JSON.parse((fn.mock.calls[1][1] as { body: string }).body)).toEqual({ action: "check" });
+  });
+
+  it("shows the privacy notice the box sent, and nothing when it sent none", async () => {
+    mockFetch([status({
+      activeProviderId: "openai",
+      activeEngine: "cloud",
+      warning: "Privacy notice: Voice uses ClawBox AI cloud TTS. Text sent for speech leaves this ClawBox.",
+    })]);
+    render(<VoiceOutputPanel active />);
+    expect(await screen.findByTestId("voice-cloud-warning")).toHaveTextContent(/leaves this ClawBox/);
+  });
+
+  it("says nothing about the cloud when the box speaks locally", async () => {
+    mockFetch([status()]);
+    render(<VoiceOutputPanel active />);
+    await screen.findByTestId("voice-speaking-now");
+    expect(screen.queryByTestId("voice-cloud-warning")).toBeNull();
+  });
+
+  it("tells the customer their choice has somewhere to move to", async () => {
+    mockFetch([status({ preferredEngine: "cloud", drifted: true, engines: [engine(), engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud" })] })]);
+    render(<VoiceOutputPanel active />);
+    expect(await screen.findByTestId("voice-drift")).toHaveTextContent(/ClawBox cloud/);
+  });
+
+  it("keeps its last good reading when the box answers something that is not a status", async () => {
+    const fn = mockFetch([status()]);
+    render(<VoiceOutputPanel active />);
+    await screen.findByTestId("voice-speaking-now");
+    fn.mockResolvedValueOnce({ ok: true, json: async () => ({ engines: [] }) });
+    fireEvent.click(screen.getByTestId("voice-check"));
+    await waitFor(() => expect(fn).toHaveBeenCalledTimes(2));
+    // Still rendered, still the old reading — not a blank panel and not a crash.
+    expect(screen.getByTestId("voice-speaking-now")).toBeTruthy();
+  });
+});
+
+describe("status validation", () => {
+  it("rejects a payload whose engines are half a shape", () => {
+    expect(isVoiceStatus(status())).toBe(true);
+    expect(isVoiceStatus({ ...status(), engines: [{ id: "local" }] })).toBe(false);
+    expect(isVoiceStatus({ ...status(), choice: "fastest" })).toBe(false);
+    expect(isVoiceStatus({ ...status(), drifted: "yes" })).toBe(false);
+    expect(isVoiceStatus({ engines: [] })).toBe(false);
+    expect(isVoiceStatus(null)).toBe(false);
+  });
+
+  it("rejects a last check that is missing the fields the render reads", () => {
+    expect(isVoiceStatus({ ...status(), lastCheck: { ok: true } })).toBe(false);
+    expect(isVoiceStatus({ ...status(), lastCheck: { at: 1, ok: true, attempts: [] } })).toBe(true);
+  });
+});

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -484,6 +484,9 @@ describe("middleware", () => {
       // in onboarding — during the setup window the device is broadcasting an
       // OPEN AP, so anyone in radio range would otherwise reach it.
       "/setup-api/local-models",
+      // POST rewrites messages.tts.provider and spawns the openclaw CLI. Same
+      // radio-range reasoning as local-models: onboarding never calls it.
+      "/setup-api/tts",
       "/setup-api/gateway",
       "/setup-api/gateway/", // trailing slash must not dodge the exact match
     ])("gates sensitive %s during the setup window", async (p) => {

--- a/src/tests/routes/tts.test.ts
+++ b/src/tests/routes/tts.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-434 — /setup-api/tts.
+ *
+ * The route's job beyond reporting is to REFUSE. A ClawBox carries a `claw_`
+ * portal token in `models.providers.openai` and ClawBox AI serves no speech, so
+ * "ClawBox cloud" is an option the box cannot honour today; writing it into
+ * `messages.tts.provider` anyway would leave a customer with a voice setting
+ * that silently never speaks. That has to hold at the API, not only in the UI.
+ */
+
+const readConfigMock = vi.fn();
+const configSetMock = vi.fn();
+const ttsInventoryMock = vi.fn();
+const spawnMock = vi.fn();
+const accessMock = vi.fn();
+const readStateMock = vi.fn();
+const writeStateMock = vi.fn();
+
+vi.mock("@/lib/openclaw-config", () => ({
+  readConfig: (...a: unknown[]) => readConfigMock(...a),
+  runOpenclawConfigSet: (...a: unknown[]) => configSetMock(...a),
+  findOpenclawBin: () => "/usr/local/bin/openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+vi.mock("@/lib/local-models", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/local-models")>();
+  return { ...actual, buildTtsInventory: (...a: unknown[]) => ttsInventoryMock(...a) };
+});
+
+vi.mock("@/lib/voice-output-store", () => ({
+  readVoiceState: (...a: unknown[]) => readStateMock(...a),
+  writeVoiceState: (...a: unknown[]) => writeStateMock(...a),
+}));
+
+vi.mock("child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("child_process")>();
+  return { ...actual, spawn: (...a: unknown[]) => spawnMock(...a) };
+});
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  return {
+    ...actual,
+    promises: { ...actual.promises, access: (...a: unknown[]) => accessMock(...a), unlink: async () => {} },
+  };
+});
+
+const LOCAL = "tts-local-cli";
+
+function config(over: Record<string, unknown> = {}) {
+  return {
+    messages: { tts: { provider: LOCAL, providers: { [LOCAL]: { command: "/opt/clawbox-tts.sh" } } } },
+    models: { providers: { openai: { apiKey: "claw_84d065b" } } },
+    ...over,
+  };
+}
+
+const piperInstalled = [{
+  id: "piper", name: "Piper", kind: "tts", runtime: "On-demand binary",
+  installed: true, enabled: null, running: "on-demand", diskBytes: 1, memoryBytes: null,
+  control: "none", detail: "Speaks on demand.",
+}];
+
+/** A fake `openclaw capability tts convert --json` that prints `stdout` and exits `code`. */
+function cliEmits(stdout: string, code = 0) {
+  return () => {
+    const handlers: Record<string, ((arg: unknown) => void)[]> = {};
+    const stream = (chunk: string) => ({
+      on: (_e: string, cb: (b: Buffer) => void) => { if (chunk) setTimeout(() => cb(Buffer.from(chunk)), 0); },
+    });
+    setTimeout(() => (handlers.close ?? []).forEach(cb => cb(code)), 5);
+    return {
+      stdout: stream(stdout),
+      stderr: stream(""),
+      kill: () => {},
+      on: (event: string, cb: (arg: unknown) => void) => {
+        (handlers[event] ??= []).push(cb);
+      },
+    };
+  };
+}
+
+async function route() {
+  return await import("@/app/setup-api/tts/route");
+}
+
+function post(body: unknown) {
+  return new Request("http://box/setup-api/tts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  readConfigMock.mockReset().mockResolvedValue(config());
+  configSetMock.mockReset().mockResolvedValue(undefined);
+  ttsInventoryMock.mockReset().mockResolvedValue(piperInstalled);
+  spawnMock.mockReset();
+  accessMock.mockReset().mockResolvedValue(undefined);
+  readStateMock.mockReset().mockResolvedValue({ choice: "auto", engineChecks: {}, lastCheck: null });
+  writeStateMock.mockReset().mockResolvedValue(undefined);
+});
+
+describe("GET /setup-api/tts", () => {
+  it("reports the engines and never caches them", async () => {
+    const { GET } = await route();
+    const res = await GET();
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = await res.json();
+    expect(body.engines.map((e: { id: string }) => e.id)).toEqual(["local", "cloud"]);
+    expect(body.activeProviderId).toBe(LOCAL);
+  });
+
+  it("never spawns the openclaw CLI just to render the panel", async () => {
+    const { GET } = await route();
+    await GET();
+    // The CLI costs 8-12s of cold start on an Orin. A panel that pays it on
+    // open reads as a broken box.
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("calls the local voice unusable when its command is gone, however healthy the voices look", async () => {
+    accessMock.mockRejectedValue(new Error("ENOENT"));
+    const { GET } = await route();
+    const body = await (await GET()).json();
+    expect(body.engines.find((e: { id: string }) => e.id === "local").usable).toBe(false);
+  });
+});
+
+describe("POST /setup-api/tts — select", () => {
+  it("writes the provider the choice resolves to", async () => {
+    readConfigMock.mockResolvedValue(config({
+      messages: { tts: { provider: "openai", providers: { [LOCAL]: { command: "/opt/clawbox-tts.sh" } } } },
+    }));
+    const { POST } = await route();
+    const res = await POST(post({ action: "select", choice: "local" }));
+    expect(res.status).toBe(200);
+    expect(configSetMock).toHaveBeenCalledWith(["messages.tts.provider", LOCAL]);
+    expect(writeStateMock.mock.calls[0][0].choice).toBe("local");
+  });
+
+  it("refuses a cloud voice the box cannot use, and changes nothing", async () => {
+    const { POST } = await route();
+    const res = await POST(post({ action: "select", choice: "cloud" }));
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "That voice is not available on this box." });
+    expect(configSetMock).not.toHaveBeenCalled();
+    expect(writeStateMock).not.toHaveBeenCalled();
+  });
+
+  it("selects the cloud voice once the box really has one", async () => {
+    readConfigMock.mockResolvedValue(config({
+      models: { providers: { openai: { apiKey: "sk-live-abc" } } },
+    }));
+    const { POST } = await route();
+    const res = await POST(post({ action: "select", choice: "cloud" }));
+    expect(res.status).toBe(200);
+    expect(configSetMock).toHaveBeenCalledWith(["messages.tts.provider", "openai"]);
+  });
+
+  it("does not rewrite the config when the box is already on that provider", async () => {
+    const { POST } = await route();
+    await POST(post({ action: "select", choice: "local" }));
+    expect(configSetMock).not.toHaveBeenCalled();
+    expect(writeStateMock.mock.calls[0][0].choice).toBe("local");
+  });
+
+  it("keeps the customer's choice out of the file when the config write failed", async () => {
+    configSetMock.mockRejectedValue(new Error("ConfigMutationConflictError"));
+    readConfigMock.mockResolvedValue(config({
+      messages: { tts: { provider: "openai", providers: { [LOCAL]: { command: "/opt/clawbox-tts.sh" } } } },
+    }));
+    const { POST } = await route();
+    const res = await POST(post({ action: "select", choice: "local" }));
+    expect(res.status).toBe(500);
+    expect(writeStateMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invented choice", async () => {
+    const { POST } = await route();
+    expect((await POST(post({ action: "select", choice: "cheapest" }))).status).toBe(400);
+    expect((await POST(post({ action: "teleport" }))).status).toBe(400);
+  });
+});
+
+describe("POST /setup-api/tts — check", () => {
+  it("records which voice actually spoke", async () => {
+    spawnMock.mockImplementation(cliEmits(JSON.stringify({
+      ok: true,
+      provider: LOCAL,
+      attempts: [{ provider: LOCAL, outcome: "success", latencyMs: 14893 }],
+    })));
+    const { POST } = await route();
+    const body = await (await POST(post({ action: "check" }))).json();
+    expect(body.lastCheck).toBeNull(); // status is re-read from the (mocked) store
+    const saved = writeStateMock.mock.calls[0][0];
+    expect(saved.lastCheck.ok).toBe(true);
+    expect(saved.lastCheck.servedEngine).toBe("local");
+    expect(saved.engineChecks.local.ok).toBe(true);
+  });
+
+  it("records the failed cloud attempt and the local voice that spoke after it", async () => {
+    spawnMock.mockImplementation(cliEmits(JSON.stringify({
+      ok: true,
+      provider: LOCAL,
+      attempts: [
+        { provider: "openai", outcome: "error", error: "rejected by the voice service" },
+        { provider: LOCAL, outcome: "success", latencyMs: 1200 },
+      ],
+    })));
+    const { POST } = await route();
+    await POST(post({ action: "check" }));
+    const saved = writeStateMock.mock.calls[0][0];
+    expect(saved.engineChecks.cloud.ok).toBe(false);
+    expect(saved.engineChecks.local.ok).toBe(true);
+  });
+
+  it("records a failure when the CLI produced no usable output at all", async () => {
+    spawnMock.mockImplementation(cliEmits("Error: TTS conversion failed", 1));
+    const { POST } = await route();
+    const res = await POST(post({ action: "check" }));
+    expect(res.status).toBe(200);
+    expect(writeStateMock.mock.calls[0][0].lastCheck.ok).toBe(false);
+  });
+
+  it("asks the CLI for the real chain rather than pinning one provider", async () => {
+    spawnMock.mockImplementation(cliEmits(JSON.stringify({ ok: true, attempts: [{ provider: LOCAL, outcome: "success" }] })));
+    const { POST } = await route();
+    await POST(post({ action: "check" }));
+    const args = spawnMock.mock.calls[0][1] as string[];
+    expect(args.slice(0, 3)).toEqual(["capability", "tts", "convert"]);
+    // No --model: the question is what happens when THIS box speaks, and the
+    // answer includes the fallback.
+    expect(args).not.toContain("--model");
+    expect(args).toContain("--json");
+  });
+});

--- a/src/tests/routes/tts.test.ts
+++ b/src/tests/routes/tts.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * TASK-434 — /setup-api/tts.
@@ -106,6 +106,13 @@ beforeEach(() => {
   writeStateMock.mockReset().mockResolvedValue(undefined);
 });
 
+// Fake timers installed by one test must not survive a failing assertion: the
+// tests after it drive `cliEmits`, whose close event is a setTimeout, and would
+// hang and report a second, misleading failure.
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe("GET /setup-api/tts", () => {
   it("reports the engines and never caches them", async () => {
     const { GET } = await route();
@@ -197,7 +204,10 @@ describe("POST /setup-api/tts — check", () => {
     })));
     const { POST } = await route();
     const body = await (await POST(post({ action: "check" }))).json();
-    expect(body.lastCheck).toBeNull(); // status is re-read from the (mocked) store
+    // The answer carries the run that just happened, rather than a status
+    // re-read from disk that would cost the box a third probe.
+    expect(body.lastCheck.servedEngine).toBe("local");
+    expect(body.engines.find((e: { id: string }) => e.id === "local").proven).toBe(true);
     const saved = writeStateMock.mock.calls[0][0];
     expect(saved.lastCheck.ok).toBe(true);
     expect(saved.lastCheck.servedEngine).toBe("local");
@@ -261,7 +271,6 @@ describe("POST /setup-api/tts — check", () => {
     const pending = POST(post({ action: "check" }));
     await vi.advanceTimersByTimeAsync(121_000);
     const res = await pending;
-    vi.useRealTimers();
     expect(killed).toBe(true);
     expect(res.status).toBe(200);
     const saved = writeStateMock.mock.calls[0][0].lastCheck;
@@ -314,5 +323,35 @@ describe("POST /setup-api/tts — check", () => {
     // answer includes the fallback.
     expect(args).not.toContain("--model");
     expect(args).toContain("--json");
+  });
+});
+
+describe("POST /setup-api/tts — failure boundary", () => {
+  it("answers with a message the panel can show when the box cannot be written to", async () => {
+    // A read-only data dir or a full disk must not surface as a framework error
+    // page: the panel would fall back to its own generic line and the box would
+    // log nothing worth reading.
+    writeStateMock.mockRejectedValue(new Error("EROFS: read-only file system"));
+    const { POST } = await route();
+    const res = await POST(post({ action: "select", choice: "local" }));
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Could not change the voice on this box." });
+  });
+
+  it("lets the customer ask again for an engine whose last check failed", async () => {
+    readConfigMock.mockResolvedValue(config({
+      models: { providers: { openai: { apiKey: "sk-live-abc" } } },
+    }));
+    readStateMock.mockResolvedValue({
+      choice: "auto",
+      engineChecks: { cloud: { providerId: "openai", engine: "cloud", ok: false, message: "rejected", latencyMs: null, at: 1 } },
+      lastCheck: null,
+    });
+    const { POST } = await route();
+    const res = await POST(post({ action: "select", choice: "cloud" }));
+    expect(res.status).toBe(200);
+    expect(configSetMock).toHaveBeenCalledWith(["messages.tts.provider", "openai"]);
+    // And the box stops reporting the old failure about a choice just re-made.
+    expect(writeStateMock.mock.calls[0][0].engineChecks.cloud).toBeUndefined();
   });
 });

--- a/src/tests/routes/tts.test.ts
+++ b/src/tests/routes/tts.test.ts
@@ -228,6 +228,82 @@ describe("POST /setup-api/tts — check", () => {
     expect(writeStateMock.mock.calls[0][0].lastCheck.ok).toBe(false);
   });
 
+
+  it("records a failure when the openclaw binary cannot be started at all", async () => {
+    spawnMock.mockImplementation(() => {
+      const handlers: Record<string, ((arg: unknown) => void)[]> = {};
+      setTimeout(() => (handlers.error ?? []).forEach(cb => cb(new Error("spawn ENOENT"))), 0);
+      return {
+        stdout: { on: () => {} },
+        stderr: { on: () => {} },
+        kill: () => {},
+        on: (event: string, cb: (arg: unknown) => void) => { (handlers[event] ??= []).push(cb); },
+      };
+    });
+    const { POST } = await route();
+    const res = await POST(post({ action: "check" }));
+    // A box with no CLI must record "no voice could speak", not throw a 500 out
+    // of the handler and leave the panel with the previous success on screen.
+    expect(res.status).toBe(200);
+    expect(writeStateMock.mock.calls[0][0].lastCheck.ok).toBe(false);
+  });
+
+  it("kills a conversion that never finishes and records that", async () => {
+    vi.useFakeTimers();
+    let killed = false;
+    spawnMock.mockImplementation(() => ({
+      stdout: { on: () => {} },
+      stderr: { on: () => {} },
+      kill: () => { killed = true; },
+      on: () => {},                       // never closes, never errors
+    }));
+    const { POST } = await route();
+    const pending = POST(post({ action: "check" }));
+    await vi.advanceTimersByTimeAsync(121_000);
+    const res = await pending;
+    vi.useRealTimers();
+    expect(killed).toBe(true);
+    expect(res.status).toBe(200);
+    const saved = writeStateMock.mock.calls[0][0].lastCheck;
+    expect(saved.ok).toBe(false);
+    expect(saved.message).toContain("took too long");
+  });
+
+  it("joins a check already in flight instead of starting a second synthesis", async () => {
+    // Two of these at once means two engines competing for the same GPU on an
+    // 8 GB board, and the client-side busy flag cannot stop a second tab.
+    spawnMock.mockImplementation(cliEmits(JSON.stringify({
+      ok: true, provider: LOCAL, attempts: [{ provider: LOCAL, outcome: "success", latencyMs: 900 }],
+    })));
+    const { POST } = await route();
+    const [a, b] = await Promise.all([POST(post({ action: "check" })), POST(post({ action: "check" }))]);
+    expect(a.status).toBe(200);
+    expect(b.status).toBe(200);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the state after the run, so a choice made during it survives", async () => {
+    // The handler must not hold a snapshot across its own 90 seconds: a
+    // customer who picks a different voice while the check runs would
+    // otherwise have that choice written back over by the stale copy.
+    const order: string[] = [];
+    spawnMock.mockImplementation((...args: unknown[]) => {
+      order.push("spawn");
+      return cliEmits(JSON.stringify({
+        ok: true, provider: LOCAL, attempts: [{ provider: LOCAL, outcome: "success", latencyMs: 900 }],
+      }))(...(args as []));
+    });
+    readStateMock.mockImplementation(async () => {
+      order.push("read");
+      // What the customer picked mid-run.
+      return { choice: "local", engineChecks: {}, lastCheck: null };
+    });
+    const { POST } = await route();
+    await POST(post({ action: "check" }));
+    expect(order.indexOf("spawn")).toBeLessThan(order.indexOf("read"));
+    expect(writeStateMock.mock.calls[0][0].choice).toBe("local");
+  });
+
   it("asks the CLI for the real chain rather than pinning one provider", async () => {
     spawnMock.mockImplementation(cliEmits(JSON.stringify({ ok: true, attempts: [{ provider: LOCAL, outcome: "success" }] })));
     const { POST } = await route();

--- a/src/tests/unit/voice-output-contract.test.ts
+++ b/src/tests/unit/voice-output-contract.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { promises as fs } from "node:fs";
+import { buildCloudTtsWarning } from "@/lib/tts-cloud-warning";
+import { isLocalProviderId, LOCAL_TTS_PROVIDER_ID } from "@/lib/voice-output";
+
+/**
+ * Two contracts the Voice panel cannot be allowed to break silently.
+ *
+ * 1. The provider id it writes must be the one install.sh selects. If the
+ *    installer ever renames it, "On this box" would write a primary no plugin
+ *    answers and the box would go mute with a green-looking setting — asserted
+ *    against the SHIPPED script, not a copy of its value.
+ *
+ * 2. It must agree with the chat privacy banner (TASK-409) about what counts as
+ *    a local engine. They are two surfaces describing the same fact, and the
+ *    one way to make a privacy notice actively harmful is to have the settings
+ *    page call an engine on-device while the banner does not.
+ */
+
+const INSTALLER = new URL("../../../install.sh", import.meta.url);
+
+describe("the voice selector agrees with the installer", () => {
+  it("writes the provider id install.sh selects", async () => {
+    const script = await fs.readFile(INSTALLER, "utf8");
+    expect(script).toContain(`oc_config_set messages.tts.provider "${LOCAL_TTS_PROVIDER_ID}"`);
+  });
+
+  it("reads the provider entry install.sh writes", async () => {
+    const script = await fs.readFile(INSTALLER, "utf8");
+    expect(script).toContain(`oc_config_set messages.tts.providers.${LOCAL_TTS_PROVIDER_ID}`);
+  });
+});
+
+describe("the voice selector agrees with the chat privacy banner", () => {
+  const ids = [
+    "tts-local-cli",
+    "kokoro",
+    "kokoro-server",
+    "piper",
+    "local-tts",
+    "openai",
+    "elevenlabs",
+    "azure",
+    "google-cloud-tts",
+  ];
+
+  it.each(ids)("classifies %s the same way the banner does", (id) => {
+    // The banner has no exported predicate, so ask it the only question it
+    // answers: an engine it considers local produces no cloud warning when it
+    // is the sole configured provider.
+    const warning = buildCloudTtsWarning({
+      enabled: true,
+      provider: id,
+      fallbackProviders: [],
+      providerStates: [{ id, label: id, configured: true }],
+    });
+    const bannerSaysLocal = warning === null;
+    expect(isLocalProviderId(id)).toBe(bannerSaysLocal);
+  });
+});

--- a/src/tests/unit/voice-output-store.test.ts
+++ b/src/tests/unit/voice-output-store.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { promises as fs } from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * TASK-434 — the selection has to survive a reboot, and a damaged state file
+ * must cost an "unproven" badge rather than the Voice panel. Validation happens
+ * per FIELD, not per envelope: a check entry whose shape is half-right would
+ * otherwise reach a render that reads a sibling it never checked, which is the
+ * failure that took the whole ClawKeep window down on TASK-398.
+ */
+
+let dir: string;
+
+async function store() {
+  return await import("@/lib/voice-output-store");
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-voice-state-"));
+  process.env.CLAWBOX_ROOT = dir;
+  await fs.mkdir(path.join(dir, "data"), { recursive: true });
+  // config-store reads CLAWBOX_ROOT at import time.
+  const { vi } = await import("vitest");
+  vi.resetModules();
+});
+
+afterEach(async () => {
+  delete process.env.CLAWBOX_ROOT;
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+async function writeRaw(contents: string) {
+  await fs.writeFile(path.join(dir, "data", "voice-output.json"), contents);
+}
+
+describe("voice-output-store", () => {
+  it("defaults to Auto when the box has never been asked", async () => {
+    const { readVoiceState } = await store();
+    const state = await readVoiceState();
+    expect(state.choice).toBe("auto");
+    expect(state.lastCheck).toBeNull();
+    expect(state.engineChecks).toEqual({});
+  });
+
+  it("round-trips a selection and a check", async () => {
+    const { readVoiceState, writeVoiceState } = await store();
+    await writeVoiceState({
+      choice: "local",
+      engineChecks: {
+        local: { providerId: "tts-local-cli", engine: "local", ok: true, message: null, latencyMs: 900, at: 7 },
+      },
+      lastCheck: {
+        at: 7, ok: true, servedByProviderId: "tts-local-cli", servedEngine: "local",
+        attempts: [{ providerId: "tts-local-cli", engine: "local", ok: true, message: null, latencyMs: 900 }],
+        message: null,
+      },
+    });
+    const state = await readVoiceState();
+    expect(state.choice).toBe("local");
+    expect(state.engineChecks.local?.ok).toBe(true);
+    expect(state.lastCheck?.servedEngine).toBe("local");
+  });
+
+  it("writes the state file so only the box's own user can read it", async () => {
+    const { writeVoiceState } = await store();
+    await writeVoiceState({ choice: "cloud", engineChecks: {}, lastCheck: null });
+    const stat = await fs.stat(path.join(dir, "data", "voice-output.json"));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+
+  it("falls back to Auto rather than throwing on a truncated file", async () => {
+    await writeRaw('{"choice": "loc');
+    const { readVoiceState } = await store();
+    expect((await readVoiceState()).choice).toBe("auto");
+  });
+
+  it("ignores a choice nobody can honour", async () => {
+    await writeRaw(JSON.stringify({ choice: "fastest" }));
+    const { readVoiceState } = await store();
+    expect((await readVoiceState()).choice).toBe("auto");
+  });
+
+  it("drops a check entry that is missing the fields the panel reads", async () => {
+    await writeRaw(JSON.stringify({
+      choice: "local",
+      engineChecks: { local: { ok: true } },      // no providerId, no timestamp
+      lastCheck: { ok: true },                     // no `at`
+    }));
+    const { readVoiceState } = await store();
+    const state = await readVoiceState();
+    expect(state.choice).toBe("local");
+    expect(state.engineChecks.local).toBeUndefined();
+    expect(state.lastCheck).toBeNull();
+  });
+
+  it("leaves no temp file behind after a write", async () => {
+    const { writeVoiceState } = await store();
+    await writeVoiceState({ choice: "auto", engineChecks: {}, lastCheck: null });
+    const entries = await fs.readdir(path.join(dir, "data"));
+    expect(entries.filter(f => f.includes(".tmp"))).toEqual([]);
+  });
+});

--- a/src/tests/unit/voice-output.test.ts
+++ b/src/tests/unit/voice-output.test.ts
@@ -8,6 +8,7 @@ import {
   configuredTtsProviderId,
   DEFAULT_VOICE_STATE,
   engineForProviderId,
+  engineSignatures,
   failedVoiceCheck,
   isVoiceChoice,
   LOCAL_TTS_PROVIDER_ID,
@@ -42,7 +43,7 @@ const config = (over: Record<string, unknown> = {}) => ({
       },
     },
   },
-  models: { providers: { openai: { apiKey: "claw_84d065b" } } },
+  models: { providers: { openai: { apiKey: "claw_example_not_a_real_token" } } },
   ...over,
 }) as unknown as VoiceConfigView;
 
@@ -112,7 +113,7 @@ describe("a portal token is not a cloud voice key", () => {
 
   it("accepts the same token once a speech endpoint is configured for it", () => {
     const withEndpoint = config({
-      models: { providers: { openai: { apiKey: "claw_84d065b", baseUrl: "https://clawbox.com/api/ai" } } },
+      models: { providers: { openai: { apiKey: "claw_example_not_a_real_token", baseUrl: "https://clawbox.com/api/ai" } } },
     });
     expect(cloudCredentialIsUnusable(withEndpoint, "openai")).toBe(false);
   });
@@ -158,7 +159,7 @@ describe("status", () => {
   it("marks an engine unusable after a real check through it failed, and says so", () => {
     const failed = state({
       engineChecks: {
-        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: false, message: "no voice model", latencyMs: 12, at: 5 },
+        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: false, message: "no voice model", latencyMs: 12, at: 5, signature: engineSignatures(config(), healthyLocal).local },
       },
     });
     const local = buildVoiceOutputStatus(config(), healthyLocal, failed).engines.find(e => e.id === "local")!;
@@ -169,7 +170,7 @@ describe("status", () => {
   it("marks an engine proven once a real check through it succeeded", () => {
     const proven = state({
       engineChecks: {
-        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: true, message: null, latencyMs: 900, at: 5 },
+        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: true, message: null, latencyMs: 900, at: 5, signature: engineSignatures(config(), healthyLocal).local },
       },
     });
     const local = buildVoiceOutputStatus(config(), healthyLocal, proven).engines.find(e => e.id === "local")!;
@@ -265,7 +266,7 @@ describe("reading a real check", () => {
       attempts: [{
         provider: "openai",
         outcome: "error",
-        error: "Incorrect API key provided: claw_84d065b0000000000000000000063c.",
+        error: "Incorrect API key provided: claw_example_not_a_real_token0000000000000000000063c.",
       }],
     }, 100);
     expect(check.ok).toBe(false);
@@ -293,7 +294,7 @@ describe("reading a real check", () => {
         { provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", latencyMs: 900 },
       ],
     }, 42);
-    const next = applyCheck(state(), check);
+    const next = applyCheck(state(), check, engineSignatures(config(), healthyLocal));
     expect(next.engineChecks.cloud?.ok).toBe(false);
     expect(next.engineChecks.local?.ok).toBe(true);
     expect(next.engineChecks.local?.at).toBe(42);
@@ -327,5 +328,74 @@ describe("refusing an explicit pick", () => {
     // say "On this box" rather than keep claiming the cloud voice.
     const broken = [engine({ id: "local" }), engine({ id: "cloud", usable: false })];
     expect(resolvePreferredEngine("cloud", broken)).toBe("local");
+  });
+});
+
+describe("a recorded failure cannot outlive its cause", () => {
+  const cloudKey = (key: string) => config({ models: { providers: { openai: { apiKey: key } } } });
+
+  it("keeps the record of an engine this check did not attempt", () => {
+    // Clearing it instead would let a known-bad engine drift back to
+    // "unproven" every time the other one is checked, and Auto would keep
+    // choosing it.
+    const sigs = engineSignatures(config(), healthyLocal);
+    const withCloudFailure = applyCheck(state(), parseVoiceCheck({
+      ok: false,
+      attempts: [{ provider: "openai", outcome: "error", error: "rejected" }],
+    }, 1), sigs);
+    const thenLocalOnly = applyCheck(withCloudFailure, parseVoiceCheck({
+      ok: true,
+      attempts: [{ provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", latencyMs: 900 }],
+    }, 2), sigs);
+    expect(thenLocalOnly.engineChecks.cloud?.ok).toBe(false);
+    expect(thenLocalOnly.engineChecks.local?.ok).toBe(true);
+  });
+
+  it("stops applying the failure once the thing that caused it changed", () => {
+    // The trap this closes: a failure marks the cloud voice unusable, Auto
+    // stops choosing it, no later check routes through it — so without this
+    // the customer who fixes it by adding a real key is still told it is
+    // unavailable, forever.
+    // A real-looking key, so the recorded failure is the reason shown. A
+    // ClawBox portal token would surface its own, more specific line instead.
+    const broken = cloudKey("sk-rejected-key");
+    const failure = applyCheck(state(), parseVoiceCheck({
+      ok: false,
+      attempts: [{ provider: "openai", outcome: "error", error: "rejected" }],
+    }, 1), engineSignatures(broken, healthyLocal));
+
+    const stillBroken = buildVoiceOutputStatus(broken, healthyLocal, failure);
+    expect(stillBroken.engines.find(e => e.id === "cloud")!.detail).toContain("rejected");
+
+    const fixed = buildVoiceOutputStatus(cloudKey("sk-a-different-key"), healthyLocal, failure);
+    const cloud = fixed.engines.find(e => e.id === "cloud")!;
+    expect(cloud.usable).toBe(true);
+    expect(cloud.detail).toContain("not proven on this box yet");
+  });
+
+  it("does not carry a proven badge across a swapped credential", () => {
+    const first = cloudKey("sk-first-key");
+    const proven = applyCheck(state(), parseVoiceCheck({
+      ok: true,
+      attempts: [{ provider: "openai", outcome: "success", latencyMs: 800 }],
+    }, 1), engineSignatures(first, healthyLocal));
+    expect(buildVoiceOutputStatus(first, healthyLocal, proven).engines.find(e => e.id === "cloud")!.proven).toBe(true);
+    expect(buildVoiceOutputStatus(cloudKey("sk-second-key"), healthyLocal, proven).engines.find(e => e.id === "cloud")!.proven).toBe(false);
+  });
+
+  it("records the shape of a credential, never the credential", () => {
+    const sig = engineSignatures(cloudKey("sk-live-super-secret"), healthyLocal);
+    expect(sig.cloud).not.toContain("super-secret");
+    expect(sig.cloud).toContain("sk");
+  });
+
+  it("re-opens the local voice once a missing voice is installed", () => {
+    const bare = { ...healthyLocal, engineNames: [] as string[] };
+    const failure = applyCheck(state(), parseVoiceCheck({
+      ok: false,
+      attempts: [{ provider: LOCAL_TTS_PROVIDER_ID, outcome: "error", error: "no voice model" }],
+    }, 1), engineSignatures(config(), bare));
+    expect(buildVoiceOutputStatus(config(), bare, failure).engines.find(e => e.id === "local")!.usable).toBe(false);
+    expect(buildVoiceOutputStatus(config(), healthyLocal, failure).engines.find(e => e.id === "local")!.usable).toBe(true);
   });
 });

--- a/src/tests/unit/voice-output.test.ts
+++ b/src/tests/unit/voice-output.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCheck,
+  buildVoiceDisclosure,
+  buildVoiceOutputStatus,
+  cloudCredentialIsUnusable,
+  cloudProviderIdFor,
+  configuredTtsProviderId,
+  DEFAULT_VOICE_STATE,
+  engineForProviderId,
+  failedVoiceCheck,
+  isVoiceChoice,
+  LOCAL_TTS_PROVIDER_ID,
+  localCommandPath,
+  parseVoiceCheck,
+  providerIdForChoice,
+  resolvePreferredEngine,
+  selectionError,
+  type LocalVoiceProbe,
+  type VoiceConfigView,
+  type VoiceEngine,
+  type VoiceOutputState,
+} from "@/lib/voice-output";
+
+/**
+ * TASK-434 — the voice selector's rules.
+ *
+ * Every assertion here is a fact read off a real box on 2026-08-22, not a
+ * preference: a ClawBox carries a `claw_` portal token in `models.providers.
+ * openai`, and a speech call with it comes back 401 because ClawBox AI has no
+ * speech endpoint to point it at. So "present in the config" must not resolve
+ * to "the box can speak with it" — that is the whole difference between this
+ * selector and a list of options.
+ */
+
+const config = (over: Record<string, unknown> = {}) => ({
+  messages: {
+    tts: {
+      provider: LOCAL_TTS_PROVIDER_ID,
+      providers: {
+        [LOCAL_TTS_PROVIDER_ID]: { command: "/home/clawbox/clawbox/scripts/openclaw/clawbox-tts.sh" },
+      },
+    },
+  },
+  models: { providers: { openai: { apiKey: "claw_84d065b" } } },
+  ...over,
+}) as unknown as VoiceConfigView;
+
+const healthyLocal: LocalVoiceProbe = {
+  providerConfigured: true,
+  commandPresent: true,
+  engineInstalled: true,
+  engineNames: ["Piper"],
+};
+
+const state = (over: Partial<VoiceOutputState> = {}): VoiceOutputState => ({
+  ...DEFAULT_VOICE_STATE,
+  engineChecks: {},
+  ...over,
+});
+
+const engine = (over: Partial<VoiceEngine> & Pick<VoiceEngine, "id">): VoiceEngine => ({
+  providerId: over.id === "local" ? LOCAL_TTS_PROVIDER_ID : "openai",
+  label: over.id === "local" ? "On this box" : "ClawBox cloud",
+  configured: true,
+  proven: false,
+  usable: true,
+  detail: "",
+  ...over,
+});
+
+describe("engine identity", () => {
+  it("calls the shipped local provider local, and an unknown provider cloud", () => {
+    expect(engineForProviderId(LOCAL_TTS_PROVIDER_ID)).toBe("local");
+    expect(engineForProviderId("kokoro-server")).toBe("local");
+    expect(engineForProviderId("openai")).toBe("cloud");
+    expect(engineForProviderId("elevenlabs")).toBe("cloud");
+    expect(engineForProviderId(null)).toBeNull();
+  });
+
+  it("reads the configured primary and the local command straight from the config", () => {
+    expect(configuredTtsProviderId(config())).toBe(LOCAL_TTS_PROVIDER_ID);
+    expect(localCommandPath(config())).toContain("clawbox-tts.sh");
+    expect(configuredTtsProviderId({} as VoiceConfigView)).toBeNull();
+  });
+
+  it("prefers an explicitly configured cloud speech provider over the shipped default", () => {
+    expect(cloudProviderIdFor(config())).toBe("openai");
+    const custom = config({
+      messages: {
+        tts: {
+          provider: LOCAL_TTS_PROVIDER_ID,
+          providers: {
+            [LOCAL_TTS_PROVIDER_ID]: { command: "/x/clawbox-tts.sh" },
+            elevenlabs: { apiKey: "el-key", baseUrl: "https://api.elevenlabs.io" },
+          },
+        },
+      },
+    });
+    expect(cloudProviderIdFor(custom)).toBe("elevenlabs");
+  });
+
+  it("reports no cloud engine at all when nothing is configured for one", () => {
+    expect(cloudProviderIdFor({ models: { providers: {} } } as VoiceConfigView)).toBeNull();
+  });
+});
+
+describe("a portal token is not a cloud voice key", () => {
+  it("rejects a claw_ token with no endpoint to send it to", () => {
+    expect(cloudCredentialIsUnusable(config(), "openai")).toBe(true);
+  });
+
+  it("accepts the same token once a speech endpoint is configured for it", () => {
+    const withEndpoint = config({
+      models: { providers: { openai: { apiKey: "claw_84d065b", baseUrl: "https://clawbox.com/api/ai" } } },
+    });
+    expect(cloudCredentialIsUnusable(withEndpoint, "openai")).toBe(false);
+  });
+
+  it("accepts a real provider key", () => {
+    const real = config({ models: { providers: { openai: { apiKey: "sk-live-abc" } } } });
+    expect(cloudCredentialIsUnusable(real, "openai")).toBe(false);
+  });
+});
+
+describe("status", () => {
+  it("shows the cloud voice as unavailable on a stock box, with a reason a customer can act on", () => {
+    const status = buildVoiceOutputStatus(config(), healthyLocal, state());
+    const cloud = status.engines.find(e => e.id === "cloud")!;
+    expect(cloud.usable).toBe(false);
+    expect(cloud.detail).toContain("does not serve the voice yet");
+    expect(cloud.detail).not.toContain("claw_");
+  });
+
+  it("resolves Auto to the on-device voice when the cloud one cannot be used", () => {
+    const status = buildVoiceOutputStatus(config(), healthyLocal, state());
+    expect(status.choice).toBe("auto");
+    expect(status.preferredEngine).toBe("local");
+    expect(status.drifted).toBe(false);
+  });
+
+  it("resolves Auto to the cloud voice when the box really has one", () => {
+    const real = config({ models: { providers: { openai: { apiKey: "sk-live-abc" } } } });
+    const status = buildVoiceOutputStatus(real, healthyLocal, state());
+    expect(status.preferredEngine).toBe("cloud");
+    // The box is still configured for the local voice, so Auto has somewhere to move.
+    expect(status.drifted).toBe(true);
+  });
+
+  it("marks the local voice unusable when no on-device engine is installed", () => {
+    const status = buildVoiceOutputStatus(config(), { ...healthyLocal, engineInstalled: false }, state());
+    const local = status.engines.find(e => e.id === "local")!;
+    expect(local.usable).toBe(false);
+    expect(local.detail).toContain("cannot speak by itself");
+    expect(status.preferredEngine).toBeNull();
+  });
+
+  it("marks an engine unusable after a real check through it failed, and says so", () => {
+    const failed = state({
+      engineChecks: {
+        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: false, message: "no voice model", latencyMs: 12, at: 5 },
+      },
+    });
+    const local = buildVoiceOutputStatus(config(), healthyLocal, failed).engines.find(e => e.id === "local")!;
+    expect(local.usable).toBe(false);
+    expect(local.detail).toContain("no voice model");
+  });
+
+  it("marks an engine proven once a real check through it succeeded", () => {
+    const proven = state({
+      engineChecks: {
+        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: true, message: null, latencyMs: 900, at: 5 },
+      },
+    });
+    const local = buildVoiceOutputStatus(config(), healthyLocal, proven).engines.find(e => e.id === "local")!;
+    expect(local.proven).toBe(true);
+    expect(local.usable).toBe(true);
+  });
+});
+
+describe("choice resolution", () => {
+  const both = [engine({ id: "local" }), engine({ id: "cloud" })];
+
+  it("honours an explicit pick", () => {
+    expect(resolvePreferredEngine("local", both)).toBe("local");
+    expect(resolvePreferredEngine("cloud", both)).toBe("cloud");
+  });
+
+  it("follows the standing cloud-first recommendation for Auto", () => {
+    expect(resolvePreferredEngine("auto", both)).toBe("cloud");
+  });
+
+  it("steps aside rather than pinning an engine the box cannot use", () => {
+    const noCloud = [engine({ id: "local" }), engine({ id: "cloud", usable: false })];
+    expect(resolvePreferredEngine("auto", noCloud)).toBe("local");
+    expect(resolvePreferredEngine("cloud", noCloud)).toBe("local");
+  });
+
+  it("resolves to nothing when neither engine can speak", () => {
+    const none = [engine({ id: "local", usable: false }), engine({ id: "cloud", usable: false })];
+    expect(resolvePreferredEngine("auto", none)).toBeNull();
+    expect(providerIdForChoice("local", none)).toBeNull();
+  });
+
+  it("maps a choice to the provider id that gets written", () => {
+    expect(providerIdForChoice("local", both)).toBe(LOCAL_TTS_PROVIDER_ID);
+    expect(providerIdForChoice("cloud", both)).toBe("openai");
+  });
+
+  it("accepts only the three real choices", () => {
+    expect(isVoiceChoice("auto")).toBe(true);
+    expect(isVoiceChoice("cheapest")).toBe(false);
+    expect(isVoiceChoice(null)).toBe(false);
+  });
+});
+
+describe("the privacy notice is the chat one, not a second one", () => {
+  it("warns plainly when the cloud voice is the primary", () => {
+    const engines = [engine({ id: "local" }), engine({ id: "cloud" })];
+    expect(buildVoiceDisclosure("openai", engines)).toContain("Voice uses ClawBox AI cloud TTS");
+  });
+
+  it("warns conditionally when the cloud voice is only the fallback", () => {
+    const engines = [engine({ id: "local" }), engine({ id: "cloud" })];
+    const notice = buildVoiceDisclosure(LOCAL_TTS_PROVIDER_ID, engines);
+    expect(notice).toContain("may use ClawBox AI cloud TTS");
+  });
+
+  it("says nothing when no cloud voice can be reached at all", () => {
+    const engines = [engine({ id: "local" }), engine({ id: "cloud", usable: false })];
+    expect(buildVoiceDisclosure(LOCAL_TTS_PROVIDER_ID, engines)).toBeNull();
+  });
+});
+
+describe("reading a real check", () => {
+  it("records which provider actually spoke", () => {
+    const check = parseVoiceCheck({
+      ok: true,
+      provider: LOCAL_TTS_PROVIDER_ID,
+      attempts: [{ provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", reasonCode: "success", latencyMs: 14893 }],
+    }, 100);
+    expect(check.ok).toBe(true);
+    expect(check.servedEngine).toBe("local");
+    expect(check.attempts[0].latencyMs).toBe(14893);
+  });
+
+  it("keeps the failed cloud attempt AND the local one that spoke after it", () => {
+    const check = parseVoiceCheck({
+      ok: true,
+      provider: LOCAL_TTS_PROVIDER_ID,
+      attempts: [
+        { provider: "openai", outcome: "error", error: "OpenAI TTS API error (401)" },
+        { provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", latencyMs: 1200 },
+      ],
+    }, 100);
+    expect(check.ok).toBe(true);
+    expect(check.servedEngine).toBe("local");
+    expect(check.attempts.map(a => a.engine)).toEqual(["cloud", "local"]);
+    expect(check.attempts[0].ok).toBe(false);
+  });
+
+  it("never lets a credential out of a provider's error text", () => {
+    const check = parseVoiceCheck({
+      ok: false,
+      attempts: [{
+        provider: "openai",
+        outcome: "error",
+        error: "Incorrect API key provided: claw_84d065b0000000000000000000063c.",
+      }],
+    }, 100);
+    expect(check.ok).toBe(false);
+    expect(check.attempts[0].message).toBeNull();
+    expect(JSON.stringify(check)).not.toContain("claw_");
+  });
+
+  it("is not a success just because the CLI exited ok with nothing spoken", () => {
+    expect(parseVoiceCheck({ ok: true, attempts: [] }, 100).ok).toBe(false);
+    expect(parseVoiceCheck("not json at all", 100).ok).toBe(false);
+  });
+
+  it("records a run that never reached a provider", () => {
+    const check = failedVoiceCheck("The voice check took too long and was stopped.", 7);
+    expect(check.ok).toBe(false);
+    expect(check.message).toContain("took too long");
+    expect(check.attempts).toEqual([]);
+  });
+
+  it("folds every attempt into the per-engine memory the panel reads", () => {
+    const check = parseVoiceCheck({
+      ok: true,
+      attempts: [
+        { provider: "openai", outcome: "error", error: "rejected" },
+        { provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", latencyMs: 900 },
+      ],
+    }, 42);
+    const next = applyCheck(state(), check);
+    expect(next.engineChecks.cloud?.ok).toBe(false);
+    expect(next.engineChecks.local?.ok).toBe(true);
+    expect(next.engineChecks.local?.at).toBe(42);
+    expect(next.lastCheck).toBe(check);
+  });
+});
+
+describe("refusing an explicit pick", () => {
+  const both = [engine({ id: "local" }), engine({ id: "cloud" })];
+
+  it("allows either engine when both work", () => {
+    expect(selectionError("local", both)).toBeNull();
+    expect(selectionError("cloud", both)).toBeNull();
+    expect(selectionError("auto", both)).toBeNull();
+  });
+
+  it("refuses a named engine the box cannot use instead of substituting the other", () => {
+    const noCloud = [engine({ id: "local" }), engine({ id: "cloud", usable: false })];
+    expect(selectionError("cloud", noCloud)).toContain("not available");
+    // Auto is still fine — resolving to whatever works is what Auto means.
+    expect(selectionError("auto", noCloud)).toBeNull();
+  });
+
+  it("refuses Auto only when the box has no voice at all", () => {
+    const none = [engine({ id: "local", usable: false }), engine({ id: "cloud", usable: false })];
+    expect(selectionError("auto", none)).toContain("no voice");
+  });
+
+  it("still reports what will actually speak after a pick that later broke", () => {
+    // Chosen cloud, cloud failed, so the gateway falls back — the panel must
+    // say "On this box" rather than keep claiming the cloud voice.
+    const broken = [engine({ id: "local" }), engine({ id: "cloud", usable: false })];
+    expect(resolvePreferredEngine("cloud", broken)).toBe("local");
+  });
+});

--- a/src/tests/unit/voice-output.test.ts
+++ b/src/tests/unit/voice-output.test.ts
@@ -8,13 +8,13 @@ import {
   configuredTtsProviderId,
   DEFAULT_VOICE_STATE,
   engineForProviderId,
-  engineSignatures,
   failedVoiceCheck,
   isVoiceChoice,
   LOCAL_TTS_PROVIDER_ID,
   localCommandPath,
   parseVoiceCheck,
   providerIdForChoice,
+  forgetEngineCheck,
   resolvePreferredEngine,
   selectionError,
   type LocalVoiceProbe,
@@ -159,7 +159,7 @@ describe("status", () => {
   it("marks an engine unusable after a real check through it failed, and says so", () => {
     const failed = state({
       engineChecks: {
-        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: false, message: "no voice model", latencyMs: 12, at: 5, signature: engineSignatures(config(), healthyLocal).local },
+        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: false, message: "no voice model", latencyMs: 12, at: 5 },
       },
     });
     const local = buildVoiceOutputStatus(config(), healthyLocal, failed).engines.find(e => e.id === "local")!;
@@ -170,7 +170,7 @@ describe("status", () => {
   it("marks an engine proven once a real check through it succeeded", () => {
     const proven = state({
       engineChecks: {
-        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: true, message: null, latencyMs: 900, at: 5, signature: engineSignatures(config(), healthyLocal).local },
+        local: { providerId: LOCAL_TTS_PROVIDER_ID, engine: "local", ok: true, message: null, latencyMs: 900, at: 5 },
       },
     });
     const local = buildVoiceOutputStatus(config(), healthyLocal, proven).engines.find(e => e.id === "local")!;
@@ -198,7 +198,10 @@ describe("choice resolution", () => {
   });
 
   it("resolves to nothing when neither engine can speak", () => {
-    const none = [engine({ id: "local", usable: false }), engine({ id: "cloud", usable: false })];
+    const none = [
+      engine({ id: "local", usable: false, configured: false }),
+      engine({ id: "cloud", usable: false, configured: false }),
+    ];
     expect(resolvePreferredEngine("auto", none)).toBeNull();
     expect(providerIdForChoice("local", none)).toBeNull();
   });
@@ -294,7 +297,7 @@ describe("reading a real check", () => {
         { provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", latencyMs: 900 },
       ],
     }, 42);
-    const next = applyCheck(state(), check, engineSignatures(config(), healthyLocal));
+    const next = applyCheck(state(), check);
     expect(next.engineChecks.cloud?.ok).toBe(false);
     expect(next.engineChecks.local?.ok).toBe(true);
     expect(next.engineChecks.local?.at).toBe(42);
@@ -311,15 +314,18 @@ describe("refusing an explicit pick", () => {
     expect(selectionError("auto", both)).toBeNull();
   });
 
-  it("refuses a named engine the box cannot use instead of substituting the other", () => {
-    const noCloud = [engine({ id: "local" }), engine({ id: "cloud", usable: false })];
+  it("refuses a named engine the box does not have instead of substituting the other", () => {
+    const noCloud = [engine({ id: "local" }), engine({ id: "cloud", usable: false, configured: false })];
     expect(selectionError("cloud", noCloud)).toContain("not available");
     // Auto is still fine — resolving to whatever works is what Auto means.
     expect(selectionError("auto", noCloud)).toBeNull();
   });
 
   it("refuses Auto only when the box has no voice at all", () => {
-    const none = [engine({ id: "local", usable: false }), engine({ id: "cloud", usable: false })];
+    const none = [
+      engine({ id: "local", usable: false, configured: false }),
+      engine({ id: "cloud", usable: false, configured: false }),
+    ];
     expect(selectionError("auto", none)).toContain("no voice");
   });
 
@@ -331,71 +337,61 @@ describe("refusing an explicit pick", () => {
   });
 });
 
-describe("a recorded failure cannot outlive its cause", () => {
+describe("a failure must not lock the customer out of retrying", () => {
   const cloudKey = (key: string) => config({ models: { providers: { openai: { apiKey: key } } } });
+  const failedCloud = () => applyCheck(state(), parseVoiceCheck({
+    ok: false,
+    attempts: [{ provider: "openai", outcome: "error", error: "rejected" }],
+  }, 1));
 
   it("keeps the record of an engine this check did not attempt", () => {
-    // Clearing it instead would let a known-bad engine drift back to
-    // "unproven" every time the other one is checked, and Auto would keep
-    // choosing it.
-    const sigs = engineSignatures(config(), healthyLocal);
-    const withCloudFailure = applyCheck(state(), parseVoiceCheck({
-      ok: false,
-      attempts: [{ provider: "openai", outcome: "error", error: "rejected" }],
-    }, 1), sigs);
-    const thenLocalOnly = applyCheck(withCloudFailure, parseVoiceCheck({
+    // Clearing it here would let a known-bad engine read as merely unproven
+    // every time the other one is checked, and Auto would keep choosing it.
+    const thenLocalOnly = applyCheck(failedCloud(), parseVoiceCheck({
       ok: true,
       attempts: [{ provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", latencyMs: 900 }],
-    }, 2), sigs);
+    }, 2));
     expect(thenLocalOnly.engineChecks.cloud?.ok).toBe(false);
     expect(thenLocalOnly.engineChecks.local?.ok).toBe(true);
   });
 
-  it("stops applying the failure once the thing that caused it changed", () => {
-    // The trap this closes: a failure marks the cloud voice unusable, Auto
-    // stops choosing it, no later check routes through it — so without this
-    // the customer who fixes it by adding a real key is still told it is
-    // unavailable, forever.
-    // A real-looking key, so the recorded failure is the reason shown. A
-    // ClawBox portal token would surface its own, more specific line instead.
-    const broken = cloudKey("sk-rejected-key");
-    const failure = applyCheck(state(), parseVoiceCheck({
-      ok: false,
-      attempts: [{ provider: "openai", outcome: "error", error: "rejected" }],
-    }, 1), engineSignatures(broken, healthyLocal));
+  it("stops Auto choosing a failed engine but still lets the customer ask for it", () => {
+    // The trap this closes: if a failure also removed the ability to pick the
+    // engine, it would be permanent by construction — Auto stops choosing it,
+    // so no later check routes through it, so nothing can ever clear it.
+    const engines = buildVoiceOutputStatus(cloudKey("sk-live-abc"), healthyLocal, failedCloud()).engines;
+    expect(resolvePreferredEngine("auto", engines)).toBe("local");
+    expect(selectionError("cloud", engines)).toBeNull();
+    expect(providerIdForChoice("cloud", engines)).toBe("openai");
+  });
 
-    const stillBroken = buildVoiceOutputStatus(broken, healthyLocal, failure);
-    expect(stillBroken.engines.find(e => e.id === "cloud")!.detail).toContain("rejected");
+  it("still refuses an engine the box genuinely does not have", () => {
+    // A stock ClawBox: the portal token is not a cloud voice key, so there is
+    // nothing to retry and the refusal stands.
+    const engines = buildVoiceOutputStatus(config(), healthyLocal, state()).engines;
+    expect(selectionError("cloud", engines)).toContain("not available");
+    expect(providerIdForChoice("cloud", engines)).toBeNull();
+  });
 
-    const fixed = buildVoiceOutputStatus(cloudKey("sk-a-different-key"), healthyLocal, failure);
-    const cloud = fixed.engines.find(e => e.id === "cloud")!;
+  it("forgets what it observed about an engine the customer picks again", () => {
+    const retried = forgetEngineCheck(failedCloud(), "cloud");
+    expect(retried.engineChecks.cloud).toBeUndefined();
+    const cloud = buildVoiceOutputStatus(cloudKey("sk-live-abc"), healthyLocal, retried)
+      .engines.find(e => e.id === "cloud")!;
     expect(cloud.usable).toBe(true);
     expect(cloud.detail).toContain("not proven on this box yet");
   });
 
-  it("does not carry a proven badge across a swapped credential", () => {
-    const first = cloudKey("sk-first-key");
-    const proven = applyCheck(state(), parseVoiceCheck({
+  it("leaves the other engine's record alone when one is retried", () => {
+    const both = applyCheck(state(), parseVoiceCheck({
       ok: true,
-      attempts: [{ provider: "openai", outcome: "success", latencyMs: 800 }],
-    }, 1), engineSignatures(first, healthyLocal));
-    expect(buildVoiceOutputStatus(first, healthyLocal, proven).engines.find(e => e.id === "cloud")!.proven).toBe(true);
-    expect(buildVoiceOutputStatus(cloudKey("sk-second-key"), healthyLocal, proven).engines.find(e => e.id === "cloud")!.proven).toBe(false);
-  });
-
-  it("records the shape of a credential, never the credential", () => {
-    const sig = engineSignatures(cloudKey("sk-live-super-secret"), healthyLocal);
-    expect(sig.cloud).not.toContain("super-secret");
-    expect(sig.cloud).toContain("sk");
-  });
-
-  it("re-opens the local voice once a missing voice is installed", () => {
-    const bare = { ...healthyLocal, engineNames: [] as string[] };
-    const failure = applyCheck(state(), parseVoiceCheck({
-      ok: false,
-      attempts: [{ provider: LOCAL_TTS_PROVIDER_ID, outcome: "error", error: "no voice model" }],
-    }, 1), engineSignatures(config(), bare));
-    expect(buildVoiceOutputStatus(config(), bare, failure).engines.find(e => e.id === "local")!.usable).toBe(false);
-    expect(buildVoiceOutputStatus(config(), healthyLocal, failure).engines.find(e => e.id === "local")!.usable).toBe(true);
+      attempts: [
+        { provider: "openai", outcome: "error", error: "rejected" },
+        { provider: LOCAL_TTS_PROVIDER_ID, outcome: "success", latencyMs: 900 },
+      ],
+    }, 3));
+    const retried = forgetEngineCheck(both, "cloud");
+    expect(retried.engineChecks.cloud).toBeUndefined();
+    expect(retried.engineChecks.local?.ok).toBe(true);
   });
 });

--- a/src/tests/unit/voice-output.test.ts
+++ b/src/tests/unit/voice-output.test.ts
@@ -230,8 +230,8 @@ describe("the privacy notice is the chat one, not a second one", () => {
     expect(notice).toContain("may use ClawBox AI cloud TTS");
   });
 
-  it("says nothing when no cloud voice can be reached at all", () => {
-    const engines = [engine({ id: "local" }), engine({ id: "cloud", usable: false })];
+  it("says nothing when the box has no cloud voice at all", () => {
+    const engines = [engine({ id: "local" }), engine({ id: "cloud", usable: false, configured: false })];
     expect(buildVoiceDisclosure(LOCAL_TTS_PROVIDER_ID, engines)).toBeNull();
   });
 });
@@ -393,5 +393,32 @@ describe("a failure must not lock the customer out of retrying", () => {
     const retried = forgetEngineCheck(both, "cloud");
     expect(retried.engineChecks.cloud).toBeUndefined();
     expect(retried.engineChecks.local?.ok).toBe(true);
+  });
+});
+
+describe("the privacy notice follows what the box will attempt", () => {
+  it("still warns when the cloud primary is failing, because the text is still sent to it", () => {
+    // Found on a real box: the gateway posts the text to the configured primary,
+    // that call fails, and only then does the on-device voice speak. Dropping
+    // the notice because the engine is "not usable" would tell the customer
+    // nothing left the box while every reply was still being sent to the cloud.
+    const engines = [
+      engine({ id: "local" }),
+      engine({ id: "cloud", usable: false, configured: true }),
+    ];
+    expect(buildVoiceDisclosure("openai", engines)).toContain("Voice uses ClawBox AI cloud TTS");
+  });
+
+  it("warns conditionally when a failing cloud engine is only the fallback", () => {
+    const engines = [
+      engine({ id: "local" }),
+      engine({ id: "cloud", usable: false, configured: true }),
+    ];
+    expect(buildVoiceDisclosure(LOCAL_TTS_PROVIDER_ID, engines)).toContain("may use ClawBox AI cloud TTS");
+  });
+
+  it("says nothing when the box does not have a cloud voice at all", () => {
+    const engines = [engine({ id: "local" }), engine({ id: "cloud", usable: false, configured: false })];
+    expect(buildVoiceDisclosure(LOCAL_TTS_PROVIDER_ID, engines)).toBeNull();
   });
 });


### PR DESCRIPTION
Closes the TTS half of TASK-434, which Yanko approved on 2026-08-22 with the scope cut to TTS only.

## Why only TTS

Of the five capabilities in the original request, exactly one has both an on-device and a cloud implementation on a ClawBox today. STT's local half is installed nowhere (`whisper-server.service` is absent, there is no `messages.stt` block), vision and image generation have no local engine at all, and embeddings already have their own controls in ClawKeep. Building all five as specified would have shipped four permanently unselectable "Local" options.

## Two facts about the box, read before writing any code

**A configured cloud voice is not a working one.** `openclaw capability tts convert --model openai/gpt-4o-mini-tts` on .177 answers HTTP 401 — the `openai` provider carries the ClawBox AI portal token and has no provider-level baseUrl, so the call goes to api.openai.com with a `claw_` key. And ClawBox AI has no speech endpoint: clawbox-website serves `/api/ai/audio/transcriptions` and `/api/ai/images/generations`, and its catch-all forwards everything else to the **chat** handler, so even pointing the provider at the proxy would return a chat body instead of audio.

So the cloud option reads *"ClawBox AI does not serve the voice yet, so this box has no cloud voice to call"* on a stock box, and the route **refuses** to select it (409) rather than quietly writing the other engine. Scope line 3 of the task says selecting Local and silently getting cloud is the failure mode to avoid; the mirror is just as bad.

**The gateway already owns the fallback.** `messages.tts` has no `fallbackProviders` key — `resolveTtsProviderOrder()` builds the chain from the primary plus every other configured speech provider. This sets the primary honestly and reports what actually served, rather than inventing a second chain that can disagree with the one that runs.

## What ships

- **Settings → Voice**: Auto / On this box / ClawBox cloud, persisted across reboot.
- **Availability is measured**, in the spirit of the Local Models tab: an engine is usable when the box really has what it needs *and* the last real attempt through it did not fail.
- **Chosen vs actually-used**, as a fact. *Check voice* synthesises a real phrase through the real chain and records every provider the CLI tried, in order — so a cloud primary that fails and an on-device voice that speaks after it are both on screen, with latencies.
- **Auto self-heals**: it follows the standing cloud-first decision but steps aside to whatever can actually speak, so a box whose cloud voice breaks keeps talking instead of going mute.
- **The privacy notice is the TASK-409 one** (PR #401), built by the same function the chat banner uses. A contract test asserts the two surfaces agree about which engines count as local; another asserts the provider id written here is the one `install.sh` selects.

## Safety and cost

- `/setup-api/tts` is in `PRE_AUTH_SENSITIVE_PREFIXES` — it rewrites `messages.tts.provider` and spawns the openclaw CLI, and during the setup window the device broadcasts an open AP. Regression case added to the middleware table.
- **GET is filesystem-only.** The openclaw CLI costs 8-12 s of cold start on an Orin; a panel that pays that on open reads as a broken box. The CLI runs only for the explicit check.
- Provider error text goes through `sanitizeErrorMessage` — the real 401 quotes the `claw_` token, and it is dropped.
- The check's audio is deleted in a `finally`.

## Tests

62 new across five files, plus one e2e leg through the real Settings window and a middleware regression case. Local gate **263 files / 3550 tests green**, `bun run build` green, changed-file ESLint 0 errors, `tsc` unchanged at 15 pre-existing errors.

Proven to bite by three targeted mutations, one failure each: accepting a `claw_` token as a cloud key, removing the route's refusal guard, and dropping the panel's per-entry payload validation.

## Not in this PR

Acceptance line 2 of the task — *"picking Local and requesting an unsupported language produces working output via cloud"* — names Kokoro's language table as the trigger and cannot be exercised end-to-end while no cloud speech endpoint exists. The other half of the same rule (local missing or unhealthy → the other engine) is exercisable and is what the hardware proof covers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Voice settings panel with automatic, local, and cloud voice-output options.
  - Displays active voice, availability, privacy disclosures, provider details, warnings, and recent voice-check results.
  - Supports voice selection, validation, and real playback checks.
  - Automatically falls back to available local voices when appropriate.
  - Persists voice preferences and check results across sessions.
- **Security**
  - Protected voice setup actions with authentication.
- **Tests**
  - Added comprehensive coverage for voice selection, fallback behavior, availability, privacy messaging, persistence, and playback checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->