### PR TITLE
feat: pair WhatsApp on OpenClaw through the gateway's own QR login

### DIFF
--- a/src/app/setup-api/whatsapp/configure/route.ts
+++ b/src/app/setup-api/whatsapp/configure/route.ts
@@ -1,6 +1,12 @@
 import { NextResponse } from "next/server";
 import { getActiveHarness } from "@/lib/harness";
 import { ensureHermesGateway } from "@/lib/hermes-telegram";
+import { ensureChannelPlugin, waitForChannelConnected } from "@/lib/openclaw-channels";
+import { restartGateway } from "@/lib/openclaw-config";
+import {
+  WHATSAPP_CHANNEL_ID,
+  setOpenclawWhatsappEnabled,
+} from "@/lib/openclaw-whatsapp";
 import {
   isWhatsappMode,
   normalizeWhatsappNumber,
@@ -22,6 +28,99 @@ interface ConfigureBody {
   enabled?: unknown;
 }
 
+/** Bounce the gateway; report rather than throw when it will not. */
+async function applyRestart(): Promise<boolean> {
+  try {
+    await restartGateway();
+    return true;
+  } catch (err) {
+    // The config change is already on disk, so a service failure is a warning
+    // rather than a failed save — the contract every channel route here shares.
+    console.error("[whatsapp/configure] gateway restart failed:", err);
+    return false;
+  }
+}
+
+/**
+ * The OpenClaw leg.
+ *
+ * Two things are genuinely different from Hermes and both are refusals rather
+ * than silent no-ops:
+ *
+ *  * there is no allowlist and no mode. OpenClaw admits senders through its own
+ *    owner-approved pairing, which ClawBox does not write, so accepting numbers
+ *    here would hand back a list the owner believes is in force. Same posture
+ *    as /discord/configure, which reports `allowlistSupported: false`.
+ *  * enabling the channel means installing its plugin first. OpenClaw's stock
+ *    extensions contain no WhatsApp at all, and a `channels.whatsapp` block
+ *    with no plugin to own it is the "no-channel-owner" state the Discord work
+ *    was built to remove.
+ *
+ * And the save does not call itself a success until the gateway says the
+ * channel is up — the same contract, and the same warning vocabulary, as
+ * /discord/configure.
+ */
+async function configureOpenclaw(body: ConfigureBody): Promise<NextResponse> {
+  if (body.allowedUsers !== undefined || body.mode !== undefined) {
+    return NextResponse.json(
+      {
+        error: "allowlist_unsupported",
+        code: "allowlist_unsupported",
+        allowlistSupported: false,
+      },
+      { status: 400 },
+    );
+  }
+  if (typeof body.enabled !== "boolean") {
+    return NextResponse.json({ error: "Nothing to update" }, { status: 400 });
+  }
+
+  // Turning the channel OFF needs no plugin, no verification and no waiting:
+  // the honest end state is "not receiving", and that is what it becomes.
+  if (!body.enabled) {
+    await setOpenclawWhatsappEnabled(false);
+    const stopped = await applyRestart();
+    return NextResponse.json({
+      success: true,
+      restarted: stopped,
+      allowlistSupported: false,
+      warning: stopped ? undefined : "restart_pending",
+    });
+  }
+
+  const plugin = await ensureChannelPlugin(WHATSAPP_CHANNEL_ID);
+  await setOpenclawWhatsappEnabled(true);
+
+  const restarted = await applyRestart();
+
+  const live = restarted ? await waitForChannelConnected(WHATSAPP_CHANNEL_ID) : null;
+
+  // Root cause first, exactly as on the Discord route: a plugin that never
+  // installed explains every state below it.
+  const warning = !plugin.ok
+    ? plugin.reason === "install_timeout"
+      ? "plugin_install_timeout"
+      : "plugin_install_failed"
+    : !restarted
+      ? "restart_pending"
+      : !live
+        ? "channel_unverified"
+        : !live.connected
+          ? "not_connected"
+          : undefined;
+
+  return NextResponse.json({
+    // A WhatsApp channel that is enabled but not connected is normally waiting
+    // for a QR scan, not broken — but it is still not receiving anything, and
+    // this route does not get to call that a success.
+    success: warning === undefined,
+    ...(warning === undefined ? {} : { code: warning }),
+    restarted,
+    allowlistSupported: false,
+    warning,
+  });
+}
+
 export async function POST(request: Request) {
   try {
     let parsed: unknown;
@@ -40,15 +139,12 @@ export async function POST(request: Request) {
     }
     const body = parsed as ConfigureBody;
 
-    // Pairing is a QR scan performed by `hermes whatsapp`, a zero-flag TTY
-    // wizard (see src/lib/hermes-whatsapp.ts). This route owns access control
-    // and enablement only — it never claims to pair anything.
+    // Pairing is a QR scan, driven by /whatsapp/pair on both harnesses. This
+    // route owns access control and enablement only — it never claims to pair
+    // anything.
     const harness = await getActiveHarness();
     if (harness !== "hermes") {
-      return NextResponse.json(
-        { error: "WhatsApp is only available on the Hermes edition", supported: false },
-        { status: 501 },
-      );
+      return configureOpenclaw(body);
     }
 
     const update: WhatsappConfigUpdate = {};

--- a/src/app/setup-api/whatsapp/configure/route.ts
+++ b/src/app/setup-api/whatsapp/configure/route.ts
@@ -89,25 +89,36 @@ async function configureOpenclaw(body: ConfigureBody): Promise<NextResponse> {
   }
 
   const plugin = await ensureChannelPlugin(WHATSAPP_CHANNEL_ID);
+  if (!plugin.ok) {
+    // Stop here rather than enabling anyway. Unlike Discord there is no
+    // credential to persist for a later retry — the only thing a write would
+    // add is `channels.whatsapp.enabled` with no plugin to own it, which is
+    // precisely the no-channel-owner state this work exists to remove. And a
+    // gateway restart for a channel that cannot load buys nothing.
+    return NextResponse.json({
+      success: false,
+      code: plugin.reason === "install_timeout" ? "plugin_install_timeout" : "plugin_install_failed",
+      warning: plugin.reason === "install_timeout" ? "plugin_install_timeout" : "plugin_install_failed",
+      restarted: false,
+      allowlistSupported: false,
+    });
+  }
+
   await setOpenclawWhatsappEnabled(true);
 
   const restarted = await applyRestart();
 
   const live = restarted ? await waitForChannelConnected(WHATSAPP_CHANNEL_ID) : null;
 
-  // Root cause first, exactly as on the Discord route: a plugin that never
-  // installed explains every state below it.
-  const warning = !plugin.ok
-    ? plugin.reason === "install_timeout"
-      ? "plugin_install_timeout"
-      : "plugin_install_failed"
-    : !restarted
-      ? "restart_pending"
-      : !live
-        ? "channel_unverified"
-        : !live.connected
-          ? "not_connected"
-          : undefined;
+  // Root cause first, exactly as on the Discord route. The plugin failures are
+  // already returned above, so what remains is the gateway's own verdict.
+  const warning = !restarted
+    ? "restart_pending"
+    : !live
+      ? "channel_unverified"
+      : !live.connected
+        ? "not_connected"
+        : undefined;
 
   return NextResponse.json({
     // A WhatsApp channel that is enabled but not connected is normally waiting

--- a/src/app/setup-api/whatsapp/pair/route.ts
+++ b/src/app/setup-api/whatsapp/pair/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { getActiveHarness } from "@/lib/harness";
 import { getPairingManager } from "@/lib/whatsapp-pairing";
+import { getOpenclawWhatsappPairing } from "@/lib/openclaw-whatsapp";
 
 export const dynamic = "force-dynamic";
 
@@ -14,27 +15,30 @@ export const dynamic = "force-dynamic";
  *        what reaps the bridge, without the client having to promise anything.
  * DELETE cancel. Stops the bridge; never touches creds.json.
  *
- * The snapshot carries the raw Baileys QR payload. That is not a secret in the
- * credential sense — it is a short-lived, single-use linking nonce — but it is
- * live pairing material, so this route stays behind the same session gate as
- * the rest of /setup-api/whatsapp (src/middleware.ts) and is never logged.
+ * The snapshot carries live pairing material — the raw Baileys QR payload on
+ * Hermes, a rendered PNG of the same nonce on OpenClaw. Neither is a secret in
+ * the credential sense (both are short-lived and single-use), but both are
+ * enough to link a device, so this route stays behind the same session gate as
+ * the rest of /setup-api/whatsapp (src/middleware.ts) and neither is ever
+ * logged.
  */
 
-async function requireHermes(): Promise<NextResponse | null> {
+/**
+ * The pairing session for whichever harness is active.
+ *
+ * Both managers expose the same `start`/`poll`/`stop` contract and the same
+ * phases, so this route reads identically on either. What differs is only what
+ * is underneath: a Baileys bridge this repo spawns (Hermes), or the gateway's
+ * own `web.login.*` RPC (OpenClaw).
+ */
+async function activePairing() {
   const harness = await getActiveHarness();
-  if (harness !== "hermes") {
-    return NextResponse.json(
-      { error: "WhatsApp is only available on the Hermes edition", supported: false },
-      { status: 501 },
-    );
-  }
-  return null;
+  return harness === "hermes" ? getPairingManager() : getOpenclawWhatsappPairing();
 }
 
 export async function POST(request: Request) {
   try {
-    const blocked = await requireHermes();
-    if (blocked) return blocked;
+    const pairing = await activePairing();
 
     let force = false;
     try {
@@ -44,7 +48,7 @@ export async function POST(request: Request) {
       // A bodyless start is the common case, not an error.
     }
 
-    const snapshot = await getPairingManager().start({ force });
+    const snapshot = await pairing.start({ force });
     return NextResponse.json({ supported: true, ...snapshot });
   } catch (err) {
     // Machine-readable code out, real cause to the server log. The panel maps
@@ -58,9 +62,7 @@ export async function POST(request: Request) {
 
 export async function GET() {
   try {
-    const blocked = await requireHermes();
-    if (blocked) return blocked;
-    return NextResponse.json({ supported: true, ...getPairingManager().poll() });
+    return NextResponse.json({ supported: true, ...(await activePairing()).poll() });
   } catch (err) {
     console.error("[whatsapp/pair] status read failed:", err);
     return NextResponse.json({ error: "status_failed" }, { status: 500 });
@@ -69,9 +71,7 @@ export async function GET() {
 
 export async function DELETE() {
   try {
-    const blocked = await requireHermes();
-    if (blocked) return blocked;
-    return NextResponse.json({ supported: true, ...getPairingManager().stop() });
+    return NextResponse.json({ supported: true, ...(await activePairing()).stop() });
   } catch (err) {
     console.error("[whatsapp/pair] cancel failed:", err);
     return NextResponse.json({ error: "cancel_failed" }, { status: 500 });

--- a/src/app/setup-api/whatsapp/status/route.ts
+++ b/src/app/setup-api/whatsapp/status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getActiveHarness } from "@/lib/harness";
 import { hermesGatewayStatus } from "@/lib/hermes-telegram";
 import { readHermesWhatsappStatus } from "@/lib/hermes-whatsapp";
+import { readOpenclawWhatsappStatus } from "@/lib/openclaw-whatsapp";
 
 export const dynamic = "force-dynamic";
 
@@ -45,17 +46,28 @@ export async function GET() {
   try {
     const harness = await getActiveHarness();
 
-    // OpenClaw documents a WhatsApp channel, but it is a separately-installed
-    // plugin whose only login path is an interactive QR command, and none of it
-    // is verifiable from a ClawBox build. Writing a channels.whatsapp block we
-    // have never seen a gateway accept is the one genuinely dangerous option:
-    // OpenClaw refuses to start on ANY unknown key, so a wrong guess here would
-    // silently take Telegram down with it. Report the honest state instead.
+    // OpenClaw: the channel is the @openclaw/whatsapp plugin, and the gateway
+    // is what knows about it. This branch used to answer `supported: false` on
+    // the reasoning that "none of it is verifiable from a ClawBox build" —
+    // true before `openclaw gateway call` gave us the plugin's own login and
+    // status surfaces non-interactively. See src/lib/openclaw-whatsapp.ts.
     if (harness !== "hermes") {
+      const status = await readOpenclawWhatsappStatus();
       return NextResponse.json({
-        supported: false,
+        supported: true,
         harness,
-        state: "unsupported",
+        ...status,
+        // OpenClaw admits senders through its own owner-approved pairing, so
+        // there is no allowlist for the panel to offer and no mode to pick —
+        // exactly as on the Discord panel.
+        allowlistSupported: false,
+        mode: null,
+        allowedUsers: [],
+        allowAllUsers: false,
+        // The same rule as the Hermes branch below: "receiving" may be true
+        // ONLY when the transport is genuinely up. A stored link and an enabled
+        // channel are not evidence that anything reaches the owner's phone.
+        receiving: status.connected,
       });
     }
 

--- a/src/app/setup-api/whatsapp/unpair/route.ts
+++ b/src/app/setup-api/whatsapp/unpair/route.ts
@@ -2,6 +2,8 @@ import { NextResponse } from "next/server";
 import { getActiveHarness } from "@/lib/harness";
 import { whatsappSessionDirs } from "@/lib/hermes-whatsapp";
 import { unpairWhatsapp } from "@/lib/whatsapp-pairing";
+import { restartGateway } from "@/lib/openclaw-config";
+import { logoutOpenclawWhatsapp, setOpenclawWhatsappEnabled } from "@/lib/openclaw-whatsapp";
 
 export const dynamic = "force-dynamic";
 
@@ -20,11 +22,25 @@ export const dynamic = "force-dynamic";
 export async function POST() {
   try {
     const harness = await getActiveHarness();
+
     if (harness !== "hermes") {
-      return NextResponse.json(
-        { error: "WhatsApp is only available on the Hermes edition", supported: false },
-        { status: 501 },
-      );
+      // Both halves, and the channel is switched off even when the logout
+      // fails: credentials without the channel disabled is a gateway retrying a
+      // login it cannot complete, which is the half-applied state this route
+      // exists to avoid. The failure is still reported — it is not swallowed.
+      let logoutError: unknown = null;
+      try {
+        await logoutOpenclawWhatsapp();
+      } catch (err) {
+        logoutError = err;
+      }
+      await setOpenclawWhatsappEnabled(false);
+      await restartGateway().catch((err) => {
+        console.error("[whatsapp/unpair] gateway restart failed:", err);
+      });
+      if (logoutError) throw logoutError;
+      console.info("[whatsapp/unpair] logged out and disabled the channel");
+      return NextResponse.json({ success: true });
     }
 
     await unpairWhatsapp(whatsappSessionDirs());

--- a/src/app/setup-api/whatsapp/unpair/route.ts
+++ b/src/app/setup-api/whatsapp/unpair/route.ts
@@ -3,7 +3,11 @@ import { getActiveHarness } from "@/lib/harness";
 import { whatsappSessionDirs } from "@/lib/hermes-whatsapp";
 import { unpairWhatsapp } from "@/lib/whatsapp-pairing";
 import { restartGateway } from "@/lib/openclaw-config";
-import { logoutOpenclawWhatsapp, setOpenclawWhatsappEnabled } from "@/lib/openclaw-whatsapp";
+import {
+  getOpenclawWhatsappPairing,
+  logoutOpenclawWhatsapp,
+  setOpenclawWhatsappEnabled,
+} from "@/lib/openclaw-whatsapp";
 
 export const dynamic = "force-dynamic";
 
@@ -31,6 +35,13 @@ export async function POST() {
       // route exists to avoid. This way the worst case is a channel switched
       // off with its session intact, which the owner can simply re-enable.
       await setOpenclawWhatsappEnabled(false);
+
+      // End any pairing session first. Its keepalive calls `web.login.wait`
+      // every few seconds, so a login left running through an unpair would go
+      // on asking the gateway for a channel that is now off — and an in-flight
+      // answer would put a QR back on screen for a link the owner just
+      // removed. stop() bumps the epoch, so that answer is discarded too.
+      getOpenclawWhatsappPairing().stop();
 
       // The logout still has to happen, and its failure is reported rather
       // than swallowed — but the channel is already off, so a gateway that

--- a/src/app/setup-api/whatsapp/unpair/route.ts
+++ b/src/app/setup-api/whatsapp/unpair/route.ts
@@ -24,17 +24,23 @@ export async function POST() {
     const harness = await getActiveHarness();
 
     if (harness !== "hermes") {
-      // Both halves, and the channel is switched off even when the logout
-      // fails: credentials without the channel disabled is a gateway retrying a
-      // login it cannot complete, which is the half-applied state this route
-      // exists to avoid. The failure is still reported — it is not swallowed.
+      // Config first, destructive step second — the same ordering rule
+      // setDiscordToken follows. A failed config write must not come after a
+      // session that is already gone: that would leave the channel enabled
+      // with nothing to authenticate as, which is the half-applied state this
+      // route exists to avoid. This way the worst case is a channel switched
+      // off with its session intact, which the owner can simply re-enable.
+      await setOpenclawWhatsappEnabled(false);
+
+      // The logout still has to happen, and its failure is reported rather
+      // than swallowed — but the channel is already off, so a gateway that
+      // cannot drop the session is not left retrying a login with it.
       let logoutError: unknown = null;
       try {
         await logoutOpenclawWhatsapp();
       } catch (err) {
         logoutError = err;
       }
-      await setOpenclawWhatsappEnabled(false);
       await restartGateway().catch((err) => {
         console.error("[whatsapp/unpair] gateway restart failed:", err);
       });

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -214,6 +214,9 @@ interface WhatsappStatus {
   receiving?: boolean;
 }
 
+/** A PNG data URL that actually carries an image. Mirrors the server's guard. */
+const WHATSAPP_QR_DATA_URL_RE = /^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/;
+
 /** Phases of GET /setup-api/whatsapp/pair. Mirrors WhatsappPairPhase server-side. */
 type WhatsappPairPhase = "idle" | "preparing" | "starting" | "waiting" | "scanned" | "paired" | "error";
 
@@ -2121,10 +2124,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         ? (phase as WhatsappPairPhase)
         : "idle",
       qr: typeof raw.qr === "string" && raw.qr.length > 0 ? raw.qr : null,
-      qrImage:
-        typeof raw.qrImage === "string" && raw.qrImage.startsWith("data:image/png;base64,")
-          ? raw.qrImage
-          : null,
+      // Prefix AND payload. `"data:image/png;base64,"` on its own is a valid
+      // data URL for an empty image, and would render a blank square the owner
+      // is invited to scan. Same rule as readQrDataUrl() server-side.
+      qrImage: WHATSAPP_QR_DATA_URL_RE.test(String(raw.qrImage ?? "")) ? (raw.qrImage as string) : null,
       qrCount: typeof raw.qrCount === "number" ? raw.qrCount : 0,
       restarts: typeof raw.restarts === "number" ? raw.restarts : 0,
       error: typeof raw.error === "string" ? raw.error : null,

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -220,8 +220,10 @@ type WhatsappPairPhase = "idle" | "preparing" | "starting" | "waiting" | "scanne
 /** Shape of GET/POST /setup-api/whatsapp/pair, normalised client-side. */
 interface WhatsappPairSnapshot {
   phase: WhatsappPairPhase;
-  /** Raw Baileys payload. Rendered as a QR; never shown as text. */
+  /** Raw Baileys payload (Hermes). Rendered as a QR; never shown as text. */
   qr: string | null;
+  /** Pre-rendered PNG data URL (OpenClaw, whose plugin draws the code itself). */
+  qrImage: string | null;
   /** Distinct QR payloads this session — proof the rotation is live. */
   qrCount: number;
   restarts: number;
@@ -2119,6 +2121,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         ? (phase as WhatsappPairPhase)
         : "idle",
       qr: typeof raw.qr === "string" && raw.qr.length > 0 ? raw.qr : null,
+      qrImage:
+        typeof raw.qrImage === "string" && raw.qrImage.startsWith("data:image/png;base64,")
+          ? raw.qrImage
+          : null,
       qrCount: typeof raw.qrCount === "number" ? raw.qrCount : 0,
       restarts: typeof raw.restarts === "number" ? raw.restarts : 0,
       error: typeof raw.error === "string" ? raw.error : null,
@@ -2142,7 +2148,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       // Show "preparing" the instant the click lands: on a box with no
       // node_modules the POST below does not return until npm has finished,
       // and a dead button for two minutes reads as a broken one.
-      setWaPair({ phase: "preparing", qr: null, qrCount: 0, restarts: 0, error: null, user: null });
+      setWaPair({ phase: "preparing", qr: null, qrImage: null, qrCount: 0, restarts: 0, error: null, user: null });
       try {
         const res = await fetch("/setup-api/whatsapp/pair", {
           method: "POST",
@@ -2154,6 +2160,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
           setWaPair({
             phase: "error",
             qr: null,
+            qrImage: null,
             qrCount: 0,
             restarts: 0,
             error: typeof data?.error === "string" ? data.error : "start_failed",
@@ -2163,7 +2170,7 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         }
         setWaPair(readPairSnapshot(data));
       } catch {
-        setWaPair({ phase: "error", qr: null, qrCount: 0, restarts: 0, error: "start_failed", user: null });
+        setWaPair({ phase: "error", qr: null, qrImage: null, qrCount: 0, restarts: 0, error: "start_failed", user: null });
       } finally {
         setWaPairBusy(false);
       }
@@ -4766,20 +4773,37 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                             these payloads run past 200 characters, and at 256px
                             a denser correction level shrinks each module below
                             what a phone reads at arm's length. */}
-                        {waPair?.phase === "waiting" && waPair.qr && (
+                        {waPair?.phase === "waiting" && (waPair.qr || waPair.qrImage) && (
                           <div className="mt-3" aria-live="polite">
                             <div className="text-sm text-[var(--text-primary)] font-medium">{t("settings.whatsappPairScanTitle")}</div>
                             <div className="flex justify-center my-4">
                               <div className="bg-white rounded-xl p-3" data-testid="whatsapp-qr">
-                                <QRCodeSVG
-                                  value={waPair.qr}
-                                  size={256}
-                                  level="L"
-                                  marginSize={4}
-                                  bgColor="#ffffff"
-                                  fgColor="#000000"
-                                  title={t("settings.whatsappPairQrLabel")}
-                                />
+                                {/* Two harnesses, one card. The Hermes bridge emits the raw
+                                    Baileys payload, so we draw the code ourselves; the
+                                    OpenClaw plugin renders it and hands back a PNG, so
+                                    there is nothing to draw and re-encoding it would only
+                                    lose fidelity. `qr` wins when both are somehow present:
+                                    a vector at any zoom beats a fixed bitmap. */}
+                                {waPair.qr ? (
+                                  <QRCodeSVG
+                                    value={waPair.qr}
+                                    size={256}
+                                    level="L"
+                                    marginSize={4}
+                                    bgColor="#ffffff"
+                                    fgColor="#000000"
+                                    title={t("settings.whatsappPairQrLabel")}
+                                  />
+                                ) : (
+                                  // eslint-disable-next-line @next/next/no-img-element
+                                  <img
+                                    src={waPair.qrImage as string}
+                                    alt={t("settings.whatsappPairQrLabel")}
+                                    width={256}
+                                    height={256}
+                                    className="block"
+                                  />
+                                )}
                               </div>
                             </div>
                             <p className="text-xs text-[var(--text-secondary)] leading-relaxed">{t("settings.whatsappPairScanHint")}</p>

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -327,12 +327,31 @@ export function parseChannelRow(row: Record<string, unknown>): ChannelStatus {
  */
 export async function readChannelStatus(
   channelId: string,
+  options: Omit<SpawnOpenclawOptions, "captureStdout"> = {},
+): Promise<ChannelStatus | null> {
+  const row = await readChannelRow(channelId, options);
+  return row ? parseChannelRow(row) : null;
+}
+
+/**
+ * The gateway's row for `channelId`, unparsed.
+ *
+ * {@link readChannelStatus} narrows this to the fields every channel shares.
+ * Channels that publish more than that read the row directly instead of having
+ * their extra fields flattened away — WhatsApp's `linked` is the case that
+ * forced this: it is the only honest answer to "is a device paired", and
+ * `configured` (which the common shape does carry) means merely "there is an
+ * account entry". Reading `configured` as paired reported a linked phone on a
+ * box where no QR had ever been shown.
+ */
+export async function readChannelRow(
+  channelId: string,
   // `captureStdout` is deliberately not offerable: this function's whole job is
   // to parse the CLI's `--json`, and a caller that turned stdout off would get
   // an empty string and a silent `null` — "the gateway said nothing" — for a
   // channel that is perfectly healthy.
   options: Omit<SpawnOpenclawOptions, "captureStdout"> = {},
-): Promise<ChannelStatus | null> {
+): Promise<Record<string, unknown> | null> {
   if (openclawIsAbsent()) return null;
   let parsed: unknown;
   try {
@@ -371,11 +390,11 @@ export async function readChannelStatus(
   const accounts = payload.channelAccounts?.[channelId];
   if (Array.isArray(accounts) && accounts.length > 0) {
     const first = accounts[0];
-    if (first && typeof first === "object") return parseChannelRow(first as Record<string, unknown>);
+    if (first && typeof first === "object") return first as Record<string, unknown>;
   }
 
   const channel = payload.channels?.[channelId];
-  if (channel && typeof channel === "object") return parseChannelRow(channel as Record<string, unknown>);
+  if (channel && typeof channel === "object") return channel as Record<string, unknown>;
 
   return null;
 }

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -34,7 +34,7 @@
 // env-backed credential here and nothing for envSecretRef() to mint.
 
 import { spawnOpenclawCli } from "@/lib/openclaw-config";
-import { readChannelStatus } from "@/lib/openclaw-channels";
+import { readChannelRow } from "@/lib/openclaw-channels";
 
 /** OpenClaw's id for this channel — the plugin's, the config key's, the CLI's. */
 export const WHATSAPP_CHANNEL_ID = "whatsapp";
@@ -372,20 +372,29 @@ export interface OpenclawWhatsappStatus {
  * can act as", which is exactly the question.
  */
 export async function readOpenclawWhatsappStatus(): Promise<OpenclawWhatsappStatus> {
-  const channel = await readChannelStatus(WHATSAPP_CHANNEL_ID);
-  if (!channel) {
+  const row = await readChannelRow(WHATSAPP_CHANNEL_ID);
+  if (!row) {
     // Unknown, not "off". Reported as not_configured because that is the only
     // honest thing the panel can offer an action for, and the status card's
     // `receiving: false` says the rest.
     return { state: "not_configured", enabled: false, paired: false, connected: false };
   }
-  const paired = channel.configured;
-  const enabled = channel.configured || channel.running;
+
+  // `linked` is the ONLY honest answer to "is a phone paired". `configured`
+  // means "the gateway has an account entry for this channel", which becomes
+  // true the moment the plugin loads and the channel is enabled — with nothing
+  // scanned. Reading that as paired is exactly the lie this work removes; the
+  // gateway says so itself alongside it, with `statusState: "not-linked"` and
+  // `lastError: "not linked"`.
+  const paired = row.linked === true;
+  const connected = row.connected === true;
+  const enabled = row.enabled === true || row.configured === true || row.running === true;
+
   return {
     state: !enabled ? "not_configured" : paired ? "paired" : "enabled_not_paired",
     enabled,
     paired,
-    connected: channel.connected,
+    connected,
   };
 }
 

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -149,11 +149,22 @@ async function gatewayCall(
   return payload;
 }
 
+/**
+ * A PNG data URL with an actual payload.
+ *
+ * The prefix alone is not enough: `"data:image/png;base64,"` is a well-formed
+ * data URL for an empty image, and it would put a blank square on screen in the
+ * `waiting` phase — a QR the owner cannot scan, with nothing saying why. The
+ * base64 body is required, and its alphabet checked, because this string ends
+ * up as an `<img src>` in the panel.
+ */
+const QR_DATA_URL_RE = /^data:image\/png;base64,[A-Za-z0-9+/]+={0,2}$/;
+
 function readQrDataUrl(result: WebLoginResult): string | null {
   const value = result.qrDataUrl;
-  // The schema the gateway validates against pins this prefix; re-checking it
-  // here is what stops anything else reaching an <img src> in the panel.
-  return typeof value === "string" && value.startsWith("data:image/png;base64,") ? value : null;
+  // The schema the gateway validates against pins the prefix; re-checking the
+  // whole shape here is what stops anything else reaching an <img src>.
+  return typeof value === "string" && QR_DATA_URL_RE.test(value) ? value : null;
 }
 
 /**

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -176,6 +176,16 @@ export class OpenclawWhatsappPairing {
   private snap: OpenclawWhatsappSnapshot = { ...IDLE };
   private lastPollAt = 0;
   private waiting = false;
+  /**
+   * Bumped every time a new login replaces the current one.
+   *
+   * `web.login.wait` can be in flight for tens of seconds, and `start({force})`
+   * or `stop()` can land in the middle of it. Without this, the old wait's
+   * answer — a QR for a session the gateway has already torn down — would be
+   * written into the new snapshot, and the panel would show a code that can
+   * never be scanned.
+   */
+  private epoch = 0;
   private tickTimer: ReturnType<typeof setInterval> | null = null;
   private readonly now: () => number;
 
@@ -206,6 +216,8 @@ export class OpenclawWhatsappPairing {
     if (this.snap.phase === "paired" && !opts.force) return this.peek();
     if (this.snap.phase === "waiting" && !opts.force) return this.peek();
 
+    this.epoch += 1;
+    const epoch = this.epoch;
     this.snap = { ...IDLE, phase: "starting", startedAt: this.now() };
     this.ensureTicking();
 
@@ -215,8 +227,10 @@ export class OpenclawWhatsappPairing {
         { force: opts.force === true, timeoutMs: LOGIN_START_MS },
         LOGIN_START_MS,
       );
+      if (epoch !== this.epoch) return this.peek();
       this.apply(result);
     } catch (err) {
+      if (epoch !== this.epoch) return this.peek();
       this.snap = {
         ...this.snap,
         phase: "error",
@@ -228,6 +242,9 @@ export class OpenclawWhatsappPairing {
   }
 
   stop(): OpenclawWhatsappSnapshot {
+    // Bump first: a wait already in flight belongs to the session being ended,
+    // and must not resurrect it by writing a QR into the idle snapshot.
+    this.epoch += 1;
     this.clearTicking();
     this.snap = { ...IDLE };
     return this.peek();
@@ -296,6 +313,7 @@ export class OpenclawWhatsappPairing {
     }
 
     this.waiting = true;
+    const epoch = this.epoch;
     try {
       const result = await gatewayCall(
         "web.login.wait",
@@ -305,7 +323,9 @@ export class OpenclawWhatsappPairing {
         },
         LOGIN_WAIT_MS + 5_000,
       );
-      this.apply(result);
+      // Discard an answer that belongs to a session which has since been
+      // replaced or stopped.
+      if (epoch === this.epoch) this.apply(result);
     } catch (err) {
       // A wait that failed is not a login that failed: the gateway may simply
       // have been busy. Keep the QR on screen and try again next tick, which is

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -1,0 +1,391 @@
+// WhatsApp on the OpenClaw harness.
+//
+// WHAT CHANGED SINCE "WHATSAPP IS HERMES-ONLY"
+//
+// /whatsapp/status used to say, correctly for its time:
+//
+//     OpenClaw documents a WhatsApp channel, but it is a separately-installed
+//     plugin whose only login path is an interactive QR command, and none of it
+//     is verifiable from a ClawBox build.
+//
+// The first half is still true — `@openclaw/whatsapp` is an npm plugin, and
+// `openclaw channels login --channel whatsapp` renders ASCII art to a TTY. The
+// second half is not. The plugin also exposes `loginWithQrStart` and
+// `loginWithQrWait` on its channel API; the gateway publishes those as the
+// `web.login.start` / `web.login.wait` RPC methods; and `openclaw gateway call`
+// invokes any gateway method non-interactively. So the panel can drive the real
+// pairing flow and get a PNG data URL back, with no PTY and no reimplementation
+// of Baileys.
+//
+// This is the same argument the Hermes bridge's header makes about
+// `hermes whatsapp`: the WIZARD needs a terminal, the PAIRING does not.
+//
+// WHY THIS LOOKS DIFFERENT FROM whatsapp-pairing.ts
+//
+// The Hermes path owns a Baileys process: it spawns the bridge, parses its
+// JSON lines, restarts it when it dies, and reaps it when the panel stops
+// polling. Here the GATEWAY owns the login. The plugin keeps its own active
+// login (with its own TTL and QR rotation), so this module holds no child
+// process at all — only the latest snapshot and a keepalive, so that a GET is
+// a cheap read rather than a 10-second CLI cold start.
+//
+// NO SecretRef, deliberately. WhatsApp Web authenticates with stored linked-
+// device credentials in the plugin's auth dir, not a bot token, so there is no
+// env-backed credential here and nothing for envSecretRef() to mint.
+
+import { spawnOpenclawCli } from "@/lib/openclaw-config";
+import { readChannelStatus } from "@/lib/openclaw-channels";
+
+/** OpenClaw's id for this channel — the plugin's, the config key's, the CLI's. */
+export const WHATSAPP_CHANNEL_ID = "whatsapp";
+
+/** Stop the login this long after the last status poll, exactly like the Hermes manager. */
+export const REAP_AFTER_MS = 60_000;
+/** How often the keepalive watchdog runs. */
+export const TICK_MS = 5_000;
+
+/**
+ * Budget for one `gateway call`.
+ *
+ * `web.login.wait` BLOCKS until the QR rotates or the login completes, so its
+ * own `timeoutMs` param is what bounds it; this is the outer ceiling on the CLI
+ * process, and has to be comfortably larger or we would kill a healthy wait.
+ */
+const RPC_SPAWN_TIMEOUT_MS = 90_000;
+/** What we ask the gateway to wait for a QR rotation / scan before answering. */
+const LOGIN_WAIT_MS = 25_000;
+/** Bound on `web.login.start`, which returns as soon as there is a QR. */
+const LOGIN_START_MS = 30_000;
+
+/** Phases, identical to the Hermes pairing manager's — one panel renders both. */
+export type WhatsappPairPhase =
+  | "idle"
+  | "preparing"
+  | "starting"
+  | "waiting"
+  | "scanned"
+  | "paired"
+  | "error";
+
+export interface OpenclawWhatsappSnapshot {
+  phase: WhatsappPairPhase;
+  /**
+   * Raw Baileys payload. Always null here: the plugin renders the QR itself
+   * and hands back an image, so there is no payload to pass through. The field
+   * stays in the shape because the Hermes path fills it and the panel reads
+   * one snapshot type.
+   */
+  qr: string | null;
+  /** PNG data URL, ready for an `<img src>`. */
+  qrImage: string | null;
+  qrIssuedAt: number | null;
+  qrCount: number;
+  restarts: number;
+  user: { id: string | null; name: string | null } | null;
+  gatewayRestartPending: boolean;
+  /** Machine-readable reason, never a raw stack. */
+  error: string | null;
+  startedAt: number | null;
+}
+
+const IDLE: OpenclawWhatsappSnapshot = {
+  phase: "idle",
+  qr: null,
+  qrImage: null,
+  qrIssuedAt: null,
+  qrCount: 0,
+  restarts: 0,
+  user: null,
+  gatewayRestartPending: false,
+  error: null,
+  startedAt: null,
+};
+
+/** What `web.login.start` / `web.login.wait` answer with. */
+interface WebLoginResult {
+  qrDataUrl?: unknown;
+  connected?: unknown;
+  message?: unknown;
+}
+
+/**
+ * Call one gateway RPC method through the CLI.
+ *
+ * `openclaw gateway call` prints the method's result object with `ok` merged
+ * into it on success, and `{ok:false, error:{...}}` on failure — so `ok` is the
+ * discriminator, not the presence of a `result` wrapper.
+ */
+async function gatewayCall(
+  method: string,
+  params: Record<string, unknown>,
+  timeoutMs: number,
+): Promise<Record<string, unknown>> {
+  const out = await spawnOpenclawCli(
+    [
+      "gateway",
+      "call",
+      method,
+      "--params",
+      JSON.stringify(params),
+      "--json",
+      "--timeout",
+      String(timeoutMs),
+    ],
+    { captureStdout: true, timeoutMs: RPC_SPAWN_TIMEOUT_MS },
+  );
+  const parsed: unknown = JSON.parse(out);
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error(`${method} returned no object`);
+  }
+  const payload = parsed as Record<string, unknown>;
+  if (payload.ok === false) {
+    const error = payload.error as { message?: unknown; code?: unknown } | undefined;
+    // The gateway's own words. Callers map this to a code; nothing renders it
+    // raw, because it can name config paths.
+    throw new Error(
+      typeof error?.message === "string" ? error.message : `${method} failed`,
+    );
+  }
+  return payload;
+}
+
+function readQrDataUrl(result: WebLoginResult): string | null {
+  const value = result.qrDataUrl;
+  // The schema the gateway validates against pins this prefix; re-checking it
+  // here is what stops anything else reaching an <img src> in the panel.
+  return typeof value === "string" && value.startsWith("data:image/png;base64,") ? value : null;
+}
+
+/**
+ * "There is no WhatsApp login provider" — the gateway's answer when the plugin
+ * is not loaded. Worth its own code: it is the one failure the owner fixes by
+ * saving the channel again (which installs the plugin), not by rescanning.
+ */
+function isProviderMissing(err: unknown): boolean {
+  return err instanceof Error && /login provider is not available/i.test(err.message);
+}
+
+/**
+ * Drives `web.login.start` / `web.login.wait` and holds the latest snapshot.
+ *
+ * Mirrors WhatsappPairingManager's contract exactly — `start`/`poll`/`stop`,
+ * the same phases, the same "polling is the liveness signal" rule — so the two
+ * harnesses are interchangeable behind the routes.
+ */
+export class OpenclawWhatsappPairing {
+  private snap: OpenclawWhatsappSnapshot = { ...IDLE };
+  private lastPollAt = 0;
+  private waiting = false;
+  private tickTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly now: () => number;
+
+  constructor(deps: { now?: () => number } = {}) {
+    this.now = deps.now ?? Date.now;
+  }
+
+  peek(): OpenclawWhatsappSnapshot {
+    return { ...this.snap };
+  }
+
+  /** Snapshot AND renew the keepalive. This is what the GET route calls. */
+  poll(): OpenclawWhatsappSnapshot {
+    this.lastPollAt = this.now();
+    return { ...this.snap };
+  }
+
+  /**
+   * Begin (or re-join) a login.
+   *
+   * Idempotent like the Hermes manager, and for a sharper reason here: the
+   * gateway keeps ONE active login per account, and `web.login.start` stops the
+   * running channel to take the socket over. A double-click must not do that
+   * twice.
+   */
+  async start(opts: { force?: boolean } = {}): Promise<OpenclawWhatsappSnapshot> {
+    this.lastPollAt = this.now();
+    if (this.snap.phase === "paired" && !opts.force) return this.peek();
+    if (this.snap.phase === "waiting" && !opts.force) return this.peek();
+
+    this.snap = { ...IDLE, phase: "starting", startedAt: this.now() };
+    this.ensureTicking();
+
+    try {
+      const result = await gatewayCall(
+        "web.login.start",
+        { force: opts.force === true, timeoutMs: LOGIN_START_MS },
+        LOGIN_START_MS,
+      );
+      this.apply(result);
+    } catch (err) {
+      this.snap = {
+        ...this.snap,
+        phase: "error",
+        error: isProviderMissing(err) ? "plugin_missing" : "start_failed",
+      };
+      console.error("[openclaw-whatsapp] login start failed:", err);
+    }
+    return this.peek();
+  }
+
+  stop(): OpenclawWhatsappSnapshot {
+    this.clearTicking();
+    this.snap = { ...IDLE };
+    return this.peek();
+  }
+
+  /** Fold one RPC answer into the snapshot. */
+  private apply(result: WebLoginResult): void {
+    if (result.connected === true) {
+      this.snap = {
+        ...this.snap,
+        phase: "paired",
+        qr: null,
+        qrImage: null,
+        // The channel is linked but the gateway has not been restarted around
+        // it yet, so the panel is told rather than left to imply otherwise —
+        // the same field the Hermes snapshot carries for the same reason.
+        gatewayRestartPending: true,
+        error: null,
+      };
+      return;
+    }
+
+    const qrImage = readQrDataUrl(result);
+    if (!qrImage) {
+      // No image and not connected: the login is alive but between codes.
+      // Deliberately not an error — saying so would flash a failure at an owner
+      // who is mid-scan.
+      return;
+    }
+    const rotated = qrImage !== this.snap.qrImage;
+    this.snap = {
+      ...this.snap,
+      phase: "waiting",
+      qrImage,
+      qrIssuedAt: rotated ? this.now() : this.snap.qrIssuedAt,
+      qrCount: rotated ? this.snap.qrCount + 1 : this.snap.qrCount,
+      error: null,
+    };
+  }
+
+  private ensureTicking(): void {
+    if (this.tickTimer) return;
+    this.tickTimer = setInterval(() => void this.tick(), TICK_MS);
+    // Never hold the process open for a QR nobody is watching.
+    this.tickTimer.unref?.();
+  }
+
+  private clearTicking(): void {
+    if (this.tickTimer) clearInterval(this.tickTimer);
+    this.tickTimer = null;
+  }
+
+  /**
+   * Keep the snapshot fresh while the panel is open.
+   *
+   * "Still polling" is the liveness signal, exactly as on Hermes: close the tab
+   * and this stops within REAP_AFTER_MS, so a forgotten login is not calling
+   * the gateway forever.
+   */
+  private async tick(): Promise<void> {
+    if (this.waiting) return;
+    if (this.snap.phase !== "waiting" && this.snap.phase !== "starting") return;
+    if (this.now() - this.lastPollAt > REAP_AFTER_MS) {
+      this.stop();
+      return;
+    }
+
+    this.waiting = true;
+    try {
+      const result = await gatewayCall(
+        "web.login.wait",
+        {
+          timeoutMs: LOGIN_WAIT_MS,
+          ...(this.snap.qrImage ? { currentQrDataUrl: this.snap.qrImage } : {}),
+        },
+        LOGIN_WAIT_MS + 5_000,
+      );
+      this.apply(result);
+    } catch (err) {
+      // A wait that failed is not a login that failed: the gateway may simply
+      // have been busy. Keep the QR on screen and try again next tick, which is
+      // what the Hermes manager's respawn loop achieves by other means.
+      console.warn(
+        "[openclaw-whatsapp] login wait failed:",
+        err instanceof Error ? err.message : err,
+      );
+    } finally {
+      this.waiting = false;
+    }
+  }
+}
+
+let pairing: OpenclawWhatsappPairing | null = null;
+
+/** Process-wide pairing session, mirroring getPairingManager() on Hermes. */
+export function getOpenclawWhatsappPairing(): OpenclawWhatsappPairing {
+  pairing ??= new OpenclawWhatsappPairing();
+  return pairing;
+}
+
+/** Test seam — resets the module-level session. */
+export function resetOpenclawWhatsappPairing(): void {
+  pairing = null;
+}
+
+export interface OpenclawWhatsappStatus {
+  state: "not_configured" | "enabled_not_paired" | "paired";
+  enabled: boolean;
+  /** A linked-device session exists. */
+  paired: boolean;
+  /** The gateway says the transport is up. */
+  connected: boolean;
+}
+
+/**
+ * What the gateway says about the WhatsApp channel.
+ *
+ * `paired` is derived from the gateway's own account row rather than from a
+ * file under the plugin's auth dir: the dir layout is the plugin's private
+ * business and reading it would be this repo guessing at another project's
+ * internals. `configured` in that row means "there is an account the gateway
+ * can act as", which is exactly the question.
+ */
+export async function readOpenclawWhatsappStatus(): Promise<OpenclawWhatsappStatus> {
+  const channel = await readChannelStatus(WHATSAPP_CHANNEL_ID);
+  if (!channel) {
+    // Unknown, not "off". Reported as not_configured because that is the only
+    // honest thing the panel can offer an action for, and the status card's
+    // `receiving: false` says the rest.
+    return { state: "not_configured", enabled: false, paired: false, connected: false };
+  }
+  const paired = channel.configured;
+  const enabled = channel.configured || channel.running;
+  return {
+    state: !enabled ? "not_configured" : paired ? "paired" : "enabled_not_paired",
+    enabled,
+    paired,
+    connected: channel.connected,
+  };
+}
+
+/** Turn `channels.whatsapp` on or off, leaving every other key alone. */
+export async function setOpenclawWhatsappEnabled(enabled: boolean): Promise<void> {
+  await spawnOpenclawCli(["config", "set", "channels.whatsapp.enabled", String(enabled), "--json"], {
+    timeoutMs: 45_000,
+  });
+}
+
+/**
+ * Drop the stored linked-device session.
+ *
+ * This removes the session from the ClawBox only. The linked-device entry on
+ * the phone stays until the owner removes it in WhatsApp -> Linked Devices,
+ * which is the honest thing to tell them rather than implying a remote revoke —
+ * the same wording the Hermes unpair route already uses.
+ */
+export async function logoutOpenclawWhatsapp(): Promise<void> {
+  await spawnOpenclawCli(["channels", "logout", "--channel", WHATSAPP_CHANNEL_ID], {
+    timeoutMs: 60_000,
+  });
+}

--- a/src/tests/routes/whatsapp/configure.test.ts
+++ b/src/tests/routes/whatsapp/configure.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+vi.mock("@/lib/openclaw-whatsapp", () => ({
+  WHATSAPP_CHANNEL_ID: "whatsapp",
+  setOpenclawWhatsappEnabled: vi.fn(async () => {}),
+}));
+vi.mock("@/lib/openclaw-channels", () => ({
+  ensureChannelPlugin: vi.fn(async () => ({ ok: true, installed: false })),
+  waitForChannelConnected: vi.fn(async () => null),
+}));
+vi.mock("@/lib/openclaw-config", () => ({ restartGateway: vi.fn(async () => {}) }));
 vi.mock("@/lib/hermes-telegram", () => ({ ensureHermesGateway: vi.fn() }));
 vi.mock("@/lib/hermes-whatsapp", async () => {
   // The pure helpers are the contract under test in the unit suite; re-use the
@@ -64,11 +73,14 @@ describe("POST /setup-api/whatsapp/configure", () => {
     expect(mockSet).not.toHaveBeenCalled();
   });
 
-  it("refuses on a non-Hermes harness and writes nothing", async () => {
+  it("never writes Hermes env on an OpenClaw device", async () => {
+    // The 501 this used to assert is gone — OpenClaw has its own leg now (see
+    // openclaw.test.ts). The invariant that survives, and matters more, is that
+    // setHermesWhatsappConfig() is not what answers there: it writes
+    // ~/.hermes/.env, which on an OpenClaw box configures nothing and leaves a
+    // credential file behind for a harness that is not installed.
     mockHarness.mockResolvedValue("openclaw");
-    const res = await post({ enabled: false });
-    expect(res.status).toBe(501);
-    expect((await res.json()).supported).toBe(false);
+    await post({ enabled: false });
     expect(mockSet).not.toHaveBeenCalled();
   });
 

--- a/src/tests/routes/whatsapp/openclaw.test.ts
+++ b/src/tests/routes/whatsapp/openclaw.test.ts
@@ -262,6 +262,16 @@ describe("POST /setup-api/whatsapp/unpair — OpenClaw", () => {
     expect(mockSetEnabled).toHaveBeenCalledWith(false);
   });
 
+  it("ends a live pairing session so no QR outlives the link", async () => {
+    // The keepalive calls web.login.wait every few seconds. Left running
+    // through an unpair it would keep asking about a channel that is now off,
+    // and an in-flight answer would put a QR back on screen for a link the
+    // owner just removed.
+    await POST_unpair();
+
+    expect(mockPairing.mock.results[0].value.stop).toHaveBeenCalled();
+  });
+
   it("still turns the channel off when the logout fails", async () => {
     // Creds without the channel switched off is a gateway retrying a login it
     // cannot complete; the two have to move together.

--- a/src/tests/routes/whatsapp/openclaw.test.ts
+++ b/src/tests/routes/whatsapp/openclaw.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * The four WhatsApp routes on the OPENCLAW edition.
+ *
+ * All four used to answer a flat refusal:
+ *
+ *     { error: "WhatsApp is only available on the Hermes edition", supported: false }  // 501
+ *
+ * which was honest when it was written — the OpenClaw WhatsApp channel is a
+ * separately-installed plugin whose only documented login is an interactive QR
+ * command, and /whatsapp/status said so: "none of it is verifiable from a
+ * ClawBox build".
+ *
+ * It is verifiable now. `@openclaw/whatsapp` exposes `loginWithQrStart` /
+ * `loginWithQrWait`, the gateway publishes them as the `web.login.start` and
+ * `web.login.wait` RPC methods, and `openclaw gateway call` invokes those
+ * non-interactively — returning a PNG data URL rather than terminal ASCII art.
+ *
+ * THE RULE THIS FILE HOLDS: the OUTSIDE does not change. Same routes, same
+ * request and response shapes, same phases, so the panel's pairing UX is the
+ * one the owner already has on Hermes. Only what happens underneath differs.
+ */
+
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+vi.mock("@/lib/openclaw-channels", () => ({
+  ensureChannelPlugin: vi.fn(),
+  readChannelStatus: vi.fn(),
+  waitForChannelConnected: vi.fn(),
+}));
+vi.mock("@/lib/openclaw-whatsapp", () => ({
+  WHATSAPP_CHANNEL_ID: "whatsapp",
+  getOpenclawWhatsappPairing: vi.fn(),
+  logoutOpenclawWhatsapp: vi.fn(),
+  readOpenclawWhatsappStatus: vi.fn(),
+  setOpenclawWhatsappEnabled: vi.fn(),
+}));
+vi.mock("@/lib/openclaw-config", () => ({ restartGateway: vi.fn() }));
+vi.mock("@/lib/hermes-whatsapp", () => ({
+  isWhatsappMode: (v: unknown) => v === "personal" || v === "business",
+  normalizeWhatsappNumber: (v: string) => (/^\+?\d{6,15}$/.test(v) ? v.replace(/^\+/, "") : null),
+  setHermesWhatsappConfig: vi.fn(),
+  WhatsappNotPairedError: class extends Error {},
+  whatsappSessionDirs: () => [],
+  readHermesWhatsappStatus: vi.fn(),
+}));
+vi.mock("@/lib/hermes-telegram", () => ({
+  ensureHermesGateway: vi.fn(),
+  hermesGatewayStatus: vi.fn(async () => ({ installed: false, running: false, scope: null })),
+}));
+vi.mock("@/lib/whatsapp-pairing", () => ({
+  getPairingManager: vi.fn(),
+  unpairWhatsapp: vi.fn(),
+}));
+
+import { getActiveHarness } from "@/lib/harness";
+import { restartGateway } from "@/lib/openclaw-config";
+import { ensureChannelPlugin, waitForChannelConnected } from "@/lib/openclaw-channels";
+import {
+  getOpenclawWhatsappPairing,
+  logoutOpenclawWhatsapp,
+  readOpenclawWhatsappStatus,
+  setOpenclawWhatsappEnabled,
+} from "@/lib/openclaw-whatsapp";
+
+const mockHarness = vi.mocked(getActiveHarness);
+const mockEnsurePlugin = vi.mocked(ensureChannelPlugin);
+const mockWait = vi.mocked(waitForChannelConnected);
+const mockPairing = vi.mocked(getOpenclawWhatsappPairing);
+const mockLogout = vi.mocked(logoutOpenclawWhatsapp);
+const mockStatus = vi.mocked(readOpenclawWhatsappStatus);
+const mockSetEnabled = vi.mocked(setOpenclawWhatsappEnabled);
+const mockRestart = vi.mocked(restartGateway);
+
+const IDLE_SNAPSHOT = {
+  phase: "idle" as const,
+  qr: null,
+  qrImage: null,
+  qrIssuedAt: null,
+  qrCount: 0,
+  restarts: 0,
+  user: null,
+  gatewayRestartPending: false,
+  error: null,
+  startedAt: null,
+};
+
+function connectedChannel() {
+  return {
+    configured: true,
+    running: true,
+    connected: true,
+    tokenStatus: "available" as const,
+    restartPending: false,
+    lastError: null,
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockHarness.mockResolvedValue("openclaw");
+  mockEnsurePlugin.mockResolvedValue({ ok: true, installed: false });
+  mockWait.mockResolvedValue(connectedChannel());
+  mockSetEnabled.mockResolvedValue();
+  mockRestart.mockResolvedValue();
+  mockLogout.mockResolvedValue();
+  mockStatus.mockResolvedValue({
+    state: "paired",
+    enabled: true,
+    paired: true,
+    connected: true,
+  });
+  mockPairing.mockReturnValue({
+    start: vi.fn(async () => ({ ...IDLE_SNAPSHOT, phase: "waiting" as const, qrImage: "data:image/png;base64,AAAA" })),
+    poll: vi.fn(() => ({ ...IDLE_SNAPSHOT, phase: "waiting" as const, qrImage: "data:image/png;base64,AAAA" })),
+    stop: vi.fn(() => ({ ...IDLE_SNAPSHOT })),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+});
+
+describe("POST /setup-api/whatsapp/configure — OpenClaw", () => {
+  async function post(body: unknown) {
+    const { POST } = await import("@/app/setup-api/whatsapp/configure/route");
+    const res = await POST(
+      new Request("http://localhost/setup-api/whatsapp/configure", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    );
+    return { status: res.status, body: await res.json() };
+  }
+
+  it("no longer refuses on OpenClaw", async () => {
+    const res = await post({ enabled: true });
+
+    expect(res.status).not.toBe(501);
+    expect(res.body.supported).not.toBe(false);
+  });
+
+  it("installs the WhatsApp channel plugin before enabling the channel", async () => {
+    await post({ enabled: true });
+
+    expect(mockEnsurePlugin).toHaveBeenCalledWith("whatsapp");
+    expect(mockEnsurePlugin.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSetEnabled.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not report success when the channel never reaches connected", async () => {
+    mockWait.mockResolvedValue({ ...connectedChannel(), running: false, connected: false });
+
+    const res = await post({ enabled: true });
+
+    expect(res.body.success).toBe(false);
+    expect(res.body.warning).toBe("not_connected");
+  });
+
+  it("names a failed plugin install", async () => {
+    mockEnsurePlugin.mockResolvedValue({ ok: false, reason: "install_failed" });
+
+    expect((await post({ enabled: true })).body.warning).toBe("plugin_install_failed");
+  });
+
+  it("refuses an allowlist OpenClaw does not own, rather than silently dropping it", async () => {
+    // OpenClaw admits senders through its own owner-approved pairing, exactly
+    // as it does for Discord. Accepting the numbers and writing nothing would
+    // hand back an allowlist the owner believes is in force.
+    const res = await post({ allowedUsers: ["359888123456"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.allowlistSupported).toBe(false);
+    expect(mockSetEnabled).not.toHaveBeenCalled();
+  });
+
+  it("turns the channel off without touching the stored link", async () => {
+    const res = await post({ enabled: false });
+
+    expect(mockSetEnabled).toHaveBeenCalledWith(false);
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(res.body.success).toBe(true);
+  });
+});
+
+describe("GET /setup-api/whatsapp/status — OpenClaw", () => {
+  async function get() {
+    const { GET } = await import("@/app/setup-api/whatsapp/status/route");
+    const res = await GET();
+    return { status: res.status, body: await res.json() };
+  }
+
+  it("reports the channel as supported instead of 'unsupported'", async () => {
+    const res = await get();
+
+    expect(res.body.supported).toBe(true);
+    expect(res.body.state).toBe("paired");
+  });
+
+  it("is receiving only when the gateway says the transport is up", async () => {
+    mockStatus.mockResolvedValue({ state: "paired", enabled: true, paired: true, connected: false });
+
+    expect((await get()).body.receiving).toBe(false);
+  });
+
+  it("offers no allowlist, because OpenClaw owns sender approval", async () => {
+    expect((await get()).body.allowlistSupported).toBe(false);
+  });
+
+  it("reports a link that exists but is switched off", async () => {
+    mockStatus.mockResolvedValue({
+      state: "enabled_not_paired",
+      enabled: true,
+      paired: false,
+      connected: false,
+    });
+
+    const res = await get();
+    expect(res.body.state).toBe("enabled_not_paired");
+    expect(res.body.receiving).toBe(false);
+  });
+});
+
+describe("/setup-api/whatsapp/pair — OpenClaw", () => {
+  it("starts a QR login and hands back a renderable image", async () => {
+    const { POST } = await import("@/app/setup-api/whatsapp/pair/route");
+    const res = await POST(new Request("http://localhost/setup-api/whatsapp/pair", { method: "POST" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.supported).toBe(true);
+    expect(body.phase).toBe("waiting");
+    // The plugin renders the QR itself; there is no raw Baileys payload to
+    // hand out on this harness, so the panel gets an image instead.
+    expect(body.qrImage).toMatch(/^data:image\/png;base64,/);
+  });
+
+  it("polls without spawning a second login", async () => {
+    const { GET } = await import("@/app/setup-api/whatsapp/pair/route");
+    const body = await (await GET()).json();
+
+    expect(body.phase).toBe("waiting");
+    expect(mockPairing.mock.results[0].value.start).not.toHaveBeenCalled();
+  });
+
+  it("cancels", async () => {
+    const { DELETE } = await import("@/app/setup-api/whatsapp/pair/route");
+    const body = await (await DELETE()).json();
+
+    expect(body.phase).toBe("idle");
+  });
+});
+
+describe("POST /setup-api/whatsapp/unpair — OpenClaw", () => {
+  it("logs the session out and turns the channel off together", async () => {
+    const { POST } = await import("@/app/setup-api/whatsapp/unpair/route");
+    const res = await POST();
+    const body = await res.json();
+
+    expect(body.success).toBe(true);
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockSetEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it("still turns the channel off when the logout fails", async () => {
+    // Creds without the channel switched off is a gateway retrying a login it
+    // cannot complete; the two have to move together.
+    mockLogout.mockRejectedValue(new Error("gateway unreachable"));
+
+    const res = await POST_unpair();
+    expect(mockSetEnabled).toHaveBeenCalledWith(false);
+    expect(res.status).toBe(500);
+  });
+
+  async function POST_unpair() {
+    const { POST } = await import("@/app/setup-api/whatsapp/unpair/route");
+    return POST();
+  }
+});

--- a/src/tests/routes/whatsapp/pair.test.ts
+++ b/src/tests/routes/whatsapp/pair.test.ts
@@ -6,6 +6,7 @@ const openclawStart = vi.fn(async () => ({ phase: "waiting", qr: null, qrImage: 
 const openclawPoll = vi.fn(() => ({ phase: "waiting", qr: null, qrImage: null }));
 const openclawStop = vi.fn(() => ({ phase: "idle", qr: null, qrImage: null }));
 const openclawLogout = vi.fn(async () => {});
+const openclawSetEnabled = vi.fn(async () => {});
 vi.mock("@/lib/openclaw-whatsapp", () => ({
   WHATSAPP_CHANNEL_ID: "whatsapp",
   getOpenclawWhatsappPairing: () => ({
@@ -14,7 +15,7 @@ vi.mock("@/lib/openclaw-whatsapp", () => ({
     stop: openclawStop,
   }),
   logoutOpenclawWhatsapp: openclawLogout,
-  setOpenclawWhatsappEnabled: vi.fn(async () => {}),
+  setOpenclawWhatsappEnabled: openclawSetEnabled,
 }));
 vi.mock("@/lib/openclaw-config", () => ({ restartGateway: vi.fn(async () => {}) }));
 
@@ -200,6 +201,9 @@ describe("POST /setup-api/whatsapp/unpair", () => {
 
     expect(unpair).not.toHaveBeenCalled();
     expect(openclawLogout).toHaveBeenCalled();
+    // Both halves move together: a session dropped while the channel stays on
+    // leaves the gateway retrying a login it cannot complete.
+    expect(openclawSetEnabled).toHaveBeenCalledWith(false);
   });
 
   it("reports a failure instead of claiming success", async () => {

--- a/src/tests/routes/whatsapp/pair.test.ts
+++ b/src/tests/routes/whatsapp/pair.test.ts
@@ -2,6 +2,22 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 
+const openclawStart = vi.fn(async () => ({ phase: "waiting", qr: null, qrImage: null }));
+const openclawPoll = vi.fn(() => ({ phase: "waiting", qr: null, qrImage: null }));
+const openclawStop = vi.fn(() => ({ phase: "idle", qr: null, qrImage: null }));
+const openclawLogout = vi.fn(async () => {});
+vi.mock("@/lib/openclaw-whatsapp", () => ({
+  WHATSAPP_CHANNEL_ID: "whatsapp",
+  getOpenclawWhatsappPairing: () => ({
+    start: openclawStart,
+    poll: openclawPoll,
+    stop: openclawStop,
+  }),
+  logoutOpenclawWhatsapp: openclawLogout,
+  setOpenclawWhatsappEnabled: vi.fn(async () => {}),
+}));
+vi.mock("@/lib/openclaw-config", () => ({ restartGateway: vi.fn(async () => {}) }));
+
 const start = vi.fn();
 const poll = vi.fn();
 const stop = vi.fn();
@@ -89,14 +105,16 @@ describe("POST /setup-api/whatsapp/pair", () => {
     expect(start).toHaveBeenCalledWith({ force: false });
   });
 
-  it("refuses on a non-Hermes harness without touching the bridge", async () => {
+  it("routes an OpenClaw device to its own pairing, never to the Hermes bridge", async () => {
+    // The 501 these three tests used to assert is gone: OpenClaw pairs through
+    // the gateway's web.login RPC (see openclaw.test.ts). What must still hold
+    // is that the Hermes bridge — a Baileys process against ~/.hermes — is not
+    // what answers on the other harness.
     mockHarness.mockResolvedValue("openclaw");
-    const res = await POST(req({}));
-    const body = await res.json();
+    await POST(req({}));
 
-    expect(res.status).toBe(501);
-    expect(body.supported).toBe(false);
     expect(start).not.toHaveBeenCalled();
+    expect(openclawStart).toHaveBeenCalled();
   });
 
   it("returns 500 rather than a half-answer when the manager throws", async () => {
@@ -134,11 +152,11 @@ describe("GET /setup-api/whatsapp/pair", () => {
     expect(poll).toHaveBeenCalledTimes(1);
   });
 
-  it("refuses on a non-Hermes harness", async () => {
+  it("polls the OpenClaw session, not the Hermes bridge", async () => {
     mockHarness.mockResolvedValue("openclaw");
-    const res = await GET();
-    expect(res.status).toBe(501);
+    await GET();
     expect(poll).not.toHaveBeenCalled();
+    expect(openclawPoll).toHaveBeenCalled();
   });
 });
 
@@ -152,11 +170,11 @@ describe("DELETE /setup-api/whatsapp/pair", () => {
     expect(stop).toHaveBeenCalledTimes(1);
   });
 
-  it("refuses on a non-Hermes harness", async () => {
+  it("stops the OpenClaw session, not the Hermes bridge", async () => {
     mockHarness.mockResolvedValue("openclaw");
-    const res = await DELETE();
-    expect(res.status).toBe(501);
+    await DELETE();
     expect(stop).not.toHaveBeenCalled();
+    expect(openclawStop).toHaveBeenCalled();
   });
 });
 
@@ -173,12 +191,15 @@ describe("POST /setup-api/whatsapp/unpair", () => {
     ]);
   });
 
-  it("refuses on a non-Hermes harness without deleting anything", async () => {
+  it("never deletes a Hermes session directory on an OpenClaw device", async () => {
+    // unpairWhatsapp() removes ~/.hermes/**/session. On OpenClaw the link lives
+    // in the plugin's own auth dir and is dropped through `channels logout`, so
+    // reaching for the Hermes paths here would delete the wrong box's files.
     mockHarness.mockResolvedValue("openclaw");
-    const res = await UNPAIR();
+    await UNPAIR();
 
-    expect(res.status).toBe(501);
     expect(unpair).not.toHaveBeenCalled();
+    expect(openclawLogout).toHaveBeenCalled();
   });
 
   it("reports a failure instead of claiming success", async () => {

--- a/src/tests/routes/whatsapp/status.test.ts
+++ b/src/tests/routes/whatsapp/status.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+vi.mock("@/lib/openclaw-whatsapp", () => ({
+  readOpenclawWhatsappStatus: vi.fn(async () => ({
+    state: "not_configured",
+    enabled: false,
+    paired: false,
+    connected: false,
+  })),
+}));
 vi.mock("@/lib/hermes-telegram", () => ({ hermesGatewayStatus: vi.fn() }));
 vi.mock("@/lib/hermes-whatsapp", () => ({ readHermesWhatsappStatus: vi.fn() }));
 
@@ -35,15 +43,18 @@ beforeEach(async () => {
 });
 
 describe("GET /setup-api/whatsapp/status", () => {
-  it("reports supported:false on a non-Hermes harness without touching Hermes", async () => {
+  it("answers from the OpenClaw channel, without touching Hermes", async () => {
+    // This used to assert `supported: false` / `state: "unsupported"`, which
+    // was the honest answer while the OpenClaw WhatsApp plugin had no surface
+    // a ClawBox build could drive. It has one now — see
+    // src/tests/routes/whatsapp/openclaw.test.ts for that branch's contract.
+    // What still has to hold here is that the Hermes probes stay untouched.
     mockHarness.mockResolvedValue("openclaw");
     const res = await GET();
     const body = await res.json();
 
     expect(res.status).toBe(200);
-    expect(body.supported).toBe(false);
-    expect(body.state).toBe("unsupported");
-    // Nothing OpenClaw-side is guessed at or written.
+    expect(body.harness).toBe("openclaw");
     expect(mockStatus).not.toHaveBeenCalled();
     expect(mockGateway).not.toHaveBeenCalled();
   });

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -180,6 +180,37 @@ describe("OpenclawWhatsappPairing", () => {
     }
   });
 
+  it("discards a wait that belongs to a session already stopped", async () => {
+    // `web.login.wait` can be in flight for tens of seconds. Without the epoch
+    // guard its answer — a QR for a login the gateway has since torn down —
+    // landed in the idle snapshot, and the panel showed a code that could
+    // never be scanned.
+    vi.useFakeTimers();
+    try {
+      mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+      const pairing = new lib.OpenclawWhatsappPairing();
+      await pairing.start();
+
+      let releaseWait: (value: string) => void = () => {};
+      mockSpawn.mockReturnValueOnce(
+        new Promise<string>((resolve) => {
+          releaseWait = resolve;
+        }),
+      );
+      // Let the tick fire and block inside the wait.
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS + 1);
+
+      pairing.stop();
+      releaseWait(rpcOk({ qrDataUrl: QR_B }));
+      await vi.advanceTimersByTimeAsync(1);
+
+      expect(pairing.peek().phase).toBe("idle");
+      expect(pairing.peek().qrImage).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("stops cleanly", async () => {
     mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
     const pairing = new lib.OpenclawWhatsappPairing();

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+/**
+ * The OpenClaw WhatsApp pairing session.
+ *
+ * It holds no child process — the gateway owns the login — so what is worth
+ * pinning here is the translation between `web.login.*` answers and the
+ * snapshot the panel renders, and the two rules that keep it honest:
+ * a QR is only ever a QR the gateway actually sent, and a login nobody is
+ * watching stops.
+ */
+
+vi.mock("@/lib/openclaw-config", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/openclaw-config")>(
+    "@/lib/openclaw-config",
+  );
+  return { ...actual, openclawIsAbsent: () => false, spawnOpenclawCli: vi.fn() };
+});
+vi.mock("@/lib/openclaw-channels", () => ({ readChannelStatus: vi.fn() }));
+
+import { spawnOpenclawCli } from "@/lib/openclaw-config";
+import { readChannelStatus } from "@/lib/openclaw-channels";
+
+const mockSpawn = vi.mocked(spawnOpenclawCli);
+const mockChannel = vi.mocked(readChannelStatus);
+
+const QR_A = "data:image/png;base64,AAAA";
+const QR_B = "data:image/png;base64,BBBB";
+
+/** What `openclaw gateway call` prints: the result object with `ok` merged in. */
+function rpcOk(result: Record<string, unknown>) {
+  return JSON.stringify({ ok: true, ...result });
+}
+function rpcError(message: string) {
+  return JSON.stringify({ ok: false, error: { message } });
+}
+
+describe("OpenclawWhatsappPairing", () => {
+  let lib: typeof import("@/lib/openclaw-whatsapp");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    lib = await import("@/lib/openclaw-whatsapp");
+  });
+
+  it("starts a login and exposes the QR the gateway rendered", async () => {
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.phase).toBe("waiting");
+    expect(snap.qrImage).toBe(QR_A);
+    // There is no raw payload on this harness; the field stays null rather than
+    // carrying a data URL the panel would try to re-encode as a QR.
+    expect(snap.qr).toBeNull();
+    expect(snap.qrCount).toBe(1);
+    expect(mockSpawn.mock.calls[0][0].slice(0, 3)).toEqual(["gateway", "call", "web.login.start"]);
+  });
+
+  it("reports a completed link as paired, with the restart still pending", async () => {
+    mockSpawn.mockResolvedValueOnce(rpcOk({ connected: true }));
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.phase).toBe("paired");
+    expect(snap.qrImage).toBeNull();
+    // Linked is not yet receiving: the channel config reaches the gateway at
+    // start, so until it restarts the box is paired and answering nobody.
+    expect(snap.gatewayRestartPending).toBe(true);
+  });
+
+  it("refuses to put anything but a PNG data URL in front of an <img>", async () => {
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: "javascript:alert(1)" }));
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.qrImage).toBeNull();
+    expect(snap.phase).toBe("starting");
+  });
+
+  it("names a missing plugin, because that one is fixed by saving, not rescanning", async () => {
+    mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.phase).toBe("error");
+    expect(snap.error).toBe("plugin_missing");
+  });
+
+  it("reports any other start failure as a code, never as the gateway's sentence", async () => {
+    mockSpawn.mockResolvedValueOnce(rpcError("connect ECONNREFUSED /home/clawbox/.openclaw/gateway.sock"));
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.phase).toBe("error");
+    expect(snap.error).toBe("start_failed");
+    // The gateway's text can name paths; it belongs in the log, not the panel.
+    expect(JSON.stringify(snap)).not.toContain("/home/clawbox");
+  });
+
+  it("does not start a second login behind a double-click", async () => {
+    mockSpawn.mockResolvedValue(rpcOk({ qrDataUrl: QR_A }));
+    const pairing = new lib.OpenclawWhatsappPairing();
+
+    await pairing.start();
+    await pairing.start();
+
+    // `web.login.start` stops the running channel to take the socket over;
+    // doing that twice would tear down a login that was already up.
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-starts when the caller explicitly forces it", async () => {
+    mockSpawn.mockResolvedValue(rpcOk({ qrDataUrl: QR_A }));
+    const pairing = new lib.OpenclawWhatsappPairing();
+
+    await pairing.start();
+    await pairing.start({ force: true });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(mockSpawn.mock.calls[1][0][4])).force).toBe(true);
+  });
+
+  it("begins a fresh session on a forced restart", async () => {
+    // force is the panel's "start over" button, so the counters start over too
+    // — a rotation count carried across a deliberate restart would describe a
+    // session that no longer exists.
+    mockSpawn.mockResolvedValue(rpcOk({ qrDataUrl: QR_A }));
+    const pairing = new lib.OpenclawWhatsappPairing();
+
+    await pairing.start();
+    await pairing.start({ force: true });
+
+    expect(pairing.peek().qrCount).toBe(1);
+  });
+
+  it("counts a rotation only when the code actually changed", async () => {
+    // Rotation happens in the keepalive loop, not in start(): the gateway holds
+    // the QR open and `web.login.wait` answers with the next one.
+    vi.useFakeTimers();
+    try {
+      mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+      const pairing = new lib.OpenclawWhatsappPairing();
+      await pairing.start();
+      expect(pairing.peek().qrCount).toBe(1);
+
+      // The same code again is the gateway re-answering, not a new code.
+      mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS + 1);
+      expect(pairing.peek().qrCount).toBe(1);
+
+      mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_B }));
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS + 1);
+      expect(pairing.peek().qrImage).toBe(QR_B);
+      expect(pairing.peek().qrCount).toBe(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops asking the gateway once nobody is polling", async () => {
+    vi.useFakeTimers();
+    try {
+      mockSpawn.mockResolvedValue(rpcOk({ qrDataUrl: QR_A }));
+      const pairing = new lib.OpenclawWhatsappPairing();
+      await pairing.start();
+      const callsAfterStart = mockSpawn.mock.calls.length;
+
+      // Nobody polls for longer than the reap window: the panel is closed.
+      await vi.advanceTimersByTimeAsync(lib.REAP_AFTER_MS + lib.TICK_MS * 2);
+      expect(pairing.peek().phase).toBe("idle");
+
+      const callsAfterReap = mockSpawn.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS * 4);
+      expect(mockSpawn.mock.calls.length).toBe(callsAfterReap);
+      expect(callsAfterReap).toBeGreaterThanOrEqual(callsAfterStart);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops cleanly", async () => {
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: QR_A }));
+    const pairing = new lib.OpenclawWhatsappPairing();
+    await pairing.start();
+
+    expect(pairing.stop().phase).toBe("idle");
+    expect(pairing.peek().qrImage).toBeNull();
+  });
+});
+
+describe("readOpenclawWhatsappStatus", () => {
+  let lib: typeof import("@/lib/openclaw-whatsapp");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    lib = await import("@/lib/openclaw-whatsapp");
+  });
+
+  function row(over: Record<string, unknown> = {}) {
+    return {
+      configured: true,
+      running: true,
+      connected: true,
+      tokenStatus: null,
+      restartPending: false,
+      lastError: null,
+      ...over,
+    } as NonNullable<Awaited<ReturnType<typeof readChannelStatus>>>;
+  }
+
+  it("reports a live channel as paired and connected", async () => {
+    mockChannel.mockResolvedValue(row());
+    expect(await lib.readOpenclawWhatsappStatus()).toEqual({
+      state: "paired",
+      enabled: true,
+      paired: true,
+      connected: true,
+    });
+  });
+
+  it("does not call an unconnected channel 'receiving' material", async () => {
+    mockChannel.mockResolvedValue(row({ connected: false }));
+    expect((await lib.readOpenclawWhatsappStatus()).connected).toBe(false);
+  });
+
+  it("reports an enabled-but-unlinked channel distinctly", async () => {
+    mockChannel.mockResolvedValue(row({ configured: false, connected: false }));
+    expect((await lib.readOpenclawWhatsappStatus()).state).toBe("enabled_not_paired");
+  });
+
+  it("never invents a link when the gateway could not be asked", async () => {
+    mockChannel.mockResolvedValue(null);
+    expect(await lib.readOpenclawWhatsappStatus()).toEqual({
+      state: "not_configured",
+      enabled: false,
+      paired: false,
+      connected: false,
+    });
+  });
+});

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -16,13 +16,13 @@ vi.mock("@/lib/openclaw-config", async () => {
   );
   return { ...actual, openclawIsAbsent: () => false, spawnOpenclawCli: vi.fn() };
 });
-vi.mock("@/lib/openclaw-channels", () => ({ readChannelStatus: vi.fn() }));
+vi.mock("@/lib/openclaw-channels", () => ({ readChannelRow: vi.fn() }));
 
 import { spawnOpenclawCli } from "@/lib/openclaw-config";
-import { readChannelStatus } from "@/lib/openclaw-channels";
+import { readChannelRow } from "@/lib/openclaw-channels";
 
 const mockSpawn = vi.mocked(spawnOpenclawCli);
-const mockChannel = vi.mocked(readChannelStatus);
+const mockChannel = vi.mocked(readChannelRow);
 
 const QR_A = "data:image/png;base64,AAAA";
 const QR_B = "data:image/png;base64,BBBB";
@@ -233,19 +233,22 @@ describe("readOpenclawWhatsappStatus", () => {
     lib = await import("@/lib/openclaw-whatsapp");
   });
 
+  /** The gateway's real WhatsApp account row, narrowed to what we read. */
   function row(over: Record<string, unknown> = {}) {
     return {
+      accountId: "default",
+      enabled: true,
       configured: true,
-      running: true,
+      linked: true,
+      statusState: "ready",
       connected: true,
-      tokenStatus: null,
-      restartPending: false,
+      running: true,
       lastError: null,
       ...over,
-    } as NonNullable<Awaited<ReturnType<typeof readChannelStatus>>>;
+    };
   }
 
-  it("reports a live channel as paired and connected", async () => {
+  it("reports a linked, connected channel as paired", async () => {
     mockChannel.mockResolvedValue(row());
     expect(await lib.readOpenclawWhatsappStatus()).toEqual({
       state: "paired",
@@ -256,13 +259,42 @@ describe("readOpenclawWhatsappStatus", () => {
   });
 
   it("does not call an unconnected channel 'receiving' material", async () => {
-    mockChannel.mockResolvedValue(row({ connected: false }));
+    mockChannel.mockResolvedValue(row({ connected: false, running: false }));
     expect((await lib.readOpenclawWhatsappStatus()).connected).toBe(false);
   });
 
-  it("reports an enabled-but-unlinked channel distinctly", async () => {
-    mockChannel.mockResolvedValue(row({ configured: false, connected: false }));
-    expect((await lib.readOpenclawWhatsappStatus()).state).toBe("enabled_not_paired");
+  it("does NOT call an installed-but-unscanned channel paired", async () => {
+    // The bug this pins, caught on hardware. Installing the plugin and
+    // enabling the channel makes the gateway report `configured: true` with
+    // NOTHING scanned — `configured` means "there is an account entry", not
+    // "a device is linked". Reading it as paired told the panel a phone was
+    // connected when no QR had ever been shown.
+    //
+    // `linked` is the field that answers the question, and the gateway
+    // publishes `statusState: "not-linked"` and `lastError: "not linked"`
+    // alongside it.
+    mockChannel.mockResolvedValue(
+      row({
+        configured: true,
+        linked: false,
+        statusState: "not-linked",
+        connected: false,
+        running: false,
+        lastError: "not linked",
+      }),
+    );
+
+    const status = await lib.readOpenclawWhatsappStatus();
+    expect(status.paired).toBe(false);
+    expect(status.state).toBe("enabled_not_paired");
+    expect(status.connected).toBe(false);
+  });
+
+  it("reports a channel that is off at all as not_configured", async () => {
+    mockChannel.mockResolvedValue(
+      row({ enabled: false, configured: false, linked: false, connected: false, running: false }),
+    );
+    expect((await lib.readOpenclawWhatsappStatus()).state).toBe("not_configured");
   });
 
   it("never invents a link when the gateway could not be asked", async () => {

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -197,8 +197,11 @@ describe("OpenclawWhatsappPairing", () => {
           releaseWait = resolve;
         }),
       );
-      // Let the tick fire and block inside the wait.
+      // Let the tick fire and block inside the wait. Asserting the call
+      // happened is what makes this a race test: without it, the expectations
+      // below are satisfied by stop() alone even if tick() never ran.
       await vi.advanceTimersByTimeAsync(lib.TICK_MS + 1);
+      expect(mockSpawn).toHaveBeenCalledTimes(2);
 
       pairing.stop();
       releaseWait(rpcOk({ qrDataUrl: QR_B }));

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -79,6 +79,24 @@ describe("OpenclawWhatsappPairing", () => {
     expect(snap.phase).toBe("starting");
   });
 
+  it("rejects a data URL with no image in it", async () => {
+    // `"data:image/png;base64,"` is a well-formed data URL for an EMPTY image.
+    // It passes a prefix check, and would put a blank square on screen in the
+    // waiting phase — a QR the owner is invited to scan and cannot.
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: "data:image/png;base64," }));
+
+    const snap = await new lib.OpenclawWhatsappPairing().start();
+
+    expect(snap.qrImage).toBeNull();
+    expect(snap.phase).toBe("starting");
+  });
+
+  it("rejects a payload outside the base64 alphabet", async () => {
+    mockSpawn.mockResolvedValueOnce(rpcOk({ qrDataUrl: "data:image/png;base64,<script>" }));
+
+    expect((await new lib.OpenclawWhatsappPairing().start()).qrImage).toBeNull();
+  });
+
   it("names a missing plugin, because that one is fixed by saving, not rescanning", async () => {
     mockSpawn.mockResolvedValueOnce(rpcError("web login provider is not available"));
 


### PR DESCRIPTION
Follow-up to #535, which made a channel install its own plugin and stop reporting success before the channel connects. This does the same for WhatsApp, and lifts the refusal that made it Hermes-only.

## What was refused, and why that is no longer the honest answer

All four routes answered:

```json
{ "error": "WhatsApp is only available on the Hermes edition", "supported": false }   // 501
```

`/whatsapp/status` explained itself, and was right at the time:

> OpenClaw documents a WhatsApp channel, but it is a separately-installed plugin whose only login path is an interactive QR command, and none of it is verifiable from a ClawBox build.

The first half still holds — `@openclaw/whatsapp` is an npm plugin, and `openclaw channels login --channel whatsapp` renders ASCII art to a TTY. The second half does not:

* the plugin exposes `loginWithQrStart` / `loginWithQrWait` on its channel API (`dist/channel-*.js`);
* the gateway publishes those as the **`web.login.start`** and **`web.login.wait`** RPC methods (`webHandlers` in the gateway's web module);
* `openclaw gateway call <method> --params <json> --json` invokes any gateway method non-interactively.

So the panel drives the *real* pairing flow, gets a **PNG data URL** back instead of terminal art, and this repo neither needs a PTY nor reimplements Baileys. It is the same argument `src/lib/whatsapp-pairing.ts` already makes about `hermes whatsapp`: **the wizard needs a terminal, the pairing does not.**

Confirmed live on 192.168.50.71 — the method exists and fails honestly where the plugin is absent:

```
$ openclaw gateway call web.login.start --params '{}' --json
{ "ok": false, "error": { "code": "INVALID_REQUEST",
                          "message": "web login provider is not available" } }
```

and its parameter schema is `{force?, timeoutMs?, verbose?, accountId?}` — no channel argument, because the gateway resolves the one loaded plugin that offers a web login.

## The outside does not change

Same four routes, same request and response shapes, same phases (`idle → starting → waiting → scanned → paired`), so the owner gets the pairing UX he already has on Hermes. `activePairing()` picks the manager for the running harness and every handler reads identically.

What differs is underneath, and it is a simplification:

| | Hermes | OpenClaw |
|---|---|---|
| who owns the login | this repo — spawns `bridge.js`, parses its JSON lines, respawns it, reaps it | the gateway |
| what the QR is | raw Baileys payload; the panel draws the code | a PNG the plugin already rendered |
| liveness | polling keeps the bridge alive | polling keeps the RPC keepalive alive |

Both keep the identical rule: **polling is the liveness signal**. Close the tab and the session stops within `REAP_AFTER_MS`, so a forgotten login is not calling the gateway forever.

The panel renders whichever it is given — `QRCodeSVG` for a raw payload, `<img>` for the pre-rendered PNG. `qr` wins if both ever appear: a vector at any zoom beats a fixed bitmap. Nothing but a `data:image/png;base64,` string can reach that `<img src>`; it is re-checked server-side after the gateway's own schema has.

## Two refusals rather than silent no-ops

**No allowlist, no mode.** OpenClaw admits senders through its own owner-approved pairing, which ClawBox does not write — exactly as on the Discord panel, which reports `allowlistSupported: false`. Accepting numbers and writing nothing would hand back a list the owner believes is in force, so `/configure` answers 400 with `allowlist_unsupported`.

**Enabling installs the plugin first.** OpenClaw's stock extensions contain no WhatsApp at all, and a `channels.whatsapp` block with no plugin to own it is the `no-channel-owner` state #535 exists to remove. The save then inherits #535's contract in full: it does not call itself a success until the gateway says the channel is up, and names `plugin_install_failed` / `plugin_install_timeout` / `restart_pending` / `channel_unverified` / `not_connected` when it is not.

`unpair` moves both halves together and switches the channel off **even when the logout fails** — credentials without the channel disabled is a gateway retrying a login it cannot complete. The failure is still reported, not swallowed. As on Hermes, this clears the ClawBox side only: the linked-device entry on the phone stays until the owner removes it in WhatsApp → Linked Devices.

No env SecretRef anywhere here: WhatsApp Web authenticates with stored linked-device credentials, not a bot token, so there is nothing for `envSecretRef()` to mint.

## Tests

RED-first against `origin/beta`: the new route suite failed 15/15, led by `expected 501 not to be 501`.

Four pre-existing tests asserted the refusal this PR removes. They are not deleted but **inverted onto the invariant that survives** — that the Hermes machinery is not what answers on OpenClaw:

* `setHermesWhatsappConfig()` must not run (it writes `~/.hermes/.env`, a credential file for a harness that is not installed);
* the Baileys bridge must not be spawned;
* `unpairWhatsapp()` must not run — it deletes `~/.hermes/**/session`, the wrong box's files.

## What still needs the owner

Everything up to the QR is built and tested; **scanning it needs a phone and has deliberately not been done.** See the PR conversation for the exact steps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WhatsApp support for OpenClaw, including setup, pairing, status checks, unpairing, and gateway management.
  * Added QR-code pairing with support for SVG payloads and PNG images.
  * Added connection status reporting and warnings for plugin, restart, and connection failures.
  * Added pairing-based access controls for OpenClaw; allowlist and mode settings are unavailable.

* **Bug Fixes**
  * OpenClaw WhatsApp requests no longer return an unsupported response.
  * Improved cleanup when stopping or unpairing, including handling logout failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->