### PR TITLE
The Coding Agent stops asking whether you trust your own box (TASK-509)

### DIFF
--- a/scripts/claude-ds
+++ b/scripts/claude-ds
@@ -141,6 +141,76 @@ export CLAUDE_CODE_EFFORT_LEVEL="${CLAUDE_DS_EFFORT:-max}"
 mkdir -p "$CLAUDE_CONFIG_DIR"
 chmod 700 "$CLAUDE_CONFIG_DIR" 2>/dev/null || true
 
+# PRE-ANSWER THE TRUST QUESTION, FOR THE BOX'S OWN HOME AND NOTHING ELSE.
+#
+# Claude Code asks "is this a project you created or one you trust?" before it
+# will read a folder, and never remembers the answer for $HOME: the flag it
+# writes, projects[<dir>].hasTrustDialogAccepted, stays false there across
+# clean exits that do record lastCost and lastSessionId. So the Coding Agent
+# app — which always opens in the owner's home — asked it on EVERY launch.
+#
+# On this appliance that question has no second answer. The folder is the
+# box's own home, behind the device login, and the dialog's other option is
+# "exit". A security prompt whose only real answer is "yes", shown every single
+# time, does not protect anybody; it teaches the owner to click through
+# prompts without reading them, which is worse than not asking.
+#
+# It is pre-answered ONLY when the harness is starting in that home directory.
+# Somebody who clones a repo and runs `claude-ds` inside it is asked, exactly
+# as before — that is the case the dialog is actually for.
+#
+# Claude Code documents this key as the supported alternative to answering
+# interactively ("accept the trust dialog here once interactively, or set
+# projects[...].hasTrustDialogAccepted in <config>").
+seed_home_trust() {
+  python3 - "$CLAUDE_CONFIG_DIR/.claude.json" "$HOME" <<'PYEOF' || true
+import json, os, sys, tempfile
+
+cfg_path, home = sys.argv[1], sys.argv[2]
+try:
+    with open(cfg_path) as fh:
+        cfg = json.load(fh)
+    if not isinstance(cfg, dict):
+        raise ValueError("not an object")
+except FileNotFoundError:
+    cfg = {}
+except Exception:
+    # A config we cannot parse is Claude Code's to repair, not ours to
+    # overwrite — losing an owner's MCP servers to save them one keypress
+    # would be a bad trade.
+    raise SystemExit(0)
+
+projects = cfg.setdefault("projects", {})
+if not isinstance(projects, dict):
+    raise SystemExit(0)
+entry = projects.setdefault(home, {})
+if not isinstance(entry, dict):
+    raise SystemExit(0)
+if entry.get("hasTrustDialogAccepted") is True:
+    raise SystemExit(0)          # already set; leave the file alone
+entry["hasTrustDialogAccepted"] = True
+
+# Written through a temp file in the same directory and renamed, so a crash
+# mid-write cannot leave Claude Code with half a config.
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(cfg_path) or ".")
+try:
+    with os.fdopen(fd, "w") as fh:
+        json.dump(cfg, fh)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, cfg_path)
+except Exception:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    raise SystemExit(0)
+PYEOF
+}
+
+if [ "$PWD" = "$HOME" ]; then
+  seed_home_trust
+fi
+
 # Say which model is actually about to answer. "Chosen vs actually used" is the
 # question this banner exists to close: the plan, not the wrapper, picks it.
 printf 'claude-ds: ClawBox AI (%s) — state in %s\n' "$MODEL" "$CLAUDE_CONFIG_DIR" >&2

--- a/src/tests/unit/claude-ds-wrapper.test.ts
+++ b/src/tests/unit/claude-ds-wrapper.test.ts
@@ -348,24 +348,41 @@ describe("the trust dialog", () => {
     expect(readFileSync(claudeConfig(), "utf-8")).toBe("{ not json at all");
   });
 
-  it("still starts Claude Code when the seed cannot be written", () => {
-    // The harness must never fail to launch over a convenience. A read-only
-    // config directory is the cheapest way to force the write to fail.
-    mkdirSync(path.join(home, ".claude-ds"), { recursive: true });
-    writeFileSync(claudeConfig(), JSON.stringify({ projects: {} }), "utf-8");
-    execFileSync("chmod", ["500", path.join(home, ".claude-ds")]);
-    try {
-      expect(runWrapper({}, [], home).status).toBe(0);
-      expect(existsSync(envDump)).toBe(true);
-    } finally {
-      execFileSync("chmod", ["700", path.join(home, ".claude-ds")]);
-    }
-  });
+  // Skipped as root, where a read-only directory does not stop a write and the
+  // test would pass without ever reaching the failure path it names. CI and a
+  // developer machine both run this unprivileged.
+  it.skipIf(typeof process.getuid === "function" && process.getuid() === 0)(
+    "still starts Claude Code when the seed cannot be written",
+    () => {
+      // The harness must never fail to launch over a convenience.
+      mkdirSync(path.join(home, ".claude-ds"), { recursive: true });
+      writeFileSync(claudeConfig(), JSON.stringify({ projects: {} }), "utf-8");
+      execFileSync("chmod", ["500", path.join(home, ".claude-ds")]);
+      try {
+        expect(runWrapper({}, [], home).status).toBe(0);
+        expect(existsSync(envDump)).toBe(true);
+      } finally {
+        execFileSync("chmod", ["700", path.join(home, ".claude-ds")]);
+      }
+    },
+  );
 
   it("does not rewrite the config when the answer is already there", () => {
+    // Compared as BYTES, not by mtime: a filesystem with coarse timestamps can
+    // report the same mtime across a real replacement, and this test would
+    // then pass while the wrapper rewrote the file on every launch. The
+    // indentation is deliberate — a rewrite through json.dump would flatten
+    // it, so the formatting itself is the tell.
+    mkdirSync(path.join(home, ".claude-ds"), { recursive: true });
+    const pretty = JSON.stringify(
+      { theme: "dark", projects: { [home]: { hasTrustDialogAccepted: true } } },
+      null,
+      4,
+    );
+    writeFileSync(claudeConfig(), pretty, "utf-8");
+
     expect(runWrapper({}, [], home).status).toBe(0);
-    const first = statSync(claudeConfig()).mtimeMs;
-    expect(runWrapper({}, [], home).status).toBe(0);
-    expect(statSync(claudeConfig()).mtimeMs).toBe(first);
+
+    expect(readFileSync(claudeConfig(), "utf-8")).toBe(pretty);
   });
 });

--- a/src/tests/unit/claude-ds-wrapper.test.ts
+++ b/src/tests/unit/claude-ds-wrapper.test.ts
@@ -60,9 +60,11 @@ function installFakeClaude(): void {
 function runWrapper(
   extraEnv: Record<string, string | undefined> = {},
   args: string[] = [],
+  cwd: string = REPO,
 ): { status: number | null; stdout: string; stderr: string } {
   const result = spawnSync("bash", [WRAPPER, ...args], {
     encoding: "utf-8",
+    cwd,
     env: {
       // A MINIMAL path on purpose. Inheriting the host's PATH made the
       // "Claude Code is not installed" case find the developer's own `claude`
@@ -272,5 +274,98 @@ describe("failing in a way the owner can act on", () => {
     const run = runWrapper();
     expect(run.stdout).not.toContain("claw_test_token");
     expect(run.stderr).not.toContain("claw_test_token");
+  });
+});
+
+/**
+ * The trust dialog, and why it is pre-answered for exactly one directory.
+ *
+ * Found on a real box: the Coding Agent asked "is this a project you created
+ * or one you trust?" on EVERY launch, because Claude Code never persists
+ * hasTrustDialogAccepted for $HOME — the flag stayed false on both test boxes
+ * across clean exits that did record lastCost and lastSessionId. A security
+ * prompt whose only other option is "exit", shown every single time, trains
+ * the owner to click through prompts instead of reading them.
+ *
+ * The line these tests hold is the SCOPE. Pre-answering the box's own home is
+ * defensible; pre-answering whatever directory the owner happens to be in is
+ * not, because a cloned repository is the case the dialog exists for.
+ */
+describe("the trust dialog", () => {
+  const claudeConfig = () => path.join(home, ".claude-ds", ".claude.json");
+  const readConfig = (): Record<string, unknown> =>
+    JSON.parse(readFileSync(claudeConfig(), "utf-8")) as Record<string, unknown>;
+  /** undefined both when the file is absent and when the key is — "not seeded" either way. */
+  const trustFor = (dir: string): unknown => {
+    if (!existsSync(claudeConfig())) return undefined;
+    return ((readConfig().projects as Record<string, Record<string, unknown>>)?.[dir])?.hasTrustDialogAccepted;
+  };
+
+  it("is pre-answered for the home directory the Coding Agent opens in", () => {
+    expect(runWrapper({}, [], home).status).toBe(0);
+    expect(trustFor(home)).toBe(true);
+  });
+
+  it("is NOT pre-answered for a folder the owner happened to be standing in", () => {
+    // A cloned repository is exactly what the dialog is for. Seeding the cwd
+    // would silently disarm it.
+    const repoDir = path.join(home, "someones-repo");
+    mkdirSync(repoDir, { recursive: true });
+    expect(runWrapper({}, [], repoDir).status).toBe(0);
+    expect(trustFor(repoDir)).toBeUndefined();
+    expect(trustFor(home)).toBeUndefined();
+  });
+
+  it("keeps everything else in the config it did not come to change", () => {
+    mkdirSync(path.join(home, ".claude-ds"), { recursive: true });
+    writeFileSync(claudeConfig(), JSON.stringify({
+      theme: "dark",
+      projects: {
+        [home]: { allowedTools: ["Bash"], projectOnboardingSeenCount: 3 },
+        "/somewhere/else": { hasTrustDialogAccepted: false },
+      },
+    }), "utf-8");
+
+    expect(runWrapper({}, [], home).status).toBe(0);
+
+    const cfg = readConfig();
+    expect(cfg.theme).toBe("dark");
+    const projects = cfg.projects as Record<string, Record<string, unknown>>;
+    expect(projects[home].allowedTools).toEqual(["Bash"]);
+    expect(projects[home].projectOnboardingSeenCount).toBe(3);
+    expect(projects[home].hasTrustDialogAccepted).toBe(true);
+    // Another folder's answer is not ours to change in either direction.
+    expect(projects["/somewhere/else"].hasTrustDialogAccepted).toBe(false);
+  });
+
+  it("leaves a config it cannot parse alone rather than overwriting it", () => {
+    // Losing an owner's MCP servers to save them one keypress would be a bad
+    // trade; a broken config is Claude Code's to repair.
+    mkdirSync(path.join(home, ".claude-ds"), { recursive: true });
+    writeFileSync(claudeConfig(), "{ not json at all", "utf-8");
+
+    expect(runWrapper({}, [], home).status).toBe(0);
+    expect(readFileSync(claudeConfig(), "utf-8")).toBe("{ not json at all");
+  });
+
+  it("still starts Claude Code when the seed cannot be written", () => {
+    // The harness must never fail to launch over a convenience. A read-only
+    // config directory is the cheapest way to force the write to fail.
+    mkdirSync(path.join(home, ".claude-ds"), { recursive: true });
+    writeFileSync(claudeConfig(), JSON.stringify({ projects: {} }), "utf-8");
+    execFileSync("chmod", ["500", path.join(home, ".claude-ds")]);
+    try {
+      expect(runWrapper({}, [], home).status).toBe(0);
+      expect(existsSync(envDump)).toBe(true);
+    } finally {
+      execFileSync("chmod", ["700", path.join(home, ".claude-ds")]);
+    }
+  });
+
+  it("does not rewrite the config when the answer is already there", () => {
+    expect(runWrapper({}, [], home).status).toBe(0);
+    const first = statSync(claudeConfig()).mtimeMs;
+    expect(runWrapper({}, [], home).status).toBe(0);
+    expect(statSync(claudeConfig()).mtimeMs).toBe(first);
   });
 });


### PR DESCRIPTION
## What a customer hits today

Open the **Coding Agent**. Clear whatever it shows, get to the prompt, close the window, open it again — and it stops here, every single time:

```
Accessing workspace: /home/clawbox
Quick safety check: Is this a project you created or one you trust?
  1. Yes, I trust this folder
  2. No, exit
```

Found in the 2026-08-23 exploratory pass on beta `4c07d43`, on the freshly flashed `.65`. Both boxes carry the same state, so it is not a clean-install quirk.

## Why it repeats

Claude Code never persists the acceptance for `$HOME`. `~/.claude-ds/.claude.json` **is** written on exit — `lastGracefulShutdown: true`, `lastCost`, `lastSessionId` all update, and so does the file's mtime — but `projects["/home/clawbox"].hasTrustDialogAccepted` stays `false`. `.177` has been through the dialog twice (`projectOnboardingSeenCount: 2`) and is still `false`.

## Why pre-answering it is the right call here

On this appliance the question has no second answer. The folder is the box's own home, reached through the device login, and the alternative on offer is to quit. A security prompt that appears on every launch and can only be answered one way does not protect anybody — it trains the owner to click past prompts without reading them.

Claude Code names this key itself as the supported alternative: *"accept the trust dialog here once interactively, or set `projects[...].hasTrustDialogAccepted` in `<config>`"*.

**Scope is the whole point of the change.** It is seeded only when the harness starts in the clawbox user's home — the directory the Coding Agent app always opens in. Someone who clones a repository and runs `claude-ds` inside it is still asked, because that is the case the dialog exists for. Two tests hold that line.

## How timid the write is

- adds the one missing key, changes nothing else in the config
- **refuses to write over a config it cannot parse** — losing an owner's MCP servers to save them a keypress would be a bad trade
- no-ops when the answer is already there, so it does not rewrite the file on every launch
- temp file + `os.replace`, so a crash mid-write cannot leave half a config
- cannot stop the harness from starting: every failure path exits 0 and Claude Code launches anyway, with the dialog, exactly as today

## Tests

Six new cases in `claude-ds-wrapper.test.ts`, run against the **shipped** `scripts/claude-ds` with a fake home and a stub `claude` — the file's existing pattern. **Three fail against beta.** They cover: seeded for home, *not* seeded for a folder the owner was standing in, other config preserved (including another folder's `false`), unparseable config left untouched, launch survives an unwritable config directory, and no rewrite on the second launch.

Full suite: 282 files / 3969 tests green. `tsc --noEmit` and ESLint clean on the files touched.

## Hardware

The fix shape was proven on `.65` before any code was written — setting the flag by hand made the app open straight to the prompt, and the edit was reverted so the real fix can be proven from a clean state. Re-verified on both boxes after merge; evidence on TASK-509 and in the TASK-379 log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claude Code launched from the home directory now automatically remembers trust approval, avoiding repeated trust prompts.
  - Existing configuration and unrelated settings are preserved.
  - Launches continue normally if trust setup cannot be completed.
- **Bug Fixes**
  - Prevented unnecessary configuration rewrites when trust approval is already recorded.
  - Trust prompts remain unchanged when launching from directories other than the home directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->