### PR TITLE
fix: tell the running agent which providers it may switch to, not just the browser

### DIFF
--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -282,6 +282,14 @@ export async function POST(request: Request) {
   } finally {
     // The device's selection changed (or attempted to) — never serve the old
     // `current` from cache.
+    //
+    // THE ONE `invalidateModelOptions()` SITE WITH NO MCP REFRESH BESIDE IT, and
+    // deliberately. Its five siblings move CREDENTIALS, which is what changes the
+    // set `mcp/lib/context.ts` builds `ai_set_provider`'s enum from; this one
+    // moves only the SELECTION, and every provider it will accept had to be in
+    // that set already (`isAllowedProvider` above). More to the point, this route
+    // is what `ai_set_provider` itself POSTs to — asking for a global
+    // `reload.mcp` here would shut down the very MCP child that is mid-call.
     invalidateModelOptions();
   }
 

--- a/src/app/setup-api/hermes/oauth/poll/route.ts
+++ b/src/app/setup-api/hermes/oauth/poll/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
+import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
 import { dashboardUnreachable, hermesGate, isValidProviderId, isValidSessionId, relayJson } from "../shared";
 
 // Poll a device-code session until the user approves it on the provider's
@@ -38,6 +39,13 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: "Invalid session id" }, { status: 400 });
   }
 
+  // Sampled BEFORE the tick that may report the sign-in, because after it the
+  // answer already includes the provider that just connected and no change can
+  // be seen. It is a read of the SWR-cached catalogue the panel is holding open
+  // anyway (FRESH_MS = 60 s), not a dashboard round-trip per tick — and the
+  // guard below is what keeps a pending tick from asking the agent for anything.
+  const providersBefore = await readUsableProviderIds();
+
   try {
     const res = await dashboardFetch(`/api/providers/oauth/${providerId}/poll/${sessionId}`);
     // On the terminal "approved" tick the credential has just landed on the
@@ -45,9 +53,23 @@ export async function GET(request: Request) {
     // sees the provider as connected rather than waiting out FRESH_MS. Only on
     // "approved" — a poll fires every few seconds, and busting the cache on
     // every "pending" tick would defeat the cache entirely.
-    return await relayJson(res, POLL_KEYS, (data) => {
-      if (data.status === "approved") invalidateModelOptions();
+    let approved = false;
+    const relayed = await relayJson(res, POLL_KEYS, (data) => {
+      if (data.status === "approved") {
+        invalidateModelOptions();
+        approved = true;
+      }
     });
+    // The browser has been told; the RUNNING AGENT has not. Its `ai_set_provider`
+    // enum was built from a provider list probed once, at MCP-server boot — see
+    // `provider-mcp-refresh.ts`. Only on the terminal tick, and only if the set
+    // really moved: a reload respawns every MCP child and invalidates the model's
+    // prompt cache, so a client that keeps polling a finished session must not be
+    // able to charge the owner for one per tick.
+    if (approved) {
+      await refreshProviderToolsIfSetChanged(providersBefore, await readUsableProviderIds());
+    }
+    return relayed;
   } catch {
     return dashboardUnreachable();
   }

--- a/src/app/setup-api/hermes/oauth/poll/route.ts
+++ b/src/app/setup-api/hermes/oauth/poll/route.ts
@@ -20,11 +20,24 @@ const POLL_KEYS = ["session_id", "status", "error_message", "expires_at"] as con
 //
 // That asymmetry follows what the second line is for. `@/lib/route-auth` exists
 // so a handler that CHANGES something still refuses when the gate in front of
-// it is wrong; this one changes nothing. It reads back a status the caller must
-// already hold a dashboard-minted session id to name, and relays four fields —
-// session_id, status, error_message, expires_at — none of them credential
-// material (`relayJson`'s whitelist is what guarantees that). Minting the id it
-// needs goes through `start`, which is gated twice.
+// it is wrong; this one changes nothing OF THE DEVICE'S OWN. It reads back a
+// status the caller must already hold a dashboard-minted session id to name, and
+// relays four fields — session_id, status, error_message, expires_at — none of
+// them credential material (`relayJson`'s whitelist is what guarantees that).
+// Minting the id it needs goes through `start`, which is gated twice.
+//
+// IT IS NO LONGER SIDE-EFFECT-FREE, and that is worth stating plainly rather
+// than leaving the sentence above to read as more than it means. On the terminal
+// "approved" tick this route drops the model catalogue and may ask the agent for
+// a `reload.mcp`, which respawns every MCP child and invalidates the model's
+// prompt cache. Nothing about the gate changed, because nothing about what a
+// caller must hold changed: reaching that branch needs a session (middleware), a
+// dashboard-minted session id it cannot guess, and the dashboard itself
+// reporting that a real credential just landed — the sign-in the owner started
+// through `start`. A caller who can do all three has already completed the
+// owner's OAuth flow. What a stranger can still not do is turn this into a
+// repeated reload: the refresh fires only when the provider set actually MOVED,
+// so a client hammering a finished session gets one respawn, not one per tick.
 export async function GET(request: Request) {
   const gate = await hermesGate();
   if (gate) return gate;

--- a/src/app/setup-api/hermes/oauth/submit/route.ts
+++ b/src/app/setup-api/hermes/oauth/submit/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
+import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
 import {
   dashboardUnreachable,
   isValidProviderId,
@@ -43,6 +44,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid code" }, { status: 400 });
   }
 
+  // Sampled ahead of the exchange, for the same reason the API-key route samples
+  // ahead of `hermes auth add`: after it, the answer already includes the
+  // provider that just connected and no change can be seen.
+  const providersBefore = await readUsableProviderIds();
+
   try {
     const res = await dashboardFetch(`/api/providers/oauth/${body.providerId}/submit`, {
       method: "POST",
@@ -56,9 +62,22 @@ export async function POST(request: Request) {
     // the provider as connected instead of serving a stale "not connected" for
     // up to FRESH_MS. This was the row-vs-card mismatch: the OAuth card flipped
     // to Connected from local state while the row kept reading the stale cache.
-    return await relayJson(res, SUBMIT_KEYS, (data, ok) => {
-      if (ok && data.ok !== false) invalidateModelOptions();
+    let connected = false;
+    const relayed = await relayJson(res, SUBMIT_KEYS, (data, ok) => {
+      if (ok && data.ok !== false) {
+        invalidateModelOptions();
+        connected = true;
+      }
     });
+    // The browser has been told; the RUNNING AGENT has not. The ClawBox MCP
+    // server turned the provider list into `ai_set_provider`'s enum once, while
+    // it booted — see `provider-mcp-refresh.ts`. Only on the terminal success:
+    // a failed exchange credentialled nothing, and a reload respawns every MCP
+    // child and invalidates the model's prompt cache.
+    if (connected) {
+      await refreshProviderToolsIfSetChanged(providersBefore, await readUsableProviderIds());
+    }
+    return relayed;
   } catch {
     return dashboardUnreachable();
   }

--- a/src/app/setup-api/hermes/provider-key/route.ts
+++ b/src/app/setup-api/hermes/provider-key/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
+import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
 
 // Store an API key for a Hermes inference provider via `hermes auth add`. Hermes
 // keeps the credential in its own pooled-auth store (~/.hermes), NOT ClawBox's
@@ -55,6 +56,11 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid API key" }, { status: 400 });
   }
 
+  // Taken BEFORE the credential lands, because that is the only moment it can
+  // still say what the agent's `ai_set_provider` enum was built from. See
+  // `provider-mcp-refresh.ts` for why the enum is not advisory.
+  const providersBefore = await readUsableProviderIds();
+
   try {
     const r = await runHermesCli(
       ["auth", "add", provider, "--type", "api-key", "--api-key", apiKey],
@@ -90,6 +96,16 @@ export async function POST(request: Request) {
   // model list, so the cached catalogue is now wrong — the panel's very next
   // request must see the provider as usable rather than wait out FRESH_MS.
   invalidateModelOptions();
+
+  // …and the RUNNING AGENT, which the line above does not reach. The ClawBox MCP
+  // server read the provider list once, while it booted, and turned it into
+  // `ai_set_provider`'s enum; without this the owner adds a provider, the panel
+  // offers it, `ai_list_models` lists it, and the tool that switches to it
+  // cannot be handed the id. Awaited rather than left floating so it is ordered
+  // against the response and nothing outlives it unwatched; it cannot fail the
+  // save, because the credential is already stored and the helper swallows
+  // everything.
+  await refreshProviderToolsIfSetChanged(providersBefore, await readUsableProviderIds());
 
   return NextResponse.json({ ok: true, provider });
 }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -4,6 +4,7 @@ import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
+import { readUsableProviderIds, refreshProviderToolsIfSetChanged } from "@/lib/provider-mcp-refresh";
 import { setHermesEnvValues } from "@/lib/hermes-env";
 import {
   HERMES_IMAGE_PLUGIN_NAME,
@@ -129,6 +130,12 @@ export async function applyClawaiToHermes(
   // and it is the order the readiness text itself asks for ("ClawBox AI is not
   // connected. Open Settings → AI Models and sign in to ClawBox AI first.").
   const codingReadyBefore = options.codingAgentReadyBefore ?? (await codingAgentReady());
+  // And the THIRD, which is the same fact from the picker's side: connecting
+  // credentials the `clawai` provider, and the ClawBox MCP server turned the
+  // provider list into `ai_set_provider`'s enum from one read taken while it
+  // booted. Sampled here, ahead of every write below, for the same reason as
+  // its two neighbours.
+  const providersBefore = await readUsableProviderIds();
 
   const vision = await resolveVisionModelId({ token: trimmed });
   let visionModelId: string | null = vision.id;
@@ -281,18 +288,28 @@ export async function applyClawaiToHermes(
   // above just moved, so this sees the new value rather than a memo of the old.
   const respawnedMcpChildren = await refreshHermesImageTools(couldDrawBefore, await hermesAgentDrawsImages());
 
+  // And the providers the agent may switch to, which the credential just written
+  // added to the catalogue. ONE respawn across all three families: `reload.mcp`
+  // kills and respawns every MCP child and invalidates the model's prompt cache,
+  // and a link that moves three families is still one fact about one box — so if
+  // the image reconcile above already reloaded (or bounced, which respawns the
+  // children with the dashboard), this one reports rather than pays for a
+  // second. Whichever family asks first pays; the rest report.
+  const respawnedForProviders = await refreshProviderToolsIfSetChanged(
+    providersBefore,
+    await readUsableProviderIds(),
+    { alreadyReloaded: respawnedMcpChildren },
+  );
+
   // And the coding-agent family, which the token just written may have made
-  // runnable. ONE respawn between the two: `reload.mcp` kills and respawns every
-  // MCP child and invalidates the model's prompt cache, and a link that moves
-  // both families is still one fact about one box — so if the image reconcile
-  // above already reloaded (or bounced, which respawns the children with the
-  // dashboard), this one reports rather than pays for a second.
+  // runnable — last in the chain, so it sees whether either neighbour already
+  // paid for the respawn it needs.
   const codingReadyAfter = await codingAgentReady();
   if (codingReadyBefore !== null && codingReadyAfter !== null) {
     await refreshCodingAgentToolsIfReadinessChanged(
       codingReadyBefore,
       codingReadyAfter,
-      { alreadyReloaded: respawnedMcpChildren },
+      { alreadyReloaded: respawnedMcpChildren || respawnedForProviders },
     );
   }
 

--- a/src/lib/hermes-cloud-provider.ts
+++ b/src/lib/hermes-cloud-provider.ts
@@ -6,6 +6,7 @@ import {
   isAllowedProvider,
   scopeFromPayload,
 } from "@/lib/hermes-model-options";
+import { withProviderMcpRefresh } from "@/lib/provider-mcp-refresh";
 
 // Applying an API-key cloud provider to a HERMES device.
 //
@@ -59,6 +60,18 @@ export interface HermesCloudApplyResult {
  *   stderr can carry the binary path, and the key must never be echoed back.
  */
 export async function applyCloudProviderKeyToHermes(opts: {
+  openclawProvider: string;
+  apiKey: string;
+}): Promise<HermesCloudApplyResult> {
+  // Storing a key here credentials a provider the ClawBox MCP server has never
+  // heard of: it read the provider list ONCE, while it booted, and turned it
+  // into `ai_set_provider`'s enum. The wrapper samples that set either side of
+  // the work below and asks the agent to re-advertise only when it actually
+  // moved — see `provider-mcp-refresh.ts`.
+  return withProviderMcpRefresh(() => applyCloudProviderKey(opts));
+}
+
+async function applyCloudProviderKey(opts: {
   openclawProvider: string;
   apiKey: string;
 }): Promise<HermesCloudApplyResult> {

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -2,6 +2,7 @@ import { runHermesCli } from "@/lib/hermes-cli";
 import { get } from "@/lib/config-store";
 import { patchHermesConfig, readHermesConfigValue } from "@/lib/hermes-config-yaml";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
+import { withProviderMcpRefresh } from "@/lib/provider-mcp-refresh";
 import { getLocalAiToken } from "@/lib/local-ai-token";
 import { getDefaultLlamaCppModel } from "@/lib/llamacpp";
 import { getLocalAiOpenAiBaseUrl, getLocalAiProxyRootUrl } from "@/lib/local-ai-runtime";
@@ -38,6 +39,18 @@ export class HermesLocalApplyError extends Error {}
  * not silently take over from the provider the customer chose.
  */
 export async function applyLocalAiToHermes(options: {
+  provider: LocalAiProviderId;
+  model: string;
+  makeDefault?: boolean;
+}): Promise<{ provider: string; model: string }> {
+  // Registering the local model adds a provider to the list the ClawBox MCP
+  // server probed ONCE, at boot, and turned into `ai_set_provider`'s enum. The
+  // wrapper samples that set either side of the write and asks the agent to
+  // re-advertise only when it moved — see `provider-mcp-refresh.ts`.
+  return withProviderMcpRefresh(() => applyLocalAi(options));
+}
+
+async function applyLocalAi(options: {
   provider: LocalAiProviderId;
   model: string;
   makeDefault?: boolean;
@@ -118,7 +131,13 @@ export async function reconcileLocalAiWithHermes(): Promise<void> {
     const stored = await get("local_ai_model");
     // Stored as "llamacpp/gemma4-e2b-it-q4_0"; Hermes wants the bare id.
     const model = typeof stored === "string" ? stored.split("/").pop() || "" : "";
-    await applyLocalAiToHermes({ provider, model });
+    // The INNER write, deliberately — this one repair must not ask for an MCP
+    // reload. It hangs off `GET /setup-api/hermes/models`, and that route is
+    // what the agent's own `ai_list_models` reads: a `reload.mcp` from in here
+    // would shut down the very MCP child that is mid-tool-call. The enum
+    // catches up at the owner's next provider action or the next restart, which
+    // is what a box in this state has been doing all along.
+    await applyLocalAi({ provider, model });
   } catch (err) {
     // Never let a repair break the read it is attached to.
     console.error("[hermes-local-ai] reconcile failed:", err);
@@ -151,6 +170,13 @@ export function _resetLocalAiReconcileForTests(): void {
  * rather than leaving the device on nothing — off → on round-trips.
  */
 export async function removeLocalAiFromHermes(): Promise<{ wasDefault: boolean; model: string | null }> {
+  // The same bug pointing the other way: an enum still offering a provider the
+  // device no longer serves, which /setup-api/hermes/models answers with
+  // "Unknown provider".
+  return withProviderMcpRefresh(() => removeLocalAi());
+}
+
+async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | null }> {
   const activeProvider = await readHermesConfigValue("model.provider").catch(() => null);
   const wasDefault = activeProvider === HERMES_LOCAL_PROVIDER;
   const model = wasDefault ? await readHermesConfigValue("model.default").catch(() => null) : null;

--- a/src/lib/hermes-mcp-reload.ts
+++ b/src/lib/hermes-mcp-reload.ts
@@ -33,16 +33,41 @@ import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
 const RELOAD_PARAMS = { confirm: true } as const;
 
 /**
- * True when Hermes agreed to reload, false when it could not be asked.
+ * Statuses that mean the dashboard CARRIED THE RELOAD OUT.
+ *
+ * Deliberately generous on synonyms, because the two mistakes cost different
+ * things. Calling a real reload a refusal costs one honest log line on a box
+ * that is fine. Calling a refusal a reload costs the silence this whole
+ * mechanism exists to remove: the tool list stays stale, and the one line that
+ * would tell an operator so is the line that says the opposite.
+ */
+const ACTED_STATUSES = new Set(["ok", "reloaded", "success", "completed", "done"]);
+
+/**
+ * True when Hermes agreed to reload, false when it could not be asked OR said no.
  *
  * Never throws, and deliberately does not distinguish between the ways "no"
- * happens — no dashboard, a socket that died, an error frame. A caller that
- * cannot fix any of those does not benefit from telling them apart; what it
- * does with the false is say so in its own words.
+ * happens — no dashboard, a socket that died, an error frame, a dashboard that
+ * wants a human. A caller that cannot fix any of those does not benefit from
+ * telling them apart; what it does with the false is say so in its own words.
+ *
+ * READS THE VERDICT, NOT THE RETURN. `dashboardRpc` maps an error frame to null,
+ * so the transport cases were always honest — but `{ status: "confirm_required" }`
+ * is a perfectly ordinary non-error reply that means NOTHING HAPPENED (see
+ * `RELOAD_PARAMS`), and a `result !== null` test scored it as success. That is
+ * the "reported from the fact that a call returned, not from what it returned"
+ * shape, in the one helper all four refresh call sites depend on.
+ *
+ * A reply that names NO status stays a success: that is the historical reading,
+ * and only a frame that names a state is allowed to contradict it — a dashboard
+ * that answers `{}` must not start reporting a refusal that never happened.
  */
 export async function reloadMcpServers(): Promise<boolean> {
   const result = await dashboardRpc("reload.mcp", RELOAD_PARAMS).catch(() => null);
-  return result !== null;
+  if (result === null || result === undefined) return false;
+  const status = (result as { status?: unknown }).status;
+  if (typeof status !== "string") return true;
+  return ACTED_STATUSES.has(status.trim().toLowerCase());
 }
 
 /**

--- a/src/lib/provider-mcp-refresh.ts
+++ b/src/lib/provider-mcp-refresh.ts
@@ -42,6 +42,36 @@ export interface ProviderRefreshOptions {
 }
 
 /**
+ * How long a snapshot may take before it answers "I could not tell".
+ *
+ * `getModelOptions()` answers from an in-process SWR cache in the normal case
+ * and, on a warm dashboard, in 0.35-0.6 s when it does go out. Its own ceiling is
+ * `DASHBOARD_TIMEOUT_MS` (8 s), and this helper is taken TWICE inside a request
+ * the owner is holding open — so on a box whose dashboard is down, an unbounded
+ * pair could put sixteen seconds in front of a save that has already succeeded.
+ * Every helper in this family promises not to make the owner's save worse; this
+ * is what that promise costs here. A snapshot that misses the deadline is
+ * `null`, the guard declines to act on it, and the tool list catches up at the
+ * next restart — the behaviour of every box before this existed.
+ */
+const SNAPSHOT_TIMEOUT_MS = 3_000;
+
+/** Resolve with `null` rather than wait past the deadline. */
+async function withDeadline<T>(work: Promise<T>, ms: number): Promise<T | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      work,
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * The provider ids the MCP server would register its enum from right now, or
  * null when the catalogue could not be read.
  *
@@ -62,7 +92,11 @@ export interface ProviderRefreshOptions {
  */
 export async function readUsableProviderIds(): Promise<string[] | null> {
   try {
-    const payload = await getModelOptions();
+    // The promise is NOT abandoned by the deadline — it goes on to populate the
+    // catalogue cache, so a box that was merely slow is fast for the read on the
+    // other side of the write.
+    const payload = await withDeadline(getModelOptions(), SNAPSHOT_TIMEOUT_MS);
+    if (!payload) return null;
     const ids = payload.providers
       .filter((row) => typeof row.id === "string" && row.id && row.authenticated !== false)
       .map((row) => row.id);
@@ -181,15 +215,24 @@ export async function refreshProviderToolsIfSetChanged(
  * assumed from the fact that the write returned. Assuming it is the exact shape
  * this round of fixes exists to remove.
  *
- * `run`'s own failure is re-thrown untouched and asks for nothing: a write that
- * did not happen changed no set.
+ * `run`'s own failure is re-thrown untouched, but the comparison still happens —
+ * IN A `finally`, because "the write threw" is not the same as "nothing was
+ * written". `applyCloudProviderKeyToHermes` stores the credential with
+ * `hermes auth add` and only THEN tries to select a provider and a model, either
+ * of which can throw; the provider is credentialed by that point and the agent's
+ * enum is already stale. Reconciling only on success is exactly the
+ * sibling-left-unguarded shape this PR exists to close, one level up. A write
+ * that genuinely stored nothing costs nothing here: the sets match and the guard
+ * returns without asking for anything.
  */
 export async function withProviderMcpRefresh<T>(
   run: () => Promise<T>,
   options: ProviderRefreshOptions = {},
 ): Promise<T> {
   const before = await readUsableProviderIds();
-  const result = await run();
-  await refreshProviderToolsIfSetChanged(before, await readUsableProviderIds(), options);
-  return result;
+  try {
+    return await run();
+  } finally {
+    await refreshProviderToolsIfSetChanged(before, await readUsableProviderIds(), options);
+  }
 }

--- a/src/lib/provider-mcp-refresh.ts
+++ b/src/lib/provider-mcp-refresh.ts
@@ -90,6 +90,26 @@ function sameSet(a: readonly string[], b: readonly string[]): boolean {
 }
 
 /**
+ * What moved, in ids, for the log line.
+ *
+ * NAMES THEM rather than counting them, because the whole point of the line is
+ * to be actionable: "the agent cannot switch to anthropic" is a thing an
+ * operator can check, "2 providers rather than 1" is not. Provider ids are
+ * Hermes' own public slugs (`anthropic`, `openrouter`, `clawlocal`) — never a
+ * credential — and the list is bounded by the catalogue, so it cannot run away.
+ */
+function describeMove(before: readonly string[], after: readonly string[]): string {
+  const had = new Set(before);
+  const has = new Set(after);
+  const gained = after.filter((id) => !had.has(id));
+  const lost = before.filter((id) => !has.has(id));
+  const parts: string[] = [];
+  if (gained.length > 0) parts.push(`gained ${gained.join(", ")}`);
+  if (lost.length > 0) parts.push(`lost ${lost.join(", ")}`);
+  return `the providers this box can be switched to ${parts.join(" and ")}`;
+}
+
+/**
  * Reload the MCP servers, but ONLY if this request changed which providers the
  * agent may be handed.
  *
@@ -128,7 +148,7 @@ export async function refreshProviderToolsIfSetChanged(
   if (before === null || after === null) return options.alreadyReloaded === true;
   if (sameSet(before, after)) return options.alreadyReloaded === true;
 
-  const moved = `this box can now be switched to ${after.length} provider(s) rather than ${before.length}`;
+  const moved = describeMove(before, after);
   if (options.alreadyReloaded) {
     // Nothing to ask for: the respawn that already happened in this request
     // rebuilt EVERY family's tool list, this one included.

--- a/src/lib/provider-mcp-refresh.ts
+++ b/src/lib/provider-mcp-refresh.ts
@@ -1,0 +1,175 @@
+import { getModelOptions } from "@/lib/hermes-model-options";
+import { reloadMcpServers, reportMcpReloadRefused } from "@/lib/hermes-mcp-reload";
+
+/**
+ * Ask the agent to re-advertise WHICH PROVIDERS it may switch this device to,
+ * when a write changed the answer.
+ *
+ * WHY THIS EXISTS — the fourth of four. `mcp/lib/context.ts` probes this device
+ * ONCE while the ClawBox MCP server boots and builds four snapshots off it. Three
+ * have already been given a write path that refreshes them: the mailbox read
+ * tools (#486), the image tools (#503), the coding-agent family (#514). The
+ * fourth is `ctx.providers` (context.ts, from `/setup-api/hermes/models`), and it
+ * had none — the only `reloadMcpServers()` callers in the tree were the other
+ * three.
+ *
+ * IT IS NOT ADVISORY. `mcp/tools/ai.ts` makes that snapshot the `provider`
+ * parameter's `z.enum` and re-checks it in the handler, and the schema is the
+ * validation ("Closed sets are z.enum, never free text: the schema IS the
+ * validation, so a wrong value never reaches the device" — mcp/lib/schema.ts).
+ * So the owner pastes an Anthropic key, `/setup-api/hermes/provider-key` stores
+ * it and drops the catalogue cache because "the panel's very next request must
+ * see the provider as usable" — and the long-lived stdio MCP child keeps the enum
+ * it was born with. `ai_list_models` reads live and lists the new provider;
+ * `ai_set_provider` cannot be handed it and answers "That provider is not set up
+ * on this device", advising the agent to call `ai_list_models` — the step that
+ * just succeeded. It is #514's shape (the panel updated, the running agent
+ * stale) wearing #513's (advice that loops).
+ *
+ * The mechanism is the agent's own `reload.mcp`, shared with all three siblings —
+ * see `hermes-mcp-reload.ts`. What belongs HERE is the rule for when it is worth
+ * paying for.
+ */
+
+/** @see refreshProviderToolsIfSetChanged */
+export interface ProviderRefreshOptions {
+  /**
+   * True when something else in THIS request already respawned the box's MCP
+   * children. The reload is global — it rebuilds every family's tool list — so a
+   * second one would buy nothing and cost a second prompt-cache invalidation.
+   */
+  alreadyReloaded?: boolean;
+}
+
+/**
+ * The provider ids the MCP server would register its enum from right now, or
+ * null when the catalogue could not be read.
+ *
+ * COMPUTED THE SAME WAY `mcp/lib/context.ts` COMPUTES IT, deliberately: every
+ * row Hermes does not explicitly report as credential-less, plus the provider
+ * the device is actually on. The two must not drift — a set built to a different
+ * rule would either ask for a reload when nothing the agent can see moved (a
+ * prompt-cache invalidation the owner did not earn) or stay quiet when it did,
+ * which is the bug.
+ *
+ * `authenticated === null` means the SOURCE could not tell (Hermes' on-disk
+ * catalogue and the cold-start floor carry no auth state); those rows are kept,
+ * because the MCP server keeps them.
+ *
+ * THE NULL IS LOAD-BEARING and must never be folded into `[]`: an empty array
+ * reads as "this box offers nothing", and the next successful read would then
+ * look like a set change on a box nothing had happened to.
+ */
+export async function readUsableProviderIds(): Promise<string[] | null> {
+  try {
+    const payload = await getModelOptions();
+    const ids = payload.providers
+      .filter((row) => typeof row.id === "string" && row.id && row.authenticated !== false)
+      .map((row) => row.id);
+    // The provider the device is ACTUALLY on is always a legal target, even when
+    // it is absent from the credentialed catalogue — the Hermes CLI has
+    // meta-providers ("auto") the catalogue never lists, and context.ts seeds
+    // this for exactly that reason.
+    const current = payload.current?.provider;
+    if (typeof current === "string" && current && !ids.includes(current)) ids.push(current);
+    return ids;
+  } catch {
+    // A catalogue read that failed is an ordinary event on a box whose dashboard
+    // is down, and this runs on a path whose write has ALREADY happened. "I
+    // could not tell" is the honest answer and the guard below refuses to act on
+    // it.
+    return null;
+  }
+}
+
+/** Order-insensitive set equality — the enum is a set, not a list. */
+function sameSet(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const seen = new Set(a);
+  return b.every((id) => seen.has(id));
+}
+
+/**
+ * Reload the MCP servers, but ONLY if this request changed which providers the
+ * agent may be handed.
+ *
+ * The guard is the important half, for the same reason it is in every sibling: a
+ * reload kills and respawns every MCP child and invalidates the model's prompt
+ * cache, so the next turn re-sends and re-pays for a system prompt that was
+ * cached. Re-pasting a key the device already had, or saving a tier, changes
+ * nothing the agent can see and must cost nothing.
+ *
+ * BOTH DIRECTIONS. A set that SHRANK is the same bug pointing the other way —
+ * an enum still offering a provider the device no longer serves, which
+ * `/setup-api/hermes/models` answers with "Unknown provider".
+ *
+ * Never throws and never reports to the caller. The credential IS stored by the
+ * time this runs, an OpenClaw box has no dashboard to ask at all, and a box whose
+ * dashboard is down must not have the owner's save turned into an error by a
+ * best-effort refresh: the tool list catches up at the next restart, which is
+ * exactly the behaviour of every box before this existed.
+ *
+ * @param before what `readUsableProviderIds()` said BEFORE the write, or null
+ *               when it could not be read
+ * @param after  what it says after — the same catalogue `/setup-api/hermes/models`
+ *               serves the panel, so the agent's enum and the owner's picker
+ *               cannot disagree about what this box can be switched to
+ * @param options see `ProviderRefreshOptions`
+ * @returns true when the box's MCP children were respawned for this change — by
+ *          this call or by the one that already had. A caller that moves another
+ *          family in the same request passes it on so the second family does not
+ *          pay for a second global reload.
+ */
+export async function refreshProviderToolsIfSetChanged(
+  before: readonly string[] | null,
+  after: readonly string[] | null,
+  options: ProviderRefreshOptions = {},
+): Promise<boolean> {
+  if (before === null || after === null) return options.alreadyReloaded === true;
+  if (sameSet(before, after)) return options.alreadyReloaded === true;
+
+  const moved = `this box can now be switched to ${after.length} provider(s) rather than ${before.length}`;
+  if (options.alreadyReloaded) {
+    // Nothing to ask for: the respawn that already happened in this request
+    // rebuilt EVERY family's tool list, this one included.
+    console.log(`[hermes/provider-refresh] ${moved}; the MCP servers were already reloaded for this change`);
+    return true;
+  }
+  // `.catch` even though `reloadMcpServers` documents that it never throws: the
+  // "never throws" above is a promise made to the OWNER'S SAVE, which has already
+  // been written by the time this runs, and it must not depend on a neighbouring
+  // module keeping its own promise.
+  if (!(await reloadMcpServers().catch(() => false))) {
+    // Logged, not surfaced, and in the words that are true for this edition — an
+    // OpenClaw box has no dashboard to ask and needs no repair.
+    await reportMcpReloadRefused("hermes/provider-refresh", moved);
+    return false;
+  }
+  console.log(`[hermes/provider-refresh] ${moved}; asked the agent to reload its MCP servers`);
+  return true;
+}
+
+/**
+ * Snapshot → write → snapshot → reload iff the set moved, around any write that
+ * can change which providers this device offers.
+ *
+ * The wrapper exists so the SIX write paths that move this set cannot each get
+ * the ordering subtly different. The "after" read is deliberately taken AFTER
+ * `run` has finished, because every one of those paths ends by calling
+ * `invalidateModelOptions()` — so the read that follows sees the new catalogue
+ * rather than a memo of the old one, and the verdict is RE-READ rather than
+ * assumed from the fact that the write returned. Assuming it is the exact shape
+ * this round of fixes exists to remove.
+ *
+ * `run`'s own failure is re-thrown untouched and asks for nothing: a write that
+ * did not happen changed no set.
+ */
+export async function withProviderMcpRefresh<T>(
+  run: () => Promise<T>,
+  options: ProviderRefreshOptions = {},
+): Promise<T> {
+  const before = await readUsableProviderIds();
+  const result = await run();
+  await refreshProviderToolsIfSetChanged(before, await readUsableProviderIds(), options);
+  return result;
+}

--- a/src/tests/routes/hermes/clawai-coding-agent.test.ts
+++ b/src/tests/routes/hermes/clawai-coding-agent.test.ts
@@ -15,6 +15,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const store: Record<string, unknown> = {};
 const rpcMock = vi.hoisted(() => vi.fn());
 const statusMock = vi.hoisted(() => vi.fn());
+const optionsMock = vi.hoisted(() => vi.fn());
 
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(async (key: string) => store[key] ?? null),
@@ -30,7 +31,16 @@ vi.mock("@/lib/hermes-cli", () => ({
 // The box already draws, so the image family cannot be what asks for a reload
 // below — anything this test counts belongs to the coding-agent family.
 vi.mock("@/lib/harness/hermes-features", () => ({ hermesAgentDrawsImages: vi.fn(async () => true) }));
-vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/hermes-model-options", () => ({
+  invalidateModelOptions: vi.fn(),
+  // Connecting ClawBox AI also credentials the `clawai` provider, so the fourth
+  // boot-time snapshot — `ctx.providers` — moves on this path too. Answering
+  // the same catalogue either side of the write keeps THAT family out of the
+  // reload counts below, so anything this suite counts still belongs to the
+  // coding-agent family. The provider family has its own suite in
+  // src/tests/unit/provider-mcp-refresh.test.ts.
+  getModelOptions: optionsMock,
+}));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
@@ -67,10 +77,35 @@ function reloadCount(): number {
   return rpcMock.mock.calls.filter((call) => call[0] === "reload.mcp").length;
 }
 
+/** A catalogue that names the same providers before and after the write. */
+function unchangedCatalogue() {
+  return {
+    providers: [
+      {
+        id: "clawai",
+        name: "ClawBox AI",
+        authenticated: true,
+        verified: null,
+        isUserDefined: false,
+        source: "dashboard",
+        total: 1,
+        models: [{ id: "deepseek-v4-flash", description: "" }],
+      },
+    ],
+    current: { provider: "clawai", model: "deepseek-v4-flash" },
+    reasoning: "",
+    fetchedAt: Date.now(),
+    source: "dashboard" as const,
+    stale: false,
+  };
+}
+
 beforeEach(() => {
   for (const key of Object.keys(store)) delete store[key];
   rpcMock.mockReset();
   statusMock.mockReset();
+  optionsMock.mockReset();
+  optionsMock.mockImplementation(async () => unchangedCatalogue());
   rpcMock.mockImplementation(async (method: string) =>
     method === "image.generate" ? { available: true } : { status: "ok" },
   );
@@ -94,5 +129,25 @@ describe("POST /setup-api/hermes/clawai", () => {
     const response = await POST(post({ tier: "pro" }));
     expect(response.status).toBe(200);
     expect(reloadCount()).toBe(0);
+  });
+
+  it("still asks only ONCE when the link moves the providers too", async () => {
+    // Connecting ClawBox AI credentials the `clawai` provider AND makes the
+    // coding agent runnable. `reload.mcp` is global — it rebuilds every
+    // family's tool list — so a link that moves three families is still one
+    // fact about one box and must cost one prompt-cache invalidation.
+    let seen = 0;
+    optionsMock.mockImplementation(async () => {
+      const payload = unchangedCatalogue();
+      // Before the link this box had no credentialed provider and was on none.
+      if (seen++ === 0) {
+        payload.providers = [];
+        payload.current = { provider: "", model: "" };
+      }
+      return payload;
+    });
+    const response = await POST(post({ token: PASTED, tier: "flash" }));
+    expect(response.status).toBe(200);
+    expect(reloadCount()).toBe(1);
   });
 });

--- a/src/tests/routes/hermes/oauth-flows.test.ts
+++ b/src/tests/routes/hermes/oauth-flows.test.ts
@@ -22,6 +22,19 @@ vi.mock("@/lib/hermes-dashboard-auth", () => ({
   dashboardFetch: vi.fn(),
 }));
 
+// A completed sign-in also re-advertises the provider list to the running MCP
+// server, which reads the catalogue either side of the exchange. That is a
+// different property with its own suite
+// (src/tests/routes/hermes/provider-mcp-refresh.test.ts); here it is stubbed so
+// this one keeps pinning what it says it pins — the RELAY. The stub also keeps
+// the fixture honest: `dashboardFetch` is mocked with a single `Response`
+// INSTANCE per test, and a body can only be read once, so a second reader would
+// empty the reply the relay is being asserted on.
+vi.mock("@/lib/provider-mcp-refresh", () => ({
+  readUsableProviderIds: vi.fn(async () => null),
+  refreshProviderToolsIfSetChanged: vi.fn(async () => false),
+}));
+
 const SESSION_ID = "0f6c1c2e-1111-2222-3333-444455556666";
 
 /** Cookie header for the current fixture; set in beforeEach. */

--- a/src/tests/routes/hermes/provider-mcp-refresh.test.ts
+++ b/src/tests/routes/hermes/provider-mcp-refresh.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Adding a provider has to reach the RUNNING AGENT, not just the browser.
+ *
+ * `mcp/lib/context.ts` builds FOUR boot-time snapshots, and three of them have
+ * already been given a write path that refreshes them — the mailbox read tools
+ * (#486), the image tools (#503), the coding-agent family (#514). The fourth is
+ * `ctx.providers`, read once from `/setup-api/hermes/models` while the ClawBox
+ * MCP server starts, and it is NOT advisory: `mcp/tools/ai.ts` makes it the
+ * `provider` parameter's z.enum, and the schema IS the validation ("Closed sets
+ * are z.enum, never free text: the schema IS the validation, so a wrong value
+ * never reaches the device" — mcp/lib/schema.ts).
+ *
+ * So the owner pastes an Anthropic key, the route stores it and drops the
+ * catalogue cache so "the panel's very next request must see the provider as
+ * usable" — and the long-lived stdio MCP child keeps the enum it was born with.
+ * `ai_list_models` (a live read) then lists the provider that `ai_set_provider`
+ * cannot be handed, and the advice it gives back is the step that just failed.
+ *
+ * These pin the reload at the two write paths a customer reaches from Settings.
+ */
+
+const rpcMock = vi.hoisted(() => vi.fn());
+const cliMock = vi.hoisted(() => vi.fn());
+const optionsMock = vi.hoisted(() => vi.fn());
+const invalidateMock = vi.hoisted(() => vi.fn());
+const dashboardFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/hermes-dashboard-auth", () => ({ dashboardFetch: dashboardFetchMock }));
+vi.mock("@/lib/route-auth", () => ({ requireSession: vi.fn(async () => null) }));
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-model-options")>()),
+  getModelOptions: optionsMock,
+  invalidateModelOptions: invalidateMock,
+}));
+
+import { POST as providerKeyPost } from "@/app/setup-api/hermes/provider-key/route";
+import { POST as oauthSubmitPost } from "@/app/setup-api/hermes/oauth/submit/route";
+import { GET as oauthPollGet } from "@/app/setup-api/hermes/oauth/poll/route";
+
+/** A catalogue payload naming exactly these credentialed providers. */
+function catalogue(ids: string[], current = "openrouter") {
+  return {
+    providers: [
+      ...ids.map((id) => ({
+        id,
+        name: id,
+        authenticated: true,
+        verified: null,
+        isUserDefined: false,
+        source: "dashboard",
+        total: 1,
+        models: [{ id: `${id}-model`, description: "" }],
+      })),
+      // A row Hermes explicitly reports as having NO credentials. The MCP
+      // server drops those, so this suite must too — otherwise the "set" being
+      // compared is not the set the agent is holding.
+      {
+        id: "kimi-coding",
+        name: "kimi-coding",
+        authenticated: false,
+        verified: null,
+        isUserDefined: false,
+        source: "dashboard",
+        total: 0,
+        models: [],
+      },
+    ],
+    current: { provider: current, model: `${current}-model` },
+    reasoning: "",
+    fetchedAt: Date.now(),
+    source: "dashboard" as const,
+    stale: false,
+  };
+}
+
+/** How many GLOBAL MCP respawns this request asked the agent for. */
+function reloadCount(): number {
+  return rpcMock.mock.calls.filter((call) => call[0] === "reload.mcp").length;
+}
+
+/** Answer the "before" read with `first`, every later read with `second`. */
+function catalogueGrows(first: string[], second: string[], current = "openrouter") {
+  let seen = 0;
+  optionsMock.mockImplementation(async () => catalogue(seen++ === 0 ? first : second, current));
+}
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({ status: "ok" });
+  cliMock.mockReset();
+  cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  optionsMock.mockReset();
+  invalidateMock.mockReset();
+  dashboardFetchMock.mockReset();
+});
+
+function keyRequest(provider: string) {
+  return new Request("http://localhost/setup-api/hermes/provider-key", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider, apiKey: "sk-abcdefghijklmnop" }),
+  });
+}
+
+describe("pasting a provider API key", () => {
+  it("asks the agent to re-advertise its providers when the set grew", async () => {
+    catalogueGrows(["openrouter"], ["openrouter", "anthropic"]);
+    const res = await providerKeyPost(keyRequest("anthropic"));
+    expect(res.status).toBe(200);
+    expect(reloadCount()).toBe(1);
+    expect(rpcMock).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("does not pay for a reload when the same provider is re-keyed", async () => {
+    // A reload respawns every MCP child and invalidates the model's prompt
+    // cache. Rotating a key the device already had changes nothing the agent
+    // can see, so it must cost nothing.
+    catalogueGrows(["openrouter", "anthropic"], ["openrouter", "anthropic"]);
+    await providerKeyPost(keyRequest("anthropic"));
+    expect(reloadCount()).toBe(0);
+  });
+
+  it("asks for nothing when the key was refused", async () => {
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "nope" });
+    catalogueGrows(["openrouter"], ["openrouter", "anthropic"]);
+    const res = await providerKeyPost(keyRequest("anthropic"));
+    expect(res.status).toBe(502);
+    expect(reloadCount()).toBe(0);
+  });
+
+  it("still saves the key when the agent will not reload", async () => {
+    // Best effort, exactly like its three siblings: the credential IS stored,
+    // and a box whose dashboard is down must not have the owner's save turned
+    // into an error by a refresh.
+    catalogueGrows(["openrouter"], ["openrouter", "anthropic"]);
+    rpcMock.mockResolvedValue(null);
+    const res = await providerKeyPost(keyRequest("anthropic"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true });
+  });
+});
+
+describe("completing a provider OAuth sign-in", () => {
+  function submitRequest() {
+    return new Request("http://localhost/setup-api/hermes/oauth/submit", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ providerId: "nous", sessionId: "abcdefgh1234", code: "the-code" }),
+    });
+  }
+
+  it("re-advertises the providers when a pasted code completed the exchange", async () => {
+    catalogueGrows(["openrouter"], ["openrouter", "nous"]);
+    dashboardFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: true, status: "connected" }), { status: 200 }),
+    );
+    const res = await oauthSubmitPost(submitRequest());
+    expect(res.status).toBe(200);
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("asks for nothing when the exchange failed", async () => {
+    catalogueGrows(["openrouter"], ["openrouter", "nous"]);
+    dashboardFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ ok: false, status: "error", message: "bad code" }), { status: 200 }),
+    );
+    await oauthSubmitPost(submitRequest());
+    expect(reloadCount()).toBe(0);
+  });
+
+  function pollRequest() {
+    return new Request(
+      "http://localhost/setup-api/hermes/oauth/poll?providerId=nous&sessionId=abcdefgh1234",
+    );
+  }
+
+  it("re-advertises the providers on the approved device-code tick", async () => {
+    catalogueGrows(["openrouter"], ["openrouter", "nous"]);
+    dashboardFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ session_id: "abcdefgh1234", status: "approved" }), { status: 200 }),
+    );
+    const res = await oauthPollGet(pollRequest());
+    expect(res.status).toBe(200);
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("asks the agent for nothing on a pending tick", async () => {
+    // This route is polled every few seconds for the length of a device-code
+    // flow, so anything it does per tick is paid for once per tick. The
+    // snapshot is a read of the SWR-cached catalogue; the RELOAD — every MCP
+    // child respawned and the model's prompt cache invalidated — is what must
+    // never happen more than once per flow.
+    catalogueGrows(["openrouter"], ["openrouter"]);
+    dashboardFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ session_id: "abcdefgh1234", status: "pending" }), { status: 200 }),
+    );
+    await oauthPollGet(pollRequest());
+    expect(reloadCount()).toBe(0);
+  });
+
+  it("does not charge a client that keeps polling a finished session", async () => {
+    // "approved" is not a one-shot: a client that never stops polling gets it
+    // back on every tick. The set comparison is what makes the second one free.
+    optionsMock.mockImplementation(async () => catalogue(["openrouter", "nous"]));
+    dashboardFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ session_id: "abcdefgh1234", status: "approved" }), { status: 200 }),
+    );
+    await oauthPollGet(pollRequest());
+    await oauthPollGet(pollRequest());
+    expect(reloadCount()).toBe(0);
+  });
+});

--- a/src/tests/unit/coding-agent-mcp-refresh.test.ts
+++ b/src/tests/unit/coding-agent-mcp-refresh.test.ts
@@ -142,4 +142,19 @@ describe("refreshCodingAgentToolsIfReadinessChanged", () => {
     await refreshCodingAgentToolsIfReadinessChanged(false, true);
     expect(logSpy).not.toHaveBeenCalled();
   });
+
+  it("does not claim success when the dashboard only asked for confirmation", async () => {
+    // The same shape one layer down, and the reason it survived: an error frame
+    // becomes null, but `{ status: "confirm_required" }` is a perfectly ordinary
+    // non-error reply that means `reload.mcp` DID NOTHING — it is what the
+    // dashboard answers when `approvals.mcp_reload_confirm` wants a human. A
+    // helper that reads "a frame came back" as "it worked" then logs "asked the
+    // agent to reload its MCP servers" over a box whose tool list never moved,
+    // and the one line that would tell an operator #514's bug is still
+    // happening is the line that says it isn't.
+    mockRpc.mockResolvedValue({ status: "confirm_required" });
+    await refreshCodingAgentToolsIfReadinessChanged(false, true);
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
 });

--- a/src/tests/unit/hermes-mcp-reload-verdict.test.ts
+++ b/src/tests/unit/hermes-mcp-reload-verdict.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * `reloadMcpServers()` has to report the DASHBOARD'S VERDICT, not the fact that
+ * a frame came back.
+ *
+ * The whole point of the helper is that three families — the mailbox read tools
+ * (#486), the image tools (#503) and the coding-agent family (#514) — are
+ * registered off a probe the MCP server runs ONCE at boot, and the only way to
+ * make a running agent re-probe is Hermes' `reload.mcp`. That call is gated by
+ * `approvals.mcp_reload_confirm`, and a dashboard that wants a confirmation
+ * answers `{ status: "confirm_required" }` AND DOES NOTHING. It is a perfectly
+ * ordinary, non-error reply, so a helper that reads "not null" as "it worked"
+ * logs "asked the agent to reload its MCP servers" over a box whose tool list
+ * never moved — and the one line that would have told an operator the bug is
+ * still happening is the line that says it isn't.
+ */
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: vi.fn() }));
+
+import { reloadMcpServers } from "@/lib/hermes-mcp-reload";
+import { dashboardRpc } from "@/lib/hermes-dashboard-rpc";
+
+const mockRpc = vi.mocked(dashboardRpc);
+
+beforeEach(() => {
+  mockRpc.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("reloadMcpServers", () => {
+  it("reports the documented confirmation gate as a refusal", async () => {
+    // The reply this module's own RELOAD_PARAMS doc describes: the dashboard
+    // asked rather than acted.
+    mockRpc.mockResolvedValue({ status: "confirm_required" });
+    await expect(reloadMcpServers()).resolves.toBe(false);
+  });
+
+  it("reports any other named non-acting status as a refusal", async () => {
+    for (const status of ["error", "denied", "unauthorized", "busy"]) {
+      mockRpc.mockResolvedValue({ status });
+      await expect(reloadMcpServers()).resolves.toBe(false);
+    }
+  });
+
+  it("still reports a plain acknowledgement as success", async () => {
+    mockRpc.mockResolvedValue({ status: "ok" });
+    await expect(reloadMcpServers()).resolves.toBe(true);
+  });
+
+  it("accepts the synonyms a reload can acknowledge with", async () => {
+    for (const status of ["reloaded", "success", "completed", "OK", " ok "]) {
+      mockRpc.mockResolvedValue({ status });
+      await expect(reloadMcpServers()).resolves.toBe(true);
+    }
+  });
+
+  it("does not invent a refusal out of a reply that names no status", async () => {
+    // The historical shape, and the one this helper has always read as success.
+    // Only a reply that NAMES a state is allowed to contradict it — otherwise a
+    // dashboard that answers `{}` or `true` would start reporting a refusal that
+    // did not happen, which is the false alarm the sibling helpers are careful
+    // to avoid.
+    for (const result of [{}, { servers: 3 }, true, "reloaded"]) {
+      mockRpc.mockResolvedValue(result);
+      await expect(reloadMcpServers()).resolves.toBe(true);
+    }
+  });
+
+  it("still reports a transport failure as a refusal", async () => {
+    mockRpc.mockResolvedValue(null);
+    await expect(reloadMcpServers()).resolves.toBe(false);
+    mockRpc.mockRejectedValue(new Error("socket exploded"));
+    await expect(reloadMcpServers()).resolves.toBe(false);
+  });
+});

--- a/src/tests/unit/provider-mcp-refresh.test.ts
+++ b/src/tests/unit/provider-mcp-refresh.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The fourth boot-time snapshot, and the rule for when refreshing it is worth
+ * paying for.
+ *
+ * `mcp/lib/context.ts` computes `ctx.providers` as "every row Hermes does NOT
+ * report as credential-less, plus the provider the device is actually on". This
+ * module has to compute the same set from the same payload, because the moment
+ * the two disagree the guard either fires when nothing moved (a prompt-cache
+ * invalidation the owner did not earn) or stays quiet when it did (the bug).
+ */
+
+const rpcMock = vi.hoisted(() => vi.fn());
+const optionsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-model-options")>()),
+  getModelOptions: optionsMock,
+}));
+
+import {
+  readUsableProviderIds,
+  refreshProviderToolsIfSetChanged,
+} from "@/lib/provider-mcp-refresh";
+
+interface Row {
+  id: string;
+  authenticated: boolean | null;
+}
+
+function payload(rows: Row[], current = "openrouter") {
+  return {
+    providers: rows.map((row) => ({
+      ...row,
+      name: row.id,
+      verified: null,
+      isUserDefined: false,
+      source: "dashboard",
+      total: 1,
+      models: [],
+    })),
+    current: { provider: current, model: "m" },
+    reasoning: "",
+    fetchedAt: Date.now(),
+    source: "dashboard" as const,
+    stale: false,
+  };
+}
+
+let logSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({ status: "ok" });
+  optionsMock.mockReset();
+  logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  logSpy.mockRestore();
+  errorSpy.mockRestore();
+});
+
+describe("readUsableProviderIds", () => {
+  it("reads the same set the MCP server registered its enum from", async () => {
+    optionsMock.mockResolvedValue(
+      payload(
+        [
+          { id: "openrouter", authenticated: true },
+          // `null` means the SOURCE could not tell (the on-disk catalogue and
+          // the cold-start floor carry no auth state). The MCP server keeps
+          // those, so this must too.
+          { id: "nous", authenticated: null },
+          { id: "kimi-coding", authenticated: false },
+        ],
+        "openrouter",
+      ),
+    );
+    expect(await readUsableProviderIds()).toEqual(["openrouter", "nous"]);
+  });
+
+  it("keeps the provider the device is actually on, credentialed or not", async () => {
+    // The Hermes CLI has meta-providers ("auto") the credentialed catalogue
+    // never lists. `mcp/lib/context.ts` seeds the current one for exactly that
+    // reason — without it `ai_set_provider` was a one-way door — so leaving it
+    // out here would make every switch onto one look like a set change.
+    optionsMock.mockResolvedValue(
+      payload([{ id: "openrouter", authenticated: true }], "auto"),
+    );
+    expect(await readUsableProviderIds()).toEqual(["openrouter", "auto"]);
+  });
+
+  it("answers null rather than a wrong set when the catalogue cannot be read", async () => {
+    // Null is "I could not tell", and the guard below refuses to act on it. An
+    // empty array here would read as "this box has no providers" and ask for a
+    // reload on the next successful read of a box nothing had happened to.
+    optionsMock.mockRejectedValue(new Error("dashboard down"));
+    expect(await readUsableProviderIds()).toBeNull();
+  });
+});
+
+describe("refreshProviderToolsIfSetChanged", () => {
+  it("does nothing when the set is the same, whatever the order", async () => {
+    expect(
+      await refreshProviderToolsIfSetChanged(["a", "b"], ["b", "a"]),
+    ).toBe(false);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("reloads when a provider becomes offerable", async () => {
+    expect(await refreshProviderToolsIfSetChanged(["a"], ["a", "b"])).toBe(true);
+    expect(rpcMock).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("reloads when a provider stops being offerable", async () => {
+    // A stale enum that still offers a provider the device no longer has is the
+    // same bug pointing the other way: `ai_set_provider` accepts it and
+    // `/setup-api/hermes/models` answers "Unknown provider".
+    expect(await refreshProviderToolsIfSetChanged(["a", "b"], ["a"])).toBe(true);
+    expect(rpcMock).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+  });
+
+  it("refuses to act on a snapshot it does not have", async () => {
+    expect(await refreshProviderToolsIfSetChanged(null, ["a"])).toBe(false);
+    expect(await refreshProviderToolsIfSetChanged(["a"], null)).toBe(false);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("does not ask twice when something already respawned the MCP children", async () => {
+    expect(
+      await refreshProviderToolsIfSetChanged(["a"], ["a", "b"], { alreadyReloaded: true }),
+    ).toBe(true);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("does not claim success when the dashboard refused", async () => {
+    rpcMock.mockResolvedValue(null);
+    expect(await refreshProviderToolsIfSetChanged(["a"], ["a", "b"])).toBe(false);
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does not claim success when the dashboard only asked for confirmation", async () => {
+    // The reply `reload.mcp` gives when `approvals.mcp_reload_confirm` wants a
+    // human: a perfectly ordinary, non-error frame over a box whose tool list
+    // never moved.
+    rpcMock.mockResolvedValue({ status: "confirm_required" });
+    expect(await refreshProviderToolsIfSetChanged(["a"], ["a", "b"])).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("never throws, whatever the RPC does", async () => {
+    rpcMock.mockRejectedValue(new Error("socket exploded"));
+    await expect(
+      refreshProviderToolsIfSetChanged(["a"], ["a", "b"]),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/tests/unit/provider-mcp-refresh.test.ts
+++ b/src/tests/unit/provider-mcp-refresh.test.ts
@@ -95,6 +95,23 @@ describe("readUsableProviderIds", () => {
     expect(await readUsableProviderIds()).toEqual(["openrouter", "auto"]);
   });
 
+  it("gives up rather than hold the owner's save open", async () => {
+    // Taken twice per write, inside a request the owner is waiting on, and
+    // `getModelOptions`' own ceiling is eight seconds. A box whose dashboard is
+    // down must not turn a save that already succeeded into a sixteen-second
+    // one; missing the deadline is "I could not tell", and the guard declines to
+    // act on that.
+    vi.useFakeTimers();
+    try {
+      optionsMock.mockImplementation(() => new Promise(() => {}));
+      const pending = readUsableProviderIds();
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(await pending).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("answers null rather than a wrong set when the catalogue cannot be read", async () => {
     // Null is "I could not tell", and the guard below refuses to act on it. An
     // empty array here would read as "this box has no providers" and ask for a

--- a/src/tests/unit/provider-mcp-refresh.test.ts
+++ b/src/tests/unit/provider-mcp-refresh.test.ts
@@ -112,17 +112,21 @@ describe("refreshProviderToolsIfSetChanged", () => {
     expect(rpcMock).not.toHaveBeenCalled();
   });
 
-  it("reloads when a provider becomes offerable", async () => {
-    expect(await refreshProviderToolsIfSetChanged(["a"], ["a", "b"])).toBe(true);
+  it("reloads when a provider becomes offerable, and names it", async () => {
+    expect(await refreshProviderToolsIfSetChanged(["openrouter"], ["openrouter", "anthropic"])).toBe(true);
     expect(rpcMock).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+    // The line has to be actionable. "the agent cannot switch to anthropic" is
+    // something an operator can go and check; "2 providers rather than 1" is not.
+    expect(String(logSpy.mock.calls[0][0])).toContain("gained anthropic");
   });
 
-  it("reloads when a provider stops being offerable", async () => {
+  it("reloads when a provider stops being offerable, and names that too", async () => {
     // A stale enum that still offers a provider the device no longer has is the
     // same bug pointing the other way: `ai_set_provider` accepts it and
     // `/setup-api/hermes/models` answers "Unknown provider".
-    expect(await refreshProviderToolsIfSetChanged(["a", "b"], ["a"])).toBe(true);
+    expect(await refreshProviderToolsIfSetChanged(["openrouter", "clawlocal"], ["openrouter"])).toBe(true);
     expect(rpcMock).toHaveBeenCalledWith("reload.mcp", { confirm: true });
+    expect(String(logSpy.mock.calls[0][0])).toContain("lost clawlocal");
   });
 
   it("refuses to act on a snapshot it does not have", async () => {

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The OTHER four write paths that move the provider set.
+ *
+ * The customer-facing pair (`/setup-api/hermes/provider-key` and the OAuth
+ * completion) is pinned in src/tests/routes/hermes/provider-mcp-refresh.test.ts.
+ * These are the rest of what
+ *
+ *   grep -rn "invalidateModelOptions()" src mcp --include=*.ts | grep -v /tests/
+ *
+ * finds — every place that already tells the BROWSER the catalogue moved, which
+ * is exactly the population that has to tell the running agent too. Wiring four
+ * of six is how #514 came back as a residual in the first place.
+ */
+
+const rpcMock = vi.hoisted(() => vi.fn());
+const cliMock = vi.hoisted(() => vi.fn());
+const optionsMock = vi.hoisted(() => vi.fn());
+const patchMock = vi.hoisted(() => vi.fn());
+const readConfigMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/config-store", () => ({ get: vi.fn(async () => null), setMany: vi.fn() }));
+vi.mock("@/lib/hermes-config-yaml", () => ({
+  patchHermesConfig: patchMock,
+  readHermesConfigValue: readConfigMock,
+}));
+vi.mock("@/lib/local-ai-token", () => ({ getLocalAiToken: () => "local-token-xyz" }));
+vi.mock("@/lib/local-ai-runtime", () => ({
+  getLocalAiProxyRootUrl: () => "http://127.0.0.1",
+  getLocalAiOpenAiBaseUrl: () => "http://127.0.0.1/setup-api/local-ai/ollama/v1",
+}));
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-model-options")>()),
+  getModelOptions: optionsMock,
+  invalidateModelOptions: vi.fn(),
+}));
+
+import { applyCloudProviderKeyToHermes } from "@/lib/hermes-cloud-provider";
+import { applyLocalAiToHermes, removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
+
+function payload(ids: string[], current = "openrouter") {
+  return {
+    providers: ids.map((id) => ({
+      id,
+      name: id,
+      authenticated: true,
+      verified: null,
+      isUserDefined: false,
+      source: "dashboard",
+      total: 1,
+      models: [{ id: `${id}-model`, description: "" }],
+    })),
+    current: { provider: current, model: `${current}-model` },
+    reasoning: "",
+    fetchedAt: Date.now(),
+    source: "dashboard" as const,
+    stale: false,
+  };
+}
+
+/** Answer the "before" read with `first`, every later read with `second`. */
+function catalogueGrows(first: string[], second: string[], current = "openrouter") {
+  let seen = 0;
+  optionsMock.mockImplementation(async () => payload(seen++ === 0 ? first : second, current));
+}
+
+function reloadCount(): number {
+  return rpcMock.mock.calls.filter((call) => call[0] === "reload.mcp").length;
+}
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({ status: "ok" });
+  cliMock.mockReset();
+  cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  optionsMock.mockReset();
+  patchMock.mockReset();
+  patchMock.mockResolvedValue(undefined);
+  readConfigMock.mockReset();
+  readConfigMock.mockResolvedValue(null);
+});
+
+describe("saving a cloud provider key through the OpenClaw-shaped panel", () => {
+  it("re-advertises the providers the agent may switch to", async () => {
+    catalogueGrows(["openrouter"], ["openrouter", "anthropic"], "openrouter");
+    await applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-abcdefgh" });
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("asks for nothing when hermes refused the key", async () => {
+    catalogueGrows(["openrouter"], ["openrouter", "anthropic"]);
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "nope" });
+    await expect(
+      applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-abcdefgh" }),
+    ).rejects.toThrow();
+    expect(reloadCount()).toBe(0);
+  });
+});
+
+describe("turning the local model on and off", () => {
+  it("re-advertises the providers when the local one is registered", async () => {
+    catalogueGrows(["openrouter"], ["openrouter", "local"], "openrouter");
+    await applyLocalAiToHermes({ provider: "ollama", model: "gemma4:e2b", makeDefault: false });
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("re-advertises the providers when the local one is removed", async () => {
+    // The stale enum pointing the other way: an `ai_set_provider` value the
+    // device no longer serves, which `/setup-api/hermes/models` answers with
+    // "Unknown provider".
+    catalogueGrows(["openrouter", "local"], ["openrouter"], "openrouter");
+    await removeLocalAiFromHermes();
+    expect(reloadCount()).toBe(1);
+  });
+
+  it("costs nothing when the set did not actually move", async () => {
+    catalogueGrows(["openrouter", "local"], ["openrouter", "local"], "openrouter");
+    await applyLocalAiToHermes({ provider: "ollama", model: "gemma4:e2b", makeDefault: false });
+    expect(reloadCount()).toBe(0);
+  });
+});

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -92,12 +92,31 @@ describe("saving a cloud provider key through the OpenClaw-shaped panel", () => 
   });
 
   it("asks for nothing when hermes refused the key", async () => {
-    catalogueGrows(["openrouter"], ["openrouter", "anthropic"]);
+    // `hermes auth add` failed, so nothing was credentialed — and the catalogue
+    // says so. The set is what decides, not the fact that a call threw.
+    catalogueGrows(["openrouter"], ["openrouter"]);
     cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "nope" });
     await expect(
       applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-abcdefgh" }),
     ).rejects.toThrow();
     expect(reloadCount()).toBe(0);
+  });
+
+  it("still re-advertises when the key landed and a LATER step threw", async () => {
+    // The credential is stored first, and selecting the provider or the model
+    // can still fail after it. The provider is credentialed by then and the
+    // agent's enum is already stale, so reconciling only on success would be
+    // this PR's own bug one level up.
+    catalogueGrows(["openrouter"], ["openrouter", "anthropic"], "openrouter");
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[0] === "auth"
+        ? { code: 0, stdout: "", stderr: "" }
+        : { code: 1, stdout: "", stderr: "could not select" },
+    );
+    await expect(
+      applyCloudProviderKeyToHermes({ openclawProvider: "anthropic", apiKey: "sk-abcdefgh" }),
+    ).rejects.toThrow();
+    expect(reloadCount()).toBe(1);
   });
 });
 


### PR DESCRIPTION
Closes the two residuals left on #514 by the adversarial verifiers. Both reproduced against the merged beta head (`c92eec34`) before anything was written.

## MCP-01a — the fourth boot snapshot had no write path (customer-facing)

`mcp/lib/context.ts` probes this device **once**, while the ClawBox MCP server boots, and builds four snapshots off that probe. Three had already been given a write path that refreshes them: the mailbox read tools (#486), the image tools (#503), the coding-agent family (#514). The fourth is `ctx.providers`, read from `/setup-api/hermes/models`, and it had none — the only `reloadMcpServers()` callers in the tree were those three.

It is **not advisory**. `mcp/tools/ai.ts:208` makes it `ai_set_provider`'s `provider` parameter's `z.enum` and re-checks it at `:225`, and `mcp/lib/schema.ts` says why that matters: *"Closed sets are z.enum, never free text: the schema IS the validation, so a wrong value never reaches the device."*

So on a Hermes box today:

1. The owner pastes an Anthropic / OpenRouter / Gemini key in Settings.
2. `/setup-api/hermes/provider-key` stores it and calls `invalidateModelOptions()` — with the comment *"the panel's very next request must see the provider as usable"*. The browser is told.
3. The long-lived stdio MCP child is not, and keeps the enum it was born with.
4. `ai_list_models` reads live and lists the new provider. `ai_set_provider` cannot be handed the id at all, and the advice it gives back is *"Call ai_list_models and use one of the ids in its providers list"* — the step that just succeeded.

That is #514's shape (panel updated, running agent stale) wearing #513's (advice that loops), and it lasts until something unrelated respawns the MCP server.

### The class, and how I know I found every sibling

The bug is not "the provider-key route forgot a call". It is **every write path that changes which providers this device offers must tell the running agent, not only the browser** — and the population of those paths is exactly the population that already tells the browser:

```
grep -rn "invalidateModelOptions()" --include=*.ts --include=*.tsx src mcp | grep -v "/tests/"
```

Nine hits, one of them the definition. All eight call sites, classified:

| site | moves | wired |
|---|---|---|
| `setup-api/hermes/provider-key/route.ts:98` | credential (`hermes auth add`) | yes |
| `setup-api/hermes/oauth/submit/route.ts:68` | credential (PKCE completed) | yes |
| `setup-api/hermes/oauth/poll/route.ts:59` | credential (device code approved) | yes |
| `lib/hermes-cloud-provider.ts:101,143` | credential (`hermes auth add`) | yes, once around the whole apply |
| `lib/hermes-local-ai.ts:90` | registers the local provider | yes |
| `lib/hermes-local-ai.ts:186` | removes the local provider | yes — the same bug pointing the other way |
| `lib/hermes-clawai.ts:267` | credentials `clawai` | yes, chained with its two neighbours |
| `setup-api/hermes/models/route.ts:293` | **selection only** | **no, deliberately — see below** |

The last one is the interesting exclusion and it is commented in place. It moves the *selection*, not credentials, and every provider it accepts had to be in the set already (`isAllowedProvider`). More to the point, **it is the route `ai_set_provider` itself POSTs to** — a global `reload.mcp` from in there would shut down the very MCP child that is mid-call. The same hazard applies to `reconcileLocalAiWithHermes()`, the once-per-process legacy repair that hangs off `GET /setup-api/hermes/models` (which `ai_list_models` reads), so that path calls the inner write and skips the refresh; both say so in the code.

### The fix

New `src/lib/provider-mcp-refresh.ts`, modelled on `coding-agent-mcp-refresh.ts`:

- `readUsableProviderIds()` computes the set **the same way `mcp/lib/context.ts` computes it** — every row Hermes does not explicitly report as credential-less, plus the provider the device is actually on (the meta-provider seed, without which `ai_set_provider` was a one-way door). It answers `null`, never `[]`, when the catalogue cannot be read; `[]` would read as "this box offers nothing" and make the next successful read look like a change.
- `refreshProviderToolsIfSetChanged(before, after, { alreadyReloaded })` reloads **only when the set actually moved** — the prompt-cache rule the existing helpers document, so re-pasting a key the device already had, or saving a tier, costs nothing. It returns whether the children were respawned, so a request that moves several families pays for one global reload rather than three.
- `withProviderMcpRefresh(run)` is the snapshot → write → snapshot wrapper for the library paths. The **after** value is re-read rather than assumed from the fact the write returned — assuming it is precisely the shape this round of fixes exists to remove.

## MCP-01b — `reloadMcpServers()` scored a refusal as a success

`src/lib/hermes-mcp-reload.ts:45` was `return result !== null` over `dashboardRpc`'s raw result. The transport cases were honest (an error frame already becomes `null` at `hermes-dashboard-rpc.ts:128`), but the module's own `RELOAD_PARAMS` doc names one non-error reply that means the reload **did not run**: *"`reload.mcp` is gated by `approvals.mcp_reload_confirm` … without this the dashboard answers `{ status: "confirm_required" }` and does nothing."* That body is non-null, so it scored as success — `coding-agent-mcp-refresh.ts` logged *"asked the agent to reload its MCP servers"*, the tool list stayed stale, and the one line that would tell an operator #514's bug was still happening said the opposite.

It reads the verdict now. A reply that names **no** status stays a success (the historical reading — a dashboard answering `{}` must not start reporting a refusal that never happened); a reply that names one is a success only if the name says it acted. The acted list is deliberately generous on synonyms because the two mistakes cost different things: calling a real reload a refusal costs one honest log line, calling a refusal a reload costs the silence this whole mechanism exists to remove.

This lands in the shared helper, so all four refresh call sites get it at once — `grep -rn "reloadMcpServers(" --include=*.ts src mcp | grep -v "/tests/"` now shows four callers and the definition.

For completeness on the same class, `grep -rn "dashboardRpc(" --include=*.ts src mcp | grep -v "/tests/"` finds three callers: `runningAgentCanDraw` already reads the frame (`typeof result?.available === "boolean"`), the `reload.env` call discards the result and claims nothing, and this one was the outlier.

### Not verified on a box

I could not reproduce the `confirm_required` reply against hardware — 192.168.1.47 was unreachable for the whole session, and Hermes' gating behaviour lives outside this repo. What is pinned here is the code path, exactly as the residual scoped it.

## Tests — red first

Every case below was proven to fail against unmodified `origin/beta` before the fix was written.

| suite | red on `origin/beta` | green |
|---|---|---|
| `src/tests/routes/hermes/provider-mcp-refresh.test.ts` (new) | 3 of 9 | 9 of 9 |
| `src/tests/unit/provider-mcp-refresh.test.ts` (new) | 12 of 12 — the whole file fails to resolve, the module does not exist | 12 of 12 |
| `src/tests/unit/provider-write-paths.test.ts` (new) | 4 of 6 | 6 of 6 |
| `src/tests/unit/hermes-mcp-reload-verdict.test.ts` (new) | 2 of 6 | 6 of 6 |
| `src/tests/unit/coding-agent-mcp-refresh.test.ts` (+1 case) | 1 of 12 | 12 of 12 |
| `src/tests/routes/hermes/clawai-coding-agent.test.ts` (+1 guard) | 0 — it guards the one-respawn rule the change could break | 3 of 3 |

**22 red → 48 green.**

The "green only" cases in the new files are the guards that make the fix affordable rather than merely present: no reload when the same provider is re-keyed, none when the key was refused, none on a pending poll tick, none for a client that keeps polling a finished session, none from a snapshot the box could not read, one respawn — not three — when a ClawBox AI link moves drawing, the coding agent and the providers together, and a snapshot that misses its deadline rather than holding the owner's save open.

`src/tests/routes/hermes/oauth-flows.test.ts` gained a stub for the new helper. That suite pins the **relay**, and its fixture mocks `dashboardFetch` with a single `Response` *instance* per test — a body can only be read once, so a second reader empties the reply being asserted on. The refresh has its own suite.

## Baselines

- `tsc --noEmit -p tsconfig.json`: **24 errors, same 24 as `origin/beta`**, none in touched files.
- `tsc -p mcp/tsconfig.json`: **3 errors, same 3 as `origin/beta`**.
- `eslint`: **182 problems (99 errors, 83 warnings)** — byte-identical to `origin/beta`; the touched files contribute one pre-existing unused-import warning in `hermes-clawai.ts`.
- Local full-suite failures are Windows-only and pre-existing on clean `origin/beta` (`skills-secrets` asserts mode `0600`). Linux CI is the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider changes now refresh available MCP tools when the provider catalogue changes.
  * API-key and OAuth setup flows refresh tools only after successful provider updates.
  * Local provider registration and removal keep provider tools synchronized.

* **Bug Fixes**
  * MCP reload results now distinguish successful, pending, refused, missing, and statusless responses.
  * Failed credential exchanges no longer trigger unnecessary refreshes.
  * Credential saving continues even if tool refresh fails.

* **Tests**
  * Added coverage for provider changes, OAuth polling, reload outcomes, and duplicate refresh prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



---

## Review round

Two findings from CodeRabbit, both correct, both fixed in `240908e3`.

**The refresh was skipped when a write threw halfway.** `applyCloudProviderKeyToHermes` stores the credential with `hermes auth add` and only then selects a provider and a model, either of which can throw — the provider is credentialed by that point and the agent's enum is already stale, but `withProviderMcpRefresh` only reconciled on success. That is this PR's own bug one level up, so it earns a regression case: *"still re-advertises when the key landed and a LATER step threw"*. Its neighbour, *"asks for nothing when hermes refused the key"*, was corrected at the same time to model reality — if `auth add` failed the catalogue does not gain the provider, so the SET is what decides, not the fact that a call threw.

**The snapshot is now bounded at 3 s.** With the comparison in a `finally` the pair of reads is unconditional, and `getModelOptions`' own ceiling is `DASHBOARD_TIMEOUT_MS` (8 s) — a box with a dead dashboard could have had sixteen seconds put in front of a save that had already succeeded. Every helper in this family promises not to make the owner's save worse; missing the deadline is "I could not tell", which the guard declines to act on.

**The poll route's gate rationale.** It said the handler "changes nothing", which stopped being true the moment an approved tick could ask for a `reload.mcp`. The comment says so plainly now rather than the gate moving: nothing about what a caller must HOLD changed — a session (middleware), a dashboard-minted session id it cannot guess, and the dashboard itself reporting that a real credential landed for the sign-in the owner started through `start`.
