### PR TITLE
A message sent as a turn finishes can no longer start a second concurrent run (TASK-517)

### DIFF
--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -508,6 +508,16 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const [sending, setSending] = useState(false)
   // Queued while a run is in flight; drained one at a time on `final`.
   const [queuedSends, setQueuedSends] = useState<{ id: string; text: string; attachments: ChatAttachment[] }[]>([])
+  // Synchronous mirrors of `sending` and the queue. A send handler can run in
+  // the window between the commit that rendered `sending === false` and the
+  // commit after the drain effect started the next queued run; deciding from
+  // the render-time closures in that window started a SECOND run while one was
+  // already in flight — which is how three accepted messages went unanswered
+  // (TASK-517). The refs are written at the moment the fact changes, so a
+  // stale closure cannot start a run it has no right to start.
+  const sendingRef = useRef(false)
+  const queuedSendsRef = useRef<{ id: string; text: string; attachments: ChatAttachment[] }[]>([])
+  useEffect(() => { queuedSendsRef.current = queuedSends }, [queuedSends])
   const { toolCalls, applyToolEvent, clearToolCalls } = useChatToolCalls()
   const [isBootstrappingHistory, setIsBootstrappingHistory] = useState(false)
   const [errorMsg, setErrorMsg] = useState('')
@@ -1398,7 +1408,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             setStreaming('')
             clearToolCalls()
             runIdRef.current = null
-            setSending(false)
+            sendingRef.current = false; setSending(false)
             // OpenClaw can ack a turn with "Sent." (delivery-mirror persona
             // pipeline / internal-source-reply) while the real reply is
             // generated server-side a moment later — persisted but never
@@ -1424,7 +1434,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             })
             clearToolCalls()
             runIdRef.current = null
-            setSending(false)
+            sendingRef.current = false; setSending(false)
             if (state === 'error') {
               // Never render the gateway's own error text. It is written for
               // an operator reading a log and has carried an absolute device
@@ -1674,6 +1684,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       if (chatMsgs.length === 0 && !greetedRef.current) {
         greetedRef.current = true
         setIsBootstrappingHistory(false)
+        sendingRef.current = true
         setSending(true)
         const idempotencyKey = uuid()
         runIdRef.current = idempotencyKey
@@ -1685,7 +1696,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
             idempotencyKey,
           })
         } catch {
-          setSending(false)
+          sendingRef.current = false; setSending(false)
           runIdRef.current = null
         }
       } else if (mightAutoGreet) {
@@ -2245,7 +2256,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         idempotencyKey,
       })
     } catch (err) {
-      setSending(false)
+      sendingRef.current = false; setSending(false)
       runIdRef.current = null
       setMessages(prev => [...prev, { role: 'system', text: describeChatFailure((err as Error)?.message), timestamp: Date.now() }])
     }
@@ -2338,7 +2349,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       }
     } finally {
       hermesAbortRef.current = null
-      setSending(false)
+      sendingRef.current = false; setSending(false)
       setStreaming('')
       runIdRef.current = null
     }
@@ -2364,6 +2375,7 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // do that job here — `displayText` carries the 📎 filenames while the
     // gateway stores and returns the prompt alone.
     setMessages(prev => [...prev, { role: 'user', text: displayText, timestamp: Date.now(), idempotencyKey, images }])
+    sendingRef.current = true
     setSending(true)
     setStreaming('')
     runIdRef.current = idempotencyKey
@@ -2386,7 +2398,12 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   const enqueueRun = useCallback((text: string) => {
     const trimmed = text.trim()
     if (!trimmed) return
-    if (sending) {
+    // Decide from the refs, not the render-time `sending`: this can run in the
+    // window between "previous turn finished" committing and the drain's next
+    // run committing, where the closure still says idle while a run is already
+    // in flight — starting here would double-start (TASK-517). A non-empty
+    // queue also forces enqueueing, or this send would jump the line.
+    if (sending || sendingRef.current || queuedSendsRef.current.length > 0) {
       setQueuedSends(prev => {
         const next = [...prev, { id: uuid(), text: trimmed, attachments: [] }]
         return next.length > MAX_QUEUED_SENDS ? next.slice(next.length - MAX_QUEUED_SENDS) : next
@@ -2420,7 +2437,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     // composer strip, which this send has just emptied. The queued/pending
     // copies of these objects are read for `name` and `path` alone.
     revokePreviews(currentAttachments)
-    if (sending) {
+    // Same ref-based decision as enqueueRun, for the same reason: an Enter can
+    // land while the drain is mid-handoff and the closure still says idle.
+    if (sending || sendingRef.current || queuedSendsRef.current.length > 0) {
       // Cap to bound memory; dropping the oldest matches "newest is freshest".
       setQueuedSends(prev => {
         const next = [...prev, { id: uuid(), text, attachments: currentAttachments }]
@@ -2432,7 +2451,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   }, [input, sending, attachments, startRun])
 
   useEffect(() => {
-    if (sending || queuedSends.length === 0) return
+    // sendingRef guards the commit-lag case: a send that started between this
+    // commit and now (stale-window Enter) is invisible to the `sending` state
+    // this effect closed over, and draining on top of it would double-start.
+    if (sending || sendingRef.current || queuedSends.length === 0) return
     const [next, ...rest] = queuedSends
     setQueuedSends(rest)
     startRun(next.text, next.attachments)

--- a/src/tests/components/chat-queue-starvation.test.tsx
+++ b/src/tests/components/chat-queue-starvation.test.tsx
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+
+/**
+ * TASK-517: three chat messages were accepted, shown in the transcript, and
+ * never answered. The durable session file proved the gateway received all
+ * three (U2 U3 U4 U1 A1 U5 A5 …) and produced no answer for the starved ones.
+ *
+ * The reachable client defect behind it: `sendMessage` decides queue-or-start
+ * from the render-time `sending` closure. When a send lands in the window
+ * between the commit where `sending` flipped false (previous turn's `final`)
+ * and the commit after the drain effect started the next queued run, the
+ * handler still sees `sending === false` and calls `startRun` directly — a
+ * SECOND run goes to the gateway while the drained one is in flight,
+ * overwriting `runIdRef` and racing the server, exactly the shape that leaves
+ * accepted turns unanswered.
+ *
+ * This test makes that window deterministic: the fake gateway dispatches a
+ * user keydown synchronously the moment the drained run's `chat.send` frame
+ * arrives — i.e. mid-window, with the stale handlers still bound. The
+ * invariant asserted is strict serialization: never a second `chat.send`
+ * before the previous run's `final`, and FIFO order for everything queued.
+ */
+
+const SEED_TS = 500;
+const SEED_TEXT = "Ready when you are.";
+const SESSION = "agent:main:main";
+
+function assistantMessage(text: string, timestamp: number) {
+  return { role: "assistant", content: [{ type: "text", text }], timestamp };
+}
+
+const SEED = assistantMessage(SEED_TEXT, SEED_TS);
+
+let history: unknown[] = [];
+/** Every request frame the component sent. */
+const sent: Array<Record<string, unknown>> = [];
+/** Called synchronously when a chat.send frame arrives, then cleared. */
+let onChatSend: (() => void) | null = null;
+
+const sockets: FakeGatewayWs[] = [];
+const socket = () => sockets[sockets.length - 1] ?? null;
+
+class FakeGatewayWs {
+  static readonly OPEN = 1;
+  readyState = FakeGatewayWs.OPEN;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(public url: string) {
+    sockets.push(this);
+    setTimeout(() => this.emit({ type: "event", event: "connect.challenge", payload: { nonce: "n" } }), 0);
+  }
+
+  send(raw: string) {
+    let frame: Record<string, unknown>;
+    try { frame = JSON.parse(raw) as Record<string, unknown>; } catch { return; }
+    if (frame.type !== "req") return;
+    sent.push(frame);
+    const id = frame.id as string;
+    if (frame.method === "connect") {
+      this.respond(id, { snapshot: { sessionDefaults: { mainSessionKey: SESSION } } });
+      return;
+    }
+    if (frame.method === "chat.history") {
+      this.respond(id, { messages: history });
+      return;
+    }
+    if (frame.method === "chat.send" && onChatSend) {
+      // Fire exactly once, synchronously — this is the stale-closure window.
+      const hook = onChatSend;
+      onChatSend = null;
+      hook();
+    }
+    this.respond(id, { runId: "r1", status: "started" });
+  }
+
+  close() {}
+
+  private respond(id: string, payload: unknown) {
+    setTimeout(() => this.emit({ type: "res", id, ok: true, payload }), 0);
+  }
+
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+function installFetch() {
+  vi.stubGlobal("fetch", vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/setup-api/gateway/ws-config")) {
+      return { ok: true, json: async () => ({ token: "t", wsUrl: "ws://localhost/gw" }) };
+    }
+    if (url.includes("/setup-api/harness/active")) {
+      return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+    }
+    if (url.includes("/setup-api/chat/model")) {
+      return { ok: true, json: async () => ({ options: [], activeOptionId: "" }) };
+    }
+    if (url.includes("/setup-api/chat/spoken-history")) {
+      return { ok: true, json: async () => ({ items: [] }) };
+    }
+    return { ok: true, json: async () => ({}) };
+  }));
+}
+
+/** Texts of every chat.send frame the gateway has seen, in arrival order. */
+function sentChatTexts(): string[] {
+  return sent
+    .filter((f) => f.method === "chat.send")
+    .map((f) => String((f.params as { message?: string; text?: string })?.message
+      ?? (f.params as { text?: string })?.text ?? ""));
+}
+
+function emitFinal(text: string) {
+  socket()?.emit({
+    type: "event",
+    event: "chat",
+    payload: {
+      sessionKey: SESSION,
+      state: "final",
+      message: assistantMessage(text, Date.now()),
+    },
+  });
+}
+
+async function mountReady() {
+  render(<ChatPopup isOpen onClose={() => {}} />);
+  await waitFor(() => expect(socket()).not.toBeNull());
+  await screen.findByText(SEED_TEXT);
+}
+
+async function typeAndSend(text: string) {
+  const textarea = await screen.findByRole("textbox");
+  fireEvent.change(textarea, { target: { value: text } });
+  fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+}
+
+async function flush() {
+  await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+}
+
+describe("chat send queue under a race with the drain", () => {
+  beforeEach(() => {
+    history = [SEED];
+    sent.length = 0;
+    sockets.length = 0;
+    onChatSend = null;
+    resetHarnessCache();
+    window.localStorage.clear();
+    Element.prototype.scrollIntoView = vi.fn();
+    vi.stubGlobal("WebSocket", FakeGatewayWs as unknown as typeof WebSocket);
+    installFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    resetHarnessCache();
+  });
+
+  it("never starts a second run before the previous one's final (TASK-517)", async () => {
+    await mountReady();
+
+    // A starts a run; B and C queue behind it.
+    await typeAndSend("msg A");
+    await waitFor(() => expect(sentChatTexts()).toHaveLength(1));
+    await typeAndSend("msg B");
+    await typeAndSend("msg C");
+    await flush();
+    expect(sentChatTexts()).toHaveLength(1);
+
+    // The user types D while A is still answering — the input commits well
+    // before the race. Only the Enter lands in the window.
+    const composer = await screen.findByRole("textbox");
+    fireEvent.change(composer, { target: { value: "msg D" } });
+    await flush();
+
+    // The moment the drain dispatches B's frame, the Enter lands — with the
+    // handlers still bound to the commit where `sending` was false. The
+    // unfixed component starts D as a SECOND concurrent run.
+    onChatSend = () => {
+      fireEvent.keyDown(screen.getByRole("textbox"), { key: "Enter", shiftKey: false });
+    };
+    await act(async () => { emitFinal("answer A"); });
+    await flush();
+
+    // Strict serialization: B went out, D must NOT have — it belongs behind C.
+    expect(sentChatTexts()).toEqual(["msg A", "msg B"]);
+
+    // Each final releases exactly the next queued turn, in FIFO order.
+    await act(async () => { emitFinal("answer B"); });
+    await flush();
+    expect(sentChatTexts()).toEqual(["msg A", "msg B", "msg C"]);
+
+    await act(async () => { emitFinal("answer C"); });
+    await flush();
+    expect(sentChatTexts()).toEqual(["msg A", "msg B", "msg C", "msg D"]);
+
+    await act(async () => { emitFinal("answer D"); });
+    await flush();
+    // Nothing extra ever went out, and every user turn reached the gateway.
+    expect(sentChatTexts()).toEqual(["msg A", "msg B", "msg C", "msg D"]);
+  });
+
+  it("a double Enter in the same window starts one run and queues the other", async () => {
+    await mountReady();
+
+    // No queue involved: the composer is idle, and two sends land in the same
+    // pre-commit window (fast double Enter). The unfixed closure check starts
+    // both as concurrent runs.
+    const textarea = await screen.findByRole("textbox");
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "first" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+      fireEvent.change(textarea, { target: { value: "second" } });
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+    });
+    await flush();
+
+    expect(sentChatTexts()).toEqual(["first"]);
+
+    await act(async () => { emitFinal("answer first"); });
+    await flush();
+    expect(sentChatTexts()).toEqual(["first", "second"]);
+  });
+});


### PR DESCRIPTION
Fixes the reachable client half of TASK-517 (three accepted chat messages never answered), with the deterministic reproduction the card asked for.

**The race, made deterministic.** `sendMessage`/`enqueueRun` decided queue-or-start from the render-time `sending` closure. In the window between the commit where `sending` flipped false (previous turn's `final`) and the commit after the drain effect started the next queued run, a landing Enter still saw `sending === false` and called `startRun` directly — a **second `chat.send` while the drained run was in flight**, overwriting `runIdRef` and racing the gateway. The new test `chat-queue-starvation.test.tsx` dispatches the Enter synchronously at the exact moment the drained run's frame reaches the fake gateway; against the unfixed component it fails with `["msg A","msg B","msg D"]` — D sent concurrently with B, no `final` between them. That concurrent-run shape is consistent with the durable-transcript evidence on the card (U2 U3 U4 present, A2 A3 A4 never produced).

**The fix.** Synchronous mirrors `sendingRef` and `queuedSendsRef`, written at the moment the facts change (startRun/auto-greet set, every `setSending(false)` site clears). `sendMessage`/`enqueueRun` enqueue whenever a run is in flight *or the queue is non-empty* (no line-jumping), and the drain effect carries the same guard against a send that started inside the commit lag. FIFO is preserved: A → B → C → D, one `final` between each.

**Tests**: 2 new — the race reproduction (fails on the unfixed component, verified) and a double-Enter serialization guard. Full suite green: 284 files / 4006 tests.

**Honesty note**: the card's live symptom was observed once and never reproduced on hardware; this PR fixes the one reachable client defect matching the evidence. If the starvation ever recurs on a box on a build with this fix, the card should be reopened toward the gateway.

**Device plan**: burst-send sanity on both boxes on the merged SHA (rapid messages while a turn runs → all answered, in order, matching durable transcript).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message handling to prevent duplicate sends and concurrent responses.
  * Ensured queued messages are processed in the correct order, including when new messages arrive during processing.
  * Fixed cases where rapid repeated submissions could cause messages to stall or be dispatched more than once.

* **Tests**
  * Added coverage for message ordering, queue processing, and rapid repeated submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->