### PR TITLE
The image allowance finally moves while you watch it (TASK-516)

### DIFF
--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -118,6 +118,15 @@ function getConnectButtonLabel(providerName?: string | null) {
  */
 const CONFIGURING_STEP_DELAYS = [0, 2000, 5000, 12000, 22000];
 
+/**
+ * How often the plan/allowance card re-asks the portal while mounted
+ * (TASK-516). Slow on purpose: the number it protects moves at most twenty
+ * times a day, and every tick is a portal round-trip. What it must beat is
+ * "forever", which is what a mount-only read gave a Settings window the
+ * desktop never unmounts.
+ */
+const ALLOWANCE_REFRESH_MS = 30_000;
+
 type ConfiguringKind = "generic" | "ollama" | "llamacpp";
 
 interface ConfiguringState {
@@ -716,33 +725,61 @@ export default function AIModelsStep({
   // in the shared tier module so these two panels cannot drift again. It reads
   // the account only when the box is actually paired, so the wizard's
   // choose-a-plan flow on an unpaired box is untouched.
+  //
+  // Not once per mount but on a slow poll (TASK-516): the desktop keeps the
+  // Settings window mounted while it is "closed", so a mount-only read froze
+  // the allowance at whatever the page load saw. The one moment the line is
+  // needed — right after the chat refused a picture at the cap — it showed the
+  // morning's number and contradicted the assistant on the same screen. The
+  // interval matches how the Voice and Local Models panels stay honest, and it
+  // pauses while the tab is hidden so a background desktop does not poll the
+  // portal all day; coming back to the tab refreshes immediately.
   useEffect(() => {
-    if (userPickedTierRef.current) return;
-    const controller = new AbortController();
-    fetch("/setup-api/ai-models/status", { cache: "no-store", signal: controller.signal })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (!data || typeof data !== "object") return;
-        // Only a live portal answer may move the card. `tierSource: "picker"`
-        // means the status route never reached the portal this cycle, and the
-        // stored device tier cannot tell Free from "we never asked" — guessing
-        // from it is how a Free user got shown a paid plan in the first place.
-        if (data.clawaiConfigured !== true || data.tierSource !== "portal") return;
-        // The allowance rides on the same live-portal gate as the tier badge,
-        // and for the same reason: `tierSource: "picker"` means nobody asked
-        // the portal this cycle, so any number attached to it is a leftover.
-        // Set unconditionally, including to null — an allowance that stays on
-        // screen after the portal stopped confirming it is a stale cap, and a
-        // stale cap is indistinguishable from a wrong one.
-        setImageAllowance(readImageAllowance(data.clawaiImages));
-        if (userPickedTierRef.current) return;
-        setClawaiTier(resolveUiTier(true, data.clawaiAccountTier ?? null));
-      })
-      .catch(() => {
-        // Offline or mid-restart: keep the stored intent rather than blanking
-        // or guessing at someone's subscription.
-      });
-    return () => controller.abort();
+    let controller: AbortController | null = null;
+    const refresh = () => {
+      controller?.abort();
+      const own = new AbortController();
+      controller = own;
+      fetch("/setup-api/ai-models/status", { cache: "no-store", signal: own.signal })
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (!data || typeof data !== "object") return;
+          // Only a live portal answer may move the card. `tierSource: "picker"`
+          // means the status route never reached the portal this cycle, and the
+          // stored device tier cannot tell Free from "we never asked" — guessing
+          // from it is how a Free user got shown a paid plan in the first place.
+          if (data.clawaiConfigured !== true || data.tierSource !== "portal") return;
+          // The allowance rides on the same live-portal gate as the tier badge,
+          // and for the same reason: `tierSource: "picker"` means nobody asked
+          // the portal this cycle, so any number attached to it is a leftover.
+          // Set unconditionally, including to null — an allowance that stays on
+          // screen after the portal stopped confirming it is a stale cap, and a
+          // stale cap is indistinguishable from a wrong one.
+          setImageAllowance(readImageAllowance(data.clawaiImages));
+          // The tier guard sits at resolution time, not at fetch time: a pick
+          // made while this request was in flight must win over its answer —
+          // and the allowance above is real either way.
+          if (userPickedTierRef.current) return;
+          setClawaiTier(resolveUiTier(true, data.clawaiAccountTier ?? null));
+        })
+        .catch(() => {
+          // Offline or mid-restart: keep the stored intent rather than blanking
+          // or guessing at someone's subscription.
+        });
+    };
+    refresh();
+    const interval = setInterval(() => {
+      if (typeof document === "undefined" || document.visibilityState !== "hidden") refresh();
+    }, ALLOWANCE_REFRESH_MS);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisible);
+      controller?.abort();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -767,7 +767,10 @@ export default function AIModelsStep({
           // or guessing at someone's subscription.
         });
     };
-    refresh();
+    // The mount read gets the same visibility gate as the ticks: a panel
+    // mounting in a background tab waits for `visibilitychange` like any
+    // other hidden refresh would.
+    if (typeof document === "undefined" || document.visibilityState !== "hidden") refresh();
     const interval = setInterval(() => {
       if (typeof document === "undefined" || document.visibilityState !== "hidden") refresh();
     }, ALLOWANCE_REFRESH_MS);

--- a/src/tests/components/ai-models-step-plan-tier.test.tsx
+++ b/src/tests/components/ai-models-step-plan-tier.test.tsx
@@ -175,6 +175,53 @@ describe("AIModelsStep — the plan card follows the account, not local storage"
     expect(await findByText("Pro plan · €9/month")).toBeInTheDocument();
   });
 
+  it("moves the allowance while the panel stays mounted, without a reload", async () => {
+    // TASK-516. The desktop never unmounts the Settings window, so a
+    // mount-only read froze this line at whatever the page load saw: an owner
+    // who had just been refused at 20 of 20 opened Settings and was told
+    // "1 of 20 images today" by the very surface built to explain the
+    // refusal. The acceptance is the card's own: with the session left open,
+    // spend an image and watch the number move.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const status: StatusStub = {
+        clawaiConfigured: true,
+        tierSource: "portal",
+        clawaiAccountTier: "pro",
+        clawaiImages: {
+          supported: true, model: "gpt-image-1-mini",
+          plan: "max", planLabel: "Max", dailyLimit: 20, used: 1,
+        },
+      };
+      vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : input instanceof Request ? input.url : input.toString();
+        if (url.includes("/setup-api/ai-models/oauth/providers")) {
+          return { ok: true, json: async () => ({ providers: [] }) };
+        }
+        if (url.includes("/setup-api/ai-models/status")) {
+          return { ok: true, json: async () => ({ ...status, clawaiImages: { ...status.clawaiImages } }) };
+        }
+        return { ok: true, json: async () => ({}) };
+      }));
+
+      const { findByTestId } = renderPanel();
+      const line = await findByTestId("clawai-image-allowance");
+      await waitFor(() => expect(line.textContent).toContain("ai.imagesUsedToday"));
+
+      // The day moves on the backend — the chat spent the allowance.
+      (status.clawaiImages as Record<string, unknown>).used = 20;
+      await act(async () => { await vi.advanceTimersByTimeAsync(31_000); });
+
+      // The line follows without any remount or reload, and flips to the
+      // exhausted state (the reset-tomorrow suffix only renders at the wall).
+      await waitFor(() =>
+        expect((line.textContent ?? "")).toContain("ai.imagesResetTomorrow"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("never overrides a plan the user picked in this session", async () => {
     // A late status answer must not yank the card out from under a click that
     // already happened — the wizard is where someone upgrades.


### PR DESCRIPTION
## What

TASK-516. `AIModelsStep` fetched `/setup-api/ai-models/status` in a mount-only effect, and the desktop keeps the Settings window mounted while “closed” — so the allowance line froze at whatever the page load saw. Right after a refusal at 20/20 it still said “1 of 20 images today”, contradicting the assistant on the same screen, and its `role="status"` announcement read a wrong number to screen-reader users.

## How

The status read becomes a slow poll (30 s, `ALLOWANCE_REFRESH_MS`) while the component is mounted:

- pauses while `document.visibilityState === "hidden"`, refreshes immediately on the tab becoming visible again — a background desktop does not hit the portal all day;
- each tick aborts the previous in-flight request;
- **TASK-468's rules are preserved**: only `clawaiConfigured && tierSource === "portal"` answers move anything, and the user-picked-tier guard sits at resolution time (as it already did for the late-response race), so a poll can never overwrite a pick — the allowance itself updates regardless, because it is real either way.

The mount-time outer `userPickedTierRef` guard is gone: it only skipped the initial fetch when a pick had somehow happened pre-mount, and the resolution-time guard already covers that case; the allowance must refresh even after a pick.

## Tests

New regression in `ai-models-step-plan-tier.test.tsx` runs the card's own acceptance: render the panel at 1/20, move the backend to 20/20, advance 31 s of fake time — the line flips to the exhausted reset-tomorrow state with no remount or reload. The existing TASK-468 suite (user pick wins over late answer, picker-source ignored, allowance gated on portal) passes unchanged.

Local gate: full `npx vitest run` green — 284 files, 3989 tests. ESLint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * AI model and image allowances now refresh automatically every 30 seconds while the page is open.
  * Allowances refresh immediately when returning to the browser tab.
  * User-selected plan tiers remain unchanged while live allowance information updates.

* **Tests**
  * Added coverage confirming image allowance changes appear without reloading or remounting the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->