### PR TITLE
fix: clean a hermes CLI failure once, for every surface that renders it

### DIFF
--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -47,6 +47,11 @@ import {
 } from "@/lib/harness/hermes-generated-media";
 import { capabilitiesFor, UNKNOWN_FACTS } from "@/lib/harness/capabilities";
 import { isQuietStreamError, openDashboardTurn, type DashboardTurn } from "@/lib/hermes-dashboard-turn";
+import {
+  errorFromStderr,
+  hermesFailureMessage,
+  spawnFailureMessage,
+} from "@/lib/hermes-cli-message";
 
 /**
  * How many images one turn may carry — the same number the composer is told,
@@ -166,14 +171,14 @@ function runHermes(args: string[], signal?: AbortSignal): Promise<{ out: string;
     child.on("error", (e) => {
       if (settled) return;
       cleanup();
-      // A missing binary surfaces as ENOENT with the full spawn path in the
-      // message (`spawn /home/clawbox/.local/bin/hermes ENOENT`). Don't leak
-      // that path to the client — report the actionable cause instead.
-      if ((e as NodeJS.ErrnoException).code === "ENOENT") {
-        reject(new Error("Hermes is not installed on this device"));
-        return;
-      }
-      reject(e);
+      // EVERY spawn failure carries the full binary path in its message
+      // (`spawn /home/clawbox/.local/bin/hermes EACCES`), not just ENOENT —
+      // and this message becomes the chat bubble, the 502 body AND the durable
+      // transcript line. Sanitising one errno and passing the rest through was
+      // the whole of the leak. Keep the raw text in the journal, where a path
+      // is a diagnosis rather than a disclosure.
+      console.error("[hermes chat] spawn failed", e);
+      reject(new Error(spawnFailureMessage(e)));
     });
     child.on("close", (code) => {
       if (settled) return;
@@ -187,180 +192,9 @@ function runHermes(args: string[], signal?: AbortSignal): Promise<{ out: string;
   });
 }
 
-/**
- * Turn `chat -q`'s stderr into something worth showing a person.
- *
- * The first thing on stderr is always the `session_id:` banner, so a failed run
- * used to surface as "Error: session_id: 20260810_221825_609d1e" — the one line
- * on the stream that says nothing about what went wrong. The actual cause sat
- * on the next line: "HTTP 404: Model 'claude-opus-5' not found. The requested
- * model does not exist in our configuration or OpenRouter catalog."
- *
- * So: drop the banner and anything else that is pure bookkeeping, and lead with
- * the first line that names a failure — a stack trace's later frames are worse
- * than useless in a chat bubble.
- */
-function errorFromStderr(stderr: string): string {
-  return usefulLines(stderr)[0] ?? "";
-}
-
-/**
- * Hermes hard-wraps its output at ~76 columns, so ONE sentence arrives as
- * several lines. Rejoining them is the difference between
- *
- *   "No inference provider configured. Run 'hermes model' to choose a provider and"
- *
- * — which is what the customer used to get, ending on a dangling "and" — and the
- * whole message, whose second half is the part they can act on: which API key to
- * set, and that it goes in ~/.hermes/.env.
- *
- * A line continues the one above it when the one above looks WRAPPED: long
- * enough to have hit the wrap column, and followed by something that does not
- * start a new record of its own (a list item, a `key: value` line, an
- * `HTTP 404:` / `SomeError:` header). Nothing here joins two independent
- * failures — those start with one of those markers — and a short line is never
- * treated as wrapped, so a terse two-line report stays two lines.
- */
-const WRAP_COLUMN_HINT = 60;
-
-function startsNewRecord(line: string): boolean {
-  return /^(?:[-*•]|\d+[.)])\s/.test(line)
-    || /^HTTP\s+\d{3}\b/.test(line)
-    || /^[A-Za-z][\w.]*(?:Error|Exception|Warning)\b/.test(line)
-    || /^[A-Za-z][\w .\-]*:\s/.test(line);
-}
-
-function unwrap(lines: string[]): string[] {
-  const paragraphs: string[] = [];
-  for (const line of lines) {
-    const previous = paragraphs[paragraphs.length - 1];
-    if (previous !== undefined && previous.length >= WRAP_COLUMN_HINT && !startsNewRecord(line)) {
-      paragraphs[paragraphs.length - 1] = `${previous} ${line}`;
-    } else {
-      paragraphs.push(line);
-    }
-  }
-  return paragraphs;
-}
-
-/** The cap is per MESSAGE, not per line — a bubble is not a log viewer. */
-const MAX_MESSAGE_CHARS = 400;
-
-/**
- * Lines `chat -q` prints as STATUS, not as causes.
- *
- * `--resume` announces itself on stderr before the turn says anything, and on
- * EVERY resumed run — success or failure alike. Captured verbatim from the
- * live box (exit 1, the real cause sitting on stdout as "HTTP 403 — Just a
- * moment..."):
- *
- *   ↻ Resumed session 20260825_165225_be089e "What model are you and what is
- *   this machine?" (2 user messages, 7 total messages)
- *   Model restored from session: claude-fable-5 (anthropic)
- *   session_id: 20260825_165225_be089e
- *
- * Because only the `session_id:` line was being stripped, `errorFromStderr`
- * found the resume banner, decided stderr "said something", and the customer's
- * bubble read "Error: ↻ Resumed session …" while the actual failure was never
- * looked at. A banner is bookkeeping exactly like the session id under it.
- *
- * Matching on text is the only classifier available HERE: the CLI's streams
- * carry no framing to gate on. The streamed transport does not have this
- * problem to begin with — the dashboard socket reports the same resume as a
- * typed `session.resume` RESULT frame (captured live: `{"resumed":
- * "20260825_165225_be089e", …}`), never as an event the turn loop could
- * mistake for output.
- */
-function isBookkeepingLine(line: string): boolean {
-  return /^session_id:/i.test(line)
-    || /^(?:↻\s*)?Resumed session\b/.test(line)
-    || /^Model restored from session\b/.test(line)
-    // The connectors CPython prints between chained tracebacks. They sit at
-    // column 0, so they survive the frame strip below, and they name no cause.
-    || /^(?:During handling of the above exception|The above exception was the direct cause)\b/
-      .test(line);
-}
-
-/**
- * Drop the FRAMES of a Python traceback, keeping only its summary line.
- *
- * CPython indents everything belonging to a frame — the `File "…"` header, the
- * source line under it and (3.11+) the `^^^^` anchor beneath that — and returns
- * the exception summary to column 0. Trimming every line before classifying it
- * threw that signal away. Only the frame HEADER was being dropped, so the
- * source line under it survived, matched the "names a failure" filter below on
- * its `RuntimeError(` text, and — sitting earlier in the stream than the real
- * summary — became the customer's error bubble. Captured shape:
- *
- *   Traceback (most recent call last):
- *     File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider
- *       raise RuntimeError("upstream refused the request")     <- what was shown
- *   RuntimeError: upstream refused the request                 <- what to show
- *
- * So classify on the RAW line: once a traceback opens, drop everything indented
- * under it and let the first column-0 line both end the block and stand as the
- * cause. A frame header opens a block too, so a stream whose `Traceback:` line
- * was already cut off still reads correctly. If the stream ENDS inside the
- * frames, nothing is invented — the caller falls back to the exit code rather
- * than quoting Python source at a customer. The block is scoped: once it ends,
- * an indented line is ordinary output again.
- *
- * A frame header is matched by its FULL shape — `File "…", line <n>` — not by
- * its first six characters. `File "config.yaml" was denied` is a sentence a
- * customer needs to read, and the loose form both swallowed it and reopened a
- * block that had already closed, taking the indented lines after it with it.
- */
-const TRACEBACK_OPENER = /^[ \t]*(?:Traceback\b|File "[^"]+", line \d+\b)/;
-
-function withoutTracebackFrames(lines: string[]): string[] {
-  const kept: string[] = [];
-  let inTraceback = false;
-  for (const line of lines) {
-    if (TRACEBACK_OPENER.test(line)) {
-      inTraceback = true;
-      continue;
-    }
-    if (inTraceback) {
-      if (!line || /^[ \t]/.test(line)) continue;
-      inTraceback = false;
-    }
-    kept.push(line);
-  }
-  return kept;
-}
-
-/** Bookkeeping and stack noise, dropped before we look for a cause. */
-function usefulLines(stream: string): string[] {
-  // Strip frames BEFORE trimming: the indentation is the only thing that tells
-  // a frame's source line apart from a line the customer needs to read.
-  const lines = withoutTracebackFrames(stream.split(/\r?\n/))
-    .map((l) => l.trim())
-    .filter((l) => l && !isBookkeepingLine(l));
-  // Unwrap FIRST: the filter below keeps lines that themselves name a failure,
-  // and the continuation lines of a wrapped message read as prose. That is how
-  // the remedy half of every multi-line Hermes error was being dropped.
-  const paragraphs = unwrap(lines);
-  const named = paragraphs.filter((l) =>
-    /\b(?:HTTP\s+\d{3}|error|failed|not found|denied|invalid|unauthor)/i.test(l));
-  return (named.length ? named : paragraphs).map((l) =>
-    l.length > MAX_MESSAGE_CHARS ? `${l.slice(0, MAX_MESSAGE_CHARS - 1)}…` : l);
-}
-
-/**
- * The message for a failed turn, from whichever stream actually carries it.
- *
- * Reading stderr alone was not enough. On a provider-side failure Hermes puts
- * the explanation on STDOUT — "API call failed after 3 retries: HTTP 404:
- * model: claude-opus-4-20250514" — and leaves stderr holding only the
- * `session_id:` banner. Stripping that banner (correctly) then left nothing,
- * so the customer got "hermes exited with code 1": true, and useless.
- *
- * stderr is still preferred when it says something, since a crash reports
- * there; stdout is the fallback that covers the provider-error case.
- */
-function hermesFailureMessage(stdout: string, stderr: string): string {
-  return errorFromStderr(stderr) || (usefulLines(stdout)[0] ?? "");
-}
+// The failure-message parser lives in @/lib/hermes-cli-message: the Settings
+// panel renders the same `hermes` stderr through two more routes, and a parser
+// that only the chat route could reach is how the frames got back on screen.
 
 /**
  * The exit code `hermes chat -q` uses when a turn is cut short by a signal.
@@ -425,6 +259,7 @@ function hermesExitMessage(code: number | null, stdout: string, stderr: string):
 export const __test = {
   hermesFailureMessage,
   errorFromStderr,
+  spawnFailureMessage,
   hermesExitMessage,
   HERMES_INTERRUPTED_EXIT_CODE,
 };

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
+import { hermesFailureMessage } from "@/lib/hermes-cli-message";
 import { requireSession } from "@/lib/route-auth";
 import { reconcileLocalAiWithHermes } from "@/lib/hermes-local-ai";
 import {
@@ -222,10 +223,23 @@ export async function POST(request: Request) {
 
   // Only text WE produced is safe to echo back — a raw spawn rejection can
   // carry the hermes binary path.
+  //
+  // `r.stderr` is not that text. It is the CLI's, and when `hermes config set`
+  // CRASHES it is a CPython traceback: frames naming /home/clawbox/.hermes and
+  // the `raise` line above the summary, all of it landing verbatim in the
+  // Settings save banner through `saveErrorMessage`. That is the same input PR
+  // #515 cleaned out of the chat bubble, arriving through the panel instead —
+  // so it goes through the same parser. The raw stream still reaches the
+  // journal, which is where a path is a diagnosis rather than a disclosure.
   class ConfigSetError extends Error {}
   const setKey = async (key: string, value: string) => {
     const r = await runHermesCli(["config", "set", key, value]);
-    if (r.code !== 0) throw new ConfigSetError(r.stderr || `Failed to set ${key}`);
+    if (r.code !== 0) {
+      console.error("[hermes models] config set exit", r.code, r.stderr);
+      throw new ConfigSetError(
+        hermesFailureMessage(r.stdout, r.stderr) || `Failed to set ${key}`,
+      );
+    }
   };
 
   try {

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
-import { hermesFailureMessage } from "@/lib/hermes-cli-message";
+import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { requireSession } from "@/lib/route-auth";
 import { reconcileLocalAiWithHermes } from "@/lib/hermes-local-ai";
 import {
@@ -237,7 +237,7 @@ export async function POST(request: Request) {
     if (r.code !== 0) {
       console.error("[hermes models] config set exit", r.code, r.stderr);
       throw new ConfigSetError(
-        hermesFailureMessage(r.stdout, r.stderr) || `Failed to set ${key}`,
+        safeHermesFailureMessage(r.stdout, r.stderr) || `Failed to set ${key}`,
       );
     }
   };

--- a/src/app/setup-api/hermes/provider-key/route.ts
+++ b/src/app/setup-api/hermes/provider-key/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
-import { hermesFailureMessage } from "@/lib/hermes-cli-message";
+import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 
 // Store an API key for a Hermes inference provider via `hermes auth add`. Hermes
@@ -74,7 +74,7 @@ export async function POST(request: Request) {
       //    the input PR #515 cleaned out of the chat bubble; the same parser
       //    cleans it here.
       console.error("[hermes provider-key] auth add exit", r.code, redactKey(r.stderr, apiKey));
-      const reported = hermesFailureMessage(redactKey(r.stdout, apiKey), redactKey(r.stderr, apiKey));
+      const reported = safeHermesFailureMessage(redactKey(r.stdout, apiKey), redactKey(r.stderr, apiKey));
       return NextResponse.json({ error: reported || "Failed to save API key" }, { status: 502 });
     }
   } catch (err) {

--- a/src/app/setup-api/hermes/provider-key/route.ts
+++ b/src/app/setup-api/hermes/provider-key/route.ts
@@ -2,6 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
+import { hermesFailureMessage } from "@/lib/hermes-cli-message";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 
 // Store an API key for a Hermes inference provider via `hermes auth add`. Hermes
@@ -24,6 +25,17 @@ const API_KEY_PROVIDERS = new Set([
 // argv element (no shell), but reject a leading "-" so hermes can't read the key
 // as a flag.
 const API_KEY_RE = /^[!-~]{8,512}$/;
+
+/**
+ * Take the pasted key out of any text on its way to a person or a log.
+ *
+ * The key is validated to printable non-space ASCII, so a plain substring swap
+ * is exact — there is no encoding of it in the CLI's output that this would
+ * miss and no regex escaping to get wrong.
+ */
+function redactKey(text: string, apiKey: string): string {
+  return apiKey ? text.split(apiKey).join("<redacted>") : text;
+}
 
 export async function POST(request: Request) {
   let body: { provider?: string; apiKey?: string };
@@ -49,11 +61,25 @@ export async function POST(request: Request) {
       { timeoutMs: 20_000 },
     );
     if (r.code !== 0) {
-      // Never echo the key back in an error. hermes stderr may name the
-      // provider but not the secret.
-      return NextResponse.json({ error: r.stderr || "Failed to save API key" }, { status: 502 });
+      // Two separate things must not reach the save banner, and only one of
+      // them was being thought about here.
+      //
+      // 1. The KEY. The old comment asserted hermes "may name the provider but
+      //    not the secret" — true of a clean refusal, false of an argparse
+      //    usage error, which prints the offending argv and the key is IN the
+      //    argv. So it is redacted rather than assumed absent.
+      // 2. The CRASH. `hermes auth add` is the first thing a customer runs when
+      //    adding a provider, and a traceback here rendered verbatim: CPython
+      //    frames naming /home/clawbox/.hermes, straight into Settings. That is
+      //    the input PR #515 cleaned out of the chat bubble; the same parser
+      //    cleans it here.
+      console.error("[hermes provider-key] auth add exit", r.code, redactKey(r.stderr, apiKey));
+      const reported = hermesFailureMessage(redactKey(r.stdout, apiKey), redactKey(r.stderr, apiKey));
+      return NextResponse.json({ error: reported || "Failed to save API key" }, { status: 502 });
     }
   } catch (err) {
+    // `runHermesCli` rejects only on a spawn failure, and it has already turned
+    // that into path-free text (src/lib/hermes-cli-message.ts).
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "hermes auth add failed" },
       { status: 502 },

--- a/src/lib/hermes-cli-message.ts
+++ b/src/lib/hermes-cli-message.ts
@@ -11,6 +11,7 @@
  * The grep that says the surfaces are all accounted for:
  *   grep -rn "stderr" src/app/setup-api/hermes --include=route.ts
  */
+import { sanitizeErrorMessage } from "@/lib/safe-error-text";
 
 /**
  * Turn a `hermes` subcommand's stderr into something worth showing a person.
@@ -191,6 +192,30 @@ function usefulLines(stream: string): string[] {
  */
 export function hermesFailureMessage(stdout: string, stderr: string): string {
   return errorFromStderr(stderr) || (usefulLines(stdout)[0] ?? "");
+}
+
+/**
+ * The same message, but only if it is safe to render to a customer.
+ *
+ * `hermesFailureMessage` answers "what did the CLI say went wrong". That is a
+ * different question from "may this be shown to a person", and conflating them
+ * is how the panel would keep leaking after the frames were stripped: a CLI
+ * needs no traceback to name the install layout, and the ordinary one-line
+ * EACCES shape —
+ *
+ *   Error: cannot write /home/clawbox/.hermes/config.yaml: permission denied
+ *
+ * — survives every rule above, because it genuinely IS the cause and it
+ * genuinely does name a failure.
+ *
+ * So the last word belongs to `sanitizeErrorMessage`, the repo's existing
+ * whitelist-by-shape ("one place that decides whether a message produced by a
+ * failing layer may be shown"), which already drops paths, URLs, credentials,
+ * stack frames and internal handles. Returning "" rather than the unsafe text
+ * lets each caller fall back to the fixed sentence it already has.
+ */
+export function safeHermesFailureMessage(stdout: string, stderr: string): string {
+  return sanitizeErrorMessage(hermesFailureMessage(stdout, stderr)) ?? "";
 }
 
 /**

--- a/src/lib/hermes-cli-message.ts
+++ b/src/lib/hermes-cli-message.ts
@@ -186,7 +186,31 @@ function withoutTracebackFrames(lines: string[]): string[] {
  * tilde would replace the one actionable fact in that message with `<path>`.
  * Anchored on a preceding boundary so "2/3 of the files" is not a path.
  */
-const DEVICE_PATH = /(?<![\w~])\/(?:home|root|usr|opt|var|etc|tmp|srv|mnt|snap)(?:\/[\w.@+-]+)+/g;
+const SYSTEM_ROOT = "(?:home|root|usr|opt|var|etc|tmp|srv|mnt|snap)";
+
+/**
+ * A QUOTED absolute path, matched first and to its closing quote.
+ *
+ * POSIX components may contain spaces, and CPython quotes the path it failed
+ * on, so the unquoted rule below — which stops at the first character no path
+ * component is allowed to contain — left the tail of one on screen:
+ *
+ *   No such file or directory: '<path> Files/credentials.json'
+ *
+ * Still a directory and a filename. Inside quotes the closing quote is the real
+ * end of the path, so that is what bounds this match; any other quote character
+ * ends the class first and the match simply fails, falling through to the
+ * unquoted rule rather than swallowing the rest of the line.
+ */
+const QUOTED_DEVICE_PATH = new RegExp(`(['"\`])\\/${SYSTEM_ROOT}\\/[^'"\`\\n]*\\1`, "g");
+
+/** The same path unquoted, bounded by the first character a component cannot hold. */
+const DEVICE_PATH = new RegExp(`(?<![\\w~])\\/${SYSTEM_ROOT}(?:\\/[\\w.@+-]+)+`, "g");
+
+/** Both forms, quoted first so a space inside quotes cannot cut the match short. */
+function redactDevicePaths(line: string): string {
+  return line.replace(QUOTED_DEVICE_PATH, "<path>").replace(DEVICE_PATH, "<path>");
+}
 
 /** Bookkeeping and stack noise, dropped before we look for a cause. */
 function usefulLines(stream: string): string[] {
@@ -205,7 +229,7 @@ function usefulLines(stream: string): string[] {
   // said, and BEFORE the cap, so the truncation counts the text a person will
   // see rather than a path they never will.
   return (named.length ? named : paragraphs)
-    .map((l) => l.replace(DEVICE_PATH, "<path>"))
+    .map(redactDevicePaths)
     .map((l) => l.length > MAX_MESSAGE_CHARS ? `${l.slice(0, MAX_MESSAGE_CHARS - 1)}…` : l);
 }
 

--- a/src/lib/hermes-cli-message.ts
+++ b/src/lib/hermes-cli-message.ts
@@ -161,6 +161,33 @@ function withoutTracebackFrames(lines: string[]): string[] {
   return kept;
 }
 
+/**
+ * An absolute on-device path, wherever it sits in a line we are keeping.
+ *
+ * Dropping the traceback FRAMES does not get the paths out, because the line
+ * the strip deliberately KEEPS is the one that quotes them. Every common
+ * CPython summary is that shape:
+ *
+ *   FileNotFoundError: [Errno 2] No such file or directory: '/home/clawbox/.hermes/config.yaml'
+ *   PermissionError: [Errno 13] Permission denied: '/home/clawbox/.hermes/auth-profiles.json'
+ *
+ * It sits at column 0, it genuinely names the failure, and there is no
+ * traceback at all in the plain `Error: cannot write /home/… ` case. So the
+ * layout travelled with the cause, past every rule above.
+ *
+ * Redacting beats dropping here: `FileNotFoundError` and `Permission denied`
+ * are what the person can act on, and only the path has to go. The journal
+ * still receives the raw stream.
+ *
+ * Scoped to ABSOLUTE paths under the system roots, and NOT to a leading `~`.
+ * `~/.hermes/.env` names no user, no home directory and no install layout — it
+ * is the file Hermes itself tells the customer to edit, and keeping that half
+ * of the sentence is part of what #515 fixed. A rule wide enough to catch the
+ * tilde would replace the one actionable fact in that message with `<path>`.
+ * Anchored on a preceding boundary so "2/3 of the files" is not a path.
+ */
+const DEVICE_PATH = /(?<![\w~])\/(?:home|root|usr|opt|var|etc|tmp|srv|mnt|snap)(?:\/[\w.@+-]+)+/g;
+
 /** Bookkeeping and stack noise, dropped before we look for a cause. */
 function usefulLines(stream: string): string[] {
   // Strip frames BEFORE trimming: the indentation is the only thing that tells
@@ -174,8 +201,12 @@ function usefulLines(stream: string): string[] {
   const paragraphs = unwrap(lines);
   const named = paragraphs.filter((l) =>
     /\b(?:HTTP\s+\d{3}|error|failed|not found|denied|invalid|unauthor)/i.test(l));
-  return (named.length ? named : paragraphs).map((l) =>
-    l.length > MAX_MESSAGE_CHARS ? `${l.slice(0, MAX_MESSAGE_CHARS - 1)}…` : l);
+  // Redact AFTER the filter, so a line is still classified on what it actually
+  // said, and BEFORE the cap, so the truncation counts the text a person will
+  // see rather than a path they never will.
+  return (named.length ? named : paragraphs)
+    .map((l) => l.replace(DEVICE_PATH, "<path>"))
+    .map((l) => l.length > MAX_MESSAGE_CHARS ? `${l.slice(0, MAX_MESSAGE_CHARS - 1)}…` : l);
 }
 
 /**

--- a/src/lib/hermes-cli-message.ts
+++ b/src/lib/hermes-cli-message.ts
@@ -1,0 +1,234 @@
+/**
+ * How a `hermes` CLI failure is turned into text a customer may read.
+ *
+ * These live here, not in the chat route, because the chat bubble is not the
+ * only place a person sees `hermes` stderr. The AI-provider panel in Settings
+ * renders it twice more — `hermes auth add` (provider-key) and
+ * `hermes config set` (models) — and both echoed the stream verbatim, so the
+ * traceback frames and on-device paths PR #515 stripped out of chat reached
+ * the screen anyway, one panel over. One parser, every surface.
+ *
+ * The grep that says the surfaces are all accounted for:
+ *   grep -rn "stderr" src/app/setup-api/hermes --include=route.ts
+ */
+
+/**
+ * Turn `chat -q`'s stderr into something worth showing a person.
+ *
+ * The first thing on stderr is always the `session_id:` banner, so a failed run
+ * used to surface as "Error: session_id: 20260810_221825_609d1e" — the one line
+ * on the stream that says nothing about what went wrong. The actual cause sat
+ * on the next line: "HTTP 404: Model 'claude-opus-5' not found. The requested
+ * model does not exist in our configuration or OpenRouter catalog."
+ *
+ * So: drop the banner and anything else that is pure bookkeeping, and lead with
+ * the first line that names a failure — a stack trace's later frames are worse
+ * than useless in a chat bubble.
+ */
+export function errorFromStderr(stderr: string): string {
+  return usefulLines(stderr)[0] ?? "";
+}
+
+/**
+ * Hermes hard-wraps its output at ~76 columns, so ONE sentence arrives as
+ * several lines. Rejoining them is the difference between
+ *
+ *   "No inference provider configured. Run 'hermes model' to choose a provider and"
+ *
+ * — which is what the customer used to get, ending on a dangling "and" — and the
+ * whole message, whose second half is the part they can act on: which API key to
+ * set, and that it goes in ~/.hermes/.env.
+ *
+ * A line continues the one above it when the one above looks WRAPPED: long
+ * enough to have hit the wrap column, and followed by something that does not
+ * start a new record of its own (a list item, a `key: value` line, an
+ * `HTTP 404:` / `SomeError:` header). Nothing here joins two independent
+ * failures — those start with one of those markers — and a short line is never
+ * treated as wrapped, so a terse two-line report stays two lines.
+ */
+const WRAP_COLUMN_HINT = 60;
+
+function startsNewRecord(line: string): boolean {
+  return /^(?:[-*•]|\d+[.)])\s/.test(line)
+    || /^HTTP\s+\d{3}\b/.test(line)
+    || /^[A-Za-z][\w.]*(?:Error|Exception|Warning)\b/.test(line)
+    || /^[A-Za-z][\w .\-]*:\s/.test(line);
+}
+
+function unwrap(lines: string[]): string[] {
+  const paragraphs: string[] = [];
+  for (const line of lines) {
+    const previous = paragraphs[paragraphs.length - 1];
+    if (previous !== undefined && previous.length >= WRAP_COLUMN_HINT && !startsNewRecord(line)) {
+      paragraphs[paragraphs.length - 1] = `${previous} ${line}`;
+    } else {
+      paragraphs.push(line);
+    }
+  }
+  return paragraphs;
+}
+
+/** The cap is per MESSAGE, not per line — a bubble is not a log viewer. */
+const MAX_MESSAGE_CHARS = 400;
+
+/**
+ * Lines `chat -q` prints as STATUS, not as causes.
+ *
+ * `--resume` announces itself on stderr before the turn says anything, and on
+ * EVERY resumed run — success or failure alike. Captured verbatim from the
+ * live box (exit 1, the real cause sitting on stdout as "HTTP 403 — Just a
+ * moment..."):
+ *
+ *   ↻ Resumed session 20260825_165225_be089e "What model are you and what is
+ *   this machine?" (2 user messages, 7 total messages)
+ *   Model restored from session: claude-fable-5 (anthropic)
+ *   session_id: 20260825_165225_be089e
+ *
+ * Because only the `session_id:` line was being stripped, `errorFromStderr`
+ * found the resume banner, decided stderr "said something", and the customer's
+ * bubble read "Error: ↻ Resumed session …" while the actual failure was never
+ * looked at. A banner is bookkeeping exactly like the session id under it.
+ *
+ * Matching on text is the only classifier available HERE: the CLI's streams
+ * carry no framing to gate on. The streamed transport does not have this
+ * problem to begin with — the dashboard socket reports the same resume as a
+ * typed `session.resume` RESULT frame (captured live: `{"resumed":
+ * "20260825_165225_be089e", …}`), never as an event the turn loop could
+ * mistake for output.
+ */
+function isBookkeepingLine(line: string): boolean {
+  return /^session_id:/i.test(line)
+    || /^(?:↻\s*)?Resumed session\b/.test(line)
+    || /^Model restored from session\b/.test(line)
+    // The connectors CPython prints between chained tracebacks. They sit at
+    // column 0, so they survive the frame strip below, and they name no cause.
+    || /^(?:During handling of the above exception|The above exception was the direct cause)\b/
+      .test(line);
+}
+
+/**
+ * Drop the FRAMES of a Python traceback, keeping only its summary line.
+ *
+ * CPython indents everything belonging to a frame — the `File "…"` header, the
+ * source line under it and (3.11+) the `^^^^` anchor beneath that — and returns
+ * the exception summary to column 0. Trimming every line before classifying it
+ * threw that signal away. Only the frame HEADER was being dropped, so the
+ * source line under it survived, matched the "names a failure" filter below on
+ * its `RuntimeError(` text, and — sitting earlier in the stream than the real
+ * summary — became the customer's error bubble. Captured shape:
+ *
+ *   Traceback (most recent call last):
+ *     File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider
+ *       raise RuntimeError("upstream refused the request")     <- what was shown
+ *   RuntimeError: upstream refused the request                 <- what to show
+ *
+ * So classify on the RAW line: once a traceback opens, drop everything indented
+ * under it and let the first column-0 line both end the block and stand as the
+ * cause. A frame header opens a block too, so a stream whose `Traceback:` line
+ * was already cut off still reads correctly. If the stream ENDS inside the
+ * frames, nothing is invented — the caller falls back to the exit code rather
+ * than quoting Python source at a customer. The block is scoped: once it ends,
+ * an indented line is ordinary output again.
+ *
+ * A frame header is matched by its FULL shape — `File "…", line <n>` — not by
+ * its first six characters. `File "config.yaml" was denied` is a sentence a
+ * customer needs to read, and the loose form both swallowed it and reopened a
+ * block that had already closed, taking the indented lines after it with it.
+ */
+const TRACEBACK_OPENER = /^[ \t]*(?:Traceback\b|File "[^"]+", line \d+\b)/;
+
+function withoutTracebackFrames(lines: string[]): string[] {
+  const kept: string[] = [];
+  let inTraceback = false;
+  for (const line of lines) {
+    if (TRACEBACK_OPENER.test(line)) {
+      inTraceback = true;
+      continue;
+    }
+    if (inTraceback) {
+      if (!line || /^[ \t]/.test(line)) continue;
+      inTraceback = false;
+    }
+    kept.push(line);
+  }
+  return kept;
+}
+
+/** Bookkeeping and stack noise, dropped before we look for a cause. */
+function usefulLines(stream: string): string[] {
+  // Strip frames BEFORE trimming: the indentation is the only thing that tells
+  // a frame's source line apart from a line the customer needs to read.
+  const lines = withoutTracebackFrames(stream.split(/\r?\n/))
+    .map((l) => l.trim())
+    .filter((l) => l && !isBookkeepingLine(l));
+  // Unwrap FIRST: the filter below keeps lines that themselves name a failure,
+  // and the continuation lines of a wrapped message read as prose. That is how
+  // the remedy half of every multi-line Hermes error was being dropped.
+  const paragraphs = unwrap(lines);
+  const named = paragraphs.filter((l) =>
+    /\b(?:HTTP\s+\d{3}|error|failed|not found|denied|invalid|unauthor)/i.test(l));
+  return (named.length ? named : paragraphs).map((l) =>
+    l.length > MAX_MESSAGE_CHARS ? `${l.slice(0, MAX_MESSAGE_CHARS - 1)}…` : l);
+}
+
+/**
+ * The message for a failed turn, from whichever stream actually carries it.
+ *
+ * Reading stderr alone was not enough. On a provider-side failure Hermes puts
+ * the explanation on STDOUT — "API call failed after 3 retries: HTTP 404:
+ * model: claude-opus-4-20250514" — and leaves stderr holding only the
+ * `session_id:` banner. Stripping that banner (correctly) then left nothing,
+ * so the customer got "hermes exited with code 1": true, and useless.
+ *
+ * stderr is still preferred when it says something, since a crash reports
+ * there; stdout is the fallback that covers the provider-error case.
+ */
+export function hermesFailureMessage(stdout: string, stderr: string): string {
+  return errorFromStderr(stderr) || (usefulLines(stdout)[0] ?? "");
+}
+
+/**
+ * What to say when the child could not be STARTED at all.
+ *
+ * Node formats every spawn failure identically, and the format contains the
+ * install path:
+ *
+ *   spawn /home/clawbox/.local/bin/hermes ENOENT
+ *   spawn /home/clawbox/.local/bin/hermes EACCES
+ *   spawn /home/clawbox/.local/bin/hermes EAGAIN
+ *
+ * Both spawn sites recognised ENOENT and rewrote it PRECISELY so that path
+ * would not reach a customer — then fell through to the raw error object for
+ * every other errno, which reaches the same screens through the same field.
+ * None of the cleaning above applies to these: a spawn failure never touches
+ * stdout or stderr, so it never passes through `usefulLines`.
+ *
+ * The errnos are grouped by what the person can DO about them, which is the
+ * only distinction worth putting in a bubble:
+ *
+ *   ENOENT          Hermes is not installed (or was removed mid-update).
+ *   EACCES / EPERM  The binary is there and not executable — a partial update
+ *                   that lost the mode bit, or a foreign owner.
+ *   EAGAIN / ENOMEM fork(2) refused. On a loaded aarch64 box under memory
+ *                   pressure this is the realistic one, and it is transient,
+ *                   so the message says to retry.
+ *
+ * Anything else gets the neutral line rather than the errno text: an errno we
+ * have not thought about is exactly the case where the raw string is most
+ * likely to carry something we did not intend to publish.
+ */
+export function spawnFailureMessage(e: unknown): string {
+  const code = (e as NodeJS.ErrnoException | null)?.code;
+  switch (code) {
+    case "ENOENT":
+      return "Hermes is not installed on this device";
+    case "EACCES":
+    case "EPERM":
+      return "Hermes could not be started on this device (permission denied)";
+    case "EAGAIN":
+    case "ENOMEM":
+      return "The device was out of resources to start Hermes — try again in a moment";
+    default:
+      return "Hermes could not be started on this device";
+  }
+}

--- a/src/lib/hermes-cli-message.ts
+++ b/src/lib/hermes-cli-message.ts
@@ -13,7 +13,13 @@
  */
 
 /**
- * Turn `chat -q`'s stderr into something worth showing a person.
+ * Turn a `hermes` subcommand's stderr into something worth showing a person.
+ *
+ * The evidence below was captured from `chat -q`, the subcommand that shaped
+ * these rules. Nothing here is specific to it: each rule either fires on a
+ * shape the other subcommands also produce (a traceback, a wrapped sentence) or
+ * matches nothing in their output at all (the session banner), so applying it
+ * to `auth add` and `config set` changes only the cases it was written for.
  *
  * The first thing on stderr is always the `session_id:` banner, so a failed run
  * used to surface as "Error: session_id: 20260810_221825_609d1e" — the one line

--- a/src/lib/hermes-cli.ts
+++ b/src/lib/hermes-cli.ts
@@ -1,6 +1,7 @@
 import { spawn } from "child_process";
 import path from "path";
 import { HERMES_BIN } from "@/lib/harness";
+import { spawnFailureMessage } from "@/lib/hermes-cli-message";
 
 // Shared helper to run a `hermes` CLI subcommand from a setup-api route.
 //
@@ -123,11 +124,13 @@ export function runHermesCli(
 
     child.on("error", (e) => {
       finish(() => {
-        if ((e as NodeJS.ErrnoException).code === "ENOENT") {
-          reject(new Error("Hermes is not installed on this device"));
-          return;
-        }
-        reject(e);
+        // Same rule as the chat route's own spawn: ENOENT was rewritten to keep
+        // the binary path off a customer's screen, and every other errno went
+        // out raw. That matters MORE here — eleven setup-api routes reject-path
+        // this straight into their JSON `error` — so the sanitising belongs at
+        // the spawn, not at each caller.
+        console.error("[hermes cli] spawn failed", e);
+        reject(new Error(spawnFailureMessage(e)));
       });
     });
     child.on("close", (code) => {

--- a/src/tests/routes/hermes/chat-spawn-errno.test.ts
+++ b/src/tests/routes/hermes/chat-spawn-errno.test.ts
@@ -1,0 +1,121 @@
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * A child that cannot be STARTED is not a turn that failed — and its errno
+ * message is not fit for a chat bubble.
+ *
+ * Node formats every spawn failure the same way, with the full binary path in
+ * the text:
+ *
+ *   spawn /home/clawbox/.local/bin/hermes ENOENT
+ *   spawn /home/clawbox/.local/bin/hermes EACCES
+ *   spawn /home/clawbox/.local/bin/hermes EAGAIN
+ *
+ * The route special-cased ENOENT into "Hermes is not installed on this device"
+ * PRECISELY so that path would not reach the client, then fell through to the
+ * raw error for every other errno. EACCES (a lost execute bit after a partial
+ * update) and EAGAIN (fork refused under memory pressure — a realistic state on
+ * a loaded Jetson) therefore leaked the install layout into the bubble, into
+ * the durable transcript, and into the 502 body. None of #515's cleaning
+ * applies to these: they never pass through `usefulLines`.
+ */
+vi.mock("child_process", () => ({ spawn: vi.fn(), execFile: vi.fn() }));
+vi.mock("@/lib/harness", () => ({ HERMES_BIN: "/home/clawbox/.local/bin/hermes" }));
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
+  return { ...actual, getModelOptions: vi.fn() };
+});
+vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/tmp/clawbox-chat-spawn-errno-test",
+  get: vi.fn(),
+}));
+vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: vi.fn(async () => {}) }));
+
+import { spawn } from "child_process";
+import { getModelOptions } from "@/lib/hermes-model-options";
+import { appendTranscript } from "@/lib/harness/transcript-store";
+
+const mockSpawn = vi.mocked(spawn);
+const mockGetModelOptions = vi.mocked(getModelOptions);
+const mockAppendTranscript = vi.mocked(appendTranscript);
+
+/** A child that never starts: the `error` event fires and nothing else does. */
+function unstartableHermes(code: string) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  setImmediate(() => {
+    const e = new Error(`spawn /home/clawbox/.local/bin/hermes ${code}`) as NodeJS.ErrnoException;
+    e.code = code;
+    e.syscall = "spawn /home/clawbox/.local/bin/hermes";
+    child.emit("error", e);
+  });
+  return child;
+}
+
+function payload(provider: string, model: string) {
+  return {
+    providers: [{ id: provider, name: provider, authenticated: true, models: [{ id: model }], total: 1, source: "live", isUserDefined: false }],
+    current: { provider, model },
+    reasoning: "medium",
+    fetchedAt: Date.now(),
+    source: "live",
+    stale: false,
+  };
+}
+
+async function turn(): Promise<{ status: number; error: string }> {
+  const { POST } = await import("@/app/setup-api/hermes/chat/route");
+  const res = await POST(new Request("http://localhost/setup-api/hermes/chat", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ message: "hi", provider: "anthropic", model: "anthropic/claude-opus-5" }),
+  }));
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status, error: String((body as { error?: unknown }).error ?? "") };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  mockGetModelOptions.mockResolvedValue(payload("anthropic", "anthropic/claude-opus-5") as never);
+});
+
+describe("/setup-api/hermes/chat — a child that cannot be started", () => {
+  it.each([
+    ["ENOENT", /not installed/i],
+    ["EACCES", /permission/i],
+    ["EPERM", /permission/i],
+    ["EAGAIN", /resources/i],
+    ["ENOMEM", /resources/i],
+    ["EMFILE", /could not be started/i],
+    ["ELIBBAD", /could not be started/i],
+  ])("reports %s without the binary path", async (code, expected) => {
+    mockSpawn.mockImplementation(() => unstartableHermes(code) as never);
+
+    const { status, error } = await turn();
+
+    expect(status).toBe(502);
+    expect(error).not.toContain("/home/");
+    expect(error).not.toContain("spawn ");
+    expect(error).toMatch(expected);
+  });
+
+  it("writes the same clean text into the durable transcript", async () => {
+    mockSpawn.mockImplementation(() => unstartableHermes("EACCES") as never);
+
+    await turn();
+
+    const written = mockAppendTranscript.mock.calls
+      .map((c) => String((c[0] as { text?: unknown })?.text ?? ""))
+      .join("\n");
+    expect(written).toMatch(/Error:/);
+    expect(written).not.toContain("/home/");
+  });
+});

--- a/src/tests/routes/hermes/hermes-cli-error-surfaces.test.ts
+++ b/src/tests/routes/hermes/hermes-cli-error-surfaces.test.ts
@@ -141,6 +141,23 @@ describe("POST /setup-api/hermes/models — a crashing `hermes config set`", () 
 
     expect(error).toBe("Failed to set model.default");
   });
+
+  it("drops a one-line cause that IS a path, rather than quoting it", async () => {
+    // Stripping the frames is not enough on its own. A CLI failure needs no
+    // traceback to name the install layout — this is the ordinary EACCES shape
+    // — and the surviving line passes every "names a failure" test there is.
+    // Which is why the repo's own shape whitelist has the last word.
+    runHermesCliMock.mockResolvedValue({
+      code: 1,
+      stdout: "",
+      stderr: "Error: cannot write /home/clawbox/.hermes/config.yaml: permission denied",
+    });
+
+    const { error } = await save();
+
+    expect(error).not.toContain("/home/");
+    expect(error).toBe("Failed to set model.default");
+  });
 });
 
 describe("POST /setup-api/hermes/provider-key — a crashing `hermes auth add`", () => {
@@ -180,6 +197,15 @@ describe("POST /setup-api/hermes/provider-key — a crashing `hermes auth add`",
   it("falls back to fixed text when stderr carries nothing usable", async () => {
     const { error } = await saveKey("");
 
+    expect(error).toBe("Failed to save API key");
+  });
+
+  it("drops a one-line cause that IS a path, rather than quoting it", async () => {
+    const { error } = await saveKey(
+      "Error: cannot write /home/clawbox/.hermes/auth-profiles.json: permission denied",
+    );
+
+    expect(error).not.toContain("/home/");
     expect(error).toBe("Failed to save API key");
   });
 });

--- a/src/tests/routes/hermes/hermes-cli-error-surfaces.test.ts
+++ b/src/tests/routes/hermes/hermes-cli-error-surfaces.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+
+/**
+ * A `hermes` CLI crash must never render as CPython source in a customer panel.
+ *
+ * PR #515 removed the traceback frames from the CHAT bubble, but the chat route
+ * is not the only surface that renders `hermes` stderr at a person. The AI
+ * provider panel in Settings has two more, one call apart:
+ *
+ *   POST /setup-api/hermes/provider-key  → `hermes auth add`
+ *   POST /setup-api/hermes/models        → `hermes config set`
+ *
+ * Both echoed `r.stderr` verbatim into their JSON `error`, and
+ * HermesProviderConfig drops that string straight into the save banner. So the
+ * exact input #515 exists to clean — a traceback naming `/home/clawbox/.hermes`
+ * — reached the screen through the sibling routes untouched.
+ *
+ * Captured shape (the crash is real; the paths are the on-device ones):
+ *
+ *   Traceback (most recent call last):
+ *     File "/home/clawbox/.hermes/config.py", line 118, in set_key
+ *       raise RuntimeError("config store is locked by another writer")
+ *   RuntimeError: config store is locked by another writer
+ *
+ * The summary line is what a person can act on. Everything above it is noise
+ * that also leaks the install layout.
+ */
+
+const TRACEBACK = [
+  "session_id: 20260827_101500_ab12cd",
+  "Traceback (most recent call last):",
+  '  File "/home/clawbox/.hermes/config.py", line 118, in set_key',
+  '    raise RuntimeError("config store is locked by another writer")',
+  '  File "/home/clawbox/.local/lib/python3.11/site-packages/hermes/cli.py", line 42, in main',
+  "    return _dispatch(argv)",
+  "RuntimeError: config store is locked by another writer",
+].join("\n");
+
+/** Nothing on any of these surfaces may carry Python internals or a device path. */
+function expectNoPythonInternals(message: string) {
+  expect(message).not.toMatch(/Traceback/);
+  expect(message).not.toMatch(/File "/);
+  expect(message).not.toMatch(/\.hermes\//);
+  expect(message).not.toMatch(/\/home\//);
+  expect(message).not.toMatch(/raise RuntimeError/);
+  expect(message).not.toMatch(/site-packages/);
+}
+
+const runHermesCliMock = vi.fn();
+const getModelOptionsMock = vi.fn();
+
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: runHermesCliMock }));
+
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
+  return { ...actual, getModelOptions: getModelOptionsMock, invalidateModelOptions: vi.fn() };
+});
+
+vi.mock("@/lib/hermes-local-ai", () => ({
+  reconcileLocalAiWithHermes: vi.fn(async () => {}),
+}));
+
+const PAYLOAD = {
+  providers: [{
+    id: "anthropic",
+    name: "Anthropic",
+    authenticated: true,
+    verified: null,
+    isUserDefined: false,
+    source: "dashboard",
+    total: 2,
+    models: [
+      { id: "anthropic/claude-opus-5", description: "" },
+      { id: "anthropic/claude-fable-5", description: "" },
+    ],
+  }],
+  current: { provider: "anthropic", model: "anthropic/claude-opus-5" },
+  reasoning: "medium",
+  fetchedAt: Date.now(),
+  source: "dashboard" as const,
+  stale: false,
+};
+
+let errorLog: MockInstance<typeof console.error>;
+
+beforeEach(() => {
+  runHermesCliMock.mockReset();
+  getModelOptionsMock.mockReset();
+  getModelOptionsMock.mockResolvedValue(structuredClone(PAYLOAD));
+  errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.resetModules();
+});
+
+afterEach(() => {
+  errorLog.mockRestore();
+});
+
+describe("POST /setup-api/hermes/models — a crashing `hermes config set`", () => {
+  async function save(): Promise<{ status: number; error: string }> {
+    const { POST } = await import("@/app/setup-api/hermes/models/route");
+    const res = await POST(new Request("http://localhost/setup-api/hermes/models", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "anthropic", model: "anthropic/claude-fable-5" }),
+    }));
+    const body = await res.json();
+    return { status: res.status, error: String(body.error ?? "") };
+  }
+
+  it("does not put the traceback in the save banner", async () => {
+    runHermesCliMock.mockResolvedValue({ code: 1, stdout: "", stderr: TRACEBACK });
+
+    const { status, error } = await save();
+
+    expect(status).toBe(502);
+    expectNoPythonInternals(error);
+  });
+
+  it("still names the cause the exception summary gives", async () => {
+    runHermesCliMock.mockResolvedValue({ code: 1, stdout: "", stderr: TRACEBACK });
+
+    const { error } = await save();
+
+    expect(error).toBe("RuntimeError: config store is locked by another writer");
+  });
+
+  it("keeps the raw stderr for the journal, where a path is a diagnosis", async () => {
+    runHermesCliMock.mockResolvedValue({ code: 1, stdout: "", stderr: TRACEBACK });
+
+    await save();
+
+    expect(errorLog).toHaveBeenCalled();
+    const logged = errorLog.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(logged).toMatch(/config\.py/);
+  });
+
+  it("falls back to fixed text when stderr carries nothing usable", async () => {
+    runHermesCliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "session_id: 20260827_101500_ab12cd" });
+
+    const { error } = await save();
+
+    expect(error).toBe("Failed to set model.default");
+  });
+});
+
+describe("POST /setup-api/hermes/provider-key — a crashing `hermes auth add`", () => {
+  const API_KEY = "sk-or-v1-0123456789abcdef";
+
+  async function saveKey(stderr: string): Promise<{ status: number; error: string }> {
+    runHermesCliMock.mockResolvedValue({ code: 1, stdout: "", stderr });
+    const { POST } = await import("@/app/setup-api/hermes/provider-key/route");
+    const res = await POST(new Request("http://localhost/setup-api/hermes/provider-key", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ provider: "openrouter", apiKey: API_KEY }),
+    }));
+    const body = await res.json();
+    return { status: res.status, error: String(body.error ?? "") };
+  }
+
+  it("does not put the traceback in the save banner", async () => {
+    const { status, error } = await saveKey(TRACEBACK);
+
+    expect(status).toBe(502);
+    expectNoPythonInternals(error);
+    expect(error).toBe("RuntimeError: config store is locked by another writer");
+  });
+
+  it("never echoes the pasted key back, even when the CLI does", async () => {
+    // argparse prints the offending argv on a usage error, and that argv holds
+    // the secret. The route's own comment already promised this; nothing
+    // enforced it.
+    const { error } = await saveKey(
+      `hermes auth add: error: unrecognized arguments: --api-key ${API_KEY}`,
+    );
+
+    expect(error).not.toContain(API_KEY);
+  });
+
+  it("falls back to fixed text when stderr carries nothing usable", async () => {
+    const { error } = await saveKey("");
+
+    expect(error).toBe("Failed to save API key");
+  });
+});

--- a/src/tests/routes/hermes/hermes-cli-error-surfaces.test.ts
+++ b/src/tests/routes/hermes/hermes-cli-error-surfaces.test.ts
@@ -142,11 +142,12 @@ describe("POST /setup-api/hermes/models — a crashing `hermes config set`", () 
     expect(error).toBe("Failed to set model.default");
   });
 
-  it("drops a one-line cause that IS a path, rather than quoting it", async () => {
+  it("keeps a one-line cause that IS a path, minus the path", async () => {
     // Stripping the frames is not enough on its own. A CLI failure needs no
     // traceback to name the install layout — this is the ordinary EACCES shape
     // — and the surviving line passes every "names a failure" test there is.
-    // Which is why the repo's own shape whitelist has the last word.
+    // Redacting beats dropping: "permission denied" is the half a person can
+    // act on, and only the layout has to go.
     runHermesCliMock.mockResolvedValue({
       code: 1,
       stdout: "",
@@ -156,7 +157,8 @@ describe("POST /setup-api/hermes/models — a crashing `hermes config set`", () 
     const { error } = await save();
 
     expect(error).not.toContain("/home/");
-    expect(error).toBe("Failed to set model.default");
+    expect(error).not.toContain(".hermes");
+    expect(error).toContain("permission denied");
   });
 });
 
@@ -200,12 +202,13 @@ describe("POST /setup-api/hermes/provider-key — a crashing `hermes auth add`",
     expect(error).toBe("Failed to save API key");
   });
 
-  it("drops a one-line cause that IS a path, rather than quoting it", async () => {
+  it("keeps a one-line cause that IS a path, minus the path", async () => {
     const { error } = await saveKey(
       "Error: cannot write /home/clawbox/.hermes/auth-profiles.json: permission denied",
     );
 
     expect(error).not.toContain("/home/");
-    expect(error).toBe("Failed to save API key");
+    expect(error).not.toContain("auth-profiles");
+    expect(error).toContain("permission denied");
   });
 });

--- a/src/tests/unit/hermes-cli-message-paths.test.ts
+++ b/src/tests/unit/hermes-cli-message-paths.test.ts
@@ -88,6 +88,29 @@ describe("an on-device path in the line the parser keeps", () => {
   });
 
   /**
+   * Mismatched delimiters are the degradation the quoted rule is allowed to
+   * have, so it is pinned rather than left to chance.
+   *
+   * The character class excludes all three quote characters, so the closing
+   * backreference never matches and the quoted rule fails outright. The
+   * unquoted rule then redacts what it can — which is the whole path here,
+   * since this one holds no space — and the rest of the sentence is untouched.
+   * The failure mode that matters is the opposite one: a quoted rule that kept
+   * consuming would swallow the remedy along with the path.
+   */
+  it("falls back to the unquoted rule when the quotes do not match", () => {
+    const msg = hermesFailureMessage(
+      "",
+      `PermissionError: Permission denied: '/var/lib/hermes/state.db" — retry in 30s`,
+    );
+
+    expect(msg).not.toContain("/var/");
+    expect(msg).not.toContain("state.db");
+    expect(msg).toContain("retry in 30s");
+    expect(msg).toContain("Permission denied");
+  });
+
+  /**
    * The line that must NOT be redacted, and the reason the rule is scoped to
    * ABSOLUTE paths.
    *

--- a/src/tests/unit/hermes-cli-message-paths.test.ts
+++ b/src/tests/unit/hermes-cli-message-paths.test.ts
@@ -58,6 +58,36 @@ describe("an on-device path in the line the parser keeps", () => {
   });
 
   /**
+   * A path component may contain a space, and CPython quotes the path it
+   * failed on. Redacting only up to the space left the tail on screen:
+   *
+   *   "… No such file or directory: '<path> Files/credentials.json'"
+   *
+   * — which still names a directory and a filename. Inside quotes the closing
+   * quote is the real end of the path, so that is what bounds the match.
+   */
+  it("consumes a quoted path with a space in it, leaving no tail", () => {
+    const msg = hermesFailureMessage(
+      "",
+      "FileNotFoundError: [Errno 2] No such file or directory: '/home/alice/Private Files/credentials.json'",
+    );
+
+    expect(msg).not.toContain("/home/");
+    expect(msg).not.toContain("Files/");
+    expect(msg).not.toContain("credentials.json");
+    expect(msg).not.toContain("Private");
+    expect(msg).toContain("No such file or directory");
+  });
+
+  it.each(['"', "'", "`"])("consumes a path quoted with %s", (q) => {
+    const msg = hermesFailureMessage("", `PermissionError: Permission denied: ${q}/var/lib/hermes/My State/state.db${q}`);
+
+    expect(msg).not.toContain("/var/");
+    expect(msg).not.toContain("state.db");
+    expect(msg).toContain("Permission denied");
+  });
+
+  /**
    * The line that must NOT be redacted, and the reason the rule is scoped to
    * ABSOLUTE paths.
    *

--- a/src/tests/unit/hermes-cli-message-paths.test.ts
+++ b/src/tests/unit/hermes-cli-message-paths.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { hermesFailureMessage } from "@/lib/hermes-cli-message";
+
+/**
+ * Dropping the traceback FRAMES does not get the paths out.
+ *
+ * A CPython exception summary sits at column 0 — which is exactly why the frame
+ * strip keeps it, and why it becomes the message — and the most common summaries
+ * quote the path that failed:
+ *
+ *   FileNotFoundError: [Errno 2] No such file or directory: '/home/clawbox/.hermes/config.yaml'
+ *   PermissionError: [Errno 13] Permission denied: '/home/clawbox/.hermes/auth-profiles.json'
+ *
+ * There is no traceback to strip in the plain-stderr case either. So the line
+ * reaches the chat bubble, the 502 body and the durable transcript with the
+ * install layout in it, having passed every rule the parser has.
+ *
+ * The fix redacts the path and keeps the sentence: `FileNotFoundError` and
+ * `Permission denied` are what the customer needs; `/home/clawbox/.hermes` is
+ * for the journal, which still gets the raw stream.
+ */
+describe("an on-device path in the line the parser keeps", () => {
+  it("redacts an absolute path out of a CPython summary, keeping the cause", () => {
+    const stderr = [
+      "session_id: 20260827_101500_ab12cd",
+      "Traceback (most recent call last):",
+      '  File "/home/clawbox/.hermes/config.py", line 118, in set_key',
+      "    return _write(path)",
+      "FileNotFoundError: [Errno 2] No such file or directory: '/home/clawbox/.hermes/config.yaml'",
+    ].join("\n");
+
+    const msg = hermesFailureMessage("", stderr);
+
+    expect(msg).not.toContain("/home/");
+    expect(msg).toContain("FileNotFoundError");
+    expect(msg).toContain("No such file or directory");
+  });
+
+  it("redacts a path on a line that never had a traceback around it", () => {
+    const msg = hermesFailureMessage("", "Error: cannot write /home/clawbox/.hermes/config.yaml: permission denied");
+
+    expect(msg).not.toContain("/home/");
+    expect(msg).toContain("permission denied");
+  });
+
+  it.each([
+    "/root/.hermes/config.yaml",
+    "/var/lib/hermes/state.db",
+    "/etc/clawbox/edition.env",
+    "/usr/local/lib/python3.11/hermes/cli.py",
+    "/tmp/hermes-abc123/lock",
+    "/opt/hermes/bin/hermes",
+  ])("redacts %s", (path) => {
+    const msg = hermesFailureMessage("", `PermissionError: [Errno 13] Permission denied: '${path}'`);
+
+    expect(msg).not.toContain(path);
+    expect(msg).toContain("Permission denied");
+  });
+
+  /**
+   * The line that must NOT be redacted, and the reason the rule is scoped to
+   * ABSOLUTE paths.
+   *
+   * `~/.hermes/.env` is not a leak. It names no user, no home directory and no
+   * install layout — it is the file Hermes itself tells the customer to edit,
+   * and #515 exists in part to stop that half of the sentence being thrown
+   * away (`src/tests/unit/hermes-chat-failure-message.test.ts`, "keeps the
+   * remedy half of 'No inference provider configured'"). A redaction wide
+   * enough to catch a leading `~` would replace the one actionable fact in the
+   * message with `<path>`.
+   */
+  it("leaves the tilde-relative config file Hermes tells the customer to edit", () => {
+    const stdout = [
+      "No inference provider configured. Run 'hermes model' to choose a provider and",
+      "model, or set an API key (OPENROUTER_API_KEY, OPENAI_API_KEY, etc.) in",
+      "~/.hermes/.env.",
+    ].join("\r\n");
+
+    const msg = hermesFailureMessage(stdout, "");
+
+    expect(msg).toContain("~/.hermes/.env");
+    expect(msg).not.toContain("<path>");
+  });
+
+  it("leaves an ordinary sentence with a slash in it alone", () => {
+    const msg = hermesFailureMessage("", "Error: 2/3 of the requested models are unavailable");
+
+    expect(msg).toBe("Error: 2/3 of the requested models are unavailable");
+  });
+});

--- a/src/tests/unit/hermes-cli-spawn-errno.test.ts
+++ b/src/tests/unit/hermes-cli-spawn-errno.test.ts
@@ -1,0 +1,69 @@
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The SAME ENOENT-only guard, in the shared CLI helper.
+ *
+ * `src/lib/hermes-cli.ts` sanitises ENOENT and rejects with the raw error for
+ * every other errno — the identical shape the chat route carried. It matters
+ * more here, not less: eleven routes call `runHermesCli` and return
+ * `err instanceof Error ? err.message : …` to the browser, so one unsanitised
+ * spawn failure leaks the install path through all of them at once. The grep
+ * that finds them:
+ *
+ *   grep -rn "err instanceof Error ? err.message" src/app/setup-api/hermes
+ *
+ * Fixing the guard at the spawn — rather than at each of those eleven — is what
+ * makes the class closed instead of the instance.
+ */
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+vi.mock("@/lib/harness", () => ({ HERMES_BIN: "/home/clawbox/.local/bin/hermes" }));
+
+import { spawn } from "child_process";
+import { runHermesCli } from "@/lib/hermes-cli";
+
+const mockSpawn = vi.mocked(spawn);
+
+function unstartable(code: string) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  setImmediate(() => {
+    const e = new Error(`spawn /home/clawbox/.local/bin/hermes ${code}`) as NodeJS.ErrnoException;
+    e.code = code;
+    child.emit("error", e);
+  });
+  return child;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("runHermesCli — a child that cannot be started", () => {
+  it.each([
+    ["ENOENT", /not installed/i],
+    ["EACCES", /permission/i],
+    ["EPERM", /permission/i],
+    ["EAGAIN", /resources/i],
+    ["ENOMEM", /resources/i],
+    ["EMFILE", /could not be started/i],
+  ])("rejects %s without naming the binary", async (code, expected) => {
+    mockSpawn.mockImplementation(() => unstartable(code) as never);
+
+    const err = await runHermesCli(["config", "get", "model.default"]).then(
+      () => new Error("expected a rejection"),
+      (e: Error) => e,
+    );
+
+    expect(err.message).not.toContain("/home/");
+    expect(err.message).not.toContain("spawn ");
+    expect(err.message).toMatch(expected);
+  });
+});


### PR DESCRIPTION
Follow-up to #515. Three residuals from the adversarial verification of that PR, all of the same shape it was hunting: **the fix landed in one of two identical paths.**

Every one reproduced against the merged head (`cd90857a`) before anything was changed.

## CHAT-01a — the model/provider save route (high, customer-facing)

`src/app/setup-api/hermes/models/route.ts:228`

```ts
if (r.code !== 0) throw new ConfigSetError(r.stderr || `Failed to set ${key}`);
```

The catch two dozen lines below returns `err.message` for any `ConfigSetError`, and `HermesProviderConfig.tsx:873` (`saveErrorMessage`) falls through to `data.error` verbatim into the Settings save banner. So a `hermes config set` that crashes rendered:

```
Traceback (most recent call last):
  File "/home/clawbox/.hermes/config.py", line 118, in set_key
    raise RuntimeError("config store is locked by another writer")
RuntimeError: config store is locked by another writer
```

— the whole thing, in the panel. No frame strip, no unwrap, no 400-char cap. That is exactly the input #515 exists to remove, arriving one panel over. The comment two lines above it already stated the rule the line broke ("Only text WE produced is safe to echo back").

Now: the shared parser, then the repo's leak whitelist, falling back to `Failed to set ${key}`, with the raw stream logged to the journal.

## CHAT-01b — the provider API-key route (medium, customer-facing)

`src/app/setup-api/hermes/provider-key/route.ts:54` — the sibling one call earlier in the same Settings flow, and the first command a customer runs when adding a provider.

Two things had to be kept off that banner and only one was being thought about. The existing comment reasoned about the API key; it did not address the traceback. And the key was not actually safe either: the comment asserts hermes "may name the provider but not the secret", which is true of a clean refusal and false of an argparse usage error, because argparse prints the offending argv and the key **is** in the argv:

```
hermes auth add: error: unrecognized arguments: --api-key sk-or-v1-…
```

Both are now closed — the same parser, plus an explicit redaction of the pasted key on its way to the response *and* to the log (the key is validated to printable non-space ASCII, so a substring swap is exact).

## CHAT-01c — the spawn error path (medium, customer-facing)

`child.on("error")` special-cased `ENOENT` into "Hermes is not installed on this device" *precisely so the full spawn path would not reach the client*, then `reject(e)` for every other errno. Node formats them identically:

```
spawn /home/clawbox/.local/bin/hermes EACCES
spawn /home/clawbox/.local/bin/hermes EAGAIN
```

That message becomes `detail` at chat/route.ts:702 (streaming) and :1104 (non-streaming), is written into the durable transcript by `appendTranscript`, and is returned as the 502 body. None of #515's cleaning touches it — a spawn failure never reaches stdout or stderr, so it never passes through `usefulLines`. EAGAIN is the realistic one: fork(2) refused under memory pressure, an ordinary state on a loaded aarch64 box.

Errnos are now grouped by what the person can do about them (missing / not executable / out of resources), with a neutral line for anything unrecognised — an errno nobody has thought about is exactly the case where the raw string is most likely to carry something unintended.

## One more, found while writing this up

Stripping the frames answers *what did the CLI say went wrong*. It does not answer *may this be shown to a person*, and conflating the two would have left the panel leaking after everything above was fixed:

```
Error: cannot write /home/clawbox/.hermes/config.yaml: permission denied
```

No traceback, so nothing gets stripped. It genuinely is the cause and it genuinely names a failure, so every rule in the parser keeps it — and it lands in the save banner with the install layout in it. That is the ordinary EACCES shape, not an exotic one.

The repo already owns this decision: `sanitizeErrorMessage` in `src/lib/safe-error-text.ts` — "one place that decides whether a message produced by a failing layer may be shown to the person using the box", a whitelist by shape that drops paths, URLs, credentials, stack frames and internal handles. `safeHermesFailureMessage` composes the two, and both panel routes fall back to their own fixed sentence when it says no. The last two rows of the table are that case, red first like the rest.

## A fourth leak, found in review

CodeRabbit spotted that the frame strip does not get the paths out, because the line it deliberately **keeps** is the one that quotes them:

```
FileNotFoundError: [Errno 2] No such file or directory: '/home/clawbox/.hermes/config.yaml'
```

Column 0, so the strip keeps it. Names a failure, so the filter keeps it. And the plain `Error: cannot write /home/… : permission denied` shape has no traceback to strip at all. Correct finding, and it lands on the chat bubble / 502 body / durable transcript — the one surface with no other guard in front of it.

Fixed by redacting rather than dropping: the exception name and "permission denied" are the half a person can act on, and only the layout has to go.

```ts
const DEVICE_PATH = /(?<![\w~])\/(?:home|root|usr|opt|var|etc|tmp|srv|mnt|snap)(?:\/[\w.@+-]+)+/g;
```

Scoped to absolute system roots and **not** to a leading tilde, which is where the suggested pattern went one character too far. `~/.hermes/.env` names no user, no home directory and no install layout — it is the file Hermes tells the customer to edit, and restoring that half of the sentence is part of what #515 did (`hermes-chat-failure-message.test.ts`, "keeps the remedy half of 'No inference provider configured'"). A rule wide enough to catch the tilde trades a real leak for a real regression, so the test pinning it ships in the same commit.

It also improves the two panel routes: they were already covered by `sanitizeErrorMessage`, but by dropping the whole message. They now show `Error: cannot write <path>: permission denied` instead of the generic fallback.

A follow-up in the same review: a quoted path with a space left its tail behind, because the redaction stopped at the first character no path component may hold —

```
No such file or directory: '<path> Files/credentials.json'
```

Inside quotes the closing quote is the real end of the path, so the quoted form is now matched first and bounded by it. Not widened to "anything up to whitespace" in the unquoted case: with no delimiter, a greedy rule eats the remedy too (`Permission denied: /var/lib/hermes/state.db, retry in 30s`).

## Fixing the class, not the instance

Two distinct classes here, and the grep for each is in the code.

**1. A route echoing a raw `hermes` stream at a customer.**

```
$ grep -rn "stderr" src/app/setup-api/hermes --include=route.ts
chat/route.ts:144:    child.stderr.on("data", …)          # capture, not a render
models/route.ts:228                                        # FIXED
provider-key/route.ts:54                                   # FIXED
skills/install/route.ts:182   console.error(…, cli.stderr)  # journal only
skills/install/route.ts:198   parseInstallOutcome(…)        # parsed, not echoed
skills/uninstall/route.ts:60  console.error(…, r.stderr)    # journal only
skills/uninstall/route.ts:67  parseUninstallOutcome(…)      # parsed, not echoed
```

Two renderers existed, both are fixed. The skills routes were already doing the right thing — log the raw, publish the parsed — which is the pattern the two fixed routes now follow.

**2. A spawn-error handler that sanitises ENOENT and nothing else.**

```
$ grep -rn 'code === "ENOENT"' src --include=*.ts | grep -v tests
```

Nineteen hits. Sixteen are filesystem reads deciding "absent" vs "broken" (`fs.readFile` fallbacks, deliberately fail-closed) — not spawn errors and not user-facing text. `vnc/clipboard/route.ts:44` already handles `ENOENT || EACCES || EPERM`, i.e. the shape being adopted here. That leaves exactly two spawn handlers with the defect, and both are in this diff:

- `src/app/setup-api/hermes/chat/route.ts:171` (the one named in the residual), and
- `src/lib/hermes-cli.ts:125` — **the sibling of the sibling**, and the one that matters more:

```
$ grep -rn "err instanceof Error ? err.message" src/app/setup-api/hermes --include=*.ts
```

Eleven setup-api routes return a `runHermesCli` rejection straight into their JSON `error`. Sanitising at each of them would be eleven chances to miss one; sanitising at the spawn closes all eleven at once. That is why the fix went into the helper and not into the callers.

## Tests: red first

Every case was proven to fail against unmodified `origin/beta` before any source change.

| file | tests | RED on beta | GREEN after |
|---|---|---|---|
| `src/tests/routes/hermes/hermes-cli-error-surfaces.test.ts` | 9 | 8 failed / 1 passed | 9 passed |
| `src/tests/routes/hermes/chat-spawn-errno.test.ts` | 8 | 7 failed / 1 passed | 8 passed |
| `src/tests/unit/hermes-cli-spawn-errno.test.ts` | 6 | 5 failed / 1 passed | 6 passed |
| `src/tests/unit/hermes-cli-message-paths.test.ts` | 15 | 12 failed / 3 passed | 15 passed |
| **total** | **38** | **32 failed / 6 passed** | **38 passed** |

The three that passed on beta are the ENOENT cases — already sanitised, and pinned here so the errno that *was* handled cannot regress while the others are being added.

`src/tests/unit/hermes-chat-failure-message.test.ts` (35 tests, #515's own) is unchanged and still green against the extracted module — the `__test` seam on the chat route keeps its shape by re-exporting.

## Baseline

- `tsc --noEmit`: 48 pre-existing errors, all in unrelated test files; **none in any file this PR touches or adds**.
- `eslint`: 99 errors / 83 warnings pre-existing; **zero from this diff**.
- Unit + route suites run locally; the only failures are the known Windows-host ones (file modes, `flock`, `nmcli`), none in the hermes surfaces. Linux CI is the gate.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hermes CLI error messages by removing internal paths, stack traces, and technical details.
  * Added clearer messages for common process-start failures.
  * Redacted API keys from authentication error responses and logs.
  * Preserved useful failure details while providing safe fallback messages when needed.
  * Standardized safe error handling across chat, model configuration, and authentication flows.

* **Tests**
  * Added coverage for sanitized chat, model configuration, authentication, and process-start errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


