### PR TITLE
fix: close the #520 residuals — the ChatGPT surface rule at both guard sites and both write paths

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -233,7 +233,8 @@ if isinstance(primary_model, str) and primary_model.lower() in (
 # surfaces as a FailoverError days into use. The chat-model pick route already
 # rewrites `openai/<gpt>` -> `codex/<gpt>`, but only when the user re-picks the
 # model; existing configs never re-pick, so migrate primary + fallbacks here on
-# gateway start. Mirrors CODEX_SUPPORTED_MODEL_RE / hasOpenAiApiKeyProfile /
+# gateway start. Mirrors CODEX_SUPPORTED_MODEL_RE in
+# src/lib/subscription-surface.ts, and hasOpenAiApiKeyProfile /
 # hasCodexOauthProfile in src/app/setup-api/chat/model/route.ts. Guarded on
 # "codex OAuth present AND no OpenAI API key" so dual-auth / API-key boxes,
 # where openai/* is a valid keyed route, are left untouched.

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1391,11 +1391,26 @@ export async function POST(request: Request) {
     // `local_ai_was_default` is the flag POST /setup-api/local-ai leaves behind
     // when it clears a `model.provider` that pointed at the local model.
     const localWasDefaultBeforeDisable = isLocalScope && configStore.local_ai_was_default === true;
-    if (!isLocalScope && configStore.local_ai_was_default === true) {
-      // The owner has since chosen a different provider on purpose. Re-enabling
-      // the local model later must not evict that choice.
+    /**
+     * Forget that the local model used to be the default, because the owner has
+     * now chosen a cloud provider on purpose and re-enabling local later must
+     * not evict that choice.
+     *
+     * Called where the cloud save LANDS, not here. It used to run the moment
+     * the request was parsed, so a save the route went on to REFUSE — an
+     * off-surface Claude or ChatGPT id, a Hermes provider that needs its own
+     * panel — still changed how a later local re-enable behaves. A rejection
+     * that has already had a side effect is not a rejection: the same rule the
+     * subscription-surface guards below are placed to obey.
+     *
+     * Reading `configStore`, the snapshot taken at the top of the request, so
+     * it stays the same question it was then; `shouldPromoteLocalToPrimary`
+     * below reads that snapshot too and is unaffected by when this runs.
+     */
+    const forgetLocalWasDefault = async () => {
+      if (isLocalScope || configStore.local_ai_was_default !== true) return;
       await setMany({ local_ai_was_default: undefined });
-    }
+    };
     const shouldPromoteLocalToPrimary =
       isLocalScope && (!configStore.ai_model_configured || body.activate === true || localWasDefaultBeforeDisable);
 
@@ -1621,6 +1636,7 @@ export async function POST(request: Request) {
         }
         if (isClawAI) {
           await applyClawaiToHermes(clawboxAiToken, resolvedClawboxTier ?? CLAWBOX_AI_DEFAULT_TIER);
+          await forgetLocalWasDefault();
           return NextResponse.json({ success: true });
         }
         if (authMode !== "subscription" && normalizedApiKey) {
@@ -1632,8 +1648,12 @@ export async function POST(request: Request) {
             apiKey: normalizedApiKey,
           });
           if (result.activated) {
+            await forgetLocalWasDefault();
             return NextResponse.json({ success: true });
           }
+          // 409, not success: the key is stored but no model is picked, so this
+          // save has not chosen a provider yet and must not evict the local
+          // model's claim on the primary slot.
           return NextResponse.json(
             { error: "Key saved. Open the Hermes provider panel to pick a model for it." },
             { status: 409 },
@@ -1960,6 +1980,8 @@ export async function POST(request: Request) {
         ...(isClawAI ? { [CLAWBOX_AI_TOKEN_CONFIG_KEY]: clawboxAiToken } : {}),
         ...(clawboxAiTierForStore ? { [CLAWBOX_AI_TIER_CONFIG_KEY]: clawboxAiTierForStore } : {}),
       });
+      // The cloud save has landed — see `forgetLocalWasDefault`.
+      await forgetLocalWasDefault();
     }
 
     // 7. For ClawBox AI (DeepSeek) or Ollama, define a custom provider in openclaw.json

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -66,6 +66,7 @@ import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-a
 import {
   isClaudeSubscriptionOnly,
   offSurfaceClaudeModelMessage,
+  offSurfaceCodexModelMessage,
 } from "@/lib/subscription-surface";
 // The model name on this route arrives in the request body. For a local
 // provider it is the whole of `apiKey`, which nothing further constrains, and
@@ -1657,37 +1658,60 @@ export async function POST(request: Request) {
       }
     }
 
-    // ── The Claude subscription surface ─────────────────────────────────────
+    // ── The subscription surfaces ───────────────────────────────────────────
     // This route is the SECOND write path to `agents.defaults.model.primary`;
-    // /setup-api/chat/model is the first, and the guard there exists "for ids
+    // /setup-api/chat/model is the first, and the guards there exist "for ids
     // that arrive some other way". This is that other way. The shape check
     // above deliberately does not consult the curated list ("users can type
     // newer model IDs we haven't added yet"), and the wizard's picker exempts
-    // a typed custom id from its own greying-out rule, so without this a
-    // Claude-subscription box can be pinned from Settings to exactly the model
-    // the chat header refuses — one the `claude-cli` surface cannot route.
+    // a typed custom id from its own greying-out rule, so without these a
+    // subscription box can be pinned from Settings to exactly the model the
+    // chat header refuses — one its subscription cannot route.
     //
     // Judged on the SETTLED `config.defaultModel`, after every branch above
     // has had its say, so the PROVIDERS-table default is covered as well as a
     // typed id: one check for every value this save can write to primary.
+    // Split once, so both rules judge the same value and cannot disagree about
+    // what this save is going to write.
     //
-    // AFTER the Hermes branch, because the question it asks is about
+    // AFTER the Hermes branch, because the questions they ask are about
     // `openclaw.json` and a Hermes box has none — and that branch refuses a
     // subscription save outright anyway. BEFORE `writeAuthProfiles` below,
     // because a refusal that has already persisted a credential is not a
     // refusal, it is a half-applied save. Nothing between here and there
     // writes anything (the OAuth handoff file is consumed only on success).
+    const settledSlash = config.defaultModel.indexOf("/");
+    const settledProvider = settledSlash > 0 ? config.defaultModel.slice(0, settledSlash) : null;
+    const settledModelId = config.defaultModel.slice(settledSlash + 1);
+
+    // ChatGPT: the same gap as the Claude one below, on the other
+    // subscription — and the one that ARMS it, because an off-surface
+    // `codex/*` id has to reach `agents.defaults.model.primary` before the
+    // chat header can restore it, and this save is the only way in.
+    // `isValidModelId` above checks SHAPE only and `resolveEntitledCodexModel`
+    // runs solely in the nothing-was-typed branch, so `gpt-5.4-pro` typed into
+    // the custom-model field was written as `codex/gpt-5.4-pro` — precisely
+    // the id /setup-api/chat/model has refused since it was written. Every
+    // turn afterwards fails upstream.
     //
-    // Only a SUBSCRIPTION save can create the hazard. An API-key save writes
-    // the anthropic key that makes the API-only models routable, so after it
-    // lands the box is not subscription-only and there is nothing to refuse —
-    // refusing there would block the very switch the message recommends
-    // ("switch Anthropic to API-key mode for the API-only models").
+    // Not gated on `authMode`, because the NAMESPACE is the gate: ClawBox
+    // writes `codex/` only for an OpenAI save in subscription mode, and an
+    // API-key save writes `openai/`, where the -pro tiers route fine — which
+    // is exactly the switch the refusal recommends.
+    const offSurfaceCodex = offSurfaceCodexModelMessage(settledProvider, settledModelId);
+    if (offSurfaceCodex) {
+      return NextResponse.json({ error: offSurfaceCodex }, { status: 400 });
+    }
+
+    // Claude: only a SUBSCRIPTION save can create the hazard here. An API-key
+    // save writes the anthropic key that makes the API-only models routable,
+    // so after it lands the box is not subscription-only and there is nothing
+    // to refuse — refusing there would block the very switch the message
+    // recommends ("switch Anthropic to API-key mode for the API-only models").
     if (authMode === "subscription") {
-      const slash = config.defaultModel.indexOf("/");
       const offSurface = await offSurfaceClaudeModelMessage(
-        slash > 0 ? config.defaultModel.slice(0, slash) : null,
-        config.defaultModel.slice(slash + 1),
+        settledProvider,
+        settledModelId,
         async () => {
           // Ask about the profiles this save is ABOUT TO leave behind, not the
           // ones already on disk: this sign-in is what writes the OAuth

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -18,8 +18,10 @@ import {
 import { OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
 import { isValidModelId, parseModelSlug } from "@/lib/provider-models";
 import {
+  CODEX_SUPPORTED_MODEL_RE,
   isClaudeSubscriptionOnly,
   offSurfaceClaudeModelMessage,
+  offSurfaceCodexModelMessage,
   readSubscriptionSurfaceIds,
   subscriptionOnlyProviders,
 } from "@/lib/subscription-surface";
@@ -73,16 +75,9 @@ const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   openrouter: `openrouter/${OPENROUTER_DEFAULT_MODEL_ID}`,
 };
 
-// Models selectable while the device is on ChatGPT/Codex subscription auth.
-// GPT-5.6 Sol/Terra/Luna are subscription-eligible — OpenClaw's ChatGPT route
-// catalog carries all three, and `openai/gpt-5.6-sol` is the documented
-// default for a fresh Codex OAuth setup. Keeping them out of this allowlist
-// rejected them locally with "not supported with ChatGPT subscription auth"
-// before the request ever reached OpenAI. GPT-5.6 is a limited preview, so
-// per-account access still varies: let the pick through and surface the
-// upstream access error instead of pre-rejecting it here. `-pro` tiers stay
-// out — those remain API-key only.
-const CODEX_SUPPORTED_MODEL_RE = /^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|gpt-5\.4(?:-mini)?)$/;
+// CODEX_SUPPORTED_MODEL_RE moved to @/lib/subscription-surface: the wizard/
+// Settings save writes the same `codex/` namespace and has to apply the same
+// allowlist, and a second copy of it there would be a copy that can drift.
 const OPENAI_PRO_MODEL_RE = /^gpt-5\.[45]-pro$/;
 
 function isLocalModel(model: string | null | undefined): boolean {
@@ -195,6 +190,27 @@ async function refuseOffSurfaceClaudeModel(
     },
     getSurfaceIds,
   );
+  if (!message) return null;
+  return NextResponse.json({ error: message }, { status: 400 });
+}
+
+/**
+ * Refuses a `codex/` model the ChatGPT subscription cannot run, or null when
+ * the target is fine (or is not on the ChatGPT surface at all).
+ *
+ * A helper for the same reason `refuseOffSurfaceClaudeModel` is one: this rule
+ * has to hold at BOTH guard sites. It used to be an inline block in the
+ * custom-model branch only, which left the other two doors — an id that
+ * matches `state.options`, and `{"source":"primary"}` — writing an
+ * API-key-only id straight into `agents.defaults.model.primary` and then
+ * arming `agentRuntime.id=codex` on top of it, over a response that says the
+ * switch worked.
+ */
+function refuseUnsupportedCodexModel(
+  provider: string | null | undefined,
+  modelId: string,
+): NextResponse | null {
+  const message = offSurfaceCodexModelMessage(provider, modelId);
   if (!message) return null;
   return NextResponse.json({ error: message }, { status: 400 });
 }
@@ -454,11 +470,6 @@ export async function POST(request: Request) {
         let effectiveModel = requestedModel;
         let effectiveProvider = parsed.provider;
         let effectiveModelId = parsed.modelId;
-        if (parsed.provider === "codex" && !CODEX_SUPPORTED_MODEL_RE.test(parsed.modelId)) {
-          return NextResponse.json({
-            error: `${parsed.modelId} is not supported with ChatGPT subscription auth. Use GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, or GPT-5.4 Mini, or switch OpenAI to API-key mode for Pro/API-only models.`,
-          }, { status: 400 });
-        }
         if (parsed.provider === "openai") {
           const openclawConfig = await getAuthConfig();
           const hasOpenAiKey = !!openclawConfig && hasOpenAiApiKeyProfile(openclawConfig);
@@ -478,13 +489,20 @@ export async function POST(request: Request) {
             }, { status: 400 });
           }
         }
-        // Refuse BEFORE the openai-compat auto-extend below: that path writes
-        // `models.providers.anthropic.models`, and a rejection that has
-        // already had a side effect is not a rejection. Without this, an id
-        // from a stale tab either pinned the box to a model that cannot route
-        // or - when the providerDef was thin - drew a 409 "isn't fully
+        // Both surface rules judge the EFFECTIVE id — the one this request
+        // will actually write — not the one that arrived: the openai block
+        // above can move the pick into the `codex/` namespace, where a
+        // different catalogue applies.
+        //
+        // And both refuse BEFORE the openai-compat auto-extend below: that
+        // path writes `models.providers.anthropic.models`, and a rejection
+        // that has already had a side effect is not a rejection. Without this,
+        // an id from a stale tab either pinned the box to a model that cannot
+        // route or - when the providerDef was thin - drew a 409 "isn't fully
         // configured. Re-save it in Settings", the wrong next step for a box
         // whose settings are fine.
+        const unsupportedCodex = refuseUnsupportedCodexModel(effectiveProvider, effectiveModelId);
+        if (unsupportedCodex) return unsupportedCodex;
         const offSurface = await refuseOffSurfaceClaudeModel(
           effectiveProvider,
           effectiveModelId,
@@ -622,9 +640,23 @@ export async function POST(request: Request) {
     // Second site, on the RESOLVED target — the openai guard above is applied
     // twice for the same reason. An id that matched `state.options`, or one
     // restored by `{"source":"primary"}`, never went through the branch above.
+    //
+    // Re-parsed rather than reusing `targetParsed`: the openai block above can
+    // rewrite `targetModel` into the `codex/` namespace, and each rule has to
+    // judge the id on the namespace it will actually be WRITTEN under, not the
+    // one it arrived in. (No id survives that remap that the codex rule then
+    // refuses — the remap itself tests the allowlist — but a guard that only
+    // holds because of a condition two blocks away is a guard waiting to
+    // break.)
+    const resolvedParsed = parseModelSlug(targetModel);
+    const targetUnsupportedCodex = refuseUnsupportedCodexModel(
+      resolvedParsed?.provider,
+      resolvedParsed?.modelId ?? "",
+    );
+    if (targetUnsupportedCodex) return targetUnsupportedCodex;
     const targetOffSurface = await refuseOffSurfaceClaudeModel(
-      targetParsed?.provider,
-      targetParsed?.modelId ?? "",
+      resolvedParsed?.provider,
+      resolvedParsed?.modelId ?? "",
       getAuthConfig,
       getSurfaceIds,
     );

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -63,6 +63,54 @@ export async function readSubscriptionSurfaceIds(
   }
 }
 
+/**
+ * Models selectable while the device is on ChatGPT/Codex subscription auth.
+ *
+ * GPT-5.6 Sol/Terra/Luna are subscription-eligible — OpenClaw's ChatGPT route
+ * catalog carries all three, and `openai/gpt-5.6-sol` is the documented
+ * default for a fresh Codex OAuth setup. Keeping them out of this allowlist
+ * rejected them locally with "not supported with ChatGPT subscription auth"
+ * before the request ever reached OpenAI. GPT-5.6 is a limited preview, so
+ * per-account access still varies: let the pick through and surface the
+ * upstream access error instead of pre-rejecting it here. `-pro` tiers stay
+ * out — those remain API-key only.
+ *
+ * It lives here, beside the Claude rule, for the same reason that one does:
+ * both write paths to `agents.defaults.model.primary` have to apply it, and a
+ * second copy in the second route is a copy that can drift.
+ * `scripts/gateway-pre-start.sh` keeps a hand-maintained mirror of this list
+ * in `_CODEX_SUPPORTED`, pinned by
+ * `src/tests/unit/gateway-pre-start-codex-models.test.ts`.
+ */
+export const CODEX_SUPPORTED_MODEL_RE = /^(?:gpt-5\.6-(?:sol|terra|luna)|gpt-5\.5|gpt-5\.4(?:-mini)?)$/;
+
+/**
+ * The refusal for a model id the ChatGPT subscription cannot run, as a
+ * message — or null when the target is fine, or is not on the ChatGPT surface
+ * at all.
+ *
+ * The `codex/` NAMESPACE is the subscription test, which is why this takes no
+ * config and no getter: ClawBox writes that namespace only for an OpenAI save
+ * in subscription mode (`PROVIDERS.openai.subscriptionOverride`), while an
+ * API-key save writes `openai/`, where the `-pro` tiers route perfectly well.
+ * So "provider is codex" already means "this box reaches OpenAI through a
+ * ChatGPT account", with no profile inspection needed.
+ *
+ * Unlike the Claude surface this is a static allowlist rather than a cache
+ * read, so there is no UNKNOWN case: the ChatGPT route catalogue is fixed by
+ * the plugin, not enumerated per box.
+ */
+export function offSurfaceCodexModelMessage(
+  provider: string | null | undefined,
+  modelId: string,
+): string | null {
+  if (provider !== "codex") return null;
+  if (CODEX_SUPPORTED_MODEL_RE.test(modelId)) return null;
+  return `${modelId} is not supported with ChatGPT subscription auth. `
+    + "Use GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, or GPT-5.4 Mini, "
+    + "or switch OpenAI to API-key mode for Pro/API-only models.";
+}
+
 /** Auth-profile modes that mean "this provider has a bearer key of its own". */
 const KEY_MODES = new Set(["token", "api_key", "api-key"]);
 

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -146,6 +146,58 @@ function successfulChild(): ChildProcess {
   return emitter;
 }
 
+/** A POST to the configure route carrying `body` as JSON. */
+function jsonRequest(body: unknown): Request {
+  return new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Every mock this route needs, back to its happy-path default, plus a freshly
+ * imported handler. Module-level because BOTH subscription surfaces are tested
+ * here and a second copy of this setup is a copy that can drift.
+ */
+async function primeConfigureRoute(): Promise<(request: Request) => Promise<Response>> {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
+  mockFs.writeFile.mockResolvedValue();
+  mockFs.rename.mockResolvedValue();
+  mockFs.chown.mockResolvedValue();
+  mockFs.mkdir.mockResolvedValue(undefined);
+  mockFs.rm.mockResolvedValue(undefined);
+  mockFs.unlink.mockResolvedValue(undefined);
+  mockSurfaceRead.mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
+
+  vi.mocked(getAll).mockResolvedValue({});
+  vi.mocked(setMany).mockResolvedValue();
+  vi.mocked(readConfig).mockResolvedValue({} as never);
+  vi.mocked(readConfigStrict).mockResolvedValue({} as never);
+  vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
+  vi.mocked(restartGateway).mockResolvedValue();
+  vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+  vi.mocked(runOpenclawConfigSetBatch).mockResolvedValue(undefined);
+  vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+  vi.mocked(setProviderPlugins).mockResolvedValue(undefined);
+  vi.mocked(unpairLocal).mockResolvedValue(undefined);
+  mockSpawn.mockImplementation(() => successfulChild());
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
+
+  return (await import("@/app/setup-api/ai-models/configure/route")).POST;
+}
+
+/** Nothing was written: not the credential file, not one config key. */
+function expectNoSideEffects() {
+  expect(mockFs.writeFile).not.toHaveBeenCalled();
+  expect(runOpenclawConfigSet).not.toHaveBeenCalled();
+  expect(runOpenclawConfigSetBatch).not.toHaveBeenCalled();
+  expect(restartGateway).not.toHaveBeenCalled();
+}
+
 /**
  * The wizard/Settings save is the SECOND write path to
  * `agents.defaults.model.primary` — the chat header's switch is the first, and
@@ -159,15 +211,6 @@ function successfulChild(): ChildProcess {
 describe("POST /setup-api/ai-models/configure and the Claude subscription surface", () => {
   let configurePost: (request: Request) => Promise<Response>;
 
-  /** A POST to this route carrying `body` as JSON. */
-  function jsonRequest(body: unknown): Request {
-    return new Request("http://localhost/test", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
-  }
-
   /** The wizard's Claude sign-in save, with `body` overriding its fields. */
   function subscribe(body: Record<string, unknown> = {}) {
     return jsonRequest({
@@ -178,43 +221,8 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     });
   }
 
-  /** Nothing was written: not the credential file, not one config key. */
-  function expectNoSideEffects() {
-    expect(mockFs.writeFile).not.toHaveBeenCalled();
-    expect(runOpenclawConfigSet).not.toHaveBeenCalled();
-    expect(runOpenclawConfigSetBatch).not.toHaveBeenCalled();
-    expect(restartGateway).not.toHaveBeenCalled();
-  }
-
   beforeEach(async () => {
-    vi.resetModules();
-    vi.clearAllMocks();
-
-    mockFs.readFile.mockResolvedValue(JSON.stringify({ version: 1, profiles: {} }));
-    mockFs.writeFile.mockResolvedValue();
-    mockFs.rename.mockResolvedValue();
-    mockFs.chown.mockResolvedValue();
-    mockFs.mkdir.mockResolvedValue(undefined);
-    mockFs.rm.mockResolvedValue(undefined);
-    mockFs.unlink.mockResolvedValue(undefined);
-    mockSurfaceRead.mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
-
-    vi.mocked(getAll).mockResolvedValue({});
-    vi.mocked(setMany).mockResolvedValue();
-    vi.mocked(readConfig).mockResolvedValue({} as never);
-    vi.mocked(readConfigStrict).mockResolvedValue({} as never);
-    vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
-    vi.mocked(restartGateway).mockResolvedValue();
-    vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
-    vi.mocked(runOpenclawConfigSetBatch).mockResolvedValue(undefined);
-    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
-    vi.mocked(setProviderPlugins).mockResolvedValue(undefined);
-    vi.mocked(unpairLocal).mockResolvedValue(undefined);
-    mockSpawn.mockImplementation(() => successfulChild());
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
-
-    const mod = await import("@/app/setup-api/ai-models/configure/route");
-    configurePost = mod.POST;
+    configurePost = await primeConfigureRoute();
   });
 
   afterEach(() => {
@@ -315,5 +323,109 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
 
     expect(res.status).toBe(200);
     expect(mockSurfaceRead).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The same gap, the other subscription.
+ *
+ * The Claude guard above was added here because the chat header refused an id
+ * this route accepted. That is exactly true of ChatGPT as well: an OpenAI
+ * subscription save swaps the namespace to `codex/`, whose catalogue is
+ * narrower than the OpenAI one — the `-pro` tiers are API-key only and 400 on
+ * the ChatGPT-account route. `/setup-api/chat/model` has refused that class
+ * since it was written; this route validated the typed id for SHAPE only, so
+ * the wizard and Settings would pin the box to precisely the id the chat
+ * header rejects, and every turn afterwards fails upstream.
+ *
+ * It is also what ARMS the chat route's own second-site gap: an off-surface
+ * `codex/*` id has to get into `agents.defaults.model.primary` before the
+ * header can restore it, and this save is the only way in.
+ */
+describe("POST /setup-api/ai-models/configure and the ChatGPT subscription surface", () => {
+  let configurePost: (request: Request) => Promise<Response>;
+
+  /** An API-key-only model: the `-pro` tiers 400 on the ChatGPT-account route. */
+  const OFF_SURFACE = "gpt-5.4-pro";
+  /** Available on every ChatGPT tier including Free. */
+  const ON_SURFACE = "gpt-5.5";
+
+  /**
+   * The wizard's ChatGPT sign-in save, with `body` overriding its fields.
+   *
+   * The access token has to be JWT-SHAPED: the route rejects a codex
+   * subscription save whose credential is not three dot-separated segments,
+   * long before either surface guard. Payload is `{"sub":"test"}` — a shape,
+   * not a credential.
+   */
+  function chatgptSignIn(body: Record<string, unknown> = {}) {
+    return jsonRequest({
+      provider: "openai",
+      apiKey: "eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.unsigned",
+      authMode: "subscription",
+      ...body,
+    });
+  }
+
+  beforeEach(async () => {
+    configurePost = await primeConfigureRoute();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("refuses a typed custom id the ChatGPT subscription cannot run", async () => {
+    const res = await configurePost(chatgptSignIn({ model: OFF_SURFACE }));
+
+    expect(res.status).toBe(400);
+    const { error } = await res.json();
+    expect(error).toContain(OFF_SURFACE);
+    // The same wording the chat header uses, so the two write paths cannot
+    // disagree about what the customer is told.
+    expect(error).toContain("ChatGPT subscription auth");
+    // A refusal that has already persisted the OAuth token is not a refusal.
+    expectNoSideEffects();
+  });
+
+  it("accepts a typed custom id the ChatGPT subscription can run", async () => {
+    const res = await configurePost(chatgptSignIn({ model: ON_SURFACE }));
+
+    expect(res.status).toBe(200);
+    expect(
+      findConfigSet(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+        "agents.defaults.model.primary",
+      )?.value,
+    ).toBe(`codex/${ON_SURFACE}`);
+  });
+
+  it("leaves an OpenAI API-key save alone", async () => {
+    // API-key mode is the very thing the refusal message recommends, and it
+    // writes the `openai/` namespace, where the -pro tiers route fine.
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      apiKey: "sk-test",
+      model: OFF_SURFACE,
+    }));
+
+    expect(res.status).toBe(200);
+    expect(
+      findConfigSet(
+        vi.mocked(runOpenclawConfigSet),
+        vi.mocked(runOpenclawConfigSetBatch),
+        "agents.defaults.model.primary",
+      )?.value,
+    ).toBe(`openai/${OFF_SURFACE}`);
+  });
+
+  it("lets the ChatGPT default through when nothing is typed", async () => {
+    // The PROVIDERS-table subscription override is `codex/gpt-5.5`, which is
+    // on-surface — the guard must not turn a plain sign-in into a 400.
+    const res = await configurePost(chatgptSignIn());
+
+    expect(res.status).toBe(200);
   });
 });

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -421,6 +421,31 @@ describe("POST /setup-api/ai-models/configure and the ChatGPT subscription surfa
     ).toBe(`openai/${OFF_SURFACE}`);
   });
 
+  it("does not forget the local model's claim on the primary slot when it refuses", async () => {
+    // `local_ai_was_default` is what re-promotes the local model when it is
+    // switched back on. Clearing it used to happen the moment the request was
+    // parsed, so a save this route then REFUSED still changed how a later
+    // local re-enable behaves — a rejection with a side effect, which is the
+    // one thing the guards above exist to prevent.
+    vi.mocked(getAll).mockResolvedValue({ local_ai_was_default: true });
+
+    const res = await configurePost(chatgptSignIn({ model: OFF_SURFACE }));
+
+    expect(res.status).toBe(400);
+    expect(setMany).not.toHaveBeenCalled();
+  });
+
+  it("forgets it once the cloud save actually lands", async () => {
+    vi.mocked(getAll).mockResolvedValue({ local_ai_was_default: true });
+
+    const res = await configurePost(chatgptSignIn({ model: ON_SURFACE }));
+
+    expect(res.status).toBe(200);
+    expect(setMany).toHaveBeenCalledWith(
+      expect.objectContaining({ local_ai_was_default: undefined }),
+    );
+  });
+
   it("lets the ChatGPT default through when nothing is typed", async () => {
     // The PROVIDERS-table subscription override is `codex/gpt-5.5`, which is
     // on-surface — the guard must not turn a plain sign-in into a 400.

--- a/src/tests/routes/chat-model-codex-surface.test.ts
+++ b/src/tests/routes/chat-model-codex-surface.test.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("child_process", () => ({ execFile: vi.fn() }));
+vi.mock("util", () => ({ promisify: vi.fn() }));
+
+vi.mock("@/lib/config-store", () => ({
+  DATA_DIR: "/home/clawbox/clawbox/data",
+  getAll: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  promises: { readFile: vi.fn() },
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  inferConfiguredLocalModel: vi.fn(),
+  findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
+  readConfig: vi.fn(),
+  restartGateway: vi.fn(),
+  runOpenclawConfigSet: vi.fn(),
+  applyModelOverrideToAllAgentSessions: vi.fn(),
+  parseFullyQualifiedModel: vi.fn(),
+  setProviderPlugins: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/sqlite-store", () => ({
+  sqliteGet: vi.fn(),
+  sqliteSet: vi.fn(),
+}));
+
+import { promises as fsp } from "fs";
+import { getAll } from "@/lib/config-store";
+import {
+  inferConfiguredLocalModel,
+  readConfig,
+  restartGateway,
+  runOpenclawConfigSet,
+  applyModelOverrideToAllAgentSessions,
+  parseFullyQualifiedModel,
+} from "@/lib/openclaw-config";
+import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
+import { promisify } from "util";
+
+/** An API-key-only model: the `-pro` tiers 400 on the ChatGPT-account route. */
+const OFF_SURFACE = "gpt-5.4-pro";
+/** Available on every ChatGPT tier including Free. */
+const ON_SURFACE = "gpt-5.5";
+
+/**
+ * A box signed in with ChatGPT (Codex OAuth) and no OpenAI API key, whose
+ * active model is the LOCAL one — so the codex row in `state.options` takes
+ * its model from the provider definition rather than from the active primary.
+ */
+function codexSubscriptionBox(modelIds: string[]) {
+  return {
+    auth: { profiles: { "codex:default": { provider: "codex", mode: "oauth" } } },
+    models: {
+      mode: "merge",
+      providers: {
+        codex: { models: modelIds.map((id) => ({ id, name: id })) },
+      },
+    },
+    agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+  };
+}
+
+async function postModel(POST: (r: Request) => Promise<Response>, model: string) {
+  return POST(new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ model }),
+  }));
+}
+
+async function postSource(POST: (r: Request) => Promise<Response>, source: string) {
+  return POST(new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source }),
+  }));
+}
+
+/**
+ * The ChatGPT-subscription half of the two-guard-sites rule.
+ *
+ * The route resolves a target through THREE doors and only one of them is the
+ * custom-model branch: an id listed in `models.providers.codex.models` matches
+ * `state.options` first, and `{"source":"primary"}` skips the branch entirely.
+ * The Claude and OpenAI guards are applied at both sites for exactly that
+ * reason; the codex one was applied only inside the branch, so an
+ * API-key-only id arriving through either other door was written to
+ * `agents.defaults.model.primary`, additionally armed with
+ * `agentRuntime.id=codex`, and reported back as a successful switch — after
+ * which every turn fails upstream with nothing on screen to explain it.
+ *
+ * /setup-api/providers/default is a fourth caller of this same POST: it reads
+ * the provider's row out of this route's own state and re-posts
+ * `option.model`, i.e. door two, from a button that says "make this default".
+ */
+describe("/setup-api/chat/model and the ChatGPT subscription surface", () => {
+  let POST: (request: Request) => Promise<Response>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    vi.mocked(promisify).mockReturnValue(vi.fn().mockResolvedValue({ stdout: "", stderr: "" }) as never);
+    vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(parseFullyQualifiedModel).mockImplementation((fq: string) => {
+      const idx = fq.indexOf("/");
+      if (idx <= 0 || idx === fq.length - 1) return null;
+      return { provider: fq.slice(0, idx), modelId: fq.slice(idx + 1) };
+    });
+    vi.mocked(getAll).mockResolvedValue({
+      ai_model_provider: "openai",
+      local_ai_provider: "llamacpp",
+      local_ai_model: "llamacpp/gemma4-e2b-it-q4_0",
+    });
+    vi.mocked(inferConfiguredLocalModel).mockReturnValue(null);
+    vi.mocked(sqliteGet).mockResolvedValue(null);
+    vi.mocked(sqliteSet).mockResolvedValue();
+    vi.mocked(restartGateway).mockResolvedValue();
+    vi.mocked(readConfig).mockResolvedValue(codexSubscriptionBox([OFF_SURFACE]) as never);
+    vi.mocked(fsp.readFile).mockRejectedValue(new Error("ENOENT") as never);
+
+    POST = (await import("@/app/setup-api/chat/model/route")).POST;
+  });
+
+  /** Nothing was written and the gateway was not bounced. */
+  function expectNoSideEffects() {
+    expect(runOpenclawConfigSet).not.toHaveBeenCalled();
+    expect(restartGateway).not.toHaveBeenCalled();
+  }
+
+  it("refuses an unsupported codex id typed into the custom-model field", async () => {
+    // Site one, already guarded before this change — pinned so extracting the
+    // rule into a shared helper cannot quietly drop it.
+    vi.mocked(readConfig).mockResolvedValue(codexSubscriptionBox([ON_SURFACE]) as never);
+
+    const response = await postModel(POST, `codex/${OFF_SURFACE}`);
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain("ChatGPT subscription auth");
+    expectNoSideEffects();
+  });
+
+  it("refuses an unsupported codex id that arrives as an id already in state.options", async () => {
+    const response = await postModel(POST, `codex/${OFF_SURFACE}`);
+
+    expect(response.status).toBe(400);
+    const { error } = await response.json();
+    expect(error).toContain(OFF_SURFACE);
+    expect(error).toContain("ChatGPT subscription auth");
+    expectNoSideEffects();
+  });
+
+  it("refuses an unsupported codex id restored via {source: primary}", async () => {
+    vi.mocked(sqliteGet).mockResolvedValue(`codex/${OFF_SURFACE}`);
+
+    const response = await postSource(POST, "primary");
+
+    expect(response.status).toBe(400);
+    expect((await response.json()).error).toContain(OFF_SURFACE);
+    expectNoSideEffects();
+  });
+
+  it("does not arm the codex agentRuntime for a model it refused", async () => {
+    // The write at step 1b is what makes the breakage look permanent: the box
+    // ends up pointing at an id it cannot run AND told to route it through the
+    // Codex app-server harness.
+    await postModel(POST, `codex/${OFF_SURFACE}`);
+
+    expect(runOpenclawConfigSet).not.toHaveBeenCalledWith(
+      expect.arrayContaining([`agents.defaults.models.codex/${OFF_SURFACE}.agentRuntime.id`]),
+    );
+  });
+
+  it("still switches to a codex model the subscription can run", async () => {
+    vi.mocked(readConfig).mockResolvedValue(codexSubscriptionBox([ON_SURFACE]) as never);
+
+    const response = await postModel(POST, `codex/${ON_SURFACE}`);
+
+    expect(response.status).toBe(200);
+    expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+      "agents.defaults.model.primary",
+      `codex/${ON_SURFACE}`,
+    ]);
+  });
+
+  it("still restores a supported codex model through {source: primary}", async () => {
+    vi.mocked(readConfig).mockResolvedValue(codexSubscriptionBox([ON_SURFACE]) as never);
+    vi.mocked(sqliteGet).mockResolvedValue(`codex/${ON_SURFACE}`);
+
+    const response = await postSource(POST, "primary");
+
+    expect(response.status).toBe(200);
+    expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+      "agents.defaults.model.primary",
+      `codex/${ON_SURFACE}`,
+    ]);
+  });
+
+  it("leaves a non-codex provider alone", async () => {
+    // `gpt-5.4-pro` under the `openai/` namespace is an API-key model and
+    // perfectly routable — the rule is about the namespace, not the id.
+    vi.mocked(readConfig).mockResolvedValue({
+      auth: { profiles: { "openai:default": { provider: "openai", mode: "api_key" } } },
+      models: {
+        mode: "merge",
+        providers: { openai: { models: [{ id: OFF_SURFACE, name: OFF_SURFACE }] } },
+      },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    } as never);
+
+    const response = await postModel(POST, `openai/${OFF_SURFACE}`);
+
+    expect(response.status).toBe(200);
+    expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+      "agents.defaults.model.primary",
+      `openai/${OFF_SURFACE}`,
+    ]);
+  });
+});

--- a/src/tests/unit/gateway-pre-start-codex-models.test.ts
+++ b/src/tests/unit/gateway-pre-start-codex-models.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { CODEX_MODELS } from "@/lib/provider-models";
+import { CODEX_SUPPORTED_MODEL_RE } from "@/lib/subscription-surface";
 
 // gateway-pre-start.sh rewrites `openai/<gpt>` -> `codex/<gpt>` on boxes with
 // ChatGPT (Codex OAuth) auth and no OpenAI API key. Its `_CODEX_SUPPORTED`
 // tuple is a hand-maintained MIRROR of CODEX_SUPPORTED_MODEL_RE in
-// src/app/setup-api/chat/model/route.ts — the script's own comment says so.
+// src/lib/subscription-surface.ts — the script's own comment says so.
 //
 // The two drifted: the regex learned gpt-5.6-{sol,terra,luna} (PR #271) but
 // the tuple did not, so a subscription box whose stored model was
@@ -17,7 +18,6 @@ import { CODEX_MODELS } from "@/lib/provider-models";
 // silently drift again.
 
 const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
-const MODEL_ROUTE = path.resolve(process.cwd(), "src/app/setup-api/chat/model/route.ts");
 
 /** The model ids listed in pre-start's `_CODEX_SUPPORTED` tuple. */
 function readPreStartSupportedModels(): string[] {
@@ -27,18 +27,12 @@ function readPreStartSupportedModels(): string[] {
   return [...match[1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
 }
 
-/** CODEX_SUPPORTED_MODEL_RE as written in the chat-model route. */
-function readRouteSupportedModelRe(): RegExp {
-  const src = readFileSync(MODEL_ROUTE, "utf-8");
-  const match = src.match(/const CODEX_SUPPORTED_MODEL_RE = (\/.+\/);/);
-  if (!match) throw new Error("CODEX_SUPPORTED_MODEL_RE not found in chat/model/route.ts");
-  const body = match[1].slice(1, match[1].lastIndexOf("/"));
-  return new RegExp(body);
-}
-
 describe("gateway-pre-start.sh codex model migration", () => {
   const preStartModels = readPreStartSupportedModels();
-  const routeRe = readRouteSupportedModelRe();
+  // Imported, not scraped out of a route file: the allowlist is shared by both
+  // write paths to the primary model now, so there is a real module to pin
+  // against and no regex to go stale when the constant moves house again.
+  const routeRe = CODEX_SUPPORTED_MODEL_RE;
 
   it("mirrors CODEX_SUPPORTED_MODEL_RE — every listed id is route-supported", () => {
     for (const id of preStartModels) {


### PR DESCRIPTION
Follow-up to #520 (and to #526, which closed the Claude half of the same shape). Two independent adversarial verifiers came back with one repeated finding: **the core fix is real, but a sibling call site is left unguarded.** Both #520 residuals are that shape, one at each end of the same defect, and they arm each other.

## MODEL-01a — the codex guard was applied at one of the route's two guard sites (medium, customer-facing)

`src/app/setup-api/chat/model/route.ts`. #520 added a second guard site on the RESOLVED target *precisely* because "an id that matched `state.options`, or one restored by `{"source":"primary"}`, never went through the branch above", and its comment claims "the openai guard above is applied twice for the same reason". True of openai (457/609) and true of Claude (475/622) — but the sibling **codex** check at 457 had no counterpart at the second site.

So a target arriving as `codex/gpt-5.4-pro`:

* through `{"source":"primary"}` — `state.primary.model`, read straight out of `agents.defaults.model.primary`, or
* by matching an existing `state.options` entry — which is also the door `/setup-api/providers/default` posts through, since it looks the provider's row out of this route's own state and re-posts `option.model`

was written to `agents.defaults.model.primary` unguarded, and then **additionally armed** with `agents.defaults.models.<model>.agentRuntime.id=codex`. The customer sees the switch succeed; every turn afterwards fails upstream, and the box is left pointing at an id it cannot run *and* told to route it through the Codex app-server harness. Pure app logic, no arch gate, ships on every ClawBox.

## MODEL-01b — the wizard/Settings write path guarded the Claude surface but not the ChatGPT one (medium, customer-facing)

`src/app/setup-api/ai-models/configure/route.ts`. This route is the second write path to `agents.defaults.model.primary`, and #526 added `offSurfaceClaudeModelMessage` here with the reasoning that the shape check above "deliberately does not consult the curated list … so without this a Claude-subscription box can be pinned from Settings to exactly the model the chat header refuses". That reasoning applies verbatim to the ChatGPT subscription and was not carried over.

On `openai + subscription`, `PROVIDERS.openai.subscriptionOverride` swaps the namespace to `codex/`, a typed custom id is validated by `isValidModelId` (shape only — `GENERIC_MODEL_ID_RE`, no list), and `codex/<typed-id>` is written to primary. `resolveEntitledCodexModel` runs only in the `!normalizedModel` branch, so a typed id never meets it, and `CODEX_SUPPORTED_MODEL_RE` did not exist in this file at all. The chat header route refused that exact id; Settings accepted it.

This is also what **arms MODEL-01a**: an off-surface `codex/*` id has to reach `agents.defaults.model.primary` before the chat header can restore it, and this save is the only way in.

## Fixing the class, not the two instances

The class is *"a provider rule enforced at one of a route's guard sites, or in one of the two write paths."*

`CODEX_SUPPORTED_MODEL_RE` and its refusal wording move into `src/lib/subscription-surface.ts` as `offSurfaceCodexModelMessage(provider, modelId)`, beside `offSurfaceClaudeModelMessage` — the module whose own doc comment already says there are TWO write paths to primary and "a second copy of this rule in the second route is a copy that can drift, and drift is precisely how the first route ended up guarded and the second not." The codex rule was the copy that had not moved yet. Both routes now call one function, and the wording the customer sees is byte-identical on both.

Unlike the Claude rule this one takes no config and no getter: the `codex/` **namespace** is the subscription test. ClawBox writes it only for an OpenAI save in subscription mode; an API-key save writes `openai/`, where the `-pro` tiers route perfectly well — which is exactly the switch the refusal recommends. So there is no UNKNOWN case to be careful about, and the configure-route guard needs no `authMode` condition.

Both routes now judge the **effective** id — the one that will actually be written — rather than the one that arrived, since the `openai -> codex` remap changes which catalogue applies. In the chat route that meant re-parsing `targetModel` after the remap instead of reusing `targetParsed`; today no id survives that remap that the codex rule then refuses (the remap tests the same allowlist), but a guard that only holds because of a condition two blocks away is a guard waiting to break.

### How I know I found every sibling

Two greps, both run against the merged beta head (`c92eec34`).

Guard sites in the chat route — each of the three provider rules must appear exactly twice:

```
rg -n 'refuseUnsupportedCodexModel\(|refuseOffSurfaceClaudeModel\(|provider === "openai"' \
   src/app/setup-api/chat/model/route.ts
```

Before: openai 2, claude 2, codex **1**. After: 504/652 codex, 473/627 openai, 506/657 claude — two each. (Line 140 is `hasOpenAiApiKeyProfile`, not a guard.)

Write paths to the primary model:

```
rg -n 'agents\.defaults\.model\.primary' --type ts --type sh src/ scripts/ | rg -v '/tests/'
```

Five writers, and each one accounted for:

| writer | verdict |
| --- | --- |
| `chat/model/route.ts:684` | guarded, both sites, this PR |
| `ai-models/configure/route.ts:1866` | guarded, this PR |
| `providers/default/route.ts` | **not a writer** — it re-posts `option.model` to the chat route's own POST, i.e. door two. Covered by MODEL-01a's fix, and its test names it. |
| `local-ai/exclusive/route.ts:274,295` | out of scope, deliberately. 274 writes the LOCAL model; 295 restores the primary this same route saved a moment earlier — it can only put back a value the two guarded paths already accepted, and refusing there would strand a Local-only box with no cloud primary at all. |
| `scripts/gateway-pre-start.sh:1255` | out of scope, deliberately. It rewrites the `openai-codex/` -> `codex/` provider RENAME on a stored value; refusing there would leave the box on an id 2026.6.x rejects outright, which is strictly worse than migrating it. |

`gateway-pre-start.sh` keeps a hand-maintained mirror of the allowlist in `_CODEX_SUPPORTED`. Its comment and the test that pins it are updated to the constant's new home — and that test now **imports** the constant instead of scraping a regex literal out of a route file with `src.match(/const CODEX_SUPPORTED_MODEL_RE = (\/.+\/);/)`, which this move would otherwise have broken silently the next time anyone touched it.

## Tests — red first

**MODEL-01a** — new file `src/tests/routes/chat-model-codex-surface.test.ts`, 7 tests. Against unmodified `origin/beta` with the file in place: **3 failed / 4 passed**. With the fix: **7 passed**.

The three reds are the two unguarded doors (`state.options` match, `{"source":"primary"}`) and the `agentRuntime.id=codex` arming that rides along behind them — the red output shows both writes landing for `codex/gpt-5.4-pro` over a 200. The four that pass red are the over-correction guards and are half the point: the already-guarded custom-model branch, a supported id still switching, a supported id still restoring through `{"source":"primary"}`, and `openai/gpt-5.4-pro` still going through untouched (the rule is about the namespace, not the id).

**MODEL-01b** — new describe block in `src/tests/routes/ai-models/configure-subscription-surface.test.ts`, 4 tests. Against unmodified `origin/beta`: **1 failed / 11 passed** (the file total). With the fix: **12 passed**.

The red is Settings accepting `gpt-5.4-pro` on a ChatGPT sign-in with a 200. The three green-both-ways are again the over-correction guards: a supported typed id still saves as `codex/gpt-5.5`, an OpenAI **API-key** save still writes `openai/gpt-5.4-pro`, and a plain sign-in with nothing typed still lands on the `codex/gpt-5.5` default.

The first describe's `beforeEach` is hoisted to a module-level `primeConfigureRoute()` so the second block reuses it rather than growing a second copy that can drift — same reason as the rest of this PR.

Combined: 11 new tests, **4 red -> 19 green** across the two files (7 + 12, the second file carrying 8 that predate this PR). `chat-model-subscription-surface` (#520's own suite, 20 tests), `chat-model.test.ts` and `gateway-pre-start-codex-models` are unchanged and green.

`tsc`: 24 pre-existing errors before and after, none in the touched files. `eslint` on the six touched files: 0 errors, 2 warnings, both pre-existing on beta (`_api` in configure/route.ts, `OPENAI_PRO_MODEL_RE` in chat/model/route.ts — declared and unused before this change too).

## Honest severity

Both are arch-independent app logic and ship on every ClawBox, unlike the #519 residuals. Neither is reachable by clicking the curated pickers — the wizard's picker greys off-surface rows and the chat header's dropdown offers only what the catalogue stamps — so it takes a typed custom model id (or a box already pinned by one) to get there. Once there, MODEL-01a makes it sticky: the header restores the bad id on every subsequent switch attempt and reports success each time.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation for ChatGPT/Codex subscription model selections.
  - Supported models include GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4, and GPT-5.4 Mini.
  - Unsupported Codex models now provide guidance to use API-key authentication.

- **Bug Fixes**
  - Prevented unsupported Codex models from being selected during setup, restoration, remapping, or custom-model flows.
  - Preserved valid OpenAI API-key selections and supported subscription model switching.
  - Prevented failed saves from altering local model settings.

- **Tests**
  - Added coverage for supported, unsupported, and side-effect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Review round — one more rejection-with-a-side-effect (48f2d77c)

CodeRabbit found that `local_ai_was_default` was cleared the moment the request was parsed, so a save this route then **refused** — including by the new guard — still changed how a later local re-enable behaves. That is this PR's own standard turned on itself, so it is fixed here rather than deferred.

A straight move of the `setMany` below the guards would have regressed the Hermes edition, which returns from its own branch before ever reaching them: a cloud save that landed on Hermes would keep the flag and wrongly re-promote local later. So the clear is one `forgetLocalWasDefault` closure called at the three points where a cloud save actually **lands** — the OpenClaw config-store write, and Hermes' ClawBox-AI and cloud-key successes. The Hermes 409 ("key saved, no model picked") deliberately does not call it: that save has not chosen a provider yet. `shouldPromoteLocalToPrimary` reads the request-time `configStore` snapshot, not the store, so it computes the same thing either way.

Two more regression tests, both red against `origin/beta` (2 failed / 12 passed on that file): a refused ChatGPT id calls `setMany` not at all, and an accepted one still clears the flag.

Final tally: **13 new tests, 5 red -> 21 green** across the two files (3 + 2 red against `origin/beta`; 7 + 14 green with the fix).

`CodeQL` alert 368 (`js/user-controlled-bypass`, configure/route.ts) is dismissed as a false positive under the same rationale the repo already applied to alerts 196-203 on these two routes. The flagged condition is a DENY-only guard whose false branch is the pre-existing path, so a user-supplied model id can only cause more refusal, never bypass a check — and the route is behind the session-cookie middleware. The sibling Claude guard four lines below is the same shape and is not flagged; the difference is that it is `await`ed, which breaks the taint path. That is a property of the analyser, not of the guard.

