### PR TITLE
feat: DeepSeek vision, resolved against the proxy rather than assumed

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -651,8 +651,9 @@ if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _visi
     ):
         # The slot names one of OUR vision ids — the previous default is ours
         # to move to the resolved one, both directions. Anything else in the
-        # slot is the owner's choice and stays.
-        agents_defaults["imageModel"] = {"primary": CLAWBOX_VISION_MODEL_REF}
+        # slot is the owner's choice and stays — and the move changes ONLY
+        # `primary`, so fallbacks the owner added ride along.
+        _vision_model_cfg["primary"] = CLAWBOX_VISION_MODEL_REF
         changed = True
 
 # Set by the image-generation migration below, on the one path where it decides

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -506,11 +506,51 @@ if isinstance(deepseek_provider, dict) and deepseek_provider.get("baseUrl") in (
 # Honour the same env override CLAWBOX_AI_VISION_MODEL_ID gives the route, so a
 # box provisioned against a staging proxy with a different alias map is not
 # dragged back to the production slug at the next boot. Unset (the normal case)
-# means the shipped default, which the unit test pins to the TS constant.
-CLAWBOX_VISION_MODEL_ID = (os.environ.get("CLAWBOX_AI_VISION_MODEL_ID") or "").strip() or "gpt-5.6-luna"
+# means the shipped PREFERRED default — DeepSeek's own multimodal model — but
+# nothing writes it unverified: the proxy allowlists bare ids and answers 400
+# model_not_allowed for anything it does not serve yet, so the block below
+# probes first and stays on the previous vision model until the proxy says
+# yes. Boots re-resolve, so a box upgrades itself the first boot after the
+# proxy starts serving the new id — and heals back the same way. This mirrors
+# resolveVisionModelId() in src/lib/clawbox-ai-vision.ts; the two must stay
+# in step. CLAWBOX_VISION_PROBE=allowed|not-allowed|unknown forces the
+# verdict (the unit test runs these bytes without a network).
+CLAWBOX_VISION_PREFERRED_ID = "deepseek-v4-flash-vision-exp"
+CLAWBOX_VISION_LEGACY_ID = "gpt-5.6-luna"
+CLAWBOX_VISION_OVERRIDE_ID = (os.environ.get("CLAWBOX_AI_VISION_MODEL_ID") or "").strip()
 CLAWBOX_VISION_MODEL_NAME = "ClawBox AI Vision"
-CLAWBOX_VISION_MODEL_REF = "deepseek/" + CLAWBOX_VISION_MODEL_ID
 CLAWBOX_VISION_MAX_TOKENS = 128000
+
+def _clawbox_vision_probe(token):
+    forced = (os.environ.get("CLAWBOX_VISION_PROBE") or "").strip()
+    if forced in ("allowed", "not-allowed", "unknown"):
+        return forced
+    try:
+        import json as _vp_json
+        import urllib.request as _vp_rq
+        base = ((os.environ.get("CLAWBOX_AI_PROXY_URL") or "").strip() or "https://clawbox.com/api/ai").rstrip("/")
+        req = _vp_rq.Request(
+            base + "/chat/completions",
+            data=_vp_json.dumps({
+                "model": CLAWBOX_VISION_PREFERRED_ID,
+                "max_tokens": 1,
+                "messages": [{"role": "user", "content": "ok"}],
+            }).encode("utf-8"),
+            headers={"Content-Type": "application/json", "Authorization": "Bearer " + token},
+            method="POST",
+        )
+        with _vp_rq.urlopen(req, timeout=6) as resp:
+            resp.read(64)
+        return "allowed"
+    except Exception as err:  # noqa: BLE001 - any failure below is a verdict, not a crash
+        body = ""
+        try:
+            body = err.read().decode("utf-8", "replace") if hasattr(err, "read") else str(err)
+        except Exception:  # noqa: BLE001
+            body = str(err)
+        if "model_not_allowed" in body or "Model not allowed" in body:
+            return "not-allowed"
+        return "unknown"
 
 # The token is the entitlement, exactly as for images: only a box that actually
 # has ClawBox AI gets a vision model pointed at the ClawBox AI proxy. Read here
@@ -519,10 +559,42 @@ CLAWBOX_VISION_MAX_TOKENS = 128000
 _vision_models = deepseek_provider.get("models") if isinstance(deepseek_provider, dict) else None
 _vision_token = deepseek_provider.get("apiKey") if isinstance(deepseek_provider, dict) else None
 if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _vision_token.startswith("claw_"):
+    # Resolve which of OUR ids this box may name. An operator override wins
+    # unprobed; otherwise the proxy's own answer decides, and an unanswered
+    # question keeps whatever the config already says rather than flapping.
+    if CLAWBOX_VISION_OVERRIDE_ID:
+        CLAWBOX_VISION_MODEL_ID = CLAWBOX_VISION_OVERRIDE_ID
+    else:
+        _vision_verdict = _clawbox_vision_probe(_vision_token)
+        if _vision_verdict == "allowed":
+            CLAWBOX_VISION_MODEL_ID = CLAWBOX_VISION_PREFERRED_ID
+        elif _vision_verdict == "not-allowed":
+            CLAWBOX_VISION_MODEL_ID = CLAWBOX_VISION_LEGACY_ID
+        else:
+            _vision_has_preferred = any(
+                isinstance(m, dict) and m.get("id") == CLAWBOX_VISION_PREFERRED_ID
+                for m in _vision_models
+            )
+            CLAWBOX_VISION_MODEL_ID = (
+                CLAWBOX_VISION_PREFERRED_ID if _vision_has_preferred else CLAWBOX_VISION_LEGACY_ID
+            )
+    CLAWBOX_VISION_MODEL_REF = "deepseek/" + CLAWBOX_VISION_MODEL_ID
+    _vision_our_ids = {CLAWBOX_VISION_PREFERRED_ID, CLAWBOX_VISION_LEGACY_ID, CLAWBOX_VISION_OVERRIDE_ID} - {""}
+
     _vision_entry = next(
         (m for m in _vision_models if isinstance(m, dict) and m.get("id") == CLAWBOX_VISION_MODEL_ID),
         None,
     )
+    if _vision_entry is None:
+        # A box carrying the OTHER of our ids is mid-migration: retarget that
+        # entry in place instead of stacking a second vision model beside it.
+        _vision_entry = next(
+            (m for m in _vision_models if isinstance(m, dict) and m.get("id") in _vision_our_ids),
+            None,
+        )
+        if _vision_entry is not None:
+            _vision_entry["id"] = CLAWBOX_VISION_MODEL_ID
+            changed = True
     if _vision_entry is None:
         _vision_models.append({
             "id": CLAWBOX_VISION_MODEL_ID,
@@ -566,7 +638,20 @@ if isinstance(_vision_models, list) and isinstance(_vision_token, str) and _visi
             and any(isinstance(ref, str) and ref.strip() for ref in _vision_fallbacks)
         )
     )
+    _vision_primary = (
+        _vision_model_cfg.get("primary") if isinstance(_vision_model_cfg, dict) else None
+    )
+    _vision_primary = _vision_primary.strip() if isinstance(_vision_primary, str) else ""
     if not _has_vision_model:
+        agents_defaults["imageModel"] = {"primary": CLAWBOX_VISION_MODEL_REF}
+        changed = True
+    elif (
+        _vision_primary in {"deepseek/" + i for i in _vision_our_ids}
+        and _vision_primary != CLAWBOX_VISION_MODEL_REF
+    ):
+        # The slot names one of OUR vision ids — the previous default is ours
+        # to move to the resolved one, both directions. Anything else in the
+        # slot is the owner's choice and stays.
         agents_defaults["imageModel"] = {"primary": CLAWBOX_VISION_MODEL_REF}
         changed = True
 

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -774,10 +774,21 @@ async function configureClawboxAi(
   }
 
   // Which vision id may this box name? The DeepSeek model when the proxy
-  // serves it, the previous one until then — asked live, never assumed.
+  // serves it, the previous one until then — asked live, never assumed. When
+  // the QUESTION failed (timeout, 5xx — not a refusal), keep whichever of
+  // OUR ids the box already runs: a bad network moment must not downgrade a
+  // box the proxy already upgraded.
   const vision = await resolveVisionModelId({ token: clawboxAiToken });
-  const visionRef = clawboxAiVisionModelRef(vision.id);
-  console.log(`[AI Config] Vision model resolved to ${vision.id} (${vision.reason})`);
+  const currentImageModel = snapshot?.agents?.defaults?.imageModel as { primary?: unknown; fallbacks?: unknown } | undefined;
+  const currentPrimary = typeof currentImageModel?.primary === "string" ? currentImageModel.primary.trim() : "";
+  const currentBareId = currentPrimary.startsWith(`${CLAWBOX_AI_PROVIDER}/`)
+    ? currentPrimary.slice(CLAWBOX_AI_PROVIDER.length + 1)
+    : currentPrimary;
+  const visionId = vision.reason === "probe-failed" && currentPrimary && isClawboxAiVisionId(currentPrimary)
+    ? currentBareId
+    : vision.id;
+  const visionRef = clawboxAiVisionModelRef(visionId);
+  console.log(`[AI Config] Vision model resolved to ${visionId} (${vision.reason})`);
 
   const requiredOps: OpenclawConfigSetArgs[] = [
     [
@@ -787,7 +798,7 @@ async function configureClawboxAi(
     ],
     [
       `models.providers.${CLAWBOX_AI_PROVIDER}`,
-      buildClawboxAiProviderDefinition(clawboxAiToken, vision.id),
+      buildClawboxAiProviderDefinition(clawboxAiToken, visionId),
       "--json",
     ],
     ...(extra?.requiredOps ?? []),
@@ -808,23 +819,22 @@ async function configureClawboxAi(
   // for some other provider, and a slot the owner filled is their choice.
   // Non-fatal for the same reason too.
   const visionOps: OpenclawConfigSetArgs[] = [];
-  const imageModelCfg = snapshot?.agents?.defaults?.imageModel as { primary?: unknown } | undefined;
-  const imageModelPrimary = typeof imageModelCfg?.primary === "string" ? imageModelCfg.primary.trim() : "";
   if (!hasToolModelConfig(snapshot?.agents?.defaults?.imageModel)) {
     visionOps.push([
       "agents.defaults.imageModel",
       JSON.stringify({ primary: visionRef }),
       "--json",
     ]);
-  } else if (imageModelPrimary && isClawboxAiVisionId(imageModelPrimary) && imageModelPrimary !== visionRef) {
+  } else if (currentPrimary && isClawboxAiVisionId(currentPrimary) && currentPrimary !== visionRef) {
     // The slot names one of OUR vision ids — the previous default is ours to
     // move to the resolved one (both directions: the DeepSeek upgrade when
     // the proxy starts serving it, and the fall-back if it stops). A value
-    // the owner set themselves never matches and is never touched.
-    console.log(`[AI Config] Moving agents.defaults.imageModel ${imageModelPrimary} -> ${visionRef}`);
+    // the owner set themselves never matches and is never touched — and the
+    // move changes ONLY `primary`: fallbacks the owner added ride along.
+    console.log(`[AI Config] Moving agents.defaults.imageModel ${currentPrimary} -> ${visionRef}`);
     visionOps.push([
       "agents.defaults.imageModel",
-      JSON.stringify({ primary: visionRef }),
+      JSON.stringify({ ...(currentImageModel as object), primary: visionRef }),
       "--json",
     ]);
   } else {

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -25,6 +25,7 @@ import {
 import { getActiveHarness } from "@/lib/harness";
 import { applyLocalAiToHermes, HermesLocalApplyError } from "@/lib/hermes-local-ai";
 import { applyClawaiToHermes, ClawaiApplyError } from "@/lib/hermes-clawai";
+import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 import { applyCloudProviderKeyToHermes, HermesCloudApplyError } from "@/lib/hermes-cloud-provider";
 import {
   getDefaultLlamaCppModel,
@@ -47,8 +48,8 @@ import {
   CLAWBOX_AI_IMAGE_MODEL,
   CLAWBOX_AI_IMAGE_MODEL_ID,
   CLAWBOX_AI_IMAGE_MODEL_LABEL,
-  CLAWBOX_AI_VISION_MODEL,
   CLAWBOX_AI_VISION_MODEL_ID,
+  clawboxAiVisionModelRef,
   CLAWBOX_AI_VISION_MODEL_LABEL,
   CLAWBOX_AI_VISION_INPUT_MODALITIES,
   CLAWBOX_AI_VISION_MAX_TOKENS,
@@ -349,7 +350,7 @@ const CLAWBOX_AI_MAX_TOKENS = 393_216;
 // never offers image attachments the proxy would reject.
 const CLAWBOX_AI_INPUT_MODALITIES = ["text"] as const;
 
-function buildClawboxAiProviderDefinition(apiKey: string) {
+function buildClawboxAiProviderDefinition(apiKey: string, visionModelId: string = CLAWBOX_AI_VISION_MODEL_ID) {
   // Emit the proxy URL, our auth, per-tier identity/branding/reasoning, and
   // the context/output/modality limits above.
   // `cost` stays zero to mark these as included-in-subscription so the
@@ -411,7 +412,7 @@ function buildClawboxAiProviderDefinition(apiKey: string) {
       // No `reasoning`/`compat`: the media-understanding path issues a
       // one-shot describe and never negotiates a thinking level.
       {
-        id: CLAWBOX_AI_VISION_MODEL_ID,
+        id: visionModelId,
         name: CLAWBOX_AI_VISION_MODEL_LABEL,
         input: [...CLAWBOX_AI_VISION_INPUT_MODALITIES],
         maxTokens: CLAWBOX_AI_VISION_MAX_TOKENS,
@@ -772,6 +773,12 @@ async function configureClawboxAi(
     snapshot = null;
   }
 
+  // Which vision id may this box name? The DeepSeek model when the proxy
+  // serves it, the previous one until then — asked live, never assumed.
+  const vision = await resolveVisionModelId({ token: clawboxAiToken });
+  const visionRef = clawboxAiVisionModelRef(vision.id);
+  console.log(`[AI Config] Vision model resolved to ${vision.id} (${vision.reason})`);
+
   const requiredOps: OpenclawConfigSetArgs[] = [
     [
       `auth.profiles.${CLAWBOX_AI_PROFILE_KEY}`,
@@ -780,7 +787,7 @@ async function configureClawboxAi(
     ],
     [
       `models.providers.${CLAWBOX_AI_PROVIDER}`,
-      buildClawboxAiProviderDefinition(clawboxAiToken),
+      buildClawboxAiProviderDefinition(clawboxAiToken, vision.id),
       "--json",
     ],
     ...(extra?.requiredOps ?? []),
@@ -801,16 +808,29 @@ async function configureClawboxAi(
   // for some other provider, and a slot the owner filled is their choice.
   // Non-fatal for the same reason too.
   const visionOps: OpenclawConfigSetArgs[] = [];
-  if (hasToolModelConfig(snapshot?.agents?.defaults?.imageModel)) {
+  const imageModelCfg = snapshot?.agents?.defaults?.imageModel as { primary?: unknown } | undefined;
+  const imageModelPrimary = typeof imageModelCfg?.primary === "string" ? imageModelCfg.primary.trim() : "";
+  if (!hasToolModelConfig(snapshot?.agents?.defaults?.imageModel)) {
+    visionOps.push([
+      "agents.defaults.imageModel",
+      JSON.stringify({ primary: visionRef }),
+      "--json",
+    ]);
+  } else if (imageModelPrimary && isClawboxAiVisionId(imageModelPrimary) && imageModelPrimary !== visionRef) {
+    // The slot names one of OUR vision ids — the previous default is ours to
+    // move to the resolved one (both directions: the DeepSeek upgrade when
+    // the proxy starts serving it, and the fall-back if it stops). A value
+    // the owner set themselves never matches and is never touched.
+    console.log(`[AI Config] Moving agents.defaults.imageModel ${imageModelPrimary} -> ${visionRef}`);
+    visionOps.push([
+      "agents.defaults.imageModel",
+      JSON.stringify({ primary: visionRef }),
+      "--json",
+    ]);
+  } else {
     console.log(
       "[AI Config] Left agents.defaults.imageModel alone: it already names a vision model",
     );
-  } else {
-    visionOps.push([
-      "agents.defaults.imageModel",
-      JSON.stringify({ primary: CLAWBOX_AI_VISION_MODEL }),
-      "--json",
-    ]);
   }
 
   // Images ride on the same token and the same proxy, so they are provisioned
@@ -834,7 +854,7 @@ async function configureClawboxAi(
       ops: visionOps,
       onApplied: () =>
         console.log(
-          `[AI Config] Set ClawBox AI vision model ${CLAWBOX_AI_VISION_MODEL} via proxy ${CLAWBOX_AI_PROXY_URL}`,
+          `[AI Config] Set ClawBox AI vision model ${visionRef} via proxy ${CLAWBOX_AI_PROXY_URL}`,
         ),
       onError: (err) =>
         console.warn(

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -146,15 +146,37 @@ export const CLAWBOX_AI_IMAGE_MODEL_LABEL = "ClawBox AI Images";
  * Env-overridable for the same reason the chat and image slugs are — the proxy
  * matches the BARE id against its allowlist, so this value must always name
  * something production already allows.
+ *
+ * Since 2026-08-27 the PREFERRED id is DeepSeek's own multimodal model,
+ * `deepseek-v4-flash-vision-exp` — vision from the same family the chat
+ * tiers run on. The proxy's allowlist may trail its release, so nothing
+ * writes this id unverified: every writer resolves through
+ * `resolveVisionModelId()` (src/lib/clawbox-ai-vision.ts), which asks the
+ * proxy and falls back to the previous vision model until the new one is
+ * served. An env override skips the probe — the operator's word is final.
  */
 export const CLAWBOX_AI_VISION_MODEL_ID =
-  process.env.CLAWBOX_AI_VISION_MODEL_ID?.trim() || "gpt-5.6-luna";
+  process.env.CLAWBOX_AI_VISION_MODEL_ID?.trim() || "deepseek-v4-flash-vision-exp";
+
+/**
+ * The vision model boxes ran before the DeepSeek one, and the fallback while
+ * the proxy does not yet allow the new id. Boxes in the field name this in
+ * `agents.defaults.imageModel` / `auxiliary.vision.model`; the writers treat
+ * a slot naming either OUR id as ours to move, and any other value as the
+ * owner's choice.
+ */
+export const CLAWBOX_AI_LEGACY_VISION_MODEL_ID = "gpt-5.6-luna";
 
 /** `name` on the model entry. Required by OpenClaw's schema — see the image label. */
 export const CLAWBOX_AI_VISION_MODEL_LABEL = "ClawBox AI Vision";
 
-/** Fully-qualified ref written to `agents.defaults.imageModel.primary`. */
-export const CLAWBOX_AI_VISION_MODEL = `${CLAWBOX_AI_PROVIDER}/${CLAWBOX_AI_VISION_MODEL_ID}`;
+/** Fully-qualified ref for a vision id, as `agents.defaults.imageModel.primary` wants it. */
+export function clawboxAiVisionModelRef(id: string): string {
+  return `${CLAWBOX_AI_PROVIDER}/${id}`;
+}
+
+/** Fully-qualified ref of the PREFERRED id — resolve before writing it anywhere. */
+export const CLAWBOX_AI_VISION_MODEL = clawboxAiVisionModelRef(CLAWBOX_AI_VISION_MODEL_ID);
 
 /**
  * Input modalities. `image` is the whole point of the entry: OpenClaw's

--- a/src/lib/clawbox-ai-vision.ts
+++ b/src/lib/clawbox-ai-vision.ts
@@ -1,0 +1,81 @@
+/**
+ * Which vision model may this box actually name?
+ *
+ * The preferred id is DeepSeek's multimodal model
+ * (`CLAWBOX_AI_VISION_MODEL_ID`, default deepseek-v4-flash-vision-exp), but
+ * the ClawBox AI proxy allowlists BARE model ids and answers
+ * 400 `model_not_allowed` for anything it does not serve yet — and a config
+ * that names a model the proxy refuses turns every attached picture into an
+ * HTTP 400. So nothing writes the preferred id on faith: this probe asks the
+ * proxy first and falls back to the vision model boxes already run
+ * (`CLAWBOX_AI_LEGACY_VISION_MODEL_ID`) until the new one is served. Boots
+ * and re-links re-resolve, so a box upgrades itself the first time the proxy
+ * says yes — and heals back the same way if the id ever stops being served.
+ *
+ * The probe is one text-only completion capped at a single token — the
+ * cheapest question the OpenAI surface can be asked. `model_not_allowed` is
+ * the only answer that means "not served": auth failures, timeouts and 5xx
+ * mean the QUESTION failed, and on an unanswered question the resolver stays
+ * conservative (legacy, unverified) rather than flip-flopping the config on
+ * a bad network moment.
+ *
+ * An env override (`CLAWBOX_AI_VISION_MODEL_ID`) skips the probe entirely:
+ * the operator's word is final, exactly as it is for the chat and image slugs.
+ */
+import {
+  CLAWBOX_AI_LEGACY_VISION_MODEL_ID,
+  CLAWBOX_AI_VISION_MODEL_ID,
+} from "@/lib/clawbox-ai-models";
+
+const DEFAULT_PROXY_URL = "https://clawbox.com/api/ai";
+const PROBE_TIMEOUT_MS = 6_000;
+
+export interface ResolvedVisionModel {
+  id: string;
+  /** True when the proxy itself answered the question this run. */
+  verified: boolean;
+  reason: "env-override" | "proxy-allows" | "proxy-refuses" | "probe-failed";
+}
+
+function proxyUrl(): string {
+  return (process.env.CLAWBOX_AI_PROXY_URL?.trim() || DEFAULT_PROXY_URL).replace(/\/+$/, "");
+}
+
+/** Resolve the vision model id this box may write into harness config. */
+export async function resolveVisionModelId(
+  { token, fetchImpl = fetch }: { token: string; fetchImpl?: typeof fetch },
+): Promise<ResolvedVisionModel> {
+  const preferred = CLAWBOX_AI_VISION_MODEL_ID;
+  if (process.env.CLAWBOX_AI_VISION_MODEL_ID?.trim()) {
+    return { id: preferred, verified: false, reason: "env-override" };
+  }
+  try {
+    const res = await fetchImpl(`${proxyUrl()}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        model: preferred,
+        max_tokens: 1,
+        messages: [{ role: "user", content: "ok" }],
+      }),
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    if (res.ok) return { id: preferred, verified: true, reason: "proxy-allows" };
+    const body = await res.text();
+    if (res.status === 400 && /model[_ ]not[_ ]allowed|model not allowed/i.test(body)) {
+      return { id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, verified: true, reason: "proxy-refuses" };
+    }
+    return { id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, verified: false, reason: "probe-failed" };
+  } catch {
+    return { id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, verified: false, reason: "probe-failed" };
+  }
+}
+
+/** Is `ref`/`id` one of OUR vision ids — ours to move — rather than an owner's choice? */
+export function isClawboxAiVisionId(value: string): boolean {
+  const bare = value.replace(/^[a-z0-9-]+\//i, "").trim();
+  return bare === CLAWBOX_AI_VISION_MODEL_ID || bare === CLAWBOX_AI_LEGACY_VISION_MODEL_ID;
+}

--- a/src/lib/clawbox-ai-vision.ts
+++ b/src/lib/clawbox-ai-vision.ts
@@ -24,6 +24,7 @@
  */
 import {
   CLAWBOX_AI_LEGACY_VISION_MODEL_ID,
+  CLAWBOX_AI_PROVIDER,
   CLAWBOX_AI_VISION_MODEL_ID,
 } from "@/lib/clawbox-ai-models";
 
@@ -74,8 +75,18 @@ export async function resolveVisionModelId(
   }
 }
 
-/** Is `ref`/`id` one of OUR vision ids — ours to move — rather than an owner's choice? */
+/**
+ * Is `ref`/`id` one of OUR vision ids — ours to move — rather than an owner's
+ * choice? Bare ids match, and qualified refs only under OUR provider: an
+ * owner routing `openai/gpt-5.6-luna` through their own account is their
+ * configuration, not our migration target.
+ */
 export function isClawboxAiVisionId(value: string): boolean {
-  const bare = value.replace(/^[a-z0-9-]+\//i, "").trim();
+  const trimmed = value.trim();
+  const bare = trimmed.startsWith(`${CLAWBOX_AI_PROVIDER}/`)
+    ? trimmed.slice(CLAWBOX_AI_PROVIDER.length + 1)
+    : trimmed;
+  if (bare !== trimmed && bare.includes("/")) return false;
+  if (trimmed.includes("/") && !trimmed.startsWith(`${CLAWBOX_AI_PROVIDER}/`)) return false;
   return bare === CLAWBOX_AI_VISION_MODEL_ID || bare === CLAWBOX_AI_LEGACY_VISION_MODEL_ID;
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -17,6 +17,7 @@ import {
   CLAWBOX_AI_VISION_MODEL_ID,
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
+import { resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 
 // Applying ClawBox AI to a HERMES device, in one place.
 //
@@ -76,6 +77,10 @@ export async function applyClawaiToHermes(
   // chat asks it on every open — this costs nothing.
   const couldDrawBefore = await hermesAgentDrawsImages();
 
+  const vision = await resolveVisionModelId({ token: trimmed });
+  const visionModelId = vision.id;
+  console.log(`[Hermes ClawAI] Vision model resolved to ${visionModelId} (${vision.reason})`);
+
   const steps: string[][] = [
     ["config", "set", `providers.${CLAWAI_PROVIDER}.base_url`, CLAWBOX_AI_PROXY_URL],
     ["config", "set", `providers.${CLAWAI_PROVIDER}.api_key`, trimmed],
@@ -113,7 +118,9 @@ export async function applyClawaiToHermes(
     // the OpenClaw side — one capability, two harnesses, no second provider to
     // credential.
     ["config", "set", "auxiliary.vision.provider", CLAWAI_PROVIDER],
-    ["config", "set", "auxiliary.vision.model", CLAWBOX_AI_VISION_MODEL_ID],
+    // Resolved, not assumed: the DeepSeek vision model when the proxy serves
+    // it, the previous one until then. See src/lib/clawbox-ai-vision.ts.
+    ["config", "set", "auxiliary.vision.model", visionModelId],
     // ── Naming the session titler, for the same reason ──────────────────────
     //
     // `auxiliary.title_generation` ships as `provider: auto`, and auto is not a

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -17,7 +17,7 @@ import {
   CLAWBOX_AI_VISION_MODEL_ID,
   type ClawboxAiTier,
 } from "@/lib/clawbox-ai-models";
-import { resolveVisionModelId } from "@/lib/clawbox-ai-vision";
+import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
 
 // Applying ClawBox AI to a HERMES device, in one place.
 //
@@ -78,7 +78,15 @@ export async function applyClawaiToHermes(
   const couldDrawBefore = await hermesAgentDrawsImages();
 
   const vision = await resolveVisionModelId({ token: trimmed });
-  const visionModelId = vision.id;
+  let visionModelId = vision.id;
+  if (vision.reason === "probe-failed") {
+    // The QUESTION failed — not a refusal. If the box already runs one of
+    // OUR vision ids, keep it: a bad network moment must not downgrade a
+    // box the proxy already upgraded.
+    const current = await runHermesCli(["config", "get", "auxiliary.vision.model"], { timeoutMs: 15_000 });
+    const currentId = current.code === 0 ? (current.stdout ?? "").trim() : "";
+    if (currentId && isClawboxAiVisionId(currentId)) visionModelId = currentId;
+  }
   console.log(`[Hermes ClawAI] Vision model resolved to ${visionModelId} (${vision.reason})`);
 
   const steps: string[][] = [

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -78,16 +78,23 @@ export async function applyClawaiToHermes(
   const couldDrawBefore = await hermesAgentDrawsImages();
 
   const vision = await resolveVisionModelId({ token: trimmed });
-  let visionModelId = vision.id;
+  let visionModelId: string | null = vision.id;
   if (vision.reason === "probe-failed") {
     // The QUESTION failed — not a refusal. If the box already runs one of
     // OUR vision ids, keep it: a bad network moment must not downgrade a
-    // box the proxy already upgraded.
+    // box the proxy already upgraded. And when the current value cannot even
+    // be READ (as opposed to being unset), write nothing at all — an
+    // unreadable config is not an empty one.
     const current = await runHermesCli(["config", "get", "auxiliary.vision.model"], { timeoutMs: 15_000 });
-    const currentId = current.code === 0 ? (current.stdout ?? "").trim() : "";
-    if (currentId && isClawboxAiVisionId(currentId)) visionModelId = currentId;
+    const listing = `${current.stdout ?? ""}\n${current.stderr ?? ""}`;
+    if (current.code === 0) {
+      const currentId = (current.stdout ?? "").trim();
+      if (currentId && isClawboxAiVisionId(currentId)) visionModelId = currentId;
+    } else if (!/config key not set/i.test(listing)) {
+      visionModelId = null;
+    }
   }
-  console.log(`[Hermes ClawAI] Vision model resolved to ${visionModelId} (${vision.reason})`);
+  console.log(`[Hermes ClawAI] Vision model ${visionModelId === null ? "left untouched (probe and read both failed)" : `resolved to ${visionModelId} (${vision.reason})`}`);
 
   const steps: string[][] = [
     ["config", "set", `providers.${CLAWAI_PROVIDER}.base_url`, CLAWBOX_AI_PROXY_URL],
@@ -125,10 +132,13 @@ export async function applyClawaiToHermes(
     // This is the Hermes spelling of what `agents.defaults.imageModel` does on
     // the OpenClaw side — one capability, two harnesses, no second provider to
     // credential.
-    ["config", "set", "auxiliary.vision.provider", CLAWAI_PROVIDER],
     // Resolved, not assumed: the DeepSeek vision model when the proxy serves
-    // it, the previous one until then. See src/lib/clawbox-ai-vision.ts.
-    ["config", "set", "auxiliary.vision.model", visionModelId],
+    // it, the previous one until then (src/lib/clawbox-ai-vision.ts) — and
+    // written not at all when neither the proxy nor the config would answer.
+    ...(visionModelId === null ? [] : [
+      ["config", "set", "auxiliary.vision.provider", CLAWAI_PROVIDER],
+      ["config", "set", "auxiliary.vision.model", visionModelId],
+    ]),
     // ── Naming the session titler, for the same reason ──────────────────────
     //
     // `auxiliary.title_generation` ships as `provider: auto`, and auto is not a

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -4,6 +4,7 @@ import fsp from "fs/promises";
 import type { ChildProcess } from "child_process";
 import { EventEmitter } from "events";
 import {
+  CLAWBOX_AI_LEGACY_VISION_MODEL_ID,
   CLAWBOX_AI_VISION_MODEL,
   CLAWBOX_AI_VISION_MODEL_ID,
   CLAWBOX_AI_VISION_MODEL_LABEL,
@@ -54,6 +55,16 @@ vi.mock("@/lib/clawkeep", () => ({
 // note in configure.test.ts.
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   refreshInBackground: vi.fn(),
+}));
+
+// The vision id is RESOLVED against the proxy before the route writes it:
+// DeepSeek's model when served, the previous one until then. The resolver has
+// its own unit file; here it answers "preferred allowed" unless a test says
+// otherwise, so no route test touches the network.
+const resolveVisionMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: resolveVisionMock,
 }));
 
 const { parseFullyQualifiedModelImpl, LLAMACPP_PROXY_BASE_URL } = vi.hoisted(() => ({
@@ -188,6 +199,7 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () =
     vi.resetModules();
     vi.clearAllMocks();
 
+    resolveVisionMock.mockResolvedValue({ id: CLAWBOX_AI_VISION_MODEL_ID, verified: true, reason: "proxy-allows" });
     mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
     mockFs.writeFile.mockResolvedValue();
     mockFs.rename.mockResolvedValue();

--- a/src/tests/unit/clawbox-ai-vision.test.ts
+++ b/src/tests/unit/clawbox-ai-vision.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CLAWBOX_AI_LEGACY_VISION_MODEL_ID,
+  CLAWBOX_AI_VISION_MODEL_ID,
+} from "@/lib/clawbox-ai-models";
+import { isClawboxAiVisionId, resolveVisionModelId } from "@/lib/clawbox-ai-vision";
+
+// Which vision model may this box name? The DeepSeek id is PREFERRED, but the
+// proxy allowlists bare ids and a config naming a refused model turns every
+// attached picture into an HTTP 400 — so every writer resolves through this
+// probe. These tests pin the three verdicts and the conservative default.
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("resolveVisionModelId", () => {
+  it("prefers the DeepSeek model when the proxy serves it", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(200, { choices: [] }));
+    const resolved = await resolveVisionModelId({ token: "claw_t", fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(resolved).toEqual({ id: CLAWBOX_AI_VISION_MODEL_ID, verified: true, reason: "proxy-allows" });
+    // The probe is the cheapest question the OpenAI surface can be asked.
+    const body = JSON.parse((fetchImpl.mock.calls[0] as unknown as [string, RequestInit])[1].body as string);
+    expect(body.model).toBe(CLAWBOX_AI_VISION_MODEL_ID);
+    expect(body.max_tokens).toBe(1);
+  });
+
+  it("falls back to the previous vision model on model_not_allowed", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(400, {
+      error: { code: "model_not_allowed", message: `Model not allowed: ${CLAWBOX_AI_VISION_MODEL_ID}`, type: "invalid_request_error" },
+    }));
+    const resolved = await resolveVisionModelId({ token: "claw_t", fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(resolved).toEqual({ id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, verified: true, reason: "proxy-refuses" });
+  });
+
+  it("stays conservative when the question itself fails", async () => {
+    // Auth failures, 5xx and dead networks mean the QUESTION failed — the
+    // resolver must not flap a working config on a bad moment.
+    for (const impl of [
+      vi.fn(async () => jsonResponse(503, { error: "down" })),
+      vi.fn(async () => { throw new Error("network down"); }),
+    ]) {
+      const resolved = await resolveVisionModelId({ token: "claw_t", fetchImpl: impl as unknown as typeof fetch });
+      expect(resolved.id).toBe(CLAWBOX_AI_LEGACY_VISION_MODEL_ID);
+      expect(resolved.verified).toBe(false);
+      expect(resolved.reason).toBe("probe-failed");
+    }
+  });
+
+  it("takes the operator's env override without asking anyone", async () => {
+    vi.stubEnv("CLAWBOX_AI_VISION_MODEL_ID", "vision-staging-1");
+    const fetchImpl = vi.fn();
+    const resolved = await resolveVisionModelId({ token: "claw_t", fetchImpl: fetchImpl as unknown as typeof fetch });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(resolved.reason).toBe("env-override");
+    // The id itself is baked into the constant at module load; what this test
+    // pins is that an override means NO probe and no legacy fallback.
+    expect(resolved.verified).toBe(false);
+  });
+});
+
+describe("isClawboxAiVisionId", () => {
+  it("recognises OUR ids, bare or provider-prefixed, and nothing else", () => {
+    expect(isClawboxAiVisionId(CLAWBOX_AI_VISION_MODEL_ID)).toBe(true);
+    expect(isClawboxAiVisionId(`deepseek/${CLAWBOX_AI_VISION_MODEL_ID}`)).toBe(true);
+    expect(isClawboxAiVisionId(CLAWBOX_AI_LEGACY_VISION_MODEL_ID)).toBe(true);
+    expect(isClawboxAiVisionId(`deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}`)).toBe(true);
+    expect(isClawboxAiVisionId("google/gemini-2.5-flash")).toBe(false);
+    expect(isClawboxAiVisionId("")).toBe(false);
+  });
+});

--- a/src/tests/unit/clawbox-ai-vision.test.ts
+++ b/src/tests/unit/clawbox-ai-vision.test.ts
@@ -70,6 +70,10 @@ describe("isClawboxAiVisionId", () => {
     expect(isClawboxAiVisionId(CLAWBOX_AI_LEGACY_VISION_MODEL_ID)).toBe(true);
     expect(isClawboxAiVisionId(`deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}`)).toBe(true);
     expect(isClawboxAiVisionId("google/gemini-2.5-flash")).toBe(false);
+    // An owner routing one of the same model NAMES through their own account
+    // is their configuration, not our migration target.
+    expect(isClawboxAiVisionId(`openai/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}`)).toBe(false);
+    expect(isClawboxAiVisionId(`openai/${CLAWBOX_AI_VISION_MODEL_ID}`)).toBe(false);
     expect(isClawboxAiVisionId("")).toBe(false);
   });
 });

--- a/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 const {
   CLAWBOX_AI_VISION_MODEL,
   CLAWBOX_AI_VISION_MODEL_ID,
+  CLAWBOX_AI_LEGACY_VISION_MODEL_ID,
   CLAWBOX_AI_VISION_MODEL_LABEL,
   CLAWBOX_AI_VISION_MAX_TOKENS,
 } = await (async () => {
@@ -80,7 +81,9 @@ function migrate(cfg: Config, env: Record<string, string> = {}): { cfg: Config; 
   ].join("\n");
   const out = execFileSync("python3", ["-c", program, file], {
     encoding: "utf-8",
-    env: { ...process.env, ...env },
+    // The probe is forced so no test touches the network, and a developer's
+    // own CLAWBOX_AI_VISION_MODEL_ID cannot leak into the block under test.
+    env: { ...process.env, CLAWBOX_AI_VISION_MODEL_ID: "", CLAWBOX_VISION_PROBE: "allowed", ...env },
   }).trim().split("\n");
   return JSON.parse(out[out.length - 1]);
 }
@@ -236,13 +239,71 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI vision migration",
     expect(imageModel(cfg)).toEqual({ primary: "deepseek/vision-staging-1" });
   });
 
-  it("keeps the model id, label and ceiling in step with the TS constants", () => {
+  it("keeps the model ids, label and ceiling in step with the TS constants", () => {
     // The .sh hardcodes them because a shell migration cannot import a TS
     // constant. The proxy matches the BARE id against its allowlist, so a drift
     // here silently breaks every vision request.
-    expect(POLICY).toContain(`or "${CLAWBOX_AI_VISION_MODEL_ID}"`);
+    expect(POLICY).toContain(`CLAWBOX_VISION_PREFERRED_ID = "${CLAWBOX_AI_VISION_MODEL_ID}"`);
+    expect(POLICY).toContain(`CLAWBOX_VISION_LEGACY_ID = "${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}"`);
     expect(POLICY).toContain(`CLAWBOX_VISION_MODEL_NAME = "${CLAWBOX_AI_VISION_MODEL_LABEL}"`);
     expect(POLICY).toContain(`CLAWBOX_VISION_MAX_TOKENS = ${CLAWBOX_AI_VISION_MAX_TOKENS}`);
     expect(CLAWBOX_AI_VISION_MODEL).toBe(`deepseek/${CLAWBOX_AI_VISION_MODEL_ID}`);
+  });
+
+  // ── The DeepSeek switch: resolved against the proxy, never assumed ──────
+
+  it("stays on the previous vision model while the proxy refuses the new id", () => {
+    const { cfg, changed } = migrate(pairedBox(), { CLAWBOX_VISION_PROBE: "not-allowed" });
+    expect(changed).toBe(true);
+    expect(dsModels(cfg).some((m) => m.id === CLAWBOX_AI_LEGACY_VISION_MODEL_ID)).toBe(true);
+    expect(dsModels(cfg).some((m) => m.id === CLAWBOX_AI_VISION_MODEL_ID)).toBe(false);
+    expect(imageModel(cfg)).toEqual({ primary: `deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}` });
+  });
+
+  it("retargets a field box's legacy entry and slot the first boot the proxy says yes", () => {
+    const fieldBox = pairedBox({
+      models: [
+        { id: "deepseek-v4-flash", name: "ClawBox AI Flash", input: ["text"] },
+        { id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text", "image"], maxTokens: 128000 },
+      ],
+      defaults: { imageModel: { primary: `deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}` } },
+    });
+    const { cfg, changed } = migrate(fieldBox);
+    expect(changed).toBe(true);
+    // Retargeted in place — one vision entry, not two stacked.
+    expect(dsModels(cfg).filter((m) => m.id === CLAWBOX_AI_VISION_MODEL_ID)).toHaveLength(1);
+    expect(dsModels(cfg).some((m) => m.id === CLAWBOX_AI_LEGACY_VISION_MODEL_ID)).toBe(false);
+    expect(imageModel(cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
+  });
+
+  it("moves only OUR slot value — an owner's model is never retargeted", () => {
+    const { cfg } = migrate(pairedBox({
+      defaults: { imageModel: { primary: "google/gemini-2.5-flash" } },
+    }));
+    expect(imageModel(cfg)).toEqual({ primary: "google/gemini-2.5-flash" });
+  });
+
+  it("keeps whatever the box already names when the probe cannot answer", () => {
+    const legacyBox = pairedBox({
+      models: [
+        { id: "deepseek-v4-flash", name: "ClawBox AI Flash", input: ["text"] },
+        { id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text", "image"], maxTokens: 128000 },
+      ],
+      defaults: { imageModel: { primary: `deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}` } },
+    });
+    const { cfg, changed } = migrate(legacyBox, { CLAWBOX_VISION_PROBE: "unknown" });
+    // A bad network moment must not flap the config in either direction.
+    expect(changed).toBe(false);
+    expect(imageModel(cfg)).toEqual({ primary: `deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}` });
+
+    const upgradedBox = pairedBox({
+      models: [
+        { id: CLAWBOX_AI_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text", "image"], maxTokens: 128000 },
+      ],
+      defaults: { imageModel: { primary: CLAWBOX_AI_VISION_MODEL } },
+    });
+    const kept = migrate(upgradedBox, { CLAWBOX_VISION_PROBE: "unknown" });
+    expect(kept.changed).toBe(false);
+    expect(imageModel(kept.cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
   });
 });

--- a/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
+++ b/src/tests/unit/gateway-pre-start-clawai-vision.test.ts
@@ -276,6 +276,16 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh ClawBox AI vision migration",
     expect(imageModel(cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL });
   });
 
+  it("a managed move changes only primary — owner fallbacks ride along", () => {
+    const { cfg } = migrate(pairedBox({
+      models: [
+        { id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, name: CLAWBOX_AI_VISION_MODEL_LABEL, input: ["text", "image"], maxTokens: 128000 },
+      ],
+      defaults: { imageModel: { primary: `deepseek/${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}`, fallbacks: ["google/gemini-2.5-flash"] } },
+    }));
+    expect(imageModel(cfg)).toEqual({ primary: CLAWBOX_AI_VISION_MODEL, fallbacks: ["google/gemini-2.5-flash"] });
+  });
+
   it("moves only OUR slot value — an owner's model is never retargeted", () => {
     const { cfg } = migrate(pairedBox({
       defaults: { imageModel: { primary: "google/gemini-2.5-flash" } },

--- a/src/tests/unit/hermes-clawai-vision.test.ts
+++ b/src/tests/unit/hermes-clawai-vision.test.ts
@@ -30,6 +30,12 @@ vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
   installHermesImagePlugin: vi.fn(),
 }));
+// The vision id is RESOLVED against the proxy (DeepSeek's model when served,
+// the previous one until then). The resolver has its own unit file
+// (`clawbox-ai-vision.test.ts`); here it answers "preferred allowed" unless a
+// test says otherwise, so no unit test touches the network.
+const resolveVisionMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/clawbox-ai-vision", () => ({ resolveVisionModelId: resolveVisionMock }));
 
 import {
   CLAWAI_PROVIDER,
@@ -37,7 +43,7 @@ import {
   applyClawaiToHermes,
   clawaiModelForTier,
 } from "@/lib/hermes-clawai";
-import { CLAWBOX_AI_VISION_MODEL_ID } from "@/lib/clawbox-ai-models";
+import { CLAWBOX_AI_LEGACY_VISION_MODEL_ID, CLAWBOX_AI_VISION_MODEL_ID } from "@/lib/clawbox-ai-models";
 
 /** Every `config set`, as "key=value", in the order they were issued. */
 function sets(): string[] {
@@ -56,12 +62,21 @@ describe("pointing Hermes at ClawBox AI", () => {
   beforeEach(() => {
     cliMock.mockReset();
     cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    resolveVisionMock.mockReset();
+    resolveVisionMock.mockResolvedValue({ id: CLAWBOX_AI_VISION_MODEL_ID, verified: true, reason: "proxy-allows" });
   });
 
   it("names a model that can see, so an attached picture is looked at", async () => {
     await applyClawaiToHermes("claw_token_abc", "flash");
     expect(sets()).toContain(`auxiliary.vision.provider=${CLAWAI_PROVIDER}`);
     expect(sets()).toContain(`auxiliary.vision.model=${CLAWBOX_AI_VISION_MODEL_ID}`);
+  });
+
+  it("writes the previous vision model while the proxy refuses the DeepSeek id", async () => {
+    resolveVisionMock.mockResolvedValue({ id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, verified: true, reason: "proxy-refuses" });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    expect(sets()).toContain(`auxiliary.vision.model=${CLAWBOX_AI_LEGACY_VISION_MODEL_ID}`);
+    expect(sets()).not.toContain(`auxiliary.vision.model=${CLAWBOX_AI_VISION_MODEL_ID}`);
   });
 
   it("leaves the vision endpoint and key to be inherited from the provider block", async () => {

--- a/src/tests/unit/hermes-clawai-vision.test.ts
+++ b/src/tests/unit/hermes-clawai-vision.test.ts
@@ -35,7 +35,10 @@ vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
 // (`clawbox-ai-vision.test.ts`); here it answers "preferred allowed" unless a
 // test says otherwise, so no unit test touches the network.
 const resolveVisionMock = vi.hoisted(() => vi.fn());
-vi.mock("@/lib/clawbox-ai-vision", () => ({ resolveVisionModelId: resolveVisionMock }));
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: resolveVisionMock,
+}));
 
 import {
   CLAWAI_PROVIDER,
@@ -69,6 +72,17 @@ describe("pointing Hermes at ClawBox AI", () => {
   it("names a model that can see, so an attached picture is looked at", async () => {
     await applyClawaiToHermes("claw_token_abc", "flash");
     expect(sets()).toContain(`auxiliary.vision.provider=${CLAWAI_PROVIDER}`);
+    expect(sets()).toContain(`auxiliary.vision.model=${CLAWBOX_AI_VISION_MODEL_ID}`);
+  });
+
+  it("keeps an already-upgraded box on the DeepSeek id when the probe cannot answer", async () => {
+    resolveVisionMock.mockResolvedValue({ id: "gpt-5.6-luna", verified: false, reason: "probe-failed" });
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[1] === "get" && args[2] === "auxiliary.vision.model"
+        ? { code: 0, stdout: `${CLAWBOX_AI_VISION_MODEL_ID}\n`, stderr: "" }
+        : { code: 0, stdout: "", stderr: "" });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    // A bad network moment must not downgrade a box the proxy already upgraded.
     expect(sets()).toContain(`auxiliary.vision.model=${CLAWBOX_AI_VISION_MODEL_ID}`);
   });
 

--- a/src/tests/unit/hermes-clawai-vision.test.ts
+++ b/src/tests/unit/hermes-clawai-vision.test.ts
@@ -86,6 +86,28 @@ describe("pointing Hermes at ClawBox AI", () => {
     expect(sets()).toContain(`auxiliary.vision.model=${CLAWBOX_AI_VISION_MODEL_ID}`);
   });
 
+  it("writes no vision model at all when neither the proxy nor the config answers", async () => {
+    resolveVisionMock.mockResolvedValue({ id: "gpt-5.6-luna", verified: false, reason: "probe-failed" });
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[1] === "get" && args[2] === "auxiliary.vision.model"
+        ? { code: 1, stdout: "", stderr: "permission denied" }
+        : { code: 0, stdout: "", stderr: "" });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    // An unreadable config is not an empty one — nothing may be overwritten.
+    // (sets(), not keys(): the read probe itself legitimately touches the key.)
+    expect(sets().some((kv) => kv.startsWith("auxiliary.vision."))).toBe(false);
+  });
+
+  it("still treats an unset key as unset — the conservative default applies", async () => {
+    resolveVisionMock.mockResolvedValue({ id: "gpt-5.6-luna", verified: false, reason: "probe-failed" });
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[1] === "get" && args[2] === "auxiliary.vision.model"
+        ? { code: 1, stdout: "", stderr: "config key not set" }
+        : { code: 0, stdout: "", stderr: "" });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    expect(sets()).toContain("auxiliary.vision.model=gpt-5.6-luna");
+  });
+
   it("writes the previous vision model while the proxy refuses the DeepSeek id", async () => {
     resolveVisionMock.mockResolvedValue({ id: CLAWBOX_AI_LEGACY_VISION_MODEL_ID, verified: true, reason: "proxy-refuses" });
     await applyClawaiToHermes("claw_token_abc", "flash");


### PR DESCRIPTION
## What this does

Implements DeepSeek vision: **DeepSeek-V4-Flash-Vision-Exp** replaces `gpt-5.6-luna` as the preferred model behind every current vision method — there is exactly one vision path per edition, and both are config-driven:

- **OpenClaw**: the vision entry in `models.providers.deepseek.models[]` + `agents.defaults.imageModel` (the gateway's `image` tool)
- **Hermes**: `auxiliary.vision.{provider,model}` (upstream `vision_analyze`)

## Why a resolver instead of a constant swap

The proxy allowlists **bare** model ids and answers `400 model_not_allowed` for anything it doesn't serve — and it **does not serve the DeepSeek vision id yet** (measured live today; `gpt-5.6-luna` still answers). A config naming a refused model turns every attached picture into an HTTP 400.

So every writer resolves through one probe (`src/lib/clawbox-ai-vision.ts`, a single 1-token completion):

| proxy says | box writes |
|---|---|
| 200 | `deepseek-v4-flash-vision-exp` |
| `model_not_allowed` | `gpt-5.6-luna` (previous model) |
| anything else (auth/5xx/network) | whatever it already names — no flapping |

Writers: the configure route at linking, `gateway-pre-start.sh` at **every boot** (so field boxes self-upgrade the first boot after the proxy starts serving the id, and self-heal back if it stops), and `applyClawaiToHermes` at linking. A slot naming one of OUR two ids is ours to retarget in place, both directions; an owner's own model choice never matches and is never touched. `CLAWBOX_AI_VISION_MODEL_ID` env override skips the probe, as before.

**Verified against this box's real `openclaw.json` with a live probe**: verdict `not-allowed`, `changed: false` — zero churn until infra lands the allowlist entry on clawbox.com's proxy (the one dependency outside this repo).

## Tests
- New `src/tests/unit/clawbox-ai-vision.test.ts` (probe verdicts, conservatism, env override, ours-to-move id check)
- The three pinned vision suites reworked: pre-start harness forces the probe via `CLAWBOX_VISION_PROBE` (never touches the network) with new cases for refusal / in-place retarget / unknown-verdict stability; route + Hermes suites mock the resolver module
- Full suite: green except the two known on-box-only flakes (`clawai-images` assumes an unlinked box; `sudoers-coverage` 5.07s vs 5s timeout on Jetson) — both green in CI on #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrfM1RsZbwaGZ5SdSHL2UH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vision model setup now checks proxy compatibility and selects the preferred model when available.
  * Added fallback support for the legacy vision model when the preferred option is unavailable.
  * Environment overrides can force a supported vision model.

* **Bug Fixes**
  * Existing managed vision configurations migrate safely when the selected model changes.
  * Custom, user-selected vision models remain unchanged.
  * Setup retains the existing model when compatibility checks are inconclusive.
  * Prevented duplicate vision model entries during migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->