### PR TITLE
fix: stamp Claude model availability from the transport the box actually routes on

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -8,7 +8,7 @@ import {
   CATALOG_PROVIDERS,
   isCatalogProvider,
   PROVIDER_CATALOGS,
-  SUBSCRIPTION_SURFACE,
+  subscriptionSurfaceProvider,
 } from "@/lib/provider-models";
 
 export const dynamic = "force-dynamic";
@@ -156,16 +156,20 @@ interface OpenclawListResponse {
 // credentials route this model", and during setup no credential is written
 // yet, so every entry comes back false. Gating the picker on it would empty
 // the list at exactly the moment the customer needs it. The auth-mode surface
-// (SUBSCRIPTION_SURFACE.surfaceProvider) is the part that IS knowable in the
-// wizard, and it is what this route stamps instead.
+// (SUBSCRIPTION_SURFACE) is the part that IS knowable in the wizard, and it is
+// what this route stamps instead.
 //
 // anthropic's surface, concretely: `openclaw models list --provider anthropic`
-// is the API-key catalogue (9 models on 2026.7.1, claude-mythos-5 and
-// claude-fable-5 among them). The Claude-subscription surface is the same
-// plugin's second catalogue, provider id `claude-cli` (5 models: opus-4-8/4-7/
-// 4-6, sonnet-5, sonnet-4-6) — no Mythos, no Fable, no Haiku. Verified on a
-// 2026.7.1-2 device against both `openclaw models list` outputs and
-// dist/extensions/anthropic/openclaw.plugin.json.
+// is the plugin's catalogue (9 models on 2026.7.1, claude-mythos-5 and
+// claude-fable-5 among them), and since PR #532 a Claude SUBSCRIPTION routes
+// through that same native plugin — `POST /v1/messages` with
+// `anthropic-beta: oauth-2025-04-20` — so the surface IS this catalogue and
+// there is no second one to enumerate. It used to be the plugin's `claude-cli`
+// catalogue (5 models, no Mythos/Fable/Haiku), which was correct while the
+// transport was the openai-compat override #532 removed; the stamp described
+// that transport and went stale with it. See SUBSCRIPTION_SURFACE for the
+// history and for why `nativeRouting` now comes from the same table the
+// transport decision reads.
 
 interface OpenRouterListResponse {
   data: Array<{
@@ -249,8 +253,15 @@ function compareCatalogModels(a: CatalogModel, b: CatalogModel): number {
  * the first three minutes after every reboot.
  */
 async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string> | null> {
-  const surfaceProvider = SUBSCRIPTION_SURFACE[provider]?.surfaceProvider;
+  const surfaceProvider = subscriptionSurfaceProvider(provider);
   if (!surfaceProvider) return null;
+  // A natively-routed provider's surface is its OWN catalogue, which this
+  // refresh is already fetching. Enumerating it again would spend a second
+  // multi-minute `openclaw models list` on the identical list, and — worse —
+  // publish it to `<provider>.json` unmerged and unsanitized, clobbering the
+  // payload the picker and the server-side guard both read. `buildPayload`
+  // stamps that case from the merged list instead.
+  if (surfaceProvider === provider) return null;
   const cached = memCache.get(surfaceProvider) ?? await readDiskCache(surfaceProvider);
   if (cached && Date.now() - cached.fetchedAt < REFRESH_INTERVAL_MS && cached.models.length > 0) {
     memCache.set(surfaceProvider, cached);
@@ -408,6 +419,20 @@ function buildPayload(
   // this stamp was built for.
   if (surfaceIds) {
     merged = merged.map((m) => ({ ...m, availableOnSubscription: surfaceIds.has(m.id) }));
+  } else if (subscriptionSurfaceProvider(provider) === provider) {
+    // The surface IS this catalogue — a natively-routed subscription runs on
+    // the provider's own plugin, so THIS list is the set it can run and every
+    // row is stamped usable. Asked as "is the surface me?" rather than
+    // "is this a subscription?" because a payload is built once and served to
+    // both auth modes; the stamp answers what a SUBSCRIPTION could route, and
+    // `isModelUsableOnSubscription` is what decides whether that applies to
+    // the box in front of the customer.
+    //
+    // Stamped `true` rather than left undefined so the two gates cannot
+    // disagree: the server-side guard in subscription-surface.ts reads this
+    // very payload back off disk, and a row the picker offers must be a row
+    // that route accepts.
+    merged = merged.map((m) => ({ ...m, availableOnSubscription: true }));
   }
   const fallbackDefault = DEFAULT_MODEL_BY_PROVIDER[provider];
   const defaultModelId = merged.find((m) => m.id === fallbackDefault)?.id
@@ -537,11 +562,16 @@ export function refreshInBackground(provider: string): void {
     fetcher = fetchOpenclawCatalog(provider);
   }
 
-  // The two enumerations are independent — the surface list never reads the
-  // API list — and each costs minutes of Jetson CPU. Start both now, and
-  // publish the main catalogue the moment IT lands: making the picker wait on
-  // the surface would double the first-boot window the whole async-first
-  // design in this file's header exists to shrink.
+  // A provider whose subscription narrows to a SECOND catalogue needs that
+  // catalogue enumerated too. The two enumerations are independent — the
+  // surface list never reads the main one — and each costs minutes of Jetson
+  // CPU, so start both now and publish the main catalogue the moment IT lands:
+  // making the picker wait on the surface would double the first-boot window
+  // the whole async-first design in this file's header exists to shrink.
+  //
+  // Resolves to null immediately for a natively-routed provider, which has no
+  // second catalogue — `buildPayload` stamps that case from the merged list on
+  // the first publish, so those boxes are never served an unstamped payload.
   const surface = fetchSubscriptionSurfaceIds(provider);
 
   const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -61,7 +61,14 @@ import {
 import { OPENROUTER_CURATED_MODELS, OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
 import { resolveEntitledCodexModel } from "@/lib/codex-model-probe";
 import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
-import { isValidModelId, isCatalogProvider, GOOGLE_MODELS, ANTHROPIC_MODELS, extractProviderModelId } from "@/lib/provider-models";
+import {
+  isValidModelId,
+  isCatalogProvider,
+  GOOGLE_MODELS,
+  ANTHROPIC_MODELS,
+  extractProviderModelId,
+  routesSubscriptionNatively,
+} from "@/lib/provider-models";
 import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
 import {
   isClaudeSubscriptionOnly,
@@ -1035,31 +1042,21 @@ async function writeOpenAICompatProvider(opts: {
 }
 
 /**
- * Providers whose SUBSCRIPTION credential is routed by the provider's own
- * OpenClaw plugin instead of by a `models.providers.<p>` openai-compat
- * override.
+ * Which providers route a SUBSCRIPTION credential through their own OpenClaw
+ * plugin instead of through a `models.providers.<p>` openai-compat override
+ * is decided by `SUBSCRIPTION_SURFACE` in provider-models.ts, and
+ * {@link routesSubscriptionNatively} is imported from there.
  *
- * Anthropic, and deliberately NOT "every provider that has an OAuth flow".
- * `OAUTH_PROVIDERS` also carries google (Gemini Code Assist), and google's
- * subscription reaches {@link applyCloudProviderTransport} the same way
- * anthropic's does — but nothing gives it a native route to fall back on.
- * `setProviderPlugins` toggles the anthropic plugin and no other, and the
- * google branch below records that the native google plugin's auth fails at
- * call time. Dropping google's override would hand its turns to a route this
- * change has no evidence about and no device to test on: the same mistake as
- * the bug being fixed here, pointed the other way. Google stays on the
- * override until someone proves the native path on hardware.
- *
- * A Set rather than a literal comparison so the next provider to earn a native
- * subscription route is added HERE, where the reason it qualifies is written
- * down, rather than by widening a condition somewhere further down the file.
+ * It used to be a `NATIVE_SUBSCRIPTION_ROUTING` Set right here, next to the
+ * transport it selects — which read as the tidy choice and was the bug. The
+ * model picker's `availableOnSubscription` stamp answers a question that only
+ * has an answer once you know the transport ("which models can this
+ * credential run?"), and it was computed from a separate table in a separate
+ * file. When #532 moved anthropic's subscription onto the native route, the
+ * stamp kept describing the override that had just been removed and greyed
+ * out three models the box had started being able to run. One table, so the
+ * next transport change moves the stamp with it.
  */
-const NATIVE_SUBSCRIPTION_ROUTING: ReadonlySet<string> = new Set(["anthropic"]);
-
-/** Does this provider+authMode pair route through the native plugin? */
-function routesSubscriptionNatively(provider: string, authMode: string): boolean {
-  return authMode === "subscription" && NATIVE_SUBSCRIPTION_ROUTING.has(provider);
-}
 
 /**
  * Take a `models.providers.<p>` openai-compat override back out.
@@ -1734,10 +1731,12 @@ export async function POST(request: Request) {
     }
 
     // Claude: only a SUBSCRIPTION save can create the hazard here. An API-key
-    // save writes the anthropic key that makes the API-only models routable,
-    // so after it lands the box is not subscription-only and there is nothing
-    // to refuse — refusing there would block the very switch the message
-    // recommends ("switch Anthropic to API-key mode for the API-only models").
+    // save writes the anthropic key, so after it lands the box is not
+    // subscription-only and there is nothing to refuse. That mattered more
+    // when the surface was narrower than the API catalogue and the refusal
+    // recommended switching to a key; since #532 the subscription routes
+    // natively on the same catalogue, and what is left to refuse is an id no
+    // Anthropic catalogue on this box carries at all.
     if (authMode === "subscription") {
       const offSurface = await offSurfaceClaudeModelMessage(
         settledProvider,
@@ -2140,7 +2139,7 @@ export async function POST(request: Request) {
       // Google's OpenAI-compat endpoint instead — for the SUBSCRIPTION
       // (Gemini Code Assist OAuth) sign-in too. Google is the one sibling of
       // the anthropic bug fixed here, and it is deliberately left alone: see
-      // NATIVE_SUBSCRIPTION_ROUTING for why taking its override away without
+      // `routesSubscriptionNatively` for why taking its override away without
       // a device to prove the native route on would repeat the same mistake.
       const googleWroteOverride = await applyCloudProviderTransport({
         provider: "google",

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -573,9 +573,9 @@ export default function AIModelsStep({
     if (authMode === "subscription" && selectedProvider) {
       // SUBSCRIPTION_SURFACE is the one table for "what does signing in change
       // about which models this provider can run". `catalogProvider` is its
-      // wholesale-swap column (openai -> codex); the narrowing column
-      // (anthropic -> claude-cli) is applied by the catalog route as a stamp,
-      // not by swapping, because the save namespace does not move with it.
+      // wholesale-swap column (openai -> codex); its other columns are applied
+      // by the catalog route as an `availableOnSubscription` stamp, not by
+      // swapping, because the save namespace does not move with them.
       const swap = SUBSCRIPTION_SURFACE[selectedProvider]?.catalogProvider;
       if (swap) return swap;
     }

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -21,12 +21,13 @@ export interface ProviderModelOption {
   label: string;
   hint: string;
   /**
-   * Whether a SUBSCRIPTION (OAuth sign-in) credential can route this model,
-   * as opposed to an API key. Anthropic ships two catalogues — the API one
-   * (9 models today, including Claude Mythos 5 and Claude Fable 5) and the
-   * Claude-subscription one (5 models, which has neither) — and a picker
-   * that renders the first while the customer is on the Subscription tab
-   * offers models their plan cannot run.
+   * Whether a SUBSCRIPTION (OAuth sign-in) credential can route this model, as
+   * opposed to an API key. A provider's subscription can put it on a different
+   * or a smaller set than its API key does, and a picker that renders the API
+   * set while the customer is on the Subscription tab offers models their plan
+   * cannot run. Which set applies is {@link SUBSCRIPTION_SURFACE}'s answer,
+   * and it is the transport that decides — read the history note there before
+   * assuming any particular provider narrows.
    *
    * `undefined` means UNKNOWN, not "yes": the device could not enumerate the
    * subscription surface (cold start, CLI failure), so nothing is marked and
@@ -128,19 +129,45 @@ export const CLAWAI_MODELS: readonly ProviderModelOption[] = [
 // header dropdown all gate on the same set.
 /**
  * What SUBSCRIPTION (OAuth sign-in) changes about the models a provider can
- * run. Two shapes, because two different things happen:
+ * run. Three shapes, because three different things happen:
  *
  *  * `catalogProvider` — the whole namespace moves. OpenAI's ChatGPT sign-in
  *    routes through `codex`: different catalogue, different credential, and a
  *    different `<provider>/<id>` written to config (see the configure route's
  *    `subscriptionOverride`). The picker swaps catalogues wholesale.
- *  * `surfaceProvider` — the namespace STAYS, the set narrows. Anthropic's
- *    Claude sign-in still writes `anthropic/<id>`, but only the models the
- *    openclaw anthropic plugin's second catalogue (`claude-cli`) carries
- *    actually route. Claude Mythos 5 and Claude Fable 5 are API-key-only.
- *    The picker keeps the API catalogue and marks the rest unavailable —
- *    swapping wholesale here would drop rows silently, which is the same
- *    lie in the other direction.
+ *  * `surfaceProvider` — the namespace STAYS, the set narrows. The provider's
+ *    subscription credential is carried by a SECOND, smaller catalogue of the
+ *    same plugin, and only what that catalogue lists actually routes. The
+ *    picker keeps the main catalogue and marks the rest unavailable — swapping
+ *    wholesale here would drop rows silently, which is the same lie in the
+ *    other direction.
+ *  * `nativeRouting` — the namespace stays and NOTHING narrows. The provider's
+ *    own plugin carries the subscription credential on the provider's own
+ *    transport, so the set it can run is the provider's own catalogue. There
+ *    is no second, smaller catalogue to enumerate, and therefore no narrowing
+ *    this box can observe.
+ *
+ * WHY ANTHROPIC MOVED (this history matters — read it before "restoring" the
+ * old value). Anthropic used to be `surfaceProvider: "claude-cli"`, and that
+ * was CORRECT when it was written and verified on a device: a Claude
+ * subscription was routed by a `models.providers.anthropic` openai-compat
+ * override, whose turns left the box as `POST /v1/chat/completions`, and the
+ * only Anthropic catalogue reachable that way was the plugin's `claude-cli`
+ * one — 5 models, no Fable, no Mythos, no Haiku.
+ *
+ * PR #532 changed the transport out from under that rule. A subscription
+ * anthropic save no longer writes the openai-compat override; it hands the
+ * provider to the native anthropic plugin, whose turns leave as
+ * `POST /v1/messages` with `anthropic-beta: oauth-2025-04-20`. That transport
+ * serves the FULL anthropic catalogue on a subscription credential — which is
+ * why the same Claude sign-in has always run claude-fable-5 on the Hermes
+ * edition, which routed natively all along.
+ *
+ * So the narrowing did not become wrong through carelessness; it became STALE.
+ * `nativeRouting` is set from the same table the transport decision reads
+ * ({@link routesSubscriptionNatively}, which the configure route imports
+ * instead of keeping its own copy) precisely so the next transport change
+ * cannot silently invalidate the availability stamp again.
  *
  * One table because this is one fact. It used to be spelled three ways in
  * three files, none of which knew about the others.
@@ -148,10 +175,52 @@ export const CLAWAI_MODELS: readonly ProviderModelOption[] = [
 export const SUBSCRIPTION_SURFACE: Readonly<Record<string, {
   catalogProvider?: string;
   surfaceProvider?: string;
+  nativeRouting?: boolean;
 }>> = Object.freeze({
   openai: { catalogProvider: "codex" },
-  anthropic: { surfaceProvider: "claude-cli" },
+  anthropic: { nativeRouting: true },
 });
+
+/**
+ * Does this provider+authMode pair route through the provider's OWN plugin
+ * rather than through a `models.providers.<p>` openai-compat override?
+ *
+ * Anthropic, and deliberately NOT "every provider that has an OAuth flow".
+ * `OAUTH_PROVIDERS` also carries google (Gemini Code Assist), and google's
+ * subscription reaches the configure route's `applyCloudProviderTransport` the
+ * same way anthropic's does — but nothing gives it a native route to fall back
+ * on. `setProviderPlugins` toggles the anthropic plugin and no other, and the
+ * google branch there records that the native google plugin's auth fails at
+ * call time. Dropping google's override would hand its turns to a route no one
+ * has evidence about and no device to test on: the same mistake as the bug
+ * #532 fixed, pointed the other way. Google stays on the override until
+ * someone proves the native path on hardware.
+ *
+ * It lives HERE, in the table, rather than as a Set inside the configure
+ * route, because the transport decision and the availability stamp are the
+ * same fact. They were two facts in two files for exactly one release, and in
+ * that release the stamp described a transport the box no longer used.
+ */
+export function routesSubscriptionNatively(provider: string, authMode: string): boolean {
+  return authMode === "subscription" && SUBSCRIPTION_SURFACE[provider]?.nativeRouting === true;
+}
+
+/**
+ * The provider id whose catalogue IS the subscription surface for `provider`,
+ * or null when its subscription does not put it on a nameable surface (OpenAI
+ * swaps the whole namespace instead — see `catalogProvider` above).
+ *
+ * For a natively-routed provider this is the provider ITSELF: its subscription
+ * runs on its own plugin, so its own catalogue is the set. That is not a
+ * no-op — it keeps the gate pointed at a real, enumerated list, so an id that
+ * is in NO Anthropic catalogue is still refused rather than silently pinned.
+ */
+export function subscriptionSurfaceProvider(provider: string): string | null {
+  const entry = SUBSCRIPTION_SURFACE[provider];
+  if (!entry) return null;
+  if (entry.nativeRouting) return provider;
+  return entry.surfaceProvider ?? null;
+}
 
 /**
  * Can this credential run this model? The one greying-out rule, named once.
@@ -176,15 +245,20 @@ export function isModelUsableOnSubscription(
 }
 
 /**
- * The provider id of the narrowed catalogue a subscription puts `provider` on,
- * or null when its subscription does not narrow this catalogue (OpenAI swaps
- * the whole namespace instead — see `catalogProvider` above).
+ * The surface a refusal should NAME, so it can say which catalogue it is
+ * refusing against rather than telling the customer their provider is
+ * misconfigured when it is not.
  *
- * Exists so a refusal can NAME the surface it is refusing against, rather than
- * telling the customer their provider is misconfigured when it is not.
+ * Null for a natively-routed provider as well as for an unlisted one: there
+ * the surface is the provider's own catalogue, and "claude-fable-5 is not on
+ * the anthropic surface (anthropic)" names nothing the customer can act on.
+ * {@link subscriptionSurfaceProvider} is the one to ask for the id to
+ * enumerate; this one is only for wording.
  */
 export function subscriptionSurfaceLabel(provider: string): string | null {
-  return SUBSCRIPTION_SURFACE[provider]?.surfaceProvider ?? null;
+  const entry = SUBSCRIPTION_SURFACE[provider];
+  if (!entry || entry.nativeRouting) return null;
+  return entry.surfaceProvider ?? null;
 }
 
 export const CATALOG_PROVIDERS = ["clawai", "anthropic", "openai", "codex", "google", "openrouter"] as const;

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -1,7 +1,7 @@
 import { promises as fsp } from "fs";
 import path from "path";
 import { DATA_DIR } from "@/lib/config-store";
-import { SUBSCRIPTION_SURFACE, subscriptionSurfaceLabel } from "@/lib/provider-models";
+import { subscriptionSurfaceLabel, subscriptionSurfaceProvider } from "@/lib/provider-models";
 
 /**
  * Server-side reads of the SUBSCRIPTION facts the UI already gets stamped into
@@ -47,8 +47,14 @@ interface CachedSurface {
 export async function readSubscriptionSurfaceIds(
   provider: string,
 ): Promise<Set<string> | null> {
-  const surfaceProvider = SUBSCRIPTION_SURFACE[provider]?.surfaceProvider;
+  const surfaceProvider = subscriptionSurfaceProvider(provider);
   if (!surfaceProvider) return null;
+  // No short-circuit when the surface is the provider ITSELF, unlike the
+  // catalog route's own copy of this lookup. There, resolving to the provider
+  // means "do not enumerate a second time"; here it means "open the file the
+  // route already wrote", which is exactly the list the pickers were stamped
+  // from. Making this one bail too would take the guard back to UNKNOWN on
+  // every box and stop refusing ids that are in no catalogue at all.
   try {
     const raw = await fsp.readFile(path.join(CACHE_DIR, `${surfaceProvider}.json`), "utf8");
     const parsed = JSON.parse(raw) as CachedSurface;
@@ -176,9 +182,15 @@ export function isClaudeSubscriptionOnly(
  * carry, as a message — or null when the target is fine (not Claude, not a
  * Claude-subscription box, or the surface could not be read).
  *
- * Anthropic's subscription keeps the `anthropic/` namespace but narrows the
- * set: only the plugin's `claude-cli` catalogue routes, so claude-mythos-5 /
- * claude-fable-5 / the Haikus are API-key-only.
+ * The set it judges against is {@link subscriptionSurfaceProvider}'s, which
+ * since PR #532 is anthropic's OWN catalogue: a Claude subscription is routed
+ * by the native anthropic plugin on `POST /v1/messages`, which serves the full
+ * catalogue. It used to be the plugin's smaller `claude-cli` catalogue, and
+ * while the openai-compat override was the transport that was right — see the
+ * history note on SUBSCRIPTION_SURFACE. What survives the change is the reason
+ * this guard exists at all: a model id in NO Anthropic catalogue must not be
+ * written to `agents.defaults.model.primary`, because that failure is silent,
+ * sticky, and survives a reboot.
  *
  * It lives here, not in a route, because there are TWO write paths to
  * `agents.defaults.model.primary` and each of them has more than one door:
@@ -211,8 +223,18 @@ export async function offSurfaceClaudeModelMessage(
   if (!(await isClaudeSubscription())) return null;
   const surfaceIds = await getSurfaceIds();
   if (!surfaceIds || surfaceIds.has(modelId)) return null;
+  const choices = `Pick one of ${[...surfaceIds].sort().join(", ")}`;
   const surface = subscriptionSurfaceLabel("anthropic");
-  return `${modelId} is not on the Claude subscription surface (${surface}). `
-    + `Pick one of ${[...surfaceIds].sort().join(", ")}, `
-    + "or switch Anthropic to API-key mode for the API-only models.";
+  // A NAMED narrower surface can be named, and the customer has a second
+  // lever: an API key reaches the models that surface omits. When the
+  // subscription routes natively there is no narrower surface and no such
+  // lever — the id is simply in no Anthropic catalogue this box knows — so
+  // recommending API-key mode would send them after a fix that changes
+  // nothing.
+  if (surface) {
+    return `${modelId} is not on the Claude subscription surface (${surface}). `
+      + `${choices}, or switch Anthropic to API-key mode for the API-only models.`;
+  }
+  return `${modelId} is not in the Anthropic model catalogue this box enumerated. `
+    + `${choices}, or check the id for a typo.`;
 }

--- a/src/tests/components/chat-header-subscription-models.test.tsx
+++ b/src/tests/components/chat-header-subscription-models.test.tsx
@@ -26,9 +26,8 @@ const NEEDS_API_KEY = translations.en["ai.modelNeedsApiKey"];
  *
  * The wizard's own help line sends the customer here ("switch between the
  * curated models from the chat window anytime"), so the unfiltered surface was
- * the one it advertised: on a Claude-subscription box the header offered
- * Claude Mythos 5 / Claude Fable 5, which the `claude-cli` surface does not
- * carry, as ordinary pickable rows.
+ * the one it advertised: on a subscription box the header offered models the
+ * box's enumerated surface does not carry as ordinary pickable rows.
  *
  * The header does not hide them — a silently missing row is the same lie in
  * the other direction. It greys them out and says why, exactly as the wizard

--- a/src/tests/routes/ai-models/catalog-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/catalog-subscription-surface.test.ts
@@ -3,21 +3,31 @@ import { EventEmitter } from "events";
 import * as childProcess from "child_process";
 import fs from "fs";
 import path from "path";
+import { isModelUsableOnSubscription } from "@/lib/provider-models";
 
-// Owner-reported from a live first-boot run: "some models like Mythos are not
-// available", on step 4's Anthropic → Subscription tab.
+// HOW MANY catalogues this route enumerates for a provider, and which.
 //
-// The cause is that Anthropic ships TWO catalogues and this route only ever
-// read one. `openclaw models list --provider anthropic` is the API-KEY
-// catalogue — 9 models on OpenClaw 2026.7.1, claude-mythos-5 and
-// claude-fable-5 among them. The Claude-subscription surface is the same
-// plugin's second catalogue, provider id `claude-cli`, and it carries 5:
-// opus-4-8 / 4-7 / 4-6, sonnet-5, sonnet-4-6. No Mythos. No Fable. No Haiku.
+// It used to ask TWO for anthropic: the plugin's own list, plus the plugin's
+// second `claude-cli` list, which was the surface a Claude SUBSCRIPTION could
+// route while the transport was a `models.providers.anthropic` openai-compat
+// override. That was right then. PR #532 replaced the override with the native
+// anthropic plugin (`POST /v1/messages`), which serves the plugin's own
+// catalogue on a subscription credential — so the second enumeration now
+// describes a transport the box no longer uses, and the models it omits
+// (Fable, Mythos, Haiku) are models the box can in fact run.
 //
-// So the refresh has to ask BOTH, and stamp each API-catalogue model with
-// whether the subscription surface carries it. Anything it cannot enumerate
-// stays unstamped — unknown is not "no", and a picker that strikes out a
-// working model is the same lie in the other direction.
+// One catalogue, then — and every row on it stamped usable, including the
+// three the owner reported greyed out.//
+// Verified on the affected box (OpenClaw 2026.7.1-2, Claude subscription):
+// claude-fable-5 and claude-haiku-4-5 both answer over
+// POST https://api.anthropic.com/v1/messages with status=200 and a real
+// completion, fallbackUsed=false. claude-mythos-5 reaches the same endpoint
+// and comes back `not_found_error: model: claude-mythos-5` — an id the
+// provider does not serve, NOT an auth or entitlement refusal, and not
+// something an API key would fix. The old rule greyed it out for a reason
+// ("requires API key") that was never true of it. Stamping it usable is the
+// honest answer to the question this flag asks — whether the SUBSCRIPTION
+// narrows the catalogue — and the 404 surfaces loudly at turn time.
 
 vi.mock("child_process", () => ({ spawn: vi.fn() }));
 
@@ -50,21 +60,49 @@ function fakeChild(json: unknown) {
   return child;
 }
 
+/**
+ * `openclaw models list --provider anthropic` as a 2026.7.1 device answers it,
+ * trimmed: the plugin's own catalogue, Fable and Mythos included. Since #532
+ * this is what a subscription credential routes on.
+ */
 const ANTHROPIC_LIST = {
-  count: 2,
+  count: 3,
   models: [
     { key: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6", contextWindow: 200_000 },
     { key: "anthropic/claude-mythos-5", name: "Claude Mythos 5", contextWindow: 1_000_000 },
+    { key: "anthropic/claude-fable-5", name: "Claude Fable 5", contextWindow: 1_000_000 },
   ],
 };
 
-const CLAUDE_CLI_LIST = {
-  count: 1,
-  models: [
-    { key: "claude-cli/claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Claude CLI)", contextWindow: 200_000 },
-  ],
-};
+/**
+ * Refresh anthropic and return the stamped payload the route publishes.
+ *
+ * The refresh is re-issued inside the poll rather than fired once: the route
+ * single-flights per provider through a module-level `refreshing` set that
+ * clears a tick after the last publish, so a call made while a previous test's
+ * refresh is still settling is silently dropped.
+ */
+async function stampedCatalogue(): Promise<Record<string, boolean | undefined>> {
+  const cacheFile = path.join(DATA_DIR, "catalog-cache", "anthropic.json");
+  let byId: Record<string, boolean | undefined> = {};
+  await vi.waitFor(() => {
+    if (!fs.existsSync(cacheFile)) {
+      refreshInBackground("anthropic");
+      throw new Error("not published yet");
+    }
+    const cached = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+    byId = Object.fromEntries(
+      (cached.models as Array<{ id: string; availableOnSubscription?: boolean }>)
+        .map((m) => [m.id, m.availableOnSubscription]),
+    );
+    // Published unstamped first so the picker stops serving `warming` early —
+    // wait for the stamped republish, not merely for the file.
+    expect(byId["claude-sonnet-4-6"]).toBe(true);
+  }, { timeout: 5000, interval: 25 });
+  return byId;
+}
 
+/** The `--provider <id>` a recorded `openclaw models list` spawn was given. */
 function providerOf(call: unknown[]): string {
   const args = call[1] as string[];
   return args[args.indexOf("--provider") + 1];
@@ -73,36 +111,51 @@ function providerOf(call: unknown[]): string {
 describe("catalog refresh — subscription surface", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // The route persists every catalogue it enumerates, surface included, so a
-    // cache left by an earlier run would (correctly) suppress the spawn these
-    // tests are counting.
+    // The route persists every catalogue it enumerates, so a cache left by an
+    // earlier run would (correctly) suppress the spawn these tests count.
     fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockSpawn.mockImplementation((() => fakeChild(ANTHROPIC_LIST)) as any);
   });
 
-  it("enumerates the Claude-subscription surface alongside the Anthropic API catalogue", async () => {
-    mockSpawn.mockImplementation(((_bin: string, args: string[]) => {
-      const provider = args[args.indexOf("--provider") + 1];
-      return fakeChild(provider === "claude-cli" ? CLAUDE_CLI_LIST : ANTHROPIC_LIST);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any);
+  it("enumerates the Anthropic catalogue ONCE — it is the surface, natively routed", async () => {
+    await stampedCatalogue();
+    // A beat, so a second spawn has room to show up if one were still issued.
+    await new Promise((resolve) => setTimeout(resolve, 250));
 
-    refreshInBackground("anthropic");
-    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(2));
-
-    const providers = mockSpawn.mock.calls.map(providerOf);
-    expect(providers).toContain("anthropic");
-    expect(providers).toContain("claude-cli");
+    expect(mockSpawn.mock.calls.map(providerOf)).toEqual(["anthropic"]);
+    // Nothing is written under the old surface id: a payload published there
+    // would be an unmerged, unsanitized copy of a list nothing reads any more.
+    expect(fs.existsSync(path.join(DATA_DIR, "catalog-cache", "claude-cli.json"))).toBe(false);
   });
 
-  it("does not go looking for a second surface for a provider that has only one", async () => {
-    mockSpawn.mockImplementation(((_bin: string, args: string[]) => {
-      const provider = args[args.indexOf("--provider") + 1];
-      return fakeChild(provider === "claude-cli" ? CLAUDE_CLI_LIST : ANTHROPIC_LIST);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any);
+  it.each(["claude-fable-5", "claude-mythos-5"])(
+    "stamps %s usable — the models the owner saw greyed out",
+    async (id) => {
+      const byId = await stampedCatalogue();
 
-    refreshInBackground("google");
-    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1));
-    expect(providerOf(mockSpawn.mock.calls[0])).toBe("google");
+      expect(byId[id]).toBe(true);
+      expect(isModelUsableOnSubscription({ availableOnSubscription: byId[id] }, true)).toBe(true);
+    },
+  );
+
+  it("stamps the curated rows too, so a thin enumeration does not grey them", async () => {
+    const byId = await stampedCatalogue();
+
+    // claude-haiku-4-5 is in ANTHROPIC_MODELS but not in the live list above,
+    // so augmentWithStaticCatalog appends it. It was stamped FALSE before —
+    // the third model the owner reported — because `claude-cli` did not carry
+    // it. The native route does.
+    expect(byId["claude-haiku-4-5"]).toBe(true);
+  });
+
+  it("does not go looking for a second surface for a provider that has none", async () => {
+    await vi.waitFor(() => {
+      if (mockSpawn.mock.calls.length === 0) refreshInBackground("google");
+      expect(mockSpawn).toHaveBeenCalled();
+    }, { timeout: 5000, interval: 25 });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(mockSpawn.mock.calls.map(providerOf)).toEqual(["google"]);
   });
 });

--- a/src/tests/routes/ai-models/catalog-surface-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-surface-cache.test.ts
@@ -4,13 +4,17 @@ import fs from "fs";
 import path from "path";
 import * as childProcess from "child_process";
 
-// The subscription surface has to be CACHED like every other catalogue this
-// route enumerates. It is credential-independent, and each enumeration is
-// another multi-minute `openclaw models list` on a Jetson — but the reason it
-// rides the DISK cache rather than a process-local map is restarts: a
-// memory-only cache would leave the Anthropic picker unmarked (every model
-// pickable, i.e. the defect this stamp exists to fix) for the first minutes
-// after every reboot.
+// The subscription STAMP has to survive a restart. Enumerating a catalogue is
+// a multi-minute `openclaw models list` on a Jetson, so a memory-only cache
+// would leave the Anthropic picker unstamped for the first minutes after every
+// reboot — and an unstamped picker is the state this whole mechanism exists to
+// replace.
+//
+// This used to be a test about caching a SECOND catalogue (`claude-cli`).
+// Since PR #532 a Claude subscription routes natively and there is no second
+// catalogue: the surface is the anthropic list itself. The property under test
+// is unchanged and so is the customer-visible failure it prevents — only the
+// list that carries it moved.
 //
 // Its own file because the route's `memCache` is module-level: a fresh module
 // is the only way to observe the cold path and the warm path in one test.
@@ -49,13 +53,8 @@ const ANTHROPIC_LIST = {
     { key: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6", contextWindow: 200_000 },
   ],
 };
-const CLAUDE_CLI_LIST = {
-  count: 1,
-  models: [
-    { key: "claude-cli/claude-sonnet-4-6", name: "Claude Sonnet 4.6 (Claude CLI)", contextWindow: 200_000 },
-  ],
-};
 
+/** The `--provider <id>` a recorded `openclaw models list` spawn was given. */
 function providerOf(call: unknown[]): string {
   const args = call[1] as string[];
   return args[args.indexOf("--provider") + 1];
@@ -67,22 +66,18 @@ describe("catalog refresh — the subscription surface is cached", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
-    mockSpawn.mockImplementation(((_bin: string, args: string[]) => {
-      const provider = args[args.indexOf("--provider") + 1];
-      return fakeChild(provider === "claude-cli" ? CLAUDE_CLI_LIST : ANTHROPIC_LIST);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockSpawn.mockImplementation((() => fakeChild(ANTHROPIC_LIST)) as any);
   });
 
   it("enumerates it once, then serves it from cache on the next refresh", async () => {
     refreshInBackground("anthropic");
-    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1));
 
-    // Persisted, so it survives the restart a process-local cache would not.
-    await vi.waitFor(() => expect(fs.existsSync(cacheFile("claude-cli"))).toBe(true));
-    // The main catalogue is published UNSTAMPED first (so the picker stops
-    // serving `warming` without waiting on the surface), then republished with
-    // the stamp — so wait for the content, not merely for the file.
+    // Persisted WITH the stamp, so it survives the restart a process-local
+    // cache would not. The payload is published unstamped first (so the picker
+    // stops serving `warming` as early as possible), then republished — so
+    // wait for the content, not merely for the file.
     await vi.waitFor(() => {
       const cached = JSON.parse(fs.readFileSync(cacheFile("anthropic"), "utf8"));
       const byId = Object.fromEntries(
@@ -92,9 +87,9 @@ describe("catalog refresh — the subscription surface is cached", () => {
       expect(byId["claude-sonnet-4-6"]).toBe(true);
       // ANTHROPIC_MODELS' curated entries get appended by
       // augmentWithStaticCatalog for the thin-enumeration case, and they are
-      // stamped too — claude-haiku-4-5 is API-key-only, and leaving it
-      // unstamped would make it pickable in exactly that case.
-      expect(byId["claude-haiku-4-5"]).toBe(false);
+      // stamped too — leaving one unstamped where the rest are stamped is a
+      // difference the pickers would render, for no reason the box can name.
+      expect(byId["claude-haiku-4-5"]).toBe(true);
     });
 
     // Ask again. `refreshing` single-flights per provider and clears a tick

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -162,9 +162,12 @@ function surfaceCache(ids: string[], provider = "anthropic") {
 
 /** Whichever cache file the guard actually opened. */
 function cacheFileFor(filePath: string) {
-  return filePath.includes("claude-cli")
-    ? surfaceCache(CLAUDE_CLI_SURFACE_IDS, "claude-cli")
-    : surfaceCache(SURFACE_IDS, "anthropic");
+  if (filePath.includes("claude-cli")) return surfaceCache(CLAUDE_CLI_SURFACE_IDS, "claude-cli");
+  if (filePath.includes("anthropic")) return surfaceCache(SURFACE_IDS, "anthropic");
+  // Anything else is a cache this guard has no business opening, and answering
+  // it with the Anthropic catalogue would let a wrong-file read pass as a
+  // right one — which is the exact failure these fixtures exist to catch.
+  throw new Error(`unexpected subscription-surface cache read: ${filePath}`);
 }
 
 /** A spawned `openclaw` that exits 0 immediately — the happy-path stand-in. */

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -116,23 +116,55 @@ const mockFs = vi.mocked(fsp);
 const mockSurfaceRead = vi.mocked(nodeFsPromises.readFile);
 const mockSpawn = vi.mocked(childProcess.spawn);
 
-/** Model ids the `claude-cli` (Claude-subscription) surface really carries. */
+/**
+ * Model ids the Claude-subscription surface really carries. Since PR #532 that
+ * is anthropic's OWN catalogue — a subscription routes through the native
+ * plugin on `POST /v1/messages`, which serves the whole list. It used to be
+ * the plugin's smaller `claude-cli` catalogue, which was right while the
+ * transport was the openai-compat override #532 removed.
+ */
 const SURFACE_IDS = [
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-sonnet-5",
+  "claude-sonnet-4-6",
+  "claude-fable-5",
+  "claude-mythos-5",
+  "claude-haiku-4-5",
+];
+
+/**
+ * The ids the plugin's OTHER catalogue carries — the pre-#532 surface. A box
+ * has both files on disk; which one the guard opens is the whole question, so
+ * the fixture answers by PATH rather than handing the same list to every read.
+ * A path-agnostic fixture would pass whichever cache the guard chose.
+ */
+const CLAUDE_CLI_SURFACE_IDS = [
   "claude-opus-4-8",
   "claude-opus-4-7",
   "claude-sonnet-5",
   "claude-sonnet-4-6",
 ];
 
+/** An id no Anthropic catalogue on this box carries — a plausible typo. */
+const OFF_CATALOGUE_ID = "claude-fabel-5";
+
 /** The catalog route's disk cache for a surface provider, as it writes it. */
-function surfaceCache(ids: string[]) {
+function surfaceCache(ids: string[], provider = "anthropic") {
   return JSON.stringify({
-    provider: "claude-cli",
+    provider,
     models: ids.map((id) => ({ id, label: id, contextWindow: 200_000 })),
     defaultModelId: ids[0],
     allowCustom: false,
     fetchedAt: Date.now(),
   });
+}
+
+/** Whichever cache file the guard actually opened. */
+function cacheFileFor(filePath: string) {
+  return filePath.includes("claude-cli")
+    ? surfaceCache(CLAUDE_CLI_SURFACE_IDS, "claude-cli")
+    : surfaceCache(SURFACE_IDS, "anthropic");
 }
 
 /** A spawned `openclaw` that exits 0 immediately — the happy-path stand-in. */
@@ -171,7 +203,9 @@ async function primeConfigureRoute(): Promise<(request: Request) => Promise<Resp
   mockFs.mkdir.mockResolvedValue(undefined);
   mockFs.rm.mockResolvedValue(undefined);
   mockFs.unlink.mockResolvedValue(undefined);
-  mockSurfaceRead.mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
+  mockSurfaceRead.mockImplementation(
+    ((filePath: string) => Promise.resolve(cacheFileFor(String(filePath)))) as never,
+  );
 
   vi.mocked(getAll).mockResolvedValue({});
   vi.mocked(setMany).mockResolvedValue();
@@ -230,13 +264,24 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     vi.unstubAllGlobals();
   });
 
-  it("refuses a typed custom Claude id the subscription surface does not carry", async () => {
-    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+  it.each(["claude-fable-5", "claude-mythos-5", "claude-haiku-4-5"])(
+    "accepts %s — the native subscription route serves it",
+    async (model) => {
+      // The owner's report, on the OTHER write path: these were refused here
+      // too, because both routes read the same stale surface.
+      const res = await configurePost(subscribe({ model }));
+
+      expect(res.status).toBe(200);
+    },
+  );
+
+  it("refuses a typed custom Claude id no catalogue on this box carries", async () => {
+    const res = await configurePost(subscribe({ model: OFF_CATALOGUE_ID }));
 
     expect(res.status).toBe(400);
     const { error } = await res.json();
-    // Name the surface, exactly as the chat-header refusal does.
-    expect(error).toContain("claude-cli");
+    expect(error).toContain(OFF_CATALOGUE_ID);
+    // It lists what IS available, so a typo is self-correcting.
     expect(error).toContain("claude-fable-5");
     // A rejection that has already persisted the credential is not a
     // rejection — it is a half-applied save the customer cannot see.
@@ -278,7 +323,7 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     const res = await configurePost(jsonRequest({
       provider: "anthropic",
       apiKey: "sk-ant-test",
-      model: "claude-fable-5",
+      model: OFF_CATALOGUE_ID,
     }));
 
     expect(res.status).toBe(200);
@@ -290,7 +335,7 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
       auth: { profiles: { "anthropic:key": { provider: "anthropic", mode: "api_key" } } },
     } as never);
 
-    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+    const res = await configurePost(subscribe({ model: OFF_CATALOGUE_ID }));
 
     expect(res.status).toBe(200);
   });
@@ -299,7 +344,7 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     // UNKNOWN is not "no" — the same rule the pickers and the chat route obey.
     mockSurfaceRead.mockRejectedValue(new Error("ENOENT") as never);
 
-    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+    const res = await configurePost(subscribe({ model: OFF_CATALOGUE_ID }));
 
     expect(res.status).toBe(200);
   });
@@ -307,7 +352,7 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
   it("lets the pick through when the cached surface is empty", async () => {
     mockSurfaceRead.mockResolvedValue(surfaceCache([]) as never);
 
-    const res = await configurePost(subscribe({ model: "claude-fable-5" }));
+    const res = await configurePost(subscribe({ model: OFF_CATALOGUE_ID }));
 
     expect(res.status).toBe(200);
   });

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -112,9 +112,12 @@ function anthropicConfig(mode: "oauth" | "api_key", extraProfiles = {}) {
 
 /** Whichever cache file the guard actually opened. */
 function cacheFileFor(filePath: string) {
-  return filePath.includes("claude-cli")
-    ? surfaceCache(CLAUDE_CLI_SURFACE_IDS, "claude-cli")
-    : surfaceCache(SURFACE_IDS, "anthropic");
+  if (filePath.includes("claude-cli")) return surfaceCache(CLAUDE_CLI_SURFACE_IDS, "claude-cli");
+  if (filePath.includes("anthropic")) return surfaceCache(SURFACE_IDS, "anthropic");
+  // Anything else is a cache this guard has no business opening, and answering
+  // it with the Anthropic catalogue would let a wrong-file read pass as a
+  // right one — which is the exact failure these fixtures exist to catch.
+  throw new Error(`unexpected subscription-surface cache read: ${filePath}`);
 }
 
 /** POST a model switch the way the chat header's dropdown does. */

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -41,19 +41,44 @@ import {
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { promisify } from "util";
 
-/** Model ids the `claude-cli` (Claude-subscription) surface really carries. */
+/**
+ * Model ids the Claude-subscription surface really carries. Since PR #532 that
+ * is anthropic's OWN catalogue — a subscription routes through the native
+ * plugin on `POST /v1/messages`, which serves the whole list — so Fable,
+ * Mythos and the Haikus are on it. It used to be the plugin's smaller
+ * `claude-cli` catalogue, which was right while the transport was the
+ * openai-compat override #532 removed.
+ */
 const SURFACE_IDS = [
   "claude-opus-4-8",
   "claude-opus-4-7",
-  "claude-opus-4-6",
+  "claude-sonnet-5",
+  "claude-sonnet-4-6",
+  "claude-fable-5",
+  "claude-mythos-5",
+  "claude-haiku-4-5",
+];
+
+/**
+ * The ids the plugin's OTHER catalogue carries — the pre-#532 surface. A box
+ * has both files on disk; which one the guard opens is the whole question, so
+ * the fixture below answers by PATH rather than handing the same list to every
+ * read. A path-agnostic fixture would pass whichever cache the guard chose.
+ */
+const CLAUDE_CLI_SURFACE_IDS = [
+  "claude-opus-4-8",
+  "claude-opus-4-7",
   "claude-sonnet-5",
   "claude-sonnet-4-6",
 ];
 
+/** An id no Anthropic catalogue on this box carries — a plausible typo. */
+const OFF_CATALOGUE_ID = "claude-fabel-5";
+
 /** The catalog route's disk cache for a surface provider, as it writes it. */
-function surfaceCache(ids: string[]) {
+function surfaceCache(ids: string[], provider = "anthropic") {
   return JSON.stringify({
-    provider: "claude-cli",
+    provider,
     models: ids.map((id) => ({ id, label: id, contextWindow: 200_000 })),
     defaultModelId: ids[0],
     allowCustom: false,
@@ -85,6 +110,14 @@ function anthropicConfig(mode: "oauth" | "api_key", extraProfiles = {}) {
   };
 }
 
+/** Whichever cache file the guard actually opened. */
+function cacheFileFor(filePath: string) {
+  return filePath.includes("claude-cli")
+    ? surfaceCache(CLAUDE_CLI_SURFACE_IDS, "claude-cli")
+    : surfaceCache(SURFACE_IDS, "anthropic");
+}
+
+/** POST a model switch the way the chat header's dropdown does. */
 async function postModel(POST: (r: Request) => Promise<Response>, model: string) {
   return POST(new Request("http://localhost/test", {
     method: "POST",
@@ -125,7 +158,9 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     vi.mocked(sqliteSet).mockResolvedValue();
     vi.mocked(restartGateway).mockResolvedValue();
     vi.mocked(readConfig).mockResolvedValue(anthropicConfig("oauth") as never);
-    vi.mocked(fsp.readFile).mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
+    vi.mocked(fsp.readFile).mockImplementation(
+      ((filePath: string) => Promise.resolve(cacheFileFor(String(filePath)))) as never,
+    );
 
     const mod = await import("@/app/setup-api/chat/model/route");
     GET = mod.GET;
@@ -192,19 +227,54 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     expect(body.subscriptionProviders).toEqual(["clawai"]);
   });
 
-  it("refuses a Claude model the subscription surface does not carry", async () => {
-    const response = await postModel(POST, "anthropic/claude-fable-5");
+  it("refuses a Claude model no catalogue on this box carries", async () => {
+    // The gate is NARROWED by #532's transport change, not removed: pinning
+    // `agents.defaults.model.primary` to a model that cannot run fails
+    // silently, sticks, and survives a reboot.
+    const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
 
     expect(response.status).toBe(400);
     const { error } = await response.json();
-    // Name the surface, so the message is diagnosable rather than mysterious.
-    expect(error).toContain("claude-cli");
+    expect(error).toContain(OFF_CATALOGUE_ID);
+    // It lists what IS available, so a typo is self-correcting.
     expect(error).toContain("claude-fable-5");
     // And it must NOT be the auto-extend's wrong advice.
     expect(error).not.toContain("Re-save it in Settings");
     expect(runOpenclawConfigSet).not.toHaveBeenCalled();
     expect(restartGateway).not.toHaveBeenCalled();
   });
+
+  it("does not send the customer after an API key that would change nothing", async () => {
+    // Against a NARROWER surface an API key genuinely reached the models that
+    // surface omitted, so recommending it was the right next step. Natively
+    // routed there is no narrower surface — the id is in no catalogue at all —
+    // and that advice would cost a key purchase for nothing.
+    const { error } = await (await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`)).json();
+
+    expect(error).not.toContain("API-key mode");
+    expect(error).not.toContain("claude-cli");
+  });
+
+  it.each(["claude-fable-5", "claude-mythos-5", "claude-haiku-4-5"])(
+    "accepts %s — the native /v1/messages route serves it on this credential",
+    async (modelId) => {
+      // The owner's report: these three were greyed out in the chat header on
+      // a Claude subscription. Verified on the box: fable and haiku answer
+      // over POST /v1/messages with 200 and a real completion. mythos reaches
+      // the same endpoint and returns `not_found_error` — an id the provider
+      // does not serve, which no API key would fix either, so greying it as
+      // "requires API key" was never true of it. This route's job is the
+      // subscription question; a 404 is the provider's answer, surfaced
+      // loudly at turn time rather than guessed at here.
+      const response = await postModel(POST, `anthropic/${modelId}`);
+
+      expect(response.status).toBe(200);
+      expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+        "agents.defaults.model.primary",
+        `anthropic/${modelId}`,
+      ]);
+    },
+  );
 
   it("accepts a Claude model the subscription surface does carry", async () => {
     const response = await postModel(POST, "anthropic/claude-opus-4-8");
@@ -218,7 +288,7 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
 
   it("lets every Claude model through on an API-key box", async () => {
     vi.mocked(readConfig).mockResolvedValue(anthropicConfig("api_key") as never);
-    const response = await postModel(POST, "anthropic/claude-fable-5");
+    const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
     expect(response.status).toBe(200);
   });
 
@@ -226,7 +296,7 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     // UNKNOWN is not "no". A cold box with no catalog cache yet must not have
     // its whole Claude list refused by a guard that never verified anything.
     vi.mocked(fsp.readFile).mockRejectedValue(new Error("ENOENT") as never);
-    const response = await postModel(POST, "anthropic/claude-fable-5");
+    const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
     expect(response.status).toBe(200);
   });
 
@@ -234,7 +304,7 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     // An empty set is the same unknown wearing a different hat — treating it
     // as authoritative would strike out every Claude model at once.
     vi.mocked(fsp.readFile).mockResolvedValue(surfaceCache([]) as never);
-    const response = await postModel(POST, "anthropic/claude-fable-5");
+    const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
     expect(response.status).toBe(200);
   });
 
@@ -262,7 +332,7 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
               apiKey: "placeholder",
               baseUrl: "https://api.anthropic.com/v1",
               api: "openai-completions",
-              models: [{ id: "claude-fable-5", name: "claude-fable-5" }],
+              models: [{ id: OFF_CATALOGUE_ID, name: OFF_CATALOGUE_ID }],
             },
           },
         },
@@ -280,10 +350,10 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     });
 
     it("refuses it when it arrives as an id already in state.options", async () => {
-      const response = await postModel(POST, "anthropic/claude-fable-5");
+      const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
 
       expect(response.status).toBe(400);
-      expect((await response.json()).error).toContain("claude-cli");
+      expect((await response.json()).error).toContain(OFF_CATALOGUE_ID);
       expect(runOpenclawConfigSet).not.toHaveBeenCalled();
       expect(restartGateway).not.toHaveBeenCalled();
     });
@@ -296,7 +366,7 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
       }));
 
       expect(response.status).toBe(400);
-      expect((await response.json()).error).toContain("claude-cli");
+      expect((await response.json()).error).toContain(OFF_CATALOGUE_ID);
       expect(runOpenclawConfigSet).not.toHaveBeenCalled();
       expect(restartGateway).not.toHaveBeenCalled();
     });
@@ -348,7 +418,7 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
       .mockRejectedValueOnce(new Error("ENOENT") as never)
       .mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
 
-    const response = await postModel(POST, "anthropic/claude-fable-5");
+    const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
 
     expect(response.status).toBe(200);
     expect(vi.mocked(fsp.readFile)).toHaveBeenCalledTimes(1);
@@ -422,11 +492,11 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
     // The cache is refreshed by the catalog route on its own schedule. A
     // module-level memo here would pin this guard to whatever the surface
     // looked like the first time anyone switched model after a restart.
-    await postModel(POST, "anthropic/claude-fable-5");
+    await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
     vi.mocked(fsp.readFile).mockResolvedValue(
-      surfaceCache([...SURFACE_IDS, "claude-fable-5"]) as never,
+      surfaceCache([...SURFACE_IDS, OFF_CATALOGUE_ID]) as never,
     );
-    const response = await postModel(POST, "anthropic/claude-fable-5");
+    const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
     expect(response.status).toBe(200);
   });
 });

--- a/src/tests/unit/subscription-surface-native-routing.test.ts
+++ b/src/tests/unit/subscription-surface-native-routing.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  SUBSCRIPTION_SURFACE,
+  isModelUsableOnSubscription,
+  routesSubscriptionNatively,
+  subscriptionSurfaceLabel,
+  subscriptionSurfaceProvider,
+} from "@/lib/provider-models";
+
+/**
+ * Owner-reported on a live OpenClaw box signed in with a Claude Pro/Max
+ * subscription: the chat header greys out Claude Fable 5, Claude Mythos 5 and
+ * Claude Haiku 4.5 with "Not in the subscription - requires API key", while
+ * the same sign-in runs claude-fable-5 on the Hermes edition.
+ *
+ * The greying was not careless. It was CORRECT when it was written: a
+ * subscription anthropic save wrote a `models.providers.anthropic`
+ * openai-compat override, every turn left as `POST /v1/chat/completions`, and
+ * the only catalogue reachable that way was the plugin's `claude-cli` one —
+ * which carries neither Fable nor Mythos nor Haiku.
+ *
+ * PR #532 moved the transport. A subscription anthropic save now hands the
+ * provider to the NATIVE anthropic plugin (`POST /v1/messages` with
+ * `anthropic-beta: oauth-2025-04-20`), which serves the provider's full
+ * catalogue on a subscription credential — which is exactly why Hermes, which
+ * routed natively all along, never had this restriction.
+ *
+ * So the rule went STALE rather than wrong, and the fix is to compute the
+ * surface from the transport the box will actually use. These tests pin that
+ * the two are read from ONE table, because they were two tables in two files
+ * for exactly one release and that release shipped this bug.
+ */
+describe("SUBSCRIPTION_SURFACE — native routing after PR #532", () => {
+  it("routes an anthropic SUBSCRIPTION through the provider's own plugin", () => {
+    expect(routesSubscriptionNatively("anthropic", "subscription")).toBe(true);
+  });
+
+  it("leaves an anthropic API KEY on the openai-compat override", () => {
+    // The native route is a property of the SUBSCRIPTION credential, not of
+    // the provider. An API key still takes the override path it always took.
+    expect(routesSubscriptionNatively("anthropic", "api_key")).toBe(false);
+  });
+
+  it("does not hand google's subscription to a native route no one has proven", () => {
+    // google (Gemini Code Assist) has an OAuth flow too, and its native plugin
+    // fails auth at call time on 2026.6.8. Widening this to "every provider
+    // with OAuth" would repeat the bug #532 fixed, pointed the other way.
+    expect(routesSubscriptionNatively("google", "subscription")).toBe(false);
+  });
+
+  it("makes the native provider's OWN catalogue the subscription surface", () => {
+    // Not null. The gate still points at a real, enumerated list — an id in no
+    // Anthropic catalogue must still be refused, because pinning
+    // `agents.defaults.model.primary` to one fails silently and survives a
+    // reboot. What changed is WHICH list, not whether there is one.
+    expect(subscriptionSurfaceProvider("anthropic")).toBe("anthropic");
+  });
+
+  it("names no narrower surface for a natively-routed provider", () => {
+    // A refusal that said "not on the anthropic surface (anthropic)" names
+    // nothing the customer can act on, and recommending API-key mode would
+    // send them after a fix that changes nothing.
+    expect(subscriptionSurfaceLabel("anthropic")).toBeNull();
+  });
+});
+
+describe("SUBSCRIPTION_SURFACE — the other columns are untouched", () => {
+  it("still swaps OpenAI's whole namespace to codex on subscription", () => {
+    expect(SUBSCRIPTION_SURFACE.openai.catalogProvider).toBe("codex");
+  });
+
+  it("does not give OpenAI a surface to narrow to, or a native route", () => {
+    // OpenAI's subscription moves the namespace wholesale; there is no second
+    // catalogue to enumerate and no native-route claim being made about it.
+    expect(subscriptionSurfaceProvider("openai")).toBeNull();
+    expect(routesSubscriptionNatively("openai", "subscription")).toBe(false);
+  });
+
+  it("says nothing at all about a provider the table does not list", () => {
+    expect(subscriptionSurfaceProvider("google")).toBeNull();
+    expect(subscriptionSurfaceLabel("google")).toBeNull();
+  });
+});
+
+describe("the greying rule still treats UNKNOWN as usable", () => {
+  it("keeps an unstamped model pickable on a subscription box", () => {
+    // Unchanged by this fix and load-bearing for it: a box that could not
+    // enumerate the surface must not invent a restriction it never verified.
+    expect(isModelUsableOnSubscription({}, true)).toBe(true);
+    expect(isModelUsableOnSubscription({ availableOnSubscription: undefined }, true)).toBe(true);
+  });
+
+  it("still greys a model an enumerated surface genuinely omits", () => {
+    // The gate is narrowed, not removed. `false` still means no.
+    expect(isModelUsableOnSubscription({ availableOnSubscription: false }, true)).toBe(false);
+  });
+});

--- a/src/tests/unit/subscription-surface-rule.test.ts
+++ b/src/tests/unit/subscription-surface-rule.test.ts
@@ -37,10 +37,15 @@ describe("isModelUsableOnSubscription", () => {
 });
 
 describe("subscriptionSurfaceLabel", () => {
-  it("names the surface a provider narrows to, so an error can say which one", () => {
-    expect(subscriptionSurfaceLabel("anthropic")).toBe(
-      SUBSCRIPTION_SURFACE.anthropic.surfaceProvider,
-    );
+  it("names nothing for a provider whose subscription routes NATIVELY", () => {
+    // Since PR #532 anthropic is that provider: its subscription runs on its
+    // own plugin, so its surface is its own catalogue. "not on the anthropic
+    // surface (anthropic)" names nothing a customer can act on, so the
+    // refusal wording drops the parenthetical instead. The id to ENUMERATE
+    // still exists — see subscriptionSurfaceProvider — the gate is narrowed,
+    // not removed.
+    expect(subscriptionSurfaceLabel("anthropic")).toBeNull();
+    expect(SUBSCRIPTION_SURFACE.anthropic.surfaceProvider).toBeUndefined();
   });
 
   it("is null for a provider whose subscription does not narrow the set", () => {


### PR DESCRIPTION
## The report

On an OpenClaw box signed in with a Claude Pro/Max **subscription**, the chat header's model picker greys out **Claude Fable 5, Claude Mythos 5 and Claude Haiku 4.5** with "Not in the subscription - requires API key". Claude Opus 4.8 and Sonnet 5 stay selectable. The same sign-in runs `claude-fable-5` on the Hermes edition.

The greying is faithful to what it measures. It is measuring the wrong thing.

## The previous rule was correct when it was written

`SUBSCRIPTION_SURFACE.anthropic` was `{ surfaceProvider: "claude-cli" }`, and on a device that was true and verified. A subscription anthropic save wrote a `models.providers.anthropic` **openai-compat override**; every turn left the box as `POST /v1/chat/completions` with an inlined bearer; and the only Anthropic catalogue reachable that way was the plugin's second one, `claude-cli` — 5 models, no Fable, no Mythos, no Haiku. Greying those three was the honest answer to "what can this credential run?".

## #532 changed the transport out from under it

PR #532 (`241cf491`) stopped writing that override for a subscription anthropic save and handed the provider to the **native anthropic plugin**: `POST /v1/messages` with `anthropic-beta: oauth-2025-04-20`. Its own before/after on this same box recorded `api=openai-completions → /v1/chat/completions → 429` before, and `api=anthropic-messages → /v1/messages → 200` after.

The availability stamp was never told. It kept describing a transport the box had stopped using, so it went **stale** — not careless. That is the whole bug, and it is why the same subscription has always run `claude-fable-5` on Hermes, which routed natively all along.

## Evidence that the three models really do route

Read live off the affected box (`dist/extensions/anthropic/openclaw.plugin.json`, OpenClaw 2026.7.1-2):

- `modelCatalog.providers.anthropic` — `baseUrl: https://api.anthropic.com`, `api: anthropic-messages`, **9 models including `claude-fable-5`, `claude-mythos-5`, `claude-haiku-4-5`**.
- `modelCatalog.providers["claude-cli"]` — 5 models, no `baseUrl`, no `api` (it is the CLI backend, not an HTTP surface).
- **No per-model auth gating anywhere in the manifest** — no `requiresApiKey`, no `authModes`, no subscription tag on any entry. The model set is credential-independent.
- `setup.providers[0]` = `{ id: "anthropic", envVars: ["ANTHROPIC_OAUTH_TOKEN", "ANTHROPIC_API_KEY"] }` — the native provider takes an **OAuth token** as a first-class credential, not only an API key.

Plus the live turns recorded in the PR discussion below.

## The fix

Compute availability from the surface the box will **actually route on**, and read that from the **same table** that decides the transport:

- `SUBSCRIPTION_SURFACE` gains a third column, `nativeRouting`. `anthropic` becomes `{ nativeRouting: true }`.
- `routesSubscriptionNatively()` moves out of `configure/route.ts` into `provider-models.ts` and is imported back. The transport decision and the availability stamp are now one fact in one place — they were two facts in two files for exactly one release, and that release shipped this bug.
- `subscriptionSurfaceProvider()` resolves a natively-routed provider to **itself**: its subscription runs on its own plugin, so its own catalogue is the set.

**The gate is narrowed, not deleted.** It still points at a real, enumerated list, so an id in no Anthropic catalogue (a typo, a hallucinated model) is still refused — pinning `agents.defaults.model.primary` to a model that cannot run fails silently, sticks, and survives a reboot. Only the claim that a subscription *narrows* the catalogue is gone, because it no longer does. `availableOnSubscription === undefined` still means "could not enumerate" and still stays pickable.

The refusal wording moves with it: with no narrower surface to name, it no longer recommends switching to API-key mode — that would send the customer after a fix that changes nothing.

## Every consumer, and the grep that found them

```
grep -rn "availableOnSubscription\|isModelUsableOnSubscription\|SUBSCRIPTION_SURFACE\|surfaceProvider\|subscriptionSurfaceLabel\|readSubscriptionSurfaceIds\|offSurfaceClaudeModelMessage\|claude-cli" --include=*.ts --include=*.tsx src/
```

Seven non-test consumers, all of which resolve through the one table and therefore move together:

| # | Consumer | Role |
|---|---|---|
| 1 | `src/app/setup-api/ai-models/catalog/route.ts` | **producer** of the stamp |
| 2 | `src/components/AIModelsStep.tsx` | setup-wizard picker |
| 3 | `src/components/ChatPopup.tsx` | chat-header picker (render **and** `onChange`) |
| 4 | `src/lib/provider-models.ts` | the table + `isModelUsableOnSubscription` |
| 5 | `src/lib/subscription-surface.ts` | server-side surface read + refusal wording |
| 6 | `src/app/setup-api/chat/model/route.ts` | server guard, write path 1 |
| 7 | `src/app/setup-api/ai-models/configure/route.ts` | server guard, write path 2 |

`offSurfaceCodexModelMessage` in the same lib is the ChatGPT sibling of this rule. It is a static allowlist rather than a cache read, takes no surface at all, and is deliberately untouched — it is the "non-native subscription surface is unchanged" case in production code, not just in tests.

Both pickers and **both** server-side write paths are covered in this PR. #520 and #526 exist because one surface was fixed and its siblings were not.

`scripts/gateway-pre-start.sh` also mentions `claude-cli`, in an unrelated dead-model migration (`claude-cli/claude-sonnet-4-20250514`). Left alone.

## Tests

RED against unmodified `beta`, GREEN after. Covered:

- a natively-routing subscription stamps the native catalogue's models usable — including the curated rows a thin enumeration appends;
- both server guards accept `claude-fable-5` / `claude-mythos-5` / `claude-haiku-4-5` on a subscription-only box;
- both server guards still **refuse** an id no catalogue carries, and still list the alternatives;
- the non-native column is unchanged — OpenAI still swaps wholesale to `codex`, google still gets no native route;
- an unenumerable or empty surface leaves models **pickable**, not greyed.

## Follow-up, not folded in: a third gate that is also ours (#549)

While proving the above, a **separate** false-restriction turned up, with a named cause. OpenClaw resolves a per-agent model allowlist like this:

```js
// parseConfiguredModelVisibilityEntries
const rawModels = Object.keys(cfg?.agents?.defaults?.models ?? {});
return { ..., hasEntries: rawModels.length > 0 };
// buildAllowedModelSetWithFallbacks
const allowAny = !visibility.hasEntries;
```

`agents.defaults.models` is an **implicit allowlist that is off only while it is empty**. ClawBox writes exactly one key into it — `agents.defaults.models["codex/<id>"].agentRuntime.id = "codex"` — from `src/app/setup-api/chat/model/route.ts` and `scripts/gateway-pre-start.sh`, for an unrelated *runtime* reason (Codex turns need the app-server harness). Writing it arms the *visibility* allowlist as a side effect, narrowing the allowed set to that one Codex model plus the primary and the fallbacks.

That is why a session model override for `anthropic/claude-sonnet-4-6` is rejected with "not allowed for this agent" on a box where nothing in our UI greys it out — a model we happily offer, refused at turn time. Filed as #549: whenever ClawBox writes a runtime binding into that map, it must keep the map a superset of what its own pickers offer. Not folded in here — different cause, different files, different risk.
