### PR TITLE
feat: pin the hermes agent to a chosen upstream release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1508,9 +1508,19 @@ step_hermes_install() {
   # diagnosis costs nothing. Renaming as ROOT is also required — the root-owned
   # __pycache__ above is not movable by the clawbox user the installer runs as.
   if [ -e "$agent_dir" ]; then
+    # One noun for whatever is being moved, set on the same arm that announces
+    # it. The move block below is shared by two very different devices — an
+    # agent that does not run, and an agent that runs fine and is merely on the
+    # wrong commit — and it used to call both of them "the unusable agent" one
+    # line after announcing "Moving the working agent aside". An owner reading
+    # that log on a healthy box has every reason to think the upgrade found
+    # something wrong with their device.
+    local moved_what
     if [ -n "$installed" ]; then
-      echo "  Moving the working agent aside so the pinned install can be undone"
+      moved_what="working agent"
+      echo "  Moving the $moved_what aside so the pinned install can be undone"
     else
+      moved_what="unusable agent"
       echo "  Hermes is present but not runnable — reinstalling the agent"
     fi
     if [ -e "$agent_dir.broken" ]; then
@@ -1526,9 +1536,9 @@ step_hermes_install() {
         return 0
       fi
     elif mv "$agent_dir" "$agent_dir.broken"; then
-      echo "  Moved the unusable agent to $agent_dir.broken"
+      echo "  Moved the $moved_what to $agent_dir.broken"
     else
-      echo "  Warning: could not move the unusable agent aside — leaving it in place" >&2
+      echo "  Warning: could not move the $moved_what aside — leaving it in place" >&2
       return 0
     fi
     # The husk MUST be deletable by the clawbox user: the factory-reset route
@@ -1588,6 +1598,50 @@ step_hermes_install() {
     # (checkout plus venv) on a disk-constrained device and is one more
     # directory a later factory reset has to be able to delete.
     rm -rf "$agent_dir.broken"
+
+    # The upgrade above is a move-aside plus a FRESH clone, and the bridge's
+    # ~80 MB node_modules is untracked — so every pinned upgrade deletes it.
+    # Nothing is broken by that: the pairing manager runs this same `npm
+    # install` the first time somebody asks for a WhatsApp QR, and it was
+    # watched doing so on hardware (bridgeReady false→true, QRs rotating).
+    # But it moves the cost to the worst possible moment — the owner has just
+    # clicked Pair and is waiting on a code — and a box that happens to be
+    # OFFLINE right then gets a pairing FAILURE where the same box would have
+    # paired before the upgrade. So pay for it here instead, while the updater
+    # demonstrably has the network and nobody is waiting.
+    #
+    # From the registry, NOT from the husk we just deleted. The husk's
+    # node_modules belongs to a DIFFERENT commit; moving it across would carry
+    # the old release's dependency tree into the new one's package.json.
+    #
+    # This runs only on the update that actually re-clones — a box already on
+    # the pin returns above and never reaches here — so a warm-up that fails
+    # falls back to the on-demand path, not to the next update.
+    #
+    # Best-effort in every direction, and deliberately so: skipped when there
+    # is nothing to warm (no bridge in this release, or its node_modules
+    # survived), time-boxed, and its failure is a WARNING. A successful Hermes
+    # install must never be reported as a failed step because an npm mirror was
+    # down — the on-demand path is still there and still works.
+    #
+    # 300s, not longer: step_post_update's budget is 900s total
+    # (src/lib/updater.ts) and this step is followed inside it by the Gemma
+    # re-cache, so a stalled registry must not be able to eat the rest of the
+    # update. An 80 MB install over a working link is far inside that, and what
+    # would consume the difference is npm's own retry backoff — exactly the
+    # case this block already declares non-fatal.
+    local bridge_dir="$agent_dir/scripts/whatsapp-bridge"
+    if [ -d "$bridge_dir" ] && [ ! -d "$bridge_dir/node_modules" ]; then
+      echo "  Warming up the WhatsApp bridge so the first pairing does not pay for it..."
+      # `env -C` gives the install its working directory without a wrapper
+      # shell to quote the path into, and leaves npm as timeout's direct child
+      # so the time box actually lands on it. HOME is explicit for the same
+      # reason as every other command in this step: npm caches under $HOME/.npm
+      # and this function's HOME is /root, which the clawbox user cannot write.
+      runuser -u "$CLAWBOX_USER" -- env -C "$bridge_dir" HOME="$CLAWBOX_HOME" \
+        timeout 300 npm install --no-fund --no-audit --progress=false \
+        || echo "  Warning: WhatsApp bridge warm-up failed (non-fatal) — the first pairing will install it on demand" >&2
+    fi
   else
     echo "  Warning: Hermes still does not run after install — the dashboard will not start" >&2
     # The diagnosis may simply have been wrong — an empty probe on a loaded

--- a/install.sh
+++ b/install.sh
@@ -370,6 +370,27 @@ BUN="$CLAWBOX_HOME/.bun/bin/bun"
 NPM_PREFIX="$CLAWBOX_HOME/.npm-global"
 OPENCLAW_BIN="$NPM_PREFIX/bin/openclaw"
 OPENCLAW_VERSION="2026.7.1-2"
+# Pinned Hermes agent release, in the same spirit as $OPENCLAW_VERSION above:
+# the fleet runs the build WE chose instead of whatever
+# NousResearch/hermes-agent had on `main` the second a box was flashed.
+# Upstream lands ~150 commits a day and cuts a tag two or three times a week,
+# so every unpinned install lands on a different, untested tree.
+#
+# The value is the 40-char COMMIT the release tag points at — not the tag
+# name, and not the annotated tag object's own SHA. The upstream installer's
+# `--commit` takes a commit only and rejects abbreviated SHAs, while
+# `--branch <tag>` is worse than useless on an existing checkout: it rewrites
+# remote.origin.fetch to a refspec with no matching head and leaves
+# origin/main stale, which breaks the agent's own `hermes update` later.
+#
+# Overridable from the environment so QA can aim one device at another commit
+# without editing the file (`HERMES_PIN_COMMIT=<sha> sudo -E bash install.sh
+# --step hermes_install`), exactly as OPENCLAW_PIN_VERSION does for OpenClaw.
+# Bump the default in a PR, ship it through beta -> main, and the fleet
+# follows on its next update.
+#
+# Current pin: upstream tag v2026.8.19 == "Hermes Agent v0.20.5".
+HERMES_PIN_COMMIT="${HERMES_PIN_COMMIT:-fcbd1076a93841fa88855acce810e342a5b78101}"
 GATEWAY_DIST="$NPM_PREFIX/lib/node_modules/openclaw/dist"
 DNSMASQ_DIR="/etc/NetworkManager/dnsmasq-shared.d"
 AVAHI_CONF="/etc/avahi/avahi-daemon.conf"
@@ -1389,9 +1410,25 @@ step_hermes_install() {
   local agent_dir="$CLAWBOX_HOME/.hermes/hermes-agent"
   local venv_python="$agent_dir/venv/bin/python"
   local installed=""
+  local pin="$HERMES_PIN_COMMIT"
+
+  # The pin is spliced into a URL below and the file that URL returns is piped
+  # into bash, so it is validated before it is used. A malformed value — a tag
+  # name, a truncated SHA, an env override carrying a slash — would otherwise
+  # fetch some other path from the same host and run it. Refuse, and leave
+  # whatever agent the device already has alone.
+  if ! printf '%s' "$pin" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+    echo "  Warning: the Hermes pin is not a 40-char commit SHA — leaving the existing agent untouched" >&2
+    return 0
+  fi
+
   # One constant so the reachability precheck and the install itself can never
-  # drift onto different hosts.
-  local installer_url="https://hermes-agent.nousresearch.com/install.sh"
+  # drift onto different hosts — and it is served FROM the pinned tree, so the
+  # installer that runs is the one that shipped with the commit being asked
+  # for. The vanity host (hermes-agent.nousresearch.com/install.sh) serves
+  # main's copy of the same file: identical today, free to change its flags
+  # under us tomorrow.
+  local installer_url="https://raw.githubusercontent.com/NousResearch/hermes-agent/$pin/scripts/install.sh"
 
   # `$shim` alone is NOT evidence of an install: it is a 4-line wrapper in
   # ~/.local/bin that execs $venv_python, and the agent it points at lives
@@ -1423,9 +1460,30 @@ step_hermes_install() {
       "$shim" --version 2>/dev/null | head -1) || installed=""
   fi
 
+  # A version string cannot answer "is this the pinned build?": upstream prints
+  # the same `v0.20.5` for the tag and for every untagged commit after it, and
+  # there are hundreds of those a week. The checkout's HEAD is the only proof,
+  # so HEAD is what decides. Read as the clawbox user for the same reason the
+  # probe is: git refuses to operate on a repository owned by somebody else
+  # ("detected dubious ownership"), and root reading a clawbox-owned tree is
+  # exactly that case. `|| at_commit=""` for the errexit reason above — a
+  # checkout that is not a git repository must fall through, not abort.
+  local at_commit=""
   if [ -n "$installed" ]; then
-    echo "  Hermes already installed ($installed)"
-    return 0
+    at_commit=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+      git -C "$agent_dir" rev-parse HEAD 2>/dev/null) || at_commit=""
+    if [ "$at_commit" = "$pin" ]; then
+      echo "  Hermes already installed at the pinned commit ($installed)"
+      return 0
+    fi
+    # A working agent on the wrong commit takes the SAME path the unrunnable
+    # one takes — reachability precheck, current checkout moved aside,
+    # install, and the move undone if no working agent comes back. An upgrade
+    # that dies halfway must leave the owner with the agent they already had,
+    # which is the whole reason this step is built the way it is.
+    echo "  Hermes runs but is not on the pinned commit — upgrading"
+    echo "    have: ${at_commit:-unknown (not a git checkout)}"
+    echo "    want: $pin"
   fi
 
   # NOTHING above this line has modified the disk, and nothing below it does
@@ -1450,7 +1508,11 @@ step_hermes_install() {
   # diagnosis costs nothing. Renaming as ROOT is also required — the root-owned
   # __pycache__ above is not movable by the clawbox user the installer runs as.
   if [ -e "$agent_dir" ]; then
-    echo "  Hermes is present but not runnable — reinstalling the agent"
+    if [ -n "$installed" ]; then
+      echo "  Moving the working agent aside so the pinned install can be undone"
+    else
+      echo "  Hermes is present but not runnable — reinstalling the agent"
+    fi
     if [ -e "$agent_dir.broken" ]; then
       # An existing husk means an earlier repair was interrupted between the
       # move and the restore: the husk is the owner's original checkout and
@@ -1480,7 +1542,7 @@ step_hermes_install() {
       || echo "  Warning: could not give $agent_dir.broken to $CLAWBOX_USER" >&2
   fi
 
-  echo "  Installing Hermes agent (NousResearch)..."
+  echo "  Installing Hermes agent (NousResearch) at $pin..."
   # Official installer clones NousResearch/hermes-agent + builds a venv. Runs as
   # the clawbox user so it lands in ~/.hermes and ~/.local/bin. The URL is
   # passed as an argument rather than spliced into the -c string, so it stays a
@@ -1488,8 +1550,18 @@ step_hermes_install() {
   # because `curl | bash` otherwise exits 0 when the fetch fails (bash just
   # reads empty stdin) and the warning below could never fire; the timeouts
   # because the caller is a systemd unit with TimeoutStartSec=7200.
+  #
+  # `--force-commit` is not optional. For an existing checkout the upstream
+  # installer fetches, checks out and fast-forwards its branch (main) FIRST
+  # and only then applies `--commit`, skipping it with "Ignoring --commit …:
+  # the checkout is already newer" whenever the pin is an ancestor of what it
+  # just pulled — which is always, a tag being older than the main it was cut
+  # from. Without the flag the pin is a silent no-op on every install,
+  # including fresh ones, and boxes keep landing on random main commits.
+  # `bash -s --` is what gets the flags through the pipe to the script.
   runuser -u "$CLAWBOX_USER" -- bash -o pipefail -c \
-    'curl -fsSL --connect-timeout 15 --max-time 600 "$1" | bash' _ "$installer_url" \
+    'curl -fsSL --connect-timeout 15 --max-time 600 "$1" | bash -s -- --commit "$2" --force-commit' \
+    _ "$installer_url" "$pin" \
     || echo "  Warning: Hermes install failed (non-fatal) — install it manually then re-run install.sh"
 
   # Verify rather than assume. The installer is fetched over the network and is
@@ -1500,7 +1572,18 @@ step_hermes_install() {
   installed=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
     "$shim" --version 2>/dev/null | head -1) || installed=""
   if [ -n "$installed" ]; then
-    echo "  Hermes installed ($installed)"
+    at_commit=$(runuser -u "$CLAWBOX_USER" -- env HOME="$CLAWBOX_HOME" \
+      git -C "$agent_dir" rev-parse HEAD 2>/dev/null) || at_commit=""
+    if [ "$at_commit" = "$pin" ]; then
+      echo "  Hermes installed ($installed) at the pinned commit"
+    else
+      # The agent RUNS, so it is NOT rolled back: a working unpinned agent is
+      # worth more than the copy moved aside, which was unpinned too. Loud,
+      # because it means the pin did not take — upstream dropping
+      # `--force-commit` would look exactly like this — and the next update
+      # will pay for the whole upgrade again.
+      echo "  Warning: Hermes installed ($installed) but HEAD is ${at_commit:-unknown}, not the pin $pin" >&2
+    fi
     # Diagnosis confirmed, so the insurance copy goes: it costs ~1.9 GB
     # (checkout plus venv) on a disk-constrained device and is one more
     # directory a later factory reset has to be able to delete.
@@ -2614,8 +2697,13 @@ step_post_update() {
   # ~/.local/bin/hermes is not runnable — so the agent has to be repaired first
   # or the repair and the provisioning would fight each other.
   #
-  # Both are fast no-ops on a healthy box: step_hermes_install returns after a
-  # `--version` probe, step_llamacpp_model after a single `[ -f ]` test.
+  # Both are fast no-ops on a box that is already where it should be:
+  # step_hermes_install returns after a `--version` probe plus one
+  # `git rev-parse`, step_llamacpp_model after a single `[ -f ]` test. The one
+  # exception is a box whose agent predates $HERMES_PIN_COMMIT (or was moved
+  # off it by a hand-run `hermes update`, which reattaches to main): that box
+  # takes the reversible pinned upgrade ONCE — a clone plus venv build, ~90s
+  # measured — and is a no-op on every update after it.
   # step_hermes_install self-gates on has_hermes_harness; step_llamacpp_model
   # deliberately does not (see its comment).
   step_hermes_install || echo "  Warning: hermes_install step failed (non-fatal)"

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -237,6 +237,26 @@ describe("step_hermes_install installs one pinned Hermes release", () => {
   });
 });
 
+describe("step_hermes_install's log does not contradict itself", () => {
+  it("never calls the agent it moved aside unusable", () => {
+    // The move block is shared by two devices that have nothing in common: an
+    // agent that will not run, and an agent that runs fine and is merely on the
+    // wrong commit. Hardcoding the noun in it meant a healthy box being
+    // upgraded printed "Moving the working agent aside" and then "Moved the
+    // unusable agent to …/hermes-agent.broken" — an owner reading that has
+    // every reason to believe the update found a fault on their device.
+    //
+    // Read as text rather than driven, because the message that is left is the
+    // one the behavioural harness cannot reach: it only prints when `mv` itself
+    // fails, which needs a filesystem the fake HOME does not have.
+    for (const line of HERMES_CODE.split(NL).filter((l) => l.includes("echo"))) {
+      expect(line, `the moved agent must not be named inline: ${line}`).not.toContain(
+        "unusable agent",
+      );
+    }
+  });
+});
+
 describe("step_hermes_install never runs hermes as root", () => {
   it("every hermes invocation goes through runuser as the clawbox user", () => {
     const invocations = HERMES_CODE.split(NL).filter(
@@ -359,6 +379,8 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
 
   const agentDir = () => path.join(tmp, ".hermes", "hermes-agent");
   const shimPath = () => path.join(tmp, ".local", "bin", "hermes");
+  /** Upstream's WhatsApp bridge, inside the agent checkout the step replaces. */
+  const bridgeDir = () => path.join(agentDir(), "scripts", "whatsapp-bridge");
   const exists = (p: string) => fs.existsSync(p);
 
   /**
@@ -418,6 +440,14 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     installHead = PIN,
     // The value of the shipped constant, overridable the way QA overrides it.
     pin = PIN,
+    // What the fresh checkout the installer lays down contains at
+    // scripts/whatsapp-bridge: "none" for a release that has no bridge at all,
+    // "fresh" for the real shape of a clone (tracked sources, NO node_modules),
+    // "warm" for a tree whose dependencies are somehow already there.
+    bridge = "none" as "none" | "fresh" | "warm",
+    // Whether the stubbed npm succeeds. A registry that is down must cost the
+    // owner a warning and nothing else.
+    npmOk = true,
   } = {}) {
     // The reachability precheck is the `-o /dev/null` call; anything else is
     // the real installer being fetched to be piped into bash.
@@ -438,10 +468,31 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
         // The real installer's `--commit` leaves the checkout detached at that
         // commit; this is the only part of that the step can observe.
         '  if [ -n "$INSTALL_HEAD" ]; then printf %s "$INSTALL_HEAD" > "$AGENT_DIR/.fake-head"; fi',
+        // A clone carries the bridge's SOURCES and never its node_modules —
+        // that directory is untracked upstream, which is the whole reason the
+        // warm-up exists.
+        '  if [ "$BRIDGE" != "none" ]; then',
+        '    mkdir -p "$AGENT_DIR/scripts/whatsapp-bridge"',
+        '    echo "{}" > "$AGENT_DIR/scripts/whatsapp-bridge/package.json"',
+        '    if [ "$BRIDGE" = "warm" ]; then',
+        '      mkdir -p "$AGENT_DIR/scripts/whatsapp-bridge/node_modules"',
+        "    fi",
+        "  fi",
         "fi",
         'echo ":"',
         "",
       ].join(NL),
+      { mode: 0o755 },
+    );
+    // npm has to be a real executable on PATH for the same reason curl does:
+    // the warm-up reaches it through `env`, which only ever does a PATH lookup.
+    // The marker is written to the process's CWD rather than to a fixed path,
+    // so WHERE it lands is the assertion that the install ran in the bridge
+    // directory — no path-shape comparison, which would not survive the two
+    // separator conventions this suite runs under.
+    fs.writeFileSync(
+      path.join(tmp, "bin", "npm"),
+      ["#!/bin/sh", 'printf "%s\\n" "$*" > npm-ran', 'exit "$NPM_RC"', ""].join(NL),
       { mode: 0o755 },
     );
     // `git -C <dir> rev-parse HEAD` is the only git the step runs, and it runs
@@ -490,8 +541,10 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       // Merged, because the warnings that matter here are all on stderr.
       "step_hermes_install 2>&1",
     ].join(NL);
+    let code = 0;
+    let out: string;
     try {
-      const out = execFileSync(
+      out = execFileSync(
         "bash",
         [
           "-c",
@@ -505,17 +558,26 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
           installHead,
           pin,
         ],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+        {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+          env: { ...process.env, BRIDGE: bridge, NPM_RC: npmOk ? "0" : "1" },
+        },
       );
-      return { code: 0, out, installerRan: exists(path.join(tmp, "installer-ran")) };
     } catch (e: unknown) {
       const err = e as { status?: number; stdout?: string; stderr?: string };
-      return {
-        code: err.status ?? 1,
-        out: `${err.stdout ?? ""}${err.stderr ?? ""}`,
-        installerRan: exists(path.join(tmp, "installer-ran")),
-      };
+      code = err.status ?? 1;
+      out = `${err.stdout ?? ""}${err.stderr ?? ""}`;
     }
+    const npmMarker = path.join(bridgeDir(), "npm-ran");
+    return {
+      code,
+      out,
+      installerRan: exists(path.join(tmp, "installer-ran")),
+      // Read out of the BRIDGE directory, so a non-null value is already proof
+      // that npm ran with the bridge as its working directory.
+      npmArgs: exists(npmMarker) ? fs.readFileSync(npmMarker, "utf8").trim() : null,
+    };
   }
 
   it("a healthy install on the pin is a no-op — nothing touched, nothing fetched", () => {
@@ -792,6 +854,90 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(r.out).toMatch(/Hermes install failed \(non-fatal\)/);
     // …and the box is still whole.
     expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+  });
+
+  it("a healthy agent moved aside for an upgrade is not called unusable", () => {
+    // Both messages come out of the same move block, and it used to hardcode
+    // the noun: a box whose agent works fine was told, one line after "Moving
+    // the working agent aside", that its agent was unusable. Nothing is broken
+    // on this device — it is simply not on the build we ship.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    const moveLine = r.out.split(NL).find((l) => l.includes("hermes-agent.broken"));
+    expect(moveLine).toMatch(/Moved the working agent to .*hermes-agent\.broken/);
+    // Scoped to the line that names it, so an unrelated future message using
+    // the word does not fail this.
+    expect(moveLine).not.toContain("unusable");
+    // A release with no bridge asks nothing of npm — the default every other
+    // run in this file uses.
+    expect(r.npmArgs).toBeNull();
+  });
+
+  it("a pinned upgrade warms up the WhatsApp bridge the fresh clone deleted", () => {
+    // The upgrade is a move-aside plus a fresh clone, and the bridge's ~80 MB
+    // node_modules is untracked, so it does not come back with the checkout.
+    // ClawBox does self-heal — the pairing manager runs this same install the
+    // first time a QR is asked for, observed on hardware — but that puts the
+    // whole install in front of an owner who has just clicked Pair, and an
+    // OFFLINE box at that moment fails to pair where it would have paired
+    // before the upgrade. So the updater pays for it, while it has the network.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ bridge: "fresh" });
+
+    expect(r.code).toBe(0);
+    expect(r.installerRan).toBe(true);
+    expect(r.out).toMatch(/Warming up the WhatsApp bridge/);
+    // npmArgs is read out of the bridge directory itself, so a non-null value
+    // is already proof the install ran there and not in some inherited cwd.
+    expect(r.npmArgs).not.toBeNull();
+    // The flags the pairing manager uses, so the warm cache is the one the
+    // on-demand path would have built.
+    expect(r.npmArgs).toContain("install");
+    expect(r.npmArgs).toContain("--no-fund");
+    expect(r.npmArgs).toContain("--no-audit");
+    expect(r.npmArgs).toContain("--progress=false");
+    // …and the step still reports what it is actually for.
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\) at the pinned commit/);
+  });
+
+  it("a warm-up that fails is a warning — the install still counts as a success", () => {
+    // A down registry, a proxy, an npm that dies on a low-memory device. The
+    // on-demand path still works, so this must not turn a good Hermes install
+    // into a failed step: step_post_update reports any non-zero return as a
+    // failed update step, on every hermes box on every update.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ bridge: "fresh", npmOk: false });
+
+    expect(r.code).toBe(0);
+    expect(r.npmArgs).not.toBeNull();
+    expect(r.out).toMatch(/WhatsApp bridge warm-up failed \(non-fatal\)/);
+    // The agent install itself is untouched by the bridge's bad luck.
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\) at the pinned commit/);
+    expect(headOf(agentDir())).toBe(PIN);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("a bridge that already has its node_modules is left alone", () => {
+    // The warm-up is repair, not routine work: node_modules that survived must
+    // not be reinstalled on top of itself. (The release-with-no-bridge case is
+    // the `bridge: "none"` default every other run in this file already uses,
+    // and is asserted on the upgrade above.)
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ bridge: "warm" });
+
+    expect(r.code).toBe(0);
+    expect(r.npmArgs).toBeNull();
+    expect(r.out).not.toMatch(/Warming up the WhatsApp bridge/);
   });
 });
 

--- a/src/tests/unit/install-hermes-install-guard.test.ts
+++ b/src/tests/unit/install-hermes-install-guard.test.ts
@@ -65,6 +65,18 @@ function shellCode(fn: string): string {
 const HERMES_INSTALL = extractShellFunction("step_hermes_install");
 const HERMES_CODE = shellCode(HERMES_INSTALL);
 
+/**
+ * The Hermes pin lives at the top of install.sh next to OPENCLAW_VERSION —
+ * one constant for the whole file. Read it from there so the behavioural
+ * harness below drives the value the fleet actually ships, instead of a copy
+ * in this file that would quietly rot at the next bump.
+ */
+const PIN_LINE = INSTALL_SH.split(NL).find((l) => l.startsWith("HERMES_PIN_COMMIT="));
+if (!PIN_LINE) throw new Error("HERMES_PIN_COMMIT not found in install.sh");
+const PIN = (PIN_LINE.match(/[0-9a-f]{40}/) ?? [""])[0];
+/** A well-formed commit that is not the pin: what an unpinned box looks like. */
+const OTHER_COMMIT = "0".repeat(39) + "1";
+
 describe("step_hermes_install treats a shim without an agent as NOT installed", () => {
   it("does not decide from the shim alone", () => {
     // The exact shape of the defect: a bare `[ -x .local/bin/hermes ]` test
@@ -156,6 +168,72 @@ describe("step_hermes_install treats a shim without an agent as NOT installed", 
     const afterInstall = HERMES_CODE.slice(installIdx);
     expect(afterInstall).toContain("--version");
     expect(afterInstall).toMatch(/Warning: Hermes still does not run/);
+  });
+});
+
+describe("step_hermes_install installs one pinned Hermes release", () => {
+  it("keeps the pin in a single constant next to OPENCLAW_VERSION", () => {
+    const lines = INSTALL_SH.split(NL);
+    const pinIdx = lines.findIndex((l) => l.startsWith("HERMES_PIN_COMMIT="));
+    const openclawIdx = lines.findIndex((l) => l.startsWith("OPENCLAW_VERSION="));
+    expect(pinIdx).toBeGreaterThan(-1);
+    expect(openclawIdx).toBeGreaterThan(-1);
+    // Same block of top-level constants as the OpenClaw pin, not buried in a
+    // function halfway down the file where the next bump would not find it.
+    expect(pinIdx - openclawIdx).toBeLessThan(40);
+    expect(PIN).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("lets QA override the pin without editing the file, like the OpenClaw pin", () => {
+    expect(PIN_LINE).toContain('"${HERMES_PIN_COMMIT:-');
+  });
+
+  it("carries no SHA of its own inside the step", () => {
+    // Two copies of a pin is one too many: the installer URL and the
+    // --commit argument have to be the same value by construction.
+    expect(HERMES_CODE).not.toMatch(/[0-9a-f]{40}/);
+    expect(HERMES_CODE).toContain('pin="$HERMES_PIN_COMMIT"');
+  });
+
+  it("refuses a pin that is not a commit SHA before building any URL", () => {
+    // The pin is spliced into a URL whose contents are piped into bash, so a
+    // tag name or a path fragment must never reach that string.
+    const validateIdx = HERMES_CODE.indexOf("[0-9a-fA-F]{40}");
+    const urlIdx = HERMES_CODE.indexOf("installer_url=");
+    expect(validateIdx).toBeGreaterThan(-1);
+    expect(validateIdx).toBeLessThan(urlIdx);
+  });
+
+  it("fetches the installer from the pinned tree, not from a moving branch", () => {
+    // The vanity host serves main's installer and can change its flags under
+    // us; the copy at the pinned commit is the one those flags belong to.
+    const urlLine = HERMES_CODE.split(NL).find((l) => l.includes("installer_url="));
+    expect(urlLine).toBeDefined();
+    expect(urlLine).toContain("$pin");
+    expect(urlLine).not.toContain("/main/");
+  });
+
+  it("passes --commit AND --force-commit, with the pin as an argument", () => {
+    const installLine = HERMES_CODE.split(NL).find((l) => l.includes("curl -fsSL"));
+    expect(installLine).toBeDefined();
+    // `bash -s --` is what carries flags through the pipe to the script.
+    expect(installLine).toContain("bash -s --");
+    expect(installLine).toContain('--commit "$2"');
+    // Without --force-commit the upstream installer fast-forwards main FIRST
+    // and then skips the pin as "already newer" — a tag is always older than
+    // the main it was cut from, so the pin would silently do nothing.
+    expect(installLine).toContain("--force-commit");
+    expect(installLine).toContain('"$installer_url" "$pin"');
+    // Never spliced into the `bash -c` string — same rule the URL follows.
+    expect(installLine).not.toMatch(/'[^']*\$pin[^']*'/);
+  });
+
+  it("decides pinned-or-not from HEAD, never from the version string", () => {
+    // `hermes --version` prints the same v0.20.5 for the tag and for every
+    // untagged commit after it — hundreds a week — so a version comparison
+    // could never see the difference. Only HEAD can.
+    expect(HERMES_CODE).toMatch(/git -C "\$agent_dir" rev-parse HEAD/);
+    expect(HERMES_CODE).toMatch(/\[ "\$at_commit" = "\$pin" \]/);
   });
 });
 
@@ -301,11 +379,22 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     fs.chmodSync(shimPath(), 0o755);
   }
 
-  /** An agent checkout, with or without the venv the shim execs. */
-  function giveAgent({ venv }: { venv: boolean }) {
+  /** The commit a fake checkout claims to be on, or null when it is not a repo. */
+  const headOf = (dir: string) => {
+    const f = path.join(dir, ".fake-head");
+    return fs.existsSync(f) ? fs.readFileSync(f, "utf8") : null;
+  };
+
+  /**
+   * An agent checkout, with or without the venv the shim execs, and with or
+   * without a HEAD — `head` omitted stands for a tree the stubbed `git`
+   * cannot read a commit out of at all.
+   */
+  function giveAgent({ venv, head }: { venv: boolean; head?: string }) {
     fs.mkdirSync(agentDir(), { recursive: true });
     // Marks THIS checkout, so we can tell "moved aside" from "recreated".
     fs.writeFileSync(path.join(agentDir(), "SENTINEL"), "original");
+    if (head) fs.writeFileSync(path.join(agentDir(), ".fake-head"), head);
     if (venv) {
       const binDir = path.join(agentDir(), "venv", "bin");
       fs.mkdirSync(binDir, { recursive: true });
@@ -320,7 +409,16 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
    * records that it ran, so "did the network install happen at all" is
    * directly observable.
    */
-  function run({ reachable = true, installOk = true, fetchOk = true } = {}) {
+  function run({
+    reachable = true,
+    installOk = true,
+    fetchOk = true,
+    // What HEAD the stubbed installer leaves behind — the pin on the happy
+    // path, something else when upstream ignores `--commit`.
+    installHead = PIN,
+    // The value of the shipped constant, overridable the way QA overrides it.
+    pin = PIN,
+  } = {}) {
     // The reachability precheck is the `-o /dev/null` call; anything else is
     // the real installer being fetched to be piped into bash.
     fs.mkdirSync(path.join(tmp, "bin"), { recursive: true });
@@ -337,8 +435,25 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
         '  mkdir -p "$AGENT_DIR/venv/bin" "$(dirname "$SHIM")"',
         '  cp "$FAKE_PY" "$AGENT_DIR/venv/bin/python"',
         '  cp "$FAKE_PY" "$SHIM"',
+        // The real installer's `--commit` leaves the checkout detached at that
+        // commit; this is the only part of that the step can observe.
+        '  if [ -n "$INSTALL_HEAD" ]; then printf %s "$INSTALL_HEAD" > "$AGENT_DIR/.fake-head"; fi',
         "fi",
         'echo ":"',
+        "",
+      ].join(NL),
+      { mode: 0o755 },
+    );
+    // `git -C <dir> rev-parse HEAD` is the only git the step runs, and it runs
+    // it through `env`, which does a PATH lookup — so, like curl, it has to be
+    // a real executable and not a shell function.
+    fs.writeFileSync(
+      path.join(tmp, "bin", "git"),
+      [
+        "#!/bin/sh",
+        '[ "$1" = "-C" ] || exit 128',
+        '[ -f "$2/.fake-head" ] || exit 128',
+        'cat "$2/.fake-head"',
         "",
       ].join(NL),
       { mode: 0o755 },
@@ -358,6 +473,10 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
       'export PRECHECK_RC="$2"',
       'export INSTALL_OK="$3"',
       'export FETCH_OK="$5"',
+      'export INSTALL_HEAD="$6"',
+      // Stands in for the top-level constant: the extracted function reads it
+      // from the environment exactly as `${HERMES_PIN_COMMIT:-…}` resolves it.
+      'export HERMES_PIN_COMMIT="$7"',
       "has_hermes_harness() { return 0; }",
       // Run the command as this user instead of switching: `runuser -u X -- cmd`.
       'runuser() { shift 2; if [ "$1" = "--" ]; then shift; fi; "$@"; }',
@@ -383,6 +502,8 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
           installOk ? "1" : "0",
           INSTALL_SH_PATH,
           fetchOk ? "1" : "0",
+          installHead,
+          pin,
         ],
         { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
       );
@@ -397,14 +518,14 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     }
   }
 
-  it("a healthy install is a no-op — nothing touched, nothing fetched", () => {
+  it("a healthy install on the pin is a no-op — nothing touched, nothing fetched", () => {
     giveShim();
-    giveAgent({ venv: true });
+    giveAgent({ venv: true, head: PIN });
 
     const r = run();
 
     expect(r.code).toBe(0);
-    expect(r.out).toMatch(/already installed \(Hermes 9\.9\.9\)/);
+    expect(r.out).toMatch(/already installed at the pinned commit \(Hermes 9\.9\.9\)/);
     // Why the reachability precheck sits AFTER the probe: a healthy box makes
     // no network call at all, on every single update.
     expect(r.installerRan).toBe(false);
@@ -558,6 +679,104 @@ describe("step_hermes_install — behaviour, driven against a fake HOME", () => 
     expect(fs.readdirSync(path.join(tmp, ".hermes")).filter((e) => e.includes(".broken"))).toEqual(
       [],
     );
+  });
+
+  it("a healthy agent on the wrong commit is upgraded, through the same reversible path", () => {
+    // The fleet case: the agent works, it just is not the build we ship. It
+    // has to be moved aside first like any other reinstall, so a half-finished
+    // upgrade can still be undone.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/not on the pinned commit/);
+    expect(r.out).toContain(OTHER_COMMIT);
+    expect(r.out).toContain(PIN);
+    expect(r.out).toMatch(/Moving the working agent aside/);
+    expect(r.installerRan).toBe(true);
+    expect(headOf(agentDir())).toBe(PIN);
+    expect(r.out).toMatch(/Hermes installed \(Hermes 9\.9\.9\) at the pinned commit/);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("a failed pinned upgrade puts the working agent back on its old commit", () => {
+    // The reason the upgrade reuses the husk path at all: an agent that was
+    // merely out of date must never end up as no agent.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ installOk: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/Restored the previous agent/);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(headOf(agentDir())).toBe(OTHER_COMMIT);
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    expect(exists(shimPath())).toBe(true);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("an unreachable installer leaves an unpinned but working agent alone", () => {
+    // post_update drives this step on every update on every hermes box, so
+    // "wrong version" plus "no internet" must cost the owner nothing.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ reachable: false });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/cannot reach the Hermes installer/);
+    expect(r.installerRan).toBe(false);
+    expect(headOf(agentDir())).toBe(OTHER_COMMIT);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("an install that lands off the pin is reported, not rolled back", () => {
+    // What upstream dropping --force-commit would look like from here. The
+    // agent runs, so restoring the copy we moved aside — unpinned too — would
+    // only cost the owner the newer tree. Say so loudly instead.
+    giveShim();
+    giveAgent({ venv: true, head: OTHER_COMMIT });
+
+    const r = run({ installHead: OTHER_COMMIT });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/but HEAD is/);
+    expect(r.out).not.toMatch(/Restored the previous agent/);
+    expect(exists(path.join(agentDir(), "venv", "bin", "python"))).toBe(true);
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
+  });
+
+  it("an agent whose HEAD cannot be read counts as unpinned", () => {
+    // A checkout that is not a git repository (or a git that refuses it) can
+    // never be shown to be the pinned build, so it is treated as not being it.
+    // It converges: the pinned install leaves a readable HEAD behind.
+    giveShim();
+    giveAgent({ venv: true });
+
+    const r = run();
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/have: unknown \(not a git checkout\)/);
+    expect(r.installerRan).toBe(true);
+    expect(headOf(agentDir())).toBe(PIN);
+  });
+
+  it("a malformed pin installs nothing at all", () => {
+    // `--branch v2026.8.19`-style values, truncated SHAs, anything with a
+    // slash in it: the URL is never built and the device is never touched.
+    giveShim();
+    giveAgent({ venv: false });
+
+    const r = run({ pin: "v2026.8.19" });
+
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/not a 40-char commit SHA/);
+    expect(r.installerRan).toBe(false);
+    expect(fs.readFileSync(path.join(agentDir(), "SENTINEL"), "utf8")).toBe("original");
+    expect(exists(`${agentDir()}.broken`)).toBe(false);
   });
 
   it("a fetch failure is reported, not swallowed by the pipe", () => {


### PR DESCRIPTION
## What

Boxes install whatever `NousResearch/hermes-agent` happened to have on `main` at
the moment they were flashed. Upstream lands ~150 commits a day and cuts a tag
two or three times a week, so no two devices run the same tree and none of them
runs a tree we tested.

`step_hermes_install` now installs **one commit we choose**: the one upstream tag
`v2026.8.19` ("Hermes Agent v0.20.5", the current stable release) points at. The
pin lives in a single constant next to `OPENCLAW_VERSION`, mirroring the OpenClaw
pin, and is overridable from the environment for QA:

```sh
HERMES_PIN_COMMIT="${HERMES_PIN_COMMIT:-fcbd1076a93841fa88855acce810e342a5b78101}"
```

## How

- **The commit, not the tag.** `--commit` takes a 40-char commit and rejects both
  abbreviated SHAs and the annotated tag object's own SHA. `--branch <tag>` is
  worse than useless on an existing checkout: it rewrites `remote.origin.fetch`
  to a refspec with no matching head and leaves `origin/main` stale, which breaks
  the agent's own `hermes update` later.
- **`--force-commit` is mandatory.** For an existing checkout the upstream
  installer fetches, checks out and fast-forwards its branch (main) *first*, and
  only then applies `--commit` — skipping it with "Ignoring `--commit` …: the
  checkout is already newer" whenever the pin is an ancestor of what it just
  pulled, which is always, a tag being older than the main it was cut from.
  Without the flag the pin is a silent no-op on every install, fresh ones
  included.
- **The installer itself is fetched from the pinned tree**
  (`raw.githubusercontent.com/NousResearch/hermes-agent/<pin>/scripts/install.sh`)
  instead of `hermes-agent.nousresearch.com/install.sh`, which serves main's copy
  of the same file — byte-identical today, free to rename its flags tomorrow.
  Both the reachability precheck and the install still go through the one
  `installer_url` variable.
- **Pinned-or-not is decided by `git rev-parse HEAD`.** `hermes --version` prints
  the same `v0.20.5` for the tag and for every untagged commit after it, so a
  version comparison could never see the difference. The read runs as the clawbox
  user — root reading a clawbox-owned repository is exactly git's "detected
  dubious ownership" case.
- **A malformed pin installs nothing.** The value is spliced into a URL whose
  contents are piped into bash, so anything that is not 40 hex characters is
  refused before the URL exists, leaving the device untouched.

## Guard semantics

Everything the factory-reset fix put in survives — probe, reachability precheck,
husk-aside, restore-on-failure — and a healthy agent on the **wrong** commit now
takes that same reversible path:

| state | outcome |
| --- | --- |
| agent runs, HEAD == pin | no-op, no network call |
| agent runs, HEAD != pin (or unreadable) | moved aside → pinned install → restored if no working agent comes back |
| agent does not run | unchanged: the existing repair path |
| installer unreachable | untouched, warning only — including for an unpinned but working agent |
| install lands off the pin | loud warning, **not** rolled back (a working unpinned agent beats the unpinned copy we moved aside) |

## Scope

- Fresh installs land on the pin. Existing boxes converge on their next update:
  `step_post_update` already runs this step, so each hermes/dual box takes the
  reversible upgrade **once** (clone + venv build, ~90s measured) and is a no-op
  on every update after that.
- `hermes update`, run by hand on a box, reattaches to `main` and un-pins it —
  upstream reattaches on a detached HEAD by design. That box is re-pinned by its
  next ClawBox update. ClawBox itself never calls `hermes update`.

## Follow-ups from live device verification

The pinned install was driven on hardware: move-aside, fresh clone at the pin,
idempotent re-run and fault-injected reversibility all behaved as designed. Two
non-blocking findings came out of that run and are fixed here.

### 1. The WhatsApp bridge is reinstalled after a pinned upgrade

The upgrade is a move-aside plus a **fresh clone**, and upstream's
`scripts/whatsapp-bridge/node_modules` (~80 MB) is untracked — so it does not
come back with the checkout.

Nothing is broken by that on its own, and it was watched self-healing on the
bench box: the pairing manager runs `npm install` the first time somebody asks
for a QR (`bridgeReady` false→true, QRs rotating). But it moves a multi-minute
install to the moment an owner clicks **Pair** and is waiting on a code — and a
box that happens to be **offline** right then gets a pairing *failure* where the
same box would have paired before the upgrade.

`step_hermes_install` now pays for it up front, after a successful pinned
install, while the updater demonstrably has the network and nobody is waiting:

```sh
runuser -u "$CLAWBOX_USER" -- env -C "$bridge_dir" HOME="$CLAWBOX_HOME" \
  timeout 300 npm install --no-fund --no-audit --progress=false \
  || echo "  Warning: WhatsApp bridge warm-up failed (non-fatal) — …" >&2
```

- **Skipped unless it is needed** — only when the bridge directory exists and
  its `node_modules` does not. A box already on the pin returns before this
  point and never reaches it.
- **From the registry, not from the husk.** The husk's `node_modules` belongs to
  a *different* commit; carrying it across would put the old release's
  dependency tree under the new one's `package.json`.
- **Warning-only.** A down registry must never turn a good Hermes install into a
  failed update step — `step_post_update` reports any non-zero return as a
  failed step, on every hermes/dual box on every update. The on-demand path is
  still there and still works.
- **300 s, not longer.** `post_update`'s budget is 900 s and the Gemma re-cache
  runs after this inside it, so a stalled registry must not be able to eat the
  rest of the update.

**Known consequence, stated plainly:** the first update that moves a box onto
the pin still *deletes* the existing bridge `node_modules` and reinstalls it
from the registry. That is inherent to the fresh-clone upgrade; this change
moves the cost off the pairing click, it does not remove it. Boxes already on
the pin are unaffected — they return before the clone.

### 2. A healthy agent is no longer called "unusable"

The move block is shared by two devices with nothing in common: an agent that
will not run, and an agent that runs fine and is merely on the wrong commit. It
hardcoded the noun, so a healthy box being upgraded printed

```
  Moving the working agent aside so the pinned install can be undone
  Moved the unusable agent to /home/clawbox/.hermes/hermes-agent.broken
```

An owner reading that has every reason to think the update found a fault on
their device. The noun is now set on the same arm that announces it, so the two
messages cannot drift apart again.

## Testing

The pinned install itself was verified on the bench box (isolated checkout, no
deploy, no service touched): move-aside, fresh clone at the pin, idempotent
re-run and fault-injected reversibility all passed. The two findings above came
out of that run.

The follow-up fixes were verified on the PC (bun 1.3.14 / vitest 4.1.10) — the
bench box was not reachable from this network at the time, and polishing a log
string and a best-effort `npm install` did not warrant taking a device offline:

- `bash -n install.sh` — clean.
- `install-hermes-install-guard` suite: **47 passed**, up from 42. Four new
  behavioural cases against the fake HOME — the warm-up fires when there is a
  bridge and no `node_modules`; a failing npm is a warning and the step still
  reports success; a bridge whose `node_modules` survived is left alone; a
  healthy agent moved aside is not called unusable — plus one text case for the
  `mv`-failure message, which is the one wording the harness cannot reach.
- Full unit project, run twice on the same machine, clean `HEAD` vs. this
  branch: **3449 → 3454 tests, 3133 → 3138 passed; 180 failed in both, across
  the same 24 files.** Those 24 are pre-existing Windows-environment failures
  (`spawn flock ENOENT` and friends), identical before and after — **this diff
  introduces none.**
- Mutation-checked, so the new assertions are not decorative: disabling the
  warm-up guard and re-hardcoding `"unusable agent"` fails 4 of the 5 new tests.
  The fifth asserts npm is *not* run, so it correctly survives both mutations.
- The time box was exercised directly: `timeout` kills a hung `npm` and returns
  124, which the `|| echo` catches — there is no wrapper shell between the two
  to swallow the signal.

**Not re-run on the device.** The heavy install path is already proven and was
deliberately not repeated. The warm-up's first live exercise is the next fleet
update, since it only runs on the update that actually re-clones.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hermes installation reliability by validating the installed version and repairing outdated or incomplete installations.
  - Failed upgrades now safely restore the previous working setup.
  - Added recovery for stale or unusable agents.
  - WhatsApp bridge dependencies are refreshed after successful Hermes reinstalls, while non-critical dependency failures no longer block completion.

- **Documentation**
  - Clarified how pinned Hermes upgrades and recovery behavior work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->