### PR TITLE
fix: don't report an aborted status read or a 429 as a failure

### DIFF
--- a/src/components/UpdateStep.tsx
+++ b/src/components/UpdateStep.tsx
@@ -269,6 +269,17 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
     }, 2000);
   }, [stopPolling]);
 
+  // The status effect must re-run for one reason only — a Retry — and never
+  // because these two callbacks changed identity. Reaching them through refs
+  // keeps them out of the effect's dependency list, so the effect cannot abort
+  // a status read it is about to re-issue on any render but a real reload.
+  const startPollingRef = useRef(startPolling);
+  const stopPollingRef = useRef(stopPolling);
+  useEffect(() => {
+    startPollingRef.current = startPolling;
+    stopPollingRef.current = stopPolling;
+  });
+
   // Fetch initial status (but don't auto-start)
   useEffect(() => {
     const controller = new AbortController();
@@ -286,10 +297,16 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
         if (data.versions) setVersions(data.versions);
 
         if (data.phase === "running") {
-          startPolling();
+          startPollingRef.current();
         }
-      } catch (err) {
-        if (err instanceof DOMException && err.name === "AbortError") return;
+      } catch {
+        // Whether this read was cancelled is a fact the controller holds, not
+        // one to be inferred from the error's type. An abort during the body
+        // read surfaces as a TypeError or a plain Error, not a DOMException, so
+        // sniffing the error let a cancelled read fall through to the failure
+        // banner while every request to the box had in fact returned 200. Ask
+        // the controller; a genuine failure (signal not aborted) still shows.
+        if (controller.signal.aborted) return;
         setFetchError(true);
       } finally {
         if (!controller.signal.aborted) setLoading(false);
@@ -298,9 +315,9 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
     init();
     return () => {
       controller.abort();
-      stopPolling();
+      stopPollingRef.current();
     };
-  }, [startPolling, stopPolling, statusReloadCount]);
+  }, [statusReloadCount]);
 
   const triggerUpdate = async () => {
     actionControllerRef.current?.abort();
@@ -315,8 +332,11 @@ export default function UpdateStep({ onNext }: UpdateStepProps) {
       });
       if (!res.ok) throw new Error(`Start update failed (${res.status})`);
       startPolling();
-    } catch (err) {
-      if (err instanceof DOMException && err.name === "AbortError") return;
+    } catch {
+      // Same rule as the status read: a cancelled request is not a failure, and
+      // its abort will not reliably arrive as a DOMException. The controller is
+      // the source of truth for whether we cancelled this.
+      if (controller.signal.aborted) return;
       setFetchError(true);
       setStarting(false);
     }

--- a/src/lib/chat-error-text.ts
+++ b/src/lib/chat-error-text.ts
@@ -40,8 +40,37 @@ function isSessionTakeover(raw: string): boolean {
     || /session takeover/i.test(raw);
 }
 
+/**
+ * The provider is rate-limiting this box's requests.
+ *
+ * An Anthropic 429 reached the owner as "The agent run failed before producing
+ * a reply." — a generic dead-end that reads like the box broke. It did not: the
+ * gateway had already worded the real cause ("API rate limit reached. Please
+ * try again later.") and its failover decision carried `reason=rate_limit`. Any
+ * of those signals — the gateway's own wording, the reason token, or a bare 429
+ * — means the same thing, so they map to the same sentence.
+ *
+ * Matched on the wire wording rather than an invented marker, in the same
+ * spirit as `isSessionTakeover`. Deliberately narrow: a *size* limit
+ * ("Request exceeds the size limit") is a different failure with a different
+ * remedy and must keep its own passthrough, so "limit" alone is never enough.
+ */
+function isRateLimit(raw: string): boolean {
+  return /\brate[ _-]?limit(ed|ing|s)?\b/i.test(raw)
+    || /\btoo many requests\b/i.test(raw)
+    || /(^|[^0-9])429([^0-9]|$)/.test(raw);
+}
+
 /** Something went wrong and we will not say what, because we cannot say it safely. */
 const GENERIC = "That message did not go through. Send it again — the details stayed in this box's log.";
+
+/**
+ * A rate limit is transient and external: the box is fine, the provider is just
+ * throttling it. So the sentence names the cause, says the box is not broken,
+ * and gives the two real remedies — wait, or switch to another provider in
+ * Settings. No "check the log": there is nothing there to act on.
+ */
+const RATE_LIMIT = "That message did not go through — the AI provider is rate-limiting this box right now. Nothing is broken. Wait a minute and send it again, or switch to a different provider in Settings.";
 
 /** The conversation changed under the turn; retry may work, New chat always does. */
 const TAKEOVER = "That message did not go through. That can happen when this chat is open in another tab or on Telegram — or when the session gets stuck. Send it again, and if it keeps failing, start a New chat — that clears it.";
@@ -57,6 +86,12 @@ export function describeChatFailure(raw: unknown): string {
   const text = typeof raw === "string" ? raw.trim() : "";
   if (!text) return GENERIC;
   if (isSessionTakeover(text)) return TAKEOVER;
+  // Before the sanitizer: the raw rate-limit wording would itself pass the leak
+  // rules ("API rate limit reached…" carries no path or handle), so without
+  // this the customer would get that bare operator line instead of the calm,
+  // actionable one — and a 429 buried in an otherwise unsafe string would be
+  // dropped to the generic fallback, losing the one fact that explains it.
+  if (isRateLimit(text)) return RATE_LIMIT;
   const safe = sanitizeErrorMessage(text);
   // A message that passes the leak rules is worth showing: "Request exceeds the
   // size limit" tells the customer what to change, and replacing it with the

--- a/src/tests/components/update-step-abort-honesty.test.tsx
+++ b/src/tests/components/update-step-abort-honesty.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { StrictMode } from "react";
+import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import { translations } from "@/lib/translations";
+import UpdateStep from "@/components/UpdateStep";
+
+// Resolve the real English strings the way the app does, so a renamed key
+// fails here instead of shipping a raw "update.foo" to the owner.
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({
+    locale: "en",
+    t: (key: string, params?: Record<string, string | number>) => {
+      let str = translations.en[key] ?? key;
+      if (params) for (const [k, v] of Object.entries(params)) str = str.replaceAll(`{${k}}`, String(v));
+      return str;
+    },
+  }),
+}));
+
+const FAILED_BANNER = translations.en["update.failedToCheck"];
+const CHECKING = translations.en["update.checkingUpdates"];
+
+// A settled status the box is already current on, so the second (kept) mount
+// renders a real screen rather than staying on the spinner.
+const IDLE_UP_TO_DATE = {
+  phase: "idle",
+  currentStepIndex: -1,
+  steps: [],
+  versions: {
+    clawbox: { current: "3.0.0", target: null },
+    openclaw: { current: "1.2.3", target: null },
+  },
+};
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function okJson(json: () => Promise<unknown>) {
+  return { ok: true, status: 200, json };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("UpdateStep — an aborted status read is not a failure", () => {
+  it("does not show the failure banner when the effect aborts its own in-flight status read", async () => {
+    // The init effect re-issues its status GET (StrictMode's mount→unmount→mount
+    // is the shipped trigger: Next renders the wizard under StrictMode). When it
+    // re-runs it calls abort() on the FIRST request's controller. On a cold box
+    // that request's git-fetch-backed body arrives ~1.8s later, and an abort
+    // DURING the body read does not surface as a DOMException/AbortError — real
+    // engines throw a TypeError. The old catch sniffed the error type, so the
+    // aborted read fell through to the failure banner even though every request
+    // to the server returned 200.
+    const firstJson = deferred<unknown>();
+    let call = 0;
+    const fetchMock = vi.fn(() => {
+      call += 1;
+      if (call === 1) return Promise.resolve(okJson(() => firstJson.promise));
+      return Promise.resolve(okJson(() => Promise.resolve(IDLE_UP_TO_DATE)));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <StrictMode>
+        <UpdateStep onNext={() => {}} />
+      </StrictMode>,
+    );
+
+    // The kept mount's request resolves and the spinner goes away.
+    await waitFor(() => {
+      expect(screen.queryByText(CHECKING)).not.toBeInTheDocument();
+    });
+
+    // Now the first request — the one the effect aborted — has its body read
+    // fail the way a real aborted read fails: a TypeError, not an AbortError.
+    await act(async () => {
+      firstJson.reject(new TypeError("terminated"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByText(FAILED_BANNER)).not.toBeInTheDocument();
+  });
+
+  it("still shows the failure banner when the status read genuinely fails", async () => {
+    // The other half of the fix: a real failure must NOT be hidden. Here the
+    // request was never aborted — the body simply could not be parsed — so the
+    // banner has to appear.
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(okJson(() => Promise.reject(new Error("Unexpected end of JSON input")))),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<UpdateStep onNext={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(FAILED_BANNER)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/tests/unit/chat-error-text.test.ts
+++ b/src/tests/unit/chat-error-text.test.ts
@@ -75,6 +75,47 @@ describe("describeChatFailure", () => {
     }
   });
 
+  it("maps an Anthropic 429 to a calm, actionable rate-limit sentence", () => {
+    // TASK: an Anthropic 429 reached the owner as "The agent run failed before
+    // producing a reply." — a generic dead-end. The gateway had already worded
+    // the real cause ("API rate limit reached. Please try again later.");
+    // reason=rate_limit / a bare 429 carry the same signal. Whichever wording
+    // reaches us, the customer must be told it is a rate limit, that the box is
+    // fine, and what to do — wait, or switch provider in Settings.
+    for (const raw of [
+      "API rate limit reached. Please try again later.",
+      "rate_limit",
+      "429 Error",
+      "Error: 429 Too Many Requests",
+    ]) {
+      const shown = describeChatFailure(raw);
+      expect(shown).toMatch(/rate[ -]?limit/i);
+      expect(shown).toMatch(/settings/i);
+      // Says the box itself is not broken.
+      expect(shown).toMatch(/nothing is (wrong|broken)|not broken|is fine/i);
+      // A rate limit is transient — never the generic "log has the details".
+      expect(shown).not.toMatch(/stayed in this box's log/i);
+    }
+  });
+
+  it("does not leak anything unsafe on the rate-limit path", () => {
+    // The rate-limit sentence is authored by us, but the matcher must not let a
+    // rate-limit-shaped string smuggle a path/UUID/CLI line onto the screen.
+    const shown = describeChatFailure(
+      "429 rate limit on run 3b45304b-89ff-496c-a392-4e1719de0878; "
+      + "see /home/clawbox/.openclaw/logs; Logs: openclaw logs --follow",
+    );
+    expect(leaks(shown)).toBe(false);
+    expect(shown).toMatch(/rate[ -]?limit/i);
+  });
+
+  it("does not misfire on ordinary text that merely mentions limits", () => {
+    // "Request exceeds the size limit" is a size limit, not a rate limit — it
+    // must keep its own useful passthrough, not get swallowed by the new case.
+    expect(describeChatFailure("Request exceeds the size limit"))
+      .toBe("Error: Request exceeds the size limit");
+  });
+
   it("drops anything that carries an internal handle, whatever the wording", () => {
     for (const raw of [
       "run 3b45304b-89ff-496c-a392-4e1719de0878 failed",


### PR DESCRIPTION
## Two false-error defects the owner hit

Both are the same class: the UI reporting a failure that is untrue, or stripping the one actionable sentence the system already produced.

### Defect 1 — `UpdateStep` showed "Failed to check update status" while every request returned 200

Device access log during the failure:

```
200 GET /setup-api/update/status 1821ms
200 GET /setup-api/update/status   86ms
200 GET /setup-api/update/status   67ms
```

The status route shells out to `git fetch` when the version cache is cold, so the first call takes ~1.8s. The init effect re-issues its status read (Next renders the wizard under `StrictMode`, whose mount → unmount → mount is the shipped trigger). When it re-runs it calls `controller.abort()` on its own in-flight request — and an abort **during the body read** does not reliably surface as a `DOMException`/`AbortError`: real engines throw a `TypeError` or a plain `Error`. The old `catch` sniffed the error type (`err instanceof DOMException && err.name === "AbortError"`), so a cancelled read fell straight through to `setFetchError(true)`. Retry re-ran the same race, which is why it failed repeatedly.

Both halves fixed:

- **(a)** An abort is never treated as an error. Every `catch` that used the `instanceof DOMException` test now asks the controller instead — `if (controller.signal.aborted) return;` — in the init read and in `triggerUpdate` (the poll path already did this). A genuine failure (signal not aborted) still shows the banner. This is not hiding errors: the "still shows the failure banner when the status read genuinely fails" test guards that.
- **(b)** The status effect no longer aborts a request it is about to re-issue on an incidental render. `startPolling`/`stopPolling` are read through refs, so the effect depends on `[statusReloadCount]` only — a real Retry — while genuine cancel-on-unmount is kept.

### Defect 2 — an Anthropic 429 reached the owner as "The agent run failed before producing a reply."

Gateway log:

```
[agent/embedded] embedded run agent end: isError=true model=claude-fable-5 provider=anthropic error=API rate limit reached. Please try again later. rawError=429 Error
[agent/embedded] embedded run failover decision: decision=surface_error reason=rate_limit next=none
```

The gateway had already produced a safe, actionable sentence ("API rate limit reached. Please try again later.") and its failover carried `reason=rate_limit`. We own the mapper — `src/lib/chat-error-text.ts` `describeChatFailure` — which special-cases session takeover and otherwise runs `sanitizeErrorMessage`. Added a rate-limit case in exactly that spirit, matched on the wire wording (`rate limit` / `rate_limit` / a bare `429` / `too many requests`), returning a sentence that says it is a rate limit, that the box is fine, and what to do:

> That message did not go through — the AI provider is rate-limiting this box right now. Nothing is broken. Wait a minute and send it again, or switch to a different provider in Settings.

It sits **before** the sanitizer: the raw "API rate limit reached…" would itself pass the leak rules, so without this the customer got the bare operator line, and a 429 buried in an otherwise-unsafe string would have dropped to the generic fallback, losing the one fact that explains it. The matcher is deliberately narrow — a *size* limit ("Request exceeds the size limit") is a different failure with a different remedy and keeps its own passthrough. Nothing unsafe leaks: a 429 string carrying a path/UUID/CLI line still returns our authored sentence (test covers it).

**Where the new case surfaces, and where the generic string comes from.** `describeChatFailure` is rendered into the chat transcript by both surfaces the owner sees — `ChatApp.tsx` and `ChatPopup.tsx`, on the WS `state === "error"` path (and their catch paths). The generic **"The agent run failed before producing a reply."** does **not** originate in this repo — it is passed through from the OpenClaw gateway as `payload.errorMessage`; a full-tree grep (`src`, `e2e`, `node_modules`) finds it nowhere in our code. Our fix maps the rate-limit signal to a friendly sentence wherever that signal reaches `errorMessage`.

**Note on `next=none` (not implemented here).** `next=none` means no fallback provider was configured for automatic failover. ClawBox has **no** setting for an automatic cross-provider fallback — providers are configured individually (`AIModelsStep` / Settings) and the user switches the active provider/model by hand. So "switch to a different provider in Settings" is the real, and only, recovery, which is what the new sentence tells them.

## Tests (red-first, proven against `origin/beta` before the fix)

- `src/tests/components/update-step-abort-honesty.test.tsx` — an aborted body read (StrictMode re-issue) must not show the banner (**RED on beta**, green after); a genuine read failure still shows it (guard).
- `src/tests/unit/chat-error-text.test.ts` — a 429 / rate-limit / `rate_limit` maps to the calm sentence and reaches Settings guidance (**RED on beta**, green after); nothing unsafe leaks on the rate-limit path (**RED on beta**, green after); a size limit does not misfire into the rate-limit case (guard).

`bun run lint` and `tsc --noEmit`: no worse than the beta baseline (both already red on pre-existing, unrelated test-file issues; the four touched files are clean).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented cancelled status checks from incorrectly showing a failure message.
  * Reduced unnecessary status refreshes during update progress.
  * Added clearer guidance when a service rate limit is reached, including Settings instructions.
  * Preserved existing handling for unrelated errors and size-limit messages.

* **Tests**
  * Added coverage for cancelled requests, genuine failures, and rate-limit error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->