### PR TITLE
A failed chat turn stops printing the session's path and UUID (TASK-440)

### DIFF
--- a/src/components/ChatApp.tsx
+++ b/src/components/ChatApp.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, memo } from 'react'
 import * as kv from '@/lib/client-kv'
+import { describeChatFailure } from '@/lib/chat-error-text'
 import { useClawboxLogin } from '@/lib/use-clawbox-login'
 import { PORTAL_LOGIN_URL } from '@/lib/max-subscription'
 import {
@@ -300,8 +301,11 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
             runIdRef.current = null
             setSending(false)
             if (state === 'error') {
-              const errMsg = (payload.errorMessage as string) || 'Chat error'
-              setMessages(prev => [...prev, { role: 'system', text: `Error: ${errMsg}`, timestamp: Date.now() }])
+              // Never render the gateway's own error text. It is written for
+              // an operator reading a log and has carried an absolute device
+              // path, a session UUID and a `openclaw logs --follow` line into
+              // the customer's transcript (TASK-440).
+              setMessages(prev => [...prev, { role: 'system', text: describeChatFailure(payload.errorMessage), timestamp: Date.now() }])
             }
           }
         }
@@ -417,7 +421,7 @@ function ChatApp({ onThinkingChange, hideHeader = false }: ChatAppProps) {
     } catch (err) {
       setSending(false)
       runIdRef.current = null
-      setMessages(prev => [...prev, { role: 'system', text: `Error: ${(err as Error).message}`, timestamp: Date.now() }])
+      setMessages(prev => [...prev, { role: 'system', text: describeChatFailure((err as Error)?.message), timestamp: Date.now() }])
     }
   }, [wsRequest])
 

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -11,6 +11,7 @@ import {
   type ChatMessage as BaseChatMessage,
 } from '@/lib/chat-history-cache'
 import { useChatToolCalls, ToolCallPills, isImageGenerationTool } from '@/lib/chat-tool-events'
+import { describeChatFailure } from '@/lib/chat-error-text'
 import { FIX_ERROR_EVENT, buildFixErrorPrompt, type FixErrorContext } from '@/lib/ui-events'
 import { isSentinel, isInterSessionEnvelope } from '@/lib/chat-sentinels'
 import { useModalDialog } from '@/hooks/useModalDialog'
@@ -1459,8 +1460,11 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             runIdRef.current = null
             setSending(false)
             if (state === 'error') {
-              const errMsg = (payload.errorMessage as string) || 'Chat error'
-              setMessages(prev => [...prev, { role: 'system', text: `Error: ${errMsg}`, timestamp: Date.now() }])
+              // Never render the gateway's own error text. It is written for
+              // an operator reading a log and has carried an absolute device
+              // path, a session UUID and a `openclaw logs --follow` line into
+              // the customer's transcript (TASK-440).
+              setMessages(prev => [...prev, { role: 'system', text: describeChatFailure(payload.errorMessage), timestamp: Date.now() }])
             }
           }
         }
@@ -2269,7 +2273,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     } catch (err) {
       setSending(false)
       runIdRef.current = null
-      setMessages(prev => [...prev, { role: 'system', text: `Error: ${(err as Error).message}`, timestamp: Date.now() }])
+      setMessages(prev => [...prev, { role: 'system', text: describeChatFailure((err as Error)?.message), timestamp: Date.now() }])
     }
   }, [wsRequest])
 
@@ -2356,7 +2360,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     } catch (err) {
       // A user-initiated Stop shows nothing, not an error line.
       if ((err as Error)?.name !== 'AbortError') {
-        setMessages(prev => [...prev, { role: 'system', text: `Error: ${(err as Error).message}`, timestamp: Date.now() }])
+        setMessages(prev => [...prev, { role: 'system', text: describeChatFailure((err as Error)?.message), timestamp: Date.now() }])
       }
     } finally {
       hermesAbortRef.current = null

--- a/src/lib/chat-error-text.ts
+++ b/src/lib/chat-error-text.ts
@@ -1,0 +1,61 @@
+// ── What a failed chat turn is allowed to say ───────────────────────────────
+//
+// When a run ends in `state: "error"`, the gateway hands the client an
+// `errorMessage` written for an operator reading a log, and both chat surfaces
+// used to render it verbatim. On a real box that produced this, in the
+// customer's transcript (TASK-440, reproduced on .177 on beta ff04cee):
+//
+//     Error: session file changed while embedded prompt lock was released:
+//       /home/clawbox/.openclaw/agents/main/sessions/3b45304b-…-…jsonl
+//     Error: ⚠️ Agent failed before reply: … Logs: openclaw logs --follow
+//
+// An absolute device path, an internal session UUID, and an instruction to run
+// a CLI the customer has no reason to open. TASK-416 closed this class of leak
+// for the happy path; the error path was never covered.
+//
+// The rule here is the same one the attachment and voice paths already follow:
+// a message from a failing layer is shown only if it survives
+// `sanitizeErrorMessage`, and otherwise the customer gets our own sentence.
+// What is different about a chat turn is that the customer can *do* something
+// about it — send it again — so the fallback says that rather than apologising.
+import { sanitizeErrorMessage } from "@/lib/safe-error-text";
+
+/**
+ * The failure OpenClaw reports when a second client takes the agent session
+ * over mid-prompt: another tab, the Telegram channel, or a New chat reset
+ * landing on a turn that is already running.
+ *
+ * Matched on the gateway's own wording rather than an invented marker, in the
+ * same spirit as `isInternalRoutingMessage`. Retrying always worked in every
+ * reproduction, which is why this one gets a sentence naming the cause instead
+ * of the generic line — a customer who knows the other window did it will not
+ * file it as the box being broken.
+ */
+function isSessionTakeover(raw: string): boolean {
+  return /session file changed while embedded prompt lock was released/i.test(raw)
+    || /session takeover/i.test(raw);
+}
+
+/** Something went wrong and we will not say what, because we cannot say it safely. */
+const GENERIC = "That message did not go through. Send it again — the details stayed in this box's log.";
+
+/** A second client had the conversation; the turn is simply retryable. */
+const TAKEOVER = "That message did not go through — this chat was open somewhere else at the same time. Send it again.";
+
+/**
+ * Customer-facing text for a chat turn that ended in `state: "error"`.
+ *
+ * Always returns something. A silent failure — a turn that just stops with no
+ * bubble — is worse than a vague one, because the customer cannot tell whether
+ * the box is thinking or dead.
+ */
+export function describeChatFailure(raw: unknown): string {
+  const text = typeof raw === "string" ? raw.trim() : "";
+  if (!text) return GENERIC;
+  if (isSessionTakeover(text)) return TAKEOVER;
+  const safe = sanitizeErrorMessage(text);
+  // A message that passes the leak rules is worth showing: "Request exceeds the
+  // size limit" tells the customer what to change, and replacing it with the
+  // generic line would throw that away.
+  return safe ? `Error: ${safe}` : GENERIC;
+}

--- a/src/lib/safe-error-text.ts
+++ b/src/lib/safe-error-text.ts
@@ -31,6 +31,19 @@ export function sanitizeErrorMessage(raw: unknown): string | null {
   if (/\b(claw_|sk-|Bearer\s)/i.test(trimmed)) return null;
   // `at fn (` — a V8 stack frame.
   if (/\bat\s+\w+\s+\(/.test(trimmed)) return null;
+  // A UUID is always an internal handle here — a session, a run, a device.
+  // It names nothing the customer can look up and cannot help them act, so
+  // it is a leak whether or not a path came with it (TASK-440: the session
+  // UUID reached the transcript alongside the path, and would have reached it
+  // alone had the message been worded slightly differently).
+  if (/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i.test(trimmed)) return null;
+  // OpenClaw's session-key shape, `agent:main:main`. Same reasoning, and it is
+  // one of the strings the acceptance matrix's own leak check looks for.
+  if (/\bagent:[\w.-]+:/.test(trimmed)) return null;
+  // An instruction to run the CLI. `Logs: openclaw logs --follow` is appended
+  // to some gateway failures and carries no path, so nothing above catches it;
+  // a chat bubble is never the right place to send someone to a terminal.
+  if (/\bopenclaw\s+[a-z-]+/i.test(trimmed)) return null;
   return trimmed;
 }
 

--- a/src/tests/unit/chat-error-text.test.ts
+++ b/src/tests/unit/chat-error-text.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { describeChatFailure } from "@/lib/chat-error-text";
+import { sanitizeErrorMessage } from "@/lib/safe-error-text";
+
+// The exact two lines a customer saw in the transcript on .177, beta ff04cee,
+// after a New chat reset landed on a turn that was already running. Kept
+// verbatim rather than paraphrased: the point of this test is that THIS string
+// never reaches a chat bubble again.
+const TAKEOVER_RAW =
+  "session file changed while embedded prompt lock was released: "
+  + "/home/clawbox/.openclaw/agents/main/sessions/3b45304b-89ff-496c-a392-4e1719de0878.jsonl";
+const FOLLOWUP_RAW =
+  "⚠️ Agent failed before reply: " + TAKEOVER_RAW + ".\nLogs: openclaw logs --follow";
+
+/** Everything the acceptance matrix's leak check looks for. */
+function leaks(text: string): boolean {
+  return /\/home\/clawbox/.test(text)
+    || /\.jsonl/.test(text)
+    || /\.openclaw\//.test(text)
+    || /openclaw logs/.test(text)
+    || /\bagent:[\w.-]+:/.test(text)
+    || /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/i.test(text);
+}
+
+describe("describeChatFailure", () => {
+  it("never renders the session-takeover error a customer actually saw", () => {
+    for (const raw of [TAKEOVER_RAW, FOLLOWUP_RAW]) {
+      const shown = describeChatFailure(raw);
+      expect(leaks(shown)).toBe(false);
+      expect(shown).not.toContain("embedded prompt lock");
+    }
+  });
+
+  it("tells the customer what to do about it, because retrying works", () => {
+    // Every reproduction of this recovered on a retry. A line that only says
+    // "something went wrong" would send a working box to support.
+    const shown = describeChatFailure(TAKEOVER_RAW);
+    expect(shown).toMatch(/send it again/i);
+    expect(shown).toMatch(/open somewhere else/i);
+  });
+
+  it("says the same thing for the followup wording", () => {
+    expect(describeChatFailure(FOLLOWUP_RAW)).toBe(describeChatFailure(TAKEOVER_RAW));
+  });
+
+  it("keeps a message that is genuinely useful to the customer", () => {
+    // Replacing this with the generic line would throw away the one thing that
+    // tells them what to change.
+    expect(describeChatFailure("Request exceeds the size limit"))
+      .toBe("Error: Request exceeds the size limit");
+  });
+
+  it("falls back rather than going silent", () => {
+    // A turn that just stops with no bubble is worse than a vague one: the
+    // customer cannot tell whether the box is thinking or dead.
+    for (const raw of [undefined, null, "", "   ", 42, {}]) {
+      const shown = describeChatFailure(raw);
+      expect(shown.length).toBeGreaterThan(0);
+      expect(shown).toMatch(/send it again/i);
+    }
+  });
+
+  it("drops anything that carries an internal handle, whatever the wording", () => {
+    for (const raw of [
+      "run 3b45304b-89ff-496c-a392-4e1719de0878 failed",
+      "lane task error: lane=session:agent:main:main",
+      "could not write /home/clawbox/.openclaw/media/x.png",
+      "Logs: openclaw logs --follow",
+      "POST https://clawbox.com/api/ai returned 500",
+      "Bearer claw_abc123 rejected",
+    ]) {
+      const shown = describeChatFailure(raw);
+      expect(leaks(shown)).toBe(false);
+      expect(shown).not.toContain("claw_");
+      expect(shown).not.toContain("https://");
+    }
+  });
+});
+
+describe("sanitizeErrorMessage — handles added for TASK-440", () => {
+  it("rejects a bare internal handle with no path attached", () => {
+    // The UUID reached the transcript alongside a path this time. It would have
+    // reached it alone had the message been worded slightly differently.
+    expect(sanitizeErrorMessage("run 3b45304b-89ff-496c-a392-4e1719de0878 failed")).toBeNull();
+    expect(sanitizeErrorMessage("lane=session:agent:main:main timed out")).toBeNull();
+  });
+
+  it("rejects an instruction to open a terminal", () => {
+    expect(sanitizeErrorMessage("Logs: openclaw logs --follow")).toBeNull();
+    expect(sanitizeErrorMessage("run openclaw doctor to repair")).toBeNull();
+  });
+
+  it("still passes plain operational text", () => {
+    expect(sanitizeErrorMessage("Request exceeds the size limit")).toBe("Request exceeds the size limit");
+    expect(sanitizeErrorMessage("The model is busy, try again")).toBe("The model is busy, try again");
+  });
+});


### PR DESCRIPTION
## Reproduced first, on the current SHA

Deterministically on `.177` on beta `ff04cee`, through the real device UI: start a turn, then hit **New chat** from a second client while it is still running. The transcript rendered

```
Error: session file changed while embedded prompt lock was released:
  /home/clawbox/.openclaw/agents/main/sessions/3b45304b-…-….jsonl
Error: ⚠️ Agent failed before reply: … Logs: openclaw logs --follow
```

An absolute device path, an internal session UUID, and an instruction to open a terminal — in a customer's chat bubble. TASK-416 closed this class of leak for the happy path; the error path was never covered, and **both** chat surfaces rendered `payload.errorMessage` verbatim.

It does **not** survive a refresh — the leak is a client-side `system` message, not anything stored in the session — so this is a client-side fix and the history path needs no guard. That was checked on the box, not assumed.

## What changes

`describeChatFailure` is now the only thing either surface renders for a failed turn: the `state: "error"` handler *and* the send-failure catch, in `ChatApp` and `ChatPopup` alike. It shows the gateway's own words only when they survive `sanitizeErrorMessage` — the same rule the attachment and voice paths already follow.

A **session takeover** gets its own sentence rather than the generic one. Every reproduction of it recovered on a retry, so the customer is told the chat was open somewhere else and to send it again. A line that only said "something went wrong" would send a working box to support.

The fallback is never silence. A turn that stops with no bubble is worse than a vague one, because the customer cannot tell whether the box is thinking or dead.

## The shared sanitizer gains three rules

They belong there rather than in the chat helper — *"two copies of a leak filter is two places to forget a rule"* is the comment that module opens with.

- **a UUID** — always an internal handle here: a session, a run, a device. It arrived with a path this time and would have arrived alone had the message been worded slightly differently.
- **OpenClaw's session-key shape**, `agent:main:main` — one of the strings the acceptance matrix's own leak check looks for.
- **an instruction to run the CLI.** `Logs: openclaw logs --follow` carries no path, so nothing already there caught it.

## Not fixed here, deliberately

Whether a session takeover should surface as an error *at all* when the turn is simply retryable. That is the second half of the card, it changes gateway retry semantics rather than what the customer is shown, and Yanko ruled on 2026-08-22 that this card is not a v4 release blocker.

## Tests

New `chat-error-text.test.ts` asserts the exact two strings the customer saw never reach a bubble again, that the takeover line is actionable, that a genuinely useful message (`Request exceeds the size limit`) is still shown rather than thrown away, that the fallback is never empty, and that every internal-handle shape is dropped. Plus the three new sanitizer rules.

Local suite: **277 files / 3849 tests green**.

## Hardware proof

Pending in this run: deploy to `.65` (clean install) and `.177` (upgrade), re-run the same New-chat race on both, and confirm the bubble is now the retry line with no path, UUID or CLI instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat error messages with clear, customer-friendly guidance.
  * Removed internal technical details, session identifiers, and command-line instructions from displayed errors.
  * Added specific retry guidance for temporary chat failures.
  * Preserved useful non-sensitive error information while providing a safe fallback when details are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->