### PR TITLE
Guard the wizard save against the Claude subscription surface too

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -61,6 +61,10 @@ import { resolveEntitledCodexModel } from "@/lib/codex-model-probe";
 import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
 import { isValidModelId, isCatalogProvider, GOOGLE_MODELS, ANTHROPIC_MODELS, extractProviderModelId } from "@/lib/provider-models";
 import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
+import {
+  isClaudeSubscriptionOnly,
+  offSurfaceClaudeModelMessage,
+} from "@/lib/subscription-surface";
 // The model name on this route arrives in the request body. For a local
 // provider it is the whole of `apiKey`, which nothing further constrains, and
 // it reaches the lines below both directly and inside a subprocess error that
@@ -1527,6 +1531,60 @@ export async function POST(request: Request) {
           return NextResponse.json({ error: err.message }, { status: 502 });
         }
         throw err; // unexpected — fall to the outer catch, which classifies it
+      }
+    }
+
+    // ── The Claude subscription surface ─────────────────────────────────────
+    // This route is the SECOND write path to `agents.defaults.model.primary`;
+    // /setup-api/chat/model is the first, and the guard there exists "for ids
+    // that arrive some other way". This is that other way. The shape check
+    // above deliberately does not consult the curated list ("users can type
+    // newer model IDs we haven't added yet"), and the wizard's picker exempts
+    // a typed custom id from its own greying-out rule, so without this a
+    // Claude-subscription box can be pinned from Settings to exactly the model
+    // the chat header refuses — one the `claude-cli` surface cannot route.
+    //
+    // Judged on the SETTLED `config.defaultModel`, after every branch above
+    // has had its say, so the PROVIDERS-table default is covered as well as a
+    // typed id: one check for every value this save can write to primary.
+    //
+    // AFTER the Hermes branch, because the question it asks is about
+    // `openclaw.json` and a Hermes box has none — and that branch refuses a
+    // subscription save outright anyway. BEFORE `writeAuthProfiles` below,
+    // because a refusal that has already persisted a credential is not a
+    // refusal, it is a half-applied save. Nothing between here and there
+    // writes anything (the OAuth handoff file is consumed only on success).
+    {
+      const slash = config.defaultModel.indexOf("/");
+      const offSurface = await offSurfaceClaudeModelMessage(
+        slash > 0 ? config.defaultModel.slice(0, slash) : null,
+        config.defaultModel.slice(slash + 1),
+        async () => {
+          // Ask about the profiles this save is ABOUT TO leave behind, not the
+          // ones on disk: a first Claude sign-in writes the OAuth profile that
+          // makes the box subscription-only, and an API-key save writes the
+          // key that stops it being. Reading disk alone gets BOTH of those
+          // backwards — it would wave the sign-in through and then refuse the
+          // very switch the refusal message recommends.
+          let existing: OpenClawConfig | null = null;
+          try {
+            existing = await readOpenClawConfig();
+          } catch {
+            // No readable config yet (fresh box). The projected profile below
+            // still answers the question on its own.
+          }
+          return isClaudeSubscriptionOnly({
+            ...(existing?.auth?.profiles ?? {}),
+            // Exactly what `baseOps` writes for this profile key below.
+            [config.profileKey]: {
+              provider: ocProvider,
+              mode: authMode === "subscription" ? "oauth" : "api_key",
+            },
+          });
+        },
+      );
+      if (offSurface) {
+        return NextResponse.json({ error: offSurface }, { status: 400 });
       }
     }
 

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1554,18 +1554,23 @@ export async function POST(request: Request) {
     // because a refusal that has already persisted a credential is not a
     // refusal, it is a half-applied save. Nothing between here and there
     // writes anything (the OAuth handoff file is consumed only on success).
-    {
+    //
+    // Only a SUBSCRIPTION save can create the hazard. An API-key save writes
+    // the anthropic key that makes the API-only models routable, so after it
+    // lands the box is not subscription-only and there is nothing to refuse —
+    // refusing there would block the very switch the message recommends
+    // ("switch Anthropic to API-key mode for the API-only models").
+    if (authMode === "subscription") {
       const slash = config.defaultModel.indexOf("/");
       const offSurface = await offSurfaceClaudeModelMessage(
         slash > 0 ? config.defaultModel.slice(0, slash) : null,
         config.defaultModel.slice(slash + 1),
         async () => {
           // Ask about the profiles this save is ABOUT TO leave behind, not the
-          // ones on disk: a first Claude sign-in writes the OAuth profile that
-          // makes the box subscription-only, and an API-key save writes the
-          // key that stops it being. Reading disk alone gets BOTH of those
-          // backwards — it would wave the sign-in through and then refuse the
-          // very switch the refusal message recommends.
+          // ones already on disk: this sign-in is what writes the OAuth
+          // profile that makes the box subscription-only, so disk alone would
+          // wave the very first Claude sign-in straight through. A key held
+          // under some other profile key still counts, and still allows.
           let existing: OpenClawConfig | null = null;
           try {
             existing = await readOpenClawConfig();
@@ -1576,10 +1581,7 @@ export async function POST(request: Request) {
           return isClaudeSubscriptionOnly({
             ...(existing?.auth?.profiles ?? {}),
             // Exactly what `baseOps` writes for this profile key below.
-            [config.profileKey]: {
-              provider: ocProvider,
-              mode: authMode === "subscription" ? "oauth" : "api_key",
-            },
+            [config.profileKey]: { provider: ocProvider, mode: "oauth" },
           });
         },
       );

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -16,8 +16,10 @@ import {
   CLAWBOX_AI_DEFAULT_TIER,
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
-import { isValidModelId, parseModelSlug, subscriptionSurfaceLabel } from "@/lib/provider-models";
+import { isValidModelId, parseModelSlug } from "@/lib/provider-models";
 import {
+  isClaudeSubscriptionOnly,
+  offSurfaceClaudeModelMessage,
   readSubscriptionSurfaceIds,
   subscriptionOnlyProviders,
 } from "@/lib/subscription-surface";
@@ -158,9 +160,11 @@ function hasCodexOauthProfile(config: OpenClawConfig): boolean {
  * null when the target is fine (or is not Claude, or the box is not on a
  * Claude subscription, or the surface could not be read).
  *
- * Anthropic's subscription keeps the `anthropic/` namespace but narrows the
- * set: only the plugin's `claude-cli` catalogue routes, so claude-mythos-5 /
- * claude-fable-5 / the Haikus are API-key-only.
+ * A thin wrapper over `offSurfaceClaudeModelMessage`, which owns the rule and
+ * the wording. The rule is shared with the wizard/Settings save
+ * (/setup-api/ai-models/configure), the OTHER write path to
+ * `agents.defaults.model.primary` — a second copy of it there would be a copy
+ * that can drift, and drift is how one path ended up guarded and the other not.
  *
  * A helper rather than an inline block because there are THREE ways a model id
  * becomes the target and only one of them is the custom-model branch: an id
@@ -169,9 +173,6 @@ function hasCodexOauthProfile(config: OpenClawConfig): boolean {
  * exactly where the old unguarded auto-extend wrote, so a box already broken
  * by this defect could re-arm itself through either door. The OpenAI guard is
  * applied at both sites for the same reason.
- *
- * `null` from `readSubscriptionSurfaceIds` means UNKNOWN, not "no": refusing
- * where the pickers allow would be a rejection over something that works.
  */
 async function refuseOffSurfaceClaudeModel(
   provider: string | null | undefined,
@@ -182,18 +183,20 @@ async function refuseOffSurfaceClaudeModel(
   getConfig: () => Promise<OpenClawConfig | null>,
   getSurfaceIds: () => Promise<Set<string> | null>,
 ): Promise<NextResponse | null> {
-  if (provider !== "anthropic") return null;
-  const config = await getConfig();
-  if (!config) return null;
-  if (!subscriptionOnlyProviders(config.auth?.profiles, normalizeProvider).includes("anthropic")) {
-    return null;
-  }
-  const surfaceIds = await getSurfaceIds();
-  if (!surfaceIds || surfaceIds.has(modelId)) return null;
-  const surface = subscriptionSurfaceLabel("anthropic");
-  return NextResponse.json({
-    error: `${modelId} is not on the Claude subscription surface (${surface}). Pick one of ${[...surfaceIds].sort().join(", ")}, or switch Anthropic to API-key mode for the API-only models.`,
-  }, { status: 400 });
+  const message = await offSurfaceClaudeModelMessage(
+    provider,
+    modelId,
+    async () => {
+      const config = await getConfig();
+      // `normalizeProvider` goes IN, not around the outside — see
+      // `subscriptionProvidersForUi` for why the alias has to collapse before
+      // the credentials are counted.
+      return !!config && isClaudeSubscriptionOnly(config.auth?.profiles, normalizeProvider);
+    },
+    getSurfaceIds,
+  );
+  if (!message) return null;
+  return NextResponse.json({ error: message }, { status: 400 });
 }
 
 function sortPrimaryOptions(options: ChatModelOption[]) {

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -1,7 +1,7 @@
 import { promises as fsp } from "fs";
 import path from "path";
 import { DATA_DIR } from "@/lib/config-store";
-import { SUBSCRIPTION_SURFACE } from "@/lib/provider-models";
+import { SUBSCRIPTION_SURFACE, subscriptionSurfaceLabel } from "@/lib/provider-models";
 
 /**
  * Server-side reads of the SUBSCRIPTION facts the UI already gets stamped into
@@ -102,4 +102,69 @@ export function subscriptionOnlyProviders(
     else if (KEY_MODES.has(mode)) keyed.add(provider);
   }
   return [...oauth].filter((provider) => !keyed.has(provider)).sort();
+}
+
+/** Auth-profile entries as `openclaw.json` carries them under `auth.profiles`. */
+export type AuthProfileEntries =
+  Record<string, { provider?: string; mode?: string } | undefined> | undefined;
+
+/**
+ * Does this profile set mean the box reaches Claude by SUBSCRIPTION only?
+ *
+ * Named once because two routes ask it and both must get the same answer. It
+ * is deliberately a question about a profile SET rather than about a config
+ * object: the wizard save has to ask it about the profiles it is *about to*
+ * write, which no file on disk carries yet.
+ */
+export function isClaudeSubscriptionOnly(
+  profiles: AuthProfileEntries,
+  normalize?: (provider: string) => string | null,
+): boolean {
+  return subscriptionOnlyProviders(profiles, normalize).includes("anthropic");
+}
+
+/**
+ * The refusal for a Claude model id the box's subscription surface does not
+ * carry, as a message — or null when the target is fine (not Claude, not a
+ * Claude-subscription box, or the surface could not be read).
+ *
+ * Anthropic's subscription keeps the `anthropic/` namespace but narrows the
+ * set: only the plugin's `claude-cli` catalogue routes, so claude-mythos-5 /
+ * claude-fable-5 / the Haikus are API-key-only.
+ *
+ * It lives here, not in a route, because there are TWO write paths to
+ * `agents.defaults.model.primary` and each of them has more than one door:
+ *
+ *   * `/setup-api/chat/model` — the custom-model branch, an id that already
+ *     matches `state.options`, and `{"source":"primary"}`.
+ *   * `/setup-api/ai-models/configure` — a typed custom id from the wizard or
+ *     Settings, and the PROVIDERS-table default the same save writes when
+ *     nothing is typed.
+ *
+ * A second copy of this rule in the second route is a copy that can drift, and
+ * drift is precisely how the first route ended up guarded and the second not.
+ *
+ * `null` from `readSubscriptionSurfaceIds` means UNKNOWN, not "no": refusing
+ * where the pickers allow would be a rejection over something that works.
+ *
+ * `isClaudeSubscription` and `getSurfaceIds` are GETTERS, not values. The
+ * provider check comes first, so a save or a switch aimed at any other
+ * provider costs no config read and no cache read at all — on a Jetson
+ * neither is free.
+ */
+export async function offSurfaceClaudeModelMessage(
+  provider: string | null | undefined,
+  modelId: string,
+  isClaudeSubscription: () => boolean | Promise<boolean>,
+  getSurfaceIds: () => Promise<Set<string> | null> = () =>
+    readSubscriptionSurfaceIds("anthropic"),
+): Promise<string | null> {
+  if (provider !== "anthropic") return null;
+  if (!(await isClaudeSubscription())) return null;
+  const surfaceIds = await getSurfaceIds();
+  if (!surfaceIds || surfaceIds.has(modelId)) return null;
+  const surface = subscriptionSurfaceLabel("anthropic");
+  return `${modelId} is not on the Claude subscription surface (${surface}). `
+    + `Pick one of ${[...surfaceIds].sort().join(", ")}, `
+    + "or switch Anthropic to API-key mode for the API-only models.";
 }

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -127,6 +127,7 @@ function surfaceCache(ids: string[]) {
   });
 }
 
+/** A spawned `openclaw` that exits 0 immediately — the happy-path stand-in. */
 function successfulChild(): ChildProcess {
   const emitter = new EventEmitter() as ChildProcess;
   emitter.stdin = { end: vi.fn() } as unknown as ChildProcess["stdin"];
@@ -150,6 +151,7 @@ function successfulChild(): ChildProcess {
 describe("POST /setup-api/ai-models/configure and the Claude subscription surface", () => {
   let configurePost: (request: Request) => Promise<Response>;
 
+  /** A POST to this route carrying `body` as JSON. */
   function jsonRequest(body: unknown): Request {
     return new Request("http://localhost/test", {
       method: "POST",
@@ -158,6 +160,7 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     });
   }
 
+  /** The wizard's Claude sign-in save, with `body` overriding its fields. */
   function subscribe(body: Record<string, unknown> = {}) {
     return jsonRequest({
       provider: "anthropic",

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import type { ChildProcess } from "child_process";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fsp from "fs/promises";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+// The route writes auth-profiles.json through `fs/promises`; the surface
+// reader reads the catalog cache through `fs`.promises. Two module ids, two
+// mocks — and the `fs` one keeps the real module except for that one read, so
+// nothing else that touches the filesystem loses its implementation.
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    rename: vi.fn(),
+    chown: vi.fn(),
+    mkdir: vi.fn(),
+    rm: vi.fn(),
+    unlink: vi.fn(),
+  },
+}));
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    default: actual,
+    promises: { ...actual.promises, readFile: vi.fn() },
+  };
+});
+
+vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/home/clawbox/clawbox/data",
+  getAll: vi.fn(),
+  setMany: vi.fn(),
+}));
+
+vi.mock("@/lib/clawkeep", () => ({ unpairLocal: vi.fn() }));
+
+// Out-of-band by design (see configure.test.ts) — stubbed so nothing logs
+// after the test that triggered it has finished.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  refreshInBackground: vi.fn(),
+}));
+
+const { parseFullyQualifiedModelImpl } = vi.hoisted(() => ({
+  parseFullyQualifiedModelImpl(fq: string) {
+    const idx = fq.indexOf("/");
+    if (idx <= 0 || idx === fq.length - 1) return null;
+    return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+  },
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR: 24000,
+  compactionReserveFloorForContext: () => 24000,
+  restartGateway: vi.fn(),
+  findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
+  readConfig: vi.fn(),
+  inferConfiguredLocalModel: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSetBatch: vi.fn(),
+  applyModelOverrideToAllAgentSessions: vi.fn(),
+  parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
+  setProviderPlugins: vi.fn(),
+  openclawIsAbsent: vi.fn().mockReturnValue(false),
+  OpenclawUnavailableError: class OpenclawUnavailableError extends Error {},
+}));
+
+vi.mock("@/lib/llamacpp", () => ({
+  getDefaultLlamaCppModel: vi.fn().mockReturnValue("gemma4-e2b-it-q4_0"),
+  getLlamaCppContextWindow: vi.fn().mockReturnValue(131072),
+  getLlamaCppMaxTokens: vi.fn().mockReturnValue(131072),
+  getLlamaCppProxyBaseUrl: vi.fn().mockReturnValue("http://127.0.0.1/llamacpp/v1"),
+}));
+
+vi.mock("@/lib/local-ai-runtime", () => ({
+  getLocalAiProxyBaseUrl: vi.fn(() => "http://127.0.0.1/local-ai"),
+  getOllamaBaseUrl: vi.fn(() => "http://127.0.0.1:11434"),
+}));
+
+vi.mock("@/lib/local-ai-token", () => ({
+  getLocalAiToken: vi.fn().mockReturnValue("a".repeat(64)),
+  verifyLocalAiBearer: vi.fn().mockReturnValue(true),
+  markLocalAiTokenMigrated: vi.fn(),
+}));
+
+import { promises as nodeFsPromises } from "fs";
+import { getAll, setMany } from "@/lib/config-store";
+import {
+  readConfig,
+  restartGateway,
+  runOpenclawConfigSet,
+  runOpenclawConfigSetBatch,
+  applyModelOverrideToAllAgentSessions,
+  inferConfiguredLocalModel,
+  setProviderPlugins,
+} from "@/lib/openclaw-config";
+import { unpairLocal } from "@/lib/clawkeep";
+import { findConfigSet } from "./config-set-calls";
+
+const mockFs = vi.mocked(fsp);
+const mockSurfaceRead = vi.mocked(nodeFsPromises.readFile);
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+/** Model ids the `claude-cli` (Claude-subscription) surface really carries. */
+const SURFACE_IDS = [
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-sonnet-5",
+  "claude-sonnet-4-6",
+];
+
+/** The catalog route's disk cache for a surface provider, as it writes it. */
+function surfaceCache(ids: string[]) {
+  return JSON.stringify({
+    provider: "claude-cli",
+    models: ids.map((id) => ({ id, label: id, contextWindow: 200_000 })),
+    defaultModelId: ids[0],
+    allowCustom: false,
+    fetchedAt: Date.now(),
+  });
+}
+
+function successfulChild(): ChildProcess {
+  const emitter = new EventEmitter() as ChildProcess;
+  emitter.stdin = { end: vi.fn() } as unknown as ChildProcess["stdin"];
+  emitter.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
+  emitter.stderr = new EventEmitter() as unknown as ChildProcess["stderr"];
+  emitter.kill = vi.fn();
+  queueMicrotask(() => emitter.emit("close", 0));
+  return emitter;
+}
+
+/**
+ * The wizard/Settings save is the SECOND write path to
+ * `agents.defaults.model.primary` — the chat header's switch is the first, and
+ * the one #520 guarded "for ids that arrive some other way". This is that
+ * other way: the custom-model field validates the typed id for SHAPE only
+ * ("we don't check against the curated list"), the picker deliberately exempts
+ * a typed id from its greying-out rule, and the OAuth save posts whatever is
+ * in that field verbatim. So a Claude-subscription box could be pinned, from
+ * the wizard, to exactly the model the chat header now refuses.
+ */
+describe("POST /setup-api/ai-models/configure and the Claude subscription surface", () => {
+  let configurePost: (request: Request) => Promise<Response>;
+
+  function jsonRequest(body: unknown): Request {
+    return new Request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  function subscribe(body: Record<string, unknown> = {}) {
+    return jsonRequest({
+      provider: "anthropic",
+      apiKey: "oauth-access-token",
+      authMode: "subscription",
+      ...body,
+    });
+  }
+
+  /** Nothing was written: not the credential file, not one config key. */
+  function expectNoSideEffects() {
+    expect(mockFs.writeFile).not.toHaveBeenCalled();
+    expect(runOpenclawConfigSet).not.toHaveBeenCalled();
+    expect(runOpenclawConfigSetBatch).not.toHaveBeenCalled();
+    expect(restartGateway).not.toHaveBeenCalled();
+  }
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
+    mockFs.writeFile.mockResolvedValue();
+    mockFs.rename.mockResolvedValue();
+    mockFs.chown.mockResolvedValue();
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.rm.mockResolvedValue(undefined);
+    mockFs.unlink.mockResolvedValue(undefined);
+    mockSurfaceRead.mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
+
+    vi.mocked(getAll).mockResolvedValue({});
+    vi.mocked(setMany).mockResolvedValue();
+    vi.mocked(readConfig).mockResolvedValue({} as never);
+    vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
+    vi.mocked(restartGateway).mockResolvedValue();
+    vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+    vi.mocked(runOpenclawConfigSetBatch).mockResolvedValue(undefined);
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(setProviderPlugins).mockResolvedValue(undefined);
+    vi.mocked(unpairLocal).mockResolvedValue(undefined);
+    mockSpawn.mockImplementation(() => successfulChild());
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
+
+    const mod = await import("@/app/setup-api/ai-models/configure/route");
+    configurePost = mod.POST;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("refuses a typed custom Claude id the subscription surface does not carry", async () => {
+    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+
+    expect(res.status).toBe(400);
+    const { error } = await res.json();
+    // Name the surface, exactly as the chat-header refusal does.
+    expect(error).toContain("claude-cli");
+    expect(error).toContain("claude-fable-5");
+    // A rejection that has already persisted the credential is not a
+    // rejection — it is a half-applied save the customer cannot see.
+    expectNoSideEffects();
+  });
+
+  it("accepts a typed custom Claude id the subscription surface does carry", async () => {
+    const res = await configurePost(subscribe({ model: "claude-opus-4-8" }));
+
+    expect(res.status).toBe(200);
+    expect(
+      findConfigSet(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+        "agents.defaults.model.primary",
+      )?.value,
+    ).toBe("anthropic/claude-opus-4-8");
+  });
+
+  it("judges the provider DEFAULT too, not only a typed id", async () => {
+    // The typed-id field is the way in that was reported, but the same write
+    // carries the PROVIDERS-table default when nothing is typed. Guarding the
+    // settled `config.defaultModel` covers both with one check.
+    mockSurfaceRead.mockResolvedValue(
+      surfaceCache(SURFACE_IDS.filter((id) => id !== "claude-sonnet-4-6")) as never,
+    );
+
+    const res = await configurePost(subscribe());
+
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toContain("claude-sonnet-4-6");
+    expectNoSideEffects();
+  });
+
+  it("lets every Claude model through on an API-key save", async () => {
+    // The save itself is what puts an anthropic key on the box, so this box is
+    // not subscription-only once it lands — refusing here would block the very
+    // switch the refusal message recommends.
+    const res = await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: "sk-ant-test",
+      model: "claude-fable-5",
+    }));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("lets a subscription save through when the box already holds an anthropic API key", async () => {
+    // Both credentials means the API-only models still route.
+    vi.mocked(readConfig).mockResolvedValue({
+      auth: { profiles: { "anthropic:key": { provider: "anthropic", mode: "api_key" } } },
+    } as never);
+
+    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("lets the pick through when the surface could not be read at all", async () => {
+    // UNKNOWN is not "no" — the same rule the pickers and the chat route obey.
+    mockSurfaceRead.mockRejectedValue(new Error("ENOENT") as never);
+
+    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("lets the pick through when the cached surface is empty", async () => {
+    mockSurfaceRead.mockResolvedValue(surfaceCache([]) as never);
+
+    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+
+    expect(res.status).toBe(200);
+  });
+
+  it("does not read the Claude surface for a non-Claude provider", async () => {
+    // The guard must cost nothing on a save it cannot apply to. On a Jetson a
+    // stray cache read per save is not free.
+    const res = await configurePost(jsonRequest({
+      provider: "google",
+      apiKey: "goog-key",
+      model: "gemini-3-pro",
+    }));
+
+    expect(res.status).toBe(200);
+    expect(mockSurfaceRead).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Follow-up to #520. One residual, closed.

## RES-520-A — `/setup-api/ai-models/configure` is the second write path to `agents.defaults.model.primary` and applied no subscription-surface guard

**Reproduced against merged beta** (`cd90857a`), by the two tests below failing on unmodified `origin/beta`.

#520 added `refuseOffSurfaceClaudeModel` at both guard sites inside `src/app/setup-api/chat/model/route.ts`, explicitly *"for ids that arrive some other way"*. The other way is a different route.

`configure/route.ts` validates a typed custom id for **shape only** — `isValidModelId(targetProvider, requestedModel)`, under the comment *"We don't check against the curated list"* — then writes `config.defaultModel = anthropic/<requestedModel>` and pushes it to `agents.defaults.model.primary`. Nothing in that file imported `@/lib/subscription-surface`.

The client-side rule does not close it either. `AIModelsStep`'s `isModelUsable` only greys out **catalogue** rows; the custom-id path is deliberately exempt (*"A typed custom id is always allowed through"*), and `allowCustom` is true for anthropic. `saveOAuthToken` sends `getRequestedCatalogModelId(true)` verbatim on the subscription path.

So on a Claude-subscription box a customer who flips to "custom model ID", types `claude-fable-5`, and signs in pins the box to a model the `claude-cli` surface cannot route — precisely the failure #520 removed from the chat header. Arch-independent, so it bites on shipped aarch64 hardware.

## The fix: one rule, not two copies

`refuseOffSurfaceClaudeModel` is lifted out of `chat/model/route.ts` into `@/lib/subscription-surface` as `offSurfaceClaudeModelMessage` (plus `isClaudeSubscriptionOnly`, the "is this box Claude-subscription-only" question both routes ask). Each route keeps a thin wrapper that turns the message into its own `NextResponse`. The chat route's behaviour and wording are byte-for-byte unchanged — its 17 existing tests pass untouched.

Two things about the new call site are deliberate:

**It judges the settled `config.defaultModel`, not the typed id.** The typed-id field is the door that was reported, but the same save writes the `PROVIDERS`-table default when nothing is typed. Checking after every branch has had its say is one check for every value this save can put in `primary`.

**It asks whether the box will be subscription-only *after* this save, not before.** Reading the profiles on disk alone gets both directions backwards. A first Claude sign-in is *what writes* the OAuth profile that makes the box subscription-only, so disk alone would wave the very first sign-in straight through; and an API-key save writes the key that makes the API-only models routable, so refusing there would block the very switch the message recommends ("switch Anthropic to API-key mode"). So the API-key half is the enclosing branch — only a subscription save is checked at all — and the predicate overlays the OAuth profile entry `baseOps` is about to write onto the ones already on disk before asking. A key held under some *other* profile key still counts, and still allows.

**Placement.** After the Hermes branch — a Hermes box has no `openclaw.json` to read, and that branch refuses a subscription save outright — and before `writeAuthProfiles`, so a refusal leaves no half-applied save behind. `UNKNOWN` (unreadable or empty surface cache) still means *allow*, the same rule the pickers and the chat route obey.

## How I know I found every sibling

The class is: a write to `agents.defaults.model.primary` that accepts a model id without asking the subscription surface about it. The grep:

```
grep -rn "agents\.defaults\.model\.primary" src/ scripts/ | grep -v "__tests__\|\.test\."
```

Four write sites, all accounted for:

| site | status |
|---|---|
| `chat/model/route.ts:634` | guarded by #520 (both doors) |
| `ai-models/configure/route.ts:1717` | **guarded by this PR** |
| `local-ai/exclusive/route.ts:274` | writes the local (`llamacpp/`/`ollama/`) model — never a Claude id |
| `local-ai/exclusive/route.ts:295` | restores the primary it saved at toggle-on. It accepts no new id, and refusing it would strand the box in Local-only with nothing to restore to — deliberately out of scope |
| `scripts/gateway-pre-start.sh:1254` | writes a `codex/` id, not anthropic |

And a second grep for anything else that reaches the same write indirectly:

```
grep -rn "refuseOffSurfaceClaudeModel\|subscription-surface\|readSubscriptionSurfaceIds\|subscriptionOnlyProviders" -r src/ --include=*.ts --include=*.tsx
```

That confirmed `chat/model/route.ts` was the only importer before this PR. `providers/default/route.ts` ("make this provider the default") writes nothing itself — it calls the `chat/model` POST handler as a plain function and so inherits the guard, which is exactly why it delegates.

## Tests — red first

New: `src/tests/routes/ai-models/configure-subscription-surface.test.ts`, 8 tests.

Against unmodified `origin/beta`: **2 failed, 6 passed** — the two that assert the refusal (`expected 200 to be 400`). The other six are the guard's negative space (API-key saves, both-credentials boxes, unreadable cache, empty cache, non-Claude providers) and had to pass before and after, or the guard would be refusing things that work.

After the fix: **8 passed**, and #520's own 17 in `chat-model-subscription-surface.test.ts` still pass. `src/tests/routes/ai-models/` + `chat-model*` + `providers/` together: 269 passed, 0 failed.

`eslint` on the four touched files: 0 errors, 2 warnings, both pre-existing (`_api`, `OPENAI_PRO_MODEL_RE`). `tsc --noEmit`: no new errors — the ones that remain are the same pre-existing test-file errors present on `origin/beta`.
