### PR TITLE
fix: a gh probe that timed out is not a missing gh

### DIFF
--- a/src/app/setup-api/coding-agent/git/route.ts
+++ b/src/app/setup-api/coding-agent/git/route.ts
@@ -46,7 +46,15 @@ export async function DELETE(request: Request) {
     );
   }
   const out = await disconnectGitHub();
-  if (!out.ok) return NextResponse.json({ error: out.detail ?? "Could not disconnect" }, { status: 500 });
+  if (!out.ok) {
+    // A dead uplink is not a broken box: 503 says "transient, try again",
+    // which is what the owner should do, and the detail no longer claims gh
+    // is missing when the logout simply timed out.
+    return NextResponse.json(
+      { error: out.detail, kind: out.kind },
+      { status: out.kind === "gh_unreachable" ? 503 : 500 },
+    );
+  }
   console.error("[coding-agent] GitHub disconnected by the owner");
   return NextResponse.json(await githubStatus());
 }
@@ -81,7 +89,13 @@ export async function POST(request: Request) {
     });
     const outcome = await backupToGitHub(directory);
     if (!outcome.pushed) {
-      return NextResponse.json({ error: outcome.detail ?? outcome.reason, kind: outcome.reason }, { status: 409 });
+      // 409 means "the request cannot be satisfied as it stands" — true of a
+      // folder with no commits, false of a network that is merely down. That
+      // one gets 503, so nothing tells the owner to install a gh they have.
+      return NextResponse.json(
+        { error: outcome.detail ?? outcome.reason, kind: outcome.reason },
+        { status: outcome.reason === "gh_unreachable" ? 503 : 409 },
+      );
     }
     console.error(`[coding-agent] backed up ${directory} to ${outcome.repo}${outcome.created ? " (new repo)" : ""}`);
     return NextResponse.json(outcome);

--- a/src/components/CodingAgentApp.tsx
+++ b/src/components/CodingAgentApp.tsx
@@ -43,7 +43,7 @@ interface GitHubState {
   loginCommand: string;
   /** "unreachable" means gh is here but could not reach github.com — a
    *  network fault. The card must not read like a missing install. */
-  reason?: "not_installed" | "unreachable";
+  reason?: "not_installed" | "unreachable" | "not_runnable";
 }
 
 interface AgentStatus {

--- a/src/components/CodingAgentApp.tsx
+++ b/src/components/CodingAgentApp.tsx
@@ -41,6 +41,9 @@ interface GitHubState {
   connected: boolean;
   login: string | null;
   loginCommand: string;
+  /** "unreachable" means gh is here but could not reach github.com — a
+   *  network fault. The card must not read like a missing install. */
+  reason?: "not_installed" | "unreachable";
 }
 
 interface AgentStatus {
@@ -557,6 +560,12 @@ export default function CodingAgentApp() {
               {github.connected ? (
                 <span className="text-[11px] text-emerald-400 truncate" data-testid="coding-agent-github-login">
                   {github.login}
+                </span>
+              ) : github.reason === "unreachable" ? (
+                // Not "not connected": we do not know whether an account is
+                // connected, only that github.com could not be asked.
+                <span className="text-[11px] text-amber-400" data-testid="coding-agent-github-unreachable">
+                  {t("codingAgent.githubUnreachable")}
                 </span>
               ) : (
                 <span className="text-[11px] text-[var(--text-muted)]">{t("codingAgent.githubOff")}</span>

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -34,6 +34,19 @@ const PUSH_TIMEOUT_MS = 180_000;
  *  Terminal app, so both say the same thing. */
 export const GH_LOGIN_COMMAND = "gh auth login --hostname github.com --git-protocol https";
 
+/**
+ * Why the probe could not answer. Absent when it did — including when the
+ * honest answer is "installed, nobody has logged in yet", which is a state,
+ * not a failure.
+ */
+export type GitHubStatusReason =
+  /** `gh` could not be started at all. The binary really is missing. */
+  | "not_installed"
+  /** `gh` ran but never finished. `gh auth status` validates the stored token
+   *  against api.github.com, so a dead uplink or a captive portal hangs it
+   *  until the timer kills it. Says nothing about whether gh is installed. */
+  | "unreachable";
+
 export interface GitHubStatus {
   /** Whether gh is installed at all. */
   installed: boolean;
@@ -43,6 +56,8 @@ export interface GitHubStatus {
   login: string | null;
   /** The command that connects, for the UI to offer. */
   loginCommand: string;
+  /** Why the probe failed, when it did. Undefined on an answer we trust. */
+  reason?: GitHubStatusReason;
 }
 
 export type BackupOutcome =
@@ -52,6 +67,9 @@ export type BackupOutcome =
 export type BackupFailure =
   /** gh is not installed on this device. */
   | "no_gh"
+  /** gh is installed but could not reach GitHub — a transient network fault,
+   *  not a missing dependency. Worth retrying; nothing to install. */
+  | "gh_unreachable"
   /** Nobody has connected a GitHub account yet. */
   | "not_connected"
   /** The folder has no commits, so there is nothing to back up. */
@@ -62,7 +80,27 @@ export type BackupFailure =
   /** git or gh refused; detail carries what it said. */
   | "failed";
 
-interface Result { code: number | null; stdout: string; stderr: string }
+export type DisconnectOutcome =
+  | { ok: true; detail?: undefined; kind?: undefined }
+  /** `kind` so the route can answer a network fault as one (503, retry) rather
+   *  than as a broken box (500). */
+  | { ok: false; kind: "no_gh" | "gh_unreachable" | "failed"; detail: string };
+
+interface Result {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  /** The signal that killed it, when one did. A signalled child closes with a
+   *  null `code` — the SAME null a failed spawn gives — so the code alone
+   *  cannot tell "killed" from "never started". This is what tells them
+   *  apart, and getting it wrong reported a network outage as a missing gh. */
+  signal: NodeJS.Signals | null;
+  /** True when OUR timer killed it: the command outlived its budget. */
+  timedOut: boolean;
+  /** True when the binary could not be started at all (ENOENT and friends).
+   *  The only evidence that the command is genuinely absent. */
+  startFailed: boolean;
+}
 
 /**
  * Run a command with a deliberate, minimal environment.
@@ -87,13 +125,39 @@ function run(bin: string, args: string[], opts: { cwd?: string; timeoutMs?: numb
     });
     let stdout = "";
     let stderr = "";
-    const timer = setTimeout(() => child.kill("SIGKILL"), opts.timeoutMs ?? GH_TIMEOUT_MS);
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, opts.timeoutMs ?? GH_TIMEOUT_MS);
     timer.unref();
     child.stdout.on("data", (c) => { stdout += String(c); });
     child.stderr.on("data", (c) => { stderr += String(c); });
-    child.on("error", () => { clearTimeout(timer); resolve({ code: null, stdout, stderr: "could not start" }); });
-    child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout: stdout.trim(), stderr: stderr.trim() }); });
+    // A failed spawn emits `error` and THEN `close` with a null code; the
+    // first resolve wins, so this is the one place startFailed is set.
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve({ code: null, stdout, stderr: "could not start", signal: null, timedOut, startFailed: true });
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, stdout: stdout.trim(), stderr: stderr.trim(), signal, timedOut, startFailed: false });
+    });
   });
+}
+
+/** True when the command ran but produced no exit code — it was killed, by our
+ *  own timer or by something else. It started, so the binary exists. */
+function wasKilled(r: Result): boolean {
+  return !r.startFailed && r.code === null;
+}
+
+/**
+ * What to tell the owner about a call that was cut short. Never mentions
+ * installing anything: the binary demonstrably ran. Never blank either — a
+ * SIGKILLed child writes no stderr, so the old `(stderr || stdout)` detail for
+ * a killed call was the empty string.
+ */
+function killedDetail(r: Result, what: string, advice = "Check this ClawBox's network connection and try again."): string {
+  const how = r.timedOut ? "timed out" : `was stopped before it finished${r.signal ? ` (${r.signal})` : ""}`;
+  return `${what} ${how}. ${advice}`;
 }
 
 /**
@@ -108,10 +172,22 @@ export function parseLogin(output: string): string | null {
   return m ? m[1] : null;
 }
 
+/**
+ * Probed fresh on every call, deliberately. `unreachable` is a statement about
+ * this moment's network, not a property of the box: caching one would outlive
+ * the outage that produced it and go on refusing backups after the uplink came
+ * back.
+ */
 export async function githubStatus(): Promise<GitHubStatus> {
   const r = await run("gh", ["auth", "status", "--hostname", "github.com"]);
-  if (r.code === null) {
-    return { installed: false, connected: false, login: null, loginCommand: GH_LOGIN_COMMAND };
+  if (r.startFailed) {
+    return { installed: false, connected: false, login: null, loginCommand: GH_LOGIN_COMMAND, reason: "not_installed" };
+  }
+  if (wasKilled(r)) {
+    // gh RAN — so it is installed. It just never got an answer out of
+    // api.github.com. Reporting this as "not installed" sent the owner off to
+    // install software that was already on the box.
+    return { installed: true, connected: false, login: null, loginCommand: GH_LOGIN_COMMAND, reason: "unreachable" };
   }
   const login = parseLogin(`${r.stderr}\n${r.stdout}`);
   return {
@@ -131,11 +207,23 @@ export async function githubStatus(): Promise<GitHubStatus> {
  *
  * Any repository already pushed stays on GitHub, and any remote already set
  * on a folder stays set — this removes the ability to push, not the history.
+ *
+ * A logout that was cut short says so, and says nothing more. gh may well have
+ * dropped its local credential before it hung, so neither "you are still
+ * connected" nor "nothing changed" would be a fact — the owner is pointed back
+ * at the status, which re-probes.
  */
-export async function disconnectGitHub(): Promise<{ ok: boolean; detail?: string }> {
+export async function disconnectGitHub(): Promise<DisconnectOutcome> {
   const r = await run("gh", ["auth", "logout", "--hostname", "github.com"]);
-  if (r.code === null) return { ok: false, detail: "gh is not installed on this ClawBox." };
-  if (r.code !== 0) return { ok: false, detail: (r.stderr || r.stdout).slice(0, 300) };
+  if (r.startFailed) return { ok: false, kind: "no_gh", detail: "gh is not installed on this ClawBox." };
+  if (wasKilled(r)) {
+    return {
+      ok: false,
+      kind: "gh_unreachable",
+      detail: `${killedDetail(r, "Signing out of GitHub")} Then read the connection again.`,
+    };
+  }
+  if (r.code !== 0) return { ok: false, kind: "failed", detail: (r.stderr || r.stdout).slice(0, 300) };
   return { ok: true };
 }
 
@@ -154,12 +242,26 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   const dir = path.resolve(directory);
 
   const status = await githubStatus();
+  if (status.reason === "unreachable") {
+    // Transient, and nothing to install. Kept distinct from no_gh so the route
+    // does not answer a network outage with "install the GitHub CLI".
+    return {
+      pushed: false,
+      reason: "gh_unreachable",
+      detail: "Could not reach GitHub from this ClawBox. Check the network connection and try again.",
+    };
+  }
   if (!status.installed) return { pushed: false, reason: "no_gh" };
   if (!status.connected) return { pushed: false, reason: "not_connected" };
 
   // Its OWN repository or nothing — the same rule as the per-run commit, and
   // for the same reason: a code project sits inside the ClawBox checkout.
   const top = await run("git", ["-C", dir, "rev-parse", "--show-toplevel"]);
+  // A killed probe is not evidence about the folder. Reading it as one would
+  // tell the owner their repository is not a repository.
+  if (wasKilled(top)) {
+    return { pushed: false, reason: "failed", detail: killedDetail(top, "Reading the folder's git repository", "Try again.") };
+  }
   if (top.code !== 0 || path.resolve(top.stdout || "") !== dir) {
     return { pushed: false, reason: "not_a_repo", detail: "This folder is not its own git repository." };
   }
@@ -171,6 +273,14 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   const branch = branchOut.code === 0 && branchOut.stdout ? branchOut.stdout : "main";
 
   const hasRemote = await run("git", ["-C", dir, "remote", "get-url", "origin"]);
+  // The consequential one. A non-zero code here means "no remote yet", and the
+  // branch below acts on it by CREATING a repository on GitHub. A killed probe
+  // returns the same null code, so reading it as "no remote" would create a
+  // second repository for a folder that already has one — an irreversible
+  // guess made from a transient fault.
+  if (wasKilled(hasRemote)) {
+    return { pushed: false, reason: "failed", detail: killedDetail(hasRemote, "Reading the folder's git remote", "Try again.") };
+  }
   let created = false;
   let repo = hasRemote.code === 0 ? hasRemote.stdout : "";
 
@@ -184,7 +294,13 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
       { cwd: dir, timeoutMs: PUSH_TIMEOUT_MS },
     );
     if (create.code !== 0) {
-      return { pushed: false, reason: "failed", detail: (create.stderr || create.stdout).slice(0, 400) };
+      return {
+        pushed: false,
+        reason: "failed",
+        detail: wasKilled(create)
+          ? killedDetail(create, "Creating the repository on GitHub")
+          : (create.stderr || create.stdout).slice(0, 400),
+      };
     }
     created = true;
     const url = await run("git", ["-C", dir, "remote", "get-url", "origin"]);
@@ -198,7 +314,13 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
     { timeoutMs: PUSH_TIMEOUT_MS },
   );
   if (push.code !== 0) {
-    return { pushed: false, reason: "failed", detail: (push.stderr || push.stdout).slice(0, 400) };
+    return {
+      pushed: false,
+      reason: "failed",
+      detail: wasKilled(push)
+        ? killedDetail(push, "Pushing to GitHub")
+        : (push.stderr || push.stdout).slice(0, 400),
+    };
   }
   return { pushed: true, repo, created, branch };
 }

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -130,11 +130,26 @@ function run(bin: string, args: string[], opts: { cwd?: string; timeoutMs?: numb
     timer.unref();
     child.stdout.on("data", (c) => { stdout += String(c); });
     child.stderr.on("data", (c) => { stderr += String(c); });
+    // `error` is not proof the binary is missing. It also fires on a child
+    // that spawned perfectly well and whose kill() could not deliver its
+    // signal — so treating every error as "not installed" would reintroduce
+    // the exact false-failure this file exists to prevent, on the timeout path
+    // of all places. `spawn` fires only when the process really started, so it
+    // is what separates "never ran" from "ran and then something went wrong".
+    let spawned = false;
+    child.on("spawn", () => { spawned = true; });
     // A failed spawn emits `error` and THEN `close` with a null code; the
     // first resolve wins, so this is the one place startFailed is set.
     child.on("error", () => {
       clearTimeout(timer);
-      resolve({ code: null, stdout, stderr: "could not start", signal: null, timedOut, startFailed: true });
+      resolve({
+        code: null,
+        stdout,
+        stderr: spawned ? stderr.trim() : "could not start",
+        signal: null,
+        timedOut,
+        startFailed: !spawned,
+      });
     });
     child.on("close", (code, signal) => {
       clearTimeout(timer);

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -45,7 +45,11 @@ export type GitHubStatusReason =
   /** `gh` ran but never finished. `gh auth status` validates the stored token
    *  against api.github.com, so a dead uplink or a captive portal hangs it
    *  until the timer kills it. Says nothing about whether gh is installed. */
-  | "unreachable";
+  | "unreachable"
+  /** The file is there but would not execute — EACCES on a binary somebody
+   *  chmod'ed, most often. Installing it again fixes nothing; the remedy is
+   *  permissions, so this must not be answered with "not installed". */
+  | "not_runnable";
 
 export interface GitHubStatus {
   /** Whether gh is installed at all. */
@@ -97,9 +101,14 @@ interface Result {
   signal: NodeJS.Signals | null;
   /** True when OUR timer killed it: the command outlived its budget. */
   timedOut: boolean;
-  /** True when the binary could not be started at all (ENOENT and friends).
-   *  The only evidence that the command is genuinely absent. */
+  /** True when the binary could not be started at all. Necessary evidence
+   *  that the command is unusable, but NOT sufficient to call it absent —
+   *  see startError. */
   startFailed: boolean;
+  /** The errno of a failed spawn: ENOENT means genuinely missing, EACCES
+   *  means present but not executable. Collapsing the two would send someone
+   *  to reinstall a binary that is sitting right there. */
+  startError: string | null;
 }
 
 /**
@@ -140,7 +149,7 @@ function run(bin: string, args: string[], opts: { cwd?: string; timeoutMs?: numb
     child.on("spawn", () => { spawned = true; });
     // A failed spawn emits `error` and THEN `close` with a null code; the
     // first resolve wins, so this is the one place startFailed is set.
-    child.on("error", () => {
+    child.on("error", (err: NodeJS.ErrnoException) => {
       clearTimeout(timer);
       resolve({
         code: null,
@@ -149,11 +158,12 @@ function run(bin: string, args: string[], opts: { cwd?: string; timeoutMs?: numb
         signal: null,
         timedOut,
         startFailed: !spawned,
+        startError: spawned ? null : (err?.code ?? null),
       });
     });
     child.on("close", (code, signal) => {
       clearTimeout(timer);
-      resolve({ code, stdout: stdout.trim(), stderr: stderr.trim(), signal, timedOut, startFailed: false });
+      resolve({ code, stdout: stdout.trim(), stderr: stderr.trim(), signal, timedOut, startFailed: false, startError: null });
     });
   });
 }
@@ -196,7 +206,18 @@ export function parseLogin(output: string): string | null {
 export async function githubStatus(): Promise<GitHubStatus> {
   const r = await run("gh", ["auth", "status", "--hostname", "github.com"]);
   if (r.startFailed) {
-    return { installed: false, connected: false, login: null, loginCommand: GH_LOGIN_COMMAND, reason: "not_installed" };
+    // ENOENT is the only errno that means "there is no such file". Anything
+    // else — EACCES above all — is a binary that EXISTS and would not run, and
+    // answering that with "not installed" hands over the one remedy that
+    // cannot work.
+    const missing = r.startError === "ENOENT" || r.startError === null;
+    return {
+      installed: !missing,
+      connected: false,
+      login: null,
+      loginCommand: GH_LOGIN_COMMAND,
+      reason: missing ? "not_installed" : "not_runnable",
+    };
   }
   if (wasKilled(r)) {
     // gh RAN — so it is installed. It just never got an answer out of
@@ -230,7 +251,13 @@ export async function githubStatus(): Promise<GitHubStatus> {
  */
 export async function disconnectGitHub(): Promise<DisconnectOutcome> {
   const r = await run("gh", ["auth", "logout", "--hostname", "github.com"]);
-  if (r.startFailed) return { ok: false, kind: "no_gh", detail: "gh is not installed on this ClawBox." };
+  if (r.startFailed) {
+    // Present but unrunnable is not missing, and must not be answered with an
+    // install: the file is there, its permissions are not.
+    return r.startError === "ENOENT" || r.startError === null
+      ? { ok: false, kind: "no_gh", detail: "gh is not installed on this ClawBox." }
+      : { ok: false, kind: "failed", detail: `The GitHub CLI is on this ClawBox but would not start (${r.startError}). Check its permissions.` };
+  }
   if (wasKilled(r)) {
     return {
       ok: false,
@@ -257,6 +284,15 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   const dir = path.resolve(directory);
 
   const status = await githubStatus();
+  if (status.reason === "not_runnable") {
+    // "failed" rather than no_gh, so the route never tells the owner to
+    // install a gh that is already sitting on the box.
+    return {
+      pushed: false,
+      reason: "failed",
+      detail: "The GitHub CLI is on this ClawBox but would not start. Check its permissions.",
+    };
+  }
   if (status.reason === "unreachable") {
     // Transient, and nothing to install. Kept distinct from no_gh so the route
     // does not answer a network outage with "install the GitHub CLI".

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -267,9 +267,22 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   }
 
   const head = await run("git", ["-C", dir, "rev-parse", "--verify", "HEAD"]);
+  // "No commits yet" is a claim about the folder. A killed probe made no such
+  // finding, and saying it would tell an owner with a full history that their
+  // work is empty.
+  if (wasKilled(head)) {
+    return { pushed: false, reason: "failed", detail: killedDetail(head, "Reading the folder's commits", "Try again.") };
+  }
   if (head.code !== 0) return { pushed: false, reason: "nothing_to_push", detail: "The folder has no commits yet." };
 
   const branchOut = await run("git", ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]);
+  // The "main" fallback is a guess, and the push below turns it into
+  // `--set-upstream origin main`. Fine when git actually answered and simply
+  // had no name to give; wrong when the probe was killed, which would push a
+  // `develop` checkout to `main` and bind it there over a transient fault.
+  if (wasKilled(branchOut)) {
+    return { pushed: false, reason: "failed", detail: killedDetail(branchOut, "Reading the folder's branch", "Try again.") };
+  }
   const branch = branchOut.code === 0 && branchOut.stdout ? branchOut.stdout : "main";
 
   const hasRemote = await run("git", ["-C", dir, "remote", "get-url", "origin"]);

--- a/src/lib/hermes-translations/bg.ts
+++ b/src/lib/hermes-translations/bg.ts
@@ -449,6 +449,7 @@ export const bg: Record<string, string> = {
   "codingAgent.tokensWord": "токена",
   "codingAgent.updated": "обновено",
   "codingAgent.githubOff": "не е свързан",
+  "codingAgent.githubUnreachable": "GitHub е недостъпен",
   "codingAgent.githubConnect": "Свържи",
   "codingAgent.githubReconnect": "Промени",
   "codingAgent.githubOut": "Изход",

--- a/src/lib/hermes-translations/de.ts
+++ b/src/lib/hermes-translations/de.ts
@@ -461,6 +461,7 @@ export const de: Record<string, string> = {
   "codingAgent.tokensWord": "Token",
   "codingAgent.updated": "aktualisiert",
   "codingAgent.githubOff": "nicht verbunden",
+  "codingAgent.githubUnreachable": "GitHub nicht erreichbar",
   "codingAgent.githubConnect": "Verbinden",
   "codingAgent.githubReconnect": "Ändern",
   "codingAgent.githubOut": "Abmelden",

--- a/src/lib/hermes-translations/en-coding-agent.ts
+++ b/src/lib/hermes-translations/en-coding-agent.ts
@@ -50,6 +50,7 @@ export const codingAgentEn: Record<string, string> = {
   "codingAgent.tokensWord": "tokens",
   "codingAgent.updated": "updated",
   "codingAgent.githubOff": "not connected",
+  "codingAgent.githubUnreachable": "GitHub unreachable",
   "codingAgent.githubConnect": "Connect",
   "codingAgent.githubReconnect": "Change",
   "codingAgent.githubOut": "Sign out",

--- a/src/lib/hermes-translations/es.ts
+++ b/src/lib/hermes-translations/es.ts
@@ -457,6 +457,7 @@ export const es: Record<string, string> = {
   "codingAgent.tokensWord": "tokens",
   "codingAgent.updated": "actualizado",
   "codingAgent.githubOff": "sin conectar",
+  "codingAgent.githubUnreachable": "GitHub no accesible",
   "codingAgent.githubConnect": "Conectar",
   "codingAgent.githubReconnect": "Cambiar",
   "codingAgent.githubOut": "Cerrar sesión",

--- a/src/lib/hermes-translations/fr.ts
+++ b/src/lib/hermes-translations/fr.ts
@@ -462,6 +462,7 @@ export const fr: Record<string, string> = {
   "codingAgent.tokensWord": "jetons",
   "codingAgent.updated": "mis à jour",
   "codingAgent.githubOff": "non connecté",
+  "codingAgent.githubUnreachable": "GitHub injoignable",
   "codingAgent.githubConnect": "Connecter",
   "codingAgent.githubReconnect": "Changer",
   "codingAgent.githubOut": "Se déconnecter",

--- a/src/lib/hermes-translations/it.ts
+++ b/src/lib/hermes-translations/it.ts
@@ -473,6 +473,7 @@ export const it: Record<string, string> = {
   "codingAgent.tokensWord": "token",
   "codingAgent.updated": "aggiornato",
   "codingAgent.githubOff": "non connesso",
+  "codingAgent.githubUnreachable": "GitHub irraggiungibile",
   "codingAgent.githubConnect": "Connetti",
   "codingAgent.githubReconnect": "Cambia",
   "codingAgent.githubOut": "Esci",

--- a/src/lib/hermes-translations/ja.ts
+++ b/src/lib/hermes-translations/ja.ts
@@ -464,6 +464,7 @@ export const ja: Record<string, string> = {
   "codingAgent.tokensWord": "トークン",
   "codingAgent.updated": "更新",
   "codingAgent.githubOff": "未接続",
+  "codingAgent.githubUnreachable": "GitHub に接続できません",
   "codingAgent.githubConnect": "接続",
   "codingAgent.githubReconnect": "変更",
   "codingAgent.githubOut": "サインアウト",

--- a/src/lib/hermes-translations/nl.ts
+++ b/src/lib/hermes-translations/nl.ts
@@ -462,6 +462,7 @@ export const nl: Record<string, string> = {
   "codingAgent.tokensWord": "tokens",
   "codingAgent.updated": "bijgewerkt",
   "codingAgent.githubOff": "niet verbonden",
+  "codingAgent.githubUnreachable": "GitHub onbereikbaar",
   "codingAgent.githubConnect": "Verbinden",
   "codingAgent.githubReconnect": "Wijzigen",
   "codingAgent.githubOut": "Afmelden",

--- a/src/lib/hermes-translations/sv.ts
+++ b/src/lib/hermes-translations/sv.ts
@@ -458,6 +458,7 @@ export const sv: Record<string, string> = {
   "codingAgent.tokensWord": "tokens",
   "codingAgent.updated": "uppdaterad",
   "codingAgent.githubOff": "inte ansluten",
+  "codingAgent.githubUnreachable": "GitHub kan inte nås",
   "codingAgent.githubConnect": "Anslut",
   "codingAgent.githubReconnect": "Ändra",
   "codingAgent.githubOut": "Logga ut",

--- a/src/lib/hermes-translations/zh.ts
+++ b/src/lib/hermes-translations/zh.ts
@@ -473,6 +473,7 @@ export const zh: Record<string, string> = {
   "codingAgent.tokensWord": "词元",
   "codingAgent.updated": "更新于",
   "codingAgent.githubOff": "未连接",
+  "codingAgent.githubUnreachable": "无法连接 GitHub",
   "codingAgent.githubConnect": "连接",
   "codingAgent.githubReconnect": "更改",
   "codingAgent.githubOut": "退出登录",

--- a/src/tests/unit/coding-github-unreachable.test.ts
+++ b/src/tests/unit/coding-github-unreachable.test.ts
@@ -1,0 +1,338 @@
+/**
+ * GH-01. A `gh` probe that TIMED OUT was reported as "gh is not installed".
+ *
+ * `run()` kills a slow child with SIGKILL, and a signalled child closes with
+ * `code === null` — the very same null the `error` handler resolves with when
+ * the binary could not be started at all. The two were indistinguishable, so
+ * `githubStatus()` answered `installed: false` for both.
+ *
+ * That matters because `gh auth status` is a NETWORK call: it validates the
+ * stored token against api.github.com. On a box whose uplink is down, or
+ * behind a captive portal, the call hangs, the timer kills it, and the device
+ * told the owner to install software that was already there — gh 2.4.0 is on
+ * the box this was found on. A transient environment fault reported as a
+ * permanent missing-dependency fact, with the wrong remedy attached.
+ *
+ * The discriminator these tests pin: the `error` event is the ONLY evidence
+ * that gh could not start. A `close` carrying a signal means the process ran,
+ * which means the binary exists.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import path from "path";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ spawn: spawnMock }));
+
+type Lib = typeof import("@/lib/coding-github");
+let lib: Lib;
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: (signal: NodeJS.Signals) => boolean;
+}
+
+function baseChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => true;
+  return child;
+}
+
+/**
+ * A child that runs forever until something kills it: `gh auth status` waiting
+ * on api.github.com behind a dead uplink. When killed it closes the way the
+ * kernel closes a signalled process — a null exit code, and the signal.
+ */
+function hangingChild(): FakeChild {
+  const child = baseChild();
+  child.kill = (signal) => {
+    setImmediate(() => child.emit("close", null, signal));
+    return true;
+  };
+  return child;
+}
+
+/**
+ * A binary that is not there. Node emits `error` for the failed spawn and then
+ * `close` with a null code and NO signal — nothing ever ran.
+ */
+function missingBinary(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
+/** A child that runs and exits, writing `text` to stderr the way gh does. */
+function exitingChild(code: number, text = ""): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    if (text) child.stderr.emit("data", Buffer.from(text));
+    child.emit("close", code, null);
+  });
+  return child;
+}
+
+/** The same, on stdout — where git answers `rev-parse` and `remote get-url`. */
+function gitChild(code: number, text = ""): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    if (text) child.stdout.emit("data", Buffer.from(text));
+    child.emit("close", code, null);
+  });
+  return child;
+}
+
+/**
+ * Drive the module's own timeout budgets, then settle the promise. The advance
+ * must clear the LONGEST of them — pushes get 180s, not the 60s a probe gets —
+ * or a hanging push is never killed and the test times out instead of asserting.
+ */
+async function withTimeoutFired<T>(work: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const promise = work();
+    await vi.advanceTimersByTimeAsync(400_000);
+    return await promise;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+beforeEach(async () => {
+  spawnMock.mockReset();
+  vi.resetModules();
+  lib = await import("@/lib/coding-github");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("a probe that timed out is not a missing gh", () => {
+  it("reports gh as INSTALLED but unreachable when the probe is killed", async () => {
+    spawnMock.mockImplementation(() => hangingChild());
+
+    const status = await withTimeoutFired(() => lib.githubStatus());
+
+    // The process ran, so the binary is there. Saying otherwise sends the
+    // owner to install something they already have.
+    expect(status.installed).toBe(true);
+    expect(status.connected).toBe(false);
+    expect(status.login).toBeNull();
+    expect(status.reason).toBe("unreachable");
+  });
+
+  it("still reports gh as MISSING when the binary genuinely cannot start", async () => {
+    spawnMock.mockImplementation(() => missingBinary());
+
+    const status = await lib.githubStatus();
+
+    expect(status.installed).toBe(false);
+    expect(status.connected).toBe(false);
+    expect(status.reason).toBe("not_installed");
+  });
+
+  it("answers normally when gh answers, with no failure reason attached", async () => {
+    spawnMock.mockImplementation(() =>
+      exitingChild(0, "github.com\n  Logged in to github.com as yalexx (/home/clawbox/.config/gh/hosts.yml)\n"),
+    );
+
+    const status = await lib.githubStatus();
+
+    expect(status.installed).toBe(true);
+    expect(status.connected).toBe(true);
+    expect(status.login).toBe("yalexx");
+    expect(status.reason).toBeUndefined();
+  });
+
+  it("reports a logged-out gh as installed and simply not connected", async () => {
+    spawnMock.mockImplementation(() =>
+      exitingChild(1, "You are not logged into any GitHub hosts. Run gh auth login to authenticate.\n"),
+    );
+
+    const status = await lib.githubStatus();
+
+    expect(status.installed).toBe(true);
+    expect(status.connected).toBe(false);
+    // Not an error state: nobody has logged in yet, which is not a failure.
+    expect(status.reason).toBeUndefined();
+  });
+
+  it("re-probes on every call — an unreachable answer is never cached", async () => {
+    // The recurring shape in this codebase: a probe taken once and reused
+    // forever. A cached "unreachable" would outlive the outage that caused it
+    // and keep denying a backup after the network came back.
+    spawnMock.mockImplementation(() => hangingChild());
+    const down = await withTimeoutFired(() => lib.githubStatus());
+    expect(down.reason).toBe("unreachable");
+
+    spawnMock.mockImplementation(() =>
+      exitingChild(0, "Logged in to github.com as yalexx (/home/clawbox/.config/gh/hosts.yml)\n"),
+    );
+    const up = await lib.githubStatus();
+
+    expect(up.connected).toBe(true);
+    expect(up.reason).toBeUndefined();
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("disconnecting over a dead network", () => {
+  it("does not claim gh is missing when the logout timed out", async () => {
+    spawnMock.mockImplementation(() => hangingChild());
+
+    const out = await withTimeoutFired(() => lib.disconnectGitHub());
+
+    expect(out.ok).toBe(false);
+    expect(out.detail ?? "").not.toMatch(/not installed/i);
+    // and it says what actually went wrong, so the owner can retry.
+    expect(out.detail ?? "").toMatch(/network|reach|timed out/i);
+  });
+
+  it("does not claim the account is still connected either", async () => {
+    // gh may well have dropped the local credential before it hung on the
+    // network. Asserting "nothing was changed" would be a guess.
+    spawnMock.mockImplementation(() => hangingChild());
+
+    const out = await withTimeoutFired(() => lib.disconnectGitHub());
+
+    expect(out.detail ?? "").not.toMatch(/nothing was changed|still connected/i);
+  });
+
+  it("still says gh is missing when the binary genuinely cannot start", async () => {
+    spawnMock.mockImplementation(() => missingBinary());
+
+    const out = await lib.disconnectGitHub();
+
+    expect(out.ok).toBe(false);
+    expect(out.detail ?? "").toMatch(/not installed/i);
+  });
+
+  it("reports a logout that exited 0 as the success it was", async () => {
+    // The other half of the same bug class: an error path firing over
+    // something that actually worked.
+    spawnMock.mockImplementation(() => exitingChild(0));
+
+    const out = await lib.disconnectGitHub();
+
+    expect(out.ok).toBe(true);
+    expect(out.detail).toBeUndefined();
+  });
+});
+
+describe("backing up when GitHub cannot be reached", () => {
+  it("does not tell the owner to install gh", async () => {
+    spawnMock.mockImplementation(() => hangingChild());
+
+    const outcome = await withTimeoutFired(() => lib.backupToGitHub("/home/clawbox/Projects/site"));
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).not.toBe("no_gh");
+    expect(outcome.reason).toBe("gh_unreachable");
+    expect(outcome.detail ?? "").toMatch(/network|reach/i);
+    expect(outcome.detail ?? "").not.toMatch(/install/i);
+  });
+
+  it("still answers no_gh when gh really is absent", async () => {
+    spawnMock.mockImplementation(() => missingBinary());
+
+    const outcome = await lib.backupToGitHub("/home/clawbox/Projects/site");
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("no_gh");
+  });
+});
+
+/**
+ * The same null code reaches four more branches once the probe is past. Each
+ * one reads a non-zero code as a FACT about the folder, and a killed call
+ * carries no fact at all — these pin that none of them guesses.
+ */
+describe("a killed git probe is never read as an answer", () => {
+  const connected = "Logged in to github.com as yalexx (/home/clawbox/.config/gh/hosts.yml)\n";
+  // backupToGitHub compares `git rev-parse --show-toplevel` against
+  // path.resolve(directory), so the stub must answer in the host's own form.
+  const DIR = "/home/clawbox/Projects/site";
+  const TOPLEVEL = path.resolve(DIR);
+
+  /** Answer each spawned command in order, by the argv it was given. */
+  function script(answer: (bin: string, args: string[]) => FakeChild): void {
+    spawnMock.mockImplementation((bin: string, args: string[]) => answer(bin, args));
+  }
+
+  it("does not create a SECOND repository when the remote probe is killed", async () => {
+    // `git remote get-url origin` exiting non-zero means "no remote yet", and
+    // the branch below it creates a repo on GitHub. A killed probe returns the
+    // same null code. Guessing here is irreversible.
+    const seen: string[][] = [];
+    script((bin, args) => {
+      seen.push([bin, ...args]);
+      if (bin === "gh" && args[0] === "auth") return exitingChild(0, connected);
+      if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+      if (args.includes("--verify")) return gitChild(0, "abc123");
+      if (args.includes("--abbrev-ref")) return gitChild(0, "main");
+      if (args.includes("get-url")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const outcome = await withTimeoutFired(() =>
+      lib.backupToGitHub(DIR),
+    );
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("failed");
+    expect(outcome.detail ?? "").toMatch(/remote/i);
+    // The point of the test: nothing was created on GitHub.
+    expect(seen.some((c) => c[0] === "gh" && c[1] === "repo" && c[2] === "create")).toBe(false);
+  });
+
+  it("does not call a repository 'not a git repository' when the probe is killed", async () => {
+    script((bin, args) => {
+      if (bin === "gh") return exitingChild(0, connected);
+      if (args.includes("--show-toplevel")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const outcome = await withTimeoutFired(() =>
+      lib.backupToGitHub(DIR),
+    );
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).not.toBe("not_a_repo");
+    expect(outcome.detail ?? "").not.toMatch(/not its own git repository/i);
+  });
+
+  it("never reports a killed push with a blank message", async () => {
+    // A SIGKILLed child writes no stderr, so `(stderr || stdout)` was "".
+    // The owner saw a failure with nothing in it.
+    script((bin, args) => {
+      if (bin === "gh") return exitingChild(0, connected);
+      if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+      if (args.includes("--verify")) return gitChild(0, "abc123");
+      if (args.includes("--abbrev-ref")) return gitChild(0, "main");
+      if (args.includes("get-url")) return gitChild(0, "git@github.com:me/site.git");
+      if (args.includes("push")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const outcome = await withTimeoutFired(() =>
+      lib.backupToGitHub(DIR),
+    );
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("failed");
+    expect((outcome.detail ?? "").trim()).not.toBe("");
+    expect(outcome.detail ?? "").toMatch(/push/i);
+  });
+});

--- a/src/tests/unit/coding-github-unreachable.test.ts
+++ b/src/tests/unit/coding-github-unreachable.test.ts
@@ -312,6 +312,50 @@ describe("a killed git probe is never read as an answer", () => {
     expect(outcome.detail ?? "").not.toMatch(/not its own git repository/i);
   });
 
+  it("does not call a repository EMPTY when the commit probe is killed", async () => {
+    // `rev-parse --verify HEAD` exiting non-zero means "no commits yet". A
+    // killed probe returns the same null, and telling an owner with a full
+    // history that the folder is empty is a lie drawn from a dead network.
+    script((bin, args) => {
+      if (bin === "gh") return exitingChild(0, connected);
+      if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+      if (args.includes("--verify")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const outcome = await withTimeoutFired(() => lib.backupToGitHub(DIR));
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).not.toBe("nothing_to_push");
+    expect(outcome.detail ?? "").not.toMatch(/no commits yet/i);
+  });
+
+  it("does not push to 'main' when the branch probe is killed", async () => {
+    // The branch name feeds `push --set-upstream origin <branch>`. Falling back
+    // to "main" on a killed probe would push a `develop` checkout to main AND
+    // bind it there — a durable wrong answer from a transient fault.
+    const seen: string[][] = [];
+    script((bin, args) => {
+      seen.push([bin, ...args]);
+      if (bin === "gh") return exitingChild(0, connected);
+      if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+      if (args.includes("--verify")) return gitChild(0, "abc123");
+      if (args.includes("--abbrev-ref")) return hangingChild();
+      if (args.includes("get-url")) return gitChild(0, "git@github.com:me/site.git");
+      return gitChild(0);
+    });
+
+    const outcome = await withTimeoutFired(() => lib.backupToGitHub(DIR));
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("failed");
+    expect(outcome.detail ?? "").toMatch(/branch/i);
+    // The point: nothing was pushed anywhere, least of all to main.
+    expect(seen.some((c) => c.includes("push"))).toBe(false);
+  });
+
   it("never reports a killed push with a blank message", async () => {
     // A SIGKILLed child writes no stderr, so `(stderr || stdout)` was "".
     // The owner saw a failure with nothing in it.

--- a/src/tests/unit/coding-github-unreachable.test.ts
+++ b/src/tests/unit/coding-github-unreachable.test.ts
@@ -71,6 +71,20 @@ function missingBinary(): FakeChild {
 }
 
 /**
+ * gh is RIGHT THERE, and would not execute — somebody chmod'ed it. Node emits
+ * `error` with EACCES and never emits `spawn`, exactly like a missing binary,
+ * yet the remedy is permissions and not an install.
+ */
+function unrunnableBinary(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", Object.assign(new Error("spawn gh EACCES"), { code: "EACCES" }));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
+/**
  * A child that started fine but whose kill() cannot deliver the signal — Node
  * reports that by emitting `error` on an ALREADY SPAWNED process. It looks
  * identical to a failed spawn unless `spawn` is tracked, which is how the
@@ -167,6 +181,40 @@ describe("a probe that timed out is not a missing gh", () => {
     expect(status.installed).toBe(false);
     expect(status.connected).toBe(false);
     expect(status.reason).toBe("not_installed");
+  });
+
+  it("does not say 'not installed' for a gh that is present but not executable", async () => {
+    // EACCES: the file exists, which is why the errno is not ENOENT. Telling
+    // the owner to install it offers the one remedy that cannot help.
+    spawnMock.mockImplementation(() => unrunnableBinary());
+
+    const status = await lib.githubStatus();
+
+    expect(status.reason).toBe("not_runnable");
+    expect(status.reason).not.toBe("not_installed");
+    expect(status.installed).toBe(true);
+    expect(status.connected).toBe(false);
+  });
+
+  it("a backup over an unrunnable gh never answers no_gh", async () => {
+    spawnMock.mockImplementation(() => unrunnableBinary());
+
+    const outcome = await lib.backupToGitHub("/home/clawbox/Projects/site");
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).not.toBe("no_gh");
+    expect(outcome.detail ?? "").toMatch(/permission/i);
+  });
+
+  it("a disconnect over an unrunnable gh never claims it is not installed", async () => {
+    spawnMock.mockImplementation(() => unrunnableBinary());
+
+    const out = await lib.disconnectGitHub();
+
+    expect(out.ok).toBe(false);
+    expect(out.detail ?? "").not.toMatch(/not installed/i);
+    expect(out.detail ?? "").toMatch(/EACCES|permission/i);
   });
 
   it("answers normally when gh answers, with no failure reason attached", async () => {

--- a/src/tests/unit/coding-github-unreachable.test.ts
+++ b/src/tests/unit/coding-github-unreachable.test.ts
@@ -57,7 +57,9 @@ function hangingChild(): FakeChild {
 
 /**
  * A binary that is not there. Node emits `error` for the failed spawn and then
- * `close` with a null code and NO signal — nothing ever ran.
+ * `close` with a null code and NO signal — nothing ever ran. Critically it
+ * never emits `spawn`, which is the only thing that distinguishes it from the
+ * child below.
  */
 function missingBinary(): FakeChild {
   const child = baseChild();
@@ -65,6 +67,22 @@ function missingBinary(): FakeChild {
     child.emit("error", Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }));
     child.emit("close", null, null);
   });
+  return child;
+}
+
+/**
+ * A child that started fine but whose kill() cannot deliver the signal — Node
+ * reports that by emitting `error` on an ALREADY SPAWNED process. It looks
+ * identical to a failed spawn unless `spawn` is tracked, which is how the
+ * missing-gh lie could sneak back in through the timeout path itself.
+ */
+function unkillableChild(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => child.emit("spawn"));
+  child.kill = () => {
+    setImmediate(() => child.emit("error", Object.assign(new Error("kill EPERM"), { code: "EPERM" })));
+    return false;
+  };
   return child;
 }
 
@@ -126,6 +144,19 @@ describe("a probe that timed out is not a missing gh", () => {
     expect(status.connected).toBe(false);
     expect(status.login).toBeNull();
     expect(status.reason).toBe("unreachable");
+  });
+
+  it("does not report a missing gh when the KILL fails on a running process", async () => {
+    // The regression that would undo this whole fix from the inside: `error`
+    // fires on a child that spawned fine, our timer's kill could not land, and
+    // reading that as "could not start" says gh is not installed again.
+    spawnMock.mockImplementation(() => unkillableChild());
+
+    const status = await withTimeoutFired(() => lib.githubStatus());
+
+    expect(status.installed).toBe(true);
+    expect(status.reason).toBe("unreachable");
+    expect(status.reason).not.toBe("not_installed");
   });
 
   it("still reports gh as MISSING when the binary genuinely cannot start", async () => {


### PR DESCRIPTION
## The defect

`gh auth status` is a **network call** — it validates the stored token against api.github.com. On a box whose uplink is down or behind a captive portal it hangs, our timer SIGKILLs it at 60 s, and a signalled child closes with `code === null`.

That is the **same null** the `error` handler resolves with when the binary could not be started at all, because the close handler destructured only `(code)` and threw the `signal` away:

```ts
const timer = setTimeout(() => child.kill("SIGKILL"), opts.timeoutMs ?? GH_TIMEOUT_MS);
child.on("error", () => resolve({ code: null, ... }));   // never started
child.on("close", (code) => resolve({ code, ... }));     // killed -> also null
```

`githubStatus()` read that null as `installed: false`. So a box with **gh 2.4.0 at `/usr/bin/gh`** reported the GitHub CLI as absent, `backupToGitHub` returned `no_gh`, and `/setup-api/coding-agent/git` answered **409 "no_gh"** — telling the owner to install software they already have instead of that the network is down. `disconnectGitHub` carried the identical conflation and answered *"gh is not installed on this ClawBox."* for a logout that merely timed out.

## Reproduced on hardware (192.168.1.45)

| | result |
|---|---|
| `command -v gh` | `/usr/bin/gh` — `gh version 2.4.0+dfsg1` |
| `gh auth status`, uplink OK | reports the token *"is no longer valid"* — it can only know that by **asking github.com**, confirming it is a network call |
| `gh auth status`, uplink blackholed | **hangs, killed at the timeout (exit 124)** — exactly the SIGKILL → `code === null` path |

So the trigger is the ordinary condition of a device on a customer LAN, and the box misreports a present binary as missing.

## The fix

`run()` now keeps three facts apart instead of collapsing them into one null:

- the `close` **signal**,
- a **`timedOut`** flag set by our own timer before it kills,
- **`startFailed`**, set *only* by the `error` event — the sole evidence the binary is genuinely absent.

`githubStatus()` gains a third state: `installed: true, connected: false, reason: "unreachable"`. It is probed **fresh on every call and never cached** — a cached "unreachable" would outlive the outage that produced it and go on refusing backups after the uplink came back.

### The same null reached four more branches

Once the probe was past, four later calls read a non-zero/null code as a *fact about the folder*. The worst one is irreversible:

> `git remote get-url origin` exiting non-zero means **"no remote yet"**, and the branch below it **creates a repository on GitHub**. A killed probe returns the same null — so a transient network fault could create a **second repo** for a folder that already had one.

The regression test pins that no `gh repo create` is issued in that case. A killed `--show-toplevel` no longer tells the owner their repository *"is not its own git repository"*, and a killed push no longer reports a **blank** message (a SIGKILLed child writes no stderr, so the old `(stderr || stdout)` detail was `""`).

### Surface

- `/setup-api/coding-agent/git` answers a network fault **503** (transient, retry) rather than 409/500, and no longer advises an install.
- The card reads **"GitHub unreachable"** rather than "not connected" — we do not know whether an account is connected, only that github.com could not be asked. Translated across all 10 locales.

## Tests

New `src/tests/unit/coding-github-unreachable.test.ts`, written red-first against unmodified `beta`:

- **RED — 8 failed / 6 passed (14)**
- **GREEN — 14 passed (14)**

The failures included `expected false to be true` (installed on a killed probe), `'gh is not installed on this ClawBox.' not to match /not installed/i`, `expected true to be false` (a **second repository actually created**), and `expected '' not to be ''` (the blank push message).

Deliberately covers the three recurring shapes called out for this codebase: a probe cached instead of refreshed, an outcome inferred from an exit code, and an error path firing over something that succeeded (a logout that exited 0 is reported as the success it was).

`lint` and `tsc --noEmit` are byte-identical to the `beta` baseline (105 problems / 24 pre-existing TS errors, none in the touched files).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub connectivity issues are now distinguished from disconnected accounts.
  * The coding agent displays a clear “GitHub unreachable” status when access cannot be verified.
  * Backup, disconnect, and repository operations provide more accurate errors and avoid unsafe actions during temporary connectivity failures.
  * Timeout and unavailable-service errors include clearer feedback.

* **Localization**
  * Added “GitHub unreachable” messages across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->