### PR TITLE
fix: close the #519 residuals — every caller reads the verdict, and the update path carries it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2791,8 +2791,28 @@ step_openclaw_tts() {
     # there — which is where an unhandled 13 would have landed — would put the
     # name of a working fallback on the box this whole fix exists to catch.
     case "$VOICE_RC" in
-      10|11|12)
+      10|12)
         echo "  On-device TTS configured (Piper CPU only — $KOKORO_REASON)"
+        ;;
+      11)
+        # 11 was bucketed with 10 and 12 and is not like them. It is
+        # install_kokoro_tts's "no Jetson CUDA build for this architecture",
+        # i.e. `uname -m` is not aarch64 — which is exactly when
+        # install_piper_engine has no pinned artifact either and publishes
+        # `skipped:arch-*` of its own. install-voice.sh has just printed "=== No
+        # on-device TTS engine applies to this board ===" for that pair, so
+        # naming a Piper CPU fallback one line later put the name of an engine
+        # this box does not have on the summary line an operator reads.
+        #
+        # Deliberately NOT a recorded provisioning failure: nothing was asked
+        # for and nothing is missing on a board neither engine ships for, which
+        # is the same rule `skipped:*` carries in step_validate_services.
+        #
+        # On stdout, not stderr, for the same reason: install-voice.sh prints
+        # its "no engine applies to this board" line on stdout too, and painting
+        # every install-x64.sh run red would only teach everyone to ignore it.
+        echo "  On-device TTS configured, but no speech engine applies to this CPU architecture"
+        echo "  (no Jetson CUDA build and no pinned Piper artifact) — this box answers speech with SILENCE"
         ;;
       1)
         # An engine SURVIVES here — install-voice.sh returns 13, not 1, when
@@ -3509,7 +3529,21 @@ step_post_update() {
   # tts-local-cli provider. Without this call the whole of TASK-383 would be
   # fresh-install-only, and every already-shipped box would keep answering a
   # spoken request with silence.
-  step_openclaw_tts || echo "  Warning: openclaw_tts step failed (non-fatal)"
+  # The SAME tolerance table step_openclaw_setup applies to this step, and for
+  # the same reason: 12, 13 and 14 are three different facts about a box's
+  # speech and the update path has to keep them apart too. A single
+  # `|| echo "(non-fatal)"` — indistinguishable from the fourteen lines around
+  # it — reported "this box answers speech with SILENCE" in the same words as a
+  # skipped VNC refresh, on the very path that reaches ALREADY-SHIPPED boxes.
+  local TTS_UPDATE_RC=0
+  step_openclaw_tts || TTS_UPDATE_RC=$?
+  case "$TTS_UPDATE_RC" in
+    0) ;;
+    12) echo "  Warning: Kokoro GPU TTS did not install (recorded above; the update continues)" ;;
+    13) echo "  Warning: this box has NO working TTS engine — it answers speech with SILENCE (recorded above; the update continues)" ;;
+    14) echo "  Warning: the TTS install did not complete (recorded above; the update continues)" ;;
+    *)  echo "  Warning: openclaw_tts returned $TTS_UPDATE_RC, which is not in its contract (non-fatal)" ;;
+  esac
   # Re-assert the gateway service after an in-app update. The full update
   # syncs repo files and rebuilds before this continuation runs; older devices
   # can therefore reach the new UI while the gateway is still using stale
@@ -4871,8 +4905,14 @@ step_validate_services() {
       # spoken request with silence.
       local tts_state="" piper_state=""
       if [ -r "$TTS_STATUS_FILE" ]; then
-        tts_state=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
-        piper_state=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
+        # `tr -d '\r'`: the file is written by a shell on the device, but it is
+        # also restored from tarballs and edited by hand, and a CRLF line ends
+        # the verdict as `ready\r` — a value that is neither `ready` nor any
+        # other word in the vocabulary. Parse the line rather than merely
+        # refusing it; what a garbled value must NOT do is score a pass, and
+        # that is what the guard below is for.
+        tts_state=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
+        piper_state=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
       fi
       # `ready` is the only verdict that means "this engine can speak".
       # `skipped:*` is a board that was never going to run it, `failed:*` is one
@@ -4884,6 +4924,16 @@ step_validate_services() {
       local kokoro_failed=false piper_failed=false
       case "$tts_state" in failed:*) kokoro_failed=true ;; esac
       case "$piper_state" in failed:*) piper_failed=true ;; esac
+      # The vocabulary is closed: `ready`, `skipped:*`, `failed:*`, or nothing
+      # at all. Anything else — a truncated write (tts_status_publish truncates
+      # the file with `>` rather than writing-then-renaming, so a box that lost
+      # power mid-publish can leave one), a typo, a stray line — matched none of
+      # the branches below and fell out of the chain as a silent PASS, while the
+      # strictly LESS informative absent verdict correctly failed. Unparseable
+      # is at least as suspicious as absent.
+      local verdict_unreadable=false
+      case "$tts_state" in ""|ready|skipped:*|failed:*) ;; *) verdict_unreadable=true ;; esac
+      case "$piper_state" in ""|ready|skipped:*|failed:*) ;; *) verdict_unreadable=true ;; esac
       # ONE verdict about this box's speech, most severe first, so the check
       # that probe_count counts as one contributes at most one line. Reporting
       # "Kokoro failed" and "Piper failed" and "no engine" as three separate
@@ -4909,6 +4959,15 @@ step_validate_services() {
         failed_probe+=("TTS: the Piper CPU fallback was requested and did NOT install ($piper_state) — this box has no fallback behind its GPU engine. $tts_fix")
       elif [ -z "$piper_state" ]; then
         failed_probe+=("TTS: no Piper verdict at $TTS_STATUS_FILE — the CPU half left no record, so whether this box has a fallback cannot be asserted either way. $tts_fix")
+      elif [ "$verdict_unreadable" = true ]; then
+        # LAST, not first: every arm above is a more specific statement about
+        # the same box, and a garbled Piper verdict next to a failed Kokoro is
+        # still best reported as "no working engine". It is deliberately an
+        # `elif` rather than the trailing `else` that would close the chain,
+        # because the chain's fall-through is also where the HEALTHY box lands
+        # (both engines `ready` match no arm) — an `else` there would fail every
+        # good box on the shelf.
+        failed_probe+=("TTS: unrecognised on-device TTS verdict at $TTS_STATUS_FILE (Kokoro: ${tts_state:-unreported}, Piper: ${piper_state:-unreported}) — a verdict outside the ready/skipped:*/failed:* vocabulary is not evidence of an engine. $tts_fix")
       fi
     fi
 
@@ -5090,6 +5149,43 @@ if [ "${1:-}" = "--step" ]; then
     echo "Available steps: ${DISPATCH_STEPS[*]}" >&2
     exit 1
   fi
+  # ── A dispatched step's recorded failures must not die with it ─────────────
+  # `"step_x"; exit 0` threw away everything record_provision_failure collected.
+  # step_post_update returns 0 whatever its fixups reported, so an in-app update
+  # whose TTS step left the box MUTE — exit 13, recorded inside
+  # step_openclaw_tts precisely so it would be carried — finished as a
+  # successful update with nothing in $PROVISION_STATUS_FILE, the marker the
+  # dashboard and the flash host read. The full-install path has printed this
+  # summary since the marker existed; the dispatch path never reached it.
+  #
+  # An EXIT trap, not `"step_x" || rc=$?`: the OR-list form would switch set -e
+  # OFF for the entire body of the dispatched step, so every guard inside it
+  # that relies on errexit to stop would run on instead. The trap also catches
+  # the step that dies mid-way under errexit, which is the case that reported
+  # nothing at all.
+  #
+  # Only `incomplete` is ever published here. One dispatched step finishing
+  # cleanly is not evidence that the whole box provisioned, so a clean run
+  # writes nothing and leaves the marker to the full install that owns it.
+  dispatch_provision_verdict() {
+    local rc=$?
+    trap - EXIT
+    if [ "${#PROVISION_FAILURES[@]}" -gt 0 ]; then
+      echo "  ############################################################"
+      echo "  # PROVISIONING INCOMPLETE — step $local_step reported errors."
+      echo "  # Steps that failed: ${PROVISION_FAILURES[*]}"
+      echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step ${PROVISION_FAILURES[0]}"
+      echo "  ############################################################"
+      write_provision_status incomplete "${PROVISION_FAILURES[*]}" || true
+      # Same stdout contract as the full install: the flash host greps these
+      # two lines, and the prefix and the verdict word are byte-identical.
+      echo "[provision-status] INCOMPLETE (${PROVISION_FAILURES[*]})"
+      echo "[provision-run] $PROVISION_RUN_ID"
+      if [ "$rc" -eq 0 ]; then rc=1; fi
+    fi
+    exit "$rc"
+  }
+  trap dispatch_provision_verdict EXIT
   "step_${local_step}"
   exit 0
 fi

--- a/install.sh
+++ b/install.sh
@@ -4931,9 +4931,14 @@ step_validate_services() {
       # the branches below and fell out of the chain as a silent PASS, while the
       # strictly LESS informative absent verdict correctly failed. Unparseable
       # is at least as suspicious as absent.
+      #
+      # `?*`, not `*`: a bare `skipped:` or `failed:` carries no reason, and a
+      # truncated write is exactly how one appears. "This board declines the
+      # engine" is a claim, and a claim with its reason cut off is not evidence
+      # for it either.
       local verdict_unreadable=false
-      case "$tts_state" in ""|ready|skipped:*|failed:*) ;; *) verdict_unreadable=true ;; esac
-      case "$piper_state" in ""|ready|skipped:*|failed:*) ;; *) verdict_unreadable=true ;; esac
+      case "$tts_state" in ""|ready|skipped:?*|failed:?*) ;; *) verdict_unreadable=true ;; esac
+      case "$piper_state" in ""|ready|skipped:?*|failed:?*) ;; *) verdict_unreadable=true ;; esac
       # ONE verdict about this box's speech, most severe first, so the check
       # that probe_count counts as one contributes at most one line. Reporting
       # "Kokoro failed" and "Piper failed" and "no engine" as three separate
@@ -4942,6 +4947,17 @@ step_validate_services() {
       local tts_fix="Fix: sudo bash $PROJECT_DIR/install.sh --step openclaw_tts"
       if [ -z "$tts_state" ] && [ -z "$piper_state" ]; then
         failed_probe+=("TTS: no on-device TTS verdict at $TTS_STATUS_FILE — the TTS step left no record, so whether this box has an engine cannot be asserted either way. $tts_fix")
+      elif [ "$verdict_unreadable" = true ]; then
+        # SECOND, ahead of every arm that names an engine state. A verdict
+        # nobody can parse does not establish one: `KOKORO=redy` next to
+        # `PIPER=failed:download` would otherwise be reported as "this box has
+        # NO working TTS engine", which is a claim about a GPU engine that may
+        # be running perfectly — the same failure-report-over-a-success this PR
+        # exists to remove. It is an `elif` and not the trailing `else` that
+        # would close the chain, because the fall-through is also where the
+        # HEALTHY box lands (both engines `ready` match no arm), so an `else`
+        # there would fail every good box on the shelf.
+        failed_probe+=("TTS: unrecognised on-device TTS verdict at $TTS_STATUS_FILE (Kokoro: ${tts_state:-unreported}, Piper: ${piper_state:-unreported}) — a verdict outside the ready/skipped:<reason>/failed:<reason> vocabulary is not evidence of an engine. $tts_fix")
       elif [ "$tts_state" != "ready" ] && [ "$piper_state" != "ready" ]         && { [ "$kokoro_failed" = true ] || [ "$piper_failed" = true ]; }; then
         # The defect this probe was rewritten for. Note what does NOT land here:
         # both engines `skipped:*` is a board that runs neither by design (no
@@ -4959,15 +4975,6 @@ step_validate_services() {
         failed_probe+=("TTS: the Piper CPU fallback was requested and did NOT install ($piper_state) — this box has no fallback behind its GPU engine. $tts_fix")
       elif [ -z "$piper_state" ]; then
         failed_probe+=("TTS: no Piper verdict at $TTS_STATUS_FILE — the CPU half left no record, so whether this box has a fallback cannot be asserted either way. $tts_fix")
-      elif [ "$verdict_unreadable" = true ]; then
-        # LAST, not first: every arm above is a more specific statement about
-        # the same box, and a garbled Piper verdict next to a failed Kokoro is
-        # still best reported as "no working engine". It is deliberately an
-        # `elif` rather than the trailing `else` that would close the chain,
-        # because the chain's fall-through is also where the HEALTHY box lands
-        # (both engines `ready` match no arm) — an `else` there would fail every
-        # good box on the shelf.
-        failed_probe+=("TTS: unrecognised on-device TTS verdict at $TTS_STATUS_FILE (Kokoro: ${tts_state:-unreported}, Piper: ${piper_state:-unreported}) — a verdict outside the ready/skipped:*/failed:* vocabulary is not evidence of an engine. $tts_fix")
       fi
     fi
 

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -768,9 +768,13 @@ if [ "${1:-}" = "--piper-only" ]; then
   # "=== Piper fallback ready ===" and exited 0 over a board that installed
   # nothing, in the very mode clawbox-tts.sh's "Piper not installed" hint tells
   # an operator to run.
+  # `skipped:?*`, not `skipped:*`: a bare `skipped:` carries no reason, and a
+  # truncated write is exactly how one appears. "No artifact applies to this
+  # board" is a claim, and a claim with its reason cut off is not evidence for
+  # it — it belongs with the unparseable values below.
   case "$TTS_PIPER_VERDICT" in
     ready) ;;
-    skipped:*)
+    skipped:?*)
       # The BOARD declines the engine — no pinned artifact for this
       # architecture. Nothing was asked for and nothing is missing, which is
       # the rule `skipped:*` already carries in --tts-only and in install.sh's
@@ -949,9 +953,9 @@ echo "  STT: Whisper (base) via on-demand server (~1.8s)"
 # fallback on every run, including the x86 runs where install_piper_engine
 # declines for want of a pinned artifact and the runs where its download failed.
 case "$TTS_PIPER_VERDICT" in
-  ready)     echo "  TTS: Kokoro-82M via on-demand server (~2s), Piper CPU fallback" ;;
-  skipped:*) echo "  TTS: Kokoro-82M via on-demand server (~2s); no Piper fallback applies to this board ($TTS_PIPER_VERDICT)" ;;
-  *)         echo "  TTS: Kokoro-82M via on-demand server (~2s); the Piper CPU fallback did NOT install (${TTS_PIPER_VERDICT:-unreported})" >&2 ;;
+  ready)      echo "  TTS: Kokoro-82M via on-demand server (~2s), Piper CPU fallback" ;;
+  skipped:?*) echo "  TTS: Kokoro-82M via on-demand server (~2s); no Piper fallback applies to this board ($TTS_PIPER_VERDICT)" ;;
+  *)          echo "  TTS: Kokoro-82M via on-demand server (~2s); the Piper CPU fallback did NOT install (${TTS_PIPER_VERDICT:-unreported})" >&2 ;;
 esac
 echo "  TTS entrypoint: $WORKSPACE/scripts/openclaw/clawbox-tts.sh"
 echo "  Services: kokoro-server, whisper-server (on-demand, auto-stop after idle)"

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -547,8 +547,12 @@ TTS_PIPER_VERDICT=""
 # actually succeeded.
 tts_status_load() {
   [ -r "$TTS_STATUS_FILE" ] || return 0
-  TTS_KOKORO_VERDICT=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
-  TTS_PIPER_VERDICT=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tail -1)
+  # `tr -d '\r'` for the same reason install.sh's reader carries it: this file
+  # is also restored from tarballs and edited by hand, and the two parsers must
+  # agree about what a line says or the installer and its own health check can
+  # disagree about the same box.
+  TTS_KOKORO_VERDICT=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
+  TTS_PIPER_VERDICT=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
 }
 
 # Rewrite $TTS_STATUS_FILE from every verdict known so far. A key with no
@@ -685,7 +689,13 @@ if [ "${1:-}" = "--tts-only" ]; then
   # The exit status is the contract with install.sh's step_openclaw_tts:
   #
   #   0        Kokoro is the engine and it is ready.
-  #   10 / 11  Kokoro does not apply to this board; the box speaks on Piper.
+  #   10       No CUDA toolkit on an aarch64 board; the box speaks on Piper.
+  #   11       No Jetson build for this ARCHITECTURE — which is the very
+  #            condition under which install_piper_engine has no pinned
+  #            artifact either, so 11 means NO engine applies to the board at
+  #            all, not "the box speaks on Piper". install.sh names the engine
+  #            off this code, and bucketing 11 with 10 put the name of a
+  #            fallback that does not exist on a box that has none.
   #   12       Kokoro was REQUESTED and did not install; the box speaks on Piper.
   #   1        the Piper half did not complete, but an engine survives.
   #   13       NO usable engine at all - this box answers speech with SILENCE.
@@ -750,6 +760,32 @@ if [ "${1:-}" = "--piper-only" ]; then
     echo "=== Piper fallback INCOMPLETE — the box may answer speech with silence ===" >&2
     exit 1
   fi
+  # Whether an engine ARRIVED is read from the published verdict, never from the
+  # return code above — the same rule --tts-only follows, and for the same
+  # reason: install_piper returns 0 for "there is no pinned artifact for this
+  # board" too, so its exit status cannot tell an installed engine from a
+  # declined one. Answering from the return code alone printed
+  # "=== Piper fallback ready ===" and exited 0 over a board that installed
+  # nothing, in the very mode clawbox-tts.sh's "Piper not installed" hint tells
+  # an operator to run.
+  case "$TTS_PIPER_VERDICT" in
+    ready) ;;
+    skipped:*)
+      # The BOARD declines the engine — no pinned artifact for this
+      # architecture. Nothing was asked for and nothing is missing, which is
+      # the rule `skipped:*` already carries in --tts-only and in install.sh's
+      # health check, so this exits clean without claiming a fallback.
+      echo "=== No Piper artifact applies to this board (Piper: $TTS_PIPER_VERDICT) ==="
+      exit 0
+      ;;
+    *)
+      # `failed:*`, nothing published, or a verdict outside the vocabulary.
+      # None of those is evidence of an engine, and an unparseable answer is at
+      # least as suspicious as an absent one.
+      echo "=== Piper fallback INCOMPLETE — no usable Piper verdict (Piper: ${TTS_PIPER_VERDICT:-unreported}) ===" >&2
+      exit 1
+      ;;
+  esac
   echo "=== Piper fallback ready ==="
   exit 0
 fi
@@ -907,6 +943,15 @@ else
   echo "  Mode: CPU"
 fi
 echo "  STT: Whisper (base) via on-demand server (~1.8s)"
-echo "  TTS: Kokoro-82M via on-demand server (~2s), Piper CPU fallback"
+# The fallback is named from the PUBLISHED verdict, not from the fact that
+# install_piper was called a few lines up. This is the third caller of
+# install_piper and it was the least honest of them: it asserted a Piper CPU
+# fallback on every run, including the x86 runs where install_piper_engine
+# declines for want of a pinned artifact and the runs where its download failed.
+case "$TTS_PIPER_VERDICT" in
+  ready)     echo "  TTS: Kokoro-82M via on-demand server (~2s), Piper CPU fallback" ;;
+  skipped:*) echo "  TTS: Kokoro-82M via on-demand server (~2s); no Piper fallback applies to this board ($TTS_PIPER_VERDICT)" ;;
+  *)         echo "  TTS: Kokoro-82M via on-demand server (~2s); the Piper CPU fallback did NOT install (${TTS_PIPER_VERDICT:-unreported})" >&2 ;;
+esac
 echo "  TTS entrypoint: $WORKSPACE/scripts/openclaw/clawbox-tts.sh"
 echo "  Services: kokoro-server, whisper-server (on-demand, auto-stop after idle)"

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -332,9 +332,12 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     expect(res.stdout).toContain("On-device TTS configured (Kokoro GPU, Piper fallback)");
   });
 
+  // 11 is deliberately NOT in this table any more — see the test below it.
+  // Every code here is one where the Piper half genuinely completed, so naming
+  // it as the surviving engine is true; --tts-only returns 13 or 1, never 10 or
+  // 12, when the fallback is missing.
   it.each([
     [10, /no CUDA toolkit/],
-    [11, /CPU architecture/],
     [12, /Kokoro GPU install failed/],
   ])("stays non-fatal and tells the truth when the voice install exits %i", (code, reason) => {
     const res = runStep(code as number);
@@ -345,6 +348,22 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     expect(res.stdout).not.toContain("Kokoro GPU, Piper fallback");
     expect(res.stdout).toContain("Piper CPU only");
     expect(res.stdout).toMatch(reason as RegExp);
+  });
+
+  it("names no engine at all when the voice install exits 11", () => {
+    // 11 is "no Jetson CUDA build for this ARCHITECTURE" — `uname -m` is not
+    // aarch64, which is the same test that leaves install_piper_engine without
+    // a pinned artifact. Both halves publish `skipped:arch-*`, install-voice.sh
+    // prints "=== No on-device TTS engine applies to this board ===" and exits
+    // 11, so the "Piper CPU only" line this case used to assert named a
+    // fallback the box does not have. It stays non-fatal and unrecorded — a
+    // board neither engine ships for was never asked for one.
+    const res = runStep(11);
+    expect(res.openclaw).toContain("config set messages.tts.provider tts-local-cli");
+    expect(res.stdout).not.toContain("Kokoro GPU, Piper fallback");
+    expect(res.stdout, "a board with no engine was told it speaks on Piper").not.toContain("Piper CPU only");
+    expect(res.stdout).toMatch(/CPU architecture/);
+    expect(res.stdout).toMatch(/SILENCE/);
   });
 
   // ── Requested-and-failed is not the same outcome as never-requested ────────

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * The SIBLINGS of the TTS-01 fix (#519).
+ *
+ * #519 taught ONE caller of each half to stop reporting success from a return
+ * code and read the published verdict instead. Every other caller was left as
+ * it was, which is the shape this review round exists to catch — a bug fixed in
+ * one of two identical paths:
+ *
+ *   1. `install-voice.sh --piper-only`, the second caller of install_piper,
+ *      still judged the outcome by `install_piper || PIPER_ONLY_RC=1`.
+ *      install_piper returns 0 for "there is no pinned artifact for this
+ *      board", so the mode printed "=== Piper fallback ready ===" and exited 0
+ *      having installed nothing — in the mode clawbox-tts.sh's own
+ *      "Piper not installed" hint tells an operator to run.
+ *   2. The full-pipeline path, the third caller, asserted "Piper CPU fallback"
+ *      in its summary on every run whatever the verdict said.
+ *   3. install.sh bucketed VOICE_RC 11 with 10 and 12 and printed "Piper CPU
+ *      only". 11 means `uname -m` is not aarch64 — exactly when install_piper
+ *      has no artifact either — so it named a fallback that does not exist one
+ *      line after install-voice.sh said no engine applies.
+ *   4. step_validate_services' probe is an if/elif chain whose fall-through is
+ *      a PASS, so a verdict outside the `ready` / `skipped:` / `failed:`
+ *      vocabulary (a
+ *      torn write, a CRLF-terminated `PIPER=ready`) scored better than an
+ *      absent one.
+ *   5. step_post_update, the second caller of step_openclaw_tts, laundered
+ *      12/13/14 into one generic `|| echo "(non-fatal)"` — and `--step`
+ *      dispatch then ran `exit 0`, throwing away the record_provision_failure
+ *      #519 added, so an in-app UPDATE that left the box mute finished as a
+ *      successful update.
+ *
+ * These tests EXECUTE the shipped artifacts against stubs, like the #519 suite
+ * they sit next to. A rewrite that keeps the prose but drops the verdict fails
+ * them.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_VOICE = path.join(REPO, "scripts", "install-voice.sh");
+const INSTALL_VOICE_SH = readFileSync(INSTALL_VOICE, "utf-8");
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+/**
+ * The stub PATH is the stub dir plus the POSIX system dirs, so the script under
+ * test cannot reach the real curl, wget or nvcc. On Windows that also makes
+ * `bash` itself unfindable, so the host PATH is appended there for the lookup
+ * only — the stub dir still comes first. Empty on Linux/CI. (Same note as the
+ * #519 suite; the reason has not changed.)
+ */
+const HOST_PATH_SUFFIX = process.platform === "win32" ? `${path.delimiter}${process.env.PATH ?? ""}` : "";
+
+function extractShellFn(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end + 2);
+}
+
+/** Read a pinned constant (e.g. PIPER_EN_ONNX_SHA256) out of the real script. */
+function shellConst(name: string): string {
+  const m = new RegExp(`^${name}="([^"]+)"`, "m").exec(INSTALL_VOICE_SH);
+  if (!m) throw new Error(`${name} not found in install-voice.sh`);
+  return m[1];
+}
+
+function writeExec(file: string, body: string) {
+  writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+}
+
+/**
+ * Run a generated shell program from a FILE rather than `bash -c "$program"`:
+ * these programs carry whole functions lifted out of install.sh and run past
+ * the 8 KiB per-argument ceiling on the Windows spawn path, where a `-c`
+ * argument is silently truncated and bash dies with "unexpected end of file"
+ * whatever the script under test did.
+ */
+function runShellProgram(program: string, env: Record<string, string>, args: string[] = []) {
+  const file = path.join(root, `prog-${Math.random().toString(36).slice(2)}.sh`);
+  writeFileSync(file, program);
+  return spawnSync("bash", [file, ...args], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, ...env },
+  });
+}
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "tts-siblings-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+// ── 1. --piper-only, the second caller of install_piper ─────────────────────
+
+interface VoiceRun {
+  status: number | null;
+  out: string;
+  ttsStatus: string;
+  verdict: (key: string) => string | null;
+}
+
+/**
+ * Build a fake device root and a PATH of stubs, then run the REAL
+ * `scripts/install-voice.sh --piper-only`.
+ *
+ * `piper: "ready"` puts the pinned binary and voices on disk so nothing is
+ * downloaded; `"broken"` leaves the disk empty with every fetch failing, which
+ * is the flaky download half of this defect. `arch` picks what `uname -m`
+ * answers: on anything but aarch64 install_piper_engine declines for want of a
+ * pinned artifact and returns 0.
+ */
+function runPiperOnly(opts: { piper?: "ready" | "broken"; arch?: string } = {}): VoiceRun {
+  const { piper = "ready", arch = "aarch64" } = opts;
+  const home = path.join(root, "home", "clawbox");
+  const bin = path.join(root, "bin");
+  const ttsStatus = path.join(root, "tts-status");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+
+  writeExec(
+    path.join(bin, "uname"),
+    [`[ "\${1:-}" = "-m" ] && { echo "\${FAKE_ARCH:-aarch64}"; exit 0; }`, 'exec /usr/bin/uname "$@"'].join("\n"),
+  );
+  // No network in a unit test, and the ONE injected fault in the "broken" case.
+  writeExec(path.join(bin, "curl"), "exit 1");
+  writeExec(path.join(bin, "wget"), "exit 1");
+  writeExec(path.join(bin, "chown"), "exit 0");
+  writeExec(path.join(bin, "sha256sum"), 'printf "%s  %s\\n" "$(head -c 64 "$1")" "$1"');
+
+  const piperDir = path.join(root, "piper");
+  if (piper === "ready") {
+    mkdirSync(path.join(piperDir, "voices"), { recursive: true });
+    writeExec(path.join(piperDir, "piper"), "exit 0");
+    writeFileSync(path.join(piperDir, "voices", "en_US-lessac-medium.onnx"), shellConst("PIPER_EN_ONNX_SHA256"));
+    writeFileSync(
+      path.join(piperDir, "voices", "en_US-lessac-medium.onnx.json"),
+      shellConst("PIPER_EN_JSON_SHA256"),
+    );
+  }
+
+  const res = spawnSync("bash", [INSTALL_VOICE, "--piper-only"], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: {
+      PATH: `${bin}:/usr/bin:/bin${HOST_PATH_SUFFIX}`,
+      HOME: home,
+      CLAWBOX_USER: "clawbox",
+      CLAWBOX_HOME: home,
+      PIPER_DIR: piperDir,
+      CLAWBOX_TTS_STATUS_FILE: ttsStatus,
+      FAKE_ARCH: arch,
+      // Cast only because this repo's ProcessEnv augmentation insists on
+      // NODE_ENV, which this deliberately minimal stub environment has no
+      // business carrying.
+    } as unknown as NodeJS.ProcessEnv,
+  });
+
+  const contents = existsSync(ttsStatus) ? readFileSync(ttsStatus, "utf-8") : "";
+  return {
+    status: res.status,
+    out: `${res.stdout ?? ""}${res.stderr ?? ""}`,
+    ttsStatus: contents,
+    verdict: (key: string) => {
+      const m = new RegExp(`^${key}=(.*)$`, "m").exec(contents);
+      return m ? m[1] : null;
+    },
+  };
+}
+
+describe.skipIf(!hasBash)("--piper-only reports the engine it published, not its return code", () => {
+  it("does not announce a fallback on a board that has no pinned artifact", () => {
+    // The residual. install_piper_engine returns 0 here — a clean decline, not
+    // an engine — and the mode printed "=== Piper fallback ready ===" over a
+    // box where nothing was installed.
+    const res = runPiperOnly({ piper: "broken", arch: "x86_64" });
+    expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^skipped:/);
+    expect(res.out, `a board with no artifact was told it has a fallback:\n${res.out}`).not.toContain(
+      "Piper fallback ready",
+    );
+    expect(res.out).toMatch(/no Piper artifact applies/i);
+  });
+
+  it("still exits 0 there — a board that declines an engine is not a failure", () => {
+    // The mirror-image over-correction. `skipped:*` means nothing was asked for
+    // and nothing is missing, the same rule --tts-only and the health check
+    // already follow; failing every x86 run would only teach everyone to
+    // ignore this mode.
+    const res = runPiperOnly({ piper: "broken", arch: "x86_64" });
+    expect(res.status, `a board with no applicable engine was called broken:\n${res.out}`).toBe(0);
+  });
+
+  it("announces the fallback when the engine is genuinely installed", () => {
+    const res = runPiperOnly({ piper: "ready" });
+    expect(res.verdict("PIPER"), res.ttsStatus).toBe("ready");
+    expect(res.status, res.out).toBe(0);
+    expect(res.out).toContain("Piper fallback ready");
+  });
+
+  it("fails when the engine was asked for and did not arrive", () => {
+    const res = runPiperOnly({ piper: "broken" });
+    expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^failed:/);
+    expect(res.status, `a failed install reported success:\n${res.out}`).not.toBe(0);
+    expect(res.out).not.toContain("Piper fallback ready");
+  });
+});
+
+describe("the full pipeline names the fallback from the verdict too", () => {
+  it("does not assert a Piper fallback in a summary the verdict never agreed to", () => {
+    // The THIRD caller of install_piper: the default path printed
+    // "Piper CPU fallback" unconditionally, including on the x86 runs where
+    // install_piper_engine declines and on the runs where its download failed.
+    const summary = INSTALL_VOICE_SH.slice(INSTALL_VOICE_SH.indexOf("=== Voice Pipeline Installed ==="));
+    expect(summary, "the full-pipeline summary is not in install-voice.sh").not.toBe("");
+    expect(summary, `the summary claims an engine without reading its verdict:\n${summary}`).toContain(
+      'case "$TTS_PIPER_VERDICT" in',
+    );
+  });
+});
+
+// ── 2. install.sh must not name an engine exit 11 does not carry ────────────
+
+/**
+ * Run the real step_openclaw_tts against a stub install-voice.sh whose exit
+ * code the test picks — the #519 harness, unchanged.
+ */
+function runStep(voiceExit: number) {
+  const projectDir = path.join(root, "project");
+  mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+  writeExec(
+    path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+    '[ "${1:-}" = "--provider-timeout-ms" ] && echo 100000\nexit 0',
+  );
+  writeExec(path.join(projectDir, "scripts", "install-voice.sh"), `exit ${voiceExit}`);
+  const openclaw = path.join(root, "openclaw");
+  writeExec(openclaw, "exit 0");
+
+  const provisionLog = path.join(root, "provision-failures.log");
+  const ttsStatus = path.join(root, "step-tts-status");
+
+  const program = [
+    "set -uo pipefail",
+    `PROJECT_DIR="${projectDir}"`,
+    `OPENCLAW_BIN="${openclaw}"`,
+    "CLAWBOX_USER=clawbox",
+    'as_clawbox() { env "$@"; }',
+    "is_hermes_edition() { return 1; }",
+    `record_provision_failure() { printf '%s\\n' "$1" >> "${provisionLog}"; }`,
+    extractShellFn(INSTALL_SH, "oc_config_set"),
+    extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
+    extractShellFn(INSTALL_SH, "step_openclaw_tts"),
+    "step_openclaw_tts",
+    'echo "STEP_RC=$?"',
+  ].join("\n");
+
+  const res = runShellProgram(program, { TTS_STATUS_FILE: ttsStatus });
+  const out = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+  return {
+    out,
+    stepRc: /STEP_RC=(\d+)/.exec(out)?.[1] ?? "",
+    provisionFailures: existsSync(provisionLog)
+      ? readFileSync(provisionLog, "utf-8").trim().split("\n").filter(Boolean)
+      : [],
+  };
+}
+
+describe.skipIf(!hasBash)("step_openclaw_tts names only the engines the exit code carries", () => {
+  it("does not name a Piper fallback on the architecture that has none (11)", () => {
+    // 11 is "no Jetson CUDA build for this architecture", which is the same
+    // `uname -m` test that leaves install_piper without a pinned artifact — so
+    // both halves published `skipped:arch-*` and install-voice.sh has just
+    // said no engine applies. Bucketing it with 10 and 12 put the name of a
+    // working fallback on a box that answers with silence.
+    const res = runStep(11);
+    expect(res.out, `an architecture with no engine was told it speaks on Piper:\n${res.out}`).not.toContain(
+      "Piper CPU only",
+    );
+    expect(res.out).toMatch(/SILENCE/);
+  });
+
+  it("keeps naming Piper for the codes that genuinely carry it (10 and 12)", () => {
+    // The over-correction guard. 10 (no CUDA toolkit) and 12 (Kokoro asked for
+    // and failed) are both reachable only with a READY Piper — --tts-only
+    // returns 13 or 1 otherwise — so the fallback claim there is true.
+    for (const code of [10, 12]) {
+      const res = runStep(code);
+      expect(res.out, `code ${code} stopped naming the engine it does have:\n${res.out}`).toContain(
+        "Piper CPU only",
+      );
+    }
+  });
+
+  it("still records nothing for a board neither engine ships for (11)", () => {
+    // Nothing was asked for and nothing is missing: 11 stays a clean provision,
+    // exactly as #519 decided for two `skipped:*` verdicts.
+    const res = runStep(11);
+    expect(res.provisionFailures).toEqual([]);
+    expect(res.stepRc).toBe("0");
+  });
+});
+
+// ── 3. The health check must not score garbage above silence ────────────────
+
+/**
+ * Run the real step_validate_services with everything except the TTS verdict
+ * stubbed healthy — the #519 harness, unchanged.
+ */
+function runValidator(contents: string | null): { status: number; out: string } {
+  const ttsStatus = path.join(root, "validator-tts-status");
+  if (contents !== null) writeFileSync(ttsStatus, contents);
+  const clock = path.join(root, "clock");
+  writeFileSync(clock, "1000\n");
+
+  const program = [
+    "set -uo pipefail",
+    "CLAWBOX_EDITION=openclaw",
+    "CLAWBOX_TEST_MODE=1",
+    "PROJECT_DIR=/home/clawbox/clawbox",
+    'IFACE_ENV="/nonexistent/network.env"',
+    "EXPECTED_ACTIVE_SERVICES=()",
+    "EXPECTED_INSTALLED_SERVICES=()",
+    "FOREIGN_EDITION_UNITS=()",
+    'is_test_mode() { [ "$CLAWBOX_TEST_MODE" = "1" ]; }',
+    'is_hermes_edition() { [ "$CLAWBOX_EDITION" = "hermes" ]; }',
+    "has_hermes_harness() { return 1; }",
+    "gateway_port_listening() { return 1; }",
+    "systemctl() { return 0; }",
+    "curl() { printf '200'; }",
+    `_CLOCK="${clock}"`,
+    'date() { local n; n=$(( $(cat "$_CLOCK") + 100 )); echo "$n" > "$_CLOCK"; printf %s "$n"; }',
+    "sleep() { :; }",
+    extractShellFn(INSTALL_SH, "step_validate_services"),
+    "step_validate_services",
+  ].join("\n");
+
+  const r = runShellProgram(program, { TTS_STATUS_FILE: ttsStatus });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe.skipIf(!hasBash)("service validation treats an unreadable verdict as no verdict", () => {
+  it("FAILS a verdict outside the vocabulary rather than falling through to a pass", () => {
+    // A truncated write (tts_status_publish truncates with `>` rather than
+    // writing-then-renaming, so a box that lost power mid-publish leaves one)
+    // or a plain typo. The chain had no arm for it, so it passed — while the
+    // strictly less informative ABSENT verdict correctly failed.
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=redy\n");
+    expect(res.status, `an unparseable verdict scored a pass:\n${res.out}`).not.toBe(0);
+    expect(res.out).toMatch(/unrecognised/i);
+  });
+
+  it("reads a CRLF verdict rather than mistaking a ready engine for a mute box", () => {
+    // A file edited on Windows or restored from a tarball ends the verdict as
+    // `ready\r`, which is not `ready`. With Kokoro ready and Piper failed that
+    // put "this box has NO working TTS engine" over a box whose GPU engine is
+    // running — a failure report over something that succeeded.
+    const res = runValidator("KOKORO=ready\r\nPIPER=failed:download\r\n");
+    expect(res.out, `a CRLF file was misread as a mute box:\n${res.out}`).not.toMatch(/NO working TTS engine/);
+    // Still a failure — the fallback really is gone — just the honest one.
+    expect(res.status, res.out).not.toBe(0);
+    expect(res.out).toMatch(/Piper CPU fallback was requested and did NOT install/);
+  });
+
+  it("still passes a box whose engines both reported ready", () => {
+    // The reason the guard is an `elif` and not the trailing `else` the report
+    // suggested: the chain's fall-through is where the HEALTHY box lands, so an
+    // unconditional `else` would fail every good box on the shelf.
+    const res = runValidator("KOKORO=ready\nPIPER=ready\n");
+    expect(res.status, `a healthy box was failed by the new guard:\n${res.out}`).toBe(0);
+  });
+
+  it("still passes a board that runs neither engine by design", () => {
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=skipped:arch-x86_64\n");
+    expect(res.status, res.out).toBe(0);
+  });
+});
+
+// ── 4. The update path is the second caller of step_openclaw_tts ────────────
+
+/**
+ * Run the real step_post_update with every step it calls stubbed to a no-op
+ * except step_openclaw_tts, whose exit code the test picks. What is under test
+ * is the sentence the update path prints about a box's speech.
+ */
+function runPostUpdate(ttsExit: number) {
+  const body = extractShellFn(INSTALL_SH, "step_post_update");
+  const called = new Set(body.match(/\bstep_[a-z_]+/g) ?? []);
+  called.delete("step_post_update");
+  called.delete("step_openclaw_tts");
+
+  const program = [
+    "set -uo pipefail",
+    ...[...called].map((fn) => `${fn}() { :; }`),
+    `step_openclaw_tts() { return ${ttsExit}; }`,
+    body,
+    "step_post_update",
+    'echo "POST_RC=$?"',
+  ].join("\n");
+
+  const res = runShellProgram(program, {});
+  const out = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+  return { out, postRc: /POST_RC=(\d+)/.exec(out)?.[1] ?? "" };
+}
+
+describe.skipIf(!hasBash)("step_post_update keeps the three TTS facts apart", () => {
+  it("says a mute box is mute instead of 'openclaw_tts step failed (non-fatal)'", () => {
+    // The dominant residual shape: the FIRST caller (step_openclaw_setup) was
+    // given a tolerance table with a distinct sentence for 12, 13 and 14; the
+    // second was left with one `|| echo` indistinguishable from the fourteen
+    // around it — on the path that reaches already-shipped boxes.
+    const res = runPostUpdate(13);
+    expect(res.out, `a mute box was reported like a skipped VNC refresh:\n${res.out}`).toMatch(/SILENCE/);
+  });
+
+  it("does not call a degraded box mute, or a mute box degraded", () => {
+    const degraded = runPostUpdate(14);
+    const kokoroGone = runPostUpdate(12);
+    expect(degraded.out).not.toMatch(/SILENCE/);
+    expect(kokoroGone.out).not.toMatch(/SILENCE/);
+    expect(kokoroGone.out).toMatch(/Kokoro/);
+  });
+
+  it("names an out-of-contract status instead of swallowing it", () => {
+    const res = runPostUpdate(99);
+    expect(res.out, `an unknown TTS status was laundered into the generic warning:\n${res.out}`).toMatch(
+      /not in its contract/,
+    );
+  });
+
+  it("stays non-fatal — an update whose TTS step failed still finishes", () => {
+    // A box that cannot speak must still complete its update and come up
+    // reachable; the verdict travels in the marker, not by aborting the run.
+    expect(runPostUpdate(13).postRc).toBe("0");
+  });
+});
+
+// ── 5. A dispatched step's recorded failures must reach the marker ──────────
+
+/** The real `--step` dispatch block, lifted out of install.sh. */
+function extractDispatchBlock(): string {
+  const start = INSTALL_SH.indexOf('if [ "${1:-}" = "--step" ]; then');
+  if (start < 0) throw new Error("the --step dispatch block is not in install.sh");
+  const end = INSTALL_SH.indexOf("\nfi\n", start);
+  if (end < 0) throw new Error("the --step dispatch block has no closing fi");
+  return INSTALL_SH.slice(start, end + 4);
+}
+
+/**
+ * Run the real dispatch block against a stub step that RECORDS a provisioning
+ * failure and then returns 0 — which is exactly what step_post_update does
+ * when its TTS step reports 13.
+ */
+function runDispatch(
+  // Returns 0 the way the real step_post_update does — every fixup inside it is
+  // `|| warn` — while having recorded a failure its caller must not lose.
+  stepBody = 'record_provision_failure openclaw_tts; echo "  Warning: TTS reported 13"; return 0',
+) {
+  const marker = path.join(root, "provision-status");
+  const program = [
+    "set -euo pipefail",
+    'PROJECT_DIR="/home/clawbox/clawbox"',
+    "PROVISION_FAILURES=()",
+    'PROVISION_RUN_ID="test-run"',
+    'record_provision_failure() { PROVISION_FAILURES+=("$1"); }',
+    `write_provision_status() { printf 'STATUS=%s\\nFAILED=%s\\n' "$1" "\${2:-}" > "${marker}"; }`,
+    "DISPATCH_STEPS=(post_update)",
+    `step_post_update() { ${stepBody}; }`,
+    extractDispatchBlock(),
+    'echo "DISPATCH_FELL_THROUGH"',
+  ].join("\n");
+
+  const res = runShellProgram(program, {}, ["--step", "post_update"]);
+  return {
+    status: res.status,
+    out: `${res.stdout ?? ""}${res.stderr ?? ""}`,
+    marker: existsSync(marker) ? readFileSync(marker, "utf-8") : "",
+  };
+}
+
+describe.skipIf(!hasBash)("--step dispatch carries the verdict its step recorded", () => {
+  it("does not exit 0 over a step that recorded a provisioning failure", () => {
+    // `"step_${local_step}"; exit 0` discarded the record_provision_failure
+    // #519 added, so an in-app update that left the box with no TTS engine
+    // reported a successful update.
+    const res = runDispatch();
+    expect(res.status, `a recorded provisioning failure exited 0:\n${res.out}`).not.toBe(0);
+  });
+
+  it("writes the incomplete verdict to the marker the flash host reads", () => {
+    const res = runDispatch();
+    expect(res.marker, `nothing was published for a failed step:\n${res.out}`).toContain("STATUS=incomplete");
+    expect(res.marker).toContain("openclaw_tts");
+  });
+
+  it("prints the same stdout sentinel the full install prints", () => {
+    const res = runDispatch();
+    expect(res.out).toContain("[provision-status] INCOMPLETE");
+    expect(res.out).toContain("[provision-run] ");
+  });
+
+  it("leaves a clean dispatched step exactly as it was — exit 0, no marker", () => {
+    // The over-correction guard, and the reason success publishes NOTHING: one
+    // dispatched step finishing cleanly is not evidence that the whole box
+    // provisioned, so writing `ok` here would let a single `--step` run mint
+    // the healthy verdict the flash host reads.
+    const res = runDispatch('echo "  all good"; return 0');
+    expect(res.status, `a clean step was failed by the new verdict block:\n${res.out}`).toBe(0);
+    expect(res.marker).toBe("");
+  });
+
+  it("still exits with a failing step's own status", () => {
+    // The trap must report the step, not replace it: a dispatched step that
+    // dies keeps its exit code, which is what the updater and the operator
+    // read.
+    const res = runDispatch("return 7");
+    expect(res.status, res.out).toBe(7);
+  });
+});

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -356,6 +356,28 @@ describe.skipIf(!hasBash)("service validation treats an unreadable verdict as no
     expect(res.out).toMatch(/unrecognised/i);
   });
 
+  it("does not read an engine state out of a verdict it could not parse", () => {
+    // A malformed verdict next to a failed sibling. "This box has NO working
+    // TTS engine" is a claim about a GPU engine that may be running perfectly,
+    // so the unreadable arm has to come first — reporting a failure over
+    // something that succeeded is the same defect one register down.
+    const res = runValidator("KOKORO=redy\nPIPER=failed:download\n");
+    expect(res.status, res.out).not.toBe(0);
+    expect(res.out).toMatch(/unrecognised/i);
+    expect(res.out, `a garbled Kokoro verdict was read as a mute box:\n${res.out}`).not.toMatch(
+      /NO working TTS engine/,
+    );
+  });
+
+  it("does not accept a skip with its reason truncated away", () => {
+    // `skipped:` matches `skipped:*` in bash, so a torn write could still be
+    // read as a legitimate board decline. A claim whose reason is cut off is
+    // not evidence for the claim.
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=skipped:\n");
+    expect(res.status, `a reasonless skip passed as a board decline:\n${res.out}`).not.toBe(0);
+    expect(res.out).toMatch(/unrecognised/i);
+  });
+
   it("reads a CRLF verdict rather than mistaking a ready engine for a mute box", () => {
     // A file edited on Windows or restored from a tarball ends the verdict as
     // `ready\r`, which is not `ready`. With Kokoro ready and Piper failed that

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -515,6 +515,16 @@ describe.skipIf(!hasBash)("--step dispatch carries the verdict its step recorded
     expect(res.marker).toBe("");
   });
 
+  it("keeps a recorded failure AND the step's own status together", () => {
+    // `sudo bash install.sh --step openclaw_tts` is the repair command every
+    // TTS failure message prints. The step both records and returns 13, and
+    // the operator needs each half: the marker for the dashboard, the exit
+    // code for whatever ran the command.
+    const res = runDispatch("record_provision_failure openclaw_tts; return 13");
+    expect(res.status, res.out).toBe(13);
+    expect(res.marker).toContain("STATUS=incomplete");
+  });
+
   it("still exits with a failing step's own status", () => {
     // The trap must report the step, not replace it: a dispatched step that
     // dies keeps its exit code, which is what the updater and the operator


### PR DESCRIPTION
Follow-up to #519. Two independent adversarial verifiers came back with the same shape: **the core fix is real, but a sibling call site was left unguarded.** This closes all four named residuals plus the third sibling the class grep turned up.

## RES-519-A — `--piper-only` reported success from a return code (medium)

`scripts/install-voice.sh` line 747. `install_piper` returns **0** for "there is no pinned artifact for this board" — that is the whole reason #519 taught `--tts-only` to read `TTS_PIPER_VERDICT` instead. `--piper-only` still did `install_piper || PIPER_ONLY_RC=1` and never looked at the verdict, so on a non-aarch64 board `install_piper_engine` took its `return 0` skip path, published `PIPER=skipped:arch-<arch>`, and the mode printed `=== Piper fallback ready ===` and exited 0 with **no engine installed** — in the mode `scripts/openclaw/clawbox-tts.sh:596` tells operators to run when it reports "Piper not installed".

It now decides the way `--tts-only` does: `ready` announces the fallback, `skipped:*` prints "no Piper artifact applies to this board" and exits 0 (the board declines — nothing was asked for and nothing is missing, the same rule `skipped:*` carries everywhere else), and `failed:*` / unreported / anything unparseable exits 1. The `PIPER_ONLY_RC` check stays in front of it, so a `deploy_voice_scripts` failure behind a ready engine still fails as before.

## RES-519-B — `VOICE_RC=11` was told it has a Piper fallback (low)

`install.sh` line 2794 bucketed `10|11|12` and printed `On-device TTS configured (Piper CPU only — …)`. 11 is `install_kokoro_tts`'s "no Jetson CUDA build for `$arch`" — i.e. `uname -m != aarch64`, which is **exactly** the condition under which `install_piper_engine` skips too. Both halves publish `skipped:arch-*`, `--tts-only` correctly prints "=== No on-device TTS engine applies to this board ===" and exits 11, and install.sh then named a fallback that does not exist one line later.

11 gets its own branch. 10 and 12 are genuinely Piper-backed — a Piper failure with Kokoro ready exits 1, with Kokoro failed exits 13 — so they keep the "Piper CPU only" line, and a test pins that. 11 stays a **clean** provision (no `record_provision_failure`, no probe failure): a board neither engine ships for is the case `skipped:*` was defined for, and failing every `install-x64.sh` run would only teach everyone to ignore the check. The stale "10 / 11 … the box speaks on Piper" contract comment in install-voice.sh is corrected with it.

## RES-519-C — the probe scored garbage above silence (low)

`install.sh` line 4911. The chain fails on empty, on `failed:*` and on "neither ready and one failed", but a non-empty value in none of those shapes matched no arm and scored a **silent pass** — so `PIPER=redy` passed while the strictly less informative `PIPER=` correctly failed. Reachable for real: `tts_status_publish` truncates with `>` rather than write-then-rename, so a box that lost power mid-publish can leave a torn value.

**Deviation from the proposed fix, deliberately:** the report suggested closing the chain with a trailing `else`. That would fail every healthy box — `KOKORO=ready` + `PIPER=ready` matches none of the arms either; the fall-through is where the good box lands. So the guard is a final `elif` on an explicit "outside the vocabulary" flag, placed last so the more specific arms above still win (a garbled Piper verdict next to a failed Kokoro is still best reported as "no working engine"). A test pins the healthy box passing.

Both readers of the file (`install.sh:4874-4875`, `install-voice.sh:550-551`) now strip CR. Without it a CRLF `KOKORO=ready` + `PIPER=failed:*` reported **"this box has NO working TTS engine"** over a box whose GPU engine is running — a failure report over something that succeeded.

## RES-519-D — the update path threw the verdict away (medium, customer-facing)

`install.sh` line 3512. #519 rewrote the first caller (`step_openclaw_setup`) with a tolerance table that keeps 12, 13 and 14 apart on purpose. The second caller was still `step_openclaw_tts || echo "  Warning: openclaw_tts step failed (non-fatal)"` — one line indistinguishable from the fourteen `|| echo` lines around it, reporting "this box answers speech with SILENCE" in the same words as a skipped VNC refresh. It now carries the same table, with `*)` naming an out-of-contract code.

And the record: `--step` dispatch ran `"step_${local_step}"; exit 0`, so the `record_provision_failure` #519 added inside `step_openclaw_tts` never reached the `PROVISION_FAILURES` summary or `write_provision_status` (install.sh:5268-5306) — an in-app update that left a shipped aarch64 box mute finished as a **successful update**. The dispatch block now publishes the verdict.

Implementation notes worth reviewing:

- An **EXIT trap**, not `"step_x" || rc=$?`. The OR-list form switches `set -e` off for the whole body of the dispatched step, so every guard inside it that relies on errexit to stop would run on instead. The trap also catches a step that dies mid-way, which previously reported nothing at all.
- Only `incomplete` is ever written there. One dispatched step finishing cleanly is not evidence that the whole box provisioned, so a clean run publishes nothing and leaves the marker to the full install that owns it. A test pins exit 0 + no marker for a clean step, and a failing step keeping its own exit code.

## Fixing the class, and how I know I found every sibling

The class is *"a caller that reports from the return code rather than from the published verdict."* Two greps, both run against the merged head:

```
rg -n 'install_piper\b'      # -> defn 263, and callers 678 (--tts-only), 747 (--piper-only), 870 (full pipeline)
rg -n 'step_openclaw_tts'    # -> defn 2584, callers 1643 (step_openclaw_setup), 3512 (step_post_update), + the dispatch whitelist
```

`install_piper` has **three** callers, not two. The third — the full-pipeline path at line 870 — was the least honest of them: it printed `TTS: Kokoro-82M …, Piper CPU fallback` unconditionally, on the x86 runs where the engine declines and on the runs where its download failed. Its summary now names the engine from `TTS_PIPER_VERDICT` too. Its exit contract is deliberately unchanged; only the claim it makes is.

A third grep covers the verdict readers, so the CR fix is complete rather than half-applied:

```
rg -n 'TTS_STATUS_FILE|tts-status'   # -> exactly two parsers: install.sh:4874-4875, install-voice.sh:550-551
```

## Tests — red first

New file `src/tests/unit/install-tts-verdict-siblings.test.ts`, 21 tests, executing the shipped artifacts against stubs like the #519 suite next to it (the real `--piper-only` dispatch, the real `step_openclaw_tts`, the real `step_validate_services`, the real `step_post_update`, and the real `--step` dispatch block lifted out of install.sh).

- Against **unmodified `origin/beta`** (4709b4f2, sources stashed, test file in place): **10 failed / 11 passed**.
- With the fix: **21 passed**.
- `install-tts-no-engine.test.ts` (#519's own suite): 23/23 still green.
- `install-provision-status-marker`, `install-post-update-units`, `root-steps`, `observability-install`, `desktop-power-wiring`: 55 passed / 8 skipped, unchanged.

The 11 that pass red are the over-correction guards, and they are the point of half of this diff: a healthy box still passes the probe, a board that declines both engines still provisions clean, 10 and 12 still name Piper, a clean dispatched step still exits 0 and writes no marker.

`bash -n` clean on both scripts. `tsc`: 24 pre-existing errors before and after, none from the new file. `eslint` clean on the new file. (`clawbox-tts.test.ts` and `install-kokoro-tts.test.ts` fail identically with and without this change on the Windows dev host — spawn-path artifacts, 46/23 and 37/9 both sides; Linux CI is the gate.)

## Honest severity

A, B and C are all gated on `uname -m != aarch64`, and shipped ClawBox hardware **is** aarch64, so none of them can mute a Jetson today. D is reachable on shipped hardware: `KOKORO_STAMP_VERSION` was bumped to 2 to force every already-stamped box to redo the Kokoro install, so a flaky network during that redo gives `KOKORO=failed:torch`, and a box whose `$PIPER_DIR/piper` is missing then gives exit 13 rather than 12.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved voice-engine installation reporting for unsupported architectures and unavailable engines.
  - Correctly distinguishes ready, skipped, failed, missing, and invalid text-to-speech statuses.
  - Provides accurate Piper fallback summaries instead of incorrectly reporting availability.
  - Reports post-update speech failures individually without interrupting the remaining update process.
  - Installer failures now return appropriate error statuses and clearly mark incomplete provisioning.

- **Tests**
  - Added comprehensive coverage for voice-engine verdicts, installation outcomes, updates, and status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->