### PR TITLE
fix: repair the Kokoro model pre-download and stop its failure reading as success

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -120,6 +120,10 @@ CLAWBOX_HOME="/home/clawbox"
 # exits non-zero, and a machine-readable marker is left for the flash host.
 PROVISION_FAILURES=()
 PROVISION_STATUS_FILE="${CLAWBOX_PROVISION_STATUS_FILE:-/etc/clawbox/provision-status}"
+# The on-device TTS verdict, written by scripts/install-voice.sh and read by
+# step_validate_services. Exported to that script rather than defaulted twice,
+# so the writer and the reader cannot drift onto two different paths.
+TTS_STATUS_FILE="${CLAWBOX_TTS_STATUS_FILE:-/etc/clawbox/tts-status}"
 # Identifies THIS run. Stamped into the marker and printed on stdout, so a
 # reader holding both can tell whose verdict it is looking at.
 PROVISION_RUN_ID="$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || echo unknown)-$$"
@@ -1566,7 +1570,14 @@ step_openclaw_setup() {
   step_openclaw_install
   step_openclaw_patch
   step_openclaw_config
-  step_openclaw_tts
+  # Non-fatal by design: a box that could not install GPU TTS must still finish
+  # provisioning and come up reachable on the CPU fallback. NOT silent, though —
+  # the step has already recorded the failure with record_provision_failure, so
+  # the final summary, install.sh's exit status and the provisioning marker all
+  # carry it, and step_validate_services fails its TTS check below. Swallowing
+  # the status here without that record is what let "flashed successfully" and
+  # "the GPU TTS silently did not install" mean the same thing.
+  step_openclaw_tts || echo "  Warning: openclaw_tts reported a failure (recorded above; provisioning continues)"
 }
 
 # Install the Hermes agent (git-based install into ~/.hermes). Needed by every
@@ -2517,13 +2528,41 @@ step_openclaw_tts() {
   # path, it reports whether Kokoro is actually there so the summary below can
   # tell the truth instead of asserting it.
   local VOICE_RC=0
-  bash "$PROJECT_DIR/scripts/install-voice.sh" --tts-only || VOICE_RC=$?
+  CLAWBOX_TTS_STATUS_FILE="$TTS_STATUS_FILE" \
+    bash "$PROJECT_DIR/scripts/install-voice.sh" --tts-only || VOICE_RC=$?
   local KOKORO_READY=false KOKORO_REASON=""
+  # The status this STEP returns, separate from whether TTS could be configured.
+  # A Kokoro that was asked for and did not arrive is a failure of this step
+  # even though the box keeps a working (CPU) voice — see the block under
+  # VOICE_RC=12 below.
+  local TTS_RC=0
   case "$VOICE_RC" in
     0)  KOKORO_READY=true ;;
     10) KOKORO_REASON="no CUDA toolkit on this board" ;;
     11) KOKORO_REASON="no Jetson CUDA build for this CPU architecture" ;;
-    12) KOKORO_REASON="the Kokoro GPU install failed, see the log above" ;;
+    12) KOKORO_REASON="the Kokoro GPU install failed, see the log above"
+        # ── A hard failure must stop arriving as a soft fallback ─────────────
+        # This is the branch that made a shipped defect invisible. Kokoro's
+        # model pre-download died on a shell syntax error, this step printed one
+        # ERROR line, returned 0, and the flash reported "Setup: 1/1 succeeded"
+        # — so every box installed in that window ran CPU Piper while the
+        # install claimed GPU TTS, and nobody noticed because speech still
+        # worked. 10 and 11 deliberately do NOT come through here: "this board
+        # has no CUDA" is a box that was never going to have Kokoro, which is a
+        # different fact from "the GPU engine you asked for did not install".
+        #
+        # Non-fatal stays non-fatal — the caller decides, the provider is still
+        # configured below, and the box keeps its voice — but the failure now
+        # reaches the run's exit status, the provisioning summary, the marker
+        # the flash host reads, and step_validate_services' checks.
+        TTS_RC=12
+        echo "  ############################################################" >&2
+        echo "  # Kokoro GPU TTS was REQUESTED and did NOT install." >&2
+        echo "  # This box answers speech on the Piper CPU fallback." >&2
+        echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step openclaw_tts" >&2
+        echo "  ############################################################" >&2
+        record_provision_failure openclaw_tts
+        ;;
     1)  KOKORO_REASON="the voice install did not complete"
         # Reworded for TASK-420: this used to say "Kokoro still works, but a
         # GPU failure will be silent", which was written when Kokoro was
@@ -2562,10 +2601,10 @@ step_openclaw_tts() {
         return 1
       fi
       echo "  TTS provider already set (tts-local-cli) — preserved, plugin registry verified"
-      return 0
+      return "$TTS_RC"
     fi
     echo "  TTS provider already set ($CURRENT_TTS) — preserving"
-    return 0
+    return "$TTS_RC"
   fi
 
   # Never point OpenClaw at a command that is not there: that configures the
@@ -2630,6 +2669,9 @@ step_openclaw_tts() {
   else
     echo "  On-device TTS configured (Piper CPU only — $KOKORO_REASON)"
   fi
+  # Configuring the provider succeeded; whether the ENGINE the owner asked for
+  # arrived is a separate verdict, and it is this one that leaves the function.
+  return "$TTS_RC"
 }
 
 step_setup_config() {
@@ -4263,6 +4305,39 @@ step_validate_services() {
       *) failed_probe+=("ClawBox: dashboard at http://localhost/ returned HTTP $http_code (expected 2xx or 3xx)") ;;
     esac
 
+    # Probe: on-device TTS delivered the engine it was asked for.
+    #
+    # scripts/install-voice.sh publishes its verdict to $TTS_STATUS_FILE for
+    # exactly this check. The distinction the file carries is the whole point:
+    # `skipped:*` means this board was never going to run Kokoro (no CUDA, no
+    # Jetson build for its architecture) and is a PASS, while `failed:*` means
+    # the GPU engine was requested and did not arrive — the box is on the Piper
+    # CPU fallback and someone has to fix it.
+    #
+    # An ABSENT verdict fails too. The TTS step runs before this check on both
+    # the install and the update path, so nothing here can assert "Kokoro is
+    # fine" from a file that is not there; the codebase has been bitten enough
+    # times by a missing signal reading as a healthy one (a gateway restart
+    # returning success after failing, an email batch reporting success having
+    # sent nothing) that "no answer" is not allowed to score as a pass.
+    #
+    # Hermes has no on-device TTS step at all, so it has nothing to verify.
+    if ! is_hermes_edition; then
+      local tts_state=""
+      if [ -r "$TTS_STATUS_FILE" ]; then
+        tts_state=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
+      fi
+      case "$tts_state" in
+        ready|skipped:*) ;;
+        "")
+          failed_probe+=("TTS: no on-device TTS verdict at $TTS_STATUS_FILE — the TTS step left no record, so whether this box has the GPU engine cannot be asserted either way. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
+          ;;
+        *)
+          failed_probe+=("TTS: Kokoro GPU TTS was requested and did NOT install ($tts_state) — this box answers speech on the Piper CPU fallback. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
+          ;;
+      esac
+    fi
+
     # Probe 3 (hermes only): the OpenClaw gateway must be GONE. This is the only
     # automated guard that the Hermes SKU never ships an unauthenticated agent
     # gateway on :18789 — a regression anywhere in the install path (a stray
@@ -4360,8 +4435,15 @@ step_validate_services() {
 
   local probe_count=2
   if is_test_mode; then probe_count=1; fi
-  # +3: gateway-inactive, gateway-port-silent, dashboard-proxy-answers.
-  if is_hermes_edition; then probe_count=$(( probe_count + 3 )); fi
+  if is_hermes_edition; then
+    # +3: gateway-inactive, gateway-port-silent, dashboard-proxy-answers.
+    probe_count=$(( probe_count + 3 ))
+  else
+    # +1: the on-device TTS verdict. Counted even when it passes, so the total
+    # the healthy line prints is the number of checks that actually ran. Hermes
+    # has no on-device TTS step, hence the either/or.
+    probe_count=$(( probe_count + 1 ))
+  fi
   # +1 (hermes AND dual): the dashboard auth provider actually verifies.
   if has_hermes_harness; then probe_count=$(( probe_count + 1 )); fi
   # One per foreign unit. Counted even when the unit is absent: "the other

--- a/install.sh
+++ b/install.sh
@@ -1570,14 +1570,27 @@ step_openclaw_setup() {
   step_openclaw_install
   step_openclaw_patch
   step_openclaw_config
-  # Non-fatal by design: a box that could not install GPU TTS must still finish
-  # provisioning and come up reachable on the CPU fallback. NOT silent, though —
-  # the step has already recorded the failure with record_provision_failure, so
-  # the final summary, install.sh's exit status and the provisioning marker all
-  # carry it, and step_validate_services fails its TTS check below. Swallowing
-  # the status here without that record is what let "flashed successfully" and
-  # "the GPU TTS silently did not install" mean the same thing.
-  step_openclaw_tts || echo "  Warning: openclaw_tts reported a failure (recorded above; provisioning continues)"
+  # Only 12 — "Kokoro was requested and did not install" — is tolerated here,
+  # and only because the step has already recorded it with
+  # record_provision_failure, so the summary, the exit status, the provisioning
+  # marker and step_validate_services' TTS probe all carry it. A box that could
+  # not install GPU TTS must still finish provisioning and come up reachable on
+  # the CPU fallback.
+  #
+  # Every OTHER non-zero return stays FATAL, exactly as it was before this
+  # tolerance existed. Those are the provider-configuration failures — no
+  # clawbox-tts.sh, a tts-local-cli plugin that will not resolve, a config write
+  # that never landed — and they mean the box has no working speech path at all,
+  # not a downgraded one. Blanket-swallowing them here would recreate this PR's
+  # own bug one layer up: a successful-looking flash over a box that cannot
+  # speak, with nothing in the marker to say so.
+  local TTS_STEP_RC=0
+  step_openclaw_tts || TTS_STEP_RC=$?
+  case "$TTS_STEP_RC" in
+    0) ;;
+    12) echo "  Warning: Kokoro GPU TTS did not install (recorded above; provisioning continues)" ;;
+    *) return "$TTS_STEP_RC" ;;
+  esac
 }
 
 # Install the Hermes agent (git-based install into ~/.hermes). Needed by every

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -40,6 +40,12 @@ KOKORO_STAMP="$CLAWBOX_HOME/.cache/clawbox/kokoro-installed"
 #    defect. The cost of the bump is one repeat of a ~4 minute install.
 KOKORO_STAMP_VERSION="2"
 
+# Where this script publishes its Kokoro verdict for readers that are NOT
+# tailing its stdout: install.sh's health check, the flash host, an operator,
+# the next update. Overridable so tests — and any run that is not root — can
+# point it somewhere writable instead of /etc.
+TTS_STATUS_FILE="${CLAWBOX_TTS_STATUS_FILE:-/etc/clawbox/tts-status}"
+
 # ── The CUDA loader path ────────────────────────────────────────────────────
 # libcusparseLt.so.0 ships INSIDE the nvidia-cusparselt-cu12 wheel, under the
 # clawbox user's site-packages, where no loader looks by default, so without
@@ -307,15 +313,48 @@ pip_as_clawbox() {
 }
 
 # Run a python3 snippet as the clawbox user with the CUDA library path set.
-# "present": these commands run here and now. The export is skipped entirely
-# when nothing resolved, because `LD_LIBRARY_PATH=:$LD_LIBRARY_PATH` hands the
-# loader an empty leading entry — the current directory.
+#
+# The snippet travels on STDIN (`python3 -`) and never inside the -c string, and
+# the -c string itself is assembled from single-quoted literals with $ld spliced
+# in as its own word — no backslash escapes, and no ${...} nested inside another
+# ${...}. Both rules exist because breaking either one broke every call:
+#
+#   su - "$CLAWBOX_USER" -c "
+#     ${ld:+export LD_LIBRARY_PATH=\"$ld\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\"}
+#     python3 -c \"$1\""
+#
+# The trap is the ESCAPED `\${`. Genuine nesting is fine — bash matches braces
+# through it, which is why `${CLAWBOX_HOME:-/home/${CLAWBOX_USER}}` above is
+# correct and must not be "fixed". But `\$` is an escaped dollar, so bash never
+# saw a nested expansion there at all: it saw a literal `$` followed by a plain
+# `{`. Its `}` was left unescaped, so THAT brace closed the OUTER ${ld:+...},
+# and the trailing `\"}` was emitted as literal text after the expansion. The
+# quote and the brace came out in the wrong order —
+#   LD_LIBRARY_PATH="…:$LD_LIBRARY_PATH"}   instead of   "…:$LD_LIBRARY_PATH}"
+# — and the stray quote swallowed the rest of the line. Every payload this
+# function produced was then a syntax error:
+#   -bash: -c: line 7: unexpected EOF while looking for matching `"'
+#   -bash: -c: line 8: syntax error: unexpected end of file
+# on every box where $ld resolved, which is every box that has CUDA. The model
+# pre-download was charged with the failure, the Piper fallback absorbed it, and
+# the flash still reported success — so shipped hardware ran CPU TTS while the
+# install said "Kokoro GPU". `import torch` on such a box fails with
+# `ImportError: libcusparseLt.so.0`, the exact library this export exists to
+# find, which is how the missing export was confirmed on device.
 clawbox_python() {
-  local ld
+  local ld payload='exec python3 -'
   ld=$(kokoro_ld_path present)
-  su - "$CLAWBOX_USER" -c "
-    ${ld:+export LD_LIBRARY_PATH=\"$ld\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\"}
-    python3 -c \"$1\""
+  # "present": these commands run here and now, and the export is skipped
+  # entirely when nothing resolved — `LD_LIBRARY_PATH=:$LD_LIBRARY_PATH` hands
+  # the loader an empty leading entry, which means the current directory.
+  #
+  # Built by concatenating a single-quoted literal, "$ld", and another
+  # single-quoted literal. Nothing is escaped and nothing nests, so $ld cannot
+  # end a quote and the ${LD_LIBRARY_PATH:+...} reaches the remote shell intact.
+  if [ -n "$ld" ]; then
+    payload='export LD_LIBRARY_PATH="'"$ld"'${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"; exec python3 -'
+  fi
+  printf '%s\n' "$1" | su - "$CLAWBOX_USER" -c "$payload"
 }
 
 install_cuda_torch() {
@@ -440,6 +479,41 @@ activate_user_units() {
   " 2>/dev/null || true
 }
 
+# Publish the Kokoro verdict — on stdout, as before, AND to $TTS_STATUS_FILE so
+# it outlives the run.
+#
+# The three states are a contract, and two of them used to be indistinguishable
+# to every reader downstream:
+#
+#   ready       requested, installed, usable.
+#   skipped:*   NOT applicable to this board (no CUDA, no Jetson build for this
+#               architecture). Nothing was asked for and nothing is missing.
+#   failed:*    requested and NOT delivered. The owner asked for GPU TTS, the
+#               box is answering speech on the Piper CPU fallback instead, and
+#               something is broken that a human has to fix.
+#
+# `failed:*` reaching only stdout is precisely how a hard failure shipped as a
+# soft fallback: the step logged an ERROR line, returned, and the flash printed
+# success. A verdict nobody can read after the fact is not a report.
+kokoro_report() {
+  local state="$1" dir
+  echo "CLAWBOX_TTS_KOKORO=$state"
+  dir=$(dirname "$TTS_STATUS_FILE")
+  # Best-effort on the WRITE, never on the SILENCE: a verdict that cannot be
+  # published is itself something install.sh has to hear about, because its
+  # health check treats a missing verdict as a failed check rather than as a
+  # pass.
+  if { mkdir -p "$dir" \
+      && printf 'KOKORO=%s\nTIMESTAMP=%s\n' \
+           "$state" "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" \
+           > "$TTS_STATUS_FILE"; } 2>/dev/null; then
+    chmod 644 "$TTS_STATUS_FILE" 2>/dev/null || true
+  else
+    echo "  Warning: could not publish the TTS verdict ($state) to $TTS_STATUS_FILE —" >&2
+    echo "           install.sh cannot health-check a result it cannot read" >&2
+  fi
+}
+
 # Install the GPU Kokoro stack. NEVER fatal: every exit path leaves Piper and
 # the deployed scripts untouched, because a box that lost its voice to a failed
 # GPU install is strictly worse than a box on the CPU fallback. The return code
@@ -457,12 +531,12 @@ install_kokoro_tts() {
     # to guess for other arches. Installing "something" here and reporting
     # Kokoro is the exact lie TASK-420 removes.
     echo "  Skipping Kokoro: no Jetson CUDA build for $arch (ClawBox ships aarch64)"
-    echo "CLAWBOX_TTS_KOKORO=skipped:arch-$arch"
+    kokoro_report "skipped:arch-$arch"
     return 11
   fi
   if ! detect_cuda; then
     echo "  Skipping Kokoro: no CUDA toolkit (no nvcc on PATH, none at $CUDA_HOME_DIR/bin/nvcc)"
-    echo "CLAWBOX_TTS_KOKORO=skipped:no-cuda"
+    kokoro_report "skipped:no-cuda"
     return 10
   fi
   echo "  CUDA detected: $("$NVCC" --version 2>/dev/null | tail -1)"
@@ -472,17 +546,17 @@ install_kokoro_tts() {
   else
     if ! install_cuda_torch; then
       echo "  ERROR: CUDA PyTorch install failed — leaving TTS on the Piper fallback" >&2
-      echo "CLAWBOX_TTS_KOKORO=failed:torch"
+      kokoro_report "failed:torch"
       return 12
     fi
     if ! install_kokoro_packages; then
       echo "  ERROR: Kokoro package install failed — leaving TTS on the Piper fallback" >&2
-      echo "CLAWBOX_TTS_KOKORO=failed:packages"
+      kokoro_report "failed:packages"
       return 12
     fi
     if ! kokoro_predownload_model; then
       echo "  ERROR: Kokoro model pre-download failed — leaving TTS on the Piper fallback" >&2
-      echo "CLAWBOX_TTS_KOKORO=failed:model"
+      kokoro_report "failed:model"
       return 12
     fi
     # Only now: every step above landed. Stamping earlier is what would turn a
@@ -495,11 +569,11 @@ install_kokoro_tts() {
   # stops working after an update.
   if ! write_kokoro_unit; then
     echo "  ERROR: could not write $SYSTEMD_USER/kokoro-server.service" >&2
-    echo "CLAWBOX_TTS_KOKORO=failed:unit"
+    kokoro_report "failed:unit"
     return 12
   fi
   activate_user_units
-  echo "CLAWBOX_TTS_KOKORO=ready"
+  kokoro_report "ready"
 }
 
 # --tts-only installs exactly what on-device TTS needs: the Piper CPU fallback,

--- a/src/tests/unit/clawbox-tts.test.ts
+++ b/src/tests/unit/clawbox-tts.test.ts
@@ -732,10 +732,14 @@ describe("install.sh wires TTS to the on-device chain", () => {
     expect(step).toMatch(/CURRENT_TTS.*!=.*"null"|"\$CURRENT_TTS" != "null"/);
     expect(step).toContain("preserving");
     // The preserve branch must return BEFORE anything is written, otherwise
-    // "seed-if-unset" is just "set".
+    // "seed-if-unset" is just "set". It returns $TTS_RC rather than a literal
+    // 0: preserving the owner's provider says nothing about whether the GPU
+    // engine installed, and a Kokoro that was requested and failed has to leave
+    // the step on this path too — that population (already-configured, updating
+    // in place) is exactly the one that had the defect.
     const guardIndex = step.indexOf("preserving");
     const setIndex = step.indexOf("oc_config_set messages.tts.provider");
-    expect(step.slice(guardIndex, setIndex)).toContain("return 0");
+    expect(step.slice(guardIndex, setIndex)).toMatch(/return "\$TTS_RC"/);
     expect(setIndex).toBeGreaterThan(guardIndex);
   });
 

--- a/src/tests/unit/install-edition-switch-refusal.test.ts
+++ b/src/tests/unit/install-edition-switch-refusal.test.ts
@@ -393,9 +393,17 @@ function runValidator(
   edition: string,
   units: Record<string, string>,
 ): { status: number; stdout: string } {
+  // The on-device TTS verdict is stubbed healthy for the same reason systemctl
+  // and curl are: this file's subject is the edition checks, and a validator
+  // that also reads the TTS verdict would otherwise fail every case here for a
+  // reason that has nothing to do with editions.
+  const ttsStatus = path.join(tmp, "tts-status");
+  fs.writeFileSync(ttsStatus, "KOKORO=ready\n");
+
   const script = [
     "set -uo pipefail",
     `CLAWBOX_EDITION=${edition}`,
+    `TTS_STATUS_FILE=${JSON.stringify(ttsStatus)}`,
     "CLAWBOX_TEST_MODE=1",
     "PROJECT_DIR=/nonexistent",
     "CLAWBOX_HOME=/nonexistent",
@@ -516,8 +524,9 @@ d("step_validate_services sees units belonging to another edition", () => {
     const total = /All (\d+) checks healthy/.exec(withoutHermes.stdout)?.[1];
     expect(total).toBeDefined();
     // 5 active (test mode drops clawbox-ap + clawbox-performance) + 6 installed
-    // + 1 probe (test mode drops the WiFi probe) + 3 foreign-unit checks.
-    expect(Number(total)).toBe(15);
+    // + 1 probe (test mode drops the WiFi probe) + 1 on-device TTS verdict
+    // (openclaw only — Hermes has no TTS step) + 3 foreign-unit checks.
+    expect(Number(total)).toBe(16);
   });
 });
 

--- a/src/tests/unit/install-edition-switch-refusal.test.ts
+++ b/src/tests/unit/install-edition-switch-refusal.test.ts
@@ -403,7 +403,6 @@ function runValidator(
   const script = [
     "set -uo pipefail",
     `CLAWBOX_EDITION=${edition}`,
-    `TTS_STATUS_FILE=${JSON.stringify(ttsStatus)}`,
     "CLAWBOX_TEST_MODE=1",
     "PROJECT_DIR=/nonexistent",
     "CLAWBOX_HOME=/nonexistent",
@@ -430,7 +429,10 @@ function runValidator(
     encoding: "utf-8",
     // NODE_ENV is not read by any shell here; it is carried only because this
     // repo's ProcessEnv typing makes it required on an env literal.
-    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV },
+    // TTS_STATUS_FILE travels as an environment variable rather than as an
+    // interpolated shell assignment: JSON quoting is not shell quoting, and a
+    // path is data, not script.
+    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV, TTS_STATUS_FILE: ttsStatus },
   });
   return { status: r.status ?? -1, stdout: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }

--- a/src/tests/unit/install-foreign-edition-teardown.test.ts
+++ b/src/tests/unit/install-foreign-edition-teardown.test.ts
@@ -397,9 +397,17 @@ function runValidator(
   edition: string,
   units: Record<string, string>,
 ): { status: number; stdout: string } {
+  // Stubbed healthy for the same reason systemctl and curl are: this file's
+  // subject is the foreign-unit checks, and a validator that also reads the
+  // on-device TTS verdict would otherwise fail every case here for a reason
+  // that has nothing to do with editions.
+  const ttsStatus = path.join(tmp, "tts-status");
+  fs.writeFileSync(ttsStatus, "KOKORO=ready\n");
+
   const script = [
     "set -uo pipefail",
     `CLAWBOX_EDITION=${edition}`,
+    `TTS_STATUS_FILE=${JSON.stringify(ttsStatus)}`,
     "CLAWBOX_TEST_MODE=1",
     "PROJECT_DIR=/home/clawbox/clawbox",
     "CLAWBOX_HOME=/nonexistent",
@@ -485,6 +493,6 @@ d("the validator now says what to run, not just what is wrong", () => {
     // The teardown adds no checks — the healthy line must not move.
     const r = runValidator("openclaw", healthyOpenclaw());
     expect(r.status).toBe(0);
-    expect(r.stdout).toMatch(/All 15 checks healthy/);
+    expect(r.stdout).toMatch(/All 16 checks healthy/);
   });
 });

--- a/src/tests/unit/install-foreign-edition-teardown.test.ts
+++ b/src/tests/unit/install-foreign-edition-teardown.test.ts
@@ -407,7 +407,6 @@ function runValidator(
   const script = [
     "set -uo pipefail",
     `CLAWBOX_EDITION=${edition}`,
-    `TTS_STATUS_FILE=${JSON.stringify(ttsStatus)}`,
     "CLAWBOX_TEST_MODE=1",
     "PROJECT_DIR=/home/clawbox/clawbox",
     "CLAWBOX_HOME=/nonexistent",
@@ -429,7 +428,10 @@ function runValidator(
 
   const r = spawnSync("bash", ["-c", script], {
     encoding: "utf-8",
-    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV },
+    // TTS_STATUS_FILE travels as an environment variable rather than as an
+    // interpolated shell assignment: JSON quoting is not shell quoting, and a
+    // path is data, not script.
+    env: { PATH: process.env.PATH ?? "", NODE_ENV: process.env.NODE_ENV, TTS_STATUS_FILE: ttsStatus },
   });
   return { status: r.status ?? -1, stdout: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -60,11 +60,23 @@ interface VoiceRun {
   status: number | null;
   stdout: string;
   stderr: string;
-  /** Every command string handed to `su - clawbox -c`, one per line. */
+  /**
+   * Every command handed to `su - clawbox -c`, one per entry — with the
+   * program that travelled on stdin appended, so a payload that reads its
+   * snippet from `python3 -` is still searchable by its contents.
+   */
   su: string[];
+  /**
+   * Payloads a real `bash -n` refused to parse, each preceded by bash's own
+   * complaint. MUST be empty: `su` hands the string to a login shell, so a
+   * payload the shell cannot parse never runs at all.
+   */
+  suSyntax: string;
   curl: string[];
   /** Every `chown` argument list, one per line. */
   chown: string[];
+  /** Contents of the published TTS verdict file, or "" when none was written. */
+  ttsStatus: string;
   home: string;
 }
 
@@ -89,10 +101,27 @@ function runTtsOnly(env: Record<string, string> = {}, stamped: boolean | string 
   const home = path.join(root, "home", "clawbox");
   const bin = path.join(root, "bin");
   const suLog = path.join(root, "su.log");
+  const suSyntaxLog = path.join(root, "su-syntax.log");
   const curlLog = path.join(root, "curl.log");
   const chownLog = path.join(root, "chown.log");
+  const ttsStatus = path.join(root, "tts-status");
+  const cudaHome = path.join(root, env.WITH_CUDA_LIBS === "1" ? "cuda" : "no-such-cuda");
   mkdirSync(bin, { recursive: true });
   mkdirSync(home, { recursive: true });
+  // A real device HAS these three directories: the cusparselt wheel unpacks
+  // into user-site and CUDA lives under /usr/local/cuda. They are what makes
+  // kokoro_ld_path() return a non-empty path, and therefore what makes the
+  // LD_LIBRARY_PATH export appear in the payload at all. Every test in this
+  // file used to run without them, so `$ld` was always empty, the export was
+  // always skipped, and the payload that is broken on real hardware was never
+  // built here — which is precisely how a script that could not execute a
+  // single python snippet on a Jetson kept a green suite.
+  if (env.WITH_CUDA_LIBS === "1") {
+    mkdirSync(path.join(home, ".local", "lib", "python3.10", "site-packages", "nvidia", "cusparselt", "lib"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(cudaHome, "lib64"), { recursive: true });
+  }
   if (stamped) {
     mkdirSync(path.join(home, ".cache", "clawbox"), { recursive: true });
     const version = typeof stamped === "string" ? stamped : shellConst("KOKORO_STAMP_VERSION");
@@ -106,8 +135,23 @@ function runTtsOnly(env: Record<string, string> = {}, stamped: boolean | string 
     [
       'cmd=""',
       'while [ $# -gt 0 ]; do case "$1" in -c) cmd="$2"; shift 2;; *) shift;; esac; done',
-      `printf '%s\\n---\\n' "$cmd" >> "${suLog}"`,
-      'case "$cmd" in',
+      // Hand the payload to a REAL shell to parse before doing anything else.
+      // `su` passes its -c string to the user's login shell, so a string that
+      // shell cannot parse is a call that never happens — and that is exactly
+      // what shipped: the model pre-download payload was
+      //   -bash: -c: line 7: unexpected EOF while looking for matching `"'
+      // on every box whose CUDA loader path resolved. These tests stayed green
+      // through it because this stub only ever pattern-matched the string, and
+      // because no test created the directories that make that path non-empty.
+      `if ! bash -n -c "$cmd" 2>>"${suSyntaxLog}"; then printf '%s\\n---\\n' "$cmd" >> "${suSyntaxLog}"; fi`,
+      // A payload that reads its program from stdin (`python3 -`, the form that
+      // keeps a snippet out of shell-quoting entirely) carries it there, so the
+      // log and the dispatch below have to see both halves.
+      'stdin_code=""',
+      'case "$cmd" in *"python3 -") stdin_code="$(cat)" ;; esac',
+      'full=$(printf "%s\\n%s" "$cmd" "$stdin_code")',
+      `printf '%s\\n---\\n' "$full" >> "${suLog}"`,
+      'case "$full" in',
       // How the script asks the box which python pip --user will unpack the
       // cusparselt wheel under, instead of pinning the version it was written
       // against. A device answers "python3.10" (JetPack 6.2); the test host's
@@ -162,8 +206,13 @@ function runTtsOnly(env: Record<string, string> = {}, stamped: boolean | string 
       CLAWBOX_HOME: home,
       PIPER_DIR: piperDir,
       // Point the /usr/local/cuda probe at nothing so a dev box or CI runner
-      // that happens to have CUDA cannot turn the no-CUDA test green.
-      CLAWBOX_CUDA_HOME: path.join(root, "no-such-cuda"),
+      // that happens to have CUDA cannot turn the no-CUDA test green. With
+      // WITH_CUDA_LIBS this is a real directory the block above created.
+      CLAWBOX_CUDA_HOME: cudaHome,
+      // Never /etc: the verdict file has to be somewhere a non-root test run
+      // can actually write, or the "it publishes its verdict" assertions would
+      // only ever be measuring the permission error.
+      CLAWBOX_TTS_STATUS_FILE: ttsStatus,
       ...env,
     },
   });
@@ -174,8 +223,10 @@ function runTtsOnly(env: Record<string, string> = {}, stamped: boolean | string 
     stdout: res.stdout ?? "",
     stderr: res.stderr ?? "",
     su: read(suLog).split("\n---\n").filter(Boolean),
+    suSyntax: read(suSyntaxLog).trim(),
     curl: read(curlLog).trim().split("\n").filter(Boolean),
     chown: read(chownLog).trim().split("\n").filter(Boolean),
+    ttsStatus: read(ttsStatus),
     home,
   };
 }
@@ -209,13 +260,23 @@ function runStep(voiceExit: number) {
     ].join("\n"),
   );
 
+  const provisionLog = path.join(root, "provision-failures.log");
+  const ttsStatus = path.join(root, "tts-status");
+
   const program = [
     "set -uo pipefail",
     `PROJECT_DIR="${projectDir}"`,
     `OPENCLAW_BIN="${openclaw}"`,
+    `TTS_STATUS_FILE="${ttsStatus}"`,
     "CLAWBOX_USER=clawbox",
     'as_clawbox() { env "$@"; }',
     "is_hermes_edition() { return 1; }",
+    // The real one appends to PROVISION_FAILURES, which the full install turns
+    // into the summary, the exit status and the marker the flash host reads.
+    // Logged here so a test can assert the step actually reaches for it: that
+    // call is the difference between a failure the operator sees and one that
+    // ends at a log line nobody greps.
+    `record_provision_failure() { printf '%s\\n' "$1" >> "${provisionLog}"; }`,
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),
@@ -230,6 +291,8 @@ function runStep(voiceExit: number) {
     stderr: res.stderr ?? "",
     voiceArgs: read(voiceArgs),
     openclaw: read(callsLog),
+    /** Step names handed to record_provision_failure, one per entry. */
+    provisionFailures: read(provisionLog),
   };
 }
 
@@ -259,14 +322,62 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     [12, /Kokoro GPU install failed/],
   ])("stays non-fatal and tells the truth when the voice install exits %i", (code, reason) => {
     const res = runStep(code as number);
-    // Non-fatal: a box must never lose its voice, or its install, to the GPU
-    // path. TTS is still configured — through Piper.
-    expect(res.status).toBe(0);
+    // Non-fatal: a box must never lose its voice to the GPU path. TTS is still
+    // configured — through Piper.
     expect(res.openclaw).toContain("config set messages.tts.provider tts-local-cli");
     // And the summary must not repeat the lie that hid this bug for a release.
     expect(res.stdout).not.toContain("Kokoro GPU, Piper fallback");
     expect(res.stdout).toContain("Piper CPU only");
     expect(res.stdout).toMatch(reason as RegExp);
+  });
+
+  // ── Requested-and-failed is not the same outcome as never-requested ────────
+  // The deeper defect, and the one that let a shell syntax error ship: the step
+  // treated "this board has no CUDA" and "the GPU engine you asked for did not
+  // install" as the same result — zero — so a flash host printed
+  // "Setup: 1/1 succeeded" over a box that had told itself it was broken.
+
+  it.each([
+    [10, "no CUDA toolkit on this board"],
+    [11, "no Jetson build for this architecture"],
+  ])("exit %i is a SKIP: nothing was requested, so nothing is reported failed", (code) => {
+    const res = runStep(code as number);
+    expect(res.status, "a board that was never going to run Kokoro is not a failed install").toBe(0);
+    expect(res.provisionFailures, "a skip was recorded as a provisioning failure").toEqual([]);
+  });
+
+  it("exit 12 is a FAILURE: it leaves the step, the summary and the operator's screen", () => {
+    const res = runStep(12);
+    // 1. The caller's status. Under `set -e` this is what makes
+    //    `install.sh --step openclaw_tts` — the form the in-app updater runs —
+    //    exit non-zero instead of announcing a clean update.
+    expect(res.status, "a requested engine that did not install still exited 0").not.toBe(0);
+    // 2. The provisioning record: summary + exit status + the marker file the
+    //    flash host reads instead of parsing stdout.
+    expect(res.provisionFailures).toContain("openclaw_tts");
+    // 3. Something an operator cannot scroll past, with the one command that
+    //    retries it.
+    expect(res.stderr).toMatch(/Kokoro GPU TTS was REQUESTED and did NOT install/);
+    expect(res.stderr).toMatch(/--step openclaw_tts/);
+    // Still non-fatal for the box's voice: the provider is configured anyway,
+    // because Piper is a working engine and refusing to configure TTS at all
+    // would cost the box speech it can actually deliver.
+    expect(res.openclaw).toContain("config set messages.tts.provider tts-local-cli");
+  });
+
+  it("carries the failure through even when the owner's provider is preserved", () => {
+    // The update path on a shipped box: messages.tts.provider is already set,
+    // so the step returns early. Returning 0 from there would drop the verdict
+    // on exactly the population that has the defect.
+    const res = runStep(12);
+    expect(res.status).not.toBe(0);
+  });
+
+  it("hands install-voice.sh the verdict path so both halves cannot drift", () => {
+    // Two independent defaults for the same file is how the writer and the
+    // health check end up looking at different paths and agreeing forever.
+    const step = extractShellFn(INSTALL_SH, "step_openclaw_tts");
+    expect(step).toContain("CLAWBOX_TTS_STATUS_FILE=");
   });
 
   it("warns about the fallback in terms of the fallback, not of Kokoro", () => {
@@ -550,5 +661,175 @@ describe.skipIf(!hasBash)("the older --piper-only entry point still works", () =
     const tts = readFileSync(path.join(REPO, "scripts/openclaw/clawbox-tts.sh"), "utf-8");
     expect(tts).toContain("--piper-only");
     expect(INSTALL_VOICE_SH).toContain('if [ "${1:-}" = "--piper-only" ]; then');
+  });
+});
+
+// ── The payload every python step is handed must be shell a shell can run ────
+//
+// `su - clawbox -c "<payload>"` hands <payload> to the user's login shell, so a
+// payload that shell cannot PARSE is a call that never happens. One shipped:
+//
+//   Pre-downloading Kokoro model...
+//   -bash: -c: line 7: unexpected EOF while looking for matching `"'
+//   -bash: -c: line 8: syntax error: unexpected end of file
+//   ERROR: Kokoro model pre-download failed — leaving TTS on the Piper fallback
+//
+// captured from a factory-fresh box during its first-boot update. The cause was
+// one line in clawbox_python():
+//
+//   ${ld:+export LD_LIBRARY_PATH=\"$ld\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\"}
+//
+// bash ends a ${var:+word} at the first UNESCAPED `}` — which was the one
+// closing the INNER ${LD_LIBRARY_PATH:+...} — so the trailing `\"}` fell
+// outside the expansion and emitted the quote and the brace in the wrong
+// order: `...:$LD_LIBRARY_PATH"}` instead of `...:$LD_LIBRARY_PATH}"`. The
+// stray quote swallowed the rest of the line and every payload became a syntax
+// error, on every box where $ld resolved — which is every box that has CUDA.
+// The graceful fallback to Piper then hid it: speech still worked, on the wrong
+// engine, and the flash reported success.
+
+describe.skipIf(!hasBash)("every su payload is shell a login shell can actually run", () => {
+  it("hands su nothing bash refuses to parse, on a box whose loader path resolves", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", WITH_CUDA_LIBS: "1", KOKORO_IMPORT_EXIT: "1" });
+    expect(
+      res.suSyntax,
+      `bash refused to parse a payload install-voice.sh handed su:\n${res.suSyntax}`,
+    ).toBe("");
+    expect(res.status, res.stderr).toBe(0);
+  });
+
+  it("still parses when nothing resolved and the export is skipped", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    expect(res.suSyntax, res.suSyntax).toBe("");
+  });
+
+  it("actually puts the cusparselt directory on LD_LIBRARY_PATH for the warm-up", () => {
+    // The functional half. Without this export `import torch` on a Jetson dies
+    // with `ImportError: libcusparseLt.so.0: cannot open shared object file` —
+    // the library that ships inside the nvidia-cusparselt-cu12 wheel, under
+    // user-site, where no loader looks by default. That is the error the
+    // affected box answered with, which is how the missing export was
+    // confirmed on device rather than inferred from the script.
+    const res = runTtsOnly({ WITH_CUDA: "1", WITH_CUDA_LIBS: "1", KOKORO_IMPORT_EXIT: "1" });
+    const warm = res.su.find((c) => c.includes("from kokoro import KPipeline"));
+    expect(warm, "the model warm-up never ran at all").toBeDefined();
+    expect(warm).toMatch(/export LD_LIBRARY_PATH=/);
+    expect(warm).toContain("nvidia/cusparselt/lib");
+  });
+
+  it("omits the export rather than leading LD_LIBRARY_PATH with an empty entry", () => {
+    // An empty entry means "the current directory" to the loader, which is not
+    // a place to resolve .so files from.
+    const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
+    const warm = res.su.find((c) => c.includes("from kokoro import KPipeline"));
+    expect(warm).toBeDefined();
+    expect(warm).not.toContain("LD_LIBRARY_PATH");
+  });
+
+  it("keeps the snippet out of the shell string entirely", () => {
+    // The structural fix, asserted structurally: the python program travels on
+    // stdin, so no amount of quoting inside it can terminate a shell quote.
+    // Another layer of escaping would have passed the tests above and broken on
+    // the next edit — this is the property that stops the bug class, not just
+    // this instance of it.
+    const fn = extractShellFn(INSTALL_VOICE_SH, "clawbox_python");
+    expect(fn).toContain("python3 -");
+    expect(fn).not.toContain('python3 -c \\"');
+  });
+});
+
+// ── A hard failure must stop being reported as a soft fallback ───────────────
+
+describe.skipIf(!hasBash)("the Kokoro verdict outlives the run", () => {
+  it("publishes failed:model where something other than stdout can read it", () => {
+    const res = runTtsOnly({
+      WITH_CUDA: "1",
+      WITH_CUDA_LIBS: "1",
+      KOKORO_IMPORT_EXIT: "1",
+      WARMUP_EXIT: "1",
+    });
+    expect(res.status).toBe(12);
+    expect(res.ttsStatus).toContain("KOKORO=failed:model");
+  });
+
+  it("publishes skipped:* as its own state — not a failure, not a success", () => {
+    const res = runTtsOnly({ KOKORO_IMPORT_EXIT: "1" });
+    expect(res.status).toBe(10);
+    expect(res.ttsStatus).toContain("KOKORO=skipped:no-cuda");
+    expect(res.ttsStatus).not.toContain("failed");
+  });
+
+  it("publishes ready when the engine genuinely landed", () => {
+    const res = runTtsOnly({ WITH_CUDA: "1", WITH_CUDA_LIBS: "1", KOKORO_IMPORT_EXIT: "1" });
+    expect(res.ttsStatus).toContain("KOKORO=ready");
+  });
+});
+
+// ── The health check that makes "flashed successfully" mean something ────────
+
+function runValidator(ttsStatusContents: string | null): { status: number; out: string } {
+  const ttsStatus = path.join(root, "validator-tts-status");
+  if (ttsStatusContents !== null) writeFileSync(ttsStatus, ttsStatusContents);
+  const clock = path.join(root, "clock");
+  writeFileSync(clock, "1000\n");
+
+  const program = [
+    "set -uo pipefail",
+    "CLAWBOX_EDITION=openclaw",
+    "CLAWBOX_TEST_MODE=1",
+    "PROJECT_DIR=/home/clawbox/clawbox",
+    'IFACE_ENV="/nonexistent/network.env"',
+    `TTS_STATUS_FILE="${ttsStatus}"`,
+    // The unit registry is another file's subject; empty lists keep this test
+    // about the one probe it is here to pin.
+    "EXPECTED_ACTIVE_SERVICES=()",
+    "EXPECTED_INSTALLED_SERVICES=()",
+    "FOREIGN_EDITION_UNITS=()",
+    'is_test_mode() { [ "$CLAWBOX_TEST_MODE" = "1" ]; }',
+    'is_hermes_edition() { [ "$CLAWBOX_EDITION" = "hermes" ]; }',
+    "has_hermes_harness() { return 1; }",
+    "gateway_port_listening() { return 1; }",
+    "systemctl() { return 0; }",
+    "curl() { printf '200'; }",
+    // The poll loop reads `date +%s` twice per pass and gives up after 30s. A
+    // file-backed clock that jumps 100s per read makes a failing run finish in
+    // one pass instead of polling for half a minute.
+    `_CLOCK="${clock}"`,
+    'date() { local n; n=$(( $(cat "$_CLOCK") + 100 )); echo "$n" > "$_CLOCK"; printf %s "$n"; }',
+    "sleep() { :; }",
+    extractShellFn(INSTALL_SH, "step_validate_services"),
+    "step_validate_services",
+  ].join("\n");
+
+  const r = spawnSync("bash", ["-c", program], { encoding: "utf-8", timeout: 60_000 });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe.skipIf(!hasBash)("service validation refuses to call a Kokoro-less box healthy", () => {
+  it("fails the install when the GPU engine was requested and did not install", () => {
+    const res = runValidator("KOKORO=failed:model\n");
+    expect(res.status, `validation passed a box with no GPU TTS:\n${res.out}`).toBe(1);
+    expect(res.out).toMatch(/requested and did NOT install/);
+    expect(res.out).toMatch(/--step openclaw_tts/);
+  });
+
+  it("passes a board that was never going to run Kokoro", () => {
+    // The distinction the whole verdict file exists for: no CUDA is not a
+    // defect, and failing every x86 or non-Jetson install would just teach
+    // everyone to ignore this check.
+    const res = runValidator("KOKORO=skipped:no-cuda\n");
+    expect(res.status, res.out).toBe(0);
+  });
+
+  it("passes a box that has the engine", () => {
+    expect(runValidator("KOKORO=ready\n").status).toBe(0);
+  });
+
+  it("refuses to read a MISSING verdict as a healthy one", () => {
+    // "No answer" scoring as a pass is the same bug one level up, and this
+    // codebase has shipped it more than once.
+    const res = runValidator(null);
+    expect(res.status).toBe(1);
+    expect(res.out).toMatch(/no on-device TTS verdict/);
   });
 });

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -237,8 +237,14 @@ function runTtsOnly(env: Record<string, string> = {}, stamped: boolean | string 
  * Run the real step_openclaw_tts against a stub `openclaw` and a stub
  * install-voice.sh whose exit code the test picks.
  */
-/** @param voiceExit the exit status the stub install-voice.sh reports. */
-function runStep(voiceExit: number) {
+/**
+ * @param voiceExit       the exit status the stub install-voice.sh reports.
+ * @param currentProvider what `openclaw config get messages.tts.provider`
+ *                        answers. Non-empty puts the step on the
+ *                        already-configured branch — the shipped-box update
+ *                        path, which returns early.
+ */
+function runStep(voiceExit: number, currentProvider = "") {
   const projectDir = path.join(root, "project");
   const callsLog = path.join(root, "openclaw.log");
   const voiceArgs = path.join(root, "voice-args.log");
@@ -256,7 +262,10 @@ function runStep(voiceExit: number) {
     openclaw,
     [
       `echo "$*" >> "${callsLog}"`,
-      'if [ "$1" = "config" ] && [ "$2" = "get" ]; then exit 0; fi',
+      'if [ "$1" = "config" ] && [ "$2" = "get" ]; then',
+      `  [ "$3" = "messages.tts.provider" ] && printf '%s' "${currentProvider}"`,
+      "  exit 0",
+      "fi",
       "exit 0",
     ].join("\n"),
   );
@@ -375,9 +384,13 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
   it("carries the failure through even when the owner's provider is preserved", () => {
     // The update path on a shipped box: messages.tts.provider is already set,
     // so the step returns early. Returning 0 from there would drop the verdict
-    // on exactly the population that has the defect.
-    const res = runStep(12);
+    // on exactly the population that has the defect — and without a provider in
+    // the stub's answer this case never reaches that branch at all, it just
+    // retreads the one above.
+    const res = runStep(12, "tts-local-cli");
+    expect(res.stdout, "the preserve branch was never reached").toContain("preserved");
     expect(res.status).not.toBe(0);
+    expect(res.provisionFailures).toContain("openclaw_tts");
   });
 
   it("hands install-voice.sh the verdict path so both halves cannot drift", () => {

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -237,6 +237,7 @@ function runTtsOnly(env: Record<string, string> = {}, stamped: boolean | string 
  * Run the real step_openclaw_tts against a stub `openclaw` and a stub
  * install-voice.sh whose exit code the test picks.
  */
+/** @param voiceExit the exit status the stub install-voice.sh reports. */
 function runStep(voiceExit: number) {
   const projectDir = path.join(root, "project");
   const callsLog = path.join(root, "openclaw.log");
@@ -267,7 +268,6 @@ function runStep(voiceExit: number) {
     "set -uo pipefail",
     `PROJECT_DIR="${projectDir}"`,
     `OPENCLAW_BIN="${openclaw}"`,
-    `TTS_STATUS_FILE="${ttsStatus}"`,
     "CLAWBOX_USER=clawbox",
     'as_clawbox() { env "$@"; }',
     "is_hermes_edition() { return 1; }",
@@ -283,7 +283,14 @@ function runStep(voiceExit: number) {
     "step_openclaw_tts",
   ].join("\n");
 
-  const res = spawnSync("bash", ["-c", program], { encoding: "utf-8", timeout: 60_000 });
+  // TTS_STATUS_FILE travels as an environment variable rather than as an
+  // interpolated shell assignment: JSON quoting is not shell quoting, and a
+  // path is data, not script.
+  const res = spawnSync("bash", ["-c", program], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, TTS_STATUS_FILE: ttsStatus },
+  });
   const read = (f: string) => (existsSync(f) ? readFileSync(f, "utf-8").trim().split("\n").filter(Boolean) : []);
   return {
     status: res.status,
@@ -767,6 +774,11 @@ describe.skipIf(!hasBash)("the Kokoro verdict outlives the run", () => {
 
 // ── The health check that makes "flashed successfully" mean something ────────
 
+/**
+ * Run the real step_validate_services with everything except the TTS verdict
+ * stubbed healthy. `ttsStatusContents` is written to the verdict file, or the
+ * file is left absent when it is null.
+ */
 function runValidator(ttsStatusContents: string | null): { status: number; out: string } {
   const ttsStatus = path.join(root, "validator-tts-status");
   if (ttsStatusContents !== null) writeFileSync(ttsStatus, ttsStatusContents);
@@ -779,7 +791,6 @@ function runValidator(ttsStatusContents: string | null): { status: number; out: 
     "CLAWBOX_TEST_MODE=1",
     "PROJECT_DIR=/home/clawbox/clawbox",
     'IFACE_ENV="/nonexistent/network.env"',
-    `TTS_STATUS_FILE="${ttsStatus}"`,
     // The unit registry is another file's subject; empty lists keep this test
     // about the one probe it is here to pin.
     "EXPECTED_ACTIVE_SERVICES=()",
@@ -801,7 +812,11 @@ function runValidator(ttsStatusContents: string | null): { status: number; out: 
     "step_validate_services",
   ].join("\n");
 
-  const r = spawnSync("bash", ["-c", program], { encoding: "utf-8", timeout: 60_000 });
+  const r = spawnSync("bash", ["-c", program], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, TTS_STATUS_FILE: ttsStatus },
+  });
   return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
 }
 
@@ -831,5 +846,65 @@ describe.skipIf(!hasBash)("service validation refuses to call a Kokoro-less box 
     const res = runValidator(null);
     expect(res.status).toBe(1);
     expect(res.out).toMatch(/no on-device TTS verdict/);
+  });
+});
+
+// ── The call site must not launder a hard failure into a warning ─────────────
+//
+// step_openclaw_tts returns 12 for "Kokoro was requested and did not install",
+// which is survivable — the box still speaks, on Piper — and is already carried
+// by record_provision_failure, the marker and the validator's TTS probe. It
+// also returns 1 from six OTHER paths that mean the box has no working speech
+// path at all: no clawbox-tts.sh, a tts-local-cli plugin that will not resolve,
+// a provider definition or selection that never landed.
+//
+// Those were fatal before the 12 case existed, because step_openclaw_setup is
+// called bare under `set -e`. Tolerating every non-zero return here would have
+// recreated this PR's own bug one layer up — a successful-looking flash over a
+// box that cannot speak, with nothing in the marker to say so.
+
+/**
+ * Run the real step_openclaw_setup with the three steps before the TTS one
+ * stubbed out and step_openclaw_tts scripted to exit `ttsExit`, so the call
+ * site's handling of that status is what is under test.
+ */
+function runOpenclawSetup(ttsExit: number): { status: number; out: string } {
+  const program = [
+    "set -euo pipefail",
+    "PROJECT_DIR=/nonexistent",
+    "is_hermes_edition() { return 1; }",
+    "step_openclaw_install() { :; }",
+    "step_openclaw_patch() { :; }",
+    "step_openclaw_config() { :; }",
+    `step_openclaw_tts() { return ${ttsExit}; }`,
+    extractShellFn(INSTALL_SH, "step_openclaw_setup"),
+    "step_openclaw_setup",
+    'echo "SETUP_COMPLETED=$?"',
+  ].join("\n");
+  const r = spawnSync("bash", ["-c", program], { encoding: "utf-8", timeout: 60_000 });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe.skipIf(!hasBash)("the openclaw setup step weighs the TTS result", () => {
+  it("continues when everything worked", () => {
+    const res = runOpenclawSetup(0);
+    expect(res.status, res.out).toBe(0);
+    expect(res.out).toContain("SETUP_COMPLETED=0");
+  });
+
+  it("continues past a Kokoro-only failure, saying so", () => {
+    const res = runOpenclawSetup(12);
+    expect(res.status, res.out).toBe(0);
+    expect(res.out).toContain("SETUP_COMPLETED=0");
+    expect(res.out).toMatch(/Kokoro GPU TTS did not install/);
+  });
+
+  it.each([1, 2])("stays FATAL on a provider-configuration failure (exit %i)", (code) => {
+    // A box with no configured speech path must not finish provisioning quietly.
+    // `set -e` carries this out of step_openclaw_setup and aborts the install,
+    // which is exactly what it did before the Kokoro tolerance was added.
+    const res = runOpenclawSetup(code as number);
+    expect(res.status, `a hard TTS failure was swallowed:\n${res.out}`).not.toBe(0);
+    expect(res.out).not.toContain("SETUP_COMPLETED=");
   });
 });

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -367,7 +367,10 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     // 1. The caller's status. Under `set -e` this is what makes
     //    `install.sh --step openclaw_tts` — the form the in-app updater runs —
     //    exit non-zero instead of announcing a clean update.
-    expect(res.status, "a requested engine that did not install still exited 0").not.toBe(0);
+    // The exact code, not merely non-zero: spawnSync reports status null on a
+    // timeout, and `null` satisfies not.toBe(0) — a hung harness would score as
+    // a pass for the very assertion this test exists to make.
+    expect(res.status, "a requested engine that did not install still exited 0").toBe(12);
     // 2. The provisioning record: summary + exit status + the marker file the
     //    flash host reads instead of parsing stdout.
     expect(res.provisionFailures).toContain("openclaw_tts");
@@ -389,7 +392,7 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     // retreads the one above.
     const res = runStep(12, "tts-local-cli");
     expect(res.stdout, "the preserve branch was never reached").toContain("preserved");
-    expect(res.status).not.toBe(0);
+    expect(res.status).toBe(12);
     expect(res.provisionFailures).toContain("openclaw_tts");
   });
 
@@ -917,7 +920,10 @@ describe.skipIf(!hasBash)("the openclaw setup step weighs the TTS result", () =>
     // `set -e` carries this out of step_openclaw_setup and aborts the install,
     // which is exactly what it did before the Kokoro tolerance was added.
     const res = runOpenclawSetup(code as number);
-    expect(res.status, `a hard TTS failure was swallowed:\n${res.out}`).not.toBe(0);
+    // The exact code, not merely non-zero: `set -e` exits with the failing
+    // command's own status, and asserting it rules out a null from a spawn
+    // timeout quietly standing in for a propagated failure.
+    expect(res.status, `a hard TTS failure was swallowed:\n${res.out}`).toBe(code);
     expect(res.out).not.toContain("SETUP_COMPLETED=");
   });
 });

--- a/src/tests/unit/install-tts-provider-registry.test.ts
+++ b/src/tests/unit/install-tts-provider-registry.test.ts
@@ -87,9 +87,16 @@ function runStep(env: Record<string, string> = {}) {
     `PROJECT_DIR="${projectDir}"`,
     `OPENCLAW_BIN="${path.join(dir, "openclaw")}"`,
     "CLAWBOX_USER=clawbox",
+    // Where install-voice.sh publishes its Kokoro verdict. This file's subject
+    // is the plugin registry, so the path only has to exist as a variable —
+    // but it does have to exist, because the step passes it down.
+    `TTS_STATUS_FILE="${path.join(dir, "tts-status")}"`,
     // as_clawbox drops privileges on a device; here it just runs the command.
     "as_clawbox() { env \"$@\"; }",
     "is_hermes_edition() { return 1; }",
+    // Recorded by the step when Kokoro was requested and did not install, so
+    // the failure reaches the provisioning summary. A no-op here.
+    "record_provision_failure() { :; }",
     extractShellFn(INSTALL_SH, "oc_config_set"),
     extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
     extractShellFn(INSTALL_SH, "step_openclaw_tts"),


### PR DESCRIPTION
## What was broken

Every Jetson flashed or updated in this window lost GPU TTS, silently.

`clawbox_python()` in `scripts/install-voice.sh` builds the command handed to
`su - clawbox -c`. The line that added the CUDA loader path was:

```sh
${ld:+export LD_LIBRARY_PATH=\"$ld\${LD_LIBRARY_PATH:+:\$LD_LIBRARY_PATH}\"}
```

The inner `$` is backslash-escaped, so bash never saw a nested parameter
expansion there — it saw a literal `$` followed by a plain `{`. Its `}` was left
unescaped, so **that** brace closed the *outer* `${ld:+...}`, and the trailing
`\"}` was emitted as literal text after the expansion. The quote and the brace
came out in the wrong order:

```
LD_LIBRARY_PATH="…:$LD_LIBRARY_PATH"}      # instead of   "…:$LD_LIBRARY_PATH}"
```

The stray quote swallowed the rest of the line, so every payload this function
produced was a syntax error on any box where `$ld` resolved — which is every box
that has CUDA, since `/usr/local/cuda/lib64` alone makes it non-empty:

```
  Pre-downloading Kokoro model...
-bash: -c: line 7: unexpected EOF while looking for matching `"'
-bash: -c: line 8: syntax error: unexpected end of file
  ERROR: Kokoro model pre-download failed — leaving TTS on the Piper fallback
CLAWBOX_TTS_KOKORO=failed:model
```

Genuine nesting is fine and is used correctly elsewhere in the same file
(`${CLAWBOX_HOME:-/home/${CLAWBOX_USER}}`) — the escaped `\${` is the trap, and
it is the only occurrence of that shape in the repo.

Two consequences beyond the pre-download, both confirmed on hardware:

- `import torch` as the clawbox user dies with
  `ImportError: libcusparseLt.so.0` — the library the missing export exists to
  find. That is the direct proof the export never reached the payload.
- `kokoro_stack_present()` runs the same helper, so its import check failed too:
  the idempotence gate could never say "already installed".

## The deeper bug: a hard failure reported as a soft fallback

The reason this shipped is not the quoting. It is that the step logged an ERROR,
returned **0**, and the flash printed success — so "flashed successfully" and
"the GPU TTS you asked for silently did not install" were compatible statements.
The Piper fallback did its job, speech still worked, and nobody looked.

This PR makes the failure visible, and — the part that was missing — makes
*requested-and-failed* distinguishable from *never-requested*:

| state | meaning | verdict |
|---|---|---|
| `ready` | requested, installed, usable | pass |
| `skipped:*` | no CUDA / no Jetson build for this arch — nothing was asked for | pass |
| `failed:*` | requested and **not** delivered; the box is on the CPU fallback | **fail** |

Concretely:

1. `scripts/install-voice.sh` publishes its verdict to `/etc/clawbox/tts-status`
   (`kokoro_report`), so it outlives the run instead of scrolling past on stdout.
2. `step_openclaw_tts` returns **non-zero** on `failed:*`, prints a bordered
   block naming the one command that retries it, and calls
   `record_provision_failure openclaw_tts` — so the failure reaches the final
   summary, install.sh's exit status, and the marker the flash host reads.
   `skipped:*` deliberately does none of this.
3. `step_validate_services` grows a probe that reads the verdict. A `failed:*`
   verdict — **or an absent one** — is a failed check, so `All N checks healthy`
   is no longer printable on a box that lost its GPU engine. This is the channel
   that covers the in-app update path, where the step runs under
   `clawbox-root-update@post_update`.

Non-fatal stays non-fatal throughout: the provider is still configured, Piper is
still installed, and a box without CUDA still provisions cleanly.

## The fix itself

The payload is no longer built by escaping. The python snippet travels on
**stdin** (`python3 -`), so nothing inside it can terminate a shell quote, and
the `-c` string is concatenated from single-quoted literals with `$ld` spliced in
as its own word — no backslashes, nothing nested:

```sh
payload='export LD_LIBRARY_PATH="'"$ld"'${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"; exec python3 -'
printf '%s\n' "$1" | su - "$CLAWBOX_USER" -c "$payload"
```

That is a structural fix rather than another escaping layer: the next edit to the
snippet cannot reintroduce this class of bug, because the snippet is not shell
text any more.

## Tests

The existing suite passed against the broken script for two compounding reasons,
both now closed:

- the `su` stub only ever *pattern-matched* the payload string; it never handed it
  to a shell, so a payload that could not parse looked identical to one that could;
- no test created the directories that make `kokoro_ld_path` non-empty, so `$ld`
  was always empty, the export was always skipped, and the broken branch was never
  built.

The stub now runs `bash -n -c` on **every** payload and fails the run if bash
refuses it, and a `WITH_CUDA_LIBS` fixture creates the loader directories a real
device has. Proven RED against this branch's parent before the fix, reproducing
the field error byte for byte:

```
AssertionError: bash refused to parse a payload install-voice.sh handed su:
bash: -c: line 7: unexpected EOF while looking for matching `"'
bash: -c: line 8: syntax error: unexpected end of file

    export LD_LIBRARY_PATH="…/cusparselt/lib:…/cuda/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH"}
    python3 -c "
from kokoro import KPipeline
…
```

Also asserted: the export actually carries the cusparselt directory; the export
is omitted rather than left with an empty leading entry when nothing resolves;
the verdict file records `ready` / `skipped:*` / `failed:model` distinctly; exit
12 returns non-zero and records a provisioning failure while 10/11 do not; and
`step_validate_services` fails on `failed:*` and on a missing verdict, but passes
on `skipped:*`.

## Validation

**On hardware** (a factory-fresh Orin dev box, JetPack 6.2, aarch64), which was
running Piper-only with no Kokoro stamp and no `kokoro-server` unit:

- before — `import torch` → `ImportError: libcusparseLt.so.0`
- after — the same `kokoro_predownload_model`, unchanged, on the fixed helper:
  `Kokoro model ready on cuda:0`, exit 0; `torch.cuda.is_available()` → `True`
- a full `--tts-only` from the repo path then exited **0** with
  `CLAWBOX_TTS_KOKORO=ready`, wrote `/etc/clawbox/tts-status`, the completion
  stamp and the `kokoro-server` user unit
- the shipped entrypoint now synthesises through Kokoro: 24 kHz WAV output
  (Piper's `en_US-lessac-medium` is 22.05 kHz)

**In a harness**: the payload-shape, verdict-file and validation-probe tests, plus
a stubbed-downloader execution of the payload proving the loader path arrives and
a non-zero downloader status still propagates.

## Scope

`bash -n` clean. The only other escaped `\${` in the repo writes a *deferred*
expansion into `~/.bashrc` from inside a plain double-quoted string, where no
outer expansion exists for the brace to close — verified to produce correct,
parseable output rather than assumed safe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent voice-synthesis installation status reporting.
  * Installation now reports ready, skipped, or failed outcomes.
  * Service validation now includes voice-synthesis health checks.

* **Bug Fixes**
  * Preserved configured voice providers and Piper fallback when Kokoro setup fails.
  * Improved handling of CUDA paths and remote Python execution during voice setup.

* **Tests**
  * Expanded coverage for installation outcomes, fallback behavior, status persistence, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->