### PR TITLE
fix: stop caching a failed hermes probe as a negative answer

### DIFF
--- a/src/lib/harness/hermes-features.ts
+++ b/src/lib/harness/hermes-features.ts
@@ -18,7 +18,17 @@ import { hermesConfigGet } from "@/lib/hermes-config-cache";
 const PROBE_TIMEOUT_MS = 30_000;
 
 /**
- * Once per process, never per request.
+ * How long a probe that never COMPLETED is left alone before we ask again.
+ *
+ * Long enough that a genuinely broken box is not starting a Python interpreter
+ * per request, short enough that a box that was merely busy gets its attach
+ * button back inside a minute rather than at the next restart. Matches
+ * `PROBE_TTL_FAIL_MS` next door in `clawai-images`.
+ */
+const PROBE_RETRY_BACKOFF_MS = 60_000;
+
+/**
+ * Once per process, never per request — for an ANSWER.
  *
  * `hermes chat --help` starts a Python interpreter, which on this hardware is
  * seconds, not milliseconds — running it per request would put that on every
@@ -28,8 +38,20 @@ const PROBE_TIMEOUT_MS = 30_000;
  * A process restart re-probes, which is exactly the granularity that matters:
  * an update replaces the checkout and restarts the web server, so the answer
  * cannot outlive the binary it describes.
+ *
+ * WHAT IS NOT KEPT THAT LONG: a probe that never answered. `runHermesCli`
+ * rejects on a timeout, on a missing binary and on its own SIGKILL, and a child
+ * killed by a signal comes back with `code: null` — none of those read the help
+ * text, so none of them say anything about `--image`. Memoising the `false`
+ * they produce made a 30 s timeout on a loaded Jetson indistinguishable from a
+ * `hermes` that genuinely lacks the flag, and both then hid the composer's
+ * attach button for the whole process lifetime, on a box that works. Those
+ * outcomes drop the memo and are re-asked after `PROBE_RETRY_BACKOFF_MS`; a
+ * real help text — flag present or absent — is still kept for the life of the
+ * process.
  */
-let probe: Promise<boolean> | null = null;
+type Probe = { promise: Promise<boolean>; expiresAt: number };
+let probe: Probe | null = null;
 
 /**
  * Does this `hermes` take an image on a chat turn?
@@ -45,18 +67,40 @@ let probe: Promise<boolean> | null = null;
  * mention in prose elsewhere in the help cannot answer yes on its own.
  */
 export async function hermesSupportsImages(): Promise<boolean> {
-  probe ??= (async () => {
+  if (probe && Date.now() < probe.expiresAt) return probe.promise;
+  // Seeded with the BACKOFF so concurrent callers during the probe share one
+  // interpreter; the real expiry is stamped on below, once we know whether we
+  // got an answer or a failure. The entry is mutated in place rather than
+  // reassigned through `probe`, so the bookkeeping cannot be undone by the
+  // assignment below if `runHermesCli` ever throws before its first await.
+  const entry: Probe = {
+    promise: Promise.resolve(false),
+    expiresAt: Date.now() + PROBE_RETRY_BACKOFF_MS,
+  };
+  entry.promise = (async () => {
     try {
       const result = await runHermesCli(["chat", "--help"], { timeoutMs: PROBE_TIMEOUT_MS });
+      // A numeric exit code means the CLI ran and argparse spoke: 0 prints the
+      // option list, and non-zero is how it rejects a subcommand or a flag it
+      // does not have (verified on the box: exit 2). Either way that is an
+      // answer about THIS checkout, and it is kept for the life of the process.
+      // `null` means the child was killed by a signal and printed nothing,
+      // which is not an answer at all.
+      if (typeof result.code !== "number") throw new Error("hermes probe was killed");
+      entry.expiresAt = Number.POSITIVE_INFINITY;
       if (result.code !== 0) return false;
       return /^\s*--image\b/m.test(`${result.stdout}\n${result.stderr}`);
     } catch {
-      // Not installed, timed out, or the checkout is broken. All of them mean
-      // the same thing to the composer: do not offer to attach a picture.
+      // Not installed, timed out, or killed. None of them read the help text,
+      // so none of them answered the question: hide the attach button for now
+      // — a wrong `true` costs the customer's file — but do not remember this
+      // as what the checkout said. Re-asked once the backoff is up.
+      entry.expiresAt = Date.now() + PROBE_RETRY_BACKOFF_MS;
       return false;
     }
   })();
-  return probe;
+  probe = entry;
+  return entry.promise;
 }
 
 /** Test seam: forget the probe so the next call runs it again. */

--- a/src/lib/hermes-config-cache.ts
+++ b/src/lib/hermes-config-cache.ts
@@ -15,6 +15,12 @@ import { runHermesCli } from "@/lib/hermes-cli";
  * answer is still current — no staleness window to tune, and no risk of serving
  * a value the user just changed.
  *
+ * What the mtime key does NOT cover is a read that never completed. A timeout
+ * or a missing binary produces no answer about the key, and storing "" for it
+ * against the current mtime remembers a failed QUESTION as a negative ANSWER —
+ * permanently, because on a linked, stable box nothing rewrites config.yaml
+ * again. Those are held for a short backoff instead (see `FAILED_READ_TTL_MS`).
+ *
  * Note the deliberate choice NOT to parse config.yaml ourselves. That was tried
  * and reverted: `^\s*(?:default|model)\s*:` matched the first `model:` anywhere
  * in the file, so it was order-dependent and wrong on some configs. The CLI is
@@ -27,7 +33,24 @@ const CONFIG_PATH = path.join(
   "config.yaml",
 );
 
-type Entry = { mtimeMs: number; value: string };
+/**
+ * How long a read that never COMPLETED is remembered before we ask again.
+ *
+ * A timeout, a missing binary or a child we had to SIGKILL is not an answer
+ * about the key — it is the question failing — so it must not be stored against
+ * config.yaml's mtime the way an answer is. But forgetting it outright would
+ * turn a hanging `hermes` into one ~800 ms Python start per request, which is
+ * the exact cost this module exists to avoid, so it is held briefly and then
+ * re-asked. Matches `PROBE_TTL_FAIL_MS` next door in `harness/clawai-images`.
+ */
+const FAILED_READ_TTL_MS = 60_000;
+
+/**
+ * `expiresAt` is `Infinity` for an answer and a near-future stamp for a failed
+ * read. An answer needs no timer: config.yaml's mtime is a complete invalidator
+ * for it, because writing that file is the only thing that can change it.
+ */
+type Entry = { mtimeMs: number; value: string; expiresAt: number };
 const cache = new Map<string, Entry>();
 
 /** mtime of config.yaml, or null when it doesn't exist yet (fresh device). */
@@ -48,18 +71,38 @@ export async function hermesConfigGet(key: string, timeoutMs = 10_000): Promise<
   const mtime = await configMtime();
   if (mtime !== null) {
     const hit = cache.get(key);
-    if (hit && hit.mtimeMs === mtime) return hit.value;
+    if (hit && hit.mtimeMs === mtime && Date.now() < hit.expiresAt) return hit.value;
   }
   let value = "";
+  // Did the CLI ANSWER the question, or did the question fail? Verified on the
+  // live box: an unset key exits 1 with `Config key not set: <key>` on stderr,
+  // so a non-zero exit is the CLI saying "nothing is configured there" — an
+  // answer, and one the mtime correctly invalidates. A child that closed with
+  // no exit code at all was killed by a signal (OOM on a loaded Jetson) and
+  // told us nothing; `runHermesCli` rejects on a timeout, a missing binary and
+  // its own SIGKILL, which likewise tell us nothing about the key.
+  let answered = false;
   try {
     const r = await runHermesCli(["config", "get", key], { timeoutMs });
+    answered = typeof r.code === "number";
     if (r.code === 0) value = r.stdout.trim();
   } catch {
-    // hermes missing or timed out — fall through with "".
+    // hermes missing or timed out — fall through with "", uncached.
   }
   // Only cache against a real mtime. With no config file there is nothing to
   // invalidate against, so we would never notice the first write.
-  if (mtime !== null) cache.set(key, { mtimeMs: mtime, value });
+  //
+  // A failed read is held only for FAILED_READ_TTL_MS. Storing it the way an
+  // answer is stored was the bug: on a linked box config.yaml is never written
+  // again, so one slow moment removed the composer's attach button — and the
+  // image tools the agent advertises — until the web server restarted.
+  if (mtime !== null) {
+    cache.set(key, {
+      mtimeMs: mtime,
+      value,
+      expiresAt: answered ? Number.POSITIVE_INFINITY : Date.now() + FAILED_READ_TTL_MS,
+    });
+  }
   return value;
 }
 

--- a/src/lib/hermes-config-cache.ts
+++ b/src/lib/hermes-config-cache.ts
@@ -49,8 +49,14 @@ const FAILED_READ_TTL_MS = 60_000;
  * `expiresAt` is `Infinity` for an answer and a near-future stamp for a failed
  * read. An answer needs no timer: config.yaml's mtime is a complete invalidator
  * for it, because writing that file is the only thing that can change it.
+ *
+ * `mtimeMs` is `null` for the one entry shape that can exist without a config
+ * file: a failed read on a box that has none yet. Storing the absence as a key
+ * value rather than skipping the cache keeps the comparison below total — the
+ * first write to config.yaml turns `null` into a number and invalidates it, the
+ * same way any other change to the file does.
  */
-type Entry = { mtimeMs: number; value: string; expiresAt: number };
+type Entry = { mtimeMs: number | null; value: string; expiresAt: number };
 const cache = new Map<string, Entry>();
 
 /** mtime of config.yaml, or null when it doesn't exist yet (fresh device). */
@@ -69,10 +75,8 @@ async function configMtime(): Promise<number | null> {
  */
 export async function hermesConfigGet(key: string, timeoutMs = 10_000): Promise<string> {
   const mtime = await configMtime();
-  if (mtime !== null) {
-    const hit = cache.get(key);
-    if (hit && hit.mtimeMs === mtime && Date.now() < hit.expiresAt) return hit.value;
-  }
+  const hit = cache.get(key);
+  if (hit && hit.mtimeMs === mtime && Date.now() < hit.expiresAt) return hit.value;
   let value = "";
   // Did the CLI ANSWER the question, or did the question fail? Verified on the
   // live box: an unset key exits 1 with `Config key not set: <key>` on stderr,
@@ -89,14 +93,19 @@ export async function hermesConfigGet(key: string, timeoutMs = 10_000): Promise<
   } catch {
     // hermes missing or timed out — fall through with "", uncached.
   }
-  // Only cache against a real mtime. With no config file there is nothing to
-  // invalidate against, so we would never notice the first write.
+  // An ANSWER is only cached against a real mtime. With no config file there is
+  // nothing to invalidate against, so a `""` kept from before the box was set
+  // up would outlive the first write and we would never notice it.
   //
-  // A failed read is held only for FAILED_READ_TTL_MS. Storing it the way an
-  // answer is stored was the bug: on a linked box config.yaml is never written
-  // again, so one slow moment removed the composer's attach button — and the
-  // image tools the agent advertises — until the web server restarted.
-  if (mtime !== null) {
+  // A FAILED read is cached either way, because its invalidator is the clock,
+  // not the file — it is held for FAILED_READ_TTL_MS and then re-asked. Storing
+  // it the way an answer is stored was the bug: on a linked box config.yaml is
+  // never written again, so one slow moment removed the composer's attach
+  // button — and the image tools the agent advertises — until the web server
+  // restarted. Skipping it entirely on a box with no config file is the mirror
+  // mistake: a hanging `hermes` would then start a Python interpreter for every
+  // request, which is the cost this module exists to avoid.
+  if (mtime !== null || !answered) {
     cache.set(key, {
       mtimeMs: mtime,
       value,

--- a/src/tests/unit/hermes-config-cache.test.ts
+++ b/src/tests/unit/hermes-config-cache.test.ts
@@ -146,6 +146,40 @@ describe("hermesConfigGet", () => {
     expect(runHermesCli).toHaveBeenCalledTimes(2);
   });
 
+  it("still backs off a failed read before config.yaml exists", async () => {
+    // The mirror of the bug. An answer has nothing to invalidate it here, so it
+    // is not kept — but a FAILURE is invalidated by the clock, not by the file,
+    // and dropping it outright would start a Python interpreter per request on
+    // exactly the box most likely to have a broken `hermes`: an unset-up one.
+    mtimeMs = null;
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("");
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("");
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("");
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue(ok("gpt-4.1-mini"));
+    vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("gpt-4.1-mini");
+  });
+
+  it("drops a failure held from before config.yaml the moment the file appears", async () => {
+    // The backoff must not become its own stale probe: the customer linking is
+    // precisely the event these reads have to notice, and it writes the file.
+    mtimeMs = null;
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("image_gen.provider")).toBe("");
+
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    mtimeMs = 1_000; // first write to config.yaml — well inside the backoff.
+    expect(await hermesConfigGet("image_gen.provider")).toBe("clawai");
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+  });
+
   it("forgets everything when the cache is invalidated by hand", async () => {
     runHermesCli.mockResolvedValue(ok("clawai"));
     const { hermesConfigGet, invalidateHermesConfigCache } = await load();

--- a/src/tests/unit/hermes-config-cache.test.ts
+++ b/src/tests/unit/hermes-config-cache.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The memo around `hermes config get <key>`.
+ *
+ * Two facts about the live box (192.168.1.47, hermes 2026-08-27) set the shape
+ * of what follows, and both were measured rather than assumed:
+ *
+ *   - one `hermes config get` costs ~816 ms on an IDLE Jetson, because it
+ *     starts a Python interpreter. That is why the memo exists at all;
+ *   - an UNSET key is not an error. `hermes config get zzz.nope` exits 1 and
+ *     prints `Config key not set: zzz.nope` on stderr, while a set key exits 0
+ *     and prints the value. So a non-zero exit is the CLI ANSWERING "nothing is
+ *     configured there", and config.yaml's mtime is a correct invalidator for
+ *     it: the only thing that can make an unset key set is a write to that file.
+ *
+ * What is NOT an answer is a read that never finished — `runHermesCli` rejects
+ * on a timeout, on a missing binary, and when it has to SIGKILL the child, and
+ * a child killed by a signal comes back with `code: null`. Caching "" for those
+ * against the current mtime remembers a failed QUESTION as a negative ANSWER,
+ * and on a linked, stable box nothing ever rewrites config.yaml again, so the
+ * memo holds it until the web server restarts.
+ */
+
+const runHermesCli = vi.fn();
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli }));
+
+/** config.yaml's mtime, controlled by each test. `null` = no file yet. */
+let mtimeMs: number | null = 1_000;
+const stat = vi.fn(async () => {
+  if (mtimeMs === null) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  return { mtimeMs };
+});
+vi.mock("fs/promises", () => ({ default: { stat: () => stat() }, stat: () => stat() }));
+
+/** Matches `FAILED_READ_TTL_MS` in the module under test, with room to spare. */
+const PAST_THE_BACKOFF_MS = 61_000;
+
+async function load() {
+  vi.resetModules();
+  return import("@/lib/hermes-config-cache");
+}
+
+const ok = (stdout: string) => ({ code: 0, stdout, stderr: "" });
+/** What the real CLI answers for a key nobody has configured. */
+const notSet = (key: string) => ({ code: 1, stdout: "", stderr: `Config key not set: ${key}` });
+
+describe("hermesConfigGet", () => {
+  beforeEach(() => {
+    mtimeMs = 1_000;
+    runHermesCli.mockReset();
+    stat.mockClear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("asks the CLI once and serves the memo while config.yaml is unchanged", async () => {
+    runHermesCli.mockResolvedValue(ok("gpt-4.1-mini"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("gpt-4.1-mini");
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("gpt-4.1-mini");
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads once config.yaml has been rewritten", async () => {
+    runHermesCli.mockResolvedValue(ok(""));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("image_gen.provider")).toBe("");
+
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    mtimeMs = 2_000; // `hermes config set` — i.e. the customer linked.
+    expect(await hermesConfigGet("image_gen.provider")).toBe("clawai");
+  });
+
+  it("keeps the CLI's own 'not set' verdict memoised", async () => {
+    // Verified on the box: an unset key exits 1. That is an ANSWER, and the
+    // mtime is the right invalidator for it — re-spawning Python for it on
+    // every poll of /setup-api/ai-models/status is the cost the memo exists to
+    // avoid, and an unlinked box hits this path on nearly every key.
+    runHermesCli.mockResolvedValue(notSet("image_gen.provider"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("image_gen.provider")).toBe("");
+    expect(await hermesConfigGet("image_gen.provider")).toBe("");
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not remember a read that timed out as an answer", async () => {
+    // THE BUG. A 10 s timeout on a loaded Jetson used to be cached as "" against
+    // the CURRENT mtime, and on a linked box config.yaml is never written again
+    // — so one slow moment hid the vision route until the next restart.
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("");
+
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue(ok("gpt-4.1-mini"));
+    vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("gpt-4.1-mini");
+  });
+
+  it("does not remember a spawn failure as an answer", async () => {
+    runHermesCli.mockRejectedValue(new Error("Hermes is not installed on this device"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("model.provider")).toBe("");
+
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+    expect(await hermesConfigGet("model.provider")).toBe("clawai");
+  });
+
+  it("does not remember a child killed by a signal as an answer", async () => {
+    // An OOM-killed CLI closes with no exit code at all. It never told us
+    // anything about the key, so it must not be stored as if it had.
+    runHermesCli.mockResolvedValue({ code: null, stdout: "", stderr: "" });
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("image_gen.provider")).toBe("");
+
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+    expect(await hermesConfigGet("image_gen.provider")).toBe("clawai");
+  });
+
+  it("does not re-spawn the CLI for every caller while a read is failing", async () => {
+    // Forgetting the failure must not turn a hanging `hermes` into one Python
+    // start per request. The failure is held for a short backoff, then re-asked.
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("model.default")).toBe("");
+    expect(await hermesConfigGet("model.default")).toBe("");
+    expect(await hermesConfigGet("model.default")).toBe("");
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("still answers, uncached, before config.yaml exists", async () => {
+    // Fresh device: nothing to invalidate against, so every call asks again.
+    mtimeMs = null;
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    const { hermesConfigGet } = await load();
+    expect(await hermesConfigGet("model.provider")).toBe("clawai");
+    expect(await hermesConfigGet("model.provider")).toBe("clawai");
+    expect(runHermesCli).toHaveBeenCalledTimes(2);
+  });
+
+  it("forgets everything when the cache is invalidated by hand", async () => {
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    const { hermesConfigGet, invalidateHermesConfigCache } = await load();
+    expect(await hermesConfigGet("model.provider")).toBe("clawai");
+    invalidateHermesConfigCache();
+    expect(await hermesConfigGet("model.provider")).toBe("clawai");
+    expect(runHermesCli).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/tests/unit/hermes-features-probe.test.ts
+++ b/src/tests/unit/hermes-features-probe.test.ts
@@ -35,6 +35,9 @@ options:
                         Single query (non-interactive mode)
 `;
 
+/** Matches `PROBE_RETRY_BACKOFF_MS` in the module under test, with room to spare. */
+const PAST_THE_BACKOFF_MS = 61_000;
+
 async function load() {
   vi.resetModules();
   return import("@/lib/harness/hermes-features");
@@ -97,6 +100,99 @@ describe("hermesSupportsImages", () => {
     ]);
     expect(answers).toEqual([true, true, true]);
     expect(await hermesSupportsImages()).toBe(true);
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a definitive answer for the process lifetime", async () => {
+    // `hermes chat --help` exits 0 and prints the option list (verified on the
+    // live box, 2026-08-27). Its answer is a fact about the INSTALLED checkout,
+    // and an update replaces the checkout and restarts the web server — so a
+    // help text that really lacks the flag must not be re-asked on a timer.
+    runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITHOUT_IMAGE, stderr: "" });
+    const { hermesSupportsImages } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+
+    vi.useFakeTimers();
+    try {
+      runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+      vi.setSystemTime(Date.now() + 10 * 60_000);
+      expect(await hermesSupportsImages()).toBe(false);
+      expect(runHermesCli).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not remember a probe that timed out as an answer", async () => {
+    // THE BUG. The memo is the in-flight PROMISE, so a `false` produced by a
+    // 30 s timeout on a loaded Jetson was indistinguishable from a `hermes`
+    // that genuinely lacks the flag — and both lived for the whole process
+    // lifetime, hiding the attach button on a working box until a restart.
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesSupportsImages } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+
+    vi.useFakeTimers();
+    try {
+      runHermesCli.mockReset();
+      runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+      vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+      expect(await hermesSupportsImages()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not remember a child killed by a signal as an answer", async () => {
+    // An OOM-killed CLI closes with no exit code at all. It never printed the
+    // help text, so it never answered the question.
+    runHermesCli.mockResolvedValue({ code: null, stdout: "", stderr: "" });
+    const { hermesSupportsImages } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+
+    vi.useFakeTimers();
+    try {
+      runHermesCli.mockReset();
+      runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+      vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+      expect(await hermesSupportsImages()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("forgets a probe that threw before it ever awaited", async () => {
+    // A spawn that fails synchronously runs the catch BEFORE the memo has been
+    // assigned, so bookkeeping done through the module-level slot would be
+    // undone by the assignment that follows it and the failure would be
+    // remembered for the whole process after all. The entry is mutated in
+    // place precisely so that ordering cannot matter.
+    runHermesCli.mockImplementation(() => {
+      throw new Error("spawn EACCES");
+    });
+    const { hermesSupportsImages } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+
+    vi.useFakeTimers();
+    try {
+      runHermesCli.mockReset();
+      runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+      vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+      expect(await hermesSupportsImages()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not re-spawn the probe for every caller while it is failing", async () => {
+    // Forgetting the failure must not turn a broken `hermes` into a Python
+    // start per request: that is the cost the memo exists to avoid. The failure
+    // is held for a short backoff, and only then re-asked.
+    runHermesCli.mockResolvedValue({ code: null, stdout: "", stderr: "" });
+    const { hermesSupportsImages } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+    expect(await hermesSupportsImages()).toBe(false);
+    expect(await hermesSupportsImages()).toBe(false);
     expect(runHermesCli).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
## The defect

Two files, one rule: **it is correct to cache a definitive answer and wrong to cache a failed question.**

`src/lib/harness/hermes-features.ts` memoised the in-flight **promise** of `hermes chat --help`. A `false` produced by a 30 s timeout on a loaded Jetson was therefore indistinguishable from a `hermes` that genuinely lacks `--image`, and both lived for the whole process lifetime — the only invalidation, `resetHermesFeatureProbe`, is documented as a test seam and has no production caller.

`src/lib/hermes-config-cache.ts` had the same shape a level down: `value` was overwritten only on exit 0, the `catch` swallowed a timeout or a spawn error the same way, and the `""` that resulted was then stored against config.yaml's **current** mtime. On a linked, stable box nothing rewrites config.yaml again, so that `""` is permanent.

The consequence lands on the two probes `hermes-features` deliberately does *not* memoise (see its own comment) precisely so they flip the moment a customer links:

- `hermesHasVisionRoute()` reads `auxiliary.vision.model` through the memo. One timed-out read sets `canAttachImages` false in `capabilitiesFor()` and removes the composer's attach button **on a box that works**, until the web server restarts.
- `hermesAgentDrawsImages()` reads `image_gen.provider` through the same memo, and `applyClawaiToHermes` calls `refreshHermesImageTools(couldDrawBefore, await hermesAgentDrawsImages())` immediately after its writes — so a poisoned `""` means the image tools are never re-advertised at the exact moment the customer links.

Both neighbouring probes in this feature (`clawaiImageRouteReachable`, `hermesCanStreamTurns`) already carry short failure TTLs for exactly this reason.

## What the box actually says

The fix turns on telling an answer apart from a failure, so the distinction was measured on the Hermes box rather than assumed:

```
$ hermes config get auxiliary.vision.model   →  gpt-5.6-luna            exit 0
$ hermes config get zzz.nope.nope            →  (stderr) Config key not set: zzz.nope.nope   exit 1
$ hermes chat --help                         →  option list incl. --image                    exit 0
$ hermes chat --nosuchflag                   →  (argparse)                                   exit 2
$ hermes config get …                        →  816 ms, three runs, on an IDLE box
```

So a **numeric exit code is the CLI answering** — including "nothing is configured there", which config.yaml's mtime correctly invalidates, because a write to that file is the only thing that can change it. What is *not* an answer is `runHermesCli` rejecting (timeout, missing binary, its own SIGKILL) or a child that closed with **no exit code at all**, i.e. killed by a signal — an OOM on a loaded Jetson.

## The change

Both modules keep an answer exactly as long as they kept it before — process lifetime for the flag probe, config.yaml's mtime for the config read — and hold a *failure* for a 60 s backoff before re-asking. The backoff is not decoration: dropping the failure outright would turn a hanging `hermes` into one ~800 ms Python start per request, which is the cost these memos exist to avoid. 60 s matches `PROBE_TTL_FAIL_MS` next door in `harness/clawai-images.ts`.

The probe's memo is now a stable entry object mutated in place rather than a promise reassigned through the module-level slot. That matters: a `runHermesCli` that throws *before* its first `await` runs the `catch` synchronously, i.e. **before** the assignment to the slot, so bookkeeping written through the slot would be silently undone and the failure remembered forever after all. There is a test for that shape.

## Tests

Written red-first against unmodified `origin/beta`:

- **RED: 7 failed | 20 passed (27)**
- **GREEN: 27 passed (27)**

The seven that were red are the "a failed question was remembered as an answer" cases: timed-out read, spawn failure, signal-killed child, and a failed read on a box with no config.yaml (config cache); timed-out probe, signal-killed probe, and a probe that threw before its first await (feature probe).

Guards against the recurring shapes this repo keeps producing, all of them tested explicitly rather than assumed:

- **a probe taken once at startup that never refreshes** — a definitive answer is asserted to survive a ten-minute clock jump with exactly one spawn, and a failed one is asserted to be re-asked after the backoff;
- **success read off an exit code without checking the outcome** — the `Config key not set` exit-1 answer is asserted to stay memoised, so "don't cache failures" cannot quietly become "re-spawn Python for every unset key on every unlinked box";
- **an error path reporting failure over something that succeeded** — the caching decision is driven by whether the CLI answered, never by whether the value came back empty; a genuine empty value at exit 0 is still cached as the answer it is.

The last of those came out of the review. The failure path originally skipped the cache entirely when config.yaml did not exist yet, which is the mirror of the bug: an unset-up box is exactly where a missing or hanging `hermes` is likely, and it paid one Python start per request with no backoff at all. An *answer* still needs a real mtime to be invalidated against and is still not kept without the file; a *failure* is invalidated by the clock instead, so it is stored with `mtimeMs: null` and the hit comparison is now total, which means the first write to config.yaml drops it. Pinned by a test, so the backoff cannot become its own stale probe at the exact moment the customer links.

`bun run lint` clean on the changed files. Typecheck unchanged from the beta baseline: 24 pre-existing errors before and after, none in these files.

## Behaviour change

On a working box, a single slow or killed `hermes` call no longer hides the attach button and the agent's image tools until the next restart — it hides them for at most 60 s. Nothing else about when a capability is offered changes; both modules still fail closed while they do not know.

Closes MR-08, MR-11 and MR-10, which reported the same rule at two call sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when detecting Hermes capabilities and reading configuration.
  * Definitive results are now retained, while temporary failures automatically retry after a short delay.
  * Correctly handles timeouts, unavailable commands, interrupted processes, and configuration changes.
  * Prevents repeated failed checks during the retry period, improving responsiveness and stability.

* **Tests**
  * Added comprehensive coverage for caching, retries, configuration changes, missing files, interrupted processes, and manual cache invalidation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

