### PR TITLE
Remove the unfiltered polkit manage-units grant and route root steps through one root-owned launcher (TASK-539)

### DIFF
--- a/config/49-clawbox-updates.pkla
+++ b/config/49-clawbox-updates.pkla
@@ -1,10 +1,3 @@
-[Allow clawbox to manage ClawBox systemd services]
-Identity=unix-user:clawbox
-Action=org.freedesktop.systemd1.manage-units
-ResultAny=yes
-ResultInactive=yes
-ResultActive=yes
-
 [Allow clawbox to manage NetworkManager]
 Identity=unix-user:clawbox
 Action=org.freedesktop.NetworkManager.wifi.scan;org.freedesktop.NetworkManager.network-control;org.freedesktop.NetworkManager.settings.modify.system;org.freedesktop.NetworkManager.wifi.share.open;org.freedesktop.NetworkManager.wifi.share.protected

--- a/config/clawbox-run-root-step.sh
+++ b/config/clawbox-run-root-step.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# The web server's one way to start a root update step.
+#
+# Until TASK-539 this went through polkit: src/lib/updater.ts and
+# /setup-api/install/run-step called `/usr/bin/systemctl start
+# clawbox-root-update@<step>.service` with no sudo at all, and
+# config/49-clawbox-updates.pkla authorised it. That grant is
+# `org.freedesktop.systemd1.manage-units` with no unit condition — `.pkla` on
+# polkit 0.105 (what JetPack ships) cannot express one — and manage-units is the
+# action systemd checks for StartTransientUnit. So it was `systemd-run /bin/sh
+# -c …`: arbitrary root, no password, for the account the web server, the in-UI
+# terminal and the agent's shell all run as. It made the whole sudoers allow-list
+# bypassable, which is why it had to go rather than be narrowed.
+#
+# sudoers CAN express a scope, so the operation moves here: one root-owned
+# entrypoint, granted once, that decides for itself which unit it will start.
+# The scoped polkit twin this replaces said the same thing —
+# config/49-clawbox-updates.rules restricts to `clawbox-root-update@` — but only
+# polkit >= 0.106 reads it.
+#
+# What this deliberately does NOT do: take a unit name. It takes a STEP name,
+# from a list narrower than the dispatcher's, and builds the unit itself. The
+# dispatcher (clawbox-root-step.sh) validates the step again on the other side
+# and is the authority on what root then runs; this is the outer bound on what
+# the WEB SERVER may ask for.
+#
+# Usage (root, from a sudoers grant):
+#   clawbox-run-root-step.sh [--no-block] <step>
+#
+# Installed by install.sh::install_root_libexec to
+# /usr/local/libexec/clawbox/clawbox-run-root-step.sh, root:root 0755.
+
+set -euo pipefail
+
+# Keep in step with WEB_ROOT_STEPS in src/lib/root-steps.ts —
+# src/tests/unit/root-steps.test.ts fails the build otherwise. Every name here
+# is a root entrypoint the web server can trigger without a password, so adding
+# one is a privilege decision, not a config line.
+WEB_ROOT_STEPS="
+ai_tools_install apt_update bootstrap_updater chpasswd chromium_install
+clawkeep_install cloudflared_install ffmpeg_install fix_git_perms gateway_setup
+hermes_edition llamacpp_install nvidia_jetpack ollama_install openclaw_config
+openclaw_install openclaw_patch openclaw_setup performance_mode post_update
+rebuild_reboot restart_ap set_hostname vnc_install vnc_refresh
+"
+
+NO_BLOCK=""
+if [ "${1:-}" = "--no-block" ]; then
+  NO_BLOCK="--no-block"
+  shift
+fi
+
+step="${1:-}"
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 [--no-block] <step>" >&2
+  exit 64
+fi
+
+# Reject anything that is not a plain step identifier before it reaches a unit
+# name. systemd instance names cannot contain `/`, but they can contain plenty
+# else, and this is the root side of the boundary.
+case "$step" in
+  *[!a-z0-9_]*|"")
+    echo "clawbox-run-root-step: refusing malformed step name: $step" >&2
+    exit 64
+    ;;
+esac
+
+permitted=1
+for allowed in $WEB_ROOT_STEPS; do
+  if [ "$allowed" = "$step" ]; then
+    permitted=0
+    break
+  fi
+done
+if [ "$permitted" -ne 0 ]; then
+  echo "clawbox-run-root-step: step not permitted from the web server: $step" >&2
+  exit 64
+fi
+
+service="clawbox-root-update@${step}.service"
+
+# Clear a previous failure first, so a step that failed once is not permanently
+# unstartable. Best-effort: a unit that never ran has nothing to reset.
+/usr/bin/systemctl reset-failed "$service" >/dev/null 2>&1 || true
+
+if [ -n "$NO_BLOCK" ]; then
+  exec /usr/bin/systemctl start --no-block "$service"
+fi
+exec /usr/bin/systemctl start "$service"

--- a/config/clawbox-sudoers
+++ b/config/clawbox-sudoers
@@ -146,14 +146,24 @@ clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl stop    ollama.service
 # Adding an instance here adds a root entrypoint — the granted step runs as root
 # through /usr/local/libexec/clawbox/clawbox-root-step.sh — so review it as a
 # privilege boundary, not as a config line. TASK-445.
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reset-failed clawbox-root-update@chpasswd.service
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start clawbox-root-update@chpasswd.service
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reset-failed clawbox-root-update@set_hostname.service
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start clawbox-root-update@set_hostname.service
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reset-failed clawbox-root-update@restart_ap.service
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start clawbox-root-update@restart_ap.service
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reset-failed clawbox-root-update@llamacpp_install.service
-clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl start --no-block clawbox-root-update@llamacpp_install.service
+# ONE grant for the whole root-step surface, and it is not a systemctl grant.
+#
+# The web server has to start ~25 different `clawbox-root-update@<step>` units:
+# four from the wizard's hand-offs, the rest from the updater and the UI's
+# install buttons. Until TASK-539 the updater did not go through sudo at all —
+# it called `systemctl start` unprivileged and the unscoped polkit
+# `manage-units` grant authorised it, which is `systemd-run /bin/sh -c …`, i.e.
+# arbitrary root. Removing that grant means the operation has to come back here.
+#
+# Enumerating 25 instances twice over (start, reset-failed) is 50 lines nobody
+# reviews, and the wildcard that would compress them is exactly what TASK-445
+# removed. So the grant names a root-owned LAUNCHER instead, and the launcher
+# decides which unit it will start: it takes a STEP name, checks it against its
+# own list (WEB_ROOT_STEPS, narrower than the root dispatcher's 48), and builds
+# the unit itself. No argument spec, deliberately — the arguments are validated
+# by root-owned code rather than by string matching, the same shape as the
+# optimize-ollama.sh grant.
+clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-run-root-step.sh
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl reboot
 clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl poweroff
 # apt is granted ONLY for the exact commands the Browser-app chromium recovery

--- a/e2e-install/06-sudoers.spec.ts
+++ b/e2e-install/06-sudoers.spec.ts
@@ -118,10 +118,8 @@ test.describe("root escalation surface", () => {
     for (const [what, needle] of [
       ["factory reset / power menu", "/usr/bin/systemctl reboot"],
       ["power menu", "/usr/bin/systemctl poweroff"],
-      ["password change", "/usr/bin/systemctl start clawbox-root-update@chpasswd.service"],
-      ["hostname change", "/usr/bin/systemctl start clawbox-root-update@set_hostname.service"],
-      ["hotspot restart", "/usr/bin/systemctl start clawbox-root-update@restart_ap.service"],
-      ["llama.cpp installer hand-off", "/usr/bin/systemctl start --no-block clawbox-root-update@llamacpp_install.service"],
+      ["every root step: password, hostname, hotspot, updater, install buttons",
+        "/usr/local/libexec/clawbox/clawbox-run-root-step.sh"],
       ["gateway restart after a config write", "/usr/bin/systemctl restart clawbox-gateway.service"],
       ["web server restart (force-update.sh)", "/usr/bin/systemctl restart clawbox-setup.service"],
       ["Settings → Local Models", "/usr/bin/systemctl disable --now ollama.service"],
@@ -204,26 +202,48 @@ test.describe("root escalation surface", () => {
     // matches again this test fails without having started anything real.
     const PAD = "e2e-nonexistent-probe.service";
     const probes: Record<string, string> = {
-      [`reset-failed clawbox-root-update@chpasswd.service ${PAD}`]: "DENIED",
-      [`reset-failed clawbox-root-update@llamacpp_install.service ${PAD}`]: "DENIED",
-      [`start clawbox-root-update@chpasswd.service ${PAD}`]: "DENIED",
-      [`start --no-block clawbox-setup.service ${PAD}`]: "DENIED",
-      // No grant names an instance outside the four the product issues, so the
-      // template is no longer a way to run an arbitrary step as root. (Those
-      // instances stay reachable through the unscoped polkit `manage-units`
-      // grant until TASK-539 removes it — this asserts the allow-list, not the
-      // whole surface.)
-      "start clawbox-root-update@e2e-not-a-step.service": "DENIED",
-      "start --no-block clawbox-root-update@e2e-not-a-step.service": "DENIED",
-      // Control: something the product really issues still runs without a
-      // password, so a pass above cannot just be "sudo denies everything".
-      // reset-failed on a unit that never ran is a no-op.
-      "reset-failed clawbox-root-update@chpasswd.service": "ALLOWED",
+      [`/usr/bin/systemctl start --no-block clawbox-setup.service ${PAD}`]: "DENIED",
+      [`/usr/bin/systemctl start clawbox-root-update@chpasswd.service ${PAD}`]: "DENIED",
+      // No rule names a root-step UNIT at all any more: those go through the
+      // launcher, which takes a STEP and builds the unit itself. TASK-539.
+      "/usr/bin/systemctl start clawbox-root-update@chpasswd.service": "DENIED",
+      "/usr/bin/systemctl start clawbox-root-update@git_pull.service": "DENIED",
+      // Control: the launcher is granted, and a step it refuses still exits
+      // non-zero from ITS check rather than from sudo's. `--help` is neither, so
+      // it proves the grant matches without starting anything.
+      "/usr/local/libexec/clawbox/clawbox-run-root-step.sh --help": "ALLOWED",
     };
-    const answers = await sudoCovers(Object.keys(probes).map((c) => `/usr/bin/systemctl ${c}`));
+    const answers = await sudoCovers(Object.keys(probes));
     for (const [cmd, want] of Object.entries(probes)) {
-      expect(answers[`/usr/bin/systemctl ${cmd}`], `sudo -n /usr/bin/systemctl ${cmd}`).toBe(want);
+      expect(answers[cmd], `sudo -n ${cmd}`).toBe(want);
     }
+  });
+
+  test("the unscoped polkit grant is gone (GAP 1 / TASK-539)", async () => {
+    // `org.freedesktop.systemd1.manage-units` is the action systemd checks for
+    // StartTransientUnit, so authorising it with no unit condition — which is
+    // all a .pkla can do on polkit 0.105 — is `systemd-run /bin/sh -c …`:
+    // arbitrary root, no password, for the account the web server runs as. It
+    // made the whole sudoers allow-list bypassable.
+    const probe = async (action: string) =>
+      (await dockerExec(
+        ["bash", "-lc", `pkcheck --action-id ${action} --process $$ >/dev/null 2>&1 && echo AUTHORIZED || echo NOT-AUTHORIZED`],
+        { user: "clawbox" },
+      )).trim();
+
+    expect(await probe("org.freedesktop.systemd1.manage-units")).toBe("NOT-AUTHORIZED");
+    // Controls, so a pass above cannot be "polkit answers no to everything
+    // because pkcheck is missing or the session is not what we think".
+    expect(await probe("org.freedesktop.systemd1.manage-unit-files")).toBe("NOT-AUTHORIZED");
+    expect(await probe("org.freedesktop.NetworkManager.wifi.scan")).toBe("AUTHORIZED");
+
+    const pkla = await dockerExec([
+      "bash", "-lc",
+      "cat /etc/polkit-1/localauthority/50-local.d/49-clawbox-updates.pkla 2>&1 || true",
+    ]);
+    expect(pkla).not.toContain("systemd1.manage-units");
+    expect(pkla, "the NetworkManager grant is scoped and still needed by nmcli")
+      .toContain("NetworkManager.wifi.scan");
   });
 
   test("root records the code it is allowed to run (GAP 2)", async () => {

--- a/install.sh
+++ b/install.sh
@@ -3253,7 +3253,7 @@ install_root_libexec() {
   local src
   # The integrity helper first: the dispatcher installed at the END of this
   # function refuses to run any step unless the manifest this writes verifies.
-  for src in clawbox-root-manifest.sh; do
+  for src in clawbox-root-manifest.sh clawbox-run-root-step.sh; do
     if [ -f "$PROJECT_DIR/config/$src" ]; then
       install -o root -g root -m 0755 "$PROJECT_DIR/config/$src" "$ROOT_LIBEXEC_DIR/$src"
     fi
@@ -4049,8 +4049,21 @@ step_polkit_rules() {
   local POLKIT_PKLA_DIR="/etc/polkit-1/localauthority/50-local.d"
   mkdir -p "$POLKIT_PKLA_DIR"
   cp "$PROJECT_DIR/config/49-clawbox-updates.pkla" "$POLKIT_PKLA_DIR/"
-  rm -f /etc/polkit-1/rules.d/49-clawbox-updates.rules
-  echo "  Polkit rule installed (allows clawbox to trigger root update steps)"
+  # Remove the manage-units authorisation from devices that already have it.
+  # The .pkla shipped above no longer contains that stanza, but `cp` only
+  # replaces the file — a box provisioned before TASK-539 keeps whatever polkit
+  # already cached until this runs, and there is no other remover.
+  #
+  # The scoped .rules twin is INSTALLED now rather than deleted. polkit 0.105
+  # (JetPack's) ignores rules.d entirely, so on the appliance it is inert
+  # documentation; on polkit >= 0.106 it is the correct narrow grant. Deleting
+  # it was how the unscoped .pkla ended up as the only authority.
+  local POLKIT_RULES_DIR="/etc/polkit-1/rules.d"
+  if [ -d "$POLKIT_RULES_DIR" ] && [ -f "$PROJECT_DIR/config/49-clawbox-updates.rules" ]; then
+    install -o root -g root -m 0644 "$PROJECT_DIR/config/49-clawbox-updates.rules" \
+      "$POLKIT_RULES_DIR/49-clawbox-updates.rules"
+  fi
+  echo "  Polkit rules installed (NetworkManager only; root steps go through sudo)"
 }
 
 step_start_services() {

--- a/scripts/check-sudoers-coverage.sh
+++ b/scripts/check-sudoers-coverage.sh
@@ -241,6 +241,28 @@ my %DECLARED_ARGV = (
     ],
     resolve => { systemctlAction => 'POWER_ACTIONS' },
   },
+  # src/lib/root-step-runner.ts — startRootStep() builds ["-n", LAUNCHER, ...].
+  # The step name is NOT enumerated here, and that is the design: the grant names
+  # the launcher with no argument spec, and the launcher decides which unit it
+  # will start by checking the step against its own WEB_ROOT_STEPS list, in
+  # root-owned code. src/tests/unit/root-steps.test.ts pins that list to
+  # src/lib/root-steps.ts. Enumerating 25 step names in a sudoers Cmnd_Spec would
+  # be 50 lines of string matching doing worse than one root-side check.
+  'src/lib/root-step-runner.ts :: "/usr/bin/sudo", argv' => {
+    argv => [
+      ['-n', '/usr/local/libexec/clawbox/clawbox-run-root-step.sh', 'chpasswd'],
+      ['-n', '/usr/local/libexec/clawbox/clawbox-run-root-step.sh', '--no-block', 'llamacpp_install'],
+    ],
+    unverified => {
+      argv => 'startRootStep() builds the list imperatively — `const argv = ["-n", '
+            . 'ROOT_STEP_LAUNCHER]`, then an optional `--no-block`, then the step — so it is '
+            . 'not one const array a symbol lookup could read back. Both shapes it can '
+            . 'produce are declared above. The STEP is deliberately not enumerated: the '
+            . 'grant names the launcher with no argument spec, and the launcher checks the '
+            . 'step against WEB_ROOT_STEPS in root-owned code (config/clawbox-run-root-step.sh), '
+            . 'which src/tests/unit/root-steps.test.ts pins to src/lib/root-steps.ts.',
+    },
+  },
 );
 
 # ── Sudo calls that are deliberately NOT in the allow-list ──────────────────
@@ -787,6 +809,20 @@ sub scan_ts {
     my ($argv, $why) = resolve_items($rel, $consts, [split_argv_items($args_src)]);
     if (!$argv) { add_unresolved($rel, $norm, $why); next; }
     push @calls, { file => $rel, argv => [$bin, @$argv] };
+  }
+
+  # 1b. spawn("sudo"|"/usr/bin/sudo", argv) where argv is a VARIABLE. The
+  #     literal-array form above cannot see this, and without it a helper that
+  #     builds its own argument list is invisible to the whole check — its grant
+  #     reads as unused and a new one would read as covered.
+  while ($raw =~ /$SPAWNERS\s*\(\s*"((?:\/usr\/bin\/)?sudo)"\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*[,)]/gs) {
+    my ($bin, $var) = ($1, $2);
+    my $norm = "\"$bin\", $var";
+    if (my $declared = declared_argv($rel, $norm, $raw, $consts)) {
+      push @calls, { file => $rel, argv => $_ } for @$declared;
+      next;
+    }
+    add_unresolved($rel, $norm, "argv is built at runtime in `$var`");
   }
 
   # 2. A variable that may hold "sudo", spawned with a non-literal argv. This is

--- a/src/app/setup-api/install/run-step/route.ts
+++ b/src/app/setup-api/install/run-step/route.ts
@@ -3,6 +3,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { requireSession } from "@/lib/route-auth";
 import { UI_ROOT_STEPS } from "@/lib/root-steps";
+import { startRootStep } from "@/lib/root-step-runner";
 
 export const dynamic = "force-dynamic";
 
@@ -79,15 +80,13 @@ export async function POST(req: Request) {
 
   const serviceName = `clawbox-root-update@${step}.service`;
   try {
-    // reset-failed is best-effort: a previous failed run leaves the unit
-    // in "failed" state and `systemctl start` would refuse without it.
-    await execFileAsync("/usr/bin/systemctl", ["reset-failed", serviceName], {
-      timeout: 10_000,
-    }).catch(() => {});
-
-    await execFileAsync("/usr/bin/systemctl", ["start", serviceName], {
-      timeout: STEP_TIMEOUT_MS,
-    });
+    // Through the root-owned launcher, which clears a previous failure
+    // itself and builds the unit name from a step it validates. This used to
+    // be an UNPRIVILEGED `systemctl start`, authorised by the polkit
+    // `manage-units` grant with no unit condition -- the same action that
+    // authorises `systemd-run`, i.e. arbitrary root with no password.
+    // TASK-539.
+    await startRootStep(step, { timeoutMs: STEP_TIMEOUT_MS });
 
     return NextResponse.json(
       { ok: true, step },

--- a/src/app/setup-api/llamacpp/install/route.ts
+++ b/src/app/setup-api/llamacpp/install/route.ts
@@ -18,12 +18,14 @@ import {
   tailLlamaCppLog,
   writeLlamaCppPid,
 } from "@/lib/llamacpp-server";
+import { startRootStep } from "@/lib/root-step-runner";
 
 const MODEL_ID_RE = /^[a-zA-Z0-9._:-]+$/;
 const encoder = new TextEncoder();
 const execFile = promisify(execFileCb);
 const CLAWBOX_HOME_DIR = process.env.CLAWBOX_HOME_DIR || process.env.HOME || "/home/clawbox";
 const LLAMACPP_INSTALL_SERVICE = "clawbox-root-update@llamacpp_install.service";
+const LLAMACPP_INSTALL_STEP = "llamacpp_install";
 // Must stay >= TimeoutStartSec in config/clawbox-root-update@.service so
 // systemd, not us, owns the kill. A cold box builds llama.cpp from source with
 // CUDA and downloads a multi-GB GGUF; 30 min was not enough and the install
@@ -121,15 +123,10 @@ function isUnitRunning(active: string): boolean {
 async function repairLlamaCppRuntime(
   onStatus: (line: string) => void,
 ): Promise<{ ok: boolean; error?: string }> {
-  await execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "reset-failed", LLAMACPP_INSTALL_SERVICE], {
-    timeout: 10_000,
-  }).catch(() => {});
-
   try {
-    await execFile(
-      "/usr/bin/sudo",
-      ["/usr/bin/systemctl", "start", "--no-block", LLAMACPP_INSTALL_SERVICE],
-      { timeout: SYSTEMCTL_QUERY_TIMEOUT_MS },
+    await startRootStep(
+      LLAMACPP_INSTALL_STEP,
+      { noBlock: true, timeoutMs: SYSTEMCTL_QUERY_TIMEOUT_MS },
     );
   } catch (err) {
     const failureLine = await readLlamaCppInstallFailure();

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -10,7 +10,7 @@ import { resetUpdateState } from "@/lib/updater";
 import { DATA_DIR } from "@/lib/config-store";
 import { CLAWKEEP_DATA_DIR } from "@/lib/clawkeep";
 import { getSystemUsername } from "@/lib/auth";
-import { CHPASSWD_INPUT_PATH, CHPASSWD_SERVICE_NAME, chpasswdRecord } from "@/lib/chpasswd";
+import { CHPASSWD_INPUT_PATH, CHPASSWD_SERVICE_NAME, CHPASSWD_STEP, chpasswdRecord } from "@/lib/chpasswd";
 import { FACTORY_DEFAULT_PASSWORD } from "@/lib/system-password";
 import { FACTORY_RESET_CONFIRMATION, isFactoryResetConfirmed } from "@/lib/factory-reset";
 import { readEdition } from "@/lib/edition-source";
@@ -20,6 +20,7 @@ import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
 import crypto from "crypto";
+import { startRootStep } from "@/lib/root-step-runner";
 
 const execFile = promisify(execFileCb);
 
@@ -372,12 +373,7 @@ async function resetSystemPasswordToDefault(): Promise<void> {
       chpasswdRecord(getSystemUsername(), FACTORY_DEFAULT_PASSWORD),
       { mode: 0o600 },
     );
-    await execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "reset-failed", CHPASSWD_SERVICE_NAME], {
-      timeout: 10_000,
-    }).catch(() => {});
-    await execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "start", CHPASSWD_SERVICE_NAME], {
-      timeout: 30_000,
-    });
+    await startRootStep(CHPASSWD_STEP, { timeoutMs: 30_000 });
     console.log("[Reset] System password reset to factory default");
   } catch (err) {
     // The input file carries a plaintext credential — scrub it on failure.
@@ -555,18 +551,8 @@ export async function POST(request: Request) {
     // 6b. Reset mDNS hostname to "clawbox" (avahi + hostnamectl). Data dir is
     // already wiped, so clawbox-root-update@set_hostname.service will read the
     // default and apply it before the reboot.
-    // reset-failed first — see the same note in system/hostname/route.ts.
-    await execFile("/usr/bin/sudo", [
-      "/usr/bin/systemctl",
-      "reset-failed",
-      "clawbox-root-update@set_hostname.service",
-    ], { timeout: 10_000 }).catch(() => {});
     try {
-      await execFile("/usr/bin/sudo", [
-        "/usr/bin/systemctl",
-        "start",
-        "clawbox-root-update@set_hostname.service",
-      ], { timeout: 10_000 });
+      await startRootStep("set_hostname", { timeoutMs: 10_000 });
     } catch (err) {
       console.warn("[Reset] Failed to reset hostname:", err instanceof Error ? err.message : err);
     }

--- a/src/app/setup-api/system/credentials/route.ts
+++ b/src/app/setup-api/system/credentials/route.ts
@@ -4,11 +4,12 @@ import { promisify } from "util";
 import fs from "fs/promises";
 import path from "path";
 import { get, set } from "@/lib/config-store";
-import { CHPASSWD_INPUT_PATH, CHPASSWD_SERVICE_NAME, chpasswdRecord } from "@/lib/chpasswd";
+import { CHPASSWD_INPUT_PATH, CHPASSWD_SERVICE_NAME, CHPASSWD_STEP, chpasswdRecord } from "@/lib/chpasswd";
 import { getSystemUsername, verifyPassword, isSafePasswordChars, bumpSessionGeneration, createSessionCookie, getSessionSigningSecret } from "@/lib/auth";
 import { checkRateLimit, clientIp, resetRateLimit } from "@/lib/rate-limit";
 import { hasOwnerPassword } from "@/lib/system-password";
 import { requireSession } from "@/lib/route-auth";
+import { startRootStep } from "@/lib/root-step-runner";
 
 export const dynamic = "force-dynamic";
 
@@ -132,12 +133,11 @@ export async function POST(request: Request) {
       mode: 0o600,
     });
     try {
-      await execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "reset-failed", CHPASSWD_SERVICE_NAME], {
-        timeout: 10_000,
-      }).catch(() => {});
-      await execFile("/usr/bin/sudo", ["/usr/bin/systemctl", "start", CHPASSWD_SERVICE_NAME], {
-        timeout: 30_000,
-      });
+      // Through the root-owned launcher: it clears a previous failure itself
+      // and builds the unit name from a step it validates, so the allow-list
+      // needs one grant for the whole root-step surface instead of a pair per
+      // instance. TASK-539.
+      await startRootStep(CHPASSWD_STEP, { timeoutMs: 30_000 });
     } catch (err) {
       // Clean up the input file on failure
       await fs.unlink(CHPASSWD_INPUT_PATH).catch(() => {});

--- a/src/app/setup-api/system/hostname/route.ts
+++ b/src/app/setup-api/system/hostname/route.ts
@@ -7,6 +7,7 @@ import { promisify } from "util";
 import { get, set } from "@/lib/config-store";
 import { gatewayIsAbsent, restartGateway, setControlUiAllowedOrigins } from "@/lib/openclaw-config";
 import { getReachableIpv4 } from "@/lib/system-info";
+import { startRootStep } from "@/lib/root-step-runner";
 
 const execFileAsync = promisify(execFile);
 
@@ -92,17 +93,8 @@ export async function POST(request: Request) {
     // systemd's start limit and every later start is refused until something
     // resets it — which used to be nothing on this path. The chpasswd and
     // llamacpp hand-offs already did this; these did not. TASK-445.
-    await execFileAsync("/usr/bin/sudo", [
-      "/usr/bin/systemctl",
-      "reset-failed",
-      "clawbox-root-update@set_hostname.service",
-    ]).catch(() => {});
   try {
-    await execFileAsync("/usr/bin/sudo", [
-      "/usr/bin/systemctl",
-      "start",
-      "clawbox-root-update@set_hostname.service",
-    ]);
+    await startRootStep("set_hostname");
   } catch (err) {
     console.warn("[hostname] Failed to trigger set_hostname service:", err);
     return NextResponse.json(

--- a/src/app/setup-api/system/hotspot/route.ts
+++ b/src/app/setup-api/system/hotspot/route.ts
@@ -5,6 +5,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { get, setMany, getAll } from "@/lib/config-store";
 import { parseNmcliTerseLine } from "@/lib/network";
+import { startRootStep } from "@/lib/root-step-runner";
 
 const execFileAsync = promisify(execFile);
 
@@ -160,17 +161,7 @@ export async function POST(request: Request) {
             "[hotspot] Box is a WiFi client; deferring AP restart to avoid severing the connection"
           );
         } else {
-          // reset-failed first — see the note in system/hostname/route.ts.
-          await execFileAsync("/usr/bin/sudo", [
-            "/usr/bin/systemctl",
-            "reset-failed",
-            "clawbox-root-update@restart_ap.service",
-          ]).catch(() => {});
-          await execFileAsync("/usr/bin/sudo", [
-            "/usr/bin/systemctl",
-            "start",
-            "clawbox-root-update@restart_ap.service",
-          ]);
+          await startRootStep("restart_ap");
           apAction = "restarted";
         }
       } else {

--- a/src/lib/chpasswd.ts
+++ b/src/lib/chpasswd.ts
@@ -16,6 +16,8 @@ import { DATA_DIR } from "@/lib/config-store";
 
 export const CHPASSWD_INPUT_PATH = path.join(DATA_DIR, ".chpasswd-input");
 export const CHPASSWD_SERVICE_NAME = "clawbox-root-update@chpasswd.service";
+/** The step name behind that unit, for `startRootStep()`. */
+export const CHPASSWD_STEP = "chpasswd";
 
 // POSIX-portable username (useradd's default policy). The username reaches us
 // via env vars (CLAWBOX_USER/SUDO_USER/USER), so validate before composing

--- a/src/lib/root-step-runner.ts
+++ b/src/lib/root-step-runner.ts
@@ -1,0 +1,43 @@
+/**
+ * The web server's one way to start a root update step.
+ *
+ * Every caller used to run `/usr/bin/systemctl start
+ * clawbox-root-update@<step>.service` with no sudo at all, and
+ * `config/49-clawbox-updates.pkla` authorised it with
+ * `org.freedesktop.systemd1.manage-units` and no unit condition — `.pkla` on
+ * polkit 0.105 (what JetPack ships) cannot express one. That action is what
+ * systemd checks for `StartTransientUnit`, so it was `systemd-run /bin/sh -c …`:
+ * arbitrary root, no password, for the account the web server, the in-UI
+ * terminal and the agent's shell all run as. It made the sudoers allow-list
+ * bypassable, which is why it is gone rather than narrowed (TASK-539).
+ *
+ * sudoers can express a scope, so the operation goes through one root-owned
+ * entrypoint instead: `/usr/local/libexec/clawbox/clawbox-run-root-step.sh`,
+ * granted once, which validates the step against WEB_ROOT_STEPS and builds the
+ * unit name itself. The root dispatcher validates it again on the far side.
+ */
+import { execFile as execFileCb } from "child_process";
+import { promisify } from "util";
+
+const execFile = promisify(execFileCb);
+
+/** Installed by install.sh::install_root_libexec, root:root 0755. */
+export const ROOT_STEP_LAUNCHER = "/usr/local/libexec/clawbox/clawbox-run-root-step.sh";
+
+/**
+ * Start `clawbox-root-update@<step>.service`.
+ *
+ * `sudo -n`, never a bare `sudo`: on a device whose allow-list is missing this
+ * grant the call has to fail in milliseconds, not block a route handler on a
+ * password prompt nobody can answer. The launcher clears a previous failure
+ * itself, so callers do not need their own `reset-failed`.
+ */
+export async function startRootStep(
+  step: string,
+  opts: { noBlock?: boolean; timeoutMs?: number } = {},
+): Promise<void> {
+  const argv = ["-n", ROOT_STEP_LAUNCHER];
+  if (opts.noBlock) argv.push("--no-block");
+  argv.push(step);
+  await execFile("/usr/bin/sudo", argv, { timeout: opts.timeoutMs ?? 30_000 });
+}

--- a/src/lib/root-steps.ts
+++ b/src/lib/root-steps.ts
@@ -16,9 +16,54 @@
  */
 
 /**
- * Steps a UI button may start. A subset of install.sh's DISPATCH_STEPS:
- * anything that reboots, rewrites networking or wipes state stays out, so a
- * one-tap escalation surface never exists.
+ * Every step the WEB SERVER can start as root, from anywhere — the UI buttons,
+ * the updater, the wizard's hand-offs. This is the outer bound of that surface,
+ * and it is deliberately narrower than install.sh's DISPATCH_STEPS (48) and than
+ * the root dispatcher's own allow-list: those two also cover steps only an
+ * operator ever runs by hand.
+ *
+ * It is enforced root-side by config/clawbox-run-root-step.sh, the single
+ * command config/clawbox-sudoers grants for this purpose. Adding a name here is
+ * adding a passwordless root entrypoint — review it as a privilege decision.
+ * The two lists are pinned together by src/tests/unit/root-steps.test.ts.
+ * TASK-539.
+ */
+export const WEB_ROOT_STEPS: readonly string[] = [
+  "ai_tools_install",
+  "apt_update",
+  "bootstrap_updater",
+  "chpasswd",
+  "chromium_install",
+  "clawkeep_install",
+  "cloudflared_install",
+  "ffmpeg_install",
+  "fix_git_perms",
+  "gateway_setup",
+  "hermes_edition",
+  "llamacpp_install",
+  "nvidia_jetpack",
+  "ollama_install",
+  "openclaw_config",
+  "openclaw_install",
+  "openclaw_patch",
+  "openclaw_setup",
+  "performance_mode",
+  "post_update",
+  "rebuild_reboot",
+  "restart_ap",
+  "set_hostname",
+  "vnc_install",
+  "vnc_refresh",
+];
+
+export function isWebRootStep(step: string): boolean {
+  return WEB_ROOT_STEPS.includes(step);
+}
+
+/**
+ * Steps a UI button may start. A subset of WEB_ROOT_STEPS: anything that
+ * reboots, rewrites networking or wipes state stays out, so a one-tap
+ * escalation surface never exists.
  */
 export const UI_ROOT_STEPS: readonly string[] = [
   "cloudflared_install",

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -15,6 +15,7 @@ import { runHermesCli } from "./hermes-cli";
 import { isPortOpen } from "./port-probe";
 import { parseHermesVersion } from "./version-utils";
 import { isSafeBranch } from "./update-branch";
+import { startRootStep } from "./root-step-runner";
 import { collectBuildIdentity } from "./build-identity";
 
 const PROJECT_DIR = process.env.CLAWBOX_ROOT || "/home/clawbox/clawbox";
@@ -236,13 +237,7 @@ async function readRootStepFailure(stepId: string): Promise<string | null> {
  * Used for steps that will kill the current process (rebuild, reboot).
  */
 async function startRootServiceFireAndForget(stepId: string): Promise<void> {
-  const service = `clawbox-root-update@${stepId}.service`;
-  execFile("/usr/bin/systemctl", ["reset-failed", service], {
-    timeout: 10_000,
-  }).catch(() => {});
-  await execFile("/usr/bin/systemctl", ["start", "--no-block", service], {
-    timeout: 10_000,
-  });
+  await startRootStep(stepId, { noBlock: true, timeoutMs: 10_000 });
 }
 
 /**
@@ -1271,20 +1266,19 @@ function applicableSteps(): UpdateStepDef[] {
 
 /**
  * Runs a root-privileged step via the clawbox-root-update@ systemd template
- * service. The main service runs as clawbox with NoNewPrivileges=true, so
- * privilege escalation is handled by systemd: the template service runs as
- * root, and polkit authorizes the clawbox user to start it.
+ * service. The main service runs as clawbox with NoNewPrivileges=true, so the
+ * escalation is systemd's: the template service runs as root.
+ *
+ * Through the root-owned launcher, not `systemctl start` directly. This used to
+ * be an unprivileged systemctl call authorised by the unscoped polkit
+ * `manage-units` grant -- the same action that authorises `systemd-run`, i.e.
+ * arbitrary root with no password. TASK-539.
  */
 async function execAsRoot(stepId: string, timeoutMs: number): Promise<void> {
   const serviceName = `clawbox-root-update@${stepId}.service`;
-  await execFile("/usr/bin/systemctl", ["reset-failed", serviceName], {
-    timeout: 10_000,
-  }).catch(() => {});
   const startedAt = Date.now();
   try {
-    await execFile("/usr/bin/systemctl", ["start", serviceName], {
-      timeout: timeoutMs + 30_000,
-    });
+    await startRootStep(stepId, { timeoutMs: timeoutMs + 30_000 });
   } catch (err) {
     // When OUR timeout kills the blocking `systemctl start`, the unit itself
     // usually keeps running (it has its own much larger TimeoutStartSec) and

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -7,6 +7,7 @@ import { stopLocalAiProvider } from "@/lib/local-ai-runtime";
 // Imported rather than spelled out so a GGUF swap cannot leave this suite
 // asserting a filename the app no longer asks for.
 import { DEFAULT_LLAMACPP_HF_FILE, DEFAULT_LLAMACPP_HF_REPO } from "@/lib/llamacpp";
+import { startRootStep } from "@/lib/root-step-runner";
 
 vi.mock("@/lib/root-step-runner", () => ({
   ROOT_STEP_LAUNCHER: "/usr/local/libexec/clawbox/clawbox-run-root-step.sh",
@@ -390,13 +391,12 @@ describe("POST /setup-api/llamacpp/install", () => {
     expect(text).toContain("Repairing the llama.cpp runtime");
     expect(text).toContain("runtime repaired");
     expect(text).toContain("\"success\":true");
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "/usr/bin/sudo",
-      // --no-block: we poll systemd ourselves so the wizard can stream progress
-      // instead of sitting silent for the whole install.
-      ["/usr/bin/systemctl", "start", "--no-block", "clawbox-root-update@llamacpp_install.service"],
-      expect.any(Object),
-      expect.any(Function),
+    // --no-block: we poll systemd ourselves so the wizard can stream progress
+    // instead of sitting silent for the whole install. Through the root-owned
+    // launcher, which also clears a previous failure itself. TASK-539.
+    expect(vi.mocked(startRootStep)).toHaveBeenCalledWith(
+      "llamacpp_install",
+      expect.objectContaining({ noBlock: true }),
     );
     expect(mockSpawn).toHaveBeenCalledTimes(2);
 

--- a/src/tests/routes/llamacpp/install.test.ts
+++ b/src/tests/routes/llamacpp/install.test.ts
@@ -8,6 +8,11 @@ import { stopLocalAiProvider } from "@/lib/local-ai-runtime";
 // asserting a filename the app no longer asks for.
 import { DEFAULT_LLAMACPP_HF_FILE, DEFAULT_LLAMACPP_HF_REPO } from "@/lib/llamacpp";
 
+vi.mock("@/lib/root-step-runner", () => ({
+  ROOT_STEP_LAUNCHER: "/usr/local/libexec/clawbox/clawbox-run-root-step.sh",
+  startRootStep: vi.fn(async () => {}),
+}));
+
 vi.mock("child_process", () => ({
   spawn: vi.fn(),
   execFile: vi.fn(),

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -701,7 +701,9 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     expect(res.status).toBe(500);
     const calls = mockExecFile.mock.calls.map(([cmd, args]) => `${cmd} ${(args as string[])?.join(" ")}`);
     expect(calls.some((c) => c.includes("connection delete"))).toBe(false);
-    expect(calls.some((c) => c.includes("clawbox-root-update@chpasswd"))).toBe(false);
+    // The password reset goes through the mocked root-step launcher, never
+    // execFile — asserting on the exec transcript here would always pass.
+    expect(vi.mocked(startRootStep)).not.toHaveBeenCalledWith("chpasswd", expect.anything());
     expect(calls.some((c) => c.includes("systemctl reboot"))).toBe(false);
   });
 });

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -3,6 +3,11 @@ import { installSessionFixture, type SessionFixture } from "@/tests/helpers/sess
 import * as childProcess from "child_process";
 import fs from "fs/promises";
 
+vi.mock("@/lib/root-step-runner", () => ({
+  ROOT_STEP_LAUNCHER: "/usr/local/libexec/clawbox/clawbox-run-root-step.sh",
+  startRootStep: vi.fn(async () => {}),
+}));
+
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
 }));
@@ -52,6 +57,7 @@ vi.mock("@/lib/login-rate-limit", () => ({
 import { resetUpdateState } from "@/lib/updater";
 import { getSystemUsername } from "@/lib/auth";
 import { startOllamaService } from "@/lib/local-ai-runtime";
+import { startRootStep } from "@/lib/root-step-runner";
 
 type ReaddirResult = Awaited<ReturnType<typeof fs.readdir>>;
 
@@ -355,27 +361,18 @@ describe("POST /setup-api/setup/reset", () => {
     expect(chpasswdCall![1]).toBe("clawbox:clawbox\n");
     expect((chpasswdCall![2] as { mode: number }).mode).toBe(0o600);
 
-    // The root systemd service must have been started — without it, the
-    // file we just wrote is just an inert text file.
-    const startCall = mockExecFile.mock.calls.find(
-      ([cmd, args]) =>
-        cmd === "/usr/bin/sudo" &&
-        args?.[0] === "/usr/bin/systemctl" &&
-        args?.[1] === "start" &&
-        args?.[2] === "clawbox-root-update@chpasswd.service",
-    );
-    expect(startCall).toBeDefined();
+    // The root step must have been started — without it, the file we just
+    // wrote is just an inert text file. Through the root-owned launcher now:
+    // the unprivileged systemctl call this replaced only worked because of the
+    // unscoped polkit `manage-units` grant. TASK-539.
+    expect(vi.mocked(startRootStep)).toHaveBeenCalledWith("chpasswd", expect.anything());
   });
 
   it("continues the reset when the password reset fails (non-fatal)", async () => {
     // chpasswd service failure must not strand the user on a half-reset box;
     // the wizard's CredentialsStep on first boot re-prompts and overwrites.
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    setupExecFileMock({
-      "systemctl start clawbox-root-update@chpasswd": new Error("polkit denied"),
-      systemctl: { stdout: "", stderr: "" },
-      nmcli: { stdout: "", stderr: "" },
-    });
+    vi.mocked(startRootStep).mockRejectedValueOnce(new Error("not permitted"));
 
     const res = await resetPost();
     const body = await res.json();
@@ -466,11 +463,7 @@ describe("POST /setup-api/setup/reset", () => {
     // writeFile succeeds but the service start fails: the plaintext credential
     // must be unlinked so it isn't left readable on disk.
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    setupExecFileMock({
-      "systemctl start clawbox-root-update@chpasswd": new Error("polkit denied"),
-      systemctl: { stdout: "", stderr: "" },
-      nmcli: { stdout: "", stderr: "" },
-    });
+    vi.mocked(startRootStep).mockRejectedValueOnce(new Error("not permitted"));
 
     await resetPost();
     errSpy.mockRestore();

--- a/src/tests/routes/system-hostname.test.ts
+++ b/src/tests/routes/system-hostname.test.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { startRootStep } from "@/lib/root-step-runner";
 
 const TEST_ROOT = path.join(os.tmpdir(), `clawbox-hostname-tests-${process.pid}-${Date.now()}`);
 const HOSTNAME_ENV_PATH = path.join(TEST_ROOT, "data", "hostname.env");
@@ -11,6 +12,11 @@ const setControlUiAllowedOriginsMock = vi.fn();
 const restartGatewayMock = vi.fn();
 const getMock = vi.fn();
 const setMock = vi.fn();
+
+vi.mock("@/lib/root-step-runner", () => ({
+  ROOT_STEP_LAUNCHER: "/usr/local/libexec/clawbox/clawbox-run-root-step.sh",
+  startRootStep: vi.fn(async () => {}),
+}));
 
 vi.mock("child_process", () => ({
   execFile: (
@@ -145,8 +151,9 @@ describe("/setup-api/system/hostname POST", () => {
     expect(body.fqdn).toBe("happy.local");
   });
 
-  it("returns 500 when systemd command fails (but persists state)", async () => {
-    execFileMock.mockReturnValue({ error: new Error("Failed to start unit") });
+  it("returns 500 when the root step fails (but persists state)", async () => {
+    execFileMock.mockReturnValue({ stdout: "" });
+    vi.mocked(startRootStep).mockRejectedValueOnce(new Error("Failed to start unit"));
     const mod = await import("@/app/setup-api/system/hostname/route");
     const res = await mod.POST(makeRequest({ hostname: "stillpersisted" }));
     expect(res.status).toBe(500);

--- a/src/tests/routes/system/credentials.test.ts
+++ b/src/tests/routes/system/credentials.test.ts
@@ -3,6 +3,11 @@ import { installSessionFixture, type SessionFixture } from "@/tests/helpers/sess
 import * as childProcess from "child_process";
 import fs from "fs/promises";
 
+vi.mock("@/lib/root-step-runner", () => ({
+  ROOT_STEP_LAUNCHER: "/usr/local/libexec/clawbox/clawbox-run-root-step.sh",
+  startRootStep: vi.fn(async () => {}),
+}));
+
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
   spawn: vi.fn(),
@@ -36,6 +41,7 @@ vi.mock("@/lib/auth", () => ({
 
 import { set } from "@/lib/config-store";
 import { getSystemUsername } from "@/lib/auth";
+import { startRootStep } from "@/lib/root-step-runner";
 
 const mockSet = vi.mocked(set);
 const mockGetSystemUsername = vi.mocked(getSystemUsername);
@@ -206,10 +212,8 @@ describe("POST /setup-api/system/credentials", () => {
     expect(body.error).toContain("control characters");
   });
 
-  it("returns 500 when systemctl fails", async () => {
-    setupExecFileMock({
-      systemctl: new Error("Service failed"),
-    });
+  it("returns 500 when the root step fails", async () => {
+    vi.mocked(startRootStep).mockRejectedValueOnce(new Error("Service failed"));
 
     const res = await credentialsPost(jsonRequest({ password: "securepassword123" }));
     const body = await res.json();
@@ -218,10 +222,8 @@ describe("POST /setup-api/system/credentials", () => {
     expect(body.error).toBe("Service failed");
   });
 
-  it("cleans up input file on systemctl failure", async () => {
-    setupExecFileMock({
-      systemctl: new Error("Service failed"),
-    });
+  it("cleans up input file when the root step fails", async () => {
+    vi.mocked(startRootStep).mockRejectedValueOnce(new Error("Service failed"));
 
     await credentialsPost(jsonRequest({ password: "securepassword123" }));
 

--- a/src/tests/routes/system/hotspot.test.ts
+++ b/src/tests/routes/system/hotspot.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import * as childProcess from "child_process";
 import fs from "fs/promises";
 
+vi.mock("@/lib/root-step-runner", () => ({
+  ROOT_STEP_LAUNCHER: "/usr/local/libexec/clawbox/clawbox-run-root-step.sh",
+  startRootStep: vi.fn(async () => {}),
+}));
+
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
 }));

--- a/src/tests/routes/system/hotspot.test.ts
+++ b/src/tests/routes/system/hotspot.test.ts
@@ -25,11 +25,13 @@ vi.mock("@/lib/config-store", () => ({
 }));
 
 import { get, setMany, getAll } from "@/lib/config-store";
+import { startRootStep } from "@/lib/root-step-runner";
 
 const mockGet = vi.mocked(get);
 const mockSetMany = vi.mocked(setMany);
 const mockGetAll = vi.mocked(getAll);
 const mockExecFile = vi.mocked(childProcess.execFile);
+const mockStartRootStep = vi.mocked(startRootStep);
 const mockFs = vi.mocked(fs);
 
 function setupExecFileMock(results: Record<string, { stdout: string; stderr: string } | Error> = {}) {
@@ -254,6 +256,10 @@ describe("/setup-api/system/hotspot", () => {
     });
 
     it("continues even if AP toggle fails", async () => {
+      // The restart runs through the root-step launcher now, so that is where
+      // the failure has to be injected — a throwing systemctl no longer
+      // reaches this path at all.
+      mockStartRootStep.mockRejectedValueOnce(new Error("Service failed"));
       setupExecFileMock({
         systemctl: new Error("Service failed"),
         bash: new Error("Script failed"),
@@ -294,6 +300,7 @@ describe("/setup-api/system/hotspot", () => {
       });
 
       it("names a failed AP restart as failed, and says why", async () => {
+        mockStartRootStep.mockRejectedValueOnce(new Error("Service failed"));
         setupExecFileMock({
           systemctl: new Error("Service failed"),
           bash: new Error("Script failed"),

--- a/src/tests/unit/desktop-power-wiring.test.ts
+++ b/src/tests/unit/desktop-power-wiring.test.ts
@@ -96,7 +96,10 @@ describe("sudoers grants", () => {
     const granted = sudoers
       .split("\n")
       .filter((l) => l.startsWith("clawbox ") && l.includes(LIBEXEC))
-      .map((l) => l.slice(l.indexOf(LIBEXEC)).trim());
+      .map((l) => l.slice(l.indexOf(LIBEXEC)).trim())
+      // Other root-owned entrypoints live under the same directory now — the
+      // root-step launcher (TASK-539) — and are not this file's business.
+      .filter((c) => /(desktop|power)-mode\.sh/.test(c));
     expect(granted.sort()).toEqual([
       `${LIBEXEC}/clawbox-desktop-mode.sh --disable`,
       `${LIBEXEC}/clawbox-desktop-mode.sh --enable`,

--- a/src/tests/unit/install-sudoers-migration.test.ts
+++ b/src/tests/unit/install-sudoers-migration.test.ts
@@ -521,7 +521,12 @@ describe("the root-owned helper scripts the grants point at", () => {
     expect(granted).toContain("optimize-ollama.sh");
     for (const script of new Set(granted)) {
       expect(libexec, `install_root_libexec must install ${script}`).toContain(script);
-      expect(fs.existsSync(path.join(REPO, "scripts", script)), `scripts/${script} must exist`).toBe(true);
+      // The feature helpers live in scripts/; the root-side entrypoints
+      // (clawbox-root-step.sh, clawbox-root-manifest.sh, clawbox-run-root-step.sh)
+      // live in config/ next to the units and the allow-list they belong to.
+      const inScripts = fs.existsSync(path.join(REPO, "scripts", script));
+      const inConfig = fs.existsSync(path.join(REPO, "config", script));
+      expect(inScripts || inConfig, `${script} must exist in scripts/ or config/`).toBe(true);
     }
   });
 
@@ -625,14 +630,16 @@ d("the allow-list a device ends up with", () => {
     "disable --now ollama.service",
     "start ollama.service",
     "stop ollama.service",
-    "reset-failed clawbox-root-update@chpasswd.service",
-    "start clawbox-root-update@chpasswd.service",
-    "reset-failed clawbox-root-update@set_hostname.service",
-    "start clawbox-root-update@set_hostname.service",
-    "reset-failed clawbox-root-update@restart_ap.service",
-    "start clawbox-root-update@restart_ap.service",
-    "reset-failed clawbox-root-update@llamacpp_install.service",
-    "start --no-block clawbox-root-update@llamacpp_install.service",
+    // No `clawbox-root-update@` instance appears here any more. Removing the
+    // unscoped polkit `manage-units` grant meant the web server had to start
+    // ~25 of those units through sudo rather than four, and enumerating them
+    // twice over (start + reset-failed) would be 50 lines of string matching
+    // nobody reviews — while the wildcard that would compress them is exactly
+    // what TASK-445 removed. The grant names a root-owned LAUNCHER instead,
+    // which is not a systemctl command and so is deliberately outside this
+    // list; `the root-step launcher` describe block below covers it, and
+    // src/tests/unit/root-steps.test.ts asserts no grant names one of these
+    // units again. TASK-539.
     "reboot",
     "poweroff",
   ];
@@ -676,7 +683,8 @@ d("the allow-list a device ends up with", () => {
     //   clawbox-ap
     //     scripts/ap-watchdog.sh (clawbox-ap-watchdog.service, root) and
     //     install.sh itself. The UI path goes through
-    //     clawbox-root-update@restart_ap.service, which IS granted above.
+    //     clawbox-root-update@restart_ap.service, which the web server starts
+    //     through the root-owned launcher rather than a grant of its own.
     //   clawbox-hermes-dashboard-proxy
     //     scripts/setup-hermes-edition.sh, which install.sh runs as root.
     const grants = systemctlGrants(install());

--- a/src/tests/unit/root-step-launcher.test.ts
+++ b/src/tests/unit/root-step-launcher.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * TASK-539 — the one command the allow-list grants for starting a root step.
+ *
+ * Removing the unscoped polkit `manage-units` grant means the updater, the UI's
+ * install buttons and the wizard's hand-offs all have to come back through
+ * sudo. Enumerating ~25 `clawbox-root-update@<step>.service` instances twice
+ * over would be 50 lines of string matching, and the wildcard that would
+ * compress them is what TASK-445 removed. So the grant names this launcher with
+ * no argument spec, and the launcher decides which unit it will start.
+ *
+ * That makes it the outer bound on the web server's root surface, so what it
+ * refuses is the whole point. These tests run the real shipped script with
+ * /usr/bin/systemctl redirected to a recorder.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const LAUNCHER_SRC = path.join(REPO, "config", "clawbox-run-root-step.sh");
+
+const CAN_RUN =
+  process.platform !== "win32"
+  && spawnSync("bash", ["-c", "true"], { stdio: "ignore" }).status === 0;
+const d = CAN_RUN ? describe : describe.skip;
+
+let tmp: string;
+let launcher: string;
+let seen: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-launcher-"));
+  seen = path.join(tmp, "systemctl-calls");
+  const stub = path.join(tmp, "systemctl");
+  fs.writeFileSync(stub, `#!/usr/bin/env bash\necho "$*" >> "${seen}"\n`, { mode: 0o755 });
+  launcher = path.join(tmp, "clawbox-run-root-step.sh");
+  fs.writeFileSync(
+    launcher,
+    fs.readFileSync(LAUNCHER_SRC, "utf-8").replace(/\/usr\/bin\/systemctl/g, stub),
+    { mode: 0o755 },
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const run = (...args: string[]) => spawnSync("bash", [launcher, ...args], { encoding: "utf-8" });
+const calls = () => (fs.existsSync(seen) ? fs.readFileSync(seen, "utf-8").trim().split("\n") : []);
+
+d("clawbox-run-root-step.sh", () => {
+  it("starts the unit for a step the web server is allowed to run", () => {
+    expect(run("chpasswd").status).toBe(0);
+    expect(calls()).toEqual([
+      "reset-failed clawbox-root-update@chpasswd.service",
+      "start clawbox-root-update@chpasswd.service",
+    ]);
+  });
+
+  it("passes --no-block through", () => {
+    expect(run("--no-block", "llamacpp_install").status).toBe(0);
+    expect(calls()).toContain("start --no-block clawbox-root-update@llamacpp_install.service");
+  });
+
+  it("clears a previous failure itself, so no caller needs its own grant", () => {
+    // clawbox-root-update@.service does not set StartLimitIntervalSec=0, so a
+    // step that failed a few times is unstartable until something resets it.
+    run("set_hostname");
+    expect(calls()[0]).toBe("reset-failed clawbox-root-update@set_hostname.service");
+  });
+
+  it("REFUSES a step outside the web-startable list", () => {
+    // git_pull, build and rebuild are the updater's own self-updating family:
+    // reachable from install.sh, never from the web server.
+    for (const step of ["git_pull", "build", "rebuild", "recover", "polkit_rules"]) {
+      const r = run(step);
+      expect(r.status, `${step} was permitted`).toBe(64);
+      expect(r.stderr).toMatch(/not permitted from the web server/);
+    }
+    expect(calls()).toEqual([]);
+  });
+
+  it("REFUSES a step name that is not a plain identifier", () => {
+    for (const step of ["../../etc/shadow", "chpasswd.service", "chpasswd ssh", "CHPASSWD", ""]) {
+      const r = run(step);
+      expect(r.status, `${JSON.stringify(step)} was permitted`).toBe(64);
+    }
+    expect(calls()).toEqual([]);
+  });
+
+  it("REFUSES more than one step, so a second unit cannot ride along", () => {
+    // The shape TASK-445's wildcard removal was about: `systemctl start` takes a
+    // LIST of units, and this is the only thing standing in front of it now.
+    expect(run("chpasswd", "ssh").status).toBe(64);
+    expect(run("--no-block", "chpasswd", "ssh").status).toBe(64);
+    expect(calls()).toEqual([]);
+  });
+
+  it("takes a STEP, never a unit name", () => {
+    const r = run("clawbox-root-update@chpasswd.service");
+    expect(r.status).toBe(64);
+    expect(calls()).toEqual([]);
+  });
+});

--- a/src/tests/unit/root-steps.test.ts
+++ b/src/tests/unit/root-steps.test.ts
@@ -1,7 +1,13 @@
 import fs from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
-import { SELF_UPDATING_ROOT_STEPS, UI_ROOT_STEPS, isUiRootStep, maySelfUpdate } from "@/lib/root-steps";
+import {
+  SELF_UPDATING_ROOT_STEPS,
+  UI_ROOT_STEPS,
+  WEB_ROOT_STEPS,
+  isUiRootStep,
+  maySelfUpdate,
+} from "@/lib/root-steps";
 
 /**
  * The root-privilege boundary is: clawbox-setup (User=clawbox) →
@@ -12,6 +18,7 @@ import { SELF_UPDATING_ROOT_STEPS, UI_ROOT_STEPS, isUiRootStep, maySelfUpdate } 
 
 const REPO = path.resolve(__dirname, "../../..");
 const DISPATCHER = path.join(REPO, "config", "clawbox-root-step.sh");
+const LAUNCHER = path.join(REPO, "config", "clawbox-run-root-step.sh");
 const UNIT = path.join(REPO, "config", "clawbox-root-update@.service");
 const INSTALL_SH = path.join(REPO, "install.sh");
 const SUDOERS = [
@@ -128,16 +135,38 @@ describe("root-executed paths are outside clawbox's write access", () => {
       }
     }
 
-    // The instances the web server really starts, spelled out.
-    const primary = read(SUDOERS[0]);
-    for (const step of ["chpasswd", "set_hostname", "restart_ap", "llamacpp_install"]) {
-      expect(primary).toContain(`clawbox-root-update@${step}.service`);
+    // And no rule names a systemd UNIT for the root-step template at all: the
+    // web server reaches those through the root-owned launcher, which builds the
+    // unit name itself from a step it has checked. TASK-539.
+    const primary = grantsIn(SUDOERS[0]);
+    for (const grant of primary) {
+      expect(grant, `a root-step unit is still named in a grant: ${grant}`)
+        .not.toContain("clawbox-root-update@");
     }
-    // The update family runs through the updater's own root chain, not through
-    // a sudo grant the web server can reach.
-    for (const step of SELF_UPDATING_ROOT_STEPS) {
-      expect(primary, `${step} must not be startable through sudo`)
-        .not.toContain(`clawbox-root-update@${step}.service`);
+    expect(primary).toContain("/usr/local/libexec/clawbox/clawbox-run-root-step.sh");
+  });
+
+  it("keeps the launcher's list identical to the TypeScript one", () => {
+    // The launcher is the outer bound on what the WEB SERVER may start as root,
+    // and it is the only thing config/clawbox-sudoers grants for that purpose.
+    // If the two lists drift, either a product feature stops working or a step
+    // becomes startable that nobody reviewed.
+    const shell = shellList(read(LAUNCHER), "WEB_ROOT_STEPS");
+    expect([...shell].sort()).toEqual([...WEB_ROOT_STEPS].sort());
+  });
+
+  it("keeps the web-startable list inside the dispatcher's own allow-list", () => {
+    const allowed = new Set(shellList(read(DISPATCHER), "ALLOWED_STEPS"));
+    for (const step of WEB_ROOT_STEPS) {
+      expect(allowed.has(step), `${step} is web-startable but the dispatcher refuses it`).toBe(true);
+    }
+    // ...and strictly narrower: the dispatcher also covers operator-only steps.
+    expect(WEB_ROOT_STEPS.length).toBeLessThan(allowed.size);
+  });
+
+  it("offers every UI step through the launcher", () => {
+    for (const step of UI_ROOT_STEPS) {
+      expect(WEB_ROOT_STEPS.includes(step), `${step} is a UI button with no way to start`).toBe(true);
     }
   });
 

--- a/src/tests/unit/sudoers-coverage.test.ts
+++ b/src/tests/unit/sudoers-coverage.test.ts
@@ -292,7 +292,7 @@ d("check-sudoers-coverage", () => {
     expect(r.status).toBe(0);
     expect(r.stdout).toMatch(/GRANTS \(\d+\):/);
     expect(r.stdout).toContain("/usr/local/libexec/clawbox/optimize-ollama.sh");
-    expect(r.stdout).toContain("/usr/bin/systemctl start clawbox-root-update@chpasswd.service");
+    expect(r.stdout).toContain("/usr/local/libexec/clawbox/clawbox-run-root-step.sh");
     expect(r.stdout).toMatch(/RESOLVED CALL SITES:/);
   });
 
@@ -318,10 +318,9 @@ describe("the call sites the allow-list has to cover", () => {
   it.runIf(CAN_RUN)("covers the wizard, updater, power, wifi, desktop and factory-reset paths", async () => {
     const out = (await shipped).list.stdout;
     for (const expected of [
-      // setup wizard: hostname + hotspot hand-off, and the chpasswd hand-off
-      "sudo /usr/bin/systemctl start clawbox-root-update@set_hostname.service",
-      "sudo /usr/bin/systemctl start clawbox-root-update@restart_ap.service",
-      "sudo /usr/bin/systemctl start clawbox-root-update@chpasswd.service",
+      // setup wizard hand-offs, the updater and the UI install buttons all go
+      // through the one root-owned launcher now (TASK-539).
+      "sudo /usr/local/libexec/clawbox/clawbox-run-root-step.sh",
       // power menu
       "sudo /usr/bin/systemctl reboot",
       "sudo /usr/bin/systemctl poweroff",

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -383,7 +383,10 @@ describe("updater", () => {
     it("fails when an overrun post_update later settles with a systemd error result", async () => {
       const timeoutErr = Object.assign(new Error("Command failed"), { killed: true });
       setupExecFileMock({
-        "start clawbox-root-update@post_update.service": timeoutErr,
+        // The root step goes through the sudo launcher now (TASK-539), so the
+        // simulated client timeout has to land on that call — an injection at
+        // `systemctl start clawbox-root-update@…` would never fire.
+        "clawbox-run-root-step.sh post_update": timeoutErr,
         "show clawbox-root-update@post_update.service -p ActiveState": {
           stdout: "failed\n",
           stderr: "",
@@ -455,7 +458,7 @@ describe("updater", () => {
 
     it("serializes post_update and repairs reported Codex consent before one recovery restart", async () => {
       setupExecFileMock({
-        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": {
           stdout: "Plugin \"codex\" requires capability consent\n[sqlite/transaction] SQLite transaction lock wait failed\n",
           stderr: "",
@@ -501,7 +504,7 @@ describe("updater", () => {
         `${cmd} ${(args as string[]).join(" ")}`,
       );
       const postUpdateIndex = calls.findIndex((call) =>
-        call.includes("systemctl start clawbox-root-update@post_update.service"),
+        call.includes("/usr/bin/sudo -n /usr/local/libexec/clawbox/clawbox-run-root-step.sh post_update"),
       );
       const preStartIndex = calls.findIndex((call) =>
         call.includes("/bin/bash") && call.includes("scripts/gateway-pre-start.sh"),
@@ -550,7 +553,7 @@ describe("updater", () => {
         "plugins install @openclaw/codex@2026.8.1 --force --accept-capabilities": new Error(
           "Codex repair timed out",
         ),
-        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": {
           stdout: "Plugin \"codex\" requires capability consent\n",
           stderr: "",
@@ -595,7 +598,7 @@ describe("updater", () => {
     it("retries a failed maintenance unmask and surfaces the cleanup failure", async () => {
       setupExecFileMock({
         "systemctl --runtime unmask clawbox-gateway.service": new Error("unmask failed"),
-        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         ping: { stdout: "", stderr: "" },
         systemctl: { stdout: "", stderr: "" },
         openclaw: { stdout: "1.0.0", stderr: "" },
@@ -628,7 +631,7 @@ describe("updater", () => {
 
     it("does not re-enable an explicitly disabled unused Codex plugin from a stale journal line", async () => {
       setupExecFileMock({
-        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": {
           stdout: "Plugin \"codex\" requires capability consent\n",
           stderr: "",
@@ -673,7 +676,7 @@ describe("updater", () => {
 
     it("records explicit consent but does not restart when current pre-start fails", async () => {
       setupExecFileMock({
-        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": {
           stdout: "Plugin \"codex\" requires capability consent\n",
           stderr: "",
@@ -806,7 +809,7 @@ describe("updater", () => {
         `${cmd} ${(args as string[]).join(" ")}`,
       );
       const installIndex = calls.findIndex((call) =>
-        call.includes("systemctl start clawbox-root-update@openclaw_install.service"),
+        call.includes("/usr/bin/sudo -n /usr/local/libexec/clawbox/clawbox-run-root-step.sh openclaw_install"),
       );
       const firstMaskIndex = calls.findIndex((call) =>
         call.includes("systemctl --runtime mask clawbox-gateway.service"),

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -260,7 +260,7 @@ describe("updater", () => {
 
     it("uses the root step journal output when a root update step fails", async () => {
       setupExecFileMock({
-        "start clawbox-root-update@apt_update.service": new Error("systemctl failed"),
+        "clawbox-run-root-step.sh apt_update": new Error("systemctl failed"),
         // The journal only overrides the error when the unit reports failed.
         "show clawbox-root-update@apt_update.service": { stdout: "failed\n", stderr: "" },
         "/usr/bin/journalctl": {
@@ -300,7 +300,7 @@ describe("updater", () => {
       // most recently and must NOT be presented as the failure.
       const timeoutErr = Object.assign(new Error("Command failed"), { killed: true });
       setupExecFileMock({
-        "start clawbox-root-update@apt_update.service": timeoutErr,
+        "clawbox-run-root-step.sh apt_update": timeoutErr,
         "show clawbox-root-update@apt_update.service": { stdout: "success\n", stderr: "" },
         "/usr/bin/journalctl": {
           stdout: "Linkdown routing sysctl installed\n",
@@ -338,7 +338,7 @@ describe("updater", () => {
       // re-runs everything) on a successful update.
       const timeoutErr = Object.assign(new Error("Command failed"), { killed: true });
       setupExecFileMock({
-        "start clawbox-root-update@post_update.service": timeoutErr,
+        "clawbox-run-root-step.sh post_update": timeoutErr,
         "show clawbox-root-update@post_update.service -p ActiveState": { stdout: "inactive\n", stderr: "" },
         "show clawbox-root-update@post_update.service -p Result": { stdout: "success\n", stderr: "" },
         ping: { stdout: "", stderr: "" },
@@ -424,7 +424,7 @@ describe("updater", () => {
 
     it("fails the continuation when gateway verification still finds no known recovery path", async () => {
       setupExecFileMock({
-        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": {
           stdout: "gateway crashed for an unrelated reason\n",
           stderr: "",
@@ -717,7 +717,7 @@ describe("updater", () => {
 
     it("quarantines known legacy gateway blockers and completes when the gateway recovers", async () => {
       setupExecFileMock({
-        "start clawbox-root-update@post_update.service": { stdout: "", stderr: "" },
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
         "/usr/bin/journalctl -u clawbox-gateway.service": {
           stdout: "conflicting plugin install metadata\nopenclaw-agent.sqlite belongs to agent piper; requested agent carl_pir\n",
           stderr: "",
@@ -761,7 +761,7 @@ describe("updater", () => {
 
     it("stops the update sequence when bootstrap_updater fails", async () => {
       setupExecFileMock({
-        "start clawbox-root-update@bootstrap_updater.service": new Error("systemctl failed"),
+        "clawbox-run-root-step.sh bootstrap_updater": new Error("systemctl failed"),
         "show clawbox-root-update@bootstrap_updater.service": { stdout: "failed\n", stderr: "" },
         "/usr/bin/journalctl": {
           stdout: "fatal: invalid branch name in .update-branch\n",


### PR DESCRIPTION
Closes **GAP 1** from Mike's audit of #471 — the last open item on TASK-445, and the one he rated CRITICAL. Base is `beta`, on top of #471 (merged).

---

## What it was

`config/49-clawbox-updates.pkla`, installed by `install.sh::step_polkit_rules`:

```
[Allow clawbox to manage ClawBox systemd services]
Identity=unix-user:clawbox
Action=org.freedesktop.systemd1.manage-units
ResultAny=yes / ResultInactive=yes / ResultActive=yes
```

No unit condition — a `.pkla` on polkit 0.105, which is what JetPack ships, cannot express one. And `org.freedesktop.systemd1.manage-units` is the action systemd checks for `StartTransientUnit`, so it is `systemd-run /bin/sh -c …`: arbitrary root, no password, for the account the web server, the in-UI terminal and the agent's shell all run as. **Every narrowing in `config/clawbox-sudoers` was bypassable while it existed.**

Worse, `step_polkit_rules` actively `rm -f`'d `/etc/polkit-1/rules.d/49-clawbox-updates.rules` — the correctly scoped twin already in this repo (`unit.indexOf("clawbox-root-update@") === 0`) — which is how the unscoped `.pkla` became the only authority.

Reproduced read-only on a board flashed from `main` this morning (2026-08-27, OpenClaw edition):

```
org.freedesktop.systemd1.manage-units        AUTHORIZED
org.freedesktop.systemd1.manage-unit-files   NOT-AUTHORIZED   # control
org.freedesktop.systemd1.reload-daemon       NOT-AUTHORIZED   # control
org.freedesktop.hostname1.set-hostname       NOT-AUTHORIZED   # control
```

The three controls are what make that a statement about the `.pkla` and not about a permissive polkit.

## Why removal rather than narrowing

The upstream research settles it: **neither harness needs this.** Hermes' installer states three times that it "does not require or retain root access", its docs list "any user without sudo access" as supported, and its own FAQ prescribes exactly the shape this PR moves to — *"configure passwordless sudo for specific commands in /etc/sudoers"*. OpenClaw's daemon is a systemd **user** service. Of the grant categories in `config/clawbox-sudoers`, none is required by a harness: they are ClawBox product features, two ClawBox defects, and one provisioning artifact.

And `.pkla` cannot be narrowed — that is the whole reason this was stuck. sudoers can.

## What replaces it

One root-owned launcher, granted once:

```
clawbox ALL=(root) NOPASSWD: /usr/local/libexec/clawbox/clawbox-run-root-step.sh
```

Not ~25 enumerated `clawbox-root-update@<step>.service` instances: that is 50 lines of string matching nobody reviews, and the wildcard that would compress them is exactly what TASK-445 removed. `config/clawbox-run-root-step.sh` instead:

* takes a **STEP** name, never a unit name, and builds the unit itself;
* checks it against `WEB_ROOT_STEPS` — 25 names, deliberately narrower than the root dispatcher's 48, which also covers operator-only steps — with `src/tests/unit/root-steps.test.ts` pinning the shell list to `src/lib/root-steps.ts`;
* refuses a second argument, so "`systemctl start` takes a LIST of units" cannot come back through it;
* clears a previous failure itself, so no caller needs its own grant and no step becomes permanently unstartable against systemd's start limit (`clawbox-root-update@.service` does not set `StartLimitIntervalSec=0`).

No argument spec in the Cmnd, deliberately: the arguments are validated by root-owned code rather than by sudo's string matching — the same shape as the existing `optimize-ollama.sh` grant, and the same shape the deleted `.rules` file expressed.

**Verified against the real script on Ubuntu 22.04**, with `/usr/bin/systemctl` redirected to a recorder (nothing started):

```
=== permitted ===                    === refused (rc 64, systemctl never called) ===
chpasswd                        ok   git_pull            build           rebuild
--no-block llamacpp_install     ok   recover             polkit_rules    systemd_services
set_hostname                    ok   ../../etc/shadow    chpasswd.service
restart_ap                      ok   CHPASSWD            <empty>
post_update                     ok   chpasswd ssh        --no-block chpasswd ssh
                                     clawbox-root-update@chpasswd.service

what reached systemctl:  reset-failed clawbox-root-update@<step>.service
                         start [--no-block] clawbox-root-update@<step>.service
```

## Call sites

All seven move to `src/lib/root-step-runner.ts::startRootStep()`: `updater.ts` (both starters), `install/run-step`, `system/credentials`, `setup/reset` (chpasswd **and** set_hostname), `system/hostname`, `system/hotspot`, `llamacpp/install`. Every one passes `sudo -n`, so a device missing the grant fails in milliseconds rather than blocking a route handler on a prompt nobody can answer.

`step_polkit_rules` stops deleting `49-clawbox-updates.rules` and installs it instead — inert on polkit 0.105, correct on anything newer.

## The NetworkManager stanza stays

It names five specific NM actions rather than a category, `nmcli` needs them for the wifi and hotspot flows, and Mike's audit assessed it as legitimately scoped. Narrowing it further means routing every `nmcli` write through sudo, which is a separate change with its own hardware verification.

## Enforcement

`scripts/check-sudoers-coverage.sh` gains the call shape that made this possible to miss in the first place: `execFile("sudo", argv)` where `argv` is a **variable**. Without it, a helper that builds its own argument list is invisible to the whole check — its grant reads as unused, and a new one would read as covered.

New/changed tests:

* `src/tests/unit/root-step-launcher.test.ts` (new) — runs the shipped launcher with systemctl stubbed: permitted steps produce exactly the two intended commands; a step outside `WEB_ROOT_STEPS`, a non-identifier, a unit name, an empty step and a second argument all exit 64 with nothing reaching systemctl.
* `src/tests/unit/root-steps.test.ts` — the launcher's list must equal `WEB_ROOT_STEPS`, must be inside the dispatcher's allow-list and strictly narrower, must cover every UI step; and no grant may name a `clawbox-root-update@` unit any more.
* `e2e-install/06-sudoers.spec.ts` — on a real provisioned device: `pkcheck --action-id org.freedesktop.systemd1.manage-units` must be **NOT-AUTHORIZED** for clawbox (with `manage-unit-files` NOT-AUTHORIZED and `NetworkManager.wifi.scan` AUTHORIZED as controls, so a pass is about this grant and not about a broken probe), the installed `.pkla` must not mention `manage-units` and must still carry the NM stanza, and `sudo -n` must deny every `clawbox-root-update@` unit while allowing the launcher.

## Rebased onto #534

#534 ("verify the sudoers declarations instead of trusting them") landed under this branch and changed two things here:

* `%DECLARED_ARGV` entries are now `{ argv, resolve, unverified }` rather than a bare list, and every dynamic argument must be named in one of the latter two. The `root-step-runner.ts` declaration is re-expressed in that schema, with `argv` under `unverified` and the reason spelled out: `startRootStep()` assembles the list imperatively (`["-n", ROOT_STEP_LAUNCHER]`, then an optional `--no-block`, then the step), so there is no single const array for a symbol lookup to read back. The **step** stays deliberately un-enumerated — that is the whole design.
* The scanner's new `execFile("sudo", <variable>)` branch now goes through `declared_argv()` so the declaration is verified, not merely looked up. (The pre-rebase spelling read `%DECLARED_ARGV` directly and would have dereferenced a hash ref as an array.)

**#534 does not make that scanner branch redundant.** Removing it and the declaration together, on top of current beta, makes the checker report:

```
UNUSED grants (1):
  config/clawbox-sudoers:158  /usr/local/libexec/clawbox/clawbox-run-root-step.sh
```

— the only grant this PR adds becomes invisible to the check. Keeping the declaration but dropping the branch fails the other way, with #534's new stale-declaration error. The two are complementary: #534 verifies that a declaration still matches the code; this branch is what makes the call shape visible in the first place.

`install-sudoers-migration.test.ts` also gained a "grants exactly the systemctl commands the product issues" list in #534. Its eight `clawbox-root-update@` entries are gone here, because the four instances they named are no longer started by a systemctl grant at all.

## What this removes, and what it keeps

**Removed** — `org.freedesktop.systemd1.manage-units` for `unix-user:clawbox`, the entire first stanza of `config/49-clawbox-updates.pkla`. That is the action systemd checks for `StartTransientUnit`, so it was `systemd-run /bin/sh -c …`: arbitrary passwordless root for the account the web server, the in-UI terminal and the agent's shell all run as.

**Removed** — eight sudoers Cmnd_Specs, the enumerated `reset-failed` / `start` pairs for `clawbox-root-update@{chpasswd,set_hostname,restart_ap,llamacpp_install}.service`.

**Added** — exactly one: `/usr/local/libexec/clawbox/clawbox-run-root-step.sh`, root-owned, no argument spec, which validates the step itself.

**Kept, unchanged** — all five NetworkManager actions (`wifi.scan`, `network-control`, `settings.modify.system`, `wifi.share.open`, `wifi.share.protected`). `nmcli` needs them for the wifi and hotspot flows and they name specific actions rather than a category.

Also kept: every other grant in `config/clawbox-sudoers` (gateway/setup/browser/tunnel service control, ollama, apt/dpkg/snap, reboot/poweroff, the desktop and power mode helpers). This PR changes the root-step surface and nothing else.

The migration order is the part worth reviewing on a device: `step_rebuild_reboot` calls `step_systemd_services` — which installs the launcher (`install_root_libexec`) and then the new allow-list — **before** `step_polkit_rules` removes the grant. A box is therefore never left with neither.

## Still to do before this merges — this stays a DRAFT

**Hardware verification of the product flows, which has not been completed.** The e2e-install container exercises the allow-list and the polkit state, not a Jetson's radio.

Progress so far: a box was brought to beta head with the in-app updater and a full pre-change baseline captured (`manage-units` AUTHORIZED; `manage-unit-files`, `reload-daemon` NOT-AUTHORIZED; all five NM actions AUTHORIZED; polkit 0.105). It went offline before the branch could be installed on it, so **nothing on this PR has been exercised on hardware yet.**

A scripted one-pass validation is ready to run the moment a box is free — preflight and baseline, migration through the product's own updater, the privilege boundary, then wifi / hotspot / VNC / a full in-app update / the remaining call sites, then teardown.

Two things that verification has to settle, and cannot be settled from the repo:

1. **Does polkit 0.105 re-read the `.pkla` after `step_polkit_rules` overwrites it?** `cp` replaces the file, and nothing reloads polkit. If `manage-units` only becomes NOT-AUTHORIZED after a reboot, `step_polkit_rules` needs an explicit reload and that is a defect in this PR, not an environment quirk.
2. **Does every root step still start through the launcher on a real device**, including a full in-app update with the grant already gone — where a missing grant surfaces as `Command failed: /usr/bin/sudo` rather than anything about polkit.

Static analysis of the sibling call sites is complete: every `startRootStep()` caller is listed above, and a sweep of the tree for unprivileged system-scope `systemctl` writes finds none left — the remaining bare `systemctl` calls are reads (`show`, `is-active`, `is-enabled`), `--user`-scope calls, or run in already-root contexts (`clawbox-firstboot-vnc.service`, `clawbox-ap.service` and `clawbox-ap-watchdog.service` all carry no `User=`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Privileged setup and update operations now run through a validated, root-owned launcher.
  * Direct systemd management access is restricted, while NetworkManager scanning remains available.

* **Bug Fixes**
  * Improved validation prevents unauthorized or malformed root-step requests.
  * Root-step failures are reset before retrying, with optional non-blocking execution preserved.

* **Tests**
  * Added coverage for allowed steps, rejected inputs, sudo permissions, and launcher behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->