### PR TITLE
Setup stops spending two and a half minutes starting Node (TASK-483)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -10,6 +10,8 @@ import {
   restartGateway,
   findOpenclawBin,
   runOpenclawConfigSet,
+  runOpenclawConfigSetBatch,
+  type OpenclawConfigSetArgs,
   compactionReserveFloorForContext,
   inferConfiguredLocalModel,
   readConfig as readOpenClawConfig,
@@ -143,6 +145,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
 
 const PROFILE_KEY_RE = /^[a-zA-Z0-9._-]+(?::[a-zA-Z0-9._-]+)*$/;
 const COMMAND_TIMEOUT_MS = 30_000;
+const BATCH_COMMAND_TIMEOUT_MS = 60_000;
 
 interface AuthProfilesFile {
   version: number;
@@ -206,6 +209,76 @@ function runCommand(cmd: string, args: string[], timeoutMs = COMMAND_TIMEOUT_MS)
     });
     child.stdin.end();
   });
+}
+
+/**
+ * Apply `config set` assignments in as few `openclaw` invocations as possible
+ * WITHOUT merging their error boundaries.
+ *
+ * Every invocation of the CLI costs ~8 s of Node startup on a Jetson (see
+ * `runOpenclawConfigSetBatch`), which is where first-run setup's silent
+ * two-and-a-half minutes came from (TASK-483). Batching is the fix, but this
+ * route deliberately treats some writes as fatal and others as not — a chat
+ * provider that works is worth more than an image tool, so a failure to
+ * provision images must not fail "Connect ClawBox AI" — and one batch is
+ * atomic, so a single combined call would make every failure fatal to
+ * everything.
+ *
+ * So: try the combined call first, and only if it fails re-issue each group on
+ * its own, which is exactly the old one-boundary-per-group behaviour. A batch
+ * that fails wrote nothing, so re-applying the same values group by group is
+ * safe. The slow path costs one extra invocation per group and is only reached
+ * when something is already wrong.
+ */
+interface ConfigSetGroup {
+  /** `config set` argvs, minus the leading `config set`. */
+  ops: OpenclawConfigSetArgs[];
+  /** Called instead of throwing when this group alone fails. Absent = fatal. */
+  onError?: (err: unknown) => void;
+  /** Called once this group's ops are known to have been applied. */
+  onApplied?: () => void;
+}
+
+function runConfigSetBatch(ops: OpenclawConfigSetArgs[]): Promise<void> {
+  return runOpenclawConfigSetBatch(ops, {
+    // A batch is one CLI start-up regardless of size, so the per-attempt budget
+    // stays in the same order as a single set; the extra headroom is because a
+    // batch that times out costs every write in it, not one.
+    timeoutMs: BATCH_COMMAND_TIMEOUT_MS,
+    uid: CLAWBOX_UID,
+    gid: CLAWBOX_GID,
+  });
+}
+
+async function applyConfigSetGroups(groups: (ConfigSetGroup | null)[]): Promise<void> {
+  const present = groups.filter((group): group is ConfigSetGroup => !!group && group.ops.length > 0);
+  if (present.length === 0) return;
+
+  if (present.length > 1) {
+    try {
+      await runConfigSetBatch(present.flatMap((group) => group.ops));
+      for (const group of present) group.onApplied?.();
+      return;
+    } catch (err) {
+      // Fall through: re-issue per group so each keeps its own fatal/non-fatal
+      // boundary. Logged because the combined failure names the real cause,
+      // while the per-group retry may only reproduce part of it.
+      console.warn(
+        "[AI Config] Combined config write failed; retrying one group at a time:",
+        err instanceof Error ? logSafe(err.message) : err,
+      );
+    }
+  }
+
+  for (const group of present) {
+    try {
+      await runConfigSetBatch(group.ops);
+      group.onApplied?.();
+    } catch (err) {
+      if (!group.onError) throw err;
+      group.onError(err);
+    }
+  }
 }
 
 async function readAuthProfiles(): Promise<AuthProfilesFile> {
@@ -601,18 +674,13 @@ function hasToolModelConfig(existing: unknown): boolean {
  * the image *understanding* (vision) model and is what `openclaw models
  * set-image` writes, which is why that CLI command is not used here.
  */
-async function configureClawboxAiImages(clawboxAiToken: string): Promise<boolean> {
-  let existingOpenAiProvider: OpenAiProviderConfig | undefined;
-  let existingImageModel: unknown;
-  try {
-    const config = await readOpenClawConfig();
-    existingOpenAiProvider = config.models?.providers?.[CLAWBOX_AI_IMAGE_PROVIDER];
-    existingImageModel = config.agents?.defaults?.imageGenerationModel;
-  } catch {
-    // No readable config yet (fresh box) — nothing to preserve.
-    existingOpenAiProvider = undefined;
-    existingImageModel = undefined;
-  }
+function buildClawboxAiImageOps(
+  clawboxAiToken: string,
+  snapshot: OpenClawConfig | null,
+): OpenclawConfigSetArgs[] {
+  let existingOpenAiProvider: OpenAiProviderConfig | undefined =
+    snapshot?.models?.providers?.[CLAWBOX_AI_IMAGE_PROVIDER];
+  const existingImageModel: unknown = snapshot?.agents?.defaults?.imageGenerationModel;
   if (typeof existingOpenAiProvider !== "object" || existingOpenAiProvider === null) {
     existingOpenAiProvider = undefined;
   }
@@ -621,7 +689,7 @@ async function configureClawboxAiImages(clawboxAiToken: string): Promise<boolean
     console.warn(
       "[AI Config] Skipped ClawBox AI image provider: models.providers.openai.apiKey holds a non-ClawBox key we will not overwrite",
     );
-    return false;
+    return [];
   }
 
   const foreignRoute = foreignOpenAiRoute(existingOpenAiProvider);
@@ -629,41 +697,59 @@ async function configureClawboxAiImages(clawboxAiToken: string): Promise<boolean
     console.warn(
       `[AI Config] Skipped ClawBox AI image provider: models.providers.openai already routes to ${logSafe(foreignRoute)}, and the apiKey we would write there is the credential for that route too`,
     );
-    return false;
+    return [];
   }
 
   // Leaf-path writes, not a whole-provider `config set models.providers.openai`:
   // replacing the object would drop any other openai settings the box carries.
-  await runCommand(OPENCLAW_BIN, [
-    "config",
-    "set",
-    `models.providers.${CLAWBOX_AI_IMAGE_PROVIDER}.apiKey`,
-    clawboxAiToken,
-  ]);
-  await runCommand(OPENCLAW_BIN, [
-    "config",
-    "set",
-    `models.providers.${CLAWBOX_AI_IMAGE_PROVIDER}.models`,
-    buildClawboxAiImageProviderModels(existingOpenAiProvider?.models),
-    "--json",
-  ]);
+  const ops: OpenclawConfigSetArgs[] = [
+    [`models.providers.${CLAWBOX_AI_IMAGE_PROVIDER}.apiKey`, clawboxAiToken],
+    [
+      `models.providers.${CLAWBOX_AI_IMAGE_PROVIDER}.models`,
+      buildClawboxAiImageProviderModels(existingOpenAiProvider?.models),
+      "--json",
+    ],
+  ];
   if (hasToolModelConfig(existingImageModel)) {
     console.log(
       "[AI Config] Left agents.defaults.imageGenerationModel alone: it already names an image model",
     );
-    return true;
+    return ops;
   }
-  await runCommand(OPENCLAW_BIN, [
-    "config",
-    "set",
+  ops.push([
     "agents.defaults.imageGenerationModel",
     JSON.stringify({ primary: CLAWBOX_AI_IMAGE_MODEL }),
     "--json",
   ]);
-  return true;
+  return ops;
 }
 
-async function configureClawboxAi(setFallback: boolean, preferredToken?: string) {
+/**
+ * Provision ClawBox AI: the auth profile, the provider definition, image
+ * understanding, image generation, and optionally the fallback slot.
+ *
+ * All of it lands in ONE `openclaw config set --batch-json` on the happy path.
+ * It used to be six to seven separate invocations at ~8 s of CLI startup each,
+ * and on the ClawBox AI wizard path this function ran TWICE — see the caller
+ * (TASK-483).
+ *
+ * The three groups below exist because their failures mean different things,
+ * and `applyConfigSetGroups` is what keeps them apart while still writing them
+ * together. Every conditional here reads `snapshot`, one config read taken
+ * before any of this request's writes, because each of those decisions is about
+ * what the owner had BEFORE we started — nothing we write in this pass changes
+ * the answer.
+ */
+async function configureClawboxAi(
+  setFallback: boolean,
+  preferredToken?: string,
+  extra?: {
+    /** Ops to write in the same must-succeed group. */
+    requiredOps?: OpenclawConfigSetArgs[];
+    /** Extra groups to write in the same batch, with their own boundaries. */
+    groups?: ConfigSetGroup[];
+  },
+) {
   const clawboxAiToken = await getConfiguredClawboxAiToken(preferredToken);
   if (!clawboxAiToken) {
     return false;
@@ -677,20 +763,27 @@ async function configureClawboxAi(setFallback: boolean, preferredToken?: string)
   };
   await writeAuthProfiles(authProfiles);
 
-  await runCommand(OPENCLAW_BIN, [
-    "config",
-    "set",
-    `auth.profiles.${CLAWBOX_AI_PROFILE_KEY}`,
-    JSON.stringify({ provider: CLAWBOX_AI_PROVIDER, mode: "api_key" }),
-    "--json",
-  ]);
-  await runCommand(OPENCLAW_BIN, [
-    "config",
-    "set",
-    `models.providers.${CLAWBOX_AI_PROVIDER}`,
-    buildClawboxAiProviderDefinition(clawboxAiToken),
-    "--json",
-  ]);
+  let snapshot: OpenClawConfig | null = null;
+  try {
+    snapshot = await readOpenClawConfig();
+  } catch {
+    // No readable config yet (fresh box) — nothing to preserve.
+    snapshot = null;
+  }
+
+  const requiredOps: OpenclawConfigSetArgs[] = [
+    [
+      `auth.profiles.${CLAWBOX_AI_PROFILE_KEY}`,
+      JSON.stringify({ provider: CLAWBOX_AI_PROVIDER, mode: "api_key" }),
+      "--json",
+    ],
+    [
+      `models.providers.${CLAWBOX_AI_PROVIDER}`,
+      buildClawboxAiProviderDefinition(clawboxAiToken),
+      "--json",
+    ],
+    ...(extra?.requiredOps ?? []),
+  ];
 
   // Point image *understanding* at the vision entry the provider definition
   // above just wrote. Without this the device accepts an attached picture and
@@ -706,35 +799,17 @@ async function configureClawboxAi(setFallback: boolean, preferredToken?: string)
   // function also runs when ClawBox AI is merely being added as a *fallback*
   // for some other provider, and a slot the owner filled is their choice.
   // Non-fatal for the same reason too.
-  try {
-    let existingVisionModel: unknown;
-    try {
-      existingVisionModel = (await readOpenClawConfig()).agents?.defaults?.imageModel;
-    } catch {
-      // No readable config yet (fresh box) — nothing to preserve.
-      existingVisionModel = undefined;
-    }
-    if (hasToolModelConfig(existingVisionModel)) {
-      console.log(
-        "[AI Config] Left agents.defaults.imageModel alone: it already names a vision model",
-      );
-    } else {
-      await runCommand(OPENCLAW_BIN, [
-        "config",
-        "set",
-        "agents.defaults.imageModel",
-        JSON.stringify({ primary: CLAWBOX_AI_VISION_MODEL }),
-        "--json",
-      ]);
-      console.log(
-        `[AI Config] Set ClawBox AI vision model ${CLAWBOX_AI_VISION_MODEL} via proxy ${CLAWBOX_AI_PROXY_URL}`,
-      );
-    }
-  } catch (err) {
-    console.warn(
-      "[AI Config] Failed to configure ClawBox AI vision model:",
-      err instanceof Error ? logSafe(err.message) : err,
+  const visionOps: OpenclawConfigSetArgs[] = [];
+  if (hasToolModelConfig(snapshot?.agents?.defaults?.imageModel)) {
+    console.log(
+      "[AI Config] Left agents.defaults.imageModel alone: it already names a vision model",
     );
+  } else {
+    visionOps.push([
+      "agents.defaults.imageModel",
+      JSON.stringify({ primary: CLAWBOX_AI_VISION_MODEL }),
+      "--json",
+    ]);
   }
 
   // Images ride on the same token and the same proxy, so they are provisioned
@@ -742,35 +817,61 @@ async function configureClawboxAi(setFallback: boolean, preferredToken?: string)
   // an image allowance whether or not ClawBox AI is also the chat provider.
   // Non-fatal: a chat provider that works is worth more than an image tool, so
   // a failure here must not fail the whole "Connect ClawBox AI" flow.
+  let imageOps: OpenclawConfigSetArgs[] = [];
   try {
-    if (await configureClawboxAiImages(clawboxAiToken)) {
-      console.log(
-        `[AI Config] Set ClawBox AI image provider ${CLAWBOX_AI_IMAGE_MODEL} via proxy ${CLAWBOX_AI_PROXY_URL}`,
-      );
-    }
+    imageOps = buildClawboxAiImageOps(clawboxAiToken, snapshot);
   } catch (err) {
-    // `logSafe`, not the raw message: this one is built from a subprocess
-    // failure, so it carries whatever `openclaw` wrote to stderr — a value that
-    // reached the CLI from this route's request body, control characters and
-    // all. Unbounded and un-escaped, it would be the caller deciding how many
-    // journal records one API call produces. The command line itself is already
-    // safe: `spawnOpenclawConfigSet` names the config path and elides the value,
-    // which for this call is the portal token (see `configSetLabelArgs`).
     console.warn(
       "[AI Config] Failed to configure ClawBox AI image provider:",
       err instanceof Error ? logSafe(err.message) : err,
     );
   }
 
-  if (setFallback) {
-    await runCommand(OPENCLAW_BIN, [
-      "config",
-      "set",
-      "agents.defaults.model.fallbacks",
-      JSON.stringify([CLAWBOX_AI_MODEL]),
-      "--json",
-    ]);
-  }
+  await applyConfigSetGroups([
+    { ops: requiredOps },
+    {
+      ops: visionOps,
+      onApplied: () =>
+        console.log(
+          `[AI Config] Set ClawBox AI vision model ${CLAWBOX_AI_VISION_MODEL} via proxy ${CLAWBOX_AI_PROXY_URL}`,
+        ),
+      onError: (err) =>
+        console.warn(
+          "[AI Config] Failed to configure ClawBox AI vision model:",
+          err instanceof Error ? logSafe(err.message) : err,
+        ),
+    },
+    {
+      ops: imageOps,
+      onApplied: () =>
+        console.log(
+          `[AI Config] Set ClawBox AI image provider ${CLAWBOX_AI_IMAGE_MODEL} via proxy ${CLAWBOX_AI_PROXY_URL}`,
+        ),
+      // `logSafe`, not the raw message: this one is built from a subprocess
+      // failure, so it carries whatever `openclaw` wrote to stderr — a value
+      // that reached the CLI from this route's request body, control characters
+      // and all. Unbounded and un-escaped, it would be the caller deciding how
+      // many journal records one API call produces. The command line itself is
+      // already safe: the batch label names the config paths and elides every
+      // value, which here includes the portal token (see
+      // `configSetBatchLabelArgs`).
+      onError: (err) =>
+        console.warn(
+          "[AI Config] Failed to configure ClawBox AI image provider:",
+          err instanceof Error ? logSafe(err.message) : err,
+        ),
+    },
+    ...(extra?.groups ?? []),
+    setFallback
+      ? {
+          ops: [[
+            "agents.defaults.model.fallbacks",
+            JSON.stringify([CLAWBOX_AI_MODEL]),
+            "--json",
+          ]],
+        }
+      : null,
+  ]);
 
   return true;
 }
@@ -807,17 +908,33 @@ async function getStoredLocalFallbackModel(): Promise<string | null> {
   }
 }
 
+/**
+ * The local model that should back up `primaryModel`, or null when there is
+ * none to use.
+ *
+ * Split out of `ensureFallbackModel` so a caller that is about to write a pile
+ * of config can learn the answer BEFORE it writes, and fold the fallback into
+ * the same batch instead of paying another CLI start-up for it (TASK-483).
+ */
+async function pickLocalFallbackModel(
+  primaryModel?: string | null,
+  preferredLocalModel?: string,
+): Promise<string | null> {
+  const fallbackCandidates = [preferredLocalModel, await getStoredLocalFallbackModel()]
+    .filter((model): model is string => !!model && model !== primaryModel);
+  return fallbackCandidates[0] ?? null;
+}
+
 async function ensureFallbackModel(
   primaryModel?: string | null,
   preferredLocalModel?: string,
   preferredClawboxAiToken?: string,
 ) {
-  const fallbackCandidates = [preferredLocalModel, await getStoredLocalFallbackModel()]
-    .filter((model): model is string => !!model && model !== primaryModel);
+  const localFallback = await pickLocalFallbackModel(primaryModel, preferredLocalModel);
 
-  if (fallbackCandidates.length > 0) {
-    await setFallbackModels([fallbackCandidates[0]]);
-    console.log(`[AI Config] Configured local fallback model: ${logSafe(fallbackCandidates[0])}`);
+  if (localFallback) {
+    await setFallbackModels([localFallback]);
+    console.log(`[AI Config] Configured local fallback model: ${logSafe(localFallback)}`);
     return;
   }
 
@@ -868,14 +985,14 @@ async function writeOpenAICompatProvider(opts: {
     apiKey: opts.apiKey,
     models: Array.from(modelIds).map((id) => ({ id, name: id })),
   });
-  await runCommand(OPENCLAW_BIN, [
-    "config", "set", `models.providers.${opts.provider}`, providerDef, "--json",
+  await applyConfigSetGroups([
+    { ops: [[`models.providers.${opts.provider}`, providerDef, "--json"]] },
+    {
+      ops: [["models.mode", "merge"]],
+      // Non-fatal: merge is the default behavior anyway
+      onError: () => {},
+    },
   ]);
-  try {
-    await runCommand(OPENCLAW_BIN, ["config", "set", "models.mode", "merge"]);
-  } catch {
-    // Non-fatal: merge is the default behavior anyway
-  }
   await ensureFallbackModel(opts.defaultModel);
 }
 
@@ -1389,27 +1506,27 @@ export async function POST(request: Request) {
       );
     }
 
-    // 3. Set auth profile and primary model sequentially (parallel writes cause
-    //    ConfigMutationConflictError because openclaw config set reads/writes the
-    //    same file).
-    await runCommand(OPENCLAW_BIN, [
-      "config",
-      "set",
-      `auth.profiles.${config.profileKey}`,
-      // Subscription → "oauth"; every key-based provider → "api_key". The old
-      // "token" mode 401s on 2026.6.8+ (see the auth-profile write above).
-      JSON.stringify(authMode === "subscription"
-        ? { provider: ocProvider, mode: "oauth" }
-        : { provider: ocProvider, mode: "api_key" }),
-      "--json",
-    ]);
+    // 3. Auth profile, primary model, compaction reserve and the local-access
+    //    gateway settings. These are seven independent leaf writes with no
+    //    reads between them, so they go out as ONE `config set --batch-json`.
+    //    Issued one at a time they cost seven CLI cold starts — about a minute
+    //    on a Jetson, for seven keys (TASK-483). They still must not be
+    //    *parallel* writes: concurrent `openclaw config set` processes race on
+    //    the same file and lose to ConfigMutationConflictError. One batched
+    //    process is not concurrency, it is one validated read-modify-write.
+    const baseOps: OpenclawConfigSetArgs[] = [
+      [
+        `auth.profiles.${config.profileKey}`,
+        // Subscription → "oauth"; every key-based provider → "api_key". The old
+        // "token" mode 401s on 2026.6.8+ (see the auth-profile write above).
+        JSON.stringify(authMode === "subscription"
+          ? { provider: ocProvider, mode: "oauth" }
+          : { provider: ocProvider, mode: "api_key" }),
+        "--json",
+      ],
+    ];
     if (!isLocalScope || shouldPromoteLocalToPrimary) {
-      await runCommand(OPENCLAW_BIN, [
-        "config",
-        "set",
-        "agents.defaults.model.primary",
-        config.defaultModel,
-      ]);
+      baseOps.push(["agents.defaults.model.primary", config.defaultModel]);
       if (shouldPromoteLocalToPrimary) {
         console.log(`[AI Config] Promoted local model to active primary: ${logSafe(config.defaultModel)}`);
       }
@@ -1424,9 +1541,7 @@ export async function POST(request: Request) {
         ? llamaCppContextWindow
         : Number.POSITIVE_INFINITY;
     const compactionReserveFloor = compactionReserveFloorForContext(activeContextWindow);
-    await runCommand(OPENCLAW_BIN, [
-      "config",
-      "set",
+    baseOps.push([
       "agents.defaults.compaction.reserveTokensFloor",
       `${compactionReserveFloor}`,
     ]);
@@ -1443,22 +1558,15 @@ export async function POST(request: Request) {
     // WS connections, and rotates legacy "clawbox" tokens automatically.
     console.log(`[AI Config] Configuring gateway for local access (provider: ${provider})`);
     const gatewayToken = await getOrGenerateGatewayToken();
-    await runCommand(OPENCLAW_BIN, [
-      "config", "set", "gateway.auth.mode", "token",
-    ]);
+    baseOps.push(["gateway.auth.mode", "token"]);
     // A null result means the token is externally managed. Preserve the
     // SecretRef/interpolation instead of replacing it with plaintext.
     if (gatewayToken !== null) {
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "gateway.auth.token", gatewayToken,
-      ]);
+      baseOps.push(["gateway.auth.token", gatewayToken]);
     }
-    await runCommand(OPENCLAW_BIN, [
-      "config", "set", "gateway.controlUi.allowInsecureAuth", "true", "--json",
-    ]);
-    await runCommand(OPENCLAW_BIN, [
-      "config", "set", "gateway.controlUi.dangerouslyDisableDeviceAuth", "true", "--json",
-    ]);
+    baseOps.push(["gateway.controlUi.allowInsecureAuth", "true", "--json"]);
+    baseOps.push(["gateway.controlUi.dangerouslyDisableDeviceAuth", "true", "--json"]);
+    await runConfigSetBatch(baseOps);
 
     // 5. Ensure openclaw config files are owned by clawbox
     await Promise.all(
@@ -1518,11 +1626,58 @@ export async function POST(request: Request) {
     // 7. For ClawBox AI (DeepSeek) or Ollama, define a custom provider in openclaw.json
     // and set models.mode=replace so the gateway uses our definition.
     if (isClawAI) {
-      await configureClawboxAi(false, clawboxAiToken);
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.mode", "merge",
-      ]);
-      await ensureFallbackModel(config.defaultModel, undefined, clawboxAiToken);
+      // ONE provisioning pass, not two. This used to call configureClawboxAi()
+      // and then ensureFallbackModel(), which — with no local model to fall
+      // back to, which is the normal case — called configureClawboxAi() a
+      // SECOND time for the sole purpose of writing
+      // `agents.defaults.model.fallbacks`. Every write in it therefore paid the
+      // CLI's ~8 s cold start twice. Decide the fallback first and hand both
+      // that decision and `models.mode` to the single pass, so the whole
+      // ClawBox AI provisioning is one `config set --batch-json` (TASK-483).
+      const localFallback = await pickLocalFallbackModel(config.defaultModel, undefined);
+      // The two fallback outcomes keep the fatality they had when they lived in
+      // ensureFallbackModel: a local fallback was written before its try block
+      // and so was fatal, while the ClawBox AI one was written inside it and so
+      // only warned. Inherited, not chosen — batching them must not quietly
+      // change either.
+      const fallbackGroup: ConfigSetGroup = localFallback
+        ? {
+            ops: [[
+              "agents.defaults.model.fallbacks",
+              JSON.stringify([localFallback]),
+              "--json",
+            ]],
+            onApplied: () =>
+              console.log(`[AI Config] Configured local fallback model: ${logSafe(localFallback)}`),
+          }
+        : {
+            ops: [[
+              "agents.defaults.model.fallbacks",
+              JSON.stringify([CLAWBOX_AI_MODEL]),
+              "--json",
+            ]],
+            onApplied: () => console.log("[AI Config] Configured ClawBox AI as fallback model"),
+            onError: (err) =>
+              console.warn(
+                "[AI Config] Failed to configure fallback model:",
+                err instanceof Error ? logSafe(err.message) : err,
+              ),
+          };
+      const clawboxAiConfigured = await configureClawboxAi(
+        false,
+        clawboxAiToken,
+        {
+          requiredOps: [["models.mode", "merge"]],
+          groups: [fallbackGroup],
+        },
+      );
+      if (!clawboxAiConfigured) {
+        // Unreachable in practice — the handler already 400s when ClawBox AI
+        // has no token — but keep the old shape rather than silently leave a
+        // stale fallback naming a provider this box no longer has.
+        await runConfigSetBatch([["models.mode", "merge"]]);
+        await ensureFallbackModel(config.defaultModel, undefined, clawboxAiToken);
+      }
       console.log(`[AI Config] Set ClawBox AI provider in openclaw.json via proxy ${CLAWBOX_AI_PROXY_URL}`);
 
       // Account-switch safety: ClawKeep pairs separately and is bound to its
@@ -1559,11 +1714,9 @@ export async function POST(request: Request) {
           maxTokens: OLLAMA_MAX_TOKENS,
         }],
       });
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.providers.ollama", providerDef, "--json",
-      ]);
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.mode", isLocalScope ? "merge" : "replace",
+      await runConfigSetBatch([
+        ["models.providers.ollama", providerDef, "--json"],
+        ["models.mode", isLocalScope ? "merge" : "replace"],
       ]);
       await ensureFallbackModel(shouldPromoteLocalToPrimary ? config.defaultModel : (isLocalScope ? null : config.defaultModel), config.defaultModel);
       // Ensure Ollama service has memory optimizations (q8_0 KV cache, flash attention)
@@ -1590,11 +1743,9 @@ export async function POST(request: Request) {
           maxTokens: llamaCppMaxTokens,
         }],
       });
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.providers.llamacpp", providerDef, "--json",
-      ]);
-      await runCommand(OPENCLAW_BIN, [
-        "config", "set", "models.mode", isLocalScope ? "merge" : "replace",
+      await runConfigSetBatch([
+        ["models.providers.llamacpp", providerDef, "--json"],
+        ["models.mode", isLocalScope ? "merge" : "replace"],
       ]);
       await ensureFallbackModel(shouldPromoteLocalToPrimary ? config.defaultModel : (isLocalScope ? null : config.defaultModel), config.defaultModel);
       console.log(`[AI Config] Set llama.cpp provider in openclaw.json: ${logSafe(modelName)} (context=${llamaCppContextWindow}, mode=replace)`);

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -101,6 +101,16 @@ function getConnectButtonLabel(providerName?: string | null) {
   return providerName ? `Connect to ${providerName}` : "Connect";
 }
 
+/**
+ * When each row of the generic "configuring" overlay lights up, in ms.
+ *
+ * The LAST entry is deliberately not used by the timer — see the effect that
+ * schedules these. Driving the final row off a stopwatch is what made this
+ * screen lie: it reached "Almost ready" at 22 s and then sat there, unchanged,
+ * for the remaining two minutes the config writes actually took, which reads as
+ * a hang on a screen that is also asking the customer not to close the page
+ * (TASK-483).
+ */
 const CONFIGURING_STEP_DELAYS = [0, 2000, 5000, 12000, 22000];
 
 type ConfiguringKind = "generic" | "ollama" | "llamacpp";
@@ -197,6 +207,12 @@ function ConfiguringOverlay({
           return (
             <li
               key={i}
+              // Which row a customer is actually looking at, stated rather than
+              // inferred from a Tailwind class. Every label is in the DOM at all
+              // times — an unreached row is rendered at opacity 0 — so "is the
+              // last row showing yet" is a question only this attribute can
+              // answer (TASK-483).
+              data-step-state={stepDone ? "done" : stepNow ? "active" : "pending"}
               className={`flex items-center gap-2 text-[length:var(--t-2)] ${
                 reached ? "opacity-100" : "opacity-0 translate-y-1"
               }`}
@@ -935,8 +951,12 @@ export default function AIModelsStep({
   useEffect(() => {
     if (configuringKind !== "generic" || configuringCompleted) return;
 
+    // Every row except the last one is timed. The last row belongs to
+    // `completeConfiguring`, so "Almost ready" appears when the request has
+    // actually come back and never before it.
+    const lastTimedIndex = CONFIGURING_STEP_DELAYS.length - 2;
     const timers = CONFIGURING_STEP_DELAYS.map((delay, index) =>
-      index === 0
+      index === 0 || index > lastTimedIndex
         ? null
         : setTimeout(() => {
             setConfiguringState((current) => {

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -86,6 +86,26 @@ export async function runOpenclawConfigSet(
   args: string[],
   options: OpenclawConfigSetOptions = {},
 ): Promise<void> {
+  await withConfigMutationRetry(
+    (timeoutMs) => spawnOpenclawConfigSet(args, { ...options, timeoutMs }),
+    options,
+    "runOpenclawConfigSet",
+  );
+}
+
+/**
+ * Retry `attempt` while it fails with `ConfigMutationConflictError`.
+ *
+ * Shared by {@link runOpenclawConfigSet} and {@link runOpenclawConfigSetBatch}
+ * so both forms of the write survive the same race. Any other failure is
+ * rethrown on the first try — a schema rejection does not become valid by
+ * being repeated.
+ */
+async function withConfigMutationRetry(
+  attemptFn: (timeoutMs: number) => Promise<void>,
+  options: OpenclawConfigSetOptions,
+  label: string,
+): Promise<void> {
   const {
     timeoutMs = 30_000,
     maxAttempts = 4,
@@ -95,7 +115,7 @@ export async function runOpenclawConfigSet(
   let lastError: Error | null = null;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
-      await spawnOpenclawConfigSet(args, { ...options, timeoutMs });
+      await attemptFn(timeoutMs);
       return;
     } catch (err) {
       lastError = err instanceof Error ? err : new Error(String(err));
@@ -110,7 +130,7 @@ export async function runOpenclawConfigSet(
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }
-  throw lastError ?? new Error("runOpenclawConfigSet exhausted retries");
+  throw lastError ?? new Error(`${label} exhausted retries`);
 }
 
 interface SpawnOpenclawOptions {
@@ -235,6 +255,111 @@ function spawnOpenclawConfigSet(
     cwd: options.cwd,
     env: options.env,
   }).then(() => undefined);
+}
+
+/**
+ * One `openclaw config set` assignment, in the same argv form
+ * {@link runOpenclawConfigSet} takes: `[path, value]`, optionally followed by
+ * `--json` when `value` is already JSON text.
+ */
+export type OpenclawConfigSetArgs = string[];
+
+/**
+ * Turn one `config set` argv into the `{ path, value }` entry the CLI's batch
+ * mode wants.
+ *
+ * The CLI's own two value modes are reproduced exactly, because a batch has to
+ * write the same config a sequence of single calls would:
+ *  - with `--json` (aka `--strict-json`) the value text is parsed as JSON and a
+ *    parse failure is an error;
+ *  - without it the CLI tries to parse the text and silently falls back to the
+ *    raw string, which is how `"24000"` becomes the number 24000 and
+ *    `"deepseek/deepseek-v4-pro"` stays a string.
+ *
+ * (The CLI reaches for JSON5 rather than JSON on the lenient path. Every value
+ * this repo writes without `--json` is a plain model id, a mode word, a token
+ * or a decimal integer, for which the two parsers agree; JSON5 is not a
+ * dependency here and pulling one in to cover values we never send would be
+ * cost without benefit.)
+ */
+export function parseConfigSetArgs(args: OpenclawConfigSetArgs): { path: string; value: unknown } {
+  const flags = args.filter((arg) => arg.startsWith("--"));
+  const positional = args.filter((arg) => !arg.startsWith("--"));
+  const [path, raw] = positional;
+  if (!path) throw new Error("config set batch entry is missing a path");
+  if (raw === undefined) throw new Error(`config set batch entry for ${path} is missing a value`);
+  const strictJson = flags.includes("--json") || flags.includes("--strict-json");
+  if (strictJson) return { path, value: JSON.parse(raw) };
+  try {
+    return { path, value: JSON.parse(raw) };
+  } catch {
+    return { path, value: raw };
+  }
+}
+
+/**
+ * Argv for a batched `config set`, with every *value* elided, for use in a log
+ * line — the batch counterpart of {@link configSetLabelArgs}.
+ *
+ * Batch mode puts the whole payload in a single argv element, so the values
+ * that {@link configSetLabelArgs} carefully keeps out of the journal (the
+ * ClawBox AI portal token, provider API keys, the gateway token) would all ride
+ * into an error message inside one JSON blob. Name the paths, which is what
+ * makes such a line diagnosable, and nothing else.
+ */
+export function configSetBatchLabelArgs(batch: readonly OpenclawConfigSetArgs[]): string[] {
+  return [
+    "config",
+    "set",
+    "--batch-json",
+    `[${batch.map((args) => `${args.filter((arg) => !arg.startsWith("--"))[0] ?? "<no path>"}=<redacted>`).join(",")}]`,
+  ];
+}
+
+/**
+ * Apply several `config set` assignments in ONE `openclaw` invocation.
+ *
+ * Why this exists: the CLI is a full Node program that loads the gateway SDK,
+ * parses plugins and validates the config schema on every run, so on a Jetson
+ * Orin Nano a single `config set` costs ~8 s of startup and does milliseconds
+ * of work. First-run setup wrote ~18 keys one at a time and spent about two and
+ * a half minutes doing it, with the wizard sitting on "Almost ready" for the
+ * last two of them (TASK-483). `--batch-json` applies N assignments in one
+ * validated read-modify-write, so N keys cost one startup instead of N.
+ *
+ * Semantics match a sequence of `config set --json` calls: the CLI applies the
+ * entries in order against one snapshot, runs the same non-destructive
+ * replacement guard per entry, and writes once. The difference that matters is
+ * atomicity — a batch either lands whole or not at all — so a caller that needs
+ * two failures kept apart must issue two batches, not one.
+ *
+ * A single-entry batch is sent through {@link runOpenclawConfigSet} unchanged:
+ * there is nothing to save, and the plain form is the one every other caller
+ * has been using.
+ */
+export async function runOpenclawConfigSetBatch(
+  batch: readonly OpenclawConfigSetArgs[],
+  options: OpenclawConfigSetOptions = {},
+): Promise<void> {
+  if (batch.length === 0) return;
+  if (batch.length === 1) {
+    await runOpenclawConfigSet(batch[0], options);
+    return;
+  }
+  const payload = JSON.stringify(batch.map(parseConfigSetArgs));
+  await withConfigMutationRetry(
+    (timeoutMs) =>
+      spawnOpenclaw(["config", "set", "--batch-json", payload], {
+        labelArgs: configSetBatchLabelArgs(batch),
+        timeoutMs,
+        uid: options.uid,
+        gid: options.gid,
+        cwd: options.cwd,
+        env: options.env,
+      }).then(() => undefined),
+    options,
+    "runOpenclawConfigSetBatch",
+  );
 }
 export const OPENCLAW_HOME = process.env.OPENCLAW_HOME || "/home/clawbox/.openclaw";
 const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || path.join(OPENCLAW_HOME, "agents");

--- a/src/tests/components/ai-models-step.test.tsx
+++ b/src/tests/components/ai-models-step.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
+import { act, fireEvent, render, waitFor } from "@/tests/helpers/test-utils";
 import AIModelsStep from "@/components/AIModelsStep";
 
 vi.mock("@/lib/i18n", () => ({
@@ -441,5 +441,74 @@ describe("AIModelsStep variants", () => {
     }, { timeout: 4000 });
 
     vi.unstubAllGlobals();
+  });
+  // TASK-483: the overlay's rows used to be driven entirely off wall-clock
+  // timers, so it reached the final row, "Almost ready", 22 seconds in and then
+  // sat there unchanged for the two further minutes the config writes actually
+  // took. On a screen that also says "Please don't close this page" that reads
+  // as a hang. The last row now belongs to the request, not the stopwatch.
+  it("does not claim 'Almost ready' until the configure request comes back", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let resolveConfigure: ((value: unknown) => void) | null = null;
+      const fetchMock = vi.mocked(fetch);
+      fetchMock.mockImplementation(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+        if (url.includes("/setup-api/ai-models/oauth/providers")) {
+          return { ok: true, json: async () => ({ providers: [] }) } as unknown as Response;
+        }
+        if (url.includes("/setup-api/ai-models/configure")) {
+          await new Promise((resolve) => { resolveConfigure = resolve; });
+          return { ok: true, json: async () => ({ success: true }) } as unknown as Response;
+        }
+        return { ok: true, json: async () => ({}) } as unknown as Response;
+      });
+
+      const { getByRole, getByText, container } = render(
+        <AIModelsStep
+          providerIds={["clawai", "openai", "anthropic", "google", "openrouter"]}
+          defaultProviderId="clawai"
+          title="Connect AI Provider"
+          description="Primary provider"
+        />,
+      );
+
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers");
+      });
+
+      fireEvent.click(getByRole("button", { name: /Show more providers/i }));
+      fireEvent.click(getByRole("radio", { name: /Anthropic Claude/i }));
+      const keyInput = container.querySelector("input[type=password], input[type=text]");
+      expect(keyInput).not.toBeNull();
+      fireEvent.change(keyInput as HTMLInputElement, { target: { value: "sk-ant-test" } });
+      fireEvent.click(getByRole("button", { name: "Connect to Anthropic Claude" }));
+
+      await waitFor(() => {
+        expect(getByText("Credentials verified")).toBeInTheDocument();
+      });
+
+      // Well past the last timer in CONFIGURING_STEP_DELAYS.
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+      });
+
+      // Every row's label is in the DOM the whole time — unreached rows are
+      // just rendered transparent — so ask each row what state it is in.
+      const stepState = (label: string) =>
+        getByText(label).closest("li")?.getAttribute("data-step-state");
+      expect(stepState("Warming up models")).toBe("active");
+      expect(stepState("Almost ready")).toBe("pending");
+
+      await act(async () => {
+        resolveConfigure?.(undefined);
+      });
+
+      await waitFor(() => {
+        expect(stepState("Almost ready")).toBe("done");
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/tests/routes/ai-models/config-set-calls.ts
+++ b/src/tests/routes/ai-models/config-set-calls.ts
@@ -1,0 +1,93 @@
+import type { Mock } from "vitest";
+
+/**
+ * Test-only view of "which `openclaw config set` assignments did the route
+ * make", across both forms the route uses.
+ *
+ * The configure route writes most of its config through
+ * `runOpenclawConfigSetBatch`, which sends N assignments in one CLI invocation
+ * because on a Jetson each invocation costs ~8 s of Node start-up (TASK-483).
+ * A handful of one-off writes still go through `runOpenclawConfigSet`. The
+ * assertions in these suites are about the assignments, not about how many
+ * processes carried them, so this flattens both mocks back into one ordered
+ * list of `[path, value, ...flags]` argvs.
+ *
+ * Ordering across the two mocks comes from vitest's `invocationCallOrder`, so
+ * the list is in the order the route actually issued the writes.
+ */
+export interface ConfigSetCall {
+  /** The config path, e.g. `agents.defaults.model.primary`. */
+  path: string;
+  /** The value exactly as the route passed it (JSON text when `json` is true). */
+  value: string;
+  /** Whether the assignment carried `--json`. */
+  json: boolean;
+  /** `config set <path> <value>[ --json]` — the form these suites assert on. */
+  command: string;
+  /** The raw argv, minus the leading `config set`. */
+  args: string[];
+}
+
+function toCall(args: string[]): ConfigSetCall {
+  const positional = args.filter((arg) => !arg.startsWith("--"));
+  const json = args.includes("--json");
+  return {
+    path: positional[0] ?? "",
+    value: positional[1] ?? "",
+    json,
+    command: ["config", "set", ...args].join(" "),
+    args,
+  };
+}
+
+export function configSetCalls(single: Mock, batch: Mock): ConfigSetCall[] {
+  const ordered: { order: number; args: string[] }[] = [];
+  single.mock.calls.forEach((call, i) => {
+    ordered.push({
+      order: single.mock.invocationCallOrder[i] ?? 0,
+      args: (call[0] as string[] | undefined) ?? [],
+    });
+  });
+  batch.mock.calls.forEach((call, i) => {
+    const order = batch.mock.invocationCallOrder[i] ?? 0;
+    for (const args of ((call[0] as string[][] | undefined) ?? [])) {
+      ordered.push({ order, args });
+    }
+  });
+  return ordered
+    .sort((a, b) => a.order - b.order)
+    .map((entry) => toCall(entry.args));
+}
+
+export function configSetCommands(single: Mock, batch: Mock): string[] {
+  return configSetCalls(single, batch).map((call) => call.command);
+}
+
+export function findConfigSet(single: Mock, batch: Mock, path: string): ConfigSetCall | undefined {
+  return configSetCalls(single, batch).find((call) => call.path === path);
+}
+
+/**
+ * Make both config-set mocks reject for any assignment whose path matches.
+ *
+ * The route sends most assignments through the batch form, so a test that only
+ * stubs `runOpenclawConfigSet` to throw would silently stop exercising the
+ * failure it was written for. Batch mode is atomic — a batch containing a
+ * matching path fails as a whole — which is what the real CLI does and what
+ * `applyConfigSetGroups` then recovers from by re-issuing each group alone.
+ */
+export function failConfigSetsMatching(
+  single: Mock,
+  batch: Mock,
+  matches: (path: string) => boolean,
+  makeError: () => Error,
+): void {
+  single.mockImplementation(async (args: string[]) => {
+    if (matches(args?.[0] ?? "")) throw makeError();
+  });
+  batch.mockImplementation(async (ops: string[][]) => {
+    for (const args of ops ?? []) {
+      if (matches(args?.[0] ?? "")) throw makeError();
+    }
+  });
+}

--- a/src/tests/routes/ai-models/configure-hermes.test.ts
+++ b/src/tests/routes/ai-models/configure-hermes.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSetBatch: vi.fn(),
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
   parseFullyQualifiedModel: vi.fn((fq: string) => {
     const i = fq.indexOf("/");
@@ -105,6 +106,7 @@ describe("POST /setup-api/ai-models/configure — hermes edition", () => {
   let POST: (req: Request) => Promise<Response>;
   let mockSetMany: ReturnType<typeof vi.fn>;
   let mockRunOpenclawConfigSet: ReturnType<typeof vi.fn>;
+  let mockRunOpenclawConfigSetBatch: ReturnType<typeof vi.fn>;
   let mockRestartGateway: ReturnType<typeof vi.fn>;
   let mockApplyLocalAiToHermes: ReturnType<typeof vi.fn>;
   let mockApplyClawaiToHermes: ReturnType<typeof vi.fn>;
@@ -121,6 +123,7 @@ describe("POST /setup-api/ai-models/configure — hermes edition", () => {
     const oc = await import("@/lib/openclaw-config");
     vi.mocked(oc.openclawIsAbsent).mockReturnValue(true);
     mockRunOpenclawConfigSet = vi.mocked(oc.runOpenclawConfigSet) as unknown as ReturnType<typeof vi.fn>;
+    mockRunOpenclawConfigSetBatch = vi.mocked(oc.runOpenclawConfigSetBatch) as unknown as ReturnType<typeof vi.fn>;
     mockRestartGateway = vi.mocked(oc.restartGateway) as unknown as ReturnType<typeof vi.fn>;
 
     const cs = await import("@/lib/config-store");
@@ -148,6 +151,7 @@ describe("POST /setup-api/ai-models/configure — hermes edition", () => {
   /** Assert that nothing in this call reached the OpenClaw CLI. */
   function expectNoOpenclawSpawn() {
     expect(mockRunOpenclawConfigSet).not.toHaveBeenCalled();
+    expect(mockRunOpenclawConfigSetBatch).not.toHaveBeenCalled();
     expect(mockRestartGateway).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
   }

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -72,6 +72,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSetBatch: vi.fn(),
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
   parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),
@@ -107,15 +108,18 @@ import {
   readConfig,
   restartGateway,
   runOpenclawConfigSet,
+  runOpenclawConfigSetBatch,
   applyModelOverrideToAllAgentSessions,
   parseFullyQualifiedModel,
 } from "@/lib/openclaw-config";
+import { configSetCalls as recordedConfigSetCalls, failConfigSetsMatching } from "./config-set-calls";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
 const mockSetMany = vi.mocked(setMany);
 const mockReadConfig = vi.mocked(readConfig);
 const mockRunOpenclawConfigSet = vi.mocked(runOpenclawConfigSet);
+const mockRunOpenclawConfigSetBatch = vi.mocked(runOpenclawConfigSetBatch);
 const mockFs = vi.mocked(fsp);
 
 function createSuccessfulChildProcess(): ChildProcess {
@@ -142,9 +146,13 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
     });
   }
 
-  /** Every `openclaw config set` the route ran, as [path, ...rest] tuples. */
+  /**
+   * Every `openclaw config set` assignment the route made, as [path, ...rest]
+   * tuples — whether it went out on its own or inside a batch.
+   */
   function configSetCalls(): string[][] {
-    return mockRunOpenclawConfigSet.mock.calls.map((call) => call[0] as string[]);
+    return recordedConfigSetCalls(mockRunOpenclawConfigSet, mockRunOpenclawConfigSetBatch)
+      .map((call) => call.args);
   }
 
   function callFor(path: string): string[] | undefined {
@@ -169,6 +177,7 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
     vi.mocked(restartGateway).mockResolvedValue();
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
     mockRunOpenclawConfigSet.mockResolvedValue(undefined);
+    mockRunOpenclawConfigSetBatch.mockResolvedValue(undefined);
     vi.mocked(unpairLocal).mockResolvedValue(undefined);
     vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
     vi.mocked(parseFullyQualifiedModel).mockImplementation(parseFullyQualifiedModelImpl);
@@ -536,18 +545,22 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
   describe("what the failure path is allowed to write to the journal", () => {
     /** The single journal record the image-provider catch produced. */
     async function failImageWritesWith(message: string): Promise<string> {
-      mockRunOpenclawConfigSet.mockImplementation(async (args: string[]) => {
-        if (args[0]?.startsWith("models.providers.openai")) throw new Error(message);
-      });
+      failConfigSetsMatching(
+        mockRunOpenclawConfigSet,
+        mockRunOpenclawConfigSetBatch,
+        (path) => path.startsWith("models.providers.openai"),
+        () => new Error(message),
+      );
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         await connectClawai();
         const records = warn.mock.calls
           .map((call) => call.map(String).join(" "))
           .filter((record) => record.includes("ClawBox AI image provider"));
-        // configureClawboxAi runs twice on this path — once for the primary and
-        // once from ensureFallbackModel — so the catch fires twice with the
-        // same message. One distinct record is what matters here.
+        // One distinct record is what matters here — the route may report the
+        // same failure more than once (the combined batch fails first, then the
+        // image group fails again on its own boundary), but it must never
+        // produce two DIFFERENT records from one subprocess message.
         expect(records.length).toBeGreaterThan(0);
         expect(new Set(records).size).toBe(1);
         return records[0];
@@ -581,9 +594,12 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
   describe("failure containment", () => {
     it("still connects ClawBox AI when the image writes fail", async () => {
       // A chat provider that works is worth more than an image tool.
-      mockRunOpenclawConfigSet.mockImplementation(async (args: string[]) => {
-        if (args[0]?.startsWith("models.providers.openai")) throw new Error("config write conflict");
-      });
+      failConfigSetsMatching(
+        mockRunOpenclawConfigSet,
+        mockRunOpenclawConfigSetBatch,
+        (path) => path.startsWith("models.providers.openai"),
+        () => new Error("config write conflict"),
+      );
 
       const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
       const body = await res.json();

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -76,6 +76,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSetBatch: vi.fn(),
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
   parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),
@@ -111,15 +112,18 @@ import {
   readConfig,
   restartGateway,
   runOpenclawConfigSet,
+  runOpenclawConfigSetBatch,
   applyModelOverrideToAllAgentSessions,
   parseFullyQualifiedModel,
 } from "@/lib/openclaw-config";
+import { configSetCalls as recordedConfigSetCalls, failConfigSetsMatching } from "./config-set-calls";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
 const mockSetMany = vi.mocked(setMany);
 const mockReadConfig = vi.mocked(readConfig);
 const mockRunOpenclawConfigSet = vi.mocked(runOpenclawConfigSet);
+const mockRunOpenclawConfigSetBatch = vi.mocked(runOpenclawConfigSetBatch);
 const mockFs = vi.mocked(fsp);
 
 function createSuccessfulChildProcess(): ChildProcess {
@@ -156,8 +160,13 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () =
     });
   }
 
+  /**
+   * Every `openclaw config set` assignment the route made, as [path, ...rest]
+   * tuples — whether it went out on its own or inside a batch.
+   */
   function configSetCalls(): string[][] {
-    return mockRunOpenclawConfigSet.mock.calls.map((call) => call[0] as string[]);
+    return recordedConfigSetCalls(mockRunOpenclawConfigSet, mockRunOpenclawConfigSetBatch)
+      .map((call) => call.args);
   }
 
   function callFor(path: string): string[] | undefined {
@@ -193,6 +202,7 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () =
     vi.mocked(restartGateway).mockResolvedValue();
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
     mockRunOpenclawConfigSet.mockResolvedValue(undefined);
+    mockRunOpenclawConfigSetBatch.mockResolvedValue(undefined);
     vi.mocked(unpairLocal).mockResolvedValue(undefined);
     vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
     vi.mocked(parseFullyQualifiedModel).mockImplementation(parseFullyQualifiedModelImpl);
@@ -318,9 +328,12 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () =
   it("still configures chat when the vision write fails", async () => {
     // Non-fatal by design: a chat provider that works is worth more than a
     // vision model, so this must not fail the whole Connect ClawBox AI flow.
-    mockRunOpenclawConfigSet.mockImplementation(async (args: string[]) => {
-      if (args[0] === "agents.defaults.imageModel") throw new Error("config set exploded");
-    });
+    failConfigSetsMatching(
+      mockRunOpenclawConfigSet,
+      mockRunOpenclawConfigSetBatch,
+      (path) => path === "agents.defaults.imageModel",
+      () => new Error("config set exploded"),
+    );
 
     const res = await configurePost(jsonRequest({ provider: "clawai", apiKey: CLAWAI_TOKEN }));
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1510,5 +1510,30 @@ describe("POST /setup-api/ai-models/configure", () => {
       ).map((call) => call.path);
       expect(paths).toContain("models.providers.deepseek");
     });
+
+    it("still fails the connect when the LOCAL fallback write fails", async () => {
+      // The mirror of the test above, and the reason the two are written
+      // separately. A local fallback was written before ensureFallbackModel's
+      // try block and so was fatal; the ClawBox AI one was written inside it
+      // and only warned. Batching them into one call must not quietly level
+      // that difference in either direction.
+      mockGetAll.mockResolvedValue({
+        local_ai_configured: true,
+        local_ai_model: "ollama/llama3.2:3b",
+      });
+      failConfigSetsMatching(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+        (path) => path === "agents.defaults.model.fallbacks",
+        () => new Error("fallback write exploded"),
+      );
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_token_abc",
+      }));
+
+      expect(res.status).toBe(500);
+    });
   });
 });

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -80,6 +80,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSetBatch: vi.fn(),
   // Added by PR #83 — the configure route sweeps agent sessions so the
   // new primary provider takes effect on the open chat without a reset.
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
@@ -126,7 +127,8 @@ vi.mock("@/lib/local-ai-token", () => ({
 
 import { getAll, setMany } from "@/lib/config-store";
 import { unpairLocal } from "@/lib/clawkeep";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, runOpenclawConfigSetBatch, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
+import { configSetCalls, configSetCommands, failConfigSetsMatching, findConfigSet } from "./config-set-calls";
 import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
 import { getLocalAiToken } from "@/lib/local-ai-token";
@@ -208,6 +210,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockRestartGateway.mockResolvedValue();
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+    vi.mocked(runOpenclawConfigSetBatch).mockResolvedValue(undefined);
     mockUnpairLocal.mockResolvedValue(undefined);
 
     // Re-apply implementations cleared by vi.clearAllMocks above. Factory
@@ -307,7 +310,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary openai/gpt-5");
   });
 
@@ -340,8 +343,8 @@ describe("POST /setup-api/ai-models/configure", () => {
       }),
     );
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.deepseek");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.deepseek");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
     expect(providerDef.apiKey).toBe("portal-token-123");
     expect(providerDef.baseUrl).toBe("https://clawbox.com/api/ai");
     expect(providerDef.models[0].compat.supportedReasoningEfforts).toEqual(["off", "high", "xhigh"]);
@@ -437,7 +440,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     // the flat 24000 default — a 24000 floor leaves too little usable input for
     // the agent's system prompt + tools, so every turn overflows before the
     // model runs.
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.compaction.reserveTokensFloor 8192");
   });
 
@@ -450,7 +453,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
     expect(commands).toContain("config set agents.defaults.compaction.reserveTokensFloor 24000");
     expect(commands).toContain("config set gateway.auth.mode token");
@@ -479,9 +482,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     const res = await configurePost(jsonRequest({ provider: "llamacpp" }));
     expect(res.status).toBe(200);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map(
-      (call) => ["config", "set", ...(call[0] ?? [])].join(" "),
-    );
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set gateway.auth.mode token");
     expect(commands.some((command) =>
       command.startsWith("config set gateway.auth.token "),
@@ -505,7 +506,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       }),
     );
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
     expect(commands).not.toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
     expect(commands).toContain("config set models.mode merge");
@@ -526,7 +527,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).not.toContain("config set agents.defaults.model.primary llamacpp/gemma4-e2b-it-q4_0");
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
     expect(commands).toContain("config set models.mode merge");
@@ -549,7 +550,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.5");
   });
 
@@ -569,7 +570,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
 
     expect(res.status).toBe(200);
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.6-sol");
   });
 
@@ -588,7 +589,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
 
     expect(res.status).toBe(200);
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.5");
   });
 
@@ -609,7 +610,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
 
     expect(res.status).toBe(200);
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary codex/gpt-5.4-mini");
     const probedCodex = fetchMock.mock.calls.some(([url]) => String(url).includes("backend-api/codex/responses"));
     expect(probedCodex).toBe(false);
@@ -642,7 +643,10 @@ describe("POST /setup-api/ai-models/configure", () => {
   });
 
   it("returns 500 when spawn command fails", async () => {
+    // Both forms: the route sends most of its writes as one batch, so stubbing
+    // only the single-set form would leave the failure it is testing unreached.
     vi.mocked(runOpenclawConfigSet).mockRejectedValue(new Error("Command failed"));
+    vi.mocked(runOpenclawConfigSetBatch).mockRejectedValue(new Error("Command failed"));
 
     const res = await configurePost(jsonRequest({
       provider: "anthropic",
@@ -722,7 +726,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-test",
     }));
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["deepseek/deepseek-v4-flash"] --json');
     expect(commands.some((command) => command.includes("config set models.providers.deepseek"))).toBe(true);
 
@@ -747,7 +751,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-openai-key",
     }));
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
     expect(commands.some((command) => command.includes("config set models.providers.deepseek"))).toBe(false);
   });
@@ -763,7 +767,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-openai-key",
     }));
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
   });
 
@@ -781,7 +785,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "sk-openai-key",
     }));
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).not.toContain('config set agents.defaults.model.fallbacks ["llamacpp/gemma4-e2b-it-q4_0"] --json');
   });
 
@@ -798,8 +802,8 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.deepseek");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.deepseek");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
 
     expect(providerDef.baseUrl).toBe("https://clawbox.com/api/ai");
     expect(providerDef.apiKey).toBe("stored-portal-token");
@@ -820,12 +824,12 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "gemma-q4",
     }));
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands.some((command) => command.includes("config set models.providers.llamacpp"))).toBe(true);
     expect(commands).toContain("config set agents.defaults.model.primary llamacpp/gemma-q4");
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.llamacpp");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.llamacpp");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
     const modelDef = providerDef?.models?.[0] ?? {};
 
     expect(providerDef.baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
@@ -839,8 +843,8 @@ describe("POST /setup-api/ai-models/configure", () => {
       apiKey: "llama3.2:3b",
     }));
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.ollama");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.ollama");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
 
     expect(providerDef.baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/ollama");
   });
@@ -859,12 +863,12 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(res.status).toBe(200);
     expect(body.success).toBe(true);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands.some((command) => command.includes("config set models.providers.openrouter"))).toBe(true);
     expect(commands).toContain("config set agents.defaults.model.primary openrouter/anthropic/claude-haiku-4.5");
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.openrouter");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.openrouter");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
 
     expect(providerDef.baseUrl).toBe("https://openrouter.ai/api/v1");
     expect(providerDef.api).toBe("openai-completions");
@@ -900,7 +904,7 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     expect(res.status).toBe(200);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary openrouter/mistralai/mistral-large");
   });
 
@@ -926,12 +930,12 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
     expect(res.status).toBe(200);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands.some((command) => command.includes("config set models.providers.google"))).toBe(true);
     expect(commands).toContain("config set agents.defaults.model.primary google/gemini-2.5-flash");
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.google");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.google");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
     expect(providerDef.baseUrl).toBe("https://generativelanguage.googleapis.com/v1beta/openai");
     expect(providerDef.api).toBe("openai-completions");
     // Real key inlined (the fix) — not delegated to the native plugin.
@@ -958,12 +962,12 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
     expect(res.status).toBe(200);
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands.some((command) => command.includes("config set models.providers.anthropic"))).toBe(true);
     expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-sonnet-4-6");
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.anthropic");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.anthropic");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
     expect(providerDef.baseUrl).toBe("https://api.anthropic.com/v1");
     expect(providerDef.api).toBe("openai-completions");
     expect(providerDef.apiKey).toBe("sk-ant-test123");
@@ -986,12 +990,12 @@ describe("POST /setup-api/ai-models/configure", () => {
     }));
     expect(res.status).toBe(200);
 
-    const providerCall = vi.mocked(runOpenclawConfigSet).mock.calls.find((call) => call[0][0] === "models.providers.anthropic");
-    const providerDef = providerCall ? JSON.parse(providerCall[0][1] ?? "{}") : {};
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.anthropic");
+    const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
     const modelIds = providerDef.models?.map((m: { id: string }) => m.id) ?? [];
     expect(modelIds).toContain("claude-opus-4-8");
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-opus-4-8");
   });
 
@@ -1060,7 +1064,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(written.profiles["codex:default"]).toBeDefined();
     expect(written.profiles["google:default"]).toBeUndefined();
 
-    const commands = vi.mocked(runOpenclawConfigSet).mock.calls.map((call) => ["config", "set", ...(call[0] ?? [])].join(" "));
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands.some((c) => c.startsWith("config set agents.defaults.model.primary codex/"))).toBe(true);
   });
 
@@ -1242,9 +1246,11 @@ describe("POST /setup-api/ai-models/configure", () => {
       );
 
     const primaryModelWritten = () =>
-      vi.mocked(runOpenclawConfigSet).mock.calls
-        .map((call) => call[0] ?? [])
-        .find((args) => args[0] === "agents.defaults.model.primary")?.[1];
+      findConfigSet(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+        "agents.defaults.model.primary",
+      )?.value;
 
     it("configures the Max model when the portal says Max, even though the picker said Pro", async () => {
       vi.stubGlobal("fetch", deviceInfo({ tier: "max" }));
@@ -1377,6 +1383,132 @@ describe("POST /setup-api/ai-models/configure", () => {
       expect(res.status).toBe(200);
       expect(fetchMock.mock.calls.some(([url]) =>
         String(url).includes("/api/clawbox-ai/device-info"))).toBe(false);
+    });
+  });
+  // TASK-483: the last wizard step sat on "Almost ready" for about three
+  // minutes on a real box. It was not a spinner problem — the route issued
+  // roughly EIGHTEEN separate `openclaw config set` processes, and on a Jetson
+  // Orin Nano the CLI costs ~8 s of Node start-up per invocation before it does
+  // any work at all. Two things made it eighteen: every key was its own
+  // process, and the ClawBox AI path provisioned ClawBox AI TWICE, because
+  // ensureFallbackModel called configureClawboxAi again purely to write
+  // `agents.defaults.model.fallbacks`.
+  //
+  // These tests pin both halves. They are deliberately about the number of
+  // PROCESSES and the number of times a path is written, not about wall clock,
+  // because those are the two things that regressed and the only two a unit
+  // test can hold.
+  describe("how many openclaw processes first-run setup costs", () => {
+    function invocationCount(): number {
+      return (
+        vi.mocked(runOpenclawConfigSet).mock.calls.length +
+        vi.mocked(runOpenclawConfigSetBatch).mock.calls.length
+      );
+    }
+
+    it("connects ClawBox AI in at most two CLI invocations", async () => {
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_token_abc",
+      }));
+
+      expect(res.status).toBe(200);
+      expect(invocationCount()).toBeLessThanOrEqual(2);
+    });
+
+    it("still writes every key the old sequence wrote", async () => {
+      await configurePost(jsonRequest({ provider: "clawai", apiKey: "claw_token_abc" }));
+
+      const paths = configSetCalls(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+      ).map((call) => call.path);
+
+      for (const expected of [
+        "auth.profiles.deepseek:default",
+        "agents.defaults.model.primary",
+        "agents.defaults.compaction.reserveTokensFloor",
+        "gateway.auth.mode",
+        "gateway.auth.token",
+        "gateway.controlUi.allowInsecureAuth",
+        "gateway.controlUi.dangerouslyDisableDeviceAuth",
+        "models.providers.deepseek",
+        "models.mode",
+        "agents.defaults.imageModel",
+        "models.providers.openai.apiKey",
+        "models.providers.openai.models",
+        "agents.defaults.imageGenerationModel",
+        "agents.defaults.model.fallbacks",
+      ]) {
+        expect(paths).toContain(expected);
+      }
+    });
+
+    it("provisions ClawBox AI once, not twice", async () => {
+      await configurePost(jsonRequest({ provider: "clawai", apiKey: "claw_token_abc" }));
+
+      const paths = configSetCalls(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+      ).map((call) => call.path);
+
+      // The expensive ones. Each of these used to be written twice.
+      expect(paths.filter((p) => p === "models.providers.deepseek")).toHaveLength(1);
+      expect(paths.filter((p) => p === "models.providers.openai.apiKey")).toHaveLength(1);
+      expect(paths.filter((p) => p === "agents.defaults.imageGenerationModel")).toHaveLength(1);
+      // Two, not one: the generic auth-profile step and the ClawBox AI step
+      // both name this path, with the same value. That overlap predates this
+      // change (it used to make three) and removing it is a different edit.
+      expect(paths.filter((p) => p === "auth.profiles.deepseek:default")).toHaveLength(2);
+    });
+
+    it("takes the local model as the fallback without a second ClawBox AI pass", async () => {
+      // The other branch of the same decision: when the box already has a local
+      // model, the fallback slot names it instead of ClawBox AI — and that has
+      // to be decided BEFORE the batch, or we are back to two passes.
+      mockGetAll.mockResolvedValue({
+        local_ai_configured: true,
+        local_ai_model: "ollama/llama3.2:3b",
+      });
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_token_abc",
+      }));
+
+      expect(res.status).toBe(200);
+      const calls = configSetCalls(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+      );
+      expect(calls.find((c) => c.path === "agents.defaults.model.fallbacks")?.value)
+        .toBe(JSON.stringify(["ollama/llama3.2:3b"]));
+      expect(calls.filter((c) => c.path === "models.providers.deepseek")).toHaveLength(1);
+      expect(invocationCount()).toBeLessThanOrEqual(2);
+    });
+
+    it("does not fail the connect when only the fallback write fails", async () => {
+      // The fallback used to be written inside ensureFallbackModel's try/catch,
+      // so it could never fail the request. Batching it alongside the required
+      // writes must not quietly promote it to fatal.
+      failConfigSetsMatching(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+        (path) => path === "agents.defaults.model.fallbacks",
+        () => new Error("fallback write exploded"),
+      );
+
+      const res = await configurePost(jsonRequest({
+        provider: "clawai",
+        apiKey: "claw_token_abc",
+      }));
+
+      expect(res.status).toBe(200);
+      const paths = configSetCalls(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+      ).map((call) => call.path);
+      expect(paths).toContain("models.providers.deepseek");
     });
   });
 });

--- a/src/tests/unit/openclaw-config-secret-logging.test.ts
+++ b/src/tests/unit/openclaw-config-secret-logging.test.ts
@@ -156,3 +156,177 @@ describe("runOpenclawConfigSet error messages", () => {
     );
   });
 });
+
+describe("configSetBatchLabelArgs", () => {
+  // Batch mode puts every value in ONE argv element, so the eliding
+  // configSetLabelArgs does per-argument has to be redone for the payload as a
+  // whole — otherwise batching first-run setup would take the portal token, the
+  // provider API key and the gateway token that were previously kept out of the
+  // journal and write all three into a single error message.
+  it("names every path and carries no value at all", () => {
+    const label = openclawConfig.configSetBatchLabelArgs([
+      ["models.providers.openai.apiKey", TOKEN],
+      ["agents.defaults.model.primary", "deepseek/deepseek-v4-pro"],
+      ["models.providers.openai.models", '[{"id":"x"}]', "--json"],
+    ]);
+
+    expect(label.slice(0, 3)).toEqual(["config", "set", "--batch-json"]);
+    expect(label.join(" ")).not.toContain(TOKEN);
+    expect(label.join(" ")).not.toContain("deepseek/deepseek-v4-pro");
+    expect(label[3]).toContain("models.providers.openai.apiKey=<redacted>");
+    expect(label[3]).toContain("agents.defaults.model.primary=<redacted>");
+    expect(label[3]).toContain("models.providers.openai.models=<redacted>");
+  });
+
+  it("survives an entry with no path rather than mislabelling one", () => {
+    expect(openclawConfig.configSetBatchLabelArgs([["--json"]])[3]).toBe("[<no path>=<redacted>]");
+  });
+});
+
+describe("runOpenclawConfigSetBatch", () => {
+  const BATCH: string[][] = [
+    ["models.providers.openai.apiKey", TOKEN],
+    ["agents.defaults.compaction.reserveTokensFloor", "24000"],
+    ["gateway.controlUi.allowInsecureAuth", "true", "--json"],
+  ];
+
+  it("writes every assignment in ONE spawn, typed the way the CLI would type them", async () => {
+    // The whole point: N keys for one CLI cold start. `--json` values are
+    // parsed as JSON; a bare value is parsed if it can be (so "24000" is the
+    // number 24000, exactly as `openclaw config set` stores it) and left as a
+    // string when it cannot be.
+    mockSpawn.mockImplementation(() => silentChild(0));
+
+    await openclawConfig.runOpenclawConfigSetBatch(BATCH);
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    const argv = mockSpawn.mock.calls[0][1] as string[];
+    expect(argv.slice(0, 3)).toEqual(["config", "set", "--batch-json"]);
+    expect(JSON.parse(argv[3])).toEqual([
+      { path: "models.providers.openai.apiKey", value: TOKEN },
+      { path: "agents.defaults.compaction.reserveTokensFloor", value: 24000 },
+      { path: "gateway.controlUi.allowInsecureAuth", value: true },
+    ]);
+  });
+
+  it("does not put any value in the timeout message", async () => {
+    mockSpawn.mockImplementation(() => hangingChild());
+
+    const err = await openclawConfig
+      .runOpenclawConfigSetBatch(BATCH, { timeoutMs: 1 })
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).not.toContain(TOKEN);
+    expect(err!.message).toContain("models.providers.openai.apiKey=<redacted>");
+    expect(err!.message).toContain("timed out");
+  });
+
+  it("does not put any value in the message for a failure that wrote no output", async () => {
+    mockSpawn.mockImplementation(() => silentChild(1));
+
+    const err = await openclawConfig
+      .runOpenclawConfigSetBatch(BATCH)
+      .then(() => null)
+      .catch((e: Error) => e);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).not.toContain(TOKEN);
+    expect(err!.message).toContain("exited with code 1");
+  });
+
+  it("spawns nothing at all for an empty batch", async () => {
+    mockSpawn.mockImplementation(() => silentChild(0));
+
+    await openclawConfig.runOpenclawConfigSetBatch([]);
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it("sends a single assignment the plain way — there is nothing to batch", async () => {
+    mockSpawn.mockImplementation(() => silentChild(0));
+
+    await openclawConfig.runOpenclawConfigSetBatch([["gateway.auth.mode", "token"]]);
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.any(String),
+      ["config", "set", "gateway.auth.mode", "token"],
+      expect.any(Object),
+    );
+  });
+
+  it("retries the whole batch on a config-mutation conflict", async () => {
+    // Same race the single form survives: the gateway touches the config while
+    // we write. A batch is one read-modify-write, so the retry re-reads the
+    // fresh hash and converges exactly as a single set does.
+    let attempts = 0;
+    mockSpawn.mockImplementation(() => {
+      attempts += 1;
+      const child = hangingChild();
+      queueMicrotask(() => {
+        if (attempts === 1) {
+          child.stderr!.emit("data", Buffer.from("ConfigMutationConflictError: config changed"));
+          child.emit("close", 1);
+        } else {
+          child.emit("close", 0);
+        }
+      });
+      return child;
+    });
+
+    await openclawConfig.runOpenclawConfigSetBatch(BATCH, { baseBackoffMs: 0 });
+
+    expect(attempts).toBe(2);
+  });
+
+  it("does not retry a failure that repeating cannot fix", async () => {
+    let attempts = 0;
+    mockSpawn.mockImplementation(() => {
+      attempts += 1;
+      const child = hangingChild();
+      queueMicrotask(() => {
+        child.stderr!.emit("data", Buffer.from("Config validation failed: bad value"));
+        child.emit("close", 1);
+      });
+      return child;
+    });
+
+    await expect(
+      openclawConfig.runOpenclawConfigSetBatch(BATCH, { baseBackoffMs: 0 }),
+    ).rejects.toThrow(/Config validation failed/);
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("parseConfigSetArgs", () => {
+  // These have to match the CLI's own two value modes or a batched write would
+  // store a different config than the same sequence of single writes did.
+  it("parses a --json value as JSON", () => {
+    expect(openclawConfig.parseConfigSetArgs(["a.b", '{"primary":"x"}', "--json"])).toEqual({
+      path: "a.b",
+      value: { primary: "x" },
+    });
+  });
+
+  it("falls back to the raw string when a bare value is not JSON", () => {
+    expect(openclawConfig.parseConfigSetArgs(["agents.defaults.model.primary", "deepseek/deepseek-v4-pro"]))
+      .toEqual({ path: "agents.defaults.model.primary", value: "deepseek/deepseek-v4-pro" });
+    expect(openclawConfig.parseConfigSetArgs(["gateway.auth.mode", "token"]))
+      .toEqual({ path: "gateway.auth.mode", value: "token" });
+  });
+
+  it("types a bare numeric value as a number, as the CLI does", () => {
+    expect(openclawConfig.parseConfigSetArgs(["agents.defaults.compaction.reserveTokensFloor", "24000"]))
+      .toEqual({ path: "agents.defaults.compaction.reserveTokensFloor", value: 24000 });
+  });
+
+  it("refuses an entry with no value rather than writing undefined", () => {
+    expect(() => openclawConfig.parseConfigSetArgs(["a.b"])).toThrow(/missing a value/);
+    expect(() => openclawConfig.parseConfigSetArgs([])).toThrow(/missing a path/);
+  });
+
+  it("rejects a --json value that is not JSON instead of storing the text", () => {
+    expect(() => openclawConfig.parseConfigSetArgs(["a.b", "not json", "--json"])).toThrow();
+  });
+});


### PR DESCRIPTION
## What a customer saw

The last wizard step showed **"Almost ready"** and **"Please don't close this page"**, and then nothing visible happened for about three minutes. On a brand new box, the most likely reaction to three silent minutes is to reload or power-cycle — exactly what that screen is asking them not to do.

## What it actually was

Not a spinner problem. Timed on `.65` through the real customer control (Settings → AI Provider → API Key → Connect, the same component and the same `/setup-api/ai-models/configure` route the wizard's last step uses), re-saving the box's own token so nothing changed:

```
run 1: 143.7 s        run 2: 147.3 s
```

Sampling `/proc/*/cmdline` at 100 ms caught the cause: **~18 `openclaw config set` processes, strictly sequential**, one starting every ~8.4 s, each alive ~7.0–7.8 s, back to back, with no gaps.

The cost is not the work. It is the CLI paying its own start-up — it loads the whole gateway SDK, parses plugins and validates the config schema on every invocation. On an idle Orin `openclaw --version` is 0.055 s but `openclaw config get <one path>` is 2.70 s, and under this route's load that grows to ~7.8 s. We were spending ~140 seconds of Node start-up to write ~18 config keys.

`src/lib/openclaw-config.ts` already documented that per-call cost ("on a NVIDIA Jetson Orin Nano this startup cost alone is 10-12 s per call") and used it only to size a timeout. Nobody multiplied it by the number of writes.

## The fix

**1. One process for N keys.** `runOpenclawConfigSetBatch` issues a single `openclaw config set --batch-json`. The CLI applies the entries in order against one snapshot, runs the same non-destructive-replacement guard per entry, and writes once — the same semantics as N sequential `config set --json` calls, for one start-up instead of N. Measured on `.65` with the same 8 paths: **8 sequential = 62.8 s, 1 batched = 7.9 s.**

**2. Batching without merging error boundaries.** This route deliberately treats some writes as fatal and others as not — a chat provider that works is worth more than an image tool, so failing to provision images must never fail "Connect ClawBox AI". A batch is atomic, so one combined call would make every failure fatal to everything. `applyConfigSetGroups` tries the combined call, and **only if it fails** re-issues each group on its own, which is exactly the old one-boundary-per-group behaviour. A failed batch wrote nothing, so re-applying group by group is safe; the slow path costs one extra invocation per group and is only reached when something is already wrong.

**3. ClawBox AI was provisioned twice.** The branch called `configureClawboxAi()`, then `ensureFallbackModel()`, which — with no local model to fall back to, the normal case — called `configureClawboxAi()` **again** purely to write `agents.defaults.model.fallbacks`. Every write in it paid the cold start twice. The fallback is now decided first (`pickLocalFallbackModel`) and folded into the same batch. Both fallback outcomes keep the fatality they had inside `ensureFallbackModel` (local = fatal, ClawBox AI = warn only) — inherited, not chosen, and batching must not change it silently.

**4. Decide first, write once.** Every conditional in the ClawBox AI path now reads one config snapshot taken before the writes. That is safe by construction: each of those decisions is about what the owner had *before* this request started (do they already name a vision model? an image model? a foreign `openai` key?), and nothing written in this pass changes the answer.

**5. The token must not follow the values into the journal.** `configSetLabelArgs` elides values per argument, but batch mode puts every value inside a *single* argv element — so the portal token, the provider API key and the gateway token would all have ridden into one error message (CWE-532). `configSetBatchLabelArgs` names the paths and carries no value at all. That is the first thing the new tests pin.

**6. The overlay stopped lying.** `CONFIGURING_STEP_DELAYS = [0, 2000, 5000, 12000, 22000]` drove all five rows off wall-clock timers, so "Almost ready" was reached at **22 seconds** and then sat unchanged for the remaining ~125 s. The last row now belongs to the request, not the stopwatch.

## Tests

- `configSetBatchLabelArgs` carries no value; `runOpenclawConfigSetBatch` keeps the token out of both its timeout message and its exit-code message.
- `parseConfigSetArgs` reproduces the CLI's two value modes exactly — `--json` parses as JSON, a bare `"24000"` becomes the number 24000, a bare `"deepseek/deepseek-v4-pro"` stays a string — because a batched write has to store the same config a sequence of single writes did.
- Batch retries the whole payload on `ConfigMutationConflictError` and does **not** retry a schema rejection; an empty batch spawns nothing; a single-entry batch goes out the plain way.
- Route: connecting ClawBox AI now costs **at most two** CLI invocations, still writes every key the old sequence wrote, and writes `models.providers.deepseek` / `models.providers.openai.apiKey` / `agents.defaults.imageGenerationModel` **once** rather than twice.
- Route: a failure that only hits `agents.defaults.model.fallbacks` still returns 200, and the provider is still configured — the boundary that batching could most easily have destroyed.
- Component: with the configure request held open, 60 s of fake timers leave "Warming up models" active and "Almost ready" **pending**; it only becomes done once the request resolves. Verified to fail without the fix.
- Existing suites keep asserting on the same assignments through a shared test view that flattens both the single and batched forms.

Full suite: **277 files / 3869 tests green.**

TASK-483

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI model setup now configures image, vision, chat, gateway, and local fallback options more efficiently.
  - Existing AI settings are preserved during setup, with improved fallback selection.

- **Bug Fixes**
  - Setup progress keeps “Almost ready” pending until configuration finishes.
  - Improved handling of partial failures, retries, and fallback configuration.
  - Sensitive information is protected in diagnostic messages.

- **Tests**
  - Expanded coverage for setup success, fallback behavior, retries, configuration failures, and progress states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->