### PR TITLE
fix: surface terminal oauth poll errors instead of spinning

### DIFF
--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -460,10 +460,31 @@ export default function HermesProviderConfig({ embedded, onNext, testId }: Props
           `/setup-api/hermes/oauth/poll?providerId=${encodeURIComponent(providerId)}&sessionId=${encodeURIComponent(sessionId)}`,
           { cache: "no-store" },
         );
-        const data = (await res.json().catch(() => ({}))) as { status?: unknown; error_message?: unknown };
+        const data = (await res.json().catch(() => ({}))) as {
+          status?: unknown;
+          error_message?: unknown;
+          error?: unknown;
+        };
         if (!alive) return;
         const status = typeof data.status === "string" ? data.status : "";
-        if (status === "approved") {
+        // A 4xx is the relay's verdict on THIS session — not found, expired, or
+        // minted for another provider — and it answers with `error`, never
+        // `status`. Reading `status` alone made those bodies indistinguishable
+        // from "keep polling", so a session that was already dead sat behind
+        // "Waiting for approval..." until the deadline above. 5xx stays
+        // transient (the dashboard may be mid-restart) and the deadline still
+        // bounds that case.
+        if (!res.ok && res.status < 500) {
+          terminal = true;
+          setSignin({
+            stage: "failed",
+            providerId,
+            message:
+              typeof data.error === "string" && data.error
+                ? data.error
+                : "Sign-in failed. Try again.",
+          });
+        } else if (status === "approved") {
           terminal = true;
           onOauthConnected(providerId);
         } else if (status === "error" || status === "expired") {

--- a/src/tests/components/hermes-oauth-inline.test.tsx
+++ b/src/tests/components/hermes-oauth-inline.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import HermesProviderConfig from "@/components/HermesProviderConfig";
 
 // The inline provider sign-in that replaced the jump to the Hermes dashboard's
@@ -42,7 +42,7 @@ vi.mock("@/hooks/useHermesModelOptions", () => ({
 /** The panel's backing routes, including the new inline-OAuth relay. Tracks a
  *  successful submit the way the dashboard would, so the status re-read after
  *  connecting reports logged_in instead of clobbering the panel's flip. */
-function stubFetch({ submitOk = true }: { submitOk?: boolean } = {}) {
+function stubFetch({ submitOk = true, poll }: { submitOk?: boolean; poll?: () => Response } = {}) {
   let anthropicLoggedIn = false;
   const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
@@ -108,7 +108,7 @@ function stubFetch({ submitOk = true }: { submitOk?: boolean } = {}) {
           } as Response);
     }
     if (url.startsWith("/setup-api/hermes/oauth/poll")) {
-      return { ok: true, json: async () => ({ status: "pending" }) } as Response;
+      return poll ? poll() : ({ ok: true, json: async () => ({ status: "pending" }) } as Response);
     }
     if (url === "/setup-api/hermes/oauth/cancel") {
       return { ok: true, json: async () => ({ ok: true }) } as Response;
@@ -132,6 +132,23 @@ describe("HermesProviderConfig inline OAuth", () => {
     openMock = vi.fn();
     vi.stubGlobal("open", openMock);
   });
+
+  afterEach(() => {
+    // Only the poll-loop tests fake timers; restoring unconditionally keeps
+    // them from leaking into whichever test runs next.
+    vi.useRealTimers();
+  });
+
+  /** The device_code sign-in, driven to its first poll. Returns a counter for
+   *  the polls issued so far, so a test can assert the loop stopped. */
+  async function startDeviceFlow(fetchMock: ReturnType<typeof stubFetch>) {
+    render(<HermesProviderConfig embedded testId="hermes-ai" />);
+    fireEvent.click(await screen.findByRole("radio", { name: /OpenAI/ }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Sign in$/ }));
+    await screen.findByTestId("hermes-oauth-user-code");
+    return () =>
+      fetchMock.mock.calls.filter(([u]) => String(u).startsWith("/setup-api/hermes/oauth/poll")).length;
+  }
 
   it("runs the pkce flow inline: opens the provider page, takes a pasted code, shows Connected", async () => {
     const fetchMock = stubFetch();
@@ -324,5 +341,63 @@ describe("HermesProviderConfig inline OAuth", () => {
     await screen.findByText("hermes auth login copilot");
     expect(screen.getByText("This provider signs in through the Hermes CLI.")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /^Sign in$/ })).not.toBeInTheDocument();
+  });
+
+  // The relay answers a dead device-code session with an HTTP error and an
+  // `error` string — no `status` key at all. Reading `status` alone made those
+  // bodies look like "keep polling", so the panel sat on "Waiting for
+  // approval..." for a session that could never be approved.
+  for (const [httpStatus, error] of [
+    [400, "Provider mismatch for session"],
+    [404, "Session not found or expired"],
+  ] as const) {
+    it(`stops polling and shows the relay's message on HTTP ${httpStatus}`, async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const fetchMock = stubFetch({
+        poll: () => ({ ok: false, status: httpStatus, json: async () => ({ error }) }) as Response,
+      });
+
+      const polls = await startDeviceFlow(fetchMock);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent(error);
+      });
+      // The wait state is gone and the row offers a fresh session.
+      expect(screen.queryByText("Waiting for approval...")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Try again/ })).toBeInTheDocument();
+
+      // Terminal means terminal: nothing re-arms the loop.
+      const issued = polls();
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30_000);
+      });
+      expect(polls()).toBe(issued);
+    });
+  }
+
+  it("keeps polling through a 5xx, which only means the dashboard is restarting", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const fetchMock = stubFetch({
+      poll: () =>
+        ({
+          ok: false,
+          status: 502,
+          json: async () => ({ error: "Hermes dashboard is unreachable" }),
+        }) as Response,
+    });
+
+    const polls = await startDeviceFlow(fetchMock);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(20_000);
+    });
+
+    expect(polls()).toBeGreaterThan(1);
+    expect(screen.getByText("Waiting for approval...")).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## The bug

`HermesProviderConfig`'s device-code poll loop read only `data.status` from each
`/setup-api/hermes/oauth/poll` response and never looked at `res.ok`.

The relay answers a session that can no longer be approved with an HTTP error and
an `error` string — and no `status` key at all. Confirmed live against the Hermes
dashboard through the relay:

- `400 {"error": "Provider mismatch for session"}`
- `404 {"error": "Session not found or expired"}`

For those bodies `typeof data.status === "string" ? data.status : ""` yields `""`,
which matches none of `approved` / `error` / `expired`, so `terminal` stayed false
and the loop re-armed. The panel kept polling a dead session behind
"Waiting for approval..." until the session's `expires_in` deadline elapsed, and
then reported a generic expiry instead of what actually went wrong.

## The fix

Treat a 4xx poll response as terminal: stop the loop and put the relay's `error`
string through the component's existing `failed` stage, which already renders the
message in the `role="alert"` line and flips the row's button back to "Try again".

5xx keeps retrying — that only means the dashboard is momentarily unreachable
(e.g. mid-restart), which is the case the loop's `catch` was already written for,
and the existing `expires_in` deadline still bounds it.

The other fetches in this file (`/oauth/start`, `/oauth/submit`, the status and
model reads, the save path) already check `res.ok`; the poll loop was the only
blind one.

## Tests

`src/tests/components/hermes-oauth-inline.test.tsx` gains three cases: poll
answering 400 and 404 (polling stops, the relay's message is shown, no further
polls are issued), and a 502 that must keep polling.

Verified on a Jetson bench box against a clean `beta` checkout:

- both new 400/404 cases fail on unpatched `beta` and pass with the change; the
  502 case passes either way
- `src/tests/components` + `src/tests/routes/hermes`: 44 files, 297 tests passed
- `tsc --noEmit`: 16 errors before and after, byte-identical lists, none in the
  changed files
- `eslint` on the changed files: 0 errors (1 pre-existing `no-img-element`
  warning on the test file's `next/image` mock)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth device authorization now stops polling promptly when a non-server error occurs.
  * Displays the error message provided by the authorization service, with a fallback message when unavailable.
  * Server-side errors continue polling as expected.
  * Retry options are shown after terminal authorization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->