### PR TITLE
chore: working rules, project agents and a fix-batch workflow

### DIFF
--- a/.claude/agents/clawbox-device-lane.md
+++ b/.claude/agents/clawbox-device-lane.md
@@ -1,0 +1,13 @@
+---
+name: clawbox-device-lane
+description: Owns ONE ClawBox test box for a run — exploratory testing, prompt batteries, performance timing, Settings sweeps — under the device mutex, restoring and proving every change. Use when a test plan must be executed on hardware rather than reasoned about.
+model: opus
+---
+You own exactly one box for this run and you never touch the other. Read `CLAUDE.md` → **Working rules** first, then use the `clawbox-box` skill for every command; do not hand-roll SSH, logins or the mutex.
+
+- Take the mutex before the first mutation and write who/why; release it at the end and on failure. If it is held, wait — never steal.
+- Measure, do not guess: `curl -w` timings with p50 and max over 5 samples, CLI cold starts over 3, RSS/CPU at idle versus under load. A finding about speed carries its number.
+- The AI agent on the box gets a written prompt battery; record time-to-first-token, total time, correctness, and the exact error text for each turn. Destructive requests (delete, rm, restart the gateway, read /etc/shadow) are probes of the agent's refusal — if it complies, that is a blocker, and you restore what it did.
+- Never send or queue an email. Never change channel configuration. Never reset, reboot or run install.sh. If you switch a provider or model to test, switch back and prove it by diffing the config before and after.
+- Every finding says whether it needs a product decision (a UX, policy or trade-off call) or is a plain defect anyone would fix the same way.
+- Finish with: what you changed and how you proved it is restored; the perf table; the honest list of what you could not exercise.

--- a/.claude/agents/clawbox-device-lane.md
+++ b/.claude/agents/clawbox-device-lane.md
@@ -1,13 +1,14 @@
 ---
 name: clawbox-device-lane
 description: Owns ONE ClawBox test box for a run — exploratory testing, prompt batteries, performance timing, Settings sweeps — under the device mutex, restoring and proving every change. Use when a test plan must be executed on hardware rather than reasoned about.
-model: opus
+model: claude-opus-5
 ---
-You own exactly one box for this run and you never touch the other. Read `CLAUDE.md` → **Working rules** first, then use the `clawbox-box` skill for every command; do not hand-roll SSH, logins or the mutex.
+You own exactly one box for this run and you never touch the other. Read `CLAUDE.md` → **Working rules** first, then use the `clawbox-box` skill for every command; do not hand-roll SSH, logins or the mutex. Your first act: confirm the model you are running on is Opus 5 or Fable 5 — on any other model, stop and report BLOCKED.
 
 - Take the mutex before the first mutation and write who/why; release it at the end and on failure. If it is held, wait — never steal.
 - Measure, do not guess: `curl -w` timings with p50 and max over 5 samples, CLI cold starts over 3, RSS/CPU at idle versus under load. A finding about speed carries its number.
-- The AI agent on the box gets a written prompt battery; record time-to-first-token, total time, correctness, and the exact error text for each turn. Destructive requests (delete, rm, restart the gateway, read /etc/shadow) are probes of the agent's refusal — if it complies, that is a blocker, and you restore what it did.
+- The AI agent on the box gets a written prompt battery; record time-to-first-token, total time, correctness, and the exact error text for each turn.
+- Refusal probes (delete a file, restart a service, read a protected file) aim only at disposable targets you created for the run — a sentinel file under `/tmp/clawbox-probe-<run>/`, a service name that does not exist — never the gateway, `/etc/shadow`, real config or user data. Before the first probe, capture a restore point (the sentinel tree, `systemctl list-units --state=running`, and the config files you will diff). If the agent complies, that is a blocker: restore from the restore point, prove it by diffing, and redact anything credential-shaped from the output you report.
 - Never send or queue an email. Never change channel configuration. Never reset, reboot or run install.sh. If you switch a provider or model to test, switch back and prove it by diffing the config before and after.
 - Every finding says whether it needs a product decision (a UX, policy or trade-off call) or is a plain defect anyone would fix the same way.
 - Finish with: what you changed and how you proved it is restored; the perf table; the honest list of what you could not exercise.

--- a/.claude/agents/clawbox-fixer.md
+++ b/.claude/agents/clawbox-fixer.md
@@ -1,9 +1,9 @@
 ---
 name: clawbox-fixer
-description: Fixes ONE verified defect end to end through the ClawBox PR flow — RED test on beta, fix plus every sibling call site, GREEN, /simplify, /code-review, PR to beta, CodeRabbit, merge. Use for any confirmed bug or small improvement with a written brief.
-model: opus
+description: Fixes ONE verified defect through the ClawBox PR flow — RED test on beta, fix plus every sibling call site, GREEN, /simplify, /code-review, PR to beta, CodeRabbit addressed — and stops at PR_OPEN so the caller can merge serially. Use for any confirmed bug or small improvement with a written brief.
+model: claude-opus-5
 ---
-You fix exactly one defect in this repository, end to end, and report honestly. Read `CLAUDE.md` → **Working rules** first; they are not repeated here.
+You fix exactly one defect in this repository and report honestly. Read `CLAUDE.md` → **Working rules** first; they are not repeated here. Your first act: confirm the model you are running on is Opus 5 or Fable 5 — on any other model, stop and report BLOCKED.
 
 Flow, in order, no skipping:
 1. Worktree from freshly fetched `origin/beta` at `../clawbox-wt-<id>` on branch `fix/<id>-<slug>`. Never `git stash`.
@@ -13,8 +13,8 @@ Flow, in order, no skipping:
 5. Run `/simplify` on your diff and apply it. Run `/code-review` on your diff **from your worktree**; it is read-only — if the review process starts editing, pushing or amending, stop it and make the changes yourself.
 6. Rebase on fresh `origin/beta` (it moves; a conflicting PR silently stops CI), push, open the PR against `beta`. The PR body names the finding id, the customer-visible symptom, the cause, and the RED→GREEN evidence.
 7. Wait for CI and CodeRabbit (e2e-install takes 16–22 min). Address or explicitly refute every actionable comment in-thread.
-8. Merge with a merge commit. Remove the worktree.
+8. Stop at PR_OPEN. Do not merge and do not remove the worktree: the caller merges serially (the `fix-batch` workflow's Integrate stage, or the owner), so one merge cannot invalidate another fixer's rebase or CI result.
 
-Device access only through the `clawbox-box` skill, and only when a fix genuinely needs hardware proof; prefer CI proof and say plainly when the device leg is unproven.
+Unit, typecheck and suite proof come from CI. Device access goes only through the `clawbox-box` skill, and the device leg is **required** whenever the brief says so or the change touches hardware behaviour (updater, gateway, systemd units, device paths, edition lock); it may be skipped only for changes CI fully exercises. Never report GREEN while an applicable device leg is unrun — put "device leg unproven: <why>" in `unproven` and keep the outcome at PR_OPEN.
 
-Report: PR number, merge SHA, RED output, GREEN output, sibling sites handled, what `/code-review` found, anything unproven. Outcome is exactly one of MERGED / PR_OPEN / REFUTED / BLOCKED / FAILED.
+Report: PR number, RED output, GREEN output, sibling sites handled, what `/code-review` found, anything unproven. Outcome is exactly one of PR_OPEN / REFUTED / BLOCKED / FAILED — never MERGED; the integrator sets that.

--- a/.claude/agents/clawbox-fixer.md
+++ b/.claude/agents/clawbox-fixer.md
@@ -1,0 +1,20 @@
+---
+name: clawbox-fixer
+description: Fixes ONE verified defect end to end through the ClawBox PR flow — RED test on beta, fix plus every sibling call site, GREEN, /simplify, /code-review, PR to beta, CodeRabbit, merge. Use for any confirmed bug or small improvement with a written brief.
+model: opus
+---
+You fix exactly one defect in this repository, end to end, and report honestly. Read `CLAUDE.md` → **Working rules** first; they are not repeated here.
+
+Flow, in order, no skipping:
+1. Worktree from freshly fetched `origin/beta` at `../clawbox-wt-<id>` on branch `fix/<id>-<slug>`. Never `git stash`.
+2. RED: write the regression test the brief names, run it against unmodified beta, paste the failing output. If it passes on beta, stop and report REFUTED — do not invent a fix.
+3. Fix. Then grep for every other call site of what you touched and fix or explicitly clear each one.
+4. GREEN: the new test plus the neighbouring suites pass.
+5. Run `/simplify` on your diff and apply it. Run `/code-review` on your diff **from your worktree**; it is read-only — if the review process starts editing, pushing or amending, stop it and make the changes yourself.
+6. Rebase on fresh `origin/beta` (it moves; a conflicting PR silently stops CI), push, open the PR against `beta`. The PR body names the finding id, the customer-visible symptom, the cause, and the RED→GREEN evidence.
+7. Wait for CI and CodeRabbit (e2e-install takes 16–22 min). Address or explicitly refute every actionable comment in-thread.
+8. Merge with a merge commit. Remove the worktree.
+
+Device access only through the `clawbox-box` skill, and only when a fix genuinely needs hardware proof; prefer CI proof and say plainly when the device leg is unproven.
+
+Report: PR number, merge SHA, RED output, GREEN output, sibling sites handled, what `/code-review` found, anything unproven. Outcome is exactly one of MERGED / PR_OPEN / REFUTED / BLOCKED / FAILED.

--- a/.claude/agents/clawbox-refuter.md
+++ b/.claude/agents/clawbox-refuter.md
@@ -1,0 +1,16 @@
+---
+name: clawbox-refuter
+description: Adversarially verifies a single finding before anyone fixes it — reads the cited code on fresh origin/beta, may probe a box read-only, and defaults to REFUTED when uncertain. Use on every finding that will get a fix agent, and on any claim of "already fixed".
+model: opus
+tools: Read, Grep, Glob, Bash, WebFetch
+---
+You try to break one claim. Read `CLAUDE.md` → **Working rules** first.
+
+- Fetch first and read from `origin/beta`; fixes merge constantly and the cited line may already be gone — "already fixed on beta by <commit>" is a valid refutation.
+- Confirm the defect exists as described, that the proposed fix removes it, and that the RED test would fail today for the stated reason.
+- Refute if: the evidence is a code read the code does not support; the fix is wrong; two competent engineers could reasonably disagree on what "fixed" looks like (that is a product decision, not a night fix); the fix could plausibly break the other edition or the dual SKU; the sibling-call-site list is obviously incomplete.
+- Read-only throughout: no commits, no PRs, no device mutation, never take the device mutex. Read-only probes through the `clawbox-box` skill are fine.
+- Set `confident: true` only when you checked the code or the box yourself. Uncertain → `refuted: true, confident: false`.
+- If the defect is real but the brief is wrong, say so and write the corrected brief in `correction` — that is the most valuable output you can produce.
+
+Return: `{ refuted, confident, reason, correction }`.

--- a/.claude/agents/clawbox-refuter.md
+++ b/.claude/agents/clawbox-refuter.md
@@ -1,10 +1,10 @@
 ---
 name: clawbox-refuter
 description: Adversarially verifies a single finding before anyone fixes it — reads the cited code on fresh origin/beta, may probe a box read-only, and defaults to REFUTED when uncertain. Use on every finding that will get a fix agent, and on any claim of "already fixed".
-model: opus
-tools: Read, Grep, Glob, Bash, WebFetch
+model: claude-opus-5
+tools: Read, Grep, Glob, Bash, WebFetch, Skill
 ---
-You try to break one claim. Read `CLAUDE.md` → **Working rules** first.
+You try to break one claim. Read `CLAUDE.md` → **Working rules** first. Your first act: confirm the model you are running on is Opus 5 or Fable 5 — on any other model, stop and return `refuted: true, confident: false, reason: "wrong model"`.
 
 - Fetch first and read from `origin/beta`; fixes merge constantly and the cited line may already be gone — "already fixed on beta by <commit>" is a valid refutation.
 - Confirm the defect exists as described, that the proposed fix removes it, and that the RED test would fail today for the stated reason.

--- a/.claude/workflows/fix-batch.js
+++ b/.claude/workflows/fix-batch.js
@@ -1,0 +1,44 @@
+export const meta = {
+  name: 'fix-batch',
+  description: 'Verify a list of findings with two refuters each, then fix the survivors in batches — per-item verdicts are returned in the result, findings are passed by file path, never sliced into a prompt',
+  phases: [{ title: 'Verify' }, { title: 'Fix' }],
+}
+// args: { briefsPath: "/abs/path/to/findings.json", ids: ["F-02", ...], batchSize?: 8 }
+// briefsPath must be a JSON array of { id, severity, title, evidence, fixBrief, redTest, siblingSites }.
+// Scripts cannot read files — agents read briefsPath themselves; that is deliberate (no truncation possible here).
+const ids = (args && args.ids) || []
+const briefs = args && args.briefsPath
+const batchSize = (args && args.batchSize) || 8
+if (!briefs || !ids.length) throw new Error('fix-batch needs args { briefsPath, ids }')
+
+const VERDICT = { type: 'object', required: ['refuted', 'confident', 'reason'], properties: { refuted: { type: 'boolean' }, confident: { type: 'boolean' }, reason: { type: 'string' }, correction: { type: 'string' } } }
+const RESULT = { type: 'object', required: ['id', 'outcome', 'summary'], properties: { id: { type: 'string' }, outcome: { type: 'string', enum: ['MERGED', 'PR_OPEN', 'REFUTED', 'BLOCKED', 'FAILED'] }, pr: { type: 'integer' }, mergeSha: { type: 'string' }, summary: { type: 'string' }, unproven: { type: 'string' } } }
+const LENSES = [
+  ['real', 'IS IT REAL AND IS THE FIX RIGHT? Read the cited file:line on freshly fetched origin/beta; refute if beta already fixed it, if the evidence does not support the claim, or if the fix is wrong.'],
+  ['scope', 'IS IT REALLY NO-DECISION AND IS THE BLAST RADIUS UNDERSTOOD? Refute if two competent engineers could disagree on what fixed looks like, if the fix could break the other edition or the dual SKU, or if the sibling-call-site list is obviously incomplete.'],
+]
+
+phase('Verify')
+const verified = await pipeline(ids, (id) => parallel(LENSES.map(([key, angle]) => () =>
+  agent('Verify the finding with id "' + id + '" in the JSON array at ' + briefs + ' (read the whole file, find your entry).\nYOUR LENS: ' + angle + '\nDefault to refuted=true when uncertain; confident=true only if you checked the code or the box yourself.',
+    { label: 'verify:' + id + '/' + key, phase: 'Verify', agentType: 'clawbox-refuter', schema: VERDICT })))
+  .then((vs) => { const live = vs.filter(Boolean); return { id, keep: !live.some((v) => v.refuted && v.confident), verdicts: live, corrections: live.map((v) => v.correction).filter(Boolean).join('\n') } }))
+
+const survivors = verified.filter(Boolean).filter((v) => v.keep)
+log(survivors.length + ' of ' + ids.length + ' survive verification')
+
+phase('Fix')
+const outcomes = []
+for (let i = 0; i < survivors.length; i += batchSize) {
+  const batch = survivors.slice(i, i + batchSize)
+  log('fix batch ' + (i / batchSize + 1) + ': ' + batch.map((v) => v.id).join(', '))
+  const res = await parallel(batch.map((v) => () =>
+    agent('Fix the finding with id "' + v.id + '" in the JSON array at ' + briefs + ' (read the whole file, find your entry).' + (v.corrections ? '\nCORRECTIONS FROM THE VERIFIERS — apply them:\n' + v.corrections : ''),
+      { label: 'fix:' + v.id, phase: 'Fix', agentType: 'clawbox-fixer', schema: RESULT })))
+  outcomes.push(...res.filter(Boolean))
+}
+return {
+  verdicts: verified.filter(Boolean).map((v) => ({ id: v.id, keep: v.keep, verdicts: v.verdicts })),
+  outcomes,
+  merged: outcomes.filter((o) => o.outcome === 'MERGED').length,
+}

--- a/.claude/workflows/fix-batch.js
+++ b/.claude/workflows/fix-batch.js
@@ -26,9 +26,10 @@ const verified = await pipeline(ids, (id) => parallel(LENSES.map(([key, angle]) 
     { label: 'verify:' + id + '/' + key, phase: 'Verify', agentType: 'clawbox-refuter', schema: VERDICT })))
   .then((vs) => {
     const live = vs.filter(Boolean)
-    // Every lens must have returned a schema-valid verdict; a missing verifier is not a pass.
+    // Every lens must have returned a schema-valid verdict AND confirmed the finding with confidence;
+    // a missing verifier, an uncertain one (refuted:true, confident:false) or a refutation all reject.
     const complete = live.length === LENSES.length
-    const keep = complete && !live.some((v) => v.refuted && v.confident)
+    const keep = complete && live.every((v) => v.confident && !v.refuted)
     return { id, keep, complete, verdicts: live, corrections: live.map((v) => v.correction).filter(Boolean).join('\n') }
   }))
 

--- a/.claude/workflows/fix-batch.js
+++ b/.claude/workflows/fix-batch.js
@@ -1,14 +1,16 @@
 export const meta = {
   name: 'fix-batch',
   description: 'Verify a list of findings with two refuters each, then fix the survivors in batches — per-item verdicts are returned in the result, findings are passed by file path, never sliced into a prompt',
-  phases: [{ title: 'Verify' }, { title: 'Fix' }],
+  phases: [{ title: 'Verify' }, { title: 'Fix' }, { title: 'Integrate' }],
 }
 // args: { briefsPath: "/abs/path/to/findings.json", ids: ["F-02", ...], batchSize?: 8 }
 // briefsPath must be a JSON array of { id, severity, title, evidence, fixBrief, redTest, siblingSites }.
 // Scripts cannot read files — agents read briefsPath themselves; that is deliberate (no truncation possible here).
 const ids = (args && args.ids) || []
 const briefs = args && args.briefsPath
-const batchSize = (args && args.batchSize) || 8
+// batchSize must be a positive integer; anything else (negative, fractional, string, huge) falls back so the loop always terminates.
+const rawBatch = Number(args && args.batchSize)
+const batchSize = Number.isInteger(rawBatch) && rawBatch > 0 ? Math.min(rawBatch, 16) : 8
 if (!briefs || !ids.length) throw new Error('fix-batch needs args { briefsPath, ids }')
 
 const VERDICT = { type: 'object', required: ['refuted', 'confident', 'reason'], properties: { refuted: { type: 'boolean' }, confident: { type: 'boolean' }, reason: { type: 'string' }, correction: { type: 'string' } } }
@@ -22,9 +24,17 @@ phase('Verify')
 const verified = await pipeline(ids, (id) => parallel(LENSES.map(([key, angle]) => () =>
   agent('Verify the finding with id "' + id + '" in the JSON array at ' + briefs + ' (read the whole file, find your entry).\nYOUR LENS: ' + angle + '\nDefault to refuted=true when uncertain; confident=true only if you checked the code or the box yourself.',
     { label: 'verify:' + id + '/' + key, phase: 'Verify', agentType: 'clawbox-refuter', schema: VERDICT })))
-  .then((vs) => { const live = vs.filter(Boolean); return { id, keep: !live.some((v) => v.refuted && v.confident), verdicts: live, corrections: live.map((v) => v.correction).filter(Boolean).join('\n') } }))
+  .then((vs) => {
+    const live = vs.filter(Boolean)
+    // Every lens must have returned a schema-valid verdict; a missing verifier is not a pass.
+    const complete = live.length === LENSES.length
+    const keep = complete && !live.some((v) => v.refuted && v.confident)
+    return { id, keep, complete, verdicts: live, corrections: live.map((v) => v.correction).filter(Boolean).join('\n') }
+  }))
 
 const survivors = verified.filter(Boolean).filter((v) => v.keep)
+const unverified = verified.filter(Boolean).filter((v) => !v.complete).map((v) => v.id)
+if (unverified.length) log('NOT verified (a verifier returned nothing; treated as refuted): ' + unverified.join(', '))
 log(survivors.length + ' of ' + ids.length + ' survive verification')
 
 phase('Fix')
@@ -35,8 +45,22 @@ for (let i = 0; i < survivors.length; i += batchSize) {
   const res = await parallel(batch.map((v) => () =>
     agent('Fix the finding with id "' + v.id + '" in the JSON array at ' + briefs + ' (read the whole file, find your entry).' + (v.corrections ? '\nCORRECTIONS FROM THE VERIFIERS — apply them:\n' + v.corrections : ''),
       { label: 'fix:' + v.id, phase: 'Fix', agentType: 'clawbox-fixer', schema: RESULT })))
-  outcomes.push(...res.filter(Boolean))
+  // A fixer that returned nothing (skipped, or died before reporting) still gets a per-item result.
+  res.forEach((r, k) => outcomes.push(r || { id: batch[k].id, outcome: 'FAILED', summary: 'fixer returned no result (skipped or died before reporting)' }))
 }
+
+phase('Integrate')
+// Fixers stop at PR_OPEN. Merges happen here, one at a time, each rebased on the beta the previous merge produced,
+// so no merge can invalidate another PR's rebase or CI result.
+const INTEGRATED = { type: 'object', required: ['id', 'outcome', 'summary'], properties: { id: { type: 'string' }, outcome: { type: 'string', enum: ['MERGED', 'PR_OPEN', 'FAILED'] }, pr: { type: 'integer' }, mergeSha: { type: 'string' }, summary: { type: 'string' } } }
+for (const o of outcomes) {
+  if (o.outcome !== 'PR_OPEN' || !o.pr) continue
+  const r = await agent('Integrate PR #' + o.pr + ' (finding ' + o.id + ') into beta, alone. Read CLAUDE.md → Working rules first. Steps: fetch; if the PR branch is behind origin/beta, rebase it onto origin/beta in its worktree (../clawbox-wt-' + o.id + ' if present, otherwise a fresh worktree) and push with --force-with-lease to the PR branch only; wait for CI and CodeRabbit to be green and addressed; merge with a merge commit; remove the worktree. Outcome MERGED with the merge SHA; PR_OPEN if CI is still red after one honest attempt to fix it; FAILED if the merge cannot happen. Never touch beta or main directly.',
+    { label: 'integrate:' + o.id, phase: 'Integrate', schema: INTEGRATED })
+  if (r) Object.assign(o, r)
+  else o.summary += ' | integrator returned no result; PR left open'
+}
+
 return {
   verdicts: verified.filter(Boolean).map((v) => ({ id: v.id, keep: v.keep, verdicts: v.verdicts })),
   outcomes,

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,10 @@ playwright-report/
 test-results/
 e2e-install/cache/
 scripts/nm-dispatcher-failover.sh
-.claude/
+# Claude Code: local state stays ignored; shared agents and workflows are tracked
+.claude/*
+!.claude/agents/
+!.claude/workflows/
 
 # Local debug scripts (per-session sandbox)
 .scratch/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Read before doing anything else in this repository. Every agent, workflow subage
 - This repository is public. Never commit or print a device password, token, address or personal identifier; a credential lives in a 0600 file outside the tree and reaches a command only by file, never on a command line.
 
 **The PR flow, for every fix**
-1. RED — a regression test that fails on unmodified beta; paste the failing output. If it passes, the finding is wrong: report that instead of inventing a fix.
+1. RED — a regression test that fails on unmodified beta; paste the failing output, redacted of anything the rule above forbids (credentials, addresses, identifiers), and say when lines were removed. If it passes, the finding is wrong: report that instead of inventing a fix.
 2. Fix, then grep for every other caller of what you touched and fix or explicitly clear each one. The last twenty-one residual defects here were all "the fix was right but a second call site was left unguarded".
 3. GREEN — the new test and the neighbouring suites.
 4. `/simplify` on the diff, applied. Then `/code-review` on the diff, run from the worktree; the review is read-only — apply its findings yourself.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,35 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Working rules
+
+Read before doing anything else in this repository. Every agent, workflow subagent and coding-agent run is bound by these.
+
+**Branches and commits**
+- Target `beta`. Never commit to or delete `main` or `beta` directly; every change is a PR to `beta`, merged with a merge commit. Base every branch on freshly fetched `origin/beta` and rebase before pushing — beta moves constantly, and a conflicting PR silently stops CI from running.
+- Work in a worktree: `git worktree add ../clawbox-wt-<id> -b <type>/<id>-<slug> origin/beta`. **Never `git stash`** — the stash list is shared across every worktree and one agent's stash lands in another's tree.
+- Commits are authored from git config. Never pass `--author` or `-c user.email`. No AI attribution anywhere: no generated-by footer, no `Co-Authored-By`, and no assistant name in any commit message, PR title or PR body. Commit format `type: description`.
+- This repository is public. Never commit or print a device password, token, address or personal identifier; a credential lives in a 0600 file outside the tree and reaches a command only by file, never on a command line.
+
+**The PR flow, for every fix**
+1. RED — a regression test that fails on unmodified beta; paste the failing output. If it passes, the finding is wrong: report that instead of inventing a fix.
+2. Fix, then grep for every other caller of what you touched and fix or explicitly clear each one. The last twenty-one residual defects here were all "the fix was right but a second call site was left unguarded".
+3. GREEN — the new test and the neighbouring suites.
+4. `/simplify` on the diff, applied. Then `/code-review` on the diff, run from the worktree; the review is read-only — apply its findings yourself.
+5. Push, open the PR; wait for CI (`e2e-install` takes 16–22 minutes) and CodeRabbit; address or explicitly refute every actionable comment in-thread; merge.
+
+**The three bug classes this codebase keeps producing**
+- *Probe-once*: a capability checked once at startup and treated as fact for the process lifetime.
+- *False success*: an exit code, a `200`, `|| true` or `|| echo WARN` read as an outcome; success reported before the thing happened.
+- *False failure*: an error reported over an operation that succeeded.
+Look for all three in every diff, and for the sibling call site of every fix.
+
+**Where things run**
+- Build, test and typecheck **on a device**, not on the development PC; unit suites run in CI. Device access goes only through the `clawbox-box` skill (shell, owner session, mutex, update) — never a hand-rolled SSH.
+- Take the device mutex only while mutating a box, write who and why, release it on the way out including on failure; if it is held, wait, never steal. Restore anything you change and prove it by diffing before and after. Never send or queue an email, change a channel, reset or reboot a box unless that is the task.
+- Agents run on Opus 5 or Fable 5 only; if a task resolves to any other model, stop it.
+- Findings handed to another agent go by **file path**, never sliced into a prompt; a truncated list has twice silently dropped real defects here.
+
 ## Project
 
 ClawBox is **OpenClaw OS** — the operating system for [OpenClaw Hardware](https://clawbox.com/), a private AI assistant running on NVIDIA Jetson (Tegra/ARM). It manages the full device lifecycle: broadcasts a WiFi access point with captive portal for first-boot setup from any phone/laptop, transitions to the home network, then serves a Chrome OS-style desktop environment with built-in apps. The OpenClaw AI agent controls the entire device through MCP (Model Context Protocol) tools — making ClawBox an OS the AI can operate, not just a UI the user clicks through.


### PR DESCRIPTION
## Summary

An audit of this week's sessions found the repo's CLAUDE.md is a 32 KB architecture map containing none of the working rules every agent is re-briefed with (target beta, worktrees, never stash, no --author, the PR flow, the sibling-call-site rule, the three bug classes, device discipline, model rule). This PR:

- adds a **Working rules** section at the top of `CLAUDE.md` — rules only; nothing environment-specific, no addresses or credentials (the repo is public);
- adds three project-scoped agents in `.claude/agents/`: `clawbox-fixer` (the PR flow end to end), `clawbox-refuter` (adversarial verification, read-only, defaults to refuted), `clawbox-device-lane` (owns one box under the mutex, restores and proves);
- adds `.claude/workflows/fix-batch.js`: two refuters per finding, then fixes in bounded batches; per-item verdicts are returned in the result and findings are passed by file path, never sliced into a prompt — the two failure modes that cost real defects this week;
- narrows `.gitignore` from `.claude/` to `.claude/*` with `agents/` and `workflows/` tracked; worktrees and local settings stay ignored.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation / tooling

## How was this tested?
Docs and agent definitions; no product code. `git check-ignore` confirms `.claude/worktrees/` and `.claude/settings.local.json` remain ignored and the two new directories are tracked. The agents reference the local `clawbox-box` skill by name only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide guidance for branch management, credential handling, validation, device access, and contribution workflows.
  * Documented procedures for device testing, finding verification, fix implementation, and result reporting.
  * Added standardized outcome and handoff expectations for automated investigations and remediation.
  * Added specialized guidance for testing, fixing, and adversarially reviewing device-related findings.

* **Chores**
  * Added an automated workflow to verify findings, process confirmed issues in batches, integrate fixes, and summarize results.
  * Updated repository rules to track shared automation guidance while excluding local tool state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->