### PR TITLE
fix: tell the running agent about the image backend linking installs

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -104,6 +104,31 @@ prompt-injection payload with a financial outcome. The plan is reported by
 
 There is also no thinking/reasoning setter yet — see "Work owned by others".
 
+### Pictures
+`image_generate` (both editions, **only where the box CANNOT draw**)
+
+The inverse of every other gate here: this one is registered when the probe says
+NO. On a box that can draw, the harness already has its own `image_generate` and
+a second one beside it would contradict it; on a box that cannot, there is no
+image tool at all — and an agent asked for a picture with no tool to draw it does
+not stop. Measured on a customer's device: it reached for the shell, hand-wrote
+an SVG, installed `cairosvg`, rasterised it, and then wrote itself a SKILL to do
+it again — producing files the chat cannot serve and telling the customer nothing
+about why. So the absence gets a voice: one tool, empty schema, whose whole job
+is to name the reason (ClawBox AI is not connected) and the fix (Settings → AI
+Providers) and to forbid improvising around it.
+
+The probe is `canGenerateImages` off `/setup-api/chat/capabilities`, resolved
+once at startup like the rest — so the same staleness the email tools had applies
+here, in both directions: after linking, the refusal must go, and the harness's
+own image tool must actually appear. Linking asks for both
+(`src/lib/hermes-image-refresh.ts`): `reload.env`, because the backend's
+credential lives in `~/.hermes/.env` and only reaches a running agent that way;
+then `reload.mcp`, which drops the refusal. Where the backend was installed into
+an agent that had already scanned its plugins — nothing reachable over the socket
+re-scans them — the dashboard is bounced instead, and only when its unit promises
+to come back.
+
 ### Device
 `system_stats` · `system_info` · `system_power` (needs `confirm: true` + a
 `reason`) · `disk_usage` · `disk_cleanup` · `update_check` (reports only, never

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -105,6 +105,7 @@ prompt-injection payload with a financial outcome. The plan is reported by
 There is also no thinking/reasoning setter yet — see "Work owned by others".
 
 ### Pictures
+
 `image_generate` (both editions, **only where the box CANNOT draw**)
 
 The inverse of every other gate here: this one is registered when the probe says

--- a/src/app/setup-api/clawkeep/restore/route.ts
+++ b/src/app/setup-api/clawkeep/restore/route.ts
@@ -5,6 +5,7 @@ import { NextRequest, NextResponse } from "next/server";
 
 import { ClawKeepError, RestoreNeedsPassphraseError, runRestore } from "@/lib/clawkeep";
 import { getEdition } from "@/lib/harness";
+import { HERMES_DASHBOARD_UNIT } from "@/lib/hermes-dashboard-auth";
 
 export const dynamic = "force-dynamic";
 
@@ -44,7 +45,7 @@ const exec = promisify(execFile);
 // quiet about it.
 function restartServicesFor(edition: string): string[] {
   return edition === "hermes"
-    ? ["clawbox-hermes-dashboard.service"]
+    ? [HERMES_DASHBOARD_UNIT]
     : ["clawbox-gateway.service"];
 }
 

--- a/src/lib/email-mcp-refresh.ts
+++ b/src/lib/email-mcp-refresh.ts
@@ -1,4 +1,4 @@
-import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
 
 /**
  * Ask Hermes to rebuild its MCP tool list when the mailbox becomes readable, or
@@ -24,21 +24,10 @@ import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
  * and 21 logged `43 tools`, the 41-tool starts all predating the mailbox
  * becoming readable, and the two missing tools were exactly these.
  *
- * The mechanism is Hermes' own. Its dashboard JSON-RPC socket accepts
- * `reload.mcp`; with `confirm: true` and NO `session_id` it runs
- * `shutdown_mcp_servers()` + `discover_mcp_tools()` globally, which is precisely
- * the respawn needed — the ClawBox server starts again and re-probes the gate,
- * and live sessions pick the new list up at their next turn boundary via
- * Hermes' own between-turns refresh. `confirm` is not optional: the call is
- * gated by `approvals.mcp_reload_confirm`, which defaults to true, and without
- * it the dashboard answers `{ status: "confirm_required" }` and does nothing.
+ * The mechanism is Hermes' own `reload.mcp`, and it is shared with the other
+ * family that has the same startup-only gate — see `hermes-mcp-reload.ts`. What
+ * belongs HERE is the rule for when it is worth paying for, below.
  */
-
-/**
- * Hermes' own confirmation flag for `reload.mcp`. Passing it is what makes the
- * call act rather than ask — see the note above.
- */
-const RELOAD_PARAMS = { confirm: true } as const;
 
 /**
  * Reload Hermes' MCP servers, but ONLY if this settings change flipped whether
@@ -60,8 +49,7 @@ const RELOAD_PARAMS = { confirm: true } as const;
  */
 export async function refreshEmailToolsIfReadabilityChanged(before: boolean, after: boolean): Promise<void> {
   if (before === after) return;
-  const result = await dashboardRpc("reload.mcp", RELOAD_PARAMS).catch(() => null);
-  if (result === null) {
+  if (!(await reloadMcpServers())) {
     // Logged, not surfaced. Worth a line because "the agent still cannot see my
     // mailbox" is otherwise invisible from the outside, and this is the one
     // place that knows the refresh was wanted and did not happen.

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1,5 +1,7 @@
 import { setMany } from "@/lib/config-store";
+import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli } from "@/lib/hermes-cli";
+import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { setHermesEnvValues } from "@/lib/hermes-env";
 import {
@@ -67,6 +69,12 @@ export async function applyClawaiToHermes(
     throw new ClawaiApplyError("Sign in to ClawBox AI first to get a device token.");
   }
   const model = clawaiModelForTier(tier);
+
+  // Read BEFORE anything is written, because the refresh at the bottom needs to
+  // know whether this call is what turned drawing on. `hermesConfigGet` is keyed
+  // on config.yaml's mtime, so on a box that has been asked this recently — the
+  // chat asks it on every open — this costs nothing.
+  const couldDrawBefore = await hermesAgentDrawsImages();
 
   const steps: string[][] = [
     ["config", "set", `providers.${CLAWAI_PROVIDER}.base_url`, CLAWBOX_AI_PROXY_URL],
@@ -172,6 +180,28 @@ export async function applyClawaiToHermes(
 
   // The device's provider/model just changed — don't serve the old selection.
   invalidateModelOptions();
+
+  // Everything above wrote to DISK. The agent that will serve the next turn is
+  // a process that has been running since long before any of it, and two of the
+  // things just written — the credential in `~/.hermes/.env` and the backend in
+  // `~/.hermes/plugins/` — are read once, at ITS startup. Without this the
+  // owner links, the chat reports `canGenerateImages: true` off the config, and
+  // the agent still has no `image_generate` to reach for. See
+  // hermes-image-refresh.ts for the measurement that found it.
+  //
+  // AWAITED rather than left floating: this call can restart the very dashboard
+  // the caller may talk to next, so it wants to be ordered rather than racing —
+  // and a floating promise here would outlive the response with nothing
+  // watching it. It cannot fail the link: the helper swallows everything and
+  // returns void.
+  //
+  // The AFTER value is re-READ rather than assumed from the try/catch above, so
+  // the refresh follows exactly the fact `/setup-api/chat/capabilities` serves
+  // — including the case where a customer had already selected a backend of
+  // their own by hand and our write failing changes nothing about what the box
+  // can do. `hermesConfigGet` is keyed on config.yaml's mtime, which the writes
+  // above just moved, so this sees the new value rather than a memo of the old.
+  await refreshHermesImageTools(couldDrawBefore, await hermesAgentDrawsImages());
 
   return { provider: CLAWAI_PROVIDER, model, tier };
 }

--- a/src/lib/hermes-dashboard-auth.ts
+++ b/src/lib/hermes-dashboard-auth.ts
@@ -11,6 +11,17 @@ import path from "path";
 // the Host header to that authority automatically, satisfying the dashboard's
 // DNS-rebind guard.
 
+/**
+ * The systemd unit that RUNS the dashboard this module talks to.
+ *
+ * Exported and named once because two unrelated callers spell it — a ClawKeep
+ * restore, which has to bounce it so the restored `state.db` is the one served,
+ * and the image refresh, which has to bounce it so a newly installed backend is
+ * discovered. A rename that reached only one of them would be a feature that
+ * half works, silently.
+ */
+export const HERMES_DASHBOARD_UNIT = "clawbox-hermes-dashboard.service";
+
 const DASH_HOST = process.env.HERMES_DASH_HOST || "127.0.0.2";
 const DASH_PORT = process.env.HERMES_PORT || "9119";
 const DASH_ORIGIN = `http://${DASH_HOST}:${DASH_PORT}`;

--- a/src/lib/hermes-dashboard-control.ts
+++ b/src/lib/hermes-dashboard-control.ts
@@ -1,0 +1,72 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { runHermesCli } from "@/lib/hermes-cli";
+import { HERMES_DASHBOARD_UNIT } from "@/lib/hermes-dashboard-auth";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Restarting the Hermes dashboard WITHOUT root.
+ *
+ * WHY THIS IS NOT `sudo systemctl restart`. There is deliberately no sudoers
+ * grant over any Hermes unit, and the reason is not caution about restarts:
+ * `systemctl restart` STARTS a stopped unit, so such a grant would let a
+ * customer on an OPENCLAW box resurrect the Hermes dashboard that the
+ * foreign-edition teardown had just stopped and disabled.
+ * `install-foreign-edition-teardown.test.ts` guards that invariant.
+ *
+ * So this asks for the one thing that is not privileged and not a resurrection:
+ * STOP the process. `hermes dashboard --stop` is upstream's own
+ * SIGTERM-grace-SIGKILL path — the unit runs it as its own `ExecStartPre` — and
+ * the unit's `Restart=always` turns the stop into a restart. A unit that is
+ * stopped and disabled stays that way, because there is no running process to
+ * stop and nothing to trigger. The capability and the invariant are both kept.
+ *
+ * WHY ANYONE WANTS IT. The dashboard is the process that serves chat, and it
+ * reads several things exactly once, when it starts: `~/.hermes/.env`, the
+ * plugin directories, and the state database. A change made underneath it —
+ * a restored backup, an image backend installed by linking ClawBox AI — is
+ * invisible to it until it comes back.
+ */
+
+/** How long the systemd query and the stop may take. Both are local. */
+const SYSTEMCTL_TIMEOUT_MS = 5_000;
+const STOP_TIMEOUT_MS = 15_000;
+
+/**
+ * Will systemd bring the dashboard back by itself?
+ *
+ * ASKED, NEVER ASSUMED, because the answer decides whether stopping the box's
+ * chat backend is a bounce or an outage. The shipped unit is `Restart=always`;
+ * on a box where it is not (a dev checkout running the dashboard by hand, an
+ * older unit file) the same call would leave the owner with no chat at all. No
+ * systemd, no unit, and a failed query all answer the same way, and that answer
+ * is the one that keeps the dashboard up.
+ *
+ * `systemctl show` is a READ, so it needs no privilege — which is the whole
+ * point of this module.
+ */
+async function restartsItself(): Promise<boolean> {
+  const { stdout } = await execFileAsync(
+    "/usr/bin/systemctl",
+    ["show", HERMES_DASHBOARD_UNIT, "--property=Restart", "--value"],
+    { timeout: SYSTEMCTL_TIMEOUT_MS },
+  ).catch(() => ({ stdout: "" }));
+  return stdout.trim() === "always";
+}
+
+/**
+ * Stop the dashboard so systemd starts it again, or answer false without
+ * touching it.
+ *
+ * NEVER THROWS. False means "this box was left exactly as it was" — either
+ * because nothing promised to restart it, or because the stop did not take —
+ * and every caller so far is in a position to say so and carry on.
+ */
+export async function bounceHermesDashboard(): Promise<boolean> {
+  if (!(await restartsItself())) return false;
+  const result = await runHermesCli(["dashboard", "--stop"], { timeoutMs: STOP_TIMEOUT_MS }).catch(
+    () => null,
+  );
+  return result?.code === 0;
+}

--- a/src/lib/hermes-image-refresh.ts
+++ b/src/lib/hermes-image-refresh.ts
@@ -1,0 +1,166 @@
+import { bounceHermesDashboard } from "@/lib/hermes-dashboard-control";
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
+
+/**
+ * Make the RUNNING Hermes serve the image backend that linking just installed.
+ *
+ * WHY THIS EXISTS. Linking ClawBox AI writes everything a Hermes box needs in
+ * order to draw — the backend into `~/.hermes/plugins/image_gen/clawai/`, the
+ * device token into `~/.hermes/.env`, and `image_gen.provider` into
+ * `config.yaml`. Two of those three are read ONCE, when the agent process
+ * starts, and the agent that serves chat is a long-lived service:
+ *
+ *   - the CREDENTIAL. `plugins/image_gen/clawai/__init__.py` reads it through
+ *     `agent.secret_scope.get_secret`, which on a single-profile box is
+ *     `os.environ` — and `~/.hermes/.env` reaches `os.environ` only via
+ *     `load_hermes_dotenv()` at entrypoint startup. Upstream knows: its own
+ *     `/reload` exists to "pick up new API keys without restarting".
+ *   - the BACKEND. `check_image_generation_requirements()` resolves it with
+ *     `get_provider(image_gen.provider)`, a plain registry lookup filled by
+ *     plugin discovery. `_ensure_plugins_discovered()` returns early once the
+ *     manager has run, and nothing reachable over the dashboard socket passes
+ *     its `force` flag — so a plugin installed after that is never seen.
+ *
+ * Measured on the owner's box (2026-08-27): linking at 09:08:52 into a
+ * dashboard that had started the previous day at 08:30:58, then a picture asked
+ * for at 09:10:07 —
+ *
+ *   tools.registry: check_fn check_image_generation_requirements returned
+ *   False; dependent tools will be unavailable this turn
+ *
+ * The box's own `/setup-api/chat/capabilities` said `hermesAgentDrawsImages:
+ * true` the whole time, because that fact reads `config.yaml`, which IS re-read
+ * per turn. So the chat promised a picture the agent had no tool to make, and
+ * the agent did what an agent with no tool does: it improvised. At 09:11:54 it
+ * had hand-written a script that produced a PNG outside the tool path, and by
+ * 09:13:27 it had written ITSELF a skill to do it again.
+ *
+ * THE THIRD THING this fixes is the ClawBox MCP server's own view. It probes
+ * `canGenerateImages` once at startup (mcp/lib/context.ts) and registers an
+ * honest-refusal `image_generate` only where the answer is no. Left stale, that
+ * refusal survives the link and tells a linked owner to go and link — the exact
+ * failure #486 fixed for `email_list`/`email_read`, and with the same mechanism.
+ *
+ * THE DEEPER FIX, named here so this reads as the bridge it is: install the
+ * backend BEFORE the process that scans for it starts, and a link changes only
+ * the credential — which is exactly what `reload.env` is for, and the probe and
+ * the bounce below both disappear. That does nothing for the boxes already
+ * running, which is why this ships first.
+ */
+
+/**
+ * Bound on the two CHEAP dashboard calls.
+ *
+ * `dashboardRpc`'s own default is 20 s, sized for `reload.mcp` — which kills and
+ * respawns every MCP child and waits for each to hand back its tool list.
+ * `reload.env` and the probe are in-process reads that answer in milliseconds,
+ * and this whole helper runs inside a request the owner is holding open. The two
+ * branches below are exclusive, so the worst case is bounded at roughly half a
+ * minute either way: 6 + 6 + 20 through the reload, 6 + 6 + 5 + 15 through the
+ * bounce.
+ */
+const QUICK_RPC_TIMEOUT_MS = 6_000;
+
+/**
+ * What the RUNNING agent says about its own ability to draw, or null when it
+ * could not be asked.
+ *
+ * `image.generate` with `probe: true` is upstream's own availability question
+ * and it runs `check_image_generation_requirements()` INSIDE the process that
+ * will serve the next turn — which is the only process whose answer matters
+ * here. Nothing is generated and no allowance is spent.
+ *
+ * THE NULL IS LOAD-BEARING and must not be folded into `false`: the penalty for
+ * a false is a SIGTERM, and the likeliest reason a local dashboard fails to
+ * answer in six seconds is that it is busy serving a turn. Bouncing a box for
+ * being busy would be this helper damaging a device that was working.
+ */
+async function runningAgentCanDraw(): Promise<boolean | null> {
+  const result = (await dashboardRpc(
+    "image.generate",
+    { probe: true },
+    { timeoutMs: QUICK_RPC_TIMEOUT_MS },
+  ).catch(() => null)) as { available?: unknown } | null;
+  return typeof result?.available === "boolean" ? result.available : null;
+}
+
+/** Ask for the MCP tool list to be rebuilt, and say so when it is not. */
+async function reloadMcpTools(why: string): Promise<void> {
+  if (await reloadMcpServers()) return;
+  // Logged, not surfaced. Worth a line because "the agent still refuses to draw"
+  // is otherwise invisible from the outside, and this is the one place that
+  // knows the refresh was wanted and did not happen.
+  console.error(`[hermes/image-refresh] ${why}, but Hermes would not reload its MCP servers`);
+}
+
+/**
+ * Reconcile every surface that answers "can this box draw" with the state
+ * linking just wrote.
+ *
+ * NEVER THROWS AND NEVER REPORTS, exactly like its email sibling. It runs on a
+ * path the owner is already waiting on, the writes it is catching up to have
+ * ALREADY happened, and a box whose dashboard is down is a perfectly ordinary
+ * box — so the worst case is a logged line and a tool list that catches up at
+ * the next restart, which is the behaviour of every box before this existed.
+ *
+ * TWO GATES, not one, because the two stale things have two lifetimes. The MCP
+ * tool list depends only on WHETHER the box can draw, so it is reloaded only on
+ * a FLIP — the same rule, and the same prompt-cache reason, as the email
+ * sibling's, and it matters more here than there because this path is also the
+ * Settings AI save and every tier change. The running agent's own state depends
+ * on the CREDENTIAL too, so it is reconciled whenever the box can draw at all:
+ * a re-link with a fresh device token leaves `before === after` and would
+ * otherwise strand the agent on a credential that no longer works.
+ *
+ * @param before what `hermesAgentDrawsImages()` said BEFORE the writes
+ * @param after  what it says after — the same fact
+ *               `/setup-api/chat/capabilities` serves, so the agent's tools and
+ *               the customer's chat cannot disagree about this box.
+ */
+export async function refreshHermesImageTools(before: boolean, after: boolean): Promise<void> {
+  if (!after) {
+    // The box cannot draw. The only stale thing is the MCP server's view, and
+    // the tool it owes an owner here is the honest refusal — a linked-looking
+    // box with no backend must say so rather than let the agent improvise.
+    if (before) await reloadMcpTools("this box can no longer draw");
+    return;
+  }
+
+  // 1. The credential. Cheap, and on a box whose agent already knows the
+  //    backend it is the whole fix.
+  await dashboardRpc("reload.env", {}, { timeoutMs: QUICK_RPC_TIMEOUT_MS }).catch(() => null);
+
+  // 2. Ask the agent itself whether that was enough. The answer separates the
+  //    two failures that look identical from out here: a stale credential
+  //    (fixed above) and a backend the process never discovered (not fixable
+  //    from out here at all).
+  const live = await runningAgentCanDraw();
+
+  if (live === true) {
+    // The agent can draw. The MCP server may still be holding the refusal tool
+    // it registered when it could not — drop it now, in the same breath.
+    if (!before) await reloadMcpTools("the agent can draw");
+    return;
+  }
+
+  if (live === null) {
+    // Asked and got no answer. Nothing here knows whether this box needs a
+    // bounce, and a bounce is not the kind of thing to do on a guess.
+    console.error("[hermes/image-refresh] the Hermes dashboard did not say whether it can draw; left it alone");
+    return;
+  }
+
+  // 3. The agent SAYS no with the credential freshly loaded, so the backend was
+  //    installed into a process that had already scanned for plugins. Only a
+  //    restart re-scans, and the bounce respawns the MCP child with it, so no
+  //    reload is wanted after this one.
+  if (await bounceHermesDashboard()) {
+    console.log("[hermes/image-refresh] bounced the Hermes dashboard so it picks up the image backend");
+    return;
+  }
+
+  console.error(
+    "[hermes/image-refresh] the image backend is installed but the running agent cannot see it; restart the agent to enable pictures",
+  );
+}

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -1,0 +1,45 @@
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+
+/**
+ * Ask Hermes to rebuild its MCP tool list, for every caller that needs to.
+ *
+ * WHY THERE IS A CALLER AT ALL. The ClawBox MCP server probes what this device
+ * can do ONCE, while it boots (`mcp/lib/context.ts`), and registers or withholds
+ * whole tool families on the answer — the mailbox read tools, the coding-agent
+ * family, the honest-refusal `image_generate`. It is then a long-lived stdio
+ * child of the agent, so a setting the owner changes underneath it never reaches
+ * the tool list until something respawns the server.
+ *
+ * The mechanism is Hermes' own: its dashboard JSON-RPC socket accepts
+ * `reload.mcp`, and with `confirm: true` and NO `session_id` it runs
+ * `shutdown_mcp_servers()` + `discover_mcp_tools()` globally — the ClawBox server
+ * starts again and re-probes, and live sessions pick the new list up at their
+ * next turn boundary via Hermes' own between-turns refresh.
+ *
+ * IT IS NOT FREE, which is why this is a plain call and not something a caller
+ * fires on every save: the reload kills and respawns every MCP child process and
+ * invalidates the model's prompt cache, so the next turn re-sends and re-pays for
+ * a system prompt that was cached. Each caller owns the rule for WHEN that is
+ * worth it, and each says so where it decides.
+ */
+
+/**
+ * Hermes' own confirmation flag. Passing it is what makes the call act rather
+ * than ask: `reload.mcp` is gated by `approvals.mcp_reload_confirm`, which
+ * defaults to true, and without this the dashboard answers
+ * `{ status: "confirm_required" }` and does nothing.
+ */
+const RELOAD_PARAMS = { confirm: true } as const;
+
+/**
+ * True when Hermes agreed to reload, false when it could not be asked.
+ *
+ * Never throws, and deliberately does not distinguish between the ways "no"
+ * happens — no dashboard, a socket that died, an error frame. A caller that
+ * cannot fix any of those does not benefit from telling them apart; what it
+ * does with the false is say so in its own words.
+ */
+export async function reloadMcpServers(): Promise<boolean> {
+  const result = await dashboardRpc("reload.mcp", RELOAD_PARAMS).catch(() => null);
+  return result !== null;
+}

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -20,8 +20,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const cliMock = vi.hoisted(() => vi.fn());
 const envMock = vi.hoisted(() => vi.fn());
 const installMock = vi.hoisted(() => vi.fn());
+const drawsMock = vi.hoisted(() => vi.fn());
+const refreshMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+// The two halves of "and then tell the RUNNING agent". The fact is mocked so a
+// case can say what the writes ended up meaning; the refresh is mocked because
+// what belongs here is that it is CALLED with that fact — what it then does
+// with it has its own suite (hermes-image-refresh.test.ts).
+vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsMock }));
+vi.mock("@/lib/hermes-image-refresh", () => ({ refreshHermesImageTools: refreshMock }));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));
@@ -49,7 +57,12 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     cliMock.mockReset();
     envMock.mockReset();
     installMock.mockReset();
+    drawsMock.mockReset();
+    refreshMock.mockReset();
     cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    // Called twice per link: once before the writes, once after. The default is
+    // the ordinary case — a box that could not draw, and now can.
+    drawsMock.mockResolvedValueOnce(false).mockResolvedValue(true);
   });
 
   it("installs the backend and names it as the one to use", async () => {
@@ -162,13 +175,30 @@ describe("enabling image generation when ClawBox AI is linked", () => {
     // Drawing is an extra. Chat, vision and transcription are not, and a box
     // that could not copy a Python file must not be left unable to talk.
     installMock.mockRejectedValue(new Error("EACCES"));
+    // And the box now reads as one that cannot draw, which is the fact the
+    // refresh is handed — the half that keeps #497's honest refusal alive.
+    drawsMock.mockResolvedValue(false);
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const result = await applyClawaiToHermes("claw_token_abc", "flash");
     expect(result.provider).toBe("clawai");
     expect(sets()).toContain("model.provider=clawai");
+    expect(refreshMock).toHaveBeenCalledWith(false, false);
     // The failure is named in the journal, and the token is not.
     expect(warn.mock.calls.flat().join(" ")).not.toContain("claw_token_abc");
     warn.mockRestore();
+  });
+
+  it("tells the RUNNING agent about the backend it just installed", async () => {
+    // The writes above all land on DISK. The agent that serves the next turn is
+    // a process that started long before them and reads its credential and its
+    // plugin list exactly once — at ITS startup. Measured on the owner's box
+    // (2026-08-27): linked at 09:08:52 into a dashboard up since the previous
+    // day, and the 09:10:07 request for a picture found no `image_generate` at
+    // all. A link that only writes files is a link the agent never hears about.
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    // Both values, because the two stale things have two lifetimes: the MCP
+    // tool list turns on the FLIP, the running agent's credential does not.
+    expect(refreshMock).toHaveBeenCalledWith(false, true);
   });
 
   it("does not stop the link when a config write for images fails", async () => {

--- a/src/tests/unit/hermes-dashboard-control.test.ts
+++ b/src/tests/unit/hermes-dashboard-control.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Restarting the chat backend without root — and, far more importantly, NOT
+ * restarting it when nothing is going to bring it back.
+ *
+ * The whole module is one dangerous verb behind one guard. `hermes dashboard
+ * --stop` is the only unprivileged way to make the dashboard re-read its `.env`
+ * and re-scan its plugins, because repo policy deliberately refuses a
+ * `systemctl` sudoers grant over any Hermes unit — a `restart` grant would let
+ * an OpenClaw box resurrect the dashboard its foreign-edition teardown just
+ * disabled. So the stop is safe exactly when systemd promises to start it
+ * again, and this suite is about that promise.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("child_process", () => ({ execFile: execFileMock }));
+
+import { bounceHermesDashboard } from "@/lib/hermes-dashboard-control";
+
+/** `systemctl show … --property=Restart --value` prints `value`. */
+function systemdRestartPolicy(value: string): void {
+  execFileMock.mockImplementation((_bin: string, _args: string[], _opts: unknown, cb: unknown) => {
+    (cb as (e: Error | null, out: { stdout: string; stderr: string }) => void)(null, {
+      stdout: `${value}\n`,
+      stderr: "",
+    });
+  });
+}
+
+/** The argv of the `systemctl` read, so the query itself can be asserted. */
+function systemctlCall(): [string, string[]] {
+  const [bin, args] = execFileMock.mock.calls[0] as [string, string[]];
+  return [bin, args];
+}
+
+beforeEach(() => {
+  cliMock.mockReset();
+  execFileMock.mockReset();
+  cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  systemdRestartPolicy("always");
+});
+
+describe("bounceHermesDashboard", () => {
+  it("stops the dashboard when systemd promises to start it again", async () => {
+    await expect(bounceHermesDashboard()).resolves.toBe(true);
+    expect(cliMock).toHaveBeenCalledWith(["dashboard", "--stop"], expect.anything());
+  });
+
+  it("asks systemd BEFORE it stops anything", async () => {
+    await bounceHermesDashboard();
+    const [bin, args] = systemctlCall();
+    // Absolute path, like every other systemctl call site in the repo, and a
+    // READ — this module must never need a privilege it cannot have.
+    expect(bin).toBe("/usr/bin/systemctl");
+    expect(args).toEqual([
+      "show",
+      "clawbox-hermes-dashboard.service",
+      "--property=Restart",
+      "--value",
+    ]);
+  });
+
+  it("refuses to stop a dashboard that nothing will restart", async () => {
+    // A dev checkout running the dashboard by hand, or an older unit file. The
+    // stop would leave the owner with no chat at all, which is far worse than
+    // whatever staleness the caller was trying to clear.
+    systemdRestartPolicy("no");
+    await expect(bounceHermesDashboard()).resolves.toBe(false);
+    expect(cliMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses when systemd cannot be asked", async () => {
+    // No systemd, no unit, a failed query: none of them is a promise, and the
+    // answer that keeps the dashboard up is the same for all three.
+    execFileMock.mockImplementation((_bin: string, _args: string[], _opts: unknown, cb: unknown) => {
+      (cb as (e: Error) => void)(new Error("no such unit"));
+    });
+    await expect(bounceHermesDashboard()).resolves.toBe(false);
+    expect(cliMock).not.toHaveBeenCalled();
+  });
+
+  it("reports false when the stop itself did not take", async () => {
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "unkillable" });
+    await expect(bounceHermesDashboard()).resolves.toBe(false);
+  });
+
+  it("does not throw when the CLI is missing entirely", async () => {
+    cliMock.mockRejectedValue(new Error("ENOENT"));
+    await expect(bounceHermesDashboard()).resolves.toBe(false);
+  });
+});

--- a/src/tests/unit/hermes-image-refresh.test.ts
+++ b/src/tests/unit/hermes-image-refresh.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Linking ClawBox AI under a RUNNING agent has to make that agent able to draw.
+ *
+ * The bug this pins is measured rather than imagined — the timeline is recorded
+ * once, in `src/lib/hermes-image-refresh.ts`. What the cases below are for is
+ * the three states a box can be in after a link, and the cheapest correct action
+ * for each: a stale credential (reload it), a backend the agent never scanned
+ * (bounce it), and a dashboard that will not say (leave it alone).
+ */
+
+const rpcMock = vi.hoisted(() => vi.fn());
+const bounceMock = vi.hoisted(() => vi.fn());
+const reloadMcpMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
+vi.mock("@/lib/hermes-dashboard-control", () => ({ bounceHermesDashboard: bounceMock }));
+vi.mock("@/lib/hermes-mcp-reload", () => ({ reloadMcpServers: reloadMcpMock }));
+
+import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
+
+/**
+ * The running agent answers the `image.generate` probe with `available`, or —
+ * for `null` — does not answer at all, which is what `dashboardRpc` reports as
+ * a dead socket, a timeout or an error frame.
+ */
+function agentSaysItCanDraw(available: boolean | null): void {
+  rpcMock.mockImplementation(async (method: string) =>
+    method === "image.generate" ? (available === null ? null : { available }) : { status: "ok" },
+  );
+}
+
+/** Every RPC method asked for, in order. */
+function methods(): string[] {
+  return rpcMock.mock.calls.map((call) => call[0] as string);
+}
+
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  bounceMock.mockReset();
+  reloadMcpMock.mockReset();
+  bounceMock.mockResolvedValue(true);
+  reloadMcpMock.mockResolvedValue(true);
+  agentSaysItCanDraw(true);
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe("refreshHermesImageTools", () => {
+  it("makes a newly linked box able to draw WITHOUT a restart when only the credential was stale", async () => {
+    // The common case, and the one the whole helper is sized for: the backend
+    // was already on disk when the agent last started, so all it was missing is
+    // the token that linking just wrote to ~/.hermes/.env.
+    await refreshHermesImageTools(false, true);
+
+    // The credential first, because it is the cheap half and on this box it is
+    // the whole fix — and `probe: true` is what makes the second call a
+    // question rather than a generation: it runs upstream's own
+    // `check_image_generation_requirements()` in the process that will serve the
+    // next turn, spends no allowance and returns no picture.
+    expect(methods()).toEqual(["reload.env", "image.generate"]);
+    expect(rpcMock).toHaveBeenCalledWith("image.generate", { probe: true }, expect.anything());
+    // #497 registers an `image_generate` that only explains why it cannot run,
+    // and only where the box cannot draw. The MCP server probes that once at
+    // startup, so without this the refusal outlives the link and tells a linked
+    // owner to go and link.
+    expect(reloadMcpMock).toHaveBeenCalledTimes(1);
+    // And nothing was restarted: a bounce here would cost the owner their chat
+    // backend to fix something that was already fixed.
+    expect(bounceMock).not.toHaveBeenCalled();
+  });
+
+  it("bounces the dashboard when the agent still cannot see the backend", async () => {
+    // The owner's actual box. `reload.env` fixes the credential and the agent
+    // STILL says no, because `_ensure_plugins_discovered()` returns early once
+    // the manager has run and nothing reachable over the socket passes `force`.
+    // A restart is the only thing that re-scans.
+    agentSaysItCanDraw(false);
+
+    await refreshHermesImageTools(false, true);
+
+    expect(bounceMock).toHaveBeenCalledTimes(1);
+    // No MCP reload after a bounce: the restart respawns the MCP child with the
+    // dashboard, so asking for one would be paying twice.
+    expect(reloadMcpMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT bounce a dashboard that merely failed to answer", async () => {
+    // The difference between "it said no" and "it said nothing" is the
+    // difference between a fix and an outage: the likeliest reason a local
+    // dashboard misses a six-second deadline is that it is busy serving a turn,
+    // and a SIGTERM is not the response to being busy.
+    agentSaysItCanDraw(null);
+
+    await refreshHermesImageTools(false, true);
+
+    expect(bounceMock).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("reloads the credential even when nothing about the box's answer changed", async () => {
+    // Re-linking with a fresh device token, or a tier change: `before` and
+    // `after` are both true, and the running agent is still holding the OLD
+    // credential. The email sibling's flip guard would skip this; here it must
+    // not, because the credential is a second thing that goes stale.
+    await refreshHermesImageTools(true, true);
+
+    expect(methods()).toContain("reload.env");
+    // The MCP tool list, though, depends only on WHETHER the box can draw — and
+    // that did not change, so the owner does not pay for a respawned tool set
+    // and a re-sent system prompt.
+    expect(reloadMcpMock).not.toHaveBeenCalled();
+  });
+
+  it("restores the honest refusal when the box stops being able to draw", async () => {
+    // The other direction, and the one that keeps #497's win intact. A box whose
+    // image backend went away must get the refusal tool back, so the agent says
+    // why instead of improvising a file the chat cannot serve.
+    await refreshHermesImageTools(true, false);
+
+    expect(reloadMcpMock).toHaveBeenCalledTimes(1);
+    // Nothing else is touched: there is no credential worth reloading into a
+    // process that has no backend to spend it through, and nothing to bounce for.
+    expect(methods()).toEqual([]);
+    expect(bounceMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing at all for a box that could not draw before and still cannot", async () => {
+    await refreshHermesImageTools(false, false);
+
+    expect(methods()).toEqual([]);
+    expect(reloadMcpMock).not.toHaveBeenCalled();
+    expect(bounceMock).not.toHaveBeenCalled();
+  });
+
+  it("never sends a session id — every reload has to be global", async () => {
+    await refreshHermesImageTools(false, true);
+
+    for (const [, params] of rpcMock.mock.calls) {
+      expect(params).not.toHaveProperty("session_id");
+    }
+  });
+
+  it("says so when Hermes will not rebuild its tool list", async () => {
+    reloadMcpMock.mockResolvedValue(false);
+
+    await refreshHermesImageTools(false, true);
+
+    // Logged, because "the agent still refuses to draw" is otherwise invisible
+    // from the outside.
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("says so when the backend is installed and the bounce was refused", async () => {
+    // A box whose unit is not `Restart=always` — a dev checkout, an older unit
+    // file. The dashboard is deliberately left up, and the owner is told what
+    // to do about it rather than left with a silently broken feature.
+    agentSaysItCanDraw(false);
+    bounceMock.mockResolvedValue(false);
+
+    await refreshHermesImageTools(false, true);
+
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not throw when the dashboard cannot be reached at all", async () => {
+    // An OpenClaw box has no dashboard; a Hermes box can have one that is down.
+    // Neither may turn a successful link into an error.
+    rpcMock.mockResolvedValue(null);
+    bounceMock.mockResolvedValue(false);
+
+    await expect(refreshHermesImageTools(false, true)).resolves.toBeUndefined();
+  });
+
+  it("does not throw when the RPC helper itself rejects", async () => {
+    rpcMock.mockRejectedValue(new Error("socket exploded"));
+    bounceMock.mockResolvedValue(false);
+
+    await expect(refreshHermesImageTools(false, true)).resolves.toBeUndefined();
+    await expect(refreshHermesImageTools(true, false)).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The bug

An owner linked ClawBox AI on a running Hermes box and then could not get a picture.

Linking writes three things: the image backend into `~/.hermes/plugins/image_gen/clawai/`, the device token into `~/.hermes/.env`, and `image_gen.provider` into `config.yaml`. The agent process that serves chat re-reads `config.yaml` per turn, and reads the other two **exactly once, when it starts**:

- the credential reaches `os.environ` only through `load_hermes_dotenv()` at entrypoint startup — upstream's own `/reload` exists because of this;
- `check_image_generation_requirements()` resolves the backend with `get_provider(image_gen.provider)`, a registry filled by plugin discovery, and `_ensure_plugins_discovered()` returns early once the manager has run.

So on a box whose agent was already up, linking left it with **no image tool at all**, while `/setup-api/chat/capabilities` — reading `config.yaml` — reported `hermesAgentDrawsImages: true`.

### Evidence from the device

```
09:08:52  ~/.hermes/.env and the clawai plugin written   (the link)
09:08:57  config.yaml written
09:10:07  tools.registry: check_fn check_image_generation_requirements
          returned False; dependent tools will be unavailable this turn
09:11:54  a PNG appears from a hand-written script, outside the tool path
09:13:27  the agent writes ITSELF a "clawbox-ai-images" skill to do it again
```

The dashboard process serving those turns had started the previous day at 08:30:58. Asked directly over its own socket, it answered `image.generate {probe:true}` → `{"available": false}` on a box whose capabilities said it could draw, and its plugin registry listed the seven bundled `image_gen/*` backends and no `clawai`.

The chat promised a picture the agent had no tool to make, so the agent improvised — which is precisely the failure #497's honest-refusal tool exists to prevent, arriving through the door #497 could not see.

## The fix

Linking now reconciles the running process, the same way #486 does for the mailbox tools.

1. **`reload.env`** — carries the credential into the running agent. On a box whose agent already knows the backend, this is the whole fix.
2. **`image.generate {probe: true}`** — asks the agent itself whether that was enough. Only that process can answer; nothing is generated and no allowance is spent.
3. **`reload.mcp`** where it was — dropping the honest-refusal `image_generate` the MCP server registered while the box could not draw, which is otherwise stale until something respawns the server.
4. **A bounce** where it was not — the backend was installed into a process that had already scanned its plugins, and nothing reachable over the socket re-scans them.

The bounce is `hermes dashboard --stop` under the unit's own `Restart=always`, guarded on a `systemctl show` read of that policy. It stays unprivileged on purpose: no Hermes unit may have a `systemctl` sudoers grant, because a `restart` grant would let an OpenClaw box resurrect the dashboard its foreign-edition teardown just disabled. A dashboard that does not *answer* the probe is left strictly alone — being busy serving a turn is not a reason to SIGTERM it.

**Two gates, not one.** The MCP tool list depends only on *whether* the box can draw, so it reloads on a flip — the same prompt-cache reasoning as the email sibling, and it matters more here because this path is also the Settings AI save and every tier change. The running agent's state also depends on the *credential*, so it is reconciled whenever the box can draw at all: a re-link with a fresh token leaves `before === after` and would otherwise strand the agent on a credential that no longer works.

`reload.mcp` moves into `hermes-mcp-reload.ts`, shared with the email refresh; the unprivileged bounce into `hermes-dashboard-control.ts`, and `HERMES_DASHBOARD_UNIT` is now named once.

## Verified on the device

Bounced the owner's box through the exact path the fix takes, then:

- `image.generate {probe:true}` → `{"available": true}` (was `false`)
- a real generation → `success: true`, `clawai_20260827_095953_bf188c16.png`, 1,128,759 bytes, produced by the `clawai` backend through the ClawBox AI proxy
- the dashboard came back on its own in seconds, a fresh MCP child re-probed, and no chat content was read

## Tests

`hermes-image-refresh.test.ts` (11) covers the three states a box can be in after a link and both directions of the flip: a stale credential fixed without a restart, a backend the agent never scanned bounced, a dashboard that will not answer left alone, a re-link that reloads the credential but not the tool list, and the honest refusal restored when the box stops being able to draw. `hermes-dashboard-control.test.ts` (6) pins the guard — it must refuse to stop a dashboard nothing will restart. `hermes-clawai-images.test.ts` gains the two assertions that linking hands the refresh the truth in both outcomes.

Zero new lint or `tsc` findings against the `beta` baseline; the pre-existing failures on the dev host are identical before and after.

## Follow-ups, deliberately not in here

- **Install the backend before the process that scans for it starts.** Then a link only ever changes the credential, `reload.env` is the whole mechanism, and the probe and the bounce both disappear. It does nothing for boxes already running, which is why this ships first — the bounce is a bridge, not the design.
- **Make `hermesAgentDrawsImages` ask the running agent.** This PR proves `config.yaml` can lie, obtains the truer answer, and throws it away. An honest `false` would also hand the customer the working composer button instead of a broken agent path.
- **The `hermes gateway` process is untouched** — a linked box whose owner asks the Telegram bot for a picture stays stale until that unit restarts.
- **`coding_agent_*` has the same startup-only gate with no refresh at all**: flipping the owner's switch leaves the agent without the tools it was just granted. `hermes-mcp-reload.ts` is now the shared place to fix that.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic refreshing of image-generation tools after connecting an AI agent.
  * Image tools now update when image-generation capabilities change, including restoring fallback behavior.
  * Improved dashboard recovery when newly enabled tools require a refresh.

* **Documentation**
  * Added MCP documentation for the image-generation tool, availability, and refresh behavior.

* **Bug Fixes**
  * Improved reliability of service restarts and MCP tool reloading during configuration and email integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->