### PR TITLE
fix: tell an edition-guard 404 apart from a bad id

### DIFF
--- a/mcp/tools/desktop.ts
+++ b/mcp/tools/desktop.ts
@@ -4,6 +4,7 @@
 // answers 404 "Not found", which a small model reads as "no such app" and
 // retries forever — and a chronically-404ing tool is exactly what trips
 // Hermes' per-server circuit breaker and takes EVERY ClawBox tool offline.
+// STORE_EDITION_RULE below is what turns that 404 into "stop".
 
 import { apiGet, apiPost, CLAWBOX_ROOT } from "../lib/api";
 import { ToolError, type ErrorRule } from "../lib/errors";
@@ -53,6 +54,21 @@ const CODE_RULES: ErrorRule[] = [
     next: "Call code_project_list for the ids that exist here, or create one with code_project_init.",
   },
 ];
+
+// openclawAppsGuard() answers 404 `{"error":"Not found","code":"not_openclaw"}`
+// from every store route. Matched on the CODE, not the status: the store routes
+// also 404 for an app id that does not exist, and the two need opposite advice.
+// The tools are registered off an edition probe taken once when the MCP child
+// spawned, so the window is a device whose harness changed since then.
+const STORE_EDITION_RULE: ErrorRule = {
+  status: 404,
+  match: /"code"\s*:\s*"not_openclaw"/,
+  code: "NOT_SUPPORTED_HERE",
+  message: "This ClawBox is not running the OpenClaw harness, so it has no app store.",
+  next:
+    "Do not retry and do not call the app store tools again this session. "
+    + "Call device_status and tell the user which harness the device is on.",
+};
 
 const WEBAPP_RULES: ErrorRule[] = [
   {
@@ -164,6 +180,7 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
       const body = await apiGet("/setup-api/apps/store", {
         query: { ...(query ? { q: query } : {}), limit },
         timeoutMs: 20_000,
+        rules: [STORE_EDITION_RULE],
       });
       return json(body);
     },
@@ -175,7 +192,11 @@ export function registerDesktopTools(reg: Registrar, ctx: McpContext): void {
     { app_id: zSlug("App id from app_search") },
     { editions: ["openclaw"], readOnly: false },
     async ({ app_id }: { app_id: string }) => {
-      await apiPost("/setup-api/apps/install", { appId: app_id }, { timeoutMs: 120_000 });
+      await apiPost(
+        "/setup-api/apps/install",
+        { appId: app_id },
+        { timeoutMs: 120_000, rules: [STORE_EDITION_RULE] },
+      );
       return text(`Installed "${app_id}". Open it with ui_open_app using "installed-${app_id}".`);
     },
   );

--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -17,7 +17,7 @@ import {
   isValidQuery,
   isValidSkillName,
 } from "../../src/lib/hermes-skills";
-import { apiGet, apiPost } from "../lib/api";
+import { type ApiOptions, apiGet, apiPost } from "../lib/api";
 import { ApiError, ToolError, type ErrorRule } from "../lib/errors";
 import { json, text, type Registrar } from "../lib/register";
 import { zBool, zEnumOf, zInt, zText } from "../lib/schema";
@@ -57,6 +57,56 @@ interface InstalledBody {
   counts?: Record<string, number>;
 }
 
+/**
+ * EVERY /setup-api/hermes/skills/* route opens with hermesSkillsGuard(), which
+ * answers 404 `{"error":"Not found","code":"not_hermes"}` when the device is
+ * not on the Hermes harness. Without a rule for it that body is indistinguish-
+ * able, to the generic mapping, from a handler saying it could not find an id:
+ * both are a 404 whose JSON carries an `error` string, so hasJsonErrorBody()
+ * classifies it RESOURCE-level and the agent is told to list what exists and
+ * call again with a real id. It cannot recover that way — skill_list goes
+ * through the same guard and 404s too — and errors.ts names exactly this
+ * confusion, in the other direction, as the thing that branch must never do.
+ *
+ * These tools are registered off an edition probe taken ONCE when the MCP child
+ * spawned, so the window is a device whose harness changed since then.
+ */
+const EDITION_RULE: ErrorRule = {
+  status: 404,
+  match: /"code"\s*:\s*"not_hermes"/,
+  code: "NOT_SUPPORTED_HERE",
+  message: "This ClawBox is not running the Hermes harness, so it has no skill store.",
+  next:
+    "Do not retry and do not call the skill_* tools again this session. "
+    + "Call device_status and tell the user which harness the device is on.",
+};
+
+// The guard is per-ROUTE, so decoding it has to be per-CALL, not per-tool: the
+// bug this closes existed because rules were attached at three call sites and
+// omitted at the other four. Going through these two wrappers is what makes
+// that impossible to get wrong again — `apiGet`/`apiPost` are not called
+// directly anywhere else in this module, and a test asserts it.
+//
+// The edition rule is PREPENDED. Every other 404 rule here is `match`-gated on
+// its own `code`, so the two cannot shadow each other; the exception is
+// skill_info's status-only 404, which the edition rule must precede or an
+// off-Hermes device would be told its id does not exist.
+type SkillsApiOptions = Omit<ApiOptions, "method" | "body">;
+
+const withEditionRule = (options: SkillsApiOptions): SkillsApiOptions => ({
+  ...options,
+  rules: [EDITION_RULE, ...(options.rules ?? [])],
+});
+
+const skillsGet = <T>(path: string, options: SkillsApiOptions = {}): Promise<T> =>
+  apiGet<T>(path, withEditionRule(options));
+
+const skillsPost = <T>(
+  path: string,
+  body: Record<string, unknown>,
+  options: SkillsApiOptions = {},
+): Promise<T> => apiPost<T>(path, body, withEditionRule(options));
+
 // Only the failures whose body says nothing useful. Every install refusal the
 // route describes in JSON is decoded in refusalToToolError() instead — an
 // ErrorRule is applied inside api() and would otherwise win first, which is how
@@ -88,12 +138,13 @@ const BUILTIN_NEXT =
  * pre-condition does.
  *
  * The 404 and 409 rules are matched on the route's `code` field and not on the
- * status alone. The Hermes edition gate answers 404 from this same route with
- * no code, and these tools are registered off an edition probe taken once at
- * startup — so on a device that changed harness since then, "no such skill is
- * installed" would be a confident answer to a question nobody asked. An
- * unlabelled status falls through to the generic mapping, which is the honest
- * outcome when we cannot tell which failure it was.
+ * status alone. The Hermes edition gate answers 404 from this same route, and
+ * these tools are registered off an edition probe taken once at startup — so on
+ * a device that changed harness since then, "no such skill is installed" would
+ * be a confident answer to a question nobody asked. That gate's own 404 is
+ * decoded by EDITION_RULE, which skillsPost() prepends; a 404 carrying neither
+ * code still falls through to the generic mapping, which is the honest outcome
+ * when we cannot tell which failure it was.
  */
 const uninstallRules = (name: string): ErrorRule[] => [
   {
@@ -143,7 +194,7 @@ const CATALOG_RULES: ErrorRule[] = [
  * was the only thing the agent ever saw.
  */
 async function installedSkills(): Promise<InstalledSkill[] | null> {
-  const body = await apiGet<InstalledBody>("/setup-api/hermes/skills/installed", {
+  const body = await skillsGet<InstalledBody>("/setup-api/hermes/skills/installed", {
     timeoutMs: 15_000,
   }).catch(() => null);
   return body?.skills ?? null;
@@ -393,7 +444,7 @@ export function registerSkillTools(reg: Registrar): void {
           "Search with plain words, 1 to 128 characters, not starting with a dash.",
         );
       }
-      const body = await apiGet<BrowseBody>("/setup-api/hermes/skills/browse", {
+      const body = await skillsGet<BrowseBody>("/setup-api/hermes/skills/browse", {
         query: { q: query, source, sort, size: limit, page: 1 },
         timeoutMs: 30_000,
         rules: CATALOG_RULES,
@@ -419,7 +470,7 @@ export function registerSkillTools(reg: Registrar): void {
     {},
     { editions: ["hermes"], readOnly: true, profile: "core", maxChars: 6_000 },
     async () => {
-      const body = await apiGet<InstalledBody>("/setup-api/hermes/skills/installed", { timeoutMs: 15_000 });
+      const body = await skillsGet<InstalledBody>("/setup-api/hermes/skills/installed", { timeoutMs: 15_000 });
       // A device ships ~77 built-in skills. One terse line each — pretty-printed
       // JSON of the full records is four times the size and no clearer, and this
       // list has to fit a 4-8B model's context alongside everything else.
@@ -459,7 +510,7 @@ export function registerSkillTools(reg: Registrar): void {
       // remote documentation. Asking for docs=1 alone gets you no metadata at
       // all, so the second call is made only when the first says it would add
       // something.
-      const phase1 = await apiGet<{ skill?: Record<string, unknown>; ambiguous?: boolean; candidates?: BrowseSkill[] }>(
+      const phase1 = await skillsGet<{ skill?: Record<string, unknown>; ambiguous?: boolean; candidates?: BrowseSkill[] }>(
         "/setup-api/hermes/skills/inspect",
         {
           query: { id },
@@ -495,7 +546,7 @@ export function registerSkillTools(reg: Registrar): void {
       let description = typeof detail.description === "string" ? detail.description : "";
       let documentation = typeof detail.body === "string" ? detail.body : "";
       if (detail.needsRemoteDocs === true) {
-        const phase2 = await apiGet<{ delta?: { description?: string; body?: string } }>(
+        const phase2 = await skillsGet<{ delta?: { description?: string; body?: string } }>(
           "/setup-api/hermes/skills/inspect",
           { query: { id, docs: 1 }, timeoutMs: 30_000 },
         ).catch(() => null);
@@ -576,7 +627,7 @@ export function registerSkillTools(reg: Registrar): void {
       }
       let body: { ok?: boolean; name?: string; files?: { repaired?: string[] } };
       try {
-        body = await apiPost<{ ok?: boolean; name?: string; files?: { repaired?: string[] } }>(
+        body = await skillsPost<{ ok?: boolean; name?: string; files?: { repaired?: string[] } }>(
           "/setup-api/hermes/skills/install",
           confirm ? { id, confirmDangerous: true } : { id },
           { timeoutMs: 180_000, rules: INSTALL_RULES },
@@ -634,7 +685,7 @@ export function registerSkillTools(reg: Registrar): void {
       // The route's field is `id`, but it means the lock NAME — the MCP
       // parameter is called `name` so the model cannot confuse it with the
       // store id that skill_install takes.
-      await apiPost(
+      await skillsPost(
         "/setup-api/hermes/skills/uninstall",
         { id: name },
         { timeoutMs: 60_000, rules: uninstallRules(name) },

--- a/src/lib/hermes-skills-server.ts
+++ b/src/lib/hermes-skills-server.ts
@@ -33,10 +33,18 @@ import { isValidSkillName } from '@/lib/hermes-skills';
  * feature, so refuse when the active harness isn't Hermes. Returns a 404
  * response to return early, or null to proceed. (On a dual box Hermes is
  * installed, so without this the CLI would run even with the store UI hidden.)
+ *
+ * The body carries `code: 'not_hermes'` so a machine caller can tell this 404
+ * apart from the ones the handlers themselves raise for an id they could not
+ * find. Both are 404 with a JSON `error` string, and the MCP's generic mapping
+ * reads any such body as "the id was wrong" — advice that sends the agent
+ * round the same guard again, since every skills route sits behind it. The
+ * status and the human-readable string are unchanged: the browser and
+ * `src/middleware.ts` see exactly what they saw before.
  */
 export async function hermesSkillsGuard(): Promise<NextResponse | null> {
   if ((await getActiveHarness()) !== 'hermes') {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ error: 'Not found', code: 'not_hermes' }, { status: 404 });
   }
   return null;
 }

--- a/src/lib/openclaw-apps-server.ts
+++ b/src/lib/openclaw-apps-server.ts
@@ -23,9 +23,16 @@
 import { NextResponse } from "next/server";
 import { getActiveHarness } from "@/lib/harness";
 
+// Labelled for the same reason hermesSkillsGuard's 404 is: a 404 whose JSON
+// carries an `error` string is what the MCP's generic mapping reads as "the id
+// you passed does not exist", and the recovery it advises — list the ids and
+// call again — comes straight back through this guard. The header comment
+// above already recorded that a chronically-404ing tool trips the agent's
+// circuit breaker; the `code` is what lets the tool stop instead. Status and
+// human-readable string unchanged.
 export async function openclawAppsGuard(): Promise<NextResponse | null> {
   if ((await getActiveHarness()) !== "openclaw") {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
+    return NextResponse.json({ error: "Not found", code: "not_openclaw" }, { status: 404 });
   }
   return null;
 }

--- a/src/tests/unit/mcp-skills-edition-guard.test.ts
+++ b/src/tests/unit/mcp-skills-edition-guard.test.ts
@@ -1,0 +1,293 @@
+import fs from "fs";
+import path from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * MCP-02a — the residual left by #513, and its sibling on the other guard.
+ *
+ * #513 taught skill_uninstall to decode the uninstall route's two LABELLED
+ * refusals (404 not_installed, 409 builtin_skill) and deliberately let an
+ * UNLABELLED 404 fall through to the generic mapping, on the grounds that
+ * "we cannot tell which failure it was" is the honest answer.
+ *
+ * The unlabelled 404 from these routes was not unknowable. Every
+ * /setup-api/hermes/skills/* route opens with hermesSkillsGuard(), which
+ * answered `{"error":"Not found"}` when the active harness is not Hermes — a
+ * JSON body with a non-empty `error` string, which is exactly what
+ * hasJsonErrorBody() reads as a RESOURCE-level 404. So the agent was told
+ * "check the id you passed, list what actually exists first, then call this
+ * tool again with one of those ids", when the real condition is an EDITION
+ * mismatch: skill_list goes through the same guard and 404s too, so the
+ * advised recovery cannot work. errors.ts's own comment at that branch names
+ * this confusion, in the other direction, as the thing it must never do.
+ *
+ * openclawAppsGuard() is the same guard for the app store and had the same
+ * defect — mcp/tools/desktop.ts's header comment already recorded that a
+ * chronically-404ing tool trips the agent's circuit breaker.
+ *
+ * Both sets of tools are registered off an edition probe taken ONCE when the
+ * MCP child spawned, so the window is a device whose harness changed since.
+ */
+
+const { apiGet, apiPost, activeHarness } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  activeHarness: vi.fn(async () => "openclaw" as string),
+}));
+
+// Reproduces what api() does around a call: a matched ErrorRule becomes a
+// ToolError before the tool handler ever sees the ApiError.
+vi.mock("../../../mcp/lib/api", async () => {
+  const { ApiError, matchRule } = await import("../../../mcp/lib/errors");
+  const withRules =
+    (fn: (...a: unknown[]) => unknown) =>
+    async (route: string, ...rest: unknown[]) => {
+      try {
+        return await fn(route, ...rest);
+      } catch (err) {
+        const opts = (rest[rest.length - 1] ?? {}) as { rules?: Parameters<typeof matchRule>[1] };
+        if (err instanceof ApiError) throw matchRule(err, opts?.rules) ?? err;
+        throw err;
+      }
+    };
+  return {
+    apiGet: withRules(apiGet),
+    apiPost: withRules(apiPost),
+    apiTry: vi.fn(async () => null),
+    API_BASE: "http://127.0.0.1:80",
+    CLAWBOX_ROOT: "/home/clawbox/clawbox",
+  };
+});
+
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: activeHarness,
+  HERMES_BIN: "/home/clawbox/.local/bin/hermes",
+}));
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet: vi.fn(async () => ""),
+  hermesConfigGetMany: vi.fn(async () => ({})),
+  invalidateHermesConfigCache: vi.fn(),
+}));
+
+import { hermesSkillsGuard } from "@/lib/hermes-skills-server";
+import { openclawAppsGuard } from "@/lib/openclaw-apps-server";
+import { ApiError } from "../../../mcp/lib/errors";
+import { registerSkillTools } from "../../../mcp/tools/skills";
+import { registerDesktopTools } from "../../../mcp/tools/desktop";
+import type { McpContext } from "../../../mcp/lib/context";
+import { captureRegistrar } from "../helpers/mcp-registrar";
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPost.mockReset();
+  activeHarness.mockReset();
+});
+
+// ── The guards' own answers ──────────────────────────────────────────────────
+
+describe("the edition guards — a refusal has to be tellable from a missing id", () => {
+  it("hermesSkillsGuard labels its 404 so a caller can tell it from a resource 404", async () => {
+    activeHarness.mockResolvedValue("openclaw");
+    const res = await hermesSkillsGuard();
+    expect(res).not.toBeNull();
+    if (!res) return;
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: string; code?: string };
+    // The status and the human string are unchanged — the browser and
+    // src/middleware.ts must see exactly what they saw before — but the
+    // machine-readable reason is now on the wire.
+    expect(body.error).toBe("Not found");
+    expect(body.code).toBe("not_hermes");
+  });
+
+  it("openclawAppsGuard labels its 404 the same way", async () => {
+    activeHarness.mockResolvedValue("hermes");
+    const res = await openclawAppsGuard();
+    expect(res).not.toBeNull();
+    if (!res) return;
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error?: string; code?: string };
+    expect(body.error).toBe("Not found");
+    expect(body.code).toBe("not_openclaw");
+  });
+
+  it("neither guard answers at all on its own harness", async () => {
+    activeHarness.mockResolvedValue("hermes");
+    expect(await hermesSkillsGuard()).toBeNull();
+    activeHarness.mockResolvedValue("openclaw");
+    expect(await openclawAppsGuard()).toBeNull();
+  });
+});
+
+// ── Every guarded tool decodes it the same way ───────────────────────────────
+
+const ctx = (edition: "openclaw" | "hermes"): McpContext => ({
+  edition,
+  install: edition,
+  profile: "full",
+  capabilities: { screenGrabber: null, imageConvert: false, journal: false, du: false },
+  providers: [],
+  emailCanRead: false,
+  codingAgent: false,
+  canGenerateImages: true,
+});
+
+describe("the guarded tools — an edition-guard 404 is not a bad id", () => {
+  /** Exactly what the guards put on the wire. */
+  const guard404 = (code: "not_hermes" | "not_openclaw") =>
+    new ApiError(404, JSON.stringify({ error: "Not found", code }));
+
+  const guardEverything = (code: "not_hermes" | "not_openclaw") => {
+    apiGet.mockRejectedValue(guard404(code));
+    apiPost.mockRejectedValue(guard404(code));
+  };
+
+  function skills() {
+    const h = captureRegistrar("hermes");
+    registerSkillTools(h.reg);
+    return h;
+  }
+
+  function desktop() {
+    const h = captureRegistrar("openclaw");
+    registerDesktopTools(h.reg, ctx("openclaw"));
+    return h;
+  }
+
+  // Every tool that reaches a guarded route, with an argument set that passes
+  // its own local validation — so the 404 is the only thing under test.
+  const CASES: {
+    tool: string;
+    args: Record<string, unknown>;
+    code: "not_hermes" | "not_openclaw";
+    harness: RegExp;
+  }[] = [
+    {
+      tool: "skill_search",
+      args: { query: "pdf", sort: "relevance", limit: 5 },
+      code: "not_hermes",
+      harness: /hermes harness/i,
+    },
+    { tool: "skill_list", args: {}, code: "not_hermes", harness: /hermes harness/i },
+    { tool: "skill_info", args: { id: "official/pdf" }, code: "not_hermes", harness: /hermes harness/i },
+    {
+      tool: "skill_install",
+      args: { id: "official/pdf", confirm: false },
+      code: "not_hermes",
+      harness: /hermes harness/i,
+    },
+    { tool: "skill_uninstall", args: { name: "pdf" }, code: "not_hermes", harness: /hermes harness/i },
+    { tool: "app_search", args: { limit: 5 }, code: "not_openclaw", harness: /openclaw harness/i },
+    { tool: "app_install", args: { app_id: "notes" }, code: "not_openclaw", harness: /openclaw harness/i },
+  ];
+
+  it.each(CASES)("$tool says the harness is wrong, not the id", async ({ tool, args, code, harness }) => {
+    guardEverything(code);
+    const h = code === "not_hermes" ? skills() : desktop();
+    const out = await h.call(tool, args);
+
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("NOT_SUPPORTED_HERE");
+    expect(out.error.message).toMatch(harness);
+    expect(out.error.next).toMatch(/do not retry/i);
+    // Every recovery the old wording offered goes back through the same guard.
+    expect(out.error.next).not.toMatch(/skill_list|skill_search|app_search|ui_list_apps|code_project_list/);
+    expect(out.error.message).not.toMatch(
+      /no skill with that id|not a valid|could not find what this tool was pointed at/i,
+    );
+  });
+
+  /**
+   * The two halves of this fix live in different packages — the route under
+   * src/, the rule under mcp/ — and nothing but a shared string literal joins
+   * them. So take the guard's REAL response body off the wire and feed it to
+   * the tool, rather than retyping what we hope it says.
+   */
+  it("decodes the body the guard actually sends, not a hand-written copy", async () => {
+    activeHarness.mockResolvedValue("openclaw");
+    const guardRes = await hermesSkillsGuard();
+    expect(guardRes).not.toBeNull();
+    if (!guardRes) return;
+    const wire = await guardRes.text();
+
+    apiGet.mockRejectedValue(new ApiError(404, wire));
+    const out = await skills().call("skill_list", {});
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("NOT_SUPPORTED_HERE");
+
+    activeHarness.mockResolvedValue("hermes");
+    const appsRes = await openclawAppsGuard();
+    expect(appsRes).not.toBeNull();
+    if (!appsRes) return;
+    apiGet.mockRejectedValue(new ApiError(404, await appsRes.text()));
+    const appOut = await desktop().call("app_search", { limit: 5 });
+    expect(appOut.isError).toBe(true);
+    if (!appOut.isError) return;
+    expect(appOut.error.code).toBe("NOT_SUPPORTED_HERE");
+  });
+
+  it("still reads a LABELLED not_installed 404 as a missing skill", async () => {
+    // Anti-shadowing: the edition rule sits first in every list, so it must not
+    // swallow the refusal #513 added.
+    apiGet.mockRejectedValue(new ApiError(502, "{}"));
+    apiPost.mockRejectedValue(
+      new ApiError(404, JSON.stringify({ error: "not installed", code: "not_installed" })),
+    );
+
+    const out = await skills().call("skill_uninstall", { name: "ghost" });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("NOT_FOUND");
+    expect(out.error.message).toMatch(/no installed skill called "ghost"/i);
+  });
+
+  it("still reads an UNLABELLED 404 from a store route as a missing app id", async () => {
+    // The other half of the same coin: a store route can 404 for an id it does
+    // not have, and that one really is the agent's to fix.
+    apiGet.mockRejectedValue(new ApiError(404, JSON.stringify({ error: "App not found" })));
+    const out = await desktop().call("app_search", { limit: 5 });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("NOT_FOUND");
+    expect(out.error.message).not.toMatch(/harness/i);
+  });
+});
+
+// ── Anti-drift ───────────────────────────────────────────────────────────────
+
+describe("no guarded call may bypass its edition rule", () => {
+  /**
+   * The bug this file closes existed because the rule lists were per-call-site
+   * and four of the seven skills call sites (installedSkills(), skill_list, the
+   * inspect docs phase, and the uninstall POST before #513) carried no rule for
+   * this at all. Routing every call through the two local wrappers is what
+   * makes "we found them all" checkable rather than claimed.
+   */
+  it("reaches the skills routes only through skillsGet/skillsPost", () => {
+    const src = fs.readFileSync(path.join(process.cwd(), "mcp/tools/skills.ts"), "utf-8");
+    const bare = src.match(/(?<![A-Za-z])api(?:Get|Post)\s*</g) ?? [];
+    // The two wrapper definitions are the only permitted uses.
+    expect(bare.length).toBe(2);
+    expect(src).not.toMatch(/(?<![A-Za-z])api(?:Get|Post)\s*\(\s*["']\/setup-api/);
+  });
+
+  /**
+   * desktop.ts has only two calls behind openclawAppsGuard() and several that
+   * are deliberately NOT guarded (apps/uninstall, apps/icon), so a blanket
+   * wrapper would be the wrong shape there. This is the check that keeps the
+   * two guarded ones honest instead.
+   */
+  it("passes the store edition rule on every call to a guarded apps route", () => {
+    const src = fs.readFileSync(path.join(process.cwd(), "mcp/tools/desktop.ts"), "utf-8");
+    const GUARDED = ["/setup-api/apps/store", "/setup-api/apps/install"];
+    for (const route of GUARDED) {
+      const at = src.indexOf(`"${route}"`);
+      expect(at, `${route} is no longer called from desktop.ts`).toBeGreaterThan(-1);
+      // The options object of that call, up to the end of the statement.
+      const stmt = src.slice(at, src.indexOf(");", at));
+      expect(stmt, `${route} does not pass STORE_EDITION_RULE`).toContain("STORE_EDITION_RULE");
+    }
+  });
+});

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -279,12 +279,14 @@ describe("skill_uninstall — a 200 is not proof anything was removed", () => {
     });
 
     /**
-     * The edition gate answers 404 from the SAME route, with no `code`. The
-     * tool is registered off a probe taken once at startup, so a device that
-     * switched harness since then reaches this branch — and "no such skill is
-     * installed" would be a confident answer to a question nobody asked.
+     * A 404 from this route carrying NO code at all: not the edition gate,
+     * which labels its refusal `not_hermes` and is decoded as
+     * NOT_SUPPORTED_HERE in mcp-skills-edition-guard.test.ts, but anything
+     * else that answers 404 in front of the handler. "No such skill is
+     * installed" would be a confident answer to a question nobody asked, so
+     * this stays on the generic mapping.
      */
-    it("does not read the Hermes edition guard's 404 as a missing skill", async () => {
+    it("does not read an unlabelled 404 as a missing skill", async () => {
       blindfolded();
       routeSays(404, { error: "Not found" });
 


### PR DESCRIPTION
Follow-up to #513. One residual, MCP-02a, plus the sibling the class check turned up.

## The residual

#513 decoded `skill_uninstall`'s two **labelled** refusals (404 `not_installed`, 409 `builtin_skill`) and deliberately let an **unlabelled** 404 fall through to the generic mapping, calling that "the honest outcome when we cannot tell which failure it was".

But the unlabelled 404 from these routes was never unknowable. It has one source: `hermesSkillsGuard()` (`src/lib/hermes-skills-server.ts:39`), which answers

```json
{ "error": "Not found" }
```

That is a JSON body with a non-empty `error` string, which is exactly the test `hasJsonErrorBody()` uses to call a 404 **resource-level**. So `fromApiError()` returned:

> The ClawBox could not find what this tool was pointed at.
> Check the id you passed. List what actually exists first (`ui_list_apps`, `code_project_list` or `skill_list`), then call this tool again with one of those ids.

The real condition is an **edition** mismatch. `skill_list` sits behind the same guard and 404s too, so every recovery that sentence names walks back into the guard. `mcp/lib/errors.ts` carries a comment at that exact branch naming this confusion — in the other direction — as the thing it must never do.

It was never only `skill_uninstall`: all six `/setup-api/hermes/skills/*` routes open with the same guard.

## Reproduced first

Against merged beta, before any source change — 12 of 15 new assertions red:

```
Tests  12 failed | 3 passed (15)
```

The 3 that passed on unmodified beta are the anti-regression ones: #513's `not_installed` decode, the store's genuine resource-404, and the guards returning `null` on their own harness. After the fix: **15 passed**.

## The fix

**Label the refusal.** Both guards now send `code: 'not_hermes'` / `code: 'not_openclaw'`. Status and the human-readable `error` string are unchanged, so the browser and `src/middleware.ts` see exactly what they saw before; only a machine caller can now tell the two 404s apart.

**Decode it everywhere, not at one call site.** `EDITION_RULE` is prepended by `skillsGet()` / `skillsPost()`, and all seven calls in `mcp/tools/skills.ts` go through them.

`skill_info` was the one that mattered most: its status-only 404 rule was already answering *"No skill with that id / call skill_search and use an id from its results"* for an off-Hermes device — a confident wrong answer, not merely a vague one. The edition rule is prepended so it precedes that rule; every other 404 rule in the module is `match`-gated on its own `code`, so none of them can shadow each other.

## How I know I found every sibling

```
grep -rn "hermesSkillsGuard" --include=*.ts --include=*.tsx . | grep -v node_modules
grep -rn "hermes/skills" mcp/ | grep -v node_modules
grep -n "apiGet\|apiPost\|rules:" mcp/tools/skills.ts
```

The first names all six guarded routes. The second names every MCP caller of them: seven in `mcp/tools/skills.ts`, one in `desktop.ts` (`ui_list_apps`, which `.catch(() => null)`s the read and reports an empty skill list — swallowed, never mis-decoded), one in `orientation.ts` (a raw `fetch` that reports `HTTP <status>` verbatim and interprets nothing). The third showed that only 3 of the 7 skills call sites passed any rules at all; `installedSkills()`, `skill_list` and the `inspect` docs phase passed none, so a per-call-site fix would have left three holes.

Rather than trust that reading, `mcp/tools/skills.ts` now reaches the API only through the two wrappers, and a test asserts `apiGet`/`apiPost` appear nowhere else in the module — the same defect cannot come back by someone adding an eighth call.

## The sibling: openclawAppsGuard

Widening from "the uninstall route" to "an edition guard's 404" put `openclawAppsGuard()` in scope, and it had the identical defect. `mcp/tools/desktop.ts`'s own header comment already recorded the consequence:

> On a Hermes device `/setup-api/apps/*` answers 404 "Not found", which a small model reads as "no such app" and retries forever — and a chronically-404ing tool is exactly what trips Hermes' per-server circuit breaker and takes EVERY ClawBox tool offline.

`app_search` and `app_install` now carry `STORE_EDITION_RULE`. Those are the only two MCP calls behind that guard: `apps/uninstall` and `apps/icon` are deliberately unguarded (the file says why), and `apps/settings` / `apps/skill-info` have no MCP caller. A wrapper would be the wrong shape there, so a test asserts the rule is present at both guarded call sites instead.

## Tests

`src/tests/unit/mcp-skills-edition-guard.test.ts`, 15 assertions:

- each guard labels its 404, and neither answers at all on its own harness
- all seven guarded tools — `skill_search`, `skill_list`, `skill_info`, `skill_install`, `skill_uninstall`, `app_search`, `app_install` — answer `NOT_SUPPORTED_HERE`, name the harness, say "do not retry", and never name a recovery that goes back through the guard
- the guard's **real** response body is taken off the wire and fed to the tools, rather than a hand-typed copy — the route lives under `src/`, the rule under `mcp/`, and nothing but a string literal joins them
- #513's `not_installed` decode still works (anti-shadowing), and a genuine unlabelled resource-404 from a store route is still `NOT_FOUND`
- the two anti-drift structural checks described above

## Severity

Low, and not customer-facing. The window is a device whose harness changed since the MCP child spawned; a dual-edition switch normally restarts the gateway and respawns it. What it costs when it opens is a small model looping on a recovery that cannot work — which is the failure mode the circuit-breaker comment was already worried about.

## Checks

- `eslint` on all five changed files: clean
- `tsc -p mcp/tsconfig.json`: 3 pre-existing errors in `src/lib/chat-history-cache.ts` and `src/lib/harness/transport.ts`, unchanged, none in touched files
- targeted suites (`mcp*`, `routes/hermes`, `routes/apps`): no new failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer support handling for app-store and skill-store requests in unsupported app editions.
  * Unsupported requests now provide actionable, non-retry guidance instead of appearing as missing apps or skills.
  * Preserved existing handling for genuine “not found” results.

* **Bug Fixes**
  * Improved consistency across browsing, searching, installing, inspecting, and uninstalling store items.
  * Added clearer error details for unsupported editions.
  * Prevented unsupported store requests from being misclassified as missing items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->