### PR TITLE
fix: remove only what a skill request actually created, and check both halves

### DIFF
--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -168,6 +168,18 @@ const uninstallRules = (name: string): ErrorRule[] => [
     next: BUILTIN_NEXT,
   },
   {
+    // The lock entry went, the directory did not. Retrying cannot help: the CLI
+    // has nothing left to uninstall and the files it could not delete are the
+    // whole problem, so a person has to deal with them on the device.
+    status: 409,
+    match: /"code"\s*:\s*"removal_incomplete"/,
+    code: "CONFLICT",
+    message: `The device removed "${name}" from the store but could not delete its files.`,
+    next:
+      "Do NOT retry — there is nothing left in the store to remove. Tell the user the skill's "
+      + "folder is still on the device and has to be deleted there.",
+  },
+  {
     status: 502,
     code: "CONFLICT",
     message: "The device could not remove that skill.",

--- a/src/app/setup-api/hermes/skills/install/route.ts
+++ b/src/app/setup-api/hermes/skills/install/route.ts
@@ -217,13 +217,19 @@ export async function POST(request: Request) {
   const lockName = (await resolveLockKey(id)) || (cliId !== id ? await resolveLockKey(cliId) : null) || fallbackName;
   const entry = hubLockEntry(await readHubLock(), lockName);
 
-  // Was this install already on the device before the request, with its files
-  // where the agent reads them? Then it is not this route's to remove. Asked
-  // about the KEY the install landed under, against the PRE-request lock, so
-  // neither a phantom entry a previous failed rollback left (entry, no files)
-  // nor a second copy under another key can be mistaken for it.
-  const preDir = lockInstallDir(hubLockEntry(preLock, lockName));
-  const preInstalled = preDir !== null && (await pathExists(preDir));
+  // Was this install already on the device before the request? Then it is not
+  // this route's to remove. Asked about the KEY the install landed under,
+  // against the PRE-request lock, so a second copy of the same id under another
+  // key cannot be mistaken for it.
+  //
+  // The one pre-existing entry that IS still this route's to clear up is a
+  // phantom a previous failed rollback left behind: an entry whose directory is
+  // PROVABLY gone. Everything else is left alone — including an entry that names
+  // no `install_path`, where nothing about the files could be checked at all,
+  // because "could not check" has never been a licence to delete.
+  const preEntry = hubLockEntry(preLock, lockName);
+  const preDir = lockInstallDir(preEntry);
+  const preInstalled = preEntry !== undefined && (preDir === null || (await pathExists(preDir)));
 
   // ── 3. Did the scanner flag it? ──────────────────────────────────────────
   const report = scanReportFromLock(entry);

--- a/src/app/setup-api/hermes/skills/install/route.ts
+++ b/src/app/setup-api/hermes/skills/install/route.ts
@@ -12,18 +12,21 @@ import {
 } from "@/lib/hermes-skill-cli-outcome";
 import {
   type HubLockEntry,
-  SKILLS_DIR,
+  type SkillRemovalVerdict,
   hermesSkillsGuard,
+  hubLockEntry,
   invalidateInstalledCache,
   isInHubLock,
   lockInstallDir,
   officialSkillDir,
+  pathExists,
   readHubLock,
   readScanReport,
   readShadowableSkillNames,
   resolveLockKey,
   scanReportFromLock,
   updateLockFiles,
+  verifySkillRemoval,
 } from "@/lib/hermes-skills-server";
 import { getCatalogRecord } from "@/lib/hermes-skill-index";
 import {
@@ -38,7 +41,6 @@ import {
   githubTreeManifest,
   listSkillFiles,
   referencedSupportPaths,
-  removeSkillDir,
   repairFromGithub,
 } from "@/lib/hermes-skill-manifest";
 import { auditSkillInstall } from "@/lib/hermes-skill-audit";
@@ -80,8 +82,11 @@ import { auditSkillInstall } from "@/lib/hermes-skill-audit";
 //     installer's collision guard only reads the hub lock, which never contains
 //     bundled skills. Now: refused up front, with the option of a distinct name.
 //
-// Every refusal cleans up after itself: the CLI's uninstall drops the lock
-// entry, and the install directory is removed directly in case it did not.
+// Every refusal cleans up after ITSELF: the CLI's uninstall drops the lock
+// entry, and the install directory is removed directly in case it did not — but
+// only for an install this request actually made. A skill the device already
+// had is left exactly as it was found, because a request to install something
+// is never a licence to delete it.
 
 /** How long the Hermes CLI gets for one install (scan + fetch on a Jetson). */
 const INSTALL_TIMEOUT_MS = 120_000;
@@ -156,6 +161,12 @@ export async function POST(request: Request) {
   // A bare ClawHub slug has to be sent as `clawhub/<slug>` or the CLI resolves
   // nothing — see cliInstallIdentifier(). `id` itself stays as the customer
   // typed/clicked it for the catalog lookup, the lock check and the audit log.
+  //
+  // The lock is read FIRST, as it was before this request. `rollback()` may only
+  // undo what this request did, and once the CLI has run nothing is left to say
+  // which entries it found and which it wrote — the installer will not overwrite
+  // its own entry, it prints "is already installed" and exits 0.
+  const preLock = await readHubLock();
   const cliId = cliInstallIdentifier(id, record?.source);
   const args = ["skills", "install", cliId, "--yes"];
   if (confirmDangerous) args.push("--force");
@@ -204,7 +215,15 @@ export async function POST(request: Request) {
     });
   }
   const lockName = (await resolveLockKey(id)) || (cliId !== id ? await resolveLockKey(cliId) : null) || fallbackName;
-  const entry = (await readHubLock())[lockName];
+  const entry = hubLockEntry(await readHubLock(), lockName);
+
+  // Was this install already on the device before the request, with its files
+  // where the agent reads them? Then it is not this route's to remove. Asked
+  // about the KEY the install landed under, against the PRE-request lock, so
+  // neither a phantom entry a previous failed rollback left (entry, no files)
+  // nor a second copy under another key can be mistaken for it.
+  const preDir = lockInstallDir(hubLockEntry(preLock, lockName));
+  const preInstalled = preDir !== null && (await pathExists(preDir));
 
   // ── 3. Did the scanner flag it? ──────────────────────────────────────────
   const report = scanReportFromLock(entry);
@@ -225,6 +244,18 @@ export async function POST(request: Request) {
     : null;
 
   if (warning && !confirmDangerous) {
+    // The skill was already here, and the installer exited 0 without touching
+    // it. There is nothing to refuse and nothing to undo — and undoing it would
+    // uninstall a skill the customer already had, possibly one they had
+    // confirmed through this very dialog. `caution` is outside CLEAN_VERDICTS,
+    // so on ClawHub that is most of the catalogue.
+    if (preInstalled) {
+      return await alreadyInstalled(warning, {
+        id,
+        name: lockName,
+        findingCount: findings.length,
+      });
+    }
     const undo = await rollback(lockName, entry);
     // A refusal we could not carry out is not the refusal the caller expects:
     // answering `dangerous_skill` here would invite a confirmation that walks
@@ -248,23 +279,30 @@ export async function POST(request: Request) {
   // ── 4. Did every file actually land? ─────────────────────────────────────
   const completeness = await verifyAndRepair(entry, record);
   if (completeness && completeness.missing.length > 0) {
-    const undo = await rollback(lockName, entry);
-    if (!undo.clean) {
-      return await rollbackIncomplete(undo, {
-        id,
-        name: lockName,
-        // Deliberately not "the download was incomplete": the same branch is
-        // reached when the installer met a lock entry a previous rollback could
-        // not remove, exited 0 without fetching anything, and there was no
-        // download to blame. What is true in both cases is that the files are
-        // not there.
-        cause: `Some of "${lockName}"'s files are missing from the device, so it was not installed.`,
-        source: entry?.source,
-        trust: entry?.trust_level,
-        scanVerdict: verdict,
-        missingFiles: completeness.missing.slice(0, 20),
-        warning,
-      });
+    const missingFiles = completeness.missing.slice(0, 20);
+    // Same rule at the second gate: an installation this request did not make is
+    // not this request's to delete. A short file list is a reason to tell the
+    // customer, not a licence to remove what they had — and the repair above has
+    // already had its go at completing it.
+    if (!preInstalled) {
+      const undo = await rollback(lockName, entry);
+      if (!undo.clean) {
+        return await rollbackIncomplete(undo, {
+          id,
+          name: lockName,
+          // Deliberately not "the download was incomplete": the same branch is
+          // reached when the installer met a lock entry a previous rollback could
+          // not remove, exited 0 without fetching anything, and there was no
+          // download to blame. What is true in both cases is that the files are
+          // not there.
+          cause: `Some of "${lockName}"'s files are missing from the device, so it was not installed.`,
+          source: entry?.source,
+          trust: entry?.trust_level,
+          scanVerdict: verdict,
+          missingFiles,
+          warning,
+        });
+      }
     }
     await auditSkillInstall({
       action: "install-incomplete",
@@ -273,13 +311,21 @@ export async function POST(request: Request) {
       source: entry?.source,
       trust: entry?.trust_level,
       verdict,
-      missingFiles: completeness.missing.slice(0, 20),
+      missingFiles,
     });
     return NextResponse.json(
       {
-        error: "The download was incomplete — the skill was not installed.",
+        // Two different true sentences, because the device is in two different
+        // states: nothing of this request's survives the rollback above, but a
+        // pre-existing install is still there and still the customer's.
+        error: preInstalled
+          ? `Some of "${lockName}"'s files are missing from the device. It was already `
+            + `installed before this request, so it was left in place — remove it from the `
+            + `Skills store and install it again.`
+          : "The download was incomplete — the skill was not installed.",
         code: "incomplete_install",
-        missingFiles: completeness.missing.slice(0, 20),
+        ...(preInstalled ? { preexisting: true } : {}),
+        missingFiles,
         expectedCount: completeness.expectedCount,
         presentCount: completeness.presentCount,
         manifestOrigin: completeness.origin,
@@ -534,22 +580,44 @@ async function findShadowConflict(
 }
 
 /**
- * What the skill directory is doing after a rollback.
+ * The 409 for a flagged skill the device ALREADY had.
  *
- * Three states, not two, because "not known to be there" is not "gone": a lock
- * entry that names no `install_path` gives the removal nothing to aim at, so
- * nothing about the directory was checked and nothing about it may be claimed.
+ * Not `dangerous_skill`: that answer says an install was refused, invites a
+ * confirmation, and — before this — was returned after a rollback had removed
+ * the customer's existing installation. Nothing was installed here and nothing
+ * was removed, so the honest answer is the one the CLI itself gave, with the
+ * scan verdict attached so the store can still say why the device is unhappy
+ * about a skill the customer is keeping.
  */
-type RollbackDir = "present" | "absent" | "unknown";
-
-/** What a rollback ACHIEVED, as opposed to what the CLI printed about it. */
-interface RollbackVerdict {
-  /** No lock entry survived and no directory is known to have. */
-  clean: boolean;
-  /** The hub lock still lists the skill — every store surface calls it installed. */
-  lockEntry: boolean;
-  /** The skill directory is still on disk — the agent would load it. */
-  dir: RollbackDir;
+async function alreadyInstalled(
+  warning: SkillDangerWarning,
+  ctx: { id: string; name: string; findingCount: number },
+): Promise<NextResponse> {
+  await auditSkillInstall({
+    action: "install-already-installed",
+    id: ctx.id,
+    name: ctx.name,
+    source: warning.source,
+    trust: warning.trust,
+    verdict: warning.verdict,
+    findingCount: ctx.findingCount,
+    capabilities: warning.capabilities.map((c) => c.id),
+    severities: warning.severityCounts,
+  });
+  return NextResponse.json(
+    {
+      error:
+        `"${ctx.name}" is already installed on this device, so nothing was installed or `
+        + `removed. Its security scan returned a ${warning.verdict ?? "failing"} verdict — `
+        + `remove it from the Skills store if you no longer want it.`,
+      code: "already_installed",
+      requiresConfirmation: false,
+      removed: false,
+      name: ctx.name,
+      warning,
+    },
+    { status: 409 },
+  );
 }
 
 /**
@@ -572,11 +640,17 @@ interface RollbackVerdict {
  * installed from the hub, and the route said it had refused the install.
  *
  * So: read the outcome, both halves of it, and let the caller answer honestly.
+ *
+ * ONLY for an install THIS request made. Both call sites check the pre-request
+ * lock first: `hermes skills install` on a skill the device already has exits 0
+ * printing "is already installed" and writes nothing, which used to make the
+ * scan gate uninstall the customer's existing copy and then report that it had
+ * refused an install.
  */
 async function rollback(
   lockName: string,
   entry: HubLockEntry | undefined,
-): Promise<RollbackVerdict> {
+): Promise<SkillRemovalVerdict> {
   try {
     await runHermesCli(["skills", "uninstall", lockName], {
       timeoutMs: UNINSTALL_TIMEOUT_MS,
@@ -585,39 +659,9 @@ async function rollback(
   } catch (err) {
     console.error("[hermes skills install] rollback uninstall failed", err);
   }
-  const installPath = entry?.install_path;
-  // `unknown` until something actually looks. With no `install_path` there is
-  // nothing to look at, and the honest answer is not `absent`: the CLI may well
-  // have left a directory behind at a location this route was never told.
-  let dir: RollbackDir = "unknown";
-  if (installPath) {
-    // Two things can leave the directory behind, so both are checked: a path
-    // `removeSkillDir` will not resolve (it answers false and removes nothing),
-    // and a removal it believes it made — `fs.rm` on a tree it cannot fully
-    // traverse, the root-owned subdirectory case this device family produces.
-    const removed = await removeSkillDir(SKILLS_DIR, installPath);
-    const abs = lockInstallDir(entry);
-    const stillThere = !removed || (abs !== null && (await pathExists(abs)));
-    dir = stillThere ? "present" : "absent";
-  }
-  invalidateInstalledCache();
-  // Read the lock AFTER the CLI, never before: it is the only thing that says
-  // whether the store will still list this skill.
-  const lockEntry = await isInHubLock(lockName, entry?.identifier);
-  // `unknown` alone is not a failure. The store lists what the lock lists, so a
-  // vanished lock entry means the customer sees nothing and has nothing to act
-  // on; refusing here would report a failure over a rollback that did its job —
-  // the mirror image of the bug this whole change exists to fix.
-  return { clean: !lockEntry && dir !== "present", lockEntry, dir };
-}
-
-async function pathExists(p: string): Promise<boolean> {
-  try {
-    await fs.stat(p);
-    return true;
-  } catch {
-    return false;
-  }
+  // The directory half and the post-condition, shared with the uninstall route
+  // so the two surfaces cannot answer differently about one device state.
+  return await verifySkillRemoval(lockName, entry);
 }
 
 /**
@@ -631,7 +675,7 @@ async function pathExists(p: string): Promise<boolean> {
  * carried, so no surface loses what it already showed.
  */
 async function rollbackIncomplete(
-  left: RollbackVerdict,
+  left: SkillRemovalVerdict,
   ctx: {
     id: string;
     name: string;

--- a/src/app/setup-api/hermes/skills/install/route.ts
+++ b/src/app/setup-api/hermes/skills/install/route.ts
@@ -19,7 +19,7 @@ import {
   isInHubLock,
   lockInstallDir,
   officialSkillDir,
-  pathExists,
+  pathState,
   readHubLock,
   readScanReport,
   readShadowableSkillNames,
@@ -224,12 +224,14 @@ export async function POST(request: Request) {
   //
   // The one pre-existing entry that IS still this route's to clear up is a
   // phantom a previous failed rollback left behind: an entry whose directory is
-  // PROVABLY gone. Everything else is left alone — including an entry that names
-  // no `install_path`, where nothing about the files could be checked at all,
-  // because "could not check" has never been a licence to delete.
+  // PROVABLY gone — an ENOENT, and nothing else. Everything else is left alone:
+  // an entry that names no `install_path`, and a stat that failed for any other
+  // reason (EACCES on the root-owned subtree this device family produces, EIO,
+  // a stalled mount). "Could not check" has never been a licence to delete.
   const preEntry = hubLockEntry(preLock, lockName);
   const preDir = lockInstallDir(preEntry);
-  const preInstalled = preEntry !== undefined && (preDir === null || (await pathExists(preDir)));
+  const preInstalled =
+    preEntry !== undefined && (preDir === null || (await pathState(preDir)) !== "absent");
 
   // ── 3. Did the scanner flag it? ──────────────────────────────────────────
   const report = scanReportFromLock(entry);

--- a/src/app/setup-api/hermes/skills/uninstall/route.ts
+++ b/src/app/setup-api/hermes/skills/uninstall/route.ts
@@ -6,9 +6,12 @@ import { isValidSkillName } from "@/lib/hermes-skills";
 import { parseUninstallOutcome } from "@/lib/hermes-skill-cli-outcome";
 import {
   hermesSkillsGuard,
+  hubLockEntry,
   invalidateInstalledCache,
   isInHubLock,
   readBundledManifestNames,
+  readHubLock,
+  verifySkillRemoval,
 } from "@/lib/hermes-skills-server";
 
 // Uninstall a Hermes skill. The positional argument is the skill NAME (the
@@ -26,6 +29,21 @@ import {
 // told the customer a skill was gone while the device still had it. Now the
 // CLI's own sentence is classified (parseUninstallOutcome), and a success has
 // to be true in the hub lock before it is reported.
+//
+// ── …and the hub lock is only half of it ────────────────────────────────────
+//
+// Removing a skill has TWO halves: the lock entry, which is what the store
+// lists, and the DIRECTORY, which is what the agent loads. PR #517 rewrote the
+// install route's rollback around that — "a skill directory left behind would be
+// loaded by the agent even with no lock entry" — and this route, driving the
+// same command, still stopped at the lock. On the device state #517's own test
+// names (a lock entry whose install_path the validator refuses, an `fs.rm` that
+// cannot traverse a root-owned subtree) the CLI drops the entry and leaves the
+// files, and `{"ok":true}` here left the customer with a skill the agent still
+// loads, re-listed by `enumerateInstalledSkills` as origin `local` — which the
+// store will not offer to remove and MCP's post-condition reads as a CONFLICT.
+// Both routes now take the same second swing and read the same verdict
+// (verifySkillRemoval).
 
 export async function POST(request: Request) {
   const blocked = await hermesSkillsGuard();
@@ -46,7 +64,11 @@ export async function POST(request: Request) {
   try {
     // Read the lock BEFORE the CLI runs: for a wording this parser has never
     // seen, an entry that was there and is gone afterwards is still a removal.
-    const hadEntry = await isInHubLock(id);
+    // The ENTRY, not just the boolean — `install_path` is the only thing that
+    // says where the files the CLI is supposed to delete actually live, and
+    // after the CLI has run there is no entry left to ask.
+    const entry = hubLockEntry(await readHubLock(), id);
+    const hadEntry = entry !== undefined;
     const r = await runHermesCli(["skills", "uninstall", id], {
       timeoutMs: 30_000,
       input: "y\n",
@@ -112,6 +134,29 @@ export async function POST(request: Request) {
           code: "uninstall_failed",
         },
         { status: 502 },
+      );
+    }
+    // The lock half is done. Take the same second swing at the directory the
+    // install route's rollback takes — the CLI's own `fs.rm` is the half that
+    // fails silently on this device family — and answer on the whole verdict.
+    // Only now: deleting the files under a lock entry that survived would
+    // manufacture the half-removed state this is here to detect.
+    const left = await verifySkillRemoval(id, entry);
+    if (left.dir === "present") {
+      console.error("[hermes skills uninstall] directory survived", JSON.stringify(id));
+      return NextResponse.json(
+        {
+          // The store no longer lists it, so "remove it from the Skills store"
+          // is advice that cannot be followed — say the one thing that can.
+          error:
+            `"${id}" is no longer listed in the Skills store, but its files are still on the `
+            + `device, so the agent would still load it. The leftover folder has to be deleted `
+            + `on the device.`,
+          code: "removal_incomplete",
+          name: id,
+          leftover: { lockEntry: left.lockEntry, directory: left.dir },
+        },
+        { status: 409 },
       );
     }
     return NextResponse.json({ ok: true, id, name: id });

--- a/src/app/setup-api/hermes/skills/uninstall/route.ts
+++ b/src/app/setup-api/hermes/skills/uninstall/route.ts
@@ -142,16 +142,35 @@ export async function POST(request: Request) {
     // Only now: deleting the files under a lock entry that survived would
     // manufacture the half-removed state this is here to detect.
     const left = await verifySkillRemoval(id, entry);
-    if (left.dir === "present") {
-      console.error("[hermes skills uninstall] directory survived", JSON.stringify(id));
+    // The whole verdict, not one field of it. `stillLocked` above was read
+    // before the directory removal, and nothing serialises this route against a
+    // concurrent install of the same name — so an entry that reappeared in the
+    // meantime has to be answered too, and `clean` is the answer that carries
+    // both halves.
+    if (!left.clean) {
+      console.error(
+        "[hermes skills uninstall] removal incomplete",
+        JSON.stringify(id),
+        "lockEntry:",
+        left.lockEntry,
+        "dir:",
+        left.dir,
+      );
+      // Say only what was established, and give the next step that state
+      // actually has: a leftover the store cannot see is a leftover the store
+      // cannot remove.
+      const leftover = left.lockEntry
+        ? left.dir === "present"
+          ? `it is listed in the Skills store again and its files are on the device`
+          : `it is listed in the Skills store again`
+        : `it is no longer listed in the Skills store, but its files are still on the device, `
+          + `so the agent would still load it`;
+      const nextStep = left.lockEntry
+        ? `Check Settings -> Skills, and remove it again if it is still there.`
+        : `The leftover folder has to be deleted on the device.`;
       return NextResponse.json(
         {
-          // The store no longer lists it, so "remove it from the Skills store"
-          // is advice that cannot be followed — say the one thing that can.
-          error:
-            `"${id}" is no longer listed in the Skills store, but its files are still on the `
-            + `device, so the agent would still load it. The leftover folder has to be deleted `
-            + `on the device.`,
+          error: `"${id}" was not fully removed: ${leftover}. ${nextStep}`,
           code: "removal_incomplete",
           name: id,
           leftover: { lockEntry: left.lockEntry, directory: left.dir },

--- a/src/components/HermesSkillsStore.tsx
+++ b/src/components/HermesSkillsStore.tsx
@@ -212,6 +212,15 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
         if (res.status === 502 && data?.code === 'incomplete_install') {
           throw new Error(COPY.installIncomplete((data.missingFiles as string[]) || []));
         }
+        // A rollback the device could not finish leaves a lock entry THIS
+        // request created, and the message tells the customer to remove it from
+        // this very store. The Installed tab still holds the pre-request list,
+        // so the row they are being sent to is not on screen until the list is
+        // re-read — the generic throw below goes straight to the error toast.
+        if (res.status === 409 && data?.code === 'rollback_incomplete') {
+          await installed.refresh();
+          throw new Error(String(data.error || COPY.installFailed));
+        }
         if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
         setProgressAutoClear(key, { status: 'success' }, 2000);
         // The detail answer changes completely once a skill is on disk (full
@@ -245,6 +254,13 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
           body: JSON.stringify({ id: name }),
         });
         const data = await res.json().catch(() => ({}));
+        // The mirror image on the way out: the lock entry went and the files did
+        // not, so the skill comes back into the list as a local one the store
+        // cannot offer to remove. The customer has to be able to see that.
+        if (res.status === 409 && data?.code === 'removal_incomplete') {
+          await installed.refresh();
+          throw new Error(String(data.error || COPY.uninstallFailed));
+        }
         if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
         const timer = timers.current.get(key);
         if (timer) clearTimeout(timer);

--- a/src/lib/hermes-skill-audit.ts
+++ b/src/lib/hermes-skill-audit.ts
@@ -45,6 +45,12 @@ export interface SkillAuditRecord {
     | 'install-incomplete'
     /** The install was refused and the device could not undo it — see the route. */
     | 'install-rollback-incomplete'
+    /**
+     * A flagged skill the device ALREADY had: the installer exited 0 without
+     * touching it and the route removed nothing. Recorded because it is the
+     * request that used to uninstall the customer's existing copy.
+     */
+    | 'install-already-installed'
     | 'install-name-conflict';
   /** Registry identifier the owner asked for. */
   id: string;

--- a/src/lib/hermes-skills-server.ts
+++ b/src/lib/hermes-skills-server.ts
@@ -24,6 +24,7 @@ import path from 'path';
 import { NextResponse } from 'next/server';
 import type { InstalledHermesSkill, ScanFinding, SkillOrigin } from '@/lib/hermes-skills';
 import { parseSkillFrontmatter, type SkillFrontmatter } from '@/lib/hermes-skill-frontmatter';
+import { removeSkillDir } from '@/lib/hermes-skill-manifest';
 import { getActiveHarness } from '@/lib/harness';
 import { hermesConfigGet } from '@/lib/hermes-config-cache';
 import { isValidSkillName } from '@/lib/hermes-skills';
@@ -97,14 +98,20 @@ export async function readHubLock(): Promise<Record<string, HubLockEntry>> {
 }
 
 /**
- * The lock entry stored under exactly `key`, or undefined.
+ * The lock entry stored under exactly `key` in a lock ALREADY READ, or
+ * undefined.
  *
  * Every lookup into `installed` goes through here because the key is caller
  * data: a plain `installed[key]` answers '__proto__', 'constructor' and
  * 'toString' out of Object.prototype even for a lock that lists none of them,
  * and an inherited member is not an installed skill.
+ *
+ * It takes the lock rather than reading one so a caller can ask about a
+ * SNAPSHOT: the install route reads the lock before the CLI runs, to tell an
+ * entry this request created from one that was already there, and a fresh
+ * `readHubLock()` afterwards would answer about a file the CLI has rewritten.
  */
-function ownEntry(
+export function hubLockEntry(
   installed: Record<string, HubLockEntry>,
   key: string,
 ): HubLockEntry | undefined {
@@ -597,7 +604,7 @@ export async function updateLockFiles(name: string, files: string[]): Promise<bo
   // Object.prototype, which is truthy, and the assignment below would then hang
   // a `files` property off every object in the process. Object.entries() only
   // ever yields own enumerable keys, so no inherited member can be selected.
-  const entry = ownEntry(installed, name);
+  const entry = hubLockEntry(installed, name);
   if (!entry) return false;
   entry.files = files.slice(0, 500).sort();
   try {
@@ -617,6 +624,90 @@ export function lockInstallDir(entry: HubLockEntry | undefined): string | null {
 let installedCache: { key: string; value: InstalledHermesSkill[] } | null = null;
 const INSTALLED_TTL_MS = 10_000;
 let installedCacheAt = 0;
+
+// ── Removing a skill: the post-condition both routes need ───────────────────
+//
+// Removing a Hermes skill has TWO halves. `hermes skills uninstall` drops the
+// LOCK ENTRY — what every store surface lists — and is supposed to delete the
+// DIRECTORY, which is what the agent actually loads. It exits 0 whether it did
+// either, so neither half may be inferred from its exit code, and a directory
+// left behind is loaded by the agent with no lock entry to show for it.
+//
+// PR #517 established that for the install route's rollback and left the
+// uninstall route checking only the lock. One implementation, used by both, is
+// what stops the two answering differently about the same device state.
+
+/**
+ * What the skill directory is doing after a removal.
+ *
+ * Three states, not two, because "not known to be there" is not "gone": a lock
+ * entry that names no `install_path` gives the removal nothing to aim at, so
+ * nothing about the directory was checked and nothing about it may be claimed.
+ */
+export type SkillRemovalDir = 'present' | 'absent' | 'unknown';
+
+/** What a removal ACHIEVED, as opposed to what the CLI printed about it. */
+export interface SkillRemovalVerdict {
+  /** No lock entry survived and no directory is known to have. */
+  clean: boolean;
+  /** The hub lock still lists the skill — every store surface calls it installed. */
+  lockEntry: boolean;
+  /** The skill directory is still on disk — the agent would load it. */
+  dir: SkillRemovalDir;
+}
+
+/** fs.stat as a boolean. */
+export async function pathExists(p: string): Promise<boolean> {
+  try {
+    await fs.stat(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Take the second swing at the directory, then report what is left of the skill.
+ *
+ * Call this AFTER `hermes skills uninstall` has run and only once the lock half
+ * is believed to have worked: it deletes the directory the entry names, and
+ * deleting the files under a lock entry that survived would manufacture exactly
+ * the half-removed state this exists to detect.
+ *
+ * The lock question is asked about the KEY, never the identifier. The key came
+ * out of the lock, so the CLI can only have removed that one key; matching on
+ * the identifier as well scans every other entry and can therefore only produce
+ * FALSE failures — a second copy of the same store id under a different name
+ * would report a completed removal as incomplete.
+ */
+export async function verifySkillRemoval(
+  lockKey: string,
+  entry: HubLockEntry | undefined,
+): Promise<SkillRemovalVerdict> {
+  const installPath = entry?.install_path;
+  // `unknown` until something actually looks. With no `install_path` there is
+  // nothing to look at, and the honest answer is not `absent`: the CLI may well
+  // have left a directory behind at a location this route was never told.
+  let dir: SkillRemovalDir = 'unknown';
+  if (installPath) {
+    // Two things can leave the directory behind, so both are checked: a path
+    // `removeSkillDir` will not resolve (it answers false and removes nothing),
+    // and a removal it believes it made — `fs.rm` on a tree it cannot fully
+    // traverse, the root-owned subdirectory case this device family produces.
+    const removed = await removeSkillDir(SKILLS_DIR, installPath);
+    const abs = lockInstallDir(entry);
+    const stillThere = !removed || (abs !== null && (await pathExists(abs)));
+    dir = stillThere ? 'present' : 'absent';
+  }
+  invalidateInstalledCache();
+  // Read the lock AFTER the CLI, never before: it is the only thing that says
+  // whether the store will still list this skill.
+  const lockEntry = Object.prototype.hasOwnProperty.call(await readHubLock(), lockKey);
+  // `unknown` alone is not a failure. The store lists what the lock lists, so a
+  // vanished lock entry means the customer sees nothing and has nothing to act
+  // on; refusing here would report a failure over a removal that did its job.
+  return { clean: !lockEntry && dir !== 'present', lockEntry, dir };
+}
 
 /** Drop the installed-skill caches — called right after an install/uninstall. */
 export function invalidateInstalledCache(): void {

--- a/src/lib/hermes-skills-server.ts
+++ b/src/lib/hermes-skills-server.ts
@@ -656,13 +656,24 @@ export interface SkillRemovalVerdict {
   dir: SkillRemovalDir;
 }
 
-/** fs.stat as a boolean. */
-export async function pathExists(p: string): Promise<boolean> {
+/**
+ * Is this path there? Three answers, because a failed `stat` has two meanings.
+ *
+ * ENOENT is the only one that proves absence. EACCES, ENOTDIR, EIO and a
+ * timed-out network mount all mean the question could not be answered — and on
+ * this device family that is not hypothetical: the root-owned subtree that
+ * defeats the CLI's own `fs.rm` is exactly the kind of tree a stat can fail on.
+ * Reading any of them as "not there" is how a caller ends up deleting an
+ * installation it could not see.
+ */
+export type PathState = 'present' | 'absent' | 'unknown';
+
+export async function pathState(p: string): Promise<PathState> {
   try {
     await fs.stat(p);
-    return true;
-  } catch {
-    return false;
+    return 'present';
+  } catch (err) {
+    return (err as NodeJS.ErrnoException)?.code === 'ENOENT' ? 'absent' : 'unknown';
   }
 }
 
@@ -696,8 +707,13 @@ export async function verifySkillRemoval(
     // traverse, the root-owned subdirectory case this device family produces.
     const removed = await removeSkillDir(SKILLS_DIR, installPath);
     const abs = lockInstallDir(entry);
-    const stillThere = !removed || (abs !== null && (await pathExists(abs)));
-    dir = stillThere ? 'present' : 'absent';
+    if (!removed) {
+      dir = 'present';
+    } else if (abs !== null) {
+      // A stat that could not answer keeps `unknown`: it is the one honest
+      // label for "the removal claimed to work and nothing could confirm it".
+      dir = await pathState(abs);
+    }
   }
   invalidateInstalledCache();
   // Read the lock AFTER the CLI, never before: it is the only thing that says

--- a/src/tests/components/hermes-skills-leftover-refresh.test.tsx
+++ b/src/tests/components/hermes-skills-leftover-refresh.test.tsx
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
+import HermesSkillsStore from "@/components/HermesSkillsStore";
+
+/**
+ * PR #517's new 409 tells the customer to go and remove a leftover. The store
+ * never showed them the leftover.
+ *
+ * `rollback_incomplete` means the request created a lock entry the device could
+ * not take back — a NEW row in the installed list — and its message is
+ * "Remove "x" from the Skills store, then try again." `doInstall` falls through
+ * to the generic `if (!res.ok) throw` and lands in the catch, which only sets an
+ * error toast; `installed.refresh()` runs exclusively on the success path. So the
+ * Installed tab still shows the pre-request list, and the skill the customer has
+ * just been told to remove is not there to remove until they reload the page.
+ *
+ * The uninstall route's `removal_incomplete` is the mirror image — the lock entry
+ * went, the directory did not, and the skill comes back into the list as a local
+ * one — so it needs the same refresh.
+ */
+
+vi.mock("@/lib/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n")>();
+  const { skillsEn } = await import("@/lib/hermes-translations/en-skills");
+  return {
+    ...actual,
+    useT: () => ({
+      locale: "en" as const,
+      localeResolved: true,
+      setLocale: () => {},
+      t: (key: string, params?: Record<string, string | number>) =>
+        Object.entries(params ?? {}).reduce(
+          (out, [name, value]) => out.replaceAll(`{${name}}`, String(value)),
+          skillsEn[key] ?? key,
+        ),
+    }),
+  };
+});
+
+const SKILL = {
+  id: "official/pdf-tools",
+  name: "PDF Tools",
+  source: "official",
+  trust: "official",
+};
+
+const BROWSE = {
+  skills: [SKILL],
+  page: 1,
+  pageSize: 24,
+  total: 1,
+  totalPages: 1,
+  hasMore: false,
+  facets: { sources: [{ id: "official", label: "Official", count: 1 }], providers: [] },
+  catalog: { origin: "index", skillCount: 90_600, fetchedAt: new Date().toISOString(), stale: false },
+  degraded: false,
+};
+
+const LEFTOVER = {
+  error:
+    'This skill did not pass the device’s security scan. The device could not fully undo the '
+    + 'install: "pdf-tools" is still listed in the Skills store and its files are still on the '
+    + 'device. Remove "pdf-tools" from the Skills store, then try again.',
+  code: "rollback_incomplete",
+  requiresConfirmation: false,
+  name: "pdf-tools",
+  leftover: { lockEntry: true, directory: "present" },
+};
+
+const HUB_ROW = {
+  id: "pdf-tools",
+  name: "PDF Tools",
+  category: "other",
+  origin: "hub",
+  source: "official",
+  identifier: "official/pdf-tools",
+  enabled: true,
+};
+
+interface Installed {
+  skills: unknown[];
+  counts: { total: number };
+  categories: unknown[];
+}
+
+const EMPTY_INSTALLED: Installed = { skills: [], counts: { total: 0 }, categories: [] };
+
+/**
+ * Serves browse from a fixed page and the installed list from a script whose
+ * LAST entry repeats, so "did the store re-read the list?" is answered by the
+ * call count and by what ends up on screen.
+ */
+function mockStore(opts: { installedPages: Installed[]; action: () => unknown }) {
+  let installedCalls = 0;
+  const fetchMock = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/skills/browse")) return { ok: true, status: 200, json: async () => BROWSE };
+    // `/skills/installed` is a prefix match for `/skills/install`, so the list
+    // endpoint has to be recognised first.
+    if (url.includes("/skills/installed")) {
+      const body = opts.installedPages[Math.min(installedCalls, opts.installedPages.length - 1)];
+      installedCalls += 1;
+      return { ok: true, status: 200, json: async () => body };
+    }
+    if (url.includes("/skills/install") || url.includes("/skills/uninstall")) {
+      return opts.action();
+    }
+    return { ok: true, status: 200, json: async () => ({}) };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { installedCalls: () => installedCalls };
+}
+
+async function openBrowseTab() {
+  render(<HermesSkillsStore />);
+  const tab = await screen.findByTestId("skill-tab-browse");
+  await act(async () => {
+    fireEvent.click(tab);
+  });
+  await screen.findByText("PDF Tools");
+}
+
+/** Click Install on the card, then confirm in the dialog. */
+async function installFromBrowse() {
+  const card = await screen.findByTestId("skill-install-btn");
+  await act(async () => {
+    fireEvent.click(within(card).getByRole("button"));
+  });
+  const dialog = await screen.findByRole("dialog");
+  await act(async () => {
+    fireEvent.click(within(dialog).getByRole("button", { name: "Install" }));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("a leftover the store has been told to remove has to be on screen", () => {
+  it("re-reads the installed list when an install reports a leftover it could not undo", async () => {
+    const { installedCalls } = mockStore({
+      // The phantom entry the failed rollback left is a NEW row: the first read
+      // (on mount) cannot contain it.
+      installedPages: [EMPTY_INSTALLED, { skills: [HUB_ROW], counts: { total: 1 }, categories: [] }],
+      action: () => ({ ok: false, status: 409, json: async () => LEFTOVER }),
+    });
+    await openBrowseTab();
+    const before = installedCalls();
+
+    await installFromBrowse();
+
+    await waitFor(() => expect(installedCalls()).toBeGreaterThan(before));
+  });
+
+  it("shows the leftover in the Installed tab, where the message says to remove it", async () => {
+    mockStore({
+      installedPages: [EMPTY_INSTALLED, { skills: [HUB_ROW], counts: { total: 1 }, categories: [] }],
+      action: () => ({ ok: false, status: 409, json: async () => LEFTOVER }),
+    });
+    await openBrowseTab();
+    await installFromBrowse();
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("skill-tab-installed"));
+    });
+    // The row the customer was told to remove, with the Remove button on it.
+    const removes = await screen.findAllByRole("button", { name: /remove/i });
+    expect(removes.length).toBeGreaterThan(0);
+  });
+
+  it("still tells the customer what happened", async () => {
+    mockStore({
+      installedPages: [EMPTY_INSTALLED],
+      action: () => ({ ok: false, status: 409, json: async () => LEFTOVER }),
+    });
+    await openBrowseTab();
+    await installFromBrowse();
+
+    expect(await screen.findByText(/could not fully undo the install/i)).toBeTruthy();
+  });
+
+  it("does not re-read the list for an ordinary refusal that changed nothing", async () => {
+    // The guard against turning every error into a refetch: a bundled-name
+    // conflict is refused BEFORE the CLI runs, so nothing on the device moved.
+    const { installedCalls } = mockStore({
+      installedPages: [EMPTY_INSTALLED],
+      action: () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({ code: "bundled_conflict", conflictsWith: "pdf", error: "no" }),
+      }),
+    });
+    await openBrowseTab();
+    const before = installedCalls();
+
+    await installFromBrowse();
+
+    await waitFor(() => expect(screen.getByText(/came with this device/i)).toBeTruthy());
+    expect(installedCalls()).toBe(before);
+  });
+});
+
+describe("the same rule for a removal the device could not finish", () => {
+  it("re-reads the installed list when an uninstall leaves the files behind", async () => {
+    const { installedCalls } = mockStore({
+      installedPages: [
+        { skills: [HUB_ROW], counts: { total: 1 }, categories: [] },
+        {
+          skills: [{ ...HUB_ROW, origin: "local", identifier: undefined }],
+          counts: { total: 1 },
+          categories: [],
+        },
+      ],
+      action: () => ({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          code: "removal_incomplete",
+          error:
+            'The device removed "pdf-tools" from the Skills store, but its files are still on the '
+            + "device.",
+          leftover: { lockEntry: false, directory: "present" },
+        }),
+      }),
+    });
+    render(<HermesSkillsStore />);
+    await act(async () => {
+      fireEvent.click(await screen.findByTestId("skill-tab-installed"));
+    });
+    const remove = (await screen.findAllByRole("button", { name: /remove/i }))[0];
+    const before = installedCalls();
+
+    await act(async () => {
+      fireEvent.click(remove);
+    });
+    const dialog = await screen.findByRole("dialog");
+    await act(async () => {
+      fireEvent.click(within(dialog).getByRole("button", { name: /remove/i }));
+    });
+
+    await waitFor(() => expect(installedCalls()).toBeGreaterThan(before));
+  });
+});

--- a/src/tests/routes/hermes/skills-install-preexisting.test.ts
+++ b/src/tests/routes/hermes/skills-install-preexisting.test.ts
@@ -290,6 +290,68 @@ describe("a re-install of a skill the device already has removes nothing", () =>
     expect(String(body.error)).toMatch(/left in place|left alone|already/i);
   });
 
+  it("leaves an entry alone when nothing about its files could be checked", async () => {
+    // A pre-existing lock entry that names no `install_path`: `lockInstallDir`
+    // resolves nothing, so the files can be neither confirmed nor ruled out.
+    // "Could not check" is not "this request created it", and the entry itself
+    // proves the request did not.
+    await writeSkill("creative/simple-english", "---\nname: simple-english\n---\nplain english\n");
+    await writeLock({
+      "simple-english": {
+        files: ["SKILL.md"],
+        identifier: "official/creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: "dangerous",
+        scan_provenance: DANGEROUS_SCAN,
+      },
+    });
+    fakeHermes({
+      defaultName: "simple-english",
+      installPath: "creative/simple-english",
+      files: { "SKILL.md": "---\nname: simple-english\n---\nplain english\n" },
+      lock: { identifier: "official/creative/simple-english", scan_verdict: "dangerous" },
+    });
+
+    const { body } = await install({ id: "official/creative/simple-english" });
+
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(body.code).toBe("already_installed");
+  });
+
+  it("still clears up a phantom entry whose files are provably gone", async () => {
+    // The pre-existing entry that IS this route's to remove: one a previous
+    // failed rollback left behind, with an install_path that resolves and
+    // nothing at the end of it. Preserving that would strand the customer with
+    // a store row for a skill that is not there.
+    await writeLock({
+      "simple-english": {
+        install_path: "creative/simple-english",
+        files: ["SKILL.md"],
+        identifier: "official/creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: "dangerous",
+        scan_provenance: DANGEROUS_SCAN,
+      },
+    });
+    fakeHermes({
+      defaultName: "simple-english",
+      installPath: "creative/simple-english",
+      files: { "SKILL.md": "---\nname: simple-english\n---\nplain english\n" },
+      lock: { identifier: "official/creative/simple-english", scan_verdict: "dangerous" },
+    });
+
+    const { body } = await install({ id: "official/creative/simple-english" });
+
+    expect(await readLock()).toEqual({});
+    expect(body.code).toBe("dangerous_skill");
+    expect(body.code).not.toBe("already_installed");
+  });
+
   it("still rolls back an install this request DID make", async () => {
     // The guard against over-correcting: with nothing pre-existing, a flagged
     // first install is still undone and still answered `dangerous_skill`.

--- a/src/tests/routes/hermes/skills-install-preexisting.test.ts
+++ b/src/tests/routes/hermes/skills-install-preexisting.test.ts
@@ -1,0 +1,412 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `rollback()` may only undo what THIS request did.
+ *
+ * PR #517 taught the install route to report a rollback it could not complete.
+ * It did not establish that there was anything of this route's to roll back.
+ * `hermes skills install` on an already-installed skill exits 0 printing "is
+ * already installed" and writes nothing — #517's own faithful fake reproduces
+ * exactly that ("The installer will not write over its own lock entry"). The
+ * pre-existing entry then makes `landed` true, the scan gate re-reads that
+ * entry's STORED verdict, `isFlaggedVerdict` treats anything outside
+ * CLEAN_VERDICTS as flagged — `caution` included, which is most of ClawHub —
+ * and with no `confirmDangerous` the route rolled back, uninstalling a skill the
+ * customer already had, including one they had previously confirmed through the
+ * danger dialog. It then said "This skill did not pass the device's security
+ * scan", describing an install it never made.
+ *
+ * Reachable from MCP with no UI at all: `skill_install` has no installed-list
+ * pre-condition (unlike `skill_uninstall`, which has one), so an agent asked
+ * twice to install the same skill destroys the existing installation.
+ *
+ * The second half of the same file: the post-condition #517 added asks "did the
+ * entry we tried to remove survive?" but answered it with `isInHubLock(lockName,
+ * entry.identifier)`, whose identifier arm scans EVERY entry. `lockName` came
+ * out of the lock, so the CLI can only have removed that one key — the identifier
+ * arm can therefore only produce FALSE POSITIVES, and a second copy of the same
+ * store id under a different lock key turns a clean rollback into
+ * `rollback_incomplete`.
+ *
+ * The CLI is faked FAITHFULLY, from the same observations #517's fake was built
+ * on: it refuses to overwrite its own lock entry, it honours `--name`, and its
+ * uninstall removes the lock key and the directory that key recorded.
+ */
+
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: vi.fn(async () => "hermes"),
+  HERMES_BIN: "/home/clawbox/.local/bin/hermes",
+}));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: vi.fn() }));
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet: vi.fn(async () => ""),
+  hermesConfigGetMany: vi.fn(async () => ({})),
+  invalidateHermesConfigCache: vi.fn(),
+}));
+vi.mock("@/lib/hermes-skill-index", () => ({ getCatalogRecord: vi.fn(async () => undefined) }));
+
+import { runHermesCli } from "@/lib/hermes-cli";
+import { getCatalogRecord } from "@/lib/hermes-skill-index";
+import { saveEnv } from "../../helpers/env";
+
+const mockCli = vi.mocked(runHermesCli);
+const mockRecord = vi.mocked(getCatalogRecord);
+
+let hermesHome: string;
+let clawboxRoot: string;
+
+function skillsDir(): string {
+  return path.join(hermesHome, "skills");
+}
+
+async function writeLock(installed: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(path.join(skillsDir(), ".hub"), { recursive: true });
+  await fs.writeFile(
+    path.join(skillsDir(), ".hub", "lock.json"),
+    JSON.stringify({ version: 1, installed }),
+  );
+}
+
+async function readLock(): Promise<Record<string, Record<string, unknown>>> {
+  const raw = await fs.readFile(path.join(skillsDir(), ".hub", "lock.json"), "utf8");
+  return (JSON.parse(raw) as { installed: Record<string, Record<string, unknown>> }).installed;
+}
+
+async function exists(p: string): Promise<boolean> {
+  return fs.access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+async function writeSkill(installPath: string, body: string): Promise<void> {
+  const dir = path.join(skillsDir(), installPath);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "SKILL.md"), body);
+}
+
+const DANGEROUS_SCAN = {
+  verdict: "dangerous",
+  scanner_version: "1.4.0",
+  findings: [
+    {
+      pattern_id: "agent-instruction-overwrite",
+      severity: "critical",
+      category: "persistence",
+      file: "SKILL.md",
+      line: 308,
+      description: "- **Agent instructions (prompts, AGENTS.md)**",
+    },
+  ],
+};
+
+/**
+ * The device's installer and uninstaller, as observed on the box.
+ *
+ * install:   refuses to overwrite its own lock entry (exit 0, "is already
+ *            installed"); otherwise writes the files and the lock entry under
+ *            the `--name` key when one is given.
+ * uninstall: removes the lock key and the directory that key recorded, and will
+ *            not delete a path that escapes the skills tree.
+ */
+function fakeHermes(newInstall: {
+  /** The lock key the installer would use when no `--name` is passed. */
+  defaultName: string;
+  installPath: string;
+  files: Record<string, string>;
+  lock: Record<string, unknown>;
+}): void {
+  mockCli.mockImplementation(async (args: string[]) => {
+    if (args[1] === "install") {
+      const nameFlag = args.indexOf("--name");
+      const key = nameFlag > -1 ? args[nameFlag + 1] : newInstall.defaultName;
+      const lock = await readLock();
+      if (Object.prototype.hasOwnProperty.call(lock, key)) {
+        return { code: 0, stdout: `Skill '${key}' is already installed\n`, stderr: "" };
+      }
+      const installPath = nameFlag > -1 ? key : newInstall.installPath;
+      for (const [rel, content] of Object.entries(newInstall.files)) {
+        const abs = path.join(skillsDir(), installPath, rel);
+        await fs.mkdir(path.dirname(abs), { recursive: true });
+        await fs.writeFile(abs, content);
+      }
+      lock[key] = {
+        install_path: installPath,
+        files: Object.keys(newInstall.files),
+        ...newInstall.lock,
+      };
+      await writeLock(lock);
+      return { code: 0, stdout: `Installed '${key}'\n`, stderr: "" };
+    }
+    if (args[1] === "uninstall") {
+      const lock = await readLock();
+      const entry = lock[args[2]] as { install_path?: string } | undefined;
+      if (!entry) {
+        return { code: 0, stdout: `Error: '${args[2]}' is not a hub-installed skill\n`, stderr: "" };
+      }
+      delete lock[args[2]];
+      await writeLock(lock);
+      const recorded = path.resolve(skillsDir(), entry.install_path ?? "");
+      if (entry.install_path && recorded.startsWith(skillsDir() + path.sep)) {
+        await fs.rm(recorded, { recursive: true, force: true });
+      }
+      return { code: 0, stdout: `Uninstalled '${args[2]}'\n`, stderr: "" };
+    }
+    return { code: 0, stdout: "", stderr: "" };
+  });
+}
+
+async function install(body: Record<string, unknown>) {
+  const { POST } = await import("@/app/setup-api/hermes/skills/install/route");
+  const res = await POST(
+    new Request("http://localhost/setup-api/hermes/skills/install", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+let restoreEnv: () => void;
+
+beforeEach(async () => {
+  vi.resetModules();
+  restoreEnv = saveEnv("HERMES_HOME", "CLAWBOX_ROOT");
+  hermesHome = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-hermes-pre-"));
+  clawboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-root-pre-"));
+  process.env.HERMES_HOME = hermesHome;
+  process.env.CLAWBOX_ROOT = clawboxRoot;
+  await fs.mkdir(skillsDir(), { recursive: true });
+  await writeLock({});
+  mockRecord.mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  restoreEnv();
+  await fs.rm(hermesHome, { recursive: true, force: true });
+  await fs.rm(clawboxRoot, { recursive: true, force: true });
+});
+
+// ── An install request may not remove an install it did not make ────────────
+
+describe("a re-install of a skill the device already has removes nothing", () => {
+  /** The customer's existing, complete, flagged install. */
+  async function seedFlagged(verdict: string): Promise<void> {
+    await writeSkill("creative/simple-english", "---\nname: simple-english\n---\nplain english\n");
+    await writeLock({
+      "simple-english": {
+        install_path: "creative/simple-english",
+        files: ["SKILL.md"],
+        identifier: "official/creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: verdict,
+        scan_provenance: { ...DANGEROUS_SCAN, verdict },
+      },
+    });
+    fakeHermes({
+      defaultName: "simple-english",
+      installPath: "creative/simple-english",
+      files: { "SKILL.md": "---\nname: simple-english\n---\nplain english\n" },
+      lock: { identifier: "official/creative/simple-english", scan_verdict: verdict },
+    });
+  }
+
+  it("leaves the lock entry and the files alone on an unconfirmed second install", async () => {
+    await seedFlagged("dangerous");
+
+    await install({ id: "official/creative/simple-english" });
+
+    // The whole defect in two assertions: the customer's skill is still there.
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english", "SKILL.md"))).toBe(
+      true,
+    );
+  });
+
+  it("says the skill is already installed rather than refusing an install it never made", async () => {
+    await seedFlagged("dangerous");
+
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(status).toBe(409);
+    expect(body.code).toBe("already_installed");
+    expect(body.code).not.toBe("dangerous_skill");
+    // Nothing to confirm: confirming would ask the device to install a skill it
+    // already has, and the answer must not read as though it had been removed.
+    expect(body.requiresConfirmation).not.toBe(true);
+    expect(String(body.error)).toMatch(/already installed/i);
+    // The scan verdict is still carried, so the store can still say WHY the
+    // device is unhappy about a skill the customer is keeping.
+    expect(body.warning).toBeTruthy();
+  });
+
+  it("treats a caution verdict the same way — that is most of the community catalogue", async () => {
+    await seedFlagged("caution");
+
+    const { body } = await install({ id: "official/creative/simple-english" });
+
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+    expect(body.code).toBe("already_installed");
+  });
+
+  it("does not delete an existing install because its file list is short", async () => {
+    // The route's OTHER rollback caller, reached with a clean verdict: a skill
+    // whose SKILL.md names a support file the installer never fetched. That is a
+    // reason to tell the customer, not a licence to remove what they had.
+    await writeSkill(
+      "algorithmic-art",
+      "---\nname: algorithmic-art\n---\nSee the [viewer](templates/viewer.html).\n",
+    );
+    await writeLock({
+      "algorithmic-art": {
+        install_path: "algorithmic-art",
+        files: ["SKILL.md"],
+        identifier: "x/algorithmic-art",
+        source: "clawhub",
+        trust_level: "community",
+        scan_verdict: "safe",
+      },
+    });
+    fakeHermes({
+      defaultName: "algorithmic-art",
+      installPath: "algorithmic-art",
+      files: { "SKILL.md": "---\nname: algorithmic-art\n---\n" },
+      lock: { identifier: "x/algorithmic-art", scan_verdict: "safe" },
+    });
+
+    const { status, body } = await install({ id: "x/algorithmic-art" });
+
+    expect(Object.keys(await readLock())).toEqual(["algorithmic-art"]);
+    expect(await exists(path.join(skillsDir(), "algorithmic-art", "SKILL.md"))).toBe(true);
+    expect(status).toBe(502);
+    expect(body.code).toBe("incomplete_install");
+    // …and the message may not claim the skill was not installed, because it is.
+    expect(String(body.error)).not.toMatch(/was not installed/i);
+    expect(String(body.error)).toMatch(/left in place|left alone|already/i);
+  });
+
+  it("still rolls back an install this request DID make", async () => {
+    // The guard against over-correcting: with nothing pre-existing, a flagged
+    // first install is still undone and still answered `dangerous_skill`.
+    fakeHermes({
+      defaultName: "simple-english",
+      installPath: "creative/simple-english",
+      files: { "SKILL.md": "---\nname: simple-english\n---\nplain english\n" },
+      lock: {
+        identifier: "official/creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: "dangerous",
+        scan_provenance: DANGEROUS_SCAN,
+      },
+    });
+
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(status).toBe(409);
+    expect(body).toMatchObject({ code: "dangerous_skill", requiresConfirmation: true });
+    expect(await readLock()).toEqual({});
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english"))).toBe(false);
+  });
+});
+
+// ── The post-condition has to ask about the KEY it tried to remove ──────────
+
+describe("a rollback that removed its own entry is not incomplete", () => {
+  it("is not failed by a different lock key that shares the identifier", async () => {
+    // The customer already runs this skill under its default name. The store id
+    // is installed a second time under an explicit `--name`, and the device
+    // records the adapter's normalised identifier on both.
+    await writeSkill("creative/simple-english", "---\nname: simple-english\n---\nplain english\n");
+    await writeLock({
+      "simple-english": {
+        install_path: "creative/simple-english",
+        files: ["SKILL.md"],
+        identifier: "creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: "safe",
+      },
+    });
+    fakeHermes({
+      defaultName: "simple-english",
+      installPath: "creative/simple-english",
+      files: { "SKILL.md": "---\nname: simple-english\n---\nplain english\n" },
+      lock: {
+        identifier: "creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: "dangerous",
+        scan_provenance: DANGEROUS_SCAN,
+      },
+    });
+
+    const { status, body } = await install({
+      id: "official/creative/simple-english",
+      name: "simple-english-2",
+    });
+
+    // The rollback did its whole job: its own key and its own directory are gone.
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+    expect(await exists(path.join(skillsDir(), "simple-english-2"))).toBe(false);
+    // So the customer must get the confirmation dialog, not an instruction to
+    // remove something from a store that no longer lists it.
+    expect(status).toBe(409);
+    expect(body.code).toBe("dangerous_skill");
+    expect(body.code).not.toBe("rollback_incomplete");
+    expect(body.requiresConfirmation).toBe(true);
+  });
+
+  it("still reports a leftover when the key itself survived", async () => {
+    // The guard on the other side: a rollback the CLI would not carry out is
+    // still reported, identifier arm or no identifier arm.
+    fakeHermes({
+      defaultName: "simple-english",
+      installPath: "creative/simple-english",
+      files: { "SKILL.md": "---\nname: simple-english\n---\nplain english\n" },
+      lock: {
+        identifier: "official/creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: "dangerous",
+        scan_provenance: DANGEROUS_SCAN,
+      },
+    });
+    mockCli.mockImplementationOnce(async (args: string[]) => {
+      // The install runs for real; the uninstall that follows throws (the 30 s
+      // timeout on a loaded Jetson).
+      const lock = await readLock();
+      await fs.mkdir(path.join(skillsDir(), "creative", "simple-english"), { recursive: true });
+      await fs.writeFile(
+        path.join(skillsDir(), "creative", "simple-english", "SKILL.md"),
+        "---\nname: simple-english\n---\nplain english\n",
+      );
+      lock["simple-english"] = {
+        install_path: "creative/simple-english",
+        files: ["SKILL.md"],
+        identifier: "official/creative/simple-english",
+        source: "official",
+        trust_level: "builtin",
+        scan_verdict: "dangerous",
+        scan_provenance: DANGEROUS_SCAN,
+      };
+      await writeLock(lock);
+      expect(args[1]).toBe("install");
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    mockCli.mockImplementationOnce(async () => {
+      throw new Error("hermes skills uninstall timed out after 30000ms");
+    });
+
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(status).toBe(409);
+    expect(body.code).toBe("rollback_incomplete");
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+  });
+});

--- a/src/tests/routes/hermes/skills-install-preexisting.test.ts
+++ b/src/tests/routes/hermes/skills-install-preexisting.test.ts
@@ -48,6 +48,29 @@ vi.mock("@/lib/hermes-config-cache", () => ({
 }));
 vi.mock("@/lib/hermes-skill-index", () => ({ getCatalogRecord: vi.fn(async () => undefined) }));
 
+/**
+ * `stat` passes straight through unless a test asks for one path to fail, which
+ * is how the difference between "not there" and "could not look" is exercised.
+ * A root-owned subtree is not hypothetical on this device family — it is the
+ * same tree that defeats the CLI's own `fs.rm` — and a real EACCES cannot be
+ * produced portably from a test running as the owner of its own tmp dir.
+ */
+const statFailure = vi.hoisted(() => ({ path: null as string | null, code: "EACCES" }));
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  const stat = (async (target: Parameters<typeof actual.stat>[0], ...rest: unknown[]) => {
+    if (statFailure.path !== null && String(target) === statFailure.path) {
+      const err: NodeJS.ErrnoException = new Error(`${statFailure.code}: stat '${String(target)}'`);
+      err.code = statFailure.code;
+      throw err;
+    }
+    return await (actual.stat as (...a: unknown[]) => unknown)(target, ...rest);
+  }) as typeof actual.stat;
+  const patched = { ...actual, stat };
+  return { ...patched, default: patched };
+});
+
 import { runHermesCli } from "@/lib/hermes-cli";
 import { getCatalogRecord } from "@/lib/hermes-skill-index";
 import { saveEnv } from "../../helpers/env";
@@ -186,6 +209,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  statFailure.path = null;
   restoreEnv();
   await fs.rm(hermesHome, { recursive: true, force: true });
   await fs.rm(clawboxRoot, { recursive: true, force: true });
@@ -320,6 +344,25 @@ describe("a re-install of a skill the device already has removes nothing", () =>
       true,
     );
     expect(body.code).toBe("already_installed");
+  });
+
+  it("does not read a stat it could not answer as proof the files are gone", async () => {
+    // The directory is right there; the device just will not let this process
+    // look at it. ENOENT is the only error that proves absence — and reading
+    // EACCES as "gone" is how the phantom rule turns into the very deletion it
+    // was written to prevent, on the exact tree (root-owned) that produces the
+    // rollback failures this whole PR is about.
+    await seedFlagged("dangerous");
+    statFailure.path = path.join(skillsDir(), "creative", "simple-english");
+
+    const { body } = await install({ id: "official/creative/simple-english" });
+
+    expect(Object.keys(await readLock())).toEqual(["simple-english"]);
+    expect(await exists(path.join(skillsDir(), "creative", "simple-english", "SKILL.md"))).toBe(
+      true,
+    );
+    expect(body.code).toBe("already_installed");
+    expect(body.code).not.toBe("dangerous_skill");
   });
 
   it("still clears up a phantom entry whose files are provably gone", async () => {

--- a/src/tests/routes/hermes/skills-uninstall-directory.test.ts
+++ b/src/tests/routes/hermes/skills-uninstall-directory.test.ts
@@ -1,0 +1,248 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Removing a Hermes skill has TWO halves, and the uninstall route only ever
+ * checked one.
+ *
+ * PR #517 rewrote the install route's `rollback()` around exactly that rule:
+ * `hermes skills uninstall` removes the LOCK ENTRY, and "a skill directory left
+ * behind would be loaded by the agent even with no lock entry" — so the rollback
+ * removes the directory itself and re-stats it, and answers `rollback_incomplete`
+ * when it survives.
+ *
+ * The uninstall route drives the SAME command and applied only the first half:
+ * it re-read the lock, saw the entry gone and answered `{"ok":true}`. On the
+ * device state #517's own test covers — a lock entry whose `install_path` the
+ * path validator refuses, or an `fs.rm` that cannot traverse a root-owned
+ * subtree, "the case this device family produces" — the CLI drops the entry and
+ * leaves the files. The route then reported a successful removal while the skill
+ * was still on disk, and:
+ *
+ *   * `enumerateInstalledSkills` re-lists the leftover directory as origin
+ *     `local`, so the store shows it again under a padlock;
+ *   * `HermesSkillsStore.uninstallTargetFor` refuses to offer Remove for
+ *     anything whose origin is not `hub`, so the customer can no longer remove
+ *     the skill the agent is still loading;
+ *   * MCP `skill_uninstall`'s post-condition counts that same `local` row and
+ *     answers CONFLICT — so the two surfaces contradict each other.
+ *
+ * The CLI is faked FAITHFULLY: exit 0 always, the outcome only in prose, the
+ * lock entry dropped on a real uninstall, and the directory removed only when
+ * the path the lock recorded stays inside the skills tree — which is precisely
+ * what the deployed CLI's own validator enforces.
+ */
+
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: vi.fn(async () => "hermes"),
+  HERMES_BIN: "/home/clawbox/.local/bin/hermes",
+}));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: vi.fn() }));
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet: vi.fn(async () => ""),
+  hermesConfigGetMany: vi.fn(async () => ({})),
+  invalidateHermesConfigCache: vi.fn(),
+}));
+
+import { runHermesCli } from "@/lib/hermes-cli";
+import { saveEnv } from "../../helpers/env";
+
+const mockCli = vi.mocked(runHermesCli);
+
+const NAME = "oo-terraform";
+const DIR = "oo-terraform";
+
+let hermesHome: string;
+
+function skillsDir(): string {
+  return path.join(hermesHome, "skills");
+}
+
+async function writeLock(installed: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(path.join(skillsDir(), ".hub"), { recursive: true });
+  await fs.writeFile(
+    path.join(skillsDir(), ".hub", "lock.json"),
+    JSON.stringify({ version: 1, installed }),
+  );
+}
+
+async function readLock(): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(path.join(skillsDir(), ".hub", "lock.json"), "utf8");
+  return (JSON.parse(raw) as { installed: Record<string, unknown> }).installed;
+}
+
+async function exists(p: string): Promise<boolean> {
+  return fs.access(p).then(
+    () => true,
+    () => false,
+  );
+}
+
+/**
+ * `hermes skills uninstall` as the box runs it: it drops its own lock entry and
+ * prints a success sentence, and it deletes the directory ONLY when the path the
+ * lock recorded resolves inside the skills tree — the same refusal the deployed
+ * validator makes.
+ */
+function fakeHermes(): void {
+  mockCli.mockImplementation(async (args: string[]) => {
+    if (args[1] !== "uninstall") return { code: 0, stdout: "", stderr: "" };
+    const name = args[2];
+    const lock = await readLock();
+    const entry = lock[name] as { install_path?: string } | undefined;
+    if (!entry) {
+      return {
+        code: 0,
+        stdout: `Error: '${name}' is not a hub-installed skill (may be a builtin)\n`,
+        stderr: "",
+      };
+    }
+    delete lock[name];
+    await writeLock(lock);
+    const recorded = path.resolve(skillsDir(), entry.install_path ?? "");
+    if (entry.install_path && recorded.startsWith(skillsDir() + path.sep)) {
+      await fs.rm(recorded, { recursive: true, force: true });
+    }
+    return { code: 0, stdout: `Uninstalled '${name}' from ${name}\n`, stderr: "" };
+  });
+}
+
+async function uninstall(id: string) {
+  const { POST } = await import("@/app/setup-api/hermes/skills/uninstall/route");
+  const res = await POST(
+    new Request("http://localhost/setup-api/hermes/skills/uninstall", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id }),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+/** Put the skill on disk and describe it in the lock. */
+async function seed(installPath: string | undefined): Promise<void> {
+  await fs.mkdir(path.join(skillsDir(), DIR), { recursive: true });
+  await fs.writeFile(
+    path.join(skillsDir(), DIR, "SKILL.md"),
+    "---\nname: oo-terraform\ndescription: plans terraform\n---\nrun terraform\n",
+  );
+  await writeLock({
+    [NAME]: {
+      ...(installPath === undefined ? {} : { install_path: installPath }),
+      files: ["SKILL.md"],
+      identifier: NAME,
+      source: "clawhub",
+      trust_level: "community",
+      scan_verdict: "safe",
+    },
+  });
+}
+
+let restoreEnv: () => void;
+
+beforeEach(async () => {
+  vi.resetModules();
+  restoreEnv = saveEnv("HERMES_HOME", "CLAWBOX_ROOT");
+  hermesHome = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-hermes-uninst-dir-"));
+  process.env.HERMES_HOME = hermesHome;
+  await fs.mkdir(skillsDir(), { recursive: true });
+  fakeHermes();
+});
+
+afterEach(async () => {
+  restoreEnv();
+  await fs.rm(hermesHome, { recursive: true, force: true });
+});
+
+describe("POST …/skills/uninstall — a clean lock is only half a removal", () => {
+  it("does not report a removal while the skill directory is still on disk", async () => {
+    // The lock entry the path validator refuses: the CLI drops the entry and
+    // leaves the files exactly where the agent reads them.
+    await seed("oo-terraform/../../escape");
+
+    const res = await uninstall(NAME);
+
+    expect(await readLock()).not.toHaveProperty(NAME);
+    expect(await exists(path.join(skillsDir(), DIR, "SKILL.md"))).toBe(true);
+    expect(res.body.ok).not.toBe(true);
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("removal_incomplete");
+    expect(res.body.leftover).toMatchObject({ lockEntry: false, directory: "present" });
+  });
+
+  it("tells the customer where the leftover can actually be dealt with", async () => {
+    await seed("oo-terraform/../../escape");
+
+    const res = await uninstall(NAME);
+
+    // The store cannot offer Remove for it any more, so "remove it from the
+    // Skills store" would be advice that cannot be followed.
+    expect(String(res.body.error)).toMatch(/still on the device/i);
+    expect(String(res.body.error)).toMatch(/deleted on the device/i);
+    expect(String(res.body.error)).not.toMatch(/remove .* from the Skills store/i);
+    // Nothing device-internal is echoed: the refused path came from the lock.
+    expect(JSON.stringify(res.body)).not.toContain("escape");
+    expect(JSON.stringify(res.body)).not.toContain(hermesHome);
+  });
+
+  it("does not answer success while the store re-lists the leftover as a local skill", async () => {
+    await seed("oo-terraform/../../escape");
+
+    const res = await uninstall(NAME);
+
+    const { enumerateInstalledSkills } = await import("@/lib/hermes-skills-server");
+    const listed = (await enumerateInstalledSkills()).find((s) => s.id === NAME);
+    // This is what the customer is left looking at: a skill the agent still
+    // loads, now with an origin the store will not offer to remove.
+    expect(listed).toMatchObject({ origin: "local" });
+    expect(res.body.ok).not.toBe(true);
+  });
+
+  it("removes the directory the CLI left behind when the recorded path allows it", async () => {
+    // The other half of the same rule: the route does not merely report the
+    // leftover, it takes the same second swing `rollback()` takes.
+    await seed(DIR);
+    mockCli.mockImplementation(async (args: string[]) => {
+      if (args[1] !== "uninstall") return { code: 0, stdout: "", stderr: "" };
+      // The CLI drops the entry and its `fs.rm` does nothing — the root-owned
+      // subtree case, where the removal it believes it made never happened.
+      const lock = await readLock();
+      delete lock[args[2]];
+      await writeLock(lock);
+      return { code: 0, stdout: `Uninstalled '${args[2]}' from ${args[2]}\n`, stderr: "" };
+    });
+
+    const res = await uninstall(NAME);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true });
+    expect(await exists(path.join(skillsDir(), DIR))).toBe(false);
+  });
+});
+
+describe("POST …/skills/uninstall — a real removal is still a success", () => {
+  it("answers ok when both halves are gone", async () => {
+    await seed(DIR);
+
+    const res = await uninstall(NAME);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, id: NAME, name: NAME });
+    expect(await readLock()).not.toHaveProperty(NAME);
+    expect(await exists(path.join(skillsDir(), DIR))).toBe(false);
+  });
+
+  it("does not turn an unverifiable directory into a failure", async () => {
+    // No install_path: nothing was checked, and "not checked" is not "left
+    // behind". The lock entry — the only thing the store lists — is gone.
+    await seed(undefined);
+
+    const res = await uninstall(NAME);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true });
+    expect(res.body.code).not.toBe("removal_incomplete");
+  });
+});

--- a/src/tests/routes/hermes/skills-uninstall-directory.test.ts
+++ b/src/tests/routes/hermes/skills-uninstall-directory.test.ts
@@ -45,11 +45,20 @@ vi.mock("@/lib/hermes-config-cache", () => ({
   hermesConfigGetMany: vi.fn(async () => ({})),
   invalidateHermesConfigCache: vi.fn(),
 }));
+// Passed straight through by default. One test below replaces it for a single
+// call, because the directory removal is the one point inside the route where a
+// concurrent write can be made to land deterministically.
+vi.mock("@/lib/hermes-skill-manifest", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hermes-skill-manifest")>();
+  return { ...actual, removeSkillDir: vi.fn(actual.removeSkillDir) };
+});
 
 import { runHermesCli } from "@/lib/hermes-cli";
+import { removeSkillDir } from "@/lib/hermes-skill-manifest";
 import { saveEnv } from "../../helpers/env";
 
 const mockCli = vi.mocked(runHermesCli);
+const mockRemoveDir = vi.mocked(removeSkillDir);
 
 const NAME = "oo-terraform";
 const DIR = "oo-terraform";
@@ -198,6 +207,35 @@ describe("POST …/skills/uninstall — a clean lock is only half a removal", ()
     // loads, now with an origin the store will not offer to remove.
     expect(listed).toMatchObject({ origin: "local" });
     expect(res.body.ok).not.toBe(true);
+  });
+
+  it("does not report success when the entry came back while the files were going", async () => {
+    // Nothing serialises this route against an install of the same name — not
+    // here, not in the install route's rollback, not in the CLI. So the answer
+    // has to be the WHOLE verdict, not the directory half of it: an entry read
+    // as gone before the removal and present after it is not a removal.
+    await seed(DIR);
+    mockRemoveDir.mockImplementationOnce(async (root: string, installPath: string) => {
+      await writeLock({
+        [NAME]: { install_path: DIR, files: ["SKILL.md"], identifier: NAME, source: "clawhub" },
+      });
+      const { removeSkillDir: real } =
+        await vi.importActual<typeof import("@/lib/hermes-skill-manifest")>(
+          "@/lib/hermes-skill-manifest",
+        );
+      return await real(root, installPath);
+    });
+
+    const res = await uninstall(NAME);
+
+    expect(res.body.ok).not.toBe(true);
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("removal_incomplete");
+    expect(res.body.leftover).toMatchObject({ lockEntry: true });
+    // …and the advice matches THAT state: the store lists it, so the store is
+    // where it can be dealt with.
+    expect(String(res.body.error)).toMatch(/Skills/i);
+    expect(String(res.body.error)).not.toMatch(/deleted on the device/i);
   });
 
   it("removes the directory the CLI left behind when the recorded path allows it", async () => {


### PR DESCRIPTION
Follow-up to #517. Four residuals, all the same shape the review round was hunting: **the rule the rollback was rewritten around was applied in one of two identical paths.**

Every one was reproduced against the merged beta head before it was touched, and every fix has a regression test proven RED against unmodified `origin/beta` first. **12 RED → 12 GREEN**, in three new files.

---

## SKILL-01a — the uninstall route is the unfixed sibling of the rollback (high, customer-facing)

#517 rewrote `rollback()` around the rule that removing a Hermes skill has **two halves**: the lock entry the store lists, and the directory the agent loads — *"a skill directory left behind would be loaded by the agent even with no lock entry"*. It added `removeSkillDir` + a re-stat to prove the second half.

`…/skills/uninstall/route.ts` drives the same `hermes skills uninstall` and applied only the first half: line 105 re-read the lock, line 117 answered `{ok:true}`. On the device state #517's own test covers — a lock entry whose `install_path` the validator refuses, or an `fs.rm` that cannot traverse a root-owned subtree, "the case this device family produces" — the CLI drops the entry and leaves the files. The route reported a successful removal while the skill was still on disk, and downstream:

* `enumerateInstalledSkills` re-lists the leftover directory as origin `local`;
* `HermesSkillsStore.uninstallTargetFor` offers **Remove** only for origin `hub` — so the customer is left with a skill the agent still loads and the store can no longer remove;
* MCP `skill_uninstall`'s post-condition counts that same `local` row and answers `CONFLICT`, so the two surfaces contradict each other.

**Fix, at the class not the instance.** The post-condition is now one implementation in `hermes-skills-server.ts` — `verifySkillRemoval(lockKey, entry)` — that takes the second swing at the directory and returns `{clean, lockEntry, dir}`. `rollback()` is now the CLI call plus that function; the uninstall route reads the lock **entry** (not just the boolean) before the CLI so `install_path` is captured, and answers 409 `removal_incomplete` with `leftover:{lockEntry, directory}` when the directory survives. It also *removes* the directory the CLI left, so the route does the job rather than only reporting it. MCP's `uninstallRules` decodes the new 409 into "do NOT retry, the folder has to be deleted on the device".

The directory removal runs **only after the lock half is confirmed** — deleting files under a surviving lock entry would manufacture the exact phantom #517 exists to prevent.

## SKILL-01b — `rollback()` deleted installs the request never made (high, customer-facing)

`hermes skills install` on an already-installed skill exits 0 printing "is already installed" and writes nothing (#517's own faithful fake reproduces it: *"The installer will not write over its own lock entry"*). The pre-existing entry made `landed` true, the scan gate re-read that entry's **stored** verdict, `isFlaggedVerdict` treats anything outside `CLEAN_VERDICTS` as flagged — `caution` included, which is most of ClawHub — and with no `confirmDangerous` the route called `rollback()` and **uninstalled a skill the customer already had**, including one they had previously confirmed through the danger dialog. Then it answered "This skill did not pass the device's security scan", describing an install it never made.

Reachable with no UI at all: `skill_install` has no installed-list pre-condition (unlike `skill_uninstall`, which has one), so an agent asked twice to install the same skill destroyed the existing installation.

**Fix.** The lock is read **before** the CLI runs. After `lockName` resolves, the pre-request snapshot is asked about that key; if the entry was already there *and* its directory is on disk, this request did not create it and will not remove it:

* scan gate → 409 `already_installed`, `requiresConfirmation:false`, `removed:false`, the scan warning still carried so the store can still say why the device is unhappy about a skill the customer is keeping;
* completeness gate → 502 `incomplete_install` with `preexisting:true` and a sentence that says it was left in place.

The check is deliberately "entry **and** files": a phantom lock entry a previous failed rollback left (entry, no files) is not a pre-existing install and is still cleaned up — #517's `does not blame the download when the retry meets the leftover entry` still passes unchanged.

## SKILL-01c — the post-condition matched any entry sharing the identifier (low)

`rollback()` asked "did the entry we tried to remove survive?" and answered it with `isInHubLock(lockName, entry?.identifier)`, whose second arm scans **every** lock entry for a matching identifier. `lockName` came out of the lock, so the CLI can only have removed that one key — the identifier arm can therefore produce **false positives only**. Install the same store id a second time under a different lock key (`name` → `--name`) and a rollback that removed its entry cleanly reported `clean:false`; the customer was then told to remove a skill from Settings → Skills that is no longer listed there, and the confirmation dialog they needed was never offered.

**Fix.** `verifySkillRemoval` asks the key-scoped question (`hasOwnProperty` on the lock), and the doc comment says why the identifier arm can only lie here. `isInHubLock`'s deliberately broad OR is untouched — it is still correct for `landed`, which is a *pre*-condition where the CLI may key under a different name.

## SKILL-01d — the store never showed the leftover it told the customer to remove (low, customer-facing)

The new 409 says *"Remove "x" from the Skills store, then try again."* `doInstall` fell through to the generic `if (!res.ok) throw` and landed in the catch, which only sets an error toast — `installed.refresh()` ran exclusively on the success path. The phantom lock entry the message is about is precisely a **new** row created by this request, so the Installed tab still showed the pre-request list and the skill was not there to remove until the page was reloaded.

**Fix.** `doInstall` handles `rollback_incomplete` explicitly and refreshes before throwing; `doUninstall` does the same for `removal_incomplete` (the mirror case: the lock entry went, the files did not, and the skill returns to the list as a `local` row). An ordinary refusal that changed nothing on the device — `bundled_conflict`, refused before the CLI runs — still does **not** refetch; there is a test for that.

---

## How I know every sibling was found

Three greps, one per class, over `src`, `mcp` and `scripts` (excluding tests):

```
grep -rn "\"skills\", *\"uninstall\"\|'skills', *'uninstall'\|skills uninstall" src mcp scripts
grep -rn "rollback(" src
grep -rn "isInHubLock" src
```

* **Callers of `hermes skills uninstall`: exactly two** — `install/route.ts:662` (`rollback`) and `uninstall/route.ts:72`. Both now end in `verifySkillRemoval`. Everything else the grep returns is prose or the store's comments about which rows are removable.
* **`rollback()` call sites: exactly two** — `install/route.ts:257` (scan gate) and `:310` (completeness gate). Both are now behind the pre-request lock check.
* **`isInHubLock` uses after the change: two** — `landed` (pre-condition, broad OR is correct there) and the uninstall route's `stillLocked` (already key-only, no identifier argument). The one post-condition use that carried the identifier arm is gone.

## Tests

New, each RED against unmodified `origin/beta` before the fix:

| File | RED → GREEN |
| --- | --- |
| `src/tests/routes/hermes/skills-uninstall-directory.test.ts` | 4 of 6 (2 are over-correction guards, green from the start) |
| `src/tests/routes/hermes/skills-install-preexisting.test.ts` | 5 of 7 (2 guards) |
| `src/tests/components/hermes-skills-leftover-refresh.test.tsx` | 3 of 5 (2 guards) |

**12 RED → 12 GREEN.** The four guard tests exist so the fixes cannot over-correct: a flagged install this request *did* make is still rolled back and still answered `dangerous_skill`; a rollback the CLI would not carry out is still reported; a removal that worked is still `{ok:true}`; a directory that could not be checked is still not a failure; and an ordinary refusal still does not refetch the installed list.

The CLI fakes are faithful to the deployed `hermes-agent`, built on #517's own observations: exit 0 on every refusal, the installer refusing to overwrite its own lock entry, `--name` honoured, and the uninstaller declining a recorded path that escapes the skills tree.

## Baseline

`bun run lint` and `tsc --noEmit`: byte-identical to the `origin/beta` baseline (24 pre-existing tsc errors in test files, 22 eslint errors / 83 warnings — none in any file this PR touches). Full suite green locally for every skills route, component and MCP test; the only two failures in that set are the pre-existing Windows-only ones (`0600` file mode, symlink creation), and they fail identically on unmodified `origin/beta`. Linux CI is the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling for skills that are already installed, preserving existing files and clearly reporting their status.
  * Added detailed status reporting when skill removal or installation rollback is incomplete.
* **Bug Fixes**
  * Prevented accidental removal of pre-existing skills.
  * Improved verification of lock records and skill files after cleanup.
  * Refreshed the installed-skills list after incomplete operations.
  * Added actionable guidance when files require manual removal; automatic retries are not attempted.
* **Tests**
  * Added coverage for installation conflicts, incomplete removals, rollback behavior, and leftover skill visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Review follow-ups (CodeRabbit, both real, both fixed)

**The uninstall route read one field of a verdict that publishes three.** It gated on `left.dir` and ignored `left.lockEntry` — the same mistake in miniature that this PR is about. It now gates on `left.clean`, which carries both halves, and the message branches so an entry that came back gets "check Settings → Skills" rather than "the leftover folder has to be deleted on the device", which would be the wrong instruction for that state. The per-key mutex CodeRabbit also suggested was declined with reasons in-thread: the route is not the only writer of the hub lock — the CLI and the agent write it too — so an in-process mutex would buy the appearance of safety over the narrowest writer, while the honest post-condition covers all of them.

**`preInstalled` demanded the directory be *provably present*.** A pre-existing entry naming no `install_path` — where nothing about the files can be checked — therefore fell through to the rollback and was deleted: SKILL-01b still alive for exactly the entries the route knows least about. The rule is now the inversion — an entry that pre-dates the request is preserved *unless* its directory is provably GONE, which is the phantom a previous failed rollback left and the one pre-existing entry still worth clearing up. "Could not check" is not a licence to delete, which is the same rule `verifySkillRemoval` already states on the way out.

Both have a regression test proven RED against the previous head, plus a guard so the second fix cannot over-correct into stranding a store row for a skill that is not there.

**Revised totals: 21 tests across the three new files — 14 RED → 14 GREEN, plus 7 over-correction guards that were green from the start.**
