### PR TITLE
The setup Welcome card centres on desktop, and ClawHub links reach a real page

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -809,6 +809,26 @@ h6 {
   z-index: 1;
 }
 
+/* ── the welcome screen is the exception ─────────────────────────────────
+   Step 1 is the shortest screen in the wizard and the one the customer meets
+   first — a crab, a wordmark, a line of status and two buttons. Top-anchored
+   on a desktop display it hangs under the bar with the whole lower half of
+   the glass empty, which reads as a page that failed to finish loading. Only
+   this screen centres, and only where there is width to spend; from step 2 on
+   the shared-horizon rule above still holds.
+
+   `safe center`, never a plain `center`: this element is the scroll
+   container, and a centred flex item taller than its box overflows in BOTH
+   directions — the card's top edge lands above the scrollable origin where no
+   scrollbar can reach it. `safe` collapses to flex-start the instant the card
+   outgrows the stage, so a short window, a zoomed page or a large font scale
+   degrades to the anchored layout instead of clipping the crab. */
+@media (min-width: 720px) {
+  .setup-main[data-welcome] {
+    justify-content: safe center;
+  }
+}
+
 .setup-footer {
   margin-top: auto;
   display: flex;

--- a/src/components/AppStore.tsx
+++ b/src/components/AppStore.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useId, useRef, useMemo } from "react"
 import { useModalDialog } from "@/hooks/useModalDialog";
 import { useT } from "@/lib/i18n";
 import { CATEGORY_COLORS, DEFAULT_CATEGORY_COLOR } from "@/lib/store-categories";
+import { clawhubSkillUrl } from "@/lib/clawhub-url";
 
 const STORE_API = "/setup-api/apps/store";
 const STORE_ICONS_BASE = "https://clawbox.com/store/icons";
@@ -502,6 +503,10 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
     // and otherwise fall back to the list's bucketed "2800+" string. One value
     // feeds both the header and the Downloads stat so they can't disagree.
     const installDisplay = detail?.installsAllTime && detail.installsAllTime > 0 ? detail.installsAllTime.toLocaleString() : selectedApp.installs;
+    // The API's own `clawhubUrl` omits the publisher segment, so it points at
+    // a page ClawHub does not serve; build the canonical one and keep the API's
+    // links only as a fallback for listings with no publisher.
+    const hubUrl = clawhubSkillUrl(selectedApp.id, selectedApp.developer) || detail?.clawhubUrl || selectedApp.url;
     return (
       <div className="h-full flex flex-col bg-[#0f1219] text-white" data-testid="app-store">
         {confirmModal}
@@ -605,9 +610,12 @@ export default function AppStore({ installedAppIds, onInstall, onUninstall }: Ap
             </div>
           )}
 
-          {/* Store link — prefer the canonical ClawHub page (full write-up). */}
-          {(detail?.clawhubUrl || selectedApp.url) && (
-            <a href={detail?.clawhubUrl || selectedApp.url} target="_blank" rel="noopener noreferrer"
+          {/* Store link — prefer the canonical ClawHub page (full write-up).
+              Built from publisher + slug, not from the API's `clawhubUrl`:
+              that field omits the publisher segment and lands on a page that
+              does not exist. See src/lib/clawhub-url.ts. */}
+          {hubUrl && (
+            <a href={hubUrl} target="_blank" rel="noopener noreferrer"
               className="inline-flex items-center gap-1.5 text-xs transition-colors"
               style={{ color: BRAND_ORANGE_LIGHT }}>
               {t("store.viewOnHub")}

--- a/src/components/InstalledAppSettings.tsx
+++ b/src/components/InstalledAppSettings.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import type { StoreApp } from "./AppStore";
 import * as kv from "@/lib/client-kv";
+import { clawhubSkillUrl } from "@/lib/clawhub-url";
 
 interface AppSetting {
   key: string;
@@ -322,7 +323,7 @@ export default function InstalledAppSettings({ appId, storeApp, icon, onUninstal
       <div className="shrink-0 px-6 py-4 border-t border-white/10 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <a
-            href={`https://clawhub.ai/skills/${appId}`}
+            href={clawhubSkillUrl(appId, storeApp.developer) || storeApp.url || "https://clawhub.ai"}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 text-xs text-white/40 hover:text-white/60 transition-colors"

--- a/src/components/SetupWizard.tsx
+++ b/src/components/SetupWizard.tsx
@@ -735,8 +735,13 @@ function SetupWizardInner({ onComplete }: SetupWizardProps = {}) {
 
       {/* Top-anchored, not centred: the steps range from ~430px to ~700px
           tall, so a centred card slides its own H1 up and down on every
-          advance. Anchored, all five screens share one horizon. */}
-      <main className="setup-main">
+          advance. Anchored, all five screens share one horizon.
+
+          The welcome screen is the one exception — it is the shortest of the
+          five and the first thing the customer sees, so on a desktop-width
+          display it centres in the stage rather than stranding half a screen
+          of empty ground beneath it. See `.setup-main[data-welcome]`. */}
+      <main className="setup-main" data-welcome={currentStep === 1 && !completionStarted ? "" : undefined}>
         <div className="w-full flex flex-col items-center">
         {completionStarted ? (
           <SetupCompletionOverlay

--- a/src/lib/clawhub-url.ts
+++ b/src/lib/clawhub-url.ts
@@ -1,0 +1,31 @@
+/**
+ * Canonical ClawHub page for a store listing.
+ *
+ * ClawHub namespaces every skill under its publisher: the real page for
+ * `security-audit-toolkit` by `gitgoodordietrying` is
+ *
+ *   https://clawhub.ai/gitgoodordietrying/skills/security-audit-toolkit
+ *
+ * We build that ourselves rather than trusting the store API, because the
+ * `clawhubUrl` the detail endpoint returns drops the publisher segment
+ * (`https://clawhub.ai/skills/<slug>`) and the desktop was also pasting the
+ * raw app id into a `https://clawhub.ai/skills/${appId}` template — which
+ * doubles the segment to `/skills/skills/<slug>` for any id that already
+ * carries a namespace. clawhub.ai is a client-routed SPA, so every one of
+ * those wrong shapes answers 200 and then renders nothing useful.
+ *
+ * Returns undefined when the publisher is unknown; callers fall back to
+ * whatever link the API gave them rather than shipping a URL that 404s in
+ * the browser.
+ */
+export function clawhubSkillUrl(
+  appId: string | undefined,
+  developer: string | undefined,
+): string | undefined {
+  if (!appId || !developer) return undefined;
+  // Installed ids can arrive namespaced (`skills/foo`, `clawhub/foo`); the
+  // slug ClawHub knows is the last segment.
+  const slug = appId.split("/").filter(Boolean).pop();
+  if (!slug) return undefined;
+  return `https://clawhub.ai/${encodeURIComponent(developer)}/skills/${encodeURIComponent(slug)}`;
+}

--- a/src/tests/unit/clawhub-url.test.ts
+++ b/src/tests/unit/clawhub-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { clawhubSkillUrl } from "@/lib/clawhub-url";
+
+describe("clawhubSkillUrl", () => {
+  it("namespaces the skill under its publisher", () => {
+    expect(clawhubSkillUrl("security-audit-toolkit", "gitgoodordietrying")).toBe(
+      "https://clawhub.ai/gitgoodordietrying/skills/security-audit-toolkit",
+    );
+  });
+
+  it("does not double the /skills/ segment for an already-namespaced id", () => {
+    expect(clawhubSkillUrl("skills/security-audit-toolkit", "gitgoodordietrying")).toBe(
+      "https://clawhub.ai/gitgoodordietrying/skills/security-audit-toolkit",
+    );
+    expect(clawhubSkillUrl("clawhub/cut", "someone")).toBe(
+      "https://clawhub.ai/someone/skills/cut",
+    );
+  });
+
+  it("returns undefined when the publisher or id is unknown, so callers can fall back", () => {
+    expect(clawhubSkillUrl("security-audit-toolkit", undefined)).toBeUndefined();
+    expect(clawhubSkillUrl(undefined, "gitgoodordietrying")).toBeUndefined();
+    expect(clawhubSkillUrl("", "gitgoodordietrying")).toBeUndefined();
+    expect(clawhubSkillUrl("/", "gitgoodordietrying")).toBeUndefined();
+  });
+
+  it("escapes path segments rather than letting them inject into the URL", () => {
+    expect(clawhubSkillUrl("a b", "pub lisher")).toBe(
+      "https://clawhub.ai/pub%20lisher/skills/a%20b",
+    );
+  });
+});


### PR DESCRIPTION
Two unrelated surface fixes, both reported from the device.

## The Welcome card sits in the middle of the stage on desktop

The wizard stage is deliberately top-anchored so all five steps share one horizon — they range ~430px to ~700px tall, and centring them all makes each card's H1 slide up and down on every advance. That rule still holds for steps 2–5.

Step 1 is the exception: it is the shortest screen and the first thing a customer sees, so top-anchored on a desktop display it hung under the bar with the entire lower half of the glass empty, which reads as a page that failed to finish loading. It now centres, gated to the shell's existing 720px desktop breakpoint, so phones keep the anchored layout unchanged.

`safe center` rather than a plain `center` is load-bearing: `.setup-main` is itself the scroll container, and a centred flex item taller than its box overflows in **both** directions, putting the card's top edge above the scrollable origin where no scrollbar can reach it. `safe` collapses back to `flex-start` the instant the card outgrows the stage — a short window, a zoomed page, or step 1 expanded into the Wi-Fi list all degrade to the anchored layout instead of clipping.

## ClawHub links pointed at pages that do not exist

Two independent causes, and one of them is the store API itself:

```
$ curl -s https://clawbox.com/api/store/apps/security-audit-toolkit
  "developer":  "gitgoodordietrying",
  "clawhubUrl": "https://clawhub.ai/skills/security-audit-toolkit"   # publisher segment missing
```

ClawHub namespaces every skill under its publisher, but the API's `clawhubUrl` drops that segment. Separately, `InstalledAppSettings` pasted the raw app id into a `https://clawhub.ai/skills/${appId}` template, which doubles the segment to `/skills/skills/<slug>` for any id that already carries a namespace.

clawhub.ai is a client-routed SPA, so every one of those wrong shapes answers HTTP 200 and then renders nothing useful — which is why this survived unnoticed.

Both call sites now build the canonical `https://clawhub.ai/<publisher>/skills/<slug>` from data we already hold, via a new `clawhubSkillUrl()` helper, and fall back to the API's own links only when the publisher is unknown rather than emitting a URL guaranteed to miss.

For the reported case that yields `https://clawhub.ai/gitgoodordietrying/skills/security-audit-toolkit`.

**Not fixed here:** the upstream API still returns a `clawhubUrl` missing its publisher segment. We now ignore that field whenever the listing carries a `developer`, but anything else consuming it still gets a broken link — worth fixing server-side too.

## Verification

- New `src/tests/unit/clawhub-url.test.ts` — 4 cases including the doubled-segment regression and the missing-publisher fallback
- `setup-wizard.test.tsx` and `app-store-install-modal.test.tsx` pass unchanged (17/17 across the three files)
- ESLint clean on all changed files; typecheck unchanged (14 pre-existing errors, all in `src/tests/`)
- Built and deployed to a live Jetson: verified the shipped bundle contains only the new publisher-namespaced builder and no trace of the old `clawhub.ai/skills/${appId}` template, and that the served stylesheet carries `@media (min-width:720px){.setup-main[data-welcome]{justify-content:safe center}}` — the `safe` keyword survives Tailwind's lightningcss transform intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added canonical ClawHub links for apps and installed app settings.
  - Links now include the appropriate developer and skill information, with reliable fallback destinations when details are unavailable.

- **UI Improvements**
  - The desktop welcome screen is now vertically centered for a more balanced initial setup experience.
  - Other setup steps retain their existing top-aligned layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->