### PR TITLE
The Local Models tab stops counting Ollama's memory twice (TASK-504)

### DIFF
--- a/src/lib/local-models.ts
+++ b/src/lib/local-models.ts
@@ -178,8 +178,27 @@ export async function readUnitState(unit: string, scope: "user" | "system"): Pro
   };
 }
 
-/** Resident bytes of every process whose command line matches `pattern`. */
-export async function processMemoryBytes(pattern: string): Promise<number | null> {
+/**
+ * Resident bytes of every process whose command line matches `pattern`, minus
+ * any whose command line also matches `exclude`.
+ *
+ * `pgrep -f` matches the WHOLE command line, which is looser than it looks:
+ * Ollama ships its own binary literally named `llama-server`
+ * (`/usr/local/lib/ollama/llama-server`), so the pattern that finds llama.cpp
+ * finds Ollama's too. Without `exclude`, a box running both engines reported
+ * Ollama's memory twice — once on its own row and once added to the Local LLM
+ * row, which on an 8 GB box turned a real 5.3 GB into a claimed 7.6 GB
+ * (TASK-504, measured on the upgraded box; the clean-install box runs only one
+ * engine and never showed it).
+ *
+ * The filter is negative rather than a positive match on the binary path
+ * because `LlamaCppLaunchSpec.binPath` is configurable, so a path this file
+ * hard-coded could drift out from under it.
+ */
+export async function processMemoryBytes(
+  pattern: string,
+  exclude?: RegExp,
+): Promise<number | null> {
   const out = await run("/usr/bin/pgrep", ["-f", pattern]);
   const pids = (out ?? "").split("\n").map(s => s.trim()).filter(Boolean);
   if (!pids.length) return null;
@@ -188,6 +207,12 @@ export async function processMemoryBytes(pattern: string): Promise<number | null
   for (const pid of pids) {
     if (!/^\d+$/.test(pid)) continue;
     try {
+      if (exclude) {
+        // NUL-separated argv; the separators only matter for not gluing
+        // arguments together, so a space is enough to match against.
+        const cmdline = (await fs.readFile(`/proc/${pid}/cmdline`, "utf8")).replace(/\0/g, " ");
+        if (exclude.test(cmdline)) continue;
+      }
       const status = await fs.readFile(`/proc/${pid}/status`, "utf8");
       const m = status.match(/^VmRSS:\s+(\d+) kB$/m);
       if (m) {
@@ -200,6 +225,12 @@ export async function processMemoryBytes(pattern: string): Promise<number | null
   }
   return sawAny ? total : null;
 }
+
+/**
+ * Ollama's bundled inference server, which shares a file name with llama.cpp's.
+ * Anything running out of an `ollama` directory belongs on the Ollama row.
+ */
+const OLLAMA_OWNED_PROCESS = /[/\\]ollama[/\\]/;
 
 async function ollamaModels(baseUrl: string): Promise<{ name: string; size: number }[] | null> {
   try {
@@ -345,7 +376,9 @@ interface LlamaCppProbe {
 }
 
 async function llamaCppEntry(probe: LlamaCppProbe): Promise<LocalModelEntry> {
-  const memoryBytes = probe.running ? await processMemoryBytes("llama-server") : null;
+  const memoryBytes = probe.running
+    ? await processMemoryBytes("llama-server", OLLAMA_OWNED_PROCESS)
+    : null;
   return {
     id: "llamacpp",
     name: probe.model ? `Local LLM (${probe.model})` : "Local LLM",

--- a/src/lib/local-models.ts
+++ b/src/lib/local-models.ts
@@ -230,7 +230,7 @@ export async function processMemoryBytes(
  * Ollama's bundled inference server, which shares a file name with llama.cpp's.
  * Anything running out of an `ollama` directory belongs on the Ollama row.
  */
-const OLLAMA_OWNED_PROCESS = /[/\\]ollama[/\\]/;
+export const OLLAMA_OWNED_PROCESS = /[/\\]ollama[/\\]/;
 
 async function ollamaModels(baseUrl: string): Promise<{ name: string; size: number }[] | null> {
   try {

--- a/src/tests/unit/local-models-memory.test.ts
+++ b/src/tests/unit/local-models-memory.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-504 — whose memory is it?
+ *
+ * `processMemoryBytes` finds processes with `pgrep -f`, which matches the whole
+ * command line. Ollama ships its own inference server literally named
+ * `llama-server`, so the pattern that finds llama.cpp finds Ollama's too, and a
+ * box running both engines showed Ollama's memory twice: once on the Ollama row
+ * and once added to the Local LLM row. On the 8 GB box where this was measured
+ * that turned a real 5.3 GB into a claimed 7.6 GB.
+ *
+ * The numbers below are the ones measured on 192.168.50.177 on 2026-08-23.
+ */
+
+let pgrepStdout = "";
+
+vi.mock("child_process", () => ({
+  execFile: (
+    _cmd: string,
+    _args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, res: { stdout: string; stderr: string }) => void,
+  ) => cb(null, { stdout: pgrepStdout, stderr: "" }),
+}));
+
+const PROC: Record<string, string> = {
+  // llama.cpp's own server — the Local LLM row's process.
+  "/proc/29942/cmdline": "/usr/local/bin/llama-server\u0000--host\u0000127.0.0.1\u0000--port\u00008080\u0000",
+  "/proc/29942/status": "Name:\tllama-server\nVmRSS:\t2682652 kB\n",
+  // Ollama's bundled server, same file name, different directory.
+  "/proc/30519/cmdline": "/usr/local/lib/ollama/llama-server\u0000--model\u0000/usr/share/ollama/blob\u0000",
+  "/proc/30519/status": "Name:\tllama-server\nVmRSS:\t2592936 kB\n",
+  // A shell that merely mentions the name, which `pgrep -f` also matches.
+  "/proc/30821/cmdline": "bash\u0000-c\u0000pgrep -af llama-server\u0000",
+  "/proc/30821/status": "Name:\tbash\nVmRSS:\t2600 kB\n",
+};
+
+vi.mock("fs", () => ({
+  promises: {
+    readFile: vi.fn(async (p: string) => {
+      if (p in PROC) return PROC[p];
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    }),
+    readdir: vi.fn(async () => []),
+    stat: vi.fn(async () => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); }),
+    access: vi.fn(async () => { throw Object.assign(new Error("ENOENT"), { code: "ENOENT" }); }),
+  },
+}));
+
+let processMemoryBytes: typeof import("@/lib/local-models")["processMemoryBytes"];
+
+beforeEach(async () => {
+  vi.resetModules();
+  ({ processMemoryBytes } = await import("@/lib/local-models"));
+});
+
+const MB = 1024;
+
+describe("processMemoryBytes", () => {
+  it("sums every match when nothing is excluded", async () => {
+    pgrepStdout = "29942\n30519\n30821\n";
+
+    expect(await processMemoryBytes("llama-server")).toBe(
+      (2682652 + 2592936 + 2600) * MB,
+    );
+  });
+
+  it("leaves Ollama's server out of the llama.cpp total", async () => {
+    // The defect: without this filter the Local LLM row reported 5.0 GB for a
+    // process using 2.68 GB, and the missing 2.54 GB was Ollama's — already
+    // reported on its own row.
+    pgrepStdout = "29942\n30519\n30821\n";
+
+    expect(await processMemoryBytes("llama-server", /[/\\]ollama[/\\]/)).toBe(
+      (2682652 + 2600) * MB,
+    );
+  });
+
+  it("returns null when nothing matched at all", async () => {
+    pgrepStdout = "";
+
+    expect(await processMemoryBytes("llama-server")).toBeNull();
+  });
+
+  it("returns null when every match was excluded", async () => {
+    // Not zero: "no llama.cpp process" and "a llama.cpp process using no
+    // memory" are different claims, and the row renders the second one.
+    pgrepStdout = "30519\n";
+
+    expect(await processMemoryBytes("llama-server", /[/\\]ollama[/\\]/)).toBeNull();
+  });
+
+  it("skips a process whose files vanished mid-read rather than failing the row", async () => {
+    pgrepStdout = "29942\n99999\n";
+
+    expect(await processMemoryBytes("llama-server", /[/\\]ollama[/\\]/)).toBe(2682652 * MB);
+  });
+});

--- a/src/tests/unit/local-models-memory.test.ts
+++ b/src/tests/unit/local-models-memory.test.ts
@@ -49,10 +49,12 @@ vi.mock("fs", () => ({
 }));
 
 let processMemoryBytes: typeof import("@/lib/local-models")["processMemoryBytes"];
+/** The real pattern the llama.cpp row passes, not a copy of it. */
+let OLLAMA_OWNED_PROCESS: RegExp;
 
 beforeEach(async () => {
   vi.resetModules();
-  ({ processMemoryBytes } = await import("@/lib/local-models"));
+  ({ processMemoryBytes, OLLAMA_OWNED_PROCESS } = await import("@/lib/local-models"));
 });
 
 const MB = 1024;
@@ -72,7 +74,7 @@ describe("processMemoryBytes", () => {
     // reported on its own row.
     pgrepStdout = "29942\n30519\n30821\n";
 
-    expect(await processMemoryBytes("llama-server", /[/\\]ollama[/\\]/)).toBe(
+    expect(await processMemoryBytes("llama-server", OLLAMA_OWNED_PROCESS)).toBe(
       (2682652 + 2600) * MB,
     );
   });
@@ -88,12 +90,12 @@ describe("processMemoryBytes", () => {
     // memory" are different claims, and the row renders the second one.
     pgrepStdout = "30519\n";
 
-    expect(await processMemoryBytes("llama-server", /[/\\]ollama[/\\]/)).toBeNull();
+    expect(await processMemoryBytes("llama-server", OLLAMA_OWNED_PROCESS)).toBeNull();
   });
 
   it("skips a process whose files vanished mid-read rather than failing the row", async () => {
     pgrepStdout = "29942\n99999\n";
 
-    expect(await processMemoryBytes("llama-server", /[/\\]ollama[/\\]/)).toBe(2682652 * MB);
+    expect(await processMemoryBytes("llama-server", OLLAMA_OWNED_PROCESS)).toBe(2682652 * MB);
   });
 });


### PR DESCRIPTION
Found by the V4 verification loop while re-checking TASK-465's reporting half on beta `ee0f6f8`. Not a v4 blocker.

## What the customer saw

On the **upgraded** box (`.177`), Settings → Local Models reported:

```
Local LLM (gemma4-e2b-it-q4_0)   Running   Memory in use 5.1 GB
Ollama                           Running   Memory in use 2.5 GB
```

That is **7.6 GB in use on an 8 GB box**. The real total was about 5.3 GB.

## What was actually true

Measured on `.177` the same minute:

| process | engine | RSS |
|---|---|---|
| `/usr/local/bin/llama-server --host 127.0.0.1 --port 8080 --alias gemma4-e2b-it-q4_0` | llama.cpp | 2.68 GB |
| `/usr/local/lib/ollama/llama-server --model …` | Ollama | 2.54 GB |
| `/usr/local/bin/ollama serve` | Ollama | 0.04 GB |

The Local LLM row was reporting llama.cpp's 2.68 GB **plus** Ollama's 2.54 GB, and that same 2.54 GB was then reported again on the Ollama row.

## Cause

`processMemoryBytes` resolves its pattern with `pgrep -f`, which matches the **whole command line**, and Ollama ships its own inference server *literally named* `llama-server`. So the pattern that finds llama.cpp finds Ollama's too.

`pgrep -f` is loose in the other direction as well — during the measurement it also matched the shell that was running `pgrep -af llama-server`.

## Fix

`processMemoryBytes` takes an optional exclusion matched against each pid's `/proc/<pid>/cmdline`, and the llama.cpp row passes `/[/\\]ollama[/\\]/`.

The filter is **negative** rather than a positive match on the llama.cpp binary path because `LlamaCppLaunchSpec.binPath` is configurable, so a path hard-coded in this file could drift out from under it.

One deliberate non-behaviour: when *every* match is excluded the result stays `null`, not `0`. "No llama.cpp process" and "a llama.cpp process using no memory" are different claims, and the row renders the second one.

## Why it survived earlier passes

It only appears where both engines run. That is the upgraded box; the clean-install box runs one engine and never reproduced it — the exact asymmetry the two-box rule exists to catch.

## Tests

New `src/tests/unit/local-models-memory.test.ts`, using the real numbers from `.177`: the unfiltered sum, the filtered sum (2.68 GB, not 5.0 GB), `null` when nothing matched, `null` — not zero — when everything matched but was excluded, and a pid whose `/proc` files vanish mid-read being skipped rather than failing the row.

Full suite: 278 files / 3875 tests green.

TASK-504

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local model memory reporting by excluding bundled Ollama server processes from llama.cpp memory totals.
  * Added handling for processes that disappear while being inspected, preventing inaccurate results or errors.

* **Tests**
  * Added coverage for matching, excluded, missing, and unavailable processes to verify accurate memory calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->