### PR TITLE
fix: show the exception, not the Python source line, when Hermes crashes

### DIFF
--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -275,13 +275,60 @@ function isBookkeepingLine(line: string): boolean {
   return /^session_id:/i.test(line)
     || /^(?:↻\s*)?Resumed session\b/.test(line)
     || /^Model restored from session\b/.test(line)
-    || /^\s*(?:Traceback|File ")/.test(line);
+    // The connectors CPython prints between chained tracebacks. They sit at
+    // column 0, so they survive the frame strip below, and they name no cause.
+    || /^(?:During handling of the above exception|The above exception was the direct cause)\b/
+      .test(line);
+}
+
+/**
+ * Drop the FRAMES of a Python traceback, keeping only its summary line.
+ *
+ * CPython indents everything belonging to a frame — the `File "…"` header, the
+ * source line under it and (3.11+) the `^^^^` anchor beneath that — and returns
+ * the exception summary to column 0. Trimming every line before classifying it
+ * threw that signal away. Only the frame HEADER was being dropped, so the
+ * source line under it survived, matched the "names a failure" filter below on
+ * its `RuntimeError(` text, and — sitting earlier in the stream than the real
+ * summary — became the customer's error bubble. Captured shape:
+ *
+ *   Traceback (most recent call last):
+ *     File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider
+ *       raise RuntimeError("upstream refused the request")     <- what was shown
+ *   RuntimeError: upstream refused the request                 <- what to show
+ *
+ * So classify on the RAW line: once a traceback opens, drop everything indented
+ * under it and let the first column-0 line both end the block and stand as the
+ * cause. A frame header opens a block too, so a stream whose `Traceback:` line
+ * was already cut off still reads correctly. If the stream ENDS inside the
+ * frames, nothing is invented — the caller falls back to the exit code rather
+ * than quoting Python source at a customer. The block is scoped: once it ends,
+ * an indented line is ordinary output again.
+ */
+const TRACEBACK_OPENER = /^[ \t]*(?:Traceback\b|File ")/;
+
+function withoutTracebackFrames(lines: string[]): string[] {
+  const kept: string[] = [];
+  let inTraceback = false;
+  for (const line of lines) {
+    if (TRACEBACK_OPENER.test(line)) {
+      inTraceback = true;
+      continue;
+    }
+    if (inTraceback) {
+      if (!line || /^[ \t]/.test(line)) continue;
+      inTraceback = false;
+    }
+    kept.push(line);
+  }
+  return kept;
 }
 
 /** Bookkeeping and stack noise, dropped before we look for a cause. */
 function usefulLines(stream: string): string[] {
-  const lines = stream
-    .split(/\r?\n/)
+  // Strip frames BEFORE trimming: the indentation is the only thing that tells
+  // a frame's source line apart from a line the customer needs to read.
+  const lines = withoutTracebackFrames(stream.split(/\r?\n/))
     .map((l) => l.trim())
     .filter((l) => l && !isBookkeepingLine(l));
   // Unwrap FIRST: the filter below keeps lines that themselves name a failure,

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -304,8 +304,13 @@ function isBookkeepingLine(line: string): boolean {
  * frames, nothing is invented — the caller falls back to the exit code rather
  * than quoting Python source at a customer. The block is scoped: once it ends,
  * an indented line is ordinary output again.
+ *
+ * A frame header is matched by its FULL shape — `File "…", line <n>` — not by
+ * its first six characters. `File "config.yaml" was denied` is a sentence a
+ * customer needs to read, and the loose form both swallowed it and reopened a
+ * block that had already closed, taking the indented lines after it with it.
  */
-const TRACEBACK_OPENER = /^[ \t]*(?:Traceback\b|File ")/;
+const TRACEBACK_OPENER = /^[ \t]*(?:Traceback\b|File "[^"]+", line \d+\b)/;
 
 function withoutTracebackFrames(lines: string[]): string[] {
   const kept: string[] = [];

--- a/src/tests/unit/hermes-chat-failure-message.test.ts
+++ b/src/tests/unit/hermes-chat-failure-message.test.ts
@@ -360,6 +360,22 @@ describe("a Python traceback in the output", () => {
       .toBe("the provider denied the request; check the API key");
   });
 
+  it("keeps a sentence that merely starts with File \"…\" after the traceback", () => {
+    // `File "` alone used to open a traceback block, so an ordinary diagnostic
+    // naming a file was both discarded AND reopened suppression over the lines
+    // under it. Only the real frame shape — File "…", line <n> — opens one.
+    const stderr = [
+      "Traceback (most recent call last):",
+      '  File "/home/clawbox/.hermes/agent.py", line 88, in run',
+      "    cfg = load(path)",
+      "KeyboardInterrupt",
+      '  File "config.yaml" was denied to the hermes user',
+    ].join("\n");
+    const msg = hermesFailureMessage("", stderr);
+    expect(msg).toBe('File "config.yaml" was denied to the hermes user');
+    expect(msg).not.toMatch(/cfg = load|agent\.py/);
+  });
+
   it("keeps indented prose that was never part of a traceback", () => {
     expect(hermesFailureMessage("    the request was denied by the provider", ""))
       .toBe("the request was denied by the provider");

--- a/src/tests/unit/hermes-chat-failure-message.test.ts
+++ b/src/tests/unit/hermes-chat-failure-message.test.ts
@@ -54,15 +54,19 @@ describe("the message shown for a failed Hermes turn", () => {
   });
 
   it("drops stack frames rather than showing them in a chat bubble", () => {
+    // A REAL CPython traceback prints an indented SOURCE line under every
+    // `File "…"` frame. Omitting it let this test pass against a filter that
+    // only knew about the frame header — the very hole it was meant to close.
     const stderr = [
       "session_id: 20260811_000000_aaaaaa",
       "Traceback (most recent call last):",
-      '  File "/home/clawbox/.hermes/x.py", line 12, in run',
+      '  File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider',
+      '    raise RuntimeError("upstream refused the request")',
       "RuntimeError: upstream refused the request",
     ].join("\n");
     const msg = hermesFailureMessage("", stderr);
     expect(msg).toBe("RuntimeError: upstream refused the request");
-    expect(msg).not.toMatch(/Traceback|File "/);
+    expect(msg).not.toMatch(/Traceback|File "|raise /);
   });
 
   it("returns empty when neither stream says anything, so the caller can be generic", () => {
@@ -264,5 +268,100 @@ describe("a failed turn on a resumed session", () => {
       'Resumed session 20260825_165225_be089e "t" (1 user message, 5 total messages)',
     );
     expect(msg).toBe("HTTP 403 — Just a moment...");
+  });
+});
+
+/**
+ * The chat bubble showed a line of PYTHON SOURCE when Hermes crashed.
+ *
+ * Every line was trimmed before it was classified, which threw away the one
+ * signal CPython gives for free: it INDENTS everything belonging to a frame —
+ * the `File "…"` header, the source line under it, and (3.11+) the `^^^^`
+ * anchor beneath that — and returns the exception summary to column 0. With
+ * the indentation gone, `raise RuntimeError("upstream refused the request")`
+ * matched the "names a failure" heuristic on "RuntimeError", sat earlier in
+ * the stream than the real summary, and won. Captured shape below is what
+ * CPython 3.11+ prints.
+ */
+describe("a Python traceback in the output", () => {
+  const TRACEBACK = [
+    "session_id: 20260811_000000_aaaaaa",
+    "Traceback (most recent call last):",
+    '  File "/home/clawbox/.hermes/agent.py", line 212, in _turn',
+    "    return self._call_provider(payload)",
+    "           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+    '  File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider',
+    '    raise RuntimeError("upstream refused the request")',
+    "RuntimeError: upstream refused the request",
+  ].join("\n");
+
+  it("shows the exception summary, never the source line that raised it", () => {
+    expect(hermesFailureMessage("", TRACEBACK)).toBe("RuntimeError: upstream refused the request");
+  });
+
+  it("shows no fragment of a frame — header, source line or anchor", () => {
+    const msg = hermesFailureMessage("", TRACEBACK);
+    expect(msg).not.toMatch(/raise |_call_provider|\^\^\^|File "|Traceback/);
+  });
+
+  it("still wins over partial answer text left on stdout", () => {
+    expect(hermesFailureMessage("half an answer", TRACEBACK))
+      .toBe("RuntimeError: upstream refused the request");
+  });
+
+  it("reads a traceback on stdout the same way", () => {
+    expect(hermesFailureMessage(TRACEBACK, "")).toBe("RuntimeError: upstream refused the request");
+  });
+
+  it("reports an exception summary, not a source line, for a chained traceback", () => {
+    const stderr = [
+      "Traceback (most recent call last):",
+      '  File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider',
+      "    resp = self.session.post(url, json=payload)",
+      "ConnectionError: connection refused",
+      "",
+      "During handling of the above exception, another exception occurred:",
+      "",
+      "Traceback (most recent call last):",
+      '  File "/home/clawbox/.hermes/chat.py", line 40, in turn',
+      '    raise RuntimeError("the turn failed")',
+      "RuntimeError: the turn failed",
+    ].join("\n");
+    const msg = hermesFailureMessage("", stderr);
+    expect(msg).toMatch(/^(?:ConnectionError|RuntimeError): /);
+    expect(msg).not.toMatch(/resp = |raise |File "|above exception/);
+  });
+
+  it("says nothing rather than guess when the stream is cut off mid-frame", () => {
+    // stderr hit the size cap partway through the frames, so no summary line
+    // ever arrived. Silence lets the caller fall back to the exit code; a
+    // source line here would be a confident wrong answer.
+    const stderr = [
+      "Traceback (most recent call last):",
+      '  File "/home/clawbox/.hermes/agent.py", line 212, in _turn',
+      "    return self._call_provider(payload)",
+    ].join("\n");
+    expect(hermesFailureMessage("", stderr)).toBe("");
+    expect(hermesExitMessage(1, "", stderr)).toBe("hermes exited with code 1");
+  });
+
+  it("stops dropping indented lines once the traceback has ended", () => {
+    // The frame rule is scoped to the traceback. An indented line in ordinary
+    // Hermes output after it is still something the customer needs, and here
+    // it is the only line naming the failure at all.
+    const stderr = [
+      "Traceback (most recent call last):",
+      '  File "/home/clawbox/.hermes/agent.py", line 88, in run',
+      "    resp = self.session.post(url, json=payload)",
+      "KeyboardInterrupt",
+      "  the provider denied the request; check the API key",
+    ].join("\n");
+    expect(hermesFailureMessage("", stderr))
+      .toBe("the provider denied the request; check the API key");
+  });
+
+  it("keeps indented prose that was never part of a traceback", () => {
+    expect(hermesFailureMessage("    the request was denied by the provider", ""))
+      .toBe("the request was denied by the provider");
   });
 });


### PR DESCRIPTION
A crashed Hermes turn put a line of **Python source** in the customer's chat bubble.

## What was wrong

`isBookkeepingLine` dropped a traceback's `Traceback` marker and its `File "…"` frame headers. But CPython prints an indented **source line** under every frame, and (3.11+) a `^^^^` anchor under that — neither matched the predicate. `usefulLines` then keeps any line matching `/error|failed|not found|denied|invalid|unauthor/i`, and

```
Traceback (most recent call last):
  File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider
    raise RuntimeError("upstream refused the request")     <- what was shown
RuntimeError: upstream refused the request                 <- what to show
```

the `raise` line matches on `RuntimeError`, sits earlier in the stream than the real summary, and wins. `unwrap` does not join it either (49 chars, under the 60-column wrap hint), so it reaches the bubble verbatim — in the module whose own comment says a stack trace's later frames are worse than useless in a chat bubble.

The turn had already failed, so this is cosmetic: the defect is that the message is the wrong line.

## Why the existing test did not catch it

`src/tests/unit/hermes-chat-failure-message.test.ts` built its traceback with the `File "…"` frame but **no source line under it** — a shape CPython never emits. It passed against the broken filter and would have passed against any filter.

## The fix

The signal was thrown away one step earlier: every line was trimmed before it was classified, and the indentation is the only thing that tells a frame apart from a line worth reading. So classify on the **raw** line:

- once a traceback opens, drop everything indented under it;
- the first column-0 line both closes the block and stands as the cause;
- a frame header opens a block too, so a stream whose `Traceback` line was already cut off (the stderr size cap truncates from the front of a chunk) still reads correctly;
- a stream that **ends inside the frames** yields nothing rather than quoting source — the caller falls back to the exit code instead of giving a confident wrong answer;
- the block is scoped, so an indented line after the traceback is ordinary output again;
- the connectors CPython prints between chained tracebacks (`During handling of the above exception…`) sit at column 0, so they are now named as bookkeeping.

## Tests

RED against `origin/beta`: **7 failed / 27 passed**. GREEN after the fix: **34 passed**.

The corrected existing case plus eight new ones: the real 3.11 shape with two frames and an anchor, the same traceback on stdout, a chained traceback, a stream cut off mid-frame, an indented line *after* the traceback (which must survive), and indented prose that was never a traceback at all.

`bun run lint` and `tsc --noEmit`: identical to the `origin/beta` baseline (103 lint problems / 22 errors, 24 pre-existing tsc errors) — neither touched file appears in either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes error messages by removing Python traceback details and chained traceback connector lines.
  * Preserved actionable exception summaries while filtering incomplete or indented traceback content.
  * Improved handling of errors reported through stderr, stdout, chained exceptions, and partial output.

* **Tests**
  * Added comprehensive coverage for traceback filtering and failure-message prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review follow-up (d3098189)

CodeRabbit was right that `File "` alone was too loose an opener: `  File "config.yaml" was denied` is a sentence the customer needs, and the loose form both discarded it and re-opened suppression in a block that had already closed. The opener now requires the full frame shape `File "…", line <n>`, which still covers the truncation case (a real frame carries its line number even when the `Traceback` heading was cut away).

Tests now **35 passed** (RED for the new case against the loose opener: 1 failed / 34 passed).
