### PR TITLE
A Max token now configures the Max model (TASK-481)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -54,6 +54,7 @@ import {
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_CURATED_MODELS, OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
 import { resolveEntitledCodexModel } from "@/lib/codex-model-probe";
+import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
 import { isValidModelId, isCatalogProvider, GOOGLE_MODELS, ANTHROPIC_MODELS, extractProviderModelId } from "@/lib/provider-models";
 import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
 // The model name on this route arrives in the request body. For a local
@@ -1101,8 +1102,43 @@ export async function POST(request: Request) {
     // Inlining the same `?? storedTier ?? DEFAULT_TIER` chain in two
     // places previously let the two sites drift on a half-applied edit;
     // a single source of truth keeps them in lockstep.
+    //
+    // `requestedClawboxAiTier` is the wizard's plan PICKER, and during a first
+    // pairing that is whatever the card defaulted to before anyone had an
+    // account to look at — "flash" (Pro). Trusting it wrote the €9 model onto
+    // boxes paired with a €49 Max token, with no way to reach the frontier
+    // model afterwards: the picker had already been consulted and the account
+    // never was (TASK-481). We hold the token and the portal will answer
+    // truthfully, so ask it, exactly as the Codex branch below asks ChatGPT
+    // for entitlement and for the same reason.
+    //
+    // Only a definitive PAID answer overrides the picker. `unreachable`
+    // (offline, timeout, 401/403 — deliberately ambiguous, see fetchPortalTier)
+    // and a Free/unrecognised verdict both leave the existing chain alone, so
+    // a portal outage can never downgrade a paying box mid-setup. The portal's
+    // own `deviceTier` stamp is honoured inside mapPortalTier, which is what
+    // keeps "Max subscriber who deliberately runs Flash on this device"
+    // working rather than being force-promoted here.
+    let portalConfirmedTier: ClawboxAiTier | null = null;
+    if (isClawAI && clawboxAiToken) {
+      try {
+        const lookup = await fetchPortalTier(clawboxAiToken);
+        if (lookup.source === "portal" && lookup.tier) {
+          portalConfirmedTier = lookup.tier;
+          if (requestedClawboxAiTier && requestedClawboxAiTier !== lookup.tier) {
+            console.log(
+              `[configure] ClawBox AI plan picker said "${requestedClawboxAiTier}", portal says "${lookup.tier}" — using the account`,
+            );
+          }
+        }
+      } catch (err) {
+        // Never let a tier probe break pairing; fall through to the picker.
+        console.warn("[configure] ClawBox AI portal tier probe failed:", err);
+      }
+    }
     const resolvedClawboxTier: ClawboxAiTier | null = isClawAI
-      ? (requestedClawboxAiTier
+      ? (portalConfirmedTier
+          ?? requestedClawboxAiTier
           ?? normalizeClawboxAiTier(configStore[CLAWBOX_AI_TIER_CONFIG_KEY])
           ?? CLAWBOX_AI_DEFAULT_TIER)
       : null;

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -11,10 +11,9 @@ import {
 } from "@/lib/clawbox-ai-models";
 import { getActiveHarness } from "@/lib/harness";
 import { hermesConfigGetMany } from "@/lib/hermes-config-cache";
-import {
-  fetchPortalTier,
-  _resetPortalTierCache,
-} from "@/lib/clawbox-ai-portal-tier";
+// Portal tier resolution lives in @/lib/clawbox-ai-portal-tier so the
+// configure route can reach the same answer from the same cache (TASK-481).
+import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
 
 export const dynamic = "force-dynamic";
 
@@ -37,12 +36,6 @@ const CLAWBOX_AI_TIER_CONFIG_KEY = "clawai_tier";
 // `applyClawaiToHermes` writes it here; the OpenClaw path reads the same token
 // from `models.providers.deepseek.apiKey` in openclaw.json instead.
 const CLAWBOX_AI_TOKEN_CONFIG_KEY = "clawai_token";
-
-// Portal tier resolution lives in @/lib/clawbox-ai-portal-tier so the
-// configure route can reach the same answer from the same cache (TASK-481).
-// Re-exported here because the route suite drives the cache through this
-// module and the seam should stay where its tests already point.
-export { _resetPortalTierCache };
 
 function normalizeProvider(provider: string | null): string | null {
   if (!provider) return null;

--- a/src/app/setup-api/ai-models/status/route.ts
+++ b/src/app/setup-api/ai-models/status/route.ts
@@ -3,7 +3,6 @@ import { readConfig } from "@/lib/openclaw-config";
 import { get as getConfigValue, set as setConfigValue } from "@/lib/config-store";
 import {
   normalizeClawboxAiTier,
-  normalizeClawboxAiPlan,
   monthlyImageLimitForPlan,
   CLAWBOX_AI_IMAGE_MODEL_ID,
   CLAWBOX_AI_PLAN_LABEL,
@@ -12,6 +11,10 @@ import {
 } from "@/lib/clawbox-ai-models";
 import { getActiveHarness } from "@/lib/harness";
 import { hermesConfigGetMany } from "@/lib/hermes-config-cache";
+import {
+  fetchPortalTier,
+  _resetPortalTierCache,
+} from "@/lib/clawbox-ai-portal-tier";
 
 export const dynamic = "force-dynamic";
 
@@ -35,202 +38,11 @@ const CLAWBOX_AI_TIER_CONFIG_KEY = "clawai_tier";
 // from `models.providers.deepseek.apiKey` in openclaw.json instead.
 const CLAWBOX_AI_TOKEN_CONFIG_KEY = "clawai_token";
 
-// Portal endpoint that maps a `claw_*` token to its current subscription
-// state. Authoritative source for the device's tier badge — local config
-// only ever stored the user's wizard *selection*, which can drift from
-// what the portal actually grants (Free user pastes a token + clicks Max
-// pill → local says "pro" but token entitles only Free).
-const PORTAL_DEVICE_INFO_URL =
-  process.env.CLAWBOX_AI_DEVICE_INFO_URL?.trim()
-  || "https://clawbox.com/api/clawbox-ai/device-info";
-
-// 120s TTL > 30s poll cadence so most polls land on a warm cache. The
-// portal's reconcile-tier already self-heals on its end inside its own
-// 60s window, so 120s here is still bounded by Stripe truth on the
-// far side.
-const PORTAL_TIER_CACHE_TTL_MS = 120_000;
-// 4s timeout — this fetch sits on the render path of the chat header
-// and Settings card. Anything longer stacks behind the 30s poll cadence
-// and stalls the badge update. On timeout we treat the portal as
-// unreachable and fall back to the picker selection.
-const PORTAL_FETCH_TIMEOUT_MS = 4_000;
-// Bound for the in-memory token cache. A single device only has one
-// active claw_ token at a time, so this only matters under factory-
-// reset / multi-account dev churn — but a long-running process would
-// otherwise leak entries forever.
-const PORTAL_TIER_CACHE_MAX_ENTRIES = 64;
-// Short negative-cache window for tokens whose last portal lookup
-// resolved to `unreachable` (4xx auth failure, 5xx, or network
-// error). With useClawboxLogin polling every 30s, this caps the
-// per-device portal load during a sustained auth-failure or
-// outage at ~1 request per 30s (down from 1-per-poll). Smaller
-// than PORTAL_TIER_CACHE_TTL_MS because the positive cache is
-// safe to hold longer; an unreachable verdict needs to clear
-// quickly enough that recovery (token re-pair, portal recovers)
-// shows up on the next poll, not minutes later.
-const PORTAL_UNREACHABLE_TTL_MS = 30_000;
-
-interface DeviceInfoResponse {
-  tier?: string;
-  deviceTier?: string | null;
-}
-
-type PortalLookup =
-  | { source: "portal"; tier: ClawboxAiTier | null; plan: ClawboxAiPlan | null }
-  | { source: "unreachable" };
-
-interface PortalCacheEntry {
-  tier: ClawboxAiTier | null;
-  // Subscription plan behind the tier. Kept alongside `tier` because the two
-  // are not interchangeable: `tier` collapses Free and "portal said something
-  // we don't recognise" into the same `null`, and the image allowance has to
-  // tell those apart (Free has a real 5-image allowance to show).
-  plan: ClawboxAiPlan | null;
-  expiresAt: number;
-}
-
-const portalTierCache = new Map<string, PortalCacheEntry>();
-// token → epoch-ms timestamp when its unreachable verdict expires.
-// Separate from portalTierCache because the value is "we tried and
-// it failed, don't try again yet" rather than "the answer is null".
-const portalUnreachableCache = new Map<string, number>();
-const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
-
-/**
- * Writes a token's resolved tier into the in-memory cache, sweeping
- * expired entries and enforcing the size cap before insertion. Map
- * iteration order is insertion order, so the first key returned by
- * `keys()` is the oldest.
- *
- * @param token Portal token (`claw_*`) used as the cache key.
- * @param tier Resolved tier (or `null` for Free / no entitlement).
- * @param plan Resolved subscription plan (or `null` when unrecognised).
- * @param now Current epoch ms; used both for expiry comparison and to
- *   set the new entry's `expiresAt`.
- */
-function rememberTier(
-  token: string,
-  tier: ClawboxAiTier | null,
-  plan: ClawboxAiPlan | null,
-  now: number,
-) {
-  for (const [key, entry] of portalTierCache) {
-    if (entry.expiresAt <= now) portalTierCache.delete(key);
-  }
-  while (portalTierCache.size >= PORTAL_TIER_CACHE_MAX_ENTRIES) {
-    const oldest = portalTierCache.keys().next().value;
-    if (oldest === undefined) break;
-    portalTierCache.delete(oldest);
-  }
-  portalTierCache.set(token, { tier, plan, expiresAt: now + PORTAL_TIER_CACHE_TTL_MS });
-}
-
-/**
- * Maps the portal's `device-info` response to the local `ClawboxAiTier`
- * enum the UI badges already understand. Prefers the device-pair stamp
- * (`deviceTier`) when present; otherwise translates the user's plan
- * name (`tier`) to its corresponding device-tier. The local enum is
- * `"flash"` (Pro plan / V4 Flash model) and `"pro"` (Max plan / V4 Pro
- * model); Free / unpaid resolves to `null` (no paid badge rendered).
- *
- * @param body Parsed JSON from `/api/clawbox-ai/device-info`.
- * @returns The badge-facing tier, or `null` for Free.
- */
-function mapPortalTier(body: DeviceInfoResponse): ClawboxAiTier | null {
-  const plan = (body.tier ?? "").trim().toLowerCase();
-  // Subscription plan is the source of truth — a stale or bogus
-  // deviceTier stamp on a Free account must never grant a paid badge.
-  if (plan !== "pro" && plan !== "max") return null;
-  // Paid: prefer the explicit device-pair stamp (lets Max subs run
-  // flash); otherwise map plan → device tier.
-  const stamped = normalizeClawboxAiTier(body.deviceTier);
-  if (stamped) return stamped;
-  return plan === "max" ? "pro" : "flash";
-}
-
-/**
- * Resolves a `claw_*` token's current tier against the portal, with
- * a short in-memory cache and concurrent-request de-duplication.
- *
- * Cache semantics:
- *   - 200 OK: parsed tier is cached for `PORTAL_TIER_CACHE_TTL_MS`.
- *   - Non-200 / network error: token is marked unreachable for
- *     `PORTAL_UNREACHABLE_TTL_MS` so we don't hit the portal every
- *     30 s status poll during a sustained auth failure or outage.
- *     A successful 200 clears the unreachable mark so recovery is
- *     responsive.
- *
- * 401/403 are deliberately treated the same as 5xx/network errors
- * (unreachable) rather than as a definitive "Free" verdict — see
- * the non-200 branch in the body for the rationale.
- *
- * @param token The bearer token to look up.
- * @returns Either a definitive `{ source: "portal", tier }` answer or
- *   `{ source: "unreachable" }` when the portal couldn't respond.
- */
-async function fetchPortalTier(token: string): Promise<PortalLookup> {
-  const now = Date.now();
-  const cached = portalTierCache.get(token);
-  if (cached && cached.expiresAt > now) {
-    return { source: "portal", tier: cached.tier, plan: cached.plan };
-  }
-
-  const unreachableUntil = portalUnreachableCache.get(token);
-  if (unreachableUntil !== undefined && unreachableUntil > now) {
-    return { source: "unreachable" };
-  }
-
-  const existing = inFlightPortalLookups.get(token);
-  if (existing) return existing;
-
-  const promise = (async (): Promise<PortalLookup> => {
-    const markUnreachable = (): PortalLookup => {
-      portalUnreachableCache.set(token, now + PORTAL_UNREACHABLE_TTL_MS);
-      return { source: "unreachable" };
-    };
-    try {
-      const res = await fetch(PORTAL_DEVICE_INFO_URL, {
-        headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(PORTAL_FETCH_TIMEOUT_MS),
-      });
-      if (res.ok) {
-        const body = await res.json() as DeviceInfoResponse;
-        const tier = mapPortalTier(body);
-        const plan = normalizeClawboxAiPlan(body.tier);
-        rememberTier(token, tier, plan, now);
-        portalUnreachableCache.delete(token);
-        return { source: "portal", tier, plan };
-      }
-      // 401/403 is ambiguous: it can mean genuinely Free OR token
-      // revoked / migrated / corrupted on a still-paid account. We
-      // can't tell from the response alone, and treating it as
-      // "Free" silently downgrades paid users with broken auth (and
-      // fires the downgrade-celebration popup). Mark unreachable
-      // instead so callers preserve localTier.
-      return markUnreachable();
-    } catch {
-      return markUnreachable();
-    }
-  })();
-
-  inFlightPortalLookups.set(token, promise);
-  try {
-    return await promise;
-  } finally {
-    inFlightPortalLookups.delete(token);
-  }
-}
-
-/**
- * Test-only escape hatch — clears both the value cache and any
- * in-flight lookups so vitest's `beforeEach` can start each test from
- * a clean module-state. Not for production use.
- */
-export function _resetPortalTierCache() {
-  portalUnreachableCache.clear();
-  portalTierCache.clear();
-  inFlightPortalLookups.clear();
-}
+// Portal tier resolution lives in @/lib/clawbox-ai-portal-tier so the
+// configure route can reach the same answer from the same cache (TASK-481).
+// Re-exported here because the route suite drives the cache through this
+// module and the seam should stay where its tests already point.
+export { _resetPortalTierCache };
 
 function normalizeProvider(provider: string | null): string | null {
   if (!provider) return null;

--- a/src/lib/clawbox-ai-portal-tier.ts
+++ b/src/lib/clawbox-ai-portal-tier.ts
@@ -1,0 +1,216 @@
+import {
+  normalizeClawboxAiTier,
+  normalizeClawboxAiPlan,
+  type ClawboxAiTier,
+  type ClawboxAiPlan,
+} from "@/lib/clawbox-ai-models";
+
+/**
+ * Resolving a `claw_*` portal token to the subscription tier it actually
+ * grants.
+ *
+ * Extracted out of the status route so the CONFIGURE route can ask the same
+ * question with the same answer. They used to disagree: status asked the
+ * portal, configure trusted the wizard's plan picker, so pairing a Max token
+ * through the wizard wrote the Pro model onto a Max box and the two surfaces
+ * then contradicted each other (TASK-481). Sharing the module also shares the
+ * cache, so the configure call almost always lands on the entry the status
+ * poll just warmed rather than paying for a second round trip.
+ */
+
+// Portal endpoint that maps a `claw_*` token to its current subscription
+// state. Authoritative source for the device's tier badge — local config
+// only ever stored the user's wizard *selection*, which can drift from
+// what the portal actually grants (Free user pastes a token + clicks Max
+// pill → local says "pro" but token entitles only Free).
+const PORTAL_DEVICE_INFO_URL =
+  process.env.CLAWBOX_AI_DEVICE_INFO_URL?.trim()
+  || "https://clawbox.com/api/clawbox-ai/device-info";
+
+// 120s TTL > 30s poll cadence so most polls land on a warm cache. The
+// portal's reconcile-tier already self-heals on its end inside its own
+// 60s window, so 120s here is still bounded by Stripe truth on the
+// far side.
+const PORTAL_TIER_CACHE_TTL_MS = 120_000;
+// 4s timeout — this fetch sits on the render path of the chat header
+// and Settings card. Anything longer stacks behind the 30s poll cadence
+// and stalls the badge update. On timeout we treat the portal as
+// unreachable and fall back to the picker selection.
+const PORTAL_FETCH_TIMEOUT_MS = 4_000;
+// Bound for the in-memory token cache. A single device only has one
+// active claw_ token at a time, so this only matters under factory-
+// reset / multi-account dev churn — but a long-running process would
+// otherwise leak entries forever.
+const PORTAL_TIER_CACHE_MAX_ENTRIES = 64;
+// Short negative-cache window for tokens whose last portal lookup
+// resolved to `unreachable` (4xx auth failure, 5xx, or network
+// error). With useClawboxLogin polling every 30s, this caps the
+// per-device portal load during a sustained auth-failure or
+// outage at ~1 request per 30s (down from 1-per-poll). Smaller
+// than PORTAL_TIER_CACHE_TTL_MS because the positive cache is
+// safe to hold longer; an unreachable verdict needs to clear
+// quickly enough that recovery (token re-pair, portal recovers)
+// shows up on the next poll, not minutes later.
+const PORTAL_UNREACHABLE_TTL_MS = 30_000;
+
+export interface DeviceInfoResponse {
+  tier?: string;
+  deviceTier?: string | null;
+}
+
+export type PortalLookup =
+  | { source: "portal"; tier: ClawboxAiTier | null; plan: ClawboxAiPlan | null }
+  | { source: "unreachable" };
+
+interface PortalCacheEntry {
+  tier: ClawboxAiTier | null;
+  // Subscription plan behind the tier. Kept alongside `tier` because the two
+  // are not interchangeable: `tier` collapses Free and "portal said something
+  // we don't recognise" into the same `null`, and the image allowance has to
+  // tell those apart (Free has a real 5-image allowance to show).
+  plan: ClawboxAiPlan | null;
+  expiresAt: number;
+}
+
+const portalTierCache = new Map<string, PortalCacheEntry>();
+// token → epoch-ms timestamp when its unreachable verdict expires.
+// Separate from portalTierCache because the value is "we tried and
+// it failed, don't try again yet" rather than "the answer is null".
+const portalUnreachableCache = new Map<string, number>();
+const inFlightPortalLookups = new Map<string, Promise<PortalLookup>>();
+
+/**
+ * Writes a token's resolved tier into the in-memory cache, sweeping
+ * expired entries and enforcing the size cap before insertion. Map
+ * iteration order is insertion order, so the first key returned by
+ * `keys()` is the oldest.
+ *
+ * @param token Portal token (`claw_*`) used as the cache key.
+ * @param tier Resolved tier (or `null` for Free / no entitlement).
+ * @param plan Resolved subscription plan (or `null` when unrecognised).
+ * @param now Current epoch ms; used both for expiry comparison and to
+ *   set the new entry's `expiresAt`.
+ */
+function rememberTier(
+  token: string,
+  tier: ClawboxAiTier | null,
+  plan: ClawboxAiPlan | null,
+  now: number,
+) {
+  for (const [key, entry] of portalTierCache) {
+    if (entry.expiresAt <= now) portalTierCache.delete(key);
+  }
+  while (portalTierCache.size >= PORTAL_TIER_CACHE_MAX_ENTRIES) {
+    const oldest = portalTierCache.keys().next().value;
+    if (oldest === undefined) break;
+    portalTierCache.delete(oldest);
+  }
+  portalTierCache.set(token, { tier, plan, expiresAt: now + PORTAL_TIER_CACHE_TTL_MS });
+}
+
+/**
+ * Maps the portal's `device-info` response to the local `ClawboxAiTier`
+ * enum the UI badges already understand. Prefers the device-pair stamp
+ * (`deviceTier`) when present; otherwise translates the user's plan
+ * name (`tier`) to its corresponding device-tier. The local enum is
+ * `"flash"` (Pro plan / V4 Flash model) and `"pro"` (Max plan / V4 Pro
+ * model); Free / unpaid resolves to `null` (no paid badge rendered).
+ *
+ * @param body Parsed JSON from `/api/clawbox-ai/device-info`.
+ * @returns The badge-facing tier, or `null` for Free.
+ */
+export function mapPortalTier(body: DeviceInfoResponse): ClawboxAiTier | null {
+  const plan = (body.tier ?? "").trim().toLowerCase();
+  // Subscription plan is the source of truth — a stale or bogus
+  // deviceTier stamp on a Free account must never grant a paid badge.
+  if (plan !== "pro" && plan !== "max") return null;
+  // Paid: prefer the explicit device-pair stamp (lets Max subs run
+  // flash); otherwise map plan → device tier.
+  const stamped = normalizeClawboxAiTier(body.deviceTier);
+  if (stamped) return stamped;
+  return plan === "max" ? "pro" : "flash";
+}
+
+/**
+ * Resolves a `claw_*` token's current tier against the portal, with
+ * a short in-memory cache and concurrent-request de-duplication.
+ *
+ * Cache semantics:
+ *   - 200 OK: parsed tier is cached for `PORTAL_TIER_CACHE_TTL_MS`.
+ *   - Non-200 / network error: token is marked unreachable for
+ *     `PORTAL_UNREACHABLE_TTL_MS` so we don't hit the portal every
+ *     30 s status poll during a sustained auth failure or outage.
+ *     A successful 200 clears the unreachable mark so recovery is
+ *     responsive.
+ *
+ * 401/403 are deliberately treated the same as 5xx/network errors
+ * (unreachable) rather than as a definitive "Free" verdict — see
+ * the non-200 branch in the body for the rationale.
+ *
+ * @param token The bearer token to look up.
+ * @returns Either a definitive `{ source: "portal", tier }` answer or
+ *   `{ source: "unreachable" }` when the portal couldn't respond.
+ */
+export async function fetchPortalTier(token: string): Promise<PortalLookup> {
+  const now = Date.now();
+  const cached = portalTierCache.get(token);
+  if (cached && cached.expiresAt > now) {
+    return { source: "portal", tier: cached.tier, plan: cached.plan };
+  }
+
+  const unreachableUntil = portalUnreachableCache.get(token);
+  if (unreachableUntil !== undefined && unreachableUntil > now) {
+    return { source: "unreachable" };
+  }
+
+  const existing = inFlightPortalLookups.get(token);
+  if (existing) return existing;
+
+  const promise = (async (): Promise<PortalLookup> => {
+    const markUnreachable = (): PortalLookup => {
+      portalUnreachableCache.set(token, now + PORTAL_UNREACHABLE_TTL_MS);
+      return { source: "unreachable" };
+    };
+    try {
+      const res = await fetch(PORTAL_DEVICE_INFO_URL, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(PORTAL_FETCH_TIMEOUT_MS),
+      });
+      if (res.ok) {
+        const body = await res.json() as DeviceInfoResponse;
+        const tier = mapPortalTier(body);
+        const plan = normalizeClawboxAiPlan(body.tier);
+        rememberTier(token, tier, plan, now);
+        portalUnreachableCache.delete(token);
+        return { source: "portal", tier, plan };
+      }
+      // 401/403 is ambiguous: it can mean genuinely Free OR token
+      // revoked / migrated / corrupted on a still-paid account. We
+      // can't tell from the response alone, and treating it as
+      // "Free" silently downgrades paid users with broken auth (and
+      // fires the downgrade-celebration popup). Mark unreachable
+      // instead so callers preserve localTier.
+      return markUnreachable();
+    } catch {
+      return markUnreachable();
+    }
+  })();
+
+  inFlightPortalLookups.set(token, promise);
+  try {
+    return await promise;
+  } finally {
+    inFlightPortalLookups.delete(token);
+  }
+}
+
+/**
+ * Test-only escape hatch — clears both the value cache and any
+ * in-flight lookups so vitest's `beforeEach` can start each test from
+ * a clean module-state. Not for production use.
+ */
+export function _resetPortalTierCache() {
+  portalUnreachableCache.clear();
+  portalTierCache.clear();
+  inFlightPortalLookups.clear();
+}

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1343,6 +1343,28 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-pro");
     });
 
+    it("reaches the primary model from the portal alone when the request omits clawaiTier", async () => {
+      // CodeRabbit's catch on #430, and a fair one: every other case here
+      // sends a picker value, so none of them proves the portal result can
+      // drive the model on its own. With `clawaiTier` absent,
+      // `requestedClawboxAiTier` is null and the whole chain past
+      // `portalConfirmedTier` is the stored value then the hardcoded default
+      // — both of which are "flash". So if the reconcile ever stopped
+      // feeding this branch, this is the only test that would notice.
+      vi.stubGlobal("fetch", deviceInfo({ tier: "max" }));
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_max_no_picker",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-pro");
+      expect(mockSetMany).toHaveBeenCalledWith(
+        expect.objectContaining({ clawai_tier: "pro" }),
+      );
+    });
+
     it("does not consult the portal for a non-ClawBox provider", async () => {
       const fetchMock = deviceInfo({ tier: "max" });
       vi.stubGlobal("fetch", fetchMock);

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1218,4 +1218,143 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect.stringContaining("oauth-device-tokens.json"),
     );
   });
+
+  // ---------------------------------------------------------------------
+  // TASK-481 — the ClawBox AI tier the box is configured for must come from
+  // the ACCOUNT, not from the wizard's plan picker.
+  //
+  // The picker is pre-pairing UI: on a first setup it holds whatever the card
+  // defaulted to before there was an account to look at ("flash" = Pro, EUR 9).
+  // Sending that as `clawaiTier` while pasting a Max token wrote the EUR 9
+  // model onto a EUR 49 box, and the customer had no way to reach the frontier
+  // model afterwards. The route already holds the token one line earlier, so
+  // it can just ask.
+  //
+  // Every case below asserts the PRIMARY MODEL that gets written, because that
+  // is what the customer actually feels — a stored tier string that no model
+  // follows is exactly the half-fixed state this bug lived in.
+  describe("ClawBox AI tier reconciliation against the portal", () => {
+    const deviceInfo = (body: unknown, status = 200) =>
+      vi.fn(async (input: string | URL) =>
+        String(input).includes("/api/clawbox-ai/device-info")
+          ? new Response(JSON.stringify(body), { status })
+          : Promise.reject(new Error("network disabled in tests")),
+      );
+
+    const primaryModelWritten = () =>
+      vi.mocked(runOpenclawConfigSet).mock.calls
+        .map((call) => call[0] ?? [])
+        .find((args) => args[0] === "agents.defaults.model.primary")?.[1];
+
+    it("configures the Max model when the portal says Max, even though the picker said Pro", async () => {
+      vi.stubGlobal("fetch", deviceInfo({ tier: "max" }));
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_max_account",
+        clawaiTier: "flash",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-pro");
+      expect(mockSetMany).toHaveBeenCalledWith(
+        expect.objectContaining({ clawai_tier: "pro" }),
+      );
+    });
+
+    it("configures the Pro model when the portal says Pro, even though the picker said Max", async () => {
+      // The mirror image, and the reason this is a reconcile rather than a
+      // promote: clicking the Max card does not entitle you to the Max model.
+      vi.stubGlobal("fetch", deviceInfo({ tier: "pro" }));
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_pro_account",
+        clawaiTier: "pro",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-flash");
+      expect(mockSetMany).toHaveBeenCalledWith(
+        expect.objectContaining({ clawai_tier: "flash" }),
+      );
+    });
+
+    it("honours the portal's deviceTier stamp so a Max subscriber can run Flash on this box", async () => {
+      // Deliberate downgrade, expressed on the portal side at pair time. The
+      // fix must not force such a device up to the plan's headline model.
+      vi.stubGlobal("fetch", deviceInfo({ tier: "max", deviceTier: "flash" }));
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_max_running_flash",
+        clawaiTier: "pro",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-flash");
+    });
+
+    it("keeps the picker's choice when the portal is unreachable", async () => {
+      // A portal outage during setup must never quietly downgrade a paying
+      // box. `fetchPortalTier` reports network failures as `unreachable`.
+      vi.stubGlobal("fetch", vi.fn(async () => {
+        throw new Error("portal down");
+      }));
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_offline",
+        clawaiTier: "pro",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-pro");
+    });
+
+    it("keeps the picker's choice when the portal answers 401", async () => {
+      // 401/403 is ambiguous — genuinely Free, or a revoked/migrated token on
+      // a still-paid account. fetchPortalTier maps it to `unreachable` for
+      // that reason and this route must inherit the same caution.
+      vi.stubGlobal("fetch", deviceInfo({}, 401));
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_bad_auth",
+        clawaiTier: "pro",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-pro");
+    });
+
+    it("keeps the picker's choice when the portal reports an unpaid account", async () => {
+      // mapPortalTier returns null for Free. Null is "no paid entitlement to
+      // reconcile against", not "downgrade them", so the existing chain wins.
+      vi.stubGlobal("fetch", deviceInfo({ tier: "free" }));
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_free_account",
+        clawaiTier: "pro",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(primaryModelWritten()).toBe("deepseek/deepseek-v4-pro");
+    });
+
+    it("does not consult the portal for a non-ClawBox provider", async () => {
+      const fetchMock = deviceInfo({ tier: "max" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const res = await configurePost(jsonRequest({
+        provider: "anthropic",
+        apiKey: "sk-ant-key",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(fetchMock.mock.calls.some(([url]) =>
+        String(url).includes("/api/clawbox-ai/device-info"))).toBe(false);
+    });
+  });
 });

--- a/src/tests/routes/ai-models/status-images.test.ts
+++ b/src/tests/routes/ai-models/status-images.test.ts
@@ -66,7 +66,8 @@ describe("/setup-api/ai-models/status — clawaiImages", () => {
     vi.stubGlobal("fetch", fetchSpy);
     const mod = await import("@/app/setup-api/ai-models/status/route");
     GET = mod.GET;
-    mod._resetPortalTierCache();
+    // Cache seam lives in the shared lib — see status.test.ts.
+    (await import("@/lib/clawbox-ai-portal-tier"))._resetPortalTierCache();
   });
 
   afterEach(() => {

--- a/src/tests/routes/ai-models/status.test.ts
+++ b/src/tests/routes/ai-models/status.test.ts
@@ -46,7 +46,9 @@ describe("/setup-api/ai-models/status", () => {
     vi.stubGlobal("fetch", fetchSpy);
     const mod = await import("@/app/setup-api/ai-models/status/route");
     GET = mod.GET;
-    resetPortalTierCache = mod._resetPortalTierCache;
+    // The portal-tier cache lives in the shared lib, not the route — a
+    // route.ts may only export handlers and route config.
+    resetPortalTierCache = (await import("@/lib/clawbox-ai-portal-tier"))._resetPortalTierCache;
     resetPortalTierCache();
   });
 


### PR DESCRIPTION
## The bug

Found by the V4 verification loop on beta `3f2ba67`, live on both loop boxes.

The wizard asks the customer which plan they are on, and then believes the answer — while holding a portal token that actually knows.

`requestedClawboxAiTier` is the plan picker's value at the moment **Connect** is pressed. On a first pairing nobody has touched that picker (there is no account to render it against yet), so it is still the card's default: `flash` — Pro, €9. The route wrote that into `agents.defaults.model.primary` and into `clawai_tier`, so a box paired with a €49 **Max** token came up on `deepseek-v4-flash`, with no way to reach the frontier model from the chat dropdown.

It is worse than a wrong label, because the **status** route already asks the portal and *persists* the answer into `clawai_tier`. The two halves therefore disagreed in place. On `.65` right now:

```
data/config.json   clawai_tier = 'pro'            # portal-confirmed: Max
openclaw.json      primary     = deepseek-v4-flash # picker default: Pro
models offered     [deepseek-v4-flash, deepseek-v4-pro, gpt-5.6-luna]
```

Settings said "Max plan · €49/month" beside a Flash model name. TASK-468 fixing the display is what made the misconfiguration visible.

## The fix

Ask the account, exactly as the Codex branch twenty lines below already asks ChatGPT for entitlement, and for the same reason its comment gives.

The portal lookup moves out of `status/route.ts` into `@/lib/clawbox-ai-portal-tier` so both routes reach the same answer through the same 120s cache — the wizard's own status poll normally warms it, so the extra round trip usually costs nothing.

**Only a definitive PAID verdict overrides the picker.** `unreachable`, timeout, 401/403 (deliberately ambiguous — a revoked token on a still-paid account is indistinguishable from Free) and an unpaid account all leave the existing `requested ?? stored ?? default` chain alone. A portal outage during setup can never downgrade a paying box.

The portal's own `deviceTier` stamp is honoured inside `mapPortalTier`, so "Max subscriber who deliberately runs Flash on this device" keeps working rather than being force-promoted.

## Tests

7 tests against the real route.

- **3 fail without the reconcile** — portal Max vs picker Pro, portal Pro vs picker Max, and the `deviceTier` stamp.
- **4 pass either way by design.** They are the safety envelope: unreachable, 401, unpaid, and non-ClawBox provider. They exist to fail a *future* version of this fix that starts downgrading on ambiguity, which is the dangerous direction.

Local gate: 272 files / 3711 tests green.

## Hardware proof

Pending — this PR is the fix half of a verification cycle. Both loop boxes (`.65` clean install, `.177` upgrade) get force-updated to the merged SHA and the pairing is re-driven through the real wizard UI before TASK-460 and TASK-481 are called done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ClawBox AI setup now verifies account tiers through the portal.
  * Paid portal tiers take precedence over selected model tiers.
  * Tier information is cached and shared to improve setup performance.

* **Bug Fixes**
  * Setup preserves the selected tier when verification is unavailable, invalid, or indicates a free account.
  * Improved handling of portal-based device downgrades and unauthorized responses.
  * Non-ClawBox providers remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->