### PR TITLE
Desktop by default with a headless toggle; balanced power profile, memory guards, OLLAMA_NUM_PARALLEL=2 (TASK-455)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Next.js rewrites in `next.config.ts` proxy gateway paths (`/api/*`, `/assets/*`,
 50+ Next.js Route Handlers namespaced under `/setup-api/` to avoid conflicts with the OpenClaw gateway's `/api/*`:
 
 - **WiFi**: `wifi/scan`, `wifi/connect`, `wifi/status`, `wifi/ethernet` — WiFi and Ethernet management
-- **System**: `system/info`, `system/stats`, `system/power`, `system/credentials`, `system/hotspot` — system info, power control, password, hotspot config
+- **System**: `system/info`, `system/stats`, `system/power`, `system/credentials`, `system/hotspot`, `system/desktop`, `system/power-profile` — system info, power control, password, hotspot config, desktop/headless toggle, Jetson power profile + memory guards
 - **AI Models**: `ai-models/configure`, `ai-models/status`, `ai-models/oauth/*` — API key config with OAuth flows (device auth + authorization code)
 - **Ollama**: `ollama/status`, `ollama/pull`, `ollama/search`, `ollama/delete` — local model management
 - **Apps**: `apps/store`, `apps/install`, `apps/uninstall`, `apps/icon/[appId]`, `apps/settings` — app store integration

--- a/config/clawbox-browser.service
+++ b/config/clawbox-browser.service
@@ -26,3 +26,10 @@ StandardError=append:/tmp/clawbox-browser.log
 # the main chrome, dbus-launch helpers) when the unit stops — no ExecStopPost
 # pgrep needed (and the prior pattern was broad enough to kill unrelated procs).
 KillMode=control-group
+# Memory guard (TASK-455). The numbers live in the drop-in
+# 50-clawbox-memory.conf that clawbox-resource-limits.sh writes from
+# config/clawbox-resource-limits.env — one place for every unit's limits.
+# MemoryAccounting is asserted here so the cgroup counters exist even on a box
+# whose drop-in has not been applied yet (an older install that has not re-run
+# install.sh or the in-app updater).
+MemoryAccounting=yes

--- a/config/clawbox-performance.service
+++ b/config/clawbox-performance.service
@@ -1,12 +1,19 @@
 [Unit]
-Description=ClawBox MAXN Power Mode and Jetson Clocks
+Description=ClawBox Jetson Power Profile
 After=multi-user.target nvpmodel.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/bash -c 'MAXN_ID=$(grep -oP "POWER_MODEL ID=\\K\\d+(?=\\s+NAME=MAXN)" /etc/nvpmodel.conf | tail -1); nvpmodel -m ${MAXN_ID:-0} && jetson_clocks'
-ExecStop=/bin/bash -c 'jetson_clocks --restore 2>/dev/null || true'
+# Applies whatever profile is persisted in /etc/clawbox/power-mode, defaulting
+# to BALANCED. Until TASK-455 this unit ran `nvpmodel -m MAXN && jetson_clocks`
+# unconditionally, which pinned every CPU to 1,728 MHz and the GPU to 1,020 MHz
+# at 4% utilisation and disabled the cpuidle states — 7.21 W and ~58 C doing
+# nothing, and 74.8 C median Tj under sustained 3B inference, over the 74 C
+# passive trip. The pinned behaviour is unchanged and still available; it is now
+# Settings -> System -> Performance mode, off by default.
+ExecStart=/usr/local/libexec/clawbox/clawbox-power-mode.sh --apply
+ExecStop=/usr/local/libexec/clawbox/clawbox-power-mode.sh --restore
 
 [Install]
 WantedBy=multi-user.target

--- a/config/clawbox-resource-limits.env
+++ b/config/clawbox-resource-limits.env
@@ -28,6 +28,11 @@ CLAWBOX_MEM_TOTAL_MIB=7607
 # still fits a 3B model with two slots plus KV growth, while capping the case
 # the report actually hit: ollama believing it owns 6.6 GiB of "VRAM" on a
 # 7.6 GiB box and pushing llama.cpp + next-server into swap.
+#
+# Known and deliberate: a 7-8B Q4 model (~5,400 MiB projected) does NOT fit
+# under this cap. It does not fit on the device either — it leaves ~300 MiB of
+# MemAvailable — so the cap turns "the box swaps itself to death" into "the pull
+# fails loudly", which is the better of the two.
 CLAWBOX_OLLAMA_MEMORY_HIGH=5G
 CLAWBOX_OLLAMA_MEMORY_MAX=5632M
 
@@ -37,13 +42,19 @@ CLAWBOX_OLLAMA_MEMORY_MAX=5632M
 CLAWBOX_BROWSER_MEMORY_HIGH=1200M
 CLAWBOX_BROWSER_MEMORY_MAX=1536M
 
-# The GNOME session (user@<uid>.service). Measured 1,585 MiB RSS / 691 MiB PSS
-# with gnome-shell + gnome-software + gnome-initial-setup up. The cap is
-# generous on purpose: the desktop is a SHIPPED, DEFAULT-ON feature (Krasi's
-# ruling, 2026-08-24), so this must never make it feel broken — it is a
-# backstop against a leaking shell extension, not a diet.
-CLAWBOX_DESKTOP_MEMORY_HIGH=1200M
-CLAWBOX_DESKTOP_MEMORY_MAX=1800M
+# The GNOME session (user@<uid>.service — the systemd user manager the shell
+# runs under; SSH logins live in session scopes outside it and are unaffected).
+# Its cgroup measured 717 MiB with gnome-shell + gnome-software +
+# gnome-initial-setup up (691 MiB PSS; the 1,585 MiB RSS figure double-counts
+# shared pages across 87 processes).
+#
+# The cap is ~2.8x that on purpose. The desktop is a SHIPPED, DEFAULT-ON
+# feature (Krasi's ruling, 2026-08-24), so a limit tight enough to OOM-kill a
+# busy-but-healthy session would be a worse regression than the memory it saves.
+# This is a backstop against a leaking shell extension, not a diet — the owner
+# who actually wants the memory back turns the desktop off.
+CLAWBOX_DESKTOP_MEMORY_HIGH=1400M
+CLAWBOX_DESKTOP_MEMORY_MAX=2048M
 
 # Concurrency for the local inference server. 1 serialised every caller: with 8
 # concurrent turns the last one waited 24.5 s and throughput stayed flat at

--- a/config/clawbox-resource-limits.env
+++ b/config/clawbox-resource-limits.env
@@ -1,0 +1,59 @@
+# ClawBox resource limits — THE single source of truth (TASK-455).
+#
+# Sized for the 8 GB Jetson Orin Nano the appliance ships on: MemTotal is
+# 7,789,948 kB = 7,607 MiB usable, of which ~5,700 MiB is available at a true
+# idle (measured on the QA box, 2026-08-22). Everything below is a cgroup v2
+# limit on ONE unit, not a global budget, and the three of them deliberately
+# over-subscribe: the desktop and the browser are only up when the owner is
+# actually looking at the box, while ollama is only near its ceiling when a
+# model is resident. The limits exist to stop ONE runaway unit from taking the
+# whole appliance down, not to partition RAM.
+#
+# Consumed by:
+#   scripts/clawbox-resource-limits.sh   -> systemd drop-ins (ollama, browser, desktop)
+#   scripts/optimize-ollama.sh           -> OLLAMA_* environment drop-in
+#   src/lib/resource-limits.ts           -> the TypeScript mirror the API/UI reads
+# `src/tests/unit/resource-limits.test.ts` pins this file and the TS mirror
+# together, so changing a number here without changing it there fails CI.
+#
+# MemoryHigh is a throttle (the kernel reclaims hard above it and the unit
+# stalls); MemoryMax is the hard kill line. Every unit gets High well below Max
+# on purpose, so pressure shows up as slowness first and an OOM kill last.
+
+# Total physical RAM of the target device, MiB. Documentation/sanity only.
+CLAWBOX_MEM_TOTAL_MIB=7607
+
+# ollama.service. A resident qwen2.5:3b costs ~2,656 MiB and
+# OLLAMA_NUM_PARALLEL=2 adds ~170 MiB on top (both measured), so 5G of headroom
+# still fits a 3B model with two slots plus KV growth, while capping the case
+# the report actually hit: ollama believing it owns 6.6 GiB of "VRAM" on a
+# 7.6 GiB box and pushing llama.cpp + next-server into swap.
+CLAWBOX_OLLAMA_MEMORY_HIGH=5G
+CLAWBOX_OLLAMA_MEMORY_MAX=5632M
+
+# clawbox-browser.service. Chromium measured 1,016 MiB RSS / 394 MiB PSS across
+# 15 processes with a handful of tabs open. 1200M/1536M leaves normal browsing
+# untouched and kills a runaway renderer instead of the box.
+CLAWBOX_BROWSER_MEMORY_HIGH=1200M
+CLAWBOX_BROWSER_MEMORY_MAX=1536M
+
+# The GNOME session (user@<uid>.service). Measured 1,585 MiB RSS / 691 MiB PSS
+# with gnome-shell + gnome-software + gnome-initial-setup up. The cap is
+# generous on purpose: the desktop is a SHIPPED, DEFAULT-ON feature (Krasi's
+# ruling, 2026-08-24), so this must never make it feel broken — it is a
+# backstop against a leaking shell extension, not a diet.
+CLAWBOX_DESKTOP_MEMORY_HIGH=1200M
+CLAWBOX_DESKTOP_MEMORY_MAX=1800M
+
+# Concurrency for the local inference server. 1 serialised every caller: with 8
+# concurrent turns the last one waited 24.5 s and throughput stayed flat at
+# 0.34 req/s. 2 measured -41% wall time at 2-4 concurrency for +170 MiB. On a
+# device where the agent and the human share one model, two consumers is the
+# normal case, not an edge case.
+CLAWBOX_OLLAMA_NUM_PARALLEL=2
+
+# Context length pinned explicitly. The old drop-in set NUM_PARALLEL but not
+# this, so llama-server silently got ollama's 4096 default; with two slots the
+# KV cache is allocated per slot, so leaving it implicit makes the memory cost
+# of the line above unpredictable.
+CLAWBOX_OLLAMA_CONTEXT_LENGTH=4096

--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -96,3 +96,22 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/apt-get install -y -qq chromium
 # Allow the Browser-app installer to recover from interrupted dpkg state.
 clawbox ALL=(root) NOPASSWD: /usr/bin/dpkg --configure -a
 clawbox ALL=(root) NOPASSWD: /usr/bin/snap install chromium
+
+# Desktop / power toggles (TASK-455). Both targets are the ROOT-OWNED copies
+# under /usr/local/libexec/clawbox, never the clawbox-writable ones in
+# /home/clawbox/clawbox/scripts — same reason as the optimize-ollama.sh grant
+# in /etc/sudoers.d/clawbox-ollama.
+#
+# Exact-match Cmnd specs, one per action, with no wildcard: these scripts branch
+# entirely on argv[1], so a trailing `*` would be a grant on every mode they will
+# ever grow, including ones added by a future PR that never got reviewed as a
+# privilege boundary.
+#
+# The `--check` modes are deliberately ABSENT. They read systemctl/nvpmodel
+# state only and run fine unprivileged, so the status route calls them with no
+# sudo at all and the sudo surface stays limited to the four actions that
+# actually change something.
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-desktop-mode.sh --enable
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-desktop-mode.sh --disable
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-power-mode.sh --balanced
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-power-mode.sh --performance

--- a/docs-site/technical/architecture.mdx
+++ b/docs-site/technical/architecture.mdx
@@ -55,7 +55,7 @@ Everything runs under systemd. The two you will interact with most are **clawbox
 | `clawbox-browser` | Desktop Chromium with CDP for AI browsing (started on demand) | 18800 (CDP) | no |
 | `clawbox-heartbeat.timer` + `clawbox-heartbeat.service` | Every 5 min the timer runs the oneshot, which curls `/setup-api/portal/heartbeat-tick` on loopback. The web app then POSTs to the portal — but only when a ClawBox AI token *and* a tunnel URL both exist ([details](/technical/networking#portal-heartbeat)) | — | timer + oneshot |
 | `clawbox-tunnel` | Optional Cloudflare Quick Tunnel → port 80 | — | always |
-| `clawbox-performance` | Jetson max-performance mode (`nvpmodel` + `jetson_clocks`) | — | oneshot |
+| `clawbox-performance` | Applies the persisted Jetson power profile at boot (see [Power profile and memory guards](#power-profile-and-memory-guards)) | — | oneshot |
 | `clawbox-root-update@<step>` | Privileged installer steps, templated (`install.sh --step <step>`) | — | oneshot |
 | `ollama` | Local model runtime (system package) | 11434 | managed by Ollama |
 
@@ -64,6 +64,30 @@ Two more servers run as **children of the web app** (no systemd unit): the termi
 ### How the unprivileged web app does root things
 
 `clawbox-setup` runs as the `clawbox` user. Anything privileged (updates, password change, hostname, reboot) is delegated to the **`clawbox-root-update@<step>`** systemd template, which runs `install.sh --step <step>` as root. A polkit rule plus a narrow sudoers file allow the `clawbox` user to start exactly these units — the web app never runs arbitrary root commands.
+
+### Desktop or headless
+
+The GNOME desktop is **shipped and on by default**. Turning it off is a setting, not a different image — nothing is uninstalled, so it is one switch away from coming back.
+
+**Settings → System → Desktop environment** posts to `/setup-api/system/desktop`, which runs the root-owned `clawbox-desktop-mode.sh`. Off sets the boot target to `multi-user.target` and disables the display manager; on sets it back to `graphical.target`. **The change applies at the next reboot**, and the UI says so: tearing the graphical session down under a logged-in user would kill their Remote Desktop view and any Chromium the agent is driving. Running headless gives back roughly 700 MB.
+
+The automation browser is unaffected either way — `clawbox-browser.service` has no `[Install]` section, so it is only ever started on demand, never at boot.
+
+### Power profile and memory guards
+
+**Balanced is the default.** `clawbox-performance.service` applies whatever profile is persisted in the root-owned `/etc/clawbox/power-mode`, defaulting to a `nvpmodel` cap with `jetson_clocks` **off** and the cpuidle states on. Earlier releases ran `nvpmodel -m MAXN_SUPER && jetson_clocks` unconditionally at every boot, which pinned all six CPU cores to 1,728 MHz and the GPU to 1,020 MHz at 4% load — 7.2 W and ~58 °C doing nothing, and 74.8 °C median Tj under sustained 3B inference, just over the 74 °C passive-cooling trip.
+
+**Settings → System → Performance mode** (off by default) restores that pinned behaviour for owners who want it and have airflow. It applies immediately — no reboot.
+
+Three cgroup v2 memory guards ship as `50-clawbox-memory.conf` drop-ins, written by `clawbox-resource-limits.sh` from **`config/clawbox-resource-limits.env`** — the single place every one of these numbers is defined, with the measurement behind it:
+
+| Unit | `MemoryHigh` | `MemoryMax` |
+|---|---|---|
+| `ollama.service` | 5G | 5632M |
+| `clawbox-browser.service` | 1200M | 1536M |
+| `user@1000.service` (the GNOME session) | 1400M | 2048M |
+
+`MemoryHigh` throttles, `MemoryMax` kills, and every unit gets High well below Max on purpose: pressure should show up as slowness first and an OOM kill last. The same env file sets `OLLAMA_NUM_PARALLEL=2` — one slot serialised every caller, so the eighth concurrent turn waited 24.5 s; a second slot costs ~170 MB and cut 2–4-way concurrent latency by ~41%.
 
 ## Request routing (port 80)
 

--- a/install.sh
+++ b/install.sh
@@ -2636,9 +2636,19 @@ install_root_libexec() {
       install -o root -g root -m 0755 "$PROJECT_DIR/config/$src" "$ROOT_LIBEXEC_DIR/$src"
     fi
   done
-  if [ -f "$PROJECT_DIR/scripts/optimize-ollama.sh" ]; then
-    install -o root -g root -m 0755 "$PROJECT_DIR/scripts/optimize-ollama.sh" \
-      "$ROOT_LIBEXEC_DIR/optimize-ollama.sh"
+  # Everything the web server may invoke as root via a NOPASSWD grant. Same
+  # rule as above: the copy that runs must not be the one clawbox can rewrite.
+  for src in optimize-ollama.sh clawbox-desktop-mode.sh clawbox-power-mode.sh \
+             clawbox-resource-limits.sh; do
+    if [ -f "$PROJECT_DIR/scripts/$src" ]; then
+      install -o root -g root -m 0755 "$PROJECT_DIR/scripts/$src" "$ROOT_LIBEXEC_DIR/$src"
+    fi
+  done
+  # The limits the scripts above read. Root-owned for the same reason they are.
+  install -d -o root -g root -m 0755 /etc/clawbox
+  if [ -f "$PROJECT_DIR/config/clawbox-resource-limits.env" ]; then
+    install -o root -g root -m 0644 "$PROJECT_DIR/config/clawbox-resource-limits.env" \
+      /etc/clawbox/resource-limits.env
   fi
 }
 
@@ -2807,6 +2817,12 @@ step_post_update() {
   # Without this call the persistent journal would be fresh-install-only, and
   # every already-shipped box would keep losing its whole log on each reboot.
   step_persistent_journal || echo "  Warning: persistent_journal step failed (non-fatal)"
+  # Re-assert the cgroup memory guards and re-sync /etc/clawbox/resource-limits.env
+  # from the repo. Without this the guards would be fresh-install-only and every
+  # already-shipped box would keep running an unbounded ollama. Idempotent.
+  # NOTE: there is deliberately no step_desktop_mode call here — the desktop
+  # toggle is the owner's decision and an update must never flip it.
+  step_resource_limits || echo "  Warning: resource_limits step failed (non-fatal)"
   # step_vnc_refresh is a tiny idempotent refresh of the clawbox-vnc.service
   # unit + autocutsel package. Devices installed before the display-:99 move
   # and the clipboard-sync addition get both here without needing a reinstall.
@@ -3116,19 +3132,26 @@ step_nvidia_jetpack() {
 }
 
 step_performance_mode() {
+  # Install the root-owned copies the sudoers rules point at FIRST — both the
+  # unit below and the ollama optimiser are now invoked through them.
+  install_root_libexec
   if is_test_mode; then
     echo "  CLAWBOX_TEST_MODE=1, skipping nvpmodel/jetson_clocks"
     return 0
   fi
-  # Find the highest MAXN mode (MAXN_SUPER > MAXN); fall back to mode 0
-  local MAXN_LINE MAXN_ID MAXN_NAME
-  MAXN_LINE=$(grep -oP 'POWER_MODEL ID=\K\d+\s+NAME=\S+' /etc/nvpmodel.conf | grep 'NAME=MAXN' | tail -1)
-  MAXN_ID="${MAXN_LINE%% *}"
-  MAXN_ID="${MAXN_ID:-0}"
-  MAXN_NAME="${MAXN_LINE#*NAME=}"
-  echo "  Setting power mode to $MAXN_ID (${MAXN_NAME:-unknown})"
-  nvpmodel -m "$MAXN_ID"
-  jetson_clocks
+  # Apply whatever profile is persisted in /etc/clawbox/power-mode. On a fresh
+  # box nothing is persisted, so this resolves to BALANCED: a real nvpmodel cap
+  # with jetson_clocks OFF.
+  #
+  # This used to be an unconditional `nvpmodel -m MAXN && jetson_clocks`, which
+  # pinned all six CPUs to 1,728 MHz and the GPU to 1,020 MHz at 4% load and
+  # disabled the cpuidle states — 7.21 W / ~58 C at idle, and 74.8 C median Tj
+  # under sustained 3B inference, over the 74 C passive-cooling trip. The pinned
+  # profile is unchanged and still one toggle away (Settings -> System ->
+  # Performance mode); it is simply no longer what a box does by default.
+  # TASK-455.
+  "$ROOT_LIBEXEC_DIR/clawbox-power-mode.sh" --apply || \
+    echo "  Warning: power profile apply failed (non-fatal)"
   # Ensure persistent service is installed and enabled for next boot
   if [ -f "$PROJECT_DIR/config/clawbox-performance.service" ]; then
     cp "$PROJECT_DIR/config/clawbox-performance.service" /etc/systemd/system/
@@ -3138,11 +3161,50 @@ step_performance_mode() {
   # snapd is kept running — required for snap-based Chromium on Ubuntu 22.04
   # Optimize Ollama for 8GB Jetson
   bash "$PROJECT_DIR/scripts/optimize-ollama.sh"
-  # Install the root-owned copy the sudoers rule points at, then the rule.
-  install_root_libexec
   cp "$PROJECT_DIR/config/sudoers-clawbox-ollama" /etc/sudoers.d/clawbox-ollama
   chmod 440 /etc/sudoers.d/clawbox-ollama
   chown root:root /etc/sudoers.d/clawbox-ollama
+  if ! visudo -cf /etc/sudoers.d/clawbox-ollama >/dev/null; then
+    rm -f /etc/sudoers.d/clawbox-ollama
+    echo "Error: clawbox-ollama sudoers drop-in failed visudo validation; removed" >&2
+    exit 1
+  fi
+  # The cgroup memory guards. Deliberately AFTER the ollama optimiser, so the
+  # unit it just restarted picks the limits up on the daemon-reload below.
+  step_resource_limits
+}
+
+step_resource_limits() {
+  # cgroup v2 MemoryHigh/MemoryMax for ollama, the automation browser and the
+  # GNOME session. Every number comes from
+  # config/clawbox-resource-limits.env — see that file. Idempotent: it only
+  # ever writes three files called 50-clawbox-memory.conf.
+  #
+  # The root-owned copy of the env file is what the script prefers at runtime;
+  # the repo copy is only a fallback, because /home/clawbox/clawbox is
+  # clawbox-writable and this runs as root.
+  install -d -o root -g root -m 0755 /etc/clawbox
+  if [ -f "$PROJECT_DIR/config/clawbox-resource-limits.env" ]; then
+    install -o root -g root -m 0644 "$PROJECT_DIR/config/clawbox-resource-limits.env" \
+      /etc/clawbox/resource-limits.env
+  fi
+  install_root_libexec
+  "$ROOT_LIBEXEC_DIR/clawbox-resource-limits.sh" --apply || \
+    echo "  Warning: resource limits apply failed (non-fatal)"
+}
+
+step_desktop_mode() {
+  # DELIBERATELY DOES NOTHING to the boot target.
+  #
+  # The desktop is shipped and default-ON (Krasi's ruling, 2026-08-24) and the
+  # headless toggle is a SETTING, not an install-time or update-time decision:
+  # an owner who switched their box to console-only must not silently get GNOME
+  # back on the next `git pull`. So install/update only make the mechanism
+  # available (the root-owned script + its sudoers grant, both handled by
+  # install_root_libexec and step_systemd_services) and report where the box
+  # currently stands. TASK-455.
+  install_root_libexec
+  "$ROOT_LIBEXEC_DIR/clawbox-desktop-mode.sh" --check || true
 }
 
 step_jtop_install() {
@@ -4204,7 +4266,8 @@ DISPATCH_STEPS=(
   chpasswd gateway_setup ffmpeg_install polkit_rules systemd_services
   directories_permissions captive_portal_dns desktop_theme
   fix_git_perms browser_launch cloudflared_install
-  nm_dispatcher sysctl_linkdown persistent_journal post_update update_smoke validate_services
+  nm_dispatcher sysctl_linkdown persistent_journal resource_limits desktop_mode
+  post_update update_smoke validate_services
 )
 
 if [ "${1:-}" = "--step" ]; then

--- a/scripts/clawbox-desktop-mode.sh
+++ b/scripts/clawbox-desktop-mode.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# Turn the GNOME desktop on or off on a ClawBox. TASK-455.
+#
+# The desktop is a SHIPPED, DEFAULT-ON feature (Krasi's ruling, 2026-08-24).
+# This script exists so an owner who wants the ~691 MiB PSS the GNOME session
+# holds can have it back, WITHOUT a separate headless image and without
+# uninstalling anything: nothing here removes GNOME, gdm or snapd, and every
+# change is one command away from being undone.
+#
+#   --check      print the current state as JSON; change nothing (dry run)
+#   --enable     desktop on   (default.target = graphical.target)
+#   --disable    desktop off  (default.target = multi-user.target)
+#
+# Applies at the NEXT BOOT by design. Tearing the graphical session down under
+# a logged-in user mid-session would kill their VNC view and any Chromium the
+# agent is driving; `systemctl isolate multi-user.target` on a box whose only
+# console is that desktop is also how you lock yourself out of a device with no
+# keyboard. So we change the boot target and report "reboot required".
+#
+# WHY set-default and not `systemctl disable gdm`: on the shipped JetPack image
+# gdm.service is a STATIC unit (measured on the QA box: `systemctl is-enabled
+# gdm` -> static, `gdm3` -> alias). `disable` on a static unit is a silent
+# no-op, so it is the boot target that actually decides. gdm is still disabled
+# best-effort below for the images where it is not static, but the target is
+# the authoritative bit and the one --check reports.
+#
+# Must run as root for --enable/--disable. --check needs no privileges.
+
+set -euo pipefail
+
+GRAPHICAL_TARGET="graphical.target"
+CONSOLE_TARGET="multi-user.target"
+
+# Display managers we switch off alongside the target, in the order they are
+# tried. Best-effort: a box with none of them installed is fine.
+DISPLAY_MANAGERS=(gdm3.service gdm.service lightdm.service sddm.service)
+
+usage() {
+  echo "Usage: $(basename "$0") --check | --enable | --disable" >&2
+  exit 2
+}
+
+have_systemctl() {
+  command -v systemctl >/dev/null 2>&1
+}
+
+current_target() {
+  if have_systemctl; then
+    systemctl get-default 2>/dev/null || echo "unknown"
+  else
+    echo "unknown"
+  fi
+}
+
+# Is the graphical stack up RIGHT NOW? This is what makes "reboot required"
+# honest: the boot target is the persisted intent, the active target is what
+# the box is actually doing, and they disagree exactly between a toggle and the
+# next reboot.
+graphical_active() {
+  have_systemctl || return 1
+  [ "$(systemctl is-active "$GRAPHICAL_TARGET" 2>/dev/null || true)" = "active" ]
+}
+
+display_manager_state() {
+  have_systemctl || { echo "unknown"; return; }
+  local dm
+  for dm in "${DISPLAY_MANAGERS[@]}"; do
+    if systemctl list-unit-files "$dm" >/dev/null 2>&1 \
+      && [ -n "$(systemctl list-unit-files "$dm" --no-legend 2>/dev/null)" ]; then
+      echo "${dm%.service}:$(systemctl is-enabled "$dm" 2>/dev/null || echo unknown)"
+      return
+    fi
+  done
+  echo "none"
+}
+
+json_escape() {
+  printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+report() {
+  local target enabled active pending dm
+  target="$(current_target)"
+  if [ "$target" = "$GRAPHICAL_TARGET" ]; then enabled=true; else enabled=false; fi
+  if graphical_active; then active=true; else active=false; fi
+  if [ "$enabled" = "$active" ]; then pending=false; else pending=true; fi
+  dm="$(display_manager_state)"
+  printf '{"supported":%s,"enabled":%s,"active":%s,"rebootRequired":%s,"defaultTarget":"%s","displayManager":"%s"}\n' \
+    "$(have_systemctl && echo true || echo false)" \
+    "$enabled" "$active" "$pending" \
+    "$(json_escape "$target")" "$(json_escape "$dm")"
+}
+
+require_root() {
+  if [ "$(id -u)" != "0" ]; then
+    echo "Error: this action must run as root" >&2
+    exit 1
+  fi
+}
+
+set_target() {
+  local target="$1"
+  have_systemctl || { echo "Error: systemctl not available" >&2; exit 1; }
+  # Idempotent: set-default on the target that is already default is a no-op
+  # that still exits 0, but skipping it keeps the log honest.
+  if [ "$(current_target)" = "$target" ]; then
+    echo "default target already $target"
+  else
+    systemctl set-default "$target" >/dev/null
+    echo "default target set to $target"
+  fi
+}
+
+set_display_managers() {
+  local action="$1" dm
+  have_systemctl || return 0
+  for dm in "${DISPLAY_MANAGERS[@]}"; do
+    [ -n "$(systemctl list-unit-files "$dm" --no-legend 2>/dev/null)" ] || continue
+    # Static units (gdm on stock JetPack) have no [Install] section, so this is
+    # a no-op there and the boot target carries the whole change. Never fatal.
+    if systemctl "$action" "$dm" >/dev/null 2>&1; then
+      echo "$action $dm"
+    else
+      echo "$action $dm skipped (static or not installable)"
+    fi
+  done
+}
+
+main() {
+  case "${1:-}" in
+    --check)
+      report
+      ;;
+    --enable)
+      require_root
+      set_target "$GRAPHICAL_TARGET"
+      set_display_managers enable
+      report
+      ;;
+    --disable)
+      require_root
+      set_target "$CONSOLE_TARGET"
+      set_display_managers disable
+      # The automation browser is on-demand only (clawbox-browser.service is a
+      # static unit with no [Install], and install.sh explicitly skips it in the
+      # enable loop), so there is nothing to switch off for it here. Stop it if
+      # it happens to be up: without a desktop there is no X display for it to
+      # draw on, and leaving ~1 GB of Chromium resident on a box whose owner
+      # just asked for the memory back would defeat the point.
+      systemctl stop clawbox-browser.service >/dev/null 2>&1 || true
+      report
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/clawbox-power-mode.sh
+++ b/scripts/clawbox-power-mode.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+#
+# Choose the Jetson power profile. TASK-455.
+#
+# WHY this exists. clawbox-performance.service used to run, unconditionally at
+# every boot:
+#
+#     nvpmodel -m <MAXN id> && jetson_clocks
+#
+# `nvpmodel -m MAXN_SUPER` on its own is only a CEILING and costs nothing when
+# the box is quiet. `jetson_clocks` is the expensive half: it pins every CPU's
+# scaling_min_freq to scaling_max_freq, pins the GPU the same way and DISABLES
+# the cpuidle states, so the board sits at 1,728 MHz x6 + 1,020 MHz GPU at 4%
+# utilisation. Measured on the QA box: 7.21 W and ~58 C doing nothing, and
+# median Tj 74.8 C (max 75.4 C) under sustained 3B inference — over the 74 C
+# passive-cooling trip, in a fanless-by-default appliance that sits in a
+# living room.
+#
+# So: BALANCED is the default (a real nvpmodel cap, DVFS left alone, idle
+# states on), and PERFORMANCE — the old pinned behaviour, verbatim — is an
+# opt-in setting the owner turns on when they want it.
+#
+#   --check         print current state as JSON; change nothing (dry run)
+#   --balanced      persist + apply the balanced profile
+#   --performance   persist + apply the pinned profile
+#   --apply         apply whatever is persisted (clawbox-performance.service)
+#   --restore       undo the pinning (unit ExecStop)
+#
+# Takes effect IMMEDIATELY — no reboot, unlike the desktop toggle.
+# --check needs no privileges; everything else must run as root.
+
+set -euo pipefail
+
+STATE_DIR="${CLAWBOX_STATE_DIR:-/etc/clawbox}"
+STATE_FILE="$STATE_DIR/power-mode"
+NVPMODEL_CONF="${CLAWBOX_NVPMODEL_CONF:-/etc/nvpmodel.conf}"
+DEFAULT_MODE="balanced"
+
+usage() {
+  echo "Usage: $(basename "$0") --check | --balanced | --performance | --apply | --restore" >&2
+  exit 2
+}
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# ── Persisted intent ─────────────────────────────────────────────────────────
+#
+# Root-owned, next to /etc/clawbox/edition.env and for the same reason: the web
+# server runs as `clawbox` and its whole config tree is clawbox-writable, so the
+# thing root acts on at boot must not be. The only values ever written are the
+# two literals below.
+read_mode() {
+  local raw=""
+  [ -f "$STATE_FILE" ] && raw="$(tr -d '[:space:]' < "$STATE_FILE" 2>/dev/null || true)"
+  case "$raw" in
+    balanced|performance) echo "$raw" ;;
+    *) echo "$DEFAULT_MODE" ;;
+  esac
+}
+
+write_mode() {
+  mkdir -p "$STATE_DIR"
+  printf '%s\n' "$1" > "$STATE_FILE"
+  chown root:root "$STATE_FILE" 2>/dev/null || true
+  chmod 0644 "$STATE_FILE"
+}
+
+# ── nvpmodel mode resolution ─────────────────────────────────────────────────
+#
+# Read the IDs out of /etc/nvpmodel.conf rather than hardcoding them: the map is
+# per-module. On the shipped Orin Nano Super it is
+#   ID=0 NAME=15W, ID=1 NAME=25W, ID=2 NAME=MAXN_SUPER
+# but the same script has to do something sane on any other Jetson.
+nvp_modes() {
+  [ -f "$NVPMODEL_CONF" ] || return 0
+  sed -n 's/^[[:space:]]*<[[:space:]]*POWER_MODEL[[:space:]]\+ID=\([0-9]\+\)[[:space:]]\+NAME=\([^[:space:]>]\+\).*/\1 \2/p' "$NVPMODEL_CONF"
+}
+
+# Highest-numbered MAXN mode — the ceiling profile.
+performance_mode_id() {
+  nvp_modes | awk '$2 ~ /MAXN/ {id=$1} END {if (id != "") print id}'
+}
+
+# Balanced = the highest mode that is NOT MAXN (25W on the shipped module).
+# Falling back to the MAXN id is deliberate: on a module whose only mode is
+# MAXN, "balanced" still means "the cap nvpmodel gives us, with jetson_clocks
+# OFF" — the pinning is the part we are actually removing.
+balanced_mode_id() {
+  local id
+  id="$(nvp_modes | awk '$2 !~ /MAXN/ {id=$1} END {if (id != "") print id}')"
+  [ -n "$id" ] || id="$(performance_mode_id)"
+  echo "${id:-0}"
+}
+
+mode_name_for_id() {
+  nvp_modes | awk -v want="$1" '$1 == want {print $2; exit}'
+}
+
+current_nvpmodel_id() {
+  have nvpmodel || { echo ""; return; }
+  nvpmodel -q 2>/dev/null | awk 'NR>1 && /^[0-9]+$/ {print; exit}'
+}
+
+# ── Clock pinning ────────────────────────────────────────────────────────────
+
+# True when the CPUs are pinned, i.e. jetson_clocks (or equivalent) has left
+# scaling_min_freq == scaling_max_freq so the governor has nothing to scale.
+clocks_pinned() {
+  local policy min max seen=0
+  for policy in /sys/devices/system/cpu/cpufreq/policy*; do
+    [ -d "$policy" ] || continue
+    min="$(cat "$policy/scaling_min_freq" 2>/dev/null || echo)"
+    max="$(cat "$policy/scaling_max_freq" 2>/dev/null || echo)"
+    [ -n "$min" ] && [ -n "$max" ] || continue
+    seen=1
+    # One policy the governor can still move is enough to say "not pinned".
+    [ "$min" = "$max" ] || return 1
+  done
+  [ "$seen" = "1" ]
+}
+
+# jetson_clocks also switches the cpuidle states off, and nothing in nvpmodel
+# turns them back on — so unpinning has to do it explicitly or the cores never
+# reach C7 again and the idle-power win never materialises.
+enable_cpuidle() {
+  local f
+  for f in /sys/devices/system/cpu/cpu*/cpuidle/state*/disable; do
+    [ -w "$f" ] || continue
+    echo 0 > "$f" 2>/dev/null || true
+  done
+}
+
+# Hand the governor its range back. `nvpmodel -m` rewrites the min/max caps for
+# the selected mode already; this is the belt-and-braces half, because a box
+# that was pinned by jetson_clocks BEFORE nvpmodel ran can end up with
+# scaling_min still at the ceiling.
+unpin_cpu_freq() {
+  local policy floor
+  for policy in /sys/devices/system/cpu/cpufreq/policy*; do
+    [ -d "$policy" ] || continue
+    floor="$(cat "$policy/cpuinfo_min_freq" 2>/dev/null || echo)"
+    [ -n "$floor" ] || continue
+    [ -w "$policy/scaling_min_freq" ] || continue
+    echo "$floor" > "$policy/scaling_min_freq" 2>/dev/null || true
+  done
+}
+
+apply_balanced() {
+  local id name
+  id="$(balanced_mode_id)"
+  name="$(mode_name_for_id "$id")"
+  if have nvpmodel; then
+    nvpmodel -m "$id" >/dev/null 2>&1 || echo "warning: nvpmodel -m $id failed" >&2
+    echo "nvpmodel mode $id (${name:-unknown})"
+  else
+    echo "nvpmodel not present, skipping mode select"
+  fi
+  # No jetson_clocks. That is the whole point of this profile.
+  unpin_cpu_freq
+  enable_cpuidle
+  echo "jetson_clocks: not applied (DVFS + cpuidle left to the kernel)"
+}
+
+apply_performance() {
+  local id name
+  id="$(performance_mode_id)"
+  [ -n "$id" ] || id="$(balanced_mode_id)"
+  name="$(mode_name_for_id "$id")"
+  if have nvpmodel; then
+    nvpmodel -m "$id" >/dev/null 2>&1 || echo "warning: nvpmodel -m $id failed" >&2
+    echo "nvpmodel mode $id (${name:-unknown})"
+  else
+    echo "nvpmodel not present, skipping mode select"
+  fi
+  if have jetson_clocks; then
+    jetson_clocks >/dev/null 2>&1 || echo "warning: jetson_clocks failed" >&2
+    echo "jetson_clocks: applied (clocks pinned)"
+  else
+    echo "jetson_clocks not present"
+  fi
+}
+
+report() {
+  local mode id name pinned supported perf
+  mode="$(read_mode)"
+  id="$(current_nvpmodel_id)"
+  name="$(mode_name_for_id "${id:-}")"
+  if clocks_pinned; then pinned=true; else pinned=false; fi
+  if have nvpmodel; then supported=true; else supported=false; fi
+  perf="$(performance_mode_id)"
+  printf '{"supported":%s,"mode":"%s","nvpmodelId":%s,"nvpmodelName":"%s","clocksPinned":%s,"balancedId":%s,"performanceId":%s}\n' \
+    "$supported" "$mode" \
+    "${id:-null}" "${name:-unknown}" "$pinned" \
+    "$(balanced_mode_id)" "${perf:-null}"
+}
+
+require_root() {
+  if [ "$(id -u)" != "0" ]; then
+    echo "Error: this action must run as root" >&2
+    exit 1
+  fi
+}
+
+main() {
+  case "${1:-}" in
+    --check)
+      report
+      ;;
+    --balanced)
+      require_root
+      write_mode balanced
+      apply_balanced
+      report
+      ;;
+    --performance)
+      require_root
+      write_mode performance
+      apply_performance
+      report
+      ;;
+    --apply)
+      require_root
+      if [ "$(read_mode)" = "performance" ]; then apply_performance; else apply_balanced; fi
+      report
+      ;;
+    --restore)
+      require_root
+      # ExecStop path. Always unpins, whatever the persisted mode is: stopping
+      # the unit means "stop holding the clocks up".
+      apply_balanced
+      ;;
+    *)
+      usage
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/clawbox-resource-limits.sh
+++ b/scripts/clawbox-resource-limits.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+#
+# Install the cgroup v2 memory guards for the three units that can eat an 8 GB
+# Jetson on their own: ollama, the automation browser and the GNOME session.
+# TASK-455.
+#
+# Every number comes from config/clawbox-resource-limits.env — see that file for
+# why each one is what it is. Nothing is hardcoded here.
+#
+#   --check    print the resolved limits and what WOULD be written; touch nothing
+#   --apply    write the drop-ins and daemon-reload
+#
+# Idempotent and reversible: --apply only ever writes three files named
+# 50-clawbox-memory.conf, so removing those three files and reloading systemd
+# restores stock behaviour exactly.
+#
+# Must run as root for --apply. --check needs no privileges at all, which is the
+# point: the setup-api route and the unit tests both drive it.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# The three unit-name -> variable-prefix pairs this script manages.
+DESKTOP_UID="${CLAWBOX_DESKTOP_UID:-1000}"
+
+DROPIN_NAME="50-clawbox-memory.conf"
+SYSTEMD_DIR="${CLAWBOX_SYSTEMD_DIR:-/etc/systemd/system}"
+
+usage() {
+  echo "Usage: $(basename "$0") --check | --apply" >&2
+  exit 2
+}
+
+# ── Reading the limits ───────────────────────────────────────────────────────
+#
+# Deliberately a parser, NOT `source`. The fallback location is the repo copy
+# under /home/clawbox/clawbox/config, which is clawbox-owned and
+# clawbox-writable; this script runs as root via a NOPASSWD sudoers grant, so
+# sourcing that file would hand root to anything with clawbox-level code
+# execution. Only `KEY=value` lines whose KEY is one we asked for are read, and
+# the value must be a bare systemd size or an integer.
+limits_file() {
+  local candidates=()
+  [ -n "${CLAWBOX_RESOURCE_LIMITS_FILE:-}" ] && candidates+=("$CLAWBOX_RESOURCE_LIMITS_FILE")
+  candidates+=("/etc/clawbox/resource-limits.env")
+  candidates+=("$SCRIPT_DIR/../config/clawbox-resource-limits.env")
+  local f
+  for f in "${candidates[@]}"; do
+    [ -f "$f" ] && { echo "$f"; return 0; }
+  done
+  return 1
+}
+
+# read_limit <KEY> — echo the value, or exit non-zero if absent/malformed.
+read_limit() {
+  local key="$1" file value
+  file="$(limits_file)" || {
+    echo "Error: no resource-limits env file found" >&2
+    return 1
+  }
+  value="$(sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\([0-9][0-9]*[KMGT]\{0,1\}\)[[:space:]]*$/\1/p" "$file" | tail -1)"
+  if [ -z "$value" ]; then
+    echo "Error: ${key} missing or malformed in ${file}" >&2
+    return 1
+  fi
+  echo "$value"
+}
+
+# ── Drop-in rendering ────────────────────────────────────────────────────────
+
+# dropin_body <High> <Max> <why>
+dropin_body() {
+  cat <<EOF
+# Written by clawbox-resource-limits.sh (TASK-455). Do not edit by hand — edit
+# config/clawbox-resource-limits.env in the ClawBox repo and re-run
+# \`sudo /usr/local/libexec/clawbox/clawbox-resource-limits.sh --apply\`.
+#
+# $3
+[Service]
+MemoryAccounting=yes
+MemoryHigh=$1
+MemoryMax=$2
+EOF
+}
+
+# One row per managed unit: unit-dir-name | High var | Max var | rationale
+managed_units() {
+  echo "ollama.service|CLAWBOX_OLLAMA_MEMORY_HIGH|CLAWBOX_OLLAMA_MEMORY_MAX|Local inference server: a resident 3B model plus two parallel slots."
+  echo "clawbox-browser.service|CLAWBOX_BROWSER_MEMORY_HIGH|CLAWBOX_BROWSER_MEMORY_MAX|Chromium under CDP automation: caps a runaway renderer, not normal browsing."
+  echo "user@${DESKTOP_UID}.service|CLAWBOX_DESKTOP_MEMORY_HIGH|CLAWBOX_DESKTOP_MEMORY_MAX|The GNOME desktop session. Backstop against a leaking shell extension."
+}
+
+main() {
+  local mode="${1:-}"
+  [ "$mode" = "--check" ] || [ "$mode" = "--apply" ] || usage
+
+  local file
+  file="$(limits_file)" || {
+    echo "Error: no resource-limits env file found" >&2
+    exit 1
+  }
+
+  if [ "$mode" = "--apply" ] && [ "$(id -u)" != "0" ]; then
+    echo "Error: --apply must run as root" >&2
+    exit 1
+  fi
+
+  echo "source: $file"
+  echo "mode: ${mode#--}"
+
+  local unit high_var max_var why high max dir dest
+  while IFS='|' read -r unit high_var max_var why; do
+    [ -n "$unit" ] || continue
+    high="$(read_limit "$high_var")"
+    max="$(read_limit "$max_var")"
+    dir="$SYSTEMD_DIR/${unit}.d"
+    dest="$dir/$DROPIN_NAME"
+    echo "unit: $unit MemoryHigh=$high MemoryMax=$max -> $dest"
+    if [ "$mode" = "--apply" ]; then
+      mkdir -p "$dir"
+      dropin_body "$high" "$max" "$why" > "$dest"
+      chown root:root "$dest" 2>/dev/null || true
+      chmod 0644 "$dest"
+    fi
+  done < <(managed_units)
+
+  if [ "$mode" = "--apply" ]; then
+    systemctl daemon-reload 2>/dev/null || true
+    # Re-apply to already-running units so the guards are live without a
+    # reboot. `set-property --runtime` is a no-op for a unit that is not
+    # running, which is the normal state for the browser and often for ollama.
+    while IFS='|' read -r unit high_var max_var _why; do
+      [ -n "$unit" ] || continue
+      high="$(read_limit "$high_var")"
+      max="$(read_limit "$max_var")"
+      systemctl set-property --runtime "$unit" "MemoryAccounting=yes" "MemoryHigh=$high" "MemoryMax=$max" \
+        >/dev/null 2>&1 || true
+    done < <(managed_units)
+    echo "result: applied"
+  else
+    echo "result: no changes made (--check)"
+  fi
+}
+
+main "$@"

--- a/scripts/optimize-ollama.sh
+++ b/scripts/optimize-ollama.sh
@@ -1,14 +1,54 @@
 #!/usr/bin/env bash
-# Optimize Ollama systemd service for 8GB Jetson:
+# Optimize Ollama systemd service for the 8GB Jetson:
 # - Q8_0 KV cache (halves KV memory vs FP16 default)
 # - Flash attention (required for KV cache quantization)
 # - Single model loaded at a time (prevents OOM)
-# - Single parallel request (prevents KV cache duplication)
+# - Two parallel slots, so the agent and the human don't queue behind each other
+# - An explicit context length, so the cost of those slots is predictable
+#
+# The two numbers on the last two lines come from
+# config/clawbox-resource-limits.env, which is also where the reasoning for them
+# is written down. The MEMORY guard for this unit is NOT here — it is a separate
+# drop-in (50-clawbox-memory.conf) written by clawbox-resource-limits.sh, so the
+# two concerns never fight over the same file.
 #
 # Must be run as root. Called from install.sh and from the configure route
 # via sudoers.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# Same strict parser as clawbox-resource-limits.sh, and deliberately NOT
+# `source`: the repo fallback below lives in the clawbox-writable tree while
+# this script runs as root under a NOPASSWD grant. Only integer values of the
+# exact keys we ask for are ever read.
+read_limit() {
+  local key="$1" fallback="$2" f value
+  for f in \
+    "${CLAWBOX_RESOURCE_LIMITS_FILE:-}" \
+    /etc/clawbox/resource-limits.env \
+    "$SCRIPT_DIR/../config/clawbox-resource-limits.env"
+  do
+    [ -n "$f" ] && [ -f "$f" ] || continue
+    value="$(sed -n "s/^[[:space:]]*${key}[[:space:]]*=[[:space:]]*\([0-9][0-9]*\)[[:space:]]*$/\1/p" "$f" | tail -1)"
+    if [ -n "$value" ]; then
+      echo "$value"
+      return 0
+    fi
+  done
+  echo "$fallback"
+}
+
+NUM_PARALLEL="$(read_limit CLAWBOX_OLLAMA_NUM_PARALLEL 2)"
+CONTEXT_LENGTH="$(read_limit CLAWBOX_OLLAMA_CONTEXT_LENGTH 4096)"
+
+if [ "${1:-}" = "--check" ]; then
+  echo "OLLAMA_NUM_PARALLEL=$NUM_PARALLEL"
+  echo "OLLAMA_CONTEXT_LENGTH=$CONTEXT_LENGTH"
+  echo "result: no changes made (--check)"
+  exit 0
+fi
 
 if ! systemctl list-unit-files ollama.service &>/dev/null; then
   echo "Ollama service not found, skipping"
@@ -16,14 +56,15 @@ if ! systemctl list-unit-files ollama.service &>/dev/null; then
 fi
 
 mkdir -p /etc/systemd/system/ollama.service.d
-cat > /etc/systemd/system/ollama.service.d/override.conf << 'EOF'
+cat > /etc/systemd/system/ollama.service.d/override.conf << EOF
 [Service]
 Environment="OLLAMA_KV_CACHE_TYPE=q8_0"
 Environment="OLLAMA_FLASH_ATTENTION=1"
 Environment="OLLAMA_MAX_LOADED_MODELS=1"
-Environment="OLLAMA_NUM_PARALLEL=1"
+Environment="OLLAMA_NUM_PARALLEL=${NUM_PARALLEL}"
+Environment="OLLAMA_CONTEXT_LENGTH=${CONTEXT_LENGTH}"
 EOF
 
 systemctl daemon-reload
 systemctl restart ollama 2>/dev/null || true
-echo "Ollama optimized (q8_0 KV cache, flash attention, single model)"
+echo "Ollama optimized (q8_0 KV cache, flash attention, single model, ${NUM_PARALLEL} parallel slots, ctx ${CONTEXT_LENGTH})"

--- a/src/app/setup-api/system/desktop/route.ts
+++ b/src/app/setup-api/system/desktop/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { requireSession } from "@/lib/route-auth";
+import {
+  ProfileUnavailableError,
+  readDesktopMode,
+  setDesktopMode,
+} from "@/lib/system-profile";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Settings → System → "Desktop environment" (TASK-455).
+ *
+ * GET  → the current state (see DesktopModeStatus).
+ * POST { enabled: boolean } → flip the boot target; applies at the next reboot.
+ *
+ * Owner-only, both verbs, with NO bootstrap carve-out. The wizard never calls
+ * this, so there is no first-boot window to keep open — and a device whose
+ * desktop anyone in radio range of the setup AP could switch off is a device
+ * anyone in radio range can take the console away from. TASK-443's rule.
+ */
+export async function GET(req: Request) {
+  const unauthorized = await requireSession(req);
+  if (unauthorized) return unauthorized;
+  return NextResponse.json(await readDesktopMode());
+}
+
+export async function POST(req: Request) {
+  const unauthorized = await requireSession(req);
+  if (unauthorized) return unauthorized;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const enabled = (body as { enabled?: unknown } | null)?.enabled;
+  if (typeof enabled !== "boolean") {
+    return NextResponse.json(
+      { error: "Invalid body. Expected { enabled: boolean }." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    return NextResponse.json(await setDesktopMode(enabled));
+  } catch (err) {
+    // A box whose root-owned script was never installed is a configuration
+    // problem, not a server fault — say so with a 503 and the command that
+    // fixes it, rather than a 500 the UI can only render as "something broke".
+    if (err instanceof ProfileUnavailableError) {
+      return NextResponse.json({ error: err.message }, { status: 503 });
+    }
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to change desktop mode" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/setup-api/system/power-profile/route.ts
+++ b/src/app/setup-api/system/power-profile/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { requireSession } from "@/lib/route-auth";
+import {
+  ProfileUnavailableError,
+  isPowerMode,
+  readPowerMode,
+  setPowerMode,
+} from "@/lib/system-profile";
+import { RESOURCE_LIMITS } from "@/lib/resource-limits";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * Settings → System → "Performance mode" (TASK-455).
+ *
+ * GET  → the current profile plus the memory guards in force, so the panel can
+ *        state the numbers instead of the UI hardcoding a second copy of them.
+ * POST { mode: "balanced" | "performance" } → applies immediately, no reboot.
+ *
+ * Owner-only, both verbs — same reasoning as the desktop route: pinning the
+ * clocks is a thermal decision on a passively-cooled appliance, not something
+ * an anonymous caller gets to make.
+ */
+export async function GET(req: Request) {
+  const unauthorized = await requireSession(req);
+  if (unauthorized) return unauthorized;
+  return NextResponse.json({
+    ...(await readPowerMode()),
+    limits: RESOURCE_LIMITS,
+  });
+}
+
+export async function POST(req: Request) {
+  const unauthorized = await requireSession(req);
+  if (unauthorized) return unauthorized;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  const mode = (body as { mode?: unknown } | null)?.mode;
+  if (!isPowerMode(mode)) {
+    return NextResponse.json(
+      { error: "Invalid body. Expected { mode: \"balanced\" | \"performance\" }." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    return NextResponse.json({ ...(await setPowerMode(mode)), limits: RESOURCE_LIMITS });
+  } catch (err) {
+    if (err instanceof ProfileUnavailableError) {
+      return NextResponse.json({ error: err.message }, { status: 503 });
+    }
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : "Failed to change power profile" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -16,6 +16,7 @@ import TelegramConfiguringOverlay from "./TelegramConfiguringOverlay";
 import RemoteControlPanel from "./RemoteControlPanel";
 import LocalModelsPanel from "./LocalModelsPanel";
 import VoiceOutputPanel from "./VoiceOutputPanel";
+import SystemProfilePanel from "./SystemProfilePanel";
 import FreeTierUpgradeCard from "./FreeTierUpgradeCard";
 import { copyToClipboard } from "@/lib/clipboard";
 import ClawBoxLoginModal, { type ClawBoxLoginFeature } from "./ClawBoxLoginModal";
@@ -2883,6 +2884,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
           <div className="max-w-xl space-y-5">
 
             <HarnessPicker />
+
+            {/* Desktop environment + Performance mode. Above the read-only
+                stats cards on purpose: these are the two controls on this tab
+                that change what the box does, and the cards below are what
+                they change. TASK-455. */}
+            <SystemProfilePanel />
 
             {stats ? (
               <>

--- a/src/components/SystemProfilePanel.tsx
+++ b/src/components/SystemProfilePanel.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useT } from "@/lib/i18n";
+import StatusMessage from "./StatusMessage";
+
+/**
+ * Settings → System → Desktop environment + Performance mode (TASK-455).
+ *
+ * Two switches over two routes. They are deliberately in ONE card: both trade
+ * the same thing (idle memory, idle watts) against the same thing (how much the
+ * box does without being asked), and an owner reasoning about one is reasoning
+ * about the other.
+ *
+ * Neither switch is optimistic. Both post, wait for the route to return the
+ * re-read state, and render THAT — because "did the desktop actually turn off"
+ * is answered by `systemctl get-default`, not by what we just asked for.
+ */
+
+interface DesktopStatus {
+  supported: boolean;
+  enabled: boolean;
+  active: boolean;
+  rebootRequired: boolean;
+  defaultTarget: string;
+  displayManager: string;
+}
+
+interface PowerLimits {
+  ollama: { memoryHigh: string; memoryMax: string };
+  browser: { memoryHigh: string; memoryMax: string };
+  desktop: { memoryHigh: string; memoryMax: string };
+  ollamaNumParallel: number;
+}
+
+interface PowerStatus {
+  supported: boolean;
+  mode: "balanced" | "performance";
+  nvpmodelId: number | null;
+  nvpmodelName: string;
+  clocksPinned: boolean;
+  limits?: PowerLimits;
+}
+
+function Switch({
+  checked, busy, disabled, label, onChange,
+}: {
+  checked: boolean;
+  busy: boolean;
+  disabled: boolean;
+  label: string;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 shrink-0">
+      {busy && (
+        <span className="material-symbols-rounded animate-spin text-[var(--text-muted)]" style={{ fontSize: 18 }} aria-hidden="true">
+          progress_activity
+        </span>
+      )}
+      <button
+        type="button"
+        role="switch"
+        aria-label={label}
+        aria-checked={checked}
+        aria-busy={busy}
+        disabled={disabled || busy}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
+          checked ? "bg-[var(--coral-bright)]" : "bg-gray-600"
+        }`}
+      >
+        <span className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${checked ? "translate-x-6" : "translate-x-1"}`} />
+      </button>
+    </div>
+  );
+}
+
+export default function SystemProfilePanel() {
+  const { t } = useT();
+  const [desktop, setDesktop] = useState<DesktopStatus | null>(null);
+  const [power, setPower] = useState<PowerStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<"desktop" | "power" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [d, p] = await Promise.all([
+        fetch("/setup-api/system/desktop", { cache: "no-store" }),
+        fetch("/setup-api/system/power-profile", { cache: "no-store" }),
+      ]);
+      if (d.ok) setDesktop(await d.json() as DesktopStatus);
+      if (p.ok) setPower(await p.json() as PowerStatus);
+      if (!d.ok && !p.ok) setError(t("systemProfile.loadFailed"));
+    } catch {
+      setError(t("systemProfile.loadFailed"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const readError = async (res: Response, fallback: string) => {
+    try {
+      const data = await res.json() as { error?: string };
+      return typeof data.error === "string" && data.error ? data.error : fallback;
+    } catch {
+      return fallback;
+    }
+  };
+
+  const toggleDesktop = async (next: boolean) => {
+    setBusy("desktop");
+    setError(null);
+    try {
+      const res = await fetch("/setup-api/system/desktop", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!res.ok) throw new Error(await readError(res, t("systemProfile.desktopFailed")));
+      setDesktop(await res.json() as DesktopStatus);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("systemProfile.desktopFailed"));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const togglePower = async (next: boolean) => {
+    setBusy("power");
+    setError(null);
+    try {
+      const res = await fetch("/setup-api/system/power-profile", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ mode: next ? "performance" : "balanced" }),
+      });
+      if (!res.ok) throw new Error(await readError(res, t("systemProfile.powerFailed")));
+      setPower(await res.json() as PowerStatus);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("systemProfile.powerFailed"));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) return null;
+
+  return (
+    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <span className="material-symbols-rounded text-[var(--coral-bright)]" style={{ fontSize: 18 }}>tune</span>
+        <label className="text-[10px] font-semibold text-[var(--text-muted)] uppercase tracking-widest">
+          {t("systemProfile.title")}
+        </label>
+      </div>
+
+      {/* Desktop environment */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-sm text-[var(--text-primary)]">{t("systemProfile.desktopLabel")}</p>
+          <p className="text-[11px] text-[var(--text-muted)] opacity-60 mt-1 leading-relaxed">
+            {t("systemProfile.desktopHelp")}
+          </p>
+          {desktop && !desktop.supported && (
+            <p className="text-[11px] text-[var(--text-muted)] opacity-60 mt-1">{t("systemProfile.unsupported")}</p>
+          )}
+          {desktop?.rebootRequired && (
+            <p className="text-[11px] text-amber-400 mt-2 flex items-center gap-1">
+              <span className="material-symbols-rounded" style={{ fontSize: 14 }} aria-hidden="true">restart_alt</span>
+              {t("systemProfile.rebootRequired")}
+            </p>
+          )}
+        </div>
+        <Switch
+          checked={desktop?.enabled ?? true}
+          busy={busy === "desktop"}
+          disabled={!desktop?.supported}
+          label={t("systemProfile.desktopLabel")}
+          onChange={toggleDesktop}
+        />
+      </div>
+
+      <div className="h-px bg-white/[0.06] my-4" />
+
+      {/* Performance mode */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-sm text-[var(--text-primary)]">{t("systemProfile.performanceLabel")}</p>
+          <p className="text-[11px] text-[var(--text-muted)] opacity-60 mt-1 leading-relaxed">
+            {t("systemProfile.performanceHelp")}
+          </p>
+          {power && !power.supported && (
+            <p className="text-[11px] text-[var(--text-muted)] opacity-60 mt-1">{t("systemProfile.unsupported")}</p>
+          )}
+          {power?.supported && (
+            <p className="text-[10px] text-[var(--text-muted)] opacity-50 mt-1 font-mono">
+              {t("systemProfile.powerState", {
+                profile: power.nvpmodelName,
+                clocks: power.clocksPinned ? t("systemProfile.clocksPinned") : t("systemProfile.clocksDynamic"),
+              })}
+            </p>
+          )}
+        </div>
+        <Switch
+          checked={power?.mode === "performance"}
+          busy={busy === "power"}
+          disabled={!power?.supported}
+          label={t("systemProfile.performanceLabel")}
+          onChange={togglePower}
+        />
+      </div>
+
+      {power?.limits && (
+        <>
+          <div className="h-px bg-white/[0.06] my-4" />
+          <p className="text-[11px] text-[var(--text-muted)] opacity-60 leading-relaxed">
+            {t("systemProfile.memoryGuards", {
+              ollama: power.limits.ollama.memoryMax,
+              browser: power.limits.browser.memoryMax,
+              desktop: power.limits.desktop.memoryMax,
+              parallel: String(power.limits.ollamaNumParallel),
+            })}
+          </p>
+        </>
+      )}
+
+      {error && <div className="mt-3"><StatusMessage type="error" message={error} /></div>}
+    </div>
+  );
+}

--- a/src/lib/hermes-translations.ts
+++ b/src/lib/hermes-translations.ts
@@ -3,6 +3,7 @@ import { settingsSecurityEn } from "./hermes-translations/en-settings-security";
 import { providerEn } from "./hermes-translations/en-provider";
 import { skillsEn } from "./hermes-translations/en-skills";
 import { localModelsEn } from "./hermes-translations/en-local-models";
+import { systemProfileEn } from "./hermes-translations/en-system-profile";
 import { bg } from "./hermes-translations/bg";
 import { de } from "./hermes-translations/de";
 import { es } from "./hermes-translations/es";
@@ -16,12 +17,12 @@ import { zh } from "./hermes-translations/zh";
 /**
  * The surfaces that used to bypass `t()` entirely: the system-password card,
  * the Hermes provider picker, the Skills store and the Local Models tab
- * (TASK-458). They are grouped here rather than appended to
+ * (TASK-458), joined by the Desktop & power card (TASK-455). They are grouped here rather than appended to
  * `desktop-translations` because they arrived as one i18n pass and a reviewer
  * should be able to read that pass as one diff.
  *
- * English is authored per surface (four `en-*` modules, so each surface's copy
- * sits next to nothing else); every other locale is one file per language.
+ * English is authored per surface (one `en-*` module each, so each surface's
+ * copy sits next to nothing else); every other locale is one file per language.
  *
  * WHY every locale is spread over `en`: a key that a translator has not reached
  * yet must still RESOLVE — to the English sentence — instead of leaving the raw
@@ -34,6 +35,7 @@ export const hermesEn: Record<string, string> = {
   ...providerEn,
   ...skillsEn,
   ...localModelsEn,
+  ...systemProfileEn,
 };
 
 const overrides: Record<Exclude<Locale, "en">, Record<string, string>> = {

--- a/src/lib/hermes-translations/bg.ts
+++ b/src/lib/hermes-translations/bg.ts
@@ -336,4 +336,20 @@ export const bg: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "Моделът не можа да бъде променен.",
   "localModels.error.unreachable": "Кутията не отговори, за да бъде променен моделът.",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "Работен плот и захранване",
+  "systemProfile.desktopLabel": "Работен плот",
+  "systemProfile.desktopHelp": "Пуска пълния работен плот GNOME на HDMI изхода на кутията и в Отдалечен работен плот. Изключете го, за да работи кутията без екран и да си върнете около 700 MB памет — нищо не се деинсталира, така че можете да го включите отново по всяко време.",
+  "systemProfile.performanceLabel": "Режим на производителност",
+  "systemProfile.performanceHelp": "Заковава честотите на процесора и графиката на максимум, вместо да ги оставя да се менят. По-бърз първи отговор, но платката тогава стои на около 7,2 W в покой, а при продължителна локална инференция измерихме 74,8 °C — точно над границата от 74 °C за пасивно охлаждане. Оставете го изключен, освен ако не пускате дълги задачи и нямате обдухване.",
+  "systemProfile.rebootRequired": "Рестартирайте кутията, за да влезе в сила промяната.",
+  "systemProfile.unsupported": "Не е налично на това устройство.",
+  "systemProfile.powerState": "Профил на захранване: {profile} · честоти: {clocks}",
+  "systemProfile.clocksPinned": "заковани",
+  "systemProfile.clocksDynamic": "динамични",
+  "systemProfile.memoryGuards": "Действащи лимити на паметта: локален AI {ollama}, браузър {browser}, работен плот {desktop}. Локалният AI обслужва {parallel} заявки едновременно.",
+  "systemProfile.loadFailed": "Настройките за работен плот и захранване не можаха да бъдат прочетени.",
+  "systemProfile.desktopFailed": "Настройката за работен плот не можа да бъде променена.",
+  "systemProfile.powerFailed": "Профилът на захранване не можа да бъде променен.",
 };

--- a/src/lib/hermes-translations/de.ts
+++ b/src/lib/hermes-translations/de.ts
@@ -348,4 +348,20 @@ export const de: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "Dieses Modell konnte nicht geändert werden.",
   "localModels.error.unreachable": "Die Box ist nicht erreichbar — dieses Modell konnte nicht geändert werden.",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "Desktop & Energie",
+  "systemProfile.desktopLabel": "Desktop-Umgebung",
+  "systemProfile.desktopHelp": "Startet den vollständigen GNOME-Desktop am HDMI-Ausgang der Box und im Remote-Desktop. Ausschalten, um die Box ohne Bildschirm zu betreiben und rund 700 MB Arbeitsspeicher zurückzubekommen — es wird nichts deinstalliert, Sie können ihn jederzeit wieder einschalten.",
+  "systemProfile.performanceLabel": "Leistungsmodus",
+  "systemProfile.performanceHelp": "Fixiert CPU und GPU auf ihren höchsten Takt, statt sie regeln zu lassen. Schneller beim ersten Token, aber das Board liegt dann im Leerlauf bei etwa 7,2 W, und dauerhafte lokale Inferenz wurde mit 74,8 °C gemessen — knapp über der Grenze von 74 °C für passive Kühlung. Lassen Sie ihn aus, außer bei langen Aufgaben mit ausreichender Belüftung.",
+  "systemProfile.rebootRequired": "Starten Sie die Box neu, um diese Änderung anzuwenden.",
+  "systemProfile.unsupported": "Auf diesem Gerät nicht verfügbar.",
+  "systemProfile.powerState": "Energieprofil: {profile} · Takt: {clocks}",
+  "systemProfile.clocksPinned": "fixiert",
+  "systemProfile.clocksDynamic": "dynamisch",
+  "systemProfile.memoryGuards": "Geltende Speichergrenzen: lokale KI {ollama}, Browser {browser}, Desktop {desktop}. Die lokale KI bedient {parallel} Anfragen gleichzeitig.",
+  "systemProfile.loadFailed": "Die Desktop- und Energieeinstellungen konnten nicht gelesen werden.",
+  "systemProfile.desktopFailed": "Die Desktop-Einstellung konnte nicht geändert werden.",
+  "systemProfile.powerFailed": "Das Energieprofil konnte nicht geändert werden.",
 };

--- a/src/lib/hermes-translations/en-system-profile.ts
+++ b/src/lib/hermes-translations/en-system-profile.ts
@@ -1,0 +1,33 @@
+/**
+ * Settings → System → Desktop environment + Performance mode (TASK-455).
+ *
+ * The help text carries the THERMAL RATIONALE on purpose: the measurement is
+ * the reason the default changed, and an owner deciding whether to pin their
+ * clocks should be told what that costs before they do it, not after their
+ * living-room appliance is sitting at 75 C.
+ */
+export const systemProfileEn: Record<string, string> = {
+  "systemProfile.title": "Desktop & power",
+
+  "systemProfile.desktopLabel": "Desktop environment",
+  "systemProfile.desktopHelp":
+    "Runs the full GNOME desktop on the box's HDMI output and in Remote Desktop. Turn it off to run headless and get back about 700 MB of memory — nothing is uninstalled, so you can turn it back on any time.",
+
+  "systemProfile.performanceLabel": "Performance mode",
+  "systemProfile.performanceHelp":
+    "Pins the CPU and GPU to their maximum clocks instead of letting them scale. Faster to first token, but the board then idles at about 7.2 W and sustained local inference measured 74.8 °C — just over the 74 °C passive-cooling limit. Leave it off unless you are running long jobs and have airflow.",
+
+  "systemProfile.rebootRequired": "Restart the box to apply this change.",
+  "systemProfile.unsupported": "Not available on this device.",
+
+  "systemProfile.powerState": "Power profile: {profile} · clocks: {clocks}",
+  "systemProfile.clocksPinned": "pinned",
+  "systemProfile.clocksDynamic": "dynamic",
+
+  "systemProfile.memoryGuards":
+    "Memory limits in force: local AI {ollama}, browser {browser}, desktop {desktop}. Local AI serves {parallel} requests at a time.",
+
+  "systemProfile.loadFailed": "Could not read the desktop and power settings.",
+  "systemProfile.desktopFailed": "Could not change the desktop setting.",
+  "systemProfile.powerFailed": "Could not change the power profile.",
+};

--- a/src/lib/hermes-translations/es.ts
+++ b/src/lib/hermes-translations/es.ts
@@ -344,4 +344,20 @@ export const es: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "No se pudo cambiar ese modelo.",
   "localModels.error.unreachable": "No se pudo contactar con la caja para cambiar ese modelo.",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "Escritorio y energía",
+  "systemProfile.desktopLabel": "Entorno de escritorio",
+  "systemProfile.desktopHelp": "Ejecuta el escritorio GNOME completo en la salida HDMI de la caja y en Escritorio remoto. Desactívalo para funcionar sin pantalla y recuperar unos 700 MB de memoria: no se desinstala nada, así que puedes volver a activarlo cuando quieras.",
+  "systemProfile.performanceLabel": "Modo de rendimiento",
+  "systemProfile.performanceHelp": "Fija la CPU y la GPU a su frecuencia máxima en lugar de dejar que se ajusten. Llega antes al primer token, pero la placa se queda en reposo a unos 7,2 W y la inferencia local sostenida se midió a 74,8 °C, justo por encima del límite de 74 °C de la refrigeración pasiva. Déjalo desactivado salvo que ejecutes tareas largas y tengas ventilación.",
+  "systemProfile.rebootRequired": "Reinicia la caja para aplicar este cambio.",
+  "systemProfile.unsupported": "No disponible en este dispositivo.",
+  "systemProfile.powerState": "Perfil de energía: {profile} · frecuencias: {clocks}",
+  "systemProfile.clocksPinned": "fijas",
+  "systemProfile.clocksDynamic": "dinámicas",
+  "systemProfile.memoryGuards": "Límites de memoria en vigor: IA local {ollama}, navegador {browser}, escritorio {desktop}. La IA local atiende {parallel} peticiones a la vez.",
+  "systemProfile.loadFailed": "No se pudieron leer los ajustes de escritorio y energía.",
+  "systemProfile.desktopFailed": "No se pudo cambiar el ajuste de escritorio.",
+  "systemProfile.powerFailed": "No se pudo cambiar el perfil de energía.",
 };

--- a/src/lib/hermes-translations/fr.ts
+++ b/src/lib/hermes-translations/fr.ts
@@ -349,4 +349,20 @@ export const fr: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "Impossible de modifier ce modèle.",
   "localModels.error.unreachable": "Impossible de joindre la box pour modifier ce modèle.",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "Bureau et alimentation",
+  "systemProfile.desktopLabel": "Environnement de bureau",
+  "systemProfile.desktopHelp": "Lance le bureau GNOME complet sur la sortie HDMI de la box et dans le Bureau à distance. Désactivez-le pour fonctionner sans écran et récupérer environ 700 Mo de mémoire — rien n'est désinstallé, vous pouvez le réactiver à tout moment.",
+  "systemProfile.performanceLabel": "Mode performance",
+  "systemProfile.performanceHelp": "Fige le processeur et le GPU à leur fréquence maximale au lieu de les laisser varier. Le premier jeton arrive plus vite, mais la carte reste alors à environ 7,2 W au repos et l'inférence locale prolongée a été mesurée à 74,8 °C, juste au-dessus de la limite de 74 °C du refroidissement passif. Laissez-le désactivé sauf pour de longues tâches avec une bonne ventilation.",
+  "systemProfile.rebootRequired": "Redémarrez la box pour appliquer ce changement.",
+  "systemProfile.unsupported": "Non disponible sur cet appareil.",
+  "systemProfile.powerState": "Profil d'alimentation : {profile} · fréquences : {clocks}",
+  "systemProfile.clocksPinned": "figées",
+  "systemProfile.clocksDynamic": "dynamiques",
+  "systemProfile.memoryGuards": "Limites de mémoire en vigueur : IA locale {ollama}, navigateur {browser}, bureau {desktop}. L'IA locale traite {parallel} requêtes à la fois.",
+  "systemProfile.loadFailed": "Impossible de lire les réglages de bureau et d'alimentation.",
+  "systemProfile.desktopFailed": "Impossible de modifier le réglage du bureau.",
+  "systemProfile.powerFailed": "Impossible de modifier le profil d'alimentation.",
 };

--- a/src/lib/hermes-translations/it.ts
+++ b/src/lib/hermes-translations/it.ts
@@ -360,4 +360,20 @@ export const it: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "Non è stato possibile modificare quel modello.",
   "localModels.error.unreachable": "Non è stato possibile raggiungere il box per modificare quel modello.",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "Desktop e alimentazione",
+  "systemProfile.desktopLabel": "Ambiente desktop",
+  "systemProfile.desktopHelp": "Avvia il desktop GNOME completo sull'uscita HDMI della box e nel Desktop remoto. Disattivalo per lavorare senza schermo e recuperare circa 700 MB di memoria: non viene disinstallato nulla, puoi riattivarlo quando vuoi.",
+  "systemProfile.performanceLabel": "Modalità prestazioni",
+  "systemProfile.performanceHelp": "Blocca CPU e GPU alla frequenza massima invece di lasciarle variare. Il primo token arriva prima, ma la scheda resta a circa 7,2 W da ferma e l'inferenza locale prolungata è stata misurata a 74,8 °C, appena sopra il limite di 74 °C del raffreddamento passivo. Lasciala disattivata a meno che tu non esegua lavori lunghi con una buona ventilazione.",
+  "systemProfile.rebootRequired": "Riavvia la box per applicare la modifica.",
+  "systemProfile.unsupported": "Non disponibile su questo dispositivo.",
+  "systemProfile.powerState": "Profilo di alimentazione: {profile} · frequenze: {clocks}",
+  "systemProfile.clocksPinned": "bloccate",
+  "systemProfile.clocksDynamic": "dinamiche",
+  "systemProfile.memoryGuards": "Limiti di memoria attivi: AI locale {ollama}, browser {browser}, desktop {desktop}. L'AI locale serve {parallel} richieste per volta.",
+  "systemProfile.loadFailed": "Impossibile leggere le impostazioni di desktop e alimentazione.",
+  "systemProfile.desktopFailed": "Impossibile modificare l'impostazione del desktop.",
+  "systemProfile.powerFailed": "Impossibile modificare il profilo di alimentazione.",
 };

--- a/src/lib/hermes-translations/ja.ts
+++ b/src/lib/hermes-translations/ja.ts
@@ -351,4 +351,20 @@ export const ja: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "そのモデルを変更できませんでした。",
   "localModels.error.unreachable": "本体に接続できなかったため、そのモデルを変更できませんでした。",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "デスクトップと電力",
+  "systemProfile.desktopLabel": "デスクトップ環境",
+  "systemProfile.desktopHelp": "本体の HDMI 出力とリモートデスクトップで GNOME デスクトップをすべて実行します。オフにするとヘッドレスで動作し、約 700 MB のメモリが戻ります。何もアンインストールされないので、いつでも戻せます。",
+  "systemProfile.performanceLabel": "パフォーマンスモード",
+  "systemProfile.performanceHelp": "CPU と GPU の周波数を可変にせず最大値に固定します。最初のトークンまでは速くなりますが、待機時の消費電力は約 7.2 W になり、ローカル推論を連続実行したときの実測は 74.8 °C で、パッシブ冷却の上限 74 °C をわずかに超えます。長時間の処理を回し、風通しがある場合を除いてオフのままにしてください。",
+  "systemProfile.rebootRequired": "この変更を適用するには本体を再起動してください。",
+  "systemProfile.unsupported": "このデバイスでは利用できません。",
+  "systemProfile.powerState": "電力プロファイル: {profile} · クロック: {clocks}",
+  "systemProfile.clocksPinned": "固定",
+  "systemProfile.clocksDynamic": "可変",
+  "systemProfile.memoryGuards": "有効なメモリ上限: ローカル AI {ollama}、ブラウザ {browser}、デスクトップ {desktop}。ローカル AI は同時に {parallel} 件のリクエストを処理します。",
+  "systemProfile.loadFailed": "デスクトップと電力の設定を読み取れませんでした。",
+  "systemProfile.desktopFailed": "デスクトップの設定を変更できませんでした。",
+  "systemProfile.powerFailed": "電力プロファイルを変更できませんでした。",
 };

--- a/src/lib/hermes-translations/nl.ts
+++ b/src/lib/hermes-translations/nl.ts
@@ -349,4 +349,20 @@ export const nl: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "Kan dat model niet wijzigen.",
   "localModels.error.unreachable": "Kan de box niet bereiken om dat model te wijzigen.",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "Bureaublad en energie",
+  "systemProfile.desktopLabel": "Bureaubladomgeving",
+  "systemProfile.desktopHelp": "Draait het volledige GNOME-bureaublad op de HDMI-uitgang van de box en in Extern bureaublad. Zet het uit om headless te draaien en ongeveer 700 MB geheugen terug te krijgen — er wordt niets verwijderd, dus je kunt het altijd weer aanzetten.",
+  "systemProfile.performanceLabel": "Prestatiemodus",
+  "systemProfile.performanceHelp": "Zet de klok van processor en GPU vast op het maximum in plaats van die te laten schalen. Het eerste token komt sneller, maar het bord blijft dan op ongeveer 7,2 W in rust en aanhoudende lokale inferentie werd gemeten op 74,8 °C, net boven de grens van 74 °C voor passieve koeling. Laat het uit staan, tenzij je lange taken draait en voor luchtstroom zorgt.",
+  "systemProfile.rebootRequired": "Start de box opnieuw op om deze wijziging toe te passen.",
+  "systemProfile.unsupported": "Niet beschikbaar op dit apparaat.",
+  "systemProfile.powerState": "Energieprofiel: {profile} · klok: {clocks}",
+  "systemProfile.clocksPinned": "vast",
+  "systemProfile.clocksDynamic": "dynamisch",
+  "systemProfile.memoryGuards": "Actieve geheugenlimieten: lokale AI {ollama}, browser {browser}, bureaublad {desktop}. De lokale AI verwerkt {parallel} verzoeken tegelijk.",
+  "systemProfile.loadFailed": "Kan de bureaublad- en energie-instellingen niet lezen.",
+  "systemProfile.desktopFailed": "Kan de bureaubladinstelling niet wijzigen.",
+  "systemProfile.powerFailed": "Kan het energieprofiel niet wijzigen.",
 };

--- a/src/lib/hermes-translations/sv.ts
+++ b/src/lib/hermes-translations/sv.ts
@@ -345,4 +345,20 @@ export const sv: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "Det gick inte att ändra den modellen.",
   "localModels.error.unreachable": "Det gick inte att nå boxen för att ändra den modellen.",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "Skrivbord och ström",
+  "systemProfile.desktopLabel": "Skrivbordsmiljö",
+  "systemProfile.desktopHelp": "Kör hela GNOME-skrivbordet på boxens HDMI-utgång och i Fjärrskrivbord. Stäng av det för att köra utan skärm och få tillbaka ungefär 700 MB minne — inget avinstalleras, så du kan slå på det igen när du vill.",
+  "systemProfile.performanceLabel": "Prestandaläge",
+  "systemProfile.performanceHelp": "Låser processorn och GPU:n på högsta klockfrekvens i stället för att låta dem variera. Första token kommer snabbare, men kortet ligger då på ungefär 7,2 W i vila och ihållande lokal inferens uppmättes till 74,8 °C, precis över gränsen på 74 °C för passiv kylning. Låt det vara av om du inte kör långa jobb och har luftflöde.",
+  "systemProfile.rebootRequired": "Starta om boxen för att tillämpa ändringen.",
+  "systemProfile.unsupported": "Inte tillgängligt på den här enheten.",
+  "systemProfile.powerState": "Strömprofil: {profile} · klockor: {clocks}",
+  "systemProfile.clocksPinned": "låsta",
+  "systemProfile.clocksDynamic": "dynamiska",
+  "systemProfile.memoryGuards": "Gällande minnesgränser: lokal AI {ollama}, webbläsare {browser}, skrivbord {desktop}. Den lokala AI:n betjänar {parallel} förfrågningar åt gången.",
+  "systemProfile.loadFailed": "Kunde inte läsa skrivbords- och ströminställningarna.",
+  "systemProfile.desktopFailed": "Kunde inte ändra skrivbordsinställningen.",
+  "systemProfile.powerFailed": "Kunde inte ändra strömprofilen.",
 };

--- a/src/lib/hermes-translations/zh.ts
+++ b/src/lib/hermes-translations/zh.ts
@@ -360,4 +360,20 @@ export const zh: Record<string, string> = {
   // === Errors ===
   "localModels.error.changeFailed": "无法更改该模型。",
   "localModels.error.unreachable": "无法连接到这台 ClawBox，因此无法更改该模型。",
+
+  // === Desktop & power (TASK-455) ===
+  "systemProfile.title": "桌面与电源",
+  "systemProfile.desktopLabel": "桌面环境",
+  "systemProfile.desktopHelp": "在设备的 HDMI 输出和远程桌面上运行完整的 GNOME 桌面。关闭后设备以无头模式运行，可释放约 700 MB 内存——不会卸载任何组件，随时可以重新开启。",
+  "systemProfile.performanceLabel": "性能模式",
+  "systemProfile.performanceHelp": "将 CPU 和 GPU 锁定在最高频率，而不是让它们动态调节。首个 token 更快，但空闲功耗会升到约 7.2 W，持续本地推理实测为 74.8 °C，略高于 74 °C 的被动散热上限。除非要跑长任务且散热良好，否则请保持关闭。",
+  "systemProfile.rebootRequired": "重启设备以应用此更改。",
+  "systemProfile.unsupported": "此设备不支持。",
+  "systemProfile.powerState": "电源配置：{profile} · 频率：{clocks}",
+  "systemProfile.clocksPinned": "锁定",
+  "systemProfile.clocksDynamic": "动态",
+  "systemProfile.memoryGuards": "当前内存上限：本地 AI {ollama}，浏览器 {browser}，桌面 {desktop}。本地 AI 同时处理 {parallel} 个请求。",
+  "systemProfile.loadFailed": "无法读取桌面与电源设置。",
+  "systemProfile.desktopFailed": "无法更改桌面设置。",
+  "systemProfile.powerFailed": "无法更改电源配置。",
 };

--- a/src/lib/resource-limits.ts
+++ b/src/lib/resource-limits.ts
@@ -27,7 +27,7 @@ export const RESOURCE_LIMITS: ResourceLimits = {
   memTotalMiB: 7607,
   ollama: { memoryHigh: "5G", memoryMax: "5632M" },
   browser: { memoryHigh: "1200M", memoryMax: "1536M" },
-  desktop: { memoryHigh: "1200M", memoryMax: "1800M" },
+  desktop: { memoryHigh: "1400M", memoryMax: "2048M" },
   ollamaNumParallel: 2,
   ollamaContextLength: 4096,
 };

--- a/src/lib/resource-limits.ts
+++ b/src/lib/resource-limits.ts
@@ -1,0 +1,62 @@
+/**
+ * The TypeScript mirror of `config/clawbox-resource-limits.env` (TASK-455).
+ *
+ * That file is the single source of truth — it is what the shell scripts read
+ * at runtime, and it is where the measurement behind each number is written
+ * down. This module exists because the API and Settings UI have to be able to
+ * SAY what the limits are ("Ollama is capped at 5G") without shelling out, and
+ * because a bundled Next.js standalone build does not ship `config/`.
+ *
+ * The two are pinned together by `src/tests/unit/resource-limits.test.ts`,
+ * which parses the env file and asserts every value here matches. Changing a
+ * number in one place and not the other fails CI — which is the whole point of
+ * having a mirror rather than a second opinion.
+ */
+
+export interface ResourceLimits {
+  /** Total physical RAM of the target device, MiB. Documentation only. */
+  memTotalMiB: number;
+  ollama: { memoryHigh: string; memoryMax: string };
+  browser: { memoryHigh: string; memoryMax: string };
+  desktop: { memoryHigh: string; memoryMax: string };
+  ollamaNumParallel: number;
+  ollamaContextLength: number;
+}
+
+export const RESOURCE_LIMITS: ResourceLimits = {
+  memTotalMiB: 7607,
+  ollama: { memoryHigh: "5G", memoryMax: "5632M" },
+  browser: { memoryHigh: "1200M", memoryMax: "1536M" },
+  desktop: { memoryHigh: "1200M", memoryMax: "1800M" },
+  ollamaNumParallel: 2,
+  ollamaContextLength: 4096,
+};
+
+/** The env-file key each mirrored value is pinned to. */
+export const RESOURCE_LIMIT_KEYS: Record<string, string | number> = {
+  CLAWBOX_MEM_TOTAL_MIB: RESOURCE_LIMITS.memTotalMiB,
+  CLAWBOX_OLLAMA_MEMORY_HIGH: RESOURCE_LIMITS.ollama.memoryHigh,
+  CLAWBOX_OLLAMA_MEMORY_MAX: RESOURCE_LIMITS.ollama.memoryMax,
+  CLAWBOX_BROWSER_MEMORY_HIGH: RESOURCE_LIMITS.browser.memoryHigh,
+  CLAWBOX_BROWSER_MEMORY_MAX: RESOURCE_LIMITS.browser.memoryMax,
+  CLAWBOX_DESKTOP_MEMORY_HIGH: RESOURCE_LIMITS.desktop.memoryHigh,
+  CLAWBOX_DESKTOP_MEMORY_MAX: RESOURCE_LIMITS.desktop.memoryMax,
+  CLAWBOX_OLLAMA_NUM_PARALLEL: RESOURCE_LIMITS.ollamaNumParallel,
+  CLAWBOX_OLLAMA_CONTEXT_LENGTH: RESOURCE_LIMITS.ollamaContextLength,
+};
+
+/** systemd size suffixes, as bytes. `K` is 1024 here, matching systemd. */
+const SUFFIXES: Record<string, number> = { K: 1024, M: 1024 ** 2, G: 1024 ** 3, T: 1024 ** 4 };
+
+/**
+ * Parse a systemd memory size ("5G", "1200M", "512") into bytes, or null when
+ * it is not one. Used by the tests and by the status route, which reports the
+ * limits in a shape the UI can format.
+ */
+export function parseSystemdSize(value: string): number | null {
+  const m = /^(\d+)([KMGT]?)$/.exec(value.trim());
+  if (!m) return null;
+  const n = Number(m[1]);
+  if (!Number.isFinite(n)) return null;
+  return m[2] ? n * SUFFIXES[m[2]] : n;
+}

--- a/src/lib/system-profile.ts
+++ b/src/lib/system-profile.ts
@@ -1,0 +1,236 @@
+/**
+ * The settings model behind Settings → System → "Desktop environment" and
+ * "Performance mode" (TASK-455).
+ *
+ * Both toggles are thin wrappers over a root-owned shell script that owns the
+ * actual system change:
+ *
+ *   /usr/local/libexec/clawbox/clawbox-desktop-mode.sh   --check|--enable|--disable
+ *   /usr/local/libexec/clawbox/clawbox-power-mode.sh     --check|--balanced|--performance
+ *
+ * The scripts are the source of truth for STATE — they read `systemctl
+ * get-default` and `nvpmodel -q`, so a box changed over SSH still reports
+ * honestly — and data/config.json only records the owner's last expressed
+ * INTENT, for the cases where the live state can't be read (nvpmodel absent in
+ * dev/CI) and so the UI has something to show before the first probe returns.
+ *
+ * Why `--check` runs WITHOUT sudo: it only reads systemctl/nvpmodel state, so
+ * the status route needs no privilege at all and the sudoers grants
+ * (config/clawbox-sudoers) cover just the four mutating invocations.
+ */
+
+import { execFile } from "child_process";
+import fs from "fs";
+import path from "path";
+import { promisify } from "util";
+import * as configStore from "./config-store";
+
+const execFileAsync = promisify(execFile);
+
+/** Root-owned entrypoint directory. Overridable for tests only. */
+export const LIBEXEC_DIR = process.env.CLAWBOX_LIBEXEC_DIR || "/usr/local/libexec/clawbox";
+
+const DESKTOP_SCRIPT = "clawbox-desktop-mode.sh";
+const POWER_SCRIPT = "clawbox-power-mode.sh";
+
+/** config.json keys. Persisted intent, not live state — see the module note. */
+export const DESKTOP_CONFIG_KEY = "desktop_environment_enabled";
+export const POWER_CONFIG_KEY = "power_profile";
+
+const COMMAND_TIMEOUT_MS = 20_000;
+
+export type PowerMode = "balanced" | "performance";
+
+export interface DesktopModeStatus {
+  /** false when systemctl isn't available at all (dev machine, container). */
+  supported: boolean;
+  /** The persisted intent: is the box set to boot into the desktop? */
+  enabled: boolean;
+  /** Is the graphical stack up RIGHT NOW? */
+  active: boolean;
+  /** enabled !== active — the toggle has been flipped but not yet rebooted into. */
+  rebootRequired: boolean;
+  defaultTarget: string;
+  displayManager: string;
+}
+
+export interface PowerModeStatus {
+  /** false when nvpmodel isn't present — i.e. this is not a Jetson. */
+  supported: boolean;
+  mode: PowerMode;
+  nvpmodelId: number | null;
+  nvpmodelName: string;
+  clocksPinned: boolean;
+  balancedId: number | null;
+  performanceId: number | null;
+}
+
+/**
+ * Where the script actually lives.
+ *
+ * The root-owned copy is the only one the sudoers grants match, so mutations
+ * always use it. `--check` falls back to the repo copy because it changes
+ * nothing and needs no privilege — without that fallback the Settings panel
+ * would be blank on a dev machine and in the component tests.
+ */
+export function resolveScript(name: string, opts: { allowRepoFallback?: boolean } = {}): string | null {
+  const installed = path.join(LIBEXEC_DIR, name);
+  if (fs.existsSync(installed)) return installed;
+  if (!opts.allowRepoFallback) return null;
+  const repo = path.join(
+    process.env.CLAWBOX_ROOT || process.cwd(),
+    "scripts",
+    name,
+  );
+  return fs.existsSync(repo) ? repo : null;
+}
+
+/**
+ * Run a script mode and parse the LAST JSON object it printed.
+ *
+ * Last, not first: the mutating modes echo a couple of human-readable progress
+ * lines ("default target set to multi-user.target") before the closing state
+ * report, and those lines are what an operator reading the journal actually
+ * wants. Taking the last object means one parser serves both --check and the
+ * mutations.
+ */
+async function runScript(script: string, args: string[], useSudo: boolean): Promise<Record<string, unknown>> {
+  const cmd = useSudo ? "sudo" : script;
+  const argv = useSudo ? [script, ...args] : args;
+  const { stdout } = await execFileAsync(cmd, argv, { timeout: COMMAND_TIMEOUT_MS });
+  const lines = stdout.split("\n").map((l) => l.trim()).filter((l) => l.startsWith("{") && l.endsWith("}"));
+  const last = lines[lines.length - 1];
+  if (!last) throw new Error("script produced no status output");
+  const parsed = JSON.parse(last) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("script status output was not an object");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function bool(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function str(value: unknown, fallback: string): string {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+function intOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function isPowerMode(value: unknown): value is PowerMode {
+  return value === "balanced" || value === "performance";
+}
+
+/**
+ * The state a box reports when the toggle's machinery isn't installed — a dev
+ * machine, CI, or a container test rig. `supported: false` is what makes the
+ * UI render the switch disabled with an explanation instead of a broken
+ * control or, worse, a switch that silently does nothing.
+ */
+function unsupportedDesktop(enabled: boolean): DesktopModeStatus {
+  return {
+    supported: false,
+    enabled,
+    active: enabled,
+    rebootRequired: false,
+    defaultTarget: "unknown",
+    displayManager: "unknown",
+  };
+}
+
+function unsupportedPower(mode: PowerMode): PowerModeStatus {
+  return {
+    supported: false,
+    mode,
+    nvpmodelId: null,
+    nvpmodelName: "unknown",
+    clocksPinned: false,
+    balancedId: null,
+    performanceId: null,
+  };
+}
+
+async function persistedDesktopIntent(): Promise<boolean> {
+  const stored = await configStore.get(DESKTOP_CONFIG_KEY);
+  // Default ON. The desktop is a shipped, default-on feature, so an absent key
+  // must read as "on" — never as "the owner turned it off".
+  return typeof stored === "boolean" ? stored : true;
+}
+
+async function persistedPowerIntent(): Promise<PowerMode> {
+  const stored = await configStore.get(POWER_CONFIG_KEY);
+  return isPowerMode(stored) ? stored : "balanced";
+}
+
+export async function readDesktopMode(): Promise<DesktopModeStatus> {
+  const script = resolveScript(DESKTOP_SCRIPT, { allowRepoFallback: true });
+  const intent = await persistedDesktopIntent();
+  if (!script) return unsupportedDesktop(intent);
+  try {
+    const raw = await runScript(script, ["--check"], false);
+    return {
+      supported: bool(raw.supported),
+      enabled: bool(raw.enabled, intent),
+      active: bool(raw.active, intent),
+      rebootRequired: bool(raw.rebootRequired),
+      defaultTarget: str(raw.defaultTarget, "unknown"),
+      displayManager: str(raw.displayManager, "unknown"),
+    };
+  } catch {
+    return unsupportedDesktop(intent);
+  }
+}
+
+export async function readPowerMode(): Promise<PowerModeStatus> {
+  const script = resolveScript(POWER_SCRIPT, { allowRepoFallback: true });
+  const intent = await persistedPowerIntent();
+  if (!script) return unsupportedPower(intent);
+  try {
+    const raw = await runScript(script, ["--check"], false);
+    return {
+      supported: bool(raw.supported),
+      mode: isPowerMode(raw.mode) ? raw.mode : intent,
+      nvpmodelId: intOrNull(raw.nvpmodelId),
+      nvpmodelName: str(raw.nvpmodelName, "unknown"),
+      clocksPinned: bool(raw.clocksPinned),
+      balancedId: intOrNull(raw.balancedId),
+      performanceId: intOrNull(raw.performanceId),
+    };
+  } catch {
+    return unsupportedPower(intent);
+  }
+}
+
+export class ProfileUnavailableError extends Error {
+  constructor(script: string) {
+    super(`${script} is not installed — run \`sudo bash install.sh --step performance_mode\``);
+    this.name = "ProfileUnavailableError";
+  }
+}
+
+/**
+ * Flip the desktop on or off. Takes effect at the next boot by design — see
+ * the header of clawbox-desktop-mode.sh for why we don't isolate the target
+ * out from under a live session.
+ */
+export async function setDesktopMode(enabled: boolean): Promise<DesktopModeStatus> {
+  const script = resolveScript(DESKTOP_SCRIPT);
+  if (!script) throw new ProfileUnavailableError(DESKTOP_SCRIPT);
+  await runScript(script, [enabled ? "--enable" : "--disable"], true);
+  // Persist AFTER the script succeeds, so a failed toggle doesn't leave
+  // config.json claiming a state the box was never put into.
+  await configStore.set(DESKTOP_CONFIG_KEY, enabled);
+  return readDesktopMode();
+}
+
+/** Switch the power profile. Applies immediately — no reboot. */
+export async function setPowerMode(mode: PowerMode): Promise<PowerModeStatus> {
+  const script = resolveScript(POWER_SCRIPT);
+  if (!script) throw new ProfileUnavailableError(POWER_SCRIPT);
+  await runScript(script, [mode === "performance" ? "--performance" : "--balanced"], true);
+  await configStore.set(POWER_CONFIG_KEY, mode);
+  return readPowerMode();
+}

--- a/src/tests/routes/system/desktop.test.ts
+++ b/src/tests/routes/system/desktop.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
+
+/**
+ * The /setup-api/system/desktop contract (TASK-455).
+ *
+ * The model is mocked: what this file guards is the HTTP surface — that both
+ * verbs are owner-only with no bootstrap carve-out, that a bad body is a 400
+ * and never reaches the system, and that a box missing the root-owned script
+ * says so with a 503 instead of a bare 500.
+ */
+
+vi.mock("@/lib/system-profile", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/system-profile")>("@/lib/system-profile");
+  return {
+    ...actual,
+    readDesktopMode: vi.fn(),
+    setDesktopMode: vi.fn(),
+  };
+});
+
+import { GET, POST } from "@/app/setup-api/system/desktop/route";
+import {
+  ProfileUnavailableError,
+  readDesktopMode,
+  setDesktopMode,
+} from "@/lib/system-profile";
+
+const mockRead = vi.mocked(readDesktopMode);
+const mockSet = vi.mocked(setDesktopMode);
+
+const STATUS = {
+  supported: true,
+  enabled: true,
+  active: true,
+  rebootRequired: false,
+  defaultTarget: "graphical.target",
+  displayManager: "gdm3:alias",
+};
+
+let session: SessionFixture;
+
+beforeEach(() => {
+  session = installSessionFixture();
+  mockRead.mockResolvedValue({ ...STATUS });
+  mockSet.mockResolvedValue({ ...STATUS, enabled: false, rebootRequired: true });
+});
+
+afterEach(() => session.cleanup());
+
+function req(init: RequestInit & { auth?: boolean } = {}) {
+  const { auth = true, ...rest } = init;
+  return new Request("http://localhost/setup-api/system/desktop", {
+    ...rest,
+    headers: auth ? { Cookie: session.cookie, ...(rest.headers ?? {}) } : rest.headers,
+  });
+}
+
+describe("GET /setup-api/system/desktop", () => {
+  it("returns the current state to the owner", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(STATUS);
+  });
+
+  it("is 401 without a session", async () => {
+    const res = await GET(req({ auth: false }));
+    expect(res.status).toBe(401);
+    expect(mockRead).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /setup-api/system/desktop", () => {
+  it("turns the desktop off and reports that a reboot is needed", async () => {
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ enabled: false }) }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ enabled: false, rebootRequired: true });
+    expect(mockSet).toHaveBeenCalledWith(false);
+  });
+
+  it("turns it back on", async () => {
+    mockSet.mockResolvedValue({ ...STATUS });
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ enabled: true }) }));
+    expect(res.status).toBe(200);
+    expect(mockSet).toHaveBeenCalledWith(true);
+  });
+
+  it("is 401 without a session, and does not touch the system", async () => {
+    const res = await POST(req({ auth: false, method: "POST", body: JSON.stringify({ enabled: false }) }));
+    expect(res.status).toBe(401);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("is 401 during the first-boot window too — there is no bootstrap carve-out", async () => {
+    session.cleanup();
+    session = installSessionFixture({ passwordConfigured: false });
+    const res = await POST(new Request("http://localhost/setup-api/system/desktop", {
+      method: "POST",
+      body: JSON.stringify({ enabled: false }),
+    }));
+    expect(res.status).toBe(401);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-boolean `enabled`", async () => {
+    for (const bad of ["false", 0, null, undefined, {}, []]) {
+      const res = await POST(req({ method: "POST", body: JSON.stringify({ enabled: bad }) }));
+      expect(res.status, JSON.stringify(bad)).toBe(400);
+    }
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body that is not JSON", async () => {
+    const res = await POST(req({ method: "POST", body: "enabled=false" }));
+    expect(res.status).toBe(400);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("answers 503, with the fix, when the root-owned script is not installed", async () => {
+    mockSet.mockRejectedValue(new ProfileUnavailableError("clawbox-desktop-mode.sh"));
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ enabled: false }) }));
+    expect(res.status).toBe(503);
+    expect((await res.json()).error).toContain("install.sh --step performance_mode");
+  });
+
+  it("answers 500 when the script itself fails", async () => {
+    mockSet.mockRejectedValue(new Error("sudo: a password is required"));
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ enabled: false }) }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toContain("password is required");
+  });
+});

--- a/src/tests/routes/system/power-profile.test.ts
+++ b/src/tests/routes/system/power-profile.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { installSessionFixture, type SessionFixture } from "@/tests/helpers/session";
+import { RESOURCE_LIMITS } from "@/lib/resource-limits";
+
+/**
+ * The /setup-api/system/power-profile contract (TASK-455).
+ *
+ * Same shape as the desktop route's test, plus the one thing this route does
+ * that the other doesn't: it echoes the memory guards back, so the Settings
+ * card can state them instead of the UI carrying a third copy of the numbers.
+ */
+
+vi.mock("@/lib/system-profile", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/system-profile")>("@/lib/system-profile");
+  return { ...actual, readPowerMode: vi.fn(), setPowerMode: vi.fn() };
+});
+
+import { GET, POST } from "@/app/setup-api/system/power-profile/route";
+import { ProfileUnavailableError, readPowerMode, setPowerMode } from "@/lib/system-profile";
+
+const mockRead = vi.mocked(readPowerMode);
+const mockSet = vi.mocked(setPowerMode);
+
+const BALANCED = {
+  supported: true, mode: "balanced" as const, nvpmodelId: 1, nvpmodelName: "25W",
+  clocksPinned: false, balancedId: 1, performanceId: 2,
+};
+const PINNED = { ...BALANCED, mode: "performance" as const, nvpmodelId: 2, nvpmodelName: "MAXN_SUPER", clocksPinned: true };
+
+let session: SessionFixture;
+
+beforeEach(() => {
+  session = installSessionFixture();
+  mockRead.mockResolvedValue({ ...BALANCED });
+  mockSet.mockResolvedValue({ ...PINNED });
+});
+
+afterEach(() => session.cleanup());
+
+function req(init: RequestInit & { auth?: boolean } = {}) {
+  const { auth = true, ...rest } = init;
+  return new Request("http://localhost/setup-api/system/power-profile", {
+    ...rest,
+    headers: auth ? { Cookie: session.cookie, ...(rest.headers ?? {}) } : rest.headers,
+  });
+}
+
+describe("GET /setup-api/system/power-profile", () => {
+  it("returns the profile and the memory guards in force", async () => {
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject(BALANCED);
+    expect(body.limits).toEqual(RESOURCE_LIMITS);
+  });
+
+  it("is 401 without a session", async () => {
+    expect((await GET(req({ auth: false }))).status).toBe(401);
+    expect(mockRead).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /setup-api/system/power-profile", () => {
+  it("switches to the pinned profile", async () => {
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ mode: "performance" }) }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ mode: "performance", clocksPinned: true });
+    expect(mockSet).toHaveBeenCalledWith("performance");
+  });
+
+  it("switches back to balanced", async () => {
+    mockSet.mockResolvedValue({ ...BALANCED });
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ mode: "balanced" }) }));
+    expect(res.status).toBe(200);
+    expect(mockSet).toHaveBeenCalledWith("balanced");
+  });
+
+  it("is 401 without a session, and does not touch the clocks", async () => {
+    const res = await POST(req({ auth: false, method: "POST", body: JSON.stringify({ mode: "performance" }) }));
+    expect(res.status).toBe(401);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("is 401 during the first-boot window too", async () => {
+    session.cleanup();
+    session = installSessionFixture({ passwordConfigured: false });
+    const res = await POST(new Request("http://localhost/setup-api/system/power-profile", {
+      method: "POST",
+      body: JSON.stringify({ mode: "performance" }),
+    }));
+    expect(res.status).toBe(401);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects any mode the script does not implement", async () => {
+    for (const bad of ["MAXN_SUPER", "maxn", "", 2, true, null, undefined, ["balanced"]]) {
+      const res = await POST(req({ method: "POST", body: JSON.stringify({ mode: bad }) }));
+      expect(res.status, JSON.stringify(bad)).toBe(400);
+    }
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body that is not JSON", async () => {
+    expect((await POST(req({ method: "POST", body: "mode=performance" }))).status).toBe(400);
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it("answers 503 when the root-owned script is not installed", async () => {
+    mockSet.mockRejectedValue(new ProfileUnavailableError("clawbox-power-mode.sh"));
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ mode: "performance" }) }));
+    expect(res.status).toBe(503);
+  });
+
+  it("answers 500 when nvpmodel fails", async () => {
+    mockSet.mockRejectedValue(new Error("nvpmodel: command not found"));
+    const res = await POST(req({ method: "POST", body: JSON.stringify({ mode: "performance" }) }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toContain("nvpmodel");
+  });
+});

--- a/src/tests/unit/desktop-power-wiring.test.ts
+++ b/src/tests/unit/desktop-power-wiring.test.ts
@@ -1,0 +1,208 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The system-side wiring for TASK-455: the units, the sudoers grants and the
+ * install/update steps that make the two toggles reachable and keep them
+ * reversible.
+ *
+ * These are file assertions rather than behaviour tests because the failure
+ * mode they guard is silent. A missing sudoers line doesn't crash — it hangs on
+ * a password prompt no one can answer. A `WantedBy` on the browser unit doesn't
+ * error — it just costs a gigabyte on every boot. Neither shows up in a route
+ * test.
+ */
+
+const REPO = process.cwd();
+const read = (...p: string[]) => fs.readFileSync(path.join(REPO, ...p), "utf-8");
+
+/**
+ * Drop `#` comment lines.
+ *
+ * Every file here documents the behaviour it is REPLACING — the unit says why
+ * it no longer runs jetson_clocks, the script says why it doesn't isolate the
+ * target — so a naive `not.toContain` matches the explanation and fails on a
+ * correct file. Assert against the executable lines only.
+ */
+const codeOnly = (raw: string) =>
+  raw.split("\n").filter((l) => !l.trimStart().startsWith("#")).join("\n");
+
+const LIBEXEC = "/usr/local/libexec/clawbox";
+
+describe("clawbox-performance.service", () => {
+  const unit = read("config", "clawbox-performance.service");
+
+  it("delegates to the root-owned power script instead of pinning inline", () => {
+    expect(unit).toContain(`ExecStart=${LIBEXEC}/clawbox-power-mode.sh --apply`);
+    expect(unit).toContain(`ExecStop=${LIBEXEC}/clawbox-power-mode.sh --restore`);
+  });
+
+  it("no longer runs jetson_clocks unconditionally at boot", () => {
+    // The finding: MAXN_SUPER + jetson_clocks at every boot left the board at
+    // 1,728 MHz x6 / 1,020 MHz GPU under 4% load — 7.21 W and ~58 C at idle.
+    expect(codeOnly(unit)).not.toContain("jetson_clocks");
+    expect(codeOnly(unit)).not.toMatch(/ExecStart=.*nvpmodel/);
+  });
+});
+
+describe("the power script's default", () => {
+  const script = read("scripts", "clawbox-power-mode.sh");
+
+  it("is balanced, so an unconfigured or corrupted state file stays cool", () => {
+    expect(script).toContain('DEFAULT_MODE="balanced"');
+  });
+
+  it("persists the choice root-owned, next to the edition lock", () => {
+    // /home/clawbox/clawbox is clawbox-writable and this script runs as root,
+    // so the file it acts on at boot must live somewhere clawbox cannot write.
+    expect(script).toContain('STATE_DIR="${CLAWBOX_STATE_DIR:-/etc/clawbox}"');
+  });
+
+  it("re-enables the cpuidle states jetson_clocks turns off", () => {
+    // nvpmodel alone does not put them back, so without this the cores never
+    // reach C7 again and the idle-power win never lands.
+    expect(script).toContain("enable_cpuidle");
+    expect(script).toContain("cpuidle/state*/disable");
+  });
+});
+
+describe("the desktop script", () => {
+  const script = read("scripts", "clawbox-desktop-mode.sh");
+
+  it("switches the boot target rather than isolating it under a live session", () => {
+    expect(script).toContain("systemctl set-default");
+    expect(codeOnly(script)).not.toContain("systemctl isolate");
+  });
+
+  it("uninstalls nothing — headless is a setting, not a separate image", () => {
+    // Krasi's ruling, 2026-08-24: do not strip GNOME/gdm/snapd from the image.
+    for (const forbidden of ["apt-get remove", "apt remove", "apt-get purge", "snap remove"]) {
+      expect(codeOnly(script), forbidden).not.toContain(forbidden);
+    }
+  });
+
+  it("stops the on-demand browser when the desktop goes away", () => {
+    // Without a desktop there is no X display for Chromium to draw on, and
+    // leaving ~1 GB resident would defeat the point of the toggle.
+    expect(script).toContain("systemctl stop clawbox-browser.service");
+  });
+});
+
+describe("sudoers grants", () => {
+  const sudoers = read("config", "clawbox-sudoers");
+
+  it("cover exactly the four mutating invocations", () => {
+    const granted = sudoers
+      .split("\n")
+      .filter((l) => l.startsWith("clawbox ") && l.includes(LIBEXEC))
+      .map((l) => l.slice(l.indexOf(LIBEXEC)).trim());
+    expect(granted.sort()).toEqual([
+      `${LIBEXEC}/clawbox-desktop-mode.sh --disable`,
+      `${LIBEXEC}/clawbox-desktop-mode.sh --enable`,
+      `${LIBEXEC}/clawbox-power-mode.sh --balanced`,
+      `${LIBEXEC}/clawbox-power-mode.sh --performance`,
+    ]);
+  });
+
+  it("grant no wildcard on either script", () => {
+    // A trailing `*` would hand over every mode these scripts ever grow.
+    for (const line of sudoers.split("\n")) {
+      if (!line.startsWith("clawbox ") || !line.includes(LIBEXEC)) continue;
+      expect(line, line).not.toContain("*");
+    }
+  });
+
+  it("never point at the clawbox-writable copies in the project tree", () => {
+    expect(sudoers).not.toContain("/home/clawbox/clawbox/scripts/");
+  });
+});
+
+describe("install.sh", () => {
+  const install = read("install.sh");
+
+  it("installs every root-invoked script root-owned outside the clawbox tree", () => {
+    for (const script of [
+      "optimize-ollama.sh",
+      "clawbox-desktop-mode.sh",
+      "clawbox-power-mode.sh",
+      "clawbox-resource-limits.sh",
+    ]) {
+      expect(install, script).toContain(script);
+    }
+    expect(install).toContain('install -o root -g root -m 0755 "$PROJECT_DIR/scripts/$src"');
+  });
+
+  it("re-applies the memory guards on update, not only on a fresh install", () => {
+    const postUpdate = install.slice(install.indexOf("step_post_update() {"));
+    expect(postUpdate.slice(0, postUpdate.indexOf("\n}\n"))).toContain("step_resource_limits");
+  });
+
+  it("never flips the desktop toggle on install or update", () => {
+    // The owner's choice must survive a `git pull`. step_desktop_mode exists so
+    // an operator can inspect the state, and reports only.
+    const step = install.slice(install.indexOf("step_desktop_mode() {"));
+    const body = step.slice(0, step.indexOf("\n}\n"));
+    expect(body).toContain("--check");
+    expect(body).not.toContain("--enable");
+    expect(body).not.toContain("--disable");
+    expect(body).not.toContain("set-default");
+    const postUpdate = install.slice(install.indexOf("step_post_update() {"));
+    expect(codeOnly(postUpdate.slice(0, postUpdate.indexOf("\n}\n"))))
+      .not.toContain("step_desktop_mode");
+  });
+
+  it("registers the new steps for --step dispatch", () => {
+    const list = install.slice(install.indexOf("DISPATCH_STEPS=("));
+    const body = list.slice(0, list.indexOf(")"));
+    expect(body).toContain("resource_limits");
+    expect(body).toContain("desktop_mode");
+  });
+
+  it("has a function for every dispatchable step", () => {
+    const list = install.slice(install.indexOf("DISPATCH_STEPS=("));
+    const body = list.slice(0, list.indexOf(")"));
+    const steps = body
+      .split("\n")
+      .slice(1)
+      .flatMap((l) => l.replace(/#.*/, "").trim().split(/\s+/))
+      .filter(Boolean);
+    expect(steps.length).toBeGreaterThan(20);
+    for (const step of steps) {
+      expect(install, `step_${step} is dispatchable but not defined`)
+        .toContain(`step_${step}()`);
+    }
+  });
+});
+
+describe("optimize-ollama.sh", () => {
+  const script = read("scripts", "optimize-ollama.sh");
+
+  it("no longer hardcodes the serialising NUM_PARALLEL=1", () => {
+    expect(script).not.toContain("OLLAMA_NUM_PARALLEL=1");
+    expect(script).toContain("OLLAMA_NUM_PARALLEL=${NUM_PARALLEL}");
+  });
+
+  it("pins a context length so the cost of the extra slot is predictable", () => {
+    expect(script).toContain("OLLAMA_CONTEXT_LENGTH=${CONTEXT_LENGTH}");
+  });
+
+  it("parses the limits file rather than sourcing it", () => {
+    // The fallback copy lives in the clawbox-writable tree while this runs as
+    // root, so `source` would be a one-step local root.
+    expect(script).not.toMatch(/^\s*(\.|source)\s+/m);
+  });
+});
+
+describe("the browser stays on-demand", () => {
+  const unit = read("config", "clawbox-browser.service");
+
+  it("has no [Install] section at all, so it can never be enabled at boot", () => {
+    expect(unit).not.toContain("[Install]");
+    expect(unit).not.toContain("WantedBy=");
+  });
+
+  it("accounts its memory so the cgroup guard can bite", () => {
+    expect(unit).toContain("MemoryAccounting=yes");
+  });
+});

--- a/src/tests/unit/hermes-translations.test.ts
+++ b/src/tests/unit/hermes-translations.test.ts
@@ -5,6 +5,7 @@ import { settingsSecurityEn } from "@/lib/hermes-translations/en-settings-securi
 import { providerEn } from "@/lib/hermes-translations/en-provider";
 import { skillsEn } from "@/lib/hermes-translations/en-skills";
 import { localModelsEn } from "@/lib/hermes-translations/en-local-models";
+import { systemProfileEn } from "@/lib/hermes-translations/en-system-profile";
 import { bg } from "@/lib/hermes-translations/bg";
 import { de } from "@/lib/hermes-translations/de";
 import { es } from "@/lib/hermes-translations/es";
@@ -37,12 +38,15 @@ const OVERRIDES: Record<Exclude<Locale, "en">, Record<string, string>> = {
 
 const NON_EN = Object.keys(OVERRIDES) as Exclude<Locale, "en">[];
 
-/** The four surfaces this pass covers, by key prefix. */
+/** The surfaces this catalogue covers, by key prefix. */
 const NAMESPACES: { name: string; matches: (key: string) => boolean }[] = [
   { name: "security/password forms", matches: (k) => k.startsWith("settings.security.") },
   { name: "Hermes provider UI", matches: (k) => k.startsWith("hermesProvider.") },
   { name: "Skills store", matches: (k) => k.startsWith("skills.") },
   { name: "Local Models tab", matches: (k) => k.startsWith("localModels.") },
+  // Desktop & power card (TASK-455). Held to exactly the same bar as the
+  // TASK-458 four: every locale carries its own copy, not an English fallback.
+  { name: "Desktop & power card", matches: (k) => k.startsWith("systemProfile.") },
 ];
 
 /**
@@ -73,12 +77,13 @@ function untranslated(locale: Exclude<Locale, "en">, keys: string[]): string[] {
 }
 
 describe("hermes-translations (TASK-458)", () => {
-  describe("the English catalogue covers all four surfaces", () => {
+  describe("the English catalogue covers every surface", () => {
     const surfaces: [string, Record<string, string>, (k: string) => boolean][] = [
       ["settingsSecurityEn", settingsSecurityEn, (k) => k.startsWith("settings.")],
       ["providerEn", providerEn, (k) => k.startsWith("hermesProvider.")],
       ["skillsEn", skillsEn, (k) => k.startsWith("skills.")],
       ["localModelsEn", localModelsEn, (k) => k.startsWith("localModels.")],
+      ["systemProfileEn", systemProfileEn, (k) => k.startsWith("systemProfile.")],
     ];
 
     for (const [name, table, prefixed] of surfaces) {
@@ -89,7 +94,7 @@ describe("hermes-translations (TASK-458)", () => {
       });
     }
 
-    it("the four surface modules do not collide", () => {
+    it("the surface modules do not collide", () => {
       const counts = surfaces.reduce((n, [, table]) => n + Object.keys(table).length, 0);
       expect(Object.keys(hermesEn).length).toBe(counts);
     });

--- a/src/tests/unit/resource-limits.test.ts
+++ b/src/tests/unit/resource-limits.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+  RESOURCE_LIMITS,
+  RESOURCE_LIMIT_KEYS,
+  parseSystemdSize,
+} from "@/lib/resource-limits";
+
+/**
+ * TASK-455 deliverable 3 says the memory guards live "as constants in one
+ * place". config/clawbox-resource-limits.env IS that place — it is what the
+ * shell scripts read at runtime — and src/lib/resource-limits.ts is a mirror
+ * the bundled web server can read without shipping config/.
+ *
+ * A mirror that can drift is worse than no mirror: the UI would state a limit
+ * the box is not actually enforcing. So this file re-parses the env file with
+ * the same rule the shell uses and asserts the two agree, key by key.
+ */
+
+const ENV_FILE = path.join(process.cwd(), "config", "clawbox-resource-limits.env");
+
+/** The shell side's parser, in TypeScript: `KEY=<digits><optional suffix>`. */
+function parseEnvFile(raw: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of raw.split(/\r?\n/)) {
+    const m = /^\s*([A-Z0-9_]+)\s*=\s*(\d+[KMGT]?)\s*$/.exec(line);
+    if (m) out[m[1]] = m[2];
+  }
+  return out;
+}
+
+describe("resource limits (TASK-455)", () => {
+  const raw = fs.readFileSync(ENV_FILE, "utf-8");
+  const env = parseEnvFile(raw);
+
+  it("the env file parses to the keys the scripts ask for", () => {
+    expect(Object.keys(env).sort()).toEqual(Object.keys(RESOURCE_LIMIT_KEYS).sort());
+  });
+
+  for (const [key, mirrored] of Object.entries(RESOURCE_LIMIT_KEYS)) {
+    it(`${key} matches the TypeScript mirror`, () => {
+      expect(env[key], `${key} missing from ${ENV_FILE}`).toBeDefined();
+      expect(env[key]).toBe(String(mirrored));
+    });
+  }
+
+  it("every memory value is a size systemd accepts", () => {
+    for (const key of Object.keys(env)) {
+      if (!key.includes("MEMORY")) continue;
+      expect(parseSystemdSize(env[key]), `${key} = ${env[key]}`).toBeGreaterThan(0);
+    }
+  });
+
+  describe("the numbers are internally coherent", () => {
+    const units = [
+      ["ollama", RESOURCE_LIMITS.ollama],
+      ["browser", RESOURCE_LIMITS.browser],
+      ["desktop", RESOURCE_LIMITS.desktop],
+    ] as const;
+
+    for (const [name, limit] of units) {
+      it(`${name}: MemoryHigh is below MemoryMax`, () => {
+        // High is the throttle, Max is the kill line. High >= Max would mean
+        // the unit is OOM-killed before it is ever throttled, i.e. the whole
+        // "degrade before you die" design is inverted.
+        const high = parseSystemdSize(limit.memoryHigh)!;
+        const max = parseSystemdSize(limit.memoryMax)!;
+        expect(high).toBeLessThan(max);
+      });
+
+      it(`${name}: MemoryMax fits inside the device's RAM`, () => {
+        const max = parseSystemdSize(limit.memoryMax)!;
+        expect(max).toBeLessThan(RESOURCE_LIMITS.memTotalMiB * 1024 * 1024);
+      });
+    }
+
+    it("no single unit may claim the whole box", () => {
+      // The guards deliberately over-subscribe (the desktop and the browser are
+      // only up when someone is looking at the box), but any ONE of them being
+      // allowed to reach MemTotal would make it useless as a guard.
+      const total = RESOURCE_LIMITS.memTotalMiB * 1024 * 1024;
+      for (const [, limit] of units) {
+        expect(parseSystemdSize(limit.memoryMax)!).toBeLessThan(total * 0.8);
+      }
+    });
+  });
+
+  describe("ollama concurrency", () => {
+    it("serves more than one request at a time", () => {
+      // The finding: NUM_PARALLEL=1 made the 8th concurrent caller wait 24.5 s
+      // with throughput flat at 0.34 req/s. On a device where the agent and the
+      // human share one model, two consumers is the normal case.
+      expect(RESOURCE_LIMITS.ollamaNumParallel).toBeGreaterThanOrEqual(2);
+    });
+
+    it("pins a context length rather than inheriting ollama's default", () => {
+      expect(RESOURCE_LIMITS.ollamaContextLength).toBeGreaterThan(0);
+    });
+  });
+
+  describe("parseSystemdSize", () => {
+    it("understands the suffixes systemd uses", () => {
+      expect(parseSystemdSize("512")).toBe(512);
+      expect(parseSystemdSize("1K")).toBe(1024);
+      expect(parseSystemdSize("1M")).toBe(1024 ** 2);
+      expect(parseSystemdSize("5G")).toBe(5 * 1024 ** 3);
+    });
+
+    it("rejects anything else", () => {
+      for (const bad of ["", "5 G", "5GB", "-1M", "abc", "1.5G"]) {
+        expect(parseSystemdSize(bad), bad).toBeNull();
+      }
+    });
+  });
+
+  it("documents the reasoning next to the numbers", () => {
+    // The env file is the only place the measurements behind these values are
+    // written down. A future edit that strips it to bare KEY=VALUE lines loses
+    // the reason anyone picked 5G, so hold the line here.
+    expect(raw).toContain("TASK-455");
+    expect(raw.split("\n").filter((l) => l.trimStart().startsWith("#")).length)
+      .toBeGreaterThan(20);
+  });
+});

--- a/src/tests/unit/system-profile-scripts.test.ts
+++ b/src/tests/unit/system-profile-scripts.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * The `--check` contract of the three TASK-455 shell scripts, exercised by
+ * actually running them.
+ *
+ * These are the modes the setup-api status route calls, and the ONLY modes it
+ * calls without sudo — so "check changes nothing and prints one parseable JSON
+ * object" is a contract the TypeScript side depends on, not a nicety. They are
+ * run for real rather than mocked because the thing that breaks is the shell,
+ * not our idea of the shell.
+ *
+ * Everything is driven through the CLAWBOX_* overrides the scripts expose, so
+ * nothing here reads or writes real system state.
+ */
+
+const REPO = process.cwd();
+const DESKTOP = path.join(REPO, "scripts", "clawbox-desktop-mode.sh");
+const POWER = path.join(REPO, "scripts", "clawbox-power-mode.sh");
+const LIMITS = path.join(REPO, "scripts", "clawbox-resource-limits.sh");
+const OLLAMA = path.join(REPO, "scripts", "optimize-ollama.sh");
+
+function run(script: string, args: string[], env: Record<string, string> = {}): string {
+  return execFileSync("bash", [script, ...args], {
+    encoding: "utf-8",
+    env: { ...process.env, ...env },
+    timeout: 30_000,
+  });
+}
+
+/** The parser src/lib/system-profile.ts uses: the LAST JSON object printed. */
+function lastJson(stdout: string): Record<string, unknown> {
+  const lines = stdout.split("\n").map((l) => l.trim()).filter((l) => l.startsWith("{") && l.endsWith("}"));
+  expect(lines.length, `no JSON object in:\n${stdout}`).toBeGreaterThan(0);
+  return JSON.parse(lines[lines.length - 1]) as Record<string, unknown>;
+}
+
+function tmpdir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-455-"));
+}
+
+describe("clawbox-desktop-mode.sh --check", () => {
+  it("prints one JSON object with the full status shape", () => {
+    const out = lastJson(run(DESKTOP, ["--check"]));
+    expect(Object.keys(out).sort()).toEqual([
+      "active", "defaultTarget", "displayManager", "enabled", "rebootRequired", "supported",
+    ]);
+    expect(typeof out.supported).toBe("boolean");
+    expect(typeof out.enabled).toBe("boolean");
+    expect(typeof out.active).toBe("boolean");
+    expect(typeof out.rebootRequired).toBe("boolean");
+    expect(typeof out.defaultTarget).toBe("string");
+  });
+
+  it("reports rebootRequired exactly when intent and live state disagree", () => {
+    // The whole point of the field: `enabled` is the boot target, `active` is
+    // what the box is doing now, and they differ only between a toggle and the
+    // reboot that applies it.
+    const out = lastJson(run(DESKTOP, ["--check"]));
+    expect(out.rebootRequired).toBe(out.enabled !== out.active);
+  });
+
+  it("rejects an unknown mode instead of guessing", () => {
+    expect(() => run(DESKTOP, ["--wat"])).toThrow();
+  });
+
+  it("refuses to mutate as a non-root user", () => {
+    // Guards the case where the sudoers grant is missing: the script must fail
+    // loudly rather than half-apply a target change it cannot make.
+    if (process.getuid?.() === 0) return;
+    expect(() => run(DESKTOP, ["--disable"])).toThrow();
+  });
+});
+
+describe("clawbox-power-mode.sh --check", () => {
+  const conf = path.join(tmpdir(), "nvpmodel.conf");
+  fs.writeFileSync(
+    conf,
+    "< POWER_MODEL ID=0 NAME=15W >\n< POWER_MODEL ID=1 NAME=25W >\n< POWER_MODEL ID=2 NAME=MAXN_SUPER >\n",
+  );
+
+  it("prints one JSON object with the full status shape", () => {
+    const state = tmpdir();
+    const out = lastJson(run(POWER, ["--check"], {
+      CLAWBOX_NVPMODEL_CONF: conf,
+      CLAWBOX_STATE_DIR: state,
+    }));
+    expect(Object.keys(out).sort()).toEqual([
+      "balancedId", "clocksPinned", "mode", "nvpmodelId", "nvpmodelName",
+      "performanceId", "supported",
+    ]);
+  });
+
+  it("resolves balanced to the highest non-MAXN mode and performance to MAXN", () => {
+    const out = lastJson(run(POWER, ["--check"], {
+      CLAWBOX_NVPMODEL_CONF: conf,
+      CLAWBOX_STATE_DIR: tmpdir(),
+    }));
+    expect(out.balancedId).toBe(1);     // 25W
+    expect(out.performanceId).toBe(2);  // MAXN_SUPER
+  });
+
+  it("defaults to balanced when nothing is persisted", () => {
+    const out = lastJson(run(POWER, ["--check"], {
+      CLAWBOX_NVPMODEL_CONF: conf,
+      CLAWBOX_STATE_DIR: tmpdir(),
+    }));
+    expect(out.mode).toBe("balanced");
+  });
+
+  it("reads the persisted profile back", () => {
+    const state = tmpdir();
+    fs.writeFileSync(path.join(state, "power-mode"), "performance\n");
+    const out = lastJson(run(POWER, ["--check"], {
+      CLAWBOX_NVPMODEL_CONF: conf,
+      CLAWBOX_STATE_DIR: state,
+    }));
+    expect(out.mode).toBe("performance");
+  });
+
+  it("falls back to balanced when the state file holds junk", () => {
+    // The file is root-owned, but a truncated write or a hand-edit must never
+    // leave the box pinned by accident — the safe default is the cool one.
+    const state = tmpdir();
+    fs.writeFileSync(path.join(state, "power-mode"), "MAXN; rm -rf /\n");
+    const out = lastJson(run(POWER, ["--check"], {
+      CLAWBOX_NVPMODEL_CONF: conf,
+      CLAWBOX_STATE_DIR: state,
+    }));
+    expect(out.mode).toBe("balanced");
+  });
+
+  it("still emits valid JSON with no nvpmodel.conf at all", () => {
+    const out = lastJson(run(POWER, ["--check"], {
+      CLAWBOX_NVPMODEL_CONF: "/nonexistent/nvpmodel.conf",
+      CLAWBOX_STATE_DIR: tmpdir(),
+    }));
+    expect(out.performanceId).toBeNull();
+    expect(out.mode).toBe("balanced");
+  });
+
+  it("rejects an unknown mode", () => {
+    expect(() => run(POWER, ["--wat"])).toThrow();
+  });
+
+  it("refuses to mutate as a non-root user", () => {
+    if (process.getuid?.() === 0) return;
+    expect(() => run(POWER, ["--performance"])).toThrow();
+  });
+});
+
+describe("clawbox-resource-limits.sh --check", () => {
+  it("reports the drop-in it would write for every managed unit, and writes nothing", () => {
+    const systemd = tmpdir();
+    const out = run(LIMITS, ["--check"], { CLAWBOX_SYSTEMD_DIR: systemd });
+    expect(out).toContain("ollama.service");
+    expect(out).toContain("clawbox-browser.service");
+    expect(out).toContain("user@1000.service");
+    expect(out).toContain("result: no changes made (--check)");
+    expect(fs.readdirSync(systemd)).toEqual([]);
+  });
+
+  it("takes its numbers from the env file, not from itself", () => {
+    const limits = path.join(tmpdir(), "limits.env");
+    fs.writeFileSync(limits, [
+      "CLAWBOX_OLLAMA_MEMORY_HIGH=3G",
+      "CLAWBOX_OLLAMA_MEMORY_MAX=4G",
+      "CLAWBOX_BROWSER_MEMORY_HIGH=100M",
+      "CLAWBOX_BROWSER_MEMORY_MAX=200M",
+      "CLAWBOX_DESKTOP_MEMORY_HIGH=300M",
+      "CLAWBOX_DESKTOP_MEMORY_MAX=400M",
+    ].join("\n") + "\n");
+    const out = run(LIMITS, ["--check"], {
+      CLAWBOX_RESOURCE_LIMITS_FILE: limits,
+      CLAWBOX_SYSTEMD_DIR: tmpdir(),
+    });
+    expect(out).toContain("MemoryHigh=3G MemoryMax=4G");
+    expect(out).toContain("MemoryHigh=100M MemoryMax=200M");
+    expect(out).toContain("MemoryHigh=300M MemoryMax=400M");
+  });
+
+  it("fails loudly on a malformed limits file rather than writing a broken unit", () => {
+    const limits = path.join(tmpdir(), "limits.env");
+    fs.writeFileSync(limits, "CLAWBOX_OLLAMA_MEMORY_HIGH=$(reboot)\n");
+    expect(() => run(LIMITS, ["--check"], {
+      CLAWBOX_RESOURCE_LIMITS_FILE: limits,
+      CLAWBOX_SYSTEMD_DIR: tmpdir(),
+    })).toThrow();
+  });
+
+  it("--apply writes the three drop-ins and is idempotent", () => {
+    // Runs against a temp systemd dir, so this exercises the writer without
+    // touching /etc. daemon-reload/set-property are best-effort no-ops here.
+    const systemd = tmpdir();
+    if (process.getuid?.() !== 0) return; // --apply requires root by design
+    run(LIMITS, ["--apply"], { CLAWBOX_SYSTEMD_DIR: systemd });
+    const first = fs.readdirSync(systemd).sort();
+    expect(first).toEqual([
+      "clawbox-browser.service.d", "ollama.service.d", "user@1000.service.d",
+    ]);
+    run(LIMITS, ["--apply"], { CLAWBOX_SYSTEMD_DIR: systemd });
+    expect(fs.readdirSync(systemd).sort()).toEqual(first);
+  });
+
+  it("refuses --apply as a non-root user", () => {
+    if (process.getuid?.() === 0) return;
+    expect(() => run(LIMITS, ["--apply"], { CLAWBOX_SYSTEMD_DIR: tmpdir() })).toThrow();
+  });
+});
+
+describe("optimize-ollama.sh --check", () => {
+  it("reports the concurrency and context length it would write", () => {
+    const out = run(OLLAMA, ["--check"]);
+    expect(out).toContain("OLLAMA_NUM_PARALLEL=2");
+    expect(out).toContain("OLLAMA_CONTEXT_LENGTH=4096");
+    expect(out).toContain("result: no changes made (--check)");
+  });
+
+  it("reads those values from the limits file", () => {
+    const limits = path.join(tmpdir(), "limits.env");
+    fs.writeFileSync(limits, "CLAWBOX_OLLAMA_NUM_PARALLEL=4\nCLAWBOX_OLLAMA_CONTEXT_LENGTH=8192\n");
+    const out = run(OLLAMA, ["--check"], { CLAWBOX_RESOURCE_LIMITS_FILE: limits });
+    expect(out).toContain("OLLAMA_NUM_PARALLEL=4");
+    expect(out).toContain("OLLAMA_CONTEXT_LENGTH=8192");
+  });
+});

--- a/src/tests/unit/system-profile.test.ts
+++ b/src/tests/unit/system-profile.test.ts
@@ -1,0 +1,227 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import * as childProcess from "child_process";
+
+/**
+ * The settings model behind the two TASK-455 toggles (src/lib/system-profile.ts).
+ *
+ * The scripts themselves are covered by system-profile-scripts.test.ts, which
+ * runs them for real. Here the child process is mocked, because what is under
+ * test is the CONTRACT between the route and the script: which argv is sent,
+ * which JSON object is believed, what happens when the script is missing, lies,
+ * or fails — and whether config.json is written when it shouldn't be.
+ */
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+
+const store = new Map<string, unknown>();
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(async (key: string) => store.get(key)),
+  set: vi.fn(async (key: string, value: unknown) => { store.set(key, value); }),
+}));
+
+const mockExecFile = vi.mocked(childProcess.execFile);
+
+/** Queue of (cmd, argv) -> stdout, matched on the joined command line. */
+let responses: { match: string; stdout?: string; error?: Error }[] = [];
+const calls: { cmd: string; argv: string[] }[] = [];
+
+function installExecFileMock() {
+  mockExecFile.mockImplementation(((
+    cmd: string,
+    argv: string[],
+    _opts: object,
+    cb?: (e: Error | null, r: { stdout: string; stderr: string }) => void,
+  ) => {
+    calls.push({ cmd, argv });
+    const line = `${cmd} ${argv.join(" ")}`;
+    const hit = responses.find((r) => line.includes(r.match));
+    if (cb) {
+      if (hit?.error) cb(hit.error, { stdout: "", stderr: "" });
+      else cb(null, { stdout: hit?.stdout ?? "", stderr: "" });
+    }
+    return {} as ReturnType<typeof childProcess.execFile>;
+  }) as unknown as typeof childProcess.execFile);
+}
+
+const DESKTOP_JSON = JSON.stringify({
+  supported: true, enabled: true, active: true, rebootRequired: false,
+  defaultTarget: "graphical.target", displayManager: "gdm3:alias",
+});
+const POWER_JSON = JSON.stringify({
+  supported: true, mode: "balanced", nvpmodelId: 1, nvpmodelName: "25W",
+  clocksPinned: false, balancedId: 1, performanceId: 2,
+});
+
+let libexec: string;
+let sp: typeof import("@/lib/system-profile");
+
+beforeAll(async () => {
+  libexec = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-libexec-"));
+  for (const name of ["clawbox-desktop-mode.sh", "clawbox-power-mode.sh"]) {
+    fs.writeFileSync(path.join(libexec, name), "#!/bin/sh\n", { mode: 0o755 });
+  }
+  process.env.CLAWBOX_LIBEXEC_DIR = libexec;
+  vi.resetModules();
+  sp = await import("@/lib/system-profile");
+});
+
+afterAll(() => {
+  delete process.env.CLAWBOX_LIBEXEC_DIR;
+  fs.rmSync(libexec, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  store.clear();
+  responses = [];
+  calls.length = 0;
+  installExecFileMock();
+});
+
+describe("isPowerMode", () => {
+  it("accepts only the two profiles the script implements", () => {
+    expect(sp.isPowerMode("balanced")).toBe(true);
+    expect(sp.isPowerMode("performance")).toBe(true);
+    for (const bad of ["MAXN", "", null, undefined, 2, {}, ["balanced"]]) {
+      expect(sp.isPowerMode(bad), String(bad)).toBe(false);
+    }
+  });
+});
+
+describe("readDesktopMode", () => {
+  it("runs --check without sudo and returns the script's state", async () => {
+    responses = [{ match: "--check", stdout: DESKTOP_JSON }];
+    const status = await sp.readDesktopMode();
+    expect(status.enabled).toBe(true);
+    expect(status.defaultTarget).toBe("graphical.target");
+    expect(calls[0].cmd).toBe(path.join(libexec, "clawbox-desktop-mode.sh"));
+    expect(calls[0].argv).toEqual(["--check"]);
+    // The status route must never need a privilege the sudoers file grants.
+    expect(calls.some((c) => c.cmd === "sudo")).toBe(false);
+  });
+
+  it("takes the LAST JSON object, so the mutating modes parse too", async () => {
+    responses = [{
+      match: "--check",
+      stdout: `default target set to multi-user.target\ndisable gdm3.service\n${DESKTOP_JSON}\n`,
+    }];
+    expect((await sp.readDesktopMode()).supported).toBe(true);
+  });
+
+  it("reports unsupported — defaulting to ON — when the script fails", async () => {
+    responses = [{ match: "--check", error: new Error("systemctl: not found") }];
+    const status = await sp.readDesktopMode();
+    expect(status.supported).toBe(false);
+    // The desktop is a shipped, default-ON feature: an unreadable box must not
+    // render the switch as "off", which would read as "the owner turned it off".
+    expect(status.enabled).toBe(true);
+  });
+
+  it("falls back to the owner's persisted intent when the script is unreadable", async () => {
+    store.set(sp.DESKTOP_CONFIG_KEY, false);
+    responses = [{ match: "--check", error: new Error("boom") }];
+    expect((await sp.readDesktopMode()).enabled).toBe(false);
+  });
+
+  it("survives a script that prints garbage instead of JSON", async () => {
+    responses = [{ match: "--check", stdout: "Segmentation fault\n" }];
+    expect((await sp.readDesktopMode()).supported).toBe(false);
+  });
+});
+
+describe("readPowerMode", () => {
+  it("returns the profile and the live nvpmodel state", async () => {
+    responses = [{ match: "--check", stdout: POWER_JSON }];
+    const status = await sp.readPowerMode();
+    expect(status).toMatchObject({
+      supported: true, mode: "balanced", nvpmodelId: 1,
+      nvpmodelName: "25W", clocksPinned: false,
+    });
+  });
+
+  it("defaults to balanced, never to the pinned profile", async () => {
+    responses = [{ match: "--check", error: new Error("no nvpmodel") }];
+    const status = await sp.readPowerMode();
+    expect(status.supported).toBe(false);
+    expect(status.mode).toBe("balanced");
+    expect(status.clocksPinned).toBe(false);
+  });
+
+  it("ignores a mode the script should never emit", async () => {
+    responses = [{ match: "--check", stdout: JSON.stringify({ supported: true, mode: "MAXN_SUPER" }) }];
+    expect((await sp.readPowerMode()).mode).toBe("balanced");
+  });
+});
+
+describe("setDesktopMode", () => {
+  it("invokes the root-owned script through sudo with the matching flag", async () => {
+    responses = [{ match: "clawbox-desktop-mode.sh", stdout: DESKTOP_JSON }];
+    await sp.setDesktopMode(false);
+    const mutation = calls.find((c) => c.argv.includes("--disable"))!;
+    expect(mutation.cmd).toBe("sudo");
+    // The path has to be the libexec copy verbatim: sudoers matches the
+    // argument list exactly, so the repo copy would fail closed on a password
+    // prompt nobody can answer.
+    expect(mutation.argv).toEqual([path.join(libexec, "clawbox-desktop-mode.sh"), "--disable"]);
+  });
+
+  it("persists the owner's intent once the script has succeeded", async () => {
+    responses = [{ match: "clawbox-desktop-mode.sh", stdout: DESKTOP_JSON }];
+    await sp.setDesktopMode(false);
+    expect(store.get(sp.DESKTOP_CONFIG_KEY)).toBe(false);
+  });
+
+  it("does NOT persist when the script fails", async () => {
+    responses = [{ match: "clawbox-desktop-mode.sh", error: new Error("sudo: a password is required") }];
+    await expect(sp.setDesktopMode(false)).rejects.toThrow("password is required");
+    expect(store.has(sp.DESKTOP_CONFIG_KEY)).toBe(false);
+  });
+
+  it("throws ProfileUnavailableError when the root-owned copy is missing", async () => {
+    process.env.CLAWBOX_LIBEXEC_DIR = path.join(libexec, "nope");
+    vi.resetModules();
+    const fresh = await import("@/lib/system-profile");
+    await expect(fresh.setDesktopMode(true)).rejects.toBeInstanceOf(fresh.ProfileUnavailableError);
+    process.env.CLAWBOX_LIBEXEC_DIR = libexec;
+    vi.resetModules();
+  });
+});
+
+describe("setPowerMode", () => {
+  it("maps the profile onto the script's flag", async () => {
+    responses = [{ match: "clawbox-power-mode.sh", stdout: POWER_JSON }];
+    await sp.setPowerMode("performance");
+    expect(calls.find((c) => c.cmd === "sudo")!.argv)
+      .toEqual([path.join(libexec, "clawbox-power-mode.sh"), "--performance"]);
+
+    calls.length = 0;
+    await sp.setPowerMode("balanced");
+    expect(calls.find((c) => c.cmd === "sudo")!.argv)
+      .toEqual([path.join(libexec, "clawbox-power-mode.sh"), "--balanced"]);
+  });
+
+  it("persists the profile after the script succeeds", async () => {
+    responses = [{ match: "clawbox-power-mode.sh", stdout: POWER_JSON }];
+    await sp.setPowerMode("performance");
+    expect(store.get(sp.POWER_CONFIG_KEY)).toBe("performance");
+  });
+});
+
+describe("resolveScript", () => {
+  it("prefers the root-owned copy", () => {
+    expect(sp.resolveScript("clawbox-power-mode.sh"))
+      .toBe(path.join(libexec, "clawbox-power-mode.sh"));
+  });
+
+  it("refuses the repo copy for mutations", () => {
+    expect(sp.resolveScript("does-not-exist.sh")).toBeNull();
+  });
+
+  it("allows the repo copy for the unprivileged --check path only", () => {
+    // Without this, the Settings panel would be blank on a dev machine.
+    const found = sp.resolveScript("clawbox-power-mode.sh", { allowRepoFallback: true });
+    expect(found).not.toBeNull();
+  });
+});

--- a/src/tests/unit/translations.test.ts
+++ b/src/tests/unit/translations.test.ts
@@ -126,6 +126,7 @@ describe("translations", () => {
         "hermesProvider",
         "skills",
         "localModels",
+        "systemProfile",
       ]);
 
       for (const key of Object.keys(translations.en)) {


### PR DESCRIPTION
## Task

**TASK-455** — Desktop by default, headless as a supported toggle; local-AI perf/power tuning.

Evidence: `validate-round1.md` from line 3383 (`TASK-455 + TASK-456`), `perf-memory-round1..4.md`, `REPORT-2026-08-22.md` §3–4 + recommendation 7.

## Krasi's ruling (2026-08-24, final)

> DESKTOP stays shipped and DEFAULT on Hermes boxes; headless remains available as a SETTING (a supported toggle), NOT a separate image. Do not strip GNOME/gdm/snapd from the image. Land the perf items alongside.

Nothing here uninstalls anything. `desktop-power-wiring.test.ts` pins that: the desktop script is asserted to contain no `apt remove` / `apt-get purge` / `snap remove`.

## What changed

### 1. Desktop/headless toggle — Settings → System → "Desktop environment", default ON

- `scripts/clawbox-desktop-mode.sh` — `--check` / `--enable` / `--disable`, installed root-owned to `/usr/local/libexec/clawbox`.
- Off ⇒ `systemctl set-default multi-user.target` + disable the display manager + stop the on-demand browser (no X display for it to draw on). On ⇒ the reverse. Idempotent and reversible.
- **`set-default`, not `systemctl disable gdm`**, because on the shipped JetPack image `gdm.service` is a *static* unit (measured on .71: `systemctl is-enabled gdm` → `static`, `gdm3` → `alias`), so `disable` there is a silent no-op. The boot target is the bit that actually decides, and it is what `--check` reports. The DM is still disabled best-effort for images where it isn't static.
- **Applies at the next reboot, and the UI says so.** `rebootRequired` is computed honestly as `enabled !== active` — persisted boot target vs. live `graphical.target`. Isolating the target out from under a logged-in user would kill their Remote Desktop view and any Chromium the agent is driving, and on a device whose only console *is* that desktop it is how you lock yourself out.
- Route `POST/GET /setup-api/system/desktop`, owner-only on **both** verbs with **no bootstrap carve-out** — the wizard never calls it.
- **Never applied automatically.** `install.sh`'s `step_desktop_mode` runs `--check` only, and `step_post_update` deliberately does not call it. A test asserts both.

### 2. Chromium on demand

Already correct and now pinned: `clawbox-browser.service` has **no `[Install]` section at all**, so it can never be enabled at boot, and `install.sh` skips it in the enable loop and `disable --now`s it for older boxes. The new work is that turning the desktop off also stops it if it happens to be up.

### 3. Memory guards

`scripts/clawbox-resource-limits.sh --check|--apply` writes one `50-clawbox-memory.conf` drop-in per unit. Idempotent; removing those three files restores stock behaviour exactly.

| Unit | `MemoryHigh` | `MemoryMax` | Measured baseline |
|---|---|---|---|
| `ollama.service` | 5G | 5632M | 3B resident ≈ 2,656 MiB (+170 MiB for slot 2) |
| `clawbox-browser.service` | 1200M | 1536M | 1,016 MiB RSS / 450 MiB cgroup |
| `user@1000.service` (GNOME) | 1400M | 2048M | 717 MiB cgroup / 691 MiB PSS |

Every number lives in **`config/clawbox-resource-limits.env`** — one place, with the measurement behind each written next to it. `src/lib/resource-limits.ts` mirrors it for the API/UI (the standalone build doesn't ship `config/`), and `resource-limits.test.ts` re-parses the env file with the shell's own rule and pins the two together, so a limit the UI *states* can never differ from the one the box *enforces*.

Two sizing calls worth flagging:
- The GNOME cap is ~2.8× the measured cgroup, not the 1,585 MiB RSS figure the report quotes — that RSS double-counts shared pages across 87 processes. On a default-ON feature, a cap tight enough to OOM-kill a busy-but-healthy session would be a worse regression than the memory it saves.
- A 7–8B Q4 model (~5,400 MiB projected) does **not** fit under the ollama cap. It doesn't fit on the device either (leaves ~300 MiB), so the cap turns "swap the box to death" into "the pull fails loudly". Documented in the env file.

### 4. Power profile — balanced by default, "Performance mode" opt-in

`clawbox-performance.service` used to run, at every boot, unconditionally:

```
nvpmodel -m <MAXN id> && jetson_clocks
```

`nvpmodel -m MAXN_SUPER` alone is only a ceiling and costs nothing at idle. `jetson_clocks` is the expensive half — it pins every CPU's `scaling_min_freq` to `scaling_max_freq`, pins the GPU the same way, and **disables the cpuidle states**. Measured on .71: all six cores at 1,728 MHz and the GPU at 1,020 MHz under **4%** load, 7.21 W and ~58 °C doing nothing, and median Tj **74.8 °C** (max 75.4 °C) under sustained 3B inference — over the 74 °C passive trip, in a fanless-by-default appliance.

- The unit now calls `clawbox-power-mode.sh --apply`, which applies whatever is persisted in the **root-owned** `/etc/clawbox/power-mode` (next to `edition.env`, same reason: the web server's config tree is clawbox-writable and this runs as root at boot).
- Default **balanced**: the highest non-MAXN `nvpmodel` mode (25W = ID 1 on the shipped module, resolved from `/etc/nvpmodel.conf` rather than hardcoded), `jetson_clocks` **not** run, and the cpuidle states explicitly re-enabled — `nvpmodel` does not put them back, so without that the cores never reach C7 again and the idle-power win never lands.
- **Performance mode** (Settings → System, default OFF) restores the old pinned behaviour verbatim. Applies immediately, no reboot.
- Thermal rationale is in the setting's help text, in all ten locales.
- A junk or truncated state file falls back to `balanced` — the safe default is the cool one. Tested.

### 5. `OLLAMA_NUM_PARALLEL=2`

`scripts/optimize-ollama.sh` now reads `NUM_PARALLEL` (1 → 2) and an explicit `OLLAMA_CONTEXT_LENGTH` from the same env file, and grew a `--check` mode. The old drop-in set `NUM_PARALLEL` but not `CONTEXT_LENGTH`, so llama-server silently got ollama's 4096 default — which with two slots makes the memory cost of the change unpredictable, since KV is allocated per slot.

Round 2 measured the alternative rather than guessing: `NUM_PARALLEL=1` left the 8th concurrent caller waiting **24.5 s** with throughput flat at 0.34 req/s regardless of concurrency; `=2` cost **+170 MiB** and cut 2- and 4-way concurrent wall time by **41%**. On a device where the agent and the human share one model, two consumers is the normal case.

### 6. Strings

`systemProfile.*` — 14 keys × 10 locales, authored per-locale (not English fallbacks), in the `hermes-translations` namespace so `hermes-translations.test.ts` holds them to the TASK-458 bar: every locale carries its own copy or the test fails.

### Security notes

- All four mutating invocations are **exact-match** sudoers Cmnd specs against the **root-owned** `/usr/local/libexec/clawbox` copies — never the clawbox-writable `scripts/` originals. No wildcards: these scripts branch entirely on `argv[1]`, so a trailing `*` would be a standing grant on every mode they ever grow. A test asserts the grant list is exactly those four and contains no `*`.
- `--check` needs **no** privilege at all (it only reads `systemctl`/`nvpmodel` state), so the status route runs it with no sudo and the sudo surface stays limited to the four actions that change something. A test asserts the read path never invokes `sudo`.
- The limits env file is **parsed, not sourced**. Its fallback location is the clawbox-writable repo copy while the reader runs as root; `source` there would be a one-step local root.

## How verified

Everything below was run locally in the worktree. **The QA box 192.168.50.71 was used READ-ONLY**: `systemctl get-default`, `systemctl is-enabled gdm/gdm3/clawbox-browser`, `grep POWER_MODEL /etc/nvpmodel.conf`, `sudo nvpmodel -q`, `systemctl show ollama.service -p Environment`. No power state, target, unit or reboot was touched.

Baseline confirmed on .71 (this is what the change is against):

```
systemctl get-default            -> graphical.target
systemctl is-enabled gdm3 / gdm  -> alias / static
grep POWER_MODEL /etc/nvpmodel.conf
  < POWER_MODEL ID=0 NAME=15W >
  < POWER_MODEL ID=1 NAME=25W >
  < POWER_MODEL ID=2 NAME=MAXN_SUPER >
sudo nvpmodel -q                 -> NV Power Mode: MAXN_SUPER / 2
systemctl show ollama.service -p Environment
  -> ... OLLAMA_MAX_LOADED_MODELS=1 OLLAMA_NUM_PARALLEL=1
systemctl is-enabled clawbox-browser.service -> static
```

### Every new script in `--check` / dry-run mode

```
$ bash scripts/clawbox-desktop-mode.sh --check
{"supported":true,"enabled":true,"active":true,"rebootRequired":false,"defaultTarget":"graphical.target","displayManager":"gdm3:alias"}

$ printf '< POWER_MODEL ID=0 NAME=15W >\n< POWER_MODEL ID=1 NAME=25W >\n< POWER_MODEL ID=2 NAME=MAXN_SUPER >\n' > /tmp/nvp455.conf
$ CLAWBOX_NVPMODEL_CONF=/tmp/nvp455.conf CLAWBOX_STATE_DIR=/tmp/pm455a bash scripts/clawbox-power-mode.sh --check
{"supported":false,"mode":"balanced","nvpmodelId":null,"nvpmodelName":"unknown","clocksPinned":true,"balancedId":1,"performanceId":2}
# balancedId=1 (25W), performanceId=2 (MAXN_SUPER) — resolved from the conf, not hardcoded.
# supported:false / nvpmodelId:null because this dev box has no nvpmodel; on a Jetson both are populated.

$ echo performance > /tmp/pm455b/power-mode
$ CLAWBOX_NVPMODEL_CONF=/tmp/nvp455.conf CLAWBOX_STATE_DIR=/tmp/pm455b bash scripts/clawbox-power-mode.sh --check
{"supported":false,"mode":"performance","nvpmodelId":null,"nvpmodelName":"unknown","clocksPinned":true,"balancedId":1,"performanceId":2}

$ bash scripts/clawbox-resource-limits.sh --check
source: .../config/clawbox-resource-limits.env
mode: check
unit: ollama.service MemoryHigh=5G MemoryMax=5632M -> /etc/systemd/system/ollama.service.d/50-clawbox-memory.conf
unit: clawbox-browser.service MemoryHigh=1200M MemoryMax=1536M -> /etc/systemd/system/clawbox-browser.service.d/50-clawbox-memory.conf
unit: user@1000.service MemoryHigh=1400M MemoryMax=2048M -> /etc/systemd/system/user@1000.service.d/50-clawbox-memory.conf
result: no changes made (--check)

$ bash scripts/optimize-ollama.sh --check
OLLAMA_NUM_PARALLEL=2
OLLAMA_CONTEXT_LENGTH=4096
result: no changes made (--check)
```

`--check` writing nothing is asserted, not just claimed: the resource-limits test points `CLAWBOX_SYSTEMD_DIR` at a temp dir and asserts it is still empty afterwards.

### Suite

```
$ bun run test
 Test Files  317 passed (317)
      Tests  4637 passed (4637)

$ bun run build
 ✓ Compiled successfully in 5.5s
   ├ ƒ /setup-api/system/desktop
   ├ ƒ /setup-api/system/power-profile

$ npx shellcheck scripts/clawbox-desktop-mode.sh scripts/clawbox-power-mode.sh \
                 scripts/clawbox-resource-limits.sh scripts/optimize-ollama.sh
 (no findings)

$ bash -n install.sh
 (ok)
```

Typecheck: `bunx tsc --noEmit` produces the **same 39 lines of pre-existing errors** on this branch as on `origin/beta` (verified by stashing the change and re-running) — all in unrelated test files (`ProcessEnv.NODE_ENV`, `node:sqlite`, `stt-bench`). `bun run lint` likewise: 22 errors / 75 warnings, identical before and after, none in files this PR touches.

### New tests (78 added)

- `resource-limits.test.ts` (23) — env-file ↔ TS-mirror pinning key by key; High < Max; Max < RAM; `parseSystemdSize` accept/reject.
- `system-profile-scripts.test.ts` (19) — runs the three shell scripts **for real** in `--check`: JSON shape, mode resolution, junk state file → balanced, missing nvpmodel.conf still emits valid JSON, unknown flags rejected, non-root mutations refused, `--check` writes nothing.
- `system-profile.test.ts` (18) — the model contract with a mocked child process: exact argv to `sudo`, LAST-JSON parsing (so mutating modes parse too), a failed toggle does **not** persist intent, unreadable box defaults the desktop to ON.
- `desktop.test.ts` / `power-profile.test.ts` (20) — 401 on both verbs incl. the first-boot window, 400 on every bad body shape, 503-with-the-fix when the root-owned script is missing, 500 otherwise.
- `desktop-power-wiring.test.ts` (21) — the units, the four exact sudoers grants, the install/update steps, "install never flips the toggle", "every dispatchable step has a function", browser still has no `[Install]`.

## What is NOT covered

- **Not applied on real hardware.** The .71 mandate is read-only, so no toggle was exercised on a Jetson: `nvpmodel -m 1`, the cpuidle re-enable and the boot-target flip are all unverified against actual silicon, as is the resulting idle wattage. The scripts degrade to `supported:false` where `nvpmodel`/`systemctl` are absent, which is the shape CI sees. **This needs one hands-on pass on a box that can be rebooted before it ships.**
- **The 41% / +170 MiB concurrency numbers are round 2's, not re-measured here.** They were measured on .71 by mutating the live drop-in, which this lane may not do.
- **No `MemoryMax` was exercised under real pressure.** The drop-ins are asserted to be written correctly; whether 5632M is where ollama should actually die is a judgement from the measured baselines, not an observation.
- **GPU frequency un-pinning is delegated to `nvpmodel -m`.** The script explicitly resets the CPU `scaling_min_freq` and the cpuidle states but relies on `nvpmodel` to restore the GPU devfreq caps from its conf. If a Jetson pass shows the GPU still pinned after a balanced apply, that needs an explicit reset added.
- **Journald persistence, the early-boot clock skew and the missing HTTP access log** (the other half of the `validate-round1.md` §TASK-455+456 block) belong to TASK-456 and are already landed on `beta`.
- **`OLLAMA_GPU_OVERHEAD`** — the report also suggests `1.5G`. Not included: unlike `NUM_PARALLEL`, it was not A/B measured, and guessing at it interacts with the `MemoryMax` this PR does set.
- Nothing here touches the chat transport, the harness abstraction, `HermesAdapter`, the OAuth inline routes or the hermes version pin (Krasi-CC's zones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added System settings controls for enabling/disabling desktop mode and selecting balanced or performance power mode.
  - Displays current power, clock, support, reboot, and memory-limit status.
  - Added authenticated setup API support for reading and changing desktop and power profiles.
  - Added configurable resource protections for system services and Ollama performance settings.
- **Documentation**
  - Expanded setup and architecture documentation for desktop mode, power profiles, reboot behavior, and resource limits.
- **Localization**
  - Added system-profile translations across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->