### PR TITLE
perf(chat): ask the hermes capability probes together, and warm them at boot

### DIFF
--- a/src/app/setup-api/chat/capabilities/route.ts
+++ b/src/app/setup-api/chat/capabilities/route.ts
@@ -32,55 +32,68 @@ export const dynamic = "force-dynamic";
 export async function GET() {
   const harness = await getActiveHarness();
   const linked = await hasClawaiToken();
+  // The five Hermes facts are asked TOGETHER, and only on a Hermes box.
+  //
+  // Together, because nothing in this list feeds the next entry, and on a cold
+  // cache each one is a real wait: `hermesSupportsImages` and the two config
+  // reads each start a Python interpreter (0.9-1.3 s on a Jetson), the
+  // streaming probe mints a ticket, and the image-route probe leaves the
+  // device. Awaited one after another they added up to 2.5-4 s of chat with no
+  // attach button on every mount while the memos were cold — and every
+  // `hermes config set` bumps config.yaml's mtime and cools two of them again.
+  // Asked at once, the wait is the slowest probe rather than the sum. Safe to
+  // gather with `Promise.all`: every probe fails CLOSED and never rejects, and
+  // each memoises its in-flight promise so concurrent callers share one spawn.
+  //
+  // Only on Hermes, because `hermes` may not be installed on an OpenClaw box
+  // at all, and no OpenClaw capability reads any of these: it has its own
+  // socket and its own streaming, makes pictures through its own bundled
+  // plugin, and reads the credential instead. Spending a spawn (and a failure)
+  // there would compute facts nobody consumes.
+  const onHermes = harness === "hermes";
+  const [supportsImages, hasVisionRoute, streamsTurns, hasImageRoute, drawsImages] =
+    await Promise.all([
+      // Whether the installed `hermes` understands `chat --image` — PROBED,
+      // once per process. An attach button shown on a guess would stage files
+      // into a turn that ignores them, which is worse than no button at all.
+      onHermes ? hermesSupportsImages() : false,
+      // The second half of the same question: whether anything on this box
+      // would LOOK at the picture the flag above lets the turn carry. Read
+      // from `auxiliary.vision.model`, which is the store the agent's own image
+      // routing reads, through the mtime-keyed config memo — so linking ClawBox
+      // AI flips it on the next re-probe rather than on the next restart.
+      onHermes ? hermesHasVisionRoute() : false,
+      // Whether a turn can go through the running dashboard and stream back,
+      // rather than spawning a CLI whose answer only exists once it exits.
+      // Probed by minting a WebSocket ticket — cheap, local, and the same door
+      // the turn itself will use, so a yes here is a yes for the real thing.
+      onHermes ? hermesCanStreamTurns() : false,
+      // Whether the ClawBox AI proxy is up and still serving the image model
+      // this box would ask for. The one fact here that leaves the device, so
+      // it is asked only where the answer can matter — on Hermes, whose
+      // picture button is the thing it gates, and only once there is a
+      // credential to spend on a picture at all. An unlinked box is already
+      // `canGenerateImages: false` and would be spending a network round trip
+      // to stay that way.
+      //
+      // Cheap and cached (0.32 s measured, 10 minutes on a yes), so a chat
+      // opened twice pays for it once. It is a plain metadata read: no
+      // generation is started and no daily allowance is spent.
+      onHermes && linked ? clawaiImageRouteReachable() : false,
+      // Whether the agent has an image backend selected — the Hermes spelling
+      // of "can this box draw". Read from `image_gen.provider` through the same
+      // mtime-keyed memo as the vision route, so it flips on the model-state
+      // event the moment ClawBox AI is linked rather than at the next restart.
+      onHermes ? hermesAgentDrawsImages() : false,
+    ]);
   const facts: HarnessFacts = {
+    // A boolean precisely so the device credential never travels to a browser.
     hasClawaiToken: linked,
-    // Whether the installed `hermes` understands `chat --image` — PROBED, once
-    // per process, and only where the answer can matter. An attach button shown
-    // on a guess would stage files into a turn that ignores them, which is
-    // worse than no button at all.
-    //
-    // Not asked on an OpenClaw box: `hermes` may not be installed there at all,
-    // and the probe would spend a spawn (and a failure) to compute a fact that
-    // no OpenClaw capability reads.
-    hermesSupportsImages: harness === "hermes" ? await hermesSupportsImages() : false,
-    // The second half of the same question: whether anything on this box would
-    // LOOK at the picture the flag above lets the turn carry. Read from
-    // `auxiliary.vision.model`, which is the store the agent's own image
-    // routing reads, through the mtime-keyed config memo — so linking ClawBox
-    // AI flips it on the next re-probe rather than on the next restart.
-    //
-    // Not asked on an OpenClaw box, for the same reason as above: `hermes` may
-    // not be installed there, and no OpenClaw capability reads this.
-    hermesHasVisionRoute: harness === "hermes" ? await hermesHasVisionRoute() : false,
-    // Whether a turn can go through the running dashboard and stream back,
-    // rather than spawning a CLI whose answer only exists once it exits. Probed
-    // by minting a WebSocket ticket — cheap, local, and the same door the turn
-    // itself will use, so a yes here is a yes for the real thing.
-    //
-    // Not asked on an OpenClaw box: it has its own socket and its own streaming,
-    // and `hermes` may not be installed there at all.
-    hermesStreamsTurns: harness === "hermes" ? await hermesCanStreamTurns() : false,
-    // Whether the ClawBox AI proxy is up and still serving the image model this
-    // box would ask for. The one fact here that leaves the device, so it is
-    // asked only where the answer can matter — on Hermes, whose picture button
-    // is the thing it gates, and only once there is a credential to spend on a
-    // picture at all. An unlinked box is already `canGenerateImages: false` and
-    // would be spending a network round trip to stay that way.
-    //
-    // Cheap and cached (0.32 s measured, 10 minutes on a yes), so a chat opened
-    // twice pays for it once. It is a plain metadata read: no generation is
-    // started and no daily allowance is spent.
-    hasClawaiImageRoute:
-      harness === "hermes" && linked ? await clawaiImageRouteReachable() : false,
-    // Whether the agent has an image backend selected — the Hermes spelling of
-    // "can this box draw". Read from `image_gen.provider` through the same
-    // mtime-keyed memo as the vision route, so it flips on the model-state
-    // event the moment ClawBox AI is linked rather than at the next restart.
-    //
-    // Not asked on an OpenClaw box: it makes pictures through its own bundled
-    // plugin and reads the credential instead, and `hermes` may not be
-    // installed there at all.
-    hermesAgentDrawsImages: harness === "hermes" ? await hermesAgentDrawsImages() : false,
+    hermesSupportsImages: supportsImages,
+    hermesHasVisionRoute: hasVisionRoute,
+    hermesStreamsTurns: streamsTurns,
+    hasClawaiImageRoute: hasImageRoute,
+    hermesAgentDrawsImages: drawsImages,
   };
   // Which of those `false`s is an ANSWER, and which is a placeholder the server
   // has already undertaken to replace by itself.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -138,6 +138,31 @@ export async function register() {
     console.error('[instrumentation] Could not warm the memory status cache:', err instanceof Error ? err.message : err)
   }
   try {
+    // The chat's capability facts on a Hermes box cost three Python starts on
+    // a cold cache, and `use-harness-adapter` asks for them on every chat
+    // mount. Pay them once here, after the boot rush, so the first chat open
+    // after a restart answers from the memos. Same delay as the memory probe
+    // above, on purpose: a probe that times out under boot load is held as a
+    // 60 s backoff, which would hide the attach button for exactly the chat
+    // open this is meant to speed up.
+    //
+    // Only on a Hermes box, and decided at fire time rather than now: an
+    // OpenClaw box can have a `hermes` checkout and a config.yaml on disk, and
+    // an ungated probe would start Python at boot for facts no OpenClaw
+    // capability reads.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { getActiveHarness } = require('./lib/harness')
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { warmHermesFeatureMemos } = require('./lib/harness/hermes-features')
+    setTimeout(() => {
+      void getActiveHarness()
+        .then((harness: string) => (harness === 'hermes' ? warmHermesFeatureMemos() : undefined))
+        .catch(() => { /* the first chat open asks for itself */ })
+    }, 45_000).unref()
+  } catch (err) {
+    console.error('[instrumentation] Could not warm the hermes chat capability memos:', err instanceof Error ? err.message : err)
+  }
+  try {
     // Memory indexing is armed the same way, from its own persisted schedule.
     // Rebuilding the timer at every boot is what makes the schedule survive a
     // reboot and an update without a crontab entry to duplicate or orphan.

--- a/src/lib/harness/hermes-features.ts
+++ b/src/lib/harness/hermes-features.ts
@@ -1,4 +1,5 @@
 import { runHermesCli } from "@/lib/hermes-cli";
+import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import {
   FAILED_READ_TTL_MS,
   hermesConfigGet,
@@ -84,13 +85,14 @@ export async function hermesSupportsImages(): Promise<boolean> {
   entry.promise = (async () => {
     try {
       const result = await runHermesCli(["chat", "--help"], { timeoutMs: PROBE_TIMEOUT_MS });
-      // A numeric exit code means the CLI ran and argparse spoke: 0 prints the
-      // option list, and non-zero is how it rejects a subcommand or a flag it
-      // does not have (verified on the box: exit 2). Either way that is an
-      // answer about THIS checkout, and it is kept for the life of the process.
-      // `null` means the child was killed by a signal and printed nothing,
-      // which is not an answer at all.
-      if (typeof result.code !== "number") throw new Error("hermes probe was killed");
+      // An exit code from the CLI means argparse spoke: 0 prints the option
+      // list, and non-zero is how it rejects a subcommand or a flag it does not
+      // have (verified on the box: exit 2). Either way that is an answer about
+      // THIS checkout, and it is kept for the life of the process. `null` (the
+      // child was killed by a signal) and the shell's own 126/127 (the shim ran
+      // but could not start the interpreter — see `hermesCliAnswered`) printed
+      // no help text and are not answers at all.
+      if (!hermesCliAnswered(result)) throw new Error("hermes probe did not answer");
       entry.expiresAt = Number.POSITIVE_INFINITY;
       if (result.code !== 0) return false;
       return /^\s*--image\b/m.test(`${result.stdout}\n${result.stderr}`);
@@ -286,4 +288,25 @@ export async function hermesAgentDrawsImages(): Promise<boolean> {
 /** Same question again, for the agent's image backend. See above. */
 export function hermesImageBackendPending(): boolean {
   return hermesConfigReadPending(IMAGE_PROVIDER_KEY);
+}
+
+/**
+ * Pay the cold probes ONCE, so the first chat open after a restart does not.
+ *
+ * Of the facts the capabilities route reports, these three are the ones that
+ * start a Python interpreter on a miss — the `--image` probe and the two config
+ * reads — and the chat asks for all of them on every mount. The streaming and
+ * image-route probes next door are cheap and short-lived, and are not warmed.
+ * Where and when to call this is the caller's decision (boot, on a Hermes box,
+ * after the boot rush); every probe here fails closed, so this never rejects.
+ */
+export async function warmHermesFeatureMemos(): Promise<void> {
+  // One interpreter at a time, on purpose. Nobody is waiting on this, and the
+  // box is still settling after boot: three Python starts at once on a Jetson
+  // are exactly the load that turns a probe into a timeout, and a timed-out
+  // probe is held as a placeholder for the backoff — the outcome the chat open
+  // this is meant to help would then inherit.
+  await hermesSupportsImages();
+  await hermesHasVisionRoute();
+  await hermesAgentDrawsImages();
 }

--- a/src/lib/hermes-cli-answered.ts
+++ b/src/lib/hermes-cli-answered.ts
@@ -1,0 +1,24 @@
+import type { HermesCliResult } from "@/lib/hermes-cli";
+
+/**
+ * Did `hermes` itself run and speak, or did the question fail before it could?
+ *
+ * The memos around the CLI keep an ANSWER for a long time (the life of the
+ * process, or until config.yaml is rewritten) and hold a FAILURE only for a
+ * short backoff, so which of the two a result is decides whether a wrong
+ * `false` hides the attach button for a minute or until the next restart.
+ * `runHermesCli` already rejects for a missing binary, a timeout and its own
+ * SIGKILL, and a child killed by a signal closes with `code: null` — none of
+ * those are answers. Neither are 126 and 127. `hermes` on the box is a shim
+ * over a venv Python, and while an update moves the checkout aside and rebuilds
+ * it (`step_hermes_install` in install.sh, about 90 s, with no web-server
+ * restart afterwards) the shim EXISTS and RUNS but exits 127 — 126 when the
+ * interpreter is there and not executable — without ever reaching argparse.
+ * Those are the shell's codes, not the CLI's: nothing about the flag or the
+ * key was said, and a memo that stored them as the CLI's verdict remembered
+ * "no `--image`" for the life of the process on a box whose checkout was back
+ * a minute later.
+ */
+export function hermesCliAnswered(result: Pick<HermesCliResult, "code">): boolean {
+  return typeof result.code === "number" && result.code !== 126 && result.code !== 127;
+}

--- a/src/lib/hermes-config-cache.ts
+++ b/src/lib/hermes-config-cache.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import { runHermesCli } from "@/lib/hermes-cli";
+import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 
 /**
  * A memo around `hermes config get <key>`.
@@ -109,12 +110,13 @@ export async function hermesConfigGet(key: string, timeoutMs = 10_000): Promise<
     // stderr, so a non-zero exit is the CLI saying "nothing is configured
     // there" — an answer, and one the mtime correctly invalidates. A child that
     // closed with no exit code at all was killed by a signal (OOM on a loaded
-    // Jetson) and told us nothing; `runHermesCli` rejects on a timeout, a
+    // Jetson) and told us nothing, and a shim that exited 126/127 never reached
+    // the CLI (see `hermesCliAnswered`); `runHermesCli` rejects on a timeout, a
     // missing binary and its own SIGKILL, which likewise tell us nothing.
     let answered = false;
     try {
       const r = await runHermesCli(["config", "get", key], { timeoutMs });
-      answered = typeof r.code === "number";
+      answered = hermesCliAnswered(r);
       if (r.code === 0) value = r.stdout.trim();
     } catch {
       // hermes missing or timed out — fall through with "".

--- a/src/tests/routes/chat/capabilities-parallel.test.ts
+++ b/src/tests/routes/chat/capabilities-parallel.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+/**
+ * `/setup-api/chat/capabilities` — that the Hermes facts are asked TOGETHER.
+ *
+ * Five of the facts this route reports are independent probes, and on a cold
+ * cache each is a real cost: `hermes chat --help` is a Python interpreter
+ * start (0.9-1.3 s on a Jetson), the two `hermes config get` reads are two
+ * more, the streaming probe mints a WebSocket ticket, and the image-route
+ * probe leaves the device. `use-harness-adapter` asks for all of them on every
+ * chat mount, and every `hermes config set` bumps config.yaml's mtime and
+ * evicts the config memos behind two of them.
+ *
+ * Awaited one after another that added up to 2.5-4 s of the customer looking
+ * at a chat with no attach button. Nothing in that chain feeds the next link,
+ * so the wait should be the SLOWEST probe, not the SUM of them.
+ *
+ * Pinned with fake timers rather than a wall clock: each probe is a 300 ms
+ * timer, and the route must have settled once the clock has moved 300 ms. A
+ * serial route needs the clock to move 1500 ms.
+ */
+
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
+vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
+vi.mock("@/lib/harness/clawai-images", () => ({ clawaiImageRouteReachable: vi.fn() }));
+vi.mock("@/lib/hermes-dashboard-turn", () => ({ hermesCanStreamTurns: vi.fn() }));
+vi.mock("@/lib/harness/hermes-features", () => ({
+  hermesSupportsImages: vi.fn(),
+  hermesHasVisionRoute: vi.fn(),
+  hermesAgentDrawsImages: vi.fn(),
+  hermesFeatureProbePending: vi.fn(),
+  hermesVisionRoutePending: vi.fn(),
+  hermesImageBackendPending: vi.fn(),
+  HERMES_FACT_RETRY_MS: 60_000,
+}));
+
+const PROBE_MS = 300;
+
+/** A probe that answers `value` after one fake-clock tick of `PROBE_MS`. */
+function slowProbe(value: boolean): () => Promise<boolean> {
+  return () => new Promise((resolve) => setTimeout(() => resolve(value), PROBE_MS));
+}
+
+interface Body {
+  harness: string;
+  facts: Record<string, boolean>;
+  factsPending: boolean;
+}
+
+let GET: () => Promise<Response>;
+let getActiveHarness: Mock;
+let hasClawaiToken: Mock;
+let probes: Record<string, Mock>;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  ({ getActiveHarness } = (await import("@/lib/harness")) as unknown as {
+    getActiveHarness: Mock;
+  });
+  ({ hasClawaiToken } = (await import("@/lib/harness/credentials")) as unknown as {
+    hasClawaiToken: Mock;
+  });
+  const images = (await import("@/lib/harness/clawai-images")) as unknown as {
+    clawaiImageRouteReachable: Mock;
+  };
+  const dashboard = (await import("@/lib/hermes-dashboard-turn")) as unknown as {
+    hermesCanStreamTurns: Mock;
+  };
+  const features = (await import("@/lib/harness/hermes-features")) as unknown as {
+    hermesSupportsImages: Mock;
+    hermesHasVisionRoute: Mock;
+    hermesAgentDrawsImages: Mock;
+    hermesFeatureProbePending: Mock;
+    hermesVisionRoutePending: Mock;
+    hermesImageBackendPending: Mock;
+  };
+  probes = {
+    hermesSupportsImages: features.hermesSupportsImages,
+    hermesHasVisionRoute: features.hermesHasVisionRoute,
+    hermesStreamsTurns: dashboard.hermesCanStreamTurns,
+    hasClawaiImageRoute: images.clawaiImageRouteReachable,
+    hermesAgentDrawsImages: features.hermesAgentDrawsImages,
+  };
+
+  getActiveHarness.mockResolvedValue("hermes");
+  hasClawaiToken.mockResolvedValue(true);
+  for (const probe of Object.values(probes)) probe.mockImplementation(slowProbe(true));
+  features.hermesFeatureProbePending.mockReturnValue(false);
+  features.hermesVisionRoutePending.mockReturnValue(false);
+  features.hermesImageBackendPending.mockReturnValue(false);
+
+  ({ GET } = await import("@/app/setup-api/chat/capabilities/route"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Starts the request and reports whether it has settled, without awaiting it. */
+function startRequest(): { settled: () => boolean; body: () => Promise<Body> } {
+  let done = false;
+  const response = GET().then((res) => {
+    done = true;
+    return res;
+  });
+  return {
+    settled: () => done,
+    body: async () => (await (await response).json()) as Body,
+  };
+}
+
+describe("GET /setup-api/chat/capabilities asks the Hermes probes together", () => {
+  it("settles after ONE probe's worth of waiting on a linked Hermes box", async () => {
+    const request = startRequest();
+    await vi.advanceTimersByTimeAsync(PROBE_MS);
+    expect(request.settled()).toBe(true);
+
+    const payload = await request.body();
+    expect(payload.harness).toBe("hermes");
+    expect(payload.facts).toMatchObject({
+      hasClawaiToken: true,
+      hermesSupportsImages: true,
+      hermesHasVisionRoute: true,
+      hermesStreamsTurns: true,
+      hasClawaiImageRoute: true,
+      hermesAgentDrawsImages: true,
+    });
+  });
+
+  it("has every probe in flight before any of them has answered", async () => {
+    startRequest();
+    // Let the two sequential pre-checks (harness, credential) resolve, but do
+    // not move the clock: no probe can have answered yet.
+    await vi.advanceTimersByTimeAsync(0);
+    for (const [name, probe] of Object.entries(probes)) {
+      expect(probe, name).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it("still leaves the proxy alone on an unlinked box", async () => {
+    // Parallel is not the same as unconditional: the one probe that leaves the
+    // device is asked only where there is a credential to spend on a picture.
+    hasClawaiToken.mockResolvedValue(false);
+    const request = startRequest();
+    await vi.advanceTimersByTimeAsync(PROBE_MS);
+    expect(request.settled()).toBe(true);
+    expect(probes.hasClawaiImageRoute).not.toHaveBeenCalled();
+    expect((await request.body()).facts.hasClawaiImageRoute).toBe(false);
+  });
+
+  it("still asks nothing of hermes on an OpenClaw box", async () => {
+    getActiveHarness.mockResolvedValue("openclaw");
+    const request = startRequest();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request.settled()).toBe(true);
+    for (const [name, probe] of Object.entries(probes)) {
+      expect(probe, name).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/src/tests/unit/hermes-config-cache.test.ts
+++ b/src/tests/unit/hermes-config-cache.test.ts
@@ -137,6 +137,25 @@ describe("hermesConfigGet", () => {
     expect(await hermesConfigGet("image_gen.provider")).toBe("clawai");
   });
 
+  it("does not remember a shim that could not start hermes as an answer", async () => {
+    // While an update rebuilds the checkout, `hermes` is a shim that runs and
+    // exits 127 without reaching the CLI. Stored against the mtime, that ""
+    // would outlive the rebuild — on a linked box nothing rewrites config.yaml
+    // — so it is held for the backoff like a timeout and re-asked.
+    for (const code of [126, 127]) {
+      runHermesCli.mockReset();
+      runHermesCli.mockResolvedValue({ code, stdout: "", stderr: "hermes: not found" });
+      const { hermesConfigGet, hermesConfigReadPending } = await load();
+      expect(await hermesConfigGet("auxiliary.vision.model"), `exit ${code}`).toBe("");
+      expect(hermesConfigReadPending("auxiliary.vision.model"), `exit ${code}`).toBe(true);
+
+      runHermesCli.mockReset();
+      runHermesCli.mockResolvedValue(ok("gpt-4.1-mini"));
+      vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+      expect(await hermesConfigGet("auxiliary.vision.model"), `exit ${code}`).toBe("gpt-4.1-mini");
+    }
+  });
+
   it("does not re-spawn the CLI for every caller while a read is failing", async () => {
     // Forgetting the failure must not turn a hanging `hermes` into one Python
     // start per request. The failure is held for a short backoff, then re-asked.

--- a/src/tests/unit/hermes-features-probe.test.ts
+++ b/src/tests/unit/hermes-features-probe.test.ts
@@ -169,6 +169,31 @@ describe("hermesSupportsImages", () => {
     }
   });
 
+  it("does not remember a shim that could not start hermes as an answer", async () => {
+    // While an update rebuilds the checkout, `hermes` is a shim that runs and
+    // exits 127 without reaching argparse. The shell's code, not the CLI's:
+    // it said nothing about `--image`, so it is held for the backoff and
+    // reported as pending, never kept as this checkout's verdict.
+    for (const code of [126, 127]) {
+      runHermesCli.mockReset();
+      runHermesCli.mockResolvedValue({ code, stdout: "", stderr: "hermes: not found" });
+      const { hermesSupportsImages, hermesFeatureProbePending } = await load();
+      expect(await hermesSupportsImages(), `exit ${code}`).toBe(false);
+      expect(hermesFeatureProbePending(), `exit ${code}`).toBe(true);
+
+      vi.useFakeTimers();
+      try {
+        runHermesCli.mockReset();
+        runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+        vi.setSystemTime(Date.now() + PAST_THE_BACKOFF_MS);
+        expect(await hermesSupportsImages(), `exit ${code}`).toBe(true);
+        expect(hermesFeatureProbePending(), `exit ${code}`).toBe(false);
+      } finally {
+        vi.useRealTimers();
+      }
+    }
+  });
+
   it("forgets a probe that threw before it ever awaited", async () => {
     // A spawn that fails synchronously runs the catch BEFORE the memo has been
     // assigned, so bookkeeping done through the module-level slot would be
@@ -348,5 +373,41 @@ describe("pending accessors", () => {
     // duplicated on the client, so the two cannot drift apart.
     const { HERMES_FACT_RETRY_MS } = await load();
     expect(HERMES_FACT_RETRY_MS).toBeGreaterThanOrEqual(PAST_THE_BACKOFF_MS - 1_000);
+  });
+});
+
+describe("warmHermesFeatureMemos", () => {
+  beforeEach(() => {
+    runHermesCli.mockReset();
+    hermesConfigGet.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it("touches exactly the memos that cost an interpreter on a miss", async () => {
+    runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+    hermesConfigGet.mockResolvedValue("");
+    const { warmHermesFeatureMemos } = await load();
+    await warmHermesFeatureMemos();
+    expect(runHermesCli).toHaveBeenCalledWith(["chat", "--help"], expect.anything());
+    expect(hermesConfigGet).toHaveBeenCalledWith("auxiliary.vision.model");
+    expect(hermesConfigGet).toHaveBeenCalledWith("image_gen.provider");
+  });
+
+  it("leaves the first chat open answering from the memo it filled", async () => {
+    runHermesCli.mockResolvedValue({ code: 0, stdout: HELP_WITH_IMAGE, stderr: "" });
+    hermesConfigGet.mockResolvedValue("");
+    const { warmHermesFeatureMemos, hermesSupportsImages } = await load();
+    await warmHermesFeatureMemos();
+    expect(await hermesSupportsImages()).toBe(true);
+    expect(runHermesCli).toHaveBeenCalledTimes(1);
+  });
+
+  it("never rejects, however the probes fail", async () => {
+    // Boot must not care how the warm-up went: every probe behind it fails
+    // closed, and the first chat open asks for itself.
+    runHermesCli.mockRejectedValue(new Error("hermes timed out"));
+    hermesConfigGet.mockRejectedValue(new Error("config read failed"));
+    const { warmHermesFeatureMemos } = await load();
+    await expect(warmHermesFeatureMemos()).resolves.toBeUndefined();
   });
 });

--- a/src/tests/unit/instrumentation-hermes-warmup.test.ts
+++ b/src/tests/unit/instrumentation-hermes-warmup.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * That the Hermes chat-capability memos are WARMED at boot, and warmed safely.
+ *
+ * `/setup-api/chat/capabilities` asks three facts that each start a Python
+ * interpreter on a cold cache, and the chat asks for them on every mount. The
+ * warm-up pays that once after boot so the first chat open answers from the
+ * memos. Like the transcript-sweep test next door, this reads the boot file
+ * rather than calling `register()`, because that function `require()`s its
+ * dependencies to keep Node APIs out of Next's Edge bundle. What can regress
+ * silently is the WIRING — and the guards on it — so that is what is pinned:
+ *
+ *   - it is deferred, and past the boot rush: a probe that times out under
+ *     load is held as a 60 s backoff, which would hide the attach button for
+ *     exactly the chat open it is meant to speed up;
+ *   - the timer is unref'd, so a server that is shutting down does not wait
+ *     for it;
+ *   - it is gated on the ACTIVE HARNESS, not on whether `hermes` is installed:
+ *     an OpenClaw box can carry a Hermes checkout, and no OpenClaw capability
+ *     reads these facts;
+ *   - a failure is swallowed — the first chat open asks for itself.
+ *
+ * Which memos are warmed, and that warming never rejects, is the feature
+ * module's own business and is covered in `hermes-features-probe.test.ts`.
+ */
+
+const BOOT_FILE = path.join(process.cwd(), "src", "instrumentation.ts");
+const source = fs.readFileSync(BOOT_FILE, "utf8");
+
+/**
+ * The warm-up block: from its `require` of the features module to the end of
+ * its own timer. Cut at that `.unref()` rather than at a fixed length, so the
+ * memory scheduler armed right after it — with a `.catch` of its own — cannot
+ * satisfy an assertion meant for this block.
+ */
+function warmupBlock(): string {
+  const start = source.indexOf("harness/hermes-features");
+  expect(start).toBeGreaterThan(-1);
+  const unref = source.indexOf(".unref()", start);
+  expect(unref).toBeGreaterThan(start);
+  return source.slice(start, unref + ".unref()".length);
+}
+
+describe("boot warms the hermes chat capability memos", () => {
+  it("calls the warm-up, rather than only importing it", () => {
+    expect(warmupBlock()).toMatch(/warmHermesFeatureMemos\s*\(\)/);
+  });
+
+  it("keeps it behind the Node-runtime guard", () => {
+    const guard = source.indexOf("NEXT_RUNTIME === 'edge'");
+    expect(guard).toBeGreaterThan(-1);
+    expect(source.indexOf("harness/hermes-features")).toBeGreaterThan(guard);
+  });
+
+  it("defers it past the boot rush on an unref'd timer", () => {
+    expect(warmupBlock()).toMatch(/setTimeout\([\s\S]*?\},\s*45_000\)\.unref\(\)/);
+  });
+
+  it("asks only on a Hermes box, decided when the timer fires", () => {
+    const block = warmupBlock();
+    const timer = block.indexOf("setTimeout(");
+    const gate = block.indexOf("=== 'hermes'");
+    expect(timer).toBeGreaterThan(-1);
+    expect(gate).toBeGreaterThan(timer);
+    expect(block).toMatch(/getActiveHarness\s*\(\)/);
+  });
+
+  it("does not let a failed warm-up stop the box booting", () => {
+    expect(warmupBlock()).toMatch(/\.catch\(/);
+  });
+});


### PR DESCRIPTION
## F-21 — chat capabilities: five Hermes probes awaited in series on every chat mount

### Customer-visible symptom
On a Hermes box, opening the chat after a restart (or after any `hermes config set`, which bumps `config.yaml`'s mtime and evicts the config memos) showed the composer with no attach button for 2.5-4 s while `/setup-api/chat/capabilities` answered. Measured on the bench box: `hermes` CLI start is 0.86-1.3 s, and the route paid three of those plus a ticket mint and an internet round trip, one after another.

### Cause
`src/app/setup-api/chat/capabilities/route.ts` awaited `hermesSupportsImages`, `hermesHasVisionRoute`, `hermesCanStreamTurns`, `clawaiImageRouteReachable` and `hermesAgentDrawsImages` sequentially inside the `facts` literal. None of them feeds the next; the cold cost was the sum of the five instead of the slowest one.

### Fix
- **Route**: keep `harness` and `linked` as the sequential pre-checks, then gather the five facts with one `Promise.all`. The Hermes-only and linked-only gating is unchanged, and the `*Pending()` accessors still read after the await. Safe to gather: every probe fails closed and never rejects, and each memoises its in-flight promise so concurrent callers share one spawn.
- **Boot warm-up** (`src/instrumentation.ts`, same shape as the memory-status block next to it): 45 s after start, on an unref'd timer, gated on `getActiveHarness() === "hermes"` at fire time (an OpenClaw box can carry a Hermes checkout and a `config.yaml`; no OpenClaw capability reads these facts), failures swallowed. It calls `warmHermesFeatureMemos()`, new in `hermes-features.ts`, which touches exactly the three memos that cost an interpreter on a miss. The ticket and image-route probes have 30 s / 10 min TTLs and are not worth warming.

### RED → GREEN
`src/tests/routes/chat/capabilities-parallel.test.ts` mocks each probe as a 300 ms fake-clock timer and asserts the GET has settled once the clock has moved 300 ms (the serial route needs 1500 ms). Against unmodified `beta`:

```
 × settles after ONE probe's worth of waiting on a linked Hermes box
 × has every probe in flight before any of them has answered
 × still leaves the proxy alone on an unlinked box
      Tests  3 failed | 1 passed (4)
```

With the fix, the same file plus the neighbouring suites (`routes/chat/**`, `hermes-features-probe`, `hermes-config-cache`, the three `instrumentation-*` wiring tests):

```
 Test Files  12 passed (12)
      Tests  193 passed (193)
```

Full `unit` project: green (`vitest run --project unit`, 56.8 s). `eslint` and `tsc --noEmit` clean.

Also added: `src/tests/unit/instrumentation-hermes-warmup.test.ts` (pins the wiring, the 45 s unref'd deferral, the fire-time harness gate and the swallowed failure) and a `warmHermesFeatureMemos` block in `hermes-features-probe.test.ts` (which memos it touches, that the first chat open then answers from the memo, that it never rejects).

### Review follow-ups (folded into the same commit)

- **Simplification pass**: `warmHermesFeatureMemos` is a plain `async` function now, and it warms the three memos one interpreter at a time — nobody is waiting on it, and three Python starts at once at boot+45 s is exactly the load that turns a probe into a timeout.
- **Review finding, fixed**: warming at boot made a pre-existing hole deterministic. The updater restarts the web server and only afterwards rebuilds the Hermes checkout (`step_hermes_install`, ~90 s, no restart after it); while the checkout is moved aside the `hermes` shim runs and exits 127 without reaching argparse. Both memos treated any numeric exit as the CLI's verdict, so a probe fired in that window kept "no `--image`" for the life of the process (and `""` against config.yaml's mtime) with nothing pending for the chat to re-ask. New `src/lib/hermes-cli-answered.ts` names what an answer is — a numeric exit that is not the shell's 126/127 — and `hermesSupportsImages` and `hermesConfigGet` (the sibling memo) both hold those as a failed question for the backoff. RED → GREEN for the two new tests, against the memos without the change:

  ```
   × does not remember a shim that could not start hermes as an answer   (hermes-features-probe)
   × does not remember a shim that could not start hermes as an answer   (hermes-config-cache)
  AssertionError: exit 126: expected false to be true
        Tests  2 failed | 43 skipped (45)
  ```

  With the change: `Tests 60 passed (60)` across the five touched suites; full `unit` project `503 files / 7887 tests` green; `eslint` and `tsc --noEmit` clean.
- **Review nit, fixed**: the warm-up wiring test's "failure is swallowed" assertion is now anchored to the warm-up's own timer (cut at its `.unref()`), so the memory scheduler's `.catch` next door can no longer satisfy it.

### Sibling call sites checked
- `hermes/clawai` GET — one config read behind the harness guard; nothing to gather.
- `hermes/models` GET — `reconcileLocalAiWithHermes()` may write config before `getModelOptions()` reads it; dependent, left sequential. Its own `readCurrentFromCli` already uses `Promise.all`.
- `ai-models/status` — already batched through `hermesConfigGetMany`.
- `use-harness-adapter.ts` mount fetch — left alone: with the server memos a warm re-mount costs no spawns, and a client-side cache would go stale across the link event, which is exactly when the adapter re-asks.

Not proven on hardware: the owner is testing on both boxes this morning, so this rides on the unit proof; the numbers above come from the finding's own measurements on the bench box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Chat capability information now loads faster because checks run in parallel.
  - Hermes capability information is preloaded after startup, helping the first chat interaction respond faster after a restart.
  - Unneeded capability checks are skipped when the active harness does not support them.

- **Reliability**
  - Capability checks continue to fail safely without preventing the application from starting or serving chat.
  - Temporary Hermes startup and shim failures are retried automatically.
  - Capability warm-up failures are deferred for retry during the first chat interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->