### PR TITLE
fix: write memory.search.* for local embeddings on OpenClaw 2

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4256,8 +4256,21 @@ step_ollama_install() {
     as_clawbox_login "$ENSURE_EMBEDDINGS" || true
     # The helper exits 0 on every soft failure by design (a missing Ollama must
     # not abort an install), so its exit code says nothing about the outcome.
-    # Read the config it was supposed to write instead.
-    if as_clawbox python3 -c 'import json,sys; ms=((json.load(open("/home/clawbox/.openclaw/openclaw.json")).get("agents",{}).get("defaults",{}) or {}).get("memorySearch",{}) or {}); sys.exit(0 if ms.get("provider")=="ollama" and ms.get("model")=="qwen3-embedding:0.6b" else 1)' 2>/dev/null; then
+    # Read the config it was supposed to write instead — from the ACTIVE home.
+    # Only an OpenClaw 2 core writes memory.search, and once that names a
+    # provider the core ignores agents.defaults.memorySearch entirely — so a
+    # stale legacy block still saying "ollama" from the box's OpenClaw 1 days,
+    # beside a memory.search the owner has since pointed at OpenAI, is a box on
+    # the cloud embedder. "Ready, needs no API key" would be false there.
+    if as_clawbox python3 - /home/clawbox/.openclaw/openclaw.json <<'PY' 2>/dev/null
+import json, sys
+cfg = json.load(open(sys.argv[1]))
+v2 = (cfg.get("memory") or {}).get("search") or {}
+legacy = ((cfg.get("agents") or {}).get("defaults") or {}).get("memorySearch") or {}
+home = v2 if v2.get("provider") else legacy
+sys.exit(0 if home.get("provider") == "ollama" and home.get("model") == "qwen3-embedding:0.6b" else 1)
+PY
+    then
       echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
     else
       echo "  WARN: local embeddings are not configured yet; semantic memory falls back to lexical FTS until the next boot retries it (non-fatal)"

--- a/scripts/ensure-local-embeddings.sh
+++ b/scripts/ensure-local-embeddings.sh
@@ -20,6 +20,14 @@
 # install.sh calls it directly, gateway-pre-start.sh launches it detached (the
 # model is a ~600MB download and pre-start is a blocking ExecStartPre).
 #
+# OpenClaw 2 (2026.8+) moved the choice from agents.defaults.memorySearch.* to
+# memory.search.* and its CLI refuses the retired path outright ("moved to
+# memory.search. Run openclaw doctor --fix"). Measured on a 2026.8.1 box: the
+# config already said memory.search.provider=ollama, this script read the old
+# path, saw "unset", tried the old write and logged "could not set the local
+# embedding model" on every boot — so no upgraded box could be pointed at local
+# embeddings. The key names follow the installed core, decided below.
+#
 # Everything here is best-effort. A failure must leave the box on lexical FTS,
 # never half-configured, and never block the gateway.
 set -euo pipefail
@@ -36,28 +44,72 @@ EMBED_RETRY_SECONDS="${EMBED_RETRY_SECONDS:-21600}"
 
 log() { echo "  [local-embeddings] $*"; }
 
+# --- which generation of OpenClaw will parse what we write? ------------------
+# gateway-pre-start.sh asks the binary and exports CLAWBOX_OPENCLAW_V2 before
+# launching this, so the two cannot disagree. install.sh calls this directly and
+# exports nothing: then read the installed core's own package.json, the one
+# next to the binary (/home/clawbox/.npm-global/lib/node_modules/openclaw) —
+# never `openclaw --version`, which costs ~10s on a Jetson. No core at all (a
+# Hermes box) keeps the legacy names, where the write fails soft as before.
+if [ -z "${CLAWBOX_OPENCLAW_V2:-}" ]; then
+  CLAWBOX_OPENCLAW_V2=0
+  OPENCLAW_PKG="$(dirname "$OPENCLAW_BIN")/../lib/node_modules/openclaw/package.json"
+  INSTALLED_VERSION="$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("version") or "")' "$OPENCLAW_PKG" 2>/dev/null || true)"
+  if [ -n "$INSTALLED_VERSION" ] && [ "$(printf '%s\n' 2026.8 "$INSTALLED_VERSION" | sort -V | head -1)" = "2026.8" ]; then
+    CLAWBOX_OPENCLAW_V2=1
+  fi
+fi
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
+  MEMORY_SEARCH_KEY="memory.search"
+else
+  MEMORY_SEARCH_KEY="agents.defaults.memorySearch"
+fi
+
 # --- read the current choice -------------------------------------------------
 # Read straight from openclaw.json rather than `openclaw config get`: this runs
 # before/around the gateway and a CLI round-trip costs ~10s on a Jetson.
-read_cfg() {
+read_path() {
   python3 - "$OPENCLAW_CONFIG" "$1" <<'PY' 2>/dev/null || true
 import json, sys
 try:
-    cfg = json.load(open(sys.argv[1]))
+    node = json.load(open(sys.argv[1]))
 except Exception:
     print("")
     sys.exit(0)
-ms = ((cfg.get("agents") or {}).get("defaults") or {}).get("memorySearch") or {}
-value = ms.get(sys.argv[2])
-print(value if isinstance(value, str) else "")
+for part in sys.argv[2].split("."):
+    node = node.get(part) if isinstance(node, dict) else None
+print(node if isinstance(node, str) else "")
 PY
 }
+read_cfg() { read_path "$MEMORY_SEARCH_KEY.$1"; }
+
+# The other generation's home. Read for ONE decision, the guard just below.
+if [ "$CLAWBOX_OPENCLAW_V2" = "1" ]; then
+  OTHER_SEARCH_KEY="agents.defaults.memorySearch"
+else
+  OTHER_SEARCH_KEY="memory.search"
+fi
 
 PROVIDER="$(read_cfg provider)"
-case "$PROVIDER" in
+# A remote provider the owner chose is left alone wherever it is recorded. On a
+# box upgraded to OpenClaw 2 whose config `doctor --fix` has not migrated yet,
+# that choice still sits in agents.defaults.memorySearch while memory.search is
+# empty; reading only the live home saw "unset", overwrote it with ollama, and
+# the later migration then had nothing left to carry forward. install.sh's
+# post-run check applies the same rule — the legacy block speaks when the live
+# home is silent. Everything AFTER this guard (the "already configured" test
+# and both writes) stays on the live home, so a legacy "ollama" on a v2 box is
+# migrated, not mistaken for done.
+RECORDED_PROVIDER="$PROVIDER"
+RECORDED_IN="$MEMORY_SEARCH_KEY"
+if [ -z "$RECORDED_PROVIDER" ]; then
+  RECORDED_PROVIDER="$(read_path "$OTHER_SEARCH_KEY.provider")"
+  RECORDED_IN="$OTHER_SEARCH_KEY"
+fi
+case "$RECORDED_PROVIDER" in
   ""|auto|ollama) ;;
   *)
-    log "memorySearch.provider is \"$PROVIDER\" — a deliberate choice, leaving it alone"
+    log "$RECORDED_IN.provider is \"$RECORDED_PROVIDER\" — a deliberate choice, leaving it alone"
     exit 0
     ;;
 esac
@@ -138,7 +190,7 @@ if ! model_present "$TAGS"; then
   state_write "$NOW" 0
   TAGS="$(fetch_tags)"
   if ! model_present "$TAGS"; then
-    log "WARN: $EMBED_MODEL still absent after a successful pull; leaving memorySearch untouched"
+    log "WARN: $EMBED_MODEL still absent after a successful pull; leaving memory search untouched"
     exit 0
   fi
   log "pulled $EMBED_MODEL"
@@ -165,7 +217,7 @@ else
   # embedding backends, so if either call fails the box is left on exactly the
   # provider it already had — never on ollama pointed at the wrong model.
   if [ "$SET_MODEL" -eq 1 ] \
-    && ! "$OPENCLAW_BIN" config set agents.defaults.memorySearch.model "$EMBED_MODEL" >/dev/null 2>&1; then
+    && ! "$OPENCLAW_BIN" config set "$MEMORY_SEARCH_KEY.model" "$EMBED_MODEL" >/dev/null 2>&1; then
     log "WARN: could not set the local embedding model (non-fatal; nothing changed, lexical FTS remains)"
     exit 0
   fi
@@ -176,8 +228,8 @@ else
   # attempt finishes the job, and a stale marker only costs one extra reindex.
   state_set_reindex_pending 1
   if [ "$SET_PROVIDER" -eq 1 ] \
-    && ! "$OPENCLAW_BIN" config set agents.defaults.memorySearch.provider ollama >/dev/null 2>&1; then
-    log "WARN: could not point memorySearch at Ollama (non-fatal; provider is unchanged, lexical FTS remains)"
+    && ! "$OPENCLAW_BIN" config set "$MEMORY_SEARCH_KEY.provider" ollama >/dev/null 2>&1; then
+    log "WARN: could not point memory search at Ollama (non-fatal; provider is unchanged, lexical FTS remains)"
     exit 0
   fi
   log "memory search -> local Ollama embeddings ($EMBED_MODEL, no API key needed)"

--- a/src/lib/memory-shard.ts
+++ b/src/lib/memory-shard.ts
@@ -7,8 +7,10 @@
  * `@/lib/memory-shard-state` instead (types and constants), never this.
  */
 
+import { readFile } from "fs/promises";
+import path from "path";
 import { get as configGet, set as configSet } from "@/lib/config-store";
-import { readConfig, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
+import { findOpenclawBin, readConfig, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
 import {
   EXTRA_PATHS_CONFIG_PATH,
   LOCAL_EMBEDDING_MODEL,
@@ -85,13 +87,57 @@ export async function writeExtraPaths(paths: readonly string[]): Promise<void> {
 }
 
 /**
+ * The installed core's own package.json, derived from the binary the way
+ * scripts/ensure-local-embeddings.sh derives it (`dirname bin`/../lib/…), so
+ * the two writers read one file and cannot disagree about the generation.
+ * Not `openclaw --version`: that costs ~10 s on a Jetson, and this runs on a
+ * wizard click right before a second CLI spawn (the write itself).
+ */
+function openclawPackageJson(): string {
+  return path.join(path.dirname(findOpenclawBin()), "..", "lib", "node_modules", "openclaw", "package.json");
+}
+
+async function installedOpenclawVersion(): Promise<string | null> {
+  try {
+    const pkg = JSON.parse(await readFile(openclawPackageJson(), "utf-8")) as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Where the installed core keeps the embedding choice.
+ *
+ * OpenClaw 2 (2026.8+) moved it from `agents.defaults.memorySearch.*` to
+ * `memory.search.*`, and its CLI refuses the retired path outright ("moved to
+ * memory.search. Run openclaw doctor --fix") — so the names must follow the
+ * core that will parse the write, on the same 2026.8 boundary
+ * scripts/ensure-local-embeddings.sh uses at boot.
+ *
+ * The two differ only when the version cannot be read at all. There, the boot
+ * script keeps the legacy names because it also runs on a Hermes box that has
+ * no core (and no binary to accept either spelling); this path is reached only
+ * by the OpenClaw wizard, so it assumes the generation ClawBox pins instead
+ * (config/openclaw-target.txt, 2026.8.x) — the write fails loudly either way
+ * if that guess is wrong, and every shipping OpenClaw box is on it.
+ */
+export function embeddingConfigHome(version: string | null): "memory.search" | "agents.defaults.memorySearch" {
+  const match = /\b(20\d{2})\.(\d+)\b/.exec(version ?? "");
+  if (match === null) return "memory.search";
+  const [year, month] = match.slice(1).map(Number);
+  const legacy = year < 2026 || (year === 2026 && month < 8);
+  return legacy ? "agents.defaults.memorySearch" : "memory.search";
+}
+
+/**
  * Point the memory index at the model running on this box.
  *
  * Named `switchTo...` rather than `use...`: the `use` prefix is reserved for
  * React hooks and the lint rule reads any such call as one.
  *
- * This is the gap the design surfaced: `agents.defaults.memorySearch` had no
- * route and no TypeScript caller anywhere in the product — only
+ * This is the gap the design surfaced: the embedding choice had no route and
+ * no TypeScript caller anywhere in the product — only
  * scripts/ensure-local-embeddings.sh wrote it, at boot, and on this box it had
  * failed six times in a row. So nothing the owner could click could move memory
  * off the cloud embedder, which is why the panel says "Cloud" while the wizard
@@ -102,9 +148,10 @@ export async function writeExtraPaths(paths: readonly string[]): Promise<void> {
  * that can interleave.
  */
 export async function switchToLocalEmbeddings(): Promise<void> {
+  const home = embeddingConfigHome(await installedOpenclawVersion());
   await runOpenclawConfigSetBatch([
-    ["agents.defaults.memorySearch.provider", "ollama"],
-    ["agents.defaults.memorySearch.model", LOCAL_EMBEDDING_MODEL],
+    [`${home}.provider`, "ollama"],
+    [`${home}.model`, LOCAL_EMBEDDING_MODEL],
   ]);
 }
 

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -74,6 +74,11 @@ beforeEach(() => {
       'if [ "${OPENCLAW_RC:-0}" != "0" ]; then exit "$OPENCLAW_RC"; fi',
       '# FAIL_ON matches against the whole argv so a test can fail exactly one call.',
       'if [ -n "${FAIL_ON:-}" ] && [[ "$*" == *"$FAIL_ON"* ]]; then exit 1; fi',
+      '# OpenClaw 2 refuses the retired key outright, exactly like the real CLI',
+      '# (its owner rule for agents.defaults.memorySearch, verified in 2026.8.1).',
+      'if [ "${STUB_OPENCLAW_V2:-0}" = "1" ] && [ "${1:-}" = "config" ] && [ "${2:-}" = "set" ] && [[ "${3:-}" == agents.defaults.memorySearch* ]]; then',
+      '  echo "agents.defaults.memorySearch moved to memory.search. Run \\"openclaw doctor --fix\\"." >&2; exit 1',
+      'fi',
       'if [ "${1:-}" = "config" ] && [ "${2:-}" = "set" ]; then',
       '  CFG_KEY="$3" CFG_VALUE="$4" python3 - "$TEST_CONFIG" <<\'PY\'',
       "import json, os, sys",
@@ -107,7 +112,21 @@ type RunOpts = {
   failOn?: string;
   flockBin?: string;
   stateFile?: string;
+  /** What gateway-pre-start.sh exports: "1" on OpenClaw 2, "0" before it, unset from install.sh. */
+  v2Env?: "1" | "0";
+  /** Where the fixture keeps provider/model: OpenClaw 2's memory.search or the legacy path. */
+  keys?: "v2" | "legacy";
+  /** Version of the installed core's package.json next to the binary (install.sh path: no env). */
+  installedVersion?: string;
+  /** Whether the stub CLI behaves like OpenClaw 2 (refuses the retired key). */
+  stubV2?: boolean;
 };
+
+/** The real CLI's rule: memory.search from 2026.8 on. */
+function isV2Release(version: string): boolean {
+  const [year, month] = version.split(".").map(Number);
+  return year > 2026 || (year === 2026 && month >= 8);
+}
 
 function run(opts: RunOpts = {}) {
   // Each run starts from a clean call log so a second run in the same test
@@ -116,10 +135,18 @@ function run(opts: RunOpts = {}) {
   const cfg: Record<string, unknown> = {};
   if (opts.provider !== undefined) cfg.provider = opts.provider;
   if (opts.model !== undefined) cfg.model = opts.model;
-  writeFileSync(
-    configPath,
-    JSON.stringify({ agents: { defaults: Object.keys(cfg).length ? { memorySearch: cfg } : {} } }),
-  );
+  const home = opts.keys === "v2" ? { memory: { search: cfg } } : { agents: { defaults: { memorySearch: cfg } } };
+  writeFileSync(configPath, JSON.stringify(Object.keys(cfg).length ? home : { agents: { defaults: {} } }));
+  // The binary lives in bin/ and the core's package.json in ../lib/node_modules/openclaw,
+  // the npm --prefix layout of /home/clawbox/.npm-global on the box.
+  let openclawBin = "openclaw";
+  if (opts.installedVersion !== undefined) {
+    const pkgDir = path.join(dir, "lib", "node_modules", "openclaw");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(path.join(pkgDir, "package.json"), JSON.stringify({ name: "openclaw", version: opts.installedVersion }));
+    openclawBin = path.join(binDir, "openclaw");
+  }
+  const stubV2 = opts.stubV2 ?? (opts.v2Env === "1" || (opts.installedVersion !== undefined && isV2Release(opts.installedVersion)));
   writeFileSync(tagsPath, opts.unreachable ? "" : opts.present ? tags([MODEL]) : tags(["llama3:8b"]));
   if (opts.state !== undefined) {
     mkdirSync(path.dirname(statePath), { recursive: true });
@@ -130,8 +157,10 @@ function run(opts: RunOpts = {}) {
     env: {
       ...process.env,
       PATH: `${binDir}:${process.env.PATH}`,
-      OPENCLAW_BIN: "openclaw",
+      OPENCLAW_BIN: openclawBin,
       OPENCLAW_CONFIG: configPath,
+      CLAWBOX_OPENCLAW_V2: opts.v2Env ?? "",
+      STUB_OPENCLAW_V2: stubV2 ? "1" : "0",
       TEST_CONFIG: configPath,
       OLLAMA_TAGS_URL: "http://stub/api/tags",
       TAGS_FIXTURE: tagsPath,
@@ -152,6 +181,8 @@ function run(opts: RunOpts = {}) {
     stderr: res.stderr ?? "",
     calls,
     memorySearch: (config.agents?.defaults?.memorySearch ?? {}) as Record<string, string>,
+    /** OpenClaw 2's home for the same choice. */
+    search: (config.memory?.search ?? {}) as Record<string, string>,
     state: existsSync(opts.stateFile ?? statePath) ? readFileSync(opts.stateFile ?? statePath, "utf-8") : "",
   };
 }
@@ -338,6 +369,105 @@ describe.skipIf(!canRun)("ensure-local-embeddings.sh", () => {
   });
 });
 
+// OpenClaw 2 (2026.8+) moved the embedding choice from
+// agents.defaults.memorySearch.* to memory.search.* and its CLI refuses the old
+// path ("moved to memory.search. Run openclaw doctor --fix"). Measured on a
+// 2026.8.1 box: openclaw.json already carried memory.search.provider=ollama, the
+// script read the retired path, saw "unset", tried the retired write, and logged
+// "WARN: could not set the local embedding model" on every gateway boot — so
+// no v2 box could ever be pointed at local embeddings, and a correctly
+// configured one was told nothing changed.
+describe.skipIf(!canRun)("ensure-local-embeddings.sh on OpenClaw 2", () => {
+  it("sees a box already on local embeddings under memory.search and leaves it alone", () => {
+    const r = run({ v2Env: "1", keys: "v2", provider: "ollama", model: MODEL, present: true });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("already runs on local embeddings");
+    expect(configSets(r.calls)).toEqual([]);
+    expect(reindexes(r.calls)).toEqual([]);
+    expect(r.search).toEqual({ provider: "ollama", model: MODEL });
+  });
+
+  it("writes memory.search.* (model first, provider last) when pre-start says OpenClaw 2", () => {
+    const r = run({ v2Env: "1", present: true });
+    expect(r.status).toBe(0);
+    expect(configSets(r.calls)).toEqual([
+      `openclaw config set memory.search.model ${MODEL}`,
+      "openclaw config set memory.search.provider ollama",
+    ]);
+    expect(reindexes(r.calls)).toHaveLength(1);
+    expect(r.search).toMatchObject({ provider: "ollama", model: MODEL });
+    // The retired path is never written on a v2 box — the CLI would refuse it anyway.
+    expect(r.memorySearch).toEqual({});
+  });
+
+  it("respects a deliberate remote provider chosen under memory.search", () => {
+    const r = run({ v2Env: "1", keys: "v2", provider: "openai", model: "text-embedding-3-large", present: true });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("deliberate choice");
+    expect(configSets(r.calls)).toEqual([]);
+    expect(pulls(r.calls)).toEqual([]);
+    expect(r.search.provider).toBe("openai");
+  });
+
+  it("leaves a remote provider alone even when it is still recorded under the legacy home", () => {
+    // The upgrade case: memory.search is empty, the owner's OpenAI choice sits
+    // in agents.defaults.memorySearch from the box's OpenClaw 1 days, and
+    // `doctor --fix` has not migrated it yet. Reading only the live home saw
+    // "unset" and pointed the box at ollama over the owner's head.
+    const r = run({ v2Env: "1", keys: "legacy", provider: "openai", model: "text-embedding-3-large", present: true });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("deliberate choice");
+    expect(configSets(r.calls)).toEqual([]);
+    expect(pulls(r.calls)).toEqual([]);
+    expect(r.search).toEqual({});
+    expect(r.memorySearch.provider).toBe("openai");
+  });
+
+  it("still migrates a legacy \"ollama\" onto memory.search — the guard reads both homes, the write does not", () => {
+    const r = run({ v2Env: "1", keys: "legacy", provider: "ollama", model: MODEL, present: true });
+    expect(r.status).toBe(0);
+    expect(configSets(r.calls)).toEqual([
+      `openclaw config set memory.search.model ${MODEL}`,
+      "openclaw config set memory.search.provider ollama",
+    ]);
+    expect(r.search).toMatchObject({ provider: "ollama", model: MODEL });
+  });
+
+  it("derives the generation from the installed core when install.sh calls it with no env", () => {
+    const r = run({ installedVersion: "2026.8.1", present: true });
+    expect(r.status).toBe(0);
+    expect(configSets(r.calls)).toEqual([
+      `openclaw config set memory.search.model ${MODEL}`,
+      "openclaw config set memory.search.provider ollama",
+    ]);
+    expect(r.search).toMatchObject({ provider: "ollama", model: MODEL });
+  });
+
+  it("keeps the legacy keys for a core older than 2026.8", () => {
+    const r = run({ installedVersion: "2026.7.3", present: true });
+    expect(r.status).toBe(0);
+    expect(configSets(r.calls)).toEqual([
+      `openclaw config set agents.defaults.memorySearch.model ${MODEL}`,
+      "openclaw config set agents.defaults.memorySearch.provider ollama",
+    ]);
+    expect(r.search).toEqual({});
+  });
+
+  it("lets the generation gateway-pre-start.sh exported win over the package on disk", () => {
+    // Pre-start asked the binary itself; a package.json that disagrees is the
+    // mid-update case, and the binary is the process that parses the write.
+    const r = run({ installedVersion: "2026.8.1", v2Env: "0", stubV2: false, present: true });
+    expect(r.status).toBe(0);
+    expect(configSets(r.calls)[0]).toBe(`openclaw config set agents.defaults.memorySearch.model ${MODEL}`);
+  });
+
+  it("never calls `openclaw --version` to find out — it costs ~10 s on a Jetson", () => {
+    const r = run({ installedVersion: "2026.8.1", present: true });
+    expect(r.calls.filter((c) => c.includes("--version"))).toEqual([]);
+    expect(readFileSync(SCRIPT, "utf-8")).not.toMatch(/"\$OPENCLAW_BIN" --version/);
+  });
+});
+
 describe("gateway-pre-start.sh local embeddings hand-off", () => {
   const src = readFileSync(PRE_START, "utf-8");
 
@@ -352,5 +482,60 @@ describe("gateway-pre-start.sh local embeddings hand-off", () => {
 
   it("no longer flips memorySearch inline — that lives in one place now", () => {
     expect(src).not.toMatch(/config set agents\.defaults\.memorySearch/);
+    expect(src).not.toMatch(/config set memory\.search/);
+  });
+
+  it("exports the generation it decided on, so the script cannot disagree with it", () => {
+    expect(src).toMatch(/^export CLAWBOX_OPENCLAW_V2$/m);
+    expect(src.indexOf("export CLAWBOX_OPENCLAW_V2")).toBeLessThan(src.indexOf('setsid nohup "$LOCAL_EMBEDDINGS"'));
+  });
+});
+
+// install.sh runs the script synchronously and then reads openclaw.json to
+// report the outcome (the script exits 0 on every soft failure by design). That
+// check must accept the key the installed core actually uses, or a v2 install
+// prints "WARN: local embeddings are not configured yet" over a configured box.
+describe.skipIf(!hasPython3)("install.sh local embeddings post-run check", () => {
+  const INSTALL_SH = readFileSync(path.resolve(process.cwd(), "install.sh"), "utf-8");
+  const HEAD = "python3 - /home/clawbox/.openclaw/openclaw.json <<'PY'";
+  const start = INSTALL_SH.indexOf(HEAD);
+  const end = start < 0 ? -1 : INSTALL_SH.indexOf("\nPY\n", start);
+  const program = start < 0 || end < 0 ? "" : INSTALL_SH.slice(INSTALL_SH.indexOf("\n", start) + 1, end);
+
+  function configured(cfg: unknown): boolean {
+    if (!program) throw new Error("install.sh post-run check not found — the heredoc test above names it");
+    const file = path.join(dir, "post-run.json");
+    writeFileSync(file, JSON.stringify(cfg));
+    return spawnSync("python3", ["-c", program, file], { encoding: "utf-8" }).status === 0;
+  }
+
+  it("ships the check as a heredoc this test can run verbatim", () => {
+    expect(program).toContain("import json");
+  });
+
+  it("accepts OpenClaw 2's memory.search home", () => {
+    expect(configured({ memory: { search: { provider: "ollama", model: MODEL } } })).toBe(true);
+  });
+
+  it("still accepts the legacy agents.defaults.memorySearch home", () => {
+    expect(configured({ agents: { defaults: { memorySearch: { provider: "ollama", model: MODEL } } } })).toBe(true);
+  });
+
+  it("does not report a box that is on a remote provider, or not configured, as ready", () => {
+    expect(configured({ memory: { search: { provider: "openai", model: "text-embedding-3-large" } } })).toBe(false);
+    expect(configured({ agents: { defaults: {} } })).toBe(false);
+    expect(configured({ memory: { search: { model: MODEL } } })).toBe(false);
+  });
+
+  it("reads only the active home — a stale legacy block cannot vouch for a box OpenClaw 2 has on the cloud", () => {
+    // The upgrade case: agents.defaults.memorySearch still says ollama from
+    // the box's OpenClaw 1 days, and the owner has since picked OpenAI under
+    // memory.search, the only home the running core reads. Every note is
+    // being sent to OpenAI; "needs no API key" would be a false claim.
+    const stale = { provider: "ollama", model: MODEL };
+    const remote = { provider: "openai", model: "text-embedding-3-large" };
+    expect(configured({ memory: { search: remote }, agents: { defaults: { memorySearch: stale } } })).toBe(false);
+    // The mirror image is ready: the active home is local, whatever the stale one says.
+    expect(configured({ memory: { search: stale }, agents: { defaults: { memorySearch: remote } } })).toBe(true);
   });
 });

--- a/src/tests/unit/memory-shard-embedding-keys.test.ts
+++ b/src/tests/unit/memory-shard-embedding-keys.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The owner's wizard step (POST /setup-api/clawkeep/memory/provider) writes the
+// embedding choice through the OpenClaw CLI. OpenClaw 2 (2026.8+) moved that
+// choice from agents.defaults.memorySearch.* to memory.search.* and refuses
+// the retired path outright ("moved to memory.search. Run openclaw doctor
+// --fix"), so on every shipping box the write 500'd with that message. The
+// key names must follow the installed core, read from the same package.json
+// scripts/ensure-local-embeddings.sh reads at boot.
+
+const OPENCLAW_PACKAGE_JSON = "/home/clawbox/.npm-global/lib/node_modules/openclaw/package.json";
+
+const { runOpenclawConfigSetBatch, readFile } = vi.hoisted(() => ({
+  runOpenclawConfigSetBatch: vi.fn(async () => ""),
+  readFile: vi.fn<(path: string, encoding: string) => Promise<string>>(),
+}));
+
+vi.mock("fs/promises", () => ({ readFile }));
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(async () => undefined),
+  set: vi.fn(async () => {}),
+}));
+vi.mock("@/lib/openclaw-config", () => ({
+  readConfig: vi.fn(async () => ({})),
+  runOpenclawConfigSetBatch,
+  // The npm --prefix layout of /home/clawbox/.npm-global on the box.
+  findOpenclawBin: () => "/home/clawbox/.npm-global/bin/openclaw",
+}));
+
+import { embeddingConfigHome, switchToLocalEmbeddings } from "@/lib/memory-shard";
+import { LOCAL_EMBEDDING_MODEL } from "@/lib/memory-shard-state";
+
+const V2_OPS = [
+  ["memory.search.provider", "ollama"],
+  ["memory.search.model", LOCAL_EMBEDDING_MODEL],
+];
+const LEGACY_OPS = [
+  ["agents.defaults.memorySearch.provider", "ollama"],
+  ["agents.defaults.memorySearch.model", LOCAL_EMBEDDING_MODEL],
+];
+
+function installedCore(version: string): void {
+  readFile.mockResolvedValue(JSON.stringify({ name: "openclaw", version }));
+}
+
+beforeEach(() => {
+  runOpenclawConfigSetBatch.mockClear();
+  readFile.mockReset();
+});
+
+describe("embeddingConfigHome", () => {
+  it("names OpenClaw 2's memory.search home from 2026.8 on", () => {
+    for (const version of ["2026.8.1", "2026.8.0", "2026.12.3", "2027.1.0"]) {
+      expect(embeddingConfigHome(version)).toBe("memory.search");
+    }
+  });
+
+  it("keeps the legacy agents.defaults.memorySearch home for earlier cores", () => {
+    for (const version of ["2026.7.12", "2025.12.1"]) {
+      expect(embeddingConfigHome(version)).toBe("agents.defaults.memorySearch");
+    }
+  });
+
+  it("assumes the generation ClawBox pins when the version cannot be read", () => {
+    expect(embeddingConfigHome(null)).toBe("memory.search");
+    expect(embeddingConfigHome("garbage")).toBe("memory.search");
+  });
+});
+
+describe("switchToLocalEmbeddings", () => {
+  it("writes memory.search.* on an OpenClaw 2 core, as one batch", async () => {
+    installedCore("2026.8.1");
+    await switchToLocalEmbeddings();
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledTimes(1);
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledWith(V2_OPS);
+  });
+
+  it("writes the legacy keys on a core older than 2026.8", async () => {
+    installedCore("2026.7.12");
+    await switchToLocalEmbeddings();
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledWith(LEGACY_OPS);
+  });
+
+  it("reads the core's own package.json, the file the boot script reads — never `openclaw --version`", async () => {
+    installedCore("2026.8.1");
+    await switchToLocalEmbeddings();
+    expect(readFile).toHaveBeenCalledWith(OPENCLAW_PACKAGE_JSON, "utf-8");
+    // The only CLI call is the write itself.
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the pinned generation when there is no package.json to read", async () => {
+    readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
+    await switchToLocalEmbeddings();
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledWith(V2_OPS);
+  });
+
+  it("falls back to the pinned generation when the package.json has no version", async () => {
+    readFile.mockResolvedValue("{ not json");
+    await switchToLocalEmbeddings();
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledWith(V2_OPS);
+  });
+});


### PR DESCRIPTION
## F-13 — an upgraded box can never be pointed at local Ollama embeddings

### Owner-visible symptom

Measured on a 2026.8.1 box. `data/local-embeddings.log`, on **every gateway boot**:

```
  [local-embeddings] WARN: could not set the local embedding model (non-fatal; nothing changed, lexical FTS remains)
```

The box's own `openclaw.json` already said `memory.search.provider = ollama`. So the script read "unset", tried to write, was refused, and reported "nothing changed" — on a box that was already correctly configured. On a box that was *not* configured, the same refusal meant semantic memory stayed on cloud embeddings forever: it needs an `OPENAI_API_KEY` most boxes do not have, so recall is simply dead, and on a box that *does* have one every indexed note is shipped to a third party to be embedded.

Nothing the owner could click fixed it either — the Memory wizard's provisioning step (`POST /setup-api/clawkeep/memory/provider`) wrote the same retired keys and 500'd with the same validation error.

### Cause

OpenClaw 2 (2026.8+) moved the embedding choice from `agents.defaults.memorySearch.*` to `memory.search.*`, and its CLI refuses the retired path outright:

```
agents.defaults.memorySearch moved to memory.search. Run "openclaw doctor --fix".
```

Three places still spoke the old dialect, with no generation check anywhere:

- `scripts/ensure-local-embeddings.sh` — read the retired path (so it saw "unset" on a configured box) and wrote it back on both `config set` calls;
- `src/lib/memory-shard.ts` `switchToLocalEmbeddings()` — the wizard's writer, same two keys;
- `install.sh` — the post-run check read only the retired path, so it printed `WARN: local embeddings are not configured yet` even when the script had just succeeded.

### Fix

Each writer picks the key names the installed core will actually parse, on one 2026.8 boundary.

- **`scripts/ensure-local-embeddings.sh`** honours `CLAWBOX_OPENCLAW_V2` when `gateway-pre-start.sh` exported it (it already does, before the detached launch, so the two cannot disagree). `install.sh` calls the script directly and exports nothing, so it falls back to the version in the core's own `package.json` next to the binary — **never `openclaw --version`**, which costs ~10 s on a Jetson and is called synchronously here. Comparison is `sort -V` against `2026.8`, the same test `gateway-pre-start.sh` already applies. The read, both writes and the log wording follow the chosen home. The one exception is the owner's-choice guard: a remote provider recorded in **either** home is left alone, so an upgraded box whose `doctor --fix` has not yet migrated its `openai` choice out of the legacy block is not pointed at Ollama over the owner's head — the same rule `install.sh`'s check applies. Only the guard reads both; the writes stay on the live home, so a legacy `ollama` is migrated, not mistaken for done.
- **`src/lib/memory-shard.ts`** derives the same package.json the same way (`dirname(bin)/../lib/…`, via the existing `findOpenclawBin()`), so both writers read one file. `embeddingConfigHome()` is exported and unit-tested on the boundary directly.
- **`install.sh`** post-run check reads the **active** home — `memory.search` when it names a provider (only an OpenClaw 2 core writes there, and once it does the core ignores the legacy path), else `agents.defaults.memorySearch`. It reports what is true on both generations, and a stale legacy block cannot vouch for a box the owner has since pointed at OpenAI.

Ordering and failure semantics are untouched: the model is still written before the provider, so a half-failure leaves the box on the provider it already had rather than on Ollama pointed at a missing model; every path still exits 0 and leaves lexical FTS.

### RED → GREEN

**RED**, on unmodified `origin/beta` (23cb5515), the new/updated test files copied into a throwaway worktree — 15 failures across the two files:

```
 ❯ src/tests/unit/memory-shard-embedding-keys.test.ts (8 tests | 7 failed)
 ❯ src/tests/unit/ensure-local-embeddings.test.ts    (34 tests | 8 failed)   # 35 after review, see thread
```

The first one reproduces the measured log line exactly — a box already on `memory.search.provider=ollama`, told nothing changed:

```
AssertionError: expected '  [local-embeddings] WARN: could not …' to contain 'already runs on local embeddings'
+   [local-embeddings] WARN: could not set the local embedding model (non-fatal; nothing changed, lexical FTS remains)
```

and the write goes to the retired path the CLI refuses:

```
- "openclaw config set memory.search.model qwen3-embedding:0.6b"
- "openclaw config set memory.search.provider ollama"
+ "openclaw config set agents.defaults.memorySearch.model qwen3-embedding:0.6b"
```

One further test is RED against this PR's **own first revision** (68f4c35a) rather than beta — the widened guard fixes a regression caught in review, see the PR comment: `expected '…memory search -> local Ollama…' to contain 'deliberate choice'`.

**GREEN** on this branch:

```
 Test Files  15 passed (15)      # ensure-local-embeddings, memory-shard*, gateway-pre-start*
      Tests  247 passed (247)

 Test Files  341 passed (341)    # the whole unit suite
      Tests  5841 passed (5841)
```

`npx tsc --noEmit -p tsconfig.json` clean, `eslint` clean, `bash -n` clean on both shell files.

The stub CLI in the test refuses `agents.defaults.memorySearch*` exactly as the real 2026.8.1 CLI does, so a test that "passes" by writing the retired key cannot.

### Sibling call sites

| Site | Verdict |
|---|---|
| `scripts/ensure-local-embeddings.sh` (read + both writes) | **Fixed.** |
| `src/lib/memory-shard.ts` `switchToLocalEmbeddings()` | **Fixed** — this is the owner-facing half; the wizard step 500'd before. |
| `install.sh` post-run check | **Fixed** — reads the active home, so it neither contradicts a successful run nor claims "needs no API key" over a stale legacy block. |
| `scripts/gateway-pre-start.sh` | **Clear.** It no longer writes either key (it hands off to this script) and already exports `CLAWBOX_OPENCLAW_V2` before the detached launch. Pinned by two assertions. |
| `src/lib/memory-shard-state.ts` `EXTRA_PATHS_CONFIG_PATH` | **Clear.** Already `memory.search.extraPaths`, unconditionally — the precedent this change follows. |
| `src/lib/clawkeep-memory.ts` (`openclaw memory status --json`) | **Clear.** Reads the CLI's own report; touches no config key. |
| `src/lib/local-models.ts`, `hermes-translations/*` `memorySearch` | **Clear.** UI label codes, not config paths. |

The fallback when the version cannot be read differs between the two writers, deliberately and now documented in both: the boot script keeps the legacy names because it also runs on a Hermes box with no core at all, while the wizard path is OpenClaw-only and assumes the pinned generation. On a real box neither fallback fires — `gateway-pre-start.sh` exports the answer, and `install.sh` runs `step_openclaw_setup` (line 5695) before `step_ollama_install` (line 5725), so the core's `package.json` is always there by then.

**Device leg unproven (CI only).**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved local embedding setup for OpenClaw 2 configurations.
  * Automatically detects the installed OpenClaw version and selects the appropriate embedding settings.
  * Supports both modern and legacy configuration layouts.

* **Bug Fixes**
  * Corrected Ollama readiness checks to validate the active embedding configuration.
  * Preserved a non-blocking lexical-search fallback warning when the required embedding model is not configured.
  * Improved compatibility when version information is unavailable or configuration paths differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->