### PR TITLE
fix(telegram): read the OpenClaw 2 pairing store from state/openclaw.sqlite (F-06)

### DIFF
--- a/src/app/setup-api/telegram/configure/route.ts
+++ b/src/app/setup-api/telegram/configure/route.ts
@@ -39,13 +39,10 @@ export async function POST(request: Request) {
     // A different bot means a fresh allowlist — previously-approved senders
     // belong to the old bot. Detect a real token change (re-saving the same
     // token keeps approvals) so we can reset the harness's allowlist/pending
-    // stores and our name map below.
+    // stores and our name map.
     const previousToken = await get("telegram_bot_token");
     const tokenChanged =
       typeof previousToken === "string" && previousToken.length > 0 && previousToken !== botToken;
-
-    // Save to ClawBox config
-    await set("telegram_bot_token", botToken);
 
     // Hand the token to whichever harness this device actually runs. A Hermes
     // device has no OpenClaw gateway at all (the unit is masked, the port is
@@ -53,13 +50,34 @@ export async function POST(request: Request) {
     // the bot never answered.
     const harness = await getActiveHarness();
 
+    // The reset runs BEFORE the new token is persisted, on purpose. A reset
+    // that fails then fails the save with nothing changed: the old bot keeps
+    // its old approvals, and the next attempt still sees a token change and
+    // retries the reset. Run after the save, a failed reset left the new bot
+    // answering senders approved for the old one — and the retry, seeing the
+    // same token, never reset again.
+    if (tokenChanged) {
+      try {
+        if (harness === "hermes") await clearHermesTelegramPairingState();
+        else await clearTelegramPairingState();
+      } catch (resetErr) {
+        console.error("[telegram/configure] Pairing reset failed; the token was not saved:", resetErr);
+        return NextResponse.json(
+          {
+            error:
+              "The previous Telegram approvals could not be cleared, so the new bot token was not saved. See the ClawBox service log.",
+          },
+          { status: 500 }
+        );
+      }
+      await set("telegram_approved_names", undefined);
+    }
+
+    // Save to ClawBox config
+    await set("telegram_bot_token", botToken);
+
     if (harness === "hermes") {
       await setHermesTelegramToken(botToken, request.signal);
-
-      if (tokenChanged) {
-        await clearHermesTelegramPairingState();
-        await set("telegram_approved_names", undefined);
-      }
 
       // Hermes' messaging gateway is the process that RECEIVES messages, so it
       // has to be installed and up. As with the OpenClaw restart below, the
@@ -93,11 +111,6 @@ export async function POST(request: Request) {
 
     // Register Telegram channel with OpenClaw gateway
     await setTelegramToken(botToken);
-
-    if (tokenChanged) {
-      await clearTelegramPairingState();
-      await set("telegram_approved_names", undefined);
-    }
 
     // Restart gateway so it picks up the new channel (and the reset allowlist).
     // The token is already persisted at this point, so a restart failure must

--- a/src/app/setup-api/telegram/pairing/route.ts
+++ b/src/app/setup-api/telegram/pairing/route.ts
@@ -61,10 +61,11 @@ async function buildApproved(
   return ids.map((id) => ({ id, name: nameMap[id] }));
 }
 
-// GET — list approved senders (fast: a single file read). With `?pending=1` it
-// also runs the harness's `pairing list` CLI, which on OpenClaw is a ~10-12 s
-// cold start on a Jetson, so pending stays opt-in rather than being fetched on
-// every status refresh.
+// GET — list approved senders (fast: one read of OpenClaw's state store, or
+// of the legacy allowFrom file on a v1 box). With `?pending=1` it also runs
+// the harness's `pairing list` CLI, which on OpenClaw is a ~10-12 s cold start
+// on a Jetson, so pending stays opt-in rather than being fetched on every
+// status refresh.
 export async function GET(request: Request) {
   try {
     if (!(await isConfigured())) {
@@ -76,7 +77,8 @@ export async function GET(request: Request) {
     const harness = await getActiveHarness();
     const params = new URL(request.url).searchParams;
     const approved = await buildApproved(harness);
-    // `?poll=1` reads the pairing-store file (fast — safe for the desktop poller);
+    // `?poll=1` reads the pairing store directly — the state database, or the
+    // legacy file on a v1 box (fast — safe for the desktop poller);
     // `?pending=1` uses the authoritative CLI (the Settings "Check" button).
     const wantsPoll = params.get("poll") === "1";
     const wantsPending = params.get("pending") === "1";

--- a/src/lib/hermes-telegram.ts
+++ b/src/lib/hermes-telegram.ts
@@ -286,8 +286,9 @@ const MAX_RESET_REVOKES = 25;
  * Wipe Telegram pairing state, for when the bot token changes: approvals belong
  * to the old bot. Revokes each approved sender (so Hermes also drops it from any
  * TELEGRAM_ALLOWED_USERS mirror it maintains), clears pending codes, then removes
- * any store file left behind. Best-effort throughout — the token is already saved
- * by the time this runs, so a failure must not fail the save.
+ * any store file left behind. Best-effort throughout: each step is a separate
+ * `hermes` process that may be missing or refuse, and the store-file removal
+ * at the end is the backstop.
  *
  * Note `hermes pairing clear-pending` takes no platform argument and clears every
  * platform's pending codes. On ClawBox Telegram is the only one configured.

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
 import { listAgentIds, sessionStorePath, sweepSessionEntries } from "./openclaw-session-store";
+import { clearPairingState, readPairingAllowEntries, readPairingRequests } from "./openclaw-state-store";
 import fsSync from "fs";
 import path from "path";
 import { execFile, spawn } from "child_process";
@@ -1813,11 +1814,15 @@ export async function setDiscordToken(botToken: string): Promise<void> {
 // === Telegram pairing (DM sender approval) ===
 //
 // OpenClaw's default `dmPolicy: "pairing"` makes an unknown Telegram sender's
-// first message inert until the owner approves their 8-char code. OpenClaw
-// persists approvals in `~/.openclaw/credentials/telegram-<account>-allowFrom.json`
-// (a string array of user ids) — a *different* file from `openclaw.json`, so the
-// boot-time `channels.telegram.allowFrom` strip in gateway-pre-start.sh never
-// touches them. We only ever approve specific senders; we never widen dmPolicy.
+// first message inert until the owner approves their 8-char code. OpenClaw 2
+// persists approvals and pending codes in `~/.openclaw/state/openclaw.sqlite`
+// (see openclaw-state-store.ts); OpenClaw 1 kept them in
+// `~/.openclaw/credentials/telegram-<account>-allowFrom.json` (a string array
+// of user ids) + `telegram-pairing.json`, which the readers below still serve
+// on a box that has not migrated. Either way it is a *different* store from
+// `openclaw.json`, so the boot-time `channels.telegram.allowFrom` strip in
+// gateway-pre-start.sh never touches them. We only ever approve specific
+// senders; we never widen dmPolicy.
 
 const CREDENTIALS_DIR = path.join(OPENCLAW_HOME, "credentials");
 export const PAIRING_CODE_RE = /^[A-Z0-9]{8}$/;
@@ -1866,11 +1871,14 @@ export async function listTelegramPairingRequests(): Promise<TelegramPairingRequ
 
 /**
  * Pending Telegram DM pairing requests read straight from OpenClaw's pairing
- * store file — a plain read with no CLI cold-start, so it's cheap enough to poll
- * for the desktop "new request" popup. The store path mirrors the allowFrom
- * store; the default account is unsuffixed (`telegram-pairing.json`).
+ * store — a plain read with no CLI cold-start, so it's cheap enough to poll
+ * for the desktop "new request" popup. OpenClaw 2 answers from the state
+ * database; the legacy file path mirrors the allowFrom store, with the default
+ * account unsuffixed (`telegram-pairing.json`).
  */
 export async function readTelegramPairingRequests(account = "default"): Promise<TelegramPairingRequest[]> {
+  const fromStore = readPairingRequests("telegram", account);
+  if (fromStore) return withDerivedNames(fromStore);
   const file = path.join(
     CREDENTIALS_DIR,
     account === "default" ? "telegram-pairing.json" : `telegram-${account}-pairing.json`,
@@ -1900,9 +1908,14 @@ export async function approveTelegramPairing(code: string): Promise<void> {
 /**
  * Approved Telegram sender ids, read from the allowFrom store (empty on any
  * failure). `account` is OpenClaw's channel account id; ClawBox is single-account
- * so it defaults to "default" (file `telegram-default-allowFrom.json`).
+ * so it defaults to "default". The v2 state database wins whenever it exists:
+ * it is what the gateway enforces, and a migrated box's leftover JSON is a
+ * stale copy that must not shadow it. Without one, the legacy file
+ * (`telegram-default-allowFrom.json`) is the store.
  */
 export async function readTelegramAllowFrom(account = "default"): Promise<string[]> {
+  const fromStore = readPairingAllowEntries("telegram", account);
+  if (fromStore) return fromStore;
   const file = path.join(CREDENTIALS_DIR, `telegram-${account}-allowFrom.json`);
   try {
     const parsed = JSON.parse(await fs.readFile(file, "utf-8")) as { allowFrom?: unknown };
@@ -1916,9 +1929,14 @@ export async function readTelegramAllowFrom(account = "default"): Promise<string
 /**
  * Wipe the per-account Telegram allowlist + pending stores. Used when the bot
  * token changes: previously-approved senders belong to the old bot, so a new
- * bot should start with a fresh allowlist. Best-effort — missing files are fine.
+ * bot should start with a fresh allowlist. Clears the v2 state database rows
+ * when the store exists, and always the legacy files, so no copy survives for
+ * a later migration to carry back in. Best-effort — a missing store or file
+ * is fine; the caller restarts the gateway right after, so nothing cached
+ * outlives the wipe.
  */
 export async function clearTelegramPairingState(account = "default"): Promise<void> {
+  clearPairingState("telegram", account);
   const files = [
     path.join(CREDENTIALS_DIR, `telegram-${account}-allowFrom.json`),
     path.join(CREDENTIALS_DIR, account === "default" ? "telegram-pairing.json" : `telegram-${account}-pairing.json`),

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1930,13 +1930,19 @@ export async function readTelegramAllowFrom(account = "default"): Promise<string
  * Wipe the per-account Telegram allowlist + pending stores. Used when the bot
  * token changes: previously-approved senders belong to the old bot, so a new
  * bot should start with a fresh allowlist. Clears the v2 state database rows
- * when the store exists, and always the legacy files, so no copy survives for
- * a later migration to carry back in. Best-effort — a missing store or file
- * is fine; the caller restarts the gateway right after, so nothing cached
- * outlives the wipe.
+ * when the store exists, then the legacy files, so no copy survives for a
+ * later migration to carry back in. A missing store or file is fine. A store
+ * that exists but could not be cleared is not: its approvals are still what
+ * the gateway enforces, so this throws — before the legacy files are touched,
+ * leaving the state exactly as it was — and the caller must not report a
+ * reset that did not happen.
  */
 export async function clearTelegramPairingState(account = "default"): Promise<void> {
-  clearPairingState("telegram", account);
+  if (!clearPairingState("telegram", account)) {
+    throw new Error(
+      "Could not clear the previous Telegram approvals from OpenClaw's state store; they are still in force",
+    );
+  }
   const files = [
     path.join(CREDENTIALS_DIR, `telegram-${account}-allowFrom.json`),
     path.join(CREDENTIALS_DIR, account === "default" ? "telegram-pairing.json" : `telegram-${account}-pairing.json`),

--- a/src/lib/openclaw-session-store.ts
+++ b/src/lib/openclaw-session-store.ts
@@ -81,7 +81,12 @@ export function sessionStorePath(agentId: string, agentsDir: string = AGENTS_DIR
   }
 }
 
-function open(dbPath: string, readOnly: boolean): DatabaseSyncType {
+/**
+ * Open one of OpenClaw's SQLite stores with the busy timeout every reader and
+ * writer here relies on. Shared with openclaw-state-store.ts, which serves the
+ * gateway-wide `state/openclaw.sqlite` the same way.
+ */
+export function openSqlite(dbPath: string, readOnly: boolean): DatabaseSyncType {
   const { DatabaseSync } = requireNodeSqlite();
   const db = new DatabaseSync(dbPath, { readOnly });
   try {
@@ -111,7 +116,7 @@ export function readTranscriptRaw(
   // 500 from a chat-history read.
   let db: DatabaseSyncType;
   try {
-    db = open(dbPath, true);
+    db = openSqlite(dbPath, true);
   } catch (err) {
     console.warn(`[session-store] could not open ${dbPath}:`, err);
     return null;
@@ -201,7 +206,7 @@ export function sweepSessionEntries(
   if (!dbPath) return null;
   let db: DatabaseSyncType;
   try {
-    db = open(dbPath, false);
+    db = openSqlite(dbPath, false);
   } catch (err) {
     console.error(`[session-store] could not open ${dbPath} for sweep:`, err);
     return { updated: 0, ok: false };

--- a/src/lib/openclaw-state-store.ts
+++ b/src/lib/openclaw-state-store.ts
@@ -1,0 +1,162 @@
+/**
+ * OpenClaw 2's gateway-wide state database, as ClawBox needs to see it.
+ *
+ * 2026.8 moved the channel pairing store out of
+ * `credentials/<channel>-<account>-allowFrom.json` + `<channel>-pairing.json`
+ * and into `state/openclaw.sqlite`, shared by every channel:
+ *   - `channel_pairing_allow_entries` — one row per approved sender,
+ *     `(channel_key, account_id, entry)`, ordered by `sort_order`.
+ *   - `channel_pairing_requests`      — one row per pending pairing code, with
+ *     the sender's Telegram name in `meta_json`.
+ * The gateway reads ONLY this database once it exists; the legacy JSON files
+ * are a one-shot migration source. So every reader here answers from the
+ * database whenever the file is present and hands back null only when it is
+ * not (a v1 box, a Hermes-only box) — the callers keep their legacy-file path
+ * for that case. A store that exists but cannot be opened or read also yields
+ * null: the caller's fallback then finds nothing (the migration emptied the
+ * legacy files), which is the same answer the gateway would give.
+ *
+ * The database is never created here: an absent file means an OpenClaw that
+ * has not migrated yet, and creating an empty store would make the doctor
+ * skip the migration that carries the approvals over.
+ *
+ * OpenClaw resolves the state dir from `OPENCLAW_STATE_DIR`, falling back to
+ * its home; the path here follows the same rule so this reads the store the
+ * gateway actually writes.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
+import { OPENCLAW_HOME_DEFAULT, openSqlite } from "./openclaw-session-store";
+
+/** The gateway-wide SQLite store, or null when this OpenClaw has not migrated to it. */
+export function statePath(home: string = OPENCLAW_HOME_DEFAULT): string | null {
+  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || home;
+  const p = path.join(stateDir, "state", "openclaw.sqlite");
+  try {
+    return fs.statSync(p).isFile() ? p : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run `fn` against the state store; null when there is no store, or when it
+ * cannot be opened or queried (logged — a corrupt or locked store must fall
+ * through to the caller's fallback, never escape as a 500).
+ */
+function withStateDb<T>(readOnly: boolean, what: string, fn: (db: DatabaseSyncType) => T): T | null {
+  const dbPath = statePath();
+  if (!dbPath) return null;
+  const log = readOnly ? console.warn : console.error;
+  let db: DatabaseSyncType;
+  try {
+    db = openSqlite(dbPath, readOnly);
+  } catch (err) {
+    log(`[state-store] could not open ${dbPath} for ${what}:`, err);
+    return null;
+  }
+  try {
+    return fn(db);
+  } catch (err) {
+    log(`[state-store] ${what} failed:`, err);
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+/** OpenClaw stores account ids lowercased, and the default account as "default". */
+function accountKey(account: string): string {
+  return account.trim().toLowerCase() || "default";
+}
+
+/**
+ * Approved sender ids for one channel account, in the order OpenClaw keeps
+ * them. Null when there is no v2 store to read.
+ */
+export function readPairingAllowEntries(channel: string, account = "default"): string[] | null {
+  return withStateDb(true, `${channel} allowlist read`, (db) => {
+    const rows = db
+      .prepare(
+        "SELECT entry FROM channel_pairing_allow_entries WHERE channel_key = ? AND account_id = ? ORDER BY sort_order, entry",
+      )
+      .all(channel, accountKey(account)) as Array<{ entry?: unknown }>;
+    return rows.map((r) => r.entry).filter((e): e is string => typeof e === "string" && e.length > 0);
+  });
+}
+
+/** The sender metadata OpenClaw attached to a request, or undefined when absent or malformed. */
+function parseMeta(metaJson: string | null): Record<string, unknown> | undefined {
+  if (typeof metaJson !== "string") return undefined;
+  try {
+    const meta: unknown = JSON.parse(metaJson);
+    return meta && typeof meta === "object" && !Array.isArray(meta) ? (meta as Record<string, unknown>) : undefined;
+  } catch {
+    return undefined; // a malformed meta only costs the display name
+  }
+}
+
+/** One pending pairing request, in the shape the legacy `<channel>-pairing.json` entries had. */
+export interface PairingRequestRow {
+  id: string;
+  code: string;
+  createdAt: string;
+  lastSeenAt: string;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Pending pairing requests for one channel account, oldest first. Null when
+ * there is no v2 store to read.
+ */
+export function readPairingRequests(channel: string, account = "default"): PairingRequestRow[] | null {
+  return withStateDb(true, `${channel} pairing-request read`, (db) => {
+    const rows = db
+      .prepare(
+        "SELECT request_id AS id, code, created_at AS createdAt, last_seen_at AS lastSeenAt, meta_json AS metaJson " +
+          "FROM channel_pairing_requests WHERE channel_key = ? AND account_id = ? ORDER BY created_at, request_id",
+      )
+      .all(channel, accountKey(account)) as Array<{
+      id: string;
+      code: string;
+      createdAt: string;
+      lastSeenAt: string;
+      metaJson: string | null;
+    }>;
+    // The table is STRICT with every column but meta_json NOT NULL, so the
+    // only shape to defend is the one the caller matches on.
+    const requests: PairingRequestRow[] = [];
+    for (const { metaJson, ...row } of rows) {
+      if (typeof row.id !== "string" || typeof row.code !== "string") continue;
+      const meta = parseMeta(metaJson);
+      requests.push(meta ? { ...row, meta } : row);
+    }
+    return requests;
+  });
+}
+
+/**
+ * Drop one channel account's approvals and pending requests — the two tables
+ * OpenClaw itself always rewrites together — in one IMMEDIATE transaction.
+ * A no-op without a v2 store; a failed write is logged, not thrown.
+ */
+export function clearPairingState(channel: string, account = "default"): void {
+  const key = accountKey(account);
+  withStateDb(false, `${channel} pairing reset`, (db) => {
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      db.prepare("DELETE FROM channel_pairing_allow_entries WHERE channel_key = ? AND account_id = ?").run(channel, key);
+      db.prepare("DELETE FROM channel_pairing_requests WHERE channel_key = ? AND account_id = ?").run(channel, key);
+      db.exec("COMMIT");
+    } catch (err) {
+      try {
+        db.exec("ROLLBACK");
+      } catch {
+        /* the connection close releases the transaction anyway */
+      }
+      throw err;
+    }
+  });
+}

--- a/src/lib/openclaw-state-store.ts
+++ b/src/lib/openclaw-state-store.ts
@@ -14,7 +14,10 @@
  * not (a v1 box, a Hermes-only box) — the callers keep their legacy-file path
  * for that case. A store that exists but cannot be opened or read also yields
  * null: the caller's fallback then finds nothing (the migration emptied the
- * legacy files), which is the same answer the gateway would give.
+ * legacy files), which is the same answer the gateway would give. The one
+ * writer, `clearPairingState`, reports such a store instead of yielding null:
+ * a reset that silently did nothing would leave the approvals in force behind
+ * a success.
  *
  * The database is never created here: an absent file means an OpenClaw that
  * has not migrated yet, and creating an empty store would make the doctor
@@ -70,13 +73,16 @@ function logOnce(readOnly: boolean, what: string, line: string, err: unknown): v
 }
 
 /**
- * Run `fn` against the state store; null when there is no store, or when it
- * cannot be opened or queried (logged — a corrupt or locked store must fall
- * through to the caller's fallback, never escape as a 500).
+ * Run `fn` against the store at `dbPath`; null when it cannot be opened or
+ * queried (logged — a corrupt or locked store must never escape as a 500: a
+ * reader falls through to its fallback, a writer reports the failure).
  */
-function withStateDb<T>(readOnly: boolean, what: string, fn: (db: DatabaseSyncType) => T): T | null {
-  const dbPath = statePath();
-  if (!dbPath) return null;
+function withOpenStore<T>(
+  dbPath: string,
+  readOnly: boolean,
+  what: string,
+  fn: (db: DatabaseSyncType) => T,
+): T | null {
   let db: DatabaseSyncType;
   try {
     db = openSqlite(dbPath, readOnly);
@@ -94,6 +100,12 @@ function withStateDb<T>(readOnly: boolean, what: string, fn: (db: DatabaseSyncTy
   } finally {
     db.close();
   }
+}
+
+/** Run `fn` against the state store; null when there is no store, or when it cannot be used. */
+function withStateDb<T>(readOnly: boolean, what: string, fn: (db: DatabaseSyncType) => T): T | null {
+  const dbPath = statePath();
+  return dbPath ? withOpenStore(dbPath, readOnly, what, fn) : null;
 }
 
 /** OpenClaw stores account ids lowercased, and the default account as "default". */
@@ -169,16 +181,22 @@ export function readPairingRequests(channel: string, account = "default"): Pairi
 /**
  * Drop one channel account's approvals and pending requests — the two tables
  * OpenClaw itself always rewrites together — in one IMMEDIATE transaction.
- * A no-op without a v2 store; a failed write is logged, not thrown.
+ * True when the account's rows are gone: cleared, or there is no v2 store to
+ * hold them. False when a store exists and could not be cleared (logged): a
+ * locked, corrupt or read-only store keeps every approved sender, so the
+ * caller has to report that rather than carry on as if the reset happened.
  */
-export function clearPairingState(channel: string, account = "default"): void {
+export function clearPairingState(channel: string, account = "default"): boolean {
+  const dbPath = statePath();
+  if (!dbPath) return true;
   const key = accountKey(account);
-  withStateDb(false, `${channel} pairing reset`, (db) => {
+  const done = withOpenStore(dbPath, false, `${channel} pairing reset`, (db) => {
     db.exec("BEGIN IMMEDIATE");
     try {
       db.prepare("DELETE FROM channel_pairing_allow_entries WHERE channel_key = ? AND account_id = ?").run(channel, key);
       db.prepare("DELETE FROM channel_pairing_requests WHERE channel_key = ? AND account_id = ?").run(channel, key);
       db.exec("COMMIT");
+      return true;
     } catch (err) {
       try {
         db.exec("ROLLBACK");
@@ -188,4 +206,5 @@ export function clearPairingState(channel: string, account = "default"): void {
       throw err;
     }
   });
+  return done === true;
 }

--- a/src/lib/openclaw-state-store.ts
+++ b/src/lib/openclaw-state-store.ts
@@ -26,19 +26,47 @@
  */
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
 import { OPENCLAW_HOME_DEFAULT, openSqlite } from "./openclaw-session-store";
 
+/**
+ * The state directory the way OpenClaw resolves it (`resolveStateDir`): an
+ * `OPENCLAW_STATE_DIR` override is trimmed, a leading `~` is the user's home
+ * and a relative path is taken from the cwd; without one it is the OpenClaw
+ * home. A literal `~/...` here would stat a path the gateway never writes.
+ */
+function stateDir(home: string): string {
+  const override = process.env.OPENCLAW_STATE_DIR?.trim();
+  if (!override) return home;
+  return path.resolve(override.replace(/^~(?=$|[\\/])/, () => process.env.HOME || os.homedir()));
+}
+
 /** The gateway-wide SQLite store, or null when this OpenClaw has not migrated to it. */
 export function statePath(home: string = OPENCLAW_HOME_DEFAULT): string | null {
-  const stateDir = process.env.OPENCLAW_STATE_DIR?.trim() || home;
-  const p = path.join(stateDir, "state", "openclaw.sqlite");
+  const p = path.join(stateDir(home), "state", "openclaw.sqlite");
   try {
     return fs.statSync(p).isFile() ? p : null;
   } catch {
     return null;
   }
+}
+
+/**
+ * The last failure logged per operation. The desktop polls the pairing store
+ * every 20 s, so a store that stays unreadable (schema drift, corruption)
+ * would otherwise repeat the same line ~4000 times a day and bury the one
+ * that matters; a failure is logged when it first appears or changes, and the
+ * slate is wiped by the next success so a relapse is logged again.
+ */
+const lastFailure = new Map<string, string>();
+
+function logOnce(readOnly: boolean, what: string, line: string, err: unknown): void {
+  const message = `${line}: ${err instanceof Error ? err.message : String(err)}`;
+  if (lastFailure.get(what) === message) return;
+  lastFailure.set(what, message);
+  (readOnly ? console.warn : console.error)(`[state-store] ${line}:`, err);
 }
 
 /**
@@ -49,18 +77,19 @@ export function statePath(home: string = OPENCLAW_HOME_DEFAULT): string | null {
 function withStateDb<T>(readOnly: boolean, what: string, fn: (db: DatabaseSyncType) => T): T | null {
   const dbPath = statePath();
   if (!dbPath) return null;
-  const log = readOnly ? console.warn : console.error;
   let db: DatabaseSyncType;
   try {
     db = openSqlite(dbPath, readOnly);
   } catch (err) {
-    log(`[state-store] could not open ${dbPath} for ${what}:`, err);
+    logOnce(readOnly, what, `could not open ${dbPath} for ${what}`, err);
     return null;
   }
   try {
-    return fn(db);
+    const result = fn(db);
+    lastFailure.delete(what);
+    return result;
   } catch (err) {
-    log(`[state-store] ${what} failed:`, err);
+    logOnce(readOnly, what, `${what} failed`, err);
     return null;
   } finally {
     db.close();

--- a/src/tests/routes/telegram/configure-hermes.test.ts
+++ b/src/tests/routes/telegram/configure-hermes.test.ts
@@ -113,6 +113,17 @@ describe("POST /setup-api/telegram/configure — harness routing", () => {
       expect(mockClearHermesPairing).not.toHaveBeenCalled();
     });
 
+    it("fails the save with the old token in place when the pairing reset throws", async () => {
+      mockGet.mockResolvedValue(TOKEN);
+      mockClearHermesPairing.mockRejectedValue(new Error("store refused"));
+      const res = await POST(req({ botToken: NEW_TOKEN }));
+
+      expect(res.status).toBe(500);
+      expect(mockSet).not.toHaveBeenCalledWith("telegram_bot_token", expect.anything());
+      expect(mockSetHermesToken).not.toHaveBeenCalled();
+      expect(mockEnsureGateway).not.toHaveBeenCalled();
+    });
+
     // The token is already persisted by then, so a gateway that won't come up
     // is a warning about delivery, not a failed save.
     it("still reports the save when the gateway cannot be started", async () => {

--- a/src/tests/routes/telegram/configure.test.ts
+++ b/src/tests/routes/telegram/configure.test.ts
@@ -84,6 +84,36 @@ describe("POST /setup-api/telegram/configure", () => {
     expect(mockSet).not.toHaveBeenCalledWith("telegram_approved_names", undefined);
   });
 
+  it("clears the old approvals before the new token is persisted", async () => {
+    mockGet.mockResolvedValue("111:OLD_token_value");
+    await telegramConfigurePost(jsonRequest({ botToken: "222:new_token_value" }));
+
+    const tokenSave = mockSet.mock.calls.findIndex(([key]) => key === "telegram_bot_token");
+    expect(tokenSave).toBeGreaterThanOrEqual(0);
+    const reset = mockClearPairing.mock.invocationCallOrder[0];
+    expect(reset).toBeLessThan(mockSet.mock.invocationCallOrder[tokenSave]);
+    expect(reset).toBeLessThan(mockSetTelegramToken.mock.invocationCallOrder[0]);
+  });
+
+  it("fails the save, old token still in place, when the old approvals cannot be cleared", async () => {
+    // A new bot must not go live answering senders approved for the old one,
+    // and the next attempt has to see the token change again so the reset is
+    // retried — both need the reset to run before anything is persisted.
+    mockGet.mockResolvedValue("111:OLD_token_value");
+    mockClearPairing.mockRejectedValue(new Error("Could not clear the previous Telegram approvals"));
+    const res = await telegramConfigurePost(jsonRequest({ botToken: "222:new_token_value" }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.success).toBeUndefined();
+    expect(body.error).toMatch(/approvals/);
+    expect(body.error).toMatch(/not saved/);
+    expect(mockSet).not.toHaveBeenCalledWith("telegram_bot_token", expect.anything());
+    expect(mockSet).not.toHaveBeenCalledWith("telegram_approved_names", undefined);
+    expect(mockSetTelegramToken).not.toHaveBeenCalled();
+    expect(mockRestartGateway).not.toHaveBeenCalled();
+  });
+
   it("returns 400 for invalid JSON", async () => {
     const req = new Request("http://localhost/test", {
       method: "POST",

--- a/src/tests/unit/telegram-allowlist-v2.test.ts
+++ b/src/tests/unit/telegram-allowlist-v2.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+import fs from "fs/promises";
+import type { DatabaseSync as DatabaseSyncType } from "node:sqlite";
+
+// OpenClaw 2 (2026.8) keeps Telegram pairing state in `state/openclaw.sqlite`
+// and reads ONLY from it; the `credentials/telegram-*.json` files are the
+// pre-migration store. A v2 box therefore has an empty credentials dir and
+// one allow-entry row per approved sender. These cases pin the sqlite path;
+// telegram-pairing.test.ts keeps covering the legacy files (v1 boxes).
+
+vi.mock("@/lib/config-store", () => ({ get: vi.fn(), set: vi.fn() }));
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "openclaw") }));
+vi.mock("@/lib/hermes-telegram", () => ({
+  approveHermesPairing: vi.fn(),
+  listHermesPairing: vi.fn(),
+  readHermesApprovedUsers: vi.fn(async () => []),
+  readHermesPairingRequests: vi.fn(async () => []),
+  notifyHermesTelegramUser: vi.fn(),
+}));
+
+import { get } from "@/lib/config-store";
+
+// The lib reaches node:sqlite lazily (vite cannot bundle the builtin); so do
+// the fixtures.
+const { DatabaseSync } = createRequire(import.meta.url)("node:sqlite") as {
+  DatabaseSync: typeof DatabaseSyncType;
+};
+
+// OpenClaw 2026.8.1's own DDL for the two pairing tables, verbatim (STRICT).
+const PAIRING_DDL = `
+CREATE TABLE IF NOT EXISTS channel_pairing_requests (
+  channel_key TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  request_id TEXT NOT NULL,
+  code TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  last_seen_at TEXT NOT NULL,
+  meta_json TEXT,
+  PRIMARY KEY (channel_key, account_id, request_id)
+) STRICT;
+CREATE TABLE IF NOT EXISTS channel_pairing_allow_entries (
+  channel_key TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  entry TEXT NOT NULL,
+  sort_order INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  PRIMARY KEY (channel_key, account_id, entry)
+) STRICT;`;
+
+const OWNER_ID = "1234567890";
+
+let tmpHome: string;
+const origHome = process.env.OPENCLAW_HOME;
+const origStateDir = process.env.OPENCLAW_STATE_DIR;
+
+function statePath(root = tmpHome): string {
+  return path.join(root, "state", "openclaw.sqlite");
+}
+
+function withDb<T>(fn: (db: DatabaseSyncType) => T, readOnly = false, root = tmpHome): T {
+  const db = new DatabaseSync(statePath(root), { readOnly });
+  try {
+    return fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+type AllowRow = [channel: string, account: string, entry: string];
+type RequestRow = {
+  channel?: string;
+  account?: string;
+  id: string;
+  code: string;
+  createdAt: string;
+  meta?: Record<string, unknown> | null;
+};
+
+async function makeStateDb(allow: AllowRow[], requests: RequestRow[] = [], root = tmpHome): Promise<void> {
+  await fs.mkdir(path.dirname(statePath(root)), { recursive: true });
+  withDb((db) => {
+    db.exec(PAIRING_DDL);
+    const insAllow = db.prepare(
+      "INSERT INTO channel_pairing_allow_entries (channel_key, account_id, entry, sort_order, updated_at) VALUES (?, ?, ?, ?, ?)",
+    );
+    allow.forEach(([channel, account, entry], i) => insAllow.run(channel, account, entry, i, Date.now()));
+    const insReq = db.prepare(
+      "INSERT INTO channel_pairing_requests (channel_key, account_id, request_id, code, created_at, last_seen_at, meta_json) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    );
+    for (const r of requests) {
+      insReq.run(
+        r.channel ?? "telegram",
+        r.account ?? "default",
+        r.id,
+        r.code,
+        r.createdAt,
+        r.createdAt,
+        r.meta == null ? null : JSON.stringify(r.meta),
+      );
+    }
+  }, false, root);
+}
+
+function countRows(table: string, channel: string, account: string): number {
+  return withDb(
+    (db) =>
+      (db
+        .prepare(`SELECT count(*) AS n FROM ${table} WHERE channel_key = ? AND account_id = ?`)
+        .get(channel, account) as { n: number }).n,
+    true,
+  );
+}
+
+async function writeLegacyAllow(ids: string[]): Promise<void> {
+  await fs.writeFile(
+    path.join(tmpHome, "credentials", "telegram-default-allowFrom.json"),
+    JSON.stringify({ version: 1, allowFrom: ids }),
+    "utf-8",
+  );
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "oc-home-v2-"));
+  process.env.OPENCLAW_HOME = tmpHome;
+  delete process.env.OPENCLAW_STATE_DIR;
+  // A v2 box: the credentials dir exists but holds no pairing files.
+  await fs.mkdir(path.join(tmpHome, "credentials"), { recursive: true });
+});
+
+afterEach(async () => {
+  if (origHome === undefined) delete process.env.OPENCLAW_HOME;
+  else process.env.OPENCLAW_HOME = origHome;
+  if (origStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
+  else process.env.OPENCLAW_STATE_DIR = origStateDir;
+  await fs.rm(tmpHome, { recursive: true, force: true });
+});
+
+describe("readTelegramAllowFrom on an OpenClaw 2 box", () => {
+  it("returns the approved sender from state/openclaw.sqlite when the credentials dir is empty", async () => {
+    await makeStateDb([["telegram", "default", OWNER_ID]]);
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    expect(await readTelegramAllowFrom()).toEqual([OWNER_ID]);
+  });
+
+  it("keeps OpenClaw's order and ignores other channels and accounts", async () => {
+    await makeStateDb([
+      ["telegram", "default", "222"],
+      ["discord", "default", "999"],
+      ["telegram", "work", "888"],
+      ["telegram", "default", "111"],
+    ]);
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    expect(await readTelegramAllowFrom()).toEqual(["222", "111"]);
+    expect(await readTelegramAllowFrom("work")).toEqual(["888"]);
+  });
+
+  it("prefers the sqlite store over a stale pre-migration JSON file", async () => {
+    await makeStateDb([["telegram", "default", OWNER_ID]]);
+    await writeLegacyAllow(["555"]);
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    expect(await readTelegramAllowFrom()).toEqual([OWNER_ID]);
+  });
+
+  it("returns [] when the store exists but nobody is approved yet", async () => {
+    await makeStateDb([]);
+    await writeLegacyAllow(["555"]);
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    expect(await readTelegramAllowFrom()).toEqual([]);
+  });
+
+  it("looks the account id up the way OpenClaw stores it (lowercased)", async () => {
+    await makeStateDb([["telegram", "work", "888"]]);
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    expect(await readTelegramAllowFrom("Work")).toEqual(["888"]);
+  });
+
+  it("honours OPENCLAW_STATE_DIR, where OpenClaw itself resolves the store", async () => {
+    const stateHome = await fs.mkdtemp(path.join(os.tmpdir(), "oc-state-dir-"));
+    try {
+      process.env.OPENCLAW_STATE_DIR = stateHome;
+      await makeStateDb([["telegram", "default", OWNER_ID]], [], stateHome);
+      const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+      expect(await readTelegramAllowFrom()).toEqual([OWNER_ID]);
+    } finally {
+      await fs.rm(stateHome, { recursive: true, force: true });
+    }
+  });
+
+  it("still reads the legacy file on a box without the v2 store", async () => {
+    await writeLegacyAllow(["555"]);
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    expect(await readTelegramAllowFrom()).toEqual(["555"]);
+  });
+
+  it("falls back to the legacy file when the store cannot be read", async () => {
+    await fs.mkdir(path.dirname(statePath()), { recursive: true });
+    await fs.writeFile(statePath(), "this is not a database", "utf-8");
+    await writeLegacyAllow(["555"]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    await expect(readTelegramAllowFrom()).resolves.toEqual(["555"]);
+    warn.mockRestore();
+  });
+});
+
+describe("readTelegramPairingRequests on an OpenClaw 2 box", () => {
+  it("lists the pending requests with id, code, createdAt and a derived name", async () => {
+    await makeStateDb([], [
+      {
+        id: "42",
+        code: "ABCD2345",
+        createdAt: "2026-09-01T10:00:00.000Z",
+        meta: { firstName: "Krasi", lastName: "K", username: "krasi" },
+      },
+      { id: "43", code: "EFGH6789", createdAt: "2026-09-01T09:00:00.000Z", meta: null },
+      { channel: "discord", id: "44", code: "ZZZZ0000", createdAt: "2026-09-01T08:00:00.000Z" },
+    ]);
+    const { readTelegramPairingRequests } = await import("@/lib/openclaw-config");
+    const requests = await readTelegramPairingRequests();
+    expect(requests.map((r) => r.id)).toEqual(["43", "42"]);
+    expect(requests[1]).toMatchObject({
+      id: "42",
+      code: "ABCD2345",
+      createdAt: "2026-09-01T10:00:00.000Z",
+      meta: { firstName: "Krasi", lastName: "K", username: "krasi" },
+      name: "Krasi K",
+    });
+    expect(requests[0].name).toBeUndefined();
+  });
+
+  it("returns [] from an empty v2 store even when a stale legacy file lingers", async () => {
+    await makeStateDb([]);
+    await fs.writeFile(
+      path.join(tmpHome, "credentials", "telegram-pairing.json"),
+      JSON.stringify({ version: 1, requests: [{ code: "OLDCODE1", id: "1" }] }),
+      "utf-8",
+    );
+    const { readTelegramPairingRequests } = await import("@/lib/openclaw-config");
+    expect(await readTelegramPairingRequests()).toEqual([]);
+  });
+});
+
+describe("clearTelegramPairingState on an OpenClaw 2 box", () => {
+  it("deletes the telegram allow entries and pending requests, leaving other channels alone", async () => {
+    await makeStateDb(
+      [
+        ["telegram", "default", OWNER_ID],
+        ["telegram", "default", "222"],
+        ["discord", "default", "999"],
+      ],
+      [
+        { id: "42", code: "ABCD2345", createdAt: "2026-09-01T10:00:00.000Z" },
+        { channel: "discord", id: "44", code: "ZZZZ0000", createdAt: "2026-09-01T08:00:00.000Z" },
+      ],
+    );
+    const { clearTelegramPairingState, readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    await clearTelegramPairingState();
+
+    expect(countRows("channel_pairing_allow_entries", "telegram", "default")).toBe(0);
+    expect(countRows("channel_pairing_requests", "telegram", "default")).toBe(0);
+    expect(countRows("channel_pairing_allow_entries", "discord", "default")).toBe(1);
+    expect(countRows("channel_pairing_requests", "discord", "default")).toBe(1);
+    expect(await readTelegramAllowFrom()).toEqual([]);
+  });
+
+  it("also removes the legacy files so a later migration cannot resurrect old approvals", async () => {
+    await makeStateDb([["telegram", "default", OWNER_ID]]);
+    const allowFile = path.join(tmpHome, "credentials", "telegram-default-allowFrom.json");
+    await writeLegacyAllow(["555"]);
+    const { clearTelegramPairingState } = await import("@/lib/openclaw-config");
+    await clearTelegramPairingState();
+    await expect(fs.access(allowFile)).rejects.toThrow();
+    expect(countRows("channel_pairing_allow_entries", "telegram", "default")).toBe(0);
+  });
+
+  it("does not throw when the store cannot be opened for writing", async () => {
+    await fs.mkdir(path.dirname(statePath()), { recursive: true });
+    await fs.writeFile(statePath(), "this is not a database", "utf-8");
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { clearTelegramPairingState } = await import("@/lib/openclaw-config");
+    await expect(clearTelegramPairingState()).resolves.toBeUndefined();
+    err.mockRestore();
+    warn.mockRestore();
+  });
+});
+
+describe("GET /setup-api/telegram/pairing on an OpenClaw 2 box", () => {
+  it("lists the approved sender read from the sqlite store", async () => {
+    await makeStateDb([["telegram", "default", OWNER_ID]]);
+    vi.mocked(get).mockImplementation(async (key: string) =>
+      key === "telegram_bot_token" ? "123:abc" : key === "telegram_approved_names" ? { [OWNER_ID]: "Owner" } : null,
+    );
+    const { GET } = await import("@/app/setup-api/telegram/pairing/route");
+    const res = await GET(new Request("http://localhost/setup-api/telegram/pairing"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.configured).toBe(true);
+    expect(body.approved).toEqual([{ id: OWNER_ID, name: "Owner" }]);
+  });
+
+  it("?poll=1 lists the pending request from the sqlite store", async () => {
+    await makeStateDb([], [
+      { id: "42", code: "ABCD2345", createdAt: "2026-09-01T10:00:00.000Z", meta: { firstName: "Krasi" } },
+    ]);
+    vi.mocked(get).mockImplementation(async (key: string) => (key === "telegram_bot_token" ? "123:abc" : null));
+    const { GET } = await import("@/app/setup-api/telegram/pairing/route");
+    const res = await GET(new Request("http://localhost/setup-api/telegram/pairing?poll=1"));
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(body.pending).toHaveLength(1);
+    expect(body.pending[0]).toMatchObject({ id: "42", code: "ABCD2345", name: "Krasi" });
+  });
+});

--- a/src/tests/unit/telegram-allowlist-v2.test.ts
+++ b/src/tests/unit/telegram-allowlist-v2.test.ts
@@ -55,6 +55,7 @@ const OWNER_ID = "1234567890";
 let tmpHome: string;
 const origHome = process.env.OPENCLAW_HOME;
 const origStateDir = process.env.OPENCLAW_STATE_DIR;
+const origUserHome = process.env.HOME;
 
 function statePath(root = tmpHome): string {
   return path.join(root, "state", "openclaw.sqlite");
@@ -136,6 +137,8 @@ afterEach(async () => {
   else process.env.OPENCLAW_HOME = origHome;
   if (origStateDir === undefined) delete process.env.OPENCLAW_STATE_DIR;
   else process.env.OPENCLAW_STATE_DIR = origStateDir;
+  if (origUserHome === undefined) delete process.env.HOME;
+  else process.env.HOME = origUserHome;
   await fs.rm(tmpHome, { recursive: true, force: true });
 });
 
@@ -190,6 +193,22 @@ describe("readTelegramAllowFrom on an OpenClaw 2 box", () => {
     }
   });
 
+  it("expands a leading ~ in OPENCLAW_STATE_DIR the way OpenClaw does", async () => {
+    // OpenClaw resolves the override through resolveUserPath, so `~/x` is the
+    // user's home; statting the literal `~/x` would miss the store the gateway
+    // writes and silently fall back to the (empty) legacy file.
+    const userHome = await fs.mkdtemp(path.join(os.tmpdir(), "oc-user-home-"));
+    try {
+      process.env.HOME = userHome;
+      process.env.OPENCLAW_STATE_DIR = "~/oc-state";
+      await makeStateDb([["telegram", "default", OWNER_ID]], [], path.join(userHome, "oc-state"));
+      const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+      expect(await readTelegramAllowFrom()).toEqual([OWNER_ID]);
+    } finally {
+      await fs.rm(userHome, { recursive: true, force: true });
+    }
+  });
+
   it("still reads the legacy file on a box without the v2 store", async () => {
     await writeLegacyAllow(["555"]);
     const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
@@ -203,6 +222,28 @@ describe("readTelegramAllowFrom on an OpenClaw 2 box", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
     await expect(readTelegramAllowFrom()).resolves.toEqual(["555"]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("logs a store that stays unreadable once, not on every poll, and again after it recovers", async () => {
+    await fs.mkdir(path.dirname(statePath()), { recursive: true });
+    await fs.writeFile(statePath(), "this is not a database", "utf-8");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    await readTelegramAllowFrom();
+    await readTelegramAllowFrom();
+    await readTelegramAllowFrom();
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // Recovery (the store rewritten as a real database) wipes the slate...
+    await fs.rm(statePath());
+    await makeStateDb([["telegram", "default", OWNER_ID]]);
+    expect(await readTelegramAllowFrom()).toEqual([OWNER_ID]);
+    // ...so a relapse is reported again.
+    await fs.writeFile(statePath(), "this is not a database", "utf-8");
+    await readTelegramAllowFrom();
+    expect(warn).toHaveBeenCalledTimes(2);
     warn.mockRestore();
   });
 });

--- a/src/tests/unit/telegram-allowlist-v2.test.ts
+++ b/src/tests/unit/telegram-allowlist-v2.test.ts
@@ -318,15 +318,53 @@ describe("clearTelegramPairingState on an OpenClaw 2 box", () => {
     expect(countRows("channel_pairing_allow_entries", "telegram", "default")).toBe(0);
   });
 
-  it("does not throw when the store cannot be opened for writing", async () => {
+  it("rejects when the store cannot be opened for writing, and leaves the legacy files alone", async () => {
+    // A store that exists but cannot be used still holds whatever it held and
+    // the gateway keeps answering those senders, so the reset has to say so
+    // instead of resolving the way the no-store case does.
     await fs.mkdir(path.dirname(statePath()), { recursive: true });
     await fs.writeFile(statePath(), "this is not a database", "utf-8");
+    const allowFile = path.join(tmpHome, "credentials", "telegram-default-allowFrom.json");
+    await writeLegacyAllow(["555"]);
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { clearTelegramPairingState } = await import("@/lib/openclaw-config");
-    await expect(clearTelegramPairingState()).resolves.toBeUndefined();
+    await expect(clearTelegramPairingState()).rejects.toThrow(/approvals/);
+    expect(err).toHaveBeenCalledTimes(1);
+    // Nothing else was touched: the legacy copy is not deleted behind a failed reset.
+    await expect(fs.access(allowFile)).resolves.toBeUndefined();
     err.mockRestore();
-    warn.mockRestore();
+  });
+
+  it("rejects when the delete fails, leaving every row the reset could not remove", async () => {
+    await makeStateDb(
+      [
+        ["telegram", "default", OWNER_ID],
+        ["telegram", "default", "222"],
+      ],
+      [{ id: "42", code: "ABCD2345", createdAt: "2026-09-01T10:00:00.000Z" }],
+    );
+    // The transaction's second DELETE is made to fail (a locked or read-only
+    // store fails the same way, only earlier), which also proves the first
+    // DELETE is rolled back rather than left half-applied.
+    withDb((db) =>
+      db.exec(
+        "CREATE TRIGGER refuse BEFORE DELETE ON channel_pairing_requests BEGIN SELECT RAISE(ABORT, 'refused'); END",
+      ),
+    );
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { clearTelegramPairingState, readTelegramAllowFrom } = await import("@/lib/openclaw-config");
+    const { clearPairingState } = await import("@/lib/openclaw-state-store");
+    await expect(clearTelegramPairingState()).rejects.toThrow(/approvals/);
+    expect(clearPairingState("telegram")).toBe(false);
+    expect(countRows("channel_pairing_allow_entries", "telegram", "default")).toBe(2);
+    expect(countRows("channel_pairing_requests", "telegram", "default")).toBe(1);
+    expect(await readTelegramAllowFrom()).toEqual([OWNER_ID, "222"]);
+    err.mockRestore();
+  });
+
+  it("reports the rows gone on a box without the v2 store, where the legacy files are the store", async () => {
+    const { clearPairingState } = await import("@/lib/openclaw-state-store");
+    expect(clearPairingState("telegram")).toBe(true);
   });
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,6 +41,12 @@ export default defineConfig({
       // file; the suite must see the same nothing everywhere. Tests that need
       // an openclaw.json point OPENCLAW_HOME at their own fixture dir.
       OPENCLAW_HOME: path.join(os.tmpdir(), `clawbox-test-openclaw-${process.pid}`),
+      // And for the override OpenClaw honours above its home: with
+      // OPENCLAW_STATE_DIR exported on the runner, openclaw-state-store.ts
+      // would read that machine's real state/openclaw.sqlite (the Telegram
+      // allowlist) instead of the fixture under OPENCLAW_HOME. Empty means
+      // "no override", so the store follows the floored home above.
+      OPENCLAW_STATE_DIR: "",
     },
     projects: [
       {


### PR DESCRIPTION
Finding **F-06** (severity high, OpenClaw edition).

## Symptom

On every OpenClaw 2 box the Telegram allowlist looks empty to ClawBox even though Telegram itself works and the owner is approved:

- the email chat-approval bot never asks anyone (`no_owner_chat`) and rejects the owner's tap (`not_owner`),
- the coding-agent finish notice goes to nobody,
- the Settings pairing panel lists no approved sender, and the `?poll=1` popup never sees a pending request,
- changing the bot token no longer resets the approvals.

Measured on a 2026.8.1 box: `~/.openclaw/credentials/` is empty; `state/openclaw.sqlite` → `channel_pairing_allow_entries` holds the owner's row (`telegram`, `default`).

## Cause

OpenClaw 2026.8 moved pairing approvals and pending codes from `credentials/telegram-<account>-allowFrom.json` + `telegram-pairing.json` into `state/openclaw.sqlite` (`channel_pairing_allow_entries`, `channel_pairing_requests`) and reads only the database once it exists; its migration deletes the JSON files. `readTelegramAllowFrom()`, `readTelegramPairingRequests()` and `clearTelegramPairingState()` in `src/lib/openclaw-config.ts` still read/removed only the legacy files.

## Fix

- New `src/lib/openclaw-state-store.ts`: the one reader/writer for the gateway-wide store. Path follows OpenClaw's `resolveStateDir` rule (`OPENCLAW_STATE_DIR` override — trimmed, `~` expanded — else the OpenClaw home), `node:sqlite` loaded lazily via the shared opener (read-only + `busy_timeout` for reads), never creates the database. `readPairingAllowEntries`, `readPairingRequests` (`request_id→id`, `created_at→createdAt`, `meta_json→meta`) and `clearPairingState` (both tables, one `BEGIN IMMEDIATE` transaction). Any open/query failure is logged (once per distinct failure, not on every 20 s poll) and yields `null`.
- The three Telegram readers answer from the state store whenever the file exists (the gateway's authority; a leftover pre-migration JSON must not shadow it) and keep the legacy files as the v1 fallback; the reset clears the sqlite rows and still removes the legacy files. Callers unchanged: `email-approval.ts`, `coding-agent-notify.ts`, `telegram/pairing/route.ts` (GET, `?poll=1`, POST name capture), `telegram/configure/route.ts`.
- `openclaw-session-store.ts`: the sqlite opener is exported as `openSqlite` so both stores share it (no behaviour change).
- A failed v2 clear is a reported failure, not a silent no-op (review round 1): `clearPairingState` returns whether the rows are gone, `clearTelegramPairingState` throws before touching the legacy files, and `/setup-api/telegram/configure` now runs the reset **before** persisting the new token and answers an honest 500 when it fails (nothing persisted, no legacy-file deletion, no restart). The order is the point: run after the save, a failed reset could never be retried — the retry saw the same stored token, computed `tokenChanged === false` and skipped it — so the new bot went live answering senders approved for the old one. The Hermes branch is reordered the same way; its best-effort clear is unchanged.
- `vitest.config.ts`: `OPENCLAW_STATE_DIR` floored to `""` beside `OPENCLAW_HOME`, so a runner with it exported cannot make the suite read that machine's real store.

Sibling sites checked: no other reader of `credentials/telegram-*` / `allowFrom.json` in `src`, `scripts`, `install.sh`; no Discord/WhatsApp legacy allowFrom readers exist in ClawBox (WhatsApp pairs by QR). F-08's `config_machine_state` reader can share `openclaw-state-store.ts`.

## Evidence

**RED** — `src/tests/unit/telegram-allowlist-v2.test.ts` on unmodified `origin/beta` (5d7d1559):

```
 FAIL  |unit| src/tests/unit/telegram-allowlist-v2.test.ts > readTelegramAllowFrom on an OpenClaw 2 box > returns the approved sender from state/openclaw.sqlite when the credentials dir is empty
AssertionError: expected [] to deeply equal [ '1234567890' ]
...
 Test Files  1 failed (1)
      Tests  12 failed | 3 passed (15)
```
(the 3 passes are the legacy-file cases that v1 boxes already had.)

**GREEN** — with the fix: `telegram-allowlist-v2.test.ts` 17/17; `telegram|pairing|session-store|email-approval|coding-agent|mcp-path-guard|openclaw-config` suites 50 files / 920 tests green; full `vitest run` 8827/8829 (the 2 misses are `chat-spoken-reply.test.tsx` audio-player cases that time out under a parallel run and pass in isolation, unrelated to this diff); `tsc --noEmit` clean; ESLint 0 errors on the changed files.

Read path proven on the live 2026.8.1 box as `clawbox` with the exact SQL, read-only + busy_timeout, against the WAL database while the gateway ran.

**Round 2 (4deac8e1, rebased on beta `47356167`)** — `telegram-allowlist-v2.test.ts` 19/19: a store that cannot be opened rejects and leaves the legacy file; a delete failing mid-transaction rejects, returns `false`, and every allow entry and request survives (the first DELETE rolled back). `configure.test.ts` + `configure-hermes.test.ts` pin the reset-before-save order and the refused save on both harnesses. `telegram|pairing|session-store|email-approval|openclaw-config` suites 22 files / 401 tests green; `tsc --noEmit` clean; ESLint 0 errors on the changed files. The reset/write path is unit-proven only — not exercised on a device in this round.

E2E Install on the previous head (run 33597439998) failed only `25-desktop-ui › opening Files, Settings, and Terminal … renders each window`: the chat popup (`chat-popup`, "Could not connect to gateway") mounted after the spec's `isVisible()` check and sat on the Files title bar, intercepting the Close click for 60 s (error-context + screenshot in the run's report artifact). The identical spec passed on #576's run 33604353006 an hour later, and nothing in this diff touches the desktop shell — unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Telegram pairing and allowlist data now supports OpenClaw 2’s SQLite state store.
  - Pairing requests include associated metadata when available.
  - Pairing state can be cleared across supported storage formats.

- **Bug Fixes**
  - Added fallback to legacy Telegram credential files when SQLite state data is unavailable.
  - Improved handling of missing, unreadable, or invalid state stores without interrupting pairing workflows.
  - Telegram token updates now preserve the existing configuration if pairing-state cleanup fails.

- **Tests**
  - Expanded coverage for SQLite reads, legacy fallback, filtering, ordering, pairing requests, state clearing, and configuration failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
