### PR TITLE
fix: make the documented coding-harness repair report, and reach the agent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4569,27 +4569,108 @@ install_claude_ds_wrapper() {
 # step_post_update calls THIS and not the bigger step: an in-app update should
 # deliver the harness without also reinstalling the Codex and Gemini CLIs on
 # every box that updates.
+# Tell a RUNNING agent that the coding harness exists now.
+#
+# The agent offers coding_agent_run / _status / _stop only when the ClawBox MCP
+# server says the harness is ready, and it asks exactly ONCE — in
+# `buildContext` while it boots (mcp/lib/context.ts probes
+# /setup-api/coding-agent/status; mcp/tools/coding-agent.ts returns without
+# declaring anything when the answer is no). The server is then a long-lived
+# stdio child of the agent, so a harness installed underneath it is invisible
+# until something respawns the server.
+#
+# The web server already covers the two paths where readiness flips from ITS
+# side — see src/lib/coding-agent-mcp-refresh.ts, hung off the enable route and
+# the ClawBox AI connect path. This step is the third path, and it had nothing:
+# a full install and step_post_update both happen to restart the agent shortly
+# afterwards (step_start_services / step_gateway_setup), and the STANDALONE
+# `--step coding_harness` — the repair checkReadiness() itself tells the owner
+# to run — did not.
+#
+# ONLY units that are ALREADY ACTIVE are touched. An agent that is stopped, or
+# masked by the edition lock, re-probes when it next starts; starting one here
+# would resurrect a unit the owner or the SKU deliberately put down, which is
+# the whole reason the Hermes edition masks clawbox-gateway.
+refresh_agent_coding_tools() {
+  local unit restarted=false found=false
+  for unit in clawbox-gateway.service clawbox-hermes-dashboard.service; do
+    systemctl is-active --quiet "$unit" 2>/dev/null || continue
+    found=true
+    if systemctl restart "$unit" >/dev/null 2>&1; then
+      echo "  Restarted $unit so the agent re-probes and offers the coding tools"
+      restarted=true
+    else
+      echo "  WARN: could not restart $unit — the agent will keep answering that it has no coding tools" >&2
+    fi
+  done
+  if [ "$found" = false ]; then
+    echo "  No agent running; it will probe the harness when it next starts"
+    return 0
+  fi
+  [ "$restarted" = true ]
+}
+
 step_coding_harness() {
+  # Whether the harness was ALREADY usable decides two things below: nothing
+  # needs telling if nothing changed, and a step that changed nothing and fixed
+  # nothing must not report that it did.
+  local was_ready=false
+  if [ -x "$CLAWBOX_HOME/.local/bin/claude-ds" ] && as_clawbox_login "command -v claude" &>/dev/null; then
+    was_ready=true
+  fi
+
   # Test mode has no network for claude.ai and no reason to download a binary,
   # but the wrapper is a file copy — install it so e2e-install exercises the
   # real delivery path instead of skipping the whole step.
   if is_test_mode; then
     echo "  CLAWBOX_TEST_MODE=1, skipping the Claude Code download"
   else
+    # Still swallowed here: a download that failed is not the verdict, the
+    # probe below is. What changed is that the verdict is now the EXIT STATUS
+    # as well as a line of text.
     ensure_claude_code || true
   fi
   install_claude_ds_wrapper || true
   ensure_clawbox_bashrc_path
 
-  # Say plainly whether the harness can actually run. Without this the only
-  # symptom of a failed CLI install is the wrapper telling the owner to run
-  # this very step again — a loop with no diagnosis in it.
   if is_test_mode; then
-    :
-  elif as_clawbox_login "command -v claude" &>/dev/null; then
-    echo "  Coding harness ready: claude-ds -> Claude Code -> ClawBox AI"
-  else
-    echo "  WARN: claude-ds is installed but Claude Code is NOT — the Coding app will refuse until it is"
+    return 0
+  fi
+
+  # Say plainly whether the harness can actually run — and MEAN it in the exit
+  # status. This step is what src/lib/coding-agent.ts tells the owner to run
+  # when the Coding app refuses ("Run: sudo bash install.sh --step
+  # coding_harness"), and it used to exit 0 whatever happened: on a box where
+  # the CLI install failed (no network, or Anthropic geo-blocking the region)
+  # the owner ran the documented repair, was told nothing had gone wrong, and
+  # went back to an app refusing in exactly the same words. A repair that
+  # cannot repair has to SAY so.
+  if ! as_clawbox_login "command -v claude" &>/dev/null; then
+    echo "  WARN: claude-ds is installed but Claude Code is NOT — the Coding app will refuse until it is" >&2
+    echo "  This step did NOT repair the coding harness. Claude Code is downloaded from" >&2
+    echo "  https://claude.ai/install.sh, so check this box's internet access (and whether" >&2
+    echo "  the installer is available in this region), then run the step again." >&2
+    return 1
+  fi
+  if [ ! -x "$CLAWBOX_HOME/.local/bin/claude-ds" ]; then
+    echo "  WARN: Claude Code is installed but the claude-ds wrapper is NOT — the Coding app will refuse until it is" >&2
+    return 1
+  fi
+
+  echo "  Coding harness ready: claude-ds -> Claude Code -> ClawBox AI"
+
+  # Only on the transition. A reload respawns every MCP child and invalidates
+  # the model's prompt cache, and this step runs on every install and every
+  # in-app update — the same rule, and the same reason for it, as the guard in
+  # refreshCodingAgentToolsIfReadinessChanged.
+  if [ "$was_ready" = false ]; then
+    # A refusal here is REPORTED (on stderr, inside the helper) and does not
+    # fail the step: the harness itself IS repaired and the Coding app works,
+    # so a non-zero exit would be the opposite lie. The agent re-probes at its
+    # next start either way.
+    if ! refresh_agent_coding_tools; then
+      echo "  The agent will offer the coding tools after its next restart" >&2
+    fi
   fi
 }
 
@@ -5398,7 +5479,15 @@ log "Installing AI coding tools (Claude Code, Codex, Gemini)..."
 step_ai_tools_install
 
 log "Installing the ClawBox coding harness (claude-ds)..."
-step_coding_harness
+# Guarded, and it has to be. The step now FAILS when the harness did not end up
+# usable — that is the whole point of the change, because this step is the
+# repair src/lib/coding-agent.ts tells the owner to run and it must not report
+# success while the Coding app still refuses. But the harness is OPTIONAL: a box
+# with no Claude Code boots, serves its dashboard and runs its agent. Under the
+# `set -euo pipefail` at the top of this file an unguarded call would turn a
+# region-blocked download into an ABORTED INSTALL, which is the opposite defect.
+step_coding_harness \
+  || echo "  Warning: the coding harness did not install; the Coding app will refuse until it does"
 
 log "Installing VNC server..."
 step_vnc_install

--- a/install.sh
+++ b/install.sh
@@ -4592,22 +4592,26 @@ install_claude_ds_wrapper() {
 # would resurrect a unit the owner or the SKU deliberately put down, which is
 # the whole reason the Hermes edition masks clawbox-gateway.
 refresh_agent_coding_tools() {
-  local unit restarted=false found=false
+  local unit failed=false found=false
   for unit in clawbox-gateway.service clawbox-hermes-dashboard.service; do
     systemctl is-active --quiet "$unit" 2>/dev/null || continue
     found=true
     if systemctl restart "$unit" >/dev/null 2>&1; then
       echo "  Restarted $unit so the agent re-probes and offers the coding tools"
-      restarted=true
     else
       echo "  WARN: could not restart $unit — the agent will keep answering that it has no coding tools" >&2
+      failed=true
     fi
   done
   if [ "$found" = false ]; then
     echo "  No agent running; it will probe the harness when it next starts"
     return 0
   fi
-  [ "$restarted" = true ]
+  # EVERY running agent, not "at least one". On the dual edition both units are
+  # up, and one that could not be restarted is one harness still blind — a
+  # partial refresh reported as a whole one is the shape this whole change is
+  # about.
+  [ "$failed" = false ]
 }
 
 step_coding_harness() {

--- a/install.sh
+++ b/install.sh
@@ -4596,7 +4596,12 @@ refresh_agent_coding_tools() {
   for unit in clawbox-gateway.service clawbox-hermes-dashboard.service; do
     systemctl is-active --quiet "$unit" 2>/dev/null || continue
     found=true
-    if systemctl restart "$unit" >/dev/null 2>&1; then
+    # try-restart, not restart. The probe above and the action below are two
+    # commands, and a unit that stops in between would be STARTED by `restart` —
+    # exactly the thing this function must never do. `try-restart` acts only on a
+    # unit that is running at the moment it runs, and exits 0 when there is
+    # nothing to do, so the invariant does not depend on the gap being small.
+    if systemctl try-restart "$unit" >/dev/null 2>&1; then
       echo "  Restarted $unit so the agent re-probes and offers the coding tools"
     else
       echo "  WARN: could not restart $unit — the agent will keep answering that it has no coding tools" >&2
@@ -4649,15 +4654,24 @@ step_coding_harness() {
   # the owner ran the documented repair, was told nothing had gone wrong, and
   # went back to an app refusing in exactly the same words. A repair that
   # cannot repair has to SAY so.
+  # BOTH halves are reported, then one return. An early return after the first
+  # would hide the second, and this step exists to tell an owner what is wrong —
+  # sending them back for a second run to discover the other half is the same
+  # repair loop in slower motion.
+  local harness_missing=false
   if ! as_clawbox_login "command -v claude" &>/dev/null; then
-    echo "  WARN: claude-ds is installed but Claude Code is NOT — the Coding app will refuse until it is" >&2
-    echo "  This step did NOT repair the coding harness. Claude Code is downloaded from" >&2
-    echo "  https://claude.ai/install.sh, so check this box's internet access (and whether" >&2
-    echo "  the installer is available in this region), then run the step again." >&2
-    return 1
+    echo "  WARN: Claude Code is NOT installed — the Coding app will refuse until it is" >&2
+    echo "  Claude Code is downloaded from https://claude.ai/install.sh, so check this" >&2
+    echo "  box's internet access (and whether the installer is available in this" >&2
+    echo "  region), then run the step again." >&2
+    harness_missing=true
   fi
   if [ ! -x "$CLAWBOX_HOME/.local/bin/claude-ds" ]; then
-    echo "  WARN: Claude Code is installed but the claude-ds wrapper is NOT — the Coding app will refuse until it is" >&2
+    echo "  WARN: the claude-ds wrapper is NOT at $CLAWBOX_HOME/.local/bin/claude-ds — the Coding app will refuse until it is" >&2
+    harness_missing=true
+  fi
+  if [ "$harness_missing" = true ]; then
+    echo "  This step did NOT repair the coding harness." >&2
     return 1
   fi
 

--- a/install.sh
+++ b/install.sh
@@ -4602,7 +4602,12 @@ refresh_agent_coding_tools() {
     # unit that is running at the moment it runs, and exits 0 when there is
     # nothing to do, so the invariant does not depend on the gap being small.
     if systemctl try-restart "$unit" >/dev/null 2>&1; then
-      echo "  Restarted $unit so the agent re-probes and offers the coding tools"
+      # "Asked", not "Restarted". try-restart exits 0 both when it restarted the
+      # unit and when the unit had stopped in the meantime and it did nothing —
+      # so claiming a restart here would be this PR's own bug in miniature. What
+      # is true in both cases is that the request was made and the agent will
+      # re-probe, now or at its next start.
+      echo "  Asked $unit to restart so the agent re-probes and offers the coding tools"
     else
       echo "  WARN: could not restart $unit — the agent will keep answering that it has no coding tools" >&2
       failed=true

--- a/src/tests/unit/install-coding-harness-repair.test.ts
+++ b/src/tests/unit/install-coding-harness-repair.test.ts
@@ -295,6 +295,11 @@ describe("the agent is told the harness exists now", () => {
     expect(run.status).toBe(0);
     expect(starts(run)).toEqual([]);
     expect(refreshes(run)).toContain("systemctl try-restart clawbox-gateway.service");
+    // And it claims only what it knows. `try-restart` exits 0 both when it
+    // restarted the unit and when it found nothing to do, so "Restarted ..."
+    // would be this PR's own bug in miniature.
+    expect(run.stdout).toMatch(/Asked clawbox-gateway\.service to restart/);
+    expect(run.stdout).not.toMatch(/Restarted clawbox-gateway\.service/);
   }, SHELL_TIMEOUT_MS);
 
   it("counts a PARTIAL refresh as a refusal on a dual box", () => {

--- a/src/tests/unit/install-coding-harness-repair.test.ts
+++ b/src/tests/unit/install-coding-harness-repair.test.ts
@@ -71,8 +71,13 @@ let systemctlLog: string;
 interface Scenario {
   /** Units `systemctl is-active --quiet` answers yes for. */
   activeUnits?: string[];
-  /** Units whose `systemctl restart` fails. */
+  /** Units whose refresh fails. */
   failingRestarts?: string[];
+  /**
+   * Units that are active at the `is-active` probe and STOPPED by the time the
+   * refresh runs. `restart` would start them again; `try-restart` must not.
+   */
+  stopsBetween?: string[];
   /** Is Claude Code on the clawbox login PATH before the step runs? */
   claudeInstalled?: boolean;
   /** Does the CLI install performed by the step succeed? */
@@ -96,6 +101,7 @@ function runStep(scenario: Scenario = {}): StepRun {
   const {
     activeUnits = [],
     failingRestarts = [],
+    stopsBetween = [],
     claudeInstalled = false,
     claudeInstallSucceeds = true,
     wrapperInstalled = false,
@@ -141,6 +147,7 @@ function runStep(scenario: Scenario = {}): StepRun {
     "",
     'ACTIVE_UNITS="' + activeUnits.join(" ") + '"',
     'FAILING_RESTARTS="' + failingRestarts.join(" ") + '"',
+    'STOPS_BETWEEN="' + stopsBetween.join(" ") + '"',
     "",
     "systemctl() {",
     '  printf "%s\\n" "systemctl $*" >> "$SYSTEMCTL_LOG"',
@@ -150,6 +157,16 @@ function runStep(scenario: Scenario = {}): StepRun {
     "      return 3",
     "      ;;",
     "    restart)",
+    "      # A real `restart` STARTS an inactive unit. The fake says so, which is",
+    "      # what lets the invariant be tested rather than assumed.",
+    '      for u in $STOPS_BETWEEN; do [ "$u" = "$2" ] && { printf "%s\\n" "STARTED-A-STOPPED-UNIT $2" >> "$SYSTEMCTL_LOG"; return 0; }; done',
+    '      for u in $FAILING_RESTARTS; do [ "$u" = "$2" ] && return 1; done',
+    "      return 0",
+    "      ;;",
+    "    try-restart)",
+    "      # ...and a real `try-restart` does nothing, successfully, for a unit",
+    "      # that is no longer running.",
+    '      for u in $STOPS_BETWEEN; do [ "$u" = "$2" ] && return 0; done',
     '      for u in $FAILING_RESTARTS; do [ "$u" = "$2" ] && return 1; done',
     "      return 0",
     "      ;;",
@@ -179,7 +196,18 @@ function runStep(scenario: Scenario = {}): StepRun {
   };
 }
 
-const restarts = (run: StepRun) => run.systemctl.filter((l) => l.startsWith("systemctl restart"));
+/**
+ * Every refresh the step asked systemd for.
+ *
+ * `try-restart`, not `restart`: the probe and the action are two commands, and
+ * `restart` would START a unit that stopped in between — the one thing this
+ * function must never do.
+ */
+const refreshes = (run: StepRun) => run.systemctl.filter((l) => l.startsWith("systemctl try-restart"));
+
+/** A unit systemd was told to bring UP. Must always be empty. */
+const starts = (run: StepRun) =>
+  run.systemctl.filter((l) => l.startsWith("systemctl restart") || l.startsWith("STARTED-A-STOPPED-UNIT"));
 
 beforeEach(() => {
   sandbox = mkdtempSync(path.join(tmpdir(), "clawbox-harness-repair-"));
@@ -222,12 +250,12 @@ describe("the agent is told the harness exists now", () => {
     // — until something unrelated respawns its MCP server.
     const run = runStep({ activeUnits: ["clawbox-gateway.service"] });
     expect(run.status).toBe(0);
-    expect(run.systemctl).toContain("systemctl restart clawbox-gateway.service");
+    expect(run.systemctl).toContain("systemctl try-restart clawbox-gateway.service");
   }, SHELL_TIMEOUT_MS);
 
   it("restarts the Hermes dashboard when that is the agent that is running", () => {
     const run = runStep({ activeUnits: ["clawbox-hermes-dashboard.service"] });
-    expect(run.systemctl).toContain("systemctl restart clawbox-hermes-dashboard.service");
+    expect(run.systemctl).toContain("systemctl try-restart clawbox-hermes-dashboard.service");
   }, SHELL_TIMEOUT_MS);
 
   it("does NOT restart anything when the harness was already there", () => {
@@ -241,7 +269,7 @@ describe("the agent is told the harness exists now", () => {
       activeUnits: ["clawbox-gateway.service"],
     });
     expect(run.status).toBe(0);
-    expect(restarts(run)).toEqual([]);
+    expect(refreshes(run)).toEqual([]);
   }, SHELL_TIMEOUT_MS);
 
   it("does NOT start an agent that is stopped or masked", () => {
@@ -250,8 +278,23 @@ describe("the agent is told the harness exists now", () => {
     // re-probes when it next starts anyway.
     const run = runStep({ activeUnits: [] });
     expect(run.status).toBe(0);
-    expect(restarts(run)).toEqual([]);
+    expect(refreshes(run)).toEqual([]);
     expect(run.stdout).toMatch(/No agent running/);
+  }, SHELL_TIMEOUT_MS);
+
+  it("never STARTS a unit that stopped between the probe and the refresh", () => {
+    // The probe and the action are two commands. `systemctl restart` on a unit
+    // that went down in the gap would bring it back up — resurrecting exactly
+    // the agent the owner, or the Hermes edition lock, put down. `try-restart`
+    // acts only on a unit that is still running and exits 0 when there is
+    // nothing to do, so the invariant does not depend on the gap being small.
+    const run = runStep({
+      activeUnits: ["clawbox-gateway.service"],
+      stopsBetween: ["clawbox-gateway.service"],
+    });
+    expect(run.status).toBe(0);
+    expect(starts(run)).toEqual([]);
+    expect(refreshes(run)).toContain("systemctl try-restart clawbox-gateway.service");
   }, SHELL_TIMEOUT_MS);
 
   it("counts a PARTIAL refresh as a refusal on a dual box", () => {
@@ -263,7 +306,7 @@ describe("the agent is told the harness exists now", () => {
       failingRestarts: ["clawbox-hermes-dashboard.service"],
     });
     expect(run.status).toBe(0);
-    expect(restarts(run)).toHaveLength(2);
+    expect(refreshes(run)).toHaveLength(2);
     expect(run.stderr).toMatch(/could not restart clawbox-hermes-dashboard\.service/);
     expect(run.stderr).toMatch(/after its next restart/);
   }, SHELL_TIMEOUT_MS);

--- a/src/tests/unit/install-coding-harness-repair.test.ts
+++ b/src/tests/unit/install-coding-harness-repair.test.ts
@@ -254,6 +254,20 @@ describe("the agent is told the harness exists now", () => {
     expect(run.stdout).toMatch(/No agent running/);
   }, SHELL_TIMEOUT_MS);
 
+  it("counts a PARTIAL refresh as a refusal on a dual box", () => {
+    // Both harnesses run on the dual edition. One agent refreshed and one not
+    // is one harness still blind, and reporting that as a clean refresh is the
+    // exact shape this change exists to remove.
+    const run = runStep({
+      activeUnits: ["clawbox-gateway.service", "clawbox-hermes-dashboard.service"],
+      failingRestarts: ["clawbox-hermes-dashboard.service"],
+    });
+    expect(run.status).toBe(0);
+    expect(restarts(run)).toHaveLength(2);
+    expect(run.stderr).toMatch(/could not restart clawbox-hermes-dashboard\.service/);
+    expect(run.stderr).toMatch(/after its next restart/);
+  }, SHELL_TIMEOUT_MS);
+
   it("says so when the restart was refused, without failing the repair", () => {
     // The harness IS repaired and the Coding app works; calling that a failed
     // repair would be the opposite lie. It must not be silent either.

--- a/src/tests/unit/install-coding-harness-repair.test.ts
+++ b/src/tests/unit/install-coding-harness-repair.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * `install.sh --step coding_harness` is not just another step. It is the exact
+ * command `checkReadiness()` puts in front of the owner when the Coding app
+ * refuses ("Run: sudo bash install.sh --step coding_harness"), and the same
+ * command scripts/claude-ds prints when it cannot find Claude Code. It is THE
+ * documented repair, and two things were wrong with it.
+ *
+ *  1. It exited 0 whatever happened. `ensure_claude_code || true` plus a WARN
+ *     that only went to stdout meant a box with no network — or one in a region
+ *     Anthropic's installer refuses — ran the repair, was told nothing had gone
+ *     wrong, and went back to an app refusing in exactly the same words. A
+ *     repair that cannot repair has to say so in its exit status.
+ *
+ *  2. It left the AGENT unable to see the harness it had just installed. The
+ *     coding_agent_* tools are registered only if the ClawBox MCP server's
+ *     one-time startup probe of /setup-api/coding-agent/status says the harness
+ *     is ready (mcp/lib/context.ts + mcp/tools/coding-agent.ts), and that
+ *     server is a long-lived stdio child of the agent. The web server covers
+ *     the two paths that flip readiness from its side
+ *     (src/lib/coding-agent-mcp-refresh.ts, on the enable route and the ClawBox
+ *     AI connect path); a full install and step_post_update both happen to
+ *     restart the agent shortly afterwards. The standalone repair — the one the
+ *     owner is actually told to run — did neither.
+ *
+ * These run the SHIPPED function bodies out of install.sh against stubs, so an
+ * edit to install.sh is what the assertions see.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+/** One shell function, verbatim, closing brace included; "" when there is none. */
+function findShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(name + "() {");
+  if (start < 0) return "";
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(name + " has no closing brace");
+  return INSTALL_SH.slice(start, end + 2);
+}
+
+function shellFunction(name: string): string {
+  const body = findShellFunction(name);
+  if (!body) throw new Error(name + " not found in install.sh");
+  return body;
+}
+
+/**
+ * The agent-refresh helper, or nothing.
+ *
+ * Deliberately tolerant, and only for this one: on the code these tests were
+ * written against there IS no such function, and its absence is the bug. A hard
+ * failure here would make every case below fail with "not found in install.sh",
+ * which proves nothing about what the old step DID — finish quietly, exit 0,
+ * and leave the agent blind. Missing means the script simply never calls it,
+ * which is exactly what it used to do.
+ */
+function agentRefreshHelper(): string {
+  return findShellFunction("refresh_agent_coding_tools");
+}
+
+let sandbox: string;
+let home: string;
+let systemctlLog: string;
+
+interface Scenario {
+  /** Units `systemctl is-active --quiet` answers yes for. */
+  activeUnits?: string[];
+  /** Units whose `systemctl restart` fails. */
+  failingRestarts?: string[];
+  /** Is Claude Code on the clawbox login PATH before the step runs? */
+  claudeInstalled?: boolean;
+  /** Does the CLI install performed by the step succeed? */
+  claudeInstallSucceeds?: boolean;
+  /** Is the claude-ds wrapper already there before the step runs? */
+  wrapperInstalled?: boolean;
+  /** Does the wrapper copy performed by the step succeed? */
+  wrapperInstallSucceeds?: boolean;
+}
+
+interface StepRun {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  systemctl: string[];
+}
+
+const SHELL_TIMEOUT_MS = 30_000;
+
+function runStep(scenario: Scenario = {}): StepRun {
+  const {
+    activeUnits = [],
+    failingRestarts = [],
+    claudeInstalled = false,
+    claudeInstallSucceeds = true,
+    wrapperInstalled = false,
+    wrapperInstallSucceeds = true,
+  } = scenario;
+
+  const makeWrapper = 'printf "#!/bin/sh\\n" > "$WRAPPER"; chmod +x "$WRAPPER"';
+
+  const lines = [
+    "set -euo pipefail",
+    "",
+    "CLAWBOX_HOME=" + JSON.stringify(home),
+    "CLAWBOX_USER=clawbox",
+    'WRAPPER="$CLAWBOX_HOME/.local/bin/claude-ds"',
+    'CLAUDE_MARKER="$CLAWBOX_HOME/.claude-installed"',
+    'SYSTEMCTL_LOG=' + JSON.stringify(systemctlLog),
+    "",
+    'mkdir -p "$CLAWBOX_HOME/.local/bin"',
+    claudeInstalled ? 'touch "$CLAUDE_MARKER"' : 'rm -f "$CLAUDE_MARKER"',
+    wrapperInstalled ? makeWrapper : 'rm -f "$WRAPPER"',
+    "",
+    "is_test_mode() { return 1; }",
+    "ensure_clawbox_bashrc_path() { :; }",
+    "",
+    "# Stands in for the real download. Its success is deliberately NOT the",
+    "# verdict: the step probes the box afterwards, which is the only thing that",
+    '# can tell a working harness from an installer that printed "installed" and',
+    "# did nothing.",
+    "ensure_claude_code() {",
+    claudeInstallSucceeds
+      ? '  touch "$CLAUDE_MARKER"; return 0'
+      : '  echo "  WARN: installer unavailable"; return 1',
+    "}",
+    "",
+    "install_claude_ds_wrapper() {",
+    wrapperInstallSucceeds
+      ? "  " + makeWrapper + "; return 0"
+      : '  echo "  WARN: source missing"; return 1',
+    "}",
+    "",
+    "# The login-shell probe: answers from the marker the fake installer writes.",
+    'as_clawbox_login() { [ -f "$CLAUDE_MARKER" ]; }',
+    "",
+    'ACTIVE_UNITS="' + activeUnits.join(" ") + '"',
+    'FAILING_RESTARTS="' + failingRestarts.join(" ") + '"',
+    "",
+    "systemctl() {",
+    '  printf "%s\\n" "systemctl $*" >> "$SYSTEMCTL_LOG"',
+    '  case "$1" in',
+    "    is-active)",
+    '      for u in $ACTIVE_UNITS; do [ "$u" = "$3" ] && return 0; done',
+    "      return 3",
+    "      ;;",
+    "    restart)",
+    '      for u in $FAILING_RESTARTS; do [ "$u" = "$2" ] && return 1; done',
+    "      return 0",
+    "      ;;",
+    "  esac",
+    "  return 0",
+    "}",
+    "",
+    agentRefreshHelper(),
+    "",
+    shellFunction("step_coding_harness"),
+    "",
+    "step_coding_harness",
+    "",
+  ];
+
+  const scriptPath = path.join(sandbox, "run.sh");
+  writeFileSync(scriptPath, lines.join("\n"), "utf-8");
+  const result = spawnSync("bash", [scriptPath], { encoding: "utf-8", cwd: REPO });
+  const log = existsSync(systemctlLog)
+    ? readFileSync(systemctlLog, "utf-8").split("\n").filter(Boolean)
+    : [];
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    systemctl: log,
+  };
+}
+
+const restarts = (run: StepRun) => run.systemctl.filter((l) => l.startsWith("systemctl restart"));
+
+beforeEach(() => {
+  sandbox = mkdtempSync(path.join(tmpdir(), "clawbox-harness-repair-"));
+  home = path.join(sandbox, "home");
+  mkdirSync(home, { recursive: true });
+  systemctlLog = path.join(sandbox, "systemctl.log");
+});
+
+afterEach(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe("the documented repair reports whether it repaired anything", () => {
+  it("FAILS when Claude Code is still missing afterwards", () => {
+    const run = runStep({ claudeInstallSucceeds: false });
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toMatch(/did NOT repair the coding harness/);
+    // And it names something the owner can act on, rather than repeating the
+    // instruction that just failed.
+    expect(run.stderr).toMatch(/internet access|region/i);
+  }, SHELL_TIMEOUT_MS);
+
+  it("FAILS when the wrapper is missing afterwards, even with the CLI present", () => {
+    const run = runStep({ wrapperInstallSucceeds: false });
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toMatch(/wrapper is NOT/);
+  }, SHELL_TIMEOUT_MS);
+
+  it("succeeds when the harness is genuinely usable afterwards", () => {
+    const run = runStep({ activeUnits: ["clawbox-gateway.service"] });
+    expect(run.status).toBe(0);
+    expect(run.stdout).toMatch(/Coding harness ready/);
+  }, SHELL_TIMEOUT_MS);
+});
+
+describe("the agent is told the harness exists now", () => {
+  it("restarts the running agent when the harness has just become available", () => {
+    // Without this the owner runs the documented repair, the Coding app starts
+    // working, and the agent goes on answering that it has no way to run code
+    // — until something unrelated respawns its MCP server.
+    const run = runStep({ activeUnits: ["clawbox-gateway.service"] });
+    expect(run.status).toBe(0);
+    expect(run.systemctl).toContain("systemctl restart clawbox-gateway.service");
+  }, SHELL_TIMEOUT_MS);
+
+  it("restarts the Hermes dashboard when that is the agent that is running", () => {
+    const run = runStep({ activeUnits: ["clawbox-hermes-dashboard.service"] });
+    expect(run.systemctl).toContain("systemctl restart clawbox-hermes-dashboard.service");
+  }, SHELL_TIMEOUT_MS);
+
+  it("does NOT restart anything when the harness was already there", () => {
+    // Every install and every in-app update runs this step. A reload respawns
+    // every MCP child and invalidates the model's prompt cache, so it is only
+    // worth paying for on the transition — the same rule the web-server-side
+    // refresh applies.
+    const run = runStep({
+      claudeInstalled: true,
+      wrapperInstalled: true,
+      activeUnits: ["clawbox-gateway.service"],
+    });
+    expect(run.status).toBe(0);
+    expect(restarts(run)).toEqual([]);
+  }, SHELL_TIMEOUT_MS);
+
+  it("does NOT start an agent that is stopped or masked", () => {
+    // The Hermes SKU masks clawbox-gateway. Starting it here would resurrect
+    // the unit the edition lock exists to keep down, and a stopped agent
+    // re-probes when it next starts anyway.
+    const run = runStep({ activeUnits: [] });
+    expect(run.status).toBe(0);
+    expect(restarts(run)).toEqual([]);
+    expect(run.stdout).toMatch(/No agent running/);
+  }, SHELL_TIMEOUT_MS);
+
+  it("says so when the restart was refused, without failing the repair", () => {
+    // The harness IS repaired and the Coding app works; calling that a failed
+    // repair would be the opposite lie. It must not be silent either.
+    const run = runStep({
+      activeUnits: ["clawbox-gateway.service"],
+      failingRestarts: ["clawbox-gateway.service"],
+    });
+    expect(run.status).toBe(0);
+    expect(run.stderr).toMatch(/could not restart clawbox-gateway\.service/);
+    expect(run.stderr).toMatch(/after its next restart/);
+  }, SHELL_TIMEOUT_MS);
+});
+
+describe("a step that can now fail must not abort the install", () => {
+  // The sibling-call-site rule, as a test. Making step_coding_harness report a
+  // real verdict is only safe if EVERY caller expects one: install.sh runs
+  // under `set -euo pipefail`, and the harness is optional — a box with no
+  // Claude Code boots, serves its dashboard and runs its agent. An unguarded
+  // call would turn a region-blocked download into an aborted install, which is
+  // the same defect pointed the other way.
+  //
+  // Backslash line-continuations are folded first, so a guard on the next line
+  // still counts as a guard.
+  const FLAT = INSTALL_SH.replace(/\\r?\n\s*/g, " ");
+
+  const callSites = FLAT.split("\n")
+    .map((text, i) => ({ line: i + 1, text }))
+    .filter(
+      ({ text }) =>
+        /(^|\s)step_coding_harness(\s|$)/.test(text)
+        && !text.trim().startsWith("#")
+        && !text.includes("() {"),
+    );
+
+  it("finds every call site (the check is not vacuously passing)", () => {
+    // The full install and step_post_update. If a third appears, it is held to
+    // the same rule by the case below.
+    expect(callSites.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it.each(callSites.map((c) => [c.line, c.text] as const))(
+    "install.sh:%s guards the call",
+    (_line, text) => {
+      expect(text).toMatch(/\|\|\s*echo/);
+    },
+  );
+});

--- a/src/tests/unit/install-coding-harness.test.ts
+++ b/src/tests/unit/install-coding-harness.test.ts
@@ -173,8 +173,15 @@ describe("the step says whether the harness can actually run", () => {
     // each other forever with no diagnosis anywhere.
     const fn = extractShellFunction("step_coding_harness");
     expect(fn).toContain("command -v claude");
-    expect(fn).toMatch(/WARN: claude-ds is installed but Claude Code is NOT/);
     expect(fn).toMatch(/Coding harness ready/);
+    // Each half names only its own component. The message used to open
+    // "claude-ds is installed but Claude Code is NOT", which is a claim about
+    // the OTHER half — and a lie on the box where both are missing, which is
+    // also the box most likely to be reading it. See
+    // install-coding-harness-repair.test.ts for the behaviour.
+    expect(fn).toMatch(/WARN: Claude Code is NOT installed/);
+    expect(fn).toMatch(/WARN: the claude-ds wrapper is NOT/);
+    expect(fn).not.toMatch(/claude-ds is installed but Claude Code is NOT/);
   });
 });
 


### PR DESCRIPTION
## The defect

`install.sh --step coding_harness` is the exact command `checkReadiness()` puts in front of the owner when the Coding app refuses:

> Claude Code is not installed on this ClawBox. **Run: `sudo bash install.sh --step coding_harness`**

`scripts/claude-ds` prints the same instruction. It is *the* documented repair, and two things were wrong with it.

### 1. It exited 0 whatever happened

`ensure_claude_code || true`, `install_claude_ds_wrapper || true`, and a WARN that only reached stdout. A box with no network — or one in a region Anthropic's installer refuses, which `ensure_claude_code` explicitly handles — ran the repair, was told nothing had gone wrong, and went back to an app refusing in exactly the same words. A loop with a success report in the middle of it.

The step now probes the box **afterwards** — the CLI on the clawbox login PATH *and* the wrapper where the app looks for it, the same two facts `checkReadiness` reports — and makes that probe the exit status, with a message naming what the owner can actually check.

### 2. It left the agent unable to see the harness it had just installed

`coding_agent_run` / `_status` / `_stop` are registered only if the ClawBox MCP server's **one-time startup probe** of `/setup-api/coding-agent/status` says the harness is ready (`mcp/lib/context.ts` → `probeCodingAgent`, `mcp/tools/coding-agent.ts` → `if (!ctx.codingAgent) return`). That server is then a long-lived stdio child of the agent, so a harness installed underneath it is invisible.

`src/lib/coding-agent-mcp-refresh.ts` already covers the two paths that flip readiness from the web server's side (the enable route and the ClawBox AI connect path). A full install and `step_post_update` both happen to restart the agent shortly afterwards (`step_start_services` / `step_gateway_setup`). The **standalone repair — the one the owner is told to run — did neither.** The Coding app started working and the agent went on answering that it had no way to run code.

The step now restarts the agent, on the same *only-when-the-verdict-flipped* guard the TypeScript side uses, and **only for units that are already active** — starting one would resurrect the gateway the Hermes edition masks on purpose.

## The real cause differs from the report

The report said the step "never restarts the service". Worth recording that **restarting `clawbox-setup` would have fixed nothing**: `checkReadiness()` stats the filesystem on every call and the status route is `force-dynamic`, so the panel was live all along. What was stale was the **agent's MCP tool list**, which is a different process and a different fix.

## Sibling call sites

* **`step_post_update`** (install.sh:3577) — already `|| echo`, unchanged.
* **The full install** (install.sh:5428) — was **unguarded**. A step that can now fail, called unguarded under `set -euo pipefail`, turns a region-blocked download into an **aborted install** — the same defect pointed the other way, and the harness is optional (a box with no Claude Code boots, serves its dashboard and runs its agent). Now guarded, and a test holds *every* present and future call site to that rule.
* **`DISPATCH_STEPS`, `config/clawbox-root-step.sh`, `src/lib/root-steps.ts`** — unchanged; `coding_harness` was already dispatchable and is deliberately still not a UI button (that would widen the root-exec surface and needs its own review).
* **`refreshCodingAgentToolsIfReadinessChanged`** — its two TypeScript callers were already correct; this adds the third path rather than changing them.

### Known adjacent defect, deliberately not fixed here

`buildContext` caches **more** than coding-agent readiness at MCP-server startup: `hasBinary()` results for the screen grabbers and `imageConvert`, plus `journal` and `du`. So `step_ffmpeg_install`, `step_chromium_install` and `step_vnc_install` have the same staleness — and `ffmpeg_install` *is* a UI button. Those are not correct as-is; the general fix is to stop treating the capability probe as a boot-time fact in `mcp/`, which is a separate change with a much wider blast radius. Flagging rather than smuggling it in.

## RED → GREEN

Tests extract the **shipped** function bodies out of `install.sh` and run them against a fake systemd, so an edit to `install.sh` is what the assertions see.

Against unmodified `beta` (6 of 8 fail, and for the right reasons — the two that pass describe behaviour that was already fine):

```
× FAILS when Claude Code is still missing afterwards
    AssertionError: expected +0 not to be +0
× FAILS when the wrapper is missing afterwards, even with the CLI present
    AssertionError: expected +0 not to be +0
× restarts the running agent when the harness has just become available
    AssertionError: expected [] to include 'systemctl restart clawbox-gateway.service'
× restarts the Hermes dashboard when that is the agent that is running
    AssertionError: expected [] to include 'systemctl restart clawbox-hermes-dashboard.service'
× does NOT start an agent that is stopped or masked
    AssertionError: expected '  Coding harness ready: ...' to match /No agent running/
× says so when the restart was refused, without failing the repair
    AssertionError: expected '' to match /could not restart clawbox-gateway\.service/
```

With the fix — 11 new + the 19 existing `install-coding-harness.test.ts` cases:

```
Test Files  2 passed (2)
     Tests  27 passed (27)
```

`bash scripts/check-sudoers-coverage.sh` — OK, 48 grants, 0 gaps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coding-tool readiness detection during installation.
  * Installations now provide separate warnings when Claude Code or its supporting wrapper is unavailable.
  * Remaining setup can continue when coding tools are unavailable.
  * Active agents refresh their coding tools when setup becomes ready.
  * Inactive or masked agents are left untouched.
  * Refresh failures no longer interrupt the overall installation process and now include clearer diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->