### PR TITLE
fix: share one interpreter per config read, and let a placeholder say so

### DIFF
--- a/src/app/setup-api/chat/capabilities/route.ts
+++ b/src/app/setup-api/chat/capabilities/route.ts
@@ -3,9 +3,13 @@ import { getActiveHarness } from "@/lib/harness";
 import { hasClawaiToken } from "@/lib/harness/credentials";
 import type { HarnessFacts } from "@/lib/harness/capabilities";
 import {
+  HERMES_FACT_RETRY_MS,
   hermesAgentDrawsImages,
+  hermesFeatureProbePending,
   hermesHasVisionRoute,
+  hermesImageBackendPending,
   hermesSupportsImages,
+  hermesVisionRoutePending,
 } from "@/lib/harness/hermes-features";
 import { clawaiImageRouteReachable } from "@/lib/harness/clawai-images";
 import { hermesCanStreamTurns } from "@/lib/hermes-dashboard-turn";
@@ -78,5 +82,36 @@ export async function GET() {
     // installed there at all.
     hermesAgentDrawsImages: harness === "hermes" ? await hermesAgentDrawsImages() : false,
   };
-  return NextResponse.json({ harness, facts });
+  // Which of those `false`s is an ANSWER, and which is a placeholder the server
+  // has already undertaken to replace by itself.
+  //
+  // Every Hermes fact above fails closed, so "this box cannot" and "this box
+  // could not say" leave by the same door — correct for the composer, because a
+  // wrong `true` stages the customer's file into a turn that ignores it, but it
+  // stranded the browser. `use-harness-adapter` fetches this once on mount and
+  // re-asks only on an explicit provider change, on no timer, so one probe
+  // timeout during chat open hid the attach button for the entire page session
+  // while the memos behind these facts recovered a minute later. Saying so lets
+  // the page come back for the real answer instead of waiting for a reload.
+  //
+  // Asked ONLY on Hermes, and only after the awaits above: these accessors read
+  // the memos without touching them, so on an OpenClaw box — where none of the
+  // probes ran — an entry left over from an earlier harness must not put that
+  // page on a timer for a fact no OpenClaw capability reads.
+  //
+  // `hasClawaiImageRoute` is deliberately NOT counted. Its probe caches a plain
+  // `false` for a minute whether the proxy answered "no" or did not answer at
+  // all — it draws no answer/failure distinction to report — so folding it in
+  // would mean claiming a precision that module does not have.
+  const factsPending =
+    harness === "hermes" &&
+    (hermesFeatureProbePending() || hermesVisionRoutePending() || hermesImageBackendPending());
+  return NextResponse.json({
+    harness,
+    facts,
+    factsPending,
+    // Published rather than duplicated in the browser, so the wait and the
+    // backoff it is waiting on cannot drift apart.
+    factsRetryAfterMs: HERMES_FACT_RETRY_MS,
+  });
 }

--- a/src/lib/harness/hermes-features.ts
+++ b/src/lib/harness/hermes-features.ts
@@ -1,5 +1,9 @@
 import { runHermesCli } from "@/lib/hermes-cli";
-import { hermesConfigGet } from "@/lib/hermes-config-cache";
+import {
+  FAILED_READ_TTL_MS,
+  hermesConfigGet,
+  hermesConfigReadPending,
+} from "@/lib/hermes-config-cache";
 
 /**
  * What the INSTALLED `hermes` can do — asked, not assumed. SERVER ONLY.
@@ -25,7 +29,7 @@ const PROBE_TIMEOUT_MS = 30_000;
  * button back inside a minute rather than at the next restart. Matches
  * `PROBE_TTL_FAIL_MS` next door in `clawai-images`.
  */
-const PROBE_RETRY_BACKOFF_MS = 60_000;
+export const PROBE_RETRY_BACKOFF_MS = 60_000;
 
 /**
  * Once per process, never per request — for an ANSWER.
@@ -109,6 +113,40 @@ export function resetHermesFeatureProbe(): void {
 }
 
 /**
+ * How long a page should wait before re-asking for a fact that is still a
+ * placeholder.
+ *
+ * Published rather than duplicated in the browser. Both memos behind these
+ * facts hold a failed read for their own backoff, and the longer of the two is
+ * the only delay after which BOTH have given up and will genuinely re-ask; a
+ * client that guessed the number would poll early on the shorter one and go
+ * stale if either constant were ever changed here.
+ */
+export const HERMES_FACT_RETRY_MS = Math.max(PROBE_RETRY_BACKOFF_MS, FAILED_READ_TTL_MS);
+
+/**
+ * Is the `--image` answer above a real one, or a placeholder held for the
+ * backoff?
+ *
+ * Every probe in this file fails CLOSED, which is right — a wrong `true` costs
+ * the customer's file — but it means "the box cannot do this" and "the box
+ * could not answer" both leave as `false`, and the browser was told only the
+ * `false`. It fetches these facts once on mount and re-asks solely on an
+ * explicit provider change, on no timer, so a single 30 s timeout during chat
+ * open hid the attach button for the entire page session while this module
+ * recovered by itself a minute later. The unknown-ness has to travel with the
+ * fact for that recovery to reach anybody.
+ *
+ * Reads the memo WITHOUT touching it: asking whether a fact is settled must not
+ * itself start a Python interpreter.
+ */
+export function hermesFeatureProbePending(): boolean {
+  // An answered probe is stamped `Infinity`. Anything finite is a failure being
+  // held for the backoff, or a probe still in flight — both are "ask again".
+  return probe !== null && probe.expiresAt !== Number.POSITIVE_INFINITY;
+}
+
+/**
  * The config key that names the model an attached picture is actually LOOKED AT
  * with. Written by `applyClawaiToHermes`; empty on a box nobody has linked.
  */
@@ -178,6 +216,17 @@ export async function hermesHasVisionRoute(): Promise<boolean> {
 }
 
 /**
+ * Same question as `hermesFeatureProbePending`, for the vision route.
+ *
+ * The key name stays private to this module: callers ask "is this FACT still a
+ * placeholder", not "is `auxiliary.vision.model` in backoff", so the route
+ * never has to know which config key answers which capability.
+ */
+export function hermesVisionRoutePending(): boolean {
+  return hermesConfigReadPending(VISION_MODEL_KEY);
+}
+
+/**
  * The config key that names the backend a drawing request is serviced BY.
  *
  * `image_gen.provider` is what `agent/image_gen_registry.get_active_provider()`
@@ -232,4 +281,9 @@ export async function hermesAgentDrawsImages(): Promise<boolean> {
     // braces — and it fails closed for the same reason the rest of this file does.
     return false;
   }
+}
+
+/** Same question again, for the agent's image backend. See above. */
+export function hermesImageBackendPending(): boolean {
+  return hermesConfigReadPending(IMAGE_PROVIDER_KEY);
 }

--- a/src/lib/harness/use-harness-adapter.ts
+++ b/src/lib/harness/use-harness-adapter.ts
@@ -206,6 +206,25 @@ export function useHarnessAdapter(wiring: HarnessWiring): UseHarnessAdapterResul
       void (async () => {
         const probed = await fetchFacts(controller.signal);
         if (controller.signal.aborted) return;
+        if (!probed) {
+          // A re-ask that did not answer is not an answer either. Abandoning
+          // the chase here would reinstate the very bug this effect removes —
+          // the placeholder `false` kept for the whole page session because one
+          // round trip happened to land during a restart or a blip. Rescheduled
+          // under the SAME cap, and with the delay the server last published,
+          // so a box that cannot answer at all still stops after two.
+          //
+          // Handled here rather than in `applyFacts` on purpose: this is the
+          // only caller that is already chasing something. The mount fetch and
+          // the provider-change reprobe both treat a failed request as "keep
+          // the cautious defaults and wait", which is unchanged.
+          setFactsRetry(
+            factsRetry.attempt < MAX_PENDING_RETRIES
+              ? { delayMs: factsRetry.delayMs, attempt: factsRetry.attempt + 1 }
+              : null,
+          );
+          return;
+        }
         applyFacts(probed, factsRetry.attempt);
       })();
     }, factsRetry.delayMs + RETRY_MARGIN_MS);

--- a/src/lib/harness/use-harness-adapter.ts
+++ b/src/lib/harness/use-harness-adapter.ts
@@ -52,18 +52,66 @@ export interface UseHarnessAdapterResult {
   resolved: boolean;
 }
 
-async function fetchFacts(signal?: AbortSignal): Promise<HarnessFacts | null> {
+/**
+ * How many times a still-pending answer is chased before the page gives up.
+ *
+ * Capped rather than repeated, because the point of the server's backoff is to
+ * stop a broken `hermes` costing a Python interpreter per request — a browser
+ * that re-asked on a loop would reintroduce exactly that from the other side.
+ * Two covers a box that was merely busy, which is the case this exists for; a
+ * box still silent after that is broken, and the customer keeps the honest
+ * hidden control until they reload or change something.
+ */
+const MAX_PENDING_RETRIES = 2;
+
+/**
+ * A little past the server's own backoff, never bang on it.
+ *
+ * The server publishes the delay it intends to hold a failed read for, and an
+ * exactly-on-time re-ask would land while that entry is still live and be
+ * served the same placeholder — spending a round trip to learn nothing.
+ */
+const RETRY_MARGIN_MS = 2_000;
+
+/** Only reached if a box claims `factsPending` without naming a delay. */
+const DEFAULT_RETRY_AFTER_MS = 60_000;
+
+interface ProbedFacts {
+  facts: HarnessFacts;
+  /**
+   * At least one fact came from a backoff entry rather than an answer, so the
+   * `false` in it is a placeholder the box will replace by itself.
+   */
+  pending: boolean;
+  /** How long the server says it will hold that placeholder for. */
+  retryAfterMs: number;
+}
+
+async function fetchFacts(signal?: AbortSignal): Promise<ProbedFacts | null> {
   try {
     const res = await fetch("/setup-api/chat/capabilities", { cache: "no-store", signal });
     if (!res.ok) return null;
-    const data = (await res.json()) as { facts?: Partial<HarnessFacts> };
+    const data = (await res.json()) as {
+      facts?: Partial<HarnessFacts>;
+      factsPending?: unknown;
+      factsRetryAfterMs?: unknown;
+    };
     return {
-      hasClawaiToken: data.facts?.hasClawaiToken === true,
-      hermesSupportsImages: data.facts?.hermesSupportsImages === true,
-      hermesHasVisionRoute: data.facts?.hermesHasVisionRoute === true,
-      hermesStreamsTurns: data.facts?.hermesStreamsTurns === true,
-      hasClawaiImageRoute: data.facts?.hasClawaiImageRoute === true,
-      hermesAgentDrawsImages: data.facts?.hermesAgentDrawsImages === true,
+      facts: {
+        hasClawaiToken: data.facts?.hasClawaiToken === true,
+        hermesSupportsImages: data.facts?.hermesSupportsImages === true,
+        hermesHasVisionRoute: data.facts?.hermesHasVisionRoute === true,
+        hermesStreamsTurns: data.facts?.hermesStreamsTurns === true,
+        hasClawaiImageRoute: data.facts?.hasClawaiImageRoute === true,
+        hermesAgentDrawsImages: data.facts?.hermesAgentDrawsImages === true,
+      },
+      // A box too old to send the field is not pending, it is simply not
+      // saying — which is the pre-existing behaviour, unchanged.
+      pending: data.factsPending === true,
+      retryAfterMs:
+        typeof data.factsRetryAfterMs === "number" && data.factsRetryAfterMs > 0
+          ? data.factsRetryAfterMs
+          : DEFAULT_RETRY_AFTER_MS,
     };
   } catch {
     // A box that cannot answer keeps the cautious defaults: a hidden control
@@ -76,6 +124,32 @@ export function useHarnessAdapter(wiring: HarnessWiring): UseHarnessAdapterResul
   const [harnessId, setHarnessId] = useState<HarnessId>("openclaw");
   const [facts, setFacts] = useState<HarnessFacts>(UNKNOWN_FACTS);
   const [resolved, setResolved] = useState(false);
+  /**
+   * The one scheduled re-ask, or null when nothing is outstanding.
+   *
+   * A fresh object each time it is set, so the effect below re-arms on every
+   * pending answer. `attempt` rides in the state rather than in a ref so the
+   * cap cannot be lost to a re-render, and so the effect's dependency is the
+   * whole decision rather than half of it.
+   */
+  const [factsRetry, setFactsRetry] = useState<{ delayMs: number; attempt: number } | null>(null);
+
+  /**
+   * Apply a fetched answer, and decide whether to come back for a better one.
+   *
+   * `attempt` is how many chased re-asks already produced THIS answer, so a
+   * provider change — a fresh cause, and one the customer is watching — starts
+   * the count over at zero, while a chased retry carries it forward.
+   */
+  const applyFacts = useCallback((probed: ProbedFacts | null, attempt: number) => {
+    if (!probed) return;
+    setFacts((prev) => (sameFacts(prev, probed.facts) ? prev : probed.facts));
+    setFactsRetry(
+      probed.pending && attempt < MAX_PENDING_RETRIES
+        ? { delayMs: probed.retryAfterMs, attempt: attempt + 1 }
+        : null,
+    );
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -86,25 +160,62 @@ export function useHarnessAdapter(wiring: HarnessWiring): UseHarnessAdapterResul
       ]);
       if (controller.signal.aborted) return;
       if (harness?.active === "hermes") setHarnessId("hermes");
-      if (probed) setFacts(probed);
+      applyFacts(probed, 0);
       setResolved(true);
     })();
     return () => controller.abort();
-  }, []);
+  }, [applyFacts]);
 
   // A capability computed from a credential goes stale the moment the customer
   // links ClawBox AI in Settings — without this the microphone would stay
   // hidden until the page was reloaded, on a box that can now transcribe.
   const reprobe = useCallback(() => {
     void (async () => {
-      const probed = await fetchFacts();
-      if (probed) setFacts((prev) => (sameFacts(prev, probed) ? prev : probed));
+      applyFacts(await fetchFacts(), 0);
     })();
-  }, []);
+  }, [applyFacts]);
   // One subscription over every name that means "providers changed", so a
   // capability computed from a credential cannot stay stale merely because the
   // component that connected the provider spoke the other harness's dialect.
   useEffect(() => onProvidersChanged(reprobe), [reprobe]);
+
+  /**
+   * Come back for a fact the box admitted was still a placeholder.
+   *
+   * THE SECOND CACHE over the same fact is this page. The server stopped
+   * remembering a failed probe as a negative answer so that a box which was
+   * merely busy "gets its attach button back inside a minute rather than at the
+   * next restart" — but these facts are fetched once, on mount, and the only
+   * other trigger is an explicit provider change, which fires on no timer. A
+   * response that SUCCEEDS while the server-side probe is in backoff carries a
+   * perfectly legitimate-looking `false`, indistinguishable from a real
+   * negative, so the recovery the server performed a minute later never reached
+   * the customer: the composer's attach button stayed hidden for the whole page
+   * session, until a reload or a Settings change.
+   *
+   * Bounded at both ends. It waits out the delay the server itself published,
+   * so it cannot poll a busy Jetson; and it stops after `MAX_PENDING_RETRIES`,
+   * so a genuinely broken box is not asked for the life of the tab — that is
+   * the very cost the server-side backoff exists to avoid, and it would be an
+   * empty fix to reintroduce it from the browser.
+   */
+  useEffect(() => {
+    if (!factsRetry) return;
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      void (async () => {
+        const probed = await fetchFacts(controller.signal);
+        if (controller.signal.aborted) return;
+        applyFacts(probed, factsRetry.attempt);
+      })();
+    }, factsRetry.delayMs + RETRY_MARGIN_MS);
+    return () => {
+      // Both halves matter: the timer may not have fired yet, and if it has,
+      // the fetch it started is a setState aimed at a tree that is going away.
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [factsRetry, applyFacts]);
 
   const capabilities = useMemo(() => capabilitiesFor(harnessId, facts), [harnessId, facts]);
 

--- a/src/lib/hermes-config-cache.ts
+++ b/src/lib/hermes-config-cache.ts
@@ -43,7 +43,7 @@ const CONFIG_PATH = path.join(
  * the exact cost this module exists to avoid, so it is held briefly and then
  * re-asked. Matches `PROBE_TTL_FAIL_MS` next door in `harness/clawai-images`.
  */
-const FAILED_READ_TTL_MS = 60_000;
+export const FAILED_READ_TTL_MS = 60_000;
 
 /**
  * `expiresAt` is `Infinity` for an answer and a near-future stamp for a failed
@@ -55,8 +55,20 @@ const FAILED_READ_TTL_MS = 60_000;
  * value rather than skipping the cache keeps the comparison below total — the
  * first write to config.yaml turns `null` into a number and invalidates it, the
  * same way any other change to the file does.
+ *
+ * `value` is the in-flight PROMISE, not the settled string, and the entry is put
+ * in the map BEFORE the CLI is awaited. That is the whole of the concurrency
+ * story: callers here are concurrent rather than sequential — the capabilities
+ * route asks two facts on every chat open with no route-level dedup, and
+ * `readCurrentFromCli` issues three reads under one `Promise.all` — so a memo
+ * that only wrote itself after the read settled shared nothing during the read.
+ * With a wedged `hermes` every overlapping request then started its own Python
+ * interpreter for the whole timeout before the backoff entry was ever written,
+ * which is the exact fan-out the backoff exists to prevent. Same shape as
+ * `harness/hermes-features`, which seeds with the backoff and stamps the real
+ * expiry on afterwards.
  */
-type Entry = { mtimeMs: number | null; value: string; expiresAt: number };
+type Entry = { mtimeMs: number | null; value: Promise<string>; expiresAt: number };
 const cache = new Map<string, Entry>();
 
 /** mtime of config.yaml, or null when it doesn't exist yet (fresh device). */
@@ -77,45 +89,85 @@ export async function hermesConfigGet(key: string, timeoutMs = 10_000): Promise<
   const mtime = await configMtime();
   const hit = cache.get(key);
   if (hit && hit.mtimeMs === mtime && Date.now() < hit.expiresAt) return hit.value;
-  let value = "";
-  // Did the CLI ANSWER the question, or did the question fail? Verified on the
-  // live box: an unset key exits 1 with `Config key not set: <key>` on stderr,
-  // so a non-zero exit is the CLI saying "nothing is configured there" — an
-  // answer, and one the mtime correctly invalidates. A child that closed with
-  // no exit code at all was killed by a signal (OOM on a loaded Jetson) and
-  // told us nothing; `runHermesCli` rejects on a timeout, a missing binary and
-  // its own SIGKILL, which likewise tell us nothing about the key.
-  let answered = false;
-  try {
-    const r = await runHermesCli(["config", "get", key], { timeoutMs });
-    answered = typeof r.code === "number";
-    if (r.code === 0) value = r.stdout.trim();
-  } catch {
-    // hermes missing or timed out — fall through with "", uncached.
-  }
-  // An ANSWER is only cached against a real mtime. With no config file there is
-  // nothing to invalidate against, so a `""` kept from before the box was set
-  // up would outlive the first write and we would never notice it.
-  //
-  // A FAILED read is cached either way, because its invalidator is the clock,
-  // not the file — it is held for FAILED_READ_TTL_MS and then re-asked. Storing
-  // it the way an answer is stored was the bug: on a linked box config.yaml is
-  // never written again, so one slow moment removed the composer's attach
-  // button — and the image tools the agent advertises — until the web server
-  // restarted. Skipping it entirely on a box with no config file is the mirror
-  // mistake: a hanging `hermes` would then start a Python interpreter for every
-  // request, which is the cost this module exists to avoid.
-  if (mtime !== null || !answered) {
-    cache.set(key, {
-      mtimeMs: mtime,
-      value,
-      expiresAt: answered ? Number.POSITIVE_INFINITY : Date.now() + FAILED_READ_TTL_MS,
-    });
-  }
-  return value;
+
+  // Seeded with the BACKOFF and published BEFORE the await, so every caller
+  // that arrives while this read is running shares this one interpreter. The
+  // real expiry is stamped on below, once we know whether we got an answer or
+  // a failure. The entry is mutated in place rather than reassigned through
+  // `cache`, so a later read that supersedes it cannot have its bookkeeping
+  // undone by this one finishing late.
+  const entry: Entry = {
+    mtimeMs: mtime,
+    value: Promise.resolve(""),
+    expiresAt: Date.now() + FAILED_READ_TTL_MS,
+  };
+  cache.set(key, entry);
+  entry.value = (async () => {
+    let value = "";
+    // Did the CLI ANSWER the question, or did the question fail? Verified on
+    // the live box: an unset key exits 1 with `Config key not set: <key>` on
+    // stderr, so a non-zero exit is the CLI saying "nothing is configured
+    // there" — an answer, and one the mtime correctly invalidates. A child that
+    // closed with no exit code at all was killed by a signal (OOM on a loaded
+    // Jetson) and told us nothing; `runHermesCli` rejects on a timeout, a
+    // missing binary and its own SIGKILL, which likewise tell us nothing.
+    let answered = false;
+    try {
+      const r = await runHermesCli(["config", "get", key], { timeoutMs });
+      answered = typeof r.code === "number";
+      if (r.code === 0) value = r.stdout.trim();
+    } catch {
+      // hermes missing or timed out — fall through with "".
+    }
+    // An ANSWER is only KEPT against a real mtime. With no config file there is
+    // nothing to invalidate against, so a `""` kept from before the box was set
+    // up would outlive the first write and we would never notice it — the entry
+    // is dropped instead, and only if it is still the live one, so a read that
+    // superseded it mid-flight is not evicted by this one landing late.
+    //
+    // A FAILED read is kept either way, because its invalidator is the clock,
+    // not the file — it is held for FAILED_READ_TTL_MS and then re-asked.
+    // Storing it the way an answer is stored was the bug: on a linked box
+    // config.yaml is never written again, so one slow moment removed the
+    // composer's attach button — and the image tools the agent advertises —
+    // until the web server restarted. Dropping it entirely on a box with no
+    // config file is the mirror mistake: a hanging `hermes` would then start a
+    // Python interpreter for every request, which is the cost this module
+    // exists to avoid.
+    if (!answered) {
+      entry.expiresAt = Date.now() + FAILED_READ_TTL_MS;
+    } else if (mtime === null) {
+      if (cache.get(key) === entry) cache.delete(key);
+    } else {
+      entry.expiresAt = Number.POSITIVE_INFINITY;
+    }
+    return value;
+  })();
+  return entry.value;
 }
 
-/** Read several keys at once, sharing one stat and one mtime comparison. */
+/**
+ * Was the last value served for `key` an ANSWER, or a placeholder?
+ *
+ * The two are the same `""` to a caller — deliberately, because every consumer
+ * of this module fails closed — and that sameness is what stranded the browser.
+ * `/setup-api/chat/capabilities` is fetched once on page load, so a `false`
+ * computed from a read that merely timed out hid the composer's attach button
+ * for the whole session while this module quietly recovered a minute later. The
+ * page needs to know which of the two it was holding in order to come back for
+ * the other, and this is the only place that knows.
+ *
+ * Reads the map WITHOUT touching it: a caller asking whether a fact is settled
+ * must not itself start a `hermes`.
+ */
+export function hermesConfigReadPending(key: string): boolean {
+  const hit = cache.get(key);
+  // An answer is stamped `Infinity`. Anything finite is either a failure being
+  // held for the backoff or a read still in flight — both are "ask me again".
+  return hit !== undefined && hit.expiresAt !== Number.POSITIVE_INFINITY;
+}
+
+/** Read several keys at once. */
 export async function hermesConfigGetMany(
   keys: string[],
   timeoutMs = 10_000,

--- a/src/tests/routes/chat/capabilities-pending.test.ts
+++ b/src/tests/routes/chat/capabilities-pending.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+/**
+ * `/setup-api/chat/capabilities` — and specifically whether it admits that a
+ * fact is still a PLACEHOLDER.
+ *
+ * Every Hermes fact here fails closed, so "the probe could not answer" and "the
+ * answer is no" leave the route by the same door: `false`. That is correct for
+ * the composer — a wrong `true` stages the customer's file into a turn that
+ * ignores it — but it is not the whole truth, and the browser was told only the
+ * `false`. `use-harness-adapter` fetches this once on mount and re-asks solely
+ * on an explicit provider change, on no timer, so one 30 s probe timeout during
+ * chat open hid the attach button for the whole page session while the server
+ * quietly recovered a minute later.
+ *
+ * So the unknown-ness has to travel: `factsPending` says at least one Hermes
+ * fact came from a backoff entry rather than an answer, and `factsRetryAfterMs`
+ * says how long the server intends to hold it — published rather than
+ * duplicated on the client, so the two numbers cannot drift.
+ */
+
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
+vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));
+vi.mock("@/lib/hermes-dashboard-turn", () => ({ hermesCanStreamTurns: vi.fn() }));
+vi.mock("@/lib/harness/hermes-features", () => ({
+  hermesSupportsImages: vi.fn(),
+  hermesHasVisionRoute: vi.fn(),
+  hermesAgentDrawsImages: vi.fn(),
+  hermesFeatureProbePending: vi.fn(),
+  hermesVisionRoutePending: vi.fn(),
+  hermesImageBackendPending: vi.fn(),
+  HERMES_FACT_RETRY_MS: 60_000,
+}));
+
+interface Body {
+  harness: string;
+  facts: Record<string, boolean>;
+  factsPending: boolean;
+  factsRetryAfterMs: number;
+}
+
+let GET: () => Promise<Response>;
+let getActiveHarness: Mock;
+let flagProbePending: Mock;
+let visionPending: Mock;
+let imageBackendPending: Mock;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  ({ getActiveHarness } = (await import("@/lib/harness")) as unknown as {
+    getActiveHarness: Mock;
+  });
+  const credentials = (await import("@/lib/harness/credentials")) as unknown as {
+    hasClawaiToken: Mock;
+  };
+  const images = (await import("@/lib/harness/clawai-images")) as unknown as {
+    clawaiImageRouteReachable: Mock;
+  };
+  const dashboard = (await import("@/lib/hermes-dashboard-turn")) as unknown as {
+    hermesCanStreamTurns: Mock;
+  };
+  const features = (await import("@/lib/harness/hermes-features")) as unknown as {
+    hermesSupportsImages: Mock;
+    hermesHasVisionRoute: Mock;
+    hermesAgentDrawsImages: Mock;
+    hermesFeatureProbePending: Mock;
+    hermesVisionRoutePending: Mock;
+    hermesImageBackendPending: Mock;
+  };
+
+  getActiveHarness.mockResolvedValue("hermes");
+  credentials.hasClawaiToken.mockResolvedValue(false);
+  images.clawaiImageRouteReachable.mockResolvedValue(false);
+  dashboard.hermesCanStreamTurns.mockResolvedValue(false);
+  features.hermesSupportsImages.mockResolvedValue(false);
+  features.hermesHasVisionRoute.mockResolvedValue(false);
+  features.hermesAgentDrawsImages.mockResolvedValue(false);
+  flagProbePending = features.hermesFeatureProbePending;
+  visionPending = features.hermesVisionRoutePending;
+  imageBackendPending = features.hermesImageBackendPending;
+  flagProbePending.mockReturnValue(false);
+  visionPending.mockReturnValue(false);
+  imageBackendPending.mockReturnValue(false);
+
+  ({ GET } = await import("@/app/setup-api/chat/capabilities/route"));
+});
+
+async function body(): Promise<Body> {
+  return (await (await GET()).json()) as Body;
+}
+
+describe("GET /setup-api/chat/capabilities", () => {
+  it("reports nothing pending when every probe answered", async () => {
+    const payload = await body();
+    expect(payload.facts.hermesSupportsImages).toBe(false);
+    expect(payload.factsPending).toBe(false);
+  });
+
+  it("reports pending when the --image flag probe is in backoff", async () => {
+    flagProbePending.mockReturnValue(true);
+    expect((await body()).factsPending).toBe(true);
+  });
+
+  it("reports pending when the vision-route read is in backoff", async () => {
+    visionPending.mockReturnValue(true);
+    expect((await body()).factsPending).toBe(true);
+  });
+
+  it("reports pending when the image-backend read is in backoff", async () => {
+    imageBackendPending.mockReturnValue(true);
+    expect((await body()).factsPending).toBe(true);
+  });
+
+  it("publishes how long the browser should wait before re-asking", async () => {
+    flagProbePending.mockReturnValue(true);
+    expect((await body()).factsRetryAfterMs).toBeGreaterThan(0);
+  });
+
+  it("never reports a Hermes fact as pending on an OpenClaw box", async () => {
+    // The probes are not run there at all, so a stale entry left behind by an
+    // earlier harness must not make an OpenClaw page re-ask on a timer for a
+    // fact no OpenClaw capability reads.
+    getActiveHarness.mockResolvedValue("openclaw");
+    flagProbePending.mockReturnValue(true);
+    visionPending.mockReturnValue(true);
+    imageBackendPending.mockReturnValue(true);
+    expect((await body()).factsPending).toBe(false);
+  });
+});

--- a/src/tests/unit/harness-facts-pending-retry.test.ts
+++ b/src/tests/unit/harness-facts-pending-retry.test.ts
@@ -47,6 +47,8 @@ let capabilities: {
   factsRetryAfterMs: number;
 };
 let capabilityFetches: number;
+/** When set, the next capabilities fetch answers non-OK rather than with facts. */
+let capabilitiesFailOnce: boolean;
 
 const gateway: GatewayLink = {
   request: async () => null,
@@ -75,6 +77,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
   capabilityFetches = 0;
+  capabilitiesFailOnce = false;
   capabilities = { facts: { ...FACTS }, factsPending: false, factsRetryAfterMs: RETRY_AFTER_MS };
   fetchHarness.mockResolvedValue({ active: "hermes", edition: "hermes" });
   vi.stubGlobal(
@@ -82,6 +85,10 @@ beforeEach(() => {
     vi.fn(async (input: RequestInfo | URL) => {
       if (String(input).includes("/setup-api/chat/capabilities")) {
         capabilityFetches += 1;
+        if (capabilitiesFailOnce) {
+          capabilitiesFailOnce = false;
+          return new Response("", { status: 503 });
+        }
         return new Response(JSON.stringify(capabilities), {
           status: 200,
           headers: { "content-type": "application/json" },
@@ -100,8 +107,10 @@ afterEach(() => {
 describe("useHarnessAdapter facts backoff", () => {
   it("re-asks once the server's backoff is up when a fact is still pending", async () => {
     capabilities.factsPending = true;
-    const { unmount } = await mount();
+    const { result, unmount } = await mount();
     expect(capabilityFetches).toBe(1);
+    // The placeholder `false` is what hides the control this test is about.
+    expect(result.current.capabilities.canAttachImages).toBe(false);
 
     // The composer's attach button is hidden on a fact the server has already
     // said it will replace. Nothing must be asked before the backoff is up …
@@ -120,12 +129,67 @@ describe("useHarnessAdapter facts backoff", () => {
       await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS);
     });
     expect(capabilityFetches).toBe(2);
+    // The whole point: the attach button the placeholder hid is back, on a
+    // page nobody reloaded. Asserting the fetch count alone would stay green
+    // through a regression in `applyFacts` or `sameFacts`.
+    expect(result.current.capabilities.canAttachImages).toBe(true);
 
     // And once it has answered, it stays answered — no polling loop.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS * 4);
     });
     expect(capabilityFetches).toBe(2);
+    unmount();
+  });
+
+  it("keeps chasing when the retry request itself does not answer", async () => {
+    // A re-ask that fails is not an answer either, and abandoning the chase on
+    // it reinstates the exact bug this retry removes: the placeholder `false`
+    // stays for the whole page session because one round trip happened to land
+    // during a restart or a blip. The cap still applies — this must not become
+    // a retry loop keyed on failure.
+    capabilities.factsPending = true;
+    const { result, unmount } = await mount();
+    expect(capabilityFetches).toBe(1);
+
+    capabilitiesFailOnce = true;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS);
+    });
+    expect(capabilityFetches).toBe(2);
+    expect(result.current.capabilities.canAttachImages).toBe(false);
+
+    // The second attempt is still owed, and it is the one that recovers.
+    capabilities = {
+      facts: { ...FACTS, hermesSupportsImages: true, hermesHasVisionRoute: true },
+      factsPending: false,
+      factsRetryAfterMs: RETRY_AFTER_MS,
+    };
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS);
+    });
+    expect(capabilityFetches).toBe(3);
+    expect(result.current.capabilities.canAttachImages).toBe(true);
+
+    // And it stops there, exactly as it does on a successful chase.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS * 3);
+    });
+    expect(capabilityFetches).toBe(3);
+    unmount();
+  });
+
+  it("does not start chasing when the MOUNT fetch fails and nothing is pending", async () => {
+    // The mount path is unchanged: a box that could not answer at all keeps the
+    // cautious defaults and waits for a provider change, as it did before. Only
+    // a chase already under way is continued through a failure.
+    capabilitiesFailOnce = true;
+    const { unmount } = await mount();
+    expect(capabilityFetches).toBe(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS * 5);
+    });
+    expect(capabilityFetches).toBe(1);
     unmount();
   });
 

--- a/src/tests/unit/harness-facts-pending-retry.test.ts
+++ b/src/tests/unit/harness-facts-pending-retry.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import type { GatewayLink } from "@/lib/harness/openclaw-gateway-adapter";
+import type { HermesTurnContext } from "@/lib/harness/hermes-adapter";
+
+/**
+ * The SECOND cache over the same fact: the browser's.
+ *
+ * The server-side fix stopped remembering a failed Hermes probe as a negative
+ * answer, and its stated customer outcome is that a box which was merely busy
+ * "gets its attach button back inside a minute rather than at the next
+ * restart". The browser never delivered that minute. `useHarnessAdapter`
+ * fetches the facts exactly once, on mount, and the only re-probe trigger is
+ * `onProvidersChanged`, which fires on an explicit provider-configure success
+ * and on no timer at all. A capabilities response that SUCCEEDS while the
+ * server-side probe is in backoff carries a legitimate-looking
+ * `hermesSupportsImages: false`, indistinguishable from a real negative — so
+ * one slow moment during chat open hid the composer's attach button for the
+ * entire page session, until a reload or a Settings change.
+ *
+ * `factsPending` is how the unknown-ness reaches here, and this is the pinning
+ * for what the hook does with it: exactly one re-ask per pending answer, no
+ * earlier than the server's own backoff, capped so a permanently broken box
+ * cannot be polled for the life of the tab.
+ */
+
+const fetchHarness = vi.fn();
+vi.mock("@/lib/client-harness", () => ({ fetchHarness }));
+
+const FACTS = {
+  hasClawaiToken: false,
+  hermesSupportsImages: false,
+  hermesHasVisionRoute: false,
+  hermesStreamsTurns: false,
+  hasClawaiImageRoute: false,
+  hermesAgentDrawsImages: false,
+};
+
+const RETRY_AFTER_MS = 60_000;
+/** Comfortably past the retry the hook should schedule, margin included. */
+const PAST_THE_RETRY_MS = RETRY_AFTER_MS + 30_000;
+
+let capabilities: {
+  facts: typeof FACTS;
+  factsPending: boolean;
+  factsRetryAfterMs: number;
+};
+let capabilityFetches: number;
+
+const gateway: GatewayLink = {
+  request: async () => null,
+  sessionKey: () => "",
+  open: async () => {},
+  close: () => {},
+  onStatus: () => () => {},
+};
+const hermesContext = (): HermesTurnContext => ({
+  devicePairing: { provider: "", model: "" },
+  modelsReady: false,
+});
+
+async function mount() {
+  const { useHarnessAdapter } = await import("@/lib/harness/use-harness-adapter");
+  const rendered = renderHook(() => useHarnessAdapter({ gateway, hermesContext }));
+  // Let the mount effect's fetches settle before anything is asserted.
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0);
+  });
+  return rendered;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  capabilityFetches = 0;
+  capabilities = { facts: { ...FACTS }, factsPending: false, factsRetryAfterMs: RETRY_AFTER_MS };
+  fetchHarness.mockResolvedValue({ active: "hermes", edition: "hermes" });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      if (String(input).includes("/setup-api/chat/capabilities")) {
+        capabilityFetches += 1;
+        return new Response(JSON.stringify(capabilities), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("useHarnessAdapter facts backoff", () => {
+  it("re-asks once the server's backoff is up when a fact is still pending", async () => {
+    capabilities.factsPending = true;
+    const { unmount } = await mount();
+    expect(capabilityFetches).toBe(1);
+
+    // The composer's attach button is hidden on a fact the server has already
+    // said it will replace. Nothing must be asked before the backoff is up …
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RETRY_AFTER_MS - 1_000);
+    });
+    expect(capabilityFetches).toBe(1);
+
+    // … and the recovered answer must arrive without a reload.
+    capabilities = {
+      facts: { ...FACTS, hermesSupportsImages: true, hermesHasVisionRoute: true },
+      factsPending: false,
+      factsRetryAfterMs: RETRY_AFTER_MS,
+    };
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS);
+    });
+    expect(capabilityFetches).toBe(2);
+
+    // And once it has answered, it stays answered — no polling loop.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS * 4);
+    });
+    expect(capabilityFetches).toBe(2);
+    unmount();
+  });
+
+  it("does not re-ask at all when every fact was answered", async () => {
+    const { unmount } = await mount();
+    expect(capabilityFetches).toBe(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS * 5);
+    });
+    expect(capabilityFetches).toBe(1);
+    unmount();
+  });
+
+  it("gives up after two attempts rather than polling a broken box for ever", async () => {
+    capabilities.factsPending = true;
+    const { unmount } = await mount();
+    expect(capabilityFetches).toBe(1);
+
+    // Each retry is only scheduled once the previous answer has been applied,
+    // so the clock is advanced a window at a time rather than in one jump.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS);
+    });
+    expect(capabilityFetches).toBe(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS);
+    });
+    expect(capabilityFetches).toBe(3);
+
+    // The mount fetch plus the two capped retries, and then silence: a box
+    // whose `hermes` is genuinely broken must not be asked for the life of the
+    // tab, which is what the server-side backoff exists to prevent in the
+    // first place.
+    for (let i = 0; i < 5; i += 1) {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS);
+      });
+    }
+    expect(capabilityFetches).toBe(3);
+    unmount();
+  });
+
+  it("schedules nothing after the component has gone", async () => {
+    capabilities.factsPending = true;
+    const { unmount } = await mount();
+    expect(capabilityFetches).toBe(1);
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(PAST_THE_RETRY_MS * 5);
+    });
+    expect(capabilityFetches).toBe(1);
+  });
+});

--- a/src/tests/unit/hermes-config-cache.test.ts
+++ b/src/tests/unit/hermes-config-cache.test.ts
@@ -45,6 +45,18 @@ const ok = (stdout: string) => ({ code: 0, stdout, stderr: "" });
 /** What the real CLI answers for a key nobody has configured. */
 const notSet = (key: string) => ({ code: 1, stdout: "", stderr: `Config key not set: ${key}` });
 
+/**
+ * Let every pending microtask run, WITHOUT advancing the fake clock.
+ *
+ * The concurrency tests below need the racing callers to have all reached
+ * `runHermesCli` — each of them first awaits the `fs.stat` behind
+ * `configMtime` — while the CLI promise is still unsettled. `vi.runAllTicks`
+ * would not help: these are plain promise continuations, not `nextTick`.
+ */
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 20; i += 1) await Promise.resolve();
+}
+
 describe("hermesConfigGet", () => {
   beforeEach(() => {
     mtimeMs = 1_000;
@@ -187,5 +199,137 @@ describe("hermesConfigGet", () => {
     invalidateHermesConfigCache();
     expect(await hermesConfigGet("model.provider")).toBe("clawai");
     expect(runHermesCli).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares ONE interpreter between callers racing the same key", async () => {
+    // The production shape, and the one a sequential `await` cannot express.
+    // `/setup-api/chat/capabilities` asks `hermesHasVisionRoute` and
+    // `hermesAgentDrawsImages` on every chat open with no route-level dedup,
+    // and `readCurrentFromCli` issues three of these under one `Promise.all`.
+    // With a wedged `hermes` the backoff entry is not written until the first
+    // read gives up, so every overlapping caller in that window used to start
+    // its own Python interpreter — on a Jetson, for the whole timeout — which
+    // is the exact fan-out the backoff exists to prevent.
+    let finish: (value: unknown) => void = () => {};
+    runHermesCli.mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const { hermesConfigGet } = await load();
+    const racing = Promise.all([
+      hermesConfigGet("auxiliary.vision.model"),
+      hermesConfigGet("auxiliary.vision.model"),
+      hermesConfigGet("auxiliary.vision.model"),
+    ]);
+    await flushMicrotasks();
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+
+    finish(ok("gpt-4.1-mini"));
+    expect(await racing).toEqual(["gpt-4.1-mini", "gpt-4.1-mini", "gpt-4.1-mini"]);
+  });
+
+  it("shares one interpreter between racing callers even when the read FAILS", async () => {
+    // The half that matters most: a hanging `hermes` is precisely when the
+    // callers pile up, and the entry has to be in the map before the failure
+    // is known, not after.
+    let fail: (reason: unknown) => void = () => {};
+    runHermesCli.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        fail = reject;
+      }),
+    );
+    const { hermesConfigGet } = await load();
+    const racing = Promise.all([
+      hermesConfigGet("image_gen.provider"),
+      hermesConfigGet("image_gen.provider"),
+      hermesConfigGet("image_gen.provider"),
+    ]);
+    await flushMicrotasks();
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+
+    fail(new Error("hermes timed out"));
+    expect(await racing).toEqual(["", "", ""]);
+    // …and the failure is still only held for the backoff, not for ever.
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+    expect(await hermesConfigGet("image_gen.provider")).toBe("clawai");
+  });
+
+  it("does not race a still-answered key against a config.yaml written mid-read", async () => {
+    // An in-flight entry is stamped with the mtime it was started against, so
+    // a write that lands while the CLI is running is still noticed by the next
+    // caller rather than being served the older question's answer.
+    let finish: (value: unknown) => void = () => {};
+    runHermesCli.mockReturnValueOnce(
+      new Promise((resolve) => {
+        finish = resolve;
+      }),
+    );
+    const { hermesConfigGet } = await load();
+    const first = hermesConfigGet("model.provider");
+    await flushMicrotasks();
+
+    mtimeMs = 2_000; // the customer linked while the first read was in flight
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    expect(await hermesConfigGet("model.provider")).toBe("clawai");
+
+    finish(ok("stale"));
+    expect(await first).toBe("stale");
+    expect(runHermesCli).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("hermesConfigReadPending", () => {
+  beforeEach(() => {
+    mtimeMs = 1_000;
+    runHermesCli.mockReset();
+    stat.mockClear();
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("says nothing is pending before anyone has asked", async () => {
+    const { hermesConfigReadPending } = await load();
+    expect(hermesConfigReadPending("model.provider")).toBe(false);
+  });
+
+  it("reports a value served from the FAILURE backoff as pending", async () => {
+    // This is the fact the browser needs and never got: the `false` it was
+    // handed is a placeholder the server will replace by itself in a minute,
+    // not a negative answer about the box.
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesConfigGet, hermesConfigReadPending } = await load();
+    expect(await hermesConfigGet("auxiliary.vision.model")).toBe("");
+    expect(hermesConfigReadPending("auxiliary.vision.model")).toBe(true);
+  });
+
+  it("does not report a real ANSWER as pending, set or unset", async () => {
+    runHermesCli.mockResolvedValue(notSet("image_gen.provider"));
+    const { hermesConfigGet, hermesConfigReadPending } = await load();
+    expect(await hermesConfigGet("image_gen.provider")).toBe("");
+    expect(hermesConfigReadPending("image_gen.provider")).toBe(false);
+
+    runHermesCli.mockResolvedValue(ok("clawai"));
+    mtimeMs = 2_000;
+    expect(await hermesConfigGet("image_gen.provider")).toBe("clawai");
+    expect(hermesConfigReadPending("image_gen.provider")).toBe(false);
+  });
+
+  it("stops reporting pending once the backoff has produced an answer", async () => {
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesConfigGet, hermesConfigReadPending } = await load();
+    expect(await hermesConfigGet("model.default")).toBe("");
+    expect(hermesConfigReadPending("model.default")).toBe(true);
+
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue(ok("claude-sonnet-5"));
+    vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+    expect(await hermesConfigGet("model.default")).toBe("claude-sonnet-5");
+    expect(hermesConfigReadPending("model.default")).toBe(false);
   });
 });

--- a/src/tests/unit/hermes-features-probe.test.ts
+++ b/src/tests/unit/hermes-features-probe.test.ts
@@ -15,7 +15,15 @@ vi.mock("@/lib/hermes-cli", () => ({ runHermesCli }));
 
 /** The mtime-keyed memo around `hermes config get <key>`. */
 const hermesConfigGet = vi.fn();
-vi.mock("@/lib/hermes-config-cache", () => ({ hermesConfigGet }));
+/** Did the memo SERVE that value, or hand back a placeholder it will replace? */
+const hermesConfigReadPending = vi.fn(() => false);
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet,
+  hermesConfigReadPending,
+  // Mirrors the module: `hermes-features` composes its published retry
+  // delay out of both backoffs, so a partial mock hides that composition.
+  FAILED_READ_TTL_MS: 60_000,
+}));
 
 /** The real help text from the box's checkout (1091472, 2026-08-22), trimmed. */
 const HELP_WITH_IMAGE = `usage: hermes chat [-h] [-q QUERY | --query-file PATH] [--image IMAGE]
@@ -262,5 +270,83 @@ describe("hermesHasVisionRoute", () => {
 
     hermesConfigGet.mockResolvedValue("gpt-4.1-mini");
     expect(await hermesHasVisionRoute()).toBe(true);
+  });
+});
+
+/**
+ * Which of these facts is still a PLACEHOLDER.
+ *
+ * Every probe in this file fails closed, so a box that could not answer and a
+ * box that answered "no" produce the same `false`. That is the right answer to
+ * give the composer — a wrong `true` costs the customer's file — but it is not
+ * the whole truth, and the browser was told only the `false`. It fetches these
+ * facts once on mount and re-asks solely on an explicit provider change, so a
+ * single slow moment during chat open hid the attach button for the entire page
+ * session while the server quietly recovered sixty seconds later. These
+ * accessors are how that recovery becomes visible to the page that needs it.
+ */
+describe("pending accessors", () => {
+  beforeEach(() => {
+    runHermesCli.mockReset();
+    hermesConfigGet.mockReset();
+    hermesConfigReadPending.mockReset();
+    hermesConfigReadPending.mockReturnValue(false);
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("says nothing is pending before anything has been probed", async () => {
+    const { hermesFeatureProbePending } = await load();
+    expect(hermesFeatureProbePending()).toBe(false);
+  });
+
+  it("reports the flag probe as pending after a probe that never answered", async () => {
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesSupportsImages, hermesFeatureProbePending } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+    expect(hermesFeatureProbePending()).toBe(true);
+  });
+
+  it("does not report a real help text as pending, flag present or absent", async () => {
+    runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITHOUT_IMAGE, stderr: "" });
+    const { hermesSupportsImages, hermesFeatureProbePending } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+    expect(hermesFeatureProbePending()).toBe(false);
+  });
+
+  it("stops reporting the flag probe as pending once the backoff answered", async () => {
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    const { hermesSupportsImages, hermesFeatureProbePending } = await load();
+    expect(await hermesSupportsImages()).toBe(false);
+    expect(hermesFeatureProbePending()).toBe(true);
+
+    runHermesCli.mockReset();
+    runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+    vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+    expect(await hermesSupportsImages()).toBe(true);
+    expect(hermesFeatureProbePending()).toBe(false);
+  });
+
+  it("passes the two config-backed facts through to the memo, by their own keys", async () => {
+    // The key names stay private to this module — the route asks "is this fact
+    // still a placeholder", not "is `auxiliary.vision.model` in backoff".
+    hermesConfigReadPending.mockImplementation(
+      (key: string) => key === "auxiliary.vision.model",
+    );
+    const { hermesVisionRoutePending, hermesImageBackendPending } = await load();
+    expect(hermesVisionRoutePending()).toBe(true);
+    expect(hermesImageBackendPending()).toBe(false);
+    expect(hermesConfigReadPending).toHaveBeenCalledWith("auxiliary.vision.model");
+    expect(hermesConfigReadPending).toHaveBeenCalledWith("image_gen.provider");
+  });
+
+  it("publishes a retry delay no shorter than the backoff it describes", async () => {
+    // The browser waits this out before re-asking. Published rather than
+    // duplicated on the client, so the two cannot drift apart.
+    const { HERMES_FACT_RETRY_MS } = await load();
+    expect(HERMES_FACT_RETRY_MS).toBeGreaterThanOrEqual(PAST_THE_BACKOFF_MS - 1_000);
   });
 });

--- a/src/tests/unit/hermes-features-probe.test.ts
+++ b/src/tests/unit/hermes-features-probe.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/hermes-cli", () => ({ runHermesCli }));
 /** The mtime-keyed memo around `hermes config get <key>`. */
 const hermesConfigGet = vi.fn();
 /** Did the memo SERVE that value, or hand back a placeholder it will replace? */
-const hermesConfigReadPending = vi.fn((_key: string) => false);
+const hermesConfigReadPending = vi.fn<(key: string) => boolean>(() => false);
 vi.mock("@/lib/hermes-config-cache", () => ({
   hermesConfigGet,
   hermesConfigReadPending,

--- a/src/tests/unit/hermes-features-probe.test.ts
+++ b/src/tests/unit/hermes-features-probe.test.ts
@@ -16,7 +16,7 @@ vi.mock("@/lib/hermes-cli", () => ({ runHermesCli }));
 /** The mtime-keyed memo around `hermes config get <key>`. */
 const hermesConfigGet = vi.fn();
 /** Did the memo SERVE that value, or hand back a placeholder it will replace? */
-const hermesConfigReadPending = vi.fn(() => false);
+const hermesConfigReadPending = vi.fn((_key: string) => false);
 vi.mock("@/lib/hermes-config-cache", () => ({
   hermesConfigGet,
   hermesConfigReadPending,


### PR DESCRIPTION
Follow-up to #516. Two residuals, both the shape the review round was hunting: **a bug fixed in one of two identical paths.** #516 fixed both Hermes memos in a single change but gave them different shapes, and the difference is exactly where these live.

Both reproduced against the merged head before anything was written.

---

## CACHE-01a — the config memo still fanned out one interpreter per concurrent caller

`harness/hermes-features.ts` deliberately memoises the **in-flight promise**, seeded with the backoff *before* the probe is awaited — its own comment says so: *"Seeded with the BACKOFF so concurrent callers during the probe share one interpreter."*

`hermesConfigGet` did not. It awaited `runHermesCli` and only wrote `cache` once the read had settled, so nothing was shared while a read was in flight. The module's new comment claims the opposite protection — *"a hanging `hermes` would then start a Python interpreter for every request, which is the cost this module exists to avoid"* — and the regression test pinning it, *"does not re-spawn the CLI for every caller while a read is failing"*, proves it only for **sequential** awaits.

In production the callers are concurrent:

- `/setup-api/chat/capabilities` runs `hermesHasVisionRoute` and `hermesAgentDrawsImages` on every chat open, with no route-level dedup;
- `hermes-model-options.ts:478-480` issues three `hermesConfigGet` calls under one `Promise.all`.

With a wedged `hermes` and a 10 s timeout, every overlapping request started its own Python interpreter for the full 10 s before the 60 s backoff entry was ever written — the exact interpreter fan-out on a Jetson the backoff was added to prevent.

**Fix.** `Entry.value` becomes `Promise<string>`, and the entry is put in the map *before* `runHermesCli` is awaited, seeded with `FAILED_READ_TTL_MS` and stamped with its real expiry once the outcome is known — the same seed-then-stamp shape as its sibling. The `mtimeMs` comparison and the `mtime !== null || !answered` retention rule are unchanged; the answered-with-no-config-file case now *deletes* the entry, and only if it is still the live one, so a read that superseded it mid-flight cannot be evicted by an older one landing late.

## CACHE-01b — the browser cached the failed probe's `false` for the whole page session

The second cache over the same fact, left unfixed. #516's stated customer outcome is that a box merely busy *"gets its attach button back inside a minute rather than at the next restart"*. The customer never got that minute.

`use-harness-adapter` fetches the facts **once, on mount**. The only re-probe trigger is `onProvidersChanged(reprobe)`, which `ui-events.ts` fires solely on an explicit provider-configure success — on no timer. `fetchFacts` correctly returns `null` for a *failed* fetch, but a fetch that **succeeds** while the server-side probe is in backoff returns a legitimate-looking `hermesSupportsImages: false`, indistinguishable from a real negative, and the client stores it. One 30 s probe timeout during chat open hid the composer's attach button for the entire page session.

**Fix — the unknown-ness travels.**

- `hermes-config-cache.ts` exposes `hermesConfigReadPending(key)`; `harness/hermes-features.ts` exposes `hermesFeatureProbePending()`, plus `hermesVisionRoutePending()` / `hermesImageBackendPending()` so the config **key names stay private to that module** — the route asks "is this *fact* still a placeholder", never "is `auxiliary.vision.model` in backoff". All three read their memo *without touching it*: asking whether a fact is settled must not itself start a `hermes`.
- The route adds `factsPending` and `factsRetryAfterMs`. The delay is **published rather than duplicated in the browser**, so the wait and the backoff it waits on cannot drift; it is `Math.max` of both backoffs, since only the longer one is the point where *both* memos have given up.
- The hook re-asks once `factsPending` is true, `RETRY_MARGIN_MS` past the published delay (an exactly-on-time re-ask lands while the entry is still live and learns nothing), cleared on unmount, **capped at `MAX_PENDING_RETRIES = 2`** — a browser polling a broken box would reintroduce from the client the very cost the server-side backoff exists to avoid.

`hasClawaiImageRoute` is **deliberately not counted** in `factsPending`: `clawai-images` caches a plain `false` for a minute whether the proxy answered "no" or did not answer at all, so it draws no answer/failure distinction to report, and folding it in would claim a precision that module does not have.

---

## Fixing the class, not the instance

The class is **"a memo that publishes its entry *after* the await, so concurrent callers fan out instead of sharing."** The grep that enumerates every memo on the Hermes fact path and shows what each one's entry holds:

```
$ grep -rnE "^(let|const) +[A-Za-z_]*([Cc]ache|[Pp]robe|[Mm]emo)[A-Za-z_]* *(:|=)|^type Entry|^type Probe" \
    src/lib/harness src/lib/hermes-config-cache.ts src/lib/hermes-dashboard-turn.ts --include=*.ts

src/lib/harness/clawai-images.ts:162:let probeCache: { promise: Promise<boolean>; expiresAt: number } | null = null;
src/lib/harness/hermes-features.ts:57:type Probe = { promise: Promise<boolean>; expiresAt: number };
src/lib/harness/hermes-features.ts:58:let probe: Probe | null = null;
src/lib/hermes-config-cache.ts:71:type Entry = { mtimeMs: number | null; value: Promise<string>; expiresAt: number };
src/lib/hermes-config-cache.ts:72:const cache = new Map<string, Entry>();
src/lib/hermes-dashboard-turn.ts:331:let probe: { at: number; value: Promise<boolean> } | null = null;
```

Four memos, and **after this PR every one of them holds a `Promise`** — so all four share in-flight work. `hermes-config-cache` was the single outlier (`value: string`); the other three already shared. The wider sweep over `src/lib` and `src/app` (same pattern, no path filter) returns 60-odd module-level memos, but the remaining ones are not on this path and do not memoise a `hermes` spawn.

The fix is **inside the memo**, not at any call site, so all nine callers get it without being touched:

```
$ grep -rn "hermesConfigGet(\|hermesConfigGetMany(" src/ --include=*.ts --include=*.tsx \
    | grep -v src/tests | grep -v hermes-config-cache.ts
```
→ `ai-models/status`, `hermes/clawai`, `hermes-features` ×2, `hermes-model-options` ×3, `hermes-pets`, `hermes-skills-server`.

For CACHE-01b the class is **"a server-side backoff whose recovery the browser never observes."** There is exactly one client-side reader of these facts, so one hook closes it:

```
$ grep -rn "setup-api/chat/capabilities" src/ --include=*.ts --include=*.tsx | grep -v src/tests
```
→ one `fetch` call site, `src/lib/harness/use-harness-adapter.ts:92`. Every other hit is prose in a comment.

---

## Tests — red first

Every test below was run against **unmodified `origin/beta`** before any source was touched.

| | |
|---|---|
| **RED** | `Tests 21 failed \| 29 passed (50)` across the 4 files |
| **GREEN** | `Tests 50 passed (50)` |

23 tests are new; 21 of them failed on beta and 2 are guards that passed there and must keep passing.

The two that name the bug directly:

- `shares ONE interpreter between callers racing the same key` — beta: `expected "vi.fn()" to be called 1 times, but got 3 times`
- `re-asks once the server's backoff is up when a fact is still pending` — beta: `expected 1 to be 2`

Also pinned: the racing callers share one spawn **when the read fails** (the case that matters most — a hanging `hermes` is precisely when callers pile up); an in-flight entry does not serve a stale answer across a `config.yaml` written mid-read; `factsPending` is never true on an OpenClaw box, where the probes never ran; and the client schedules nothing after unmount.

## Gates

`tsc` and `lint` are unchanged from the beta baseline — 24 pre-existing `tsc` errors and 182 lint problems (99 errors, 83 warnings), all in files this PR does not touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capability responses now indicate when Hermes image-related checks are pending.
  * Added retry timing information for capability updates.
  * Temporary pending results retry automatically while confirmed answers remain available.

* **Bug Fixes**
  * Prevented duplicate concurrent capability and configuration checks.
  * Improved recovery from failed checks without blocking newer results.
  * Ensured pending Hermes results do not affect OpenClaw capabilities.

* **Tests**
  * Added coverage for pending states, retry limits, cancellation, concurrent reads, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->