### PR TITLE
fix: close the #518 residuals — the git twin, the calls that leave the box, and the card

### DIFF
--- a/src/app/setup-api/coding-agent/git/route.ts
+++ b/src/app/setup-api/coding-agent/git/route.ts
@@ -92,9 +92,15 @@ export async function POST(request: Request) {
       // 409 means "the request cannot be satisfied as it stands" — true of a
       // folder with no commits, false of a network that is merely down. That
       // one gets 503, so nothing tells the owner to install a gh they have.
+      //
+      // `transient` covers the same class one layer down: a local `git
+      // rev-parse` our own timer killed has no reason of its own to report, and
+      // answering 409 would tell the owner their request was wrong about a
+      // request that was fine.
+      const retryable = outcome.reason === "gh_unreachable" || outcome.transient === true;
       return NextResponse.json(
         { error: outcome.detail ?? outcome.reason, kind: outcome.reason },
-        { status: outcome.reason === "gh_unreachable" ? 503 : 409 },
+        { status: retryable ? 503 : 409 },
       );
     }
     console.error(`[coding-agent] backed up ${directory} to ${outcome.repo}${outcome.created ? " (new repo)" : ""}`);

--- a/src/components/CodingAgentApp.tsx
+++ b/src/components/CodingAgentApp.tsx
@@ -42,7 +42,10 @@ interface GitHubState {
   login: string | null;
   loginCommand: string;
   /** "unreachable" means gh is here but could not reach github.com — a
-   *  network fault. The card must not read like a missing install. */
+   *  network fault. "not_runnable" means it is here and would not execute, so
+   *  the remedy is permissions, not `gh auth login`. Neither reads like a
+   *  missing install, and neither reads like "not connected": every reason the
+   *  library can answer has an arm below, or the card says something false. */
   reason?: "not_installed" | "unreachable" | "not_runnable";
 }
 
@@ -567,19 +570,31 @@ export default function CodingAgentApp() {
                 <span className="text-[11px] text-amber-400" data-testid="coding-agent-github-unreachable">
                   {t("codingAgent.githubUnreachable")}
                 </span>
+              ) : github.reason === "not_runnable" ? (
+                // gh is on the box and would not start. "Not connected" is not
+                // what was found, and Connect — which opens a terminal on
+                // `gh auth login` — is the one remedy that cannot work here.
+                <span className="text-[11px] text-amber-400" data-testid="coding-agent-github-not-runnable">
+                  {t("codingAgent.githubNotRunnable")}
+                </span>
               ) : (
                 <span className="text-[11px] text-[var(--text-muted)]">{t("codingAgent.githubOff")}</span>
               )}
             </div>
             <div className="flex items-center gap-1.5 shrink-0">
-              <button
-                type="button"
-                onClick={connectGithub}
-                data-testid="coding-agent-github-connect"
-                className="text-[11px] px-2.5 py-1 rounded-lg border border-white/10 text-[var(--text-secondary)] hover:bg-white/5"
-              >
-                {github.connected ? t("codingAgent.githubReconnect") : t("codingAgent.githubConnect")}
-              </button>
+              {/* Not offered to a gh that would not start: the button opens a
+                  terminal on `gh auth login`, which needs the very binary that
+                  will not execute. The badge beside it says what to fix. */}
+              {github.reason !== "not_runnable" && (
+                <button
+                  type="button"
+                  onClick={connectGithub}
+                  data-testid="coding-agent-github-connect"
+                  className="text-[11px] px-2.5 py-1 rounded-lg border border-white/10 text-[var(--text-secondary)] hover:bg-white/5"
+                >
+                  {github.connected ? t("codingAgent.githubReconnect") : t("codingAgent.githubConnect")}
+                </button>
+              )}
               {github.connected && (
                 <button
                   type="button"

--- a/src/lib/child-run.ts
+++ b/src/lib/child-run.ts
@@ -122,9 +122,32 @@ export function inconclusive(r: ChildResult): boolean {
 /**
  * ENOENT is the only errno that means "there is no such file". Anything else —
  * EACCES above all — is a binary that EXISTS and would not run.
+ *
+ * A spawn error with NO errno is not evidence of absence either. It is the
+ * absence of evidence, and this module's whole subject is not confusing the
+ * two: the pre-#518 code guessed "missing" from a bare null exit code, and
+ * folding `startError === null` in here would have kept that same guess alive
+ * one layer down, with the same wrong remedy attached. So: ENOENT, or nothing.
  */
 export function startedMissing(r: ChildResult): boolean {
-  return r.startFailed && (r.startError === "ENOENT" || r.startError === null);
+  return r.startFailed && r.startError === "ENOENT";
+}
+
+/**
+ * What to say about a binary that would not start, claiming exactly as much as
+ * the errno supports and no more.
+ *
+ * Three cases, three different remedies, and the third one names both because
+ * an unrecognised errno tells us only that the command did not run. Naming a
+ * single remedy there would be a guess — and the guess this code used to make
+ * was "go and install it".
+ */
+export function startFailureDetail(r: ChildResult, name: string): string {
+  if (r.startError === "ENOENT") return `${name} is not installed on this ClawBox.`;
+  if (r.startError === "EACCES" || r.startError === "EPERM") {
+    return `${name} is on this ClawBox but would not start (${r.startError}). Check its permissions.`;
+  }
+  return `${name} would not start${r.startError ? ` (${r.startError})` : ""}. Check that it is installed and that it can be executed.`;
 }
 
 /**

--- a/src/lib/child-run.ts
+++ b/src/lib/child-run.ts
@@ -1,0 +1,156 @@
+/**
+ * One child-process wrapper for the coding agent's `git` and `gh` calls, and
+ * one set of rules for reading what it gives back.
+ *
+ * WHY THIS FILE EXISTS
+ *
+ * `code === null` is ambiguous, and the ambiguity is expensive. A child killed
+ * by SIGKILL closes with a null code; a child that never started resolves with
+ * a null code too. Reading the second meaning into the first told owners to
+ * install a `gh` that was already on the box (#518), and — in the git twin of
+ * the same wrapper — turned "this folder belongs to another repository, refuse"
+ * into `git init` inside somebody else's tracked tree.
+ *
+ * Two facts settle it, and neither can be recovered from the exit code:
+ *
+ *   - `spawn` fires only when the process really started. It is the only thing
+ *     separating "never ran" from "ran and then something went wrong" — `error`
+ *     also fires on a perfectly healthy child whose kill() could not deliver a
+ *     signal.
+ *   - the spawn errno separates ENOENT (genuinely missing) from EACCES (right
+ *     there, wrong mode bits). Collapsing them offers the one remedy that
+ *     cannot help.
+ *
+ * Both callers used to carry their own copy of this. coding-github.ts was
+ * fixed; coding-git.ts kept the pre-fix copy. Sharing the wrapper is what stops
+ * the next fix landing in one of two identical paths.
+ */
+
+import { spawn } from "child_process";
+
+export interface ChildResult {
+  /** The exit code, or null when the process was killed or never started. */
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  /** The signal that killed it, when one did. */
+  signal: NodeJS.Signals | null;
+  /** True when OUR timer killed it: the command outlived its budget. */
+  timedOut: boolean;
+  /** True when the binary could not be started at all. Necessary evidence that
+   *  the command is unusable, but NOT sufficient to call it absent — see
+   *  startError. */
+  startFailed: boolean;
+  /** The errno of a failed spawn: ENOENT means genuinely missing, EACCES means
+   *  present but not executable. */
+  startError: string | null;
+}
+
+export interface RunChildOptions {
+  cwd?: string;
+  timeoutMs: number;
+  /** The whole environment the child gets — deliberately built by the caller,
+   *  because git and gh need different things and neither needs the server's. */
+  env: Record<string, string>;
+  /** What stderr reads when the binary never started. */
+  notStarted?: string;
+}
+
+/**
+ * Run a command with a deliberate, minimal environment and a hard timeout.
+ * Never rejects: every outcome is described in the result.
+ */
+export function runChild(bin: string, args: string[], opts: RunChildOptions): Promise<ChildResult> {
+  return new Promise((resolve) => {
+    const child = spawn(bin, args, {
+      cwd: opts.cwd,
+      // Cast only because this repo's ProcessEnv augmentation insists on
+      // NODE_ENV, which neither git nor gh has any use for.
+      env: opts.env as unknown as NodeJS.ProcessEnv,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, opts.timeoutMs);
+    timer.unref();
+    child.stdout.on("data", (c) => { stdout += String(c); });
+    child.stderr.on("data", (c) => { stderr += String(c); });
+    // `error` is not proof the binary is missing. It also fires on a child that
+    // spawned perfectly well and whose kill() could not deliver its signal — so
+    // treating every error as "not installed" would reintroduce the exact
+    // false-failure this module exists to prevent, on the timeout path of all
+    // places.
+    let spawned = false;
+    child.on("spawn", () => { spawned = true; });
+    // A failed spawn emits `error` and THEN `close` with a null code; the first
+    // resolve wins, so this is the one place startFailed is set.
+    child.on("error", (err: NodeJS.ErrnoException) => {
+      clearTimeout(timer);
+      resolve({
+        code: null,
+        stdout,
+        stderr: spawned ? stderr.trim() : (opts.notStarted ?? "could not start"),
+        signal: null,
+        timedOut,
+        startFailed: !spawned,
+        startError: spawned ? null : (err?.code ?? null),
+      });
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({ code, stdout: stdout.trim(), stderr: stderr.trim(), signal, timedOut, startFailed: false, startError: null });
+    });
+  });
+}
+
+/** True when the command ran but produced no exit code — it was killed, by our
+ *  own timer or by something else. It started, so the binary exists. */
+export function wasKilled(r: ChildResult): boolean {
+  return !r.startFailed && r.code === null;
+}
+
+/**
+ * True when the result carries NO finding about the world: the command either
+ * never started or was cut short. A non-zero exit code is a finding; this is
+ * the absence of one, and acting on it is guessing.
+ */
+export function inconclusive(r: ChildResult): boolean {
+  return r.startFailed || wasKilled(r);
+}
+
+/**
+ * ENOENT is the only errno that means "there is no such file". Anything else —
+ * EACCES above all — is a binary that EXISTS and would not run.
+ */
+export function startedMissing(r: ChildResult): boolean {
+  return r.startFailed && (r.startError === "ENOENT" || r.startError === null);
+}
+
+/**
+ * What to tell the owner about a call that was cut short. Never mentions
+ * installing anything: the binary demonstrably ran. Never blank either — a
+ * SIGKILLed child writes no stderr, so a `(stderr || stdout)` detail for a
+ * killed call was the empty string, and the surfaces that render
+ * `detail ?? reason` showed the owner a failure with nothing in it.
+ */
+export function killedDetail(
+  r: ChildResult,
+  what: string,
+  advice = "Check this ClawBox's network connection and try again.",
+): string {
+  const how = r.timedOut ? "timed out" : `was stopped before it finished${r.signal ? ` (${r.signal})` : ""}`;
+  return `${what} ${how}. ${advice}`;
+}
+
+/**
+ * The detail for ANY failed call, killed or not. The rule the residuals kept
+ * breaking in one branch at a time: read the published evidence, never the
+ * exit code alone, and never hand back an empty string.
+ */
+export function failureDetail(r: ChildResult, what: string, advice = "Try again."): string {
+  // A failed spawn was never "stopped before it finished" — it never began.
+  if (r.startFailed) return `${what} could not be started (${r.startError ?? "unknown error"}). ${advice}`;
+  if (wasKilled(r)) return killedDetail(r, what, advice);
+  return (r.stderr || r.stdout || `${what} failed.`).slice(0, 400);
+}

--- a/src/lib/coding-git.ts
+++ b/src/lib/coding-git.ts
@@ -31,8 +31,15 @@
  * somewhere is a separate decision the owner makes.
  */
 
-import { spawn } from "child_process";
 import path from "path";
+import {
+  type ChildResult,
+  failureDetail,
+  inconclusive,
+  killedDetail,
+  runChild,
+  startedMissing,
+} from "@/lib/child-run";
 
 /** A commit message never grows past this, however long the summary is. */
 const MAX_MESSAGE_CHARS = 900;
@@ -53,48 +60,61 @@ export type GitSkipReason =
   | "no_changes"
   /** The folder belongs to a repository that tracks it — not ours to commit to. */
   | "foreign_repo"
-  /** git is not installed. */
+  /** git is not installed — the spawn failed with ENOENT and nothing else.
+   *  A git that ran, or one present with the wrong mode bits, is NOT this:
+   *  answering either with "install git" offers the one remedy that cannot
+   *  work. */
   | "no_git"
-  /** git refused; detail carries what it said. */
+  /** git refused, was cut short, or would not start. `detail` always says
+   *  which, and is never blank — the run panel renders `detail ?? reason`. */
   | "git_failed";
-
-interface RunResult {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-}
 
 /**
  * Run one git command in a folder.
  *
  * `git -C` with an argv array, never a shell: the folder name and the commit
  * message both come from outside and neither is quoted by us.
+ *
+ * The wrapper and the rules for reading a null exit code are shared with
+ * coding-github.ts (`@/lib/child-run`). They did not used to be: this file kept
+ * its own pre-#518 copy, with no `spawn` listener and no errno, so every fault
+ * here — a killed call, a git that would not execute — arrived as the same
+ * bare `code: null` and was read as "git is not installed".
  */
-function git(dir: string, args: string[]): Promise<RunResult> {
-  return new Promise((resolve) => {
-    const child = spawn("git", ["-C", dir, ...args], {
-      // Cast only because this repo's ProcessEnv augmentation insists on
-      // NODE_ENV, which git has no use for. GIT_TERMINAL_PROMPT=0 matters:
-      // git must fail rather than block forever waiting for a password that
-      // nobody is there to type.
-      env: {
-        PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-        HOME: process.env.HOME ?? "",
-        GIT_TERMINAL_PROMPT: "0",
-        GIT_CONFIG_NOSYSTEM: "1",
-        LANG: "C",
-      } as unknown as NodeJS.ProcessEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    const timer = setTimeout(() => child.kill("SIGKILL"), GIT_TIMEOUT_MS);
-    timer.unref();
-    child.stdout.on("data", (c) => { stdout += String(c); });
-    child.stderr.on("data", (c) => { stderr += String(c); });
-    child.on("error", () => { clearTimeout(timer); resolve({ code: null, stdout, stderr: "git could not be started" }); });
-    child.on("close", (code) => { clearTimeout(timer); resolve({ code, stdout: stdout.trim(), stderr: stderr.trim() }); });
+function git(dir: string, args: string[]): Promise<ChildResult> {
+  return runChild("git", ["-C", dir, ...args], {
+    timeoutMs: GIT_TIMEOUT_MS,
+    // GIT_TERMINAL_PROMPT=0 matters: git must fail rather than block forever
+    // waiting for a password that nobody is there to type.
+    env: {
+      PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+      HOME: process.env.HOME ?? "",
+      GIT_TERMINAL_PROMPT: "0",
+      GIT_CONFIG_NOSYSTEM: "1",
+      LANG: "C",
+    },
+    notStarted: "git could not be started",
   });
+}
+
+/**
+ * The answer to a yes/no question about the folder — or the admission that the
+ * probe never produced one.
+ *
+ * A non-zero exit code is a FINDING: git looked and said no. A null code is
+ * not; the call was killed or never started. Collapsing the second into the
+ * first is what turned "this folder belongs to another repository, refuse" into
+ * `git init` inside somebody else's tracked tree.
+ */
+type Probe =
+  | { known: true; value: boolean }
+  | { known: false; result: ChildResult };
+
+/** The refusal for a probe that found nothing. Never blank, and it never
+ *  mentions installing anything: git demonstrably ran, or said why it could
+ *  not start. */
+function unknownShape(probe: { known: false; result: ChildResult }, what: string): GitOutcome {
+  return { committed: false, reason: "git_failed", detail: failureDetail(probe.result, what) };
 }
 
 /**
@@ -103,24 +123,27 @@ function git(dir: string, args: string[]): Promise<RunResult> {
  * Deliberately compares resolved paths: being *inside* a repository is not
  * enough, and is exactly the case that would commit into ClawBox's own tree.
  */
-async function isOwnRepoRoot(dir: string): Promise<boolean> {
+async function isOwnRepoRoot(dir: string): Promise<Probe> {
   const r = await git(dir, ["rev-parse", "--show-toplevel"]);
-  if (r.code !== 0 || !r.stdout) return false;
-  return path.resolve(r.stdout) === path.resolve(dir);
+  if (inconclusive(r)) return { known: false, result: r };
+  if (r.code !== 0 || !r.stdout) return { known: true, value: false };
+  return { known: true, value: path.resolve(r.stdout) === path.resolve(dir) };
 }
 
 /** Whether an enclosing repository ignores this folder — i.e. a private repo
  *  inside it is invisible to that outer tree. */
-async function ignoredByOuterRepo(dir: string): Promise<boolean> {
+async function ignoredByOuterRepo(dir: string): Promise<Probe> {
   const parent = path.dirname(path.resolve(dir));
   const r = await git(parent, ["check-ignore", "-q", path.resolve(dir)]);
-  return r.code === 0;
+  if (inconclusive(r)) return { known: false, result: r };
+  return { known: true, value: r.code === 0 };
 }
 
 /** Whether the folder sits inside ANY repository. */
-async function insideSomeRepo(dir: string): Promise<boolean> {
+async function insideSomeRepo(dir: string): Promise<Probe> {
   const r = await git(dir, ["rev-parse", "--is-inside-work-tree"]);
-  return r.code === 0 && r.stdout === "true";
+  if (inconclusive(r)) return { known: false, result: r };
+  return { known: true, value: r.code === 0 && r.stdout === "true" };
 }
 
 /**
@@ -129,7 +152,10 @@ async function insideSomeRepo(dir: string): Promise<boolean> {
  */
 async function initRepo(dir: string): Promise<string | null> {
   const init = await git(dir, ["init", "--quiet"]);
-  if (init.code !== 0) return init.stderr || "git init failed";
+  // Never `init.stderr` alone: a killed `git init` writes none, and the caller
+  // renders `detail ?? reason`, so an empty string reached the owner as a
+  // failure with nothing in it.
+  if (init.code !== 0) return failureDetail(init, "Creating a git repository for the folder");
   await git(dir, ["config", "user.name", COMMIT_NAME]);
   await git(dir, ["config", "user.email", COMMIT_EMAIL]);
   return null;
@@ -167,14 +193,47 @@ export async function commitRunWork(input: {
   const dir = path.resolve(input.directory);
 
   const probe = await git(dir, ["--version"]);
-  if (probe.code === null) return { committed: false, reason: "no_git" };
+  // `code === null` was read here as "git is not installed". It is not: a
+  // failed spawn and a killed child close identically, and even a failed spawn
+  // only means absent when the errno is ENOENT. EACCES is a git that is right
+  // there with the wrong mode bits, and "install git" is the one remedy that
+  // cannot help it.
+  if (probe.startFailed) {
+    return startedMissing(probe)
+      ? { committed: false, reason: "no_git", detail: "git is not installed on this ClawBox." }
+      : {
+          committed: false,
+          reason: "git_failed",
+          detail: `git is on this ClawBox but would not start (${probe.startError}). Check its permissions.`,
+        };
+  }
+  if (probe.code === null) {
+    // It RAN. Being killed says nothing about whether git is on the box.
+    return { committed: false, reason: "git_failed", detail: killedDetail(probe, "Reading the git version", "Try again.") };
+  }
 
   let initialized = false;
-  if (!(await isOwnRepoRoot(dir))) {
+  const ownRoot = await isOwnRepoRoot(dir);
+  if (!ownRoot.known) return unknownShape(ownRoot, "Reading the folder's git repository");
+  if (!ownRoot.value) {
     // Inside something else's tree, and that tree tracks us: refuse. This is
     // the case that would commit into the ClawBox checkout.
-    if ((await insideSomeRepo(dir)) && !(await ignoredByOuterRepo(dir))) {
-      return { committed: false, reason: "foreign_repo", detail: "The folder belongs to another git repository." };
+    //
+    // Both halves of that test must be FINDINGS. A killed probe read as
+    // "no repo here" turns the refusal into `git init` inside a tree somebody
+    // else's repository tracks — shadowing that subtree's history and
+    // committing into it, from a transient fault. An unknown repository shape
+    // is not an absent one, and `git init` is not a step to take on a guess.
+    const inside = await insideSomeRepo(dir);
+    if (!inside.known) return unknownShape(inside, "Checking whether the folder is inside a git repository");
+    if (inside.value) {
+      const ignored = await ignoredByOuterRepo(dir);
+      // The mirror lie: a killed check-ignore read as "not ignored" tells the
+      // owner their folder belongs to another repository when it may not.
+      if (!ignored.known) return unknownShape(ignored, "Checking whether the outer repository ignores the folder");
+      if (!ignored.value) {
+        return { committed: false, reason: "foreign_repo", detail: "The folder belongs to another git repository." };
+      }
     }
     const err = await initRepo(dir);
     if (err) return { committed: false, reason: "git_failed", detail: err };
@@ -183,7 +242,10 @@ export async function commitRunWork(input: {
 
   // Stage everything in THIS repository. Safe now: its root is this folder.
   const add = await git(dir, ["add", "-A"]);
-  if (add.code !== 0) return { committed: false, reason: "git_failed", detail: add.stderr };
+  // Not `add.stderr`: a SIGKILLed child writes none, and coding-agent.ts renders
+  // `detail ?? reason` — "" is not nullish, so the run panel showed the owner
+  // literally "Not committed: " and stopped there.
+  if (add.code !== 0) return { committed: false, reason: "git_failed", detail: failureDetail(add, "Staging the run's changes") };
 
   const staged = await git(dir, ["diff", "--cached", "--name-only"]);
   if (staged.code === 0 && !staged.stdout) return { committed: false, reason: "no_changes" };
@@ -194,7 +256,7 @@ export async function commitRunWork(input: {
     "-c", `user.email=${COMMIT_EMAIL}`,
     "commit", "--no-verify", "-m", message,
   ]);
-  if (commit.code !== 0) return { committed: false, reason: "git_failed", detail: commit.stderr };
+  if (commit.code !== 0) return { committed: false, reason: "git_failed", detail: failureDetail(commit, "Committing the run's changes") };
 
   const sha = await git(dir, ["rev-parse", "--short", "HEAD"]);
   return { committed: true, sha: sha.stdout || "unknown", initialized };

--- a/src/lib/coding-git.ts
+++ b/src/lib/coding-git.ts
@@ -39,6 +39,7 @@ import {
   killedDetail,
   runChild,
   startedMissing,
+  startFailureDetail,
 } from "@/lib/child-run";
 
 /** A commit message never grows past this, however long the summary is. */
@@ -199,13 +200,14 @@ export async function commitRunWork(input: {
   // there with the wrong mode bits, and "install git" is the one remedy that
   // cannot help it.
   if (probe.startFailed) {
+    // ENOENT, and only ENOENT, is "no_git". EACCES is a git sitting right there
+    // with the wrong mode bits; an errno-less spawn error is not evidence of
+    // anything at all, and naming one remedy for it would be the same guess in
+    // a smaller hat. startFailureDetail says exactly what each case supports.
+    const detail = startFailureDetail(probe, "git");
     return startedMissing(probe)
-      ? { committed: false, reason: "no_git", detail: "git is not installed on this ClawBox." }
-      : {
-          committed: false,
-          reason: "git_failed",
-          detail: `git is on this ClawBox but would not start (${probe.startError}). Check its permissions.`,
-        };
+      ? { committed: false, reason: "no_git", detail }
+      : { committed: false, reason: "git_failed", detail };
   }
   if (probe.code === null) {
     // It RAN. Being killed says nothing about whether git is on the box.

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -23,8 +23,14 @@
  * in a file should not have that mistake amplified into a public repo.
  */
 
-import { spawn } from "child_process";
 import path from "path";
+import {
+  type ChildResult,
+  killedDetail,
+  runChild,
+  startedMissing,
+  wasKilled,
+} from "@/lib/child-run";
 
 const GH_TIMEOUT_MS = 60_000;
 /** Pushing over the network gets longer than a local git call. */
@@ -66,7 +72,20 @@ export interface GitHubStatus {
 
 export type BackupOutcome =
   | { pushed: true; repo: string; created: boolean; branch: string }
-  | { pushed: false; reason: BackupFailure; detail?: string };
+  | {
+      pushed: false;
+      reason: BackupFailure;
+      detail?: string;
+      /**
+       * The fault was transient — a call our own timer killed, or one that
+       * never started — and the same request is worth making again unchanged.
+       * `gh_unreachable` says this for the calls that reach github.com; this
+       * says it for the LOCAL git probes, which have no reason of their own
+       * and whose refusal would otherwise be answered 409: "your request is
+       * wrong", about a request that was fine.
+       */
+      transient?: boolean;
+    };
 
 export type BackupFailure =
   /** gh is not installed on this device. */
@@ -90,99 +109,39 @@ export type DisconnectOutcome =
    *  than as a broken box (500). */
   | { ok: false; kind: "no_gh" | "gh_unreachable" | "failed"; detail: string };
 
-interface Result {
-  code: number | null;
-  stdout: string;
-  stderr: string;
-  /** The signal that killed it, when one did. A signalled child closes with a
-   *  null `code` — the SAME null a failed spawn gives — so the code alone
-   *  cannot tell "killed" from "never started". This is what tells them
-   *  apart, and getting it wrong reported a network outage as a missing gh. */
-  signal: NodeJS.Signals | null;
-  /** True when OUR timer killed it: the command outlived its budget. */
-  timedOut: boolean;
-  /** True when the binary could not be started at all. Necessary evidence
-   *  that the command is unusable, but NOT sufficient to call it absent —
-   *  see startError. */
-  startFailed: boolean;
-  /** The errno of a failed spawn: ENOENT means genuinely missing, EACCES
-   *  means present but not executable. Collapsing the two would send someone
-   *  to reinstall a binary that is sitting right there. */
-  startError: string | null;
-}
-
 /**
  * Run a command with a deliberate, minimal environment.
  *
  * HOME is the one thing gh genuinely needs — its credential lives in
  * ~/.config/gh/hosts.yml. GIT_TERMINAL_PROMPT=0 so a missing credential fails
  * instead of blocking forever on a prompt nobody can answer.
+ *
+ * The wrapper itself, and the rules for reading a null exit code, live in
+ * `@/lib/child-run` — shared with coding-git.ts, which used to carry its own
+ * pre-#518 copy of both.
  */
-function run(bin: string, args: string[], opts: { cwd?: string; timeoutMs?: number } = {}): Promise<Result> {
-  return new Promise((resolve) => {
-    const child = spawn(bin, args, {
-      cwd: opts.cwd,
-      env: {
-        PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
-        HOME: process.env.HOME ?? "/home/clawbox",
-        GIT_TERMINAL_PROMPT: "0",
-        GH_PROMPT_DISABLED: "1",
-        NO_COLOR: "1",
-        LANG: "C",
-      } as unknown as NodeJS.ProcessEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    let stdout = "";
-    let stderr = "";
-    let timedOut = false;
-    const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, opts.timeoutMs ?? GH_TIMEOUT_MS);
-    timer.unref();
-    child.stdout.on("data", (c) => { stdout += String(c); });
-    child.stderr.on("data", (c) => { stderr += String(c); });
-    // `error` is not proof the binary is missing. It also fires on a child
-    // that spawned perfectly well and whose kill() could not deliver its
-    // signal — so treating every error as "not installed" would reintroduce
-    // the exact false-failure this file exists to prevent, on the timeout path
-    // of all places. `spawn` fires only when the process really started, so it
-    // is what separates "never ran" from "ran and then something went wrong".
-    let spawned = false;
-    child.on("spawn", () => { spawned = true; });
-    // A failed spawn emits `error` and THEN `close` with a null code; the
-    // first resolve wins, so this is the one place startFailed is set.
-    child.on("error", (err: NodeJS.ErrnoException) => {
-      clearTimeout(timer);
-      resolve({
-        code: null,
-        stdout,
-        stderr: spawned ? stderr.trim() : "could not start",
-        signal: null,
-        timedOut,
-        startFailed: !spawned,
-        startError: spawned ? null : (err?.code ?? null),
-      });
-    });
-    child.on("close", (code, signal) => {
-      clearTimeout(timer);
-      resolve({ code, stdout: stdout.trim(), stderr: stderr.trim(), signal, timedOut, startFailed: false, startError: null });
-    });
+function run(bin: string, args: string[], opts: { cwd?: string; timeoutMs?: number } = {}): Promise<ChildResult> {
+  return runChild(bin, args, {
+    cwd: opts.cwd,
+    timeoutMs: opts.timeoutMs ?? GH_TIMEOUT_MS,
+    env: {
+      PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+      HOME: process.env.HOME ?? "/home/clawbox",
+      GIT_TERMINAL_PROMPT: "0",
+      GH_PROMPT_DISABLED: "1",
+      NO_COLOR: "1",
+      LANG: "C",
+    },
   });
 }
 
-/** True when the command ran but produced no exit code — it was killed, by our
- *  own timer or by something else. It started, so the binary exists. */
-function wasKilled(r: Result): boolean {
-  return !r.startFailed && r.code === null;
-}
-
 /**
- * What to tell the owner about a call that was cut short. Never mentions
- * installing anything: the binary demonstrably ran. Never blank either — a
- * SIGKILLed child writes no stderr, so the old `(stderr || stdout)` detail for
- * a killed call was the empty string.
+ * The refusal for a local git call that carried no finding — killed by our own
+ * timer, or never started. `transient` is what tells the route this is a fault
+ * to retry (503) and not a request that cannot be satisfied (409).
  */
-function killedDetail(r: Result, what: string, advice = "Check this ClawBox's network connection and try again."): string {
-  const how = r.timedOut ? "timed out" : `was stopped before it finished${r.signal ? ` (${r.signal})` : ""}`;
-  return `${what} ${how}. ${advice}`;
+function transientGit(r: ChildResult, what: string): BackupOutcome {
+  return { pushed: false, reason: "failed", detail: killedDetail(r, what, "Try again."), transient: true };
 }
 
 /**
@@ -210,7 +169,7 @@ export async function githubStatus(): Promise<GitHubStatus> {
     // else — EACCES above all — is a binary that EXISTS and would not run, and
     // answering that with "not installed" hands over the one remedy that
     // cannot work.
-    const missing = r.startError === "ENOENT" || r.startError === null;
+    const missing = startedMissing(r);
     return {
       installed: !missing,
       connected: false,
@@ -254,7 +213,7 @@ export async function disconnectGitHub(): Promise<DisconnectOutcome> {
   if (r.startFailed) {
     // Present but unrunnable is not missing, and must not be answered with an
     // install: the file is there, its permissions are not.
-    return r.startError === "ENOENT" || r.startError === null
+    return startedMissing(r)
       ? { ok: false, kind: "no_gh", detail: "gh is not installed on this ClawBox." }
       : { ok: false, kind: "failed", detail: `The GitHub CLI is on this ClawBox but would not start (${r.startError}). Check its permissions.` };
   }
@@ -311,7 +270,7 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   // A killed probe is not evidence about the folder. Reading it as one would
   // tell the owner their repository is not a repository.
   if (wasKilled(top)) {
-    return { pushed: false, reason: "failed", detail: killedDetail(top, "Reading the folder's git repository", "Try again.") };
+    return transientGit(top, "Reading the folder's git repository");
   }
   if (top.code !== 0 || path.resolve(top.stdout || "") !== dir) {
     return { pushed: false, reason: "not_a_repo", detail: "This folder is not its own git repository." };
@@ -322,7 +281,7 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   // finding, and saying it would tell an owner with a full history that their
   // work is empty.
   if (wasKilled(head)) {
-    return { pushed: false, reason: "failed", detail: killedDetail(head, "Reading the folder's commits", "Try again.") };
+    return transientGit(head, "Reading the folder's commits");
   }
   if (head.code !== 0) return { pushed: false, reason: "nothing_to_push", detail: "The folder has no commits yet." };
 
@@ -332,7 +291,7 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   // had no name to give; wrong when the probe was killed, which would push a
   // `develop` checkout to `main` and bind it there over a transient fault.
   if (wasKilled(branchOut)) {
-    return { pushed: false, reason: "failed", detail: killedDetail(branchOut, "Reading the folder's branch", "Try again.") };
+    return transientGit(branchOut, "Reading the folder's branch");
   }
   const branch = branchOut.code === 0 && branchOut.stdout ? branchOut.stdout : "main";
 
@@ -343,7 +302,7 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   // second repository for a folder that already has one — an irreversible
   // guess made from a transient fault.
   if (wasKilled(hasRemote)) {
-    return { pushed: false, reason: "failed", detail: killedDetail(hasRemote, "Reading the folder's git remote", "Try again.") };
+    return transientGit(hasRemote, "Reading the folder's git remote");
   }
   let created = false;
   let repo = hasRemote.code === 0 ? hasRemote.stdout : "";
@@ -358,13 +317,23 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
       { cwd: dir, timeoutMs: PUSH_TIMEOUT_MS },
     );
     if (create.code !== 0) {
-      return {
-        pushed: false,
-        reason: "failed",
-        detail: wasKilled(create)
-          ? killedDetail(create, "Creating the repository on GitHub")
-          : (create.stderr || create.stdout).slice(0, 400),
-      };
+      // A killed create is a NETWORK fault, and the detail below already says
+      // so — "check this ClawBox's network connection and try again". Leaving
+      // the reason as "failed" made the route answer 409, a non-retryable
+      // client error, to its own retry advice. gh_unreachable is what 503 is
+      // wired to, and it is the true statement about a call that hung on the
+      // uplink for three minutes.
+      if (wasKilled(create)) {
+        return {
+          pushed: false,
+          reason: "gh_unreachable",
+          detail: killedDetail(create, "Creating the repository on GitHub"),
+          transient: true,
+        };
+      }
+      // GitHub itself refusing — a name already taken, a scope missing — IS a
+      // request that cannot be satisfied as it stands. That one keeps its 409.
+      return { pushed: false, reason: "failed", detail: (create.stderr || create.stdout).slice(0, 400) };
     }
     created = true;
     const url = await run("git", ["-C", dir, "remote", "get-url", "origin"]);
@@ -378,13 +347,17 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
     { timeoutMs: PUSH_TIMEOUT_MS },
   );
   if (push.code !== 0) {
-    return {
-      pushed: false,
-      reason: "failed",
-      detail: wasKilled(push)
-        ? killedDetail(push, "Pushing to GitHub")
-        : (push.stderr || push.stdout).slice(0, 400),
-    };
+    // Same rule as the create above: the push is the other call that leaves
+    // the box, and a killed one is the network, not the request.
+    if (wasKilled(push)) {
+      return {
+        pushed: false,
+        reason: "gh_unreachable",
+        detail: killedDetail(push, "Pushing to GitHub"),
+        transient: true,
+      };
+    }
+    return { pushed: false, reason: "failed", detail: (push.stderr || push.stdout).slice(0, 400) };
   }
   return { pushed: true, repo, created, branch };
 }

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -29,6 +29,7 @@ import {
   killedDetail,
   runChild,
   startedMissing,
+  startFailureDetail,
   wasKilled,
 } from "@/lib/child-run";
 
@@ -213,9 +214,13 @@ export async function disconnectGitHub(): Promise<DisconnectOutcome> {
   if (r.startFailed) {
     // Present but unrunnable is not missing, and must not be answered with an
     // install: the file is there, its permissions are not.
+    // Same rule as the status probe: only ENOENT is "not installed". The
+    // detail is built from the errno rather than asserted, so an unrecognised
+    // one never renders as "(null)" or as a remedy nobody can act on.
+    const detail = startFailureDetail(r, "gh");
     return startedMissing(r)
-      ? { ok: false, kind: "no_gh", detail: "gh is not installed on this ClawBox." }
-      : { ok: false, kind: "failed", detail: `The GitHub CLI is on this ClawBox but would not start (${r.startError}). Check its permissions.` };
+      ? { ok: false, kind: "no_gh", detail }
+      : { ok: false, kind: "failed", detail };
   }
   if (wasKilled(r)) {
     return {

--- a/src/lib/hermes-translations/bg.ts
+++ b/src/lib/hermes-translations/bg.ts
@@ -450,6 +450,7 @@ export const bg: Record<string, string> = {
   "codingAgent.updated": "обновено",
   "codingAgent.githubOff": "не е свързан",
   "codingAgent.githubUnreachable": "GitHub е недостъпен",
+  "codingAgent.githubNotRunnable": "gh е инсталиран, но не се стартира — проверете правата му",
   "codingAgent.githubConnect": "Свържи",
   "codingAgent.githubReconnect": "Промени",
   "codingAgent.githubOut": "Изход",

--- a/src/lib/hermes-translations/de.ts
+++ b/src/lib/hermes-translations/de.ts
@@ -462,6 +462,7 @@ export const de: Record<string, string> = {
   "codingAgent.updated": "aktualisiert",
   "codingAgent.githubOff": "nicht verbunden",
   "codingAgent.githubUnreachable": "GitHub nicht erreichbar",
+  "codingAgent.githubNotRunnable": "gh ist installiert, startet aber nicht — Berechtigungen prüfen",
   "codingAgent.githubConnect": "Verbinden",
   "codingAgent.githubReconnect": "Ändern",
   "codingAgent.githubOut": "Abmelden",

--- a/src/lib/hermes-translations/en-coding-agent.ts
+++ b/src/lib/hermes-translations/en-coding-agent.ts
@@ -51,6 +51,7 @@ export const codingAgentEn: Record<string, string> = {
   "codingAgent.updated": "updated",
   "codingAgent.githubOff": "not connected",
   "codingAgent.githubUnreachable": "GitHub unreachable",
+  "codingAgent.githubNotRunnable": "gh installed but will not start — check its permissions",
   "codingAgent.githubConnect": "Connect",
   "codingAgent.githubReconnect": "Change",
   "codingAgent.githubOut": "Sign out",

--- a/src/lib/hermes-translations/es.ts
+++ b/src/lib/hermes-translations/es.ts
@@ -458,6 +458,7 @@ export const es: Record<string, string> = {
   "codingAgent.updated": "actualizado",
   "codingAgent.githubOff": "sin conectar",
   "codingAgent.githubUnreachable": "GitHub no accesible",
+  "codingAgent.githubNotRunnable": "gh está instalado pero no arranca: revisa sus permisos",
   "codingAgent.githubConnect": "Conectar",
   "codingAgent.githubReconnect": "Cambiar",
   "codingAgent.githubOut": "Cerrar sesión",

--- a/src/lib/hermes-translations/fr.ts
+++ b/src/lib/hermes-translations/fr.ts
@@ -463,6 +463,7 @@ export const fr: Record<string, string> = {
   "codingAgent.updated": "mis à jour",
   "codingAgent.githubOff": "non connecté",
   "codingAgent.githubUnreachable": "GitHub injoignable",
+  "codingAgent.githubNotRunnable": "gh est installé mais ne démarre pas — vérifiez ses permissions",
   "codingAgent.githubConnect": "Connecter",
   "codingAgent.githubReconnect": "Changer",
   "codingAgent.githubOut": "Se déconnecter",

--- a/src/lib/hermes-translations/it.ts
+++ b/src/lib/hermes-translations/it.ts
@@ -474,6 +474,7 @@ export const it: Record<string, string> = {
   "codingAgent.updated": "aggiornato",
   "codingAgent.githubOff": "non connesso",
   "codingAgent.githubUnreachable": "GitHub irraggiungibile",
+  "codingAgent.githubNotRunnable": "gh è installato ma non si avvia — controlla i permessi",
   "codingAgent.githubConnect": "Connetti",
   "codingAgent.githubReconnect": "Cambia",
   "codingAgent.githubOut": "Esci",

--- a/src/lib/hermes-translations/ja.ts
+++ b/src/lib/hermes-translations/ja.ts
@@ -465,6 +465,7 @@ export const ja: Record<string, string> = {
   "codingAgent.updated": "更新",
   "codingAgent.githubOff": "未接続",
   "codingAgent.githubUnreachable": "GitHub に接続できません",
+  "codingAgent.githubNotRunnable": "gh は入っていますが起動しません — 権限を確認してください",
   "codingAgent.githubConnect": "接続",
   "codingAgent.githubReconnect": "変更",
   "codingAgent.githubOut": "サインアウト",

--- a/src/lib/hermes-translations/nl.ts
+++ b/src/lib/hermes-translations/nl.ts
@@ -463,6 +463,7 @@ export const nl: Record<string, string> = {
   "codingAgent.updated": "bijgewerkt",
   "codingAgent.githubOff": "niet verbonden",
   "codingAgent.githubUnreachable": "GitHub onbereikbaar",
+  "codingAgent.githubNotRunnable": "gh is geïnstalleerd maar start niet — controleer de rechten",
   "codingAgent.githubConnect": "Verbinden",
   "codingAgent.githubReconnect": "Wijzigen",
   "codingAgent.githubOut": "Afmelden",

--- a/src/lib/hermes-translations/sv.ts
+++ b/src/lib/hermes-translations/sv.ts
@@ -459,6 +459,7 @@ export const sv: Record<string, string> = {
   "codingAgent.updated": "uppdaterad",
   "codingAgent.githubOff": "inte ansluten",
   "codingAgent.githubUnreachable": "GitHub kan inte nås",
+  "codingAgent.githubNotRunnable": "gh är installerat men startar inte — kontrollera behörigheterna",
   "codingAgent.githubConnect": "Anslut",
   "codingAgent.githubReconnect": "Ändra",
   "codingAgent.githubOut": "Logga ut",

--- a/src/lib/hermes-translations/zh.ts
+++ b/src/lib/hermes-translations/zh.ts
@@ -474,6 +474,7 @@ export const zh: Record<string, string> = {
   "codingAgent.updated": "更新于",
   "codingAgent.githubOff": "未连接",
   "codingAgent.githubUnreachable": "无法连接 GitHub",
+  "codingAgent.githubNotRunnable": "gh 已安装但无法启动 — 请检查其权限",
   "codingAgent.githubConnect": "连接",
   "codingAgent.githubReconnect": "更改",
   "codingAgent.githubOut": "退出登录",

--- a/src/tests/components/coding-agent-github-card.test.tsx
+++ b/src/tests/components/coding-agent-github-card.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * GH-01d. The GitHub row of the Coding Agent card.
+ *
+ * #518 split one failure into three reasons and added all three to this
+ * component's GitHubState type — and then branched on only one of them.
+ * `githubStatus()` answers `{ installed: true, reason: "not_runnable" }` for a
+ * gh that is sitting on the box with the wrong mode bits, so the row rendered
+ * (it is gated on `installed`), said "not connected", and offered Connect —
+ * which opens a terminal on `gh auth login`, the remedy the library layer
+ * explicitly refuses to suggest: "Installing it again fixes nothing; the
+ * remedy is permissions."
+ *
+ * backupToGitHub() and disconnectGitHub() both got a not_runnable message.
+ * The surface the owner actually looks at did not.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@/tests/helpers/test-utils";
+import { translations } from "@/lib/translations";
+import CodingAgentApp from "@/components/CodingAgentApp";
+
+const t = (key: string, params?: Record<string, string | number>) => {
+  let str = translations.en[key] ?? key;
+  if (params) for (const [k, v] of Object.entries(params)) str = str.replaceAll(`{${k}}`, String(v));
+  return str;
+};
+vi.mock("@/lib/i18n", () => ({ useT: () => ({ locale: "en", t }) }));
+
+const READY = { ready: true, wrapperInstalled: true, claudeInstalled: true, clawaiConnected: true, problems: [] as string[] };
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+/** The device answering the three loads the card makes, with `git` under test. */
+function stubFetch(github: Record<string, unknown>) {
+  vi.stubGlobal("fetch", vi.fn(async (input: string | URL) => {
+    const url = input.toString();
+    if (url.startsWith("/setup-api/coding-agent/status")) {
+      return json({
+        enabled: true, ready: true, readiness: READY, running: 0,
+        harnessCommand: "claude-ds", maxTaskChars: 4000, defaultDirectory: null,
+      });
+    }
+    if (url.startsWith("/setup-api/coding-agent/runs")) return json({ runs: [] });
+    if (url.startsWith("/setup-api/coding-agent/git")) return json(github);
+    return json({ error: "unexpected" }, 404);
+  }));
+}
+
+const LOGIN_COMMAND = "gh auth login --hostname github.com --git-protocol https";
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("a gh that is installed but will not run", () => {
+  it("does not say 'not connected' — that is not what was found", async () => {
+    stubFetch({ installed: true, connected: false, login: null, loginCommand: LOGIN_COMMAND, reason: "not_runnable" });
+    render(<CodingAgentApp />);
+
+    const badge = await screen.findByTestId("coding-agent-github-not-runnable");
+    expect(badge).toBeTruthy();
+    expect(screen.queryByText(translations.en["codingAgent.githubOff"])).toBeNull();
+  });
+
+  it("says gh would not start and points at permissions, in real English copy", async () => {
+    stubFetch({ installed: true, connected: false, login: null, loginCommand: LOGIN_COMMAND, reason: "not_runnable" });
+    render(<CodingAgentApp />);
+
+    const badge = await screen.findByTestId("coding-agent-github-not-runnable");
+    // A missing key would render the key itself; this pins real copy.
+    expect(badge.textContent ?? "").not.toContain("codingAgent.");
+    expect(badge.textContent ?? "").toMatch(/permission/i);
+  });
+
+  it("does not offer Connect, which opens the one remedy that cannot work", async () => {
+    stubFetch({ installed: true, connected: false, login: null, loginCommand: LOGIN_COMMAND, reason: "not_runnable" });
+    render(<CodingAgentApp />);
+
+    await screen.findByTestId("coding-agent-github-not-runnable");
+    const connect = screen.queryByTestId("coding-agent-github-connect");
+    // Either gone or visibly unusable — never a live button onto `gh auth login`.
+    expect(connect === null || (connect as HTMLButtonElement).disabled).toBe(true);
+  });
+});
+
+describe("the reasons that already worked keep working", () => {
+  it("still shows the unreachable badge for a network fault", async () => {
+    stubFetch({ installed: true, connected: false, login: null, loginCommand: LOGIN_COMMAND, reason: "unreachable" });
+    render(<CodingAgentApp />);
+
+    expect(await screen.findByTestId("coding-agent-github-unreachable")).toBeTruthy();
+    expect(screen.queryByTestId("coding-agent-github-not-runnable")).toBeNull();
+  });
+
+  it("still offers Connect to a gh that simply has nobody logged in", async () => {
+    stubFetch({ installed: true, connected: false, login: null, loginCommand: LOGIN_COMMAND });
+    render(<CodingAgentApp />);
+
+    const connect = await screen.findByTestId("coding-agent-github-connect");
+    expect((connect as HTMLButtonElement).disabled).toBe(false);
+    await waitFor(() => expect(screen.getByText(translations.en["codingAgent.githubOff"])).toBeTruthy());
+  });
+
+  it("still shows the account when one is connected", async () => {
+    stubFetch({ installed: true, connected: true, login: "yalexx", loginCommand: LOGIN_COMMAND });
+    render(<CodingAgentApp />);
+
+    expect((await screen.findByTestId("coding-agent-github-login")).textContent).toBe("yalexx");
+    expect(screen.queryByTestId("coding-agent-github-not-runnable")).toBeNull();
+  });
+});

--- a/src/tests/routes/coding-agent/git-transient.test.ts
+++ b/src/tests/routes/coding-agent/git-transient.test.ts
@@ -1,0 +1,85 @@
+/**
+ * GH-01c, at the surface the owner's browser actually sees.
+ *
+ * POST /setup-api/coding-agent/git answers 409 or 503 from one ternary. #518
+ * set the rule: 409 means "the request cannot be satisfied as it stands" —
+ * true of a folder with no commits, false of a network that is merely down.
+ * A backup killed by our own timer is the second kind, and answering 409 hands
+ * the owner a non-retryable client error whose body says "try again".
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackupOutcome } from "@/lib/coding-github";
+
+const backup = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/coding-github", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/coding-github")>()),
+  backupToGitHub: backup,
+  githubStatus: vi.fn(async () => ({ installed: true, connected: true, login: "yalexx", loginCommand: "gh auth login" })),
+  disconnectGitHub: vi.fn(),
+}));
+
+vi.mock("@/lib/owner-session", () => ({ hasOwnerSession: vi.fn(async () => true) }));
+
+vi.mock("@/lib/coding-agent", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/coding-agent")>()),
+  resolveWorkingDirectory: vi.fn(async () => ({ directory: "/home/clawbox/Projects/site", projectId: null })),
+}));
+
+let POST: (req: Request) => Promise<Response>;
+
+function request(): Request {
+  return new Request("http://localhost/setup-api/coding-agent/git", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ directory: "/home/clawbox/Projects/site" }),
+  });
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  backup.mockReset();
+  ({ POST } = await import("@/app/setup-api/coding-agent/git/route"));
+});
+
+describe("a transient backup failure answers 503, not 409", () => {
+  it("answers 503 for gh_unreachable", async () => {
+    backup.mockResolvedValue({ pushed: false, reason: "gh_unreachable", detail: "Could not reach GitHub." } satisfies BackupOutcome);
+
+    const res = await POST(request());
+
+    expect(res.status).toBe(503);
+  });
+
+  it("answers 503 for a killed local git probe", async () => {
+    // reason stays "failed" — git did not refuse anything, it was killed —
+    // but the outcome carries that the fault was transient.
+    backup.mockResolvedValue({
+      pushed: false,
+      reason: "failed",
+      detail: "Reading the folder's git remote timed out. Try again.",
+      transient: true,
+    } satisfies BackupOutcome);
+
+    const res = await POST(request());
+
+    expect(res.status).toBe(503);
+    const body = await res.json() as { error?: string };
+    expect(body.error ?? "").toMatch(/timed out/i);
+  });
+
+  it("still answers 409 for a request that cannot be satisfied as it stands", async () => {
+    backup.mockResolvedValue({ pushed: false, reason: "nothing_to_push", detail: "The folder has no commits yet." } satisfies BackupOutcome);
+
+    const res = await POST(request());
+
+    expect(res.status).toBe(409);
+  });
+
+  it("still answers 409 when GitHub itself refused", async () => {
+    backup.mockResolvedValue({ pushed: false, reason: "failed", detail: "Name already exists on this account" } satisfies BackupOutcome);
+
+    const res = await POST(request());
+
+    expect(res.status).toBe(409);
+  });
+});

--- a/src/tests/unit/coding-git-killed-probe.test.ts
+++ b/src/tests/unit/coding-git-killed-probe.test.ts
@@ -86,6 +86,20 @@ function unrunnableBinary(): FakeChild {
   return child;
 }
 
+/**
+ * A spawn that failed and did not say why — an `error` with no errno. The
+ * absence of evidence, which the code used to fold in with ENOENT and answer
+ * "not installed": the same guess this module exists to stop, one layer down.
+ */
+function errnoLessFailure(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", new Error("spawn failed"));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
 /** A child that ran and exited, writing `text` to stdout. */
 function gitChild(code: number, text = "", errText = ""): FakeChild {
   const child = baseChild();
@@ -164,6 +178,27 @@ describe("GH-01a — a null exit code is not proof git is missing", () => {
     if (out.committed) return;
     expect(out.reason).toBe("no_git");
     expect(out.detail ?? "").toMatch(/not installed/i);
+  });
+
+  it("does not say 'git is not installed' for a spawn failure with NO errno", async () => {
+    // Raised in review on this PR. ENOENT is the only errno that means "there
+    // is no such file"; an error carrying none means the spawn failed and did
+    // not say why. Reading that as absence is the same unfounded guess as
+    // reading a null exit code as absence — and it hands over the same wrong
+    // remedy. The message must name both things worth checking, neither as a
+    // finding.
+    script(() => errnoLessFailure());
+
+    const out = await lib.commitRunWork(INPUT);
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).not.toBe("no_git");
+    expect(out.reason).toBe("git_failed");
+    expect(out.detail ?? "").not.toMatch(/is not installed/i);
+    expect(out.detail ?? "").toMatch(/would not start/i);
+    // and never the raw errno slot rendered empty
+    expect(out.detail ?? "").not.toMatch(/\(null\)|\(undefined\)/);
   });
 
   it("does not say 'git is not installed' when the version probe was KILLED", async () => {

--- a/src/tests/unit/coding-git-killed-probe.test.ts
+++ b/src/tests/unit/coding-git-killed-probe.test.ts
@@ -1,0 +1,332 @@
+/**
+ * GH-01a / GH-01b. src/lib/coding-git.ts was the unfixed twin of
+ * src/lib/coding-github.ts.
+ *
+ * #518 removed one belief from the GitHub wrapper: that `code === null` means
+ * the binary is missing. It does not. A child killed by our own SIGKILL closes
+ * with exactly the same null a failed spawn produces, and a spawn `error` is
+ * not proof of absence either — ENOENT means missing, EACCES means present and
+ * not executable, and the remedies are opposites.
+ *
+ * coding-git.ts kept a byte-for-byte copy of the pre-#518 wrapper: no `spawn`
+ * listener, no signal, no timedOut, no startError. Three consequences, all
+ * pinned below.
+ *
+ *  1. `if (probe.code === null) return no_git` reports a git that RAN — or one
+ *     sitting right there with the wrong mode bits — as "git is not
+ *     installed", the one remedy that cannot help.
+ *
+ *  2. A SIGKILLed child writes no stderr, so `detail: add.stderr` was "".
+ *     coding-agent.ts renders `outcome.detail ?? outcome.reason`, and "" is
+ *     not nullish, so the run panel showed the owner literally
+ *     "Not committed: " with no reason at all.
+ *
+ *  3. The consequential one. This file's own header calls the rule
+ *     non-negotiable: a folder inside a repository that TRACKS it is someone
+ *     else's working tree and a run has no business committing to it. That
+ *     refusal is decided by two probes that both returned `false` for a null
+ *     code — so one killed `rev-parse --is-inside-work-tree` turned the
+ *     refusal into `git init` INSIDE another repository's tracked tree,
+ *     shadowing that subtree's history and committing into it. An unknown
+ *     repository shape is not an absent one.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import path from "path";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ spawn: spawnMock }));
+
+type Lib = typeof import("@/lib/coding-git");
+let lib: Lib;
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: (signal: NodeJS.Signals) => boolean;
+}
+
+function baseChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => true;
+  return child;
+}
+
+/** A child that runs forever until our timer kills it. It SPAWNED, so git is
+ *  installed; the kernel closes it with a null code and the signal. */
+function hangingChild(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => child.emit("spawn"));
+  child.kill = (signal) => {
+    setImmediate(() => child.emit("close", null, signal));
+    return true;
+  };
+  return child;
+}
+
+/** git is genuinely absent: `error` with ENOENT, never a `spawn`. */
+function missingBinary(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", Object.assign(new Error("spawn git ENOENT"), { code: "ENOENT" }));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
+/** git is RIGHT THERE and would not execute. Same null code, opposite remedy. */
+function unrunnableBinary(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", Object.assign(new Error("spawn git EACCES"), { code: "EACCES" }));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
+/** A child that ran and exited, writing `text` to stdout. */
+function gitChild(code: number, text = "", errText = ""): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("spawn");
+    if (text) child.stdout.emit("data", Buffer.from(text));
+    if (errText) child.stderr.emit("data", Buffer.from(errText));
+    child.emit("close", code, null);
+  });
+  return child;
+}
+
+/** Fire the module's 30 s GIT_TIMEOUT_MS, then settle. */
+async function withTimeoutFired<T>(work: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const promise = work();
+    await vi.advanceTimersByTimeAsync(120_000);
+    return await promise;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+const DIR = "/home/clawbox/Projects/site";
+const TOPLEVEL = path.resolve(DIR);
+const INPUT = { directory: DIR, runId: "run-aaaa1111", task: "add a toggle", summary: "did it" };
+
+/** Answer each spawned git by the argv it was given, recording the calls. */
+let seen: string[][];
+function script(answer: (args: string[]) => FakeChild): void {
+  seen = [];
+  spawnMock.mockImplementation((bin: string, args: string[]) => {
+    seen.push([bin, ...args]);
+    return answer(args);
+  });
+}
+
+/** True when `git init` was run — the irreversible step. */
+function ranInit(): boolean {
+  return seen.some((c) => c.includes("init"));
+}
+
+beforeEach(async () => {
+  spawnMock.mockReset();
+  seen = [];
+  vi.resetModules();
+  lib = await import("@/lib/coding-git");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GH-01a — a null exit code is not proof git is missing", () => {
+  it("does not say 'git is not installed' for a git that is present but not executable", async () => {
+    // EACCES: the file exists, which is why the errno is not ENOENT. Sending
+    // the owner to install it offers the one remedy that cannot work.
+    script(() => unrunnableBinary());
+
+    const out = await lib.commitRunWork(INPUT);
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).not.toBe("no_git");
+    expect(out.detail ?? "").toMatch(/permission/i);
+    expect(out.detail ?? "").not.toMatch(/not installed/i);
+  });
+
+  it("still says git is missing when the binary genuinely cannot start", async () => {
+    script(() => missingBinary());
+
+    const out = await lib.commitRunWork(INPUT);
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).toBe("no_git");
+    expect(out.detail ?? "").toMatch(/not installed/i);
+  });
+
+  it("does not say 'git is not installed' when the version probe was KILLED", async () => {
+    // It ran. Being killed says nothing about whether it is on the box.
+    script(() => hangingChild());
+
+    const out = await withTimeoutFired(() => lib.commitRunWork(INPUT));
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).not.toBe("no_git");
+    expect(out.reason).toBe("git_failed");
+    expect((out.detail ?? "").trim()).not.toBe("");
+  });
+
+  it("never reports a killed `git add` with a blank message", async () => {
+    // A SIGKILLed child writes no stderr, so `detail: add.stderr` was "". The
+    // owner's run panel then read "Not committed: " and stopped there.
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+      if (args.includes("add")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const out = await withTimeoutFired(() => lib.commitRunWork(INPUT));
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).toBe("git_failed");
+    expect((out.detail ?? "").trim()).not.toBe("");
+  });
+
+  it("never reports a killed `git commit` with a blank message", async () => {
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+      if (args.includes("--cached")) return gitChild(0, "index.html");
+      if (args.includes("commit")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const out = await withTimeoutFired(() => lib.commitRunWork(INPUT));
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).toBe("git_failed");
+    expect((out.detail ?? "").trim()).not.toBe("");
+  });
+
+  it("still reports what git actually said when git actually spoke", async () => {
+    // The other half: a real refusal must keep its real message.
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+      if (args.includes("add")) return gitChild(128, "", "fatal: pathspec did not match");
+      return gitChild(0);
+    });
+
+    const out = await lib.commitRunWork(INPUT);
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).toBe("git_failed");
+    expect(out.detail ?? "").toMatch(/pathspec/);
+  });
+});
+
+describe("GH-01b — an inconclusive repository shape is never acted on", () => {
+  it("does not `git init` inside another repository when the inside-work-tree probe is killed", async () => {
+    // The consequential one. `rev-parse --is-inside-work-tree` returning
+    // non-zero means "no repo here", and the branch below it CREATES one. A
+    // killed probe returns the same null, so reading it as a finding runs
+    // `git init` in a tree somebody else's repository tracks — shadowing that
+    // subtree's history and committing into it.
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return gitChild(0, "/home/clawbox/clawbox");
+      if (args.includes("--is-inside-work-tree")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const out = await withTimeoutFired(() => lib.commitRunWork(INPUT));
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).toBe("git_failed");
+    expect((out.detail ?? "").trim()).not.toBe("");
+    // The point of the test: nothing was created.
+    expect(ranInit()).toBe(false);
+  });
+
+  it("does not claim the folder belongs to another repository when check-ignore is killed", async () => {
+    // The mirror lie. A killed `check-ignore` was read as "not ignored", which
+    // with an enclosing repo produces the refusal message about a folder that
+    // may well be ignored and perfectly free to init.
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return gitChild(0, "/home/clawbox/clawbox");
+      if (args.includes("--is-inside-work-tree")) return gitChild(0, "true");
+      if (args.includes("check-ignore")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const out = await withTimeoutFired(() => lib.commitRunWork(INPUT));
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).not.toBe("foreign_repo");
+    expect(out.detail ?? "").not.toMatch(/belongs to another git repository/i);
+    expect(ranInit()).toBe(false);
+  });
+
+  it("does not `git init` when the repo-root probe itself is killed", async () => {
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const out = await withTimeoutFired(() => lib.commitRunWork(INPUT));
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).toBe("git_failed");
+    expect((out.detail ?? "").trim()).not.toBe("");
+    expect(ranInit()).toBe(false);
+  });
+
+  it("still REFUSES a folder an enclosing repository really does track", async () => {
+    // The rule itself must survive the fix: real findings still decide.
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return gitChild(0, "/home/clawbox/clawbox");
+      if (args.includes("--is-inside-work-tree")) return gitChild(0, "true");
+      if (args.includes("check-ignore")) return gitChild(1);
+      return gitChild(0);
+    });
+
+    const out = await lib.commitRunWork(INPUT);
+
+    expect(out.committed).toBe(false);
+    if (out.committed) return;
+    expect(out.reason).toBe("foreign_repo");
+    expect(ranInit()).toBe(false);
+  });
+
+  it("still gives a folder its own repository when the outer tree ignores it", async () => {
+    script((args) => {
+      if (args.includes("--version")) return gitChild(0, "git version 2.43.0");
+      if (args.includes("--show-toplevel")) return gitChild(0, "/home/clawbox/clawbox");
+      if (args.includes("--is-inside-work-tree")) return gitChild(0, "true");
+      if (args.includes("check-ignore")) return gitChild(0);
+      if (args.includes("--cached")) return gitChild(0, "index.html");
+      if (args.includes("--short")) return gitChild(0, "abc1234");
+      return gitChild(0);
+    });
+
+    const out = await lib.commitRunWork(INPUT);
+
+    expect(out.committed).toBe(true);
+    if (!out.committed) return;
+    expect(out.initialized).toBe(true);
+    expect(ranInit()).toBe(true);
+  });
+});

--- a/src/tests/unit/coding-github-transient.test.ts
+++ b/src/tests/unit/coding-github-transient.test.ts
@@ -1,0 +1,236 @@
+/**
+ * GH-01c. #518 classified a dead uplink as a retryable fault — "a network that
+ * is merely down gets 503, retry; 409 is for a request that cannot be
+ * satisfied as it stands" — and wired `gh_unreachable` from githubStatus()
+ * through backupToGitHub() to the route.
+ *
+ * It applied that only to the PROBE. The two calls that actually reach
+ * github.com are `gh repo create --push` and `git push --set-upstream`, both on
+ * the 180 s PUSH_TIMEOUT_MS, and both still answered `reason: "failed"` when
+ * their child was killed — even though the very detail they attach reads
+ * "Check this ClawBox's network connection and try again." reason "failed" is
+ * not "gh_unreachable", so the route's ternary returned 409: a non-retryable
+ * client error whose own text tells the owner to retry.
+ *
+ * The four killed LOCAL git probes have the same problem one step earlier: a
+ * `git rev-parse` that our timer killed is a transient fault too, and 409 says
+ * the request is wrong when nothing about it is.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import path from "path";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ spawn: spawnMock }));
+
+type Lib = typeof import("@/lib/coding-github");
+let lib: Lib;
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: (signal: NodeJS.Signals) => boolean;
+}
+
+function baseChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => true;
+  return child;
+}
+
+/** A call that hangs on a dead uplink until our timer kills it. */
+function hangingChild(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => child.emit("spawn"));
+  child.kill = (signal) => {
+    setImmediate(() => child.emit("close", null, signal));
+    return true;
+  };
+  return child;
+}
+
+function exitingChild(code: number, text = ""): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("spawn");
+    if (text) child.stderr.emit("data", Buffer.from(text));
+    child.emit("close", code, null);
+  });
+  return child;
+}
+
+function gitChild(code: number, text = "", errText = ""): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("spawn");
+    if (text) child.stdout.emit("data", Buffer.from(text));
+    if (errText) child.stderr.emit("data", Buffer.from(errText));
+    child.emit("close", code, null);
+  });
+  return child;
+}
+
+/** Clear the LONGEST budget in the module — pushes get 180 s, not 60. */
+async function withTimeoutFired<T>(work: () => Promise<T>): Promise<T> {
+  vi.useFakeTimers();
+  try {
+    const promise = work();
+    await vi.advanceTimersByTimeAsync(400_000);
+    return await promise;
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+const CONNECTED = "Logged in to github.com as yalexx (/home/clawbox/.config/gh/hosts.yml)\n";
+const DIR = "/home/clawbox/Projects/site";
+const TOPLEVEL = path.resolve(DIR);
+
+function script(answer: (bin: string, args: string[]) => FakeChild): void {
+  spawnMock.mockImplementation((bin: string, args: string[]) => answer(bin, args));
+}
+
+/** Everything up to and including the remote lookup answers normally. */
+function upToRemote(bin: string, args: string[], remote: FakeChild | null): FakeChild | null {
+  if (bin === "gh" && args[0] === "auth") return exitingChild(0, CONNECTED);
+  if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+  if (args.includes("--verify")) return gitChild(0, "abc123");
+  if (args.includes("--abbrev-ref")) return gitChild(0, "main");
+  if (args.includes("get-url")) return remote;
+  return null;
+}
+
+beforeEach(async () => {
+  spawnMock.mockReset();
+  vi.resetModules();
+  lib = await import("@/lib/coding-github");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("a network fault on the calls that reach github.com is reported as one", () => {
+  it("answers gh_unreachable when `gh repo create` is killed", async () => {
+    // No remote yet, so the create branch runs — and hangs on the uplink.
+    script((bin, args) => {
+      const early = upToRemote(bin, args, gitChild(1));
+      if (early) return early;
+      if (bin === "gh" && args[0] === "repo") return hangingChild();
+      return gitChild(0);
+    });
+
+    const outcome = await withTimeoutFired(() => lib.backupToGitHub(DIR));
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    // The detail already says "check the network and try again". The reason
+    // has to agree, or the route answers 409 to its own retry advice.
+    expect(outcome.reason).toBe("gh_unreachable");
+    expect(outcome.detail ?? "").toMatch(/network|timed out/i);
+  });
+
+  it("answers gh_unreachable when `git push` is killed", async () => {
+    script((bin, args) => {
+      const early = upToRemote(bin, args, gitChild(0, "git@github.com:me/site.git"));
+      if (early) return early;
+      if (args.includes("push")) return hangingChild();
+      return gitChild(0);
+    });
+
+    const outcome = await withTimeoutFired(() => lib.backupToGitHub(DIR));
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("gh_unreachable");
+    expect(outcome.detail ?? "").toMatch(/push/i);
+  });
+
+  it("still answers `failed` when GitHub itself refused the create", async () => {
+    // The discriminator: a real refusal from a reachable GitHub is NOT
+    // transient, and must keep answering 409 with what gh said.
+    script((bin, args) => {
+      const early = upToRemote(bin, args, gitChild(1));
+      if (early) return early;
+      if (bin === "gh" && args[0] === "repo") return exitingChild(1, "GraphQL: Name already exists on this account");
+      return gitChild(0);
+    });
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("failed");
+    expect(outcome.transient).toBeFalsy();
+    expect(outcome.detail ?? "").toMatch(/already exists/i);
+  });
+
+  it("still answers `failed` when the remote rejected the push", async () => {
+    script((bin, args) => {
+      const early = upToRemote(bin, args, gitChild(0, "git@github.com:me/site.git"));
+      if (early) return early;
+      if (args.includes("push")) return gitChild(1, "", "! [rejected] main -> main (fetch first)");
+      return gitChild(0);
+    });
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("failed");
+    expect(outcome.transient).toBeFalsy();
+    expect(outcome.detail ?? "").toMatch(/rejected/i);
+  });
+});
+
+/**
+ * The four local probes. Each already refuses to invent a finding (#518); what
+ * they did not do is say the refusal was transient, so the owner got a 409 —
+ * "your request is wrong" — for a git call our own timer killed.
+ */
+describe("a killed local git probe is reported as transient", () => {
+  const cases: { name: string; hang: (args: string[]) => boolean; remote: number }[] = [
+    { name: "the repo-root probe", hang: (a) => a.includes("--show-toplevel"), remote: 0 },
+    { name: "the commit probe", hang: (a) => a.includes("--verify"), remote: 0 },
+    { name: "the branch probe", hang: (a) => a.includes("--abbrev-ref"), remote: 0 },
+    { name: "the remote probe", hang: (a) => a.includes("get-url"), remote: 0 },
+  ];
+
+  for (const c of cases) {
+    it(`marks ${c.name} transient so the route can answer 503`, async () => {
+      script((bin, args) => {
+        if (bin === "gh" && args[0] === "auth") return exitingChild(0, CONNECTED);
+        if (c.hang(args)) return hangingChild();
+        if (args.includes("--show-toplevel")) return gitChild(0, TOPLEVEL);
+        if (args.includes("--verify")) return gitChild(0, "abc123");
+        if (args.includes("--abbrev-ref")) return gitChild(0, "main");
+        if (args.includes("get-url")) return gitChild(c.remote, "git@github.com:me/site.git");
+        return gitChild(0);
+      });
+
+      const outcome = await withTimeoutFired(() => lib.backupToGitHub(DIR));
+
+      expect(outcome.pushed).toBe(false);
+      if (outcome.pushed) return;
+      expect(outcome.transient).toBe(true);
+      expect((outcome.detail ?? "").trim()).not.toBe("");
+    });
+  }
+
+  it("does not mark a genuine `not a repo` transient", async () => {
+    script((bin, args) => {
+      if (bin === "gh" && args[0] === "auth") return exitingChild(0, CONNECTED);
+      if (args.includes("--show-toplevel")) return gitChild(128, "");
+      return gitChild(0);
+    });
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("not_a_repo");
+    expect(outcome.transient).toBeFalsy();
+  });
+});

--- a/src/tests/unit/coding-github-transient.test.ts
+++ b/src/tests/unit/coding-github-transient.test.ts
@@ -61,6 +61,16 @@ function exitingChild(code: number, text = ""): FakeChild {
   return child;
 }
 
+/** A spawn that failed and did not say why — an `error` with no errno. */
+function errnoLessFailure(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", new Error("spawn failed"));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
 function gitChild(code: number, text = "", errText = ""): FakeChild {
   const child = baseChild();
   setImmediate(() => {
@@ -218,6 +228,42 @@ describe("a killed local git probe is reported as transient", () => {
       expect((outcome.detail ?? "").trim()).not.toBe("");
     });
   }
+
+  it("does not call gh MISSING when the spawn failed with no errno", async () => {
+    // Raised in review on this PR: `startError === null` was folded in with
+    // ENOENT, so a spawn error that named no reason answered "not installed"
+    // — the wrong remedy, drawn from no evidence at all.
+    spawnMock.mockImplementation(() => errnoLessFailure());
+
+    const status = await lib.githubStatus();
+
+    expect(status.reason).not.toBe("not_installed");
+    expect(status.connected).toBe(false);
+
+    const out = await lib.disconnectGitHub();
+    expect(out.ok).toBe(false);
+    expect(out.kind).not.toBe("no_gh");
+    expect(out.detail ?? "").not.toMatch(/is not installed/i);
+    expect(out.detail ?? "").toMatch(/would not start/i);
+    expect(out.detail ?? "").not.toMatch(/\(null\)|\(undefined\)/);
+  });
+
+  it("still calls gh MISSING for a real ENOENT", async () => {
+    // The discriminator: tightening the rule must not lose the true case.
+    spawnMock.mockImplementation(() => {
+      const child = baseChild();
+      setImmediate(() => {
+        child.emit("error", Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }));
+        child.emit("close", null, null);
+      });
+      return child;
+    });
+
+    const status = await lib.githubStatus();
+
+    expect(status.installed).toBe(false);
+    expect(status.reason).toBe("not_installed");
+  });
 
   it("does not mark a genuine `not a repo` transient", async () => {
     script((bin, args) => {

--- a/src/tests/unit/coding-github-unreachable.test.ts
+++ b/src/tests/unit/coding-github-unreachable.test.ts
@@ -454,7 +454,10 @@ describe("a killed git probe is never read as an answer", () => {
 
     expect(outcome.pushed).toBe(false);
     if (outcome.pushed) return;
-    expect(outcome.reason).toBe("failed");
+    // GH-01c: the reason used to be "failed", which the route answers 409 —
+    // a non-retryable client error attached to a detail that says "check the
+    // network and try again". A push killed on the uplink is the network.
+    expect(outcome.reason).toBe("gh_unreachable");
     expect((outcome.detail ?? "").trim()).not.toBe("");
     expect(outcome.detail ?? "").toMatch(/push/i);
   });


### PR DESCRIPTION
Follow-up to #518. Four residuals, all reproduced against the merged beta head (`cd90857`) before anything was written.

#518's subject was a single conflation: `code === null` cannot tell *never started* from *started and was killed*, and a spawn `error` is not proof a binary is missing — ENOENT means absent, EACCES means present with the wrong mode bits, and the remedies are opposites. That lesson was applied to **one of two identical wrappers**, to the **probe** and not to the **work**, and to **one of three** reasons the card can receive.

## What was wrong, and what it did to an owner

### GH-01a — `src/lib/coding-git.ts` was the unfixed twin (customer-facing)

`git()` at line 73 was a byte-for-byte copy of the pre-#518 wrapper: no `spawn` listener, no `signal`, no `timedOut`, no `startError`; `child.on("error")` resolved `{code: null}` for every error including a post-spawn one. So line 170 —

```ts
const probe = await git(dir, ["--version"]);
if (probe.code === null) return { committed: false, reason: "no_git" };
```

— is the exact statement #518 deleted from `githubStatus()`. A git present but not executable was reported as "git is not installed", the one remedy that cannot help it.

The blank was worse. A SIGKILLed child writes no stderr, so lines 186/197 returned `detail: ""`, and `src/lib/coding-agent.ts:1674` renders:

```ts
pushProgress(run, `Not committed: ${outcome.detail ?? outcome.reason}`);
```

`""` is not nullish. The run panel showed the owner literally **`Not committed: `** and stopped there. 30 s `GIT_TIMEOUT_MS` on `git add -A` over a large project on eMMC is not a hypothetical. `killedDetail()` exists in `coding-github.ts` precisely to stop that blank; this module never got it.

### GH-01b — a killed repo-shape probe downgraded the `foreign_repo` refusal into `git init` in someone else's tree (customer-facing)

#518 named the consequential form of this class in its own comment: *"A killed probe returns the same null code, so reading it as 'no remote' would create a second repository for a folder that already has one — an irreversible guess made from a transient fault."* The identical shape was unguarded in the twin: `isOwnRepoRoot` (108), `insideSomeRepo` (123) and `ignoredByOuterRepo` (117) each returned `false` for a null code.

The rule this file's own header calls non-negotiable — *"inside a repo that TRACKS it → refuse. That is someone else's working tree and a run has no business committing to it"* — is enforced by one line:

```ts
if ((await insideSomeRepo(dir)) && !(await ignoredByOuterRepo(dir))) { /* refuse */ }
```

so a single killed `rev-parse --is-inside-work-tree` turned that refusal into `initRepo(dir)`: `git init` inside a tree somebody else's repository tracks, shadowing that subtree's history, then committing into it. The mirror case — a killed `check-ignore` — produced the opposite false claim, "The folder belongs to another git repository", about a folder that does not.

The three probes are now tri-state (`{known: true, value} | {known: false, result}`), and an unknown shape aborts with a real detail. **`git init` is never run on an inconclusive probe.** An unknown repository shape is not an absent one.

### GH-01c — the two calls that actually reach github.com still answered 409 (customer-facing)

#518 introduced the classification *"a network that is merely down gets 503, retry — 409 is for a request that cannot be satisfied as it stands"* and wired `gh_unreachable` through to `src/app/setup-api/coding-agent/git/route.ts:92`. It applied the new reason **only to the probe**. `gh repo create --push` (363) and `git push --set-upstream` (383), both on the 180 s `PUSH_TIMEOUT_MS`, still returned `reason: "failed"` when `wasKilled()` was true — while attaching a detail that reads *"Creating the repository on GitHub timed out. Check this ClawBox's network connection and try again."* `"failed"` is not `"gh_unreachable"`, so the route's ternary answered **409**: a non-retryable client error whose own body tells the owner to retry.

Both killed branches now return `gh_unreachable` (503) and keep the `killedDetail` text. A *genuine* refusal from a reachable GitHub — a name already taken, a rejected push — still returns `"failed"` and still gets 409; there are tests for both halves.

The four killed **local** git probes (314/325/335/346) had the same problem one layer down: they correctly refuse to invent a finding, but "failed" made the route call a `rev-parse` our own timer killed a malformed request. They now carry `transient: true` on a new optional `BackupOutcome` member, and the route reads `reason === "gh_unreachable" || outcome.transient === true`.

### GH-01d — `CodingAgentApp` declared `not_runnable` and branched only on `unreachable` (customer-facing)

#518 added all three reasons to `GitHubState` at line 46 and then branched on one. `githubStatus()` answers `{installed: true, reason: "not_runnable"}` for an EACCES gh, so the card rendered (it is gated on `installed`), said `codingAgent.githubOff` — "not connected" — and offered **Connect**, which opens a terminal on `gh auth login`: the remedy the library layer explicitly refuses to suggest (*"Installing it again fixes nothing; the remedy is permissions"*). `backupToGitHub` and `disconnectGitHub` both got a not_runnable message; the surface the owner actually looks at did not.

There is now a `not_runnable` arm with a new `codingAgent.githubNotRunnable` string in **all ten catalogues** (en + bg/de/es/fr/it/ja/nl/sv/zh — `hermes-translations.test.ts` holds `codingAgent.*` to per-locale copy, not an English fallback), and the Connect button is not rendered for that reason.

## Fixing the class, not the four instances

The shape that produced all of this is *two copies of one wrapper, one of them fixed*. So the wrapper is now singular: `src/lib/child-run.ts` holds `ChildResult`, `runChild()`, the `spawn` listener, `wasKilled()`, `inconclusive()`, `startedMissing()` (the ENOENT/EACCES split), `killedDetail()` and a never-blank `failureDetail()`. `coding-git.ts` and `coding-github.ts` both call it; the duplicated ENOENT test inside `githubStatus()` and `disconnectGitHub()` is now the shared `startedMissing()`.

**How I know I found every sibling.** Three greps, all over production code only (`| grep -v /tests/`):

```
$ grep -rn 'code === null\|code == null' src/ mcp/ scripts/*.ts | grep -v /tests/
src/lib/child-run.ts:110:  return !r.startFailed && r.code === null;      # the wrapper itself
src/lib/coding-git.ts:206:  if (probe.code === null) {                    # the explicit killed-probe guard
```
Nothing else in the codebase reads a null exit code as a fact any more; every other reader goes through `wasKilled`/`inconclusive`.

```
$ grep -rn 'spawn("git"\|spawn("gh"' src/ mcp/ | grep -v /tests/
(no output)

$ grep -rn 'runChild(' src/ mcp/ | grep -v /tests/
src/lib/child-run.ts:63    src/lib/coding-git.ts:81    src/lib/coding-github.ts:124
```
Exactly two callers and the helper. There is no third copy left to drift out of step.

I also checked the one other place that claims a binary is not installed — `src/lib/coding-agent.ts:701`, "Claude Code is not installed on this ClawBox". It is **not** an instance of this class: it resolves through `isExecutableFile()`, a filesystem stat plus the executable bit, never a spawn exit code. Left alone deliberately.

## Tests: red first

Every assertion below was proven to fail against unmodified `origin/beta` before the fix was written.

| File | RED on beta | GREEN after |
|---|---|---|
| `src/tests/unit/coding-git-killed-probe.test.ts` (new) | 8 failed / 3 passed | 11 passed |
| `src/tests/unit/coding-github-transient.test.ts` (new) | 6 failed / 3 passed | 9 passed |
| `src/tests/routes/coding-agent/git-transient.test.ts` (new) | 1 failed / 3 passed | 4 passed |
| `src/tests/components/coding-agent-github-card.test.tsx` (new) | 3 failed / 3 passed | 6 passed |
| **total** | **18 red** | **30 green** |

The three tests that passed in each new unit file are the *discriminators* — a genuinely missing binary must still answer `no_git`/`no_gh`, a real refusal must still keep its own message and its 409, a folder an enclosing repo really does track must still be refused. They passed before and after, which is the point: the fix must not buy honesty about killed calls by losing the findings.

One existing assertion changed, in `coding-github-unreachable.test.ts` — "never reports a killed push with a blank message" asserted `reason === "failed"`, which is precisely GH-01c. Its stated purpose (never blank, always mentions the push) is preserved; the reason is now `gh_unreachable`, with a comment saying why.

## Gates

- `npx tsc --noEmit`: **24 errors, identical to the beta baseline**, none in any file this PR touches.
- `npx eslint`: **105 problems (22 errors, 83 warnings), byte-identical to the beta baseline.**
- `src/tests/unit/coding-git.test.ts` (the pre-existing real-git suite) cannot pass on the Windows dev host — it fails 6/8 on unmodified beta too, on git's `safe.directory` ownership check in temp dirs. With this branch it fails 5, i.e. strictly one better. Linux CI is the gate for it.

## Severity, honestly

All four are real and all four are reachable on current hardware — unlike the TTS-01 residuals, none of these is gated behind a non-aarch64 check. GH-01b is the one I would fix first even alone: every other item here produces a *wrong message*, but GH-01b writes to a repository that is not ours.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GitHub and Git backup status handling, including clearer distinction between unavailable and non-runnable command-line tools.
  * Added retryable handling for temporary network interruptions and timeouts.
  * Added clearer diagnostic messages for Git and GitHub operation failures.
  * Added translated messaging for non-runnable GitHub CLI installations across supported languages.

* **Bug Fixes**
  * Prevented uncertain repository checks from triggering unsafe initialization or incorrect repository decisions.
  * Connect and reconnect actions are now hidden when the GitHub CLI cannot be launched.

* **Tests**
  * Expanded coverage for interrupted commands, timeouts, permissions, repository safeguards, and retryable backup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->