### PR TITLE
Hermes security hardening: pre-setup auth window, password oracle, root escalation, telemetry gating (TASK-443/444/445/446)

### DIFF
--- a/config/clawbox-root-step.sh
+++ b/config/clawbox-root-step.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+#
+# Root entrypoint for clawbox-root-update@<step>.service.
+#
+# Installed by install.sh to /usr/local/libexec/clawbox/clawbox-root-step.sh as
+# root:root 0755, under root-owned directories. That location matters: the unit
+# used to ExecStart /home/clawbox/clawbox/install.sh directly, and every path
+# component of that — the project dir, and install.sh itself — is writable by
+# the clawbox user the web server runs as. install.sh even hands the tree back
+# with `chown -R clawbox:clawbox` on every root run. So "clawbox may start
+# clawbox-root-update@*.service" meant "clawbox may edit the file root is about
+# to execute": a scoped NOPASSWD grant that is a one-step local root. TASK-445.
+#
+# This script cannot make install.sh itself immutable — the updater has to be
+# able to replace it — so it does the two things a root-owned entrypoint can:
+#
+#   1. Validates the instance name against its own allow-list. The sudoers grant
+#      is `clawbox-root-update@*.service`, so without this the step name is
+#      unvalidated input on the root side of the boundary.
+#
+#   2. Decides whether this step may self-update. install.sh's bootstrap block
+#      does `git fetch` + `git reset --hard origin/<branch>` + re-exec, and it
+#      ran on EVERY `--step` — including `chpasswd`. A password change must not
+#      reach out to the network, and must not be a way to pull new code onto the
+#      box. Only the update family gets CLAWBOX_ALLOW_SELF_UPDATE=1; everything
+#      else is pinned to the on-disk copy.
+#
+# Keep the two lists below in step with src/lib/root-steps.ts and install.sh's
+# DISPATCH_STEPS — src/tests/unit/root-steps.test.ts fails the build otherwise.
+
+set -euo pipefail
+
+PROJECT_DIR="/home/clawbox/clawbox"
+ENTRYPOINT="$PROJECT_DIR/install.sh"
+
+step="${1:-}"
+
+if [ -z "$step" ]; then
+  echo "clawbox-root-step: no step given" >&2
+  exit 64
+fi
+
+# Reject anything that isn't a plain step identifier before it reaches a case
+# match, a path, or a git ref.
+case "$step" in
+  *[!a-z0-9_]*)
+    echo "clawbox-root-step: refusing malformed step name: $step" >&2
+    exit 64
+    ;;
+esac
+
+# Every step the root-update template is allowed to run. Mirrors install.sh's
+# DISPATCH_STEPS.
+ALLOWED_STEPS="
+bootstrap_updater apt_update nvidia_jetpack performance_mode jtop_install
+ollama_install llamacpp_install llamacpp_model chromium_install ai_tools_install
+coding_harness vnc_install vnc_refresh openclaw_setup openclaw_install
+openclaw_patch openclaw_config openclaw_models openclaw_tts edition_lock
+edition_foreign_teardown hermes_install hermes_edition network_setup
+set_hostname setup_config system_config git_pull build rebuild rebuild_reboot
+restart restart_ap recover chpasswd gateway_setup ffmpeg_install polkit_rules
+systemd_services directories_permissions captive_portal_dns desktop_theme
+fix_git_perms browser_launch cloudflared_install nm_dispatcher sysctl_linkdown
+post_update update_smoke validate_services clawkeep_install
+"
+
+# Steps allowed to run install.sh's git fetch / reset --hard self-update.
+SELF_UPDATING_STEPS="
+bootstrap_updater git_pull build rebuild rebuild_reboot post_update update_smoke
+"
+
+contains() {
+  local needle="$1" haystack="$2" item
+  for item in $haystack; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+if ! contains "$step" "$ALLOWED_STEPS"; then
+  echo "clawbox-root-step: step not permitted: $step" >&2
+  exit 64
+fi
+
+if [ ! -f "$ENTRYPOINT" ]; then
+  echo "clawbox-root-step: $ENTRYPOINT is missing" >&2
+  exit 66
+fi
+
+if contains "$step" "$SELF_UPDATING_STEPS"; then
+  export CLAWBOX_ALLOW_SELF_UPDATE=1
+else
+  # Pin this run to the on-disk copy: no fetch, no reset --hard, no re-exec.
+  export CLAWBOX_INSTALL_BOOTSTRAPPED=1
+fi
+
+exec /bin/bash "$ENTRYPOINT" --step "$step"

--- a/config/clawbox-root-update@.service
+++ b/config/clawbox-root-update@.service
@@ -11,7 +11,14 @@ EnvironmentFile=-/etc/clawbox/network.env
 # directly (it is the authority, not this environment), but exporting it here
 # keeps anything the steps shell out to consistent with the resolved edition.
 EnvironmentFile=-/etc/clawbox/edition.env
-ExecStart=/bin/bash /home/clawbox/clawbox/install.sh --step %i
+# Root-owned entrypoint, outside every clawbox-writable directory. Pointing
+# ExecStart straight at /home/clawbox/clawbox/install.sh meant the clawbox user
+# — who the web server, the in-UI terminal and the agent's shell all run as —
+# could edit the file root was about to execute, turning the scoped
+# `clawbox-root-update@*.service` sudoers grant into a one-step local root. The
+# dispatcher also validates %i (that grant accepts ANY instance name) and only
+# lets the update family run install.sh's git-fetch/reset self-update. TASK-445.
+ExecStart=/usr/local/libexec/clawbox/clawbox-root-step.sh %i
 # 30 min was not enough for llamacpp_install on a cold box: that step builds
 # llama.cpp from source with CUDA on a 6-core Jetson Orin AND downloads the
 # multi-GB Gemma 4 GGUF. systemd killed the unit mid-build, so "Provisioning

--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -74,8 +74,13 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl enable  --now ollama.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl disable --now ollama.service
 
 # Update / power / install paths.
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reset-failed *
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block *
+#
+# `reset-failed *` and `start --no-block *` used to take ANY unit name. Both are
+# only ever called with a clawbox-* unit (src/lib/updater.ts, the llamacpp
+# installer, the credentials chpasswd path, install/run-step), so scope them to
+# that prefix rather than handing over the whole unit namespace. TASK-445.
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reset-failed clawbox-*
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block clawbox-*
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start clawbox-root-update@*.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff

--- a/config/sudoers-clawbox-ollama
+++ b/config/sudoers-clawbox-ollama
@@ -1,2 +1,9 @@
-# Allow clawbox user to optimize Ollama service without password
-clawbox ALL=(root) NOPASSWD: /home/clawbox/clawbox/scripts/optimize-ollama.sh
+# Allow clawbox user to optimize Ollama service without password.
+#
+# The target MUST be the root-owned copy under /usr/local/libexec/clawbox, not
+# the one in the project tree. /home/clawbox/clawbox/scripts/ is clawbox-owned
+# and clawbox-writable (as is the script, and every directory above it), so
+# granting NOPASSWD root on it let anything with clawbox-level code execution
+# overwrite the file and run it — no wildcard, no injection, no race needed.
+# install.sh installs this copy root:root 0755. TASK-445.
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/optimize-ollama.sh

--- a/e2e-install/10-setup-wizard.spec.ts
+++ b/e2e-install/10-setup-wizard.spec.ts
@@ -26,7 +26,7 @@ import {
   readInstallLog,
   waitForHttpReady,
 } from "./helpers/container";
-import { getStatus } from "./helpers/setup-api";
+import { getStatus, getStatusAuthed } from "./helpers/setup-api";
 
 const env = loadEnvTest();
 
@@ -172,11 +172,43 @@ test.describe("fresh-install setup wizard (UI)", () => {
   });
 
   test("setup is complete after the wizard", async () => {
+    // The wizard's progress flags are public — /login reads them with no
+    // session to decide whether to bounce an unfinished setup to /setup.
     const status = await getStatus();
     expect(status.setup_complete).toBe(true);
     expect(status.wifi_configured).toBe(true);
     expect(status.password_configured).toBe(true);
-    expect(status.ai_model_configured).toBe(true);
+
+    // Which provider the box got wired to is NOT public, so ask the way the
+    // desktop asks: with a session.
+    const authed = await getStatusAuthed();
+    expect(authed.ai_model_configured).toBe(true);
+  });
+
+  test("setup status does not leak provider detail to an anonymous caller", async () => {
+    // /setup-api/setup/status is public by design and is also served through
+    // the cloudflared tunnel, so whatever it returns unauthenticated is
+    // readable by anyone holding that URL. It must carry the wizard's progress
+    // and nothing else. The wizard above configured OpenAI, so if the trim
+    // regressed, `ai_model_provider` is sitting right here. TASK-446.
+    const anonymous = (await getStatus()) as unknown as Record<string, unknown>;
+
+    for (const field of [
+      "local_ai_configured",
+      "local_ai_provider",
+      "local_ai_model",
+      "ai_model_configured",
+      "ai_model_provider",
+      "telegram_configured",
+    ]) {
+      expect(anonymous, `${field} must not be readable without a session`).not.toHaveProperty(field);
+    }
+    expect(JSON.stringify(anonymous)).not.toContain("openai");
+
+    // ...and the same box does hand all of it back once you authenticate, so
+    // this is a gate, not a removed feature.
+    const authed = await getStatusAuthed();
+    expect(authed.ai_model_configured).toBe(true);
   });
 });
 

--- a/e2e-install/helpers/setup-api.ts
+++ b/e2e-install/helpers/setup-api.ts
@@ -69,11 +69,26 @@ export async function loginSessionCookie(
   );
 }
 
-export interface SetupStatus {
+/**
+ * What /setup-api/setup/status tells a caller with NO session.
+ *
+ * This route is the one deliberately public /setup-api endpoint (the /login
+ * page and the desktop bootstrap both read it before a session exists) AND it
+ * is reachable through the cloudflared tunnel, so its unauthenticated payload
+ * is readable by anyone holding that URL. It therefore carries only the
+ * wizard's own progress — which AI provider the box is wired to, which local
+ * model it runs and whether Telegram is configured are session-only.
+ */
+export interface SetupStatusPublic {
   setup_complete: boolean;
   wifi_configured: boolean;
   update_completed: boolean;
   password_configured: boolean;
+  setup_progress_step: number | null;
+}
+
+/** The full payload, served only to a caller with a session. */
+export interface SetupStatus extends SetupStatusPublic {
   local_ai_configured: boolean;
   local_ai_provider?: string | null;
   local_ai_model?: string | null;
@@ -81,7 +96,19 @@ export interface SetupStatus {
   telegram_configured: boolean;
 }
 
-export const getStatus = () => request<SetupStatus>("/setup-api/setup/status");
+/** The trimmed payload an anonymous caller sees. */
+export const getStatus = () => request<SetupStatusPublic>("/setup-api/setup/status");
+
+/**
+ * The full payload, fetched the way the desktop actually fetches it — with a
+ * session. Use this for anything beyond the wizard's progress flags.
+ */
+export async function getStatusAuthed(
+  password: string = SETUP_PASSWORD,
+): Promise<SetupStatus> {
+  const cookie = await loginSessionCookie(password);
+  return request<SetupStatus>("/setup-api/setup/status", { headers: { cookie } });
+}
 
 export const scanWifi = () =>
   request<{ scanning: boolean; networks: Array<{ ssid: string }> | null }>("/setup-api/wifi/scan?live=1", {

--- a/install.sh
+++ b/install.sh
@@ -29,7 +29,27 @@ fi
 # already registers. Pulling and re-exec'ing up-front (before constants are
 # parsed) breaks the race. CLAWBOX_INSTALL_BOOTSTRAPPED prevents recursion.
 
-if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] && [ -d "$(dirname "${BASH_SOURCE[0]}")/.git" ]; then
+# Only the update family may self-update. The root-owned dispatcher
+# (/usr/local/libexec/clawbox/clawbox-root-step.sh) sets CLAWBOX_ALLOW_SELF_UPDATE
+# for those steps and pins every other one with CLAWBOX_INSTALL_BOOTSTRAPPED=1.
+# A bare `sudo bash install.sh` (no --step) is an operator running a full
+# install and still bootstraps.
+#
+# This block used to run on EVERY invocation, so `--step chpasswd` did
+# `git fetch` + `git reset --hard origin/<branch>` + `chown -R clawbox` + re-exec
+# before it touched /etc/shadow. A password change must not depend on GitHub
+# being reachable, must not mutate the source tree, and must not be a way to
+# pull new code onto the box. The journal showed it firing for chpasswd,
+# set_hostname and validate_services. TASK-445.
+_clawbox_may_self_update() {
+  [ -n "${CLAWBOX_ALLOW_SELF_UPDATE:-}" ] && return 0
+  [ "${1:-}" != "--step" ] && return 0
+  return 1
+}
+
+if [ -z "${CLAWBOX_INSTALL_BOOTSTRAPPED:-}" ] \
+  && _clawbox_may_self_update "${1:-}" \
+  && [ -d "$(dirname "${BASH_SOURCE[0]}")/.git" ]; then
   _b="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   # Resolve the branch like resolve_update_branch() does below — explicit
   # CLAWBOX_BRANCH, else the pinned .update-branch, else the current branch,
@@ -2594,6 +2614,34 @@ step_persistent_journal() {
   # property of the Orin Nano dev kit, not something install.sh can correct.
 }
 
+# ── Root-owned entrypoints ───────────────────────────────────────────────────
+#
+# Anything root executes on behalf of the unprivileged clawbox web server must
+# live somewhere clawbox cannot write, or the privilege boundary is decorative.
+# /home/clawbox/clawbox and /home/clawbox/clawbox/scripts are both
+# clawbox-owned and group-writable, and install.sh's own bootstrap hands the
+# tree back with `chown -R clawbox:clawbox` on every root run — so a NOPASSWD
+# grant on a script in there is a one-step local root for anything with
+# clawbox-level code execution (the web server itself, the in-UI terminal, the
+# agent's shell). Copy them here instead, root:root, under root-owned dirs.
+# TASK-445.
+ROOT_LIBEXEC_DIR="/usr/local/libexec/clawbox"
+
+install_root_libexec() {
+  install -d -o root -g root -m 0755 /usr/local/libexec
+  install -d -o root -g root -m 0755 "$ROOT_LIBEXEC_DIR"
+  local src
+  for src in clawbox-root-step.sh; do
+    if [ -f "$PROJECT_DIR/config/$src" ]; then
+      install -o root -g root -m 0755 "$PROJECT_DIR/config/$src" "$ROOT_LIBEXEC_DIR/$src"
+    fi
+  done
+  if [ -f "$PROJECT_DIR/scripts/optimize-ollama.sh" ]; then
+    install -o root -g root -m 0755 "$PROJECT_DIR/scripts/optimize-ollama.sh" \
+      "$ROOT_LIBEXEC_DIR/optimize-ollama.sh"
+  fi
+}
+
 step_systemd_services() {
   local ALL_SERVICES=("${EXPECTED_ACTIVE_SERVICES[@]}" "${EXPECTED_INSTALLED_SERVICES[@]}")
   # The registry the drift guard checks against: this edition's install lists
@@ -2687,6 +2735,9 @@ step_systemd_services() {
   if [ ! -x /usr/local/bin/cloudflared ]; then
     systemctl disable --now clawbox-tunnel.service >/dev/null 2>&1 || true
   fi
+  # Root-owned copies of everything root executes on clawbox's behalf. Must run
+  # BEFORE the sudoers drop-in, which points at them.
+  install_root_libexec
   # Install sudoers rules so the clawbox user can manage services (systemctl restart, reboot, etc.)
   if [ -f "$PROJECT_DIR/config/clawbox-sudoers" ]; then
     cp "$PROJECT_DIR/config/clawbox-sudoers" /etc/sudoers.d/clawbox
@@ -3087,9 +3138,11 @@ step_performance_mode() {
   # snapd is kept running — required for snap-based Chromium on Ubuntu 22.04
   # Optimize Ollama for 8GB Jetson
   bash "$PROJECT_DIR/scripts/optimize-ollama.sh"
-  # Install sudoers rule so the web UI can run optimize-ollama.sh as root
+  # Install the root-owned copy the sudoers rule points at, then the rule.
+  install_root_libexec
   cp "$PROJECT_DIR/config/sudoers-clawbox-ollama" /etc/sudoers.d/clawbox-ollama
   chmod 440 /etc/sudoers.d/clawbox-ollama
+  chown root:root /etc/sudoers.d/clawbox-ollama
 }
 
 step_jtop_install() {

--- a/src/app/login-api/route.ts
+++ b/src/app/login-api/route.ts
@@ -13,18 +13,32 @@ export const dynamic = "force-dynamic";
 
 const VALID_DURATIONS = new Set([1200, 21600, 43200, 86400]);
 
-// On a LAN device the request socket IP isn't easy to recover from a
-// Next.js Request, and any client can spoof X-Forwarded-For. CF-Connecting-IP
-// is the only header upstream rewrites cleanly when the device is fronted by
-// the cloudflared tunnel; fall back to a single "global" bucket so an
-// IP-rotating attacker still hits the cap.
-// A trusted per-client key gets the full escalating lockout; the shared LAN
-// fallback bucket is capped (see maxLockMs) so it can't be used to lock the
-// owner out. `maxLockMs` undefined = no cap.
-function rateLimitKey(req: Request): { key: string; maxLockMs?: number } {
+// Every attempt is counted against TWO buckets, and both must be clear for the
+// attempt to proceed.
+//
+//   global      — always. Capped at SHARED_BUCKET_MAX_LOCK_MS (5 min) so it can
+//                 never be driven to the 24h tier and used to lock the owner
+//                 out, but it does throttle everyone, including an attacker who
+//                 is rotating headers.
+//   cf:<ip>     — when CF-Connecting-IP is present. Full escalating schedule up
+//                 to 24h, because behind the cloudflared tunnel that header is
+//                 rewritten by the edge and is a real per-client identity.
+//
+// Why both: the box serves plain HTTP on port 80 with no reverse proxy, so on
+// the LAN CF-Connecting-IP is just a header the client picks. Keying only on it
+// meant every new value minted a fresh, empty, un-capped bucket — the escalating
+// lockout was one `-H 'CF-Connecting-IP: <random>'` away from irrelevant, which
+// is exactly what the live validation demonstrated. The global bucket is now
+// always in the path, so header rotation buys an attacker nothing beyond the
+// 5-minute shared cap. X-Forwarded-For is still deliberately never consulted.
+// TASK-444c.
+function rateLimitBuckets(req: Request): Array<{ key: string; maxLockMs?: number }> {
+  const buckets: Array<{ key: string; maxLockMs?: number }> = [
+    { key: "global", maxLockMs: SHARED_BUCKET_MAX_LOCK_MS },
+  ];
   const cf = req.headers.get("cf-connecting-ip")?.trim();
-  if (cf) return { key: `cf:${cf}` };
-  return { key: "global", maxLockMs: SHARED_BUCKET_MAX_LOCK_MS };
+  if (cf) buckets.unshift({ key: `cf:${cf}` });
+  return buckets;
 }
 
 // Cookies are marked Secure only when the request actually arrived over HTTPS
@@ -55,12 +69,14 @@ function lockoutResponse(retryAfterSeconds: number): NextResponse {
 
 export async function POST(request: Request) {
   const startedAt = Date.now();
-  const { key, maxLockMs } = rateLimitKey(request);
+  const buckets = rateLimitBuckets(request);
 
-  const lock = await checkLockout(key);
-  if (lock.locked) {
-    await padResponseTime(startedAt);
-    return lockoutResponse(lock.retryAfterSeconds);
+  for (const bucket of buckets) {
+    const lock = await checkLockout(bucket.key);
+    if (lock.locked) {
+      await padResponseTime(startedAt);
+      return lockoutResponse(lock.retryAfterSeconds);
+    }
   }
 
   // If password not configured, check if this is an upgrade from a pre-auth version
@@ -97,15 +113,23 @@ export async function POST(request: Request) {
 
   const valid = await verifyPassword(password);
   if (!valid) {
-    const after = await recordFailure(key, { maxLockMs });
+    // Record against every bucket, then report the longest lock in force so the
+    // client's Retry-After is honest about when it can actually try again.
+    let worstRetryAfter = 0;
+    for (const bucket of buckets) {
+      const after = await recordFailure(bucket.key, { maxLockMs: bucket.maxLockMs });
+      if (after.locked) worstRetryAfter = Math.max(worstRetryAfter, after.retryAfterSeconds);
+    }
     await padResponseTime(startedAt);
-    if (after.locked) {
-      return lockoutResponse(after.retryAfterSeconds);
+    if (worstRetryAfter > 0) {
+      return lockoutResponse(worstRetryAfter);
     }
     return NextResponse.json({ error: "Incorrect password" }, { status: 401 });
   }
 
-  await recordSuccess(key);
+  // A correct password clears both buckets, so the owner who fat-fingers it a
+  // few times and then gets it right is not left sitting behind the shared cap.
+  for (const bucket of buckets) await recordSuccess(bucket.key);
 
   const secret = await getSessionSigningSecret();
   const gen = await getSessionGeneration();

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1721,7 +1721,7 @@ export async function POST(request: Request) {
       await ensureFallbackModel(shouldPromoteLocalToPrimary ? config.defaultModel : (isLocalScope ? null : config.defaultModel), config.defaultModel);
       // Ensure Ollama service has memory optimizations (q8_0 KV cache, flash attention)
       try {
-        await runCommand("sudo", ["/home/clawbox/clawbox/scripts/optimize-ollama.sh"]);
+        await runCommand("sudo", ["/usr/local/libexec/clawbox/optimize-ollama.sh"]);
       } catch (err) {
         // Non-fatal: Ollama will still work, just use more memory
         console.warn("[AI Config] Failed to optimize Ollama service:", err instanceof Error ? logSafe(err.message) : err);

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
+import { requireSession } from "@/lib/route-auth";
 import { reconcileLocalAiWithHermes } from "@/lib/hermes-local-ai";
 import {
   getModelOptions,
@@ -57,8 +58,22 @@ function unionModels(payload: ModelOptionsPayload): HermesModelOption[] {
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const refresh = flag(url.searchParams.get("refresh"));
   const provider = (url.searchParams.get("provider") || "").trim();
+
+  // `?refresh=1` is not a read: it busts Hermes' per-provider disk cache and
+  // fans out into a live /v1/models call per provider. An unauthenticated
+  // caller could therefore drive real upstream traffic and — before the
+  // downgrade guard in hermes-model-options.ts — swap a healthy 47-provider
+  // catalogue for the 2-provider disk fallback by timing it against a slow
+  // dashboard. The plain GET stays reachable for the wizard; the cache bust
+  // needs a session. Degrading to a read (rather than 401ing) keeps the panel
+  // rendering for a caller whose session expired mid-page. TASK-446.
+  let refresh = flag(url.searchParams.get("refresh"));
+  let refreshDenied = false;
+  if (refresh && (await requireSession(request))) {
+    refresh = false;
+    refreshDenied = true;
+  }
 
   // A device whose local model was enabled before Hermes knew how to host it
   // repairs itself here — once per process, and a no-op on every other device.
@@ -90,6 +105,14 @@ export async function GET(request: Request) {
         id: row.id,
         name: row.name,
         authenticated: row.authenticated,
+        // Same value, honestly named. `authenticated` means Hermes found an API
+        // key or a user-defined endpoint — presence, never a working
+        // credential. `verified` is the one that would mean it works, and is
+        // null until something actually probes the provider. A consumer that
+        // reads `authenticated` as "this will answer" is the reason a bogus
+        // provider looked healthy right up until the first turn 403'd.
+        credentialPresent: row.authenticated,
+        verified: row.verified,
         isUserDefined: row.isUserDefined,
         source: row.source,
         total: row.total,
@@ -98,6 +121,8 @@ export async function GET(request: Request) {
       source: payload.source,
       stale: payload.stale,
       fetchedAt: payload.fetchedAt,
+      ...(payload.degraded ? { degraded: payload.degraded } : {}),
+      ...(refreshDenied ? { refreshDenied: true } : {}),
     });
   } catch {
     // Never surface the dashboard origin, its password, or the hermes binary

--- a/src/app/setup-api/install/run-step/route.ts
+++ b/src/app/setup-api/install/run-step/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { requireSession } from "@/lib/route-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -54,6 +55,12 @@ async function getJournalTail(unit: string): Promise<string> {
 }
 
 export async function POST(req: Request) {
+  // Starts clawbox-root-update@<step>.service, which runs install.sh as root.
+  // Its only callers are VNCApp and RemoteControlPanel — desktop apps, always
+  // post-setup — so it fails closed unconditionally. TASK-443/445.
+  const unauthorized = await requireSession(req);
+  if (unauthorized) return unauthorized;
+
   let step: string;
   try {
     const body = (await req.json()) as { step?: unknown };

--- a/src/app/setup-api/install/run-step/route.ts
+++ b/src/app/setup-api/install/run-step/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { requireSession } from "@/lib/route-auth";
+import { UI_ROOT_STEPS } from "@/lib/root-steps";
 
 export const dynamic = "force-dynamic";
 
@@ -15,25 +16,16 @@ const execFileAsync = promisify(execFile);
 // until the install step finishes so the UI can chain a reboot or refresh
 // on success.
 //
-// Steps are whitelisted here on top of install.sh's own DISPATCH_STEPS
-// list. Only steps that are safe to invoke from a clicked button in the
-// UI go in. Anything that would reboot, modify networking, or wipe state
-// stays out — we don't want a one-tap escalation surface.
-const ALLOWED_STEPS = new Set([
-  "cloudflared_install",
-  "vnc_install",
-  "vnc_refresh",
-  "chromium_install",
-  "ai_tools_install",
-  "ollama_install",
-  "llamacpp_install",
-  "ffmpeg_install",
-  "openclaw_install",
-  "openclaw_setup",
-  "openclaw_patch",
-  "openclaw_config",
-  "clawkeep_install",
-]);
+// Steps are whitelisted on top of install.sh's own DISPATCH_STEPS list. Only
+// steps that are safe to invoke from a clicked button in the UI go in. Anything
+// that would reboot, modify networking, or wipe state stays out — we don't want
+// a one-tap escalation surface.
+//
+// This list is advisory-in-depth: the sudoers grant is
+// `clawbox-root-update@*.service`, so the authoritative check is the one the
+// root-owned dispatcher does (config/clawbox-root-step.sh). Keeping both in
+// src/lib/root-steps.ts is what lets a test pin them together. TASK-445.
+const ALLOWED_STEPS = new Set(UI_ROOT_STEPS);
 
 // Most install steps complete in ~30-120s on a warm Jetson. vnc_install /
 // chromium_install can take several minutes when apt has to fetch fresh.

--- a/src/app/setup-api/ollama/pull/route.ts
+++ b/src/app/setup-api/ollama/pull/route.ts
@@ -2,10 +2,18 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { ensureLocalAiReady, getOllamaBaseUrl } from "@/lib/local-ai-runtime";
+import { requireSession } from "@/lib/route-auth";
 
 const OLLAMA_BASE = getOllamaBaseUrl();
 
 export async function POST(request: Request) {
+  // A bodyless POST used to default to pulling llama3.2:3b, so an anonymous
+  // caller on the setup AP could fill the disk one multi-GB pull at a time.
+  // Local Models is a desktop/AIModelsStep surface and both are authenticated
+  // by the time they run, so it fails closed. TASK-443.
+  const unauthorized = await requireSession(request);
+  if (unauthorized) return unauthorized;
+
   let body: { model?: string };
   try {
     body = await request.json();

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { requireSession } from "@/lib/route-auth";
 import { resetUpdateState } from "@/lib/updater";
 import { DATA_DIR } from "@/lib/config-store";
 import { CLAWKEEP_DATA_DIR } from "@/lib/clawkeep";
@@ -385,7 +386,16 @@ function scheduleReboot(): void {
   }, 1_000);
 }
 
-export async function POST() {
+export async function POST(request: Request) {
+  // Factory reset wipes data/, ~/.openclaw, ~/.hermes and reboots. It has no
+  // onboarding role whatsoever, so it never gets the bootstrap carve-out: no
+  // session, no reset, on any device state. This handler USED to be
+  // `export async function POST()` — zero parameters, so it could not read a
+  // cookie even in principle — and an unauthenticated POST really did wipe the
+  // QA box on 2026-08-22T00:04Z. TASK-443.
+  const unauthorized = await requireSession(request);
+  if (unauthorized) return unauthorized;
+
   try {
     resetUpdateState();
 

--- a/src/app/setup-api/setup/status/route.ts
+++ b/src/app/setup-api/setup/status/route.ts
@@ -1,10 +1,20 @@
 import { NextResponse } from "next/server";
 import { getAll } from "@/lib/config-store";
 import { inferConfiguredLocalModel, readConfig as readOpenClawConfig, type OpenClawConfig } from "@/lib/openclaw-config";
+import { hasValidSession } from "@/lib/route-auth";
 
 export const dynamic = "force-dynamic";
 
-export async function GET() {
+export async function GET(request: Request) {
+  // The one genuinely public /setup-api route: /login and the desktop bootstrap
+  // read it before a session exists, and it stays reachable through the
+  // cloudflared tunnel. So an unauthenticated caller gets only what those
+  // bootstraps need — the wizard's own progress. Which local model the box
+  // runs, which cloud provider it is configured against and whether Telegram is
+  // wired up are operational detail that was world-readable to anyone holding
+  // the tunnel URL. TASK-446.
+  const authenticated = await hasValidSession(request);
+
   try {
     const [config, openclawConfig] = await Promise.all([
       getAll(),
@@ -32,19 +42,26 @@ export async function GET() {
     const setupProgressStep = typeof config.setup_progress_step === "number"
       ? config.setup_progress_step
       : Number(config.setup_progress_step ?? 0);
-    return NextResponse.json({
+    // Steps 1-3 of the wizard run before a session can exist, so their state
+    // stays public; everything below is step 4+ and is behind the same session
+    // the wizard holds by then.
+    const publicFields = {
       setup_complete: !!config.setup_complete,
       password_configured: !!config.password_configured,
       update_completed: !!config.update_completed,
       wifi_configured: !!config.wifi_configured,
       setup_progress_step: Number.isInteger(setupProgressStep) && setupProgressStep > 0 ? setupProgressStep : null,
+    };
+
+    return NextResponse.json(authenticated ? {
+      ...publicFields,
       local_ai_configured: localAiConfigured,
       local_ai_provider: localAiProvider,
       local_ai_model: localAiModel,
       ai_model_configured: !!config.ai_model_configured,
       ai_model_provider: liveCloudProvider || config.ai_model_provider || null,
       telegram_configured: !!config.telegram_bot_token,
-    }, {
+    } : publicFields, {
       headers: {
         "Cache-Control": "no-store",
       },

--- a/src/app/setup-api/system/credentials/route.ts
+++ b/src/app/setup-api/system/credentials/route.ts
@@ -7,12 +7,18 @@ import { get, set } from "@/lib/config-store";
 import { CHPASSWD_INPUT_PATH, CHPASSWD_SERVICE_NAME, chpasswdRecord } from "@/lib/chpasswd";
 import { getSystemUsername, verifyPassword, isSafePasswordChars, bumpSessionGeneration, createSessionCookie, getSessionSigningSecret } from "@/lib/auth";
 import { checkRateLimit, clientIp, resetRateLimit } from "@/lib/rate-limit";
+import { hasSystemPassword } from "@/lib/system-password";
+import { requireSession } from "@/lib/route-auth";
 
 export const dynamic = "force-dynamic";
 
 const execFile = promisify(execFileCb);
 
 const PASSWORD_RATE_LIMIT = { windowMs: 15 * 60 * 1000, max: 5 };
+
+// Lifetime of the session minted on the first-boot password set. 24h matches
+// the default the login page offers and the fallback the change path uses.
+const INITIAL_SESSION_SECONDS = 86400;
 
 // Cookies are marked Secure only over HTTPS (tunnel); plain-HTTP LAN must stay
 // non-Secure or the browser would never send the cookie back.
@@ -78,8 +84,27 @@ export async function POST(request: Request) {
     // After the initial setup, require the current password to make a change.
     // During first-boot setup (no password configured yet), CredentialsStep
     // calls this without `currentPassword` to set the initial value.
-    const passwordAlreadyConfigured = !!(await get("password_configured"));
+    //
+    // /etc/shadow is consulted as well as the config flag, and either one
+    // saying "there is a password" is enough (TASK-444a). The flag alone is a
+    // cache that a factory reset wipes and a partial restore can drop; on a box
+    // where config.json says "no password" but the account really has one, the
+    // old check skipped `currentPassword` entirely and let an unauthenticated
+    // caller take the OS account over. `hasSystemPassword()` returns null when
+    // it cannot tell, which is deliberately NOT treated as "no password".
+    const flagSaysConfigured = !!(await get("password_configured"));
+    const shadowSaysConfigured = await hasSystemPassword();
+    const passwordAlreadyConfigured = flagSaysConfigured || shadowSaysConfigured === true;
+
     if (passwordAlreadyConfigured) {
+      // Defence in depth behind middleware: changing the owner's password is
+      // never part of onboarding once an owner exists, so it needs a session
+      // even if the middleware gate is somehow bypassed. Re-proving
+      // `currentPassword` below is necessary but not sufficient — without this
+      // the route is also an unauthenticated password oracle.
+      const unauthorized = await requireSession(request);
+      if (unauthorized) return unauthorized;
+
       if (!currentPassword) {
         return NextResponse.json({ error: "Current password is required" }, { status: 400 });
       }
@@ -142,7 +167,31 @@ export async function POST(request: Request) {
       }
     }
 
-    return NextResponse.json({ success: true });
+    // First-boot initial set: mint the owner's session here.
+    //
+    // This is what lets the bootstrap allow-list stay as small as it is. The
+    // wizard's remaining steps (AI models, Telegram, setup/complete) and even
+    // the hotspot write CredentialsStep makes immediately after this call now
+    // run authenticated, so none of them needs a pre-auth carve-out — and the
+    // window in which the device answers anything unauthenticated ends the
+    // moment it has an owner. Best-effort, exactly like the re-issue path
+    // above: the password is already set, so failing to mint the cookie must
+    // not 500. Worst case the user sees /login and signs in with the password
+    // they just chose. TASK-443.
+    try {
+      const secret = await getSessionSigningSecret();
+      const res = NextResponse.json({ success: true, authenticated: true });
+      res.cookies.set("clawbox_session", createSessionCookie(INITIAL_SESSION_SECONDS, secret, 0), {
+        httpOnly: true,
+        sameSite: "lax",
+        path: "/",
+        maxAge: INITIAL_SESSION_SECONDS,
+        secure: requestIsHttps(request),
+      });
+      return res;
+    } catch {
+      return NextResponse.json({ success: true });
+    }
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to set password" },

--- a/src/app/setup-api/system/credentials/verify/route.ts
+++ b/src/app/setup-api/system/credentials/verify/route.ts
@@ -1,24 +1,99 @@
 import { NextResponse } from "next/server";
 import { verifyPassword } from "@/lib/auth";
-import { checkRateLimit, clientIp } from "@/lib/rate-limit";
+import { requireSession } from "@/lib/route-auth";
+import {
+  checkLockout,
+  recordFailure,
+  recordSuccess,
+  padResponseTime,
+  SHARED_BUCKET_MAX_LOCK_MS,
+} from "@/lib/login-rate-limit";
 
 export const dynamic = "force-dynamic";
 
-const PASSWORD_RATE_LIMIT = { windowMs: 15 * 60 * 1000, max: 5 };
+/**
+ * Re-prove the current OS password (SettingsApp asks for it before a password
+ * change and before factory reset).
+ *
+ * This route is a right/wrong password oracle, so it must be exactly as
+ * expensive to ask as /login-api is — it used to answer in ~64 ms against
+ * /login-api's 300 ms pad, and it used the in-memory per-XFF `rate-limit.ts`
+ * bucket, which a client can reset at will by changing a header it fully
+ * controls. An attacker who could reach it therefore had a fast, effectively
+ * unthrottled oracle sitting next to a carefully throttled login. TASK-444b.
+ *
+ * Now it shares /login-api's machinery outright: the same persisted escalating
+ * lockout, the same shared-bucket cap, and the same MIN_RESPONSE_MS pad on
+ * every exit path — including the 400s, so "malformed request" and "wrong
+ * password" are indistinguishable by timing too.
+ */
+
+/** Same dual-bucket keying as /login-api — see the comment there. */
+function lockoutBuckets(req: Request): Array<{ key: string; maxLockMs?: number }> {
+  const buckets: Array<{ key: string; maxLockMs?: number }> = [
+    { key: "global", maxLockMs: SHARED_BUCKET_MAX_LOCK_MS },
+  ];
+  const cf = req.headers.get("cf-connecting-ip")?.trim();
+  if (cf) buckets.unshift({ key: `cf:${cf}` });
+  return buckets;
+}
+
+function lockoutResponse(retryAfterSeconds: number): NextResponse {
+  return NextResponse.json(
+    { error: "Too many attempts. Please try again later.", retryAfterSeconds },
+    { status: 429, headers: { "Retry-After": String(retryAfterSeconds) } },
+  );
+}
 
 export async function POST(request: Request) {
-  const ip = clientIp(request);
-  if (!checkRateLimit("password", ip, PASSWORD_RATE_LIMIT)) {
-    return NextResponse.json({ error: "Too many attempts. Please try again later." }, { status: 429 });
+  const startedAt = Date.now();
+
+  // Verifying a password has no first-boot role: CredentialsStep sets the
+  // initial password, it never re-proves one. So no bootstrap carve-out — this
+  // never answers an anonymous caller.
+  const unauthorized = await requireSession(request);
+  if (unauthorized) {
+    await padResponseTime(startedAt);
+    return unauthorized;
+  }
+
+  const buckets = lockoutBuckets(request);
+  for (const bucket of buckets) {
+    const lock = await checkLockout(bucket.key);
+    if (lock.locked) {
+      await padResponseTime(startedAt);
+      return lockoutResponse(lock.retryAfterSeconds);
+    }
   }
 
   let body: { password?: string };
-  try { body = await request.json(); } catch { return NextResponse.json({ error: "Invalid JSON" }, { status: 400 }); }
+  try {
+    body = await request.json();
+  } catch {
+    await padResponseTime(startedAt);
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
 
   const password = body.password ?? "";
-  if (!password) return NextResponse.json({ error: "Password is required" }, { status: 400 });
+  if (!password) {
+    await padResponseTime(startedAt);
+    return NextResponse.json({ error: "Password is required" }, { status: 400 });
+  }
 
   const ok = await verifyPassword(password);
-  if (!ok) return NextResponse.json({ error: "Incorrect password" }, { status: 401 });
+  if (!ok) {
+    let worst = 0;
+    for (const bucket of buckets) {
+      const after = await recordFailure(bucket.key, { maxLockMs: bucket.maxLockMs });
+      if (after.locked) worst = Math.max(worst, after.retryAfterSeconds);
+    }
+    await padResponseTime(startedAt);
+    if (worst > 0) return lockoutResponse(worst);
+    return NextResponse.json({ error: "Incorrect password" }, { status: 401 });
+  }
+
+  for (const bucket of buckets) await recordSuccess(bucket.key);
+
+  await padResponseTime(startedAt);
   return NextResponse.json({ ok: true });
 }

--- a/src/app/setup-api/system/power/route.ts
+++ b/src/app/setup-api/system/power/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { execFile } from "child_process";
 import { promisify } from "util";
+import { requireSession } from "@/lib/route-auth";
 
 const execFileAsync = promisify(execFile);
 
@@ -12,6 +13,14 @@ const POWER_ACTIONS: Record<string, string> = {
 };
 
 export async function POST(req: Request) {
+  // Shutdown/reboot is only ever driven from the desktop (SettingsApp, the
+  // taskbar power menu) or the MCP `system_power` tool, both of which are
+  // authenticated. Nothing in the wizard calls it, so there is no bootstrap
+  // carve-out — an anonymous POST could otherwise power the box off from
+  // radio range of the open setup AP. TASK-443.
+  const unauthorized = await requireSession(req);
+  if (unauthorized) return unauthorized;
+
   let action: unknown;
   try {
     ({ action } = await req.json());

--- a/src/app/setup-api/update/run/route.ts
+++ b/src/app/setup-api/update/run/route.ts
@@ -2,8 +2,17 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { startUpdate, isUpdateCompleted } from "@/lib/updater";
+import { requireSession } from "@/lib/route-auth";
 
 export async function POST(request: Request) {
+  // The one destructive route the wizard genuinely needs before a password can
+  // exist (UpdateStep is step 2, CredentialsStep is step 3), so it takes the
+  // bootstrap carve-out — but only that. The moment `password_configured` (or
+  // /etc/shadow) says the device has an owner, an anonymous caller can no
+  // longer start a root-privileged git-pull-and-rebuild. TASK-443/445.
+  const unauthorized = await requireSession(request, { allowBootstrap: true });
+  if (unauthorized) return unauthorized;
+
   try {
     let force = false;
     try {

--- a/src/app/setup-api/wifi/connect/route.ts
+++ b/src/app/setup-api/wifi/connect/route.ts
@@ -6,10 +6,19 @@ import {
   type ConnectFailReason,
 } from "@/lib/network";
 import { set, setMany } from "@/lib/config-store";
+import { requireSession } from "@/lib/route-auth";
 
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request) {
+  // WifiStep is step 1, before any password can exist, so this takes the
+  // bootstrap carve-out. Post-password it needs a session: joining the box to
+  // an attacker-chosen SSID takes it off the owner's LAN, and a WPA password
+  // typed into `nmcli` is a credential the caller shouldn't be able to plant
+  // anonymously. TASK-443.
+  const unauthorized = await requireSession(request, { allowBootstrap: true });
+  if (unauthorized) return unauthorized;
+
   let body: { ssid?: unknown; password?: unknown; skip?: unknown };
   try {
     body = await request.json();

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -69,6 +69,20 @@ const COLD_START_MODELS: Record<string, string[]> = {
 
 export type ModelOptionsSource = "dashboard" | "catalog-file" | "cold-start";
 
+/**
+ * How much a payload is worth, high to low. Used to stop a degraded read from
+ * evicting a better cached one — see `load()`.
+ *
+ * `dashboard` is the live catalogue (47 providers on the QA box). `catalog-file`
+ * is Hermes' on-disk manifest, which in practice holds 2. `cold-start` is the
+ * hardcoded floor.
+ */
+const SOURCE_RANK: Record<ModelOptionsSource, number> = {
+  dashboard: 3,
+  "catalog-file": 2,
+  "cold-start": 1,
+};
+
 export interface HermesModelOption {
   id: string;
   description: string;
@@ -81,8 +95,28 @@ export interface HermesModelOption {
 export interface HermesProviderRow {
   id: string;
   name: string;
-  /** null when the source can't tell (the on-disk catalog carries no auth state). */
+  /**
+   * Hermes' `authenticated` flag, verbatim.
+   *
+   * It means "this provider has an API key set, or is a user-defined
+   * endpoint" — credential PRESENCE, not a working credential. Hermes derives
+   * it from `not is_skeleton`, never from a call to the provider. A row can be
+   * `authenticated: true` and still 403 on every turn, which is exactly what
+   * made a bogus user-defined provider look healthy in the picker. Prefer
+   * `credentialPresent` when reading this; see `verified` for the other half.
+   *
+   * null when the source can't tell (the on-disk catalog carries no auth state).
+   */
   authenticated: boolean | null;
+  /**
+   * Whether a credential was actually exercised against the provider:
+   * `true`/`false` when something upstream probed it, `null` when nobody did.
+   *
+   * ClawBox performs no probe of its own, so this is `null` unless the Hermes
+   * envelope carries it — but it is a distinct field so a consumer can no
+   * longer read "has a key" as "works". TASK-446.
+   */
+  verified: boolean | null;
   isUserDefined: boolean;
   source: string;
   total: number;
@@ -101,6 +135,13 @@ export interface ModelOptionsPayload {
   source: ModelOptionsSource;
   /** True when the payload did not come from the live dashboard. */
   stale: boolean;
+  /**
+   * Set when a live read failed and the caller is being served the previous,
+   * better cached payload instead of the thin fallback. The client can say
+   * "couldn't refresh" rather than silently rendering 2 providers where 47
+   * were a moment ago.
+   */
+  degraded?: "dashboard-unreachable";
 }
 
 export interface ProviderScope {
@@ -188,6 +229,7 @@ interface DashboardProviderRow {
   total_models?: unknown;
   source?: unknown;
   authenticated?: unknown;
+  verified?: unknown;
   is_user_defined?: unknown;
   warning?: unknown;
   featured_models?: unknown;
@@ -314,6 +356,7 @@ function normalizeRow(raw: DashboardProviderRow, localModelId: string): HermesPr
     id,
     name: asString(raw.name) || id,
     authenticated: typeof raw.authenticated === "boolean" ? raw.authenticated : null,
+    verified: typeof raw.verified === "boolean" ? raw.verified : null,
     isUserDefined: raw.is_user_defined === true,
     source: asString(raw.source) || "unknown",
     // `total_models` is the dashboard's count; after seeding it would understate
@@ -413,6 +456,7 @@ async function readDiskCatalog(): Promise<HermesProviderRow[] | null> {
       name: slug,
       // The manifest carries no credential state — say "unknown", never "yes".
       authenticated: null,
+      verified: null,
       isUserDefined: false,
       source: "catalog-file",
       total: models.length,
@@ -480,6 +524,7 @@ async function buildPayload(refresh: boolean): Promise<ModelOptionsPayload> {
       id,
       name: id,
       authenticated: null,
+      verified: null,
       isUserDefined: true,
       source: "cold-start",
       total: ids.length,
@@ -493,6 +538,19 @@ async function buildPayload(refresh: boolean): Promise<ModelOptionsPayload> {
   };
 }
 
+/**
+ * True when `next` is a worse answer than the `previous` one still in cache and
+ * that cached answer has not aged out.
+ *
+ * Only downgrades are refused. An equal-or-better source always installs, so a
+ * dashboard read that legitimately returns fewer providers (a key was removed)
+ * still lands, and a stale-but-good cache still expires on its own schedule.
+ */
+function isDowngrade(next: ModelOptionsPayload, previous: ModelOptionsPayload): boolean {
+  if (SOURCE_RANK[next.source] >= SOURCE_RANK[previous.source]) return false;
+  return Date.now() - previous.fetchedAt < STALE_MS;
+}
+
 function load(refresh: boolean): Promise<ModelOptionsPayload> {
   // Single-flight PER MODE. Concurrent callers share one dashboard round-trip,
   // but an explicit refresh must never be satisfied by a plain in-flight load:
@@ -504,8 +562,21 @@ function load(refresh: boolean): Promise<ModelOptionsPayload> {
   if (existing) return existing;
 
   const gen = generation;
+  const previous = cached;
   const run = buildPayload(refresh)
     .then((payload) => {
+      // A dashboard timeout makes buildPayload fall back to the 2-provider disk
+      // manifest. Installing that over a healthy 47-provider cache — which is
+      // what used to happen, unconditionally — turns one transient 8 s timeout
+      // into a device that has apparently lost 45 providers, and a `?refresh=1`
+      // an anonymous caller could trigger into a catalogue-poisoning primitive.
+      // Serve the better payload we already have and SAY that the refresh
+      // failed. TASK-446.
+      if (previous && isDowngrade(payload, previous)) {
+        const kept: ModelOptionsPayload = { ...previous, degraded: "dashboard-unreachable" };
+        if (gen === generation) cached = kept;
+        return kept;
+      }
       // A config write landed while we were reading, so this payload's
       // `current` is pre-write. Hand it to the caller that asked for it, but
       // never let it become the cache for everyone else.

--- a/src/lib/root-steps.ts
+++ b/src/lib/root-steps.ts
@@ -1,0 +1,65 @@
+/**
+ * Which `install.sh --step <name>` invocations the web server may start as
+ * root, and which of them are allowed to touch the network and the source tree.
+ *
+ * The privilege hand-off is: clawbox-setup (User=clawbox) →
+ * `systemctl start clawbox-root-update@<step>.service` → install.sh as root.
+ * The sudoers grant for that is `clawbox-root-update@*.service`, i.e. any
+ * instance name at all — so the step name is attacker-influenced input on the
+ * root side of the boundary, and the only real check is whatever the root-owned
+ * entrypoint does with it. That check lives in
+ * config/clawbox-root-step.sh, which is installed root-owned outside the
+ * clawbox-writable tree; the lists here are the same data for the TypeScript
+ * side, and `root-steps.test.ts` pins the two together. TASK-445.
+ */
+
+/**
+ * Steps a UI button may start. A subset of install.sh's DISPATCH_STEPS:
+ * anything that reboots, rewrites networking or wipes state stays out, so a
+ * one-tap escalation surface never exists.
+ */
+export const UI_ROOT_STEPS: readonly string[] = [
+  "cloudflared_install",
+  "vnc_install",
+  "vnc_refresh",
+  "chromium_install",
+  "ai_tools_install",
+  "ollama_install",
+  "llamacpp_install",
+  "ffmpeg_install",
+  "openclaw_install",
+  "openclaw_setup",
+  "openclaw_patch",
+  "openclaw_config",
+  "clawkeep_install",
+];
+
+/**
+ * Steps that are allowed to run install.sh's self-update bootstrap —
+ * `git fetch` + `git reset --hard origin/<branch>` + re-exec.
+ *
+ * Everything else runs with `CLAWBOX_INSTALL_BOOTSTRAPPED=1` pre-set so the
+ * bootstrap block is skipped. It used to run on EVERY `--step`, which meant a
+ * password change reached out to the network and hard-reset the source tree
+ * before touching /etc/shadow: the journal shows it firing for `chpasswd`,
+ * `set_hostname` and `validate_services`. A credential change must not depend
+ * on GitHub being reachable, and must not be a vector for pulling new code.
+ * TASK-445.
+ */
+export const SELF_UPDATING_ROOT_STEPS: readonly string[] = [
+  "bootstrap_updater",
+  "git_pull",
+  "build",
+  "rebuild",
+  "rebuild_reboot",
+  "post_update",
+  "update_smoke",
+];
+
+export function isUiRootStep(step: string): boolean {
+  return UI_ROOT_STEPS.includes(step);
+}
+
+export function maySelfUpdate(step: string): boolean {
+  return SELF_UPDATING_ROOT_STEPS.includes(step);
+}

--- a/src/lib/route-auth.ts
+++ b/src/lib/route-auth.ts
@@ -129,7 +129,18 @@ function verifySignedCookie(cookie: string, secret: string, expectedGen: number)
   }
 }
 
-/** True when the request carries a valid session cookie or the MCP bearer. */
+/**
+ * True when the request carries a valid session cookie or the MCP bearer.
+ *
+ * Deliberately does NOT honour `CLAWBOX_TEST_MODE`, unlike `requireSession`
+ * below. The two answer different questions: `requireSession` is a GATE ("may
+ * this request run at all"), and test mode is the documented escape hatch that
+ * opens the whole /setup-api surface to the e2e-install harness. This is an
+ * IDENTITY question ("is this the owner"), asked by handlers that shape their
+ * response — `setup/status` serves a trimmed payload to anyone who isn't. A
+ * harness that can reach a route still isn't the owner, and letting test mode
+ * say otherwise would mean the trimmed payload is never exercised end-to-end.
+ */
 export async function hasValidSession(request: Request | undefined): Promise<boolean> {
   // Next.js always hands a Request to a route handler; a caller that doesn't
   // (an older test, a direct invocation) gets "not authenticated" rather than

--- a/src/lib/route-auth.ts
+++ b/src/lib/route-auth.ts
@@ -1,0 +1,168 @@
+/**
+ * In-handler authentication for /setup-api/* route handlers.
+ *
+ * Middleware (src/middleware.ts) is the primary gate, but it is one
+ * hand-maintained list in front of a ~100-route surface: one mis-ordered
+ * `startsWith`, one rewrite, one route reached by a path the matcher doesn't
+ * cover, and a destructive handler runs unauthenticated. TASK-443's
+ * factory-reset incident is exactly that failure mode — `setup/reset` was
+ * `export async function POST()`, a handler that could not have read a cookie
+ * if it wanted to.
+ *
+ * So the destructive handlers check for themselves too. `requireSession`
+ * returns a 401 NextResponse to return verbatim, or `null` to proceed.
+ *
+ * Deliberately self-contained: this module reads data/config.json and
+ * data/.session-secret directly rather than going through `@/lib/config-store`
+ * and `@/lib/auth`. That mirrors middleware's own resolution (so the two can't
+ * drift), keeps the second line of defence independent of the app modules it is
+ * defending, and means a route test that mocks config-store doesn't
+ * accidentally mock the auth check out of existence.
+ */
+
+import { NextResponse } from "next/server";
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import { verifyMcpBearer } from "./mcp-token";
+import { hasSystemPassword } from "./system-password";
+
+function dataDir(): string {
+  const root = process.env.CLAWBOX_ROOT
+    || (process.env.NODE_ENV === "development" ? process.cwd() : "/home/clawbox/clawbox");
+  return path.join(root, "data");
+}
+
+interface ConfigFacts {
+  passwordConfigured: boolean;
+  sessionGeneration: number;
+}
+
+/**
+ * Fail-closed config read. A config.json that is genuinely absent is a
+ * first-boot device (no owner). Any other read/parse failure is a provisioned
+ * box with a damaged file, and is treated as "has an owner" so a corrupt or
+ * clobbered config can't reopen the bootstrap window.
+ */
+function readConfigFacts(): ConfigFacts {
+  try {
+    const raw = fs.readFileSync(path.join(dataDir(), "config.json"), "utf-8");
+    const parsed = JSON.parse(raw) as { password_configured?: unknown; session_generation?: unknown };
+    const gen = typeof parsed.session_generation === "number" && Number.isFinite(parsed.session_generation)
+      ? parsed.session_generation
+      : 0;
+    return { passwordConfigured: parsed.password_configured === true, sessionGeneration: gen };
+  } catch (err) {
+    const missing = (err as NodeJS.ErrnoException)?.code === "ENOENT";
+    return { passwordConfigured: !missing, sessionGeneration: 0 };
+  }
+}
+
+function sessionSecret(): string | null {
+  const fromEnv = process.env.SESSION_SECRET?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const onDisk = fs.readFileSync(path.join(dataDir(), ".session-secret"), "utf-8").trim();
+    return onDisk.length >= 32 ? onDisk : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface RequireSessionOptions {
+  /**
+   * Let the request through while the device is in the genuine first-boot
+   * bootstrap window — no password has ever been set, so there is no owner to
+   * authenticate as and no credential to protect. Set this ONLY for routes the
+   * wizard must reach before CredentialsStep runs (wifi/connect, update/run).
+   * Everything destructive leaves it false and fails closed.
+   */
+  allowBootstrap?: boolean;
+}
+
+/**
+ * True once the device has an owner credential — the point from which every
+ * sensitive route must fail closed.
+ *
+ * Checks BOTH sources deliberately. `password_configured` lives in
+ * data/config.json, which factory reset wipes and a partial restore can drop;
+ * /etc/shadow is the real thing. TASK-444a is precisely that drift: config.json
+ * says "no password" while the account has one, and the initial-set path
+ * re-opens to an anonymous caller.
+ */
+export async function deviceHasOwner(): Promise<boolean> {
+  if (readConfigFacts().passwordConfigured) return true;
+  return (await hasSystemPassword()) === true;
+}
+
+function readSessionCookie(request: Request): string | null {
+  const raw = request.headers.get("cookie");
+  if (!raw) return null;
+  const m = /(?:^|;\s*)clawbox_session=([^;]*)/.exec(raw);
+  if (!m || !m[1]) return null;
+  try {
+    return decodeURIComponent(m[1]);
+  } catch {
+    return m[1];
+  }
+}
+
+function verifySignedCookie(cookie: string, secret: string, expectedGen: number): boolean {
+  const dot = cookie.indexOf(".");
+  if (dot < 0) return false;
+  const payload = cookie.slice(0, dot);
+  const sig = cookie.slice(dot + 1);
+  if (!payload || !/^[0-9a-f]{64}$/i.test(sig)) return false;
+
+  try {
+    const expected = crypto.createHmac("sha256", secret).update(payload).digest("hex");
+    const a = Buffer.from(sig.toLowerCase(), "hex");
+    const b = Buffer.from(expected, "hex");
+    if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return false;
+
+    const data = JSON.parse(Buffer.from(payload, "base64url").toString());
+    if (typeof data.exp !== "number" || data.exp <= Math.floor(Date.now() / 1000)) return false;
+    // Cookies minted before the last password change are revoked.
+    return (typeof data.gen === "number" ? data.gen : 0) === expectedGen;
+  } catch {
+    return false;
+  }
+}
+
+/** True when the request carries a valid session cookie or the MCP bearer. */
+export async function hasValidSession(request: Request | undefined): Promise<boolean> {
+  // Next.js always hands a Request to a route handler; a caller that doesn't
+  // (an older test, a direct invocation) gets "not authenticated" rather than
+  // a TypeError that a `catch` upstream could turn into a success path.
+  if (!request || typeof request.headers?.get !== "function") return false;
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader && verifyMcpBearer(authHeader)) return true;
+
+  const cookie = readSessionCookie(request);
+  if (!cookie) return false;
+  const secret = sessionSecret();
+  if (!secret) return false;
+  return verifySignedCookie(cookie, secret, readConfigFacts().sessionGeneration);
+}
+
+/**
+ * Returns a 401 response when the caller may not run this route, or `null`
+ * when it may. Mirrors middleware's decision order so the two can't disagree:
+ * MCP bearer → session cookie → test mode → bootstrap window.
+ */
+export async function requireSession(
+  request: Request | undefined,
+  opts: RequireSessionOptions = {},
+): Promise<NextResponse | null> {
+  if (await hasValidSession(request)) return null;
+
+  // Same escape hatch middleware §3b uses for the e2e-install harness, which
+  // drives the whole wizard over HTTP with no cookie jar. install.sh only
+  // writes this flag when it boots under CLAWBOX_TEST_MODE.
+  if (process.env.CLAWBOX_TEST_MODE === "1") return null;
+
+  if (opts.allowBootstrap && !(await deviceHasOwner())) return null;
+
+  return NextResponse.json({ error: "Authentication required" }, { status: 401 });
+}

--- a/src/lib/setup-api-gate.ts
+++ b/src/lib/setup-api-gate.ts
@@ -1,0 +1,101 @@
+/**
+ * Which /setup-api/* routes the first-boot wizard may reach before a session
+ * exists — an ALLOW-list, deliberately.
+ *
+ * The previous model was a deny-list (`PRE_AUTH_SENSITIVE_PREFIXES`): while
+ * `setup_complete !== true`, every /setup-api/* path that wasn't explicitly
+ * named passed through unauthenticated. Over a ~100-route surface that is a
+ * gate that grows a hole every time someone adds a route and doesn't think
+ * about the wizard. It grew several: setup/reset, update/run, system/power,
+ * install/run-step, wifi/connect and ollama/pull were all reachable with no
+ * credential by anyone in radio range of the OPEN `ClawBox-Setup` AP — which
+ * is broadcasting during exactly this window. TASK-443/446.
+ *
+ * Inverted, the default is 401 and the list below is the whole attack surface.
+ * Adding a route no longer changes the security posture; opening one is an
+ * explicit, reviewable edit to this file.
+ *
+ * NOTE the second half of the fix, in `middleware.ts`: this window is open only
+ * while the device has NO owner credential at all. The moment
+ * `password_configured` flips true — even if `setup_complete` is still false,
+ * i.e. a half-finished or resumed wizard — the window closes and the entire
+ * surface requires a session. There is then someone to authenticate as, so
+ * there is no excuse to stay open.
+ */
+
+/**
+ * Routes the wizard calls BEFORE CredentialsStep sets the password (steps 1-3:
+ * WifiStep, UpdateStep, CredentialsStep). Everything the wizard does after that
+ * — AIModelsStep, TelegramStep, setup/complete — runs with the session cookie
+ * that `system/credentials` mints on the initial password set, so those routes
+ * are deliberately NOT here.
+ *
+ * Prefix match on a path-segment boundary (`/a` matches `/a` and `/a/b`, never
+ * `/ab`).
+ */
+export const BOOTSTRAP_ALLOWED_PREFIXES = [
+  // Wizard state machine. `setup/status` is also public post-setup (it drives
+  // the /login and desktop bootstraps), but it answers a trimmed payload to an
+  // unauthenticated caller — see the route.
+  "/setup-api/setup/status",
+  "/setup-api/setup/progress",
+
+  // Step 1 — WifiStep. The device is on its own AP with no route to anywhere,
+  // so these have to work before any credential can exist.
+  "/setup-api/wifi/scan",
+  "/setup-api/wifi/connect",
+  "/setup-api/wifi/connect-status",
+  "/setup-api/wifi/ethernet",
+
+  // Step 2 — UpdateStep. update/run kicks off the root updater, which is why
+  // it ALSO checks `requireSession({ allowBootstrap: true })` in-handler: the
+  // moment a password exists this stops being reachable, middleware or not.
+  "/setup-api/update/run",
+  "/setup-api/update/status",
+  // The wizard's readiness poll while the updater restarts services.
+  "/setup-api/gateway/health",
+
+  // Step 3 — CredentialsStep. `system/credentials` is the route that ENDS this
+  // window: it sets the password and hands back a session cookie, so the
+  // hostname/hotspot writes it makes afterwards are already authenticated.
+  // `/credentials/verify` is deliberately absent — it is a password oracle
+  // with no onboarding role (TASK-444b).
+  "/setup-api/system/hostname",
+  "/setup-api/system/hotspot",
+
+  // Which agent this SKU runs; AIModelsStep reads it to pick its own shape.
+  // Read-only, and the wizard needs it on the step boundary.
+  "/setup-api/harness/active",
+] as const;
+
+/** Exact matches — no subtree. Keeps `/credentials/verify` out while
+ *  `/credentials` itself is allowed. */
+export const BOOTSTRAP_ALLOWED_EXACT: ReadonlySet<string> = new Set([
+  "/setup-api/system/credentials",
+  // The mascot's phrase bag. GET-only, returns nothing but display strings,
+  // and it is read before a session can exist. The `/regenerate` leaf next to
+  // it is deliberately NOT here and never will be: each call cold-loads a
+  // ~3.8 GB model for up to three minutes, so on the open `ClawBox-Setup` AP
+  // it was a free way to pin the box's memory and CPU. The exact match is what
+  // keeps the two apart.
+  "/setup-api/mascot-lines",
+]);
+
+/** Normalize a single trailing slash so `/setup-api/x/` can't dodge a match. */
+export function normalizeApiPath(pathname: string): string {
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}
+
+/**
+ * True when this path may be served without a session during the genuine
+ * no-password-yet bootstrap window. Callers must check the window is actually
+ * open first — this function says nothing about device state.
+ */
+export function isBootstrapAllowedPath(pathname: string): boolean {
+  const p = normalizeApiPath(pathname);
+  if (BOOTSTRAP_ALLOWED_EXACT.has(p)) return true;
+  for (const prefix of BOOTSTRAP_ALLOWED_PREFIXES) {
+    if (p === prefix || p.startsWith(prefix + "/")) return true;
+  }
+  return false;
+}

--- a/src/lib/system-password.ts
+++ b/src/lib/system-password.ts
@@ -1,0 +1,73 @@
+/**
+ * Is there a real password on the OS account?
+ *
+ * data/config.json's `password_configured` flag is a cache, not the truth:
+ * factory reset wipes it, a partial restore can drop it, and anything with a
+ * write primitive into data/ can clear it. /etc/shadow is the authority.
+ * TASK-444a turns on exactly that gap — with the flag falsy the credentials
+ * route skips the `currentPassword` check and lets an unauthenticated caller
+ * overwrite the owner's OS password.
+ *
+ * `passwd -S <user>` prints `<user> <status> ...` where status is
+ *   P  = usable password set
+ *   NP = no password
+ *   L  = locked (either `!`-prefixed hash or `!` alone)
+ * It reads /etc/shadow through the setuid helper, so it works as `clawbox`
+ * for `clawbox`'s own account without sudo.
+ */
+
+import { execFile as execFileCb } from "child_process";
+import os from "os";
+import { promisify } from "util";
+
+const execFile = promisify(execFileCb);
+
+/**
+ * The install user. Duplicated from `@/lib/auth`'s `getSystemUsername` rather
+ * than imported so this module — which the in-handler auth guard depends on —
+ * stays free of `@/lib/config-store`, whose module-scope DATA_DIR makes it a
+ * common mock target in route tests.
+ */
+function systemUsername(): string {
+  let osUsername: string | undefined;
+  try {
+    osUsername = os.userInfo().username;
+  } catch {
+    osUsername = undefined;
+  }
+  return process.env.CLAWBOX_USER
+    || process.env.SUDO_USER
+    || process.env.USER
+    || osUsername
+    || "clawbox";
+}
+
+const PASSWD_BIN = "/usr/bin/passwd";
+
+/** Parse the second field of a `passwd -S` line. Exported for tests. */
+export function parsePasswdStatus(stdout: string): boolean | null {
+  const line = stdout.split("\n").find((l) => l.trim().length > 0);
+  if (!line) return null;
+  const status = line.trim().split(/\s+/)[1];
+  if (status === "P") return true;
+  if (status === "NP" || status === "L") return false;
+  return null;
+}
+
+/**
+ * `true`  — the account has a usable password
+ * `false` — it demonstrably does not (NP / locked)
+ * `null`  — couldn't tell (helper missing, permission denied, odd output)
+ *
+ * Callers must treat `null` as "unknown", never as "no password": on a box
+ * where `passwd -S` is unavailable, answering `false` would re-open the very
+ * initial-set path this exists to close.
+ */
+export async function hasSystemPassword(user: string = systemUsername()): Promise<boolean | null> {
+  try {
+    const { stdout } = await execFile(PASSWD_BIN, ["-S", user], { timeout: 5_000 });
+    return parsePasswdStatus(stdout);
+  } catch {
+    return null;
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,43 +4,89 @@ import fs from "fs";
 import path from "path";
 import { verifyMcpBearer } from "@/lib/mcp-token";
 import { readEdition } from "@/lib/edition-source";
+import { isBootstrapAllowedPath } from "@/lib/setup-api-gate";
 
 // ─── Setup completion ────────────────────────────────────────────────────────
 //
-// While the wizard is still running there is no session cookie yet, so every
-// /setup-api/* call would be 307'd to /login. We mirror config-store's
-// CONFIG_ROOT resolution and treat "config.json missing" or "setup_complete
-// not yet true" as the bootstrap window where /setup-api/* must pass through.
-// Cached by mtime so the per-request hit is one stat() in the steady state.
+// Before the owner has set a password there is no session cookie to have, so a
+// narrow allow-list of wizard routes must pass through unauthenticated. We
+// mirror config-store's CONFIG_ROOT resolution to read that state. Cached by
+// mtime so the per-request hit is one stat() in the steady state.
 
 const CONFIG_ROOT = process.env.CLAWBOX_ROOT
   || (process.env.NODE_ENV === "development" ? process.cwd() : "/home/clawbox/clawbox");
 const CONFIG_PATH = path.join(CONFIG_ROOT, "data", "config.json");
 
-let configCache: { mtimeMs: number; setupComplete: boolean; sessionGen: number } | null = null;
+interface ConfigSnapshot {
+  mtimeMs: number;
+  setupComplete: boolean;
+  passwordConfigured: boolean;
+  sessionGen: number;
+}
 
-function readConfigCached(): { setupComplete: boolean; sessionGen: number } {
+let configCache: ConfigSnapshot | null = null;
+
+function readConfigCached(): ConfigSnapshot {
   try {
     const stat = fs.statSync(CONFIG_PATH);
     if (configCache && configCache.mtimeMs === stat.mtimeMs) return configCache;
     const raw = fs.readFileSync(CONFIG_PATH, "utf-8");
-    const parsed = JSON.parse(raw) as { setup_complete?: unknown; session_generation?: unknown };
-    const setupComplete = parsed.setup_complete === true;
+    const parsed = JSON.parse(raw) as {
+      setup_complete?: unknown;
+      password_configured?: unknown;
+      session_generation?: unknown;
+    };
     const sessionGen = typeof parsed.session_generation === "number" && Number.isFinite(parsed.session_generation)
       ? parsed.session_generation
       : 0;
-    configCache = { mtimeMs: stat.mtimeMs, setupComplete, sessionGen };
+    configCache = {
+      mtimeMs: stat.mtimeMs,
+      setupComplete: parsed.setup_complete === true,
+      passwordConfigured: parsed.password_configured === true,
+      sessionGen,
+    };
     return configCache;
-  } catch {
-    // Missing/unreadable config = pre-setup. Cache the negative answer so we
-    // don't statSync on every request before config.json is first written.
-    configCache = { mtimeMs: -1, setupComplete: false, sessionGen: 0 };
+  } catch (err) {
+    // A config.json that is genuinely ABSENT is a first-boot device: the
+    // bootstrap window has to open or the wizard can never run.
+    //
+    // A config.json that EXISTS but won't parse is a different animal — a
+    // provisioned box with a corrupt or truncated file, or one an attacker
+    // just clobbered. Treating that as "pre-setup" is fail-OPEN and hands
+    // back the whole unauthenticated window on a device that has an owner
+    // (TASK-446, crit11 note). Fail closed instead: assume set up and
+    // password-configured, so everything needs a session.
+    const missing = (err as NodeJS.ErrnoException)?.code === "ENOENT";
+    configCache = {
+      mtimeMs: -1,
+      setupComplete: !missing,
+      passwordConfigured: !missing,
+      sessionGen: 0,
+    };
     return configCache;
   }
 }
 
-function isSetupComplete(): boolean {
-  return readConfigCached().setupComplete;
+/**
+ * The first-boot bootstrap window: no owner credential exists yet, so a subset
+ * of /setup-api/* (see src/lib/setup-api-gate.ts) is reachable without a
+ * session because there is no session to have.
+ *
+ * Gated on `password_configured`, NOT on `setup_complete`. The old gate used
+ * setup_complete alone, which meant a box that had set a password but not
+ * finished (or resumed) the wizard — and, after the factory-reset incident, a
+ * box whose config.json had simply lost the key — served setup/reset,
+ * update/run, system/power and install/run-step to anyone on the open AP.
+ * Once a password exists there is someone to log in as, so the window shuts.
+ *
+ * `password_configured` here is the config-store flag only; middleware is a
+ * synchronous hot path and cannot shell out to `passwd -S` per request. The
+ * handlers that care about config-vs-shadow drift (system/credentials) resolve
+ * the authoritative answer themselves via src/lib/system-password.ts.
+ */
+function isBootstrapWindowOpen(): boolean {
+  const cfg = readConfigCached();
+  return !cfg.setupComplete && !cfg.passwordConfigured;
 }
 
 // Current session generation — bumped on password change to revoke every cookie
@@ -86,12 +132,26 @@ const APPLE_PATHS = new Set([
 
 const PUBLIC_PREFIXES = [
   "/login",
-  "/setup",
   "/login-api",
   "/_next/",
   "/fonts/",
   "/images/",
 ];
+
+// The wizard PAGE. Public only while the device has no owner credential — the
+// same window its API surface is open in.
+//
+// Once a password exists, a half-finished or resumed wizard has to log in
+// first. That isn't just tidiness: it is what makes the API allow-list
+// survivable. CredentialsStep's password POST hands back a session cookie, so
+// steps 4-5 (AI models, Telegram, setup/complete) run authenticated and need no
+// pre-auth carve-out at all. A user who comes back in a fresh browser gets
+// /login?redirect=/setup and lands right back on the step they left.
+const WIZARD_PAGE_PREFIX = "/setup";
+
+function isWizardPagePath(pathname: string): boolean {
+  return pathname === WIZARD_PAGE_PREFIX || pathname.startsWith(WIZARD_PAGE_PREFIX + "/");
+}
 
 // Endpoints the unauthenticated /login + /setup pages must reach before a
 // session exists. Everything else under /setup-api/ requires a session
@@ -120,85 +180,12 @@ const LOOPBACK_PROXY_PREFIXES = [
   "/setup-api/local-ai/ollama",
 ];
 
-// Sensitive /setup-api/* surfaces that must NEVER be reachable without a session
-// (or the MCP bearer) — not even during the pre-setup wizard window. These are
-// desktop-app / agent backends (file access, browser automation, the code
-// workspace, the remote-desktop bridge, and the gateway-token endpoints) with
-// no role in first-boot onboarding. The blanket pre-setup pass below used to
-// expose them unauthenticated while the open `ClawBox-Setup` AP was up, turning
-// otherwise-local issues into network-adjacent, pre-auth ones.
-const PRE_AUTH_SENSITIVE_PREFIXES = [
-  "/setup-api/files",
-  "/setup-api/browser",
-  "/setup-api/code",        // code workspace file ops / build (also /code/*)
-  "/setup-api/code-server",
-  "/setup-api/webapps",
-  "/setup-api/vnc",
-  "/setup-api/terminal",
-  "/setup-api/clawkeep",    // backup restore/encryption/pairing — data-injection surface
-  "/setup-api/tunnel",      // enabling remote tunnel access
-  "/setup-api/portal",      // same privileged tunnel start/stop/enable as /tunnel
-  "/setup-api/apps/install",
-  "/setup-api/apps/uninstall",
-  "/setup-api/apps/settings",  // privileged `openclaw config set skills.*` + credential writes
-  "/setup-api/gateway/ws-config", // hands back the live gateway auth token
-  "/setup-api/chat",        // reads generated media out of the harness media tree
-  "/setup-api/local-models", // POST enables/disables real systemd units through sudo
-  "/setup-api/tts",         // POST rewrites messages.tts.provider and spawns the openclaw CLI
-  "/setup-api/pets",        // POST downloads ~2.2 MB from a third party and rewrites display.pet.*
-  // Hermes edition. During setup the device broadcasts an OPEN `ClawBox-Setup`
-  // AP, so anything left pre-auth is reachable by anyone in radio range.
-  //   - /hermes/chat runs a full agent turn with shell/tool access, unlimited.
-  //   - /hermes/skills/* installs & uninstalls agent skills (code execution).
-  //   - /harness/select rewrites which agent the device runs.
-  // None of the three has any onboarding role: chat is only called from
-  // ChatPopup, the skills store only from HermesSkillsStore (both desktop-only,
-  // mounted from page.tsx), and the harness picker only from SettingsApp.
-  //
-  // Deliberately NOT listed — the wizard calls these BEFORE setup completes, so
-  // gating them would make the Hermes SKU unprovisionable:
-  //   /setup-api/harness/active         (AIModelsStep.tsx — the ONLY harness
-  //                                      route the wizard touches; /status is
-  //                                      HarnessPicker-only, so it is gated)
-  //   /setup-api/hermes/models          (HermesProviderConfig + useHermesModelOptions)
-  //   /setup-api/hermes/clawai          (ClawBox AI sign-in during onboarding)
-  //   /setup-api/hermes/oauth           (provider OAuth status during onboarding)
-  //   /setup-api/hermes/provider-key    (writes the provider key the wizard collects)
-  // That is exactly the same pre-auth exposure the OpenClaw SKU already accepts
-  // for /setup-api/ai-models/* on the same AP, and the read paths return status
-  // booleans (hasToken/loggedIn), never the stored secrets.
-  "/setup-api/hermes/chat",
-  "/setup-api/hermes/skills",
-  "/setup-api/harness/select",
-  "/setup-api/harness/status",  // probes both harnesses; only the desktop picker calls it
-];
-// Exact-match only: a bare `/setup-api/gateway` subtree deny would also catch
-// `/setup-api/gateway/health`, which the wizard's readiness check legitimately
-// polls before setup completes. The SPA proxy at the bare path injects the
-// gateway token into HTML, so it stays gated.
-const PRE_AUTH_SENSITIVE_EXACT = new Set([
-  "/setup-api/gateway",
-  // The leaf only, NOT the `/setup-api/mascot-lines` subtree: the GET is what
-  // the crab reads its phrases from and it runs on the wizard, so gating the
-  // subtree would leave the mascot mute during setup. The POST is the
-  // expensive half — each call cold-loads a ~3.8 GB model on a Jetson for up
-  // to three minutes — and it has no onboarding role at all: its only caller
-  // is the Settings button, which is desktop-only and therefore post-setup.
-  // Left ungated it was a free way for anyone in radio range of the open
-  // `ClawBox-Setup` AP to pin the box's memory and CPU.
-  "/setup-api/mascot-lines/regenerate",
-]);
-
-function isSensitiveSetupApi(pathname: string): boolean {
-  // Normalize a trailing slash so `/setup-api/gateway/` can't dodge the exact
-  // match (Next.js may not always redirect it before middleware runs).
-  const p0 = pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
-  if (PRE_AUTH_SENSITIVE_EXACT.has(p0)) return true;
-  for (const p of PRE_AUTH_SENSITIVE_PREFIXES) {
-    if (p0 === p || p0.startsWith(p + "/")) return true;
-  }
-  return false;
-}
+// Which /setup-api/* routes are reachable during the first-boot bootstrap
+// window lives in src/lib/setup-api-gate.ts as an ALLOW-list. See that file for
+// why the previous deny-list (`PRE_AUTH_SENSITIVE_PREFIXES`) was inverted:
+// every route nobody remembered to name was served unauthenticated on the open
+// `ClawBox-Setup` AP, which is how setup/reset, update/run, system/power and
+// install/run-step ended up pre-auth (TASK-443/446).
 
 // Paths that exist ONLY because next.config.ts rewrites them to the OpenClaw
 // gateway (see the edition check in the middleware body).
@@ -224,6 +211,9 @@ const PUBLIC_EXACT = new Set([
 function isPublicPath(pathname: string): boolean {
   if (PUBLIC_EXACT.has(pathname)) return true;
   if (PRE_AUTH_API_PATHS.has(pathname)) return true;
+  // `/setup-api/...` also starts with `/setup`, so this must not be a bare
+  // prefix test — isWizardPagePath matches on a segment boundary.
+  if (isWizardPagePath(pathname) && isBootstrapWindowOpen()) return true;
   // Match each prefix on a path-segment boundary. Bare `startsWith("/setup")`
   // would also match `/setup-api/...` and silently expose every protected
   // setup-api route — that was the original auth-bypass.
@@ -333,28 +323,35 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // 3a. Setup wizard bootstrap — production-server.js always provisions
+  // 3a. First-boot bootstrap — production-server.js always provisions
   // SESSION_SECRET so the env-var short-circuit above never fires in real
-  // deployments. While setup_complete is not yet true the wizard runs without
-  // a session cookie; let it reach its API surface so it can configure WiFi,
-  // run the updater, set the password, etc. Once setup completes the gate
-  // closes and every /setup-api/* request requires a valid session.
-  if (pathname.startsWith("/setup-api/") && !isSetupComplete()) {
-    // ...except the sensitive surfaces above, which stay gated even pre-setup
-    // (they play no part in onboarding). They fall through to the session /
-    // MCP-bearer checks below, so an authenticated caller still reaches them.
-    if (!isSensitiveSetupApi(pathname)) {
+  // deployments. While the device has no owner credential the wizard runs
+  // without a session cookie, so the handful of routes steps 1-3 need are let
+  // through; everything else falls to the session / MCP-bearer checks below.
+  //
+  // Two changes from the old gate, both load-bearing (TASK-443):
+  //   - ALLOW-list, not deny-list. The default is now 401.
+  //   - keyed on `password_configured`, not `setup_complete`. A box that has a
+  //     password but an unfinished wizard is a box with an owner.
+  if (pathname.startsWith("/setup-api/") && isBootstrapWindowOpen()) {
+    if (isBootstrapAllowedPath(pathname)) {
       return NextResponse.next();
     }
   }
 
   // 3b. Trusted-test-environment escape hatch for the e2e-install harness.
-  // Scoped to /setup-api/* only — page requests still go through the
-  // normal /login redirect so the login-round-trip spec can verify it.
+  // Scoped to /setup-api/* and the wizard page — every other page request
+  // still goes through the normal /login redirect so the login-round-trip
+  // spec can verify it. The harness drives the wizard past the password step
+  // over plain HTTP with no cookie jar, which the session gate on /setup
+  // would otherwise stop.
   // Mirrors the convention src/lib/network.ts uses to skip hardware-only
   // nmcli paths; both are gated on the flag install.sh writes when it
   // boots under CLAWBOX_TEST_MODE.
-  if (process.env.CLAWBOX_TEST_MODE === "1" && pathname.startsWith("/setup-api/")) {
+  if (
+    process.env.CLAWBOX_TEST_MODE === "1"
+    && (pathname.startsWith("/setup-api/") || isWizardPagePath(pathname))
+  ) {
     return NextResponse.next();
   }
 

--- a/src/tests/helpers/session.ts
+++ b/src/tests/helpers/session.ts
@@ -1,0 +1,78 @@
+/**
+ * Test helpers for the in-handler session guard (`@/lib/route-auth`).
+ *
+ * `route-auth` deliberately reads data/config.json and data/.session-secret off
+ * disk instead of going through `@/lib/config-store` / `@/lib/auth`, so it can't
+ * be mocked out from under the route it's protecting. These helpers set up that
+ * on-disk state under a temp CLAWBOX_ROOT and mint a matching cookie.
+ */
+
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const SECRET = "test-session-secret-0123456789abcdef";
+
+export interface SessionFixture {
+  root: string;
+  /** `Cookie` header value carrying a valid session. */
+  cookie: string;
+  cleanup: () => void;
+}
+
+export interface SessionFixtureOptions {
+  /** Written to config.json. Defaults to a provisioned device (owner exists). */
+  passwordConfigured?: boolean;
+  setupComplete?: boolean;
+  sessionGeneration?: number;
+}
+
+/** Sign a session cookie the way `route-auth` verifies it. */
+export function signSessionCookie(
+  opts: { expiresInSeconds?: number; gen?: number; secret?: string } = {},
+): string {
+  const exp = Math.floor(Date.now() / 1000) + (opts.expiresInSeconds ?? 3600);
+  const payload = Buffer.from(JSON.stringify({ exp, gen: opts.gen ?? 0 })).toString("base64url");
+  const sig = crypto.createHmac("sha256", opts.secret ?? SECRET).update(payload).digest("hex");
+  return `${payload}.${sig}`;
+}
+
+/**
+ * Point CLAWBOX_ROOT at a temp dir holding a config.json and a session secret,
+ * and return a cookie header that authenticates against them. Call `cleanup()`
+ * in afterEach.
+ */
+export function installSessionFixture(opts: SessionFixtureOptions = {}): SessionFixture {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-session-"));
+  const dataDir = path.join(root, "data");
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dataDir, "config.json"),
+    JSON.stringify({
+      password_configured: opts.passwordConfigured ?? true,
+      setup_complete: opts.setupComplete ?? true,
+      session_generation: opts.sessionGeneration ?? 0,
+    }),
+  );
+  fs.writeFileSync(path.join(dataDir, ".session-secret"), SECRET, { mode: 0o600 });
+
+  const previousRoot = process.env.CLAWBOX_ROOT;
+  const previousSecret = process.env.SESSION_SECRET;
+  process.env.CLAWBOX_ROOT = root;
+  // route-auth prefers SESSION_SECRET; keep both in agreement so a test that
+  // leaves the env var set from elsewhere can't silently pass.
+  process.env.SESSION_SECRET = SECRET;
+
+  return {
+    root,
+    cookie: `clawbox_session=${signSessionCookie({ gen: opts.sessionGeneration ?? 0 })}`,
+    cleanup() {
+      if (previousRoot === undefined) delete process.env.CLAWBOX_ROOT;
+      else process.env.CLAWBOX_ROOT = previousRoot;
+      if (previousSecret === undefined) delete process.env.SESSION_SECRET;
+      else process.env.SESSION_SECRET = previousSecret;
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -300,10 +300,20 @@ describe("middleware", () => {
       expect(response.status).toBe(401);
     });
 
-    it.each(["/setup-api/wifi/scan", "/setup-api/update/status", "/setup-api/update/run", "/setup-api/system/credentials", "/setup-api/ai-models/configure", "/setup-api/telegram/configure"])("allows %s during setup wizard bootstrap", async (p) => {
+    it.each([
+      "/setup-api/wifi/scan",
+      "/setup-api/wifi/connect",
+      "/setup-api/update/status",
+      "/setup-api/update/run",
+      "/setup-api/system/credentials",
+      "/setup-api/system/hostname",
+      "/setup-api/system/hotspot",
+      "/setup-api/gateway/health",
+      "/setup-api/harness/active",
+    ])("allows %s during setup wizard bootstrap", async (p) => {
       // production-server.js auto-creates SESSION_SECRET so the env-var
-      // short-circuit never fires; the wizard must still reach its API
-      // surface before setup_complete is written. Regression for the
+      // short-circuit never fires; the wizard must still reach the routes
+      // steps 1-3 need before a password can exist. Regression for the
       // "Failed to check update status" wizard breakage.
       process.env.SESSION_SECRET = "test-secret";
       vi.resetModules();
@@ -312,6 +322,61 @@ describe("middleware", () => {
       const req = createRequest(p);
       const response = await mod.middleware(req);
       expect(response.status).toBe(200);
+    });
+
+    // TASK-443. The gate is an ALLOW-list now, so a route nobody thought about
+    // is closed rather than open. These six were all reachable with no
+    // credential from radio range of the OPEN `ClawBox-Setup` AP; setup/reset
+    // in that state really did wipe the QA box.
+    it.each([
+      "/setup-api/setup/reset",
+      "/setup-api/system/power",
+      "/setup-api/install/run-step",
+      "/setup-api/ollama/pull",
+      "/setup-api/system/info",
+      "/setup-api/kv",
+    ])("gates %s even during setup wizard bootstrap", async (p) => {
+      process.env.SESSION_SECRET = "test-secret";
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest(p));
+      expect(response.status).toBe(401);
+      await expect(response.json()).resolves.toEqual({ error: "Authentication required" });
+    });
+
+    // TASK-443. The window used to be keyed on setup_complete alone, so a box
+    // that had a password but an unfinished wizard — including one whose
+    // config.json had simply lost the setup_complete key — served the whole
+    // bootstrap surface to anyone. A device with a password has an owner.
+    it.each([
+      "/setup-api/wifi/connect",
+      "/setup-api/update/run",
+      "/setup-api/system/credentials",
+      "/setup-api/harness/active",
+    ])("closes the bootstrap window for %s once a password is configured", async (p) => {
+      process.env.SESSION_SECRET = "test-secret";
+      writeConfig({ password_configured: true }); // setup_complete still absent
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest(p));
+      expect(response.status).toBe(401);
+    });
+
+    it("fails closed when config.json exists but cannot be parsed", async () => {
+      // A missing config.json is a first-boot device and must open the window.
+      // A corrupt one is a provisioned box with a damaged (or clobbered) file,
+      // and treating that as "pre-setup" hands the window back. TASK-446.
+      process.env.SESSION_SECRET = "test-secret";
+      const dataDir = path.join(tmpRoot, "data");
+      fs.mkdirSync(dataDir, { recursive: true });
+      fs.writeFileSync(path.join(dataDir, "config.json"), "{ this is not json");
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      expect((await mod.middleware(createRequest("/setup-api/update/run"))).status).toBe(401);
+      expect((await mod.middleware(createRequest("/setup-api/wifi/scan"))).status).toBe(401);
     });
 
     it("re-locks /setup-api/* after config.json flips setup_complete", async () => {
@@ -577,20 +642,92 @@ describe("middleware", () => {
       expect((await mod.middleware(createRequest(p))).status).toBe(401);
     });
 
-    it.each([
-      "/setup-api/harness/active",
-      "/setup-api/hermes/models",
-      "/setup-api/hermes/clawai",
-      "/setup-api/hermes/oauth",
-      "/setup-api/hermes/provider-key",
-    ])("still allows the wizard's %s during the setup window", async (p) => {
-      // AIModelsStep → HermesProviderConfig calls all five before setup
-      // completes; gating them would make the Hermes SKU unprovisionable.
+    it("still allows the wizard's /setup-api/harness/active during the setup window", async () => {
+      // AIModelsStep reads which agent this SKU runs on the step boundary,
+      // before a password can exist, so it is on the bootstrap allow-list.
       process.env.SESSION_SECRET = "test-secret";
       vi.resetModules();
       const mod = await import("@/middleware");
 
-      expect((await mod.middleware(createRequest(p))).status).toBe(200);
+      expect((await mod.middleware(createRequest("/setup-api/harness/active"))).status).toBe(200);
+    });
+
+    it.each([
+      "/setup-api/hermes/models",
+      "/setup-api/hermes/clawai",
+      "/setup-api/hermes/oauth",
+      "/setup-api/hermes/provider-key",
+      "/setup-api/ai-models/configure",
+      "/setup-api/telegram/configure",
+    ])("requires the wizard's own session for %s", async (p) => {
+      // These are steps 4-5, which run AFTER CredentialsStep. The password set
+      // hands back a session cookie, so the wizard reaches them authenticated
+      // and they need no pre-auth carve-out — which matters because the device
+      // is broadcasting an OPEN AP for this whole window. TASK-443/446.
+      process.env.SESSION_SECRET = "test-secret";
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      expect((await mod.middleware(createRequest(p))).status).toBe(401);
+
+      const authed = new NextRequest(new URL(`http://localhost${p}`), {
+        headers: {
+          cookie: `clawbox_session=${await createSignedSessionCookie(Math.floor(Date.now() / 1000) + 60)}`,
+        },
+      });
+      expect((await mod.middleware(authed)).status).toBe(200);
+    });
+  });
+
+  describe("the wizard page follows the same window as its API", () => {
+    it("serves /setup unauthenticated while the device has no owner", async () => {
+      process.env.SESSION_SECRET = "test-secret";
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      expect((await mod.middleware(createRequest("/setup"))).status).toBe(200);
+    });
+
+    it("redirects /setup to /login once a password is configured", async () => {
+      // A resumed or half-finished wizard has an owner, so it logs in first —
+      // and then steps 4-5 work through the session gate rather than needing a
+      // pre-auth carve-out. TASK-443.
+      process.env.SESSION_SECRET = "test-secret";
+      writeConfig({ password_configured: true });
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const response = await mod.middleware(createRequest("/setup"));
+      expect(response.status).toBe(307);
+      const location = new URL(response.headers.get("Location")!);
+      expect(location.pathname).toBe("/login");
+      expect(location.searchParams.get("redirect")).toBe("/setup");
+    });
+
+    it("serves /setup again to a caller with a valid session", async () => {
+      process.env.SESSION_SECRET = "test-secret";
+      writeConfig({ password_configured: true });
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      const req = new NextRequest(new URL("http://localhost/setup"), {
+        headers: {
+          cookie: `clawbox_session=${await createSignedSessionCookie(Math.floor(Date.now() / 1000) + 60)}`,
+        },
+      });
+      expect((await mod.middleware(req)).status).toBe(200);
+    });
+
+    it("does not let the /setup prefix leak /setup-api past the gate", async () => {
+      // `startsWith("/setup")` also matches `/setup-api/...`; that was the
+      // original auth bypass, and the wizard-page carve-out must not reopen it.
+      process.env.SESSION_SECRET = "test-secret";
+      writeConfig({ setup_complete: true, password_configured: true });
+      vi.resetModules();
+      const mod = await import("@/middleware");
+
+      expect((await mod.middleware(createRequest("/setup-api/system/info"))).status).toBe(401);
+      expect((await mod.middleware(createRequest("/setupmagic"))).status).toBe(307);
     });
   });
 

--- a/src/tests/middleware/middleware.test.ts
+++ b/src/tests/middleware/middleware.test.ts
@@ -333,8 +333,16 @@ describe("middleware", () => {
       "/setup-api/system/power",
       "/setup-api/install/run-step",
       "/setup-api/ollama/pull",
+      // The telemetry family (TASK-446). Every one of these answered 200 with
+      // no session while the open AP was up: hostname, kernel, CPU model, RAM,
+      // uptime, disk, the LAN address, raw UI state, and which AI provider and
+      // Telegram bot the box is wired to.
       "/setup-api/system/info",
+      "/setup-api/system/stats",
+      "/setup-api/wifi/status",
       "/setup-api/kv",
+      "/setup-api/ai-models/status",
+      "/setup-api/telegram/status",
     ])("gates %s even during setup wizard bootstrap", async (p) => {
       process.env.SESSION_SECRET = "test-secret";
       vi.resetModules();

--- a/src/tests/routes/credentials-verify.test.ts
+++ b/src/tests/routes/credentials-verify.test.ts
@@ -1,71 +1,142 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
 
 const verifyPasswordMock = vi.fn();
-const checkRateLimitMock = vi.fn();
-const clientIpMock = vi.fn();
 
 vi.mock("@/lib/auth", () => ({ verifyPassword: verifyPasswordMock }));
-vi.mock("@/lib/rate-limit", () => ({
-  checkRateLimit: checkRateLimitMock,
-  clientIp: clientIpMock,
-}));
 
-afterEach(() => {
-  verifyPasswordMock.mockReset();
-  checkRateLimitMock.mockReset();
-  clientIpMock.mockReset();
-});
+/**
+ * /setup-api/system/credentials/verify is a right/wrong password oracle, so
+ * TASK-444b requires it to cost exactly what /login-api costs to ask: the same
+ * MIN_RESPONSE_MS pad, the same persisted escalating lockout, and a session.
+ * It previously answered in ~64 ms off an in-memory per-X-Forwarded-For bucket
+ * the caller could reset by changing a header it controls.
+ */
 
-function makeRequest(body: unknown): Request {
+let session: SessionFixture;
+let POST: (req: Request) => Promise<Response>;
+let MIN_RESPONSE_MS: number;
+
+async function loadRoute() {
+  vi.resetModules();
+  const limits = await import("@/lib/login-rate-limit");
+  limits._resetForTest();
+  MIN_RESPONSE_MS = limits.MIN_RESPONSE_MS;
+  const mod = await import("@/app/setup-api/system/credentials/verify/route");
+  POST = mod.POST;
+}
+
+function makeRequest(body: unknown, headers: Record<string, string> = {}): Request {
   return new Request("http://localhost/setup-api/system/credentials/verify", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", Cookie: session.cookie, ...headers },
     body: typeof body === "string" ? body : JSON.stringify(body),
   });
 }
 
+/** Same request with no session cookie. */
+function anonymousRequest(body: unknown): Request {
+  return new Request("http://localhost/setup-api/system/credentials/verify", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(async () => {
+  session = installSessionFixture();
+  await loadRoute();
+});
+
+afterEach(() => {
+  verifyPasswordMock.mockReset();
+  session.cleanup();
+});
+
 describe("/setup-api/system/credentials/verify", () => {
-  it("rejects when rate-limited", async () => {
-    clientIpMock.mockReturnValue("1.2.3.4");
-    checkRateLimitMock.mockReturnValue(false);
-    const mod = await import("@/app/setup-api/system/credentials/verify/route");
-    const res = await mod.POST(makeRequest({ password: "x" }));
-    expect(res.status).toBe(429);
+  it("rejects an unauthenticated caller with 401", async () => {
+    verifyPasswordMock.mockResolvedValue(true);
+    const res = await POST(anonymousRequest({ password: "right" }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+    // The oracle must not even be consulted for a caller with no session.
+    expect(verifyPasswordMock).not.toHaveBeenCalled();
   });
 
   it("rejects malformed JSON with 400", async () => {
-    clientIpMock.mockReturnValue("1.2.3.4");
-    checkRateLimitMock.mockReturnValue(true);
-    const mod = await import("@/app/setup-api/system/credentials/verify/route");
-    const res = await mod.POST(makeRequest("not-json"));
+    const res = await POST(makeRequest("not-json"));
     expect(res.status).toBe(400);
   });
 
   it("rejects empty password with 400", async () => {
-    clientIpMock.mockReturnValue("1.2.3.4");
-    checkRateLimitMock.mockReturnValue(true);
-    const mod = await import("@/app/setup-api/system/credentials/verify/route");
-    const res = await mod.POST(makeRequest({ password: "" }));
+    const res = await POST(makeRequest({ password: "" }));
     expect(res.status).toBe(400);
   });
 
   it("returns 401 for an incorrect password", async () => {
-    clientIpMock.mockReturnValue("1.2.3.4");
-    checkRateLimitMock.mockReturnValue(true);
     verifyPasswordMock.mockResolvedValue(false);
-    const mod = await import("@/app/setup-api/system/credentials/verify/route");
-    const res = await mod.POST(makeRequest({ password: "wrong" }));
+    const res = await POST(makeRequest({ password: "wrong" }));
     expect(res.status).toBe(401);
   });
 
   it("returns 200 ok:true for a correct password", async () => {
-    clientIpMock.mockReturnValue("1.2.3.4");
-    checkRateLimitMock.mockReturnValue(true);
     verifyPasswordMock.mockResolvedValue(true);
-    const mod = await import("@/app/setup-api/system/credentials/verify/route");
-    const res = await mod.POST(makeRequest({ password: "right" }));
+    const res = await POST(makeRequest({ password: "right" }));
     expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.ok).toBe(true);
+    expect((await res.json()).ok).toBe(true);
+  });
+
+  // ── TASK-444b: the timing oracle ───────────────────────────────────────────
+
+  it("pads a correct and an incorrect answer to the same floor", async () => {
+    verifyPasswordMock.mockResolvedValue(false);
+    const wrongStart = Date.now();
+    await POST(makeRequest({ password: "wrong" }));
+    const wrongMs = Date.now() - wrongStart;
+
+    await loadRoute();
+    verifyPasswordMock.mockResolvedValue(true);
+    const rightStart = Date.now();
+    await POST(makeRequest({ password: "right" }));
+    const rightMs = Date.now() - rightStart;
+
+    // Both sit on the pad. Before the fix the wrong answer came back in ~60 ms
+    // and the right one did too, but neither was padded at all — the oracle was
+    // ~5x faster than /login-api, which is what made it worth attacking.
+    expect(wrongMs).toBeGreaterThanOrEqual(MIN_RESPONSE_MS - 20);
+    expect(rightMs).toBeGreaterThanOrEqual(MIN_RESPONSE_MS - 20);
+  });
+
+  it("pads the 400 paths too, so a malformed body is not a faster answer", async () => {
+    const start = Date.now();
+    await POST(makeRequest({ password: "" }));
+    expect(Date.now() - start).toBeGreaterThanOrEqual(MIN_RESPONSE_MS - 20);
+  });
+
+  // ── TASK-444b/c: the throttle ──────────────────────────────────────────────
+
+  it("locks out after repeated wrong passwords", async () => {
+    verifyPasswordMock.mockResolvedValue(false);
+    let last: Response | null = null;
+    for (let i = 0; i < 5; i++) last = await POST(makeRequest({ password: "wrong" }));
+    expect(last!.status).toBe(429);
+    expect(last!.headers.get("Retry-After")).toBeTruthy();
+
+    // And a *correct* password is still refused while the lock stands, so the
+    // lockout can't be stepped over by guessing right on the next attempt.
+    verifyPasswordMock.mockResolvedValue(true);
+    const after = await POST(makeRequest({ password: "right" }));
+    expect(after.status).toBe(429);
+  });
+
+  it("still hits the global cap when CF-Connecting-IP is rotated", async () => {
+    verifyPasswordMock.mockResolvedValue(false);
+    let last: Response | null = null;
+    for (let i = 0; i < 5; i++) {
+      last = await POST(makeRequest({ password: "wrong" }, { "CF-Connecting-IP": `203.0.113.${i}` }));
+    }
+    // Every request carried a different "client IP", so the per-IP buckets are
+    // all at one failure — but the shared global bucket counted all five.
+    expect(last!.status).toBe(429);
   });
 });

--- a/src/tests/routes/hermes/models-refresh-auth.test.ts
+++ b/src/tests/routes/hermes/models-refresh-auth.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
+
+/**
+ * `?refresh=1` is not a read. It busts Hermes' per-provider disk cache and fans
+ * out into a live /v1/models call per provider, so an unauthenticated caller
+ * could drive real upstream traffic with it — and, paired with a slow
+ * dashboard, use it to swap the live catalogue for the 2-provider disk
+ * fallback. The plain GET stays open for the wizard; the cache bust needs a
+ * session. TASK-446.
+ */
+
+const getModelOptionsMock = vi.fn();
+
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
+  return { ...actual, getModelOptions: getModelOptionsMock };
+});
+
+vi.mock("@/lib/hermes-local-ai", () => ({
+  reconcileLocalAiWithHermes: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/hermes-cli", () => ({
+  runHermesCli: vi.fn(async () => ({ stdout: "", stderr: "", code: 0 })),
+}));
+
+const PAYLOAD = {
+  providers: [{
+    id: "anthropic",
+    name: "Anthropic",
+    authenticated: true,
+    verified: null,
+    isUserDefined: false,
+    source: "dashboard",
+    total: 1,
+    models: [{ id: "anthropic/claude-opus-5", description: "" }],
+  }],
+  current: { provider: "anthropic", model: "anthropic/claude-opus-5" },
+  reasoning: "medium",
+  fetchedAt: Date.now(),
+  source: "dashboard" as const,
+  stale: false,
+};
+
+let session: SessionFixture;
+let GET: (req: Request) => Promise<Response>;
+
+function request(query: string, authed: boolean): Request {
+  return new Request(`http://localhost/setup-api/hermes/models${query}`, {
+    headers: authed ? { Cookie: session.cookie } : {},
+  });
+}
+
+beforeEach(async () => {
+  session = installSessionFixture();
+  getModelOptionsMock.mockReset();
+  getModelOptionsMock.mockResolvedValue(PAYLOAD);
+  vi.resetModules();
+  ({ GET } = await import("@/app/setup-api/hermes/models/route"));
+});
+
+afterEach(() => {
+  session.cleanup();
+});
+
+describe("GET /setup-api/hermes/models", () => {
+  it("honours ?refresh=1 for an authenticated caller", async () => {
+    const res = await GET(request("?refresh=1", true));
+
+    expect(res.status).toBe(200);
+    expect(getModelOptionsMock).toHaveBeenCalledWith({ refresh: true });
+    expect(await res.json()).not.toHaveProperty("refreshDenied");
+  });
+
+  it("downgrades ?refresh=1 to a plain read for an anonymous caller", async () => {
+    const res = await GET(request("?refresh=1", false));
+
+    expect(res.status).toBe(200);
+    // The cache bust did NOT happen...
+    expect(getModelOptionsMock).toHaveBeenCalledWith({ refresh: false });
+    // ...and the client is told, rather than silently getting a no-op refresh.
+    expect((await res.json()).refreshDenied).toBe(true);
+  });
+
+  it("leaves the plain read reachable — the wizard needs it", async () => {
+    const res = await GET(request("", false));
+
+    expect(res.status).toBe(200);
+    expect(getModelOptionsMock).toHaveBeenCalledWith({ refresh: false });
+  });
+
+  it("does not honour ?refresh=1 on the scoped provider read either", async () => {
+    await GET(request("?provider=anthropic&refresh=1", false));
+    expect(getModelOptionsMock).toHaveBeenCalledWith({ refresh: false });
+  });
+
+  it("reports credential presence and verification as separate fields", async () => {
+    const body = await (await GET(request("", true))).json();
+
+    expect(body.providers[0]).toMatchObject({
+      authenticated: true,
+      credentialPresent: true,
+      verified: null,
+    });
+  });
+});

--- a/src/tests/routes/ollama/pull.test.ts
+++ b/src/tests/routes/ollama/pull.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
 
 vi.mock("@/lib/local-ai-runtime", () => ({
   ensureLocalAiReady: vi.fn(),
@@ -7,17 +8,19 @@ vi.mock("@/lib/local-ai-runtime", () => ({
 
 describe("POST /setup-api/ollama/pull", () => {
   let ollamaPullPost: (req: Request) => Promise<Response>;
+  let session: SessionFixture;
 
   function jsonRequest(body: unknown): Request {
     return new Request("http://localhost/test", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: session.cookie },
       body: JSON.stringify(body),
     });
   }
 
   beforeEach(async () => {
     vi.resetModules();
+    session = installSessionFixture();
     vi.stubGlobal("fetch", vi.fn());
     const mod = await import("@/app/setup-api/ollama/pull/route");
     ollamaPullPost = mod.POST;
@@ -25,12 +28,13 @@ describe("POST /setup-api/ollama/pull", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    session.cleanup();
   });
 
   it("returns 400 for invalid JSON", async () => {
     const req = new Request("http://localhost/test", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: session.cookie },
       body: "not json",
     });
     const res = await ollamaPullPost(req);

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
 import * as childProcess from "child_process";
 import fs from "fs/promises";
 
@@ -71,6 +72,7 @@ function setupExecFileMock(results: Record<string, { stdout: string; stderr: str
 
 describe("POST /setup-api/setup/reset", () => {
   let resetPost: () => Promise<Response>;
+  let session: SessionFixture;
 
   beforeEach(async () => {
     vi.resetModules();
@@ -102,14 +104,22 @@ describe("POST /setup-api/setup/reset", () => {
       systemctl: { stdout: "", stderr: "" },
     });
 
+    session = installSessionFixture();
     const mod = await import("@/app/setup-api/setup/reset/route");
-    resetPost = mod.POST;
+    // The handler now requires a session (TASK-443), so every call in this
+    // file goes through an authenticated request. `reset-requires-auth.test.ts`
+    // covers the unauthenticated case.
+    resetPost = () => mod.POST(new Request("http://localhost/setup-api/setup/reset", {
+      method: "POST",
+      headers: { Cookie: session.cookie },
+    }));
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    session.cleanup();
   });
 
   it("performs factory reset successfully", async () => {
@@ -462,6 +472,7 @@ describe("POST /setup-api/setup/reset", () => {
  */
 describe("POST /setup-api/setup/reset — Hermes agent + offline model survive", () => {
   let resetPost: () => Promise<Response>;
+  let session: SessionFixture;
   const HOME = process.env.HOME || "/home/clawbox";
   const HERMES = `${HOME}/.hermes`;
 
@@ -511,14 +522,22 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     mockResetUpdateState.mockReturnValue();
     setupExecFileMock({ nmcli: { stdout: "", stderr: "" }, systemctl: { stdout: "", stderr: "" } });
 
+    session = installSessionFixture();
     const mod = await import("@/app/setup-api/setup/reset/route");
-    resetPost = mod.POST;
+    // The handler now requires a session (TASK-443), so every call in this
+    // file goes through an authenticated request. `reset-requires-auth.test.ts`
+    // covers the unauthenticated case.
+    resetPost = () => mod.POST(new Request("http://localhost/setup-api/setup/reset", {
+      method: "POST",
+      headers: { Cookie: session.cookie },
+    }));
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.clearAllMocks();
+    session.cleanup();
   });
 
   it("never removes ~/.hermes/hermes-agent, directly or via its parent", async () => {

--- a/src/tests/routes/setup/status.test.ts
+++ b/src/tests/routes/setup/status.test.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { signSessionCookie } from "@/tests/helpers/session";
 
 const TEST_ROOT = path.join(os.tmpdir(), `clawbox-setup-status-tests-${process.pid}-${Date.now()}`);
 const DATA_DIR = path.join(TEST_ROOT, "data");
@@ -11,16 +12,32 @@ const OPENCLAW_CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 
 type RouteGet = (request?: Request) => Promise<Response>;
 
-let statusGet: RouteGet;
+const SESSION_SECRET = "status-test-secret-0123456789abcdef";
+
+function anonymousRequest(): Request {
+  return new Request("http://localhost/setup-api/setup/status");
+}
+
+function authedRequest(): Request {
+  return new Request("http://localhost/setup-api/setup/status", {
+    headers: { Cookie: `clawbox_session=${signSessionCookie({ secret: SESSION_SECRET })}` },
+  });
+}
+
+let statusRoute: RouteGet;
+// The route trims its payload for unauthenticated callers (TASK-446), so the
+// existing assertions — which all cover the full shape — go through a session.
+const statusGet: RouteGet = (request) => statusRoute(request ?? authedRequest());
 
 beforeAll(async () => {
   process.env.CLAWBOX_ROOT = TEST_ROOT;
   process.env.OPENCLAW_HOME = OPENCLAW_HOME;
+  process.env.SESSION_SECRET = SESSION_SECRET;
   await fs.mkdir(DATA_DIR, { recursive: true });
   await fs.mkdir(OPENCLAW_HOME, { recursive: true });
   await fs.writeFile(OPENCLAW_CONFIG_PATH, JSON.stringify({}), "utf-8");
   vi.resetModules();
-  ({ GET: statusGet } = await import("@/app/setup-api/setup/status/route"));
+  ({ GET: statusRoute } = await import("@/app/setup-api/setup/status/route"));
 });
 
 beforeEach(async () => {
@@ -31,7 +48,64 @@ beforeEach(async () => {
 afterAll(async () => {
   delete process.env.CLAWBOX_ROOT;
   delete process.env.OPENCLAW_HOME;
+  delete process.env.SESSION_SECRET;
   await fs.rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+describe("GET /setup-api/setup/status — unauthenticated payload", () => {
+  // This route is public by design (the /login page and the desktop bootstrap
+  // read it before a session exists) AND it is served through the cloudflared
+  // tunnel, so whatever it returns is readable by anyone holding that URL.
+  // Only the wizard's own progress belongs there. TASK-446.
+  const OPERATIONAL_FIELDS = [
+    "local_ai_configured",
+    "local_ai_provider",
+    "local_ai_model",
+    "ai_model_configured",
+    "ai_model_provider",
+    "telegram_configured",
+  ];
+
+  it("returns only setup progress to a caller with no session", async () => {
+    await fs.writeFile(CONFIG_PATH, JSON.stringify({
+      setup_complete: true,
+      password_configured: true,
+      local_ai_configured: true,
+      local_ai_provider: "ollama",
+      local_ai_model: "ollama/llama3.2:3b",
+      ai_model_provider: "anthropic",
+      telegram_bot_token: "12345:secret",
+    }), "utf-8");
+
+    const body = await (await statusRoute(anonymousRequest())).json();
+
+    expect(body).toEqual({
+      setup_complete: true,
+      password_configured: true,
+      update_completed: false,
+      wifi_configured: false,
+      setup_progress_step: null,
+    });
+    for (const field of OPERATIONAL_FIELDS) {
+      expect(body).not.toHaveProperty(field);
+    }
+    // And nothing that looks like the token leaks through some other key.
+    expect(JSON.stringify(body)).not.toContain("12345:secret");
+  });
+
+  it("returns the full payload to a caller with a session", async () => {
+    await fs.writeFile(CONFIG_PATH, JSON.stringify({
+      setup_complete: true,
+      local_ai_configured: true,
+      local_ai_provider: "ollama",
+      telegram_bot_token: "12345:secret",
+    }), "utf-8");
+
+    const body = await (await statusRoute(authedRequest())).json();
+
+    expect(body.local_ai_provider).toBe("ollama");
+    expect(body.telegram_configured).toBe(true);
+  });
 });
 
 describe("GET /setup-api/setup/status", () => {

--- a/src/tests/routes/setup/status.test.ts
+++ b/src/tests/routes/setup/status.test.ts
@@ -10,7 +10,11 @@ const CONFIG_PATH = path.join(DATA_DIR, "config.json");
 const OPENCLAW_HOME = path.join(TEST_ROOT, ".openclaw");
 const OPENCLAW_CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");
 
-type RouteGet = (request?: Request) => Promise<Response>;
+// The handler itself always takes a Request (it reads the session cookie off
+// it, TASK-446); the wrapper below is what lets the existing call sites keep
+// invoking it with no argument.
+type RouteGet = (request: Request) => Promise<Response>;
+type RouteGetOptional = (request?: Request) => Promise<Response>;
 
 const SESSION_SECRET = "status-test-secret-0123456789abcdef";
 
@@ -27,7 +31,7 @@ function authedRequest(): Request {
 let statusRoute: RouteGet;
 // The route trims its payload for unauthenticated callers (TASK-446), so the
 // existing assertions — which all cover the full shape — go through a session.
-const statusGet: RouteGet = (request) => statusRoute(request ?? authedRequest());
+const statusGet: RouteGetOptional = (request) => statusRoute(request ?? authedRequest());
 
 beforeAll(async () => {
   process.env.CLAWBOX_ROOT = TEST_ROOT;

--- a/src/tests/routes/system/credentials.test.ts
+++ b/src/tests/routes/system/credentials.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
 import * as childProcess from "child_process";
 import fs from "fs/promises";
 
@@ -74,6 +75,7 @@ function setupExecFileMock(results: Record<string, { stdout: string; stderr: str
 
 describe("POST /setup-api/system/credentials", () => {
   let credentialsPost: (req: Request) => Promise<Response>;
+  let session: SessionFixture;
 
   function jsonRequest(body: unknown, headers?: Record<string, string>): Request {
     return new Request("http://localhost/test", {
@@ -86,6 +88,7 @@ describe("POST /setup-api/system/credentials", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    session = installSessionFixture();
 
     mockFs.mkdir.mockResolvedValue(undefined);
     mockFs.writeFile.mockResolvedValue();
@@ -103,6 +106,7 @@ describe("POST /setup-api/system/credentials", () => {
   afterEach(() => {
     vi.clearAllMocks();
     delete process.env.CLAWBOX_USER;
+    session.cleanup();
   });
 
   it("sets password successfully", async () => {
@@ -225,7 +229,7 @@ describe("POST /setup-api/system/credentials", () => {
     const res = await credentialsPost(jsonRequest({
       password: "newsecurepassword123",
       currentPassword: "oldpassword123",
-    }));
+    }, { Cookie: session.cookie }));
 
     expect(res.status).toBe(200);
     expect(vi.mocked(bumpSessionGeneration)).toHaveBeenCalled();
@@ -239,7 +243,33 @@ describe("POST /setup-api/system/credentials", () => {
     const res = await credentialsPost(jsonRequest({ password: "securepassword123" }));
     expect(res.status).toBe(200);
     expect(vi.mocked(bumpSessionGeneration)).not.toHaveBeenCalled();
-    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  it("mints the owner's session on the first-boot password set", async () => {
+    // There is no prior session to revoke, but there IS now an owner — so the
+    // wizard's remaining steps run authenticated instead of needing a pre-auth
+    // carve-out, and the bootstrap window closes behind them. TASK-443.
+    const res = await credentialsPost(jsonRequest({ password: "securepassword123" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ success: true, authenticated: true });
+    const cookie = res.headers.get("set-cookie");
+    expect(cookie).toContain("clawbox_session=reissued.cookie");
+    expect(cookie).toContain("HttpOnly");
+  });
+
+  it("refuses an unauthenticated password CHANGE once one is configured", async () => {
+    const { get } = await import("@/lib/config-store");
+    vi.mocked(get).mockResolvedValue(true); // password_configured → this is a change
+
+    const res = await credentialsPost(jsonRequest({
+      password: "newsecurepassword123",
+      currentPassword: "oldpassword123",
+    }));
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Authentication required" });
+    // Nothing was written and the root chpasswd unit was never started.
+    expect(mockSet).not.toHaveBeenCalledWith("password_configured", true);
   });
 
   it("resets rate limit on successful password change", async () => {

--- a/src/tests/routes/system/power.test.ts
+++ b/src/tests/routes/system/power.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
 import { execFile } from "child_process";
 
 vi.mock("child_process", () => ({
@@ -31,17 +32,24 @@ function rejectOnce(error: Error) {
 
 describe("/setup-api/system/power", () => {
   let POST: (req: Request) => Promise<Response>;
+  let session: SessionFixture;
 
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    session = installSessionFixture();
     const mod = await import("@/app/setup-api/system/power/route");
     POST = mod.POST;
+  });
+
+  afterEach(() => {
+    session.cleanup();
   });
 
   it("awaits systemctl poweroff for the shutdown action", async () => {
     resolveOnce();
     const req = new Request("http://localhost/setup-api/system/power", {
+      headers: { Cookie: session.cookie },
       method: "POST",
       body: JSON.stringify({ action: "shutdown" }),
     });
@@ -60,6 +68,7 @@ describe("/setup-api/system/power", () => {
   it("awaits systemctl reboot for the restart action", async () => {
     resolveOnce();
     const req = new Request("http://localhost/setup-api/system/power", {
+      headers: { Cookie: session.cookie },
       method: "POST",
       body: JSON.stringify({ action: "restart" }),
     });
@@ -78,6 +87,7 @@ describe("/setup-api/system/power", () => {
   it("returns 500 when the power command fails to dispatch", async () => {
     rejectOnce(new Error("sudo: a password is required"));
     const req = new Request("http://localhost/setup-api/system/power", {
+      headers: { Cookie: session.cookie },
       method: "POST",
       body: JSON.stringify({ action: "shutdown" }),
     });
@@ -89,6 +99,7 @@ describe("/setup-api/system/power", () => {
 
   it("rejects an invalid action without invoking execFile", async () => {
     const req = new Request("http://localhost/setup-api/system/power", {
+      headers: { Cookie: session.cookie },
       method: "POST",
       body: JSON.stringify({ action: "invalid" }),
     });
@@ -99,6 +110,7 @@ describe("/setup-api/system/power", () => {
 
   it("returns 400 on an invalid JSON body", async () => {
     const req = new Request("http://localhost/setup-api/system/power", {
+      headers: { Cookie: session.cookie },
       method: "POST",
       body: "not json",
     });

--- a/src/tests/routes/update/run.test.ts
+++ b/src/tests/routes/update/run.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
 
 vi.mock("@/lib/updater", () => ({
   startUpdate: vi.fn(),
@@ -12,22 +13,27 @@ const mockIsUpdateCompleted = vi.mocked(isUpdateCompleted);
 
 describe("POST /setup-api/update/run", () => {
   let updateRunPost: (req: Request) => Promise<Response>;
+  let session: SessionFixture;
 
   function jsonRequest(body: unknown): Request {
     return new Request("http://localhost/test", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: session.cookie },
       body: JSON.stringify(body),
     });
   }
 
   function emptyRequest(): Request {
-    return new Request("http://localhost/test", { method: "POST" });
+    return new Request("http://localhost/test", {
+      method: "POST",
+      headers: { Cookie: session.cookie },
+    });
   }
 
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    session = installSessionFixture();
 
     mockStartUpdate.mockReturnValue({ started: true });
     mockIsUpdateCompleted.mockResolvedValue(false);
@@ -38,6 +44,7 @@ describe("POST /setup-api/update/run", () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    session.cleanup();
   });
 
   it("starts an update successfully", async () => {
@@ -75,7 +82,7 @@ describe("POST /setup-api/update/run", () => {
   it("handles invalid JSON body gracefully", async () => {
     const req = new Request("http://localhost/test", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: session.cookie },
       body: "not json",
     });
 

--- a/src/tests/routes/wifi/connect.test.ts
+++ b/src/tests/routes/wifi/connect.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
 
 // vi.mock is hoisted above this file's top-level code, so the auth-error class
 // the factory returns must be built inside vi.hoisted() to exist when it runs.
@@ -34,11 +35,12 @@ const mockSetMany = vi.mocked(setMany);
 
 describe("POST /setup-api/wifi/connect", () => {
   let wifiConnectPost: (req: Request) => Promise<Response>;
+  let session: SessionFixture;
 
   function jsonRequest(body: unknown): Request {
     return new Request("http://localhost/test", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: session.cookie },
       body: JSON.stringify(body),
     });
   }
@@ -46,6 +48,7 @@ describe("POST /setup-api/wifi/connect", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    session = installSessionFixture();
 
     mockSwitchToClient.mockResolvedValue({ message: "connected" });
     mockSet.mockResolvedValue();
@@ -58,6 +61,7 @@ describe("POST /setup-api/wifi/connect", () => {
   afterEach(() => {
     vi.clearAllMocks();
     vi.useRealTimers();
+    session.cleanup();
   });
 
   // The single-radio handoff tears down the setup hotspot mid-connect, so the
@@ -138,7 +142,7 @@ describe("POST /setup-api/wifi/connect", () => {
   it("returns 400 for invalid JSON", async () => {
     const req = new Request("http://localhost/test", {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", Cookie: session.cookie },
       body: "not json",
     });
     const res = await wifiConnectPost(req);

--- a/src/tests/unit/hermes-model-options-downgrade.test.ts
+++ b/src/tests/unit/hermes-model-options-downgrade.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A failed catalogue refresh must not replace a good catalogue with a thin one.
+ *
+ * `buildPayload` falls back to Hermes' on-disk manifest whenever the dashboard
+ * is unreachable or slower than the 8 s timeout, and `load()` used to install
+ * whatever came back as the shared cache, unconditionally. On the QA box that
+ * turned one transient timeout into 47 providers becoming 2 — and, because
+ * `?refresh=1` was reachable pre-auth, gave an attacker a way to trigger it.
+ * TASK-446.
+ */
+
+const dashboardFetchMock = vi.fn();
+const runHermesCliMock = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock("@/lib/hermes-dashboard-auth", () => ({
+  dashboardFetch: dashboardFetchMock,
+  __esModule: true,
+}));
+
+vi.mock("@/lib/hermes-cli", () => ({
+  runHermesCli: runHermesCliMock,
+}));
+
+vi.mock("fs/promises", () => ({
+  default: { readFile: readFileMock },
+  readFile: readFileMock,
+}));
+
+/** A dashboard envelope carrying `count` providers, each with one model. */
+function dashboardEnvelope(count: number) {
+  return {
+    providers: Array.from({ length: count }, (_, i) => ({
+      slug: `provider${i}`,
+      name: `Provider ${i}`,
+      authenticated: true,
+      total_models: 1,
+      source: "dashboard",
+      models: [{ id: `provider${i}/model-a`, description: "" }],
+    })),
+    current: { provider: "provider0", model: "provider0/model-a" },
+  };
+}
+
+function dashboardOk(count: number) {
+  dashboardFetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => dashboardEnvelope(count),
+  });
+}
+
+function dashboardDown() {
+  dashboardFetchMock.mockRejectedValueOnce(new Error("timed out"));
+}
+
+/** Hermes' on-disk fallback manifest — the real one holds exactly 2 providers. */
+const DISK_CATALOG = JSON.stringify({
+  providers: {
+    openrouter: { models: [{ id: "openrouter/auto", description: "" }] },
+    nous: { models: [{ id: "nous/hermes", description: "" }] },
+  },
+});
+
+describe("hermes-model-options — a failed refresh must not poison the cache", () => {
+  let mod: typeof import("@/lib/hermes-model-options");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    dashboardFetchMock.mockReset();
+    runHermesCliMock.mockReset();
+    readFileMock.mockReset();
+    runHermesCliMock.mockResolvedValue({ stdout: "", stderr: "", code: 0 });
+    readFileMock.mockResolvedValue(DISK_CATALOG);
+    mod = await import("@/lib/hermes-model-options");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps the healthy dashboard catalogue when a refresh cannot reach the dashboard", async () => {
+    dashboardOk(47);
+    const healthy = await mod.getModelOptions();
+    expect(healthy.source).toBe("dashboard");
+    expect(healthy.providers).toHaveLength(47);
+
+    // The refresh finds the dashboard down and falls back to the 2-provider
+    // disk manifest. Before the fix that payload became the cache.
+    dashboardDown();
+    const refreshed = await mod.getModelOptions({ refresh: true });
+
+    expect(refreshed.providers).toHaveLength(47);
+    expect(refreshed.source).toBe("dashboard");
+    expect(refreshed.degraded).toBe("dashboard-unreachable");
+  });
+
+  it("leaves the next plain read on the good catalogue, not the fallback", async () => {
+    dashboardOk(47);
+    await mod.getModelOptions();
+    dashboardDown();
+    await mod.getModelOptions({ refresh: true });
+
+    // No further dashboard call: the cache is still fresh AND still good.
+    const after = await mod.getModelOptions();
+    expect(after.providers).toHaveLength(47);
+    expect(after.source).toBe("dashboard");
+  });
+
+  it("still installs a dashboard payload that legitimately shrank", async () => {
+    // A provider losing its key is a real change, not a degradation — same
+    // source rank, so it must land.
+    dashboardOk(47);
+    await mod.getModelOptions();
+
+    dashboardOk(3);
+    const refreshed = await mod.getModelOptions({ refresh: true });
+
+    expect(refreshed.providers).toHaveLength(3);
+    expect(refreshed.degraded).toBeUndefined();
+  });
+
+  it("serves the disk fallback when there is no better cache to keep", async () => {
+    // Cold start with a dead dashboard: the fallback is the best available
+    // answer and must still be returned rather than an error.
+    dashboardDown();
+    const cold = await mod.getModelOptions();
+
+    expect(cold.source).toBe("catalog-file");
+    expect(cold.providers).toHaveLength(2);
+    expect(cold.stale).toBe(true);
+  });
+
+  it("reports credential presence and verification as separate fields", async () => {
+    // Hermes' `authenticated` means "a key is set", never "the key works", so a
+    // consumer must not be able to read one as the other. TASK-446.
+    dashboardOk(1);
+    const payload = await mod.getModelOptions();
+
+    expect(payload.providers[0].authenticated).toBe(true);
+    expect(payload.providers[0].verified).toBeNull();
+  });
+});

--- a/src/tests/unit/root-steps.test.ts
+++ b/src/tests/unit/root-steps.test.ts
@@ -1,0 +1,140 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+import { SELF_UPDATING_ROOT_STEPS, UI_ROOT_STEPS, isUiRootStep, maySelfUpdate } from "@/lib/root-steps";
+
+/**
+ * The root-privilege boundary is: clawbox-setup (User=clawbox) →
+ * `sudo systemctl start clawbox-root-update@<step>.service` → install.sh as
+ * root. Three things have to hold for that to be a boundary at all, and each is
+ * enforced in a different file — so they are pinned together here. TASK-445.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const DISPATCHER = path.join(REPO, "config", "clawbox-root-step.sh");
+const UNIT = path.join(REPO, "config", "clawbox-root-update@.service");
+const INSTALL_SH = path.join(REPO, "install.sh");
+const SUDOERS = [
+  path.join(REPO, "config", "clawbox-sudoers"),
+  path.join(REPO, "config", "sudoers-clawbox-ollama"),
+];
+
+const read = (p: string) => fs.readFileSync(p, "utf-8");
+
+/** Pull a whitespace-separated shell list assigned as NAME="..." . */
+function shellList(source: string, name: string): string[] {
+  const m = new RegExp(`^${name}="([^"]*)"`, "m").exec(source);
+  if (!m) throw new Error(`${name} not found in the dispatcher`);
+  return m[1].split(/\s+/).filter(Boolean);
+}
+
+describe("root-step allow-lists", () => {
+  it("keeps the TypeScript UI list inside the dispatcher's allow-list", () => {
+    const allowed = new Set(shellList(read(DISPATCHER), "ALLOWED_STEPS"));
+    for (const step of UI_ROOT_STEPS) {
+      expect(allowed.has(step), `${step} is offered by the UI but the root dispatcher rejects it`).toBe(true);
+    }
+  });
+
+  it("keeps the self-update list identical on both sides", () => {
+    const shell = shellList(read(DISPATCHER), "SELF_UPDATING_STEPS");
+    expect([...shell].sort()).toEqual([...SELF_UPDATING_ROOT_STEPS].sort());
+  });
+
+  it("only lets the dispatcher run steps install.sh can actually dispatch", () => {
+    // A step the dispatcher permits but install.sh has no function for is a
+    // root unit that fails; the reverse (install.sh knows it, the dispatcher
+    // refuses) is safe and expected for anything not reachable from the web.
+    const m = /^DISPATCH_STEPS=\(([^)]*)\)/m.exec(read(INSTALL_SH));
+    expect(m).not.toBeNull();
+    const dispatchable = new Set(
+      m![1].split(/\s+/).map((t) => t.trim()).filter((t) => t && !t.startsWith("#")),
+    );
+    // Pre-existing, and deliberately not fixed here: `clawkeep_install` has a
+    // `step_clawkeep_install` function but was never added to DISPATCH_STEPS,
+    // so `install.sh --step clawkeep_install` already exits "Unknown step".
+    // The UI's install button has therefore never worked. Keeping it in both
+    // allow-lists preserves exactly today's behaviour (the request reaches
+    // install.sh and install.sh refuses it); adding it to DISPATCH_STEPS would
+    // ENABLE a root step, which is a product change, not a security fix.
+    const KNOWN_UNDISPATCHABLE = new Set(["clawkeep_install"]);
+
+    // install.sh's array carries inline comments; drop anything that isn't a
+    // bare identifier.
+    for (const step of shellList(read(DISPATCHER), "ALLOWED_STEPS")) {
+      if (KNOWN_UNDISPATCHABLE.has(step)) continue;
+      expect(dispatchable.has(step), `${step} is permitted as root but install.sh cannot dispatch it`).toBe(true);
+    }
+  });
+
+  it("never lets a credential or hostname change self-update", () => {
+    // install.sh's bootstrap does `git fetch` + `git reset --hard` + re-exec.
+    // A password change must not reach the network or mutate the source tree.
+    for (const step of ["chpasswd", "set_hostname", "restart_ap", "edition_lock", "validate_services"]) {
+      expect(maySelfUpdate(step), `${step} must not run install.sh's self-update`).toBe(false);
+    }
+  });
+
+  it("still lets the update family self-update", () => {
+    expect(maySelfUpdate("git_pull")).toBe(true);
+    expect(maySelfUpdate("bootstrap_updater")).toBe(true);
+  });
+
+  it("keeps destructive steps off the UI list", () => {
+    for (const step of ["chpasswd", "git_pull", "rebuild_reboot", "recover", "network_setup", "restart"]) {
+      expect(isUiRootStep(step), `${step} must not be startable from a UI button`).toBe(false);
+    }
+  });
+});
+
+describe("root-executed paths are outside clawbox's write access", () => {
+  it("runs the root-update unit from a root-owned entrypoint", () => {
+    const unit = read(UNIT);
+    const execStart = /^ExecStart=(.+)$/m.exec(unit)?.[1] ?? "";
+    expect(execStart).toContain("/usr/local/libexec/clawbox/");
+    // The project tree is clawbox-owned and clawbox-writable, and install.sh
+    // `chown -R clawbox`s it on every root run.
+    expect(execStart).not.toContain("/home/clawbox");
+  });
+
+  it("grants NOPASSWD root only on paths clawbox cannot write", () => {
+    for (const file of SUDOERS) {
+      const grants = read(file)
+        .split("\n")
+        .filter((l) => l.trim().startsWith("clawbox ") && l.includes("NOPASSWD:"))
+        .map((l) => l.split("NOPASSWD:")[1].trim());
+
+      for (const grant of grants) {
+        expect(
+          grant.includes("/home/clawbox"),
+          `sudoers grants root on a clawbox-writable path: ${grant}`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("does not hand over the whole systemd unit namespace", () => {
+    const grants = read(SUDOERS[0]);
+    // `reset-failed *` / `start --no-block *` took ANY unit name. Every real
+    // caller passes a clawbox-* unit.
+    expect(grants).not.toMatch(/systemctl reset-failed \*/);
+    expect(grants).not.toMatch(/systemctl start --no-block \*\s*$/m);
+    expect(grants).toContain("systemctl reset-failed clawbox-*");
+    expect(grants).toContain("systemctl start --no-block clawbox-*");
+  });
+
+  it("installs the root-owned copies before the sudoers rules that point at them", () => {
+    const sh = read(INSTALL_SH);
+    expect(sh).toContain("install_root_libexec");
+    // The ollama grant's target must be the installed copy, not the repo one.
+    expect(read(SUDOERS[1])).toContain("/usr/local/libexec/clawbox/optimize-ollama.sh");
+    const libexecAt = sh.indexOf("  install_root_libexec\n  # Install sudoers rules");
+    expect(libexecAt, "install_root_libexec must run before the sudoers drop-in").toBeGreaterThan(0);
+  });
+
+  it("gates install.sh's self-update on an explicit opt-in", () => {
+    const sh = read(INSTALL_SH);
+    expect(sh).toContain("CLAWBOX_ALLOW_SELF_UPDATE");
+    expect(sh).toContain("_clawbox_may_self_update");
+  });
+});


### PR DESCRIPTION
Task: TASK-443/444/445/446 (Hermes QA epic TASK-442) — reported by krasi@idrobots.com

Four security fixes that all sit on the same shared surface (`/setup-api/*` +
auth), so they land together. Both editions.

> **Rebased onto beta `0343573` on 2026-08-24** — see "Rebase notes" at the end.

Evidence: `findings/validate-round1.md` §TASK-443 (l.521), §444 (l.853),
§445 (l.896), §446 (l.1058).

---

## TASK-443 — the pre-setup trust window

The gate in front of `/setup-api/*` was a **deny-list** evaluated whenever
`setup_complete !== true`: any path nobody had remembered to name was served
with no credential. Over a ~100-route surface that grew holes, and it grew them
in the one window where the device is broadcasting an **open `ClawBox-Setup`
AP**. `setup/reset`, `update/run`, `system/power`, `install/run-step`,
`wifi/connect` and `ollama/pull` were all reachable from radio range — and on
2026-08-22T00:04Z an unauthenticated POST to `setup/reset` really did wipe the
QA box.

**Inverted to an allow-list** (`src/lib/setup-api-gate.ts`) holding only what
wizard steps 1–3 call. The default is 401; adding a route no longer changes the
security posture. Two further changes keep that list small enough to be honest:

- **The window is keyed on `password_configured`, not `setup_complete`.** A box
  with a password has an owner, even if its wizard never finished or its
  config.json lost a key. This is the sub-fix that actually closes the incident:
  the box that got wiped had a password and no `setup_complete`.
- **The initial password set mints the owner's session**, so steps 4–5 (AI
  models, Telegram, `setup/complete`) run authenticated and need no carve-out at
  all. The wizard **page** follows the same window, so a resumed wizard hits
  `/login?redirect=/setup` and comes back with a session.

A missing config.json is still first boot; a **corrupt** one now fails closed
instead of handing the window back.

Destructive handlers also check for themselves, via a deliberately
self-contained `@/lib/route-auth` (it reads config.json and `.session-secret`
directly, so a route test that mocks `config-store` can't mock the guard away).
`setup/reset` used to be `export async function POST()` — a handler that could
not have read a cookie if it wanted to.

| route | gated |
|---|---|
| `setup/reset`, `system/power`, `install/run-step`, `ollama/pull` | always — no bootstrap carve-out |
| `update/run`, `wifi/connect` | bootstrap only (steps 1–2 predate any password) |
| `system/credentials` | initial set open; **change** requires a session |

## TASK-444 — password oracle + lockout bypass

- `credentials/verify` answered in ~64 ms next to a login padded to 300 ms, and
  was throttled only by an in-memory per-`X-Forwarded-For` bucket the caller
  could reset by changing a header it controls. It now shares `/login-api`'s
  machinery outright — same `MIN_RESPONSE_MS` pad **on every exit path**
  (including the 400s), same persisted escalating lockout — and requires a
  session. It has no first-boot role.
- `system/credentials` consults **/etc/shadow** as well as the config flag, so
  drift between the two can't re-open the initial-set path (444a).
  `hasSystemPassword()` returns `null` when it can't tell, which is deliberately
  never read as "no password".
- **Login lockout:** every attempt is now counted against a capped `global`
  bucket *as well as* `cf:<ip>`. On a box serving plain HTTP with no proxy in
  front, `CF-Connecting-IP` is just a header the client picks, so keying only on
  it meant each new value minted a fresh, empty, un-capped bucket — the
  escalating lockout was one `-H 'CF-Connecting-IP: <random>'` away from
  irrelevant (confirmed live). The global bucket stays capped at
  `SHARED_BUCKET_MAX_LOCK_MS`, so **the owner still cannot be locked out**, and a
  correct password clears both. `X-Forwarded-For` is still never consulted.

## TASK-445 — root escalation

Every part of the root hand-off resolved back into a clawbox-writable directory:

- `/etc/sudoers.d/clawbox-ollama` granted NOPASSWD root on
  `/home/clawbox/clawbox/scripts/optimize-ollama.sh` — clawbox-owned, in
  clawbox-owned directories. Anything with clawbox-level code execution could
  overwrite the file and then ask sudo to run it. No wildcard, no race.
- The root-update unit `ExecStart`'d `/home/clawbox/clawbox/install.sh`, which
  install.sh hands back with `chown -R clawbox` on every root run.

Both now run from **`/usr/local/libexec/clawbox`**, installed root:root 0755
under root-owned dirs. The unit goes through a root-owned dispatcher
(`config/clawbox-root-step.sh`) that also **validates its instance name** — the
grant is `clawbox-root-update@*.service`, so the step name was unvalidated input
on the root side of the boundary.

install.sh's bootstrap (`git fetch` + `git reset --hard origin/<branch>` +
re-exec) ran on **every** `--step`; the journal shows it firing for `chpasswd`,
`set_hostname` and `validate_services`. A password change now neither reaches
the network nor mutates the source tree — only the update family gets
`CLAWBOX_ALLOW_SELF_UPDATE`. And `reset-failed *` / `start --no-block *` no
longer hand over the whole systemd unit namespace (every real caller passes a
`clawbox-*` unit).

`update/run` requires auth — see TASK-443.

## TASK-446 — unauth telemetry + catalog poison

Per the brief, I re-checked each route on the box first. **Already closed on a
provisioned device** — all seven telemetry routes plus `hermes/models` return
401 unauthenticated today, exactly as the validation found; the leak is strictly
the pre-setup window, which the TASK-443 inversion closes. Verified just now:

```
system/info 401  system/stats 401  wifi/status 401  kv 401
ai-models/status 401  telegram/status 401  gateway/health 401
hermes/models 401  hermes/models?refresh=1 401      setup/status 200
```

**Still open, and fixed here:**

- `setup/status` is public by design (`/login` and the desktop bootstrap read it
  before a session exists) **and** is served through the cloudflared tunnel, so
  it leaked `local_ai_provider`, `local_ai_model`, `ai_model_provider` and
  `telegram_configured` to anyone holding the URL. An unauthenticated caller now
  gets only the wizard's own progress.
- **Cache downgrade.** A dashboard timeout makes `buildPayload` fall back to the
  2-provider disk manifest, and `load()` installed that over a healthy
  47-provider cache *unconditionally* — one transient 8 s timeout and the device
  had apparently lost 45 providers. Payloads now carry a source rank; a worse one
  is refused while the cached one is inside its stale window, and the caller gets
  `degraded: "dashboard-unreachable"` instead of a quietly thinner catalogue.
- `?refresh=1` needs a session (it is a cache bust that fans out into a live call
  per provider, not a read). The plain GET stays reachable. An anonymous
  `?refresh=1` degrades to a read and is told so via `refreshDenied`.
- **`credentialPresent` vs `verified`** are now separate fields. Hermes'
  `authenticated` means "a key is set", never "the key works" (it is derived from
  `not is_skeleton`), and reading one as the other is why a bogus provider looked
  healthy right up until the first turn 403'd.

`gateway/health` stays on the bootstrap allow-list — UpdateStep polls it for
readiness before a password can exist, and it returns
`{available, port}`. Flagging it rather than breaking the wizard.

---

## Tests

`npm test` — **74 failed | 3622 passed | 54 skipped**, byte-identical to the
`origin/beta` baseline (`74 failed | 3595 passed`), same 6 files:
`chat-attachments`, `chat-media`, `chat-transcribe`, `files/path`, `files/route`,
`hermes-chat-failure-message`. **Zero new failures; +27 passing.**

`npx tsc --noEmit` — 17 errors, all pre-existing, all in `src/tests/*` files this
PR doesn't touch. `npx eslint` on every changed file — clean.

New/extended coverage, each of which fails against the old code:

- `middleware.test.ts` — the six routes gated even during bootstrap; the
  telemetry family gated; the window closing on `password_configured`; fail-closed
  on corrupt config; the `/setup` page gate (and that its prefix still can't leak
  `/setup-api` past the gate).
- `credentials-verify.test.ts` — rewritten: 401 without a session, right and wrong
  padded to the same floor, the 400 paths padded too, lockout survives a correct
  password, and rotating `CF-Connecting-IP` still hits the global cap.
- `system/credentials.test.ts` — session minted on first-boot set; unauthenticated
  **change** refused with nothing written.
- `hermes-model-options-downgrade.test.ts` — a failed refresh keeps the
  47-provider catalogue and reports `degraded`; a legitimate shrink still lands;
  cold start still serves the fallback.
- `models-refresh-auth.test.ts` — `?refresh=1` honoured for a session, downgraded
  for anonymous, plain GET untouched.
- `root-steps.test.ts` — the path-allowlist unit: TS/shell/install.sh lists pinned
  together, no NOPASSWD grant resolves under `/home/clawbox`, no `systemctl *`
  wildcard, `chpasswd`/`set_hostname` can't self-update.
- `setup/status.test.ts` — the trimmed anonymous payload, asserted field-by-field.

## Verification that needs the box (not covered by vitest)

The systemd/sudoers half of TASK-445 is install-time. After deploy:

```sh
sudo -l -U clawbox                      # no /home/clawbox target; no bare `*` unit specs
ls -la /usr/local/libexec/clawbox/       # root:root 0755, both scripts
systemctl cat clawbox-root-update@       # ExecStart -> /usr/local/libexec/clawbox/clawbox-root-step.sh
sudo /usr/local/libexec/clawbox/clawbox-root-step.sh nope_step   # exit 64, "step not permitted"
# change the password from Settings, then:
sudo journalctl -u 'clawbox-root-update@chpasswd.service' | grep -i bootstrap   # must be EMPTY
```

The last one is the TASK-445 regression that matters most: today that journal
line says `[bootstrap] Refreshing install.sh from origin/beta...` on a password
change.

## Notes for review

- **Behaviour change to flag:** `/setup` now redirects to `/login` once a
  password exists and the wizard is unfinished. That is what makes the allow-list
  small — steps 4–5 go through the session gate instead of a carve-out. A wizard
  resumed in the same browser is unaffected (the cookie is minted at step 3); one
  resumed in a fresh browser logs in first. `CLAWBOX_TEST_MODE` covers `/setup`
  too, so the e2e-install harness is unaffected.
- **Pre-existing bug surfaced, deliberately not fixed:** `clawkeep_install` is in
  the UI's step list but was never added to install.sh's `DISPATCH_STEPS`, so
  `install.sh --step clawkeep_install` already exits "Unknown step" — that button
  has never worked. Adding it would *enable* a root step, which is a product
  change, not a security fix. Documented in `root-steps.test.ts`.
- **Not mine, skipped:** `crit15c` (disabling Local AI leaves a dangling
  `model.provider: "clawlocal"`) is local-ai provider wiring — TASK-448/451
  territory.
- `src/app/setup-api/ai-models/configure/route.ts` is touched for one line (the
  `optimize-ollama.sh` path) to keep it matching the sudoers grant.

---

## Rebase notes (2026-08-24)

Replayed onto beta `0343573`, after the merges of #435 (MCP/tooling), #437
(observability), #440 (BG i18n), #442 (reasoning) and #444 (docs). Only four of
this branch's 38 files were touched on both sides, and only one of them
conflicted.

- **`src/middleware.ts` — the one real conflict.** beta had added
  `/setup-api/pets` and `/setup-api/mascot-lines/regenerate` to
  `PRE_AUTH_SENSITIVE_PREFIXES` / `_EXACT`; this branch deletes that deny-list
  and replaces it with the allow-list in `src/lib/setup-api-gate.ts`. Both
  additions are **subsumed by the inversion** — under an allow-list neither path
  is named, so both are 401 by default, which is what beta wanted and stronger
  than what beta wrote. beta's assertions for them are kept verbatim and still
  pass.
  - The one thing the inversion *would* have broken is beta's other intent: the
    bare `GET /setup-api/mascot-lines` must stay reachable on the wizard. It is
    now an **exact** entry in `BOOTSTRAP_ALLOWED_EXACT` — exact, so the
    `/regenerate` leaf next to it (a ~3.8 GB cold model load, up to three
    minutes, desktop-only caller) stays gated exactly as beta gated it.
- **`src/tests/middleware/middleware.test.ts`** — auto-merged; beta's new cases
  (`pets`, `pets/select`, `mascot-lines/regenerate`, and "still allows the
  mascot GET") all pass unchanged against the allow-list.
- **`install.sh`** and **`src/app/setup-api/ai-models/configure/route.ts`** —
  auto-merged, disjoint hunks. Re-checked by hand that the
  `/usr/local/libexec/clawbox/optimize-ollama.sh` sudo call and the
  `_clawbox_may_self_update` bootstrap gate both survived beta's rewrites intact.

One new commit on top of the three original ones: `setup/status.test.ts` typed
its imported handler as taking an optional `Request`, which stopped
typechecking once TASK-446 made the handler read the session cookie off that
argument. Split into a required-arg handler type and the optional-arg wrapper
the existing assertions call.

### Verification after the rebase

Run in a clean worktree of the rebased branch (`bun install --frozen-lockfile`),
against a clean worktree of `origin/beta` as the baseline:

| | beta `0343573` | this branch |
|---|---|---|
| `npx vitest run --config vitest.config.ts` | 310 files, **4429 passed, 0 failed** | 310 files, **4482 passed, 0 failed** |
| `npx tsc --noEmit` | 19 errors | **19 errors — the identical set**, diff empty |
| `bun run build` | — | exit 0 |
| `npx eslint <changed .ts/.tsx>` | — | 0 errors, 1 warning (`_api` unused in `ai-models/configure/route.ts`, **pre-existing on beta**, byte-identical) |

The +53 tests are this PR's own. The earlier "74 failed" baseline in the
Tests section above was an artefact of the old worktree's shared
`node_modules` symlink (node builtins failed to resolve); with a real install
both sides are fully green, so that section's numbers are superseded by this
table.

`src/tests/unit/run-tunnel.test.ts` flaked once across the three full runs
("keeps the URL history across the stop") and passes in isolation and on the
other two runs; it is a shell-script test this PR does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Added session protection to setup, installation, reset, power, Wi‑Fi, update, and Ollama actions.
  * Restricted bootstrap access and privileged system operations to approved workflows.
  * Improved password protection with global and per-address lockouts and consistent response timing.
  * Limited sensitive setup details to authenticated sessions.

* **Reliability**
  * Preserved higher-quality Hermes model data when refreshes use degraded fallbacks.
  * Added clearer credential verification and degraded-status reporting.

* **Tests**
  * Expanded coverage for authentication, authorization, lockouts, bootstrap access, and privileged operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->