### PR TITLE
fix: report what the uninstaller said, not its exit code (TASK-547)

### DIFF
--- a/src/app/setup-api/hermes/skills/uninstall/route.ts
+++ b/src/app/setup-api/hermes/skills/uninstall/route.ts
@@ -3,11 +3,30 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { isValidSkillName } from "@/lib/hermes-skills";
-import { hermesSkillsGuard, invalidateInstalledCache } from "@/lib/hermes-skills-server";
+import { parseUninstallOutcome } from "@/lib/hermes-skill-cli-outcome";
+import {
+  hermesSkillsGuard,
+  invalidateInstalledCache,
+  isInHubLock,
+  readBundledManifestNames,
+} from "@/lib/hermes-skills-server";
 
 // Uninstall a Hermes skill. The positional argument is the skill NAME (the
 // lock.json key, e.g. "1password"), NOT the full registry identifier. There is
 // no `--yes` flag — the CLI prompts `Confirm [y/N]:`, so we pipe "y\n" on stdin.
+//
+// ── TASK-547: the exit code is not an answer ────────────────────────────────
+//
+// `hermes skills uninstall` exits 0 whether it removed the skill or refused to:
+// `do_uninstall` prints `uninstall_skill`'s message and returns. That is the
+// exact habit PR #504 handled for install, and the reason the install route's
+// own rollback deliberately does not trust this command. Reading only the exit
+// code, this route answered {"ok":true} for a builtin, for a name that does
+// not exist, and for a lock entry the path validator refused — and the store
+// told the customer a skill was gone while the device still had it. Now the
+// CLI's own sentence is classified (parseUninstallOutcome), and a success has
+// to be true in the hub lock before it is reported.
+
 export async function POST(request: Request) {
   const blocked = await hermesSkillsGuard();
   if (blocked) return blocked;
@@ -25,18 +44,75 @@ export async function POST(request: Request) {
   }
 
   try {
+    // Read the lock BEFORE the CLI runs: for a wording this parser has never
+    // seen, an entry that was there and is gone afterwards is still a removal.
+    const hadEntry = await isInHubLock(id);
     const r = await runHermesCli(["skills", "uninstall", id], {
       timeoutMs: 30_000,
       input: "y\n",
     });
-    // The skill directory is gone — drop the cached installed list before we
-    // answer so the client's re-fetch can't be served the pre-removal walk.
+    // The skill directory may be gone — drop the cached installed list before
+    // we answer so the client's re-fetch can't be served the pre-removal walk.
     invalidateInstalledCache();
     if (r.code !== 0) {
       // Raw stderr can carry a Python traceback with the binary path and local
       // install dirs — log it, never send it to the browser.
       console.error("[hermes skills uninstall] exit", r.code, r.stderr);
-      return NextResponse.json({ error: "Uninstall failed" }, { status: 502 });
+      return NextResponse.json(
+        { error: "Uninstall failed", code: "uninstall_failed" },
+        { status: 502 },
+      );
+    }
+
+    const outcome = parseUninstallOutcome(r.stdout, r.stderr);
+    if (outcome.kind === "not-installed") {
+      // The CLI cannot tell a skill that shipped with the device from a name
+      // it has never seen — the bundled manifest can, and the difference is
+      // the difference between "you cannot" and "there is nothing to remove".
+      if ((await readBundledManifestNames()).has(id)) {
+        return NextResponse.json(
+          {
+            error: `"${id}" came with this device, so it cannot be removed.`,
+            code: "builtin_skill",
+          },
+          { status: 409 },
+        );
+      }
+      return NextResponse.json(
+        {
+          error: `No store skill called "${id}" is installed on this device.`,
+          code: "not_installed",
+        },
+        { status: 404 },
+      );
+    }
+    if (outcome.kind === "refused") {
+      // The reason after the colon is a raw exception string that can name
+      // on-device paths — log it, answer with fixed words. Same rule as the
+      // non-zero-exit branch.
+      console.error("[hermes skills uninstall] CLI refused", r.stdout);
+      return NextResponse.json(
+        { error: "The device refused to remove that skill.", code: "uninstall_refused" },
+        { status: 502 },
+      );
+    }
+
+    // 'uninstalled', 'cancelled' or 'unknown': the hub lock decides. The CLI
+    // drops the lock entry before it prints its success sentence, so an entry
+    // that survived contradicts anything the output said — and for output this
+    // parser does not recognise, only the entry's disappearance proves a
+    // removal.
+    const stillLocked = await isInHubLock(id);
+    const removed = !stillLocked && (outcome.kind === "uninstalled" || hadEntry);
+    if (!removed) {
+      console.error("[hermes skills uninstall] exit 0 without removing", outcome.kind, r.stdout);
+      return NextResponse.json(
+        {
+          error: "The device's uninstaller stopped without removing the skill.",
+          code: "uninstall_failed",
+        },
+        { status: 502 },
+      );
     }
     return NextResponse.json({ ok: true, id, name: id });
   } catch (err) {

--- a/src/lib/hermes-skill-cli-outcome.ts
+++ b/src/lib/hermes-skill-cli-outcome.ts
@@ -288,3 +288,56 @@ export function parseInstallOutcome(stdout: string, stderr = ''): InstallOutcome
   }
   return { ...empty, kind: 'unknown' };
 }
+
+// ── Uninstall ───────────────────────────────────────────────────────────────
+//
+// TASK-547 — `hermes skills uninstall` has the same habit: it exits 0 whether
+// it removed the skill or refused to. `do_uninstall`
+// (hermes_cli/skills_hub.py:1222) prints `uninstall_skill`'s message
+// (tools/skills_hub.py:4081) and returns, so the printed sentence is the only
+// record of what happened. Same discipline as parseInstallOutcome: match a
+// whitespace-collapsed copy (the 80-column wrap again), recognise only the
+// CLI's own templated sentences, and never keep a free-text exception string,
+// which can carry on-device paths.
+
+export type UninstallOutcomeKind =
+  /** `Uninstalled '<name>' from <path>` — printed after the lock entry is dropped. */
+  | 'uninstalled'
+  /** `'<name>' is not a hub-installed skill (may be a builtin)`. */
+  | 'not-installed'
+  /**
+   * `Refusing to uninstall '<name>': <exception>` — the lock-path validator
+   * rejected the entry's install_path. The tail is a raw exception string and
+   * is deliberately not kept.
+   */
+  | 'refused'
+  /** `Cancelled.` — the confirmation prompt was not answered with yes. */
+  | 'cancelled'
+  /** The uninstaller said something this parser does not recognise. */
+  | 'unknown';
+
+export interface UninstallOutcome {
+  kind: UninstallOutcomeKind;
+}
+
+const UNINSTALL_REFUSED_RE = /Refusing to uninstall '[^']*':/i;
+const UNINSTALL_NOT_INSTALLED_RE = /'[^']*' is not a hub-installed skill/i;
+const UNINSTALL_OK_RE = /Uninstalled '[^']*' from /i;
+const UNINSTALL_CANCELLED_RE = /\bCancelled\./;
+
+/**
+ * Classify one `hermes skills uninstall` run that exited 0.
+ *
+ * The two refusals are checked before the success sentence so a refusal that
+ * happens to contain the word "uninstall" can never be read as a removal.
+ */
+export function parseUninstallOutcome(stdout: string, stderr = ''): UninstallOutcome {
+  const flat = `${stdout || ''}\n${stderr || ''}`
+    .slice(0, MAX_OUTPUT_CHARS)
+    .replace(/\s+/g, ' ');
+  if (UNINSTALL_REFUSED_RE.test(flat)) return { kind: 'refused' };
+  if (UNINSTALL_NOT_INSTALLED_RE.test(flat)) return { kind: 'not-installed' };
+  if (UNINSTALL_OK_RE.test(flat)) return { kind: 'uninstalled' };
+  if (UNINSTALL_CANCELLED_RE.test(flat)) return { kind: 'cancelled' };
+  return { kind: 'unknown' };
+}

--- a/src/tests/routes/hermes/skills-uninstall-honest.test.ts
+++ b/src/tests/routes/hermes/skills-uninstall-honest.test.ts
@@ -1,0 +1,225 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-547 — the uninstall route answered `{"ok":true}` for skills it never
+ * removed, because it read the CLI's EXIT CODE and `hermes skills uninstall`
+ * exits 0 whether it removed the skill or refused to. `do_uninstall`
+ * (hermes_cli/skills_hub.py:1222) prints `uninstall_skill`'s refusal
+ * (tools/skills_hub.py:4081) and returns — so asking to remove a builtin, a
+ * name that does not exist, or a skill whose lock entry the path validator
+ * rejects all came back as success, and the store's UI told the customer the
+ * skill was gone while the device still had it. The exact defect class
+ * PR #504 fixed for install; the install route's own rollback comment already
+ * recorded the fact for uninstall.
+ *
+ * The CLI is faked FAITHFULLY from the deployed hermes-agent: exit 0 always,
+ * the outcome only in the printed sentence, the lock entry removed only on a
+ * real uninstall.
+ */
+
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: vi.fn(async () => "hermes"),
+  HERMES_BIN: "/home/clawbox/.local/bin/hermes",
+}));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: vi.fn() }));
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet: vi.fn(async () => ""),
+  hermesConfigGetMany: vi.fn(async () => ({})),
+  invalidateHermesConfigCache: vi.fn(),
+}));
+
+import { runHermesCli } from "@/lib/hermes-cli";
+import { saveEnv } from "../../helpers/env";
+
+const mockCli = vi.mocked(runHermesCli);
+
+let hermesHome: string;
+
+const INSTALLED = "oo-terraform";
+
+function skillsDir(): string {
+  return path.join(hermesHome, "skills");
+}
+
+async function writeLock(installed: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(path.join(skillsDir(), ".hub"), { recursive: true });
+  await fs.writeFile(
+    path.join(skillsDir(), ".hub", "lock.json"),
+    JSON.stringify({ version: 1, installed }),
+  );
+}
+
+async function readLock(): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(path.join(skillsDir(), ".hub", "lock.json"), "utf8");
+  return (JSON.parse(raw) as { installed: Record<string, unknown> }).installed;
+}
+
+/**
+ * `hermes skills uninstall`, exactly as the box runs it: the confirmation
+ * prompt on stdout, exit 0 no matter what, and the outcome only in prose.
+ * An entry whose install_path the validator would reject is refused with the
+ * raw exception string, and its lock entry survives.
+ */
+function fakeHermes(): void {
+  mockCli.mockImplementation(async (args: string[]) => {
+    if (args[1] !== "uninstall") return { code: 0, stdout: "", stderr: "" };
+    const name = args[2];
+    const prompt = `\nUninstall '${name}'?\nConfirm [y/N]: `;
+    const lock = await readLock();
+    const entry = lock[name] as { install_path?: string } | undefined;
+    if (!entry) {
+      return {
+        code: 0,
+        stdout: `${prompt}Error: '${name}' is not a hub-installed skill (may be a builtin)\n`,
+        stderr: "",
+      };
+    }
+    if ((entry.install_path ?? "").includes("..")) {
+      return {
+        code: 0,
+        stdout:
+          `${prompt}Error: Refusing to uninstall '${name}': lock entry install_path `
+          + `'${entry.install_path}' escapes the skills directory\n`,
+        stderr: "",
+      };
+    }
+    delete lock[name];
+    await writeLock(lock);
+    return {
+      code: 0,
+      stdout: `${prompt}Uninstalled '${name}' from ${name}\n`,
+      stderr: "",
+    };
+  });
+}
+
+async function uninstall(id: string) {
+  const { POST } = await import("@/app/setup-api/hermes/skills/uninstall/route");
+  const res = await POST(
+    new Request("http://localhost/setup-api/hermes/skills/uninstall", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+let restoreEnv: () => void;
+
+beforeEach(async () => {
+  vi.resetModules();
+  restoreEnv = saveEnv("HERMES_HOME", "CLAWBOX_ROOT");
+  hermesHome = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-hermes-uninst-"));
+  process.env.HERMES_HOME = hermesHome;
+  await fs.mkdir(skillsDir(), { recursive: true });
+  await writeLock({
+    [INSTALLED]: {
+      install_path: INSTALLED,
+      files: ["SKILL.md"],
+      identifier: INSTALLED,
+      source: "clawhub",
+      trust_level: "community",
+      scan_verdict: "safe",
+    },
+  });
+  fakeHermes();
+});
+
+afterEach(async () => {
+  restoreEnv();
+  await fs.rm(hermesHome, { recursive: true, force: true });
+});
+
+describe("POST …/skills/uninstall — a refusal is not a success", () => {
+  it("does not report success for a name the device never had", async () => {
+    const res = await uninstall("no-such-skill");
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ code: "not_installed" });
+    expect(res.body.ok).toBeUndefined();
+  });
+
+  it("says a skill that came with the device cannot be removed", async () => {
+    // `.bundled_manifest` is `name:hash` per line — the shipped skills.
+    await fs.writeFile(path.join(skillsDir(), ".bundled_manifest"), "pdf:abc123\nqr:def456\n");
+
+    const res = await uninstall("pdf");
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "builtin_skill" });
+    expect(String(res.body.error)).toMatch(/came with this device/i);
+  });
+
+  it("reports the lock-path validator's refusal without echoing its exception", async () => {
+    await writeLock({
+      poisoned: { install_path: "../../.ssh", identifier: "poisoned", source: "clawhub" },
+    });
+
+    const res = await uninstall("poisoned");
+
+    expect(res.status).toBe(502);
+    expect(res.body).toMatchObject({ code: "uninstall_refused" });
+    expect(JSON.stringify(res.body)).not.toContain(".ssh");
+    expect(JSON.stringify(res.body)).not.toContain("escapes the skills directory");
+  });
+
+  it("does not report success when the CLI says something unrecognised and the lock still holds the skill", async () => {
+    mockCli.mockResolvedValue({ code: 0, stdout: "a sentence from a future CLI\n", stderr: "" });
+
+    const res = await uninstall(INSTALLED);
+
+    expect(res.status).toBe(502);
+    expect(res.body).toMatchObject({ code: "uninstall_failed" });
+    expect(await readLock()).toHaveProperty(INSTALLED);
+  });
+
+  it("does not report success when the confirmation was not accepted", async () => {
+    mockCli.mockResolvedValue({
+      code: 0,
+      stdout: `\nUninstall '${INSTALLED}'?\nConfirm [y/N]: Cancelled.\n`,
+      stderr: "",
+    });
+
+    const res = await uninstall(INSTALLED);
+
+    expect(res.status).toBe(502);
+    expect(res.body).toMatchObject({ code: "uninstall_failed" });
+  });
+});
+
+describe("POST …/skills/uninstall — a real uninstall still works", () => {
+  it("answers ok and the lock entry is gone", async () => {
+    const res = await uninstall(INSTALLED);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, id: INSTALLED, name: INSTALLED });
+    expect(await readLock()).not.toHaveProperty(INSTALLED);
+  });
+
+  it("accepts a wording change from a future CLI when the lock proves the removal", async () => {
+    mockCli.mockImplementation(async (args: string[]) => {
+      const lock = await readLock();
+      delete lock[args[2]];
+      await writeLock(lock);
+      return { code: 0, stdout: "Skill removed.\n", stderr: "" };
+    });
+
+    const res = await uninstall(INSTALLED);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true });
+  });
+
+  it("still answers 502 for a non-zero exit", async () => {
+    mockCli.mockResolvedValue({ code: 1, stdout: "", stderr: "Traceback (most recent call last)" });
+
+    const res = await uninstall(INSTALLED);
+
+    expect(res.status).toBe(502);
+    expect(String(res.body.error)).not.toContain("Traceback");
+  });
+});

--- a/src/tests/unit/hermes-skill-cli-outcome.test.ts
+++ b/src/tests/unit/hermes-skill-cli-outcome.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseAmbiguousSkills, parseInstallOutcome } from '@/lib/hermes-skill-cli-outcome';
+import {
+  parseAmbiguousSkills,
+  parseInstallOutcome,
+  parseUninstallOutcome,
+} from '@/lib/hermes-skill-cli-outcome';
 
 /**
  * TASK-453 round 3 — `hermes skills install` exits 0 on every refusal, so the
@@ -294,5 +298,91 @@ describe('parseAmbiguousSkills — the real table', () => {
     ].join('\n');
 
     expect(parseAmbiguousSkills(many, 5)).toHaveLength(5);
+  });
+});
+
+/**
+ * TASK-547 — `hermes skills uninstall` has the same habit as install: it exits
+ * 0 whether it removed the skill or refused to. `do_uninstall`
+ * (hermes_cli/skills_hub.py:1222) prints `uninstall_skill`'s message
+ * (tools/skills_hub.py:4081) and returns, so the ONLY record of what happened
+ * is the sentence itself:
+ *
+ *   Uninstalled '<name>' from <install_path>                     — it worked
+ *   Error: '<name>' is not a hub-installed skill (may be a builtin)
+ *   Error: Refusing to uninstall '<name>': <free-text exception>
+ *   Cancelled.                                                   — no confirm
+ *
+ * The transcripts below reproduce those verbatim, including the `Confirm
+ * [y/N]:` prompt that `input()` writes to stdout ahead of the answer, and the
+ * 80-column wrap a `rich` console applies when stdout is a pipe.
+ */
+
+const UNINSTALL_OK = [
+  '',
+  "Uninstall 'oo-terraform'?",
+  "Confirm [y/N]: Uninstalled 'oo-terraform' from oo-terraform",
+  '',
+].join('\n');
+
+const UNINSTALL_NOT_INSTALLED = [
+  '',
+  "Uninstall 'pdf'?",
+  "Confirm [y/N]: Error: 'pdf' is not a hub-installed skill (may be a builtin)",
+  '',
+].join('\n');
+
+// The lock-path validator's refusal. The tail after the colon is a raw
+// exception string and can carry on-device paths.
+const UNINSTALL_REFUSED = [
+  '',
+  "Uninstall 'helm'?",
+  "Confirm [y/N]: Error: Refusing to uninstall 'helm': lock entry install_path ",
+  "'../../.ssh' escapes the skills directory",
+  '',
+].join('\n');
+
+describe('parseUninstallOutcome — what the uninstaller actually said', () => {
+  it('reads the success sentence as uninstalled', () => {
+    expect(parseUninstallOutcome(UNINSTALL_OK).kind).toBe('uninstalled');
+  });
+
+  it('reads the builtin/unknown-name refusal as not-installed, not as success', () => {
+    expect(parseUninstallOutcome(UNINSTALL_NOT_INSTALLED).kind).toBe('not-installed');
+  });
+
+  it('still classifies the refusal when the 80-column wrap splits the sentence', () => {
+    const wrapped = [
+      "Confirm [y/N]: Error: 'a-skill-with-a-rather-long-name' is not a ",
+      'hub-installed skill (may be a builtin)',
+    ].join('\n');
+
+    expect(parseUninstallOutcome(wrapped).kind).toBe('not-installed');
+  });
+
+  it('reads the lock-path validator refusal as refused', () => {
+    expect(parseUninstallOutcome(UNINSTALL_REFUSED).kind).toBe('refused');
+  });
+
+  it('never carries the refusal’s free-text exception, which can name on-device paths', () => {
+    const out = parseUninstallOutcome(UNINSTALL_REFUSED);
+
+    expect(JSON.stringify(out)).not.toContain('.ssh');
+    expect(JSON.stringify(out)).not.toContain('escapes the skills directory');
+  });
+
+  it('reads an unconfirmed prompt as cancelled', () => {
+    expect(
+      parseUninstallOutcome("\nUninstall 'pdf'?\nConfirm [y/N]: Cancelled.\n").kind,
+    ).toBe('cancelled');
+  });
+
+  it('does not guess when the uninstaller says something it has never seen', () => {
+    expect(parseUninstallOutcome('a sentence from a future CLI\n').kind).toBe('unknown');
+  });
+
+  it('does not read the confirmation prompt itself as an outcome', () => {
+    // A timed-out run can die with only the prompt written.
+    expect(parseUninstallOutcome("\nUninstall 'pdf'?\nConfirm [y/N]: ").kind).toBe('unknown');
   });
 });


### PR DESCRIPTION
## What

`POST /setup-api/hermes/skills/uninstall` inferred success from the exit code of `hermes skills uninstall` — but the CLI exits 0 whether it removed the skill or refused to (`do_uninstall` prints `uninstall_skill`'s message and returns). Asking to remove a builtin, a name that does not exist, or a skill whose lock entry the CLI's own validator rejects all answered `{"ok":true}`, and the store told the customer a skill was gone while the device still had it.

This is the same defect class #504 fixed for install, and the install route's `rollback()` comment already recorded the fact for uninstall ("the CLI prints its refusals and still exits 0"). TASK-547.

## How

- `src/lib/hermes-skill-cli-outcome.ts` (built in #504) now also classifies uninstall output. `parseUninstallOutcome` recognises the CLI's templated sentences — uninstalled / not-installed / refused / cancelled — matched against a whitespace-collapsed copy for the 80-column wrap, and never keeps the refusal's free-text exception tail, which can carry on-device paths.
- The route answers what actually happened:
  - `404` `not_installed` — the name is not a store-installed skill;
  - `409` `builtin_skill` — the name is in the bundled manifest: it shipped with the device and cannot be removed (the CLI cannot tell these two apart; the manifest can);
  - `502` `uninstall_refused` — the CLI refused the lock entry; the reason is logged server-side and the browser gets fixed words, the same rule the non-zero-exit branch follows;
  - `502` `uninstall_failed` — exit 0 with output the parser does not recognise while the hub lock still holds the entry (and the existing non-zero-exit branch, which now carries a `code` too).
- A reported success additionally has to be true in the hub lock. For output the parser has never seen, an entry that was present before the CLI ran and is gone after still counts as a removal — a future CLI wording change fails safe, not loud.

## Tests (red first)

- `src/tests/unit/hermes-skill-cli-outcome.test.ts` — 8 new cases against verbatim transcripts of the deployed CLI (`hermes_cli/skills_hub.py::do_uninstall`, `tools/skills_hub.py::uninstall_skill`), including the 80-column wrap and the never-echo rule.
- `src/tests/routes/hermes/skills-uninstall-honest.test.ts` — the route against a faithful CLI fake (exit 0 always, outcome only in prose, lock entry removed only on a real uninstall): refusals are not successes, the exception tail is never echoed, and a legitimate uninstall still works end to end.
- On `beta` before the fix, 13 of these 35 tests fail — every "refusal is not a success" case answers `200 {"ok":true}` there. All 35 pass with the fix. Full suite, lint and typecheck are at the beta baseline.

## Follow-ups (deliberately out of scope — one issue per PR)

- `install/route.ts` `rollback()` runs the same uninstall and already distrusts it (belt-and-braces directory removal), but a refused rollback can still leave the lock ENTRY behind — it could reuse `parseUninstallOutcome` and drop the entry directly.
- `mcp/tools/skills.ts` `skill_uninstall` keeps its before/after installed-list workaround (still correct); its `UNINSTALL_RULES` could now surface the route's `not_installed` / `builtin_skill` / `uninstall_refused` codes for crisper agent-facing messages.
- No enable/disable/update sibling routes exist; browse/inspect/installed/secrets already parse CLI output rather than trusting exit codes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill uninstallation reporting to distinguish successful removals from missing, built-in, refused, cancelled, or unrecognized outcomes.
  * Prevented false success responses when the CLI refuses or fails to remove a skill.
  * Added verification that successfully removed skills are no longer installed.
  * Improved error responses while preventing sensitive CLI details from being exposed.
  * Ensured installed-skill information is refreshed after successful removal.

* **Tests**
  * Added coverage for successful, refused, cancelled, missing, and unexpected uninstall outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->