### PR TITLE
fix: clean the failure text on every Hermes surface, not just the one #515 found

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1650,7 +1650,17 @@ export async function POST(request: Request) {
           || err instanceof HermesLocalApplyError
           || err instanceof ClawaiApplyError
         ) {
-          // Author-controlled, non-credential message — safe to echo.
+          // Safe to echo because each of these classes now CLEANS its message
+          // before constructing itself — `safeHermesFailureMessage` for a
+          // `hermes` stream, `sanitizeErrorMessage` for an fs error — and falls
+          // back to a fixed sentence when nothing survives.
+          //
+          // The comment here used to read "Author-controlled, non-credential
+          // message — safe to echo", and it was false for all three: every one
+          // of them was built from a raw `hermes` stderr or a raw Node fs
+          // error, and this line published it to the save banner. The claim is
+          // now an invariant the throw sites keep rather than an assumption
+          // this one makes.
           return NextResponse.json({ error: err.message }, { status: 502 });
         }
         throw err; // unexpected — fall to the outer catch, which classifies it

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -50,6 +50,7 @@ import { isQuietStreamError, openDashboardTurn, type DashboardTurn } from "@/lib
 import {
   errorFromStderr,
   hermesFailureMessage,
+  safeHermesFailureMessage,
   spawnFailureMessage,
 } from "@/lib/hermes-cli-message";
 
@@ -454,7 +455,12 @@ async function settleTurn(
  *   `done`  — the settled turn, byte-identical in shape to what the non-
  *             streaming path returns, including the tool steps and the
  *             deduplicated reasoning that only the agent's database has.
- *   `error` — the turn failed; the message is already customer-readable.
+ *   `error` — the turn failed, and the message has been MADE customer-readable
+ *             on the way out. It used to say "already", which was an assumption
+ *             about Python text written on the other side of a socket — the
+ *             exact assumption the CLI transport needed a 200-line parser to
+ *             stop making. Both transports now hand their failure text to
+ *             `safeHermesFailureMessage` before anyone sees it.
  *
  * Once the first byte is out the status code is spent, so a failure after that
  * point is reported inside the stream rather than as an HTTP error. Everything
@@ -514,7 +520,19 @@ function streamTurn(turn: DashboardTurn, fallbackSessionId: string): Response {
           },
         );
         if (final.status === "error") {
-          const detail = final.error || final.text || "Hermes chat failed";
+          // The dashboard's `payload.error` is Python-authored text off a
+          // socket, no different in kind from the CLI's stderr — so it takes
+          // the same road out. `final.text` is NOT a fallback for it: the
+          // answer body is not an error message, and the transport caps it at
+          // MAX_TEXT_BYTES (2,000,000), so using it wrote up to a two-megabyte
+          // `Error: …` row into a customer's durable transcript where the CLI
+          // branch would have capped the same failure at 400 characters.
+          //
+          // The raw frame stays in the journal, the pattern the provider-key
+          // route already uses: the diagnosis is not lost, it just stops being
+          // published.
+          if (final.error) console.error("[hermes chat] dashboard turn failed", final.error);
+          const detail = safeHermesFailureMessage("", final.error || "") || "Hermes chat failed";
           await appendTranscript({
             role: "system",
             text: `Error: ${detail}`,
@@ -534,7 +552,17 @@ function streamTurn(turn: DashboardTurn, fallbackSessionId: string): Response {
           );
         }
       } catch (err) {
-        const detail = err instanceof Error ? err.message : "Hermes chat failed";
+        // The sibling of the branch above, and it carries the SAME text from
+        // the SAME place: hermes-dashboard-turn.ts rethrows the transport's
+        // `error` frame as `new Error(payload.message)`. ClawBox-authored
+        // failures thrown here (a quiet stream, a cancelled call) pass through
+        // the parser unchanged — nothing in them looks like a traceback or a
+        // path — so one treatment is right for both.
+        const raw = err instanceof Error ? err.message : "";
+        // Not for an abort: the socket died because the customer pressed Stop,
+        // and a journal line per cancelled turn is noise, not diagnosis.
+        if (raw && !isAbort(err)) console.error("[hermes chat] dashboard stream failed", raw);
+        const detail = safeHermesFailureMessage("", raw) || "Hermes chat failed";
         // ── Silence is not failure: ask the agent before saying so ─────────
         //
         // A quiet stream means this socket stopped hearing. It does NOT mean

--- a/src/app/setup-api/hermes/provider-key/route.ts
+++ b/src/app/setup-api/hermes/provider-key/route.ts
@@ -2,7 +2,7 @@ export const dynamic = "force-dynamic";
 
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
-import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
+import { redactKey, safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 
 // Store an API key for a Hermes inference provider via `hermes auth add`. Hermes
@@ -26,16 +26,13 @@ const API_KEY_PROVIDERS = new Set([
 // as a flag.
 const API_KEY_RE = /^[!-~]{8,512}$/;
 
-/**
- * Take the pasted key out of any text on its way to a person or a log.
- *
- * The key is validated to printable non-space ASCII, so a plain substring swap
- * is exact — there is no encoding of it in the CLI's output that this would
- * miss and no regex escaping to get wrong.
- */
-function redactKey(text: string, apiKey: string): string {
-  return apiKey ? text.split(apiKey).join("<redacted>") : text;
-}
+// `redactKey` — take the pasted key out of any text on its way to a person or a
+// log — now lives beside the parser it runs in front of. It moved because
+// `applyCloudProviderKeyToHermes` runs the SAME `hermes auth add` for the
+// Settings/wizard panel and needed the same redaction; a second copy would have
+// been a second place to forget it. The key is validated to printable non-space
+// ASCII below, so a plain substring swap is exact — no encoding of it in the
+// CLI's output that this would miss, and no regex escaping to get wrong.
 
 export async function POST(request: Request) {
   let body: { provider?: string; apiKey?: string };

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -2,7 +2,7 @@ import { setMany } from "@/lib/config-store";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli } from "@/lib/hermes-cli";
-import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
+import { redactKey, safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { setHermesEnvValues } from "@/lib/hermes-env";
@@ -228,10 +228,23 @@ export async function applyClawaiToHermes(
       // configure route returns it as `{ error }`, and the clawai poll route
       // re-throws it unchanged), so the raw stream stops here: `hermes config
       // set` is a Python CLI and a crash prints /home/clawbox/.hermes at the
-      // customer. The journal keeps the whole thing.
-      console.error(`[hermes/clawai] ${args.join(" ")} exit`, r.code, r.stderr);
+      // customer.
+      //
+      // The journal gets the diagnosis but NOT the credential, and that needs
+      // saying twice because the token appears in two places at once. One of
+      // these steps is `config set providers.clawai.api_key <device token>`, so
+      // the KEY is logged and the value is not; and an argparse usage error
+      // prints the argv it choked on, so the stream is redacted before either
+      // the log or the parser sees it — the same order the `hermes auth add`
+      // callers use.
+      // Passed as ARGUMENTS rather than interpolated into the message: a
+      // template built from argv is a tainted format string, and CodeQL is
+      // right that a value flowing into the shape of a log line is a different
+      // risk from one flowing into its data.
+      console.error("[hermes/clawai] config write failed", args[1], args[2], r.code, redactKey(r.stderr, trimmed));
       throw new ClawaiApplyError(
-        safeHermesFailureMessage(r.stdout, r.stderr) || "Failed to configure ClawBox AI",
+        safeHermesFailureMessage(redactKey(r.stdout, trimmed), redactKey(r.stderr, trimmed))
+          || "Failed to configure ClawBox AI",
       );
     }
   }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -2,6 +2,7 @@ import { setMany } from "@/lib/config-store";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli } from "@/lib/hermes-cli";
+import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { setHermesEnvValues } from "@/lib/hermes-env";
@@ -223,7 +224,15 @@ export async function applyClawaiToHermes(
     const r = await runHermesCli(args, { timeoutMs: 15_000 });
     // `unset` of an absent key is a no-op; only a failing `set` is fatal.
     if (r.code !== 0 && args[1] === "set") {
-      throw new ClawaiApplyError(r.stderr || "Failed to configure ClawBox AI");
+      // This message is rendered verbatim in the Settings save banner (the
+      // configure route returns it as `{ error }`, and the clawai poll route
+      // re-throws it unchanged), so the raw stream stops here: `hermes config
+      // set` is a Python CLI and a crash prints /home/clawbox/.hermes at the
+      // customer. The journal keeps the whole thing.
+      console.error(`[hermes/clawai] ${args.join(" ")} exit`, r.code, r.stderr);
+      throw new ClawaiApplyError(
+        safeHermesFailureMessage(r.stdout, r.stderr) || "Failed to configure ClawBox AI",
+      );
     }
   }
 

--- a/src/lib/hermes-cli-message.ts
+++ b/src/lib/hermes-cli-message.ts
@@ -9,7 +9,20 @@
  * the screen anyway, one panel over. One parser, every surface.
  *
  * The grep that says the surfaces are all accounted for:
+ *   grep -rn "\.std\(out\|err\)" src --include=*.ts --include=*.tsx
+ *
+ * That grep is WIDER than the one this header used to record, and the widening
+ * is the point. The old one —
+ *
  *   grep -rn "stderr" src/app/setup-api/hermes --include=route.ts
+ *
+ * — was scoped to a single directory, and named itself a completeness proof
+ * while three libraries outside it (`hermes-cloud-provider`, `hermes-clawai`,
+ * `hermes-config-yaml`) were handing the same raw stream to the same browser
+ * through /setup-api/ai-models/configure. A proof that only looks where the
+ * bug was first found proves nothing about where it also lives. The wide form
+ * is noisier — it lists the plumbing that merely COLLECTS a stream — but every
+ * site that RENDERS one is in its output.
  */
 import { sanitizeErrorMessage } from "@/lib/safe-error-text";
 
@@ -271,6 +284,28 @@ export function hermesFailureMessage(stdout: string, stderr: string): string {
  */
 export function safeHermesFailureMessage(stdout: string, stderr: string): string {
   return sanitizeErrorMessage(hermesFailureMessage(stdout, stderr)) ?? "";
+}
+
+/**
+ * Blank a secret out of a stream before anything else looks at it.
+ *
+ * Argv is the leak: `hermes auth add … --api-key <key>` puts the credential on
+ * the command line, and an argparse usage error prints the command line back.
+ * None of the rules above would catch it — the key is not a path, not a URL,
+ * and `sanitizeErrorMessage`'s credential test knows only the `sk-`/`claw_`
+ * prefixes, which a bring-your-own-key provider need not use.
+ *
+ * So the caller that HAS the secret removes it, and does so BEFORE the parser
+ * rather than after: the cap and the line filter both work on the text a person
+ * will see, and a key spliced out afterwards would already have been counted
+ * (or, worse, have been the 400 characters that survived).
+ *
+ * Lives here rather than beside one route because two callers now need it —
+ * /setup-api/hermes/provider-key and `applyCloudProviderKeyToHermes`, which
+ * runs the very same `auth add` for the wizard's Settings panel.
+ */
+export function redactKey(text: string, apiKey: string): string {
+  return apiKey ? text.split(apiKey).join("<redacted>") : text;
 }
 
 /**

--- a/src/lib/hermes-cloud-provider.ts
+++ b/src/lib/hermes-cloud-provider.ts
@@ -1,4 +1,5 @@
 import { runHermesCli } from "@/lib/hermes-cli";
+import { redactKey, safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { setMany } from "@/lib/config-store";
 import {
   getModelOptions,
@@ -55,8 +56,14 @@ export interface HermesCloudApplyResult {
  * Store an API key for a cloud provider on Hermes and, when a model can be
  * resolved for it, make it the active provider.
  *
- * @throws HermesCloudApplyError with only ClawBox-authored text — a raw hermes
+ * @throws HermesCloudApplyError carrying either ClawBox-authored text or a
+ *   `hermes` message that has been through `safeHermesFailureMessage` — a raw
  *   stderr can carry the binary path, and the key must never be echoed back.
+ *
+ *   That sentence used to read "with only ClawBox-authored text", twenty-eight
+ *   lines above a `throw` that handed back `add.stderr` verbatim. The docstring
+ *   was right about the risk and wrong about the code; the code now matches it,
+ *   and the promise is kept by a function rather than by a comment.
  */
 export async function applyCloudProviderKeyToHermes(opts: {
   openclawProvider: string;
@@ -82,8 +89,27 @@ export async function applyCloudProviderKeyToHermes(opts: {
     { timeoutMs: 20_000 },
   );
   if (add.code !== 0) {
-    // Never echo the key. hermes stderr may name the provider but not the secret.
-    throw new HermesCloudApplyError(add.stderr || "Failed to save the API key.");
+    // Two separate things must not reach the Settings banner, and the old
+    // comment ("hermes stderr may name the provider but not the secret") was
+    // only thinking about one of them — and was wrong about that one too.
+    //
+    // 1. The KEY. True of a clean refusal, false of an argparse usage error,
+    //    which prints the offending argv and the key is IN the argv. Redacted
+    //    rather than assumed absent, and redacted BEFORE the parser so the cap
+    //    counts the text a person will actually see.
+    // 2. The CRASH. `hermes auth add` is the first command a customer's saved
+    //    key runs through, and a traceback here rendered verbatim in the save
+    //    banner: CPython frames naming /home/clawbox/.hermes. That is the input
+    //    PR #515 cleaned out of the chat bubble, on a screen its grep did not
+    //    reach.
+    //
+    // The raw stream still goes to the journal, so nothing is lost for the
+    // person diagnosing it — it just stops being published.
+    console.error("[hermes cloud-provider] auth add exit", add.code, redactKey(add.stderr, key));
+    throw new HermesCloudApplyError(
+      safeHermesFailureMessage(redactKey(add.stdout, key), redactKey(add.stderr, key))
+        || "Failed to save the API key.",
+    );
   }
   invalidateModelOptions();
 
@@ -109,13 +135,23 @@ export async function applyCloudProviderKeyToHermes(opts: {
     return { provider: slug, model: "", activated: false };
   }
 
+  // The two ACTIVATION writes are the same call site three lines apart, and the
+  // sibling-call-site shape is exactly what gets missed: a fix applied to the
+  // `auth add` above and not to these would have left the leak live for every
+  // customer whose key stored fine and whose config write did not.
   const setProvider = await runHermesCli(["config", "set", "model.provider", slug], { timeoutMs: 15_000 });
   if (setProvider.code !== 0) {
-    throw new HermesCloudApplyError(setProvider.stderr || "Failed to select the provider.");
+    console.error("[hermes cloud-provider] config set model.provider exit", setProvider.code, setProvider.stderr);
+    throw new HermesCloudApplyError(
+      safeHermesFailureMessage(setProvider.stdout, setProvider.stderr) || "Failed to select the provider.",
+    );
   }
   const setModel = await runHermesCli(["config", "set", "model.default", model], { timeoutMs: 15_000 });
   if (setModel.code !== 0) {
-    throw new HermesCloudApplyError(setModel.stderr || "Failed to set the model.");
+    console.error("[hermes cloud-provider] config set model.default exit", setModel.code, setModel.stderr);
+    throw new HermesCloudApplyError(
+      safeHermesFailureMessage(setModel.stdout, setModel.stderr) || "Failed to set the model.",
+    );
   }
 
   // Keep the wizard's own status route consistent: without ai_model_configured

--- a/src/lib/hermes-config-yaml.ts
+++ b/src/lib/hermes-config-yaml.ts
@@ -40,7 +40,9 @@ import fs from "fs/promises";
 import path from "path";
 
 import { runHermesCli } from "@/lib/hermes-cli";
+import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { invalidateHermesConfigCache } from "@/lib/hermes-config-cache";
+import { sanitizeErrorMessage } from "@/lib/safe-error-text";
 import { hermesHome } from "@/lib/hermes-env";
 import { getYamlPath, setYamlPath, unsetYamlPath, YamlEditUnsupported } from "@/lib/yaml-block-edit";
 
@@ -132,7 +134,16 @@ async function applyViaCli(patch: HermesConfigPatch): Promise<void> {
   for (const [key, value] of Object.entries(patch.set ?? {})) {
     const r = await runHermesCli(["config", "set", key, value], { timeoutMs: 15_000 });
     if (r.code !== 0) {
-      throw new HermesConfigWriteError(r.stderr.trim() || `Failed to set ${key} in the Hermes config`);
+      // `HermesConfigWriteError` is re-wrapped by hermes-local-ai as
+      // `HermesLocalApplyError` and returned to the browser as `{ error }`, so
+      // this string is a save banner. A raw `hermes config set` stderr is
+      // Python: a traceback here names /home/clawbox/.hermes on the customer's
+      // screen. Same parser as every other `hermes` surface; raw goes to the
+      // journal.
+      console.error("[hermes-config-yaml] config set exit", r.code, r.stderr);
+      throw new HermesConfigWriteError(
+        safeHermesFailureMessage(r.stdout, r.stderr) || `Failed to set ${key} in the Hermes config`,
+      );
     }
   }
   for (const key of patch.unset ?? []) {
@@ -165,8 +176,21 @@ export async function patchHermesConfig(patch: HermesConfigPatch): Promise<Herme
       if (!(err instanceof YamlEditUnsupported)) {
         // A read or write error is not something the CLI would do better at —
         // it writes the same file, as the same user.
+        //
+        // And it is the COMMON leak on this path, not the rare one: the CLI
+        // fallback below runs only for a file the merge cannot parse, while
+        // every EACCES on config.yaml lands here, and Node writes the path into
+        // the message it hands over —
+        //
+        //   EACCES: permission denied, open '/home/clawbox/.hermes/config.yaml'
+        //
+        // — which then became the save banner verbatim. `sanitizeErrorMessage`
+        // is the repo's whitelist-by-shape; null from it means "say something
+        // generic", never "say nothing", so the fixed sentence stands in.
+        console.error("[hermes-config-yaml] merge write failed", err);
         throw new HermesConfigWriteError(
-          err instanceof Error ? err.message : "Failed to update the Hermes config",
+          sanitizeErrorMessage(err instanceof Error ? err.message : "")
+            || "Failed to update the Hermes config",
         );
       }
       fallbackReason = err.message;

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -5,6 +5,7 @@ import { invalidateModelOptions } from "@/lib/hermes-model-options";
 import { getLocalAiToken } from "@/lib/local-ai-token";
 import { getDefaultLlamaCppModel } from "@/lib/llamacpp";
 import { getLocalAiOpenAiBaseUrl, getLocalAiProxyRootUrl } from "@/lib/local-ai-runtime";
+import { sanitizeErrorMessage } from "@/lib/safe-error-text";
 
 /**
  * Register the on-device model with Hermes.
@@ -69,8 +70,14 @@ export async function applyLocalAiToHermes(options: {
   try {
     await patchHermesConfig({ set });
   } catch (err) {
+    // Guarded here as well as at the source, because this catch is `catch
+    // (err)` — it re-publishes the message of ANY throw from the write path,
+    // not only the `HermesConfigWriteError` that path cleans. A wrapper whose
+    // safety depends on every future thrower having remembered is the shape
+    // this whole round is about.
     throw new HermesLocalApplyError(
-      err instanceof Error ? err.message : "Failed to register the local model with Hermes",
+      sanitizeErrorMessage(err instanceof Error ? err.message : "")
+        || "Failed to register the local model with Hermes",
     );
   }
 

--- a/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
+++ b/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The STREAMED transport's failure text, which #515 never reached.
+ *
+ * #515 taught the chat route to clean the text of a failed Hermes turn:
+ * `withoutTracebackFrames` drops the CPython frames, `redactDevicePaths`
+ * replaces `/home/clawbox/…` with `<path>`, and `MAX_MESSAGE_CHARS` caps the
+ * result at 400. All of it lived on the CLI transport, and the CLI transport is
+ * the FALLBACK: `POST` opens a dashboard turn first for every non-image turn
+ * (route.ts, "the fast path"), and the chat surface asks for
+ * `Accept: text/event-stream`, so the streamed branch is what a customer
+ * actually gets.
+ *
+ * On that branch the Hermes Python dashboard's own text went out untouched —
+ * `payload.error` off `message.complete`, `payload.message` off the `error`
+ * frame — into two places at once: the SSE `error` event the chat bubble
+ * renders, and the customer's DURABLE transcript, which survives the refresh
+ * that would have hidden a one-off bubble.
+ *
+ * These pin the streamed branch against the same inputs the CLI branch was
+ * fixed for, plus the one that needs no traceback at all: an errored turn with
+ * no `error` field, where the answer body — capped upstream at 2 MB, not at 400
+ * chars — was being written into the transcript as the failure.
+ */
+
+const openTurnMock = vi.hoisted(() => vi.fn());
+const spawnMock = vi.hoisted(() => vi.fn());
+const appendMock = vi.hoisted(() => vi.fn());
+const readTurnMock = vi.hoisted(() => vi.fn());
+
+// Only the OPENING is faked, for the reason the sibling suite gives: the
+// route's recovery path turns on `isQuietStreamError`, and a hand-written
+// stand-in would let the predicate and the route drift.
+vi.mock("@/lib/hermes-dashboard-turn", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-dashboard-turn")>()),
+  openDashboardTurn: openTurnMock,
+}));
+vi.mock("child_process", () => ({ spawn: spawnMock }));
+vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock }));
+vi.mock("@/lib/harness/hermes-turn-record", () => ({ readHermesTurn: readTurnMock }));
+vi.mock("@/lib/harness/media-root", () => ({
+  resolveInMediaRoot: vi.fn(async (p: string) => p),
+  chatMediaRoot: vi.fn(async () => "/tmp/clawbox-dashboard-error-media"),
+}));
+vi.mock("@/lib/hermes-model-options", () => ({
+  getModelOptions: vi.fn(async () => null),
+  isAllowedProvider: vi.fn(() => true),
+  isPairAllowed: vi.fn(() => true),
+  shouldEnforcePairing: vi.fn(() => false),
+}));
+
+import { POST } from "@/app/setup-api/hermes/chat/route";
+
+/** A turn handle that settles exactly as the dashboard said it did. */
+function fakeTurn(opts: { text?: string; status?: string; error?: string; fail?: Error }) {
+  return {
+    sessionId: "20260828_101500_a1b2c3",
+    model: "",
+    provider: "",
+    async run() {
+      if (opts.fail) throw opts.fail;
+      return {
+        text: opts.text ?? "",
+        reasoning: "",
+        status: opts.status ?? "complete",
+        ...(opts.error ? { error: opts.error } : {}),
+      };
+    },
+    close() {},
+  };
+}
+
+function post(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/setup-api/hermes/chat", {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "text/event-stream" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function readEvents(res: Response): Promise<Array<[string, Record<string, unknown>]>> {
+  const text = await res.text();
+  const out: Array<[string, Record<string, unknown>]> = [];
+  for (const frame of text.split("\n\n")) {
+    if (!frame.trim()) continue;
+    let name = "message";
+    const data: string[] = [];
+    for (const line of frame.split("\n")) {
+      if (line.startsWith("event:")) name = line.slice(6).trim();
+      else if (line.startsWith("data:")) data.push(line.slice(5).replace(/^ /, ""));
+    }
+    out.push([name, JSON.parse(data.join("\n")) as Record<string, unknown>]);
+  }
+  return out;
+}
+
+/** The `error` event's text, and the transcript line written beside it. */
+async function failureOf(res: Response): Promise<{ shown: string; recorded: string }> {
+  const events = await readEvents(res);
+  const [name, payload] = events[events.length - 1];
+  expect(name).toBe("error");
+  const row = appendMock.mock.calls
+    .map(([record]) => record as Record<string, unknown>)
+    .find((r) => r.variant === "error");
+  return { shown: String(payload.error ?? ""), recorded: String(row?.text ?? "") };
+}
+
+beforeEach(() => {
+  openTurnMock.mockReset();
+  spawnMock.mockReset();
+  appendMock.mockReset();
+  appendMock.mockResolvedValue(true);
+  readTurnMock.mockReset();
+  readTurnMock.mockResolvedValue(null);
+});
+
+describe("a streamed turn that failed", () => {
+  it("shows the exception, not the Python frames under it", async () => {
+    // The shape hermes-dashboard-turn.ts reports as `payload.error` on
+    // `message.complete` when the agent's own call stack blew up.
+    openTurnMock.mockResolvedValue(fakeTurn({
+      status: "error",
+      error: [
+        "Traceback (most recent call last):",
+        '  File "/home/clawbox/.hermes/agent.py", line 88, in _call_provider',
+        '    raise RuntimeError("upstream refused the request")',
+        "RuntimeError: upstream refused the request",
+      ].join("\n"),
+    }));
+    const { shown, recorded } = await failureOf(await POST(post({ message: "Hey" })));
+    expect(shown).toBe("RuntimeError: upstream refused the request");
+    expect(shown).not.toContain('File "');
+    expect(shown).not.toContain("/home/clawbox");
+    // The transcript is the durable copy — a leak there outlives the bubble.
+    expect(recorded).toBe("Error: RuntimeError: upstream refused the request");
+    expect(recorded).not.toContain("/home/clawbox");
+  });
+
+  it("keeps the device layout out of a one-line failure that names no traceback", async () => {
+    openTurnMock.mockResolvedValue(fakeTurn({
+      status: "error",
+      error: "Error: cannot write /home/clawbox/.hermes/config.yaml: permission denied",
+    }));
+    const { shown, recorded } = await failureOf(await POST(post({ message: "Hey" })));
+    expect(shown).not.toContain("/home/clawbox");
+    // Redacted, not dropped: "permission denied" is the half a person can act on.
+    expect(shown).toContain("permission denied");
+    expect(recorded).not.toContain("/home/clawbox");
+  });
+
+  it("cleans the `error` FRAME the same way, not only the settled turn", async () => {
+    // hermes-dashboard-turn.ts throws `payload.message` verbatim on the error
+    // frame, so this arrives at the route's catch rather than its status check.
+    // Both write the same bubble and the same transcript row.
+    openTurnMock.mockResolvedValue(fakeTurn({
+      fail: new Error([
+        "Traceback (most recent call last):",
+        '  File "/home/clawbox/.hermes/dashboard/rpc.py", line 210, in _dispatch',
+        '    raise PermissionError(13, "auth-profiles.json")',
+        "PermissionError: [Errno 13] Permission denied: '/home/clawbox/.hermes/auth-profiles.json'",
+      ].join("\n")),
+    }));
+    const { shown, recorded } = await failureOf(await POST(post({ message: "Hey" })));
+    expect(shown).not.toContain("/home/clawbox");
+    expect(shown).not.toContain('File "');
+    expect(shown).toContain("Permission denied");
+    expect(recorded).not.toContain("/home/clawbox");
+  });
+
+  it("never writes the ANSWER body into the transcript as the failure", async () => {
+    // Provable without a traceback. `final.text` was a legal fallback for the
+    // failure text, and the transport caps an answer at MAX_TEXT_BYTES =
+    // 2,000,000 — four thousand times the 400-char cap the CLI branch applies —
+    // so a status-error turn with no `error` field wrote a multi-megabyte
+    // `Error: …` row into a customer's durable transcript.
+    const body = "x".repeat(5000);
+    openTurnMock.mockResolvedValue(fakeTurn({ status: "error", text: body }));
+    const { shown, recorded } = await failureOf(await POST(post({ message: "Hey" })));
+    expect(shown).toBe("Hermes chat failed");
+    expect(recorded).toBe("Error: Hermes chat failed");
+    expect(recorded).not.toContain("xxxx");
+  });
+
+  it("caps what it shows, because a bubble is not a log viewer", async () => {
+    openTurnMock.mockResolvedValue(fakeTurn({
+      status: "error",
+      error: `provider request failed: ${"detail ".repeat(200)}`,
+    }));
+    const { shown } = await failureOf(await POST(post({ message: "Hey" })));
+    expect(shown.length).toBeLessThanOrEqual(400);
+  });
+});

--- a/src/tests/unit/hermes-apply-error-text.test.ts
+++ b/src/tests/unit/hermes-apply-error-text.test.ts
@@ -169,6 +169,33 @@ describe("linking ClawBox AI on Hermes", () => {
     expectCustomerSafe(await messageFor(() => applyClawaiToHermes("claw_token_abc", "flash")));
   });
 
+  it("puts the device token in neither the banner nor the journal", async () => {
+    // One of the `config set` steps is `providers.clawai.api_key <token>`, so
+    // the argv carries the credential — and an argparse usage error prints the
+    // argv back. Both the log line and the thrown message have to be clean.
+    const token = "claw_device_token_0123456789";
+    const journal = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Fail the ONE step that carries the credential, so the assertions are
+      // about that step rather than about whichever `set` happens to be first.
+      cliMock.mockImplementation(async (args: string[]) =>
+        args[1] === "set" && args[2] === "providers.clawai.api_key"
+          ? {
+            code: 2,
+            stdout: "",
+            stderr: `hermes config set: error: unrecognized arguments: ${token}`,
+          }
+          : { code: 0, stdout: "", stderr: "" });
+      const message = await messageFor(() => applyClawaiToHermes(token, "flash"));
+      expect(message).not.toContain(token);
+      expect(journal.mock.calls.flat().join(" ")).not.toContain(token);
+      // The log still says WHICH write failed — redaction, not silence.
+      expect(journal.mock.calls.flat().join(" ")).toContain("providers.clawai.api_key");
+    } finally {
+      journal.mockRestore();
+    }
+  });
+
   it("stays a ClawaiApplyError, so the configure route still classifies it", async () => {
     cliMock.mockImplementation(async (args: string[]) =>
       args[1] === "set"

--- a/src/tests/unit/hermes-apply-error-text.test.ts
+++ b/src/tests/unit/hermes-apply-error-text.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The AI-provider save path's failure text — the surfaces #515's parser was
+ * never pointed at.
+ *
+ * The extraction that gave #515 a home in `@/lib/hermes-cli-message` wrote its
+ * own completeness proof into the file header:
+ *
+ *   grep -rn "stderr" src/app/setup-api/hermes --include=route.ts
+ *
+ * That grep is scoped to ONE directory, and the AI-provider save path does not
+ * live in it. `runHermesCli` resolves with RAW stdout/stderr — it sanitises only
+ * the spawn-failure reject — so three libraries handed that stream straight to
+ * the browser:
+ *
+ *   hermes-cloud-provider.ts   `hermes auth add`, `hermes config set`
+ *   hermes-clawai.ts           `hermes config set`
+ *   hermes-config-yaml.ts      `hermes config set` (the CLI fallback), and the
+ *                              fs error from the merge path above it
+ *
+ * All four throw classes are caught together in /setup-api/ai-models/configure
+ * and returned as `{ error: err.message }`; AIModelsStep's `extractError`
+ * returns `data.error` unchanged into `showError`. So a failed `hermes auth add`
+ * printed its CPython traceback — `/home/clawbox/.hermes/…` and all — into the
+ * Settings save banner, which is precisely the input #515 removed from the chat
+ * bubble one directory over.
+ *
+ * The fixtures are the shapes a Python CLI actually produces: a traceback whose
+ * summary is the only line worth reading, and the one-line EACCES that carries
+ * the install layout with no traceback at all.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn(), get: vi.fn(async () => null) }));
+// The image half of the ClawBox AI apply writes to ~/.hermes and copies a plugin
+// into it; neither belongs in this file's blast radius, and both have their own.
+vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
+vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
+  refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
+}));
+vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
+  installHermesImagePlugin: vi.fn(),
+}));
+const resolveVisionMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: resolveVisionMock,
+}));
+vi.mock("@/lib/hermes-model-options", () => ({
+  invalidateModelOptions: vi.fn(),
+  getModelOptions: vi.fn(async () => null),
+  isAllowedProvider: vi.fn(() => false),
+  scopeFromPayload: vi.fn(async () => ({ defaultModel: "" })),
+}));
+
+import { HermesCloudApplyError, applyCloudProviderKeyToHermes } from "@/lib/hermes-cloud-provider";
+import { ClawaiApplyError, applyClawaiToHermes } from "@/lib/hermes-clawai";
+import { CLAWBOX_AI_VISION_MODEL_ID } from "@/lib/clawbox-ai-models";
+
+const TRACEBACK = [
+  "Traceback (most recent call last):",
+  '  File "/home/clawbox/.hermes/cli/auth.py", line 142, in add',
+  '    raise PermissionError(13, "auth-profiles.json")',
+  "PermissionError: [Errno 13] Permission denied: '/home/clawbox/.hermes/auth-profiles.json'",
+].join("\n");
+
+const ONE_LINE_EACCES = "Error: cannot write /home/clawbox/.hermes/config.yaml: permission denied";
+
+/** The message a customer would be shown for this failure. */
+async function messageFor(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error("expected the call to fail, and it did not");
+}
+
+/** Every assertion that applies to every one of these surfaces. */
+function expectCustomerSafe(message: string): void {
+  expect(message).not.toContain("/home/clawbox");
+  expect(message).not.toContain('File "');
+  expect(message).not.toContain("Traceback");
+  // Null means "say something generic", never "say nothing" — an empty banner
+  // is the silent failure the sanitiser exists to prevent.
+  expect(message.trim()).not.toBe("");
+}
+
+beforeEach(() => {
+  cliMock.mockReset();
+  resolveVisionMock.mockReset();
+  resolveVisionMock.mockResolvedValue({
+    id: CLAWBOX_AI_VISION_MODEL_ID,
+    verified: true,
+    reason: "proxy-allows",
+  });
+});
+
+describe("saving a cloud provider key on Hermes", () => {
+  it("does not put a Python traceback in the Settings banner", async () => {
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: TRACEBACK });
+    expectCustomerSafe(await messageFor(() =>
+      applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-test-key" })));
+  });
+
+  it("does not name the install layout when there is no traceback at all", async () => {
+    // The shape that survives every rule in the parser, because it genuinely IS
+    // the cause and it genuinely does name a failure.
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: ONE_LINE_EACCES });
+    const message = await messageFor(() =>
+      applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-test-key" }));
+    expectCustomerSafe(message);
+    expect(message).not.toContain(".hermes");
+  });
+
+  it("never echoes the API key back, even when the CLI printed the argv it sat in", async () => {
+    // An argparse usage error prints the offending command line, and the key is
+    // in it. The redaction runs BEFORE the parser for that reason — the order
+    // /setup-api/hermes/provider-key already uses.
+    const key = "sk-ant-secret-value-0123456789";
+    cliMock.mockResolvedValue({
+      code: 2,
+      stdout: "",
+      stderr: [
+        "usage: hermes auth add [-h] --type TYPE --api-key API_KEY provider",
+        `hermes auth add: error: unrecognized arguments: --api-key ${key}`,
+      ].join("\n"),
+    });
+    const message = await messageFor(() =>
+      applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: key }));
+    expect(message).not.toContain(key);
+    expect(message.trim()).not.toBe("");
+  });
+
+  it("stays a HermesCloudApplyError, so the configure route still classifies it", async () => {
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: TRACEBACK });
+    await expect(
+      applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-test-key" }),
+    ).rejects.toBeInstanceOf(HermesCloudApplyError);
+  });
+
+  it("cleans the two `config set` failures after the key is stored, not just the first", async () => {
+    // The sibling call sites: `auth add` succeeds, a model resolves, and the
+    // activation writes fail. Same class, same screen, three lines apart.
+    const options = await import("@/lib/hermes-model-options");
+    vi.mocked(options.isAllowedProvider).mockReturnValue(true);
+    vi.mocked(options.scopeFromPayload).mockResolvedValue(
+      { defaultModel: "claude-opus-5" } as Awaited<ReturnType<typeof options.scopeFromPayload>>,
+    );
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[0] === "auth"
+        ? { code: 0, stdout: "", stderr: "" }
+        : { code: 1, stdout: "", stderr: TRACEBACK });
+    expectCustomerSafe(await messageFor(() =>
+      applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-test-key" })));
+  });
+});
+
+describe("linking ClawBox AI on Hermes", () => {
+  it("does not put a Python traceback in the Settings banner", async () => {
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[1] === "set"
+        ? { code: 1, stdout: "", stderr: TRACEBACK }
+        : { code: 0, stdout: "", stderr: "" });
+    expectCustomerSafe(await messageFor(() => applyClawaiToHermes("claw_token_abc", "flash")));
+  });
+
+  it("stays a ClawaiApplyError, so the configure route still classifies it", async () => {
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[1] === "set"
+        ? { code: 1, stdout: "", stderr: TRACEBACK }
+        : { code: 0, stdout: "", stderr: "" });
+    await expect(applyClawaiToHermes("claw_token_abc", "flash")).rejects.toBeInstanceOf(ClawaiApplyError);
+  });
+});

--- a/src/tests/unit/hermes-config-write-error-text.test.ts
+++ b/src/tests/unit/hermes-config-write-error-text.test.ts
@@ -1,0 +1,144 @@
+import fsActual from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `patchHermesConfig` fails in two ways, and BOTH of them reached the browser.
+ *
+ * It is the write path behind "save a local model" on a Hermes box:
+ * hermes-local-ai.ts re-wraps whatever it throws as `HermesLocalApplyError`,
+ * /setup-api/ai-models/configure returns that as `{ error: err.message }` under
+ * a comment reading "Author-controlled, non-credential message — safe to echo",
+ * and AIModelsStep renders it verbatim in the save banner.
+ *
+ *   1. The CLI FALLBACK, taken when the comment-preserving merge cannot handle
+ *      the file: `hermes config set`'s raw stderr became the banner. Same class
+ *      as #515's chat bubble, same Python CLI, different screen.
+ *
+ *   2. The MERGE path's own fs error, which is the COMMON case rather than the
+ *      fallback — and the one shape that needs no traceback to leak the
+ *      layout:
+ *
+ *        EACCES: permission denied, open '/home/clawbox/.hermes/config.yaml'
+ *
+ * The fs half is mocked rather than provoked, because the only portable way to
+ * make a real read fail (a directory where the file should be) produces an
+ * errno message with no path in it — which would make the assertion pass
+ * without testing anything.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/hermes-config-cache", () => ({ invalidateHermesConfigCache: vi.fn() }));
+
+// Delegates to the real fs unless a test arms a failure, so the CLI-fallback
+// case below runs against a genuine file on disk.
+const fsState = vi.hoisted(() => ({ readFileFailure: null as NodeJS.ErrnoException | null }));
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  const readFile = ((...args: unknown[]) =>
+    fsState.readFileFailure
+      ? Promise.reject(fsState.readFileFailure)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      : (actual.readFile as any)(...args)) as typeof actual.readFile;
+  const api = { ...actual, readFile };
+  return { ...api, default: api };
+});
+
+const TRACEBACK = [
+  "Traceback (most recent call last):",
+  '  File "/home/clawbox/.hermes/cli/config.py", line 61, in set_value',
+  '    raise PermissionError(13, "config.yaml")',
+  "PermissionError: [Errno 13] Permission denied: '/home/clawbox/.hermes/config.yaml'",
+].join("\n");
+
+/** A file `yaml-block-edit` declines, so the write takes the CLI fallback. */
+const MULTI_DOCUMENT = "---\nmodel:\n  provider: anthropic\n---\nother: 1\n";
+
+let home: string;
+
+async function loadModule() {
+  vi.resetModules();
+  return await import("@/lib/hermes-config-yaml");
+}
+
+async function messageFor(run: () => Promise<unknown>): Promise<string> {
+  try {
+    await run();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error("expected the write to fail, and it did not");
+}
+
+beforeEach(async () => {
+  cliMock.mockReset();
+  fsState.readFileFailure = null;
+  home = await fsActual.mkdtemp(path.join(os.tmpdir(), "hermes-config-err-"));
+  process.env.HERMES_HOME = home;
+});
+
+afterEach(async () => {
+  delete process.env.HERMES_HOME;
+  fsState.readFileFailure = null;
+  await fsActual.rm(home, { recursive: true, force: true });
+});
+
+describe("a Hermes config write that failed", () => {
+  it("does not put `hermes config set`'s traceback in the save banner", async () => {
+    await fsActual.writeFile(path.join(home, "config.yaml"), MULTI_DOCUMENT, { mode: 0o600 });
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: TRACEBACK });
+    const { patchHermesConfig } = await loadModule();
+    const message = await messageFor(() => patchHermesConfig({ set: { "model.default": "gemma-4" } }));
+    // The fallback really was taken — otherwise this asserts nothing.
+    expect(cliMock).toHaveBeenCalled();
+    expect(message).not.toContain("/home/clawbox");
+    expect(message).not.toContain('File "');
+    expect(message).not.toContain("Traceback");
+    expect(message.trim()).not.toBe("");
+  });
+
+  it("does not put the fs error's own path in the save banner", async () => {
+    const err: NodeJS.ErrnoException = Object.assign(
+      new Error("EACCES: permission denied, open '/home/clawbox/.hermes/config.yaml'"),
+      { code: "EACCES", path: "/home/clawbox/.hermes/config.yaml" },
+    );
+    fsState.readFileFailure = err;
+    const { patchHermesConfig } = await loadModule();
+    const message = await messageFor(() => patchHermesConfig({ set: { "model.default": "gemma-4" } }));
+    expect(message).not.toContain("/home/clawbox");
+    expect(message.trim()).not.toBe("");
+    // Never the fallback path either: an unreadable file is not something
+    // `hermes config set` would do better at — it writes the same file.
+    expect(cliMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("registering a local model when the config write failed", () => {
+  it("does not carry the raw message through HermesLocalApplyError", async () => {
+    // The wrapper is its own surface: it re-wraps `err.message` from ANY throw,
+    // so it has to be safe on its own rather than on the promise that whoever
+    // threw already cleaned it.
+    vi.resetModules();
+    vi.doMock("@/lib/hermes-config-yaml", () => ({
+      patchHermesConfig: vi.fn(async () => {
+        throw new Error("EACCES: permission denied, open '/home/clawbox/.hermes/config.yaml'");
+      }),
+      readHermesConfigValue: vi.fn(async () => null),
+    }));
+    vi.doMock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+    vi.doMock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));
+    vi.doMock("@/lib/local-ai-runtime", () => ({
+      getLocalAiProxyRootUrl: () => "http://127.0.0.1",
+      getLocalAiOpenAiBaseUrl: () => "http://127.0.0.1/setup-api/local-ai/ollama/v1",
+    }));
+    vi.doMock("@/lib/config-store", () => ({ get: vi.fn(async () => null) }));
+    const { applyLocalAiToHermes } = await import("@/lib/hermes-local-ai");
+    const message = await messageFor(() =>
+      applyLocalAiToHermes({ provider: "ollama", model: "gemma-4:e2b", makeDefault: true }));
+    expect(message).not.toContain("/home/clawbox");
+    expect(message.trim()).not.toBe("");
+    vi.doUnmock("@/lib/hermes-config-yaml");
+  });
+});


### PR DESCRIPTION
Follow-up to #515. Two adversarial verifiers returned the same shape against the merged head — *the core fix is real, but a sibling call site is left unguarded* — and #515 had two of them. Both are closed here.

## CHAT-01a — the streaming transport wrote raw dashboard text into the bubble and the transcript

`src/app/setup-api/hermes/chat/route.ts:517` and `:537`.

#515 (and the extraction into `src/lib/hermes-cli-message.ts`) cleans the text of a failed Hermes turn on the **CLI** transport: `withoutTracebackFrames` drops the CPython frames, `redactDevicePaths` replaces `/home/clawbox/…` with `<path>`, `MAX_MESSAGE_CHARS` caps it at 400.

The chat route has **two** transports for the same bubble, and the CLI one is the *fallback*. `POST` tries `openDashboardTurn` first for every non-image turn (route.ts:906, "the fast path"), and `src/lib/harness/hermes-adapter.ts:406` sends `Accept: text/event-stream` — so the streamed branch is what a customer actually gets. On it:

* `const detail = final.error || final.text || "Hermes chat failed"` — `final.error` is `payload.error` off `message.complete` (`hermes-dashboard-turn.ts:1210`), Python-authored, unparsed;
* `err.message` in the catch — `hermes-dashboard-turn.ts:1228` rethrows the transport's `error` frame as `new Error(payload.message)`, also unparsed.

Both then went **two** places: the SSE `error` event (`hermes-adapter.ts:260` turns it into the chat failure text) and `appendTranscript` as `Error: ${detail}` — the *durable* copy, which outlives the refresh that would have hidden a one-off bubble.

The route's own comment on the `error` event asserted "the message is already customer-readable". That was an assumption about upstream Python text — the exact assumption the CLI side needed a 200-line parser to stop making. It now says *made* readable, and names the function that does it.

Separately provable **without a traceback**: `final.text` was a legal fallback for the failure text, and `hermes-dashboard-turn.ts` caps answer text at `MAX_TEXT_BYTES = 2,000,000`. So a status-error turn with no `error` field wrote up to a two-megabyte single `Error: …` row into a customer's transcript, where the CLI path would have capped the same failure at 400 characters. `final.text` is dropped: the answer body is not an error message.

## CHAT-01b — three more surfaces still echoed raw `hermes` stderr

The extraction that gave #515 a home stated its own completeness proof in the file header:

```
grep -rn "stderr" src/app/setup-api/hermes --include=route.ts
```

That grep is scoped to **one directory**, and the AI-provider save path does not live in it. `runHermesCli` (`src/lib/hermes-cli.ts:137`) resolves with **raw** stdout/stderr — it sanitises only the spawn-failure reject — so three libraries handed that stream to the browser:

| file | command | class |
|---|---|---|
| `hermes-cloud-provider.ts:86, :114, :118` | `hermes auth add`, `hermes config set` ×2 | `HermesCloudApplyError` |
| `hermes-clawai.ts:226` | `hermes config set` | `ClawaiApplyError` |
| `hermes-config-yaml.ts:135` | `hermes config set` (CLI fallback) | `HermesConfigWriteError` → `HermesLocalApplyError` |

All of them are caught together at `src/app/setup-api/ai-models/configure/route.ts:1649-1653` and returned as `{ error: err.message }` under a comment reading *"Author-controlled, non-credential message — safe to echo"* — false for all three. `AIModelsStep.tsx:1109`/`:1334` call `extractError` (line 876-881), which returns `data.error` unchanged, into `showError`.

`hermes-cloud-provider.ts` contradicted itself outright: its docstring at line 58 promised "`HermesCloudApplyError` with only ClawBox-authored text — a raw hermes stderr can carry the binary path", twenty-eight lines above the `throw` that did exactly that.

This is the mainline Hermes-edition flow — Settings or wizard, paste a provider key, `hermes` refuses — on shipped aarch64 hardware. A failed `hermes auth add` prints a CPython traceback naming `/home/clawbox/.hermes`; an argparse usage error prints the offending argv, and **the key is in the argv**.

### One more found while reading, same class, and it is the *common* case

`hermes-config-yaml.ts:168`. The CLI fallback at :135 runs only for a file the comment-preserving merge cannot parse. Every `EACCES` on `config.yaml` lands on the **merge** path instead, and Node writes the path into the message:

```
EACCES: permission denied, open '/home/clawbox/.hermes/config.yaml'
```

which became the save banner verbatim through the same three lines. Fixed with `sanitizeErrorMessage`, and `hermes-local-ai.ts:72` — a bare `catch (err)` that re-publishes the message of *any* throw from that path — is guarded too, so the wrapper is safe on its own rather than on the promise that every future thrower remembered.

## The class, and how I know I found every sibling

**The class:** *text authored outside ClawBox (a `hermes` stream, a Node fs error, a dashboard frame) becoming a customer-visible message without passing the chokepoint.*

The grep that found them, and the one now recorded in `hermes-cli-message.ts`'s header in place of the directory-scoped one:

```
grep -rn "\.std\(out\|err\)" src --include=*.ts --include=*.tsx | grep -v /tests/
```

Wider than the old form on purpose — it lists plumbing that merely *collects* a stream — but every site that *renders* one is in its output. Triaging its 50 hits:

* **Fixed here** — `hermes-cloud-provider.ts:86/114/118`, `hermes-clawai.ts:226`, `hermes-config-yaml.ts:135`.
* **Already chokepointed** — `hermes/models/route.ts:240` and `hermes/provider-key/route.ts:77` (`safeHermesFailureMessage`); `hermes/skills/install/route.ts:193` and `uninstall/route.ts:82` return a fixed message and log the raw (#513).
* **Console only, never rendered** — `hermes-clawai.ts:345/366` (the caller logs it and the link still succeeds), `hermes-pets.ts:534/558/569` (`cliFailure` `console.warn`s the detail and returns a *reason code*), `hermes-telegram.ts:503`.
* **Not `hermes`** — `coding-github.ts`, `updater.ts`, `child-run.ts`, `clawkeep`, `tts`, `network`, `tunnel`, `vnc`. A separate surface with its own rules; out of scope for this PR rather than overlooked.

And for the throw sites that reach the configure route's shared catch:

```
grep -rn "HermesCloudApplyError(\|ClawaiApplyError(\|HermesLocalApplyError(\|HermesConfigWriteError(" src --include=*.ts | grep -v /tests/
```

Twelve hits: eight are fixed sentences, one (`ai-models/clawai/poll/route.ts:95`) re-throws a `ClawaiApplyError`'s message unchanged and is fixed by fixing its source, and the remaining three are the leaks above.

For the streamed chat, the same question asked of the route itself:

```
grep -n 'text: `Error: \${\|send("error"' src/app/setup-api/hermes/chat/route.ts
```

Five sites: `:520`/`:524` (the settled-turn branch) and `:575`/`:579` (the catch) are the two fixed here — they share one `detail` each — and `:946` is the CLI path, whose `err.message` `runHermes` already built from `errorFromStderr` / `spawnFailureMessage` / `hermesExitMessage`. `openDashboardTurn` has exactly one consumer (`grep -rn "openDashboardTurn" src`), so there is no third transport.

## Tests — red first

Three new files, each proven to fail against unmodified `origin/beta` before the fix.

| file | tests | RED on beta | GREEN after |
|---|---|---|---|
| `src/tests/routes/hermes-chat-dashboard-error-text.test.ts` | 5 | 5 | 5 |
| `src/tests/unit/hermes-apply-error-text.test.ts` | 7 | 5 | 7 |
| `src/tests/unit/hermes-config-write-error-text.test.ts` | 3 | 3 | 3 |
| **total** | **15** | **13** | **15** |

The four that were green on beta are invariants deliberately kept beside the regressions — that each failure is still thrown as the class the configure route classifies on, so a fix that cleaned the text by swallowing the type would fail here.

What they pin, beyond "no `/home/clawbox`": that a traceback's **summary** survives while its frames do not; that `permission denied` survives while the path is redacted rather than the whole line dropped; that the pasted API key does not come back in an argparse usage error; that a status-error turn's 5,000-character answer body does not become the transcript row; and that no banner is ever left **empty** — `sanitizeErrorMessage` returning null means "say something generic", never "say nothing".

## Checks

* `eslint` on all eleven changed/added files: **0 errors**, 2 warnings, both pre-existing on `beta` (`_api` and `CLAWBOX_AI_VISION_MODEL_ID` unused).
* `tsc --noEmit`: **24 errors before, 24 after** — the identical pre-existing set.
* Suites for every touched module (`hermes-config-yaml`, `hermes-local-ai`, `clawai-connect`, `hermes-clawai-vision`, `hermes-chat-streaming`): **8 failed / 61 passed before, 8 failed / 61 passed after** — byte-identical, and those eight are this Windows host's `0600`/file-mode cases, not the change. Linux CI is the real gate.

`hermes-chat-streaming.test.ts`'s existing error cases still pass unchanged: `"the provider is rate limiting"` and `"dashboard stream went quiet"` both survive the parser intact, which is the point — the cleaning is invisible to text that was already clean.

## Not in scope

`redactKey` moved out of `provider-key/route.ts` into `hermes-cli-message.ts` rather than being copied, because `applyCloudProviderKeyToHermes` runs the same `hermes auth add` and needed the same redaction, in the same order (before the parser, so the 400-char cap counts the text a person will see). No behaviour change at the original call site.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across Hermes setup, configuration, provider, and chat workflows.
  * Sensitive information, including API keys, file paths, device details, and technical tracebacks, is now removed from customer-facing messages.
  * Dashboard and configuration failures provide safer fallback messages while preserving appropriate error classifications.
  * Aborted chat requests remain quiet and are not surfaced as errors.

* **Tests**
  * Added coverage for sanitized streamed chat errors, setup failures, and configuration write errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->