### PR TITLE
fix: retry coding agent after read-only inspection

### DIFF
--- a/src/lib/coding-agent.ts
+++ b/src/lib/coding-agent.ts
@@ -590,6 +590,8 @@ interface LiveRun {
   setprivPath: string;
   /** What this run was spawned with — a retry must match, not re-read. */
   settings: { effort: CodingEffort; subagents: boolean };
+  /** A shell command ran whose effects cannot be proven read-only. */
+  commandMayHaveSideEffects: boolean;
 }
 
 /** Newest first. `null` until first use. */
@@ -1054,6 +1056,24 @@ function noteFile(run: CodingRun, file: string | null): void {
   run.filesTouched.push(file);
 }
 
+/**
+ * Commands that inspect the project without changing it.
+ *
+ * `commandsRun === 0` was too blunt for the retry gate: the real authentication
+ * failure can arrive after Claude Code has only run `ls -la`, leaving no state
+ * that makes a fresh attempt unsafe. Keep this deliberately narrower than the
+ * Bash allow-list. Shell composition/redirection and commands such as npm,
+ * Python, git commit, mkdir or cp remain side-effecting because proving their
+ * behaviour from a command string is not possible.
+ */
+export function isReadOnlyInspectionCommand(command: unknown): boolean {
+  if (typeof command !== "string") return false;
+  const trimmed = command.trim();
+  if (!trimmed || /[;&|<>`\n\r]|\$\(/.test(trimmed)) return false;
+  return /^(?:pwd|ls|cat|head|tail|wc|grep)(?:\s|$)/.test(trimmed)
+    || /^git\s+(?:status|diff|log)(?:\s|$)/.test(trimmed);
+}
+
 interface StreamEvent {
   type?: string;
   subtype?: string;
@@ -1090,6 +1110,7 @@ function handleEvent(run: CodingRun, state: LiveRun, event: StreamEvent): void {
         switch (block.name) {
           case "Bash":
             run.commandsRun += 1;
+            if (!isReadOnlyInspectionCommand(input.command)) state.commandMayHaveSideEffects = true;
             pushProgress(run, `$ ${typeof input.command === "string" ? input.command : ""}`);
             break;
           case "Write":
@@ -1236,9 +1257,10 @@ function finishRun(run: CodingRun, state: LiveRun, exitCode: number | null): voi
   //
   // The guards are what make this safe rather than a loop: once only, only a
   // transient shape, only a run the owner did not stop, and only one that
-  // changed NOTHING — no files, no commands. A run that had already edited
-  // something must never be silently repeated, because the second attempt
-  // starts from the first one's leftovers.
+  // changed NOTHING — no files and no command that may have side effects. A
+  // read-only inspection such as `ls -la` is safe and must not suppress the
+  // recovery. A run that may have edited something must never be silently
+  // repeated, because the second attempt starts from the first one's leftovers.
   //
   // A FRESH session, never a resume: Claude Code persists the failure in the
   // session and replays it, which is how one bad run became two identical
@@ -1250,7 +1272,7 @@ function finishRun(run: CodingRun, state: LiveRun, exitCode: number | null): voi
     && !state.timedOut
     && isTransientFailure(run.error)
     && run.filesTouched.length === 0
-    && run.commandsRun === 0
+    && !state.commandMayHaveSideEffects
   ) {
     {
       run.retries = 1;
@@ -1325,6 +1347,7 @@ function spawnRun(
     openSubagents: new Set<string>(),
     setprivPath,
     settings,
+    commandMayHaveSideEffects: false,
     timeout: setTimeout(() => {
       state.timedOut = true;
       killTree(child, "SIGTERM");

--- a/src/tests/unit/coding-agent-retry.test.ts
+++ b/src/tests/unit/coding-agent-retry.test.ts
@@ -12,7 +12,7 @@
  * that already touched files, would be worse than the failure it fixes.
  */
 import { describe, expect, it } from "vitest";
-import { isTransientFailure } from "@/lib/coding-agent";
+import { isReadOnlyInspectionCommand, isTransientFailure } from "@/lib/coding-agent";
 
 describe("what counts as transient", () => {
   it("catches the failure actually seen on the box", () => {
@@ -58,5 +58,22 @@ describe("what counts as transient", () => {
     expect(isTransientFailure("I added a Cloudflare Worker to the project.")).toBe(true);
     // ^ deliberately true: this classifier only ever reads run.error, which
     //   the device writes, never run.summary, which the model writes.
+  });
+});
+
+describe("what is safe to repeat", () => {
+  it("allows only single read-only inspection commands", () => {
+    for (const command of ["ls -la", "pwd", "cat package.json", "git status --short", "git diff --check", "git log -5"]) {
+      expect(isReadOnlyInspectionCommand(command), command).toBe(true);
+    }
+  });
+
+  it("rejects shell composition, redirection, and commands that may mutate", () => {
+    for (const command of [
+      "ls; touch changed", "cat a > b", "echo $(touch changed)", "npm test", "python3 script.py",
+      "git commit -am fix", "mkdir output", "cp a b", "find . -delete", "",
+    ]) {
+      expect(isReadOnlyInspectionCommand(command), command).toBe(false);
+    }
   });
 });

--- a/src/tests/unit/coding-agent.test.ts
+++ b/src/tests/unit/coding-agent.test.ts
@@ -560,6 +560,34 @@ describe("retrying a transient upstream failure", () => {
     expect(fs.readFileSync(counter(), "utf-8").trim()).toBe("1");
   });
 
+  it("does retry after a read-only inspection command", async () => {
+    const LS = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "ls -la" } }] },
+    });
+    flakyWrapper(`echo '${LS}'`);
+    makeProject("site");
+    const run = await finished((await lib.startRun({ task: "t", projectId: "site", source: "agent" })).id);
+
+    expect(run.status).toBe("completed");
+    expect(run.retries).toBe(1);
+    expect(run.commandsRun).toBe(2);
+  });
+
+  it("does NOT retry after a command that may have side effects", async () => {
+    const NPM = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "npm test" } }] },
+    });
+    flakyWrapper(`echo '${NPM}'`);
+    makeProject("site");
+    const run = await finished((await lib.startRun({ task: "t", projectId: "site", source: "agent" })).id);
+
+    expect(run.status).toBe("failed");
+    expect(run.retries).toBe(0);
+    expect(fs.readFileSync(counter(), "utf-8").trim()).toBe("1");
+  });
+
   it("does NOT retry a real refusal — a turn ceiling is an answer, not an accident", async () => {
     installFakeWrapper([
       `echo '${INIT}'`,


### PR DESCRIPTION
Fixes the transient-provider retry gate discovered on the .65 hardware test box.

The previous guard required `commandsRun === 0`, so a harmless `ls -la` before an intermittent auth/Cloudflare-shaped failure suppressed the fresh-session retry. This change classifies a deliberately narrow set of single read-only inspection commands while keeping shell composition, redirection, interpreters, package commands, filesystem mutation, and mutating git commands fail-closed.

Verification:
- Focused Vitest suites: 45/45 passed
- Added regression coverage for `ls -la` retry
- Added fail-closed coverage for side-effecting commands and shell composition