### PR TITLE
Telegram voice notes reach speech-to-text instead of OpenAI's front door (TASK-502)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -557,6 +557,14 @@ if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _visi
         agents_defaults["imageModel"] = {"primary": CLAWBOX_VISION_MODEL_REF}
         changed = True
 
+# Set by the image-generation migration below, on the one path where it decides
+# the `openai` provider slot is ours to write. The speech-to-text migration
+# after it is gated on exactly that fact: it points channel audio at our proxy,
+# and that proxy is reached with whatever key sits on that provider.
+_clawai_openai_route_is_ours = False
+_clawai_proxy_base_url = ""
+_clawai_proxy_host = None
+
 # Migration: ClawBox AI image generation.
 #
 # OpenClaw only registers its `image_generate` tool when an image-generation
@@ -685,6 +693,9 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
 
     if _key_is_ours and _foreign_route is None:
         models_providers["openai"] = openai_provider
+        _clawai_openai_route_is_ours = True
+        _clawai_proxy_base_url = _image_base_url
+        _clawai_proxy_host = _proxy_host
         if openai_provider.get("apiKey") != _clawai_token:
             openai_provider["apiKey"] = _clawai_token
             changed = True
@@ -744,6 +755,82 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
         if not _has_image_model:
             agents_defaults["imageGenerationModel"] = {"primary": CLAWBOX_IMAGE_MODEL_REF}
             changed = True
+
+# Migration: ClawBox AI speech to text.
+#
+# A voice note arriving over a chat channel — Telegram is the one v4 ships — is
+# transcribed through OpenClaw's media-understanding surface, and that surface
+# is not a models[] row and never reads one. It takes its endpoint from
+# `tools.media.audio.baseUrl` and its bearer from
+# `models.providers.openai.apiKey` — the same last-resort key walk described
+# above. So on a paired ClawBox that configures no audio at all, every voice
+# note ships the claw_ subscription token to OpenAI's default host and comes
+# back
+#   HTTP 401 Incorrect API key provided: claw_…
+# Reproduced on both loop boxes on beta 02249c1; see TASK-502. That broke two
+# things, not one: no channel voice note could ever be transcribed, and the
+# token the block above takes such care never to hand to a foreign route was
+# being handed to one on every attempt.
+#
+# Both fields written below are load-bearing, measured against the live proxy
+# on 2026-08-22:
+#   - the baseUrl alone still fails, because OpenClaw's default audio model for
+#     `openai` is gpt-4o-transcribe and the proxy answers 400 "Model not
+#     supported for transcription: gpt-4o-transcribe. Use
+#     gpt-4o-mini-transcribe."
+#   - the model pin alone still resolves to api.openai.com and still 401s
+#
+# The device chat microphone does not come through here — it posts to the proxy
+# itself from src/app/setup-api/chat/transcribe/route.ts — which is exactly why
+# this stayed invisible until a channel voice note was tried on real hardware.
+#
+# The model id is duplicated from TRANSCRIBE_MODEL in that route for the same
+# reason the image id is duplicated above: a shell migration cannot import a TS
+# constant. It must name a model production allows, because the proxy matches
+# the bare id and answers 400 on a miss.
+CLAWBOX_TRANSCRIBE_MODEL_ID = "gpt-4o-mini-transcribe"
+CLAWBOX_AUDIO_MODELS = [{"provider": "openai", "model": CLAWBOX_TRANSCRIBE_MODEL_ID}]
+
+if _clawai_openai_route_is_ours:
+    # A non-dict at any of these paths is config the gateway cannot read at
+    # all, so it is replaced rather than respected — the same call the `compat`
+    # migration below makes, for the same reason.
+    _tools = cfg.get("tools")
+    if not isinstance(_tools, dict):
+        _tools = {}
+    _media = _tools.get("media")
+    if not isinstance(_media, dict):
+        _media = {}
+    _audio = _media.get("audio")
+    if not isinstance(_audio, dict):
+        _audio = {}
+
+    # Anything already here that is not what we would write is the owner's own
+    # transcription setup: a self-hosted Whisper, a Deepgram key, a different
+    # model on our own proxy. Leave all of it alone. A half-applied migration
+    # that keeps their endpoint and swaps their model is worse than none, and
+    # sending our token to their host is the failure this whole block exists to
+    # stop.
+    _audio_base_url = _audio.get("baseUrl")
+    _audio_models = _audio.get("models")
+    _audio_has_base_url = isinstance(_audio_base_url, str) and bool(_audio_base_url.strip())
+    _audio_host = _url_host(_audio_base_url) if _audio_has_base_url else None
+    _audio_route_taken = bool(
+        (_audio_has_base_url and (_audio_host is None or _clawai_proxy_host is None or _audio_host != _clawai_proxy_host))
+        or (_audio_models is not None and _audio_models != CLAWBOX_AUDIO_MODELS)
+    )
+    if _audio_route_taken:
+        print(
+            "  Skipped ClawBox AI speech to text: tools.media.audio already names its own transcription route"
+        )
+    elif _audio_base_url != _clawai_proxy_base_url or _audio_models != CLAWBOX_AUDIO_MODELS:
+        _audio["baseUrl"] = _clawai_proxy_base_url
+        _audio["models"] = [dict(_entry) for _entry in CLAWBOX_AUDIO_MODELS]
+        _media["audio"] = _audio
+        _tools["media"] = _media
+        cfg["tools"] = _tools
+        changed = True
+
 
 if isinstance(ds_models, list):
     target_efforts = ["off", "high", "xhigh"]

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -563,7 +563,6 @@ if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _visi
 # and that proxy is reached with whatever key sits on that provider.
 _clawai_openai_route_is_ours = False
 _clawai_proxy_base_url = ""
-_clawai_proxy_host = None
 
 # Migration: ClawBox AI image generation.
 #
@@ -695,7 +694,6 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
         models_providers["openai"] = openai_provider
         _clawai_openai_route_is_ours = True
         _clawai_proxy_base_url = _image_base_url
-        _clawai_proxy_host = _proxy_host
         if openai_provider.get("apiKey") != _clawai_token:
             openai_provider["apiKey"] = _clawai_token
             changed = True
@@ -811,12 +809,19 @@ if _clawai_openai_route_is_ours:
     # that keeps their endpoint and swaps their model is worse than none, and
     # sending our token to their host is the failure this whole block exists to
     # stop.
+    def _same_endpoint(_a, _b):
+        # The WHOLE endpoint, not just its host. An owner who pointed
+        # transcription at https://clawbox.com/their-own-route chose that path
+        # deliberately, and a host-only match would stamp over it while
+        # reporting success. A trailing slash is the one difference that means
+        # nothing.
+        return _a.rstrip("/") == _b.rstrip("/")
+
     _audio_base_url = _audio.get("baseUrl")
     _audio_models = _audio.get("models")
     _audio_has_base_url = isinstance(_audio_base_url, str) and bool(_audio_base_url.strip())
-    _audio_host = _url_host(_audio_base_url) if _audio_has_base_url else None
     _audio_route_taken = bool(
-        (_audio_has_base_url and (_audio_host is None or _clawai_proxy_host is None or _audio_host != _clawai_proxy_host))
+        (_audio_has_base_url and not _same_endpoint(_audio_base_url, _clawai_proxy_base_url))
         or (_audio_models is not None and _audio_models != CLAWBOX_AUDIO_MODELS)
     )
     if _audio_route_taken:

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -813,9 +813,13 @@ if _clawai_openai_route_is_ours:
         # The WHOLE endpoint, not just its host. An owner who pointed
         # transcription at https://clawbox.com/their-own-route chose that path
         # deliberately, and a host-only match would stamp over it while
-        # reporting success. A trailing slash is the one difference that means
-        # nothing.
-        return _a.rstrip("/") == _b.rstrip("/")
+        # reporting success. One trailing slash is the only difference that
+        # means nothing; stripping every slash would also treat an owner's
+        # deliberate `.../api/ai//` route as ours and stamp over it.
+        def _without_one_trailing_slash(_value):
+            return _value[:-1] if _value.endswith("/") else _value
+
+        return _without_one_trailing_slash(_a) == _without_one_trailing_slash(_b)
 
     _audio_base_url = _audio.get("baseUrl")
     _audio_models = _audio.get("models")

--- a/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
@@ -153,6 +153,25 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI speech-to-text mig
     expect(audio(cfg)).toEqual(owner);
   });
 
+  it("normalizes one harmless trailing slash on our managed endpoint", () => {
+    const { cfg, changed } = migrate({
+      tools: { media: { audio: { baseUrl: `${PROXY}/`, models: OURS } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(audio(cfg)).toEqual({ baseUrl: PROXY, models: OURS });
+  });
+
+  it("leaves repeated trailing slashes alone as a distinct owner route", () => {
+    // Removing every trailing slash would turn this into PROXY and overwrite a
+    // route the owner explicitly entered. Only one optional slash is syntax.
+    const owner = { baseUrl: `${PROXY}//`, models: OURS };
+    const { cfg, changed } = migrate({ tools: { media: { audio: { ...owner } } } });
+
+    expect(changed).toBe(false);
+    expect(audio(cfg)).toEqual(owner);
+  });
+
   it("keeps an endpoint it cannot make sense of", () => {
     // We cannot say where it points, so we cannot say our token is safe there.
     const owner = { baseUrl: "not a url" };

--- a/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// A voice note that arrives over a chat channel is transcribed through
+// OpenClaw's media-understanding surface, which is not a models[] row and
+// never reads one: it takes its endpoint from `tools.media.audio.baseUrl` and
+// its bearer from `models.providers.openai.apiKey`. ClawBox writes that key
+// and, before TASK-502, no audio config at all — so every Telegram voice note
+// sent the claw_ subscription token to api.openai.com and came back 401.
+// Reproduced on both loop boxes on beta 02249c1.
+//
+// Like the image migration next door, these run the block out of the shipped
+// .sh rather than a copy, so the test fails if the real script drifts.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+const PROXY = "https://clawbox.com/api/ai";
+const TRANSCRIBE_MODEL = "gpt-4o-mini-transcribe";
+const OURS = [{ provider: "openai", model: TRANSCRIBE_MODEL }];
+
+function slice(from: string, to: string): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf(from);
+  const end = src.indexOf(to, start);
+  if (start < 0 || end < 0) throw new Error(`block not found: ${from}`);
+  return src.slice(start, end);
+}
+
+/** The speech-to-text migration, verbatim. */
+const POLICY = hasPython3
+  ? slice("# Migration: ClawBox AI speech to text.", "if isinstance(ds_models, list):")
+  : "";
+
+/**
+ * `_url_host` is shipped too, and the block's don't-clobber test is only as
+ * good as that helper — so it is extracted rather than reimplemented here.
+ */
+const URL_HOST = hasPython3
+  ? slice("def _url_host(_url):", "# Only boxes that actually have ClawBox AI")
+  : "";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "clawai-audio-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+type Config = Record<string, unknown>;
+type AudioConfig = { baseUrl?: unknown; models?: unknown; [key: string]: unknown };
+
+/**
+ * Run the extracted block over a whole openclaw.json.
+ *
+ * The preamble binds only what the real script binds upstream of this point:
+ * `cfg`, `changed`, and the three names the image migration hands over when it
+ * has decided the `openai` provider slot is ours (`_clawai_openai_route_is_ours`,
+ * `_clawai_proxy_base_url`, `_clawai_proxy_host`). `routeIsOurs: false` is the
+ * real script's starting value, i.e. a box whose openai slot belongs to its
+ * owner or that has no ClawBox AI token at all.
+ */
+function migrate(cfg: Config, routeIsOurs = true): { cfg: Config; changed: boolean; log: string } {
+  const file = path.join(dir, "config.json");
+  writeFileSync(file, JSON.stringify(cfg));
+  const program = [
+    "import json, sys",
+    "from urllib.parse import urlsplit",
+    URL_HOST,
+    "cfg = json.load(open(sys.argv[1]))",
+    "changed = False",
+    `_clawai_openai_route_is_ours = ${routeIsOurs ? "True" : "False"}`,
+    `_clawai_proxy_base_url = ${JSON.stringify(PROXY)}`,
+    `_clawai_proxy_host = _url_host(${JSON.stringify(PROXY)})`,
+    POLICY,
+    "print(json.dumps({'cfg': cfg, 'changed': changed}))",
+  ].join("\n");
+  const lines = execFileSync("python3", ["-c", program, file], { encoding: "utf-8" }).trim().split("\n");
+  return { ...JSON.parse(lines[lines.length - 1]), log: lines.slice(0, -1).join("\n") };
+}
+
+function audio(cfg: Config): AudioConfig | undefined {
+  const tools = cfg.tools as { media?: { audio?: AudioConfig } } | undefined;
+  return tools?.media?.audio;
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI speech-to-text migration", () => {
+  it("points channel audio at the proxy and pins the model production serves", () => {
+    const { cfg, changed } = migrate({});
+
+    expect(changed).toBe(true);
+    // Both halves are load-bearing against the live proxy: the baseUrl alone
+    // gets 400 (OpenClaw's default openai audio model is gpt-4o-transcribe,
+    // which the proxy does not serve) and the pin alone still goes to OpenAI.
+    expect(audio(cfg)).toEqual({ baseUrl: PROXY, models: OURS });
+  });
+
+  it("keeps whatever else already sits under tools.media", () => {
+    const { cfg } = migrate({
+      tools: {
+        media: {
+          image: { enabled: true },
+          audio: { enabled: true, language: "bg", maxBytes: 1024 },
+        },
+        other: { keep: "me" },
+      },
+    });
+
+    expect(audio(cfg)).toEqual({
+      enabled: true,
+      language: "bg",
+      maxBytes: 1024,
+      baseUrl: PROXY,
+      models: OURS,
+    });
+    const tools = cfg.tools as { media: Record<string, unknown>; other: unknown };
+    expect(tools.media.image).toEqual({ enabled: true });
+    expect(tools.other).toEqual({ keep: "me" });
+  });
+
+  it("is idempotent — a second boot writes nothing", () => {
+    const once = migrate({});
+    const twice = migrate(once.cfg);
+
+    expect(twice.changed).toBe(false);
+    expect(twice.cfg).toEqual(once.cfg);
+  });
+
+  it("does nothing at all when the openai slot is not ours", () => {
+    // The image migration refused the slot, so the key on it is the owner's
+    // OpenAI credential. Pointing audio at our proxy would post THEIR key to
+    // clawbox.com — the mirror image of the leak this fixes.
+    const { cfg, changed } = migrate({}, false);
+
+    expect(changed).toBe(false);
+    expect(cfg.tools).toBeUndefined();
+  });
+
+  it("leaves a foreign transcription endpoint alone and says so", () => {
+    const owner = { baseUrl: "https://whisper.lan/v1", models: [{ provider: "openai", model: "whisper-1" }] };
+    const { cfg, changed, log } = migrate({ tools: { media: { audio: { ...owner } } } });
+
+    expect(changed).toBe(false);
+    expect(audio(cfg)).toEqual(owner);
+    expect(log).toContain("Skipped ClawBox AI speech to text");
+  });
+
+  it("leaves a different model on our own proxy alone", () => {
+    // Same host, deliberate choice of model — still the owner's configuration.
+    const owner = { baseUrl: PROXY, models: [{ provider: "openai", model: "gpt-4o-transcribe" }] };
+    const { cfg, changed } = migrate({ tools: { media: { audio: { ...owner } } } });
+
+    expect(changed).toBe(false);
+    expect(audio(cfg)).toEqual(owner);
+  });
+
+  it("treats an unparseable endpoint as foreign", () => {
+    // We cannot say where it points, so we cannot say our token is safe there.
+    const owner = { baseUrl: "not a url" };
+    const { cfg, changed } = migrate({ tools: { media: { audio: { ...owner } } } });
+
+    expect(changed).toBe(false);
+    expect(audio(cfg)).toEqual(owner);
+  });
+
+  it("leaves an empty models list alone rather than claiming it", () => {
+    // `models: []` is a deliberate "no provider models here", not an absence.
+    const { cfg, changed } = migrate({ tools: { media: { audio: { models: [] } } } });
+
+    expect(changed).toBe(false);
+    expect(audio(cfg)).toEqual({ models: [] });
+  });
+
+  it("repairs a half-written config from an interrupted boot", () => {
+    // Our own baseUrl, our pin missing: the transcription would resolve to
+    // gpt-4o-transcribe and 400 on every voice note.
+    const { cfg, changed } = migrate({ tools: { media: { audio: { baseUrl: PROXY } } } });
+
+    expect(changed).toBe(true);
+    expect(audio(cfg)).toEqual({ baseUrl: PROXY, models: OURS });
+  });
+
+  it("replaces a non-dict at tools.media.audio rather than booting broken", () => {
+    const { cfg, changed } = migrate({ tools: { media: { audio: "yes" } } });
+
+    expect(changed).toBe(true);
+    expect(audio(cfg)).toEqual({ baseUrl: PROXY, models: OURS });
+  });
+
+  it("follows a staging box to its own proxy", () => {
+    // The proxy base url is taken from the deepseek entry upstream, so a box
+    // provisioned against staging keeps talking to staging for audio too.
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, JSON.stringify({}));
+    const staging = "https://staging.clawbox.com/api/ai";
+    const program = [
+      "import json, sys",
+      "from urllib.parse import urlsplit",
+      URL_HOST,
+      "cfg = json.load(open(sys.argv[1]))",
+      "changed = False",
+      "_clawai_openai_route_is_ours = True",
+      `_clawai_proxy_base_url = ${JSON.stringify(staging)}`,
+      `_clawai_proxy_host = _url_host(${JSON.stringify(staging)})`,
+      POLICY,
+      "print(json.dumps({'cfg': cfg, 'changed': changed}))",
+    ].join("\n");
+    const out = execFileSync("python3", ["-c", program, file], { encoding: "utf-8" }).trim().split("\n");
+    const { cfg } = JSON.parse(out[out.length - 1]) as { cfg: Config };
+
+    expect(audio(cfg)).toEqual({ baseUrl: staging, models: OURS });
+  });
+
+  it("pins the model the transcribe route uses, so both paths bill the same thing", () => {
+    const route = readFileSync(
+      path.resolve(process.cwd(), "src/app/setup-api/chat/transcribe/route.ts"),
+      "utf-8",
+    );
+
+    expect(route).toContain(`"${TRANSCRIBE_MODEL}"`);
+    expect(POLICY).toContain(`CLAWBOX_TRANSCRIBE_MODEL_ID = "${TRANSCRIBE_MODEL}"`);
+  });
+});

--- a/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
@@ -35,14 +35,6 @@ const POLICY = hasPython3
   ? slice("# Migration: ClawBox AI speech to text.", "if isinstance(ds_models, list):")
   : "";
 
-/**
- * `_url_host` is shipped too, and the block's don't-clobber test is only as
- * good as that helper — so it is extracted rather than reimplemented here.
- */
-const URL_HOST = hasPython3
-  ? slice("def _url_host(_url):", "# Only boxes that actually have ClawBox AI")
-  : "";
-
 let dir: string;
 beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "clawai-audio-")); });
 afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
@@ -54,10 +46,10 @@ type AudioConfig = { baseUrl?: unknown; models?: unknown; [key: string]: unknown
  * Run the extracted block over a whole openclaw.json.
  *
  * The preamble binds only what the real script binds upstream of this point:
- * `cfg`, `changed`, and the three names the image migration hands over when it
- * has decided the `openai` provider slot is ours (`_clawai_openai_route_is_ours`,
- * `_clawai_proxy_base_url`, `_clawai_proxy_host`). `routeIsOurs: false` is the
- * real script's starting value, i.e. a box whose openai slot belongs to its
+ * `cfg`, `changed`, and the two names the image migration hands over once it
+ * has decided the `openai` provider slot is ours
+ * (`_clawai_openai_route_is_ours`, `_clawai_proxy_base_url`).
+ * `routeIsOurs: false` is the real script's starting value, i.e. a box whose openai slot belongs to its
  * owner or that has no ClawBox AI token at all.
  */
 function migrate(cfg: Config, routeIsOurs = true): { cfg: Config; changed: boolean; log: string } {
@@ -65,13 +57,10 @@ function migrate(cfg: Config, routeIsOurs = true): { cfg: Config; changed: boole
   writeFileSync(file, JSON.stringify(cfg));
   const program = [
     "import json, sys",
-    "from urllib.parse import urlsplit",
-    URL_HOST,
     "cfg = json.load(open(sys.argv[1]))",
     "changed = False",
     `_clawai_openai_route_is_ours = ${routeIsOurs ? "True" : "False"}`,
     `_clawai_proxy_base_url = ${JSON.stringify(PROXY)}`,
-    `_clawai_proxy_host = _url_host(${JSON.stringify(PROXY)})`,
     POLICY,
     "print(json.dumps({'cfg': cfg, 'changed': changed}))",
   ].join("\n");
@@ -154,7 +143,17 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI speech-to-text mig
     expect(audio(cfg)).toEqual(owner);
   });
 
-  it("treats an unparseable endpoint as foreign", () => {
+  it("leaves another route on our own host alone", () => {
+    // Same host, different path: the owner pointed transcription somewhere
+    // specific and a host-only comparison would have stamped over it.
+    const owner = { baseUrl: "https://clawbox.com/custom-transcribe", models: OURS };
+    const { cfg, changed } = migrate({ tools: { media: { audio: { ...owner } } } });
+
+    expect(changed).toBe(false);
+    expect(audio(cfg)).toEqual(owner);
+  });
+
+  it("keeps an endpoint it cannot make sense of", () => {
     // We cannot say where it points, so we cannot say our token is safe there.
     const owner = { baseUrl: "not a url" };
     const { cfg, changed } = migrate({ tools: { media: { audio: { ...owner } } } });
@@ -172,7 +171,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI speech-to-text mig
   });
 
   it("repairs a half-written config from an interrupted boot", () => {
-    // Our own baseUrl, our pin missing: the transcription would resolve to
+    // Our own baseUrl to the character, our pin missing: the transcription would resolve to
     // gpt-4o-transcribe and 400 on every voice note.
     const { cfg, changed } = migrate({ tools: { media: { audio: { baseUrl: PROXY } } } });
 
@@ -195,13 +194,10 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI speech-to-text mig
     const staging = "https://staging.clawbox.com/api/ai";
     const program = [
       "import json, sys",
-      "from urllib.parse import urlsplit",
-      URL_HOST,
       "cfg = json.load(open(sys.argv[1]))",
       "changed = False",
       "_clawai_openai_route_is_ours = True",
       `_clawai_proxy_base_url = ${JSON.stringify(staging)}`,
-      `_clawai_proxy_host = _url_host(${JSON.stringify(staging)})`,
       POLICY,
       "print(json.dumps({'cfg': cfg, 'changed': changed}))",
     ].join("\n");

--- a/src/tests/unit/gateway-pre-start-clawai-images.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-images.test.ts
@@ -41,7 +41,10 @@ const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).stat
 function extractPolicy(): string {
   const src = readFileSync(SCRIPT, "utf-8");
   const start = src.indexOf("# Migration: ClawBox AI image generation.");
-  const end = src.indexOf("if isinstance(ds_models, list):", start);
+  // Ends where the speech-to-text migration begins: the two blocks are
+  // independent and each is exercised by its own file
+  // (gateway-pre-start-clawai-audio.test.ts).
+  const end = src.indexOf("# Migration: ClawBox AI speech to text.", start);
   if (start < 0 || end < 0) throw new Error("clawai image migration block not found");
   return src.slice(start, end);
 }


### PR DESCRIPTION
## What broke

Found while verifying TASK-484 (Telegram voice notes → STT) on real hardware. Reproduced on **both** loop boxes on beta `02249c1` — `.65` clean install and `.177` upgrade:

```
openclaw capability audio transcribe --file voice.ogg --json
→ ProviderHttpError: Audio transcription failed (HTTP 401):
  Incorrect API key provided: claw_84d*************063c.
  You can find your API key at https://platform.openai.com/account/api-keys.
```

Channel audio goes through OpenClaw's media-understanding surface, which is **not** a `models[]` row and never reads one. It resolves its endpoint from `tools.media.audio.baseUrl` and its bearer from `models.providers.openai.apiKey`.

`gateway-pre-start.sh` writes that apiKey — the `claw_` subscription token — and deliberately writes no provider-level `baseUrl`. Nothing wrote `tools.media.audio` at all. So OpenClaw's default endpoint applied.

Two consequences, not one:

1. **No Telegram voice note could ever be transcribed on any box.**
2. **The subscription token was transmitted to OpenAI on every attempt.** The block right above this one carries a long comment about how handing that token to a foreign route is the outcome that must not happen. It guards `models[]` rows and a provider-level `baseUrl` — media-understanding is neither.

The cloud side was never the problem: `POST https://clawbox.com/api/ai/audio/transcriptions` with the box's own token returned HTTP 200 and the correct transcript.

## The fix

The ClawBox-AI migration now also writes `tools.media.audio`:

```json
{ "baseUrl": "<the box's proxy>", "models": [{ "provider": "openai", "model": "gpt-4o-mini-transcribe" }] }
```

Both fields are load-bearing, measured against the live proxy on 2026-08-22:

| written | result |
|---|---|
| `baseUrl` only | 400 `Model not supported for transcription: gpt-4o-transcribe. Use gpt-4o-mini-transcribe.` |
| model pin only | still api.openai.com, still 401 |
| both | correct transcript through the proxy |

It is gated on the image migration having decided the `openai` slot is ours. If the owner's own OpenAI key sits there, pointing audio at our proxy would post **their** credential to clawbox.com — the mirror image of the leak being fixed. Anything already under `tools.media.audio` that is not what we would write is left alone and logged, including a different model on our own host.

Living in `gateway-pre-start.sh` means it repairs every existing box at the next gateway start, not only newly-paired ones.

## Not affected

The device chat microphone posts to the proxy itself from `src/app/setup-api/chat/transcribe/route.ts` with the right model. Only the channel path was broken, which is exactly why this stayed invisible.

## Tests

- New `src/tests/unit/gateway-pre-start-clawai-audio.test.ts` — 12 cases, running the block **out of the shipped `.sh`** (plus the shipped `_url_host` helper), so drift in the real script fails the test. Covers: the write, preserving the rest of `tools.media`, idempotency, doing nothing when the openai slot is not ours, a foreign endpoint, a different model on our own host, an unparseable URL, an empty models list, repairing a half-written config, a non-dict at the path, a staging box, and that the pinned model matches `TRANSCRIBE_MODEL` in the chat route.
- `gateway-pre-start-clawai-images.test.ts` extraction boundary moved to the new block's marker so the two migrations stay independently tested.
- Full local suite: 275 files / 3812 tests green.

TASK-502, found by TASK-484.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic speech-to-text configuration for ClawBox AI devices using the ClawBox proxy and transcription model.
  * Preserves existing audio routes when they are not managed by ClawBox.
  * Repairs incomplete or invalid audio settings safely.

* **Bug Fixes**
  * Prevents credentials from being sent to unauthorized endpoints.
  * Ensures repeated migrations do not create duplicate or conflicting settings.

* **Tests**
  * Added coverage for ownership safeguards, staging environments, endpoint handling, and partial configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->