### PR TITLE
perf(ci): fail the install harness fast, take the sleeps out of the unit suite, write only the coverage CI reads

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -25,7 +25,7 @@ jobs:
       # Cache Playwright browser binaries between runs (~250MB Chromium download).
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package.json') }}
@@ -51,7 +51,7 @@ jobs:
       # to disk unless experimental.turbopackFileSystemCacheForBuild is on; this
       # step is where that cache would land too, once it is enabled.)
       - name: Cache Next.js build cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .next/cache
           key: nextjs-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('src/**', 'public/**', 'next.config.ts', 'tsconfig.json') }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -39,6 +39,25 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit == 'true'
         run: bunx playwright install-deps chromium
 
+      # `next build` (run by playwright.config.ts's webServer) keeps its
+      # incremental state in .next/cache; restoring it lets the build's type
+      # check pick up where the last run left off instead of checking every
+      # file from scratch. The key names every build input, so an exact hit is
+      # a cache for these very sources; restore-keys fall back to the newest
+      # cache for the same lockfile, which is still valid — the compiler
+      # verifies each cached file against the source it sees, so a stale entry
+      # is recomputed, never trusted. Saved after the job by actions/cache.
+      # (Next 16 builds with Turbopack, whose own compiler cache is not written
+      # to disk unless experimental.turbopackFileSystemCacheForBuild is on; this
+      # step is where that cache would land too, once it is enabled.)
+      - name: Cache Next.js build cache
+        uses: actions/cache@v6
+        with:
+          path: .next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('src/**', 'public/**', 'next.config.ts', 'tsconfig.json') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('bun.lock') }}-
+
       - name: Run E2E tests with coverage
         id: e2e
         run: bun run test:e2e:coverage

--- a/.github/workflows/pr-tests-coverage.yml
+++ b/.github/workflows/pr-tests-coverage.yml
@@ -36,8 +36,15 @@ jobs:
       - name: Sudoers allow-list coverage
         run: bun run check:sudoers
 
+      # CI's variant of `bun run test:coverage`: the same suite, the same
+      # thresholds, only the reporters differ. The full set (text, html, clover,
+      # json-summary) is for a person looking at a checkout; here nothing reads
+      # the ~550-file html tree, the clover XML or the text table — the only
+      # consumer is "Parse coverage" below, which reads coverage-summary.json.
+      # Writing the other ~590 files and printing the table bought nothing but a
+      # few seconds and 600 lines of job log nobody scrolls through.
       - name: Test
-        run: bun run test:coverage
+        run: bun run test:coverage:ci
 
       # Always parse coverage so the PR comment can show numbers even on failure.
       - name: Parse coverage
@@ -53,6 +60,8 @@ jobs:
               w('branches',s.branches.pct);
               w('functions',s.functions.pct);
               w('lines',s.lines.pct);
+              // The text table no longer prints in CI, so leave the totals in the log.
+              console.log('coverage: statements '+s.statements.pct+'%, branches '+s.branches.pct+'%, functions '+s.functions.pct+'%, lines '+s.lines.pct+'%');
             "
           else
             echo "found=false" >> "$GITHUB_OUTPUT"

--- a/e2e-install/README.md
+++ b/e2e-install/README.md
@@ -74,7 +74,15 @@ Expect ~15-25 min for the first run on x86 (qemu slowdown dominates).
 Subsequent runs with `CLAWBOX_E2E_SKIP_SETUP=1` are fast.
 
 On real Jetson hardware (arm64 host), no emulation is needed and the full
-run finishes in ~3-5 min.
+run finishes in ~3-5 min. On the native arm64 CI runner a green run measures
+~6-7 min end to end (PR #558).
+
+A broken install fails fast: `waitForInstallComplete()` asks systemd on every
+poll whether `clawbox-bootstrap.service` has failed and gives up within one
+5-second poll of that, with the tail of the install log in the error — before
+this, a bootstrap that exited at minute 3 was reported at the 40-minute
+deadline (41 min on PR #558). The deadline stays as the backstop for an
+installer that hangs without failing.
 
 ## Real AI providers
 

--- a/e2e-install/global-setup.ts
+++ b/e2e-install/global-setup.ts
@@ -10,7 +10,14 @@
  * `docker compose -f e2e-install/docker-compose.test.yml down -v` after the
  * playwright run.
  */
-import { composeUp, waitForInstallComplete, readInstallLog, dockerExec } from "./helpers/container";
+import {
+  composeUp,
+  waitForInstallComplete,
+  readInstallLog,
+  dockerExec,
+  InstallBootstrapFailedError,
+  BOOTSTRAP_UNIT,
+} from "./helpers/container";
 
 const SKIP = process.env.CLAWBOX_E2E_SKIP_SETUP === "1";
 const REBUILD = process.env.CLAWBOX_E2E_REBUILD === "1";
@@ -26,12 +33,18 @@ export default async function globalSetup() {
     await waitForInstallComplete();
     console.log("[e2e-install] install complete");
   } catch (err) {
-    const log = await readInstallLog(500).catch(() => "(log unavailable)");
+    // The fail-fast error already carries the install-log tail in its
+    // message, which Playwright prints; dumping the log here as well would
+    // show it twice. The deadline path (installer hung, unit never failed)
+    // still gets the long dump, because that error has no log of its own.
+    if (!(err instanceof InstallBootstrapFailedError)) {
+      const log = await readInstallLog(500).catch(() => "(log unavailable)");
+      console.error("[e2e-install] install failed — last 500 lines of install log:\n" + log);
+    }
     const journal = await dockerExec(
-      ["bash", "-c", "journalctl -u clawbox-bootstrap.service --no-pager | tail -n 200"],
+      ["bash", "-c", `journalctl -u ${BOOTSTRAP_UNIT} --no-pager | tail -n 200`],
       { user: "root" },
     ).catch(() => "(journal unavailable)");
-    console.error("[e2e-install] install failed — last 500 lines of install log:\n" + log);
     console.error("[e2e-install] bootstrap journal:\n" + journal);
     throw err;
   }

--- a/e2e-install/helpers/container.ts
+++ b/e2e-install/helpers/container.ts
@@ -163,31 +163,181 @@ export async function waitForHttpReady(timeoutMs = 20 * 60_000): Promise<void> {
   throw new Error(`Container HTTP not ready after ${timeoutMs}ms: ${String(lastError)}`);
 }
 
+/** The systemd unit that runs install.sh on first boot (e2e-install/clawbox-bootstrap.service). */
+export const BOOTSTRAP_UNIT = "clawbox-bootstrap.service";
+/** Removed by the bootstrap unit only after install.sh exited 0 (see its ExecStart). */
+export const INSTALL_MARKER = "/home/clawbox/clawbox/.needs-install";
+export const INSTALL_LOG = "/var/log/clawbox-install.log";
+const INSTALL_POLL_MS = 5_000;
+
+export interface BootstrapUnitState {
+  /** systemd ActiveState: activating | active | failed | inactive | unknown. */
+  activeState: string;
+  /** systemd Result: success | exit-code | timeout | signal | ... | unknown. */
+  result: string;
+}
+
+/**
+ * Parse `systemctl show -p ActiveState -p Result <unit>` output. Property
+ * lines, not `--value`, because the order `--value` prints multiple
+ * properties in is not something we want to depend on across systemd
+ * versions; a missing property reads as "unknown", which is never "failed".
+ */
+export function parseUnitState(stdout: string): BootstrapUnitState {
+  const props = new Map<string, string>();
+  for (const line of stdout.split("\n")) {
+    const eq = line.indexOf("=");
+    if (eq > 0) props.set(line.slice(0, eq).trim(), line.slice(eq + 1).trim());
+  }
+  return {
+    activeState: props.get("ActiveState") || "unknown",
+    result: props.get("Result") || "unknown",
+  };
+}
+
+export type InstallVerdict = "done" | "failed" | "wait";
+
+/**
+ * The decision one poll of waitForInstallComplete makes, kept pure so the
+ * unit test can pin it without a container.
+ *
+ * "done" wins over "failed": the marker only disappears after install.sh
+ * exited 0, so a gone marker plus a live server is the success the harness
+ * has always accepted, whatever systemd says in that instant. A failed unit
+ * with the marker still present means install.sh has EXITED non-zero (or
+ * systemd timed it out) and nothing will ever remove the marker — waiting
+ * for the deadline can only add time, never information.
+ */
+export function classifyInstallState(state: {
+  markerGone: boolean;
+  httpReady: boolean;
+  unitFailed: boolean;
+}): InstallVerdict {
+  if (state.markerGone && state.httpReady) return "done";
+  if (state.unitFailed) return "failed";
+  return "wait";
+}
+
+/**
+ * Thrown by waitForInstallComplete the moment the bootstrap unit fails. It
+ * carries the tail of the install log so the cause is in the error Playwright
+ * prints, not only in a dump further down the job log; global-setup.ts knows
+ * this and does not print the log a second time for this error.
+ */
+export class InstallBootstrapFailedError extends Error {
+  readonly unit: BootstrapUnitState;
+  readonly installLogTail: string;
+
+  constructor(unit: BootstrapUnitState, installLogTail: string, elapsedMs: number) {
+    super(
+      `bootstrap failed: ${BOOTSTRAP_UNIT} is ${unit.activeState} (Result=${unit.result}) after ` +
+      `${Math.round(elapsedMs / 1000)}s — install.sh exited, or systemd stopped it (Result=${unit.result}), ` +
+      `without removing ${INSTALL_MARKER}, ` +
+      `so the install cannot complete; giving up now instead of at the deadline.\n` +
+      `Tail of ${INSTALL_LOG}:\n${installLogTail}`,
+    );
+    this.name = "InstallBootstrapFailedError";
+    this.unit = unit;
+    this.installLogTail = installLogTail;
+  }
+}
+
+/** What one poll of the install asks the container; swapped for fakes in the unit test. */
+export interface InstallProbes {
+  markerGone(): Promise<boolean>;
+  httpReady(): Promise<boolean>;
+  bootstrapUnit(): Promise<BootstrapUnitState>;
+  installLogTail(): Promise<string>;
+  sleep(ms: number): Promise<void>;
+  now(): number;
+}
+
+/**
+ * The real probes. Every one of them answers the conservative value when the
+ * container cannot be asked (docker exec failing, HTTP refused): "marker
+ * still there", "HTTP not ready", "unit state unknown". A transient docker
+ * hiccup must keep the loop waiting, never end it either way.
+ */
+export const dockerInstallProbes: InstallProbes = {
+  async markerGone() {
+    try {
+      await dockerExec(["test", "!", "-f", INSTALL_MARKER]);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  async httpReady() {
+    try {
+      const res = await fetch(`${BASE_URL}/setup-api/setup/status`, {
+        signal: AbortSignal.timeout(5_000),
+      });
+      return res.ok;
+    } catch {
+      return false;
+    }
+  },
+  async bootstrapUnit() {
+    try {
+      // `systemctl show` exits 0 whatever the state, so a non-zero exit here
+      // is docker or systemd itself being unreachable — reported as unknown.
+      const stdout = await dockerExec(
+        ["systemctl", "show", "-p", "ActiveState", "-p", "Result", BOOTSTRAP_UNIT],
+        { user: "root", timeoutMs: 15_000 },
+      );
+      return parseUnitState(stdout);
+    } catch {
+      return { activeState: "unknown", result: "unknown" };
+    }
+  },
+  // 500 lines, the same amount the deadline path's dump in global-setup shows:
+  // this tail REPLACES that dump for a bootstrap failure, and the cause of a
+  // failed install.sh is rarely in its last 200 lines.
+  installLogTail: () => readInstallLog(500),
+  sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+  now: () => Date.now(),
+};
+
 /**
  * Wait for install.sh to finish (marker file removed) AND HTTP to be ready.
  * The bootstrap service removes /home/clawbox/clawbox/.needs-install on
  * success; checking for its absence is more reliable than just probing HTTP
  * because the server technically comes up during the install (after the
  * `step_build` / `step_start_services` steps).
+ *
+ * Every poll also asks systemd whether the bootstrap unit has FAILED, and
+ * gives up at once when it has. Measured on PR #558: the unit exited 1 at
+ * ~3 min and this loop kept polling the marker until its 40-minute deadline,
+ * so the job took 41 minutes to report a failure it could have reported at
+ * minute 3. The deadline stays as the backstop for an installer that hangs
+ * without failing.
  */
-export async function waitForInstallComplete(timeoutMs = 40 * 60_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    try {
-      await dockerExec(["test", "!", "-f", "/home/clawbox/clawbox/.needs-install"]);
-      await waitForHttpReady(60_000);
-      return;
-    } catch {
-      // not done yet
+export async function waitForInstallComplete(
+  timeoutMs = 40 * 60_000,
+  probes: InstallProbes = dockerInstallProbes,
+): Promise<void> {
+  const started = probes.now();
+  const deadline = started + timeoutMs;
+  for (;;) {
+    const markerGone = await probes.markerGone();
+    // HTTP is only meaningful once the marker is gone; before that a live
+    // server is the installer's own mid-run start, not completion.
+    const httpReady = markerGone ? await probes.httpReady() : false;
+    const unit = await probes.bootstrapUnit();
+    const verdict = classifyInstallState({ markerGone, httpReady, unitFailed: unit.activeState === "failed" });
+    if (verdict === "done") return;
+    if (verdict === "failed") {
+      throw new InstallBootstrapFailedError(unit, await probes.installLogTail(), probes.now() - started);
     }
-    await new Promise((r) => setTimeout(r, 5_000));
+    if (probes.now() >= deadline) break;
+    await probes.sleep(INSTALL_POLL_MS);
   }
-  throw new Error(`install.sh did not finish within ${timeoutMs}ms`);
+  throw new Error(`install.sh did not finish within ${timeoutMs}ms (${BOOTSTRAP_UNIT} never reported failure)`);
 }
 
 export async function readInstallLog(tailLines = 200): Promise<string> {
   try {
-    return await dockerExec(["tail", `-n${tailLines}`, "/var/log/clawbox-install.log"]);
+    return await dockerExec(["tail", `-n${tailLines}`, INSTALL_LOG]);
   } catch {
     return "(install log not available)";
   }

--- a/e2e/helpers/clawbox.ts
+++ b/e2e/helpers/clawbox.ts
@@ -1634,6 +1634,21 @@ export async function openLauncher(page: Page) {
 
   const button = page.locator('[data-testid="shelf-launcher-button"]:visible').first();
   await waitForHydration(button);
-  await button.click({ force: true });
+  // Click until the launcher is actually there. A forced click can land in the
+  // gap between hydration and the shelf's handlers being wired (React attaches
+  // its root listener before every component has subscribed to it), and with
+  // a second browser competing for CPU that gap is wide enough to lose the
+  // click entirely — the old single click + 15 s wait was the one flake that
+  // kept the e2e job on one worker. Re-checking before each retry keeps a
+  // late-arriving open from being toggled shut by the next click.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    if (await launcher.isVisible().catch(() => false)) return;
+    await button.click({ force: true });
+    const shown = await launcher
+      .waitFor({ state: "visible", timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (shown) return;
+  }
   await expect(launcher).toBeVisible();
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:components": "vitest run --config vitest.config.ts --project components",
     "test:watch": "vitest --config vitest.config.ts",
     "test:coverage": "vitest run --config vitest.config.ts --coverage",
+    "test:coverage:ci": "vitest run --config vitest.config.ts --coverage --coverage.reporter=json-summary",
     "test:e2e": "playwright test",
     "test:e2e:coverage": "rm -f coverage/e2e-summary.json coverage/e2e-bundles.json && playwright test && node scripts/e2e-coverage-report.mjs",
     "test:e2e:ui": "playwright test --ui",

--- a/src/tests/components/setup-wizard.test.tsx
+++ b/src/tests/components/setup-wizard.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
+import { act, fireEvent, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import SetupWizard from "@/components/SetupWizard";
 import { resetHarnessCache } from "@/lib/client-harness";
@@ -68,6 +68,24 @@ vi.mock("@/components/StatusMessage", () => ({
   default: ({ message }: { message: string }) => <div>{message}</div>,
 }));
 
+// The completion overlay runs on real time: 0.9 s before the first phase, a
+// readiness poll of SETUP_COMPLETION_MAX_HEALTH_CHECKS (6) attempts 2 s apart,
+// and 2 s in the finished phase before onComplete. A device whose agent never
+// reports ready therefore takes ~15 s to finish — which two cases below wait
+// out for real, and a third waits ~3 s. Fake timers (advancing on their own so
+// RTL's waitFor and React's scheduler keep working, as elsewhere in this
+// suite) jump the clock instead; the phases, the attempt budget and the
+// interval are the wizard's own and are not changed here.
+const FIRST_PHASE_MS = 900;
+const HEALTH_POLL_BUDGET_MS = 6 * 2_000;
+const FINISHED_PHASE_MS = 2_000;
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
 function jsonResponse(data: unknown, ok = true): Response {
   return {
     ok,
@@ -83,7 +101,7 @@ function called(fetchMock: ReturnType<typeof vi.fn>, path: string): boolean {
 
 describe("SetupWizard", () => {
   beforeEach(() => {
-    vi.useRealTimers();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     // The edition is cached for the lifetime of a document; without this the
     // first test's answer would decide every later test's edition.
     resetHarnessCache();
@@ -201,17 +219,24 @@ describe("SetupWizard", () => {
 
     fireEvent.click(await screen.findByText("telegram-next"));
 
+    // The whole attempt budget has to run out first — an offline gateway must
+    // not end setup early, and must not stop it either.
+    await advance(FIRST_PHASE_MS + HEALTH_POLL_BUDGET_MS / 2);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await advance(HEALTH_POLL_BUDGET_MS / 2 + FINISHED_PHASE_MS);
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
-    }, { timeout: 30_000 });
+    });
 
     // An OpenClaw box still waits on its gateway, and never on the Hermes side.
     expect(called(fetchMock, "/setup-api/gateway/health")).toBe(true);
     expect(called(fetchMock, "/setup-api/hermes/models")).toBe(false);
-  }, 35_000);
+  });
 
   it("waits on the Hermes agent, not the OpenClaw gateway, on a hermes device", async () => {
     const onComplete = vi.fn();
+    let modelsCalls = 0;
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
       if (url === "/setup-api/setup/status") {
@@ -237,8 +262,16 @@ describe("SetupWizard", () => {
       }
       if (url === "/setup-api/hermes/models") {
         // `stale: false` is the models route's "the live Hermes dashboard
-        // answered" signal.
-        return jsonResponse({ stale: false, source: "dashboard", models: [] });
+        // answered" signal. It comes on the SECOND attempt: the copy under
+        // test is on screen only while the wizard is polling, and a first
+        // answer that is already ready ends the poll in the same tick the
+        // edition is resolved — there is nothing in between to look at.
+        modelsCalls += 1;
+        return jsonResponse(
+          modelsCalls === 1
+            ? { stale: true, source: "cold-start", models: [] }
+            : { stale: false, source: "dashboard", models: [] },
+        );
       }
 
       return jsonResponse({});
@@ -250,6 +283,9 @@ describe("SetupWizard", () => {
     fireEvent.click(await screen.findByText("telegram-next"));
 
     expect(await screen.findByTestId("setup-completion-overlay")).toBeInTheDocument();
+    // The edition is resolved once the first phase has passed, and the first
+    // poll has been answered "not yet".
+    await advance(FIRST_PHASE_MS);
     // The copy names the agent this device actually runs...
     await waitFor(() => {
       expect(screen.getByText("wizard.completionHermesTitle")).toBeInTheDocument();
@@ -262,13 +298,16 @@ describe("SetupWizard", () => {
     expect(screen.queryByText("telegram.waitingGateway")).not.toBeInTheDocument();
     expect(screen.queryByText("telegram.pleaseWait")).not.toBeInTheDocument();
 
+    // One poll interval to the answer that is ready, then the finished phase.
+    await advance(2_000 + FINISHED_PHASE_MS);
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
-    }, { timeout: 30_000 });
+    });
 
     expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
-    expect(called(fetchMock, "/setup-api/hermes/models")).toBe(true);
-  }, 35_000);
+    // Asked, told "not yet", asked again — and not a third time once ready.
+    expect(modelsCalls).toBe(2);
+  });
 
   it("still finishes on a hermes device whose agent never reports ready", async () => {
     const onComplete = vi.fn();
@@ -308,14 +347,18 @@ describe("SetupWizard", () => {
 
     fireEvent.click(await screen.findByText("telegram-next"));
 
+    await advance(FIRST_PHASE_MS + HEALTH_POLL_BUDGET_MS / 2);
+    expect(onComplete).not.toHaveBeenCalled();
+
+    await advance(HEALTH_POLL_BUDGET_MS / 2 + FINISHED_PHASE_MS);
     await waitFor(() => {
       expect(onComplete).toHaveBeenCalledTimes(1);
-    }, { timeout: 30_000 });
+    });
 
     // Both halves matter. The negative alone would also hold if the wizard
     // polled NOTHING — a different bug with the same symptom — so assert that
     // it did reach for the Hermes readiness signal and simply never got it.
     expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
     expect(called(fetchMock, "/setup-api/hermes/models")).toBe(true);
-  }, 35_000);
+  });
 });

--- a/src/tests/components/telegram-configuring-overlay.test.tsx
+++ b/src/tests/components/telegram-configuring-overlay.test.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@/tests/helpers/test-utils";
+import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import TelegramConfiguringOverlay from "@/components/TelegramConfiguringOverlay";
 import { resetHarnessCache } from "@/lib/client-harness";
 
@@ -14,6 +14,24 @@ vi.mock("@/lib/i18n", () => ({
   useT: () => ({ t: (key: string) => key, locale: "en", setLocale: vi.fn() }),
 }));
 
+// The overlay's choreography is real time: 1.5 s + 2.5 s + 2 s of fixed phases
+// before it polls at all, a 2 s poll interval, then 1.5 s in the ready phase —
+// 7.5 s per case, 10 s for the give-up case, ~25 s of sleeping for three cases
+// that assert nothing about wall-clock time. Fake timers (advancing on their
+// own so RTL's waitFor and React's scheduler keep working, as elsewhere in this
+// suite) let each case jump the clock past the whole sequence in one step; the
+// sequence itself, the poll count and the readiness rule are unchanged.
+//
+// The fixed phases, in ms, and the ready phase after a poll succeeds.
+const PHASES_MS = 1_500 + 2_500 + 2_000;
+const READY_PHASE_MS = 1_500;
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
 function jsonResponse(data: unknown): Response {
   return { ok: true, status: 200, json: async () => data } as Response;
 }
@@ -25,12 +43,13 @@ function called(fetchMock: ReturnType<typeof vi.fn>, path: string): boolean {
 
 describe("TelegramConfiguringOverlay readiness", () => {
   beforeEach(() => {
-    vi.useRealTimers();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     resetHarnessCache();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.useRealTimers();
     resetHarnessCache();
   });
 
@@ -61,9 +80,11 @@ describe("TelegramConfiguringOverlay readiness", () => {
     expect(screen.queryByText("telegram.restartingGateway")).not.toBeInTheDocument();
     expect(screen.queryByText("telegram.waitingGateway")).not.toBeInTheDocument();
 
+    // Through the fixed phases, the first (successful) poll and the ready phase.
+    await advance(PHASES_MS + READY_PHASE_MS);
     await waitFor(() => {
       expect(onDone).toHaveBeenCalledTimes(1);
-    }, { timeout: 20_000 });
+    });
 
     expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
     expect(called(fetchMock, "/setup-api/telegram/status")).toBe(true);
@@ -72,7 +93,7 @@ describe("TelegramConfiguringOverlay readiness", () => {
     // The label lands in two places at phase 4 — the visible subtitle and the
     // sr-only live region — so count rather than expect a single node.
     expect(screen.queryAllByText("telegram.botReady").length).toBeGreaterThan(0);
-  }, 30_000);
+  });
 
   it("still polls the gateway on an openclaw device", async () => {
     const onDone = vi.fn();
@@ -95,13 +116,14 @@ describe("TelegramConfiguringOverlay readiness", () => {
     });
     expect(screen.queryByText("telegram.hermesStartingService")).not.toBeInTheDocument();
 
+    await advance(PHASES_MS + READY_PHASE_MS);
     await waitFor(() => {
       expect(onDone).toHaveBeenCalledTimes(1);
-    }, { timeout: 20_000 });
+    });
 
     expect(called(fetchMock, "/setup-api/gateway/health")).toBe(true);
     expect(called(fetchMock, "/setup-api/telegram/status")).toBe(false);
-  }, 30_000);
+  });
 
   it("hands control back without a ready phase when hermes never starts listening", async () => {
     const onDone = vi.fn();
@@ -118,14 +140,20 @@ describe("TelegramConfiguringOverlay readiness", () => {
     });
     vi.stubGlobal("fetch", fetchMock);
 
-    // Short budget so the give-up path is reached quickly.
+    // Short budget so the give-up path is reached quickly: two 2 s attempts.
+    const healthTimeoutMs = 4_000;
     render(
-      <TelegramConfiguringOverlay onDone={onDone} waitFor={Promise.resolve()} healthTimeoutMs={4_000} />,
+      <TelegramConfiguringOverlay onDone={onDone} waitFor={Promise.resolve()} healthTimeoutMs={healthTimeoutMs} />,
     );
 
+    // Not there yet: the budget has to run out before the overlay gives up.
+    await advance(PHASES_MS + healthTimeoutMs / 2);
+    expect(onDone).not.toHaveBeenCalled();
+
+    await advance(healthTimeoutMs / 2);
     await waitFor(() => {
       expect(onDone).toHaveBeenCalledTimes(1);
-    }, { timeout: 20_000 });
+    });
 
     // The parent surfaces its own error — the overlay must not claim success.
     expect(screen.queryAllByText("telegram.botReady")).toHaveLength(0);
@@ -134,5 +162,5 @@ describe("TelegramConfiguringOverlay readiness", () => {
     // outcome. Assert it did ask Hermes and simply never got a listener.
     expect(called(fetchMock, "/setup-api/gateway/health")).toBe(false);
     expect(called(fetchMock, "/setup-api/telegram/status")).toBe(true);
-  }, 30_000);
+  });
 });

--- a/src/tests/helpers/slow-first-sequencer.ts
+++ b/src/tests/helpers/slow-first-sequencer.ts
@@ -1,0 +1,45 @@
+import { relative } from "path";
+import { BaseSequencer, type TestSpecification } from "vitest/node";
+
+/**
+ * The files that dominate a run, longest first.
+ *
+ * Measured in CI (ubuntu-latest, 4 workers, 2026-08): the sudoers file scans
+ * the whole repo with bash+perl once per case (~50 s) and the type-check gate
+ * runs a full `tsc --noEmit` (~28 s). Nothing else comes close once the
+ * suites that slept on real timers were fixed.
+ *
+ * WHY THE ORDER MATTERS. With no timing cache — which is every CI run —
+ * vitest orders files by SIZE, and these two are mid-sized, so they started
+ * late; whichever started last was the run's tail, three workers idle while
+ * the fourth finished it. A parallel run can never be shorter than the file
+ * that starts last; started first, the same files hide behind everything
+ * else. Paths are relative to the repo root, forward slashes.
+ */
+export const SLOW_FIRST: readonly string[] = [
+  "src/tests/unit/sudoers-coverage.test.ts",
+  "src/tests/unit/build-typecheck.test.ts",
+];
+
+export default class SlowFirstSequencer extends BaseSequencer {
+  async sort(files: TestSpecification[]): Promise<TestSpecification[]> {
+    const sorted = await super.sort(files);
+    // The base order groups files by project and the groups run in turn; only
+    // the order WITHIN a group is changed here, or a slow unit file would be
+    // pulled ahead of a project it does not belong to.
+    const groupOf = new Map<string, number>();
+    for (const spec of sorted) {
+      if (!groupOf.has(spec.project.name)) groupOf.set(spec.project.name, groupOf.size);
+    }
+    const rank = (spec: TestSpecification): number => {
+      const rel = relative(this.ctx.config.root, spec.moduleId).split("\\").join("/");
+      const i = SLOW_FIRST.indexOf(rel);
+      return i === -1 ? SLOW_FIRST.length : i;
+    };
+    // Array.prototype.sort is stable: files of equal rank keep the base order.
+    return [...sorted].sort(
+      (a, b) =>
+        groupOf.get(a.project.name)! - groupOf.get(b.project.name)! || rank(a) - rank(b),
+    );
+  }
+}

--- a/src/tests/routes/discord/status.test.ts
+++ b/src/tests/routes/discord/status.test.ts
@@ -9,6 +9,15 @@ vi.setConfig({ testTimeout: 30_000 });
 
 vi.mock("@/lib/config-store", () => ({ get: vi.fn() }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+// The OpenClaw branch asks the gateway for the channel's row through
+// `openclaw channels status` — a full CLI cold start, 8-10 s per call on a
+// Jetson that has the binary. Left unmocked, every case here paid for one
+// (65 s for the file on the box), and on a machine without `openclaw` the same
+// cases silently exercised the spawn-failure path instead. The row's mapping
+// is pinned by status-openclaw-state.test.ts; this file is about the Discord
+// bot probe, so the gateway answers "could not be asked" (null) unless a case
+// says otherwise.
+vi.mock("@/lib/openclaw-channels", () => ({ readChannelStatus: vi.fn() }));
 vi.mock("@/lib/hermes-discord", async () => {
   const actual = await vi.importActual<typeof import("@/lib/hermes-discord")>("@/lib/hermes-discord");
   return {
@@ -30,9 +39,11 @@ vi.mock("@/lib/hermes-discord", async () => {
 
 import { get } from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
+import { readChannelStatus } from "@/lib/openclaw-channels";
 
 const mockGet = vi.mocked(get);
 const mockHarness = vi.mocked(getActiveHarness);
+const mockChannel = vi.mocked(readChannelStatus);
 
 const TOKEN = "clawbox-test-not-a-real-discord-bot-token-000000";
 
@@ -58,6 +69,7 @@ describe("GET /setup-api/discord/status — OpenClaw", () => {
 
     mockHarness.mockResolvedValue("openclaw");
     mockGet.mockResolvedValue(TOKEN);
+    mockChannel.mockResolvedValue(null);
 
     GET = (await import("@/app/setup-api/discord/status/route")).GET;
   });
@@ -82,7 +94,11 @@ describe("GET /setup-api/discord/status — OpenClaw", () => {
       username: "clawbot",
       botId: "42",
       tokenRejected: false,
+      // The gateway was asked and could not answer: unknown, never "offline".
+      verified: false,
+      state: null,
     });
+    expect(mockChannel).toHaveBeenCalledWith("discord");
   });
 
   it("keeps a legacy discriminator in the reported name", async () => {

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,6 +1,14 @@
 import "@testing-library/jest-dom/vitest";
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import { afterEach, vi } from "vitest";
+
+// Testing Library's waitFor/findBy give up after 1 s by default. That is a
+// budget for a render on an idle laptop; on a loaded CI runner or this Jetson
+// (four workers, the slow files started first) a jsdom render of the chat can
+// take longer, and the only tests that ever tripped it were waiting for
+// something that arrived a moment later. A passing wait costs the same at any
+// budget; only a genuinely failing one takes longer to say so.
+configure({ asyncUtilTimeout: 5_000 });
 
 // Cleanup after each test
 afterEach(() => {

--- a/src/tests/unit/ci-workflows.test.ts
+++ b/src/tests/unit/ci-workflows.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * The CI workflows are configuration no other test sees, and two of their
+ * speed-ups are only correct while a relation BETWEEN files holds:
+ *
+ * - pr-tests-coverage.yml runs vitest with the json-summary reporter alone
+ *   (the html tree, the clover XML and the text table cost real time in a
+ *   550-file suite and nothing in CI reads them). That is safe precisely
+ *   because "Parse coverage" reads coverage-summary.json — the one file
+ *   json-summary writes. Drop that reporter, or read a different file, and
+ *   the step's `if [ -f ... ]` guard switches the PR comment's numbers off
+ *   silently instead of failing the job.
+ * - e2e-tests.yml restores .next/cache before the build. Put the cache step
+ *   after the run step and it restores nothing while looking like it does.
+ *
+ * These read the files as text on purpose: the repo has no YAML parser as a
+ * direct dependency, and the checks are about lines, not structure.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+const read = (rel: string) => fs.readFileSync(path.join(REPO, rel), "utf-8");
+
+describe("Tests workflow coverage reporters", () => {
+  const scripts = JSON.parse(read("package.json")).scripts as Record<string, string>;
+  const workflow = read(".github/workflows/pr-tests-coverage.yml");
+
+  it("test:coverage:ci is test:coverage with only the reporter set changed", () => {
+    // Same vitest, same config file, same thresholds: a CI-only script that
+    // ran a different suite would let coverage pass on CI and fail locally.
+    expect(scripts["test:coverage:ci"]).toMatch(/^vitest run --config vitest\.config\.ts --coverage\b/);
+    expect(scripts["test:coverage:ci"].startsWith(scripts["test:coverage"])).toBe(true);
+    expect(scripts["test:coverage:ci"]).toContain("--coverage.reporter=json-summary");
+    for (const reporter of ["html", "clover", "text"]) {
+      expect(scripts["test:coverage:ci"]).not.toContain(`--coverage.reporter=${reporter}`);
+    }
+  });
+
+  it("the workflow runs the CI script and parses the file json-summary writes", () => {
+    expect(workflow).toMatch(/^\s+run: bun run test:coverage:ci$/m);
+    // vitest's json-summary reporter writes coverage/coverage-summary.json;
+    // the parse step's guard and its readFileSync must both name that file.
+    expect(workflow).toMatch(/if \[ -f coverage\/coverage-summary\.json \]/);
+    expect(workflow).toMatch(/readFileSync\('coverage\/coverage-summary\.json'/);
+  });
+
+  it("the local script keeps every reporter for a person at a checkout", () => {
+    expect(scripts["test:coverage"]).not.toContain("--coverage.reporter");
+    const config = read("vitest.config.ts");
+    expect(config).toMatch(/reporter: \["text", "json-summary", "html", "clover"\]/);
+  });
+});
+
+describe("E2E workflow Next.js build cache", () => {
+  const workflow = read(".github/workflows/e2e-tests.yml");
+
+  it("restores .next/cache before the build that fills it", () => {
+    const cacheStep = workflow.indexOf("path: .next/cache");
+    const runStep = workflow.indexOf("run: bun run test:e2e:coverage");
+    expect(cacheStep).toBeGreaterThan(-1);
+    expect(runStep).toBeGreaterThan(-1);
+    expect(cacheStep).toBeLessThan(runStep);
+  });
+
+  it("keys the cache on the lockfile and the build inputs, with a lockfile fallback", () => {
+    const step = workflow.slice(workflow.indexOf("path: .next/cache"), workflow.indexOf("run: bun run test:e2e:coverage"));
+    // An exact key must change whenever the sources do; otherwise a hit would
+    // hand the build a cache from other code (Next re-validates entries, so
+    // that is slow rather than wrong — but it would be a cache that never
+    // updates). The prefix fallback is what makes an unrelated change warm.
+    expect(step).toMatch(/key: nextjs-\$\{\{ runner\.os \}\}-\$\{\{ hashFiles\('bun\.lock'\) \}\}-\$\{\{ hashFiles\('src\/\*\*'/);
+    expect(step).toMatch(/restore-keys: \|\n\s+nextjs-\$\{\{ runner\.os \}\}-\$\{\{ hashFiles\('bun\.lock'\) \}\}-\n/);
+  });
+});

--- a/src/tests/unit/coding-run-preview.test.ts
+++ b/src/tests/unit/coding-run-preview.test.ts
@@ -137,7 +137,10 @@ function watch(
     child.stdout.on("data", onData);
     child.stderr.on("data", onData);
     child.on("error", (err) => { clearTimeout(ctrlC); reject(err); });
-    child.on("exit", (code, signal) => { clearTimeout(ctrlC); resolve({ out, code, signal }); });
+    // `close`, not `exit`: the process can be gone while its piped stdout is
+    // still delivering, and a watch resolved on `exit` could hand back an
+    // `out` missing the last lines the view wrote on its way down.
+    child.on("close", (code, signal) => { clearTimeout(ctrlC); resolve({ out, code, signal }); });
   });
 }
 

--- a/src/tests/unit/coding-run-preview.test.ts
+++ b/src/tests/unit/coding-run-preview.test.ts
@@ -10,7 +10,7 @@
  * not moving — and a thought that has words shows a line of them rather than
  * a bare "thinking…".
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, describe, expect, it } from "vitest";
 import { spawn } from "child_process";
 import fs from "fs";
 import os from "os";
@@ -19,9 +19,18 @@ import path from "path";
 const SCRIPT = path.join(process.cwd(), "scripts", "coding-run-preview");
 const SESSION = "61400ab6-0da9-4feb-8ad5-b547239c1367";
 
-let base: string;
-afterEach(() => {
-  if (base) fs.rmSync(base, { recursive: true, force: true });
+// The cases run concurrently — each is a python process that mostly sleeps,
+// and the file's time was the sum of their windows — so every case owns its
+// working folder rather than sharing one variable; they are all removed at
+// the end.
+const bases: string[] = [];
+function workdir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "coding-run-preview-"));
+  bases.push(dir);
+  return dir;
+}
+afterAll(() => {
+  for (const dir of bases) fs.rmSync(dir, { recursive: true, force: true });
 });
 
 /**
@@ -60,34 +69,113 @@ function runsFile(root: string, run: Record<string, unknown>): void {
 }
 
 /**
- * Run the view for `ms`, then Ctrl-C it the way the terminal would — SIGINT
- * to the whole process group — and hand back what it printed.
+ * The script's floor for CLAWBOX_PREVIEW_HEARTBEAT. The follow loop checks the
+ * file every POLL = 0.5 s, so at this setting the first beat lands on the
+ * second check after the last line — about 0.7 s in — and a case waiting for
+ * one is not paying for a second of silence first.
  */
-function watch(args: string[], env: Record<string, string>, ms: number): Promise<{ out: string; code: number | null; signal: string | null }> {
+const HEARTBEAT_S = 0.2;
+/** The script's own file-check interval, in ms; a beat is never earlier. */
+const POLL_MS = 500;
+
+interface WatchOptions {
+  /**
+   * Ctrl-C as soon as the output satisfies this — the window is a ceiling for
+   * a view that never gets there, not the time every case spends. Without it
+   * each case ran its whole window (2.5–3.5 s) and the file took ~15 s for
+   * assertions that were settled in the first second.
+   */
+  until?: (out: string) => boolean;
+  /** Keep watching this long after `until` is met, for "and then nothing more". */
+  settleMs?: number;
+  /**
+   * Called with the whole output each time more arrives. How a case grows the
+   * transcript AFTER the view has replayed it: appending on a timer raced the
+   * view's own start, and the beat then counted the wrong turn.
+   */
+  onOutput?: (out: string) => void;
+  /** Seconds of silence before a beat; the script's floor unless a case needs more. */
+  heartbeatS?: number;
+}
+
+/**
+ * Run the view until `until` holds (plus `settleMs`), or for `ceilingMs`, then
+ * Ctrl-C it the way the terminal would — SIGINT to the whole process group —
+ * and hand back what it printed.
+ */
+function watch(
+  args: string[],
+  env: Record<string, string>,
+  ceilingMs: number,
+  { until, settleMs = 0, onOutput, heartbeatS = HEARTBEAT_S }: WatchOptions = {},
+): Promise<{ out: string; code: number | null; signal: string | null }> {
   return new Promise((resolve, reject) => {
     const child = spawn("bash", [SCRIPT, ...args], {
-      env: { ...process.env, ...env, CLAWBOX_PREVIEW_HEARTBEAT: "1" },
+      env: { ...process.env, ...env, CLAWBOX_PREVIEW_HEARTBEAT: String(heartbeatS) },
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
     });
     let out = "";
-    child.stdout.on("data", (d) => { out += String(d); });
-    child.stderr.on("data", (d) => { out += String(d); });
+    let done = false;
     // Ctrl-C is for a view still running at the deadline. A script that ended
     // on its own (no transcript, no arguments) must not leave a timer behind
     // that later signals a process group the OS may have handed to someone
     // else — and keeps the worker's event loop busy for nothing.
-    const ctrlC = setTimeout(() => {
+    const interrupt = () => {
       try { process.kill(-child.pid!, "SIGINT"); } catch { /* already gone */ }
-    }, ms);
+    };
+    let ctrlC = setTimeout(interrupt, ceilingMs);
+    const onData = (d: Buffer) => {
+      out += String(d);
+      onOutput?.(out);
+      if (!done && until?.(out)) {
+        done = true;
+        clearTimeout(ctrlC);
+        ctrlC = setTimeout(interrupt, settleMs);
+      }
+    };
+    child.stdout.on("data", onData);
+    child.stderr.on("data", onData);
     child.on("error", (err) => { clearTimeout(ctrlC); reject(err); });
     child.on("exit", (code, signal) => { clearTimeout(ctrlC); resolve({ out, code, signal }); });
   });
 }
 
-describe("coding-run-preview", () => {
+/** The last line the view replays from the fixture: everything before it is on screen. */
+const REPLAYED = "✗ 1 failing";
+const beat = (out: string) => out.includes("still working");
+
+/**
+ * The heartbeat for a case that grows the file: the view must read the new
+ * lines BEFORE its first beat, and the append is written from inside the
+ * view's first POLL sleep (see growOnceReplayed), so the margin for the
+ * worker to react to the replay is the smaller of POLL and the heartbeat. A
+ * second of silence keeps it at the full POLL; the cases run concurrently, so
+ * the longer wait costs the file nothing.
+ */
+const GROWTH_HEARTBEAT_S = 1;
+
+/**
+ * Append to the transcript once the view has replayed it — from inside the
+ * view's first POLL sleep, so the line is read on the next check and the beat
+ * that follows counts it. Appending on a timer of our own raced the python
+ * start-up.
+ */
+function growOnceReplayed(file: string, lines: Record<string, unknown>[]): (out: string) => void {
+  let grown = false;
+  return (out) => {
+    if (grown || !out.includes(REPLAYED)) return;
+    grown = true;
+    fs.appendFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  };
+}
+
+/** A ceiling no passing case reaches; a hung view fails in this long, not the test timeout. */
+const CEILING_MS = 8_000;
+
+describe.concurrent("coding-run-preview", () => {
   it("names the task, shows a line of each thought, and beats while the model is quiet", async () => {
-    base = fs.mkdtempSync(path.join(os.tmpdir(), "coding-run-preview-"));
+    const base = workdir();
     const file = transcript(path.join(base, "projects", "-home-clawbox-x"));
     const now = Date.now();
     runsFile(base, {
@@ -95,7 +183,7 @@ describe("coding-run-preview", () => {
       startedAt: now - 12 * 60_000, thinkingTokens: 56_000, lastActivityAt: now - 4_000,
     });
 
-    const { out, code } = await watch([file, "run-k3x9q2ab"], { CLAWBOX_ROOT: base }, 3_000);
+    const { out, code } = await watch([file, "run-k3x9q2ab"], { CLAWBOX_ROOT: base }, CEILING_MS, { until: beat });
 
     expect(out).toContain("── task: Build a countdown timer");
     // The thought itself, on one line, cut — not a bare "thinking…".
@@ -110,71 +198,77 @@ describe("coding-run-preview", () => {
     // went on to the heartbeat.
     expect(out).not.toContain("Traceback");
     expect(out).not.toContain("weird");
-    // The heartbeat, within ~3 s at HEARTBEAT=1, built from the record. Turn
-    // 3: two message ids over four assistant lines; the line with no message is not a turn.
-    const beat = out.split("\n").find((l) => l.includes("still working"));
-    expect(beat, out).toBeDefined();
-    expect(beat).toContain("12m in, turn 3");
-    expect(beat).toContain("thinking 56k tokens");
-    expect(beat).toMatch(/last activity \d+s ago/);
+    // The heartbeat, built from the record. Turn 3: two message ids over four
+    // assistant lines; the line with no message is not a turn.
+    const line = out.split("\n").find(beat);
+    expect(line, out).toBeDefined();
+    expect(line).toContain("12m in, turn 3");
+    expect(line).toContain("thinking 56k tokens");
+    expect(line).toMatch(/last activity \d+s ago/);
     // Ctrl-C ended it cleanly.
     expect(code).toBe(0);
   }, 15_000);
 
   it("finds the record by session id when no run id is given, and says so when there is none", async () => {
-    base = fs.mkdtempSync(path.join(os.tmpdir(), "coding-run-preview-"));
+    const base = workdir();
     const file = transcript(path.join(base, "projects", "-home-clawbox-x"));
     runsFile(base, { id: "run-other", sessionId: SESSION, status: "running", startedAt: Date.now() - 30_000, thinkingTokens: 900, lastActivityAt: Date.now() });
 
-    const bySession = await watch([file], { CLAWBOX_ROOT: base }, 2_500);
+    const bySession = await watch([file], { CLAWBOX_ROOT: base }, CEILING_MS, { until: beat });
     expect(bySession.out).toContain("thinking 900 tokens");
 
     // No runs file at all — a run that has not been persisted yet, or a
     // transcript opened from somewhere else. Still a sign of life.
-    const none = await watch([file], { CLAWBOX_ROOT: path.join(base, "nowhere") }, 2_500);
+    const none = await watch([file], { CLAWBOX_ROOT: path.join(base, "nowhere") }, CEILING_MS, { until: beat });
     expect(none.out).toContain("still working — waiting for the model");
     expect(none.out).not.toContain("tokens");
   }, 15_000);
 
   it("keeps following a file that grows, and stops beating once the record says the run is over", async () => {
-    base = fs.mkdtempSync(path.join(os.tmpdir(), "coding-run-preview-"));
+    const base = workdir();
     const file = transcript(path.join(base, "projects", "-home-clawbox-x"));
     runsFile(base, { id: "run-k3x9q2ab", sessionId: SESSION, status: "completed", startedAt: Date.now() - 30_000 });
-    setTimeout(() => {
-      fs.appendFileSync(file, JSON.stringify({ type: "assistant", message: { id: "msg_03", content: [{ type: "text", text: "All done, tests pass." }] } }) + "\n");
-    }, 500);
 
-    const { out } = await watch([file, "run-k3x9q2ab"], { CLAWBOX_ROOT: base }, 3_500);
+    const { out } = await watch([file, "run-k3x9q2ab"], { CLAWBOX_ROOT: base }, CEILING_MS, {
+      onOutput: growOnceReplayed(file, [
+        { type: "assistant", message: { id: "msg_03", content: [{ type: "text", text: "All done, tests pass." }] } },
+      ]),
+      until: (o) => o.includes("■ run completed"),
+      heartbeatS: GROWTH_HEARTBEAT_S,
+      // Long enough for a second beat to have arrived, had beating not stopped.
+      settleMs: GROWTH_HEARTBEAT_S * 1000 + 2 * POLL_MS,
+    });
     expect(out).toContain("All done, tests pass.");
     expect(out.split("\n").filter((l) => l.includes("■ run completed"))).toHaveLength(1);
     expect(out).not.toContain("still working");
   }, 15_000);
 
   it("counts a turn per message id as the file grows, not a line per block", async () => {
-    base = fs.mkdtempSync(path.join(os.tmpdir(), "coding-run-preview-"));
+    const base = workdir();
     const file = transcript(path.join(base, "projects", "-home-clawbox-x"));
     runsFile(base, { id: "run-k3x9q2ab", sessionId: SESSION, status: "running", startedAt: Date.now() - 30_000 });
-    setTimeout(() => {
+
+    const { out } = await watch([file, "run-k3x9q2ab"], { CLAWBOX_ROOT: base }, CEILING_MS, {
       // Turn 3 lands as two lines; the model is then IN turn 4.
-      fs.appendFileSync(file, [
+      onOutput: growOnceReplayed(file, [
         { type: "assistant", message: { id: "msg_03", content: [{ type: "thinking", thinking: "Now the tests." }] } },
         { type: "assistant", message: { id: "msg_03", content: [{ type: "tool_use", id: "t3", name: "Bash", input: { command: "npm test" } }] } },
-      ].map((l) => JSON.stringify(l)).join("\n") + "\n");
-    }, 300);
-
-    const { out } = await watch([file, "run-k3x9q2ab"], { CLAWBOX_ROOT: base }, 3_000);
+      ]),
+      until: beat,
+      heartbeatS: GROWTH_HEARTBEAT_S,
+    });
     expect(out).toContain("· thinking: Now the tests.");
-    const beat = out.split("\n").find((l) => l.includes("still working"));
-    expect(beat, out).toBeDefined();
-    expect(beat).toContain("turn 4");
+    const line = out.split("\n").find(beat);
+    expect(line, out).toBeDefined();
+    expect(line).toContain("turn 4");
   }, 15_000);
 
   it("refuses to start without a transcript to follow", async () => {
-    base = fs.mkdtempSync(path.join(os.tmpdir(), "coding-run-preview-"));
-    const missing = await watch([path.join(base, "nope.jsonl")], {}, 2_000);
+    const base = workdir();
+    const missing = await watch([path.join(base, "nope.jsonl")], {}, CEILING_MS);
     expect(missing.code).toBe(1);
     expect(missing.out).toContain("No transcript yet");
-    const noArgs = await watch([], {}, 2_000);
+    const noArgs = await watch([], {}, CEILING_MS);
     expect(noArgs.code).toBe(2);
   }, 15_000);
 });

--- a/src/tests/unit/e2e-install-wait.test.ts
+++ b/src/tests/unit/e2e-install-wait.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyInstallState,
+  parseUnitState,
+  waitForInstallComplete,
+  InstallBootstrapFailedError,
+  BOOTSTRAP_UNIT,
+  type BootstrapUnitState,
+  type InstallProbes,
+} from "../../../e2e-install/helpers/container";
+
+/**
+ * The e2e-install harness waits for install.sh inside a systemd container.
+ * Measured on PR #558: clawbox-bootstrap.service exited 1 at ~3 min, and the
+ * wait loop kept polling the .needs-install marker until its 40-minute
+ * deadline — 41 minutes to report a failure known at minute 3. The container
+ * cannot run here; these tests pin the loop's decisions through fake probes so
+ * that fail-fast, the success path and the backstop deadline are all proven
+ * without docker.
+ */
+
+const ACTIVATING: BootstrapUnitState = { activeState: "activating", result: "success" };
+const FAILED: BootstrapUnitState = { activeState: "failed", result: "exit-code" };
+const ACTIVE: BootstrapUnitState = { activeState: "active", result: "success" };
+
+type Poll = { markerGone: boolean; httpReady: boolean; unit: BootstrapUnitState };
+
+/**
+ * Fake probes that replay a scripted sequence of container states, one per
+ * poll, and count how often the loop asked and slept. The last state repeats
+ * so a "keeps waiting" script cannot run off its end.
+ */
+function scripted(polls: Poll[], opts: { stepMs?: number } = {}) {
+  const calls = { markerGone: 0, httpReady: 0, bootstrapUnit: 0, installLogTail: 0, sleeps: [] as number[] };
+  let clock = 0;
+  const at = () => polls[Math.min(calls.markerGone - 1, polls.length - 1)];
+  const probes: InstallProbes = {
+    async markerGone() { calls.markerGone++; return at().markerGone; },
+    async httpReady() { calls.httpReady++; return at().httpReady; },
+    async bootstrapUnit() { calls.bootstrapUnit++; return at().unit; },
+    async installLogTail() { calls.installLogTail++; return "step_build: FAILED\nnext build exited 1"; },
+    async sleep(ms) { calls.sleeps.push(ms); clock += opts.stepMs ?? ms; },
+    now: () => clock,
+  };
+  return { probes, calls };
+}
+
+describe("classifyInstallState", () => {
+  it("marker present + unit failed → failed", () => {
+    expect(classifyInstallState({ markerGone: false, httpReady: false, unitFailed: true })).toBe("failed");
+  });
+
+  it("marker gone + http ready → done", () => {
+    expect(classifyInstallState({ markerGone: true, httpReady: true, unitFailed: false })).toBe("done");
+  });
+
+  it("marker present + unit still running → wait", () => {
+    expect(classifyInstallState({ markerGone: false, httpReady: false, unitFailed: false })).toBe("wait");
+  });
+
+  it("marker gone but server not up yet → wait (the server comes up after the marker goes)", () => {
+    expect(classifyInstallState({ markerGone: true, httpReady: false, unitFailed: false })).toBe("wait");
+  });
+
+  it("a live server with the marker still present is the installer's mid-run start, not completion", () => {
+    expect(classifyInstallState({ markerGone: false, httpReady: true, unitFailed: false })).toBe("wait");
+  });
+
+  it("done wins over a failed unit: the marker only goes after install.sh exited 0", () => {
+    expect(classifyInstallState({ markerGone: true, httpReady: true, unitFailed: true })).toBe("done");
+  });
+});
+
+describe("parseUnitState", () => {
+  it("reads the two properties systemctl show prints", () => {
+    expect(parseUnitState("ActiveState=failed\nResult=exit-code\n")).toEqual(FAILED);
+  });
+
+  it("is independent of property order", () => {
+    expect(parseUnitState("Result=exit-code\nActiveState=failed\n")).toEqual(FAILED);
+  });
+
+  it("a missing property is unknown, never failed", () => {
+    expect(parseUnitState("")).toEqual({ activeState: "unknown", result: "unknown" });
+    expect(parseUnitState("garbage without equals")).toEqual({ activeState: "unknown", result: "unknown" });
+  });
+});
+
+describe("waitForInstallComplete", () => {
+  it("marker present + unit failed → throws 'bootstrap failed' on the first poll, no further polling", async () => {
+    const { probes, calls } = scripted([{ markerGone: false, httpReady: false, unit: FAILED }]);
+    const err = await waitForInstallComplete(40 * 60_000, probes).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(InstallBootstrapFailedError);
+    const message = (err as Error).message;
+    expect(message).toMatch(/^bootstrap failed/);
+    expect(message).toContain(BOOTSTRAP_UNIT);
+    expect(message).toContain("Result=exit-code");
+    // The cause is in the error itself, so the job log shows it where the
+    // failure is reported, not only in a dump further down.
+    expect(message).toContain("step_build: FAILED");
+    expect((err as InstallBootstrapFailedError).installLogTail).toContain("next build exited 1");
+    expect(calls.markerGone).toBe(1);
+    expect(calls.bootstrapUnit).toBe(1);
+    expect(calls.installLogTail).toBe(1);
+    expect(calls.sleeps).toEqual([]);
+  });
+
+  it("a unit that fails after a few polls ends the wait on the poll that sees it", async () => {
+    const { probes, calls } = scripted([
+      { markerGone: false, httpReady: false, unit: ACTIVATING },
+      { markerGone: false, httpReady: false, unit: ACTIVATING },
+      { markerGone: false, httpReady: false, unit: FAILED },
+    ]);
+    await expect(waitForInstallComplete(40 * 60_000, probes)).rejects.toBeInstanceOf(InstallBootstrapFailedError);
+    expect(calls.markerGone).toBe(3);
+    expect(calls.sleeps).toHaveLength(2);
+  });
+
+  it("marker gone + http ready → resolves without sleeping", async () => {
+    const { probes, calls } = scripted([{ markerGone: true, httpReady: true, unit: ACTIVE }]);
+    await expect(waitForInstallComplete(40 * 60_000, probes)).resolves.toBeUndefined();
+    expect(calls.sleeps).toEqual([]);
+  });
+
+  it("marker present + unit active → keeps waiting until the marker goes and the server answers", async () => {
+    const { probes, calls } = scripted([
+      { markerGone: false, httpReady: false, unit: ACTIVATING },
+      { markerGone: false, httpReady: false, unit: ACTIVATING },
+      { markerGone: true, httpReady: false, unit: ACTIVE },
+      { markerGone: true, httpReady: true, unit: ACTIVE },
+    ]);
+    await expect(waitForInstallComplete(40 * 60_000, probes)).resolves.toBeUndefined();
+    expect(calls.markerGone).toBe(4);
+    expect(calls.sleeps).toEqual([5_000, 5_000, 5_000]);
+    // HTTP is only asked once the marker is gone — before that a live server
+    // is the installer's own mid-run start, not completion.
+    expect(calls.httpReady).toBe(2);
+    expect(calls.installLogTail).toBe(0);
+  });
+
+  it("an unknown unit state (docker exec failed) is not a failure — the loop keeps waiting", async () => {
+    const { probes, calls } = scripted([
+      { markerGone: false, httpReady: false, unit: { activeState: "unknown", result: "unknown" } },
+      { markerGone: true, httpReady: true, unit: ACTIVE },
+    ]);
+    await expect(waitForInstallComplete(40 * 60_000, probes)).resolves.toBeUndefined();
+    expect(calls.sleeps).toHaveLength(1);
+  });
+
+  it("the deadline is still the backstop for an installer that hangs without failing", async () => {
+    // Each fake sleep advances the clock by one minute, so a 40-minute
+    // deadline is reached after 40 polls of a unit that never fails.
+    const { probes, calls } = scripted(
+      [{ markerGone: false, httpReady: false, unit: ACTIVATING }],
+      { stepMs: 60_000 },
+    );
+    const err = await waitForInstallComplete(40 * 60_000, probes).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(InstallBootstrapFailedError);
+    expect((err as Error).message).toContain("did not finish within 2400000ms");
+    expect(calls.sleeps).toHaveLength(40);
+    expect(calls.installLogTail).toBe(0);
+  });
+});

--- a/src/tests/unit/network.test.ts
+++ b/src/tests/unit/network.test.ts
@@ -81,12 +81,29 @@ describe("network", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.clearAllMocks();
+    // doScan() sleeps a real 3 s after `nmcli device wifi rescan` so the driver
+    // has results to list — every scan below paid for it, ten of them, and
+    // the box was never asked anything real. The clock is faked instead and
+    // scan() runs it forward; the settle itself stays the product's.
+    vi.useFakeTimers();
     process.env.CLAWBOX_ROOT = "/tmp/clawbox-test-nonexistent-" + Math.random().toString(36).slice(2);
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
+
+  /**
+   * scanWifi() with the post-rescan settle elapsed on the fake clock. The
+   * execFile mock answers through microtasks, so every timer the scan sets is
+   * already pending by the time the runner looks for one.
+   */
+  async function scan(): ReturnType<typeof network.scanWifi> {
+    const pending = network.scanWifi();
+    await vi.runAllTimersAsync();
+    return pending;
+  }
 
   describe("scanWifi", () => {
     it("returns cached results if fresh", async () => {
@@ -98,13 +115,13 @@ describe("network", () => {
       network = await import("@/lib/network");
 
       // First call populates cache
-      const result1 = await network.scanWifi();
+      const result1 = await scan();
       expect(result1).toHaveLength(1);
       expect(result1[0].ssid).toBe("HomeNet");
 
       // Second call should use cache (no additional exec calls)
       const callCount = mockExecFile.mock.calls.length;
-      const result2 = await network.scanWifi();
+      const result2 = await scan();
       expect(result2).toEqual(result1);
       // Should not have made more calls
       expect(mockExecFile.mock.calls.length).toBe(callCount);
@@ -120,7 +137,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result).toHaveLength(3);
       expect(result[0]).toEqual({ ssid: "Network1", signal: 85, security: "WPA2", freq: "5180" });
@@ -138,7 +155,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result).toHaveLength(1);
       expect(result[0].ssid).toBe("OtherNet");
@@ -154,7 +171,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result).toHaveLength(1);
       expect(result[0].signal).toBe(90);
@@ -170,7 +187,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result).toHaveLength(1);
       expect(result[0].ssid).toBe("My:Network:Name");
@@ -186,7 +203,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result).toHaveLength(1);
       expect(result[0].ssid).toBe("ValidNet");
@@ -202,7 +219,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result).toHaveLength(1);
       expect(result[0].ssid).toBe("ValidNet");
@@ -218,7 +235,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result).toHaveLength(1);
       expect(result[0].ssid).toBe("GoodNet");
@@ -234,7 +251,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      const result = await network.scanWifi();
+      const result = await scan();
 
       expect(result[0].ssid).toBe("High");
       expect(result[1].ssid).toBe("Mid");
@@ -260,7 +277,7 @@ describe("network", () => {
       });
 
       network = await import("@/lib/network");
-      await network.scanWifi();
+      await scan();
 
       const status = network.getScanStatus();
 
@@ -280,7 +297,7 @@ describe("network", () => {
       network = await import("@/lib/network");
 
       // Populate cache
-      await network.scanWifi();
+      await scan();
 
       const callCount = mockExecFile.mock.calls.length;
 

--- a/src/tests/unit/slow-first-sequencer.test.ts
+++ b/src/tests/unit/slow-first-sequencer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { TestSpecification, Vitest } from "vitest/node";
+import fs from "fs";
+import path from "path";
+import SlowFirstSequencer, { SLOW_FIRST } from "@/tests/helpers/slow-first-sequencer";
+
+/**
+ * The sequencer vitest.config.ts installs: the files known to take longest
+ * start first, so a four-worker run does not end on one of them while the
+ * other three workers sit idle.
+ */
+
+const REPO = path.resolve(__dirname, "../../..");
+
+/** The base sequencer with nothing cached — what every CI run looks like. */
+function sequencer(): SlowFirstSequencer {
+  const ctx = {
+    config: { root: REPO },
+    cache: { getFileTestResults: () => undefined, getFileStats: () => undefined },
+  };
+  return new SlowFirstSequencer(ctx as unknown as Vitest);
+}
+
+function spec(project: string, rel: string): TestSpecification {
+  return {
+    moduleId: path.join(REPO, rel),
+    project: { name: project, config: { sequence: { groupOrder: 0 }, isolate: true } },
+  } as unknown as TestSpecification;
+}
+
+const rel = (s: TestSpecification) => path.relative(REPO, s.moduleId);
+
+describe("SlowFirstSequencer", () => {
+  it("names files that exist, so a rename cannot silently drop one out of the fast lane", () => {
+    for (const file of SLOW_FIRST) {
+      expect(fs.existsSync(path.join(REPO, file)), `${file} is listed but not in the tree`).toBe(true);
+    }
+  });
+
+  it("starts the known-slow files first, in the listed order, ahead of files the base order put before them", async () => {
+    const files = [
+      spec("unit", "src/tests/unit/a.test.ts"),
+      spec("unit", SLOW_FIRST[1]),
+      spec("unit", "src/tests/unit/b.test.ts"),
+      spec("unit", SLOW_FIRST[0]),
+    ];
+    const sorted = await sequencer().sort(files);
+    expect(sorted.map(rel)).toEqual([SLOW_FIRST[0], SLOW_FIRST[1], "src/tests/unit/a.test.ts", "src/tests/unit/b.test.ts"]);
+  });
+
+  it("keeps the base order among the rest and never crosses a project boundary", async () => {
+    // The base sequencer runs projects one after another (components before
+    // unit, by name). A slow UNIT file must not be pulled ahead of the
+    // component files, only ahead of its own project's files.
+    const files = [
+      spec("unit", "src/tests/unit/z.test.ts"),
+      spec("unit", SLOW_FIRST[0]),
+      spec("components", "src/tests/components/y.test.tsx"),
+      spec("components", "src/tests/components/x.test.tsx"),
+    ];
+    const sorted = await sequencer().sort(files);
+    expect(sorted.map((s) => `${s.project.name}:${rel(s)}`)).toEqual([
+      "components:src/tests/components/y.test.tsx",
+      "components:src/tests/components/x.test.tsx",
+      `unit:${SLOW_FIRST[0]}`,
+      "unit:src/tests/unit/z.test.ts",
+    ]);
+  });
+});

--- a/src/tests/unit/slow-first-sequencer.test.ts
+++ b/src/tests/unit/slow-first-sequencer.test.ts
@@ -28,7 +28,9 @@ function spec(project: string, rel: string): TestSpecification {
   } as unknown as TestSpecification;
 }
 
-const rel = (s: TestSpecification) => path.relative(REPO, s.moduleId);
+// Forward slashes whatever the host separator: SLOW_FIRST and the expected
+// values are written with `/`, and the sequencer normalises its own paths.
+const rel = (s: TestSpecification) => path.relative(REPO, s.moduleId).split(path.sep).join("/");
 
 describe("SlowFirstSequencer", () => {
   it("names files that exist, so a rename cannot silently drop one out of the fast lane", () => {

--- a/src/tests/unit/sudoers-coverage.test.ts
+++ b/src/tests/unit/sudoers-coverage.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 
 // Every test here spawns the real checker over the real src/ and mcp/ trees,
 // which takes ~5 s on a Jetson Orin Nano — right on the default 5 s test
 // timeout, so the suite failed on the device it protects while passing in CI.
 // The budget is per test; the checker's own OK line is still the assertion.
 vi.setConfig({ testTimeout: 60_000 });
-import { spawnSync } from "child_process";
+import { execFile, spawnSync } from "child_process";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -37,6 +37,56 @@ function run(root: string, args: string[] = []) {
   });
 }
 
+interface Checked {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** run(), off the worker thread, so that scans of the same tree can overlap. */
+function runAsync(root: string, args: string[] = []): Promise<Checked> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "bash",
+      [CHECKER, ...args],
+      { encoding: "utf-8", env: { ...process.env, CLAWBOX_REPO_ROOT: root }, maxBuffer: 16 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        // A non-zero exit is the checker's answer, not a failure to run it:
+        // execFile reports it as an error whose `code` is the exit status.
+        // Anything else (no bash, output over maxBuffer) has no such status
+        // and IS a failure to run.
+        const status = err ? (err as { code?: unknown }).code : 0;
+        if (typeof status !== "number") {
+          reject(err);
+          return;
+        }
+        resolve({ status, stdout, stderr });
+      },
+    );
+  });
+}
+
+/**
+ * The tree as it ships, scanned once per file rather than once per test.
+ *
+ * Four tests read the checker's verdict on the REAL repo — the pass line, the
+ * --list dump (twice) and the --json report. They differ only in how the same
+ * scan is printed, and each was paying for the whole scan (~5 s on the box,
+ * ~1.5 s in CI). Three modes, three scans, started side by side: the checker
+ * is one single-threaded perl pass, so they overlap where a core is free.
+ * Every test that mutates a fixture still scans its own fixture.
+ */
+let shipped: Promise<{ check: Checked; list: Checked; json: Checked }>;
+beforeAll(() => {
+  if (!CAN_RUN) return;
+  shipped = Promise.all([runAsync(REPO), runAsync(REPO, ["--list"]), runAsync(REPO, ["--json"])]).then(
+    ([check, list, json]) => ({ check, list, json }),
+  );
+  // A scan that could not run still fails the tests that await it; this only
+  // keeps the rejection from surfacing as an unhandled one first.
+  void shipped.catch(() => undefined);
+}, 120_000);
+
 let fixture: string;
 
 /**
@@ -63,6 +113,15 @@ afterEach(() => {
 });
 
 const grants = () => path.join(fixture, "config/clawbox-sudoers");
+/**
+ * The fixture scanned before anything touched it. Two tests assert exactly
+ * that it passes — that the fixture is not itself the thing under test, and
+ * that the bare-unit twins the shipped list carries are accepted — and one
+ * scan answers both; the second keeps the first's verdict. Any test that
+ * changes its fixture uses run() and pays for its own.
+ */
+let pristine: ReturnType<typeof run> | null = null;
+const runPristine = () => (pristine ??= run(fixture));
 const appendGrant = (line: string) => fs.appendFileSync(grants(), `${line}\n`);
 const dropGrant = (needle: string) =>
   fs.writeFileSync(
@@ -71,14 +130,14 @@ const dropGrant = (needle: string) =>
   );
 
 d("check-sudoers-coverage", () => {
-  it("passes on the repo as it ships", () => {
-    const r = run(REPO);
+  it("passes on the repo as it ships", async () => {
+    const r = (await shipped).check;
     expect(r.stderr + r.stdout).toMatch(/OK — \d+ grants, \d+ resolved sudo invocations, 0 gaps/);
     expect(r.status).toBe(0);
   });
 
   it("passes on the fixture, so the fixture itself is not the thing under test", () => {
-    expect(run(fixture).status).toBe(0);
+    expect(runPristine().status).toBe(0);
   });
 
   it("fails when a sudo call has no grant", () => {
@@ -114,7 +173,7 @@ d("check-sudoers-coverage", () => {
   // sudoers matches arguments as exact strings; only one spelling is ever called.
   it("accepts the bare-unit twin of a grant that is used", () => {
     expect(fs.readFileSync(grants(), "utf-8")).toMatch(/systemctl restart clawbox-gateway$/m);
-    expect(run(fixture).status).toBe(0);
+    expect(runPristine().status).toBe(0);
   });
 
   // Fail-closed: a sudo call the checker cannot read is never quietly a pass.
@@ -228,8 +287,8 @@ d("check-sudoers-coverage", () => {
   // root-steps.test.ts, which reads both drop-ins; the tests above prove the
   // checker is what fails CI when one comes back.
 
-  it("lists what it matched", () => {
-    const r = run(REPO, ["--list"]);
+  it("lists what it matched", async () => {
+    const r = (await shipped).list;
     expect(r.status).toBe(0);
     expect(r.stdout).toMatch(/GRANTS \(\d+\):/);
     expect(r.stdout).toContain("/usr/local/libexec/clawbox/optimize-ollama.sh");
@@ -237,8 +296,8 @@ d("check-sudoers-coverage", () => {
     expect(r.stdout).toMatch(/RESOLVED CALL SITES:/);
   });
 
-  it("reports machine-readably", () => {
-    const r = run(REPO, ["--json"]);
+  it("reports machine-readably", async () => {
+    const r = (await shipped).json;
     expect(r.status).toBe(0);
     const report = JSON.parse(r.stdout);
     expect(report.uncovered).toEqual([]);
@@ -254,15 +313,10 @@ d("check-sudoers-coverage", () => {
 });
 
 describe("the call sites the allow-list has to cover", () => {
-  const listed = () => {
-    const r = run(REPO, ["--list"]);
-    return r.stdout;
-  };
-
   // Every path the task brief names, traced end to end. If one of these stops
   // being covered the device loses that feature to a password prompt.
-  it.runIf(CAN_RUN)("covers the wizard, updater, power, wifi, desktop and factory-reset paths", () => {
-    const out = listed();
+  it.runIf(CAN_RUN)("covers the wizard, updater, power, wifi, desktop and factory-reset paths", async () => {
+    const out = (await shipped).list.stdout;
     for (const expected of [
       // setup wizard: hostname + hotspot hand-off, and the chpasswd hand-off
       "sudo /usr/bin/systemctl start clawbox-root-update@set_hostname.service",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import os from "os";
 import path from "path";
 import { defineConfig } from "vitest/config";
 import tsconfigPaths from "vite-tsconfig-paths";
+import SlowFirstSequencer from "./src/tests/helpers/slow-first-sequencer";
 
 export default defineConfig({
   plugins: [tsconfigPaths()],
@@ -9,6 +10,11 @@ export default defineConfig({
     clearMocks: true,
     restoreMocks: true,
     mockReset: true,
+    // Start the files known to take longest first (see the sequencer for the
+    // measurements). Without a timing cache — every CI run — vitest orders by
+    // file size, and the 50 s sudoers file and the 28 s tsc gate then started
+    // late enough to be the tail of a four-worker run.
+    sequence: { sequencer: SlowFirstSequencer },
     // Keep the suite HERMETIC. src/lib/edition-source.ts reads the device's
     // real /etc/clawbox/edition.env to resolve the SKU, so running the tests on
     // an actual ClawBox made them assert against that box's edition instead of


### PR DESCRIPTION
## Summary

Measured on PR #558's runs and fixed at the cause, without weakening what the tests prove.

**e2e-install fails fast.** A green run is ~6–7 min, but when `install.sh`'s bootstrap failed at ~3 min the harness kept polling for the install marker until its 40-minute deadline (41 min to report a failure it could have known at minute 3). `waitForInstallComplete` now asks systemd on every 5 s poll whether `clawbox-bootstrap.service` has failed and throws at once with the unit's state and the tail of the install log; the deadline stays as the backstop for an installer that hangs without failing. The decision is a pure, exported function pinned by a unit test with scripted probes (fails on the poll the unit fails, resolves on marker-gone + HTTP, keeps waiting on activating/unknown, deadline still fires).

**Unit-suite long poles** (CI wall per file → this box after; CI had 4 workers over 529 s of per-file time, 280 s wall):
- `discord/status` 8 tests × a real `openclaw channels status` CLI cold start: 65 s → 0.4 s (the sibling test's mock, plus two more assertions).
- `setup-wizard` 33 s → 0.45 s, `telegram-configuring-overlay` 25 s → 0.3 s, `network` 33 s → 0.2 s: real polling/settle delays driven with fake timers; the "never ready" cases now also assert nothing fires mid-budget.
- `coding-run-preview` 15 s → 3 s: Ctrl-C as soon as the asserted output is there instead of fixed windows; cases run concurrently.
- `sudoers-coverage` 140 s → 112 s on the box: the three scans of the shipped tree run once and are shared; the 30 fixture-mutating scans stay.
- A slow-first sequencer (`src/tests/helpers/slow-first-sequencer.ts`) starts the known-long files first so `sudoers-coverage` and `build-typecheck` are no longer the wall-clock tail. Full suite on the Jetson: 209 s wall.

**CI config.** The Tests job runs `test:coverage:ci` — the same run with only the `json-summary` reporter CI actually reads (588 files and a 600-line coverage table no longer written; the four totals are logged instead); the E2E job caches `.next/cache` across runs; a Playwright helper race (`openLauncher`'s single forced click, lost when a second browser competes for CPU) is fixed with a re-checked retry. Two workers were measured but not enabled: with the retry the whole suite ran 43/43 in 1.1 min at `--workers=2 --retries=0` on the Jetson, but the second run lost one launcher-item click in `browser-vnc.spec.ts` — a different flake class — so CI stays on one worker until that click is made as robust; the evidence is in this PR's discussion.

## Test plan

- [x] Each long-pole file measured alone before/after; the seven together, then the full unit suite on the device (573/574 files — the one failure, `chat-spoken-reply`, is the known load flake and passes alone)
- [x] `e2e-install-wait.test.ts` (15) pins the fail-fast; `ci-workflows.test.ts` (5) pins that the CI script is the local one plus a reporter override and that the cache step precedes the run
- [x] Workflow YAML parsed; `bunx eslint` clean on every touched file
- [ ] CI: Tests, E2E, e2e-install green on this PR — the Tests job's wall time is the number to compare against 280 s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EV9GMHpNmCHHnL2RTALj51


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installation checks now detect bootstrap failures promptly and provide clearer diagnostic log details.
  * Launcher opening is more reliable through automatic retry handling.
  * Improved setup and configuration flow coverage for readiness, timeout, and offline scenarios.

* **Performance**
  * Faster CI builds through build-cache restoration.
  * More efficient test execution by prioritizing slower tests and reducing unnecessary repeated setup.

* **Documentation**
  * Updated installation guidance with clearer timing expectations and failure-diagnostic details.

* **Testing**
  * Expanded coverage for installation, workflow configuration, networking, status reporting, and asynchronous UI behavior.
  * CI coverage now produces a concise machine-readable summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->