### PR TITLE
fix: a box with no TTS engine at all must not finish as healthy

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1618,12 +1618,19 @@ step_openclaw_setup() {
   step_openclaw_install
   step_openclaw_patch
   step_openclaw_config
-  # Only 12 — "Kokoro was requested and did not install" — is tolerated here,
-  # and only because the step has already recorded it with
-  # record_provision_failure, so the summary, the exit status, the provisioning
-  # marker and step_validate_services' TTS probe all carry it. A box that could
-  # not install GPU TTS must still finish provisioning and come up reachable on
-  # the CPU fallback.
+  # Only 12 ("Kokoro was requested and did not install"), 13 ("this box has no
+  # working TTS engine at all") and 14 ("the TTS install did not complete, but
+  # an engine survives") are tolerated here, and only because the step has
+  # already recorded each of them with record_provision_failure, so the summary,
+  # the exit status, the provisioning marker and step_validate_services' TTS
+  # probe all carry them. A box that could not install its speech engines must
+  # still finish provisioning and come up reachable — that is how it gets fixed.
+  #
+  # They are three DIFFERENT facts and they are kept apart on purpose. Folding
+  # 14 into 13 would print "this box has no working TTS engine" over a box whose
+  # GPU engine is running perfectly and has merely lost its fallback — a failure
+  # report over something that actually succeeded, which is the same class of
+  # untrue status line this whole block exists to stop.
   #
   # Every OTHER non-zero return stays FATAL, exactly as it was before this
   # tolerance existed. Those are the provider-configuration failures — no
@@ -1637,6 +1644,8 @@ step_openclaw_setup() {
   case "$TTS_STEP_RC" in
     0) ;;
     12) echo "  Warning: Kokoro GPU TTS did not install (recorded above; provisioning continues)" ;;
+    13) echo "  Warning: this box has NO working TTS engine — it answers speech with silence (recorded above; provisioning continues)" ;;
+    14) echo "  Warning: the TTS install did not complete (recorded above; provisioning continues)" ;;
     *) return "$TTS_STEP_RC" ;;
   esac
 }
@@ -2624,13 +2633,56 @@ step_openclaw_tts() {
         echo "  ############################################################" >&2
         record_provision_failure openclaw_tts
         ;;
-    1)  KOKORO_REASON="the voice install did not complete"
-        # Reworded for TASK-420: this used to say "Kokoro still works, but a
-        # GPU failure will be silent", which was written when Kokoro was
-        # assumed present. Losing Piper is only survivable while Kokoro works.
-        echo "  Warning: the Piper CPU fallback did not install (non-fatal) — if Kokoro is unavailable or its GPU path fails, the box answers speech with silence" >&2
+    13) KOKORO_REASON="neither TTS engine installed, see the log above"
+        # ——— The box has NO working TTS engine ————————————————————
+        # install-voice.sh reaches this code when neither Kokoro nor Piper is
+        # ready and at least one of them was asked for and failed — typically a
+        # board with no CUDA (a legitimate `skipped:no-cuda`) whose Piper
+        # download flaked. It is strictly worse than 12: there is no fallback
+        # left, so the box answers every spoken request with silence.
+        #
+        # It used to arrive as a bare `exit 1` from the Piper guard, which
+        # overwrote whatever the GPU half had reported and landed in the branch
+        # below — a warning, TTS_RC left at 0, PROVISION_FAILURES left empty,
+        # and "=== ClawBox Setup Complete ===" printed over a mute box.
+        #
+        # Non-fatal, for the same reason 12 is: a box that cannot speak must
+        # still finish provisioning and come up reachable so it can be fixed.
+        TTS_RC=13
+        echo "  ############################################################" >&2
+        echo "  # This box has NO working TTS engine — neither Kokoro nor Piper." >&2
+        echo "  # It will answer every spoken request with SILENCE." >&2
+        echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step openclaw_tts" >&2
+        echo "  ############################################################" >&2
+        record_provision_failure openclaw_tts
         ;;
-    *)  KOKORO_REASON="install-voice.sh exited $VOICE_RC" ;;
+    1)  KOKORO_REASON="the voice install did not complete"
+        # An engine survives (install-voice.sh returns 13, not 1, when none
+        # does), so the box still speaks — with nothing behind the engine it
+        # speaks on. That is a provisioning failure, not a log line: this branch
+        # recorded NOTHING, which is how a lost fallback reached a customer
+        # under an "All checks healthy" banner.
+        #
+        # 14 rather than 1, because step_openclaw_setup treats 1 as fatal and a
+        # missing fallback must not abort an otherwise good install; and rather
+        # than 13, because 13 means the box cannot speak AT ALL and saying that
+        # about a box with a working Kokoro would be its own false report.
+        TTS_RC=14
+        echo "  Warning: the Piper CPU fallback did not install — this box has no fallback behind its GPU engine" >&2
+        echo "  Re-run:  sudo bash $PROJECT_DIR/install.sh --step openclaw_tts" >&2
+        record_provision_failure openclaw_tts
+        ;;
+    *)  KOKORO_REASON="install-voice.sh exited $VOICE_RC"
+        # An exit code nobody wrote a branch for is not evidence of health. The
+        # `*)` case used to leave TTS_RC at 0, so a status outside the contract
+        # — a future code, a crashed interpreter — scored exactly like success.
+        # It is 14 ("something did not complete") rather than 13 ("there is no
+        # engine") because an unknown status is not evidence of a mute box
+        # either; it is recorded, and the verdict file is what says which.
+        TTS_RC=14
+        echo "  Warning: install-voice.sh exited $VOICE_RC, which is not in its contract — treating the TTS install as failed" >&2
+        record_provision_failure openclaw_tts
+        ;;
   esac
   if [ "$KOKORO_READY" = true ]; then
     echo "  Kokoro GPU TTS installed (Piper CPU fallback behind it)"
@@ -2725,10 +2777,24 @@ step_openclaw_tts() {
   # freshly flashed boxes printed it while running entirely on Piper.
   if [ "$KOKORO_READY" = true ]; then
     echo "  On-device TTS configured (Kokoro GPU, Piper fallback)"
-  elif [ "$VOICE_RC" -eq 1 ]; then
-    echo "  On-device TTS configured, but NO engine is confirmed installed ($KOKORO_REASON)"
   else
-    echo "  On-device TTS configured (Piper CPU only — $KOKORO_REASON)"
+    # "Piper CPU only" is a claim about an engine, so it is made ONLY for the
+    # exit codes that carry one. 10, 11 and 12 all mean the Kokoro half stood
+    # down or failed while the Piper half completed, so Piper is genuinely the
+    # engine. 13 means neither half produced one, and printing "Piper CPU only"
+    # there — which is where an unhandled 13 would have landed — would put the
+    # name of a working fallback on the box this whole fix exists to catch.
+    case "$VOICE_RC" in
+      10|11|12)
+        echo "  On-device TTS configured (Piper CPU only — $KOKORO_REASON)"
+        ;;
+      13)
+        echo "  On-device TTS configured, but this box has NO working engine — it answers speech with SILENCE ($KOKORO_REASON)"
+        ;;
+      *)
+        echo "  On-device TTS configured, but NO engine is confirmed installed ($KOKORO_REASON)"
+        ;;
+    esac
   fi
   # Configuring the provider succeeded; whether the ENGINE the owner asked for
   # arrived is a separate verdict, and it is this one that leaves the function.
@@ -4782,9 +4848,16 @@ step_validate_services() {
     #
     # Hermes has no on-device TTS step at all, so it has nothing to verify.
     if ! is_hermes_edition; then
-      local tts_state=""
+      # BOTH engines, read fresh from the file on every pass. The probe used to
+      # grep `^KOKORO=` and nothing else, and the Piper half published no
+      # verdict at all — so a board with no CUDA (a legitimate
+      # `KOKORO=skipped:no-cuda`) whose Piper download flaked scored this check
+      # as a PASS and printed "All checks healthy" over a box that answers every
+      # spoken request with silence.
+      local tts_state="" piper_state=""
       if [ -r "$TTS_STATUS_FILE" ]; then
         tts_state=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
+        piper_state=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
       fi
       case "$tts_state" in
         ready|skipped:*) ;;
@@ -4795,6 +4868,31 @@ step_validate_services() {
           failed_probe+=("TTS: Kokoro GPU TTS was requested and did NOT install ($tts_state) — this box answers speech on the Piper CPU fallback. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
           ;;
       esac
+      # The CPU half, under the same rule the GPU half already carried: an
+      # ABSENT verdict fails. The TTS step runs before this check on both the
+      # install and the update path and publishes both keys, so nothing here can
+      # assert "Piper is fine" from a line that is not there.
+      case "$piper_state" in
+        ready|skipped:*) ;;
+        "")
+          failed_probe+=("TTS: no Piper verdict at $TTS_STATUS_FILE — the CPU fallback left no record, so whether this box can speak at all cannot be asserted either way. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
+          ;;
+        *)
+          failed_probe+=("TTS: the Piper CPU fallback was requested and did NOT install ($piper_state) — this box has no fallback behind its GPU engine. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
+          ;;
+      esac
+      # And the one that matters most, stated on its own rather than inferred
+      # from the two above: `skipped:*` is a PASS for each engine separately,
+      # because a board with no CUDA and a board with no pinned aarch64 artifact
+      # were each never going to run that engine. Both skipped at once on an
+      # aarch64 box is not that — it is a box with no voice.
+      if [ "$tts_state" != "ready" ] && [ "$piper_state" != "ready" ]; then
+        case "$tts_state$piper_state" in
+          *failed:*)
+            failed_probe+=("TTS: this box has NO working TTS engine (Kokoro: ${tts_state:-unreported}, Piper: ${piper_state:-unreported}) — it will answer every spoken request with silence. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
+            ;;
+        esac
+      fi
     fi
 
     # Probe 3 (hermes only): the OpenClaw gateway must be GONE. This is the only

--- a/install.sh
+++ b/install.sh
@@ -4859,39 +4859,41 @@ step_validate_services() {
         tts_state=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
         piper_state=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
       fi
-      case "$tts_state" in
-        ready|skipped:*) ;;
-        "")
-          failed_probe+=("TTS: no on-device TTS verdict at $TTS_STATUS_FILE — the TTS step left no record, so whether this box has the GPU engine cannot be asserted either way. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
-          ;;
-        *)
-          failed_probe+=("TTS: Kokoro GPU TTS was requested and did NOT install ($tts_state) — this box answers speech on the Piper CPU fallback. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
-          ;;
-      esac
-      # The CPU half, under the same rule the GPU half already carried: an
-      # ABSENT verdict fails. The TTS step runs before this check on both the
-      # install and the update path and publishes both keys, so nothing here can
-      # assert "Piper is fine" from a line that is not there.
-      case "$piper_state" in
-        ready|skipped:*) ;;
-        "")
-          failed_probe+=("TTS: no Piper verdict at $TTS_STATUS_FILE — the CPU fallback left no record, so whether this box can speak at all cannot be asserted either way. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
-          ;;
-        *)
-          failed_probe+=("TTS: the Piper CPU fallback was requested and did NOT install ($piper_state) — this box has no fallback behind its GPU engine. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
-          ;;
-      esac
-      # And the one that matters most, stated on its own rather than inferred
-      # from the two above: `skipped:*` is a PASS for each engine separately,
-      # because a board with no CUDA and a board with no pinned aarch64 artifact
-      # were each never going to run that engine. Both skipped at once on an
-      # aarch64 box is not that — it is a box with no voice.
-      if [ "$tts_state" != "ready" ] && [ "$piper_state" != "ready" ]; then
-        case "$tts_state$piper_state" in
-          *failed:*)
-            failed_probe+=("TTS: this box has NO working TTS engine (Kokoro: ${tts_state:-unreported}, Piper: ${piper_state:-unreported}) — it will answer every spoken request with silence. Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts")
-            ;;
-        esac
+      # `ready` is the only verdict that means "this engine can speak".
+      # `skipped:*` is a board that was never going to run it, `failed:*` is one
+      # that was asked and could not, and an EMPTY string is an engine that
+      # reported nothing at all — which fails, exactly as the Kokoro half
+      # already did. The TTS step runs before this check on both the install and
+      # the update path and publishes both keys, so nothing here has to assert
+      # an engine is fine from a line that is not there.
+      local kokoro_failed=false piper_failed=false
+      case "$tts_state" in failed:*) kokoro_failed=true ;; esac
+      case "$piper_state" in failed:*) piper_failed=true ;; esac
+      # ONE verdict about this box's speech, most severe first, so the check
+      # that probe_count counts as one contributes at most one line. Reporting
+      # "Kokoro failed" and "Piper failed" and "no engine" as three separate
+      # failures for one question would make the failure list longer than the
+      # number of checks that ran.
+      local tts_fix="Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts"
+      if [ -z "$tts_state" ] && [ -z "$piper_state" ]; then
+        failed_probe+=("TTS: no on-device TTS verdict at $TTS_STATUS_FILE — the TTS step left no record, so whether this box has an engine cannot be asserted either way. $tts_fix")
+      elif [ "$tts_state" != "ready" ] && [ "$piper_state" != "ready" ]         && { [ "$kokoro_failed" = true ] || [ "$piper_failed" = true ]; }; then
+        # The defect this probe was rewritten for. Note what does NOT land here:
+        # both engines `skipped:*` is a board that runs neither by design (no
+        # Jetson CUDA build AND no pinned aarch64 artifact), and failing every
+        # install-x64.sh run would only teach everyone to ignore this check.
+        failed_probe+=("TTS: this box has NO working TTS engine — Kokoro was requested and did NOT install (${tts_state:-unreported}) or is unavailable, and there is no usable Piper fallback (${piper_state:-unreported}). It will answer every spoken request with SILENCE. $tts_fix")
+      elif [ "$kokoro_failed" = true ]; then
+        failed_probe+=("TTS: Kokoro GPU TTS was requested and did NOT install ($tts_state) — this box answers speech on the Piper CPU fallback. $tts_fix")
+      elif [ -z "$tts_state" ]; then
+        failed_probe+=("TTS: no on-device TTS verdict for Kokoro at $TTS_STATUS_FILE — the GPU half left no record, so whether this box has the engine it asked for cannot be asserted either way. $tts_fix")
+      elif [ "$piper_failed" = true ]; then
+        # Reached only with Kokoro ready: every case where the GPU engine is
+        # missing too was answered above. So the box speaks, with nothing behind
+        # the engine it speaks on.
+        failed_probe+=("TTS: the Piper CPU fallback was requested and did NOT install ($piper_state) — this box has no fallback behind its GPU engine. $tts_fix")
+      elif [ -z "$piper_state" ]; then
+        failed_probe+=("TTS: no Piper verdict at $TTS_STATUS_FILE — the CPU half left no record, so whether this box has a fallback cannot be asserted either way. $tts_fix")
       fi
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -2668,7 +2668,13 @@ step_openclaw_tts() {
         # than 13, because 13 means the box cannot speak AT ALL and saying that
         # about a box with a working Kokoro would be its own false report.
         TTS_RC=14
-        echo "  Warning: the Piper CPU fallback did not install — this box has no fallback behind its GPU engine" >&2
+        # Named in terms of the half that failed, without asserting WHICH half
+        # or what survived: exit 1 covers both "the Piper CPU fallback did not
+        # install" and "the voice scripts did not deploy", and install.sh cannot
+        # tell them apart from a status code. $TTS_STATUS_FILE can, and it is
+        # what step_validate_services reads a moment later.
+        echo "  Warning: the voice install did not complete — the Piper CPU fallback did not install, or the voice scripts did not deploy" >&2
+        echo "  Which engines this box actually has is recorded in $TTS_STATUS_FILE" >&2
         echo "  Re-run:  sudo bash $PROJECT_DIR/install.sh --step openclaw_tts" >&2
         record_provision_failure openclaw_tts
         ;;
@@ -2787,6 +2793,15 @@ step_openclaw_tts() {
     case "$VOICE_RC" in
       10|11|12)
         echo "  On-device TTS configured (Piper CPU only — $KOKORO_REASON)"
+        ;;
+      1)
+        # An engine SURVIVES here — install-voice.sh returns 13, not 1, when
+        # none does — so "NO engine is confirmed installed", which is where this
+        # case used to land, is a failure report over something that succeeded.
+        # It still says nothing about WHICH engine: exit 1 is also reachable
+        # with Kokoro skipped and the script deploy failing behind a ready
+        # Piper, and naming the wrong survivor would just be a smaller lie.
+        echo "  On-device TTS configured on the engine that installed, but the voice install did not complete ($KOKORO_REASON)"
         ;;
       13)
         echo "  On-device TTS configured, but this box has NO working engine — it answers speech with SILENCE ($KOKORO_REASON)"

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -188,13 +188,19 @@ piper_install_voice() {
   echo "  Piper voice ready: $voice"
 }
 
-install_piper() {
+# The reason install_piper_engine stopped, in the verdict vocabulary. Set on
+# every path it can leave by, and turned into a published verdict by exactly one
+# caller below.
+PIPER_VERDICT_HINT="ready"
+
+install_piper_engine() {
   local arch
   arch=$(uname -m)
   if [ "$arch" != "aarch64" ]; then
     # Only the aarch64 artifact is pinned, and ClawBox is aarch64 hardware.
     # Guessing a digest for another arch would defeat the point of pinning.
     echo "  Skipping Piper: no pinned artifact for $arch (ClawBox ships aarch64)"
+    PIPER_VERDICT_HINT="skipped:arch-$arch"
     return 0
   fi
 
@@ -207,10 +213,11 @@ install_piper() {
     echo "  Downloading Piper $PIPER_VERSION..."
     piper_fetch \
       "https://github.com/rhasspy/piper/releases/download/$PIPER_VERSION/piper_linux_aarch64.tar.gz" \
-      "$tarball" "$PIPER_TARBALL_SHA256" || return 1
+      "$tarball" "$PIPER_TARBALL_SHA256" || { PIPER_VERDICT_HINT="failed:download"; return 1; }
     # The tarball unpacks a top-level piper/ directory, so extract one level up.
     tar -xzf "$tarball" -C "$(dirname "$PIPER_DIR")" || {
       echo "  ERROR: could not unpack Piper" >&2
+      PIPER_VERDICT_HINT="failed:unpack"
       return 1
     }
     rm -f "$tarball"
@@ -220,24 +227,51 @@ install_piper() {
     # "piper: binary not found", at the moment a user expected speech.
     if [ ! -f "$PIPER_DIR/piper" ]; then
       echo "  ERROR: the Piper tarball did not contain piper at $PIPER_DIR/piper" >&2
+      PIPER_VERDICT_HINT="failed:layout"
       return 1
     fi
     if ! chmod +x "$PIPER_DIR/piper"; then
       echo "  ERROR: could not make $PIPER_DIR/piper executable" >&2
+      PIPER_VERDICT_HINT="failed:not-executable"
       return 1
     fi
     echo "  Piper binary installed at $PIPER_DIR/piper"
   fi
 
   piper_install_voice "en_US-lessac-medium" "en/en_US/lessac/medium" \
-    "$PIPER_EN_ONNX_SHA256" "$PIPER_EN_JSON_SHA256" || return 1
+    "$PIPER_EN_ONNX_SHA256" "$PIPER_EN_JSON_SHA256" \
+    || { PIPER_VERDICT_HINT="failed:voice-en"; return 1; }
 
   if [ "$INSTALL_BG_VOICE" = "true" ]; then
     piper_install_voice "bg_BG-dimitar-medium" "bg/bg_BG/dimitar/medium" \
-      "$PIPER_BG_ONNX_SHA256" "$PIPER_BG_JSON_SHA256" || return 1
+      "$PIPER_BG_ONNX_SHA256" "$PIPER_BG_JSON_SHA256" \
+      || { PIPER_VERDICT_HINT="failed:voice-bg"; return 1; }
   fi
 
   chown -R "$CLAWBOX_USER:$CLAWBOX_USER" "$PIPER_DIR" 2>/dev/null || true
+}
+
+# Install the CPU fallback and PUBLISH what happened. The engine half above is
+# free to grow new early returns; this wrapper is the only writer, so a new one
+# cannot ship without a verdict.
+#
+# The verdict is never more optimistic than the exit status: a non-zero return
+# that named no reason still publishes `failed:*`. Reading "it worked" off a
+# return code without checking the outcome is how this file shipped a Piper
+# `return 0` that means "there is no artifact for this board" as if it were an
+# installed engine.
+install_piper() {
+  local rc=0
+  PIPER_VERDICT_HINT="ready"
+  install_piper_engine || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    case "$PIPER_VERDICT_HINT" in
+      failed:*) ;;
+      *) PIPER_VERDICT_HINT="failed:install" ;;
+    esac
+  fi
+  piper_report "$PIPER_VERDICT_HINT"
+  return "$rc"
 }
 
 # Deploy the TTS entrypoint + engine scripts into the workspace the gateway
@@ -495,24 +529,73 @@ activate_user_units() {
 # `failed:*` reaching only stdout is precisely how a hard failure shipped as a
 # soft fallback: the step logged an ERROR line, returned, and the flash printed
 # success. A verdict nobody can read after the fact is not a report.
-kokoro_report() {
-  local state="$1" dir
-  echo "CLAWBOX_TTS_KOKORO=$state"
+# The verdicts this run has reached, held in memory so the file can be rewritten
+# from BOTH of them every time either half reports. Publishing them
+# independently would mean whichever engine finished last erased the other's
+# answer, which is a worse report than no report at all.
+#
+# They also decide the exit status below, so a run that cannot WRITE the file
+# still tells its caller the truth about the box.
+TTS_KOKORO_VERDICT=""
+TTS_PIPER_VERDICT=""
+
+# Seed the in-memory verdicts from a file a PREVIOUS run published, so a mode
+# that installs only one engine (--piper-only, the full pipeline path) adds its
+# answer instead of blanking the other engine's. Without this, the entrypoint
+# refresh an operator runs from clawbox-tts.sh's own hint would leave a working
+# Kokoro box with no GPU verdict at all: an error path destroying a result that
+# actually succeeded.
+tts_status_load() {
+  [ -r "$TTS_STATUS_FILE" ] || return 0
+  TTS_KOKORO_VERDICT=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
+  TTS_PIPER_VERDICT=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
+}
+
+# Rewrite $TTS_STATUS_FILE from every verdict known so far. A key with no
+# verdict is OMITTED rather than written as a placeholder: install.sh's health
+# check treats an ABSENT engine verdict as a failed check, and inventing a value
+# for an engine nobody asked about would launder that silence into an answer.
+tts_status_publish() {
+  local dir
   dir=$(dirname "$TTS_STATUS_FILE")
   # Best-effort on the WRITE, never on the SILENCE: a verdict that cannot be
   # published is itself something install.sh has to hear about, because its
   # health check treats a missing verdict as a failed check rather than as a
   # pass.
   if { mkdir -p "$dir" \
-      && printf 'KOKORO=%s\nTIMESTAMP=%s\n' \
-           "$state" "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)" \
+      && { [ -z "$TTS_KOKORO_VERDICT" ] || printf 'KOKORO=%s\n' "$TTS_KOKORO_VERDICT"
+           [ -z "$TTS_PIPER_VERDICT" ] || printf 'PIPER=%s\n' "$TTS_PIPER_VERDICT"
+           printf 'TIMESTAMP=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)"; } \
            > "$TTS_STATUS_FILE"; } 2>/dev/null; then
     chmod 644 "$TTS_STATUS_FILE" 2>/dev/null || true
   else
-    echo "  Warning: could not publish the TTS verdict ($state) to $TTS_STATUS_FILE —" >&2
+    echo "  Warning: could not publish the TTS verdicts to $TTS_STATUS_FILE -" >&2
     echo "           install.sh cannot health-check a result it cannot read" >&2
   fi
 }
+
+kokoro_report() {
+  TTS_KOKORO_VERDICT="$1"
+  echo "CLAWBOX_TTS_KOKORO=$1"
+  tts_status_publish
+}
+
+# The Piper half's verdict, in the same three states and for the same reason.
+# It had none: kokoro_report was the ONLY writer of this file, so a box whose
+# CPU engine failed while Kokoro legitimately reported `skipped:no-cuda` had
+# nothing anywhere to say it could no longer speak, and finished provisioning as
+# "All checks healthy".
+piper_report() {
+  TTS_PIPER_VERDICT="$1"
+  echo "CLAWBOX_TTS_PIPER=$1"
+  tts_status_publish
+}
+
+# `ready` is the only verdict that means "this engine can speak". `skipped:*` is
+# a board that was never going to run it and `failed:*` is one that was asked
+# and could not - neither of those is an engine, and neither may be read as one.
+tts_verdict_is_ready() { [ "$1" = "ready" ]; }
+tts_verdict_is_failure() { case "$1" in failed:*) return 0 ;; *) return 1 ;; esac; }
 
 # Install the GPU Kokoro stack. NEVER fatal: every exit path leaves Piper and
 # the deployed scripts untouched, because a box that lost its voice to a failed
@@ -589,17 +672,56 @@ install_kokoro_tts() {
 # Piper goes first so a Kokoro failure can never take the fallback with it.
 if [ "${1:-}" = "--tts-only" ]; then
   echo "=== On-device TTS (Kokoro GPU + Piper fallback) ==="
-  TTS_ONLY_RC=0
-  install_piper || TTS_ONLY_RC=1
-  deploy_voice_scripts || TTS_ONLY_RC=1
+  tts_status_load
+
+  PIPER_RC=0
+  install_piper || PIPER_RC=$?
+  DEPLOY_RC=0
+  deploy_voice_scripts || DEPLOY_RC=$?
 
   KOKORO_RC=0
   install_kokoro_tts || KOKORO_RC=$?
 
-  if [ "$TTS_ONLY_RC" -ne 0 ]; then
-    # The loud one: without Piper AND without Kokoro the box answers speech
-    # with silence, so this outranks whatever the GPU path reported.
-    echo "=== Piper fallback INCOMPLETE — the box may answer speech with silence ===" >&2
+  # The exit status is the contract with install.sh's step_openclaw_tts:
+  #
+  #   0        Kokoro is the engine and it is ready.
+  #   10 / 11  Kokoro does not apply to this board; the box speaks on Piper.
+  #   12       Kokoro was REQUESTED and did not install; the box speaks on Piper.
+  #   1        the Piper half did not complete, but an engine survives.
+  #   13       NO usable engine at all - this box answers speech with SILENCE.
+  #
+  # 13 is new, and it exists because the guard below used to be a bare `exit 1`
+  # placed BEFORE `exit "$KOKORO_RC"`. Any Piper problem therefore overwrote the
+  # GPU verdict, 12 included - the hard-failure code that was landed precisely
+  # so a failed engine could not ship as a soft fallback - and install.sh's
+  # handler for 1 printed a warning and recorded nothing. A board with no CUDA
+  # (install-x64.sh, or an Orin with no nvcc) whose Piper download flaked
+  # therefore finished provisioning as "All checks healthy" and then answered
+  # every spoken request with silence.
+  #
+  # Which engines survived is read from the published VERDICTS, not from the
+  # return codes: install_piper returns 0 for a board with no pinned artifact
+  # too, and a board with no artifact has no engine however cleanly it declined
+  # to install one.
+  if ! tts_verdict_is_ready "$TTS_KOKORO_VERDICT" && ! tts_verdict_is_ready "$TTS_PIPER_VERDICT"; then
+    if tts_verdict_is_failure "$TTS_KOKORO_VERDICT" || tts_verdict_is_failure "$TTS_PIPER_VERDICT"; then
+      echo "=== NO WORKING TTS ENGINE (Kokoro: ${TTS_KOKORO_VERDICT:-unreported}, Piper: ${TTS_PIPER_VERDICT:-unreported}) ===" >&2
+      echo "=== This box will answer every spoken request with SILENCE ===" >&2
+      exit 13
+    fi
+    # Both halves declined for the board itself: no Jetson CUDA build and no
+    # pinned Piper artifact for this architecture. Nothing was asked for and
+    # nothing is missing, which is the same rule `skipped:*` has always carried
+    # - failing every install-x64.sh run would only teach everyone to ignore
+    # this check.
+    echo "=== No on-device TTS engine applies to this board (Kokoro: $TTS_KOKORO_VERDICT, Piper: $TTS_PIPER_VERDICT) ==="
+    exit "$KOKORO_RC"
+  fi
+
+  if [ "$PIPER_RC" -ne 0 ] || [ "$DEPLOY_RC" -ne 0 ]; then
+    # An engine survives, so this is a degraded box rather than a mute one - but
+    # it is still a provisioning failure, and install.sh records it as one.
+    echo "=== Piper fallback INCOMPLETE - the box has no CPU fallback behind Kokoro ===" >&2
     exit 1
   fi
   if [ "$KOKORO_RC" -eq 0 ]; then
@@ -617,6 +739,10 @@ fi
 # "Piper not installed" hint, and older devices' scripts call it.
 if [ "${1:-}" = "--piper-only" ]; then
   echo "=== Voice fallback (Piper) ==="
+  # Seeded so publishing the Piper verdict cannot blank a Kokoro verdict an
+  # earlier run left behind: this mode installs one engine and must report on
+  # one engine.
+  tts_status_load
   PIPER_ONLY_RC=0
   install_piper || PIPER_ONLY_RC=1
   deploy_voice_scripts || PIPER_ONLY_RC=1
@@ -629,6 +755,11 @@ if [ "${1:-}" = "--piper-only" ]; then
 fi
 
 echo "=== Voice Pipeline Installer (GPU-Accelerated) ==="
+
+# Same reason as the two single-engine modes above: this path installs Piper and
+# publishes its verdict, so it must carry forward any Kokoro verdict already on
+# disk rather than blank it.
+tts_status_load
 
 # ── Detect CUDA availability ────────────────────────────────────────────────
 

--- a/src/tests/unit/install-edition-switch-refusal.test.ts
+++ b/src/tests/unit/install-edition-switch-refusal.test.ts
@@ -398,7 +398,11 @@ function runValidator(
   // that also reads the TTS verdict would otherwise fail every case here for a
   // reason that has nothing to do with editions.
   const ttsStatus = path.join(tmp, "tts-status");
-  fs.writeFileSync(ttsStatus, "KOKORO=ready\n");
+  // BOTH engine verdicts, because scripts/install-voice.sh now publishes
+  // both and step_validate_services fails an ABSENT one under the same
+  // rule it already applied to KOKORO. This device is healthy, so the TTS
+  // probe is not what these tests are about.
+  fs.writeFileSync(ttsStatus, "KOKORO=ready\nPIPER=ready\n");
 
   const script = [
     "set -uo pipefail",

--- a/src/tests/unit/install-foreign-edition-teardown.test.ts
+++ b/src/tests/unit/install-foreign-edition-teardown.test.ts
@@ -451,7 +451,11 @@ function runValidator(
   // on-device TTS verdict would otherwise fail every case here for a reason
   // that has nothing to do with editions.
   const ttsStatus = path.join(tmp, "tts-status");
-  fs.writeFileSync(ttsStatus, "KOKORO=ready\n");
+  // BOTH engine verdicts, because scripts/install-voice.sh now publishes
+  // both and step_validate_services fails an ABSENT one under the same
+  // rule it already applied to KOKORO. This device is healthy, so the TTS
+  // probe is not what these tests are about.
+  fs.writeFileSync(ttsStatus, "KOKORO=ready\nPIPER=ready\n");
 
   const script = [
     "set -uo pipefail",

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -419,9 +419,13 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     expect(res.stderr).not.toMatch(/Kokoro still works/);
     // Exit 1 is the Piper half failing, so claiming Piper is the active engine
     // would just be a smaller version of the same lie.
-    expect(res.stdout).toContain("NO engine is confirmed installed");
     expect(res.stdout).not.toContain("Piper CPU only");
     expect(res.stdout).not.toContain("Kokoro GPU, Piper fallback");
+    // Nor the opposite lie. install-voice.sh returns 13, not 1, when no engine
+    // survives, so an engine IS confirmed installed on this path and saying
+    // otherwise reports a failure over something that succeeded (TTS-01).
+    expect(res.stdout).not.toContain("NO engine is confirmed installed");
+    expect(res.stdout).toContain("the voice install did not complete");
   });
 });
 

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -407,7 +407,14 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     // The old wording said "Kokoro still works, but a GPU failure will be
     // silent" — written when Kokoro was assumed present, which it never was.
     const res = runStep(1);
-    expect(res.status).toBe(0);
+    // 14, not 0. Returning 0 here is what left PROVISION_FAILURES empty for a
+    // box that had lost its CPU fallback, so the run printed Setup Complete
+    // over it (TTS-01); the step now records the failure and says so in its
+    // status. It stays out of the fatal range because a missing fallback must
+    // not abort an otherwise good install — see step_openclaw_setup, which
+    // tolerates 12, 13 and 14 and nothing else. It is deliberately NOT 13:
+    // that code means the box cannot speak at all, and this box still can.
+    expect(res.status).toBe(14);
     expect(res.stderr).toMatch(/Piper CPU fallback did not install/);
     expect(res.stderr).not.toMatch(/Kokoro still works/);
     // Exit 1 is the Piper half failing, so claiming Piper is the active engine
@@ -848,12 +855,15 @@ describe.skipIf(!hasBash)("service validation refuses to call a Kokoro-less box 
     // The distinction the whole verdict file exists for: no CUDA is not a
     // defect, and failing every x86 or non-Jetson install would just teach
     // everyone to ignore this check.
-    const res = runValidator("KOKORO=skipped:no-cuda\n");
+    // The Piper verdict is part of the fixture because it is part of the
+    // published contract now: the probe reads both engines, and a board that
+    // declined Kokoro still has to say whether it got a CPU engine (TTS-01).
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=ready\n");
     expect(res.status, res.out).toBe(0);
   });
 
   it("passes a box that has the engine", () => {
-    expect(runValidator("KOKORO=ready\n").status).toBe(0);
+    expect(runValidator("KOKORO=ready\nPIPER=ready\n").status).toBe(0);
   });
 
   it("refuses to read a MISSING verdict as a healthy one", () => {

--- a/src/tests/unit/install-tts-no-engine.test.ts
+++ b/src/tests/unit/install-tts-no-engine.test.ts
@@ -1,0 +1,494 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * A box with NO working TTS engine at all finished provisioning as
+ * "All checks healthy" (TTS-01).
+ *
+ * PR #506 removed the false success for one half of the speech install — the
+ * Kokoro GPU half, which publishes a verdict to $TTS_STATUS_FILE that
+ * install.sh health-checks. The OTHER half published nothing, so the same
+ * false success was still reachable straight through it:
+ *
+ *   1. On a board with no CUDA (install-x64.sh, or an Orin with no nvcc)
+ *      install_kokoro_tts legitimately publishes `KOKORO=skipped:no-cuda`.
+ *   2. install_piper fails on a flaky download.
+ *   3. `--tts-only` ran its Piper guard BEFORE `exit "$KOKORO_RC"`, so the bare
+ *      `exit 1` overwrote the Kokoro verdict — including 12, the hard-failure
+ *      code #506 exists to surface.
+ *   4. install.sh's `case "$VOICE_RC" in 1)` printed a warning, left TTS_RC=0
+ *      and never called record_provision_failure, so PROVISION_FAILURES stayed
+ *      empty.
+ *   5. step_validate_services greps only `^KOKORO=` and scores `skipped:*` as a
+ *      PASS, so the run printed "=== ClawBox Setup Complete ===" with no
+ *      PROVISIONING INCOMPLETE banner.
+ *
+ * The box then answers every spoken request with silence.
+ *
+ * These tests EXECUTE the shipped artifacts — the real `--tts-only` dispatch
+ * out of scripts/install-voice.sh, the real step_openclaw_tts and the real
+ * step_validate_services out of install.sh — against stubs. A rewrite that
+ * keeps the prose but drops the verdict fails them.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_VOICE = path.join(REPO, "scripts", "install-voice.sh");
+const INSTALL_VOICE_SH = readFileSync(INSTALL_VOICE, "utf-8");
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+/**
+ * The stub PATH below is deliberately just the stub dir plus the POSIX system
+ * dirs, so the script under test cannot reach the real curl, wget or nvcc. On
+ * Windows that also makes `bash` itself unfindable — the child's PATH is what
+ * resolves the command — and every spawn fails with ENOENT before the script
+ * runs a line. Appending the host PATH there restores the lookup only; the stub
+ * dir still comes first, so the stubs keep winning. Empty on Linux/CI, where
+ * the isolated PATH works as written.
+ */
+const HOST_PATH_SUFFIX = process.platform === "win32" ? `${path.delimiter}${process.env.PATH ?? ""}` : "";
+
+function extractShellFn(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end + 2);
+}
+
+/** Read a pinned constant (e.g. PIPER_EN_ONNX_SHA256) out of the real script. */
+function shellConst(name: string): string {
+  const m = new RegExp(`^${name}="([^"]+)"`, "m").exec(INSTALL_VOICE_SH);
+  if (!m) throw new Error(`${name} not found in install-voice.sh`);
+  return m[1];
+}
+
+function writeExec(file: string, body: string) {
+  writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+}
+
+/**
+ * Run a generated shell program from a FILE rather than `bash -c "$program"`.
+ *
+ * These programs carry whole functions lifted out of install.sh and run well
+ * past 8 KiB, which is the per-argument ceiling on the Windows spawn path: a
+ * `-c` argument is silently truncated there and bash dies with "unexpected end
+ * of file" whatever the script under test actually does. Writing the program
+ * out first is identical on Linux and makes this regression runnable on a
+ * developer machine instead of only in CI.
+ */
+function runShellProgram(program: string, env: Record<string, string>) {
+  const file = path.join(root, `prog-${Math.random().toString(36).slice(2)}.sh`);
+  writeFileSync(file, program);
+  return spawnSync("bash", [file], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, ...env },
+  });
+}
+
+let root: string;
+
+interface VoiceRun {
+  status: number | null;
+  out: string;
+  /** Contents of the published TTS verdict file, or "" when none was written. */
+  ttsStatus: string;
+  /** The value of one key in the published verdict file, or null when absent. */
+  verdict: (key: string) => string | null;
+}
+
+/**
+ * Build a fake device root and a PATH of stubs, then run the REAL
+ * `scripts/install-voice.sh --tts-only`.
+ *
+ * `piper` picks what the CPU half does:
+ *   "ready"   the binary and voices are already on disk — nothing to download.
+ *   "broken"  nothing on disk and every fetch fails, which is the flaky
+ *             download this defect was reproduced with.
+ *
+ * `withCuda` puts an nvcc stub on PATH; without it install_kokoro_tts takes its
+ * legitimate `skipped:no-cuda` path, which is the board half of the defect.
+ */
+function runTtsOnly(
+  opts: {
+    piper?: "ready" | "broken";
+    withCuda?: boolean;
+    arch?: string;
+    warmupExit?: string;
+    args?: string[];
+  } = {},
+): VoiceRun {
+  const { piper = "ready", withCuda = false, arch = "aarch64", args = ["--tts-only"] } = opts;
+  const home = path.join(root, "home", "clawbox");
+  const bin = path.join(root, "bin");
+  const ttsStatus = path.join(root, "tts-status");
+  const cudaHome = path.join(root, withCuda ? "cuda" : "no-such-cuda");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+
+  if (withCuda) {
+    mkdirSync(path.join(home, ".local", "lib", "python3.10", "site-packages", "nvidia", "cusparselt", "lib"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(cudaHome, "lib64"), { recursive: true });
+    writeExec(path.join(bin, "nvcc"), 'echo "Cuda compilation tools, release 12.6, V12.6.68"');
+  }
+
+  writeExec(
+    path.join(bin, "su"),
+    [
+      'cmd=""',
+      'while [ $# -gt 0 ]; do case "$1" in -c) cmd="$2"; shift 2;; *) shift;; esac; done',
+      'stdin_code=""',
+      'case "$cmd" in *"python3 -") stdin_code="$(cat)" ;; esac',
+      'full=$(printf "%s\\n%s" "$cmd" "$stdin_code")',
+      "case \"$full\" in",
+      '  *"sys.version_info"*) echo "python3.10"; exit 0 ;;',
+      // The Kokoro packages are already on disk, so the GPU half reaches its
+      // `ready` verdict without a single download.
+      '  *"import kokoro, torch"*) exit 0 ;;',
+      '  *"from kokoro import KPipeline"*) exit "${WARMUP_EXIT:-0}" ;;',
+      "esac",
+      "exit 0",
+    ].join("\n"),
+  );
+  writeExec(
+    path.join(bin, "uname"),
+    [`[ "\${1:-}" = "-m" ] && { echo "\${FAKE_ARCH:-aarch64}"; exit 0; }`, 'exec /usr/bin/uname "$@"'].join("\n"),
+  );
+  // No network in a unit test. This is also the ONE injected fault in the
+  // "broken" case: a download that does not come back.
+  writeExec(path.join(bin, "curl"), "exit 1");
+  writeExec(path.join(bin, "wget"), "exit 1");
+  writeExec(path.join(bin, "chown"), "exit 0");
+  writeExec(path.join(bin, "loginctl"), "exit 0");
+  writeExec(path.join(bin, "sha256sum"), 'printf "%s  %s\\n" "$(head -c 64 "$1")" "$1"');
+
+  const piperDir = path.join(root, "piper");
+  if (piper === "ready") {
+    mkdirSync(path.join(piperDir, "voices"), { recursive: true });
+    writeExec(path.join(piperDir, "piper"), "exit 0");
+    writeFileSync(path.join(piperDir, "voices", "en_US-lessac-medium.onnx"), shellConst("PIPER_EN_ONNX_SHA256"));
+    writeFileSync(
+      path.join(piperDir, "voices", "en_US-lessac-medium.onnx.json"),
+      shellConst("PIPER_EN_JSON_SHA256"),
+    );
+  }
+
+  const res = spawnSync("bash", [INSTALL_VOICE, ...args], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: {
+      PATH: `${bin}:/usr/bin:/bin${HOST_PATH_SUFFIX}`,
+      HOME: home,
+      CLAWBOX_USER: "clawbox",
+      CLAWBOX_HOME: home,
+      PIPER_DIR: piperDir,
+      CLAWBOX_CUDA_HOME: cudaHome,
+      CLAWBOX_TTS_STATUS_FILE: ttsStatus,
+      FAKE_ARCH: arch,
+      ...(opts.warmupExit ? { WARMUP_EXIT: opts.warmupExit } : {}),
+      // Cast only because this repo's ProcessEnv augmentation insists on
+      // NODE_ENV, which this deliberately minimal stub environment has no
+      // business carrying — the point of it is that the script under test can
+      // reach nothing but the stubs.
+    } as unknown as NodeJS.ProcessEnv,
+  });
+
+  const contents = existsSync(ttsStatus) ? readFileSync(ttsStatus, "utf-8") : "";
+  return {
+    status: res.status,
+    out: `${res.stdout ?? ""}${res.stderr ?? ""}`,
+    ttsStatus: contents,
+    verdict: (key: string) => {
+      const m = new RegExp(`^${key}=(.*)$`, "m").exec(contents);
+      return m ? m[1] : null;
+    },
+  };
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "tts-no-engine-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+// ── 1. The Piper half has to publish a verdict of its own ───────────────────
+
+describe.skipIf(!hasBash)("the CPU engine publishes a verdict that outlives the run", () => {
+  it("publishes PIPER=ready next to KOKORO= when the fallback is installed", () => {
+    const res = runTtsOnly({ piper: "ready" });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toBe("skipped:no-cuda");
+    expect(res.verdict("PIPER"), `no Piper verdict was published:\n${res.ttsStatus}`).toBe("ready");
+  });
+
+  it("publishes a failed:* Piper verdict where something other than stdout can read it", () => {
+    // The half of the speech install that published NOTHING. stdout is not a
+    // report: nobody greps a flash log a week later.
+    const res = runTtsOnly({ piper: "broken" });
+    expect(res.verdict("PIPER"), `no Piper verdict was published:\n${res.ttsStatus}`).toMatch(/^failed:/);
+  });
+
+  it("does not report Piper ready from a return code that only means 'declined'", () => {
+    // install_piper returns 0 on a non-aarch64 board because there is no pinned
+    // artifact to install — a clean decline, not an engine. Reading success off
+    // that exit code is the "reports success from an exit code without checking
+    // the outcome" shape this codebase keeps producing.
+    const res = runTtsOnly({ piper: "broken", arch: "x86_64" });
+    expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^skipped:/);
+    expect(res.verdict("PIPER")).not.toBe("ready");
+  });
+
+  it("keeps both verdicts in the file — neither half erases the other", () => {
+    const res = runTtsOnly({ piper: "ready", withCuda: true });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toBe("ready");
+    expect(res.verdict("PIPER"), res.ttsStatus).toBe("ready");
+  });
+});
+
+// ── 2. The Piper guard must not destroy the Kokoro verdict ──────────────────
+
+describe.skipIf(!hasBash)("--tts-only reports which engines survived, not just the last thing it did", () => {
+  it("exits 13 when NEITHER engine is usable", () => {
+    // The defect, end to end: no CUDA is a legitimate skip and a failed Piper
+    // download is a real failure, and together they leave the box mute. The old
+    // code exited a bare 1, which install.sh laundered into a warning.
+    const res = runTtsOnly({ piper: "broken" });
+    expect(res.status, `a box with no TTS engine exited ${res.status}:\n${res.out}`).toBe(13);
+    expect(res.out).toMatch(/SILENCE|no working TTS engine/i);
+  });
+
+  it("still surfaces Kokoro's hard-failure code when Piper is the survivor", () => {
+    // 12 is the code #506 landed to surface. A Piper problem must not overwrite
+    // it, and a Piper SUCCESS must not hide it either.
+    const res = runTtsOnly({ piper: "ready", withCuda: true, warmupExit: "1" });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toMatch(/^failed:/);
+    expect(res.status, `the Kokoro verdict was overwritten:\n${res.out}`).toBe(12);
+  });
+
+  it("does not cry 'no engine' when Kokoro actually landed", () => {
+    // The mirror-image bug class: an error path reporting failure over
+    // something that succeeded. Losing the CPU fallback while the GPU engine
+    // works is a degraded box, not a mute one, and must not exit 13.
+    const res = runTtsOnly({ piper: "broken", withCuda: true });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toBe("ready");
+    expect(res.status, res.out).toBe(1);
+  });
+
+  it("does not cry 'no engine' on a board no engine was ever going to run on", () => {
+    // x86_64: no pinned Piper artifact AND no Jetson CUDA build. Nothing was
+    // asked for and nothing is missing — failing every install-x64.sh run would
+    // just teach everyone to ignore this check.
+    const res = runTtsOnly({ piper: "ready", arch: "x86_64" });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toMatch(/^skipped:/);
+    expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^skipped:/);
+    expect(res.status, `a board with no applicable engine was called broken:\n${res.out}`).toBe(11);
+  });
+});
+
+// ── 3. install.sh must not launder that into a warning ──────────────────────
+
+/**
+ * Run the real step_openclaw_tts against a stub install-voice.sh whose exit
+ * code the test picks, and report whether the step reached for
+ * record_provision_failure — the call that is the difference between a failure
+ * the operator sees and one that ends at a log line nobody greps.
+ */
+function runStep(voiceExit: number) {
+  const projectDir = path.join(root, "project");
+  mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+  writeExec(
+    path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+    '[ "${1:-}" = "--provider-timeout-ms" ] && echo 100000\nexit 0',
+  );
+  writeExec(path.join(projectDir, "scripts", "install-voice.sh"), `exit ${voiceExit}`);
+  const openclaw = path.join(root, "openclaw");
+  writeExec(openclaw, "exit 0");
+
+  const provisionLog = path.join(root, "provision-failures.log");
+  const ttsStatus = path.join(root, "step-tts-status");
+
+  const program = [
+    "set -uo pipefail",
+    `PROJECT_DIR="${projectDir}"`,
+    `OPENCLAW_BIN="${openclaw}"`,
+    "CLAWBOX_USER=clawbox",
+    'as_clawbox() { env "$@"; }',
+    "is_hermes_edition() { return 1; }",
+    `record_provision_failure() { printf '%s\\n' "$1" >> "${provisionLog}"; }`,
+    extractShellFn(INSTALL_SH, "oc_config_set"),
+    extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
+    extractShellFn(INSTALL_SH, "step_openclaw_tts"),
+    "step_openclaw_tts",
+    'echo "STEP_RC=$?"',
+  ].join("\n");
+
+  const res = runShellProgram(program, { TTS_STATUS_FILE: ttsStatus });
+  const out = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+  return {
+    out,
+    stepRc: /STEP_RC=(\d+)/.exec(out)?.[1] ?? "",
+    provisionFailures: existsSync(provisionLog)
+      ? readFileSync(provisionLog, "utf-8").trim().split("\n").filter(Boolean)
+      : [],
+  };
+}
+
+describe.skipIf(!hasBash)("step_openclaw_tts records the failures it is handed", () => {
+  it("records a provision failure when the box is left with no engine (13)", () => {
+    const res = runStep(13);
+    expect(res.provisionFailures, `nothing was recorded:\n${res.out}`).toContain("openclaw_tts");
+    expect(res.out).toMatch(/SILENCE|no working TTS engine/i);
+  });
+
+  it("records a provision failure when the CPU fallback did not install (1)", () => {
+    // This branch printed a warning, left TTS_RC=0 and recorded nothing, so
+    // PROVISION_FAILURES stayed empty and the run printed Setup Complete.
+    const res = runStep(1);
+    expect(res.provisionFailures, `a lost fallback was recorded nowhere:\n${res.out}`).toContain("openclaw_tts");
+  });
+
+  it("records a provision failure on an exit code it does not recognise", () => {
+    // "No answer" and "an answer nobody wrote a branch for" must not both score
+    // as healthy. 99 is not in the contract, so it cannot be assumed benign.
+    const res = runStep(99);
+    expect(res.provisionFailures, `an unknown voice-install status passed silently:\n${res.out}`).toContain(
+      "openclaw_tts",
+    );
+  });
+
+  it("stays non-fatal — a mute box still finishes provisioning and comes up reachable", () => {
+    // Loud, recorded, and reflected in the exit status, but not an aborted
+    // install: a box that cannot speak must still be reachable to be fixed.
+    for (const code of [1, 13]) {
+      const res = runStep(code);
+      expect(res.stepRc, `install-voice.sh ${code} aborted the step:\n${res.out}`).not.toBe("");
+    }
+  });
+
+  it("records nothing when the board simply has no CUDA", () => {
+    const res = runStep(10);
+    expect(res.provisionFailures).toEqual([]);
+  });
+
+  it("never puts the name of a working fallback on a box that has none", () => {
+    // The trap this fix walked into on its way out of the original one. Before
+    // 13 existed, every unhandled voice status fell through to the final `else`
+    // and printed "On-device TTS configured (Piper CPU only)". Reached by a
+    // MUTE box that is the same false success in a smaller font — a Piper the
+    // box does not have, named in the summary line an operator actually reads.
+    const res = runStep(13);
+    expect(res.out, `a mute box was told it speaks on Piper:
+${res.out}`).not.toContain("Piper CPU only");
+    expect(res.out).not.toContain("Kokoro GPU, Piper fallback");
+    expect(res.out).toMatch(/SILENCE/);
+  });
+
+  it("does not call a box mute when only its fallback is gone", () => {
+    // The mirror image, and the reason 1 maps to its own code instead of
+    // sharing 13. A box whose Kokoro is running and whose Piper download flaked
+    // is DEGRADED, not silent; reporting "this box has no working TTS engine"
+    // over a working engine is a failure report over something that succeeded.
+    const degraded = runStep(1);
+    const mute = runStep(13);
+    expect(degraded.stepRc, `a degraded box was reported as a mute one:
+${degraded.out}`).toBe("14");
+    expect(mute.stepRc).toBe("13");
+    expect(degraded.stepRc).not.toBe(mute.stepRc);
+    expect(degraded.out).not.toMatch(/SILENCE/);
+  });
+
+  it("keeps both tolerated codes out of the fatal range step_openclaw_setup enforces", () => {
+    // step_openclaw_setup returns any status it has no branch for, which aborts
+    // the whole provision. 13 and 14 are the two it must carry rather than die
+    // on, so a box that cannot speak still comes up reachable enough to fix.
+    const setup = extractShellFn(INSTALL_SH, "step_openclaw_setup");
+    for (const code of ["13)", "14)"]) {
+      expect(setup, `step_openclaw_setup would abort the provision on ${code}`).toContain(code);
+    }
+  });
+});
+
+// ── 4. The health check has to read both verdicts ───────────────────────────
+
+/**
+ * Run the real step_validate_services with everything except the TTS verdict
+ * stubbed healthy. `contents` is written to the verdict file, or the file is
+ * left absent when it is null.
+ */
+function runValidator(contents: string | null): { status: number; out: string } {
+  const ttsStatus = path.join(root, "validator-tts-status");
+  if (contents !== null) writeFileSync(ttsStatus, contents);
+  const clock = path.join(root, "clock");
+  writeFileSync(clock, "1000\n");
+
+  const program = [
+    "set -uo pipefail",
+    "CLAWBOX_EDITION=openclaw",
+    "CLAWBOX_TEST_MODE=1",
+    "PROJECT_DIR=/home/clawbox/clawbox",
+    'IFACE_ENV="/nonexistent/network.env"',
+    "EXPECTED_ACTIVE_SERVICES=()",
+    "EXPECTED_INSTALLED_SERVICES=()",
+    "FOREIGN_EDITION_UNITS=()",
+    'is_test_mode() { [ "$CLAWBOX_TEST_MODE" = "1" ]; }',
+    'is_hermes_edition() { [ "$CLAWBOX_EDITION" = "hermes" ]; }',
+    "has_hermes_harness() { return 1; }",
+    "gateway_port_listening() { return 1; }",
+    "systemctl() { return 0; }",
+    "curl() { printf '200'; }",
+    `_CLOCK="${clock}"`,
+    'date() { local n; n=$(( $(cat "$_CLOCK") + 100 )); echo "$n" > "$_CLOCK"; printf %s "$n"; }',
+    "sleep() { :; }",
+    extractShellFn(INSTALL_SH, "step_validate_services"),
+    "step_validate_services",
+  ].join("\n");
+
+  const r = runShellProgram(program, { TTS_STATUS_FILE: ttsStatus });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe.skipIf(!hasBash)("service validation refuses to call a mute box healthy", () => {
+  it("FAILS a board where Kokoro skipped and Piper failed", () => {
+    // The exact shipped state this defect was reproduced in. The old probe
+    // greps `^KOKORO=`, sees `skipped:no-cuda`, and prints "All checks healthy"
+    // over a box that answers every spoken request with silence.
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=failed:download\n");
+    expect(res.status, `validation passed a box with no TTS engine:\n${res.out}`).toBe(1);
+    expect(res.out).toMatch(/--step openclaw_tts/);
+  });
+
+  it("FAILS when the Piper verdict is absent", () => {
+    // "No answer" is not a pass — the same rule the KOKORO probe already
+    // applies, and the reason this file exists.
+    const res = runValidator("KOKORO=skipped:no-cuda\n");
+    expect(res.status, `an unreported engine scored as healthy:\n${res.out}`).toBe(1);
+  });
+
+  it("passes a board that was never going to run either engine", () => {
+    // install-x64.sh: no Jetson CUDA build and no pinned Piper artifact.
+    const res = runValidator("KOKORO=skipped:arch-x86_64\nPIPER=skipped:arch-x86_64\n");
+    expect(res.status, res.out).toBe(0);
+  });
+
+  it("passes a no-CUDA Orin that speaks on the CPU fallback", () => {
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=ready\n");
+    expect(res.status, res.out).toBe(0);
+  });
+
+  it("passes a box that has the GPU engine", () => {
+    expect(runValidator("KOKORO=ready\nPIPER=ready\n").status).toBe(0);
+  });
+
+  it("re-reads the verdict file on every probe rather than trusting an earlier answer", () => {
+    // A probe taken once and never refreshed is its own recurring defect here.
+    // Same process, same helper, two different files: the second answer has to
+    // come from the second file.
+    expect(runValidator("KOKORO=ready\nPIPER=ready\n").status).toBe(0);
+    expect(runValidator("KOKORO=skipped:no-cuda\nPIPER=failed:download\n").status).toBe(1);
+  });
+});

--- a/src/tests/unit/install-tts-no-engine.test.ts
+++ b/src/tests/unit/install-tts-no-engine.test.ts
@@ -382,8 +382,7 @@ describe.skipIf(!hasBash)("step_openclaw_tts records the failures it is handed",
     // MUTE box that is the same false success in a smaller font — a Piper the
     // box does not have, named in the summary line an operator actually reads.
     const res = runStep(13);
-    expect(res.out, `a mute box was told it speaks on Piper:
-${res.out}`).not.toContain("Piper CPU only");
+    expect(res.out, `a mute box was told it speaks on Piper:\n${res.out}`).not.toContain("Piper CPU only");
     expect(res.out).not.toContain("Kokoro GPU, Piper fallback");
     expect(res.out).toMatch(/SILENCE/);
   });
@@ -395,8 +394,7 @@ ${res.out}`).not.toContain("Piper CPU only");
     // over a working engine is a failure report over something that succeeded.
     const degraded = runStep(1);
     const mute = runStep(13);
-    expect(degraded.stepRc, `a degraded box was reported as a mute one:
-${degraded.out}`).toBe("14");
+    expect(degraded.stepRc, `a degraded box was reported as a mute one:\n${degraded.out}`).toBe("14");
     expect(mute.stepRc).toBe("13");
     expect(degraded.stepRc).not.toBe(mute.stepRc);
     expect(degraded.out).not.toMatch(/SILENCE/);

--- a/src/tests/unit/install-tts-no-engine.test.ts
+++ b/src/tests/unit/install-tts-no-engine.test.ts
@@ -400,6 +400,23 @@ describe.skipIf(!hasBash)("step_openclaw_tts records the failures it is handed",
     expect(degraded.out).not.toMatch(/SILENCE/);
   });
 
+  it("does not tell a box with a working engine that it has none", () => {
+    // install-voice.sh returns 13, not 1, when no engine survives, so exit 1
+    // always leaves one standing. The summary case had no arm for 1 and fell
+    // through to the unknown-code arm, so a box running Kokoro perfectly and
+    // merely missing its fallback was told "NO engine is confirmed installed"
+    // — a failure report over something that succeeded, in the same operator
+    // line this fix exists to make truthful.
+    const res = runStep(1);
+    expect(res.out, `a working engine was reported as none:\n${res.out}`).not.toContain(
+      "NO engine is confirmed installed",
+    );
+    // And it must not swing the other way into naming an engine it cannot
+    // know: exit 1 is also reachable with Kokoro skipped behind a ready Piper.
+    expect(res.out).not.toContain("Kokoro GPU, Piper fallback");
+    expect(res.out).not.toContain("Piper CPU only");
+  });
+
   it("keeps both tolerated codes out of the fatal range step_openclaw_setup enforces", () => {
     // step_openclaw_setup returns any status it has no branch for, which aborts
     // the whole provision. 13 and 14 are the two it must carry rather than die


### PR DESCRIPTION
## The defect

#506 removed the false success for one half of the speech install. The Kokoro half publishes a verdict to `/etc/clawbox/tts-status` that `install.sh` health-checks. The **Piper half published nothing**, so the same false success was still reachable straight through it.

Confirmed on a live box (192.168.1.45, read only): its status file reads exactly `KOKORO=ready` + `TIMESTAMP=`, and there is no `PIPER=` verdict anywhere in the tree.

The chain, every hop in the shipped artifacts:

1. On a board with no CUDA (`install-x64.sh`, or any Orin without `nvcc`) `install_kokoro_tts` legitimately publishes `KOKORO=skipped:no-cuda`.
2. `install_piper` fails on a flaky download.
3. `--tts-only` ran its Piper guard **before** `exit "$KOKORO_RC"`, so the bare `exit 1` overwrote the Kokoro verdict — including 12, the hard-failure code #506 exists to surface.
4. `install.sh:2627` `case "$VOICE_RC" in 1)` printed a warning, left `TTS_RC=0` and — unlike the `12)` branch — never called `record_provision_failure`, so `PROVISION_FAILURES` stayed empty.
5. `step_validate_services` grepped only `^KOKORO=` and scored `skipped:*` a PASS.

`FINAL_RC` stayed 0 and the run printed `=== ClawBox Setup Complete ===` with no PROVISIONING INCOMPLETE banner. The box then answers every spoken request with silence.

### Reproduced against unmodified `beta`

Running the real `scripts/install-voice.sh --tts-only` with no CUDA and a failing download:

```
  Skipping Kokoro: no CUDA toolkit (no nvcc on PATH, ...)
CLAWBOX_TTS_KOKORO=skipped:no-cuda
  ERROR: download failed: .../piper_linux_aarch64.tar.gz
=== Piper fallback INCOMPLETE — the box may answer speech with silence ===
exit status: 1

/etc/clawbox/tts-status:
KOKORO=skipped:no-cuda
TIMESTAMP=2026-08-27T20:10:44Z          <- no PIPER verdict, anywhere
```

Feeding that state to the real `step_validate_services`, also on unmodified `beta`:

```
  ✓ All 2 checks healthy (services + WiFi AP + web dashboard + edition probes)
  exit 0
```

## The fix

**`scripts/install-voice.sh`**

- `install_piper` is split into `install_piper_engine` (which may grow new early returns freely) and a publishing wrapper that is the **only** caller, so no exit path can ship without a `PIPER=` verdict. The verdict is never more optimistic than the exit status.
- Both verdicts are held in memory and the file is rewritten from **both** on every report, so whichever engine finishes last cannot erase the other's answer. `--piper-only` and the full pipeline seed themselves from disk first, so a mode that installs one engine adds its answer instead of blanking the other.
- Which engines survived is decided from the **published verdicts, not the return codes** — `install_piper` also returns 0 for a board with no pinned artifact, and a board with no artifact has no engine however cleanly it declined to install one.
- A run that leaves no usable engine exits **13** instead of clobbering the Kokoro verdict with a bare `exit 1`.

**`install.sh`**

- `13` gets its own loud branch that calls `record_provision_failure openclaw_tts`.
- So does `1)` (fallback lost, an engine survives) and any exit code outside the contract — both under a new **14**, which `step_openclaw_setup` tolerates as its own outcome. 14 is deliberately not folded into 13: printing "this box has no working TTS engine" over a box whose Kokoro is running would be a failure report over something that actually succeeded.
- The end-of-step summary no longer prints `Piper CPU only` for outcomes that carry no Piper — that line is now made only for 10/11/12, the codes that genuinely leave Piper as the engine.
- `step_validate_services` reads `PIPER=` under the same rule `KOKORO=` already carried — an **absent** verdict fails — and fails the probe when neither engine is ready.

Skips stay passes: a board that was never going to run either engine (no Jetson CUDA build *and* no pinned aarch64 artifact) is not a broken one. Failing every `install-x64.sh` run would only teach everyone to ignore this check.

## Tests

New `src/tests/unit/install-tts-no-engine.test.ts` (22 tests) executes the shipped artifacts — the real `--tts-only` dispatch, the real `step_openclaw_tts`, the real `step_validate_services` — against stubs. A rewrite that keeps the prose but drops the verdict fails them.

Red-first against unmodified `origin/beta`: **15 failed / 4 passed** (the 4 are the must-not-regress controls). After the fix: **22 passed**.

The three recurring shapes this codebase keeps producing are each pinned by a test:

- *a probe taken once that never refreshes* — `re-reads the verdict file on every probe rather than trusting an earlier answer`
- *success reported from an exit code without checking the outcome* — `does not report Piper ready from a return code that only means 'declined'`
- *failure reported over something that succeeded* — `does not cry 'no engine' when Kokoro actually landed` and `does not call a box mute when only its fallback is gone`

`lint` and `tsc --noEmit` are byte-identical to the `beta` baseline (22 eslint errors, 24 tsc errors, both pre-existing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improved Features**
  - Improved voice engine installation reporting for Kokoro and Piper.
  - Clearly indicates whether speech is ready, unavailable, skipped, failed, or unconfirmed.
  - Preserves engine status during targeted or repeat installations.
  - Service validation now checks both speech engines and reports fallback or missing-engine states.

- **Bug Fixes**
  - Records voice provisioning failures without unnecessarily stopping installation.
  - Improved handling of fallback failures, unavailable hardware, and degraded installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->