### PR TITLE
Make the sudoers quarantine prove the allow-list landed, and fix the Hermes gateway restart (TASK-445 follow-up)

### DIFF
--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -62,6 +62,36 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl enable  clawbox-tunnel
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl disable clawbox-tunnel.service
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl disable clawbox-tunnel
 
+# Hermes' messaging gateway. This is the unit `hermes gateway install --system`
+# writes, and it is the process that RECEIVES Telegram / WhatsApp / Discord /
+# Email — so every config save on a provisioned Hermes box restarts it
+# (src/lib/hermes-telegram.ts ensureHermesGateway). It is NOT install-time-only.
+#
+# This grant is a strict REDUCTION in privilege, not an addition:
+#
+#   * The unit is root-owned in /etc/systemd/system and runs `User=clawbox`
+#     (Hermes writes it that way — `gateway install --system --run-as-user
+#     clawbox`). Restarting it therefore starts a process the clawbox user could
+#     have started itself. That is less than the `restart clawbox-gateway` grant
+#     above, whose unit has no User= at all.
+#   * It REPLACES `sudo -n /home/clawbox/.local/bin/hermes gateway restart
+#     --system`. That binary, and every directory above it, is clawbox-owned and
+#     clawbox-writable — exactly the shape the optimize-ollama.sh grant was moved
+#     to /usr/local/libexec to avoid. It could never be granted; the coverage
+#     checker had to carry it in EXEMPT_CALLS instead, which meant the restart
+#     silently failed on a narrowed box and the route still answered "restarted".
+#
+# No `start`: the restart grant starts a stopped unit too. No `reset-failed`:
+# the generated unit sets StartLimitIntervalSec=0, so there is no start limit to
+# clear. No wildcard: profile units (hermes-gateway-<profile>.service) are a
+# different privilege question and ClawBox only ever runs the default profile.
+# The first-time `gateway install --system` stays deliberately UNGRANTED — it
+# writes into /etc/systemd/system and cannot be expressed safely against a
+# clawbox-writable binary; it fails fast under `sudo -n` and the route now says
+# so instead of reporting success. TASK-445 follow-up.
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl restart hermes-gateway.service
+clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl restart hermes-gateway
+
 # Ollama, for Settings -> Local Models. Ollama is a system unit and it holds
 # real RAM on an 8 GB box, so the owner has to be able to stop it and have it
 # stay stopped; until this grant existed nothing in the UI could. `--now` is

--- a/install.sh
+++ b/install.sh
@@ -2686,14 +2686,30 @@ install_sudoers_dropin() {
     return 1
   fi
 
-  install -d -o root -g root -m 0755 "$SUDOERS_DIR"
-  install -d -o root -g root -m 0700 "$SUDOERS_STAGING_DIR"
+  install -d -o root -g root -m 0755 "$SUDOERS_DIR" || return 1
+  install -d -o root -g root -m 0700 "$SUDOERS_STAGING_DIR" || return 1
 
   local staged
   staged="$(mktemp "$SUDOERS_STAGING_DIR/.sudoers-candidate.XXXXXX")" || return 1
-  cat "$src" > "$staged"
-  chown root:root "$staged"
-  chmod 0440 "$staged"
+  # Checked, not assumed. Both call sites invoke this function in a CONDITION
+  # context (`if install_sudoers_dropin …`, `… || echo`), and bash disables
+  # `set -e` for the whole dynamic extent of a command being tested. So every
+  # step in here has to carry its own `|| return 1`: an unchecked failure does
+  # not abort the script, it falls through to the next line and reports success.
+  # A truncated-but-parseable candidate — a `cat` that hit ENOSPC halfway down
+  # the allow-list — validates under visudo and installs cleanly. TASK-445.
+  if ! cat "$src" > "$staged"; then
+    rm -f "$staged"
+    echo "Error: could not stage $src; keeping the existing $dest" >&2
+    return 1
+  fi
+  if ! cmp -s "$src" "$staged"; then
+    rm -f "$staged"
+    echo "Error: staged copy of $src is truncated; keeping the existing $dest" >&2
+    return 1
+  fi
+  chown root:root "$staged" || { rm -f "$staged"; return 1; }
+  chmod 0440 "$staged" || { rm -f "$staged"; return 1; }
 
   if ! visudo -cf "$staged" >/dev/null 2>&1; then
     rm -f "$staged"
@@ -2711,20 +2727,52 @@ install_sudoers_dropin() {
   local backup=""
   if [ -f "$dest" ]; then
     backup="$(mktemp "$SUDOERS_STAGING_DIR/.sudoers-previous.XXXXXX")" || { rm -f "$staged"; return 1; }
-    cat "$dest" > "$backup"
+    if ! cat "$dest" > "$backup" || ! cmp -s "$dest" "$backup"; then
+      rm -f "$staged" "$backup"
+      echo "Error: could not back up $dest; leaving it as it is" >&2
+      return 1
+    fi
   fi
 
   # install(1) writes to a temp file and renames, so sudo never sees a
   # half-written drop-in.
-  install -o root -g root -m 0440 "$staged" "$dest"
+  #
+  # POSITIVE PROOF, not a return code. The caller uses this function's result to
+  # decide whether it is safe to quarantine the blanket `NOPASSWD: ALL` drop-in,
+  # and the `visudo -c` below cannot tell it: when `install` fails, visudo
+  # happily validates whatever is STILL on disk and answers 0. On a device whose
+  # only grant is the blanket one, that sequence ends with the narrow file never
+  # written and the blanket file removed — no working sudo at all, on an
+  # appliance with no console. So compare the bytes that actually landed.
+  if ! install -o root -g root -m 0440 "$staged" "$dest" 2>/dev/null || ! cmp -s "$staged" "$dest"; then
+    if [ -n "$backup" ]; then
+      # `install` may have left a partial/renamed file behind; put the previous
+      # content back rather than trusting that it never got that far.
+      install -o root -g root -m 0440 "$backup" "$dest" 2>/dev/null \
+        || echo "Error: could not restore $dest from its backup at $backup" >&2
+    else
+      rm -f "$dest"
+    fi
+    rm -f "$staged" "$backup"
+    echo "Error: could not install $name into $dest; leaving the existing grants alone" >&2
+    return 1
+  fi
   rm -f "$staged"
 
   # Re-check the WHOLE set: a fragment can be valid on its own and still collide
   # with another drop-in (duplicate alias, bad include order).
   if ! visudo -c >/dev/null 2>&1; then
     if [ -n "$backup" ]; then
-      install -o root -g root -m 0440 "$backup" "$dest"
-      echo "Error: installing $name broke /etc/sudoers validation; rolled $dest back" >&2
+      # The "rolled back" message used to print whether or not the rollback
+      # worked. Say what actually happened — a device that is now missing its
+      # drop-in entirely has to be distinguishable in the install log from one
+      # that is safely back on its previous rules.
+      if install -o root -g root -m 0440 "$backup" "$dest" 2>/dev/null; then
+        echo "Error: installing $name broke /etc/sudoers validation; rolled $dest back" >&2
+      else
+        rm -f "$dest"
+        echo "Error: installing $name broke /etc/sudoers validation AND the rollback failed; removed $dest" >&2
+      fi
     else
       rm -f "$dest"
       echo "Error: installing $name broke /etc/sudoers validation; removed $dest" >&2
@@ -2947,7 +2995,25 @@ step_systemd_services() {
   # the device" shape TASK-445 exists to close. step_systemd_services is the one
   # step both a fresh install and the in-app updater (step_post_update) always
   # run, unconditionally. TASK-445.
-  if install_sudoers_dropin "$PROJECT_DIR/config/clawbox-sudoers" clawbox; then
+  #
+  # Called plainly, never as the tested command of an `if`: bash suspends
+  # `set -e` for the entire dynamic extent of a command run in a condition
+  # context, so that spelling disarmed every unchecked command inside the
+  # function body too. The function now checks its own steps, and the status
+  # comes back through an explicit variable.
+  local sudoers_status=0
+  set +e
+  install_sudoers_dropin "$PROJECT_DIR/config/clawbox-sudoers" clawbox
+  sudoers_status=$?
+  set -e
+
+  # Two independent gates before the blanket grant is removed: the installer
+  # reported success, AND the bytes on the device are the allow-list we shipped.
+  # The second one is the load-bearing half — it is proof about the device, not
+  # about a code path, and it is what makes "installed the narrow rules" a
+  # precondition of "removed the wide ones" instead of an assumption.
+  if [ "$sudoers_status" -eq 0 ] \
+    && cmp -s "$PROJECT_DIR/config/clawbox-sudoers" "$SUDOERS_DIR/clawbox"; then
     echo "  Sudoers rules installed"
     # Gated on the PRIMARY allow-list only. That file is what keeps the box
     # operable (wizard, updater, power, hotspot); the ollama grant is one

--- a/scripts/check-sudoers-coverage.sh
+++ b/scripts/check-sudoers-coverage.sh
@@ -137,8 +137,14 @@ my %EXEMPT_CALLS = (
     'runHermesCli({sudo:true}) execs HERMES_BIN under /home/clawbox/.local/bin, which '
     . 'the clawbox user owns and can rewrite. Deliberately ungranted: `sudo -n` fails '
     . 'closed in milliseconds rather than blocking a route handler on a prompt, and the '
-    . 'alternative is passwordless root on a clawbox-writable file. The only caller '
-    . '(hermes-telegram.ts installGatewayService) treats the failure as non-fatal.',
+    . 'alternative is passwordless root on a clawbox-writable file. Exactly ONE caller '
+    . 'is left — the first-time `gateway install --system`, which '
+    . 'writes a unit into /etc/systemd/system and has no safe Cmnd spelling. It is '
+    . 'genuinely install-time-only, and its failure is now REPORTED (the `applied` flag) '
+    . 'rather than swallowed. The RESTART branch used to be exempted under this same '
+    . 'entry on the claim that it was install-time-only too; it was not — every '
+    . 'Telegram/WhatsApp/Discord/Email config save hits it — so it moved to '
+    . '`systemctl restart hermes-gateway.service`, which is granted.',
   'scripts/force-update.sh :: sudo -u %STR% bash -c %STR%' =>
     'Operator recovery script, run by hand from the Terminal app or over SSH. Dropping '
     . 'to the clawbox user is interactive by design — the owner types the password.',

--- a/src/app/setup-api/discord/configure/route.ts
+++ b/src/app/setup-api/discord/configure/route.ts
@@ -127,7 +127,9 @@ async function applyRestart(harness: string, signal: AbortSignal, secret: string
   try {
     if (harness === "hermes") {
       const status = await ensureHermesGateway(signal);
-      return status.running;
+      // A refused restart leaves the previous process up, and the unprivileged
+      // status probe cannot tell the two apart — so require both.
+      return status.running && status.applied;
     }
     await restartGateway();
     return true;

--- a/src/app/setup-api/email/configure/route.ts
+++ b/src/app/setup-api/email/configure/route.ts
@@ -140,7 +140,11 @@ export async function POST(request: Request) {
               // A gateway nobody installed cannot be restarted from here, so
               // it is still receiving on the credentials it loaded at
               // startup. Saying nothing would read as "receiving stopped".
-              ...(stop === "unmanaged"
+              // "unmanaged" and "restart-failed" both mean the same thing to
+              // the owner: nothing restarted, so it is still receiving on the
+              // credentials it loaded at startup. Saying nothing would read as
+              // "receiving stopped".
+              ...(stop === "unmanaged" || stop === "restart-failed"
                 ? { warning: "Saved — receiving stops on the next gateway restart" }
                 : {}),
             });

--- a/src/app/setup-api/telegram/configure/route.ts
+++ b/src/app/setup-api/telegram/configure/route.ts
@@ -67,7 +67,10 @@ export async function POST(request: Request) {
       // failed save.
       try {
         const status = await ensureHermesGateway(request.signal);
-        if (!status.running) {
+        // `applied` and not just `running`: the status probe runs unprivileged
+        // and a refused restart leaves the OLD process up, so `running` alone
+        // reported the new token as live when it was not.
+        if (!status.running || !status.applied) {
           return NextResponse.json({
             success: true,
             reset: tokenChanged,

--- a/src/app/setup-api/whatsapp/configure/route.ts
+++ b/src/app/setup-api/whatsapp/configure/route.ts
@@ -133,7 +133,9 @@ export async function POST(request: Request) {
     // as /telegram/configure.
     try {
       const status = await ensureHermesGateway(request.signal);
-      if (!status.running) {
+      // See /telegram/configure: `running` alone is satisfied by the pre-restart
+      // process, so the new config would be reported live while unread.
+      if (!status.running || !status.applied) {
         return NextResponse.json({ success: true, restarted: false, warning: warning ?? "restart_pending" });
       }
     } catch (gatewayErr) {

--- a/src/lib/hermes-email.ts
+++ b/src/lib/hermes-email.ts
@@ -111,7 +111,9 @@ export async function hermesEmailState(): Promise<{
 /** Restart Hermes' messaging gateway so the adapter picks up the new .env. */
 export async function restartHermesForEmail(signal?: AbortSignal): Promise<boolean> {
   const status = await ensureHermesGateway(signal);
-  return status.running;
+  // Both halves: a restart that was refused leaves the gateway running on the
+  // PREVIOUS .env, which is exactly the state this function exists to rule out.
+  return status.running && status.applied;
 }
 
 /**
@@ -121,8 +123,15 @@ export async function restartHermesForEmail(signal?: AbortSignal): Promise<boole
  *   "stopped"      — the service was restarted and has dropped the adapter.
  *   "unmanaged"    — a gateway is running that this device did not install,
  *                    and it is STILL RECEIVING. See below.
+ *   "restart-failed" — the restart was attempted and refused (no grant, systemd
+ *                    error). Same user-visible consequence as "unmanaged": the
+ *                    old process is still polling the old mailbox.
  */
-export type EmailPollingStop = "none-running" | "stopped" | "unmanaged";
+export type EmailPollingStop =
+  | "none-running"
+  | "stopped"
+  | "unmanaged"
+  | "restart-failed";
 
 /**
  * Restart the gateway ONLY if one is already up, and report what that did.
@@ -147,6 +156,8 @@ export async function stopHermesEmailPolling(signal?: AbortSignal): Promise<Emai
   const before = await hermesGatewayStatus(signal);
   if (!before.running) return "none-running";
   if (!before.installed) return "unmanaged";
-  await ensureHermesGateway(signal);
-  return "stopped";
+  const after = await ensureHermesGateway(signal);
+  // runHermesCli resolves on non-zero and the status probe is unprivileged, so
+  // an unchecked await here reported "stopped" for a restart that was refused.
+  return after.applied ? "stopped" : "restart-failed";
 }

--- a/src/lib/hermes-telegram.ts
+++ b/src/lib/hermes-telegram.ts
@@ -20,10 +20,14 @@
 //
 // Everything here goes through runHermesCli (argv only, never a shell).
 
+import { execFile } from "child_process";
 import fs from "fs/promises";
 import path from "path";
+import { promisify } from "util";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { PAIRING_TOKEN_RE, normalizePairingToken } from "@/lib/telegram-pairing-token";
+
+const execFileAsync = promisify(execFile);
 
 const PLATFORM = "telegram";
 
@@ -419,6 +423,93 @@ export async function hermesGatewayStatus(signal?: AbortSignal): Promise<HermesG
 /** Unix user the gateway system service should run as. */
 const GATEWAY_SERVICE_USER = process.env.CLAWBOX_USER || "clawbox";
 
+/** The system unit `hermes gateway install --system` writes. */
+const HERMES_GATEWAY_UNIT = "hermes-gateway.service";
+const SYSTEMCTL_BIN = "/usr/bin/systemctl";
+
+/**
+ * What `ensureHermesGateway` observed, plus whether the change it tried to make
+ * actually took.
+ *
+ * `running` alone is not an answer. The status probe runs `hermes gateway
+ * status` UNPRIVILEGED, so after a restart that was refused it still sees the
+ * OLD process — up, serving the PREVIOUS config — and reports `running: true`.
+ * Callers that keyed on that answered `{ restarted: true }` for a restart that
+ * never happened, and the user's new Telegram token silently did nothing.
+ */
+export interface HermesGatewayEnsureResult extends HermesGatewayStatus {
+  /**
+   * The restart (or first-time install) reported success. When false, the
+   * process serving right now may still be the one from before the config
+   * change, so the caller must degrade to "saved — applies on next restart"
+   * rather than claiming the change is live.
+   */
+  applied: boolean;
+}
+
+/**
+ * Restart the gateway's SYSTEM unit through systemctl.
+ *
+ * Not `sudo hermes gateway restart --system`: that execs
+ * /home/clawbox/.local/bin/hermes, which the clawbox user owns and can rewrite,
+ * so it is a file we must never hand passwordless root — and consequently one
+ * that could not be allow-listed, which is why the restart silently failed on a
+ * narrowed box. The unit is root-owned and runs `User=clawbox`, so restarting it
+ * through systemctl grants nothing the clawbox user did not already have.
+ *
+ * `-n` so a box without the grant fails in milliseconds instead of waiting on a
+ * password prompt no appliance can answer.
+ *
+ * Trade-off worth naming: the CLI's restart first attempts a SIGUSR1 graceful
+ * drain of in-flight turns. systemd sends SIGTERM instead, which the unit
+ * already handles (KillSignal=SIGTERM, KillMode=mixed, TimeoutStopSec). The CLI
+ * falls back to the same forced `systemctl restart` whenever the drain does not
+ * finish in budget, so this is the CLI's own fallback path, taken directly.
+ */
+async function restartHermesGatewayUnit(signal?: AbortSignal): Promise<boolean> {
+  try {
+    // argv[0] spelled as a literal, like every other privileged exec in the
+    // tree: scripts/check-sudoers-coverage.sh can only resolve a call site whose
+    // sudo binary is written out, and a grant it cannot see is a grant nobody
+    // notices going stale.
+    await execFileAsync("/usr/bin/sudo", ["-n", SYSTEMCTL_BIN, "restart", HERMES_GATEWAY_UNIT], {
+      timeout: GATEWAY_TIMEOUT_MS,
+      signal,
+    });
+    return true;
+  } catch (err) {
+    console.error("[hermes] gateway restart failed:", err);
+    return false;
+  }
+}
+
+/**
+ * Restart a USER-scope gateway service. Stays on the CLI (systemctl --user from
+ * a system service would be aimed at root's session bus, not clawbox's), and no
+ * sudo is involved, so there is nothing to allow-list.
+ *
+ * The exit code is checked rather than assumed: runHermesCli RESOLVES on a
+ * non-zero exit — it only rejects on spawn failure, timeout or abort — so an
+ * unchecked `await` here reads as success for every kind of failure the CLI
+ * reports properly.
+ */
+async function restartHermesGatewayUserService(signal?: AbortSignal): Promise<boolean> {
+  try {
+    const res = await runHermesCli(["gateway", "restart"], {
+      timeoutMs: GATEWAY_TIMEOUT_MS,
+      signal,
+    });
+    if (res.code !== 0) {
+      console.error(`[hermes] gateway restart exited ${res.code}: ${res.stderr || res.stdout}`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    console.error("[hermes] gateway restart failed:", err);
+    return false;
+  }
+}
+
 /**
  * Make sure Hermes' messaging gateway is installed and running, so Telegram
  * messages are actually received.
@@ -429,40 +520,51 @@ const GATEWAY_SERVICE_USER = process.env.CLAWBOX_USER || "clawbox";
  * ClawBox user, and Hermes resolves that user's home for HERMES_HOME itself, so
  * the unit is correct even though the install runs through sudo.
  */
-export async function ensureHermesGateway(signal?: AbortSignal): Promise<HermesGatewayStatus> {
+export async function ensureHermesGateway(signal?: AbortSignal): Promise<HermesGatewayEnsureResult> {
   const before = await hermesGatewayStatus(signal);
 
   if (before.installed) {
     // A system unit can only be controlled by root; a user unit must NOT be,
     // or systemctl --user would be aimed at root's session bus.
-    const systemScope = before.scope === "system";
-    await runHermesCli(["gateway", "restart", ...(systemScope ? ["--system"] : [])], {
-      timeoutMs: GATEWAY_TIMEOUT_MS,
-      signal,
-      sudo: systemScope,
-    });
-    return hermesGatewayStatus(signal);
+    const applied = before.scope === "system"
+      ? await restartHermesGatewayUnit(signal)
+      : await restartHermesGatewayUserService(signal);
+    return { ...(await hermesGatewayStatus(signal)), applied };
   }
 
   // A gateway running without a service unit is somebody's foreground
   // `hermes gateway run`. It is already receiving, and `gateway restart` would
   // fall through to running the next one in the FOREGROUND — which from a route
   // handler means blocking until the timeout kills it. Leave it alone.
-  if (before.running) return before;
+  //
+  // Nothing was applied here either: that process is still serving the config it
+  // started with, so the caller must not claim the change is live.
+  if (before.running) return { ...before, applied: false };
 
-  await runHermesCli(
-    [
-      "gateway",
-      "install",
-      "--system",
-      "--run-as-user",
-      GATEWAY_SERVICE_USER,
-      "--start-now",
-      "--start-on-login",
-    ],
-    { timeoutMs: GATEWAY_TIMEOUT_MS, signal, sudo: true },
-  );
-  return hermesGatewayStatus(signal);
+  // First-time provisioning only, and deliberately ungranted in sudoers: this
+  // writes a unit into /etc/systemd/system, and the only way to allow-list it
+  // would be a NOPASSWD grant on a clawbox-writable binary. `sudo -n` fails in
+  // milliseconds on a narrowed box; the `applied` flag carries that outward
+  // instead of it disappearing into a status probe.
+  let applied = false;
+  try {
+    const res = await runHermesCli(
+      [
+        "gateway",
+        "install",
+        "--system",
+        "--run-as-user",
+        GATEWAY_SERVICE_USER,
+        "--start-now",
+        "--start-on-login",
+      ],
+      { timeoutMs: GATEWAY_TIMEOUT_MS, signal, sudo: true },
+    );
+    applied = res.code === 0;
+  } catch (err) {
+    console.error("[hermes] gateway install failed:", err);
+  }
+  return { ...(await hermesGatewayStatus(signal)), applied };
 }
 
 /**

--- a/src/lib/whatsapp-pairing.ts
+++ b/src/lib/whatsapp-pairing.ts
@@ -680,7 +680,9 @@ export function createRealDeps(): PairingDeps {
       // than reinvented: no new sudo rights are involved, and a box whose
       // gateway cannot be restarted from here reports the fact instead.
       const status = await ensureHermesGateway();
-      return status.running;
+      // `applied` too — a refused restart leaves the old process up and the
+      // unprivileged status probe would report it as a successful restart.
+      return status.running && status.applied;
     },
 
     spawnBridge() {

--- a/src/tests/routes/discord/configure-hermes.test.ts
+++ b/src/tests/routes/discord/configure-hermes.test.ts
@@ -80,7 +80,7 @@ describe("POST /setup-api/discord/configure — Hermes", () => {
     mockHarness.mockResolvedValue("hermes");
     mockSetHermesToken.mockResolvedValue();
     mockSetAllowlist.mockResolvedValue({ changedKeys: [], allowedUsers: [], authorized: true });
-    mockEnsureGateway.mockResolvedValue({ installed: true, running: true, scope: "system" });
+    mockEnsureGateway.mockResolvedValue({ installed: true, running: true, scope: "system", applied: true });
 
     POST = (await import("@/app/setup-api/discord/configure/route")).POST;
   });
@@ -105,7 +105,7 @@ describe("POST /setup-api/discord/configure — Hermes", () => {
   });
 
   it("reports a gateway that would not come up as saved-with-warning", async () => {
-    mockEnsureGateway.mockResolvedValue({ installed: true, running: false, scope: "system" });
+    mockEnsureGateway.mockResolvedValue({ installed: true, running: false, scope: "system", applied: false });
 
     const res = await POST(req());
     const body = await res.json();

--- a/src/tests/routes/discord/configure-onboarding.test.ts
+++ b/src/tests/routes/discord/configure-onboarding.test.ts
@@ -130,7 +130,7 @@ describe("POST /setup-api/discord/configure — onboarding", () => {
     mockGet.mockResolvedValue(TOKEN);
     mockHarness.mockResolvedValue("hermes");
     mockSetToken.mockResolvedValue();
-    mockEnsureGateway.mockResolvedValue({ installed: true, running: true, scope: "system" });
+    mockEnsureGateway.mockResolvedValue({ installed: true, running: true, scope: "system", applied: true });
     mockSetAllowlist.mockImplementation(async (ids: string[]) => ({
       changedKeys: ids.length > 0 ? ["DISCORD_ALLOWED_USERS"] : [],
       allowedUsers: ids,
@@ -321,7 +321,7 @@ describe("POST /setup-api/discord/configure — onboarding", () => {
 
     it("reports a pending restart honestly instead of claiming success", async () => {
       useApi();
-      mockEnsureGateway.mockResolvedValue({ installed: true, running: false, scope: "system" });
+      mockEnsureGateway.mockResolvedValue({ installed: true, running: false, scope: "system", applied: false });
 
       const body = await (await POST(req({ allowedUserIds: [OWNER_ID] }))).json();
 

--- a/src/tests/routes/telegram/configure-hermes.test.ts
+++ b/src/tests/routes/telegram/configure-hermes.test.ts
@@ -65,7 +65,7 @@ describe("POST /setup-api/telegram/configure — harness routing", () => {
     mockClearOpenclawPairing.mockResolvedValue();
     mockSetHermesToken.mockResolvedValue();
     mockClearHermesPairing.mockResolvedValue();
-    mockEnsureGateway.mockResolvedValue({ installed: true, running: true, scope: "system" });
+    mockEnsureGateway.mockResolvedValue({ installed: true, running: true, scope: "system", applied: true });
 
     POST = (await import("@/app/setup-api/telegram/configure/route")).POST;
   });
@@ -126,8 +126,25 @@ describe("POST /setup-api/telegram/configure — harness routing", () => {
       expect(body.warning).toBeTruthy();
     });
 
+    // The false success this route used to answer. A restart that sudo refused
+    // leaves the OLD gateway process up, and `hermes gateway status` runs
+    // unprivileged — so `running` was true, the route said {restarted: true},
+    // and the owner's new bot token silently kept not working.
+    it("does not claim restarted:true when the restart was refused", async () => {
+      mockEnsureGateway.mockResolvedValue({
+        installed: true,
+        running: true,
+        scope: "system",
+        applied: false,
+      });
+      const body = await (await POST(req({ botToken: TOKEN }))).json();
+
+      expect(body).toMatchObject({ success: true, restarted: false });
+      expect(body.warning).toBeTruthy();
+    });
+
     it("warns when the gateway install returned but nothing is running", async () => {
-      mockEnsureGateway.mockResolvedValue({ installed: true, running: false, scope: "system" });
+      mockEnsureGateway.mockResolvedValue({ installed: true, running: false, scope: "system", applied: false });
       const body = await (await POST(req({ botToken: TOKEN }))).json();
 
       expect(body).toMatchObject({ success: true, restarted: false });

--- a/src/tests/routes/whatsapp/configure.test.ts
+++ b/src/tests/routes/whatsapp/configure.test.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
     paired: true,
     authorized: true,
   });
-  mockEnsure.mockResolvedValue({ installed: true, running: true, scope: "system" });
+  mockEnsure.mockResolvedValue({ installed: true, running: true, scope: "system", applied: true });
   POST = (await import("@/app/setup-api/whatsapp/configure/route")).POST;
 });
 
@@ -145,7 +145,7 @@ describe("POST /setup-api/whatsapp/configure", () => {
   });
 
   it("reports success without a restart when the gateway is not running", async () => {
-    mockEnsure.mockResolvedValue({ installed: false, running: false, scope: null });
+    mockEnsure.mockResolvedValue({ installed: false, running: false, scope: null, applied: false });
     const body = await (await post({ mode: "bot" })).json();
     expect(body).toMatchObject({ success: true, restarted: false, warning: "restart_pending" });
   });
@@ -187,7 +187,7 @@ describe("POST /setup-api/whatsapp/configure", () => {
       paired: true,
       authorized: false,
     });
-    mockEnsure.mockResolvedValue({ installed: false, running: false, scope: null });
+    mockEnsure.mockResolvedValue({ installed: false, running: false, scope: null, applied: false });
     const body = await (await post({ enabled: true })).json();
     expect(body).toMatchObject({ success: true, restarted: false, warning: "no_allowed_users" });
   });

--- a/src/tests/unit/hermes-email.test.ts
+++ b/src/tests/unit/hermes-email.test.ts
@@ -27,10 +27,22 @@ beforeEach(() => {
 describe("stopHermesEmailPolling", () => {
   it("restarts the gateway when one is already running", async () => {
     mockStatus.mockResolvedValue({ installed: true, running: true, scope: "system" });
-    mockEnsure.mockResolvedValue({ installed: true, running: true, scope: "system" });
+    mockEnsure.mockResolvedValue({ installed: true, running: true, scope: "system", applied: true });
 
     await expect(stopHermesEmailPolling()).resolves.toBe("stopped");
     expect(mockEnsure).toHaveBeenCalledTimes(1);
+  });
+
+  // runHermesCli resolves on a non-zero exit and the status probe runs
+  // unprivileged, so before `applied` existed a restart that was REFUSED still
+  // came back as `running: true` and this function answered "stopped" — telling
+  // the owner receiving had ended while the old process kept polling the old
+  // mailbox with the old allowlist.
+  it("does not claim 'stopped' when the restart was refused", async () => {
+    mockStatus.mockResolvedValue({ installed: true, running: true, scope: "system" });
+    mockEnsure.mockResolvedValue({ installed: true, running: true, scope: "system", applied: false });
+
+    await expect(stopHermesEmailPolling()).resolves.toBe("restart-failed");
   });
 
   it("installs nothing on a device whose gateway is not running", async () => {

--- a/src/tests/unit/hermes-telegram.test.ts
+++ b/src/tests/unit/hermes-telegram.test.ts
@@ -14,6 +14,19 @@ import path from "path";
 const runHermesCliMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: runHermesCliMock }));
 
+// The system-scope restart goes through `sudo -n /usr/bin/systemctl restart
+// hermes-gateway.service` rather than the Hermes CLI — see ensureHermesGateway.
+const execFileMock = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ execFile: execFileMock }));
+
+/** Make the mocked execFile succeed / fail the way promisify(execFile) sees it. */
+function execFileSucceeds() {
+  execFileMock.mockImplementation((_bin: string, _argv: string[], _opts: unknown, cb: (e: Error | null, out?: string, err?: string) => void) => cb(null, "", ""));
+}
+function execFileFails(message: string) {
+  execFileMock.mockImplementation((_bin: string, _argv: string[], _opts: unknown, cb: (e: Error | null) => void) => cb(new Error(message)));
+}
+
 // Captured verbatim from `hermes pairing list` with two pending requests and
 // one approved user. Note the second pending row: the display name is wider
 // than its 20-char column, so every field after it is shifted — column offsets
@@ -71,6 +84,16 @@ const GATEWAY_SERVICE_RUNNING = `● hermes-gateway.service - Hermes Agent Gatew
 ✓ System gateway service is running
 Configured to run as: clawbox
 ✓ System service starts at boot without requiring systemd linger`;
+
+// The user-scope spelling of the same verdict. ClawBox installs a SYSTEM unit,
+// but a device someone set up by hand can have this one, and it must never be
+// driven through sudo — `systemctl --user` from a system service would target
+// root's session bus, not clawbox's.
+const GATEWAY_USER_SERVICE_RUNNING = `● hermes-gateway.service - Hermes Agent Gateway - Messaging Platform Integration
+     Loaded: loaded (/home/clawbox/.config/systemd/user/hermes-gateway.service; enabled)
+     Active: active (running) since Mon 2026-08-10 22:45:04 UTC; 21s ago
+   Main PID: 86759 (hermes)
+✓ User gateway service is running`;
 
 const GATEWAY_MANUAL_RUNNING = `✓ Gateway is running (PID: 4242)
   (Running manually, not as a system service)
@@ -336,6 +359,8 @@ describe("ensureHermesGateway", () => {
   beforeEach(() => {
     vi.resetModules();
     runHermesCliMock.mockReset();
+    execFileMock.mockReset();
+    execFileSucceeds();
   });
 
   it("installs a boot-time system service when none exists", async () => {
@@ -360,18 +385,60 @@ describe("ensureHermesGateway", () => {
     expect(opts.sudo).toBe(true);
   });
 
-  it("restarts an installed system service as root instead of reinstalling", async () => {
+  // The restart used to be `sudo -n /home/clawbox/.local/bin/hermes gateway
+  // restart --system`. That binary is clawbox-owned and clawbox-writable, so it
+  // could never be allow-listed — the sudoers coverage checker had to EXEMPT it
+  // — which meant the restart silently failed on any narrowed box. The unit is
+  // root-owned and runs User=clawbox, so systemctl grants nothing new.
+  it("restarts an installed system service through systemctl, not the CLI", async () => {
     runHermesCliMock
       .mockResolvedValueOnce({ code: 0, stdout: GATEWAY_SERVICE_STOPPED, stderr: "" })
-      .mockResolvedValueOnce({ code: 0, stdout: "✓ System service restarted", stderr: "" })
       .mockResolvedValueOnce({ code: 0, stdout: GATEWAY_SERVICE_RUNNING, stderr: "" });
 
     const { ensureHermesGateway } = await import("@/lib/hermes-telegram");
-    await ensureHermesGateway();
+    await expect(ensureHermesGateway()).resolves.toMatchObject({ running: true, applied: true });
 
-    const [args, opts] = runHermesCliMock.mock.calls[1];
-    expect(args).toEqual(["gateway", "restart", "--system"]);
-    expect(opts.sudo).toBe(true);
+    expect(execFileMock).toHaveBeenCalledTimes(1);
+    const [bin, argv] = execFileMock.mock.calls[0];
+    expect(bin).toBe("/usr/bin/sudo");
+    expect(argv).toEqual(["-n", "/usr/bin/systemctl", "restart", "hermes-gateway.service"]);
+    // Never sudo the clawbox-writable hermes binary again.
+    for (const [, opts] of runHermesCliMock.mock.calls) {
+      expect(opts?.sudo).not.toBe(true);
+    }
+  });
+
+  // THE FALSE SUCCESS. `hermes gateway status` runs UNPRIVILEGED, so after a
+  // refused restart it still sees the OLD process and answers "running". The
+  // route then replied {restarted: true} and the owner's new token did nothing.
+  it("reports applied: false when the restart is refused, even though the old process is still up", async () => {
+    runHermesCliMock
+      .mockResolvedValueOnce({ code: 0, stdout: GATEWAY_SERVICE_RUNNING, stderr: "" })
+      .mockResolvedValueOnce({ code: 0, stdout: GATEWAY_SERVICE_RUNNING, stderr: "" });
+    execFileFails("sudo: a password is required");
+
+    const { ensureHermesGateway } = await import("@/lib/hermes-telegram");
+    await expect(ensureHermesGateway()).resolves.toMatchObject({
+      running: true,
+      applied: false,
+    });
+  });
+
+  // A user-scope unit must NOT be driven with sudo (systemctl --user would be
+  // aimed at root's session bus), so that branch stays on the CLI — but
+  // runHermesCli RESOLVES on a non-zero exit, so the code has to be checked.
+  it("keeps a user-scope service on the CLI and honours its exit code", async () => {
+    runHermesCliMock
+      .mockResolvedValueOnce({ code: 0, stdout: GATEWAY_USER_SERVICE_RUNNING, stderr: "" })
+      .mockResolvedValueOnce({ code: 1, stdout: "", stderr: "Failed to restart" })
+      .mockResolvedValueOnce({ code: 0, stdout: GATEWAY_USER_SERVICE_RUNNING, stderr: "" });
+
+    const { ensureHermesGateway } = await import("@/lib/hermes-telegram");
+    const res = await ensureHermesGateway();
+    expect(res).toMatchObject({ scope: "user", running: true, applied: false });
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(runHermesCliMock.mock.calls[1][0]).toEqual(["gateway", "restart"]);
+    expect(runHermesCliMock.mock.calls[1][1]?.sudo).toBeUndefined();
   });
 
   // `gateway restart` with no service unit falls back to starting the gateway

--- a/src/tests/unit/install-foreign-edition-teardown.test.ts
+++ b/src/tests/unit/install-foreign-edition-teardown.test.ts
@@ -377,13 +377,57 @@ describe("stop+disable is the right amount of force", () => {
     // `start clawbox-gateway` grant, and `systemctl restart` brings a stopped
     // unit up just the same — so the escalation the mask exists to block is
     // unchanged.
-    const grants = SUDOERS.split("\n").filter(
-      (l) => l.startsWith("clawbox ") && l.includes("systemctl"),
-    );
+    //
+    // ── Revisited, TASK-445 follow-up ──────────────────────────────────────
+    // The rule used to be "no Hermes unit may appear in sudoers at all", which
+    // is stricter than the reason behind it. The two directions of the teardown
+    // defend different things:
+    //
+    //   clawbox-gateway is foreign on HERMES because it is an unauthenticated
+    //   agent surface on :18789. That is a security boundary, so the teardown
+    //   removes the unit file AND masks it — the grants above are dead there.
+    //
+    //   hermes-gateway is foreign on OPENCLAW because two harnesses polling one
+    //   Telegram token deadlock each other. That is a functional conflict, and
+    //   the teardown deliberately only stops+disables it: the unit is written by
+    //   the UPSTREAM Hermes installer, so a persistent mask would make a later
+    //   `hermes gateway install --system` write to /dev/null — the exact trap
+    //   step_edition_gateway_state's unmask branch exists to undo.
+    //
+    // So `restart hermes-gateway` is allowed, because the alternative was worse:
+    // that restart was running `sudo -n /home/clawbox/.local/bin/hermes`, a
+    // clawbox-WRITABLE binary, i.e. one-step local root. Restarting a root-owned
+    // unit that runs `User=clawbox` grants nothing new.
+    //
+    // The tripwire stays, sharpened: hermes-dashboard (a web surface) still gets
+    // nothing, and hermes-gateway gets `restart` and NOTHING else — no `start`,
+    // `enable`, `stop` or `unmask`, any of which would be a new capability
+    // rather than a cheaper spelling of one we already had.
+    // Trimmed: a Windows checkout of config/clawbox-sudoers carries CRLF (the
+    // file has no extension, so .gitattributes' `eol=lf` rules miss it) and the
+    // exact-match assertion below is anchored.
+    const grants = SUDOERS.split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith("clawbox ") && l.includes("systemctl"));
     expect(grants.some((l) => /\b(?:re)?start\s+clawbox-gateway/.test(l))).toBe(true);
-    for (const unit of ["hermes-dashboard", "hermes-gateway"]) {
-      expect(grants.some((l) => l.includes(unit))).toBe(false);
+
+    // The dashboard units remain completely ungranted.
+    expect(grants.some((l) => l.includes("hermes-dashboard"))).toBe(false);
+
+    // hermes-gateway: restart only, both spellings, nothing else.
+    const hermesGateway = grants.filter((l) => /\bhermes-gateway\b/.test(l));
+    expect(hermesGateway).toHaveLength(2);
+    for (const line of hermesGateway) {
+      expect(line).toMatch(
+        /^clawbox ALL=\(root\) NOPASSWD: \/usr\/bin\/systemctl restart hermes-gateway(\.service)?$/,
+      );
     }
+
+    // And the teardown must still bring it down on an OpenClaw box, so the grant
+    // is only ever a way to restart a gateway that BELONGS on the device.
+    expect(TEARDOWN_FN).toContain('systemctl stop "$funit"');
+    expect(TEARDOWN_FN).toContain('systemctl disable "$funit"');
+    expect(SERVICE_REGISTRY).toContain("hermes-gateway.service");
   });
 
   it("hermes-gateway.service is not ours to delete", () => {

--- a/src/tests/unit/install-sudoers-migration.test.ts
+++ b/src/tests/unit/install-sudoers-migration.test.ts
@@ -76,9 +76,27 @@ beforeEach(() => {
   fs.mkdirSync(path.join(tmp, "bin"));
   fs.mkdirSync(path.join(tmp, "sudoers.d"));
   fs.mkdirSync(path.join(tmp, "staging"));
+  // The fake `install` also knows how to FAIL, because that is the case the
+  // helper could not previously see: `visudo -c` re-reads whatever is on disk,
+  // so an install that never wrote anything still validates and answers 0.
+  //   INSTALL_FAIL_DEST     — refuse outright (read-only /etc, EPERM)
+  //   INSTALL_TRUNCATE_DEST — exit 0 having written only a PREFIX of the file,
+  //                           which is what ENOSPC part-way down the allow-list
+  //                           looks like, and which still parses under visudo
   fs.writeFileSync(
     path.join(tmp, "bin/install"),
-    "#!/usr/bin/env bash\nargs=(); while [ $# -gt 0 ]; do case \"$1\" in -o|-g) shift 2;; *) args+=(\"$1\"); shift;; esac; done\nexec /usr/bin/install \"${args[@]}\"\n",
+    [
+      "#!/usr/bin/env bash",
+      'args=(); while [ $# -gt 0 ]; do case "$1" in -o|-g) shift 2;; *) args+=("$1"); shift;; esac; done',
+      'dest="${args[${#args[@]}-1]}"',
+      'src="${args[${#args[@]}-2]}"',
+      'if [ -n "${INSTALL_FAIL_DEST:-}" ] && [ "$dest" = "$INSTALL_FAIL_DEST" ]; then exit 1; fi',
+      'if [ -n "${INSTALL_TRUNCATE_DEST:-}" ] && [ "$dest" = "$INSTALL_TRUNCATE_DEST" ]; then',
+      '  head -c 40 "$src" > "$dest"; exit 0',
+      "fi",
+      'exec /usr/bin/install "${args[@]}"',
+      "",
+    ].join("\n"),
     { mode: 0o755 },
   );
   fs.writeFileSync(path.join(tmp, "bin/chown"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
@@ -196,6 +214,123 @@ d("install_sudoers_dropin", () => {
   });
 });
 
+/**
+ * The blocker this file exists to close.
+ *
+ * `install_sudoers_dropin` used to report success after an `install` that never
+ * wrote anything. Both its call sites run it in a CONDITION context, which
+ * suspends `set -e` for the whole function body, and the trailing `visudo -c`
+ * validates whatever is STILL on disk — so a failed install produced exit 0.
+ * The caller then quarantined the blanket drop-in, and a device whose only
+ * grant was the blanket one ended up with NEITHER: no working sudo at all, on
+ * an appliance with no console.
+ */
+d("install_sudoers_dropin — a failed install must not read as success", () => {
+  const dest = () => path.join(tmp, "sudoers.d/clawbox");
+
+  it("fails when install(1) refuses, and keeps the previous grants", () => {
+    fs.writeFileSync(path.join(tmp, "prev"), "clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reboot\n");
+    expect(runShell(`install_sudoers_dropin "${tmp}/prev" clawbox`).status).toBe(0);
+
+    const r = runShell(`install_sudoers_dropin "$REPO/config/clawbox-sudoers" clawbox`, {
+      INSTALL_FAIL_DEST: dest(),
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/could not install clawbox into/);
+    expect(fs.readFileSync(dest(), "utf-8")).toContain("systemctl reboot");
+  });
+
+  it("fails when install(1) exits 0 having written only part of the file", () => {
+    // ENOSPC half-way down the allow-list. The prefix still PARSES — sudoers is
+    // line-oriented — so visudo cannot catch it and only a byte comparison can.
+    const r = runShell(`install_sudoers_dropin "$REPO/config/clawbox-sudoers" clawbox`, {
+      INSTALL_TRUNCATE_DEST: dest(),
+    });
+    expect(r.status).toBe(1);
+    expect(fs.existsSync(dest())).toBe(false);
+  });
+
+  it("leaves no staged candidate behind when the install fails", () => {
+    runShell(`install_sudoers_dropin "$REPO/config/clawbox-sudoers" clawbox`, {
+      INSTALL_FAIL_DEST: dest(),
+    });
+    expect(fs.readdirSync(path.join(tmp, "staging"))).toEqual([]);
+  });
+
+});
+
+/**
+ * The gate itself, run as install.sh really runs it.
+ *
+ * These lift the actual bytes out of step_systemd_services rather than
+ * re-implementing them, so the test cannot drift away from the shipped code.
+ */
+d("step_systemd_services' sudoers gate", () => {
+  /** The real gate: `local sudoers_status=0` through the end of its if/else. */
+  function gateBlock(): string {
+    const start = INSTALL_SH.indexOf("  local sudoers_status=0");
+    const end = INSTALL_SH.indexOf(
+      '  install_sudoers_dropin "$PROJECT_DIR/config/sudoers-clawbox-ollama"',
+    );
+    if (start < 0 || end < 0) throw new Error("sudoers gate markers not found in install.sh");
+    return INSTALL_SH.slice(start, end);
+  }
+
+  /** Run the extracted gate with PROJECT_DIR pointed at the real repo. */
+  function runGate(env: Record<string, string> = {}) {
+    return runShell(
+      `PROJECT_DIR="$REPO"\nrun_gate() {\n${gateBlock()}\n}\nrun_gate`,
+      env,
+    );
+  }
+
+  /** A device as it ships today: blanket grant, no narrow drop-in yet. */
+  function seedBlanketOnlyDevice() {
+    fs.writeFileSync(
+      path.join(tmp, "sudoers.d/90-clawbox-nopasswd"),
+      "clawbox ALL=(ALL) NOPASSWD: ALL\n",
+    );
+  }
+
+  it("quarantines the blanket grant once the allow-list really landed", () => {
+    seedBlanketOnlyDevice();
+    const r = runGate();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("Sudoers rules installed");
+    expect(fs.existsSync(path.join(tmp, "sudoers.d/90-clawbox-nopasswd"))).toBe(false);
+    expect(fs.readFileSync(path.join(tmp, "sudoers.d/clawbox"), "utf-8")).toBe(
+      fs.readFileSync(path.join(REPO, "config/clawbox-sudoers"), "utf-8"),
+    );
+  });
+
+  // THE REGRESSION. Before the fix this left the device with no sudoers at all.
+  it("does NOT quarantine the blanket grant when the install failed", () => {
+    seedBlanketOnlyDevice();
+    const r = runGate({ INSTALL_FAIL_DEST: path.join(tmp, "sudoers.d/clawbox") });
+    expect(r.stderr).toMatch(/sudoers rules NOT updated/);
+    expect(
+      fs.existsSync(path.join(tmp, "sudoers.d/90-clawbox-nopasswd")),
+      "the blanket drop-in must survive a failed narrow install — removing it "
+      + "here leaves the device with no working sudo at all",
+    ).toBe(true);
+    expect(fs.existsSync(path.join(tmp, "sudoers.d/clawbox"))).toBe(false);
+  });
+
+  it("does NOT quarantine the blanket grant on a silently truncated install", () => {
+    seedBlanketOnlyDevice();
+    const r = runGate({ INSTALL_TRUNCATE_DEST: path.join(tmp, "sudoers.d/clawbox") });
+    expect(r.stderr).toMatch(/sudoers rules NOT updated/);
+    expect(fs.existsSync(path.join(tmp, "sudoers.d/90-clawbox-nopasswd"))).toBe(true);
+  });
+
+  it("does NOT quarantine the blanket grant when the candidate fails visudo", () => {
+    seedBlanketOnlyDevice();
+    const r = runGate({ VISUDO_C_STATUS: "1" });
+    expect(r.stderr).toMatch(/sudoers rules NOT updated/);
+    expect(fs.existsSync(path.join(tmp, "sudoers.d/90-clawbox-nopasswd"))).toBe(true);
+  });
+});
+
 d("quarantine_overbroad_sudoers", () => {
   const seed = () => {
     fs.writeFileSync(path.join(tmp, "sudoers.d/90-clawbox-nopasswd"), "clawbox ALL=(ALL) NOPASSWD: ALL\n");
@@ -282,7 +417,27 @@ describe("install.sh wiring", () => {
   // with neither.
   it("skips the quarantine when the allow-list failed to install", () => {
     expect(fn("step_systemd_services")).toMatch(
-      /if install_sudoers_dropin "\$PROJECT_DIR\/config\/clawbox-sudoers" clawbox; then[\s\S]*?quarantine_overbroad_sudoers[\s\S]*?else[\s\S]*?Warning: sudoers rules NOT updated/,
+      /sudoers_status=\$\?[\s\S]*?quarantine_overbroad_sudoers[\s\S]*?else[\s\S]*?Warning: sudoers rules NOT updated/,
+    );
+  });
+
+  // Bash suspends `set -e` for the whole dynamic extent of a command run in a
+  // condition context, so `if install_sudoers_dropin …; then` disarmed every
+  // unchecked command inside the function body too. The status has to come back
+  // through an explicit variable, not through the test of an `if`.
+  it("does not call install_sudoers_dropin from a condition context", () => {
+    const body = fn("step_systemd_services");
+    expect(body).not.toMatch(/if\s+install_sudoers_dropin/);
+    expect(body).toMatch(/^\s*install_sudoers_dropin "\$PROJECT_DIR\/config\/clawbox-sudoers" clawbox$/m);
+    expect(body).toMatch(/^\s*sudoers_status=\$\?$/m);
+  });
+
+  // The gate that actually protects the device is a fact about the DEVICE, not
+  // a return code: the bytes in /etc/sudoers.d/clawbox have to equal the
+  // allow-list we shipped before the blanket grant is taken away.
+  it("proves the allow-list landed byte-for-byte before quarantining", () => {
+    expect(fn("step_systemd_services")).toMatch(
+      /cmp -s "\$PROJECT_DIR\/config\/clawbox-sudoers" "\$SUDOERS_DIR\/clawbox"[\s\S]*?quarantine_overbroad_sudoers/,
     );
   });
 


### PR DESCRIPTION
Follow-up to #471 — **targets `fix/hermes-sudoers-445-r2`, not `beta`**, so it lands with the narrowing rather than after it. Please review it as part of #471; it is not independently mergeable.

Closes the two blockers from the deep review of #471, plus a documentation correction. The agent-capability research that motivated the second one is posted as a comment on #471.

---

## B1 — a failed sudoers install could still trigger the quarantine

`install_sudoers_dropin` (install.sh:2680) could return **0 after an `install(1)` that never wrote anything**, and `step_systemd_services` used that success as permission to remove `/etc/sudoers.d/90-clawbox-nopasswd`. On a device whose only grant is the blanket one — which is every shipped box — the sequence ends with **neither** file: no working sudo at all, on an appliance with no console.

Two defects combined:

**1. Both call sites ran the function in a condition context.** install.sh:2950 (`if install_sudoers_dropin …; then`) and install.sh:2961 (`… || echo`). Bash suspends `set -e` for the whole *dynamic extent* of a command being tested, so every unchecked line inside the function body was silently non-fatal too:

| install.sh | unchecked | what it hides |
|---|---|---|
| 2694 | `cat "$src" > "$staged"` | ENOSPC → a truncated allow-list that still **parses**, so `visudo -cf` passes and it installs |
| 2716 | `cat "$dest" > "$backup"` | a backup that cannot restore |
| 2723 | `install … "$staged" "$dest"` | **the blocker** |
| 2728 | rollback `install … "$backup" "$dest"` | prints `rolled … back` whether or not it did |

**2. The function's own success signal could not see the failure.** The closing `visudo -c` (install.sh:2724) re-reads whatever is on disk, so after a failed install it validates the **old** file and answers 0.

### Fix

* Every step inside the function carries its own check — the function no longer depends on `set -e` at all.
* The destination is verified **byte-for-byte** against the staged candidate (`cmp -s`). A return code cannot distinguish "wrote nothing" from "wrote everything"; a comparison can, and it also catches the truncation case that `visudo` structurally cannot.
* The caller invokes it **plainly** and reads an explicit `sudoers_status`, so the condition-context trap cannot come back.
* The quarantine is gated on a second, load-bearing proof: `cmp -s "$PROJECT_DIR/config/clawbox-sudoers" "$SUDOERS_DIR/clawbox"` — a fact about the **device**, not about a code path.
* The rollback now reports what actually happened, so a stranded device is distinguishable from a safely-restored one in the install log.

### Tests

`src/tests/unit/install-sudoers-migration.test.ts` gains a suite that lifts the **real gate** out of `step_systemd_services` (rather than re-implementing it, so it cannot drift) and runs it against a temp `/etc/sudoers.d` with a fake `install(1)` that can refuse (`INSTALL_FAIL_DEST`) or exit 0 having written a prefix (`INSTALL_TRUNCATE_DEST`). Three regression cases assert the blanket drop-in **survives**: refused install, truncated install, failing `visudo -c`. Plus a happy-path case asserting it *is* quarantined once the allow-list really landed.

---

## B2 — `hermes gateway restart` is not install-time-only, and it reported false success

The `EXEMPT_CALLS` rationale in `scripts/check-sudoers-coverage.sh:136` said the sudo'd Hermes CLI call is install-time-only and its failure non-fatal. **Both halves are wrong for the restart branch.**

* `ensureHermesGateway` takes `sudo: systemScope` on the **restart** branch too (`src/lib/hermes-telegram.ts:442`). That is the path every Telegram / WhatsApp / Discord / Email config save hits on a provisioned Hermes box — `telegram/configure/route.ts:69`, `discord/configure/route.ts:129`, `whatsapp/configure/route.ts:135`, `hermes-email.ts:113` and `:150`, `whatsapp-pairing.ts:682`.
* It execs `/home/clawbox/.local/bin/hermes`, which the clawbox user **owns and can rewrite** (verified on a device: `-rwxr-xr-x 1 clawbox clawbox`). That is why it could not be granted and had to be exempted — and therefore why the restart silently stops working once the blanket grant is gone.
* The failure was invisible: `runHermesCli` **resolves** on a non-zero exit (`src/lib/hermes-cli.ts:117` — it only rejects on spawn failure, timeout or abort), and the status check that follows runs `hermes gateway status` **without** sudo. It sees the still-running old process, answers `running: true`, and `telegram/configure/route.ts:75` replies **`{restarted: true}`**. The owner's new bot token then quietly kept not working.

### Fix — a zero-escalation grant

`hermes gateway install --system --run-as-user clawbox` writes a **root-owned** unit that runs `User=clawbox`. Verified against the installed CLI's unit template (`hermes_cli/gateway.py:3514`):

```
[Service]
User={username}          # = clawbox
Group={group_name}
ExecStart={venv python} -m hermes_cli.main gateway run
Restart=always
StartLimitIntervalSec=0
```

So `systemctl restart hermes-gateway.service` starts a process the clawbox user could have started itself — **strictly less** privilege than the existing `restart clawbox-gateway` grant, whose unit has no `User=` at all. `gateway.py:3878` prints `sudo systemctl restart <svc>` as the CLI's own remediation hint, so this is its sanctioned path.

* System scope now runs `sudo -n /usr/bin/systemctl restart hermes-gateway.service`.
* Two grants added (`config/clawbox-sudoers`), bare + `.service`, no wildcard — profile units (`hermes-gateway-<profile>.service`) are a separate privilege question and ClawBox only ever runs the default profile. No `start` (restart starts a stopped unit) and no `reset-failed` (`StartLimitIntervalSec=0` means there is no start limit to clear).
* User scope stays on the CLI — `systemctl --user` from a system service would target root's session bus — but its **exit code is now checked** instead of assumed.
* `gateway install --system` stays deliberately **ungranted**: it writes into `/etc/systemd/system` and has no safe Cmnd spelling against a clawbox-writable binary. It fails fast under `-n`, and the new `applied` flag carries that outward instead of it disappearing into a status probe.

A note on the unit name, since it will look odd on a box you check today: `hermes-gateway.service` does not exist until the first messaging platform is configured — that is what `ensureHermesGateway` installs. On a box that has never had Telegram/WhatsApp/Discord/Email set up, `systemctl show hermes-gateway.service` reports "no such file", and the grant is simply not exercised yet. It is not a dead line.

### Fix — stop faking the result

`ensureHermesGateway` now returns `HermesGatewayEnsureResult` = status **plus `applied`**: did the change it attempted actually take? Every caller requires `running && applied` before claiming a restart, and degrades to the existing *"Saved — will apply on next gateway restart"* warning otherwise. `stopHermesEmailPolling` gains a `"restart-failed"` outcome so `/email/configure` warns instead of reporting that receiving stopped.

Making `applied` a **required** field was deliberate: it forced every existing mock in the suite to state explicitly whether it was modelling a real restart or a refused one.

### Trade-off, stated plainly

The CLI's restart first attempts a SIGUSR1 **graceful drain** of in-flight turns (`gateway.py:4082-4160`); `systemctl restart` relies on the unit's own `KillSignal=SIGTERM` / `TimeoutStopSec` instead. The CLI already falls through to the identical forced `systemctl restart` whenever the drain does not finish in budget, so this is its own fallback path taken directly. Flagging it so it is a decision, not a surprise.

---

## Validation — what is live-verified and what is not

**Live-verified on a device (read-only, before the boxes went off-subnet):**
- `/home/clawbox/.local/bin/hermes` is `clawbox:clawbox 0755` — the binary the old path sudo'd is user-writable.
- The Hermes CLI unit template writes `User={username}` into a root-owned `/etc/systemd/system/hermes-gateway.service`, and `systemd_restart(system=True)` reduces to `systemctl restart <svc>`.
- Denied-sudo timing: **28 ms** with `-n`, **30 ms** without one in a no-TTY context (how the app spawns children); **unbounded hang** on `[sudo] password for …` when a PTY is attached. So `-n` is doing real work here.
- `/etc/sudoers.d/90-clawbox-nopasswd` (`clawbox ALL=(ALL) NOPASSWD: ALL`) is still live on the QA box, i.e. the migration this PR guards is the one that matters.

**Harness-verified on Linux (Ubuntu 22.04, real `visudo`, LF checkout of this branch):**
- `visudo -cf config/clawbox-sudoers` → `parsed OK`.
- `scripts/check-sudoers-coverage.sh` → `OK — 43 grants, 43 resolved sudo invocations, 0 gaps`.
- The B1 gate, run as install.sh really runs it: blanket quarantined on the happy path; blanket **survives** a refused install, a truncated install and a failing `visudo -c`. 8/8.

**NOT verified:** no live `/etc/sudoers.d` swap was performed. Both boxes moved off this machine's subnet mid-task, and the owner's box was mid-testing and off limits for sudoers changes throughout. I would rather say so than imply device coverage I do not have. A live install/update run on a box that still carries the blanket drop-in is the one check outstanding — it is also exactly what `e2e-install/06-sudoers.spec.ts` and the e2e-install container exercise.

**Test/lint:**
- `eslint` on every changed file: **0 problems**.
- `tsc --noEmit`: **0 new errors** vs the base branch (diffed error lists).
- `vitest`: 52 unit + 259 route tests across the affected areas pass. The full suite has pre-existing Windows-environment failures (missing `flock`, path separators) in unrelated files; none of the changed files appear in them.
- `src/tests/unit/install-sudoers-migration.test.ts` self-skips off Linux (`CAN_RUN` needs `/usr/sbin/visudo`), so its new cases were additionally run through a standalone harness on Linux — result above.

---

## Not addressed here, on purpose

`config/49-clawbox-updates.pkla` grants `unix-user:clawbox` the **unfiltered** `org.freedesktop.systemd1.manage-units` action with `ResultAny=yes`, which makes the systemd half of this allow-list advisory. Details, evidence and the JetPack constraint are in a separate comment on #471 — it needs a design decision rather than a patch, and it is yours to route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Gateway configuration now reports success only when changes are actually applied, not merely when the gateway is running.
  * Added clear pending or failed-restart warnings across Discord, Telegram, WhatsApp, and email setup.
  * Email polling now distinguishes failed gateway restarts from successful shutdowns.

* **Security**
  * Restricted service restart permissions to the required gateway action.
  * Hardened permission installation and recovery to preserve existing rules when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->