### PR TITLE
A hotspot switched off in the wizard stops coming back twenty seconds later (TASK-507)

### DIFF
--- a/scripts/ap-watchdog.sh
+++ b/scripts/ap-watchdog.sh
@@ -12,13 +12,22 @@
 # This watchdog (run every ~20s by clawbox-ap-watchdog.timer) brings the AP back
 # whenever it's down and setup isn't finished — UNLESS a deliberate WiFi handoff
 # is in progress, in which case the web server holds a lock while it owns the
-# radio to join the home network and we leave it alone.
+# radio to join the home network and we leave it alone, or UNLESS the owner has
+# switched the hotspot off (TASK-507).
+#
+# THE DIFFERENCE BETWEEN A DROP AND A DECISION is the whole job of this script.
+# Healing an AP that fell over is why it exists. Resurrecting one the owner
+# deliberately turned off is not healing, it is overruling — and it is how a box
+# came out of setup broadcasting an open, unpassworded network after its owner
+# had switched that network off and been told "Hotspot will not start
+# automatically."
 set -uo pipefail
 
 IFACE="${NETWORK_INTERFACE:-wlP1p1s0}"
 ROOT="${CLAWBOX_ROOT:-/home/clawbox/clawbox}"
 CONFIG_FILE="$ROOT/data/config.json"
 CONNECT_LOCK="$ROOT/data/wifi-connecting.lock"
+HOTSPOT_ENV="$ROOT/data/hotspot.env"
 START_AP="$ROOT/scripts/start-ap.sh"
 # A connect (with retries) + AP restore can legitimately take a couple of
 # minutes; ignore a lock older than this so a web-server crash mid-handoff can't
@@ -29,6 +38,29 @@ LOCK_MAX_AGE="${WIFI_CONNECT_LOCK_MAX_AGE:-180}"
 # don't fight it.
 if [ -f "$CONFIG_FILE" ] && grep -E -q '"setup_complete":[[:space:]]*true' "$CONFIG_FILE" 2>/dev/null; then
   exit 0
+fi
+
+# The owner switched the hotspot off. Do not bring it back.
+#
+# `HOTSPOT_DISABLED=1` is written by POST /setup-api/system/hotspot the moment
+# the switch is turned off, and that handler also stops the AP — successfully.
+# Twenty seconds later this watchdog used to undo it, because the only thing it
+# looked at was whether setup had finished, and at the Security step it has not:
+# the customer still has AI Provider and Telegram to go. start-ap.sh gates its
+# own HOTSPOT_DISABLED check behind `setup_complete = true` for the same reason,
+# so the flag was ignored on both sides of the loop and the AP came straight
+# back up. It then stayed up until the next reboot, when setup_complete was
+# finally true and start-ap.sh skipped correctly.
+#
+# Sourced rather than grepped so a quoted SSID with a `#` in it cannot be
+# misread, and in a subshell so a malformed file cannot take the watchdog's own
+# variables with it. Missing file, unset flag, or anything other than 1 all mean
+# "not disabled" — the failure direction that keeps a box reachable.
+if [ -f "$HOTSPOT_ENV" ]; then
+  hotspot_disabled="$( ( set +u; . "$HOTSPOT_ENV" >/dev/null 2>&1; printf '%s' "${HOTSPOT_DISABLED:-}" ) 2>/dev/null )"
+  if [ "$hotspot_disabled" = "1" ]; then
+    exit 0
+  fi
 fi
 
 # A deliberate client-connect owns the radio right now — leave it alone so we

--- a/src/tests/unit/ap-watchdog-honours-disable.test.ts
+++ b/src/tests/unit/ap-watchdog-honours-disable.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * TASK-507. A hotspot switched off in the setup wizard came back roughly twenty
+ * seconds later and stayed up until the next reboot.
+ *
+ * The route did its job: it wrote `HOTSPOT_DISABLED=1` and ran stop-ap.sh, and
+ * the AP went down. But `setup_complete` is still false at the Security step —
+ * the customer has AI Provider and Telegram to go — and this watchdog exited
+ * early ONLY on setup_complete. Seeing an idle radio and unfinished setup, it
+ * took its "the hotspot was torn down with nothing to bring it back" branch and
+ * started the AP again. start-ap.sh gates its own HOTSPOT_DISABLED check behind
+ * the same `setup_complete = true`, so the flag was ignored on both sides of the
+ * loop. Measured on a freshly flashed .65 (beta 97072ba): the box came out of
+ * setup broadcasting an open, unpassworded network its owner had switched off
+ * and been told would not start.
+ *
+ * These tests EXECUTE the shipped scripts/ap-watchdog.sh against a fake root and
+ * stubbed nmcli, and assert on whether it actually invoked start-ap.sh. Grepping
+ * the source would pass on a rewrite that kept the words and dropped the guard.
+ *
+ * The distinction under test is drop versus decision: healing an AP that fell
+ * over is the reason this watchdog exists, and it must keep doing that.
+ */
+
+const REPO = process.cwd();
+const WATCHDOG = path.join(REPO, "scripts", "ap-watchdog.sh");
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+let root: string;
+let bin: string;
+
+/** A fake CLAWBOX_ROOT plus a PATH of stubs, so nothing touches a real radio. */
+function makeBox(opts: {
+  setupComplete: boolean;
+  hotspotEnv?: string | null;
+  /** What `nmcli -t -f DEVICE,STATE device status` reports for the radio. */
+  radioState?: string;
+}) {
+  root = mkdtempSync(path.join(tmpdir(), "clawbox-ap-"));
+  bin = path.join(root, "bin");
+  mkdirSync(path.join(root, "data"), { recursive: true });
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  mkdirSync(bin, { recursive: true });
+
+  writeFileSync(
+    path.join(root, "data", "config.json"),
+    JSON.stringify({ setup_complete: opts.setupComplete })
+  );
+  if (opts.hotspotEnv !== null && opts.hotspotEnv !== undefined) {
+    writeFileSync(path.join(root, "data", "hotspot.env"), opts.hotspotEnv);
+  }
+
+  // start-ap.sh is replaced by a witness: if the watchdog calls it, a file
+  // appears. That is the whole assertion — "did it bring the AP back".
+  writeFileSync(
+    path.join(root, "scripts", "start-ap.sh"),
+    `#!/usr/bin/env bash\ntouch "${path.join(root, "STARTED")}"\n`,
+    { mode: 0o755 }
+  );
+
+  const state = opts.radioState ?? "disconnected";
+  writeFileSync(
+    path.join(bin, "nmcli"),
+    `#!/usr/bin/env bash\necho "wlP1p1s0:${state}"\n`,
+    { mode: 0o755 }
+  );
+}
+
+function runWatchdog(): { started: boolean; status: number | null } {
+  const res = spawnSync("bash", [WATCHDOG], {
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      CLAWBOX_ROOT: root,
+      NETWORK_INTERFACE: "wlP1p1s0",
+    },
+    encoding: "utf-8",
+  });
+  return { started: existsSync(path.join(root, "STARTED")), status: res.status };
+}
+
+afterEach(() => {
+  if (root) rmSync(root, { recursive: true, force: true });
+});
+
+describe.skipIf(!hasBash)("the AP watchdog tells a drop from a decision", () => {
+  it("does NOT resurrect a hotspot the owner switched off", () => {
+    // The exact state a box is in between the Security step and the end of the
+    // wizard: disabled on purpose, setup not finished, radio idle.
+    makeBox({
+      setupComplete: false,
+      hotspotEnv: "HOTSPOT_SSID='ClawBox-Setup'\nHOTSPOT_DISABLED=1\n",
+    });
+    expect(runWatchdog()).toMatchObject({ started: false, status: 0 });
+  });
+
+  it("still heals an AP that dropped on its own", () => {
+    // The reason this watchdog exists. ClawBox-Setup is autoconnect=no, so a
+    // driver hiccup or a stray `nmcli connection down` leaves the radio dark
+    // with nothing to bring it back, and mid-setup that is a box nobody can
+    // reach without a cable.
+    makeBox({
+      setupComplete: false,
+      hotspotEnv: "HOTSPOT_SSID='ClawBox-Setup'\n",
+    });
+    expect(runWatchdog().started).toBe(true);
+  });
+
+  it("heals when there is no hotspot.env at all", () => {
+    // A box that has never reached the Security step has no env file. Reading
+    // that absence as "disabled" would strand every customer who unboxes one.
+    makeBox({ setupComplete: false, hotspotEnv: null });
+    expect(runWatchdog().started).toBe(true);
+  });
+
+  it.each(["HOTSPOT_DISABLED=0", "HOTSPOT_DISABLED=", "HOTSPOT_DISABLED=true", "HOTSPOT_SSID='x #1'"])(
+    "treats %j as not-disabled and still heals",
+    (line) => {
+      // Only an explicit 1 means off. Every other shape — including an SSID
+      // with a '#' in it, which is why this is sourced rather than grepped —
+      // fails in the direction that keeps a box reachable.
+      makeBox({ setupComplete: false, hotspotEnv: `${line}\n` });
+      expect(runWatchdog().started).toBe(true);
+    }
+  );
+
+  it("does not fall over on a malformed env file", () => {
+    // A truncated or corrupt file must not take the watchdog's own variables
+    // with it, or a box loses its lifeline to a stray byte.
+    makeBox({ setupComplete: false, hotspotEnv: "HOTSPOT_SSID='unterminated\n" });
+    const r = runWatchdog();
+    expect(r.status).toBe(0);
+    expect(r.started).toBe(true);
+  });
+
+  it("keeps out of the way once setup is finished, disabled or not", () => {
+    // Post-setup the hotspot is owned by the normal flow; the watchdog has
+    // always stood down there and still must.
+    makeBox({ setupComplete: true, hotspotEnv: "HOTSPOT_DISABLED=1\n" });
+    expect(runWatchdog().started).toBe(false);
+    rmSync(root, { recursive: true, force: true });
+    makeBox({ setupComplete: true, hotspotEnv: "HOTSPOT_SSID='ClawBox-Setup'\n" });
+    expect(runWatchdog().started).toBe(false);
+  });
+
+  it("leaves a connected radio alone", () => {
+    // Either the AP is up (nothing to heal) or the box joined a network on
+    // purpose (the AP is meant to be down).
+    makeBox({ setupComplete: false, radioState: "connected" });
+    expect(runWatchdog().started).toBe(false);
+  });
+
+  it("stands down while a deliberate WiFi handoff owns the radio", () => {
+    makeBox({ setupComplete: false });
+    writeFileSync(path.join(root, "data", "wifi-connecting.lock"), "");
+    expect(runWatchdog().started).toBe(false);
+  });
+
+  it("reads the disable from the same file the route writes", () => {
+    // The route and the watchdog agreeing on one path is the guarantee here;
+    // two spellings of it is how this bug comes back.
+    const route = readFileSync(
+      path.join(REPO, "src", "app", "setup-api", "system", "hotspot", "route.ts"),
+      "utf-8"
+    );
+    expect(route).toContain('"hotspot.env"');
+    expect(route).toContain("HOTSPOT_DISABLED=1");
+    expect(readFileSync(WATCHDOG, "utf-8")).toContain('data/hotspot.env');
+  });
+});

--- a/src/tests/unit/ap-watchdog-honours-disable.test.ts
+++ b/src/tests/unit/ap-watchdog-honours-disable.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync, existsSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
@@ -30,6 +30,18 @@ import path from "node:path";
 const REPO = process.cwd();
 const WATCHDOG = path.join(REPO, "scripts", "ap-watchdog.sh");
 const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+// Unconditional, not skipIf. This file is the ONLY thing standing between a
+// customer and an open network they switched off, and a suite that quietly
+// skips itself on a runner without bash would report green while proving
+// nothing — which is the same shape of silence the fix itself is about.
+beforeAll(() => {
+  if (!hasBash) {
+    throw new Error(
+      "bash is required: these tests execute scripts/ap-watchdog.sh rather than reading it"
+    );
+  }
+});
 
 let root: string;
 let bin: string;
@@ -88,7 +100,7 @@ afterEach(() => {
   if (root) rmSync(root, { recursive: true, force: true });
 });
 
-describe.skipIf(!hasBash)("the AP watchdog tells a drop from a decision", () => {
+describe("the AP watchdog tells a drop from a decision", () => {
   it("does NOT resurrect a hotspot the owner switched off", () => {
     // The exact state a box is in between the Security step and the end of the
     // wizard: disabled on purpose, setup not finished, radio idle.


### PR DESCRIPTION
Found by walking the setup wizard as a customer on a **freshly flashed `.65`** (beta `97072ba`), during the clean-install pass.

## What a customer does

Turn the hotspot **off** at the Security step. The box answers *"Hotspot will not start automatically."*, saves, and moves on.

## What actually happens

The box finishes setup with the open, unpassworded `ClawBox-Setup` network **still broadcasting**, and keeps broadcasting it until the next reboot. Nothing tells the owner.

Measured on `.65` the moment the wizard completed:

| | |
|---|---|
| `data/config.json` | `hotspot_enabled: false` |
| `data/hotspot.env` | `HOTSPOT_DISABLED=1` |
| UI | "Hotspot will not start automatically." |
| `nmcli con show --active` | `ClawBox-Setup:wlP1p1s0:activated` ← **broadcasting** |

## The route is not at fault

`POST /setup-api/system/hotspot` writes the flag and runs `stop-ap.sh`, and the AP genuinely goes down — I ran the same script by hand as the same user afterwards and it took the AP down cleanly, exit 0.

**This watchdog undid it.** `setup_complete` is still `false` at the Security step (AI Provider and Telegram still to go), and the only early exit here was on `setup_complete`. Seeing unfinished setup and an idle radio, it took its *"the hotspot was torn down with nothing to bring it back"* branch and started the AP again — every twenty seconds, for the rest of setup. `start-ap.sh` gates its own `HOTSPOT_DISABLED` check behind the same `setup_complete = true`, so the flag was ignored on **both** sides of the loop.

After a reboot the behaviour is correct: `setup_complete` is true by then and `start-ap.sh` skips. So the window is "from the Security step until the next reboot" — which for a customer who never reboots is forever.

## Why this is not cosmetic

- **Security.** An open Wi-Fi network with no password stays live on a box whose owner explicitly turned it off, in radio range of anyone, fronting the box's own web surface.
- **Trust.** The box states in plain words that it will not do a thing, and then does it.
- It affects **every clean install**, because the wizard is the only place a new owner meets this switch.

## The fix

The distinction this adds is **a drop versus a decision**. Healing an AP that fell over is why the watchdog exists and it still does exactly that — `ClawBox-Setup` is `autoconnect=no`, so a driver hiccup or a stray `nmcli connection down` leaves the radio dark mid-setup with nothing to bring it back. Resurrecting one the owner deliberately switched off is not healing, it is overruling.

The flag is **sourced in a subshell**, not grepped: an SSID containing a `#` would defeat a grep, and a malformed file must not take the watchdog's own variables with it. Missing file, unset value, and anything that is not exactly `1` all mean "not disabled" — the failure direction that keeps a box reachable.

**Not changed, deliberately:** `start-ap.sh`'s own gate. Any path that explicitly restarts `clawbox-ap` during setup will still bring the AP up, and the notable one is WiFi-connect failure recovery — where the AP is a customer's only way back to a box they joined over WiFi. Narrowing that is a product call, not a defect fix.

## Tests

12 new tests **execute** the shipped `scripts/ap-watchdog.sh` against a fake root and a stubbed `nmcli`, asserting whether `start-ap.sh` was actually invoked. They **fail against the script as it was** (2 failures) and pass against this one — grepping the source would have passed on a rewrite that kept the words and dropped the guard.

280 files / 3950 tests green.

Board: TASK-507 under TASK-379.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled hotspots are no longer restored during watchdog recovery when explicitly turned off.
  * Hotspot recovery continues to work for missing, dropped, or otherwise recoverable hotspot states.
  * Existing behavior remains unchanged for completed setup, connected radios, handoff locks, malformed settings, and other configuration values.

* **Tests**
  * Added coverage for disabled-hotspot handling and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->