### PR TITLE
A box whose password was set outside the wizard can be logged into again

### DIFF
--- a/src/app/login-api/route.ts
+++ b/src/app/login-api/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { get, set } from "@/lib/config-store";
 import { verifyPassword, createSessionCookie, getSessionSigningSecret, getSessionGeneration } from "@/lib/auth";
+import { hasOwnerPassword } from "@/lib/system-password";
 import {
   checkLockout,
   recordFailure,
@@ -85,6 +86,28 @@ export async function POST(request: Request) {
     const setupComplete = await get("setup_complete");
     if (setupComplete) {
       // Auto-migrate: user completed setup before auth was added
+      await set("password_configured", true);
+      await set("password_configured_at", new Date().toISOString());
+    } else if ((await hasOwnerPassword()) === true) {
+      // /etc/shadow is the authority, the flag is only a cache — the same
+      // argument system/credentials already makes (TASK-444a). When the two
+      // disagree in this direction the box is otherwise UNCLAIMABLE:
+      //
+      //   this route          — flag says "no password"  → 400 "Complete setup first"
+      //   system/credentials  — shadow says "owned"      → 401 "Authentication required"
+      //
+      // Neither gate can be satisfied, so the wizard cannot claim the box and
+      // the owner cannot log in. Nothing in the UI recovers it. That state is
+      // reachable without anything exotic: a box imaged by a rig that pre-sets
+      // the account password, a restore that brings back the OS account but not
+      // data/config.json, or an installer who just ran `passwd` over SSH before
+      // opening the wizard.
+      //
+      // Trusting shadow here does NOT weaken the gate. hasOwnerPassword() is
+      // false for both "no password" and the published factory default, so an
+      // as-flashed box still gets the 400 and still cannot be logged into with
+      // the default everyone knows — only a password somebody deliberately set
+      // opens this path, and the caller must still prove it below.
       await set("password_configured", true);
       await set("password_configured_at", new Date().toISOString());
     } else {

--- a/src/tests/routes/login-api.test.ts
+++ b/src/tests/routes/login-api.test.ts
@@ -13,6 +13,10 @@ vi.mock("@/lib/auth", () => ({
   getSessionGeneration: vi.fn().mockResolvedValue(0),
 }));
 
+vi.mock("@/lib/system-password", () => ({
+  hasOwnerPassword: vi.fn(),
+}));
+
 vi.mock("@/lib/login-rate-limit", () => ({
   checkLockout: vi.fn(),
   recordFailure: vi.fn(),
@@ -25,6 +29,7 @@ vi.mock("@/lib/login-rate-limit", () => ({
 import * as config from "@/lib/config-store";
 import { verifyPassword, createSessionCookie, getSessionSigningSecret } from "@/lib/auth";
 import { checkLockout, recordFailure, recordSuccess, padResponseTime } from "@/lib/login-rate-limit";
+import { hasOwnerPassword } from "@/lib/system-password";
 
 const mockGet = vi.mocked(config.get);
 const mockSet = vi.mocked(config.set);
@@ -35,6 +40,7 @@ const mockCheckLockout = vi.mocked(checkLockout);
 const mockRecordFailure = vi.mocked(recordFailure);
 const mockRecordSuccess = vi.mocked(recordSuccess);
 const mockPadResponseTime = vi.mocked(padResponseTime);
+const mockHasOwnerPassword = vi.mocked(hasOwnerPassword);
 
 describe("/login-api", () => {
   let POST: (req: Request) => Promise<Response>;
@@ -49,6 +55,9 @@ describe("/login-api", () => {
     mockCheckLockout.mockResolvedValue({ locked: false, retryAfterSeconds: 0 });
     mockRecordFailure.mockResolvedValue({ locked: false, retryAfterSeconds: 0 });
     mockRecordSuccess.mockResolvedValue(undefined);
+    // Default: no owner password on the account, so the flag alone decides and
+    // the pre-existing cases below are unaffected by the shadow fallback.
+    mockHasOwnerPassword.mockResolvedValue(false);
     const mod = await import("@/app/login-api/route");
     POST = mod.POST;
   });
@@ -185,5 +194,103 @@ describe("/login-api", () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(mockSet).toHaveBeenCalledWith("password_configured", true);
+  });
+
+  // The unclaimable-box deadlock: config.json says "no password" while the OS
+  // account carries one somebody set. system/credentials refuses (shadow says
+  // the box is owned, so it demands a session) and this route used to refuse
+  // too (flag says unconfigured), leaving no way in from the UI at all.
+  describe("when the flag and /etc/shadow disagree", () => {
+    it("lets the owner log in when shadow says the account is owned", async () => {
+      mockGet
+        .mockResolvedValueOnce(null as never)   // password_configured
+        .mockResolvedValueOnce(false as never); // setup_complete — wizard never finished
+      mockHasOwnerPassword.mockResolvedValue(true);
+      mockVerifyPassword.mockResolvedValue(true);
+
+      const req = new Request("http://localhost/login-api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "cf-connecting-ip": "1.2.3.11" },
+        body: JSON.stringify({ password: "the-owners-password", duration: 43200 }),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(200);
+      expect((await res.json()).success).toBe(true);
+    });
+
+    it("heals the stale flag so the next request takes the normal path", async () => {
+      mockGet
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce(false as never);
+      mockHasOwnerPassword.mockResolvedValue(true);
+      mockVerifyPassword.mockResolvedValue(true);
+
+      const req = new Request("http://localhost/login-api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "cf-connecting-ip": "1.2.3.12" },
+        body: JSON.stringify({ password: "the-owners-password", duration: 43200 }),
+      });
+      await POST(req);
+
+      expect(mockSet).toHaveBeenCalledWith("password_configured", true);
+    });
+
+    it("still rejects the wrong password on such a box", async () => {
+      mockGet
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce(false as never);
+      mockHasOwnerPassword.mockResolvedValue(true);
+      mockVerifyPassword.mockResolvedValue(false);
+
+      const req = new Request("http://localhost/login-api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "cf-connecting-ip": "1.2.3.13" },
+        body: JSON.stringify({ password: "wrong", duration: 43200 }),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(401);
+    });
+
+    // The security property that makes trusting shadow safe: hasOwnerPassword()
+    // is false for the published factory default, so an as-flashed box is still
+    // refused here and must go through the wizard.
+    it("keeps refusing an as-flashed box, whose account holds only the factory default", async () => {
+      mockGet
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce(false as never);
+      mockHasOwnerPassword.mockResolvedValue(false);
+      mockVerifyPassword.mockResolvedValue(true);
+
+      const req = new Request("http://localhost/login-api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "cf-connecting-ip": "1.2.3.14" },
+        body: JSON.stringify({ password: "clawbox", duration: 43200 }),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+      expect(mockSet).not.toHaveBeenCalledWith("password_configured", true);
+    });
+
+    // hasOwnerPassword() returns null when /etc/shadow cannot be read at all.
+    // "Unknown" must not open the path.
+    it("refuses when the shadow state cannot be read", async () => {
+      mockGet
+        .mockResolvedValueOnce(null as never)
+        .mockResolvedValueOnce(false as never);
+      mockHasOwnerPassword.mockResolvedValue(null);
+      mockVerifyPassword.mockResolvedValue(true);
+
+      const req = new Request("http://localhost/login-api", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "cf-connecting-ip": "1.2.3.15" },
+        body: JSON.stringify({ password: "anything", duration: 43200 }),
+      });
+      const res = await POST(req);
+
+      expect(res.status).toBe(400);
+    });
   });
 });


### PR DESCRIPTION
Found during a QA sweep of a freshly-flashed unit on `beta` @ `cac44028`. The box could not be claimed at all.

## The deadlock

`/etc/shadow` is the authority for "does this box have an owner"; the `password_configured` flag in `data/config.json` is only a cache of it. `system/credentials` already knows this (TASK-444a). `/login-api` did not — it gated on the flag alone. When the two disagreed, both onboarding gates refused:

| Endpoint | Consults | Answer |
|---|---|---|
| `/login-api` | `password_configured` flag → falsy | `400 Password not configured. Complete setup first.` |
| `/setup-api/system/credentials` | `/etc/shadow` → owned | `401 Authentication required` |

The wizard cannot claim the box, and the owner cannot log in. Nothing in the UI recovers it — only an SSH session that resets the account back to the factory default.

## Observed on hardware

```
$ passwd -S clawbox
clawbox P 08/30/2026 0 99999 7 -1          # a usable password is set

$ printf "clawbox\0" | /usr/sbin/unix_chkpwd clawbox nonull; echo $?
7                                           # PAM_AUTH_ERR — not the factory default

$ cat data/config.json
{"setup_progress_step": 3, "hostname": "clawbox"}   # no password_configured key

$ curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1/login-api \
    -H "Content-Type: application/json" -d "{\"password\":\"<the owner password>\"}"
400          {"error":"Password not configured. Complete setup first."}

$ curl -s -o /dev/null -w "%{http_code}\n" -X POST http://127.0.0.1/setup-api/system/credentials \
    -H "Content-Type: application/json" -d "{\"password\":\"<a new password>\"}"
401          {"error":"Authentication required"}
```

Restoring the account to the factory default is the only thing that breaks the tie — after `chpasswd` puts `clawbox` back, the unmodified wizard call succeeds immediately, which isolates the account state as the sole cause:

```
$ echo clawbox:clawbox | sudo chpasswd
$ curl -s -w "%{http_code}\n" -X POST http://127.0.0.1/setup-api/system/credentials \
    -H "Content-Type: application/json" -d "{\"password\":\"<a new password>\"}"
200          {"success":true,"authenticated":true}
```

The state needs nothing exotic to reach: an imaging rig that pre-sets the account password, a restore that brings back the OS account but not `data/config.json`, or an installer who ran `passwd` over SSH before opening the wizard.

## The fix

When the flag is falsy and setup is not complete, ask `hasOwnerPassword()` before refusing. If `/etc/shadow` says the account carries a password somebody set, let the login proceed and heal the stale flag.

## Why this does not weaken the gate

`hasOwnerPassword()` answers:

- `false` for **no password** and for the **published factory default** → an as-flashed box still gets the `400` and still cannot be logged into with the default that is in this repository
- `null` when `/etc/shadow` cannot be read at all → stays closed
- `true` only for a password somebody deliberately set → and the caller must still prove it via `verifyPassword`

## Tests

`src/tests/routes/login-api.test.ts` — 5 new cases, 3 of which fail on `beta` and pass here:

- ✅ lets the owner log in when shadow says the account is owned *(fails before)*
- ✅ heals the stale flag so the next request takes the normal path *(fails before)*
- ✅ still rejects the wrong password on such a box *(fails before)*
- ✅ keeps refusing an as-flashed box holding only the factory default *(guards the security property)*
- ✅ refuses when the shadow state cannot be read *(guards the `null` case)*

Full suite: **8423 passed / 579 files**, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Login now recognizes an existing configured system password even when the setup status is stale.
  - Successful authentication repairs the password configuration status automatically.
  - Systems without a configured owner password continue to require initial setup.
  - Invalid credentials, factory-default accounts, and unreadable password states remain blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->