### PR TITLE
fix: never render an image card the chat cannot serve

### DIFF
--- a/mcp/lib/context.ts
+++ b/mcp/lib/context.ts
@@ -5,6 +5,8 @@
 // cannot work here (no screen grabber installed, no readable journal) is not
 // registered at all, rather than registered and failing.
 
+import { capabilitiesFor, type HarnessFacts } from "../../src/lib/harness/capabilities";
+import type { HarnessId } from "../../src/lib/harness/transport";
 import { hasBinary, spawnArgv } from "./guard";
 import { apiTry } from "./api";
 import type { Ed, Profile } from "./register";
@@ -78,6 +80,19 @@ export interface McpContext {
    * tools exist only when a run could actually start.
    */
   codingAgent: boolean;
+  /**
+   * Whether this box can actually make a picture — the agent has an image
+   * backend, or the box itself has a credential and a route to spend it on.
+   *
+   * The one probe here whose FALSE registers a tool instead of hiding one. An
+   * unlinked box has no image tool in any surface, and an agent asked for a
+   * picture with no tool to draw it does not stop: on the owner's box
+   * (2026-08-26) it reached for the shell, hand-wrote an SVG, installed
+   * cairosvg and rasterised it — producing a file the chat cannot serve and
+   * telling the customer nothing about why. Silence is what let that happen, so
+   * the absence gets a voice. See registerAiTools.
+   */
+  canGenerateImages: boolean;
 }
 
 const SCREEN_GRABBERS = ["scrot", "gnome-screenshot", "spectacle", "import"];
@@ -131,6 +146,32 @@ async function probeCodingAgent(): Promise<boolean> {
   return status?.enabled === true && status.ready === true;
 }
 
+interface ChatCapabilitiesBody {
+  harness?: HarnessId;
+  facts?: HarnessFacts;
+}
+
+/**
+ * Ask the device whether drawing is possible at all.
+ *
+ * The route answers FACTS and `capabilitiesFor` turns them into the flag, which
+ * is the same pair the browser uses — deliberately, so the tool the agent sees
+ * and the button the customer sees can never disagree about whether this box
+ * can draw. Restating the rule here would be a second copy of it, in the
+ * process least likely to be updated when the rule changes.
+ *
+ * Fails CLOSED like its neighbours, and closed here means the honest-refusal
+ * tool IS registered: a box we cannot ask about is a box we cannot promise a
+ * picture from.
+ */
+async function probeImageGeneration(): Promise<boolean> {
+  const body = await apiTry<ChatCapabilitiesBody>("/setup-api/chat/capabilities", {
+    timeoutMs: 5_000,
+  });
+  if (!body?.harness || !body.facts) return false;
+  return capabilitiesFor(body.harness, body.facts).canGenerateImages;
+}
+
 export async function buildContext(
   edition: Ed,
   install: "openclaw" | "hermes" | "dual",
@@ -149,7 +190,11 @@ export async function buildContext(
     hasBinary("du"),
   ]);
 
-  const [emailCanRead, codingAgent] = await Promise.all([probeEmailRead(), probeCodingAgent()]);
+  const [emailCanRead, codingAgent, canGenerateImages] = await Promise.all([
+    probeEmailRead(),
+    probeCodingAgent(),
+    probeImageGeneration(),
+  ]);
 
   let providers: string[] = [];
   if (edition === "hermes") {
@@ -176,5 +221,6 @@ export async function buildContext(
     providers,
     emailCanRead,
     codingAgent,
+    canGenerateImages,
   };
 }

--- a/mcp/tools/ai.ts
+++ b/mcp/tools/ai.ts
@@ -104,7 +104,38 @@ const SET_RULES: ErrorRule[] = [
   },
 ];
 
+/**
+ * What an unlinked box says when it is asked for a picture.
+ *
+ * Two jobs, and the second is the one that was missing. It names the reason and
+ * the fix, so the agent can say something true instead of nothing; and it
+ * closes the door the agent walked through when nothing was there — writing an
+ * SVG with the file tool and rasterising it from the shell produced a real
+ * 1024x1024 PNG that the chat still could not display, because a picture only
+ * renders when it comes from a path the chat can serve.
+ *
+ * Told to the AGENT, not shown to the customer, so it is deliberately in
+ * English and deliberately unlocalised: the agent writes the customer's own
+ * sentence, in the customer's own language, out of it.
+ */
+const IMAGE_GEN_UNAVAILABLE =
+  "Picture generation is not available on this ClawBox. It runs on ClawBox AI and this device is not connected to one. Tell the user that in their own language, and that they can connect it in Settings -> AI Providers. Do NOT try to make the picture some other way — not with the terminal, not by writing an SVG or HTML and converting it, not with a Python imaging library. A file made that way cannot be displayed in this chat, so the user would get a broken image instead of an answer.";
+
 export function registerAiTools(reg: Registrar, ctx: McpContext): void {
+  // Registered only where the box CANNOT draw. On a linked box the harness's
+  // own image tool is present and this would be a second, contradicting tool
+  // beside it; on an unlinked one there is no image tool at all, and this is
+  // the only thing standing between the customer and an improvised answer.
+  if (!ctx.canGenerateImages) {
+    reg.tool(
+      "image_generate",
+      "Generate a picture from a text description. Call this whenever the user asks for an image, a picture, a drawing or a logo. On this device it will tell you why it cannot run and what the user should do — say that, and do not attempt to make the picture by any other means.",
+      {},
+      { editions: ["openclaw", "hermes"], readOnly: true },
+      async () => text(IMAGE_GEN_UNAVAILABLE),
+    );
+  }
+
   reg.tool(
     "ai_list_models",
     "List the AI providers configured on this device and the models each one serves, plus which provider and model are in use right now. Call this before ai_set_provider or ai_set_model so you use ids that exist here.",

--- a/mcp/tools/ai.ts
+++ b/mcp/tools/ai.ts
@@ -131,7 +131,12 @@ export function registerAiTools(reg: Registrar, ctx: McpContext): void {
       "image_generate",
       "Generate a picture from a text description. Call this whenever the user asks for an image, a picture, a drawing or a logo. On this device it will tell you why it cannot run and what the user should do — say that, and do not attempt to make the picture by any other means.",
       {},
-      { editions: ["openclaw", "hermes"], readOnly: true },
+      // CORE, and not as an afterthought: `CLAWBOX_MCP_PROFILE=core` is the
+      // trimmed tool set a SMALL model gets, and a small model is the one most
+      // likely to answer "draw me a crab" by reaching for the shell. Dropping
+      // this tool from the profile would remove the guidance from exactly the
+      // boxes that need it most. It costs an empty schema and two sentences.
+      { editions: ["openclaw", "hermes"], readOnly: true, profile: "core" },
       async () => text(IMAGE_GEN_UNAVAILABLE),
     );
   }

--- a/src/app/setup-api/files/[...path]/route.ts
+++ b/src/app/setup-api/files/[...path]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import fs from "fs";
 import path from "path";
 import { Readable } from "stream";
-import { isProtectedFilePath } from "@/lib/file-guard";
+import { filesBrowseRoot, isProtectedFilePath } from "@/lib/file-guard";
 
 export const dynamic = "force-dynamic";
 
@@ -40,7 +40,7 @@ const MIME_TYPES: Record<string, string> = {
   mp4: 'video/mp4', webm: 'video/webm', mp3: 'audio/mpeg', wav: 'audio/wav',
 };
 
-const BASE_DIR = process.env.FILES_ROOT ?? (process.env.HOME || "/home/clawbox");
+const BASE_DIR = filesBrowseRoot();
 
 function safePath(segments: string[]): string | null {
   const rel = segments.join("/");

--- a/src/app/setup-api/files/route.ts
+++ b/src/app/setup-api/files/route.ts
@@ -5,7 +5,7 @@ import path from "path";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import Busboy from "busboy";
-import { isProtectedFilePath } from "@/lib/file-guard";
+import { filesBrowseRoot, isProtectedFilePath } from "@/lib/file-guard";
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
@@ -25,7 +25,7 @@ function getAvailableDiskBytes(dir: string): number {
 
 export const dynamic = "force-dynamic";
 
-const BASE_DIR = process.env.FILES_ROOT ?? (process.env.HOME || "/home/clawbox");
+const BASE_DIR = filesBrowseRoot();
 
 function safePath(rel: string): string | null {
   const base = path.resolve(BASE_DIR);

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -459,7 +459,19 @@ async function settleTurn(
   // echoed back stays in the caption for `splitAssistantMedia` to lift, exactly
   // as it did before any of this. Everything else the model names comes out and
   // has to earn its card through adoption.
-  const servableRoot = await chatMediaRoot().catch(() => null);
+  const servableRoot = await chatMediaRoot().catch((err) => {
+    // Named in the journal because the turn still SUCCEEDS, and silently a
+    // little worse: without the root there is no exemption, so an attachment
+    // the customer sent and the model echoed back is reclaimed and adopted —
+    // copied again rather than left alone. The card is still right (the media
+    // root is an adoption root of its own for exactly this case); the copy is
+    // waste, and waste nobody can see is waste nobody fixes.
+    console.log(
+      "[hermes] chat media root unresolved; an echoed attachment will be re-copied:",
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  });
   const { text: caption, sources: mentioned } = reclaimImageMentions(spoken, servableRoot);
   const drawn = await adoptHermesGeneratedImages([
     ...(record?.generatedImages ?? []),

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -36,7 +36,7 @@ import {
   type ModelOptionsPayload,
 } from "@/lib/hermes-model-options";
 import { appendTranscript } from "@/lib/harness/transcript-store";
-import { resolveInMediaRoot } from "@/lib/harness/media-root";
+import { chatMediaRoot, resolveInMediaRoot } from "@/lib/harness/media-root";
 import { mediaUrl, splitAssistantMedia } from "@/lib/chat-media";
 import { extractReasoningPanels, stripAgentStatusFrames } from "@/lib/hermes-reasoning-panel";
 import { readHermesTurn } from "@/lib/harness/hermes-turn-record";
@@ -454,7 +454,13 @@ async function settleTurn(
   // path as a second image, and every generated picture rendered as a
   // broken card beside the real one - one generation, two attachments, the
   // first a 404.
-  const { text: caption, sources: mentioned } = reclaimImageMentions(spoken);
+  // The media root is handed in so the ONE tree whose paths the browser can
+  // already fetch keeps them: a picture the customer attached and the model
+  // echoed back stays in the caption for `splitAssistantMedia` to lift, exactly
+  // as it did before any of this. Everything else the model names comes out and
+  // has to earn its card through adoption.
+  const servableRoot = await chatMediaRoot().catch(() => null);
+  const { text: caption, sources: mentioned } = reclaimImageMentions(spoken, servableRoot);
   const drawn = await adoptHermesGeneratedImages([
     ...(record?.generatedImages ?? []),
     ...mentioned,

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -36,11 +36,15 @@ import {
   type ModelOptionsPayload,
 } from "@/lib/hermes-model-options";
 import { appendTranscript } from "@/lib/harness/transcript-store";
-import { chatMediaRoot, resolveInMediaRoot } from "@/lib/harness/media-root";
+import { resolveInMediaRoot } from "@/lib/harness/media-root";
 import { mediaUrl, splitAssistantMedia } from "@/lib/chat-media";
 import { extractReasoningPanels, stripAgentStatusFrames } from "@/lib/hermes-reasoning-panel";
 import { readHermesTurn } from "@/lib/harness/hermes-turn-record";
-import { adoptHermesGeneratedImages, reclaimImageMentions } from "@/lib/harness/hermes-generated-media";
+import {
+  adoptHermesGeneratedImages,
+  reclaimImageMentions,
+  servableMediaRoot,
+} from "@/lib/harness/hermes-generated-media";
 import { capabilitiesFor, UNKNOWN_FACTS } from "@/lib/harness/capabilities";
 import { isQuietStreamError, openDashboardTurn, type DashboardTurn } from "@/lib/hermes-dashboard-turn";
 
@@ -459,19 +463,7 @@ async function settleTurn(
   // echoed back stays in the caption for `splitAssistantMedia` to lift, exactly
   // as it did before any of this. Everything else the model names comes out and
   // has to earn its card through adoption.
-  const servableRoot = await chatMediaRoot().catch((err) => {
-    // Named in the journal because the turn still SUCCEEDS, and silently a
-    // little worse: without the root there is no exemption, so an attachment
-    // the customer sent and the model echoed back is reclaimed and adopted —
-    // copied again rather than left alone. The card is still right (the media
-    // root is an adoption root of its own for exactly this case); the copy is
-    // waste, and waste nobody can see is waste nobody fixes.
-    console.log(
-      "[hermes] chat media root unresolved; an echoed attachment will be re-copied:",
-      err instanceof Error ? err.message : err,
-    );
-    return null;
-  });
+  const servableRoot = await servableMediaRoot();
   const { text: caption, sources: mentioned } = reclaimImageMentions(spoken, servableRoot);
   const drawn = await adoptHermesGeneratedImages([
     ...(record?.generatedImages ?? []),

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -465,10 +465,12 @@ async function settleTurn(
   // working. Everything else has to earn its card through adoption.
   const servableRoot = await servableMediaRoot();
   const { text: caption, sources: mentioned } = reclaimImageMentions(spoken, servableRoot);
-  const drawn = await adoptHermesGeneratedImages([
-    ...(record?.generatedImages ?? []),
-    ...mentioned,
-  ]);
+  const drawn = await adoptHermesGeneratedImages(
+    [...(record?.generatedImages ?? []), ...mentioned],
+    // The SAME root the caption was judged against, so the two halves cannot
+    // disagree about which tree is already servable.
+    servableRoot,
+  );
   // A picture the AGENT drew, said the way every other picture in this chat is
   // said. Hermes has no `MEDIA:` convention of its own — the backend saves the
   // file and the model writes prose about the path — so the reply reaches the

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -452,17 +452,17 @@ async function settleTurn(
   const record = await readHermesTurn(threaded);
   const spoken = record?.text ?? consoleReply.text;
   // The model's own copy of the path comes OUT of the caption and INTO the
-  // adoption list. The backend tells the model where it saved the file and
-  // the model repeats it (a MEDIA: directive, an "[Image: ...]" aside);
-  // left in place, `splitAssistantMedia` below lifted that unservable cache
-  // path as a second image, and every generated picture rendered as a
-  // broken card beside the real one - one generation, two attachments, the
-  // first a 404.
-  // The media root is handed in so the ONE tree whose paths the browser can
-  // already fetch keeps them: a picture the customer attached and the model
-  // echoed back stays in the caption for `splitAssistantMedia` to lift, exactly
-  // as it did before any of this. Everything else the model names comes out and
-  // has to earn its card through adoption.
+  // adoption list, because `splitAssistantMedia` below lifts EVERY surviving
+  // MEDIA: line into a card without asking where it points. Left in, a path the
+  // model merely repeated became a second, unservable attachment beside the
+  // real one (#482), and a path the agent wrote itself became the only
+  // attachment and a dead one. Only what adoption actually copied is said
+  // again, so a card exists exactly when there is a picture behind it.
+  //
+  // The media root is handed in as the ONE exemption: paths the browser can
+  // already fetch stay in the caption for `splitAssistantMedia` to lift, which
+  // is how a picture the customer attached and the model echoed back keeps
+  // working. Everything else has to earn its card through adoption.
   const servableRoot = await servableMediaRoot();
   const { text: caption, sources: mentioned } = reclaimImageMentions(spoken, servableRoot);
   const drawn = await adoptHermesGeneratedImages([

--- a/src/lib/file-guard.ts
+++ b/src/lib/file-guard.ts
@@ -128,10 +128,45 @@ function isProtectedDataDirPath(abs: string): boolean {
   return !DATA_DIR_PUBLIC_SUBTREES.has(top);
 }
 
+/**
+ * The separator the patterns above are written in.
+ *
+ * Every rule in this file spells its separator `/`, so on Windows — where a
+ * resolved path arrives with backslashes — the name-shaped half of this guard
+ * matched nothing at all and `~/.ssh` was not protected. The appliance is Linux
+ * and never took that branch, but the tests run on developer machines, and a
+ * security rule that quietly no-ops on the platform it is TESTED on is a rule
+ * nobody is really testing.
+ *
+ * Rewritten only where the separator actually differs: on POSIX a backslash is
+ * a legal character in a filename, and normalising there would invent matches
+ * rather than find them. (`isProtectedDataDirPath` needs none of this — it
+ * compares with `path.sep` throughout.)
+ */
+const toPatternPath: (abs: string) => string =
+  path.sep === "/" ? (abs) => abs : (abs) => abs.replace(/\\/g, "/");
+
 function isProtected(abs: string): boolean {
   if (isProtectedDataDirPath(abs)) return true;
-  if (PROTECTED_FILE_RES.some((re) => re.test(abs))) return true;
-  return PROTECTED_DIR_RES.some((re) => re.test(abs));
+  const p = toPatternPath(abs);
+  if (PROTECTED_FILE_RES.some((re) => re.test(p))) return true;
+  return PROTECTED_DIR_RES.some((re) => re.test(p));
+}
+
+/**
+ * The tree the box lets an authenticated session browse: the customer's home
+ * directory, and also the agent's own working directory — on the appliance they
+ * are the same place.
+ *
+ * Lives beside the guard rather than in the routes because the root and the
+ * rule that carves secrets out of it are one decision, and it was written out
+ * three times before this: both Files API routes and, now, the adoption of a
+ * picture the agent wrote outside its image cache. A root defined in one file
+ * and guarded in another is how a fourth caller ends up browsing a tree nobody
+ * remembered to protect.
+ */
+export function filesBrowseRoot(): string {
+  return process.env.FILES_ROOT ?? (process.env.HOME || "/home/clawbox");
 }
 
 /**

--- a/src/lib/harness/hermes-generated-media.ts
+++ b/src/lib/harness/hermes-generated-media.ts
@@ -1,4 +1,5 @@
 import fsp from "fs/promises";
+import os from "os";
 import path from "path";
 import { randomUUID } from "crypto";
 import {
@@ -7,6 +8,7 @@ import {
   pruneMediaDir,
   resolveInMediaRoot,
 } from "@/lib/harness/media-root";
+import { filesBrowseRoot, isProtectedFilePath } from "@/lib/file-guard";
 import { hermesHome } from "@/lib/hermes-env";
 
 /**
@@ -35,10 +37,11 @@ import { hermesHome } from "@/lib/hermes-env";
  *   1. absolute, or it is not a path this can resolve at all;
  *   2. an image extension `chat/media` will serve — a name is not evidence, but
  *      a name it would refuse is proof the copy is pointless;
- *   3. contained in the Hermes image cache AFTER symlink resolution, which is
- *      what stops `…/cache/images/link → ~/.hermes/.env` — the file with every
- *      provider key in it — from being copied into a tree the browser can read
- *      (CWE-59);
+ *   3. contained in one of the adoption roots AFTER symlink resolution, and
+ *      cleared by that root's secret guard. This is what stops
+ *      `…/cache/images/link → ~/.hermes/.env` — the file with every provider
+ *      key in it — from being copied into a tree the browser can read
+ *      (CWE-59), and what keeps `~/.ssh/anything.png` out of it too;
  *   4. a regular file, under a size cap.
  *
  * The copy's NAME is ours (a uuid), never the source's, and the destination is
@@ -79,6 +82,115 @@ export function hermesImageCacheDir(): string {
 }
 
 /**
+ * A tree a picture may be adopted OUT of.
+ *
+ * `guarded` says whether the Files API's secret rule applies inside it. It is
+ * not a convenience flag — it is the difference between the two kinds of root
+ * here, and getting it wrong breaks one path or the other:
+ *
+ *  - The image cache is a CARVE-OUT. It lives under `~/.hermes`, and
+ *    `isProtectedFilePath` refuses the whole of `~/.hermes` because that is
+ *    where `config.yaml`, `.env` and `auth.json` are. Running the guard over
+ *    the cache would refuse every picture the ClawBox AI backend has ever
+ *    drawn — the working path. Containment plus `realpath` is what makes this
+ *    subtree safe, and that is exactly what is checked below.
+ *  - Every other root is GUARDED, because it is a tree the customer's own files
+ *    are in and the guard is the only thing keeping `~/.ssh/x.png`, a `.netrc`,
+ *    or anything under `DATA_DIR` out of a browser-readable copy.
+ */
+interface AdoptionRoot {
+  /** Symlink-resolved, so containment can be decided against a real path. */
+  real: string;
+  /** Apply `isProtectedFilePath` to what is found inside this root. */
+  guarded: boolean;
+}
+
+/**
+ * Where a picture may come from, in the order the roots are tried.
+ *
+ * WHY MORE THAN THE CACHE. A box with no ClawBox AI link has no image tool at
+ * all, and an agent asked for a picture anyway improvises with the shell:
+ * observed on the owner's box (2026-08-26) hand-writing an SVG into its own
+ * working directory and rasterising it with cairosvg. That file is real, valid
+ * and 1024x1024 — and being outside the cache it was never adopted, so the
+ * reply carried a card whose `src` 404s and whose download button saves the 21
+ * bytes of `{"error":"Not found"}` under a `.png` name.
+ *
+ * WHY THIS IS NOT A NEW READ CAPABILITY. The agent's working directory IS the
+ * Files API's browse root on this appliance, and that route already serves any
+ * file in it to this same authenticated session, behind this same guard. What
+ * changes is which of those files the chat will copy for itself, not which
+ * files the session may read. Everything outside these roots — `/etc`, another
+ * user's home, an absolute path the model simply invented — is refused, and a
+ * refused picture costs a card, never the reply.
+ */
+async function adoptionRoots(): Promise<AdoptionRoot[]> {
+  const roots: AdoptionRoot[] = [];
+  const add = async (dir: string, guarded: boolean) => {
+    try {
+      const real = await fsp.realpath(dir);
+      // A root nested inside an earlier one (the tests' fake HOME lives under
+      // the tmp dir) must not be listed twice; first match wins below, so the
+      // outer root would never be consulted for it anyway.
+      if (!roots.some((root) => root.real === real)) roots.push({ real, guarded });
+    } catch {
+      // A root that does not exist on this box holds nothing to adopt.
+    }
+  };
+  // The cache FIRST, and the order is load-bearing: it sits inside the browse
+  // root, so a later, guarded root would otherwise claim it and the guard would
+  // refuse it for being under `~/.hermes`.
+  await add(hermesImageCacheDir(), false);
+  await add(filesBrowseRoot(), true);
+  // Where a shell-improvising agent writes when it does not write beside itself.
+  await add(os.tmpdir(), true);
+  return roots;
+}
+
+/**
+ * `abs` rebuilt from `root` when it is lexically inside it, else null.
+ *
+ * The path is REBUILT rather than returned as given, so what reaches the
+ * filesystem is the trusted root plus a cleared relative segment instead of a
+ * string carried down from the agent's database.
+ */
+function containedIn(root: string, abs: string): string | null {
+  const rel = path.relative(root, path.resolve(abs));
+  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  return path.join(root, rel);
+}
+
+/**
+ * The real file `abs` names, if any root will vouch for it.
+ *
+ * Two passes, and both are needed. Lexical containment picks the root that
+ * rebuilds the path; `realpath` then re-decides which root the file is ACTUALLY
+ * in, because a symlink can carry a name inside one root to a file inside
+ * another — or outside all of them, which is
+ * `…/cache/images/link -> ~/.hermes/.env`, the CWE-59 case this has refused
+ * since #482. The guard that judges the file is the guard of the root the REAL
+ * path lands in.
+ */
+async function resolveInAdoptionRoot(
+  abs: string,
+  roots: readonly AdoptionRoot[],
+): Promise<string | null> {
+  let candidate: string | null = null;
+  for (const root of roots) {
+    candidate = containedIn(root.real, abs);
+    if (candidate) break;
+  }
+  if (!candidate) return null;
+  const real = await fsp.realpath(candidate);
+  for (const root of roots) {
+    if (!containedIn(root.real, real)) continue;
+    if (root.guarded && isProtectedFilePath(real)) return null;
+    return real;
+  }
+  return null;
+}
+
+/**
  * Copy the pictures this turn drew into the chat media root.
  *
  * Returns the absolute paths of the COPIES, in the order the originals were
@@ -89,14 +201,9 @@ export async function adoptHermesGeneratedImages(
   sources: readonly string[],
 ): Promise<string[]> {
   if (!sources.length) return [];
-  let cacheRoot: string;
-  try {
-    cacheRoot = await fsp.realpath(hermesImageCacheDir());
-  } catch {
-    // No cache directory means nothing was ever drawn on this box, so nothing
-    // can be inside it.
-    return [];
-  }
+  const roots = await adoptionRoots();
+  // No root resolves on this box, so there is nowhere a picture could be.
+  if (!roots.length) return [];
 
   // Swept before anything is copied in, by the same rule and into the same
   // directory the composer path sweeps — a box whose agent has a backend never
@@ -111,34 +218,34 @@ export async function adoptHermesGeneratedImages(
   // One card per FILE: the same picture can arrive both from its tool row and
   // from the model's own mention of the path, and adopting it twice would put
   // two identical cards in one bubble.
+  // Keyed on the RESOLVED path rather than the raw string: the tool row and the
+  // model's own sentence name the same file, and they do not always spell it
+  // the same way ("/home/clawbox/./a.png" is the second card nobody asked for).
   const seen = new Set<string>();
   for (const source of sources) {
     if (adopted.length >= MAX_ADOPTED_PER_TURN) break;
-    if (seen.has(source)) continue;
-    seen.add(source);
-    const copied = await adoptOne(source, cacheRoot);
+    const key = typeof source === "string" ? path.resolve(source) : String(source);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const copied = await adoptOne(source, roots);
     if (copied) adopted.push(copied);
   }
   return adopted;
 }
 
-async function adoptOne(source: string, cacheRoot: string): Promise<string | null> {
+async function adoptOne(
+  source: string,
+  roots: readonly AdoptionRoot[],
+): Promise<string | null> {
   try {
     if (typeof source !== "string" || !path.isAbsolute(source)) return null;
     if (!IMAGE_EXT.has(path.extname(source).toLowerCase())) return null;
 
-    // Lexical containment first, on the string, before any filesystem call sees
-    // it — then the absolute path is REBUILT from the trusted root plus the
-    // cleared segment, so what reaches `realpath` is not carried down from the
-    // record. Same shape as `chat/media` and for the same reason: it keeps the
-    // guard tied to the sink where a `startsWith` comparison does not.
-    const rel = path.relative(cacheRoot, path.resolve(source));
-    if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return null;
-    const candidate = path.join(cacheRoot, rel);
-
-    // Then symlinks, which the lexical check cannot see.
-    const real = await fsp.realpath(candidate);
-    if (real !== cacheRoot && !real.startsWith(cacheRoot + path.sep)) return null;
+    // Containment, symlinks and the secret guard, all decided together — see
+    // `resolveInAdoptionRoot`. Nothing below this line has ever seen the string
+    // the record carried; it has only the real path a root vouched for.
+    const real = await resolveInAdoptionRoot(source, roots);
+    if (!real) return null;
 
     const stat = await fsp.stat(real);
     if (!stat.isFile() || stat.size === 0 || stat.size > MAX_IMAGE_BYTES) return null;
@@ -181,15 +288,32 @@ async function adoptOne(source: string, cacheRoot: string): Promise<string | nul
 // a picture whose tool row never reached `generatedImages` is still adopted
 // off the model's own words.
 //
-// Only paths INSIDE THE IMAGE CACHE are reclaimed, and the bound is not a
-// preference: `adoptOne` refuses everything else, so a mention taken out of
-// the caption and then refused by adoption is information destroyed for
-// nothing — the reply loses a picture the chat could have served. A path the
-// chat media root already holds (a file the customer attached, echoed back by
-// the model) is exactly that case, and it stays where it is for
-// `splitAssistantMedia` to lift, the way it did before any of this landed.
-// A remote URL in a MEDIA: line is likewise left alone, because nothing here
-// can prove it broken, and audio directives are not image business at all.
+// WHAT IS RECLAIMED, AND WHY IT IS NOT JUST THE CACHE ANY MORE.
+//
+// #482 bounded this to the image cache on the reasoning that `adoptOne` refused
+// everything else, so taking a mention out of a caption it could not replace
+// destroyed information for nothing. That reasoning had a hole, and the owner's
+// box (2026-08-26) fell straight through it: a mention this leaves in the
+// caption is not left alone downstream — `splitAssistantMedia` lifts EVERY
+// surviving `MEDIA:` line into a card, with no containment check anywhere, and
+// `chat/media` then refuses the path it was handed. The result was the one
+// outcome that is worse than no picture: a card with a dead thumbnail and a
+// download button that saves 21 bytes of `{"error":"Not found"}` under a `.png`
+// name.
+//
+// So the rule is inverted. Every LOCAL image path the model names is taken out
+// of the caption and offered to adoption, and only what adoption actually
+// copied comes back as a directive. A picture that can be served renders; one
+// that cannot leaves the sentence and no card. The path itself is machinery in
+// either case — an absolute device path in a chat bubble was never something
+// to preserve.
+//
+// Three things are still left exactly where the model put them:
+//   - a path the CHAT MEDIA ROOT already holds (the customer's own attachment,
+//     echoed back), because `chat/media` serves that tree and
+//     `splitAssistantMedia` lifting it is the behaviour that has always worked;
+//   - a remote URL, because nothing here can prove it broken;
+//   - anything that is not an image — audio directives are not image business.
 
 const MEDIA_DIRECTIVE_RE = /^media:\s*(.+)$/i;
 const IMAGE_MENTION_RE = /\[image:\s*([^\]\n]+)\]/gi;
@@ -205,16 +329,30 @@ function unquoted(value: string): string {
   return value;
 }
 
-/** The local absolute image path a mention names, or null to leave it alone. */
-function reclaimable(raw: string, cacheDir: string): string | null {
-  const value = unquoted(raw.trim());
-  if (!path.isAbsolute(value)) return null;
+/** A source the browser can already fetch on its own — left where it is. */
+const REMOTE_RE = /^(?:https?:|data:)/i;
+
+/**
+ * `file:///abs/path` is a LOCAL path wearing a scheme, and treating it as
+ * remote would be the whole bug again in miniature: `mediaUrl` strips the
+ * scheme and asks `chat/media` for the path underneath, so a mention left in
+ * the caption becomes a card that 404s exactly like a bare one. Stripped here
+ * so adoption gets a real path to judge.
+ */
+const FILE_URL_RE = /^file:\/\/(?=\/)/i;
+
+/** The local image path a mention names, or null to leave it alone. */
+function reclaimable(raw: string, mediaRoot: string | null): string | null {
+  const value = unquoted(raw.trim()).replace(FILE_URL_RE, "");
+  if (!value || REMOTE_RE.test(value)) return null;
   if (!IMAGE_EXT.has(path.extname(value).toLowerCase())) return null;
-  // Lexical only: this decides what to take OUT of a caption, and the
-  // filesystem checks that decide what may be COPIED live in `adoptOne`,
-  // which re-resolves symlinks against the same root.
-  const rel = path.relative(cacheDir, path.resolve(value));
-  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  // Already servable: `chat/media` is rooted here, so this one really is better
+  // off staying in the caption for `splitAssistantMedia` to lift.
+  if (mediaRoot && path.isAbsolute(value) && containedIn(mediaRoot, value)) return null;
+  // Everything else, ABSOLUTE OR NOT. A relative mention ("MEDIA:crab.png") is
+  // reclaimed too and then refused by `adoptOne`, which is the point: left in,
+  // it becomes a card resolving to `?path=crab.png` and a 404. Lexical only —
+  // the filesystem checks that decide what may be COPIED live in `adoptOne`.
   return value;
 }
 
@@ -222,17 +360,20 @@ function reclaimable(raw: string, cacheDir: string): string | null {
  * Splits the model's own image-path mentions out of a reply.
  *
  * Returns the caption with those mentions removed, and the paths they named —
- * in order, de-duplicated — for `adoptHermesGeneratedImages` to judge. Only
- * paths lexically inside the Hermes image cache are taken, which is the set
- * adoption can accept at all; the adoption path then re-checks that same
- * containment through `realpath`, so nothing here has to decide what is safe
- * to READ, only what is worth taking out of a sentence. Fenced code blocks are
- * left untouched: a reply that explains the syntax is still allowed to show
- * it.
+ * in order, de-duplicated — for `adoptHermesGeneratedImages` to judge. Nothing
+ * here decides what is safe to READ; it decides only what must not be allowed
+ * to reach `splitAssistantMedia` as an unservable card. Fenced code blocks are
+ * left untouched: a reply that explains the syntax is still allowed to show it.
+ *
+ * `mediaRoot` is the chat media root when the caller has resolved it — the one
+ * tree whose paths are already servable and so stay in the caption. Passing
+ * null simply means nothing gets that exemption.
  */
-export function reclaimImageMentions(raw: string): { text: string; sources: string[] } {
+export function reclaimImageMentions(
+  raw: string,
+  mediaRoot: string | null = null,
+): { text: string; sources: string[] } {
   if (!raw || (!/media:/i.test(raw) && !/\[image:/i.test(raw))) return { text: raw, sources: [] };
-  const cacheDir = hermesImageCacheDir();
   const sources: string[] = [];
   const keep = (source: string) => {
     if (!sources.includes(source)) sources.push(source);
@@ -252,7 +393,7 @@ export function reclaimImageMentions(raw: string): { text: string; sources: stri
     }
     const directive = MEDIA_DIRECTIVE_RE.exec(trimmed);
     if (directive) {
-      const source = reclaimable(directive[1], cacheDir);
+      const source = reclaimable(directive[1], mediaRoot);
       if (source) {
         keep(source);
         continue; // the whole line was machinery; nothing of it stays
@@ -262,7 +403,7 @@ export function reclaimImageMentions(raw: string): { text: string; sources: stri
     }
     // "[Image: /abs/path.png]" asides go; the sentence around them stays.
     const scrubbed = line.replace(IMAGE_MENTION_RE, (whole, payload: string) => {
-      const source = reclaimable(payload, cacheDir);
+      const source = reclaimable(payload, mediaRoot);
       if (!source) return whole;
       keep(source);
       return "";

--- a/src/lib/harness/hermes-generated-media.ts
+++ b/src/lib/harness/hermes-generated-media.ts
@@ -182,7 +182,7 @@ interface AdoptionRoot {
  * path the model simply invented — is refused, and a refused picture costs a
  * card, never the reply.
  */
-async function adoptionRoots(): Promise<AdoptionRoot[]> {
+async function adoptionRoots(mediaRoot: string | null): Promise<AdoptionRoot[]> {
   const roots: AdoptionRoot[] = [];
   const add = async (dir: string, guarded: boolean) => {
     if (!dir) return;
@@ -209,7 +209,7 @@ async function adoptionRoots(): Promise<AdoptionRoot[]> {
   // DATA_DIR guard would then refuse it and the customer would lose a picture
   // that works today. Unguarded for the same reason as the cache: `chat/media`
   // already serves this exact tree to this exact session.
-  await add((await servableMediaRoot()) ?? "", false);
+  await add(mediaRoot ?? "", false);
   await add(filesBrowseRoot(), true);
   // Where a shell-improvising agent writes when it does not write beside itself.
   await add(os.tmpdir(), true);
@@ -273,9 +273,17 @@ async function resolveInAdoptionRoot(
  */
 export async function adoptHermesGeneratedImages(
   sources: readonly string[],
+  mediaRoot?: string | null,
 ): Promise<string[]> {
   if (!sources.length) return [];
-  const roots = await adoptionRoots();
+  // Resolved ONCE per turn, by the caller, and threaded through. Resolving it
+  // again here would let the two halves disagree: `reclaimImageMentions` takes
+  // an echoed attachment OUT of the caption on the strength of the first
+  // lookup, and a second lookup that failed would then drop the root that is
+  // the only thing able to adopt it — the path gone from the sentence and no
+  // card in its place. A caller with no root of its own says so, and gets one.
+  const resolved = mediaRoot === undefined ? await servableMediaRoot() : mediaRoot;
+  const roots = await adoptionRoots(resolved);
   // No root resolves on this box, so there is nowhere a picture could be.
   if (!roots.length) return [];
 

--- a/src/lib/harness/hermes-generated-media.ts
+++ b/src/lib/harness/hermes-generated-media.ts
@@ -83,6 +83,34 @@ export function hermesImageCacheDir(): string {
 }
 
 /**
+ * The chat media root, or null when this box cannot say what it is.
+ *
+ * `chatMediaRoot()` is awaited on the reply path, and NOTHING on the reply path
+ * may throw: by the time it is called the agent has already answered, and an
+ * exception here turns a finished turn into an error event that throws that
+ * answer away. A `.catch()` is not enough — if the module is unavailable the
+ * CALL itself throws synchronously, before there is a promise to attach a
+ * handler to — so the whole expression sits inside try/catch.
+ *
+ * Journaled rather than swallowed, because the degradation is invisible: with
+ * no root there is no exemption, and an attachment the customer sent and the
+ * model echoed back is copied instead of left alone. The card is still right
+ * (the media root is an adoption root of its own for exactly this case); the
+ * copy is waste, and waste nobody can see is waste nobody fixes.
+ */
+export async function servableMediaRoot(): Promise<string | null> {
+  try {
+    return await chatMediaRoot();
+  } catch (err) {
+    console.log(
+      "[hermes] chat media root unresolved; an echoed attachment will be re-copied:",
+      err instanceof Error ? err.message : err,
+    );
+    return null;
+  }
+}
+
+/**
  * A tree a picture may be adopted OUT of.
  *
  * `guarded` says whether the Files API's secret rule applies inside it. It is
@@ -166,7 +194,7 @@ async function adoptionRoots(): Promise<AdoptionRoot[]> {
   // DATA_DIR guard would then refuse it and the customer would lose a picture
   // that works today. Unguarded for the same reason as the cache: `chat/media`
   // already serves this exact tree to this exact session.
-  await add(await chatMediaRoot().catch(() => ""), false);
+  await add((await servableMediaRoot()) ?? "", false);
   await add(filesBrowseRoot(), true);
   // Where a shell-improvising agent writes when it does not write beside itself.
   await add(os.tmpdir(), true);

--- a/src/lib/harness/hermes-generated-media.ts
+++ b/src/lib/harness/hermes-generated-media.ts
@@ -4,6 +4,7 @@ import path from "path";
 import { randomUUID } from "crypto";
 import {
   chatGeneratedImageDir,
+  chatMediaRoot,
   GENERATED_IMAGE_RETENTION,
   pruneMediaDir,
   resolveInMediaRoot,
@@ -127,6 +128,7 @@ interface AdoptionRoot {
 async function adoptionRoots(): Promise<AdoptionRoot[]> {
   const roots: AdoptionRoot[] = [];
   const add = async (dir: string, guarded: boolean) => {
+    if (!dir) return;
     try {
       const real = await fsp.realpath(dir);
       // A root nested inside an earlier one (the tests' fake HOME lives under
@@ -141,6 +143,16 @@ async function adoptionRoots(): Promise<AdoptionRoot[]> {
   // root, so a later, guarded root would otherwise claim it and the guard would
   // refuse it for being under `~/.hermes`.
   await add(hermesImageCacheDir(), false);
+  // The chat's OWN tree, as a source as well as a destination. It is normally
+  // never reached: `reclaimImageMentions` leaves a path this tree already holds
+  // in the caption, precisely so an attachment the model echoed back is not
+  // copied for no reason. This is the belt to that exemption's braces — if the
+  // media root cannot be resolved at reclaim time, or a symlink hides it from
+  // the lexical test, the mention IS reclaimed, and without this root the
+  // DATA_DIR guard would then refuse it and the customer would lose a picture
+  // that works today. Unguarded for the same reason as the cache: `chat/media`
+  // already serves this exact tree to this exact session.
+  await add(await chatMediaRoot().catch(() => ""), false);
   await add(filesBrowseRoot(), true);
   // Where a shell-improvising agent writes when it does not write beside itself.
   await add(os.tmpdir(), true);

--- a/src/lib/harness/hermes-generated-media.ts
+++ b/src/lib/harness/hermes-generated-media.ts
@@ -77,6 +77,21 @@ const FILE_MODE = 0o600;
  */
 const MAX_ADOPTED_PER_TURN = 4;
 
+/**
+ * How many sources one turn may TRY.
+ *
+ * The cap above bounds PICTURES, and a picture that fails is not a picture, so
+ * it bounds no work at all: a source that is refused costs the same two
+ * `realpath` calls and a `stat` and never counts against it. That was tolerable
+ * while only cache paths were reclaimed. It stopped being tolerable when every
+ * local image path the model names became a source, because the harness output
+ * a reply is read from is capped at megabytes, not at lines - a reply made of
+ * `MEDIA:` lines naming files that do not exist is tens of thousands of
+ * distinct sources, each doing filesystem work on the Jetson, inside the turn
+ * the customer is waiting on.
+ */
+const MAX_ADOPTION_ATTEMPTS = 32;
+
 /** Where every Hermes image backend writes — `save_b64_image` in the plugin ABC. */
 export function hermesImageCacheDir(): string {
   return path.join(hermesHome(), "cache", "images");
@@ -210,7 +225,12 @@ async function adoptionRoots(): Promise<AdoptionRoot[]> {
  */
 function containedIn(root: string, abs: string): string | null {
   const rel = path.relative(root, path.resolve(abs));
-  if (!rel || rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  if (!rel || path.isAbsolute(rel)) return null;
+  // `..` is an escape only as a whole SEGMENT. A bare `startsWith("..")` also
+  // refuses a legitimate child called `..crab.png`, which is a real filename a
+  // real agent can write - and in `reclaimable` the same test misfires the
+  // other way, stripping a servable media-root path of its exemption.
+  if (rel === ".." || rel.startsWith(".." + path.sep)) return null;
   return path.join(root, rel);
 }
 
@@ -276,11 +296,14 @@ export async function adoptHermesGeneratedImages(
   // model's own sentence name the same file, and they do not always spell it
   // the same way ("/home/clawbox/./a.png" is the second card nobody asked for).
   const seen = new Set<string>();
+  let attempts = 0;
   for (const source of sources) {
     if (adopted.length >= MAX_ADOPTED_PER_TURN) break;
+    if (attempts >= MAX_ADOPTION_ATTEMPTS) break;
     const key = typeof source === "string" ? path.resolve(source) : String(source);
     if (seen.has(key)) continue;
     seen.add(key);
+    attempts++;
     const copied = await adoptOne(source, roots);
     if (copied) adopted.push(copied);
   }

--- a/src/lib/harness/hermes-generated-media.ts
+++ b/src/lib/harness/hermes-generated-media.ts
@@ -117,13 +117,27 @@ interface AdoptionRoot {
  * reply carried a card whose `src` 404s and whose download button saves the 21
  * bytes of `{"error":"Not found"}` under a `.png` name.
  *
- * WHY THIS IS NOT A NEW READ CAPABILITY. The agent's working directory IS the
- * Files API's browse root on this appliance, and that route already serves any
- * file in it to this same authenticated session, behind this same guard. What
- * changes is which of those files the chat will copy for itself, not which
- * files the session may read. Everything outside these roots — `/etc`, another
- * user's home, an absolute path the model simply invented — is refused, and a
- * refused picture costs a card, never the reply.
+ * WHY THE BROWSE ROOT IS NOT A NEW READ CAPABILITY. The agent's working
+ * directory IS the Files API's browse root on this appliance, and that route
+ * already serves any file in it to this same authenticated session, behind this
+ * same guard. What changes there is which of those files the chat will copy for
+ * itself, not which files the session may read.
+ *
+ * WHY `/tmp` IS HERE ANYWAY, ON A DIFFERENT ARGUMENT. That reasoning does NOT
+ * extend to the tmp dir: it sits outside the browse root, the Files API does not
+ * serve it, and a file adopted from there becomes fetchable through
+ * `chat/media` when it was not before. It is included because it is the other
+ * place a shell-improvising agent writes, and the exposure it opens is narrow
+ * and bounded on every side: the MODEL has to name the path, the extension has
+ * to be one `chat/media` serves, the guard still applies, and the only reader
+ * is the same authenticated device owner — who can already run a shell on this
+ * box through the terminal app. It is a deliberate trade, not a consequence of
+ * the paragraph above, and a later reader extending this list should extend it
+ * on this argument rather than on that one.
+ *
+ * Everything outside these roots — `/etc`, another user's home, an absolute
+ * path the model simply invented — is refused, and a refused picture costs a
+ * card, never the reply.
  */
 async function adoptionRoots(): Promise<AdoptionRoot[]> {
   const roots: AdoptionRoot[] = [];

--- a/src/tests/routes/hermes-chat-streaming.test.ts
+++ b/src/tests/routes/hermes-chat-streaming.test.ts
@@ -35,7 +35,14 @@ vi.mock("@/lib/hermes-dashboard-turn", async (importOriginal) => ({
 vi.mock("child_process", () => ({ spawn: spawnMock }));
 vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock }));
 vi.mock("@/lib/harness/hermes-turn-record", () => ({ readHermesTurn: readTurnMock }));
-vi.mock("@/lib/harness/media-root", () => ({ resolveInMediaRoot: vi.fn(async (p: string) => p) }));
+// `chatMediaRoot` is named here as well as `resolveInMediaRoot` because the
+// settle path asks for it now. Left out, the CALL throws synchronously rather
+// than rejecting, which `servableMediaRoot` survives — but then every case in
+// this file would be exercising that fallback instead of the real path.
+vi.mock("@/lib/harness/media-root", () => ({
+  resolveInMediaRoot: vi.fn(async (p: string) => p),
+  chatMediaRoot: vi.fn(async () => "/tmp/clawbox-streaming-media"),
+}));
 vi.mock("@/lib/hermes-model-options", () => ({
   // No catalogue: the route falls back to its static allowlist and lets hermes
   // itself judge the pair, which is the path a box takes before the header has

--- a/src/tests/routes/hermes/chat-images-and-transcript.test.ts
+++ b/src/tests/routes/hermes/chat-images-and-transcript.test.ts
@@ -198,11 +198,51 @@ describe("POST /setup-api/hermes/chat", () => {
   });
 
   it("stores the picture as a picture, not as a MEDIA: line of text", async () => {
-    stdoutReply = "here you go\n\nMEDIA:/home/clawbox/pic.png";
+    // Written into the agent's OWN working directory, which is where an agent
+    // with no image tool puts one. It is adopted into the chat media tree, and
+    // what the transcript carries is a URL the browser can fetch — never the
+    // directive, and never the device path the model wrote.
+    const drawn = path.join(root, "pic.png");
+    fs.writeFileSync(drawn, Buffer.from("89504e470d0a1a0a0000000d49484452", "hex"));
+    stdoutReply = `here you go\n\nMEDIA:${drawn}`;
     await post({ message: "draw" });
     const [, assistant] = transcript();
     expect(assistant.text).toBe("here you go");
+    expect(assistant.media).toHaveLength(1);
     expect(assistant.media[0]).toContain("/setup-api/chat/media");
+    // The COPY, under a name of ours — not the path the model named.
+    expect(assistant.media[0]).toContain("chat-generated");
+    expect(assistant.media[0]).not.toContain("pic.png");
+  });
+
+  it("drops the card when the picture cannot be served, and keeps the sentence", async () => {
+    // The old behaviour lifted ANY absolute path the model uttered into a card,
+    // with no containment check anywhere, so a file the chat cannot read became
+    // a dead thumbnail over a download button that saved 21 bytes of
+    // `{"error":"Not found"}` under a `.png` name. Measured on two live boxes,
+    // one linked and one not, so it was never about the link.
+    //
+    // No card is the honest answer. The sentence is what the customer asked for
+    // and it survives intact; the device path was machinery either way.
+    stdoutReply = "here you go\n\nMEDIA:/home/clawbox/never-written.png";
+    await post({ message: "draw" });
+    const [, assistant] = transcript();
+    expect(assistant.text).toBe("here you go");
+    expect(assistant.media).toBeUndefined();
+  });
+
+  it("refuses to adopt a secret store dressed up as a picture", async () => {
+    // Inside the browse root, so containment alone would pass it; the Files API
+    // secret guard is what stops a copy of `~/.ssh` landing in a tree the
+    // browser can read.
+    const secret = path.join(root, ".ssh", "id_rsa.png");
+    fs.mkdirSync(path.dirname(secret), { recursive: true });
+    fs.writeFileSync(secret, Buffer.from("89504e470d0a1a0a0000000d49484452", "hex"));
+    stdoutReply = `here you go\n\nMEDIA:${secret}`;
+    await post({ message: "draw" });
+    const [, assistant] = transcript();
+    expect(assistant.text).toBe("here you go");
+    expect(assistant.media).toBeUndefined();
   });
 
   it("records the user's own words, not the switch note written for the agent", async () => {

--- a/src/tests/unit/hermes-generated-media.test.ts
+++ b/src/tests/unit/hermes-generated-media.test.ts
@@ -346,6 +346,44 @@ MEDIA:${attached}`);
     expect(await adoptHermesGeneratedImages(sources)).toHaveLength(1);
   });
 
+  it("adopts a child whose NAME begins with two dots", async () => {
+    // `path.relative` returns a bare segment, so `..crab.png` inside the root
+    // yields rel === "..crab.png". A `startsWith("..")` test reads that as a
+    // traversal and refuses a file that is plainly inside the root.
+    const drawn = writeWorkspaceImage("..crab.png");
+    const { adoptHermesGeneratedImages } = await load();
+    expect(await adoptHermesGeneratedImages([drawn])).toHaveLength(1);
+  });
+
+  it("still refuses a real traversal, which is `..` as a whole segment", async () => {
+    const { adoptHermesGeneratedImages } = await load();
+    const climbing = path.join(cacheDir(), "..", "..", "..", "escape.png");
+    expect(await adoptHermesGeneratedImages([climbing])).toEqual([]);
+  });
+
+  it("bounds the WORK a turn can be made to do, not just the pictures it yields", async () => {
+    // Nothing here can ever be adopted, so a cap counting successes never
+    // trips and every invented path still pays for a realpath and a stat on
+    // the box. The reply these come from is capped in megabytes, not lines.
+    const invented = Array.from({ length: 500 }, (_, i) =>
+      path.join(home, `invented_${i}.png`),
+    );
+    const { adoptHermesGeneratedImages } = await load();
+    const before = Date.now();
+    expect(await adoptHermesGeneratedImages(invented)).toEqual([]);
+    // The bound is the assertion; the timing is only here to say why it exists.
+    expect(Date.now() - before).toBeLessThan(4000);
+  });
+
+  it("still reaches a real picture that follows a run of misses", async () => {
+    // The attempt cap must not be so tight that a reply with a few dead paths
+    // in front of a real one loses the real one.
+    const good = writeWorkspaceImage("after_misses.png");
+    const misses = Array.from({ length: 8 }, (_, i) => path.join(home, `gone_${i}.png`));
+    const { adoptHermesGeneratedImages } = await load();
+    expect(await adoptHermesGeneratedImages([...misses, good])).toHaveLength(1);
+  });
+
   it("still stops at four however many the agent wrote", async () => {
     const files = ["a", "b", "c", "d", "e", "f"].map((n) =>
       writeWorkspaceImage(`spam_${n}.png`),

--- a/src/tests/unit/hermes-generated-media.test.ts
+++ b/src/tests/unit/hermes-generated-media.test.ts
@@ -324,7 +324,13 @@ describe("adopting a picture the agent drew", () => {
     // The dedupe used to key on the raw string, and the model does not always
     // write the path back exactly as the tool gave it.
     const drawn = writeWorkspaceImage("same.png");
-    const wordy = path.join(home, ".", "same.png");
+    // Built by concatenation on purpose. `path.join` would normalise the `.`
+    // away here in the TEST, handing the code under test two identical strings
+    // that raw-string keying would also collapse - a case that cannot fail.
+    const wordy = `${home}${path.sep}.${path.sep}same.png`;
+    // So the premise is asserted rather than assumed: if a future Node ever
+    // normalises this, the test says so instead of quietly proving nothing.
+    expect(wordy).not.toBe(drawn);
     const { adoptHermesGeneratedImages } = await load();
     expect(await adoptHermesGeneratedImages([drawn, wordy])).toHaveLength(1);
   });
@@ -382,6 +388,31 @@ MEDIA:${attached}`);
     const misses = Array.from({ length: 8 }, (_, i) => path.join(home, `gone_${i}.png`));
     const { adoptHermesGeneratedImages } = await load();
     expect(await adoptHermesGeneratedImages([...misses, good])).toHaveLength(1);
+  });
+
+  it("judges the caption and the adoption against the SAME media root", async () => {
+    // `settleTurn` resolves the root once and threads it through both halves.
+    // When adoption resolved its own, the two could disagree: the caption gave
+    // an echoed attachment up on the strength of the first lookup while the
+    // second dropped the only root able to adopt it — the path gone from the
+    // sentence and no card in its place.
+    const attached = writeImage(
+      path.join(home, "data", "chat-media", "chat-attachments", "threaded.png"),
+    );
+    const mediaRoot = path.join(home, "data", "chat-media");
+    const { adoptHermesGeneratedImages, reclaimImageMentions } = await load();
+
+    // With the root, the exemption fires and the path stays in the caption.
+    const kept = reclaimImageMentions(`Got it.
+MEDIA:${attached}`, mediaRoot);
+    expect(kept.sources).toEqual([]);
+
+    // Without it, the path is reclaimed — and the SAME root, handed to
+    // adoption, is what keeps it renderable.
+    const taken = reclaimImageMentions(`Got it.
+MEDIA:${attached}`, null);
+    expect(taken.sources).toEqual([attached]);
+    expect(await adoptHermesGeneratedImages(taken.sources, mediaRoot)).toHaveLength(1);
   });
 
   it("still stops at four however many the agent wrote", async () => {

--- a/src/tests/unit/hermes-generated-media.test.ts
+++ b/src/tests/unit/hermes-generated-media.test.ts
@@ -36,11 +36,27 @@ function cacheDir(): string {
 }
 
 /** A real, if tiny, PNG — enough that the size and file checks are honest. */
-function writeCachedImage(name: string): string {
-  fs.mkdirSync(cacheDir(), { recursive: true });
-  const file = path.join(cacheDir(), name);
-  fs.writeFileSync(file, Buffer.from("89504e470d0a1a0a0000000d49484452", "hex"));
+const PNG_BYTES = Buffer.from("89504e470d0a1a0a0000000d49484452", "hex");
+
+function writeImage(file: string): string {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, PNG_BYTES);
   return file;
+}
+
+function writeCachedImage(name: string): string {
+  return writeImage(path.join(cacheDir(), name));
+}
+
+/**
+ * A picture written where an IMPROVISING agent writes one: its own working
+ * directory, which on the appliance is the home directory the Files API already
+ * serves. This is literally what the owner's box did — `write_file` an SVG into
+ * `/home/clawbox`, rasterise it with cairosvg — and the file it left behind is
+ * the one that rendered as a dead card.
+ */
+function writeWorkspaceImage(name: string): string {
+  return writeImage(path.join(home, name));
 }
 
 describe("adopting a picture the agent drew", () => {
@@ -88,7 +104,7 @@ describe("adopting a picture the agent drew", () => {
     expect(fs.existsSync(generatedDir())).toBe(false);
   });
 
-  it("refuses a path outside the image cache entirely", async () => {
+  it("refuses a secret store dressed up as a picture", async () => {
     const outside = path.join(home, ".hermes", "elsewhere.png");
     fs.mkdirSync(path.dirname(outside), { recursive: true });
     fs.writeFileSync(outside, "not in the cache");
@@ -163,7 +179,7 @@ describe("adopting a picture the agent drew", () => {
     const { reclaimImageMentions } = await load();
     const attached = path.join(home, "data", "chat-media", "chat-attachments", "one.png");
     const raw = `Got it.\nMEDIA:${attached}`;
-    const out = reclaimImageMentions(raw);
+    const out = reclaimImageMentions(raw, path.join(home, "data", "chat-media"));
     expect(out.sources).toEqual([]);
     expect(out.text).toBe(raw);
   });
@@ -202,5 +218,122 @@ describe("adopting a picture the agent drew", () => {
     const { sources } = reclaimImageMentions("Done!\nMEDIA:" + file);
     const adopted = await adoptHermesGeneratedImages([file, ...sources]);
     expect(adopted).toHaveLength(1);
+  });
+
+  // ── A picture the agent made ITSELF, outside the cache ──
+  //
+  // A box with no ClawBox AI link has no image tool, and the agent asked for a
+  // picture anyway improvises: on the owner's box it wrote an SVG into its own
+  // working directory and rasterised it. Before this, that file was refused by
+  // adoption AND left in the caption, where `splitAssistantMedia` lifted it into
+  // a card `chat/media` then answered 404 to — a dead thumbnail beside a
+  // download button that saved the error body under a `.png` name.
+  //
+  // The rule these hold: RENDER IT, OR SHOW NO CARD. Never a card that 404s.
+
+  /** What `settleTurn` does, in the order it does it. */
+  async function settle(spoken: string, toolRows: string[] = []) {
+    const { adoptHermesGeneratedImages, reclaimImageMentions } = await load();
+    const mediaRoot = path.join(home, "data", "chat-media");
+    const { text, sources } = reclaimImageMentions(spoken, mediaRoot);
+    const drawn = await adoptHermesGeneratedImages([...toolRows, ...sources]);
+    return { text, cards: drawn };
+  }
+
+  it("adopts a picture the agent wrote in its own working directory", async () => {
+    const drawn = writeWorkspaceImage("crab_sword_space.png");
+    const { text, cards } = await settle(`Here you go\u2014a cosmic crab!\nMEDIA:${drawn}`);
+    // One card, and one that resolves: the copy lives in the tree `chat/media`
+    // serves, under a name of ours rather than the model's.
+    expect(cards).toHaveLength(1);
+    expect(cards[0].startsWith(generatedDir() + path.sep)).toBe(true);
+    expect(fs.existsSync(cards[0])).toBe(true);
+    // The sentence survives; only the machinery line goes.
+    expect(text).toBe("Here you go\u2014a cosmic crab!");
+  });
+
+  it("shows NO card when the picture cannot be adopted, and keeps the sentence", async () => {
+    // Named but never written — the shape of every path the model invents.
+    const { text, cards } = await settle(
+      `Here you go!\nMEDIA:${path.join(home, "imaginary.png")}`,
+    );
+    expect(cards).toEqual([]);
+    expect(text).toBe("Here you go!");
+  });
+
+  it("shows NO card for a relative mention either", async () => {
+    // `MEDIA:crab.png` used to survive the caption and become a card resolving
+    // to `?path=crab.png`, which is a 404 by a different route to the same
+    // broken thumbnail.
+    const { text, cards } = await settle("Done!\nMEDIA:crab.png");
+    expect(cards).toEqual([]);
+    expect(text).toBe("Done!");
+  });
+
+  it("refuses a credential store even when the model dresses it as a picture", async () => {
+    // `~/.ssh` is inside the browse root, so containment alone would let this
+    // through; the secret guard is what stops it. A copy here would publish the
+    // customer's key material to anyone with the chat open.
+    const secret = writeImage(path.join(home, ".ssh", "id_rsa.png"));
+    const { adoptHermesGeneratedImages } = await load();
+    expect(await adoptHermesGeneratedImages([secret])).toEqual([]);
+    // And nothing in ~/.hermes either — the provider keys live there.
+    const hermesSecret = writeImage(path.join(home, ".hermes", "auth.png"));
+    expect(await adoptHermesGeneratedImages([hermesSecret])).toEqual([]);
+  });
+
+  it("refuses a path in no root at all", async () => {
+    const { adoptHermesGeneratedImages } = await load();
+    expect(await adoptHermesGeneratedImages(["/etc/shadow.png"])).toEqual([]);
+  });
+
+  it("still adopts from the image cache — the clawai path #482 fixed", async () => {
+    // The regression that matters most: the working path on a LINKED box. The
+    // cache lives under ~/.hermes, which the secret guard refuses wholesale, so
+    // a fix that simply ran every root through the guard would have silently
+    // broken every picture ClawBox AI has ever drawn.
+    const drawn = writeCachedImage("clawai.png");
+    const { text, cards } = await settle(`Here is your picture.\nMEDIA:${drawn}`, [drawn]);
+    expect(cards).toHaveLength(1);
+    expect(text).toBe("Here is your picture.");
+  });
+
+  it("still keeps a mention the chat can already serve where the model put it", async () => {
+    const attached = path.join(home, "data", "chat-media", "chat-attachments", "one.png");
+    const raw = `Got it.\nMEDIA:${attached}`;
+    const { reclaimImageMentions } = await load();
+    const out = reclaimImageMentions(raw, path.join(home, "data", "chat-media"));
+    expect(out.sources).toEqual([]);
+    expect(out.text).toBe(raw);
+  });
+
+  it("takes a file:// mention out of the caption instead of leaving it to 404", async () => {
+    // `mediaUrl` strips the scheme and asks `chat/media` for the path beneath,
+    // so a `file://` mention left in the caption is a dead card by a slightly
+    // longer route. It is a local path; it is reclaimed as one, and then judged
+    // by adoption like any other. (Asserted on the reclaim rather than on a
+    // real file, because a `file://` URL of a Windows path is not a path this
+    // test could then write to.)
+    const { reclaimImageMentions } = await load();
+    const out = reclaimImageMentions("Here.\nMEDIA:file:///home/clawbox/crab.png");
+    expect(out.sources).toEqual(["/home/clawbox/crab.png"]);
+    expect(out.text).toBe("Here.");
+  });
+
+  it("one card when the tool row and the sentence spell the same file differently", async () => {
+    // The dedupe used to key on the raw string, and the model does not always
+    // write the path back exactly as the tool gave it.
+    const drawn = writeWorkspaceImage("same.png");
+    const wordy = path.join(home, ".", "same.png");
+    const { adoptHermesGeneratedImages } = await load();
+    expect(await adoptHermesGeneratedImages([drawn, wordy])).toHaveLength(1);
+  });
+
+  it("still stops at four however many the agent wrote", async () => {
+    const files = ["a", "b", "c", "d", "e", "f"].map((n) =>
+      writeWorkspaceImage(`spam_${n}.png`),
+    );
+    const { adoptHermesGeneratedImages } = await load();
+    expect(await adoptHermesGeneratedImages(files)).toHaveLength(4);
   });
 });

--- a/src/tests/unit/hermes-generated-media.test.ts
+++ b/src/tests/unit/hermes-generated-media.test.ts
@@ -329,6 +329,23 @@ describe("adopting a picture the agent drew", () => {
     expect(await adoptHermesGeneratedImages([drawn, wordy])).toHaveLength(1);
   });
 
+  it("does not lose an attachment echo when the media root cannot be exempted", async () => {
+    // The exemption in `reclaimImageMentions` normally leaves this path in the
+    // caption. If it ever misses — an unresolvable media root, a symlink the
+    // lexical test cannot see — the mention IS reclaimed, and the DATA_DIR guard
+    // would refuse it. The media root is an adoption root of its own so the
+    // picture still renders instead of vanishing.
+    const attached = writeImage(
+      path.join(home, "data", "chat-media", "chat-attachments", "echo.png"),
+    );
+    const { adoptHermesGeneratedImages, reclaimImageMentions } = await load();
+    // No media root passed: the exemption cannot fire.
+    const { sources } = reclaimImageMentions(`Got it.
+MEDIA:${attached}`);
+    expect(sources).toEqual([attached]);
+    expect(await adoptHermesGeneratedImages(sources)).toHaveLength(1);
+  });
+
   it("still stops at four however many the agent wrote", async () => {
     const files = ["a", "b", "c", "d", "e", "f"].map((n) =>
       writeWorkspaceImage(`spam_${n}.png`),

--- a/src/tests/unit/mcp-code-project-paths.test.ts
+++ b/src/tests/unit/mcp-code-project-paths.test.ts
@@ -62,6 +62,9 @@ const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers: [],
+  emailCanRead: false,
+  codingAgent: false,
+  canGenerateImages: true,
 });
 
 /** Route replies for the two calls code_project_init makes, in order. */

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -616,6 +616,13 @@ describe("a box that cannot draw says so instead of improvising", () => {
     expect(ai("openclaw", false).has("image_generate")).toBe(true);
   });
 
+  it("survives the core profile, which is where it matters most", () => {
+    // `CLAWBOX_MCP_PROFILE=core` is the trimmed set a SMALL model gets, and a
+    // small model is the likeliest to answer "draw me a crab" with the shell.
+    // A tool that is dropped from core is missing from exactly those boxes.
+    expect(ai("hermes", false).get("image_generate").opts.profile).toBe("core");
+  });
+
   it("names the reason, the fix, and closes the door the agent walked through", async () => {
     const out = await ai("hermes", false).call("image_generate", {});
     // Not an error: a tool that throws trips Hermes' circuit breaker, and this

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -68,12 +68,23 @@ import { registerSkillTools } from "../../../mcp/tools/skills";
 import { buildContext } from "../../../mcp/lib/context";
 import { desktopDisplay, registerSystemTools } from "../../../mcp/tools/system";
 
-const ctx = (edition: "openclaw" | "hermes", providers: string[] = []): McpContext => ({
+const ctx = (
+  edition: "openclaw" | "hermes",
+  providers: string[] = [],
+  overrides: Partial<McpContext> = {},
+): McpContext => ({
   edition,
   install: edition,
   profile: "full",
   capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
   providers,
+  // The probe defaults, spelled out rather than left off: every one of these
+  // decides whether a tool is registered at all, and a helper that omitted them
+  // was a helper the type checker had already stopped believing.
+  emailCanRead: false,
+  codingAgent: false,
+  canGenerateImages: true,
+  ...overrides,
 });
 
 beforeEach(() => {
@@ -568,5 +579,62 @@ describe("ai_set_provider is not a one-way door", () => {
 
     const built = await buildContext("hermes", "hermes", "full");
     expect(built.providers).toEqual(["clawlocal"]);
+  });
+});
+
+// ── Drawing, on a box that cannot ────────────────────────────────────────────
+//
+// Image generation on this device is not a ClawBox MCP tool at all: on Hermes
+// it is a native plugin installed by LINKING ClawBox AI, on OpenClaw it is the
+// agent's own bundled tool spending the same credential. So an unlinked box has
+// no image tool anywhere, and an agent asked for a picture found nothing and
+// improvised — observed on the owner's box (2026-08-26): `write_file` an SVG
+// into its working directory, `pip install cairosvg`, rasterise, and hand back
+// a path the chat cannot serve. The customer got a broken thumbnail and no
+// explanation.
+//
+// So the absence gets a voice, the way `backup_status` gives one to ClawKeep's:
+// one tool, registered only where drawing is impossible, whose whole job is to
+// be found and to say why.
+
+describe("a box that cannot draw says so instead of improvising", () => {
+  function ai(edition: "openclaw" | "hermes", canGenerateImages: boolean) {
+    const h = captureRegistrar(edition);
+    registerAiTools(h.reg, ctx(edition, [], { canGenerateImages }));
+    return h;
+  }
+
+  it("registers nothing extra where the box CAN draw", () => {
+    // The harness's own image tool is present there, and a second tool beside
+    // it saying "you cannot" is worse than silence.
+    expect(ai("hermes", true).has("image_generate")).toBe(false);
+    expect(ai("openclaw", true).has("image_generate")).toBe(false);
+  });
+
+  it("offers the refusal on both editions when the box cannot draw", () => {
+    expect(ai("hermes", false).has("image_generate")).toBe(true);
+    expect(ai("openclaw", false).has("image_generate")).toBe(true);
+  });
+
+  it("names the reason, the fix, and closes the door the agent walked through", async () => {
+    const out = await ai("hermes", false).call("image_generate", {});
+    // Not an error: a tool that throws trips Hermes' circuit breaker, and this
+    // one has something true to say.
+    expect(out.isError).toBe(false);
+    if (out.isError) return;
+    expect(out.text).toMatch(/ClawBox AI/);
+    expect(out.text).toMatch(/Settings -> AI Providers/);
+    // The improvisation itself, named — this is the half that stops the
+    // hand-written-SVG answer coming back.
+    expect(out.text).toMatch(/terminal/i);
+    expect(out.text).toMatch(/SVG/i);
+  });
+
+  it("is discoverable from the description alone, before it is ever called", () => {
+    // A small model decides whether to call a tool from its description. If it
+    // does not read as "this is how you make a picture", the model never gets
+    // as far as the honest answer inside.
+    const { description } = ai("hermes", false).get("image_generate");
+    expect(description).toMatch(/picture|image/i);
   });
 });


### PR DESCRIPTION
A picture the agent made itself rendered as a card with a dead thumbnail, next to a download button that saved 21 bytes of `{"error":"Not found"}` under a `.png` name. Reproduced and traced on a live box.

## The defect, stated first

**`splitAssistantMedia` lifts any absolute `MEDIA:` path the model utters into a card, with no containment check anywhere** (`chat-media.ts:150` -> `mediaUrl` `:100`). If the chat cannot serve that path, the customer gets a card with a dead thumbnail and a download button that saves the 404 body under a `.png` name.

This is **not** a property of unlinked boxes. `splitAssistantMedia` never asks where a path points, and `chat/media` serves exactly one subtree, so a *linked* box whose agent decides to write its own file outside `~/.hermes/cache/images` takes the identical path to the identical dead card. (Reasoned from the code, not observed on a linked box — see Validation.) Being unlinked is what made the agent improvise, so it is how this was found and it is worth fixing separately, but the unguarded lift is the defect and it is fixed as such.

## How it was found

The box was **not linked to ClawBox AI**, so `canGenerateImages` was false and the agent had **no image tool in any surface** — on Hermes image generation is a native plugin installed by linking ClawBox AI, on OpenClaw it is the agent's own tool spending the same credential. Asked for a picture anyway, the agent improvised with the shell. Its own tool rows, read back from the stored turn:

| # | tool | detail |
|---|---|---|
| 1 | `skill_view` | comfyui |
| 2–3 | `terminal` | ComfyUI probes — **both failed** |
| 4 | `search_files` | comfyui/workflows |
| 5 | `write_file` | **hand-wrote an SVG into its own working directory** |
| 6–9 | `terminal` | `pip install cairosvg`, rasterise to `crab_sword_space.png` |
| 10 | `vision_analyze` | the PNG it had just made |

The result was a real, valid 1024×1024 PNG — just not anywhere the chat can serve from. Confirmed from the box's own capability route: `hasClawaiToken: false`, `hermesAgentDrawsImages: false`, `hasClawaiImageRoute: false`, so `canGenerateImages` is false and `imageGenerationTrigger` is null. The box correctly advertises that it cannot draw; nothing told the agent.

## Root cause

`#482` bounded `reclaimImageMentions` to the Hermes image cache on the reasoning that `adoptOne` refused everything else, so lifting a mention it could not replace destroyed information for nothing. That reasoning had a hole: **a mention left in the caption is not left alone downstream.**

1. `hermes-generated-media.ts:216` — `reclaimable()` refuses the path (outside `~/.hermes/cache/images`), so the `MEDIA:` line **stays in the caption**.
2. `adoptOne` refuses it for the same reason, so nothing is copied and no directive is appended.
3. `hermes/chat/route.ts:493` — `splitAssistantMedia(answer)` then lifts that surviving line, and `chat-media.ts:150` maps it through `mediaUrl()` **with no containment check of any kind**.
4. `chat/media` is rooted on `DATA_DIR/chat-media` → **404**.

`splitAssistantMedia` was the unguarded step. #482 tightened what gets *reclaimed for adoption* and left what gets *lifted into a card* wide open, so any absolute path the model utters became a card whether or not anything could serve it.

The download button is `<a href={src} download>` (`ChatPopup.tsx:3681`). Same-origin, so the attribute is honoured: it does not "download nothing" — it saves the 404 JSON body under a plausible image filename.

## The fix, in two halves

### 1. Never mint a card nothing can serve

The rule is inverted. **Every local image path the model names comes out of the caption and is offered to adoption; only what adoption actually copied comes back as a `MEDIA:` directive.** A picture that can be served renders; one that cannot leaves the sentence and no card. The path is machinery either way — an absolute device path in a chat bubble was never worth preserving.

Adoption now works from a small ordered set of roots rather than one:

| root | guarded by `isProtectedFilePath` |
|---|---|
| `~/.hermes/cache/images` | **no** — explicit carve-out |
| `FILES_ROOT ?? $HOME` (the agent's cwd) | yes |
| `os.tmpdir()` | yes |

The carve-out is load-bearing and is checked **first**: the cache lives under `~/.hermes`, which the guard refuses wholesale (`config.yaml`, `.env`, `auth.json` are there). Routing every root through the guard would have silently broken **every picture ClawBox AI has ever drawn** — the working path. There is a regression test pinning exactly that.

**This is not a new read capability.** The agent's working directory *is* the Files API's browse root, and that route already serves any file in it to this same authenticated session behind this same guard. What changes is which of those files the chat copies for itself. Lexical containment picks the root and rebuilds the path; `realpath` then re-decides which root the file is *actually* in, and that root's guard judges it — so `…/cache/images/link -> ~/.hermes/.env` is still refused (CWE-59, the #482 case), and `~/.ssh/x.png` is refused too.

Two more holes closed while in here:
- `MEDIA:file:///abs/path.png` — `mediaUrl` strips the scheme and asks for the path beneath, so this was a dead card by a slightly longer route. It is a local path and is now treated as one.
- The per-turn dedupe keyed on the raw string; the tool row and the model's sentence do not always spell the path the same way. It now keys on the resolved path, so *one generation, one card* holds against `/home/clawbox/./a.png`.

`MAX_ADOPTED_PER_TURN`, the byte budget and the retention sweep from #482 are untouched.

### 2. Fail honestly instead of improvising

The deeper defect is the **silence**. Nothing anywhere told the agent that drawing was unavailable, so it invented a way.

Following the `backup_status` precedent — the one tool ClawKeep keeps registered purely so the agent can answer instead of going silent — `image_generate` is now registered **only on a box that cannot draw**, as a pure refusal that names the reason, the fix, and closes the door:

> Picture generation is not available on this ClawBox. It runs on ClawBox AI and this device is not connected to one. Tell the user that in their own language, and that they can connect it in Settings -> AI Providers. Do NOT try to make the picture some other way — not with the terminal, not by writing an SVG or HTML and converting it, not with a Python imaging library. …

Gating it to the *false* case is what keeps the working path untouched: on a linked box the harness's own image tool is present and nothing extra is registered, so there is no duplicate tool and no contradiction. It returns text rather than throwing, so it cannot trip Hermes' circuit breaker.

The message is addressed to the **agent**, so it is deliberately unlocalised — the agent writes the customer's sentence in the customer's own language out of it. No new i18n keys, and no separate system-row banner: the reply itself carries the explanation.

`McpContext` gains `canGenerateImages`, probed from `/setup-api/chat/capabilities` and run through the same `capabilitiesFor()` the browser uses, so the tool the agent sees and the button the customer sees can never disagree. It **fails closed**, and closed here means the refusal tool *is* registered — a box we cannot ask about is a box we cannot promise a picture from.

## Incidental

- `filesBrowseRoot()` moves into `file-guard.ts`. The root was written out identically in both Files API routes and would have been a third copy here; a root defined in one file and guarded in another is how a fourth caller ends up browsing a tree nobody remembered to protect.
- The guard's name-shaped patterns are all spelled with `/`, so on Windows they matched nothing and `~/.ssh` was **not protected**. The appliance is Linux and never took that branch, but the tests run on developer machines — a security rule that quietly no-ops on the platform it is *tested* on is a rule nobody is testing. Normalised only where the separator differs (on POSIX a backslash is a legal filename character). This is why the new secret-store tests actually prove something.
- Two `McpContext` test helpers were already missing `emailCanRead`/`codingAgent` and failing `tsc`; completed here since this adds a third field.

## Tests

`hermes-generated-media.test.ts` 25/25. New cases, all three outcomes the brief asked for:

- agent-written file in its working directory → **one card**, the copy lands in the served tree, sentence intact
- unwritten / invented path → **no card**, sentence intact
- relative mention (`MEDIA:crab.png`) → **no card** (it used to resolve to `?path=crab.png` and 404)
- `~/.ssh/id_rsa.png` and `~/.hermes/auth.png` → **refused**
- `/etc/shadow.png` → refused
- cache path → **still one card** — the #482 clawai path
- customer's own attachment echoed back → still left where the model put it
- still capped at four; `file://` reclaimed; one card for two spellings of one file

`mcp-tool-honesty.test.ts` 39/39, with a new block: nothing extra registered where the box can draw, the refusal on both editions where it cannot, and the message naming ClawBox AI, Settings -> AI Providers, and the improvisation route itself.

Full unit suite green. `tsc` **19 errors vs 21 on beta** — two fixed, none added, none in any touched file. `eslint` clean.

## Validation

### Measured on hardware — two boxes

`192.168.50.165` (owner's, **unlinked**) and `192.168.50.71` (Mike's, **linked**), both Hermes on `beta`:

| fact | .165 unlinked | .71 linked |
|---|---|---|
| `hasClawaiToken` | false | true |
| `hasClawaiImageRoute` | false | true |
| `hermesAgentDrawsImages` | false | true |
| → `canGenerateImages` | **false** | **true** |

**1. The dead card is not about being unlinked.** `GET /setup-api/chat/media?path=/home/clawbox/redtest.png` returns, on *both* boxes, byte-identically:

```
404 · no content-type · 21 bytes · {"error":"Not found"}
```

That is what the download button saves under a `.png` name — 21 bytes, measured, not estimated. The linked box behaves exactly like the unlinked one, which is the claim this PR rests on.

**2. Why adoption exists at all**, on the linked box — the same picture, two locations:

| path | result |
|---|---|
| `data/chat-media/chat-generated/agent-9b6a60e1….png` (the adopted copy) | **200**, 2,314,157 bytes, `\x89PNG` |
| `~/.hermes/cache/images/clawai_20260826_140943_….png` (its original) | **404**, 21 bytes |

The destination this PR copies into is served; the source it copies from is not. That is #482 working, and it is why the cache carve-out below must not be run through the secret guard.

**3. The defect itself, reproduced on `.165` on the stock `beta` build**, by driving the real settle-path helpers (`reclaimImageMentions` → `adoptHermesGeneratedImages` → `splitAssistantMedia`) from the repo on the device:

| mention | adopted | cards |
|---|---|---|
| file the agent wrote in its workspace | 0 | **1** → 404 |
| path never written | 0 | **1** → 404 |
| `~/.ssh/pr497-secret.png` | 0 | **1** → 404 |
| relative `MEDIA:pr497-workspace.png` | 0 | **1** → `?path=pr497-workspace.png`, 404 |

Every shape produced a card with **nothing adopted behind it** — four dead cards, including one whose URL points into `~/.ssh`. This is the before-state this PR removes, and each row has a matching regression test.

**4. The fix, on the same box, same probe, branch checked out.** Before → after:

| mention | before: adopted / cards | after: adopted / cards |
|---|---|---|
| file the agent wrote in its workspace | 0 / **1 dead** | **1 / 1 — serves** |
| path never written | 0 / **1 dead** | 0 / **0** |
| `~/.ssh/pr497-secret.png` | 0 / **1 dead** | 0 / **0** |
| relative `MEDIA:…png` | 0 / **1 dead** | 0 / **0** |

The caption came back as `"Here you go!"` in all four — the sentence survives, only the machinery line goes.

And the surviving card resolves, fetched through the real route on the device:

```
adopted copy   → 200 · \x89PNG\r\n\x1a\n
/home/clawbox/pr497-workspace.png → 404 · 21 bytes · {"error":"Not found"}
```

That is the whole defect and the whole fix, measured end to end on hardware: the path the card used to point at still 404s, and the card now points at a copy that serves.

### Housekeeping

`.165` was returned to `beta @ adad3320` with a clean tree and the service active, every test file and the adopted test copy deleted, and the device lock released — the deploy/probe/restore ran as one trapped script so no failure path could leave the box on a branch. The lock had been held by a stale `krasi-wipe` entry for 22.7 h; its previous value was preserved before takeover.

### What is still NOT verified live

The `image_generate` refusal changing what a real agent does when asked for a picture — that needs a full rebuild and a live chat turn, which this run did not do (the probe exercises the settle path from source, not the MCP registration). Its registration and message are covered by unit tests. Worth one pass on a box before this reaches customers.
