### PR TITLE
docs: the box ships with a local model, and say which one

### DIFF
--- a/docs-site/hardware/clawbox-connect.mdx
+++ b/docs-site/hardware/clawbox-connect.mdx
@@ -6,11 +6,11 @@ summary: "Hardware specifications for ClawBox Connect — the always-on AI assis
 
 The entry-tier ClawBox: a compact, low-power, always-on AI assistant for your desk.
 
-<Card title="Get ClawBox Connect — €549" href="https://clawbox.com" icon="cart-shopping" horizontal>
+<Card title="Get ClawBox Connect — €579" href="https://clawbox.com" icon="cart-shopping" horizontal>
   Pre-configured with OpenClaw. Ships ready to use.
 </Card>
 
-<Card title="Prefer Hermes Agent? — €549" href="https://clawbox.com/hermes" icon="cart-shopping" horizontal>
+<Card title="Prefer Hermes Agent? — €579" href="https://clawbox.com/hermes" icon="cart-shopping" horizontal>
   ClawBox Hermes Edition is the same hardware, shipped running Hermes Agent by Nous
   Research instead of OpenClaw. Every specification on this page applies to both.
 </Card>
@@ -34,9 +34,40 @@ The entry-tier ClawBox: a compact, low-power, always-on AI assistant for your de
 
 - A **24/7 personal assistant** you message from Telegram or the web, with additional OpenClaw channels available for advanced setups when supported.
 - **Browser automation** and everyday agent tasks.
-- Running with **cloud AI providers** (ClawBox AI, Claude, GPT, Gemini) or smaller local models.
+- Running the **preinstalled on-device model** offline, or **cloud AI providers** (ClawBox AI, Claude, GPT, Gemini) when you want heavier reasoning.
 
-## Local model performance
+## The local model it ships with
+
+ClawBox arrives with a local model already installed and running, so it works
+offline out of the box with nothing to download. It is **Google Gemma 4 E2B**
+(the QAT Q4_0 build) served by **llama.cpp**, and it appears in the provider and
+chat pickers as **Gemma 4 (on-device)**. No API key, no account, no internet.
+
+| Gemma 4 E2B (shipped default) | |
+|---|---|
+| Generation | ~29 tok/s |
+| Download / resident | ~3.1 GB / ~3.3 GB |
+| Agentic tool use | 92.3% |
+| Strict JSON | 100% |
+
+Measured on a Jetson Orin Nano 8GB against llama-server, the runtime the device
+actually ships.
+
+**Why this build, and not a faster one.** Four candidates from the same model
+family were benchmarked on the device. Three were faster — one reached 34.7
+tok/s — and all four scored 100% on strict JSON. This one ships because it is the
+only one that reliably completes a two-step tool chain: look up the contact, then
+send the mail. The others stop halfway and ask you for the address they were sent
+to find. The larger E4B variant was rejected on the same grounds: 18.3 tok/s and
+1.8 GB more memory for no gain in accuracy.
+
+<Note>
+Installing Gemma 4 E2B from **Ollama** instead gives you a Q8_0 artifact of about
+8.1 GB, which does not fit in 8 GB. The 3.1 GB above is the Q4_0 GGUF this device
+ships with.
+</Note>
+
+## Bring your own local model (Ollama)
 
 | Model | Speed | Quality |
 |---|---|---|

--- a/docs-site/hardware/requirements.mdx
+++ b/docs-site/hardware/requirements.mdx
@@ -61,10 +61,41 @@ Running OpenClaw on dedicated hardware vs a shared VPS or your daily-use laptop:
 | **24/7 uptime** — heartbeats, schedules, monitoring never stop | Stops when your laptop sleeps or restarts |
 | **No resource competition** — 100% dedicated CPU/GPU/RAM | Browser, Slack, IDE fight for memory |
 | **Consistent performance** — no noisy neighbors | Unpredictable slowdowns |
-| **Lower long-term cost** — €549 once vs €20–40/mo VPS | €720–2,880 over 3 years |
+| **Lower long-term cost** — €579 once vs €20–40/mo VPS | €720–2,880 over 3 years |
 | **True privacy** — data stays on your hardware | Cloud provider has access |
 
-## Local model performance (ClawBox Connect, 67 TOPS)
+## The local model it ships with
+
+ClawBox arrives with a local model already installed and running, so it works
+offline out of the box with nothing to download. It is **Google Gemma 4 E2B**
+(the QAT Q4_0 build) served by **llama.cpp**, and it appears in the provider and
+chat pickers as **Gemma 4 (on-device)**. No API key, no account, no internet.
+
+| Gemma 4 E2B (shipped default) | |
+|---|---|
+| Generation | ~29 tok/s |
+| Download / resident | ~3.1 GB / ~3.3 GB |
+| Agentic tool use | 92.3% |
+| Strict JSON | 100% |
+
+Measured on a Jetson Orin Nano 8GB against llama-server, the runtime the device
+actually ships.
+
+**Why this build, and not a faster one.** Four candidates from the same model
+family were benchmarked on the device. Three were faster — one reached 34.7
+tok/s — and all four scored 100% on strict JSON. This one ships because it is the
+only one that reliably completes a two-step tool chain: look up the contact, then
+send the mail. The others stop halfway and ask you for the address they were sent
+to find. The larger E4B variant was rejected on the same grounds: 18.3 tok/s and
+1.8 GB more memory for no gain in accuracy.
+
+<Note>
+Installing Gemma 4 E2B from **Ollama** instead gives you a Q8_0 artifact of about
+8.1 GB, which does not fit in 8 GB. The 3.1 GB above is the Q4_0 GGUF this device
+ships with.
+</Note>
+
+## Bring your own local model (Ollama)
 
 | Model | Speed | Quality |
 |---|---|---|

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -57,7 +57,7 @@ These are separate products at checkout, so your order is identifiable as one or
 
 <Columns cols={2}>
   <Card title="ClawBox Connect" href="/hardware/clawbox-connect" icon="cube">
-    NVIDIA Jetson Orin Nano · 67 TOPS · always-on assistant. **€549**
+    NVIDIA Jetson Orin Nano · 67 TOPS · always-on assistant. **€579**
   </Card>
   <Card title="ClawBox Workstation" href="/hardware/clawbox-workstation" icon="server">
     NVIDIA DGX Spark · 1 PFLOP · run 200B-param models locally. **€5,499**

--- a/docs-site/llms.txt
+++ b/docs-site/llms.txt
@@ -44,9 +44,9 @@ Key facts: web UI at http://<box-ip> port 80 (never :18789 — that's the token-
 
 ## Hardware
 
-- [ClawBox Connect](https://docs.clawbox.com/hardware/clawbox-connect): Jetson Orin Nano model
+- [ClawBox Connect](https://docs.clawbox.com/hardware/clawbox-connect): Jetson Orin Nano model; ships with Google Gemma 4 E2B (QAT Q4_0) preinstalled on llama.cpp, ~29 tok/s, ~3.3 GB resident, offline with no API key
 - [ClawBox Workstation](https://docs.clawbox.com/hardware/clawbox-workstation): DGX Spark model
-- [Requirements](https://docs.clawbox.com/hardware/requirements)
+- [Requirements](https://docs.clawbox.com/hardware/requirements): the shipped on-device model and its measured numbers, plus the Ollama bring-your-own table
 
 ## Using ClawBox
 

--- a/docs-site/support/faq.mdx
+++ b/docs-site/support/faq.mdx
@@ -8,7 +8,7 @@ summary: "Frequently asked questions about ClawBox hardware, software, and subsc
   <Accordion title="Does ClawBox run OpenClaw or Hermes Agent?">
     Either — you choose when you order. **ClawBox (Connect)** ships running OpenClaw.
     **ClawBox Hermes Edition** ships running Hermes Agent by Nous Research. Both are
-    €549 and identical hardware; they are separate products at checkout, so your box
+    €579 and identical hardware; they are separate products at checkout, so your box
     arrives already set up with the agent you picked.
 
     You are not locked in. Switching between OpenClaw and Hermes Agent on a box you
@@ -31,7 +31,7 @@ summary: "Frequently asked questions about ClawBox hardware, software, and subsc
     [Choose Your AI Provider](/setup/choose-ai-provider).
   </Accordion>
   <Accordion title="What's the difference between Connect and Workstation?">
-    **ClawBox Connect** (Jetson Orin Nano, €549) is a low-power always-on assistant.
+    **ClawBox Connect** (Jetson Orin Nano, €579) is a low-power always-on assistant.
     **ClawBox Workstation** (DGX Spark, €5,499) is a personal AI supercomputer that runs
     large models locally. Full comparison on the
     [Workstation page](/hardware/clawbox-workstation).


### PR DESCRIPTION
## The gap

`hardware/requirements.mdx` and `hardware/clawbox-connect.mdx` listed four Ollama models under **Local model performance** and never mentioned that ClawBox already has a working local model on it. Read literally, they say the box arrives empty and that offline use starts with a download. It does not — **Google Gemma 4 E2B (QAT Q4_0)** is preinstalled and served by llama.cpp, offline, no API key. Only `editions/hermes-providers.mdx` named it, in passing.

This is a sales problem as much as a docs one: "it works offline the moment you plug it in" is one of the strongest things about the product and it was nowhere on the hardware pages.

## What this adds

A **The local model it ships with** section on both pages, with the numbers from the device team's own candidate bake-off on a Jetson Orin Nano 8GB against llama-server (the runtime we actually ship — source: `src/lib/llamacpp.ts`):

| Gemma 4 E2B (shipped default) | |
|---|---|
| Generation | ~29 tok/s |
| Download / resident | ~3.1 GB / ~3.3 GB |
| Agentic tool use | 92.3% |
| Strict JSON | 100% |

And **why that build rather than a faster one**, which is the more useful fact for a buyer: three of the four candidates were faster (one at 34.7 tok/s) and all four scored 100% on strict JSON, but only this one reliably completes a two-step tool chain — look up the contact, then send the mail. The others stop halfway and ask for the address they were sent to find. E4B was rejected on the same grounds: 18.3 tok/s and 1.8 GB more memory for no gain.

The existing Ollama table keeps its numbers and its methodology link, retitled **Bring your own local model (Ollama)** — which is what it always described.

A `<Note>` warns that Ollama's own Gemma 4 E2B is a **Q8_0 artifact of ~8.1 GB** and will not fit in 8 GB, so nobody reads the 3.1 GB figure and pulls the wrong artifact.

`llms.txt` summaries updated so the same facts reach anything consuming the docs that way.

## Also in here

The price has been **€579 since 21 August** and six places still said €549: `requirements.mdx`, `clawbox-connect.mdx` (×2), `index.mdx`, `faq.mdx` (×2). Fixed with a lookbehind so the Workstation's €5,499 is untouched.

## Notes

No code, docs only. Numbers are quoted, not derived — same table now lives in the support bot KB so the two surfaces cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated ClawBox Connect and Hermes Edition pricing to €579 across the website.
  - Added details about the preinstalled Gemma 4 E2B Q4_0 local model, including runtime, performance, resource usage, tool use, and JSON capabilities.
  - Clarified offline, on-device inference and cloud-provider differences.
  - Added guidance for using models through Ollama, including storage considerations.
  - Expanded hardware and requirements reference pages with deployment and performance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->