### PR TITLE
fix: give skill_uninstall's 404 and 409 the reason the route sent

### DIFF
--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -70,12 +70,51 @@ const INSTALL_RULES: ErrorRule[] = [
   },
 ];
 
-const UNINSTALL_RULES: ErrorRule[] = [
+// The two reasons a skill cannot be removed, worded once. skill_uninstall can
+// reach either conclusion twice over — from the installed list in its own
+// pre-condition, or from the route's 404/409 when that list could not be read —
+// and one device state must not produce two different sentences.
+const notInstalledMessage = (name: string) =>
+  `There is no installed skill called "${name}" on this device.`;
+const NOT_INSTALLED_NEXT =
+  "Call skill_list and pass the name field of a skill it actually lists. Do not retry this name.";
+const builtinMessage = (name: string) => `"${name}" came with the device, so it cannot be removed.`;
+const BUILTIN_NEXT =
+  "Only skills that skill_list marks \"from the store\" can be removed. "
+  + "Tell the user this one is built in. Do not retry.";
+
+/**
+ * Built per call so the refusals can name the skill, exactly as the
+ * pre-condition does.
+ *
+ * The 404 and 409 rules are matched on the route's `code` field and not on the
+ * status alone. The Hermes edition gate answers 404 from this same route with
+ * no code, and these tools are registered off an edition probe taken once at
+ * startup — so on a device that changed harness since then, "no such skill is
+ * installed" would be a confident answer to a question nobody asked. An
+ * unlabelled status falls through to the generic mapping, which is the honest
+ * outcome when we cannot tell which failure it was.
+ */
+const uninstallRules = (name: string): ErrorRule[] => [
   {
     status: 400,
     code: "BAD_ARGUMENT",
     message: "Uninstall takes the short skill name, not the full store id.",
     next: "Call skill_list and pass the name field of the skill you want removed.",
+  },
+  {
+    status: 404,
+    match: /"code"\s*:\s*"not_installed"/,
+    code: "NOT_FOUND",
+    message: notInstalledMessage(name),
+    next: NOT_INSTALLED_NEXT,
+  },
+  {
+    status: 409,
+    match: /"code"\s*:\s*"builtin_skill"/,
+    code: "CONFLICT",
+    message: builtinMessage(name),
+    next: BUILTIN_NEXT,
   },
   {
     status: 502,
@@ -559,25 +598,21 @@ export function registerSkillTools(reg: Registrar): void {
         // its identifier is what the post-condition needs.
         const entry = before.find((sk) => sk.name === name && isStoreSkill(sk)) ?? before.find((sk) => sk.name === name);
         if (!entry) {
-          throw new ToolError(
-            "NOT_FOUND",
-            `There is no installed skill called "${name}" on this device.`,
-            "Call skill_list and pass the name field of a skill it actually lists. Do not retry this name.",
-          );
+          throw new ToolError("NOT_FOUND", notInstalledMessage(name), NOT_INSTALLED_NEXT);
         }
         if (!isStoreSkill(entry)) {
-          throw new ToolError(
-            "CONFLICT",
-            `"${name}" came with the device, so it cannot be removed.`,
-            "Only skills that skill_list marks \"from the store\" can be removed. Tell the user this one is built in.",
-          );
+          throw new ToolError("CONFLICT", builtinMessage(name), BUILTIN_NEXT);
         }
         removing = entry;
       }
       // The route's field is `id`, but it means the lock NAME — the MCP
       // parameter is called `name` so the model cannot confuse it with the
       // store id that skill_install takes.
-      await apiPost("/setup-api/hermes/skills/uninstall", { id: name }, { timeoutMs: 60_000, rules: UNINSTALL_RULES });
+      await apiPost(
+        "/setup-api/hermes/skills/uninstall",
+        { id: name },
+        { timeoutMs: 60_000, rules: uninstallRules(name) },
+      );
       // POST-CONDITION. A STORE skill still there means the CLI refused it
       // quietly; a builtin of the same name resurfacing means it worked.
       const after = await installedSkills();

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -224,6 +224,98 @@ describe("skill_uninstall — a 200 is not proof anything was removed", () => {
     expect(out.isError).toBe(false);
     expect(apiPost).toHaveBeenCalled();
   });
+
+  /**
+   * MCP-02 — the pre-condition above is the ONLY thing that normally decodes
+   * "there is no such skill" and "that one is built in", and it is skipped
+   * whenever the installed list cannot be read (installedSkills() swallows any
+   * failure and returns null). In that window the route's own structured
+   * refusals are all the agent gets, and neither had a rule: the 404 became the
+   * generic resource-404 and the 409 became a generic CONFLICT whose next step
+   * was "ask them to finish the setup in Settings" — advice that cannot make a
+   * built-in skill removable.
+   */
+  describe("the route's own refusals, when the pre-condition could not run", () => {
+    /** The installed list is unreadable, so the route's answer is the whole story. */
+    const blindfolded = () => apiGet.mockRejectedValue(new ApiError(502, "{}"));
+    const routeSays = (status: number, body: Record<string, string>) =>
+      apiPost.mockRejectedValue(new ApiError(status, JSON.stringify(body)));
+
+    it("reports a built-in skill as built in, not as unfinished setup", async () => {
+      blindfolded();
+      routeSays(409, {
+        error: '"memo" came with this device, so it cannot be removed.',
+        code: "builtin_skill",
+      });
+
+      const out = await skills().call("skill_uninstall", { name: "memo" });
+      expect(out.isError).toBe(true);
+      if (!out.isError) return;
+      expect(out.error.code).toBe("CONFLICT");
+      expect(out.error.message).toMatch(/came with the device/i);
+      expect(out.error.next).toMatch(/built in/i);
+      expect(out.error.next).toMatch(/do not retry/i);
+      // The generic 409 sent the agent to Settings. There is nothing to finish
+      // there, and the skill will still be built in when it comes back.
+      expect(out.error.next).not.toMatch(/settings/i);
+    });
+
+    it("reports a name the device does not have as not installed", async () => {
+      blindfolded();
+      routeSays(404, {
+        error: 'No store skill called "ghost" is installed on this device.',
+        code: "not_installed",
+      });
+
+      const out = await skills().call("skill_uninstall", { name: "ghost" });
+      expect(out.isError).toBe(true);
+      if (!out.isError) return;
+      expect(out.error.code).toBe("NOT_FOUND");
+      expect(out.error.message).toMatch(/no installed skill called "ghost"/i);
+      expect(out.error.next).toMatch(/skill_list/);
+      expect(out.error.next).toMatch(/do not retry this name/i);
+      // The generic resource-404 offered tools that have nothing to do with skills.
+      expect(out.error.next).not.toMatch(/ui_list_apps|code_project_list/);
+    });
+
+    /**
+     * The edition gate answers 404 from the SAME route, with no `code`. The
+     * tool is registered off a probe taken once at startup, so a device that
+     * switched harness since then reaches this branch — and "no such skill is
+     * installed" would be a confident answer to a question nobody asked.
+     */
+    it("does not read the Hermes edition guard's 404 as a missing skill", async () => {
+      blindfolded();
+      routeSays(404, { error: "Not found" });
+
+      const out = await skills().call("skill_uninstall", { name: "pdf" });
+      expect(out.isError).toBe(true);
+      if (!out.isError) return;
+      expect(out.error.message).not.toMatch(/no installed skill called/i);
+    });
+
+    /**
+     * Anti-drift: the same device state has to produce the same sentence
+     * whichever path noticed it, or the agent gets two stories about one fact.
+     */
+    it("says the same thing as the pre-condition for the same device state", async () => {
+      installed([{ name: "memo", origin: "builtin" }]);
+      const viaPrecondition = await skills().call("skill_uninstall", { name: "memo" });
+
+      apiGet.mockReset();
+      blindfolded();
+      routeSays(409, {
+        error: '"memo" came with this device, so it cannot be removed.',
+        code: "builtin_skill",
+      });
+      const viaRoute = await skills().call("skill_uninstall", { name: "memo" });
+
+      expect(viaPrecondition.isError).toBe(true);
+      expect(viaRoute.isError).toBe(true);
+      if (!viaPrecondition.isError || !viaRoute.isError) return;
+      expect(viaRoute.error).toEqual(viaPrecondition.error);
+    });
+  });
 });
 
 // ── skill_info ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The defect

#510 gave `src/app/setup-api/hermes/skills/uninstall/route.ts` two structured refusals of its own:

- **404 `not_installed`** — no store skill by that name is here
- **409 `builtin_skill`** — `"x" came with this device, so it cannot be removed`

`UNINSTALL_RULES` in `mcp/tools/skills.ts` had exactly two rules, for status 400 and status 502. Both new codes fell straight through to `fromApiError()`, and the 409 came out of the agent's mouth as:

> **CONFLICT** — "The device refused this change in its current state."
> next: "Do not retry. Tell the user what you tried and **ask them to finish the setup in Settings**."

There is nothing to finish in Settings, and the skill will still be built in when the user comes back. The 404 fared a little better but pointed the agent at `ui_list_apps` and `code_project_list` — tools with nothing to do with skills.

### When it is actually reachable

`skill_uninstall`'s own pre-condition normally intercepts both cases with the right wording. It is skipped whenever the installed list cannot be read: `installedSkills()` swallows every failure of `/setup-api/hermes/skills/installed` and returns `null` (`skills.ts` — `.catch(() => null)`), the pre-condition block does not run, and the route's answer is the only information the agent gets. Narrow, but in that window the tool tells the user something false about what to do next.

## The fix

`UNINSTALL_RULES` becomes `uninstallRules(name)`, built per call so a refusal can name the skill exactly as the pre-condition does, plus rules for the two new codes.

The wording now lives in one place — `notInstalledMessage()` / `NOT_INSTALLED_NEXT`, `builtinMessage()` / `BUILTIN_NEXT` — used by **both** the pre-condition throw and the rule. One device state, one sentence, whichever path noticed it. A test asserts the two envelopes are deeply equal so they cannot drift apart later.

### Why the rules match on `code`, not on the status alone

`hermesSkillsGuard()` answers **404 from this same route** with `{"error":"Not found"}` and no `code` when the active harness is not Hermes. These tools are registered off an edition probe taken **once at startup**, so a device that changed harness since then reaches exactly that branch — and "there is no installed skill called X" would be a confident answer to a question nobody asked. A 404 or 409 without the route's own `code` still falls through to the generic mapping, which is the honest outcome when we cannot tell which failure it was.

## Tests

Added to `src/tests/unit/mcp-tool-honesty.test.ts`, under a new `the route's own refusals, when the pre-condition could not run` block that blindfolds the tool (installed list 502s) and lets the route answer:

| test | before | after |
|---|---|---|
| built-in skill → built in, not unfinished setup | RED | GREEN |
| unknown name → not installed, `skill_list`, do not retry this name | RED | GREEN |
| same words as the pre-condition for the same state | RED | GREEN |
| edition guard's bare 404 is **not** read as a missing skill | green | green (over-reach guard) |

`mcp-tool-honesty.test.ts`: **51 passed** on `origin/beta` → **3 failed / 52 passed** with the tests added, unmodified source → **55 passed** with the fix.

`npx tsc -p mcp/tsconfig.json`: 3 pre-existing errors on `origin/beta` (`src/lib/chat-history-cache.ts`, `src/lib/harness/transport.ts`), unchanged by this branch. `eslint` clean on both changed files.

## Behaviour change

Only what the agent is told when `skill_uninstall` hits the route's 404 `not_installed` or 409 `builtin_skill` without having been able to read the installed list first. No route change, no change to any successful uninstall, and the pre-condition path keeps its wording — it is now the single source of it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved skill removal error handling with clearer messages for built-in and already uninstalled skills.
  * Correctly distinguishes missing skills from unrelated 404 errors.
  * Provides more relevant retry guidance and next steps for uninstall failures.

* **Tests**
  * Added coverage to ensure consistent error responses across skill removal scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->