### PR TITLE
Hermes observability: persistent journald, HTTP access log, honest service exit, stats sleep (TASK-456)

### DIFF
--- a/config/clawbox-setup.service
+++ b/config/clawbox-setup.service
@@ -16,6 +16,16 @@ WorkingDirectory=/home/clawbox/clawbox
 ExecStart=/usr/bin/node /home/clawbox/clawbox/production-server.js
 Restart=always
 RestartSec=3
+# A clean stop is not a failure. systemd stops this unit with SIGTERM; with no
+# SuccessExitStatus every `systemctl restart clawbox-setup` (which the in-app
+# updater and every deploy end with) wrote
+#   clawbox-setup.service: Main process exited, code=exited, status=143/n/a
+#   clawbox-setup.service: Failed with result 'exit-code'.
+# into the journal and left the unit red in `systemctl status` — indistinguishable
+# from a real crash for anyone triaging the device. production-server.js now
+# handles SIGTERM and exits 0 on its own; this line covers the window before that
+# handler is installed and any Node/Next path that still exits 143.
+SuccessExitStatus=143 SIGTERM
 EnvironmentFile=-/home/clawbox/clawbox/data/network.env
 EnvironmentFile=-/home/clawbox/clawbox/.env
 # MUST stay LAST of the EnvironmentFile= lines. /home/clawbox/clawbox/.env is

--- a/config/clawbox-tunnel.service
+++ b/config/clawbox-tunnel.service
@@ -14,6 +14,12 @@ ExecStart=/home/clawbox/clawbox/scripts/run-tunnel.sh
 # rather than the user noticing remote access is silently down.
 Restart=always
 RestartSec=5
+# Same reason as clawbox-setup.service: a SIGTERM stop exited 143 and systemd
+# recorded `Failed with result 'exit-code'`, which the Remote Access panel then
+# renders as a red "Tunnel failed to start" alert after the user themselves
+# pressed Stop. run-tunnel.sh now returns 0 on a signalled stop; this keeps the
+# unit honest either way.
+SuccessExitStatus=143 SIGTERM
 TimeoutStartSec=30
 TimeoutStopSec=15
 StandardOutput=journal

--- a/config/journald-clawbox.conf
+++ b/config/journald-clawbox.conf
@@ -1,0 +1,45 @@
+# ClawBox journald policy — installed to /etc/systemd/journald.conf.d/10-clawbox.conf
+# by install.sh (step_persistent_journal).
+#
+# WHY: shipped devices ran with journald's `Storage=auto` default and no
+# /var/log/journal directory, which means VOLATILE — the whole journal lived in
+# /run/log/journal (tmpfs) and was destroyed on every reboot. On a QA box that
+# was 72 MB of logs charged to RAM on a 7.6 GiB device, and it meant the single
+# most common support question ("what happened before it rebooted?") had no
+# answer at all. It also made an HTTP access log pointless: there was nowhere
+# durable for it to land.
+[Journal]
+# The whole point: keep the journal in /var/log/journal across reboots.
+# install.sh also creates that directory, because Storage=persistent creates it
+# itself but only on the next journald start.
+Storage=persistent
+
+# Bound it. A Jetson boots off eMMC and an unbounded journal is a flash-wear and
+# disk-space problem, not just a tidiness one. 200M over 1 month is ~4x the
+# steady-state volume measured on a device with 12 months of uptime records.
+SystemMaxUse=200M
+SystemKeepFree=500M
+SystemMaxFileSize=25M
+MaxRetentionSec=1month
+
+# The tmpfs half still exists (early boot, before /var is mounted, and any boot
+# where the disk journal is unavailable). Cap it so it can never eat RAM the way
+# the volatile-only setup did.
+RuntimeMaxUse=64M
+RuntimeMaxFileSize=8M
+
+# Rate limiting, stated explicitly rather than inherited.
+#
+# Port 80 is reachable from the LAN, from the open ClawBox-Setup AP and — when
+# remote access is on — from the public Cloudflare tunnel, and the web tier now
+# writes one access line per request. 200 unauthenticated requests were measured
+# completing in 0.80 s, so an attacker can trivially try to flood the journal.
+# The cap turns that into a bounded, self-announcing event ("Suppressed N
+# messages") instead of unbounded eMMC writes. 5000 lines / 30 s is far above
+# anything the device produces legitimately.
+RateLimitIntervalSec=30s
+RateLimitBurst=5000
+
+# Do not also duplicate everything into /dev/kmsg or the console.
+ForwardToKMsg=no
+ForwardToConsole=no

--- a/docs-site/support/troubleshooting.mdx
+++ b/docs-site/support/troubleshooting.mdx
@@ -217,6 +217,33 @@ journalctl -u clawbox-setup -n 50 --no-pager     # web app / login / setup API
 journalctl -u clawbox-gateway -n 50 --no-pager   # AI gateway / providers / channels
 ```
 
+The journal is **persistent** — it lives in `/var/log/journal` and survives a
+reboot, so a log tail is still useful after the box has been power-cycled. Add
+`-b -1` to read the previous boot, or `--since "1 hour ago"`.
+
+Every HTTP request the web app serves is logged to the `clawbox-setup` journal,
+which is the fastest way to tell whether a request reached the device at all and
+where it came from:
+
+```bash
+journalctl -u clawbox-setup --no-pager | grep '\[access\]'
+# [access] 200 GET /setup-api/system/stats 9ms ip=192.168.50.10 host=clawbox.local
+```
+
+`ip=` is the real client address (it reads Cloudflare's `CF-Connecting-IP`, so
+requests arriving over Remote Access show the visitor, not `127.0.0.1`), and
+`host=` is the hostname the request arrived on — useful for telling LAN traffic
+apart from traffic through a `*.trycloudflare.com` Remote Access URL. Sensitive
+query values are replaced with `REDACTED`.
+
+<Note>
+The first ~10 seconds of every boot (roughly 888 kernel lines) are timestamped
+about a year early. The Jetson Orin Nano has no battery-backed real-time clock,
+so the kernel starts with an incorrect date and only picks up the right one when
+the `nvvrs-pseq-rtc` driver hands over. Timestamps after that point — including
+everything from ClawBox's own services — are correct.
+</Note>
+
 You can also message the assistant `/diagnostics` in chat (if it's responding) to get a self-report.
 
 ## Still stuck?

--- a/install.sh
+++ b/install.sh
@@ -2403,6 +2403,58 @@ step_system_config() {
   step_polkit_rules
   step_nm_dispatcher
   step_sysctl_linkdown
+  step_persistent_journal
+}
+
+step_persistent_journal() {
+  # Make the journal survive a reboot.
+  #
+  # Shipped devices ran journald with `Storage=auto` and no /var/log/journal,
+  # which means volatile: the entire journal lived in /run/log/journal (tmpfs),
+  # was charged to RAM (72 MB measured on a QA box), and was destroyed on every
+  # reboot. "What happened before it rebooted?" — the first question of every
+  # support case — had no answer on any ClawBox ever shipped, and there was
+  # nowhere durable for the web tier's access log to land either.
+  #
+  # Idempotent: cp + mkdir + a journald restart that flushes /run into /var.
+  local drop_in_dir="/etc/systemd/journald.conf.d"
+  local drop_in="$drop_in_dir/10-clawbox.conf"
+  local src="$PROJECT_DIR/config/journald-clawbox.conf"
+
+  if [ ! -f "$src" ]; then
+    echo "  Warning: $src missing, skipping persistent journal setup"
+    return 0
+  fi
+
+  mkdir -p "$drop_in_dir"
+  cp "$src" "$drop_in"
+  chmod 644 "$drop_in"
+
+  # journald creates /var/log/journal itself when Storage=persistent, but only
+  # on its next start — and systemd-tmpfiles is what applies the correct
+  # ownership and the systemd-journal ACL, so do it explicitly rather than
+  # leaving a root-only directory behind.
+  mkdir -p /var/log/journal
+  systemd-tmpfiles --create --prefix /var/log/journal >/dev/null 2>&1 || true
+
+  # Restart rather than reload: Storage= is only read at start. This also
+  # flushes what is currently in /run into /var, so the CURRENT boot's log is
+  # the first one that survives, not the next one.
+  systemctl restart systemd-journald >/dev/null 2>&1 || true
+  journalctl --flush >/dev/null 2>&1 || true
+
+  if [ -d /var/log/journal ]; then
+    echo "  Journal is persistent (/var/log/journal), capped at 200M"
+  else
+    echo "  Warning: /var/log/journal was not created — journal stays volatile"
+  fi
+
+  # NOT fixed here, and not fixable from userspace: the first ~10 s of every
+  # boot (~888 kernel lines) are stamped ~361 days early, because the Jetson has
+  # no battery-backed RTC and nvvrs-pseq-rtc only sets the system clock at
+  # monotonic ~10 s. `journalctl -b` timestamps before that handoff are bogus and
+  # `--list-boots` shows one "boot" spanning the gap. This is a hardware/BSP
+  # property of the Orin Nano dev kit, not something install.sh can correct.
 }
 
 step_systemd_services() {
@@ -2564,6 +2616,9 @@ step_post_update() {
   step_set_hostname || echo "  Warning: set_hostname step failed (non-fatal)"
   step_nm_dispatcher || echo "  Warning: nm_dispatcher step failed (non-fatal)"
   step_sysctl_linkdown || echo "  Warning: sysctl_linkdown step failed (non-fatal)"
+  # Without this call the persistent journal would be fresh-install-only, and
+  # every already-shipped box would keep losing its whole log on each reboot.
+  step_persistent_journal || echo "  Warning: persistent_journal step failed (non-fatal)"
   # step_vnc_refresh is a tiny idempotent refresh of the clawbox-vnc.service
   # unit + autocutsel package. Devices installed before the display-:99 move
   # and the clipboard-sync addition get both here without needing a reinstall.
@@ -3954,7 +4009,7 @@ DISPATCH_STEPS=(
   chpasswd gateway_setup ffmpeg_install polkit_rules systemd_services
   directories_permissions captive_portal_dns desktop_theme
   fix_git_perms browser_launch cloudflared_install
-  nm_dispatcher sysctl_linkdown post_update update_smoke validate_services
+  nm_dispatcher sysctl_linkdown persistent_journal post_update update_smoke validate_services
 )
 
 if [ "${1:-}" = "--step" ]; then

--- a/production-server.js
+++ b/production-server.js
@@ -10,6 +10,7 @@ const https = require("https");
 const fs = require("fs");
 const path = require("path");
 const WebSocket = require("ws");
+const { attachAccessLog } = require("./scripts/access-log.js");
 
 const GATEWAY_PORT = parseInt(process.env.GATEWAY_PORT || "18789", 10);
 const TERMINAL_WS_PORT = parseInt(process.env.TERMINAL_WS_PORT || "3006", 10);
@@ -218,6 +219,58 @@ try {
   console.warn("[production-server] Failed to set up local-ai token:", err.message);
 }
 
+// ─── Honest shutdown ───
+// systemd stops this unit with SIGTERM. With no handler the process died on the
+// default disposition and systemd recorded
+//   `Main process exited, code=exited, status=143/n/a` + `Failed with result 'exit-code'`
+// for EVERY clean stop or restart — so `systemctl status clawbox-setup` showed
+// red for the rest of the session and the Remote Access panel rendered a
+// "failed" alert after a perfectly normal restart. A support engineer cannot
+// tell that state apart from a real crash.
+//
+// Belt and braces with `SuccessExitStatus=143 SIGTERM` in the unit file: this
+// makes the exit genuinely 0, the unit line covers the window before this
+// handler is installed and any child that still exits 143.
+const SHUTDOWN_GRACE_MS = parseInt(process.env.SHUTDOWN_GRACE_MS || "5000", 10);
+const managedServers = new Set();
+let shuttingDown = false;
+
+function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`[production-server] ${signal} received — closing listeners`);
+
+  // Backstop: a socket that refuses to drain must not turn a clean stop into a
+  // SIGKILL (which systemd DOES report as a failure, and rightly).
+  const force = setTimeout(() => {
+    console.log("[production-server] shutdown grace elapsed — exiting");
+    process.exit(0);
+  }, SHUTDOWN_GRACE_MS);
+
+  let pending = managedServers.size;
+  if (pending === 0) {
+    clearTimeout(force);
+    process.exit(0);
+    return;
+  }
+  const done = () => {
+    if (--pending === 0) {
+      clearTimeout(force);
+      process.exit(0);
+    }
+  };
+  for (const server of managedServers) {
+    try {
+      server.close(done);
+    } catch {
+      done();
+    }
+  }
+}
+
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+
 // HTTP upgrade proxy — raw TCP pipe (works fine with bun's http.Server).
 // Routes by path: UPGRADE_ROUTES entries (e.g. /terminal-ws) go to their
 // configured port; everything else goes to the OpenClaw gateway.
@@ -328,6 +381,7 @@ function startHttpsServer(httpServer) {
       });
     });
 
+    managedServers.add(httpsServer);
     httpsServer.listen(HTTPS_PORT, "0.0.0.0", () => {
       console.log(`[production-server] HTTPS server listening on port ${HTTPS_PORT}`);
     });
@@ -347,6 +401,13 @@ function startHttpsServer(httpServer) {
 // Monkey-patch http.Server.prototype.listen to capture the server instance
 const originalListen = http.Server.prototype.listen;
 http.Server.prototype.listen = function (...args) {
+  managedServers.add(this);
+  // Attached here, on the ONE server Next actually creates, before it starts
+  // accepting. HTTPS requests are re-emitted onto this same server (see
+  // startHttpsServer), so this single call covers :80 and :443 both.
+  if (attachAccessLog(this)) {
+    console.log("[production-server] HTTP access log enabled");
+  }
   if (IS_DEV) {
     attachUpgradeProxy(this);
   } else {

--- a/scripts/access-log.js
+++ b/scripts/access-log.js
@@ -1,0 +1,231 @@
+// scripts/access-log.js
+//
+// HTTP access log for the ClawBox web tier.
+//
+// Until this existed the device kept NO record of any HTTP request. A QA probe
+// for a unique path over both the LAN and the public Cloudflare tunnel produced
+// zero journal lines on the box and there was no access-log file anywhere on
+// disk, so "which tunnel hostname is this request arriving on, and from where"
+// was simply unanswerable — the retired-quick-tunnel investigation stalled on
+// exactly that.
+//
+// Written as CommonJS because its only consumer, production-server.js, is CJS
+// (it has to be: it monkey-patches http.Server.prototype.listen before Next's
+// standalone bundle is required).
+//
+// The line goes to stdout, which for clawbox-setup.service is the journal — and
+// the journal is persistent now (config/journald-clawbox.conf), so these
+// survive a reboot. `logs_tail { unit: "clawbox-setup" }` surfaces them to the
+// agent with no extra wiring.
+
+/** Query parameter names whose VALUE must never reach a log line. */
+const SENSITIVE_QUERY_KEY = /(token|secret|password|passwd|pwd|key|auth|code|sig)/i;
+
+/** Hard ceiling on the logged request target. Bounds a log-flood line. */
+const MAX_PATH_CHARS = 512;
+const MAX_HOST_CHARS = 128;
+
+/** Request targets skipped by default — build assets, high volume, zero signal. */
+const STATIC_PREFIXES = ["/_next/static/", "/_next/image"];
+
+function isOff(value) {
+  return value === "0" || value === "false" || value === "off" || value === "no";
+}
+
+/** Access logging is on unless CLAWBOX_ACCESS_LOG explicitly turns it off. */
+function accessLogEnabled(env = process.env) {
+  return !isOff(String(env.CLAWBOX_ACCESS_LOG || "").toLowerCase());
+}
+
+/** Static assets are skipped unless CLAWBOX_ACCESS_LOG_STATIC asks for them. */
+function logsStaticAssets(env = process.env) {
+  const raw = String(env.CLAWBOX_ACCESS_LOG_STATIC || "").toLowerCase();
+  return raw === "1" || raw === "true" || raw === "on" || raw === "yes";
+}
+
+/** Strip anything that could forge a second log line or a terminal escape. */
+function stripControl(value) {
+  let out = "";
+  for (const ch of String(value)) {
+    const code = ch.codePointAt(0);
+    out += code < 0x20 || code === 0x7f ? "?" : ch;
+  }
+  return out;
+}
+
+function truncate(value, max) {
+  return value.length > max ? `${value.slice(0, max)}...` : value;
+}
+
+function safeDecode(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * The request target with sensitive query VALUES replaced by `REDACTED`.
+ * Parameter names are kept — knowing a request carried `?token=` is the useful
+ * half, and the value is the half that must not be written down.
+ */
+function sanitizePath(rawUrl) {
+  if (typeof rawUrl !== "string" || rawUrl === "") return "-";
+  const clean = stripControl(rawUrl);
+  const q = clean.indexOf("?");
+  if (q < 0) return truncate(clean, MAX_PATH_CHARS);
+
+  const pathname = clean.slice(0, q);
+  const redacted = clean
+    .slice(q + 1)
+    .split("&")
+    .map((pair) => {
+      const eq = pair.indexOf("=");
+      if (eq < 0) return pair;
+      const name = pair.slice(0, eq);
+      return SENSITIVE_QUERY_KEY.test(safeDecode(name)) ? `${name}=REDACTED` : pair;
+    })
+    .join("&");
+
+  return truncate(`${pathname}?${redacted}`, MAX_PATH_CHARS);
+}
+
+/** First entry of a possibly comma-joined forwarding header, if it looks like an IP. */
+function firstForwardedIp(headerValue) {
+  if (!headerValue) return null;
+  const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  const first = String(raw).split(",")[0].trim();
+  // Deliberately loose (v4, v6, v6-with-zone) but closed: a client controls
+  // these headers, so anything that is not IP-shaped is dropped rather than
+  // echoed into the log.
+  if (!first || first.length > 45 || !/^[0-9a-fA-F.:%]+$/.test(first)) return null;
+  return normalizeIp(first);
+}
+
+function normalizeIp(value) {
+  if (!value) return null;
+  // ::ffff:192.168.1.5 is how a v4 client shows up on a dual-stack listener.
+  return String(value).replace(/^::ffff:/i, "");
+}
+
+/**
+ * Client IP, Cloudflare-aware.
+ *
+ * Remote access runs through a Cloudflare Quick Tunnel, so for every request
+ * that matters `req.socket.remoteAddress` is 127.0.0.1 and the only real client
+ * address is in `cf-connecting-ip`. Order: cf-connecting-ip, x-forwarded-for,
+ * x-real-ip, socket.
+ *
+ * Note these headers are client-settable on a direct LAN request — the value is
+ * a diagnostic, not an authentication input, and nothing here consumes it as one.
+ */
+function clientIp(req) {
+  const headers = (req && req.headers) || {};
+  return (
+    firstForwardedIp(headers["cf-connecting-ip"]) ||
+    firstForwardedIp(headers["x-forwarded-for"]) ||
+    firstForwardedIp(headers["x-real-ip"]) ||
+    normalizeIp(req && req.socket && req.socket.remoteAddress) ||
+    "-"
+  );
+}
+
+/**
+ * The Host header the request arrived on. This is what makes a stray tunnel
+ * hostname traceable: the same box answers on clawbox.local, an IP, and every
+ * *.trycloudflare.com URL it has ever published, and the access line is the only
+ * place that distinction is recorded.
+ */
+function requestHost(req) {
+  const headers = (req && req.headers) || {};
+  const raw = headers["host"];
+  if (!raw) return "-";
+  const host = stripControl(Array.isArray(raw) ? raw[0] : raw).trim();
+  if (!host || !/^[A-Za-z0-9._:\-[\]]+$/.test(host)) return "-";
+  return truncate(host, MAX_HOST_CHARS);
+}
+
+/**
+ * One access line. Stable, greppable, fixed field order:
+ *
+ *   [access] 200 GET /setup-api/system/stats 9ms ip=192.168.50.10 host=clawbox.local
+ *   [access] 404 GET /probe 1ms ip=203.0.113.7 host=abc.trycloudflare.com aborted
+ */
+function formatAccessLine(entry) {
+  const parts = [
+    "[access]",
+    String(entry.status == null ? "-" : entry.status),
+    stripControl(entry.method || "-"),
+    entry.path || "-",
+    `${Math.max(0, Math.round(entry.durationMs || 0))}ms`,
+    `ip=${entry.ip || "-"}`,
+    `host=${entry.host || "-"}`,
+  ];
+  if (entry.aborted) parts.push("aborted");
+  return parts.join(" ");
+}
+
+function shouldSkip(rawUrl, env) {
+  if (logsStaticAssets(env)) return false;
+  const target = typeof rawUrl === "string" ? rawUrl : "";
+  return STATIC_PREFIXES.some((p) => target.startsWith(p));
+}
+
+/**
+ * Attach the request logger to an http/https server.
+ *
+ * Adding a second 'request' listener does not displace Next's handler — Node
+ * calls every registered listener — so this observes without intercepting. The
+ * timer stops on 'close' rather than 'finish' because an aborted response never
+ * fires 'finish', and a request that died halfway is exactly the one worth
+ * having in the log.
+ *
+ * Returns true when logging was attached, false when it is disabled.
+ */
+function attachAccessLog(server, options = {}) {
+  const env = options.env || process.env;
+  if (!accessLogEnabled(env)) return false;
+  const write = options.write || ((line) => console.log(line));
+  const now = options.now || (() => Number(process.hrtime.bigint() / 1000000n));
+
+  server.on("request", (req, res) => {
+    if (shouldSkip(req.url, env)) return;
+    const startedAt = now();
+    const ip = clientIp(req);
+    const host = requestHost(req);
+    const method = req.method;
+    const path = sanitizePath(req.url);
+
+    res.on("close", () => {
+      try {
+        write(
+          formatAccessLine({
+            status: res.statusCode,
+            method,
+            path,
+            durationMs: now() - startedAt,
+            ip,
+            host,
+            aborted: res.writableEnded === false,
+          }),
+        );
+      } catch {
+        // A logger must never take the request path down with it.
+      }
+    });
+  });
+
+  return true;
+}
+
+module.exports = {
+  accessLogEnabled,
+  attachAccessLog,
+  clientIp,
+  formatAccessLine,
+  logsStaticAssets,
+  requestHost,
+  sanitizePath,
+  shouldSkip,
+};

--- a/scripts/run-tunnel.sh
+++ b/scripts/run-tunnel.sh
@@ -11,6 +11,14 @@ set -uo pipefail
 DATA_DIR="${CLAWBOX_ROOT:-/home/clawbox/clawbox}/data"
 TUNNEL_DIR="$DATA_DIR/cloudflared"
 TUNNEL_URL_FILE="$TUNNEL_DIR/tunnel.url"
+# Append-only record of every URL this box has published, newest last. Deliberately
+# NOT removed by cleanup(): `tunnel.url` answers "what is the URL right now", and
+# it is erased on every stop. This answers "which hostnames has this device ever
+# been reachable on", which is the question a stray quick-tunnel URL raises — and
+# with no HTTP access log and a volatile journal there was previously no way to
+# answer it at all.
+TUNNEL_URL_LOG="$TUNNEL_DIR/tunnel-url.log"
+TUNNEL_URL_LOG_MAX=50
 LOCAL_SERVICE_URL="${LOCAL_SERVICE_URL:-http://localhost:80}"
 CLOUDFLARED_BIN="${CLOUDFLARED_BIN:-/usr/local/bin/cloudflared}"
 
@@ -20,7 +28,30 @@ rm -f "$TUNNEL_URL_FILE"
 cleanup() {
   rm -f "$TUNNEL_URL_FILE"
 }
-trap cleanup EXIT INT TERM
+
+# A stop is not a failure. systemd stops this unit with SIGTERM, which kills
+# cloudflared in the control group; with `pipefail` the pipeline below then
+# returned 143 and systemd logged `Failed with result 'exit-code'`, which the
+# Remote Access panel renders as a red "Tunnel failed to start" alert — right
+# after the user pressed Stop themselves.
+SIGNALLED=0
+on_signal() {
+  SIGNALLED=1
+}
+trap cleanup EXIT
+trap on_signal INT TERM
+
+record_url() {
+  local url="$1"
+  printf '%s\n' "$url" > "$TUNNEL_URL_FILE"
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$url" >> "$TUNNEL_URL_LOG"
+  # Keep the history bounded — it is a diagnostic, not an archive.
+  if [ "$(wc -l < "$TUNNEL_URL_LOG" 2>/dev/null || echo 0)" -gt "$TUNNEL_URL_LOG_MAX" ]; then
+    tail -n "$TUNNEL_URL_LOG_MAX" "$TUNNEL_URL_LOG" > "$TUNNEL_URL_LOG.tmp" &&
+      mv "$TUNNEL_URL_LOG.tmp" "$TUNNEL_URL_LOG"
+  fi
+  echo "[run-tunnel] captured URL: $url"
+}
 
 if [ ! -x "$CLOUDFLARED_BIN" ]; then
   echo "[run-tunnel] cloudflared not found at $CLOUDFLARED_BIN" >&2
@@ -39,8 +70,16 @@ while IFS= read -r line; do
   if [ ! -s "$TUNNEL_URL_FILE" ]; then
     url=$(printf '%s\n' "$line" | grep -oE 'https://[a-z0-9-]+\.trycloudflare\.com' | head -n 1 || true)
     if [ -n "${url:-}" ]; then
-      printf '%s\n' "$url" > "$TUNNEL_URL_FILE"
-      echo "[run-tunnel] captured URL: $url"
+      record_url "$url"
     fi
   fi
 done
+STATUS=${PIPESTATUS[0]}
+
+# 143 = 128+SIGTERM, 130 = 128+SIGINT. Either means "someone asked us to stop",
+# and the honest exit status for that is 0.
+if [ "$SIGNALLED" = "1" ] || [ "$STATUS" = "143" ] || [ "$STATUS" = "130" ]; then
+  echo "[run-tunnel] stopped by signal — exiting cleanly"
+  exit 0
+fi
+exit "$STATUS"

--- a/src/app/setup-api/portal/status/route.ts
+++ b/src/app/setup-api/portal/status/route.ts
@@ -3,6 +3,7 @@ import {
   getTunnelServiceState,
   isInstalled,
   readTunnelUrl,
+  readTunnelUrlHistory,
 } from "@/lib/cloudflared";
 import { pushHeartbeatIfChanged } from "@/lib/portal-heartbeat";
 
@@ -16,14 +17,21 @@ const PORTAL_BASE = process.env.PORTAL_WEB || "https://clawbox.com";
  *   tunnel.installed  — cloudflared binary is on PATH
  *   tunnel.service    — systemd state for clawbox-tunnel.service
  *   tunnel.url        — the *.trycloudflare.com URL the tunnel published
+ *   tunnel.history    — the last few URLs this device has published, newest
+ *                       first, each with the time it was published. `url` goes
+ *                       null the moment the tunnel stops, so without this there
+ *                       was no way to find out which hostnames the box had ever
+ *                       been reachable on — the question a stray, still-serving
+ *                       quick-tunnel URL raises.
  *   portalAddDeviceUrl — link to the portal's "Add Device" page
  */
 export async function GET() {
   try {
-    const [installed, service, url] = await Promise.all([
+    const [installed, service, url, history] = await Promise.all([
       isInstalled(),
       getTunnelServiceState(),
       readTunnelUrl(),
+      readTunnelUrlHistory(),
     ]);
 
     // Fire-and-forget: push the new URL to the portal so the user's Devices
@@ -36,6 +44,7 @@ export async function GET() {
         installed,
         service,
         url,
+        history,
       },
       portalAddDeviceUrl: `${PORTAL_BASE}/portal/devices?addDevice=1`,
       portalWeb: PORTAL_BASE,

--- a/src/app/setup-api/system/stats/route.ts
+++ b/src/app/setup-api/system/stats/route.ts
@@ -4,6 +4,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import fs from "fs";
 import fsP from "fs/promises";
+import { getCpuUsage } from "@/lib/cpu-usage";
 
 const execFileAsync = promisify(execFile);
 
@@ -31,36 +32,6 @@ interface ProcessEntry {
   cpu: number;
   mem: number;
   command: string;
-}
-
-async function getCpuUsage(): Promise<number> {
-  try {
-    const stat1 = fs.readFileSync("/proc/stat", "utf-8");
-    const line1 = stat1.split("\n")[0];
-    const parts1 = line1.trim().split(/\s+/).slice(1).map(Number);
-    const idle1 = parts1[3];
-    const total1 = parts1.reduce((a, b) => a + b, 0);
-
-    // Sample /proc/stat twice with a non-blocking 200ms gap. A synchronous
-    // busy-wait here would freeze the single Node event loop on every poll.
-    await new Promise((r) => setTimeout(r, 200));
-
-    const stat2 = fs.readFileSync("/proc/stat", "utf-8");
-    const line2 = stat2.split("\n")[0];
-    const parts2 = line2.trim().split(/\s+/).slice(1).map(Number);
-    const idle2 = parts2[3];
-    const total2 = parts2.reduce((a, b) => a + b, 0);
-
-    const dIdle = idle2 - idle1;
-    const dTotal = total2 - total1;
-
-    if (dTotal === 0) return 0;
-    return Math.round(((dTotal - dIdle) / dTotal) * 100);
-  } catch {
-    // Fallback: use load average approximation
-    const cpuCount = os.cpus().length;
-    return Math.min(100, Math.round((os.loadavg()[0] / cpuCount) * 100));
-  }
 }
 
 async function getDiskUsage(): Promise<DiskMount[]> {
@@ -228,11 +199,11 @@ export async function GET() {
     const freeMem = os.freemem();
     const usedMem = totalMem - freeMem;
 
-    // Gather everything that touches the event loop (the 200ms CPU sample,
-    // temp/gpu reads, and the promisified execFile shells) in parallel so we
-    // never block the single Node process.
-    const [cpuUsage, temp, gpuUsage, kernel, storage, processes] = await Promise.all([
-      getCpuUsage(),
+    // CPU usage is a cached-delta read now (src/lib/cpu-usage.ts) — no sleep, no
+    // await. Everything below it still touches the event loop (temp/gpu reads,
+    // promisified execFile shells) so it stays in one Promise.all.
+    const cpuUsage = getCpuUsage();
+    const [temp, gpuUsage, kernel, storage, processes] = await Promise.all([
       getTemperature(),
       getGpuUsage(),
       getKernelRelease(),

--- a/src/lib/cloudflared.ts
+++ b/src/lib/cloudflared.ts
@@ -9,7 +9,20 @@ const execFileAsync = promisify(execFile);
 export const CLOUDFLARED_BIN = process.env.CLOUDFLARED_BIN || "/usr/local/bin/cloudflared";
 export const CLOUDFLARED_DIR = path.join(DATA_DIR, "cloudflared");
 export const TUNNEL_URL_FILE = path.join(CLOUDFLARED_DIR, "tunnel.url");
+/**
+ * Append-only record of every URL the tunnel has published, written by
+ * scripts/run-tunnel.sh as `<iso8601> <url>` lines, newest last.
+ *
+ * `tunnel.url` is erased on every stop, so it can only ever answer "what is the
+ * URL right now". When a retired *.trycloudflare.com hostname was still serving
+ * this box, nobody could say which URLs it had ever published — the journal was
+ * volatile and there was no HTTP access log. This file is that record.
+ */
+export const TUNNEL_URL_LOG_FILE = path.join(CLOUDFLARED_DIR, "tunnel-url.log");
 export const TUNNEL_SERVICE = "clawbox-tunnel.service";
+
+/** Shape of a Cloudflare Quick Tunnel hostname — nothing else is ever returned. */
+const TUNNEL_URL_PATTERN = /^https:\/\/[a-z0-9-]+\.trycloudflare\.com\/?$/i;
 
 export async function isInstalled(): Promise<boolean> {
   try {
@@ -26,11 +39,45 @@ export async function readTunnelUrl(): Promise<string | null> {
     const raw = (await fs.readFile(TUNNEL_URL_FILE, "utf-8")).trim();
     if (!raw) return null;
     // Sanity-check the shape so we never return garbage.
-    if (!/^https:\/\/[a-z0-9-]+\.trycloudflare\.com\/?$/i.test(raw)) return null;
+    if (!TUNNEL_URL_PATTERN.test(raw)) return null;
     return raw.replace(/\/+$/, "");
   } catch {
     return null;
   }
+}
+
+export interface TunnelUrlRecord {
+  /** ISO-8601 UTC timestamp of when the URL was published. */
+  at: string;
+  url: string;
+}
+
+/**
+ * Recent tunnel URLs, newest first. Missing or unparsable lines are skipped
+ * rather than thrown — this is a diagnostic, and a half-written line must never
+ * take the status endpoint down.
+ */
+export async function readTunnelUrlHistory(limit = 10): Promise<TunnelUrlRecord[]> {
+  if (!Number.isFinite(limit) || limit <= 0) return [];
+  let raw: string;
+  try {
+    raw = await fs.readFile(TUNNEL_URL_LOG_FILE, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const records: TunnelUrlRecord[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [at, url] = trimmed.split(/\s+/, 2);
+    if (!at || !url) continue;
+    if (!TUNNEL_URL_PATTERN.test(url)) continue;
+    if (Number.isNaN(Date.parse(at))) continue;
+    records.push({ at, url: url.replace(/\/+$/, "") });
+  }
+
+  return records.reverse().slice(0, limit);
 }
 
 export async function startTunnelService(): Promise<void> {

--- a/src/lib/cpu-usage.ts
+++ b/src/lib/cpu-usage.ts
@@ -1,0 +1,98 @@
+import fs from "fs";
+import os from "os";
+
+/**
+ * CPU utilisation from /proc/stat, WITHOUT a per-request sleep.
+ *
+ * The old `getCpuUsage()` in the stats route read /proc/stat, slept 200 ms, read
+ * it again and diffed. That put a hard ~209 ms floor under every
+ * `/setup-api/system/stats` response (measured on the box: 5 authenticated
+ * requests, 208-211 ms, of which ~8-11 ms was the actual work) for an endpoint
+ * that the System app and Settings > System poll every 3 s.
+ *
+ * The delta does not need a sleep — it needs two samples. Keep the last sample
+ * in module scope and diff the current read against it, so the figure is a real
+ * average over the caller's own poll interval (3 s) instead of an artificial
+ * 200 ms window. First call after boot has nothing to diff against and falls
+ * back to the load-average approximation, exactly as the old code did when
+ * /proc/stat was unreadable.
+ */
+
+export interface CpuSample {
+  idle: number;
+  total: number;
+  /** Date.now() at read time — only used to detect a stale sample. */
+  at: number;
+}
+
+/**
+ * A sample older than this is not diffed. Nothing polls that slowly in normal
+ * operation, so an older sample means the endpoint was idle for a long time and
+ * the resulting figure would be an average over minutes, presented as "now".
+ */
+const MAX_SAMPLE_AGE_MS = 60_000;
+
+let lastSample: CpuSample | null = null;
+let lastUsage: number | null = null;
+
+/** Parse the aggregate `cpu` line of /proc/stat. Returns null if unusable. */
+export function parseProcStat(raw: string, now: number): CpuSample | null {
+  const line = raw.split("\n")[0];
+  if (!line || !line.startsWith("cpu")) return null;
+  const parts = line.trim().split(/\s+/).slice(1).map(Number);
+  // idle is field 4 (user nice system idle ...). Anything shorter is not
+  // /proc/stat and must not be treated as a zero-idle 100%-busy CPU.
+  if (parts.length < 4 || parts.some((n) => !Number.isFinite(n))) return null;
+  const idle = parts[3];
+  const total = parts.reduce((a, b) => a + b, 0);
+  if (total <= 0) return null;
+  return { idle, total, at: now };
+}
+
+function loadAverageApproximation(): number {
+  const cpuCount = os.cpus().length || 1;
+  return Math.min(100, Math.max(0, Math.round((os.loadavg()[0] / cpuCount) * 100)));
+}
+
+/**
+ * Percent busy since the previous call. Never sleeps, never blocks.
+ *
+ * Returns the load-average approximation on the first call, when /proc/stat is
+ * unreadable, or when the previous sample is stale; returns the previously
+ * computed value when two calls land inside the same jiffy (dTotal === 0), which
+ * is what a double-click on Refresh looks like.
+ */
+export function getCpuUsage(now: number = Date.now()): number {
+  let current: CpuSample | null = null;
+  try {
+    current = parseProcStat(fs.readFileSync("/proc/stat", "utf-8"), now);
+  } catch {
+    current = null;
+  }
+
+  if (!current) return lastUsage ?? loadAverageApproximation();
+
+  const previous = lastSample;
+  lastSample = current;
+
+  if (!previous || now - previous.at > MAX_SAMPLE_AGE_MS) {
+    // Nothing (usable) to diff against yet. The NEXT call gets a real figure.
+    return lastUsage ?? loadAverageApproximation();
+  }
+
+  const dTotal = current.total - previous.total;
+  const dIdle = current.idle - previous.idle;
+  // A counter that went backwards means /proc/stat was re-read across a
+  // suspend/rollover; treat it like "no usable previous sample".
+  if (dTotal <= 0 || dIdle < 0) return lastUsage ?? loadAverageApproximation();
+
+  const usage = Math.min(100, Math.max(0, Math.round(((dTotal - dIdle) / dTotal) * 100)));
+  lastUsage = usage;
+  return usage;
+}
+
+/** Test seam — drops the cached sample so each test starts cold. */
+export function __resetCpuUsageCache(): void {
+  lastSample = null;
+  lastUsage = null;
+}

--- a/src/tests/routes/portal.test.ts
+++ b/src/tests/routes/portal.test.ts
@@ -6,6 +6,7 @@ const cloudflaredMock = {
   stopTunnelService: vi.fn(),
   getTunnelServiceState: vi.fn(),
   readTunnelUrl: vi.fn(),
+  readTunnelUrlHistory: vi.fn(),
 };
 const heartbeatMock = {
   pushHeartbeatIfChanged: vi.fn(),
@@ -26,6 +27,10 @@ describe("/setup-api/portal/status", () => {
     cloudflaredMock.readTunnelUrl.mockResolvedValue(
       "https://abc.trycloudflare.com",
     );
+    cloudflaredMock.readTunnelUrlHistory.mockResolvedValue([
+      { at: "2026-08-22T09:00:00Z", url: "https://abc.trycloudflare.com" },
+      { at: "2026-08-21T09:00:00Z", url: "https://old.trycloudflare.com" },
+    ]);
 
     const mod = await import("@/app/setup-api/portal/status/route");
     const res = await mod.GET();
@@ -35,6 +40,10 @@ describe("/setup-api/portal/status", () => {
       installed: true,
       service: "active",
       url: "https://abc.trycloudflare.com",
+      history: [
+        { at: "2026-08-22T09:00:00Z", url: "https://abc.trycloudflare.com" },
+        { at: "2026-08-21T09:00:00Z", url: "https://old.trycloudflare.com" },
+      ],
     });
     expect(body.portalAddDeviceUrl).toMatch(/clawbox\.com.*addDevice/);
     expect(body.portalWeb).toMatch(/clawbox\.com/);
@@ -47,6 +56,12 @@ describe("/setup-api/portal/status", () => {
     cloudflaredMock.isInstalled.mockResolvedValue(false);
     cloudflaredMock.getTunnelServiceState.mockResolvedValue("inactive");
     cloudflaredMock.readTunnelUrl.mockResolvedValue(null);
+    // A stopped tunnel still has to say which hostnames it HAS published —
+    // that is the question a stray, still-serving quick-tunnel URL raises, and
+    // `url` alone can never answer it.
+    cloudflaredMock.readTunnelUrlHistory.mockResolvedValue([
+      { at: "2026-08-21T09:00:00Z", url: "https://retired.trycloudflare.com" },
+    ]);
 
     const mod = await import("@/app/setup-api/portal/status/route");
     const res = await mod.GET();
@@ -54,6 +69,9 @@ describe("/setup-api/portal/status", () => {
     expect(body.tunnel.installed).toBe(false);
     expect(body.tunnel.service).toBe("inactive");
     expect(body.tunnel.url).toBeNull();
+    expect(body.tunnel.history).toEqual([
+      { at: "2026-08-21T09:00:00Z", url: "https://retired.trycloudflare.com" },
+    ]);
   });
 
   it("returns 500 when an underlying call throws", async () => {

--- a/src/tests/routes/system/stats.test.ts
+++ b/src/tests/routes/system/stats.test.ts
@@ -179,6 +179,20 @@ SwapFree:        1500000 kB`;
     expect(body.cpu).toBeDefined();
   });
 
+  it("responds without the 200 ms per-request sleep (TASK-456)", async () => {
+    // The route used to read /proc/stat, `await` a 200 ms timer, then read it
+    // again — a hard ~209 ms floor on every response, measured live on the box
+    // (5 authenticated requests, 208-211 ms), for an endpoint the System app
+    // and Settings > System poll every 3 s. src/lib/cpu-usage.ts diffs against
+    // a cached snapshot instead. Three sequential requests could not finish in
+    // under 600 ms on the old implementation.
+    const startedAt = Date.now();
+    await systemStatsGet();
+    await systemStatsGet();
+    await systemStatsGet();
+    expect(Date.now() - startedAt).toBeLessThan(150);
+  });
+
   it("handles df command failure gracefully", async () => {
     mockExecSync.mockImplementation((cmd: string) => {
       if (cmd.startsWith("df")) {

--- a/src/tests/unit/access-log.test.ts
+++ b/src/tests/unit/access-log.test.ts
@@ -1,0 +1,305 @@
+import { EventEmitter } from "events";
+import { describe, expect, it } from "vitest";
+
+// scripts/access-log.js is CommonJS on purpose — production-server.js is CJS and
+// has to be (it monkey-patches http.Server.prototype.listen before Next's
+// standalone bundle loads), so the logger it requires cannot be an ES module.
+import accessLog from "../../../scripts/access-log.js";
+
+const {
+  accessLogEnabled,
+  attachAccessLog,
+  clientIp,
+  formatAccessLine,
+  logsStaticAssets,
+  requestHost,
+  sanitizePath,
+  shouldSkip,
+} = accessLog as {
+  accessLogEnabled: (env?: NodeJS.ProcessEnv) => boolean;
+  attachAccessLog: (
+    server: EventEmitter,
+    options?: { env?: NodeJS.ProcessEnv; write?: (line: string) => void; now?: () => number },
+  ) => boolean;
+  clientIp: (req: unknown) => string;
+  formatAccessLine: (entry: Record<string, unknown>) => string;
+  logsStaticAssets: (env?: NodeJS.ProcessEnv) => boolean;
+  requestHost: (req: unknown) => string;
+  sanitizePath: (rawUrl: unknown) => string;
+  shouldSkip: (rawUrl: unknown, env?: NodeJS.ProcessEnv) => boolean;
+};
+
+/** A minimal stand-in for an http.IncomingMessage. */
+function fakeReq(overrides: Record<string, unknown> = {}) {
+  return {
+    method: "GET",
+    url: "/setup-api/system/stats",
+    headers: { host: "clawbox.local" },
+    socket: { remoteAddress: "192.168.50.10" },
+    ...overrides,
+  };
+}
+
+/** A minimal stand-in for an http.ServerResponse. */
+class FakeRes extends EventEmitter {
+  statusCode = 200;
+  writableEnded = true;
+}
+
+describe("access log — line format", () => {
+  // The bug: the device kept NO record of any HTTP request. Two probes to a
+  // unique path (one over the LAN, one over the public tunnel) produced zero
+  // journal lines anywhere on the box and there was no access-log file on disk.
+  it("emits method, path, status, duration, client ip and host", () => {
+    expect(
+      formatAccessLine({
+        status: 200,
+        method: "GET",
+        path: "/setup-api/system/stats",
+        durationMs: 9.4,
+        ip: "192.168.50.10",
+        host: "clawbox.local",
+      }),
+    ).toBe("[access] 200 GET /setup-api/system/stats 9ms ip=192.168.50.10 host=clawbox.local");
+  });
+
+  it("marks an aborted response instead of silently reporting 200", () => {
+    expect(
+      formatAccessLine({
+        status: 404,
+        method: "GET",
+        path: "/probe",
+        durationMs: 1,
+        ip: "203.0.113.7",
+        host: "abc.trycloudflare.com",
+        aborted: true,
+      }),
+    ).toBe("[access] 404 GET /probe 1ms ip=203.0.113.7 host=abc.trycloudflare.com aborted");
+  });
+
+  it("never emits a negative or fractional duration", () => {
+    const line = formatAccessLine({ status: 200, method: "GET", path: "/", durationMs: -5, ip: "-", host: "-" });
+    expect(line).toContain(" 0ms ");
+  });
+
+  it("fills every missing field rather than printing undefined", () => {
+    expect(formatAccessLine({})).toBe("[access] - - - 0ms ip=- host=-");
+  });
+});
+
+describe("access log — path sanitising", () => {
+  it("keeps an ordinary path untouched", () => {
+    expect(sanitizePath("/setup-api/portal/status")).toBe("/setup-api/portal/status");
+  });
+
+  it("redacts sensitive query VALUES but keeps the parameter names", () => {
+    // Knowing a request carried a token is the useful half; the value is the
+    // half that must not end up in a durable, agent-readable journal.
+    expect(sanitizePath("/x?token=abcdef&page=2")).toBe("/x?token=REDACTED&page=2");
+    expect(sanitizePath("/x?apiKey=sk-live-1&password=hunter2")).toBe(
+      "/x?apiKey=REDACTED&password=REDACTED",
+    );
+    expect(sanitizePath("/setup-api/oauth?code=4/0AX&state=s")).toBe(
+      "/setup-api/oauth?code=REDACTED&state=s",
+    );
+  });
+
+  it("redacts a percent-encoded parameter name too", () => {
+    expect(sanitizePath("/x?%74oken=secretvalue")).toBe("/x?%74oken=REDACTED");
+  });
+
+  it("leaves non-sensitive query parameters readable", () => {
+    expect(sanitizePath("/setup-api/webapps?app=notes")).toBe("/setup-api/webapps?app=notes");
+  });
+
+  it("strips control characters so a request cannot forge a second log line", () => {
+    expect(sanitizePath("/a\nb\r[access] 200 GET /fake 0ms")).not.toContain("\n");
+    expect(sanitizePath("/a\nb")).toBe("/a?b");
+  });
+
+  it("bounds the logged target so a long URL cannot bloat the journal", () => {
+    const line = sanitizePath(`/${"a".repeat(2000)}`);
+    expect(line.length).toBeLessThanOrEqual(515);
+    expect(line.endsWith("...")).toBe(true);
+  });
+
+  it("handles a missing or non-string url", () => {
+    expect(sanitizePath(undefined)).toBe("-");
+    expect(sanitizePath("")).toBe("-");
+  });
+});
+
+describe("access log — client ip", () => {
+  // Remote access runs through a Cloudflare Quick Tunnel, so for every request
+  // that arrives from the internet the socket address is 127.0.0.1 and the only
+  // real client address is in cf-connecting-ip.
+  it("prefers cf-connecting-ip over the loopback socket address", () => {
+    expect(
+      clientIp(
+        fakeReq({
+          headers: { host: "abc.trycloudflare.com", "cf-connecting-ip": "203.0.113.7" },
+          socket: { remoteAddress: "127.0.0.1" },
+        }),
+      ),
+    ).toBe("203.0.113.7");
+  });
+
+  it("falls back to x-forwarded-for, then x-real-ip, then the socket", () => {
+    expect(clientIp(fakeReq({ headers: { "x-forwarded-for": "198.51.100.4, 10.0.0.1" } }))).toBe(
+      "198.51.100.4",
+    );
+    expect(clientIp(fakeReq({ headers: { "x-real-ip": "198.51.100.9" } }))).toBe("198.51.100.9");
+    expect(clientIp(fakeReq({ headers: {} }))).toBe("192.168.50.10");
+  });
+
+  it("unwraps an IPv4-mapped IPv6 socket address", () => {
+    expect(clientIp(fakeReq({ headers: {}, socket: { remoteAddress: "::ffff:192.168.50.10" } }))).toBe(
+      "192.168.50.10",
+    );
+  });
+
+  it("drops a forwarding header that is not IP-shaped instead of echoing it", () => {
+    // These headers are client-settable on a direct LAN request.
+    expect(clientIp(fakeReq({ headers: { "cf-connecting-ip": "not an ip <script>" } }))).toBe(
+      "192.168.50.10",
+    );
+    expect(clientIp(fakeReq({ headers: { "x-forwarded-for": "a".repeat(100) } }))).toBe(
+      "192.168.50.10",
+    );
+  });
+
+  it("returns - when there is nothing at all", () => {
+    expect(clientIp({ headers: {}, socket: {} })).toBe("-");
+    expect(clientIp({})).toBe("-");
+  });
+});
+
+describe("access log — host", () => {
+  // The Host header is what makes a stray tunnel hostname traceable: the same
+  // box answers on clawbox.local, an IP, and every *.trycloudflare.com URL it
+  // has published.
+  it("records the hostname the request arrived on", () => {
+    expect(requestHost(fakeReq({ headers: { host: "abc-123.trycloudflare.com" } }))).toBe(
+      "abc-123.trycloudflare.com",
+    );
+    expect(requestHost(fakeReq({ headers: { host: "10.42.0.1:80" } }))).toBe("10.42.0.1:80");
+  });
+
+  it("rejects a malformed host rather than logging it", () => {
+    expect(requestHost(fakeReq({ headers: { host: "evil host\nX" } }))).toBe("-");
+    expect(requestHost(fakeReq({ headers: {} }))).toBe("-");
+  });
+});
+
+describe("access log — volume controls", () => {
+  it("is on by default and off only when explicitly disabled", () => {
+    expect(accessLogEnabled({} as NodeJS.ProcessEnv)).toBe(true);
+    expect(accessLogEnabled({ CLAWBOX_ACCESS_LOG: "1" } as NodeJS.ProcessEnv)).toBe(true);
+    for (const off of ["0", "false", "off", "no", "OFF"]) {
+      expect(accessLogEnabled({ CLAWBOX_ACCESS_LOG: off } as NodeJS.ProcessEnv)).toBe(false);
+    }
+  });
+
+  it("skips build assets by default and includes them on request", () => {
+    const env = {} as NodeJS.ProcessEnv;
+    expect(shouldSkip("/_next/static/chunks/main.js", env)).toBe(true);
+    expect(shouldSkip("/_next/image?url=x", env)).toBe(true);
+    expect(shouldSkip("/setup-api/system/stats", env)).toBe(false);
+
+    const verbose = { CLAWBOX_ACCESS_LOG_STATIC: "1" } as NodeJS.ProcessEnv;
+    expect(logsStaticAssets(verbose)).toBe(true);
+    expect(shouldSkip("/_next/static/chunks/main.js", verbose)).toBe(false);
+  });
+});
+
+describe("access log — attachAccessLog", () => {
+  function run(options: { env?: NodeJS.ProcessEnv; reqOverrides?: Record<string, unknown> } = {}) {
+    const server = new EventEmitter();
+    const lines: string[] = [];
+    let clock = 0;
+    const attached = attachAccessLog(server, {
+      env: options.env ?? ({} as NodeJS.ProcessEnv),
+      write: (line) => lines.push(line),
+      now: () => clock,
+    });
+    const req = fakeReq(options.reqOverrides);
+    const res = new FakeRes();
+    server.emit("request", req, res);
+    clock = 12;
+    return { lines, res, attached, finish: () => res.emit("close") };
+  }
+
+  it("logs one line per completed request", () => {
+    const { lines, res, finish, attached } = run();
+    expect(attached).toBe(true);
+    expect(lines).toEqual([]); // nothing logged until the response closes
+    res.statusCode = 200;
+    finish();
+    expect(lines).toEqual([
+      "[access] 200 GET /setup-api/system/stats 12ms ip=192.168.50.10 host=clawbox.local",
+    ]);
+  });
+
+  it("logs an aborted request — the one most worth having", () => {
+    // 'finish' never fires on an aborted response, which is why the timer stops
+    // on 'close'.
+    const { lines, res, finish } = run();
+    res.writableEnded = false;
+    res.statusCode = 499;
+    finish();
+    expect(lines[0]).toContain("499");
+    expect(lines[0]).toContain("aborted");
+  });
+
+  it("attaches without displacing an existing request handler", () => {
+    const server = new EventEmitter();
+    const seen: string[] = [];
+    server.on("request", () => seen.push("next-handler"));
+    attachAccessLog(server, { env: {} as NodeJS.ProcessEnv, write: () => {} });
+    server.emit("request", fakeReq(), new FakeRes());
+    expect(seen).toEqual(["next-handler"]);
+  });
+
+  it("does nothing when disabled", () => {
+    const server = new EventEmitter();
+    const attached = attachAccessLog(server, {
+      env: { CLAWBOX_ACCESS_LOG: "0" } as NodeJS.ProcessEnv,
+      write: () => {},
+    });
+    expect(attached).toBe(false);
+    expect(server.listenerCount("request")).toBe(0);
+  });
+
+  it("records the tunnel hostname and the real client ip for a remote request", () => {
+    const { lines, finish } = run({
+      reqOverrides: {
+        url: "/login?token=supersecret",
+        headers: { host: "abc-123.trycloudflare.com", "cf-connecting-ip": "203.0.113.7" },
+        socket: { remoteAddress: "127.0.0.1" },
+      },
+    });
+    finish();
+    expect(lines[0]).toBe(
+      "[access] 200 GET /login?token=REDACTED 12ms ip=203.0.113.7 host=abc-123.trycloudflare.com",
+    );
+  });
+
+  it("skips static assets so the log stays signal", () => {
+    const { lines, finish } = run({ reqOverrides: { url: "/_next/static/chunks/main.js" } });
+    finish();
+    expect(lines).toEqual([]);
+  });
+
+  it("never lets a failing writer take the request path down", () => {
+    const server = new EventEmitter();
+    attachAccessLog(server, {
+      env: {} as NodeJS.ProcessEnv,
+      write: () => {
+        throw new Error("journal is full");
+      },
+    });
+    const res = new FakeRes();
+    server.emit("request", fakeReq(), res);
+    expect(() => res.emit("close")).not.toThrow();
+  });
+});

--- a/src/tests/unit/cloudflared.test.ts
+++ b/src/tests/unit/cloudflared.test.ts
@@ -28,6 +28,7 @@ vi.mock("child_process", () => ({
 
 let cloudflared: typeof import("@/lib/cloudflared");
 let TUNNEL_URL_FILE: string;
+let TUNNEL_URL_LOG_FILE: string;
 
 beforeAll(async () => {
   process.env.CLAWBOX_ROOT = TEST_ROOT;
@@ -37,6 +38,7 @@ beforeAll(async () => {
   cloudflared = await import("@/lib/cloudflared");
   await fs.mkdir(cloudflared.CLOUDFLARED_DIR, { recursive: true });
   TUNNEL_URL_FILE = cloudflared.TUNNEL_URL_FILE;
+  TUNNEL_URL_LOG_FILE = cloudflared.TUNNEL_URL_LOG_FILE;
 });
 
 afterAll(async () => {
@@ -48,6 +50,7 @@ afterAll(async () => {
 beforeEach(async () => {
   execFileMock.mockReset();
   await fs.rm(TUNNEL_URL_FILE, { force: true });
+  await fs.rm(TUNNEL_URL_LOG_FILE, { force: true });
   await fs.rm(FAKE_BIN, { force: true });
 });
 
@@ -147,5 +150,69 @@ describe("cloudflared — getTunnelServiceState", () => {
   it("returns `unknown` for unrecognized output", async () => {
     execFileMock.mockReturnValue({ stdout: "weird\n" });
     expect(await cloudflared.getTunnelServiceState()).toBe("unknown");
+  });
+});
+
+describe("cloudflared — readTunnelUrlHistory", () => {
+  // `tunnel.url` is deleted by run-tunnel.sh on every stop, so it can only ever
+  // answer "what is the URL right now". When a retired *.trycloudflare.com
+  // hostname was found still serving the box, nobody could say which URLs it
+  // had published — the journal was volatile and there was no access log. This
+  // file is that record.
+  it("returns [] when the history file does not exist", async () => {
+    expect(await cloudflared.readTunnelUrlHistory()).toEqual([]);
+  });
+
+  it("returns records newest-first", async () => {
+    await fs.writeFile(
+      TUNNEL_URL_LOG_FILE,
+      [
+        "2026-08-20T10:00:00Z https://old-one.trycloudflare.com",
+        "2026-08-21T11:30:00Z https://middle-one.trycloudflare.com",
+        "2026-08-22T09:15:00Z https://newest-one.trycloudflare.com",
+        "",
+      ].join("\n"),
+    );
+
+    expect(await cloudflared.readTunnelUrlHistory()).toEqual([
+      { at: "2026-08-22T09:15:00Z", url: "https://newest-one.trycloudflare.com" },
+      { at: "2026-08-21T11:30:00Z", url: "https://middle-one.trycloudflare.com" },
+      { at: "2026-08-20T10:00:00Z", url: "https://old-one.trycloudflare.com" },
+    ]);
+  });
+
+  it("honours the limit", async () => {
+    const lines = Array.from(
+      { length: 20 },
+      (_, i) => `2026-08-22T00:00:${String(i).padStart(2, "0")}Z https://url-${i}.trycloudflare.com`,
+    );
+    await fs.writeFile(TUNNEL_URL_LOG_FILE, lines.join("\n"));
+
+    expect(await cloudflared.readTunnelUrlHistory()).toHaveLength(10); // default
+    expect(await cloudflared.readTunnelUrlHistory(3)).toEqual([
+      { at: "2026-08-22T00:00:19Z", url: "https://url-19.trycloudflare.com" },
+      { at: "2026-08-22T00:00:18Z", url: "https://url-18.trycloudflare.com" },
+      { at: "2026-08-22T00:00:17Z", url: "https://url-17.trycloudflare.com" },
+    ]);
+    expect(await cloudflared.readTunnelUrlHistory(0)).toEqual([]);
+    expect(await cloudflared.readTunnelUrlHistory(-1)).toEqual([]);
+  });
+
+  it("skips garbage instead of throwing — a half-written line must not 500 the status route", async () => {
+    await fs.writeFile(
+      TUNNEL_URL_LOG_FILE,
+      [
+        "not-a-timestamp https://ok.trycloudflare.com",
+        "2026-08-22T09:00:00Z https://evil.example.com",
+        "2026-08-22T09:00:01Z",
+        "",
+        "   ",
+        "2026-08-22T09:00:02Z https://good.trycloudflare.com/",
+      ].join("\n"),
+    );
+
+    expect(await cloudflared.readTunnelUrlHistory()).toEqual([
+      { at: "2026-08-22T09:00:02Z", url: "https://good.trycloudflare.com" },
+    ]);
   });
 });

--- a/src/tests/unit/cpu-usage.test.ts
+++ b/src/tests/unit/cpu-usage.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+
+vi.mock("fs");
+vi.mock("os");
+
+const mockFs = vi.mocked(fs);
+const mockOs = vi.mocked(os);
+
+let cpuUsage: typeof import("@/lib/cpu-usage");
+
+/** `cpu user nice system idle …` — only fields 1-4 matter to the sampler. */
+function procStat(user: number, idle: number): string {
+  return `cpu  ${user} 0 0 ${idle} 0 0 0 0 0 0\ncpu0 1 2 3 4\n`;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockOs.cpus.mockReturnValue([{} as os.CpuInfo, {} as os.CpuInfo, {} as os.CpuInfo, {} as os.CpuInfo]);
+  mockOs.loadavg.mockReturnValue([1.0, 1.0, 1.0]);
+  cpuUsage = await import("@/lib/cpu-usage");
+});
+
+describe("getCpuUsage — no per-request sleep (TASK-456)", () => {
+  // The bug: the stats route read /proc/stat, `await`ed a 200 ms timer, then
+  // read it again. That put a hard ~209 ms floor under every
+  // /setup-api/system/stats response — measured live, 5 requests, 208-211 ms —
+  // on an endpoint polled every 3 s. This test fails on that implementation.
+  it("returns synchronously fast and reads /proc/stat exactly once per call", () => {
+    mockFs.readFileSync.mockReturnValue(procStat(100, 900));
+
+    const startedAt = Date.now();
+    cpuUsage.getCpuUsage();
+    cpuUsage.getCpuUsage();
+    const elapsed = Date.now() - startedAt;
+
+    expect(mockFs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(mockFs.readFileSync).toHaveBeenCalledWith("/proc/stat", "utf-8");
+    // Two calls of the OLD implementation could not finish under 400 ms.
+    expect(elapsed).toBeLessThan(100);
+  });
+
+  it("diffs the second call against the cached first sample", () => {
+    // 1000 -> 1100 total (+100), idle 900 -> 950 (+50) = 50% busy.
+    mockFs.readFileSync
+      .mockReturnValueOnce(procStat(100, 900))
+      .mockReturnValueOnce(procStat(150, 950));
+
+    // No prior sample: falls back to the load-average approximation
+    // (loadavg 1.0 over 4 cores = 25%), same as the old code's error path.
+    expect(cpuUsage.getCpuUsage(1_000)).toBe(25);
+    expect(cpuUsage.getCpuUsage(4_000)).toBe(50);
+  });
+
+  it("averages over the caller's real poll interval, not a 200 ms window", () => {
+    mockFs.readFileSync
+      .mockReturnValueOnce(procStat(0, 1000))
+      .mockReturnValueOnce(procStat(300, 1000)); // +300 busy, +0 idle = 100%
+
+    cpuUsage.getCpuUsage(1_000);
+    expect(cpuUsage.getCpuUsage(4_000)).toBe(100);
+  });
+
+  it("re-uses the previous figure when two calls land in the same jiffy", () => {
+    mockFs.readFileSync
+      .mockReturnValueOnce(procStat(100, 900))
+      .mockReturnValueOnce(procStat(150, 950))
+      .mockReturnValueOnce(procStat(150, 950)); // identical — dTotal === 0
+
+    cpuUsage.getCpuUsage(1_000);
+    expect(cpuUsage.getCpuUsage(4_000)).toBe(50);
+    expect(cpuUsage.getCpuUsage(4_010)).toBe(50);
+  });
+
+  it("ignores a stale sample rather than averaging over minutes", () => {
+    mockFs.readFileSync
+      .mockReturnValueOnce(procStat(0, 1000))
+      .mockReturnValueOnce(procStat(1000, 1000));
+
+    cpuUsage.getCpuUsage(1_000);
+    // 5 minutes later: the delta is real arithmetic but it is not "now".
+    expect(cpuUsage.getCpuUsage(301_000)).toBe(25); // loadavg fallback
+  });
+
+  it("falls back to the load average when /proc/stat is unreadable", () => {
+    mockFs.readFileSync.mockImplementation(() => {
+      throw new Error("Permission denied");
+    });
+    mockOs.loadavg.mockReturnValue([2.0, 1.5, 1.0]); // 2.0 / 4 cores
+
+    expect(cpuUsage.getCpuUsage()).toBe(50);
+  });
+
+  it("does not treat a truncated /proc/stat as a busy CPU", () => {
+    // A short line has no idle field. Reading parts[3] as `undefined` used to
+    // make idle NaN; clamping that to 0 would report 100% busy forever.
+    mockFs.readFileSync.mockReturnValue("cpu  100 200\n");
+    expect(cpuUsage.getCpuUsage()).toBe(25); // loadavg fallback, not 100
+  });
+
+  it("survives a counter that goes backwards", () => {
+    mockFs.readFileSync
+      .mockReturnValueOnce(procStat(500, 5000))
+      .mockReturnValueOnce(procStat(10, 20)); // rollover / re-read
+
+    cpuUsage.getCpuUsage(1_000);
+    expect(cpuUsage.getCpuUsage(4_000)).toBe(25); // loadavg fallback, not negative
+  });
+
+  it("clamps to 0-100", () => {
+    mockFs.readFileSync
+      .mockReturnValueOnce(procStat(0, 1000))
+      .mockReturnValueOnce(procStat(0, 1100)); // all idle
+
+    cpuUsage.getCpuUsage(1_000);
+    const usage = cpuUsage.getCpuUsage(4_000);
+    expect(usage).toBeGreaterThanOrEqual(0);
+    expect(usage).toBeLessThanOrEqual(100);
+    expect(usage).toBe(0);
+  });
+
+  it("__resetCpuUsageCache drops the cached sample", () => {
+    mockFs.readFileSync
+      .mockReturnValueOnce(procStat(100, 900))
+      .mockReturnValueOnce(procStat(150, 950));
+
+    cpuUsage.getCpuUsage(1_000);
+    cpuUsage.__resetCpuUsageCache();
+    expect(cpuUsage.getCpuUsage(4_000)).toBe(25); // cold again -> loadavg
+  });
+});
+
+describe("parseProcStat", () => {
+  it("sums every field into total and picks idle from field 4", () => {
+    const sample = cpuUsage.parseProcStat("cpu  1 2 3 4 5 6\n", 42);
+    expect(sample).toEqual({ idle: 4, total: 21, at: 42 });
+  });
+
+  it("rejects a line that is not /proc/stat", () => {
+    expect(cpuUsage.parseProcStat("intr 1 2 3 4\n", 0)).toBeNull();
+    expect(cpuUsage.parseProcStat("", 0)).toBeNull();
+    expect(cpuUsage.parseProcStat("cpu  a b c d\n", 0)).toBeNull();
+  });
+});

--- a/src/tests/unit/observability-install.test.ts
+++ b/src/tests/unit/observability-install.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Install-time and unit-file invariants for TASK-456 (observability).
+ *
+ * Each block below pins a behaviour that was measured wrong on a shipped device:
+ *   - the journal was volatile, so every reboot destroyed the whole log
+ *   - a clean SIGTERM stop was recorded as `Failed with result 'exit-code'`
+ *   - production-server.js had no signal handling at all
+ *   - run-tunnel.sh's pipeline returned 143 on a user-requested stop
+ *
+ * They are file-content assertions because the thing being fixed IS a file the
+ * installer copies to /etc — there is no runtime seam to test instead.
+ */
+
+const REPO = process.cwd();
+const read = (rel: string) => readFileSync(path.join(REPO, rel), "utf-8");
+
+const INSTALL_SH = read("install.sh");
+const SETUP_UNIT = read("config/clawbox-setup.service");
+const TUNNEL_UNIT = read("config/clawbox-tunnel.service");
+const JOURNALD_CONF = read("config/journald-clawbox.conf");
+const RUN_TUNNEL_SH = read("scripts/run-tunnel.sh");
+const PRODUCTION_SERVER = read("production-server.js");
+
+/** Value of a systemd `Key=` directive, ignoring commented-out lines. */
+function directive(unit: string, key: string): string | null {
+  for (const line of unit.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#")) continue;
+    if (trimmed.startsWith(`${key}=`)) return trimmed.slice(key.length + 1).trim();
+  }
+  return null;
+}
+
+function extractShellFunction(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end);
+}
+
+describe("a clean stop is not reported as a failure", () => {
+  // Measured on the box: `systemctl show clawbox-setup.service -p SuccessExitStatus`
+  // was empty, KillSignal was 15, and the journal already held
+  //   Main process exited, code=exited, status=143/n/a
+  //   Failed with result 'exit-code'.
+  // for both units — so `systemctl status` showed red after every normal
+  // restart, and the Remote Access panel rendered that as a red alert.
+  it.each([
+    ["clawbox-setup.service", SETUP_UNIT],
+    ["clawbox-tunnel.service", TUNNEL_UNIT],
+  ])("%s accepts a SIGTERM exit as success", (_name, unit) => {
+    const value = directive(unit, "SuccessExitStatus");
+    expect(value).not.toBeNull();
+    expect(value).toContain("143");
+  });
+
+  it("production-server.js handles SIGTERM and exits 0", () => {
+    expect(PRODUCTION_SERVER).toContain('process.on("SIGTERM"');
+    expect(PRODUCTION_SERVER).toContain('process.on("SIGINT"');
+    // Closing the listeners is the point; a bare process.exit would drop
+    // in-flight responses on every deploy.
+    expect(PRODUCTION_SERVER).toMatch(/server\.close\(done\)/);
+    expect(PRODUCTION_SERVER).toContain("SHUTDOWN_GRACE_MS");
+  });
+
+  it("run-tunnel.sh returns 0 when it was asked to stop", () => {
+    // `set -o pipefail` + cloudflared killed by SIGTERM = pipeline status 143.
+    expect(RUN_TUNNEL_SH).toContain("PIPESTATUS[0]");
+    expect(RUN_TUNNEL_SH).toMatch(/SIGNALLED.*=.*"1".*\|\|.*143.*\|\|.*130/s);
+    expect(RUN_TUNNEL_SH).toContain("trap on_signal INT TERM");
+  });
+});
+
+describe("the journal survives a reboot", () => {
+  // Measured on the box: /var/log/journal did not exist, journald.conf held
+  // nothing but its `[Journal]` header (so Storage=auto -> volatile), and 72 MB
+  // of journal was sitting in /run/log/journal (tmpfs), charged to RAM and
+  // destroyed on every reboot.
+  it("the drop-in sets persistent storage", () => {
+    expect(directive(JOURNALD_CONF, "Storage")).toBe("persistent");
+  });
+
+  it("the drop-in bounds both the disk and the tmpfs journal", () => {
+    // Unbounded logs on a Jetson's eMMC is a flash-wear problem, and the
+    // volatile half is what ate 72 MB of RAM.
+    expect(directive(JOURNALD_CONF, "SystemMaxUse")).toBe("200M");
+    expect(directive(JOURNALD_CONF, "RuntimeMaxUse")).toBe("64M");
+    expect(directive(JOURNALD_CONF, "SystemKeepFree")).toBeTruthy();
+  });
+
+  it("the drop-in states an explicit rate limit", () => {
+    // Port 80 is reachable from the LAN, the open setup AP and the public
+    // tunnel, and the web tier now writes a line per request: 200 unauth
+    // requests were measured completing in 0.80 s.
+    expect(directive(JOURNALD_CONF, "RateLimitIntervalSec")).toBeTruthy();
+    expect(directive(JOURNALD_CONF, "RateLimitBurst")).toBeTruthy();
+  });
+
+  it("install.sh installs the drop-in and creates /var/log/journal", () => {
+    const step = extractShellFunction(INSTALL_SH, "step_persistent_journal");
+    expect(step).toContain("config/journald-clawbox.conf");
+    expect(step).toContain("/etc/systemd/journald.conf.d");
+    // Storage=persistent only creates the directory on journald's NEXT start,
+    // and systemd-tmpfiles is what applies the systemd-journal ACL.
+    expect(step).toContain("mkdir -p /var/log/journal");
+    expect(step).toContain("systemd-tmpfiles --create --prefix /var/log/journal");
+    // Restart, not reload: Storage= is only read at start.
+    expect(step).toContain("systemctl restart systemd-journald");
+  });
+
+  it("the step runs on fresh installs, in-app updates and by hand", () => {
+    // Without the post_update call this would be fresh-install-only and every
+    // already-shipped box would keep losing its log on each reboot.
+    expect(extractShellFunction(INSTALL_SH, "step_system_config")).toContain(
+      "step_persistent_journal",
+    );
+    expect(extractShellFunction(INSTALL_SH, "step_post_update")).toContain(
+      "step_persistent_journal",
+    );
+    const dispatch = INSTALL_SH.slice(
+      INSTALL_SH.indexOf("DISPATCH_STEPS=("),
+      INSTALL_SH.indexOf("\n)", INSTALL_SH.indexOf("DISPATCH_STEPS=(")),
+    );
+    expect(dispatch).toContain("persistent_journal");
+  });
+});
+
+describe("the web tier logs requests", () => {
+  it("production-server.js attaches the access log to the listening server", () => {
+    expect(PRODUCTION_SERVER).toContain('require("./scripts/access-log.js")');
+    expect(PRODUCTION_SERVER).toContain("attachAccessLog(this)");
+  });
+});
+
+describe("published tunnel URLs are recorded", () => {
+  it("run-tunnel.sh appends every captured URL to a bounded history file", () => {
+    // `tunnel.url` is erased by cleanup() on every stop, so it can only answer
+    // "what is the URL right now" — never "which hostnames has this box ever
+    // been reachable on", which is the question a stray still-serving
+    // quick-tunnel URL raises.
+    expect(RUN_TUNNEL_SH).toContain('TUNNEL_URL_LOG="$TUNNEL_DIR/tunnel-url.log"');
+    expect(RUN_TUNNEL_SH).toContain("TUNNEL_URL_LOG_MAX");
+    expect(RUN_TUNNEL_SH).toMatch(/date -u \+%Y-%m-%dT%H:%M:%SZ/);
+    // cleanup() must NOT delete the history — that is the whole point.
+    expect(extractShellFunction(RUN_TUNNEL_SH, "cleanup")).not.toContain("TUNNEL_URL_LOG");
+  });
+});

--- a/src/tests/unit/run-tunnel.test.ts
+++ b/src/tests/unit/run-tunnel.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawn } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * scripts/run-tunnel.sh, actually executed.
+ *
+ * Two behaviours are proven here rather than asserted about:
+ *
+ *  1. A SIGTERM stop exits 0. The old script's pipeline ran under
+ *     `set -o pipefail`, so cloudflared dying on SIGTERM made the whole script
+ *     return 143 — measured on the box as
+ *       clawbox-tunnel.service: Main process exited, code=exited, status=143/n/a
+ *       clawbox-tunnel.service: Failed with result 'exit-code'.
+ *     and rendered by the Remote Access panel as a red "Tunnel failed to start"
+ *     alert right after the user pressed Stop. Running the pre-fix script under
+ *     this harness gives EXIT=143; the fixed one gives 0.
+ *
+ *  2. Every published URL lands in a history file that a stop does NOT erase.
+ *
+ * SIGTERM goes to the whole process group, which is what systemd does with the
+ * unit's default KillMode=control-group.
+ */
+
+const REPO = process.cwd();
+const RUN_TUNNEL = path.join(REPO, "scripts/run-tunnel.sh");
+const FAKE_URL = "https://fake-observability-456.trycloudflare.com";
+
+let root: string;
+let fakeBin: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(os.tmpdir(), "clawbox-run-tunnel-"));
+  fakeBin = path.join(root, "fake-cloudflared");
+  // Prints the URL the way cloudflared does (on stderr), then stays up.
+  writeFileSync(
+    fakeBin,
+    `#!/usr/bin/env bash\necho "INF |  ${FAKE_URL}  |" >&2\nwhile true; do sleep 0.2; done\n`,
+    { mode: 0o755 },
+  );
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+const dataFile = (name: string) => path.join(root, "data", "cloudflared", name);
+
+/** Start the script, wait until it has published a URL, then SIGTERM its group. */
+async function runAndStop(scriptPath: string): Promise<number | null> {
+  const child = spawn("bash", [scriptPath], {
+    env: { ...process.env, CLAWBOX_ROOT: root, CLOUDFLARED_BIN: fakeBin },
+    detached: true, // its own process group, so we can signal the group
+    stdio: "ignore",
+  });
+
+  const exited = new Promise<number | null>((resolve) => {
+    child.on("exit", (code, signal) => resolve(signal ? null : code));
+  });
+
+  for (let i = 0; i < 100 && !existsSync(dataFile("tunnel.url")); i++) {
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  process.kill(-child.pid!, "SIGTERM");
+  return exited;
+}
+
+describe("run-tunnel.sh — a user-requested stop is not a failure", () => {
+  it("exits 0 when SIGTERM'd", async () => {
+    expect(await runAndStop(RUN_TUNNEL)).toBe(0);
+  }, 20_000);
+
+  it("keeps the URL history across the stop but clears the live URL", async () => {
+    await runAndStop(RUN_TUNNEL);
+
+    // tunnel.url answers "what is the URL right now" — a stopped tunnel has none.
+    expect(existsSync(dataFile("tunnel.url"))).toBe(false);
+    // The history answers "which hostnames has this box ever been reachable on".
+    const history = readFileSync(dataFile("tunnel-url.log"), "utf-8").trim().split("\n");
+    expect(history).toHaveLength(1);
+    expect(history[0]).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z https:\/\/fake-observability-456\.trycloudflare\.com$/,
+    );
+  }, 20_000);
+
+  it("appends across restarts instead of overwriting", async () => {
+    mkdirSync(path.dirname(dataFile("tunnel-url.log")), { recursive: true });
+    writeFileSync(dataFile("tunnel-url.log"), `2026-08-01T00:00:00Z ${FAKE_URL}\n`);
+
+    await runAndStop(RUN_TUNNEL);
+
+    const history = readFileSync(dataFile("tunnel-url.log"), "utf-8").trim().split("\n");
+    expect(history).toHaveLength(2);
+    expect(history[0]).toContain("2026-08-01T00:00:00Z");
+  }, 20_000);
+
+  it("still reports a real failure honestly", async () => {
+    // cloudflared missing -> exit 1, and that must stay 1.
+    const child = spawn("bash", [RUN_TUNNEL], {
+      env: { ...process.env, CLAWBOX_ROOT: root, CLOUDFLARED_BIN: path.join(root, "nope") },
+      stdio: "ignore",
+    });
+    const code = await new Promise<number | null>((resolve) =>
+      child.on("exit", (c) => resolve(c)),
+    );
+    expect(code).toBe(1);
+  }, 20_000);
+});


### PR DESCRIPTION
Task: TASK-456 (Hermes QA epic TASK-442) — reported by krasi@idrobots.com

Five confirmed-live observability gaps. Evidence for each is in
`findings/validate-round1.md` §"TASK-455 + TASK-456" and REPORT §3 / rec 10.

## 1. The journal was volatile — every reboot destroyed the whole log

`journald-volatile`, CONFIRMED-LIVE. `/var/log/journal` did not exist and
`journald.conf` contained nothing but its `[Journal]` header, so `Storage=auto`
resolved to volatile: 72 MB of journal sitting in `/run/log/journal` (tmpfs),
charged to RAM on a 7.6 GiB device, gone on every reboot. It also meant there
was nowhere durable to put an access log.

- **New `config/journald-clawbox.conf`** → `/etc/systemd/journald.conf.d/10-clawbox.conf`:
  `Storage=persistent`, `SystemMaxUse=200M` / `SystemKeepFree=500M` /
  `MaxRetentionSec=1month` (a Jetson boots off eMMC — an unbounded journal is a
  flash-wear problem), `RuntimeMaxUse=64M` for the tmpfs half, and an explicit
  `RateLimitIntervalSec=30s` / `RateLimitBurst=5000`.
- **New `step_persistent_journal`** in install.sh: installs the drop-in, creates
  `/var/log/journal`, runs `systemd-tmpfiles --create` (that is what applies the
  `systemd-journal` ACL — `Storage=persistent` alone only creates the directory
  on journald's *next* start), then restarts journald and flushes `/run` into
  `/var` so the **current** boot is the first one that survives.
- Wired into `step_system_config` (fresh installs), `step_post_update` (in-app
  updates, so already-shipped boxes get it) and `DISPATCH_STEPS` (`--step
  persistent_journal` by hand).

The rate limit is deliberate, not decorative: port 80 is reachable from the LAN,
the open setup AP and the public tunnel, 200 unauthenticated requests were
measured completing in 0.80 s, and item 2 below adds a line per request.

## 2. No HTTP access log — remote requests were invisible

`no-http-access-log`, CONFIRMED-LIVE. Two probes to a unique path (307 over the
LAN, 404 over the tunnel) produced **zero** journal lines anywhere and there was
no access-log file on disk. That is also why round 1 could not establish where
the stale quick-tunnel hostname was anchored.

**New `scripts/access-log.js`**, attached in `production-server.js` to the one
server Next creates (HTTPS re-emits `request` onto it, so `:80` and `:443` are
both covered):

```
[access] 200 GET /setup-api/system/stats 9ms ip=192.168.50.10 host=clawbox.local
[access] 404 GET /probe?token=REDACTED 1ms ip=203.0.113.7 host=abc.trycloudflare.com aborted
```

- `ip=` is **CF-Connecting-IP aware**, then `X-Forwarded-For`, then `X-Real-IP`,
  then the socket — over Remote Access the socket address is always `127.0.0.1`,
  so without this the log would record nothing useful about who called.
  Non-IP-shaped header values are dropped rather than echoed.
- `host=` is the hostname the request arrived on. This is the field that makes a
  stray `*.trycloudflare.com` URL traceable.
- Sensitive query **values** are replaced with `REDACTED` (names are kept —
  knowing a request carried `?token=` is the useful half). Control characters are
  stripped so a request cannot forge a second log line; the target is capped at
  512 chars.
- Stops on `close`, not `finish`, so an **aborted** request — the one most worth
  having — is logged too, and marked.
- `_next/static` skipped by default; `CLAWBOX_ACCESS_LOG=0` disables entirely;
  `CLAWBOX_ACCESS_LOG_STATIC=1` includes assets.
- It observes without intercepting: adding a second `request` listener does not
  displace Next's handler, and a throwing writer cannot take a request down.

It lands in the `clawbox-setup` journal, so the existing `logs_tail` MCP tool
surfaces it to the agent with no extra wiring — and with item 1, it survives a
reboot.

## 3. `clawbox-setup` / `clawbox-tunnel` reported "failed" on a clean SIGTERM

`sigterm-recorded-as-failed`, CONFIRMED-LIVE. Neither unit set
`SuccessExitStatus`; the journal already held `status=143/n/a` +
`Failed with result 'exit-code'` for both. Every `systemctl restart
clawbox-setup` — which the in-app updater and every deploy end with — left the
unit red for the rest of the session, and the Remote Access panel renders the
tunnel's version of that as a red "Tunnel failed to start" alert *after the user
pressed Stop themselves*.

Fixed at both ends, deliberately:
- `SuccessExitStatus=143 SIGTERM` on both units.
- `production-server.js` handles SIGTERM/SIGINT: closes its listeners (so
  in-flight responses are not dropped on every deploy) and exits 0, with a
  `SHUTDOWN_GRACE_MS` backstop so a socket that refuses to drain cannot turn a
  clean stop into a SIGKILL.
- `scripts/run-tunnel.sh` returns 0 when it was signalled, instead of leaking
  `pipefail`'s 143 from the killed cloudflared.

## 4. `system/stats` slept 200 ms on every request

`stats-200ms-sleep`, CONFIRMED-LIVE, and identical in the checkout and the
deployed build, so a rebuild would not have fixed it. Line 46 was
`await new Promise((r) => setTimeout(r, 200))`; 5 live authenticated requests
measured 208-211 ms, of which ~8-11 ms was the actual work — on an endpoint the
System app and Settings > System poll every 3 s.

**New `src/lib/cpu-usage.ts`** keeps the previous `/proc/stat` sample in module
scope and diffs the current read against it. No sleep, and the figure is now a
real average over the caller's own 3 s poll interval rather than an artificial
200 ms window. It falls back to the load-average approximation when cold, when
`/proc/stat` is unreadable, or when the cached sample is stale (>60 s), and
handles a truncated `/proc/stat` and a backwards counter without reporting a
bogus 100%.

## 5. Published tunnel URLs are now recorded

`tunnel.url` is deleted on every stop, so it can only ever answer "what is the
URL right now" — never "which hostnames has this box been reachable on", which
is exactly the question the stray-quick-tunnel finding raised.

- `run-tunnel.sh` appends `<iso8601> <url>` to a bounded (50-line)
  `data/cloudflared/tunnel-url.log` that `cleanup()` does **not** erase.
- `readTunnelUrlHistory()` in `src/lib/cloudflared.ts` parses it newest-first,
  skipping garbage rather than throwing (a half-written line must not 500 the
  status route) and applying the same URL-shape check as `readTunnelUrl`.
- `/setup-api/portal/status` returns it as `tunnel.history`. No UI change.

## Not fixed — noted, out of our control

The early-boot clock skew (`early-boot-361-day-skew`) is a hardware property:
the Orin Nano dev kit has no battery-backed RTC, so the first ~10 s of every
boot (~888 kernel lines) are stamped ~361 days early until `nvvrs-pseq-rtc`
hands the clock over at monotonic ~10 s, and `--list-boots` shows one "boot"
spanning the gap. Documented in `docs-site/support/troubleshooting.mdx` and in
`step_persistent_journal` rather than papered over. Note the report's "~34 s"
window is wrong — validation measured ~10 s.

## Tests

`npm test` — **276 files, 3771 tests, all passing.** Coverage 70.75 / 60.84 /
70.38 / 72.74, above the 63 / 52 / 61 / 65 ratchet.

The two behavioural regressions are *proven*, not asserted about:

- `src/tests/unit/run-tunnel.test.ts` actually executes `run-tunnel.sh` against
  a fake cloudflared and SIGTERMs its process group (what systemd's
  `KillMode=control-group` does). The **pre-fix script gives EXIT=143 under this
  same harness; the fixed one gives 0** — verified both ways. It also proves the
  history survives the stop, appends across restarts, and that a genuinely
  failed start still returns 1.
- `src/tests/routes/system/stats.test.ts` asserts three sequential requests
  complete in under 150 ms. The old implementation could not finish in under 600.

Plus `src/tests/unit/cpu-usage.test.ts` (12 cases: delta arithmetic, cold start,
stale sample, same-jiffy, truncated `/proc/stat`, backwards counter),
`src/tests/unit/access-log.test.ts` (27 cases: format, redaction incl.
percent-encoded names, CF-Connecting-IP precedence, header-injection rejection,
aborted requests, non-displacement of Next's handler),
`src/tests/unit/observability-install.test.ts` (unit-file directives, journald
drop-in contents, install.sh wiring across all three call sites), and new
`readTunnelUrlHistory` cases in `cloudflared.test.ts`.

Typecheck: `npx tsc --noEmit` reports the same 33 pre-existing errors before and
after this branch (all in unrelated test files); none in the changed files.
Lint: 0 new errors or warnings attributable to these files.

## Verification notes for the live deploy

The systemd and journald changes are covered by file/unit-file assertions —
executing `step_persistent_journal` restarts a system daemon and rewrites
`/etc/systemd`, which is not something to run on a dev box or in CI (this matches
how every other `install.sh` step is tested in this repo). On the box, the
follow-up smoke should be:

```bash
sudo bash /home/clawbox/clawbox/install.sh --step persistent_journal
journalctl --disk-usage                       # now under /var/log/journal
systemctl show clawbox-setup.service -p SuccessExitStatus   # 143 SIGTERM
sudo systemctl restart clawbox-setup && systemctl is-failed clawbox-setup  # -> active, not failed
curl -s -o /dev/null http://127.0.0.1/setup-api/system/stats -w '%{time_total}\n'   # ~0.01s, was ~0.209s
journalctl -u clawbox-setup -n 20 --no-pager | grep '\[access\]'
```

## Scope

Only TASK-456. `src/app/setup-api/portal/status/route.ts` is touched (one added
field) — it is shared with the Remote Access work but not owned by
TASK-448/449/450/451; no other lane's files were edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added persistent, bounded journald storage with configurable retention and size limits.
  - Added HTTP/HTTPS access logging with privacy filtering and request details.
  - Tunnel status now includes recent tunnel URL history.
  - System statistics now report CPU usage without request delays.

- **Bug Fixes**
  - Clean service and tunnel shutdowns are no longer reported as failures.
  - Tunnel shutdowns preserve URL history while exiting successfully.

- **Documentation**
  - Expanded troubleshooting guidance for persistent logs, access logs, filtering, and boot-time considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->