### PR TITLE
fix: refuse to save openclaw.json over a config that could not be read (F-15)

### DIFF
--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -174,7 +174,7 @@ export CLAWBOX_EXTRA_ORIGINS
 export CLAWBOX_DEVICE_STORE="$CLAWBOX_ROOT/data/config.json"
 
 python3 - "$OPENCLAW_CONFIG" <<'PY'
-import json, os, sys, tempfile, secrets
+import json, os, sys, tempfile, secrets, shutil, time
 
 # OpenClaw 2 config homes — see the bash block that computes this.
 CLAWBOX_OPENCLAW_V2 = os.environ.get("CLAWBOX_OPENCLAW_V2") == "1"
@@ -241,9 +241,27 @@ try:
         cfg = json.load(f)
 except FileNotFoundError:
     cfg = {}
-except json.JSONDecodeError:
-    # Corrupt file — start from an empty object and let the gateway
-    # re-seed on first write; the alternative is refusing to boot.
+except json.JSONDecodeError as err:
+    # Corrupt file — start from an empty object and let the gateway re-seed on
+    # first write; the alternative is refusing to boot. But that {} is written
+    # back below, and until it was copied first the write replaced every
+    # provider, auth profile and channel with an allowedOrigins-only file and
+    # logged "Updated gateway config" — the same fragment overwrite the setup
+    # writers refuse in src/lib/openclaw-config.ts. So the previous contents
+    # are kept beside the file as openclaw.json.corrupt-<utc> BEFORE anything
+    # replaces them. (src/tests/unit/gateway-pre-start-corrupt-config.test.ts
+    # extracts this block by its first and last lines.)
+    backup = f"{cfg_path}.corrupt-{time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())}"
+    try:
+        shutil.copy2(cfg_path, backup)
+        kept = f"previous contents kept at {backup}"
+    except OSError as copy_err:
+        kept = f"previous contents could NOT be copied aside ({copy_err})"
+    print(
+        f"  WARN: {os.path.basename(cfg_path)} is not valid JSON ({err}); "
+        f"re-seeding from an empty object, {kept}",
+        file=sys.stderr,
+    )
     cfg = {}
 
 changed = False

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -828,17 +828,10 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 }
 
 export async function readConfig(): Promise<OpenClawConfig> {
+  // Same file, same root rule as the writers' reader — an unreadable file is
+  // the one place they differ: a reader gets `{}`, a writer gets the throw.
   try {
-    const raw = await fs.readFile(CONFIG_PATH, "utf-8");
-    const parsed: unknown = JSON.parse(raw);
-    // The ROOT is a container too, and it is the one every helper below stands
-    // on. A file holding `[]` parses fine, so without this the writers attach
-    // their keys to an array and `JSON.stringify` drops all of them; a root
-    // string or number makes the first assignment throw in strict mode. Either
-    // way a caller that only ever reads gets `{}`, which is what this function
-    // already promises for every other unusable file. See
-    // {@link ensurePlainObject}.
-    return isPlainObject(parsed) ? (parsed as OpenClawConfig) : {};
+    return await readConfigForWrite();
   } catch {
     return {};
   }
@@ -863,14 +856,8 @@ export async function readConfig(): Promise<OpenClawConfig> {
  * and every other read or parse failure throws.
  */
 export async function readConfigStrict(): Promise<OpenClawConfig> {
-  let raw: string;
-  try {
-    raw = await fs.readFile(CONFIG_PATH, "utf-8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return {};
-    throw err;
-  }
-  const parsed: unknown = JSON.parse(raw);
+  const parsed = await parseConfigFileIfPresent();
+  if (parsed === undefined) return {};
   // Deliberately the OPPOSITE of readConfig's answer for the same file. This
   // function exists so a caller about to skip a repair cannot be told "already
   // clean" by a config it could not read, and a root array or primitive is
@@ -881,6 +868,80 @@ export async function readConfigStrict(): Promise<OpenClawConfig> {
     throw new Error("openclaw.json does not contain a configuration object");
   }
   return parsed as OpenClawConfig;
+}
+
+/**
+ * The read half of a read-modify-write.
+ *
+ * `readConfig` answers `{}` to every failure alike, and a writer that starts
+ * from that `{}` and saves has just replaced the whole file with the one block
+ * it was asked to add — every model provider, auth profile and gateway setting
+ * gone, and the route answers 200. That is exactly what a momentarily
+ * unreadable file produces: an EACCES, a file caught half-written by a
+ * concurrent `openclaw config set`. So here a file that cannot be read or
+ * parsed THROWS, the route answers 500, and the config on disk is untouched.
+ *
+ * Two shapes are still forgiven, deliberately. ENOENT is the first-run
+ * contract: there is nothing to lose. And a parseable non-object root (`[]`,
+ * `"nope"`, `3`, `null`) is a file OpenClaw cannot load at all — the gateway
+ * exits 78/CONFIG on it — so there is no working configuration to protect, and
+ * the writers repair it inside the same atomic write (see
+ * {@link ensurePlainObject}). That last case is the one difference from
+ * {@link readConfigStrict}, whose callers are about to SKIP a repair and must
+ * not be told "already clean" by a root that is not a config.
+ */
+export async function readConfigForWrite(): Promise<OpenClawConfig> {
+  const parsed = await parseConfigFileIfPresent();
+  // The ROOT is a container too, and it is the one every helper below stands
+  // on. A file holding `[]` parses fine, so without this the writers attach
+  // their keys to an array and `JSON.stringify` drops all of them; a root
+  // string or number makes the first assignment throw in strict mode. See
+  // {@link ensurePlainObject}.
+  return isPlainObject(parsed) ? (parsed as OpenClawConfig) : {};
+}
+
+/**
+ * openclaw.json exists but could not be read or parsed. The message is the
+ * one the owner sees — the Telegram routes answer it as the 500 body — so it
+ * says what happened and what was (not) done, never the parser's internals or
+ * the file's absolute path. The underlying error is kept on `cause`.
+ */
+export class OpenclawConfigUnreadableError extends Error {
+  readonly code = "config_unreadable";
+
+  constructor(cause: unknown) {
+    const reason =
+      cause instanceof SyntaxError
+        ? "it is not valid JSON"
+        : (cause as NodeJS.ErrnoException)?.code ?? "read failed";
+    super(
+      `OpenClaw's configuration file (openclaw.json) could not be read (${reason}), so nothing was saved. Check the file and try again.`,
+      { cause },
+    );
+    this.name = "OpenclawConfigUnreadableError";
+  }
+}
+
+/**
+ * The file's parsed JSON, or `undefined` when there is no file (JSON.parse
+ * never yields `undefined`, so the sentinel cannot collide with content).
+ * Every other read error and every parse error surfaces as
+ * {@link OpenclawConfigUnreadableError} — the callers above exist to tell "no
+ * config" apart from "could not read the config".
+ */
+async function parseConfigFileIfPresent(): Promise<unknown> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(CONFIG_PATH, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return undefined;
+    throw new OpenclawConfigUnreadableError(err);
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (err) {
+    throw new OpenclawConfigUnreadableError(err);
+  }
 }
 
 /**
@@ -1402,39 +1463,13 @@ export async function ensureLocalAiProxyUrls(): Promise<boolean> {
   return changed;
 }
 
-export async function ensureCompactionReserveFloor(
-  reserveTokensFloor = DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR
-): Promise<void> {
-  const config = await readConfig();
-  // OpenClaw 2 replaced the reserve-tuning keys with compaction.mode and
-  // fails config validation on reserveTokensFloor — writing it here would
-  // brick the next gateway load. The mode key is the generation marker the
-  // loader migration leaves behind; a config carrying it never gets the
-  // legacy write. (A fresh v2 box without it is covered by the writers all
-  // being gone: install.sh, the configure route and the reset seed are
-  // version-gated, so this repair is the last legacy writer standing.)
-  const compactionProbe = (config as { agents?: { defaults?: { compaction?: { mode?: unknown } } } })
-    .agents?.defaults?.compaction;
-  if (compactionProbe && typeof compactionProbe.mode === "string") return;
-  const agents = ensurePlainObject(asBag(config), "agents");
-  const defaults = ensurePlainObject(agents, "defaults");
-  const compaction = ensurePlainObject(defaults, "compaction");
-  if (
-    typeof compaction.reserveTokensFloor !== "number" ||
-    compaction.reserveTokensFloor < reserveTokensFloor
-  ) {
-    compaction.reserveTokensFloor = reserveTokensFloor;
-    await writeConfig(config);
-  }
-}
-
 /**
  * Set the OpenClaw gateway control-UI allowed origins to include the given
  * mDNS hostname. Always preserves the standard local origins so the device
  * remains reachable via IP and the AP captive portal even after a rename.
  */
 export async function setControlUiAllowedOrigins(hostname: string): Promise<void> {
-  const config = await readConfig();
+  const config = await readConfigForWrite();
   const gateway = ensurePlainObject(asBag(config), "gateway");
   const controlUi = ensurePlainObject(gateway, "controlUi");
   const existing = Array.isArray(controlUi.allowedOrigins)
@@ -1456,7 +1491,7 @@ export async function setControlUiAllowedOrigins(hostname: string): Promise<void
 const TELEGRAM_CHANNEL_ID = "telegram";
 
 export async function setTelegramToken(botToken: string): Promise<void> {
-  const config = await readConfig();
+  const config = await readConfigForWrite();
   const channels = ensurePlainObject(asBag(config), "channels");
   // Do NOT set `dmPolicy` or `allowFrom` here. OpenClaw's default
   // (`dmPolicy: "pairing"`) requires the owner to approve every new sender
@@ -1491,7 +1526,7 @@ export async function getTelegramProgressStreaming(): Promise<boolean> {
 }
 
 export async function setTelegramProgressStreaming(enabled: boolean): Promise<void> {
-  const config = await readConfig();
+  const config = await readConfigForWrite();
   const channels = ensurePlainObject(asBag(config), "channels");
   const existing = existingChannelBlock(channels, TELEGRAM_CHANNEL_ID);
   if (enabled) {
@@ -1748,7 +1783,7 @@ export function trustChannelPlugin(config: OpenClawConfig, channelId: string): v
 }
 
 export async function setDiscordToken(botToken: string): Promise<void> {
-  const config = await readConfig();
+  const config = await readConfigForWrite();
   const channels = ensurePlainObject(asBag(config), "channels");
   const {
     dmPolicy: _dmPolicy,

--- a/src/tests/unit/discord-openclaw-config.test.ts
+++ b/src/tests/unit/discord-openclaw-config.test.ts
@@ -566,21 +566,6 @@ describe("config containers that arrive as something other than a plain object",
     ]);
   });
 
-  it("still writes the compaction floor when agents is an array", async () => {
-    // ensureCompactionReserveFloor decides it changed something and writes —
-    // and the floor it just set is dropped on the way to disk, so the next boot
-    // reads the same config back and repeats the whole no-op for ever.
-    mockFs.readFile.mockResolvedValue(JSON.stringify({ agents: [] }));
-
-    await openclawConfig.ensureCompactionReserveFloor(4096);
-
-    const written = writtenJsonConfig() as {
-      agents?: { defaults?: { compaction?: { reserveTokensFloor?: number } } };
-    };
-    expect(Array.isArray(written.agents)).toBe(false);
-    expect(written.agents?.defaults?.compaction?.reserveTokensFloor).toBe(4096);
-  });
-
   it("still writes the control-UI origins when gateway is an array", async () => {
     // A dropped allowedOrigins list is a box that stops answering on its own
     // hostname after a rename the route reported as done.

--- a/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
+++ b/src/tests/unit/gateway-pre-start-corrupt-config.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+
+// F-15, the boot-time sibling. gateway-pre-start.sh loads openclaw.json, edits
+// a few keys and writes the object back on every gateway start. A file that
+// did not parse was answered with `{}` — deliberately, boot over refuse — but
+// that `{}` is what gets written back, so one torn or corrupt file cost every
+// provider, auth profile and channel, and the log said "Updated gateway
+// config". The loader must copy the previous contents aside BEFORE it answers
+// `{}`. The real function is extracted from the shipped script and run under
+// python3, the same way the token-policy test does it.
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+
+const hasPython3 =
+  spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+function extractLoader(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf("\ntry:\n    with open(cfg_path) as f:\n        cfg = json.load(f)\n");
+  const end = src.indexOf("\n    cfg = {}\n\nchanged = False\n", start);
+  if (start < 0 || end < 0) {
+    throw new Error("config load block not found in gateway-pre-start.sh");
+  }
+  return src.slice(start, end + "\n    cfg = {}\n".length);
+}
+
+const LOADER = hasPython3 ? extractLoader() : "";
+
+/** Run the loader against `cfgPath`; answers its JSON result and stderr. */
+function load(cfgPath: string): { result: unknown; stderr: string } {
+  const proc = spawnSync(
+    "python3",
+    [
+      "-c",
+      `import json, os, sys, shutil, time\ncfg_path = sys.argv[1]${LOADER}\nprint(json.dumps(cfg))`,
+      cfgPath,
+    ],
+    { encoding: "utf-8" },
+  );
+  if (proc.status !== 0) throw new Error(`loader exited ${proc.status}: ${proc.stderr}`);
+  return { result: JSON.parse(proc.stdout.trim()), stderr: proc.stderr };
+}
+
+describe.skipIf(!hasPython3)("gateway-pre-start.sh config load block", () => {
+  let dir: string;
+  let cfgPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(os.tmpdir(), "clawbox-prestart-"));
+    cfgPath = path.join(dir, "openclaw.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("answers the file's JSON when it parses, and copies nothing", () => {
+    writeFileSync(cfgPath, JSON.stringify({ gateway: { port: 18789 } }));
+
+    expect(load(cfgPath).result).toEqual({ gateway: { port: 18789 } });
+    expect(readdirSync(dir)).toEqual(["openclaw.json"]);
+  });
+
+  it("answers {} for a missing file with no backup (first run)", () => {
+    expect(load(cfgPath).result).toEqual({});
+    expect(readdirSync(dir)).toEqual([]);
+  });
+
+  it("keeps a corrupt file's bytes beside it before answering {}", () => {
+    const torn = '{"gateway":{"port":18789},"models":{"providers":{"openai":{"apiKey":"sk-te';
+    writeFileSync(cfgPath, torn);
+
+    const { result, stderr } = load(cfgPath);
+
+    expect(result).toEqual({});
+    const backups = readdirSync(dir).filter((f) => f.startsWith("openclaw.json.corrupt-"));
+    expect(backups).toHaveLength(1);
+    expect(readFileSync(path.join(dir, backups[0]), "utf-8")).toBe(torn);
+    // The loader itself never touches the original; the script's later write does.
+    expect(readFileSync(cfgPath, "utf-8")).toBe(torn);
+    expect(stderr).toMatch(/WARN: openclaw\.json is not valid JSON/);
+    expect(stderr).toContain(backups[0]);
+  });
+
+  // The block runs with the script's own imports; a change there must move here.
+  it("needs only what the script imports", () => {
+    const src = readFileSync(SCRIPT, "utf-8");
+    expect(src).toMatch(/^import json, os, sys, tempfile, secrets, shutil, time$/m);
+  });
+});

--- a/src/tests/unit/openclaw-config-write-refuses-unreadable.test.ts
+++ b/src/tests/unit/openclaw-config-write-refuses-unreadable.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import fs from "fs/promises";
+
+// F-15. Every writer in openclaw-config.ts is a read-modify-write of the whole
+// file: it reads openclaw.json, sets its one block, and saves the object back.
+// The read half used to be readConfig(), which answers `{}` to EVERY failure —
+// a missing file, an EACCES, a file caught half-written by a concurrent
+// `openclaw config set`. A writer that starts from that `{}` and saves has just
+// replaced the whole file with the one block it was asked to add: every model
+// provider, auth profile and gateway setting gone, and the route answers 200.
+//
+// The four writers here must refuse an unreadable or unparseable file instead
+// (the route answers 500, the file is untouched), while still honouring the two
+// shapes that are genuinely safe to start from: no file at all (first run) and
+// a parseable non-object root (`[]`, `3`, ...), which OpenClaw cannot load
+// anyway and which the writers repair — see the MALFORMED_ROOT cases in
+// discord-openclaw-config.test.ts.
+
+vi.mock("child_process", () => ({ execFile: vi.fn(), spawn: vi.fn() }));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    rename: vi.fn(),
+    mkdir: vi.fn(),
+    chmod: vi.fn(),
+  },
+}));
+
+vi.mock("fs", () => ({
+  default: {
+    readFileSync: vi.fn(),
+    existsSync: vi.fn(() => false),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  },
+}));
+
+const mockFs = vi.mocked(fs);
+
+const TOKEN = "clawbox-test-not-a-real-bot-token-000000";
+
+function fsError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`${code}: mock`), { code });
+}
+
+type Lib = typeof import("@/lib/openclaw-config");
+
+// name, writer — one row per read-modify-write the finding names.
+const WRITERS: ReadonlyArray<[string, (lib: Lib) => Promise<void>]> = [
+  ["setTelegramToken", (lib) => lib.setTelegramToken(TOKEN)],
+  ["setDiscordToken", (lib) => lib.setDiscordToken(TOKEN)],
+  ["setTelegramProgressStreaming", (lib) => lib.setTelegramProgressStreaming(false)],
+  ["setControlUiAllowedOrigins", (lib) => lib.setControlUiAllowedOrigins("clawbox-test")],
+];
+
+const UNREADABLE: ReadonlyArray<[string, () => void]> = [
+  ["the file is not JSON", () => mockFs.readFile.mockResolvedValue("{ not json")],
+  ["the file is half-written", () => mockFs.readFile.mockResolvedValue('{"gateway":{"port":1')],
+  ["the file cannot be read (EACCES)", () => mockFs.readFile.mockRejectedValue(fsError("EACCES"))],
+  ["the read fails with EIO", () => mockFs.readFile.mockRejectedValue(fsError("EIO"))],
+];
+
+let lib: Lib;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mockFs.readFile.mockResolvedValue("{}");
+  mockFs.writeFile.mockResolvedValue(undefined);
+  mockFs.rename.mockResolvedValue(undefined);
+  mockFs.mkdir.mockResolvedValue(undefined);
+  mockFs.chmod.mockResolvedValue(undefined);
+  lib = await import("@/lib/openclaw-config");
+});
+
+describe("config writers refuse an unreadable openclaw.json (F-15)", () => {
+  describe.each(WRITERS)("%s", (_name, write) => {
+    it.each(UNREADABLE)("throws and writes nothing when %s", async (_why, arrange) => {
+      arrange();
+
+      await expect(write(lib)).rejects.toThrow();
+
+      // Nothing reaches disk: no tmp file, no rename over the real one, and
+      // for Discord no env file either — a token on disk for a channel the
+      // config no longer names is its own failure mode.
+      expect(mockFs.writeFile).not.toHaveBeenCalled();
+      expect(mockFs.rename).not.toHaveBeenCalled();
+    });
+
+    it("still treats a missing file as a fresh config", async () => {
+      mockFs.readFile.mockRejectedValue(fsError("ENOENT"));
+
+      await write(lib);
+
+      expect(mockFs.rename).toHaveBeenCalledWith(
+        expect.stringContaining("openclaw.json.tmp"),
+        expect.stringContaining("openclaw.json"),
+      );
+    });
+
+    it("keeps every unrelated key of a readable config", async () => {
+      mockFs.readFile.mockResolvedValue(
+        JSON.stringify({
+          gateway: { port: 18789 },
+          models: { providers: { openai: { apiKey: "sk-test" } } },
+          auth: { profiles: { "openai:default": { mode: "api_key" } } },
+        }),
+      );
+
+      await write(lib);
+
+      const call = mockFs.writeFile.mock.calls.find((c) =>
+        String(c[0]).endsWith("openclaw.json.tmp"),
+      );
+      const written = JSON.parse(String(call?.[1]));
+      expect(written.gateway).toMatchObject({ port: 18789 });
+      expect(written.models.providers.openai.apiKey).toBe("sk-test");
+      expect(written.auth.profiles["openai:default"].mode).toBe("api_key");
+    });
+  });
+});
+
+describe("readConfigForWrite", () => {
+  it("returns {} for a missing file (first-run contract)", async () => {
+    mockFs.readFile.mockRejectedValue(fsError("ENOENT"));
+    await expect(lib.readConfigForWrite()).resolves.toEqual({});
+  });
+
+  // The message is what the Telegram routes answer as the 500 body, so it has
+  // to read as a sentence for the owner: what happened, what was not done —
+  // not the parser's internals and not the file's absolute path.
+  it("throws on any other read error, in the owner's words", async () => {
+    const cause = fsError("EACCES");
+    mockFs.readFile.mockRejectedValue(cause);
+    const err = await lib.readConfigForWrite().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(lib.OpenclawConfigUnreadableError);
+    expect((err as Error).message).toMatch(/could not be read \(EACCES\), so nothing was saved/);
+    expect((err as Error).message).not.toMatch(/\/home\//);
+    expect((err as Error).cause).toBe(cause);
+  });
+
+  it("throws on a file that does not parse, in the owner's words", async () => {
+    mockFs.readFile.mockResolvedValue("{ not json");
+    const err = await lib.readConfigForWrite().catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(lib.OpenclawConfigUnreadableError);
+    expect((err as Error).message).toMatch(/not valid JSON/);
+    expect((err as Error).message).not.toMatch(/Unexpected token|position \d/);
+    expect((err as Error).cause).toBeInstanceOf(SyntaxError);
+  });
+
+  // Unlike readConfigStrict: a parseable non-object root is not a config the
+  // gateway can load, so there is nothing to protect and the writers repair it.
+  it.each([
+    ["an array", "[]"],
+    ["a string", '"nope"'],
+    ["a number", "3"],
+    ["null", "null"],
+  ])("returns {} when the root is %s so the writer can repair it", async (_why, raw) => {
+    mockFs.readFile.mockResolvedValue(raw);
+    await expect(lib.readConfigForWrite()).resolves.toEqual({});
+  });
+
+  it("returns a well-formed config as-is", async () => {
+    mockFs.readFile.mockResolvedValue(JSON.stringify({ gateway: { port: 18789 } }));
+    await expect(lib.readConfigForWrite()).resolves.toEqual({ gateway: { port: 18789 } });
+  });
+});

--- a/src/tests/unit/openclaw-config.test.ts
+++ b/src/tests/unit/openclaw-config.test.ts
@@ -148,20 +148,6 @@ describe("openclaw-config", () => {
     });
   });
 
-  describe("ensureCompactionReserveFloor", () => {
-    it("writes the default reserve floor when compaction config is missing", async () => {
-      mockFs.readFile.mockResolvedValueOnce(JSON.stringify({ agents: { defaults: {} } }) as never);
-
-      await openclawConfig.ensureCompactionReserveFloor();
-
-      expect(mockFs.writeFile).toHaveBeenCalledWith(
-        expect.stringContaining("openclaw.json.tmp"),
-        expect.stringContaining('"reserveTokensFloor": 24000'),
-        "utf-8"
-      );
-    });
-  });
-
   describe("compactionReserveFloorForContext", () => {
     it("scales the reserve down for small local windows (Ollama 32K → 8192)", () => {
       expect(openclawConfig.compactionReserveFloorForContext(32768)).toBe(8192);
@@ -333,7 +319,7 @@ describe("openclaw-config", () => {
     });
 
     it("handles missing config file", async () => {
-      mockFs.readFile.mockRejectedValue(new Error("ENOENT"));
+      mockFs.readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
 
       await openclawConfig.setTelegramToken("123:abc");
 


### PR DESCRIPTION
## F-15 — config writers could save a fragment over an unreadable openclaw.json

### Customer-visible symptom
Saving a Telegram or Discord bot token, toggling Telegram progress streaming, or renaming the box (which rewrites the control-UI allowed origins) while `~/.openclaw/openclaw.json` was momentarily unreadable — an EACCES, a half-written file from a concurrent `openclaw config set`, a parse error — replaced the WHOLE file with just the one block that was being written. Every model provider, auth profile and gateway setting was gone, the gateway would not start, and the route answered 200. The boot script had the same shape one restart later: a file that did not parse was re-seeded as `{}` and written back with only the allowed origins, and the log said "Updated gateway config".

### Cause
`setTelegramToken`, `setDiscordToken`, `setTelegramProgressStreaming` and `setControlUiAllowedOrigins` are read-modify-write of the whole file and all started from `readConfig()`, which answers `{}` to every failure alike (right for the many read-only "is X on?" callers, wrong for a writer). #565 already moved `setSkillEnabled`, `clearSkillEntry` and the primary-model write onto `readConfigStrict()`; these four were left behind. `scripts/gateway-pre-start.sh` did the same in python on `json.JSONDecodeError`.

### Fix
- New `readConfigForWrite()`: ENOENT is still a fresh `{}` (first-run contract), a parseable non-object root (`[]`, `"nope"`, `3`, `null`) is still repaired in place (the gateway cannot load such a file anyway, and the existing MALFORMED_ROOT tests keep asserting the repair), but any other read error or a parse failure now throws, so the route answers 500 and the file on disk is untouched. Exactly those four writers switched to it. `readConfig()` now delegates to the same reader and swallows the throw, so readers and writers share one root rule; `readConfigStrict` shares the same file helper.
- The throw is a typed `OpenclawConfigUnreadableError` (`code: "config_unreadable"`, original error on `cause`) whose message is written for the owner — the Telegram routes answer `err.message` as the 500 body: "OpenClaw's configuration file (openclaw.json) could not be read (EACCES / it is not valid JSON), so nothing was saved. Check the file and try again." Never the parser's internals, never the absolute path.
- `scripts/gateway-pre-start.sh`: keeps boot-over-refuse, but a file that does not parse is copied aside as `openclaw.json.corrupt-<utc>` BEFORE `{}` replaces it, and says so on stderr.
- Deleted `ensureCompactionReserveFloor` (no production caller since the v2 loader migration; it would write the retired `reserveTokensFloor` key OpenClaw 2 rejects) and its two tests. `DEFAULT_COMPACTION_RESERVE_TOKENS_FLOOR` stays — `compactionReserveFloorForContext` uses it and the ai-models route tests mock it.

### RED → GREEN
`src/tests/unit/openclaw-config-write-refuses-unreadable.test.ts` (existing fs/promises mock idiom): for each of the four writers × {not JSON, half-written, EACCES, EIO} the call must reject and neither `writeFile` nor `rename` may be called; ENOENT must still write; a readable config keeps every unrelated key; plus the `readConfigForWrite` contract and the owner-facing error text.

On unmodified beta (`0f9c2380`):
```
Tests  24 failed | 8 passed (32)
AssertionError: promise resolved "undefined" instead of rejecting   (x16 — the writer saved the fragment)
TypeError: lib.readConfigForWrite is not a function                 (x8)
```

`src/tests/unit/gateway-pre-start-corrupt-config.test.ts` extracts the script's real load block and runs it under python3 (the token-policy test's idiom) against a temp dir. On unmodified beta:
```
× keeps a corrupt file's bytes beside it before answering {}
  AssertionError: expected [] to have a length of 1 but got +0     (no copy is made)
× needs only what the script imports                               (no shutil/time)
```

With the fix:
```
Targeted (post-rebase on 5d7d1559): Test Files 34 passed (34)  Tests 728 passed (728)
  (both new files + openclaw-config, discord-openclaw-config, openclaw-config-import, every gateway-pre-start-* and gateway-origins suite, system-hostname,
   every suite that names a writer or a reader, telegram/discord/hostname/ai-models route suites)
Full run: Test Files 609 passed | 1 failed (610)  Tests 8845 passed | 1 failed (8846)
  the one failure is components/chat-spoken-reply, which passes in isolation on this branch (18/18) and is flaky on beta alike
tsc --noEmit clean; eslint 0 errors on the changed files (the repo's 18 pre-existing errors are in six files this PR does not touch, identical on 0f9c2380)
bash -n and a compile of the embedded python block pass
```
Existing-test adjustment: `openclaw-config.test.ts` "handles missing config file" mocked `new Error("ENOENT")` with no `.code`; the mock now carries `code: "ENOENT"` like the real error, because only a real ENOENT is forgiven.

### Sibling call sites (all cleared)
- In-lib writers already strict (`setPrimaryModelWithoutCatalogValidation`, `setSkillEnabled`, `clearSkillEntry`): unchanged.
- `ensureMicrosoftTtsExcluded`, `ensureLocalAiProxyUrls`: read-then-write, but both return early without writing when the read yields `{}` (no `providers`), so they cannot wipe; left lenient on purpose — they run at boot and a throw there would abort startup.
- Every `readConfig()` caller outside the lib (`openclaw-channels`, `memory-shard`, `provider-status`, `harness/credentials`, `stt`, `tts`, `tts/sample`, `chat/model`, `ai-models/status`, `local-ai/exclusive`) either only reads or writes single keys through `openclaw config set`, which does its own read — none serialises a whole object. `openclaw-whatsapp.ts` does not touch the file.
- Routes: `telegram/configure`, `discord/configure` (re-throws into its outer catch, fixed "Failed to save") and `telegram/streaming` map the throw to 500; `system/hostname` catches and warns (the rename itself still completes; the origins write is skipped rather than wiping).
- `scripts/gateway-pre-start.sh` (boot-time python): fixed here, see above.

### Review passes
- `/simplify` (single pass, applied): one `parseConfigFileIfPresent()` behind both strict readers; `readConfigForWrite` is one expression; the new test's duplicated `beforeEach` hoisted.
- `/code-review` (high, six findings): applied — the owner-facing error type (raw `SyntaxError`/EACCES text reached the Settings UI through the Telegram routes' `err.message`), `readConfig` delegating to `readConfigForWrite` (one root rule instead of two hand-kept copies), and the `gateway-pre-start.sh` sibling. Refuted — "the commit does not name the `ensureCompactionReserveFloor` deletion": the commit body's closing paragraph does. Deferred as follow-ups, not in this PR: (a) the four writers still run outside `withOpenclawConfigSidecarLock`, so a concurrent `openclaw config set` can still be lost to a stale read-modify-write (a lost update, distinct from the torn-read wipe fixed here) — taking the lock changes the routes' behaviour (30 s reclaim wait, new fs surface none of the writer suites mock) and is an owner decision; (b) an `updateConfig(mutate)` = lock + read + write chokepoint with `writeConfig` un-exported, same reason.
- CodeRabbit on the first push: no actionable comments.

### Not proven on a device
Every one of the four writers changes channel or gateway config, which is off-limits on the test boxes this morning; the mock-fs test exercises the exact code path, the pre-start test runs the script's real python, and CI is the proof. Also not proven: whether the gateway's own loader accepts anything `JSON.parse` rejects (a BOM, JSON5) — unchanged by this PR, every reader here already used `JSON.parse`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Configuration updates now refuse to overwrite unreadable or malformed files.
  - Missing configuration files remain supported for first-time setup.
  - Invalid configuration files are backed up with a timestamp before being reset, with a warning displayed.
  - Valid configuration data and unrelated settings are preserved during updates.

- **Tests**
  - Added coverage for unreadable, missing, malformed, and valid configuration scenarios.
  - Added coverage for corrupt-file backups and migration warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->