### PR TITLE
fix: repoint OpenClaw 2 sessions through the gateway instead of rewriting the store

### DIFF
--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -1,11 +1,18 @@
 export const dynamic = "force-dynamic";
 
 import fs from "fs/promises";
-import { listAgentIds, sessionStorePath, sweepSessionEntries } from "@/lib/openclaw-session-store";
+import { listAgentIds, readSessionEntries, sessionStorePath } from "@/lib/openclaw-session-store";
+import {
+  isPatchableSession,
+  patchSessionModels,
+  sessionModelRef,
+  type SessionPatchTarget,
+} from "@/lib/openclaw-session-model";
 import path from "path";
 import { NextResponse } from "next/server";
 import { get, set, setMany } from "@/lib/config-store";
 import {
+  callGatewayRpc,
   gatewayIsAbsent,
   readConfig,
   restartGateway,
@@ -44,6 +51,22 @@ type SessionOverrideField = (typeof SESSION_OVERRIDE_FIELDS)[number];
 type SessionOverrideSnapshot = Partial<Record<SessionOverrideField, unknown>>;
 type SessionsFileBackup = Record<string, SessionOverrideSnapshot>;
 type FilesBackup = Record<string, SessionsFileBackup>;
+
+/**
+ * The override fields a session carries right now, for the backup. Uses an
+ * own-property check so "field explicitly set to null" stays distinct from
+ * "field absent": on restore, absent fields are deleted rather than written
+ * as null.
+ */
+function snapshotOverrides(session: Record<string, unknown>): SessionOverrideSnapshot {
+  const snapshot: SessionOverrideSnapshot = {};
+  for (const field of SESSION_OVERRIDE_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(session, field)) {
+      snapshot[field] = session[field];
+    }
+  }
+  return snapshot;
+}
 
 // Route OpenClaw config mutations through the shared retry-aware helper.
 // The gateway reload + gateway-pre-start.sh write the same config file
@@ -120,49 +143,73 @@ async function readSessionsJson(
 }
 
 /**
- * For every entry in every `sessions.json` on disk, replace the model
- * and provider override fields with the Local-only target, and return
- * a backup of the prior values (per file, per session key) so the
- * toggle can be reversed later.
+ * Repoint every existing session to the Local-only target and return a
+ * backup of the prior override values (per store or file, per session key)
+ * so the toggle can be reversed later.
  *
- * Sessions that were already pointing at a local provider are left
- * untouched but still recorded in the backup with their exact prior
- * values, so flipping back and forth preserves them.
+ * OpenClaw 2 agents keep their sessions in a SQLite store the gateway alone
+ * may write (see openclaw-session-store.ts), so they are switched through
+ * `sessions.patchMany`; the backup key is the synthetic `sqlite:<agentId>`
+ * and restore routes it back through the gateway. Legacy agents get the
+ * `sessions.json` rewrite.
+ *
+ * Sessions that were already pointing at a local provider are still
+ * recorded in the backup with their exact prior values, so flipping back
+ * and forth preserves them.
+ *
+ * `sessionsSkipped` counts the sessions the gateway would not switch (each
+ * one logged with its reason). They still route to their previous provider,
+ * which for Local-only is a privacy claim, not a routing detail — so the
+ * caller says so.
  */
 async function patchAllSessionOverrides(
   localProvider: string,
   localModelId: string,
-): Promise<FilesBackup> {
+): Promise<{ backup: FilesBackup; sessionsSkipped: number }> {
   const filesBackup: FilesBackup = {};
-  // OpenClaw 2 agents keep their sessions in SQLite. The sweep and its
-  // backup work exactly as for the legacy files; the backup key is the
-  // synthetic `sqlite:<agentId>` and restore routes it back to the store.
+  let sessionsSkipped = 0;
+  const localModel = `${localProvider}/${localModelId}`;
+  // An agent with a store is served from it whatever else is on disk: its
+  // leftover sessions.json is an archive the gateway no longer reads. Patching
+  // that too would record the same agent twice, and a restore routed through
+  // the store for the archive's entry would push pre-migration values over
+  // live sessions.
+  const migratedAgents = new Set<string>();
   for (const agentId of listAgentIds(AGENTS_DIR)) {
     if (!sessionStorePath(agentId, AGENTS_DIR)) continue;
+    migratedAgents.add(agentId);
+    const rows = readSessionEntries(agentId, AGENTS_DIR);
+    if (!rows) {
+      console.error(`[local-only] could not list the sessions of agent ${agentId}; they keep their previous model`);
+      continue;
+    }
+    const snapshots: SessionsFileBackup = {};
+    const targets: SessionPatchTarget[] = [];
+    for (const { key, entry } of rows) {
+      if (!isPatchableSession(entry)) continue;
+      snapshots[key] = snapshotOverrides(entry);
+      targets.push({ key, agentId });
+    }
+    if (targets.length === 0) continue;
     const fileBackup: SessionsFileBackup = {};
-    const swept = sweepSessionEntries(agentId, (sessionKey, session) => {
-      const snapshot: SessionOverrideSnapshot = {};
-      for (const field of SESSION_OVERRIDE_FIELDS) {
-        if (Object.prototype.hasOwnProperty.call(session, field)) {
-          snapshot[field] = session[field];
-        }
+    for (const outcome of await patchSessionModels(targets, localModel, { call: callGatewayRpc })) {
+      if (!outcome.ok) {
+        sessionsSkipped += 1;
+        console.error(
+          `[local-only] session ${outcome.key} (agent ${agentId}) keeps its previous model:`,
+          outcome.error,
+        );
+        continue;
       }
-      fileBackup[sessionKey] = snapshot;
-      session.providerOverride = localProvider;
-      session.modelOverride = localModelId;
-      session.modelOverrideSource = "manual";
-      session.authProfileOverride = `${localProvider}:default`;
-      session.authProfileOverrideSource = "manual";
-      session.modelProvider = localProvider;
-      session.model = localModelId;
-      return true;
-    }, AGENTS_DIR);
-    // A failed sweep wrote nothing (single transaction) - recording its
-    // backup would let a later restore write stale values over sessions
-    // this pass never touched.
-    if (swept?.ok) filesBackup[`sqlite:${agentId}`] = fileBackup;
+      // Only a session the gateway actually switched is recorded: restoring
+      // a snapshot over one this pass never changed would write stale values.
+      fileBackup[outcome.key] = snapshots[outcome.key];
+    }
+    if (Object.keys(fileBackup).length > 0) filesBackup[`sqlite:${agentId}`] = fileBackup;
   }
-  const files = await listSessionsFiles();
+  const files = (await listSessionsFiles()).filter(
+    (file) => !migratedAgents.has(path.basename(path.dirname(path.dirname(file)))),
+  );
   for (const file of files) {
     const parsed = await readSessionsJson(file, "patch");
     if (!parsed) continue;
@@ -170,18 +217,7 @@ async function patchAllSessionOverrides(
     const fileBackup: SessionsFileBackup = {};
     for (const [sessionKey, session] of Object.entries(parsed)) {
       if (!session || typeof session !== "object") continue;
-
-      const snapshot: SessionOverrideSnapshot = {};
-      for (const field of SESSION_OVERRIDE_FIELDS) {
-        // Use Object.prototype.hasOwnProperty-style check so we can tell
-        // "field explicitly set to null" apart from "field absent". On
-        // restore, absent fields are deleted rather than written as null.
-        if (Object.prototype.hasOwnProperty.call(session, field)) {
-          snapshot[field] = session[field];
-        }
-      }
-      fileBackup[sessionKey] = snapshot;
-
+      fileBackup[sessionKey] = snapshotOverrides(session);
       session.providerOverride = localProvider;
       session.modelOverride = localModelId;
       session.modelOverrideSource = "manual";
@@ -198,7 +234,7 @@ async function patchAllSessionOverrides(
       console.error(`[local-only] Failed to write patched sessions file ${file}:`, err);
     }
   }
-  return filesBackup;
+  return { backup: filesBackup, sessionsSkipped };
 }
 
 /**
@@ -207,31 +243,60 @@ async function patchAllSessionOverrides(
  * prior value — or delete it entirely if it was absent before.
  *
  * Sessions that have appeared since the backup was taken are left alone
- * (no backup entry → nothing to restore → user's current state wins).
+ * (no backup entry → nothing to restore → user's current state wins), and
+ * so are sessions that have since been deleted (nothing left to restore —
+ * and the core keeps a placeholder for a deleted key, which a patch would
+ * turn back into a session).
+ *
+ * `complete` is false only for a failure worth retrying: a gateway that
+ * refused for now, or a legacy file that could not be written. A refusal
+ * that will not change is counted in `sessionsKept` — those sessions stay
+ * on the local model, and the toggle still finishes, because a switch the
+ * owner can never move off is worse than a chat they can reset.
  */
-async function restoreSessionOverrides(backup: FilesBackup): Promise<boolean> {
-  let allOk = true;
-  const restoreIntoStore = (agentId: string, sessions: SessionsFileBackup) => {
-    const swept = sweepSessionEntries(agentId, (sessionKey, session) => {
-      const snapshot = sessions[sessionKey];
-      if (!snapshot) return false;
-      for (const field of SESSION_OVERRIDE_FIELDS) {
-        if (Object.prototype.hasOwnProperty.call(snapshot, field)) {
-          session[field] = snapshot[field];
-        } else {
-          delete session[field];
-        }
+async function restoreSessionOverrides(
+  backup: FilesBackup,
+): Promise<{ complete: boolean; sessionsKept: number }> {
+  let complete = true;
+  let sessionsKept = 0;
+  // Through the gateway, a session goes back to the `<provider>/<model>` its
+  // snapshot pinned, or — when it had no pin — to the agent default (`model:
+  // null`), which is the primary restored alongside. One patchMany per
+  // distinct target keeps this to a couple of CLI calls, not one per session.
+  const restoreIntoStore = async (agentId: string, sessions: SessionsFileBackup) => {
+    const rows = readSessionEntries(agentId, AGENTS_DIR);
+    if (!rows) {
+      // Cannot tell which of these sessions still exist; patching blind could
+      // recreate a deleted one. Keep the snapshot for a later attempt.
+      complete = false;
+      console.error(`[local-only] could not list the sessions of agent ${agentId}; its restore is deferred`);
+      return;
+    }
+    const live = new Map(rows.map((row) => [row.key, row.entry]));
+    const byModel = new Map<string | null, SessionPatchTarget[]>();
+    for (const [key, snapshot] of Object.entries(sessions)) {
+      const entry = live.get(key);
+      if (!entry || !isPatchableSession(entry)) continue;
+      const model = sessionModelRef(snapshot);
+      const group = byModel.get(model);
+      if (group) group.push({ key, agentId });
+      else byModel.set(model, [{ key, agentId }]);
+    }
+    for (const [model, targets] of byModel) {
+      for (const outcome of await patchSessionModels(targets, model, { call: callGatewayRpc })) {
+        if (outcome.ok) continue;
+        if (outcome.retryable) complete = false;
+        else sessionsKept += 1;
+        console.error(
+          `[local-only] session ${outcome.key} (agent ${agentId}) could not be switched back${outcome.retryable ? " yet" : ""}:`,
+          outcome.error,
+        );
       }
-      return true;
-    }, AGENTS_DIR);
-    if (!swept?.ok) {
-      allOk = false;
-      console.error(`[local-only] SQLite restore did not complete for agent ${agentId}`);
     }
   };
   for (const [file, sessions] of Object.entries(backup)) {
     if (file.startsWith("sqlite:")) {
-      restoreIntoStore(file.slice("sqlite:".length), sessions);
+      await restoreIntoStore(file.slice("sqlite:".length), sessions);
       continue;
     }
     const parsed = await readSessionsJson(file, "restore");
@@ -243,7 +308,7 @@ async function restoreSessionOverrides(backup: FilesBackup): Promise<boolean> {
       // silently leaving every session pinned to the local model.
       const agentId = path.basename(path.dirname(path.dirname(file)));
       if (agentId && sessionStorePath(agentId, AGENTS_DIR)) {
-        restoreIntoStore(agentId, sessions);
+        await restoreIntoStore(agentId, sessions);
       }
       continue;
     }
@@ -263,18 +328,20 @@ async function restoreSessionOverrides(backup: FilesBackup): Promise<boolean> {
     try {
       await atomicWriteJson(file, parsed);
     } catch (err) {
-      // A legacy write that failed is exactly as incomplete as a refused
-      // SQLite sweep: the caller must keep the snapshot and the mode.
-      allOk = false;
+      // A legacy write that failed is exactly as incomplete as a session the
+      // gateway would not switch back yet: the caller must keep the snapshot
+      // and the mode.
+      complete = false;
       console.error(`[local-only] Failed to write restored sessions file ${file}:`, err);
     }
   }
-  return allOk;
+  return { complete, sessionsKept };
 }
 
 // Local-only mode is built entirely out of OpenClaw CLI calls: it flips
-// `agents.defaults.model.primary`, empties `fallbacks`, and sweeps
-// `~/.openclaw/agents/*/sessions/sessions.json`. Hermes has none of those —
+// `agents.defaults.model.primary`, empties `fallbacks`, and repoints every
+// session (gateway `sessions.patchMany`, or the legacy sessions.json). Hermes
+// has none of those —
 // `hermes-local-ai.ts` can install and remove a local provider but has no
 // fallback chain to make exclusive, so there is nothing here to port.
 //
@@ -319,6 +386,7 @@ export async function POST(request: Request) {
     if (currentMode === body.enabled) {
       return NextResponse.json({ enabled: body.enabled });
     }
+    const warnings: string[] = [];
 
     if (body.enabled) {
       const localModel = (await get("local_ai_model")) as string | undefined;
@@ -352,11 +420,16 @@ export async function POST(request: Request) {
       //    flip — any chat pane that was already open silently keeps
       //    routing to its previously-bound cloud provider, and users
       //    have no UI signal that Local-only isn't actually local.
-      const sessionBackup = await patchAllSessionOverrides(
+      const { backup, sessionsSkipped } = await patchAllSessionOverrides(
         parsedLocal.provider,
         parsedLocal.modelId,
       );
-      await set(SAVED_SESSION_OVERRIDES_KEY, sessionBackup);
+      await set(SAVED_SESSION_OVERRIDES_KEY, backup);
+      if (sessionsSkipped > 0) {
+        warnings.push(
+          `${sessionsSkipped} open chat(s) could not be switched to the local model and still route to their previous provider — start a new chat to stay local.`,
+        );
+      }
 
       await set(MODE_KEY, true);
     } else {
@@ -370,46 +443,55 @@ export async function POST(request: Request) {
       if (Array.isArray(savedFallbacks) && savedFallbacks.length > 0) {
         await setConfig("agents.defaults.model.fallbacks", JSON.stringify(savedFallbacks));
       }
-      let restoreOk = true;
-      if (savedSessionOverrides) {
-        restoreOk = await restoreSessionOverrides(savedSessionOverrides);
-      }
+      const restore = savedSessionOverrides
+        ? await restoreSessionOverrides(savedSessionOverrides)
+        : { complete: true, sessionsKept: 0 };
 
       await setMany({
         [SAVED_PRIMARY_KEY]: undefined,
         [SAVED_FALLBACKS_KEY]: undefined,
         // The snapshot is the ONLY copy of the pre-Local-only overrides. A
-        // restore that could not complete (contended or corrupt store) keeps
-        // it, so the next toggle-off can finish the job instead of stranding
-        // every session on the local model for ever.
-        [SAVED_SESSION_OVERRIDES_KEY]: restoreOk ? undefined : savedSessionOverrides,
+        // restore that could not complete yet (the gateway was not reachable,
+        // or refused for now) keeps it, so the next toggle-off can finish the
+        // job instead of stranding every session on the local model for ever.
+        [SAVED_SESSION_OVERRIDES_KEY]: restore.complete ? undefined : savedSessionOverrides,
         // The mode stays ON while the restore is incomplete: clearing it
         // would make the next disable return early as a no-op, and an
         // enable-then-disable cycle would overwrite the kept snapshot with
         // local values. The owner retries the same toggle instead.
-        [MODE_KEY]: restoreOk ? undefined : true,
+        [MODE_KEY]: restore.complete ? undefined : true,
       });
-      if (!restoreOk) {
-        return NextResponse.json({
-          enabled: true,
-          restoreIncomplete: true,
-          warning:
-            "Some sessions could not be switched back yet (the session store was busy). Local-only stays on — try turning it off again in a moment.",
-        });
+      if (!restore.complete) {
+        // Not a 2xx: the panel reads `res.ok` as "the switch moved" and would
+        // paint the toggle OFF over a box that is still in Local-only. A
+        // failure status keeps the switch where the server is and shows why.
+        return NextResponse.json(
+          {
+            enabled: true,
+            restoreIncomplete: true,
+            error:
+              "Some sessions could not be switched back yet (the gateway did not accept the change). Local-only stays on — try turning it off again in a moment.",
+          },
+          { status: 503 },
+        );
+      }
+      if (restore.sessionsKept > 0) {
+        warnings.push(
+          `${restore.sessionsKept} chat(s) could not be switched back and stay on the local model — reset those chats to use the restored provider.`,
+        );
       }
     }
 
-    let restartWarning: string | undefined;
     try {
       await restartGateway();
     } catch (err) {
-      restartWarning = err instanceof Error ? err.message : String(err);
+      warnings.push(`Gateway restart failed: ${err instanceof Error ? err.message : String(err)}`);
       console.error("Failed to restart gateway after exclusive config change:", err);
     }
 
     return NextResponse.json({
       enabled: body.enabled,
-      ...(restartWarning ? { warning: `Gateway restart failed: ${restartWarning}` } : {}),
+      ...(warnings.length > 0 ? { warning: warnings.join(" ") } : {}),
     });
   } catch (err) {
     return NextResponse.json(

--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -158,16 +158,18 @@ async function readSessionsJson(
  * and forth preserves them.
  *
  * `sessionsSkipped` counts the sessions the gateway would not switch (each
- * one logged with its reason). They still route to their previous provider,
- * which for Local-only is a privacy claim, not a routing detail — so the
- * caller says so.
+ * one logged with its reason) and `agentsUnread` the agents whose store could
+ * not even be listed (locked, unreadable). Either way those sessions still
+ * route to their previous provider, which for Local-only is a privacy claim,
+ * not a routing detail — so the caller says so.
  */
 async function patchAllSessionOverrides(
   localProvider: string,
   localModelId: string,
-): Promise<{ backup: FilesBackup; sessionsSkipped: number }> {
+): Promise<{ backup: FilesBackup; sessionsSkipped: number; agentsUnread: number }> {
   const filesBackup: FilesBackup = {};
   let sessionsSkipped = 0;
+  let agentsUnread = 0;
   const localModel = `${localProvider}/${localModelId}`;
   // An agent with a store is served from it whatever else is on disk: its
   // leftover sessions.json is an archive the gateway no longer reads. Patching
@@ -180,6 +182,7 @@ async function patchAllSessionOverrides(
     migratedAgents.add(agentId);
     const rows = readSessionEntries(agentId, AGENTS_DIR);
     if (!rows) {
+      agentsUnread += 1;
       console.error(`[local-only] could not list the sessions of agent ${agentId}; they keep their previous model`);
       continue;
     }
@@ -234,7 +237,7 @@ async function patchAllSessionOverrides(
       console.error(`[local-only] Failed to write patched sessions file ${file}:`, err);
     }
   }
-  return { backup: filesBackup, sessionsSkipped };
+  return { backup: filesBackup, sessionsSkipped, agentsUnread };
 }
 
 /**
@@ -420,7 +423,7 @@ export async function POST(request: Request) {
       //    flip — any chat pane that was already open silently keeps
       //    routing to its previously-bound cloud provider, and users
       //    have no UI signal that Local-only isn't actually local.
-      const { backup, sessionsSkipped } = await patchAllSessionOverrides(
+      const { backup, sessionsSkipped, agentsUnread } = await patchAllSessionOverrides(
         parsedLocal.provider,
         parsedLocal.modelId,
       );
@@ -428,6 +431,11 @@ export async function POST(request: Request) {
       if (sessionsSkipped > 0) {
         warnings.push(
           `${sessionsSkipped} open chat(s) could not be switched to the local model and still route to their previous provider — start a new chat to stay local.`,
+        );
+      }
+      if (agentsUnread > 0) {
+        warnings.push(
+          `The sessions of ${agentsUnread} agent(s) could not be listed and still route to their previous provider — start a new chat to stay local.`,
         );
       }
 
@@ -447,21 +455,26 @@ export async function POST(request: Request) {
         ? await restoreSessionOverrides(savedSessionOverrides)
         : { complete: true, sessionsKept: 0 };
 
-      await setMany({
-        [SAVED_PRIMARY_KEY]: undefined,
-        [SAVED_FALLBACKS_KEY]: undefined,
-        // The snapshot is the ONLY copy of the pre-Local-only overrides. A
-        // restore that could not complete yet (the gateway was not reachable,
-        // or refused for now) keeps it, so the next toggle-off can finish the
-        // job instead of stranding every session on the local model for ever.
-        [SAVED_SESSION_OVERRIDES_KEY]: restore.complete ? undefined : savedSessionOverrides,
-        // The mode stays ON while the restore is incomplete: clearing it
-        // would make the next disable return early as a no-op, and an
-        // enable-then-disable cycle would overwrite the kept snapshot with
-        // local values. The owner retries the same toggle instead.
-        [MODE_KEY]: restore.complete ? undefined : true,
-      });
       if (!restore.complete) {
+        // The mode stays ON: the snapshot is the ONLY copy of the pre-Local-only
+        // overrides, and a restore that could not complete yet (the gateway
+        // was not reachable, or refused for now) must be retried from it —
+        // clearing the mode would make that retry an early no-op, and an
+        // enable-then-disable cycle would overwrite the snapshot with local
+        // values. Nothing saved is cleared either, so the retry starts over.
+        //
+        // The primary and fallbacks were already written back to the cloud
+        // values above, and a box that says Local-only while every new
+        // session after the next gateway start would go to the cloud is a
+        // box claiming a state it does not have. Put them back where the
+        // mode says they are.
+        const localModel = (await get("local_ai_model")) as string | undefined;
+        if (localModel) {
+          await setConfig("agents.defaults.model.primary", JSON.stringify(localModel));
+          await setConfig("agents.defaults.model.fallbacks", "[]");
+        } else {
+          console.error("[local-only] restore incomplete and no local model recorded; the primary stays on the saved provider");
+        }
         // Not a 2xx: the panel reads `res.ok` as "the switch moved" and would
         // paint the toggle OFF over a box that is still in Local-only. A
         // failure status keeps the switch where the server is and shows why.
@@ -475,6 +488,12 @@ export async function POST(request: Request) {
           { status: 503 },
         );
       }
+      await setMany({
+        [SAVED_PRIMARY_KEY]: undefined,
+        [SAVED_FALLBACKS_KEY]: undefined,
+        [SAVED_SESSION_OVERRIDES_KEY]: undefined,
+        [MODE_KEY]: undefined,
+      });
       if (restore.sessionsKept > 0) {
         warnings.push(
           `${restore.sessionsKept} chat(s) could not be switched back and stay on the local model — reset those chats to use the restored provider.`,

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises";
-import { listAgentIds, sessionStorePath, sweepSessionEntries } from "./openclaw-session-store";
+import { listAgentIds, readSessionEntries, sessionStorePath } from "./openclaw-session-store";
+import { isPatchableSession, patchSessionModels, type GatewayRpcCall } from "./openclaw-session-model";
 import { clearPairingState, readPairingAllowEntries, readPairingRequests } from "./openclaw-state-store";
 import fsSync from "fs";
 import path from "path";
@@ -252,6 +253,55 @@ export function spawnOpenclawCli(
   options: SpawnOpenclawOptions = {},
 ): Promise<string> {
   return spawnOpenclaw(args, options);
+}
+
+/** Bound on the gateway round trip itself; the spawn budget adds the CLI's own start-up on top. */
+const GATEWAY_RPC_TIMEOUT_MS = 20_000;
+const GATEWAY_RPC_SPAWN_ALLOWANCE_MS = 30_000;
+
+/**
+ * One gateway RPC through the CLI: `openclaw gateway call <method> --params
+ * <json> --json`. The CLI is the gateway's own client — it holds the device
+ * identity, the token and the protocol version, so nothing here can drift
+ * from what the gateway accepts. With `--json` it prints the method's result
+ * object and nothing else on success; a failure is written as an error
+ * payload with exit 1, which `spawnOpenclaw` turns into a rejection carrying
+ * that text. The `ok === false` check is for a build that reports a refusal
+ * on exit 0.
+ *
+ * Costs one CLI start-up (10-12 s on a Jetson), so callers batch: a sweep
+ * over N sessions is one `sessions.patchMany`, not N calls.
+ */
+export async function callGatewayRpc(
+  method: string,
+  params: Record<string, unknown>,
+  options: { timeoutMs?: number } = {},
+): Promise<Record<string, unknown>> {
+  const timeoutMs = options.timeoutMs ?? GATEWAY_RPC_TIMEOUT_MS;
+  const out = await spawnOpenclaw(
+    ["gateway", "call", method, "--params", JSON.stringify(params), "--json", "--timeout", String(timeoutMs)],
+    {
+      captureStdout: true,
+      timeoutMs: timeoutMs + GATEWAY_RPC_SPAWN_ALLOWANCE_MS,
+      // Session keys are not secrets, but a 100-target params blob is not a log line either.
+      labelArgs: ["gateway", "call", method, "--params", "<json>", "--json"],
+    },
+  );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(out);
+  } catch {
+    throw new Error(`${method} returned no JSON`);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${method} returned no object`);
+  }
+  const payload = parsed as Record<string, unknown>;
+  if (payload.ok === false) {
+    const error = payload.error as { message?: unknown } | undefined;
+    throw new Error(typeof error?.message === "string" ? error.message : `${method} failed`);
+  }
+  return payload;
 }
 
 /**
@@ -519,8 +569,33 @@ interface ApplyModelOverrideOpts {
    * chat). No such surface ships today, so this branch currently has
    * no production caller — kept for the test contract and as the
    * obvious extension point.
+   *
+   * Before that surface ships, note the contract is now backend-dependent:
+   * on an OpenClaw 2 agent the gateway records "pinned to the new default"
+   * by clearing the override (no `modelOverrideSource: "user"` survives),
+   * so a later soft sweep would not see that session as sticky, where the
+   * legacy file path leaves the tag in place.
    */
   skipUserTagged?: boolean;
+  /**
+   * The gateway transport for OpenClaw 2 agents (their sessions live in a
+   * store only the gateway may write). Defaults to the CLI-backed
+   * {@link callGatewayRpc}; tests inject a fake.
+   */
+  callGateway?: GatewayRpcCall;
+}
+
+export interface ApplyModelOverrideResult {
+  /** Agents whose sessions changed: one per store or sessions.json touched. */
+  filesUpdated: number;
+  sessionsUpdated: number;
+  /**
+   * OpenClaw 2 sessions the gateway would not repoint (each one logged with
+   * the gateway's reason). They keep their previous model; nothing else is
+   * tried, because the only other way to change them is the store rewrite
+   * that invalidates every row.
+   */
+  sessionsSkipped: number;
 }
 
 async function listAgentSessionsFiles(agentsDir: string): Promise<string[]> {
@@ -550,48 +625,60 @@ async function atomicWriteSessionsFile(filePath: string, data: unknown): Promise
 }
 
 /**
- * Rewrite every session's per-session model/provider override across
- * every agent on disk to the given target, tagged with the given
- * source. Returns how many sessions were touched.
+ * Repoint every existing session, across every agent on disk, to the given
+ * model, so the switch reaches the chats that are already open and not only
+ * the sessions born after it.
  *
- * Use `source: "user"` (also the default) when the caller is acting
- * on a direct user choice — chat-panel model dropdown, Local-only
- * toggle, etc. OpenClaw's per-turn model resolver explicitly returns
- * early for entries whose `modelOverrideSource === "user"`, which is
- * the only value that survives the auto-picker re-evaluating on
- * every message. `"manual"` looks reasonable but is not special-cased
- * anywhere in the OpenClaw dist and gets silently overwritten back
- * to `"auto"` on the next turn.
+ * Two store generations, two mechanisms:
+ *   - OpenClaw 2 agents (an `agent/openclaw-agent.sqlite`) are patched through
+ *     the gateway — `sessions.patchMany { model }` — which writes the override
+ *     fields itself, tags them `modelOverrideSource: "user"` and normalises a
+ *     stale `thinkingLevel`. The store is only READ, to learn the session keys.
+ *     A session the gateway refuses is counted in `sessionsSkipped` and left
+ *     alone; there is no fallback, because a direct `session_nodes` write is
+ *     what bricked chat on every switch (finding M-03).
+ *   - Legacy agents (`sessions/sessions.json`) get the atomic file rewrite,
+ *     with the fields below written by hand. `source: "user"` (the default) is
+ *     the only value OpenClaw's per-turn resolver treats as sticky; `"manual"`
+ *     is not special-cased anywhere and is overwritten back to `"auto"` on the
+ *     next turn.
  *
- * Writes are atomic (temp + rename). If any individual sessions.json
- * fails to parse/write, the error is logged and the sweep continues —
- * one bad file should not block the rest.
+ * One bad agent — an unreadable store, a corrupt file — is logged and the
+ * sweep continues with the rest.
  */
 export async function applyModelOverrideToAllAgentSessions(
   update: SessionOverrideUpdate,
   opts: ApplyModelOverrideOpts = {},
-): Promise<{ filesUpdated: number; sessionsUpdated: number }> {
+): Promise<ApplyModelOverrideResult> {
   const agentsDir = opts.agentsDir ?? AGENTS_DIR;
   const source = update.source ?? "user";
   const authProfile = update.authProfile ?? `${update.provider}:default`;
   const skipUserTagged = opts.skipUserTagged === true;
+  const callGateway = opts.callGateway ?? callGatewayRpc;
 
   let filesUpdated = 0;
   let sessionsUpdated = 0;
+  let sessionsSkipped = 0;
 
-  /** The per-entry mutation, shared verbatim by both store generations. */
+  /**
+   * The soft sweep's exclusion: a session the user pinned to something else.
+   * A pin that already matches the target is still swept so its source and
+   * auth profile converge.
+   */
+  const keepsUserPick = (session: Record<string, unknown>): boolean => {
+    if (!skipUserTagged || session.modelOverrideSource !== "user") return false;
+    const sameProvider =
+      session.providerOverride === update.provider ||
+      session.modelProvider === update.provider;
+    const sameModel =
+      session.modelOverride === update.modelId ||
+      session.model === update.modelId;
+    return !sameProvider || !sameModel;
+  };
+
+  /** The legacy-file mutation. */
   const applyToSession = (session: Record<string, unknown>): boolean => {
-    if (skipUserTagged && session.modelOverrideSource === "user") {
-      const sameProvider =
-        session.providerOverride === update.provider ||
-        session.modelProvider === update.provider;
-      const sameModel =
-        session.modelOverride === update.modelId ||
-        session.model === update.modelId;
-      if (!sameProvider || !sameModel) {
-        return false;
-      }
-    }
+    if (keepsUserPick(session)) return false;
     session.providerOverride = update.provider;
     session.modelOverride = update.modelId;
     session.modelOverrideSource = source;
@@ -599,6 +686,14 @@ export async function applyModelOverrideToAllAgentSessions(
     session.authProfileOverrideSource = source;
     session.modelProvider = update.provider;
     session.model = update.modelId;
+    // Normalise the sticky reasoning-effort override to the new model's
+    // capability. `thinkingLevel` is a per-session sticky the gateway keeps
+    // (set via `sessions.patch`); repointing the session to a model that
+    // can't honour the old level would otherwise leave e.g. a DeepSeek
+    // `high` on a local llama.cpp Gemma session, and the gateway rejects the
+    // next turn with `thinkingLevel "high" is not supported for llamacpp/…
+    // (use off)`. Only rewrite when the existing level is actually
+    // unsupported, so a compatible level (e.g. cloud→cloud) is left intact.
     if (isThinkingLevel(session.thinkingLevel)) {
       const reasoning = getProviderReasoningConfig(update.provider, `${update.provider}/${update.modelId}`);
       if (!reasoning.levels.includes(session.thinkingLevel)) {
@@ -608,23 +703,38 @@ export async function applyModelOverrideToAllAgentSessions(
     return true;
   };
 
-  // OpenClaw 2 agents keep their sessions in SQLite; an agent with a store is
-  // swept there and its (absent or archived) sessions.json is left alone.
+  // OpenClaw 2 agents: the store names the sessions, the gateway changes them.
+  // An agent with a store is served from it whatever else is on disk — its
+  // (absent or archived) sessions.json is an archive the gateway no longer
+  // reads, and is left alone below.
   const migratedAgents = new Set<string>();
+  const model = `${update.provider}/${update.modelId}`;
   for (const agentId of listAgentIds(agentsDir)) {
     if (!sessionStorePath(agentId, agentsDir)) continue;
-    const result = sweepSessionEntries(agentId, (_key, entry) => applyToSession(entry), agentsDir);
-    // A newer SQLite schema is still authoritative for this migrated agent.
-    // It refused our write on purpose; falling through to an old sessions.json
-    // would report success while the gateway keeps reading unchanged SQLite.
-    if (result?.unsupportedSchema !== undefined) migratedAgents.add(agentId);
-    // Other failed sweeps retain the established best-effort legacy behavior.
-    if (!result?.ok) continue;
     migratedAgents.add(agentId);
-    if (result.updated > 0) {
-      filesUpdated += 1;
-      sessionsUpdated += result.updated;
+    const rows = readSessionEntries(agentId, agentsDir);
+    if (!rows) {
+      console.warn(`[openclaw-config] could not list the sessions of agent ${agentId}; they keep their previous model`);
+      continue;
     }
+    const targets = rows
+      .filter(({ entry }) => isPatchableSession(entry) && !keepsUserPick(entry))
+      .map(({ key }) => ({ key, agentId }));
+    if (targets.length === 0) continue;
+    let patched = 0;
+    for (const outcome of await patchSessionModels(targets, model, { call: callGateway })) {
+      if (outcome.ok) {
+        patched += 1;
+        continue;
+      }
+      sessionsSkipped += 1;
+      console.warn(
+        `[openclaw-config] session ${outcome.key} (agent ${agentId}) keeps its previous model:`,
+        outcome.error,
+      );
+    }
+    sessionsUpdated += patched;
+    if (patched > 0) filesUpdated += 1;
   }
 
   const files = (await listAgentSessionsFiles(agentsDir)).filter(
@@ -644,21 +754,7 @@ export async function applyModelOverrideToAllAgentSessions(
     let touchedInFile = 0;
     for (const session of Object.values(sessions)) {
       if (!session || typeof session !== "object") continue;
-      // Preserve sticky per-session user choices when the caller asked
-      // for a soft sweep. A session whose existing override matches
-      // the new target is still touched so its source/authProfile
-      // converge with the target — only diverging user picks stay put.
-      if (!applyToSession(session)) {
-        continue;
-      }
-      // Normalise the sticky reasoning-effort override to the new model's
-      // capability. `thinkingLevel` is a per-session sticky the gateway keeps
-      // (set via `sessions.patch`); repointing the session to a model that
-      // can't honour the old level would otherwise leave e.g. a DeepSeek
-      // `high` on a local llama.cpp Gemma session, and the gateway rejects the
-      // next turn with `thinkingLevel "high" is not supported for llamacpp/…
-      // (use off)`. Only rewrite when the existing level is actually
-      // unsupported, so a compatible level (e.g. cloud→cloud) is left intact.
+      if (!applyToSession(session)) continue;
       touchedInFile += 1;
     }
 
@@ -672,7 +768,7 @@ export async function applyModelOverrideToAllAgentSessions(
     }
   }
 
-  return { filesUpdated, sessionsUpdated };
+  return { filesUpdated, sessionsUpdated, sessionsSkipped };
 }
 
 /**

--- a/src/lib/openclaw-session-model.ts
+++ b/src/lib/openclaw-session-model.ts
@@ -1,0 +1,218 @@
+/**
+ * Per-session model overrides on an OpenClaw 2 agent, applied through the
+ * gateway's own API — `sessions.patchMany` with `{ model }` — and never by
+ * writing the agent store. The store's `session_nodes` table is trigger-owned
+ * by the core (see openclaw-session-store.ts): a row rewritten by anything
+ * but the gateway is invalid at the next start, and chat is dead until
+ * `openclaw doctor --fix`.
+ *
+ * What the gateway does with a `model` patch (2026.8.1, sessions-patch.ts +
+ * sessions/model-overrides.ts in the core): resolves `<provider>/<model>`
+ * against its catalog, writes `providerOverride` / `modelOverride` /
+ * `modelOverrideSource: "user"` / `modelOverrideRouteResolution` itself, drops
+ * an auth-profile override the new provider cannot use, and folds a sticky
+ * `thinkingLevel` the new model cannot honour down to one it can. `model: null`
+ * clears the override so the session follows the agent default again. Every
+ * field ClawBox's old sweeps wrote by hand is therefore set by the owner of
+ * the row, in the shape that owner validates.
+ *
+ * One consequence worth knowing: when the patched model IS the agent's new
+ * default — which it is on both model-switch routes, because they write
+ * `agents.defaults.model.primary` first — the core records that by DELETING
+ * the per-session override rather than writing one. That reaches the same
+ * place the old hand-written sweep aimed for (the session resolves to the new
+ * primary), expressed the core's way, which is why nothing here asserts on
+ * particular override fields afterwards.
+ *
+ * Pure: the transport is injected, so the callers (openclaw-config's model
+ * sweep, the Local-only toggle) wire the CLI-backed `callGatewayRpc` and the
+ * tests wire a fake.
+ */
+
+/** One gateway RPC round trip; resolves with the method's result object. */
+export type GatewayRpcCall = (
+  method: string,
+  params: Record<string, unknown>,
+  opts?: { timeoutMs?: number },
+) => Promise<Record<string, unknown>>;
+
+/** The core's SESSIONS_PATCH_MANY_MAX_TARGETS: a larger `targets` array is rejected outright. */
+export const SESSIONS_PATCH_MANY_MAX_TARGETS = 100;
+
+const DEFAULT_RETRY_DELAY_MS = 2_000;
+
+export interface SessionPatchTarget {
+  key: string;
+  agentId: string;
+}
+
+export interface SessionPatchOutcome extends SessionPatchTarget {
+  ok: boolean;
+  /** The gateway's own words when `ok` is false. */
+  error?: string;
+  /**
+   * With `ok` false: the refusal was transient — the catalog still loading,
+   * a gateway that was not reachable — and has already had its one retry
+   * here, so a caller with a "try again later" of its own can honour it.
+   * False means the answer will not change (a locked selection, an unknown
+   * model, a session the gateway does not know), and waiting is pointless.
+   */
+  retryable?: boolean;
+}
+
+export interface PatchSessionModelsOptions {
+  call: GatewayRpcCall;
+  /** Pause before the one retry of a transient refusal. Default {@link DEFAULT_RETRY_DELAY_MS}. */
+  retryDelayMs?: number;
+  /** Forwarded to `call` unchanged. */
+  timeoutMs?: number;
+}
+
+/**
+ * A row the gateway can patch. Entries without a session id are placeholder
+ * aliases the core keeps for a retention window; patching one would give it
+ * an id — i.e. create a session — which no model switch means to do.
+ */
+export function isPatchableSession(entry: Record<string, unknown>): boolean {
+  return typeof entry.sessionId === "string" && entry.sessionId.length > 0;
+}
+
+/**
+ * The `<provider>/<model>` an entry (or a snapshot of one) is pinned to, or
+ * null when it carries no complete override — the value to hand back to
+ * `sessions.patch` so the session returns to exactly that pin, or to the
+ * agent default when it had none.
+ */
+export function sessionModelRef(entry: Record<string, unknown>): string | null {
+  return (
+    modelRef(entry.providerOverride, entry.modelOverride) ??
+    // The pre-2026.8 spelling, still present on entries the doctor migrated.
+    modelRef(entry.modelProvider, entry.model)
+  );
+}
+
+function modelRef(provider: unknown, model: unknown): string | null {
+  if (typeof provider !== "string" || !provider) return null;
+  if (typeof model !== "string" || !model) return null;
+  return `${provider}/${model}`;
+}
+
+/** Map key for one target. Exact by construction: a session key may contain any separator we could pick. */
+function outcomeId(target: SessionPatchTarget): string {
+  return JSON.stringify([target.agentId, target.key]);
+}
+
+function describeError(error: unknown): { message: string; retryable: boolean } {
+  // The protocol's ErrorShape is `{ code, message }`; a bare string is
+  // accepted too, so a build that flattens it still names its reason.
+  const shape: { code?: unknown; message?: unknown } =
+    typeof error === "string" ? { message: error } : error && typeof error === "object" ? error : {};
+  const message = typeof shape.message === "string" && shape.message ? shape.message : "the gateway refused the patch";
+  // "model catalog is still loading; retry in a few seconds" is the one the
+  // core documents; it arrives as UNAVAILABLE.
+  const retryable = shape.code === "UNAVAILABLE" || /still loading/i.test(message);
+  return { message, retryable };
+}
+
+async function patchChunk(
+  chunk: SessionPatchTarget[],
+  model: string | null,
+  opts: PatchSessionModelsOptions,
+): Promise<Map<string, SessionPatchOutcome>> {
+  const results = new Map<string, SessionPatchOutcome>();
+  let payload: Record<string, unknown>;
+  try {
+    payload = await opts.call(
+      "sessions.patchMany",
+      {
+        targets: chunk.map((t) => ({ key: t.key, agentId: t.agentId })),
+        patch: { model },
+      },
+      { timeoutMs: opts.timeoutMs },
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    for (const target of chunk) {
+      results.set(outcomeId(target), { ...target, ok: false, error: message, retryable: true });
+    }
+    return results;
+  }
+
+  const reported = new Map<string, { ok: boolean; error?: unknown }>();
+  const outcomes = Array.isArray(payload.outcomes) ? payload.outcomes : [];
+  for (const raw of outcomes) {
+    if (!raw || typeof raw !== "object") continue;
+    const outcome = raw as { key?: unknown; agentId?: unknown; ok?: unknown; error?: unknown };
+    if (typeof outcome.key !== "string") continue;
+    // The gateway echoes agentId only when the target named one; every target
+    // here does, so a missing echo still resolves through the target's own.
+    const agentId =
+      typeof outcome.agentId === "string" ? outcome.agentId : chunk.find((t) => t.key === outcome.key)?.agentId;
+    if (!agentId) continue;
+    reported.set(outcomeId({ key: outcome.key, agentId }), { ok: outcome.ok === true, error: outcome.error });
+  }
+  if (reported.size === 0) {
+    // N indistinguishable per-session lines would hide the real news: the
+    // envelope is not the one this code knows. Say so once, with its keys.
+    console.error(
+      `[session-model] sessions.patchMany answered with no recognisable outcome for any of ${chunk.length} session(s); response keys: ${Object.keys(payload).join(", ") || "(none)"}`,
+    );
+  }
+  for (const target of chunk) {
+    const id = outcomeId(target);
+    const outcome = reported.get(id);
+    if (!outcome) {
+      results.set(id, {
+        ...target,
+        ok: false,
+        error: "the gateway reported no outcome for this session",
+        retryable: false,
+      });
+    } else if (outcome.ok) {
+      results.set(id, { ...target, ok: true });
+    } else {
+      const { message, retryable } = describeError(outcome.error);
+      results.set(id, { ...target, ok: false, error: message, retryable });
+    }
+  }
+  return results;
+}
+
+/** Every target, in gateway-sized calls, keyed by {@link outcomeId}. */
+async function patchInChunks(
+  targets: SessionPatchTarget[],
+  model: string | null,
+  opts: PatchSessionModelsOptions,
+): Promise<Map<string, SessionPatchOutcome>> {
+  const results = new Map<string, SessionPatchOutcome>();
+  for (let i = 0; i < targets.length; i += SESSIONS_PATCH_MANY_MAX_TARGETS) {
+    const chunk = targets.slice(i, i + SESSIONS_PATCH_MANY_MAX_TARGETS);
+    for (const [id, outcome] of await patchChunk(chunk, model, opts)) results.set(id, outcome);
+  }
+  return results;
+}
+
+/**
+ * Pin every target session to `model` (`<provider>/<model>`), or clear the
+ * pin with null, through `sessions.patchMany`. One outcome per target, in
+ * target order; a target the gateway refused (a locked selection, an unknown
+ * model, a session that no longer exists) is reported, never forced. A
+ * transient refusal — the catalog still loading right after a config change,
+ * or a gateway that was not reachable — gets exactly one retry after a pause.
+ */
+export async function patchSessionModels(
+  targets: SessionPatchTarget[],
+  model: string | null,
+  opts: PatchSessionModelsOptions,
+): Promise<SessionPatchOutcome[]> {
+  const results = await patchInChunks(targets, model, opts);
+
+  const retry = targets.filter((t) => results.get(outcomeId(t))?.retryable);
+  if (retry.length > 0) {
+    await new Promise((resolve) => setTimeout(resolve, opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS));
+    for (const [id, outcome] of await patchInChunks(retry, model, opts)) results.set(id, outcome);
+  }
+
+  // Every target has an entry: patchChunk writes one per target on both paths.
+  return targets.map((target) => results.get(outcomeId(target)) as SessionPatchOutcome);
+}

--- a/src/lib/openclaw-session-store.ts
+++ b/src/lib/openclaw-session-store.ts
@@ -11,17 +11,30 @@
  *                         same JSON the old .jsonl files carried, ordered by
  *                         `seq` per `session_id`.
  *
- * Every reader/writer here decides per agent: a box the doctor has migrated
- * has the .sqlite file and is served from it; a box still on the legacy
- * files (mid-update, or a downgrade) keeps the old path — the callers all
- * fall back. Writes mirror what the gateway itself does closely enough for
- * the same sweeps the sessions.json writers ran (the gateway reads entries
- * back from the store on demand, exactly as it re-read the JSON file).
+ * Every reader here decides per agent: a box the doctor has migrated has the
+ * .sqlite file and is served from it; a box still on the legacy files
+ * (mid-update, or a downgrade) keeps the old path — the callers all fall back.
+ *
+ * READ-ONLY for the agent store, without exception. The core owns
+ * `session_nodes` with triggers:
+ *
+ *   CREATE TRIGGER session_nodes_entry_valid_after_entry_update
+ *   AFTER UPDATE OF entry_json ON session_nodes
+ *   BEGIN UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key; END;
+ *
+ * and its scan throws SessionCanonicalKeyMigrationRequiredError for any row
+ * whose `entry_valid` is not 1 — the gateway then refuses to start until
+ * `openclaw doctor --fix`. Only the core's own write path re-validates a row,
+ * so an external UPDATE of `entry_json` is never safe, whatever the schema
+ * version says (2026.8.1 stamps 19; the sweep this module used to carry
+ * checked exactly that and still bricked chat on every model switch — finding
+ * M-03). Anything that must change an entry goes through the gateway's own
+ * API: see openclaw-session-model.ts.
  *
  * node:sqlite on purpose: it ships with the Node 22 the box runs, needs no
- * native build on Tegra, and `DatabaseSync` keeps these sweeps as simple as
- * the readFile/writeFile they replace. Opened with a busy timeout so a
- * concurrently writing gateway makes us wait, not fail.
+ * native build on Tegra, and `DatabaseSync` keeps these reads as simple as
+ * the readFile they replace. Opened with a busy timeout so a concurrently
+ * writing gateway makes us wait, not fail.
  */
 
 import fs from "node:fs";
@@ -83,8 +96,11 @@ export function sessionStorePath(agentId: string, agentsDir: string = AGENTS_DIR
 
 /**
  * Open one of OpenClaw's SQLite stores with the busy timeout every reader and
- * writer here relies on. Shared with openclaw-state-store.ts, which serves the
- * gateway-wide `state/openclaw.sqlite` the same way.
+ * writer relies on. Shared with openclaw-state-store.ts, which serves the
+ * gateway-wide `state/openclaw.sqlite` the same way (and may write there —
+ * that store has no validity trigger). Inside THIS module every call passes
+ * `readOnly: true`; see the module comment for why there is no other mode
+ * for the agent store.
  */
 export function openSqlite(dbPath: string, readOnly: boolean): DatabaseSyncType {
   const { DatabaseSync } = requireNodeSqlite();
@@ -95,6 +111,20 @@ export function openSqlite(dbPath: string, readOnly: boolean): DatabaseSyncType 
     /* busy_timeout is advisory; a refusal changes nothing below */
   }
   return db;
+}
+
+/**
+ * {@link open}, with a failed open resolved to null. A corrupt header or a
+ * permission error must reach the caller as "no store" — the legacy-file
+ * fallback — not escape as a 500 from a chat read.
+ */
+function openOrNull(dbPath: string): DatabaseSyncType | null {
+  try {
+    return openSqlite(dbPath, true);
+  } catch (err) {
+    console.warn(`[session-store] could not open ${dbPath}:`, err);
+    return null;
+  }
 }
 
 /**
@@ -111,16 +141,8 @@ export function readTranscriptRaw(
 ): { raw: string; identity: string } | null {
   const dbPath = sessionStorePath(agentId, agentsDir);
   if (!dbPath) return null;
-  // open() sits INSIDE the guarded region: a corrupt header or permission
-  // error must resolve to null (the legacy-file fallback), not escape as a
-  // 500 from a chat-history read.
-  let db: DatabaseSyncType;
-  try {
-    db = openSqlite(dbPath, true);
-  } catch (err) {
-    console.warn(`[session-store] could not open ${dbPath}:`, err);
-    return null;
-  }
+  const db = openOrNull(dbPath);
+  if (!db) return null;
   try {
     const node = db
       .prepare("SELECT current_session_id AS sid, updated_at AS updatedAt FROM session_nodes WHERE session_key = ?")
@@ -170,97 +192,46 @@ export function listAgentIds(agentsDir: string = AGENTS_DIR_DEFAULT): string[] {
   }
 }
 
-/**
- * The newest agent-store schema this sweep has been verified against —
- * OpenClaw 2026.8.1 stamps PRAGMA user_version 19 and its own maintenance
- * code hard-refuses anything newer, so ours does too.
- */
-const KNOWN_SESSION_SCHEMA_VERSION = 19;
-
-export interface SessionEntrySweepResult {
-  /** Entries the mutator changed and that were written back. */
-  updated: number;
-  /** False when the sweep died (a contended or corrupt store): nothing can
-   *  be said about what was written, and a caller must not treat the pass
-   *  as done — record no backup, count no update. */
-  ok: boolean;
-  /** Present only when the store is from a newer OpenClaw generation. The
-   *  caller must not reinterpret that refusal as permission to mutate a
-   *  leftover legacy sessions.json for the same migrated agent. */
-  unsupportedSchema?: number;
+export interface SessionEntryRow {
+  key: string;
+  /** The parsed `entry_json` object (modelOverride, thinkingLevel, sessionId, …). */
+  entry: Record<string, unknown>;
 }
 
 /**
- * Read every session entry in one agent's SQLite store, hand each to the
- * mutator, and write back the ones it changed. The mutator receives the
- * parsed `entry_json` object keyed by session key and returns true to
- * persist its mutation. One IMMEDIATE transaction per store: the sweep the
- * sessions.json writers did with a whole-file rewrite stays just as atomic.
+ * Every session entry in one agent's SQLite store, parsed, or null when the
+ * agent has no store or it cannot be read (logged). Rows whose `entry_json`
+ * is not a JSON object are left out — the core keeps `{}` placeholder rows
+ * for a retention window, and they describe no session.
  */
-export function sweepSessionEntries(
+export function readSessionEntries(
   agentId: string,
-  mutate: (sessionKey: string, entry: Record<string, unknown>) => boolean,
   agentsDir: string = AGENTS_DIR_DEFAULT,
-): SessionEntrySweepResult | null {
+): SessionEntryRow[] | null {
   const dbPath = sessionStorePath(agentId, agentsDir);
   if (!dbPath) return null;
-  let db: DatabaseSyncType;
+  const db = openOrNull(dbPath);
+  if (!db) return null;
   try {
-    db = openSqlite(dbPath, false);
-  } catch (err) {
-    console.error(`[session-store] could not open ${dbPath} for sweep:`, err);
-    return { updated: 0, ok: false };
-  }
-  try {
-    db.exec("BEGIN IMMEDIATE");
-    let updated = 0;
-    try {
-      // Inspect the schema only AFTER taking the write reservation. Otherwise
-      // another OpenClaw process can migrate v19 → v20 between this read and
-      // BEGIN IMMEDIATE, leaving this old writer to mutate a schema it never
-      // understood. OpenClaw's own store code refuses versions above its cap;
-      // this sweep must be no braver. 2026.8.1 stamps user_version 19.
-      const versionRow = db.prepare("PRAGMA user_version").get() as { user_version?: number } | undefined;
-      const schemaVersion = typeof versionRow?.user_version === "number" ? versionRow.user_version : 0;
-      if (schemaVersion > KNOWN_SESSION_SCHEMA_VERSION) {
-        console.error(
-          `[session-store] ${dbPath} carries schema v${schemaVersion}, newer than the v${KNOWN_SESSION_SCHEMA_VERSION} this sweep knows; refusing to write`,
-        );
-        db.exec("ROLLBACK");
-        return { updated: 0, ok: false, unsupportedSchema: schemaVersion };
-      }
-
-      const rows = db
-        .prepare("SELECT session_key AS key, entry_json AS entry FROM session_nodes")
-        .all() as Array<{ key?: string | null; entry?: string | null }>;
-      const write = db.prepare("UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?");
-      for (const row of rows) {
-        if (typeof row.key !== "string" || typeof row.entry !== "string") continue;
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(row.entry);
-        } catch {
-          continue;
-        }
-        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
-        const entry = parsed as Record<string, unknown>;
-        if (!mutate(row.key, entry)) continue;
-        write.run(JSON.stringify(entry), Date.now(), row.key);
-        updated += 1;
-      }
-      db.exec("COMMIT");
-    } catch (err) {
+    const rows = db
+      .prepare("SELECT session_key AS key, entry_json AS entry FROM session_nodes ORDER BY session_key")
+      .all() as Array<{ key?: string | null; entry?: string | null }>;
+    const entries: SessionEntryRow[] = [];
+    for (const row of rows) {
+      if (typeof row.key !== "string" || typeof row.entry !== "string") continue;
+      let parsed: unknown;
       try {
-        db.exec("ROLLBACK");
+        parsed = JSON.parse(row.entry);
       } catch {
-        /* the connection close below releases the transaction anyway */
+        continue;
       }
-      throw err;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+      entries.push({ key: row.key, entry: parsed as Record<string, unknown> });
     }
-    return { updated, ok: true };
+    return entries;
   } catch (err) {
-    console.error(`[session-store] sweep failed for agent ${agentId}:`, err);
-    return { updated: 0, ok: false };
+    console.warn(`[session-store] could not read sessions of agent ${agentId}:`, err);
+    return null;
   } finally {
     db.close();
   }

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -188,7 +188,7 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI image provider", ()
     mockRunOpenclawConfigSet.mockResolvedValue(undefined);
     mockRunOpenclawConfigSetBatch.mockResolvedValue(undefined);
     vi.mocked(unpairLocal).mockResolvedValue(undefined);
-    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
     vi.mocked(parseFullyQualifiedModel).mockImplementation(parseFullyQualifiedModelImpl);
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
 

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -233,7 +233,7 @@ async function primeConfigureRoute(): Promise<(request: Request) => Promise<Resp
   vi.mocked(restartGateway).mockResolvedValue();
   vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
   vi.mocked(runOpenclawConfigSetBatch).mockResolvedValue(undefined);
-  vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+  vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
   vi.mocked(setProviderPlugins).mockResolvedValue(undefined);
   vi.mocked(unpairLocal).mockResolvedValue(undefined);
   mockSpawn.mockImplementation(() => successfulChild());

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -225,7 +225,7 @@ describe("POST /setup-api/ai-models/configure — ClawBox AI vision model", () =
     mockRunOpenclawConfigSet.mockResolvedValue(undefined);
     mockRunOpenclawConfigSetBatch.mockResolvedValue(undefined);
     vi.mocked(unpairLocal).mockResolvedValue(undefined);
-    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
     vi.mocked(parseFullyQualifiedModel).mockImplementation(parseFullyQualifiedModelImpl);
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -257,7 +257,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     // Re-apply implementations cleared by vi.clearAllMocks above. Factory
     // defaults set in `vi.mock(...)` hold across vi.resetModules but are
     // wiped by mockClear call history cleanup, so we seed them per-test.
-    mockApplyModelOverrideToAllAgentSessions.mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    mockApplyModelOverrideToAllAgentSessions.mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
     mockParseFullyQualifiedModel.mockImplementation(parseFullyQualifiedModelImpl);
     mockGetDefaultLlamaCppModel.mockReturnValue("gemma4-e2b-it-q4_0");
     mockGetLlamaCppContextWindow.mockReturnValue(131072);
@@ -1244,7 +1244,7 @@ describe("POST /setup-api/ai-models/configure", () => {
       mockReadOpenClawConfig.mockResolvedValue({});
       mockReadOpenClawConfigStrict.mockResolvedValue({});
       mockParseFullyQualifiedModel.mockImplementation(parseFullyQualifiedModelImpl);
-      mockApplyModelOverrideToAllAgentSessions.mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+      mockApplyModelOverrideToAllAgentSessions.mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
 
       const res = await configurePost(jsonRequest({
         provider,

--- a/src/tests/routes/chat-model-codex-surface.test.ts
+++ b/src/tests/routes/chat-model-codex-surface.test.ts
@@ -106,7 +106,7 @@ describe("/setup-api/chat/model and the ChatGPT subscription surface", () => {
 
     vi.mocked(promisify).mockReturnValue(vi.fn().mockResolvedValue({ stdout: "", stderr: "" }) as never);
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
-    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
     vi.mocked(parseFullyQualifiedModel).mockImplementation((fq: string) => {
       const idx = fq.indexOf("/");
       if (idx <= 0 || idx === fq.length - 1) return null;

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -150,7 +150,7 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
 
     vi.mocked(promisify).mockReturnValue(vi.fn().mockResolvedValue({ stdout: "", stderr: "" }) as never);
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
-    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
     vi.mocked(parseFullyQualifiedModel).mockImplementation((fq: string) => {
       const idx = fq.indexOf("/");
       if (idx <= 0 || idx === fq.length - 1) return null;

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -48,7 +48,7 @@ describe("/setup-api/chat/model", () => {
     mockExec = vi.fn().mockResolvedValue({ stdout: "", stderr: "" });
     vi.mocked(promisify).mockReturnValue(mockExec as never);
     vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
-    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0 });
+    vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
     // Mirror real `parseFullyQualifiedModel` from `@/lib/openclaw-config`
     // exactly — trailing-slash rejection matters, a lax mock can mask bugs.
     vi.mocked(parseFullyQualifiedModel).mockImplementation((fq: string) => {

--- a/src/tests/routes/local-ai-exclusive-sessions.test.ts
+++ b/src/tests/routes/local-ai-exclusive-sessions.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * The Local-only toggle's session round trip on an OpenClaw 2 box: the store
+ * is read to learn the sessions, the gateway (`sessions.patchMany`) switches
+ * them, and the backup records only what the gateway confirmed. The other
+ * tests of this route cover the Hermes refusal and the primary/fallback
+ * config writes; this one is about the sessions.
+ */
+
+const state = vi.hoisted(() => ({ store: new Map<string, unknown>() }));
+
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(async (key: string) => state.store.get(key)),
+  set: vi.fn(async (key: string, value: unknown) => {
+    state.store.set(key, value);
+  }),
+  setMany: vi.fn(async (entries: Record<string, unknown>) => {
+    for (const [key, value] of Object.entries(entries)) {
+      if (value === undefined) state.store.delete(key);
+      else state.store.set(key, value);
+    }
+  }),
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  callGatewayRpc: vi.fn(),
+  gatewayIsAbsent: () => false,
+  readConfig: vi.fn(async () => ({
+    agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro", fallbacks: [] } } },
+  })),
+  restartGateway: vi.fn(async () => {}),
+  runOpenclawConfigSet: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/openclaw-session-store", () => ({
+  listAgentIds: vi.fn(() => ["main", "legacy"]),
+  // `main` is migrated (has a store); `legacy` is still on sessions.json.
+  sessionStorePath: vi.fn((agentId: string) => (agentId === "main" ? `/store/${agentId}/agent/openclaw-agent.sqlite` : null)),
+  readSessionEntries: vi.fn(),
+}));
+
+import { callGatewayRpc } from "@/lib/openclaw-config";
+import { readSessionEntries } from "@/lib/openclaw-session-store";
+
+type Params = { targets: Array<{ key: string; agentId: string }>; patch: { model: string | null } };
+type Outcome = { ok: boolean; key: string; agentId?: string; error?: { code: string; message: string } };
+
+const gateway = vi.mocked(callGatewayRpc);
+const rows = vi.mocked(readSessionEntries);
+
+/** Answers every target `ok`, except the keys in `refuse`. */
+function answering(refuse: Record<string, { code: string; message: string }> = {}) {
+  gateway.mockImplementation(async (_method, params) => {
+    const { targets } = params as Params;
+    const outcomes: Outcome[] = targets.map((t) =>
+      refuse[t.key] ? { ok: false, key: t.key, agentId: t.agentId, error: refuse[t.key] } : { ok: true, key: t.key, agentId: t.agentId },
+    );
+    return { outcomes };
+  });
+}
+
+const DEEPSEEK_PIN = { providerOverride: "deepseek", modelOverride: "deepseek-v4-pro" };
+
+let agentsDir: string;
+let POST: (request: Request) => Promise<Response>;
+
+const post = (enabled: boolean) =>
+  POST(new Request("http://clawbox.local/setup-api/local-ai/exclusive", { method: "POST", body: JSON.stringify({ enabled }) }));
+
+beforeEach(async () => {
+  state.store.clear();
+  agentsDir = mkdtempSync(path.join(os.tmpdir(), "clawbox-local-only-"));
+  process.env.OPENCLAW_AGENTS_DIR = agentsDir;
+  vi.resetModules();
+  ({ POST } = await import("@/app/setup-api/local-ai/exclusive/route"));
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  rmSync(agentsDir, { recursive: true, force: true });
+  delete process.env.OPENCLAW_AGENTS_DIR;
+});
+
+function writeSessionsJson(agentId: string, sessions: Record<string, unknown>): string {
+  const dir = path.join(agentsDir, agentId, "sessions");
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, "sessions.json");
+  writeFileSync(file, JSON.stringify(sessions));
+  return file;
+}
+
+describe("Local-only on (sessions)", () => {
+  beforeEach(() => {
+    state.store.set("local_ai_model", "llamacpp/gemma4-e2b-it-q4_0");
+    rows.mockReturnValue([
+      { key: "agent:main:clawbox-1", entry: { sessionId: "s1" } },
+      { key: "agent:main:main", entry: { sessionId: "s-main", ...DEEPSEEK_PIN } },
+      { key: "agent:main:retained", entry: {} },
+    ]);
+  });
+
+  it("switches the store's sessions through the gateway and records only what it confirmed", async () => {
+    // A migrated agent's leftover sessions.json is an archive, not a store.
+    const archive = writeSessionsJson("main", { "agent:main:main": { sessionId: "old", ...DEEPSEEK_PIN } });
+    const legacy = writeSessionsJson("legacy", { "agent:legacy:main": { sessionId: "l1", ...DEEPSEEK_PIN } });
+    answering({ "agent:main:clawbox-1": { code: "INVALID_REQUEST", message: "model selection is locked" } });
+
+    const res = await post(true);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      enabled: true,
+      warning: expect.stringMatching(/^1 open chat\(s\) could not be switched to the local model/),
+    });
+    expect(gateway).toHaveBeenCalledTimes(1);
+    expect(gateway).toHaveBeenCalledWith(
+      "sessions.patchMany",
+      {
+        targets: [
+          { key: "agent:main:clawbox-1", agentId: "main" },
+          { key: "agent:main:main", agentId: "main" },
+        ],
+        patch: { model: "llamacpp/gemma4-e2b-it-q4_0" },
+      },
+      expect.anything(),
+    );
+    expect(state.store.get("local_only_mode")).toBe(true);
+    expect(state.store.get("local_only_saved_primary")).toBe("deepseek/deepseek-v4-pro");
+    // The refused session is not in the backup: nothing changed there, so
+    // there is nothing to put back.
+    expect(state.store.get("local_only_saved_session_overrides")).toEqual({
+      "sqlite:main": { "agent:main:main": DEEPSEEK_PIN },
+      [legacy]: { "agent:legacy:main": DEEPSEEK_PIN },
+    });
+    expect(JSON.parse(readFileSync(archive, "utf8"))["agent:main:main"].modelOverride).toBe("deepseek-v4-pro");
+    expect(JSON.parse(readFileSync(legacy, "utf8"))["agent:legacy:main"].modelOverride).toBe("gemma4-e2b-it-q4_0");
+  });
+});
+
+describe("Local-only off (sessions)", () => {
+  beforeEach(() => {
+    state.store.set("local_only_mode", true);
+    state.store.set("local_only_saved_primary", "deepseek/deepseek-v4-pro");
+    state.store.set("local_only_saved_session_overrides", {
+      "sqlite:main": {
+        "agent:main:main": DEEPSEEK_PIN,
+        "agent:main:clawbox-1": {},
+        "agent:main:closed": DEEPSEEK_PIN,
+      },
+    });
+    // `closed` was deleted while Local-only was on: only a placeholder is left.
+    rows.mockReturnValue([
+      { key: "agent:main:clawbox-1", entry: { sessionId: "s1", providerOverride: "llamacpp", modelOverride: "gemma4-e2b-it-q4_0" } },
+      { key: "agent:main:closed", entry: {} },
+      { key: "agent:main:main", entry: { sessionId: "s-main", providerOverride: "llamacpp", modelOverride: "gemma4-e2b-it-q4_0" } },
+    ]);
+  });
+
+  it("puts each live session back on its snapshot's model, or on the agent default, and skips deleted ones", async () => {
+    answering();
+
+    const res = await post(false);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ enabled: false });
+    const calls = gateway.mock.calls.map(([method, params]) => [method, params]);
+    expect(calls).toEqual([
+      ["sessions.patchMany", { targets: [{ key: "agent:main:main", agentId: "main" }], patch: { model: "deepseek/deepseek-v4-pro" } }],
+      ["sessions.patchMany", { targets: [{ key: "agent:main:clawbox-1", agentId: "main" }], patch: { model: null } }],
+    ]);
+    expect(state.store.has("local_only_mode")).toBe(false);
+    expect(state.store.has("local_only_saved_session_overrides")).toBe(false);
+  });
+
+  it("finishes the toggle when a refusal will not change, and says which chats stayed local", async () => {
+    answering({ "agent:main:main": { code: "INVALID_REQUEST", message: "unknown model: deepseek/deepseek-v4-pro" } });
+
+    const res = await post(false);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      enabled: false,
+      warning: expect.stringMatching(/^1 chat\(s\) could not be switched back and stay on the local model/),
+    });
+    expect(state.store.has("local_only_mode")).toBe(false);
+    expect(state.store.has("local_only_saved_session_overrides")).toBe(false);
+  });
+
+  it("keeps Local-only on, with the snapshot, and answers a failure status when the gateway refused for now", async () => {
+    gateway.mockRejectedValue(new Error("gateway closed (1006)"));
+
+    const res = await post(false);
+
+    // The panel reads `res.ok` as "the switch moved"; a 2xx here would paint
+    // the toggle OFF over a box still in Local-only.
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      enabled: true,
+      restoreIncomplete: true,
+      error: expect.stringMatching(/could not be switched back yet/),
+    });
+    expect(state.store.get("local_only_mode")).toBe(true);
+    expect(state.store.get("local_only_saved_session_overrides")).toEqual({
+      "sqlite:main": { "agent:main:main": DEEPSEEK_PIN, "agent:main:clawbox-1": {}, "agent:main:closed": DEEPSEEK_PIN },
+    });
+  }, 10_000);
+});

--- a/src/tests/routes/local-ai-exclusive-sessions.test.ts
+++ b/src/tests/routes/local-ai-exclusive-sessions.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/openclaw-session-store", () => ({
   readSessionEntries: vi.fn(),
 }));
 
-import { callGatewayRpc } from "@/lib/openclaw-config";
+import { callGatewayRpc, runOpenclawConfigSet } from "@/lib/openclaw-config";
 import { readSessionEntries } from "@/lib/openclaw-session-store";
 
 type Params = { targets: Array<{ key: string; agentId: string }>; patch: { model: string | null } };
@@ -51,6 +51,7 @@ type Outcome = { ok: boolean; key: string; agentId?: string; error?: { code: str
 
 const gateway = vi.mocked(callGatewayRpc);
 const rows = vi.mocked(readSessionEntries);
+const configWrites = () => vi.mocked(runOpenclawConfigSet).mock.calls.map(([args]) => args);
 
 /** Answers every target `ok`, except the keys in `refuse`. */
 function answering(refuse: Record<string, { code: string; message: string }> = {}) {
@@ -139,11 +140,28 @@ describe("Local-only on (sessions)", () => {
     expect(JSON.parse(readFileSync(archive, "utf8"))["agent:main:main"].modelOverride).toBe("deepseek-v4-pro");
     expect(JSON.parse(readFileSync(legacy, "utf8"))["agent:legacy:main"].modelOverride).toBe("gemma4-e2b-it-q4_0");
   });
+
+  it("says so when an agent's sessions could not be listed, instead of claiming every chat is local", async () => {
+    rows.mockReturnValue(null);
+    answering();
+
+    const res = await post(true);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      enabled: true,
+      warning: expect.stringMatching(/^The sessions of 1 agent\(s\) could not be listed/),
+    });
+    expect(gateway).not.toHaveBeenCalled();
+    expect(state.store.get("local_only_mode")).toBe(true);
+    expect(state.store.get("local_only_saved_session_overrides")).toEqual({});
+  });
 });
 
 describe("Local-only off (sessions)", () => {
   beforeEach(() => {
     state.store.set("local_only_mode", true);
+    state.store.set("local_ai_model", "llamacpp/gemma4-e2b-it-q4_0");
     state.store.set("local_only_saved_primary", "deepseek/deepseek-v4-pro");
     state.store.set("local_only_saved_session_overrides", {
       "sqlite:main": {
@@ -171,6 +189,27 @@ describe("Local-only off (sessions)", () => {
     expect(calls).toEqual([
       ["sessions.patchMany", { targets: [{ key: "agent:main:main", agentId: "main" }], patch: { model: "deepseek/deepseek-v4-pro" } }],
       ["sessions.patchMany", { targets: [{ key: "agent:main:clawbox-1", agentId: "main" }], patch: { model: null } }],
+    ]);
+    expect(state.store.has("local_only_mode")).toBe(false);
+    expect(state.store.has("local_only_saved_session_overrides")).toBe(false);
+  });
+
+  it("routes a backup that names a since-migrated sessions.json through the gateway", async () => {
+    // Local-only went on before the OpenClaw 2 migration: the backup names
+    // the agent's sessions.json, which the doctor has since folded into the
+    // store and removed. Same keys, same entries — restore them where the
+    // gateway reads them now, for the sessions that still exist.
+    const archive = path.join(agentsDir, "main", "sessions", "sessions.json");
+    state.store.set("local_only_saved_session_overrides", {
+      [archive]: { "agent:main:main": DEEPSEEK_PIN, "agent:main:closed": DEEPSEEK_PIN },
+    });
+    answering();
+
+    const res = await post(false);
+
+    expect(res.status).toBe(200);
+    expect(gateway.mock.calls.map(([method, params]) => [method, params])).toEqual([
+      ["sessions.patchMany", { targets: [{ key: "agent:main:main", agentId: "main" }], patch: { model: "deepseek/deepseek-v4-pro" } }],
     ]);
     expect(state.store.has("local_only_mode")).toBe(false);
     expect(state.store.has("local_only_saved_session_overrides")).toBe(false);
@@ -207,5 +246,14 @@ describe("Local-only off (sessions)", () => {
     expect(state.store.get("local_only_saved_session_overrides")).toEqual({
       "sqlite:main": { "agent:main:main": DEEPSEEK_PIN, "agent:main:clawbox-1": {}, "agent:main:closed": DEEPSEEK_PIN },
     });
+    // The box must be what the mode says it is: the cloud primary written
+    // for the restore goes back to the local model, and the saved primary
+    // survives so the next toggle-off starts over.
+    expect(configWrites()).toEqual([
+      ["agents.defaults.model.primary", JSON.stringify("deepseek/deepseek-v4-pro"), "--json"],
+      ["agents.defaults.model.primary", JSON.stringify("llamacpp/gemma4-e2b-it-q4_0"), "--json"],
+      ["agents.defaults.model.fallbacks", "[]", "--json"],
+    ]);
+    expect(state.store.get("local_only_saved_primary")).toBe("deepseek/deepseek-v4-pro");
   }, 10_000);
 });

--- a/src/tests/unit/apply-model-override-v2-store.test.ts
+++ b/src/tests/unit/apply-model-override-v2-store.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { createRequire } from "module";
+import os from "os";
+import path from "path";
+import { applyModelOverrideToAllAgentSessions } from "@/lib/openclaw-config";
+
+// The OpenClaw 2 (2026.8.x) agent store, as the installed core creates it. The
+// trigger is copied from the dist: the core owns `session_nodes`, and ANY
+// external rewrite of `entry_json` flips `entry_valid` to 0. The core's scan
+// then throws SessionCanonicalKeyMigrationRequiredError for that row at the
+// next gateway start, and the box is dead until `openclaw doctor --fix`.
+// Finding M-03: a model switch swept every row with a direct UPDATE, so one
+// switch invalidated every session.
+const requireNodeSqlite = createRequire(import.meta.url);
+const { DatabaseSync } = requireNodeSqlite("node:sqlite");
+
+const tmpRoots: string[] = [];
+
+function makeV2AgentStore(agentId: string, entries: Record<string, object>): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), "clawbox-v2-store-"));
+  tmpRoots.push(root);
+  const agentDir = path.join(root, agentId, "agent");
+  mkdirSync(agentDir, { recursive: true });
+  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+  db.exec("PRAGMA user_version = 19");
+  db.exec(`CREATE TABLE session_nodes (
+    session_key TEXT PRIMARY KEY,
+    entry_json TEXT NOT NULL,
+    current_session_id TEXT,
+    entry_valid INTEGER NOT NULL DEFAULT 1,
+    updated_at INTEGER NOT NULL DEFAULT 0
+  )`);
+  db.exec(`CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_entry_update
+    AFTER UPDATE OF entry_json ON session_nodes
+    BEGIN UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key; END`);
+  const insert = db.prepare(
+    "INSERT INTO session_nodes (session_key, entry_json, current_session_id, entry_valid, updated_at) VALUES (?, ?, ?, 1, 1000)",
+  );
+  for (const [key, entry] of Object.entries(entries)) {
+    const sessionId = (entry as { sessionId?: string }).sessionId ?? null;
+    insert.run(key, JSON.stringify(entry), sessionId);
+  }
+  db.close();
+  return root;
+}
+
+function readRows(root: string, agentId = "main") {
+  const db = new DatabaseSync(path.join(root, agentId, "agent", "openclaw-agent.sqlite"), { readOnly: true });
+  const rows = db
+    .prepare("SELECT session_key AS key, entry_json AS entry, entry_valid AS valid FROM session_nodes ORDER BY session_key")
+    .all() as Array<{ key: string; entry: string; valid: number }>;
+  db.close();
+  return rows;
+}
+
+afterEach(() => {
+  for (const root of tmpRoots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("applyModelOverrideToAllAgentSessions on an OpenClaw 2 (SQLite) agent store", () => {
+  const seed = {
+    "agent:main:main": { sessionId: "sid-main", modelOverride: "old-model", providerOverride: "openai", modelOverrideSource: "user" },
+    "agent:main:clawbox-abc": { sessionId: "sid-abc", modelOverride: "old-model", providerOverride: "openai", modelOverrideSource: "auto" },
+  };
+
+  it("never rewrites session_nodes: every row keeps entry_valid = 1 and its entry_json", async () => {
+    const root = makeV2AgentStore("main", seed);
+    const before = readRows(root);
+    const callGateway = vi.fn(async (_method: string, params: Record<string, unknown>) => ({
+      outcomes: (params.targets as Array<{ key: string }>).map((t) => ({ ok: true, key: t.key })),
+    }));
+
+    await applyModelOverrideToAllAgentSessions(
+      { provider: "deepseek", modelId: "deepseek-v4-pro" },
+      { agentsDir: root, callGateway },
+    );
+
+    const after = readRows(root);
+    expect(after.map((r) => r.valid)).toEqual([1, 1]);
+    expect(after).toEqual(before);
+  });
+
+  it("applies the override through the gateway's sessions.patchMany, one target per real session", async () => {
+    const root = makeV2AgentStore("main", {
+      ...seed,
+      // A `{}` placeholder row (the core keeps these with entry_valid = -1 for
+      // a retention window) has no session to patch; patching it would create one.
+      "agent:main:retained": {},
+    });
+    const callGateway = vi.fn(async (_method: string, params: Record<string, unknown>) => ({
+      outcomes: (params.targets as Array<{ key: string }>).map((t) => ({ ok: true, key: t.key })),
+    }));
+
+    const result = await applyModelOverrideToAllAgentSessions(
+      { provider: "deepseek", modelId: "deepseek-v4-pro", source: "user" },
+      { agentsDir: root, callGateway },
+    );
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(callGateway).toHaveBeenCalledWith(
+      "sessions.patchMany",
+      {
+        targets: [
+          { key: "agent:main:clawbox-abc", agentId: "main" },
+          { key: "agent:main:main", agentId: "main" },
+        ],
+        patch: { model: "deepseek/deepseek-v4-pro" },
+      },
+      expect.anything(),
+    );
+    expect(result).toEqual({ filesUpdated: 1, sessionsUpdated: 2, sessionsSkipped: 0 });
+  });
+
+  it("reports a session the gateway refused instead of falling back to SQL", async () => {
+    const root = makeV2AgentStore("main", seed);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const callGateway = vi.fn(async (_method: string, params: Record<string, unknown>) => ({
+      outcomes: (params.targets as Array<{ key: string }>).map((t) =>
+        t.key === "agent:main:main"
+          ? { ok: false, key: t.key, error: { code: "INVALID_REQUEST", message: "model selection is locked" } }
+          : { ok: true, key: t.key },
+      ),
+    }));
+
+    const result = await applyModelOverrideToAllAgentSessions(
+      { provider: "deepseek", modelId: "deepseek-v4-pro" },
+      { agentsDir: root, callGateway },
+    );
+
+    expect(result).toEqual({ filesUpdated: 1, sessionsUpdated: 1, sessionsSkipped: 1 });
+    expect(readRows(root).map((r) => r.valid)).toEqual([1, 1]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("agent:main:main"), expect.stringContaining("model selection is locked"));
+  });
+
+  it("keeps the legacy sessions.json rewrite for a v1 agent and never calls the gateway for it", async () => {
+    const root = makeV2AgentStore("main", seed);
+    const legacyDir = path.join(root, "legacy", "sessions");
+    mkdirSync(legacyDir, { recursive: true });
+    const legacyPath = path.join(legacyDir, "sessions.json");
+    writeFileSync(legacyPath, JSON.stringify({ "agent:legacy:main": { sessionId: "sid-l", modelOverride: "old" } }));
+    const callGateway = vi.fn(async (_method: string, params: Record<string, unknown>) => ({
+      outcomes: (params.targets as Array<{ key: string }>).map((t) => ({ ok: true, key: t.key })),
+    }));
+
+    const result = await applyModelOverrideToAllAgentSessions(
+      { provider: "deepseek", modelId: "deepseek-v4-pro" },
+      { agentsDir: root, callGateway },
+    );
+
+    expect(result).toEqual({ filesUpdated: 2, sessionsUpdated: 3, sessionsSkipped: 0 });
+    const legacy = JSON.parse(readFileSync(legacyPath, "utf8"));
+    expect(legacy["agent:legacy:main"].modelOverride).toBe("deepseek-v4-pro");
+    expect(legacy["agent:legacy:main"].providerOverride).toBe("deepseek");
+    // Only the v2 agent's sessions went through the gateway.
+    const targets = callGateway.mock.calls.flatMap(([, params]) => (params.targets as Array<{ agentId: string }>).map((t) => t.agentId));
+    expect(targets).toEqual(["main", "main"]);
+  });
+});

--- a/src/tests/unit/openclaw-session-model.test.ts
+++ b/src/tests/unit/openclaw-session-model.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isPatchableSession,
+  patchSessionModels,
+  sessionModelRef,
+  SESSIONS_PATCH_MANY_MAX_TARGETS,
+  type GatewayRpcCall,
+  type SessionPatchTarget,
+} from "@/lib/openclaw-session-model";
+
+type Params = { targets: SessionPatchTarget[]; patch: { model: string | null } };
+
+/** A gateway that answers `ok` for every target, unless `refuse` names it. */
+function gatewayOf(refuse: Record<string, { code?: string; message?: string }> = {}) {
+  // Typed as the real transport, so the fake cannot drift from the contract.
+  return vi.fn<GatewayRpcCall>(async (_method, params) => {
+    const { targets } = params as Params;
+    return {
+      outcomes: targets.map((t) =>
+        refuse[t.key] ? { ok: false, key: t.key, agentId: t.agentId, error: refuse[t.key] } : { ok: true, key: t.key, agentId: t.agentId },
+      ),
+    };
+  });
+}
+
+const targets = (...keys: string[]): SessionPatchTarget[] => keys.map((key) => ({ key, agentId: "main" }));
+
+describe("isPatchableSession", () => {
+  it("wants a session id: placeholder rows describe no session to patch", () => {
+    expect(isPatchableSession({ sessionId: "abc" })).toBe(true);
+    expect(isPatchableSession({ sessionId: "" })).toBe(false);
+    expect(isPatchableSession({})).toBe(false);
+    expect(isPatchableSession({ modelOverride: "x" })).toBe(false);
+  });
+});
+
+describe("sessionModelRef", () => {
+  it("reads the override pair, then the legacy pair, else nothing", () => {
+    expect(sessionModelRef({ providerOverride: "deepseek", modelOverride: "deepseek-v4-pro" })).toBe("deepseek/deepseek-v4-pro");
+    expect(sessionModelRef({ modelProvider: "anthropic", model: "claude-sonnet-4-6" })).toBe("anthropic/claude-sonnet-4-6");
+    expect(sessionModelRef({ providerOverride: "deepseek" })).toBeNull();
+    expect(sessionModelRef({ providerOverride: null, modelOverride: "x", modelProvider: "p", model: "m" })).toBe("p/m");
+    expect(sessionModelRef({})).toBeNull();
+  });
+});
+
+describe("patchSessionModels", () => {
+  it("sends one sessions.patchMany with every target and the model, and maps the outcomes back in order", async () => {
+    const call = gatewayOf({ "agent:main:locked": { code: "INVALID_REQUEST", message: "model selection is locked" } });
+
+    const outcomes = await patchSessionModels(targets("agent:main:a", "agent:main:locked", "agent:main:b"), "deepseek/v4", { call });
+
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(call).toHaveBeenCalledWith(
+      "sessions.patchMany",
+      {
+        targets: [
+          { key: "agent:main:a", agentId: "main" },
+          { key: "agent:main:locked", agentId: "main" },
+          { key: "agent:main:b", agentId: "main" },
+        ],
+        patch: { model: "deepseek/v4" },
+      },
+      { timeoutMs: undefined },
+    );
+    expect(outcomes).toEqual([
+      { key: "agent:main:a", agentId: "main", ok: true },
+      { key: "agent:main:locked", agentId: "main", ok: false, error: "model selection is locked", retryable: false },
+      { key: "agent:main:b", agentId: "main", ok: true },
+    ]);
+  });
+
+  it("reads the gateway's own result shape (SessionsPatchManyResultSchema, core v2026.8.1)", async () => {
+    // A literal response, NOT derived from the targets sent, so a drift in the
+    // envelope (`outcomes`, `key`, `agentId`, `error: { code, message }`) is
+    // caught here rather than on the box as N "no outcome" lines.
+    const call = vi.fn<GatewayRpcCall>(async () => ({
+      outcomes: [
+        { ok: true, key: "agent:main:main", agentId: "main" },
+        {
+          ok: false,
+          key: "agent:main:clawbox-1",
+          agentId: "main",
+          error: { code: "INVALID_REQUEST", message: "unknown model: nope/x", details: { retryable: false } },
+        },
+      ],
+    }));
+
+    const outcomes = await patchSessionModels(targets("agent:main:main", "agent:main:clawbox-1"), "nope/x", { call });
+
+    expect(outcomes).toEqual([
+      { key: "agent:main:main", agentId: "main", ok: true },
+      { key: "agent:main:clawbox-1", agentId: "main", ok: false, error: "unknown model: nope/x", retryable: false },
+    ]);
+  });
+
+  it("names the reason when a build sends the error as a bare string", async () => {
+    const call = vi.fn<GatewayRpcCall>(async () => ({
+      outcomes: [{ ok: false, key: "agent:main:a", error: "model catalog is still loading; retry in a few seconds" }],
+    }));
+
+    const outcomes = await patchSessionModels(targets("agent:main:a"), "deepseek/v4", { call, retryDelayMs: 0 });
+
+    // Still recognised as transient, so it was retried once.
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(outcomes[0]).toMatchObject({ ok: false, error: "model catalog is still loading; retry in a few seconds", retryable: true });
+  });
+
+  it("says once, loudly, when the envelope matches none of the targets", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const call = vi.fn<GatewayRpcCall>(async () => ({ results: [{ sessionKey: "agent:main:a", ok: true }] }));
+
+    const outcomes = await patchSessionModels(targets("agent:main:a", "agent:main:b"), "deepseek/v4", { call });
+
+    expect(outcomes.every((o) => !o.ok && !o.retryable)).toBe(true);
+    expect(error).toHaveBeenCalledTimes(1);
+    expect(error.mock.calls[0][0]).toMatch(/no recognisable outcome for any of 2 session\(s\); response keys: results/);
+  });
+
+  it("clears the pin with model: null", async () => {
+    const call = gatewayOf();
+    await patchSessionModels(targets("agent:main:a"), null, { call });
+    expect(call.mock.calls[0][1]).toEqual({ targets: [{ key: "agent:main:a", agentId: "main" }], patch: { model: null } });
+  });
+
+  it("splits more targets than the gateway accepts per call into several calls", async () => {
+    const call = gatewayOf();
+    const many = targets(...Array.from({ length: SESSIONS_PATCH_MANY_MAX_TARGETS + 5 }, (_, i) => `agent:main:s${i}`));
+
+    const outcomes = await patchSessionModels(many, "deepseek/v4", { call });
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect((call.mock.calls[0][1] as Params).targets).toHaveLength(SESSIONS_PATCH_MANY_MAX_TARGETS);
+    expect((call.mock.calls[1][1] as Params).targets).toHaveLength(5);
+    expect(outcomes.every((o) => o.ok)).toBe(true);
+    expect(outcomes.map((o) => o.key)).toEqual(many.map((t) => t.key));
+  });
+
+  it("reports a target the gateway said nothing about as not patched", async () => {
+    const call = vi.fn<GatewayRpcCall>(async () => ({ outcomes: [{ ok: true, key: "agent:main:a" }] }));
+
+    const outcomes = await patchSessionModels(targets("agent:main:a", "agent:main:b"), "deepseek/v4", { call });
+
+    expect(outcomes).toEqual([
+      { key: "agent:main:a", agentId: "main", ok: true },
+      { key: "agent:main:b", agentId: "main", ok: false, error: "the gateway reported no outcome for this session", retryable: false },
+    ]);
+  });
+
+  it("retries once, for the transient targets only, when the catalog is still loading", async () => {
+    // The core answers UNAVAILABLE "model catalog is still loading; retry in a
+    // few seconds" right after a config change — exactly when a switch runs.
+    let attempt = 0;
+    const call = vi.fn<GatewayRpcCall>(async (_method, params) => {
+      attempt += 1;
+      const { targets } = params as Params;
+      return {
+        outcomes: targets.map((t) =>
+          t.key === "agent:main:slow" && attempt === 1
+            ? { ok: false, key: t.key, error: { code: "UNAVAILABLE", message: "model catalog is still loading; retry in a few seconds" } }
+            : t.key === "agent:main:locked"
+              ? { ok: false, key: t.key, error: { code: "INVALID_REQUEST", message: "model selection is locked" } }
+              : { ok: true, key: t.key },
+        ),
+      };
+    });
+
+    const outcomes = await patchSessionModels(targets("agent:main:a", "agent:main:slow", "agent:main:locked"), "deepseek/v4", { call, retryDelayMs: 0 });
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect((call.mock.calls[1][1] as Params).targets).toEqual([{ key: "agent:main:slow", agentId: "main" }]);
+    expect(outcomes).toEqual([
+      { key: "agent:main:a", agentId: "main", ok: true },
+      { key: "agent:main:slow", agentId: "main", ok: true },
+      { key: "agent:main:locked", agentId: "main", ok: false, error: "model selection is locked", retryable: false },
+    ]);
+  });
+
+  it("retries once when the gateway was not reachable, then reports every target with the transport's words", async () => {
+    const call = vi.fn<GatewayRpcCall>(async () => {
+      throw new Error("gateway closed (1006)");
+    });
+
+    const outcomes = await patchSessionModels(targets("agent:main:a", "agent:main:b"), "deepseek/v4", { call, retryDelayMs: 0 });
+
+    expect(call).toHaveBeenCalledTimes(2);
+    expect(outcomes).toEqual([
+      { key: "agent:main:a", agentId: "main", ok: false, error: "gateway closed (1006)", retryable: true },
+      { key: "agent:main:b", agentId: "main", ok: false, error: "gateway closed (1006)", retryable: true },
+    ]);
+  });
+
+  it("does not retry a refusal that will not change", async () => {
+    const call = gatewayOf({ "agent:main:a": { code: "INVALID_REQUEST", message: "unknown model: nope/x" } });
+    await patchSessionModels(targets("agent:main:a"), "nope/x", { call, retryDelayMs: 0 });
+    expect(call).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards the timeout to the transport", async () => {
+    const call = gatewayOf();
+    await patchSessionModels(targets("agent:main:a"), "deepseek/v4", { call, timeoutMs: 5_000 });
+    expect(call.mock.calls[0][2]).toEqual({ timeoutMs: 5_000 });
+  });
+});

--- a/src/tests/unit/openclaw-session-store.test.ts
+++ b/src/tests/unit/openclaw-session-store.test.ts
@@ -1,11 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { createRequire } from "module";
-import { Worker } from "node:worker_threads";
 import os from "os";
 import path from "path";
-import { sweepSessionEntries } from "@/lib/openclaw-session-store";
-import { applyModelOverrideToAllAgentSessions } from "@/lib/openclaw-config";
+import { readSessionEntries, sessionStorePath } from "@/lib/openclaw-session-store";
 
 // vite cannot bundle the builtin, so the fixtures reach node:sqlite lazily
 // too. createRequire is fine HERE — vitest never bundles a test file — and
@@ -16,32 +14,36 @@ const { DatabaseSync } = requireNodeSqlite("node:sqlite");
 
 const tmpRoots: string[] = [];
 
-function makeAgentStore(userVersion: number, entries: Record<string, object>) {
+/** A store shaped like the one OpenClaw 2026.8.1 creates, trigger included. */
+function makeAgentStore(entries: Record<string, string>) {
   const root = mkdtempSync(path.join(os.tmpdir(), "clawbox-session-store-"));
   tmpRoots.push(root);
   const agentDir = path.join(root, "main", "agent");
   mkdirSync(agentDir, { recursive: true });
   const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
-  db.exec(`PRAGMA user_version = ${userVersion}`);
-  db.exec("CREATE TABLE session_nodes (session_key TEXT PRIMARY KEY, entry_json TEXT, updated_at INTEGER)");
-  const insert = db.prepare("INSERT INTO session_nodes (session_key, entry_json, updated_at) VALUES (?, ?, 0)");
-  for (const [key, entry] of Object.entries(entries)) insert.run(key, JSON.stringify(entry));
+  db.exec("PRAGMA user_version = 19");
+  db.exec("CREATE TABLE session_nodes (session_key TEXT PRIMARY KEY, entry_json TEXT NOT NULL, entry_valid INTEGER NOT NULL DEFAULT 1, updated_at INTEGER NOT NULL DEFAULT 0)");
+  db.exec(`CREATE TRIGGER session_nodes_entry_valid_after_entry_update
+    AFTER UPDATE OF entry_json ON session_nodes
+    BEGIN UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key; END`);
+  const insert = db.prepare("INSERT INTO session_nodes (session_key, entry_json) VALUES (?, ?)");
+  for (const [key, entry] of Object.entries(entries)) insert.run(key, entry);
   db.close();
   return root;
 }
 
-function readEntries(root: string): Record<string, Record<string, unknown>> {
+function readValidity(root: string): number[] {
   const db = new DatabaseSync(path.join(root, "main", "agent", "openclaw-agent.sqlite"), { readOnly: true });
-  const rows = db.prepare("SELECT session_key AS key, entry_json AS entry FROM session_nodes").all() as Array<{ key: string; entry: string }>;
+  const rows = db.prepare("SELECT entry_valid AS valid FROM session_nodes").all() as Array<{ valid: number }>;
   db.close();
-  return Object.fromEntries(rows.map((r) => [r.key, JSON.parse(r.entry)]));
+  return rows.map((r) => r.valid);
 }
 
 afterEach(() => {
   for (const root of tmpRoots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("sweepSessionEntries schema guard", () => {
+describe("openclaw-session-store", () => {
   it("uses the device home fallback when HOME is present but empty", async () => {
     const originalClawboxHome = process.env.CLAWBOX_OPENCLAW_HOME;
     const originalOpenclawHome = process.env.OPENCLAW_HOME;
@@ -65,82 +67,57 @@ describe("sweepSessionEntries schema guard", () => {
     }
   });
 
-  it("sweeps a store at the schema it knows (2026.8.1 stamps v19)", () => {
-    const root = makeAgentStore(19, { "agent:main:main": { modelOverride: "old/model" } });
-    const result = sweepSessionEntries("main", (_key, entry) => {
-      entry.modelOverride = "new/model";
-      return true;
-    }, root);
-    expect(result).toEqual({ updated: 1, ok: true });
-    expect(readEntries(root)["agent:main:main"].modelOverride).toBe("new/model");
+  describe("readSessionEntries", () => {
+    it("returns every object entry, by key, and skips rows that describe no session", () => {
+      const root = makeAgentStore({
+        "agent:main:main": JSON.stringify({ sessionId: "s1", modelOverride: "old/model" }),
+        "agent:main:clawbox-1": JSON.stringify({ sessionId: "s2" }),
+        "agent:main:broken": "{ not json",
+        "agent:main:list": "[1, 2]",
+      });
+      expect(readSessionEntries("main", root)).toEqual([
+        { key: "agent:main:clawbox-1", entry: { sessionId: "s2" } },
+        { key: "agent:main:main", entry: { sessionId: "s1", modelOverride: "old/model" } },
+      ]);
+    });
+
+    it("is null for an agent without a store, and for a store that cannot be read", () => {
+      const root = mkdtempSync(path.join(os.tmpdir(), "clawbox-session-store-"));
+      tmpRoots.push(root);
+      expect(readSessionEntries("main", root)).toBeNull();
+
+      const agentDir = path.join(root, "main", "agent");
+      mkdirSync(agentDir, { recursive: true });
+      writeFileSync(path.join(agentDir, "openclaw-agent.sqlite"), "not a database");
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      expect(sessionStorePath("main", root)).not.toBeNull();
+      expect(readSessionEntries("main", root)).toBeNull();
+      expect(warn).toHaveBeenCalled();
+    });
+
+    it("leaves the core's row validity untouched", () => {
+      const root = makeAgentStore({ "agent:main:main": JSON.stringify({ sessionId: "s1" }) });
+      readSessionEntries("main", root);
+      expect(readValidity(root)).toEqual([1]);
+    });
   });
 
-  it("refuses to write a NEWER schema than it knows, the way OpenClaw's own store code does", () => {
-    // OpenClaw hard-refuses user_version above its build's cap
-    // (createNewerSqliteSchemaVersionError); a blind UPDATE from ClawBox
-    // against a newer core could corrupt what it no longer understands —
-    // the auth-profiles lesson, one store over.
-    const root = makeAgentStore(20, { "agent:main:main": { modelOverride: "old/model" } });
-    const result = sweepSessionEntries("main", (_key, entry) => {
-      entry.modelOverride = "new/model";
-      return true;
-    }, root);
-    expect(result).toEqual({ updated: 0, ok: false, unsupportedSchema: 20 });
-    expect(readEntries(root)["agent:main:main"].modelOverride).toBe("old/model");
-  });
-
-  it("takes the write reservation before checking schema so a concurrent migration cannot race it", async () => {
-    const root = makeAgentStore(19, { "agent:main:main": { modelOverride: "old/model" } });
-    const dbPath = path.join(root, "main", "agent", "openclaw-agent.sqlite");
-    const worker = new Worker(`
-      const { parentPort, workerData } = require("node:worker_threads");
-      const { DatabaseSync } = require("node:sqlite");
-      const db = new DatabaseSync(workerData.dbPath);
-      db.exec("BEGIN IMMEDIATE; PRAGMA user_version = 20");
-      parentPort.postMessage("migration-started");
-      setTimeout(() => {
-        db.exec("COMMIT");
-        db.close();
-        parentPort.postMessage("migration-complete");
-        parentPort.close();
-      }, 100);
-    `, { eval: true, workerData: { dbPath } });
-    const workerError = new Promise<never>((_, reject) => worker.once("error", reject));
-    const nextMessage = () => new Promise<string>((resolve) => worker.once("message", resolve));
-
-    expect(await Promise.race([nextMessage(), workerError])).toBe("migration-started");
-    const workerExit = new Promise<number>((resolve) => worker.once("exit", resolve));
-
-    // The old ordering read v19 here, then waited for BEGIN IMMEDIATE. Once the
-    // worker committed v20 it blindly updated that newer store. The fixed
-    // ordering waits for the reservation first and therefore observes v20.
-    const result = sweepSessionEntries("main", (_key, entry) => {
-      entry.modelOverride = "new/model";
-      return true;
-    }, root);
-
-    expect(result).toEqual({ updated: 0, ok: false, unsupportedSchema: 20 });
-    expect(readEntries(root)["agent:main:main"].modelOverride).toBe("old/model");
-    expect(await Promise.race([workerExit, workerError])).toBe(0);
-  });
-
-  it("does not mutate a leftover sessions.json after a newer SQLite schema refuses the sweep", async () => {
-    const root = makeAgentStore(20, { "agent:main:main": { modelOverride: "sqlite/old" } });
-    const sessionsDir = path.join(root, "main", "sessions");
-    const legacyPath = path.join(sessionsDir, "sessions.json");
-    mkdirSync(sessionsDir, { recursive: true });
-    writeFileSync(legacyPath, JSON.stringify({
-      "agent:main:main": { modelOverride: "legacy/old" },
-    }));
-
-    const result = await applyModelOverrideToAllAgentSessions({
-      provider: "deepseek",
-      modelId: "deepseek-v4-pro",
-    }, { agentsDir: root });
-
-    expect(result).toEqual({ filesUpdated: 0, sessionsUpdated: 0 });
-    expect(readEntries(root)["agent:main:main"].modelOverride).toBe("sqlite/old");
-    expect(JSON.parse(readFileSync(legacyPath, "utf8"))["agent:main:main"].modelOverride)
-      .toBe("legacy/old");
+  it("carries no write path to the store at all", () => {
+    // The core invalidates any row whose entry_json is rewritten by anything
+    // but itself (finding M-03: the old sweep here bricked chat on every model
+    // switch). Everything that changes an entry goes through the gateway's
+    // API; this module only ever opens the store read-only. A tripwire, so the
+    // next "small" write cannot come back quietly.
+    const source = readFileSync(path.resolve(__dirname, "../../lib/openclaw-session-store.ts"), "utf8");
+    const code = source
+      .split("\n")
+      .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+      .join("\n");
+    expect(code).not.toMatch(/\b(UPDATE|INSERT|DELETE|REPLACE)\b/);
+    // `openSqlite(path, readOnly)` is exported for the gateway-wide state
+    // store (a different database); every use INSIDE this module is read-only.
+    const uses = (code.match(/openSqlite\([^)]*\)/g) ?? []).filter((call) => !call.startsWith("openSqlite(dbPath: string"));
+    expect(uses.length).toBeGreaterThan(0);
+    for (const use of uses) expect(use).toMatch(/,\s*true\)$/);
   });
 });

--- a/src/tests/unit/openclaw-session-store.test.ts
+++ b/src/tests/unit/openclaw-session-store.test.ts
@@ -113,7 +113,10 @@ describe("openclaw-session-store", () => {
       .split("\n")
       .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
       .join("\n");
-    expect(code).not.toMatch(/\b(?:UPDATE|INSERT|DELETE|REPLACE)\b/i);
+    // DML, DDL and the maintenance verbs alike. PRAGMA is not listed: the one
+    // here (`busy_timeout`) is connection-scoped, and a read-only connection
+    // cannot write `user_version` or anything else anyway.
+    expect(code).not.toMatch(/\b(?:UPDATE|INSERT|DELETE|REPLACE|CREATE|DROP|ALTER|VACUUM|REINDEX|ANALYZE)\b/i);
     // `openSqlite(path, readOnly)` is exported for the gateway-wide state
     // store (a different database); every use INSIDE this module is read-only,
     // and it is the only constructor path, so that covers every open.

--- a/src/tests/unit/openclaw-session-store.test.ts
+++ b/src/tests/unit/openclaw-session-store.test.ts
@@ -113,9 +113,11 @@ describe("openclaw-session-store", () => {
       .split("\n")
       .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
       .join("\n");
-    expect(code).not.toMatch(/\b(UPDATE|INSERT|DELETE|REPLACE)\b/);
+    expect(code).not.toMatch(/\b(?:UPDATE|INSERT|DELETE|REPLACE)\b/i);
     // `openSqlite(path, readOnly)` is exported for the gateway-wide state
-    // store (a different database); every use INSIDE this module is read-only.
+    // store (a different database); every use INSIDE this module is read-only,
+    // and it is the only constructor path, so that covers every open.
+    expect(code.match(/\bnew DatabaseSync\(/g) ?? []).toHaveLength(1);
     const uses = (code.match(/openSqlite\([^)]*\)/g) ?? []).filter((call) => !call.startsWith("openSqlite(dbPath: string"));
     expect(uses.length).toBeGreaterThan(0);
     for (const use of uses) expect(use).toMatch(/,\s*true\)$/);


### PR DESCRIPTION
**Finding M-03 (board TASK-649)** — a successful model switch corrupted the OpenClaw 2 session store.

## Owner-visible symptom

On the OpenClaw edition with core 2026.8.x, right after a model switch (chat popup or Settings) the gateway logged

```
SessionCanonicalKeyMigrationRequiredError: invalid persisted session row requires repair
for agent:main:clawbox-<id>; stop the Gateway and run openclaw doctor --fix
```

and refused to start. Health refresh, memory dreaming cleanup, the sessions prewarm and the WebSocket `agent`
request all failed with `errorCode=UNAVAILABLE`, and the CLI could not start. Chat was dead until `doctor --fix`.
It was masked until now because the switch itself used to fail earlier (finding M-01, fixed separately in #578).

## Cause

`applyModelOverrideToAllAgentSessions` swept every session through `sweepSessionEntries`, which did

```sql
UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?
```

for every row. The core owns that table, with a trigger (from the installed dist):

```sql
CREATE TRIGGER IF NOT EXISTS session_nodes_entry_valid_after_entry_update
AFTER UPDATE OF entry_json ON session_nodes
BEGIN UPDATE session_nodes SET entry_valid = 0 WHERE session_key = NEW.session_key; END;
```

and its scan throws `canonicalSessionKeyMigrationRequiredError` for any row whose `entry_valid` is not 1.
Only the core's own write path re-validates a row. So **any** external rewrite of `entry_json` invalidates it —
the schema-version guard the sweep carried was beside the point (2026.8.1 stamps exactly the `user_version = 19`
it accepted, so it proceeded). Direct SQL writes into `session_nodes` are never safe on OpenClaw 2.

## Fix

- **v2 (SQLite) agents are repointed through the gateway's own API**: one `sessions.patchMany`
  (`{ targets: [{ key, agentId }], patch: { model: "<provider>/<model>" } }`) per agent, issued through
  `openclaw gateway call sessions.patchMany --params <json> --json`. The store is only ever **read**, to learn
  the session keys. The core then writes `providerOverride` / `modelOverride` / `modelOverrideSource: "user"` /
  `modelOverrideRouteResolution` itself, drops an auth-profile override the new provider cannot use, and folds a
  sticky `thinkingLevel` the new model cannot honour down to one it can — every field the old sweep wrote by
  hand, in the shape their owner validates.
- **v1 agents keep the `sessions.json` file rewrite**, unchanged.
- **A session the gateway refuses is reported, never forced.** There is no fallback to the SQL write; the result
  now carries `sessionsSkipped` and each skip is logged with the gateway's own reason. A *transient* refusal
  (`UNAVAILABLE` — "model catalog is still loading", or a gateway that was not reachable) gets exactly one retry.
- **`sweepSessionEntries` is deleted**, not merely disabled, and `openclaw-session-store.ts` now opens the store
  `readOnly: true` on every path, so there is no write API left for another caller to reach for. A tripwire test
  greps the module for SQL write verbs so it cannot come back quietly.
- **Every sibling call site handled**: `src/app/setup-api/chat/model/route.ts` (~776) and
  `src/app/setup-api/ai-models/configure/route.ts` (~2365) needed no edit — they call the same helper, which now
  routes itself. `src/app/setup-api/local-ai/exclusive/route.ts` had the other two callers (the Local-only
  patch and its restore) and both now go through the gateway; the restore replays each session's snapshotted
  `<provider>/<model>`, or `model: null` to fall back to the agent default when it had no pin.

The Local-only route also had review findings of its own on the newly-fallible path (it had no tests before):
- an incomplete restore now answers **503** with `error` — the panel reads `res.ok` as "the switch moved", so the
  old 200 painted the toggle OFF over a box still in Local-only, with the warning never shown;
- a refusal that will not change (unknown model, a session the gateway does not know) no longer wedges the toggle
  ON for ever: the toggle finishes and the response names how many chats stayed on the local model. Only a
  *retryable* refusal (`retryable: true` on the outcome) keeps the mode and the snapshot for a later attempt;
- the restore re-reads the live store and skips sessions deleted in the meantime (the core keeps a `{}` placeholder
  for those, and a patch would turn it back into a session);
- a migrated agent's leftover `sessions.json` is no longer patched or backed up (it is an archive the gateway does
  not read; restoring it through the store pushed pre-migration values over live sessions);
- refused sessions on *enable* are reported in `warning`, and so is an agent whose store could not be listed at all
  (for Local-only that is a privacy claim, not a routing detail);
- when the restore cannot finish, the cloud primary/fallbacks that were already written back go back to the local
  model and everything saved is kept, so the box is what the mode says it is and the next toggle-off starts over.

One behaviour worth knowing: when the patched model **is** the agent's new default — which it is on both switch
routes, because they write `agents.defaults.model.primary` first — the core records that by *deleting* the
per-session override rather than writing one. That reaches the same place the old hand-written sweep aimed for
(the session resolves to the new primary), expressed the core's way.

## How the contract was confirmed

Against the core release this image pins (`install.sh: OPENCLAW_VERSION="2026.8.1"`), read at tag `v2026.8.1`:
`packages/gateway-protocol/src/schema/sessions-patch.ts` (`SessionsPatchManyParamsSchema` — a closed object of
`targets[]` + `patch`, `model: NonEmptyString | null`, `SESSIONS_PATCH_MANY_MAX_TARGETS = 100`),
`src/gateway/server-methods/sessions-mutations.ts` (the handler and its outcome list),
`src/gateway/sessions-patch.ts` + `src/sessions/model-overrides.ts` (what a `model` patch writes, including the
`isDefault` clear), and `src/cli/gateway-cli/register.ts` (`gateway call <method> --params <json> --json`).
Chunking, the outcome mapping and the `UNAVAILABLE` retry all follow those files.

## RED → GREEN

RED, on unmodified `beta` — the trigger fires and every row is invalidated, and the gateway is never called:

```
 ❯ |unit| src/tests/unit/apply-model-override-v2-store.test.ts (4 tests | 4 failed)
   × never rewrites session_nodes: every row keeps entry_valid = 1 and its entry_json
   × applies the override through the gateway's sessions.patchMany, one target per real session
   × reports a session the gateway refused instead of falling back to SQL
   × keeps the legacy sessions.json rewrite for a v1 agent and never calls the gateway for it

AssertionError: expected [ +0, +0 ] to deeply equal [ 1, 1 ]
  [
-   1,
-   1,
+   0,
+   0,
  ]
 ❯ src/tests/unit/apply-model-override-v2-store.test.ts:80
     80|     expect(after.map((r) => r.valid)).toEqual([1, 1]);

AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
 ❯ src/tests/unit/apply-model-override-v2-store.test.ts:100
    100|     expect(callGateway).toHaveBeenCalledTimes(1);
```

GREEN, whole suite:

```
 Test Files  618 passed (618)
      Tests  8919 passed (8919)
```

plus `tsc --noEmit -p tsconfig.json` at 0 errors and `eslint` clean on the changed files.

The RED fixture is a real temp SQLite file shaped like the v2 store — `session_nodes` with `entry_valid`, the
trigger above, `PRAGMA user_version = 19` — so it fails for exactly the reason the box did.

## Device leg

**Unproven — CI only.** No box was touched for this change: the on-hardware leg (a real switch through
`/setup-api/chat/model` on a 2026.8.1 box, then a gateway start with every row still `entry_valid = 1`) is the
owner's to run. What CI cannot show is whether the gateway's model catalog always has the target at sweep time;
the `UNAVAILABLE` retry covers the documented case, and anything else is now reported as a skipped session
rather than silently forced.

## Follow-up (not in this PR)

Both model-switch routes still discard the sweep's result, as they did before: a per-session refusal is logged with
the gateway's reason but the response says "Switched chat to X" regardless. Surfacing `sessionsSkipped` there means
editing the exact lines #578 is changing and teaching the chat popup a new field, so it is left for a separate PR.

## Merge note

Rebased on `beta` after #574: its exported `openSqlite(dbPath, readOnly)` is kept for `openclaw-state-store.ts`
(a different database, no validity trigger); every use inside `openclaw-session-store.ts` passes `true`, and the
tripwire test checks exactly that.

PR #578 (M-01) touches `src/lib/openclaw-config.ts` and `src/app/setup-api/local-ai/exclusive/route.ts` in
different regions, plus some of the same test files. Its new `src/tests/routes/local-ai/exclusive.test.ts`
mocks `@/lib/openclaw-session-store` with `sweepSessionEntries` (deleted here) and no `readSessionEntries`;
whichever of the two lands second needs that mock factory updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model overrides now support migrated sessions while preserving legacy session handling.
  - Session updates report successful, skipped, and refused sessions for clearer results.
  - Session model changes can be applied or cleared across supported sessions.

- **Bug Fixes**
  - Improved Local-only mode restoration, including retry handling and deleted-session detection.
  - Local-only mode remains enabled when restoration is incomplete, with a service-unavailable response and combined warnings.
  - Session changes avoid modifying sessions that cannot be safely updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->