### PR TITLE
fix: centre the lock glyph in the write-down dialog's danger badge

### DIFF
--- a/src/components/CredentialsWriteDownDialog.tsx
+++ b/src/components/CredentialsWriteDownDialog.tsx
@@ -140,19 +140,31 @@ export default function CredentialsWriteDownDialog({
             borderBottom: `1px solid ${DANGER_EDGE}`,
           }}
         >
+          {/* The badge and the glyph are two elements on purpose. `globals.css`
+              declares `.material-symbols-rounded { display: inline-block }`
+              UNLAYERED, and Tailwind's `.grid` lives inside `@layer utilities`
+              — unlayered always wins the cascade over layered, whatever the
+              source order. So a badge that wore the font class ITSELF stayed
+              inline-block, `place-items-center` had no grid to act on, and the
+              lock sat against the top-left corner of the 2.3rem square. Kept
+              apart, the badge is a real grid box and centres its child on both
+              axes — the same shape the acknowledgement box below uses, and the
+              icon badges in UpdateStep. */}
           <span
             aria-hidden="true"
-            className="material-symbols-rounded grid shrink-0 place-items-center rounded-[10px]"
+            data-testid="writedown-danger-badge"
+            className="grid shrink-0 place-items-center rounded-[10px]"
             style={{
               width: "2.3rem",
               height: "2.3rem",
-              fontSize: 20,
               color: DANGER_INK,
               background: DANGER_BADGE_FILL,
               border: `1px solid ${DANGER_BADGE_EDGE}`,
             }}
           >
-            lock
+            <span className="material-symbols-rounded" style={{ fontSize: 20 }}>
+              lock
+            </span>
           </span>
           <div className="min-w-0">
             <h2

--- a/src/tests/components/credentials-writedown.test.tsx
+++ b/src/tests/components/credentials-writedown.test.tsx
@@ -357,4 +357,25 @@ describe("CredentialsStep write-down confirmation", () => {
     expect(hermesBand).toContain("255, 95, 82");
     expect(hermesBand).not.toContain("rgb(18, 214, 164)");
   });
+
+  it("centres the lock in its badge instead of letting the font class flatten it", async () => {
+    // `globals.css` sets `.material-symbols-rounded { display: inline-block }`
+    // outside any cascade layer, and Tailwind's `.grid` sits in
+    // `@layer utilities` — unlayered beats layered regardless of source order.
+    // A badge wearing the font class itself therefore stays inline-block, and
+    // `place-items-center` centres nothing: the glyph lands top-left. jsdom
+    // computes no layout, so what is held here is the STRUCTURE that made the
+    // difference — the centring box and the glyph are separate elements.
+    const { container } = await mountStep(false);
+    fillForm(container);
+    fireEvent.click(connect());
+
+    const badge = screen.getByTestId("writedown-danger-badge");
+    expect(badge.className).toContain("grid");
+    expect(badge.className).toContain("place-items-center");
+    expect(badge.className).not.toContain("material-symbols-rounded");
+
+    const glyph = badge.querySelector(".material-symbols-rounded");
+    expect(glyph?.textContent?.trim()).toBe("lock");
+  });
 });


### PR DESCRIPTION
The lock in the step-3 write-down dialog's red band sat against the **top-left corner** of its rounded badge instead of the middle.

### Why

The badge carried `material-symbols-rounded` on the *same element* as `grid place-items-center`:

```tsx
<span className="material-symbols-rounded grid shrink-0 place-items-center rounded-[10px]" …>
  lock
</span>
```

`globals.css` declares that class **unlayered**:

```css
.material-symbols-rounded { … display: inline-block; … }
```

while Tailwind's `.grid` lives inside `@layer utilities`. Unlayered declarations beat layered ones regardless of source order or specificity, so `display: inline-block` won: the badge never became a grid box, `place-items-center` had no grid to act on, and the glyph rendered as ordinary inline text starting at the box's top-left.

### The fix

Split the two roles apart — a plain centring box with the glyph as its child:

```tsx
<span className="grid shrink-0 place-items-center rounded-[10px]" …>
  <span className="material-symbols-rounded" style={{ fontSize: 20 }}>lock</span>
</span>
```

This is not a new pattern. It is the shape the acknowledgement checkbox two blocks below already uses, and the shape `UpdateStep`'s status badges use — this one badge was the only place in the repo that put the font class on the centring element itself, which is why it was the only one that broke.

Nothing else about the dialog changes: same size, same colours, same copy, same behaviour.

### Test

`src/tests/components/credentials-writedown.test.tsx` gains one case. jsdom computes no layout, so it holds the **structure** that made the difference rather than a pixel: the badge has the centring classes and does *not* wear the font class, and the glyph is a separate child. 13/13 green in that file; `tsc` and `eslint` clean on both touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the danger badge layout in the credential write-down dialog so the lock icon remains properly centered.

* **Tests**
  * Added coverage to verify the lock icon and badge centering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->