### PR TITLE
Save a skill API key without rewriting the rest of ~/.hermes/.env (TASK-452 gap 1)

### DIFF
--- a/docs-site/editions/hermes-skills.mdx
+++ b/docs-site/editions/hermes-skills.mdx
@@ -67,7 +67,8 @@ A few things are worth knowing before you install:
     When that happens the store tells you so: which verdict the scan returned,
     which kind of source the skill came from, and that the device will not
     install it even if you confirm. There is deliberately no "install anyway"
-    here, because it would not work. Nothing is written to the device.
+    here, because it would not work. No skill files reach the device; the only
+    thing written is the device's own record that it refused.
 
     This is a limit of the device's skill installer, not of the store.
   </Accordion>

--- a/docs-site/editions/hermes-skills.mdx
+++ b/docs-site/editions/hermes-skills.mdx
@@ -58,6 +58,19 @@ A few things are worth knowing before you install:
     This applies to **every** publisher, including the skills Hermes itself
     publishes. A trusted name is not a reason to skip the question.
   </Accordion>
+  <Accordion title="Some skills the device refuses outright, and you cannot override it">
+    A few skills never reach that question. Hermes' own installer refuses a
+    skill rated **dangerous** when it comes from a community or third-party
+    source, and it refuses it before ClawBox is consulted — so there is nothing
+    to tick and no way to proceed from the store.
+
+    When that happens the store tells you so: which verdict the scan returned,
+    which kind of source the skill came from, and that the device will not
+    install it even if you confirm. There is deliberately no "install anyway"
+    here, because it would not work. Nothing is written to the device.
+
+    This is a limit of the device's skill installer, not of the store.
+  </Accordion>
   <Accordion title="An incomplete download is not an install">
     A skill is its instructions plus the files those instructions point at. If
     any of them could not be fetched, the device says which ones are missing and
@@ -125,7 +138,7 @@ Under Hermes' own data directory, `~/.hermes/skills/`:
 | `~/.hermes/skills/<category>/<name>/SKILL.md` | The skill itself — instructions plus any supporting files |
 | `~/.hermes/skills/.hub/lock.json` | The record of everything installed from the store |
 | `~/.hermes/skills/.bundled_manifest` | What shipped with the device |
-| `~/.hermes/.env` | API keys you entered for skills that need one |
+| `~/.hermes/.env` | Hermes' own environment file, where an API key you enter for a skill is stored. ClawBox edits one line of it — the rest, including Hermes' settings and its commented key hints, is left exactly as it was |
 
 Alongside those, ClawBox keeps its own record of any flagged skill you chose to
 install anyway, at `data/skill-install-audit.log` — one line per decision, with

--- a/src/app/setup-api/hermes/skills/secrets/route.ts
+++ b/src/app/setup-api/hermes/skills/secrets/route.ts
@@ -50,8 +50,18 @@ export async function GET(request: Request) {
   }
   try {
     return NextResponse.json({ secrets: await hermesSecretsPresent(keys) });
-  } catch {
-    return NextResponse.json({ error: "Could not read stored keys" }, { status: 500 });
+  } catch (err) {
+    // A file that could not be read holds no answer about which keys are set,
+    // and reporting them all as unset is how a customer is shown an empty field
+    // for a credential that may well be there.
+    console.error("[hermes skills secrets] read failed", err);
+    return NextResponse.json(
+      {
+        error: "The device's environment file could not be read.",
+        code: err instanceof HermesEnvUnreadableError ? "env_unreadable" : undefined,
+      },
+      { status: 500 },
+    );
   }
 }
 

--- a/src/app/setup-api/hermes/skills/secrets/route.ts
+++ b/src/app/setup-api/hermes/skills/secrets/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { hermesSkillsGuard } from "@/lib/hermes-skills-server";
 import {
+  HermesEnvUnreadableError,
   clearHermesSecret,
   hermesSecretsPresent,
   isValidEnvKey,
@@ -106,6 +107,19 @@ export async function POST(request: Request) {
   } catch (err) {
     // The message could name the .env path; log it, answer generically.
     console.error("[hermes skills secrets] write failed", err);
+    // One failure the customer can act on, and the one that must never be
+    // mistaken for a save: the device's environment file is there but could not
+    // be read, so it was left exactly as it was rather than replaced by a file
+    // built from nothing.
+    if (err instanceof HermesEnvUnreadableError) {
+      return NextResponse.json(
+        {
+          error: "The device's environment file could not be read, so nothing was changed.",
+          code: "env_unreadable",
+        },
+        { status: 500 },
+      );
+    }
     return NextResponse.json({ error: "Could not save the key" }, { status: 500 });
   }
 }

--- a/src/lib/hermes-env.ts
+++ b/src/lib/hermes-env.ts
@@ -187,7 +187,7 @@ export function applyEnvValues(existing: string, values: Record<string, string |
 export async function readHermesEnv(): Promise<Record<string, string>> {
   let raw: string;
   try {
-    raw = await fs.readFile(hermesEnvPath(), "utf-8");
+    raw = await readEnvText(hermesEnvPath());
   } catch (err) {
     // ENOENT: no .env, or no ~/.hermes to hold one. ENOTDIR: a component of
     // the path is a file, so there is no ~/.hermes directory either. Both mean
@@ -197,6 +197,26 @@ export async function readHermesEnv(): Promise<Record<string, string>> {
     throw err;
   }
   return parseHermesEnv(raw);
+}
+
+/**
+ * Read a path that may not be a regular file, without ever blocking on it.
+ *
+ * `fs.readFile` opens the path with plain `O_RDONLY`, and opening a FIFO that
+ * way parks until someone opens the write end — a request that never returns,
+ * which is worse than any wrong answer. `O_NONBLOCK` makes that open return
+ * immediately; it has no effect on a regular file, which is the only case that
+ * matters here. Errors are left exactly as the OS raised them (a directory
+ * still surfaces EISDIR), because the caller's ENOENT/ENOTDIR distinction is
+ * what tells "not configured" apart from "broken".
+ */
+async function readEnvText(envPath: string): Promise<string> {
+  const handle = await fs.open(envPath, constants.O_RDONLY | constants.O_NONBLOCK);
+  try {
+    return await handle.readFile("utf-8");
+  } finally {
+    await handle.close().catch(() => {});
+  }
 }
 
 /** The pure half of readHermesEnv, so parsing is testable without a file. */

--- a/src/lib/hermes-env.ts
+++ b/src/lib/hermes-env.ts
@@ -37,10 +37,43 @@
 // in-process; a concurrent interactive provisioning run is not something either
 // side can detect.
 
+import { constants } from "fs";
 import fs from "fs/promises";
+import type { FileHandle } from "fs/promises";
 import path from "path";
 
 const ENV_VAR_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Beyond this, the existing file is not something this module will merge into.
+ * ~/.hermes/.env is Hermes' own ~25 KB template plus a handful of settings; a
+ * quarter of a megabyte is not that file.
+ */
+const MAX_ENV_BYTES = 256 * 1024;
+
+export type HermesEnvUnreadableReason = "not-a-regular-file" | "too-large" | "unreadable";
+
+/**
+ * The existing ~/.hermes/.env is there but could not be read in a way that
+ * makes merging into it safe.
+ *
+ * Thrown rather than swallowed, because the alternative is what this module
+ * used to do: treat any read failure as "no .env yet" and write a file built
+ * from an empty base. That turns an EACCES or a failing eMMC into the silent
+ * deletion of every setting in the file — a whole-file loss reported as a 200.
+ * TASK-452's own version of that bug destroyed 500 lines of Hermes' template on
+ * a real device; the same hazard was live here for the email, WhatsApp, Discord
+ * and ClawAI writers, which is why the guard belongs in the shared writer.
+ */
+export class HermesEnvUnreadableError extends Error {
+  readonly reason: HermesEnvUnreadableReason;
+
+  constructor(reason: HermesEnvUnreadableReason) {
+    super(`the Hermes environment file could not be read safely (${reason})`);
+    this.name = "HermesEnvUnreadableError";
+    this.reason = reason;
+  }
+}
 
 /** Hermes' data root. Matches HERMES_HOME resolution in the CLI. */
 export function hermesHome(): string {
@@ -189,6 +222,45 @@ export async function getHermesEnvValue(key: string): Promise<string | null> {
   return Object.prototype.hasOwnProperty.call(env, key) ? env[key] : null;
 }
 
+/**
+ * The text a merge-write must build on, and the mode to write it back as.
+ *
+ * Absent is fine — that is a box with nothing configured yet, and the answer is
+ * an empty base and a fresh 0600 file. ANY OTHER failure is not fine: merging
+ * into a base we could not read means writing a file whose previous contents
+ * nobody saw. That case throws.
+ *
+ * The open is done ONCE and the stat and read both run through that descriptor,
+ * so the size and regular-file checks cannot be made against a different file
+ * than the one that is read (the path can come to mean something else between
+ * two lookups). O_NONBLOCK because the regular-file check now happens after the
+ * open: opening a fifo for reading would otherwise park here until someone
+ * opens the write end, and a hang is a worse outcome than the race it closes.
+ * It has no effect on regular files, the only case that goes on to read.
+ */
+async function readForMerge(envPath: string): Promise<{ existing: string; mode: number }> {
+  let handle: FileHandle;
+  try {
+    handle = await fs.open(envPath, constants.O_RDONLY | constants.O_NONBLOCK);
+  } catch (err) {
+    // ENOENT: no .env. ENOTDIR: a component of the path is a file, so there is
+    // no ~/.hermes directory either. Both mean "nothing configured yet".
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR") return { existing: "", mode: 0o600 };
+    throw new HermesEnvUnreadableError("unreadable");
+  }
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) throw new HermesEnvUnreadableError("not-a-regular-file");
+    if (stat.size > MAX_ENV_BYTES) throw new HermesEnvUnreadableError("too-large");
+    return { existing: await handle.readFile("utf-8"), mode: stat.mode & 0o777 };
+  } catch (err) {
+    throw err instanceof HermesEnvUnreadableError ? err : new HermesEnvUnreadableError("unreadable");
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
 // One writer at a time within this process. Two Settings saves landing together
 // would otherwise read the same base text and the second would drop the first.
 let writeChain: Promise<unknown> = Promise.resolve();
@@ -202,18 +274,11 @@ export async function setHermesEnvValues(values: Record<string, string | null>):
     const envPath = hermesEnvPath();
     await fs.mkdir(path.dirname(envPath), { recursive: true });
 
-    let existing = "";
-    let mode = 0o600;
-    try {
-      existing = await fs.readFile(envPath, "utf-8");
-      const stat = await fs.stat(envPath);
-      mode = stat.mode & 0o777;
-    } catch {
-      // No .env yet — create one at 0600.
-    }
-    if (existing.charCodeAt(0) === 0xfeff) existing = existing.slice(1);
+    const { existing, mode } = await readForMerge(envPath);
+    // Tolerate a BOM — Hermes reads with utf-8-sig for the same reason.
+    const base = existing.charCodeAt(0) === 0xfeff ? existing.slice(1) : existing;
 
-    const next = applyEnvValues(existing, values);
+    const next = applyEnvValues(base, values);
     const tmp = `${envPath}.clawbox.tmp`;
     // writeFile's `mode` is ignored when the path already exists (a stale temp
     // from a crash would keep its old, possibly wider, permissions), so chmod

--- a/src/lib/hermes-env.ts
+++ b/src/lib/hermes-env.ts
@@ -213,6 +213,14 @@ export async function readHermesEnv(): Promise<Record<string, string>> {
 async function readEnvText(envPath: string): Promise<string> {
   const handle = await fs.open(envPath, constants.O_RDONLY | constants.O_NONBLOCK);
   try {
+    const stat = await handle.stat();
+    // A directory raises the OS's own EISDIR from the read below, and callers
+    // key on those codes, so it is left to do that. Anything else that is not a
+    // regular file — a FIFO, a socket, a device — would READ perfectly well and
+    // answer nothing, which this module would then report as "no settings are
+    // configured". A pipe where the environment file should be is a fault, and
+    // is refused as one.
+    if (!stat.isFile() && !stat.isDirectory()) throw new HermesEnvUnreadableError("not-a-regular-file");
     return await handle.readFile("utf-8");
   } finally {
     await handle.close().catch(() => {});

--- a/src/lib/hermes-env.ts
+++ b/src/lib/hermes-env.ts
@@ -206,9 +206,12 @@ export async function readHermesEnv(): Promise<Record<string, string>> {
  * way parks until someone opens the write end — a request that never returns,
  * which is worse than any wrong answer. `O_NONBLOCK` makes that open return
  * immediately; it has no effect on a regular file, which is the only case that
- * matters here. Errors are left exactly as the OS raised them (a directory
- * still surfaces EISDIR), because the caller's ENOENT/ENOTDIR distinction is
- * what tells "not configured" apart from "broken".
+ * goes on to read.
+ *
+ * The OS's own errors are passed through unchanged, because `readHermesEnv`
+ * tells "not configured" apart from "broken" by their codes. The one thing
+ * added is a refusal for a path that is not a regular file and would otherwise
+ * read as nothing at all — see below.
  */
 async function readEnvText(envPath: string): Promise<string> {
   const handle = await fs.open(envPath, constants.O_RDONLY | constants.O_NONBLOCK);

--- a/src/lib/hermes-skill-secrets.ts
+++ b/src/lib/hermes-skill-secrets.ts
@@ -7,38 +7,42 @@
 // `OP_SERVICE_ACCOUNT_TOKEN`, given a link to go and create one, and then left
 // with nowhere on the device to type it — the skill silently does nothing.
 //
-// Hermes reads process environment from ~/.hermes/.env; that is where
-// `hermes config set TELEGRAM_BOT_TOKEN` puts the Telegram token
-// (src/lib/hermes-telegram.ts is the working precedent for the same idea). This
-// module writes that file directly rather than through the CLI, because
-// `hermes config set` routes only its OWN allowlisted keys to .env — an
-// arbitrary skill's variable name is not on that list and would land in
-// config.yaml, where nothing would ever read it as an environment variable.
+// ── What this module is, and what it is NOT ─────────────────────────────────
 //
-// Rules that make a direct write safe:
-//   * the KEY must look like an environment variable and nothing else, so a
-//     value can never smuggle in a second assignment or a shell fragment;
-//   * the VALUE must be printable ASCII, so one secret is always one line and
-//     no control byte survives into a file support engineers read;
-//   * the file is rewritten whole from a parsed map, so a malformed pre-existing
-//     line cannot be duplicated or half-edited;
-//   * it is written 0600 through a temp file + rename, so a reader never sees a
-//     half-written secrets file and no other account can read it;
-//   * values are NEVER read back out to the browser — only whether a key is set.
+// It is the skill store's ALPHABET for a secret, and nothing else. The bytes go
+// to ~/.hermes/.env through `hermes-env.ts`, which is the device's one writer
+// for that file — the same one the email, WhatsApp, Discord and ClawAI settings
+// use. That matters for a reason a real device proved:
+//
+// The first cut of this module was its own reader and writer. It parsed the
+// file into a map and wrote the map back out, on the premise that ~/.hermes/.env
+// is a secret store ClawBox owns. It is not: the installer creates it from
+// Hermes' own 504-line template and `hermes config env-path` points customers at
+// it. Saving ONE skill API key took the file from 24792 bytes to 372 — every
+// live value survived, and all 116 of its commented-out key hints did not.
+// `applyEnvValues` had been merge-writing that file correctly the whole time;
+// the fork simply did not use it. A second writer also meant a second
+// read-modify-write cycle outside `hermes-env.ts`'s single-writer chain, so a
+// skill-secret save landing beside a Settings save could silently drop one.
+//
+// So: the rules below decide what a skill secret may look like, and
+// `setHermesEnvValues` decides what happens to the file.
 
-import { constants } from 'fs';
+import {
+  clearHermesEnvValues,
+  hermesEnvPath,
+  readHermesEnv as readHermesEnvRecord,
+  setHermesEnvValues,
+} from '@/lib/hermes-env';
 import fs from 'fs/promises';
-import type { FileHandle } from 'fs/promises';
-import path from 'path';
 
-const HERMES_HOME =
-  process.env.HERMES_HOME || path.join(process.env.HOME || '/home/clawbox', '.hermes');
-
-export const HERMES_ENV_PATH = path.join(HERMES_HOME, '.env');
+export { HermesEnvUnreadableError } from '@/lib/hermes-env';
 
 // The shape every declared skill secret uses (OP_SERVICE_ACCOUNT_TOKEN,
-// BRAVE_API_KEY, …). Deliberately upper-snake only: a lowercase or dotted name
-// is a config key, not an env var, and belongs in a different store.
+// BRAVE_API_KEY, …). Deliberately upper-snake only, and stricter than the
+// `^[A-Za-z_][A-Za-z0-9_]*$` the .env writer itself accepts: a lowercase or
+// dotted name is a config key, not an env var, and belongs in a different
+// store.
 const ENV_KEY_RE = /^[A-Z][A-Z0-9_]{1,63}$/;
 
 export function isValidEnvKey(key: string): boolean {
@@ -62,112 +66,62 @@ export function isValidEnvValue(value: string): boolean {
   return typeof value === 'string' && ENV_VALUE_RE.test(value);
 }
 
-const MAX_ENV_BYTES = 256 * 1024;
+/** Every live assignment in ~/.hermes/.env, for lookup only. */
+export async function readHermesEnv(): Promise<Map<string, string>> {
+  try {
+    return new Map(Object.entries(await readHermesEnvRecord()));
+  } catch {
+    // A file that cannot be read holds no keys this store can report. The WRITE
+    // path treats the same condition as a refusal; a read has nothing to
+    // destroy by answering "nothing is set".
+    return new Map();
+  }
+}
 
 /**
- * Parse ~/.hermes/.env into a map, preserving nothing but the assignments.
- * Comments and blank lines are dropped on purpose: this file is a secret store
- * written by tooling, and round-tripping arbitrary text through a rewrite is
- * how half-edited files happen.
+ * Set one skill secret, leaving the rest of ~/.hermes/.env alone.
+ *
+ * Returns false when the key or value is not acceptable. Throws
+ * HermesEnvUnreadableError when the existing file cannot be read — the caller
+ * must report that as a failure, never as a save.
  */
-export async function readHermesEnv(): Promise<Map<string, string>> {
-  const out = new Map<string, string>();
-  let raw: string;
-  // Open once, then stat and read through that SAME descriptor. Statting the
-  // path and then reading the path are two lookups, and between them the name
-  // ~/.hermes/.env can come to mean a different file — a symlink swap, or a
-  // rename by anything else that writes this file. The size cap would then have
-  // been checked against a file we never read, and the regular-file check
-  // against a path that is now a fifo, which blocks the read forever. A handle
-  // is pinned to one inode, so what we measured is what we get.
-  let handle: FileHandle | undefined;
-  try {
-    // O_NONBLOCK, because the regular-file check now happens after the open
-    // rather than before it: opening a fifo for reading otherwise parks here
-    // until someone opens the write end, and a hang is a worse outcome than the
-    // stale-stat race this open is meant to close. It has no effect on regular
-    // files, which is the only case that goes on to read.
-    handle = await fs.open(HERMES_ENV_PATH, constants.O_RDONLY | constants.O_NONBLOCK);
-    const st = await handle.stat();
-    if (!st.isFile() || st.size > MAX_ENV_BYTES) return out;
-    raw = await handle.readFile('utf8');
-  } catch {
-    return out;
-  } finally {
-    await handle?.close().catch(() => {});
-  }
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#')) continue;
-    const eq = trimmed.indexOf('=');
-    if (eq <= 0) continue;
-    const key = trimmed.slice(0, eq).replace(/^export\s+/, '').trim();
-    if (!isValidEnvKey(key)) continue;
-    out.set(key, unquote(trimmed.slice(eq + 1).trim()));
-  }
-  return out;
-}
-
-function unquote(value: string): string {
-  if (value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"') {
-    return value.slice(1, -1).replace(/\\(["\\])/g, '$1');
-  }
-  if (value.length >= 2 && value[0] === "'" && value[value.length - 1] === "'") {
-    return value.slice(1, -1);
-  }
-  return value;
-}
-
-// Quote only when the raw form would be ambiguous. An unquoted token is what
-// every existing hand-written .env on these devices looks like, and keeping the
-// common case unquoted means a support engineer reading the file sees what they
-// expect.
-function quote(value: string): string {
-  if (value === '') return '""';
-  if (/^[A-Za-z0-9._:/@+-]+$/.test(value)) return value;
-  return `"${value.replace(/([\\"])/g, '\\$1')}"`;
-}
-
-function serialize(env: Map<string, string>): string {
-  const lines = ['# Managed by ClawBox. One KEY=value per line.'];
-  for (const key of Array.from(env.keys()).sort()) {
-    lines.push(`${key}=${quote(env.get(key) as string)}`);
-  }
-  return `${lines.join('\n')}\n`;
-}
-
-async function writeHermesEnv(env: Map<string, string>): Promise<void> {
-  await fs.mkdir(HERMES_HOME, { recursive: true });
-  const tmp = `${HERMES_ENV_PATH}.tmp-${process.pid}`;
-  await fs.writeFile(tmp, serialize(env), { mode: 0o600 });
-  await fs.rename(tmp, HERMES_ENV_PATH);
-  // rename preserves the temp file's mode, but an .env that predates this code
-  // may be 0644; make the final state explicit either way.
-  await fs.chmod(HERMES_ENV_PATH, 0o600).catch(() => {});
-}
-
-/** Set one skill secret. Returns false when the key or value is not acceptable. */
 export async function setHermesSecret(key: string, value: string): Promise<boolean> {
   // Both alphabets are re-tested here, against the same anchored expressions
   // the exported predicates use, rather than being delegated to them. This is
-  // the function that puts bytes in the file, so the check that decides what
-  // may end up there belongs on this line: a future caller that forgets to
-  // pre-validate, or a predicate that grows a special case, cannot widen what
-  // reaches ~/.hermes/.env without editing the write path itself.
+  // the function that decides what may end up in the file, so the check belongs
+  // on this line: a future caller that forgets to pre-validate, or a predicate
+  // that grows a special case, cannot widen what reaches ~/.hermes/.env without
+  // editing the write path itself.
   if (!ENV_KEY_RE.test(key) || !ENV_VALUE_RE.test(value)) return false;
-  const env = await readHermesEnv();
-  env.set(key, value);
-  await writeHermesEnv(env);
+  await setHermesEnvValues({ [key]: value });
+  await tightenEnvMode();
   return true;
 }
 
 /** Clear one skill secret. Returns true when it existed and is now gone. */
 export async function clearHermesSecret(key: string): Promise<boolean> {
   if (!isValidEnvKey(key)) return false;
-  const env = await readHermesEnv();
-  if (!env.delete(key)) return false;
-  await writeHermesEnv(env);
+  if (!(await readHermesEnv()).has(key)) return false;
+  await clearHermesEnvValues([key]);
   return true;
+}
+
+/**
+ * Never widen, but do narrow. `setHermesEnvValues` preserves whatever mode the
+ * file already had, deliberately — it mirrors Hermes' own writer. That is the
+ * right default for a settings file and the wrong one for the moment a
+ * credential is first written into it: the installer's template arrives 0644 on
+ * some boxes, and a world-readable file holding an API key is worth quietly
+ * fixing. Best-effort: a failure here must not turn a stored key into an error.
+ */
+async function tightenEnvMode(): Promise<void> {
+  const envPath = hermesEnvPath();
+  try {
+    const mode = (await fs.stat(envPath)).mode & 0o777;
+    if (mode & 0o077) await fs.chmod(envPath, mode & 0o700);
+  } catch {
+    // The write succeeded; the permissions are a hardening, not the result.
+  }
 }
 
 /**

--- a/src/lib/hermes-skill-secrets.ts
+++ b/src/lib/hermes-skill-secrets.ts
@@ -29,6 +29,7 @@
 // `setHermesEnvValues` decides what happens to the file.
 
 import {
+  HermesEnvUnreadableError,
   clearHermesEnvValues,
   hermesEnvPath,
   readHermesEnv as readHermesEnvRecord,
@@ -66,15 +67,20 @@ export function isValidEnvValue(value: string): boolean {
   return typeof value === 'string' && ENV_VALUE_RE.test(value);
 }
 
-/** Every live assignment in ~/.hermes/.env, for lookup only. */
+/**
+ * Every live assignment in ~/.hermes/.env, for lookup only.
+ *
+ * An ABSENT file is an empty map — that is a box with nothing configured yet,
+ * and the shared reader already answers it that way. Anything else is a fault
+ * and is raised, because "no keys are set" is the wrong answer twice over: it
+ * has the customer retype a credential into a file nothing could read, and it
+ * makes `clearHermesSecret` report a key as already gone when it never looked.
+ */
 export async function readHermesEnv(): Promise<Map<string, string>> {
   try {
     return new Map(Object.entries(await readHermesEnvRecord()));
-  } catch {
-    // A file that cannot be read holds no keys this store can report. The WRITE
-    // path treats the same condition as a refusal; a read has nothing to
-    // destroy by answering "nothing is set".
-    return new Map();
+  } catch (err) {
+    throw err instanceof HermesEnvUnreadableError ? err : new HermesEnvUnreadableError('unreadable');
   }
 }
 

--- a/src/tests/routes/hermes/skills-secrets.test.ts
+++ b/src/tests/routes/hermes/skills-secrets.test.ts
@@ -193,25 +193,29 @@ describe("skill secrets (TASK-452)", () => {
   // ran against the path again. They now run against one open descriptor, and
   // the open is non-blocking so the regular-file check can still be reached.
   it("does not hang on a path that is not a regular file", async () => {
-    const { readHermesEnv } = await import("@/lib/hermes-skill-secrets");
+    const { HermesEnvUnreadableError, readHermesEnv } = await import("@/lib/hermes-skill-secrets");
     try {
       execFileSync("mkfifo", [envPath()]);
       if (!(await fs.stat(envPath())).isFIFO()) return;
     } catch {
       return; // no real FIFOs here; CI runs on Linux, which has them
     }
-    // Settling is the property under test: a non-blocking read of a
-    // writer-less FIFO gives EOF on some kernels and EAGAIN on others, and
-    // either is a fine answer. Parking the request forever is not.
+    // Two properties, and the first is why the open is O_NONBLOCK: it must
+    // ANSWER. A blocking open of a writer-less FIFO parks the request forever.
     let timer: ReturnType<typeof setTimeout>;
     const hung = new Promise((_, reject) => {
       timer = setTimeout(() => reject(new Error("readHermesEnv hung on a fifo")), 2000);
     });
+    let outcome: unknown;
     try {
-      await Promise.race([readHermesEnv().catch((err: unknown) => err), hung]);
+      outcome = await Promise.race([readHermesEnv().catch((err: unknown) => err), hung]);
     } finally {
       clearTimeout(timer!);
     }
+    // And the answer must be a fault. A FIFO reads as zero bytes, which would
+    // otherwise be reported as "no keys are set" for a device whose secrets
+    // file has been replaced by a pipe.
+    expect(outcome).toBeInstanceOf(HermesEnvUnreadableError);
   });
 
   // Answering "nothing is set" for a file nobody could read is the wrong answer

--- a/src/tests/routes/hermes/skills-secrets.test.ts
+++ b/src/tests/routes/hermes/skills-secrets.test.ts
@@ -216,3 +216,172 @@ describe("skill secrets (TASK-452)", () => {
     expect((await get("BRAVE_API_KEY")).status).toBe(404);
   });
 });
+
+// ── round 2, gap 1: saving one key must not rewrite the file ────────────────
+//
+// Live on the box: saving ONE skill API key took ~/.hermes/.env from 24 792
+// bytes to 372 — 504 lines to 12, and 116 commented-out key hints to 0. The
+// module rewrote the whole file from a parsed map on the premise that it owns
+// it. It does not: the installer creates that file from Hermes' own template
+// ("Created ~/.hermes/.env from template") and `hermes config env-path` points
+// customers at it. No live value was lost, and all of the documentation was.
+//
+// Same class as the config.yaml rewrite TASK-446 hit, fixed there by a
+// merge-write; these are the merge-write's terms.
+
+/** ~/.hermes/.env as the installer creates it: hints, blanks, live settings. */
+function hermesTemplate(): string {
+  const lines = [
+    "# Hermes environment",
+    "# One KEY=value per line. Uncomment a key to enable it.",
+    "",
+    "# ── Messaging ─────────────────────────────────────────────",
+    "TELEGRAM_BOT_TOKEN=123:abc",
+    "# TELEGRAM_ALLOWED_CHATS=",
+    "# DISCORD_BOT_TOKEN=",
+    "",
+    "# ── Providers ─────────────────────────────────────────────",
+    "ANTHROPIC_API_KEY=sk-ant-live",
+  ];
+  // The bulk of the real file: commented hints naming every variable Hermes
+  // understands. These are the 116 lines the rewrite destroyed.
+  for (let i = 0; i < 116; i++) lines.push(`# HERMES_OPTION_${i}=`);
+  lines.push("", "# ── Local ─────────────────────────────────────────────────", "OLLAMA_HOST=127.0.0.1:11434", "");
+  return lines.join("\n");
+}
+
+function commentedHints(raw: string): number {
+  return raw.split("\n").filter((l) => /^#\s*[A-Za-z_][A-Za-z0-9_]*=/.test(l)).length;
+}
+
+describe("skill secrets keep the rest of .env (TASK-452 round 2, gap 1)", () => {
+  it("adds a key and changes NOTHING else — the round trip that regressed", async () => {
+    const before = hermesTemplate();
+    await fs.writeFile(envPath(), before, { mode: 0o600 });
+
+    const { status } = await post({ key: "BRAVE_API_KEY", value: "brv_live" });
+    expect(status).toBe(200);
+
+    const after = await fs.readFile(envPath(), "utf8");
+    // The whole previous file is still there, byte for byte, and the new
+    // assignment is the only addition.
+    expect(after).toBe(`${before}BRAVE_API_KEY=brv_live\n`);
+    expect(after.length).toBeGreaterThan(before.length);
+  });
+
+  it("keeps every commented key hint the installer's template documents", async () => {
+    const before = hermesTemplate();
+    await fs.writeFile(envPath(), before, { mode: 0o600 });
+    expect(commentedHints(before)).toBe(118);
+
+    await post({ key: "BRAVE_API_KEY", value: "brv_live" });
+
+    const after = await fs.readFile(envPath(), "utf8");
+    expect(commentedHints(after)).toBe(118);
+    expect(after.split("\n")).toHaveLength(before.split("\n").length + 1);
+  });
+
+  it("keeps every other live setting, and their order", async () => {
+    await fs.writeFile(envPath(), hermesTemplate(), { mode: 0o600 });
+    await post({ key: "BRAVE_API_KEY", value: "brv_live" });
+
+    const { readHermesEnv } = await import("@/lib/hermes-skill-secrets");
+    const env = await readHermesEnv();
+    expect(env.get("TELEGRAM_BOT_TOKEN")).toBe("123:abc");
+    expect(env.get("ANTHROPIC_API_KEY")).toBe("sk-ant-live");
+    expect(env.get("OLLAMA_HOST")).toBe("127.0.0.1:11434");
+    expect(env.get("BRAVE_API_KEY")).toBe("brv_live");
+
+    const after = await fs.readFile(envPath(), "utf8");
+    expect(after.indexOf("TELEGRAM_BOT_TOKEN")).toBeLessThan(after.indexOf("ANTHROPIC_API_KEY"));
+  });
+
+  it("edits an existing key in place — exactly one line differs", async () => {
+    const before = hermesTemplate();
+    await fs.writeFile(envPath(), before, { mode: 0o600 });
+
+    await post({ key: "ANTHROPIC_API_KEY", value: "sk-ant-new" });
+
+    const after = (await fs.readFile(envPath(), "utf8")).split("\n");
+    const differing = before.split("\n").map((line, i) => [line, after[i]]).filter(([a, b]) => a !== b);
+    expect(differing).toEqual([["ANTHROPIC_API_KEY=sk-ant-live", "ANTHROPIC_API_KEY=sk-ant-new"]]);
+  });
+
+  it("clears a key by removing its line, and nothing else", async () => {
+    const before = hermesTemplate();
+    await fs.writeFile(envPath(), before, { mode: 0o600 });
+
+    const { status } = await post({ key: "ANTHROPIC_API_KEY", value: "" });
+    expect(status).toBe(200);
+
+    const after = await fs.readFile(envPath(), "utf8");
+    expect(after).toBe(before.replace("ANTHROPIC_API_KEY=sk-ant-live\n", ""));
+    expect(commentedHints(after)).toBe(118);
+  });
+
+  // The `export KEY=` form has to be RECOGNISED, or the write appends a second
+  // assignment below it and the old credential wins on the next read. The
+  // rewritten line drops the prefix and the file is normalised to LF, because
+  // that is what Hermes' own writer does to a file it edits — a skill secret
+  // goes through the same writer as every other Hermes setting rather than
+  // inventing a second dialect for one file.
+  it("replaces an export-prefixed assignment in place instead of duplicating it", async () => {
+    await fs.writeFile(envPath(), "# note\nexport BRAVE_API_KEY=old\n# tail\n", { mode: 0o600 });
+
+    await post({ key: "BRAVE_API_KEY", value: "new" });
+
+    expect(await fs.readFile(envPath(), "utf8")).toBe("# note\nBRAVE_API_KEY=new\n# tail\n");
+  });
+
+  // A file that assigns the same key twice is ambiguous about which one a
+  // parser takes, so leaving a stale duplicate behind is how the previous
+  // credential comes back.
+  it("rewrites every assignment of the key, leaving no stale credential", async () => {
+    await fs.writeFile(envPath(), "BRAVE_API_KEY=old1\n# hint\nBRAVE_API_KEY=old2\n", { mode: 0o600 });
+
+    await post({ key: "BRAVE_API_KEY", value: "new" });
+
+    const after = await fs.readFile(envPath(), "utf8");
+    // The first definition is rewritten in place, so key order is stable, and
+    // the shadowing duplicate is dropped rather than left holding a value.
+    expect(after).toBe("BRAVE_API_KEY=new\n# hint\n");
+    expect(after).not.toContain("old");
+  });
+
+  it("appends to a file with no trailing newline without joining two lines", async () => {
+    await fs.writeFile(envPath(), "TELEGRAM_BOT_TOKEN=123:abc", { mode: 0o600 });
+
+    await post({ key: "BRAVE_API_KEY", value: "brv" });
+
+    expect(await fs.readFile(envPath(), "utf8")).toBe("TELEGRAM_BOT_TOKEN=123:abc\nBRAVE_API_KEY=brv\n");
+  });
+
+  // A file this module could not READ is a file it must not WRITE: the old code
+  // fell back to an empty map, and an empty map serialises to a two-line file.
+  it("refuses the write when the path is not a regular file, and leaves it alone", async () => {
+    await fs.mkdir(envPath());
+
+    const { status, body } = await post({ key: "BRAVE_API_KEY", value: "brv" });
+    expect(status).toBe(500);
+    expect(body).toMatchObject({ code: "env_unreadable" });
+    expect((await fs.stat(envPath())).isDirectory()).toBe(true);
+  });
+
+  it("refuses the write when the file is past the size this module will parse", async () => {
+    const huge = `# big\n${"# padding padding padding\n".repeat(12_000)}TELEGRAM_BOT_TOKEN=123:abc\n`;
+    await fs.writeFile(envPath(), huge, { mode: 0o600 });
+
+    const { status, body } = await post({ key: "BRAVE_API_KEY", value: "brv" });
+    expect(status).toBe(500);
+    expect(body).toMatchObject({ code: "env_unreadable" });
+    expect(await fs.readFile(envPath(), "utf8")).toBe(huge);
+  });
+
+  it("leaves no temporary file behind next to the secrets file", async () => {
+    await fs.writeFile(envPath(), hermesTemplate(), { mode: 0o600 });
+    await post({ key: "BRAVE_API_KEY", value: "brv" });
+
+    const entries = await fs.readdir(hermesHome);
+    expect(entries.filter((name) => name.startsWith(".env."))).toEqual([]);
+  });
+});

--- a/src/tests/routes/hermes/skills-secrets.test.ts
+++ b/src/tests/routes/hermes/skills-secrets.test.ts
@@ -53,7 +53,7 @@ async function get(keys: string) {
   const res = await GET(
     new Request(`http://localhost/setup-api/hermes/skills/secrets?keys=${encodeURIComponent(keys)}`),
   );
-  return { status: res.status, body: (await res.json()) as { secrets?: Record<string, boolean> } };
+  return { status: res.status, body: (await res.json()) as { secrets?: Record<string, boolean>; code?: string } };
 }
 
 describe("skill secrets (TASK-452)", () => {
@@ -192,21 +192,55 @@ describe("skill secrets (TASK-452)", () => {
   // regular-file checks used to run against a stat of the path, then the read
   // ran against the path again. They now run against one open descriptor, and
   // the open is non-blocking so the regular-file check can still be reached.
-  it("reads nothing through a path that is not a regular file, and does not hang", async () => {
+  it("does not hang on a path that is not a regular file", async () => {
     const { readHermesEnv } = await import("@/lib/hermes-skill-secrets");
-    execFileSync("mkfifo", [envPath()]);
-    await expect(
-      Promise.race([
-        readHermesEnv(),
-        new Promise((_, reject) => setTimeout(() => reject(new Error("readHermesEnv hung on a fifo")), 2000)),
-      ]),
-    ).resolves.toEqual(new Map());
+    try {
+      execFileSync("mkfifo", [envPath()]);
+      if (!(await fs.stat(envPath())).isFIFO()) return;
+    } catch {
+      return; // no real FIFOs here; CI runs on Linux, which has them
+    }
+    // Settling is the property under test: a non-blocking read of a
+    // writer-less FIFO gives EOF on some kernels and EAGAIN on others, and
+    // either is a fine answer. Parking the request forever is not.
+    let timer: ReturnType<typeof setTimeout>;
+    const hung = new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error("readHermesEnv hung on a fifo")), 2000);
+    });
+    try {
+      await Promise.race([readHermesEnv().catch((err: unknown) => err), hung]);
+    } finally {
+      clearTimeout(timer!);
+    }
   });
 
-  it("reads nothing when the path is a directory", async () => {
-    const { readHermesEnv } = await import("@/lib/hermes-skill-secrets");
+  // Answering "nothing is set" for a file nobody could read is the wrong answer
+  // twice over: the owner is shown an empty field for a credential that may
+  // well be there, and a clear reports a key already gone that it never looked
+  // for.
+  it("raises rather than reporting an empty store when the path is a directory", async () => {
+    const { HermesEnvUnreadableError, readHermesEnv } = await import("@/lib/hermes-skill-secrets");
     await fs.mkdir(envPath());
-    expect(await readHermesEnv()).toEqual(new Map());
+    await expect(readHermesEnv()).rejects.toBeInstanceOf(HermesEnvUnreadableError);
+  });
+
+  it("answers the presence GET 500 rather than reporting every key unset", async () => {
+    await fs.mkdir(envPath());
+    const { status, body } = await get("BRAVE_API_KEY");
+    expect(status).toBe(500);
+    expect(body).toMatchObject({ code: "env_unreadable" });
+    expect(body.secrets).toBeUndefined();
+  });
+
+  // The one CodeRabbit found: clearHermesSecret read the file, got an empty map
+  // from the swallowed failure, concluded the key was already absent and
+  // answered 200 {set:false} for a secret it never removed.
+  it("does not report a key cleared when it could not read the file", async () => {
+    await fs.mkdir(envPath());
+    const { status, body } = await post({ key: "BRAVE_API_KEY", value: "" });
+    expect(status).toBe(500);
+    expect(body).toMatchObject({ code: "env_unreadable" });
+    expect(body).not.toMatchObject({ ok: true });
   });
 
   it("is 404 off Hermes, like the rest of the skills family", async () => {

--- a/src/tests/unit/hermes-env.test.ts
+++ b/src/tests/unit/hermes-env.test.ts
@@ -253,21 +253,25 @@ describe("setHermesEnvValues on disk", () => {
     // SETTLING is the property under test, not which way it settles: a
     // non-blocking read of a writer-less FIFO gives EOF on some kernels and
     // EAGAIN on others, and either is a fine answer. Hanging is not.
-    const settles = async (work: Promise<unknown>, what: string) => {
+    const inTime = async (work: Promise<unknown>, what: string) => {
       let timer: ReturnType<typeof setTimeout>;
       const hung = new Promise((_, reject) => {
         timer = setTimeout(() => reject(new Error(`${what} hung on a fifo`)), 2000);
       });
       try {
-        await Promise.race([work.catch((err: unknown) => err), hung]);
+        await Promise.race([work, hung]);
       } finally {
         clearTimeout(timer!);
       }
     };
-    await settles(readHermesEnv(), "readHermesEnv");
-    // The write must not merely settle — it must REFUSE. A FIFO is not a base
-    // to build the next .env on.
-    await settles(
+    // Neither side may merely settle: a FIFO reads as zero bytes, so "it
+    // resolved empty" would be this module reporting a device whose settings
+    // file is a pipe as a device with no settings.
+    await inTime(
+      expect(readHermesEnv()).rejects.toBeInstanceOf(HermesEnvUnreadableError),
+      "readHermesEnv",
+    );
+    await inTime(
       expect(setHermesEnvValues({ A: "1" })).rejects.toBeInstanceOf(HermesEnvUnreadableError),
       "setHermesEnvValues",
     );

--- a/src/tests/unit/hermes-env.test.ts
+++ b/src/tests/unit/hermes-env.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "child_process";
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
@@ -230,6 +231,46 @@ describe("setHermesEnvValues on disk", () => {
     await fs.mkdir(hermesEnvPath(), { recursive: true });
     await expect(readHermesEnv()).rejects.toMatchObject({ code: "EISDIR" });
     await expect(getHermesEnvValue("A")).rejects.toMatchObject({ code: "EISDIR" });
+  });
+
+  // A FIFO at the path is the one shape that must not produce a WRONG kind of
+  // answer: `fs.readFile` opens with plain O_RDONLY, and opening a FIFO that
+  // way parks until someone opens the write end — a request that never
+  // returns. Both paths open O_NONBLOCK for that reason.
+  it("does not hang when the path is a fifo", async () => {
+    // Skipped where the platform cannot make one — Git Bash on Windows exits 0
+    // from `mkfifo` and creates nothing, which would make this test assert the
+    // opposite of what it is for. CI runs on Linux, which has real FIFOs.
+    const isFifo = await (async () => {
+      try {
+        execFileSync("mkfifo", [hermesEnvPath()]);
+        return (await fs.stat(hermesEnvPath())).isFIFO();
+      } catch {
+        return false;
+      }
+    })();
+    if (!isFifo) return;
+    // SETTLING is the property under test, not which way it settles: a
+    // non-blocking read of a writer-less FIFO gives EOF on some kernels and
+    // EAGAIN on others, and either is a fine answer. Hanging is not.
+    const settles = async (work: Promise<unknown>, what: string) => {
+      let timer: ReturnType<typeof setTimeout>;
+      const hung = new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${what} hung on a fifo`)), 2000);
+      });
+      try {
+        await Promise.race([work.catch((err: unknown) => err), hung]);
+      } finally {
+        clearTimeout(timer!);
+      }
+    };
+    await settles(readHermesEnv(), "readHermesEnv");
+    // The write must not merely settle — it must REFUSE. A FIFO is not a base
+    // to build the next .env on.
+    await settles(
+      expect(setHermesEnvValues({ A: "1" })).rejects.toBeInstanceOf(HermesEnvUnreadableError),
+      "setHermesEnvValues",
+    );
   });
 
   // TASK-452 round 2. The READ path has refused to flatten a fault into

--- a/src/tests/unit/hermes-env.test.ts
+++ b/src/tests/unit/hermes-env.test.ts
@@ -4,7 +4,9 @@ import os from "os";
 import path from "path";
 
 import {
+  HermesEnvUnreadableError,
   applyEnvValues,
+  clearHermesEnvValues,
   envLineDefinesKey,
   getHermesEnvValue,
   hermesEnvPath,
@@ -228,6 +230,50 @@ describe("setHermesEnvValues on disk", () => {
     await fs.mkdir(hermesEnvPath(), { recursive: true });
     await expect(readHermesEnv()).rejects.toMatchObject({ code: "EISDIR" });
     await expect(getHermesEnvValue("A")).rejects.toMatchObject({ code: "EISDIR" });
+  });
+
+  // TASK-452 round 2. The READ path has refused to flatten a fault into
+  // "nothing configured" since the WhatsApp panel bug above; the WRITE path was
+  // still doing exactly that, one `catch` further down, and the consequence is
+  // worse. `existing` stayed "" and `applyEnvValues("", …)` then wrote a
+  // two-line file over whatever was there — the whole of ~/.hermes/.env, which
+  // on a real device is Hermes' own 504-line template plus every credential the
+  // email, WhatsApp, Discord, ClawAI and skill-secret settings have stored.
+  //
+  // A file this module cannot read is a file it must not merge into.
+  describe("a base it could not read", () => {
+    it("refuses to write rather than rebuilding the file from nothing", async () => {
+      await fs.mkdir(hermesEnvPath(), { recursive: true });
+
+      await expect(setHermesEnvValues({ A: "1" })).rejects.toBeInstanceOf(HermesEnvUnreadableError);
+      // Still a directory: nothing was renamed over it.
+      expect((await fs.stat(hermesEnvPath())).isDirectory()).toBe(true);
+    });
+
+    it("refuses when the file is larger than it will parse, and changes nothing", async () => {
+      const huge = `# big\n${"# padding padding padding\n".repeat(12_000)}KEEP_ME=yes\n`;
+      await fs.writeFile(hermesEnvPath(), huge, { mode: 0o600 });
+
+      await expect(setHermesEnvValues({ A: "1" })).rejects.toMatchObject({ reason: "too-large" });
+      expect(await fs.readFile(hermesEnvPath(), "utf8")).toBe(huge);
+    });
+
+    it("leaves a clearing write refused too, so a delete cannot empty the file", async () => {
+      await fs.mkdir(hermesEnvPath(), { recursive: true });
+
+      await expect(clearHermesEnvValues(["A"])).rejects.toBeInstanceOf(HermesEnvUnreadableError);
+      expect((await fs.stat(hermesEnvPath())).isDirectory()).toBe(true);
+    });
+
+    it("keeps writing after a refusal — the single-writer chain survives it", async () => {
+      const blocked = hermesEnvPath();
+      await fs.mkdir(blocked, { recursive: true });
+      await expect(setHermesEnvValues({ A: "1" })).rejects.toBeInstanceOf(HermesEnvUnreadableError);
+
+      await fs.rm(blocked, { recursive: true, force: true });
+      await setHermesEnvValues({ A: "1" });
+      expect(await readHermesEnv()).toEqual({ A: "1" });
+    });
   });
 });
 


### PR DESCRIPTION
Closes the remaining HIGH gap from TASK-452's round-2 validation. (The other one — the installer refusing a skill while exiting 0 — landed meanwhile in #504; this PR deliberately does not touch it.)

---

## What happened on the device

Saving ONE skill API key through `POST /setup-api/hermes/skills/secrets` took `~/.hermes/.env` from **24 792 bytes to 372** — 504 lines to 12, and **116 commented-out key hints to 0**. Every live value survived; all of the file's documentation did not.

`hermes-skill-secrets.ts` parsed the file into a map and wrote the map back out, on the premise stated in its own comment:

> *"Comments and blank lines are dropped on purpose: this file is a secret store written by tooling."*

That premise is false. The installer creates `~/.hermes/.env` from **Hermes' own 504-line template** (`✓ Created ~/.hermes/.env from template`), and `hermes config env-path` points customers at it. Same bug class as the `config.yaml` rewrite TASK-446 hit; #472 fixed that one with a merge-write and landed *after* the code here, so the lesson never reached this file.

## The fix is to stop having two writers

`src/lib/hermes-env.ts` has been this device's writer for `~/.hermes/.env` all along — the one the email, WhatsApp, Discord and ClawAI settings use — and `applyEnvValues` has always merged in place: an existing assignment replaced on its own line, a new one appended, duplicate definitions collapsed, every other byte carried through. It also mirrors Hermes' own `_quote_env_value` character for character, so a value ClawBox writes reads back identically through Hermes' parser.

The store simply had a second implementation beside it. That second implementation also wrote **outside** `hermes-env.ts`'s single-writer chain, so a skill-secret save landing beside a Settings save could silently drop one of them.

So the fork goes. `hermes-skill-secrets.ts` keeps only what is skill-specific — the alphabet a browser-supplied secret must match (upper-snake key, printable-ASCII value, deliberately stricter than the writer's own rule) and the write-only presence check — and the bytes go through `setHermesEnvValues`.

## The other half: a write refused instead of a file rebuilt from nothing

`setHermesEnvValues` caught **every** read failure of the existing file and carried on with `existing = ""`:

```ts
try { existing = await fs.readFile(envPath, "utf-8"); … }
catch { /* No .env yet — create one at 0600. */ }
```

An `EACCES` after a root-owned write, an `EIO` on a failing eMMC, a path that is not a regular file — all of them ended as a short file written over whatever was there. That is the same whole-file loss this task is about, and it was live on the path that stores the mail password and the Discord and WhatsApp tokens.

It now reads its base through **one descriptor** — the size and regular-file checks run on that same handle, so they cannot be made against a different file than the one that is read — opened `O_NONBLOCK` so a fifo at the path cannot park the request. Anything that is not "the file is absent" **refuses the write**. `readHermesEnv` already refused to flatten a fault into "nothing configured"; the write path now matches it.

The secrets route reports that as `500 {code: "env_unreadable"}` — "the device's environment file could not be read, so nothing was changed" — rather than as a save.

## Live-data evidence

The real template pulled read-only off a Hermes box (`24792 B`, `md5 b7be6ae03bba1b880dc9cfec32dce13f`, 504 lines, 11 live keys, 116 hints), run through both versions with **no device mutated**:

```
before:  24792 B ->   420 B    505 -> 14 lines    hints 116 -> 0      # the regression, reproduced
after:   24792 B -> 24840 B    505 -> 506 lines   hints 116 -> 116    # +1 line, the new assignment

          the previous bytes are a prefix of the new file:            true
          editing an existing key (TERMINAL_MODAL_IMAGE):             1 line differs
          add -> edit -> revert -> clear:  24792 B, md5 b7be6ae0…     byte-identical
```

## Two more failures the same premise was hiding

Both found after the first push, both the same shape — an answer given about a file nobody read:

- **`readHermesEnv` turned every read failure into an empty map.** A `.env` that is a directory, or that the process cannot read, therefore looked like a box with nothing configured: `clearHermesSecret` concluded the key was already absent, skipped the write, and the route answered `200 {ok:true, set:false}` for a secret it never removed. The presence `GET` reported every asked-for key as unset for the same reason — which is how an owner is shown an empty field for a credential that may well be there, and retypes it into a file nothing could read. Absence is still an empty map; anything else is now raised. (CodeRabbit found the clear; the GET came with it.)
- **A FIFO at the path could park a request forever.** `fs.readFile` opens with plain `O_RDONLY`, and opening a FIFO that way blocks until someone opens the write end. That is why the store's own reader used `O_NONBLOCK`, and routing through the shared one lost it — caught by CI, which runs on Linux and has real FIFOs where this workstation does not. The shared reader opens the same way now, so every caller of it gets the guarantee.

## Tests

**13** new on the store's side (17 -> 30 cases) and **5** on the shared writer's (33 -> 38). Confirmed RED first — 10 of the first 11 and all 5 of the writer's fail against `origin/beta`:

- the round trip above, as a byte-equality assertion against a template-shaped fixture;
- the 116 commented hints, the 11 other live settings and their order;
- editing an existing key changes exactly one line; clearing removes exactly one;
- an `export`-prefixed assignment is replaced rather than duplicated (a duplicate is how the previous credential comes back);
- appending to a file with no trailing newline does not join two lines;
- a clear that could not read the file does **not** answer 200, and the presence GET does not answer a list of `false`s;
- and on the shared writer: a base that is not a regular file, and a base past the parse cap, both **refuse** and leave the file exactly as it was — including on the clearing path, so a delete cannot empty the file either. Plus one proving the single-writer chain survives a refusal, and one proving a FIFO settles fast rather than parking the request (skipped where the platform has no real FIFOs; CI has them).

## Verification

- `vitest` on every suite that touches a changed module (secrets, hermes-env, email, WhatsApp, ClawAI ×2): the only failures are **the same 5 `origin/beta` produces on the same files** — Windows-only `chmod`-mode and path-separator assertions, green on Linux CI.
- `tsc -p tsconfig.json`: 22 errors, **byte-identical to the beta baseline**, none in changed files. `bun run mcp/check-tools.ts`: `Tool contract OK`.
- `eslint src mcp`: 0 problems in changed files. `bun run build`: green.

## Also in here

Two documentation corrections, both about promises the product does not keep:

- the `~/.hermes/.env` row now says whose file it is and that ClawBox edits one line of it;
- an accordion for the skills a device refuses outright. The page currently reads *"Nothing is installed unless you tick 'I understand'… and choose to continue"*, which implies you always can — and since #504 the store correctly tells the customer that some skills the installer will not take even when confirmed. This documents that.

## Not covered

`setHermesEnvValues` still preserves whatever mode the file already had, deliberately, mirroring Hermes' own writer. Because this route's whole purpose is to put a credential in that file, `setHermesSecret` narrows a group- or world-readable `.env` to `0600` afterwards — it never widens. Making that the shared writer's policy would change behaviour for four other callers and belongs in its own change.
