### PR TITLE
Chat header model picker: obey the subscription surface the wizard already obeys

### DIFF
--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -127,10 +127,12 @@ function defaultModelForProvider(provider: string | null): string | null {
  * whenever the provider changes.
  */
 function subscriptionProvidersForUi(config: OpenClawConfig): string[] {
-  const ids = subscriptionOnlyProviders(config.auth?.profiles)
-    .map((provider) => normalizeProvider(provider))
-    .filter((provider): provider is string => !!provider);
-  return [...new Set(ids)].sort();
+  // `normalizeProvider` goes IN, not around the outside. deepseek and clawai
+  // are one provider under two names, so collapsing the alias after the
+  // credentials are counted would read an OAuth profile written as `deepseek`
+  // and an API key written as `clawai` as two separate providers, and report
+  // the box subscription-only on a key it actually holds.
+  return subscriptionOnlyProviders(config.auth?.profiles, normalizeProvider);
 }
 
 function hasOpenAiApiKeyProfile(config: OpenClawConfig): boolean {
@@ -183,7 +185,9 @@ async function refuseOffSurfaceClaudeModel(
   if (provider !== "anthropic") return null;
   const config = await getConfig();
   if (!config) return null;
-  if (!subscriptionOnlyProviders(config.auth?.profiles).includes("anthropic")) return null;
+  if (!subscriptionOnlyProviders(config.auth?.profiles, normalizeProvider).includes("anthropic")) {
+    return null;
+  }
   const surfaceIds = await getSurfaceIds();
   if (!surfaceIds || surfaceIds.has(modelId)) return null;
   const surface = subscriptionSurfaceLabel("anthropic");

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -16,7 +16,11 @@ import {
   CLAWBOX_AI_DEFAULT_TIER,
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
-import { isValidModelId, parseModelSlug } from "@/lib/provider-models";
+import { isValidModelId, parseModelSlug, subscriptionSurfaceLabel } from "@/lib/provider-models";
+import {
+  readSubscriptionSurfaceIds,
+  subscriptionOnlyProviders,
+} from "@/lib/subscription-surface";
 
 export const dynamic = "force-dynamic";
 
@@ -107,6 +111,26 @@ function defaultModelForProvider(provider: string | null): string | null {
   return DEFAULT_PROVIDER_MODELS[normalized]
     ?? DEFAULT_PROVIDER_MODELS[normalizeProvider(provider) ?? ""]
     ?? null;
+}
+
+/**
+ * Providers this box authenticates to by subscription only, normalized to the
+ * ids the UI uses (deepseek → clawai) so the browser can match them against
+ * the provider on its own header pill.
+ *
+ * The catalogue the pickers render is stamped with `availableOnSubscription`
+ * per model, but that stamp is a property of the PROVIDER's plugin, not of
+ * this device — nothing in it says whether this box is on a subscription. The
+ * setup wizard knew because the customer was standing on the Subscription tab;
+ * the chat header had no such context and so applied no rule at all. This is
+ * that missing half, delivered on the state the header already refetches
+ * whenever the provider changes.
+ */
+function subscriptionProvidersForUi(config: OpenClawConfig): string[] {
+  const ids = subscriptionOnlyProviders(config.auth?.profiles)
+    .map((provider) => normalizeProvider(provider))
+    .filter((provider): provider is string => !!provider);
+  return [...new Set(ids)].sort();
 }
 
 function hasOpenAiApiKeyProfile(config: OpenClawConfig): boolean {
@@ -309,6 +333,7 @@ async function loadChatModelState() {
       label: localLabel,
       model: localModel,
     },
+    subscriptionProviders: subscriptionProvidersForUi(openclawConfig),
   };
 }
 
@@ -386,6 +411,35 @@ export async function POST(request: Request) {
             return NextResponse.json({
               error: `${parsed.modelId} requires OpenAI API-key mode. ChatGPT subscription auth supports GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, and GPT-5.4 Mini.`,
             }, { status: 400 });
+          }
+        }
+        // The Claude equivalent of the Codex branch above. Anthropic's
+        // subscription keeps the `anthropic/` namespace but narrows the set:
+        // only the plugin's `claude-cli` catalogue actually routes, so
+        // claude-mythos-5 / claude-fable-5 / the Haikus are API-key-only.
+        //
+        // Without this, an id from a stale tab (or any browser that never
+        // received the catalogue stamp) fell through to the openai-compat
+        // auto-extend below, which either wrote it to
+        // `models.providers.anthropic.models` and pinned the box to a model
+        // that cannot route, or — when the providerDef was thin — answered
+        // 409 "isn't fully configured. Re-save it in Settings", which is the
+        // wrong next step for a box whose settings are fine.
+        if (effectiveProvider === "anthropic") {
+          const openclawConfig = await getAuthConfig();
+          const onSubscription = !!openclawConfig
+            && subscriptionOnlyProviders(openclawConfig.auth?.profiles).includes("anthropic");
+          if (onSubscription) {
+            // Null = the surface could not be read. UNKNOWN is not "no": the
+            // pickers keep an unstamped model usable, and refusing here where
+            // the UI allowed would be a rejection over something that works.
+            const surfaceIds = await readSubscriptionSurfaceIds("anthropic");
+            if (surfaceIds && !surfaceIds.has(effectiveModelId)) {
+              const surface = subscriptionSurfaceLabel("anthropic");
+              return NextResponse.json({
+                error: `${effectiveModelId} is not on the Claude subscription surface (${surface}). Pick one of ${[...surfaceIds].sort().join(", ")}, or switch Anthropic to API-key mode for the API-only models.`,
+              }, { status: 400 });
+            }
           }
         }
         // Normalize the parsed provider so the deepseek/clawai alias

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -151,6 +151,46 @@ function hasCodexOauthProfile(config: OpenClawConfig): boolean {
   });
 }
 
+/**
+ * Refuses a Claude model the box's subscription surface does not carry, or
+ * null when the target is fine (or is not Claude, or the box is not on a
+ * Claude subscription, or the surface could not be read).
+ *
+ * Anthropic's subscription keeps the `anthropic/` namespace but narrows the
+ * set: only the plugin's `claude-cli` catalogue routes, so claude-mythos-5 /
+ * claude-fable-5 / the Haikus are API-key-only.
+ *
+ * A helper rather than an inline block because there are THREE ways a model id
+ * becomes the target and only one of them is the custom-model branch: an id
+ * already in `models.providers.anthropic.models` matches `state.options`
+ * first, and `{"source":"primary"}` skips the branch entirely. That list is
+ * exactly where the old unguarded auto-extend wrote, so a box already broken
+ * by this defect could re-arm itself through either door. The OpenAI guard is
+ * applied at both sites for the same reason.
+ *
+ * `null` from `readSubscriptionSurfaceIds` means UNKNOWN, not "no": refusing
+ * where the pickers allow would be a rejection over something that works.
+ */
+async function refuseOffSurfaceClaudeModel(
+  provider: string | null | undefined,
+  modelId: string,
+  // A getter, not the config: the provider check comes first, so a switch to
+  // any other provider costs no openclaw.json read at all. On a Jetson that
+  // read is not free, and it is the caller's memoised one either way.
+  getConfig: () => Promise<OpenClawConfig | null>,
+): Promise<NextResponse | null> {
+  if (provider !== "anthropic") return null;
+  const config = await getConfig();
+  if (!config) return null;
+  if (!subscriptionOnlyProviders(config.auth?.profiles).includes("anthropic")) return null;
+  const surfaceIds = await readSubscriptionSurfaceIds("anthropic");
+  if (!surfaceIds || surfaceIds.has(modelId)) return null;
+  const surface = subscriptionSurfaceLabel("anthropic");
+  return NextResponse.json({
+    error: `${modelId} is not on the Claude subscription surface (${surface}). Pick one of ${[...surfaceIds].sort().join(", ")}, or switch Anthropic to API-key mode for the API-only models.`,
+  }, { status: 400 });
+}
+
 function sortPrimaryOptions(options: ChatModelOption[]) {
   return [...options].sort((a, b) => {
     const aRank = PROVIDER_ORDER.indexOf((a.provider ?? "") as typeof PROVIDER_ORDER[number]);
@@ -413,35 +453,19 @@ export async function POST(request: Request) {
             }, { status: 400 });
           }
         }
-        // The Claude equivalent of the Codex branch above. Anthropic's
-        // subscription keeps the `anthropic/` namespace but narrows the set:
-        // only the plugin's `claude-cli` catalogue actually routes, so
-        // claude-mythos-5 / claude-fable-5 / the Haikus are API-key-only.
-        //
-        // Without this, an id from a stale tab (or any browser that never
-        // received the catalogue stamp) fell through to the openai-compat
-        // auto-extend below, which either wrote it to
-        // `models.providers.anthropic.models` and pinned the box to a model
-        // that cannot route, or — when the providerDef was thin — answered
-        // 409 "isn't fully configured. Re-save it in Settings", which is the
-        // wrong next step for a box whose settings are fine.
-        if (effectiveProvider === "anthropic") {
-          const openclawConfig = await getAuthConfig();
-          const onSubscription = !!openclawConfig
-            && subscriptionOnlyProviders(openclawConfig.auth?.profiles).includes("anthropic");
-          if (onSubscription) {
-            // Null = the surface could not be read. UNKNOWN is not "no": the
-            // pickers keep an unstamped model usable, and refusing here where
-            // the UI allowed would be a rejection over something that works.
-            const surfaceIds = await readSubscriptionSurfaceIds("anthropic");
-            if (surfaceIds && !surfaceIds.has(effectiveModelId)) {
-              const surface = subscriptionSurfaceLabel("anthropic");
-              return NextResponse.json({
-                error: `${effectiveModelId} is not on the Claude subscription surface (${surface}). Pick one of ${[...surfaceIds].sort().join(", ")}, or switch Anthropic to API-key mode for the API-only models.`,
-              }, { status: 400 });
-            }
-          }
-        }
+        // Refuse BEFORE the openai-compat auto-extend below: that path writes
+        // `models.providers.anthropic.models`, and a rejection that has
+        // already had a side effect is not a rejection. Without this, an id
+        // from a stale tab either pinned the box to a model that cannot route
+        // or - when the providerDef was thin - drew a 409 "isn't fully
+        // configured. Re-save it in Settings", the wrong next step for a box
+        // whose settings are fine.
+        const offSurface = await refuseOffSurfaceClaudeModel(
+          effectiveProvider,
+          effectiveModelId,
+          getAuthConfig,
+        );
+        if (offSurface) return offSurface;
         // Normalize the parsed provider so the deepseek/clawai alias
         // comparison works — option.provider was set via normalizeProvider
         // (deepseek → clawai), so a raw `parsed.provider === "deepseek"`
@@ -553,6 +577,16 @@ export async function POST(request: Request) {
         }, { status: 400 });
       }
     }
+
+    // Second site, on the RESOLVED target — the openai guard above is applied
+    // twice for the same reason. An id that matched `state.options`, or one
+    // restored by `{"source":"primary"}`, never went through the branch above.
+    const targetOffSurface = await refuseOffSurfaceClaudeModel(
+      targetParsed?.provider,
+      targetParsed?.modelId ?? "",
+      getAuthConfig,
+    );
+    if (targetOffSurface) return targetOffSurface;
 
     if (state.activeModel === targetModel) {
       return NextResponse.json({

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -174,16 +174,17 @@ function hasCodexOauthProfile(config: OpenClawConfig): boolean {
 async function refuseOffSurfaceClaudeModel(
   provider: string | null | undefined,
   modelId: string,
-  // A getter, not the config: the provider check comes first, so a switch to
-  // any other provider costs no openclaw.json read at all. On a Jetson that
-  // read is not free, and it is the caller's memoised one either way.
+  // Getters, not values: the provider check comes first, so a switch to any
+  // other provider costs no openclaw.json read and no cache read at all. On a
+  // Jetson neither is free, and both are the caller's per-request memo.
   getConfig: () => Promise<OpenClawConfig | null>,
+  getSurfaceIds: () => Promise<Set<string> | null>,
 ): Promise<NextResponse | null> {
   if (provider !== "anthropic") return null;
   const config = await getConfig();
   if (!config) return null;
   if (!subscriptionOnlyProviders(config.auth?.profiles).includes("anthropic")) return null;
-  const surfaceIds = await readSubscriptionSurfaceIds("anthropic");
+  const surfaceIds = await getSurfaceIds();
   if (!surfaceIds || surfaceIds.has(modelId)) return null;
   const surface = subscriptionSurfaceLabel("anthropic");
   return NextResponse.json({
@@ -409,6 +410,23 @@ export async function POST(request: Request) {
       }
       return authConfig;
     };
+    // ONE snapshot of the Claude subscription surface for this request. The
+    // two guard sites straddle the auto-extend's config write, and the catalog
+    // route refreshes that cache on its own schedule: read it twice and a
+    // refresh landing in between lets the first guard allow, the write happen,
+    // and the second guard refuse — a failure reported over an operation that
+    // already succeeded. Memoised per request, both guards agree, and a
+    // refusal always lands at the first site, before any write.
+    //
+    // Per REQUEST, not per process: a module-level memo would pin the guard to
+    // whatever the surface looked like after the last restart.
+    let surfaceIds: Set<string> | null | undefined;
+    const getSurfaceIds = async () => {
+      if (surfaceIds === undefined) {
+        surfaceIds = await readSubscriptionSurfaceIds("anthropic");
+      }
+      return surfaceIds;
+    };
 
     if (typeof body.model === "string" && body.model.trim()) {
       const requestedModel = body.model.trim();
@@ -464,6 +482,7 @@ export async function POST(request: Request) {
           effectiveProvider,
           effectiveModelId,
           getAuthConfig,
+          getSurfaceIds,
         );
         if (offSurface) return offSurface;
         // Normalize the parsed provider so the deepseek/clawai alias
@@ -585,6 +604,7 @@ export async function POST(request: Request) {
       targetParsed?.provider,
       targetParsed?.modelId ?? "",
       getAuthConfig,
+      getSurfaceIds,
     );
     if (targetOffSurface) return targetOffSurface;
 

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -22,6 +22,7 @@ import {
   extractProviderModelId,
   isCatalogProvider,
   isValidModelId,
+  isModelUsableOnSubscription,
   SUBSCRIPTION_SURFACE,
 } from "@/lib/provider-models";
 import { useProviderCatalog } from "@/hooks/useProviderCatalog";
@@ -1140,13 +1141,12 @@ export default function AIModelsStep({
   const currentAuthMode = activeAuth?.mode ?? authMode;
   const isSubscription = currentAuthMode === "subscription";
 
-  // The one rule, named once. `availableOnSubscription === undefined` means
-  // the box could not enumerate the subscription surface — unknown is not
-  // "no", so an unstamped model stays usable and the customer keeps the full
-  // list rather than the UI inventing a restriction.
+  // The one rule, named once — and now named in provider-models.ts, next to
+  // the SUBSCRIPTION_SURFACE table it reads, because the chat header's inline
+  // model switcher has to apply the same rule to the same catalogue.
   const isModelUsable = useCallback(
     (model: { availableOnSubscription?: boolean }) =>
-      !isSubscription || model.availableOnSubscription !== false,
+      isModelUsableOnSubscription(model, isSubscription),
     [isSubscription],
   );
 

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -141,6 +141,12 @@ interface ChatModelState {
   }>
   primary: { available: boolean; label: string | null; model: string | null }
   local: { available: boolean; label: string | null; model: string | null }
+  /** Providers this box authenticates to by SUBSCRIPTION only. The catalogue's
+   * `availableOnSubscription` stamp says what a provider's subscription
+   * surface carries; this says whether that applies to this device. Optional
+   * so an older/partial payload reads as "no provider is subscription-only" —
+   * unknown must not invent a restriction. */
+  subscriptionProviders?: string[]
 }
 
 // Left dropdown is the provider selector — always show the friendly
@@ -207,6 +213,7 @@ import { scrollToBottomAfterLayout } from '@/lib/scroll'
 import { useT } from '@/lib/i18n'
 import {
   extractProviderModelId,
+  isModelUsableOnSubscription,
 } from '@/lib/provider-models'
 import { useProviderCatalog } from '@/hooks/useProviderCatalog'
 // Hermes chat header. Deliberately a separate namespace from the OpenClaw
@@ -687,6 +694,15 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     ? thinkingLevel
     : reasoningConfig.default
   const chatProviderCatalog = useProviderCatalog(headerProvider)
+  // Does the greying-out rule apply to THIS box? `chatModelState` is refetched
+  // whenever the provider changes or a configure lands, so this follows the
+  // device rather than being sampled once at mount — a box that swaps a Claude
+  // sign-in for an API key gets its full model list back without a reload.
+  const headerOnSubscription = useMemo(
+    () => !!headerProvider
+      && !!chatModelState?.subscriptionProviders?.includes(headerProvider),
+    [headerProvider, chatModelState],
+  )
   // Pull live tier so the chat-model picker can filter ClawBox AI options
   // by entitlement. Without this, a Free user could pick deepseek-v4-pro,
   // see a "Switched chat to deepseek/deepseek-v4-pro" success message,
@@ -3658,13 +3674,30 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
                   activeModelLabel,
                   getProviderPillText(activeOption),
                 )}
-                options={modelOptions.map(option => ({
-                  id: option.id,
-                  label: option.label,
-                  hint: option.hint,
-                }))}
+                // A model the box's SUBSCRIPTION surface does not carry is
+                // SHOWN, not hidden, and it says why — the same treatment the
+                // setup wizard gives it, because the wizard's help line sends
+                // the customer here to switch models. Dropping the row would
+                // be the same lie in the other direction.
+                options={modelOptions.map(option => {
+                  const blocked = !isModelUsableOnSubscription(option, headerOnSubscription)
+                  return {
+                    id: option.id,
+                    label: option.label,
+                    hint: option.hint,
+                    disabled: blocked,
+                    unavailableReason: blocked ? t('ai.modelNeedsApiKey') : undefined,
+                  }
+                })}
                 onChange={(nextId) => {
                   if (nextId === activeModelId) return
+                  // The list already refuses a disabled row, but the switch is
+                  // not allowed to depend on that: the server guard exists for
+                  // ids that arrive some other way, and this one exists so the
+                  // customer is never shown a "Switched to ..." for a model
+                  // the same screen just told them the box cannot run.
+                  const next = modelOptions.find(option => option.id === nextId)
+                  if (next && !isModelUsableOnSubscription(next, headerOnSubscription)) return
                   // Wire-format provider for ClawBox AI is `deepseek`
                   // (Mike's gateway routes via DeepSeek). Sending
                   // `clawai/...` would be rejected by the gateway as

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -153,6 +153,40 @@ export const SUBSCRIPTION_SURFACE: Readonly<Record<string, {
   anthropic: { surfaceProvider: "claude-cli" },
 });
 
+/**
+ * Can this credential run this model? The one greying-out rule, named once.
+ *
+ * `availableOnSubscription === undefined` means the box could not enumerate
+ * the subscription surface — unknown is not "no", so an unstamped model stays
+ * usable and the customer keeps the full list rather than the UI inventing a
+ * restriction it never verified.
+ *
+ * It lives here, next to the table it reads, because BOTH model pickers have
+ * to obey it: the setup wizard's (AIModelsStep) and the chat header's
+ * (ChatPopup). It used to be a closure inside the wizard, so the header — the
+ * surface the wizard's own help line points the customer at ("switch between
+ * the curated models from the chat window anytime") — offered every
+ * API-key-only model as an ordinary pickable row.
+ */
+export function isModelUsableOnSubscription(
+  model: { availableOnSubscription?: boolean },
+  isSubscription: boolean,
+): boolean {
+  return !isSubscription || model.availableOnSubscription !== false;
+}
+
+/**
+ * The provider id of the narrowed catalogue a subscription puts `provider` on,
+ * or null when its subscription does not narrow this catalogue (OpenAI swaps
+ * the whole namespace instead — see `catalogProvider` above).
+ *
+ * Exists so a refusal can NAME the surface it is refusing against, rather than
+ * telling the customer their provider is misconfigured when it is not.
+ */
+export function subscriptionSurfaceLabel(provider: string): string | null {
+  return SUBSCRIPTION_SURFACE[provider]?.surfaceProvider ?? null;
+}
+
 export const CATALOG_PROVIDERS = ["clawai", "anthropic", "openai", "codex", "google", "openrouter"] as const;
 export type CatalogProvider = typeof CATALOG_PROVIDERS[number];
 

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -1,0 +1,96 @@
+import { promises as fsp } from "fs";
+import path from "path";
+import { DATA_DIR } from "@/lib/config-store";
+import { SUBSCRIPTION_SURFACE } from "@/lib/provider-models";
+
+/**
+ * Server-side reads of the SUBSCRIPTION facts the UI already gets stamped into
+ * its catalogue — so a model id that reaches an API route without passing
+ * through a current browser tab is judged by the same rule the picker used.
+ *
+ * Deliberately read-only. The catalog route
+ * (/setup-api/ai-models/catalog) owns enumerating and refreshing the surface;
+ * it spawns `openclaw models list`, which takes ~3 minutes on a Jetson and has
+ * no business happening inside a model-switch request. This module only reads
+ * the cache that route maintains.
+ */
+
+const CACHE_DIR = path.join(DATA_DIR, "catalog-cache");
+
+interface CachedSurface {
+  models?: Array<{ id?: unknown }>;
+  fetchedAt?: unknown;
+}
+
+/**
+ * Model ids the subscription surface for `provider` carries, or null when it
+ * could not be determined.
+ *
+ * Null means UNKNOWN and every caller must treat it as "do not refuse" — the
+ * same rule `isModelUsableOnSubscription` applies in the pickers. An empty
+ * cache is unknown too: treating it as authoritative would refuse the entire
+ * catalogue on a box whose enumeration simply has not run yet.
+ *
+ * No age check and no memo. Both are deliberate:
+ *
+ *  * No memo, because the cache is refreshed behind our back on the catalog
+ *    route's own 6h schedule (and on `?refresh=1`). A module-level probe would
+ *    pin this guard to whatever the surface looked like the first time anyone
+ *    switched model after a restart, and then refuse a model the box has since
+ *    learned it can run.
+ *  * No age check, because this must agree with what the CUSTOMER WAS SHOWN.
+ *    The picker's stamps come from this same cache via the catalog route,
+ *    which serves stale payloads rather than blocking. Expiring the file here
+ *    but not there would let the UI grey a row out while the route accepted
+ *    it, or the reverse.
+ */
+export async function readSubscriptionSurfaceIds(
+  provider: string,
+): Promise<Set<string> | null> {
+  const surfaceProvider = SUBSCRIPTION_SURFACE[provider]?.surfaceProvider;
+  if (!surfaceProvider) return null;
+  try {
+    const raw = await fsp.readFile(path.join(CACHE_DIR, `${surfaceProvider}.json`), "utf8");
+    const parsed = JSON.parse(raw) as CachedSurface;
+    if (!Array.isArray(parsed.models)) return null;
+    const ids = parsed.models
+      .map((m) => m?.id)
+      .filter((id): id is string => typeof id === "string" && id.length > 0);
+    return ids.length > 0 ? new Set(ids) : null;
+  } catch {
+    // Missing, unreadable, or half-written cache. Unknown, not "no".
+    return null;
+  }
+}
+
+/** Auth-profile modes that mean "this provider has a bearer key of its own". */
+const KEY_MODES = new Set(["token", "api_key", "api-key"]);
+
+/**
+ * Providers this box authenticates to by SUBSCRIPTION only — an OAuth profile
+ * and no key-based profile for the same provider.
+ *
+ * "and no key" matters: a box that has signed in with Claude AND pasted an API
+ * key can still route the API-only models, so calling it subscription-only
+ * would grey out rows it can actually run. This mirrors the reasoning already
+ * spelled out for OpenAI in the chat/model route
+ * (`!hasOpenAiKey && hasCodexOauth`), generalised so every provider in
+ * SUBSCRIPTION_SURFACE gets the same answer from one place.
+ */
+export function subscriptionOnlyProviders(
+  profiles: Record<string, { provider?: string; mode?: string } | undefined> | undefined,
+): string[] {
+  const oauth = new Set<string>();
+  const keyed = new Set<string>();
+  for (const [profileKey, entry] of Object.entries(profiles ?? {})) {
+    const rawProvider = typeof entry?.provider === "string" && entry.provider.trim()
+      ? entry.provider
+      : profileKey.split(":")[0];
+    const provider = rawProvider.trim().toLowerCase();
+    if (!provider) continue;
+    const mode = typeof entry?.mode === "string" ? entry.mode.trim().toLowerCase() : "";
+    if (mode === "oauth") oauth.add(provider);
+    else if (KEY_MODES.has(mode)) keyed.add(provider);
+  }
+  return [...oauth].filter((provider) => !keyed.has(provider)).sort();
+}

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -17,9 +17,9 @@ import { SUBSCRIPTION_SURFACE } from "@/lib/provider-models";
 
 const CACHE_DIR = path.join(DATA_DIR, "catalog-cache");
 
+/** Only the part of the catalog route's cached payload this module reads. */
 interface CachedSurface {
   models?: Array<{ id?: unknown }>;
-  fetchedAt?: unknown;
 }
 
 /**

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -76,9 +76,18 @@ const KEY_MODES = new Set(["token", "api_key", "api-key"]);
  * spelled out for OpenAI in the chat/model route
  * (`!hasOpenAiKey && hasCodexOauth`), generalised so every provider in
  * SUBSCRIPTION_SURFACE gets the same answer from one place.
+ *
+ * `normalize` collapses provider ALIASES, and it is applied here rather than
+ * to the result because the two are not interchangeable: deepseek and clawai
+ * are one provider under two names (wire format vs UI id), so an OAuth profile
+ * written under one and an API key under the other read as two providers if
+ * the alias is collapsed afterwards — and the box gets called
+ * subscription-only over a credential it does have. Aliasing has to happen
+ * before the credentials are counted, not after.
  */
 export function subscriptionOnlyProviders(
   profiles: Record<string, { provider?: string; mode?: string } | undefined> | undefined,
+  normalize: (provider: string) => string | null = (provider) => provider,
 ): string[] {
   const oauth = new Set<string>();
   const keyed = new Set<string>();
@@ -86,7 +95,7 @@ export function subscriptionOnlyProviders(
     const rawProvider = typeof entry?.provider === "string" && entry.provider.trim()
       ? entry.provider
       : profileKey.split(":")[0];
-    const provider = rawProvider.trim().toLowerCase();
+    const provider = normalize(rawProvider.trim().toLowerCase()) ?? "";
     if (!provider) continue;
     const mode = typeof entry?.mode === "string" ? entry.mode.trim().toLowerCase() : "";
     if (mode === "oauth") oauth.add(provider);

--- a/src/tests/components/chat-header-subscription-models.test.tsx
+++ b/src/tests/components/chat-header-subscription-models.test.tsx
@@ -1,0 +1,184 @@
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import ChatPopup from "@/components/ChatPopup";
+import { resetHarnessCache } from "@/lib/client-harness";
+import { translations } from "@/lib/translations";
+
+// Resolve against the REAL English table rather than a hand-written map, so
+// this test breaks if the header stops reusing the wizard's own copy.
+vi.mock("@/lib/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n")>();
+  return {
+    ...actual,
+    useT: () => ({ t: (key: string) => translations.en[key] ?? key }),
+    I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  };
+});
+
+/** The one string both pickers put on a row the subscription cannot run. */
+const NEEDS_API_KEY = translations.en["ai.modelNeedsApiKey"];
+
+/**
+ * The chat header's inline model switcher and the setup wizard's picker read
+ * the SAME catalogue, stamped by the same route with the same
+ * `availableOnSubscription` flag — and only the wizard obeyed it.
+ *
+ * The wizard's own help line sends the customer here ("switch between the
+ * curated models from the chat window anytime"), so the unfiltered surface was
+ * the one it advertised: on a Claude-subscription box the header offered
+ * Claude Mythos 5 / Claude Fable 5, which the `claude-cli` surface does not
+ * carry, as ordinary pickable rows.
+ *
+ * The header does not hide them — a silently missing row is the same lie in
+ * the other direction. It greys them out and says why, exactly as the wizard
+ * does.
+ */
+
+const ANTHROPIC_CATALOG = {
+  provider: "anthropic",
+  models: [
+    { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", contextWindow: 200_000, availableOnSubscription: true },
+    { id: "claude-opus-4-8", label: "Claude Opus 4.8", contextWindow: 1_000_000, availableOnSubscription: true },
+    { id: "claude-fable-5", label: "Claude Fable 5", contextWindow: 1_000_000, availableOnSubscription: false },
+    { id: "claude-mythos-5", label: "Claude Mythos 5", contextWindow: 1_000_000, availableOnSubscription: false },
+  ],
+  defaultModelId: "claude-sonnet-4-6",
+  allowCustom: true,
+  fetchedAt: Date.now(),
+};
+
+/** GET /setup-api/chat/model as the route answers it for a Claude box. */
+function chatModelState(subscriptionProviders: string[]) {
+  return {
+    activeOptionId: "anthropic/claude-sonnet-4-6",
+    activeModel: "anthropic/claude-sonnet-4-6",
+    activeSource: "primary",
+    activeLabel: "Anthropic Claude",
+    options: [
+      {
+        id: "anthropic/claude-sonnet-4-6",
+        label: "Anthropic Claude",
+        model: "anthropic/claude-sonnet-4-6",
+        provider: "anthropic",
+        available: true,
+        settingsSection: "ai",
+        isLocal: false,
+      },
+    ],
+    primary: { available: true, label: "Anthropic Claude", model: "anthropic/claude-sonnet-4-6" },
+    local: { available: false, label: null, model: null },
+    subscriptionProviders,
+  };
+}
+
+function installFetch(subscriptionProviders: string[]) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/setup-api/harness/active")) {
+        return { ok: true, json: async () => ({ active: "openclaw", edition: "openclaw" }) };
+      }
+      if (url.includes("/setup-api/ai-models/catalog")) {
+        return { ok: true, json: async () => ANTHROPIC_CATALOG };
+      }
+      if (url.includes("/setup-api/chat/model")) {
+        return { ok: true, json: async () => chatModelState(subscriptionProviders) };
+      }
+      if (url.includes("/setup-api/chat/history")) {
+        return { ok: true, json: async () => ({ messages: [] }) };
+      }
+      return { ok: true, json: async () => ({}) };
+    }),
+  );
+}
+
+/** Open the model pill and return its listbox rows, keyed by label. */
+async function openModelPicker() {
+  const trigger = await screen.findByRole("button", { name: /Anthropic Claude model/i });
+  fireEvent.click(trigger);
+  await waitFor(() => expect(screen.getAllByRole("option").length).toBeGreaterThan(1));
+  const rows = new Map<string, HTMLElement>();
+  for (const row of screen.getAllByRole("option")) {
+    const label = row.querySelector(".header-dropdown-option-label")?.textContent ?? "";
+    rows.set(label, row as HTMLElement);
+  }
+  return rows;
+}
+
+beforeEach(() => {
+  resetHarnessCache();
+  window.localStorage.clear();
+  Element.prototype.scrollIntoView = vi.fn();
+  vi.stubGlobal(
+    "WebSocket",
+    class {
+      close() {}
+      send() {}
+      addEventListener() {}
+      removeEventListener() {}
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetHarnessCache();
+});
+
+describe("the chat header's model picker on a Claude-subscription box", () => {
+  it("greys out the models the subscription surface cannot run", async () => {
+    installFetch(["anthropic"]);
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    const rows = await openModelPicker();
+    expect(rows.get("Claude Fable 5")?.getAttribute("aria-disabled")).toBe("true");
+    expect(rows.get("Claude Mythos 5")?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  it("says WHY, rather than leaving a silently dead row", async () => {
+    installFetch(["anthropic"]);
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    const rows = await openModelPicker();
+    expect(rows.get("Claude Fable 5")?.textContent).toContain(NEEDS_API_KEY);
+    // Same wording the wizard uses, not a lookalike written for this surface.
+    expect(NEEDS_API_KEY).toContain("needs an API key");
+  });
+
+  it("still SHOWS them — a missing row is the same lie in the other direction", async () => {
+    installFetch(["anthropic"]);
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    const rows = await openModelPicker();
+    expect(rows.has("Claude Fable 5")).toBe(true);
+    expect(rows.has("Claude Mythos 5")).toBe(true);
+  });
+
+  it("refuses to switch onto one when it is clicked", async () => {
+    installFetch(["anthropic"]);
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    const rows = await openModelPicker();
+    fireEvent.click(rows.get("Claude Fable 5")!);
+
+    // No POST may leave the browser for a model the box has just been told it
+    // cannot run — the picker must not lean on the server guard to say no.
+    await waitFor(() => {
+      const posted = vi.mocked(fetch).mock.calls.some(([url, init]) =>
+        String(url).includes("/setup-api/chat/model")
+        && (init as RequestInit | undefined)?.method === "POST");
+      expect(posted).toBe(false);
+    });
+  });
+
+  it("leaves every model pickable on an API-key box", async () => {
+    installFetch([]);
+    render(<ChatPopup isOpen onClose={() => {}} />);
+
+    const rows = await openModelPicker();
+    expect(rows.get("Claude Fable 5")?.getAttribute("aria-disabled")).toBeNull();
+    expect(rows.get("Claude Mythos 5")?.getAttribute("aria-disabled")).toBeNull();
+  });
+});

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -297,6 +297,26 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     });
   });
 
+  it("judges one request against ONE snapshot of the surface", async () => {
+    // The two guard sites straddle the auto-extend's config write. If the
+    // catalog route's background refresh lands between them, the first guard
+    // sees UNKNOWN and allows, the write happens, and the second guard then
+    // refuses — a failure reported over an operation that already succeeded,
+    // leaving the id in `models.providers.anthropic.models` anyway.
+    //
+    // The surface is read once per request, so both guards agree. Either they
+    // both allow (write, report success) or they both refuse — and a refusal
+    // lands at the FIRST site, before the write.
+    vi.mocked(fsp.readFile)
+      .mockRejectedValueOnce(new Error("ENOENT") as never)
+      .mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
+
+    const response = await postModel(POST, "anthropic/claude-fable-5");
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(fsp.readFile)).toHaveBeenCalledTimes(1);
+  });
+
   it("re-reads the surface on every request instead of probing once", async () => {
     // The cache is refreshed by the catalog route on its own schedule. A
     // module-level memo here would pin this guard to whatever the surface

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+vi.mock("util", () => ({ promisify: vi.fn() }));
+
+vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/home/clawbox/clawbox/data",
+  getAll: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  promises: { readFile: vi.fn() },
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  inferConfiguredLocalModel: vi.fn(),
+  findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
+  readConfig: vi.fn(),
+  restartGateway: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
+  applyModelOverrideToAllAgentSessions: vi.fn(),
+  parseFullyQualifiedModel: vi.fn(),
+  setProviderPlugins: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/sqlite-store", () => ({
+  sqliteGet: vi.fn(),
+  sqliteSet: vi.fn(),
+}));
+
+import { promises as fsp } from "fs";
+import { getAll } from "@/lib/config-store";
+import {
+  inferConfiguredLocalModel,
+  readConfig,
+  restartGateway,
+  runOpenclawConfigSet,
+  applyModelOverrideToAllAgentSessions,
+  parseFullyQualifiedModel,
+} from "@/lib/openclaw-config";
+import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
+import { promisify } from "util";
+
+/** Model ids the `claude-cli` (Claude-subscription) surface really carries. */
+const SURFACE_IDS = [
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-sonnet-5",
+  "claude-sonnet-4-6",
+];
+
+/** The catalog route's disk cache for a surface provider, as it writes it. */
+function surfaceCache(ids: string[]) {
+  return JSON.stringify({
+    provider: "claude-cli",
+    models: ids.map((id) => ({ id, label: id, contextWindow: 200_000 })),
+    defaultModelId: ids[0],
+    allowCustom: false,
+    fetchedAt: Date.now(),
+  });
+}
+
+/** An anthropic auth profile in the given mode, plus a complete providerDef. */
+function anthropicConfig(mode: "oauth" | "api_key", extraProfiles = {}) {
+  return {
+    auth: {
+      profiles: {
+        "anthropic:default": { provider: "anthropic", mode },
+        ...extraProfiles,
+      },
+    },
+    models: {
+      mode: "merge",
+      providers: {
+        anthropic: {
+          apiKey: "placeholder",
+          baseUrl: "https://api.anthropic.com/v1",
+          api: "openai-completions",
+          models: [{ id: "claude-sonnet-4-6", name: "claude-sonnet-4-6" }],
+        },
+      },
+    },
+    agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
+  };
+}
+
+async function postModel(POST: (r: Request) => Promise<Response>, model: string) {
+  return POST(new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model }),
+  }));
+}
+
+/**
+ * The pill in the chat header is not the only way a model id reaches this
+ * route — a stale tab, a scripted call, or a browser that never received the
+ * catalogue stamp can all submit an API-key-only Claude model while the box is
+ * on Claude subscription auth. The route already refuses this class for
+ * OpenAI/Codex; anthropic fell straight through to the openai-compat
+ * auto-extend, which either pinned the box to a model that cannot route or
+ * answered 409 "not fully configured, re-save it in Settings" — a wrong next
+ * step for a box whose settings are fine.
+ */
+describe("/setup-api/chat/model and the Claude subscription surface", () => {
+  let GET: () => Promise<Response>;
+  let POST: (request: Request) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    vi.mocked(promisify).mockReturnValue(vi.fn().mockResolvedValue({ stdout: "", stderr: "" }) as never);
+    vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(parseFullyQualifiedModel).mockImplementation((fq: string) => {
+      const idx = fq.indexOf("/");
+      if (idx <= 0 || idx === fq.length - 1) return null;
+      return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+    });
+    vi.mocked(getAll).mockResolvedValue({ ai_model_provider: "anthropic" });
+    vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
+    vi.mocked(sqliteGet).mockResolvedValue(null);
+    vi.mocked(sqliteSet).mockResolvedValue();
+    vi.mocked(restartGateway).mockResolvedValue();
+    vi.mocked(readConfig).mockResolvedValue(anthropicConfig("oauth") as never);
+    vi.mocked(fsp.readFile).mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
+
+    const mod = await import("@/app/setup-api/chat/model/route");
+    GET = mod.GET;
+    POST = mod.POST;
+  });
+
+  it("tells the browser which providers are on subscription auth", async () => {
+    // Without this the header has the stamped catalogue but no idea whether
+    // the stamp applies to THIS box, so it cannot grey anything out.
+    const body = await (await GET()).json();
+    expect(body.subscriptionProviders).toEqual(["anthropic"]);
+  });
+
+  it("reports no subscription provider when the box holds an API key", async () => {
+    vi.mocked(readConfig).mockResolvedValue(anthropicConfig("api_key") as never);
+    const body = await (await GET()).json();
+    expect(body.subscriptionProviders).toEqual([]);
+  });
+
+  it("does not call a provider subscription-only when BOTH credentials exist", async () => {
+    // An API key alongside the OAuth profile means the box can still route the
+    // API-only models; greying them out would be a restriction it invented.
+    vi.mocked(readConfig).mockResolvedValue(
+      anthropicConfig("oauth", { "anthropic:key": { provider: "anthropic", mode: "api_key" } }) as never,
+    );
+    const body = await (await GET()).json();
+    expect(body.subscriptionProviders).toEqual([]);
+  });
+
+  it("refuses a Claude model the subscription surface does not carry", async () => {
+    const response = await postModel(POST, "anthropic/claude-fable-5");
+
+    expect(response.status).toBe(400);
+    const { error } = await response.json();
+    // Name the surface, so the message is diagnosable rather than mysterious.
+    expect(error).toContain("claude-cli");
+    expect(error).toContain("claude-fable-5");
+    // And it must NOT be the auto-extend's wrong advice.
+    expect(error).not.toContain("Re-save it in Settings");
+    expect(runOpenclawConfigSet).not.toHaveBeenCalled();
+    expect(restartGateway).not.toHaveBeenCalled();
+  });
+
+  it("accepts a Claude model the subscription surface does carry", async () => {
+    const response = await postModel(POST, "anthropic/claude-opus-4-8");
+
+    expect(response.status).toBe(200);
+    expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+      "agents.defaults.model.primary",
+      "anthropic/claude-opus-4-8",
+    ]);
+  });
+
+  it("lets every Claude model through on an API-key box", async () => {
+    vi.mocked(readConfig).mockResolvedValue(anthropicConfig("api_key") as never);
+    const response = await postModel(POST, "anthropic/claude-fable-5");
+    expect(response.status).toBe(200);
+  });
+
+  it("lets the pick through when the surface could not be read at all", async () => {
+    // UNKNOWN is not "no". A cold box with no catalog cache yet must not have
+    // its whole Claude list refused by a guard that never verified anything.
+    vi.mocked(fsp.readFile).mockRejectedValue(new Error("ENOENT") as never);
+    const response = await postModel(POST, "anthropic/claude-fable-5");
+    expect(response.status).toBe(200);
+  });
+
+  it("lets the pick through when the cached surface is empty", async () => {
+    // An empty set is the same unknown wearing a different hat — treating it
+    // as authoritative would strike out every Claude model at once.
+    vi.mocked(fsp.readFile).mockResolvedValue(surfaceCache([]) as never);
+    const response = await postModel(POST, "anthropic/claude-fable-5");
+    expect(response.status).toBe(200);
+  });
+
+  it("re-reads the surface on every request instead of probing once", async () => {
+    // The cache is refreshed by the catalog route on its own schedule. A
+    // module-level memo here would pin this guard to whatever the surface
+    // looked like the first time anyone switched model after a restart.
+    await postModel(POST, "anthropic/claude-fable-5");
+    vi.mocked(fsp.readFile).mockResolvedValue(
+      surfaceCache([...SURFACE_IDS, "claude-fable-5"]) as never,
+    );
+    const response = await postModel(POST, "anthropic/claude-fable-5");
+    expect(response.status).toBe(200);
+  });
+});

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -155,6 +155,43 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     expect(body.subscriptionProviders).toEqual([]);
   });
 
+  /**
+   * `deepseek` and `clawai` are the same provider wearing two names: the wire
+   * format is deepseek (Mike's gateway forwards there), the UI id is clawai.
+   * Classifying credentials BEFORE collapsing the alias makes an OAuth profile
+   * under one name and an API key under the other look like two providers, and
+   * the box gets reported as subscription-only on a credential it does not
+   * actually lack.
+   */
+  it.each([
+    ["deepseek OAuth + clawai API key", "deepseek", "clawai"],
+    ["clawai OAuth + deepseek API key", "clawai", "deepseek"],
+  ])("collapses the deepseek/clawai alias before classifying: %s", async (_name, oauthAs, keyedAs) => {
+    vi.mocked(readConfig).mockResolvedValue({
+      auth: {
+        profiles: {
+          "a:oauth": { provider: oauthAs, mode: "oauth" },
+          "b:key": { provider: keyedAs, mode: "api_key" },
+        },
+      },
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+    } as never);
+
+    const body = await (await GET()).json();
+    expect(body.subscriptionProviders).toEqual([]);
+  });
+
+  it("still reports the alias as subscription-only when there is no key at all", async () => {
+    vi.mocked(readConfig).mockResolvedValue({
+      auth: { profiles: { "deepseek:default": { provider: "deepseek", mode: "oauth" } } },
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+    } as never);
+
+    // Reported under the UI's id, which is what the header pill carries.
+    const body = await (await GET()).json();
+    expect(body.subscriptionProviders).toEqual(["clawai"]);
+  });
+
   it("refuses a Claude model the subscription surface does not carry", async () => {
     const response = await postModel(POST, "anthropic/claude-fable-5");
 

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -201,6 +201,102 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     expect(response.status).toBe(200);
   });
 
+  /**
+   * The custom-model branch is not the only way an id becomes the target.
+   * A model already listed in `models.providers.anthropic.models` shows up in
+   * `state.options` and matches BEFORE that branch; `{"source":"primary"}`
+   * skips it entirely. Both matter here in particular, because the very defect
+   * this PR fixes is what writes an off-surface Claude id into that list — so a
+   * box broken by the old behaviour could re-arm itself through either door.
+   *
+   * The OpenAI guard is applied twice for exactly this reason (once in the
+   * branch, once on the resolved target). The Claude one has to be too.
+   */
+  describe("a target that never passes through the custom-model branch", () => {
+    /** Active model is LOCAL, so the anthropic row takes its model from the
+     * provider definition — which is where the old auto-extend wrote. */
+    function boxWithOffSurfaceModelConfigured() {
+      return {
+        auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
+        models: {
+          mode: "merge",
+          providers: {
+            anthropic: {
+              apiKey: "placeholder",
+              baseUrl: "https://api.anthropic.com/v1",
+              api: "openai-completions",
+              models: [{ id: "claude-fable-5", name: "claude-fable-5" }],
+            },
+          },
+        },
+        agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+      };
+    }
+
+    beforeEach(() => {
+      vi.mocked(readConfig).mockResolvedValue(boxWithOffSurfaceModelConfigured() as never);
+      vi.mocked(getAll).mockResolvedValue({
+        ai_model_provider: "anthropic",
+        local_ai_provider: "llamacpp",
+        local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+      });
+    });
+
+    it("refuses it when it arrives as an id already in state.options", async () => {
+      const response = await postModel(POST, "anthropic/claude-fable-5");
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toContain("claude-cli");
+      expect(runOpenclawConfigSet).not.toHaveBeenCalled();
+      expect(restartGateway).not.toHaveBeenCalled();
+    });
+
+    it("refuses it when it is restored via {source: primary}", async () => {
+      const response = await POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source: "primary" }),
+      }));
+
+      expect(response.status).toBe(400);
+      expect((await response.json()).error).toContain("claude-cli");
+      expect(runOpenclawConfigSet).not.toHaveBeenCalled();
+      expect(restartGateway).not.toHaveBeenCalled();
+    });
+
+    it("still restores a supported Claude model through {source: primary}", async () => {
+      const config = boxWithOffSurfaceModelConfigured();
+      config.models.providers.anthropic.models = [
+        { id: "claude-sonnet-4-6", name: "claude-sonnet-4-6" },
+      ];
+      vi.mocked(readConfig).mockResolvedValue(config as never);
+
+      const response = await POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source: "primary" }),
+      }));
+
+      expect(response.status).toBe(200);
+      expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+        "agents.defaults.model.primary",
+        "anthropic/claude-sonnet-4-6",
+      ]);
+    });
+
+    it("leaves the local model alone", async () => {
+      // The guard must not reach past its own provider.
+      const response = await POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ source: "local" }),
+      }));
+
+      // Already the active model, so the route answers with state and no write.
+      expect(response.status).toBe(200);
+    });
+  });
+
   it("re-reads the surface on every request instead of probing once", async () => {
     // The cache is refreshed by the catalog route on its own schedule. A
     // module-level memo here would pin this guard to whatever the surface

--- a/src/tests/unit/subscription-surface-rule.test.ts
+++ b/src/tests/unit/subscription-surface-rule.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBSCRIPTION_SURFACE,
+  isModelUsableOnSubscription,
+  subscriptionSurfaceLabel,
+} from "@/lib/provider-models";
+
+/**
+ * The greying-out rule, as a rule rather than as a line inside one component.
+ *
+ * It used to live only in AIModelsStep, so the chat header — which the wizard
+ * itself points the customer at ("switch between the curated models from the
+ * chat window anytime") — offered every API-key-only model as pickable. One
+ * fact, one home, two consumers.
+ */
+describe("isModelUsableOnSubscription", () => {
+  it("keeps every model usable when the device is NOT on subscription auth", () => {
+    expect(isModelUsableOnSubscription({ availableOnSubscription: false }, false)).toBe(true);
+    expect(isModelUsableOnSubscription({ availableOnSubscription: true }, false)).toBe(true);
+    expect(isModelUsableOnSubscription({}, false)).toBe(true);
+  });
+
+  it("blocks a model the subscription surface does not carry", () => {
+    expect(isModelUsableOnSubscription({ availableOnSubscription: false }, true)).toBe(false);
+  });
+
+  it("allows a model the subscription surface does carry", () => {
+    expect(isModelUsableOnSubscription({ availableOnSubscription: true }, true)).toBe(true);
+  });
+
+  it("treats UNKNOWN as usable — the box could not enumerate the surface", () => {
+    // `undefined` is not "no". Marking it would invent a restriction the
+    // device never verified, and strike out the whole list on a cold cache.
+    expect(isModelUsableOnSubscription({}, true)).toBe(true);
+    expect(isModelUsableOnSubscription({ availableOnSubscription: undefined }, true)).toBe(true);
+  });
+});
+
+describe("subscriptionSurfaceLabel", () => {
+  it("names the surface a provider narrows to, so an error can say which one", () => {
+    expect(subscriptionSurfaceLabel("anthropic")).toBe(
+      SUBSCRIPTION_SURFACE.anthropic.surfaceProvider,
+    );
+  });
+
+  it("is null for a provider whose subscription does not narrow the set", () => {
+    // OpenAI's subscription swaps the whole catalogue (catalogProvider) rather
+    // than narrowing this one, so there is no surface to name here.
+    expect(subscriptionSurfaceLabel("google")).toBeNull();
+    expect(subscriptionSurfaceLabel("openai")).toBeNull();
+  });
+});


### PR DESCRIPTION
## The defect

The setup wizard greys out models a Claude subscription cannot run. The chat header's inline model switcher reads the **same catalogue**, stamped by the **same route** with the **same `availableOnSubscription` flag** — and applied no rule at all.

`grep -rn availableOnSubscription src mcp` on beta finds exactly one UI consumer: `AIModelsStep.tsx`. `ChatPopup.tsx` builds its switcher from the same `useProviderCatalog` hook and never mentions it. So on a Claude-subscription box the header offered Claude Mythos 5 and Claude Fable 5 as ordinary pickable rows — and the wizard's own help line is what sends the customer there: *"switch between the curated models from the chat window anytime."*

The route behind the pill guarded this class only for OpenAI (`CODEX_SUPPORTED_MODEL_RE`). `anthropic` is in `OPENAI_COMPAT_PROVIDERS`, so a Claude id fell straight through to the auto-extend.

**Reproduced before any fix**, with the tests in this PR:

- `POST /setup-api/chat/model {"model":"anthropic/claude-fable-5"}` on a box with an `anthropic` OAuth profile returned **200** and wrote `claude-fable-5` into `models.providers.anthropic.models` — the box is now pinned to a model that cannot route. (The other branch of the same fall-through answers 409 *"isn't fully configured. Re-save it in Settings"*, which is the wrong next step for a box whose settings are fine.)
- Rendering `ChatPopup` and opening the model pill: the Claude Fable 5 row had `aria-disabled` **null**, carried no reason, and clicking it fired the POST.

## The fix

**One rule, one home, both consumers.** `isModelUsableOnSubscription(model, isSubscription)` moves into `src/lib/provider-models.ts`, next to the `SUBSCRIPTION_SURFACE` table it reads. `AIModelsStep` now calls it instead of inlining it; `ChatPopup` calls it too.

**The header disables and annotates, it does not drop.** Same treatment the wizard gives — a silently missing row is the same lie in the other direction. It reuses the wizard's own copy (`ai.modelNeedsApiKey`), and refuses the switch on click, so no *"Switched to …"* can appear for a model the same screen just said the box cannot run.

**The half the browser could not know.** The catalogue's stamp is a property of the *provider's plugin*, not of *this device* — nothing in it says whether this box is on a subscription. The wizard knew because the customer was standing on the Subscription tab. `GET /setup-api/chat/model` now reports `subscriptionProviders`: providers with an OAuth profile and **no** key-based profile for the same provider. A box holding both credentials is not called subscription-only, because it can still route the API-only models.

**The missing server guard.** `POST` gains the Claude equivalent of the Codex branch, placed before the `OPENAI_COMPAT_PROVIDERS` auto-extend. It refuses with a message that names the `claude-cli` surface and lists what that surface carries, instead of the auto-extend's misleading "re-save it in Settings".

## Unknown is not "no"

Threaded through every layer, and tested at each:

- an **unstamped** model stays usable (the device could not enumerate the surface);
- an **unreadable** surface cache means the pick goes through;
- an **empty** cached surface is the same unknown wearing a different hat — treating it as authoritative would refuse the entire Claude catalogue at once.

## The recurring bug classes

- **Probe taken once at startup.** `readSubscriptionSurfaceIds` has no module memo and no age check, and there is a test that a surface changed between two requests changes the answer. The catalog route refreshes that cache on its own 6h schedule; a memo here would pin the guard to whatever the surface looked like after the last restart. No age check either, deliberately: the picker's stamps come from this same cache via the catalog route, which serves stale payloads rather than blocking — expiring it here but not there would let the UI grey a row out while the route accepted it, or the reverse.
- **Reporting failure over something that succeeded.** This is why the guard fails open on every unknown, and why "OAuth profile present" alone is not enough to call a provider subscription-only.
- **Reporting success without checking the outcome.** The client-side refusal exists so the switch does not depend on the list's `disabled` flag alone, and the server-side one exists for ids that reach the route some other way.

The new module is read-only by design: enumerating the surface means spawning `openclaw models list`, ~3 minutes on a Jetson, which has no business inside a model-switch request. The catalog route owns that; this only reads the cache it maintains.

## Tests

`13 failed / 7 passed` against unmodified `origin/beta` → `20 passed` with the fix.

- `src/tests/unit/subscription-surface-rule.test.ts` — the rule and the surface label
- `src/tests/routes/chat-model-subscription-surface.test.ts` — `subscriptionProviders`, the POST refusal, and every fail-open path
- `src/tests/components/chat-header-subscription-models.test.tsx` — a real `ChatPopup` render: the rows are shown, disabled, carry the reason, refuse the click, and stay fully pickable on an API-key box

`bun run lint` and `tsc --noEmit` are byte-identical to the beta baseline (105 problems / 24 pre-existing errors, none in the touched files).

## What changed for the customer

On a box signed in with Claude and no API key, the chat header's model list now greys out the models that subscription cannot run and says why, instead of accepting the pick and leaving the box on a model that never answers. Everything else is unchanged: API-key boxes keep the full list, boxes holding both credentials keep the full list, and a box that cannot enumerate the surface keeps the full list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved subscription-based model availability in chat setup and model selection.
  * Subscription-backed providers now reflect models supported by their service.
  * Unsupported models remain visible but disabled with guidance to add an API key.
  * Model switching and requests validate subscription compatibility before proceeding.

* **Bug Fixes**
  * Preserved full model access for API-key users and handled unknown catalog states safely.

* **Tests**
  * Added coverage for subscription filtering, selection, provider configurations, and request validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->