### PR TITLE
fix: make Jetson Python CLI installs PEP 668-safe (rebase of #531)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1001,6 +1001,33 @@ wait_for_apt() {
   recover_dpkg
 }
 
+# Best-effort pipx bootstrap. step_apt_update installs pipx as part of the
+# full-install/update sequence, but step_clawkeep_install and (the Hugging
+# Face CLI install inside) step_llamacpp_install can also run standalone via
+# a root-owned standalone step service, outside that sequence — so each calls
+# this first rather than assuming apt_update already ran on this boot.
+#
+# pipx is what keeps these installs working under PEP 668 (the
+# externally-managed-environment policy Ubuntu enforces from 24.04 / JetPack
+# 7 onward); on JetPack 6.2 / Ubuntu 22.04 it is optional polish; pip --user
+# still works there, so callers fall back to it when this returns non-zero.
+ensure_pipx() {
+  as_clawbox_login "command -v pipx" &>/dev/null && return 0
+  wait_for_apt
+  # Refresh package metadata first — a standalone dispatch (see comment
+  # above) may run on a boot where step_apt_update never ran, so the local
+  # apt cache can be stale or empty and "apt-get install pipx" would 404 on
+  # a fresh image. Tolerate failure here (offline JetPack 6.2 hosts still
+  # need to fall through to the pip --user path below) but don't hide it.
+  if ! DEBIAN_FRONTEND=noninteractive apt-get update -qq; then
+    echo "  Warning: apt-get update failed (offline?) — trying pipx install from the existing cache" >&2
+  fi
+  if ! DEBIAN_FRONTEND=noninteractive apt-get install -y -qq pipx; then
+    echo "  Warning: apt-get install pipx failed" >&2
+  fi
+  as_clawbox_login "command -v pipx" &>/dev/null
+}
+
 step_apt_update() {
   wait_for_apt
   DEBIAN_FRONTEND=noninteractive apt-get update -qq
@@ -1016,7 +1043,7 @@ step_apt_update() {
   # filters those formats need (and pulls in libreoffice-common, which owns the
   # /usr/bin/libreoffice launcher) — the full `libreoffice` metapackage would add
   # Calc, Impress, Base and a Java runtime for nothing the box ever converts.
-  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git curl network-manager avahi-daemon iptables iw python3 python3-pip python-is-python3 gh build-essential cmake ninja-build pkg-config poppler-utils libreoffice-writer
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq git curl network-manager avahi-daemon iptables iw python3 python3-pip python-is-python3 pipx gh build-essential cmake ninja-build pkg-config poppler-utils libreoffice-writer
   # Node.js for production server and OpenClaw. OpenClaw 2026.8.1 tightened
   # its engines to >=22.22.3; older ClawBox images may have v22.22.2, which
   # looks like "Node 22" but crashes the OpenClaw CLI after npm install.
@@ -2326,7 +2353,7 @@ for p in d.get("plugins", []):
 step_clawkeep_install() {
   # Install (or refresh) the device-side ClawKeep Python package from the
   # in-tree source. The user-runtime CLI lives at ~/.local/bin/clawkeep
-  # and ~/.local/bin/clawkeepd; without --force-reinstall, an existing
+  # and ~/.local/bin/clawkeepd; without a forced reinstall, an existing
   # install with the same version string ("0.1.0") would skip the upgrade
   # and leave stale code on disk after a `git pull`.
   if [ ! -d "$PROJECT_DIR/clawkeep" ]; then
@@ -2334,6 +2361,45 @@ step_clawkeep_install() {
     return 0
   fi
 
+  # pipx builds into its own isolated venv, which sidesteps PEP 668
+  # (externally-managed-environment, enforced on Ubuntu 24.04+ / JetPack 7)
+  # and, as a side effect, the Jetson UNKNOWN-0.0.0 wheel failure the pip
+  # fallback below works around — pipx's venv bootstraps its own pip rather
+  # than reusing the stock L4T pip 22.0.2 + setuptools 59.6.0 combination
+  # that triggers it. Prefer pipx; fall back to the pip --user path — still
+  # correct on JetPack 6.2 / Ubuntu 22.04, where PEP 668 does not apply —
+  # only when pipx could not be provisioned.
+  if ! ensure_pipx; then
+    echo "  Warning: pipx unavailable — falling back to pip --user (blocked by PEP 668 on Ubuntu 24.04+)" >&2
+    step_clawkeep_install_pip_user_fallback
+    return $?
+  fi
+
+  echo "  Installing ClawKeep CLI via pipx"
+  # A device upgraded from a pre-pipx install has real pip-installed scripts
+  # at these paths; pipx refuses to overwrite files it did not create, so the
+  # stale scripts would keep running after every future `git pull` unless
+  # removed first.
+  as_clawbox_login "rm -f $CLAWBOX_HOME/.local/bin/clawkeep $CLAWBOX_HOME/.local/bin/clawkeepd" \
+    2>/dev/null || true
+  if ! as_clawbox_login "pipx install --force '$PROJECT_DIR/clawkeep'"; then
+    echo "  Warning: clawkeep pipx install failed (non-fatal — restore/scheduler will be unavailable)" >&2
+    return 0
+  fi
+
+  local CLAWKEEPD_BIN="$CLAWBOX_HOME/.local/bin/clawkeepd"
+  if [ ! -x "$CLAWKEEPD_BIN" ]; then
+    echo "Error: clawkeep pipx install completed but $CLAWKEEPD_BIN is missing." >&2
+    echo "       Try: pipx uninstall clawkeep && sudo bash install.sh" >&2
+    return 1
+  fi
+  echo "  ClawKeep CLI installed: $(as_clawbox_login 'clawkeep --help' 2>&1 | head -n1 || echo 'verify failed')"
+}
+
+# Legacy path, used only when pipx could not be provisioned. Still the
+# expected path on JetPack 6.2 / Ubuntu 22.04 hosts where apt could not
+# install pipx (e.g. offline) — PEP 668 does not block pip --user there.
+step_clawkeep_install_pip_user_fallback() {
   # Jetson L4T ships pip 22.0.2 + setuptools 59.6.0. setuptools 59
   # predates PEP 621 ([project] in pyproject.toml), and pip 22's build
   # isolation is patched on Debian/Ubuntu in a way that lets the legacy
@@ -4289,11 +4355,30 @@ step_llamacpp_install() {
     apt-get install -y -qq git curl python3 python3-pip python-is-python3 build-essential cmake ninja-build pkg-config
   fi
 
-  if ! as_clawbox_login "command -v hf" &>/dev/null; then
-    echo "  Installing Hugging Face CLI..."
-    as_clawbox_login "python3 -m pip install --user --upgrade 'huggingface_hub[cli]'"
+  # Run the pipx migration whether or not `hf` already resolves: a device
+  # upgraded from a pre-pipx install has a real pip --user-installed `hf` on
+  # PATH already, and gating this on "hf missing" (as before) would leave
+  # that stale shim running forever instead of migrating it to pipx. Only
+  # fall back to "leave it alone" / pip --user when pipx could not be
+  # provisioned at all.
+  if ensure_pipx; then
+    echo "  Installing Hugging Face CLI via pipx"
+    # A device upgraded from a pre-pipx install may have a real pip-
+    # installed `hf` at these paths; pipx refuses to overwrite files it
+    # did not create, so remove them first or the stale scripts keep
+    # running after every future update.
+    as_clawbox_login "rm -f $CLAWBOX_HOME/.local/bin/hf $CLAWBOX_HOME/.local/bin/huggingface-cli" \
+      2>/dev/null || true
+    as_clawbox_login "pipx install --force 'huggingface_hub[cli]'" \
+      || echo "  Warning: pipx install of huggingface_hub failed" >&2
+  elif as_clawbox_login "command -v hf" &>/dev/null; then
+    echo "  Hugging Face CLI already installed (pipx unavailable — leaving existing install as-is)"
   else
-    echo "  Hugging Face CLI already installed"
+    # pipx unavailable (e.g. offline apt) — pip --user still works on
+    # JetPack 6.2 / Ubuntu 22.04, where PEP 668 does not apply.
+    echo "  Warning: pipx unavailable — falling back to pip --user (blocked by PEP 668 on Ubuntu 24.04+)" >&2
+    as_clawbox_login "python3 -m pip install --user --upgrade 'huggingface_hub[cli]'" \
+      || echo "  Warning: Hugging Face CLI install failed (pipx unavailable, pip blocked by PEP 668 on newer bases)" >&2
   fi
 
   # Determine if a rebuild is needed. Rebuild when:

--- a/src/tests/unit/install-clawkeep-pep668.test.ts
+++ b/src/tests/unit/install-clawkeep-pep668.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// PEP 668 (externally-managed-environment) blocks `pip install --user`
+// outright on Ubuntu 24.04+ / JetPack 7, which is where the ClawKeep and
+// Hugging Face CLI installs in install.sh used to fail. These pin the fix:
+// pipx is preferred (it builds into its own isolated venv, immune to the
+// distro's PEP 668 policy), pip --user only runs as a fallback for hosts
+// where pipx could not be provisioned (still correct on JetPack 6.2 /
+// Ubuntu 22.04, which predates PEP 668 enforcement), and neither path ever
+// reaches for `--break-system-packages`.
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+function extractShellFunction(name: string): string {
+  const start = INSTALL_SH.indexOf(`${name}() {`);
+  if (start < 0) throw new Error(`${name} not found in install.sh`);
+  const end = INSTALL_SH.indexOf("\n}", start);
+  if (end < 0) throw new Error(`${name} has no closing brace`);
+  return INSTALL_SH.slice(start, end);
+}
+
+describe("installer never uses --break-system-packages", () => {
+  it("nowhere in install.sh", () => {
+    expect(INSTALL_SH).not.toContain("--break-system-packages");
+  });
+});
+
+describe("ensure_pipx bootstrap helper", () => {
+  it("is defined before step_apt_update, and installs the pipx apt package", () => {
+    const helperAt = INSTALL_SH.indexOf("ensure_pipx() {");
+    const stepApAt = INSTALL_SH.indexOf("step_apt_update() {");
+    expect(helperAt).toBeGreaterThan(-1);
+    expect(stepApAt).toBeGreaterThan(-1);
+    expect(helperAt).toBeLessThan(stepApAt);
+
+    const fn = extractShellFunction("ensure_pipx");
+    // Idempotent: a pipx already on PATH short-circuits before any apt call.
+    expect(fn).toMatch(/command -v pipx.*&&\s*return 0/);
+    expect(fn).toContain("apt-get install -y -qq pipx");
+  });
+
+  it("refreshes apt metadata before installing pipx, in that order, using noninteractive APT", () => {
+    // A root-owned standalone step dispatch can hit
+    // this function on a boot where step_apt_update never ran, so the local
+    // apt cache may be empty/stale — installing pipx without an update
+    // first can 404 on a fresh image.
+    const fn = extractShellFunction("ensure_pipx");
+    const updateAt = fn.indexOf("apt-get update -qq");
+    const installAt = fn.indexOf("apt-get install -y -qq pipx");
+    expect(updateAt).toBeGreaterThan(-1);
+    expect(installAt).toBeGreaterThan(-1);
+    expect(updateAt).toBeLessThan(installAt);
+    expect(fn).toMatch(/DEBIAN_FRONTEND=noninteractive apt-get update -qq/);
+    expect(fn).toMatch(/DEBIAN_FRONTEND=noninteractive apt-get install -y -qq pipx/);
+  });
+
+  it("does not silently discard the apt-get install result — failures surface a warning, not a swallowed exit code", () => {
+    const fn = extractShellFunction("ensure_pipx");
+    // The old body piped stderr to /dev/null and unconditionally forced
+    // success (`|| true`) on the install line itself, hiding *why* pipx
+    // ended up unavailable. The function's real signal is still the final
+    // `command -v pipx` probe, but a failed install must now be audible.
+    expect(fn).not.toMatch(/apt-get install -y -qq pipx\s*2>\/dev\/null\s*\|\|\s*true/);
+    expect(fn).toMatch(/apt-get install -y -qq pipx; then\s*\n\s*echo\s+"\s*Warning: apt-get install pipx failed"/);
+  });
+
+  it("tolerates an update failure (offline JetPack 6.2) rather than aborting before the install attempt", () => {
+    const fn = extractShellFunction("ensure_pipx");
+    expect(fn).toMatch(/if ! DEBIAN_FRONTEND=noninteractive apt-get update -qq; then[\s\S]*fi/);
+    // The update failing must not `return` early — install (and the final
+    // command -v probe that determines the real fallback decision) still run.
+    const updateBlockEnd = fn.indexOf("fi", fn.indexOf("apt-get update -qq"));
+    const updateBlock = fn.slice(fn.indexOf("apt-get update -qq"), updateBlockEnd);
+    expect(updateBlock).not.toContain("return");
+  });
+
+  it("pipx is provisioned up front by step_apt_update, for the fast path on a fresh install", () => {
+    const fn = extractShellFunction("step_apt_update");
+    expect(fn).toMatch(/apt-get install -y -qq[^\n]*\bpipx\b/);
+  });
+
+  it("both standalone-dispatchable pip installers call ensure_pipx rather than assuming apt_update already ran", () => {
+    // step_clawkeep_install and step_llamacpp_install's Hugging Face CLI
+    // install can each run outside the full-install sequence (e.g. via
+    // the root-owned step service), so neither may assume
+    // step_apt_update has provisioned pipx on this boot already.
+    expect(extractShellFunction("step_clawkeep_install")).toContain("ensure_pipx");
+    expect(extractShellFunction("step_llamacpp_install")).toContain("ensure_pipx");
+  });
+});
+
+describe("ClawKeep install prefers pipx, Ubuntu 22.04 and 24.04-safe", () => {
+  const fn = extractShellFunction("step_clawkeep_install");
+
+  it("installs via pipx --force when pipx is available", () => {
+    expect(fn).toContain("pipx install --force '$PROJECT_DIR/clawkeep'");
+  });
+
+  it("falls back to the pip --user path only when pipx could not be provisioned", () => {
+    expect(fn).toMatch(/if ! ensure_pipx; then[\s\S]*step_clawkeep_install_pip_user_fallback/);
+  });
+
+  it("clears stale pre-pipx shims first, so pipx's own symlinks aren't skipped", () => {
+    // pipx refuses to overwrite files it did not create. Without this, a
+    // device already carrying a pip --user-installed clawkeep/clawkeepd
+    // would keep running the stale binary after every future `git pull`.
+    const rmAt = fn.indexOf("rm -f $CLAWBOX_HOME/.local/bin/clawkeep $CLAWBOX_HOME/.local/bin/clawkeepd");
+    const pipxInstallAt = fn.indexOf("pipx install --force");
+    expect(rmAt).toBeGreaterThan(-1);
+    expect(pipxInstallAt).toBeGreaterThan(-1);
+    expect(rmAt).toBeLessThan(pipxInstallAt);
+  });
+
+  it("verifies clawkeepd landed on disk before declaring success", () => {
+    expect(fn).toContain('local CLAWKEEPD_BIN="$CLAWBOX_HOME/.local/bin/clawkeepd"');
+    expect(fn).toMatch(/if \[ ! -x "\$CLAWKEEPD_BIN" \]; then/);
+  });
+
+  it("the pip --user fallback exists, still forces a reinstall, and never adds --break-system-packages", () => {
+    const fallback = extractShellFunction("step_clawkeep_install_pip_user_fallback");
+    expect(fallback).toContain("pip install --user --force-reinstall --no-deps --use-pep517");
+    expect(fallback).not.toContain("--break-system-packages");
+  });
+});
+
+describe("Hugging Face CLI install prefers pipx, Ubuntu 22.04 and 24.04-safe", () => {
+  const fn = extractShellFunction("step_llamacpp_install");
+
+  it("installs via pipx --force when pipx is available", () => {
+    expect(fn).toContain("pipx install --force 'huggingface_hub[cli]'");
+  });
+
+  it("clears stale pre-pipx shims (hf, huggingface-cli) before the pipx install", () => {
+    const rmAt = fn.indexOf("rm -f $CLAWBOX_HOME/.local/bin/hf $CLAWBOX_HOME/.local/bin/huggingface-cli");
+    const pipxInstallAt = fn.indexOf("pipx install --force 'huggingface_hub[cli]'");
+    expect(rmAt).toBeGreaterThan(-1);
+    expect(pipxInstallAt).toBeGreaterThan(-1);
+    expect(rmAt).toBeLessThan(pipxInstallAt);
+  });
+
+  it("the pipx migration is dispatched on ensure_pipx succeeding, not gated behind an `hf` presence check", () => {
+    // Regression guard for the original bug: `if ! command -v hf` wrapped
+    // the whole migration, so a device with a working pre-existing pip
+    // --user `hf` never got migrated to pipx. The pipx branch must now be
+    // reachable purely from `ensure_pipx` succeeding.
+    expect(fn).toMatch(/if ensure_pipx; then\s*\n\s*echo\s+"\s*Installing Hugging Face CLI via pipx"/);
+    // And no gate of the form `if ! ... command -v hf ... ; then` wraps the
+    // pipx branch anywhere ahead of it in this function.
+    const pipxBranchAt = fn.indexOf("if ensure_pipx; then");
+    const staleGateAt = fn.indexOf('if ! as_clawbox_login "command -v hf"');
+    expect(pipxBranchAt).toBeGreaterThan(-1);
+    // The only remaining `command -v hf` check is the "already installed,
+    // pipx unavailable" probe, which must come AFTER (inside the ensure_pipx
+    // failure branch), never wrapping the pipx branch itself.
+    if (staleGateAt !== -1) {
+      expect(staleGateAt).toBeGreaterThan(pipxBranchAt);
+    }
+  });
+
+  it("falls back to plain pip --user, or leaves an already-working install alone, only when ensure_pipx fails", () => {
+    expect(fn).toMatch(
+      /if ensure_pipx; then[\s\S]*pipx install --force 'huggingface_hub\[cli\]'[\s\S]*elif as_clawbox_login "command -v hf" &>\/dev\/null; then[\s\S]*already installed[\s\S]*else[\s\S]*pip install --user --upgrade 'huggingface_hub\[cli\]'/,
+    );
+  });
+
+  it("the pip --user fallback only runs when hf is truly absent (both ensure_pipx and hf presence gate it)", () => {
+    const elifAt = fn.indexOf('elif as_clawbox_login "command -v hf" &>/dev/null; then');
+    const pipInstallAt = fn.indexOf("pip install --user --upgrade 'huggingface_hub[cli]'");
+    expect(elifAt).toBeGreaterThan(-1);
+    expect(pipInstallAt).toBeGreaterThan(elifAt);
+  });
+});
+
+describe("no unsafe system-wide pip mutation was introduced", () => {
+  it("every actual pip invocation in install.sh stays scoped to --user", () => {
+    // Matches real invocations only (`python3 -m pip install` / `pip3
+    // install`) — deliberately narrower than a bare "pip install" substring
+    // search, which would also match the prose in comments and echoed
+    // troubleshooting text elsewhere in this same file.
+    const invocation = /(?:python3\s+-m\s+pip|pip3)\s+install\b/;
+    const offenders = INSTALL_SH.split("\n")
+      .map((l) => l.trim())
+      .filter((l) => invocation.test(l) && !/--user\b/.test(l));
+    // jetson-stats (`pip3 install jetson-stats`) legitimately installs into
+    // system site-packages — it's an NVIDIA-recommended root-level tool, not
+    // one of the two PEP 668-hardened CLI installs this change targets.
+    const allowed = offenders.filter((l) => !l.includes("jetson-stats"));
+    expect(allowed).toEqual([]);
+  });
+});


### PR DESCRIPTION
Rebase of #531 by @jamesachurchill onto current `beta`, plus real-hardware verification.

The original PR could not be merged: it was ~110 commits behind `beta` and `CONFLICTING`, and
it comes from a fork, so the rebase could not be pushed to the contributor's branch. The commit
here is theirs, unchanged — only the base moved. It rebased cleanly with no content conflicts.

## What it does

Installs the ClawKeep and Hugging Face CLIs through `pipx` instead of `pip --user`, so they keep
working under PEP 668 (`externally-managed-environment`, enforced from Ubuntu 24.04 / JetPack 7).
Keeps the `pip --user` path as a fallback for offline JetPack 6.2 / Ubuntu 22.04 hosts, and removes
stale pre-pipx command shims before pipx writes its own.

## Device verification

Flashed a clean Orin Nano 8GB (serial `1791526043297`) from `beta`, then ran this branch on it.

Baseline before the change, on JetPack 6.2 / Ubuntu 22.04 / Python 3.10.12:

```
pipx: NONE
-rwxrwxr-x 1 clawbox clawbox 177 /home/clawbox/.local/bin/clawkeep      # pip --user script
-rwxrwxr-x 1 clawbox clawbox 179 /home/clawbox/.local/bin/clawkeepd
```

This is exactly the "upgrade from a pre-pipx install" case the change handles.

Ran `sudo bash install.sh --step post_update` (the real in-app-update path that reaches
`step_clawkeep_install`):

```
installing clawkeep from spec '/home/clawbox/clawbox/clawkeep'...
done! 
  installed package clawkeep 0.1.0, installed using Python 3.10.12
  ClawKeep CLI installed: usage: clawkeep <command> [args...]
```

After:

```
pipx: /usr/bin/pipx
clawkeep  -> /home/clawbox/.local/pipx/venvs/clawkeep/bin/clawkeep
clawkeepd -> /home/clawbox/.local/pipx/venvs/clawkeep/bin/clawkeepd
$ clawkeep --help
usage: clawkeep <command> [args...]
```

The stale pip scripts were replaced by pipx symlinks, `pipx list` reports `clawkeep 0.1.0`, and
both commands resolve and run from a login shell. `clawbox-gateway` and `clawbox-setup` are active
afterwards (gateway `200` on 18789).

Note this box is Ubuntu 22.04, where PEP 668 does not apply — so this run verifies the change does
not regress the currently shipping platform, and that the pipx migration path works on real
hardware. It does not exercise the 24.04 enforcement itself.

Closes #531.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved installation reliability by preferring isolated `pipx` environments for ClawKeep and Hugging Face CLI tools.
  * Added fallback behavior for offline systems or environments where `pipx` cannot be installed.
  * Automatically removes outdated launchers and verifies installed commands are executable.
  * Supports migrating existing Hugging Face CLI installations to `pipx` when available.

* **Bug Fixes**
  * Improved compatibility with systems enforcing externally managed Python environments.
  * Prevented unsafe package installation methods during setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->