### PR TITLE
fix(updater): resume the post-reboot update steps at server boot (F-04)

### DIFF
--- a/e2e-install/90-upgrade-main-to-beta.spec.ts
+++ b/e2e-install/90-upgrade-main-to-beta.spec.ts
@@ -90,12 +90,13 @@ test.describe(`in-app upgrade: main → ${UPGRADE_BRANCH}`, () => {
     // The updater restarts clawbox-setup.service mid-run (the replacement
     // for `reboot` in test mode). `waitForUpdate` retries across that
     // downtime; it also needs to see the `post_update` step run via
-    // `checkContinuation` after the service is back up.
+    // `checkContinuation`, which the server's own boot hook fires a few
+    // seconds after it is back up (our status polls are only the fallback).
     const state = await waitForUpdate({ timeoutMs: 45 * 60_000 });
     // phase may legitimately be "completed" (after post_update ran) or
-    // "running" if checkContinuation hasn't fired yet. We poll through the
-    // restart, so by the time this returns we should be at one of the
-    // terminal states.
+    // "running" while the resumed second half is still going. We poll
+    // through the restart, so by the time this returns we should be at one
+    // of the terminal states.
     expect(["completed", "failed"]).toContain(state.phase);
     if (state.phase === "failed") {
       const failedStep = state.steps.find((s) => s.status === "failed");

--- a/e2e-install/90-upgrade-main-to-beta.spec.ts
+++ b/e2e-install/90-upgrade-main-to-beta.spec.ts
@@ -93,10 +93,9 @@ test.describe(`in-app upgrade: main → ${UPGRADE_BRANCH}`, () => {
     // `checkContinuation`, which the server's own boot hook fires a few
     // seconds after it is back up (our status polls are only the fallback).
     const state = await waitForUpdate({ timeoutMs: 45 * 60_000 });
-    // phase may legitimately be "completed" (after post_update ran) or
-    // "running" while the resumed second half is still going. We poll
-    // through the restart, so by the time this returns we should be at one
-    // of the terminal states.
+    // `waitForUpdate` returns only a terminal phase — "completed" once
+    // post_update and the checks after it ran, or "failed" — polling through
+    // the restart and the resumed second half to get there.
     expect(["completed", "failed"]).toContain(state.phase);
     if (state.phase === "failed") {
       const failedStep = state.steps.find((s) => s.status === "failed");

--- a/e2e-install/README.md
+++ b/e2e-install/README.md
@@ -149,10 +149,12 @@ docker compose -f e2e-install/docker-compose.test.yml exec --user clawbox clawbo
 `install.sh` contains `reboot` inside `step_rebuild_reboot`. When
 `CLAWBOX_TEST_MODE=1` is set, that call is replaced by
 `systemctl restart clawbox-setup.service` — the Next.js process goes down,
-the updater's post-reboot `checkContinuation` fires on the next
-`/setup-api/update/status` poll, and `post_update` runs. This is how the
-upgrade test exercises the same "cross-restart" code path that would run on
-a real reboot without actually stopping the container.
+the updater's post-reboot `checkContinuation` fires from the server's own
+boot hook (`src/instrumentation.ts`, a few seconds after start; a
+`/setup-api/update/status` poll is only the fallback), and `post_update`
+runs. This is how the upgrade test exercises the same "cross-restart" code
+path that would run on a real reboot without actually stopping the
+container.
 
 For tests that want to simulate a full container reboot, call
 `composeRestart()` from `helpers/container.ts` — the `clawbox-home` volume

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -49,6 +49,46 @@ export async function repairOpenclawConfig(repairs: {
   }
 }
 
+/**
+ * Ask the updater, once the boot rush has passed, whether an update is waiting
+ * for its second half.
+ *
+ * WHY. An update reboots the box halfway through: the system fixups, the
+ * Hermes re-provisioning and the build-identity check run AFTER the restart,
+ * and `checkContinuation()` is what starts them. Its only caller was the
+ * update status route, so the second half waited for somebody to open the
+ * Update page — both test boxes sat at "running" for six and a half hours and
+ * then bounced the gateway and the dashboard the moment a page was opened
+ * (2026-09-01). Nothing an update does should depend on being watched.
+ *
+ * The status route keeps its call as the fallback. The two never collide: the
+ * check consumes the persisted flag synchronously before any real I/O, so
+ * whichever asks first resumes and the other finds nothing to do.
+ *
+ * Never awaited and never allowed to throw: clawbox-setup.service is
+ * Restart=always, so an unhandled rejection here is a crash loop, not a
+ * missed step. Unref'd, so an exiting server does not wait on it. A plain
+ * function with the check handed in, so a test can drive it with fake timers
+ * without `require()`-ing the real updater.
+ */
+export function armUpdateContinuation(
+  checkContinuation: () => Promise<boolean>,
+  delayMs = 5_000,
+): NodeJS.Timeout {
+  const timer = setTimeout(() => {
+    void Promise.resolve()
+      .then(() => checkContinuation())
+      .then((resumed) => {
+        if (resumed) console.log('[Updater] continuation resumed at boot')
+      })
+      .catch((err: unknown) => {
+        console.error('[instrumentation] Update continuation at boot failed:', err instanceof Error ? err.message : err)
+      })
+  }, delayMs)
+  timer.unref()
+  return timer
+}
+
 export async function register() {
   if (typeof process === 'undefined' || process.env.NEXT_RUNTIME === 'edge') return
 
@@ -61,6 +101,16 @@ export async function register() {
   // One-time repairs of openclaw.json, in sequence — see repairOpenclawConfig
   // for why they must not run together. Never awaited: boot goes on.
   void repairOpenclawConfig({ ensureLocalAiProxyUrls, ensureMicrosoftTtsExcluded, restartGateway })
+  try {
+    // An update that rebooted the box still has its second half to run. Ask
+    // here, so it starts whether or not anyone opens the Update page — see
+    // armUpdateContinuation.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { checkContinuation } = require('./lib/updater')
+    armUpdateContinuation(checkContinuation)
+  } catch (err) {
+    console.error('[instrumentation] Could not arm the update continuation:', err instanceof Error ? err.message : err)
+  }
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const clawkeepScheduler = require('./lib/clawkeep-scheduler')

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -62,8 +62,15 @@ export async function repairOpenclawConfig(repairs: {
  * (2026-09-01). Nothing an update does should depend on being watched.
  *
  * The status route keeps its call as the fallback. The two never collide: the
- * check consumes the persisted flag synchronously before any real I/O, so
- * whichever asks first resumes and the other finds nothing to do.
+ * check is single-flight (it claims the continuation before its first await),
+ * so whichever asks first resumes and the other finds nothing to do.
+ *
+ * Waits for the boot-time config repair first. That repair restarts the
+ * gateway when it changed something, and the resumed update's first act is to
+ * mask and stop the gateway for post_update: started together, the restart
+ * either fails against the mask (a spurious boot error) or the stop lands on
+ * the gateway's pre-start halfway through. Whether the repair succeeded or
+ * not is beside the point — only that it is over.
  *
  * Never awaited and never allowed to throw: clawbox-setup.service is
  * Restart=always, so an unhandled rejection here is a crash loop, not a
@@ -73,22 +80,58 @@ export async function repairOpenclawConfig(repairs: {
  */
 export function armUpdateContinuation(
   checkContinuation: () => Promise<boolean>,
-  delayMs = 5_000,
+  options: { afterConfigRepair?: Promise<unknown>; delayMs?: number } = {},
 ): NodeJS.Timeout {
-  const timer = setTimeout(() => {
-    void Promise.resolve()
-      .then(() => checkContinuation())
-      .then((resumed) => {
-        if (resumed) console.log('[Updater] continuation resumed at boot')
-      })
-      .catch((err: unknown) => {
-        console.error('[instrumentation] Update continuation at boot failed:', err instanceof Error ? err.message : err)
-      })
+  const { afterConfigRepair = Promise.resolve(), delayMs = 5_000 } = options
+  const timer = setTimeout(async () => {
+    try {
+      await afterConfigRepair.catch(() => undefined)
+      if (await checkContinuation()) console.log('[Updater] continuation resumed at boot')
+    } catch (err) {
+      console.error('[Updater] continuation at boot failed:', err instanceof Error ? err.message : err)
+    }
   }, delayMs)
   timer.unref()
   return timer
 }
 
+/**
+ * Warm the memory-status cache once the boot rush has passed — unless an
+ * update owns the box.
+ *
+ * WHY THE GATE. The probe boots a whole OpenClaw process against the v2
+ * SQLite store, and the resumed second half of an update (armed above) runs
+ * post_update against that same store with the gateway masked and stopped
+ * precisely so it has ONE writer. With the continuation resumed at boot the
+ * probe would land inside that window on every first boot after an update:
+ * "database is locked", and post_update's fixups — non-fatal by design —
+ * silently skipped. An update in flight means no warm; the first reader pays
+ * the probe instead, as it always did. A gate that cannot be read is treated
+ * the same way: better one slow Settings open than a second writer.
+ */
+export function armMemoryStatusWarm(deps: {
+  warm: () => Promise<void>
+  updateInFlight: () => Promise<boolean>
+  delayMs?: number
+}): NodeJS.Timeout {
+  const { warm, updateInFlight, delayMs = 45_000 } = deps
+  const timer = setTimeout(async () => {
+    try {
+      if (await updateInFlight()) return
+      await warm()
+    } catch {
+      /* the first reader retries */
+    }
+  }, delayMs)
+  timer.unref()
+  return timer
+}
+
+/**
+ * Next.js calls this once per server start, in both runtimes. Everything
+ * below is Node-only and loaded through `require()` so the Edge bundle never
+ * sees it; each hook fails on its own and none of them may stop the boot.
+ */
 export async function register() {
   if (typeof process === 'undefined' || process.env.NEXT_RUNTIME === 'edge') return
 
@@ -99,15 +142,16 @@ export async function register() {
   const { ensureLocalAiProxyUrls, ensureMicrosoftTtsExcluded, restartGateway } = require('./lib/openclaw-config')
   startTerminalServer()
   // One-time repairs of openclaw.json, in sequence — see repairOpenclawConfig
-  // for why they must not run together. Never awaited: boot goes on.
-  void repairOpenclawConfig({ ensureLocalAiProxyUrls, ensureMicrosoftTtsExcluded, restartGateway })
+  // for why they must not run together. Never awaited: boot goes on. Never
+  // rejects: every step inside catches for itself.
+  const configRepaired = repairOpenclawConfig({ ensureLocalAiProxyUrls, ensureMicrosoftTtsExcluded, restartGateway })
   try {
     // An update that rebooted the box still has its second half to run. Ask
     // here, so it starts whether or not anyone opens the Update page — see
-    // armUpdateContinuation.
+    // armUpdateContinuation, including why it waits for the repair above.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { checkContinuation } = require('./lib/updater')
-    armUpdateContinuation(checkContinuation)
+    armUpdateContinuation(checkContinuation, { afterConfigRepair: configRepaired })
   } catch (err) {
     console.error('[instrumentation] Could not arm the update continuation:', err instanceof Error ? err.message : err)
   }
@@ -175,14 +219,15 @@ export async function register() {
     // Jetson). Pay it once, after the boot rush (gateway restart, schedulers,
     // Next's own warm-up) has passed, so the first Settings → Local AI open
     // answers from the cache. Not on Hermes: there is no openclaw to probe.
+    // Not under an update either — see armMemoryStatusWarm.
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { openclawIsAbsent } = require('./lib/openclaw-config')
     if (!openclawIsAbsent()) {
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { warmMemoryStatusCache } = require('./lib/clawkeep-memory')
-      setTimeout(() => {
-        void warmMemoryStatusCache().catch(() => { /* the first reader retries */ })
-      }, 45_000).unref()
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { updateInFlight } = require('./lib/updater')
+      armMemoryStatusWarm({ warm: warmMemoryStatusCache, updateInFlight })
     }
   } catch (err) {
     console.error('[instrumentation] Could not warm the memory status cache:', err instanceof Error ? err.message : err)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -62,8 +62,8 @@ export async function repairOpenclawConfig(repairs: {
  * (2026-09-01). Nothing an update does should depend on being watched.
  *
  * The status route keeps its call as the fallback. The two never collide: the
- * check is single-flight (it claims the continuation before its first await),
- * so whichever asks first resumes and the other finds nothing to do.
+ * check is single-flight, so a poll that lands on the boot hook's read joins
+ * it and gets the same answer instead of resuming a second time.
  *
  * Waits for the boot-time config repair first. That repair restarts the
  * gateway when it changed something, and the resumed update's first act is to

--- a/src/lib/clawkeep-memory-scheduler.ts
+++ b/src/lib/clawkeep-memory-scheduler.ts
@@ -20,6 +20,7 @@ import {
   startMemoryIndex,
   type MemoryIndexSchedule,
 } from "@/lib/clawkeep-memory";
+import { updateInFlight } from "@/lib/updater";
 
 let armed: NodeJS.Timeout | null = null;
 let armedFor = 0;
@@ -44,17 +45,7 @@ function fire(): void {
   // time that has already passed for as long as the index runs, and the panel
   // shows a "next run" in the past.
   clear();
-  // Incremental, never a full reindex: a scheduled run must not spend hours
-  // re-embedding everything unattended. The one exception is a box with no
-  // index at all, where an incremental pass cannot succeed — startMemoryIndex
-  // settles that through the same rule as the button, so the two agree. It
-  // is single-flight, and declines this slot before it asks anything of the
-  // CLI, so a manual run already in progress keeps its record; the one log
-  // line is the only trace a declined slot leaves.
-  void startMemoryIndex("incremental", "schedule")
-    .then(({ accepted }) => {
-      if (!accepted) console.log("[clawkeep-memory-scheduler] skipped: an index run is in progress");
-    })
+  void runSlot()
     .catch((err) => {
       console.warn(
         "[clawkeep-memory-scheduler] scheduled index failed:",
@@ -64,6 +55,27 @@ function fire(): void {
     .finally(() => {
       void rearm();
     });
+}
+
+async function runSlot(): Promise<void> {
+  // An update owns the OpenClaw store while it runs: post_update repairs it
+  // with the gateway masked and stopped so there is ONE writer, and
+  // `openclaw memory index` would be a second. A slot that lands inside an
+  // update is skipped — one missed incremental pass costs nothing (see the
+  // file comment) — and the next one runs as normal.
+  if (await updateInFlight()) {
+    console.log("[clawkeep-memory-scheduler] skipped: an update is in progress");
+    return;
+  }
+  // Incremental, never a full reindex: a scheduled run must not spend hours
+  // re-embedding everything unattended. The one exception is a box with no
+  // index at all, where an incremental pass cannot succeed — startMemoryIndex
+  // settles that through the same rule as the button, so the two agree. It
+  // is single-flight, and declines this slot before it asks anything of the
+  // CLI, so a manual run already in progress keeps its record; the one log
+  // line is the only trace a declined slot leaves.
+  const { accepted } = await startMemoryIndex("incremental", "schedule");
+  if (!accepted) console.log("[clawkeep-memory-scheduler] skipped: an index run is in progress");
 }
 
 async function rearm(): Promise<void> {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -763,6 +763,10 @@ const GATEWAY_PORT = Number(process.env.GATEWAY_PORT || "18789");
 const GATEWAY_HEALTH_WAIT_MS = Number(process.env.GATEWAY_HEALTH_WAIT_MS || "30000");
 const GATEWAY_RECOVERY_WAIT_MS = Number(process.env.GATEWAY_RECOVERY_WAIT_MS || "45000");
 const GATEWAY_WAIT_INTERVAL_MS = Number(process.env.GATEWAY_WAIT_INTERVAL_MS || "1500");
+// The unit's TimeoutStartSec (config/clawbox-gateway.service): a pre-start
+// still running at this point is killed by systemd itself, so the wait below
+// never outlives the thing it waits for.
+const GATEWAY_PRE_START_TIMEOUT_MS = Number(process.env.GATEWAY_PRE_START_TIMEOUT_MS || "600000");
 const ROOT_STEP_SETTLE_TIMEOUT_MS = Number(process.env.ROOT_STEP_SETTLE_TIMEOUT_MS || "7200000");
 const LEGACY_GATEWAY_BLOCKER_RE =
   /installs\.json|conflicting plugin install metadata|carl_pir|belongs to agent piper/i;
@@ -843,12 +847,54 @@ async function removeGatewayMaintenanceMask(): Promise<void> {
 }
 
 /**
+ * Let a gateway that is still in its ExecStartPre finish it before it is
+ * stopped.
+ *
+ * WHY. clawbox-gateway.service and clawbox-setup.service start together at
+ * boot, and gateway-pre-start.sh can spend minutes in a plugin install on a
+ * cold box. The second half of an update is resumed from boot now, and its
+ * first act is to quiesce the gateway: `systemctl stop` on a unit in
+ * `start-pre` kills the pre-start halfway through the same migration that
+ * ensureGatewayHealthy budgets 600 s for precisely so it is never killed.
+ * `start-pre` is the only sub-state that matters — `auto-restart` is also
+ * `activating` but nothing runs in it, and Type=simple leaves `start` at once.
+ *
+ * A query that fails says nothing about the pre-start, so it does not hold
+ * the update: the box carries on exactly as it did before this wait existed.
+ */
+async function waitForGatewayPreStart(): Promise<void> {
+  const deadline = Date.now() + GATEWAY_PRE_START_TIMEOUT_MS;
+  let announced = false;
+  while (Date.now() < deadline) {
+    let subState: string;
+    try {
+      const { stdout } = await execFile(
+        "/usr/bin/systemctl",
+        ["show", "clawbox-gateway.service", "-p", "SubState", "--value"],
+        { timeout: 10_000 },
+      );
+      subState = stdout.trim();
+    } catch {
+      return;
+    }
+    if (subState !== "start-pre") return;
+    if (!announced) {
+      announced = true;
+      console.log("[Updater] waiting for clawbox-gateway to finish its pre-start before quiescing it");
+    }
+    await delay(GATEWAY_WAIT_INTERVAL_MS);
+  }
+  console.warn("[Updater] clawbox-gateway pre-start did not finish within its ceiling — quiescing anyway");
+}
+
+/**
  * Keep systemd from starting the gateway while an OpenClaw writer is active.
  * Mask comes before stop so a root update step cannot race the stop with its
  * own restart. The runtime mask is always removed, including failure paths.
  */
 async function withGatewayQuiesced<T>(operation: () => Promise<T>): Promise<T> {
   if (gatewayIsAbsent()) return operation();
+  await waitForGatewayPreStart();
 
   let masked = false;
   let outcome!: { ok: true; value: T } | { ok: false; error: unknown };
@@ -1653,14 +1699,40 @@ function launchUpdate(steps: UpdateStepDef[], startFrom: number, options: RunOpt
     });
 }
 
+// Taken before the first await in checkContinuation and released when it
+// returns. `running` covers a launched run; this covers the reads before it,
+// so two callers in one tick — the boot hook and a status poll — cannot both
+// find the flag set and both resume.
+let continuationClaimed = false;
+
+/**
+ * Whether an update owns the box right now: one is running, or one has
+ * rebooted the box and is waiting for its second half to be resumed. Boot
+ * hooks that touch what post_update repairs — the OpenClaw store above all —
+ * ask this before they start.
+ */
+export async function updateInFlight(): Promise<boolean> {
+  if (running || continuationClaimed) return true;
+  return Boolean(await get("update_needs_continuation"));
+}
+
 /**
  * Check if a post-restart continuation is needed and trigger it.
  * Called once from the server boot path (src/instrumentation.ts) and from
- * the status route on every idle poll as the fallback. The flag is consumed
- * synchronously before any real I/O, so the two cannot both resume.
+ * the status route on every idle poll as the fallback. Single-flight: of two
+ * overlapping callers only the first reads the flag; the other gets false.
  */
 export async function checkContinuation(): Promise<boolean> {
-  if (running) return false;
+  if (running || continuationClaimed) return false;
+  continuationClaimed = true;
+  try {
+    return await resumeContinuation();
+  } finally {
+    continuationClaimed = false;
+  }
+}
+
+async function resumeContinuation(): Promise<boolean> {
   const needsContinuation = await get("update_needs_continuation");
   if (!needsContinuation) return false;
 

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1671,15 +1671,16 @@ function createInitialState(steps: UpdateStepDef[]): UpdateState {
 
 let state: UpdateState = createInitialState(applicableSteps());
 let running = false;
-// Taken before the first await in checkContinuation and released when it
-// returns. `running` covers a launched run; this covers the reads before it,
-// so two callers in one tick — the boot hook and a status poll — cannot both
-// find the flag set and both resume, and no full run can start underneath.
-let continuationClaimed = false;
+// The continuation being read, if one is. Assigned before that read's first
+// await and cleared when it settles: `running` covers a launched run, this
+// covers the reads before it, so two callers in one tick — the boot hook and
+// a status poll — share one resume instead of each running their own, and no
+// full run can start underneath it.
+let continuationInFlight: Promise<boolean> | null = null;
 
 /** An update owns the box: one is running, or a continuation is being read. */
 function updateOwned(): boolean {
-  return running || continuationClaimed;
+  return running || continuationInFlight !== null;
 }
 
 export function getUpdateState(): UpdateState {
@@ -1693,6 +1694,7 @@ export function getUpdateState(): UpdateState {
 export function resetUpdateState(): void {
   state = createInitialState(applicableSteps());
   running = false;
+  continuationInFlight = null;
 }
 
 export async function isUpdateCompleted(): Promise<boolean> {
@@ -1736,17 +1738,18 @@ export async function updateInFlight(): Promise<boolean> {
 /**
  * Check if a post-restart continuation is needed and trigger it.
  * Called once from the server boot path (src/instrumentation.ts) and from
- * the status route on every idle poll as the fallback. Single-flight: of two
- * overlapping callers only the first reads the flag; the other gets false.
+ * the status route on every idle poll as the fallback. Single-flight:
+ * overlapping callers share one resume and get its one answer, so a status
+ * poll that lands on the boot hook's read answers "running", not "idle".
  */
-export async function checkContinuation(): Promise<boolean> {
-  if (updateOwned()) return false;
-  continuationClaimed = true;
-  try {
-    return await resumeContinuation();
-  } finally {
-    continuationClaimed = false;
+export function checkContinuation(): Promise<boolean> {
+  if (running) return Promise.resolve(false);
+  if (!continuationInFlight) {
+    continuationInFlight = resumeContinuation().finally(() => {
+      continuationInFlight = null;
+    });
   }
+  return continuationInFlight;
 }
 
 async function resumeContinuation(): Promise<boolean> {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -763,10 +763,10 @@ const GATEWAY_PORT = Number(process.env.GATEWAY_PORT || "18789");
 const GATEWAY_HEALTH_WAIT_MS = Number(process.env.GATEWAY_HEALTH_WAIT_MS || "30000");
 const GATEWAY_RECOVERY_WAIT_MS = Number(process.env.GATEWAY_RECOVERY_WAIT_MS || "45000");
 const GATEWAY_WAIT_INTERVAL_MS = Number(process.env.GATEWAY_WAIT_INTERVAL_MS || "1500");
-// The unit's TimeoutStartSec (config/clawbox-gateway.service): a pre-start
-// still running at this point is killed by systemd itself, so the wait below
-// never outlives the thing it waits for.
-const GATEWAY_PRE_START_TIMEOUT_MS = Number(process.env.GATEWAY_PRE_START_TIMEOUT_MS || "600000");
+// The unit's own TimeoutStartSec (config/clawbox-gateway.service), not a
+// tunable: a pre-start still running at this point is killed by systemd
+// itself, so the wait below never outlives the thing it waits for.
+const GATEWAY_PRE_START_TIMEOUT_MS = 600_000;
 const ROOT_STEP_SETTLE_TIMEOUT_MS = Number(process.env.ROOT_STEP_SETTLE_TIMEOUT_MS || "7200000");
 const LEGACY_GATEWAY_BLOCKER_RE =
   /installs\.json|conflicting plugin install metadata|carl_pir|belongs to agent piper/i;
@@ -848,7 +848,9 @@ async function removeGatewayMaintenanceMask(): Promise<void> {
 
 /**
  * Let a gateway that is still in its ExecStartPre finish it before it is
- * stopped.
+ * stopped. Called with the runtime mask already in place: a masked unit
+ * cannot be started again, so nothing can enter `start-pre` behind this
+ * wait — checked, then masked, would leave that gap open.
  *
  * WHY. clawbox-gateway.service and clawbox-setup.service start together at
  * boot, and gateway-pre-start.sh can spend minutes in a plugin install on a
@@ -880,27 +882,29 @@ async function waitForGatewayPreStart(): Promise<void> {
     if (subState !== "start-pre") return;
     if (!announced) {
       announced = true;
-      console.log("[Updater] waiting for clawbox-gateway to finish its pre-start before quiescing it");
+      console.log("[Updater] waiting for clawbox-gateway to finish its pre-start before stopping it");
     }
     await delay(GATEWAY_WAIT_INTERVAL_MS);
   }
-  console.warn("[Updater] clawbox-gateway pre-start did not finish within its ceiling — quiescing anyway");
+  console.warn("[Updater] clawbox-gateway pre-start did not finish within its ceiling — stopping anyway");
 }
 
 /**
  * Keep systemd from starting the gateway while an OpenClaw writer is active.
  * Mask comes before stop so a root update step cannot race the stop with its
- * own restart. The runtime mask is always removed, including failure paths.
+ * own restart, and before the pre-start wait so no new activation can slip
+ * into `start-pre` behind it. The runtime mask is always removed, including
+ * failure paths.
  */
 async function withGatewayQuiesced<T>(operation: () => Promise<T>): Promise<T> {
   if (gatewayIsAbsent()) return operation();
-  await waitForGatewayPreStart();
 
   let masked = false;
   let outcome!: { ok: true; value: T } | { ok: false; error: unknown };
   try {
     await setGatewayMaintenanceMask(true);
     masked = true;
+    await waitForGatewayPreStart();
     await stopGatewayForMaintenance();
     outcome = { ok: true, value: await operation() };
   } catch (err) {
@@ -1660,6 +1664,16 @@ function createInitialState(steps: UpdateStepDef[]): UpdateState {
 
 let state: UpdateState = createInitialState(applicableSteps());
 let running = false;
+// Taken before the first await in checkContinuation and released when it
+// returns. `running` covers a launched run; this covers the reads before it,
+// so two callers in one tick — the boot hook and a status poll — cannot both
+// find the flag set and both resume, and no full run can start underneath.
+let continuationClaimed = false;
+
+/** An update owns the box: one is running, or a continuation is being read. */
+function updateOwned(): boolean {
+  return running || continuationClaimed;
+}
 
 export function getUpdateState(): UpdateState {
   return {
@@ -1699,12 +1713,6 @@ function launchUpdate(steps: UpdateStepDef[], startFrom: number, options: RunOpt
     });
 }
 
-// Taken before the first await in checkContinuation and released when it
-// returns. `running` covers a launched run; this covers the reads before it,
-// so two callers in one tick — the boot hook and a status poll — cannot both
-// find the flag set and both resume.
-let continuationClaimed = false;
-
 /**
  * Whether an update owns the box right now: one is running, or one has
  * rebooted the box and is waiting for its second half to be resumed. Boot
@@ -1712,7 +1720,7 @@ let continuationClaimed = false;
  * ask this before they start.
  */
 export async function updateInFlight(): Promise<boolean> {
-  if (running || continuationClaimed) return true;
+  if (updateOwned()) return true;
   return Boolean(await get("update_needs_continuation"));
 }
 
@@ -1723,7 +1731,7 @@ export async function updateInFlight(): Promise<boolean> {
  * overlapping callers only the first reads the flag; the other gets false.
  */
 export async function checkContinuation(): Promise<boolean> {
-  if (running || continuationClaimed) return false;
+  if (updateOwned()) return false;
   continuationClaimed = true;
   try {
     return await resumeContinuation();
@@ -1790,7 +1798,7 @@ async function resumeContinuation(): Promise<boolean> {
 }
 
 export function startUpdate(): { started: boolean; error?: string } {
-  if (running) {
+  if (updateOwned()) {
     return { started: false, error: "Update already in progress" };
   }
 
@@ -1829,7 +1837,7 @@ const OPENCLAW_UPDATE_STEPS: UpdateStepDef[] = [
 ];
 
 export function startOpenclawUpdate(): { started: boolean; error?: string } {
-  if (running) {
+  if (updateOwned()) {
     return { started: false, error: "Update already in progress" };
   }
   // Every step in this list is OpenClaw's, so there is no filtered version of

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1655,7 +1655,9 @@ function launchUpdate(steps: UpdateStepDef[], startFrom: number, options: RunOpt
 
 /**
  * Check if a post-restart continuation is needed and trigger it.
- * Called from the status route on first poll after restart.
+ * Called once from the server boot path (src/instrumentation.ts) and from
+ * the status route on every idle poll as the fallback. The flag is consumed
+ * synchronously before any real I/O, so the two cannot both resume.
  */
 export async function checkContinuation(): Promise<boolean> {
   if (running) return false;

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1728,7 +1728,9 @@ function launchUpdate(steps: UpdateStepDef[], startFrom: number, options: RunOpt
  */
 export async function updateInFlight(): Promise<boolean> {
   if (updateOwned()) return true;
-  return Boolean(await get("update_needs_continuation"));
+  const needsContinuation = await get("update_needs_continuation");
+  // An update may have claimed the box while the flag was being read.
+  return updateOwned() || Boolean(needsContinuation);
 }
 
 /**

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -861,14 +861,16 @@ async function removeGatewayMaintenanceMask(): Promise<void> {
  * `start-pre` is the only sub-state that matters — `auto-restart` is also
  * `activating` but nothing runs in it, and Type=simple leaves `start` at once.
  *
- * A query that fails says nothing about the pre-start, so it does not hold
- * the update: the box carries on exactly as it did before this wait existed.
+ * A query that fails says nothing about the pre-start, so it is asked again:
+ * stopping on an unanswered query would kill the very migration this wait
+ * protects. A unit that cannot be seen out of `start-pre` by the ceiling is
+ * left running and the step fails instead.
  */
 async function waitForGatewayPreStart(): Promise<void> {
   const deadline = Date.now() + GATEWAY_PRE_START_TIMEOUT_MS;
   let announced = false;
   while (Date.now() < deadline) {
-    let subState: string;
+    let subState: string | null = null;
     try {
       const { stdout } = await execFile(
         "/usr/bin/systemctl",
@@ -877,16 +879,20 @@ async function waitForGatewayPreStart(): Promise<void> {
       );
       subState = stdout.trim();
     } catch {
-      return;
+      // Unanswered is not "finished": a query that times out under a cold
+      // box's load says nothing about the pre-start. Ask again.
     }
-    if (subState !== "start-pre") return;
+    if (subState !== null && subState !== "start-pre") return;
     if (!announced) {
       announced = true;
       console.log("[Updater] waiting for clawbox-gateway to finish its pre-start before stopping it");
     }
     await delay(GATEWAY_WAIT_INTERVAL_MS);
   }
-  console.warn("[Updater] clawbox-gateway pre-start did not finish within its ceiling — stopping anyway");
+  // systemd's own TimeoutStartSec has killed any pre-start by now, so this is
+  // a unit whose state could not be confirmed for ten minutes. Leave it alone:
+  // the step fails and the mask is lifted, the gateway is not stopped.
+  throw new Error("clawbox-gateway did not leave its pre-start within the unit's ceiling — not stopping it");
 }
 
 /**

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -887,7 +887,8 @@ async function waitForGatewayPreStart(): Promise<void> {
       announced = true;
       console.log("[Updater] waiting for clawbox-gateway to finish its pre-start before stopping it");
     }
-    await delay(GATEWAY_WAIT_INTERVAL_MS);
+    // Never sleep past the ceiling: the gateway is masked while this waits.
+    await delay(Math.min(GATEWAY_WAIT_INTERVAL_MS, Math.max(0, deadline - Date.now())));
   }
   // systemd's own TimeoutStartSec has killed any pre-start by now, so this is
   // a unit whose state could not be confirmed for ten minutes. Leave it alone:

--- a/src/tests/components/update-step-abort-honesty.test.tsx
+++ b/src/tests/components/update-step-abort-honesty.test.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from "react";
 import { act, render, screen, waitFor } from "@/tests/helpers/test-utils";
 import { translations } from "@/lib/translations";
 import UpdateStep from "@/components/UpdateStep";
+import { deferred } from "@/tests/helpers/deferred";
 
 // Resolve the real English strings the way the app does, so a renamed key
 // fails here instead of shipping a raw "update.foo" to the owner.
@@ -31,16 +32,6 @@ const IDLE_UP_TO_DATE = {
     openclaw: { current: "1.2.3", target: null },
   },
 };
-
-function deferred<T>() {
-  let resolve!: (v: T) => void;
-  let reject!: (e: unknown) => void;
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res;
-    reject = rej;
-  });
-  return { promise, resolve, reject };
-}
 
 function okJson(json: () => Promise<unknown>) {
   return { ok: true, status: 200, json };

--- a/src/tests/helpers/deferred.ts
+++ b/src/tests/helpers/deferred.ts
@@ -1,0 +1,10 @@
+/**
+ * A promise settled by the test, not by the code under test — for pinning
+ * ordering: "B must not start until A has finished".
+ */
+export function deferred<T = void>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}

--- a/src/tests/unit/clawkeep-memory-scheduler.test.ts
+++ b/src/tests/unit/clawkeep-memory-scheduler.test.ts
@@ -89,6 +89,7 @@ describe("the memory index scheduler", () => {
     // settle. The empty-index upgrade it applies to the request is covered in
     // clawkeep-memory.test.ts.
     const startMemoryIndex = vi.fn(async () => ({ accepted: true, run: {} as never }));
+    vi.doMock("@/lib/updater", () => ({ updateInFlight: vi.fn(async () => false) }));
     vi.doMock("@/lib/clawkeep-memory", async () => {
       const actual = await vi.importActual<typeof import("@/lib/clawkeep-memory")>("@/lib/clawkeep-memory");
       return { ...actual, startMemoryIndex };
@@ -108,6 +109,7 @@ describe("the memory index scheduler", () => {
     // over it. Before this line existed a declined slot left no trace at all
     // — the card showed the manual run, the journal showed nothing.
     const startMemoryIndex = vi.fn(async () => ({ accepted: false, run: { status: "running" } as never }));
+    vi.doMock("@/lib/updater", () => ({ updateInFlight: vi.fn(async () => false) }));
     vi.doMock("@/lib/clawkeep-memory", async () => {
       const actual = await vi.importActual<typeof import("@/lib/clawkeep-memory")>("@/lib/clawkeep-memory");
       return { ...actual, startMemoryIndex };
@@ -120,6 +122,34 @@ describe("the memory index scheduler", () => {
     await vi.advanceTimersByTimeAsync(61 * 60_000);
     expect(startMemoryIndex).toHaveBeenCalledTimes(1);
     expect(log).toHaveBeenCalledWith(expect.stringContaining("skipped: an index run is in progress"));
+    log.mockRestore();
+  });
+
+  it("stands down for the slot while an update is in flight, and re-arms", async () => {
+    // post_update repairs the OpenClaw store with the gateway masked so there
+    // is one writer; `openclaw memory index` would be a second. A slot that
+    // lands inside an update is skipped — one missed incremental pass costs
+    // nothing — and the next slot is armed as usual.
+    const startMemoryIndex = vi.fn(async () => ({ accepted: true, run: {} as never }));
+    const updateInFlight = vi.fn(async () => true);
+    vi.doMock("@/lib/updater", () => ({ updateInFlight }));
+    vi.doMock("@/lib/clawkeep-memory", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/clawkeep-memory")>("@/lib/clawkeep-memory");
+      return { ...actual, startMemoryIndex };
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await writeSchedule({ enabled: true, frequency: "daily", timeOfDay: "06:00", weekday: 0 });
+    const sched = await import("@/lib/clawkeep-memory-scheduler");
+    await sched.start();
+
+    await vi.advanceTimersByTimeAsync(61 * 60_000);
+    expect(updateInFlight).toHaveBeenCalledTimes(1);
+    expect(startMemoryIndex).not.toHaveBeenCalled();
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("skipped: an update is in progress"));
+    // Tomorrow's slot, not nothing (the re-arm re-reads the schedule file).
+    await vi.waitFor(() => {
+      expect(sched.nextRunAtMs()).toBe(new Date("2026-08-23T06:00:00").getTime());
+    });
     log.mockRestore();
   });
 });

--- a/src/tests/unit/instrumentation-config-repairs.test.ts
+++ b/src/tests/unit/instrumentation-config-repairs.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { repairOpenclawConfig } from "@/instrumentation";
+import { deferred } from "@/tests/helpers/deferred";
 
 /**
  * The boot-time repairs of openclaw.json ran TOGETHER. Each is a read-modify-
@@ -11,13 +12,6 @@ import { repairOpenclawConfig } from "@/instrumentation";
  * The sequencing is a plain function with the repairs handed in, so this can
  * pin the order without `require()`-ing the real config module.
  */
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (err: unknown) => void;
-  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej; });
-  return { promise, resolve, reject };
-}
 
 describe("repairOpenclawConfig", () => {
   it("starts the second repair only after the first has finished", async () => {

--- a/src/tests/unit/instrumentation-memory-warm.test.ts
+++ b/src/tests/unit/instrumentation-memory-warm.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import { armMemoryStatusWarm } from "@/instrumentation";
+
+/**
+ * The boot-time memory-status warm boots an OpenClaw process against the v2
+ * SQLite store 45 s after start. The second half of an update is resumed from
+ * boot now, and it runs post_update against that same store with the gateway
+ * masked and stopped so there is ONE writer — the warm would have been a
+ * second one on every first boot after an update ("database is locked", and
+ * the fixups, non-fatal by design, silently skipped). So the warm asks the
+ * updater first and stands down while an update owns the box.
+ *
+ * Driven here with fake timers through the plain helper; the wiring into
+ * `register()` is pinned by reading the boot file, as the other hooks are.
+ */
+
+const WARM_DELAY_MS = 45_000;
+const BOOT_CALL = /armMemoryStatusWarm\(\{ warm: warmMemoryStatusCache, updateInFlight \}\)/;
+
+describe("armMemoryStatusWarm", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("warms once the boot rush has passed on a box with no update in flight", async () => {
+    const warm = vi.fn(async () => {});
+    const updateInFlight = vi.fn(async () => false);
+
+    armMemoryStatusWarm({ warm, updateInFlight });
+    await vi.advanceTimersByTimeAsync(WARM_DELAY_MS - 1);
+    expect(warm).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(updateInFlight).toHaveBeenCalledTimes(1);
+    expect(warm).toHaveBeenCalledTimes(1);
+  });
+
+  it("stands down while an update owns the box", async () => {
+    const warm = vi.fn(async () => {});
+    const updateInFlight = vi.fn(async () => true);
+
+    armMemoryStatusWarm({ warm, updateInFlight, delayMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(updateInFlight).toHaveBeenCalledTimes(1);
+    expect(warm).not.toHaveBeenCalled();
+  });
+
+  it("stands down when it cannot tell", async () => {
+    // Better one slow Settings open than a second writer on the store.
+    const warm = vi.fn(async () => {});
+    const updateInFlight = vi.fn(async (): Promise<boolean> => {
+      throw new Error("config unreadable");
+    });
+
+    armMemoryStatusWarm({ warm, updateInFlight, delayMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(warm).not.toHaveBeenCalled();
+  });
+
+  it("swallows a failed probe — the first reader retries", async () => {
+    const warm = vi.fn(async () => {
+      throw new Error("memory status unavailable");
+    });
+
+    armMemoryStatusWarm({ warm, updateInFlight: async () => false, delayMs: 10 });
+    await expect(vi.advanceTimersByTimeAsync(10)).resolves.not.toThrow();
+    expect(warm).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not keep the process alive for it", () => {
+    const timer = armMemoryStatusWarm({ warm: async () => {}, updateInFlight: async () => false });
+    expect(timer.hasRef()).toBe(false);
+    clearTimeout(timer);
+  });
+});
+
+describe("boot arms the memory-status warm behind the update gate", () => {
+  const source = fs.readFileSync(path.join(process.cwd(), "src", "instrumentation.ts"), "utf8");
+
+  it("hands the helper the real probe and the updater's gate", () => {
+    expect(source).toMatch(BOOT_CALL);
+    const call = source.search(BOOT_CALL);
+    const tryStart = source.lastIndexOf("try {", call);
+    const inside = source.slice(tryStart, call);
+    expect(inside).toMatch(/require\(['"]\.\/lib\/clawkeep-memory['"]\)/);
+    expect(inside).toMatch(/require\(['"]\.\/lib\/updater['"]\)/);
+  });
+
+  it("keeps it off the Hermes edition", () => {
+    // There is no openclaw to probe there; the guard has to come first.
+    const guard = source.indexOf("if (!openclawIsAbsent())");
+    const call = source.search(BOOT_CALL);
+    expect(guard).toBeGreaterThan(-1);
+    expect(call).toBeGreaterThan(guard);
+  });
+});

--- a/src/tests/unit/updater-continuation-boot.test.ts
+++ b/src/tests/unit/updater-continuation-boot.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import fs from "fs";
 import path from "path";
 import { armUpdateContinuation } from "@/instrumentation";
+import { deferred } from "@/tests/helpers/deferred";
 
 /**
  * The second half of an update — the system fixups, the Hermes
@@ -20,8 +21,9 @@ import { armUpdateContinuation } from "@/instrumentation";
  */
 
 const BOOT_DELAY_MS = 5_000;
-// The call in register(), as distinct from the helper's own definition.
-const BOOT_CALL = /armUpdateContinuation\(checkContinuation\)/;
+// The call in register(), as distinct from the helper's own definition. The
+// repair promise is part of the pin: see "waits for the config repair".
+const BOOT_CALL = /armUpdateContinuation\(checkContinuation, \{ afterConfigRepair: configRepaired \}\)/;
 
 describe("armUpdateContinuation", () => {
   beforeEach(() => {
@@ -52,11 +54,42 @@ describe("armUpdateContinuation", () => {
     expect(checkContinuation).toHaveBeenCalledTimes(1);
   });
 
+  it("waits for the config repair to finish before asking", async () => {
+    // The repair restarts the gateway when it wrote something; the resumed
+    // update masks and stops the gateway first thing. Overlapped, the restart
+    // fails against the mask or the stop kills the gateway's pre-start.
+    const repair = deferred();
+    const checkContinuation = vi.fn(async () => false);
+
+    armUpdateContinuation(checkContinuation, { afterConfigRepair: repair.promise, delayMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(checkContinuation).not.toHaveBeenCalled();
+
+    repair.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(checkContinuation).toHaveBeenCalledTimes(1);
+  });
+
+  it("still asks when the config repair failed", async () => {
+    // Only that the repair is OVER matters, not how it ended: an update must
+    // not lose its second half to a broken openclaw.json repair.
+    const repair = deferred();
+    const checkContinuation = vi.fn(async () => false);
+
+    armUpdateContinuation(checkContinuation, { afterConfigRepair: repair.promise, delayMs: 10 });
+    await vi.advanceTimersByTimeAsync(10);
+    expect(checkContinuation).not.toHaveBeenCalled();
+
+    repair.reject(new Error("no config"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(checkContinuation).toHaveBeenCalledTimes(1);
+  });
+
   it("says nothing when there was no update to resume", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const checkContinuation = vi.fn(async () => false);
 
-    armUpdateContinuation(checkContinuation, 10);
+    armUpdateContinuation(checkContinuation, { delayMs: 10 });
     await vi.advanceTimersByTimeAsync(10);
 
     expect(checkContinuation).toHaveBeenCalledTimes(1);
@@ -71,7 +104,7 @@ describe("armUpdateContinuation", () => {
       throw new Error("config unreadable");
     });
 
-    armUpdateContinuation(checkContinuation, 10);
+    armUpdateContinuation(checkContinuation, { delayMs: 10 });
     await vi.advanceTimersByTimeAsync(10);
 
     expect(error).toHaveBeenCalledWith(expect.stringContaining("continuation"), "config unreadable");
@@ -83,7 +116,7 @@ describe("armUpdateContinuation", () => {
       throw new Error("updater failed to load");
     });
 
-    armUpdateContinuation(checkContinuation, 10);
+    armUpdateContinuation(checkContinuation, { delayMs: 10 });
     await vi.advanceTimersByTimeAsync(10);
 
     expect(error).toHaveBeenCalledWith(expect.stringContaining("continuation"), "updater failed to load");
@@ -111,6 +144,15 @@ describe("boot arms the update continuation", () => {
     const call = source.search(BOOT_CALL);
     expect(guard).toBeGreaterThan(-1);
     expect(call).toBeGreaterThan(guard);
+  });
+
+  it("hands it the config repair it has to wait for", () => {
+    // The promise named in the call must be the one repairOpenclawConfig
+    // returned, not a fresh one: the sequencing is the whole point.
+    const repair = source.search(/const configRepaired = repairOpenclawConfig\(/);
+    const call = source.search(BOOT_CALL);
+    expect(repair).toBeGreaterThan(-1);
+    expect(call).toBeGreaterThan(repair);
   });
 
   it("does not let a failed load stop the box booting", () => {

--- a/src/tests/unit/updater-continuation-boot.test.ts
+++ b/src/tests/unit/updater-continuation-boot.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import { armUpdateContinuation } from "@/instrumentation";
+
+/**
+ * The second half of an update — the system fixups, the Hermes
+ * re-provisioning, the build-identity check — runs after the reboot, and only
+ * once something calls `checkContinuation()`. The only caller was the status
+ * route, so the update sat at "running" until somebody opened the Update page:
+ * both test boxes waited six and a half hours after booting and then bounced
+ * the gateway and the dashboard the moment a page was opened (2026-09-01). The
+ * server has to ask on its own.
+ *
+ * The arming is a plain function with the check handed in, driven here with
+ * fake timers. The wiring into `register()` is pinned by reading the boot file,
+ * as the transcript sweep does: `register()` pulls its dependencies in through
+ * `require()` to keep Node APIs out of the Edge bundle and is never called from
+ * a test. What was missing was the WIRING, so the wiring is what this pins.
+ */
+
+const BOOT_DELAY_MS = 5_000;
+// The call in register(), as distinct from the helper's own definition.
+const BOOT_CALL = /armUpdateContinuation\(checkContinuation\)/;
+
+describe("armUpdateContinuation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("asks the updater once the boot rush has passed, without any request", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const checkContinuation = vi.fn(async () => true);
+
+    armUpdateContinuation(checkContinuation);
+    expect(checkContinuation).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(BOOT_DELAY_MS - 1);
+    expect(checkContinuation).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(checkContinuation).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith("[Updater] continuation resumed at boot");
+
+    // Once. A second ask would find the flag consumed anyway, but the log line
+    // is what an owner greps for, so it must not repeat.
+    await vi.advanceTimersByTimeAsync(BOOT_DELAY_MS * 10);
+    expect(checkContinuation).toHaveBeenCalledTimes(1);
+  });
+
+  it("says nothing when there was no update to resume", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const checkContinuation = vi.fn(async () => false);
+
+    armUpdateContinuation(checkContinuation, 10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(checkContinuation).toHaveBeenCalledTimes(1);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("logs a check that rejects instead of raising it into boot", async () => {
+    // clawbox-setup.service is Restart=always: an unhandled rejection here
+    // would be a crash loop, not a missed update step.
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const checkContinuation = vi.fn(async () => {
+      throw new Error("config unreadable");
+    });
+
+    armUpdateContinuation(checkContinuation, 10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("continuation"), "config unreadable");
+  });
+
+  it("logs a check that throws synchronously the same way", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const checkContinuation = vi.fn((): Promise<boolean> => {
+      throw new Error("updater failed to load");
+    });
+
+    armUpdateContinuation(checkContinuation, 10);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("continuation"), "updater failed to load");
+  });
+
+  it("does not keep the process alive for it", () => {
+    const timer = armUpdateContinuation(async () => false);
+    expect(timer.hasRef()).toBe(false);
+    clearTimeout(timer);
+  });
+});
+
+describe("boot arms the update continuation", () => {
+  const source = fs.readFileSync(path.join(process.cwd(), "src", "instrumentation.ts"), "utf8");
+
+  it("reaches for the updater's checkContinuation", () => {
+    expect(source).toContain("lib/updater");
+    expect(source).toMatch(BOOT_CALL);
+  });
+
+  it("keeps it behind the Node-runtime guard", () => {
+    // `register` runs in both runtimes. The updater shells out and reads the
+    // disk, so it has to sit after the edge early-return.
+    const guard = source.indexOf("NEXT_RUNTIME === 'edge'");
+    const call = source.search(BOOT_CALL);
+    expect(guard).toBeGreaterThan(-1);
+    expect(call).toBeGreaterThan(guard);
+  });
+
+  it("does not let a failed load stop the box booting", () => {
+    // The require() and the arming sit inside their own try/catch, like every
+    // other boot hook: a broken updater module must cost the update its
+    // second half, not the box its web server.
+    const call = source.search(BOOT_CALL);
+    const tryStart = source.lastIndexOf("try {", call);
+    expect(tryStart).toBeGreaterThan(-1);
+    const inside = source.slice(tryStart, call);
+    expect(inside).toMatch(/require\(['"]\.\/lib\/updater['"]\)/);
+    expect(inside).not.toContain("catch");
+    const after = source.slice(call, call + 400);
+    expect(after).toMatch(/\}\s*catch\s*\(/);
+  });
+});

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -1061,6 +1061,23 @@ describe("updater", () => {
       expect(await updater.updateInFlight()).toBe(true);
     });
 
+    it("is true when an update starts while the flag is being read", async () => {
+      // Owner clicks Update in the same instant the 45 s warm asks. The
+      // ownership check before the flag read is stale by the time the read
+      // resolves; without a re-check the warm would run under the update.
+      updater.resetUpdateState();
+      const flagRead = deferred();
+      mockGet.mockImplementation(async (key: string) =>
+        key === "update_needs_continuation" ? flagRead.promise.then(() => undefined) : undefined,
+      );
+
+      const asked = updater.updateInFlight();
+      expect(updater.startUpdate()).toEqual({ started: true });
+      flagRead.resolve();
+
+      expect(await asked).toBe(true);
+    });
+
     it("is true while the post-reboot half is still waiting to be resumed", async () => {
       updater.resetUpdateState();
       mockGet.mockImplementation(async (key: string) =>

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -28,6 +28,7 @@ vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: mockRunHermesCli }));
 
 import { get, set, setMany } from "@/lib/config-store";
 import { isPortOpen } from "@/lib/port-probe";
+import { deferred } from "@/tests/helpers/deferred";
 
 const mockGet = vi.mocked(get);
 const mockSet = vi.mocked(set);
@@ -378,6 +379,52 @@ describe("updater", () => {
       expect(mockSetMany).toHaveBeenCalledWith(
         expect.objectContaining({ update_completed: true }),
       );
+    });
+
+    it("does not stop the gateway while its pre-start is still running", async () => {
+      // At boot clawbox-gateway.service and clawbox-setup.service start
+      // together, and the gateway's ExecStartPre (gateway-pre-start.sh) can
+      // spend minutes in a plugin install on a cold box. The second half of
+      // an update is resumed from boot now, and its first act is to quiesce
+      // the gateway — `systemctl stop` on a unit in `start-pre` kills that
+      // migration halfway, the very thing the pre-start budget exists to
+      // prevent. The quiesce has to let the pre-start finish first.
+      const preStart = { stdout: "start-pre\n", stderr: "" };
+      setupExecFileMock({
+        "show clawbox-gateway.service -p SubState": preStart,
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+      // The first query sees the pre-start running; every later one sees it
+      // done (the mock reads `preStart` at call time).
+      const answer = mockExecFile.getMockImplementation()!;
+      let preStartQueries = 0;
+      mockExecFile.mockImplementation(((cmd: string, args: string[], ...rest: unknown[]) => {
+        if (args.join(" ").includes("clawbox-gateway.service -p SubState") && preStartQueries++ > 0) {
+          preStart.stdout = "running\n";
+        }
+        return (answer as (...a: unknown[]) => unknown)(cmd, args, ...rest);
+      }) as unknown as typeof childProcess.execFile);
+
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue(true);
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().phase).toBe("completed");
+      });
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      const firstMask = calls.findIndex((call) => call.includes("systemctl --runtime mask clawbox-gateway.service"));
+      const preStartQueriesBeforeMask = calls
+        .slice(0, firstMask)
+        .filter((call) => call.includes("show clawbox-gateway.service -p SubState --value"));
+      expect(firstMask).toBeGreaterThan(-1);
+      // Asked, saw the pre-start running, asked again, and only then masked.
+      expect(preStartQueriesBeforeMask.length).toBeGreaterThanOrEqual(2);
     });
 
     it("fails when an overrun post_update later settles with a systemd error result", async () => {
@@ -857,6 +904,25 @@ describe("updater", () => {
       expect(mockSet).toHaveBeenCalledWith("update_needs_continuation", undefined);
     });
 
+    it("resumes once when a boot check and a status poll overlap", async () => {
+      // The boot hook and the status route can both ask within the same
+      // tick. The flag read is an await, so without a claim taken BEFORE it
+      // both callers read the flag as set and both launch the second half of
+      // the update — post_update twice, two gateway restarts.
+      updater.resetUpdateState();
+      const flagRead = deferred();
+      mockGet.mockImplementation(async (key: string) =>
+        key === "update_needs_continuation" ? flagRead.promise.then(() => true) : undefined,
+      );
+
+      const fromBoot = updater.checkContinuation();
+      const fromPoll = updater.checkContinuation();
+      flagRead.resolve();
+
+      expect(await Promise.all([fromBoot, fromPoll])).toEqual([true, false]);
+      expect(mockSet.mock.calls.filter(([key]) => key === "update_needs_continuation")).toHaveLength(1);
+    });
+
     it("reports a failed update instead of resuming when the rebuild unit failed", async () => {
       // The continuation flag only proves the rebuild unit STARTED. If the
       // server came back without the unit succeeding (georgi: a config-set
@@ -904,6 +970,31 @@ describe("updater", () => {
       const state = updater.getUpdateState();
       expect(state.phase).toBe("failed");
       expect(state.error).toContain("without producing a new build");
+    });
+  });
+
+  describe("updateInFlight", () => {
+    // What the boot hooks that touch the OpenClaw store ask before starting:
+    // an update is in flight while it runs AND while its second half is still
+    // waiting to be resumed after the reboot.
+    it("is false on a box with nothing to update", async () => {
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue(undefined);
+      expect(await updater.updateInFlight()).toBe(false);
+    });
+
+    it("is true while an update runs", async () => {
+      updater.resetUpdateState();
+      updater.startUpdate();
+      expect(await updater.updateInFlight()).toBe(true);
+    });
+
+    it("is true while the post-reboot half is still waiting to be resumed", async () => {
+      updater.resetUpdateState();
+      mockGet.mockImplementation(async (key: string) =>
+        key === "update_needs_continuation" ? "build-before-reboot" : undefined,
+      );
+      expect(await updater.updateInFlight()).toBe(true);
     });
   });
 

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -958,11 +958,13 @@ describe("updater", () => {
       expect(mockSet).toHaveBeenCalledWith("update_needs_continuation", undefined);
     });
 
-    it("resumes once when a boot check and a status poll overlap", async () => {
+    it("resumes once when a boot check and a status poll overlap, and tells both", async () => {
       // The boot hook and the status route can both ask within the same
       // tick. The flag read is an await, so without a claim taken BEFORE it
       // both callers read the flag as set and both launch the second half of
-      // the update — post_update twice, two gateway restarts.
+      // the update — post_update twice, two gateway restarts. The second
+      // caller joins the first's read: a poll that lands here must answer
+      // "running", not "idle", so it gets the same true.
       updater.resetUpdateState();
       const flagRead = deferred();
       mockGet.mockImplementation(async (key: string) =>
@@ -973,8 +975,9 @@ describe("updater", () => {
       const fromPoll = updater.checkContinuation();
       flagRead.resolve();
 
-      expect(await Promise.all([fromBoot, fromPoll])).toEqual([true, false]);
+      expect(await Promise.all([fromBoot, fromPoll])).toEqual([true, true]);
       expect(mockSet.mock.calls.filter(([key]) => key === "update_needs_continuation")).toHaveLength(1);
+      expect(mockGet.mock.calls.filter(([key]) => key === "update_needs_continuation")).toHaveLength(1);
     });
 
     it("refuses a full or scoped update while the continuation is being read", async () => {

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -431,6 +431,56 @@ describe("updater", () => {
       expect(subStateQueries.filter((index) => index < firstStop).length).toBeGreaterThanOrEqual(2);
     });
 
+    it("keeps waiting when the pre-start state cannot be read", async () => {
+      // A `systemctl show` that times out under a cold box's load says
+      // nothing about the pre-start. Treating "unanswered" as "finished"
+      // would stop the gateway mid-migration on exactly the boot this wait
+      // exists for. Ask again; stop only once the unit is seen out of
+      // `start-pre`.
+      const preStart = { stdout: "start-pre\n", stderr: "" };
+      setupExecFileMock({
+        "show clawbox-gateway.service -p SubState": preStart,
+        "clawbox-run-root-step.sh post_update": { stdout: "", stderr: "" },
+        ping: { stdout: "", stderr: "" },
+        systemctl: { stdout: "", stderr: "" },
+        openclaw: { stdout: "1.0.0", stderr: "" },
+      });
+      const answer = mockExecFile.getMockImplementation()!;
+      const answers = [new Error("systemctl timed out"), { stdout: "start-pre\n", stderr: "" }, { stdout: "running\n", stderr: "" }];
+      let query = 0;
+      mockExecFile.mockImplementation(((cmd: string, args: string[], ...rest: unknown[]) => {
+        if (args.join(" ").includes("clawbox-gateway.service -p SubState")) {
+          const next = answers[Math.min(query++, answers.length - 1)];
+          if (next instanceof Error) {
+            const callback = rest.find((arg) => typeof arg === "function") as
+              ((error: Error | null, result: { stdout: string; stderr: string }) => void) | undefined;
+            callback?.(next, { stdout: "", stderr: "" });
+            return { then: (_: unknown, reject: (err: Error) => void) => reject(next) };
+          }
+          preStart.stdout = next.stdout;
+        }
+        return (answer as (...a: unknown[]) => unknown)(cmd, args, ...rest);
+      }) as unknown as typeof childProcess.execFile);
+
+      updater.resetUpdateState();
+      mockGet.mockResolvedValue(true);
+      expect(await updater.checkContinuation()).toBe(true);
+      await vi.waitFor(() => {
+        expect(updater.getUpdateState().phase).toBe("completed");
+      });
+
+      const calls = mockExecFile.mock.calls.map(([cmd, args]) =>
+        `${cmd} ${(args as string[]).join(" ")}`,
+      );
+      const firstStop = calls.findIndex((call) => call.includes("systemctl stop clawbox-gateway.service"));
+      const subStateQueriesBeforeStop = calls
+        .slice(0, firstStop)
+        .filter((call) => call.includes("show clawbox-gateway.service -p SubState --value"));
+      expect(firstStop).toBeGreaterThan(-1);
+      // Unanswered, then start-pre, then running — and only then stopped.
+      expect(subStateQueriesBeforeStop.length).toBeGreaterThanOrEqual(3);
+    });
+
     it("fails when an overrun post_update later settles with a systemd error result", async () => {
       const timeoutErr = Object.assign(new Error("Command failed"), { killed: true });
       setupExecFileMock({

--- a/src/tests/unit/updater.test.ts
+++ b/src/tests/unit/updater.test.ts
@@ -419,12 +419,16 @@ describe("updater", () => {
         `${cmd} ${(args as string[]).join(" ")}`,
       );
       const firstMask = calls.findIndex((call) => call.includes("systemctl --runtime mask clawbox-gateway.service"));
-      const preStartQueriesBeforeMask = calls
-        .slice(0, firstMask)
-        .filter((call) => call.includes("show clawbox-gateway.service -p SubState --value"));
+      const firstStop = calls.findIndex((call) => call.includes("systemctl stop clawbox-gateway.service"));
+      const subStateQueries = calls
+        .map((call, index) => call.includes("show clawbox-gateway.service -p SubState --value") ? index : -1)
+        .filter((index) => index >= 0);
       expect(firstMask).toBeGreaterThan(-1);
-      // Asked, saw the pre-start running, asked again, and only then masked.
-      expect(preStartQueriesBeforeMask.length).toBeGreaterThanOrEqual(2);
+      expect(firstStop).toBeGreaterThan(firstMask);
+      // Masked first (nothing can enter start-pre behind the wait), then
+      // asked, saw the pre-start running, asked again, and only then stopped.
+      expect(subStateQueries[0]).toBeGreaterThan(firstMask);
+      expect(subStateQueries.filter((index) => index < firstStop).length).toBeGreaterThanOrEqual(2);
     });
 
     it("fails when an overrun post_update later settles with a systemd error result", async () => {
@@ -921,6 +925,24 @@ describe("updater", () => {
 
       expect(await Promise.all([fromBoot, fromPoll])).toEqual([true, false]);
       expect(mockSet.mock.calls.filter(([key]) => key === "update_needs_continuation")).toHaveLength(1);
+    });
+
+    it("refuses a full or scoped update while the continuation is being read", async () => {
+      // Between the claim and `running = true` the check is reading persisted
+      // state. A POST /update/run in that window used to see `running` false
+      // and launch a full update under the second half about to resume.
+      updater.resetUpdateState();
+      const flagRead = deferred();
+      mockGet.mockImplementation(async (key: string) =>
+        key === "update_needs_continuation" ? flagRead.promise.then(() => true) : undefined,
+      );
+
+      const continuation = updater.checkContinuation();
+      expect(updater.startUpdate()).toEqual({ started: false, error: "Update already in progress" });
+      expect(updater.startOpenclawUpdate()).toEqual({ started: false, error: "Update already in progress" });
+
+      flagRead.resolve();
+      expect(await continuation).toBe(true);
     });
 
     it("reports a failed update instead of resuming when the rebuild unit failed", async () => {


### PR DESCRIPTION
## Summary

Finding **F-04** (severity high, both editions).

**Customer-visible symptom.** After an update reboots the box, the second half of the update — "Applying system fixups", "Provisioning Hermes edition", "Verifying gateway health", "Verifying the new build matches the code" — does not run until somebody opens the Update page. Both test boxes sat at phase `running` for six and a half hours after booting; the moment a status request arrived, the fixups started and the gateway (OpenClaw box) or the dashboard (Hermes box) were restarted under the owner, with no warning, at whatever they were doing.

**Cause.** `checkContinuation()` in `src/lib/updater.ts` — the function that resumes the post-reboot steps from the persisted `update_needs_continuation` flag — had exactly one caller: `GET /setup-api/update/status`. Nothing on the server itself ever asked.

**Fix.** `src/instrumentation.ts` gains `armUpdateContinuation(checkContinuation, { afterConfigRepair })`, and `register()` arms it after the Node-runtime guard inside its own `try/catch`, the same shape as the other boot hooks. Five seconds after the web server starts it calls `checkContinuation()`, logs `[Updater] continuation resumed at boot` when an update was resumed, logs (never throws) on any failure — `clawbox-setup.service` is `Restart=always`, so an unhandled rejection at boot would be a crash loop — and `unref()`s the timer. The status route keeps its call as the fallback.

Resuming from boot puts the continuation next to three other boot-time actors that the status-poll trigger never met, so the second commit serializes it with them:

- **`checkContinuation()` is single-flight.** The resume is a shared in-flight promise assigned before its first `await`, so the boot hook and a status poll arriving in the same tick share one resume instead of both reading the flag as set and both launching the second half (post_update twice, two gateway restarts). The second caller gets the same answer, so a poll that lands on the boot hook's read sees "running", never one poll of "idle" with versions. `running` covers a launched run; the in-flight promise covers the reads before it.
- **Armed after `repairOpenclawConfig()` has settled.** That repair restarts the gateway when it wrote something; the resumed update's first act is to mask and stop the gateway for post_update. Started together, the restart fails against the mask or the stop lands on the gateway mid-restart. Only that the repair is over matters, not how it ended — a rejected repair still lets the continuation run.
- **`withGatewayQuiesced` masks, then waits for the gateway to leave `start-pre`, then stops.** At boot `clawbox-gateway.service` and `clawbox-setup.service` start together, and `gateway-pre-start.sh` (the unit's blocking `ExecStartPre`, `TimeoutStartSec=600`) can spend minutes in a plugin install on a cold box. `systemctl stop` on a unit in `start-pre` kills that migration halfway — the very thing the pre-start budget in `ensureGatewayHealthy` exists to prevent. The mask comes first so no new activation can slip into `start-pre` behind the wait; the wait polls `systemctl show clawbox-gateway.service -p SubState --value` (no sudo) until it is not `start-pre`, capped at the unit's own ceiling. A failed or timed-out query is asked again, never taken as "finished"; a unit that cannot be seen out of `start-pre` by the ceiling fails the step with the mask lifted and the gateway left alone. `start-pre` is the only sub-state that matters: `auto-restart` is also `activating` but nothing runs in it. This is in the shared quiesce, so every caller (post_update, openclaw_install, the recovery path) gets it.
- **`startUpdate()` and `startOpenclawUpdate()` refuse under the claim.** One `updateOwned()` (`running || continuationClaimed`) guards every entry point, so a `POST /update/run` arriving while the continuation is reading persisted state cannot launch a full update under the second half about to resume.
- **The memory-index scheduler stands down for a slot inside an update.** `openclaw memory index` is a real writer on the same store; a scheduled slot that lands while `updateInFlight()` is true is skipped with a log line and the next slot armed as usual — one missed incremental pass costs nothing, by the scheduler's own rule.
- **The 45 s memory-status warm stands down during an update.** New `updateInFlight()` in the updater (running, claimed, or the persisted flag still set); `armMemoryStatusWarm({ warm, updateInFlight })` skips the probe when it is true. The probe boots an OpenClaw process against the same v2 SQLite store that post_update masks the gateway to own alone — on every first boot after an update it would have landed inside that window ("database is locked", and post_update's non-fatal fixups silently skipped). The first Settings → Local AI open pays the probe instead, as it always did.

Docs: `e2e-install/README.md` and `90-upgrade-main-to-beta.spec.ts` described the status poll as the trigger; it is the fallback now.

No change to `production-server.js`: `register()` is proven to run in the standalone server (journal `[instrumentation] Terminal server starting` on both boxes).

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change
- [ ] Documentation / tooling
- [ ] Other: ___

## How was this tested?

Tests written first and run against the unmodified code:

**RED — boot hook** (`src/tests/unit/updater-continuation-boot.test.ts` against `origin/beta` 0f9c2380, 8/8 fail):

```
× asks the updater once the boot rush has passed, without any request
  TypeError: armUpdateContinuation is not a function
× reaches for the updater's checkContinuation
  AssertionError: expected '/**\n * Next.js instrumentation hook …' to contain 'lib/updater'
× keeps it behind the Node-runtime guard
  AssertionError: expected -1 to be greater than 2176
(+5 more, same cause)
Test Files  1 failed (1)   Tests  8 failed (8)
```

**RED — serialization** (`src/tests/unit/updater.test.ts` against the first commit):

```
× checkContinuation > resumes once when a boot check and a status poll overlap
  (two resumes: the flag read twice, cleared twice, launchUpdate twice)
× startUpdate > does not stop the gateway while its pre-start is still running
  AssertionError: expected 0 to be greater than or equal to 2
```

Both callers resumed the same update, and the gateway was masked without a single look at its pre-start. Against the second commit, for the review follow-ups:

```
× does not stop the gateway while its pre-start is still running
  AssertionError: expected 1 to be greater than 3        (SubState read before the mask)
× refuses a full or scoped update while the continuation is being read
  AssertionError: expected { started: true } to deeply equal { started: false, … }
× keeps waiting when the pre-start state cannot be read
  AssertionError: expected 1 to be greater than or equal to 3   (stopped on the unanswered query)
```

**GREEN** — the new files plus the neighbouring suites (`updater`, `updater-build-identity`, `updater-branch-resolution`, `instrumentation-config-repairs`, `instrumentation-transcript-sweep`, `instrumentation-memory-warm`, `updater-continuation-boot`), rebased on `origin/beta` 5d7d1559:

```
Test Files  7 passed (7)   Tests  113 passed (113)
```

Full `bun run test:unit` on the final tree: `Test Files 503 passed (503)  Tests 7900 passed (7900)`. `bunx tsc --noEmit` clean; `eslint` clean on the changed files (one pre-existing warning in `updater.ts` untouched).

- [x] `bun run lint` passes (changed files)
- [x] `bun run test` passes (see above)
- [ ] `bun run build` succeeds (CI)
- [ ] Manually verified on device / dev install — CI-only proof; the boxes were in use by the owner this morning

Sibling call sites checked: `src/app/setup-api/update/status/route.ts:39` (kept, fallback; now provably cannot double-resume); `production-server.js` (no hook needed, see above); the legacy boolean `update_needs_continuation` flag handling unchanged; `withGatewayQuiesced`'s three callers all get the pre-start wait.

## Checklist

- [x] Branch is up to date with the target branch
- [x] Follows the conventions in [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] No secrets, tokens, or credentials committed
- [x] Added/updated tests where it makes sense
- [x] Updated docs where user-facing behavior changed — e2e-install README and spec comments

## Screenshots / logs (if UI or runtime change)

On the next update, the journal of `clawbox-setup.service` should show `[Updater] continuation resumed at boot` followed by `[Updater] Running step: Applying system fixups` within seconds of `[instrumentation] Terminal server starting`, with no status request in between. On a cold box it may first show `[Updater] waiting for clawbox-gateway to finish its pre-start before stopping it`.
