### PR TITLE
fix: the TTS step must name its engines from the published verdict, not from the exit code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2600,6 +2600,28 @@ step_openclaw_tts() {
   local VOICE_RC=0
   CLAWBOX_TTS_STATUS_FILE="$TTS_STATUS_FILE" \
     bash "$PROJECT_DIR/scripts/install-voice.sh" --tts-only || VOICE_RC=$?
+
+  # WHICH engines this box has is a fact the run just PUBLISHED; $VOICE_RC only
+  # says how far it got. Reading the first off the second is the defect this
+  # step was built around and then reproduced one line lower: exit 1 means "an
+  # engine survives, the other half did not complete", and the engine line below
+  # printed "Kokoro GPU TTS NOT installed" over a box whose GPU engine had
+  # installed, warmed up and written KOKORO=ready — while
+  # step_validate_services, reading the same file, correctly reported the PIPER
+  # half as the missing one. One run, two mutually exclusive facts.
+  #
+  # `tr -d '\r'` for the same reason the other two readers of this file do it
+  # (install.sh's probe, install-voice.sh's tts_status_load): the file is also
+  # restored from tarballs and edited by hand, and a CRLF `ready\r` is not
+  # `ready`. Absent or unreadable leaves both empty, and every claim below then
+  # falls back to what the exit code carries — nothing to read is not licence
+  # to invent.
+  local KOKORO_VERDICT="" PIPER_VERDICT=""
+  if [ -r "$TTS_STATUS_FILE" ]; then
+    KOKORO_VERDICT=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
+    PIPER_VERDICT=$(sed -n 's/^PIPER=//p' "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
+  fi
+
   local KOKORO_READY=false KOKORO_REASON=""
   # The status this STEP returns, separate from whether TTS could be configured.
   # A Kokoro that was asked for and did not arrive is a failure of this step
@@ -2690,13 +2712,32 @@ step_openclaw_tts() {
         record_provision_failure openclaw_tts
         ;;
   esac
-  if [ "$KOKORO_READY" = true ]; then
-    echo "  Kokoro GPU TTS installed (Piper CPU fallback behind it)"
-  else
+  # The GPU engine, named from the verdict where there is one. KOKORO_READY (an
+  # inference from $VOICE_RC) is only the answer when the run published nothing.
+  local KOKORO_HAVE="$KOKORO_READY"
+  case "$KOKORO_VERDICT" in
+    ready) KOKORO_HAVE=true ;;
+    ?*)    KOKORO_HAVE=false
+           # Only reachable if the verdict contradicts a clean exit, which the
+           # contract does not allow — but "the file says the engine is not
+           # there" beats "the status code implied it was", and the reason has
+           # to come from somewhere when the exit code named none.
+           [ -n "$KOKORO_REASON" ] || KOKORO_REASON="the voice install published KOKORO=$KOKORO_VERDICT"
+           ;;
+  esac
+  if [ "$KOKORO_HAVE" != true ]; then
     # No engine claim here: on VOICE_RC=1 the Piper half is the thing that
     # failed, so "Piper is the active engine" would be its own small lie. The
     # summary at the end of the step names the engine.
     echo "  Kokoro GPU TTS NOT installed: $KOKORO_REASON"
+  elif [ "$VOICE_RC" -eq 0 ]; then
+    echo "  Kokoro GPU TTS installed (Piper CPU fallback behind it)"
+  elif [ "$PIPER_VERDICT" = "ready" ]; then
+    # Both engines are there and the run still did not finish clean, so what is
+    # missing is the deploy behind them — say that rather than pick a half.
+    echo "  Kokoro GPU TTS installed, and so is the Piper CPU fallback — but the voice install did not complete"
+  else
+    echo "  Kokoro GPU TTS installed, but the CPU fallback did not — no CPU fallback behind this box's GPU engine (Piper: ${PIPER_VERDICT:-unreported})"
   fi
 
   # Seed-if-unset, same contract as the primary model above: an owner who has
@@ -2781,7 +2822,7 @@ step_openclaw_tts() {
   # Only claim Kokoro when Kokoro is genuinely there. This line asserting
   # "Kokoro GPU" unconditionally is what kept TASK-420 invisible: three
   # freshly flashed boxes printed it while running entirely on Piper.
-  if [ "$KOKORO_READY" = true ]; then
+  if [ "$KOKORO_HAVE" = true ] && [ "$VOICE_RC" -eq 0 ]; then
     echo "  On-device TTS configured (Kokoro GPU, Piper fallback)"
   else
     # "Piper CPU only" is a claim about an engine, so it is made ONLY for the
@@ -2818,10 +2859,19 @@ step_openclaw_tts() {
         # An engine SURVIVES here — install-voice.sh returns 13, not 1, when
         # none does — so "NO engine is confirmed installed", which is where this
         # case used to land, is a failure report over something that succeeded.
-        # It still says nothing about WHICH engine: exit 1 is also reachable
+        # It said nothing about WHICH engine, because exit 1 is also reachable
         # with Kokoro skipped and the script deploy failing behind a ready
-        # Piper, and naming the wrong survivor would just be a smaller lie.
-        echo "  On-device TTS configured on the engine that installed, but the voice install did not complete ($KOKORO_REASON)"
+        # Piper, and naming the wrong survivor would just be a smaller lie. The
+        # VERDICT knows, though, and an operator reading this line is about to
+        # be told by step_validate_services which half is missing — so when the
+        # file names a ready Kokoro and a Piper that is not ready, say it here
+        # too. NOT by setting KOKORO_READY: that would route into the "Kokoro
+        # GPU, Piper fallback" line above and claim the very thing that is gone.
+        if [ "$KOKORO_VERDICT" = "ready" ] && [ "$PIPER_VERDICT" != "ready" ]; then
+          echo "  On-device TTS configured (Kokoro GPU, NO CPU fallback behind it — Piper: ${PIPER_VERDICT:-unreported})"
+        else
+          echo "  On-device TTS configured on the engine that installed, but the voice install did not complete ($KOKORO_REASON)"
+        fi
         ;;
       13)
         echo "  On-device TTS configured, but this box has NO working engine — it answers speech with SILENCE ($KOKORO_REASON)"

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -901,6 +901,11 @@ if kokoro_predownload_model; then
     kokoro_mark_installed
   fi
 else
+  # Clears the flag for the same reason install_cuda_torch and
+  # install_kokoro_packages do: without the model there is no engine, and this
+  # arm is the one that skips kokoro_mark_installed. Leaving the flag true left
+  # the only in-memory record of the failure at a Warning line.
+  KOKORO_FULL_OK=false
   echo "  Warning: Kokoro model pre-download reported an error"
 fi
 
@@ -916,7 +921,33 @@ deploy_voice_scripts
 # Install systemd user services for persistent model servers. The Kokoro unit
 # comes from the shared writer so this path and --tts-only cannot disagree
 # about it; the Whisper unit is STT and only exists on this path.
-write_kokoro_unit
+# Still fatal, exactly as the bare call was under `set -e` — the only thing
+# added is that the box is left with a RECORD of why, instead of dying with the
+# Kokoro half of its verdict file unwritten.
+if ! write_kokoro_unit; then
+  kokoro_report "failed:unit"
+  echo "  ERROR: could not write $SYSTEMD_USER/kokoro-server.service" >&2
+  exit 1
+fi
+
+# PUBLISH the Kokoro verdict on this path too. This file installs the GPU stack
+# inline rather than through install_kokoro_tts, which is the only other writer
+# of KOKORO=, so a full-pipeline run left that half of the verdict file
+# UNWRITTEN — or, worse, stale from an earlier run — and install.sh's
+# step_validate_services then reported "no on-device TTS verdict for Kokoro" on
+# a box that had just built one. The summary below reads it back, so the run
+# states a fact about the engine instead of asserting one.
+if ! $HAS_CUDA; then
+  kokoro_report "skipped:no-cuda"
+elif $KOKORO_FULL_OK; then
+  kokoro_report "ready"
+else
+  # One of install_cuda_torch / install_kokoro_packages / the model pre-download
+  # reported an error above. Each printed a Warning and the pipeline carried on,
+  # which is how "TTS: Kokoro-82M via on-demand server" ended up on the summary
+  # of a run whose GPU stack never finished.
+  kokoro_report "failed:install"
+fi
 
 cat > "$SYSTEMD_USER/whisper-server.service" << EOF
 [Unit]
@@ -947,15 +978,28 @@ else
   echo "  Mode: CPU"
 fi
 echo "  STT: Whisper (base) via on-demand server (~1.8s)"
-# The fallback is named from the PUBLISHED verdict, not from the fact that
-# install_piper was called a few lines up. This is the third caller of
-# install_piper and it was the least honest of them: it asserted a Piper CPU
-# fallback on every run, including the x86 runs where install_piper_engine
-# declines for want of a pinned artifact and the runs where its download failed.
+# BOTH engines are named from their PUBLISHED verdicts, not from the fact that
+# install_piper and the Kokoro steps were called a few lines up.
+#
+# The Piper half was converted first: this is the third caller of install_piper
+# and it was the least honest of them, asserting a Piper CPU fallback on every
+# run — including the x86 runs where install_piper_engine declines for want of a
+# pinned artifact and the runs where its download failed.
+#
+# The Kokoro half was worse still, because it read no status at all: every one
+# of those three arms opened with "TTS: Kokoro-82M via on-demand server (~2s)",
+# printed identically on the runs where install_cuda_torch, the Kokoro packages
+# or the model pre-download had reported an error a few dozen lines above and
+# the pipeline carried on. Same class, same fix: state the verdict.
+case "$TTS_KOKORO_VERDICT" in
+  ready)      echo "  TTS engine: Kokoro-82M via on-demand server (~2s)" ;;
+  skipped:?*) echo "  TTS engine: no Kokoro GPU engine applies to this board ($TTS_KOKORO_VERDICT)" ;;
+  *)          echo "  TTS engine: the Kokoro GPU engine did NOT install (${TTS_KOKORO_VERDICT:-unreported})" >&2 ;;
+esac
 case "$TTS_PIPER_VERDICT" in
-  ready)      echo "  TTS: Kokoro-82M via on-demand server (~2s), Piper CPU fallback" ;;
-  skipped:?*) echo "  TTS: Kokoro-82M via on-demand server (~2s); no Piper fallback applies to this board ($TTS_PIPER_VERDICT)" ;;
-  *)          echo "  TTS: Kokoro-82M via on-demand server (~2s); the Piper CPU fallback did NOT install (${TTS_PIPER_VERDICT:-unreported})" >&2 ;;
+  ready)      echo "  TTS fallback: Piper CPU" ;;
+  skipped:?*) echo "  TTS fallback: no Piper fallback applies to this board ($TTS_PIPER_VERDICT)" ;;
+  *)          echo "  TTS fallback: the Piper CPU fallback did NOT install (${TTS_PIPER_VERDICT:-unreported})" >&2 ;;
 esac
 echo "  TTS entrypoint: $WORKSPACE/scripts/openclaw/clawbox-tts.sh"
 echo "  Services: kokoro-server, whisper-server (on-demand, auto-stop after idle)"

--- a/src/tests/unit/install-tts-survivor-verdict.test.ts
+++ b/src/tests/unit/install-tts-survivor-verdict.test.ts
@@ -42,6 +42,12 @@ const INSTALL_VOICE_SH = readFileSync(path.join(REPO, "scripts", "install-voice.
 
 const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
 
+/**
+ * Lift one shell function verbatim out of a script so the test runs the SHIPPED
+ * body rather than a copy of it. Matches from `name() {` to the first
+ * column-zero `}`, which is the style every function in install.sh is written
+ * in.
+ */
 function extractShellFn(source: string, name: string): string {
   const start = source.indexOf(`${name}() {`);
   if (start < 0) throw new Error(`${name} not found`);
@@ -50,6 +56,7 @@ function extractShellFn(source: string, name: string): string {
   return source.slice(start, end + 2);
 }
 
+/** Write an executable stub — the shebang and the +x bit, so PATH lookup finds it. */
 function writeExec(file: string, body: string) {
   writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
 }

--- a/src/tests/unit/install-tts-survivor-verdict.test.ts
+++ b/src/tests/unit/install-tts-survivor-verdict.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * The LAST residual of the TTS-01 fix (#519), and its class.
+ *
+ * #519 created the state "an engine survives, the other half did not complete"
+ * and gave it its own exit code: `install-voice.sh --tts-only` returns 1 when
+ * Kokoro is `ready` and the Piper half (or the script deploy behind it) did not
+ * land. Its own regression test pins that — `runTtsOnly({piper:'broken',
+ * withCuda:true})` asserts `KOKORO=ready` and status 1.
+ *
+ * install.sh maps that 1 to TTS_RC=14 but left `KOKORO_READY` at false, and the
+ * engine line is printed off that flag alone. So the step announced
+ *
+ *     Kokoro GPU TTS NOT installed: the voice install did not complete
+ *
+ * over a box whose GPU engine installed, warmed up and published `KOKORO=ready`
+ * — and step_validate_services then contradicted it a moment later with the
+ * correct "the Piper CPU fallback was requested and did NOT install ... this
+ * box has no fallback behind its GPU engine". One run, two mutually exclusive
+ * facts about the same box.
+ *
+ * The class is the one this review round is hunting: an engine CLAIM derived
+ * from a return code when the run has already PUBLISHED a verdict that answers
+ * the question directly. #519 taught install-voice.sh's `--tts-only` guard and
+ * step_validate_services' probe to read the verdict; #533 taught `--piper-only`
+ * and the full pipeline's Piper line. step_openclaw_tts's own prose was never
+ * converted, and neither was the Kokoro half of the full-pipeline summary —
+ * which asserts the GPU engine from nothing at all.
+ *
+ * These tests EXECUTE the shipped step against stubs, like the two suites they
+ * sit next to.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_VOICE_SH = readFileSync(path.join(REPO, "scripts", "install-voice.sh"), "utf-8");
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+function extractShellFn(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end + 2);
+}
+
+function writeExec(file: string, body: string) {
+  writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+}
+
+/**
+ * Run a generated shell program from a FILE rather than `bash -c "$program"`:
+ * these programs carry whole functions lifted out of install.sh and run past
+ * the 8 KiB per-argument ceiling on the Windows spawn path, where a `-c`
+ * argument is silently truncated and bash dies with "unexpected end of file"
+ * whatever the script under test did.
+ */
+function runShellProgram(program: string, env: Record<string, string>) {
+  const file = path.join(root, `prog-${Math.random().toString(36).slice(2)}.sh`);
+  writeFileSync(file, program);
+  return spawnSync("bash", [file], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, ...env },
+  });
+}
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "tts-survivor-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+/**
+ * Run the real step_openclaw_tts against a stub install-voice.sh that PUBLISHES
+ * the verdicts the test picks and then exits with the code the test picks —
+ * which is exactly what the real script does, in that order.
+ *
+ * `verdicts: null` leaves the status file absent: the case where the step has
+ * nothing but the exit code to go on.
+ */
+function runStep(voiceExit: number, verdicts: Record<string, string> | null) {
+  const projectDir = path.join(root, "project");
+  mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+  writeExec(
+    path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+    '[ "${1:-}" = "--provider-timeout-ms" ] && echo 100000\nexit 0',
+  );
+  const publish =
+    verdicts === null
+      ? ""
+      : Object.entries(verdicts)
+          .map(([k, v]) => `printf '%s=%b\\n' ${k} '${v}' >> "$CLAWBOX_TTS_STATUS_FILE"`)
+          .join("\n");
+  writeExec(path.join(projectDir, "scripts", "install-voice.sh"), `${publish}\nexit ${voiceExit}`);
+  const openclaw = path.join(root, "openclaw");
+  writeExec(openclaw, "exit 0");
+
+  const provisionLog = path.join(root, "provision-failures.log");
+  const ttsStatus = path.join(root, "step-tts-status");
+
+  const program = [
+    "set -uo pipefail",
+    `PROJECT_DIR="${projectDir}"`,
+    `OPENCLAW_BIN="${openclaw}"`,
+    "CLAWBOX_USER=clawbox",
+    'as_clawbox() { env "$@"; }',
+    "is_hermes_edition() { return 1; }",
+    `record_provision_failure() { printf '%s\\n' "$1" >> "${provisionLog}"; }`,
+    extractShellFn(INSTALL_SH, "oc_config_set"),
+    extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
+    extractShellFn(INSTALL_SH, "step_openclaw_tts"),
+    "step_openclaw_tts",
+    'echo "STEP_RC=$?"',
+  ].join("\n");
+
+  const res = runShellProgram(program, { TTS_STATUS_FILE: ttsStatus });
+  const out = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+  return {
+    out,
+    stepRc: /STEP_RC=(\d+)/.exec(out)?.[1] ?? "",
+    provisionFailures: existsSync(provisionLog)
+      ? readFileSync(provisionLog, "utf-8").trim().split("\n").filter(Boolean)
+      : [],
+  };
+}
+
+// The state #519 invented and then denied: GPU engine up, CPU fallback gone.
+const SURVIVOR = { KOKORO: "ready", PIPER: "failed:download" };
+
+describe.skipIf(!hasBash)("step_openclaw_tts reads the verdict before it denies an engine", () => {
+  it("does not tell a box its Kokoro is missing when Kokoro published ready", () => {
+    const res = runStep(1, SURVIVOR);
+    expect(res.out, `a running GPU engine was reported as not installed:\n${res.out}`).not.toContain(
+      "Kokoro GPU TTS NOT installed",
+    );
+  });
+
+  it("names the half that actually failed, the way the health check does", () => {
+    // step_validate_services reports this same box as "the Piper CPU fallback
+    // was requested and did NOT install ... this box has no fallback behind its
+    // GPU engine". One run must not print two mutually exclusive facts.
+    const res = runStep(1, SURVIVOR);
+    expect(res.out, `the step never says which half failed:\n${res.out}`).toMatch(/no CPU fallback behind/i);
+    expect(res.out).toContain("failed:download");
+  });
+
+  it("says so on the summary line an operator actually reads", () => {
+    const res = runStep(1, SURVIVOR);
+    const summary = res.out.split("\n").filter((l) => l.includes("On-device TTS configured"));
+    expect(summary.length, `no summary line was printed:\n${res.out}`).toBeGreaterThan(0);
+    expect(summary.join("\n"), `the summary hides the surviving engine:\n${res.out}`).toMatch(
+      /Kokoro GPU, NO CPU fallback/,
+    );
+  });
+
+  it("still does not claim the fallback it has just called missing", () => {
+    // The trap the proposed fix walks into: flipping KOKORO_READY to true would
+    // route into "Kokoro GPU, Piper fallback" and name the very thing that is
+    // gone.
+    const res = runStep(1, SURVIVOR);
+    expect(res.out, `the missing fallback was named as present:\n${res.out}`).not.toContain(
+      "Kokoro GPU, Piper fallback",
+    );
+    expect(res.out).not.toContain("Piper CPU only");
+  });
+
+  it("keeps #519's verdict: still recorded, still 14, still non-fatal", () => {
+    // The engine line is the only thing that changes. A box with no fallback
+    // behind its GPU engine is still a provisioning failure.
+    const res = runStep(1, SURVIVOR);
+    expect(res.stepRc, `the step status changed:\n${res.out}`).toBe("14");
+    expect(res.provisionFailures).toContain("openclaw_tts");
+  });
+
+  it("does not swing the other way and claim Kokoro when Kokoro is not ready", () => {
+    // The over-correction guard. Exit 1 is also reachable with Kokoro SKIPPED
+    // behind a ready Piper and a failed script deploy; naming the wrong
+    // survivor would just be a smaller lie.
+    const res = runStep(1, { KOKORO: "skipped:no-cuda", PIPER: "ready" });
+    expect(res.out, `a skipped GPU engine was reported as installed:\n${res.out}`).not.toMatch(
+      /Kokoro GPU TTS installed/,
+    );
+    expect(res.out).not.toContain("Kokoro GPU, NO CPU fallback");
+    expect(res.stepRc).toBe("14");
+  });
+
+  it("falls back to the exit code when the run published no verdict at all", () => {
+    // Nothing to read is not licence to invent: with no status file the step
+    // keeps exactly the wording #519 landed.
+    const res = runStep(1, null);
+    expect(res.out, `an unpublished run changed its story:\n${res.out}`).toContain(
+      "Kokoro GPU TTS NOT installed",
+    );
+    expect(res.stepRc).toBe("14");
+    expect(res.provisionFailures).toContain("openclaw_tts");
+  });
+
+  it("still announces the healthy box the same way", () => {
+    const res = runStep(0, { KOKORO: "ready", PIPER: "ready" });
+    expect(res.out, `a healthy box lost its summary:\n${res.out}`).toContain(
+      "Kokoro GPU TTS installed (Piper CPU fallback behind it)",
+    );
+    expect(res.out).toContain("On-device TTS configured (Kokoro GPU, Piper fallback)");
+    expect(res.stepRc).toBe("0");
+    expect(res.provisionFailures).toEqual([]);
+  });
+
+  it("parses a CRLF verdict file rather than reading it as a missing engine", () => {
+    // Both other readers of this file strip CR (install.sh:4914-4915,
+    // install-voice.sh:554-555). A third reader that did not would report the
+    // survivor as absent again, for a file restored from a tarball.
+    const res = runStep(1, { KOKORO: "ready\\r", PIPER: "failed:download\\r" });
+    expect(res.out, `a CRLF verdict denied a running engine:\n${res.out}`).not.toContain(
+      "Kokoro GPU TTS NOT installed",
+    );
+  });
+});
+
+describe("the full pipeline names its GPU engine from the verdict too", () => {
+  it("does not assert Kokoro in a summary no verdict ever agreed to", () => {
+    // The mirror of the residual above, in the other direction: this path never
+    // calls install_kokoro_tts, so it published no KOKORO verdict at all and
+    // then printed "TTS: Kokoro-82M via on-demand server (~2s)" on every run —
+    // including the runs where install_cuda_torch or the Kokoro package install
+    // reported an error and KOKORO_FULL_OK is false.
+    const summary = INSTALL_VOICE_SH.slice(INSTALL_VOICE_SH.indexOf("=== Voice Pipeline Installed ==="));
+    expect(summary, "the full-pipeline summary is not in install-voice.sh").not.toBe("");
+    expect(summary, `the summary claims the GPU engine without reading its verdict:\n${summary}`).toContain(
+      'case "$TTS_KOKORO_VERDICT" in',
+    );
+  });
+
+  it("publishes a Kokoro verdict on the path that installs Kokoro inline", () => {
+    // A run that leaves the KOKORO half of the file unwritten is also the run
+    // step_validate_services reports as "no on-device TTS verdict for Kokoro".
+    const pipeline = INSTALL_VOICE_SH.slice(INSTALL_VOICE_SH.indexOf("[8/8] Deploying voice server scripts"));
+    expect(pipeline, `the full pipeline never publishes a Kokoro verdict:\n${pipeline}`).toContain(
+      "kokoro_report",
+    );
+  });
+});


### PR DESCRIPTION
Follow-up to #519, and to #533 which closed the first three of its residuals. The fourth is the one #533 did not have: it was found against #533's own merged head.

## First, what did NOT reproduce

Three of the four residuals handed to me were already closed by #533 (merged as `c92eec34`). I re-checked each against the current `beta` head before touching anything, and none of them reproduces:

| residual | claim | state on `beta` today |
| --- | --- | --- |
| TTS-01a | `--piper-only` reports success from the return code | **closed.** `scripts/install-voice.sh:775` is now `case "$TTS_PIPER_VERDICT" in`, with `skipped:*` printing "No Piper artifact applies to this board" and everything unparseable exiting non-zero. |
| TTS-01b | exit 11 bucketed with 10/12 and told "Piper CPU only" | **closed.** `install.sh:2794` has 11 on its own arm — "no speech engine applies to this CPU architecture … this box answers speech with SILENCE" — and pinned by a test. |
| TTS-01c | an unparseable verdict scores a PASS | **closed.** `install.sh:4886` has the `verdict_unreadable` guard, placed as an `elif` ahead of the engine-naming arms, and both readers strip CR. |

So this PR closes **TTS-01d only**, plus the sibling the class grep turned up.

## TTS-01d — the step denied an engine that had installed

`install.sh:2699`, reproduced against `c92eec34`.

#519 deliberately created the state *"an engine survives, the other half did not complete"* and gave it its own exit code. `scripts/install-voice.sh:731-736`:

```sh
if [ "$PIPER_RC" -ne 0 ] || [ "$DEPLOY_RC" -ne 0 ]; then
  echo "=== Piper fallback INCOMPLETE - the box has no CPU fallback behind Kokoro ===" >&2
  exit 1
fi
```

That guard sits **after** the "neither engine is ready" check, so exit 1 always leaves an engine standing — and #519's own regression test pins it: `runTtsOnly({piper:'broken', withCuda:true})` asserts `KOKORO=ready` and status 1.

`install.sh` mapped that 1 to `TTS_RC=14` but left `KOKORO_READY=false`, and the engine line was printed off that flag alone:

```
  Kokoro GPU TTS NOT installed: the voice install did not complete
```

over a box whose GPU engine had installed, warmed up and written `KOKORO=ready`. `step_validate_services` then read the same file and got it right (`install.sh:4973`): *"the Piper CPU fallback was requested and did NOT install … this box has no fallback behind its GPU engine."* One run, two mutually exclusive facts about the same box — a false failure report over a successful operation, inside the PR that exists to remove exactly that.

**Reachable on shipped hardware, and nothing here is arch-gated:** an aarch64 Jetson with CUDA whose pinned Piper download flakes. That is why this one is marked customer-facing where a, b and c were not.

#519 fixed the *summary* line at 2796-2806 to stop asserting a survivor. It left the earlier line flatly denying the survivor by name.

### The fix

The step reads `KOKORO=` and `PIPER=` out of `$TTS_STATUS_FILE` and names engines from them, falling back to the exit code only when the run published nothing:

```sh
local KOKORO_VERDICT="" PIPER_VERDICT=""
if [ -r "$TTS_STATUS_FILE" ]; then
  KOKORO_VERDICT=$(sed -n 's/^KOKORO=//p' "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
  PIPER_VERDICT=$(sed -n 's/^PIPER=//p'  "$TTS_STATUS_FILE" 2>/dev/null | tr -d '\r' | tail -1)
fi
```

Four decisions worth reviewing:

- **`KOKORO_READY` is not flipped true.** The proposed fix said so and it is right: `true` routes into the `"Kokoro GPU, Piper fallback"` line at 2785 and claims the fallback that is the thing missing. A separate `KOKORO_HAVE` carries the verdict; the summary arm at 2785 additionally requires `VOICE_RC -eq 0`, so nothing but a clean run can reach it.
- **Exit 1 is also reachable with a ready Piper**, when `deploy_voice_scripts` is what failed. The new wording therefore has an arm for that (`"and so is the Piper CPU fallback — but the voice install did not complete"`) instead of asserting "no fallback" from `VOICE_RC` alone. Every claim printed is backed by a verdict, not by a code.
- **No verdict file, no new story.** With nothing to read, both variables stay empty and the step prints exactly the #519 wording. A test pins that. Nothing to read is not licence to invent.
- **`tr -d '\r'`.** The other two readers of this file already strip CR (`install.sh:4914-4915`, `install-voice.sh:554-555`). A third reader that did not would have reported the survivor as absent again for a file restored from a tarball. A test pins it.

`TTS_RC` stays 14, `record_provision_failure openclaw_tts` stays, and the summary block gets the matching arm the report asked for: `On-device TTS configured (Kokoro GPU, NO CPU fallback behind it — Piper: …)`, gated on `PIPER != ready` so it cannot claim a missing fallback on a box that has one.

## The sibling the class grep turned up — the full pipeline asserted Kokoro from nothing

`scripts/install-voice.sh:955`. Same class, opposite direction: a false **assertion** rather than a false denial.

The full-pipeline path installs the GPU stack inline instead of calling `install_kokoro_tts`, which is the only other writer of `KOKORO=`. So that path published **no Kokoro verdict at all** — and then every one of the three arms #533 rewrote opened with `"TTS: Kokoro-82M via on-demand server (~2s)"`, printed identically on runs where `install_cuda_torch`, `install_kokoro_packages` or the model pre-download had reported an error a few dozen lines above and the pipeline carried on:

```sh
install_cuda_torch     || { KOKORO_FULL_OK=false; echo "  Warning: CUDA PyTorch install reported an error"; }
install_kokoro_packages|| { KOKORO_FULL_OK=false; echo "  Warning: Kokoro package install reported an error"; }
```

#533 converted the Piper half of that line and left the Kokoro half, which read no status whatsoever. It now publishes the verdict and names both engines from it, on separate lines so each states one fact:

```sh
case "$TTS_KOKORO_VERDICT" in
  ready)      echo "  TTS engine: Kokoro-82M via on-demand server (~2s)" ;;
  skipped:?*) echo "  TTS engine: no Kokoro GPU engine applies to this board ($TTS_KOKORO_VERDICT)" ;;
  *)          echo "  TTS engine: the Kokoro GPU engine did NOT install (…)" >&2 ;;
esac
```

Two smaller things fall out of it, both in the same class:

- A failed model pre-download only printed a Warning and left `KOKORO_FULL_OK` **true**, unlike the two failures above it. It is the arm that skips `kokoro_mark_installed`, so the flag was the only in-memory record disagreeing with the disk. It clears now.
- `write_kokoro_unit` was a bare call under `set -e`, so a failure killed the script with the Kokoro half of the verdict file unwritten. It is **still fatal** — the only change is that it publishes `failed:unit` and names the file before it exits.

Leaving that half unpublished was not cosmetic either: `step_validate_services` reports a box with no `KOKORO=` line as *"no on-device TTS verdict for Kokoro … cannot be asserted either way"*, i.e. a failed check on a box that had just built the engine.

## Fixing the class, and how I know I found every sibling

The class is *"an engine CLAIM derived from a return code — or from nothing — when the run has already published a verdict that answers the question directly."*

The grep is over the claims, not over the callers, because the callers were already enumerated by #533 and the defect is in what they **print**:

```
rg -n 'Piper CPU|Piper fallback|Kokoro GPU|no fallback|NO engine|no engine' \
   --glob '!node_modules' --glob '!src/tests' -g '*.sh' -g '*.ts' -g '*.py'
```

That returns 59 hits. Stripping the comment lines leaves **10 engine-claim sites plus the probe's four-line block**, and here is every one of them. Line numbers are `beta`'s, i.e. where each site was before this diff:

| site | reads | verdict |
| --- | --- | --- |
| `install.sh:2694` "Kokoro GPU TTS installed (Piper fallback behind it)" | `KOKORO_READY` | **fixed** — verdict + `VOICE_RC -eq 0` |
| `install.sh:2699` "Kokoro GPU TTS NOT installed" | `KOKORO_READY` | **fixed** — TTS-01d |
| `install.sh:2785` "(Kokoro GPU, Piper fallback)" | `KOKORO_READY` | **fixed** — verdict + `VOICE_RC -eq 0` |
| `install.sh:2795` "(Piper CPU only)" for 10\|12 | `VOICE_RC` | sound: 10 and 12 are reachable only with a ready Piper (`--tts-only` returns 13 or 1 otherwise). Pinned by #533's test; left alone |
| `install.sh:2805` 11, "no engine applies" | `VOICE_RC` | closed by #533 |
| `install.sh:2825` 1, "on the engine that installed" | `VOICE_RC` | **fixed** — names the survivor when the verdict does |
| `install.sh:2831` 13, "NO working engine" | `VOICE_RC` | sound: 13 is defined as "neither verdict is ready" |
| `install.sh:4949-4977` the probe's `failed_probe` lines | **verdict** | closed by #519 + #533 |
| `install-voice.sh:734` "Piper fallback INCOMPLETE" (`--tts-only`) | `PIPER_RC`/`DEPLOY_RC` | correct source: this is a claim about the install ACTION, and the guard above it has already established from the verdicts that an engine is ready. Left alone |
| `install-voice.sh:760`/`:789` "Piper fallback INCOMPLETE" (`--piper-only`) | rc, then **verdict** | closed by #533 |
| `install-voice.sh:738-740` "(Kokoro GPU, Piper fallback)" / "Piper CPU only" | `KOKORO_RC` | **audited, provably equivalent, left alone.** Reached only with `PIPER_RC=0` and `DEPLOY_RC=0`; `install_piper_engine`'s only non-failure skip is `uname -m != aarch64` (line 199), and on that same board `install_kokoro_tts` returns **11** (line 616), which the guard above catches and exits before this line. So `KOKORO_RC=0` here implies `PIPER=ready`. Converting it would be churn with no reachable behaviour change and no red test to justify it |
| `install-voice.sh:793` "Piper fallback ready" | **verdict** | closed by #533 |
| `install-voice.sh:955` "TTS: Kokoro-82M …" | **nothing at all** | **fixed** |

And the writers, to be sure the verdict file is actually complete on every path that installs an engine:

```
rg -n 'kokoro_report|piper_report'   # -> piper_report: install_piper (the sole wrapper, 273)
                                     #    kokoro_report: install_kokoro_tts x6 (621-663)
                                     #    -> the full pipeline called NEITHER writer for Kokoro
rg -n 'TTS_STATUS_FILE|tts-status'   # -> three parsers now: install.sh:4914-4915, :2617-2618,
                                     #    install-voice.sh:554-555 — all three strip CR
                                     #    (the new one is install.sh:2621-2622)
```

`rg -n 'install_piper\b'` and `rg -n 'step_openclaw_tts'` still return the call sites #533 enumerated (3 and 2 + the dispatch whitelist); no new caller has appeared.

## Tests — red first

New file `src/tests/unit/install-tts-survivor-verdict.test.ts`, 11 tests. The step tests EXECUTE the real `step_openclaw_tts` against a stub `install-voice.sh` that **publishes the verdicts and then exits the code**, in that order, which is what the real script does — so a rewrite that keeps the prose but drops the verdict fails them.

- Against **unmodified `origin/beta`** (`c92eec34`, both scripts restored, test file in place): **6 failed / 5 passed.**
- With the fix: **11 passed.**

The 5 that pass red are the over-correction guards, and they are why the diff is shaped the way it is: a skipped Kokoro is still not claimed as installed, a run that published nothing keeps the #519 wording, the healthy box's two lines are unchanged, and the missing fallback is never named as present.

Neighbouring suites, all with the fix applied: `install-tts-no-engine` 23/23 (#519's own), `install-tts-verdict-siblings` 24/24 (#533's), `install-kokoro-tts` 46/46, `clawbox-tts` 61/61, `install-tts-provider-registry` 8/8, `install-provision-status-marker` 10/10, `install-post-update-units` 9/9, `root-steps` 12/12, `observability-install` 11/11 — **215 passed, 0 failed.**

`bash -n` clean on both scripts. `tsc --noEmit`: 24 pre-existing errors before and after, none in the new file (same 14 files as #533 reported). `eslint` clean on the new file.

*Environment note, since it affects how the numbers were taken:* the Windows dev host cannot run these spawn-heavy suites at all — every test in `install-tts-no-engine` times out there, on unmodified `beta` as much as with this change. The counts above were taken on Linux (WSL Ubuntu 22.04, node 22, `npm ci` from the committed lockfile), one file per `vitest` process; running ten files in parallel in that VM makes 3-7 of the pre-existing `step_validate_services` tests flake on the 5 s `testTimeout`, a different set each run and with beta's own sources too. Linux CI is the gate.

## Honest severity

TTS-01d is the only one of the four that is customer-facing, and the only one that is not arch-gated: `KOKORO_STAMP_VERSION` was bumped to 2, so every already-stamped aarch64 box redoes the Kokoro install on its next update, and a flaky Piper download during that redo puts a shipped Jetson straight into this branch. The box keeps speaking, so nothing looks wrong — which is exactly the condition under which a false line in the install log gets believed.

The full-pipeline sibling is operator-facing only: nothing in `install.sh` runs that path (it is the manual voice-pipeline install, STT included), so it cannot mislead a provisioning run. It is fixed because it is the same class and it was one line away.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice setup reporting to accurately identify installed and available speech engines.
  * Distinguishes successful, partial, skipped, failed, and unsupported configurations.
  * Prevents incorrect claims about Kokoro or Piper availability after provisioning failures.
  * Preserves installation errors and handles status data consistently across environments.

* **Tests**
  * Added regression coverage for engine status reporting, fallback behavior, line-ending differences, and provisioning failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->