### PR TITLE
fix: report what an operation actually achieved, in three places that did not

### DIFF
--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -66,12 +66,27 @@ restart_openclaw_gateway() {
 # non-zero for `degraded` — an ordinary state on these devices, and one where
 # systemd is very much running. Only "no answer at all" and an explicit
 # `offline` mean there is no manager.
-systemd_manager_available() {
-  command -v systemctl >/dev/null 2>&1 || return 1
-  case "$(systemctl is-system-running 2>/dev/null)" in
+systemd_scope_running() {
+  local answer
+  case "$1" in
+    user) answer="$(systemctl --user is-system-running 2>/dev/null)" ;;
+    *)    answer="$(systemctl is-system-running 2>/dev/null)" ;;
+  esac
+  case "$answer" in
     ""|offline|unknown) return 1 ;;
     *) return 0 ;;
   esac
+}
+
+# BOTH scopes, because restart_openclaw_gateway tries both. A host with an
+# offline system manager and a reachable USER manager that refused the unit has
+# had its refresh refused, not skipped — and reporting that as "nothing to do
+# here" is the same silence this file exists to remove, one level up.
+systemd_manager_available() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  systemd_scope_running system && return 0
+  systemd_scope_running user && return 0
+  return 1
 }
 
 should_refresh_openclaw() {

--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -54,6 +54,26 @@ restart_openclaw_gateway() {
   return 1
 }
 
+# Is there a systemd MANAGER to talk to — not merely a systemctl binary?
+#
+# `command -v systemctl` is not that question. Plenty of containers ship
+# /usr/bin/systemctl with no manager behind it, and on one of those every
+# restart attempt fails for a reason that is not the device's: the harness
+# switch would 502 on a box where there is no gateway to refresh in the first
+# place. That is the false-FAILURE twin of the bug this file is fixing.
+#
+# `is-system-running` answers by TEXT, not by exit status, because the status is
+# non-zero for `degraded` — an ordinary state on these devices, and one where
+# systemd is very much running. Only "no answer at all" and an explicit
+# `offline` mean there is no manager.
+systemd_manager_available() {
+  command -v systemctl >/dev/null 2>&1 || return 1
+  case "$(systemctl is-system-running 2>/dev/null)" in
+    ""|offline|unknown) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 should_refresh_openclaw() {
   if [ "$TARGET_HARNESS" = "openclaw" ]; then
     return 0
@@ -83,10 +103,11 @@ if [ -d "$OC_WS" ]; then
   if should_refresh_openclaw; then
     if restart_openclaw_gateway; then
       echo "[identity-sync] clawbox-gateway restarted; OpenClaw has re-read the identity files"
-    elif ! command -v systemctl >/dev/null 2>&1; then
-      # No init to ask - a dev checkout or a container. There is no running
-      # gateway holding a stale copy either, so nothing was left undone.
-      echo "[identity-sync] no systemctl on this host; skipping the gateway refresh"
+    elif ! systemd_manager_available; then
+      # No init to ask - a dev checkout, or a container with the binary but no
+      # manager. There is no running gateway holding a stale copy either, so
+      # nothing was left undone.
+      echo "[identity-sync] no systemd manager on this host; skipping the gateway refresh"
     else
       echo "[identity-sync] could not restart clawbox-gateway: OpenClaw would keep" >&2
       echo "  answering as whoever it was before this sync. Refusing to report success." >&2

--- a/scripts/clawbox-identity-sync.sh
+++ b/scripts/clawbox-identity-sync.sh
@@ -36,6 +36,24 @@ resolve_active_harness() {
   node -e 'try{const c=require(process.argv[1]);process.stdout.write(String(c.active_harness||"openclaw"))}catch(e){process.stdout.write("openclaw")}' "$CONFIG_JSON" 2>/dev/null || echo openclaw
 }
 
+# The gateway restart, and whether it actually happened.
+#
+# This restart is not a nicety attached to the sync - for OpenClaw it IS the
+# sync. The copies below land on disk in a directory the gateway already scanned
+# and cached at start, so until it restarts, OpenClaw keeps answering as whoever
+# it was before. The old form ended `|| true`, which turned "the identity did not
+# change" into "[identity-sync] done" and exit 0 - and left the caller's own
+# guard unreachable: /setup-api/harness/select refuses to switch harnesses when
+# this script fails, and this script could not fail.
+#
+# System unit first, user unit as the fallback for a dev box; a non-zero return
+# means NEITHER worked.
+restart_openclaw_gateway() {
+  sudo -n /usr/bin/systemctl restart clawbox-gateway.service 2>/dev/null && return 0
+  systemctl --user restart clawbox-gateway 2>/dev/null && return 0
+  return 1
+}
+
 should_refresh_openclaw() {
   if [ "$TARGET_HARNESS" = "openclaw" ]; then
     return 0
@@ -63,9 +81,17 @@ if [ -d "$OC_WS" ]; then
     [ -f "$CANON/$f.md" ] && cp "$CANON/$f.md" "$OC_WS/$f.md"
   done
   if should_refresh_openclaw; then
-    # Refresh the gateway's cached workspace-file scan (best-effort).
-    sudo -n /usr/bin/systemctl restart clawbox-gateway.service 2>/dev/null || \
-      systemctl --user restart clawbox-gateway 2>/dev/null || true
+    if restart_openclaw_gateway; then
+      echo "[identity-sync] clawbox-gateway restarted; OpenClaw has re-read the identity files"
+    elif ! command -v systemctl >/dev/null 2>&1; then
+      # No init to ask - a dev checkout or a container. There is no running
+      # gateway holding a stale copy either, so nothing was left undone.
+      echo "[identity-sync] no systemctl on this host; skipping the gateway refresh"
+    else
+      echo "[identity-sync] could not restart clawbox-gateway: OpenClaw would keep" >&2
+      echo "  answering as whoever it was before this sync. Refusing to report success." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/src/app/setup-api/portal/heartbeat-tick/route.ts
+++ b/src/app/setup-api/portal/heartbeat-tick/route.ts
@@ -61,10 +61,16 @@ export async function GET(request: Request) {
     let restarted = false;
     if (mayRestart()) {
       try {
-        await startTunnelService();
+        // The `enable` verdict is read, not discarded. It is NOT surfaced in the
+        // body: this path restarts a unit that was already running, so it was
+        // already enabled, and the timer has no owner watching it. What a failure
+        // here means is that the box's own repair could not re-arm boot start —
+        // worth a line in the journal an operator can find, and nothing more.
+        const { bootPersisted, bootPersistWarning } = await startTunnelService();
         markRestarted();
         restarted = true;
         console.warn(`[heartbeat-tick] tunnel hostname dead, restarted clawbox-tunnel (was ${tunnelUrl})`);
+        if (!bootPersisted) console.warn(`[heartbeat-tick] ${bootPersistWarning}`);
       } catch (err) {
         console.warn("[heartbeat-tick] tunnel restart failed:", err instanceof Error ? err.message : err);
       }

--- a/src/app/setup-api/portal/start/route.ts
+++ b/src/app/setup-api/portal/start/route.ts
@@ -11,8 +11,15 @@ export async function POST() {
         { status: 400 }
       );
     }
-    await startTunnelService();
-    return NextResponse.json({ success: true });
+    // `success` is about the unit being up, which it is — a failed `enable` is
+    // not a failed start and must not read as one. But it IS a second fact the
+    // owner acts on, so it travels with the answer instead of dying in a log.
+    const { bootPersisted, bootPersistWarning } = await startTunnelService();
+    return NextResponse.json({
+      success: true,
+      bootPersisted,
+      ...(bootPersistWarning ? { warning: bootPersistWarning } : {}),
+    });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to start tunnel" },

--- a/src/app/setup-api/portal/stop/route.ts
+++ b/src/app/setup-api/portal/stop/route.ts
@@ -5,7 +5,11 @@ export const dynamic = "force-dynamic";
 
 export async function POST() {
   try {
-    await stopTunnelService();
+    // Both halves of "off": the unit down now, and the unit still down after a
+    // reboot. A `disable` that failed leaves a box that starts publishing a
+    // public *.trycloudflare.com address again on the next power cycle, so it
+    // cannot be answered with the same `{ success: true }` as a clean stop.
+    const { bootPersisted, bootPersistWarning } = await stopTunnelService();
     const state = await getTunnelServiceState();
     if (state === "active" || state === "activating") {
       return NextResponse.json(
@@ -19,7 +23,11 @@ export async function POST() {
         { status: 500 }
       );
     }
-    return NextResponse.json({ success: true });
+    return NextResponse.json({
+      success: true,
+      bootPersisted,
+      ...(bootPersistWarning ? { warning: bootPersistWarning } : {}),
+    });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : "Failed to stop tunnel" },

--- a/src/app/setup-api/system/hotspot/route.ts
+++ b/src/app/setup-api/system/hotspot/route.ts
@@ -19,6 +19,18 @@ const HOTSPOT_ENV_PATH = path.join(
 let getCache: { body: unknown; at: number } | null = null;
 const GET_TTL_MS = 3_000;
 
+/**
+ * What the save did to the access point, as one word.
+ *
+ *  * `restarted` — the AP was bounced, so this connection has just dropped.
+ *  * `deferred`  — deliberately not bounced (the radio is a client right now);
+ *                  the saved settings apply at the next AP start.
+ *  * `stopped`   — the owner turned the hotspot off and it went down.
+ *  * `failed`    — the toggle threw; the settings are saved, the radio is not
+ *                  in the state the owner asked for, and `warning` says so.
+ */
+type HotspotApAction = "restarted" | "deferred" | "stopped" | "failed";
+
 export async function GET() {
   if (getCache && Date.now() - getCache.at < GET_TTL_MS) {
     return NextResponse.json(getCache.body);
@@ -126,7 +138,16 @@ export async function POST(request: Request) {
     });
 
     // Start or stop the AP service based on enabled state.
-    let apRestarted = false;
+    //
+    // FOUR OUTCOMES, NOT ONE BOOLEAN. `apRestarted: false` used to mean all of
+    // "we deliberately held off", "we stopped the AP as asked" and "the toggle
+    // THREW and nothing happened" — three different facts, and only one of them
+    // is fine. The deferral is a designed behaviour the wizard must treat as
+    // success; the throw is a box whose hotspot is not in the state its owner
+    // just asked for, reported to that owner as "Settings saved". So the verdict
+    // is named, and a failure carries its reason.
+    let apAction: HotspotApAction = isEnabled ? "deferred" : "stopped";
+    let apWarning: string | null = null;
     try {
       if (isEnabled) {
         // Single-radio guard: if the box is currently a WiFi *client* (it joined
@@ -150,7 +171,7 @@ export async function POST(request: Request) {
             "start",
             "clawbox-root-update@restart_ap.service",
           ]);
-          apRestarted = true;
+          apAction = "restarted";
         }
       } else {
         // Stop the AP — run stop-ap.sh directly since clawbox user can execute it
@@ -163,12 +184,29 @@ export async function POST(request: Request) {
       }
     } catch (apErr) {
       console.warn("[hotspot] Failed to toggle AP:", apErr);
-      // Non-fatal: settings are saved for next AP start
+      // Still not fatal — the settings ARE saved and apply at the next AP start
+      // — but it stops being invisible.
+      apAction = "failed";
+      apWarning = isEnabled
+        ? "Your hotspot settings were saved, but this ClawBox could not restart "
+          + "its hotspot. The new settings apply the next time it starts."
+        : "Your hotspot settings were saved, but this ClawBox could not switch "
+          + "its hotspot off. It may still be broadcasting until the next restart.";
     }
+
+    // The GET handler caches for 3s, which is long enough to answer the reload
+    // that follows this save with the settings it just replaced.
+    getCache = null;
 
     // apRestarted tells the wizard whether the connection was actually dropped
     // (so it should show the reconnect handoff) vs. saved without disruption.
-    return NextResponse.json({ success: true, apRestarted });
+    // Kept, and now derived from the verdict rather than being it.
+    return NextResponse.json({
+      success: true,
+      apRestarted: apAction === "restarted",
+      apAction,
+      ...(apWarning ? { warning: apWarning } : {}),
+    });
   } catch (err) {
     return NextResponse.json(
       {

--- a/src/components/CredentialsHandoffOverlay.tsx
+++ b/src/components/CredentialsHandoffOverlay.tsx
@@ -20,6 +20,17 @@ interface CredentialsHandoffOverlayProps {
    * rejoin is needed (e.g. only the device name changed over Ethernet).
    */
   hotspotSsid: string | null;
+  /**
+   * Something the save could NOT do, carried across the handoff.
+   *
+   * A hotspot toggle that threw is saved but not applied, and the customer has
+   * to be told — but when the device was also renamed, this origin is about to
+   * stop answering, so the reconnect cannot wait for them to read a message on
+   * a page that is going away. It rides along instead. Only ever shown when
+   * there is no rejoin instruction, which is exactly the case: a toggle that
+   * threw restarted no AP, so there is no new network to rejoin.
+   */
+  notice?: string | null;
   /** Advance to the next step once the box is reachable again (same-origin only). */
   onContinue: () => void;
   /** Hermes edition: the overlay waits in the agent's green, not coral. */
@@ -40,6 +51,7 @@ export default function CredentialsHandoffOverlay({
   targetUrl,
   sameOrigin,
   hotspotSsid,
+  notice = null,
   onContinue,
   hermes = false,
   graceMs = 4000,
@@ -95,7 +107,7 @@ export default function CredentialsHandoffOverlay({
       doneTone="cyan"
       title={completed ? t("settings.backOnline") : t("credentials.handoffTitle")}
       description={completed ? t("ai.almostReady") : t("credentials.handoffDesc")}
-      instruction={completed || !hotspotSsid ? undefined : rejoinLabel}
+      instruction={completed ? undefined : (hotspotSsid ? rejoinLabel : notice ?? undefined)}
       action={completed ? undefined : { label: t("wifi.openUrl", { url: prettyUrl }), href: targetUrl }}
     />
   );

--- a/src/components/CredentialsStep.tsx
+++ b/src/components/CredentialsStep.tsx
@@ -148,6 +148,8 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
     targetUrl: string;
     sameOrigin: boolean;
     hotspotSsid: string | null;
+    /** A saved-but-not-applied hotspot toggle, carried across the reconnect. */
+    notice?: string | null;
   } | null>(null);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const saveControllerRef = useRef<AbortController | null>(null);
@@ -345,6 +347,11 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
       // apRestarted:false, and the owner is told rather than shown "Settings
       // saved!". The text comes from the route, like the error text above it.
       const apFailed = hotspotData.apAction === "failed";
+      const apWarning = apFailed
+        ? (typeof hotspotData.warning === "string" && hotspotData.warning.trim()
+          ? hotspotData.warning
+          : t("credentials.failedSaveHotspot"))
+        : null;
       const currentHost = window.location.hostname.toLowerCase();
       const hostnameChanged =
         currentHost.endsWith(".local") && currentHost !== newHost && isAllowedRedirect;
@@ -364,17 +371,17 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
             : new URL("/setup", window.location.href).toString(),
           sameOrigin: !hostnameChanged,
           hotspotSsid: apRestarted && submission.hotspotEnabled ? submission.hotspotName : null,
+          // A rename plus a failed AP toggle is the one combination where the
+          // warning would otherwise be lost: this origin is about to stop
+          // answering, so it travels with the reconnect instead of being held
+          // on a page the box is leaving.
+          notice: apWarning,
         });
         return;
       }
 
-      if (apFailed) {
-        setStatus({
-          type: "info",
-          message: typeof hotspotData.warning === "string" && hotspotData.warning.trim()
-            ? hotspotData.warning
-            : t("credentials.failedSaveHotspot"),
-        });
+      if (apWarning) {
+        setStatus({ type: "info", message: apWarning });
         // No auto-advance: the one thing that must not happen here is the
         // message being replaced by the next step before it has been read.
         return;
@@ -476,6 +483,7 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
           targetUrl={handoff.targetUrl}
           sameOrigin={handoff.sameOrigin}
           hotspotSsid={handoff.hotspotSsid}
+          notice={handoff.notice ?? null}
           onContinue={onNext}
         />
       )}

--- a/src/components/CredentialsStep.tsx
+++ b/src/components/CredentialsStep.tsx
@@ -136,7 +136,10 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
   // rather than merely hinting there is a field.
   const [hotspotSecretOpen, setHotspotSecretOpen] = useState(false);
   const [status, setStatus] = useState<{
-    type: "success" | "error";
+    // "info" is the saved-but-not-fully-applied case: the hotspot settings are
+    // on disk, and the radio did not do what they say. Reporting that as plain
+    // success is what let a failed AP toggle read as "Settings saved!".
+    type: "success" | "error" | "info";
     message: string;
   } | null>(null);
   // When a save restarts the setup AP (and/or renames the device), the connection
@@ -337,6 +340,11 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
       // device name changed the box reappears at a new *.local origin. Either
       // way the overlay probes until the box answers, then continues.
       const apRestarted = hotspotData.apRestarted === true;
+      // A save whose AP toggle THREW is saved, not applied. The route now says
+      // which of the two happened (`apAction`) instead of answering both with
+      // apRestarted:false, and the owner is told rather than shown "Settings
+      // saved!". The text comes from the route, like the error text above it.
+      const apFailed = hotspotData.apAction === "failed";
       const currentHost = window.location.hostname.toLowerCase();
       const hostnameChanged =
         currentHost.endsWith(".local") && currentHost !== newHost && isAllowedRedirect;
@@ -350,6 +358,18 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
           sameOrigin: !hostnameChanged,
           hotspotSsid: apRestarted && submission.hotspotEnabled ? submission.hotspotName : null,
         });
+        return;
+      }
+
+      if (apFailed) {
+        setStatus({
+          type: "info",
+          message: typeof hotspotData.warning === "string" && hotspotData.warning.trim()
+            ? hotspotData.warning
+            : t("credentials.failedSaveHotspot"),
+        });
+        // No auto-advance: the one thing that must not happen here is the
+        // message being replaced by the next step before it has been read.
         return;
       }
 

--- a/src/components/CredentialsStep.tsx
+++ b/src/components/CredentialsStep.tsx
@@ -349,6 +349,13 @@ export default function CredentialsStep({ onNext, hermes = false }: CredentialsS
       const hostnameChanged =
         currentHost.endsWith(".local") && currentHost !== newHost && isAllowedRedirect;
 
+      // The handoff wins over the AP warning, and only in one combination: the
+      // device was ALSO renamed, so this origin is about to stop answering.
+      // (`apRestarted` and `apFailed` are mutually exclusive — a toggle that
+      // threw restarted nothing.) Holding a message on a page the box is no
+      // longer reachable at would strand the customer, so the reconnect goes
+      // first; the hotspot warning is still recoverable from Settings, where
+      // the same verdict is read.
       if (apRestarted || hostnameChanged) {
         if (timeoutRef.current) clearTimeout(timeoutRef.current);
         setHandoff({

--- a/src/components/RemoteControlPanel.tsx
+++ b/src/components/RemoteControlPanel.tsx
@@ -25,6 +25,11 @@ export default function RemoteControlPanel() {
   const [loading, setLoading] = useState(true);
   const [action, setAction] = useState<"idle" | "starting" | "stopping" | "regenerating">("idle");
   const [error, setError] = useState<string | null>(null);
+  // A start/stop that WORKED but could not be recorded for the next boot.
+  // Not an error — the unit is in the state the owner asked for — but the
+  // owner has to know a reboot will undo it, which a silent `{success:true}`
+  // never told them.
+  const [bootWarning, setBootWarning] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   // Inline autoinstall — replaces the old "run sudo bash install.sh ..."
   // warning text with a one-click button. Posts to the generic install
@@ -60,6 +65,12 @@ export default function RemoteControlPanel() {
     return fallback;
   }, []);
 
+  /** Carry a 200's `warning` (a failed enable/disable) into the panel. */
+  const readBootWarning = useCallback(async (res: Response) => {
+    const data = await res.json().catch(() => null) as { warning?: unknown } | null;
+    setBootWarning(typeof data?.warning === "string" && data.warning.trim() ? data.warning : null);
+  }, []);
+
   useEffect(() => {
     let alive = true;
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -88,11 +99,13 @@ export default function RemoteControlPanel() {
   const handleStart = async () => {
     setAction("starting");
     setError(null);
+    setBootWarning(null);
     try {
       const res = await fetch("/setup-api/portal/start", { method: "POST" });
       if (!res.ok) {
         throw new Error(await readErrorMessage(res, t("remoteControl.startFailed")));
       }
+      await readBootWarning(res);
       await fetchStatus();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("remoteControl.startFailed"));
@@ -107,6 +120,7 @@ export default function RemoteControlPanel() {
   const handleRegenerate = async () => {
     setAction("regenerating");
     setError(null);
+    setBootWarning(null);
     // Optimistically clear the URL so the UI flips to the "negotiating" state
     // without waiting for the next poll to observe it.
     setStatus(prev => prev ? { ...prev, tunnel: { ...prev.tunnel, url: null } } : prev);
@@ -115,6 +129,7 @@ export default function RemoteControlPanel() {
       if (!res.ok) {
         throw new Error(await readErrorMessage(res, t("remoteControl.startFailed")));
       }
+      await readBootWarning(res);
       await fetchStatus();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("remoteControl.startFailed"));
@@ -126,11 +141,13 @@ export default function RemoteControlPanel() {
   const handleStop = async () => {
     setAction("stopping");
     setError(null);
+    setBootWarning(null);
     try {
       const res = await fetch("/setup-api/portal/stop", { method: "POST" });
       if (!res.ok) {
         throw new Error(await readErrorMessage(res, t("remoteControl.stopFailed")));
       }
+      await readBootWarning(res);
       await fetchStatus();
     } catch (err) {
       setError(err instanceof Error ? err.message : t("remoteControl.stopFailed"));
@@ -210,6 +227,7 @@ export default function RemoteControlPanel() {
       </div>
 
       {error && <StatusMessage type="error" message={error} />}
+      {bootWarning && <StatusMessage type="info" message={bootWarning} />}
 
       {!tunnelInstalled && (
         <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -715,16 +715,23 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   const [hotspotEnabled, setHotspotEnabled] = useState<boolean | null>(null);
   const [hotspotSSID, setHotspotSSID] = useState("ClawBox-Setup");
   const [hotspotToggling, setHotspotToggling] = useState(false);
+  // The hotspot route saves the SETTINGS and then tries to move the radio, and
+  // those are two different outcomes. It used to answer both with
+  // `{ success: true, apRestarted: false }`, so a toggle whose AP command threw
+  // flipped this switch and said nothing — a box still broadcasting behind a
+  // control that reads "off". It now names the verdict; this is where a failed
+  // one is shown.
+  const [hotspotApWarning, setHotspotApWarning] = useState<string | null>(null);
   const [hotspotSSIDInput, setHotspotSSIDInput] = useState("ClawBox-Setup");
   const [hotspotSSIDSaving, setHotspotSSIDSaving] = useState(false);
-  const [hotspotSSIDStatus, setHotspotSSIDStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [hotspotSSIDStatus, setHotspotSSIDStatus] = useState<{ type: "success" | "error" | "info"; message: string } | null>(null);
   const [hotspotHasPassword, setHotspotHasPassword] = useState(false);
   const [hotspotActive, setHotspotActive] = useState<boolean | null>(null);
   const [hotspotBlockedBy, setHotspotBlockedBy] = useState<string | null>(null);
   const [hotspotPassword, setHotspotPassword] = useState("");
   const [hotspotPasswordShow, setHotspotPasswordShow] = useState(false);
   const [hotspotPasswordSaving, setHotspotPasswordSaving] = useState(false);
-  const [hotspotPasswordStatus, setHotspotPasswordStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
+  const [hotspotPasswordStatus, setHotspotPasswordStatus] = useState<{ type: "success" | "error" | "info"; message: string } | null>(null);
   const [hotspotConfirmEnable, setHotspotConfirmEnable] = useState(false);
   const [savedNetworks, setSavedNetworks] = useState<{ name: string; priority: number; device: string | null }[]>([]);
   const [savedEditing, setSavedEditing] = useState<string | null>(null);
@@ -1129,8 +1136,25 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
     }
   };
 
+  /**
+   * What a 200 from the hotspot route actually achieved.
+   *
+   * `apAction` separates the three things the old `apRestarted: false` collapsed
+   * into one: a deliberate deferral (the radio is a client, so bouncing the AP
+   * would sever this connection), a clean stop, and a toggle that THREW. Only
+   * the last one is a problem, and only it carries a `warning`.
+   */
+  const readHotspotVerdict = async (res: Response): Promise<string | null> => {
+    const data = await res.json().catch(() => ({})) as { apAction?: unknown; warning?: unknown };
+    if (data.apAction !== "failed") return null;
+    return typeof data.warning === "string" && data.warning.trim()
+      ? data.warning
+      : "Your hotspot settings were saved, but the hotspot itself did not change.";
+  };
+
   const performHotspotToggle = async (newEnabled: boolean) => {
     setHotspotToggling(true);
+    setHotspotApWarning(null);
     try {
       const res = await fetch("/setup-api/system/hotspot", {
         method: "POST",
@@ -1138,7 +1162,12 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         body: JSON.stringify({ ssid: hotspotSSID, enabled: newEnabled }),
       });
       if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || "Failed");
+      // The switch follows the SAVED setting, which did change. What may not
+      // have changed is the radio, and that is what the warning is for — the
+      // "off" case especially, where a box goes on broadcasting behind a
+      // control that says it stopped.
       setHotspotEnabled(newEnabled);
+      setHotspotApWarning(await readHotspotVerdict(res));
     } catch { /* leave state unchanged */ } finally {
       setHotspotToggling(false);
     }
@@ -1179,7 +1208,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         throw new Error(data.error || "Failed");
       }
       setHotspotSSID(next);
-      setHotspotSSIDStatus({ type: "success", message: "Hotspot name updated" });
+      const apWarning = await readHotspotVerdict(res);
+      setHotspotSSIDStatus(apWarning
+        ? { type: "info", message: apWarning }
+        : { type: "success", message: "Hotspot name updated" });
     } catch (err) {
       setHotspotSSIDStatus({ type: "error", message: err instanceof Error ? err.message : "Failed" });
     } finally {
@@ -1210,7 +1242,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       }
       setHotspotHasPassword(true);
       setHotspotPassword("");
-      setHotspotPasswordStatus({ type: "success", message: "Hotspot password updated" });
+      const apWarning = await readHotspotVerdict(res);
+      setHotspotPasswordStatus(apWarning
+        ? { type: "info", message: apWarning }
+        : { type: "success", message: "Hotspot password updated" });
     } catch (err) {
       setHotspotPasswordStatus({ type: "error", message: err instanceof Error ? err.message : "Failed" });
     } finally {
@@ -3211,6 +3246,9 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
                   <span className={`absolute top-0.5 left-0.5 w-5 h-5 rounded-full bg-white shadow transition-transform ${hotspotEnabled ? "translate-x-5" : "translate-x-0"}`} />
                 </button>
               </div>
+              {hotspotApWarning && (
+                <div className="mt-3"><StatusMessage type="info" message={hotspotApWarning} /></div>
+              )}
               {hotspotEnabled && hotspotActive !== false && (
                 <p className="text-[11px] text-[var(--text-muted)] opacity-50 mt-3 leading-relaxed">
                   {t("settings.hotspotDesc", { ssid: hotspotSSID })}

--- a/src/components/SettingsApp.tsx
+++ b/src/components/SettingsApp.tsx
@@ -724,14 +724,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
   const [hotspotApWarning, setHotspotApWarning] = useState<string | null>(null);
   const [hotspotSSIDInput, setHotspotSSIDInput] = useState("ClawBox-Setup");
   const [hotspotSSIDSaving, setHotspotSSIDSaving] = useState(false);
-  const [hotspotSSIDStatus, setHotspotSSIDStatus] = useState<{ type: "success" | "error" | "info"; message: string } | null>(null);
+  const [hotspotSSIDStatus, setHotspotSSIDStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const [hotspotHasPassword, setHotspotHasPassword] = useState(false);
   const [hotspotActive, setHotspotActive] = useState<boolean | null>(null);
   const [hotspotBlockedBy, setHotspotBlockedBy] = useState<string | null>(null);
   const [hotspotPassword, setHotspotPassword] = useState("");
   const [hotspotPasswordShow, setHotspotPasswordShow] = useState(false);
   const [hotspotPasswordSaving, setHotspotPasswordSaving] = useState(false);
-  const [hotspotPasswordStatus, setHotspotPasswordStatus] = useState<{ type: "success" | "error" | "info"; message: string } | null>(null);
+  const [hotspotPasswordStatus, setHotspotPasswordStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
   const [hotspotConfirmEnable, setHotspotConfirmEnable] = useState(false);
   const [savedNetworks, setSavedNetworks] = useState<{ name: string; priority: number; device: string | null }[]>([]);
   const [savedEditing, setSavedEditing] = useState<string | null>(null);
@@ -1208,10 +1208,14 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
         throw new Error(data.error || "Failed");
       }
       setHotspotSSID(next);
-      const apWarning = await readHotspotVerdict(res);
-      setHotspotSSIDStatus(apWarning
-        ? { type: "info", message: apWarning }
-        : { type: "success", message: "Hotspot name updated" });
+      // The AP verdict lives in ONE place — the card-level warning — and is
+      // written on every AP outcome, `null` included. Setting it only on
+      // failure would leave a stale warning from an earlier failed toggle
+      // sitting over a save that has since worked, which is the same class of
+      // wrong answer this PR is about. The field status stays about the field:
+      // the name WAS saved, whatever the radio did.
+      setHotspotApWarning(await readHotspotVerdict(res));
+      setHotspotSSIDStatus({ type: "success", message: "Hotspot name updated" });
     } catch (err) {
       setHotspotSSIDStatus({ type: "error", message: err instanceof Error ? err.message : "Failed" });
     } finally {
@@ -1242,10 +1246,10 @@ export default function SettingsApp({ ui }: SettingsAppProps) {
       }
       setHotspotHasPassword(true);
       setHotspotPassword("");
-      const apWarning = await readHotspotVerdict(res);
-      setHotspotPasswordStatus(apWarning
-        ? { type: "info", message: apWarning }
-        : { type: "success", message: "Hotspot password updated" });
+      // Same rule as the SSID save above: one home for the AP verdict, written
+      // on every outcome so a later success clears an earlier failure.
+      setHotspotApWarning(await readHotspotVerdict(res));
+      setHotspotPasswordStatus({ type: "success", message: "Hotspot password updated" });
     } catch (err) {
       setHotspotPasswordStatus({ type: "error", message: err instanceof Error ? err.message : "Failed" });
     } finally {

--- a/src/lib/cloudflared.ts
+++ b/src/lib/cloudflared.ts
@@ -109,24 +109,84 @@ export async function readTunnelUrlFromJournal(lines = 200): Promise<string | nu
   }
 }
 
-export async function startTunnelService(): Promise<void> {
+/**
+ * What a start/stop actually achieved.
+ *
+ * Turning Remote Access on or off is TWO facts, not one: the unit's state right
+ * now (`restart`/`stop`) and the same intent recorded for the next boot
+ * (`enable`/`disable`). They are two systemctl calls because
+ * config/clawbox-sudoers grants the plain verbs and no `--now` variant, so they
+ * can and do fail independently.
+ *
+ * The second one used to be swallowed into a `console.warn` behind a `void`
+ * return, which made "stopped" and "stopped until the next reboot puts it back"
+ * the same answer to the caller — and the second is the one where the box keeps
+ * serving itself to the public internet after the owner switched it off. The
+ * first call still throws (nothing happened at all); the second is reported.
+ */
+export interface TunnelServiceResult {
+  /** True when the change was also recorded for the next boot. */
+  bootPersisted: boolean;
+  /** Why it was not, in the owner's words — null when it was. */
+  bootPersistWarning: string | null;
+}
+
+const START_PERSIST_WARNING =
+  "Remote access is running, but this ClawBox could not be told to start it "
+  + "again automatically — it will be off after the next reboot.";
+
+const STOP_PERSIST_WARNING =
+  "Remote access is stopped, but this ClawBox could not be told to keep it off "
+  + "— it will start serving a public address again after the next reboot.";
+
+/**
+ * Run the boot-persistence call and say whether it worked.
+ *
+ * Never throws: the unit is already in the state the caller asked for by the
+ * time this runs, and the caller decides what a failed persist means. It
+ * REPORTS, though — that is the whole difference from the `.catch(warn)` this
+ * replaces.
+ *
+ * Takes a THUNK rather than the verb, so the argv stays a literal at the call
+ * site. sudo matches the argument list exactly and
+ * scripts/check-sudoers-coverage.sh reads these statically; a `verb` parameter
+ * makes both the grant and the check unresolvable.
+ */
+async function persistTunnelIntent(
+  label: "enable" | "disable",
+  run: () => Promise<unknown>,
+  warning: string,
+): Promise<TunnelServiceResult> {
+  try {
+    await run();
+    return { bootPersisted: true, bootPersistWarning: null };
+  } catch (err) {
+    console.warn(`[cloudflared] ${label} failed:`, err instanceof Error ? err.message : err);
+    return { bootPersisted: false, bootPersistWarning: warning };
+  }
+}
+
+export async function startTunnelService(): Promise<TunnelServiceResult> {
   await execFileAsync("sudo", ["-n", "/usr/bin/systemctl", "restart", TUNNEL_SERVICE]);
   // Persist the user's intent across reboots — without `enable`, the next
   // power cycle would leave the box unreachable until they SSH in again,
-  // which defeats the whole point of Remote Access. Best-effort: a failure
-  // here is non-fatal because the tunnel itself just got started above.
-  await execFileAsync("sudo", ["-n", "/usr/bin/systemctl", "enable", TUNNEL_SERVICE]).catch((err) => {
-    console.warn("[cloudflared] enable failed (non-fatal):", err instanceof Error ? err.message : err);
-  });
+  // which defeats the whole point of Remote Access.
+  return persistTunnelIntent(
+    "enable",
+    () => execFileAsync("sudo", ["-n", "/usr/bin/systemctl", "enable", TUNNEL_SERVICE]),
+    START_PERSIST_WARNING,
+  );
 }
 
-export async function stopTunnelService(): Promise<void> {
+export async function stopTunnelService(): Promise<TunnelServiceResult> {
   await execFileAsync("sudo", ["-n", "/usr/bin/systemctl", "stop", TUNNEL_SERVICE]);
   // Mirror image of startTunnelService — without `disable` the unit comes
   // back on the next reboot, silently overriding the user's stop intent.
-  await execFileAsync("sudo", ["-n", "/usr/bin/systemctl", "disable", TUNNEL_SERVICE]).catch((err) => {
-    console.warn("[cloudflared] disable failed (non-fatal):", err instanceof Error ? err.message : err);
-  });
+  return persistTunnelIntent(
+    "disable",
+    () => execFileAsync("sudo", ["-n", "/usr/bin/systemctl", "disable", TUNNEL_SERVICE]),
+    STOP_PERSIST_WARNING,
+  );
 }
 
 export type TunnelUnitState = "active" | "inactive" | "failed" | "activating" | "unknown";

--- a/src/tests/components/credentials-hotspot-ap-failure.test.tsx
+++ b/src/tests/components/credentials-hotspot-ap-failure.test.tsx
@@ -1,0 +1,121 @@
+// A hotspot save whose AP toggle THREW is saved, not applied. The route used to
+// answer that with the same bytes as a deliberate deferral —
+// `{ success: true, apRestarted: false }` — so Step 3 showed "Settings saved!"
+// and walked the customer on to the next step, leaving a box whose hotspot is
+// not in the state they just asked for and nothing anywhere that says so.
+//
+// These hold the two halves in place: the failure is SHOWN, in the route's own
+// words, and the step does not advance past it on a timer.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import CredentialsStep from "@/components/CredentialsStep";
+
+const STRINGS: Record<string, string> = {
+  "credentials.settingsSaved": "Settings saved! Continuing...",
+  "credentials.failedSaveHotspot": "Failed to save hotspot settings",
+  "credentials.writeDownContinue": "I've saved them — continue",
+  "settings.connect": "Connect",
+  continue: "Continue",
+};
+
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({ t: (key: string) => STRINGS[key] ?? key }),
+}));
+
+const SYSTEM_PASSWORD = "Probe1234!";
+const HOTSPOT_PASSWORD = "Hotspot-9876";
+const AP_WARNING =
+  "Your hotspot settings were saved, but this ClawBox could not restart its "
+  + "hotspot. The new settings apply the next time it starts.";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+let hotspotPostBody: Record<string, unknown>;
+
+beforeEach(() => {
+  vi.useRealTimers();
+  hotspotPostBody = { success: true, apRestarted: false, apAction: "failed", warning: AP_WARNING };
+  fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (init?.method === "POST") {
+      if (url === "/setup-api/system/hotspot") {
+        return { ok: true, json: async () => hotspotPostBody } as Response;
+      }
+      return { ok: true, json: async () => ({}) } as Response;
+    }
+    if (url === "/setup-api/system/hotspot") {
+      return { ok: true, json: async () => ({ ssid: "ClawBox-Setup", enabled: true }) } as Response;
+    }
+    if (url === "/setup-api/system/hostname") {
+      return { ok: true, json: async () => ({ hostname: "clawbox" }) } as Response;
+    }
+    return { ok: false, status: 404, json: async () => ({}) } as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function field(container: HTMLElement, selector: string): HTMLInputElement {
+  const el = container.querySelector<HTMLInputElement>(selector);
+  if (!el) throw new Error(`missing field: ${selector}`);
+  return el;
+}
+
+/** Fill Step 3 and take it all the way through the write-down dialog. */
+async function saveStep(onNext: () => void) {
+  const { container } = render(<CredentialsStep onNext={onNext} />);
+  await waitFor(() => {
+    expect(fetchMock).toHaveBeenCalledWith("/setup-api/system/hostname", expect.any(Object));
+  });
+
+  fireEvent.change(field(container, "#cred-password"), { target: { value: SYSTEM_PASSWORD } });
+  fireEvent.change(field(container, "#cred-confirm"), { target: { value: SYSTEM_PASSWORD } });
+  const discloser = container.querySelector<HTMLButtonElement>('[aria-controls="hotspot-secret-panel"]');
+  if (!discloser) throw new Error("hotspot secret disclosure missing");
+  fireEvent.click(discloser);
+  fireEvent.change(field(container, "#hotspot-password"), { target: { value: HOTSPOT_PASSWORD } });
+  fireEvent.change(field(container, "#hotspot-confirm"), { target: { value: HOTSPOT_PASSWORD } });
+
+  fireEvent.click(screen.getByRole("button", { name: "Connect" }));
+  fireEvent.click(screen.getByTestId("writedown-ack"));
+  fireEvent.click(screen.getByTestId("writedown-continue"));
+
+  await waitFor(() => {
+    expect(
+      fetchMock.mock.calls.some(
+        ([input, init]) =>
+          String(input) === "/setup-api/system/hotspot"
+          && (init as RequestInit | undefined)?.method === "POST",
+      ),
+    ).toBe(true);
+  });
+}
+
+describe("Step 3 — a hotspot save whose AP toggle failed", () => {
+  it("shows the route's warning instead of 'Settings saved!'", async () => {
+    await saveStep(vi.fn());
+    await waitFor(() => expect(screen.getByText(AP_WARNING)).toBeInTheDocument());
+    expect(screen.queryByText("Settings saved! Continuing...")).toBeNull();
+  });
+
+  it("does not walk the customer past the message", async () => {
+    const onNext = vi.fn();
+    await saveStep(onNext);
+    await waitFor(() => expect(screen.getByText(AP_WARNING)).toBeInTheDocument());
+    // The success path advances on a 1.5s timer; this one must not.
+    await new Promise((r) => setTimeout(r, 2_000));
+    expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it("still reports a deferral as a clean save", async () => {
+    // The deliberate hold-off — the radio is a client, so bouncing the AP would
+    // sever this very connection — is not a failure and must not read as one.
+    hotspotPostBody = { success: true, apRestarted: false, apAction: "deferred" };
+    await saveStep(vi.fn());
+    await waitFor(() =>
+      expect(screen.getByText("Settings saved! Continuing...")).toBeInTheDocument(),
+    );
+  });
+});

--- a/src/tests/components/credentials-hotspot-ap-failure.test.tsx
+++ b/src/tests/components/credentials-hotspot-ap-failure.test.tsx
@@ -11,6 +11,11 @@ import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import CredentialsStep from "@/components/CredentialsStep";
 
 const STRINGS: Record<string, string> = {
+  "credentials.handoffTitle": "Applying your settings",
+  "credentials.handoffDesc": "Waiting for this ClawBox to answer again",
+  "credentials.handoffApplying": "Applying",
+  "settings.waitingOnline": "Waiting",
+  "settings.backOnline": "Back online",
   "credentials.settingsSaved": "Settings saved! Continuing...",
   "credentials.failedSaveHotspot": "Failed to save hotspot settings",
   "credentials.writeDownContinue": "I've saved them — continue",
@@ -29,6 +34,7 @@ const AP_WARNING =
   + "hotspot. The new settings apply the next time it starts.";
 
 let fetchMock: ReturnType<typeof vi.fn>;
+let originalLocation: PropertyDescriptor | null = null;
 let hotspotPostBody: Record<string, unknown>;
 
 beforeEach(() => {
@@ -55,6 +61,10 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  // `vi.unstubAllGlobals` does not reach a defineProperty on window.location,
+  // and a leaked origin would silently change what the NEXT test's save decides.
+  if (originalLocation) Object.defineProperty(window, "location", originalLocation);
+  originalLocation = null;
 });
 
 function field(container: HTMLElement, selector: string): HTMLInputElement {
@@ -64,12 +74,18 @@ function field(container: HTMLElement, selector: string): HTMLInputElement {
 }
 
 /** Fill Step 3 and take it all the way through the write-down dialog. */
-async function saveStep(onNext: () => void) {
+async function saveStep(onNext: () => void, hostname?: string) {
   const { container } = render(<CredentialsStep onNext={onNext} />);
   await waitFor(() => {
     expect(fetchMock).toHaveBeenCalledWith("/setup-api/system/hostname", expect.any(Object));
   });
 
+  if (hostname) {
+    const nameDiscloser = container.querySelector<HTMLButtonElement>('[aria-controls="cred-hostname-panel"]');
+    if (nameDiscloser) fireEvent.click(nameDiscloser);
+    const nameField = container.querySelector<HTMLInputElement>("#cred-hostname");
+    if (nameField) fireEvent.change(nameField, { target: { value: hostname } });
+  }
   fireEvent.change(field(container, "#cred-password"), { target: { value: SYSTEM_PASSWORD } });
   fireEvent.change(field(container, "#cred-confirm"), { target: { value: SYSTEM_PASSWORD } });
   const discloser = container.querySelector<HTMLButtonElement>('[aria-controls="hotspot-secret-panel"]');
@@ -107,6 +123,36 @@ describe("Step 3 — a hotspot save whose AP toggle failed", () => {
     // The success path advances on a 1.5s timer; this one must not.
     await new Promise((r) => setTimeout(r, 2_000));
     expect(onNext).not.toHaveBeenCalled();
+  });
+
+  it("carries the warning into the reconnect when the device was also renamed", async () => {
+    // The one combination where the message would otherwise be lost: this
+    // origin is about to stop answering, so the reconnect cannot wait for the
+    // customer to read something on a page the box is leaving. It rides along
+    // in the overlay instead — the instruction slot is free precisely here,
+    // because a toggle that threw restarted no AP and there is no network to
+    // rejoin.
+    // The step only offers a handoff for a same-scheme, same-port *.local
+    // rename, so every field that guard reads has to be present.
+    originalLocation = Object.getOwnPropertyDescriptor(window, "location") ?? null;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        protocol: "http:",
+        port: "",
+        hostname: "clawbox.local",
+        host: "clawbox.local",
+        origin: "http://clawbox.local",
+        href: "http://clawbox.local/setup",
+        replace: vi.fn(),
+        assign: vi.fn(),
+      },
+    });
+    await saveStep(vi.fn(), "newname");
+    // The overlay, not the inline status: proof this went down the handoff path
+    // rather than passing for the ordinary reason.
+    await waitFor(() => expect(screen.getByText("Applying your settings")).toBeInTheDocument());
+    expect(screen.getByText(AP_WARNING)).toBeInTheDocument();
   });
 
   it("still reports a deferral as a clean save", async () => {

--- a/src/tests/components/remote-control-boot-persist.test.tsx
+++ b/src/tests/components/remote-control-boot-persist.test.tsx
@@ -1,0 +1,88 @@
+// Remote Access is two facts, not one: the tunnel's state right now, and the
+// same intent recorded for the next boot. `systemctl stop` and
+// `systemctl disable` are separate calls (config/clawbox-sudoers grants no
+// `--now` variant for this unit), so they fail independently — and the failure
+// that matters is the second one, where the owner switches Remote Access OFF,
+// is told it worked, and the box starts publishing a public
+// *.trycloudflare.com address again at the next power cycle.
+//
+// The route now carries that verdict in its 200. This is the panel showing it.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import RemoteControlPanel from "@/components/RemoteControlPanel";
+
+const STRINGS: Record<string, string> = {
+  "remoteControl.stop": "Turn off",
+  "remoteControl.stopping": "Turning off...",
+};
+
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({ t: (key: string) => STRINGS[key] ?? key }),
+}));
+
+vi.mock("@/lib/clipboard", () => ({ copyToClipboard: vi.fn(async () => true) }));
+
+const STOP_WARNING =
+  "Remote access is stopped, but this ClawBox could not be told to keep it off "
+  + "— it will start serving a public address again after the next reboot.";
+
+const RUNNING_STATUS = {
+  tunnel: {
+    installed: true,
+    service: "active",
+    url: "https://abc.trycloudflare.com",
+    history: [],
+  },
+  portalAddDeviceUrl: "https://clawbox.com/addDevice",
+  portalWeb: "https://clawbox.com",
+};
+
+let stopBody: Record<string, unknown>;
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function stopWasPosted() {
+  return fetchMock.mock.calls.some(
+    ([input, init]) =>
+      String(input) === "/setup-api/portal/stop"
+      && (init as RequestInit | undefined)?.method === "POST",
+  );
+}
+
+beforeEach(() => {
+  stopBody = { success: true, bootPersisted: false, warning: STOP_WARNING };
+  fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === "/setup-api/portal/stop" && init?.method === "POST") {
+      return { ok: true, json: async () => stopBody } as Response;
+    }
+    return { ok: true, json: async () => RUNNING_STATUS } as Response;
+  });
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function mountPanel() {
+  render(<RemoteControlPanel />);
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "Turn off" })).toBeInTheDocument(),
+  );
+}
+
+describe("RemoteControlPanel — the boot-persist verdict", () => {
+  it("tells the owner when an OFF will undo itself at the next reboot", async () => {
+    await mountPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Turn off" }));
+    await waitFor(() => expect(screen.getByText(STOP_WARNING)).toBeInTheDocument());
+  });
+
+  it("says nothing extra when the OFF was recorded properly", async () => {
+    stopBody = { success: true, bootPersisted: true };
+    await mountPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Turn off" }));
+    await waitFor(() => expect(stopWasPosted()).toBe(true));
+    expect(screen.queryByText(STOP_WARNING)).toBeNull();
+  });
+});

--- a/src/tests/routes/heartbeat-tick.test.ts
+++ b/src/tests/routes/heartbeat-tick.test.ts
@@ -41,7 +41,7 @@ async function tick(req: Request = request()) {
 beforeEach(() => {
   vi.resetModules();
   liveness.mayRestart.mockReturnValue(true);
-  cloudflared.startTunnelService.mockResolvedValue(undefined);
+  cloudflared.startTunnelService.mockResolvedValue({ bootPersisted: true, bootPersistWarning: null });
   // Default for the behavioural tests below: the systemd unit, presenting the
   // install's internal token.
   internalToken.isInternalRequest.mockReturnValue(true);

--- a/src/tests/routes/portal.test.ts
+++ b/src/tests/routes/portal.test.ts
@@ -101,14 +101,35 @@ describe("/setup-api/portal/start", () => {
 
   it("starts the systemd unit and returns success", async () => {
     cloudflaredMock.isInstalled.mockResolvedValue(true);
-    cloudflaredMock.startTunnelService.mockResolvedValue(undefined);
+    cloudflaredMock.startTunnelService.mockResolvedValue({
+      bootPersisted: true,
+      bootPersistWarning: null,
+    });
 
     const mod = await import("@/app/setup-api/portal/start/route");
     const res = await mod.POST();
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body).toEqual({ success: true });
+    expect(body).toEqual({ success: true, bootPersisted: true });
     expect(cloudflaredMock.startTunnelService).toHaveBeenCalledTimes(1);
+  });
+
+  it("says so when the unit started but boot-start was not recorded", async () => {
+    cloudflaredMock.isInstalled.mockResolvedValue(true);
+    cloudflaredMock.startTunnelService.mockResolvedValue({
+      bootPersisted: false,
+      bootPersistWarning: "Remote access is running, but ... after the next reboot.",
+    });
+
+    const mod = await import("@/app/setup-api/portal/start/route");
+    const res = await mod.POST();
+    // Still 200 — the tunnel IS up, and calling that a failure would be the
+    // opposite lie. What changes is that the second fact travels with it.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.bootPersisted).toBe(false);
+    expect(body.warning).toMatch(/reboot/);
   });
 
   it("returns 500 when systemctl restart throws", async () => {
@@ -127,14 +148,39 @@ describe("/setup-api/portal/start", () => {
 
 describe("/setup-api/portal/stop", () => {
   it("stops the systemd unit and returns success", async () => {
-    cloudflaredMock.stopTunnelService.mockResolvedValue(undefined);
+    cloudflaredMock.stopTunnelService.mockResolvedValue({
+      bootPersisted: true,
+      bootPersistWarning: null,
+    });
     cloudflaredMock.getTunnelServiceState.mockResolvedValue("inactive");
 
     const mod = await import("@/app/setup-api/portal/stop/route");
     const res = await mod.POST();
     expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.success ?? body.ok ?? true).toBeTruthy();
+    expect(body.success).toBe(true);
+    expect(body.bootPersisted).toBe(true);
+    expect(body.warning).toBeUndefined();
     expect(cloudflaredMock.stopTunnelService).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not answer a stop that will undo itself with a bare success", async () => {
+    // `systemctl stop` worked, `systemctl disable` did not: the tunnel is down
+    // now and comes back at the next boot, still publishing this box to the
+    // public internet. The old answer to this was byte-identical to the answer
+    // for a clean stop.
+    cloudflaredMock.stopTunnelService.mockResolvedValue({
+      bootPersisted: false,
+      bootPersistWarning:
+        "Remote access is stopped, but ... after the next reboot.",
+    });
+    cloudflaredMock.getTunnelServiceState.mockResolvedValue("inactive");
+
+    const mod = await import("@/app/setup-api/portal/stop/route");
+    const res = await mod.POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.bootPersisted).toBe(false);
+    expect(body.warning).toMatch(/reboot/);
   });
 });

--- a/src/tests/routes/system/hotspot.test.ts
+++ b/src/tests/routes/system/hotspot.test.ts
@@ -262,6 +262,86 @@ describe("/setup-api/system/hotspot", () => {
       expect(body.success).toBe(true);
     });
 
+    describe("the AP verdict is a fact, not a leftover boolean", () => {
+      /**
+       * `{ success: true, apRestarted: false }` was the answer to THREE
+       * different things: "we deliberately held off", "we stopped it as asked"
+       * and "the toggle threw and nothing happened". The wizard read the same
+       * bytes in all three and showed "Settings saved!" — including for the box
+       * whose hotspot is not in the state its owner just asked for.
+       */
+
+      it("distinguishes a deliberate deferral from a failure", async () => {
+        // Deferral: the radio is a client on a real network, so bouncing the AP
+        // would sever THIS connection. Nothing failed.
+        setupExecFileMock({
+          nmcli: { stdout: "HomeWiFi:802-11-wireless:wlP1p1s0", stderr: "" },
+          systemctl: { stdout: "", stderr: "" },
+        });
+
+        const res = await hotspotPost(jsonRequest({ ssid: "MyHotspot", enabled: true }));
+        const body = await res.json();
+
+        expect(res.status).toBe(200);
+        expect(body.apRestarted).toBe(false);
+        expect(body.apAction).toBe("deferred");
+        expect(body.warning).toBeUndefined();
+      });
+
+      it("names a failed AP restart as failed, and says why", async () => {
+        setupExecFileMock({
+          systemctl: new Error("Service failed"),
+          bash: new Error("Script failed"),
+        });
+
+        const res = await hotspotPost(jsonRequest({ ssid: "MyHotspot", enabled: true }));
+        const body = await res.json();
+
+        expect(body.apRestarted).toBe(false);
+        expect(body.apAction).toBe("failed");
+        expect(body.warning).toMatch(/could not restart/i);
+      });
+
+      it("names a failed AP stop as failed, so 'off' is not claimed for a live radio", async () => {
+        setupExecFileMock({ bash: new Error("Script failed") });
+
+        const res = await hotspotPost(jsonRequest({ ssid: "MyHotspot", enabled: false }));
+        const body = await res.json();
+
+        expect(body.apAction).toBe("failed");
+        expect(body.warning).toMatch(/still be broadcasting/i);
+      });
+
+      it("names a clean stop as stopped", async () => {
+        const res = await hotspotPost(jsonRequest({ ssid: "MyHotspot", enabled: false }));
+        const body = await res.json();
+
+        expect(body.apAction).toBe("stopped");
+        expect(body.apRestarted).toBe(false);
+        expect(body.warning).toBeUndefined();
+      });
+
+      it("names a real restart as restarted, and keeps apRestarted true for the handoff", async () => {
+        const res = await hotspotPost(jsonRequest({ ssid: "MyHotspot", enabled: true }));
+        const body = await res.json();
+
+        expect(body.apAction).toBe("restarted");
+        expect(body.apRestarted).toBe(true);
+      });
+    });
+
+    it("does not answer the next GET out of a cache the save just invalidated", async () => {
+      // GET caches for 3s. Without an invalidation the reload that follows a
+      // save is answered with the settings it just replaced.
+      mockGetAll.mockResolvedValue({ hotspot_ssid: "OldName", hotspot_enabled: true });
+      expect((await (await hotspotGet()).json()).ssid).toBe("OldName");
+
+      await hotspotPost(jsonRequest({ ssid: "NewName" }));
+      mockGetAll.mockResolvedValue({ hotspot_ssid: "NewName", hotspot_enabled: true });
+
+      expect((await (await hotspotGet()).json()).ssid).toBe("NewName");
+    });
+
     it("returns 500 on setMany failure", async () => {
       mockSetMany.mockRejectedValue(new Error("Config write failed"));
 

--- a/src/tests/unit/cloudflared.test.ts
+++ b/src/tests/unit/cloudflared.test.ts
@@ -118,6 +118,27 @@ describe("cloudflared — startTunnelService", () => {
     });
     await expect(cloudflared.startTunnelService()).resolves.not.toThrow();
   });
+
+  it("reports that boot-start was NOT recorded when enable fails", async () => {
+    // Non-fatal is not the same as unreported. The tunnel is up, and it will be
+    // down again after the next reboot — two facts, and the caller only ever
+    // got the first one.
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes("enable")) return { error: new Error("Failed to enable") };
+      return { stdout: "" };
+    });
+    const result = await cloudflared.startTunnelService();
+    expect(result.bootPersisted).toBe(false);
+    expect(result.bootPersistWarning).toMatch(/reboot/i);
+  });
+
+  it("reports a clean start as persisted, with nothing to warn about", async () => {
+    execFileMock.mockReturnValue({ stdout: "" });
+    expect(await cloudflared.startTunnelService()).toEqual({
+      bootPersisted: true,
+      bootPersistWarning: null,
+    });
+  });
 });
 
 describe("cloudflared — stopTunnelService", () => {
@@ -127,6 +148,36 @@ describe("cloudflared — stopTunnelService", () => {
     const calls = execFileMock.mock.calls.map(([cmd, args]) => `${cmd} ${args.join(" ")}`);
     expect(calls).toContain("sudo -n /usr/bin/systemctl stop clawbox-tunnel.service");
     expect(calls).toContain("sudo -n /usr/bin/systemctl disable clawbox-tunnel.service");
+  });
+
+  it("reports that the OFF was NOT recorded when disable fails", async () => {
+    // The one that matters. A stop whose `disable` failed leaves a box that
+    // starts publishing a public *.trycloudflare.com address again at the next
+    // power cycle — after its owner switched Remote Access off and was told it
+    // worked.
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes("disable")) return { error: new Error("Failed to disable") };
+      return { stdout: "" };
+    });
+    const result = await cloudflared.stopTunnelService();
+    expect(result.bootPersisted).toBe(false);
+    expect(result.bootPersistWarning).toMatch(/reboot/i);
+  });
+
+  it("still throws when the stop itself fails — that is not a warning", async () => {
+    execFileMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args.includes("stop")) return { error: new Error("Failed to stop") };
+      return { stdout: "" };
+    });
+    await expect(cloudflared.stopTunnelService()).rejects.toThrow(/Failed to stop/);
+  });
+
+  it("reports a clean stop as persisted", async () => {
+    execFileMock.mockReturnValue({ stdout: "" });
+    expect(await cloudflared.stopTunnelService()).toEqual({
+      bootPersisted: true,
+      bootPersistWarning: null,
+    });
   });
 });
 

--- a/src/tests/unit/false-success-call-sites.test.ts
+++ b/src/tests/unit/false-success-call-sites.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * The rule these three fixes have in common, encoded so the next call site
+ * cannot quietly opt out of it.
+ *
+ * Every one of them was the same shape: an operation that reports the fact a
+ * call RETURNED rather than what it returned. Fixing the lib and the one route
+ * named in the bug report is not enough — what has repeatedly gone wrong in
+ * this repo is a correct fix with an unguarded sibling, so the check is over
+ * EVERY caller, not the one that was reported.
+ *
+ * File granularity on purpose: coarse enough to survive refactoring, precise
+ * enough that a new caller which ignores the verdict fails here rather than on
+ * a customer's box.
+ */
+
+const SRC = path.join(process.cwd(), "src");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (entry === "tests" || entry === "node_modules") continue;
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.tsx?$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+const FILES = walk(SRC).map((file) => ({ file, text: readFileSync(file, "utf-8") }));
+
+/** Paths relative to the repo, so a failure names the file to open. */
+const rel = (file: string) => path.relative(process.cwd(), file).split(path.sep).join("/");
+
+describe("the tunnel's boot-persist verdict reaches every caller", () => {
+  // `systemctl stop` and `systemctl disable` are separate calls, and the second
+  // is the one that decides whether the box publishes itself again after a
+  // reboot. It used to be swallowed into a console.warn.
+  const callers = FILES.filter(
+    ({ file, text }) =>
+      !file.endsWith(path.join("lib", "cloudflared.ts"))
+      && /\b(start|stop)TunnelService\s*\(/.test(text),
+  );
+
+  it("has callers at all (the check is not vacuously passing)", () => {
+    expect(callers.length).toBeGreaterThan(0);
+  });
+
+  it.each(callers.map(({ file, text }) => [rel(file), text] as const))(
+    "%s reads the verdict rather than assuming it",
+    (_name, text) => {
+      expect(text).toContain("bootPersisted");
+    },
+  );
+});
+
+describe("the hotspot AP verdict reaches every caller", () => {
+  // `{ success: true, apRestarted: false }` was the answer to a deliberate
+  // deferral, a clean stop AND a toggle that threw. A caller that reads only
+  // `apRestarted` still cannot tell the third from the first two.
+  const callers = FILES.filter(({ text }) =>
+    /fetch\(\s*"\/setup-api\/system\/hotspot"[\s\S]{0,400}?method:\s*"POST"/.test(text),
+  );
+
+  it("has callers at all (the check is not vacuously passing)", () => {
+    expect(callers.length).toBeGreaterThan(0);
+  });
+
+  it.each(callers.map(({ file, text }) => [rel(file), text] as const))(
+    "%s reads apAction rather than only apRestarted",
+    (_name, text) => {
+      expect(text).toContain("apAction");
+    },
+  );
+});

--- a/src/tests/unit/false-success-call-sites.test.ts
+++ b/src/tests/unit/false-success-call-sites.test.ts
@@ -12,12 +12,28 @@ import path from "node:path";
  * this repo is a correct fix with an unguarded sibling, so the check is over
  * EVERY caller, not the one that was reported.
  *
- * File granularity on purpose: coarse enough to survive refactoring, precise
- * enough that a new caller which ignores the verdict fails here rather than on
- * a customer's box.
+ * Two things make it more than a grep for a word:
+ *
+ *  1. Comments and string contents are stripped before the assertion, so a file
+ *     that only MENTIONS `bootPersisted` in prose no longer passes.
+ *  2. The verdict has to appear near the call it belongs to, not anywhere in
+ *     the file. The one legitimate indirection — Settings hands the response to
+ *     a helper — is named explicitly, and that helper is itself checked.
  */
 
 const SRC = path.join(process.cwd(), "src");
+
+/** The name of the one helper allowed to stand in for reading the verdict. */
+const HOTSPOT_VERDICT_HELPER = "readHotspotVerdict";
+
+/** A call to either tunnel operation. Identifiers, so matched against code. */
+const TUNNEL_CALL = /\b(?:start|stop)TunnelService\s*\(/;
+
+/**
+ * A POST to the hotspot route. Matched against the ORIGINAL text, because the
+ * route path only exists as a string literal and the stripper blanks those.
+ */
+const HOTSPOT_POST = /fetch\(\s*"\/setup-api\/system\/hotspot"[\s\S]{0,400}?method:\s*"POST"/;
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {
@@ -29,49 +45,155 @@ function walk(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-const FILES = walk(SRC).map((file) => ({ file, text: readFileSync(file, "utf-8") }));
+/**
+ * Blank out comments and string/template contents, keeping every offset intact
+ * so a window into the result still lines up with the original source.
+ *
+ * Deliberately a scanner rather than a parser: it only has to stop prose from
+ * satisfying a code assertion, and a character walk does that without pulling a
+ * TypeScript AST into a unit test.
+ */
+function codeOnly(src: string): string {
+  const out = src.split("");
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k += 1) {
+      if (out[k] !== "\n") out[k] = " ";
+    }
+  };
+  let i = 0;
+  while (i < src.length) {
+    const two = src.slice(i, i + 2);
+    if (two === "//") {
+      const end = src.indexOf("\n", i);
+      const stop = end < 0 ? src.length : end;
+      blank(i, stop);
+      i = stop;
+      continue;
+    }
+    if (two === "/*") {
+      const end = src.indexOf("*/", i + 2);
+      const stop = end < 0 ? src.length : end + 2;
+      blank(i, stop);
+      i = stop;
+      continue;
+    }
+    if (src[i] === '"' || src[i] === "'" || src[i] === "`") {
+      const quote = src[i];
+      let j = i + 1;
+      while (j < src.length) {
+        if (src[j] === "\\") { j += 2; continue; }
+        if (src[j] === quote) { j += 1; break; }
+        j += 1;
+      }
+      blank(i + 1, j - 1);
+      i = j;
+      continue;
+    }
+    i += 1;
+  }
+  return out.join("");
+}
+
+const FILES = walk(SRC).map((file) => {
+  const text = readFileSync(file, "utf-8");
+  return { file, text, code: codeOnly(text) };
+});
 
 /** Paths relative to the repo, so a failure names the file to open. */
 const rel = (file: string) => path.relative(process.cwd(), file).split(path.sep).join("/");
 
-describe("the tunnel's boot-persist verdict reaches every caller", () => {
+/**
+ * Every window of CODE around a match, so the verdict must sit WITH its call.
+ *
+ * `haystack` is what the pattern is matched against; `code` is what the window
+ * is cut from. Same offsets, because `codeOnly` blanks in place. The two differ
+ * only where the pattern needs a string literal that the stripper removes.
+ */
+function windowsAround(
+  haystack: string,
+  code: string,
+  pattern: RegExp,
+  before = 300,
+  after = 500,
+): string[] {
+  const flags = pattern.flags.includes("g") ? pattern.flags : pattern.flags + "g";
+  const re = new RegExp(pattern.source, flags);
+  const found: string[] = [];
+  for (const m of haystack.matchAll(re)) {
+    const at = m.index ?? 0;
+    found.push(code.slice(Math.max(0, at - before), at + after));
+  }
+  return found;
+}
+
+describe("the tunnel's boot-persist verdict is read AT every call", () => {
   // `systemctl stop` and `systemctl disable` are separate calls, and the second
   // is the one that decides whether the box publishes itself again after a
   // reboot. It used to be swallowed into a console.warn.
   const callers = FILES.filter(
-    ({ file, text }) =>
-      !file.endsWith(path.join("lib", "cloudflared.ts"))
-      && /\b(start|stop)TunnelService\s*\(/.test(text),
+    ({ file, code }) =>
+      !file.endsWith(path.join("lib", "cloudflared.ts")) && TUNNEL_CALL.test(code),
   );
 
   it("has callers at all (the check is not vacuously passing)", () => {
     expect(callers.length).toBeGreaterThan(0);
   });
 
-  it.each(callers.map(({ file, text }) => [rel(file), text] as const))(
-    "%s reads the verdict rather than assuming it",
-    (_name, text) => {
-      expect(text).toContain("bootPersisted");
+  it.each(callers.map(({ file, code }) => [rel(file), code] as const))(
+    "%s reads bootPersisted at each call, not somewhere else in the file",
+    (_name, code) => {
+      // Matched on code, not text: the identifier is never inside a string, and
+      // a mention in a comment must not conjure a call site that does not exist.
+      const windows = windowsAround(code, code, TUNNEL_CALL);
+      expect(windows.length).toBeGreaterThan(0);
+      for (const w of windows) expect(w).toContain("bootPersisted");
     },
   );
 });
 
-describe("the hotspot AP verdict reaches every caller", () => {
+describe("the hotspot AP verdict is read at every call", () => {
   // `{ success: true, apRestarted: false }` was the answer to a deliberate
   // deferral, a clean stop AND a toggle that threw. A caller that reads only
   // `apRestarted` still cannot tell the third from the first two.
-  const callers = FILES.filter(({ text }) =>
-    /fetch\(\s*"\/setup-api\/system\/hotspot"[\s\S]{0,400}?method:\s*"POST"/.test(text),
-  );
+  const callers = FILES.filter(({ text }) => HOTSPOT_POST.test(text));
 
   it("has callers at all (the check is not vacuously passing)", () => {
     expect(callers.length).toBeGreaterThan(0);
   });
 
-  it.each(callers.map(({ file, text }) => [rel(file), text] as const))(
-    "%s reads apAction rather than only apRestarted",
-    (_name, text) => {
-      expect(text).toContain("apAction");
+  it.each(callers.map(({ file, text, code }) => [rel(file), text, code] as const))(
+    "%s reads apAction at each POST, directly or through the one helper",
+    (_name, text, code) => {
+      // 2000 chars of CODE after the call: enough to cover the request, the
+      // `!res.ok` branch and the handling of the body, and nowhere near enough
+      // to reach an unrelated handler. Comments do not count towards it — they
+      // have been blanked — which is the whole point.
+      const windows = windowsAround(text, code, HOTSPOT_POST, 0, 2000);
+      expect(windows.length).toBeGreaterThan(0);
+      for (const w of windows) {
+        expect(w.includes("apAction") || w.includes(HOTSPOT_VERDICT_HELPER)).toBe(true);
+      }
     },
   );
+
+  it(`${HOTSPOT_VERDICT_HELPER} — the one allowed indirection — actually reads apAction`, () => {
+    // Otherwise the escape hatch above would be a hole rather than a helper.
+    const decl = `const ${HOTSPOT_VERDICT_HELPER} =`;
+    const holder = FILES.find(({ code }) => code.includes(decl));
+    expect(holder, `no file defines ${HOTSPOT_VERDICT_HELPER}`).toBeDefined();
+    const at = holder!.code.indexOf(decl);
+    expect(holder!.code.slice(at, at + 600)).toContain("apAction");
+  });
+});
+
+describe("the stripper itself", () => {
+  // The assertions above are only worth anything if prose really is removed.
+  it("removes comments and string contents but keeps offsets", () => {
+    const src = 'const a = 1; // bootPersisted\nconst b = "bootPersisted"; const c = bootPersisted;';
+    const out = codeOnly(src);
+    expect(out).toHaveLength(src.length);
+    expect(out.split("\n")[0]).not.toContain("bootPersisted");
+    expect(out).toContain("const c = bootPersisted;");
+    expect(out.indexOf("const c")).toBe(src.indexOf("const c"));
+  });
 });

--- a/src/tests/unit/identity-sync.test.ts
+++ b/src/tests/unit/identity-sync.test.ts
@@ -39,6 +39,33 @@ function installFake(name: string, exitCode: number): void {
   );
 }
 
+/**
+ * A fake systemctl that answers `is-system-running` and every other verb
+ * separately, because the script has to tell those two apart.
+ *
+ * @param manager what `is-system-running` PRINTS. `"offline"` — or nothing at
+ *   all — is a container carrying the binary with no manager behind it;
+ *   `"degraded"` is a real, running systemd that happens to exit non-zero, an
+ *   ordinary state on these devices and the reason the script reads the word
+ *   rather than the status.
+ * @param verbExit what every other verb returns.
+ */
+function installSystemctl(manager: string, verbExit: number): void {
+  writeFileSync(
+    path.join(binDir, "systemctl"),
+    [
+      "#!/usr/bin/env bash",
+      'if [ "$1" = "is-system-running" ]; then',
+      manager ? `  echo ${manager}` : '  echo "Failed to connect to bus" >&2',
+      // `running` is the only state systemd itself exits 0 for.
+      manager === "running" ? "  exit 0" : "  exit 1",
+      "fi",
+      `exit ${verbExit}`,
+    ].join("\n"),
+    { mode: 0o755 },
+  );
+}
+
 function runSync(target = "openclaw"): { status: number | null; stdout: string; stderr: string } {
   const result = spawnSync("bash", [SCRIPT, target], {
     encoding: "utf-8",
@@ -76,7 +103,7 @@ afterEach(() => {
 describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
   it("succeeds when the gateway restart worked", () => {
     installFake("sudo", 0);
-    installFake("systemctl", 0);
+    installSystemctl("running", 0);
 
     const run = runSync();
     expect(run.status).toBe(0);
@@ -88,7 +115,7 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
     // disk changed and the running agent did not, which is the one outcome
     // that must not be reported as a completed sync.
     installFake("sudo", 1);
-    installFake("systemctl", 1);
+    installSystemctl("running", 1);
 
     const run = runSync();
     expect(run.status).not.toBe(0);
@@ -98,11 +125,46 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
 
   it("falls back to the user unit when sudo is refused", () => {
     installFake("sudo", 1);
-    installFake("systemctl", 0);
+    installSystemctl("running", 0);
 
     const run = runSync();
     expect(run.status).toBe(0);
     expect(run.stdout).toContain("[identity-sync] done");
+  }, SHELL_TIMEOUT_MS);
+
+  it("skips, rather than fails, when systemctl exists but no manager does", () => {
+    // A container ships /usr/bin/systemctl with nothing behind it. Failing here
+    // would 502 the harness switch on a host that has no running gateway to
+    // refresh at all - the false-FAILURE twin of the bug this file fixes.
+    installFake("sudo", 1);
+    installSystemctl("offline", 1);
+
+    const run = runSync();
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("no systemd manager on this host");
+    expect(run.stdout).toContain("[identity-sync] done");
+  }, SHELL_TIMEOUT_MS);
+
+  it("treats a systemctl that cannot reach the bus at all as no manager", () => {
+    installFake("sudo", 1);
+    installSystemctl("", 1);
+
+    const run = runSync();
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("no systemd manager on this host");
+  }, SHELL_TIMEOUT_MS);
+
+  it("still FAILS on a DEGRADED systemd whose restart was refused", () => {
+    // `is-system-running` exits non-zero for `degraded`, which is an everyday
+    // state on these devices with a real manager running. Reading the exit
+    // status instead of the word would route every degraded box into the skip
+    // above and hand back the exact silence this change removes.
+    installFake("sudo", 1);
+    installSystemctl("degraded", 1);
+
+    const run = runSync();
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toMatch(/could not restart clawbox-gateway/);
   }, SHELL_TIMEOUT_MS);
 
   it("does not refresh — or fail — when the target harness is Hermes", () => {
@@ -110,7 +172,7 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
     // the target argument exists to prevent, so a dead systemctl is irrelevant
     // here and must not fail the switch.
     installFake("sudo", 1);
-    installFake("systemctl", 1);
+    installSystemctl("running", 1);
 
     const run = runSync("hermes");
     expect(run.status).toBe(0);

--- a/src/tests/unit/identity-sync.test.ts
+++ b/src/tests/unit/identity-sync.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * These run the SHIPPED script — scripts/clawbox-identity-sync.sh — against a
+ * fake systemd, because the bug is not in what it does but in what it REPORTS.
+ *
+ * For OpenClaw the gateway restart IS the sync: the canonical SOUL/USER/MEMORY
+ * files are copied into ~/.openclaw/workspace, and the gateway scanned and
+ * cached that directory when it started, so until it restarts OpenClaw keeps
+ * answering as whoever it was before. The restart line used to end in
+ * `|| true`, so a box where it did not happen printed "[identity-sync] done"
+ * and exited 0 — and /setup-api/harness/select, which refuses to complete a
+ * switch when this script fails, could never fire.
+ */
+
+/**
+ * Each case spawns a real bash and two fake binaries. That is milliseconds on
+ * Linux and seconds on a Windows dev box, so the budget is generous — nothing
+ * here is timing-dependent, only process-spawn-bound.
+ */
+const SHELL_TIMEOUT_MS = 30_000;
+
+const REPO = process.cwd();
+const SCRIPT = path.join(REPO, "scripts", "clawbox-identity-sync.sh");
+
+let home: string;
+let binDir: string;
+
+/** A stand-in for one command on PATH, with the exit status we want from it. */
+function installFake(name: string, exitCode: number): void {
+  writeFileSync(
+    path.join(binDir, name),
+    ["#!/usr/bin/env bash", `exit ${exitCode}`].join("\n"),
+    { mode: 0o755 },
+  );
+}
+
+function runSync(target = "openclaw"): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync("bash", [SCRIPT, target], {
+    encoding: "utf-8",
+    cwd: REPO,
+    env: {
+      ...process.env,
+      // binDir goes FIRST, and every test installs a fake for both `sudo` and
+      // `systemctl`, so the host's real ones are unreachable whatever else is
+      // on the inherited PATH.
+      PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+      HOME: home,
+    } as unknown as NodeJS.ProcessEnv,
+  });
+  return { status: result.status, stdout: result.stdout ?? "", stderr: result.stderr ?? "" };
+}
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(tmpdir(), "clawbox-identity-"));
+  binDir = path.join(home, "bin");
+  mkdirSync(binDir, { recursive: true });
+
+  // The canonical identity, and an OpenClaw workspace to copy it into.
+  const canon = path.join(home, ".clawbox", "agent-identity");
+  mkdirSync(canon, { recursive: true });
+  mkdirSync(path.join(home, ".openclaw", "workspace"), { recursive: true });
+  for (const f of ["SOUL", "USER", "MEMORY"]) {
+    writeFileSync(path.join(canon, `${f}.md`), `# ${f}\n`, "utf-8");
+  }
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
+  it("succeeds when the gateway restart worked", () => {
+    installFake("sudo", 0);
+    installFake("systemctl", 0);
+
+    const run = runSync();
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("[identity-sync] done");
+  }, SHELL_TIMEOUT_MS);
+
+  it("FAILS when neither systemctl form could restart the gateway", () => {
+    // Both the system unit (via sudo) and the user unit refuse. The files on
+    // disk changed and the running agent did not, which is the one outcome
+    // that must not be reported as a completed sync.
+    installFake("sudo", 1);
+    installFake("systemctl", 1);
+
+    const run = runSync();
+    expect(run.status).not.toBe(0);
+    expect(run.stdout).not.toContain("[identity-sync] done");
+    expect(run.stderr).toMatch(/could not restart clawbox-gateway/);
+  }, SHELL_TIMEOUT_MS);
+
+  it("falls back to the user unit when sudo is refused", () => {
+    installFake("sudo", 1);
+    installFake("systemctl", 0);
+
+    const run = runSync();
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("[identity-sync] done");
+  }, SHELL_TIMEOUT_MS);
+
+  it("does not refresh — or fail — when the target harness is Hermes", () => {
+    // Bouncing the gateway on a switch AWAY from OpenClaw is the harmful case
+    // the target argument exists to prevent, so a dead systemctl is irrelevant
+    // here and must not fail the switch.
+    installFake("sudo", 1);
+    installFake("systemctl", 1);
+
+    const run = runSync("hermes");
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("[identity-sync] done");
+  }, SHELL_TIMEOUT_MS);
+});

--- a/src/tests/unit/identity-sync.test.ts
+++ b/src/tests/unit/identity-sync.test.ts
@@ -40,25 +40,36 @@ function installFake(name: string, exitCode: number): void {
 }
 
 /**
- * A fake systemctl that answers `is-system-running` and every other verb
- * separately, because the script has to tell those two apart.
+ * A fake systemctl that answers `is-system-running` per SCOPE, and every other
+ * verb with one status — because the script has to tell those apart, and
+ * because it tries the system unit and the `--user` unit in turn.
  *
- * @param manager what `is-system-running` PRINTS. `"offline"` — or nothing at
- *   all — is a container carrying the binary with no manager behind it;
- *   `"degraded"` is a real, running systemd that happens to exit non-zero, an
- *   ordinary state on these devices and the reason the script reads the word
- *   rather than the status.
+ * @param scopes what `is-system-running` PRINTS for each scope. `"offline"` —
+ *   or `""`, no answer at all — is a manager that is not there; `"degraded"` is
+ *   a real, running systemd that happens to exit non-zero, an ordinary state on
+ *   these devices and the reason the script reads the word rather than the
+ *   status.
  * @param verbExit what every other verb returns.
  */
-function installSystemctl(manager: string, verbExit: number): void {
+function installSystemctl(
+  scopes: { system: string; user?: string },
+  verbExit: number,
+): void {
+  const user = scopes.user ?? scopes.system;
+  const answer = (state: string) => [
+    state ? `  echo ${state}` : '  echo "Failed to connect to bus" >&2',
+    // `running` is the only state systemd itself exits 0 for.
+    state === "running" ? "  exit 0" : "  exit 1",
+  ];
   writeFileSync(
     path.join(binDir, "systemctl"),
     [
       "#!/usr/bin/env bash",
+      'if [ "$1" = "--user" ] && [ "$2" = "is-system-running" ]; then',
+      ...answer(user),
+      "fi",
       'if [ "$1" = "is-system-running" ]; then',
-      manager ? `  echo ${manager}` : '  echo "Failed to connect to bus" >&2',
-      // `running` is the only state systemd itself exits 0 for.
-      manager === "running" ? "  exit 0" : "  exit 1",
+      ...answer(scopes.system),
       "fi",
       `exit ${verbExit}`,
     ].join("\n"),
@@ -103,7 +114,7 @@ afterEach(() => {
 describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
   it("succeeds when the gateway restart worked", () => {
     installFake("sudo", 0);
-    installSystemctl("running", 0);
+    installSystemctl({ system: "running" }, 0);
 
     const run = runSync();
     expect(run.status).toBe(0);
@@ -115,7 +126,7 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
     // disk changed and the running agent did not, which is the one outcome
     // that must not be reported as a completed sync.
     installFake("sudo", 1);
-    installSystemctl("running", 1);
+    installSystemctl({ system: "running" }, 1);
 
     const run = runSync();
     expect(run.status).not.toBe(0);
@@ -125,7 +136,7 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
 
   it("falls back to the user unit when sudo is refused", () => {
     installFake("sudo", 1);
-    installSystemctl("running", 0);
+    installSystemctl({ system: "running" }, 0);
 
     const run = runSync();
     expect(run.status).toBe(0);
@@ -137,7 +148,7 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
     // would 502 the harness switch on a host that has no running gateway to
     // refresh at all - the false-FAILURE twin of the bug this file fixes.
     installFake("sudo", 1);
-    installSystemctl("offline", 1);
+    installSystemctl({ system: "offline", user: "offline" }, 1);
 
     const run = runSync();
     expect(run.status).toBe(0);
@@ -147,11 +158,25 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
 
   it("treats a systemctl that cannot reach the bus at all as no manager", () => {
     installFake("sudo", 1);
-    installSystemctl("", 1);
+    installSystemctl({ system: "", user: "" }, 1);
 
     const run = runSync();
     expect(run.status).toBe(0);
     expect(run.stdout).toContain("no systemd manager on this host");
+  }, SHELL_TIMEOUT_MS);
+
+  it("FAILS when the system manager is offline but a live USER manager refused", () => {
+    // restart_openclaw_gateway tries the system unit AND the --user unit, so
+    // "no manager" has to mean neither. A reachable user manager that rejected
+    // the unit has REFUSED the refresh, not skipped it, and calling that a skip
+    // would put the silence back one level up.
+    installFake("sudo", 1);
+    installSystemctl({ system: "offline", user: "running" }, 1);
+
+    const run = runSync();
+    expect(run.status).not.toBe(0);
+    expect(run.stdout).not.toContain("no systemd manager on this host");
+    expect(run.stderr).toMatch(/could not restart clawbox-gateway/);
   }, SHELL_TIMEOUT_MS);
 
   it("still FAILS on a DEGRADED systemd whose restart was refused", () => {
@@ -160,7 +185,7 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
     // status instead of the word would route every degraded box into the skip
     // above and hand back the exact silence this change removes.
     installFake("sudo", 1);
-    installSystemctl("degraded", 1);
+    installSystemctl({ system: "degraded" }, 1);
 
     const run = runSync();
     expect(run.status).not.toBe(0);
@@ -172,7 +197,7 @@ describe("clawbox-identity-sync.sh — the OpenClaw gateway refresh", () => {
     // the target argument exists to prevent, so a dead systemctl is irrelevant
     // here and must not fail the switch.
     installFake("sudo", 1);
-    installSystemctl("running", 1);
+    installSystemctl({ system: "running" }, 1);
 
     const run = runSync("hermes");
     expect(run.status).toBe(0);


### PR DESCRIPTION
Three instances of one shape: **the answer is built from the fact that a call returned, not from what it returned.**

## 1. `src/lib/cloudflared.ts` — the OFF that comes back at the next boot

Turning Remote Access on or off is **two** systemctl calls: the unit's state now, and the same intent recorded for the next boot. `config/clawbox-sudoers` grants no `--now` variant for `clawbox-tunnel` (unlike `setEngineEnabled` and `startOllamaService`, which get one command and report honestly), so they fail independently — and `enable`/`disable` was swallowed into a `console.warn` behind a `void` return.

A `disable` that failed leaves a box that **goes back to publishing a public `*.trycloudflare.com` address at the next power cycle**, after its owner switched Remote Access off and was told it worked — answered with bytes identical to a clean stop.

The lib now returns a verdict; both portal routes carry it in their 200 (**still** 200 — the unit *is* in the requested state, and calling that a failure would be the opposite lie); the Remote Control panel shows it.

## 2. `src/app/setup-api/system/hotspot/route.ts` — one boolean for three outcomes

`{ success: true, apRestarted: false }` was the answer to a **deliberate deferral** (the radio is a client, so bouncing the AP would sever the request's own connection), a **clean stop**, and a toggle that **threw**. Callers could not tell them apart, so a box whose hotspot did not change was reported to its owner as "Settings saved!".

The route now names the verdict (`apAction: "restarted" | "deferred" | "stopped" | "failed"`) and a failure carries a `warning`. `apRestarted` is **kept** and derived from it, because the wizard's reconnect handoff genuinely asks "did this connection just drop".

The GET's 3-second cache is also invalidated on write — it was long enough to answer the reload that follows a save with the settings it just replaced.

## 3. `scripts/clawbox-identity-sync.sh` — `|| true` on the line that *is* the sync

For OpenClaw the gateway restart is not a nicety attached to the sync, it **is** the sync: the canonical `SOUL`/`USER`/`MEMORY` files are copied into a workspace the gateway scanned and cached at start. The line ended `|| true`, so a box where the restart did not happen printed `[identity-sync] done` and exited 0 — and `/setup-api/harness/select`, which refuses to complete a switch when this script fails, **could never fire**. Its careful 502 was unreachable code.

It now fails, while still distinguishing a host with no systemd at all (a dev checkout — nothing was left undone) from a restart that was tried and refused.

## Sibling call sites

Every caller, not the three named:

| Surface | Callers | What changed |
|---|---|---|
| `start`/`stopTunnelService` | `portal/start`, `portal/stop` | carry the verdict in the 200 |
| | `portal/heartbeat-tick` | **reads** it, logs rather than surfaces it — that path restarts a unit that was already running, so it was already enabled, and no owner is watching a timer |
| | `RemoteControlPanel` | shows it |
| POST `/setup-api/system/hotspot` | `CredentialsStep` (wizard) | shows the warning, stops auto-advancing past it |
| | `SettingsApp` × 3 (toggle, SSID save, password save) | all three read the same verdict through one helper. The toggle is the sharpest: it used to flip to "off" over a radio that was still broadcasting |
| `clawbox-identity-sync.sh` | `harness/select` | unchanged — it was already correct, and this is what makes its guard reachable |

Deliberately **not** changed, and why:

* **`local-models.ts` `setEngineEnabled`** and **`local-ai-runtime.ts` `startOllamaService`** — the other `enable`/`disable` sites. Both issue a single atomic `enable --now` / `disable --now` and either return a `ToggleResult` or throw. Correct as-is; they are the pattern `cloudflared` now matches.
* **`scripts/nm-dispatcher-failover.sh`** restarts `clawbox-gateway` with a swallow too, but for network failover, not identity — different contract, out of scope here.
* The 500-on-`stop`-failure path in `portal/stop` — unchanged. A failed `stop` still throws.

`src/tests/unit/false-success-call-sites.test.ts` encodes the rule so the *next* caller of either surface cannot quietly ignore the verdict, which is how this class of defect keeps getting in.

## RED → GREEN

New and updated tests against **unmodified `beta` sources** (tests kept, sources reverted):

```
❯ src/tests/unit/cloudflared.test.ts                        (5 failed)
❯ src/tests/routes/portal.test.ts                           (4 failed)
❯ src/tests/routes/system/hotspot.test.ts                   (6 failed)
❯ src/tests/components/remote-control-boot-persist.test.tsx (1 failed)
❯ src/tests/components/credentials-hotspot-ap-failure.tsx   (2 failed)
❯ src/tests/unit/identity-sync.test.ts                      (1 failed)

Tests  19 failed | 49 passed
```

(one of those 19, `isInstalled > not executable`, is a pre-existing Windows-only `X_OK` artifact of the dev box and fails on `beta` too)

With the fix:

```
Test Files  8 passed
     Tests  86 passed  (1 = the same pre-existing X_OK case)
```

`bash scripts/check-sudoers-coverage.sh` — OK, 48 grants, 46 resolved sudo invocations, 0 gaps. That check is why `persistTunnelIntent` takes a thunk rather than the verb: sudo matches argv exactly, and a `verb` parameter made both the grant and the static check unresolvable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tunnel start and stop actions now report reboot-persistence status and warnings.
  * Remote-control screens display persistence warnings after successful actions.
  * Hotspot settings distinguish saved configuration from restart, deferral, and failure outcomes.
  * Hotspot warnings preserve saved settings and prevent premature setup advancement.
  * Status refreshes immediately after hotspot changes, including reconnect handoffs.

* **Bug Fixes**
  * Gateway restart failures are now reported instead of silently ignored.
  * Gateway restart handling falls back to user-level services when available.

* **Tests**
  * Added coverage for tunnel persistence, hotspot outcomes, setup handoffs, and gateway restart behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->