### PR TITLE
Coding agent: start a run with no Linux capabilities

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -272,6 +272,13 @@ shell tool, not less and not more:
   the run is using — but never the run's own `data/code-projects/<id>`), are
   denied to Claude Code's own Read/Edit/Write. A guard rail, not a sandbox —
   the same caveat as `bash`;
+- the run holds **no Linux capabilities**. `clawbox-setup.service` gives the web
+  server `CAP_NET_BIND_SERVICE`, `CAP_NET_ADMIN` and `CAP_NET_RAW` ambiently for
+  WiFi management and port 80, and ambient capabilities are inherited across
+  `execve` — so a run used to start with all three while the agent's own shell
+  tool, spawned by the gateway, had none. The wrapper is now spawned through
+  `setpriv --ambient-caps=-all --inh-caps=-all --no-new-privs`, and a box
+  without `setpriv` reports not-ready rather than running with them;
 - the folder must be a code project or a directory inside the home that is
   neither protected nor the ClawBox checkout itself, so a prompt-injected
   "fix the OS" cannot edit the running product in place;

--- a/src/components/CodingAgentPanel.tsx
+++ b/src/components/CodingAgentPanel.tsx
@@ -25,6 +25,10 @@ interface Readiness {
   wrapperInstalled: boolean;
   claudeInstalled: boolean;
   clawaiConnected: boolean;
+  /** setpriv, which strips the web server's network capabilities off a run.
+   *  Not given a row of its own: it is present on every ClawBox, and when it
+   *  is not, `problems` says so in the owner's words. */
+  capabilityDropAvailable: boolean;
   problems: string[];
 }
 

--- a/src/lib/coding-agent.ts
+++ b/src/lib/coding-agent.ts
@@ -33,6 +33,18 @@
  *     Claude Code's own Read/Edit/Write as well. That is a guard rail against a
  *     mistake, not a sandbox: a shell can spell a path in ways no pattern list
  *     enumerates, exactly as mcp/README.md says of `bash`.
+ *   - The run starts with NO Linux capabilities. `clawbox-setup.service` grants
+ *     the web server `CAP_NET_BIND_SERVICE`, `CAP_NET_ADMIN` and `CAP_NET_RAW`
+ *     as AMBIENT capabilities so it can manage WiFi and bind port 80, and
+ *     ambient capabilities are inherited across execve by design — so without
+ *     this a run held `CapAmb=0x3400` while the agent's own shell tool, which
+ *     the gateway spawns, held none. Measured on a real box: a run asked for
+ *     `python3 -c "…/proc/self/status…"` — an allow-listed interpreter, so no
+ *     tool policy applied — and printed the three capabilities back. That is
+ *     more power than the bar this feature is held to, so the wrapper is
+ *     spawned through `setpriv` with the ambient and inheritable sets emptied
+ *     and no-new-privs set. Readiness refuses to start a run when `setpriv` is
+ *     missing rather than quietly running with the capabilities.
  *   - `--setting-sources user`: the ClawBox OS checkout's own CLAUDE.md and
  *     .claude/settings must not leak into a run that happens to sit under it
  *     (every code project does — data/code-projects is inside the repo).
@@ -94,6 +106,21 @@ const MAX_STDOUT_LINE_CHARS = 1_000_000;
 const STOP_GRACE_MS = 3_000;
 /** How often progress is flushed to disk while a run is busy. */
 const FLUSH_INTERVAL_MS = 1_000;
+
+/**
+ * The run is spawned through this, not directly, so it starts with an empty
+ * ambient and inheritable capability set. See the header: the web server holds
+ * CAP_NET_ADMIN and CAP_NET_RAW ambiently and every child would otherwise keep
+ * them. `--no-new-privs` is here for the same reason — a run has no business
+ * regaining through a setuid binary what these flags just took away.
+ */
+export const CAPABILITY_DROP_COMMAND = "setpriv";
+export const CAPABILITY_DROP_ARGS: readonly string[] = [
+  "--ambient-caps=-all",
+  "--inh-caps=-all",
+  "--no-new-privs",
+  "--",
+];
 
 /** Claude Code tools the run may use at all (`--tools`). No Task (sub-agents
  *  multiply cost), no WebFetch/WebSearch (the appliance is offline-first and
@@ -175,6 +202,11 @@ export interface CodingHarnessReadiness {
   wrapperInstalled: boolean;
   claudeInstalled: boolean;
   clawaiConnected: boolean;
+  /**
+   * Whether `setpriv` is here to strip the web server's inherited network
+   * capabilities off the run. False means no run may start: see the header.
+   */
+  capabilityDropAvailable: boolean;
   /** Owner-facing sentences, one per missing piece. Empty when ready. */
   problems: string[];
 }
@@ -258,20 +290,25 @@ async function isExecutableFile(file: string): Promise<boolean> {
   }
 }
 
-async function findOnPath(binary: string, pathValue: string): Promise<boolean> {
+/** The absolute path of `binary` on the runner's PATH, or null. */
+export async function findExecutableOnPath(binary: string, pathValue: string = runnerPath()): Promise<string | null> {
   for (const dir of pathValue.split(":")) {
     if (!dir) continue;
-    if (await isExecutableFile(path.join(dir, binary))) return true;
+    const candidate = path.join(dir, binary);
+    if (await isExecutableFile(candidate)) return candidate;
   }
-  return false;
+  return null;
 }
 
 export async function checkReadiness(): Promise<CodingHarnessReadiness> {
-  const [wrapperInstalled, claudeInstalled, token] = await Promise.all([
+  const [wrapperInstalled, claudePath, setprivPath, token] = await Promise.all([
     isExecutableFile(wrapperPath()),
-    findOnPath("claude", runnerPath()),
+    findExecutableOnPath("claude"),
+    findExecutableOnPath(CAPABILITY_DROP_COMMAND),
     configGet("clawai_token"),
   ]);
+  const claudeInstalled = claudePath !== null;
+  const capabilityDropAvailable = setprivPath !== null;
   const clawaiConnected = typeof token === "string" && token.trim() !== "";
   const problems: string[] = [];
   if (!claudeInstalled) {
@@ -283,11 +320,15 @@ export async function checkReadiness(): Promise<CodingHarnessReadiness> {
   if (!clawaiConnected) {
     problems.push("ClawBox AI is not connected. Open Settings → AI Models and sign in to ClawBox AI first.");
   }
+  if (!capabilityDropAvailable) {
+    problems.push(`${CAPABILITY_DROP_COMMAND} (part of util-linux) is missing, and without it a run would inherit the web server's network capabilities. Install util-linux.`);
+  }
   return {
     ready: problems.length === 0,
     wrapperInstalled,
     claudeInstalled,
     clawaiConnected,
+    capabilityDropAvailable,
     problems,
   };
 }
@@ -946,9 +987,18 @@ function installExitHook(): void {
   });
 }
 
-function spawnRun(run: CodingRun, resumeSessionId: string | null): void {
-  const args = buildRunArgs({ resumeSessionId });
-  const child = spawn(wrapperPath(), args, {
+/**
+ * The argv the box actually spawns: `setpriv`, the capability-dropping flags,
+ * then the wrapper and its own arguments. Exported for the contract test —
+ * this prefix is a security boundary, not a detail.
+ */
+export function buildSpawnArgv(setprivPath: string, claudeArgs: string[]): { bin: string; argv: string[] } {
+  return { bin: setprivPath, argv: [...CAPABILITY_DROP_ARGS, wrapperPath(), ...claudeArgs] };
+}
+
+function spawnRun(run: CodingRun, resumeSessionId: string | null, setprivPath: string): void {
+  const { bin, argv } = buildSpawnArgv(setprivPath, buildRunArgs({ resumeSessionId }));
+  const child = spawn(bin, argv, {
     cwd: run.directory,
     // Deliberately NOT process.env: see the header. The cast is only because
     // this repo's ProcessEnv augmentation insists on NODE_ENV, which a run has
@@ -1043,6 +1093,16 @@ export async function startRun(input: StartRunInput): Promise<CodingRun> {
   if (!readiness.ready) {
     throw new CodingAgentError("not_ready", readiness.problems.join(" "));
   }
+  // Resolved again rather than carried out of checkReadiness: this path is what
+  // strips the web server's network capabilities off the run, and a run must
+  // never start without it — not even if the binary vanished a moment ago.
+  const setprivPath = await findExecutableOnPath(CAPABILITY_DROP_COMMAND);
+  if (!setprivPath) {
+    throw new CodingAgentError(
+      "not_ready",
+      `${CAPABILITY_DROP_COMMAND} (part of util-linux) is missing, and without it a run would inherit the web server's network capabilities. Install util-linux.`,
+    );
+  }
 
   let resumeSessionId: string | null = null;
   let directory: string;
@@ -1101,7 +1161,7 @@ export async function startRun(input: StartRunInput): Promise<CodingRun> {
   }
   persist(true);
   console.error(`[coding-agent] ${run.id} started by ${run.source} in ${run.directory}`);
-  spawnRun(run, resumeSessionId);
+  spawnRun(run, resumeSessionId, setprivPath);
   return cloneRun(run);
 }
 

--- a/src/tests/unit/coding-agent.test.ts
+++ b/src/tests/unit/coding-agent.test.ts
@@ -156,7 +156,20 @@ describe("readiness", () => {
   it("is ready once the installer's files and a ClawBox AI token are there", async () => {
     readyDevice();
     const r = await lib.checkReadiness();
-    expect(r).toMatchObject({ ready: true, claudeInstalled: true, wrapperInstalled: true, clawaiConnected: true, problems: [] });
+    expect(r).toMatchObject({
+      ready: true, claudeInstalled: true, wrapperInstalled: true, clawaiConnected: true,
+      capabilityDropAvailable: true, problems: [],
+    });
+  });
+
+  it("counts the capability stripper among the things a run needs", async () => {
+    readyDevice();
+    // setpriv is util-linux; if it ever is not here, a run must not start at
+    // all rather than start holding the web server's network capabilities.
+    expect(await lib.findExecutableOnPath(lib.CAPABILITY_DROP_COMMAND)).toMatch(/\/setpriv$/);
+    expect(await lib.findExecutableOnPath("definitely-not-installed-xyz")).toBeNull();
+    const r = await lib.checkReadiness();
+    expect(r.capabilityDropAvailable).toBe(true);
   });
 
   it("looks for claude on a login shell's PATH, not the web server's", () => {
@@ -260,6 +273,9 @@ describe("a run", () => {
     expect(run.status).toBe("running");
     await finished(run.id);
 
+    // What the wrapper received: setpriv strips its own arguments at `--`, so
+    // the wrapper still sees exactly the Claude Code flags. That it ran at all
+    // is the evidence the setpriv chain is well-formed.
     const argv = fs.readFileSync(argvFile(), "utf-8").split("\n").filter(Boolean);
     const joined = argv.join(" ");
     expect(argv[0]).toBe("-p");
@@ -406,6 +422,34 @@ describe("a run", () => {
     const run = await finished((await lib.startRun({ task: "x", projectId: "site", source: "agent" })).id);
     expect(run.status).toBe("failed");
     expect(run.error).toBeTruthy();
+  });
+});
+
+describe("the capabilities a run starts with", () => {
+  /**
+   * clawbox-setup.service grants the web server CAP_NET_BIND_SERVICE,
+   * CAP_NET_ADMIN and CAP_NET_RAW as AMBIENT capabilities, and ambient
+   * capabilities are inherited across execve. Measured on a real box before
+   * this guard existed: a run asked for `python3 -c "…/proc/self/status…"` —
+   * an allow-listed interpreter, so no Claude Code tool policy applied — and
+   * printed back CapAmb=0x3400, while the gateway that hosts the agent's own
+   * shell tool holds none. This pins the prefix that closes that gap.
+   */
+  it("is spawned through setpriv, with the ambient and inheritable sets emptied", () => {
+    const { bin, argv } = lib.buildSpawnArgv("/usr/bin/setpriv", ["-p", "--verbose"]);
+    expect(bin).toBe("/usr/bin/setpriv");
+    expect(argv.slice(0, 4)).toEqual(["--ambient-caps=-all", "--inh-caps=-all", "--no-new-privs", "--"]);
+    // The wrapper comes after the separator, then its own arguments untouched.
+    expect(argv[4]).toBe(lib.wrapperPath());
+    expect(argv.slice(5)).toEqual(["-p", "--verbose"]);
+  });
+
+  it("puts every capability flag before the separator, or setpriv would pass them to the wrapper", () => {
+    const { argv } = lib.buildSpawnArgv("/usr/bin/setpriv", []);
+    const sep = argv.indexOf("--");
+    expect(sep).toBeGreaterThan(0);
+    expect(argv.slice(0, sep).every((a) => a.startsWith("--"))).toBe(true);
+    expect(argv.indexOf(lib.wrapperPath())).toBe(sep + 1);
   });
 });
 


### PR DESCRIPTION
Follow-up to #485. Found by the adversarial review pass of the merged change, confirmed on the device — and then **partly refuted by the review's own verification stage**, which changed why this is worth doing. Both halves are below, because the first framing was wrong and the record should say so.

### What is measurably true

`clawbox-setup.service` grants the web server three **ambient** capabilities so it can manage WiFi and bind port 80:

```
config/clawbox-setup.service:47
AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_ADMIN CAP_NET_RAW
```

Ambient capabilities are inherited across `execve` — that is what they are for — so every coding run started holding all three:

```
web server  (pid 72052)  CapAmb: 0000000000003400   <- NET_BIND_SERVICE|NET_ADMIN|NET_RAW
gateway     (pid 63862)  CapAmb: 0000000000000000
```

Reachable from inside a run, not theoretical. `python3` is on the Bash allow-list, so no Claude Code tool policy applies to what the interpreter then does:

```
run-93nboaal  status=completed  turns=2  permissionDenials=0
summary: ['CapInh:\t0000000000003400', 'CapPrm:\t0000000000003400',
          'CapEff:\t0000000000003400', 'CapBnd:\t000001ffffffffff',
          'CapAmb:\t0000000000003400']
```

(The file-access guard held throughout — the same probe via `grep`/`cat`/Read was refused five times. The interpreter is the path that walked around it.)

### What I first claimed, and why it was wrong

I originally called this a breach of the bar this feature is held to — *"no more than the agent already has through its own shell tool"*. A verifying agent refuted that, and checking on the box, it is right:

- `config/clawbox-sudoers` grants `clawbox` NOPASSWD `systemctl start clawbox-root-update@*.service`; `config/clawbox-root-step.sh:97` ends `exec /bin/bash "$ENTRYPOINT" --step "$step"` with `ENTRYPOINT=$PROJECT_DIR/install.sh`, and `install.sh` is `-rwxr-xr-x clawbox clawbox` — writable by the same user.
- The agent's own `bash` tool applies no sudo filtering (`mcp/lib/jobs.ts`, `mcp/tools/coding.ts`).

So on the OpenClaw edition the agent's shell can already reach **root**, which subsumes these three capabilities. `mcp/README.md` says as much in plain words: *"OpenClaw + `bash` = the agent can reach anything the device user can."* This was never an escalation relative to the agent.

### Why it still lands

Least privilege, not a breach fix. The coding run is the *unattended, prompt-driven* path — the one with an explicit Bash allow-list, file deny rules and folder containment, all built on the premise that a delegated run gets only what the task needs. A run that builds and tests code in one folder has no use for `CAP_NET_ADMIN` (reconfigure interfaces, routes, firewall) or `CAP_NET_RAW` (raw sockets), and it was getting them for free from an unrelated unit setting. Dropping them costs nothing and stops an unrelated configuration change from silently following the web server into every run.

### The change

```
setpriv --ambient-caps=-all --inh-caps=-all --no-new-privs -- ~/.local/bin/claude-ds -p …
```

Both sets emptied before the run starts; `--no-new-privs` stops it regaining through a setuid binary what those flags took away. `setpriv` is util-linux, on every ClawBox; readiness counts it among the things a run needs and `startRun` resolves it again and **refuses** rather than falling back to a spawn that keeps the capabilities. No existing guard was relaxed.

### Verified on hardware, after the fix

Same probe, same allow-listed interpreter, rebuilt box — see the comment below: `CapAmb: 0000000000000000`, run completes normally.

### Tests

`buildSpawnArgv` is pinned exactly (flags before the separator, wrapper after — get that order wrong and setpriv hands the flags to the wrapper), readiness reports the new requirement, and the existing fake-wrapper integration tests now exercise the whole setpriv chain: a malformed invocation would stop the wrapper running and fail them all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
