### PR TITLE
fix: load node:sqlite through process.getBuiltinModule so the standalone build can open the session store (F-05)

### DIFF
--- a/.github/workflows/build-identity.yml
+++ b/.github/workflows/build-identity.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Build
         run: bun run build
 
+      # A builtin loaded in a shape Turbopack cannot externalise (F-05:
+      # `createRequire(import.meta.url)("node:sqlite")`) builds fine and passes
+      # vitest, and only the built chunk shows the throwing stub it became. The
+      # chunks are here, so they are read here — and nowhere the customer's
+      # updater runs (see the script header).
+      - name: Assert no Node builtin was compiled into a throwing stub
+        run: bash scripts/check-bundled-builtins.sh
+
       # actions/checkout leaves HEAD at the exact commit under test (the merge
       # commit for a PR), which is what the built artefact must name. Passing
       # it explicitly rather than letting the script read HEAD keeps the

--- a/scripts/check-bundled-builtins.sh
+++ b/scripts/check-bundled-builtins.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Assert that no server chunk of the production build carries a Turbopack
+# "external" stub where a Node builtin should be.
+#
+# Why this exists: src/lib/openclaw-session-store.ts loaded node:sqlite through
+# `createRequire(import.meta.url)`. Turbopack cannot externalise that shape and
+# compiled the call into a stub that THROWS at runtime —
+#   Cannot find module 'node:sqlite': Unsupported external type Url for commonjs reference
+# — while `bun run build` succeeded and vitest (which does not bundle) stayed
+# green. On the box every reader of the SQLite session store then failed its
+# open() and silently fell back to legacy files OpenClaw 2 no longer writes.
+# Only the built chunks can show this, so the built chunks are what is checked.
+#
+# Callers: CI (.github/workflows/build-identity.yml) right after `bun run build`.
+# It is deliberately NOT part of postbuild or of verify-build-identity.sh — both
+# run inside the customer's updater, and a failed check there would take the
+# site down over a bug that this script exists to catch in CI first.
+#
+# Usage:
+#   scripts/check-bundled-builtins.sh [--project-dir DIR]
+#
+# Exit codes: 0 = clean, 1 = a stub was found, 2 = nothing to check / usage.
+set -uo pipefail
+
+PROJECT_DIR=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project-dir)
+      [ -n "${2:-}" ] || { echo "check-bundled-builtins: $1 needs a value" >&2; exit 2; }
+      PROJECT_DIR="$2"; shift 2 ;;
+    -h|--help) sed -n '2,22p' "$0"; exit 0 ;;
+    *) echo "check-bundled-builtins: unknown argument '$1'" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "$PROJECT_DIR" ]; then
+  PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+fi
+
+# Both trees when both exist: `.next/server/chunks` is what the build produced,
+# `.next/standalone/.next/server/chunks` is what the service actually runs from.
+CHUNK_DIRS=(
+  "$PROJECT_DIR/.next/server/chunks"
+  "$PROJECT_DIR/.next/standalone/.next/server/chunks"
+)
+
+# The stub's message, in two halves so the check is class-wide: the second
+# half names the builtin family, the first is what Turbopack says about ANY
+# external it could not resolve, whatever the module is called next time.
+CHECKED=0
+FOUND=0
+for dir in "${CHUNK_DIRS[@]}"; do
+  [ -d "$dir" ] || continue
+  CHECKED=$((CHECKED + 1))
+  HITS="$(grep -rlF --include='*.js' \
+    -e "Unsupported external type" \
+    -e "Cannot find module 'node:" \
+    -- "$dir" 2>/dev/null || true)"
+  if [ -n "$HITS" ]; then
+    FOUND=1
+    echo "BUNDLED BUILTINS: FAIL — a Turbopack external stub is compiled into:" >&2
+    printf '%s\n' "$HITS" | sed "s|^$PROJECT_DIR/|  |" >&2
+  fi
+  # Positive control: the session store's loader must have reached the chunks
+  # as the call it is in the source. Without this, a Next release that rewords
+  # the stub would make the negative grep above print OK over the same bug.
+  LOADER="$(grep -rlF --include='*.js' -- "getBuiltinModule" "$dir" 2>/dev/null \
+    | xargs -r grep -lF -- "node:sqlite" 2>/dev/null || true)"
+  if [ -z "$LOADER" ]; then
+    FOUND=1
+    echo "BUNDLED BUILTINS: FAIL — no chunk under ${dir#"$PROJECT_DIR/"} carries the session store's" >&2
+    echo "  process.getBuiltinModule(\"node:sqlite\") loader; it was rewritten or dropped by the bundler." >&2
+  fi
+done
+
+if [ "$CHECKED" -eq 0 ]; then
+  echo "BUNDLED BUILTINS: no server chunks under $PROJECT_DIR/.next — run 'bun run build' first" >&2
+  exit 2
+fi
+
+if [ "$FOUND" -ne 0 ]; then
+  echo "BUNDLED BUILTINS: FAIL — see above. Load a Node builtin with process.getBuiltinModule()" >&2
+  echo "  (see src/lib/openclaw-session-store.ts), never createRequire(): Turbopack turns that into a throwing stub." >&2
+  exit 1
+fi
+
+echo "BUNDLED BUILTINS: OK — no Turbopack external stubs in $CHECKED chunk tree(s)"

--- a/scripts/check-bundled-builtins.sh
+++ b/scripts/check-bundled-builtins.sh
@@ -65,8 +65,10 @@ for dir in "${CHUNK_DIRS[@]}"; do
   # Positive control: the session store's loader must have reached the chunks
   # as the call it is in the source. Without this, a Next release that rewords
   # the stub would make the negative grep above print OK over the same bug.
-  LOADER="$(grep -rlF --include='*.js' -- "getBuiltinModule" "$dir" 2>/dev/null \
-    | xargs -r grep -lF -- "node:sqlite" 2>/dev/null || true)"
+  # Null-delimited end to end, so a project directory with a space in its
+  # path cannot split a chunk name and turn a clean build into a FAIL.
+  LOADER="$(grep -rlFZ --include='*.js' -- "getBuiltinModule" "$dir" 2>/dev/null \
+    | xargs -0 -r grep -lF -- "node:sqlite" 2>/dev/null || true)"
   if [ -z "$LOADER" ]; then
     FOUND=1
     echo "BUNDLED BUILTINS: FAIL — no chunk under ${dir#"$PROJECT_DIR/"} carries the session store's" >&2

--- a/src/lib/openclaw-session-store.ts
+++ b/src/lib/openclaw-session-store.ts
@@ -26,19 +26,42 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { createRequire } from "node:module";
 import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
 
-// node:sqlite is loaded lazily through require, NOT imported statically:
-// vite's client test environment cannot bundle it (the builtin is newer than
-// its externals list), and a static import here crashed every jsdom suite
-// whose import graph merely REACHES this file through openclaw-config. The
-// functions below only ever run on the server, where the require succeeds.
-const requireNodeSqlite = (() => {
-  let mod: { DatabaseSync: typeof DatabaseSyncType } | null = null;
-  const req = createRequire(import.meta.url);
-  return () => {
-    if (!mod) mod = req("node:sqlite") as { DatabaseSync: typeof DatabaseSyncType };
+type NodeSqlite = { DatabaseSync: typeof DatabaseSyncType };
+
+/**
+ * node:sqlite, resolved lazily at CALL time through `process.getBuiltinModule`
+ * — not imported statically, and not through `createRequire`:
+ *   - a static import crashed every jsdom suite whose import graph merely
+ *     REACHES this file through openclaw-config (vite cannot bundle the
+ *     builtin; it is newer than its externals list);
+ *   - `createRequire(import.meta.url)("node:sqlite")` passed every vitest suite
+ *     (vitest does not bundle) and was compiled by Turbopack into a stub that
+ *     throws "Cannot find module 'node:sqlite': Unsupported external type Url
+ *     for commonjs reference" — so on the box, where the builtin exists, every
+ *     reader here failed its open() and silently fell back to legacy files
+ *     OpenClaw 2 no longer writes. scripts/check-bundled-builtins.sh reads the
+ *     built chunks in CI so that shape cannot come back.
+ * `getBuiltinModule` is a plain runtime call the bundler leaves alone. It
+ * arrived in Node 22.3 and node:sqlite in 22.5 (behind --experimental-sqlite
+ * until 22.13), so a runtime missing the one is missing the other too — that
+ * case throws here, with the version in the message, and every caller already
+ * treats a failed open() as "not migrated".
+ * Exported so the next reader of an OpenClaw .sqlite file shares this loader
+ * instead of growing a third shape.
+ */
+export const requireNodeSqlite = (() => {
+  let mod: NodeSqlite | null = null;
+  return (): NodeSqlite => {
+    if (mod) return mod;
+    const loaded = process.getBuiltinModule?.("node:sqlite") as NodeSqlite | undefined;
+    if (typeof loaded?.DatabaseSync !== "function") {
+      throw new Error(
+        `node:sqlite is not available on Node ${process.versions.node} (it needs Node >= 22.13, or 22.5+ with --experimental-sqlite)`,
+      );
+    }
+    mod = loaded;
     return mod;
   };
 })();

--- a/src/tests/unit/openclaw-session-store-loader.test.ts
+++ b/src/tests/unit/openclaw-session-store-loader.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "fs";
+import os from "os";
+import path from "path";
+import { requireNodeSqlite } from "@/lib/openclaw-session-store";
+
+/**
+ * That node:sqlite reaches the STANDALONE BUILD, not only this test runner.
+ *
+ * The session store loaded the builtin through `createRequire(import.meta.url)`.
+ * Every vitest suite passed — vitest does not bundle — while Turbopack, which
+ * cannot externalise that shape, compiled the call into a stub that throws
+ * "Cannot find module 'node:sqlite': Unsupported external type Url for
+ * commonjs reference". On the box, where the builtin exists, every reader of
+ * the SQLite store then failed its open() and silently fell back to legacy
+ * files OpenClaw 2 no longer writes (F-05): spoken-history recovery, the
+ * model-override sweep and Local-only mode were all dead, and 70 journal lines
+ * said so to nobody.
+ *
+ * The real assertion is on the built chunks — scripts/check-bundled-builtins.sh,
+ * run by CI right after `bun run build`. What is pinned HERE is the shape of
+ * the loader and the wiring of that check, the way instrumentation-transcript-
+ * sweep.test.ts pins its boot wiring: a behavioural test cannot see what the
+ * bundler does to the source.
+ */
+
+const ROOT = process.cwd();
+const STORE_FILE = path.join(ROOT, "src", "lib", "openclaw-session-store.ts");
+
+/**
+ * The code without its comment LINES — the loader's own JSDoc names the trap.
+ * Line-based on purpose: a regex that strips block comments would also swallow
+ * everything between a `"image/*"` string literal and the next `*\/`, and a
+ * `createRequire(` in that span would go unseen.
+ */
+function codeLines(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => !/^\s*(\/\/|\/\*|\*)/.test(line))
+    .join("\n");
+}
+
+const storeCode = codeLines(readFileSync(STORE_FILE, "utf8"));
+
+const tmpRoots: string[] = [];
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+/** Every .ts/.tsx under src/ that Next may bundle — the tests are not it. */
+function bundledSources(): string[] {
+  const srcDir = path.join(ROOT, "src");
+  // `encoding` picks the string[] overload; without it @types/node 20 types the
+  // result as string[] | Buffer[] and the build's type check fails.
+  return readdirSync(srcDir, { recursive: true, encoding: "utf8" })
+    .filter((rel) => /\.tsx?$/.test(rel) && !rel.endsWith(".d.ts") && !rel.startsWith(`tests${path.sep}`))
+    .map((rel) => path.join(srcDir, rel));
+}
+
+describe("the node:sqlite loader survives the Turbopack build", () => {
+  it("resolves the builtin through process.getBuiltinModule, which the bundler leaves alone", () => {
+    expect(storeCode).toMatch(/getBuiltinModule(\?\.)?\(\s*["']node:sqlite["']\s*\)/);
+  });
+
+  it("never reaches it through createRequire, which the bundler turns into a throwing stub", () => {
+    expect(storeCode).not.toMatch(/createRequire/);
+  });
+
+  it("hands back a DatabaseSync that opens a store", () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "clawbox-sqlite-loader-"));
+    tmpRoots.push(root);
+    const { DatabaseSync } = requireNodeSqlite();
+    const db = new DatabaseSync(path.join(root, "probe.sqlite"));
+    db.exec("CREATE TABLE t (v TEXT)");
+    db.prepare("INSERT INTO t (v) VALUES (?)").run("ok");
+    expect(db.prepare("SELECT v FROM t").get()).toEqual({ v: "ok" });
+    db.close();
+  });
+
+  it("is the same module object on every call", () => {
+    expect(requireNodeSqlite()).toBe(requireNodeSqlite());
+  });
+});
+
+describe("no bundled module loads anything through createRequire", () => {
+  // Class-wide: the next builtin someone reaches for the same way would build
+  // just as cleanly and die just as quietly. The test fixtures may use
+  // createRequire freely — vitest never bundles them.
+  it("src/ outside the tests is free of createRequire", () => {
+    const offenders = bundledSources()
+      .filter((file) => /createRequire\s*\(/.test(codeLines(readFileSync(file, "utf8"))))
+      .map((file) => path.relative(ROOT, file));
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe("CI reads the built chunks", () => {
+  const workflow = readFileSync(path.join(ROOT, ".github", "workflows", "build-identity.yml"), "utf8");
+  const script = readFileSync(path.join(ROOT, "scripts", "check-bundled-builtins.sh"), "utf8");
+
+  it("runs the bundled-builtins check right after the build", () => {
+    const build = workflow.indexOf("run: bun run build");
+    const check = workflow.indexOf("scripts/check-bundled-builtins.sh");
+    expect(build).toBeGreaterThan(-1);
+    expect(check).toBeGreaterThan(build);
+  });
+
+  it("looks for the stub's message, not for one module's name", () => {
+    expect(script).toContain("Unsupported external type");
+    expect(script).toContain("Cannot find module 'node:");
+  });
+
+  it("also asserts the loader itself reached the chunks, so a reworded stub cannot pass as clean", () => {
+    expect(script).toContain("getBuiltinModule");
+  });
+});

--- a/src/tests/unit/openclaw-session-store.test.ts
+++ b/src/tests/unit/openclaw-session-store.test.ts
@@ -7,8 +7,10 @@ import path from "path";
 import { sweepSessionEntries } from "@/lib/openclaw-session-store";
 import { applyModelOverrideToAllAgentSessions } from "@/lib/openclaw-config";
 
-// The store lib reaches node:sqlite the same lazy way (vite cannot bundle the
-// builtin); the fixtures here do too.
+// vite cannot bundle the builtin, so the fixtures reach node:sqlite lazily
+// too. createRequire is fine HERE — vitest never bundles a test file — and
+// wrong in the lib, where Turbopack compiles it into a throwing stub (see
+// openclaw-session-store-loader.test.ts).
 const requireNodeSqlite = createRequire(import.meta.url);
 const { DatabaseSync } = requireNodeSqlite("node:sqlite");
 


### PR DESCRIPTION
## F-05 — `node:sqlite` is compiled into a throwing stub in the standalone build

### Customer-visible symptom (OpenClaw edition)
On a box running the published beta (`dd51eb57`, Node v22.23.2) the journal has 70 lines since boot of

```
Cannot find module 'node:sqlite': Unsupported external type Url for commonjs reference
```

so every reader of the OpenClaw 2 SQLite session store fails its `open()` and silently falls back to legacy files that OpenClaw 2 no longer writes. Spoken-history recovery, the model-override sweep (`applyModelOverrideToAllAgentSessions`) and Local-only mode's restore path are all dead on the device, while `node -e 'require("node:sqlite")'` works fine there.

### Cause
`src/lib/openclaw-session-store.ts` loaded the builtin through `createRequire(import.meta.url)("node:sqlite")`. Every vitest suite passed — vitest does not bundle — while Turbopack (Next 16) cannot externalise that shape and compiles the call into a stub that throws the message above. `bun run build` succeeds, so nothing in the pipeline could see it: only the built chunks show the stub. (A bare `require("node:sqlite")` compiles to the identical stub, so it is not a usable fallback.)

### Fix
- `src/lib/openclaw-session-store.ts`: the lazy loader now resolves through `process.getBuiltinModule("node:sqlite")`, a plain runtime call the bundler leaves alone (Node ≥ 22.3; `node:sqlite` itself is 22.5+, unflagged from 22.13 — a runtime lacking it gets a clear error naming the version, and every caller already treats a failed open as "not migrated"). Same lazy shape and `import type`, so the jsdom suites whose import graph reaches this file keep importing cleanly. The loader is exported (`requireNodeSqlite`) so the next reader of an OpenClaw `.sqlite` file shares it instead of growing a third loading shape.
- `scripts/check-bundled-builtins.sh` + a step in `.github/workflows/build-identity.yml` right after `bun run build`: reads `.next/server/chunks` and `.next/standalone/.next/server/chunks` and fails on Turbopack's external-stub message (class-wide, so the next builtin fails loudly too) and — as a positive control against a reworded stub — on the session store's `getBuiltinModule` loader missing from the chunks. Deliberately not in `postbuild` or `verify-build-identity.sh`, which run inside the customer's updater.
- `src/tests/unit/openclaw-session-store-loader.test.ts`: pins the loader shape, that no bundled source under `src/` uses `createRequire`, that the loader hands back a working `DatabaseSync`, and that CI wires the chunk check after the build.

### RED → GREEN
RED — unmodified beta head `5d7d1559`, `bun run build` then the check:
```
BUNDLED BUILTINS: FAIL — a Turbopack external stub is compiled into:
  .next/server/chunks/src_lib_0jfvchk._.js
  .next/server/chunks/src_lib_0uklej9._.js
  .next/server/chunks/src_lib_15zr2ga._.js
  .next/server/chunks/src_lib_1za7e1l._.js
BUNDLED BUILTINS: FAIL — a Turbopack external stub is compiled into:
  .next/standalone/.next/server/chunks/src_lib_0jfvchk._.js
  .next/standalone/.next/server/chunks/src_lib_0uklej9._.js
  .next/standalone/.next/server/chunks/src_lib_15zr2ga._.js
  .next/standalone/.next/server/chunks/src_lib_1za7e1l._.js
exit 1
```
(the same four chunks the device's own `.next` carries). The new vitest file against the unmodified loader: 5 of 7 tests fail.

GREEN — this branch, `bun run build` then the check:
```
BUNDLED BUILTINS: OK — no Turbopack external stubs in 2 chunk tree(s)
exit 0
```
The compiled chunk now carries `process.getBuiltinModule?.("node:sqlite")` verbatim. `bunx tsc --noEmit` clean; loader test 7/7; the 23 neighbouring suites (session store, spoken history, model-override sweep, local-ai panel, ai-models/configure*, chat-model*, hermes-honest-settings) 355/355.

### Sibling sites
- `grep createRequire src` outside `src/tests`: the session store was the only one; the fixtures in `src/tests/unit/openclaw-session-store.test.ts` keep it (never bundled) with a comment saying why.
- `src/lib/harness/hermes-turn-record.ts` reads `node:sqlite` through a variable-specifier `await import` that Turbopack compiles healthily — left untouched.
- The three silent consumers (`chat-spoken-history.ts`, `openclaw-config.ts` sweep, `local-ai/exclusive`) already log every failed open and answer `restoreIncomplete` + `warning`; they are not changed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SQLite loading reliability in supported Node.js environments.
  - Added clearer errors when required SQLite functionality is unavailable.
  - Ensured the SQLite module is loaded consistently and reused safely.

- **Tests**
  - Expanded coverage for SQLite database functionality and module loading.
  - Added build validation to detect bundling issues that could prevent SQLite features from working correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->