### PR TITLE
fix: replace a non-object config container instead of writing into it

### DIFF
--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -800,6 +800,72 @@ export async function readConfigStrict(): Promise<OpenClawConfig> {
   return JSON.parse(raw);
 }
 
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Return `container[key]` as a plain object, REPLACING first whatever else is
+ * there — an array, a string, a number, a boolean.
+ *
+ * `??=` is not enough for this, and the difference does not show up until the
+ * write has already been reported as successful:
+ *
+ *   * `[]` is not nullish, so `config.plugins ??= {}` keeps the array. The next
+ *     assignment attaches a NAMED PROPERTY to it, and `JSON.stringify` — which
+ *     is how every config write in this module reaches disk — drops named
+ *     properties of arrays. The save writes a config missing the very key it
+ *     was called to add, and answers 200.
+ *   * `[].entries` is not nullish either: it is `Array.prototype.entries`. So
+ *     `plugins.entries ??= {}` keeps the intrinsic and the channel's trust
+ *     entry is written onto a shared JS function. Measured: after one such
+ *     save, an unrelated `[].entries.discord` reads `{"enabled":true}` for the
+ *     rest of the server process's life.
+ *   * a string or a number is worse again — assigning a property to a
+ *     primitive THROWS in strict mode (ES modules always are), so the save dies
+ *     halfway as an opaque 500.
+ *
+ * Replacing rather than refusing is deliberate, and it is the opposite of the
+ * choice {@link envSecretRef} makes one screen down. A non-object `secrets` is
+ * the operator's own credential wiring: we cannot interpret it, and overwriting
+ * it would break channels that resolve through it today, so that path refuses
+ * and writes nothing. A non-object `plugins`/`channels`/`agents`/`gateway` is
+ * not a shape OpenClaw's schema can load at all — the gateway exits 78/CONFIG
+ * on it — so there is no working configuration to protect, and refusing would
+ * only leave the box stuck in the state it is already broken in. Normalising
+ * repairs it inside the same atomic write.
+ */
+function ensurePlainObject(container: Record<string, unknown>, key: string): Record<string, unknown> {
+  const existing = container[key];
+  if (isPlainObject(existing)) return existing;
+  const replacement: Record<string, unknown> = {};
+  container[key] = replacement;
+  return replacement;
+}
+
+/** The config as a bag of keys, for the container helpers above. */
+function asBag(config: OpenClawConfig): Record<string, unknown> {
+  return config as Record<string, unknown>;
+}
+
+/**
+ * The existing block for one channel, as something safe to spread.
+ *
+ * Every channel writer here rebuilds the block as `{...existing, enabled, …}`
+ * so it can drop the keys it re-secures. Spreading a STRING splits it into
+ * indexed characters (`"on"` becomes `{"0":"o","1":"n"}`), and one key OpenClaw
+ * does not know takes the whole gateway down with exit 78/CONFIG — every other
+ * channel with it. A block that is not a plain object carries nothing worth
+ * merging, so it is treated as absent.
+ */
+function existingChannelBlock(
+  channels: Record<string, unknown>,
+  channelId: string,
+): Record<string, unknown> {
+  const existing = channels[channelId];
+  return isPlainObject(existing) ? existing : {};
+}
+
 async function writeConfig(config: OpenClawConfig): Promise<void> {
   await fs.mkdir(OPENCLAW_HOME, { recursive: true });
   const tmpPath = CONFIG_PATH + ".tmp";
@@ -839,14 +905,14 @@ export async function ensureCompactionReserveFloor(
   reserveTokensFloor = DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR
 ): Promise<void> {
   const config = await readConfig();
-  config.agents ??= {};
-  config.agents.defaults ??= {};
-  config.agents.defaults.compaction ??= {};
+  const agents = ensurePlainObject(asBag(config), "agents");
+  const defaults = ensurePlainObject(agents, "defaults");
+  const compaction = ensurePlainObject(defaults, "compaction");
   if (
-    typeof config.agents.defaults.compaction.reserveTokensFloor !== "number" ||
-    config.agents.defaults.compaction.reserveTokensFloor < reserveTokensFloor
+    typeof compaction.reserveTokensFloor !== "number" ||
+    compaction.reserveTokensFloor < reserveTokensFloor
   ) {
-    config.agents.defaults.compaction.reserveTokensFloor = reserveTokensFloor;
+    compaction.reserveTokensFloor = reserveTokensFloor;
     await writeConfig(config);
   }
 }
@@ -858,8 +924,8 @@ export async function ensureCompactionReserveFloor(
  */
 export async function setControlUiAllowedOrigins(hostname: string): Promise<void> {
   const config = await readConfig();
-  const gateway = (config.gateway ?? {}) as Record<string, unknown>;
-  const controlUi = (gateway.controlUi ?? {}) as Record<string, unknown>;
+  const gateway = ensurePlainObject(asBag(config), "gateway");
+  const controlUi = ensurePlainObject(gateway, "controlUi");
   const existing = Array.isArray(controlUi.allowedOrigins)
     ? (controlUi.allowedOrigins as unknown[]).filter((v): v is string => typeof v === "string")
     : [];
@@ -872,16 +938,15 @@ export async function setControlUiAllowedOrigins(hostname: string): Promise<void
     "http://10.43.0.1", // alt subnet when home network collides with 10.42.0.0/24
   ]);
   controlUi.allowedOrigins = Array.from(origins);
-  gateway.controlUi = controlUi;
-  config.gateway = gateway;
   await writeConfig(config);
 }
 
+/** OpenClaw's id for the Telegram channel — the config key's, and the plugin's. */
+const TELEGRAM_CHANNEL_ID = "telegram";
+
 export async function setTelegramToken(botToken: string): Promise<void> {
   const config = await readConfig();
-  if (!config.channels) {
-    config.channels = {};
-  }
+  const channels = ensurePlainObject(asBag(config), "channels");
   // Do NOT set `dmPolicy` or `allowFrom` here. OpenClaw's default
   // (`dmPolicy: "pairing"`) requires the owner to approve every new sender
   // via an in-Telegram pairing code before the agent responds. Writing
@@ -890,8 +955,12 @@ export async function setTelegramToken(botToken: string): Promise<void> {
   // finds the handle. Reconfiguring a bot token on a device with those
   // values already stored should re-secure the channel, so strip them here
   // too rather than merging on top of the stale insecure config.
-  const { dmPolicy: _dmPolicy, allowFrom: _allowFrom, ...rest } = config.channels.telegram ?? {};
-  config.channels.telegram = {
+  const {
+    dmPolicy: _dmPolicy,
+    allowFrom: _allowFrom,
+    ...rest
+  } = existingChannelBlock(channels, TELEGRAM_CHANNEL_ID);
+  channels[TELEGRAM_CHANNEL_ID] = {
     ...rest,
     enabled: true,
     botToken,
@@ -912,17 +981,15 @@ export async function getTelegramProgressStreaming(): Promise<boolean> {
 
 export async function setTelegramProgressStreaming(enabled: boolean): Promise<void> {
   const config = await readConfig();
-  if (!config.channels) {
-    config.channels = {};
-  }
-  const existing = config.channels.telegram ?? {};
+  const channels = ensurePlainObject(asBag(config), "channels");
+  const existing = existingChannelBlock(channels, TELEGRAM_CHANNEL_ID);
   if (enabled) {
     // Restore OpenClaw's default by dropping our override entirely.
     const { streaming: _streaming, ...rest } = existing;
-    config.channels.telegram = { ...rest };
+    channels[TELEGRAM_CHANNEL_ID] = { ...rest };
   } else {
     // Final-answer-only: suppress the progress/preview draft.
-    config.channels.telegram = { ...existing, streaming: { mode: "off" } };
+    channels[TELEGRAM_CHANNEL_ID] = { ...existing, streaming: { mode: "off" } };
   }
   // Note: unlike setTelegramToken this does not strip dmPolicy/allowFrom — it's
   // a preference toggle, not a token re-secure; gateway-pre-start.sh already
@@ -1015,10 +1082,6 @@ export class EnvSecretProviderConflictError extends Error {
     );
     this.name = "EnvSecretProviderConflictError";
   }
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 export function envSecretRef(
@@ -1160,23 +1223,29 @@ export async function writeDiscordGatewayEnv(botToken: string): Promise<void> {
  * keys this repo knows nothing about.
  */
 export function trustChannelPlugin(config: OpenClawConfig, channelId: string): void {
-  const plugins = (config.plugins ??= {});
-  const entries = (plugins.entries ??= {});
-  entries[channelId] = { ...entries[channelId], enabled: true };
+  // `??=` cannot be used for either container: `"plugins": []` is not nullish
+  // and neither is `[].entries` (it is `Array.prototype.entries`), so the entry
+  // would be attached to an array — dropped by `JSON.stringify` on the way to
+  // disk — or onto a JS intrinsic. Both look like a successful save and leave
+  // the gateway answering `unknown channel` for a channel it is configured for,
+  // which is the failure this whole function exists to prevent. See
+  // {@link ensurePlainObject}.
+  const plugins = ensurePlainObject(asBag(config), "plugins");
+  const entries = ensurePlainObject(plugins, "entries");
+  const existing = entries[channelId];
+  entries[channelId] = { ...(isPlainObject(existing) ? existing : {}), enabled: true };
 }
 
 export async function setDiscordToken(botToken: string): Promise<void> {
   const config = await readConfig();
-  if (!config.channels) {
-    config.channels = {};
-  }
+  const channels = ensurePlainObject(asBag(config), "channels");
   const {
     dmPolicy: _dmPolicy,
     allowFrom: _allowFrom,
     botToken: _legacyLiteralToken,
     ...rest
-  } = config.channels.discord ?? {};
-  config.channels.discord = {
+  } = existingChannelBlock(channels, DISCORD_CHANNEL_ID);
+  channels[DISCORD_CHANNEL_ID] = {
     ...rest,
     enabled: true,
     // envSecretRef also installs `secrets.providers.default`, without which

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -762,10 +762,23 @@ export function inferConfiguredLocalModel(config: OpenClawConfig): { provider: "
   return null;
 }
 
+/** A JSON value that can hold named keys — i.e. not an array, null or a primitive. */
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export async function readConfig(): Promise<OpenClawConfig> {
   try {
     const raw = await fs.readFile(CONFIG_PATH, "utf-8");
-    return JSON.parse(raw);
+    const parsed: unknown = JSON.parse(raw);
+    // The ROOT is a container too, and it is the one every helper below stands
+    // on. A file holding `[]` parses fine, so without this the writers attach
+    // their keys to an array and `JSON.stringify` drops all of them; a root
+    // string or number makes the first assignment throw in strict mode. Either
+    // way a caller that only ever reads gets `{}`, which is what this function
+    // already promises for every other unusable file. See
+    // {@link ensurePlainObject}.
+    return isPlainObject(parsed) ? (parsed as OpenClawConfig) : {};
   } catch {
     return {};
   }
@@ -797,11 +810,17 @@ export async function readConfigStrict(): Promise<OpenClawConfig> {
     if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return {};
     throw err;
   }
-  return JSON.parse(raw);
-}
-
-export function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+  const parsed: unknown = JSON.parse(raw);
+  // Deliberately the OPPOSITE of readConfig's answer for the same file. This
+  // function exists so a caller about to skip a repair cannot be told "already
+  // clean" by a config it could not read, and a root array or primitive is
+  // exactly that: parseable, and not a config. Normalising it to `{}` here
+  // would hand back the false "nothing to remove" this variant was written to
+  // prevent.
+  if (!isPlainObject(parsed)) {
+    throw new Error("openclaw.json does not contain a configuration object");
+  }
+  return parsed as OpenClawConfig;
 }
 
 /**

--- a/src/tests/unit/discord-openclaw-config.test.ts
+++ b/src/tests/unit/discord-openclaw-config.test.ts
@@ -405,3 +405,202 @@ describe("envSecretRef against a malformed config", () => {
     expect(writtenJsonConfig().secrets).toEqual({ providers: { default: { source: "env" } } });
   });
 });
+
+// A malformed CONTAINER is the same class of defect as a malformed `secrets`
+// value, and it fails far more quietly.
+//
+// `??=` only replaces `null`/`undefined`, so `"plugins": []` sails straight
+// through it, and the write that follows lands somewhere harmless-looking and
+// unserialisable. Two distinct things then go wrong, both silent:
+//
+//   1. a named property attached to an ARRAY is dropped by `JSON.stringify`,
+//      which is how writeConfig reaches disk. `setDiscordToken` saves the
+//      channel and the token, omits `plugins.entries.discord.enabled`, and the
+//      gateway answers `unknown channel: discord` from then on while the
+//      panel's card sits at "unknown" — the exact failure trustChannelPlugin's
+//      doc comment exists to prevent, re-created by the helper written to
+//      prevent it.
+//
+//   2. worse, `[].entries` is NOT nullish: it is `Array.prototype.entries`. So
+//      `plugins.entries ??= {}` keeps that function, and the next line writes
+//      the trust entry onto a shared JS intrinsic. In a long-lived Next.js
+//      server every later `[].entries` in the process carries it. Verified:
+//      after one such save, `[].entries.discord` reads `{"enabled":true}`.
+//
+// Every assertion here goes through the real JSON round trip and then refuses
+// to read a value off a prototype — see `roundTrippedTrustEntry`. A plain
+// `written.plugins?.entries?.discord` check PASSES on the broken code, because
+// defect 2 puts the answer on `Array.prototype.entries`, where defect 1's empty
+// array happily finds it again.
+function roundTrippedTrustEntry(channelId: string): unknown {
+  const plugins = (writtenJsonConfig() as { plugins?: unknown }).plugins;
+  if (!plugins || typeof plugins !== "object" || Array.isArray(plugins)) {
+    throw new Error(`plugins did not round-trip as an object: ${JSON.stringify(plugins) ?? "undefined"}`);
+  }
+  const entries = (plugins as Record<string, unknown>).entries;
+  if (!entries || typeof entries !== "object" || Array.isArray(entries)) {
+    throw new Error(
+      `plugins.entries did not round-trip as an object: ${JSON.stringify(entries) ?? "undefined"}`,
+    );
+  }
+  return (entries as Record<string, unknown>)[channelId];
+}
+
+describe("config containers that arrive as something other than a plain object", () => {
+  let openclawConfig: typeof import("@/lib/openclaw-config");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockFs.readFile.mockResolvedValue("{}");
+    mockFs.writeFile.mockResolvedValue(undefined);
+    mockFs.rename.mockResolvedValue(undefined);
+    mockFs.mkdir.mockResolvedValue(undefined);
+    mockFs.chmod.mockResolvedValue(undefined);
+    openclawConfig = await import("@/lib/openclaw-config");
+  });
+
+  // `null` already worked (`??=` does replace it); it is in the table so the
+  // regression net covers every shape the operator's file can hold, not only
+  // the ones that are broken today.
+  const MALFORMED_PLUGINS = [
+    ["plugins is an array", []],
+    ["plugins is a string", "@openclaw/discord"],
+    ["plugins is a number", 3],
+    ["plugins is a boolean", true],
+    ["plugins is null", null],
+  ] as const;
+
+  it.each(MALFORMED_PLUGINS)("still trusts the plugin when %s", async (_why, plugins) => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ plugins }));
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    expect(roundTrippedTrustEntry("discord")).toEqual({ enabled: true });
+  });
+
+  const MALFORMED_ENTRIES = [
+    ["entries is an array", []],
+    ["entries is a string", "discord"],
+    ["entries is a number", 0],
+    ["entries is a boolean", false],
+  ] as const;
+
+  it.each(MALFORMED_ENTRIES)("still trusts the plugin when %s", async (_why, entries) => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ plugins: { entries } }));
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    expect(roundTrippedTrustEntry("discord")).toEqual({ enabled: true });
+  });
+
+  it("still trusts the plugin when the channel's own entry is a string", async () => {
+    // `{...\"on\"}` spreads to `{\"0\":\"o\",\"1\":\"n\"}`, and an unknown key in
+    // plugins.entries.discord is another way to lose the gateway to 78/CONFIG.
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ plugins: { entries: { discord: "on" } } }));
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    expect(roundTrippedTrustEntry("discord")).toEqual({ enabled: true });
+  });
+
+  it("does not write the trust entry onto Array.prototype.entries", async () => {
+    // A config save has no business mutating a JS intrinsic. This is the
+    // process-wide half of the array case: it outlives the request, and every
+    // `[].entries` in the server sees it afterwards.
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ plugins: [] }));
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    expect(Object.prototype.hasOwnProperty.call(Array.prototype.entries, "discord")).toBe(false);
+  });
+
+  it("keeps the operator's other plugin keys when the registry is well formed", async () => {
+    // The repair must not become a reason to flatten a healthy registry.
+    mockFs.readFile.mockResolvedValue(
+      JSON.stringify({ plugins: { autoUpdate: false, entries: { anthropic: { enabled: true } } } }),
+    );
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    expect(writtenJsonConfig().plugins).toEqual({
+      autoUpdate: false,
+      entries: { anthropic: { enabled: true }, discord: { enabled: true } },
+    });
+  });
+
+  // Same defect, same file, different container: `if (!config.channels)` is
+  // false for `[]`, so the discord block is attached to an array and vanishes
+  // on serialise — while `discord.env` is still written. That is a token on
+  // disk for a channel nothing reads, which this module's own comments call the
+  // hardest failure mode to see.
+  it("still writes the channel when channels is an array", async () => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ channels: [] }));
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    const channels = writtenJsonConfig().channels;
+    expect(Array.isArray(channels)).toBe(false);
+    expect(channels.discord).toMatchObject({ enabled: true });
+  });
+
+  // A non-object channel block is destructured today, so its characters become
+  // config keys. One out-of-schema key takes the WHOLE gateway down with exit
+  // 78/CONFIG — every other channel with it.
+  it("writes no stray keys when the existing discord block is a string", async () => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ channels: { discord: "on" } }));
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    expect(Object.keys(writtenJsonConfig().channels.discord).sort()).toEqual(["enabled", "token"]);
+  });
+
+  it("writes no stray keys when the existing telegram block is a string", async () => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ channels: { telegram: "on" } }));
+
+    await openclawConfig.setTelegramToken("123:abc");
+
+    expect(Object.keys(writtenJsonConfig().channels.telegram).sort()).toEqual([
+      "botToken",
+      "enabled",
+    ]);
+  });
+
+  it("still writes the compaction floor when agents is an array", async () => {
+    // ensureCompactionReserveFloor decides it changed something and writes —
+    // and the floor it just set is dropped on the way to disk, so the next boot
+    // reads the same config back and repeats the whole no-op for ever.
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ agents: [] }));
+
+    await openclawConfig.ensureCompactionReserveFloor(4096);
+
+    const written = writtenJsonConfig() as {
+      agents?: { defaults?: { compaction?: { reserveTokensFloor?: number } } };
+    };
+    expect(Array.isArray(written.agents)).toBe(false);
+    expect(written.agents?.defaults?.compaction?.reserveTokensFloor).toBe(4096);
+  });
+
+  it("still writes the control-UI origins when gateway is an array", async () => {
+    // A dropped allowedOrigins list is a box that stops answering on its own
+    // hostname after a rename the route reported as done.
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ gateway: [] }));
+
+    await openclawConfig.setControlUiAllowedOrigins("clawbox-test");
+
+    const written = writtenJsonConfig() as {
+      gateway?: { controlUi?: { allowedOrigins?: string[] } };
+    };
+    expect(Array.isArray(written.gateway)).toBe(false);
+    expect(written.gateway?.controlUi?.allowedOrigins).toContain("http://clawbox-test.local");
+  });
+
+  it("keeps the rest of a well-formed gateway block", async () => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ gateway: { port: 18789 } }));
+
+    await openclawConfig.setControlUiAllowedOrigins("clawbox-test");
+
+    const written = writtenJsonConfig() as { gateway?: { port?: number } };
+    expect(written.gateway?.port).toBe(18789);
+  });
+});

--- a/src/tests/unit/discord-openclaw-config.test.ts
+++ b/src/tests/unit/discord-openclaw-config.test.ts
@@ -595,6 +595,42 @@ describe("config containers that arrive as something other than a plain object",
     expect(written.gateway?.controlUi?.allowedOrigins).toContain("http://clawbox-test.local");
   });
 
+  // The ROOT is a container too, and it is the one every helper stands on. A
+  // file holding `[]` parses fine, so the channel, the secrets block and the
+  // trust entry are all attached to an array and the write lands as `[]`.
+  const MALFORMED_ROOT = [
+    ["the whole file is an array", "[]"],
+    ["the whole file is a string", '"nope"'],
+    ["the whole file is a number", "3"],
+    ["the whole file is null", "null"],
+  ] as const;
+
+  it.each(MALFORMED_ROOT)("still writes a usable config when %s", async (_why, raw) => {
+    mockFs.readFile.mockResolvedValue(raw);
+
+    await openclawConfig.setDiscordToken(TOKEN);
+
+    const written = writtenJsonConfig();
+    expect(Array.isArray(written)).toBe(false);
+    expect(written.channels.discord).toMatchObject({ enabled: true });
+    expect(roundTrippedTrustEntry("discord")).toEqual({ enabled: true });
+  });
+
+  // readConfigStrict answers the opposite question and must give the opposite
+  // answer: it exists so a caller about to SKIP a repair is never told "already
+  // clean" by a file it could not read.
+  it.each(MALFORMED_ROOT)("readConfigStrict refuses when %s", async (_why, raw) => {
+    mockFs.readFile.mockResolvedValue(raw);
+
+    await expect(openclawConfig.readConfigStrict()).rejects.toThrow();
+  });
+
+  it("readConfigStrict still returns a well-formed config", async () => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ gateway: { port: 18789 } }));
+
+    await expect(openclawConfig.readConfigStrict()).resolves.toEqual({ gateway: { port: 18789 } });
+  });
+
   it("keeps the rest of a well-formed gateway block", async () => {
     mockFs.readFile.mockResolvedValue(JSON.stringify({ gateway: { port: 18789 } }));
 


### PR DESCRIPTION
## What this is

The one CodeRabbit finding from #535 that was merged with **no reply and no fix**. Its three siblings were fixed in `f172910f`; this one (`src/lib/openclaw-config.ts:1165`, posted 2026-08-28 10:34Z) was left.

## The bug

```ts
const plugins = (config.plugins ??= {});
const entries = (plugins.entries ??= {});
entries[channelId] = { ...entries[channelId], enabled: true };
```

`??=` only replaces `null`/`undefined`. `"plugins": []` is neither, so it sails through. What happens next is two separate defects, and both of them are silent:

**1. The trust entry never reaches disk.** A named property attached to an array is dropped by `JSON.stringify`, which is how `writeConfig` writes `openclaw.json`. `setDiscordToken` saves the channel and writes the token env file, omits `plugins.entries.discord.enabled`, and returns success. The gateway then answers

```
channels.discord: channel is configured, but external plugin "discord" is
installed without explicit trust. Add plugins.entries.discord.enabled=true.
```

and `channels status` says `unknown channel: discord` from then on while the Settings card sits at "unknown". That is verbatim the failure the doc comment directly above `trustChannelPlugin` describes — the one it was written to prevent. The helper re-created it.

**2. It writes onto a JS intrinsic.** `[].entries` is not nullish either: it is `Array.prototype.entries`. So `plugins.entries ??= {}` keeps the intrinsic and the next line assigns the trust entry onto a shared function object. Measured:

```
$ node -e '"use strict"; const c={plugins:[]};
  const p=(c.plugins??={}); const e=(p.entries??={});
  e["discord"]={...e["discord"],enabled:true};
  console.log(JSON.stringify(c), JSON.stringify([].entries.discord));'
{"plugins":[]} {"enabled":true}
```

An unrelated `[].entries.discord` reads `{"enabled":true}` for the rest of the server process's life. In a long-lived Next.js server that outlives the request that caused it.

This is the false-success class again: the write appears to succeed and quietly does nothing (while mutating something it should never touch).

## The fix

One helper, `ensurePlainObject(container, key)`, applied at every container in this file that is read off disk and written back. It replaces anything that is not a plain object — array, string, number, boolean — rather than only `null`/`undefined`.

### Why replace rather than refuse

CodeRabbit's suggested patch threw. This one normalises, and the difference is deliberate, because the file already contains both answers and they are not interchangeable:

- `envSecretRef` **refuses** (`EnvSecretProviderConflictError`) and is left exactly as it is. A non-object `secrets` is the operator's own credential wiring. We cannot interpret it, and overwriting it would break channels that resolve through it today. Refusing costs one actionable message; writing costs a working channel.
- A non-object `plugins` / `channels` / `agents` / `gateway` is **not a shape OpenClaw's schema can load at all** — the gateway exits 78/CONFIG on it. There is no working configuration to protect, and refusing would only pin the box in the broken state it is already in. Normalising repairs it inside the same atomic write.

## Sibling sites — the grep, and what it found

```
$ grep -rn "??=" src/ --include=*.ts --include=*.tsx
$ grep -rn "?? {}" src/lib --include=*.ts
```

The second grep is there because `(config.gateway ?? {})` has exactly the same failure mode as `??=` on a container — `[]` is not nullish, so the fallback never fires — and the first grep does not see it.

| Site | Verdict |
| --- | --- |
| `openclaw-config.ts` `trustChannelPlugin` — `plugins`, `plugins.entries` | **fixed** (the reported one) |
| `openclaw-config.ts` `trustChannelPlugin` — the per-channel entry it spreads | **fixed**; `{..."on"}` becomes `{"0":"o","1":"n"}` and one unknown key is 78/CONFIG |
| `openclaw-config.ts` `envSecretRef` — `secrets`, `secrets.providers` | already guarded by `isPlainObject` in `f172910f`; **left alone on purpose**, see above |
| `openclaw-config.ts` `ensureCompactionReserveFloor` — `agents`, `.defaults`, `.compaction` | **fixed**; with `"agents": []` it decides it changed something, writes, and the floor is dropped on the way out — so every boot repeats the same no-op for ever |
| `openclaw-config.ts` `setControlUiAllowedOrigins` — `gateway`, `.controlUi` (`?? {}` form) | **fixed**; a dropped `allowedOrigins` is a box that stops answering on its own hostname after a rename the route reported as done |
| `openclaw-config.ts` `setDiscordToken` / `setTelegramToken` / `setTelegramProgressStreaming` — `config.channels` and each channel block | **fixed**; `if (!config.channels)` is false for `[]`, so the channel block vanishes on serialise while `discord.env` is still written — a token on disk for a channel nothing reads |
| `openclaw-config.ts` `readConfig` / `readConfigStrict` — the ROOT of the parsed file | **fixed** in `6f1c1f9` after CodeRabbit raised it on this PR. `readConfig` normalises to `{}`; `readConfigStrict` refuses, because it exists so a caller about to skip a repair is never told "already clean" by a file it could not read |
| `ai-models/status/route.ts:95`, `chat-spoken-history.ts:344` | not applicable — `??=` on a scalar, not a container |
| `tests/routes/tts.test.ts` (`(handlers[event] ??= []).push`) | not applicable — the intended type there IS an array, and nothing is serialised |
| `clawkeep.ts`, `client-harness.ts`, `pet-client.ts`, `harness/hermes-turn-record.ts` | not applicable — `?? {}` on a value that is only read from, never assigned into and written back |
| `hermes-config-yaml.ts`, `hermes-model-options.ts`, `provider-status.ts`, `voice-output.ts`, `subscription-surface.ts`, `mascot-phrases-server.ts`, `webapp-registry.ts` | not applicable — all feed `Object.entries(...)`/reads; `Object.entries([])` is `[]`, which is the correct answer |

## Tests

RED-first, proven against unmodified `origin/beta`'s `src/lib/openclaw-config.ts` with this PR's test file in place:

- **RED: 23 failed / 30 passed (53)**
- **GREEN: 53 passed (53)**

The three new cases that pass in both runs are deliberate regression guards (`plugins: null`, which `??=` did handle; a well-formed registry that must not be flattened; a well-formed `gateway` block that must keep its other keys).

Two things about how these are written matter:

- Every assertion goes through the **real JSON round trip** — `writtenJsonConfig()` parses what `fs.writeFile` was actually handed. An in-memory object check passes on the broken code, because the property genuinely is there right up until it is serialised.
- `roundTrippedTrustEntry()` refuses to read the answer off a prototype. My first draft asserted `written.plugins?.entries?.discord` and the `plugins: []` case **passed on the broken code** — defect 2 had put the answer on `Array.prototype.entries`, where defect 1's empty array found it again. The helper now fails loudly if `plugins` or `plugins.entries` did not round-trip as a plain object. There is also a dedicated test that `Array.prototype.entries` gains no own property.

## Checks

- `tsc --noEmit`: **24 errors, all pre-existing on beta, none in either changed file**
- `eslint` on both changed files: **0 errors** (6 pre-existing `_dmPolicy`-style unused-var warnings, unchanged in count and kind)

Closes the residual finding on #535.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved configuration updates when settings contain invalid or unexpected values.
  - Preserved valid neighboring settings while removing insecure or outdated credential data.
  - Prevented malformed configuration data and prototype-pollution risks during updates.
  - Ensured channel, compaction, plugin trust, and control interface settings are saved reliably.
  - Improved recovery from malformed configuration files while correctly rejecting invalid data in strict validation.

- **Tests**
  - Added regression coverage for malformed containers, data preservation, safe JSON round trips, and non-mutating updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->