### PR TITLE
fix: re-advertise the coding-agent tools when connecting the AI is what made them runnable

### DIFF
--- a/src/app/setup-api/hermes/clawai/route.ts
+++ b/src/app/setup-api/hermes/clawai/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { get, setMany } from "@/lib/config-store";
 import { hermesConfigGet } from "@/lib/hermes-config-cache";
 import { getActiveHarness } from "@/lib/harness";
+import { getCodingAgentStatus } from "@/lib/coding-agent";
 import {
   CLAWAI_PROVIDER,
   ClawaiApplyError,
@@ -100,10 +101,25 @@ export async function POST(request: Request) {
   const suppliedToken = typeof (body as { token?: unknown } | null)?.token === "string"
     ? ((body as { token?: string }).token || "").trim()
     : "";
+  // Storing it first is also why the coding-agent verdict has to be sampled
+  // HERE rather than inside the apply. The ClawBox MCP server registers
+  // `coding_agent_run`/`_status`/`_stop` only when `getCodingAgentStatus().ready`
+  // is true, and `ready` is `enabled` AND the harness installed AND ClawBox AI
+  // connected — where "connected" IS the `clawai_token` the next line stores.
+  // Read it a line later and the answer is always true, the apply's
+  // before/after guard sees no change, and a box whose switch was already on
+  // ends up with a panel that says ready over an agent that still has none of
+  // the three tools. Left undefined on the no-token path, where the apply's own
+  // snapshot is taken before any write and is honest; and on a probe that threw,
+  // which must not turn a link into a 500.
+  let codingAgentReadyBefore: boolean | undefined;
   if (suppliedToken) {
     if (!isPlausibleClawaiToken(suppliedToken)) {
       return NextResponse.json({ error: "That doesn't look like a ClawBox AI token." }, { status: 400 });
     }
+    codingAgentReadyBefore = await getCodingAgentStatus()
+      .then((status) => status.ready)
+      .catch(() => undefined);
     await setMany({ clawai_token: suppliedToken });
   }
 
@@ -118,7 +134,7 @@ export async function POST(request: Request) {
   }
 
   try {
-    const result = await applyClawaiToHermes(token, tier);
+    const result = await applyClawaiToHermes(token, tier, { codingAgentReadyBefore });
     return NextResponse.json({ ok: true, ...result });
   } catch (err) {
     // Only OUR own error text is safe to echo — a raw spawn error can carry the

--- a/src/lib/coding-agent-mcp-refresh.ts
+++ b/src/lib/coding-agent-mcp-refresh.ts
@@ -1,4 +1,4 @@
-import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
+import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 
 /**
  * Ask the agent to rebuild its MCP tool list when the coding agent becomes
@@ -29,6 +29,18 @@ import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
  * paying for, below.
  */
 
+/** @see refreshCodingAgentToolsIfReadinessChanged */
+export interface CodingAgentRefreshOptions {
+  /**
+   * True when something else in THIS request already respawned the box's MCP
+   * children — the image reconciler on the ClawBox AI connect path, which
+   * reloads or bounces for its own family and takes every other family's tool
+   * list with it. The reload is global, so a second one would buy nothing and
+   * cost a second prompt-cache invalidation.
+   */
+  alreadyReloaded?: boolean;
+}
+
 /**
  * Reload the MCP servers, but ONLY if this request flipped whether the coding
  * agent family would be registered at all.
@@ -54,29 +66,43 @@ import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
  * next restart — which is exactly the behaviour of every box before this
  * existed.
  *
+ * BOTH WRITE PATHS, not just the switch. `ready` is `enabled` AND the harness
+ * installed AND ClawBox AI connected, and the owner can move the third one on
+ * its own: `applyClawaiToHermes` is what writes `clawai_token`, and every Hermes
+ * connect entry point funnels through it. A box whose switch is already on goes
+ * ready:false → ready:true the moment the AI is connected — which is exactly the
+ * order the readiness text sends the owner in ("ClawBox AI is not connected.
+ * Open Settings → AI Models and sign in to ClawBox AI first."). So this helper
+ * hangs off the connect path too; see `hermes-clawai.ts`.
+ *
  * @param before what `getCodingAgentStatus().ready` said BEFORE the write
  * @param after  what it says after — the same field the panel is shown, so the
  *               agent's tools and the owner's panel cannot disagree.
+ * @param options see `CodingAgentRefreshOptions`
  */
-export async function refreshCodingAgentToolsIfReadinessChanged(before: boolean, after: boolean): Promise<void> {
+export async function refreshCodingAgentToolsIfReadinessChanged(
+  before: boolean,
+  after: boolean,
+  options: CodingAgentRefreshOptions = {},
+): Promise<void> {
   if (before === after) return;
+  const became = `the coding agent became ${after ? "available" : "unavailable"}`;
+  if (options.alreadyReloaded) {
+    // Nothing to ask for: the respawn that already happened in this request
+    // rebuilt EVERY family's tool list, this one included.
+    console.log(`[coding-agent/mcp-refresh] ${became}; the MCP servers were already reloaded for this change`);
+    return;
+  }
   // `.catch` even though `reloadMcpServers` documents that it never throws: the
   // "never throws" above is a promise made to the OWNER'S SAVE, which has
   // already been written to disk by the time this runs, and it must not depend
   // on a neighbouring module keeping its own promise.
   if (!(await reloadMcpServers().catch(() => false))) {
-    // Logged, not surfaced. Worth a line because "I turned it on and the
-    // assistant still cannot start a run" is otherwise invisible from the
-    // outside, and this is the one place that knows the refresh was wanted and
-    // did not happen.
-    console.error(
-      `[coding-agent/mcp-refresh] the coding agent became ${after ? "available" : "unavailable"}, `
-        + "but the agent would not reload its MCP servers",
-    );
+    // Logged, not surfaced, and in the words that are true for this edition —
+    // an OpenClaw box has no dashboard to ask and needs no repair. See
+    // `reportMcpReloadRefused` for why that distinction is worth making.
+    await reportMcpReloadRefused("coding-agent/mcp-refresh", became);
     return;
   }
-  console.log(
-    `[coding-agent/mcp-refresh] the coding agent became ${after ? "available" : "unavailable"}; `
-      + "asked the agent to reload its MCP servers",
-  );
+  console.log(`[coding-agent/mcp-refresh] ${became}; asked the agent to reload its MCP servers`);
 }

--- a/src/lib/email-mcp-refresh.ts
+++ b/src/lib/email-mcp-refresh.ts
@@ -1,4 +1,4 @@
-import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
+import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 
 /**
  * Ask Hermes to rebuild its MCP tool list when the mailbox becomes readable, or
@@ -45,18 +45,22 @@ import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
  * box that has no dashboard at all, must not have its email settings save turned
  * into an error by a best-effort refresh: the settings ARE saved, the gate is
  * still enforced route-side, and the tool list catches up at the next restart —
- * which is exactly the behaviour of every box before this existed.
+ * which is exactly the behaviour of every box before this existed. WHICH of
+ * those two it was decides how it is said; `reportMcpReloadRefused` owns that
+ * rule for all three refresh helpers.
  */
 export async function refreshEmailToolsIfReadabilityChanged(before: boolean, after: boolean): Promise<void> {
   if (before === after) return;
-  if (!(await reloadMcpServers())) {
+  const became = `mailbox readability changed to ${after}`;
+  // `.catch` even though `reloadMcpServers` documents that it never throws: the
+  // settings ARE saved by the time this runs, and that promise must not depend
+  // on a neighbouring module keeping its own.
+  if (!(await reloadMcpServers().catch(() => false))) {
     // Logged, not surfaced. Worth a line because "the agent still cannot see my
     // mailbox" is otherwise invisible from the outside, and this is the one
     // place that knows the refresh was wanted and did not happen.
-    console.error(
-      `[email/mcp-refresh] mailbox readability changed to ${after}, but Hermes would not reload its MCP servers`,
-    );
+    await reportMcpReloadRefused("email/mcp-refresh", became);
     return;
   }
-  console.log(`[email/mcp-refresh] mailbox readability changed to ${after}; asked Hermes to reload its MCP servers`);
+  console.log(`[email/mcp-refresh] ${became}; asked Hermes to reload its MCP servers`);
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1,4 +1,5 @@
 import { setMany } from "@/lib/config-store";
+import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
@@ -54,14 +55,58 @@ export function clawaiModelForTier(tier: ClawboxAiTier): string {
 export class ClawaiApplyError extends Error {}
 
 /**
+ * `getCodingAgentStatus().ready`, or null when the question could not be
+ * answered.
+ *
+ * NULL IS LOAD-BEARING. Linking is not allowed to fail because a readiness probe
+ * did — it stats a wrapper, looks for two binaries on PATH and lists the project
+ * folders, and any of those can throw on a box with a half-installed harness or
+ * an unreadable folder. This is a best-effort courtesy to the RUNNING agent laid
+ * on top of writes that have already happened (or are about to), so an
+ * unanswerable question means "do nothing", never "abandon the link".
+ *
+ * IMPORTED HERE, not at the top of the file. `coding-agent` owns the runs store
+ * and reaches DATA_DIR while it is still being evaluated, and this module is
+ * re-exported by `harness/credentials`, which every edition-agnostic credential
+ * lookup pulls in. A static import would put that whole machinery in the graph
+ * of routes that never link a box, for one boolean.
+ */
+async function codingAgentReady(): Promise<boolean | null> {
+  return await import("@/lib/coding-agent")
+    .then((mod) => mod.getCodingAgentStatus())
+    .then((status) => status.ready)
+    .catch(() => null);
+}
+
+/** @see applyClawaiToHermes */
+export interface ApplyClawaiOptions {
+  /**
+   * What `getCodingAgentStatus().ready` said before the caller touched
+   * anything, for a caller that wrote `clawai_token` ITSELF before calling.
+   *
+   * `ready` is `enabled` AND the harness installed AND ClawBox AI connected,
+   * and that third fact IS the stored token — so a snapshot taken in here, after
+   * such a caller has already written it, reads true no matter what the box
+   * looked like a moment earlier. The guard then sees before === after and the
+   * reload silently never happens. `/setup-api/hermes/clawai` persists a PASTED
+   * token before it applies it and is the one caller that needs this; the two
+   * others (the configure route and the device-code finaliser) write nothing
+   * first, so they leave it unset and the snapshot below is honest.
+   */
+  codingAgentReadyBefore?: boolean;
+}
+
+/**
  * Point Hermes at ClawBox AI and persist the device state.
  *
  * @param token device token minted by the portal (never logged, never echoed)
  * @param tier  device tier — decides which bare deepseek id becomes model.default
+ * @param options see `ApplyClawaiOptions`
  */
 export async function applyClawaiToHermes(
   token: string,
   tier: ClawboxAiTier,
+  options: ApplyClawaiOptions = {},
 ): Promise<{ provider: string; model: string; tier: ClawboxAiTier }> {
   const trimmed = token.trim();
   // A token that starts with "-" would be read by hermes as a flag. runHermesCli
@@ -76,6 +121,14 @@ export async function applyClawaiToHermes(
   // on config.yaml's mtime, so on a box that has been asked this recently — the
   // chat asks it on every open — this costs nothing.
   const couldDrawBefore = await hermesAgentDrawsImages();
+  // The SECOND family this call can move, and for the same reason: the ClawBox
+  // MCP server decides whether `coding_agent_run`/`_status`/`_stop` exist at all
+  // from one probe taken while it booted, and `ready` is `enabled` AND the
+  // harness installed AND ClawBox AI connected. #514 taught the enable route to
+  // notice when the SWITCH moved that verdict; connecting is the sibling write,
+  // and it is the order the readiness text itself asks for ("ClawBox AI is not
+  // connected. Open Settings → AI Models and sign in to ClawBox AI first.").
+  const codingReadyBefore = options.codingAgentReadyBefore ?? (await codingAgentReady());
 
   const vision = await resolveVisionModelId({ token: trimmed });
   let visionModelId: string | null = vision.id;
@@ -226,7 +279,22 @@ export async function applyClawaiToHermes(
   // their own by hand and our write failing changes nothing about what the box
   // can do. `hermesConfigGet` is keyed on config.yaml's mtime, which the writes
   // above just moved, so this sees the new value rather than a memo of the old.
-  await refreshHermesImageTools(couldDrawBefore, await hermesAgentDrawsImages());
+  const respawnedMcpChildren = await refreshHermesImageTools(couldDrawBefore, await hermesAgentDrawsImages());
+
+  // And the coding-agent family, which the token just written may have made
+  // runnable. ONE respawn between the two: `reload.mcp` kills and respawns every
+  // MCP child and invalidates the model's prompt cache, and a link that moves
+  // both families is still one fact about one box — so if the image reconcile
+  // above already reloaded (or bounced, which respawns the children with the
+  // dashboard), this one reports rather than pays for a second.
+  const codingReadyAfter = await codingAgentReady();
+  if (codingReadyBefore !== null && codingReadyAfter !== null) {
+    await refreshCodingAgentToolsIfReadinessChanged(
+      codingReadyBefore,
+      codingReadyAfter,
+      { alreadyReloaded: respawnedMcpChildren },
+    );
+  }
 
   return { provider: CLAWAI_PROVIDER, model, tier };
 }

--- a/src/lib/hermes-image-refresh.ts
+++ b/src/lib/hermes-image-refresh.ts
@@ -1,6 +1,6 @@
 import { bounceHermesDashboard } from "@/lib/hermes-dashboard-control";
 import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
-import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
+import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
 
 /**
  * Make the RUNNING Hermes serve the image backend that linking just installed.
@@ -85,13 +85,22 @@ async function runningAgentCanDraw(): Promise<boolean | null> {
   return typeof result?.available === "boolean" ? result.available : null;
 }
 
-/** Ask for the MCP tool list to be rebuilt, and say so when it is not. */
-async function reloadMcpTools(why: string): Promise<void> {
-  if (await reloadMcpServers()) return;
-  // Logged, not surfaced. Worth a line because "the agent still refuses to draw"
-  // is otherwise invisible from the outside, and this is the one place that
-  // knows the refresh was wanted and did not happen.
-  console.error(`[hermes/image-refresh] ${why}, but Hermes would not reload its MCP servers`);
+/**
+ * Ask for the MCP tool list to be rebuilt, and say so when it is not.
+ *
+ * @returns true when the children were actually respawned. The caller passes
+ *          that on, because the respawn is GLOBAL: it rebuilt every other
+ *          family's tool list too, and a second family must not pay for a
+ *          second one.
+ */
+async function reloadMcpTools(why: string): Promise<boolean> {
+  if (await reloadMcpServers().catch(() => false)) return true;
+  // Logged, not surfaced, and in the words that are true for this edition. Worth
+  // a line because "the agent still refuses to draw" is otherwise invisible from
+  // the outside, and this is the one place that knows the refresh was wanted and
+  // did not happen.
+  await reportMcpReloadRefused("hermes/image-refresh", why);
+  return false;
 }
 
 /**
@@ -117,14 +126,20 @@ async function reloadMcpTools(why: string): Promise<void> {
  * @param after  what it says after — the same fact
  *               `/setup-api/chat/capabilities` serves, so the agent's tools and
  *               the customer's chat cannot disagree about this box.
+ * @returns true when this call respawned the box's MCP children — by reloading
+ *          them or by bouncing the dashboard that owns them. Both rebuild EVERY
+ *          family's tool list, not just the image one, so a caller that also
+ *          moved another family (the coding agent, on the ClawBox AI connect
+ *          path) can skip a second global reload and the second prompt-cache
+ *          invalidation that comes with it.
  */
-export async function refreshHermesImageTools(before: boolean, after: boolean): Promise<void> {
+export async function refreshHermesImageTools(before: boolean, after: boolean): Promise<boolean> {
   if (!after) {
     // The box cannot draw. The only stale thing is the MCP server's view, and
     // the tool it owes an owner here is the honest refusal — a linked-looking
     // box with no backend must say so rather than let the agent improvise.
-    if (before) await reloadMcpTools("this box can no longer draw");
-    return;
+    if (before) return await reloadMcpTools("this box can no longer draw");
+    return false;
   }
 
   // 1. The credential. Cheap, and on a box whose agent already knows the
@@ -140,15 +155,15 @@ export async function refreshHermesImageTools(before: boolean, after: boolean): 
   if (live === true) {
     // The agent can draw. The MCP server may still be holding the refusal tool
     // it registered when it could not — drop it now, in the same breath.
-    if (!before) await reloadMcpTools("the agent can draw");
-    return;
+    if (!before) return await reloadMcpTools("the agent can draw");
+    return false;
   }
 
   if (live === null) {
     // Asked and got no answer. Nothing here knows whether this box needs a
     // bounce, and a bounce is not the kind of thing to do on a guess.
     console.error("[hermes/image-refresh] the Hermes dashboard did not say whether it can draw; left it alone");
-    return;
+    return false;
   }
 
   // 3. The agent SAYS no with the credential freshly loaded, so the backend was
@@ -157,10 +172,14 @@ export async function refreshHermesImageTools(before: boolean, after: boolean): 
   //    reload is wanted after this one.
   if (await bounceHermesDashboard()) {
     console.log("[hermes/image-refresh] bounced the Hermes dashboard so it picks up the image backend");
-    return;
+    // The bounce takes the MCP children down with the dashboard and brings them
+    // back, so every family's tool list is rebuilt — the same effect a reload
+    // would have had, by a bigger hammer.
+    return true;
   }
 
   console.error(
     "[hermes/image-refresh] the image backend is installed but the running agent cannot see it; restart the agent to enable pictures",
   );
+  return false;
 }

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -1,3 +1,4 @@
+import { getActiveHarness } from "@/lib/harness";
 import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
 
 /**
@@ -42,4 +43,44 @@ const RELOAD_PARAMS = { confirm: true } as const;
 export async function reloadMcpServers(): Promise<boolean> {
   const result = await dashboardRpc("reload.mcp", RELOAD_PARAMS).catch(() => null);
   return result !== null;
+}
+
+/**
+ * Say that a wanted reload did not happen — in the words that are TRUE for THIS
+ * box, which is not the same sentence on both editions.
+ *
+ * Every family this module serves is registered on BOTH editions (the mailbox
+ * read tools, the coding-agent family, the honest-refusal `image_generate`), but
+ * the only mechanism here is HERMES' dashboard JSON-RPC. An OpenClaw box has no
+ * dashboard by design, so `reloadMcpServers()` can never return true there — and
+ * nothing is broken when it does not: OpenClaw spawns the ClawBox MCP server
+ * lazily per session and reaps it after ten idle minutes, so the probe re-runs
+ * and the tool list catches up on its own. Reporting that as an ERROR is the
+ * recurring false-alarm shape — a repair announced over an operation that in
+ * fact succeeded — and it costs a real one: an operator who learns to skip these
+ * lines skips the Hermes box that genuinely refused.
+ *
+ * So `console.error` is kept for exactly the case a human can act on: a box that
+ * HAS a dashboard and it said no. Everything else is a `console.log` that says
+ * what will actually happen next.
+ *
+ * UNKNOWN IS NOT OPENCLAW. `getActiveHarness()` swallows its own read failures
+ * and answers `openclaw` by default, but if the call itself throws we keep the
+ * error — a harness lookup that fell over must not be the thing that quiets a
+ * real Hermes failure.
+ *
+ * @param tag   the caller's log prefix, e.g. `coding-agent/mcp-refresh`
+ * @param what  what changed, in the caller's own words, e.g. "the coding agent
+ *              became available"
+ */
+export async function reportMcpReloadRefused(tag: string, what: string): Promise<void> {
+  const harness = await getActiveHarness().catch(() => null);
+  if (harness !== null && harness !== "hermes") {
+    console.log(
+      `[${tag}] ${what}; this edition has no dashboard to ask — the tool list re-probes `
+        + "when the MCP server is next spawned",
+    );
+    return;
+  }
+  console.error(`[${tag}] ${what}, but the agent would not reload its MCP servers`);
 }

--- a/src/tests/routes/coding-agent/enable.test.ts
+++ b/src/tests/routes/coding-agent/enable.test.ts
@@ -32,7 +32,12 @@ vi.mock("@/lib/coding-agent", async (importOriginal) => ({
 // this file pins the BEHAVIOUR the owner is owed — "the running agent is told" —
 // and not the name of the module that happens to tell it.
 const reloadMcp = vi.hoisted(() => vi.fn());
-vi.mock("@/lib/hermes-mcp-reload", () => ({ reloadMcpServers: reloadMcp }));
+// Only the ASK is replaced; `reportMcpReloadRefused` stays real, so a refusal
+// still travels the path it travels on a device.
+vi.mock("@/lib/hermes-mcp-reload", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-mcp-reload")>()),
+  reloadMcpServers: reloadMcp,
+}));
 
 import { get as configGet } from "@/lib/config-store";
 

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Pasting a ClawBox AI token has to re-advertise the coding-agent tools.
+ *
+ * This route is the one connect entry point that persists the token ITSELF,
+ * before it hands it to `applyClawaiToHermes` — so a "was the coding agent
+ * runnable before this request" snapshot taken inside the apply reads the token
+ * this route just wrote and is already true. The guard then sees
+ * before === after, skips the reload, and the box ends up exactly where it was
+ * without the fix: panel says ready, running MCP child still has no
+ * `coding_agent_run`. The snapshot has to be taken here, ahead of the write.
+ */
+
+const store: Record<string, unknown> = {};
+const rpcMock = vi.hoisted(() => vi.fn());
+const statusMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(async (key: string) => store[key] ?? null),
+  setMany: vi.fn(async (values: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(values)) store[key] = value;
+  }),
+}));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+vi.mock("@/lib/hermes-config-cache", () => ({ hermesConfigGet: vi.fn(async () => "clawai") }));
+vi.mock("@/lib/hermes-cli", () => ({
+  runHermesCli: vi.fn(async () => ({ code: 0, stdout: "", stderr: "" })),
+}));
+// The box already draws, so the image family cannot be what asks for a reload
+// below — anything this test counts belongs to the coding-agent family.
+vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: vi.fn(async () => true) }));
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
+vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
+  installHermesImagePlugin: vi.fn(),
+}));
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: vi.fn(async () => ({ id: "vision", verified: true, reason: "proxy-allows" })),
+}));
+// `ready` is `enabled AND harness installed AND ClawBox AI connected`, and the
+// third of those is the config-store key this route writes. Modelling it off the
+// same store is what makes the ordering trap reproducible.
+vi.mock("@/lib/coding-agent", () => ({
+  getCodingAgentStatus: statusMock,
+}));
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
+vi.mock("@/lib/hermes-dashboard-control", () => ({ bounceHermesDashboard: vi.fn(async () => true) }));
+
+import { POST } from "@/app/setup-api/hermes/clawai/route";
+
+/** A well-formed pasted token: charset+length is all the route checks. */
+const PASTED = "claw_abcdef0123456789";
+
+function post(body: unknown): Request {
+  return new Request("http://localhost/setup-api/hermes/clawai", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** How many GLOBAL MCP respawns this request asked the agent for. */
+function reloadCount(): number {
+  return rpcMock.mock.calls.filter((call) => call[0] === "reload.mcp").length;
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(store)) delete store[key];
+  rpcMock.mockReset();
+  statusMock.mockReset();
+  rpcMock.mockImplementation(async (method: string) =>
+    method === "image.generate" ? { available: true } : { status: "ok" },
+  );
+  // The owner's switch is on; connecting is the only thing left.
+  statusMock.mockImplementation(async () => ({
+    ready: typeof store.clawai_token === "string" && store.clawai_token !== "",
+  }));
+});
+
+describe("POST /setup-api/hermes/clawai", () => {
+  it("re-advertises the coding-agent tools when a pasted token is what connected the box", async () => {
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+    expect(response.status).toBe(200);
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("does not reload when the box was already connected and already ready", async () => {
+    // Re-applying a tier. Nothing about the tool list moved, and a reload
+    // invalidates the model's prompt cache.
+    store.clawai_token = PASTED;
+    const response = await POST(post({ tier: "pro" }));
+    expect(response.status).toBe(200);
+    expect(reloadCount()).toBe(0);
+  });
+});

--- a/src/tests/unit/coding-agent-mcp-refresh.test.ts
+++ b/src/tests/unit/coding-agent-mcp-refresh.test.ts
@@ -15,17 +15,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: vi.fn() }));
+// The mechanism this helper has is HERMES' dashboard socket, and only a Hermes
+// box has one — so the edition decides what a refused reload MEANS. Most cases
+// below are a Hermes box; the OpenClaw ones say so.
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+import { getActiveHarness } from "@/lib/harness";
 
 const mockRpc = vi.mocked(dashboardRpc);
+const mockHarness = vi.mocked(getActiveHarness);
 let errorSpy: ReturnType<typeof vi.spyOn>;
 let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   mockRpc.mockReset();
   mockRpc.mockResolvedValue({ status: "ok" });
+  mockHarness.mockReset();
+  mockHarness.mockResolvedValue("hermes");
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 });
@@ -81,6 +89,50 @@ describe("refreshCodingAgentToolsIfReadinessChanged", () => {
     mockRpc.mockRejectedValue(new Error("socket exploded"));
     await expect(refreshCodingAgentToolsIfReadinessChanged(true, false)).resolves.toBeUndefined();
     expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not report an OpenClaw box as broken for having no dashboard", async () => {
+    // The coding_agent_* family is registered on BOTH editions
+    // (mcp/tools/coding-agent.ts), but the only mechanism here is Hermes'
+    // dashboard JSON-RPC. An OpenClaw box has none BY DESIGN, so `reload.mcp`
+    // can never succeed there — and nothing is wrong: OpenClaw spawns the
+    // ClawBox MCP server per session and reaps it after ten idle minutes, so
+    // the probe re-runs and the tool list catches up on its own. An ERROR line
+    // over an operation that needed no repair is the recurring false-alarm
+    // shape, not a diagnosis.
+    mockHarness.mockResolvedValue("openclaw");
+    mockRpc.mockResolvedValue(null);
+    await refreshCodingAgentToolsIfReadinessChanged(false, true);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+    expect(String(logSpy.mock.calls[0][0])).toMatch(/re-probes|next spawned/i);
+  });
+
+  it("still reports a HERMES box whose dashboard refused", async () => {
+    // The one case a human should act on: a box that HAS a dashboard and it
+    // said no. Softening this one too would trade a false alarm for a silence.
+    mockHarness.mockResolvedValue("hermes");
+    mockRpc.mockResolvedValue(null);
+    await refreshCodingAgentToolsIfReadinessChanged(false, true);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("keeps the error when the edition cannot be read at all", async () => {
+    // Unknown is not "OpenClaw". A harness lookup that throws must not be the
+    // thing that quiets a real Hermes failure.
+    mockHarness.mockRejectedValue(new Error("no config"));
+    mockRpc.mockResolvedValue(null);
+    await refreshCodingAgentToolsIfReadinessChanged(false, true);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not ask the dashboard twice when something already respawned the MCP children", async () => {
+    // Linking ClawBox AI can move drawing AND the coding agent in one request.
+    // The reload is global, so the second family must not pay for a second
+    // prompt-cache invalidation.
+    await refreshCodingAgentToolsIfReadinessChanged(false, true, { alreadyReloaded: true });
+    expect(mockRpc).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
   });
 
   it("does not claim success when the dashboard refused", async () => {

--- a/src/tests/unit/email-mcp-refresh.test.ts
+++ b/src/tests/unit/email-mcp-refresh.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * The narrow trigger that keeps `email_list`/`email_read` in step with the
@@ -13,15 +13,32 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  */
 
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: vi.fn() }));
+// `email_list`/`email_read` are registered on BOTH editions, but the only
+// mechanism here is Hermes' dashboard socket — so the edition decides what a
+// refused reload MEANS. Hermes unless a case says otherwise.
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 
 import { refreshEmailToolsIfReadabilityChanged } from "@/lib/email-mcp-refresh";
 import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+import { getActiveHarness } from "@/lib/harness";
 
 const mockRpc = vi.mocked(dashboardRpc);
+const mockHarness = vi.mocked(getActiveHarness);
+let errorSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   mockRpc.mockReset();
   mockRpc.mockResolvedValue({ status: "ok" });
+  mockHarness.mockReset();
+  mockHarness.mockResolvedValue("hermes");
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+  logSpy.mockRestore();
 });
 
 describe("refreshEmailToolsIfReadabilityChanged", () => {
@@ -70,6 +87,25 @@ describe("refreshEmailToolsIfReadabilityChanged", () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     mockRpc.mockRejectedValue(new Error("socket exploded"));
     await expect(refreshEmailToolsIfReadabilityChanged(true, false)).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not report an OpenClaw box as broken for having no dashboard", async () => {
+    // Same rule as the coding-agent sibling, and for the same reason: an
+    // OpenClaw box has no dashboard BY DESIGN, so a refusal there is the
+    // edition, not a fault. Its MCP server is spawned per session and reaped
+    // when idle, so the tool list catches up on its own.
+    mockHarness.mockResolvedValue("openclaw");
+    mockRpc.mockResolvedValue(null);
+    await refreshEmailToolsIfReadabilityChanged(false, true);
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  it("still reports a HERMES box whose dashboard refused", async () => {
+    mockHarness.mockResolvedValue("hermes");
+    mockRpc.mockResolvedValue(null);
+    await refreshEmailToolsIfReadabilityChanged(false, true);
     expect(errorSpy).toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/hermes-clawai-coding-agent.test.ts
+++ b/src/tests/unit/hermes-clawai-coding-agent.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Connecting ClawBox AI has to re-advertise the coding-agent tools, for the same
+ * reason flipping the switch does.
+ *
+ * `getCodingAgentStatus().ready` is three facts ANDed together — the owner's
+ * switch, the harness on disk, and ClawBox AI connected — and the ClawBox MCP
+ * server reads exactly that verdict ONCE, while it boots
+ * (`mcp/lib/context.ts` probeCodingAgent), to decide whether
+ * `coding_agent_run`/`_status`/`_stop` exist at all. #514 taught the enable
+ * route to reload the tool list when the SWITCH moved the verdict. This file
+ * pins the sibling write path: the third of those facts is written here, by
+ * `applyClawaiToHermes`, which every Hermes connect entry point funnels through
+ * (`/setup-api/hermes/clawai`, `/setup-api/ai-models/configure`, and the
+ * device-code finaliser in `/setup-api/ai-models/clawai/poll`). Without this a
+ * box with the switch already on goes ready:false → ready:true, the panel says
+ * ready, and the long-lived MCP child still has none of the three tools.
+ *
+ * The second rule here is the COST one. A reload kills and respawns every MCP
+ * child and invalidates the model's prompt cache, and this one call can move two
+ * families at once (drawing and the coding agent), so a link that changes both
+ * must still cost exactly ONE respawn.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+const drawsMock = vi.hoisted(() => vi.fn());
+const statusMock = vi.hoisted(() => vi.fn());
+const rpcMock = vi.hoisted(() => vi.fn());
+const bounceMock = vi.hoisted(() => vi.fn());
+const resolveVisionMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsMock }));
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
+vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
+  installHermesImagePlugin: vi.fn(),
+}));
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: resolveVisionMock,
+}));
+// The coding-agent module owns a runs store keyed off DATA_DIR; only its verdict
+// is wanted here, and `checkReadiness` has its own suite.
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: statusMock }));
+// A Hermes box, so the refresh helpers report in Hermes' words.
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+// NOT mocked, deliberately: `hermes-image-refresh`, `coding-agent-mcp-refresh`
+// and `hermes-mcp-reload` are the three modules whose combined behaviour is the
+// subject. Only the socket underneath them is faked.
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
+vi.mock("@/lib/hermes-dashboard-control", () => ({ bounceHermesDashboard: bounceMock }));
+
+import { applyClawaiToHermes } from "@/lib/hermes-clawai";
+import { CLAWBOX_AI_VISION_MODEL_ID } from "@/lib/clawbox-ai-models";
+
+/** How many GLOBAL MCP respawns this link asked the agent for. */
+function reloadCount(): number {
+  return rpcMock.mock.calls.filter((call) => call[0] === "reload.mcp").length;
+}
+
+/**
+ * @param drawsBefore/drawsAfter what `hermesAgentDrawsImages()` says either side
+ * @param readyBefore/readyAfter what `getCodingAgentStatus().ready` says either side
+ */
+function box(opts: {
+  drawsBefore: boolean;
+  drawsAfter: boolean;
+  readyBefore: boolean;
+  readyAfter: boolean;
+}): void {
+  drawsMock.mockResolvedValueOnce(opts.drawsBefore).mockResolvedValue(opts.drawsAfter);
+  statusMock
+    .mockResolvedValueOnce({ ready: opts.readyBefore })
+    .mockResolvedValue({ ready: opts.readyAfter });
+}
+
+beforeEach(() => {
+  cliMock.mockReset();
+  drawsMock.mockReset();
+  statusMock.mockReset();
+  rpcMock.mockReset();
+  bounceMock.mockReset();
+  resolveVisionMock.mockReset();
+  cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  resolveVisionMock.mockResolvedValue({
+    id: CLAWBOX_AI_VISION_MODEL_ID,
+    verified: true,
+    reason: "proxy-allows",
+  });
+  bounceMock.mockResolvedValue(true);
+  // The running agent answers every probe happily, so nothing below is a bounce.
+  rpcMock.mockImplementation(async (method: string) =>
+    method === "image.generate" ? { available: true } : { status: "ok" },
+  );
+});
+
+describe("applyClawaiToHermes and the coding-agent tool list", () => {
+  it("re-advertises the coding-agent tools when connecting is what made them runnable", async () => {
+    // The customer path this exists for: the owner turns the coding agent on
+    // FIRST (the switch saves fine, `ready` stays false because no AI is
+    // connected — the readiness text even tells them to go and connect one),
+    // then connects ClawBox AI. That second step is what moves the verdict, and
+    // before this fix nothing told the running agent.
+    box({ drawsBefore: true, drawsAfter: true, readyBefore: false, readyAfter: true });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    expect(reloadCount()).toBe(1);
+    // `confirm` is not decoration: `reload.mcp` is gated by
+    // approvals.mcp_reload_confirm, which defaults to true.
+    expect(rpcMock).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("costs ONE respawn when the same link moves drawing and the coding agent together", async () => {
+    // A reload respawns every MCP child and invalidates the prompt cache. Two
+    // families changing in one request is one fact about one box, not two
+    // reloads to pay for.
+    box({ drawsBefore: false, drawsAfter: true, readyBefore: false, readyAfter: true });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("does not reload when neither family moved", async () => {
+    // Re-applying a tier on a box that was already linked and already ready.
+    // Nothing about the tool list changed, so the owner may not be charged a
+    // prompt-cache invalidation for it.
+    box({ drawsBefore: true, drawsAfter: true, readyBefore: true, readyAfter: true });
+    await applyClawaiToHermes("claw_token_abc", "pro");
+    expect(reloadCount()).toBe(0);
+  });
+
+  it("reads the BEFORE verdict before it writes the token, not after", async () => {
+    // The trap: `checkReadiness` reads `clawai_token` from the config store, and
+    // this function writes that key. A verdict sampled after the write is always
+    // true, the guard sees before === after, and the reload silently never
+    // happens. The first `getCodingAgentStatus()` must therefore land before the
+    // `setMany` at the bottom of the apply.
+    box({ drawsBefore: true, drawsAfter: true, readyBefore: false, readyAfter: true });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    expect(statusMock).toHaveBeenCalledTimes(2);
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("does not let a readiness probe that threw fail the link", async () => {
+    // `checkReadiness` stats a wrapper, looks for two binaries on PATH and lists
+    // the project folders — all of which can throw on a half-installed box. This
+    // whole refresh is a courtesy laid on top of writes that already happened;
+    // turning it into "cannot link at all" would be the fail-soft promise the
+    // image half of this function makes, broken by its neighbour.
+    statusMock.mockRejectedValue(new Error("no such file"));
+    drawsMock.mockResolvedValue(true);
+    await expect(applyClawaiToHermes("claw_token_abc", "flash")).resolves.toMatchObject({
+      provider: "clawai",
+    });
+    expect(reloadCount()).toBe(0);
+  });
+
+  it("does not reload on a half-answered verdict", async () => {
+    // Readable before, unreadable after: that is not a flip, it is an unknown,
+    // and a global respawn is not the thing to do on a guess.
+    drawsMock.mockResolvedValue(true);
+    statusMock
+      .mockResolvedValueOnce({ ready: false })
+      .mockRejectedValue(new Error("no such file"));
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    expect(reloadCount()).toBe(0);
+  });
+
+  it("lets the caller supply the BEFORE verdict when it wrote the token first", async () => {
+    // `/setup-api/hermes/clawai` persists a PASTED token before it applies it,
+    // so a snapshot taken in here would already be true. The route takes its own
+    // and hands it over; this pins that the override is honoured.
+    box({ drawsBefore: true, drawsAfter: true, readyBefore: true, readyAfter: true });
+    await applyClawaiToHermes("claw_token_abc", "flash", { codingAgentReadyBefore: false });
+    expect(reloadCount()).toBe(1);
+  });
+});

--- a/src/tests/unit/hermes-clawai-images.test.ts
+++ b/src/tests/unit/hermes-clawai-images.test.ts
@@ -30,6 +30,13 @@ vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
 // with it has its own suite (hermes-image-refresh.test.ts).
 vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: drawsMock }));
 vi.mock("@/lib/hermes-image-refresh", () => ({ refreshHermesImageTools: refreshMock }));
+// `hermes-clawai` now reads the coding-agent verdict either side of the writes,
+// and that module owns a runs store keyed off DATA_DIR. Only the verdict is
+// wanted here; `checkReadiness` has its own suite.
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
+vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
+  refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
+}));
 vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
 vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: envMock }));

--- a/src/tests/unit/hermes-clawai-vision.test.ts
+++ b/src/tests/unit/hermes-clawai-vision.test.ts
@@ -26,6 +26,13 @@ vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
 // Neither belongs in a unit test's blast radius, and both have their own file
 // (`hermes-clawai-images.test.ts`).
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
+// `hermes-clawai` now reads the coding-agent verdict either side of the writes,
+// and that module owns a runs store keyed off DATA_DIR. Only the verdict is
+// wanted here; `checkReadiness` has its own suite.
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
+vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
+  refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
+}));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
   installHermesImagePlugin: vi.fn(),

--- a/src/tests/unit/hermes-image-refresh.test.ts
+++ b/src/tests/unit/hermes-image-refresh.test.ts
@@ -16,7 +16,16 @@ const reloadMcpMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/hermes-dashboard-control", () => ({ bounceHermesDashboard: bounceMock }));
-vi.mock("@/lib/hermes-mcp-reload", () => ({ reloadMcpServers: reloadMcpMock }));
+// Only the ASK is faked. `reportMcpReloadRefused` is the real one, because the
+// rule it owns — an OpenClaw box has no dashboard and needs no repair, a Hermes
+// box that refused does — is part of what this file pins.
+vi.mock("@/lib/hermes-mcp-reload", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-mcp-reload")>()),
+  reloadMcpServers: reloadMcpMock,
+}));
+// This helper's only caller (`applyClawaiToHermes`) is gated on a Hermes box by
+// all three of its entry points, so that is the box every case below runs on.
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
 
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 
@@ -175,14 +184,36 @@ describe("refreshHermesImageTools", () => {
     rpcMock.mockResolvedValue(null);
     bounceMock.mockResolvedValue(false);
 
-    await expect(refreshHermesImageTools(false, true)).resolves.toBeUndefined();
+    // …and the answer is an honest "nothing was respawned", which is what keeps
+    // the coding-agent family on the same path from skipping its own reload.
+    await expect(refreshHermesImageTools(false, true)).resolves.toBe(false);
   });
 
   it("does not throw when the RPC helper itself rejects", async () => {
     rpcMock.mockRejectedValue(new Error("socket exploded"));
     bounceMock.mockResolvedValue(false);
 
-    await expect(refreshHermesImageTools(false, true)).resolves.toBeUndefined();
-    await expect(refreshHermesImageTools(true, false)).resolves.toBeUndefined();
+    await expect(refreshHermesImageTools(false, true)).resolves.toBe(false);
+    await expect(refreshHermesImageTools(true, false)).resolves.toBe(true);
+  });
+
+  it("reports the respawn so a second family does not pay for a second one", async () => {
+    // The reload is GLOBAL — it rebuilds every family's tool list, not just the
+    // image one. Linking ClawBox AI can move drawing and the coding agent in one
+    // request, and the second must be able to see that the first already paid.
+    await expect(refreshHermesImageTools(false, true)).resolves.toBe(true);
+
+    // A bounce counts too: it takes the MCP children down with the dashboard and
+    // brings them back.
+    reloadMcpMock.mockResolvedValue(false);
+    agentSaysItCanDraw(false);
+    bounceMock.mockResolvedValue(true);
+    await expect(refreshHermesImageTools(false, true)).resolves.toBe(true);
+  });
+
+  it("says nothing was respawned when the box was already drawing", async () => {
+    // Re-linking with a fresh token. The credential is reloaded, but no MCP
+    // child was respawned, so a caller must not skip its own reload on it.
+    await expect(refreshHermesImageTools(true, true)).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
Follow-up to #514. Two residuals were reported against the merged head by the adversarial verifiers; both reproduce, both are closed here.

## MCP-01a — connecting ClawBox AI flipped readiness without refreshing the tool list (medium, customer-facing)

`getCodingAgentStatus().ready` is three facts ANDed together — the owner's switch, the harness on disk, and ClawBox AI connected (`src/lib/coding-agent.ts:735`, `checkReadiness` at `:689`) — and the ClawBox MCP server reads exactly that verdict ONCE while it boots (`mcp/lib/context.ts` `probeCodingAgent`) to decide whether `coding_agent_run` / `_status` / `_stop` are declared at all.

#514 guarded the **first** of the three, in `/setup-api/coding-agent/enable`. The **third** is written in-app by `applyClawaiToHermes` (`src/lib/hermes-clawai.ts`), which every Hermes connect entry point funnels through — `/setup-api/hermes/clawai`, `/setup-api/ai-models/configure` (the `openclawIsAbsent()` branch), and the device-code finaliser in `/setup-api/ai-models/clawai/poll`. None of them refreshed anything, so on a box with the switch already on:

connect the AI → `ready` false → true → the panel says ready → the running MCP child still has none of the three tools, until something unrelated respawns it.

That is the order the product itself asks for: the readiness text says *"ClawBox AI is not connected. Open Settings → AI Models and sign in to ClawBox AI first."*

**Reproduced against merged head** by the new `src/tests/unit/hermes-clawai-coding-agent.test.ts` and `src/tests/routes/hermes/clawai-coding-agent.test.ts` (RED counts below).

### The fix

- `applyClawaiToHermes` now samples the verdict either side of its writes and calls `refreshCodingAgentToolsIfReadinessChanged`, next to the `refreshHermesImageTools` call that already did this dance for the image family.
- **The ordering trap (the verifier's MUST-FIX).** `/setup-api/hermes/clawai/route.ts` persists a PASTED token *before* it calls the apply, and `ready` reads that very key — so a snapshot taken inside the lib is already `true` on that path and the guard silently no-ops. The route now takes its own snapshot ahead of its write and passes it in (`ApplyClawaiOptions.codingAgentReadyBefore`). The two other entry points write nothing first, so they leave it unset and the lib's own snapshot is honest. There is a test for exactly this route, and it fails without the snapshot.
- **One respawn, not two.** `reload.mcp` kills and respawns every MCP child and invalidates the model's prompt cache. A link can move drawing *and* the coding agent in the same request, so `refreshHermesImageTools` now returns whether it respawned the children — by reloading, or by bouncing the dashboard, which takes them down with it — and the coding-agent refresh reports instead of paying for a second one. Deterministic rather than a race: both verdicts are computed from post-write state before either helper acts.
- **Fail-soft.** `checkReadiness` stats a wrapper, looks for two binaries on `PATH` and lists the project folders; any of those can throw on a half-installed box. An unanswerable verdict now means "leave the tool list alone", never "abandon the link" — the same promise the image half of that function already makes.

## MCP-01b — a console.error on a box where nothing is wrong (low)

The `coding_agent_*` family is registered on **both** editions (`mcp/tools/coding-agent.ts:229/:286/:327`), but the only mechanism the refresh helper has is Hermes' dashboard JSON-RPC. An OpenClaw box has no dashboard by design, so `reloadMcpServers()` always returns false there and every readiness move logged `[coding-agent/mcp-refresh] … but the agent would not reload its MCP servers` at ERROR level — while nothing was broken: OpenClaw spawns the ClawBox MCP server lazily per session and reaps it after ten idle minutes, so the probe re-runs and the tool list catches up on its own. That is the third recurring class: a repair announced over an operation that in fact succeeded.

New `reportMcpReloadRefused(tag, what)` in `src/lib/hermes-mcp-reload.ts` owns the rule for **all three** refresh helpers (`coding-agent-mcp-refresh`, `email-mcp-refresh` — the verifier's "consider" — and `hermes-image-refresh`): `console.error` is kept for the one case a human can act on, a box that *has* a dashboard and it refused; everything else is a `console.log` that says what actually happens next. **Unknown is not OpenClaw** — if the harness lookup itself throws, the error is kept, so a failed lookup can never quiet a real Hermes failure. There is a test for that too.

## Fixing the class, not the instance

The shape #514 exists to remove is "the verdict moved and nothing told the running agent". Three greps, all run against this branch:

```
# 1. every writer that can move getCodingAgentStatus().ready
grep -rn "clawai_token\|setCodingAgentEnabled\|CODING_AGENT_CONFIG_KEY" --include='*.ts' src mcp | grep -v tests
```

- `coding_agent_enabled` — exactly one writer, `setCodingAgentEnabled`, called only from `/setup-api/coding-agent/enable` (covered by #514).
- `clawai_token` — `src/lib/hermes-clawai.ts` (all three Hermes connects funnel here, covered now), `src/app/setup-api/hermes/clawai/route.ts` (the early write, snapshotted now), and `/setup-api/ai-models/configure` lines 1719/1753, which are the **OpenClaw** path — that box has no dashboard to ask, and its MCP server is spawned per session and reaped when idle, so the probe re-runs on its own. Nothing clears the token in-app.
- The harness/`setpriv` third is written by `install.sh`, not by the app; installing it restarts the box.

```
# 2. every caller of the connect path, to prove the library is the right seam
grep -rn "applyClawaiToHermes" --include='*.ts' src | grep -v tests
```

Three route call sites, one library definition — so the refresh belongs in the library, and all three are covered by one change.

```
# 3. every emitter of the false "would not reload" error
grep -rn "would not reload" --include='*.ts' src | grep -v tests
```

Was three (`coding-agent-mcp-refresh`, `email-mcp-refresh`, `hermes-image-refresh`); now one, inside `reportMcpReloadRefused`, which is the only place that decides how a refusal is reported.

## Tests

Red-first, each proven to fail against unmodified `origin/beta`:

| test | file |
|---|---|
| the BEFORE verdict is read before the token is written | `src/tests/unit/hermes-clawai-coding-agent.test.ts` |
| the caller's BEFORE snapshot is honoured | `src/tests/unit/hermes-clawai-coding-agent.test.ts` |
| connecting re-advertises the coding-agent tools | `src/tests/unit/hermes-clawai-coding-agent.test.ts` |
| a pasted token through `/setup-api/hermes/clawai` reloads exactly once | `src/tests/routes/hermes/clawai-coding-agent.test.ts` |
| an OpenClaw box is not reported as broken (coding agent) | `src/tests/unit/coding-agent-mcp-refresh.test.ts` |
| an OpenClaw box is not reported as broken (email) | `src/tests/unit/email-mcp-refresh.test.ts` |
| no second respawn when the children were already reloaded | `src/tests/unit/coding-agent-mcp-refresh.test.ts` |

**7 RED against `origin/beta` → 0 RED, all green on this branch.** Targeted suites (`routes/hermes`, `routes/coding-agent`, `routes/ai-models`, `routes/email` and the six affected unit files): 692 passed, 1 failed — `skills-secrets` "writes the file 0600", which fails identically on unmodified `origin/beta` on this host because Windows has no POSIX mode bits.

Guard cases that were already green and stay green: no reload when neither family moved; no reload on a half-answered verdict; a refused reload still reports on Hermes; the link survives a readiness probe that throws.

## Baseline

`npm run lint` — 182 problems (99 errors, 83 warnings), identical to `origin/beta`; none in the touched files. `tsc --noEmit` — 24 errors, identical to `origin/beta`, none in the touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - ClawBox AI connections now detect coding-agent readiness changes and refresh available tools when needed.
  - Duplicate MCP refreshes are avoided when tools have already been reloaded.
  - Readiness checks tolerate temporary probe failures without blocking setup.

- **Bug Fixes**
  - MCP reload failures now provide harness-appropriate feedback and clearer error handling.
  - Image and email tool refreshes more accurately report whether a reload occurred.

- **Tests**
  - Added coverage for readiness transitions, reload behavior, refusal handling, and failed status checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->