### PR TITLE
fix: refresh Hermes MCP tools when the mailbox becomes readable

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -159,6 +159,17 @@ tool offline. The route enforces the gate independently, because the two live on
 opposite sides of a process boundary and the owner can change the mode under a
 running server.
 
+Because the probe is startup-only, a mode or credential change would otherwise
+leave a long-lived server with the tool list it built at boot — a mailbox
+connected under a running server stayed invisible to the agent until something
+respawned the server. So `/setup-api/email/configure` now asks Hermes to reload
+its MCP servers (`reload.mcp` on the dashboard socket, `confirm: true`) whenever
+a save or a disconnect **flips** `canRead`; the server starts again and re-probes
+the gate, and live sessions pick the new list up at their next turn boundary.
+Only on a flip: a reload respawns every MCP child process and invalidates the
+model's prompt cache, so it is not free and must not fire on an ordinary save.
+See `src/lib/email-mcp-refresh.ts`.
+
 Both read tools ARE `readOnly`, and that claim is literal rather than polite: the
 mailbox is opened with `EXAMINE` (read-only at the protocol level) and every
 fetch uses `BODY.PEEK`, so listing and reading do not even set `\Seen`. No

--- a/src/app/setup-api/email/configure/route.ts
+++ b/src/app/setup-api/email/configure/route.ts
@@ -11,16 +11,24 @@
 //
 // DELETE disconnects: it clears ClawBox's stored credentials and, on Hermes,
 // removes the EMAIL_* block from ~/.hermes/.env.
+//
+// BOTH VERBS also tell Hermes to rebuild its MCP tool list when — and only when
+// — this change flips whether the agent may read the mailbox. The MCP server
+// probes that gate once at startup, so without this a mailbox connected under a
+// running server stays invisible to the agent. See email-mcp-refresh.ts for the
+// whole story, including why the reload is not fired on an ordinary save.
 
 import { NextResponse } from "next/server";
 import {
   clearEmailSettings,
   modeAllowsReading,
   parseEmailConfigure,
+  publicEmailStatus,
   saveEmailSettings,
   toImapConfig,
   toSmtpConfig,
 } from "@/lib/email-config";
+import { refreshEmailToolsIfReadabilityChanged } from "@/lib/email-mcp-refresh";
 import { clearPending } from "@/lib/email-pending";
 import { ImapError, verifyImap } from "@/lib/imap-client";
 import { getActiveHarness } from "@/lib/harness";
@@ -92,7 +100,41 @@ export async function POST(request: Request) {
       }
     }
 
+    // Whether the agent may open the mailbox, asked BEFORE the write and again
+    // after it. Read through publicEmailStatus rather than re-derived here:
+    // email-config.ts answers `canRead` in one place on purpose (its comment
+    // says so), and a second copy of "which modes allow reading" is a copy that
+    // can drift when a fourth mode arrives.
+    const couldReadBefore = (await publicEmailStatus()).canRead;
+
     await saveEmailSettings(settings);
+
+    // The "after" side needs no second read of the store. An account is provably
+    // connected at this point — the address, the password and the SMTP host were
+    // just accepted by the real server — so the mode is the whole of the answer,
+    // through the same helper `canRead` is built from.
+    //
+    // AWAITED, deliberately, rather than left to run after the response. Three
+    // reasons, in order of weight. It only ever does anything on a readability
+    // FLIP, which happens about once in the life of a mailbox, so the latency is
+    // not paid by ordinary saves. This route already awaits `restartHermesForEmail`
+    // below — a full gateway restart — on the inbound path, so seconds are
+    // already inside its budget and a tool-list reload is the smaller of the two.
+    // And a floating promise here would outlive the response with nothing
+    // watching it, on a request whose own later branches can restart the very
+    // gateway it is talking to; awaiting keeps the call ordered, bounded by the
+    // helper's own deadline, and observable by a test.
+    //
+    // It cannot fail the save: the helper swallows everything and returns void,
+    // so the worst case is a logged line and a tool list that catches up at the
+    // next restart.
+    //
+    // On a send → answer change the gateway restart below ALSO respawns the MCP
+    // servers, making this reload redundant for that one transition. Skipping it
+    // there would mean guessing that the restart is going to happen and going to
+    // succeed — and the case where it does not is precisely the case that needs
+    // the refresh, so the redundant reload is the cheaper mistake.
+    await refreshEmailToolsIfReadabilityChanged(couldReadBefore, modeAllowsReading(settings.mode));
 
     // Hermes' native adapter is the only way the agent can RECEIVE mail, and it
     // is opt-in. On OpenClaw there is no email channel at all (inventing one
@@ -189,6 +231,12 @@ export async function POST(request: Request) {
 
 export async function DELETE(request: Request) {
   try {
+    // Asked before the account is dropped, for the same reason POST asks: this
+    // is the other direction of the same flip. An agent whose box no longer has
+    // a mailbox must stop being offered email_list/email_read, or every call it
+    // makes to them answers 409 — which is the failure the registration gate
+    // exists to avoid in the first place.
+    const couldReadBefore = (await publicEmailStatus()).canRead;
     await clearEmailSettings();
     // Drafts waiting on an account that no longer exists can never be approved,
     // and they hold agent-composed text. Disconnecting drops them.
@@ -204,6 +252,9 @@ export async function DELETE(request: Request) {
         console.error("[email/configure] Hermes email teardown failed:", err);
       }
     }
+    // There is no account left, so "after" is false by construction — no read of
+    // the store can say anything else. Same await-and-swallow contract as POST.
+    await refreshEmailToolsIfReadabilityChanged(couldReadBefore, false);
     return NextResponse.json({ success: true });
   } catch (err) {
     return NextResponse.json(

--- a/src/lib/email-mcp-refresh.ts
+++ b/src/lib/email-mcp-refresh.ts
@@ -1,0 +1,74 @@
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+
+/**
+ * Ask Hermes to rebuild its MCP tool list when the mailbox becomes readable, or
+ * stops being.
+ *
+ * WHY THIS EXISTS. Two tools, `email_list` and `email_read`, are registered
+ * CONDITIONALLY by the ClawBox MCP server (mcp/tools/email.ts): the server asks
+ * `/setup-api/email/status` for `canRead` while it boots (mcp/lib/context.ts)
+ * and, when the answer is no, it never declares them. That is not caution about
+ * the mailbox — the route refuses the call anyway. It is about Hermes' own
+ * per-server circuit breaker: a tool that can only ever answer 409 keeps
+ * failing, the breaker opens, and it takes EVERY ClawBox tool offline with it,
+ * not just the two. So "not registered" really is the right answer for a
+ * send-only box, and registering them always is not an option.
+ *
+ * The bug it fixes is that the probe happens ONCE, at server startup, and the
+ * server is a long-lived stdio child of Hermes. When the owner connects a
+ * mailbox or moves the mode from "Send only" to "Read on demand", the running
+ * server keeps the tool list it built at boot, so the agent still has no way to
+ * open the mailbox the owner just gave it — until something unrelated happens
+ * to respawn the server. Measured on the owner's device
+ * (`~/.hermes/logs/mcp-stderr.log`): 8 starts logged `profile=full, 41 tools`
+ * and 21 logged `43 tools`, the 41-tool starts all predating the mailbox
+ * becoming readable, and the two missing tools were exactly these.
+ *
+ * The mechanism is Hermes' own. Its dashboard JSON-RPC socket accepts
+ * `reload.mcp`; with `confirm: true` and NO `session_id` it runs
+ * `shutdown_mcp_servers()` + `discover_mcp_tools()` globally, which is precisely
+ * the respawn needed — the ClawBox server starts again and re-probes the gate,
+ * and live sessions pick the new list up at their next turn boundary via
+ * Hermes' own between-turns refresh. `confirm` is not optional: the call is
+ * gated by `approvals.mcp_reload_confirm`, which defaults to true, and without
+ * it the dashboard answers `{ status: "confirm_required" }` and does nothing.
+ */
+
+/**
+ * Hermes' own confirmation flag for `reload.mcp`. Passing it is what makes the
+ * call act rather than ask — see the note above.
+ */
+const RELOAD_PARAMS = { confirm: true } as const;
+
+/**
+ * Reload Hermes' MCP servers, but ONLY if this settings change flipped whether
+ * the agent may read the mailbox.
+ *
+ * The guard is the important half. A reload kills and respawns every MCP child
+ * process and invalidates the model's prompt cache, so the next turn on this box
+ * re-sends and re-pays for a system prompt that was cached — it is not free, and
+ * firing it on every email save (a display name edited, a password rotated in
+ * place) would charge the owner for nothing. Readability flips maybe once in the
+ * life of a mailbox; that is the event worth a reload, and it is the only one
+ * this fires on.
+ *
+ * Never throws and never reports. A box whose dashboard is down, or an OpenClaw
+ * box that has no dashboard at all, must not have its email settings save turned
+ * into an error by a best-effort refresh: the settings ARE saved, the gate is
+ * still enforced route-side, and the tool list catches up at the next restart —
+ * which is exactly the behaviour of every box before this existed.
+ */
+export async function refreshEmailToolsIfReadabilityChanged(before: boolean, after: boolean): Promise<void> {
+  if (before === after) return;
+  const result = await dashboardRpc("reload.mcp", RELOAD_PARAMS).catch(() => null);
+  if (result === null) {
+    // Logged, not surfaced. Worth a line because "the agent still cannot see my
+    // mailbox" is otherwise invisible from the outside, and this is the one
+    // place that knows the refresh was wanted and did not happen.
+    console.error(
+      `[email/mcp-refresh] mailbox readability changed to ${after}, but Hermes would not reload its MCP servers`,
+    );
+    return;
+  }
+  console.log(`[email/mcp-refresh] mailbox readability changed to ${after}; asked Hermes to reload its MCP servers`);
+}

--- a/src/lib/hermes-dashboard-rpc.ts
+++ b/src/lib/hermes-dashboard-rpc.ts
@@ -1,0 +1,151 @@
+import { WebSocket } from "ws";
+import { DASHBOARD_WS_ORIGIN, dashboardWsTicket } from "@/lib/hermes-dashboard-auth";
+
+/**
+ * ONE JSON-RPC call to the Hermes dashboard's socket, for callers that want an
+ * answer rather than a conversation.
+ *
+ * `hermes-dashboard-turn.ts` opens the same socket and drives a whole streaming
+ * turn across it — a session to settle, deltas to forward, an approval prompt
+ * that will hang the agent if nobody answers it. Almost none of that applies to
+ * a call like `reload.mcp`: send one frame, read one reply, hang up. This module
+ * is that shape, and it deliberately reuses the turn module's idiom for the part
+ * that IS the same — mint a single-use ticket, dial `DASHBOARD_WS_ORIGIN`,
+ * `await` the `open` event because `ws` comes up asynchronously, then read
+ * frames until one carries our request id (the dashboard opens with
+ * `gateway.ready` and keeps emitting housekeeping events throughout, so a reply
+ * is found by id and never by position).
+ *
+ * IT NEVER THROWS. Every caller so far is a side effect on a path the owner is
+ * already waiting on — a settings save — and a box with no dashboard at all is a
+ * perfectly ordinary box: the OpenClaw edition ships without one. "The dashboard
+ * did not answer" is an expected answer here, not a fault, so it comes back as
+ * `null` and the caller carries on.
+ */
+
+/**
+ * Bound on the upgrade itself. Local, and it answers in milliseconds — the same
+ * number `hermes-dashboard-turn.ts` uses against the same endpoint.
+ */
+const CONNECT_TIMEOUT_MS = 8_000;
+
+/**
+ * Bound on the whole call, handshake included.
+ *
+ * Sized for the heaviest thing this is used for rather than the average one:
+ * `reload.mcp` runs `shutdown_mcp_servers()` + `discover_mcp_tools()`, which
+ * KILLS every MCP child process and spawns them again, and each one then has to
+ * complete an initialize handshake and list its tools before the reply comes
+ * back. ClawBox's own server alone probes binaries, the journal and
+ * `/setup-api/email/status` while it boots (mcp/lib/context.ts). Seconds, not
+ * milliseconds — so a bound in the low seconds would report failure on a box
+ * that was working, and start a pointless retry.
+ *
+ * It is still a bound, because the failure this exists to survive is not a slow
+ * reload but a dashboard that accepts the socket and then says nothing at all.
+ */
+const DEFAULT_TIMEOUT_MS = 20_000;
+
+/** The only id this module ever sends. One call, one socket, one reply. */
+const REQUEST_ID = 1;
+
+/** A frame off the socket, as far as we are willing to assume. */
+interface RpcFrame {
+  id?: number;
+  result?: unknown;
+  error?: { message?: unknown };
+}
+
+function parseFrame(raw: unknown): RpcFrame | null {
+  const text = typeof raw === "string" ? raw : Buffer.isBuffer(raw) ? raw.toString("utf8") : "";
+  if (!text) return null;
+  try {
+    const value = JSON.parse(text) as unknown;
+    return value && typeof value === "object" ? (value as RpcFrame) : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface DashboardRpcOptions {
+  /** Bound on the whole call. Defaults to DEFAULT_TIMEOUT_MS. */
+  readonly timeoutMs?: number;
+}
+
+/**
+ * Call `method` on the dashboard and hand back its `result`, or null.
+ *
+ * Null means "no answer to act on", and it deliberately does not distinguish
+ * between the ways that happens: no dashboard, no ticket, a socket that died, a
+ * reply that never came, or an error frame. A caller that cannot fix any of
+ * those does not benefit from telling them apart, and every caller so far is in
+ * exactly that position.
+ */
+export async function dashboardRpc(
+  method: string,
+  params: Record<string, unknown>,
+  opts: DashboardRpcOptions = {},
+): Promise<unknown | null> {
+  const deadline = Date.now() + (opts.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+
+  // Minting a ticket is also the probe: it proves the dashboard process is up,
+  // that the stored password still opens it, and that the socket endpoints are
+  // enabled. Nothing weaker tests all three, and on an edition with no
+  // dashboard it is the call that fails first and cheapest.
+  const ticket = await dashboardWsTicket().catch(() => null);
+  if (!ticket) return null;
+
+  let socket: WebSocket;
+  try {
+    socket = new WebSocket(`${DASHBOARD_WS_ORIGIN}/api/ws?ticket=${encodeURIComponent(ticket)}`, {
+      handshakeTimeout: Math.max(1, Math.min(CONNECT_TIMEOUT_MS, deadline - Date.now())),
+    });
+  } catch {
+    return null;
+  }
+
+  try {
+    return await new Promise<unknown | null>((resolve) => {
+      let settled = false;
+      const finish = (value: unknown | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(value);
+      };
+      // The one deadline that covers everything after the ticket: a handshake
+      // that never completes, a reply that never arrives, and the gap between.
+      const timer = setTimeout(() => finish(null), Math.max(1, deadline - Date.now()));
+
+      socket.on("error", () => finish(null));
+      // Closing is how this call ENDS in the happy path too — see the `finally`
+      // below — so the guard above is what keeps the answer we already have.
+      socket.on("close", () => finish(null));
+      socket.on("message", (raw: unknown) => {
+        const frame = parseFrame(raw);
+        // Events and other callers' replies are not this call's answer.
+        if (!frame || frame.id !== REQUEST_ID) return;
+        finish(frame.error ? null : (frame.result ?? null));
+      });
+
+      const send = () => {
+        try {
+          socket.send(JSON.stringify({ jsonrpc: "2.0", id: REQUEST_ID, method, params }));
+        } catch {
+          finish(null);
+        }
+      };
+      // `ws` comes up asynchronously, but a socket handed to us already open
+      // would never emit `open` again and the call would sit here until the
+      // deadline.
+      if (socket.readyState === WebSocket.OPEN) send();
+      else socket.once("open", send);
+    });
+  } finally {
+    try {
+      socket.close();
+    } catch {
+      /* already gone */
+    }
+  }
+}

--- a/src/tests/routes/email/configure.test.ts
+++ b/src/tests/routes/email/configure.test.ts
@@ -23,13 +23,15 @@ vi.mock("@/lib/hermes-email", async () => {
     stopHermesEmailPolling: vi.fn(),
   };
 });
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: vi.fn() }));
 vi.mock("@/lib/smtp-client", async () => {
   const actual = await vi.importActual<typeof import("@/lib/smtp-client")>("@/lib/smtp-client");
   return { ...actual, verifySmtp: vi.fn() };
 });
 
-import { setMany } from "@/lib/config-store";
+import { get, setMany } from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
 import {
   applyHermesEmail,
   clearHermesEmail,
@@ -40,6 +42,8 @@ import { ImapError, verifyImap } from "@/lib/imap-client";
 import { SmtpError, verifySmtp } from "@/lib/smtp-client";
 
 const mockSetMany = vi.mocked(setMany);
+const mockGet = vi.mocked(get);
+const mockDashboardRpc = vi.mocked(dashboardRpc);
 const mockHarness = vi.mocked(getActiveHarness);
 const mockVerify = vi.mocked(verifySmtp);
 const mockVerifyImap = vi.mocked(verifyImap);
@@ -70,6 +74,7 @@ beforeEach(async () => {
   mockApplyHermes.mockResolvedValue({ inbound: false });
   mockRestart.mockResolvedValue(true);
   mockStopPolling.mockResolvedValue("none-running");
+  mockDashboardRpc.mockResolvedValue({ status: "ok" });
   const mod = await import("@/app/setup-api/email/configure/route");
   POST = mod.POST;
   DELETE = mod.DELETE;
@@ -310,5 +315,91 @@ describe("POST /setup-api/email/configure — read modes", () => {
     const res = await POST(request(READ_BODY));
     expect(res.status).toBe(200);
     expect(setMany).toHaveBeenCalledWith(expect.objectContaining({ email_mode: "read" }));
+  });
+});
+
+// ── Keeping the agent's email tools in step with the mode ────────────────────
+//
+// `email_list`/`email_read` are registered only when the MCP server's startup
+// probe says the mailbox is readable, and that server is a long-lived child of
+// Hermes. Without a nudge, a mailbox connected under a running server stays
+// invisible to the agent: on the owner's device 8 of 29 server starts logged
+// `41 tools` instead of `43`, and the two missing ones were exactly these.
+//
+// The nudge costs a prompt cache, so what is pinned here is as much when it does
+// NOT fire as when it does.
+
+/** Put a configured account in the store, in the given mode. */
+function storedAccount(mode: string): void {
+  mockGet.mockImplementation(async (key: string) => {
+    switch (key) {
+      case "email_address":
+        return "box@example.com";
+      case "email_password":
+        return PASSWORD;
+      case "email_smtp_host":
+        return "smtp.gmail.com";
+      case "email_smtp_port":
+        return 587;
+      case "email_mode":
+        return mode;
+      default:
+        return undefined;
+    }
+  });
+}
+
+describe("email/configure — MCP tool refresh", () => {
+  const BODY = { address: "box@example.com", password: PASSWORD };
+
+  it("reloads Hermes' MCP servers when the mode gains reading", async () => {
+    storedAccount("send");
+    const res = await POST(request({ ...BODY, mode: "read" }));
+    expect(res.status).toBe(200);
+    // `confirm` is not decoration: without it the dashboard answers
+    // `confirm_required` and does nothing, which looks exactly like success.
+    expect(mockDashboardRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("does NOT reload when an unrelated field changes", async () => {
+    // The account could already read, and still can. Nothing about the tool list
+    // is different, so nothing may be respawned and no prompt cache thrown away.
+    storedAccount("read");
+    const res = await POST(request({ ...BODY, mode: "read", fromName: "ClawBox" }));
+    expect(res.status).toBe(200);
+    expect(mockDashboardRpc).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload when a send-only account is re-saved", async () => {
+    storedAccount("send");
+    await POST(request({ ...BODY, mode: "send" }));
+    expect(mockDashboardRpc).not.toHaveBeenCalled();
+  });
+
+  it("saves successfully even when the dashboard cannot be reached", async () => {
+    // A box whose dashboard is down — or an OpenClaw box that never had one —
+    // must not have its email settings save turned into an error by a
+    // best-effort refresh.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    storedAccount("send");
+    mockDashboardRpc.mockRejectedValue(new Error("dashboard is down"));
+    const res = await POST(request({ ...BODY, mode: "read" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).success).toBe(true);
+    expect(mockSetMany).toHaveBeenCalledWith(expect.objectContaining({ email_mode: "read" }));
+    errorSpy.mockRestore();
+  });
+
+  it("reloads on disconnect, so tools that can only 409 stop being offered", async () => {
+    storedAccount("read");
+    const res = await DELETE(new Request("http://localhost/setup-api/email/configure", { method: "DELETE" }));
+    expect(res.status).toBe(200);
+    expect(mockDashboardRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("does NOT reload when disconnecting a box that had no account", async () => {
+    const res = await DELETE(new Request("http://localhost/setup-api/email/configure", { method: "DELETE" }));
+    expect(res.status).toBe(200);
+    expect(mockDashboardRpc).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/routes/email/configure.test.ts
+++ b/src/tests/routes/email/configure.test.ts
@@ -67,6 +67,13 @@ function request(body: unknown): Request {
 beforeEach(async () => {
   vi.resetModules();
   vi.clearAllMocks();
+  // Belt and braces on the stored-config reader. `vitest.config.ts` sets
+  // `mockReset: true` globally, so implementations are already cleared between
+  // tests and the suite passes without this — but `storedAccount()` installs an
+  // implementation rather than a return value, and the no-account cases assert
+  // on its ABSENCE. Resetting explicitly means those assertions keep meaning
+  // what they say even if the global config is ever relaxed.
+  mockGet.mockReset();
   vi.stubGlobal("fetch", vi.fn(async () => new Response("{}", { status: 500 })));
   mockHarness.mockResolvedValue("openclaw");
   mockVerify.mockResolvedValue(undefined);

--- a/src/tests/unit/email-mcp-refresh.test.ts
+++ b/src/tests/unit/email-mcp-refresh.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The narrow trigger that keeps `email_list`/`email_read` in step with the
+ * owner's mailbox mode.
+ *
+ * The gate those two tools are registered behind is probed ONCE, when the MCP
+ * server starts, so a mailbox connected under a running server never reaches the
+ * agent. Asking Hermes to reload its MCP servers fixes that — and a reload
+ * respawns every MCP child process and invalidates the model's prompt cache, so
+ * the no-op case below is the load-bearing test: firing on saves that changed
+ * nothing about readability would charge the owner for nothing, on every edit.
+ */
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: vi.fn() }));
+
+import { refreshEmailToolsIfReadabilityChanged } from "@/lib/email-mcp-refresh";
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+
+const mockRpc = vi.mocked(dashboardRpc);
+
+beforeEach(() => {
+  mockRpc.mockReset();
+  mockRpc.mockResolvedValue({ status: "ok" });
+});
+
+describe("refreshEmailToolsIfReadabilityChanged", () => {
+  it("does NOTHING when readability did not change", async () => {
+    // The prompt cache is the reason this test exists. A password rotated in
+    // place, a display name edited, an allowlist trimmed — none of them change
+    // which tools the MCP server would register, and none of them may reload.
+    await refreshEmailToolsIfReadabilityChanged(false, false);
+    await refreshEmailToolsIfReadabilityChanged(true, true);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("reloads when the mailbox becomes readable", async () => {
+    await refreshEmailToolsIfReadabilityChanged(false, true);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    // `confirm` is not decoration: the call is gated by
+    // approvals.mcp_reload_confirm, which defaults to true, and without the flag
+    // the dashboard answers `confirm_required` and does nothing.
+    expect(mockRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("reloads when the mailbox stops being readable", async () => {
+    // The other direction matters just as much: tools left registered against a
+    // mailbox that is gone answer 409 forever, which is what opens Hermes'
+    // per-server circuit breaker and takes EVERY ClawBox tool offline.
+    await refreshEmailToolsIfReadabilityChanged(true, false);
+    expect(mockRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("never sends a session id — the reload has to be global", async () => {
+    await refreshEmailToolsIfReadabilityChanged(false, true);
+    const params = mockRpc.mock.calls[0][1];
+    expect(params).not.toHaveProperty("session_id");
+  });
+
+  it("does not throw when the dashboard cannot be reached", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockRpc.mockResolvedValue(null);
+    await expect(refreshEmailToolsIfReadabilityChanged(false, true)).resolves.toBeUndefined();
+    // Logged, because "the agent still cannot see my mailbox" is otherwise
+    // invisible from the outside.
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not throw when the RPC helper itself rejects", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockRpc.mockRejectedValue(new Error("socket exploded"));
+    await expect(refreshEmailToolsIfReadabilityChanged(true, false)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/hermes-dashboard-rpc.test.ts
+++ b/src/tests/unit/hermes-dashboard-rpc.test.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * One JSON-RPC call to the Hermes dashboard, for callers that want an answer
+ * rather than a conversation.
+ *
+ * What has to be true for `reload.mcp` to be safe to fire from a settings save
+ * is what is pinned here: the confirmation flag really is on the wire (without
+ * it the dashboard answers `confirm_required` and does nothing, which would look
+ * exactly like success), and EVERY way this can fail comes back as null instead
+ * of an exception — the caller is a save the owner is waiting on, and a box with
+ * no dashboard at all is an ordinary box.
+ */
+
+const ticketMock = vi.hoisted(() => vi.fn());
+
+/**
+ * Just enough of `ws` to be wrong in the ways that matter: listeners registered
+ * by name, a `readyState` that starts closed, and an `open` that has to be
+ * driven — because the real socket comes up asynchronously and code that
+ * assumes otherwise passes here and hangs on the box.
+ */
+const fake = vi.hoisted(() => {
+  const made: FakeSocket[] = [];
+  class FakeSocket {
+    static OPEN = 1;
+    readyState = 0;
+    sent: Array<Record<string, unknown>> = [];
+    closed = false;
+    private readonly listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+    constructor(readonly url: string) {
+      made.push(this);
+    }
+    on(event: string, cb: (...args: unknown[]) => void) {
+      const list = this.listeners.get(event) || [];
+      list.push(cb);
+      this.listeners.set(event, list);
+      return this;
+    }
+    once(event: string, cb: (...args: unknown[]) => void) {
+      const wrapped = (...args: unknown[]) => {
+        this.off(event, wrapped);
+        cb(...args);
+      };
+      return this.on(event, wrapped);
+    }
+    off(event: string, cb: (...args: unknown[]) => void) {
+      this.listeners.set(event, (this.listeners.get(event) || []).filter((f) => f !== cb));
+      return this;
+    }
+    emit(event: string, ...args: unknown[]) {
+      for (const cb of [...(this.listeners.get(event) || [])]) cb(...args);
+    }
+    send(raw: string) {
+      this.sent.push(JSON.parse(raw) as Record<string, unknown>);
+    }
+    close() {
+      this.closed = true;
+    }
+    /** Come up, the way `ws` does asynchronously. */
+    open() {
+      this.readyState = FakeSocket.OPEN;
+      this.emit("open");
+    }
+    /** Deliver one JSON-RPC frame from the server. */
+    deliver(frame: unknown) {
+      this.emit("message", JSON.stringify(frame));
+    }
+  }
+  return { made, FakeSocket };
+});
+
+type FakeSocket = InstanceType<typeof fake.FakeSocket>;
+
+vi.mock("ws", () => ({ WebSocket: fake.FakeSocket }));
+vi.mock("@/lib/hermes-dashboard-auth", () => ({
+  dashboardWsTicket: ticketMock,
+  DASHBOARD_WS_ORIGIN: "ws://127.0.0.2:9119",
+}));
+
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+
+/** The socket the module just made, after letting the ticket promise settle. */
+async function latest(): Promise<FakeSocket> {
+  for (let i = 0; i < 50 && fake.made.length === 0; i++) await Promise.resolve();
+  return fake.made[fake.made.length - 1];
+}
+
+beforeEach(() => {
+  fake.made.length = 0;
+  ticketMock.mockReset();
+  ticketMock.mockResolvedValue("tkt-1");
+});
+
+describe("dashboardRpc", () => {
+  it("sends the method with its params, carrying the confirmation flag", async () => {
+    const call = dashboardRpc("reload.mcp", { confirm: true });
+    const socket = await latest();
+    socket.open();
+    socket.deliver({ jsonrpc: "2.0", id: 1, result: { status: "ok", servers: 1 } });
+
+    expect(await call).toEqual({ status: "ok", servers: 1 });
+    expect(socket.sent).toHaveLength(1);
+    expect(socket.sent[0]).toMatchObject({ method: "reload.mcp", params: { confirm: true } });
+    // Without `confirm` the dashboard answers `confirm_required` and does
+    // nothing at all — a silent no-op dressed as a success.
+    expect((socket.sent[0].params as Record<string, unknown>).confirm).toBe(true);
+    expect(socket.url).toContain("ticket=tkt-1");
+    // The socket is for this one call and nothing else.
+    expect(socket.closed).toBe(true);
+  });
+
+  it("waits for the reply that carries ITS id, not the first frame that arrives", async () => {
+    const call = dashboardRpc("reload.mcp", { confirm: true });
+    const socket = await latest();
+    socket.open();
+    // The dashboard opens with `gateway.ready` and keeps emitting housekeeping
+    // events throughout, so a reply is found by id and never by position.
+    socket.deliver({ jsonrpc: "2.0", method: "event", params: { type: "gateway.ready" } });
+    socket.deliver({ jsonrpc: "2.0", id: 99, result: { not: "ours" } });
+    socket.deliver({ jsonrpc: "2.0", id: 1, result: { status: "ok" } });
+
+    expect(await call).toEqual({ status: "ok" });
+  });
+
+  it("returns null when no ticket can be minted — the edition may have no dashboard", async () => {
+    ticketMock.mockResolvedValue(null);
+    expect(await dashboardRpc("reload.mcp", { confirm: true })).toBeNull();
+    expect(fake.made).toHaveLength(0);
+  });
+
+  it("returns null, rather than throwing, when minting the ticket fails outright", async () => {
+    ticketMock.mockRejectedValue(new Error("dashboard is down"));
+    await expect(dashboardRpc("reload.mcp", { confirm: true })).resolves.toBeNull();
+  });
+
+  it("returns null when the socket errors", async () => {
+    const call = dashboardRpc("reload.mcp", { confirm: true });
+    const socket = await latest();
+    socket.emit("error", new Error("ECONNREFUSED"));
+    expect(await call).toBeNull();
+  });
+
+  it("returns null when the socket closes before the reply", async () => {
+    const call = dashboardRpc("reload.mcp", { confirm: true });
+    const socket = await latest();
+    socket.open();
+    socket.emit("close", 1006);
+    expect(await call).toBeNull();
+  });
+
+  it("returns null when the dashboard accepts the socket and then says nothing", async () => {
+    // The failure the deadline exists for: not a slow reload, but a half-dead
+    // process that takes the connection and never answers.
+    const call = dashboardRpc("reload.mcp", { confirm: true }, { timeoutMs: 20 });
+    const socket = await latest();
+    socket.open();
+    expect(await call).toBeNull();
+    expect(socket.closed).toBe(true);
+  });
+
+  it("returns null when the dashboard answers with an error frame", async () => {
+    const call = dashboardRpc("reload.mcp", { confirm: true });
+    const socket = await latest();
+    socket.open();
+    socket.deliver({ jsonrpc: "2.0", id: 1, error: { message: "unknown method" } });
+    expect(await call).toBeNull();
+  });
+});


### PR DESCRIPTION
## The symptom

On a Hermes ClawBox the agent could not read the owner's mailbox from chat. Asking it to
list recent mail did not reach `email_list`; the agent behaved as though the tool did not
exist — because it did not.

## Root cause

`email_list` and `email_read` are registered **conditionally**. `mcp/tools/email.ts`
registers `email_send` unconditionally and then returns early:

```ts
// ── Reading, on demand ───────────────────────────────────────────────
// Registered ONLY when the owner chose a mode that opens the mailbox.
if (!ctx.emailCanRead) return;
```

`ctx.emailCanRead` is probed **once, at MCP server startup** (`mcp/lib/context.ts`, from
`/setup-api/email/status` → `canRead`, which is `modeAllowsReading(mode)` in
`src/lib/email-config.ts`). The gate itself is deliberate and correct: a tool that could
only ever answer 409 trips Hermes' per-server circuit breaker and takes *every* ClawBox
tool offline — the existing comment says exactly that, and it stays.

**The defect is that the probe is startup-only.** When the owner connects a mailbox,
switches Settings → Email from "Send only" to "Read on demand"/"Answer senders", or
re-saves credentials, the already-running MCP child keeps the tool list it built at boot.
The read tools stay missing until something happens to respawn it. `mcp/README.md` already
acknowledged the owner can change the mode under a running server — but only the HTTP route
re-checked the gate; the tool list never caught up.

### Evidence from the device

`~/.hermes/logs/mcp-stderr.log`, every server start it has ever logged:

```
      8 41 tools
     21 43 tools
```

The 41-tool starts are all earlier than the 43-tool ones, and the two absent tools are
exactly `email_list` and `email_read`. The MCP server, the schema cache
(`~/.hermes/cache/mcp_schema_cache.json`) and the gateway registry
(`agent.log`: `MCP server 'clawbox' (stdio): registered 43 tool(s): …`) all agree once the
gate is open.

### What it is NOT

This was previously suspected to be a Hermes per-platform tool-assembly bug that dropped the
last two tools for sessions on the `clawbox-chat` platform. It is not. Running Hermes' own
resolver on the device for both platforms returns **identical** results:

```
source='clawbox-chat' -> platform='clawbox-chat'
   enabled_toolsets = ['bfl','clarify','clawbox','code_execution','computer_use','cronjob',
                       'delegation','file','image_gen','kanban','memory','project',
                       'session_search','skills','terminal','todo','tts','vision','web']
source='cli'         -> platform='cli'
   enabled_toolsets = [ ...the same 19... ]
```

(`tui_gateway/server.py:7189` builds the agent with
`_load_enabled_toolsets(_resolve_agent_platform(platform_override))`; the MCP toolset
`mcp-clawbox` is all-or-nothing and `resolve_toolset('clawbox')` returns all 43.) There is
no cap, allowlist slice, dedup, ordering overwrite or schema drop anywhere on that path.

## The fix

When an email-settings change **flips `canRead`** — in either direction — ask Hermes to
reload its MCP servers so the ClawBox MCP child respawns and re-probes the gate.

Verified against the live gateway before writing a line of it:

```
reload.mcp {}                 -> { status: "confirm_required", … }   (no reload)
reload.mcp { confirm: true }  -> { status: "reloaded", loaded_rev: "1fbcc174115d" }
```

and the MCP start count in `mcp-stderr.log` went 29 → 30, the new start logging
`profile=full, 43 tools`. Live sessions pick the refreshed list up at their next turn
boundary through Hermes' own between-turns refresh.

Reloading invalidates the model prompt cache, so it is **not** free — which is why the
trigger fires only on an actual change in readability and is a no-op for every other
settings save. That no-op is the test worth reading.

The call is fail-soft: a box with no dashboard (OpenClaw edition) or a dashboard that is
down must never have a successful email-settings save turned into an error by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email tool availability now updates automatically when mailbox read access changes.
  * Email configuration changes and disconnections refresh active tool lists at the next session turn when needed.
* **Bug Fixes**
  * Email settings continue saving successfully even if the dashboard refresh is unavailable or fails.
  * Unrelated configuration changes and send-only accounts no longer trigger unnecessary refreshes.
* **Tests**
  * Added coverage for email-tool refresh behavior and dashboard communication failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->