### PR TITLE
fix: stop reading a hardcoded field as whatsapp enablement

### DIFF
--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -56,6 +56,18 @@ const RPC_SPAWN_TIMEOUT_MS = 90_000;
 const LOGIN_WAIT_MS = 25_000;
 /** Bound on `web.login.start`, which returns as soon as there is a QR. */
 const LOGIN_START_MS = 30_000;
+/**
+ * Headroom the RPC round trip gets over the method's own budget.
+ *
+ * `--timeout` bounds the transport; `params.timeoutMs` is how long the gateway
+ * may spend producing the answer. Setting them equal is a race the caller
+ * loses: `startWebLoginWithQr` is allowed the full window to produce the first
+ * QR, and a transport deadline that expires in the same instant abandons the
+ * call exactly as the answer is handed over — reported to the owner as
+ * `start_failed` for a login that worked. A Jetson is precisely where that
+ * window gets used up.
+ */
+const RPC_HEADROOM_MS = 5_000;
 
 /** Phases, identical to the Hermes pairing manager's — one panel renders both. */
 export type WhatsappPairPhase =
@@ -111,9 +123,14 @@ interface WebLoginResult {
 /**
  * Call one gateway RPC method through the CLI.
  *
- * `openclaw gateway call` prints the method's result object with `ok` merged
- * into it on success, and `{ok:false, error:{...}}` on failure — so `ok` is the
- * discriminator, not the presence of a `result` wrapper.
+ * With `--json`, `openclaw gateway call` prints the method's RESULT OBJECT and
+ * nothing else on success — there is no `ok` wrapper to unwrap and no `result`
+ * key to reach through. On failure it writes an error payload and exits 1, so
+ * the failure arrives here as a rejection from `spawnOpenclawCli` carrying that
+ * text, which is what `isProviderMissing` matches against.
+ *
+ * The `ok === false` check below is therefore belt-and-braces for a build that
+ * reports a refusal on exit 0, not the normal path.
  */
 async function gatewayCall(
   method: string,
@@ -236,7 +253,7 @@ export class OpenclawWhatsappPairing {
       const result = await gatewayCall(
         "web.login.start",
         { force: opts.force === true, timeoutMs: LOGIN_START_MS },
-        LOGIN_START_MS,
+        LOGIN_START_MS + RPC_HEADROOM_MS,
       );
       if (epoch !== this.epoch) return this.peek();
       this.apply(result);
@@ -332,7 +349,7 @@ export class OpenclawWhatsappPairing {
           timeoutMs: LOGIN_WAIT_MS,
           ...(this.snap.qrImage ? { currentQrDataUrl: this.snap.qrImage } : {}),
         },
-        LOGIN_WAIT_MS + 5_000,
+        LOGIN_WAIT_MS + RPC_HEADROOM_MS,
       );
       // Discard an answer that belongs to a session which has since been
       // replaced or stopped.
@@ -399,7 +416,27 @@ export async function readOpenclawWhatsappStatus(): Promise<OpenclawWhatsappStat
   // `lastError: "not linked"`.
   const paired = row.linked === true;
   const connected = row.connected === true;
-  const enabled = row.enabled === true || row.configured === true || row.running === true;
+  // `configured` is deliberately NOT in this disjunction, and leaving it in was
+  // the same mistake one field over. The plugin hardcodes it:
+  //
+  //   resolveAccountSnapshot: async ({ account, runtime }) => ({
+  //     accountId, name, enabled: account.enabled,
+  //     configured: true,                      // <- @openclaw/whatsapp 2026.7.1
+  //     extra: { statusState: authState, linked, connected, ... },
+  //   })
+  //
+  // and that snapshot IS the per-account row `channels status --json` publishes
+  // (createAsyncComputedAccountStatusAdapter maps it onto the host's
+  // `status.buildAccountSnapshot`). So `configured === true` on every WhatsApp
+  // row there has ever been, including one the owner has just switched off —
+  // which made this report the channel enabled, and the card "paired", for a
+  // channel receiving nothing.
+  //
+  // `enabled` is the plugin's real answer (`account.enabled && cfg.web?.enabled
+  // !== false`). `running` stays because a channel the gateway is actually
+  // running is enabled whatever the config says; it is an observation, not a
+  // constant.
+  const enabled = row.enabled === true || row.running === true;
 
   return {
     state: !enabled ? "not_configured" : paired ? "paired" : "enabled_not_paired",

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -58,6 +58,40 @@ describe("OpenclawWhatsappPairing", () => {
     expect(mockSpawn.mock.calls[0][0].slice(0, 3)).toEqual(["gateway", "call", "web.login.start"]);
   });
 
+  /** `--timeout <ms>` as it was handed to the CLI, and the method's own budget. */
+  function budgets(call: number): { rpc: number; method: number } {
+    const args = mockSpawn.mock.calls[call][0] as string[];
+    return {
+      rpc: Number(args[args.indexOf("--timeout") + 1]),
+      method: Number(JSON.parse(String(args[args.indexOf("--params") + 1])).timeoutMs),
+    };
+  }
+
+  it("gives the transport more time than the method it is carrying", async () => {
+    // `--timeout` bounds the RPC round trip; `params.timeoutMs` is how long the
+    // gateway itself may spend producing the answer. Equal budgets race: a QR
+    // that takes the whole window is abandoned by the caller at the moment the
+    // gateway is handing it over, and the panel says `start_failed` for a login
+    // that worked. A Jetson is exactly where that window is used up.
+    //
+    // The wait call already reserves headroom; the start call did not.
+    vi.useFakeTimers();
+    try {
+      mockSpawn.mockResolvedValue(rpcOk({ qrDataUrl: QR_A }));
+      const pairing = new lib.OpenclawWhatsappPairing();
+      await pairing.start();
+
+      const start = budgets(0);
+      expect(start.rpc).toBeGreaterThan(start.method);
+
+      await vi.advanceTimersByTimeAsync(lib.TICK_MS + 1);
+      const wait = budgets(1);
+      expect(wait.rpc).toBeGreaterThan(wait.method);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("reports a completed link as paired, with the restart still pending", async () => {
     mockSpawn.mockResolvedValueOnce(rpcOk({ connected: true }));
 
@@ -313,6 +347,62 @@ describe("readOpenclawWhatsappStatus", () => {
       row({ enabled: false, configured: false, linked: false, connected: false, running: false }),
     );
     expect((await lib.readOpenclawWhatsappStatus()).state).toBe("not_configured");
+  });
+
+  // `configured` is not a fact about this channel — the plugin HARDCODES it.
+  //
+  //   resolveAccountSnapshot: async ({ account, runtime }) => ({
+  //     accountId, name, enabled: account.enabled,
+  //     configured: true,                       // <- @openclaw/whatsapp 2026.7.1
+  //     extra: { statusState: authState, linked, connected, ... },
+  //   })
+  //
+  // and that snapshot is exactly what `channels status --json` publishes as the
+  // per-account row (createAsyncComputedAccountStatusAdapter maps it to the
+  // host's `status.buildAccountSnapshot`). So every real WhatsApp row carries
+  // `configured: true` — including one the owner has just switched off.
+  //
+  // The fixture above cannot happen on a device: it pairs `enabled: false` with
+  // `configured: false`, and the gateway never says that. These two cases use
+  // the shape it does say.
+  it("believes the channel is off when the gateway's own enabled flag says so", async () => {
+    // Straight after Settings -> WhatsApp -> off. `enabled` is the plugin's
+    // real answer (isEnabled: account.enabled && cfg.web?.enabled !== false);
+    // `configured: true` is the constant beside it.
+    mockChannel.mockResolvedValue(
+      row({ enabled: false, configured: true, linked: false, connected: false, running: false }),
+    );
+
+    const status = await lib.readOpenclawWhatsappStatus();
+
+    expect(status.enabled).toBe(false);
+    expect(status.state).toBe("not_configured");
+  });
+
+  it("does not report a switched-off channel as paired because a phone is still linked", async () => {
+    // The worst version of the same shape: the owner turned WhatsApp off but
+    // the linked device is still on disk. Reading `configured` as enablement
+    // put the card back at "paired"/active for a channel receiving nothing —
+    // the false-success class, one field over from the one #548 removed.
+    mockChannel.mockResolvedValue(
+      row({ enabled: false, configured: true, linked: true, connected: false, running: false }),
+    );
+
+    const status = await lib.readOpenclawWhatsappStatus();
+
+    expect(status.enabled).toBe(false);
+    expect(status.state).toBe("not_configured");
+  });
+
+  it("still trusts a running channel that forgot to say it was enabled", async () => {
+    // `running` stays in the disjunction on purpose: a channel the gateway is
+    // actually running is enabled, whatever the config row claims. Only
+    // `configured` is dropped, because only `configured` is a constant.
+    mockChannel.mockResolvedValue(
+      row({ enabled: false, configured: true, linked: true, connected: true, running: true }),
+    );
+
+    expect((await lib.readOpenclawWhatsappStatus()).state).toBe("paired");
   });
 
   it("never invents a link when the gateway could not be asked", async () => {


### PR DESCRIPTION
## What this is

Two residuals from #548, both found by reading `@openclaw/whatsapp@2026.7.1` and `openclaw@2026.7.1-2` themselves rather than by re-testing the panel. Neither is visible from the ClawBox side alone, which is why they got through.

## 1. `configured` is not a fact about the channel — the plugin hardcodes it

```ts
const enabled = row.enabled === true || row.configured === true || row.running === true;
```

`@openclaw/whatsapp` publishes its per-account row like this:

```js
resolveAccountSnapshot: async ({ account, runtime }) => ({
  accountId: account.accountId,
  name: account.name,
  enabled: account.enabled,
  configured: true,                    // <- constant
  extra: { statusState: authState, linked, connected, ... },
})
```

and that snapshot *is* the row `channels status --json` publishes: `createAsyncComputedAccountStatusAdapter` maps `resolveAccountSnapshot` onto the host's `status.buildAccountSnapshot`, which `buildChannelAccountSnapshot` calls for every account in `channelAccounts`. `readChannelRow` prefers exactly that row.

So `row.configured` is `true` on every WhatsApp row there has ever been, and the disjunction made `enabled` unconditionally true whenever a row existed at all.

**What the owner saw.** Turn WhatsApp off in Settings, reload the card: it says the channel is on. With the linked device still on disk it says **paired**, for a channel that is receiving nothing. `state` could never return to `not_configured` once a `channels.whatsapp` account existed. That is the same false-state class #548 removed one field over — `configured` read as *paired* — reappearing as `configured` read as *enabled*.

`enabled` is the plugin's real answer (`isEnabled: (account, cfg) => account.enabled && cfg.web?.enabled !== false`), and it is already in the row. `running` stays in the disjunction on purpose: a channel the gateway is actually running is enabled whatever the config claims — that one is an observation, not a constant. Only `configured` goes.

### Why the existing test did not catch it

```ts
row({ enabled: false, configured: false, linked: false, connected: false, running: false })
```

That row cannot occur. The gateway never pairs `enabled: false` with `configured: false` for this channel, because `configured` is the constant above. The two new cases use the shape it does emit — `enabled: false, configured: true` — one with the phone unlinked and one with it still linked.

## 2. `web.login.start` had no headroom over the method it was carrying

```ts
gatewayCall("web.login.start", { force, timeoutMs: LOGIN_START_MS }, LOGIN_START_MS)
```

`--timeout` bounds the RPC round trip; `params.timeoutMs` is how long the gateway may spend producing the answer. Equal budgets race, and the caller loses: `startWebLoginWithQr` is allowed the full window for the first QR (`resolveWhatsAppLoginTimeoutMs(opts.timeoutMs, 30_000, 5_000)`), and a transport deadline expiring in the same instant abandons the call exactly as the answer is handed over. The panel then says `start_failed` for a login that worked — on a Jetson, which is the machine where that window actually gets used.

The `wait` call already reserved 5 s. Both now share one named `RPC_HEADROOM_MS`, and a test asserts the relationship for both calls rather than the two literals.

## 3. Comment correction (no behaviour change)

`gatewayCall`'s doc said the CLI "prints the method's result object with `ok` merged into it on success, and `{ok:false, …}` on failure". With `--json` it prints `writeJson(result)` — the result object, no `ok` — and on failure it writes an error payload and **exits 1**, so the failure reaches us as a `spawnOpenclawCli` rejection, which is what `isProviderMissing` actually matches against. The `ok === false` branch is kept as belt-and-braces and now says so, rather than describing itself as the normal path.

## Tests

RED-first, against unmodified `origin/beta` (i.e. with #548 merged):

- **RED: 3 failed / 20 passed (23)**
- **GREEN: 23 passed (23)**

Wider run over the WhatsApp and channel-plugin suites: **152 passed (7 files)**.

## Checks

- `tsc --noEmit`: **24 errors, all pre-existing on beta, none in the changed file**
- `eslint` on both changed files: **0 problems**

## Not verified on hardware

The 192.168.50.x network was unreachable from this machine for the whole session, so neither finding was reproduced on a box. Both are read off the shipped plugin/host sources and are quoted above; the fixes are small and the tests pin the row shapes the plugin emits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WhatsApp login reliability by adding extra timeout headroom during pairing.
  - Corrected WhatsApp status reporting for disabled channels, including linked phones.
  - Running channels are now correctly recognized as paired when appropriate.
  - Updated gateway-call behavior to clearly reflect direct results and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->