### PR TITLE
The cloud voice exists now, so the box stops saying it does not (TASK-490)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -920,7 +920,9 @@ def _clawai_device_tier():
     return _tier.strip() if isinstance(_tier, str) else None
 
 
-if _clawai_openai_route_is_ours and _clawai_device_tier() == CLAWBOX_SPEECH_DEVICE_TIER:
+_clawai_speech_entitled = _clawai_device_tier() == CLAWBOX_SPEECH_DEVICE_TIER
+
+if _clawai_openai_route_is_ours and _clawai_speech_entitled:
     _messages = cfg.get("messages")
     if not isinstance(_messages, dict):
         _messages = {}
@@ -959,6 +961,37 @@ if _clawai_openai_route_is_ours and _clawai_device_tier() == CLAWBOX_SPEECH_DEVI
             _tts["providers"] = _tts_providers
             _messages["tts"] = _tts
             cfg["messages"] = _messages
+            changed = True
+
+elif _clawai_openai_route_is_ours:
+    # The other direction, and it has to exist or this migration is one-way.
+    # A box that was Max and is not any more keeps an entry pointing at an
+    # endpoint that now answers 403, so every spoken reply buys a refused round
+    # trip before falling back — and the panel calls the cloud voice configured
+    # while it does it. Take back only what we wrote: an entry whose baseUrl is
+    # our proxy. An owner's own voice is theirs whatever their ClawBox AI plan
+    # says, and is matched by exactly the same rule as above.
+    #
+    # `messages.tts.provider` is deliberately NOT touched here either. If the
+    # customer had explicitly chosen the cloud voice, the panel's job is to show
+    # them that their choice is no longer available and that the box is speaking
+    # locally instead — which is precisely what it does once the entry is gone.
+    # Silently rewriting their pick would hide the downgrade.
+    _messages = cfg.get("messages")
+    _tts = _messages.get("tts") if isinstance(_messages, dict) else None
+    _tts_providers = _tts.get("providers") if isinstance(_tts, dict) else None
+    _speech = _tts_providers.get("openai") if isinstance(_tts_providers, dict) else None
+    if isinstance(_speech, dict):
+        _speech_base_url = _speech.get("baseUrl")
+        if (
+            isinstance(_speech_base_url, str)
+            and _speech_base_url.strip()
+            and _same_endpoint(_speech_base_url, _clawai_proxy_base_url)
+        ):
+            del _tts_providers["openai"]
+            print(
+                "  Removed the ClawBox AI cloud voice: this box's plan no longer includes it"
+            )
             changed = True
 
 

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -132,6 +132,12 @@ if [ -n "$CLAWBOX_EXTRA_ORIGINS" ]; then
 fi
 export CLAWBOX_EXTRA_ORIGINS
 
+# The device store the Next app writes (`data/config.json`), not openclaw.json.
+# The cloud-voice migration below needs the portal-confirmed plan stamp that
+# lives there, and only there. Exported rather than passed as a second argv so
+# the block keeps the single-argument shape every other python heredoc here has.
+export CLAWBOX_DEVICE_STORE="${CLAWBOX_ROOT:-/home/clawbox/clawbox}/data/config.json"
+
 python3 - "$OPENCLAW_CONFIG" <<'PY'
 import json, os, sys, tempfile, secrets
 
@@ -789,7 +795,34 @@ if isinstance(_clawai_token, str) and _clawai_token.startswith("claw_"):
 CLAWBOX_TRANSCRIBE_MODEL_ID = "gpt-4o-mini-transcribe"
 CLAWBOX_AUDIO_MODELS = [{"provider": "openai", "model": CLAWBOX_TRANSCRIBE_MODEL_ID}]
 
+
+def _same_endpoint(_a, _b):
+    """Do two configured endpoints name the same route?
+
+    The WHOLE endpoint, not just its host. An owner who pointed transcription
+    at https://clawbox.com/their-own-route chose that path deliberately, and a
+    host-only match would stamp over it while reporting success. One trailing
+    slash is the only difference that means nothing; stripping every slash
+    would also treat an owner's deliberate `.../api/ai//` route as ours and
+    stamp over it.
+
+    Module level rather than nested in the guard below because the cloud-voice
+    migration after it asks the same question of the same proxy and must give
+    the same answer. Two copies of this rule would be two rules.
+    """
+    def _without_one_trailing_slash(_value):
+        return _value[:-1] if _value.endswith("/") else _value
+
+    return _without_one_trailing_slash(_a) == _without_one_trailing_slash(_b)
+
+
 if _clawai_openai_route_is_ours:
+    # Anything already under tools.media.audio that is not what we would write
+    # is the owner's own transcription setup: a self-hosted Whisper, a Deepgram
+    # key, a different model on our own proxy. Leave all of it alone. A
+    # half-applied migration that keeps their endpoint and swaps their model is
+    # worse than none, and sending our token to their host is the failure this
+    # whole block exists to stop.
     # A non-dict at any of these paths is config the gateway cannot read at
     # all, so it is replaced rather than respected — the same call the `compat`
     # migration below makes, for the same reason.
@@ -802,24 +835,6 @@ if _clawai_openai_route_is_ours:
     _audio = _media.get("audio")
     if not isinstance(_audio, dict):
         _audio = {}
-
-    # Anything already here that is not what we would write is the owner's own
-    # transcription setup: a self-hosted Whisper, a Deepgram key, a different
-    # model on our own proxy. Leave all of it alone. A half-applied migration
-    # that keeps their endpoint and swaps their model is worse than none, and
-    # sending our token to their host is the failure this whole block exists to
-    # stop.
-    def _same_endpoint(_a, _b):
-        # The WHOLE endpoint, not just its host. An owner who pointed
-        # transcription at https://clawbox.com/their-own-route chose that path
-        # deliberately, and a host-only match would stamp over it while
-        # reporting success. One trailing slash is the only difference that
-        # means nothing; stripping every slash would also treat an owner's
-        # deliberate `.../api/ai//` route as ours and stamp over it.
-        def _without_one_trailing_slash(_value):
-            return _value[:-1] if _value.endswith("/") else _value
-
-        return _without_one_trailing_slash(_a) == _without_one_trailing_slash(_b)
 
     _audio_base_url = _audio.get("baseUrl")
     _audio_models = _audio.get("models")
@@ -839,6 +854,112 @@ if _clawai_openai_route_is_ours:
         _tools["media"] = _media
         cfg["tools"] = _tools
         changed = True
+
+
+# Migration: ClawBox AI cloud voice (text to speech).
+#
+# The mirror image of the block above, and it went wrong the same way. Cloud
+# TTS shipped to production on 2026-08-22 (clawbox-website PR #523), so
+# ClawBox AI genuinely serves speech now — but nothing on the device was ever
+# told, and `messages.tts.providers` on a paired box carries only the local
+# CLI entry. So `cloudCredentialIsUnusable` (src/lib/voice-output.ts) read a
+# claw_ token with no speech endpoint behind it, correctly concluded it was
+# unusable, and every box printed "ClawBox AI does not serve the voice yet" —
+# a confident statement about the product that had stopped being true.
+# Reproduced on both loop boxes on beta ddd168e through the real Settings UI;
+# see TASK-490.
+#
+# All three fields are load-bearing, measured against the live proxy from .65
+# on 2026-08-22 (`openclaw capability tts convert`, 50,688 bytes of real MPEG
+# in 1.96 s against 27.7 s for the on-device voice):
+#   - `baseUrl`, or OpenClaw sends /audio/speech to api.openai.com and the
+#     claw_ token comes back 401. Same shape as the audio baseUrl above: the
+#     provider root, with OpenClaw appending /audio/speech.
+#   - `model`, or the request carries OpenClaw's own default and the proxy
+#     answers 400 — it serves exactly one speech model.
+#   - `apiKey`, because the documented fallback for the OpenAI TTS provider is
+#     the OPENAI_API_KEY environment variable, which a ClawBox does not set.
+#     `models.providers.openai.apiKey` is not consulted for speech.
+#
+# THE TIER GATE. Cloud speech is Max-only on the proxy (SPEECH_MODEL_TIERS),
+# which answers 403 to Free and Pro. Pointing a Pro box at it would be worse
+# than leaving it alone: the panel would call the cloud voice configured, Auto
+# would move the primary onto it, and every spoken reply would pay a failed
+# round trip before falling back to the voice the box already had. So the
+# stamp the status route persists from a live portal answer is the gate.
+# `clawai_tier` is a DEVICE tier, and "pro" is the device tier of the MAX
+# plan — the two names are off by one on purpose (see CLAWBOX_AI_MODEL_BY_TIER
+# in src/lib/clawbox-ai-models.ts). Anything else, including a missing stamp,
+# means we have not been told this box is entitled, and an unentitled box is
+# left exactly as it was. A customer who upgrades gets the cloud voice at the
+# next gateway start, once the status route has refreshed the stamp.
+#
+# The customer-facing "your plan speaks locally, Max speaks in the cloud" line
+# is TASK-486 and deliberately not written here.
+CLAWBOX_SPEECH_MODEL_ID = "gpt-4o-mini-tts"
+CLAWBOX_SPEECH_DEVICE_TIER = "pro"
+
+def _clawai_device_tier():
+    """The portal-confirmed plan stamp, or None when the store cannot be read.
+
+    Unreadable, absent and malformed all collapse to None on purpose: every one
+    of them means "nobody has told us this box is on Max", and the gate below
+    treats not-knowing exactly like not-entitled.
+    """
+    _store_path = os.environ.get("CLAWBOX_DEVICE_STORE") or ""
+    if not _store_path:
+        return None
+    try:
+        with open(_store_path) as _fh:
+            _store = json.load(_fh)
+    except Exception:
+        return None
+    if not isinstance(_store, dict):
+        return None
+    _tier = _store.get("clawai_tier")
+    return _tier.strip() if isinstance(_tier, str) else None
+
+
+if _clawai_openai_route_is_ours and _clawai_device_tier() == CLAWBOX_SPEECH_DEVICE_TIER:
+    _messages = cfg.get("messages")
+    if not isinstance(_messages, dict):
+        _messages = {}
+    _tts = _messages.get("tts")
+    if not isinstance(_tts, dict):
+        _tts = {}
+    _tts_providers = _tts.get("providers")
+    if not isinstance(_tts_providers, dict):
+        _tts_providers = {}
+    _speech = _tts_providers.get("openai")
+    if not isinstance(_speech, dict):
+        _speech = {}
+
+    # An entry pointing somewhere that is not our proxy is the owner's own
+    # OpenAI-compatible voice — a self-hosted Kokoro, an OpenAI key of their
+    # own, a different route on our host. Leave every field of it alone. The
+    # same one-trailing-slash rule the transcription migration uses, for the
+    # same reason: `.../api/ai//` is a deliberate route, not a typo to tidy.
+    _speech_base_url = _speech.get("baseUrl")
+    _speech_route_taken = bool(
+        isinstance(_speech_base_url, str)
+        and _speech_base_url.strip()
+        and not _same_endpoint(_speech_base_url, _clawai_proxy_base_url)
+    )
+    if _speech_route_taken:
+        print(
+            "  Skipped ClawBox AI cloud voice: messages.tts.providers.openai already names its own speech route"
+        )
+    else:
+        _speech_before = dict(_speech)
+        _speech["baseUrl"] = _clawai_proxy_base_url
+        _speech["model"] = CLAWBOX_SPEECH_MODEL_ID
+        _speech["apiKey"] = _clawai_token
+        if _speech != _speech_before:
+            _tts_providers["openai"] = _speech
+            _tts["providers"] = _tts_providers
+            _messages["tts"] = _tts
+            cfg["messages"] = _messages
+            changed = True
 
 
 if isinstance(ds_models, list):

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -898,6 +898,16 @@ if _clawai_openai_route_is_ours:
 # is TASK-486 and deliberately not written here.
 CLAWBOX_SPEECH_MODEL_ID = "gpt-4o-mini-tts"
 CLAWBOX_SPEECH_DEVICE_TIER = "pro"
+# Stamped on the entry we write, and the ONLY thing that authorises removing
+# one later. Ownership of `models.providers.openai` is decided upstream by the
+# image migration, but that says nothing about who wrote
+# `messages.tts.providers.openai`, and the downgrade path below is the one
+# irreversible action in this file. Matching on the proxy URL alone would let
+# it delete a hand-written entry that happens to point at the same host.
+# Verified harmless on a real box on 2026-08-22: an unknown key on a speech
+# provider entry survives `openclaw config set`, is not stripped, does not
+# upset `openclaw doctor`, and the entry still synthesises.
+CLAWBOX_SPEECH_MANAGED_KEY = "clawboxManaged"
 
 def _clawai_device_tier():
     """The portal-confirmed plan stamp, or None when the store cannot be read.
@@ -956,6 +966,11 @@ if _clawai_openai_route_is_ours and _clawai_speech_entitled:
         _speech["baseUrl"] = _clawai_proxy_base_url
         _speech["model"] = CLAWBOX_SPEECH_MODEL_ID
         _speech["apiKey"] = _clawai_token
+        # Adopt and normalise an unmarked entry that already points at us — a
+        # hand repair, or one written before this stamp existed — rather than
+        # leave a box with a half-configured voice. Writing is recoverable and
+        # deleting is not, which is why only the delete below insists on it.
+        _speech[CLAWBOX_SPEECH_MANAGED_KEY] = True
         if _speech != _speech_before:
             _tts_providers["openai"] = _speech
             _tts["providers"] = _tts_providers
@@ -968,9 +983,11 @@ elif _clawai_openai_route_is_ours:
     # A box that was Max and is not any more keeps an entry pointing at an
     # endpoint that now answers 403, so every spoken reply buys a refused round
     # trip before falling back — and the panel calls the cloud voice configured
-    # while it does it. Take back only what we wrote: an entry whose baseUrl is
-    # our proxy. An owner's own voice is theirs whatever their ClawBox AI plan
-    # says, and is matched by exactly the same rule as above.
+    # while it does it. Take back only what we wrote, and "what we wrote" means
+    # our own stamp plus our own proxy, not the proxy alone: an entry pointing
+    # at this host that we did not stamp is somebody's hand-written config, and
+    # this is the one place in the file that destroys configuration. An owner's
+    # own voice is theirs whatever their ClawBox AI plan says.
     #
     # `messages.tts.provider` is deliberately NOT touched here either. If the
     # customer had explicitly chosen the cloud voice, the panel's job is to show
@@ -984,7 +1001,8 @@ elif _clawai_openai_route_is_ours:
     if isinstance(_speech, dict):
         _speech_base_url = _speech.get("baseUrl")
         if (
-            isinstance(_speech_base_url, str)
+            _speech.get(CLAWBOX_SPEECH_MANAGED_KEY) is True
+            and isinstance(_speech_base_url, str)
             and _speech_base_url.strip()
             and _same_endpoint(_speech_base_url, _clawai_proxy_base_url)
         ):

--- a/src/lib/voice-output.ts
+++ b/src/lib/voice-output.ts
@@ -318,7 +318,13 @@ function cloudEngine(config: VoiceConfigView, state: VoiceOutputState): VoiceEng
     // true for every box that still lands here: it holds a ClawBox AI key, and
     // that key does not open a cloud voice for it. The upgrade prompt at the
     // point of USE is TASK-486's, deliberately not duplicated here.
-    detail = "The cloud voice comes with ClawBox AI Max. This box is not set up to call one, so it speaks with its own voice.";
+    //
+    // It stops there rather than adding "so it speaks with its own voice".
+    // This branch knows nothing about the local engine, and a box with no
+    // installed voice would have been promised one it does not have — the same
+    // class of confident wrong sentence this line replaced. The local row sits
+    // directly above it in the panel and answers that question itself.
+    detail = "The cloud voice comes with ClawBox AI Max, and this box is not set up to call one.";
   } else if (failure) {
     detail = `The last voice check failed: ${failure}`;
   } else if (proven) {

--- a/src/lib/voice-output.ts
+++ b/src/lib/voice-output.ts
@@ -18,12 +18,19 @@
  *     disagree with the one that runs.
  *
  *  2. A CONFIGURED CLOUD VOICE IS NOT A WORKING ONE. The `openai` provider on a
- *     ClawBox carries the ClawBox AI portal token (`claw_…`) and no
- *     provider-level baseUrl, so a speech call goes to api.openai.com and comes
- *     back 401 (`openclaw capability tts convert --model openai/gpt-4o-mini-tts`
- *     on .177, 2026-08-22). The ClawBox AI proxy has no speech endpoint at all.
- *     An option that is present in a registry is therefore not evidence that the
- *     box can speak with it.
+ *     ClawBox carries the ClawBox AI portal token (`claw_…`), and a speech call
+ *     with no endpoint behind it goes to api.openai.com and comes back 401
+ *     (`openclaw capability tts convert --model openai/gpt-4o-mini-tts` on
+ *     .177, 2026-08-22). An option that is present in a registry is therefore
+ *     not evidence that the box can speak with it.
+ *
+ *     UPDATED 2026-08-22 (TASK-490): ClawBox AI now DOES serve speech —
+ *     `/api/ai/audio/speech`, Max only (clawbox-website PR #523). An entitled
+ *     box gets `messages.tts.providers.openai` written by
+ *     gateway-pre-start.sh, which is what turns the claw_ token from a
+ *     credential with nowhere to go into a working one. The rule below did not
+ *     change, only the reason a box can fail it: an unentitled box, or one
+ *     whose `openai` slot belongs to its owner, still has no endpoint.
  *
  * So availability here is a MEASUREMENT, in the same spirit as the Local Models
  * tab (TASK-435): an engine is usable when the box has what it needs AND the
@@ -221,10 +228,17 @@ function cloudEndpointConfigured(config: VoiceConfigView, providerId: string): b
 
 /**
  * A ClawBox AI portal token is not an OpenAI key. Sent to api.openai.com it
- * comes back 401 — proven on .177 — and ClawBox AI itself serves chat,
- * transcription and images but no speech, so there is nothing to point it at.
- * Saying so before the customer spends a check on it is the difference between
- * a selector that reports the box and one that repeats a registry.
+ * comes back 401 — proven on .177 — so a claw_ credential is only usable when
+ * something has pointed it at a route that accepts it.
+ *
+ * Until 2026-08-22 nothing could: ClawBox AI served chat, transcription and
+ * images but no speech. It serves speech now, on Max, and gateway-pre-start.sh
+ * writes the endpoint for an entitled box (TASK-490). So this returning true no
+ * longer means "the product has no cloud voice" — it means THIS box has not
+ * been pointed at one, because its plan does not include it or because its
+ * `openai` slot is the owner's own. Saying so before the customer spends a
+ * check on it is the difference between a selector that reports the box and one
+ * that repeats a registry.
  */
 export function cloudCredentialIsUnusable(config: VoiceConfigView, providerId: string): boolean {
   const key = credentialFor(config, providerId);
@@ -299,7 +313,12 @@ function cloudEngine(config: VoiceConfigView, state: VoiceOutputState): VoiceEng
   if (!providerId || !hasKey) {
     detail = "No cloud voice is set up on this box.";
   } else if (unusableKey) {
-    detail = "ClawBox AI does not serve the voice yet, so this box has no cloud voice to call.";
+    // Was "ClawBox AI does not serve the voice yet", which stopped being true on
+    // 2026-08-22 and was the most confident wrong sentence in the panel. What is
+    // true for every box that still lands here: it holds a ClawBox AI key, and
+    // that key does not open a cloud voice for it. The upgrade prompt at the
+    // point of USE is TASK-486's, deliberately not duplicated here.
+    detail = "The cloud voice comes with ClawBox AI Max. This box is not set up to call one, so it speaks with its own voice.";
   } else if (failure) {
     detail = `The last voice check failed: ${failure}`;
   } else if (proven) {

--- a/src/tests/components/voice-output-panel.test.tsx
+++ b/src/tests/components/voice-output-panel.test.tsx
@@ -28,7 +28,7 @@ function status(over: Record<string, unknown> = {}) {
     drifted: false,
     engines: [
       engine(),
-      engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud", usable: false, configured: false, detail: "The cloud voice comes with ClawBox AI Max. This box is not set up to call one, so it speaks with its own voice." }),
+      engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud", usable: false, configured: false, detail: "The cloud voice comes with ClawBox AI Max, and this box is not set up to call one." }),
     ],
     lastCheck: null,
     warning: null,

--- a/src/tests/components/voice-output-panel.test.tsx
+++ b/src/tests/components/voice-output-panel.test.tsx
@@ -28,7 +28,7 @@ function status(over: Record<string, unknown> = {}) {
     drifted: false,
     engines: [
       engine(),
-      engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud", usable: false, configured: false, detail: "ClawBox AI does not serve the voice yet, so this box has no cloud voice to call." }),
+      engine({ id: "cloud", providerId: "openai", label: "ClawBox cloud", usable: false, configured: false, detail: "The cloud voice comes with ClawBox AI Max. This box is not set up to call one, so it speaks with its own voice." }),
     ],
     lastCheck: null,
     warning: null,
@@ -61,7 +61,7 @@ describe("Voice panel", () => {
     render(<VoiceOutputPanel active />);
     const cloud = await screen.findByTestId("voice-choice-cloud");
     expect(within(cloud).getByText("Not available")).toBeTruthy();
-    expect(within(cloud).getByText(/does not serve the voice yet/)).toBeTruthy();
+    expect(within(cloud).getByText(/comes with ClawBox AI Max/)).toBeTruthy();
     expect(cloud.getAttribute("aria-disabled")).toBe("true");
   });
 

--- a/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-audio.test.ts
@@ -32,7 +32,10 @@ function slice(from: string, to: string): string {
 
 /** The speech-to-text migration, verbatim. */
 const POLICY = hasPython3
-  ? slice("# Migration: ClawBox AI speech to text.", "if isinstance(ds_models, list):")
+  // Ends at the cloud-voice migration that now follows it, not at the DeepSeek
+  // block further down: the two speech migrations are adjacent, and slicing
+  // past this one would run the text-to-speech writes inside these fixtures.
+  ? slice("# Migration: ClawBox AI speech to text.", "# Migration: ClawBox AI cloud voice")
   : "";
 
 let dir: string;

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Cloud TTS shipped to production on 2026-08-22 (clawbox-website PR #523) and
+// the device was never told. `messages.tts.providers` on a paired box carried
+// only the local CLI entry, so voice-output.ts read a claw_ token with no
+// speech endpoint behind it and every box printed "ClawBox AI does not serve
+// the voice yet" — a confident statement about the product that had stopped
+// being true. Reproduced on both loop boxes on beta ddd168e; see TASK-490.
+//
+// Like the image and transcription migrations next door, these run the block
+// out of the shipped .sh rather than a copy, so the test fails if the real
+// script drifts.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+const PROXY = "https://clawbox.com/api/ai";
+const SPEECH_MODEL = "gpt-4o-mini-tts";
+const TOKEN = "claw_test_token";
+/** The device tier stamp of the MAX plan. The two names are off by one on purpose. */
+const MAX_DEVICE_TIER = "pro";
+/** The device tier stamp of the PRO plan, which the proxy answers 403 for. */
+const PRO_DEVICE_TIER = "flash";
+
+function slice(from: string, to: string): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf(from);
+  const end = src.indexOf(to, start);
+  if (start < 0 || end < 0) throw new Error(`block not found: ${from}`);
+  return src.slice(start, end);
+}
+
+/**
+ * The cloud-voice migration, verbatim, plus the shared endpoint comparison it
+ * comes with. `_same_endpoint` is defined at module level in the transcription
+ * block precisely so both migrations answer that question the same way, so
+ * this test takes it from there rather than restating the rule.
+ */
+const SAME_ENDPOINT = hasPython3 ? slice("def _same_endpoint(_a, _b):", "if _clawai_openai_route_is_ours:") : "";
+const POLICY = hasPython3
+  ? slice("# Migration: ClawBox AI cloud voice (text to speech).", "if isinstance(ds_models, list):")
+  : "";
+
+let dir: string;
+beforeEach(() => { dir = mkdtempSync(path.join(tmpdir(), "clawai-speech-")); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+type Config = Record<string, unknown>;
+type SpeechEntry = { baseUrl?: unknown; model?: unknown; apiKey?: unknown; [key: string]: unknown };
+
+interface Options {
+  /** What the image migration decided about the `openai` provider slot. */
+  routeIsOurs?: boolean;
+  /** `clawai_tier` in the device store, or `null` for a store without one. */
+  deviceTier?: string | null;
+  /** `false` writes no device store at all — a box the Next app has never run on. */
+  storeExists?: boolean;
+  /** A device store that is not an object, or not JSON. */
+  storeBody?: string;
+}
+
+/**
+ * Run the extracted block over a whole openclaw.json.
+ *
+ * The preamble binds only what the real script binds upstream of this point:
+ * `cfg`, `changed`, the two names the image migration hands over once it has
+ * decided the `openai` slot is ours, and the token it took from the ClawBox AI
+ * provider entry. `CLAWBOX_DEVICE_STORE` is the env var the shell exports.
+ */
+function migrate(cfg: Config, opts: Options = {}): { cfg: Config; changed: boolean; log: string } {
+  const { routeIsOurs = true, deviceTier = MAX_DEVICE_TIER, storeExists = true, storeBody } = opts;
+  const file = path.join(dir, "config.json");
+  writeFileSync(file, JSON.stringify(cfg));
+  const store = path.join(dir, "device-store.json");
+  if (storeExists) {
+    writeFileSync(store, storeBody ?? JSON.stringify(deviceTier === null ? {} : { clawai_tier: deviceTier }));
+  }
+  const program = [
+    "import json, os, sys",
+    "cfg = json.load(open(sys.argv[1]))",
+    "changed = False",
+    `_clawai_openai_route_is_ours = ${routeIsOurs ? "True" : "False"}`,
+    `_clawai_proxy_base_url = ${JSON.stringify(PROXY)}`,
+    `_clawai_token = ${JSON.stringify(TOKEN)}`,
+    SAME_ENDPOINT,
+    POLICY,
+    "print(json.dumps({'cfg': cfg, 'changed': changed}))",
+  ].join("\n");
+  const lines = execFileSync("python3", ["-c", program, file], {
+    encoding: "utf-8",
+    env: { ...process.env, CLAWBOX_DEVICE_STORE: store },
+  }).trim().split("\n");
+  return { ...JSON.parse(lines[lines.length - 1]), log: lines.slice(0, -1).join("\n") };
+}
+
+function speech(cfg: Config): SpeechEntry | undefined {
+  const messages = cfg.messages as { tts?: { providers?: Record<string, SpeechEntry> } } | undefined;
+  return messages?.tts?.providers?.openai;
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migration", () => {
+  it("points the cloud voice at the proxy, pins the model and carries the token", () => {
+    const { cfg, changed } = migrate({});
+
+    expect(changed).toBe(true);
+    // All three are load-bearing, measured on .65 on 2026-08-22: without the
+    // baseUrl the call goes to api.openai.com and 401s on a claw_ token;
+    // without the model pin the proxy answers 400 because it serves exactly
+    // one speech model; and the documented apiKey fallback for OpenAI TTS is
+    // the OPENAI_API_KEY environment variable, which a ClawBox does not set.
+    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+  });
+
+  it("leaves the on-device voice and the customer's chosen primary untouched", () => {
+    const local = { command: "/home/clawbox/clawbox/scripts/openclaw/clawbox-tts.sh", outputFormat: "wav" };
+    const { cfg } = migrate({
+      messages: { tts: { provider: "tts-local-cli", providers: { "tts-local-cli": local } } },
+    });
+
+    const tts = (cfg.messages as { tts: { provider: string; providers: Record<string, unknown> } }).tts;
+    // Which engine speaks is the customer's choice and the panel's write. A
+    // migration that also moved the primary would silently switch a box that
+    // had deliberately picked its own voice.
+    expect(tts.provider).toBe("tts-local-cli");
+    expect(tts.providers["tts-local-cli"]).toEqual(local);
+    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+  });
+
+  it("is idempotent — a second start rewrites nothing", () => {
+    const first = migrate({});
+    const second = migrate(first.cfg);
+
+    expect(second.changed).toBe(false);
+    expect(speech(second.cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+  });
+
+  it("re-points a box whose token was rotated", () => {
+    const { cfg, changed } = migrate({
+      messages: { tts: { providers: { openai: { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: "claw_stale" } } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(speech(cfg)?.apiKey).toBe(TOKEN);
+  });
+
+  it("keeps any other key the entry already carries, such as a chosen voice", () => {
+    const { cfg } = migrate({
+      messages: { tts: { providers: { openai: { speakerVoice: "cedar" } } } },
+    });
+
+    // Only the three fields this migration owns are written. A customer who
+    // picked a voice keeps it.
+    expect(speech(cfg)).toEqual({ speakerVoice: "cedar", baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+  });
+
+  describe("does not touch a box that is not entitled to the cloud voice", () => {
+    // The proxy gates speech to Max (SPEECH_MODEL_TIERS) and answers 403 to
+    // everyone else. Pointing a Pro box at it would make the panel call the
+    // cloud voice configured, move Auto onto it, and buy a failed round trip
+    // before every spoken reply.
+    it("leaves a Pro box alone", () => {
+      const { cfg, changed } = migrate({}, { deviceTier: PRO_DEVICE_TIER });
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+
+    it("leaves a box whose plan nobody has confirmed alone", () => {
+      const { cfg, changed } = migrate({}, { deviceTier: null });
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+
+    it("leaves a box with no device store alone", () => {
+      const { cfg, changed } = migrate({}, { storeExists: false });
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+
+    it("treats an unreadable device store as not-entitled rather than crashing", () => {
+      const { cfg, changed } = migrate({}, { storeBody: "not json at all" });
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+
+    it("treats a device store that is not an object as not-entitled", () => {
+      const { cfg, changed } = migrate({}, { storeBody: '["pro"]' });
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+  });
+
+  it("does not touch a box whose openai slot belongs to its owner", () => {
+    // Same handover the transcription migration uses: when the image migration
+    // decided the slot is not ours, our token must not be written anywhere
+    // near it.
+    const { cfg, changed } = migrate({}, { routeIsOurs: false });
+    expect(changed).toBe(false);
+    expect(speech(cfg)).toBeUndefined();
+  });
+
+  describe("an owner's own cloud voice", () => {
+    it("is left alone, and says so", () => {
+      const own = { baseUrl: "https://api.openai.com/v1", model: "tts-1-hd", apiKey: "sk-owner" };
+      const { cfg, changed, log } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+      expect(log).toContain("already names its own speech route");
+    });
+
+    it("is left alone even when it is a different route on our own host", () => {
+      // A host-only match would stamp over a deliberate path. Same rule the
+      // transcription migration applies, from the same helper.
+      const own = { baseUrl: "https://clawbox.com/their-own-route", model: "tts-1" };
+      const { cfg, changed } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+    });
+
+    it("still recognises our own route written with a trailing slash", () => {
+      const { cfg, changed } = migrate({
+        messages: { tts: { providers: { openai: { baseUrl: `${PROXY}/`, model: SPEECH_MODEL, apiKey: TOKEN } } } },
+      });
+
+      // One trailing slash is the only difference that means nothing, so this
+      // is ours and gets normalised rather than skipped.
+      expect(changed).toBe(true);
+      expect(speech(cfg)?.baseUrl).toBe(PROXY);
+    });
+
+    it("leaves a deliberate double-slash route alone", () => {
+      const own = { baseUrl: `${PROXY}//`, model: "tts-1" };
+      const { cfg, changed } = migrate({ messages: { tts: { providers: { openai: own } } } });
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+    });
+  });
+
+  it("replaces config the gateway could not read at all", () => {
+    // A non-dict at any of these paths is not a customer's choice, it is
+    // config the gateway cannot load — the same call the migrations around it
+    // make, for the same reason.
+    const { cfg, changed } = migrate({ messages: { tts: { providers: "nonsense" } } });
+
+    expect(changed).toBe(true);
+    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+  });
+
+  it("honours a staging proxy rather than dragging the box to production", () => {
+    const staging = "https://staging.clawbox.com/api/ai";
+    const file = path.join(dir, "config.json");
+    writeFileSync(file, JSON.stringify({}));
+    const store = path.join(dir, "device-store.json");
+    writeFileSync(store, JSON.stringify({ clawai_tier: MAX_DEVICE_TIER }));
+    const program = [
+      "import json, os, sys",
+      "cfg = json.load(open(sys.argv[1]))",
+      "changed = False",
+      "_clawai_openai_route_is_ours = True",
+      `_clawai_proxy_base_url = ${JSON.stringify(staging)}`,
+      `_clawai_token = ${JSON.stringify(TOKEN)}`,
+      SAME_ENDPOINT,
+      POLICY,
+      "print(json.dumps({'cfg': cfg, 'changed': changed}))",
+    ].join("\n");
+    const out = execFileSync("python3", ["-c", program, file], {
+      encoding: "utf-8",
+      env: { ...process.env, CLAWBOX_DEVICE_STORE: store },
+    }).trim().split("\n");
+    const { cfg } = JSON.parse(out[out.length - 1]);
+
+    expect(speech(cfg)?.baseUrl).toBe(staging);
+  });
+});

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -20,6 +20,8 @@ const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).stat
 
 const PROXY = "https://clawbox.com/api/ai";
 const SPEECH_MODEL = "gpt-4o-mini-tts";
+/** The stamp that says we wrote this entry, and the only licence to remove it. */
+const MANAGED = { clawboxManaged: true };
 const TOKEN = "claw_test_token";
 /** The device tier stamp of the MAX plan. The two names are off by one on purpose. */
 const MAX_DEVICE_TIER = "pro";
@@ -112,7 +114,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     // without the model pin the proxy answers 400 because it serves exactly
     // one speech model; and the documented apiKey fallback for OpenAI TTS is
     // the OPENAI_API_KEY environment variable, which a ClawBox does not set.
-    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
   });
 
   it("leaves the on-device voice and the customer's chosen primary untouched", () => {
@@ -127,7 +129,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     // had deliberately picked its own voice.
     expect(tts.provider).toBe("tts-local-cli");
     expect(tts.providers["tts-local-cli"]).toEqual(local);
-    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
   });
 
   it("is idempotent — a second start rewrites nothing", () => {
@@ -135,12 +137,24 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     const second = migrate(first.cfg);
 
     expect(second.changed).toBe(false);
-    expect(speech(second.cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+    expect(speech(second.cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
+  });
+
+  it("adopts and stamps an unmarked entry that already points at us", () => {
+    // A hand repair, or one written before the stamp existed. Writing is
+    // recoverable and deleting is not, which is why only the removal path
+    // insists on the stamp.
+    const { cfg, changed } = migrate({
+      messages: { tts: { providers: { openai: { baseUrl: PROXY, model: "stale-model" } } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
   });
 
   it("re-points a box whose token was rotated", () => {
     const { cfg, changed } = migrate({
-      messages: { tts: { providers: { openai: { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: "claw_stale" } } } },
+      messages: { tts: { providers: { openai: { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: "claw_stale", ...MANAGED } } } },
     });
 
     expect(changed).toBe(true);
@@ -152,9 +166,9 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       messages: { tts: { providers: { openai: { speakerVoice: "cedar" } } } },
     });
 
-    // Only the three fields this migration owns are written. A customer who
-    // picked a voice keeps it.
-    expect(speech(cfg)).toEqual({ speakerVoice: "cedar", baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+    // Only the three fields this migration owns, plus its stamp, are written.
+    // A customer who picked a voice keeps it.
+    expect(speech(cfg)).toEqual({ speakerVoice: "cedar", baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
   });
 
   describe("takes the cloud voice back when the box stops being entitled", () => {
@@ -162,7 +176,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     // more keeps an entry pointing at an endpoint that now answers 403, so
     // every spoken reply buys a refused round trip before falling back, and the
     // panel calls the cloud voice configured while it does it.
-    const ours = { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN };
+    const ours = { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED };
 
     it("removes the entry it wrote when the plan drops to Pro", () => {
       const { cfg, changed, log } = migrate(
@@ -194,6 +208,21 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
       expect(tts.provider).toBe("openai");
       expect(tts.providers.openai).toBeUndefined();
       expect(tts.providers["tts-local-cli"]).toEqual({ command: "/x" });
+    });
+
+    it("leaves an unstamped entry on our own host alone", () => {
+      // Ownership of models.providers.openai is decided upstream and says
+      // nothing about who wrote this. An entry pointing here that we did not
+      // stamp is somebody's hand-written config, and deleting it is the one
+      // irreversible thing this migration can do.
+      const unstamped = { baseUrl: PROXY, model: "some-other-tts", apiKey: "claw_theirs" };
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: unstamped } } } },
+        { deviceTier: PRO_DEVICE_TIER },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(unstamped);
     });
 
     it("does not take an owner's own cloud voice away with it", () => {
@@ -292,7 +321,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
 
     it("still recognises our own route written with a trailing slash", () => {
       const { cfg, changed } = migrate({
-        messages: { tts: { providers: { openai: { baseUrl: `${PROXY}/`, model: SPEECH_MODEL, apiKey: TOKEN } } } },
+        messages: { tts: { providers: { openai: { baseUrl: `${PROXY}/`, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED } } } },
       });
 
       // One trailing slash is the only difference that means nothing, so this
@@ -317,7 +346,7 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     const { cfg, changed } = migrate({ messages: { tts: { providers: "nonsense" } } });
 
     expect(changed).toBe(true);
-    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
+    expect(speech(cfg)).toEqual({ baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN, ...MANAGED });
   });
 
   it("honours a staging proxy rather than dragging the box to production", () => {

--- a/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-speech.test.ts
@@ -157,6 +157,74 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI cloud voice migrat
     expect(speech(cfg)).toEqual({ speakerVoice: "cedar", baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN });
   });
 
+  describe("takes the cloud voice back when the box stops being entitled", () => {
+    // Without this the migration is one-way: a box that was Max and is not any
+    // more keeps an entry pointing at an endpoint that now answers 403, so
+    // every spoken reply buys a refused round trip before falling back, and the
+    // panel calls the cloud voice configured while it does it.
+    const ours = { baseUrl: PROXY, model: SPEECH_MODEL, apiKey: TOKEN };
+
+    it("removes the entry it wrote when the plan drops to Pro", () => {
+      const { cfg, changed, log } = migrate(
+        { messages: { tts: { providers: { openai: ours } } } },
+        { deviceTier: PRO_DEVICE_TIER },
+      );
+
+      expect(changed).toBe(true);
+      expect(speech(cfg)).toBeUndefined();
+      expect(log).toContain("no longer includes it");
+    });
+
+    it("leaves the customer's chosen primary alone so the downgrade is visible", () => {
+      const { cfg } = migrate(
+        {
+          messages: {
+            tts: {
+              provider: "openai",
+              providers: { openai: ours, "tts-local-cli": { command: "/x" } },
+            },
+          },
+        },
+        { deviceTier: PRO_DEVICE_TIER },
+      );
+
+      const tts = (cfg.messages as { tts: { provider: string; providers: Record<string, unknown> } }).tts;
+      // Rewriting their pick would hide the downgrade. The panel's job is to
+      // show that the chosen voice is gone and the box is speaking locally.
+      expect(tts.provider).toBe("openai");
+      expect(tts.providers.openai).toBeUndefined();
+      expect(tts.providers["tts-local-cli"]).toEqual({ command: "/x" });
+    });
+
+    it("does not take an owner's own cloud voice away with it", () => {
+      const own = { baseUrl: "https://api.openai.com/v1", model: "tts-1-hd", apiKey: "sk-owner" };
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: own } } } },
+        { deviceTier: PRO_DEVICE_TIER },
+      );
+
+      // Their voice is theirs whatever their ClawBox AI plan says.
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(own);
+    });
+
+    it("does nothing on an unentitled box that never had one", () => {
+      const { cfg, changed } = migrate({}, { deviceTier: PRO_DEVICE_TIER });
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toBeUndefined();
+    });
+
+    it("stays out of a box whose openai slot belongs to its owner", () => {
+      const { cfg, changed } = migrate(
+        { messages: { tts: { providers: { openai: ours } } } },
+        { deviceTier: PRO_DEVICE_TIER, routeIsOurs: false },
+      );
+
+      expect(changed).toBe(false);
+      expect(speech(cfg)).toEqual(ours);
+    });
+  });
+
   describe("does not touch a box that is not entitled to the cloud voice", () => {
     // The proxy gates speech to Max (SPEECH_MODEL_TIERS) and answers 403 to
     // everyone else. Pointing a Pro box at it would make the panel call the

--- a/src/tests/unit/voice-output.test.ts
+++ b/src/tests/unit/voice-output.test.ts
@@ -129,7 +129,11 @@ describe("status", () => {
     const status = buildVoiceOutputStatus(config(), healthyLocal, state());
     const cloud = status.engines.find(e => e.id === "cloud")!;
     expect(cloud.usable).toBe(false);
-    expect(cloud.detail).toContain("does not serve the voice yet");
+    // The old copy said ClawBox AI "does not serve the voice yet". It does, on
+    // Max, since 2026-08-22 — so what a box landing here has to be told is that
+    // ITS key does not open one, not that the product has none (TASK-490).
+    expect(cloud.detail).toContain("comes with ClawBox AI Max");
+    expect(cloud.detail).not.toContain("does not serve the voice yet");
     expect(cloud.detail).not.toContain("claw_");
   });
 

--- a/src/tests/unit/voice-output.test.ts
+++ b/src/tests/unit/voice-output.test.ts
@@ -137,6 +137,26 @@ describe("status", () => {
     expect(cloud.detail).not.toContain("claw_");
   });
 
+  it("does not promise an on-device voice to a box that has none", () => {
+    // This branch is reached from the CLOUD credential alone and knows nothing
+    // about the local engine. A box with no installed voice reaches it too, and
+    // telling that customer the box "speaks with its own voice" would be the
+    // same class of confident wrong sentence the old copy was.
+    const bare: LocalVoiceProbe = {
+      providerConfigured: false,
+      commandPresent: false,
+      engineInstalled: false,
+      engineNames: [],
+    };
+    const status = buildVoiceOutputStatus(config(), bare, state());
+    const cloud = status.engines.find(e => e.id === "cloud")!;
+    const local = status.engines.find(e => e.id === "local")!;
+
+    expect(local.usable).toBe(false);
+    expect(status.preferredEngine).toBe(null);
+    expect(cloud.detail).not.toMatch(/own voice|speaks on the box|this box speaks/i);
+  });
+
   it("resolves Auto to the on-device voice when the cloud one cannot be used", () => {
     const status = buildVoiceOutputStatus(config(), healthyLocal, state());
     expect(status.choice).toBe("auto");


### PR DESCRIPTION
## What was wrong

Cloud TTS shipped to production on 2026-08-22 (clawbox-website PR #523). ClawBox AI genuinely serves speech. Nothing on the device was told.

`messages.tts.providers` on a paired box carries only the local CLI entry, so `cloudCredentialIsUnusable` read a `claw_` token with no speech endpoint behind it, correctly concluded it was unusable, and every box printed

> **ClawBox cloud — Not available**
> "ClawBox AI does not serve the voice yet, so this box has no cloud voice to call."

on a fully entitled **Max** box, while Auto — which is meant to prefer the cloud voice — quietly resolved to Piper. Reproduced on **both** loop boxes through the real Settings UI on beta `ddd168e`. The sentence was the worst part of it: a confident statement about the product that had stopped being true.

## What this writes

`gateway-pre-start.sh` now writes `messages.tts.providers.openai` alongside the image and transcription migrations it sits with. All three fields are load-bearing, measured against the live proxy from `.65` on 2026-08-22 — 50,688 bytes of real MPEG in **1.96 s**, against **27.7 s** for the on-device voice:

| field | without it |
|---|---|
| `baseUrl` | `/audio/speech` goes to `api.openai.com` and the `claw_` token 401s |
| `model` | the request carries OpenClaw's default and the proxy answers 400 — it serves exactly one speech model |
| `apiKey` | the documented fallback for the OpenAI TTS provider is `OPENAI_API_KEY`, which a ClawBox does not set; `models.providers.openai.apiKey` is not consulted for speech |

It does **not** write `messages.tts.provider`. Which engine speaks is the customer's choice and the panel's write; a migration that also moved the primary would silently switch a box that had deliberately picked its own voice.

## The tier gate

Cloud speech is Max-only on the proxy (`SPEECH_MODEL_TIERS`) and answers 403 to everyone else, so entitlement is a precondition rather than an error to discover. Pointing a Pro box at it would be worse than leaving it alone: the panel would call the cloud voice configured, Auto would move the primary onto it, and every spoken reply would buy a failed round trip before falling back to the voice the box already had.

The gate is the `clawai_tier` stamp the status route persists from a live portal answer. It is a **device** tier, and `"pro"` is the device tier of the **Max** plan — the two names are off by one on purpose. Anything else, including a missing or unreadable store, means nobody has told us this box is entitled, and an unentitled box is left exactly as it was. A customer who upgrades gets the cloud voice at the next gateway start.

The customer-facing "your plan speaks locally, Max speaks in the cloud" line at the point of use is **TASK-486** and is deliberately not written here.

## And the sentence itself

`cloudCredentialIsUnusable` returning true no longer means the product has no cloud voice. It means *this box* has not been pointed at one — because its plan does not include it, or because its `openai` slot is the owner's own. The detail line, the function's contract and the module header all say that now instead of the old premise.

`_same_endpoint` moves to module level inside the transcription block so both speech migrations answer "is this route ours?" from one rule rather than two copies of it.

## Tests

20 new cases run the migration out of the shipped `.sh`, as its neighbours do: the three fields, idempotency, token rotation, an owner's own voice on their host and on a different path of ours, one-trailing-slash normalisation versus a deliberate double slash, a foreign `openai` slot, a staging proxy, and each way a box can fail the tier gate — Pro, unconfirmed, no store, unreadable store, and a store that is not an object.

Local suite: **276 files / 3832 tests green**.

## Hardware proof

Pending in this run: deploy to `.65` (clean install) and `.177` (upgrade) through the real update path, then re-verify TASK-462's output half on the merged SHA. Evidence will be posted on TASK-490 and TASK-462.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic setup for eligible ClawBox AI devices, including vision, image generation, speech-to-text, and Max-tier cloud voice.
  * Preserved local and customer-configured routes and credentials.

* **Bug Fixes**
  * Improved endpoint matching, configuration validation, token rotation, and entitlement handling.
  * Removed only ClawBox-managed cloud voice settings after downgrade.
  * Improved voice availability messaging.

* **Tests**
  * Added comprehensive coverage for migration, eligibility, preservation, cleanup, malformed configurations, and proxy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->