### PR TITLE
fix: a box with no working TTS engine must fail provisioning, not pass it

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2631,7 +2631,32 @@ step_openclaw_tts() {
   case "$VOICE_RC" in
     0)  KOKORO_READY=true ;;
     10) KOKORO_REASON="no CUDA toolkit on this board" ;;
-    11) KOKORO_REASON="no Jetson CUDA build for this CPU architecture" ;;
+    11) KOKORO_REASON="no Jetson CUDA build for this CPU architecture, and no pinned Piper artifact either"
+        # ── "Nothing applies to this board" is still a box that cannot speak ──
+        # 11 was deliberately left clean: no TTS_RC, no recorded failure, on the
+        # grounds that a board neither engine ships for was never asked for one
+        # and that failing every such run "would only teach everyone to ignore
+        # the check". The summary this arm then printed said, in its own words,
+        # "this box answers speech with SILENCE" — and the run finished as a
+        # healthy provision. A run that describes a mute box and grades it
+        # healthy is not a check anyone can act on.
+        #
+        # install-voice.sh now answers that board with 13, so 11 should never
+        # arrive here again. The branch stays, and it fails, because a code
+        # whose meaning is "no engine applies to this board" must never be the
+        # one that grades clean if any future path revives it — leaving the
+        # lenient branch behind is exactly how the sibling call sites in #519,
+        # #533 and #544 stayed unguarded after each fix.
+        TTS_RC=13
+        echo "  ############################################################" >&2
+        echo "  # This box has NO working TTS engine — no Kokoro GPU build and" >&2
+        echo "  # no pinned Piper artifact apply to this CPU architecture." >&2
+        echo "  # It will answer every spoken request with SILENCE." >&2
+        echo "  # Engines and reasons: $TTS_STATUS_FILE" >&2
+        echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step openclaw_tts" >&2
+        echo "  ############################################################" >&2
+        record_provision_failure openclaw_tts
+        ;;
     12) KOKORO_REASON="the Kokoro GPU install failed, see the log above"
         # ── A hard failure must stop arriving as a soft fallback ─────────────
         # This is the branch that made a shipped defect invisible. Kokoro's
@@ -2674,6 +2699,14 @@ step_openclaw_tts() {
         echo "  ############################################################" >&2
         echo "  # This box has NO working TTS engine — neither Kokoro nor Piper." >&2
         echo "  # It will answer every spoken request with SILENCE." >&2
+        # Both engines named with the reason each one is absent. 13 now covers
+        # the board that DECLINED both halves as well as the one whose install
+        # failed, and "neither engine is here" is not an actionable report on
+        # its own — which half declined for want of CUDA and which one failed
+        # its download lead to different fixes. The verdicts are what the run
+        # published, so they are what gets printed.
+        echo "  # Kokoro (GPU): ${KOKORO_VERDICT:-no verdict published}" >&2
+        echo "  # Piper (CPU):  ${PIPER_VERDICT:-no verdict published}" >&2
         echo "  # Re-run:  sudo bash $PROJECT_DIR/install.sh --step openclaw_tts" >&2
         echo "  ############################################################" >&2
         record_provision_failure openclaw_tts
@@ -2840,20 +2873,16 @@ step_openclaw_tts() {
         # install_kokoro_tts's "no Jetson CUDA build for this architecture",
         # i.e. `uname -m` is not aarch64 — which is exactly when
         # install_piper_engine has no pinned artifact either and publishes
-        # `skipped:arch-*` of its own. install-voice.sh has just printed "=== No
-        # on-device TTS engine applies to this board ===" for that pair, so
-        # naming a Piper CPU fallback one line later put the name of an engine
-        # this box does not have on the summary line an operator reads.
+        # `skipped:arch-*` of its own. So 11 is a box with NO engine.
         #
-        # Deliberately NOT a recorded provisioning failure: nothing was asked
-        # for and nothing is missing on a board neither engine ships for, which
-        # is the same rule `skipped:*` carries in step_validate_services.
-        #
-        # On stdout, not stderr, for the same reason: install-voice.sh prints
-        # its "no engine applies to this board" line on stdout too, and painting
-        # every install-x64.sh run red would only teach everyone to ignore it.
-        echo "  On-device TTS configured, but no speech engine applies to this CPU architecture"
-        echo "  (no Jetson CUDA build and no pinned Piper artifact) — this box answers speech with SILENCE"
+        # It used to print these two lines on stdout and record nothing, which
+        # meant the run said "this box answers speech with SILENCE" and then
+        # graded itself healthy. It is a recorded provisioning failure now (see
+        # the 11 arm above), so this line reports the same fact the rest of the
+        # step reports, on stderr with the other failures rather than in the
+        # middle of the success summary.
+        echo "  On-device TTS configured, but no speech engine applies to this CPU architecture" >&2
+        echo "  (no Jetson CUDA build and no pinned Piper artifact) — this box answers speech with SILENCE" >&2
         ;;
       1)
         # An engine SURVIVES here — install-voice.sh returns 13, not 1, when
@@ -4932,11 +4961,17 @@ step_validate_services() {
     # Probe: on-device TTS delivered the engine it was asked for.
     #
     # scripts/install-voice.sh publishes its verdict to $TTS_STATUS_FILE for
-    # exactly this check. The distinction the file carries is the whole point:
-    # `skipped:*` means this board was never going to run Kokoro (no CUDA, no
-    # Jetson build for its architecture) and is a PASS, while `failed:*` means
-    # the GPU engine was requested and did not arrive — the box is on the Piper
-    # CPU fallback and someone has to fix it.
+    # exactly this check. The distinction the file carries tells an operator
+    # WHAT to fix: `skipped:*` means this board was never going to run that
+    # engine (no CUDA, no Jetson build for its architecture), `failed:*` means
+    # it was requested and did not arrive.
+    #
+    # What the distinction does NOT decide is whether the check passes. That is
+    # decided by one question asked of both engines together — is either one
+    # `ready`? A `skipped:*` engine is a PASS only while the other half is
+    # carrying the box; two skipped engines is a box with no voice, and it used
+    # to score healthy here because the arm below asked for a `failed:*` before
+    # it would report one.
     #
     # An ABSENT verdict fails too. The TTS step runs before this check on both
     # the install and the update path, so nothing here can assert "Kokoro is
@@ -5008,12 +5043,38 @@ step_validate_services() {
         # HEALTHY box lands (both engines `ready` match no arm), so an `else`
         # there would fail every good box on the shelf.
         failed_probe+=("TTS: unrecognised on-device TTS verdict at $TTS_STATUS_FILE (Kokoro: ${tts_state:-unreported}, Piper: ${piper_state:-unreported}) — a verdict outside the ready/skipped:<reason>/failed:<reason> vocabulary is not evidence of an engine. $tts_fix")
-      elif [ "$tts_state" != "ready" ] && [ "$piper_state" != "ready" ]         && { [ "$kokoro_failed" = true ] || [ "$piper_failed" = true ]; }; then
-        # The defect this probe was rewritten for. Note what does NOT land here:
-        # both engines `skipped:*` is a board that runs neither by design (no
-        # Jetson CUDA build AND no pinned aarch64 artifact), and failing every
-        # install-x64.sh run would only teach everyone to ignore this check.
-        failed_probe+=("TTS: this box has NO working TTS engine — Kokoro was requested and did NOT install (${tts_state:-unreported}) or is unavailable, and there is no usable Piper fallback (${piper_state:-unreported}). It will answer every spoken request with SILENCE. $tts_fix")
+      elif [ -n "$tts_state" ] && [ -n "$piper_state" ] \
+        && [ "$tts_state" != "ready" ] && [ "$piper_state" != "ready" ]; then
+        # ── No `ready` engine is a FAILED check, whatever the reasons are ────
+        # This arm used to carry `&& { kokoro_failed || piper_failed }`, so a
+        # box whose two verdicts were both `skipped:*` matched no arm at all and
+        # fell out of the chain as a silent PASS. The comment defending it said
+        # both engines skipped is "a board that runs neither by design" and that
+        # failing every install-x64.sh run "would only teach everyone to ignore
+        # this check".
+        #
+        # install-x64.sh does not run this check. It contains no reference to
+        # voice, TTS, Piper or Kokoro, and `grep -n 'install-voice.sh' *.sh`
+        # names install.sh:2602 as the only caller of the script that publishes
+        # these verdicts. So the run the leniency was protecting does not exist,
+        # and what the leniency actually passed was a box that answers every
+        # spoken request with silence.
+        #
+        # `ready` is the only verdict that means an engine can speak, and this
+        # arm asks nothing else. Both reasons are printed because "no engine" is
+        # not actionable on its own — a skip and a failed download are different
+        # repairs.
+        failed_probe+=("TTS: this box has NO working TTS engine — Kokoro: $tts_state, Piper: $piper_state. Neither engine is installed, so it will answer every spoken request with SILENCE. $tts_fix")
+      elif [ "$tts_state" != "ready" ] && [ "$piper_state" != "ready" ]; then
+        # Same rule, weaker evidence: one half published a verdict that is not
+        # `ready` and the other published nothing. That is still no engine this
+        # box can prove it has, so it still fails — but it is NOT stated as
+        # "answers with SILENCE", because an unreported half is unknown rather
+        # than absent, and asserting a mute box from a missing line would be the
+        # failure-report-over-a-success this file keeps having to remove. The
+        # arms below stay reachable and stay accurate: past this point exactly
+        # one engine is `ready`, so each of them names the half that is not.
+        failed_probe+=("TTS: no on-device TTS engine on this box is confirmed ready — Kokoro: ${tts_state:-unreported}, Piper: ${piper_state:-unreported}. $tts_fix")
       elif [ "$kokoro_failed" = true ]; then
         failed_probe+=("TTS: Kokoro GPU TTS was requested and did NOT install ($tts_state) — this box answers speech on the Piper CPU fallback. $tts_fix")
       elif [ -z "$tts_state" ]; then

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -863,7 +863,9 @@ if [ "${1:-}" = "--piper-only" ]; then
     *)
       # `failed:*`, nothing published, or a verdict outside the vocabulary.
       # None of those is evidence of an engine, and an unparseable answer is at
-      # least as suspicious as an absent one.
+      # least as suspicious as an absent one. Also reached only past the guard
+      # above, so this is a LOST FALLBACK behind a working Kokoro rather than a
+      # mute box — which is why it stays 1 and does not borrow 13's words.
       echo "=== Piper fallback INCOMPLETE — no usable Piper verdict (Piper: ${TTS_PIPER_VERDICT:-unreported}) ===" >&2
       exit 1
       ;;

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -521,7 +521,11 @@ activate_user_units() {
 #
 #   ready       requested, installed, usable.
 #   skipped:*   NOT applicable to this board (no CUDA, no Jetson build for this
-#               architecture). Nothing was asked for and nothing is missing.
+#               architecture). This engine is absent by the board's own
+#               design — but it is still ABSENT. `skipped:*` says nothing is
+#               missing only as long as the OTHER half is `ready`; a box where
+#               both halves are `skipped:*` has no engine at all and is mute,
+#               which is a broken box however politely each half declined.
 #   failed:*    requested and NOT delivered. The owner asked for GPU TTS, the
 #               box is answering speech on the Piper CPU fallback instead, and
 #               something is broken that a human has to fix.
@@ -598,8 +602,34 @@ piper_report() {
 # `ready` is the only verdict that means "this engine can speak". `skipped:*` is
 # a board that was never going to run it and `failed:*` is one that was asked
 # and could not - neither of those is an engine, and neither may be read as one.
+#
+# There is deliberately no `tts_verdict_is_failure` beside this any more. It
+# existed to separate "both halves FAILED" (reported) from "both halves
+# SKIPPED" (silently clean), and that separation is the defect: the two produce
+# the identical box, one that cannot speak. WHY each engine is absent is a
+# sentence for the operator — tts_verdict_explain below writes it — not an
+# input to whether the run passed.
 tts_verdict_is_ready() { [ "$1" = "ready" ]; }
-tts_verdict_is_failure() { case "$1" in failed:*) return 0 ;; *) return 1 ;; esac; }
+
+# One engine's verdict, spelled out for a human reading a flash log.
+#
+# Every place that reports "this box cannot speak" has to name WHICH engines it
+# tried and WHY each one is not there, or the operator is left to go and read
+# $TTS_STATUS_FILE to learn what the run already knew. Kept in one function so
+# the three reporting sites below cannot drift into three vocabularies.
+#
+# Always returns 0: it is called inside `echo "$(...)"` under `set -e`, and a
+# verdict this cannot classify is still something to print, not something to
+# die on.
+tts_verdict_explain() {
+  case "${1:-}" in
+    ready)      printf 'ready' ;;
+    skipped:?*) printf 'SKIPPED (%s) - this board does not run it' "${1#skipped:}" ;;
+    failed:?*)  printf 'FAILED (%s) - it was asked for and did not install' "${1#failed:}" ;;
+    "")         printf 'no verdict published - the install left no record of it' ;;
+    *)          printf 'unreadable verdict "%s" - not evidence of an engine' "$1" ;;
+  esac
+}
 
 # Install the GPU Kokoro stack. NEVER fatal: every exit path leaves Piper and
 # the deployed scripts untouched, because a box that lost its voice to a failed
@@ -690,42 +720,65 @@ if [ "${1:-}" = "--tts-only" ]; then
   #
   #   0        Kokoro is the engine and it is ready.
   #   10       No CUDA toolkit on an aarch64 board; the box speaks on Piper.
-  #   11       No Jetson build for this ARCHITECTURE — which is the very
-  #            condition under which install_piper_engine has no pinned
-  #            artifact either, so 11 means NO engine applies to the board at
-  #            all, not "the box speaks on Piper". install.sh names the engine
-  #            off this code, and bucketing 11 with 10 put the name of a
-  #            fallback that does not exist on a box that has none.
+  #            Reachable ONLY with a ready Piper — the guard below returns 13
+  #            otherwise — so 10 is a box that speaks, and it stays clean.
   #   12       Kokoro was REQUESTED and did not install; the box speaks on Piper.
   #   1        the Piper half did not complete, but an engine survives.
   #   13       NO usable engine at all - this box answers speech with SILENCE.
+  #            Every route to a box with no `ready` engine ends here, whether
+  #            the halves failed or declined; see the guard below for why the
+  #            "both declined" route stopped being a clean exit.
   #
-  # 13 is new, and it exists because the guard below used to be a bare `exit 1`
-  # placed BEFORE `exit "$KOKORO_RC"`. Any Piper problem therefore overwrote the
-  # GPU verdict, 12 included - the hard-failure code that was landed precisely
-  # so a failed engine could not ship as a soft fallback - and install.sh's
-  # handler for 1 printed a warning and recorded nothing. A board with no CUDA
-  # (install-x64.sh, or an Orin with no nvcc) whose Piper download flaked
-  # therefore finished provisioning as "All checks healthy" and then answered
-  # every spoken request with silence.
+  # 11 (install_kokoro_tts's "no Jetson build for this ARCHITECTURE") is no
+  # longer reachable as an exit STATUS of this mode. It is emitted on exactly
+  # the board where install_piper_engine has no pinned artifact either, so it
+  # always arrives with no engine ready and is answered by 13 above. install.sh
+  # still carries a branch for it, because a code that means "no engine applies"
+  # must never grade clean if some future path revives it.
+  #
+  # 13 exists because the guard below used to be a bare `exit 1` placed BEFORE
+  # `exit "$KOKORO_RC"`. Any Piper problem therefore overwrote the GPU verdict,
+  # 12 included - the hard-failure code that was landed precisely so a failed
+  # engine could not ship as a soft fallback - and install.sh's handler for 1
+  # printed a warning and recorded nothing. An aarch64 Orin with no nvcc (a
+  # legitimate `skipped:no-cuda`) whose Piper download flaked therefore finished
+  # provisioning as "All checks healthy" and then answered every spoken request
+  # with silence.
   #
   # Which engines survived is read from the published VERDICTS, not from the
   # return codes: install_piper returns 0 for a board with no pinned artifact
   # too, and a board with no artifact has no engine however cleanly it declined
   # to install one.
   if ! tts_verdict_is_ready "$TTS_KOKORO_VERDICT" && ! tts_verdict_is_ready "$TTS_PIPER_VERDICT"; then
-    if tts_verdict_is_failure "$TTS_KOKORO_VERDICT" || tts_verdict_is_failure "$TTS_PIPER_VERDICT"; then
-      echo "=== NO WORKING TTS ENGINE (Kokoro: ${TTS_KOKORO_VERDICT:-unreported}, Piper: ${TTS_PIPER_VERDICT:-unreported}) ===" >&2
-      echo "=== This box will answer every spoken request with SILENCE ===" >&2
-      exit 13
-    fi
-    # Both halves declined for the board itself: no Jetson CUDA build and no
-    # pinned Piper artifact for this architecture. Nothing was asked for and
-    # nothing is missing, which is the same rule `skipped:*` has always carried
-    # - failing every install-x64.sh run would only teach everyone to ignore
-    # this check.
-    echo "=== No on-device TTS engine applies to this board (Kokoro: $TTS_KOKORO_VERDICT, Piper: $TTS_PIPER_VERDICT) ==="
-    exit "$KOKORO_RC"
+    # ── No engine is no engine, however each half came to decline ────────────
+    # This used to be two outcomes. "One half FAILED" exited 13 and was
+    # reported; "both halves SKIPPED" printed "No on-device TTS engine applies
+    # to this board" on stdout and exited $KOKORO_RC (10 or 11), which
+    # install.sh graded as a clean provision and step_validate_services scored
+    # as a PASS. The box that came out of it is the same box either way: it
+    # answers every spoken request with silence.
+    #
+    # The reason given for the split was that failing a board neither engine
+    # ships for "would only teach everyone to ignore this check", naming
+    # install-x64.sh as the run it would fail. That run does not exist:
+    # install-x64.sh contains no reference to voice, TTS, Piper or Kokoro and
+    # never calls this script - `grep -n 'install-voice.sh' *.sh` returns
+    # install.sh:2602 and nothing else. So nothing legitimate lands here. What
+    # does land here is install.sh run on a host whose `uname -m` is not
+    # aarch64, which is the ONLY way both halves skip: install_piper_engine's
+    # single non-failure skip is the architecture test, and on that same board
+    # install_kokoro_tts returns 11 for the same reason. The outcome is a box
+    # with no speech, and it was being reported as a healthy one.
+    #
+    # A silent box is not a healthy box. One exit code, one verdict, and every
+    # engine named with the concrete reason it is not here - a report that
+    # sends someone to $TTS_STATUS_FILE to find out what happened is not a
+    # report.
+    echo "=== NO WORKING TTS ENGINE - this box will answer every spoken request with SILENCE ===" >&2
+    echo "===   Kokoro (GPU): $(tts_verdict_explain "$TTS_KOKORO_VERDICT")" >&2
+    echo "===   Piper (CPU):  $(tts_verdict_explain "$TTS_PIPER_VERDICT")" >&2
+    echo "===   Verdicts recorded in $TTS_STATUS_FILE" >&2
+    exit 13
   fi
 
   if [ "$PIPER_RC" -ne 0 ] || [ "$DEPLOY_RC" -ne 0 ]; then
@@ -756,6 +809,29 @@ if [ "${1:-}" = "--piper-only" ]; then
   PIPER_ONLY_RC=0
   install_piper || PIPER_ONLY_RC=1
   deploy_voice_scripts || PIPER_ONLY_RC=1
+
+  # ── The mute-box question is asked FIRST, and it is asked of both halves ───
+  # The sibling call site. --tts-only above now refuses to grade a box with no
+  # `ready` engine as anything but a failure; this mode reached the same state
+  # by a different route and still exited 0 for it — `skipped:?*` below printed
+  # "No Piper artifact applies to this board" and returned success, and the
+  # `PIPER_ONLY_RC` guard returned a plain 1 that says "the fallback did not
+  # complete" even on a box where the fallback was the only engine there was.
+  #
+  # This mode installs ONE engine, so whether the box can speak is a question
+  # about the other half too — and tts_status_load has just read that half's
+  # verdict off disk for exactly this reason. Asked before the two guards below
+  # because it is the more severe fact: "no engine at all" outranks "the CPU
+  # half specifically did not land", and it must not be reported as the lesser
+  # one.
+  if ! tts_verdict_is_ready "$TTS_PIPER_VERDICT" && ! tts_verdict_is_ready "$TTS_KOKORO_VERDICT"; then
+    echo "=== NO WORKING TTS ENGINE - this box will answer every spoken request with SILENCE ===" >&2
+    echo "===   Piper (CPU):  $(tts_verdict_explain "$TTS_PIPER_VERDICT")" >&2
+    echo "===   Kokoro (GPU): $(tts_verdict_explain "$TTS_KOKORO_VERDICT")" >&2
+    echo "===   Verdicts recorded in $TTS_STATUS_FILE" >&2
+    exit 13
+  fi
+
   if [ "$PIPER_ONLY_RC" -ne 0 ]; then
     echo "=== Piper fallback INCOMPLETE — the box may answer speech with silence ===" >&2
     exit 1
@@ -776,10 +852,12 @@ if [ "${1:-}" = "--piper-only" ]; then
     ready) ;;
     skipped:?*)
       # The BOARD declines the engine — no pinned artifact for this
-      # architecture. Nothing was asked for and nothing is missing, which is
-      # the rule `skipped:*` already carries in --tts-only and in install.sh's
-      # health check, so this exits clean without claiming a fallback.
-      echo "=== No Piper artifact applies to this board (Piper: $TTS_PIPER_VERDICT) ==="
+      # architecture. Reached only past the guard above, so a `ready` Kokoro is
+      # already established and the box does speak; the CPU fallback being
+      # absent by design behind a working GPU engine is not a broken box. On a
+      # board with no Kokoro either, this line is unreachable — that box exited
+      # 13 above rather than being told nothing is missing.
+      echo "=== No Piper artifact applies to this board (Piper: $TTS_PIPER_VERDICT) — the box speaks on Kokoro ==="
       exit 0
       ;;
     *)
@@ -1003,3 +1081,20 @@ case "$TTS_PIPER_VERDICT" in
 esac
 echo "  TTS entrypoint: $WORKSPACE/scripts/openclaw/clawbox-tts.sh"
 echo "  Services: kokoro-server, whisper-server (on-demand, auto-stop after idle)"
+
+# ── The third caller, and the third route to a silent box ───────────────────
+# The two arms above got their engine NAMES from the verdicts in #544, and the
+# script then fell off its last `echo` — so a run that had just printed "no
+# Kokoro GPU engine applies to this board" AND "no Piper fallback applies to
+# this board" exited 0. This is the manual voice-pipeline install an operator
+# runs by hand; reporting a mute box to them as a clean run is the same defect
+# --tts-only and --piper-only carried, one caller further out. Same rule, same
+# exit code, same named reasons.
+if ! tts_verdict_is_ready "$TTS_KOKORO_VERDICT" && ! tts_verdict_is_ready "$TTS_PIPER_VERDICT"; then
+  echo "" >&2
+  echo "=== NO WORKING TTS ENGINE - this box will answer every spoken request with SILENCE ===" >&2
+  echo "===   Kokoro (GPU): $(tts_verdict_explain "$TTS_KOKORO_VERDICT")" >&2
+  echo "===   Piper (CPU):  $(tts_verdict_explain "$TTS_PIPER_VERDICT")" >&2
+  echo "===   Verdicts recorded in $TTS_STATUS_FILE" >&2
+  exit 13
+fi

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -350,20 +350,25 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
     expect(res.stdout).toMatch(reason as RegExp);
   });
 
-  it("names no engine at all when the voice install exits 11", () => {
+  it("names no engine at all when the voice install exits 11, and RECORDS it", () => {
     // 11 is "no Jetson CUDA build for this ARCHITECTURE" — `uname -m` is not
     // aarch64, which is the same test that leaves install_piper_engine without
-    // a pinned artifact. Both halves publish `skipped:arch-*`, install-voice.sh
-    // prints "=== No on-device TTS engine applies to this board ===" and exits
-    // 11, so the "Piper CPU only" line this case used to assert named a
-    // fallback the box does not have. It stays non-fatal and unrecorded — a
-    // board neither engine ships for was never asked for one.
+    // a pinned artifact. Both halves publish `skipped:arch-*`, so 11 means the
+    // box has NO engine, and the "Piper CPU only" line this case used to assert
+    // named a fallback it does not have.
+    //
+    // It stayed non-fatal AND unrecorded, so the step said "this box answers
+    // speech with SILENCE" and graded the provision clean. Non-fatal is right —
+    // a mute box must still come up reachable so it can be fixed — but silent
+    // is not: it is recorded now, and the two lines moved to stderr with the
+    // other failures. See install-tts-mute-box-fails.test.ts.
     const res = runStep(11);
     expect(res.openclaw).toContain("config set messages.tts.provider tts-local-cli");
     expect(res.stdout).not.toContain("Kokoro GPU, Piper fallback");
     expect(res.stdout, "a board with no engine was told it speaks on Piper").not.toContain("Piper CPU only");
-    expect(res.stdout).toMatch(/CPU architecture/);
-    expect(res.stdout).toMatch(/SILENCE/);
+    expect(res.stderr).toMatch(/CPU architecture/);
+    expect(res.stderr).toMatch(/SILENCE/);
+    expect(res.provisionFailures, "a box with no engine was not recorded as a failure").toContain("openclaw_tts");
   });
 
   // ── Requested-and-failed is not the same outcome as never-requested ────────
@@ -372,14 +377,21 @@ describe.skipIf(!hasBash)("step_openclaw_tts installs the engine it advertises",
   // install" as the same result — zero — so a flash host printed
   // "Setup: 1/1 succeeded" over a box that had told itself it was broken.
 
-  it.each([
-    [10, "no CUDA toolkit on this board"],
-    [11, "no Jetson build for this architecture"],
-  ])("exit %i is a SKIP: nothing was requested, so nothing is reported failed", (code) => {
-    const res = runStep(code as number);
-    expect(res.status, "a board that was never going to run Kokoro is not a failed install").toBe(0);
-    expect(res.provisionFailures, "a skip was recorded as a provisioning failure").toEqual([]);
-  });
+  // 11 used to be in this table beside 10 and is not any more. Both are skips
+  // of the GPU engine, but they leave DIFFERENT boxes: 10 is an aarch64 board
+  // with no nvcc, where install_piper still has its pinned artifact and the box
+  // speaks on the CPU fallback, while 11 is `uname -m` != aarch64, which is the
+  // same test that leaves install_piper with nothing to install — so 11 is a
+  // box with NO engine and is a recorded failure now. See
+  // install-tts-mute-box-fails.test.ts.
+  it.each([[10, "no CUDA toolkit on this board"]])(
+    "exit %i is a SKIP: the GPU engine was never requested and the box still speaks",
+    (code) => {
+      const res = runStep(code as number);
+      expect(res.status, "a board that was never going to run Kokoro is not a failed install").toBe(0);
+      expect(res.provisionFailures, "a skip was recorded as a provisioning failure").toEqual([]);
+    },
+  );
 
   it("exit 12 is a FAILURE: it leaves the step, the summary and the operator's screen", () => {
     const res = runStep(12);
@@ -698,11 +710,15 @@ describe.skipIf(!hasBash)("install-voice.sh --tts-only never costs the box its v
     expect(res.stdout).toMatch(/Piper voice ready/);
   });
 
-  it("skips Kokoro on an architecture with no Jetson build", () => {
+  it("skips Kokoro on an architecture with no Jetson build, and fails the run", () => {
     // install_piper already refuses to guess a digest off aarch64; the CUDA
-    // torch wheel is just as aarch64-only.
+    // torch wheel is just as aarch64-only. So this board declines BOTH halves
+    // and has nothing to speak with — the run exits 13 rather than the 11 it
+    // used to hand back as a clean provision. The verdict is unchanged: which
+    // engine skipped and why is still published, it just no longer decides
+    // whether the run passed. See install-tts-mute-box-fails.test.ts.
     const res = runTtsOnly({ FAKE_ARCH: "x86_64", WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "1" });
-    expect(res.status).toBe(11);
+    expect(res.status).toBe(13);
     expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=skipped:arch-x86_64");
     expect(res.su.filter((c) => c.includes("pip3 install"))).toEqual([]);
   });
@@ -868,10 +884,28 @@ function runValidator(ttsStatusContents: string | null): { status: number; out: 
 
 describe.skipIf(!hasBash)("service validation refuses to call a Kokoro-less box healthy", () => {
   it("fails the install when the GPU engine was requested and did not install", () => {
+    // The fixture carries no PIPER line, so neither engine is `ready` here and
+    // the probe reports it as such. It used to match the Kokoro-specific arm,
+    // whose sentence ends "— this box answers speech on the Piper CPU
+    // fallback": a fallback claim made from an UNREPORTED verdict. That arm is
+    // now reached only with a ready Piper, and this state gets a sentence that
+    // names both halves and asserts a fallback for neither.
     const res = runValidator("KOKORO=failed:model\n");
     expect(res.status, `validation passed a box with no GPU TTS:\n${res.out}`).toBe(1);
-    expect(res.out).toMatch(/requested and did NOT install/);
+    expect(res.out).toMatch(/no on-device TTS engine on this box is confirmed ready/);
+    expect(res.out).toMatch(/failed:model/);
+    expect(res.out, "a fallback was claimed from an unreported verdict").not.toMatch(
+      /answers speech on the Piper CPU fallback/,
+    );
     expect(res.out).toMatch(/--step openclaw_tts/);
+  });
+
+  it("still names the Kokoro half specifically when the CPU fallback IS there", () => {
+    // The arm above did not disappear — it moved behind the evidence it needs.
+    const res = runValidator("KOKORO=failed:model\nPIPER=ready\n");
+    expect(res.status, `validation passed a box with no GPU TTS:\n${res.out}`).toBe(1);
+    expect(res.out).toMatch(/requested and did NOT install/);
+    expect(res.out).toMatch(/Piper CPU fallback/);
   });
 
   it("passes a board that was never going to run Kokoro", () => {

--- a/src/tests/unit/install-tts-mute-box-fails.test.ts
+++ b/src/tests/unit/install-tts-mute-box-fails.test.ts
@@ -52,6 +52,8 @@ const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status ===
 /** See install-tts-no-engine.test.ts: keeps the isolated stub PATH usable on Windows. */
 const HOST_PATH_SUFFIX = process.platform === "win32" ? `${path.delimiter}${process.env.PATH ?? ""}` : "";
 
+/** Lift a multi-line shell function verbatim out of a shipped script, so the
+ *  test executes the real body rather than a paraphrase of it. */
 function extractShellFn(source: string, name: string): string {
   const start = source.indexOf(`${name}() {`);
   if (start < 0) throw new Error(`${name} not found`);
@@ -77,12 +79,16 @@ function extractShellFnOrStub(source: string, name: string, stub: string): strin
   return source.includes(`${name}() {`) ? extractShellFn(source, name) : `${name}() { ${stub}; }`;
 }
 
+/** Read a pinned constant (e.g. PIPER_EN_ONNX_SHA256) out of the real script,
+ *  so a fixture cannot drift away from the digest the installer enforces. */
 function shellConst(name: string): string {
   const m = new RegExp(`^${name}="([^"]+)"`, "m").exec(INSTALL_VOICE_SH);
   if (!m) throw new Error(`${name} not found in install-voice.sh`);
   return m[1];
 }
 
+/** Write an executable bash stub onto the isolated PATH the script under test
+ *  will resolve its commands from. */
 function writeExec(file: string, body: string) {
   writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
 }
@@ -497,6 +503,11 @@ describe.skipIf(!hasBash)("step_openclaw_tts records a box with no engine as a f
 
 // ── 5. The health check is the last layer that called it healthy ────────────
 
+/**
+ * Run the real step_validate_services against a verdict file of the test's
+ * choosing, with every probe but the TTS one stubbed out. `null` writes no file
+ * at all, which is the "the step left no record" case.
+ */
 function runValidator(contents: string | null): { status: number; out: string } {
   const ttsStatus = path.join(root, "validator-tts-status");
   if (contents !== null) writeFileSync(ttsStatus, contents);

--- a/src/tests/unit/install-tts-mute-box-fails.test.ts
+++ b/src/tests/unit/install-tts-mute-box-fails.test.ts
@@ -1,0 +1,590 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * A box that finishes provisioning with NO working speech engine must FAIL,
+ * loudly, naming every engine it tried and why each one is not there.
+ *
+ * #519, #533 and #544 removed the false successes one at a time, but all three
+ * kept one carve-out: when BOTH engines report `skipped:*` the run was graded
+ * clean. `--tts-only` printed "No on-device TTS engine applies to this board"
+ * on stdout and exited $KOKORO_RC; step_openclaw_tts mapped that to TTS_RC=0
+ * with no record_provision_failure; and step_validate_services' probe asked for
+ * a `failed:*` before it would report a mute box, so two `skipped:*` verdicts
+ * matched no arm and fell out of the chain as a silent PASS.
+ *
+ * The defence for it, repeated in all three PRs, was that failing a board
+ * neither engine ships for "would only teach everyone to ignore this check",
+ * naming install-x64.sh as the run it would fail. That run does not exist:
+ *
+ *   $ grep -c 'voice\|tts\|piper\|kokoro' install-x64.sh   -> 0
+ *   $ grep -n 'install-voice.sh' *.sh                      -> install.sh:2602
+ *
+ * install-x64.sh never calls the script that publishes these verdicts, so
+ * nothing legitimate lands in the carve-out. What lands in it is install.sh run
+ * where `uname -m` is not aarch64 — the only way both halves skip, since
+ * install_piper_engine's single non-failure skip is the architecture test and
+ * install_kokoro_tts returns 11 on that same board. The box that comes out has
+ * no voice, and every layer called it healthy.
+ *
+ * A silent box is not a healthy box. These tests EXECUTE the shipped artifacts
+ * — the real `--tts-only` and `--piper-only` dispatches out of
+ * scripts/install-voice.sh, the real engine-report block at the end of its full
+ * pipeline, the real step_openclaw_tts and the real step_validate_services out
+ * of install.sh — against stubs, so a rewrite that keeps the prose but drops
+ * the verdict fails them.
+ *
+ * Roughly half of these are over-correction guards, and they are the point of
+ * half the diff: a box with ONE engine is not a mute box, and reporting it as
+ * one would be the same class of untrue status line pointed the other way.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_VOICE = path.join(REPO, "scripts", "install-voice.sh");
+const INSTALL_VOICE_SH = readFileSync(INSTALL_VOICE, "utf-8");
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+/** See install-tts-no-engine.test.ts: keeps the isolated stub PATH usable on Windows. */
+const HOST_PATH_SUFFIX = process.platform === "win32" ? `${path.delimiter}${process.env.PATH ?? ""}` : "";
+
+function extractShellFn(source: string, name: string): string {
+  const start = source.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found`);
+  const end = source.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return source.slice(start, end + 2);
+}
+
+/** A one-line shell helper (`name() { ... }` all on one line), lifted verbatim. */
+function extractShellOneLiner(source: string, name: string): string {
+  const m = new RegExp(`^${name}\\(\\) \\{.*\\}$`, "m").exec(source);
+  if (!m) throw new Error(`${name} not found as a one-liner`);
+  return m[0];
+}
+
+/**
+ * A helper the block under test MAY not carry yet, lifted when it is there and
+ * stubbed when it is not. Without this the over-correction guards below could
+ * not run against a tree that predates the helper, and a guard that errors for
+ * a reason unrelated to what it guards proves nothing.
+ */
+function extractShellFnOrStub(source: string, name: string, stub: string): string {
+  return source.includes(`${name}() {`) ? extractShellFn(source, name) : `${name}() { ${stub}; }`;
+}
+
+function shellConst(name: string): string {
+  const m = new RegExp(`^${name}="([^"]+)"`, "m").exec(INSTALL_VOICE_SH);
+  if (!m) throw new Error(`${name} not found in install-voice.sh`);
+  return m[1];
+}
+
+function writeExec(file: string, body: string) {
+  writeFileSync(file, `#!/usr/bin/env bash\n${body}\n`, { mode: 0o755 });
+}
+
+/** Programs run from a FILE, not `bash -c`: see install-tts-no-engine.test.ts. */
+function runShellProgram(program: string, env: Record<string, string>) {
+  const file = path.join(root, `prog-${Math.random().toString(36).slice(2)}.sh`);
+  writeFileSync(file, program);
+  return spawnSync("bash", [file], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: { ...process.env, ...env },
+  });
+}
+
+let root: string;
+
+interface VoiceRun {
+  status: number | null;
+  out: string;
+  ttsStatus: string;
+  verdict: (key: string) => string | null;
+}
+
+/**
+ * Build a fake device root and run the REAL scripts/install-voice.sh.
+ *
+ * `arch` is the whole defect surface: on x86_64 install_piper_engine has no
+ * pinned artifact and install_kokoro_tts has no Jetson wheel, so BOTH halves
+ * publish `skipped:arch-x86_64` and the box has nothing to speak with.
+ *
+ * `seedStatus` writes a verdict file before the run, which is how a mode that
+ * installs ONE engine (--piper-only) learns about the other half — the case
+ * that separates "this box lost its fallback" from "this box is mute".
+ */
+function runVoice(
+  opts: {
+    args?: string[];
+    piper?: "ready" | "broken";
+    withCuda?: boolean;
+    arch?: string;
+    seedStatus?: string;
+  } = {},
+): VoiceRun {
+  const { args = ["--tts-only"], piper = "ready", withCuda = false, arch = "aarch64" } = opts;
+  const home = path.join(root, "home", "clawbox");
+  const bin = path.join(root, "bin");
+  const ttsStatus = path.join(root, "tts-status");
+  const cudaHome = path.join(root, withCuda ? "cuda" : "no-such-cuda");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  if (opts.seedStatus !== undefined) writeFileSync(ttsStatus, opts.seedStatus);
+
+  if (withCuda) {
+    mkdirSync(path.join(home, ".local", "lib", "python3.10", "site-packages", "nvidia", "cusparselt", "lib"), {
+      recursive: true,
+    });
+    mkdirSync(path.join(cudaHome, "lib64"), { recursive: true });
+    writeExec(path.join(bin, "nvcc"), 'echo "Cuda compilation tools, release 12.6, V12.6.68"');
+  }
+
+  writeExec(
+    path.join(bin, "su"),
+    [
+      'cmd=""',
+      'while [ $# -gt 0 ]; do case "$1" in -c) cmd="$2"; shift 2;; *) shift;; esac; done',
+      'stdin_code=""',
+      'case "$cmd" in *"python3 -") stdin_code="$(cat)" ;; esac',
+      'full=$(printf "%s\\n%s" "$cmd" "$stdin_code")',
+      "case \"$full\" in",
+      '  *"sys.version_info"*) echo "python3.10"; exit 0 ;;',
+      '  *"import kokoro, torch"*) exit 0 ;;',
+      '  *"from kokoro import KPipeline"*) exit 0 ;;',
+      "esac",
+      "exit 0",
+    ].join("\n"),
+  );
+  writeExec(
+    path.join(bin, "uname"),
+    [`[ "\${1:-}" = "-m" ] && { echo "\${FAKE_ARCH:-aarch64}"; exit 0; }`, 'exec /usr/bin/uname "$@"'].join("\n"),
+  );
+  writeExec(path.join(bin, "curl"), "exit 1");
+  writeExec(path.join(bin, "wget"), "exit 1");
+  writeExec(path.join(bin, "chown"), "exit 0");
+  writeExec(path.join(bin, "loginctl"), "exit 0");
+  writeExec(path.join(bin, "sha256sum"), 'printf "%s  %s\\n" "$(head -c 64 "$1")" "$1"');
+
+  const piperDir = path.join(root, "piper");
+  if (piper === "ready") {
+    mkdirSync(path.join(piperDir, "voices"), { recursive: true });
+    writeExec(path.join(piperDir, "piper"), "exit 0");
+    writeFileSync(path.join(piperDir, "voices", "en_US-lessac-medium.onnx"), shellConst("PIPER_EN_ONNX_SHA256"));
+    writeFileSync(
+      path.join(piperDir, "voices", "en_US-lessac-medium.onnx.json"),
+      shellConst("PIPER_EN_JSON_SHA256"),
+    );
+  }
+
+  const res = spawnSync("bash", [INSTALL_VOICE, ...args], {
+    encoding: "utf-8",
+    timeout: 60_000,
+    env: {
+      PATH: `${bin}:/usr/bin:/bin${HOST_PATH_SUFFIX}`,
+      HOME: home,
+      CLAWBOX_USER: "clawbox",
+      CLAWBOX_HOME: home,
+      PIPER_DIR: piperDir,
+      CLAWBOX_CUDA_HOME: cudaHome,
+      CLAWBOX_TTS_STATUS_FILE: ttsStatus,
+      FAKE_ARCH: arch,
+    } as unknown as NodeJS.ProcessEnv,
+  });
+
+  const contents = existsSync(ttsStatus) ? readFileSync(ttsStatus, "utf-8") : "";
+  return {
+    status: res.status,
+    out: `${res.stdout ?? ""}${res.stderr ?? ""}`,
+    ttsStatus: contents,
+    verdict: (key: string) => {
+      const m = new RegExp(`^${key}=(.*)$`, "m").exec(contents);
+      return m ? m[1] : null;
+    },
+  };
+}
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "tts-mute-"));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+// ── 1. --tts-only: no `ready` engine is a failure, however each half declined ─
+
+describe.skipIf(!hasBash)("--tts-only fails a box that ends with no engine", () => {
+  it("exits 13 when BOTH halves skip for the board itself", () => {
+    // The ruling. x86_64: no pinned Piper artifact AND no Jetson CUDA build, so
+    // both halves publish `skipped:arch-*`. This exited 11 and install.sh
+    // graded it a clean provision.
+    const res = runVoice({ piper: "ready", arch: "x86_64" });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toMatch(/^skipped:/);
+    expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^skipped:/);
+    expect(res.status, `a box with no engine at all exited clean:\n${res.out}`).toBe(13);
+  });
+
+  it("names BOTH engines and the concrete reason each one is absent", () => {
+    // Not a bare "no engine": a report that sends the operator off to read
+    // $TTS_STATUS_FILE to find out what happened is not a report. The reason
+    // travels with the verdict, so it travels into the banner.
+    const res = runVoice({ piper: "ready", arch: "x86_64" });
+    expect(res.out).toMatch(/NO WORKING TTS ENGINE/);
+    expect(res.out).toMatch(/SILENCE/);
+    expect(res.out, `the Kokoro half was not named:\n${res.out}`).toMatch(/Kokoro/);
+    expect(res.out, `the Piper half was not named:\n${res.out}`).toMatch(/Piper/);
+    expect(res.out, `neither reason was given:\n${res.out}`).toMatch(/arch-x86_64/);
+  });
+
+  it("still publishes both verdicts on the way out", () => {
+    // The failure has to outlive the run: install.sh's health check and the
+    // next update both read the file, not the flash log.
+    const res = runVoice({ piper: "ready", arch: "x86_64" });
+    expect(res.ttsStatus).toMatch(/^KOKORO=skipped:/m);
+    expect(res.ttsStatus).toMatch(/^PIPER=skipped:/m);
+  });
+
+  it("reports the reason it FAILED on, not just the reason it skipped", () => {
+    // The other route into the same arm, which already exited 13: a legitimate
+    // `skipped:no-cuda` next to a Piper download that flaked. Both routes now
+    // produce one outcome and both name their halves.
+    const res = runVoice({ piper: "broken" });
+    expect(res.status, res.out).toBe(13);
+    expect(res.out).toMatch(/failed/i);
+  });
+
+  // ── over-correction guards ────────────────────────────────────────────────
+
+  it("does NOT fail a no-CUDA board that speaks on the CPU fallback", () => {
+    // An aarch64 Orin with no nvcc: Kokoro legitimately skips, Piper installs,
+    // the box speaks. `skipped:*` behind a working engine is still not a defect
+    // — the rule that changed is only what happens when NOTHING is ready.
+    const res = runVoice({ piper: "ready" });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toBe("skipped:no-cuda");
+    expect(res.verdict("PIPER"), res.ttsStatus).toBe("ready");
+    expect(res.status, `a box that speaks on Piper was failed:\n${res.out}`).toBe(10);
+  });
+
+  it("does NOT fail a healthy box with both engines", () => {
+    const res = runVoice({ piper: "ready", withCuda: true });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toBe("ready");
+    expect(res.status, `a healthy box was failed:\n${res.out}`).toBe(0);
+  });
+
+  it("keeps 'lost the fallback behind a working engine' as its own outcome (1, not 13)", () => {
+    // Folding this into 13 would print "this box has NO working TTS engine"
+    // over a box whose GPU engine is running perfectly.
+    const res = runVoice({ piper: "broken", withCuda: true });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toBe("ready");
+    expect(res.status, res.out).toBe(1);
+  });
+});
+
+// ── 2. --piper-only: the sibling call site, reached by a different route ─────
+
+describe.skipIf(!hasBash)("--piper-only fails a box that ends with no engine", () => {
+  it("exits 13 when it declines Piper and no other engine is on record", () => {
+    // The mode clawbox-tts.sh tells an operator to run when it reports "Piper
+    // not installed". On a board with no pinned artifact it printed "No Piper
+    // artifact applies to this board" and exited 0 — a clean success handed to
+    // someone who ran it BECAUSE the box could not speak.
+    const res = runVoice({ args: ["--piper-only"], piper: "broken", arch: "x86_64" });
+    expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^skipped:/);
+    expect(res.status, `a mute box was told nothing is missing:\n${res.out}`).toBe(13);
+    expect(res.out).toMatch(/NO WORKING TTS ENGINE/);
+  });
+
+  it("exits 13 when the fallback FAILED and no other engine is on record", () => {
+    // Previously a plain 1, "the fallback did not complete" — the lesser fact,
+    // on a box where the fallback was the only engine there was.
+    const res = runVoice({ args: ["--piper-only"], piper: "broken" });
+    expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^failed:/);
+    expect(res.status, res.out).toBe(13);
+  });
+
+  // ── over-correction guards ────────────────────────────────────────────────
+
+  it("still exits 0 when it declines Piper behind a Kokoro that IS ready", () => {
+    // The guard that decides the shape of the fix: the question is not "did
+    // Piper install", it is "can this box speak". tts_status_load has just read
+    // the GPU half's verdict off disk, and on this board it says yes.
+    const res = runVoice({
+      args: ["--piper-only"],
+      piper: "broken",
+      arch: "x86_64",
+      seedStatus: "KOKORO=ready\n",
+    });
+    expect(res.status, `a box with a working GPU engine was called mute:\n${res.out}`).toBe(0);
+    expect(res.out).toMatch(/No Piper artifact applies/i);
+  });
+
+  it("still exits 1 when the fallback is lost behind a ready Kokoro", () => {
+    const res = runVoice({ args: ["--piper-only"], piper: "broken", seedStatus: "KOKORO=ready\n" });
+    expect(res.status, res.out).toBe(1);
+  });
+
+  it("still announces the fallback when it genuinely installs", () => {
+    const res = runVoice({ args: ["--piper-only"], piper: "ready" });
+    expect(res.verdict("PIPER"), res.ttsStatus).toBe("ready");
+    expect(res.status, res.out).toBe(0);
+    expect(res.out).toContain("Piper fallback ready");
+  });
+
+  it("does not blank a Kokoro verdict an earlier run published", () => {
+    // The #533 guard, re-pinned because this PR adds a reader of the seeded
+    // value: if tts_status_load ever stopped seeding, the new mute-box check
+    // would fail every --piper-only run on a healthy Kokoro box.
+    const res = runVoice({ args: ["--piper-only"], piper: "ready", seedStatus: "KOKORO=ready\n" });
+    expect(res.verdict("KOKORO"), res.ttsStatus).toBe("ready");
+  });
+});
+
+// ── 3. The full pipeline is the third caller, and it fell off its last echo ──
+
+/**
+ * Execute the REAL engine-report block at the end of scripts/install-voice.sh —
+ * everything from the line that names the entrypoint to EOF — with the two
+ * verdicts preset. The pipeline above it installs CUDA torch and builds
+ * CTranslate2 from source, which no unit test can run; this block is the part
+ * that decides what the operator is told and what status they get back.
+ */
+function runPipelineReport(kokoro: string, piper: string) {
+  const marker = 'echo "  TTS entrypoint:';
+  const at = INSTALL_VOICE_SH.indexOf(marker);
+  if (at < 0) throw new Error("the pipeline's engine-report block moved");
+  const program = [
+    "set -uo pipefail",
+    `TTS_STATUS_FILE="${path.join(root, "tts-status")}"`,
+    'WORKSPACE="/home/clawbox/.openclaw/workspace"',
+    `TTS_KOKORO_VERDICT="${kokoro}"`,
+    `TTS_PIPER_VERDICT="${piper}"`,
+    extractShellOneLiner(INSTALL_VOICE_SH, "tts_verdict_is_ready"),
+    extractShellFnOrStub(INSTALL_VOICE_SH, "tts_verdict_explain", 'printf %s "${1:-unreported}"'),
+    INSTALL_VOICE_SH.slice(at),
+  ].join("\n");
+  const r = runShellProgram(program, {});
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe.skipIf(!hasBash)("the manual voice-pipeline install fails a box with no engine", () => {
+  it("exits 13 after printing that neither engine applies", () => {
+    // It printed "no Kokoro GPU engine applies to this board" AND "no Piper
+    // fallback applies to this board" and then exited 0, because the script
+    // ended on an echo. #544 taught these two lines to read the verdicts and
+    // left the status alone.
+    const res = runPipelineReport("skipped:arch-x86_64", "skipped:arch-x86_64");
+    expect(res.status, `the manual installer reported a mute box as success:\n${res.out}`).toBe(13);
+    expect(res.out).toMatch(/NO WORKING TTS ENGINE/);
+    expect(res.out).toMatch(/arch-x86_64/);
+  });
+
+  it("exits 0 when an engine is there", () => {
+    const res = runPipelineReport("ready", "ready");
+    expect(res.status, res.out).toBe(0);
+  });
+
+  it("exits 0 on a no-CUDA board that has the CPU engine", () => {
+    const res = runPipelineReport("skipped:no-cuda", "ready");
+    expect(res.status, res.out).toBe(0);
+  });
+});
+
+// ── 4. install.sh must record it, not launder it into a summary line ─────────
+
+/**
+ * Run the real step_openclaw_tts against a stub install-voice.sh that publishes
+ * the verdicts and THEN exits the chosen code, in that order — which is what
+ * the real script does, so a rewrite that keeps the prose but reads the exit
+ * code instead of the file fails here.
+ */
+function runStep(voiceExit: number, statusFileContents: string | null = null) {
+  const projectDir = path.join(root, "project");
+  const provisionLog = path.join(root, "provision-failures.log");
+  const ttsStatus = path.join(root, "step-tts-status");
+  mkdirSync(path.join(projectDir, "scripts", "openclaw"), { recursive: true });
+  writeExec(
+    path.join(projectDir, "scripts", "openclaw", "clawbox-tts.sh"),
+    '[ "${1:-}" = "--provider-timeout-ms" ] && echo 100000\nexit 0',
+  );
+  writeExec(
+    path.join(projectDir, "scripts", "install-voice.sh"),
+    statusFileContents === null
+      ? `exit ${voiceExit}`
+      : [`cat > "$CLAWBOX_TTS_STATUS_FILE" <<'EOF'\n${statusFileContents}EOF`, `exit ${voiceExit}`].join("\n"),
+  );
+  const openclaw = path.join(root, "openclaw");
+  writeExec(openclaw, ['if [ "$1" = "config" ] && [ "$2" = "get" ]; then exit 0; fi', "exit 0"].join("\n"));
+
+  const program = [
+    "set -uo pipefail",
+    `PROJECT_DIR="${projectDir}"`,
+    `OPENCLAW_BIN="${openclaw}"`,
+    "CLAWBOX_USER=clawbox",
+    'as_clawbox() { env "$@"; }',
+    "is_hermes_edition() { return 1; }",
+    `record_provision_failure() { printf '%s\\n' "$1" >> "${provisionLog}"; }`,
+    extractShellFn(INSTALL_SH, "oc_config_set"),
+    extractShellFn(INSTALL_SH, "tts_ensure_provider_registered"),
+    extractShellFn(INSTALL_SH, "step_openclaw_tts"),
+    "step_openclaw_tts",
+    'echo "STEP_RC=$?"',
+  ].join("\n");
+
+  const r = runShellProgram(program, { TTS_STATUS_FILE: ttsStatus });
+  const out = `${r.stdout ?? ""}${r.stderr ?? ""}`;
+  return {
+    out,
+    stepRc: /STEP_RC=(\d+)/.exec(out)?.[1] ?? "",
+    provisionFailures: existsSync(provisionLog)
+      ? readFileSync(provisionLog, "utf-8").trim().split("\n").filter(Boolean)
+      : [],
+  };
+}
+
+describe.skipIf(!hasBash)("step_openclaw_tts records a box with no engine as a failure", () => {
+  it("RECORDS exit 11 instead of grading it a clean provision", () => {
+    // 11 is "no Jetson CUDA build for this architecture", which is the same
+    // `uname -m` test that leaves install_piper without a pinned artifact — so
+    // 11 has always meant "this box has NO engine". It printed "this box
+    // answers speech with SILENCE" and returned 0, with PROVISION_FAILURES left
+    // empty and nothing in the marker the flash host reads.
+    const res = runStep(11);
+    expect(
+      res.provisionFailures,
+      `a box with no engine at all was not recorded as a failure:\n${res.out}`,
+    ).toContain("openclaw_tts");
+    expect(res.stepRc, res.out).toBe("13");
+  });
+
+  it("names both engines and their reasons when the run published them", () => {
+    const res = runStep(13, "KOKORO=skipped:no-cuda\nPIPER=failed:download\n");
+    expect(res.out).toMatch(/skipped:no-cuda/);
+    expect(res.out).toMatch(/failed:download/);
+  });
+
+  it("keeps the provider configured — a mute box must still come up fixable", () => {
+    // Non-fatal stays non-fatal. A box that cannot speak has to finish
+    // provisioning and be reachable, which is how it gets repaired.
+    const res = runStep(11);
+    expect(res.out).not.toMatch(/^\s*ERROR/m);
+  });
+
+  // ── over-correction guards ────────────────────────────────────────────────
+
+  it("still grades a no-CUDA board that speaks on Piper as clean (10)", () => {
+    const res = runStep(10, "KOKORO=skipped:no-cuda\nPIPER=ready\n");
+    expect(res.provisionFailures, `a box that speaks on Piper was recorded broken:\n${res.out}`).toEqual([]);
+    expect(res.stepRc, res.out).toBe("0");
+    expect(res.out).toContain("Piper CPU only");
+  });
+
+  it("still grades a fully healthy box as clean (0)", () => {
+    const res = runStep(0, "KOKORO=ready\nPIPER=ready\n");
+    expect(res.provisionFailures, res.out).toEqual([]);
+    expect(res.stepRc, res.out).toBe("0");
+  });
+
+  it("does not call a box mute when only its fallback is gone (1 -> 14)", () => {
+    const res = runStep(1, "KOKORO=ready\nPIPER=failed:download\n");
+    expect(res.stepRc, res.out).toBe("14");
+    expect(res.out, `a box with a working GPU engine was called mute:\n${res.out}`).not.toMatch(
+      /NO working TTS engine/,
+    );
+  });
+});
+
+// ── 5. The health check is the last layer that called it healthy ────────────
+
+function runValidator(contents: string | null): { status: number; out: string } {
+  const ttsStatus = path.join(root, "validator-tts-status");
+  if (contents !== null) writeFileSync(ttsStatus, contents);
+  const clock = path.join(root, "clock");
+  writeFileSync(clock, "1000\n");
+
+  const program = [
+    "set -uo pipefail",
+    "CLAWBOX_EDITION=openclaw",
+    "CLAWBOX_TEST_MODE=1",
+    "PROJECT_DIR=/home/clawbox/clawbox",
+    'IFACE_ENV="/nonexistent/network.env"',
+    "EXPECTED_ACTIVE_SERVICES=()",
+    "EXPECTED_INSTALLED_SERVICES=()",
+    "FOREIGN_EDITION_UNITS=()",
+    'is_test_mode() { [ "$CLAWBOX_TEST_MODE" = "1" ]; }',
+    'is_hermes_edition() { [ "$CLAWBOX_EDITION" = "hermes" ]; }',
+    "has_hermes_harness() { return 1; }",
+    "gateway_port_listening() { return 1; }",
+    "systemctl() { return 0; }",
+    "curl() { printf '200'; }",
+    `_CLOCK="${clock}"`,
+    'date() { local n; n=$(( $(cat "$_CLOCK") + 100 )); echo "$n" > "$_CLOCK"; printf %s "$n"; }',
+    "sleep() { :; }",
+    extractShellFn(INSTALL_SH, "step_validate_services"),
+    "step_validate_services",
+  ].join("\n");
+
+  const r = runShellProgram(program, { TTS_STATUS_FILE: ttsStatus });
+  return { status: r.status ?? -1, out: `${r.stdout ?? ""}${r.stderr ?? ""}` };
+}
+
+describe.skipIf(!hasBash)("service validation refuses to pass a box with no engine", () => {
+  it("FAILS a board where both engines skipped", () => {
+    // The carve-out. The probe asked for a `failed:*` before it would report a
+    // mute box, so two `skipped:*` verdicts matched no arm and scored a PASS —
+    // "All 2 checks healthy" over a box that answers with silence.
+    const res = runValidator("KOKORO=skipped:arch-x86_64\nPIPER=skipped:arch-x86_64\n");
+    expect(res.status, `validation passed a box with no TTS engine:\n${res.out}`).toBe(1);
+    expect(res.out).toMatch(/SILENCE/);
+  });
+
+  it("names both engines and both reasons in the failure it reports", () => {
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=skipped:arch-x86_64\n");
+    expect(res.status, res.out).toBe(1);
+    expect(res.out).toMatch(/skipped:no-cuda/);
+    expect(res.out).toMatch(/skipped:arch-x86_64/);
+  });
+
+  it("FAILS the mixed case too — one skipped, one failed", () => {
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=failed:download\n");
+    expect(res.status, res.out).toBe(1);
+  });
+
+  // ── over-correction guards ────────────────────────────────────────────────
+
+  it("passes a no-CUDA Orin that speaks on the CPU fallback", () => {
+    const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=ready\n");
+    expect(res.status, `a box that speaks on Piper was failed:\n${res.out}`).toBe(0);
+  });
+
+  it("passes a box whose GPU engine is up and whose fallback the board declines", () => {
+    // The mirror image, and the reason the new arm asks "is EITHER ready"
+    // rather than "is either skipped": a `skipped:*` Piper behind a running
+    // Kokoro is not a mute box.
+    const res = runValidator("KOKORO=ready\nPIPER=skipped:arch-x86_64\n");
+    expect(res.status, res.out).toBe(0);
+  });
+
+  it("passes a fully healthy box", () => {
+    expect(runValidator("KOKORO=ready\nPIPER=ready\n").status).toBe(0);
+  });
+
+  it("still reports an unreported half as unassertable rather than as silence", () => {
+    // `-n` on both verdicts before the SILENCE claim: an engine that published
+    // nothing is unknown, not absent, and asserting a mute box off a missing
+    // line would be a failure report over something that may have succeeded.
+    const res = runValidator("KOKORO=skipped:no-cuda\n");
+    expect(res.status, `an unreported engine scored as healthy:\n${res.out}`).toBe(1);
+    expect(res.out, `a missing line was reported as proven silence:\n${res.out}`).not.toMatch(/with SILENCE/);
+  });
+
+  it("still puts an unreadable verdict ahead of the engine-naming arms", () => {
+    // #533's guard. A garbled Kokoro verdict next to a ready Piper must not be
+    // reported as "no engine" — that is a claim about an engine that may be
+    // running perfectly.
+    const res = runValidator("KOKORO=redy\nPIPER=ready\n");
+    expect(res.status, res.out).toBe(1);
+    expect(res.out).toMatch(/unrecognised/i);
+  });
+});

--- a/src/tests/unit/install-tts-no-engine.test.ts
+++ b/src/tests/unit/install-tts-no-engine.test.ts
@@ -279,14 +279,21 @@ describe.skipIf(!hasBash)("--tts-only reports which engines survived, not just t
     expect(res.status, res.out).toBe(1);
   });
 
-  it("does not cry 'no engine' on a board no engine was ever going to run on", () => {
-    // x86_64: no pinned Piper artifact AND no Jetson CUDA build. Nothing was
-    // asked for and nothing is missing — failing every install-x64.sh run would
-    // just teach everyone to ignore this check.
+  it("cries 'no engine' on a board no engine was ever going to run on", () => {
+    // REVERSED, deliberately. x86_64: no pinned Piper artifact AND no Jetson
+    // CUDA build, so both halves decline and the box has nothing to speak with.
+    // This used to exit 11 and grade clean, on the grounds that failing every
+    // install-x64.sh run would teach everyone to ignore the check — but
+    // install-x64.sh never calls this script (it contains no reference to
+    // voice, TTS, Piper or Kokoro at all), so the run being protected does not
+    // exist and what the leniency passed was a box with no voice. Both halves
+    // still publish `skipped:*`: WHY each engine is absent is a sentence for
+    // the operator, not an input to whether the run passed.
+    // See install-tts-mute-box-fails.test.ts.
     const res = runTtsOnly({ piper: "ready", arch: "x86_64" });
     expect(res.verdict("KOKORO"), res.ttsStatus).toMatch(/^skipped:/);
     expect(res.verdict("PIPER"), res.ttsStatus).toMatch(/^skipped:/);
-    expect(res.status, `a board with no applicable engine was called broken:\n${res.out}`).toBe(11);
+    expect(res.status, `a box with no engine at all exited clean:\n${res.out}`).toBe(13);
   });
 });
 
@@ -484,10 +491,13 @@ describe.skipIf(!hasBash)("service validation refuses to call a mute box healthy
     expect(res.status, `an unreported engine scored as healthy:\n${res.out}`).toBe(1);
   });
 
-  it("passes a board that was never going to run either engine", () => {
-    // install-x64.sh: no Jetson CUDA build and no pinned Piper artifact.
+  it("FAILS a board that was never going to run either engine", () => {
+    // REVERSED. No Jetson CUDA build and no pinned Piper artifact is still a
+    // box that answers every spoken request with silence, and this probe used
+    // to score it healthy because the mute-box arm asked for a `failed:*`
+    // first. See install-tts-mute-box-fails.test.ts.
     const res = runValidator("KOKORO=skipped:arch-x86_64\nPIPER=skipped:arch-x86_64\n");
-    expect(res.status, res.out).toBe(0);
+    expect(res.status, `validation passed a box with no TTS engine:\n${res.out}`).toBe(1);
   });
 
   it("passes a no-CUDA Orin that speaks on the CPU fallback", () => {

--- a/src/tests/unit/install-tts-verdict-siblings.test.ts
+++ b/src/tests/unit/install-tts-verdict-siblings.test.ts
@@ -118,13 +118,19 @@ interface VoiceRun {
  * answers: on anything but aarch64 install_piper_engine declines for want of a
  * pinned artifact and returns 0.
  */
-function runPiperOnly(opts: { piper?: "ready" | "broken"; arch?: string } = {}): VoiceRun {
+function runPiperOnly(
+  opts: { piper?: "ready" | "broken"; arch?: string; seedStatus?: string } = {},
+): VoiceRun {
   const { piper = "ready", arch = "aarch64" } = opts;
   const home = path.join(root, "home", "clawbox");
   const bin = path.join(root, "bin");
   const ttsStatus = path.join(root, "tts-status");
   mkdirSync(bin, { recursive: true });
   mkdirSync(home, { recursive: true });
+  // A verdict file a PREVIOUS run left behind, which is what tts_status_load
+  // seeds the OTHER engine's verdict from — the difference between "this box
+  // lost its CPU fallback" and "this box has nothing to speak with".
+  if (opts.seedStatus !== undefined) writeFileSync(ttsStatus, opts.seedStatus);
 
   writeExec(
     path.join(bin, "uname"),
@@ -186,16 +192,34 @@ describe.skipIf(!hasBash)("--piper-only reports the engine it published, not its
     expect(res.out, `a board with no artifact was told it has a fallback:\n${res.out}`).not.toContain(
       "Piper fallback ready",
     );
-    expect(res.out).toMatch(/no Piper artifact applies/i);
+    // With no other engine on record this board is mute, so the mode says so
+    // rather than "no artifact applies" — the "applies" wording is now reserved
+    // for the board where a ready Kokoro is carrying the speech, which the next
+    // test pins. Either way it is not an announced fallback.
+    expect(res.out).toMatch(/NO WORKING TTS ENGINE/);
   });
 
-  it("still exits 0 there — a board that declines an engine is not a failure", () => {
-    // The mirror-image over-correction. `skipped:*` means nothing was asked for
-    // and nothing is missing, the same rule --tts-only and the health check
-    // already follow; failing every x86 run would only teach everyone to
-    // ignore this mode.
+  it("says 'no artifact applies' when a ready Kokoro is carrying the box", () => {
+    const res = runPiperOnly({ piper: "broken", arch: "x86_64", seedStatus: "KOKORO=ready\n" });
+    expect(res.out).toMatch(/no Piper artifact applies/i);
+    expect(res.out).not.toContain("Piper fallback ready");
+  });
+
+  it("exits 13 there when nothing else on the box can speak either", () => {
+    // REVERSED. `skipped:*` means nothing is missing only while the OTHER half
+    // is carrying the box; with no Kokoro verdict on disk this is a mute box,
+    // and the mode an operator runs BECAUSE the box cannot speak was answering
+    // them with a clean exit 0. See install-tts-mute-box-fails.test.ts.
     const res = runPiperOnly({ piper: "broken", arch: "x86_64" });
-    expect(res.status, `a board with no applicable engine was called broken:\n${res.out}`).toBe(0);
+    expect(res.status, `a mute box was told nothing is missing:\n${res.out}`).toBe(13);
+  });
+
+  it("still exits 0 there when a ready Kokoro is on record", () => {
+    // The over-correction guard that replaces it: the question is "can this box
+    // speak", not "did Piper install", and tts_status_load has already read the
+    // GPU half's verdict off disk.
+    const res = runPiperOnly({ piper: "broken", arch: "x86_64", seedStatus: "KOKORO=ready\n" });
+    expect(res.status, `a box with a working GPU engine was called mute:\n${res.out}`).toBe(0);
   });
 
   it("announces the fallback when the engine is genuinely installed", () => {
@@ -298,12 +322,16 @@ describe.skipIf(!hasBash)("step_openclaw_tts names only the engines the exit cod
     }
   });
 
-  it("still records nothing for a board neither engine ships for (11)", () => {
-    // Nothing was asked for and nothing is missing: 11 stays a clean provision,
-    // exactly as #519 decided for two `skipped:*` verdicts.
+  it("RECORDS a board neither engine ships for (11)", () => {
+    // REVERSED. 11 was a clean provision on the grounds that nothing was asked
+    // for and nothing is missing — while the very same arm printed "this box
+    // answers speech with SILENCE". A run that describes a mute box and grades
+    // it healthy is not a check anyone can act on. It stays non-fatal (the box
+    // must come up reachable so it can be fixed) and it is recorded now.
+    // See install-tts-mute-box-fails.test.ts.
     const res = runStep(11);
-    expect(res.provisionFailures).toEqual([]);
-    expect(res.stepRc).toBe("0");
+    expect(res.provisionFailures, `a box with no engine was not recorded:\n${res.out}`).toContain("openclaw_tts");
+    expect(res.stepRc).toBe("13");
   });
 });
 
@@ -398,9 +426,11 @@ describe.skipIf(!hasBash)("service validation treats an unreadable verdict as no
     expect(res.status, `a healthy box was failed by the new guard:\n${res.out}`).toBe(0);
   });
 
-  it("still passes a board that runs neither engine by design", () => {
+  it("FAILS a board that runs neither engine by design", () => {
+    // REVERSED. "By design" describes why each engine is absent, not whether
+    // the box can speak — and it cannot. See install-tts-mute-box-fails.test.ts.
     const res = runValidator("KOKORO=skipped:no-cuda\nPIPER=skipped:arch-x86_64\n");
-    expect(res.status, res.out).toBe(0);
+    expect(res.status, `validation passed a box with no TTS engine:\n${res.out}`).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #519, #533 and #544. All three removed a false success in this chain and all three kept the same carve-out, in the same words: when **both** engines report `skipped:*` the run is graded clean. The ruling from the product owner is that the carve-out goes — *"a silent box is not a healthy box."*

**A box that finishes provisioning with no working speech engine now FAILS, naming every engine it tried and the concrete reason each one is not there.**

### The carve-out, and why nothing legitimate was behind it

Three layers each let it through:

| layer | what it did with two `skipped:*` verdicts |
| --- | --- |
| `install-voice.sh` `--tts-only` | printed `=== No on-device TTS engine applies to this board ===` on **stdout** and `exit "$KOKORO_RC"` (10 or 11) |
| `install.sh` `step_openclaw_tts` | `11)` set `TTS_RC=0` and called no `record_provision_failure` |
| `install.sh` `step_validate_services` | the mute-box arm carried `&& { kokoro_failed || piper_failed }`, so two skips matched **no arm** and fell out of the chain as a silent PASS |

The summary line that same step printed for `VOICE_RC=11`, verbatim from `beta`:

```
  On-device TTS configured, but no speech engine applies to this CPU architecture
  (no Jetson CUDA build and no pinned Piper artifact) — this box answers speech with SILENCE
```

on stdout, `TTS_RC=0`, `PROVISION_FAILURES` empty, and then `=== ClawBox Setup Complete ===`. A run that describes a mute box in its own words and grades it healthy is not a check anyone can act on.

**The justification does not hold up.** The comment defending it — repeated in #519, #533 and #544 — is that failing a board neither engine ships for *"would only teach everyone to ignore this check"*, and it names `install-x64.sh` as the run it would fail. That run does not exist:

```
$ grep -c 'voice\|tts\|TTS\|VOICE\|piper\|kokoro' install-x64.sh
0
$ grep -rn 'install-voice.sh' --include='*.sh' . | grep -v '^./scripts/bench'
./install.sh:2602:    bash "$PROJECT_DIR/scripts/install-voice.sh" --tts-only
```

`install-x64.sh` never calls the script that publishes these verdicts, so **no shipped run lands in the carve-out**. What does land in it is `install.sh` run where `uname -m` is not aarch64 — the only way both halves skip, since `install_piper_engine`'s single non-failure skip is the architecture test (`install-voice.sh:199`) and `install_kokoro_tts` returns 11 on that same board (`install-voice.sh:616`). The outcome is a box with no speech, reported as a healthy one.

### The fix

**One question, asked at every call site: is either engine `ready`?**

`skipped:*` still says *why* an engine is absent — it is the sentence the operator needs, and a new `tts_verdict_explain` writes it — but it no longer decides whether the run passed. `skipped:*` means "nothing is missing" only while the *other* half is carrying the box.

`scripts/install-voice.sh`

- **`--tts-only`**: the two-outcome guard collapses to one. No `ready` engine is `exit 13`, on stderr, naming both engines and the concrete reason each is absent. `11` is no longer reachable as an exit status of this mode.
- **`--piper-only`** *(sibling)*: `skipped:?*` printed "No Piper artifact applies to this board" and **exited 0** — in the mode `clawbox-tts.sh:596` tells an operator to run *because* the box will not speak. The mute-box question is now asked first, of **both** halves (`tts_status_load` has already read the Kokoro verdict off disk for exactly this reason), and placed ahead of the `PIPER_ONLY_RC` guard because "no engine at all" outranks "the CPU half specifically did not land".
- **The full pipeline** *(sibling)*: #544 taught its two engine lines to read the verdicts and left the status alone, so a run that printed *"no Kokoro GPU engine applies to this board"* **and** *"no Piper fallback applies to this board"* still exited 0 — the script ends on an `echo`. Same guard, same code.
- `tts_verdict_is_failure` is **removed**: it existed only to separate "both failed" from "both skipped", and that separation is the defect.

`install.sh`

- **`11)`** is a recorded provisioning failure returning `TTS_RC=13`. It is unreachable from the fixed `--tts-only`, and it stays and fails anyway — a code whose meaning is "no engine applies to this board" must never be the one that grades clean if some future path revives it. Leaving the lenient branch behind is exactly how the siblings in #519/#533/#544 stayed unguarded after each fix.
- **`13)`**'s banner now names `KOKORO=` and `PIPER=` from the verdict file. 13 covers the declining board as well as the failing one, and "neither engine is here" is not actionable on its own — a skip and a failed download are different repairs.
- The `11` summary line moves to **stderr**, with the other failures rather than inside the success summary.
- **`step_validate_services`**: the mute-box arm drops the `failed:*` precondition.

#### One thing got *narrower*, deliberately

The mute-box arm asserts SILENCE only when **both** verdicts are present (`-n` on each). One half non-`ready` and the other **unreported** still fails, but under a separate arm that says *"no engine on this box is confirmed ready"* — an unreported half is unknown, not absent, and asserting a mute box from a missing line is the failure-report-over-a-success this chain keeps producing.

That also tightens the arms below it. Past that point exactly one engine is `ready`, so `kokoro_failed` is reached only with a ready Piper and `piper_failed` only with a ready Kokoro — each finally states a fallback it can prove. `KOKORO=failed:model` with no `PIPER=` line used to match the Kokoro arm, whose sentence ends *"— this box answers speech on the Piper CPU fallback"*: a fallback claimed from an **unreported** verdict. A test pins both halves of that.

### Fixing the class, and how I know I found every site

The class is *"a verdict that explains an engine's absence being read as permission to pass."*

```
rg -n 'skipped:'  -g '*.sh' -g '*.ts' -g '*.py'   # -> only install.sh + install-voice.sh decide anything on it
rg -n 'TTS_STATUS_FILE|tts-status'                # -> 3 readers in install.sh, 1 in install-voice.sh; all strip CR
rg -n 'install_piper\b'                           # -> defn + 3 callers: --tts-only, --piper-only, full pipeline
rg -n 'step_openclaw_tts'                         # -> defn + step_openclaw_setup:1643, step_post_update:3589,
                                                  #    and the --step whitelist
```

| site | verdict |
| --- | --- |
| `install-voice.sh` `--tts-only` both-declined arm | **fixed** — exit 13 |
| `install-voice.sh` `--piper-only` `skipped:?*` arm | **fixed** — sibling |
| `install-voice.sh` full-pipeline tail | **fixed** — sibling |
| `install.sh` `step_openclaw_tts` `11)` | **fixed** — recorded, TTS_RC=13 |
| `install.sh` `step_openclaw_tts` `13)` banner | **fixed** — names both verdicts |
| `install.sh` summary `11)` arm | **fixed** — stderr |
| `install.sh` probe mute-box arm | **fixed** — drops the `failed:*` precondition |
| `install.sh` `step_openclaw_setup:1643` tolerance table | **already correct** — 13 is tolerated, warned and recorded; it now simply receives more cases |
| `install.sh` `step_post_update:3589` tolerance table | **already correct** — same table, same reason |
| `install.sh` `--step` dispatch EXIT trap | **already correct** — publishes `incomplete` from `PROVISION_FAILURES`, which this PR now populates for 11 |
| `install.sh` summary `10\|12` "Piper CPU only" | **sound, left alone** — reachable only with a ready Piper (`--tts-only` returns 13 or 1 otherwise); pinned by a test |
| `install-voice.sh:738-740` "(Kokoro GPU, Piper fallback)" | **sound, left alone** — #544's proof still holds: reached only with `PIPER_RC=0`/`DEPLOY_RC=0` past the new guard |
| `src/lib/local-models.ts`, dashboard, API | **no consumer** — nothing outside these two scripts reads the verdict |

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation / tooling
- [ ] Other: ___

Non-breaking in the sense that matters: a box that could not install its speech engines still finishes provisioning and comes up reachable, which is how it gets fixed. What changes is that the run now says so, in the exit status, the provisioning marker and the health check.

## How was this tested?

- [x] `bun run lint` passes — `eslint` clean on all four test files
- [x] `bun run test` passes — see the counts below
- [ ] `bun run build` succeeds — not run; no application code in this diff (two shell scripts and four test files). CI's `build-identity`, `test`, `e2e` and `e2e-install` are green.
- [x] Manually verified on device — Jetson Orin, `aarch64`, `R36 (release), REVISION: 5.0`

### Unit tests — red first

New `src/tests/unit/install-tts-mute-box-fails.test.ts`, 30 tests, executing the shipped artifacts against stubs: the real `--tts-only` and `--piper-only` dispatches, the real engine-report block at the end of the full pipeline, the real `step_openclaw_tts`, the real `step_validate_services`.

- Against unmodified `origin/beta` (`3694ae72`, sources restored, final test files in place): **18 failed / 107 passed** across the four touched suites.
- With the fix: **247 passed / 0 failed** across those four plus `install-tts-survivor-verdict`, `install-tts-provider-registry`, `clawbox-tts`, `install-provision-status-marker`, `install-post-update-units`, `root-steps`, `observability-install`.
- `install-edition-switch-refusal`, `install-foreign-edition-teardown`, `desktop-power-wiring` and that group: **139 passed**, unchanged.
- The new suite run four consecutive times: 30/30 each time.

Roughly half the new suite are **over-correction guards**, and they are the point of half the diff — a box with one engine is not a mute box:

- a no-CUDA Orin that speaks on Piper still exits 10 and provisions clean
- a healthy box still exits 0
- a lost fallback behind a working Kokoro is still 1 -> 14, never 13
- `--piper-only` on a board with no artifact still exits 0 **when a ready Kokoro is on record**
- `KOKORO=ready` + `PIPER=skipped:arch-*` still passes the probe
- an unreadable verdict still outranks the engine-naming arms (#533's guard)
- an unreported half is still reported as unassertable, not as proven silence

#### Assertions deliberately reversed

Four existing tests pinned the behaviour the ruling overturns. Each is reversed in place with the reason inline, rather than deleted:

- `install-tts-no-engine`: *"passes a board that was never going to run either engine"* -> **FAILS**; *"does not cry 'no engine'..."* -> exit 11 -> **13**
- `install-tts-verdict-siblings`: *"still exits 0 there..."* -> **13** (plus a new guard for the seeded-Kokoro case); *"still records nothing for a board neither engine ships for (11)"* -> **RECORDS**
- `install-kokoro-tts`: `it.each([[10],[11]])` "exit %i is a SKIP" -> 10 only, with 11's move explained; the exit-11 step test now asserts the recorded failure and reads the two lines off **stderr**

`bash -n` clean on both scripts. `tsc --noEmit`: **24 errors before and after**, the same pre-existing set #533 and #544 both reported; the one hit inside a file this PR touches is `install-kokoro-tts.test.ts:202`, in the harness's `ProcessEnv` cast, untouched by this diff.

*Environment note:* the Windows dev host cannot run these spawn-heavy suites. All counts above were taken on Linux (WSL Ubuntu 22.04, node 22, `npm ci` from the committed lockfile). Linux CI is the gate.

## Screenshots / logs

### Before / after, on a real Orin

`aarch64`, `R36 (release), REVISION: 5.0`. Both versions of `scripts/install-voice.sh` fetched onto the board from this repo and run there, with `PIPER_DIR` and the verdict file redirected to scratch paths so no box state was mutated. `uname` is shimmed to `x86_64` for A and B — that is the only way to make a real Orin take the both-declined path, and everything else about the run is the shipped script.

**A — `beta` (`a1021dee`), board declines both engines:**

```
=== On-device TTS (Kokoro GPU + Piper fallback) ===
  Skipping Piper: no pinned artifact for x86_64 (ClawBox ships aarch64)
CLAWBOX_TTS_PIPER=skipped:arch-x86_64
  Skipping Kokoro: no Jetson CUDA build for x86_64 (ClawBox ships aarch64)
CLAWBOX_TTS_KOKORO=skipped:arch-x86_64
=== No on-device TTS engine applies to this board (...) ===     <- stdout
### exit status: 11                                             <- install.sh grades this clean
```

**B — this branch, same board, same shim:**

```
CLAWBOX_TTS_PIPER=skipped:arch-x86_64
CLAWBOX_TTS_KOKORO=skipped:arch-x86_64
=== NO WORKING TTS ENGINE - this box will answer every spoken request with SILENCE ===
===   Kokoro (GPU): SKIPPED (arch-x86_64) - this board does not run it
===   Piper (CPU):  SKIPPED (arch-x86_64) - this board does not run it
===   Verdicts recorded in /tmp/tts-b/status
### exit status: 13
```

**C — this branch, REAL aarch64 board, nothing shimmed:** no regression.

```
  Piper binary installed at /tmp/tts-c2/piper/piper
  Piper voice ready: en_US-lessac-medium
CLAWBOX_TTS_PIPER=ready
  CUDA detected: Build cuda_12.6.r12.6/compiler.34714021_0
CLAWBOX_TTS_KOKORO=ready
=== On-device TTS ready (Kokoro GPU, Piper fallback) ===
### exit status: 0
KOKORO=ready
PIPER=ready
```

**E — `--piper-only` on the real board, this branch:** `=== Piper fallback ready ===`, exit 0, `PIPER=ready`. **F — the box still speaks:** the shipped entrypoint returns a 24 kHz Kokoro WAV, exit 0.

The board's `/etc/clawbox/tts-status`, its installed Piper, and its `kokoro-server.service` (md5 identical before and after) were left untouched.

**And the full-install harness agrees:** `e2e-install` — a real systemd container running `install.sh` end to end — is **green on this branch**. It runs arm64 (native runner, or qemu on x86), so `uname -m` is `aarch64` there and Piper is always asked for; the both-declined path is not reachable in it, which is exactly the point made below about blast radius.


### Does voice actually work on our hardware?

This was the more important half of the brief, and the answer is **yes** — the "both engines skip on our own boards" hypothesis does **not** reproduce. Measured on a live Orin (`aarch64`, `R36 (release), REVISION: 5.0`) running the real shipped script from `beta` HEAD, with `PIPER_DIR` and the status file redirected to scratch paths so no box state was mutated:

```
$ bash /home/clawbox/clawbox/scripts/install-voice.sh --tts-only
=== On-device TTS (Kokoro GPU + Piper fallback) ===
  Downloading Piper 2023.11.14-2...
  Piper binary installed at /tmp/ttsprobe/piper/piper
  Piper voice ready: en_US-lessac-medium
CLAWBOX_TTS_PIPER=ready
  CUDA detected: Build cuda_12.6.r12.6/compiler.34714021_0
  Kokoro already installed by a previous run — skipping the GPU install
CLAWBOX_TTS_KOKORO=ready
=== On-device TTS ready (Kokoro GPU, Piper fallback) ===
### exit status: 0

$ cat /tmp/tts-probe-status
KOKORO=ready
PIPER=ready
```

Both engines reach `ready`, and both genuinely speak:

```
$ ~/.openclaw/workspace/scripts/openclaw/clawbox-tts.sh "ClawBox voice check one two three." /tmp/tts-probe.wav
$ file /tmp/tts-probe.wav
/tmp/tts-probe.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 24000 Hz   # Kokoro

$ /tmp/ttsprobe/piper/piper --model .../en_US-lessac-medium.onnx --output_file /tmp/piper-probe.wav
[piper] [info] Real-time factor: 0.126 (infer=0.18 sec, audio=1.44 sec)
$ file /tmp/piper-probe.wav
/tmp/piper-probe.wav: RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 22050 Hz  # Piper
```

`detect_cuda` resolves `nvcc` through its `$CUDA_HOME_DIR/bin/nvcc` fallback (it is **not** on the default PATH on JetPack, and that fallback is what saves it), `import kokoro, torch` succeeds under the unit's `LD_LIBRARY_PATH` with `torch.cuda.is_available() == True`, and the pinned Piper tarball and voice still download and verify against their sha256.

So `skipped:*` for **both** engines is not something aarch64 hardware can reach: on aarch64 Piper is always *asked* for, and its outcome is `ready` or `failed:*` — the latter already exits 13. **This PR's honest blast radius is therefore `install.sh` run on a non-aarch64 host**, plus every future path that reaches "no engine" by a route nobody has thought of yet, which is what the three sibling PRs before this one were each about.

## Checklist

- [x] Branch is up to date with the target branch (rebased on `3694ae72`)
- [x] Follows the conventions in CLAUDE.md and CONTRIBUTING.md
- [x] No secrets, tokens, or credentials committed
- [x] Added/updated tests where it makes sense
- [ ] Updated docs where user-facing behavior changed — no doc change: the user-facing behaviour that changes is a provisioning run failing where it used to pass, and the contract it belongs to is documented in the scripts' own comments, which this diff updates
