### PR TITLE
Desktop toggle no longer destroys the desktop; leaving performance mode releases the EMC lock (TASK-455 hardware pass)

### DIFF
--- a/scripts/clawbox-desktop-mode.sh
+++ b/scripts/clawbox-desktop-mode.sh
@@ -18,12 +18,13 @@
 # console is that desktop is also how you lock yourself out of a device with no
 # keyboard. So we change the boot target and report "reboot required".
 #
-# WHY set-default and not `systemctl disable gdm`: on the shipped JetPack image
-# gdm.service is a STATIC unit (measured on the QA box: `systemctl is-enabled
-# gdm` -> static, `gdm3` -> alias). `disable` on a static unit is a silent
-# no-op, so it is the boot target that actually decides. gdm is still disabled
-# best-effort below for the images where it is not static, but the target is
-# the authoritative bit and the one --check reports.
+# WHY set-default and not `systemctl disable gdm`: the boot target is the
+# authoritative bit and the one --check reports. An earlier revision ALSO
+# disabled the display manager "best-effort", believing `disable` to be a no-op
+# on the shipped JetPack image because `systemctl is-enabled gdm` answers
+# `static`. On hardware that is false and it cost the desktop permanently — see
+# dm_is_installable below for the measurement and the trap. Display managers are
+# now only enabled/disabled when their [Install] symlinks are genuinely ours.
 #
 # Must run as root for --enable/--disable. --check needs no privileges.
 
@@ -35,6 +36,13 @@ CONSOLE_TARGET="multi-user.target"
 # Display managers we switch off alongside the target, in the order they are
 # tried. Best-effort: a box with none of them installed is fine.
 DISPLAY_MANAGERS=(gdm3.service gdm.service lightdm.service sddm.service)
+
+# The symlink that actually starts the desktop. On Ubuntu/JetPack the display
+# manager package installs it as an alias of the real unit, and
+# `graphical.target` pulls it in via `Wants=display-manager.service`. If the
+# link is missing the target still activates — with nothing under it — so the
+# box boots to a black screen no matter what `set-default` says.
+DISPLAY_MANAGER_ALIAS="/etc/systemd/system/display-manager.service"
 
 usage() {
   echo "Usage: $(basename "$0") --check | --enable | --disable" >&2
@@ -62,13 +70,34 @@ graphical_active() {
   [ "$(systemctl is-active "$GRAPHICAL_TARGET" 2>/dev/null || true)" = "active" ]
 }
 
+# Does graphical.target actually pull the display manager in on this image?
+#
+# Wants, not Requires: on stock JetPack graphical.target has
+# `Requires=multi-user.target` and reaches the display manager through
+# `Wants=display-manager.service`. Asking only about Requires made both the
+# repair and the --check warning silent no-ops on the very box they were
+# written for. Ask for both, once, from one place.
+graphical_target_wants_display_manager() {
+  systemctl show "$GRAPHICAL_TARGET" -p Wants -p Requires 2>/dev/null \
+    | grep -q 'display-manager\.service'
+}
+
 display_manager_state() {
   have_systemctl || { echo "unknown"; return; }
-  local dm
+  local dm suffix=""
+  # `is-enabled` on an alias answers "alias" whether or not the alias symlink
+  # still exists, so it reads identically on a healthy box and on one whose
+  # display-manager.service link was deleted. Say so explicitly, or --check
+  # cannot tell "desktop off" from "desktop broken". Free-form string by
+  # contract (src/lib/system-profile.ts reads it as an opaque label), so this
+  # adds no schema.
+  if [ ! -e "$DISPLAY_MANAGER_ALIAS" ] && graphical_target_wants_display_manager; then
+    suffix=":missing-alias"
+  fi
   for dm in "${DISPLAY_MANAGERS[@]}"; do
     if systemctl list-unit-files "$dm" >/dev/null 2>&1 \
       && [ -n "$(systemctl list-unit-files "$dm" --no-legend 2>/dev/null)" ]; then
-      echo "${dm%.service}:$(systemctl is-enabled "$dm" 2>/dev/null || echo unknown)"
+      echo "${dm%.service}:$(systemctl is-enabled "$dm" 2>/dev/null || echo unknown)${suffix}"
       return
     fi
   done
@@ -112,19 +141,92 @@ set_target() {
   fi
 }
 
+# May `systemctl <action>` be run on this unit, or would it do damage?
+#
+# The original code disabled every name in DISPLAY_MANAGERS "best-effort, never
+# fatal", on the stated reasoning that "disable on a static unit is a silent
+# no-op". On hardware it is not: `systemctl disable` removes every symlink that
+# enables the unit, and on stock JetPack one of them is
+# /etc/systemd/system/display-manager.service — what graphical.target pulls in
+# via Wants=. `enable` cannot put it back (the real unit is static: no
+# [Install]/Alias= to install from), so turning the desktop off destroyed it
+# permanently while the API went on answering {"enabled":true}.
+#
+# The trap that makes this so easy to get wrong — measured on the QA box,
+# 2026-08-24, with `bash -x`:
+#
+#   symlink present:  systemctl is-enabled gdm.service -> indirect
+#   symlink deleted:  systemctl is-enabled gdm.service -> static
+#
+# So `static` is what the box reports AFTER the damage is done. Anyone probing
+# a box that has already been through one --disable sees `static`, concludes
+# "disable is a no-op here", and ships the loop that broke it. Only `indirect`
+# — the state that means "enabled through a symlink" — is visible beforehand,
+# and it is exactly the state where disable is destructive.
+#
+# Hence a WHITELIST, not a blacklist of known-bad states. systemd's vocabulary
+# also includes generated/transient/masked/linked/indirect, and guessing which
+# of those are safe is how this bug happened twice. Only `enabled`,
+# `enabled-runtime` and `disabled` describe a unit whose [Install] symlinks are
+# ours to add or remove; for everything else the boot target carries the
+# change, which is what this script was designed around anyway.
+#
+# NOTE on the exit status: `systemctl is-enabled` prints the state on stdout
+# but exits NON-ZERO for several of these. `$(systemctl is-enabled "$1" || echo
+# unknown)` therefore captures BOTH words — "static\nunknown" — matching no arm
+# and falling through to the destructive branch. Keep status handling separate
+# from the capture.
+dm_is_installable() {
+  local state
+  state="$(systemctl is-enabled "$1" 2>/dev/null)" || true
+  case "$state" in
+    enabled|enabled-runtime|disabled) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 set_display_managers() {
   local action="$1" dm
   have_systemctl || return 0
   for dm in "${DISPLAY_MANAGERS[@]}"; do
     [ -n "$(systemctl list-unit-files "$dm" --no-legend 2>/dev/null)" ] || continue
-    # Static units (gdm on stock JetPack) have no [Install] section, so this is
-    # a no-op there and the boot target carries the whole change. Never fatal.
+    if ! dm_is_installable "$dm"; then
+      # The boot target carries the whole change here, which is what this
+      # script was always designed around.
+      echo "$action $dm skipped ($(systemctl is-enabled "$dm" 2>/dev/null || true) — the boot target decides)"
+      continue
+    fi
     if systemctl "$action" "$dm" >/dev/null 2>&1; then
       echo "$action $dm"
     else
-      echo "$action $dm skipped (static or not installable)"
+      echo "$action $dm skipped (not installable)"
     fi
   done
+}
+
+# Put back a display-manager.service alias that an earlier --disable deleted.
+#
+# Needed for every device already shipped with the bug above: `set-default
+# graphical.target` alone leaves them black-screened, because the unit the
+# target requires no longer resolves. Idempotent, and does nothing on a healthy
+# box or on an image that never had the alias.
+repair_display_manager_alias() {
+  local dm unit
+  have_systemctl || return 0
+  [ -e "$DISPLAY_MANAGER_ALIAS" ] && return 0
+  graphical_target_wants_display_manager || return 0
+
+  for dm in "${DISPLAY_MANAGERS[@]}"; do
+    # Resolve through the alias to the unit file that actually exists, so the
+    # link points at gdm.service rather than at another symlink.
+    unit="$(systemctl show "$dm" -p FragmentPath --value 2>/dev/null || true)"
+    [ -n "$unit" ] && [ -f "$unit" ] || continue
+    ln -sf "$unit" "$DISPLAY_MANAGER_ALIAS"
+    systemctl daemon-reload >/dev/null 2>&1 || true
+    echo "repaired $DISPLAY_MANAGER_ALIAS -> $unit"
+    return 0
+  done
+  echo "warning: $DISPLAY_MANAGER_ALIAS is missing and no display manager unit was found" >&2
 }
 
 main() {
@@ -136,6 +238,11 @@ main() {
       require_root
       set_target "$GRAPHICAL_TARGET"
       set_display_managers enable
+      # Before reporting success: a box that was turned headless by an older
+      # build of this script has no display-manager.service left, and would
+      # otherwise reboot into a graphical.target with nothing under it while
+      # this command exits 0 saying the desktop is on.
+      repair_display_manager_alias
       report
       ;;
     --disable)

--- a/scripts/clawbox-power-mode.sh
+++ b/scripts/clawbox-power-mode.sh
@@ -145,10 +145,64 @@ unpin_cpu_freq() {
   done
 }
 
+# Where the pre-pin clock state is snapshotted, so switching back to balanced
+# can hand every knob back rather than only the ones we remembered to name.
+#
+# `nvpmodel -m <balanced>` rewrites the CPU and GPU caps for us — measured: the
+# GPU devfreq really does return to 306-918 MHz with no help. It does NOT clear
+# the EMC rate lock that jetson_clocks sets, so on the QA box a
+# performance -> balanced round trip left EMC pinned at 3,199 MHz with
+# FreqOverride=1 and idle draw at 5,992 mW instead of 4,831 mW — +1,161 mW,
+# half of everything this profile saves, held until the next reboot
+# (measured 2026-08-24).
+#
+# Writing 0 to .../clk/emc/mrq_rate_locked clears the override flag but leaves
+# the rate itself at 3,199 MHz (also measured), so the flag alone is not the
+# fix. jetson_clocks' own --store/--restore is, and it covers whatever else a
+# future JetPack decides to pin.
+CLOCK_SNAPSHOT="/var/lib/clawbox/l4t_dfs.conf"
+EMC_RATE_LOCK="/sys/kernel/debug/bpmp/debug/clk/emc/mrq_rate_locked"
+
+# Snapshot the UNPINNED state, once. Guarded because a second --performance on
+# an already-pinned box would otherwise overwrite the pristine snapshot with a
+# pinned one, and then --balanced would "restore" the pinning.
+store_clock_state() {
+  have jetson_clocks || return 0
+  [ -e "$CLOCK_SNAPSHOT" ] && return 0
+  mkdir -p "$(dirname "$CLOCK_SNAPSHOT")" 2>/dev/null || return 0
+  if jetson_clocks --store "$CLOCK_SNAPSHOT" >/dev/null 2>&1; then
+    echo "clock state stored to $CLOCK_SNAPSHOT"
+  else
+    echo "warning: could not store clock state; EMC may stay pinned until reboot" >&2
+  fi
+}
+
+# Hand the clocks back. Falls back to clearing the EMC lock directly for boxes
+# that were already pinned when this build landed and so have no snapshot —
+# they still need a reboot to drop the rate, but they stop being *locked*.
+restore_clock_state() {
+  if have jetson_clocks && [ -e "$CLOCK_SNAPSHOT" ]; then
+    if jetson_clocks --restore "$CLOCK_SNAPSHOT" >/dev/null 2>&1; then
+      echo "clock state restored from $CLOCK_SNAPSHOT"
+    else
+      echo "warning: jetson_clocks --restore failed" >&2
+    fi
+    # Consume it, so the next --performance snapshots a fresh unpinned state.
+    rm -f "$CLOCK_SNAPSHOT" 2>/dev/null || true
+    return 0
+  fi
+  if [ -w "$EMC_RATE_LOCK" ] && [ "$(cat "$EMC_RATE_LOCK" 2>/dev/null || echo 0)" = "1" ]; then
+    echo 0 > "$EMC_RATE_LOCK" 2>/dev/null || true
+    echo "EMC rate lock cleared (no snapshot; rate drops at next reboot)"
+  fi
+}
+
 apply_balanced() {
   local id name
   id="$(balanced_mode_id)"
   name="$(mode_name_for_id "$id")"
+  # Before nvpmodel, so the mode's own caps are the last word.
+  restore_clock_state
   if have nvpmodel; then
     nvpmodel -m "$id" >/dev/null 2>&1 || echo "warning: nvpmodel -m $id failed" >&2
     echo "nvpmodel mode $id (${name:-unknown})"
@@ -173,6 +227,8 @@ apply_performance() {
     echo "nvpmodel not present, skipping mode select"
   fi
   if have jetson_clocks; then
+    # Snapshot BEFORE pinning — after it, there is nothing worth remembering.
+    store_clock_state
     jetson_clocks >/dev/null 2>&1 || echo "warning: jetson_clocks failed" >&2
     echo "jetson_clocks: applied (clocks pinned)"
   else

--- a/src/tests/unit/desktop-power-hardware-pass.test.ts
+++ b/src/tests/unit/desktop-power-hardware-pass.test.ts
@@ -1,0 +1,143 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regressions caught by the TASK-455 hardware pass on box .71 (2026-08-24).
+ *
+ * Both bugs here were invisible to every existing test because both scripts
+ * behaved correctly in isolation and reported success afterwards. They only
+ * appear on a real Jetson, one reboot later:
+ *
+ *   1. `--disable` ran `systemctl disable` over the display managers.
+ *      `systemctl disable gdm.service` removes EVERY symlink pointing at that
+ *      unit, and one of them is /etc/systemd/system/display-manager.service —
+ *      what graphical.target pulls in via Wants=. `enable` could not recreate
+ *      it (a static unit has no [Install]/Alias=), so the desktop never came
+ *      back and the API still answered {"enabled":true}.
+ *   2. `--balanced` after `--performance` left the EMC rate locked at
+ *      3,199 MHz: +1,161 mW at idle (5,992 mW vs 4,831 mW), held until reboot.
+ *
+ * File assertions, like the sibling desktop-power-wiring suite, and for the
+ * same reason: the failure mode is silent success, so there is no thrown error
+ * for a behaviour test to catch.
+ */
+
+const REPO = process.cwd();
+const read = (...p: string[]) => fs.readFileSync(path.join(REPO, ...p), "utf-8");
+
+/**
+ * Drop `#` comment lines. Both scripts document the behaviour they replace, so
+ * a naive `not.toContain` matches the explanation and fails a correct file.
+ */
+const codeOnly = (raw: string) =>
+  raw.split("\n").filter((l) => !l.trimStart().startsWith("#")).join("\n");
+
+describe("clawbox-desktop-mode.sh — the desktop toggle is reversible", () => {
+  const script = read("scripts", "clawbox-desktop-mode.sh");
+  const code = codeOnly(script);
+
+  it("only enables/disables display managers whose [Install] symlinks are ours", () => {
+    // The whole bug in one line: `systemctl disable gdm.service` removes every
+    // symlink that enables the unit, display-manager.service included, so the
+    // old unguarded loop destroyed the desktop.
+    //
+    // A WHITELIST, deliberately. Measured on hardware: with the symlink present
+    // `is-enabled gdm.service` is `indirect`; only once the symlink is gone does
+    // it become `static`. A blacklist written from a post-damage probe therefore
+    // misses the one state that matters — which is how this regressed twice.
+    expect(code).toMatch(/enabled\|enabled-runtime\|disabled\)\s*return 0/);
+    expect(code).not.toMatch(/indirect\)\s*return 0/);
+    // The guard has to be consulted by the loop, not merely defined.
+    expect(code).toMatch(/if ! dm_is_installable "\$dm"/);
+  });
+
+  it("does not let is-enabled's non-zero exit corrupt the captured state", () => {
+    // `systemctl is-enabled` prints the state but exits non-zero for several of
+    // them, so `$(... || echo unknown)` captures "static\nunknown" and matches
+    // no arm — the exact way the first attempt at this fix still deleted the
+    // symlink on hardware.
+    expect(code).not.toMatch(/is-enabled "\$1" 2>\/dev\/null \|\| echo/);
+    expect(code).toMatch(/state="\$\(systemctl is-enabled "\$1" 2>\/dev\/null\)" \|\| true/);
+  });
+
+  it("repairs a deleted display-manager.service alias on --enable", () => {
+    // Required for devices already shipped with the bug: set-default alone
+    // leaves them booting into a graphical.target with nothing under it.
+    expect(code).toContain("repair_display_manager_alias");
+    expect(code).toMatch(/--enable\)[\s\S]{0,400}repair_display_manager_alias/);
+    expect(code).toContain("/etc/systemd/system/display-manager.service");
+  });
+
+  it("only repairs when graphical.target actually pulls the alias in", () => {
+    // Never invent the symlink on an image that legitimately has no display
+    // manager.
+    // Wants, not Requires: graphical.target has Requires=multi-user.target and
+    // pulls the display manager in through Wants=. Checking Requires alone made
+    // the repair a silent no-op on the box it was written for.
+    expect(code).toMatch(/-p Wants -p Requires/);
+    expect(code).toMatch(/-p Wants -p Requires[\s\S]{0,200}display-manager/);
+  });
+
+  it("resolves the alias to a real unit file rather than another symlink", () => {
+    expect(code).toMatch(/FragmentPath/);
+  });
+
+  it("reports a missing alias so --check can tell 'off' from 'broken'", () => {
+    // `is-enabled` answers "alias"/"static" whether or not the symlink
+    // survives, so the pre-fix JSON was byte-identical on a healthy box and a
+    // bricked one.
+    expect(code).toContain("missing-alias");
+  });
+
+  it("still lets the boot target carry the change", () => {
+    expect(code).toContain("systemctl set-default");
+    // And still refuses to isolate the target out from under a live session.
+    expect(code).not.toContain("systemctl isolate");
+  });
+});
+
+describe("clawbox-power-mode.sh — leaving performance mode gives the clocks back", () => {
+  const script = read("scripts", "clawbox-power-mode.sh");
+  const code = codeOnly(script);
+
+  it("snapshots the unpinned clock state before pinning", () => {
+    expect(code).toContain("jetson_clocks --store");
+    expect(code).toMatch(/store_clock_state[\s\S]{0,200}jetson_clocks >/);
+  });
+
+  it("never overwrites a pristine snapshot with an already-pinned one", () => {
+    // A second --performance must not capture the pinned state as "the state
+    // to restore", or --balanced would restore the pinning.
+    expect(code).toMatch(/\[ -e "\$CLOCK_SNAPSHOT" \] && return 0/);
+  });
+
+  it("restores the clocks when switching back to balanced", () => {
+    expect(code).toContain("jetson_clocks --restore");
+    expect(code).toMatch(/apply_balanced\(\)[\s\S]{0,300}restore_clock_state/);
+  });
+
+  it("restores before nvpmodel so the mode's own caps are the last word", () => {
+    const balanced = code.slice(code.indexOf("apply_balanced()"));
+    expect(balanced.indexOf("restore_clock_state")).toBeGreaterThanOrEqual(0);
+    expect(balanced.indexOf("restore_clock_state")).toBeLessThan(balanced.indexOf("nvpmodel -m"));
+  });
+
+  it("falls back to clearing the EMC lock on boxes with no snapshot", () => {
+    // Devices already pinned when this build lands have nothing stored.
+    expect(code).toContain("mrq_rate_locked");
+  });
+
+  it("consumes the snapshot so the next pin captures a fresh one", () => {
+    expect(code).toMatch(/rm -f "\$CLOCK_SNAPSHOT"/);
+  });
+
+  it("still does not run jetson_clocks in the balanced profile", () => {
+    const balanced = code.slice(
+      code.indexOf("apply_balanced()"),
+      code.indexOf("apply_performance()"),
+    );
+    // --restore is a restore, not a pin; a bare `jetson_clocks` here would be.
+    expect(balanced).not.toMatch(/^\s*jetson_clocks\s*(>|$)/m);
+  });
+});


### PR DESCRIPTION
From the 2026-08-24 hardware pass on box .71 (findings: automation/hermes-night/findings/hwtest-round1.md, Part B). Two defects found on real Jetson silicon after PR #466:

1. **CRITICAL — desktop toggle OFF then ON permanently destroyed the desktop.** `set_display_managers disable` ran `systemctl disable` on `gdm3.service`, which is an *alias* of `gdm.service` (no `[Install]` section), so systemd deleted `/etc/systemd/system/display-manager.service` and `--enable` could never recreate it. `graphical.target` Requires that unit → no GNOME/gdm/Xorg ever again; the API still reported `enabled:true`. Fix: never disable alias/static units, `--enable` repairs a missing `display-manager.service` symlink, `--check` reports whether it resolves.
2. **Medium — leaving Performance mode left the memory controller pinned** (`mrq_rate_locked=1`, EMC 3199 MHz, +1.16 W idle = half the feature's saving) until reboot. Fix: `jetson_clocks --store` before pinning, `--restore` on the way back, fallback writes 0 to the EMC lock.

Measured on hardware: balanced idle 4.83 W vs 7.17 W pinned (−32.6 %), tj 57.0 → 54.6 °C; 3B load no longer crosses the 74 °C trip.

Opened by Mike on behalf of the hardware-test lane (author Krasi). Reviewed diff stat only; CI decides.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop mode handling for display-manager configurations, including safer enable/disable behavior and automatic repair when configuration links are missing.
  * Improved performance and balanced power-mode switching by preserving and restoring hardware clock settings.
  * Added fallback handling to prevent clock-rate settings from remaining locked after switching modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->