### PR TITLE
fix: answer honestly when a skill install cannot be rolled back

### DIFF
--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -194,6 +194,12 @@ interface InstallRefusal {
   missingFiles?: string[];
   /** `unresolved`: the ids the device's "did you mean" list offered instead. */
   candidates?: string[];
+  /** `rollback_incomplete`: what the failed undo left behind. */
+  leftover?: {
+    /** The store still lists it — so the store is where it can be removed. */
+    lockEntry?: boolean;
+    directory?: "present" | "absent" | "unknown";
+  };
   warning?: {
     verdict?: string;
     trust?: string;
@@ -319,12 +325,18 @@ function refusalToToolError(err: unknown): ToolError | null {
     // lock entry makes the installer say "already installed" and exit 0 without
     // fetching anything, so the next attempt fails on the files that are not
     // there. A person has to remove it first.
+    // A leftover the store cannot see cannot be removed from the store, so the
+    // advice has to follow the same branch the route's message does.
+    const listed = payload.leftover?.lockEntry !== false;
     return new ToolError(
       "CONFLICT",
       payload.error
         ?? "The device refused the install and could not fully undo it; the skill is listed but not installed.",
       "Do NOT retry and do NOT ask the user to confirm — neither can succeed while the leftover is there. "
-        + "Tell the user to remove that skill in Settings -> Skills, and to try the install again afterwards.",
+        + (listed
+          ? "Tell the user to remove that skill in Settings -> Skills, and to try the install again afterwards."
+          : "The skill is NOT in Settings -> Skills, so it cannot be removed there: tell the user the "
+            + "leftover folder has to be deleted on the device before this skill can be installed again."),
     );
   }
   if (payload.code === "incomplete_install") {

--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -313,6 +313,20 @@ function refusalToToolError(err: unknown): ToolError | null {
       "Do not retry. Tell the user the device already has that skill built in; built-in skills update with the device.",
     );
   }
+  if (payload.code === "rollback_incomplete") {
+    // The device refused the install AND could not take back what the installer
+    // had already done. Retrying is the one thing that cannot work: the leftover
+    // lock entry makes the installer say "already installed" and exit 0 without
+    // fetching anything, so the next attempt fails on the files that are not
+    // there. A person has to remove it first.
+    return new ToolError(
+      "CONFLICT",
+      payload.error
+        ?? "The device refused the install and could not fully undo it; the skill is listed but not installed.",
+      "Do NOT retry and do NOT ask the user to confirm — neither can succeed while the leftover is there. "
+        + "Tell the user to remove that skill in Settings -> Skills, and to try the install again afterwards.",
+    );
+  }
   if (payload.code === "incomplete_install") {
     const missing = (payload.missingFiles ?? []).slice(0, 5).join(", ");
     return new ToolError(

--- a/src/app/setup-api/hermes/skills/install/route.ts
+++ b/src/app/setup-api/hermes/skills/install/route.ts
@@ -225,14 +225,47 @@ export async function POST(request: Request) {
     : null;
 
   if (warning && !confirmDangerous) {
-    await rollback(lockName, entry);
+    const undo = await rollback(lockName, entry);
+    // A refusal we could not carry out is not the refusal the caller expects:
+    // answering `dangerous_skill` here would invite a confirmation that walks
+    // straight into the completeness check below, on a skill whose files this
+    // rollback has already removed.
+    if (!undo.clean) {
+      return await rollbackIncomplete(undo, {
+        id,
+        name: lockName,
+        cause: "This skill did not pass the device's security scan.",
+        source: entry?.source,
+        trust: entry?.trust_level,
+        scanVerdict: verdict,
+        findingCount: findings.length,
+        warning,
+      });
+    }
     return await askTheOwner(warning, { id, findingCount: findings.length });
   }
 
   // ── 4. Did every file actually land? ─────────────────────────────────────
   const completeness = await verifyAndRepair(entry, record);
   if (completeness && completeness.missing.length > 0) {
-    await rollback(lockName, entry);
+    const undo = await rollback(lockName, entry);
+    if (!undo.clean) {
+      return await rollbackIncomplete(undo, {
+        id,
+        name: lockName,
+        // Deliberately not "the download was incomplete": the same branch is
+        // reached when the installer met a lock entry a previous rollback could
+        // not remove, exited 0 without fetching anything, and there was no
+        // download to blame. What is true in both cases is that the files are
+        // not there.
+        cause: `Some of "${lockName}"'s files are missing from the device, so it was not installed.`,
+        source: entry?.source,
+        trust: entry?.trust_level,
+        scanVerdict: verdict,
+        missingFiles: completeness.missing.slice(0, 20),
+        warning,
+      });
+    }
     await auditSkillInstall({
       action: "install-incomplete",
       id,
@@ -500,16 +533,41 @@ async function findShadowConflict(
   return null;
 }
 
+/** What a rollback ACHIEVED, as opposed to what the CLI printed about it. */
+interface RollbackVerdict {
+  /** Neither a lock entry nor a skill directory was left behind. */
+  clean: boolean;
+  /** The hub lock still lists the skill — every store surface calls it installed. */
+  lockEntry: boolean;
+  /** The skill directory is still on disk — the agent would load it. */
+  dir: boolean;
+}
+
 /**
- * Undo an install this route has decided not to keep.
+ * Undo an install this route has decided not to keep, and report what is left.
  *
  * `hermes skills uninstall` is what removes the LOCK entry, so it runs first
  * and its result is deliberately not trusted: the CLI prints its refusals and
  * still exits 0. The directory removal is the belt to that braces — a skill
  * directory left behind would be loaded by the agent even with no lock entry,
  * which is the exact failure this whole route exists to prevent.
+ *
+ * TASK-547 / PR #510 gave the uninstall ROUTE the post-condition that follows
+ * from that distrust — a removal is only real when the lock entry is gone
+ * afterwards — and this rollback, which drives the same command, kept inferring
+ * success from having called it. It could not: `runHermesCli` throws on the
+ * 30 s timeout a loaded Jetson hits mid-install and the throw was swallowed with
+ * a console line, `removeSkillDir` returns false for a path the validator
+ * refuses and its answer was discarded, and nothing re-read the lock. A refused
+ * skill then stayed in the lock, `enumerateInstalledSkills` listed it as
+ * installed from the hub, and the route said it had refused the install.
+ *
+ * So: read the outcome, both halves of it, and let the caller answer honestly.
  */
-async function rollback(lockName: string, entry: HubLockEntry | undefined): Promise<void> {
+async function rollback(
+  lockName: string,
+  entry: HubLockEntry | undefined,
+): Promise<RollbackVerdict> {
   try {
     await runHermesCli(["skills", "uninstall", lockName], {
       timeoutMs: UNINSTALL_TIMEOUT_MS,
@@ -519,8 +577,96 @@ async function rollback(lockName: string, entry: HubLockEntry | undefined): Prom
     console.error("[hermes skills install] rollback uninstall failed", err);
   }
   const installPath = entry?.install_path;
-  if (installPath) await removeSkillDir(SKILLS_DIR, installPath);
+  let dir = false;
+  if (installPath) {
+    // Two things can leave the directory behind, so both are checked: a path
+    // `removeSkillDir` will not resolve (it answers false and removes nothing),
+    // and a removal it believes it made — `fs.rm` on a tree it cannot fully
+    // traverse, the root-owned subdirectory case this device family produces.
+    const removed = await removeSkillDir(SKILLS_DIR, installPath);
+    const abs = lockInstallDir(entry);
+    dir = !removed || (abs !== null && (await pathExists(abs)));
+  }
   invalidateInstalledCache();
+  // Read the lock AFTER the CLI, never before: it is the only thing that says
+  // whether the store will still list this skill.
+  const lockEntry = await isInHubLock(lockName, entry?.identifier);
+  return { clean: !lockEntry && !dir, lockEntry, dir };
+}
+
+async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * The answer for an install this route refused and could not undo.
+ *
+ * Distinct from both refusals it replaces, because the device is in a state
+ * neither of them describes and the next step is neither of theirs: there is
+ * nothing to confirm (`requiresConfirmation` is false — confirming re-enters the
+ * completeness check on a skill whose files are gone) and nothing to retry until
+ * the leftover is removed. The scan warning and the missing-file list are still
+ * carried, so no surface loses what it already showed.
+ */
+async function rollbackIncomplete(
+  left: RollbackVerdict,
+  ctx: {
+    id: string;
+    name: string;
+    /** Why the install was being undone, as a finished sentence. */
+    cause: string;
+    source?: string;
+    trust?: string;
+    scanVerdict?: string;
+    findingCount?: number;
+    missingFiles?: string[];
+    warning?: SkillDangerWarning | null;
+  },
+): Promise<NextResponse> {
+  const leftover = left.lockEntry
+    ? left.dir
+      ? `"${ctx.name}" is still listed in the Skills store and its files are still on the device`
+      : `"${ctx.name}" is still listed in the Skills store although its files were removed`
+    : `"${ctx.name}" is no longer listed in the Skills store but its files are still on the device`;
+  console.error(
+    "[hermes skills install] rollback incomplete",
+    ctx.name,
+    "lockEntry:",
+    left.lockEntry,
+    "dir:",
+    left.dir,
+  );
+  await auditSkillInstall({
+    action: "install-rollback-incomplete",
+    id: ctx.id,
+    name: ctx.name,
+    source: ctx.source,
+    trust: ctx.warning?.trust ?? ctx.trust,
+    verdict: ctx.scanVerdict,
+    findingCount: ctx.findingCount,
+    missingFiles: ctx.missingFiles,
+    capabilities: ctx.warning?.capabilities.map((c) => c.id),
+    severities: ctx.warning?.severityCounts,
+  });
+  return NextResponse.json(
+    {
+      error:
+        `${ctx.cause} The device could not fully undo the install: ${leftover}. `
+        + `Remove "${ctx.name}" from the Skills store, then try again.`,
+      code: "rollback_incomplete",
+      requiresConfirmation: false,
+      name: ctx.name,
+      leftover: { lockEntry: left.lockEntry, directory: left.dir },
+      ...(ctx.missingFiles?.length ? { missingFiles: ctx.missingFiles } : {}),
+      ...(ctx.warning ? { warning: ctx.warning } : {}),
+    },
+    { status: 409 },
+  );
 }
 
 interface VerifiedCompleteness extends CompletenessReport {

--- a/src/app/setup-api/hermes/skills/install/route.ts
+++ b/src/app/setup-api/hermes/skills/install/route.ts
@@ -533,14 +533,23 @@ async function findShadowConflict(
   return null;
 }
 
+/**
+ * What the skill directory is doing after a rollback.
+ *
+ * Three states, not two, because "not known to be there" is not "gone": a lock
+ * entry that names no `install_path` gives the removal nothing to aim at, so
+ * nothing about the directory was checked and nothing about it may be claimed.
+ */
+type RollbackDir = "present" | "absent" | "unknown";
+
 /** What a rollback ACHIEVED, as opposed to what the CLI printed about it. */
 interface RollbackVerdict {
-  /** Neither a lock entry nor a skill directory was left behind. */
+  /** No lock entry survived and no directory is known to have. */
   clean: boolean;
   /** The hub lock still lists the skill — every store surface calls it installed. */
   lockEntry: boolean;
   /** The skill directory is still on disk — the agent would load it. */
-  dir: boolean;
+  dir: RollbackDir;
 }
 
 /**
@@ -577,7 +586,10 @@ async function rollback(
     console.error("[hermes skills install] rollback uninstall failed", err);
   }
   const installPath = entry?.install_path;
-  let dir = false;
+  // `unknown` until something actually looks. With no `install_path` there is
+  // nothing to look at, and the honest answer is not `absent`: the CLI may well
+  // have left a directory behind at a location this route was never told.
+  let dir: RollbackDir = "unknown";
   if (installPath) {
     // Two things can leave the directory behind, so both are checked: a path
     // `removeSkillDir` will not resolve (it answers false and removes nothing),
@@ -585,13 +597,18 @@ async function rollback(
     // traverse, the root-owned subdirectory case this device family produces.
     const removed = await removeSkillDir(SKILLS_DIR, installPath);
     const abs = lockInstallDir(entry);
-    dir = !removed || (abs !== null && (await pathExists(abs)));
+    const stillThere = !removed || (abs !== null && (await pathExists(abs)));
+    dir = stillThere ? "present" : "absent";
   }
   invalidateInstalledCache();
   // Read the lock AFTER the CLI, never before: it is the only thing that says
   // whether the store will still list this skill.
   const lockEntry = await isInHubLock(lockName, entry?.identifier);
-  return { clean: !lockEntry && !dir, lockEntry, dir };
+  // `unknown` alone is not a failure. The store lists what the lock lists, so a
+  // vanished lock entry means the customer sees nothing and has nothing to act
+  // on; refusing here would report a failure over a rollback that did its job —
+  // the mirror image of the bug this whole change exists to fix.
+  return { clean: !lockEntry && dir !== "present", lockEntry, dir };
 }
 
 async function pathExists(p: string): Promise<boolean> {
@@ -628,14 +645,27 @@ async function rollbackIncomplete(
     warning?: SkillDangerWarning | null;
   },
 ): Promise<NextResponse> {
+  // Say only what was actually established. `unknown` is its own sentence
+  // because the alternative — calling it removed — is the false-success this
+  // change is here to stop telling.
   const leftover = left.lockEntry
-    ? left.dir
+    ? left.dir === "present"
       ? `"${ctx.name}" is still listed in the Skills store and its files are still on the device`
-      : `"${ctx.name}" is still listed in the Skills store although its files were removed`
-    : `"${ctx.name}" is no longer listed in the Skills store but its files are still on the device`;
+      : left.dir === "absent"
+        ? `"${ctx.name}" is still listed in the Skills store although its files were removed`
+        : `"${ctx.name}" is still listed in the Skills store, and the entry names no location, so whether its files are still on the device could not be checked`
+    : `"${ctx.name}" is no longer listed in the Skills store, but its files are still on the device`;
+  // A leftover the store cannot see is a leftover the store cannot remove, so
+  // the two states get the two different next steps they actually have.
+  const nextStep = left.lockEntry
+    ? `Remove "${ctx.name}" from the Skills store, then try again.`
+    : `It is not in the Skills store to remove — the leftover folder has to be deleted on the device `
+      + `before this skill can be installed again.`;
+  // JSON.stringify, not the bare name: this is caller-derived and a log line is
+  // parsed by whoever reads the journal. Escaped, it cannot forge a second line.
   console.error(
     "[hermes skills install] rollback incomplete",
-    ctx.name,
+    JSON.stringify(ctx.name),
     "lockEntry:",
     left.lockEntry,
     "dir:",
@@ -655,9 +685,7 @@ async function rollbackIncomplete(
   });
   return NextResponse.json(
     {
-      error:
-        `${ctx.cause} The device could not fully undo the install: ${leftover}. `
-        + `Remove "${ctx.name}" from the Skills store, then try again.`,
+      error: `${ctx.cause} The device could not fully undo the install: ${leftover}. ${nextStep}`,
       code: "rollback_incomplete",
       requiresConfirmation: false,
       name: ctx.name,

--- a/src/lib/hermes-skill-audit.ts
+++ b/src/lib/hermes-skill-audit.ts
@@ -43,6 +43,8 @@ export interface SkillAuditRecord {
     /** The device's own installer refused it outright — no confirmation overrides this one. */
     | 'install-blocked-by-device'
     | 'install-incomplete'
+    /** The install was refused and the device could not undo it — see the route. */
+    | 'install-rollback-incomplete'
     | 'install-name-conflict';
   /** Registry identifier the owner asked for. */
   id: string;

--- a/src/tests/routes/hermes/skills-install-rollback.test.ts
+++ b/src/tests/routes/hermes/skills-install-rollback.test.ts
@@ -1,0 +1,378 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The install route's ROLLBACK has to be as distrustful of the CLI as the
+ * uninstall route is.
+ *
+ * PR #510 established the post-condition for `hermes skills uninstall`: the
+ * command exits 0 whether it removed the skill or refused to, so a removal is
+ * only real when the hub lock entry is gone afterwards. The install route drives
+ * exactly the same command from `rollback()` and did not apply it — it ran the
+ * uninstall, swallowed a thrown timeout with a console line, threw away
+ * `removeSkillDir`'s boolean and never re-read the lock.
+ *
+ * The end state on a loaded Jetson: the scan gate refuses a skill, the rollback
+ * cannot undo the install, and the route still answers "this skill did not pass
+ * the device's security scan" — while the lock entry it failed to remove keeps
+ * the refused skill in the installed list (enumerateInstalledSkills iterates
+ * every lock entry unconditionally). The store says installed, the API says
+ * refused, and the retry that follows can never succeed.
+ *
+ * The CLI is faked, but faked FAITHFULLY: the fake writes and deletes the same
+ * lock entries and directories the real one does, and refuses in the two ways
+ * the real one refuses — a timeout that throws, and an exit 0 that removes
+ * nothing.
+ */
+
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: vi.fn(async () => "hermes"),
+  HERMES_BIN: "/home/clawbox/.local/bin/hermes",
+}));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: vi.fn() }));
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet: vi.fn(async () => ""),
+  hermesConfigGetMany: vi.fn(async () => ({})),
+  invalidateHermesConfigCache: vi.fn(),
+}));
+vi.mock("@/lib/hermes-skill-index", () => ({ getCatalogRecord: vi.fn(async () => undefined) }));
+
+import { runHermesCli } from "@/lib/hermes-cli";
+import { getCatalogRecord } from "@/lib/hermes-skill-index";
+
+const mockCli = vi.mocked(runHermesCli);
+const mockRecord = vi.mocked(getCatalogRecord);
+
+let hermesHome: string;
+let clawboxRoot: string;
+
+function skillsDir(): string {
+  return path.join(hermesHome, "skills");
+}
+
+async function readLock(): Promise<Record<string, Record<string, unknown>>> {
+  const raw = await fs.readFile(path.join(skillsDir(), ".hub", "lock.json"), "utf8");
+  return (JSON.parse(raw) as { installed: Record<string, Record<string, unknown>> }).installed;
+}
+
+async function writeLock(installed: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(path.join(skillsDir(), ".hub"), { recursive: true });
+  await fs.writeFile(
+    path.join(skillsDir(), ".hub", "lock.json"),
+    JSON.stringify({ version: 1, installed }),
+  );
+}
+
+async function exists(p: string): Promise<boolean> {
+  return fs.access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  hermesHome = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-hermes-"));
+  clawboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-root-"));
+  process.env.HERMES_HOME = hermesHome;
+  process.env.CLAWBOX_ROOT = clawboxRoot;
+  await fs.mkdir(skillsDir(), { recursive: true });
+  await writeLock({});
+  mockRecord.mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  delete process.env.HERMES_HOME;
+  delete process.env.CLAWBOX_ROOT;
+  await fs.rm(hermesHome, { recursive: true, force: true });
+  await fs.rm(clawboxRoot, { recursive: true, force: true });
+});
+
+async function install(body: Record<string, unknown>) {
+  const { POST } = await import("@/app/setup-api/hermes/skills/install/route");
+  const res = await POST(
+    new Request("http://localhost/setup-api/hermes/skills/install", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, never> };
+}
+
+/** How the faked `hermes skills uninstall` behaves — all three are real. */
+type UninstallBehaviour =
+  /** Removes the lock entry and the directory. */
+  | "works"
+  /** The 30 s timeout on a loaded Jetson: runHermesCli throws. */
+  | "throws"
+  /** Its documented habit — prints a refusal, removes nothing, exits 0. */
+  | "exit0-noop";
+
+function fakeHermes(opts: {
+  name: string;
+  /** Where the fake writes the files. */
+  installPath: string;
+  /** What the lock records, when that differs from where the files went. */
+  lockInstallPath?: string;
+  files: Record<string, string>;
+  lock: Record<string, unknown>;
+  uninstall: UninstallBehaviour;
+}) {
+  mockCli.mockImplementation(async (args: string[]) => {
+    if (args[1] === "install") {
+      const lock = await readLock();
+      // The installer will not write over its own lock entry: it says the skill
+      // is already there and exits 0, whatever is or is not on disk.
+      if (Object.prototype.hasOwnProperty.call(lock, opts.name)) {
+        return { code: 0, stdout: `Skill '${opts.name}' is already installed\n`, stderr: "" };
+      }
+      const dir = path.join(skillsDir(), opts.installPath);
+      for (const [rel, content] of Object.entries(opts.files)) {
+        const abs = path.join(dir, rel);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, content);
+      }
+      lock[opts.name] = {
+        install_path: opts.lockInstallPath ?? opts.installPath,
+        files: Object.keys(opts.files),
+        ...opts.lock,
+      };
+      await writeLock(lock);
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    if (args[1] === "uninstall") {
+      if (opts.uninstall === "throws") {
+        throw new Error("hermes skills uninstall timed out after 30000ms");
+      }
+      if (opts.uninstall === "exit0-noop") {
+        return {
+          code: 0,
+          stdout: `'${args[2]}' is not a hub-installed skill (may be a builtin)\n`,
+          stderr: "",
+        };
+      }
+      const lock = await readLock();
+      delete lock[args[2]];
+      await writeLock(lock);
+      // The CLI removes the directory its OWN lock entry names, and, like the
+      // route, will not delete a path that escapes the skills tree.
+      const recorded = path.resolve(skillsDir(), opts.lockInstallPath ?? opts.installPath);
+      if (recorded.startsWith(skillsDir() + path.sep)) {
+        await fs.rm(recorded, { recursive: true, force: true });
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+}
+
+const DANGEROUS_SCAN = {
+  verdict: "dangerous",
+  scanner_version: "1.4.0",
+  findings: [
+    {
+      pattern_id: "agent-instruction-overwrite",
+      severity: "critical",
+      category: "persistence",
+      file: "SKILL.md",
+      line: 308,
+      description: "- **Agent instructions (prompts, AGENTS.md)**",
+    },
+  ],
+};
+
+function fakeDangerousInstall(uninstall: UninstallBehaviour, over: Record<string, unknown> = {}) {
+  fakeHermes({
+    name: "simple-english",
+    installPath: "creative/simple-english",
+    files: { "SKILL.md": "---\nname: simple-english\n---\nplain english\n" },
+    lock: {
+      identifier: "official/creative/simple-english",
+      source: "official",
+      trust_level: "builtin",
+      scan_verdict: "dangerous",
+      scan_provenance: DANGEROUS_SCAN,
+    },
+    uninstall,
+    ...over,
+  });
+}
+
+// ── The scan gate cannot claim a clean refusal it did not make ──────────────
+
+describe("a rollback the device could not complete is not a plain refusal", () => {
+  it("says the entry survived instead of answering the ordinary security-scan 409", async () => {
+    fakeDangerousInstall("throws");
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    // The lock entry is the whole problem: it is still there.
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+
+    expect(body.code).not.toBe("dangerous_skill");
+    expect(body.code).toBe("rollback_incomplete");
+    expect(status).toBe(409);
+    // Nothing may invite a confirmation: confirming walks into the 502 below.
+    expect(body.requiresConfirmation).not.toBe(true);
+    expect(String(body.error)).toMatch(/listed/i);
+    expect(String(body.error)).toMatch(/remove/i);
+    // The warning is still carried, so the store can still say WHAT was refused.
+    expect(body.warning).toBeTruthy();
+  });
+
+  it("the survivor is a real phantom — the installed list shows the refused skill", async () => {
+    fakeDangerousInstall("throws");
+    await install({ id: "official/creative/simple-english" });
+
+    const { enumerateInstalledSkills } = await import("@/lib/hermes-skills-server");
+    const listed = (await enumerateInstalledSkills()).find((s) => s.id === "simple-english");
+    // This is what the customer sees while the API says the install was refused,
+    // and it is why the answer above has to name it.
+    expect(listed).toMatchObject({ origin: "hub" });
+    // …and the skill is not actually on disk.
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english"))).toBe(false);
+  });
+
+  it("does not blame the download when the retry meets the leftover entry", async () => {
+    fakeDangerousInstall("throws");
+    const first = await install({ id: "official/creative/simple-english" });
+    expect(first.status).toBe(409);
+
+    // The trap: the installer sees its own lock entry, exits 0 without writing
+    // anything, `landed` is true, the completeness check finds no SKILL.md — and
+    // the route told the customer "The download was incomplete".
+    const retry = await install({
+      id: "official/creative/simple-english",
+      confirmDangerous: true,
+    });
+    expect(retry.body.code).not.toBe("incomplete_install");
+    expect(String(retry.body.error)).not.toMatch(/download was incomplete/i);
+    expect(retry.body.code).toBe("rollback_incomplete");
+  });
+
+  it("reports the leftover when the CLI exits 0 having removed nothing", async () => {
+    // No install_path in the lock entry, so the belt-and-braces directory
+    // removal has nothing to aim at either: the exit code is the ONLY thing
+    // that said this rollback worked, and it lied.
+    fakeDangerousInstall("exit0-noop", { lockInstallPath: "" });
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(status).toBe(409);
+    expect(body.code).toBe("rollback_incomplete");
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+    // The directory the agent would load is still there — the exact thing the
+    // rollback exists to prevent.
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english", "SKILL.md"))).toBe(
+      true,
+    );
+  });
+
+  it("reports a directory the rollback could not remove even when the lock is clean", async () => {
+    // A lock entry whose install_path the path validator refuses (#510 names
+    // this case for uninstall): the CLI drops the entry, `removeSkillDir`
+    // resolves nothing and returns false, and the files stay where the agent
+    // reads them.
+    fakeDangerousInstall("works", {
+      installPath: "creative/simple-english",
+      lockInstallPath: "creative/../../escape",
+    });
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(await readLock()).toEqual({});
+    expect(status).toBe(409);
+    expect(body.code).toBe("rollback_incomplete");
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english", "SKILL.md"))).toBe(
+      true,
+    );
+  });
+
+  it("audit-logs the incomplete rollback rather than a clean refusal", async () => {
+    fakeDangerousInstall("throws");
+    await install({ id: "official/creative/simple-english" });
+
+    const { readSkillAuditLog } = await import("@/lib/hermes-skill-audit");
+    const log = await readSkillAuditLog();
+    expect(log.map((r) => r.action)).toContain("install-rollback-incomplete");
+    expect(log[0]).toMatchObject({
+      id: "official/creative/simple-english",
+      name: "simple-english",
+      verdict: "dangerous",
+    });
+  });
+});
+
+// ── …and a rollback that DID work must not be reported as a failure ─────────
+
+describe("a rollback that worked keeps the honest refusal it already had", () => {
+  it("still answers the plain security-scan 409 when the undo is complete", async () => {
+    fakeDangerousInstall("works");
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(status).toBe(409);
+    expect(body).toMatchObject({ code: "dangerous_skill", requiresConfirmation: true });
+    expect(await readLock()).toEqual({});
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english"))).toBe(false);
+  });
+
+  it("still installs on the confirmed retry after a clean rollback", async () => {
+    fakeDangerousInstall("works");
+    expect((await install({ id: "official/creative/simple-english" })).status).toBe(409);
+    const second = await install({
+      id: "official/creative/simple-english",
+      confirmDangerous: true,
+    });
+    expect(second.status).toBe(200);
+    expect(second.body).toMatchObject({ ok: true, name: "simple-english" });
+  });
+
+  it("still blames the download when an incomplete install rolls back cleanly", async () => {
+    // The other caller of rollback(): a skill whose SKILL.md names files that
+    // were never fetched. The undo works, so the answer must stay the one that
+    // describes the real cause.
+    fakeHermes({
+      name: "algorithmic-art",
+      installPath: "algorithmic-art",
+      files: {
+        "SKILL.md": "---\nname: algorithmic-art\n---\nSee the [viewer](templates/viewer.html).\n",
+      },
+      lock: {
+        identifier: "x/algorithmic-art",
+        source: "clawhub",
+        trust_level: "community",
+        scan_verdict: "safe",
+      },
+      uninstall: "works",
+    });
+
+    const { status, body } = await install({ id: "x/algorithmic-art" });
+    expect(status).toBe(502);
+    expect(body).toMatchObject({ code: "incomplete_install" });
+    expect(await readLock()).toEqual({});
+  });
+
+  it("reports the leftover when an incomplete install cannot be rolled back", async () => {
+    fakeHermes({
+      name: "algorithmic-art",
+      installPath: "algorithmic-art",
+      files: {
+        "SKILL.md": "---\nname: algorithmic-art\n---\nSee the [viewer](templates/viewer.html).\n",
+      },
+      lock: {
+        identifier: "x/algorithmic-art",
+        source: "clawhub",
+        trust_level: "community",
+        scan_verdict: "safe",
+      },
+      uninstall: "throws",
+    });
+
+    const { status, body } = await install({ id: "x/algorithmic-art" });
+    expect(status).toBe(409);
+    expect(body.code).toBe("rollback_incomplete");
+    // The missing files are still named — the customer loses no information.
+    expect((body.missingFiles as unknown as string[]) ?? []).toContain("templates/viewer.html");
+    expect(Object.keys(await readLock())).toEqual(["algorithmic-art"]);
+  });
+});

--- a/src/tests/routes/hermes/skills-install-rollback.test.ts
+++ b/src/tests/routes/hermes/skills-install-rollback.test.ts
@@ -267,6 +267,26 @@ describe("a rollback the device could not complete is not a plain refusal", () =
     expect(await exists(path.join(skillsDir(), "creative", "simple-english", "SKILL.md"))).toBe(
       true,
     );
+    // …so nothing may say the files went. Nothing looked at them: the entry
+    // named no location, and "not checked" is not "removed".
+    expect(body.leftover).toMatchObject({ lockEntry: true, directory: "unknown" });
+    expect(String(body.error)).not.toMatch(/files were removed/i);
+    expect(String(body.error)).toMatch(/could not be checked/i);
+  });
+
+  it("sends a directory-only leftover somewhere it can actually be removed", async () => {
+    // Lock entry gone, files still there: the Skills store no longer lists it,
+    // so "remove it from the Skills store" is advice that cannot be followed.
+    fakeDangerousInstall("works", {
+      installPath: "creative/simple-english",
+      lockInstallPath: "creative/../../escape",
+    });
+    const { body } = await install({ id: "official/creative/simple-english" });
+
+    expect(body.leftover).toMatchObject({ lockEntry: false, directory: "present" });
+    expect(String(body.error)).not.toMatch(/remove .* from the Skills store/i);
+    expect(String(body.error)).toMatch(/not in the Skills store/i);
+    expect(String(body.error)).toMatch(/deleted on the device/i);
   });
 
   it("reports a directory the rollback could not remove even when the lock is clean", async () => {
@@ -314,6 +334,21 @@ describe("a rollback that worked keeps the honest refusal it already had", () =>
     expect(body).toMatchObject({ code: "dangerous_skill", requiresConfirmation: true });
     expect(await readLock()).toEqual({});
     expect(await exists(path.join(skillsDir(), "creative", "simple-english"))).toBe(false);
+  });
+
+  it("does not turn an unverifiable directory into a failure when the lock is clean", async () => {
+    // The lock entry names no install_path, so the directory could not be
+    // checked either way — but the entry itself is gone, so the store lists
+    // nothing and the customer has nothing to act on. Answering
+    // `rollback_incomplete` here would be this bug's mirror image: reporting a
+    // failure over a rollback that did the one thing that was visible.
+    fakeDangerousInstall("works", { lockInstallPath: "" });
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(await readLock()).toEqual({});
+    expect(status).toBe(409);
+    expect(body.code).toBe("dangerous_skill");
+    expect(body.code).not.toBe("rollback_incomplete");
   });
 
   it("still installs on the confirmed retry after a clean rollback", async () => {


### PR DESCRIPTION
## The defect

`hermes skills uninstall` exits 0 whether it removed the skill or refused to. That is what PR #510 (TASK-547) established, and why it gave the uninstall **route** a post-condition: read the hub lock before and after, and treat the removal as real only when the entry is gone.

The install route drives the same command from `rollback()` — and never got that post-condition. It:

- ran `runHermesCli(["skills","uninstall", …])` and swallowed a throw with a `console.error`,
- called `removeSkillDir(SKILLS_DIR, installPath)` and threw its boolean away,
- never re-read the lock.

So `rollback()` returned `void` and the callers inferred success from having called it.

### What that does on a real device

A `dangerous` scan verdict calls `rollback(lockName, entry)`. On a loaded Jetson the uninstall hits `UNINSTALL_TIMEOUT_MS`, `runHermesCli` throws, the throw is logged and dropped. The directory removal succeeds. **The lock entry survives.**

The route then answers `409 dangerous_skill` — "this skill did not pass the device's security scan" — while `enumerateInstalledSkills` (`src/lib/hermes-skills-server.ts`) walks every lock entry unconditionally and lists the refused skill as installed, `origin: 'hub'`.

Two surfaces now lie in opposite directions, and the retry the 409 invites can never work: with the lock entry present the installer says "already installed" and exits 0 without fetching anything, `landed` is true so the scan gate is skipped, `verifyAndRepair` finds no `SKILL.md` on disk, and the customer is told `502 "The download was incomplete."` — for a download that never ran.

## The fix

`rollback()` returns a `RollbackVerdict` instead of `void`:

- the hub lock is **re-read after** the CLI call (`isInHubLock`, already imported) — the live read, same one #510 uses;
- the directory is judged by `removeSkillDir`'s boolean **and** by the disk afterwards, because `fs.rm` can believe a removal it did not complete on a tree it cannot fully traverse;
- `clean` is `!lockEntry && !dir`.

Both call sites answer `rollback_incomplete` (409) when something survived, naming what is left. The response carries the scan warning and the missing-file list, so no surface loses what it already showed, and sets `requiresConfirmation: false` — confirming cannot succeed while the leftover is there, and would re-enter the completeness check on a skill whose files this rollback already removed.

A rollback that really worked keeps the refusal it always had. The MCP refusal decoder gets the matching branch (`CONFLICT`, do-not-retry), and the audit log an `install-rollback-incomplete` action.

## Tests — red first

New: `src/tests/routes/hermes/skills-install-rollback.test.ts` (10 cases). The CLI is faked, but faithfully: the fake writes and deletes the same lock entries and directories the real one does, and refuses in the two ways the real one refuses — a timeout that throws, and an exit 0 that removes nothing.

Against unmodified `origin/beta` with only the test applied: **6 failed / 4 passed**. With the fix: **10 passed**.

The four that already passed are the control cases — a clean rollback must keep answering the plain security-scan 409, must still let the confirmed retry install, and must still blame the download when the download really was incomplete. Plus one characterisation test proving the phantom row is real (`enumerateInstalledSkills` lists the refused skill).

On the recurring shapes named in the review guidance:

- **success inferred from an exit code** — `reports the leftover when the CLI exits 0 having removed nothing` covers it, with no `install_path` in the lock so the exit code is the only signal.
- **failure reported over something that succeeded** — the whole second `describe` is that guard.
- **a probe read once and never refreshed** — `readHubLock` reads the file on every call, so the post-condition is a live read, not a cached one; the test asserts the on-disk lock, not a cached view.

`bun run lint` and `tsc --noEmit` are byte-identical to the beta baseline (105 problems / 22 errors; 48 tsc lines) — none of them in the four files touched here. Directly affected suites: 53/53 green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of failed skill installations when automatic cleanup cannot fully complete.
  - Added clear conflict guidance directing users to remove the skill from **Settings → Skills** or delete the leftover folder before retrying.
  - Preserved existing refusal and retry behavior when cleanup succeeds.
  - Added audit tracking for incomplete installation rollbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->