### PR TITLE
fix: tell a local skill apart from one that is not installed

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -85,6 +85,15 @@ The **id vs name** split is the trap: `skill_install` takes the full store id
 (`official/pdf`), `skill_uninstall` takes the short lock name (`pdf`).
 `skill_install` returns the lock name so the model never has to guess it.
 
+The second trap is **which** installed skills can be removed. A device has three
+origins — `builtin` (shipped with it), `hub` (installed from the store) and
+`local` (a skill directory that is neither: written by the agent, hand-copied,
+or left behind by a failed install rollback). `hermes skills uninstall` works
+off the hub lock, so only `hub` is removable, and that is the single rule
+`skill_list`'s "from the store" mark, `skill_uninstall`'s pre-condition and the
+Skills page's Remove button all use. A `local` skill gets its own refusal: it is
+on the device, it is not built in, and only deleting its folder there removes it.
+
 `skill_install` also carries a `confirm` flag, and it is the one argument the
 model must never set on its own judgement (TASK-452). When the device's scanner
 flags a skill the install route answers 409 with what the skill can do; the tool

--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -14,6 +14,7 @@ import {
   SORT_OPTIONS,
   checkInstallIdentifier,
   isBrowsableSource,
+  isRemovableOrigin,
   isValidQuery,
   isValidSkillName,
 } from "../../src/lib/hermes-skills";
@@ -237,37 +238,16 @@ async function installedSkills(): Promise<InstalledSkill[] | null> {
 }
 
 /**
- * Can `hermes skills uninstall` remove this row?
- *
- * There are THREE origins, not two (src/lib/hermes-skills.ts): `builtin` is a
- * name in .bundled_manifest, `hub` is a key in the hub lock, and `local` is a
- * skill directory that is NEITHER — left by a failed install rollback or a
- * partial removal, hand-copied, written by the agent itself, or every hub skill
- * at once on a box whose lock file got truncated (readHubLock() answers {} for
- * an unreadable lock).
- *
- * The CLI works off the LOCK, so only `hub` can be removed. Deciding this as
- * "not builtin" put `local` on the removable side, which is what let skill_list
- * mark such a row "from the store" and skill_uninstall wave it through to a
- * route that can only answer 404. The Skills page has always used this rule —
- * HermesSkillsStore.tsx offers Remove for `origin === 'hub'` and badges a local
- * skill as unremovable — and the agent and the customer's own page have to give
- * one answer for one device state.
- */
-function isRemovable(s: InstalledSkill): boolean {
-  return s.origin === "hub";
-}
-
-/**
  * Is this row anything OTHER than a skill that shipped with the device? A row
  * with no origin at all is treated as built in, exactly as the uninstall
  * pre-condition does.
  *
- * Deliberately wider than isRemovable(): this is the POST-condition's test, and
- * the half-removed state #517 and TASK-547 both name — the CLI drops the lock
- * entry and cannot delete the directory — brings the row back as `local`. That
- * is a failed uninstall, and narrowing this to `hub` would report it as a
- * success. Only un-shadowing a builtin counts as the name legitimately staying.
+ * Deliberately wider than isRemovableOrigin(), which is what decides whether a
+ * skill can be uninstalled: this is the POST-condition's test, and the
+ * half-removed state #517 and TASK-547 both name — the CLI drops the lock entry
+ * and cannot delete the directory — brings the row back as `local`, which is a
+ * FAILED uninstall. Narrowing this to `hub` would report it as a success. Only
+ * un-shadowing a builtin counts as the name legitimately staying.
  */
 function isStoreSkill(s: InstalledSkill): boolean {
   return !!s.origin && s.origin !== "builtin";
@@ -547,7 +527,7 @@ export function registerSkillTools(reg: Registrar): void {
         // so it has to be the removable rule and nothing wider. A `local` row is
         // not built in either, and saying nothing about it would leave the only
         // unexplained row on the list, so it gets its own mark.
-        if (isRemovable(s)) marks.push("from the store");
+        if (isRemovableOrigin(s.origin)) marks.push("from the store");
         else if (s.origin === "local") marks.push("made on this device, cannot be removed from here");
         if (s.incompatible) marks.push("cannot run here");
         if (s.enabled === false) marks.push("disabled");
@@ -743,11 +723,11 @@ export function registerSkillTools(reg: Registrar): void {
         // The hub copy, not the builtin it may be shadowing: when both are
         // listed under one name, the hub one is the only removable row and its
         // identifier is what the post-condition needs.
-        const entry = before.find((sk) => sk.name === name && isRemovable(sk)) ?? before.find((sk) => sk.name === name);
+        const entry = before.find((sk) => sk.name === name && isRemovableOrigin(sk.origin)) ?? before.find((sk) => sk.name === name);
         if (!entry) {
           throw new ToolError("NOT_FOUND", notInstalledMessage(name), NOT_INSTALLED_NEXT);
         }
-        if (!isRemovable(entry)) {
+        if (!isRemovableOrigin(entry.origin)) {
           // Three origins, three answers. Calling a `local` skill built in would
           // be wrong (it did not ship with the device) and letting it through to
           // the route would earn a 404 that reads as "there is no such skill" —

--- a/mcp/tools/skills.ts
+++ b/mcp/tools/skills.ts
@@ -120,10 +120,16 @@ const INSTALL_RULES: ErrorRule[] = [
   },
 ];
 
-// The two reasons a skill cannot be removed, worded once. skill_uninstall can
-// reach either conclusion twice over — from the installed list in its own
-// pre-condition, or from the route's 404/409 when that list could not be read —
-// and one device state must not produce two different sentences.
+// The reasons a skill cannot be removed, worded once per DEVICE STATE.
+// skill_uninstall can reach a conclusion two ways — from the installed list in
+// its own pre-condition, or from the route's 404/409 when that list could not be
+// read — and one device state must not produce two different sentences.
+//
+// The pre-condition's three refusals below are for states it can actually tell
+// apart, because it has the list. The route's `not_installed` is worded
+// separately, in uninstallRules(), for the opposite reason: from there the list
+// is unreadable, so "not on the device" and "here but not from the store" are
+// one indistinguishable state and only the weaker of the two claims is true.
 const notInstalledMessage = (name: string) =>
   `There is no installed skill called "${name}" on this device.`;
 const NOT_INSTALLED_NEXT =
@@ -132,6 +138,15 @@ const builtinMessage = (name: string) => `"${name}" came with the device, so it 
 const BUILTIN_NEXT =
   "Only skills that skill_list marks \"from the store\" can be removed. "
   + "Tell the user this one is built in. Do not retry.";
+// The THIRD origin. `hermes skills uninstall` works off the hub lock, so a
+// directory that is in neither the lock nor .bundled_manifest cannot be removed
+// from here — by the store either, which is why the Skills page has always
+// badged it rather than offering Remove.
+const localMessage = (name: string) =>
+  `"${name}" is on this device but was not installed from the skill store, `
+  + "so it cannot be removed from here.";
+const LOCAL_NEXT =
+  "Do not retry. Tell the user its folder has to be deleted on the device.";
 
 /**
  * Built per call so the refusals can name the skill, exactly as the
@@ -154,11 +169,20 @@ const uninstallRules = (name: string): ErrorRule[] => [
     next: "Call skill_list and pass the name field of the skill you want removed.",
   },
   {
+    // The route reaches `not_installed` for a name that is in neither the hub
+    // lock nor .bundled_manifest — which is a name the device does not have AND
+    // a name it has as a `local` directory, and its own sentence says "No STORE
+    // skill called x is installed". This rule only ever runs when the installed
+    // list could not be read, so the two cannot be told apart here; claiming the
+    // stronger of them is how a skill that skill_list shows came to be reported
+    // as not installed at all.
     status: 404,
     match: /"code"\s*:\s*"not_installed"/,
     code: "NOT_FOUND",
-    message: notInstalledMessage(name),
-    next: NOT_INSTALLED_NEXT,
+    message: `There is no installed skill called "${name}" that came from the skill store.`,
+    next:
+      "Do not retry this name. Call skill_list: if it is not listed, it is not installed; "
+      + "if it is listed, it was made on this device and its folder has to be deleted there.",
   },
   {
     status: 409,
@@ -213,9 +237,37 @@ async function installedSkills(): Promise<InstalledSkill[] | null> {
 }
 
 /**
- * Is this row a skill the store put there, as opposed to one that shipped with
- * the device? `origin` is "builtin" | "hub" | "local"; a row with no origin at
- * all is treated as built in, exactly as the uninstall pre-condition does.
+ * Can `hermes skills uninstall` remove this row?
+ *
+ * There are THREE origins, not two (src/lib/hermes-skills.ts): `builtin` is a
+ * name in .bundled_manifest, `hub` is a key in the hub lock, and `local` is a
+ * skill directory that is NEITHER — left by a failed install rollback or a
+ * partial removal, hand-copied, written by the agent itself, or every hub skill
+ * at once on a box whose lock file got truncated (readHubLock() answers {} for
+ * an unreadable lock).
+ *
+ * The CLI works off the LOCK, so only `hub` can be removed. Deciding this as
+ * "not builtin" put `local` on the removable side, which is what let skill_list
+ * mark such a row "from the store" and skill_uninstall wave it through to a
+ * route that can only answer 404. The Skills page has always used this rule —
+ * HermesSkillsStore.tsx offers Remove for `origin === 'hub'` and badges a local
+ * skill as unremovable — and the agent and the customer's own page have to give
+ * one answer for one device state.
+ */
+function isRemovable(s: InstalledSkill): boolean {
+  return s.origin === "hub";
+}
+
+/**
+ * Is this row anything OTHER than a skill that shipped with the device? A row
+ * with no origin at all is treated as built in, exactly as the uninstall
+ * pre-condition does.
+ *
+ * Deliberately wider than isRemovable(): this is the POST-condition's test, and
+ * the half-removed state #517 and TASK-547 both name — the CLI drops the lock
+ * entry and cannot delete the directory — brings the row back as `local`. That
+ * is a failed uninstall, and narrowing this to `hub` would report it as a
+ * success. Only un-shadowing a builtin counts as the name legitimately staying.
  */
 function isStoreSkill(s: InstalledSkill): boolean {
   return !!s.origin && s.origin !== "builtin";
@@ -490,7 +542,13 @@ export function registerSkillTools(reg: Registrar): void {
       // is 2 KB of noise that says nothing.
       const lines = (body.skills ?? []).map((s) => {
         const marks: string[] = [];
-        if (s.origin && s.origin !== "builtin") marks.push("from the store");
+        // "from the store" is the mark this tool's own description, the header
+        // below and skill_uninstall's builtin refusal all use to mean REMOVABLE,
+        // so it has to be the removable rule and nothing wider. A `local` row is
+        // not built in either, and saying nothing about it would leave the only
+        // unexplained row on the list, so it gets its own mark.
+        if (isRemovable(s)) marks.push("from the store");
+        else if (s.origin === "local") marks.push("made on this device, cannot be removed from here");
         if (s.incompatible) marks.push("cannot run here");
         if (s.enabled === false) marks.push("disabled");
         return `${s.name} (${s.category ?? "other"})${marks.length ? ` — ${marks.join(", ")}` : ""}`;
@@ -498,7 +556,7 @@ export function registerSkillTools(reg: Registrar): void {
       const c = body.counts ?? {};
       const header = `${c.total ?? lines.length} skills installed. `
         + "Only the ones marked \"from the store\" can be removed with skill_uninstall; "
-        + "the rest came with the device.";
+        + "the rest came with the device or were made on it.";
       return text([header, ...lines].join("\n"));
     },
   );
@@ -682,15 +740,21 @@ export function registerSkillTools(reg: Registrar): void {
       const before = await installedSkills();
       let removing: InstalledSkill | undefined;
       if (before) {
-        // The store copy, not the builtin it may be shadowing: when both are
-        // listed under one name, the store one is the only removable row and
-        // its identifier is what the post-condition needs.
-        const entry = before.find((sk) => sk.name === name && isStoreSkill(sk)) ?? before.find((sk) => sk.name === name);
+        // The hub copy, not the builtin it may be shadowing: when both are
+        // listed under one name, the hub one is the only removable row and its
+        // identifier is what the post-condition needs.
+        const entry = before.find((sk) => sk.name === name && isRemovable(sk)) ?? before.find((sk) => sk.name === name);
         if (!entry) {
           throw new ToolError("NOT_FOUND", notInstalledMessage(name), NOT_INSTALLED_NEXT);
         }
-        if (!isStoreSkill(entry)) {
-          throw new ToolError("CONFLICT", builtinMessage(name), BUILTIN_NEXT);
+        if (!isRemovable(entry)) {
+          // Three origins, three answers. Calling a `local` skill built in would
+          // be wrong (it did not ship with the device) and letting it through to
+          // the route would earn a 404 that reads as "there is no such skill" —
+          // about a skill skill_list is listing.
+          throw entry.origin === "local"
+            ? new ToolError("CONFLICT", localMessage(name), LOCAL_NEXT)
+            : new ToolError("CONFLICT", builtinMessage(name), BUILTIN_NEXT);
         }
         removing = entry;
       }

--- a/src/components/HermesSkillsStore.tsx
+++ b/src/components/HermesSkillsStore.tsx
@@ -15,6 +15,7 @@ import {
   type SortOption,
   MAX_FACET_VALUES,
   SORT_OPTIONS,
+  isRemovableOrigin,
   sourceLabel,
   trustMeta,
 } from '@/lib/hermes-skills';
@@ -154,8 +155,10 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
         (s) => s.identifier === skill.id || (s.origin === 'hub' && s.id === skill.id),
       );
       // Only hub-installed skills are removable: `hermes skills uninstall`
-      // works off the lock, so a Remove for anything else can only fail.
-      if (!match || match.origin !== 'hub') return null;
+      // works off the lock, so a Remove for anything else can only fail. The
+      // rule is shared with the agent's skill_list/skill_uninstall so the page
+      // and the assistant cannot answer one device state two ways.
+      if (!match || !isRemovableOrigin(match.origin)) return null;
       return { name: match.id, key: skill.id, identifier: match.identifier || skill.id };
     },
     [installed.skills],
@@ -360,7 +363,7 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
       // Only skills the STORE installed are removable: `hermes skills uninstall`
       // works off the hub lock, so offering Remove for a bundled skill or one
       // the agent wrote itself would be a button that can only fail.
-      if (skill.origin !== 'hub') {
+      if (!isRemovableOrigin(skill.origin)) {
         return (
           <span className="inline-flex items-center gap-1 text-xs text-[var(--text-secondary)]">
             <span className="material-symbols-rounded" style={{ fontSize: 14 }} aria-hidden="true">
@@ -716,7 +719,8 @@ export default function HermesSkillsStore({ testId }: { testId?: string }) {
   // ── Detail view ───────────────────────────────────────────────────────────
   if (selected) {
     // Same rule as the installed cards: only hub-installed skills get an action.
-    const fixedOrigin = 'origin' in selected && selected.origin !== 'hub' ? selected.origin : null;
+    const fixedOrigin =
+      'origin' in selected && !isRemovableOrigin(selected.origin) ? selected.origin : null;
     const action = fixedOrigin ? (
       <span className="inline-flex items-center gap-1 text-sm text-[var(--text-secondary)]">
         <span className="material-symbols-rounded" style={{ fontSize: 16 }} aria-hidden="true">

--- a/src/lib/hermes-skills.ts
+++ b/src/lib/hermes-skills.ts
@@ -39,6 +39,27 @@ export interface HermesSkill {
 
 export type SkillOrigin = 'builtin' | 'hub' | 'local';
 
+/**
+ * Can `hermes skills uninstall` remove a skill with this origin?
+ *
+ * `builtin` shipped with the device, `hub` came from the store, and `local` is a
+ * skill directory that is NEITHER — written by the agent, hand-copied, or left
+ * behind by a failed install rollback or a partial removal. The CLI works off
+ * the hub LOCK, so only `hub` can be removed; the other two need someone to
+ * delete the folder on the device.
+ *
+ * This is one exported rule rather than a comparison repeated per call site
+ * because BOTH surfaces that answer the question read it — the Skills page
+ * (src/components/HermesSkillsStore.tsx) and the agent's skill_list /
+ * skill_uninstall (mcp/tools/skills.ts) — and one device state that gets two
+ * answers is a bug the customer sees as their own page and their assistant
+ * disagreeing. That is exactly what happened: the MCP side had spelled the rule
+ * "not builtin", which put `local` on the removable side.
+ */
+export function isRemovableOrigin(origin?: string): boolean {
+  return origin === 'hub';
+}
+
 /** Card payload for the Installed grid — everything comes from disk. */
 export interface InstalledHermesSkill {
   /** Skill name — the lock.json key and the `uninstall` positional argument. */

--- a/src/tests/unit/mcp-skills-local-origin.test.ts
+++ b/src/tests/unit/mcp-skills-local-origin.test.ts
@@ -14,9 +14,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  *
  * `hermes skills uninstall` works off the HUB LOCK, so only `hub` is removable.
  * The Skills page has always said so — `HermesSkillsStore.tsx` offers Remove
- * only for `origin === 'hub'` and badges a `local` skill as unremovable — but
+ * only for a hub skill and badges a `local` one as unremovable — but
  * `mcp/tools/skills.ts` decided removability with `origin !== "builtin"`, which
- * puts `local` on the removable side.
+ * puts `local` on the removable side. There is now ONE exported rule,
+ * `isRemovableOrigin()`, and both surfaces read it.
  *
  * So for one device state the agent and the customer's own Skills page told two
  * different stories:
@@ -70,6 +71,7 @@ vi.mock("../../../mcp/lib/api", async () => {
   };
 });
 
+import { isRemovableOrigin } from "@/lib/hermes-skills";
 import { ApiError } from "../../../mcp/lib/errors";
 import { registerSkillTools } from "../../../mcp/tools/skills";
 import { captureRegistrar } from "../helpers/mcp-registrar";
@@ -349,28 +351,33 @@ describe("anti-regression — the refusals #513 shipped", () => {
 // ── Anti-drift: one device state, one story ─────────────────────────────────
 
 describe("the agent and the Skills page must answer one device state the same way", () => {
-  /**
-   * The defect was a SECOND definition of "removable" that had drifted from the
-   * store's. This is the check that stops a third appearing: the removability
-   * test is spelled against `hub`, in one named predicate, and `!== "builtin"`
-   * survives only inside the wider isStoreSkill() the post-condition needs.
-   */
-  it("no removability test in mcp/tools/skills.ts is written as `!== builtin`", () => {
-    const src = fs.readFileSync(path.join(process.cwd(), "mcp/tools/skills.ts"), "utf-8");
-    expect(src, "isRemovable() is gone or was renamed").toMatch(/function isRemovable\s*\(/);
-    expect(src).toMatch(/origin\s*===\s*"hub"/);
-    const notBuiltin = src.match(/origin\s*!==\s*"builtin"/g) ?? [];
-    expect(notBuiltin.length, "`origin !== \"builtin\"` leaked back out of isStoreSkill()").toBe(1);
+  it("the shared rule removes hub skills and nothing else", () => {
+    expect(isRemovableOrigin("hub")).toBe(true);
+    expect(isRemovableOrigin("builtin")).toBe(false);
+    expect(isRemovableOrigin("local")).toBe(false);
+    // A row from an older build that carries no origin at all.
+    expect(isRemovableOrigin(undefined)).toBe(false);
+    expect(isRemovableOrigin("")).toBe(false);
   });
 
-  it("agrees with HermesSkillsStore.tsx on which origin can be removed", () => {
-    const store = fs.readFileSync(
-      path.join(process.cwd(), "src/components/HermesSkillsStore.tsx"),
-      "utf-8",
-    );
-    // The store's rule, unchanged by this fix and the reference the MCP side is
-    // now aligned to.
-    expect(store).toMatch(/match\.origin\s*!==\s*'hub'/);
-    expect(store).toMatch(/skill\.origin\s*!==\s*'hub'/);
+  /**
+   * The defect was a SECOND definition of "removable", in the MCP package, that
+   * had drifted from the Skills page's. There is now one exported rule and both
+   * read it, so the drift is not possible rather than merely absent — and these
+   * two checks are what keep a third definition from being written.
+   */
+  it("both surfaces import the rule rather than re-deriving it", () => {
+    for (const file of ["mcp/tools/skills.ts", "src/components/HermesSkillsStore.tsx"]) {
+      const src = fs.readFileSync(path.join(process.cwd(), file), "utf-8");
+      expect(src, `${file} does not use the shared rule`).toContain("isRemovableOrigin");
+    }
+  });
+
+  it("keeps `!== builtin` to the one place that is not a removability test", () => {
+    const src = fs.readFileSync(path.join(process.cwd(), "mcp/tools/skills.ts"), "utf-8");
+    const notBuiltin = src.match(/origin\s*!==\s*"builtin"/g) ?? [];
+    // isStoreSkill() — the POST-condition's wider test. Anywhere else it is the
+    // bug this file exists to close.
+    expect(notBuiltin.length, "`origin !== \"builtin\"` leaked out of isStoreSkill()").toBe(1);
   });
 });

--- a/src/tests/unit/mcp-skills-local-origin.test.ts
+++ b/src/tests/unit/mcp-skills-local-origin.test.ts
@@ -1,0 +1,376 @@
+import fs from "fs";
+import path from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * MCP-02a — the residual left by #513.
+ *
+ * A Hermes device has THREE skill origins, not two (`src/lib/hermes-skills.ts`,
+ * and the two writers in `src/lib/hermes-skills-server.ts`):
+ *
+ *   builtin — shipped with the device (name is in .bundled_manifest)
+ *   hub     — installed from the store (name is a key in the hub lock)
+ *   local   — a directory on disk that is NEITHER of those
+ *
+ * `hermes skills uninstall` works off the HUB LOCK, so only `hub` is removable.
+ * The Skills page has always said so — `HermesSkillsStore.tsx` offers Remove
+ * only for `origin === 'hub'` and badges a `local` skill as unremovable — but
+ * `mcp/tools/skills.ts` decided removability with `origin !== "builtin"`, which
+ * puts `local` on the removable side.
+ *
+ * So for one device state the agent and the customer's own Skills page told two
+ * different stories:
+ *
+ *   skill_list       marks the row "from the store", under a header saying only
+ *                    such rows can be removed
+ *   skill_uninstall  waves it past its own pre-condition, POSTs, and the route
+ *                    answers 404 `not_installed` (not in the lock, not in
+ *                    .bundled_manifest)
+ *   #513's new rule  turns that into "There is no installed skill called "x" on
+ *                    this device. Call skill_list and pass the name field of a
+ *                    skill it actually lists. Do not retry this name."
+ *
+ * skill_list DOES list it. The agent is sent to the one tool that reproduces the
+ * contradiction, and told not to retry. Before #513 the same state gave the
+ * vaguer generic resource-404, so the fix made the false claim confident — which
+ * is the anti-drift property #513 exists to guarantee, inverted.
+ *
+ * `local` is reachable on shipped aarch64 Hermes hardware: a directory left by a
+ * failed install rollback or a partial removal (both named in the install and
+ * uninstall routes' own #517/TASK-547 comments), a hand-copied skill folder, a
+ * skill the agent wrote itself, and — because readHubLock() returns {} for an
+ * unreadable or corrupt lock — EVERY hub skill on a box whose lock file got
+ * truncated. It is reached by a plain "remove the X skill" chat request.
+ */
+
+const { apiGet, apiPost } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+}));
+
+vi.mock("../../../mcp/lib/api", async () => {
+  const { ApiError, matchRule } = await import("../../../mcp/lib/errors");
+  const withRules =
+    (fn: (...a: unknown[]) => unknown) =>
+    async (route: string, ...rest: unknown[]) => {
+      try {
+        return await fn(route, ...rest);
+      } catch (err) {
+        const opts = (rest[rest.length - 1] ?? {}) as { rules?: Parameters<typeof matchRule>[1] };
+        if (err instanceof ApiError) throw matchRule(err, opts?.rules) ?? err;
+        throw err;
+      }
+    };
+  return {
+    apiGet: withRules(apiGet),
+    apiPost: withRules(apiPost),
+    apiTry: vi.fn(async () => null),
+    API_BASE: "http://127.0.0.1:80",
+    CLAWBOX_ROOT: "/home/clawbox/clawbox",
+  };
+});
+
+import { ApiError } from "../../../mcp/lib/errors";
+import { registerSkillTools } from "../../../mcp/tools/skills";
+import { captureRegistrar } from "../helpers/mcp-registrar";
+
+const INSTALLED = "/setup-api/hermes/skills/installed";
+const UNINSTALL = "/setup-api/hermes/skills/uninstall";
+
+interface Row {
+  name: string;
+  origin?: string;
+  identifier?: string;
+  category?: string;
+}
+
+/** What enumerateInstalledSkills() puts on the wire, in miniature. */
+const BUILTIN: Row = { name: "pdf-builtin", origin: "builtin", category: "documents" };
+const HUB: Row = { name: "invoices", origin: "hub", identifier: "official/invoices", category: "hub" };
+/** A directory on disk that is in neither the lock nor the bundled manifest. */
+const LOCAL: Row = { name: "scratchpad", origin: "local", category: "other" };
+
+function skills() {
+  const h = captureRegistrar("hermes");
+  registerSkillTools(h.reg);
+  return h;
+}
+
+/**
+ * Answer the installed list with one round per GET, so a test can describe the
+ * device before and after the uninstall. The last round repeats.
+ */
+function installedIs(...rounds: Row[][]) {
+  let i = 0;
+  apiGet.mockImplementation(async (route: string) => {
+    if (route !== INSTALLED) throw new Error(`unexpected GET ${route}`);
+    const rows = rounds[Math.min(i, rounds.length - 1)];
+    i += 1;
+    return { skills: rows, counts: { total: rows.length } };
+  });
+}
+
+beforeEach(() => {
+  apiGet.mockReset();
+  apiPost.mockReset();
+});
+
+// ── skill_list must not advertise what skill_uninstall cannot do ────────────
+
+describe("skill_list — \"from the store\" has to mean removable", () => {
+  it("does not mark a local-origin skill \"from the store\"", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_list", {});
+    expect(out.isError).toBe(false);
+    if (out.isError) return;
+    const line = out.text.split("\n").find((l) => l.startsWith(LOCAL.name));
+    expect(line, "skill_list dropped the local skill entirely").toBeDefined();
+    expect(line).not.toMatch(/from the store/);
+  });
+
+  it("still marks a hub-installed skill \"from the store\"", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_list", {});
+    expect(out.isError).toBe(false);
+    if (out.isError) return;
+    const line = out.text.split("\n").find((l) => l.startsWith(HUB.name));
+    expect(line).toMatch(/from the store/);
+  });
+
+  it("says why the local one is not removable rather than leaving it unexplained", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_list", {});
+    expect(out.isError).toBe(false);
+    if (out.isError) return;
+    const line = out.text.split("\n").find((l) => l.startsWith(LOCAL.name));
+    expect(line).toMatch(/made on this device/i);
+  });
+});
+
+// ── skill_uninstall must refuse it locally, in its own words ────────────────
+
+describe("skill_uninstall — a local skill is not a missing skill", () => {
+  it("refuses a local-origin skill without ever calling the route", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    apiPost.mockRejectedValue(new Error("skill_uninstall must not POST for a local skill"));
+    const out = await skills().call("skill_uninstall", { name: LOCAL.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(apiPost).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the skill is not installed — skill_list lists it", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_uninstall", { name: LOCAL.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.message).not.toMatch(/there is no installed skill called/i);
+    expect(out.error.next).not.toMatch(/a skill it actually lists/i);
+    // It IS on the device — say so.
+    expect(out.error.message).toMatch(new RegExp(`"${LOCAL.name}" is on this device`, "i"));
+  });
+
+  it("does not call it built in either — it did not ship with the device", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_uninstall", { name: LOCAL.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.message).not.toMatch(/came with the device/i);
+  });
+
+  it("tells the agent to stop and hand the user the only real next step", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_uninstall", { name: LOCAL.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("CONFLICT");
+    expect(out.error.next).toMatch(/do not retry/i);
+    expect(out.error.next).toMatch(/deleted on the device/i);
+  });
+
+  /**
+   * The contradiction itself, as an invariant over the whole list rather than
+   * over one fixture row: skill_list's header says the rows it marks "from the
+   * store" are the removable ones, so feeding every marked name straight back to
+   * skill_uninstall must never produce "there is no such skill".
+   */
+  it("every row skill_list marks \"from the store\" is one skill_uninstall accepts", async () => {
+    const rows = [BUILTIN, HUB, LOCAL];
+    installedIs(rows);
+    const listed = await skills().call("skill_list", {});
+    expect(listed.isError).toBe(false);
+    if (listed.isError) return;
+    const marked = listed.text
+      .split("\n")
+      // The first line is the header, which names the mark rather than carrying it.
+      .slice(1)
+      .filter((l) => l.includes("from the store"))
+      .map((l) => l.split(" ")[0]);
+    expect(marked.length, "nothing was marked, so the invariant is vacuous").toBeGreaterThan(0);
+
+    for (const name of marked) {
+      apiGet.mockReset();
+      apiPost.mockReset();
+      // The device removed it: gone from the second read.
+      installedIs(rows, rows.filter((r) => r.name !== name));
+      // The real route, not an obliging stub. `hermes skills uninstall` works
+      // off the hub lock, so a name that is not a lock key gets the 404 the
+      // route's own not-installed branch sends.
+      apiPost.mockImplementation(async (route: string, sent: { id?: string }) => {
+        expect(route).toBe(UNINSTALL);
+        const row = rows.find((r) => r.name === sent.id);
+        if (row?.origin !== "hub") {
+          throw new ApiError(
+            404,
+            JSON.stringify({
+              error: `No store skill called "${sent.id}" is installed on this device.`,
+              code: "not_installed",
+            }),
+          );
+        }
+        return { ok: true };
+      });
+      const out = await skills().call("skill_uninstall", { name });
+      expect(out.isError, `skill_uninstall refused "${name}", which skill_list offered`).toBe(false);
+      expect(apiPost).toHaveBeenCalledWith(UNINSTALL, { id: name }, expect.anything());
+    }
+  });
+});
+
+// ── The same claim, made by the route instead of the pre-condition ──────────
+
+/**
+ * The pre-condition is skipped whenever the installed list cannot be read
+ * (installedSkills() swallows the failure and returns null), and then the
+ * route's own 404 is the whole story. The route reaches `not_installed` for a
+ * name in neither the hub lock nor .bundled_manifest — a name the device does
+ * not have AND a `local` skill — and its own sentence says "No STORE skill
+ * called x is installed". #513 mapped it to the stronger "There is no installed
+ * skill called x on this device", which in that window is the same false claim
+ * about a skill skill_list shows, reached by a different path.
+ */
+describe("the route's not_installed, when the pre-condition could not run", () => {
+  const blindfolded = () => apiGet.mockRejectedValue(new ApiError(502, "{}"));
+
+  beforeEach(() => {
+    blindfolded();
+    apiPost.mockRejectedValue(
+      new ApiError(
+        404,
+        JSON.stringify({
+          error: 'No store skill called "scratchpad" is installed on this device.',
+          code: "not_installed",
+        }),
+      ),
+    );
+  });
+
+  it("does not claim more than the route established", async () => {
+    const out = await skills().call("skill_uninstall", { name: LOCAL.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("NOT_FOUND");
+    expect(out.error.message).toMatch(/from the skill store/i);
+    expect(out.error.message).not.toMatch(/on this device\.$/);
+  });
+
+  it("does not send the agent to skill_list expecting the name to be absent from it", async () => {
+    const out = await skills().call("skill_uninstall", { name: LOCAL.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.next).not.toMatch(/pass the name field of a skill it actually lists/i);
+    // Both branches, because from here the two cannot be told apart.
+    expect(out.error.next).toMatch(/if it is listed/i);
+    expect(out.error.next).toMatch(/do not retry/i);
+  });
+});
+
+// ── Everything #513 established has to keep working ─────────────────────────
+
+describe("anti-regression — the refusals #513 shipped", () => {
+  it("a builtin is still refused as built in", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_uninstall", { name: BUILTIN.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("CONFLICT");
+    expect(out.error.message).toMatch(/came with the device/i);
+  });
+
+  it("a name the device does not have is still \"there is no installed skill called\"", async () => {
+    installedIs([BUILTIN, HUB, LOCAL]);
+    const out = await skills().call("skill_uninstall", { name: "ghost" });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("NOT_FOUND");
+    expect(out.error.message).toMatch(/there is no installed skill called "ghost"/i);
+    expect(out.error.next).toMatch(/do not retry this name/i);
+  });
+
+  it("a hub skill is still removed, and the success says so", async () => {
+    installedIs([BUILTIN, HUB], [BUILTIN]);
+    apiPost.mockResolvedValue({ ok: true });
+    const out = await skills().call("skill_uninstall", { name: HUB.name });
+    expect(out.isError).toBe(false);
+    if (out.isError) return;
+    expect(out.text).toMatch(/removed the skill "invoices"/i);
+  });
+
+  it("un-shadowing a builtin is still reported as a success, not a failure", async () => {
+    installedIs(
+      [{ name: "pdf", origin: "hub", identifier: "official/pdf" }],
+      [{ name: "pdf", origin: "builtin" }],
+    );
+    apiPost.mockResolvedValue({ ok: true });
+    const out = await skills().call("skill_uninstall", { name: "pdf" });
+    expect(out.isError).toBe(false);
+    if (out.isError) return;
+    expect(out.text).toMatch(/built-in "pdf" was underneath it/i);
+  });
+
+  /**
+   * The post-condition keeps the WIDER not-builtin test on purpose. #517 and
+   * TASK-547 both name the half-removed state where the CLI drops the lock entry
+   * and leaves the directory: the row comes back as origin `local`, and that is
+   * a FAILED uninstall, not a clean one. Narrowing removability must not narrow
+   * this.
+   */
+  it("a hub skill that came back as `local` still reads as a failed uninstall", async () => {
+    installedIs([HUB], [{ name: HUB.name, origin: "local" }]);
+    apiPost.mockResolvedValue({ ok: true });
+    const out = await skills().call("skill_uninstall", { name: HUB.name });
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("CONFLICT");
+    expect(out.error.message).toMatch(/did not remove "invoices"/i);
+  });
+});
+
+// ── Anti-drift: one device state, one story ─────────────────────────────────
+
+describe("the agent and the Skills page must answer one device state the same way", () => {
+  /**
+   * The defect was a SECOND definition of "removable" that had drifted from the
+   * store's. This is the check that stops a third appearing: the removability
+   * test is spelled against `hub`, in one named predicate, and `!== "builtin"`
+   * survives only inside the wider isStoreSkill() the post-condition needs.
+   */
+  it("no removability test in mcp/tools/skills.ts is written as `!== builtin`", () => {
+    const src = fs.readFileSync(path.join(process.cwd(), "mcp/tools/skills.ts"), "utf-8");
+    expect(src, "isRemovable() is gone or was renamed").toMatch(/function isRemovable\s*\(/);
+    expect(src).toMatch(/origin\s*===\s*"hub"/);
+    const notBuiltin = src.match(/origin\s*!==\s*"builtin"/g) ?? [];
+    expect(notBuiltin.length, "`origin !== \"builtin\"` leaked back out of isStoreSkill()").toBe(1);
+  });
+
+  it("agrees with HermesSkillsStore.tsx on which origin can be removed", () => {
+    const store = fs.readFileSync(
+      path.join(process.cwd(), "src/components/HermesSkillsStore.tsx"),
+      "utf-8",
+    );
+    // The store's rule, unchanged by this fix and the reference the MCP side is
+    // now aligned to.
+    expect(store).toMatch(/match\.origin\s*!==\s*'hub'/);
+    expect(store).toMatch(/skill\.origin\s*!==\s*'hub'/);
+  });
+});


### PR DESCRIPTION
Follow-up to #513, closing residual MCP-02a. (Separate from #522, which was labelled MCP-02a too but was about `hermesSkillsGuard()`'s unlabelled 404 — a different sentence on a different path.)

## The residual

A Hermes device has **three** skill origins, not two — `src/lib/hermes-skills.ts` says so and `enumerateInstalledSkills()` writes all three (`hermes-skills-server.ts:793`, `:814`):

| origin | means | removable? |
|---|---|---|
| `builtin` | the name is in `.bundled_manifest` | no |
| `hub` | the name is a key in the hub lock | **yes** |
| `local` | a skill directory that is **neither** | no |

`hermes skills uninstall` works off the **lock**, so only `hub` can be removed. The Skills page has always said exactly that: `HermesSkillsStore.tsx` offers Remove only for a hub skill and badges a local one as unremovable.

`mcp/tools/skills.ts` decided it as `!!s.origin && s.origin !== "builtin"`, which puts `local` on the removable side. For one device state the agent and the customer's own Skills page then told two different stories:

1. `skill_list` marks the row **"from the store"** (`:493`), under a header saying *"Only the ones marked "from the store" can be removed with skill_uninstall"*.
2. `skill_uninstall`'s pre-condition (`:688`) reads the same predicate and waves it through.
3. The route answers 404 `not_installed` — the CLI reports it is not hub-installed and `.bundled_manifest` does not have it.
4. #513's brand-new rule turns that into: *"There is no installed skill called "x" on this device. Call skill_list and pass the name field of a skill it actually lists. **Do not retry this name.**"*

`skill_list` **does** list it. The agent is sent to the one tool that reproduces the contradiction, with an explicit do-not-retry. Before #513 the same state produced the vaguer generic resource-404, so the fix made the false claim *more confident* — the inverse of the anti-drift property #513 exists to guarantee.

`origin: 'local'` is reachable on shipped hardware, on the Hermes edition, by a plain "remove the X skill" chat request:

- a skill directory left behind by a failed install rollback or a partial removal — both named in the install and uninstall routes' own #517 / TASK-547 comments, and the uninstall route's header comment says the leftover is *"re-listed by `enumerateInstalledSkills` as origin `local`"* in as many words;
- a hand-copied skill folder, or one the agent wrote itself;
- **every** hub skill at once on a box whose lock file got truncated, because `readHubLock()` returns `{}` for an unreadable or corrupt lock (`hermes-skills-server.ts:90-98`).

## Reproduced first

With both call-site files at merged beta (`c92eec34`) and only the new shared rule added — additive, it fixes nothing on its own — 10 of the 18 new assertions are red:

```
Tests  10 failed | 8 passed (18)
```

After the fix: **18 passed**. The 8 that pass on unmodified beta are the anti-regression ones — #513's builtin refusal, its not-installed refusal for a name the device really lacks, the un-shadowing success, and the post-condition's failed-uninstall detection.

## The fix

**One exported rule, read by every surface that answers the question.**

Removability was written out **four** times with nothing holding them together — once in `mcp/tools/skills.ts` and three times in `HermesSkillsStore.tsx` (`uninstallTargetFor`, the installed-card action, the detail view). They agreed until one of them stopped. So the rule now lives in `src/lib/hermes-skills.ts`, which both packages already import:

```ts
export function isRemovableOrigin(origin?: string): boolean {
  return origin === 'hub';
}
```

All four call sites read it; the three in the component are behaviour-preserving (its 40 component assertions pass unchanged). On the MCP side `skill_list`'s mark and `skill_uninstall`'s pre-condition are the two that change. A `local` row now gets its own line on the list (`made on this device, cannot be removed from here`) rather than being the one unexplained row, and its own refusal instead of a builtin's or a missing skill's:

> `"x" is on this device but was not installed from the skill store, so it cannot be removed from here.`
> Do not retry. Tell the user its folder has to be deleted on the device.

**`isStoreSkill()` deliberately stays wider.** It is the POST-condition's test, and the half-removed state #517 and TASK-547 both name — the CLI drops the lock entry and cannot delete the directory — brings a hub skill back as `local`. That is a *failed* uninstall; narrowing this one to `hub` would report it as a success. A regression test pins that, and the two doc comments now say which is which and why.

**The route's `not_installed` rule is reworded.** That rule only ever runs when the installed list could not be read (`installedSkills()` swallows the failure and returns `null`), and the route reaches `not_installed` for a name in neither the lock nor the manifest — which is *both* "the device does not have it" and "the device has it as a `local` directory". Its own sentence is careful about that: *"No **store** skill called "x" is installed on this device."* #513 mapped it to the stronger claim, so the same falsehood was reachable a second way, on a path the pre-condition never guards. It now claims only what the route established, and names both branches in `next`.

That leaves #513's confident *"There is no installed skill called x on this device"* reachable only from the pre-condition, which is the one place that has the list and can know it is true.

## How I know I found every sibling

```
grep -rnE "origin\s*(===|!==)\s*['\"](builtin|hub|local)['\"]" --include=*.ts --include=*.tsx . | grep -v node_modules
```

Every origin comparison in both packages. Before this change the two in `mcp/tools/skills.ts` (`isStoreSkill` at `:221`, the `skill_list` mark at `:493`) were the only ones written against `builtin`; the three in `HermesSkillsStore.tsx` were already written against `hub` but each spelled out separately. The remaining hits are not removability decisions and are left alone — `inspect/route.ts:277` picks a catalogue record for hub rows, `:306`/`:307` and `hermes-skills-server.ts:929` synthesise a `source`/`trust` label, `SkillCard.tsx:64` badges the local chip, and `HermesSkillsStore.tsx` is the rule this change aligns to.

```
grep -rn "isRemovableOrigin\|isStoreSkill" --include=*.ts --include=*.tsx . | grep -v node_modules
```

Names every call site of both predicates and shows which one each got: `skill_list`'s mark, both halves of the uninstall pre-condition, and the store component's three decisions all take `isRemovableOrigin`; `stillInstalled()` and the `unshadowed` check keep `isStoreSkill`.

```
grep -rn "not_installed" --include=*.ts --include=*.tsx . | grep -v node_modules
```

One producer (`skills/uninstall/route.ts:106`) and one consumer (`mcp/tools/skills.ts`). The other hits are `coding-github.ts`'s unrelated `gh`-status reason of the same name.

A structural test asserts `origin !== "builtin"` survives at exactly **one** site — inside `isStoreSkill()` — so the wider test cannot leak back out into a removability decision.

## Tests

`src/tests/unit/mcp-skills-local-origin.test.ts`, 18 assertions:

- `skill_list` does not mark a `local` row "from the store", still marks a `hub` one, and explains the local one;
- **the invariant, over the whole list**: every name `skill_list` marks "from the store" is fed straight back into `skill_uninstall` against a route that behaves like the device (404 `not_installed` for anything that is not a lock key) — and none of them may be refused. That is the contradiction itself, tested as a property rather than against one fixture row;
- `skill_uninstall` refuses a `local` skill without ever reaching the route, does not call it missing, does not call it built in, and gives the only next step that state has;
- the route path with the pre-condition blindfolded: the 404 no longer out-claims what the route established, and does not send the agent to `skill_list` expecting the name to be absent from it;
- anti-regression on all four of #513's outcomes, plus the `local`-after-removal case that must stay a failure;
- three anti-drift checks: the shared rule's behaviour (`hub` removable; `builtin`, `local`, absent and empty not), that both surfaces import it rather than re-deriving it, and that `origin !== "builtin"` survives at exactly one site — inside `isStoreSkill()` — so the wider post-condition test cannot leak back into a removability decision, which is how this bug happened.

## Severity

Medium, and customer-facing on current hardware — Hermes edition, aarch64, no device-state prerequisite beyond one skill directory that is not in the lock, which the two routes' own comments describe as a state they produce.

## Checks

- `eslint` on all four changed source files — clean
- `tsc -p mcp/tsconfig.json` — 3 pre-existing errors in `src/lib/chat-history-cache.ts` and `src/lib/harness/transport.ts`, unchanged, none in touched files
- `bun run mcp/check-tools.ts` — Tool contract OK
- targeted suites (`src/tests/unit/mcp*`, `src/tests/routes/hermes`, `src/tests/unit/hermes-skill*`) and the four `hermes-skills*` / `chat-skill*` component suites run before and after: **no new failures**; the Windows host's pre-existing symlink/git failures are unchanged and Linux CI is the gate
- no device verification: both boxes are off this host's network right now. The defect is MCP-layer logic and the tests feed the uninstall route's real response body, so there is nothing here a device run would settle that the suite does not.
