### PR TITLE
A box whose primary model is llamacpp can answer again

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -254,10 +254,14 @@ if isinstance(_primary_now, str):
 _fallbacks_now = model_defaults.get("fallbacks")
 if isinstance(_fallbacks_now, list):
     _llamacpp_refs.extend([f for f in _fallbacks_now if isinstance(f, str)])
-_wants_llamacpp = [r for r in _llamacpp_refs if r.startswith("llamacpp/")]
+# The runtime trims the ref before it checks the prefix, so " llamacpp/x " starts
+# the local runtime but would skip this repair and still fail model resolution.
+_wants_llamacpp = [r.strip() for r in _llamacpp_refs if r.strip().startswith("llamacpp/")]
 
 _mp = cfg.setdefault("models", {}).setdefault("providers", {})
-if _wants_llamacpp and not _mp.get("llamacpp"):
+# Key presence, not truthiness: an existing but empty {} entry is a deliberate
+# operator choice and must be preserved, which .get() would silently overwrite.
+if _wants_llamacpp and "llamacpp" not in _mp:
     # The proxy authenticates openclaw -> Next.js with a per-install bearer
     # (src/lib/local-ai-token.ts). Writing the entry WITHOUT it would trade
     # "Unknown model" for a 401 on every turn, which is not an improvement, so
@@ -281,7 +285,13 @@ if _wants_llamacpp and not _mp.get("llamacpp"):
         )
     else:
         _model_id = _wants_llamacpp[0][len("llamacpp/"):]
-        _ctx = int(os.environ.get("LLAMACPP_CONTEXT_WINDOW") or 0)
+        # A non-numeric override must not abort gateway pre-start: this migration
+        # runs on the path that repairs a mute box, so raising here would turn a
+        # bad env var into a box that never starts at all.
+        try:
+            _ctx = int(os.environ.get("LLAMACPP_CONTEXT_WINDOW") or 0)
+        except ValueError:
+            _ctx = 0
         if _ctx < 16384:
             _ctx = 131072
         _proxy_root = (

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -223,6 +223,87 @@ if isinstance(primary_model, str) and primary_model.lower() in (
     model_defaults["primary"] = "llamacpp/gemma4-e2b-it-q4_0"
     changed = True
 
+# Migration: a primary (or fallback) that names `llamacpp/<model>` while
+# `models.providers.llamacpp` is absent. OpenClaw ships an `ollama` plugin but
+# NO llamacpp one, so `llamacpp/*` resolves ONLY through an explicit provider
+# entry. Without it every chat turn dies before the agent can reply:
+#
+#   [model-fallback/decision] decision=candidate_failed
+#       requested=llamacpp/gemma4-e2b-it-q4_0 reason=model_not_found next=none
+#   Embedded agent failed before reply: Unknown model: llamacpp/gemma4-e2b-it-q4_0
+#
+# Measured on a freshly-provisioned Orin Nano: `models.providers` was `{}` from
+# the install onward, and the dead-Anthropic migration directly above then moved
+# `primary` onto the local model — swapping one unresolvable id for another and
+# leaving the box just as mute. The device's OWN status route reports the model
+# `available: true` the whole time (it reads the llamacpp runtime, which is
+# genuinely installed and answers on its proxy), so nothing surfaces the gap.
+#
+# `ai-models/configure` writes this entry on the local-AI path, but a box that
+# reaches llamacpp through the migration above — or through an image that
+# pre-set `primary` — never runs that route. Same shape, and the same fix, as
+# the OpenRouter provider-def migration further down.
+#
+# Keep in step with the isLlamaCpp branch of
+# src/app/setup-api/ai-models/configure/route.ts and the constants in
+# src/lib/llamacpp.ts; a shell migration cannot import them.
+_llamacpp_refs = []
+_primary_now = model_defaults.get("primary")
+if isinstance(_primary_now, str):
+    _llamacpp_refs.append(_primary_now)
+_fallbacks_now = model_defaults.get("fallbacks")
+if isinstance(_fallbacks_now, list):
+    _llamacpp_refs.extend([f for f in _fallbacks_now if isinstance(f, str)])
+_wants_llamacpp = [r for r in _llamacpp_refs if r.startswith("llamacpp/")]
+
+_mp = cfg.setdefault("models", {}).setdefault("providers", {})
+if _wants_llamacpp and not _mp.get("llamacpp"):
+    # The proxy authenticates openclaw -> Next.js with a per-install bearer
+    # (src/lib/local-ai-token.ts). Writing the entry WITHOUT it would trade
+    # "Unknown model" for a 401 on every turn, which is not an improvement, so
+    # a box with no token file is left alone and told why.
+    _token_path = os.path.join(
+        os.environ.get("CLAWBOX_ROOT", "/home/clawbox/clawbox"), "data", ".local-ai-token"
+    )
+    try:
+        with open(_token_path) as _tf:
+            _local_ai_token = _tf.read().strip()
+    except OSError:
+        _local_ai_token = ""
+
+    if len(_local_ai_token) < 16:
+        print(
+            "  Skipped llamacpp provider repair: "
+            + _wants_llamacpp[0]
+            + " is configured but "
+            + _token_path
+            + " is missing or too short, so the proxy would reject every call."
+        )
+    else:
+        _model_id = _wants_llamacpp[0][len("llamacpp/"):]
+        _ctx = int(os.environ.get("LLAMACPP_CONTEXT_WINDOW") or 0)
+        if _ctx < 16384:
+            _ctx = 131072
+        _proxy_root = (
+            os.environ.get("CLAWBOX_LOCAL_AI_PROXY_BASE_URL") or "http://127.0.0.1"
+        ).strip().rstrip("/")
+        _mp["llamacpp"] = {
+            "baseUrl": _proxy_root + "/setup-api/local-ai/llamacpp/v1",
+            "api": "openai-completions",
+            "apiKey": _local_ai_token,
+            "models": [{
+                "id": _model_id,
+                "name": _model_id,
+                "reasoning": False,
+                "input": ["text"],
+                "cost": {"input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0},
+                "contextWindow": _ctx,
+                "maxTokens": _ctx,
+            }],
+        }
+        changed = True
+        print("  Repaired models.providers.llamacpp for " + _wants_llamacpp[0])
+
 # Model migration: legacy ChatGPT-subscription devices can have their active
 # model — or a fallback — stored as `openai/<gpt>` from before the setup UI
 # routed ChatGPT picks through Codex. On a device with ChatGPT (Codex OAuth)

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// A ClawBox whose `agents.defaults.model.primary` names `llamacpp/<model>` while
+// `models.providers` has no `llamacpp` entry cannot answer at all. OpenClaw
+// ships an `ollama` plugin but no llamacpp one, so `llamacpp/*` resolves ONLY
+// through an explicit provider def, and without it every turn ends:
+//
+//   [model-fallback/decision] decision=candidate_failed
+//       requested=llamacpp/gemma4-e2b-it-q4_0 reason=model_not_found next=none
+//   Embedded agent failed before reply: Unknown model: llamacpp/gemma4-e2b-it-q4_0
+//
+// Observed on a freshly-provisioned Orin Nano (TASK-512): `models.providers` was
+// `{}` from install onward, and the dead-Anthropic migration then moved
+// `primary` onto the local model — swapping one unresolvable id for another.
+// That pairing is why both blocks are extracted together below: the repair has
+// to hold for the config the migration itself produces.
+//
+// These run the migration out of the shipped .sh, not a copy, so the test fails
+// if the real script drifts. Same approach as
+// gateway-pre-start-clawai-images.test.ts.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const hasPython3 = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+/**
+ * Pull the dead-Anthropic model migration AND the llamacpp provider repair that
+ * follows it out of the .sh verbatim, as one region.
+ */
+function extractPolicy(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf("# Model migration: some early ClawBox images/configs");
+  const end = src.indexOf("# Model migration: legacy ChatGPT-subscription devices", start);
+  if (start < 0 || end < 0) throw new Error("llamacpp provider migration block not found");
+  return src.slice(start, end);
+}
+
+const POLICY = hasPython3 ? extractPolicy() : "";
+
+let dir: string;
+let root: string;
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "llamacpp-provider-"));
+  root = path.join(dir, "clawbox");
+  mkdirSync(path.join(root, "data"), { recursive: true });
+});
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+type Config = Record<string, unknown>;
+type ProviderDef = {
+  baseUrl?: string;
+  api?: string;
+  apiKey?: string;
+  models?: Array<{ id?: string; name?: string; contextWindow?: number; maxTokens?: number }>;
+};
+
+const TOKEN = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+function writeToken(value: string | null): void {
+  if (value === null) return;
+  writeFileSync(path.join(root, "data", ".local-ai-token"), value);
+}
+
+/**
+ * Run the extracted region over a whole openclaw.json.
+ *
+ * The preamble reproduces only the names the region reads from its surrounding
+ * scope, exactly as the real script binds them upstream (`cfg`,
+ * `agents_defaults`, `changed`) — mock at that boundary and nothing else, so
+ * the logic under test is 100% the shipped bytes.
+ */
+function migrate(cfg: Config, env: Record<string, string> = {}): { cfg: Config; changed: boolean; log: string } {
+  const file = path.join(dir, "config.json");
+  writeFileSync(file, JSON.stringify(cfg));
+  const program = [
+    "import json, os, sys",
+    "cfg = json.load(open(sys.argv[1]))",
+    'agents_defaults = cfg.setdefault("agents", {}).setdefault("defaults", {})',
+    "changed = False",
+    POLICY,
+    "print(json.dumps({'cfg': cfg, 'changed': changed}))",
+  ].join("\n");
+  const lines = execFileSync("python3", ["-c", program, file], {
+    encoding: "utf-8",
+    env: { ...process.env, CLAWBOX_ROOT: root, ...env },
+  }).trim().split("\n");
+  return { ...JSON.parse(lines[lines.length - 1]), log: lines.slice(0, -1).join("\n") };
+}
+
+function llamacppProvider(cfg: Config): ProviderDef {
+  const models = (cfg.models ?? {}) as { providers?: Record<string, ProviderDef> };
+  return models.providers?.llamacpp ?? {};
+}
+
+function primaryOf(cfg: Config): unknown {
+  const agents = (cfg.agents ?? {}) as { defaults?: { model?: { primary?: unknown } } };
+  return agents.defaults?.model?.primary;
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without a provider def", () => {
+  it("registers the provider when the primary names llamacpp and none exists", () => {
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(true);
+    const p = llamacppProvider(cfg);
+    expect(p.baseUrl).toBe("http://127.0.0.1/setup-api/local-ai/llamacpp/v1");
+    expect(p.api).toBe("openai-completions");
+    expect(p.apiKey).toBe(TOKEN);
+    expect(p.models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
+    expect(p.models?.[0]?.contextWindow).toBe(131072);
+  });
+
+  // The exact hardware sequence: a box on the retired Anthropic id with an empty
+  // provider map. The migration moves it to llamacpp; the repair must make that
+  // destination resolvable, or the box is mute either way.
+  it("leaves the box answerable after the dead-Anthropic migration moves it to llamacpp", () => {
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-20250514" } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(primaryOf(cfg)).toBe("llamacpp/gemma4-e2b-it-q4_0");
+    expect(llamacppProvider(cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
+    expect(llamacppProvider(cfg).apiKey).toBe(TOKEN);
+  });
+
+  it("repairs from a fallback that names llamacpp, not only the primary", () => {
+    writeToken(TOKEN);
+    const { cfg } = migrate({
+      models: { providers: {} },
+      agents: {
+        defaults: {
+          model: { primary: "clawai/some-cloud-model", fallbacks: ["llamacpp/gemma4-e2b-it-q4_0"] },
+        },
+      },
+    });
+
+    expect(llamacppProvider(cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
+  });
+
+  it("uses the model id actually configured, not a hardcoded one", () => {
+    writeToken(TOKEN);
+    const { cfg } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/some-other-model-q8" } } },
+    });
+
+    expect(llamacppProvider(cfg).models?.[0]?.id).toBe("some-other-model-q8");
+    expect(llamacppProvider(cfg).models?.[0]?.name).toBe("some-other-model-q8");
+  });
+
+  it("honours LLAMACPP_CONTEXT_WINDOW, and ignores a value below the floor", () => {
+    writeToken(TOKEN);
+    const big = migrate(
+      { models: { providers: {} }, agents: { defaults: { model: { primary: "llamacpp/m" } } } },
+      { LLAMACPP_CONTEXT_WINDOW: "32768" },
+    );
+    expect(llamacppProvider(big.cfg).models?.[0]?.contextWindow).toBe(32768);
+
+    const tooSmall = migrate(
+      { models: { providers: {} }, agents: { defaults: { model: { primary: "llamacpp/m" } } } },
+      { LLAMACPP_CONTEXT_WINDOW: "128" },
+    );
+    expect(llamacppProvider(tooSmall.cfg).models?.[0]?.contextWindow).toBe(131072);
+  });
+
+  // Writing the entry without the bearer would trade "Unknown model" for a 401
+  // on every turn. That is not an improvement, so it must refuse and say so.
+  it("refuses to write a provider it cannot authenticate, and says why", () => {
+    writeToken(null);
+    const { cfg, changed, log } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(llamacppProvider(cfg)).toEqual({});
+    expect(log).toContain("Skipped llamacpp provider repair");
+    expect(log).toContain(".local-ai-token");
+  });
+
+  it("refuses on a truncated token rather than writing a key that cannot work", () => {
+    writeToken("tooshort");
+    const { changed, log } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(log).toContain("Skipped llamacpp provider repair");
+  });
+
+  it("leaves an existing llamacpp provider untouched", () => {
+    writeToken(TOKEN);
+    const existing = {
+      baseUrl: "http://127.0.0.1:8080/v1",
+      api: "openai-completions",
+      apiKey: "an-operators-own-key",
+      models: [{ id: "gemma4-e2b-it-q4_0", name: "gemma4-e2b-it-q4_0" }],
+    };
+    const { cfg, changed } = migrate({
+      models: { providers: { llamacpp: existing } },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(llamacppProvider(cfg)).toEqual(existing);
+  });
+
+  it("does nothing on a box that does not use llamacpp at all", () => {
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: { openai: { baseUrl: "https://api.openai.com/v1" } } },
+      agents: { defaults: { model: { primary: "openai/gpt-5.5", fallbacks: ["clawai/x"] } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(llamacppProvider(cfg)).toEqual({});
+  });
+});

--- a/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
+++ b/src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts
@@ -226,4 +226,51 @@ describe.skipIf(!hasPython3)("gateway-pre-start.sh — llamacpp primary without 
     expect(changed).toBe(false);
     expect(llamacppProvider(cfg)).toEqual({});
   });
+
+  // --- CodeRabbit round on #562 ------------------------------------------
+
+  it("repairs a primary carrying stray whitespace", () => {
+    // The runtime trims before it checks the prefix, so "  llamacpp/x  " starts
+    // the local runtime; without trimming here the repair is skipped and the box
+    // stays mute for a reason nothing reports.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: {} },
+      agents: { defaults: { model: { primary: "  llamacpp/gemma4-e2b-it-q4_0  " } } },
+    });
+
+    expect(changed).toBe(true);
+    expect(llamacppProvider(cfg).models?.[0]?.id).toBe("gemma4-e2b-it-q4_0");
+  });
+
+  it("preserves an existing but EMPTY llamacpp provider entry", () => {
+    // {} is falsy, so a .get() check would silently overwrite an operator's
+    // deliberate empty entry, contrary to the migration's preservation contract.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate({
+      models: { providers: { llamacpp: {} } },
+      agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+    });
+
+    expect(changed).toBe(false);
+    expect(llamacppProvider(cfg)).toEqual({});
+  });
+
+  it("survives a non-numeric LLAMACPP_CONTEXT_WINDOW instead of aborting pre-start", () => {
+    // int("banana") raised ValueError and took gateway pre-start down with it,
+    // turning a bad env var into a box that never starts at all.
+    writeToken(TOKEN);
+    const { cfg, changed } = migrate(
+      {
+        models: { providers: {} },
+        agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } },
+      },
+      { LLAMACPP_CONTEXT_WINDOW: "banana" },
+    );
+
+    expect(changed).toBe(true);
+    const ctx = llamacppProvider(cfg).models?.[0]?.contextWindow;
+    expect(typeof ctx).toBe("number");
+    expect(ctx).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Symptom

On a freshly-provisioned Orin Nano, chat is completely non-functional. Every
turn fails before the agent can reply:

```
[gateway] agent model: llamacpp/gemma4-e2b-it-q4_0 (thinking=medium, fast=off)
[diagnostic] lane task error: lane=main
    error="FailoverError: Unknown model: llamacpp/gemma4-e2b-it-q4_0"
[model-fallback/decision] decision=candidate_failed
    requested=llamacpp/gemma4-e2b-it-q4_0 candidate=llamacpp/gemma4-e2b-it-q4_0
    reason=model_not_found next=none
Embedded agent failed before reply: Unknown model: llamacpp/gemma4-e2b-it-q4_0
```

Driven through the real gateway WebSocket (`connect` → `chat.send`, exactly what
`ChatApp.tsx:410-420` sends), the user sees:

```
chat state=final
"⚠️ Agent failed before reply: Unknown model: llamacpp/gemma4-e2b-it-q4_0."
```

## Root cause

`~/.openclaw/openclaw.json` on the affected box:

```json
"models":  { "providers": {} },
"agents":  { "defaults": { "model": { "primary": "llamacpp/gemma4-e2b-it-q4_0" } } }
```

OpenClaw ships an `ollama` plugin but **no llamacpp one** — its own `health`
event lists the loaded plugins as `browser, canvas, device-pair, file-transfer,
memory-core, ollama, phone-control, talk-voice, tts-local-cli`. So `llamacpp/*`
resolves **only** through an explicit `models.providers.llamacpp` entry, and
there isn't one. `openclaw-config.ts:387` states the same rule from the other
side: "a present-but-empty `models.providers.<p>` is still read by the gateway
as a provider definition."

The config backups show how the box got there:

```
openclaw.json.bak.4   12:51:39  providers=[] primary='anthropic/claude-sonnet-4-20250514'
openclaw.json.bak     13:48:09  providers=[] primary='anthropic/claude-sonnet-4-20250514'
openclaw.json         14:06:01  providers=[] primary='llamacpp/gemma4-e2b-it-q4_0'
```

`models.providers` was `{}` from the install onward. At 14:06 the primary flipped
to the local model — that is the "Model migration" block in
`scripts/gateway-pre-start.sh`, which rescues boxes stuck on the retired May-2025
Sonnet id. It writes `primary` and **nothing else**, so it moves the box from one
unresolvable model to another and leaves it just as mute. Its own comment says it
exists because "every chat turn fails before the agent can reply" — which remained
true afterwards.

`ai-models/configure` writes the provider def on the local-AI path
(`src/app/setup-api/ai-models/configure/route.ts:2127-2146`), and
`src/app/setup-api/llamacpp/install/route.ts:210-214` invokes it — but a box that
arrives at llamacpp *through the migration*, or from an image that pre-set
`primary`, never runs that route. The runtime is installed and fine; only the
OpenClaw-side registration is missing.

Two things make this hard to notice: the failure is only visible in the gateway
log, and ClawBox actively reports the broken model as usable —
`/setup-api/chat/model` returns `"available": true` for it, derived from the
llamacpp runtime being present and never cross-checked against
`models.providers`.

## Fix

Repair the config at gateway start, in the same script and immediately after the
migration that creates the state: when the primary or any fallback names
`llamacpp/<model>` and `models.providers.llamacpp` is absent, write the provider
def the local-AI path would have written.

This is the same bug shape — and the same remedy — as the OpenRouter
provider-def migration already in this script ("`auth.profiles.openrouter:default`
set but no `models.providers.openrouter` entry, so OpenClaw's runtime has no
baseUrl to call and every chat turn silently returns `usage: 0/0/0`").

Deliberate refusals:

- **No token, no write.** If `data/.local-ai-token` is missing or shorter than 16
  chars, it writes nothing and logs why. The proxy authenticates
  openclaw → Next.js with a per-install bearer (`src/lib/local-ai-token.ts`);
  writing the entry without it would trade "Unknown model" for a 401 on every
  turn, which is not an improvement.
- **Never overwrites** an existing `models.providers.llamacpp`.
- **Uses the configured model id**, not a hardcoded one.
- Honours `LLAMACPP_CONTEXT_WINDOW`, with the same ≥16384 floor as
  `src/lib/llamacpp.ts`.

## Evidence

Verified on real hardware (Jetson Orin Nano, `CLAWBOX_EDITION=openclaw`) that the
defect reproduces exactly as described above, and that the llamacpp runtime
itself is healthy — through the very proxy OpenClaw is meant to use:

```
POST /setup-api/local-ai/llamacpp/v1/chat/completions   (Bearer <local-ai token>)
{"model":"gemma4-e2b-it-q4_0","messages":[{"role":"user","content":"Reply with exactly: PONG"}]}

HTTP=200  TIME=15.91s      # includes the standby cold start
{"choices":[{"message":{"role":"assistant","content":"PONG"}}],"usage":{"total_tokens":18}}
$ ss -ltn | grep 8080
LISTEN 127.0.0.1:8080      # llama-server woke on demand, as designed
```

So the model answers fine; only the registration was missing.

## Test

`src/tests/unit/gateway-pre-start-llamacpp-provider.test.ts` — 9 cases. It
extracts the migration region out of the **shipped** `.sh` rather than a copy, so
it fails if the real script drifts (same approach as
`gateway-pre-start-clawai-images.test.ts`).

```
# script reverted to pre-fix
 Test Files  1 failed (1)
      Tests  7 failed | 2 passed (9)

# with the fix
 Test Files  1 passed (1)
      Tests  9 passed (9)
```

The 2 that pass either way are the negative cases ("leaves an existing provider
untouched", "does nothing on a non-llamacpp box"), which should hold regardless.

One case reproduces the exact hardware sequence: primary on the retired Anthropic
id with `models.providers: {}` → the migration moves it to
`llamacpp/gemma4-e2b-it-q4_0` **and** the destination is now resolvable.

## Not covered here

Nothing asserts that `agents.defaults.model.primary` names a provider that
actually exists in `models.providers`, and `/setup-api/chat/model` still reports
`available: true` without consulting it. This PR repairs the state at boot; it
does not add that invariant. Worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic setup for Llama.cpp model connections configured as the primary model or a fallback.
  * Supports configurable proxy URLs, model identifiers, and context-window settings.
  * Preserves existing provider configurations, including empty entries, and handles legacy provider setups.

* **Bug Fixes**
  * Repairs missing or invalid Llama.cpp provider configuration during gateway startup.
  * Ignores malformed configuration values and skips changes when authentication credentials are unavailable or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->