### PR TITLE
Coding agent: re-advertise the coding_agent_* tools when the owner flips the switch

### DIFF
--- a/src/app/setup-api/coding-agent/enable/route.ts
+++ b/src/app/setup-api/coding-agent/enable/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hasOwnerSession } from "@/lib/owner-session";
 import {
   CodingAgentError,
@@ -87,6 +88,19 @@ export async function POST(request: Request) {
   }
 
   try {
+    // The family's availability BEFORE the write, read only on requests that
+    // can actually move it. `ready` — not the raw switch — because `ready` is
+    // the fact `probeCodingAgent` reads to decide whether the coding_agent_*
+    // tools exist at all, and it is the field this route already answers with.
+    //
+    // It is a SECOND status read on the switch branch, deliberately, rather than
+    // deriving the old verdict from the new one: `ready` is `enabled AND the
+    // harness is installed AND ClawBox AI is connected`, and only the first of
+    // those three is this request's to know. The reads are a handful of stat()s
+    // and one readdir, on the one branch that flips a switch — and null here
+    // means "this request cannot move the family", which is every other setting
+    // the route carries.
+    const readyBefore = hasEnabled ? (await getCodingAgentStatus()).ready : null;
     if (hasDirectory) {
       const saved = await setDefaultDirectory(fields.defaultDirectory as string | null);
       console.error(`[coding-agent] default folder ${saved ? "set" : "cleared"} by the owner`);
@@ -107,7 +121,22 @@ export async function POST(request: Request) {
       await setCodingAgentEnabled(fields.enabled as boolean);
       console.error(`[coding-agent] switched ${fields.enabled ? "on" : "off"} by the owner`);
     }
-    return NextResponse.json(await getCodingAgentStatus());
+    const status = await getCodingAgentStatus();
+    // Tell the RUNNING agent, not just the browser. The coding_agent_* tools are
+    // registered behind a probe the MCP server takes ONCE while it boots, and
+    // that server is a long-lived stdio child — so without this the panel says
+    // "ready" while the agent still has no way to start a run. Same shape and
+    // same mechanism as #486 (email) and #503 (images); see the helper for the
+    // rule about when a reload is worth its cost.
+    //
+    // AWAITED, and it cannot fail the save: the helper swallows everything and
+    // returns void, so the worst case is a logged line and a tool list that
+    // catches up at the next restart. A floating promise here would outlive the
+    // response with nothing watching it.
+    if (readyBefore !== null) {
+      await refreshCodingAgentToolsIfReadinessChanged(readyBefore, status.ready);
+    }
+    return NextResponse.json(status);
   } catch (err) {
     // The folder rules answer in the owner's words ("that folder holds
     // credentials…"); pass them through as a 400 rather than a 500, because

--- a/src/app/setup-api/coding-agent/enable/route.ts
+++ b/src/app/setup-api/coding-agent/enable/route.ts
@@ -15,14 +15,7 @@ import {
 export const dynamic = "force-dynamic";
 
 /**
- * POST { enabled: boolean } → flip the owner's switch.
- * POST { defaultDirectory: string | null } → set (or clear) the folder a run
- * works in when the assistant names neither a project nor a directory.
- * POST { effort: "low"|"medium"|"high"|"xhigh"|"max" } → how hard a run thinks.
- * POST { maxTurns: number } → how many steps a run gets.
- * POST { tokenLimit: number | null } → token ceiling, or null for none.
- * Either way the answer is the same payload as GET
- * /setup-api/coding-agent/status, re-read after the change.
+ * The one refusal this route has: no owner browser session, no change.
  *
  * OWNER ONLY — the one thing in this subtree the agent must never be able to
  * do to itself. Middleware admits every /setup-api/* call on the MCP bearer,
@@ -39,6 +32,30 @@ function forbidden() {
   );
 }
 
+/**
+ * Change one coding-agent setting, then answer with the whole status.
+ *
+ * POST { enabled: boolean } → flip the owner's switch.
+ * POST { defaultDirectory: string | null } → set (or clear) the folder a run
+ * works in when the assistant names neither a project nor a directory.
+ * POST { effort: "low"|"medium"|"high"|"xhigh"|"max" } → how hard a run thinks.
+ * POST { maxTurns: number } → how many steps a run gets.
+ * POST { tokenLimit: number | null } → token ceiling, or null for none.
+ * Either way the answer is the same payload as GET
+ * /setup-api/coding-agent/status, re-read after the change.
+ *
+ * Owner-only; see `forbidden` for why middleware is not trusted here.
+ *
+ * The switch branch does one thing the others do not: it tells the RUNNING
+ * agent. The coding_agent_* tools are registered behind a probe the MCP server
+ * takes once at boot, so a flip that only reaches the browser leaves the panel
+ * claiming "ready" over an agent that still cannot start a run — see
+ * `refreshCodingAgentToolsIfReadinessChanged`.
+ *
+ * @param request the owner's browser request, JSON body as above
+ * @returns 200 with the re-read status, 400 on a body this route cannot read,
+ *          or 403 without an owner session
+ */
 export async function POST(request: Request) {
   if (!(await hasOwnerSession(request))) return forbidden();
 

--- a/src/lib/coding-agent-mcp-refresh.ts
+++ b/src/lib/coding-agent-mcp-refresh.ts
@@ -1,0 +1,82 @@
+import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
+
+/**
+ * Ask the agent to rebuild its MCP tool list when the coding agent becomes
+ * usable, or stops being.
+ *
+ * WHY THIS EXISTS. Three tools — `coding_agent_run`, `coding_agent_status` and
+ * `coding_agent_stop` — are registered CONDITIONALLY by the ClawBox MCP server
+ * (mcp/tools/coding-agent.ts): the server asks
+ * `/setup-api/coding-agent/status` while it boots (mcp/lib/context.ts
+ * `probeCodingAgent`) and, when the answer is no, `registerCodingAgentTools`
+ * returns without declaring any of them. That is not caution about the switch —
+ * the routes refuse the call anyway. It is the same circuit-breaker rule the
+ * email read tools are held to: a tool that can only ever answer 409 keeps
+ * failing, the agent's per-server breaker opens, and it takes EVERY ClawBox tool
+ * offline with it, not just these three.
+ *
+ * The bug it fixes is that the probe happens ONCE, at server startup, and the
+ * server is a long-lived stdio child of the agent. When the owner flips the
+ * switch on, `/setup-api/coding-agent/enable` writes the setting and hands the
+ * browser a freshly-read status that says "ready" — and nothing tells the
+ * running agent, so it still has no way to start the run the panel is now
+ * advertising, until something unrelated respawns the server. It is the third
+ * instance of one shape: #486 fixed it for `email_list`/`email_read` and #503
+ * for the image tools, and this was the call site left out.
+ *
+ * The mechanism is the agent's own `reload.mcp`, shared with both siblings — see
+ * `hermes-mcp-reload.ts`. What belongs HERE is the rule for when it is worth
+ * paying for, below.
+ */
+
+/**
+ * Reload the MCP servers, but ONLY if this request flipped whether the coding
+ * agent family would be registered at all.
+ *
+ * The guard is the important half. A reload kills and respawns every MCP child
+ * process and invalidates the model's prompt cache, so the next turn on this box
+ * re-sends and re-pays for a system prompt that was cached — it is not free, and
+ * the route this hangs off also carries the effort, step-limit, token-ceiling
+ * and default-folder settings. None of those change WHICH tools exist, and
+ * neither does the switch itself on a box whose harness is not installed: there
+ * `ready` stays false either way, and the owner must not be charged for a
+ * reload that would register nothing.
+ *
+ * The verdict compared is `CodingAgentStatus.ready` — `enabled` AND the harness
+ * installed AND ClawBox AI connected — because that is the same fact
+ * `probeCodingAgent` reads. Comparing the raw switch instead would fire on a box
+ * that cannot run anything, and stay silent on none of the cases that matter.
+ *
+ * Never throws and never reports. The setting IS saved by the time this runs, an
+ * OpenClaw box has no dashboard to ask at all, and a box whose dashboard is down
+ * must not have the owner's save turned into an error by a best-effort refresh:
+ * the switch is still enforced route-side and the tool list catches up at the
+ * next restart — which is exactly the behaviour of every box before this
+ * existed.
+ *
+ * @param before what `getCodingAgentStatus().ready` said BEFORE the write
+ * @param after  what it says after — the same field the panel is shown, so the
+ *               agent's tools and the owner's panel cannot disagree.
+ */
+export async function refreshCodingAgentToolsIfReadinessChanged(before: boolean, after: boolean): Promise<void> {
+  if (before === after) return;
+  // `.catch` even though `reloadMcpServers` documents that it never throws: the
+  // "never throws" above is a promise made to the OWNER'S SAVE, which has
+  // already been written to disk by the time this runs, and it must not depend
+  // on a neighbouring module keeping its own promise.
+  if (!(await reloadMcpServers().catch(() => false))) {
+    // Logged, not surfaced. Worth a line because "I turned it on and the
+    // assistant still cannot start a run" is otherwise invisible from the
+    // outside, and this is the one place that knows the refresh was wanted and
+    // did not happen.
+    console.error(
+      `[coding-agent/mcp-refresh] the coding agent became ${after ? "available" : "unavailable"}, `
+        + "but the agent would not reload its MCP servers",
+    );
+    return;
+  }
+  console.log(
+    `[coding-agent/mcp-refresh] the coding agent became ${after ? "available" : "unavailable"}; `
+      + "asked the agent to reload its MCP servers",
+  );
+}

--- a/src/tests/routes/coding-agent/enable.test.ts
+++ b/src/tests/routes/coding-agent/enable.test.ts
@@ -20,10 +20,19 @@ vi.mock("@/lib/config-store", async (importOriginal) => ({
 
 const setEnabled = vi.hoisted(() => vi.fn());
 const getStatus = vi.hoisted(() => vi.fn());
-vi.mock("@/lib/coding-agent", () => ({
+const setEffort = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/coding-agent", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/coding-agent")>()),
   setCodingAgentEnabled: setEnabled,
   getCodingAgentStatus: getStatus,
+  setEffort,
 }));
+
+// The reload is mocked at its own seam rather than at the refresh helper's, so
+// this file pins the BEHAVIOUR the owner is owed — "the running agent is told" —
+// and not the name of the module that happens to tell it.
+const reloadMcp = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-mcp-reload", () => ({ reloadMcpServers: reloadMcp }));
 
 import { get as configGet } from "@/lib/config-store";
 
@@ -56,6 +65,8 @@ beforeEach(async () => {
   vi.mocked(configGet).mockImplementation(async () => undefined);
   getStatus.mockResolvedValue(STATUS);
   setEnabled.mockResolvedValue(undefined);
+  reloadMcp.mockResolvedValue(true);
+  setEffort.mockResolvedValue("low");
   const route = await import("@/app/setup-api/coding-agent/enable/route");
   POST = route.POST;
 });
@@ -113,5 +124,85 @@ describe("the body", () => {
   it("checks the session before it looks at the body", async () => {
     const res = await POST(request({ raw: "not json" }));
     expect(res.status).toBe(403);
+  });
+});
+
+/**
+ * Flipping the switch has to reach the RUNNING agent, not just the browser.
+ *
+ * The coding_agent_* family is registered behind a probe the ClawBox MCP server
+ * takes ONCE while it boots (`mcp/lib/context.ts` probeCodingAgent), and that
+ * server is a long-lived stdio child of the agent. Before this, the route wrote
+ * the setting, logged it and handed the browser a fresh status that said
+ * "ready" — while the agent still had no coding_agent_run, coding_agent_status
+ * or coding_agent_stop, until something unrelated respawned the child. Same
+ * shape, and the same fix, as #486 (email_list/email_read) and #503 (the image
+ * tools); this was the third call site of three and the only one left out.
+ */
+describe("telling the running agent", () => {
+  /** Status before the write, then after it — the pair the refresh compares. */
+  function readyGoes(before: boolean, after: boolean): void {
+    getStatus
+      .mockResolvedValueOnce({ ...STATUS, ready: before })
+      .mockResolvedValueOnce({ ...STATUS, ready: after });
+  }
+
+  it("reloads the MCP servers when the switch makes the family available", async () => {
+    readyGoes(false, true);
+    const res = await POST(request({ cookie: ownerCookie(), body: { enabled: true } }));
+    expect(res.status).toBe(200);
+    expect(reloadMcp).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads them when the switch takes the family away", async () => {
+    // The other direction matters as much: tools left registered against a
+    // switch the owner turned off answer 409 forever, and a permanently-failing
+    // tool is what opens Hermes' per-server circuit breaker.
+    readyGoes(true, false);
+    const res = await POST(request({ cookie: ownerCookie(), body: { enabled: false } }));
+    expect(res.status).toBe(200);
+    expect(reloadMcp).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT reload when the verdict did not move", async () => {
+    // A reload respawns every MCP child and invalidates the model's prompt
+    // cache. On a box with no harness installed the switch changes nothing the
+    // agent can see, and the owner must not pay for that.
+    readyGoes(false, false);
+    const res = await POST(request({ cookie: ownerCookie(), body: { enabled: true } }));
+    expect(res.status).toBe(200);
+    expect(reloadMcp).not.toHaveBeenCalled();
+  });
+
+  it("does NOT reload for the settings that leave the family alone", async () => {
+    // effort, step limit, token ceiling, default folder — none of them change
+    // WHICH tools exist, so none of them may cost a reload.
+    const res = await POST(request({ cookie: ownerCookie(), body: { effort: "low" } }));
+    expect(res.status).toBe(200);
+    expect(reloadMcp).not.toHaveBeenCalled();
+  });
+
+  it("still saves the switch when the reload is refused", async () => {
+    // The recurring shape this guards: an error path that reports failure over
+    // something that actually succeeded. The write HAPPENED; a dashboard that
+    // will not reload (an OpenClaw box has none at all) must not turn the
+    // owner's save into an error.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    readyGoes(false, true);
+    reloadMcp.mockResolvedValue(false);
+    const res = await POST(request({ cookie: ownerCookie(), body: { enabled: true } }));
+    expect(res.status).toBe(200);
+    expect(setEnabled).toHaveBeenCalledWith(true);
+    errorSpy.mockRestore();
+  });
+
+  it("still saves the switch when the reload throws", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    readyGoes(true, false);
+    reloadMcp.mockRejectedValue(new Error("socket exploded"));
+    const res = await POST(request({ cookie: ownerCookie(), body: { enabled: false } }));
+    expect(res.status).toBe(200);
+    expect(setEnabled).toHaveBeenCalledWith(false);
+    errorSpy.mockRestore();
   });
 });

--- a/src/tests/unit/coding-agent-mcp-refresh.test.ts
+++ b/src/tests/unit/coding-agent-mcp-refresh.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The narrow trigger that keeps `coding_agent_run` / `_status` / `_stop` in step
+ * with the owner's switch.
+ *
+ * The gate that family is registered behind is probed ONCE, when the MCP server
+ * starts (`mcp/lib/context.ts` probeCodingAgent), and the server is a long-lived
+ * stdio child of the agent — so a switch flipped underneath it never reaches the
+ * tool list. Asking Hermes to reload its MCP servers fixes that, and a reload
+ * respawns every MCP child and invalidates the model's prompt cache, so the
+ * no-op cases below are the load-bearing ones: the enable route also carries the
+ * effort, step-limit, token-ceiling and default-folder settings, and none of
+ * those change which tools exist.
+ */
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: vi.fn() }));
+
+import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+
+const mockRpc = vi.mocked(dashboardRpc);
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mockRpc.mockReset();
+  mockRpc.mockResolvedValue({ status: "ok" });
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  logSpy.mockRestore();
+});
+
+describe("refreshCodingAgentToolsIfReadinessChanged", () => {
+  it("does NOTHING when the verdict did not change", async () => {
+    // The prompt cache is the reason this test exists. Switching on a box whose
+    // harness is not installed leaves the family unavailable either way, and a
+    // save that changes nothing the agent can see may not cost a reload.
+    await refreshCodingAgentToolsIfReadinessChanged(false, false);
+    await refreshCodingAgentToolsIfReadinessChanged(true, true);
+    expect(mockRpc).not.toHaveBeenCalled();
+  });
+
+  it("reloads when the family becomes available", async () => {
+    await refreshCodingAgentToolsIfReadinessChanged(false, true);
+    expect(mockRpc).toHaveBeenCalledTimes(1);
+    // `confirm` is not decoration: the call is gated by
+    // approvals.mcp_reload_confirm, which defaults to true, and without the flag
+    // the dashboard answers `confirm_required` and does nothing.
+    expect(mockRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("reloads when the family stops being available", async () => {
+    // Tools left registered against a switch the owner turned off answer 409
+    // forever, which is what opens Hermes' per-server circuit breaker and takes
+    // EVERY ClawBox tool offline with it, not just these three.
+    await refreshCodingAgentToolsIfReadinessChanged(true, false);
+    expect(mockRpc).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("never sends a session id — the reload has to be global", async () => {
+    await refreshCodingAgentToolsIfReadinessChanged(false, true);
+    const params = mockRpc.mock.calls[0][1];
+    expect(params).not.toHaveProperty("session_id");
+  });
+
+  it("does not throw when the dashboard cannot be reached", async () => {
+    // An OpenClaw box has no dashboard at all, and the setting IS saved. The
+    // worst case is a logged line and a tool list that catches up at the next
+    // restart — the behaviour of every box before this existed.
+    mockRpc.mockResolvedValue(null);
+    await expect(refreshCodingAgentToolsIfReadinessChanged(false, true)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not throw when the RPC helper itself rejects", async () => {
+    mockRpc.mockRejectedValue(new Error("socket exploded"));
+    await expect(refreshCodingAgentToolsIfReadinessChanged(true, false)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not claim success when the dashboard refused", async () => {
+    // The recurring shape: reporting success from a call that returned, without
+    // checking what it returned. A refused reload has to read as a refusal.
+    mockRpc.mockResolvedValue(null);
+    await refreshCodingAgentToolsIfReadinessChanged(false, true);
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The defect

Flipping the coding agent ON never reaches the running agent.

`coding_agent_run`, `coding_agent_status` and `coding_agent_stop` are registered **conditionally**: the ClawBox MCP server asks `/setup-api/coding-agent/status` once while it boots (`mcp/lib/context.ts` `probeCodingAgent`) and `mcp/tools/coding-agent.ts` opens with

```ts
if (!ctx.codingAgent) return;
```

so a `false` withholds the whole family. That gate is right — an always-409 tool opens the agent's per-server circuit breaker and takes *every* ClawBox tool offline with it, which is the same reason `email_list`/`email_read` are gated.

The problem is the probe is taken **once**, and the MCP server is a long-lived stdio child. `src/app/setup-api/coding-agent/enable/route.ts` wrote `setCodingAgentEnabled(true)`, logged it, and returned a freshly-read status to the browser — and told the running agent nothing. The panel says ready; the agent has no `coding_agent_*` at all until something unrelated respawns the child.

This is the **third** instance of one shape, and the only call site that was left out:

| # | Trigger | Refresh helper |
|---|---|---|
| #486 | mailbox becomes readable | `src/lib/email-mcp-refresh.ts` |
| #503 | the box becomes able to draw | `src/lib/hermes-image-refresh.ts` |
| **this** | the coding agent becomes usable | `src/lib/coding-agent-mcp-refresh.ts` |

`grep -rn reloadMcpServers src mcp` returned exactly those two callers before this change.

## The fix

`src/lib/coding-agent-mcp-refresh.ts`, modelled on both siblings: compare the verdict before and after the write, call `reloadMcpServers()` only on a **transition**, never throw, never turn the owner's save into an error.

The verdict compared is `CodingAgentStatus.ready` — `enabled` AND the harness installed AND ClawBox AI connected — because that is the same fact `probeCodingAgent` reads. Comparing the raw switch would fire on a box that can run nothing.

The guard is the load-bearing half. A reload kills and respawns every MCP child and invalidates the model's prompt cache. The same route also carries `effort`, `maxTurns`, `tokenLimit` and `defaultDirectory`; none of those change *which* tools exist, and neither does the switch on a box with no harness installed. All of those now cost nothing, and there are tests for each.

The route reads the status twice on the switch branch, deliberately: `ready` is three facts and only one of them is this request's to know. It is a handful of `stat()`s plus one `readdir`, on the one branch that flips a switch.

## Tests — RED first, against unmodified `origin/beta`

```
src/tests/routes/coding-agent/enable.test.ts    2 failed | 12 passed
  x reloads the MCP servers when the switch makes the family available
      AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
  x reloads them when the switch takes the family away
      AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
src/tests/unit/coding-agent-mcp-refresh.test.ts  suite failed to load (7 tests unrun)
      Error: Cannot find package '@/lib/coding-agent-mcp-refresh'
```

GREEN after the fix: **21 passed (2 files)**.

The route test mocks `reloadMcpServers` at its own seam rather than mocking the new helper, so it pins the behaviour the owner is owed — "the running agent is told" — and not the name of the module that happens to tell it.

## The recurring shapes this was checked against

- **A probe taken once at startup that never refreshes** — this *is* that bug; both directions of the flip are tested, and so is the no-op case that must not fire.
- **Reporting success from a call that returned, without checking what it returned** — `reloadMcpServers()` returning `false` must read as a refusal: `does not claim success when the dashboard refused` asserts nothing is logged as success.
- **An error path reporting failure over something that succeeded** — the write has already happened when the refresh runs, and an OpenClaw box has no dashboard at all. Two route tests assert the save still answers 200 when the reload is refused and when it throws.

## Deliberately not in scope

- **No honest-refusal `coding_agent_run`.** The image family registers one because an agent with no image tool *improvises* a picture the chat cannot display. There is no equivalent failure here — an agent with no `coding_agent_run` uses its own file tools, which is a reasonable answer, not a broken one — and `src/tests/unit/mcp-coding-agent-tools.test.ts` already pins "the family is absent when the device says the coding agent is off (circuit-breaker rule)". Adding a tool would contradict a decision this repo already made on purpose.
- **Linking ClawBox AI also moves `ready`** (via `clawaiConnected`), and that path already reloads for the image tools. Piggy-backing a second reload there would need coordination with `refreshHermesImageTools` to avoid two reloads on one save; worth its own change, not this one.

## Baselines

`bun run lint` and `tsc --noEmit`: unchanged from `origin/beta` (22 errors / 81 warnings, 24 TS errors — all pre-existing, none in any file this touches).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Coding-agent tools now refresh automatically when readiness changes.
  * Unchanged readiness and unrelated setting updates no longer trigger unnecessary refreshes.
  * Settings continue to save successfully even if a tool refresh cannot be completed.
  * Updated status information is returned immediately after configuration changes.

* **Reliability**
  * Tool refresh failures are handled gracefully without interrupting coding-agent configuration.
  * Refresh requests are only reported as successful when accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->