### PR TITLE
Hermes parity: stop offering three OpenClaw-only controls as if they worked

### DIFF
--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -4,7 +4,12 @@ import fs from "fs/promises";
 import path from "path";
 import { NextResponse } from "next/server";
 import { get, set, setMany } from "@/lib/config-store";
-import { readConfig, restartGateway, runOpenclawConfigSet } from "@/lib/openclaw-config";
+import {
+  gatewayIsAbsent,
+  readConfig,
+  restartGateway,
+  runOpenclawConfigSet,
+} from "@/lib/openclaw-config";
 
 const SAVED_PRIMARY_KEY = "local_only_saved_primary";
 const SAVED_FALLBACKS_KEY = "local_only_saved_fallbacks";
@@ -194,12 +199,37 @@ async function restoreSessionOverrides(backup: FilesBackup): Promise<void> {
   }
 }
 
+// Local-only mode is built entirely out of OpenClaw CLI calls: it flips
+// `agents.defaults.model.primary`, empties `fallbacks`, and sweeps
+// `~/.openclaw/agents/*/sessions/sessions.json`. Hermes has none of those —
+// `hermes-local-ai.ts` can install and remove a local provider but has no
+// fallback chain to make exclusive, so there is nothing here to port.
+//
+// Ungated, every call reached `runOpenclawConfigSet`, which throws
+// `OpenclawUnavailableError`, which the catch-all turned into a 500 whose body
+// SettingsApp painted verbatim into a red banner: "The OpenClaw CLI is not
+// available on this edition." That is the product telling a Hermes owner about
+// our internals, in an error colour, for a control we chose to show them.
+//
+// Refusing with `supported: false` lets the UI hide the card instead — and the
+// refusal is stated the same way `whatsapp/configure` states its own.
+const UNSUPPORTED = {
+  error: "Local-only mode is an OpenClaw feature; this edition does not have it.",
+  supported: false,
+} as const;
+
 export async function GET() {
+  if (gatewayIsAbsent()) {
+    return NextResponse.json({ enabled: false, ...UNSUPPORTED });
+  }
   const enabled = !!(await get(MODE_KEY));
   return NextResponse.json({ enabled });
 }
 
 export async function POST(request: Request) {
+  if (gatewayIsAbsent()) {
+    return NextResponse.json(UNSUPPORTED, { status: 501 });
+  }
   let body: { enabled?: boolean };
   try {
     body = await request.json();

--- a/src/app/setup-api/system/hostname/route.ts
+++ b/src/app/setup-api/system/hostname/route.ts
@@ -5,7 +5,7 @@ import os from "os";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { get, set } from "@/lib/config-store";
-import { setControlUiAllowedOrigins, restartGateway } from "@/lib/openclaw-config";
+import { gatewayIsAbsent, restartGateway, setControlUiAllowedOrigins } from "@/lib/openclaw-config";
 import { getReachableIpv4 } from "@/lib/system-info";
 
 const execFileAsync = promisify(execFile);
@@ -69,11 +69,22 @@ export async function POST(request: Request) {
   // UI keeps working at http://<name>.local. Restart the gateway so it picks
   // up the new origin list. Both are best-effort: if either fails the
   // hostname change still proceeds (a reboot will reconcile).
-  try {
-    await setControlUiAllowedOrigins(name);
-    await restartGateway();
-  } catch (err) {
-    console.warn("[hostname] Failed to update OpenClaw allowed origins:", err);
+  // Skipped entirely on Hermes. `setControlUiAllowedOrigins` ends in
+  // `writeConfig`, which MKDIRs `~/.openclaw` and writes an
+  // `openclaw.json` carrying a `gateway.controlUi.allowedOrigins` block —
+  // manufacturing OpenClaw state on the one SKU whose defining property is not
+  // having any, for a gateway that is removed and masked there and will never
+  // read it. `restartGateway()` then no-ops. The hostname change itself is
+  // unaffected either way, so this was never a false success — just litter,
+  // and litter that makes `~/.openclaw` exist is the kind that misleads the
+  // next person debugging an edition question.
+  if (!gatewayIsAbsent()) {
+    try {
+      await setControlUiAllowedOrigins(name);
+      await restartGateway();
+    } catch (err) {
+      console.warn("[hostname] Failed to update OpenClaw allowed origins:", err);
+    }
   }
 
   try {

--- a/src/app/setup-api/telegram/streaming/route.ts
+++ b/src/app/setup-api/telegram/streaming/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import {
+  gatewayIsAbsent,
   getTelegramProgressStreaming,
   setTelegramProgressStreaming,
   restartGateway,
@@ -7,9 +8,42 @@ import {
 
 export const dynamic = "force-dynamic";
 
+// Progress streaming is a property of the OPENCLAW gateway's Telegram channel:
+// it lives at `channels.telegram.streaming.mode` in `~/.openclaw/openclaw.json`
+// and only the gateway reads it. Hermes runs Telegram out of `~/.hermes/.env`
+// (`hermes-telegram.ts`) and has no streaming concept at all.
+//
+// Ungated, both verbs lied on Hermes, in the two worst ways available:
+//
+//   GET  `readConfig()` answers `{}` for a file that does not exist, so
+//        `mode !== "off"` was `undefined !== "off"` — TRUE. The switch showed
+//        itself already ON before the owner touched anything.
+//   POST `writeConfig()` MKDIR'd `~/.openclaw` on a box whose whole SKU is not
+//        having one, wrote a setting nothing would ever read, and then called
+//        `restartGateway()` — which returns immediately on Hermes
+//        (`gatewayIsAbsent()`) — and answered `{success:true, restarted:true}`.
+//
+// `restarted: true` for a gateway that does not exist is the exact shape this
+// codebase has already been bitten by. Sibling routes get this right:
+// `telegram/configure` branches on the harness, `whatsapp/configure` answers
+// 501 `{supported:false}` on the wrong edition. This now does the same.
+const UNSUPPORTED = {
+  error: "Progress streaming is an OpenClaw gateway feature; this edition does not have it.",
+  supported: false,
+} as const;
+
 // Read whether the Telegram bot streams live tool/research progress while it
 // works. Defaults to ON (true) when no override is set.
 export async function GET() {
+  if (gatewayIsAbsent()) {
+    // `enabled: false` beside `supported: false` so a client that reads only
+    // the flag renders an OFF switch rather than an ON one — the honest
+    // fallback if it ignores the rest.
+    return NextResponse.json(
+      { enabled: false, ...UNSUPPORTED },
+      { status: 200, headers: { "Cache-Control": "no-store" } },
+    );
+  }
   try {
     const enabled = await getTelegramProgressStreaming();
     return NextResponse.json(
@@ -25,6 +59,9 @@ export async function GET() {
 }
 
 export async function POST(request: Request) {
+  if (gatewayIsAbsent()) {
+    return NextResponse.json(UNSUPPORTED, { status: 501 });
+  }
   try {
     let body: { enabled?: unknown };
     try {

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -3538,7 +3538,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
               </div>
             )}
 
-            {localAiStatus?.configured && (
+            {/* Local AI itself works on Hermes (see HERMES_LOCAL_PROVIDER_ID
+                above) — Local-ONLY mode does not. It is built from OpenClaw CLI
+                calls against a fallback chain Hermes has no equivalent of, so
+                this is the one control in the section that cannot work here.
+                Its route now refuses with `supported:false`; hiding the card
+                keeps the owner from discovering that through a red banner
+                quoting our internals at them. */}
+            {localAiStatus?.configured && edition !== "hermes" && (
               <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
                 <div className="flex items-center justify-between gap-4">
                   <div className="min-w-0 flex-1">
@@ -3694,6 +3701,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       {t("settings.openInTelegram", { name: `@${tgBotInfo.username}` })}
                     </a>
                   )}
+                  {/* Progress streaming is the OpenClaw gateway's Telegram
+                      channel setting. Hermes runs Telegram from ~/.hermes/.env
+                      and has no streaming mode at all, so this switch rendered
+                      itself ON (a missing config file reads as "not off") over
+                      a route that answered {restarted:true} for a gateway that
+                      does not exist. Telegram ITSELF works on Hermes — only
+                      this sub-setting does not, so only this row goes. */}
+                  {edition !== "hermes" && (
                   <div className="flex items-center justify-between gap-4 bg-white/[0.03] border border-white/[0.06] rounded-xl px-4 py-3.5 mb-4">
                     <div className="min-w-0 flex-1">
                       <div className="text-sm text-[var(--text-primary)] font-medium">{t("settings.telegramProgress")}</div>
@@ -3719,6 +3734,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                       </button>
                     </div>
                   </div>
+                  )}
                   <button
                     onClick={() => { setTgReconfigure(true); setTgStatus(null); }}
                     className="text-sm text-[var(--coral-bright)] hover:text-orange-300 bg-transparent border-none cursor-pointer underline underline-offset-2"

--- a/src/lib/ui-events.ts
+++ b/src/lib/ui-events.ts
@@ -60,7 +60,18 @@ export function buildFixErrorPrompt(ctx: FixErrorContext): string {
   if (ctx.details) lines.push("", "Extra context:", ctx.details);
   lines.push(
     "",
-    "Steps: read relevant logs (e.g. `journalctl -u clawbox-setup -u clawbox-gateway -n 200`), check the failing command directly, and apply a concrete fix. Report back what you found and what you changed.",
+    // Deliberately does NOT name units. It used to say `journalctl -u
+    // clawbox-setup -u clawbox-gateway`, and clawbox-gateway does not exist on
+    // Hermes — install removes and masks it — so on that edition the command
+    // read an empty log and never mentioned clawbox-hermes-dashboard, which is
+    // the one holding the answer. This module is bundled into the browser, so
+    // it cannot read the root-owned edition file to pick the right list.
+    //
+    // It does not need to: the agent has `logs_tail`, whose unit enum is
+    // already built per edition in mcp/tools/system.ts. Pointing at the tool
+    // instead of at a guessed command is both shorter and incapable of going
+    // stale the next time the unit set changes.
+    "Steps: read the relevant service logs with the `logs_tail` tool (it lists the services this device actually runs), check the failing command directly, and apply a concrete fix. Report back what you found and what you changed.",
   );
   return lines.join("\n");
 }

--- a/src/tests/routes/hermes-honest-settings.test.ts
+++ b/src/tests/routes/hermes-honest-settings.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Three OpenClaw-only controls that Settings offered to Hermes owners as if
+ * they worked.
+ *
+ * The Telegram one is the sharpest, because it is the exact shape this
+ * codebase has already been bitten by twice: a route answering
+ * `{restarted: true}` for a service that does not exist on the edition asking.
+ * `restartGateway()` returns immediately when `gatewayIsAbsent()`, so the
+ * "restart" always "succeeded".
+ */
+
+const readEdition = vi.fn<() => string>();
+vi.mock("@/lib/edition-source", () => ({ readEdition: () => readEdition() }));
+
+// The real module, except for the edition it resolves — everything else
+// (gatewayIsAbsent, readConfig's ENOENT behaviour) is exercised as shipped.
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(async () => undefined),
+  set: vi.fn(async () => {}),
+  setMany: vi.fn(async () => {}),
+}));
+
+function post(body: unknown): Request {
+  return new Request("http://localhost/setup-api", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  readEdition.mockReturnValue("hermes");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Telegram progress streaming on Hermes", () => {
+  it("does not claim a gateway it does not have was restarted", async () => {
+    // THE regression. `restartGateway()` is a no-op on Hermes, so the old code
+    // sailed past its own try/catch and answered `{success:true,
+    // restarted:true}` — for a setting living in `~/.openclaw/openclaw.json`,
+    // which Hermes neither has nor reads.
+    const route = await import("@/app/setup-api/telegram/streaming/route");
+    const res = await route.POST(post({ enabled: true }));
+    const body = await res.json();
+
+    expect(res.status).toBe(501);
+    expect(body.supported).toBe(false);
+    expect(body.restarted).toBeUndefined();
+    expect(body.success).toBeUndefined();
+  });
+
+  it("does not report the switch as already ON", async () => {
+    // `readConfig()` answers `{}` for a missing file, so the shipped
+    // expression `mode !== "off"` was `undefined !== "off"` — true. A Hermes
+    // owner opened Settings and found a feature they do not have turned on.
+    const route = await import("@/app/setup-api/telegram/streaming/route");
+    const body = await (await route.GET()).json();
+
+    expect(body.enabled).toBe(false);
+    expect(body.supported).toBe(false);
+  });
+
+  it("still works normally on the openclaw edition", async () => {
+    readEdition.mockReturnValue("openclaw");
+    const route = await import("@/app/setup-api/telegram/streaming/route");
+    const body = await (await route.GET()).json();
+
+    // No `supported:false` short-circuit — the real reader runs.
+    expect(body.supported).toBeUndefined();
+    expect(typeof body.enabled).toBe("boolean");
+  });
+});
+
+describe("Local-only mode on Hermes", () => {
+  it("refuses instead of leaking a CLI error into a red banner", async () => {
+    // Every path here calls `runOpenclawConfigSet`, which throws
+    // `OpenclawUnavailableError` on Hermes. The catch-all turned that into a
+    // 500 whose body SettingsApp painted verbatim: "The OpenClaw CLI is not
+    // available on this edition." That is our internals, in an error colour,
+    // for a control we chose to show them.
+    const route = await import("@/app/setup-api/local-ai/exclusive/route");
+    const res = await route.POST(post({ enabled: true }));
+    const body = await res.json();
+
+    expect(res.status).toBe(501);
+    expect(body.supported).toBe(false);
+    expect(body.error).not.toMatch(/CLI/i);
+  });
+
+  it("reports local-only as off rather than unknown", async () => {
+    const route = await import("@/app/setup-api/local-ai/exclusive/route");
+    const body = await (await route.GET()).json();
+
+    expect(body.enabled).toBe(false);
+    expect(body.supported).toBe(false);
+  });
+});
+
+describe("the Fix-it prompt", () => {
+  it("names no systemd unit, so it cannot name the wrong one", async () => {
+    // It used to hardcode `journalctl -u clawbox-setup -u clawbox-gateway`.
+    // clawbox-gateway is removed and masked on Hermes, so that read an empty
+    // log and never mentioned clawbox-hermes-dashboard. This module is bundled
+    // into the browser and cannot read the root-owned edition file, so the fix
+    // is to defer to `logs_tail`, whose enum is already per-edition.
+    const { buildFixErrorPrompt } = await import("@/lib/ui-events");
+    const prompt = buildFixErrorPrompt({ source: "Settings", message: "boom" });
+
+    expect(prompt).not.toContain("clawbox-gateway");
+    expect(prompt).toContain("logs_tail");
+  });
+});

--- a/src/tests/routes/system-hostname.test.ts
+++ b/src/tests/routes/system-hostname.test.ts
@@ -23,9 +23,14 @@ vi.mock("child_process", () => ({
     else cb(null, { stdout: result?.stdout ?? "", stderr: "" });
   },
 }));
+// `gatewayIsAbsent` decides whether the OpenClaw allowed-origins write happens
+// at all. Default false so these cases keep exercising the OpenClaw path they
+// were written for; the Hermes case below flips it.
+const gatewayIsAbsentMock = vi.fn(() => false);
 vi.mock("@/lib/openclaw-config", () => ({
   setControlUiAllowedOrigins: setControlUiAllowedOriginsMock,
   restartGateway: restartGatewayMock,
+  gatewayIsAbsent: gatewayIsAbsentMock,
 }));
 vi.mock("@/lib/config-store", () => ({
   get: getMock,
@@ -153,5 +158,24 @@ describe("/setup-api/system/hostname POST", () => {
     const mod = await import("@/app/setup-api/system/hostname/route");
     const res = await mod.POST(makeRequest({ hostname: "gracedeg" }));
     expect(res.status).toBe(200);
+  });
+
+  it("does not manufacture ~/.openclaw on an edition that has no gateway", async () => {
+    // `setControlUiAllowedOrigins` ends in `writeConfig`, which MKDIRs
+    // `~/.openclaw` and writes an allowedOrigins block — on the one SKU whose
+    // defining property is not having one, for a gateway that is removed and
+    // masked there and will never read it. The rename itself is unaffected,
+    // so this was never a false success; it is litter that makes `~/.openclaw`
+    // exist and misleads the next person debugging an edition question.
+    gatewayIsAbsentMock.mockReturnValue(true);
+    execFileMock.mockReturnValue({ stdout: "" });
+    setControlUiAllowedOriginsMock.mockResolvedValue(undefined);
+
+    const mod = await import("@/app/setup-api/system/hostname/route");
+    const res = await mod.POST(makeRequest({ hostname: "gracedeg" }));
+
+    expect(res.status).toBe(200);
+    expect(setControlUiAllowedOriginsMock).not.toHaveBeenCalled();
+    expect(restartGatewayMock).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/routes/system-hostname.test.ts
+++ b/src/tests/routes/system-hostname.test.ts
@@ -53,6 +53,10 @@ beforeEach(() => {
   restartGatewayMock.mockReset().mockResolvedValue(undefined);
   getMock.mockReset();
   setMock.mockReset().mockResolvedValue(undefined);
+  // Reset like the rest. `mockReturnValue` outlives the test that set it, so
+  // without this the gateway-absent case below would silently make every test
+  // added after it run on the Hermes branch.
+  gatewayIsAbsentMock.mockReset().mockReturnValue(false);
 });
 
 afterEach(async () => {


### PR DESCRIPTION
A Hermes parity sweep over every `setup-api` route, every MCP tool, the Settings panels and the setup wizard. Four findings, all one class: **the product presenting something as working on an edition that cannot do it.**

Scope note: these are bundled because three of the four land in `SettingsApp.tsx`, which several people are editing right now. Four PRs would mean four rebases on the same hot file for four ~5-line changes.

## 1. Telegram progress streaming reported `{restarted: true}` — FALSE SUCCESS

`src/app/setup-api/telegram/streaming/route.ts`

The setting lives at `channels.telegram.streaming.mode` in `~/.openclaw/openclaw.json`, and only the OpenClaw gateway reads it. Hermes runs Telegram out of `~/.hermes/.env` (`hermes-telegram.ts`) and has **no streaming concept at all** — zero hits for `stream`/`progress` in that module.

Ungated, both verbs lied, in the two worst ways available:

- **POST** `writeConfig()` **`mkdir`-ed `~/.openclaw`** on a box whose defining property is not having one, wrote a key nothing would ever read, then called `restartGateway()` — which returns immediately on Hermes (`gatewayIsAbsent()`, `openclaw-config.ts:1109`) — and answered `{success: true, restarted: true}`.
- **GET** `readConfig()` answers `{}` for a missing file, so the shipped expression `config.channels?.telegram?.streaming?.mode !== "off"` was `undefined !== "off"` → **`true`**. The switch rendered itself **already ON** before the owner touched anything.

`restarted: true` for a gateway that does not exist is the exact shape this codebase has already been bitten by. Sibling routes get this right — `telegram/configure:56` branches on the harness, `whatsapp/configure:47` answers 501 `{supported:false}` — so this now does the same.

**Telegram itself keeps working on Hermes.** Only this one row goes.

## 2. Local-only mode 500'd with our internals in the error — SHOULD-SAY-UNAVAILABLE

`src/app/setup-api/local-ai/exclusive/route.ts`

Every path calls `runOpenclawConfigSet`, which throws `OpenclawUnavailableError` when `openclawIsAbsent()`. The catch-all turned that into a **500 whose body `SettingsApp` paints verbatim into a red banner**: *"The OpenClaw CLI is not available on this edition."* That is our internals, in an error colour, for a control we chose to show them.

**Local AI itself works on Hermes** (`local-ai/route.ts:75` calls `removeLocalAiFromHermes`; `HERMES_LOCAL_PROVIDER_ID` is a real thing). Local-**only** mode does not: it is built from `agents.defaults.model.primary` + `fallbacks` + a sweep of `~/.openclaw/agents/*/sessions/sessions.json`, and `hermes-local-ai.ts` has no fallback chain to make exclusive. There is nothing to port, so the honest move is to say so.

Both routes now refuse with `supported: false`, and the card is hidden rather than left to fail. No half-applied state was possible (`currentPrimary` is `null` on Hermes, so `SAVED_PRIMARY_KEY` was never written before the throw) — this is purely about what the owner is shown.

## 3. The "Fix it" prompt pointed the agent at a nonexistent unit

`src/lib/ui-events.ts`

The desktop's "Fix it" button handed the agent `journalctl -u clawbox-setup -u clawbox-gateway -n 200`. `clawbox-gateway` is **removed and persistently masked** on Hermes, so half that command read an empty log — and `clawbox-hermes-dashboard`, the unit that would actually have the answer, was never named.

`ui-events.ts` is bundled into the browser, so it cannot read the root-owned edition file to pick the right list. It does not need to: the agent has `logs_tail`, whose unit enum is **already built per edition** (`mcp/tools/system.ts:332`). The prompt now points at the tool instead of guessing a command — shorter, and incapable of going stale the next time the unit set changes.

## 4. The hostname route manufactured `~/.openclaw` on Hermes — BROKEN-SILENT

`src/app/setup-api/system/hostname/route.ts:72`

`setControlUiAllowedOrigins(name)` ends in `writeConfig()`, which `mkdir`s `~/.openclaw` and writes a `gateway.controlUi.allowedOrigins` block for a gateway that is masked on that edition and will never read it. `restartGateway()` then no-ops.

**Not a false success** — the rename itself still happens via `clawbox-root-update@set_hostname.service` and the route's 200 is honest. But litter that makes `~/.openclaw` *exist* on the SKU whose whole point is not having one will mislead the next person debugging an edition question. Now skipped when `gatewayIsAbsent()`.

> **Open question for the Hermes owner, deliberately not guessed at:** whether Hermes needs its *own* allowed-origins update after a rename so the dashboard proxy keeps working at the new `<name>.local`. I could not determine that from the code and have not invented an answer. Filed rather than fixed.

## Tests

`src/tests/routes/hermes-honest-settings.test.ts` (6). Each asserts the *old* behaviour is gone: no `restarted` key in the Telegram response, `enabled: false` rather than the phantom `true`, no `/CLI/i` string in the local-only error, no `clawbox-gateway` in the prompt — plus one case pinning that the OpenClaw edition still takes the real path, so this is a gate and not a removal.

`eslint` 0 errors; `tsc --noEmit` **24 on this branch, 24 on `f75d8d1`, none in touched files**; 474 related existing tests (`*telegram*`, `*local-ai*`, settings components) all pass.

## Audited and found already correct — recorded so the next sweep can skip them

`setup/reset` (`gatewayIsPartOfThisEdition` + the entry-by-entry `.hermes` wipe), `updater.ts` (the `applies:` predicates and the `needsUpdate` arithmetic — no phantom "update available" on Hermes), `telegram/configure`, `discord/configure`, `whatsapp/*`, `apps/install`, `apps/settings`, `local-ai/route.ts`, `local-models`, `browser/manage`, `ai-models/catalog`, `harness/select`, `file-guard.ts` (`.hermes` is protected), `mcp/tools/system.ts` (`logs_tail` units, `backup_status`, `backup_now`), `desktop.ts` `app_uninstall`, `orientation.ts` `clawbox_health`, `SetupWizard.tsx` `pollHermesReady`, `TelegramConfiguringOverlay`, `page.tsx` `OPENCLAW_ONLY_APP_IDS`, and all of `harness/capabilities.ts`.

TASK-453's items (`skill_uninstall`, `app_uninstall` webapp leak, ClawHub ids, `ai_list_models`, MCP path echoes, tunnel status) were confirmed covered by #474 and deliberately not touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup behavior on editions without an OpenClaw gateway.
  * Unsupported Local-only and Telegram streaming settings now report clear disabled states instead of misleading errors.
  * Hostname updates continue to work when gateway services are unavailable.
  * Fix-it guidance now uses edition-compatible log diagnostics.

* **UI Improvements**
  * Hid unavailable Local-only and Telegram streaming controls on Hermes editions.

* **Tests**
  * Added coverage for unsupported settings, hostname updates, and edition-compatible troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->