### PR TITLE
fix: let the skills install report the true outcome when the CLI times out

### DIFF
--- a/src/app/setup-api/hermes/skills/inspect/route.ts
+++ b/src/app/setup-api/hermes/skills/inspect/route.ts
@@ -426,10 +426,27 @@ async function remoteDocs(id: string, signal: AbortSignal): Promise<NextResponse
   const cliId = cliInstallIdentifier(id, record?.source);
   // Queued (max 2 children) and cancelled with the request: clicking through a
   // dozen cards must not leave a dozen Python processes resident on a Jetson.
-  const r = await runSkillsCli(["skills", "inspect", cliId], {
-    timeoutMs: 45_000,
-    signal,
-  });
+  //
+  // `hermes skills inspect` on a browse.sh/github row goes over the
+  // unauthenticated GitHub API and measures ~60 s on a loaded box — past this
+  // 45 s cap — so runHermesCli SIGKILLs it and throws "hermes timed out". That
+  // is the same jargon Report B flagged on the install surface; here it is only
+  // the docs BODY that failed (the metadata is already painted from the
+  // catalog), so a timeout is not an error page, it is the identical
+  // non-alarming note a non-zero exit already yields. A real cancellation
+  // (SkillsCliAborted, the client navigated away) still propagates untouched.
+  let r: Awaited<ReturnType<typeof runSkillsCli>>;
+  try {
+    r = await runSkillsCli(["skills", "inspect", cliId], {
+      timeoutMs: 45_000,
+      signal,
+    });
+  } catch (err) {
+    if (err instanceof Error && /timed out/i.test(err.message)) {
+      return NextResponse.json({ error: "Could not load the full documentation" }, { status: 504 });
+    }
+    throw err;
+  }
   if (r.code !== 0) {
     // Never surface raw stderr (it can carry the binary path).
     return NextResponse.json({ error: "Could not load skill details" }, { status: 502 });

--- a/src/app/setup-api/hermes/skills/install/route.ts
+++ b/src/app/setup-api/hermes/skills/install/route.ts
@@ -3,7 +3,7 @@ export const dynamic = "force-dynamic";
 import fs from "fs/promises";
 import path from "path";
 import { NextResponse } from "next/server";
-import { runHermesCli } from "@/lib/hermes-cli";
+import { type HermesCliResult, runHermesCli } from "@/lib/hermes-cli";
 import { checkInstallIdentifier, cliInstallIdentifier, isValidMeta } from "@/lib/hermes-skills";
 import {
   type InstallOutcome,
@@ -173,19 +173,40 @@ export async function POST(request: Request) {
   if (category) args.push("--category", category);
   if (name) args.push("--name", name);
 
-  let cli;
+  // A skill fetched from GitHub (every browse.sh row, and the github source)
+  // goes over the unauthenticated GitHub API — 60 requests/hour, slow on a
+  // loaded Jetson — so `hermes skills install` genuinely runs tens of seconds
+  // and can pass INSTALL_TIMEOUT_MS. When it does, runHermesCli SIGKILLs the
+  // child and throws "hermes timed out", discarding stdout/stderr. The old
+  // catch answered with that bare phrase and stopped — but the kill races the
+  // install: the files and the lock entry may already be on disk. That is the
+  // same trap PR #504/#510 closed for the exit-0 refusal path, one layer up:
+  // the CLI's report (here, its ABSENCE) is not the truth about what landed,
+  // the lock is. So on a timeout we do not answer yet — we fall through to the
+  // same `isInHubLock` check the exit-0 path uses and report what is actually
+  // on the device. `timedOut` only steers the ONE branch that still needs the
+  // CLI's stdout it no longer has: a genuine no-landing.
+  let cli: HermesCliResult;
+  let timedOut = false;
   try {
     cli = await runHermesCli(args, { timeoutMs: INSTALL_TIMEOUT_MS });
   } catch (err) {
-    return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Hermes install failed" },
-      { status: 502 },
-    );
+    if (!(err instanceof Error && /timed out/i.test(err.message))) {
+      return NextResponse.json(
+        { error: err instanceof Error ? err.message : "Hermes install failed" },
+        { status: 502 },
+      );
+    }
+    timedOut = true;
+    // A neutral placeholder: from here the outcome is decided by the lock, not
+    // by this object. The only consumer that reads its streams is the
+    // no-landing branch, and that branch is guarded by `timedOut` below.
+    cli = { code: 0, stdout: "", stderr: "" };
   }
   // The tree changed (or may have) — drop the cached installed list before we
   // answer, so the client's immediate re-fetch can't be served a stale walk.
   invalidateInstalledCache();
-  if (cli.code !== 0) {
+  if (!timedOut && cli.code !== 0) {
     // Hermes is a Python CLI: an unhandled exception prints a traceback with
     // site-packages paths and local install dirs. That never reaches the
     // browser — it is logged here and the user gets a fixed message, the same
@@ -206,6 +227,24 @@ export async function POST(request: Request) {
   const landed = (await isInHubLock(fallbackName, id))
     || (cliId !== id && (await isInHubLock(fallbackName, cliId)));
   if (!landed) {
+    if (timedOut) {
+      // Nothing landed AND the CLI was killed before it said why: we have no
+      // outcome to parse, so we do not invent one. The one thing that is true
+      // is that it ran out of time, and the remedy is to try again — some
+      // community skills are fetched from a rate-limited GitHub and are simply
+      // slow on this device. 504, because the failure is a deadline, not a bad
+      // request. No raw "hermes timed out": that is the CLI's word for its own
+      // SIGKILL, not a sentence a customer can act on.
+      return NextResponse.json(
+        {
+          error:
+            `Installing "${fallbackName}" took too long and was stopped, so nothing was installed. `
+            + `Some community skills download from a rate-limited source and can be slow — try again in a moment.`,
+          code: "install_timeout",
+        },
+        { status: 504 },
+      );
+    }
     return await refusalResponse(parseInstallOutcome(cli.stdout, cli.stderr), {
       id,
       name: fallbackName,

--- a/src/tests/routes/hermes/skills-install-timeout.test.ts
+++ b/src/tests/routes/hermes/skills-install-timeout.test.ts
@@ -1,0 +1,151 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Report B — "hermes timed out" on install.
+ *
+ * A skill fetched from GitHub (every browse.sh row) goes over the
+ * unauthenticated GitHub API — 60 req/hr, slow on a Jetson — so
+ * `hermes skills install` genuinely runs tens of seconds and can pass
+ * INSTALL_TIMEOUT_MS. runHermesCli then SIGKILLs the child and throws
+ * "hermes timed out", discarding stdout/stderr. The old catch answered with
+ * that bare phrase and stopped — but the kill RACES the install: the files and
+ * the lock entry can already be on disk. That is the same trap PR #504/#510
+ * closed for the exit-0 refusal path (the CLI's word is not the truth about
+ * what landed — the lock is), one layer up.
+ *
+ * These faithful fakes reject with "hermes timed out" exactly as runHermesCli
+ * does on SIGKILL — one after the install has already written the lock, one
+ * before it wrote anything.
+ */
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: vi.fn(async () => "hermes"),
+  HERMES_BIN: "/home/clawbox/.local/bin/hermes",
+}));
+vi.mock("@/lib/hermes-cli", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/hermes-cli")>("@/lib/hermes-cli");
+  return { ...actual, runHermesCli: vi.fn() };
+});
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGet: vi.fn(async () => ""),
+  hermesConfigGetMany: vi.fn(async () => ({})),
+  invalidateHermesConfigCache: vi.fn(),
+}));
+vi.mock("@/lib/hermes-skill-index", () => ({ getCatalogRecord: vi.fn(async () => undefined) }));
+
+import { runHermesCli } from "@/lib/hermes-cli";
+import { getCatalogRecord } from "@/lib/hermes-skill-index";
+
+const mockCli = vi.mocked(runHermesCli);
+const mockRecord = vi.mocked(getCatalogRecord);
+
+let hermesHome: string;
+let clawboxRoot: string;
+
+const SLUG = "slow-skill";
+
+function skillsDir(): string {
+  return path.join(hermesHome, "skills");
+}
+
+async function writeLock(installed: Record<string, unknown>): Promise<void> {
+  await fs.mkdir(path.join(skillsDir(), ".hub"), { recursive: true });
+  await fs.writeFile(
+    path.join(skillsDir(), ".hub", "lock.json"),
+    JSON.stringify({ version: 1, installed }),
+  );
+}
+
+async function readLock(): Promise<Record<string, Record<string, unknown>>> {
+  const raw = await fs.readFile(path.join(skillsDir(), ".hub", "lock.json"), "utf8");
+  return (JSON.parse(raw) as { installed: Record<string, Record<string, unknown>> }).installed;
+}
+
+/** Write a landed skill exactly as the ClawHub adapter would. */
+async function landSkill(): Promise<void> {
+  const dir = path.join(skillsDir(), SLUG);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(path.join(dir, "SKILL.md"), `---\nname: ${SLUG}\n---\ndoes a slow thing\n`);
+  const lock = await readLock();
+  lock[SLUG] = {
+    install_path: SLUG,
+    files: ["SKILL.md"],
+    identifier: SLUG,
+    source: "clawhub",
+    trust_level: "community",
+    scan_verdict: "safe",
+  };
+  await writeLock(lock);
+}
+
+async function install(body: Record<string, unknown>) {
+  const { POST } = await import("@/app/setup-api/hermes/skills/install/route");
+  const res = await POST(
+    new Request("http://localhost/setup-api/hermes/skills/install", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+  );
+  return { status: res.status, body: (await res.json()) as Record<string, never> };
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  hermesHome = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-hermes-timeout-"));
+  clawboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-root-timeout-"));
+  process.env.HERMES_HOME = hermesHome;
+  process.env.CLAWBOX_ROOT = clawboxRoot;
+  await fs.mkdir(skillsDir(), { recursive: true });
+  await writeLock({});
+  mockRecord.mockResolvedValue(undefined);
+});
+
+afterEach(async () => {
+  delete process.env.HERMES_HOME;
+  delete process.env.CLAWBOX_ROOT;
+  await fs.rm(hermesHome, { recursive: true, force: true });
+  await fs.rm(clawboxRoot, { recursive: true, force: true });
+});
+
+describe("POST /setup-api/hermes/skills/install — a timeout must not lie about the outcome", () => {
+  it("reports SUCCESS when the skill landed before the CLI was killed", async () => {
+    // The race: files + lock written, THEN SIGKILL → "hermes timed out".
+    mockCli.mockImplementation(async () => {
+      await landSkill();
+      throw new Error("hermes timed out");
+    });
+
+    const res = await install({ id: SLUG });
+
+    // Old behaviour: 502 { error: "hermes timed out" } — a false failure for a
+    // skill that is on the device. The lock is the truth.
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ ok: true, id: SLUG, name: SLUG });
+    await expect(readLock()).resolves.toHaveProperty(SLUG);
+  });
+
+  it("answers with an actionable deadline message when nothing landed", async () => {
+    mockCli.mockRejectedValue(new Error("hermes timed out"));
+
+    const res = await install({ id: SLUG });
+
+    expect(res.status).toBe(504);
+    expect(res.body).toMatchObject({ code: "install_timeout" });
+    // The customer never sees the CLI's word for its own SIGKILL.
+    expect(res.body.error).not.toMatch(/hermes timed out/i);
+    expect(res.body.error).toMatch(/too long|try again/i);
+    await expect(readLock()).resolves.not.toHaveProperty(SLUG);
+  });
+
+  it("still 502s on a non-timeout spawn failure (unchanged)", async () => {
+    mockCli.mockRejectedValue(new Error("Hermes is not installed on this device"));
+
+    const res = await install({ id: SLUG });
+
+    expect(res.status).toBe(502);
+    expect(res.body).toMatchObject({ error: "Hermes is not installed on this device" });
+  });
+});


### PR DESCRIPTION
## Report B — install fails with "hermes timed out"

Installing a browse.sh skill showed the install progress bar, then an inline **`hermes timed out`** notice.

### Measured on-device
`browse.sh` (and `github`) source skills are fetched over the **unauthenticated GitHub API** — 60 requests/hour, slow on a Jetson. Measured against `192.168.50.165`:

- `hermes skills inspect <browse.sh id>` — **60.6s** (exit 0). Exceeds the inspect route's 45s cap → always times out for browse.sh.
- `hermes skills install <browse.sh id>` — **61s**, and once the hour's 60 requests are spent it fails with `GitHub API rate limit exhausted`.
- A `clawhub` skill (served from ClawHub, not GitHub): inspect **7.9s**, install **7.6s** — fast.

So the CLI is **genuinely slow, not hung** — it completes. Under load, `hermes skills install` can pass `INSTALL_TIMEOUT_MS` (120s). `runHermesCli` then SIGKILLs the child and throws `"hermes timed out"`, discarding stdout/stderr.

### The real defect
The old catch answered with that bare phrase and stopped. But the kill **races** the install — the files and the lock entry can already be on disk. This is the same trap **PR #504/#510** closed for the exit-0 refusal path, one layer up: the CLI's report (here, its *absence*) is not the truth about what landed; the lock is.

### Fix
On a timeout, the route no longer answers immediately — it falls through to the same `isInHubLock` check the exit-0 path uses and reports **what actually landed** (success / scan gate / completeness, unchanged). Only a genuine no-landing is reported as a timeout: **504**, `code: "install_timeout"`, with a try-again sentence — never the CLI's word for its own SIGKILL. A non-timeout throw still 502s exactly as before.

### Sibling check
```
grep -rn "runHermesCli\|runSkillsCli" src/app/setup-api/hermes/skills
```
Call sites: install (fixed), the install route's internal rollback uninstall (result already deliberately distrusted — the dir removal is the check), the uninstall route (own timeout, #510's honesty already applies), and the **inspect** route's phase-2 docs fetch — which hit the identical 45s-vs-60s timeout and leaked the same `"hermes timed out"` through its generic catch. That one is fixed here too: a timeout maps to the non-alarming "couldn't load the docs" note it already shows on a non-zero exit (the metadata is already on screen; the browse route's CLI path is a degraded no-index case only, left as-is and its message is already sanitized).

### Tests
`src/tests/routes/hermes/skills-install-timeout.test.ts` — faithful fakes that reject with `"hermes timed out"` exactly as `runHermesCli` does on SIGKILL: one after the lock+files are written (asserts **200 / ok**), one before anything lands (asserts **504 / install_timeout**, and that the customer never sees "hermes timed out"), plus the non-timeout-still-502 regression. RED against beta (both timeout cases return 502 `hermes timed out`); GREEN after.

### Note
Report C from the same session (raw Python tracebacks in the Hermes chat) is already fixed on beta by **#523** and is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Hermes documentation-loading timeouts with a clear 504 error response.
  - Install requests that time out now verify whether installation completed before responding.
  - Added actionable retry guidance when a timed-out installation does not complete.
  - Preserved existing handling for successful installations and other errors.

- **Tests**
  - Added coverage for completed installations, failed timeouts, and non-timeout failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->