### PR TITLE
fix: verify the sudoers declarations instead of trusting them

### DIFF
--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -27,6 +27,15 @@ jobs:
       - name: Install
         run: bun install --frozen-lockfile
 
+      # Explicit, and first: the sudoers allow-list is a privilege boundary, and
+      # until now this check only reached CI as a side effect of one vitest case
+      # (src/tests/unit/sudoers-coverage.test.ts, which skips itself off Linux).
+      # A change to the vitest config or a rename of that file would have taken
+      # the guard off the build without anything saying so. It runs in seconds,
+      # so it also fails fast rather than after the whole suite.
+      - name: Sudoers allow-list coverage
+        run: bun run check:sudoers
+
       - name: Test
         run: bun run test:coverage
 

--- a/scripts/check-sudoers-coverage.sh
+++ b/scripts/check-sudoers-coverage.sh
@@ -453,6 +453,52 @@ sub symbol_definition {
   return (undef, undef);
 }
 
+# The text of every `return …;` in a function body. Quotes and brackets are
+# respected so a `;` inside a string or a nested literal does not end the
+# expression early.
+sub return_expressions {
+  my ($body) = @_;
+  my @out;
+  my ($i, $n) = (0, length $body);
+  while ($i < $n) {
+    my $ch = substr($body, $i, 1);
+    if ($ch eq '"' || $ch eq "'" || $ch eq '`') {
+      my $q = $ch;
+      $i++;
+      # ord(), not a backslash literal: this file is a shell heredoc wrapping a
+      # perl script, and a lone `\` in it has three layers to survive.
+      while ($i < $n) { my $c = substr($body, $i, 1); $i++; last if $c eq $q; $i++ if ord($c) == 92 }
+      next;
+    }
+    if (substr($body, $i, 6) eq 'return'
+        && ($i == 0 || substr($body, $i - 1, 1) !~ /[A-Za-z0-9_\$]/)
+        && ($i + 6 >= $n || substr($body, $i + 6, 1) !~ /[A-Za-z0-9_\$]/)) {
+      my $j = $i + 6;
+      my $start = $j;
+      my $depth = 0;
+      while ($j < $n) {
+        my $c = substr($body, $j, 1);
+        if ($c eq '"' || $c eq "'" || $c eq '`') {
+          my $q = $c;
+          $j++;
+          while ($j < $n) { my $d = substr($body, $j, 1); $j++; last if $d eq $q; $j++ if ord($d) == 92 }
+          next;
+        }
+        $depth++ if $c =~ /[\(\[\{]/;
+        $depth-- if $c =~ /[\)\]\}]/;
+        last if $depth < 0;
+        last if $c eq ';' && $depth == 0;
+        $j++;
+      }
+      push @out, substr($body, $start, $j - $start);
+      $i = $j + 1;
+      next;
+    }
+    $i++;
+  }
+  return @out;
+}
+
 sub unquote {
   my ($s) = @_;
   return $1 if $s =~ /^"([^"\\]*)"$/;
@@ -483,16 +529,31 @@ sub resolve_symbol_values {
     }
     push @groups, \@items;
   } else {
-    # A function: the union of every array literal in its body. Restricted to
-    # array literals on purpose — harvesting every string in the body would
-    # collect the operands of `edition === "hermes"` as if they were units.
-    my ($i, $n) = (0, length $body);
-    while ($i < $n) {
-      if (substr($body, $i, 1) eq '[') {
-        my $g = balanced_group(substr($body, $i), '[', ']');
-        if (defined $g) { push @groups, [split_argv_items($g)]; $i += length($g) + 2; next }
+    # A function: the array literals in its RETURN expressions, and nothing
+    # else. Two narrowings, both deliberate:
+    #
+    #   * array literals only, not every string. Harvesting the whole body
+    #     would collect the operands of `edition === "hermes"` as if they were
+    #     unit names.
+    #   * return expressions only. An unrelated array elsewhere in the body —
+    #     a validation list, an error message built from a template literal —
+    #     would otherwise be demanded as a privileged argument, and the cheapest
+    #     way to silence that is to ADD a grant for it. A check that pushes the
+    #     next author towards widening the allow-list is worse than no check.
+    #
+    # A helper whose return is not a literal array contributes nothing and
+    # fails the "yielded no values" test below, which is the fail-closed
+    # answer: point `resolve` at the symbol that holds the values, or say in
+    # `unverified` why it cannot be resolved.
+    for my $expr (return_expressions($body)) {
+      my ($i, $n) = (0, length $expr);
+      while ($i < $n) {
+        if (substr($expr, $i, 1) eq '[') {
+          my $g = balanced_group(substr($expr, $i), '[', ']');
+          if (defined $g) { push @groups, [split_argv_items($g)]; $i += length($g) + 2; next }
+        }
+        $i++;
       }
-      $i++;
     }
   }
 

--- a/scripts/check-sudoers-coverage.sh
+++ b/scripts/check-sudoers-coverage.sh
@@ -20,6 +20,22 @@
 #     twin of a grant that IS invoked (see the header of config/clawbox-sudoers
 #     for why both spellings are shipped) or is acknowledged in
 #     ACKNOWLEDGED_UNUSED with a reason.
+#   * A DECLARED_ARGV entry is VERIFIED against the code, not trusted. Every
+#     dynamic argument in the declared call has to name the symbol its values
+#     come from; that symbol is re-resolved on every run and the declaration
+#     fails the build the moment the two disagree. An argument that genuinely
+#     cannot be resolved goes in `unverified` with a reason, and is reviewed
+#     like a grant.
+#   * A DECLARED_ARGV or EXEMPT_CALLS entry that matches nothing is an ERROR.
+#     A reviewed decision must not outlive the call site it was made about.
+#
+# The third rule is not theoretical. `for (const svc of
+# restartServicesFor(getEdition()))` in the ClawKeep restore route kept its
+# source text byte-for-byte while the helper behind it grew a Hermes branch
+# restarting clawbox-hermes-dashboard.service. The hand-written declaration
+# still said the site only ever restarts clawbox-gateway.service, so this check
+# reported "0 gaps" — and the owner's restore on a real Hermes box put every
+# file back and then could not restart the dashboard.
 #
 # It also enforces two SHAPE invariants on the allow-list itself, because
 # coverage alone does not make a grant safe (TASK-445 audit, GAP 2 and GAP 3):
@@ -138,49 +154,93 @@ my %SCAN_SKIP_FILE = ('scripts/check-sudoers-coverage.sh' => 1);
 
 # ── Call sites whose argv is not a literal array ────────────────────────────
 # Key   = "<repo-relative path> :: <argv source text, whitespace-collapsed>"
-# Value = the concrete argument lists that call site can produce.
+# Value = { argv => [...], resolve => {...}, unverified => {...} }
 #
-# Keying on the source text rather than a line number means unrelated edits
-# above the call do not invalidate the declaration, but editing the CALL does:
-# the key stops matching, the site becomes unresolved, and this check fails.
-# That is the point — a new dynamic argument gets re-reviewed as a privilege
-# boundary instead of inheriting someone else's review.
+#   argv       the concrete argument lists this call site can produce.
+#   resolve    { <dynamic item> => <symbol> | [<symbol>, ...] }. The symbol is
+#              RE-RESOLVED out of the file on every run and `argv` is checked
+#              against it, so the declaration is verified rather than trusted.
+#   unverified { <dynamic item> => 'why the resolver cannot see it' }. Reviewed
+#              like a grant, because nothing else is checking it.
+#
+# Keying on the source text means unrelated edits above the call do not
+# invalidate the declaration, but editing the CALL does: the key stops matching,
+# the site becomes unresolved, and this check fails.
+#
+# THAT WAS NOT ENOUGH, and the gap it left shipped. When a call takes its
+# argument from a helper — `for (const svc of restartServicesFor(getEdition()))`
+# — the helper can grow a whole new unit without the call text changing by a
+# byte. The hand-written `argv` below then quietly stops being the truth: the
+# declaration said the site only ever restarts `clawbox-gateway.service`, the
+# code had grown a Hermes branch restarting `clawbox-hermes-dashboard.service`,
+# and this check reported "0 gaps" while that restart failed on every Hermes
+# device it ran on.
+#
+# So the source text is no longer the only thing pinned. Every non-literal item
+# in the key must be listed in `resolve` (verified against the code) or in
+# `unverified` (with a reason). An item in neither is a hard failure, a
+# `resolve` whose value set no longer matches `argv` is a hard failure, and a
+# declaration whose call site has disappeared is a hard failure too — a stale
+# declaration is how a reviewed decision outlives the code it was about.
 my %DECLARED_ARGV = (
   # src/lib/system-profile.ts — runScript() builds cmd = useSudo ? "sudo" :
   # script and argv = [script, ...args]. The two scripts do NOT share modes, so
   # this is enumerated per script rather than as a cartesian product; --check is
   # absent because the status path runs it without sudo.
-  'src/lib/system-profile.ts :: cmd, argv' => [
-    ['sudo', '/usr/local/libexec/clawbox/clawbox-desktop-mode.sh', '--enable'],
-    ['sudo', '/usr/local/libexec/clawbox/clawbox-desktop-mode.sh', '--disable'],
-    ['sudo', '/usr/local/libexec/clawbox/clawbox-power-mode.sh', '--balanced'],
-    ['sudo', '/usr/local/libexec/clawbox/clawbox-power-mode.sh', '--performance'],
-  ],
+  'src/lib/system-profile.ts :: cmd, argv' => {
+    argv => [
+      ['sudo', '/usr/local/libexec/clawbox/clawbox-desktop-mode.sh', '--enable'],
+      ['sudo', '/usr/local/libexec/clawbox/clawbox-desktop-mode.sh', '--disable'],
+      ['sudo', '/usr/local/libexec/clawbox/clawbox-power-mode.sh', '--balanced'],
+      ['sudo', '/usr/local/libexec/clawbox/clawbox-power-mode.sh', '--performance'],
+    ],
+    unverified => {
+      cmd  => 'runScript() sets cmd = useSudo ? "sudo" : script — a branch on its own '
+            . 'parameter, not a value set anything can enumerate from the file.',
+      argv => 'argv = [script, ...args], assembled from runScript()\'s parameters at each '
+            . 'call site rather than from a table. The four lists above are every MUTATING '
+            . 'caller; the --check modes are absent because the status path runs them with '
+            . 'no sudo at all.',
+    },
+  },
   # src/lib/local-models.ts — verb is enable|disable; unit is constrained to
   # SYSTEM_UNITS by the `allowed.has(unit)` guard immediately above the call.
-  'src/lib/local-models.ts :: "/usr/bin/systemctl", verb, "--now", unit' => [
-    ['/usr/bin/systemctl', 'enable', '--now', 'ollama.service'],
-    ['/usr/bin/systemctl', 'disable', '--now', 'ollama.service'],
-  ],
+  'src/lib/local-models.ts :: "/usr/bin/systemctl", verb, "--now", unit' => {
+    argv => [
+      ['/usr/bin/systemctl', 'enable', '--now', 'ollama.service'],
+      ['/usr/bin/systemctl', 'disable', '--now', 'ollama.service'],
+    ],
+    resolve    => { unit => 'SYSTEM_UNITS' },
+    unverified => {
+      verb => 'enable|disable, chosen from a boolean by the caller. A parameter, not a '
+            . 'table — but it can only ever be one of those two spellings, and both are '
+            . 'enumerated above.',
+    },
+  },
   # src/lib/local-ai-runtime.ts — systemctlOllama() is private to the module and
   # every caller passes one of the three module-level const argv arrays declared
-  # right above it, each already a literal list. Enumerated here rather than
-  # resolved because the call spreads them (`["-n", ...argv]`).
-  'src/lib/local-ai-runtime.ts :: "-n", ...argv' => [
-    ['-n', '/usr/bin/systemctl', 'enable', '--now', 'ollama.service'],
-    ['-n', '/usr/bin/systemctl', 'start', 'ollama.service'],
-    ['-n', '/usr/bin/systemctl', 'stop', 'ollama.service'],
-  ],
+  # right above it. The CONTENTS of those three arrays are re-resolved on every
+  # run, so a `--now` or a unit rename inside one fails this check instead of
+  # failing on a device.
+  'src/lib/local-ai-runtime.ts :: "-n", ...argv' => {
+    argv => [
+      ['-n', '/usr/bin/systemctl', 'enable', '--now', 'ollama.service'],
+      ['-n', '/usr/bin/systemctl', 'start', 'ollama.service'],
+      ['-n', '/usr/bin/systemctl', 'stop', 'ollama.service'],
+    ],
+    resolve => {
+      '...argv' => ['OLLAMA_ENABLE_NOW_ARGV', 'OLLAMA_START_ARGV', 'OLLAMA_STOP_ARGV'],
+    },
+  },
   # src/app/setup-api/system/power/route.ts — POWER_ACTIONS maps the request
   # body to exactly these two; an unmapped action 400s before the call.
-  'src/app/setup-api/system/power/route.ts :: "/usr/bin/systemctl", systemctlAction' => [
-    ['/usr/bin/systemctl', 'poweroff'],
-    ['/usr/bin/systemctl', 'reboot'],
-  ],
-  # src/app/setup-api/clawkeep/restore/route.ts — svc iterates RESTART_SERVICES.
-  'src/app/setup-api/clawkeep/restore/route.ts :: "/usr/bin/systemctl", "restart", svc' => [
-    ['/usr/bin/systemctl', 'restart', 'clawbox-gateway.service'],
-  ],
+  'src/app/setup-api/system/power/route.ts :: "/usr/bin/systemctl", systemctlAction' => {
+    argv => [
+      ['/usr/bin/systemctl', 'poweroff'],
+      ['/usr/bin/systemctl', 'reboot'],
+    ],
+    resolve => { systemctlAction => 'POWER_ACTIONS' },
+  },
 );
 
 # ── Sudo calls that are deliberately NOT in the allow-list ──────────────────
@@ -301,12 +361,306 @@ sub local_consts {
   return \%c;
 }
 
+# ── Verifying a declaration against the code it describes ───────────────────
+#
+# A DECLARED_ARGV entry is a hand-written claim about what a call site can
+# produce, and an unchecked claim rots the moment its producer changes. That is
+# not hypothetical: the ClawKeep restore declaration kept saying
+# "clawbox-gateway.service" long after the route had grown a Hermes branch
+# restarting clawbox-hermes-dashboard.service, and this check reported "0 gaps"
+# while that restart failed on every Hermes device.
+#
+# Everything below re-derives the claim from the source on every run, so the
+# claim fails the build instead of the device.
+
+my (%DECL_USED, %DECL_VERIFIED, %EXEMPT_USED);
+
+# Comments come out before any symbol lookup: an apostrophe in prose would
+# otherwise open a "string" and swallow the brace matching below.
+sub strip_ts_comments {
+  my ($src) = @_;
+  my ($out, $i, $n) = ('', 0, length $src);
+  while ($i < $n) {
+    my $two = substr($src, $i, 2);
+    if ($two eq '//') { $i += 2; $i++ while $i < $n && substr($src, $i, 1) ne "\n"; next }
+    if ($two eq '/*') { $i += 2; $i++ while $i < $n && substr($src, $i, 2) ne '*/'; $i += 2; next }
+    my $ch = substr($src, $i, 1);
+    if ($ch eq '"' || $ch eq "'" || $ch eq '`') {
+      my $q = $ch;
+      $out .= $ch;
+      $i++;
+      while ($i < $n) {
+        my $c = substr($src, $i, 1);
+        $out .= $c;
+        $i++;
+        last if $c eq $q;
+        if ($c eq '\\' && $i < $n) { $out .= substr($src, $i, 1); $i++ }
+      }
+      next;
+    }
+    $out .= $ch;
+    $i++;
+  }
+  return $out;
+}
+
+# The inner text of the balanced group $text starts with, quotes respected.
+sub balanced_group {
+  my ($text, $open, $close) = @_;
+  return undef unless length($text) && substr($text, 0, 1) eq $open;
+  my ($depth, $i, $n) = (0, 0, length $text);
+  while ($i < $n) {
+    my $ch = substr($text, $i, 1);
+    if ($ch eq '"' || $ch eq "'" || $ch eq '`') {
+      my $q = $ch;
+      $i++;
+      while ($i < $n) {
+        my $c = substr($text, $i, 1);
+        $i++;
+        last if $c eq $q;
+        $i++ if $c eq '\\';
+      }
+      next;
+    }
+    if ($ch eq $open) { $depth++ }
+    elsif ($ch eq $close) {
+      $depth--;
+      return substr($text, 1, $i - 1) if $depth == 0;
+    }
+    $i++;
+  }
+  return undef;
+}
+
+# Where a symbol's values live: ('array'|'object'|'function', the inner text).
+sub symbol_definition {
+  my ($src, $name) = @_;
+  if ($src =~ /(?:^|[^A-Za-z0-9_\$])(?:export\s+)?(?:const|let|var)\s+\Q$name\E\s*(?::[^=\n]*)?=\s*/g) {
+    my $rest = substr($src, pos($src));
+    $rest =~ s/^new\s+(?:Set|Map)\s*\(\s*//;
+    return ('array',  balanced_group($rest, '[', ']')) if substr($rest, 0, 1) eq '[';
+    return ('object', balanced_group($rest, '{', '}')) if substr($rest, 0, 1) eq '{';
+    return ('opaque', undef);
+  }
+  if ($src =~ /(?:^|[^A-Za-z0-9_\$])(?:export\s+)?(?:async\s+)?function\s+\Q$name\E\s*(?=\()/g) {
+    my $rest = substr($src, pos($src));
+    my $params = balanced_group($rest, '(', ')');
+    return ('opaque', undef) unless defined $params;
+    my $after = substr($rest, length($params) + 2);
+    $after =~ s/^[^{]*//s;
+    return ('function', balanced_group($after, '{', '}'));
+  }
+  return (undef, undef);
+}
+
+sub unquote {
+  my ($s) = @_;
+  return $1 if $s =~ /^"([^"\\]*)"$/;
+  return $1 if $s =~ /^'([^'\\]*)'$/;
+  return $1 if $s =~ /^`([^`\\\$]*)`$/;
+  return undef;
+}
+
+# Every value a symbol can contribute.
+#   want 'scalar' -> one [value] per array element / Set member / map value
+#   want 'list'   -> one arrayref per array literal, kept whole (for a spread)
+sub resolve_symbol_values {
+  my ($key, $rel, $clean, $consts, $name, $want) = @_;
+  my ($kind, $body) = symbol_definition($clean, $name);
+  fatal("DECLARED_ARGV{$key}\n"
+      . "  `resolve` names `$name`, which $rel does not define as a const array, Set, object\n"
+      . "  literal or function. Point it at the symbol that really holds the values, or move\n"
+      . "  the argument to `unverified` with the reason it cannot be resolved.\n")
+    unless defined $kind && $kind ne 'opaque' && defined $body;
+
+  my @groups;
+  if ($kind eq 'array') {
+    push @groups, [split_argv_items($body)];
+  } elsif ($kind eq 'object') {
+    my @items;
+    while ($body =~ /(?:^|[,{])\s*(?:"[^"]*"|'[^']*'|\[[^\]]*\]|[A-Za-z_\$][A-Za-z0-9_\$]*)\s*:\s*("[^"\\]*"|'[^'\\]*'|[A-Za-z_\$][A-Za-z0-9_\$]*)/g) {
+      push @items, $1;
+    }
+    push @groups, \@items;
+  } else {
+    # A function: the union of every array literal in its body. Restricted to
+    # array literals on purpose — harvesting every string in the body would
+    # collect the operands of `edition === "hermes"` as if they were units.
+    my ($i, $n) = (0, length $body);
+    while ($i < $n) {
+      if (substr($body, $i, 1) eq '[') {
+        my $g = balanced_group(substr($body, $i), '[', ']');
+        if (defined $g) { push @groups, [split_argv_items($g)]; $i += length($g) + 2; next }
+      }
+      $i++;
+    }
+  }
+
+  my @out;
+  for my $g (@groups) {
+    next unless @$g;
+    my ($argv, $why) = resolve_items($rel, $consts, $g);
+    fatal("DECLARED_ARGV{$key}\n"
+        . "  cannot read the values of `$name` in $rel: $why.\n"
+        . "  Give it string literals or string constants, or move the argument to\n"
+        . "  `unverified` with a reason.\n")
+      unless $argv;
+    if ($want eq 'list') { push @out, $argv }
+    else { push @out, map { [$_] } @$argv }
+  }
+  fatal("DECLARED_ARGV{$key}\n"
+      . "  `$name` in $rel yielded no values at all, so nothing was verified. A declaration\n"
+      . "  that silently checks nothing is the failure mode this whole mechanism is for.\n")
+    unless @out;
+  return \@out;
+}
+
+sub report_drift {
+  my ($key, $what, $want, $got, $symbols) = @_;
+  my @missing = grep { !$got->{$_} } sort keys %$want;
+  my @extra   = grep { !$want->{$_} } sort keys %$got;
+  return unless @missing || @extra;
+  my $show = sub { join('', map { '    ' . join(' ', split /\0/, $_) . "\n" } @{ $_[0] }) };
+  my $msg = "DECLARED_ARGV{$key}\n"
+          . "  no longer describes the code. $what resolves out of "
+          . join(', ', @$symbols) . " to a different\n  set of values than the declaration lists.\n";
+  $msg .= "  produced by the code, missing from the declaration:\n" . $show->(\@missing) if @missing;
+  $msg .= "  listed in the declaration, no longer produced by the code:\n" . $show->(\@extra) if @extra;
+  $msg .= "  Update `argv` to match — then check the allow-list still covers every line of it,\n"
+        . "  because a new value here is a new privileged command, and that is what this catches.\n";
+  fatal($msg);
+}
+
+sub verify_declaration {
+  my ($key, $tmpl_src, $decl, $rel, $src, $consts) = @_;
+
+  fatal("DECLARED_ARGV{$key}\n  must be a hash with an `argv` list of argument lists.\n")
+    unless ref $decl eq 'HASH' && ref $decl->{argv} eq 'ARRAY' && @{ $decl->{argv} };
+  my $resolve    = $decl->{resolve}    || {};
+  my $unverified = $decl->{unverified} || {};
+
+  my @tmpl = split_argv_items($tmpl_src);
+  my @dyn;
+  for my $i (0 .. $#tmpl) {
+    next if defined unquote($tmpl[$i]);
+    push @dyn, { idx => $i, name => $tmpl[$i] };
+  }
+
+  # Fail-closed in both directions: nothing dynamic goes undeclared, and nothing
+  # declared outlives the argument it was about.
+  for my $d (@dyn) {
+    next if exists $resolve->{ $d->{name} } || exists $unverified->{ $d->{name} };
+    fatal("DECLARED_ARGV{$key}\n"
+        . "  says nothing about the dynamic argument `$d->{name}`.\n"
+        . "  Add it to `resolve`, naming the symbol that holds its values so this check can\n"
+        . "  verify the declaration against the code, or to `unverified` with the reason it\n"
+        . "  cannot be. A dynamic argument nobody described is how a new privileged command\n"
+        . "  reaches a device without a grant.\n");
+  }
+  my %is_dyn = map { $_->{name} => 1 } @dyn;
+  for my $name (sort(keys %$resolve), sort(keys %$unverified)) {
+    next if $is_dyn{$name};
+    fatal("DECLARED_ARGV{$key}\n"
+        . "  describes `$name`, which this call site no longer passes. Drop it, or re-point it\n"
+        . "  at the argument the call really builds.\n");
+  }
+  for my $name (sort keys %$unverified) {
+    fatal("DECLARED_ARGV{$key}\n  `unverified` entry `$name` needs a reason, not an empty string.\n")
+      unless defined $unverified->{$name} && $unverified->{$name} =~ /\S/;
+  }
+  return unless %$resolve;
+
+  my $clean = strip_ts_comments($src);
+  my @spread = grep { $_->{name} =~ /^\.\.\./ } @dyn;
+
+  if (@spread) {
+    fatal("DECLARED_ARGV{$key}\n"
+        . "  mixes a spread with another dynamic argument. A spread can only be verified when\n"
+        . "  every other item in the call is a literal; mark them `unverified` instead.\n")
+      if @spread > 1 || @dyn > 1;
+    my $sp = $spread[0];
+    my $syms = $resolve->{ $sp->{name} };
+    my @symbols = ref $syms eq 'ARRAY' ? @$syms : ($syms);
+    my %want;
+    for my $sym (@symbols) {
+      $want{ join("\0", @$_) } = 1
+        for @{ resolve_symbol_values($key, $rel, $clean, $consts, $sym, 'list') };
+    }
+    my @before = map { unquote($tmpl[$_]) } (0 .. $sp->{idx} - 1);
+    my @after  = map { unquote($tmpl[$_]) } ($sp->{idx} + 1 .. $#tmpl);
+    my %got;
+    for my $a (@{ $decl->{argv} }) {
+      my @c = @$a;
+      fatal("DECLARED_ARGV{$key}\n  a declared argv is shorter than the literals around the spread.\n")
+        if @c < @before + @after;
+      for my $j (0 .. $#before) {
+        fatal("DECLARED_ARGV{$key}\n"
+            . "  argument $j is the literal `$before[$j]` in the call but `$c[$j]` in a declared\n"
+            . "  argv. The declaration does not describe this call site.\n")
+          unless $c[$j] eq $before[$j];
+      }
+      for my $j (0 .. $#after) {
+        my $pos = scalar(@c) - scalar(@after) + $j;
+        fatal("DECLARED_ARGV{$key}\n"
+            . "  the trailing literal `$after[$j]` is `$c[$pos]` in a declared argv.\n")
+          unless $c[$pos] eq $after[$j];
+      }
+      splice(@c, scalar(@c) - scalar(@after), scalar @after) if @after;
+      splice(@c, 0, scalar @before) if @before;
+      $got{ join("\0", @c) } = 1;
+    }
+    report_drift($key, "the spread `$sp->{name}`", \%want, \%got, \@symbols);
+    return;
+  }
+
+  my $n = scalar @tmpl;
+  fatal("DECLARED_ARGV{$key}\n"
+      . "  has `resolve` entries, but the declared argument lists are not the same length as\n"
+      . "  the call's own argument list, so there is no position to verify them against.\n"
+      . "  Declare the argv the call really passes, or mark every dynamic item `unverified`.\n")
+    if grep { scalar @$_ != $n } @{ $decl->{argv} };
+
+  for my $i (0 .. $#tmpl) {
+    my $lit = unquote($tmpl[$i]);
+    next unless defined $lit;
+    for my $a (@{ $decl->{argv} }) {
+      fatal("DECLARED_ARGV{$key}\n"
+          . "  argument $i is the literal `$lit` in the call but `$a->[$i]` in a declared argv.\n"
+          . "  The declaration does not describe this call site.\n")
+        unless $a->[$i] eq $lit;
+    }
+  }
+  for my $d (@dyn) {
+    next unless exists $resolve->{ $d->{name} };
+    my $syms = $resolve->{ $d->{name} };
+    my @symbols = ref $syms eq 'ARRAY' ? @$syms : ($syms);
+    my %want;
+    for my $sym (@symbols) {
+      $want{ $_->[0] } = 1
+        for @{ resolve_symbol_values($key, $rel, $clean, $consts, $sym, 'scalar') };
+    }
+    my %got = map { $_->[ $d->{idx} ] => 1 } @{ $decl->{argv} };
+    report_drift($key, "`$d->{name}`", \%want, \%got, \@symbols);
+  }
+}
+
+# The one entry point the scanners use: look the declaration up, verify it
+# against the file it describes, and hand back the argument lists.
+sub declared_argv {
+  my ($rel, $norm, $src, $consts) = @_;
+  my $key = "$rel :: $norm";
+  my $decl = $DECLARED_ARGV{$key} or return undef;
+  $DECL_USED{$key} = 1;
+  verify_declaration($key, $norm, $decl, $rel, $src, $consts) unless $DECL_VERIFIED{$key}++;
+  return $decl->{argv};
+}
+
 my (@calls, @unresolved);
 
 sub add_unresolved {
   my ($rel, $raw, $why) = @_;
   my $key = "$rel :: $raw";
-  return if exists $EXEMPT_CALLS{$key};
+  if (exists $EXEMPT_CALLS{$key}) { $EXEMPT_USED{$key} = 1; return }
   push @unresolved, { file => $rel, raw => $raw, why => $why, key => $key };
 }
 
@@ -365,7 +719,7 @@ sub scan_ts {
   while ($raw =~ /$SPAWNERS\s*\(\s*"((?:\/usr\/bin\/)?sudo)"\s*,\s*\[([^\]]*)\]/gs) {
     my ($bin, $args_src) = ($1, $2);
     my $norm = collapse($args_src);
-    if (my $declared = $DECLARED_ARGV{"$rel :: $norm"}) {
+    if (my $declared = declared_argv($rel, $norm, $raw, $consts)) {
       push @calls, { file => $rel, argv => $_ } for @$declared;
       next;
     }
@@ -389,7 +743,7 @@ sub scan_ts {
     while ($raw =~ /$SPAWNERS\s*\(\s*\Q$var\E\s*,\s*([A-Za-z_][A-Za-z0-9_]*)\s*[,)]/gs) {
       my $second = $1;
       my $norm = "$var, $second";
-      if (my $declared = $DECLARED_ARGV{"$rel :: $norm"}) {
+      if (my $declared = declared_argv($rel, $norm, $raw, $consts)) {
         push @calls, { file => $rel, argv => $_ } for @$declared;
         next;
       }
@@ -398,7 +752,7 @@ sub scan_ts {
     while ($raw =~ /$SPAWNERS\s*\(\s*\Q$var\E\s*,\s*\[([^\]]*)\]/gs) {
       my $args_src = $1;
       my $norm = collapse($args_src);
-      if (my $declared = $DECLARED_ARGV{"$rel :: $norm"}) {
+      if (my $declared = declared_argv($rel, $norm, $raw, $consts)) {
         push @calls, { file => $rel, argv => $_ } for @$declared;
         next;
       }
@@ -467,6 +821,34 @@ for my $rel (@files) {
   close $fh;
   next unless defined $src && $src =~ /sudo/;
   if ($rel =~ /\.sh$/) { scan_sh($rel, $src) } else { scan_ts($rel, $src) }
+}
+
+# ── Nothing described here may outlive the code it described ────────────────
+# A declaration or an exemption is a reviewed decision about one call site. When
+# that call site changes shape or goes away, the decision has to be re-made, not
+# inherited: a leftover entry is a standing permission to skip a check, keyed on
+# text nothing in the tree produces any more.
+for my $key (sort keys %DECLARED_ARGV) {
+  next if $DECL_USED{$key};
+  fatal("DECLARED_ARGV{$key}
+"
+      . "  matches no sudo call site in the tree. The call it described was edited, moved or
+"
+      . "  removed; delete the entry, or re-key it on the call as it is written now so it is
+"
+      . "  reviewed against today's code instead of yesterday's.
+");
+}
+for my $key (sort keys %EXEMPT_CALLS) {
+  next if $EXEMPT_USED{$key};
+  fatal("EXEMPT_CALLS{$key}
+"
+      . "  matches no unresolved sudo call site. Either the call is gone, or it now resolves
+"
+      . "  and is being checked properly — both mean the exemption is a permission nobody is
+"
+      . "  using. Delete it.
+");
 }
 
 # ── Match ───────────────────────────────────────────────────────────────────

--- a/src/app/setup-api/clawkeep/restore/route.ts
+++ b/src/app/setup-api/clawkeep/restore/route.ts
@@ -6,47 +6,81 @@ import { NextRequest, NextResponse } from "next/server";
 import { ClawKeepError, RestoreNeedsPassphraseError, runRestore } from "@/lib/clawkeep";
 import { getEdition } from "@/lib/harness";
 import { HERMES_DASHBOARD_UNIT } from "@/lib/hermes-dashboard-auth";
+import { bounceHermesDashboard } from "@/lib/hermes-dashboard-control";
 
 export const dynamic = "force-dynamic";
 
 const exec = promisify(execFile);
 
-// Services that hold the restored state open while running. After we swap a
-// directory (or file) atomically, their existing handles still see the OLD
-// inodes, so they have to be restarted for user-facing behaviour to reflect
-// the restored state.
+// The OpenClaw unit that holds the restored state open. After we swap a
+// directory (or file) atomically, a running process's existing handles still
+// see the OLD inodes, so it has to be restarted for user-facing behaviour to
+// reflect the restored state.
 //
-// WHICH service is per-edition, and getting it wrong is not a cosmetic bug.
-// install.sh's step_edition_gateway_state REMOVES the clawbox-gateway unit
-// file on Hermes and persistently masks it, so restarting it there fails
-// twice over — while `clawbox-hermes-dashboard`, which is the process
-// actually holding `~/.hermes/state.db` open, is never touched. The restore
-// then reports success and the agent keeps serving pre-restore state until
-// something else happens to restart it. That is the same false-success shape
-// this codebase has already been bitten by twice.
-//
-// Names use the .service suffix so they match the NOPASSWD sudoers rules in
+// Spelled with `.service` so it matches the NOPASSWD rule in
 // config/clawbox-sudoers verbatim — sudoers Cmnd_Spec is exact-string, so
 // "clawbox-gateway" would NOT match "clawbox-gateway.service".
-//
-// NOTE on the Hermes side: there is deliberately NO sudoers grant for
-// `clawbox-hermes-dashboard`, and this route does not add one. `systemctl
-// restart` starts a stopped unit, so such a grant would let a customer on an
-// OPENCLAW box resurrect the Hermes dashboard that the foreign-edition
-// teardown just stopped and disabled — the exact resurrection the gateway's
-// mask exists to prevent, in the other direction.
-// `install-foreign-edition-teardown.test.ts` guards that invariant.
-//
-// So the restart is ATTEMPTED (it succeeds on devices whose sudoers policy
-// allows it) and, where it is refused, the failure travels back in
-// `restartErrors` and the result card tells the owner to restart the agent
-// themselves. An unrestarted dashboard keeps serving pre-restore state from
-// the file handles it already holds, so the one thing we must not do is stay
-// quiet about it.
-function restartServicesFor(edition: string): string[] {
-  return edition === "hermes"
-    ? [HERMES_DASHBOARD_UNIT]
-    : ["clawbox-gateway.service"];
+const OPENCLAW_RESTART_UNIT = "clawbox-gateway.service";
+
+/**
+ * Bring the process that holds the restored state back onto the new inodes.
+ *
+ * WHICH process is per-edition, and so is HOW it is restarted.
+ *
+ * OPENCLAW — `clawbox-gateway.service`, restarted through the sudoers grant
+ * that exists for it.
+ *
+ * HERMES — `clawbox-hermes-dashboard.service`, and NOT through sudo. There is
+ * deliberately no sudoers grant over any Hermes unit:
+ * `install-foreign-edition-teardown.test.ts` asserts it, because `systemctl
+ * restart` STARTS a stopped unit and such a grant would let a customer on an
+ * OpenClaw box resurrect the Hermes dashboard the foreign-edition teardown had
+ * just stopped and disabled. That decision is right and it stays.
+ *
+ * What was wrong was reaching for `sudo systemctl restart` anyway and calling
+ * the guaranteed refusal "best effort". On the owner's Hermes box the restore
+ * put every file back and then reported it could not restart the dashboard.
+ *
+ * `bounceHermesDashboard()` is the path built for exactly this: it asks the
+ * unit whether it is `Restart=always`, and if so runs `hermes dashboard
+ * --stop`, which is unprivileged (the dashboard runs `User=clawbox`, and the
+ * unit's own ExecStartPre runs the same command) and is a stop, not a start —
+ * so a dashboard that is stopped and disabled stays that way. Its own doc
+ * comment names "a restored backup" as the reason it exists; ClawKeep simply
+ * never picked it up, because it landed after this route was written.
+ *
+ * Either way a failure is REPORTED, never swallowed: an unrestarted process
+ * keeps serving pre-restore state from the handles it already holds, so the one
+ * thing this must not do is stay quiet about it. The caller puts whatever comes
+ * back into `restartErrors` and the result card tells the owner which unit to
+ * restart by hand.
+ */
+async function restartStateHolder(edition: string): Promise<string[]> {
+  if (edition === "hermes") {
+    if (await bounceHermesDashboard()) return [];
+    // No exception to quote: bounceHermesDashboard() never throws, it answers
+    // "this box was left exactly as it was". Say which of its two reasons the
+    // owner can act on rather than inventing a detail we do not have.
+    const detail =
+      "could not be bounced from here — the unit is not Restart=always, or the stop did not take";
+    console.warn(`[clawkeep/restore] ${HERMES_DASHBOARD_UNIT} ${detail}`);
+    return [`${HERMES_DASHBOARD_UNIT}: ${detail}`];
+  }
+  try {
+    // The unit name comes from the const above rather than being spelled again
+    // here, and scripts/check-sudoers-coverage.sh resolves it: one name, checked
+    // against the allow-list, with no second copy to drift.
+    await exec("/usr/bin/sudo", ["/usr/bin/systemctl", "restart", OPENCLAW_RESTART_UNIT], {
+      timeout: 30_000,
+    });
+    return [];
+  } catch (e) {
+    const detail = e instanceof Error ? e.message : String(e);
+    // Visible in journalctl this way even if the user dismisses the result
+    // card before reading restartErrors.
+    console.warn(`[clawkeep/restore] systemctl restart ${OPENCLAW_RESTART_UNIT} failed: ${detail}`);
+    return [`${OPENCLAW_RESTART_UNIT}: ${detail}`];
+  }
 }
 
 // POST /setup-api/clawkeep/restore
@@ -76,23 +110,10 @@ export async function POST(request: NextRequest) {
 
     const result = await runRestore(name, { passphrase });
 
-    // Best-effort service restart. Swallow individual failures — the
-    // restore itself succeeded, and a manual `systemctl restart` is a
-    // recoverable follow-up.
-    const restartErrors: string[] = [];
-    for (const svc of restartServicesFor(getEdition())) {
-      try {
-        await exec("/usr/bin/sudo", ["/usr/bin/systemctl", "restart", svc], {
-          timeout: 30_000,
-        });
-      } catch (e) {
-        const detail = e instanceof Error ? e.message : String(e);
-        // Service-restart failures are visible in journalctl this way even
-        // if the user dismisses the result card before reading restartErrors.
-        console.warn(`[clawkeep/restore] systemctl restart ${svc} failed: ${detail}`);
-        restartErrors.push(`${svc}: ${detail}`);
-      }
-    }
+    // The restore itself has succeeded by here. A process that could not be
+    // brought back onto the restored inodes is still a partial result, so the
+    // reasons travel out to the caller instead of being swallowed.
+    const restartErrors = await restartStateHolder(getEdition());
 
     return NextResponse.json(
       {

--- a/src/tests/routes/clawkeep-restore-restart.test.ts
+++ b/src/tests/routes/clawkeep-restore-restart.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * What a ClawKeep restore does AFTER the files are back.
+ *
+ * A restored directory is swapped in atomically, so a process that was already
+ * running keeps reading the OLD inodes through the handles it holds. Unless the
+ * process is bounced, the restore succeeds and the box keeps serving
+ * pre-restore state — the false-success shape this codebase has shipped before.
+ *
+ * The bug this file locks down: on Hermes the route reached for
+ * `sudo systemctl restart clawbox-hermes-dashboard.service`, and there is
+ * deliberately no sudoers grant for any Hermes unit (a `restart` grant STARTS a
+ * stopped unit, which is exactly how an OpenClaw box could resurrect the
+ * dashboard its foreign-edition teardown had just disabled —
+ * install-foreign-edition-teardown.test.ts owns that invariant). So the call
+ * could only ever fail. On the owner's box the restore put every file back and
+ * then reported it could not restart the agent.
+ *
+ * The fix is not a new grant. `bounceHermesDashboard()` stops the dashboard as
+ * the clawbox user that already owns the process and lets the unit's
+ * `Restart=always` bring it back: no privilege, and a stop can never resurrect
+ * a unit that is down. These tests assert BOTH halves — that the Hermes path
+ * bounces and never shells out to sudo, and that a failure is still reported
+ * rather than swallowed.
+ */
+
+const h = vi.hoisted(() => ({
+  edition: "openclaw" as string,
+  bounce: true,
+  bounceCalls: 0,
+  execCalls: [] as { file: string; args: string[] }[],
+  execFailure: null as string | null,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (
+    file: string,
+    args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, res?: { stdout: string; stderr: string }) => void,
+  ) => {
+    h.execCalls.push({ file, args });
+    if (h.execFailure) cb(new Error(h.execFailure));
+    else cb(null, { stdout: "", stderr: "" });
+  },
+}));
+
+vi.mock("@/lib/harness", () => ({ getEdition: () => h.edition }));
+
+vi.mock("@/lib/hermes-dashboard-control", () => ({
+  bounceHermesDashboard: async () => {
+    h.bounceCalls += 1;
+    return h.bounce;
+  },
+}));
+
+vi.mock("@/lib/clawkeep", () => ({
+  ClawKeepError: class ClawKeepError extends Error {
+    status = 500;
+  },
+  RestoreNeedsPassphraseError: class RestoreNeedsPassphraseError extends Error {
+    status = 401;
+    kind = "passphrase_missing";
+  },
+  runRestore: async () => ({
+    archive: "2026-08-28T00-00-00.000Z-openclaw-backup.tar.gz",
+    archiveBytes: 4096,
+    assets: [],
+    skippedMembers: [],
+  }),
+}));
+
+import type { NextRequest } from "next/server";
+
+import { POST } from "@/app/setup-api/clawkeep/restore/route";
+import { HERMES_DASHBOARD_UNIT } from "@/lib/hermes-dashboard-auth";
+
+const post = () =>
+  POST(
+    new Request("http://localhost/setup-api/clawkeep/restore", {
+      method: "POST",
+      body: JSON.stringify({ name: "2026-08-28T00-00-00.000Z-openclaw-backup.tar.gz" }),
+    }) as unknown as NextRequest,
+  );
+
+beforeEach(() => {
+  h.edition = "openclaw";
+  h.bounce = true;
+  h.bounceCalls = 0;
+  h.execCalls.length = 0;
+  h.execFailure = null;
+});
+
+describe("POST /setup-api/clawkeep/restore — bringing the state holder back", () => {
+  it("restarts clawbox-gateway.service through the grant that exists for it", async () => {
+    const body = await (await post()).json();
+    expect(body.ok).toBe(true);
+    expect(body.restartErrors).toEqual([]);
+    expect(h.execCalls).toEqual([
+      {
+        file: "/usr/bin/sudo",
+        args: ["/usr/bin/systemctl", "restart", "clawbox-gateway.service"],
+      },
+    ]);
+    // The .service spelling is load-bearing: sudoers Cmnd_Spec is exact-string,
+    // so a bare "clawbox-gateway" would not match the granted rule.
+    expect(h.execCalls[0].args[2]).toBe("clawbox-gateway.service");
+  });
+
+  it("reports an OpenClaw restart failure instead of swallowing it", async () => {
+    h.execFailure = "Command failed: sudo: a password is required";
+    const body = await (await post()).json();
+    expect(body.ok).toBe(true);
+    expect(body.restartErrors).toHaveLength(1);
+    expect(body.restartErrors[0]).toMatch(/^clawbox-gateway\.service: /);
+    expect(body.restartErrors[0]).toContain("a password is required");
+  });
+
+  // THE REGRESSION. This used to be a sudo call that could not succeed.
+  it("bounces the Hermes dashboard without sudo, and never shells out", async () => {
+    h.edition = "hermes";
+    const body = await (await post()).json();
+    expect(body.ok).toBe(true);
+    expect(h.bounceCalls).toBe(1);
+    expect(body.restartErrors).toEqual([]);
+    // Not "did not call sudo on the dashboard" — did not call sudo AT ALL.
+    // A Hermes box has no clawbox-gateway either, so any exec here is wrong.
+    expect(h.execCalls).toEqual([]);
+  });
+
+  it("still tells the owner when the Hermes bounce did not take", async () => {
+    h.edition = "hermes";
+    h.bounce = false;
+    const body = await (await post()).json();
+    expect(body.ok).toBe(true);
+    expect(h.execCalls).toEqual([]);
+    expect(body.restartErrors).toHaveLength(1);
+    // The result card parses the unit off the front of this string to print
+    // `sudo systemctl restart <unit>`, so the prefix has to stay a unit name.
+    expect(body.restartErrors[0].startsWith(`${HERMES_DASHBOARD_UNIT}: `)).toBe(true);
+  });
+
+  it("never restarts the OpenClaw gateway on a Hermes box", async () => {
+    // install.sh removes AND masks clawbox-gateway on Hermes, so restarting it
+    // there fails twice over — and reporting that failure to the owner points
+    // them at a unit that does not exist on their device.
+    h.edition = "hermes";
+    await post();
+    expect(h.execCalls.some((c) => c.args.join(" ").includes("clawbox-gateway"))).toBe(false);
+  });
+});

--- a/src/tests/unit/install-sudoers-migration.test.ts
+++ b/src/tests/unit/install-sudoers-migration.test.ts
@@ -559,3 +559,134 @@ describe("the root-owned helper scripts the grants point at", () => {
     }
   });
 });
+
+// ── What a real device's allow-list actually grants ─────────────────────────
+//
+// The allow-list is only ever as good as the audit of what the product runs,
+// and that audit drifts. It drifted here: PR #471/#495 narrowed the drop-in,
+// then a Hermes branch was added to the ClawKeep restore route and nothing
+// noticed that the unit it restarts has no grant — the restore put every file
+// back on the owner's box and then reported it could not restart the agent.
+//
+// These tests install the SHIPPED file through the real helper and read the
+// exact (verb, unit) pairs back off disk, so no grant can appear or disappear
+// without a test being edited. Editing it is the point: config/clawbox-sudoers
+// is a privilege boundary, and a diff that changes this list is a diff a
+// reviewer has to look at.
+d("the allow-list a device ends up with", () => {
+  const install = () => {
+    const r = runShell(`install_sudoers_dropin "$REPO/config/clawbox-sudoers" clawbox`);
+    expect(r.status).toBe(0);
+    return fs.readFileSync(path.join(tmp, "sudoers.d/clawbox"), "utf-8");
+  };
+  const systemctlGrants = (text: string) =>
+    text
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith("clawbox ") && l.includes("/usr/bin/systemctl"))
+      .map((l) => l.replace(/^.*\/usr\/bin\/systemctl\s+/, "").replace(/\s+/g, " "));
+
+  // Every systemctl privilege the appliance has, in one place. Each line is a
+  // command some product code really issues — scripts/check-sudoers-coverage.sh
+  // fails the build for any line here that nothing invokes, and for any
+  // invocation with no line here.
+  const EXPECTED = [
+    "restart clawbox-gateway.service",
+    "restart clawbox-gateway",
+    "stop clawbox-gateway.service",
+    "stop clawbox-gateway",
+    "--runtime mask clawbox-gateway.service",
+    "--runtime mask clawbox-gateway",
+    "--runtime unmask clawbox-gateway.service",
+    "--runtime unmask clawbox-gateway",
+    "restart clawbox-setup.service",
+    "restart clawbox-setup",
+    "start clawbox-browser.service",
+    "start clawbox-browser",
+    "stop clawbox-browser.service",
+    "stop clawbox-browser",
+    "stop clawbox-tunnel.service",
+    "stop clawbox-tunnel",
+    "restart clawbox-tunnel.service",
+    "restart clawbox-tunnel",
+    "enable clawbox-tunnel.service",
+    "enable clawbox-tunnel",
+    "disable clawbox-tunnel.service",
+    "disable clawbox-tunnel",
+    "restart hermes-gateway.service",
+    "restart hermes-gateway",
+    "enable --now ollama.service",
+    "disable --now ollama.service",
+    "start ollama.service",
+    "stop ollama.service",
+    "reset-failed clawbox-root-update@chpasswd.service",
+    "start clawbox-root-update@chpasswd.service",
+    "reset-failed clawbox-root-update@set_hostname.service",
+    "start clawbox-root-update@set_hostname.service",
+    "reset-failed clawbox-root-update@restart_ap.service",
+    "start clawbox-root-update@restart_ap.service",
+    "reset-failed clawbox-root-update@llamacpp_install.service",
+    "start --no-block clawbox-root-update@llamacpp_install.service",
+    "reboot",
+    "poweroff",
+  ];
+
+  it("grants exactly the systemctl commands the product issues, and no others", () => {
+    expect(systemctlGrants(install())).toEqual(EXPECTED);
+  });
+
+  it("grants the unit a ClawKeep restore restarts on OpenClaw, in both spellings", () => {
+    // src/app/setup-api/clawkeep/restore/route.ts, restartStateHolder(): the
+    // non-hermes branch runs `sudo /usr/bin/systemctl restart
+    // clawbox-gateway.service`. sudoers Cmnd_Spec is exact-string, hence both.
+    const grants = systemctlGrants(install());
+    expect(grants).toContain("restart clawbox-gateway.service");
+    expect(grants).toContain("restart clawbox-gateway");
+  });
+
+  it("still grants nothing over a Hermes dashboard unit", () => {
+    // The Hermes half of the same restore does NOT go through sudo — it calls
+    // bounceHermesDashboard(), which stops the dashboard as the clawbox user
+    // that owns it and lets Restart=always bring it back. A `restart` grant
+    // here would also START a stopped unit, which is precisely how an OpenClaw
+    // box could resurrect the dashboard its foreign-edition teardown had just
+    // stopped and disabled. install-foreign-edition-teardown.test.ts owns that
+    // invariant; this asserts the same thing from the installed file.
+    expect(systemctlGrants(install()).some((g) => g.includes("hermes-dashboard"))).toBe(false);
+  });
+
+  it("grants nothing over the units only root-context code drives", () => {
+    // Each of these appeared on a first-pass grep of "units the product
+    // restarts", and every one of them is issued from somewhere that is ALREADY
+    // root, so a grant would be privilege handed out for nothing:
+    //
+    //   clawbox-vnc, clawbox-websockify, clawbox-firstboot-vnc
+    //     scripts/ensure-vnc-on-first-boot.sh, run by clawbox-firstboot-vnc
+    //     .service — a unit install.sh writes with no User=, i.e. as root.
+    //   clawbox-ap
+    //     scripts/ap-watchdog.sh (clawbox-ap-watchdog.service, root) and
+    //     install.sh itself. The UI path goes through
+    //     clawbox-root-update@restart_ap.service, which IS granted above.
+    //   clawbox-hermes-dashboard-proxy
+    //     scripts/setup-hermes-edition.sh, which install.sh runs as root.
+    const grants = systemctlGrants(install());
+    for (const unit of [
+      "clawbox-vnc",
+      "clawbox-websockify",
+      "clawbox-firstboot-vnc",
+      "clawbox-ap.service",
+      "clawbox-hermes-dashboard-proxy",
+    ]) {
+      expect(grants.some((g) => g.includes(unit)), `${unit} is granted`).toBe(false);
+    }
+  });
+
+  it("reintroduces no blanket rule", () => {
+    // Asserted through the installer's own detector, not a regex of our own:
+    // the thing that has to agree the file is narrow is the code that
+    // quarantines wide ones on real devices.
+    install();
+    const r = runShell(`sudoers_grants_blanket_nopasswd "${tmp}/sudoers.d/clawbox"`);
+    expect(r.status).toBe(1);
+  });
+});

--- a/src/tests/unit/install-sudoers-migration.test.ts
+++ b/src/tests/unit/install-sudoers-migration.test.ts
@@ -632,7 +632,11 @@ d("the allow-list a device ends up with", () => {
   ];
 
   it("grants exactly the systemctl commands the product issues, and no others", () => {
-    expect(systemctlGrants(install())).toEqual(EXPECTED);
+    // Sorted on both sides: these are all NOPASSWD allows with no overlapping
+    // Cmnd, so reordering lines in the file changes no privilege. Comparing in
+    // file order would fail a pure reshuffle with a diff that reads like a
+    // privilege change, and that is the diff nobody looks at twice.
+    expect([...systemctlGrants(install())].sort()).toEqual([...EXPECTED].sort());
   });
 
   it("grants the unit a ClawKeep restore restarts on OpenClaw, in both spellings", () => {

--- a/src/tests/unit/sudoers-coverage.test.ts
+++ b/src/tests/unit/sudoers-coverage.test.ts
@@ -338,7 +338,7 @@ const exempting = (perl: string) => (src: string) => {
  * A sudo call whose unit comes out of a helper — the shape that slipped
  * through. The CALL text is fixed; only the helper decides which units exist.
  */
-function writeUnitProbe(hermes: string, openclaw: string, extraBody = "") {
+function writeUnitProbe(hermes: string, openclaw: string, extraBody = "", returnLine = "") {
   fs.writeFileSync(
     path.join(fixture, "scripts/zz-probe.ts"),
     [
@@ -346,7 +346,8 @@ function writeUnitProbe(hermes: string, openclaw: string, extraBody = "") {
       "",
       "function zzUnits(edition: string): string[] {",
       ...(extraBody ? [extraBody] : []),
-      `  return edition === "hermes" ? ["${hermes}"] : ["${openclaw}"];`,
+      returnLine
+        || `  return edition === "hermes" ? ["${hermes}"] : ["${openclaw}"];`,
       "}",
       "",
       "export function zzRestart(edition: string) {",
@@ -434,6 +435,48 @@ d("a declaration is verified against its producer", () => {
       declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service"])),
     );
     expect(r.stderr).not.toMatch(/not-a-unit/);
+    expect(r.status).toBe(0);
+  });
+
+  // Comments are stripped before any symbol is looked up, so a commented-out
+  // return contributes nothing. Pinned here rather than left implicit: the
+  // stripping happens in verify_declaration and is passed DOWN into the
+  // resolver, so resolving against the raw source instead would silently bring
+  // this back — as a phantom unit reported uncovered, which is the direction
+  // that pressures the next author into adding a grant.
+  it("does not read units out of commented-out code", () => {
+    writeUnitProbe(
+      "zz-hermes.service",
+      "zz-openclaw.service",
+      '  // return ["cr-line-comment.service"];\n'
+      + '  /* return ["cr-block-comment.service"]; */',
+    );
+    grantRestart("zz-openclaw.service");
+    grantRestart("zz-hermes.service");
+    const r = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service"])),
+    );
+    expect(r.stderr).not.toMatch(/cr-line-comment|cr-block-comment/);
+    expect(r.status).toBe(0);
+  });
+
+  it("does not read units out of a comment inside the return expression", () => {
+    writeUnitProbe(
+      "zz-hermes.service",
+      "zz-openclaw.service",
+      "",
+      '  return edition === "hermes"\n'
+      + '    ? ["zz-hermes.service"] // ["cr-trailing.service"]\n'
+      + '    : /* ["cr-inline.service"] */ ["zz-openclaw.service"];',
+    );
+    grantRestart("zz-openclaw.service");
+    grantRestart("zz-hermes.service");
+    const r = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service"])),
+    );
+    expect(r.stderr).not.toMatch(/cr-trailing|cr-inline/);
     expect(r.status).toBe(0);
   });
 

--- a/src/tests/unit/sudoers-coverage.test.ts
+++ b/src/tests/unit/sudoers-coverage.test.ts
@@ -338,13 +338,14 @@ const exempting = (perl: string) => (src: string) => {
  * A sudo call whose unit comes out of a helper — the shape that slipped
  * through. The CALL text is fixed; only the helper decides which units exist.
  */
-function writeUnitProbe(hermes: string, openclaw: string) {
+function writeUnitProbe(hermes: string, openclaw: string, extraBody = "") {
   fs.writeFileSync(
     path.join(fixture, "scripts/zz-probe.ts"),
     [
       'import { execFile } from "node:child_process";',
       "",
       "function zzUnits(edition: string): string[] {",
+      ...(extraBody ? [extraBody] : []),
       `  return edition === "hermes" ? ["${hermes}"] : ["${openclaw}"];`,
       "}",
       "",
@@ -413,6 +414,26 @@ d("a declaration is verified against its producer", () => {
       declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service"])),
     );
     expect(r.stderr + r.stdout).toMatch(/0 gaps/);
+    expect(r.status).toBe(0);
+  });
+
+  // Only the RETURN expressions of a helper are harvested. An unrelated array in
+  // its body — a validation list, a message built from a template literal — is
+  // not a set of privileged arguments, and demanding grants for it would push
+  // the next author into widening the allow-list to silence this check.
+  it("ignores an array literal that is not part of a return expression", () => {
+    writeUnitProbe(
+      "zz-hermes.service",
+      "zz-openclaw.service",
+      '  const known = ["not-a-unit", "also-not-a-unit"];\n  void known;',
+    );
+    grantRestart("zz-openclaw.service");
+    grantRestart("zz-hermes.service");
+    const r = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service"])),
+    );
+    expect(r.stderr).not.toMatch(/not-a-unit/);
     expect(r.status).toBe(0);
   });
 

--- a/src/tests/unit/sudoers-coverage.test.ts
+++ b/src/tests/unit/sudoers-coverage.test.ts
@@ -286,3 +286,195 @@ describe("the call sites the allow-list has to cover", () => {
     }
   });
 });
+
+// ── A declaration is checked against the code, not believed ─────────────────
+//
+// DECLARED_ARGV is how a sudo call whose argv is not a literal array gets past
+// the fail-closed resolver: someone writes down what the call can produce and
+// that list is used instead. Writing it down is a review. Nothing kept the
+// review honest afterwards.
+//
+// The shipped defect, exactly: the ClawKeep restore route's call read
+// `["/usr/bin/systemctl", "restart", svc]` before and after a Hermes branch was
+// added to the helper feeding `svc`. The call's source text — the only thing
+// the declaration was keyed on — never changed, so the declaration went on
+// claiming the site restarts clawbox-gateway.service while the code had grown a
+// second unit with no grant at all. This check said "0 gaps"; a real Hermes box
+// restored every file and then could not restart its own agent.
+//
+// So `resolve` now names the symbol the values come from, the checker
+// re-resolves it on every run, and a declaration that has stopped matching the
+// code is a build failure that names the drift.
+let patchSeq = 0;
+
+function runPatched(root: string, patch: (src: string) => string, args: string[] = []) {
+  // Written OUTSIDE the fixture: a checker copy inside scripts/ would be
+  // scanned as if it were product code.
+  const file = path.join(os.tmpdir(), `clawbox-sudoers-checker-${process.pid}-${patchSeq++}.sh`);
+  const patched = patch(fs.readFileSync(CHECKER, "utf-8"));
+  fs.writeFileSync(file, patched);
+  try {
+    return spawnSync("bash", [file, ...args], {
+      encoding: "utf-8",
+      env: { ...process.env, CLAWBOX_REPO_ROOT: root },
+    });
+  } finally {
+    fs.rmSync(file, { force: true });
+  }
+}
+
+const declaring = (perl: string) => (src: string) => {
+  const anchor = "my %DECLARED_ARGV = (";
+  if (!src.includes(anchor)) throw new Error("DECLARED_ARGV anchor not found");
+  return src.replace(anchor, `${anchor}\n${perl}`);
+};
+const exempting = (perl: string) => (src: string) => {
+  const anchor = "my %EXEMPT_CALLS = (";
+  if (!src.includes(anchor)) throw new Error("EXEMPT_CALLS anchor not found");
+  return src.replace(anchor, `${anchor}\n${perl}`);
+};
+
+/**
+ * A sudo call whose unit comes out of a helper — the shape that slipped
+ * through. The CALL text is fixed; only the helper decides which units exist.
+ */
+function writeUnitProbe(hermes: string, openclaw: string) {
+  fs.writeFileSync(
+    path.join(fixture, "scripts/zz-probe.ts"),
+    [
+      'import { execFile } from "node:child_process";',
+      "",
+      "function zzUnits(edition: string): string[] {",
+      `  return edition === "hermes" ? ["${hermes}"] : ["${openclaw}"];`,
+      "}",
+      "",
+      "export function zzRestart(edition: string) {",
+      "  for (const svc of zzUnits(edition)) {",
+      '    execFile("sudo", ["/usr/bin/systemctl", "restart", svc]);',
+      "  }",
+      "}",
+      "",
+    ].join("\n"),
+  );
+}
+
+const ZZ_KEY = `'scripts/zz-probe.ts :: "/usr/bin/systemctl", "restart", svc'`;
+const zzDeclaration = (units: string[], extra = "resolve => { svc => 'zzUnits' },") =>
+  `  ${ZZ_KEY} => {\n`
+  + `    argv => [${units.map((u) => `['/usr/bin/systemctl', 'restart', '${u}']`).join(", ")}],\n`
+  + `    ${extra}\n  },`;
+const grantRestart = (unit: string) =>
+  appendGrant(`clawbox ALL=(root) NOPASSWD: /usr/bin/systemctl restart ${unit}`);
+
+d("a declaration is verified against its producer", () => {
+  // THE REGRESSION. Reproduced in miniature: the helper grows a unit, the call
+  // does not change, and the declaration is now a lie.
+  it("fails when the helper grows a unit the declaration does not list", () => {
+    writeUnitProbe("zz-hermes.service", "zz-openclaw.service");
+    grantRestart("zz-openclaw.service");
+    const r = runPatched(fixture, declaring(zzDeclaration(["zz-openclaw.service"])));
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/no longer describes the code/);
+    expect(r.stderr).toMatch(/zz-hermes\.service/);
+  });
+
+  it("fails when the declaration lists a unit the code no longer produces", () => {
+    writeUnitProbe("zz-hermes.service", "zz-openclaw.service");
+    for (const u of ["zz-openclaw.service", "zz-hermes.service", "zz-ghost.service"]) grantRestart(u);
+    const r = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service", "zz-ghost.service"])),
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/no longer produced by the code/);
+    expect(r.stderr).toMatch(/zz-ghost\.service/);
+  });
+
+  // The point of catching the drift: the NEW value is a new privileged command,
+  // and it is the allow-list that has to have kept up.
+  it("reports the newly resolved unit as uncovered when nothing grants it", () => {
+    writeUnitProbe("zz-hermes.service", "zz-openclaw.service");
+    grantRestart("zz-openclaw.service");
+    const r = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service"])),
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/UNCOVERED sudo invocations/);
+    expect(r.stderr).toMatch(/systemctl restart zz-hermes\.service/);
+  });
+
+  it("passes once the declaration and the allow-list have both caught up", () => {
+    writeUnitProbe("zz-hermes.service", "zz-openclaw.service");
+    grantRestart("zz-openclaw.service");
+    grantRestart("zz-hermes.service");
+    const r = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service", "zz-hermes.service"])),
+    );
+    expect(r.stderr + r.stdout).toMatch(/0 gaps/);
+    expect(r.status).toBe(0);
+  });
+
+  // Fail-closed for anything new: a dynamic argument nobody described is how a
+  // privileged command reaches a device without ever being reviewed.
+  it("refuses a declaration that says nothing about its dynamic argument", () => {
+    writeUnitProbe("zz-hermes.service", "zz-openclaw.service");
+    grantRestart("zz-openclaw.service");
+    const r = runPatched(fixture, declaring(zzDeclaration(["zz-openclaw.service"], "")));
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/says nothing about the dynamic argument `svc`/);
+  });
+
+  it("accepts `unverified` only with a reason", () => {
+    writeUnitProbe("zz-hermes.service", "zz-openclaw.service");
+    grantRestart("zz-openclaw.service");
+    const empty = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service"], "unverified => { svc => '' },")),
+    );
+    expect(empty.status).toBe(1);
+    expect(empty.stderr).toMatch(/needs a reason/);
+  });
+
+  it("refuses a `resolve` pointed at a symbol that does not exist", () => {
+    writeUnitProbe("zz-hermes.service", "zz-openclaw.service");
+    grantRestart("zz-openclaw.service");
+    const r = runPatched(
+      fixture,
+      declaring(zzDeclaration(["zz-openclaw.service"], "resolve => { svc => 'zzNoSuchThing' },")),
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/does not define as a const array, Set, object/);
+  });
+
+  // The other direction: a reviewed decision must not outlive its call site.
+  it("refuses a declaration whose call site no longer exists", () => {
+    const r = runPatched(
+      fixture,
+      declaring("  'src/gone.ts :: a, b' => { argv => [['sudo', '/usr/bin/systemctl', 'reboot']],"
+        + " unverified => { a => 'gone', b => 'gone' } },"),
+    );
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/matches no sudo call site in the tree/);
+  });
+
+  it("refuses an exemption nothing uses", () => {
+    const r = runPatched(fixture, exempting("  'src/gone.ts :: bin, argv' => 'no longer real',"));
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/matches no unresolved sudo call site/);
+  });
+
+  // Proof that the declarations the repo really ships are being verified rather
+  // than skipped: break one of them and the real tree fails.
+  it("verifies the declarations the repo itself ships", () => {
+    const r = runPatched(REPO, (src) => {
+      const before = "      ['/usr/bin/systemctl', 'poweroff'],\n      ['/usr/bin/systemctl', 'reboot'],";
+      if (!src.includes(before)) throw new Error("power-route declaration not found");
+      return src.replace(before, "      ['/usr/bin/systemctl', 'poweroff'],");
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/no longer describes the code/);
+    expect(r.stderr).toMatch(/reboot/);
+  });
+});


### PR DESCRIPTION
## What happened

A ClawKeep restore on a Hermes box restored every file and then reported, honestly:

> Cannot automatically restart 1 service. Run `sudo systemctl restart clawbox-hermes-dashboard.service` manually.

ClawKeep behaved correctly and is not changed here — it attempted the restart, it failed, and it said so with the exact command. What is wrong is that the restart could never have worked, and that the guard which exists to notice exactly this said "0 gaps".

## Grants added: NONE. Here is why that is the right answer

`config/clawbox-sudoers` is unchanged. Not one line added or removed.

**The dashboard.** There is deliberately no sudoers grant over any Hermes unit, and `install-foreign-edition-teardown.test.ts` asserts it:

```js
// The dashboard units remain completely ungranted.
expect(grants.some((l) => l.includes("hermes-dashboard"))).toBe(false);
```

The reason is symmetric to the gateway's mask: `systemctl restart` **starts** a stopped unit, so a `restart clawbox-hermes-dashboard` grant would let anyone with clawbox-level access on an **OpenClaw** box resurrect the Hermes dashboard that the foreign-edition teardown had just stopped and disabled. `18978f94` made that call deliberately, and it is right.

So the fix is not a grant. `src/lib/hermes-dashboard-control.ts` already has the unprivileged path, and its own doc comment names the reason it exists:

> A change made underneath it — **a restored backup**, an image backend installed by linking ClawBox AI — is invisible to it until it comes back.

`bounceHermesDashboard()` asks the unit whether it is `Restart=always`, and if so runs `hermes dashboard --stop`. That needs no privilege (the unit runs `User=clawbox`, and the unit's own `ExecStartPre` runs the same command), and it is a **stop**, not a start — a unit that is stopped and disabled stays that way, so the teardown invariant is untouched. It landed in `fe11da98`, *after* the restore route was written, and nobody went back to use it. Now the restore does.

**The other eight units** a shallow grep of "units the product restarts" suggests are missing — `clawbox-hermes-dashboard-proxy`, `clawbox-ap`, `clawbox-vnc`, `clawbox-websockify`, `clawbox-firstboot-vnc`, and the `enable`/`disable` verbs on them — are every one of them issued from code that is **already root**, so a grant would be privilege handed out for nothing:

| unit / verb | where it is actually issued | runs as |
|---|---|---|
| `restart`/`enable clawbox-vnc`, `clawbox-websockify`; `disable clawbox-firstboot-vnc` | `scripts/ensure-vnc-on-first-boot.sh` | `clawbox-firstboot-vnc.service`, written by install.sh with **no `User=`** → root |
| `restart clawbox-ap` | `scripts/ap-watchdog.sh` (`clawbox-ap-watchdog.service`, root) and install.sh. The UI path goes through `clawbox-root-update@restart_ap.service`, **which is already granted** | root |
| `restart`/`enable clawbox-hermes-dashboard(-proxy)` | `scripts/setup-hermes-edition.sh` (`# Run as root`), invoked by install.sh `step_hermes_edition` | root |
| `disable clawbox-gateway` | `scripts/setup-hermes-edition.sh` teardown | root |

Each of those was checked by opening the unit file or the script header, not by grepping for `sudo`.

## How I know the list of privileged operations is complete

Not by grepping for unit names — that is what produced the eight false positives above. The boundary that matters is **clawbox → root**, which on this appliance is crossed in exactly one way: an invocation of `sudo`. So the authoritative list is the set of `sudo` invocations reachable from code that runs as `clawbox`, and `scripts/check-sudoers-coverage.sh` already enumerates it fail-closed — anything it cannot resolve to concrete arguments is an error, not a skip.

`bash scripts/check-sudoers-coverage.sh --list` on this branch resolves **46 invocations across 20 files** against **48 grants**, with 0 uncovered, 0 unresolved and 0 unused. That output is the list.

Two things I checked by hand rather than trusting the tool:

1. **The scan surface.** `SCAN_DIRS` is `src`, `mcp`, `scripts`. I grepped every other tree for `sudo`: only `install.sh`, `install-x64.sh` and `config/clawbox-root-step.sh` match, and all three only ever run *as* root. The `clawkeep/` Python tree — a whole product component the checker does not scan — contains no `sudo` and no `systemctl` call at all (one mention, in a docstring), and its units run `User=clawkeep`.
2. **Non-sudo `systemctl` mutations.** `src/app/setup-api/install/run-step/route.ts` and `src/lib/updater.ts` call `systemctl reset-failed` / `start` with no `sudo`, relying on the polkit rule in `config/49-clawbox-updates.rules`. Those are a different privilege path (TASK-539) and out of scope here, but they are not gaps in the sudoers list.

Verified live against the factory allow-list on a freshly flashed box (192.168.50.71, `sudo -n -l`): the installed drop-in matches `config/clawbox-sudoers` line for line, in order.

## Why check-sudoers-coverage.sh missed it — and what changed

The checker was not missing from CI (it runs transitively via `src/tests/unit/sudoers-coverage.test.ts`), and it does check both directions. It missed this because of `DECLARED_ARGV`.

A sudo call whose argv is not a literal array gets past the fail-closed resolver by having someone **write down** what it can produce. The entry is keyed on the call's source text, on the stated theory that "editing the CALL invalidates the declaration".

The call was never edited:

```ts
for (const svc of restartServicesFor(getEdition())) {
  await exec("/usr/bin/sudo", ["/usr/bin/systemctl", "restart", svc], …);
}
```

`41bb01bf` added a Hermes branch to `restartServicesFor`. The call's source text did not change by a byte, so the key still matched, and the declaration went on saying:

```perl
# src/app/setup-api/clawkeep/restore/route.ts — svc iterates RESTART_SERVICES.
'…:: "/usr/bin/systemctl", "restart", svc' => [
  ['/usr/bin/systemctl', 'restart', 'clawbox-gateway.service'],
],
```

— stale in content *and* in its comment (`RESTART_SERVICES` had not existed for two commits). The checker reported "0 gaps" for a call site that could not work on half the fleet.

**A declaration is now verified against the code instead of believed.** Each entry gains:

- `resolve => { <arg> => <symbol> }` — the symbol whose values the checker **re-resolves out of the file on every run**. It reads const array / `new Set([…])` / object literals and the array literals inside a function body, following string constants across files. A declaration whose set no longer matches the code fails and names the drift in both directions.
- `unverified => { <arg> => '<reason>' }` — for shapes the resolver genuinely cannot see (`runScript()`'s `cmd, argv`, built from parameters). A reason is mandatory and is reviewed like a grant, because nothing else is checking it.
- An argument in **neither** is a hard failure. That is what makes it fail-closed for the next feature.

Two more leaks closed while in here:

- A `DECLARED_ARGV` or `EXEMPT_CALLS` entry that matches no call site is now an error. A reviewed decision must not outlive the code it was made about.
- `check:sudoers` is now its own step in `pr-tests-coverage.yml`. It previously only reached CI as a side effect of one vitest case that skips itself off Linux; a vitest config change or a file rename would have taken the guard off the build with nothing saying so. It also now fails in seconds instead of after the whole suite.

Of the five declarations the repo ships, **four are now fully verified** against `restartServicesFor`-style producers (`POWER_ACTIONS`, `SYSTEM_UNITS`, the three `OLLAMA_*_ARGV` arrays); the fifth (`system-profile.ts`) is `unverified` with a written reason. The ClawKeep entry is deleted outright — the call is a literal now, so the resolver reads it directly.

## RED → GREEN

**RED, against unmodified `origin/beta` product code**, with only the checker changed:

```
$ bash scripts/check-sudoers-coverage.sh
check-sudoers-coverage: DECLARED_ARGV{src/app/setup-api/clawkeep/restore/route.ts :: "/usr/bin/systemctl", "restart", svc}
  no longer describes the code. `svc` resolves out of restartServicesFor to a different
  set of values than the declaration lists.
  produced by the code, missing from the declaration:
    clawbox-hermes-dashboard.service
```

The new checker names the exact unit the owner hit, from beta's own source.

**GREEN, on this branch:**

```
$ bash scripts/check-sudoers-coverage.sh
check-sudoers-coverage: OK — 48 grants, 46 resolved sudo invocations, 0 gaps
```

**New tests — 23, all RED on beta:**

| file | count | covers |
|---|---|---|
| `src/tests/unit/sudoers-coverage.test.ts` | 13 | the helper grows a unit the declaration lacks → fail, naming it; the declaration lists a unit the code no longer produces → fail; the newly resolved unit reported **uncovered** when nothing grants it; passes once declaration *and* allow-list have both caught up; a dynamic argument declared nowhere → fail; `unverified` with an empty reason → fail; `resolve` at a non-existent symbol → fail; a declaration whose call site is gone → fail; an exemption nothing uses → fail; an array literal outside a `return` expression is not harvested; commented-out code contributes no units (line, block, and inside the return expression); **breaking a declaration the repo really ships makes the real tree fail** (proof the shipped entries are live-verified, not skipped) |
| `src/tests/unit/install-sudoers-migration.test.ts` | 5 | installs the shipped drop-in through the real `install_sudoers_dropin` and asserts the **exact** 38-entry systemctl grant set a device ends up with; the OpenClaw restore unit granted in both spellings; nothing granted over any `hermes-dashboard` unit; nothing granted over the five root-context units; no blanket rule, asserted through the installer's own `sudoers_grants_blanket_nopasswd` detector |
| `src/tests/routes/clawkeep-restore-restart.test.ts` | 5 | OpenClaw restarts `clawbox-gateway.service` via sudo; an OpenClaw failure is reported, not swallowed; **Hermes bounces without sudo and shells out not at all**; a failed bounce still reaches `restartErrors` with the unit-name prefix the result card parses; a Hermes box never touches `clawbox-gateway` |

All eight checker scenarios were additionally reproduced end-to-end against a real fixture tree before being written as tests.

## Honest-failure audit (follow-ups, not fixed here)

ClawKeep was the good case and stays that way. Siblings that would report success where the same privileged call had failed:

1. **`src/lib/cloudflared.ts`** — `stopTunnelService()` awaits the `stop` but swallows the `disable`. The comment says the quiet part: *"without `disable` the unit comes back on the next reboot, silently overriding the user's stop intent"* — and then catches. Settings → Remote Control reports the tunnel stopped; the next reboot brings it back. Same shape for `enable` in `startTunnelService()`.
2. **`src/app/setup-api/system/hotspot/route.ts`** — the AP-restart failure is caught and the route answers `{ success: true, apRestarted: false }`. `apRestarted: false` also means "deliberately deferred because the box is a WiFi client", so the UI cannot tell a safe deferral from an SSID/password change that did not apply.
3. **`scripts/clawbox-identity-sync.sh`** — `sudo -n … restart || systemctl --user … || true`. A failed identity refresh leaves the agent on stale SOUL/MEMORY with nothing logged.

Same family as #504 / #506 / #510 / #519. Happy to file these as issues.

## Security review notes

- `config/clawbox-sudoers` is **byte-identical** to `origin/beta`. `git diff origin/beta -- config/` is empty.
- The one behaviour change to a privileged path is a **removal**: the ClawKeep restore no longer attempts `sudo systemctl restart <a Hermes unit>` at all.
- `scripts/check-sudoers-coverage.sh` gains only checks. Every existing invariant (no wildcards, root-owned prefixes only, absolute paths, no `..`, `(root)` runas only, no bare `ALL`, coverage in both directions) is untouched and still asserted by the existing tests.

## Live verification, Hermes box 192.168.50.165 (`CLAWBOX_EDITION=hermes`)

Device mutex taken and released; the box is on `beta`.

**Reproduced the owner's failure** — the exact call the old route made:

```
$ sudo -n -l | grep -i hermes-dashboard
(nothing — no NOPASSWD grant for the dashboard unit, as designed)

$ sudo -n /usr/bin/systemctl restart clawbox-hermes-dashboard.service
sudo: a password is required
rc=1
```

**Proved the new path works**, running the exact sequence `bounceHermesDashboard()` performs, with no sudo anywhere in it:

```
Restart=always                                    ← restartsItself(), a systemctl show READ
$ /home/clawbox/.local/bin/hermes dashboard --stop ← unprivileged, User=clawbox owns the process
  ⟲ Stopping 1 dashboard process(es) (requested via --stop)
      ✓ stopped PID 1950
  rc=0

t+5s   active=deactivating  MainPID=0
t+10s  active=activating    MainPID=0
t+15s  active=active        MainPID=4142       ← systemd's Restart=always brought it back
```

Old pid 1950 → new pid 4142 in 15 seconds, `active` and still `enabled`. Confirmed serving afterwards: `http=302` direct on `127.0.0.2:9119` (the dashboard's auth redirect) and `clawbox-hermes-dashboard-proxy.service` active.

That is the whole of what the restore route now does on Hermes, so the restart half of a ClawKeep restore succeeds on this box where it previously could not. What was **not** run end-to-end: a full paired backup→restore cycle, because the owner is actively testing on this device and it is about to be reflashed for store testing. The restore path either side of the restart is unchanged by this PR.

Also measured, on the freshly flashed reference box (192.168.50.71): the installed `/etc/sudoers.d/clawbox` matches `config/clawbox-sudoers` line for line and in order.


## Review dispositions (CodeRabbit)

| finding | disposition |
|---|---|
| `resolve_symbol_values` harvests every array literal in a helper body | **Fixed.** Narrowed to `return` expressions. The failure mode was worse than described: an unrelated array would have been reported as a privileged argument the allow-list does not cover, and the cheapest way to silence that is to add a grant — a check that pushes an author towards widening `clawbox-sudoers` is worse than no check. Re-verified the narrowing costs no coverage (beta's route + beta's declaration still names the missing unit). New test. |
| grant-set comparison is order-sensitive | **Fixed.** Sorted both sides, with the reasoning in a comment. |
| do not render Hermes failures as `sudo systemctl restart` | **Refuted, and withdrawn by the reviewer.** The premise was that Hermes has no sudo grant so the command cannot work. The allow-list governs `sudo -n` from the web server, not a human at a shell: `clawbox` is in the `sudo` group (install.sh:935), and the box answers `sudo: a password is required`, not "not allowed". The card is owner-facing and that command is exactly what the owner ran to recover. |
| symbol resolution reads `return` out of comments | **Refuted — comments are already stripped** (`verify_declaration` builds `strip_ts_comments($src)` and hands it to the resolver), demonstrated against a fixture with a commented-out return, a comment inside the return expression, and a URL in a string. **Two regression tests added anyway**, because the ordering is implicit — the stripping happens in the caller — and resolving against the raw source would bring the class back as a phantom uncovered unit, the direction that pressures the next author into adding a grant. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ClawKeep restore now restarts only the appropriate service for each edition.
  - Hermes restores use the dashboard recovery process instead of restarting the OpenClaw gateway.
  - Restore responses now report restart failures and unavailable recovery actions instead of silently continuing.

- **Reliability**
  - Added validation to keep privileged system commands accurate, minimal, and aligned with supported recovery operations.
  - Expanded automated coverage for restore behavior and service-permission safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->