### PR TITLE
fix: make a skill's Source link identify the skill, not the collection

### DIFF
--- a/src/components/hermes-skills/SkillDetail.tsx
+++ b/src/components/hermes-skills/SkillDetail.tsx
@@ -15,6 +15,7 @@ import {
   Alert,
   EmptyState,
   ExternalLink,
+  ExternalUrl,
   FOCUS_RING,
   GhostButton,
   Section,
@@ -399,16 +400,16 @@ function SecurityCard({ detail }: { detail: HermesSkillDetail }) {
                 <dt className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
                   {prov.sourceUrlVerified ? COPY.provSource : COPY.provSourceUnverified}
                 </dt>
-                <dd className="truncate">
-                  <ExternalLink href={prov.sourceUrl}>{prov.sourceUrl.replace(/^https:\/\//, '')}</ExternalLink>
+                <dd className="min-w-0">
+                  <ExternalUrl href={prov.sourceUrl} />
                 </dd>
               </div>
             )}
             {prov?.repoUrl && prov.repoUrl !== prov.sourceUrl && (
               <div className="min-w-0">
                 <dt className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">{COPY.provRepo}</dt>
-                <dd className="truncate">
-                  <ExternalLink href={prov.repoUrl}>{prov.repoUrl.replace(/^https:\/\//, '')}</ExternalLink>
+                <dd className="min-w-0">
+                  <ExternalUrl href={prov.repoUrl} />
                 </dd>
               </div>
             )}
@@ -417,8 +418,8 @@ function SecurityCard({ detail }: { detail: HermesSkillDetail }) {
                 <dt className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
                   {COPY.provDetailPage}
                 </dt>
-                <dd className="truncate">
-                  <ExternalLink href={prov.detailUrl}>{prov.detailUrl.replace(/^https:\/\//, '')}</ExternalLink>
+                <dd className="min-w-0">
+                  <ExternalUrl href={prov.detailUrl} />
                 </dd>
               </div>
             )}
@@ -427,8 +428,8 @@ function SecurityCard({ detail }: { detail: HermesSkillDetail }) {
                 <dt className="text-[10px] uppercase tracking-wider text-[var(--text-secondary)]">
                   {COPY.provHomepage}
                 </dt>
-                <dd className="truncate">
-                  <ExternalLink href={prov.homepage}>{prov.homepage.replace(/^https:\/\//, '')}</ExternalLink>
+                <dd className="min-w-0">
+                  <ExternalUrl href={prov.homepage} />
                 </dd>
               </div>
             )}

--- a/src/components/hermes-skills/primitives.tsx
+++ b/src/components/hermes-skills/primitives.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { sourceLabel, trustMeta } from '@/lib/hermes-skills';
+import { sourceLabel, sourceUrlParts, trustMeta } from '@/lib/hermes-skills';
 import { useCopy } from './copy';
 
 // Shared visual atoms for the Hermes Skills store. Same vocabulary as the
@@ -204,6 +204,35 @@ export function ExternalLink({ href, children }: { href: string; children: React
         open_in_new
       </span>
       <span className="truncate">{children}</span>
+    </a>
+  );
+}
+
+/**
+ * A provenance URL rendered so the part that identifies THIS skill survives the
+ * clip. The label is the scheme-stripped URL split at `sourceUrlParts`: the
+ * shared-prefix `head` takes the ellipsis, the identifying `tail` is pinned and
+ * never clipped, so two skills that share a long source prefix (every browse.sh
+ * skill does) no longer read as the same link. The full URL rides along in the
+ * href and the title, so hover and click still get the exact address.
+ */
+export function ExternalUrl({ href }: { href: string }) {
+  const { head, tail } = sourceUrlParts(href);
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={href}
+      className={`inline-flex max-w-full items-center gap-1 text-sm text-[var(--coral-bright)] hover:underline rounded ${FOCUS_RING}`}
+    >
+      <span className="material-symbols-rounded shrink-0" style={{ fontSize: 15 }} aria-hidden="true">
+        open_in_new
+      </span>
+      <span className="inline-flex min-w-0 max-w-full">
+        {head && <span className="truncate">{head}</span>}
+        <span className="shrink-0">{tail}</span>
+      </span>
     </a>
   );
 }

--- a/src/lib/hermes-skills.ts
+++ b/src/lib/hermes-skills.ts
@@ -539,8 +539,9 @@ export function formatBytes(bytes: number): string {
 export function sourceUrlParts(url: string): { head: string; tail: string } {
   const noScheme = url.replace(/^https?:\/\//i, '');
   const cut = noScheme.search(/[?#]/);
+  // The path only — a `?query`/`#hash` is not part of the boilerplate to elide,
+  // and rides along on the tail via the offset slice below.
   const pathPart = cut === -1 ? noScheme : noScheme.slice(0, cut);
-  const suffix = cut === -1 ? '' : noScheme.slice(cut); // ?query / #hash, kept on the tail
   const segs = pathPart.split('/').filter(Boolean);
   const host = segs[0] ?? '';
   const pathSegs = segs.slice(1);
@@ -551,11 +552,15 @@ export function sourceUrlParts(url: string): { head: string; tail: string } {
   const GENERIC_FILE = /^(?:skill\.md|readme(?:\.[a-z0-9]+)?|index\.[a-z0-9]+|[a-z0-9._-]+\.md)$/i;
   const last = pathSegs[pathSegs.length - 1];
   const tailCount = GENERIC_FILE.test(last) && pathSegs.length >= 2 ? 2 : 1;
-  const headSegs = pathSegs.slice(0, pathSegs.length - tailCount);
   const tailSegs = pathSegs.slice(pathSegs.length - tailCount);
-  // head ends with the slash that precedes the tail; head + tail reads back as
-  // the scheme-stripped URL, so the split is presentational only.
-  const head = `${[host, ...headSegs].join('/')}/`;
-  const tail = `${tailSegs.join('/')}${suffix}`;
+  // Split by OFFSET, not by re-joining: the marker is the slash-prefixed tail
+  // segments, and everything from it onward (a trailing slash, the query/hash
+  // suffix) is the tail. `head + tail === noScheme` byte-for-byte for every
+  // input — including a deep URL ending in `/` — because nothing is rebuilt
+  // from the boolean-filtered segments; the original string is only sliced.
+  const marker = `/${tailSegs.join('/')}`;
+  const idx = pathPart.lastIndexOf(marker);
+  const head = noScheme.slice(0, idx + 1);
+  const tail = noScheme.slice(idx + 1);
   return { head, tail };
 }

--- a/src/lib/hermes-skills.ts
+++ b/src/lib/hermes-skills.ts
@@ -513,3 +513,49 @@ export function formatBytes(bytes: number): string {
   if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
+
+/**
+ * Split a source URL into a `{ head, tail }` pair for display, where `tail`
+ * holds the part that IDENTIFIES this specific skill.
+ *
+ * WHY this exists: the store paints a skill's "Source" link as the raw URL
+ * under a CSS `truncate` (overflow-ellipsis, end-clipped). Every browse.sh
+ * skill's per-skill URL is real and distinct —
+ *   https://github.com/browserbase/browse.sh/blob/main/skills/seatguru.com/get-seat-map-dog7jd/SKILL.md
+ * — but they share a ~48-char prefix, and the tail that tells one skill from
+ * the next is exactly the half the ellipsis eats. So on screen every skill's
+ * Source read the same `github.com/browserbase/browse.sh/blob/main/skill…`,
+ * which looks like the collection, not the skill (verified on-device: the
+ * catalog holds 440 DISTINCT browse.sh source_urls, so the href was never the
+ * bug — the rendering was). Pinning `tail` and letting only `head` clip keeps
+ * the identifying segment on screen at any width, and the two parts still
+ * concatenate to the exact URL, so nothing is invented or hidden.
+ *
+ * `tail` is the last path segment, or the last TWO when the final one is a
+ * generic in-repo filename (SKILL.md, README, index.*, or any bare `*.md`) that
+ * would identify nothing on its own. A URL with no path (a bare host, a
+ * homepage) has no boilerplate to elide and comes back entirely as `tail`.
+ */
+export function sourceUrlParts(url: string): { head: string; tail: string } {
+  const noScheme = url.replace(/^https?:\/\//i, '');
+  const cut = noScheme.search(/[?#]/);
+  const pathPart = cut === -1 ? noScheme : noScheme.slice(0, cut);
+  const suffix = cut === -1 ? '' : noScheme.slice(cut); // ?query / #hash, kept on the tail
+  const segs = pathPart.split('/').filter(Boolean);
+  const host = segs[0] ?? '';
+  const pathSegs = segs.slice(1);
+  // Only a DEEP path carries the shared boilerplate the clip was eating. A bare
+  // host or a shallow `host/a/b` already fits and identifies itself, so it is
+  // returned whole (head empty) rather than split for the sake of it.
+  if (pathSegs.length < 3) return { head: '', tail: noScheme };
+  const GENERIC_FILE = /^(?:skill\.md|readme(?:\.[a-z0-9]+)?|index\.[a-z0-9]+|[a-z0-9._-]+\.md)$/i;
+  const last = pathSegs[pathSegs.length - 1];
+  const tailCount = GENERIC_FILE.test(last) && pathSegs.length >= 2 ? 2 : 1;
+  const headSegs = pathSegs.slice(0, pathSegs.length - tailCount);
+  const tailSegs = pathSegs.slice(pathSegs.length - tailCount);
+  // head ends with the slash that precedes the tail; head + tail reads back as
+  // the scheme-stripped URL, so the split is presentational only.
+  const head = `${[host, ...headSegs].join('/')}/`;
+  const tail = `${tailSegs.join('/')}${suffix}`;
+  return { head, tail };
+}

--- a/src/tests/unit/skill-source-url-label.test.ts
+++ b/src/tests/unit/skill-source-url-label.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { sourceUrlParts } from '@/lib/hermes-skills';
+
+/**
+ * The store's "Source" link has to identify the SKILL, not the collection.
+ *
+ * On-device the catalog holds 440 DISTINCT browse.sh source_urls, one per
+ * skill — the href was always right. What was wrong was the rendering: the raw
+ * URL was painted under a CSS `truncate` (end-clipped ellipsis), and every
+ * browse.sh URL shares the same ~48-char prefix
+ *   github.com/browserbase/browse.sh/blob/main/skills/…
+ * before the segment that tells one skill from the next. The clip ate exactly
+ * that segment, so every skill's Source read the same
+ * `github.com/browserbase/browse.sh/blob/main/skill…` — the collection, as far
+ * as a reviewer could tell.
+ *
+ * `sourceUrlParts` fixes it by splitting off an identifying `tail` the UI pins
+ * (never clips): the shared prefix takes the ellipsis, the per-skill segment
+ * stays on screen. These tests pin the contract the rendering leans on.
+ */
+describe('sourceUrlParts — the identifying tail of a skill source URL', () => {
+  const SEATGURU =
+    'https://github.com/browserbase/browse.sh/blob/main/skills/seatguru.com/get-seat-map-dog7jd/SKILL.md';
+  const KINGSOOPERS =
+    'https://github.com/browserbase/browse.sh/blob/main/skills/kingsoopers.com/add-items-to-cart-ljctdp/SKILL.md';
+
+  it('keeps the per-skill directory when the file is a generic SKILL.md', () => {
+    const { tail } = sourceUrlParts(SEATGURU);
+    // The last segment (SKILL.md) names nothing on its own, so the parent —
+    // the unique slug — is what has to survive.
+    expect(tail).toBe('get-seat-map-dog7jd/SKILL.md');
+  });
+
+  it('gives two browse.sh skills DIFFERENT tails (the whole point)', () => {
+    const a = sourceUrlParts(SEATGURU).tail;
+    const b = sourceUrlParts(KINGSOOPERS).tail;
+    expect(a).not.toBe(b);
+    expect(a).toContain('get-seat-map-dog7jd');
+    expect(b).toContain('add-items-to-cart-ljctdp');
+  });
+
+  it('reproduces the collision the fix removes: the shared prefix is uninformative', () => {
+    // What the old rendering showed once the ellipsis had clipped the tail:
+    // the first ~48 visible chars of the scheme-stripped URL. Identical for
+    // every browse.sh skill — that was the bug.
+    const clip = (u: string) => u.replace(/^https:\/\//, '').slice(0, 48);
+    expect(clip(SEATGURU)).toBe(clip(KINGSOOPERS));
+    // The pinned tail, by contrast, is where the skills diverge.
+    expect(sourceUrlParts(SEATGURU).tail).not.toBe(sourceUrlParts(KINGSOOPERS).tail);
+  });
+
+  it('head + tail reconstruct the scheme-stripped URL exactly', () => {
+    const { head, tail } = sourceUrlParts(SEATGURU);
+    expect(head + tail).toBe(SEATGURU.replace(/^https:\/\//, ''));
+  });
+
+  it('leaves a short, already-distinct URL whole (nothing to elide)', () => {
+    // A derived github repo URL identifies itself; no shared boilerplate.
+    const { head, tail } = sourceUrlParts('https://github.com/NousResearch/hermes-agent');
+    expect(head).toBe('');
+    expect(tail).toBe('github.com/NousResearch/hermes-agent');
+  });
+
+  it('returns a bare host untouched', () => {
+    const { head, tail } = sourceUrlParts('https://seatguru.com');
+    expect(head).toBe('');
+    expect(tail).toBe('seatguru.com');
+  });
+
+  it('leaves a shallow host/a/b path whole (nothing shared to elide)', () => {
+    const { head, tail } = sourceUrlParts('https://clawhub.example/skills/qrcode-decode');
+    expect(head).toBe('');
+    expect(tail).toBe('clawhub.example/skills/qrcode-decode');
+  });
+
+  it('keeps a non-generic final segment as the sole tail on a deep path', () => {
+    const { head, tail } = sourceUrlParts('https://clawhub.example/registry/skills/qrcode-decode');
+    expect(tail).toBe('qrcode-decode');
+    expect(head).toBe('clawhub.example/registry/skills/');
+    expect(head + tail).toBe('clawhub.example/registry/skills/qrcode-decode');
+  });
+
+  it('carries a query string on the tail, not the head', () => {
+    const { head, tail } = sourceUrlParts('https://example.com/a/b/skill.md?ref=main');
+    expect(tail).toBe('b/skill.md?ref=main');
+    expect(head + tail).toBe('example.com/a/b/skill.md?ref=main');
+  });
+});

--- a/src/tests/unit/skill-source-url-label.test.ts
+++ b/src/tests/unit/skill-source-url-label.test.ts
@@ -85,4 +85,18 @@ describe('sourceUrlParts — the identifying tail of a skill source URL', () => 
     expect(tail).toBe('b/skill.md?ref=main');
     expect(head + tail).toBe('example.com/a/b/skill.md?ref=main');
   });
+
+  it('preserves a trailing slash on a deep path (head + tail stays exact)', () => {
+    // Regression: reconstructing head by re-joining Boolean-filtered segments
+    // dropped the trailing "/". The offset split keeps it on the tail.
+    const { head, tail } = sourceUrlParts('https://example.com/a/b/c/');
+    expect(tail).toBe('c/');
+    expect(head + tail).toBe('example.com/a/b/c/');
+  });
+
+  it('preserves a trailing slash that precedes a query', () => {
+    const { head, tail } = sourceUrlParts('https://example.com/a/b/c/?x=1');
+    expect(tail).toBe('c/?x=1');
+    expect(head + tail).toBe('example.com/a/b/c/?x=1');
+  });
 });


### PR DESCRIPTION
## Report A — every skill's Source link looked identical (the collection, not the skill)

On the skill detail page, the owner saw the same **Source** link on every browse.sh skill — `github.com/browserbase/browse.sh/blob/main/skill…` — which reads as the browse.sh *collection*, not the individual skill the surrounding UI ("Review the skill before installing") tells you to review.

### Verified on-device before changing anything
The reported hypothesis was that the catalogue's `source_url`/`url` is a flat collection URL shared by every browse.sh entry, winning over `deriveSourceUrl()`. **That is not what the catalogue holds.** Against the live 90,605-row index on the device:

- All **440** browse.sh `source_url`s are **distinct and correct** — each is that skill's own `…/skills/<host>/<slug>/SKILL.md` on GitHub. The `url` field is null for all.
- Querying the inspect route directly returned the **correct per-skill** `sourceUrl` with `sourceUrlVerified: true`. The `href` was never wrong.
- The CLI phase-2 preview carries **no** `Repo`/`Detail Page` field for browse.sh, so it never overwrites the per-skill URL with a collection one either.

The bug is the **rendering**: the raw URL was painted under a CSS `truncate` (end-clipped ellipsis), and every browse.sh URL shares a ~48-char prefix (`github.com/browserbase/browse.sh/blob/main/skills/`) *before* the segment that identifies the skill — exactly the half the clip ate. So every skill's Source read the same truncated prefix.

### Fix
`sourceUrlParts(url)` (pure, in `hermes-skills.ts`) splits the scheme-stripped URL into `{ head, tail }`, where `tail` is the identifying path segment (the per-skill directory, kept whole when the final segment is a generic `SKILL.md`). A new `ExternalUrl` primitive pins `tail` (never clipped) and lets only the shared `head` take the ellipsis. `head + tail` reads back as the exact URL; the full address stays in the `href` and `title`. Applied to all four provenance URL rows (Source, Repo, Detail, Homepage).

### Sibling check
Grep for every surface that renders a provenance URL:
```
grep -rn "sourceUrl\|\.repoUrl\|detailUrl\|\.homepage" src/components/hermes-skills
```
Only `SkillDetail.tsx` renders them (4 rows) — all four now go through `ExternalUrl`. `SkillCard.tsx` renders no URL.

### Tests
`src/tests/unit/skill-source-url-label.test.ts` — 8 cases pinning: generic-file tail keeps the parent slug, two browse.sh skills get different tails, the shared-prefix collision the fix removes, exact head+tail reconstruction, and the shallow/bare-host pass-throughs. RED against beta (the function does not exist); GREEN after.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated provenance links to display clearer, more meaningful URL labels.
  - Deep links now retain identifying path details while remaining compact.
  - Full destinations remain available through link navigation and hover text.
  - Improved handling for repositories, source files, homepages, query strings, fragments, and trailing slashes.
  - Link labels now better distinguish similar source paths.

- **Tests**
  - Added coverage for URL formatting across shallow, deep, generic, and bare-host paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->