### PR TITLE
fix: harden gateway recovery across network outages

### DIFF
--- a/config/clawbox-channel-recovery.service
+++ b/config/clawbox-channel-recovery.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Recover breaker-suppressed OpenClaw channels after network return
+After=network-online.target clawbox-gateway.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=clawbox
+Group=clawbox
+WorkingDirectory=/home/clawbox
+Environment=HOME=/home/clawbox
+Environment=PATH=/home/clawbox/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ExecStart=/home/clawbox/clawbox/scripts/recover-openclaw-channels.sh
+TimeoutStartSec=90
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=read-only
+ProtectSystem=strict
+ReadWritePaths=/home/clawbox/.openclaw

--- a/config/clawbox-channel-recovery.timer
+++ b/config/clawbox-channel-recovery.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodically reconcile OpenClaw channel recovery
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=5min
+AccuracySec=15s
+Unit=clawbox-channel-recovery.service
+
+[Install]
+WantedBy=timers.target

--- a/config/clawbox-gateway.service
+++ b/config/clawbox-gateway.service
@@ -22,7 +22,7 @@ ExecStartPre=/home/clawbox/clawbox/scripts/gateway-pre-start.sh
 # which gateway-pre-start.sh keeps as a strong per-device value (and which
 # gateway-proxy.ts injects into the SPA). Passing a literal here would override
 # that and reintroduce the shared-token / UI-drift bug (issues #149, #150).
-ExecStart=/home/clawbox/.npm-global/bin/openclaw gateway --allow-unconfigured --bind lan
+ExecStart=/home/clawbox/clawbox/scripts/run-openclaw-gateway.sh --allow-unconfigured --bind lan
 # OpenClaw restarts itself by EXITING and letting its supervisor start it again:
 # it detects systemd from INVOCATION_ID/JOURNAL_STREAM, logs "restart mode: full
 # process restart (supervisor restart)", writes a handoff file and calls exit(0).

--- a/install.sh
+++ b/install.sh
@@ -495,9 +495,16 @@ EXPECTED_INSTALLED_SERVICES=(
 # registered in one of the two lists above.
 EDITION_SCOPED_UNITS=(
   clawbox-gateway.service                 # openclaw + dual (removed on hermes)
+  clawbox-channel-recovery.service        # openclaw + dual
+  clawbox-channel-recovery.timer          # openclaw + dual
   clawbox-hermes-dashboard.service        # hermes + dual
   clawbox-hermes-dashboard-proxy.service  # hermes + dual
 )
+
+if has_openclaw_harness; then
+  EXPECTED_ACTIVE_SERVICES+=(clawbox-channel-recovery.timer)
+  EXPECTED_INSTALLED_SERVICES+=(clawbox-channel-recovery.service)
+fi
 
 # Hermes harness editions (hermes + the premium dual) run the Hermes dashboard
 # and its auth proxy.
@@ -2998,6 +3005,13 @@ install_root_libexec() {
       install -o root -g root -m 0755 "$PROJECT_DIR/scripts/$src" "$ROOT_LIBEXEC_DIR/$src"
     fi
   done
+  # Shared network readiness logic is sourced by the root NetworkManager
+  # dispatcher and by unprivileged Gateway/channel wrappers. Keep the runtime
+  # copy outside the clawbox-writable project tree.
+  if [ -f "$PROJECT_DIR/scripts/network-readiness.sh" ]; then
+    install -o root -g root -m 0644 "$PROJECT_DIR/scripts/network-readiness.sh" \
+      "$ROOT_LIBEXEC_DIR/network-readiness.sh"
+  fi
   # The limits the scripts above read. Root-owned for the same reason they are.
   install -d -o root -g root -m 0755 /etc/clawbox
   if [ -f "$PROJECT_DIR/config/clawbox-resource-limits.env" ]; then
@@ -3345,6 +3359,7 @@ step_systemd_services() {
     # Timer-driven one-shot (no [Install]); enabled via its .timer below.
     [[ "$svc" == "clawbox-ap-watchdog.service" ]] && continue
     [[ "$svc" == "clawbox-codex-auth-sync.service" ]] && continue
+    [[ "$svc" == "clawbox-channel-recovery.service" ]] && continue
     systemctl enable "$svc"
   done
   # Start the heartbeat timer immediately so the portal sees the device
@@ -3362,6 +3377,11 @@ step_systemd_services() {
   # this release strips any refresh_token 3.1.11 planted in its mirrors without
   # waiting for a reboot — that token is what burns the OAuth family.
   systemctl enable --now clawbox-codex-auth-sync.timer
+  if has_openclaw_harness; then
+    # Bounded no-op while channels are healthy; repairs only accounts stopped
+    # specifically by OpenClaw's restart-loop breaker after network recovery.
+    systemctl enable --now clawbox-channel-recovery.timer
+  fi
   # Clean up older installs that enabled on-demand units at boot.
   systemctl disable --now clawbox-browser.service >/dev/null 2>&1 || true
   # Migration: prior installs enabled clawbox-tunnel by default, which loops
@@ -3441,14 +3461,20 @@ step_nm_dispatcher() {
   local DISPATCHER_DIR="/etc/NetworkManager/dispatcher.d"
   local SRC="$PROJECT_DIR/scripts/nm-dispatcher-failover.sh"
   local DEST="$DISPATCHER_DIR/90-clawbox-failover"
+  local HELPER_SRC="$PROJECT_DIR/scripts/network-readiness.sh"
+  local HELPER_DEST="$ROOT_LIBEXEC_DIR/network-readiness.sh"
   if [ ! -f "$SRC" ]; then
     echo "  Skipping NM dispatcher: $SRC missing"
     return
   fi
+  if [ ! -f "$HELPER_SRC" ]; then
+    echo "  Skipping NM dispatcher: $HELPER_SRC missing"
+    return 1
+  fi
+  install -d -o root -g root -m 0755 "$ROOT_LIBEXEC_DIR"
+  install -o root -g root -m 0644 "$HELPER_SRC" "$HELPER_DEST"
   mkdir -p "$DISPATCHER_DIR"
-  cp "$SRC" "$DEST"
-  chown root:root "$DEST"
-  chmod 0755 "$DEST"
+  install -o root -g root -m 0755 "$SRC" "$DEST"
   echo "  NetworkManager failover dispatcher installed"
 }
 

--- a/scripts/network-readiness.sh
+++ b/scripts/network-readiness.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Bounded proof that the host has a usable public route before ClawBox restarts
+# network-dependent services. Callers may override the commands and target for
+# synthetic tests; the installed NetworkManager dispatcher clears those
+# overrides before calling this helper as root.
+
+clawbox_network_ready() {
+  local ip_bin="${CLAWBOX_IP_BIN:-ip}"
+  local curl_bin="${CLAWBOX_CURL_BIN:-curl}"
+  local probe_ip="${CLAWBOX_NETWORK_PROBE_IP:-1.1.1.1}"
+  local probe_url="${CLAWBOX_NETWORK_PROBE_URL:-https://1.1.1.1/cdn-cgi/trace}"
+  local http_code
+
+  "$ip_bin" -4 route get "$probe_ip" >/dev/null 2>&1 || return 1
+  http_code=$("$curl_bin" --silent --show-error --output /dev/null \
+    --connect-timeout 3 --max-time 5 --write-out '%{http_code}' "$probe_url" 2>/dev/null) || return 1
+  case "$http_code" in
+    2??|3??|4??) return 0 ;;
+    *) return 1 ;;
+  esac
+}

--- a/scripts/nm-dispatcher-failover.sh
+++ b/scripts/nm-dispatcher-failover.sh
@@ -7,6 +7,7 @@
 
 set -u
 
+NETWORK_READINESS_LIB="/usr/local/libexec/clawbox/network-readiness.sh"
 IFACE="${1:-}"
 ACTION="${2:-}"
 WIFI_IFACE="${NETWORK_INTERFACE:-wlP1p1s0}"
@@ -14,6 +15,37 @@ AP_PROFILE="ClawBox-Setup"
 LOG_TAG="clawbox-failover"
 
 log() { logger -t "$LOG_TAG" -- "$*"; }
+
+if [ ! -r "$NETWORK_READINESS_LIB" ]; then
+  log "Network readiness helper is unavailable; leaving the Gateway unchanged"
+  exit 0
+fi
+
+# NetworkManager runs this dispatcher as root. Never honor test overrides from
+# its environment when selecting route/probe commands or destinations.
+unset CLAWBOX_IP_BIN CLAWBOX_CURL_BIN CLAWBOX_NETWORK_PROBE_IP CLAWBOX_NETWORK_PROBE_URL
+# shellcheck source=/usr/local/libexec/clawbox/network-readiness.sh
+source "$NETWORK_READINESS_LIB"
+
+schedule_channel_recovery() {
+  systemctl restart clawbox-channel-recovery.timer >/dev/null 2>&1 || \
+    log "Could not schedule channel recovery"
+}
+
+restart_gateway_on_ready_route() {
+  if ! clawbox_network_ready; then
+    log "Replacement public route is not ready; leaving clawbox-gateway running"
+    return 1
+  fi
+  if systemctl is-active --quiet clawbox-gateway.service; then
+    log "Public route ready — restarting clawbox-gateway to rebind sockets"
+    systemctl restart clawbox-gateway.service >/dev/null 2>&1 || {
+      log "Gateway restart failed"
+      return 1
+    }
+  fi
+  schedule_channel_recovery
+}
 
 # Only react to ethernet up/down events.
 case "$IFACE" in
@@ -25,11 +57,8 @@ esac
 # interface. Existing sockets bound to the WiFi IP would otherwise be sent
 # down Eth as asymmetric traffic and silently fail.
 if [ "$ACTION" = "up" ]; then
-  if systemctl is-active --quiet clawbox-gateway.service; then
-    log "Ethernet '$IFACE' up — restarting clawbox-gateway to rebind sockets"
-    systemctl restart clawbox-gateway.service >/dev/null 2>&1 || \
-      log "Gateway restart failed"
-  fi
+  log "Ethernet '$IFACE' up — checking replacement route before Gateway restart"
+  restart_gateway_on_ready_route || true
   exit 0
 fi
 
@@ -43,15 +72,8 @@ fi
 
 log "Ethernet '$IFACE' down — attempting WiFi failover"
 
-# Kill TCP sockets the OpenClaw gateway holds bound to the now-dead interface
-# IPs. HTTP/2 keep-alives to OpenAI/Anthropic/Telegram look ESTABLISHED but
-# silently blackhole until TCP times out (~120s). A service restart drops them
-# and forces fresh connections on the surviving interface.
-if systemctl is-active --quiet clawbox-gateway.service; then
-  log "Restarting clawbox-gateway to drop sockets bound to dead $IFACE"
-  systemctl restart clawbox-gateway.service >/dev/null 2>&1 || \
-    log "Gateway restart failed"
-fi
+# Do not restart the Gateway yet. Starting network-dependent providers without
+# a replacement route can turn a short link outage into a process crash loop.
 
 # If the AP is currently active on the WiFi radio, take it down so the radio is free.
 if nmcli -t -f NAME,DEVICE connection show --active | grep -qE "^${AP_PROFILE}:${WIFI_IFACE}$"; then
@@ -63,7 +85,8 @@ fi
 if nmcli -t -f TYPE,STATE,DEVICE device status | grep -qE "^wifi:connected:${WIFI_IFACE}$"; then
   active_wifi=$(nmcli -t -f NAME,TYPE,DEVICE connection show --active | awk -F: -v i="$WIFI_IFACE" -v ap="$AP_PROFILE" '$2=="802-11-wireless" && $3==i && $1!=ap {print $1; exit}')
   if [ -n "$active_wifi" ]; then
-    log "Already on WiFi '$active_wifi' — no failover needed"
+    log "Already on WiFi '$active_wifi' — rebinding Gateway on the proven route"
+    restart_gateway_on_ready_route || true
     exit 0
   fi
 fi
@@ -83,6 +106,7 @@ for profile in "${profiles[@]}"; do
   log "Trying WiFi profile '$profile'"
   if nmcli connection up "$profile" ifname "$WIFI_IFACE" >/dev/null 2>&1; then
     log "Connected to '$profile' — failover complete"
+    restart_gateway_on_ready_route || true
     exit 0
   fi
 done

--- a/scripts/recover-openclaw-channels.sh
+++ b/scripts/recover-openclaw-channels.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NETWORK_READINESS_LIB="${CLAWBOX_NETWORK_READINESS_LIB:-/usr/local/libexec/clawbox/network-readiness.sh}"
+OPENCLAW_BIN="${CLAWBOX_OPENCLAW_BIN:-/home/clawbox/.npm-global/bin/openclaw}"
+LOG_TAG="clawbox-channel-recovery"
+VERIFY_ATTEMPTS="${CLAWBOX_CHANNEL_RECOVERY_VERIFY_ATTEMPTS:-6}"
+VERIFY_DELAY_SECONDS="${CLAWBOX_CHANNEL_RECOVERY_VERIFY_DELAY_SECONDS:-5}"
+
+log() { logger -t "$LOG_TAG" -- "$*"; }
+
+if [ ! -r "$NETWORK_READINESS_LIB" ]; then
+  log "Network readiness helper is unavailable; refusing channel recovery"
+  exit 1
+fi
+
+# shellcheck source=/usr/local/libexec/clawbox/network-readiness.sh
+source "$NETWORK_READINESS_LIB"
+
+if ! clawbox_network_ready; then
+  log "Public route is not ready; leaving channels stopped for the next bounded retry"
+  exit 0
+fi
+
+status_json=$($OPENCLAW_BIN channels status --probe --json)
+mapfile -t recovery_targets < <(
+  python3 -c '
+import json, sys
+payload = json.load(sys.stdin)
+for channel, accounts in (payload.get("channelAccounts") or {}).items():
+    for account in accounts or []:
+        error = str(account.get("lastError") or "").lower()
+        suppressed = "crash-loop breaker" in error or "restart-loop breaker" in error
+        probe_ok = (account.get("probe") or {}).get("ok") is True
+        if (account.get("enabled") is True and account.get("configured") is True
+                and account.get("running") is not True and suppressed and probe_ok):
+            account_id = account.get("accountId") or "default"
+            print(channel, account_id, sep="\t")
+' <<<"$status_json"
+)
+
+if [ "${#recovery_targets[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+for target in "${recovery_targets[@]}"; do
+  IFS=$'\t' read -r channel account_id <<<"$target"
+  params=$(python3 -c 'import json,sys; print(json.dumps({"channel":sys.argv[1],"accountId":sys.argv[2]}, separators=(",",":")))' "$channel" "$account_id")
+  log "Starting breaker-suppressed channel account $channel/$account_id"
+  $OPENCLAW_BIN gateway call channels.start --params "$params" --json --timeout 30000 >/dev/null
+done
+
+for ((attempt=1; attempt<=VERIFY_ATTEMPTS; attempt++)); do
+  status_json=$($OPENCLAW_BIN channels status --json)
+  if python3 -c '
+import json, sys
+targets = {tuple(item.split("\t", 1)) for item in sys.argv[1:]}
+payload = json.load(sys.stdin)
+current = {}
+for channel, accounts in (payload.get("channelAccounts") or {}).items():
+    for account in accounts or []:
+        current[(channel, account.get("accountId") or "default")] = account
+raise SystemExit(0 if all(
+    current.get(target, {}).get("running") is True
+    and current.get(target, {}).get("connected") is True
+    for target in targets
+) else 1)
+' "${recovery_targets[@]}" <<<"$status_json"; then
+    log "Recovered ${#recovery_targets[@]} breaker-suppressed channel account(s)"
+    exit 0
+  fi
+  if [ "$attempt" -lt "$VERIFY_ATTEMPTS" ]; then
+    sleep "$VERIFY_DELAY_SECONDS"
+  fi
+done
+
+log "Channel recovery did not reach running+connected state"
+exit 1

--- a/scripts/run-openclaw-gateway.sh
+++ b/scripts/run-openclaw-gateway.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NETWORK_READINESS_LIB="${CLAWBOX_NETWORK_READINESS_LIB:-/usr/local/libexec/clawbox/network-readiness.sh}"
+OPENCLAW_BIN="${CLAWBOX_OPENCLAW_BIN:-/home/clawbox/.npm-global/bin/openclaw}"
+LOG_TAG="clawbox-gateway-network-guard"
+
+if [ ! -r "$NETWORK_READINESS_LIB" ]; then
+  logger -t "$LOG_TAG" -- \
+    "Network readiness helper is unavailable; starting Gateway without the offline guard"
+  exec "$OPENCLAW_BIN" gateway "$@"
+fi
+
+# shellcheck source=/usr/local/libexec/clawbox/network-readiness.sh
+source "$NETWORK_READINESS_LIB"
+
+if ! clawbox_network_ready; then
+  # Keep the local control plane alive while preventing network-dependent
+  # channels from turning a temporary route outage into a Gateway crash loop.
+  export OPENCLAW_SKIP_CHANNELS=1
+  logger -t "$LOG_TAG" -- \
+    "Public route unavailable at Gateway start; deferring channel auto-start"
+fi
+
+exec "$OPENCLAW_BIN" gateway "$@"

--- a/scripts/test-network-resilience.py
+++ b/scripts/test-network-resilience.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parent.parent
+DISPATCHER = ROOT / "scripts" / "nm-dispatcher-failover.sh"
+GATEWAY_WRAPPER = ROOT / "scripts" / "run-openclaw-gateway.sh"
+CHANNEL_RECOVERY = ROOT / "scripts" / "recover-openclaw-channels.sh"
+NETWORK_READINESS = ROOT / "scripts" / "network-readiness.sh"
+
+
+def write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+    path.chmod(0o755)
+
+
+class NetworkResilienceTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory(prefix="clawbox-network-test-")
+        self.root = Path(self.tempdir.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.log = self.root / "calls.log"
+        self.state = self.root / "state.json"
+        self.dispatcher = self.root / "nm-dispatcher-failover.sh"
+        self.dispatcher.write_text(
+            DISPATCHER.read_text(encoding="utf-8").replace(
+                "/usr/local/libexec/clawbox/network-readiness.sh",
+                str(NETWORK_READINESS),
+            ),
+            encoding="utf-8",
+        )
+        self.dispatcher.chmod(0o755)
+        self._install_mocks()
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def _install_mocks(self) -> None:
+        write_executable(
+            self.bin / "logger",
+            r"""
+            #!/usr/bin/env bash
+            printf 'logger %s\n' "$*" >>"$MOCK_LOG"
+            """,
+        )
+        write_executable(
+            self.bin / "ip",
+            r"""
+            #!/usr/bin/env bash
+            [ "${MOCK_ROUTE_READY:-0}" = "1" ]
+            """,
+        )
+        write_executable(
+            self.bin / "curl",
+            r"""
+            #!/usr/bin/env bash
+            if [ "${MOCK_ROUTE_READY:-0}" = "1" ]; then
+              printf '204'
+              exit 0
+            fi
+            exit 7
+            """,
+        )
+        write_executable(
+            self.bin / "systemctl",
+            r"""
+            #!/usr/bin/env bash
+            printf 'systemctl %s\n' "$*" >>"$MOCK_LOG"
+            exit 0
+            """,
+        )
+        write_executable(
+            self.bin / "nmcli",
+            r"""
+            #!/usr/bin/env bash
+            args="$*"
+            case "$args" in
+              '-t -f TYPE,STATE device status') printf 'ethernet:disconnected\nwifi:disconnected\n' ;;
+              '-t -f NAME,DEVICE connection show --active') ;;
+              '-t -f TYPE,STATE,DEVICE device status') printf 'wifi:disconnected:wlP1p1s0\n' ;;
+              '-t -f NAME,TYPE,AUTOCONNECT-PRIORITY connection show')
+                if [ "${MOCK_WIFI_PROFILE:-0}" = "1" ]; then
+                  printf 'HomeWifi:802-11-wireless:10\n'
+                fi
+                ;;
+              'connection up HomeWifi ifname wlP1p1s0')
+                [ "${MOCK_WIFI_CONNECTS:-0}" = "1" ]
+                ;;
+              *) printf 'unexpected nmcli: %s\n' "$args" >&2; exit 2 ;;
+            esac
+            """,
+        )
+        write_executable(
+            self.bin / "openclaw",
+            r"""
+            #!/usr/bin/env python3
+            import json, os, pathlib, sys
+
+            log = pathlib.Path(os.environ["MOCK_LOG"])
+            state_path = pathlib.Path(os.environ["MOCK_STATE"])
+            args = sys.argv[1:]
+            with log.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    "openclaw skip=%s %s\n"
+                    % (os.environ.get("OPENCLAW_SKIP_CHANNELS", ""), " ".join(args))
+                )
+            if args and args[0] == "gateway" and len(args) > 1 and args[1] != "call":
+                raise SystemExit(0)
+            mode = os.environ.get("MOCK_CHANNEL_MODE", "suppressed")
+            started = state_path.exists()
+            if args[:2] == ["channels", "status"]:
+                if mode == "auth-failure":
+                    alfred = {
+                        "accountId": "alfred", "enabled": True, "configured": True,
+                        "running": False, "connected": False, "lastError": "unauthorized",
+                        "probe": {"ok": True},
+                    }
+                else:
+                    alfred = {
+                        "accountId": "alfred", "enabled": True, "configured": True,
+                        "running": started, "connected": started,
+                        "lastError": None if started else
+                            "gateway restart-loop breaker tripped; suppressing channel auto-start",
+                        "probe": {"ok": True},
+                    }
+                payload = {"channelAccounts": {"telegram": [
+                    alfred,
+                    {"accountId": "default", "enabled": True, "configured": True,
+                     "running": True, "connected": True, "lastError": None,
+                     "probe": {"ok": True}},
+                ]}}
+                print(json.dumps(payload))
+                raise SystemExit(0)
+            if args[:3] == ["gateway", "call", "channels.start"]:
+                state_path.write_text("started", encoding="utf-8")
+                print(json.dumps({"started": True}))
+                raise SystemExit(0)
+            raise SystemExit(2)
+            """,
+        )
+
+    def _env(self, **overrides: str) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.bin}:{env.get('PATH', '')}",
+                "MOCK_LOG": str(self.log),
+                "MOCK_STATE": str(self.state),
+                "CLAWBOX_NETWORK_READINESS_LIB": str(NETWORK_READINESS),
+                "CLAWBOX_OPENCLAW_BIN": str(self.bin / "openclaw"),
+                "CLAWBOX_CHANNEL_RECOVERY_VERIFY_ATTEMPTS": "1",
+                "CLAWBOX_CHANNEL_RECOVERY_VERIFY_DELAY_SECONDS": "0",
+            }
+        )
+        env.update(overrides)
+        return env
+
+    def _run(self, script: Path, *args: str, env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(script), *args],
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=15,
+            check=False,
+        )
+
+    def _calls(self) -> str:
+        return self.log.read_text(encoding="utf-8") if self.log.exists() else ""
+
+    def test_link_down_without_replacement_route_does_not_restart_gateway(self) -> None:
+        result = self._run(self.dispatcher, "enP8p1s0", "down", env=self._env(MOCK_ROUTE_READY="0"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("restart clawbox-gateway.service", self._calls())
+
+    def test_wifi_failover_restarts_only_after_public_route_is_ready(self) -> None:
+        result = self._run(
+            self.dispatcher,
+            "enP8p1s0",
+            "down",
+            env=self._env(MOCK_ROUTE_READY="1", MOCK_WIFI_PROFILE="1", MOCK_WIFI_CONNECTS="1"),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self._calls()
+        self.assertIn("restart clawbox-gateway.service", calls)
+        self.assertIn("restart clawbox-channel-recovery.timer", calls)
+
+    def test_link_up_without_public_route_does_not_restart_gateway(self) -> None:
+        result = self._run(self.dispatcher, "enP8p1s0", "up", env=self._env(MOCK_ROUTE_READY="0"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("restart clawbox-gateway.service", self._calls())
+
+    def test_gateway_wrapper_defers_channels_when_network_is_unavailable(self) -> None:
+        result = self._run(
+            GATEWAY_WRAPPER,
+            "--allow-unconfigured",
+            env=self._env(MOCK_ROUTE_READY="0"),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("openclaw skip=1 gateway --allow-unconfigured", self._calls())
+
+    def test_gateway_wrapper_starts_channels_normally_when_network_is_ready(self) -> None:
+        result = self._run(
+            GATEWAY_WRAPPER,
+            "--allow-unconfigured",
+            env=self._env(MOCK_ROUTE_READY="1"),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("openclaw skip= gateway --allow-unconfigured", self._calls())
+
+    def test_recovery_starts_only_breaker_suppressed_account_and_verifies_connected(self) -> None:
+        result = self._run(CHANNEL_RECOVERY, env=self._env(MOCK_ROUTE_READY="1"))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self._calls()
+        self.assertIn("gateway call channels.start", calls)
+        self.assertIn('"accountId":"alfred"', calls)
+        self.assertNotIn('"accountId":"default"', calls)
+
+    def test_recovery_does_not_override_authentication_failure(self) -> None:
+        result = self._run(
+            CHANNEL_RECOVERY,
+            env=self._env(MOCK_ROUTE_READY="1", MOCK_CHANNEL_MODE="auth-failure"),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("gateway call channels.start", self._calls())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/src/tests/unit/network-resilience.test.ts
+++ b/src/tests/unit/network-resilience.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const REPO = process.cwd();
+const SOURCE_DISPATCHER = path.join(REPO, "scripts/nm-dispatcher-failover.sh");
+const GATEWAY_WRAPPER = path.join(REPO, "scripts/run-openclaw-gateway.sh");
+const CHANNEL_RECOVERY = path.join(REPO, "scripts/recover-openclaw-channels.sh");
+const NETWORK_READINESS = path.join(REPO, "scripts/network-readiness.sh");
+
+function executable(file: string, body: string): void {
+  writeFileSync(file, body.replace(/^\n/, ""), { mode: 0o755 });
+}
+
+describe("ClawBox network-aware Gateway lifecycle", () => {
+  let root: string;
+  let bin: string;
+  let log: string;
+  let state: string;
+  let dispatcher: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "clawbox-network-resilience-"));
+    bin = path.join(root, "bin");
+    log = path.join(root, "calls.log");
+    state = path.join(root, "state");
+    dispatcher = path.join(root, "nm-dispatcher-failover.sh");
+    mkdirSync(bin);
+
+    executable(
+      path.join(bin, "logger"),
+      `#!/usr/bin/env bash
+printf 'logger %s\\n' "$*" >>"$MOCK_LOG"
+`,
+    );
+    executable(
+      path.join(bin, "ip"),
+      `#!/usr/bin/env bash
+[ "\${MOCK_ROUTE_READY:-0}" = "1" ]
+`,
+    );
+    executable(
+      path.join(bin, "curl"),
+      `#!/usr/bin/env bash
+if [ "\${MOCK_ROUTE_READY:-0}" = "1" ]; then printf '204'; exit 0; fi
+exit 7
+`,
+    );
+    executable(
+      path.join(bin, "systemctl"),
+      `#!/usr/bin/env bash
+printf 'systemctl %s\\n' "$*" >>"$MOCK_LOG"
+exit 0
+`,
+    );
+    executable(
+      path.join(bin, "nmcli"),
+      `#!/usr/bin/env bash
+case "$*" in
+  '-t -f TYPE,STATE device status') printf 'ethernet:disconnected\\nwifi:disconnected\\n' ;;
+  '-t -f NAME,DEVICE connection show --active') ;;
+  '-t -f TYPE,STATE,DEVICE device status') printf 'wifi:disconnected:wlP1p1s0\\n' ;;
+  '-t -f NAME,TYPE,AUTOCONNECT-PRIORITY connection show')
+    [ "\${MOCK_WIFI_PROFILE:-0}" = "1" ] && printf 'HomeWifi:802-11-wireless:10\\n'
+    ;;
+  'connection up HomeWifi ifname wlP1p1s0') [ "\${MOCK_WIFI_CONNECTS:-0}" = "1" ] ;;
+  *) printf 'unexpected nmcli: %s\\n' "$*" >&2; exit 2 ;;
+esac
+`,
+    );
+    executable(
+      path.join(bin, "openclaw"),
+      `#!/usr/bin/env bash
+printf 'openclaw skip=%s %s\\n' "\${OPENCLAW_SKIP_CHANNELS:-}" "$*" >>"$MOCK_LOG"
+if [ "\${1:-}" = gateway ] && [ "\${2:-}" != call ]; then exit 0; fi
+if [ "\${1:-} \${2:-}" = 'channels status' ]; then
+  if [ "\${MOCK_CHANNEL_MODE:-suppressed}" = auth-failure ]; then
+    printf '%s\\n' '{"channelAccounts":{"telegram":[{"accountId":"alfred","enabled":true,"configured":true,"running":false,"connected":false,"lastError":"unauthorized","probe":{"ok":true}},{"accountId":"default","enabled":true,"configured":true,"running":true,"connected":true,"lastError":null,"probe":{"ok":true}}]}}'
+  elif [ -f "$MOCK_STATE" ]; then
+    printf '%s\\n' '{"channelAccounts":{"telegram":[{"accountId":"alfred","enabled":true,"configured":true,"running":true,"connected":true,"lastError":null,"probe":{"ok":true}},{"accountId":"default","enabled":true,"configured":true,"running":true,"connected":true,"lastError":null,"probe":{"ok":true}}]}}'
+  else
+    printf '%s\\n' '{"channelAccounts":{"telegram":[{"accountId":"alfred","enabled":true,"configured":true,"running":false,"connected":false,"lastError":"gateway restart-loop breaker tripped; suppressing channel auto-start","probe":{"ok":true}},{"accountId":"default","enabled":true,"configured":true,"running":true,"connected":true,"lastError":null,"probe":{"ok":true}}]}}'
+  fi
+  exit 0
+fi
+if [ "\${1:-} \${2:-} \${3:-}" = 'gateway call channels.start' ]; then
+  : >"$MOCK_STATE"
+  printf '%s\\n' '{"started":true}'
+  exit 0
+fi
+exit 2
+`,
+    );
+
+    copyFileSync(SOURCE_DISPATCHER, dispatcher);
+    const dispatcherText = readFileSync(dispatcher, "utf8").replace(
+      "/usr/local/libexec/clawbox/network-readiness.sh",
+      NETWORK_READINESS,
+    );
+    writeFileSync(dispatcher, dispatcherText);
+    chmodSync(dispatcher, 0o755);
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function env(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+    return {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH ?? ""}`,
+      MOCK_LOG: log,
+      MOCK_STATE: state,
+      CLAWBOX_NETWORK_READINESS_LIB: NETWORK_READINESS,
+      CLAWBOX_OPENCLAW_BIN: path.join(bin, "openclaw"),
+      CLAWBOX_CHANNEL_RECOVERY_VERIFY_ATTEMPTS: "1",
+      CLAWBOX_CHANNEL_RECOVERY_VERIFY_DELAY_SECONDS: "0",
+      ...overrides,
+    };
+  }
+
+  function run(script: string, args: string[], overrides: NodeJS.ProcessEnv = {}) {
+    return spawnSync(script, args, { env: env(overrides), encoding: "utf8", timeout: 15_000 });
+  }
+
+  function calls(): string {
+    try {
+      return readFileSync(log, "utf8");
+    } catch {
+      return "";
+    }
+  }
+
+  it("does not restart the Gateway when Ethernet drops without a replacement route", () => {
+    const result = run(dispatcher, ["enP8p1s0", "down"]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls()).not.toContain("restart clawbox-gateway.service");
+  });
+
+  it("restarts only after successful Wi-Fi failover has a public route", () => {
+    const result = run(dispatcher, ["enP8p1s0", "down"], {
+      MOCK_ROUTE_READY: "1",
+      MOCK_WIFI_PROFILE: "1",
+      MOCK_WIFI_CONNECTS: "1",
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls()).toContain("restart clawbox-gateway.service");
+    expect(calls()).toContain("restart clawbox-channel-recovery.timer");
+  });
+
+  it("does not restart on Ethernet up until the public route is ready", () => {
+    const result = run(dispatcher, ["enP8p1s0", "up"]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls()).not.toContain("restart clawbox-gateway.service");
+  });
+
+  it("defers channel autostart when the Gateway starts offline", () => {
+    const result = run(GATEWAY_WRAPPER, ["--allow-unconfigured"]);
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls()).toContain("openclaw skip=1 gateway --allow-unconfigured");
+  });
+
+  it("starts channels normally when the Gateway has a public route", () => {
+    const result = run(GATEWAY_WRAPPER, ["--allow-unconfigured"], { MOCK_ROUTE_READY: "1" });
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls()).toContain("openclaw skip= gateway --allow-unconfigured");
+  });
+
+  it("starts only the breaker-suppressed account and verifies connected state", () => {
+    const result = run(CHANNEL_RECOVERY, [], { MOCK_ROUTE_READY: "1" });
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls()).toContain("gateway call channels.start");
+    expect(calls()).toContain('"accountId":"alfred"');
+    expect(calls()).not.toContain('"accountId":"default"');
+  });
+
+  it("does not override an authentication failure", () => {
+    const result = run(CHANNEL_RECOVERY, [], {
+      MOCK_ROUTE_READY: "1",
+      MOCK_CHANNEL_MODE: "auth-failure",
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(calls()).not.toContain("gateway call channels.start");
+  });
+});
+
+describe("network-resilience installation boundary", () => {
+  const install = readFileSync(path.join(REPO, "install.sh"), "utf8");
+  const dispatcher = readFileSync(SOURCE_DISPATCHER, "utf8");
+
+  it("installs the shared helper outside the clawbox-writable project tree", () => {
+    expect(install).toContain('install -o root -g root -m 0644 "$HELPER_SRC" "$HELPER_DEST"');
+    expect(dispatcher).toContain('/usr/local/libexec/clawbox/network-readiness.sh');
+    expect(dispatcher).toContain("unset CLAWBOX_IP_BIN CLAWBOX_CURL_BIN");
+  });
+
+  it("installs and activates channel recovery only for OpenClaw-capable editions", () => {
+    expect(install).toContain("if has_openclaw_harness; then\n  EXPECTED_ACTIVE_SERVICES+=(clawbox-channel-recovery.timer)");
+    expect(install).toContain("systemctl enable --now clawbox-channel-recovery.timer");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #529.

ClawBox currently restarts the OpenClaw Gateway as soon as Ethernet drops or returns, before proving that a usable public route exists. On releases affected by `openclaw/openclaw#106598`, this can turn a short link outage into a Gateway crash loop; the restart-loop breaker can then leave channels suppressed after connectivity returns.

This change:

- waits for a proven public route before NetworkManager restarts the Gateway;
- defers channel autostart when the Gateway itself starts offline;
- adds a bounded timer that starts only accounts stopped by OpenClaw's crash/restart-loop breaker;
- verifies recovered accounts reach both `running=true` and `connected=true`;
- leaves authentication and configuration failures stopped for review;
- installs the shared network-readiness helper root-owned outside the writable project tree; and
- scopes the recovery units to OpenClaw-capable editions.

The provider-level OpenClaw crash was fixed separately by `openclaw/openclaw#113905`. This PR addresses the ClawBox lifecycle behavior and keeps older bundled releases from reaching the full crash-loop outcome.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation / tooling
- [ ] Other: ___

## How was this tested?

Contained aarch64 Testbench verification against the current `beta` base:

- seven synthetic route/channel scenarios passed;
- candidate systemd units passed `systemd-analyze verify`;
- a transient timer launched and completed the suite;
- default-deny egress containment remained intact;
- temporary test state and units were removed; and
- production service, listener, configuration, and session-store snapshots were unchanged.

Additional focused checks passed: `git diff --check`, `bash -n`, Python compile, and ShellCheck. ShellCheck reported only the expected SC1091 informational findings for runtime-selected sourced helpers.

- [ ] `bun run lint` passes — not run locally; CI is the gate
- [ ] `bun run test` passes — focused resilience tests passed; full suite not run locally
- [ ] `bun run build` succeeds — not run locally; CI is the gate
- [x] Manually verified on device / dev install — contained aarch64 Testbench

## Checklist

- [x] Branch is up to date with the target branch
- [x] Follows the conventions in [CLAUDE.md](../CLAUDE.md) and [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or credentials committed
- [x] Added/updated tests where it makes sense
- [x] Updated docs where user-facing behavior changed — not applicable; no UI or configuration contract changed

## Screenshots / logs (if UI or runtime change)

No UI change. Sanitized Testbench result: all seven scenarios, systemd verification, timer lifecycle, cleanup, containment, and production-invariance assertions passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added network-aware gateway recovery that waits for a usable public connection before restarting services.
  * Added automatic recovery for channels suppressed after crash-loop protection, with connection verification.
  * Added scheduled channel checks after startup and at regular intervals.

* **Bug Fixes**
  * Prevented unnecessary gateway restarts while network connectivity is unavailable.
  * Deferred channel startup when the gateway launches offline, reducing failed connection attempts.

* **Tests**
  * Added coverage for network failover, offline startup, channel recovery, and authentication-failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->