### PR TITLE
fix: show the Hermes agent version in Settings About on hermes boxes

### DIFF
--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -317,6 +317,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   const [versionInfo, setVersionInfo] = useState<{
     clawbox: { current: string; target: string | null; updateAvailable?: boolean };
     openclaw: { current: string | null; target: string | null; updateAvailable?: boolean };
+    // Both optional: a device that has not been updated yet still answers
+    // /update/versions with the old two-key shape.
+    hermes?: { current: string | null; target: string | null; updateAvailable?: boolean };
+    edition?: "openclaw" | "hermes" | "dual";
   } | null>(null);
   const [versionLoading, setVersionLoading] = useState(false);
   const [updateBranch, setUpdateBranch] = useState<string | null>(null);
@@ -3039,10 +3043,25 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   <span className="text-[var(--text-muted)]">{t("settings.version")}</span>
                   <span className="text-[var(--text-primary)]">{versionInfo?.clawbox.current ?? process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown"}</span>
                 </div>
-                <div className="flex justify-between text-sm">
-                  <span className="text-[var(--text-muted)]">OpenClaw</span>
-                  <span className="text-[var(--text-primary)]">{cleanVersion(versionInfo?.openclaw.current) ?? t("settings.notInstalled")}</span>
-                </div>
+                {/* Harness version, per edition. The Hermes SKU ships no
+                    OpenClaw at all, so its row could only ever read "not
+                    installed" — a meaningless line about software the device
+                    was never supposed to have. Show the harness this box
+                    actually runs instead; `dual` has both, so it shows both.
+                    A server that predates the `edition` field falls through to
+                    the OpenClaw row exactly as before. */}
+                {versionInfo?.edition !== "hermes" && (
+                  <div className="flex justify-between text-sm">
+                    <span className="text-[var(--text-muted)]">OpenClaw</span>
+                    <span className="text-[var(--text-primary)]">{cleanVersion(versionInfo?.openclaw.current) ?? t("settings.notInstalled")}</span>
+                  </div>
+                )}
+                {versionInfo?.hermes && (
+                  <div className="flex justify-between text-sm">
+                    <span className="text-[var(--text-muted)]">Hermes</span>
+                    <span className="text-[var(--text-primary)]">{versionInfo.hermes.current ?? t("settings.notInstalled")}</span>
+                  </div>
+                )}
                 <div className="flex justify-between text-sm">
                   <span className="text-[var(--text-muted)]">{t("settings.runtime")}</span>
                   <span className="text-[var(--text-primary)]">Next.js + Bun</span>

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -9,8 +9,10 @@ import {
   openclawIsAbsent,
   gatewayIsAbsent,
 } from "./openclaw-config";
-import { hasHermesHarness } from "./edition-source";
+import { hasHermesHarness, readEdition, type EditionName } from "./edition-source";
+import { runHermesCli } from "./hermes-cli";
 import { isPortOpen } from "./port-probe";
+import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
 
 const PROJECT_DIR = "/home/clawbox/clawbox";
@@ -618,6 +620,22 @@ interface ComponentVersionInfo {
 interface VersionInfo {
   clawbox: ComponentVersionInfo & { current: string };
   openclaw: ComponentVersionInfo;
+  /**
+   * The Hermes agent, reported ONLY on the SKUs that ship it (`hermes` and
+   * `dual`). Absent — not null — on `openclaw`, so the field's presence is
+   * itself the "this device has a Hermes to talk about" signal and the UI
+   * never has to guess.
+   */
+  hermes?: ComponentVersionInfo;
+  /**
+   * Which harnesses this device actually has. The About screen needs it to
+   * decide which version rows are meaningful: a Hermes box has no OpenClaw
+   * at all, so an "OpenClaw: not installed" row there is noise, not news.
+   *
+   * Additive: an older client that ignores this field renders exactly as
+   * before.
+   */
+  edition: EditionName;
 }
 
 let cachedVersionInfo: VersionInfo | null = null;
@@ -678,6 +696,30 @@ async function readClawboxVersion(): Promise<string> {
   return process.env.NEXT_PUBLIC_APP_VERSION || "unknown";
 }
 
+/**
+ * The installed Hermes agent version, or null if it cannot be determined.
+ *
+ * The caller MUST gate this on the edition: `openclaw` boxes have no Hermes
+ * binary, and spawning one there would be a guaranteed ENOENT on every
+ * version read. It is only ever reached from getVersionInfo(), whose whole
+ * result is cached for TARGET_VERSION_CACHE_TTL, so the About screen polling
+ * for versions cannot turn into a subprocess storm.
+ *
+ * Never throws: a device mid-upgrade (the Hermes installer briefly replaces
+ * the venv the shim execs) should report an unknown version for a few
+ * seconds, not fail the whole version endpoint that ClawBox's own update
+ * tile also depends on.
+ */
+async function readHermesVersion(): Promise<string | null> {
+  try {
+    const { code, stdout } = await runHermesCli(["--version"], { timeoutMs: 10_000 });
+    if (code !== 0) return null;
+    return parseHermesVersion(stdout);
+  } catch {
+    return null;
+  }
+}
+
 async function getPinnedBranchTarget(gitCmd: string): Promise<{
   branch: string;
   currentSha: string;
@@ -712,7 +754,9 @@ export async function getVersionInfo(): Promise<VersionInfo> {
   }
 
   const gitCmd = `git -c safe.directory=${PROJECT_DIR} -C ${PROJECT_DIR}`;
-  const [targetVersion, openclawCurrent, openclawTarget, rawVersion] = await Promise.all([
+  const edition = readEdition();
+  const hasHermes = hasHermesHarness();
+  const [targetVersion, openclawCurrent, openclawTarget, rawVersion, hermesCurrent] = await Promise.all([
     getTargetVersion(),
     // The Hermes edition ships no openclaw binary, so skip the spawn and read
     // the version from the installed package.json (absent there too → null,
@@ -737,6 +781,9 @@ export async function getVersionInfo(): Promise<VersionInfo> {
       }
     })(),
     readClawboxVersion(),
+    // Gated on the edition, not on a try/catch: the `openclaw` SKU has no
+    // hermes binary, so this must never spawn there.
+    hasHermes ? readHermesVersion() : Promise.resolve(null),
   ]);
   const pinnedBranchTarget = await getPinnedBranchTarget(gitCmd);
 
@@ -764,6 +811,13 @@ export async function getVersionInfo(): Promise<VersionInfo> {
       target: openclawTarget && openclawCurrent && openclawCurrent.includes(openclawTarget) ? null : openclawTarget,
       updateAvailable: !!(openclawTarget && openclawCurrent && !openclawCurrent.includes(openclawTarget)),
     },
+    // Hermes ships from its own upstream installer, not from a ClawBox pin, so
+    // there is no target to converge on and nothing to offer an update for —
+    // only the installed version is reportable.
+    ...(hasHermes
+      ? { hermes: { current: hermesCurrent, target: null, updateAvailable: false } }
+      : {}),
+    edition,
   };
   versionInfoCacheTime = Date.now();
   return cachedVersionInfo;

--- a/src/lib/version-utils.ts
+++ b/src/lib/version-utils.ts
@@ -18,3 +18,29 @@ export function cleanVersion(v: string | null | undefined): string | null {
     .trim();
   return cleaned || null;
 }
+
+/**
+ * Reduce the Hermes agent's `--version` banner to a bare version tag.
+ *
+ * `hermes --version` is a multi-line report, not a version string:
+ *
+ *   Hermes Agent v0.20.5 (2026.8.19) — upstream 261a4efb — local 10914727
+ *   Install directory: /home/clawbox/.hermes/hermes-agent
+ *   Install method: git
+ *
+ * Only the tag belongs in an About row, and `cleanVersion` cannot get it:
+ * its rules are shaped for OpenClaw/git-describe output, and none of them
+ * match here — the parenthesised build date is mid-line, not at the end.
+ *
+ * Returns null for empty input so callers keep their own fallback.
+ */
+export function parseHermesVersion(raw: string | null | undefined): string | null {
+  const line = (raw || "").split(/\r?\n/, 1)[0]?.trim();
+  if (!line) return null;
+  // First semver-ish token, keeping the leading "v" when Hermes printed one.
+  const match = line.match(/\bv?\d+\.\d+(?:\.\d+)*(?:[-+][0-9A-Za-z.]+)?\b/);
+  if (match) return match[0];
+  // Unrecognised banner: show it rather than "not installed" — the agent did
+  // answer — but cap it so a runaway line can't blow out the row.
+  return line.length > 64 ? `${line.slice(0, 64)}…` : line;
+}

--- a/src/tests/components/settings-about-version.test.tsx
+++ b/src/tests/components/settings-about-version.test.tsx
@@ -1,0 +1,156 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@/tests/helpers/test-utils";
+import SettingsApp, { type UISettings } from "@/components/SettingsApp";
+
+vi.mock("@/lib/i18n", () => ({
+  LANGUAGES: [{ code: "en", name: "English" }],
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useT: () => ({
+    t: (key: string) => key,
+    locale: "en",
+    setLocale: vi.fn(),
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: () => null,
+}));
+
+const defaultUi: UISettings = {
+  wallpaperId: "default",
+  wpFit: "fill",
+  wpBgColor: "#000000",
+  wpOpacity: 100,
+  mascotHidden: false,
+  wallpapers: [{ id: "default", name: "Default" }],
+  customWallpapers: [],
+  onWallpaperChange: vi.fn(),
+  onWpFitChange: vi.fn(),
+  onWpBgColorChange: vi.fn(),
+  onWpOpacityChange: vi.fn(),
+  onMascotToggle: vi.fn(),
+  onWallpaperUpload: vi.fn(),
+  onCustomWallpaperDelete: vi.fn(),
+};
+
+function jsonResponse(data: unknown) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+}
+
+// About renders `${arch} ${platform}` unguarded, so the stats payload has to
+// be shaped even though this suite is not about it.
+const statsResponse = {
+  overview: { hostname: "clawbox-test", os: "TestOS", kernel: "6.8.0", uptime: "1h", arch: "arm64", platform: "linux" },
+  cpu: { usage: 12, model: "Test CPU", cores: 4, loadAvg: ["0.10", "0.12", "0.14"], speed: 1800 },
+  memory: { total: 8e9, used: 2e9, free: 6e9, usedPercent: 25, swap: { used: 0, total: 0, percent: 0 } },
+  temperature: { value: 42, display: "42C" },
+  gpu: { usage: 0 },
+  storage: [],
+  network: [],
+  processes: [],
+  timestamp: Date.now(),
+};
+
+/**
+ * The About screen's version block, scoped so "OpenClaw" appearing anywhere
+ * else on the page cannot make an assertion pass or fail by accident.
+ */
+async function openAboutVersions(versions: unknown) {
+  vi.stubGlobal("fetch", vi.fn((input: string | URL) => {
+    const url = input.toString();
+    if (url === "/setup-api/update/versions") return jsonResponse(versions);
+    if (url === "/setup-api/update/status") return jsonResponse({ phase: "idle", steps: [] });
+    if (url === "/setup-api/system/stats") return jsonResponse(statsResponse);
+    return jsonResponse({});
+  }));
+
+  render(<SettingsApp ui={defaultUi} />);
+  fireEvent.click(screen.getByRole("button", { name: /settings\.about$/ }));
+
+  const label = await screen.findByText("settings.version");
+  const block = label.closest(".space-y-2");
+  if (!block) throw new Error("About version block not found");
+  return within(block as HTMLElement);
+}
+
+/** Read the value cell of a version row by its label. */
+function rowValue(block: ReturnType<typeof within>, label: string): string {
+  const cell = block.getByText(label).parentElement?.lastElementChild;
+  return cell?.textContent ?? "";
+}
+
+/**
+ * On the Hermes edition the OpenClaw harness is not installed at all, so the
+ * About screen's "OpenClaw" row could only ever read "not installed" — a fact
+ * about software this SKU was never supposed to have, and no information about
+ * the agent the box actually runs. The row now follows the edition.
+ */
+describe("SettingsApp About — harness version row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the Hermes version and no OpenClaw row on the hermes edition", async () => {
+    const block = await openAboutVersions({
+      clawbox: { current: "v3.1.0", target: null },
+      openclaw: { current: null, target: null },
+      hermes: { current: "v0.20.5", target: null, updateAvailable: false },
+      edition: "hermes",
+    });
+
+    expect(block.queryByText("OpenClaw")).not.toBeInTheDocument();
+    expect(block.getByText("Hermes")).toBeInTheDocument();
+    expect(rowValue(block, "Hermes")).toBe("v0.20.5");
+  });
+
+  it("still says 'not installed' on hermes when the agent cannot be probed", async () => {
+    const block = await openAboutVersions({
+      clawbox: { current: "v3.1.0", target: null },
+      openclaw: { current: null, target: null },
+      hermes: { current: null, target: null, updateAvailable: false },
+      edition: "hermes",
+    });
+
+    expect(block.queryByText("OpenClaw")).not.toBeInTheDocument();
+    expect(rowValue(block, "Hermes")).toBe("settings.notInstalled");
+  });
+
+  it("is unchanged on the openclaw edition — OpenClaw only, no Hermes row", async () => {
+    const block = await openAboutVersions({
+      clawbox: { current: "v3.1.0", target: null },
+      openclaw: { current: "OpenClaw 2026.7.1 (3e72c03)", target: null },
+      edition: "openclaw",
+    });
+
+    expect(block.queryByText("Hermes")).not.toBeInTheDocument();
+    expect(rowValue(block, "OpenClaw")).toBe("2026.7.1");
+  });
+
+  it("labels both harnesses on the dual edition", async () => {
+    const block = await openAboutVersions({
+      clawbox: { current: "v3.1.0", target: null },
+      openclaw: { current: "OpenClaw 2026.7.1 (3e72c03)", target: null },
+      hermes: { current: "v0.20.5", target: null, updateAvailable: false },
+      edition: "dual",
+    });
+
+    expect(rowValue(block, "OpenClaw")).toBe("2026.7.1");
+    expect(rowValue(block, "Hermes")).toBe("v0.20.5");
+  });
+
+  it("falls back to the old OpenClaw-only row when the server predates the edition field", async () => {
+    // A device that has not been updated yet answers with the two-key shape.
+    const block = await openAboutVersions({
+      clawbox: { current: "v3.0.3", target: null },
+      openclaw: { current: "2026.7.1", target: null },
+    });
+
+    expect(rowValue(block, "OpenClaw")).toBe("2026.7.1");
+    expect(block.queryByText("Hermes")).not.toBeInTheDocument();
+  });
+});

--- a/src/tests/routes/update/status.test.ts
+++ b/src/tests/routes/update/status.test.ts
@@ -39,6 +39,7 @@ describe("GET /setup-api/update/status", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "1.0.0", target: "1.1.0" },
       openclaw: { current: "0.5.0", target: "0.5.1" },
+      edition: "openclaw",
     });
 
     const mod = await import("@/app/setup-api/update/status/route");
@@ -64,6 +65,7 @@ describe("GET /setup-api/update/status", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "1.1.0", target: null, updateAvailable: false },
       openclaw: { current: "0.5.1", target: null, updateAvailable: false },
+      edition: "openclaw",
     });
 
     const res = await updateStatusGet();
@@ -80,6 +82,7 @@ describe("GET /setup-api/update/status", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "1.0.0", target: "1.1.0", updateAvailable: true },
       openclaw: { current: "0.5.1", target: null, updateAvailable: false },
+      edition: "openclaw",
     });
 
     const res = await updateStatusGet();

--- a/src/tests/routes/update/versions.test.ts
+++ b/src/tests/routes/update/versions.test.ts
@@ -23,6 +23,7 @@ describe("GET /setup-api/update/versions", () => {
     mockGetVersionInfo.mockResolvedValue({
       clawbox: { current: "v2.2.2", target: "v2.2.3" },
       openclaw: { current: "2026.4.5", target: "2026.4.6" },
+      edition: "openclaw",
     });
 
     const mod = await import("@/app/setup-api/update/versions/route");
@@ -36,8 +37,28 @@ describe("GET /setup-api/update/versions", () => {
     await expect(response.json()).resolves.toEqual({
       clawbox: { current: "v2.2.2", target: "v2.2.3" },
       openclaw: { current: "2026.4.5", target: "2026.4.6" },
+      edition: "openclaw",
     });
     expect(mockInvalidateVersionCache).not.toHaveBeenCalled();
+  });
+
+  // The About screen reads the harness version from this route; it must carry
+  // the hermes component through untouched rather than flattening it away.
+  it("passes the Hermes component through on a hermes device", async () => {
+    mockGetVersionInfo.mockResolvedValue({
+      clawbox: { current: "v3.1.0", target: null },
+      openclaw: { current: null, target: null },
+      hermes: { current: "v0.20.5", target: null, updateAvailable: false },
+      edition: "hermes",
+    });
+
+    const response = await getVersions(makeRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      hermes: { current: "v0.20.5", target: null, updateAvailable: false },
+      edition: "hermes",
+    });
   });
 
   it("force=1 invalidates the cache before reading versions", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -21,6 +21,11 @@ vi.mock("@/lib/port-probe", () => ({
   isPortOpen: vi.fn(),
 }));
 
+// The Hermes version probe goes through the shared CLI wrapper, so the wrapper
+// is the seam: nothing in these tests may spawn a real `hermes`.
+const { mockRunHermesCli } = vi.hoisted(() => ({ mockRunHermesCli: vi.fn() }));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: mockRunHermesCli }));
+
 import { get, set, setMany } from "@/lib/config-store";
 import { isPortOpen } from "@/lib/port-probe";
 
@@ -808,5 +813,104 @@ describe("updater", () => {
         expect.objectContaining({ update_completed: true }),
       );
     });
+  });
+});
+
+/**
+ * The About screen used to report an OpenClaw version on every SKU. On the
+ * Hermes edition there IS no OpenClaw — the harness is not installed — so the
+ * row could only read "not installed": a line about software the device was
+ * never meant to have, and nothing at all about the agent it actually runs.
+ *
+ * getVersionInfo() therefore reports the harness the device really has, and
+ * must do it without ever spawning a hermes binary on an openclaw box.
+ */
+describe("getVersionInfo harness reporting", () => {
+  const HERMES_BANNER =
+    "Hermes Agent v0.20.5 (2026.8.19) — upstream 261a4efb — local 10914727\n" +
+    "Install directory: /home/clawbox/.hermes/hermes-agent";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    mockGet.mockResolvedValue(undefined);
+    setupExecMock({ "ls-remote": { stdout: "abc123\trefs/tags/v1.0.0\n", stderr: "" } });
+    setupExecFileMock({ openclaw: { stdout: "1.0.0", stderr: "" } });
+    mockRunHermesCli.mockResolvedValue({ code: 0, stdout: HERMES_BANNER, stderr: "" });
+  });
+
+  afterEach(() => {
+    delete process.env.CLAWBOX_EDITION;
+  });
+
+  async function versionsFor(edition: string) {
+    vi.resetModules();
+    process.env.CLAWBOX_EDITION = edition;
+    const fresh = await import("@/lib/updater");
+    return fresh.getVersionInfo();
+  }
+
+  it("reports the Hermes agent version on the hermes edition", async () => {
+    const info = await versionsFor("hermes");
+
+    expect(info.edition).toBe("hermes");
+    expect(info.hermes?.current).toBe("v0.20.5");
+    expect(mockRunHermesCli).toHaveBeenCalledWith(["--version"], expect.anything());
+  });
+
+  it("never spawns hermes on the openclaw edition, and reports no hermes field", async () => {
+    const info = await versionsFor("openclaw");
+
+    expect(info.edition).toBe("openclaw");
+    expect(info.hermes).toBeUndefined();
+    expect(mockRunHermesCli).not.toHaveBeenCalled();
+    // OpenClaw itself is unchanged — this SKU's About row still has a version.
+    expect(info.openclaw.current).toBe("1.0.0");
+  });
+
+  it("reports both harnesses on dual", async () => {
+    const info = await versionsFor("dual");
+
+    expect(info.edition).toBe("dual");
+    expect(info.openclaw.current).toBe("1.0.0");
+    expect(info.hermes?.current).toBe("v0.20.5");
+  });
+
+  it("reports a null hermes version rather than failing when the CLI is missing", async () => {
+    mockRunHermesCli.mockRejectedValue(new Error("Hermes is not installed on this device"));
+
+    const info = await versionsFor("hermes");
+
+    // The field is still present (the SKU has a Hermes) but has no version,
+    // and the ClawBox half of the payload is unaffected.
+    expect(info.hermes).toEqual({ current: null, target: null, updateAvailable: false });
+    expect(info.clawbox.current).toBeTruthy();
+  });
+
+  it("reports a null hermes version when the CLI exits non-zero", async () => {
+    mockRunHermesCli.mockResolvedValue({ code: 1, stdout: "", stderr: "boom" });
+
+    const info = await versionsFor("hermes");
+
+    expect(info.hermes?.current).toBeNull();
+  });
+
+  it("offers no Hermes update — ClawBox does not pin the agent", async () => {
+    const info = await versionsFor("hermes");
+
+    expect(info.hermes?.target).toBeNull();
+    expect(info.hermes?.updateAvailable).toBe(false);
+  });
+
+  it("probes hermes once per cache window, not once per caller", async () => {
+    vi.resetModules();
+    process.env.CLAWBOX_EDITION = "hermes";
+    const fresh = await import("@/lib/updater");
+
+    await fresh.getVersionInfo();
+    await fresh.getVersionInfo();
+    await fresh.getVersionInfo();
+
+    expect(mockRunHermesCli).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tests/unit/version-utils.test.ts
+++ b/src/tests/unit/version-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { cleanVersion } from "@/lib/version-utils";
+import { cleanVersion, parseHermesVersion } from "@/lib/version-utils";
 
 describe("version-utils", () => {
   it("returns null for empty values", () => {
@@ -26,5 +26,47 @@ describe("version-utils", () => {
 
   it("leaves already clean versions intact", () => {
     expect(cleanVersion("v1.2.3")).toBe("v1.2.3");
+  });
+});
+
+describe("parseHermesVersion", () => {
+  // The real banner from a hermes-edition box (`hermes --version`, v0.20.5).
+  const banner = [
+    "Hermes Agent v0.20.5 (2026.8.19) — upstream 261a4efb — local 10914727 (+1 carried commit)",
+    "Install directory: /home/clawbox/.hermes/hermes-agent",
+    "Install method: git",
+  ].join("\n");
+
+  it("reduces the multi-line banner to the version tag", () => {
+    expect(parseHermesVersion(banner)).toBe("v0.20.5");
+  });
+
+  it("returns null for empty values", () => {
+    expect(parseHermesVersion(undefined)).toBeNull();
+    expect(parseHermesVersion(null)).toBeNull();
+    expect(parseHermesVersion("")).toBeNull();
+    expect(parseHermesVersion("   \n  ")).toBeNull();
+  });
+
+  it("keeps a bare tag as-is and tolerates a missing v prefix", () => {
+    expect(parseHermesVersion("v0.20.5")).toBe("v0.20.5");
+    expect(parseHermesVersion("Hermes Agent 0.21.0")).toBe("0.21.0");
+  });
+
+  it("keeps a prerelease suffix", () => {
+    expect(parseHermesVersion("Hermes Agent v0.21.0-rc.2 (2026.9.1)")).toBe("v0.21.0-rc.2");
+  });
+
+  it("falls back to the first line when nothing looks like a version", () => {
+    expect(parseHermesVersion("Hermes Agent (dev build)\nInstall method: git")).toBe(
+      "Hermes Agent (dev build)",
+    );
+  });
+
+  it("caps an unrecognised banner so it cannot blow out the About row", () => {
+    const long = `Hermes ${"x".repeat(200)}`;
+    const parsed = parseHermesVersion(long);
+    expect(parsed).toHaveLength(65);
+    expect(parsed?.endsWith("…")).toBe(true);
   });
 });


### PR DESCRIPTION
## The bug

Settings → About showed an **OpenClaw** version row on every SKU. The `hermes`
edition ships no OpenClaw harness at all (`openclawIsAbsent()`), so that row
could only ever read "not installed" — a statement about software the device
was never supposed to have, and nothing at all about the agent it actually
runs.

## Where the value came from

`SettingsApp.tsx` (About) reads `versionInfo` from `GET /setup-api/update/versions`
→ `getVersionInfo()` in `src/lib/updater.ts`, which reported exactly two
components: `clawbox` and `openclaw`.

## The fix

**Server** — `getVersionInfo()` now also reports the harness the device really has:

- `hermes`: present **only** on the SKUs that ship it (`hermes`, `dual`).
  Installed version only — Hermes comes from its own upstream installer, not a
  ClawBox pin, so there is no target to converge on and nothing to offer an
  update for.
- `edition`: which harnesses exist, so the UI never has to guess.

Both are **additive**; the existing keys are untouched, so an older client
renders exactly as before. No new route — `/setup-api/update/versions` (and
`/update/status`, which shares the same source) just carry the extra fields.

The probe goes through the existing `runHermesCli` wrapper (argv-only, no
shell, capped output, timeout) and is **gated on `hasHermesHarness()`**, so an
`openclaw` box never spawns a hermes binary. It rides the existing 60 s version
cache, so polling About cannot become a subprocess storm — measured on a Jetson
the probe costs ~0.35 s, once per cache window.

`hermes --version` prints a multi-line banner rather than a tag, and
`cleanVersion()`'s rules (shaped for OpenClaw / git-describe output) match none
of it — the parenthesised build date is mid-line, not at the end. So
`parseHermesVersion()` reduces it to the tag.

**Client** — the About version block renders per edition:

| edition | rows |
| --- | --- |
| `hermes` | Hermes only |
| `openclaw` | OpenClaw only (unchanged) |
| `dual` | both, labelled |
| older server (no `edition` field) | OpenClaw only, exactly as today |

The ClawBox version row and everything else in About are untouched. Both labels
are brand names already rendered untranslated, so no new i18n keys were needed.

## Live evidence (hermes bench box, v3.9.0)

`GET /setup-api/update/versions`:

```json
{"clawbox":{"current":"v3.9.0","target":null,"updateAvailable":false},
 "openclaw":{"current":null,"target":"2026.7.1-2","updateAvailable":false},
 "hermes":{"current":"v0.20.5","target":null,"updateAvailable":false},
 "edition":"hermes"}
```

matching the device's own `hermes --version` first line
(`Hermes Agent v0.20.5 (2026.8.19) · upstream … · local …`).

## Tests

75 passing across 7 suites, run on the hermes bench box:

- `src/tests/unit/version-utils.test.ts` — `parseHermesVersion` (banner → tag,
  bare tag, missing `v`, prerelease suffix, unrecognised-banner fallback + cap,
  empty input)
- `src/tests/unit/updater.test.ts` — server-side resolution with the CLI
  mocked: hermes reports a version, **openclaw never spawns hermes**, dual
  reports both, missing/failing CLI degrades to `null` instead of failing the
  endpoint, no Hermes update is ever offered, and the probe runs once per cache
  window
- `src/tests/components/settings-about-version.test.tsx` — edition-conditional
  rendering for all four cases in the table above
- `src/tests/routes/update/versions.test.ts` — the route carries the `hermes`
  component through
- plus `update/status`, `settings-app`, `system-update-app` for regressions

`tsc --noEmit` matches the branch point exactly (same 16 pre-existing errors,
none in touched files); `eslint` on changed files reports 0 errors.

## Known gap

The System Update confirmation modal still lists an OpenClaw row on hermes.
Left alone deliberately to keep the `SettingsApp.tsx` diff local to About
(that block is duplicated twice in the file) — worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added edition-aware version reporting for OpenClaw and Hermes devices.
  - The About section now displays the appropriate product version and hides irrelevant version details.
  - Hermes version information is shown when available, including support for legacy and dual-edition devices.

- **Bug Fixes**
  - Improved handling of missing, failed, or unrecognized Hermes version responses.
  - Prevented unnecessary version checks on devices that do not support Hermes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->