### PR TITLE
fix(configure): restart the gateway when a subscription save fails after doctor --fix stopped it

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1216,7 +1216,60 @@ async function applyCloudProviderTransport(opts: {
   return false;
 }
 
+/**
+ * Where the OpenClaw branch of one request has left clawbox-gateway.
+ *
+ * `runOpenclawDoctorFix` stops the unit before `doctor --fix` migrates the
+ * auth store the gateway holds open, and the matching restart is step 9 at
+ * the very end of the save. systemd does not start a unit again after an
+ * explicit `stop`, so every error exit between the two — the 502 rollback when
+ * doctor fails, the 400 profile-key refusal, any 500 from the config-set batch
+ * — used to answer with the gateway down: chat and every channel stayed dead
+ * until a reboot or a later save that happened to succeed (F-07).
+ */
+type GatewayState =
+  /** Nothing touched it: every early exit, and the API-key path before step 9. */
+  | "untouched"
+  /** Stopped for `doctor --fix`; no later step has restarted it. */
+  | "stopped-for-doctor"
+  /** Step 9 issued its restart — it came up, or step 9 answered its own 502. */
+  | "restart-issued";
+
+/** Folded into the error the owner sees when the restore itself fails. */
+const GATEWAY_OFFLINE_HINT =
+  "The assistant is offline until the gateway restarts — use Restart in the system tray.";
+
 export async function POST(request: Request) {
+  const gateway: { state: GatewayState } = { state: "untouched" };
+  const response = await configureModel(request, gateway);
+  if (gateway.state !== "stopped-for-doctor") return response;
+  // An error exit between the doctor stop and step 9. Only `restart` is
+  // granted to the clawbox user (config/clawbox-sudoers has no `start`), and
+  // it runs AFTER the rollback archived the legacy file, so the gateway does
+  // not boot straight into the AuthProfileMigrationRequired it would have hit.
+  try {
+    await restartGateway();
+    return response;
+  } catch (err) {
+    // A runtime mask (an update in flight) refuses the restart; never unmask
+    // from here. The save already failed — tell the owner what is left to do.
+    console.error(
+      "[configure] Gateway restart after the failed save also failed:",
+      err instanceof Error ? logSafe(err.message) : err,
+    );
+    return withGatewayOfflineHint(response);
+  }
+}
+
+async function withGatewayOfflineHint(response: Response): Promise<Response> {
+  const body = (await response.json().catch(() => ({}))) as { error?: unknown };
+  const error = typeof body.error === "string"
+    ? `${body.error} ${GATEWAY_OFFLINE_HINT}`
+    : GATEWAY_OFFLINE_HINT;
+  return NextResponse.json({ ...body, error }, { status: response.status });
+}
+
+async function configureModel(request: Request, gateway: { state: GatewayState }): Promise<Response> {
   // Hoisted so the catch can classify the failure without re-parsing the body —
   // a local-model or wrong-edition failure must not be reported as a credential
   // problem (there is no credential to check).
@@ -1928,6 +1981,9 @@ export async function POST(request: Request) {
       // proof; an early doctor failure may create none, so the installed binary
       // version is the second authority. An explicit v1 keeps its legitimate
       // legacy file and the old best-effort behavior.
+      // The stop inside is unconditional; POST restores the unit if no later
+      // step restarts it.
+      gateway.state = "stopped-for-doctor";
       try {
         await runOpenclawDoctorFix();
       } catch (doctorErr) {
@@ -2419,6 +2475,7 @@ export async function POST(request: Request) {
     // un-migrated auth store.)
 
     // 9. Restart OpenClaw gateway so it picks up the new auth profile and model
+    gateway.state = "restart-issued";
     try {
       await restartGateway();
     } catch (err) {

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1244,7 +1244,25 @@ const GATEWAY_OFFLINE_HINT =
 
 export async function POST(request: Request) {
   const gateway: GatewayTracker = { state: "untouched" };
-  const response = await configureModel(request, gateway);
+  let response: Response;
+  try {
+    response = await configureModel(request, gateway);
+  } catch (err) {
+    // `configureModel` answers a Response for every failure it can classify, so
+    // reaching here means its own catch block threw. Restoring only off the
+    // returned value would leave the gateway stopped on exactly that path —
+    // the failure this whole tracker exists to prevent. Restore, then let the
+    // original throw become Next's generic 500.
+    if (gateway.state === "stopped-for-doctor") {
+      await restartGateway().catch((restartErr) => {
+        console.error(
+          "[configure] Gateway restart after an unhandled save failure also failed:",
+          restartErr instanceof Error ? logSafe(restartErr.message) : restartErr,
+        );
+      });
+    }
+    throw err;
+  }
   if (gateway.state !== "stopped-for-doctor") return response;
   // An error exit between the doctor stop and step 9. Only `restart` is
   // granted to the clawbox user (config/clawbox-sudoers has no `start`), and

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1235,12 +1235,15 @@ type GatewayState =
   /** Step 9 issued its restart — it came up, or step 9 answered its own 502. */
   | "restart-issued";
 
+/** Shared by reference: `configureModel` has too many exits to return it. */
+type GatewayTracker = { state: GatewayState };
+
 /** Folded into the error the owner sees when the restore itself fails. */
 const GATEWAY_OFFLINE_HINT =
   "The assistant is offline until the gateway restarts — use Restart in the system tray.";
 
 export async function POST(request: Request) {
-  const gateway: { state: GatewayState } = { state: "untouched" };
+  const gateway: GatewayTracker = { state: "untouched" };
   const response = await configureModel(request, gateway);
   if (gateway.state !== "stopped-for-doctor") return response;
   // An error exit between the doctor stop and step 9. Only `restart` is
@@ -1269,7 +1272,7 @@ async function withGatewayOfflineHint(response: Response): Promise<Response> {
   return NextResponse.json({ ...body, error }, { status: response.status });
 }
 
-async function configureModel(request: Request, gateway: { state: GatewayState }): Promise<Response> {
+async function configureModel(request: Request, gateway: GatewayTracker): Promise<Response> {
   // Hoisted so the catch can classify the failure without re-parsing the body —
   // a local-model or wrong-edition failure must not be reported as a credential
   // problem (there is no credential to check).

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -609,6 +609,21 @@ describe("POST /setup-api/ai-models/configure and the gateway doctor --fix stopp
     expect(restartGateway).toHaveBeenCalledTimes(1);
   });
 
+  it("restarts the gateway when the route's own error handling throws", async () => {
+    // The handler's catch classifies the failure and logs `logSafe(err.message)`,
+    // which reads `.length` — an Error carrying a null message makes the catch
+    // itself throw, so nothing returns a Response and the restore that hangs off
+    // the return value never runs. Contrived on purpose: it is the one shape that
+    // reaches past the catch today, and without it any future await added to that
+    // block would silently re-open F-07 with the gateway left down.
+    const poisoned = new Error("boom") as unknown as { message: unknown };
+    poisoned.message = null;
+    vi.mocked(runOpenclawConfigSetBatch).mockRejectedValueOnce(poisoned);
+
+    await expect(configurePost(subscribe())).rejects.toThrow();
+    expect(restartGateway).toHaveBeenCalledTimes(1);
+  });
+
   it("tells the owner the assistant is offline when that restart fails too", async () => {
     vi.mocked(runOpenclawDoctorFix).mockRejectedValueOnce(new Error("doctor exited 1"));
     mockFs.readdir.mockResolvedValueOnce([MIGRATED_SIBLING] as never);

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -22,6 +22,7 @@ vi.mock("fs/promises", () => ({
     mkdir: vi.fn(),
     rm: vi.fn(),
     unlink: vi.fn(),
+    readdir: vi.fn(),
   },
 }));
 
@@ -119,6 +120,7 @@ import {
   restartGateway,
   runOpenclawConfigSet,
   runOpenclawConfigSetBatch,
+  runOpenclawDoctorFix,
   applyModelOverrideToAllAgentSessions,
   inferConfiguredLocalModel,
   setProviderPlugins,
@@ -205,6 +207,16 @@ function jsonRequest(body: unknown): Request {
   });
 }
 
+/** The wizard's Claude sign-in save, with `body` overriding its fields. */
+function subscribe(body: Record<string, unknown> = {}) {
+  return jsonRequest({
+    provider: "anthropic",
+    apiKey: "oauth-access-token",
+    authMode: "subscription",
+    ...body,
+  });
+}
+
 /**
  * Every mock this route needs, back to its happy-path default, plus a freshly
  * imported handler. Module-level because BOTH subscription surfaces are tested
@@ -221,6 +233,7 @@ async function primeConfigureRoute(): Promise<(request: Request) => Promise<Resp
   mockFs.mkdir.mockResolvedValue(undefined);
   mockFs.rm.mockResolvedValue(undefined);
   mockFs.unlink.mockResolvedValue(undefined);
+  mockFs.readdir.mockResolvedValue([]);
   mockSurfaceRead.mockImplementation(
     ((filePath: string) => Promise.resolve(cacheFileFor(String(filePath)))) as never,
   );
@@ -262,16 +275,6 @@ function expectNoSideEffects() {
  */
 describe("POST /setup-api/ai-models/configure and the Claude subscription surface", () => {
   let configurePost: (request: Request) => Promise<Response>;
-
-  /** The wizard's Claude sign-in save, with `body` overriding its fields. */
-  function subscribe(body: Record<string, unknown> = {}) {
-    return jsonRequest({
-      provider: "anthropic",
-      apiKey: "oauth-access-token",
-      authMode: "subscription",
-      ...body,
-    });
-  }
 
   beforeEach(async () => {
     configurePost = await primeConfigureRoute();
@@ -555,5 +558,104 @@ describe("POST /setup-api/ai-models/configure and the ChatGPT subscription surfa
     const res = await configurePost(chatgptSignIn());
 
     expect(res.status).toBe(200);
+  });
+});
+
+/**
+ * F-07. `runOpenclawDoctorFix` STOPS clawbox-gateway before `doctor --fix`
+ * migrates the auth store the gateway holds open, and the route's only restart
+ * was step 9 at the very end. Every error exit in between — the 502 rollback
+ * when doctor fails, the 400 profile-key refusal, any 500 from the config-set
+ * batch — answered with the unit still stopped, and systemd does not start a
+ * unit again after an explicit `stop`. Chat and every channel stayed dead
+ * until a reboot or a later save that happened to succeed.
+ */
+describe("POST /setup-api/ai-models/configure and the gateway doctor --fix stopped", () => {
+  let configurePost: (request: Request) => Promise<Response>;
+
+  /** What `doctor --fix` leaves behind once it has migrated an OpenClaw 2 store. */
+  const MIGRATED_SIBLING = "auth-profiles.json.migrated-2026-09-01T00-00-00-000Z";
+
+  beforeEach(async () => {
+    configurePost = await primeConfigureRoute();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("restarts the gateway when doctor --fix fails and the sign-in is rolled back", async () => {
+    vi.mocked(runOpenclawDoctorFix).mockRejectedValueOnce(new Error("doctor exited 1"));
+    // A migrated sibling proves an OpenClaw 2 store: the route archives the
+    // legacy file and answers 502 — the exit the owner actually hit.
+    mockFs.readdir.mockResolvedValueOnce([MIGRATED_SIBLING] as never);
+
+    const res = await configurePost(subscribe());
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toMatch(/rolled back/);
+    expect(restartGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("restarts the gateway when a later step throws after doctor --fix stopped it", async () => {
+    vi.mocked(runOpenclawConfigSetBatch).mockRejectedValueOnce(
+      new Error("config set --batch-json exited 1"),
+    );
+
+    const res = await configurePost(subscribe());
+
+    expect(res.status).toBe(500);
+    expect(restartGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("tells the owner the assistant is offline when that restart fails too", async () => {
+    vi.mocked(runOpenclawDoctorFix).mockRejectedValueOnce(new Error("doctor exited 1"));
+    mockFs.readdir.mockResolvedValueOnce([MIGRATED_SIBLING] as never);
+    // An updater holds a runtime mask on the unit: restart is refused and this
+    // route must not unmask it.
+    vi.mocked(restartGateway).mockRejectedValueOnce(
+      new Error("Unit clawbox-gateway.service is masked."),
+    );
+
+    const res = await configurePost(subscribe());
+
+    expect(res.status).toBe(502);
+    const { error } = await res.json();
+    expect(error).toMatch(/rolled back/);
+    expect(error).toMatch(/offline until the gateway restarts/);
+  });
+
+  it("restarts the gateway exactly once on a save that lands", async () => {
+    // The restore must not add a second full gateway cycle (pre-start script
+    // plus boot, 30 s+ on a Jetson) to every successful subscription save.
+    const res = await configurePost(subscribe());
+
+    expect(res.status).toBe(200);
+    expect(restartGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a restart that step 9 already reported as failed", async () => {
+    vi.mocked(restartGateway).mockRejectedValueOnce(new Error("Start request repeated too quickly"));
+
+    const res = await configurePost(subscribe());
+
+    expect(res.status).toBe(502);
+    expect((await res.json()).error).toMatch(/failed to restart/);
+    expect(restartGateway).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the gateway alone when an API-key save fails — nothing stopped it", async () => {
+    // The API-key path pastes through the CLI and never runs doctor, so a
+    // failure there has no stopped unit to restore.
+    vi.mocked(runOpenclawConfigSetBatch).mockRejectedValueOnce(
+      new Error("config set --batch-json exited 1"),
+    );
+
+    const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-ant-test" }));
+
+    expect(res.status).toBe(500);
+    expect(runOpenclawDoctorFix).not.toHaveBeenCalled();
+    expect(restartGateway).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Finding **F-07** (severity high, OpenClaw edition).

## Symptom

An Anthropic or ChatGPT subscription sign-in that fails part-way leaves the box with no assistant: chat and every channel (Telegram, Discord, email) stay dead until the owner reboots the device or a later save happens to succeed. The Settings/wizard error the owner sees (`502 Credential migration failed…`, `400 Invalid profile key format`, or the generic `500`) says nothing about that.

Measured on a 2026.8.1 box: `sudo -n -l` grants the `clawbox` user `systemctl stop clawbox-gateway.service` (and `restart`, but no `start`); `auth-profiles.json.migrated-*` siblings exist, so a failed `doctor --fix` takes the 502 rollback exit.

## Cause

`runOpenclawDoctorFix()` (`src/lib/openclaw-config.ts`) stops `clawbox-gateway.service` before `doctor --fix` migrates the auth store the gateway holds open. In `src/app/setup-api/ai-models/configure/route.ts` the only matching restart was step 9 at the very end of the save. Every exit between the two — the 502 rollback when doctor fails, the 400 profile-key refusal, any throw from the config-set batch or a later step reaching the outer catch — returned with the unit still stopped, and systemd does not start a unit again after an explicit `stop`.

## Fix

`POST` now tracks where the request left the gateway (`untouched` → `stopped-for-doctor` right before the doctor call → `restart-issued` at step 9) and, on any exit that stopped it without restarting it, issues the one granted verb, `restartGateway()`. Properties the tests pin:

- a save that lands still restarts exactly once (no second pre-start + boot cycle on a Jetson);
- a step-9 restart that already failed is not retried;
- the API-key path never ran doctor, so a failure there never touches the unit;
- the restore runs after the rollback has archived the legacy `auth-profiles.json`, so the gateway does not boot straight into `AuthProfileMigrationRequiredError`;
- when the restore itself is refused (an updater's runtime mask — never unmasked from here) the error body says the assistant is offline until the gateway restarts, and where the Restart control is.

Sibling sites checked: the updater's own `runOpenclawDoctorFix` runs inside `withGatewayQuiesced` and is always followed by `restartGateway()` (a failed pre-start migration is deliberately fatal there); `setup/reset` stops the gateway as part of the factory reset; `install.sh` and `setup-hermes-edition.sh` restart in the same script. The Hermes edition is unaffected: `runOpenclawDoctorFix` and `restartGateway` are no-ops via `gatewayIsAbsent()`.

## Evidence

**RED** — `src/tests/routes/ai-models/configure-subscription-surface.test.ts` (new `doctor --fix stopped` block) against the route from unmodified `origin/beta` (47356167):

```
 × restarts the gateway when doctor --fix fails and the sign-in is rolled back
 × restarts the gateway when a later step throws after doctor --fix stopped it
 × tells the owner the assistant is offline when that restart fails too
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
AssertionError: expected 'Credential migration failed. The subs…' to match /offline until the gateway restarts/
 Test Files  1 failed (1)
      Tests  3 failed | 21 passed (24)
```

**GREEN** — with the fix: `configure-subscription-surface.test.ts` 24/24; every `src/tests/routes/ai-models/` suite 14 files / 258 tests green; `tsc --noEmit` clean; ESLint 0 errors on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved AI model configuration recovery when the gateway is temporarily stopped during subscription setup.
  - The gateway now attempts to restart after migration or later configuration failures.
  - Added clearer offline-recovery guidance when the gateway cannot be restarted.
  - Prevented duplicate gateway restart attempts.
  - API-key configuration remains unaffected.
  - Improved handling of OAuth doctor migration failures so the gateway can be restored reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->