### PR TITLE
fix: stop routing Claude subscription auth through the openai-compat transport

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -11,6 +11,7 @@ import {
   findOpenclawBin,
   runOpenclawConfigSet,
   runOpenclawConfigSetBatch,
+  runOpenclawConfigUnset,
   type OpenclawConfigSetArgs,
   compactionReserveFloorForContext,
   inferConfiguredLocalModel,
@@ -1031,6 +1032,81 @@ async function writeOpenAICompatProvider(opts: {
   await ensureFallbackModel(opts.defaultModel);
 }
 
+/**
+ * Take a `models.providers.<p>` openai-compat override back out.
+ *
+ * Only ever called on the subscription path, and only when the device actually
+ * has one: `openclaw config unset` exits 1 with "Config path not found" on an
+ * absent path (verified on 2026.7.1-2), and a removal that genuinely fails must
+ * stay loud — reporting success while the poisoned override is still on disk is
+ * the failure mode this whole fix exists to remove.
+ */
+async function clearOpenAICompatProvider(provider: string): Promise<void> {
+  const configPath = `models.providers.${provider}`;
+  const config = await readOpenClawConfig();
+  if (!config.models?.providers?.[provider]) return;
+  await runOpenclawConfigUnset(configPath, { uid: CLAWBOX_UID, gid: CLAWBOX_GID });
+  console.log(`[AI Config] Removed stale openai-compat override ${configPath}`);
+}
+
+/**
+ * Decide how a cloud provider's turns leave the box, and write that decision.
+ *
+ * Every caller of {@link writeOpenAICompatProvider} goes through here, because
+ * that helper is an API-KEY construction and nothing in its signature says so:
+ * it pins the provider to `api: "openai-completions"` and inlines the
+ * credential, so each turn goes out as `POST <baseUrl>/chat/completions` with a
+ * bearer token and none of the provider-native headers.
+ *
+ * A Claude Pro/Max subscription credential is not an API key, and that surface
+ * does not accept one. Anthropic answers 429 to an OAuth access token on
+ * `/chat/completions` no matter how much quota is left — proven on a device
+ * against one token inside one minute: `/v1/chat/completions` 429,
+ * `/v1/messages` with `anthropic-beta: oauth-2025-04-20` 200 with a real
+ * completion, `/v1/messages` without that header 429. The override made the
+ * subscription look permanently rate-limited on the OpenClaw edition while the
+ * same sign-in worked on Hermes, which routes natively.
+ *
+ * So on a subscription save the override is not written, and any override the
+ * device already had is removed — the second half matters as much as the first,
+ * because a box configured with an API key and later switched to a
+ * subscription kept the old entry (nothing here ever deleted one) and stayed
+ * broken. Routing then belongs to the provider's native plugin, which is what
+ * `setProviderPlugins` enables a few steps later.
+ */
+async function applyCloudProviderTransport(opts: {
+  provider: string;
+  baseUrl: string;
+  apiKey: string;
+  authMode: string;
+  defaultModel: string;
+  curatedModels: readonly { id: string }[];
+}): Promise<void> {
+  if (opts.authMode !== "subscription") {
+    await writeOpenAICompatProvider(opts);
+    console.log(
+      `[AI Config] Set ${opts.provider} provider (openai-compat): ${logSafe(opts.defaultModel)}`,
+    );
+    return;
+  }
+
+  await clearOpenAICompatProvider(opts.provider);
+  // Same two writes the non-provider `else` branch below makes: cloud providers
+  // auto-detect their catalog in merge mode, and the primary still needs a
+  // fallback behind it.
+  await applyConfigSetGroups([
+    {
+      ops: [["models.mode", "merge"]],
+      // Non-fatal: merge is the default behavior anyway
+      onError: () => {},
+    },
+  ]);
+  await ensureFallbackModel(opts.defaultModel);
+  console.log(
+    `[AI Config] Set ${opts.provider} provider (native plugin, subscription auth): ${logSafe(opts.defaultModel)}`,
+  );
+}
+
 export async function POST(request: Request) {
   // Hoisted so the catch can classify the failure without re-parsing the body —
   // a local-model or wrong-edition failure must not be reported as a credential
@@ -1943,40 +2019,45 @@ export async function POST(request: Request) {
       console.log(`[AI Config] Set llama.cpp provider in openclaw.json: ${logSafe(modelName)} (context=${llamaCppContextWindow}, mode=replace)`);
     } else if (isOpenRouter) {
       // OpenRouter has no native OpenClaw adapter, so without this explicit
-      // provider entry the chat turn silently returns usage 0/0/0.
-      await writeOpenAICompatProvider({
+      // provider entry the chat turn silently returns usage 0/0/0. (API-key
+      // only today — the wizard offers OpenRouter no subscription sign-in.)
+      await applyCloudProviderTransport({
         provider: "openrouter",
         baseUrl: "https://openrouter.ai/api/v1",
         apiKey: normalizedApiKey,
+        authMode,
         defaultModel: config.defaultModel,
         curatedModels: OPENROUTER_CURATED_MODELS,
       });
-      console.log(`[AI Config] Set openrouter provider (openai-compat): ${logSafe(config.defaultModel)}`);
     } else if (isGoogle) {
       // Native google plugin registers Gemini models but its 2026.6.8 auth
       // fails at call time (runs fall back with reason=auth). Route through
       // Google's OpenAI-compat endpoint instead.
-      await writeOpenAICompatProvider({
+      await applyCloudProviderTransport({
         provider: "google",
         baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
         apiKey: normalizedApiKey,
+        authMode,
         defaultModel: config.defaultModel,
         curatedModels: GOOGLE_MODELS,
       });
-      console.log(`[AI Config] Set google provider (openai-compat): ${logSafe(config.defaultModel)}`);
     } else if (isAnthropic) {
-      // Native anthropic plugin reads a per-agent sqlite auth store that
-      // ClawBox's file auth profile doesn't populate, so it fails with
-      // "No API key found" at call time. Route through Anthropic's OpenAI-compat
-      // endpoint with the key inline instead.
-      await writeOpenAICompatProvider({
+      // With an API KEY: the native anthropic plugin reads a per-agent sqlite
+      // auth store that ClawBox's file auth profile doesn't populate, so it
+      // fails with "No API key found" at call time — route through Anthropic's
+      // OpenAI-compat endpoint with the key inline instead.
+      //
+      // With a Claude Pro/Max SUBSCRIPTION: that same override is what made
+      // every turn 429. applyCloudProviderTransport keeps the two apart; see
+      // its doc comment for the transport proof.
+      await applyCloudProviderTransport({
         provider: "anthropic",
         baseUrl: "https://api.anthropic.com/v1",
         apiKey: normalizedApiKey,
+        authMode,
         defaultModel: config.defaultModel,
         curatedModels: ANTHROPIC_MODELS,
       });
-      console.log(`[AI Config] Set anthropic provider (openai-compat): ${logSafe(config.defaultModel)}`);
     } else {
       // Switching away from Ollama/ClawBox AI — reset models.mode so cloud providers
       // auto-detect their model catalog normally.

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1114,6 +1114,15 @@ async function clearOpenAICompatProvider(provider: string): Promise<void> {
  * broken. Routing then belongs to the anthropic plugin, which is what
  * `setProviderPlugins` enables a few steps later.
  */
+/**
+ * Which transport a save ended up on. Returned rather than logged here so the
+ * line is written by the caller, whose provider name is a literal: `opts`
+ * carries the request body's apiKey and authMode, so anything read back off it
+ * is taint-tracked to `request.json()` and a log line built from it trips
+ * CodeQL's js/log-injection whether or not it goes through `logSafe`.
+ */
+type CloudProviderTransport = "openai-compat" | "native plugin, subscription auth";
+
 async function applyCloudProviderTransport(opts: {
   provider: string;
   baseUrl: string;
@@ -1121,13 +1130,10 @@ async function applyCloudProviderTransport(opts: {
   authMode: string;
   defaultModel: string;
   curatedModels: readonly { id: string }[];
-}): Promise<void> {
+}): Promise<CloudProviderTransport> {
   if (!routesSubscriptionNatively(opts.provider, opts.authMode)) {
     await writeOpenAICompatProvider(opts);
-    console.log(
-      `[AI Config] Set ${logSafe(opts.provider)} provider (openai-compat): ${logSafe(opts.defaultModel)}`,
-    );
-    return;
+    return "openai-compat";
   }
 
   await clearOpenAICompatProvider(opts.provider);
@@ -1142,9 +1148,7 @@ async function applyCloudProviderTransport(opts: {
     },
   ]);
   await ensureFallbackModel(opts.defaultModel);
-  console.log(
-    `[AI Config] Set ${logSafe(opts.provider)} provider (native plugin, subscription auth): ${logSafe(opts.defaultModel)}`,
-  );
+  return "native plugin, subscription auth";
 }
 
 export async function POST(request: Request) {
@@ -2062,7 +2066,7 @@ export async function POST(request: Request) {
       // provider entry the chat turn silently returns usage 0/0/0 — and no
       // OAuth flow either (it is absent from OAUTH_PROVIDERS), so every save
       // that reaches here is key-based and keeps the override.
-      await applyCloudProviderTransport({
+      const openrouterTransport = await applyCloudProviderTransport({
         provider: "openrouter",
         baseUrl: "https://openrouter.ai/api/v1",
         apiKey: normalizedApiKey,
@@ -2070,6 +2074,7 @@ export async function POST(request: Request) {
         defaultModel: config.defaultModel,
         curatedModels: OPENROUTER_CURATED_MODELS,
       });
+      console.log(`[AI Config] Set openrouter provider (${openrouterTransport}): ${logSafe(config.defaultModel)}`);
     } else if (isGoogle) {
       // Native google plugin registers Gemini models but its 2026.6.8 auth
       // fails at call time (runs fall back with reason=auth). Route through
@@ -2078,7 +2083,7 @@ export async function POST(request: Request) {
       // the anthropic bug fixed here, and it is deliberately left alone: see
       // NATIVE_SUBSCRIPTION_ROUTING for why taking its override away without
       // a device to prove the native route on would repeat the same mistake.
-      await applyCloudProviderTransport({
+      const googleTransport = await applyCloudProviderTransport({
         provider: "google",
         baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
         apiKey: normalizedApiKey,
@@ -2086,6 +2091,7 @@ export async function POST(request: Request) {
         defaultModel: config.defaultModel,
         curatedModels: GOOGLE_MODELS,
       });
+      console.log(`[AI Config] Set google provider (${googleTransport}): ${logSafe(config.defaultModel)}`);
     } else if (isAnthropic) {
       // With an API KEY: the native anthropic plugin reads a per-agent sqlite
       // auth store that ClawBox's file auth profile doesn't populate, so it
@@ -2095,7 +2101,7 @@ export async function POST(request: Request) {
       // With a Claude Pro/Max SUBSCRIPTION: that same override is what made
       // every turn 429. applyCloudProviderTransport keeps the two apart; see
       // its doc comment for the transport proof.
-      await applyCloudProviderTransport({
+      const anthropicTransport = await applyCloudProviderTransport({
         provider: "anthropic",
         baseUrl: "https://api.anthropic.com/v1",
         apiKey: normalizedApiKey,
@@ -2103,6 +2109,7 @@ export async function POST(request: Request) {
         defaultModel: config.defaultModel,
         curatedModels: ANTHROPIC_MODELS,
       });
+      console.log(`[AI Config] Set anthropic provider (${anthropicTransport}): ${logSafe(config.defaultModel)}`);
     } else {
       // Switching away from Ollama/ClawBox AI — reset models.mode so cloud providers
       // auto-detect their model catalog normally.

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1115,14 +1115,17 @@ async function clearOpenAICompatProvider(provider: string): Promise<void> {
  * `setProviderPlugins` enables a few steps later.
  */
 /**
- * Which transport a save ended up on. Returned rather than logged here so the
- * line is written by the caller, whose provider name is a literal: `opts`
- * carries the request body's apiKey and authMode, so anything read back off it
- * is taint-tracked to `request.json()` and a log line built from it trips
- * CodeQL's js/log-injection whether or not it goes through `logSafe`.
+ * True when the save wrote the openai-compat override, false when it handed the
+ * provider to its native plugin.
+ *
+ * A boolean, and reported by the CALLER rather than logged here, because both
+ * halves are needed to keep the log line clean under CodeQL: `opts` carries the
+ * request body's apiKey and authMode, so anything read back off it — or
+ * returned from a function that took it — is taint-tracked to `request.json()`
+ * and trips js/log-injection, which does not recognise `logSafe` as a barrier.
+ * A boolean carries no text into the line; the caller picks between two string
+ * literals and names its own provider, which is a literal there too.
  */
-type CloudProviderTransport = "openai-compat" | "native plugin, subscription auth";
-
 async function applyCloudProviderTransport(opts: {
   provider: string;
   baseUrl: string;
@@ -1130,10 +1133,10 @@ async function applyCloudProviderTransport(opts: {
   authMode: string;
   defaultModel: string;
   curatedModels: readonly { id: string }[];
-}): Promise<CloudProviderTransport> {
+}): Promise<boolean> {
   if (!routesSubscriptionNatively(opts.provider, opts.authMode)) {
     await writeOpenAICompatProvider(opts);
-    return "openai-compat";
+    return true;
   }
 
   await clearOpenAICompatProvider(opts.provider);
@@ -1148,7 +1151,7 @@ async function applyCloudProviderTransport(opts: {
     },
   ]);
   await ensureFallbackModel(opts.defaultModel);
-  return "native plugin, subscription auth";
+  return false;
 }
 
 export async function POST(request: Request) {
@@ -2066,7 +2069,7 @@ export async function POST(request: Request) {
       // provider entry the chat turn silently returns usage 0/0/0 — and no
       // OAuth flow either (it is absent from OAUTH_PROVIDERS), so every save
       // that reaches here is key-based and keeps the override.
-      const openrouterTransport = await applyCloudProviderTransport({
+      const openrouterWroteOverride = await applyCloudProviderTransport({
         provider: "openrouter",
         baseUrl: "https://openrouter.ai/api/v1",
         apiKey: normalizedApiKey,
@@ -2074,7 +2077,7 @@ export async function POST(request: Request) {
         defaultModel: config.defaultModel,
         curatedModels: OPENROUTER_CURATED_MODELS,
       });
-      console.log(`[AI Config] Set openrouter provider (${openrouterTransport}): ${logSafe(config.defaultModel)}`);
+      console.log(`[AI Config] Set openrouter provider (${openrouterWroteOverride ? "openai-compat" : "native plugin, subscription auth"}): ${logSafe(config.defaultModel)}`);
     } else if (isGoogle) {
       // Native google plugin registers Gemini models but its 2026.6.8 auth
       // fails at call time (runs fall back with reason=auth). Route through
@@ -2083,7 +2086,7 @@ export async function POST(request: Request) {
       // the anthropic bug fixed here, and it is deliberately left alone: see
       // NATIVE_SUBSCRIPTION_ROUTING for why taking its override away without
       // a device to prove the native route on would repeat the same mistake.
-      const googleTransport = await applyCloudProviderTransport({
+      const googleWroteOverride = await applyCloudProviderTransport({
         provider: "google",
         baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
         apiKey: normalizedApiKey,
@@ -2091,7 +2094,7 @@ export async function POST(request: Request) {
         defaultModel: config.defaultModel,
         curatedModels: GOOGLE_MODELS,
       });
-      console.log(`[AI Config] Set google provider (${googleTransport}): ${logSafe(config.defaultModel)}`);
+      console.log(`[AI Config] Set google provider (${googleWroteOverride ? "openai-compat" : "native plugin, subscription auth"}): ${logSafe(config.defaultModel)}`);
     } else if (isAnthropic) {
       // With an API KEY: the native anthropic plugin reads a per-agent sqlite
       // auth store that ClawBox's file auth profile doesn't populate, so it
@@ -2101,7 +2104,7 @@ export async function POST(request: Request) {
       // With a Claude Pro/Max SUBSCRIPTION: that same override is what made
       // every turn 429. applyCloudProviderTransport keeps the two apart; see
       // its doc comment for the transport proof.
-      const anthropicTransport = await applyCloudProviderTransport({
+      const anthropicWroteOverride = await applyCloudProviderTransport({
         provider: "anthropic",
         baseUrl: "https://api.anthropic.com/v1",
         apiKey: normalizedApiKey,
@@ -2109,7 +2112,7 @@ export async function POST(request: Request) {
         defaultModel: config.defaultModel,
         curatedModels: ANTHROPIC_MODELS,
       });
-      console.log(`[AI Config] Set anthropic provider (${anthropicTransport}): ${logSafe(config.defaultModel)}`);
+      console.log(`[AI Config] Set anthropic provider (${anthropicWroteOverride ? "openai-compat" : "native plugin, subscription auth"}): ${logSafe(config.defaultModel)}`);
     } else {
       // Switching away from Ollama/ClawBox AI — reset models.mode so cloud providers
       // auto-detect their model catalog normally.

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -16,6 +16,7 @@ import {
   compactionReserveFloorForContext,
   inferConfiguredLocalModel,
   readConfig as readOpenClawConfig,
+  readConfigStrict as readOpenClawConfigStrict,
   applyModelOverrideToAllAgentSessions,
   parseFullyQualifiedModel,
   setProviderPlugins,
@@ -1033,6 +1034,33 @@ async function writeOpenAICompatProvider(opts: {
 }
 
 /**
+ * Providers whose SUBSCRIPTION credential is routed by the provider's own
+ * OpenClaw plugin instead of by a `models.providers.<p>` openai-compat
+ * override.
+ *
+ * Anthropic, and deliberately NOT "every provider that has an OAuth flow".
+ * `OAUTH_PROVIDERS` also carries google (Gemini Code Assist), and google's
+ * subscription reaches {@link applyCloudProviderTransport} the same way
+ * anthropic's does — but nothing gives it a native route to fall back on.
+ * `setProviderPlugins` toggles the anthropic plugin and no other, and the
+ * google branch below records that the native google plugin's auth fails at
+ * call time. Dropping google's override would hand its turns to a route this
+ * change has no evidence about and no device to test on: the same mistake as
+ * the bug being fixed here, pointed the other way. Google stays on the
+ * override until someone proves the native path on hardware.
+ *
+ * A Set rather than a literal comparison so the next provider to earn a native
+ * subscription route is added HERE, where the reason it qualifies is written
+ * down, rather than by widening a condition somewhere further down the file.
+ */
+const NATIVE_SUBSCRIPTION_ROUTING: ReadonlySet<string> = new Set(["anthropic"]);
+
+/** Does this provider+authMode pair route through the native plugin? */
+function routesSubscriptionNatively(provider: string, authMode: string): boolean {
+  return authMode === "subscription" && NATIVE_SUBSCRIPTION_ROUTING.has(provider);
+}
+
+/**
  * Take a `models.providers.<p>` openai-compat override back out.
  *
  * Only ever called on the subscription path, and only when the device actually
@@ -1043,10 +1071,16 @@ async function writeOpenAICompatProvider(opts: {
  */
 async function clearOpenAICompatProvider(provider: string): Promise<void> {
   const configPath = `models.providers.${provider}`;
-  const config = await readOpenClawConfig();
+  // STRICT read, because this check can only ever decide to do NOTHING. The
+  // ordinary `readConfig` answers `{}` to an EACCES or a half-written file just
+  // as it does to a clean config, and `{}` here reads as "no override to
+  // remove" — so an unreadable config would skip the repair, return 200, and
+  // leave the poisoned override exactly where it was. That is the failure this
+  // whole fix exists to remove, so an unreadable config throws instead.
+  const config = await readOpenClawConfigStrict();
   if (!config.models?.providers?.[provider]) return;
   await runOpenclawConfigUnset(configPath, { uid: CLAWBOX_UID, gid: CLAWBOX_GID });
-  console.log(`[AI Config] Removed stale openai-compat override ${configPath}`);
+  console.log(`[AI Config] Removed stale openai-compat override ${logSafe(configPath)}`);
 }
 
 /**
@@ -1067,11 +1101,17 @@ async function clearOpenAICompatProvider(provider: string): Promise<void> {
  * subscription look permanently rate-limited on the OpenClaw edition while the
  * same sign-in worked on Hermes, which routes natively.
  *
- * So on a subscription save the override is not written, and any override the
- * device already had is removed — the second half matters as much as the first,
- * because a box configured with an API key and later switched to a
- * subscription kept the old entry (nothing here ever deleted one) and stayed
- * broken. Routing then belongs to the provider's native plugin, which is what
+ * The override also FREEZES the credential. `apiKey` is written inline at save
+ * time, and a subscription access token is short-lived — so even a save that
+ * worked for a while expired within hours and never self-healed, because an
+ * inline key never goes back through the auth profile that holds the refresh
+ * token. An affected device was found with an inline token six hours dead.
+ *
+ * So on an anthropic subscription save the override is not written, and any
+ * override the device already had is removed — the second half matters as much
+ * as the first, because a box configured with an API key and later switched to
+ * a subscription kept the old entry (nothing here ever deleted one) and stayed
+ * broken. Routing then belongs to the anthropic plugin, which is what
  * `setProviderPlugins` enables a few steps later.
  */
 async function applyCloudProviderTransport(opts: {
@@ -1082,10 +1122,10 @@ async function applyCloudProviderTransport(opts: {
   defaultModel: string;
   curatedModels: readonly { id: string }[];
 }): Promise<void> {
-  if (opts.authMode !== "subscription") {
+  if (!routesSubscriptionNatively(opts.provider, opts.authMode)) {
     await writeOpenAICompatProvider(opts);
     console.log(
-      `[AI Config] Set ${opts.provider} provider (openai-compat): ${logSafe(opts.defaultModel)}`,
+      `[AI Config] Set ${logSafe(opts.provider)} provider (openai-compat): ${logSafe(opts.defaultModel)}`,
     );
     return;
   }
@@ -1103,7 +1143,7 @@ async function applyCloudProviderTransport(opts: {
   ]);
   await ensureFallbackModel(opts.defaultModel);
   console.log(
-    `[AI Config] Set ${opts.provider} provider (native plugin, subscription auth): ${logSafe(opts.defaultModel)}`,
+    `[AI Config] Set ${logSafe(opts.provider)} provider (native plugin, subscription auth): ${logSafe(opts.defaultModel)}`,
   );
 }
 
@@ -2019,8 +2059,9 @@ export async function POST(request: Request) {
       console.log(`[AI Config] Set llama.cpp provider in openclaw.json: ${logSafe(modelName)} (context=${llamaCppContextWindow}, mode=replace)`);
     } else if (isOpenRouter) {
       // OpenRouter has no native OpenClaw adapter, so without this explicit
-      // provider entry the chat turn silently returns usage 0/0/0. (API-key
-      // only today — the wizard offers OpenRouter no subscription sign-in.)
+      // provider entry the chat turn silently returns usage 0/0/0 — and no
+      // OAuth flow either (it is absent from OAUTH_PROVIDERS), so every save
+      // that reaches here is key-based and keeps the override.
       await applyCloudProviderTransport({
         provider: "openrouter",
         baseUrl: "https://openrouter.ai/api/v1",
@@ -2032,7 +2073,11 @@ export async function POST(request: Request) {
     } else if (isGoogle) {
       // Native google plugin registers Gemini models but its 2026.6.8 auth
       // fails at call time (runs fall back with reason=auth). Route through
-      // Google's OpenAI-compat endpoint instead.
+      // Google's OpenAI-compat endpoint instead — for the SUBSCRIPTION
+      // (Gemini Code Assist OAuth) sign-in too. Google is the one sibling of
+      // the anthropic bug fixed here, and it is deliberately left alone: see
+      // NATIVE_SUBSCRIPTION_ROUTING for why taking its override away without
+      // a device to prove the native route on would repeat the same mistake.
       await applyCloudProviderTransport({
         provider: "google",
         baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -530,46 +530,61 @@ export async function POST(request: Request) {
           const providerDef = openclawConfig.models?.providers?.[providerId] as
             | { models?: { id?: string; name?: string }[]; apiKey?: string; baseUrl?: string; api?: string }
             | undefined;
-          // The reroute (ai-models/configure) writes baseUrl + api + apiKey
-          // alongside models. If the endpoint, api type, or inline key is missing
-          // (legacy or half-written state), appending only `.models` would leave
-          // a provider that can't authenticate — make the user re-save rather
-          // than switch the primary onto an incomplete provider.
-          if (!providerDef?.apiKey || !providerDef?.baseUrl || !providerDef?.api) {
-            return NextResponse.json(
-              { error: `${labelForProvider(providerId, providerId)} isn't fully configured. Re-save it in Settings, then pick the model again.` },
-              { status: 409 },
-            );
-          }
-          const existingModels = providerDef.models ?? [];
-          const configuredIds = existingModels
-            .map((m) => m?.id)
-            .filter((id): id is string => typeof id === "string" && id.length > 0);
-          // Append whenever the requested slug isn't already there — even for a
-          // freshly-configured provider whose seed providerDef has only the
-          // user's chosen default (the earlier `length > 0` guard silently fell
-          // back to local on the first switch after a clean setup).
-          if (!configuredIds.includes(effectiveModelId)) {
-            // Emit only `id`+`name`; OpenClaw looks the rest (contextWindow,
-            // modalities, cost) up from its bundled provider catalog by id.
-            const nextModels = [
-              ...existingModels,
-              { id: effectiveModelId, name: effectiveModelId },
-            ];
-            try {
-              await runOpenclawConfigSet([
-                `models.providers.${providerId}.models`,
-                JSON.stringify(nextModels),
-                "--json",
-              ]);
-            } catch (err) {
-              console.error(`[chat/model] auto-extend ${providerId} providerDef failed:`, err);
+          // A SUBSCRIPTION box has no `models.providers.<p>` entry at all, and
+          // that is the fixed state, not a broken one: the openai-compat
+          // override is an API-key construction, and writing an OAuth token
+          // into it made every Anthropic turn 429 (see ai-models/configure).
+          // Routing belongs to the native plugin, whose own catalog resolves
+          // any id — the same reason clawai/openai/codex skip this block
+          // entirely. Without this the 409 below would fire on every model
+          // switch such a box makes, because there is correctly nothing to
+          // extend. An entry that EXISTS but is half-written still 409s.
+          const nativeSubscriptionRouting =
+            !providerDef
+            && subscriptionOnlyProviders(openclawConfig.auth?.profiles, normalizeProvider)
+              .includes(providerId);
+          if (!nativeSubscriptionRouting) {
+            // The reroute (ai-models/configure) writes baseUrl + api + apiKey
+            // alongside models. If the endpoint, api type, or inline key is
+            // missing (legacy or half-written state), appending only `.models`
+            // would leave a provider that can't authenticate — make the user
+            // re-save rather than switch the primary onto an incomplete provider.
+            if (!providerDef?.apiKey || !providerDef?.baseUrl || !providerDef?.api) {
               return NextResponse.json(
-                {
-                  error: `Could not register ${requestedModel} with the ${labelForProvider(providerId, providerId)} provider. Re-save it in Settings to refresh the model list.`,
-                },
-                { status: 502 },
+                { error: `${labelForProvider(providerId, providerId)} isn't fully configured. Re-save it in Settings, then pick the model again.` },
+                { status: 409 },
               );
+            }
+            const existingModels = providerDef.models ?? [];
+            const configuredIds = existingModels
+              .map((m) => m?.id)
+              .filter((id): id is string => typeof id === "string" && id.length > 0);
+            // Append whenever the requested slug isn't already there — even for a
+            // freshly-configured provider whose seed providerDef has only the
+            // user's chosen default (the earlier `length > 0` guard silently fell
+            // back to local on the first switch after a clean setup).
+            if (!configuredIds.includes(effectiveModelId)) {
+              // Emit only `id`+`name`; OpenClaw looks the rest (contextWindow,
+              // modalities, cost) up from its bundled provider catalog by id.
+              const nextModels = [
+                ...existingModels,
+                { id: effectiveModelId, name: effectiveModelId },
+              ];
+              try {
+                await runOpenclawConfigSet([
+                  `models.providers.${providerId}.models`,
+                  JSON.stringify(nextModels),
+                  "--json",
+                ]);
+              } catch (err) {
+                console.error(`[chat/model] auto-extend ${providerId} providerDef failed:`, err);
+                return NextResponse.json(
+                  {
+                    error: `Could not register ${requestedModel} with the ${labelForProvider(providerId, providerId)} provider. Re-save it in Settings to refresh the model list.`,
+                  },
+                  { status: 502 },
+                );
+              }
             }
           }
         }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -736,6 +736,35 @@ export async function readConfig(): Promise<OpenClawConfig> {
   }
 }
 
+/**
+ * {@link readConfig}, except that only an ENOENT is allowed to mean "there is
+ * no config".
+ *
+ * `readConfig` answers `{}` to every failure alike — a missing file, an EACCES,
+ * a file caught half-written by a concurrent `config set`. That is the right
+ * default for the many callers asking "is X switched on?", where UNKNOWN and NO
+ * lead to the same harmless place.
+ *
+ * It is the wrong default for a caller that is about to SKIP a repair because
+ * the thing it repairs reads as already absent. There, `{}` from an unreadable
+ * file is indistinguishable from a genuinely clean config, so the repair is
+ * quietly declared unnecessary and the route reports success while the state it
+ * promised to remove is still on disk.
+ *
+ * So: ENOENT returns `{}` (there is nothing to read, and nothing to repair),
+ * and every other read or parse failure throws.
+ */
+export async function readConfigStrict(): Promise<OpenClawConfig> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(CONFIG_PATH, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return {};
+    throw err;
+  }
+  return JSON.parse(raw);
+}
+
 async function writeConfig(config: OpenClawConfig): Promise<void> {
   await fs.mkdir(OPENCLAW_HOME, { recursive: true });
   const tmpPath = CONFIG_PATH + ".tmp";

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -362,6 +362,40 @@ export async function runOpenclawConfigSetBatch(
     "runOpenclawConfigSetBatch",
   );
 }
+
+/**
+ * Run `openclaw config unset <path>`, with the same conflict retry as
+ * {@link runOpenclawConfigSet}.
+ *
+ * `config set` has no way to say "remove this key": a `null` or `{}` value
+ * leaves the path present, and a present-but-empty `models.providers.<p>` is
+ * still read by the gateway as a provider definition. Removal needs the CLI's
+ * own `unset` verb — and it races the gateway's config reload exactly like a
+ * set does, so it gets the same retry rather than a bare spawn.
+ *
+ * NOT safe to call unconditionally: verified against OpenClaw 2026.7.1-2, the
+ * CLI exits 1 with "Config path not found: <path>. Nothing was changed." when
+ * the path is absent. Callers must check the config first and only unset a path
+ * that is actually there, so a real removal failure stays loud.
+ */
+export async function runOpenclawConfigUnset(
+  configPath: string,
+  options: OpenclawConfigSetOptions = {},
+): Promise<void> {
+  await withConfigMutationRetry(
+    (timeoutMs) =>
+      spawnOpenclaw(["config", "unset", configPath], {
+        timeoutMs,
+        uid: options.uid,
+        gid: options.gid,
+        cwd: options.cwd,
+        env: options.env,
+      }).then(() => undefined),
+    options,
+    "runOpenclawConfigUnset",
+  );
+}
+
 export const OPENCLAW_HOME = process.env.OPENCLAW_HOME || "/home/clawbox/.openclaw";
 const AGENTS_DIR = process.env.OPENCLAW_AGENTS_DIR || path.join(OPENCLAW_HOME, "agents");
 export const CONFIG_PATH = path.join(OPENCLAW_HOME, "openclaw.json");

--- a/src/tests/routes/ai-models/configure-hermes.test.ts
+++ b/src/tests/routes/ai-models/configure-hermes.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),
+  runOpenclawConfigUnset: vi.fn(),
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
   parseFullyQualifiedModel: vi.fn((fq: string) => {
     const i = fq.indexOf("/");

--- a/src/tests/routes/ai-models/configure-hermes.test.ts
+++ b/src/tests/routes/ai-models/configure-hermes.test.ts
@@ -37,6 +37,9 @@ vi.mock("@/lib/openclaw-config", () => ({
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
+  // The configure route reads the config STRICTLY before it removes an
+  // openai-compat override, so the mock has to carry both readers.
+  readConfigStrict: vi.fn().mockResolvedValue({}),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -70,6 +70,9 @@ vi.mock("@/lib/openclaw-config", () => ({
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
+  // The configure route reads the config STRICTLY before it removes an
+  // openai-compat override, so the mock has to carry both readers.
+  readConfigStrict: vi.fn().mockResolvedValue({}),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -73,6 +73,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),
+  runOpenclawConfigUnset: vi.fn(),
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
   parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -110,6 +110,7 @@ import { unpairLocal } from "@/lib/clawkeep";
 import {
   inferConfiguredLocalModel,
   readConfig,
+  readConfigStrict,
   restartGateway,
   runOpenclawConfigSet,
   runOpenclawConfigSetBatch,
@@ -122,6 +123,7 @@ const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
 const mockSetMany = vi.mocked(setMany);
 const mockReadConfig = vi.mocked(readConfig);
+const mockReadConfigStrict = vi.mocked(readConfigStrict);
 const mockRunOpenclawConfigSet = vi.mocked(runOpenclawConfigSet);
 const mockRunOpenclawConfigSetBatch = vi.mocked(runOpenclawConfigSetBatch);
 const mockFs = vi.mocked(fsp);
@@ -176,6 +178,7 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
     mockFs.unlink.mockResolvedValue(undefined);
     mockGetAll.mockResolvedValue({});
     mockReadConfig.mockResolvedValue({});
+    mockReadConfigStrict.mockResolvedValue({});
     vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
     mockSetMany.mockResolvedValue();
     vi.mocked(restartGateway).mockResolvedValue();

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -62,6 +62,10 @@ vi.mock("@/lib/openclaw-config", () => ({
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
+  // The configure route imports this to remove a stale openai-compat override.
+  // A factory mock replaces the whole module, so an export the route imports but
+  // the factory omits fails module loading the moment a test reaches it.
+  runOpenclawConfigUnset: vi.fn(),
   // The configure route reads the config STRICTLY before it removes an
   // openai-compat override, so the mock has to carry both readers.
   readConfigStrict: vi.fn().mockResolvedValue({}),

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -62,6 +62,9 @@ vi.mock("@/lib/openclaw-config", () => ({
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
+  // The configure route reads the config STRICTLY before it removes an
+  // openai-compat override, so the mock has to carry both readers.
+  readConfigStrict: vi.fn().mockResolvedValue({}),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -97,6 +97,7 @@ import { promises as nodeFsPromises } from "fs";
 import { getAll, setMany } from "@/lib/config-store";
 import {
   readConfig,
+  readConfigStrict,
   restartGateway,
   runOpenclawConfigSet,
   runOpenclawConfigSetBatch,
@@ -197,6 +198,7 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     vi.mocked(getAll).mockResolvedValue({});
     vi.mocked(setMany).mockResolvedValue();
     vi.mocked(readConfig).mockResolvedValue({} as never);
+    vi.mocked(readConfigStrict).mockResolvedValue({} as never);
     vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
     vi.mocked(restartGateway).mockResolvedValue();
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -85,6 +85,9 @@ vi.mock("@/lib/openclaw-config", () => ({
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
+  // The configure route reads the config STRICTLY before it removes an
+  // openai-compat override, so the mock has to carry both readers.
+  readConfigStrict: vi.fn().mockResolvedValue({}),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -125,6 +125,7 @@ import { unpairLocal } from "@/lib/clawkeep";
 import {
   inferConfiguredLocalModel,
   readConfig,
+  readConfigStrict,
   restartGateway,
   runOpenclawConfigSet,
   runOpenclawConfigSetBatch,
@@ -137,6 +138,7 @@ const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
 const mockSetMany = vi.mocked(setMany);
 const mockReadConfig = vi.mocked(readConfig);
+const mockReadConfigStrict = vi.mocked(readConfigStrict);
 const mockRunOpenclawConfigSet = vi.mocked(runOpenclawConfigSet);
 const mockRunOpenclawConfigSetBatch = vi.mocked(runOpenclawConfigSetBatch);
 const mockFs = vi.mocked(fsp);
@@ -213,6 +215,7 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () =
     mockFs.unlink.mockResolvedValue(undefined);
     mockGetAll.mockResolvedValue({});
     mockReadConfig.mockResolvedValue({});
+    mockReadConfigStrict.mockResolvedValue({});
     vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
     mockSetMany.mockResolvedValue();
     vi.mocked(restartGateway).mockResolvedValue();

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -88,6 +88,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),
+  runOpenclawConfigUnset: vi.fn(),
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
   parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   restartGateway: vi.fn(),
   findOpenclawBin: vi.fn().mockReturnValue("/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
+  readConfigStrict: vi.fn(),
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),
@@ -132,7 +133,7 @@ vi.mock("@/lib/local-ai-token", () => ({
 
 import { getAll, setMany } from "@/lib/config-store";
 import { unpairLocal } from "@/lib/clawkeep";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, runOpenclawConfigSetBatch, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, readConfigStrict, restartGateway, runOpenclawConfigSet, runOpenclawConfigSetBatch, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
 import { configSetCalls, configSetCommands, failConfigSetsMatching, findConfigSet } from "./config-set-calls";
 import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
@@ -143,6 +144,7 @@ const mockGetAll = vi.mocked(getAll);
 const mockSetMany = vi.mocked(setMany);
 const mockInferConfiguredLocalModel = vi.mocked(inferConfiguredLocalModel);
 const mockReadOpenClawConfig = vi.mocked(readConfig);
+const mockReadOpenClawConfigStrict = vi.mocked(readConfigStrict);
 const mockRestartGateway = vi.mocked(restartGateway);
 const mockFs = vi.mocked(fsp);
 const mockApplyModelOverrideToAllAgentSessions = vi.mocked(applyModelOverrideToAllAgentSessions);
@@ -210,6 +212,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockFs.unlink.mockResolvedValue(undefined);
     mockGetAll.mockResolvedValue({});
     mockReadOpenClawConfig.mockResolvedValue({});
+    mockReadOpenClawConfigStrict.mockResolvedValue({});
     mockInferConfiguredLocalModel.mockReturnValue(null);
     mockSetMany.mockResolvedValue();
     mockRestartGateway.mockResolvedValue();
@@ -1090,7 +1093,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     // route ever deleted a provider entry, so the old override outlived the key
     // that justified it and kept poisoning the transport. Not writing a NEW one
     // does not repair those devices; only removing the old one does.
-    mockReadOpenClawConfig.mockResolvedValue({
+    mockReadOpenClawConfigStrict.mockResolvedValue({
       models: {
         providers: {
           anthropic: {
@@ -1139,18 +1142,26 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(JSON.parse(providerCall?.value || "{}").api).toBe("openai-completions");
   });
 
-  it("does not write an openai-compat override for any subscription sign-in", async () => {
-    // Sibling shape. `writeOpenAICompatProvider` has three call sites —
-    // openrouter, google, anthropic — and an OAuth credential is wrong on every
-    // one of them for the same reason. Only anthropic offers a subscription in
-    // the wizard today, but this route takes `authMode` from the request body,
-    // so the guard lives on the shared path rather than in the anthropic branch
-    // where the next provider to gain an OAuth flow would miss it.
+  it("keeps the openai-compat override for a provider with no native subscription route", async () => {
+    // The sibling question, answered with evidence rather than symmetry.
+    // `writeOpenAICompatProvider` has three call sites — openrouter, google,
+    // anthropic — but only anthropic earns the native path here.
+    //
+    // OpenRouter has no OAuth flow at all (absent from OAUTH_PROVIDERS), so a
+    // subscription save for it cannot arrive from the wizard. Google DOES have
+    // one (Gemini Code Assist), and it reaches the same helper — but nothing
+    // gives google a native route to fall back on: setProviderPlugins toggles
+    // the anthropic plugin and no other, and the google branch records that
+    // the native google plugin's auth fails at call time. Taking google's
+    // override away on the strength of anthropic's proof would be this very
+    // bug pointed the other way, so google keeps the transport it has until
+    // someone proves the native route on a device.
     for (const provider of ["google", "openrouter"] as const) {
       vi.clearAllMocks();
       mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
       mockGetAll.mockResolvedValue({});
       mockReadOpenClawConfig.mockResolvedValue({});
+      mockReadOpenClawConfigStrict.mockResolvedValue({});
       mockParseFullyQualifiedModel.mockImplementation(parseFullyQualifiedModelImpl);
       mockApplyModelOverrideToAllAgentSessions.mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
 
@@ -1161,12 +1172,39 @@ describe("POST /setup-api/ai-models/configure", () => {
       }));
       expect(res.status, provider).toBe(200);
 
-      const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
-      expect(
-        commands.some((command) => command.includes(`config set models.providers.${provider}`)),
-        provider,
-      ).toBe(false);
+      const providerCall = findConfigSet(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+        `models.providers.${provider}`,
+      );
+      expect(providerCall, provider).toBeTruthy();
+      expect(JSON.parse(providerCall?.value || "{}").api, provider).toBe("openai-completions");
+      // ...and nothing is unset, because there is no native route to hand over to.
+      expect(vi.mocked(runOpenclawConfigUnset), provider).not.toHaveBeenCalled();
     }
+  });
+
+  it("fails the subscription save when the config cannot be read", async () => {
+    // The removal decides to do NOTHING when it sees no override, and the
+    // ordinary readConfig answers `{}` to an unreadable file exactly as it does
+    // to a clean one. Reading through that would let an EACCES or a
+    // half-written config skip the repair, report 200, and leave the poisoned
+    // override on disk — the precise failure this fix exists to remove. So an
+    // unreadable config has to be loud.
+    mockReadOpenClawConfigStrict.mockRejectedValue(
+      Object.assign(new Error("EACCES: permission denied, open '/home/clawbox/.openclaw/openclaw.json'"), {
+        code: "EACCES",
+      }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: ANTHROPIC_OAUTH_ACCESS,
+      authMode: "subscription",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+    }));
+    expect(res.status).not.toBe(200);
   });
 
   it("seeds a user-picked non-curated model into the provider entry", async () => {

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -81,6 +81,7 @@ vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   runOpenclawConfigSet: vi.fn(),
   runOpenclawConfigSetBatch: vi.fn(),
+  runOpenclawConfigUnset: vi.fn(),
   // Added by PR #83 — the configure route sweeps agent sessions so the
   // new primary provider takes effect on the open chat without a reset.
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
@@ -131,7 +132,7 @@ vi.mock("@/lib/local-ai-token", () => ({
 
 import { getAll, setMany } from "@/lib/config-store";
 import { unpairLocal } from "@/lib/clawkeep";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, runOpenclawConfigSetBatch, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, runOpenclawConfigSetBatch, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
 import { configSetCalls, configSetCommands, failConfigSetsMatching, findConfigSet } from "./config-set-calls";
 import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
@@ -215,6 +216,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     mockSpawn.mockImplementation(() => createSuccessfulChildProcess());
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
     vi.mocked(runOpenclawConfigSetBatch).mockResolvedValue(undefined);
+    vi.mocked(runOpenclawConfigUnset).mockResolvedValue(undefined);
     mockUnpairLocal.mockResolvedValue(undefined);
 
     // Re-apply implementations cleared by vi.clearAllMocks above. Factory
@@ -1034,6 +1036,137 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(writtenContent.profiles["anthropic:default"]).toEqual(
       expect.objectContaining({ type: "api_key", provider: "anthropic", key: "sk-ant-test123" })
     );
+  });
+
+  // ------------------------------------------------------------------
+  // Gap A1 — a Claude Pro/Max subscription 429'd on EVERY turn on the
+  // OpenClaw edition while the same sign-in worked on Hermes.
+  //
+  // Not a rate limit. `writeOpenAICompatProvider` is an API-key construction:
+  // it pins the provider to `api: "openai-completions"` and inlines the
+  // credential, so turns leave as `POST /v1/chat/completions` with a bearer
+  // token and none of the provider-native headers. Proven on a device against
+  // ONE token inside ONE minute: `/v1/chat/completions` -> 429;
+  // `/v1/messages` with `anthropic-beta: oauth-2025-04-20` -> 200 and a real
+  // completion; `/v1/messages` without that header -> 429. The override was
+  // the whole difference, and it was written for subscription sign-ins because
+  // the branch never looked at `authMode`.
+  //
+  // The credential here is a placeholder string, never a real token — this
+  // repository is public.
+  const ANTHROPIC_OAUTH_ACCESS = "anthropic-oauth-access-token-placeholder";
+
+  it("does not write the openai-compat override for a Claude subscription sign-in", async () => {
+    const res = await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: ANTHROPIC_OAUTH_ACCESS,
+      authMode: "subscription",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+    }));
+    expect(res.status).toBe(200);
+
+    // The override is what forces the openai-completions transport. Absent, the
+    // native anthropic plugin owns routing and sends /v1/messages with the
+    // oauth beta header.
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
+    expect(commands.some((command) => command.includes("config set models.providers.anthropic"))).toBe(false);
+
+    // ...and the rest of the save is unchanged: the subscription still becomes
+    // the primary, in merge mode, with an oauth auth profile.
+    expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-sonnet-4-6");
+    expect(commands).toContain("config set models.mode merge");
+
+    const writtenContent = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
+    expect(writtenContent.profiles["anthropic:default"]).toEqual(
+      expect.objectContaining({ type: "oauth", provider: "anthropic", access: ANTHROPIC_OAUTH_ACCESS }),
+    );
+  });
+
+  it("removes a stale openai-compat override when a device switches from API key to subscription", async () => {
+    // The migration half. Boxes in the field are already in the broken state:
+    // they were set up with an `sk-ant-api03-…` key, which wrote the override,
+    // and then the owner signed in with their subscription. Nothing in this
+    // route ever deleted a provider entry, so the old override outlived the key
+    // that justified it and kept poisoning the transport. Not writing a NEW one
+    // does not repair those devices; only removing the old one does.
+    mockReadOpenClawConfig.mockResolvedValue({
+      models: {
+        providers: {
+          anthropic: {
+            baseUrl: "https://api.anthropic.com/v1",
+            api: "openai-completions",
+            apiKey: "previously-configured-api-key",
+          },
+        },
+      },
+    });
+
+    const res = await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: ANTHROPIC_OAUTH_ACCESS,
+      authMode: "subscription",
+      refreshToken: "refresh-token",
+      expiresIn: 3600,
+    }));
+    expect(res.status).toBe(200);
+
+    expect(vi.mocked(runOpenclawConfigUnset)).toHaveBeenCalledWith(
+      "models.providers.anthropic",
+      expect.anything(),
+    );
+
+    const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
+    expect(commands.some((command) => command.includes("config set models.providers.anthropic"))).toBe(false);
+  });
+
+  it("leaves the openai-compat override alone for an anthropic API key", async () => {
+    // The guard is on `authMode`, not on the provider: an API key still needs
+    // the override, because the native plugin reads a sqlite auth store ClawBox
+    // does not populate and 401s at call time.
+    mockReadOpenClawConfig.mockResolvedValue({
+      models: { providers: { anthropic: { api: "openai-completions", apiKey: "old-key" } } },
+    });
+
+    const res = await configurePost(jsonRequest({
+      provider: "anthropic",
+      apiKey: "sk-ant-test123",
+    }));
+    expect(res.status).toBe(200);
+
+    expect(vi.mocked(runOpenclawConfigUnset)).not.toHaveBeenCalled();
+    const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.anthropic");
+    expect(JSON.parse(providerCall?.value || "{}").api).toBe("openai-completions");
+  });
+
+  it("does not write an openai-compat override for any subscription sign-in", async () => {
+    // Sibling shape. `writeOpenAICompatProvider` has three call sites —
+    // openrouter, google, anthropic — and an OAuth credential is wrong on every
+    // one of them for the same reason. Only anthropic offers a subscription in
+    // the wizard today, but this route takes `authMode` from the request body,
+    // so the guard lives on the shared path rather than in the anthropic branch
+    // where the next provider to gain an OAuth flow would miss it.
+    for (const provider of ["google", "openrouter"] as const) {
+      vi.clearAllMocks();
+      mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
+      mockGetAll.mockResolvedValue({});
+      mockReadOpenClawConfig.mockResolvedValue({});
+      mockParseFullyQualifiedModel.mockImplementation(parseFullyQualifiedModelImpl);
+      mockApplyModelOverrideToAllAgentSessions.mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+
+      const res = await configurePost(jsonRequest({
+        provider,
+        apiKey: `${provider}-oauth-access-token-placeholder`,
+        authMode: "subscription",
+      }));
+      expect(res.status, provider).toBe(200);
+
+      const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
+      expect(
+        commands.some((command) => command.includes(`config set models.providers.${provider}`)),
+        provider,
+      ).toBe(false);
+    }
   });
 
   it("seeds a user-picked non-curated model into the provider entry", async () => {

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -354,6 +354,70 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     expect(vi.mocked(fsp.readFile)).toHaveBeenCalledTimes(1);
   });
 
+  /**
+   * Gap A1's other half, in the OTHER route that knows about
+   * `OPENAI_COMPAT_PROVIDERS`.
+   *
+   * Once ai-models/configure stops writing the openai-completions override for
+   * a subscription sign-in, a subscription box correctly has NO
+   * `models.providers.anthropic` at all. This block's auto-extend exists only
+   * to keep that override's `models` list in sync, and its "is it complete?"
+   * check reads a missing entry as a half-written one — so every model switch
+   * on a fixed box would answer 409 "Re-save it in Settings", which is exactly
+   * the wrong next step for a box whose settings are now right.
+   *
+   * Native routing needs no list: the plugin resolves ids from its own
+   * catalog, which is why clawai/openai/codex never enter this block.
+   */
+  describe("a subscription box that routes natively", () => {
+    /** Subscription auth, and no openai-compat override — the fixed state. */
+    function nativeSubscriptionConfig(mode: "oauth" | "api_key" = "oauth") {
+      return {
+        auth: { profiles: { "anthropic:default": { provider: "anthropic", mode } } },
+        models: { mode: "merge", providers: {} },
+        agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
+      };
+    }
+
+    it("switches model without demanding a re-save", async () => {
+      vi.mocked(readConfig).mockResolvedValue(nativeSubscriptionConfig() as never);
+
+      const response = await postModel(POST, "anthropic/claude-opus-4-8");
+
+      expect(response.status).toBe(200);
+      expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+        "agents.defaults.model.primary",
+        "anthropic/claude-opus-4-8",
+      ]);
+    });
+
+    it("does not recreate the override it was just freed from", async () => {
+      // Appending to `models.providers.anthropic.models` would resurrect the
+      // very entry whose presence made every turn 429.
+      vi.mocked(readConfig).mockResolvedValue(nativeSubscriptionConfig() as never);
+
+      await postModel(POST, "anthropic/claude-opus-4-8");
+
+      const wrotePaths = vi.mocked(runOpenclawConfigSet).mock.calls
+        .map(([args]) => (args as string[])[0]);
+      expect(wrotePaths).not.toContain("models.providers.anthropic.models");
+    });
+
+    it("still demands a re-save when an API-key box has no provider entry", async () => {
+      // The guard keys on subscription auth, not on "entry missing". An
+      // API-key box with no override cannot authenticate through the native
+      // plugin (it reads a sqlite auth store ClawBox does not populate), so
+      // that case keeps the 409 it has always had.
+      vi.mocked(readConfig).mockResolvedValue(nativeSubscriptionConfig("api_key") as never);
+
+      const response = await postModel(POST, "anthropic/claude-opus-4-8");
+
+      expect(response.status).toBe(409);
+      const { error } = await response.json();
+      expect(error).toContain("Re-save it in Settings");
+    });
+  });
+
   it("re-reads the surface on every request instead of probing once", async () => {
     // The cache is refreshed by the catalog route on its own schedule. A
     // module-level memo here would pin this guard to whatever the surface


### PR DESCRIPTION
## The defect

A Claude Pro/Max **subscription** (OAuth) sign-in returns HTTP 429 on every chat turn on the OpenClaw edition, while the same sign-in works on Hermes. It reads like a rate limit. It is not.

`writeOpenAICompatProvider` is an API-KEY construction, and nothing in its signature says so: it pins the provider to `api: "openai-completions"` and inlines the credential, so each turn leaves as `POST <baseUrl>/chat/completions` with a bearer token and none of the provider-native headers. The `isAnthropic` branch called it unconditionally — it never looked at `authMode` — so on a subscription save it wrote the OAuth access token into that override. Anthropic answers 429 to an OAuth token on `/chat/completions` no matter how much quota is left.

Hermes is unaffected because it routes natively (`/v1/messages` **with** `anthropic-beta: oauth-2025-04-20`) and carries no `models.providers` override.

Two further consequences, both found on a real device:

* **Nothing ever deleted a stale override.** A box set up with an API key and later switched to a subscription kept the old entry and stayed broken. Field boxes are already in that state, so not writing a *new* override does not repair them — only removing the old one does.
* **The override freezes the credential.** `apiKey` is written inline at save time, and a subscription access token is short-lived. Even a save that worked expired within hours and never self-healed, because an inline key never goes back through the auth profile that holds the refresh token. The affected device was found carrying an inline token six hours dead.

## The fix

1. On an anthropic subscription save, do not write the openai-compat override — the native anthropic plugin owns routing (`setProviderPlugins` enables it a few steps later).
2. **Migration:** on that same path, unset any pre-existing `models.providers.anthropic`, so a device previously configured with an API key is repaired when it switches to a subscription.
3. `/setup-api/chat/model` no longer answers 409 "Re-save it in Settings" to a natively-routed box. That auto-extend exists to keep the override's model list in sync; a subscription box correctly has no entry, and the completeness check read that absence as a half-written one. An entry that exists but is incomplete still 409s.

## Sibling providers — the grep

```
grep -rn "models\.providers" src/ --include=*.ts --include=*.tsx | grep -v "^src/tests"
```

Three call sites reach `writeOpenAICompatProvider` (openrouter, google, anthropic); the remaining hits are clawai's image provider, ollama, llamacpp, and the chat/model auto-extend. Every one of the three now goes through `applyCloudProviderTransport`, so the transport decision is made in one place.

The answer is **not** "guard on `authMode` and treat all three alike" — that was the first attempt here, and it was wrong:

```
grep -n "OAUTH_PROVIDERS" -A 40 src/lib/oauth-config.ts
```

`OAUTH_PROVIDERS` carries **anthropic, openai, and google** (Gemini Code Assist). So google's subscription reaches the same helper and would have lost its override too — but nothing gives google a native route to land on: `setProviderPlugins` toggles the anthropic plugin and no other, and the google branch records that the native google plugin's auth fails at call time. Taking google's override away on the strength of anthropic's evidence would be this same bug pointed the other way, in a flow with no device to test on.

So the native path is keyed to the providers that have earned it, with the reason written beside the entry:

```ts
const NATIVE_SUBSCRIPTION_ROUTING: ReadonlySet<string> = new Set(["anthropic"]);
```

OpenRouter has no OAuth flow anywhere (absent from `OAUTH_PROVIDERS`), so it is unaffected either way. A test pins google and openrouter to the unchanged behaviour so a future widening cannot happen silently.

## Live proof — the same device, the same subscription, 20 minutes apart

An OpenClaw box found in exactly the field state described: `auth.profiles["anthropic:default"].mode = oauth`, and `models.providers.anthropic` still holding an inline-key openai-compat override.

**Before** — gateway log, and the reply the customer actually got:

```
[model-fetch] start    provider=anthropic api=openai-completions model=claude-sonnet-4-6
               POST https://api.anthropic.com/v1/chat/completions
[model-fetch] response provider=anthropic api=openai-completions status=429
[agent/embedded] error=⚠️ API rate limit reached. Please try again later. rawError=429 Error
[model-fallback/decision] candidate_failed reason=rate_limit next=llamacpp/gemma4-e2b-it-q4_0
executionTrace: winnerProvider=llamacpp   ← the answer came from the local model, not Claude
```

**After** the fix, one subscription re-save through `/setup-api/ai-models/configure`:

```
[AI Config] Removed stale openai-compat override models.providers.anthropic
[AI Config] Set anthropic provider (native plugin, subscription auth): anthropic/claude-sonnet-4-6

[model-fetch] start    provider=anthropic api=anthropic-messages model=claude-sonnet-4-6
               POST https://api.anthropic.com/v1/messages
[model-fetch] response provider=anthropic api=anthropic-messages status=200 contentType=text/event-stream
executionTrace: winnerProvider=anthropic winnerModel=claude-sonnet-4-6 fallbackUsed=false
```

`openclaw config get models.providers.anthropic` → `Config path not found`, and `plugins.entries.anthropic.enabled` → `true`. The transport moved from `/chat/completions` to `/v1/messages`, and the 429 became a real completion.

## Tests

RED against `origin/beta` source with these tests in place — 4 failed / 93 passed:

* does not write the openai-compat override for a Claude subscription sign-in
* removes a stale openai-compat override when a device switches from API key to subscription
* fails the subscription save when the config cannot be read
* switches model without demanding a re-save

GREEN with the fix — 97/97 in those two files, 249/249 across `src/tests/routes/ai-models/` plus the chat-model surface suite. `tsc --noEmit` and `eslint` report nothing new in any file this PR touches.

`readConfigStrict` was added for the third of those: `readConfig` answers `{}` to an EACCES or a half-written file exactly as it does to a clean config, and `{}` read as "no override to remove" — so an unreadable config would have skipped the repair, returned 200, and left the poisoned override on disk. Only an ENOENT now means "no config"; anything else throws.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Anthropic subscription sign-ins now use native connectivity and automatically remove outdated compatibility settings.
  * Anthropic API-key, Google, and OpenRouter configurations continue using compatibility connectivity.
  * Subscription users can switch models without configuration errors or unwanted overrides.

* **Bug Fixes**
  * Prevented repeated “isn’t fully configured” errors during subscription model changes.
  * Added safer handling when configuration data is missing or unreadable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->