### PR TITLE
fix: read the whole verdict on every git and gh call, not only the killed half

### DIFF
--- a/src/app/setup-api/coding-agent/git/route.ts
+++ b/src/app/setup-api/coding-agent/git/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { hasOwnerSession } from "@/lib/owner-session";
-import { backupToGitHub, disconnectGitHub, githubStatus } from "@/lib/coding-github";
+import { BACKUP_MESSAGE, backupToGitHub, disconnectGitHub, githubStatus } from "@/lib/coding-github";
 import { CodingAgentError, resolveWorkingDirectory } from "@/lib/coding-agent";
 
 export const dynamic = "force-dynamic";
@@ -99,7 +99,9 @@ export async function POST(request: Request) {
       // request that was fine.
       const retryable = outcome.reason === "gh_unreachable" || outcome.transient === true;
       return NextResponse.json(
-        { error: outcome.detail ?? outcome.reason, kind: outcome.reason },
+        // `kind` keeps the token — the card branches on it. `error` is the
+        // half a person reads, and must never be an identifier.
+        { error: outcome.detail ?? BACKUP_MESSAGE[outcome.reason], kind: outcome.reason },
         { status: retryable ? 503 : 409 },
       );
     }

--- a/src/components/CodingAgentApp.tsx
+++ b/src/components/CodingAgentApp.tsx
@@ -107,6 +107,8 @@ const RUNS_PAGE = 10;
 /** Where the preview script lives on the device. */
 const CLAWBOX_ROOT = "/home/clawbox/clawbox";
 const POLL_MS = 5_000;
+/** How often to ask again while the GitHub answer is one we do not trust. */
+const GITHUB_REPROBE_MS = 15_000;
 
 function Switch({
   checked, busy, disabled, label, onChange,
@@ -242,6 +244,19 @@ export default function CodingAgentApp() {
 
   useEffect(() => { void load(); }, [load]);
 
+  /** Just the GitHub half of `load()`. The re-probe below wants this one answer
+   *  refreshed and nothing else: re-running the whole load on a timer would also
+   *  overwrite the run list and fight the folder draft for no reason. */
+  const loadGithub = useCallback(async () => {
+    try {
+      const g = await fetch("/setup-api/coding-agent/git", { cache: "no-store" });
+      if (g.ok) setGithub(await g.json() as GitHubState);
+    } catch {
+      // A failed re-probe is not new information — the card already says the
+      // uplink is down. Leave the badge alone and ask again next tick.
+    }
+  }, []);
+
   // A running run changes every few seconds; nothing else here does.
   const anyRunning = runs.some((r) => r.status === "running");
   useEffect(() => {
@@ -249,6 +264,23 @@ export default function CodingAgentApp() {
     const id = setInterval(() => { void load(); }, POLL_MS);
     return () => clearInterval(id);
   }, [anyRunning, load]);
+
+  // `githubStatus()` refuses to cache an `unreachable` answer, and says why:
+  // "caching one would outlive the outage that produced it and go on refusing
+  // backups after the uplink came back". Holding it in React state and never
+  // asking again is that same cache one layer out — the card went on saying
+  // "GitHub unreachable" for as long as the panel stayed mounted, with no
+  // refresh affordance, long after the uplink was back.
+  //
+  // Only the inconclusive reason re-probes. "not_installed" and "not_runnable"
+  // are properties of the box, not of this moment, and polling them would be a
+  // timer with nothing to learn.
+  const githubInconclusive = github?.reason === "unreachable";
+  useEffect(() => {
+    if (!githubInconclusive) return;
+    const id = setInterval(() => { void loadGithub(); }, GITHUB_REPROBE_MS);
+    return () => clearInterval(id);
+  }, [githubInconclusive, loadGithub]);
 
   const readError = async (res: Response, fallback: string) => {
     try {
@@ -365,6 +397,9 @@ export default function CodingAgentApp() {
       await load();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("codingAgent.backupFailed"));
+      // A refused backup is the other moment the card's GitHub row can be
+      // stale — a 503 usually means the probe would answer differently now.
+      void loadGithub();
     } finally {
       setBusy(null);
     }
@@ -383,6 +418,9 @@ export default function CodingAgentApp() {
       setConfirmSignOut(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : t("codingAgent.githubOutFailed"));
+      // Same reason: a logout that failed leaves the row showing whatever it
+      // showed before, which may no longer be true.
+      void loadGithub();
     } finally {
       setBusy(null);
     }

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -26,6 +26,8 @@
 import path from "path";
 import {
   type ChildResult,
+  failureDetail,
+  inconclusive,
   killedDetail,
   runChild,
   startedMissing,
@@ -104,6 +106,28 @@ export type BackupFailure =
   /** git or gh refused; detail carries what it said. */
   | "failed";
 
+/**
+ * What each refusal reads as when nothing more specific is known.
+ *
+ * It lives here, next to the type, because both halves of the problem need it:
+ * `backupToGitHub` had two refusals that carried no detail at all — `no_gh` and
+ * `not_connected`, the two branches #518 rewrote when it split `no_gh` away
+ * from `gh_unreachable` — and the route answers `detail ?? reason`, so those two
+ * reached the owner's error banner as the literal token `not_connected`.
+ *
+ * `Record<BackupFailure, string>` is the part that fixes the class rather than
+ * the two instances: adding a reason without a sentence for it is a compile
+ * error, not a bug an owner finds.
+ */
+export const BACKUP_MESSAGE: Record<BackupFailure, string> = {
+  no_gh: "The GitHub CLI is not installed on this ClawBox, so there is nothing to back up with.",
+  gh_unreachable: "Could not reach GitHub from this ClawBox. Check the network connection and try again.",
+  not_connected: "No GitHub account is connected yet. Use Connect on the Coding Agent card to sign in first.",
+  nothing_to_push: "The folder has no commits yet, so there is nothing to back up.",
+  not_a_repo: "This folder is not its own git repository, so it cannot be backed up on its own.",
+  failed: "The backup did not finish. Try again.",
+};
+
 export type DisconnectOutcome =
   | { ok: true; detail?: undefined; kind?: undefined }
   /** `kind` so the route can answer a network fault as one (503, retry) rather
@@ -136,13 +160,33 @@ function run(bin: string, args: string[], opts: { cwd?: string; timeoutMs?: numb
   });
 }
 
+/** Advice for a call that never left the box, and for one that tried to. */
+const RETRY_LOCAL = "Try again.";
+const RETRY_NETWORK = "Check this ClawBox's network connection and try again.";
+
 /**
- * The refusal for a local git call that carried no finding — killed by our own
- * timer, or never started. `transient` is what tells the route this is a fault
- * to retry (503) and not a request that cannot be satisfied (409).
+ * The refusal for a call that carried NO FINDING — one our own timer killed, or
+ * one that never started at all. `inconclusive()` is the single question worth
+ * asking here, and asking only `wasKilled()` is what this whole follow-up is
+ * about: that helper is defined as `!r.startFailed && r.code === null`, so it
+ * deliberately answers false for a spawn that failed, and every guard built on
+ * it alone lets a `git` that could not be forked fall through to the line below
+ * — which then reads the null code as a fact about the owner's folder.
+ *
+ * `transient` is what tells the route this is a fault to retry (503) and not a
+ * request that cannot be satisfied (409).
  */
-function transientGit(r: ChildResult, what: string): BackupOutcome {
-  return { pushed: false, reason: "failed", detail: killedDetail(r, what, "Try again."), transient: true };
+function noFinding(r: ChildResult, what: string, reach: "local" | "network"): BackupOutcome {
+  return {
+    pushed: false,
+    // `gh_unreachable` is a claim about the NETWORK, and only a call that
+    // actually started and then hung supports it. A spawn that never began
+    // says nothing about GitHub — it is a fault on this box — so it keeps the
+    // neutral reason and leans on `transient` for its 503.
+    reason: reach === "network" && !r.startFailed ? "gh_unreachable" : "failed",
+    detail: failureDetail(r, what, reach === "network" ? RETRY_NETWORK : RETRY_LOCAL),
+    transient: true,
+  };
 }
 
 /**
@@ -229,7 +273,11 @@ export async function disconnectGitHub(): Promise<DisconnectOutcome> {
       detail: `${killedDetail(r, "Signing out of GitHub")} Then read the connection again.`,
     };
   }
-  if (r.code !== 0) return { ok: false, kind: "failed", detail: (r.stderr || r.stdout).slice(0, 300) };
+  // Never the raw `(stderr || stdout)`: a non-zero exit that wrote to neither
+  // stream renders the empty string, and the route hands `detail` straight to
+  // the owner's error banner. failureDetail() is the one place that guarantees
+  // a sentence.
+  if (r.code !== 0) return { ok: false, kind: "failed", detail: failureDetail(r, "Signing out of GitHub") };
   return { ok: true };
 }
 
@@ -266,16 +314,20 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
       detail: "Could not reach GitHub from this ClawBox. Check the network connection and try again.",
     };
   }
-  if (!status.installed) return { pushed: false, reason: "no_gh" };
-  if (!status.connected) return { pushed: false, reason: "not_connected" };
+  // Both of these carry a sentence for the same reason every other refusal in
+  // this function does: the route answers `detail ?? reason` and the card shows
+  // `data.error` verbatim, so a refusal with no detail reaches the owner as the
+  // literal token `no_gh`.
+  if (!status.installed) return { pushed: false, reason: "no_gh", detail: BACKUP_MESSAGE.no_gh };
+  if (!status.connected) return { pushed: false, reason: "not_connected", detail: BACKUP_MESSAGE.not_connected };
 
   // Its OWN repository or nothing — the same rule as the per-run commit, and
   // for the same reason: a code project sits inside the ClawBox checkout.
   const top = await run("git", ["-C", dir, "rev-parse", "--show-toplevel"]);
-  // A killed probe is not evidence about the folder. Reading it as one would
-  // tell the owner their repository is not a repository.
-  if (wasKilled(top)) {
-    return transientGit(top, "Reading the folder's git repository");
+  // A probe that carried no finding is not evidence about the folder. Reading
+  // one as evidence would tell the owner their repository is not a repository.
+  if (inconclusive(top)) {
+    return noFinding(top, "Reading the folder's git repository", "local");
   }
   if (top.code !== 0 || path.resolve(top.stdout || "") !== dir) {
     return { pushed: false, reason: "not_a_repo", detail: "This folder is not its own git repository." };
@@ -283,31 +335,32 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
 
   const head = await run("git", ["-C", dir, "rev-parse", "--verify", "HEAD"]);
   // "No commits yet" is a claim about the folder. A killed probe made no such
-  // finding, and saying it would tell an owner with a full history that their
-  // work is empty.
-  if (wasKilled(head)) {
-    return transientGit(head, "Reading the folder's commits");
+  // finding, and neither did one that never started — saying it would tell an
+  // owner with a full history that their work is empty.
+  if (inconclusive(head)) {
+    return noFinding(head, "Reading the folder's commits", "local");
   }
   if (head.code !== 0) return { pushed: false, reason: "nothing_to_push", detail: "The folder has no commits yet." };
 
   const branchOut = await run("git", ["-C", dir, "rev-parse", "--abbrev-ref", "HEAD"]);
   // The "main" fallback is a guess, and the push below turns it into
   // `--set-upstream origin main`. Fine when git actually answered and simply
-  // had no name to give; wrong when the probe was killed, which would push a
-  // `develop` checkout to `main` and bind it there over a transient fault.
-  if (wasKilled(branchOut)) {
-    return transientGit(branchOut, "Reading the folder's branch");
+  // had no name to give; wrong when the probe told us nothing, which would push
+  // a `develop` checkout to `main` and bind it there over a transient fault.
+  if (inconclusive(branchOut)) {
+    return noFinding(branchOut, "Reading the folder's branch", "local");
   }
   const branch = branchOut.code === 0 && branchOut.stdout ? branchOut.stdout : "main";
 
   const hasRemote = await run("git", ["-C", dir, "remote", "get-url", "origin"]);
   // The consequential one. A non-zero code here means "no remote yet", and the
   // branch below acts on it by CREATING a repository on GitHub. A killed probe
-  // returns the same null code, so reading it as "no remote" would create a
-  // second repository for a folder that already has one — an irreversible
-  // guess made from a transient fault.
-  if (wasKilled(hasRemote)) {
-    return transientGit(hasRemote, "Reading the folder's git remote");
+  // returns the same null code — and so does one that could not be forked at
+  // all, which is why this asks `inconclusive` and not `wasKilled`. Reading
+  // either as "no remote" would create a SECOND repository for a folder that
+  // already has one: an irreversible guess made from a transient fault.
+  if (inconclusive(hasRemote)) {
+    return noFinding(hasRemote, "Reading the folder's git remote", "local");
   }
   let created = false;
   let repo = hasRemote.code === 0 ? hasRemote.stdout : "";
@@ -322,23 +375,20 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
       { cwd: dir, timeoutMs: PUSH_TIMEOUT_MS },
     );
     if (create.code !== 0) {
-      // A killed create is a NETWORK fault, and the detail below already says
-      // so — "check this ClawBox's network connection and try again". Leaving
-      // the reason as "failed" made the route answer 409, a non-retryable
-      // client error, to its own retry advice. gh_unreachable is what 503 is
-      // wired to, and it is the true statement about a call that hung on the
-      // uplink for three minutes.
-      if (wasKilled(create)) {
-        return {
-          pushed: false,
-          reason: "gh_unreachable",
-          detail: killedDetail(create, "Creating the repository on GitHub"),
-          transient: true,
-        };
+      // A create that carried no finding is a FAULT, not a refusal: killed on
+      // the uplink after three minutes, or never forked at all. Leaving the
+      // reason as "failed" with no `transient` made the route answer 409, a
+      // non-retryable client error, to its own retry advice. `wasKilled` alone
+      // covered only the first half — a failed spawn fell through to the line
+      // below and was reported as GitHub refusing, carrying runChild's
+      // five-word "could not start" placeholder as the owner's message.
+      if (inconclusive(create)) {
+        return noFinding(create, "Creating the repository on GitHub", "network");
       }
       // GitHub itself refusing — a name already taken, a scope missing — IS a
-      // request that cannot be satisfied as it stands. That one keeps its 409.
-      return { pushed: false, reason: "failed", detail: (create.stderr || create.stdout).slice(0, 400) };
+      // request that cannot be satisfied as it stands. That one keeps its 409,
+      // and failureDetail keeps its message from ever being blank.
+      return { pushed: false, reason: "failed", detail: failureDetail(create, "Creating the repository on GitHub") };
     }
     created = true;
     const url = await run("git", ["-C", dir, "remote", "get-url", "origin"]);
@@ -353,16 +403,12 @@ export async function backupToGitHub(directory: string): Promise<BackupOutcome> 
   );
   if (push.code !== 0) {
     // Same rule as the create above: the push is the other call that leaves
-    // the box, and a killed one is the network, not the request.
-    if (wasKilled(push)) {
-      return {
-        pushed: false,
-        reason: "gh_unreachable",
-        detail: killedDetail(push, "Pushing to GitHub"),
-        transient: true,
-      };
+    // the box, and one that produced no finding is the machine or the network,
+    // not the request.
+    if (inconclusive(push)) {
+      return noFinding(push, "Pushing to GitHub", "network");
     }
-    return { pushed: false, reason: "failed", detail: (push.stderr || push.stdout).slice(0, 400) };
+    return { pushed: false, reason: "failed", detail: failureDetail(push, "Pushing to GitHub") };
   }
   return { pushed: true, repo, created, branch };
 }

--- a/src/lib/coding-github.ts
+++ b/src/lib/coding-github.ts
@@ -177,14 +177,18 @@ const RETRY_NETWORK = "Check this ClawBox's network connection and try again.";
  * request that cannot be satisfied (409).
  */
 function noFinding(r: ChildResult, what: string, reach: "local" | "network"): BackupOutcome {
+  // Only a call that actually STARTED can support a claim about the network.
+  // A spawn that never began says nothing about GitHub — it is a fault on this
+  // box — so it must carry neither `gh_unreachable` nor the "check your
+  // connection" remedy. One expression, used for both, because the review on
+  // this PR caught the reason and the advice disagreeing: the reason had it
+  // right and the advice told an owner with an ENOMEM to go and check their
+  // uplink, which is the wrong-remedy defect this whole change removes.
+  const reachedNetwork = reach === "network" && !r.startFailed;
   return {
     pushed: false,
-    // `gh_unreachable` is a claim about the NETWORK, and only a call that
-    // actually started and then hung supports it. A spawn that never began
-    // says nothing about GitHub — it is a fault on this box — so it keeps the
-    // neutral reason and leans on `transient` for its 503.
-    reason: reach === "network" && !r.startFailed ? "gh_unreachable" : "failed",
-    detail: failureDetail(r, what, reach === "network" ? RETRY_NETWORK : RETRY_LOCAL),
+    reason: reachedNetwork ? "gh_unreachable" : "failed",
+    detail: failureDetail(r, what, reachedNetwork ? RETRY_NETWORK : RETRY_LOCAL),
     transient: true,
   };
 }

--- a/src/tests/components/coding-agent-github-reprobe.test.tsx
+++ b/src/tests/components/coding-agent-github-reprobe.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * GH-01c. `githubStatus()` refuses to cache, and says why at coding-github.ts
+ * lines 160-165: "`unreachable` is a statement about this moment's network, not
+ * a property of the box: caching one would outlive the outage that produced it
+ * and go on refusing backups after the uplink came back."
+ *
+ * The card then caches it anyway. `load()` runs once on mount; the only re-poll
+ * is gated on `anyRunning`, i.e. a run being in progress. So an owner who opens
+ * the panel during a thirty-second uplink blip sees "GitHub unreachable" with
+ * no refresh affordance for as long as the panel stays mounted — the outage
+ * outlives itself on the one surface the owner looks at. It is the probe-once
+ * shape #518 exists to remove, moved one layer out.
+ *
+ * The two facts pinned here: the card keeps asking while the answer is
+ * inconclusive, and it stops asking once it is not.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@/tests/helpers/test-utils";
+import { translations } from "@/lib/translations";
+import CodingAgentApp from "@/components/CodingAgentApp";
+
+const t = (key: string, params?: Record<string, string | number>) => {
+  let str = translations.en[key] ?? key;
+  if (params) for (const [k, v] of Object.entries(params)) str = str.replaceAll(`{${k}}`, String(v));
+  return str;
+};
+vi.mock("@/lib/i18n", () => ({ useT: () => ({ locale: "en", t }) }));
+
+const READY = { ready: true, wrapperInstalled: true, claudeInstalled: true, clawaiConnected: true, problems: [] as string[] };
+const LOGIN_COMMAND = "gh auth login --hostname github.com --git-protocol https";
+
+function json(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+const UNREACHABLE = { installed: true, connected: false, login: null, loginCommand: LOGIN_COMMAND, reason: "unreachable" };
+const CONNECTED = { installed: true, connected: true, login: "yalexx", loginCommand: LOGIN_COMMAND };
+
+/** The device, with a git answer the test can change mid-flight. */
+function stubFetch(next: () => Record<string, unknown>) {
+  const gitCalls = { count: 0 };
+  vi.stubGlobal("fetch", vi.fn(async (input: string | URL) => {
+    const url = input.toString();
+    if (url.startsWith("/setup-api/coding-agent/status")) {
+      return json({
+        enabled: true, ready: true, readiness: READY, running: 0,
+        harnessCommand: "claude-ds", maxTaskChars: 4000, defaultDirectory: null,
+      });
+    }
+    if (url.startsWith("/setup-api/coding-agent/runs")) return json({ runs: [] });
+    if (url.startsWith("/setup-api/coding-agent/git")) {
+      gitCalls.count += 1;
+      return json(next());
+    }
+    return json({ error: "unexpected" }, 404);
+  }));
+  return gitCalls;
+}
+
+/** Let the mount's three fetches settle before anything is counted. */
+async function settle() {
+  await act(async () => { await vi.advanceTimersByTimeAsync(50); });
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("an inconclusive GitHub answer is asked again", () => {
+  it("keeps re-probing while the card says GitHub is unreachable", async () => {
+    const calls = stubFetch(() => UNREACHABLE);
+    render(<CodingAgentApp />);
+    await settle();
+
+    expect(screen.queryByTestId("coding-agent-github-unreachable")).not.toBeNull();
+    const afterMount = calls.count;
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+
+    // No run is in progress, so the existing poll is off. If the card only ever
+    // asks once, the outage is permanent until the panel is remounted.
+    expect(calls.count).toBeGreaterThan(afterMount);
+  });
+
+  it("shows the account again once the uplink comes back, without a remount", async () => {
+    let answer: Record<string, unknown> = UNREACHABLE;
+    stubFetch(() => answer);
+    render(<CodingAgentApp />);
+    await settle();
+
+    expect(screen.queryByTestId("coding-agent-github-unreachable")).not.toBeNull();
+
+    answer = CONNECTED;
+    await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+
+    expect(screen.queryByTestId("coding-agent-github-unreachable")).toBeNull();
+    expect(screen.queryByTestId("coding-agent-github-login")?.textContent).toBe("yalexx");
+  });
+
+  it("stops asking once the answer is one to trust", async () => {
+    // The discriminator: a healthy, connected box must not acquire a new
+    // background poll it never had. Re-probing is for the inconclusive state
+    // only.
+    const calls = stubFetch(() => CONNECTED);
+    render(<CodingAgentApp />);
+    await settle();
+
+    const afterMount = calls.count;
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+
+    expect(calls.count).toBe(afterMount);
+  });
+
+  it("stops asking once a settled failure is known", async () => {
+    // `not_installed` is a property of the box, not of this moment's network.
+    // Asking again forever would be a poll with nothing to learn.
+    const calls = stubFetch(() => ({
+      installed: false, connected: false, login: null, loginCommand: LOGIN_COMMAND, reason: "not_installed",
+    }));
+    render(<CodingAgentApp />);
+    await settle();
+
+    const afterMount = calls.count;
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+
+    expect(calls.count).toBe(afterMount);
+  });
+});

--- a/src/tests/routes/coding-agent/git-refusal-message.test.ts
+++ b/src/tests/routes/coding-agent/git-refusal-message.test.ts
@@ -1,0 +1,94 @@
+/**
+ * GH-01b. The backup route answers `outcome.detail ?? outcome.reason`, and the
+ * card's `readError()` shows `data.error` whenever it is a non-empty string. So
+ * every refusal that carries no detail is rendered to the owner as the raw enum
+ * token: the error banner reads literally `not_connected`.
+ *
+ * `no_gh` and `not_connected` are the two that carry none — and they are
+ * exactly the two branches #518 rewrote when it split `no_gh` away from
+ * `gh_unreachable`. Every other refusal in the same function was given a
+ * sentence.
+ *
+ * This is the same class as the blank detail #518 removed from the killed push:
+ * the surface renders `detail ?? reason` and is handed something that is not a
+ * sentence. The fix has to be at the route as well as in the library, because
+ * the fallback is what makes a reason added later leak the same way.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BackupOutcome, BackupFailure } from "@/lib/coding-github";
+
+const backup = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/coding-github", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/coding-github")>()),
+  backupToGitHub: backup,
+  githubStatus: vi.fn(async () => ({ installed: true, connected: true, login: "yalexx", loginCommand: "gh auth login" })),
+  disconnectGitHub: vi.fn(),
+}));
+
+vi.mock("@/lib/owner-session", () => ({ hasOwnerSession: vi.fn(async () => true) }));
+
+vi.mock("@/lib/coding-agent", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/coding-agent")>()),
+  resolveWorkingDirectory: vi.fn(async () => ({ directory: "/home/clawbox/Projects/site", projectId: null })),
+}));
+
+let POST: (req: Request) => Promise<Response>;
+
+function request(): Request {
+  return new Request("http://localhost/setup-api/coding-agent/git", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ directory: "/home/clawbox/Projects/site" }),
+  });
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  backup.mockReset();
+  ({ POST } = await import("@/app/setup-api/coding-agent/git/route"));
+});
+
+/** Every refusal the library can answer. Listing them here is the point: the
+ *  rule is about the class, not about the two that happen to be bare today. */
+const REASONS: BackupFailure[] = [
+  "no_gh",
+  "gh_unreachable",
+  "not_connected",
+  "nothing_to_push",
+  "not_a_repo",
+  "failed",
+];
+
+describe("the owner is never shown the enum token", () => {
+  for (const reason of REASONS) {
+    it(`answers a sentence, not "${reason}", when the library gives no detail`, async () => {
+      backup.mockResolvedValue({ pushed: false, reason } satisfies BackupOutcome);
+
+      const res = await POST(request());
+      const body = await res.json() as { error?: string; kind?: string };
+
+      // `kind` is the machine-readable half and must keep the token: the card
+      // branches on it. `error` is the half a human reads.
+      expect(body.kind).toBe(reason);
+      expect(body.error ?? "").not.toBe(reason);
+      // A sentence, not a snake_case identifier.
+      expect(body.error ?? "").not.toMatch(/^[a-z]+(_[a-z]+)+$/);
+      expect((body.error ?? "").trim()).not.toBe("");
+    });
+  }
+
+  it("still prefers the library's own detail when there is one", async () => {
+    // The discriminator: the fallback must not start overwriting the specific
+    // message git or gh actually produced.
+    backup.mockResolvedValue({
+      pushed: false,
+      reason: "failed",
+      detail: "GraphQL: Name already exists on this account",
+    } satisfies BackupOutcome);
+
+    const res = await POST(request());
+    const body = await res.json() as { error?: string };
+
+    expect(body.error).toBe("GraphQL: Name already exists on this account");
+  });
+});

--- a/src/tests/unit/coding-github-refusal-detail.test.ts
+++ b/src/tests/unit/coding-github-refusal-detail.test.ts
@@ -1,0 +1,97 @@
+/**
+ * GH-01b, at the library rather than the route.
+ *
+ * `backupToGitHub` gives every refusal a sentence except two: `no_gh` and
+ * `not_connected` return `{ pushed: false, reason }` and nothing else. Those
+ * two are the branches #518 rewrote when it split `no_gh` away from
+ * `gh_unreachable`, and they are the two the owner meets first — tapping Backup
+ * before connecting GitHub is the ordinary way to arrive here, not an edge.
+ *
+ * The route's fallback is fixed separately (git-refusal-message.test.ts); this
+ * pins the library, because `detail` is what any other caller reads and the
+ * route should never be the only thing standing between an enum and a person.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ spawn: spawnMock }));
+
+type Lib = typeof import("@/lib/coding-github");
+let lib: Lib;
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: (signal: NodeJS.Signals) => boolean;
+}
+
+function baseChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => true;
+  return child;
+}
+
+function exitingChild(code: number, out = "", err = ""): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("spawn");
+    if (out) child.stdout.emit("data", Buffer.from(out));
+    if (err) child.stderr.emit("data", Buffer.from(err));
+    child.emit("close", code, null);
+  });
+  return child;
+}
+
+/** gh is genuinely absent: ENOENT on spawn. */
+function missing(): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", Object.assign(new Error("spawn gh ENOENT"), { code: "ENOENT" }));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
+const DIR = "/home/clawbox/Projects/site";
+
+/** A refusal a person can act on: real words, and not the enum token. */
+function expectSentence(detail: string | undefined, reason: string): void {
+  expect((detail ?? "").trim()).not.toBe("");
+  expect(detail).not.toBe(reason);
+  expect(detail ?? "").not.toMatch(/^[a-z]+(_[a-z]+)+$/);
+  expect(detail ?? "").toMatch(/\s/);
+}
+
+beforeEach(async () => {
+  spawnMock.mockReset();
+  vi.resetModules();
+  lib = await import("@/lib/coding-github");
+});
+
+describe("every backup refusal carries words, not just a token", () => {
+  it("says the GitHub CLI is missing rather than answering `no_gh`", async () => {
+    spawnMock.mockImplementation(() => missing());
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("no_gh");
+    expectSentence(outcome.detail, "no_gh");
+  });
+
+  it("says nobody has signed in rather than answering `not_connected`", async () => {
+    // gh runs and exits 0, but prints no "Logged in to ... as ..." line.
+    spawnMock.mockImplementation(() => exitingChild(1, "", "You are not logged into any GitHub hosts.\n"));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("not_connected");
+    expectSentence(outcome.detail, "not_connected");
+  });
+});

--- a/src/tests/unit/coding-github-spawn-failure.test.ts
+++ b/src/tests/unit/coding-github-spawn-failure.test.ts
@@ -192,6 +192,10 @@ describe("a call that left the box and could not start is reported as a fault, n
     expect(outcome.detail ?? "").toMatch(/EAGAIN/);
     // Nothing about the request was wrong, so the route must not answer 409.
     expect(outcome.transient).toBe(true);
+    // Raised by review on this PR. A create that never started never reached
+    // the uplink, so "check your network connection" is the wrong remedy —
+    // the same wrong-remedy defect this PR removes, one line over.
+    expect(outcome.detail ?? "").not.toMatch(/network/i);
   });
 
   it("does not hand back runChild's placeholder when `git push` failed to spawn", async () => {
@@ -204,6 +208,7 @@ describe("a call that left the box and could not start is reported as a fault, n
     expect(outcome.detail ?? "").not.toBe("could not start");
     expect(outcome.detail ?? "").toMatch(/EAGAIN/);
     expect(outcome.transient).toBe(true);
+    expect(outcome.detail ?? "").not.toMatch(/network/i);
   });
 
   it("never renders a blank message for a create that wrote to neither stream", async () => {

--- a/src/tests/unit/coding-github-spawn-failure.test.ts
+++ b/src/tests/unit/coding-github-spawn-failure.test.ts
@@ -1,0 +1,286 @@
+/**
+ * GH-01a and GH-01d — the half of #518's lesson that landed in `coding-git.ts`
+ * and not in its twin.
+ *
+ * `wasKilled()` is defined as `!r.startFailed && r.code === null`. It
+ * DELIBERATELY excludes a failed spawn, because a killed child and a child that
+ * never started are different facts with different remedies. The shared module
+ * exports `inconclusive()` — "started-and-killed OR never started", i.e. no
+ * finding either way — precisely so a guard that only wants to know "did this
+ * call tell me anything about the world?" asks one question.
+ *
+ * `backupToGitHub` guards all four of its local git probes with `wasKilled`
+ * alone. So when `git` cannot be started at all — EAGAIN or ENOMEM on fork
+ * under load, EMFILE, a git chmod'ed 644 — every guard is skipped and the next
+ * line reads the null code as a FINDING about the folder:
+ *
+ *   - `top.code !== 0`       -> "This folder is not its own git repository."
+ *   - `head.code !== 0`      -> "The folder has no commits yet."
+ *   - `hasRemote.code !== 0` -> `gh repo create --private --source --push`
+ *
+ * That last one is the irreversible outcome #518's own comment pins against:
+ * "reading it as 'no remote' would create a second repository for a folder that
+ * already has one — an irreversible guess made from a transient fault." The
+ * guard was written for the killed case and never for the spawn-failure case.
+ *
+ * GH-01d is the same conflation on the way out: `gh repo create`, `git push`
+ * and `gh auth logout` build their detail from raw `(stderr || stdout)`, so a
+ * failed spawn renders runChild's five-word placeholder and an exit that wrote
+ * to neither stream renders the empty string — the blank #518 removed from the
+ * killed push, still live one branch over.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import path from "path";
+
+const spawnMock = vi.hoisted(() => vi.fn());
+vi.mock("child_process", () => ({ spawn: spawnMock }));
+
+type Lib = typeof import("@/lib/coding-github");
+let lib: Lib;
+
+interface FakeChild extends EventEmitter {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: (signal: NodeJS.Signals) => boolean;
+}
+
+function baseChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => true;
+  return child;
+}
+
+/**
+ * A spawn that never happened: `error` WITHOUT a preceding `spawn`, carrying a
+ * real errno. EAGAIN is what fork() returns on a Jetson that is out of process
+ * slots — the loaded-box condition, not an exotic one.
+ */
+function startFailure(errno = "EAGAIN"): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("error", Object.assign(new Error(`spawn ${errno}`), { code: errno }));
+    child.emit("close", null, null);
+  });
+  return child;
+}
+
+function exitingChild(code: number, out = "", err = ""): FakeChild {
+  const child = baseChild();
+  setImmediate(() => {
+    child.emit("spawn");
+    if (out) child.stdout.emit("data", Buffer.from(out));
+    if (err) child.stderr.emit("data", Buffer.from(err));
+    child.emit("close", code, null);
+  });
+  return child;
+}
+
+const CONNECTED = "Logged in to github.com as yalexx (/home/clawbox/.config/gh/hosts.yml)\n";
+const DIR = "/home/clawbox/Projects/site";
+const TOPLEVEL = path.resolve(DIR);
+
+/** Everything healthy, except the one call the test names. */
+function script(broken: (bin: string, args: string[]) => FakeChild | null, remoteCode = 0): void {
+  spawnMock.mockImplementation((bin: string, args: string[]) => {
+    const hit = broken(bin, args);
+    if (hit) return hit;
+    if (bin === "gh" && args[0] === "auth") return exitingChild(0, "", CONNECTED);
+    if (args.includes("--show-toplevel")) return exitingChild(0, TOPLEVEL);
+    if (args.includes("--verify")) return exitingChild(0, "abc123");
+    if (args.includes("--abbrev-ref")) return exitingChild(0, "main");
+    if (args.includes("get-url")) return exitingChild(remoteCode, "git@github.com:me/site.git");
+    return exitingChild(0);
+  });
+}
+
+/** What the module actually spawned, in order — the only proof that a repository
+ *  was or was not created. */
+function spawned(): [string, string[]][] {
+  return spawnMock.mock.calls as [string, string[]][];
+}
+
+function ghRepoCreateSpawned(): boolean {
+  return spawned().some(([bin, args]) => bin === "gh" && args[0] === "repo" && args[1] === "create");
+}
+
+beforeEach(async () => {
+  spawnMock.mockReset();
+  vi.resetModules();
+  lib = await import("@/lib/coding-github");
+});
+
+describe("a git that could not be started is not a finding about the folder", () => {
+  it("never creates a second GitHub repository because the remote probe failed to spawn", async () => {
+    // THE consequential one. `git remote get-url origin` never ran, so nothing
+    // is known about whether this folder already has an origin — and the branch
+    // below it makes a repository on github.com that cannot be un-made.
+    script((bin, args) => (bin === "git" && args.includes("get-url") ? startFailure() : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(ghRepoCreateSpawned()).toBe(false);
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.transient).toBe(true);
+    expect(outcome.detail ?? "").toMatch(/EAGAIN/);
+  });
+
+  it("does not report 'not its own git repository' when the toplevel probe failed to spawn", async () => {
+    script((bin, args) => (bin === "git" && args.includes("--show-toplevel") ? startFailure() : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).not.toBe("not_a_repo");
+    expect(outcome.transient).toBe(true);
+    expect(outcome.detail ?? "").not.toMatch(/not its own git repository/i);
+  });
+
+  it("does not report 'no commits yet' when the HEAD probe failed to spawn", async () => {
+    script((bin, args) => (bin === "git" && args.includes("--verify") ? startFailure() : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).not.toBe("nothing_to_push");
+    expect(outcome.transient).toBe(true);
+  });
+
+  it("does not push a guessed branch when the branch probe failed to spawn", async () => {
+    // The "main" fallback is fine when git answered and had no name to give.
+    // When git never ran it binds a `develop` checkout to origin/main over a
+    // transient fault, so the call must refuse instead.
+    script((bin, args) => (bin === "git" && args.includes("--abbrev-ref") ? startFailure() : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.transient).toBe(true);
+    const pushed = spawned().some(([, args]) => args.includes("push"));
+    expect(pushed).toBe(false);
+  });
+
+  it("names the errno rather than saying the call was stopped before it finished", async () => {
+    // A failed spawn was never "stopped before it finished" — it never began,
+    // and killedDetail's wording describes a child that ran.
+    script((bin, args) => (bin === "git" && args.includes("--show-toplevel") ? startFailure("ENOMEM") : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.detail ?? "").toMatch(/ENOMEM/);
+    expect(outcome.detail ?? "").not.toMatch(/stopped before it finished|timed out/i);
+  });
+});
+
+describe("a call that left the box and could not start is reported as a fault, not a refusal", () => {
+  it("does not hand back runChild's placeholder when `gh repo create` failed to spawn", async () => {
+    script((bin, args) => (bin === "gh" && args[0] === "repo" ? startFailure() : null), 1);
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.detail ?? "").not.toBe("could not start");
+    expect(outcome.detail ?? "").toMatch(/EAGAIN/);
+    // Nothing about the request was wrong, so the route must not answer 409.
+    expect(outcome.transient).toBe(true);
+  });
+
+  it("does not hand back runChild's placeholder when `git push` failed to spawn", async () => {
+    script((bin, args) => (bin === "git" && args.includes("push") ? startFailure() : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.detail ?? "").not.toBe("could not start");
+    expect(outcome.detail ?? "").toMatch(/EAGAIN/);
+    expect(outcome.transient).toBe(true);
+  });
+
+  it("never renders a blank message for a create that wrote to neither stream", async () => {
+    script((bin, args) => (bin === "gh" && args[0] === "repo" ? exitingChild(1) : null), 1);
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect((outcome.detail ?? "").trim()).not.toBe("");
+  });
+
+  it("never renders a blank message for a push that wrote to neither stream", async () => {
+    script((bin, args) => (bin === "git" && args.includes("push") ? exitingChild(1) : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect((outcome.detail ?? "").trim()).not.toBe("");
+  });
+
+  it("never renders a blank message for a logout that wrote to neither stream", async () => {
+    spawnMock.mockImplementation(() => exitingChild(1));
+
+    const out = await lib.disconnectGitHub();
+
+    expect(out.ok).toBe(false);
+    if (out.ok) return;
+    expect((out.detail ?? "").trim()).not.toBe("");
+  });
+});
+
+describe("the findings that are real are still reported as findings", () => {
+  it("still answers not_a_repo when git looked and said no", async () => {
+    script((bin, args) => (bin === "git" && args.includes("--show-toplevel") ? exitingChild(128) : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("not_a_repo");
+    expect(outcome.transient).toBeFalsy();
+  });
+
+  it("still answers nothing_to_push for a folder with no commits", async () => {
+    script((bin, args) => (bin === "git" && args.includes("--verify") ? exitingChild(128) : null));
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("nothing_to_push");
+    expect(outcome.transient).toBeFalsy();
+  });
+
+  it("still creates the repository when git really says there is no remote", async () => {
+    script((bin, args) => (bin === "gh" && args[0] === "repo" ? exitingChild(0) : null), 1);
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(ghRepoCreateSpawned()).toBe(true);
+    expect(outcome.pushed).toBe(true);
+  });
+
+  it("still keeps GitHub's own refusal, and its 409", async () => {
+    script(
+      (bin, args) => (bin === "gh" && args[0] === "repo" ? exitingChild(1, "", "GraphQL: Name already exists") : null),
+      1,
+    );
+
+    const outcome = await lib.backupToGitHub(DIR);
+
+    expect(outcome.pushed).toBe(false);
+    if (outcome.pushed) return;
+    expect(outcome.reason).toBe("failed");
+    expect(outcome.transient).toBeFalsy();
+    expect(outcome.detail ?? "").toMatch(/already exists/i);
+  });
+});


### PR DESCRIPTION
Follow-up to #518 (and to #524, which closed the first round of its residuals). Four residuals, all reproduced against the merged beta head `c92eec3` before anything was written.

#518 and #524 established one rule: **a null exit code is not a finding, and a spawn `error` is not proof a binary is missing.** `src/lib/child-run.ts` exports two predicates for it —

```ts
export function wasKilled(r: ChildResult): boolean {
  return !r.startFailed && r.code === null;      // ran, and was cut short
}
export function inconclusive(r: ChildResult): boolean {
  return r.startFailed || wasKilled(r);          // told us nothing, either way
}
```

`inconclusive()` is the question a guard actually wants: *did this call tell me anything about the world at all?* `coding-git.ts` — the sibling that was hardened afterwards — asks it, at lines 129/139/146. `coding-github.ts` asks the narrower one at all eight of its sites, and `inconclusive` was not even in its import list.

## What was wrong, and what it did to an owner

### GH-01a — a `git` that could not be forked created a second repository on GitHub (customer-facing, high)

All four local probes in `backupToGitHub` were guarded with `wasKilled()` alone. That predicate deliberately answers **false** for a failed spawn, so when `git` cannot be started at all — EAGAIN or ENOMEM on `fork()` on a loaded Jetson, EMFILE, a `git` chmod'ed 644 — every guard was skipped and the next line read the null code as a *fact about the folder*:

| probe | line read | what the owner was told |
|---|---|---|
| `rev-parse --show-toplevel` | `top.code !== 0` | "This folder is not its own git repository." |
| `rev-parse --verify HEAD` | `head.code !== 0` | "The folder has no commits yet." |
| `rev-parse --abbrev-ref HEAD` | falls through to the `"main"` fallback | a `develop` checkout pushed to `origin/main` and bound there |
| `remote get-url origin` | `hasRemote.code !== 0` | **`gh repo create <name> --private --source <dir> --push`** |

That last row is verbatim the irreversible outcome #518's own comment pins against:

> *"A killed probe returns the same null code, so reading it as 'no remote' would create a second repository for a folder that already has one — an irreversible guess made from a transient fault."*

The guard was written for the killed case and never for the spawn-failure case. Nothing here is arch-gated, and no existing test emitted a spawn `error` on a git probe — `coding-github-unreachable.test.ts:67` emits one only for `gh` — so CI was green over the hole.

### GH-01b — the route handed the owner the raw enum token (customer-facing)

`backupToGitHub` returned `{ pushed: false, reason: "no_gh" }` and `{ pushed: false, reason: "not_connected" }` with **no `detail`**. The route answers `outcome.detail ?? outcome.reason`, and `CodingAgentApp`'s `readError()` returns `data.error` whenever it is a non-empty string — so the owner's error banner read literally **`not_connected`**.

Every other refusal in the same function was given a sentence. These two are the leftovers, and they are exactly the two branches #518 rewrote when it split `no_gh` away from `gh_unreachable`. Tapping **Backup** before connecting GitHub is the ordinary way to arrive here, not an edge.

### GH-01c — the outage outlived itself on the only surface the owner sees (customer-facing)

`githubStatus()` is uncached on purpose, and says why at `coding-github.ts:160-165`:

> *"`unreachable` is a statement about this moment's network, not a property of the box: caching one would outlive the outage that produced it and go on refusing backups after the uplink came back."*

The card then did exactly that. `load()` runs once on mount; the only re-poll is `setInterval` gated on `anyRunning` — *a run being in progress*. So once the row rendered `coding-agent-github-unreachable`, it kept saying "GitHub unreachable", with no refresh affordance, until the panel was remounted. Probe-once, moved one layer out.

### GH-01d — a failed spawn reported as a GitHub refusal, and a blank message

`gh repo create` (341), `git push` (365) and `gh auth logout` (232) built their detail from raw `(stderr || stdout)`. `child-run.ts:174` exports `failureDetail(r, what, advice)` written for precisely this — its own doc says *"the rule the residuals kept breaking in one branch at a time: read the published evidence, never the exit code alone, and never hand back an empty string"* — and `coding-git.ts` uses it at 118/159/250/261. `coding-github.ts` did not import it.

On a failed spawn the code is null, `wasKilled` is false, and `(stderr || stdout)` is runChild's placeholder `"could not start"` — a five-word non-sentence, classified `reason: "failed"`, which the route answers **409** ("your request is wrong") for a fault that has nothing to do with the request. An exit that wrote to neither stream rendered the empty string: the same blank #518 removed from the killed push, still live one branch over.

## Fixing the class, not the four instances

The shape is *two predicates, one of them weaker, and the weak one used at every site in one file.* So:

- Every guard that is asking **"is there a finding here?"** now asks `inconclusive()`. `wasKilled()` survives at exactly two sites — `githubStatus` and `disconnectGitHub` — and only because `startFailed` is handled on the lines directly above them, which makes the narrower question the correct one there.
- `transientGit()` becomes `noFinding(result, what, reach)`. It keeps `gh_unreachable` for the network claim that **only a call which really started** can support, gives a spawn failure the neutral `failed`, and marks both `transient` so the route answers 503.
- The three hand-rolled details go through the shared `failureDetail()`, the one function that cannot return an empty string.
- `BACKUP_MESSAGE` is a `Record<BackupFailure, string>` living next to the type, used both as the library's detail for the two bare refusals and as the route's fallback. The route can no longer emit a token at all, and **adding a reason without a sentence is now a compile error** rather than something an owner finds.

**How I know I found every sibling.** Three greps over production code only:

```
$ grep -rn 'wasKilled(' src/ mcp/ scripts/ | grep -v /tests/
src/lib/child-run.ts:109,119,177          # the predicate and its two users
src/lib/coding-github.ts:226,269          # githubStatus / disconnectGitHub
```
Eight call sites in `coding-github.ts` before, two after — and those two are the pair where `startFailed` is already handled above.

```
$ grep -rn 'stderr || .*stdout' src/lib/coding-git*.ts src/lib/child-run.ts
src/lib/child-run.ts:178                  # inside failureDetail itself
```
No caller builds a detail by hand any more.

```
$ grep -rn 'runChild(' src/ mcp/ scripts/ | grep -v /tests/
src/lib/child-run.ts:63  src/lib/coding-git.ts:86  src/lib/coding-github.ts:149
```
Two callers and the helper. There is no third copy left to drift out of step.

I also checked the other `(stderr || stdout)` sites the first grep turns up outside these two modules — `hermes-pets.ts`, `hermes-telegram.ts`, `hermes-skill-cli-outcome.ts`, `updater.ts`, `apps/install/route.ts`. **None is an instance of this class**: none of them goes through `runChild`, so none has a `startFailed` flag to conflate in the first place. Left alone deliberately.

## Tests: red first

Every assertion below was proven to **fail against unmodified `origin/beta`** before the fix was written.

| File | RED on beta | GREEN after |
|---|---|---|
| `src/tests/unit/coding-github-spawn-failure.test.ts` (new) | 10 failed / 4 passed | 14 passed |
| `src/tests/unit/coding-github-refusal-detail.test.ts` (new) | 2 failed / 0 passed | 2 passed |
| `src/tests/routes/coding-agent/git-refusal-message.test.ts` (new) | 6 failed / 1 passed | 7 passed |
| `src/tests/components/coding-agent-github-reprobe.test.tsx` (new) | 2 failed / 2 passed | 4 passed |
| **total** | **20 red** | **27 green** |

The headline red was `never creates a second GitHub repository because the remote probe failed to spawn` — on beta, `gh repo create` really is spawned.

The seven that passed on beta as well are the **discriminators**, and they are the point: the fix must not buy honesty about faults by losing the findings.

- a folder git really looked at and refused must still be `not_a_repo`, and must not be marked transient
- a folder with no commits must still be `nothing_to_push`
- a create GitHub itself rejected ("Name already exists") must keep its own message and its 409
- git really saying there is no remote must still create the repository
- the route must still prefer the library's specific detail over the fallback
- a healthy, connected card must **not** acquire a background poll it never had
- `not_installed` — a property of the box, not of this moment — must not be re-probed forever

## Gates

- `npx tsc --noEmit`: **24 errors, identical to the beta baseline**, none in any file this PR touches.
- `npx eslint .`: **105 problems (22 errors, 83 warnings), identical to the beta baseline.** The touched files are clean.
- The coding-agent suites that spawn a real `git` or `claude` fail **47/148 on this Windows dev host on unmodified beta, and 47/148 on this branch** — byte-identical. Linux CI is the gate for those.

## Severity, honestly

All four are reachable on shipped hardware; none is arch-gated. **GH-01a is the one I would fix alone if I could fix only one** — the other three produce a wrong or missing *message*, but GH-01a creates a repository on someone's GitHub account that cannot be un-created, from a transient `fork()` failure on a loaded box. GH-01b is the most *frequently* met: it is what an owner sees the first time they tap Backup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved GitHub backup error messages with clear, consistent guidance.
  - Prevented temporary connection or command failures from producing misleading repository status results.
  - GitHub connectivity now automatically rechecks after becoming unreachable.
  - Backup and disconnect failures trigger an immediate GitHub status refresh.
  - Preserved actionable error details while retaining status information for appropriate recovery handling.

- **Tests**
  - Added coverage for GitHub status recovery, backup refusals, and transient command failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->