### PR TITLE
The plan card says what you are paying for, not what a browser remembered (TASK-468)

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -33,7 +33,8 @@ import { cachedEdition, fetchHarness } from "@/lib/client-harness";
 // the Hermes provider panel renders the SAME experience instead of a lookalike.
 import {
   CLAWAI_TIER_STORAGE_KEY,
-  normalizeClawaiUiTier,
+  readStoredUiTier,
+  resolveUiTier,
   type ClawaiTier,
 } from "@/lib/clawbox-ai-tiers";
 
@@ -592,11 +593,17 @@ export default function AIModelsStep({
     }
   }, [activeCatalog, currentModel, modelTouched, selectedProvider]);
   const [configuringState, setConfiguringState] = useState<ConfiguringState | null>(null);
-  const [clawaiTier, setClawaiTier] = useState<ClawaiTier>(() => {
-    if (typeof window === "undefined") return "flash";
-    return normalizeClawaiUiTier(window.localStorage?.getItem(CLAWAI_TIER_STORAGE_KEY)) ?? "flash";
-  });
+  // Seeded from local storage because that is all this panel can know before it
+  // has asked the box anything; the effect below reconciles it against the
+  // portal-confirmed account as soon as an answer arrives. Local storage alone
+  // is NOT the answer for a paired box — see TASK-468.
+  const [clawaiTier, setClawaiTier] = useState<ClawaiTier>(() => readStoredUiTier());
+  // Set the moment the user touches the plan picker. The reconcile below must
+  // never yank the card out from under a pick that already happened — on the
+  // wizard this picker is someone CHOOSING a plan they do not have yet.
+  const userPickedTierRef = useRef(false);
   const persistClawaiTier = useCallback((tier: ClawaiTier) => {
+    userPickedTierRef.current = true;
     setClawaiTier(tier);
     if (typeof window !== "undefined") {
       try {
@@ -665,6 +672,43 @@ export default function AIModelsStep({
     setSaving(false);
     setStatus((current) => (current?.type === "error" ? null : current));
   }, [normalizedCurrentProvider, stopClawaiLogin, resetClawaiLogin]);
+
+  // ── Make the plan card agree with the account ─────────────────────────────
+  //
+  // This panel used to seed the plan purely from local storage and never ask
+  // the box anything, so on a browser that had never stored a tier — every
+  // customer's first visit, and every visit after clearing site data — it fell
+  // back to the hardcoded "flash" and rendered "Pro plan · €9/month". On a Max
+  // box that sat directly under a MAX badge in the same panel, contradicting
+  // it, and the same state is what `payload.clawaiTier` writes on save, so a
+  // save from that screen downgraded a €49 account off the frontier weights
+  // without saying so. (TASK-468.)
+  //
+  // `resolveUiTier` is the rule the Hermes panel has always used; it now lives
+  // in the shared tier module so these two panels cannot drift again. It reads
+  // the account only when the box is actually paired, so the wizard's
+  // choose-a-plan flow on an unpaired box is untouched.
+  useEffect(() => {
+    if (userPickedTierRef.current) return;
+    const controller = new AbortController();
+    fetch("/setup-api/ai-models/status", { cache: "no-store", signal: controller.signal })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data || typeof data !== "object") return;
+        // Only a live portal answer may move the card. `tierSource: "picker"`
+        // means the status route never reached the portal this cycle, and the
+        // stored device tier cannot tell Free from "we never asked" — guessing
+        // from it is how a Free user got shown a paid plan in the first place.
+        if (data.clawaiConfigured !== true || data.tierSource !== "portal") return;
+        if (userPickedTierRef.current) return;
+        setClawaiTier(resolveUiTier(true, data.clawaiAccountTier ?? null));
+      })
+      .catch(() => {
+        // Offline or mid-restart: keep the stored intent rather than blanking
+        // or guessing at someone's subscription.
+      });
+    return () => controller.abort();
+  }, []);
 
   useEffect(() => {
     fetch("/setup-api/ai-models/oauth/providers")

--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -16,8 +16,7 @@ import {
 import {
   CLAWAI_TIER_INFO,
   CLAWAI_TIER_STORAGE_KEY,
-  deviceTierToUiTier,
-  normalizeClawaiUiTier,
+  resolveUiTier,
   uiTierToDeviceTier,
   type ClawaiTier,
 } from "@/lib/clawbox-ai-tiers";
@@ -90,32 +89,6 @@ interface Props {
 // "connected" state to register and short enough not to feel stalled. This panel
 // is the SAME step on a Hermes device, so it advances the same way.
 const AUTO_ADVANCE_DELAY_MS = 900;
-
-function readStoredUiTier(): ClawaiTier {
-  if (typeof window === "undefined") return "flash";
-  try {
-    return normalizeClawaiUiTier(window.localStorage?.getItem(CLAWAI_TIER_STORAGE_KEY)) ?? "flash";
-  } catch {
-    return "flash";
-  }
-}
-
-/**
- * Which PLAN card to show for a paired device.
- *
- * The device tier cannot represent Free: `uiTierToDeviceTier` maps both "free"
- * and "flash" to the device's "flash" (Free and Pro run the same DeepSeek V4
- * Flash weights), so a stored "flash" means Free OR Pro. Trusting it blindly
- * showed "Pro plan — €9/month" to a Free user, and made this panel disagree
- * with the OpenClaw wizard, which reads the stored UI intent. "pro" (Max) is
- * unambiguous and always wins over local storage.
- */
-function resolveUiTier(hasToken: boolean, tierStored: string | null): ClawaiTier {
-  if (!hasToken) return readStoredUiTier();
-  const device = deviceTierToUiTier(tierStored);
-  if (device !== "flash") return device;
-  return readStoredUiTier() === "free" ? "free" : "flash";
-}
 
 export default function HermesProviderConfig({ embedded, onNext, testId }: Props) {
   const uid = useId();

--- a/src/lib/clawbox-ai-tiers.ts
+++ b/src/lib/clawbox-ai-tiers.ts
@@ -126,3 +126,44 @@ export function uiTierToDeviceTier(tier: ClawaiTier): ClawboxAiTier {
 export function deviceTierToUiTier(stored: string | null | undefined): ClawaiTier {
   return stored === "pro" ? "pro" : stored === "flash" ? "flash" : "free";
 }
+
+/**
+ * The UI tier the customer last chose, or the safe default.
+ *
+ * "flash" ("Pro plan") is the default only because it is what the connect flow
+ * pre-selects for someone who has not paired anything yet. It must never be
+ * used as the answer for a box that IS paired — see `resolveUiTier`.
+ */
+export function readStoredUiTier(): ClawaiTier {
+  if (typeof window === "undefined") return "flash";
+  try {
+    return normalizeClawaiUiTier(window.localStorage?.getItem(CLAWAI_TIER_STORAGE_KEY)) ?? "flash";
+  } catch {
+    return "flash";
+  }
+}
+
+/**
+ * Which PLAN card to show for a paired device.
+ *
+ * The device tier cannot represent Free: `uiTierToDeviceTier` maps both "free"
+ * and "flash" to the device's "flash" (Free and Pro run the same DeepSeek V4
+ * Flash weights), so a stored "flash" means Free OR Pro. Trusting local storage
+ * blindly showed "Pro plan — €9/month" to a Free user; trusting it on a paired
+ * Max box shows "Pro plan — €9/month" to someone paying €49 (TASK-468). "pro"
+ * (Max) is unambiguous and always wins over local storage.
+ *
+ * `hasToken` is what makes this safe for the wizard: an UNPAIRED box has no
+ * account to reconcile against, and the picker there is the customer choosing a
+ * plan they do not have yet, so their stored intent must survive untouched.
+ *
+ * Shared by both provider panels on purpose. The OpenClaw panel read only local
+ * storage for months while the Hermes panel had this rule, which is exactly the
+ * drift this module exists to prevent.
+ */
+export function resolveUiTier(hasToken: boolean, tierStored: string | null | undefined): ClawaiTier {
+  if (!hasToken) return readStoredUiTier();
+  const device = deviceTierToUiTier(tierStored);
+  if (device !== "flash") return device;
+  return readStoredUiTier() === "free" ? "free" : "flash";
+}

--- a/src/tests/components/ai-models-step-plan-tier.test.tsx
+++ b/src/tests/components/ai-models-step-plan-tier.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
+import { act, fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
 import AIModelsStep from "@/components/AIModelsStep";
 import { CLAWAI_TIER_STORAGE_KEY } from "@/lib/clawbox-ai-tiers";
 
@@ -140,6 +140,11 @@ describe("AIModelsStep — the plan card follows the account, not local storage"
     // already happened — the wizard is where someone upgrades.
     let releaseStatus: (() => void) | null = null;
     const gate = new Promise<void>((resolve) => { releaseStatus = resolve; });
+    // Resolves once the panel has actually READ the late answer. Asserting on
+    // "fetch was called" alone would pass before the response ever came back,
+    // which would make this test green for the wrong reason.
+    let statusConsumed: (() => void) | null = null;
+    const statusRead = new Promise<void>((resolve) => { statusConsumed = resolve; });
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
       if (url.includes("/setup-api/ai-models/oauth/providers")) {
@@ -147,7 +152,13 @@ describe("AIModelsStep — the plan card follows the account, not local storage"
       }
       if (url.includes("/setup-api/ai-models/status")) {
         await gate;
-        return { ok: true, json: async () => ({ clawaiConfigured: true, tierSource: "portal", clawaiAccountTier: "flash" }) };
+        return {
+          ok: true,
+          json: async () => {
+            statusConsumed?.();
+            return { clawaiConfigured: true, tierSource: "portal", clawaiAccountTier: "flash" };
+          },
+        };
       }
       return { ok: true, json: async () => ({}) };
     }));
@@ -158,14 +169,18 @@ describe("AIModelsStep — the plan card follows the account, not local storage"
     fireEvent.click(getByRole("radio", { name: /Max tier/i }));
     await waitFor(() => expect(window.localStorage.getItem(CLAWAI_TIER_STORAGE_KEY)).toBe("pro"));
 
-    releaseStatus?.();
-    // Give the resolved status every chance to land before asserting it did
-    // not win — an assertion that races the fetch would pass for the wrong
-    // reason.
-    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+    expect(fetch).toHaveBeenCalledWith(
       "/setup-api/ai-models/status",
       expect.objectContaining({ cache: "no-store" }),
-    ));
+    );
+
+    releaseStatus?.();
+    // Wait until the panel has read the late answer, then let React drain, so
+    // this asserts the reconcile DECLINED to move the card rather than that it
+    // simply had not run yet.
+    await statusRead;
+    await act(async () => { await Promise.resolve(); });
+
     // The account says flash; the user just said Max. The user wins.
     expect(window.localStorage.getItem(CLAWAI_TIER_STORAGE_KEY)).toBe("pro");
     expect(queryByText("Pro plan · €9/month")).not.toBeInTheDocument();

--- a/src/tests/components/ai-models-step-plan-tier.test.tsx
+++ b/src/tests/components/ai-models-step-plan-tier.test.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
+import AIModelsStep from "@/components/AIModelsStep";
+import { CLAWAI_TIER_STORAGE_KEY } from "@/lib/clawbox-ai-tiers";
+
+// TASK-468. The plan summary in the AI Provider panel used to be seeded purely
+// from local storage, so on a browser that had never stored a tier — every
+// customer's first visit — it fell back to the hardcoded "flash" and rendered
+// "Pro plan · €9/month" no matter what the account actually was. On a Max box
+// that sat directly under the panel's own MAX badge, and the same state is what
+// `payload.clawaiTier` writes on save, so it was a silent downgrade waiting to
+// happen, not a cosmetic slip.
+//
+// These tests drive the REAL component against the REAL status route shape, so
+// they fail if the reconcile is removed or if the status contract moves.
+
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({ t: (key: string) => (key === "ai.showMore" ? "Show more providers..." : key) }),
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useOllamaModels", () => ({
+  useOllamaModels: () => ({
+    ollamaRunning: false, ollamaModels: [], ollamaSearch: "", ollamaSearchResults: [],
+    ollamaSearching: false, ollamaPulling: false, ollamaPullProgress: null, ollamaSaving: false,
+    checkOllamaStatus: vi.fn(), handleOllamaSearchChange: vi.fn(), pullOllamaModel: vi.fn(),
+    saveOllamaConfig: vi.fn(), deleteOllamaModel: vi.fn(),
+    formatOllamaBytes: vi.fn((b: number) => `${b}`), clearSearch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useLlamaCppModels", () => ({
+  useLlamaCppModels: () => ({
+    llamaCppRunning: false, llamaCppInstalled: false, llamaCppModels: [],
+    llamaCppEndpoint: "http://127.0.0.1:8080/v1", llamaCppSaving: false,
+    llamaCppProgress: null, checkLlamaCppStatus: vi.fn(), saveLlamaCppConfig: vi.fn(),
+  }),
+}));
+
+/** The fields of /setup-api/ai-models/status this panel is allowed to read. */
+type StatusStub = {
+  clawaiConfigured?: boolean;
+  tierSource?: "portal" | "picker";
+  clawaiAccountTier?: "flash" | "pro" | null;
+};
+
+function mockStatus(status: StatusStub | null) {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+    if (url.includes("/setup-api/ai-models/oauth/providers")) {
+      return { ok: true, json: async () => ({ providers: [] }) };
+    }
+    if (url.includes("/setup-api/ai-models/status")) {
+      if (status === null) return { ok: false, json: async () => ({}) };
+      return { ok: true, json: async () => status };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+function renderPanel() {
+  return render(
+    <AIModelsStep
+      embedded
+      providerIds={["clawai", "openai"]}
+      defaultProviderId="clawai"
+      title="Connect AI Provider"
+      description="Primary provider"
+    />,
+  );
+}
+
+describe("AIModelsStep — the plan card follows the account, not local storage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("shows Max for a portal-confirmed Max account on a browser that stored nothing", async () => {
+    // The exact reproduction: a Max box, a first visit, no stored tier.
+    mockStatus({ clawaiConfigured: true, tierSource: "portal", clawaiAccountTier: "pro" });
+    const { findByText, queryByText } = renderPanel();
+
+    expect(await findByText("Max plan · €49/month")).toBeInTheDocument();
+    // The bug was not "Max is missing", it was "Pro is claimed". Assert the
+    // wrong answer is gone, or a panel that rendered both would still pass.
+    expect(queryByText("Pro plan · €9/month")).not.toBeInTheDocument();
+  });
+
+  it("shows Pro for a portal-confirmed Pro account", async () => {
+    mockStatus({ clawaiConfigured: true, tierSource: "portal", clawaiAccountTier: "flash" });
+    const { findByText, queryByText } = renderPanel();
+
+    expect(await findByText("Pro plan · €9/month")).toBeInTheDocument();
+    expect(queryByText("Max plan · €49/month")).not.toBeInTheDocument();
+  });
+
+  it("shows Free when the portal reconciled the account down to Free", async () => {
+    // mapPortalTier returns null for anything that is not a paid plan, so a
+    // paired Free box answers configured + portal + null. Showing "Pro plan
+    // €9/month" to someone who is not paying is the other half of this bug.
+    mockStatus({ clawaiConfigured: true, tierSource: "portal", clawaiAccountTier: null });
+    const { findByText, queryByText } = renderPanel();
+
+    expect(await findByText("Free plan · free forever")).toBeInTheDocument();
+    expect(queryByText("Pro plan · €9/month")).not.toBeInTheDocument();
+  });
+
+  it("leaves the card alone when the portal did not answer this cycle", async () => {
+    // tierSource "picker" means the status route never reached the portal. The
+    // stored device tier cannot tell Free from "we never asked", so moving the
+    // card off a guess here is how a Free user got shown a paid plan.
+    window.localStorage.setItem(CLAWAI_TIER_STORAGE_KEY, "pro");
+    mockStatus({ clawaiConfigured: true, tierSource: "picker", clawaiAccountTier: "flash" });
+    const { findByText, queryByText } = renderPanel();
+
+    expect(await findByText("Max plan · €49/month")).toBeInTheDocument();
+    expect(queryByText("Pro plan · €9/month")).not.toBeInTheDocument();
+  });
+
+  it("keeps the stored choice when no ClawBox AI account is paired at all", async () => {
+    // The wizard's connect flow: this picker is someone CHOOSING a plan they do
+    // not have yet, and there is no account to reconcile against.
+    window.localStorage.setItem(CLAWAI_TIER_STORAGE_KEY, "pro");
+    mockStatus({ clawaiConfigured: false, tierSource: "picker", clawaiAccountTier: null });
+    const { findByText } = renderPanel();
+
+    expect(await findByText("Max plan · €49/month")).toBeInTheDocument();
+  });
+
+  it("survives a status route that fails outright", async () => {
+    mockStatus(null);
+    const { findByText } = renderPanel();
+    // No answer, so the stored default stands and nothing blows up.
+    expect(await findByText("Pro plan · €9/month")).toBeInTheDocument();
+  });
+
+  it("never overrides a plan the user picked in this session", async () => {
+    // A late status answer must not yank the card out from under a click that
+    // already happened — the wizard is where someone upgrades.
+    let releaseStatus: (() => void) | null = null;
+    const gate = new Promise<void>((resolve) => { releaseStatus = resolve; });
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+      if (url.includes("/setup-api/ai-models/oauth/providers")) {
+        return { ok: true, json: async () => ({ providers: [] }) };
+      }
+      if (url.includes("/setup-api/ai-models/status")) {
+        await gate;
+        return { ok: true, json: async () => ({ clawaiConfigured: true, tierSource: "portal", clawaiAccountTier: "flash" }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }));
+
+    const { getByRole, findByText, queryByText } = renderPanel();
+    // Open the picker and choose Max before the box has answered.
+    fireEvent.click(await findByText("Pro plan · €9/month"));
+    fireEvent.click(getByRole("radio", { name: /Max tier/i }));
+    await waitFor(() => expect(window.localStorage.getItem(CLAWAI_TIER_STORAGE_KEY)).toBe("pro"));
+
+    releaseStatus?.();
+    // Give the resolved status every chance to land before asserting it did
+    // not win — an assertion that races the fetch would pass for the wrong
+    // reason.
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith(
+      "/setup-api/ai-models/status",
+      expect.objectContaining({ cache: "no-store" }),
+    ));
+    // The account says flash; the user just said Max. The user wins.
+    expect(window.localStorage.getItem(CLAWAI_TIER_STORAGE_KEY)).toBe("pro");
+    expect(queryByText("Pro plan · €9/month")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Found by the V4 verification loop on beta `2747eb2`, reproduced on both loop boxes.

## What a customer sees

Open **Settings → AI Provider** on a Max box, in any browser that has never been there before:

- the STATUS card says **ClawBox AI · MAX**
- six lines below it, the Plan row says **Pro plan · €9/month**

Same panel, same screen, same moment. On `.177` the chat header also says "Max Tier" and `/setup-api/ai-models/status` returns `clawaiTier: "pro"`, `clawaiAccountTier: "pro"`, `tierSource: "portal"`, `clawaiImages.plan: "max"`. Every surface says Max except the plan row.

`localStorage` was verifiably empty on both origins — which is exactly what a customer's first visit looks like, and what any visit after clearing site data looks like.

## Why

`AIModelsStep` seeded its tier from `localStorage` alone and asked the box nothing. It is the one provider panel that never fetched `/setup-api/ai-models/status`, so with no stored value it fell back to the hardcoded `"flash"`, whose card is `CLAWAI_TIER_INFO.flash` = "Pro plan" at €9. The account tier it needed was already being fetched two components away to paint the badge sitting right above it.

## Why it is not just a label

`AIModelsStep` sends `payload.clawaiTier = clawaiTier` on save. A Max subscriber who opens this screen in a fresh browser and saves anything from it writes the **flash** device tier — moving their box off the V4 Pro frontier weights, silently, on a €49/month account. It cuts the other way too: a paired **Free** user was shown "Pro plan · €9/month" as though they were paying.

## The fix

The rule already existed — in the other panel. `HermesProviderConfig` has carried `resolveUiTier` since the Free-user version of this bug was fixed there, and its comment names the symptom verbatim. Only that panel ever got it.

So: move the rule into `src/lib/clawbox-ai-tiers.ts`, beside `uiTierToDeviceTier` and `deviceTierToUiTier`, in the module whose own header says a shared module is the only thing that stops these two panels drifting — and have **both** panels use it.

Each branch is load-bearing:

| situation | result | why |
|---|---|---|
| portal-confirmed `"pro"` (Max) | Max | unambiguous, wins over local storage |
| portal-confirmed `"flash"` | local storage decides | `uiTierToDeviceTier` maps Free **and** Pro onto the device's single flash tier, so the device tier genuinely cannot tell them apart |
| `tierSource: "picker"` | nothing moves | the portal was not reached this cycle; guessing a plan from a stored device tier is how a Free user got shown a paid plan |
| no clawai profile paired | stored intent kept | on the wizard this picker is someone **choosing** a plan they do not have yet |
| user picked this session | user wins | a late status answer must not yank the card out from under a click that already happened |

## Tests

`src/tests/components/ai-models-step-plan-tier.test.tsx` drives the real component against the real status-route shape: Max, Pro, Free, portal-unreachable, unpaired, a status route that fails outright, and a user pick racing a deliberately gated slow answer.

Each case asserts the **wrong** plan is absent as well as the right one present — a panel that rendered both would otherwise pass. Verified they fail with the reconcile removed (2 of 7 fail), so they are not vacuous.

Local gate: `npx vitest run` — **272 files / 3704 tests, all green**. ESLint clean on every touched file.

## Verification still owed

This lands as a `v4-defect` fix under the release-verification loop. It unblocks **TASK-478** (Settings tells the truth about the provider and the plan), which must then be re-run on the merged SHA on **both** boxes — `.65` on the clean-install path and `.177` on the upgrade path — before anything is called done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI model plan displays now reflect portal-confirmed account tiers for paired devices.
  * Preserves user-selected plans when account information is unavailable or updates arrive late.
  * Safely defaults to the Flash tier when no valid saved plan is available.
  * Max devices consistently display the Pro plan.

* **Bug Fixes**
  * Improved handling of status failures, missing account data, invalid saved settings, and unavailable portal information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->