### PR TITLE
fix: say only what the removal verdict and the install refusal establish

### DIFF
--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -255,13 +255,23 @@ interface InstallRefusal {
   error?: string;
   conflictsWith?: string;
   missingFiles?: string[];
+  /**
+   * `incomplete_install`: the skill was already installed before this request,
+   * so the owner's copy was left in place. Without this the branch below is
+   * true only of the other state the code covers.
+   */
+  preexisting?: boolean;
   /** `unresolved`: the ids the device's "did you mean" list offered instead. */
   candidates?: string[];
   /** `rollback_incomplete`: what the failed undo left behind. */
   leftover?: {
     /** The store still lists it — so the store is where it can be removed. */
     lockEntry?: boolean;
-    directory?: "present" | "absent" | "unknown";
+    /**
+     * `unchecked` — nothing looked, the entry named no location. `unknown` —
+     * the check ran on the location the entry named and could not answer.
+     */
+    directory?: "present" | "absent" | "unchecked" | "unknown";
   };
   warning?: {
     verdict?: string;
@@ -404,6 +414,20 @@ function refusalToToolError(err: unknown): ToolError | null {
   }
   if (payload.code === "incomplete_install") {
     const missing = (payload.missingFiles ?? []).slice(0, 5).join(", ");
+    if (payload.preexisting) {
+      // The skill was already installed when this request arrived, so the
+      // rollback left the owner's copy alone. "Nothing was installed" would be
+      // false, and the retry it implies is the one thing that cannot work: the
+      // installer meets the surviving lock entry, exits 0 without fetching, and
+      // the completeness check lands on the same missing files. The repair pass
+      // has already had its go, so only a removal changes the outcome.
+      return new ToolError(
+        "CONFLICT",
+        `That skill was already installed and some of its files are missing from the device${missing ? ` (missing: ${missing})` : ""}, so it was left in place.`,
+        "Do NOT retry the install and do not check the network — neither changes this. "
+          + "Tell the user, and offer to call skill_uninstall for it and then skill_install again.",
+      );
+    }
     return new ToolError(
       "CONFLICT",
       `The skill's download was incomplete, so nothing was installed${missing ? ` (missing: ${missing})` : ""}.`,

--- a/src/app/setup-api/hermes/skills/install/route.ts
+++ b/src/app/setup-api/hermes/skills/install/route.ts
@@ -697,15 +697,21 @@ async function rollbackIncomplete(
     warning?: SkillDangerWarning | null;
   },
 ): Promise<NextResponse> {
-  // Say only what was actually established. `unknown` is its own sentence
-  // because the alternative — calling it removed — is the false-success this
-  // change is here to stop telling.
+  // Say only what was actually established, and no more: each unanswered state
+  // gets its own sentence because the alternative — calling it removed — is the
+  // false-success this change is here to stop telling, and because naming a
+  // CAUSE the verdict did not establish is the same failure wearing a different
+  // sentence. `unchecked` is the only state in which "the entry names no
+  // location" is a fact; under `unknown` the entry named one, the check ran on
+  // it, and only the answer is missing.
   const leftover = left.lockEntry
     ? left.dir === "present"
       ? `"${ctx.name}" is still listed in the Skills store and its files are still on the device`
       : left.dir === "absent"
         ? `"${ctx.name}" is still listed in the Skills store although its files were removed`
-        : `"${ctx.name}" is still listed in the Skills store, and the entry names no location, so whether its files are still on the device could not be checked`
+        : left.dir === "unchecked"
+          ? `"${ctx.name}" is still listed in the Skills store, and the entry names no location, so whether its files are still on the device could not be checked`
+          : `"${ctx.name}" is still listed in the Skills store, and whether its files were removed could not be checked`
     : `"${ctx.name}" is no longer listed in the Skills store, but its files are still on the device`;
   // A leftover the store cannot see is a leftover the store cannot remove, so
   // the two states get the two different next steps they actually have.

--- a/src/components/HermesSkillsStore.tsx
+++ b/src/components/HermesSkillsStore.tsx
@@ -308,6 +308,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
   const renderBrowseAction = useCallback(
     (skill: HermesSkill, size: 'card' | 'detail' = 'card'): ReactNode => {
       const state = progress[skill.id];
+      const target = uninstallTargetFor(skill);
       if (state?.status === 'working') {
         return (
           <span className="inline-flex items-center gap-2 text-xs text-[var(--text-secondary)]">
@@ -324,13 +325,29 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
             <span className="text-xs text-red-400 line-clamp-1" title={state.message}>
               {state.message}
             </span>
-            <GhostButton tone="danger" onClick={() => setConfirmInstall(skill)}>
-              {COPY.retry}
-            </GhostButton>
+            {/*
+              The button has to be the one the message asks for. A hub row
+              exists for this skill, so the install just failed over a copy that
+              is ON the device — the two refusals that say so ("remove it from
+              the Skills store and install it again", and the leftover a
+              rollback could not undo) both name removal as the next step, and
+              Retry is the one action that cannot work: the installer meets the
+              lock entry and exits 0 without fetching. `target` is null for
+              anything the store cannot remove, so a skill that is genuinely not
+              installed keeps Retry.
+            */}
+            {target ? (
+              <GhostButton tone="danger" onClick={() => setConfirmUninstall(target)}>
+                {COPY.remove}
+              </GhostButton>
+            ) : (
+              <GhostButton tone="danger" onClick={() => setConfirmInstall(skill)}>
+                {COPY.retry}
+              </GhostButton>
+            )}
           </span>
         );
       }
-      const target = uninstallTargetFor(skill);
       if (state?.status === 'success' || isInstalled(skill)) {
         return (
           <span className="flex items-center gap-2 flex-wrap">

--- a/src/components/HermesSkillsStore.tsx
+++ b/src/components/HermesSkillsStore.tsx
@@ -210,6 +210,21 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
           throw new Error(COPY.nameConflict(String(data.conflictsWith || skill.name)));
         }
         if (res.status === 502 && data?.code === 'incomplete_install') {
+          // Two device states share this code. `preexisting` means the skill was
+          // already installed before this request, so the rollback deliberately
+          // left the customer's copy alone — and the translated copy for the
+          // other state ("Nothing was installed. Check your internet connection
+          // and try again.") is false twice over: it IS installed, and the retry
+          // it invites re-enters this branch, because the installer meets the
+          // surviving lock entry and exits 0 without fetching anything. The
+          // route's own sentence is the one that matches the device, the same
+          // way `rollback_incomplete` below takes it.
+          if (data.preexisting) {
+            // The row they are being told to remove is the one on screen: the
+            // Installed tab still holds the pre-request list.
+            await installed.refresh();
+            throw new Error(String(data.error || COPY.installFailed));
+          }
           throw new Error(COPY.installIncomplete((data.missingFiles as string[]) || []));
         }
         // A rollback the device could not finish leaves a lock entry THIS

--- a/src/lib/hermes-skills-server.ts
+++ b/src/lib/hermes-skills-server.ts
@@ -640,11 +640,23 @@ let installedCacheAt = 0;
 /**
  * What the skill directory is doing after a removal.
  *
- * Three states, not two, because "not known to be there" is not "gone": a lock
- * entry that names no `install_path` gives the removal nothing to aim at, so
- * nothing about the directory was checked and nothing about it may be claimed.
+ * Four states, not two, because "not known to be there" is not "gone" — and
+ * because there are two different ways not to know, which a caller writing a
+ * sentence for the customer cannot tell apart from one label:
+ *
+ * - `unchecked` — nothing ever looked. A lock entry that names no
+ *   `install_path` gives the removal nothing to aim at, so nothing about the
+ *   directory was checked and nothing about it may be claimed.
+ * - `unknown` — something looked and the device would not answer: the removal
+ *   believed it worked and the confirming `stat` failed with anything other
+ *   than ENOENT (see `pathState`). The entry DOES name a location here, and the
+ *   files are most likely still at it.
+ *
+ * They were one value, and the install route's refusal named the first as the
+ * cause of both — telling a customer whose skill was still on the device that
+ * the entry named no location. Neither surface has to guess now.
  */
-export type SkillRemovalDir = 'present' | 'absent' | 'unknown';
+export type SkillRemovalDir = 'present' | 'absent' | 'unchecked' | 'unknown';
 
 /** What a removal ACHIEVED, as opposed to what the CLI printed about it. */
 export interface SkillRemovalVerdict {
@@ -696,10 +708,10 @@ export async function verifySkillRemoval(
   entry: HubLockEntry | undefined,
 ): Promise<SkillRemovalVerdict> {
   const installPath = entry?.install_path;
-  // `unknown` until something actually looks. With no `install_path` there is
+  // `unchecked` until something actually looks. With no `install_path` there is
   // nothing to look at, and the honest answer is not `absent`: the CLI may well
   // have left a directory behind at a location this route was never told.
-  let dir: SkillRemovalDir = 'unknown';
+  let dir: SkillRemovalDir = 'unchecked';
   if (installPath) {
     // Two things can leave the directory behind, so both are checked: a path
     // `removeSkillDir` will not resolve (it answers false and removes nothing),
@@ -710,8 +722,9 @@ export async function verifySkillRemoval(
     if (!removed) {
       dir = 'present';
     } else if (abs !== null) {
-      // A stat that could not answer keeps `unknown`: it is the one honest
-      // label for "the removal claimed to work and nothing could confirm it".
+      // A stat that could not answer is `unknown`, NOT `unchecked`: the check
+      // ran, the entry named the location it ran on, and only the answer is
+      // missing. Nothing may call that "no location was named".
       dir = await pathState(abs);
     }
   }
@@ -719,9 +732,10 @@ export async function verifySkillRemoval(
   // Read the lock AFTER the CLI, never before: it is the only thing that says
   // whether the store will still list this skill.
   const lockEntry = Object.prototype.hasOwnProperty.call(await readHubLock(), lockKey);
-  // `unknown` alone is not a failure. The store lists what the lock lists, so a
-  // vanished lock entry means the customer sees nothing and has nothing to act
-  // on; refusing here would report a failure over a removal that did its job.
+  // Neither unanswered state is a failure on its own. The store lists what the
+  // lock lists, so a vanished lock entry means the customer sees nothing and
+  // has nothing to act on; refusing here would report a failure over a removal
+  // that did its job.
   return { clean: !lockEntry && dir !== 'present', lockEntry, dir };
 }
 

--- a/src/tests/components/hermes-skills-preexisting-incomplete.test.tsx
+++ b/src/tests/components/hermes-skills-preexisting-incomplete.test.tsx
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
+import HermesSkillsStore from "@/components/HermesSkillsStore";
+
+/**
+ * `incomplete_install` has two device states, and the store only ever told the
+ * customer about one of them.
+ *
+ * The route distinguishes them: when the skill was ALREADY installed before the
+ * request, the rollback deliberately leaves the customer's copy alone and the
+ * body carries `preexisting: true` plus a sentence that says so. Nothing read
+ * that flag — `grep -rn preexisting src/ mcp/` returned only the producer — so
+ * the store threw `COPY.installIncomplete(...)`, whose copy reads "The download
+ * was incomplete" / "Nothing was installed. Check your internet connection and
+ * try again."
+ *
+ * Both halves are false here. The skill IS installed, and the retry that
+ * sentence invites re-enters the same branch: `verifyAndRepair` has already had
+ * its go, so the files are still missing and the installer meets its own lock
+ * entry and exits 0 without fetching anything.
+ */
+
+vi.mock("@/lib/i18n", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/i18n")>();
+  const { skillsEn } = await import("@/lib/hermes-translations/en-skills");
+  return {
+    ...actual,
+    useT: () => ({
+      locale: "en" as const,
+      localeResolved: true,
+      setLocale: () => {},
+      t: (key: string, params?: Record<string, string | number>) =>
+        Object.entries(params ?? {}).reduce(
+          (out, [name, value]) => out.replaceAll(`{${name}}`, String(value)),
+          skillsEn[key] ?? key,
+        ),
+    }),
+  };
+});
+
+const SKILL = {
+  id: "official/pdf-tools",
+  name: "PDF Tools",
+  source: "official",
+  trust: "official",
+};
+
+const BROWSE = {
+  skills: [SKILL],
+  page: 1,
+  pageSize: 24,
+  total: 1,
+  totalPages: 1,
+  hasMore: false,
+  facets: { sources: [{ id: "official", label: "Official", count: 1 }], providers: [] },
+  catalog: { origin: "index", skillCount: 90_600, fetchedAt: new Date().toISOString(), stale: false },
+  degraded: false,
+};
+
+/** The route's body for the branch that leaves a pre-existing install alone. */
+const PREEXISTING = {
+  error:
+    'Some of "pdf-tools"\'s files are missing from the device. It was already installed before '
+    + "this request, so it was left in place — remove it from the Skills store and install it again.",
+  code: "incomplete_install",
+  preexisting: true,
+  missingFiles: ["reference/pdf.md"],
+  expectedCount: 4,
+  presentCount: 3,
+  manifestOrigin: "skill-md",
+};
+
+/** The same code for the state the old copy DID describe: nothing installed. */
+const DOWNLOAD_INCOMPLETE = {
+  error: "The download was incomplete — the skill was not installed.",
+  code: "incomplete_install",
+  missingFiles: ["reference/pdf.md"],
+  expectedCount: 4,
+  presentCount: 2,
+  manifestOrigin: "skill-md",
+};
+
+const HUB_ROW = {
+  id: "pdf-tools",
+  name: "PDF Tools",
+  category: "other",
+  origin: "hub",
+  source: "official",
+  identifier: "official/pdf-tools",
+  enabled: true,
+};
+
+interface Installed {
+  skills: unknown[];
+  counts: { total: number };
+  categories: unknown[];
+}
+
+const EMPTY_INSTALLED: Installed = { skills: [], counts: { total: 0 }, categories: [] };
+
+function mockStore(opts: { installedPages: Installed[]; body: Record<string, unknown> }) {
+  let installedCalls = 0;
+  const fetchMock = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/skills/browse")) return { ok: true, status: 200, json: async () => BROWSE };
+    // `/skills/installed` is a prefix match for `/skills/install`, so the list
+    // endpoint has to be recognised first.
+    if (url.includes("/skills/installed")) {
+      const body = opts.installedPages[Math.min(installedCalls, opts.installedPages.length - 1)];
+      installedCalls += 1;
+      return { ok: true, status: 200, json: async () => body };
+    }
+    if (url.includes("/skills/install")) {
+      return { ok: false, status: 502, json: async () => opts.body };
+    }
+    return { ok: true, status: 200, json: async () => ({}) };
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return { installedCalls: () => installedCalls };
+}
+
+async function openBrowseTab() {
+  render(<HermesSkillsStore />);
+  const tab = await screen.findByTestId("skill-tab-browse");
+  await act(async () => {
+    fireEvent.click(tab);
+  });
+  await screen.findByText("PDF Tools");
+}
+
+async function installFromBrowse() {
+  const card = await screen.findByTestId("skill-install-btn");
+  await act(async () => {
+    fireEvent.click(within(card).getByRole("button"));
+  });
+  const dialog = await screen.findByRole("dialog");
+  await act(async () => {
+    fireEvent.click(within(dialog).getByRole("button", { name: "Install" }));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("an install refused over a skill that is still installed", () => {
+  it("does not tell the customer nothing was installed", async () => {
+    mockStore({ installedPages: [EMPTY_INSTALLED], body: PREEXISTING });
+    await openBrowseTab();
+    await installFromBrowse();
+
+    // The route's own sentence, which is the one that matches the device.
+    expect(await screen.findByText(/already installed before this request/i)).toBeTruthy();
+    // …and not the download story, which sends them to check the WiFi over a
+    // skill that is sitting on the device.
+    expect(screen.queryByText(/download was incomplete/i)).toBeNull();
+  });
+
+  it("re-reads the installed list, because the row to remove is the one on screen", async () => {
+    const { installedCalls } = mockStore({
+      installedPages: [EMPTY_INSTALLED, { skills: [HUB_ROW], counts: { total: 1 }, categories: [] }],
+      body: PREEXISTING,
+    });
+    await openBrowseTab();
+    const before = installedCalls();
+
+    await installFromBrowse();
+
+    await waitFor(() => expect(installedCalls()).toBeGreaterThan(before));
+  });
+
+  it("keeps the download story for the state it actually describes", async () => {
+    // The guard against fixing this by deleting the branch: when nothing was
+    // installed, "the download was incomplete" is the true sentence and the
+    // translated copy is the right one to show.
+    const { installedCalls } = mockStore({
+      installedPages: [EMPTY_INSTALLED],
+      body: DOWNLOAD_INCOMPLETE,
+    });
+    await openBrowseTab();
+    const before = installedCalls();
+
+    await installFromBrowse();
+
+    expect(await screen.findByText(/download was incomplete/i)).toBeTruthy();
+    // Nothing landed on the device, so there is no new row to go and find.
+    expect(installedCalls()).toBe(before);
+  });
+});

--- a/src/tests/components/hermes-skills-preexisting-incomplete.test.tsx
+++ b/src/tests/components/hermes-skills-preexisting-incomplete.test.tsx
@@ -174,6 +174,22 @@ describe("an install refused over a skill that is still installed", () => {
     await waitFor(() => expect(installedCalls()).toBeGreaterThan(before));
   });
 
+  it("offers Remove on the card, not the Retry that cannot work", async () => {
+    // The message says to remove it and install it again. Retry re-enters this
+    // same branch: the installer meets the surviving lock entry, exits 0
+    // without fetching, and the completeness check fails on the same files.
+    mockStore({
+      installedPages: [EMPTY_INSTALLED, { skills: [HUB_ROW], counts: { total: 1 }, categories: [] }],
+      body: PREEXISTING,
+    });
+    await openBrowseTab();
+    await installFromBrowse();
+
+    await screen.findByText(/already installed before this request/i);
+    await waitFor(() => expect(screen.getByRole("button", { name: /^remove$/i })).toBeTruthy());
+    expect(screen.queryByRole("button", { name: /^retry$/i })).toBeNull();
+  });
+
   it("keeps the download story for the state it actually describes", async () => {
     // The guard against fixing this by deleting the branch: when nothing was
     // installed, "the download was incomplete" is the true sentence and the
@@ -190,5 +206,17 @@ describe("an install refused over a skill that is still installed", () => {
     expect(await screen.findByText(/download was incomplete/i)).toBeTruthy();
     // Nothing landed on the device, so there is no new row to go and find.
     expect(installedCalls()).toBe(before);
+  });
+
+  it("keeps Retry for a failure that left nothing on the device", async () => {
+    // The guard on the button swap: no hub row for this skill, so there is
+    // nothing to remove and Retry is the only step there is.
+    mockStore({ installedPages: [EMPTY_INSTALLED], body: DOWNLOAD_INCOMPLETE });
+    await openBrowseTab();
+    await installFromBrowse();
+
+    await screen.findByText(/download was incomplete/i);
+    await waitFor(() => expect(screen.getByRole("button", { name: /^retry$/i })).toBeTruthy());
+    expect(screen.queryByRole("button", { name: /^remove$/i })).toBeNull();
   });
 });

--- a/src/tests/routes/hermes/skills-install-rollback.test.ts
+++ b/src/tests/routes/hermes/skills-install-rollback.test.ts
@@ -268,10 +268,56 @@ describe("a rollback the device could not complete is not a plain refusal", () =
       true,
     );
     // …so nothing may say the files went. Nothing looked at them: the entry
-    // named no location, and "not checked" is not "removed".
-    expect(body.leftover).toMatchObject({ lockEntry: true, directory: "unknown" });
+    // named no location, and "not checked" is not "removed" — which is the
+    // verdict's `unchecked`, distinct from the `unknown` of a check that ran
+    // and could not answer (the test below).
+    expect(body.leftover).toMatchObject({ lockEntry: true, directory: "unchecked" });
     expect(String(body.error)).not.toMatch(/files were removed/i);
     expect(String(body.error)).toMatch(/could not be checked/i);
+    // Here — and only here — the cause IS established, so it may be named.
+    expect(String(body.error)).toMatch(/names no location/i);
+  });
+
+  it("does not claim the entry named no location when it named one", async () => {
+    // The other way a directory check comes back unanswered: the entry DOES
+    // name a location, the removal believed it worked, and the `stat` that
+    // would have confirmed it failed with something other than ENOENT — EACCES
+    // on the root-owned subtree this device family produces. The customer was
+    // told "the entry names no location", which is false, and the sentence
+    // that follows from it — "whether its files are still on the device could
+    // not be checked" — was the only true half.
+    fakeDangerousInstall("throws");
+    const inner = mockCli.getMockImplementation()!;
+    let rolledBack = false;
+    mockCli.mockImplementation(async (...args: Parameters<typeof runHermesCli>) => {
+      if (args[0][1] === "uninstall") rolledBack = true;
+      return await inner(...args);
+    });
+
+    const abs = path.join(skillsDir(), "creative", "simple-english");
+    const realStat = fs.stat;
+    // Scoped to the post-rollback check on that one path: everything the
+    // install itself stats has to keep its real answer, or the route would be
+    // failing for a different reason than the one under test.
+    vi.spyOn(fs, "stat").mockImplementation((async (p: Parameters<typeof fs.stat>[0]) => {
+      if (rolledBack && path.resolve(String(p)) === path.resolve(abs)) {
+        const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }
+      return realStat(p);
+    }) as typeof fs.stat);
+
+    const { status, body } = await install({ id: "official/creative/simple-english" });
+
+    expect(status).toBe(409);
+    expect(body.code).toBe("rollback_incomplete");
+    expect(body.leftover).toMatchObject({ lockEntry: true, directory: "unknown" });
+    // The claim the verdict does not support.
+    expect(String(body.error)).not.toMatch(/names no location/i);
+    // The consequence, which is still true and still what the customer needs.
+    expect(String(body.error)).toMatch(/could not be checked/i);
+    expect(String(body.error)).toMatch(/still listed in the Skills store/i);
   });
 
   it("sends a directory-only leftover somewhere it can actually be removed", async () => {

--- a/src/tests/unit/hermes-skill-removal-verdict.test.ts
+++ b/src/tests/unit/hermes-skill-removal-verdict.test.ts
@@ -1,0 +1,121 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `verifySkillRemoval` is shared by the install route's rollback and the
+ * uninstall route precisely so the two surfaces cannot describe one device
+ * state differently (PR #517, then the shared extraction). That only holds if
+ * the verdict carries everything a message needs — and one of its three values
+ * did not.
+ *
+ * `dir: 'unknown'` had TWO causes:
+ *
+ *   1. the lock entry named no `install_path`, so nothing ever looked at a
+ *      directory, and
+ *   2. the removal was believed to have worked and the `stat` that would have
+ *      confirmed it failed with something other than ENOENT — EACCES on the
+ *      root-owned subtree this device family produces, EIO, a stalled mount.
+ *
+ * One label, two causes, so a consumer that wants to name the cause has to
+ * GUESS which one it was. The install route guessed (1) and said so as fact.
+ * The fix is here rather than in the sentence: the verdict distinguishes the
+ * two, and no consumer has to guess again.
+ */
+
+let hermesHome: string;
+
+function skillsDir(): string {
+  return path.join(hermesHome, "skills");
+}
+
+async function writeLock(installed: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(path.join(skillsDir(), ".hub"), { recursive: true });
+  await fs.writeFile(
+    path.join(skillsDir(), ".hub", "lock.json"),
+    JSON.stringify({ version: 1, installed }),
+  );
+}
+
+async function verify(lockKey: string, entry: Record<string, unknown> | undefined) {
+  const mod = await import("@/lib/hermes-skills-server");
+  return await mod.verifySkillRemoval(
+    lockKey,
+    entry as unknown as Parameters<typeof mod.verifySkillRemoval>[1],
+  );
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  hermesHome = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-removal-"));
+  process.env.HERMES_HOME = hermesHome;
+  await fs.mkdir(skillsDir(), { recursive: true });
+  await writeLock({});
+});
+
+afterEach(async () => {
+  delete process.env.HERMES_HOME;
+  await fs.rm(hermesHome, { recursive: true, force: true });
+});
+
+describe("the removal verdict says which question went unanswered", () => {
+  it("reports 'unchecked' when the entry names no location, because nothing looked", async () => {
+    await writeLock({ "simple-english": {} });
+
+    const left = await verify("simple-english", {});
+
+    // Not 'unknown': "nobody asked" and "the device would not answer" are
+    // different facts, and a caller that wants to explain itself needs to know
+    // which of them happened.
+    expect(left.dir).toBe("unchecked");
+    expect(left.lockEntry).toBe(true);
+    // The behaviour that must NOT change: neither value is a failure on its
+    // own — a vanished lock entry means the store lists nothing to act on.
+    expect(left.clean).toBe(false);
+  });
+
+  it("reports 'unknown' when something looked and the device would not say", async () => {
+    const rel = "creative/simple-english";
+    const abs = path.join(skillsDir(), "creative", "simple-english");
+    await fs.mkdir(abs, { recursive: true });
+    await fs.writeFile(path.join(abs, "SKILL.md"), "---\nname: simple-english\n---\n");
+    await writeLock({ "simple-english": { install_path: rel } });
+
+    // The removal believes it worked; the confirming stat cannot answer. This
+    // is the second cause the single 'unknown' label used to hide.
+    const realStat = fs.stat;
+    vi.spyOn(fs, "stat").mockImplementation((async (p: Parameters<typeof fs.stat>[0]) => {
+      if (path.resolve(String(p)) === path.resolve(abs)) {
+        const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        throw err;
+      }
+      return realStat(p);
+    }) as typeof fs.stat);
+
+    const left = await verify("simple-english", { install_path: rel });
+
+    expect(left.dir).toBe("unknown");
+    expect(left.dir).not.toBe("unchecked");
+    expect(left.clean).toBe(false);
+  });
+
+  it("still reports the two answers a stat CAN give", async () => {
+    const rel = "creative/simple-english";
+    const abs = path.join(skillsDir(), "creative", "simple-english");
+    await fs.mkdir(abs, { recursive: true });
+    await fs.writeFile(path.join(abs, "SKILL.md"), "---\nname: simple-english\n---\n");
+    await writeLock({});
+
+    const gone = await verify("simple-english", { install_path: rel });
+
+    expect(gone).toMatchObject({ dir: "absent", lockEntry: false, clean: true });
+
+    // …and a path the validator refuses is removed by nobody, so it is there.
+    await fs.mkdir(abs, { recursive: true });
+    const escaped = await verify("simple-english", { install_path: "creative/../../escape" });
+    expect(escaped.dir).toBe("present");
+    expect(escaped.clean).toBe(false);
+  });
+});

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -849,6 +849,38 @@ describe("skill_install — a refusal the agent can act on", () => {
     expect(e.next).toMatch(/wifi_status/);
   });
 
+  it("does not tell the agent nothing was installed when the skill is still there", async () => {
+    // The SECOND state behind `incomplete_install`: the skill was already
+    // installed before the request, so the rollback left the owner's copy in
+    // place. The route says so and flags it; the decoder read neither, so the
+    // agent was told "nothing was installed" about a skill that is on the
+    // device, and sent to check the WiFi and retry — which cannot work, because
+    // the installer meets the surviving lock entry and exits 0 without
+    // fetching, landing back on the same missing files.
+    refuse(502, {
+      error:
+        "Some of \"pdf-tools\"'s files are missing from the device. It was already installed "
+        + "before this request, so it was left in place — remove it from the Skills store and "
+        + "install it again.",
+      code: "incomplete_install",
+      preexisting: true,
+      missingFiles: ["reference/pdf.md"],
+    });
+
+    const e = await installErr();
+
+    expect(e.code).toBe("CONFLICT");
+    expect(e.message).not.toMatch(/nothing was installed/i);
+    expect(e.message).toMatch(/already installed|left in place/i);
+    // The missing files are still worth relaying — they are what is wrong.
+    expect(e.message).toMatch(/reference\/pdf\.md/);
+    // The next step that CAN work, and not the one that cannot.
+    expect(e.next).not.toMatch(/wifi_status/);
+    expect(e.next).not.toMatch(/retry once/i);
+    expect(e.next).toMatch(/do NOT retry/i);
+    expect(e.next).toMatch(/skill_uninstall/);
+  });
+
   it("refuses a short name the store cannot narrow down, without inventing an id", async () => {
     refuse(409, { error: "More than one skill goes by that name.", code: "ambiguous_id" });
 


### PR DESCRIPTION
Follow-up to #517. Two residuals found by the adversarial verifiers, both reproduced against the merged head (`c92eec34`) before anything was changed. Both are the same shape as the pattern that round was hunting: **a fact the producer establishes that a sibling consumer never reads.**

## SKILL-01a — the leftover message named a cause the shared verdict no longer guarantees

`src/app/setup-api/hermes/skills/install/route.ts:707` told the customer:

> "…is still listed in the Skills store, **and the entry names no location**, so whether its files are still on the device could not be checked"

When #517 wrote that, it was true: `unknown` had exactly one cause. `rollback()` now delegates to the shared `verifySkillRemoval` (`src/lib/hermes-skills-server.ts`), which sets `dir = await pathState(abs)` after a removal it believes worked — and `pathState` returns `unknown` for **any** non-ENOENT stat error: EACCES on the root-owned subtree the file's own comment says this device family produces, EIO, a stalled mount. So `unknown` grew a second cause, and in that second case the entry **does** name a location, the files are most likely still at it, and the sentence states the opposite of the thing that matters.

The uninstall route, consuming the identical verdict, deliberately claims no cause (`uninstall/route.ts:162-167` collapses everything non-`present` to "it is listed in the Skills store again") — so the two surfaces had started describing one device state differently, which is exactly what sharing `verifySkillRemoval` was supposed to stop.

**Fixed at the source, not in the sentence.** `SkillRemovalDir` now distinguishes the two:

- `unchecked` — nothing ever looked (the entry named no `install_path`, so the removal had nothing to aim at)
- `unknown` — the check ran on the location the entry named and could not answer

No consumer has to guess any more. The install route names the cause only under `unchecked`, where it is a fact, and keeps the consequence — "whether its files were removed could not be checked", which is what the customer needs either way — in both. `clean` is computed exactly as before (`!lockEntry && dir !== 'present'`), so no removal changes its pass/fail.

## SKILL-01b — `preexisting: true` was read by nobody

`install/route.ts:335` emits `preexisting: true` alongside a route message that says the skill *"was already installed before this request, so it was left in place — remove it from the Skills store and install it again."* #517 established the rule that a new refusal state gets its branch in **both** consumers of the install contract, and did that correctly for `rollback_incomplete`. The flag on the `incomplete_install` branch it edited in the same commit got neither:

- `src/components/HermesSkillsStore.tsx:213` discarded `data.error` and threw `COPY.installIncomplete(...)` — "The download was incomplete — missing: {files}" / "Nothing was installed. Check your internet connection and try again." (`en-skills.ts:216-217`, and the nine other locales).
- `mcp/tools/skills.ts:405` told the agent "The skill's download was incomplete, so nothing was installed" and "Call `wifi_status`. If the device is online, retry once."

Both statements are false when the customer's copy is still installed, and both send the user or the agent into a retry that **cannot** work: the installer meets the surviving lock entry, exits 0 without fetching anything, and the completeness check lands on the same missing files — `verifyAndRepair` has already had its go.

Both consumers now branch on the flag. The store shows the route's own sentence (the same fallback `rollback_incomplete` already uses one branch below — the sentence is composed from device state, so it is not catalogue copy) and calls `installed.refresh()`, because the row the customer is being told to remove is the one on screen. `skill_install` returns CONFLICT with "already installed … left in place" and points at `skill_uninstall` then `skill_install`, not at the network. `preexisting?: boolean` is now on `InstallRefusal`.

## How I know I found every sibling

Two greps, both re-run after the change:

**Every reader of the removal verdict** — `grep -rn "SkillRemovalVerdict\|SkillRemovalDir\|verifySkillRemoval\|left\.dir\|\.directory" src/ mcp/ --include=*.ts --include=*.tsx | grep -v src/tests/`

Three files touch it and all three are accounted for: `hermes-skills-server.ts` (producer), `install/route.ts` (both call sites — the sentence at 708-714 and the `leftover.directory` it publishes at 750), `uninstall/route.ts` (163, 176 — its sentence already claimed no cause, so it needed no change and is correct under the new value). `mcp/tools/skills.ts` only re-declares the wire union, which is updated. The only other hits are `git -c safe.directory` in `updater.ts`/`build-identity.ts` and `installed.dir` in `inspect/route.ts`, neither of which is this type.

**Every reader of the refusal flag** — `grep -rn "preexisting" src/ mcp/ --include=*.ts --include=*.tsx | grep -v src/tests/`

Before: one hit, the producer. After: the producer plus both consumers.

**Every caller of the endpoint that produces it** — `grep -rn "skills/install" src/ mcp/ e2e/ --include=*.ts --include=*.tsx | grep -v "src/tests/|install/route.ts"`

Exactly two POST the install route: `src/components/HermesSkillsStore.tsx:189` and `mcp/tools/skills.ts:667`. Every other hit is the `/skills/installed` list endpoint, which is a different route. Both callers are in this diff, so the consumer set is closed rather than sampled. I also enumerated every discriminator the install route can emit (`grep -n 'code: "' src/app/setup-api/hermes/skills/install/route.ts` → 13 codes, plus `requiresConfirmation`, `overridable`, `conflictsWith`, `missingFiles`, `candidates`, `leftover`, `repaired`) and checked each against both consumers; `preexisting` was the only one with no branch on either side.

## Tests — red first

Every one of these was run against unmodified `origin/beta` and failed there:

| Test | File | Fails on beta with |
|---|---|---|
| `reports 'unchecked' when the entry names no location` | `src/tests/unit/hermes-skill-removal-verdict.test.ts` | `expected 'unknown' to be 'unchecked'` |
| `reports the leftover when the CLI exits 0 having removed nothing` (existing test, tightened) | `src/tests/routes/hermes/skills-install-rollback.test.ts` | `directory: "unknown"` ≠ `"unchecked"` |
| `does not claim the entry named no location when it named one` | `src/tests/routes/hermes/skills-install-rollback.test.ts` | `expected '…' not to match /names no location/i` |
| `does not tell the customer nothing was installed` | `src/tests/components/hermes-skills-preexisting-incomplete.test.tsx` | route sentence not on screen |
| `re-reads the installed list…` | `src/tests/components/hermes-skills-preexisting-incomplete.test.tsx` | `expected 1 to be greater than 1` |
| `does not tell the agent nothing was installed when the skill is still there` | `src/tests/unit/mcp-tool-honesty.test.ts` | `expected '…' not to match /nothing was installed/i` |

**RED 6 → GREEN 6.** Four further companion tests guard the other direction and pass on both trees: the two answers a `stat` *can* give, `unknown` staying distinct from `unchecked`, the download story surviving for the state it actually describes, and the store not refetching for a refusal that changed nothing on the device.

`vitest run` over the touched suites plus their siblings (`skills-install-rollback`, `skills-install-preexisting`, `skills-uninstall-directory`, `hermes-skills-leftover-refresh`, `mcp-tool-honesty`, and the two new files): **97 passed**. `tsc --noEmit` clean; `eslint` over the repo clean; `tsc -p mcp/tsconfig.json` reports the same three pre-existing DOM-lib errors as `origin/beta`, unchanged.

## Review

CodeRabbit found a real consequence of the store fix, fixed in `ce4b1778`: refreshing the installed list put the row on screen, but `renderBrowseAction` answered the error state before it resolved the installed one, so the Browse card offered **Retry** — the one action that cannot work here — and hid **Remove**, which is what the refusal asks for. The removable target is now resolved first and the error branch prefers it; `uninstallTargetFor` returns null for anything the store cannot remove, so a skill that is genuinely not installed keeps Retry. Two more regression tests pin both directions.

## Severity

SKILL-01a is low and SKILL-01b is medium; both are Hermes edition, on shipped aarch64 hardware, and neither is arch-gated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete skill installations, including cases where a previous installation already exists.
  * Provides clearer guidance to remove an existing installation before retrying.
  * Reports cleanup status more accurately when installation locations are unavailable or cannot be verified.
  * Refreshes the installed-skills list before displaying relevant installation errors.

* **Tests**
  * Added coverage for pre-existing installations, rollback outcomes, cleanup verification, and accurate error classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
