### PR TITLE
fix: pull the live model catalogue instead of the hard-coded lists

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -6,8 +6,9 @@ import { findOpenclawBin, openclawIsAbsent } from "@/lib/openclaw-config";
 import { DATA_DIR } from "@/lib/config-store";
 import {
   CATALOG_PROVIDERS,
+  getProviderCatalog,
   isCatalogProvider,
-  PROVIDER_CATALOGS,
+  isNonChatModelId,
   subscriptionSurfaceProvider,
 } from "@/lib/provider-models";
 
@@ -29,7 +30,8 @@ export const dynamic = "force-dynamic";
 //   minute 4 onward.
 // * If both caches are empty (fresh install, first picker open), we serve
 //   the curated cold-start list from src/lib/provider-models.ts with
-//   `warming: true` and `fallback: true`.
+//   `warming: true` and no `source`, which is what "not the box's answer"
+//   means on the wire.
 //
 // Force-refresh via `?refresh=1` triggers a refresh in the background
 // and serves whatever's currently cached — the user never waits.
@@ -37,8 +39,8 @@ export const dynamic = "force-dynamic";
 // THE ONE RULE THIS FILE EXISTS TO KEEP (M-05): a payload the harness did not
 // produce is never persisted, and never presented as though it were. Only a
 // live enumeration is written to the disk cache, and only such a payload is
-// stamped `source: "live"`; everything else is served marked `fallback` so the
-// client comes back for the real answer. An enumeration that returns ZERO
+// stamped `source: "live"`. Everything else arrives without that stamp, which
+// is how the client knows to come back for the real answer. An enumeration that returns ZERO
 // models is not an answer either — the previous good catalogue is kept and the
 // CLI's own reason is logged, because "0 models" means the plugin is off or the
 // provider id is gone, not that the box can run nothing.
@@ -70,7 +72,7 @@ interface CatalogResponse {
   stale?: boolean;
   /**
    * Set when neither cache has anything yet. The curated cold-start list is
-   * served alongside it (and `fallback`), so the picker has rows to render
+   * served alongside it, without a `source`, so the picker has rows to render
    * while the first enumeration runs.
    */
   warming?: boolean;
@@ -85,17 +87,10 @@ interface CatalogResponse {
    * cold-start arrays, which is exactly the state that made three hard-coded
    * model names the truth on a box that could run eleven. An unmarked file is
    * therefore re-enumerated — once if that succeeds, and thereafter on the
-   * `nextAttemptAt` backoff if it does not, so a provider that can never
+   * failed-refresh backoff if it does not, so a provider that can never
    * enumerate cannot turn this rule into a fork per request.
    */
   source?: "live";
-  /**
-   * Set on a response the route could not answer from a live enumeration —
-   * a cold start, or a cached payload no device produced. It is served (a
-   * blank picker helps nobody) but it says what it is, so the client keeps
-   * asking instead of settling on the curated list for the next six hours.
-   */
-  fallback?: boolean;
 }
 
 // Process-local hot cache. Survives request boundaries within a single
@@ -105,51 +100,66 @@ const memCache = new Map<string, CatalogResponse>();
 const refreshing = new Set<string>();
 
 /**
- * "The last refresh for this provider did not answer, so re-enumerate."
+ * "The last enumeration for this provider did not answer" — the deadline
+ * before it may be asked again, and the wait that produced it.
  *
- * A SET rather than a flag on the cached payload, because the payload is not
+ * ONE map, carrying BOTH numbers, because neither recovers the other. The
+ * deadline alone cannot: by the time a second failure records, the first
+ * deadline has necessarily passed (that is how the attempt got past the
+ * guard), so `deadline - now` is negative and doubling it lands back on the
+ * floor every time — a flat two minutes forever, which is not a backoff. Its
+ * key set is also the "is this provider stale" answer, so there is no second
+ * structure for that: an entry means the last attempt failed, a publish
+ * deletes it.
+ *
+ * A MAP rather than a flag on the cached payload, because the payload is not
  * always there to flag: `bootWarmup` runs before any request has loaded the
  * disk cache into `memCache`, so a boot-time failure had nothing to mark and
  * the next request read a live, under-6h file off disk and sat on it for the
- * rest of the interval — the failure was silently forgotten in exactly the
- * window it is most likely to happen.
- */
-const staleProviders = new Set<string>();
-
-/**
- * Earliest time a provider may be enumerated again after an attempt that did
- * not answer. Without it, "re-enumerate whenever the payload is not live"
+ * rest of the interval — forgotten in exactly the window it is most likely to
+ * happen.
+ *
+ * Why it exists: without it, "re-enumerate whenever the payload is not live"
  * means a provider that CANNOT enumerate — plugin disabled, provider id gone,
  * an edition with no CLI — forks `openclaw models list` on every request
- * forever: ~3 minutes and ~2 cores of a Jetson each, and the single-flight set
- * only collapses the concurrent ones. The client retry (12 attempts with
- * `refresh=1`) and two mounted pickers keep that loop fed.
+ * forever, ~3 minutes and ~2 cores of a Jetson each, and the single-flight set
+ * only collapses the concurrent ones. `?refresh=1` does NOT bypass it: the
+ * client retry is the thing being rate-limited.
  *
- * So a failed attempt costs the next one a wait, doubling to the ordinary
- * refresh interval; a success clears it. `?refresh=1` does NOT bypass it —
- * the retry loop is the very thing being rate-limited.
+ * Per-process on purpose. It limits THIS process's forks, it sits beside
+ * `memCache` and `refreshing` which are already per-process, and a restart is
+ * a legitimate reason to try again — `bootWarmup` re-enumerates anyway.
  */
-const nextAttemptAt = new Map<string, number>();
+interface FailedRefresh {
+  /** Epoch ms before which this provider must not be enumerated again. */
+  until: number;
+  /** The wait that produced `until`, so the next one can double it. */
+  waitMs: number;
+}
+const failedRefreshes = new Map<string, FailedRefresh>();
 const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
 
-function refreshBlockedUntil(provider: string): number {
-  return nextAttemptAt.get(provider) ?? 0;
+function refreshIsBlocked(provider: string): boolean {
+  const failure = failedRefreshes.get(provider);
+  return failure !== undefined && failure.until > Date.now();
+}
+
+/** Did the last attempt for this provider fail? Its cached payload is stale. */
+function refreshFailedLast(provider: string): boolean {
+  return failedRefreshes.has(provider);
 }
 
 function recordFailedRefresh(provider: string): void {
-  const previous = nextAttemptAt.get(provider);
-  const lastWait = previous ? Math.min(previous - Date.now(), REFRESH_INTERVAL_MS) : 0;
-  const wait = Math.min(
-    Math.max(lastWait * 2, FAILED_REFRESH_BACKOFF_MS),
+  const previous = failedRefreshes.get(provider)?.waitMs ?? 0;
+  const waitMs = Math.min(
+    Math.max(previous * 2, FAILED_REFRESH_BACKOFF_MS),
     REFRESH_INTERVAL_MS,
   );
-  nextAttemptAt.set(provider, Date.now() + wait);
-  staleProviders.add(provider);
+  failedRefreshes.set(provider, { until: Date.now() + waitMs, waitMs });
 }
 
 function recordSuccessfulRefresh(provider: string): void {
-  nextAttemptAt.delete(provider);
-  staleProviders.delete(provider);
+  failedRefreshes.delete(provider);
 }
 
 const DEFAULT_MODEL_BY_PROVIDER: Record<string, string> = {
@@ -345,48 +355,6 @@ const ALLOWED_MODEL_RE_BY_PROVIDER: Record<string, RegExp> = {
   codex: /^(?:gpt-5\.5|gpt-5\.4(?:-mini)?|gpt-5\.6-(?:sol|terra|luna))$/,
 };
 
-// Model families that are not CHAT models, whatever provider lists them —
-// image, audio/speech, transcription, video, embeddings, moderation, and the
-// pre-chat completion engines. `openclaw models list` enumerates a provider's
-// whole catalogue and offers no capability filter to ask for the chat ones
-// (`--all`, `--local`, `--provider` and nothing else on 2026.8.1), and the rows
-// carry no capability field either: an image SKU comes back with the same shape
-// as a chat model — `openai/gpt-image-1-mini` alongside `openai/gpt-5.6-sol`,
-// `input` reported as "-" for both on a stock host. That gap is worth reporting
-// upstream; until it closes, this is the honest stopgap.
-//
-// It is a MODALITY exclusion, deliberately not a generation allowlist: it can
-// only hide SKUs a chat picker has no way to talk to, never a chat model the
-// box has learned about. That distinction is the point — the generation
-// allowlist it replaces (`/^gpt-5\.[45](-pro|-mini)?$/`) hid the whole gpt-5.6
-// generation, which is the defect this change exists to fix. Older chat
-// generations the box lists are now shown: the standing instruction is that the
-// device's own catalogue decides, and an older model the box can route is not a
-// dead button.
-const NON_CHAT_MODEL_RE = new RegExp([
-  "^(?:gpt-image|dall-e|whisper|tts-|text-embedding|omni-moderation|sora",
-  "|davinci|babbage|codex-mini)",
-  // Suffix families: gpt-4o-audio-preview, gpt-4o-realtime-preview,
-  // gpt-4o-transcribe, gpt-4o-mini-tts.
-  "|(?:-audio|-realtime|-transcribe|-tts)(?:-|$)",
-].join(""));
-
-/**
- * The model segment of an id, for the modality test above.
- *
- * OpenRouter ids keep their `<org>/<model>` slug (`openai/gpt-image-1`), so an
- * anchored pattern tested against the whole id can never match one — the
- * exclusion was silently inert for the single largest catalogue we serve.
- */
-function modelSegment(id: string): string {
-  const slash = id.lastIndexOf("/");
-  return slash >= 0 ? id.slice(slash + 1) : id;
-}
-
-function isNonChatModel(id: string): boolean {
-  return NON_CHAT_MODEL_RE.test(modelSegment(id));
-}
-
 // Newest-first ordering: bigger context generally means newer model on
 // every catalog we ship today (claude 200k+, gpt-5 400k, gemini 1M).
 // Fall back to alpha when contextWindow is unknown/equal so the list
@@ -461,20 +429,18 @@ function transformOpenclawEntries(
   provider: string,
   entries: OpenclawListResponse["models"],
 ): CatalogModel[] {
-  const allowed = ALLOWED_MODEL_RE_BY_PROVIDER[provider];
   const out: CatalogModel[] = [];
   for (const entry of entries) {
     if (typeof entry.key !== "string") continue;
     const id = modelIdFromKey(entry.key);
-    if (!id) continue;
     // Explicitly `false` only. `null`/absent is the harness saying it did not
     // determine one, and hiding a row over that would empty the picker on
     // exactly the boxes that have not finished setting up.
     if (entry.available === false) continue;
+    // The only checks that read the ROW rather than the id; everything else is
+    // `isOfferableModelId`, shared with the sanitiser.
     if (entry.tags?.includes("deprecated")) continue;
-    if (DEPRECATED_MODEL_IDS.has(id)) continue;
-    if (isNonChatModel(id)) continue;
-    if (allowed && !allowed.test(id)) continue;
+    if (!isOfferableModelId(provider, id)) continue;
     out.push({
       id,
       label: typeof entry.name === "string" && entry.name.trim() ? entry.name : id,
@@ -491,17 +457,26 @@ function transformOpenclawEntries(
   return out;
 }
 
-function isAllowedCatalogModel(provider: string, model: CatalogModel): boolean {
-  if (!model.id) return false;
+/**
+ * Every rule that depends only on the model ID, in ONE place.
+ *
+ * Both the transform (which decides whether an enumeration answered at all)
+ * and the payload sanitiser (which re-applies the current rules to a cached
+ * payload) have to agree: a filter that decides what the box can run must not
+ * differ between the path that publishes and the path that serves. They were
+ * two hand-maintained copies, and every new rule had to be added to both.
+ */
+function isOfferableModelId(provider: string, id: string): boolean {
+  if (!id) return false;
   const allowed = ALLOWED_MODEL_RE_BY_PROVIDER[provider];
-  if (allowed && !allowed.test(model.id)) return false;
-  if (isNonChatModel(model.id)) return false;
-  if (DEPRECATED_MODEL_IDS.has(model.id)) return false;
+  if (allowed && !allowed.test(id)) return false;
+  if (isNonChatModelId(id)) return false;
+  if (DEPRECATED_MODEL_IDS.has(id)) return false;
   return true;
 }
 
 function sanitizeCatalogModels(provider: string, models: CatalogModel[]): CatalogModel[] {
-  return models.filter((model) => isAllowedCatalogModel(provider, model));
+  return models.filter((model) => isOfferableModelId(provider, model.id));
 }
 
 function transformOpenRouterEntries(entries: OpenRouterListResponse["data"]): CatalogModel[] {
@@ -533,22 +508,6 @@ const ALLOW_CUSTOM_BY_PROVIDER: Record<string, boolean> = {
   clawai: false,
 };
 
-// Context-window lookup for the curated cold-start entries. Values from each
-// provider's official model docs. Read ONLY when building a fallback payload —
-// a live row carries the window the device reported.
-const STATIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
-  // Anthropic — https://platform.claude.com/docs/en/about-claude/models
-  "claude-opus-5": 1_000_000,
-  "claude-sonnet-5": 1_000_000,
-  "claude-opus-4-8": 1_000_000,
-  "claude-opus-4-7": 1_000_000,
-  "claude-opus-4-6": 1_000_000,
-  "claude-sonnet-4-6": 1_000_000,
-  "claude-sonnet-4-5": 200_000,
-  "claude-opus-4-5": 200_000,
-  "claude-haiku-4-5": 200_000,
-};
-
 /**
  * The curated cold-start entry for one id, if the shipped list carries it.
  *
@@ -557,8 +516,7 @@ const STATIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
  * window, the existence of the row at all — comes from the device.
  */
 function hintFor(provider: string, id: string): string | undefined {
-  if (!isCatalogProvider(provider)) return undefined;
-  const hint = PROVIDER_CATALOGS[provider]?.models.find((m) => m.id === id)?.hint;
+  const hint = getProviderCatalog(provider)?.models.find((m) => m.id === id)?.hint;
   return hint || undefined;
 }
 
@@ -576,8 +534,7 @@ function hintFor(provider: string, id: string): string | undefined {
  * `fallback`, and never written to disk.
  */
 function staticCatalogModels(provider: string): CatalogModel[] {
-  if (!isCatalogProvider(provider)) return [];
-  const staticEntry = PROVIDER_CATALOGS[provider];
+  const staticEntry = getProviderCatalog(provider);
   if (!staticEntry) return [];
   // NOT sorted. `compareCatalogModels` orders by context window and then
   // alphabetically, which is right for an enumeration — the device reports a
@@ -589,7 +546,12 @@ function staticCatalogModels(provider: string): CatalogModel[] {
   return staticEntry.models.map((sm) => ({
     id: sm.id,
     label: sm.label,
-    contextWindow: STATIC_MODEL_CONTEXT_WINDOWS[sm.id] ?? 200_000,
+    // Zero, not a guess. A curated row has no MEASURED window — the device is
+    // the only thing that reports one — and the table of hand-copied numbers
+    // that used to sit here was read by nothing: the client drops the field on
+    // a fallback row, and the comparator above is deliberately not applied to
+    // this list. A number nobody reads is a number that silently goes stale.
+    contextWindow: 0,
     hint: sm.hint,
   }));
 }
@@ -598,6 +560,9 @@ function buildPayload(
   provider: string,
   models: CatalogModel[],
   surfaceIds?: Set<string> | null,
+  // A parameter, because every caller overwrote the `Date.now()` this used to
+  // stamp: only a live publish means "as of now".
+  fetchedAt = 0,
 ): CatalogResponse {
   // Do not trust old disk caches blindly. Earlier builds could persist
   // Codex/ChatGPT-account models like gpt-5.5-pro that the upstream
@@ -635,20 +600,17 @@ function buildPayload(
     models: merged,
     defaultModelId,
     allowCustom: ALLOW_CUSTOM_BY_PROVIDER[provider] ?? true,
-    fetchedAt: Date.now(),
+    fetchedAt,
   };
 }
 
 /**
- * A payload built from the curated cold-start list. Marked `fallback`, and
- * — the whole point — never handed to `writeDiskCache`.
+ * A payload built from the curated cold-start list. It carries no
+ * `source: "live"` stamp — that absence IS the marking — and, the whole point,
+ * is never handed to `writeDiskCache`.
  */
 function buildFallbackPayload(provider: string): CatalogResponse {
-  return {
-    ...buildPayload(provider, staticCatalogModels(provider)),
-    fetchedAt: 0,
-    fallback: true,
-  };
+  return buildPayload(provider, staticCatalogModels(provider));
 }
 
 /** Did a device enumeration produce this payload? See `CatalogResponse.source`. */
@@ -657,17 +619,10 @@ function isLivePayload(payload: CatalogResponse | null | undefined): boolean {
 }
 
 function sanitizeCachedPayload(provider: string, cached: CatalogResponse): CatalogResponse {
-  const next = buildPayload(provider, cached.models);
   return {
-    ...next,
-    fetchedAt: cached.fetchedAt,
+    ...buildPayload(provider, cached.models, null, cached.fetchedAt),
     stale: cached.stale,
-    warming: cached.warming,
     source: cached.source,
-    // An unmarked cache — written by a build from before `source` existed, or
-    // by the path that used to persist the curated list as though a device had
-    // answered — is served, and says so.
-    fallback: isLivePayload(cached) ? undefined : true,
   };
 }
 
@@ -705,6 +660,17 @@ function sanitizeCachedPayload(provider: string, cached: CatalogResponse): Catal
  * `model: "openai/<id>"` and `reauthRequired`, and `subscriptionProviders`
  * containing `codex` — not on this catalogue.
  */
+
+/**
+ * Providers this route never asks `openclaw models list` about.
+ *
+ * openrouter has its own REST catalogue; clawai's two device tiers are the
+ * gateway's whole routing table; codex is not a provider on this core at all,
+ * per the note above. Naming them in one place keeps "who is CLI-backed" a
+ * single fact — it was spelled as two inequalities in one function and a
+ * separate branch in another.
+ */
+const NO_ENUMERATION_PROVIDERS: ReadonlySet<string> = new Set(["openrouter", "clawai", "codex"]);
 
 interface CatalogFetchResult {
   models: CatalogModel[];
@@ -822,15 +788,14 @@ export function refreshInBackground(provider: string): void {
   // is the only brake on the "not live -> re-enumerate" rule, so it comes
   // before every other check — including the edition guard below, whose log
   // line would otherwise repeat on every request of a Hermes box's session.
-  const blockedUntil = refreshBlockedUntil(provider);
-  if (blockedUntil > Date.now()) return;
+  if (refreshIsBlocked(provider)) return;
 
-  // OpenRouter (REST) and ClawBox AI (static) never touch the CLI; every other
-  // provider's catalog comes from `openclaw models list`. On an edition without
+  // Providers that never touch the CLI (see NO_ENUMERATION_PROVIDERS); every
+  // other one's catalog comes from `openclaw models list`. On an edition without
   // the binary (Hermes) that spawn is a guaranteed ENOENT, so skip it cleanly
   // rather than fork a missing binary for each provider on every boot warmup.
   // Hermes surfaces its own model list through the Hermes dashboard, not here.
-  const usesOpenclawCli = provider !== "openrouter" && provider !== "clawai";
+  const usesOpenclawCli = !NO_ENUMERATION_PROVIDERS.has(provider);
   if (usesOpenclawCli && openclawIsAbsent()) {
     console.log(`[catalog] skipping ${provider}: the openclaw CLI is not present on this edition`);
     // Recorded as a failed attempt so the line above appears once per backoff
@@ -841,6 +806,18 @@ export function refreshInBackground(provider: string): void {
   }
 
   refreshing.add(provider);
+
+  if (provider === "codex") {
+    // Documented above: this core has no ChatGPT-surface enumeration, and the
+    // CLI answers `Unknown provider filter "codex"`. Forking a whole openclaw
+    // process on a Jetson to be told that again — at every boot, and once per
+    // backoff window after — buys a log line whose content is already written
+    // down here. The picker gets the curated list marked `fallback`.
+    console.log(`[catalog] ${provider}: no enumeration on this core, serving the curated list`);
+    recordFailedRefresh(provider);
+    refreshing.delete(provider);
+    return;
+  }
 
   let fetcher: Promise<CatalogFetchResult>;
   if (provider === "openrouter") {
@@ -867,7 +844,10 @@ export function refreshInBackground(provider: string): void {
   const surface = fetchSubscriptionSurfaceIds(provider);
 
   const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {
-    const payload: CatalogResponse = { ...buildPayload(provider, models, surfaceIds), source: "live" };
+    const payload: CatalogResponse = {
+      ...buildPayload(provider, models, surfaceIds, Date.now()),
+      source: "live",
+    };
     memCache.set(provider, payload);
     recordSuccessfulRefresh(provider);
     await writeDiskCache(provider, payload);
@@ -878,19 +858,17 @@ export function refreshInBackground(provider: string): void {
   };
 
   /**
-   * Keep whatever good payload this box already has, mark it stale so a later
-   * request re-enumerates rather than sitting on it for the refresh interval,
-   * and make the next attempt wait.
+   * Keep whatever good payload this box already has, and record the failure —
+   * which both makes the next attempt wait and marks the provider stale, since
+   * `refreshFailedLast` reads the same map GET consults.
    *
-   * The mark goes in `staleProviders`, not on the cached payload: at boot
-   * warmup there is no cached payload to mark. Nothing is written to disk —
-   * the file there is the last answer a device actually gave, and rewriting it
-   * would spend a write to record that a LATER attempt failed.
+   * Recorded in that map rather than stamped on the cached payload, because at
+   * boot warmup there is no cached payload to stamp. Nothing is written to
+   * disk either: the file there is the last answer a device actually gave, and
+   * rewriting it would spend a write to record that a LATER attempt failed.
    */
   const markStale = () => {
     recordFailedRefresh(provider);
-    const cached = memCache.get(provider);
-    if (cached) memCache.set(provider, { ...cached, stale: true });
   };
 
   fetcher
@@ -977,7 +955,7 @@ export async function GET(req: NextRequest) {
   const ageMs = cached ? Date.now() - cached.fetchedAt : Infinity;
   const isStale = ageMs > REFRESH_INTERVAL_MS
     || cached?.stale === true
-    || staleProviders.has(provider);
+    || refreshFailedLast(provider);
   // A payload no device produced is a reason to ask AGAIN, not a reason to
   // wait six hours. That includes a cache written before `source` existed —
   // on an upgraded box those files hold the curated list a failed enumeration
@@ -1005,8 +983,8 @@ export async function GET(req: NextRequest) {
   }
 
   // Nothing cached yet — the first picker open after a restart. Serve the
-  // curated list so the picker is not blank, marked `fallback` so the client
-  // knows what it is holding.
+  // curated list so the picker is not blank; it carries no `source`, which is
+  // how the client knows what it is holding.
   const payload: CatalogResponse = {
     ...buildFallbackPayload(provider),
     ...(enumerating ? { warming: true } : {}),

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -68,7 +68,11 @@ interface CatalogResponse {
   fetchedAt: number;
   /** Set by GET when the cached payload is older than REFRESH_INTERVAL_MS. */
   stale?: boolean;
-  /** Set when neither cache has anything yet — client falls back to static catalog. */
+  /**
+   * Set when neither cache has anything yet. The curated cold-start list is
+   * served alongside it (and `fallback`), so the picker has rows to render
+   * while the first enumeration runs.
+   */
   warming?: boolean;
   /**
    * Where these models came from. `"live"` means a device enumeration
@@ -79,8 +83,10 @@ interface CatalogResponse {
    * Absent is not a synonym for "old": a payload persisted by a build before
    * this field existed is indistinguishable from one built out of the curated
    * cold-start arrays, which is exactly the state that made three hard-coded
-   * Claude entries the truth on a box that could run eleven. Treating an
-   * unmarked file as NOT live re-enumerates it once and costs nothing else.
+   * model names the truth on a box that could run eleven. An unmarked file is
+   * therefore re-enumerated — once if that succeeds, and thereafter on the
+   * `nextAttemptAt` backoff if it does not, so a provider that can never
+   * enumerate cannot turn this rule into a fork per request.
    */
   source?: "live";
   /**
@@ -97,6 +103,54 @@ interface CatalogResponse {
 const memCache = new Map<string, CatalogResponse>();
 // Single-flight guard so two concurrent requests don't both fork openclaw.
 const refreshing = new Set<string>();
+
+/**
+ * "The last refresh for this provider did not answer, so re-enumerate."
+ *
+ * A SET rather than a flag on the cached payload, because the payload is not
+ * always there to flag: `bootWarmup` runs before any request has loaded the
+ * disk cache into `memCache`, so a boot-time failure had nothing to mark and
+ * the next request read a live, under-6h file off disk and sat on it for the
+ * rest of the interval — the failure was silently forgotten in exactly the
+ * window it is most likely to happen.
+ */
+const staleProviders = new Set<string>();
+
+/**
+ * Earliest time a provider may be enumerated again after an attempt that did
+ * not answer. Without it, "re-enumerate whenever the payload is not live"
+ * means a provider that CANNOT enumerate — plugin disabled, provider id gone,
+ * an edition with no CLI — forks `openclaw models list` on every request
+ * forever: ~3 minutes and ~2 cores of a Jetson each, and the single-flight set
+ * only collapses the concurrent ones. The client retry (12 attempts with
+ * `refresh=1`) and two mounted pickers keep that loop fed.
+ *
+ * So a failed attempt costs the next one a wait, doubling to the ordinary
+ * refresh interval; a success clears it. `?refresh=1` does NOT bypass it —
+ * the retry loop is the very thing being rate-limited.
+ */
+const nextAttemptAt = new Map<string, number>();
+const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
+
+function refreshBlockedUntil(provider: string): number {
+  return nextAttemptAt.get(provider) ?? 0;
+}
+
+function recordFailedRefresh(provider: string): void {
+  const previous = nextAttemptAt.get(provider);
+  const lastWait = previous ? Math.min(previous - Date.now(), REFRESH_INTERVAL_MS) : 0;
+  const wait = Math.min(
+    Math.max(lastWait * 2, FAILED_REFRESH_BACKOFF_MS),
+    REFRESH_INTERVAL_MS,
+  );
+  nextAttemptAt.set(provider, Date.now() + wait);
+  staleProviders.add(provider);
+}
+
+function recordSuccessfulRefresh(provider: string): void {
+  nextAttemptAt.delete(provider);
+  staleProviders.delete(provider);
+}
 
 const DEFAULT_MODEL_BY_PROVIDER: Record<string, string> = {
   clawai: "deepseek-v4-flash",
@@ -292,17 +346,46 @@ const ALLOWED_MODEL_RE_BY_PROVIDER: Record<string, RegExp> = {
 };
 
 // Model families that are not CHAT models, whatever provider lists them —
-// image generation, speech, embeddings. `openclaw models list` enumerates a
-// provider's whole catalogue and offers no capability filter to ask for the
-// chat ones (`--all`, `--local`, `--provider` and nothing else on 2026.8.1),
-// and the rows carry no capability field either: an image SKU comes back with
-// the same shape as a chat model — `openai/gpt-image-1-mini` alongside
-// `openai/gpt-5.6-sol`, `input` reported as "-" for both on a stock host. So
-// this is a modality exclusion, deliberately NOT a generation allowlist: it
-// cannot hide a chat model the box has learned about, only the SKUs a chat
-// picker has no way to talk to. If the harness grows a capability filter, this
-// should become a read of it.
-const NON_CHAT_MODEL_RE = /^(?:gpt-image|dall-e|whisper|tts-|text-embedding|omni-moderation)/;
+// image, audio/speech, transcription, video, embeddings, moderation, and the
+// pre-chat completion engines. `openclaw models list` enumerates a provider's
+// whole catalogue and offers no capability filter to ask for the chat ones
+// (`--all`, `--local`, `--provider` and nothing else on 2026.8.1), and the rows
+// carry no capability field either: an image SKU comes back with the same shape
+// as a chat model — `openai/gpt-image-1-mini` alongside `openai/gpt-5.6-sol`,
+// `input` reported as "-" for both on a stock host. That gap is worth reporting
+// upstream; until it closes, this is the honest stopgap.
+//
+// It is a MODALITY exclusion, deliberately not a generation allowlist: it can
+// only hide SKUs a chat picker has no way to talk to, never a chat model the
+// box has learned about. That distinction is the point — the generation
+// allowlist it replaces (`/^gpt-5\.[45](-pro|-mini)?$/`) hid the whole gpt-5.6
+// generation, which is the defect this change exists to fix. Older chat
+// generations the box lists are now shown: the standing instruction is that the
+// device's own catalogue decides, and an older model the box can route is not a
+// dead button.
+const NON_CHAT_MODEL_RE = new RegExp([
+  "^(?:gpt-image|dall-e|whisper|tts-|text-embedding|omni-moderation|sora",
+  "|davinci|babbage|codex-mini)",
+  // Suffix families: gpt-4o-audio-preview, gpt-4o-realtime-preview,
+  // gpt-4o-transcribe, gpt-4o-mini-tts.
+  "|(?:-audio|-realtime|-transcribe|-tts)(?:-|$)",
+].join(""));
+
+/**
+ * The model segment of an id, for the modality test above.
+ *
+ * OpenRouter ids keep their `<org>/<model>` slug (`openai/gpt-image-1`), so an
+ * anchored pattern tested against the whole id can never match one — the
+ * exclusion was silently inert for the single largest catalogue we serve.
+ */
+function modelSegment(id: string): string {
+  const slash = id.lastIndexOf("/");
+  return slash >= 0 ? id.slice(slash + 1) : id;
+}
+
+function isNonChatModel(id: string): boolean {
+  return NON_CHAT_MODEL_RE.test(modelSegment(id));
+}
 
 // Newest-first ordering: bigger context generally means newer model on
 // every catalog we ship today (claude 200k+, gpt-5 400k, gemini 1M).
@@ -390,7 +473,7 @@ function transformOpenclawEntries(
     if (entry.available === false) continue;
     if (entry.tags?.includes("deprecated")) continue;
     if (DEPRECATED_MODEL_IDS.has(id)) continue;
-    if (NON_CHAT_MODEL_RE.test(id)) continue;
+    if (isNonChatModel(id)) continue;
     if (allowed && !allowed.test(id)) continue;
     out.push({
       id,
@@ -412,7 +495,7 @@ function isAllowedCatalogModel(provider: string, model: CatalogModel): boolean {
   if (!model.id) return false;
   const allowed = ALLOWED_MODEL_RE_BY_PROVIDER[provider];
   if (allowed && !allowed.test(model.id)) return false;
-  if (NON_CHAT_MODEL_RE.test(model.id)) return false;
+  if (isNonChatModel(model.id)) return false;
   if (DEPRECATED_MODEL_IDS.has(model.id)) return false;
   return true;
 }
@@ -496,14 +579,19 @@ function staticCatalogModels(provider: string): CatalogModel[] {
   if (!isCatalogProvider(provider)) return [];
   const staticEntry = PROVIDER_CATALOGS[provider];
   if (!staticEntry) return [];
-  const models = staticEntry.models.map((sm) => ({
+  // NOT sorted. `compareCatalogModels` orders by context window and then
+  // alphabetically, which is right for an enumeration — the device reports a
+  // real window for every row — and wrong here: STATIC_MODEL_CONTEXT_WINDOWS
+  // only carries the Anthropic ids, so every other curated row takes the
+  // 200_000 default, ties, and falls back to alphabetical. CODEX_MODELS,
+  // hand-ordered newest-first, would be served GPT-5.4 first. These arrays are
+  // curated in the order they should be read; that IS their metadata.
+  return staticEntry.models.map((sm) => ({
     id: sm.id,
     label: sm.label,
     contextWindow: STATIC_MODEL_CONTEXT_WINDOWS[sm.id] ?? 200_000,
     hint: sm.hint,
   }));
-  models.sort(compareCatalogModels);
-  return models;
 }
 
 function buildPayload(
@@ -584,30 +672,39 @@ function sanitizeCachedPayload(provider: string, cached: CatalogResponse): Catal
 }
 
 /**
- * Which provider id is ENUMERATED for a given catalogue id.
+ * WHY `codex` IS NOT ENUMERATED FROM `openai`, though both name the same
+ * upstream.
  *
  * `codex` was a provider in the OpenClaw core through 2026.6.x. It is gone in
- * 2026.8.1 — `openclaw models list --provider codex` answers "Unknown provider
- * filter" — and a ChatGPT subscription is an `openai` OAuth profile now
- * (`openclaw models auth login --provider openai`, docs.openclaw.ai/cli/models)
- * serving `openai/*`. So the rows a ChatGPT account can run are the `openai`
- * catalogue narrowed by ALLOWED_MODEL_RE_BY_PROVIDER.codex, which is the
- * documented ChatGPT-account set — not a list maintained by hand here.
+ * 2026.8.1: `models list --provider codex --all --json` answers
+ * `{"ok": false, "error": {"message": "Unknown provider filter \"codex\"…"}}`,
+ * and a ChatGPT sign-in is an `openai` OAuth profile now
+ * (`openclaw models auth login --provider openai`, docs.openclaw.ai/cli/models).
+ * The obvious move is to serve the ChatGPT catalogue from the `openai` one,
+ * narrowed by the documented ChatGPT-account allowlist. It is wrong, twice:
  *
- * The `codex` CATALOGUE id itself is being retired separately (TASK-652); this
- * entry keeps the picker showing real models until it is, and goes with it.
+ *  * The openai catalogue is NOT plan-scoped. It lists `gpt-5.6-sol` on any
+ *    box — measured, one row and that row on a stock host — while gpt-5.6 is
+ *    plan-gated upstream (Plus/Pro/Max). A Free account would be handed it as
+ *    the only row AND as the saved default, and every turn would 400. The old
+ *    "no dead buttons" property came from `codex` being a plan-aware
+ *    catalogue; nothing in `openai` replaces it.
+ *  * `available` cannot rescue it. Every openai row reads `available: true` as
+ *    soon as ANY openai profile exists — on the affected box that was the
+ *    ClawBox AI image token, an API key that cannot chat.
  *
- * WHAT THIS DOES NOT ANSWER: whether the box can RUN these rows on a ChatGPT
- * account. Every openai row comes back `available: true` as soon as any openai
- * profile exists — on the affected box that was the ClawBox AI image token, an
- * API key that cannot chat — so `available` here means "the openai catalogue
- * carries it", never "the ChatGPT route will take it". That second question is
- * "is there an openai OAUTH profile", which lives with the credential store
- * (TASK-652 surfaces it); a picker must not answer it from this payload.
+ * So this core exposes no enumeration of the ChatGPT surface, and that is a
+ * finding, not a licence to synthesise one: replacing a hard-coded list with a
+ * WRONG live list is the same defect pointed the other way. `codex` therefore
+ * enumerates nothing, publishes nothing, and its picker is served the curated
+ * list marked `fallback` — never persisted, never dressed up as the box's own
+ * answer, and logged with the CLI's own refusal.
+ *
+ * The ChatGPT rendering belongs on the credential facts TASK-652 introduces —
+ * `GET /setup-api/chat/model` rows carrying `provider: "codex"` with
+ * `model: "openai/<id>"` and `reauthRequired`, and `subscriptionProviders`
+ * containing `codex` — not on this catalogue.
  */
-const ENUMERATION_PROVIDER: Record<string, string> = {
-  codex: "openai",
-};
 
 interface CatalogFetchResult {
   models: CatalogModel[];
@@ -623,17 +720,26 @@ function toFetchResult(
   parsed: OpenclawListResponse,
   stderr: string,
 ): CatalogFetchResult {
+  const rows = parsed.models ?? [];
+  const models = transformOpenclawEntries(provider, rows);
   const refusal = parsed.ok === false ? parsed.error?.message?.trim() : "";
-  return {
-    models: transformOpenclawEntries(provider, parsed.models ?? []),
-    diagnostic: refusal || stderr.trim(),
-  };
+  let diagnostic = refusal || stderr.trim();
+  if (!diagnostic && models.length === 0 && rows.length > 0) {
+    // The CLI answered, listed rows, and none of them survived. Which filter
+    // ate them decides what an operator does next — "sign in" is a different
+    // problem from "this catalogue has no chat models" — and neither is
+    // "the plugin is gone", which is what a bare "0 models" implied.
+    const unavailable = rows.filter((row) => row.available === false).length;
+    diagnostic = unavailable === rows.length
+      ? `all ${rows.length} listed rows report available: false (no route this box can take yet)`
+      : `${rows.length} rows listed, none of them chat models this picker can offer`;
+  }
+  return { models, diagnostic };
 }
 
 function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
-  const enumerated = ENUMERATION_PROVIDER[provider] ?? provider;
   return new Promise((resolve, reject) => {
-    const child = spawn(OPENCLAW_BIN, ["models", "list", "--provider", enumerated, "--all", "--json"], {
+    const child = spawn(OPENCLAW_BIN, ["models", "list", "--provider", provider, "--all", "--json"], {
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
@@ -712,6 +818,12 @@ async function fetchOpenRouterCatalog(): Promise<CatalogFetchResult> {
 // next service restart.
 export function refreshInBackground(provider: string): void {
   if (refreshing.has(provider)) return;
+  // A provider that just failed to answer waits before it is asked again. This
+  // is the only brake on the "not live -> re-enumerate" rule, so it comes
+  // before every other check — including the edition guard below, whose log
+  // line would otherwise repeat on every request of a Hermes box's session.
+  const blockedUntil = refreshBlockedUntil(provider);
+  if (blockedUntil > Date.now()) return;
 
   // OpenRouter (REST) and ClawBox AI (static) never touch the CLI; every other
   // provider's catalog comes from `openclaw models list`. On an edition without
@@ -721,6 +833,10 @@ export function refreshInBackground(provider: string): void {
   const usesOpenclawCli = provider !== "openrouter" && provider !== "clawai";
   if (usesOpenclawCli && openclawIsAbsent()) {
     console.log(`[catalog] skipping ${provider}: the openclaw CLI is not present on this edition`);
+    // Recorded as a failed attempt so the line above appears once per backoff
+    // window instead of once per picker open: on this edition it can never
+    // succeed, and it is the one branch that is guaranteed to repeat.
+    recordFailedRefresh(provider);
     return;
   }
 
@@ -753,6 +869,7 @@ export function refreshInBackground(provider: string): void {
   const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {
     const payload: CatalogResponse = { ...buildPayload(provider, models, surfaceIds), source: "live" };
     memCache.set(provider, payload);
+    recordSuccessfulRefresh(provider);
     await writeDiskCache(provider, payload);
     console.log(
       `[catalog] refreshed ${provider}: ${models.length} models`
@@ -761,13 +878,17 @@ export function refreshInBackground(provider: string): void {
   };
 
   /**
-   * Keep whatever good payload this box already has, and mark it stale so the
-   * next request re-enumerates instead of sitting on it for the refresh
-   * interval. Deliberately in memory only: the disk copy is the last answer a
-   * device actually gave, and rewriting it here would spend a write to record
-   * that a LATER attempt failed.
+   * Keep whatever good payload this box already has, mark it stale so a later
+   * request re-enumerates rather than sitting on it for the refresh interval,
+   * and make the next attempt wait.
+   *
+   * The mark goes in `staleProviders`, not on the cached payload: at boot
+   * warmup there is no cached payload to mark. Nothing is written to disk —
+   * the file there is the last answer a device actually gave, and rewriting it
+   * would spend a write to record that a LATER attempt failed.
    */
   const markStale = () => {
+    recordFailedRefresh(provider);
     const cached = memCache.get(provider);
     if (cached) memCache.set(provider, { ...cached, stale: true });
   };
@@ -786,6 +907,10 @@ export function refreshInBackground(provider: string): void {
           + (diagnostic ? ` — ${diagnostic.slice(-300)}` : " (the CLI gave no reason)"),
         );
         markStale();
+        // Settled, not abandoned: for a provider with a genuinely narrower
+        // surface this is a second multi-minute fork, and returning without it
+        // would release the single-flight guard while it still burns CPU.
+        await surface;
         return;
       }
       await publish(models, null);
@@ -850,7 +975,9 @@ export async function GET(req: NextRequest) {
   }
 
   const ageMs = cached ? Date.now() - cached.fetchedAt : Infinity;
-  const isStale = ageMs > REFRESH_INTERVAL_MS || cached?.stale === true;
+  const isStale = ageMs > REFRESH_INTERVAL_MS
+    || cached?.stale === true
+    || staleProviders.has(provider);
   // A payload no device produced is a reason to ask AGAIN, not a reason to
   // wait six hours. That includes a cache written before `source` existed —
   // on an upgraded box those files hold the curated list a failed enumeration
@@ -859,16 +986,30 @@ export async function GET(req: NextRequest) {
     refreshInBackground(provider);
   }
 
+  // "An answer is actually on its way" — the ONE thing that tells a client
+  // whether coming back is worth anything. A provider under the failed-refresh
+  // backoff has no enumeration running and will not get one soon, so it is not
+  // warming and a picker must not sit there polling for it; the cold start,
+  // where a fork really is out there, is.
+  const enumerating = refreshing.has(provider);
+
   if (cached) {
     const sanitized = sanitizeCachedPayload(provider, cached);
     memCache.set(provider, sanitized);
-    const payload: CatalogResponse = isStale ? { ...sanitized, stale: true } : sanitized;
+    const payload: CatalogResponse = {
+      ...sanitized,
+      ...(isStale ? { stale: true } : {}),
+      ...(enumerating && !isLivePayload(cached) ? { warming: true } : {}),
+    };
     return NextResponse.json(payload, { headers: noStore() });
   }
 
-  // Nothing cached yet — the first picker open after a restart, while the
-  // enumeration is still running. Serve the curated list so the picker is not
-  // blank, marked `fallback` so the client comes back for the real one.
-  const warming: CatalogResponse = { ...buildFallbackPayload(provider), warming: true };
-  return NextResponse.json(warming, { headers: noStore() });
+  // Nothing cached yet — the first picker open after a restart. Serve the
+  // curated list so the picker is not blank, marked `fallback` so the client
+  // knows what it is holding.
+  const payload: CatalogResponse = {
+    ...buildFallbackPayload(provider),
+    ...(enumerating ? { warming: true } : {}),
+  };
+  return NextResponse.json(payload, { headers: noStore() });
 }

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { findOpenclawBin, openclawIsAbsent } from "@/lib/openclaw-config";
 import { DATA_DIR } from "@/lib/config-store";
 import { CODEX_SUPPORTED_MODEL_RE } from "@/lib/subscription-surface";
+import { lastModelSegment } from "@/lib/chat-header-pills";
 import {
   CATALOG_PROVIDERS,
   getProviderCatalog,
@@ -167,29 +168,75 @@ const failedRefreshes = new Map<string, FailedRefresh>();
 const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
 
 /**
- * "A provider-set change arrived while this provider was already enumerating,
- * and the answer in flight predates it."
+ * PER-PROVIDER CHANGE GENERATION — "how many times has the box changed for this
+ * provider", and which generation each answer is about.
  *
- * The single-flight guard is right to collapse two overlapping enumerations —
- * but only when they would ask the same question. A connect changes the
- * question: the fork already running was started before the credential existed
- * and will answer for a box that no longer exists. Dropped, it does worse than
- * lose the refresh, because that pre-credential answer is then PUBLISHED with
- * `source: "live"` and a fresh `fetchedAt` — one openai row on a stock host
- * where a linked box lists ten — and `force || isStale || !isLivePayload` is
- * false against it for the next six hours. The marker this route exists to
- * introduce would be vouching for the very thing it was introduced to catch.
+ * A boolean cannot express this, and two rounds of review found the two halves
+ * it gets wrong. What has to be answerable is: *is the catalogue we are serving
+ * the answer for the box as it is now?* Three facts give that:
  *
- * The wizard's own timing makes this the common case rather than a race:
- * `bootWarmup` starts on the FIRST picker GET, not at boot, and staggers the
- * providers 5s apart at ~3 minutes each on a Jetson, so a key saved a minute
- * after the AI-models step opens lands inside its provider's window.
+ *  * `changeSeq` — bumped by every accepted provider-set change (a connect, a
+ *    plugin switched on, a credential written).
+ *  * `inFlight` — the generation the running fork will answer for, and whether
+ *    a change is what started it. Captured when the fork STARTS, because that
+ *    is when the box it reads is fixed.
+ *  * `publishedSeq` — the generation of the payload currently in `memCache`
+ *    and on disk.
  *
- * So the change is remembered here and re-entered from the `.finally` that
- * releases the guard. Bounded: the entry is deleted before the re-entry, and
- * the re-entry is serialised by `refreshing` like any other.
+ * Everything follows:
+ *
+ *  * A fork whose generation is behind `changeSeq` by the time it answers is
+ *    describing a box that no longer exists. Its result is NOT published —
+ *    not to memCache, not to disk, and above all not stamped `source: "live"`.
+ *    Publishing it was a false success the width of the replacement fork
+ *    (~3 minutes on a Jetson): every GET in that window — a reload, the chat
+ *    picker, a second tab — was handed the PRE-credential list marked live and
+ *    unstale, one line before the `.finally` scheduled its replacement.
+ *  * `publishedSeq < changeSeq` IS the warming condition. It stays true for
+ *    every poll until the current-generation fork lands, where the previous
+ *    `|| force` was true for exactly one response — the single `?refresh=1` —
+ *    and the hook's next poll two seconds later saw `warming: false` with three
+ *    minutes still to run, so a picker open across a connect settled on the
+ *    pre-change rows.
+ *  * A change arriving while a fork of the CURRENT generation is already out,
+ *    started by a change, is the same signal reaching the route twice —
+ *    `configure` step 8c and then the client's `?refresh=1`, which are ordered
+ *    by awaits, not racing. It is ignored, because the fork out there already
+ *    answers for the box as it now is. Bumping again cost every connect a
+ *    second full ~3-minute `openclaw models list` at the wizard's most
+ *    latency-sensitive moment. `fromChange` is what keeps that distinct from a
+ *    warmup or poll fork, which started before the change and must NOT absorb
+ *    it.
+ *
+ * Per-process, like `memCache`, `refreshing` and `failedRefreshes` beside it. A
+ * restart re-enumerates through `bootWarmup` anyway.
+ */
+const changeSeq = new Map<string, number>();
+const publishedSeq = new Map<string, number>();
+interface InFlightFork {
+  /** The generation this fork's answer describes. */
+  seq: number;
+  /** Was it started BY a provider-set change, rather than a warmup or poll? */
+  fromChange: boolean;
+}
+const inFlight = new Map<string, InFlightFork>();
+
+/**
+ * Providers with a change no fork has answered yet, re-entered from the
+ * `.finally` that releases the single-flight guard. A Set: several signals
+ * arriving during one fork collapse to one re-entry, which is what keeps the
+ * replacement bounded at one extra enumeration per provider.
  */
 const pendingProviderChange = new Set<string>();
+
+function currentSeq(provider: string): number {
+  return changeSeq.get(provider) ?? 0;
+}
+
+/** Is the payload we would serve the answer for the box as it is now? */
+function publishedIsCurrent(provider: string): boolean {
+  return (publishedSeq.get(provider) ?? -1) >= currentSeq(provider);
+}
 
 function refreshIsBlocked(provider: string): boolean {
   const failure = failedRefreshes.get(provider);
@@ -491,6 +538,17 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     return null;
   } finally {
     refreshing.delete(surfaceProvider);
+    inFlight.delete(surfaceProvider);
+    // The SECOND place that releases the guard, so the second place a pending
+    // change would otherwise sit unclaimed: a `providerChanged` for a provider
+    // that is in `refreshing` only because it is somebody else's subscription
+    // surface was recorded and never re-entered, then fired against whatever
+    // unrelated fork happened to finish next. Unreachable while
+    // SUBSCRIPTION_SURFACE names no `surfaceProvider`, which is why it is
+    // closed here rather than left for the day one is added.
+    if (pendingProviderChange.delete(surfaceProvider)) {
+      refreshInBackground(surfaceProvider, { providerChanged: true, alreadyCounted: true });
+    }
   }
 }
 
@@ -562,7 +620,13 @@ function isOfferableModelId(provider: string, id: string): boolean {
   const allowed = ALLOWED_MODEL_RE_BY_PROVIDER[provider];
   if (allowed && !allowed.test(id)) return false;
   if (!MODALITY_REPORTING_PROVIDERS.has(provider) && isNonChatModelId(id)) return false;
-  if (DEPRECATED_MODEL_IDS.has(id)) return false;
+  // Matched on the last path segment, like `isNonChatModelId`, because
+  // OpenRouter ids keep their `<org>/` slug: tested against the whole id this
+  // set could never fire for the largest catalogue we serve. Measured on the
+  // live endpoint (423 rows, 2026-09-02) it changes nothing today — no row's
+  // segment is one of these two, and none carries `deprecated: true` — so this
+  // is the set doing what it says rather than a change in what is offered.
+  if (DEPRECATED_MODEL_IDS.has(lastModelSegment(id))) return false;
   return true;
 }
 
@@ -949,6 +1013,14 @@ export function refreshInBackground(
      * its warming polls.
      */
     providerChanged?: boolean;
+    /**
+     * Internal: this change has already been counted, it is only now being
+     * served. Set solely by the re-entry in the `.finally` below, which drains
+     * a change that arrived while a fork was out. Without it the re-entry would
+     * bump the generation a second time for one change, and the next genuine
+     * change would then look like a duplicate of it.
+     */
+    alreadyCounted?: boolean;
   } = {},
 ): void {
   // Providers that never touch the CLI (see NO_CLI_ENUMERATION_PROVIDERS);
@@ -965,15 +1037,33 @@ export function refreshInBackground(
   // the property that log line's own comment claims.
   const changeCouldMakeItEnumerable = !hasNoEnumerationOnThisCore(provider) && !cliMissing;
 
+  const changeAccepted = opts.providerChanged === true && changeCouldMakeItEnumerable;
+  const countsAsNewChange = changeAccepted && opts.alreadyCounted !== true;
+  const running = inFlight.get(provider);
+
+  // The SAME change reaching the route a second time. `configure` step 8c fires
+  // one statement after the credential write, the client's `?refresh=1` follows
+  // when the response lands — ordered by awaits, not racing — and both say
+  // `providerChanged`. The fork already out was started by the first of them,
+  // so it is reading the box this second signal is reporting. Bumping again
+  // bought a duplicate ~3-minute `openclaw models list` on every connect.
+  const alreadyAnswering = running !== undefined
+    && running.fromChange
+    && running.seq === currentSeq(provider);
+
+  if (countsAsNewChange && !alreadyAnswering) {
+    changeSeq.set(provider, currentSeq(provider) + 1);
+  }
+
   if (refreshing.has(provider)) {
-    // Collapsed, but NOT forgotten — see `pendingProviderChange`. The fork in
+    // Collapsed, but NOT forgotten — see the generation note above. The fork in
     // flight was started before this change and answers for the box as it was.
-    if (opts.providerChanged && changeCouldMakeItEnumerable) {
+    if (countsAsNewChange && !alreadyAnswering) {
       pendingProviderChange.add(provider);
     }
     return;
   }
-  if (opts.providerChanged && changeCouldMakeItEnumerable) {
+  if (changeAccepted) {
     clearFailedRefresh(provider);
   }
   // A provider that just failed to answer waits before it is asked again. This
@@ -996,6 +1086,9 @@ export function refreshInBackground(
   }
 
   refreshing.add(provider);
+  // Captured at START, because that is when the box this fork reads is fixed.
+  const forkSeq = currentSeq(provider);
+  inFlight.set(provider, { seq: forkSeq, fromChange: changeAccepted });
 
   if (hasNoEnumerationOnThisCore(provider)) {
     // Documented above: this core has no ChatGPT-surface enumeration, and the
@@ -1006,6 +1099,7 @@ export function refreshInBackground(
     console.log(`[catalog] ${provider}: no enumeration on this core, serving the curated list`);
     recordFailedRefresh(provider);
     refreshing.delete(provider);
+    inFlight.delete(provider);
     return;
   }
 
@@ -1034,12 +1128,32 @@ export function refreshInBackground(
   const surface = fetchSubscriptionSurfaceIds(provider);
 
   const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {
+    // The CLI answered, so the provider is enumerable — that much is true
+    // whatever generation this is, and it is what the backoff tracks.
+    recordSuccessfulRefresh(provider);
+
+    if (forkSeq < currentSeq(provider)) {
+      // The box changed after this fork started. What it is holding is the
+      // answer for a box that no longer exists — on the connect path, the
+      // PRE-credential list: one openai row where the linked box lists ten.
+      // Serving it would be this route's own false success, and stamping it
+      // `source: "live"` with a fresh `fetchedAt` is what made the previous
+      // build sit on it. The replacement is already scheduled: the same change
+      // that superseded this fork put the provider in `pendingProviderChange`,
+      // which the `.finally` below drains.
+      console.log(
+        `[catalog] discarding ${provider}: ${models.length} models from before the provider changed`
+        + ` (generation ${forkSeq} < ${currentSeq(provider)}), re-enumerating`,
+      );
+      return;
+    }
+
     const payload: CatalogResponse = {
       ...buildPayload(provider, models, surfaceIds, Date.now()),
       source: "live",
     };
     memCache.set(provider, payload);
-    recordSuccessfulRefresh(provider);
+    publishedSeq.set(provider, forkSeq);
     await writeDiskCache(provider, payload);
     console.log(
       `[catalog] refreshed ${provider}: ${models.length} models`
@@ -1099,12 +1213,13 @@ export function refreshInBackground(
       // handled by the `.catch` above.
       await surface.catch(() => {});
       refreshing.delete(provider);
+      inFlight.delete(provider);
       // A provider-set change that arrived while the fork above was running was
       // collapsed into it, and that fork answered for the box as it was BEFORE
       // the change. Serve it now, against the box as it is. Deleted first, so
       // this can re-enter at most once per signal.
       if (pendingProviderChange.delete(provider)) {
-        refreshInBackground(provider, { providerChanged: true });
+        refreshInBackground(provider, { providerChanged: true, alreadyCounted: true });
       }
     });
 }
@@ -1171,7 +1286,10 @@ export async function GET(req: NextRequest) {
   const isStale = ageMs > REFRESH_INTERVAL_MS
     || cached?.stale === true
     || refreshFailedLast(provider)
-    || servedEmpty;
+    || servedEmpty
+    // The box changed after the payload we hold was enumerated. Age says
+    // nothing about that: the pre-connect answer is seconds old and wrong.
+    || !publishedIsCurrent(provider);
   // A payload no device produced is a reason to ask AGAIN, not a reason to
   // wait six hours. That includes a cache written before `source` existed —
   // on an upgraded box those files hold the curated list a failed enumeration
@@ -1200,16 +1318,19 @@ export async function GET(req: NextRequest) {
       // whenever a fork is out there AND what this response carries is not the
       // answer that fork will bring:
       //  * the payload is not a device's (cold start, upgraded cache);
-      //  * `force` — the provider set just changed, so even a LIVE payload is
-      //    the pre-change one. Without this clause a connect on a provider that
-      //    already had a live catalogue was invisible: the hook polls only on
-      //    `warming`, so it read once, settled, and the post-credential list
-      //    landed three minutes later with nobody asking;
       //  * the sanitiser emptied it, so the client is about to render the
-      //    curated rows instead.
-      // The plain 6h refresh still passes none of these, which is what keeps
-      // every mounted picker from polling through it.
-      ...(enumerating && (!isLivePayload(cached) || force || servedEmpty)
+      //    curated rows instead;
+      //  * the box has CHANGED since this payload was enumerated — even a live
+      //    one is then the pre-change answer. Read from the generation rather
+      //    than from `force`, which was true for exactly one response (the
+      //    single `?refresh=1` the hook sends per signal); its next poll two
+      //    seconds later saw `warming: false` with three minutes of enumeration
+      //    still to run, so a picker open across a connect settled on the
+      //    pre-change rows. The generation stays behind until the fork that
+      //    answers for the new box actually publishes.
+      // The plain 6h refresh passes none of these, which is what keeps every
+      // mounted picker from polling through it.
+      ...(enumerating && (!isLivePayload(cached) || servedEmpty || !publishedIsCurrent(provider))
         ? { warming: true }
         : {}),
     };

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -4,6 +4,7 @@ import { promises as fsp } from "fs";
 import path from "path";
 import { findOpenclawBin, openclawIsAbsent } from "@/lib/openclaw-config";
 import { DATA_DIR } from "@/lib/config-store";
+import { CODEX_SUPPORTED_MODEL_RE } from "@/lib/subscription-surface";
 import {
   CATALOG_PROVIDERS,
   getProviderCatalog,
@@ -60,6 +61,17 @@ interface CatalogModel {
   /** Whether the provider's SUBSCRIPTION surface carries this model. See
    * SUBSCRIPTION_SURFACE in provider-models.ts; `undefined` = not determined. */
   availableOnSubscription?: boolean;
+  /**
+   * The harness tagged this row `default` for its provider.
+   *
+   * Carried rather than dropped because it is the box's own answer to the same
+   * question `DEFAULT_MODEL_BY_PROVIDER` answers by hand, and a hand-written
+   * default is the identical defect to a hand-written list: on a 2026.8.1 host
+   * `openclaw models list --provider openai` tags `gpt-5.6-sol`, while the map
+   * says `gpt-5.4`. Only a live enumeration ever sets it — the curated
+   * cold-start rows carry no such claim.
+   */
+  isDefault?: boolean;
 }
 
 interface CatalogResponse {
@@ -77,10 +89,17 @@ interface CatalogResponse {
    */
   warming?: boolean;
   /**
-   * Where these models came from. `"live"` means a device enumeration
-   * answered — `openclaw models list --provider <p> --all --json`, or
-   * OpenRouter's own /api/v1/models — and ONLY such a payload is ever written
-   * to the disk cache.
+   * Where these models came from. `"live"` means THE BOX ANSWERED — the
+   * enumeration this route performs for that provider returned rows, and ONLY
+   * such a payload is ever written to the disk cache.
+   *
+   * For every CLI provider that is `openclaw models list --provider <p> --all
+   * --json`, and for openrouter it is that catalogue's own /api/v1/models. For
+   * `clawai` the enumeration IS a literal (`CLAWAI_STATIC_MODELS`), and it is
+   * stamped all the same, deliberately: Mike's gateway routes exactly the two
+   * device tiers, so those two rows are the routing table rather than a
+   * stand-in for one nobody asked. The rule this field carries is "not a
+   * placeholder for an answer", not "a subprocess ran".
    *
    * Absent is not a synonym for "old": a payload persisted by a build before
    * this field existed is indistinguishable from one built out of the curated
@@ -123,8 +142,16 @@ const refreshing = new Set<string>();
  * means a provider that CANNOT enumerate — plugin disabled, provider id gone,
  * an edition with no CLI — forks `openclaw models list` on every request
  * forever, ~3 minutes and ~2 cores of a Jetson each, and the single-flight set
- * only collapses the concurrent ones. `?refresh=1` does NOT bypass it: the
- * client retry is the thing being rate-limited.
+ * only collapses the concurrent ones.
+ *
+ * What it rate-limits is a client ASKING AGAIN. It must not survive the box
+ * CHANGING, and the two are different events: a provider connect enables the
+ * plugin and writes the credential, which is the moment a provider that could
+ * not enumerate starts being able to. Blocking there recreates the reported
+ * symptom through this very brake — no fork, therefore no `warming`, therefore
+ * nothing polling, therefore the curated list stands until some unrelated
+ * request happens along after the deadline. So `providerChanged` clears the
+ * entry (see `refreshInBackground`), and only the poll path is held.
  *
  * Per-process on purpose. It limits THIS process's forks, it sits beside
  * `memCache` and `refreshing` which are already per-process, and a restart is
@@ -159,6 +186,18 @@ function recordFailedRefresh(provider: string): void {
 }
 
 function recordSuccessfulRefresh(provider: string): void {
+  failedRefreshes.delete(provider);
+}
+
+/**
+ * "The box changed, so the last failure says nothing about the next attempt."
+ *
+ * Separate from `recordSuccessfulRefresh` because nothing succeeded — this is
+ * the credential/plugin write that makes the next enumeration worth spending,
+ * and it also drops the doubling back to the floor, which is right: the reason
+ * the previous attempts failed has just been removed.
+ */
+function clearFailedRefresh(provider: string): void {
   failedRefreshes.delete(provider);
 }
 
@@ -299,7 +338,7 @@ interface OpenRouterListResponse {
     name?: string;
     description?: string;
     context_length?: number;
-    architecture?: { input_modalities?: string[] };
+    architecture?: { input_modalities?: string[]; output_modalities?: string[] };
     deprecated?: boolean;
   }>;
 }
@@ -345,14 +384,18 @@ const DEPRECATED_MODEL_IDS: ReadonlySet<string> = new Set([
 // generation is called; the harness's catalogue can, and the whole point of
 // this route is to ask it.
 const ALLOWED_MODEL_RE_BY_PROVIDER: Record<string, RegExp> = {
-  // Explicit alternation, not /^gpt-5\.[45](-mini)?$/ — that would also
-  // accept gpt-5.5-mini (which doesn't exist on the Codex auth path
-  // and would 400 the same way gpt-5.4-pro did). Per
-  // developers.openai.com/codex/models the supported set under
-  // ChatGPT-account auth is gpt-5.4, gpt-5.4-mini, gpt-5.5, plus the
-  // gpt-5.6-{sol,terra,luna} models (plan-gated upstream, so they only
-  // appear in the live catalog for accounts entitled to them).
-  codex: /^(?:gpt-5\.5|gpt-5\.4(?:-mini)?|gpt-5\.6-(?:sol|terra|luna))$/,
+  // IMPORTED, not spelled again. `CODEX_SUPPORTED_MODEL_RE` is the same
+  // alternation, and its own doc says it lives there so that "a second copy in
+  // the second route is a copy that can drift" — this route was that second
+  // copy. It is the rule the write path enforces, so the picker must offer
+  // exactly it: a row this list shows and that guard refuses is a dead button,
+  // and the reverse is a model the customer cannot reach.
+  //
+  // `scripts/gateway-pre-start.sh` keeps a third, hand-maintained mirror in
+  // `_CODEX_SUPPORTED` (it runs before node exists), pinned by
+  // src/tests/unit/gateway-pre-start-codex-models.test.ts. That one cannot
+  // import; this one could, and now does.
+  codex: CODEX_SUPPORTED_MODEL_RE,
 };
 
 // Newest-first ordering: bigger context generally means newer model on
@@ -390,26 +433,39 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     memCache.set(surfaceProvider, cached);
     return new Set(cached.models.map((m) => m.id));
   }
+  // The SAME single-flight guard the main path takes. This function publishes
+  // to `<surfaceProvider>.json` like any other refresh, so without it a
+  // `refreshInBackground(surfaceProvider)` arriving from a picker open could
+  // run a second `openclaw models list` for that provider beside this one —
+  // two multi-minute forks on a Jetson for one catalogue. Released in the
+  // `finally` below, including on the error path.
+  if (refreshing.has(surfaceProvider)) return null;
+  refreshing.add(surfaceProvider);
   try {
     const { models } = await fetchOpenclawCatalog(surfaceProvider);
     if (models.length === 0) return null;
+    // Through `buildPayload`, not hand-assembled beside it. The hand-built
+    // version skipped `sanitizeCatalogModels`, `DEFAULT_MODEL_BY_PROVIDER` and
+    // `ALLOW_CUSTOM_BY_PROVIDER` while writing to the very file the picker and
+    // the server-side guard read back — a second, quieter way for this route to
+    // persist something no other path would have produced.
     const payload: CatalogResponse = {
-      provider: surfaceProvider,
-      models,
-      defaultModelId: models[0].id,
-      allowCustom: false,
-      fetchedAt: Date.now(),
+      ...buildPayload(surfaceProvider, models, null, Date.now()),
       source: "live",
     };
     memCache.set(surfaceProvider, payload);
+    recordSuccessfulRefresh(surfaceProvider);
     await writeDiskCache(surfaceProvider, payload);
-    return new Set(models.map((m) => m.id));
+    return new Set(payload.models.map((m) => m.id));
   } catch (err) {
     console.warn(
       `[catalog] subscription surface (${surfaceProvider}) unavailable for ${provider}:`,
       err instanceof Error ? err.message : err,
     );
+    recordFailedRefresh(surfaceProvider);
     return null;
+  } finally {
+    refreshing.delete(surfaceProvider);
   }
 }
 
@@ -446,6 +502,7 @@ function transformOpenclawEntries(
       label: typeof entry.name === "string" && entry.name.trim() ? entry.name : id,
       contextWindow: typeof entry.contextWindow === "number" ? entry.contextWindow : 0,
       input: typeof entry.input === "string" ? entry.input : undefined,
+      ...(entry.tags?.includes("default") ? { isDefault: true } : {}),
       // The live `name` is the label, and there is no live hint. Inventing one
       // is how a picker ends up describing a model nobody measured, so a hint
       // only survives where the curated entry for the SAME id already carried
@@ -466,11 +523,20 @@ function transformOpenclawEntries(
  * differ between the path that publishes and the path that serves. They were
  * two hand-maintained copies, and every new rule had to be added to both.
  */
+/**
+ * Catalogues that publish a capability field, so the name-shaped modality guess
+ * must not be applied to them: the field is the answer, and the guess can only
+ * disagree with it. OpenRouter's `architecture.output_modalities` is read in
+ * `outputIsRenderableChat` at transform time; every other catalogue this route
+ * serves reports nothing of the sort.
+ */
+const MODALITY_REPORTING_PROVIDERS: ReadonlySet<string> = new Set(["openrouter"]);
+
 function isOfferableModelId(provider: string, id: string): boolean {
   if (!id) return false;
   const allowed = ALLOWED_MODEL_RE_BY_PROVIDER[provider];
   if (allowed && !allowed.test(id)) return false;
-  if (isNonChatModelId(id)) return false;
+  if (!MODALITY_REPORTING_PROVIDERS.has(provider) && isNonChatModelId(id)) return false;
   if (DEPRECATED_MODEL_IDS.has(id)) return false;
   return true;
 }
@@ -479,11 +545,51 @@ function sanitizeCatalogModels(provider: string, models: CatalogModel[]): Catalo
   return models.filter((model) => isOfferableModelId(provider, model.id));
 }
 
+/**
+ * OpenRouter's own namespace — `openrouter/auto`, `openrouter/auto-beta` and
+ * the other meta entries. A row here is a ROUTER, not a model, and the
+ * modalities it declares are the union over everything it can route to: both
+ * `auto` rows report `["image","text"]` output for that reason while routing
+ * text prompts to text models. So the modality test below, which is a fact
+ * about one model, does not apply to them.
+ */
+function isOpenRouterMetaModel(id: string): boolean {
+  return id.startsWith("openrouter/");
+}
+
+/**
+ * Is this row's OUTPUT something a chat picker can render?
+ *
+ * This is the capability answer the harness cannot give us: `openclaw models
+ * list` publishes no capability field, so those catalogues fall back to the
+ * name-shaped `isNonChatModelId`. OpenRouter DOES publish one, so it is read
+ * here and the guess is not used at all for this catalogue.
+ *
+ * Measured against the live endpoint this route fetches (2026-09-02, 423 rows):
+ * every row carries `output_modalities`; 408 are `["text"]`, 11 are
+ * `["image","text"]` and 4 are `["audio","text"]`. Of the 15 non-text rows, 13
+ * are real image/audio SKUs (`google/gemini-2.5-flash-image`,
+ * `openai/gpt-5-image`, `google/lyria-3-pro-preview`, `openai/gpt-audio`, …)
+ * that the name-shaped rule let through, and the other 2 are the meta routers
+ * above. A row whose output includes image or audio is not something this chat
+ * surface can show, so it is not offered.
+ *
+ * A row with no field at all is KEPT — absent is not "no", the same rule the
+ * per-row `available` tristate follows.
+ */
+function outputIsRenderableChat(entry: OpenRouterListResponse["data"][number]): boolean {
+  const outputs = entry.architecture?.output_modalities;
+  if (!Array.isArray(outputs) || outputs.length === 0) return true;
+  if (isOpenRouterMetaModel(entry.id)) return true;
+  return outputs.every((modality) => modality === "text");
+}
+
 function transformOpenRouterEntries(entries: OpenRouterListResponse["data"]): CatalogModel[] {
   const out: CatalogModel[] = [];
   for (const entry of entries) {
     if (typeof entry.id !== "string" || !entry.id) continue;
     if (entry.deprecated) continue;
+    if (!outputIsRenderableChat(entry)) continue;
     const inputs = entry.architecture?.input_modalities ?? [];
     const inputMode = inputs.length > 0 ? inputs.join("+") : undefined;
     out.push({
@@ -590,8 +696,15 @@ function buildPayload(
     // that route accepts.
     merged = merged.map((m) => ({ ...m, availableOnSubscription: true }));
   }
+  // The BOX's answer first. `openclaw models list` tags one row `default` per
+  // provider, and preferring the hand-written map over it is the same defect
+  // this change exists to fix, pointed at the default instead of the list: on a
+  // stock 2026.8.1 host the map picks `gpt-5.4` while the box says
+  // `gpt-5.6-sol`. The map stays as the fallback for a catalogue that tags
+  // nothing and for the curated cold-start rows, which carry no tag at all.
   const fallbackDefault = DEFAULT_MODEL_BY_PROVIDER[provider];
-  const defaultModelId = merged.find((m) => m.id === fallbackDefault)?.id
+  const defaultModelId = merged.find((m) => m.isDefault)?.id
+    ?? merged.find((m) => m.id === fallbackDefault)?.id
     ?? merged[0]?.id
     ?? fallbackDefault
     ?? "";
@@ -784,8 +897,26 @@ async function fetchOpenRouterCatalog(): Promise<CatalogFetchResult> {
 // refresh right after the user adds an API key — otherwise the
 // catalog stays on the pre-auth snapshot from boot warmup until the
 // next service restart.
-export function refreshInBackground(provider: string): void {
+export function refreshInBackground(
+  provider: string,
+  opts: {
+    /**
+     * The PROVIDER SET changed — a connect, a plugin switched on, a credential
+     * written — as opposed to a client polling for an answer. Clears the
+     * failed-refresh backoff, because the condition that produced those
+     * failures is the one that just changed.
+     *
+     * The fork rate stays bounded without the backoff here: `refreshing` admits
+     * one enumeration per provider at a time, and the only two callers that set
+     * this are `configure`'s post-save refresh and a `?refresh=1` GET, which
+     * `useProviderCatalog` now sends once per provider-set signal and never on
+     * its warming polls.
+     */
+    providerChanged?: boolean;
+  } = {},
+): void {
   if (refreshing.has(provider)) return;
+  if (opts.providerChanged) clearFailedRefresh(provider);
   // A provider that just failed to answer waits before it is asked again. This
   // is the only brake on the "not live -> re-enumerate" rule, so it comes
   // before every other check — including the edition guard below, whose log
@@ -971,7 +1102,11 @@ export async function GET(req: NextRequest) {
   // on an upgraded box those files hold the curated list a failed enumeration
   // left behind, and nothing else would ever dislodge them.
   if (force || isStale || !isLivePayload(cached)) {
-    refreshInBackground(provider);
+    // `?refresh=1` is the provider-set signal reaching the route: since the
+    // hook stopped sending it on warming polls it arrives once per connect,
+    // enable or removal, which is exactly the event the backoff must not
+    // outlive. A plain poll passes nothing and stays behind the brake.
+    refreshInBackground(provider, { providerChanged: force });
   }
 
   // "An answer is actually on its way" — the ONE thing that tells a client

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -787,6 +787,17 @@ function sanitizeCachedPayload(provider: string, cached: CatalogResponse): Catal
  */
 const NO_CLI_ENUMERATION_PROVIDERS: ReadonlySet<string> = new Set(["openrouter", "clawai", "codex"]);
 
+/**
+ * Of those three, the one with NOTHING to ask rather than something else to
+ * ask. openrouter has a REST catalogue and clawai has its routing table; codex
+ * has no enumeration on this core in any form, so unlike the other two it is
+ * not merely CLI-exempt — no state the box can reach makes it listable, which
+ * is why a provider-set change does not clear its backoff.
+ */
+function hasNoEnumerationOnThisCore(provider: string): boolean {
+  return provider === "codex";
+}
+
 interface CatalogFetchResult {
   models: CatalogModel[];
   /**
@@ -916,7 +927,14 @@ export function refreshInBackground(
   } = {},
 ): void {
   if (refreshing.has(provider)) return;
-  if (opts.providerChanged) clearFailedRefresh(provider);
+  // A provider-set change clears the wait — but only where a change to the box
+  // could plausibly make this provider enumerable. `codex` is not a provider on
+  // this core at all (see the note above `NO_CLI_ENUMERATION_PROVIDERS`), so no
+  // connect, plugin switch or credential makes it listable, and clearing there
+  // would only reprint its one log line on every `?refresh=1` the picker sends.
+  if (opts.providerChanged && !hasNoEnumerationOnThisCore(provider)) {
+    clearFailedRefresh(provider);
+  }
   // A provider that just failed to answer waits before it is asked again. This
   // is the only brake on the "not live -> re-enumerate" rule, so it comes
   // before every other check — including the edition guard below, whose log
@@ -940,7 +958,7 @@ export function refreshInBackground(
 
   refreshing.add(provider);
 
-  if (provider === "codex") {
+  if (hasNoEnumerationOnThisCore(provider)) {
     // Documented above: this core has no ChatGPT-surface enumeration, and the
     // CLI answers `Unknown provider filter "codex"`. Forking a whole openclaw
     // process on a Jetson to be told that again — at every boot, and once per

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -40,7 +40,7 @@ export const dynamic = "force-dynamic";
 // stamped `source: "live"`; everything else is served marked `fallback` so the
 // client comes back for the real answer. An enumeration that returns ZERO
 // models is not an answer either — the previous good catalogue is kept and the
-// CLI's stderr is logged, because "0 models" means the plugin is off or the
+// CLI's own reason is logged, because "0 models" means the plugin is off or the
 // provider id is gone, not that the box can run nothing.
 
 const OPENCLAW_BIN = findOpenclawBin();
@@ -596,6 +596,14 @@ function sanitizeCachedPayload(provider: string, cached: CatalogResponse): Catal
  *
  * The `codex` CATALOGUE id itself is being retired separately (TASK-652); this
  * entry keeps the picker showing real models until it is, and goes with it.
+ *
+ * WHAT THIS DOES NOT ANSWER: whether the box can RUN these rows on a ChatGPT
+ * account. Every openai row comes back `available: true` as soon as any openai
+ * profile exists — on the affected box that was the ClawBox AI image token, an
+ * API key that cannot chat — so `available` here means "the openai catalogue
+ * carries it", never "the ChatGPT route will take it". That second question is
+ * "is there an openai OAUTH profile", which lives with the credential store
+ * (TASK-652 surfaces it); a picker must not answer it from this payload.
  */
 const ENUMERATION_PROVIDER: Record<string, string> = {
   codex: "openai",

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -166,6 +166,31 @@ interface FailedRefresh {
 const failedRefreshes = new Map<string, FailedRefresh>();
 const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
 
+/**
+ * "A provider-set change arrived while this provider was already enumerating,
+ * and the answer in flight predates it."
+ *
+ * The single-flight guard is right to collapse two overlapping enumerations —
+ * but only when they would ask the same question. A connect changes the
+ * question: the fork already running was started before the credential existed
+ * and will answer for a box that no longer exists. Dropped, it does worse than
+ * lose the refresh, because that pre-credential answer is then PUBLISHED with
+ * `source: "live"` and a fresh `fetchedAt` — one openai row on a stock host
+ * where a linked box lists ten — and `force || isStale || !isLivePayload` is
+ * false against it for the next six hours. The marker this route exists to
+ * introduce would be vouching for the very thing it was introduced to catch.
+ *
+ * The wizard's own timing makes this the common case rather than a race:
+ * `bootWarmup` starts on the FIRST picker GET, not at boot, and staggers the
+ * providers 5s apart at ~3 minutes each on a Jetson, so a key saved a minute
+ * after the AI-models step opens lands inside its provider's window.
+ *
+ * So the change is remembered here and re-entered from the `.finally` that
+ * releases the guard. Bounded: the entry is deleted before the re-entry, and
+ * the re-entry is serialised by `refreshing` like any other.
+ */
+const pendingProviderChange = new Set<string>();
+
 function refreshIsBlocked(provider: string): boolean {
   const failure = failedRefreshes.get(provider);
   return failure !== undefined && failure.until > Date.now();
@@ -926,28 +951,42 @@ export function refreshInBackground(
     providerChanged?: boolean;
   } = {},
 ): void {
-  if (refreshing.has(provider)) return;
-  // A provider-set change clears the wait — but only where a change to the box
-  // could plausibly make this provider enumerable. `codex` is not a provider on
-  // this core at all (see the note above `NO_CLI_ENUMERATION_PROVIDERS`), so no
-  // connect, plugin switch or credential makes it listable, and clearing there
-  // would only reprint its one log line on every `?refresh=1` the picker sends.
-  if (opts.providerChanged && !hasNoEnumerationOnThisCore(provider)) {
+  // Providers that never touch the CLI (see NO_CLI_ENUMERATION_PROVIDERS);
+  // every other one's catalog comes from `openclaw models list`. On an edition
+  // without the binary (Hermes) that spawn is a guaranteed ENOENT.
+  const usesOpenclawCli = !NO_CLI_ENUMERATION_PROVIDERS.has(provider);
+  const cliMissing = usesOpenclawCli && openclawIsAbsent();
+
+  // "Could any change to this box make this provider enumerable?" Two say no
+  // for reasons no credential touches: `codex` is not a provider on this core
+  // at all (see the note above NO_CLI_ENUMERATION_PROVIDERS), and an edition
+  // without the CLI has nothing to ask. Clearing the wait for either would only
+  // reprint their one log line on every `?refresh=1` the picker sends, which is
+  // the property that log line's own comment claims.
+  const changeCouldMakeItEnumerable = !hasNoEnumerationOnThisCore(provider) && !cliMissing;
+
+  if (refreshing.has(provider)) {
+    // Collapsed, but NOT forgotten — see `pendingProviderChange`. The fork in
+    // flight was started before this change and answers for the box as it was.
+    if (opts.providerChanged && changeCouldMakeItEnumerable) {
+      pendingProviderChange.add(provider);
+    }
+    return;
+  }
+  if (opts.providerChanged && changeCouldMakeItEnumerable) {
     clearFailedRefresh(provider);
   }
   // A provider that just failed to answer waits before it is asked again. This
   // is the only brake on the "not live -> re-enumerate" rule, so it comes
-  // before every other check — including the edition guard below, whose log
-  // line would otherwise repeat on every request of a Hermes box's session.
+  // before every other check that can log — the edition guard below would
+  // otherwise repeat its line on every request of a Hermes box's session, which
+  // is why the clear above excludes exactly that case.
   if (refreshIsBlocked(provider)) return;
 
-  // Providers that never touch the CLI (see NO_CLI_ENUMERATION_PROVIDERS);
-  // every other one's catalog comes from `openclaw models list`. On an edition without
-  // the binary (Hermes) that spawn is a guaranteed ENOENT, so skip it cleanly
-  // rather than fork a missing binary for each provider on every boot warmup.
-  // Hermes surfaces its own model list through the Hermes dashboard, not here.
-  const usesOpenclawCli = !NO_CLI_ENUMERATION_PROVIDERS.has(provider);
-  if (usesOpenclawCli && openclawIsAbsent()) {
+  // Skip a missing binary cleanly rather than fork it for each provider on
+  // every boot warmup. Hermes surfaces its own model list through the Hermes
+  // dashboard, not here.
+  if (cliMissing) {
     console.log(`[catalog] skipping ${provider}: the openclaw CLI is not present on this edition`);
     // Recorded as a failed attempt so the line above appears once per backoff
     // window instead of once per picker open: on this edition it can never
@@ -1060,6 +1099,13 @@ export function refreshInBackground(
       // handled by the `.catch` above.
       await surface.catch(() => {});
       refreshing.delete(provider);
+      // A provider-set change that arrived while the fork above was running was
+      // collapsed into it, and that fork answered for the box as it was BEFORE
+      // the change. Serve it now, against the box as it is. Deleted first, so
+      // this can re-enter at most once per signal.
+      if (pendingProviderChange.delete(provider)) {
+        refreshInBackground(provider, { providerChanged: true });
+      }
     });
 }
 
@@ -1111,10 +1157,21 @@ export async function GET(req: NextRequest) {
     }
   }
 
+  // Sanitised BEFORE freshness is judged, because the sanitiser is what decides
+  // how many rows this response actually carries. A live, under-6h payload
+  // whose every row the CURRENT rules filter out is served as `models: []` —
+  // and judged on the raw cache it looked fresh, live and unfailed, so nothing
+  // re-enumerated and the picker sat on the curated list. That state arrives
+  // the first time a filter is tightened, which is exactly what this branch
+  // just did to the previous generation of caches.
+  const sanitized = cached ? sanitizeCachedPayload(provider, cached) : null;
+  const servedEmpty = sanitized !== null && sanitized.models.length === 0;
+
   const ageMs = cached ? Date.now() - cached.fetchedAt : Infinity;
   const isStale = ageMs > REFRESH_INTERVAL_MS
     || cached?.stale === true
-    || refreshFailedLast(provider);
+    || refreshFailedLast(provider)
+    || servedEmpty;
   // A payload no device produced is a reason to ask AGAIN, not a reason to
   // wait six hours. That includes a cache written before `source` existed —
   // on an upgraded box those files hold the curated list a failed enumeration
@@ -1134,13 +1191,27 @@ export async function GET(req: NextRequest) {
   // where a fork really is out there, is.
   const enumerating = refreshing.has(provider);
 
-  if (cached) {
-    const sanitized = sanitizeCachedPayload(provider, cached);
+  if (cached && sanitized) {
     memCache.set(provider, sanitized);
     const payload: CatalogResponse = {
       ...sanitized,
       ...(isStale ? { stale: true } : {}),
-      ...(enumerating && !isLivePayload(cached) ? { warming: true } : {}),
+      // `warming` means "asking again is worth something", so it is true
+      // whenever a fork is out there AND what this response carries is not the
+      // answer that fork will bring:
+      //  * the payload is not a device's (cold start, upgraded cache);
+      //  * `force` — the provider set just changed, so even a LIVE payload is
+      //    the pre-change one. Without this clause a connect on a provider that
+      //    already had a live catalogue was invisible: the hook polls only on
+      //    `warming`, so it read once, settled, and the post-credential list
+      //    landed three minutes later with nobody asking;
+      //  * the sanitiser emptied it, so the client is about to render the
+      //    curated rows instead.
+      // The plain 6h refresh still passes none of these, which is what keeps
+      // every mounted picker from polling through it.
+      ...(enumerating && (!isLivePayload(cached) || force || servedEmpty)
+        ? { warming: true }
+        : {}),
     };
     return NextResponse.json(payload, { headers: noStore() });
   }

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -170,6 +170,15 @@ async function writeDiskCache(provider: string, payload: CatalogResponse): Promi
 
 interface OpenclawListResponse {
   count: number;
+  /**
+   * A refused command answers `{ok: false, error}` on STDOUT and exits 0 —
+   * measured: `models list --provider codex --all --json` on 2026.8.1 prints
+   * `Unknown provider filter "codex" for this installation` in that body, with
+   * an empty stderr and exit code 0. An empty list has to be able to say why,
+   * so this is read rather than the exit code.
+   */
+  ok?: boolean;
+  error?: { type?: string; message?: string };
   models: Array<{
     key: string;
     name?: string;
@@ -594,8 +603,23 @@ const ENUMERATION_PROVIDER: Record<string, string> = {
 
 interface CatalogFetchResult {
   models: CatalogModel[];
-  /** The CLI's stderr, so a zero-model answer can say why it was empty. */
-  stderr: string;
+  /**
+   * Why an empty list was empty: the CLI's own `error.message` when it refused
+   * the command, else its stderr. Empty when it simply had nothing to list.
+   */
+  diagnostic: string;
+}
+
+function toFetchResult(
+  provider: string,
+  parsed: OpenclawListResponse,
+  stderr: string,
+): CatalogFetchResult {
+  const refusal = parsed.ok === false ? parsed.error?.message?.trim() : "";
+  return {
+    models: transformOpenclawEntries(provider, parsed.models ?? []),
+    diagnostic: refusal || stderr.trim(),
+  };
 }
 
 function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
@@ -630,10 +654,7 @@ function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
       try {
         const parsed = JSON.parse(stdout) as OpenclawListResponse;
         clearTimeout(timer);
-        finish(() => resolve({
-          models: transformOpenclawEntries(provider, parsed.models ?? []),
-          stderr,
-        }));
+        finish(() => resolve(toFetchResult(provider, parsed, stderr)));
       } catch {
         // Partial JSON — keep accumulating.
       }
@@ -653,7 +674,7 @@ function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
       finish(() => {
         try {
           const parsed = JSON.parse(stdout) as OpenclawListResponse;
-          resolve({ models: transformOpenclawEntries(provider, parsed.models ?? []), stderr });
+          resolve(toFetchResult(provider, parsed, stderr));
         } catch {
           reject(new Error(`openclaw produced non-JSON output: ${stdout.slice(0, 200)}`));
         }
@@ -671,7 +692,7 @@ async function fetchOpenRouterCatalog(): Promise<CatalogFetchResult> {
     throw new Error(`openrouter ${res.status}`);
   }
   const data = (await res.json()) as OpenRouterListResponse;
-  return { models: transformOpenRouterEntries(data.data ?? []), stderr: "" };
+  return { models: transformOpenRouterEntries(data.data ?? []), diagnostic: "" };
 }
 
 // Refresh the catalog for `provider` in the background. Returns
@@ -704,7 +725,7 @@ export function refreshInBackground(provider: string): void {
     // The only catalogue with no upstream to ask: Mike's gateway routes the
     // two device tiers and nothing else, so these two rows ARE the device's
     // answer rather than a stand-in for one.
-    fetcher = Promise.resolve({ models: CLAWAI_STATIC_MODELS, stderr: "" });
+    fetcher = Promise.resolve({ models: CLAWAI_STATIC_MODELS, diagnostic: "" });
   } else {
     fetcher = fetchOpenclawCatalog(provider);
   }
@@ -744,7 +765,7 @@ export function refreshInBackground(provider: string): void {
   };
 
   fetcher
-    .then(async ({ models, stderr }) => {
+    .then(async ({ models, diagnostic }) => {
       if (models.length === 0) {
         // NOT a success. "[catalog] refreshed codex: 0 models" used to be
         // followed by a disk write of the curated list, which then read back
@@ -754,7 +775,7 @@ export function refreshInBackground(provider: string): void {
         // of those are facts about what the box can run.
         console.warn(
           `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
-          + (stderr.trim() ? ` — ${stderr.slice(-300).trim()}` : " (no stderr)"),
+          + (diagnostic ? ` — ${diagnostic.slice(-300)}` : " (the CLI gave no reason)"),
         );
         markStale();
         return;

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -177,9 +177,8 @@ const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
  *
  *  * `changeSeq` — bumped by every accepted provider-set change (a connect, a
  *    plugin switched on, a credential written).
- *  * `inFlight` — the generation the running fork will answer for, and whether
- *    a change is what started it. Captured when the fork STARTS, because that
- *    is when the box it reads is fixed.
+ *  * the generation the running fork will answer for, captured in `forkSeq`
+ *    when it STARTS, because that is when the box it reads is fixed.
  *  * `publishedSeq` — the generation of the payload currently in `memCache`
  *    and on disk.
  *
@@ -198,44 +197,43 @@ const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
  *    and the hook's next poll two seconds later saw `warming: false` with three
  *    minutes still to run, so a picker open across a connect settled on the
  *    pre-change rows.
- *  * A change arriving while a fork of the CURRENT generation is already out,
- *    started by a change, is the same signal reaching the route twice —
- *    `configure` step 8c and then the client's `?refresh=1`, which are ordered
- *    by awaits, not racing. It is ignored, because the fork out there already
- *    answers for the box as it now is. Bumping again cost every connect a
- *    second full ~3-minute `openclaw models list` at the wizard's most
- *    latency-sensitive moment. `fromChange` is what keeps that distinct from a
- *    warmup or poll fork, which started before the change and must NOT absorb
- *    it.
+ *  * ONLY A SERVER-SIDE WRITE COUNTS. `configure` step 8c, `providers/enabled`
+ *    and the plugin re-gate inside `chat/model` (which `providers/default`
+ *    delegates to) each call `notifyProviderSetChanged`; a client's
+ *    `?refresh=1` is demoted to `serveCurrent`, which asks whether the current
+ *    generation has an answer and never claims one happened.
+ *
+ *    That split is what removed the duplicate enumeration per connect —
+ *    step 8c and the client's echo are the same change, and only the write
+ *    counts — WITHOUT the predicate that used to do it. That predicate read
+ *    the shape of the fork in flight rather than the identity of the signal,
+ *    so a second, genuinely different change 30 seconds later (a corrected
+ *    key, a provider switched off and back on) landed on the same branch and
+ *    was dropped: no bump, no re-entry, and the pre-change fork then published
+ *    as the current generation with nothing left to re-enumerate for six
+ *    hours. One write is one bump; two writes are two generations.
  *
  * Per-process, like `memCache`, `refreshing` and `failedRefreshes` beside it. A
  * restart re-enumerates through `bootWarmup` anyway.
  */
 const changeSeq = new Map<string, number>();
 const publishedSeq = new Map<string, number>();
-interface InFlightFork {
-  /** The generation this fork's answer describes. */
-  seq: number;
-  /** Was it started BY a provider-set change, rather than a warmup or poll? */
-  fromChange: boolean;
-}
-const inFlight = new Map<string, InFlightFork>();
-
-/**
- * Providers with a change no fork has answered yet, re-entered from the
- * `.finally` that releases the single-flight guard. A Set: several signals
- * arriving during one fork collapse to one re-entry, which is what keeps the
- * replacement bounded at one extra enumeration per provider.
- */
-const pendingProviderChange = new Set<string>();
 
 function currentSeq(provider: string): number {
   return changeSeq.get(provider) ?? 0;
 }
 
-/** Is the payload we would serve the answer for the box as it is now? */
+/**
+ * Is the payload we would serve the answer for the box as it is now?
+ *
+ * An unpublished provider defaults to generation 0, the same floor `changeSeq`
+ * starts from, so a fresh process is "current" until something actually
+ * changes. Defaulting it BELOW the floor made every provider stale and warming
+ * after every restart, which put each mounted picker into a poll loop over a
+ * box nobody had touched.
+ */
 function publishedIsCurrent(provider: string): boolean {
-  return (publishedSeq.get(provider) ?? -1) >= currentSeq(provider);
+  return (publishedSeq.get(provider) ?? 0) >= currentSeq(provider);
 }
 
 function refreshIsBlocked(provider: string): boolean {
@@ -526,6 +524,11 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
       source: "live",
     };
     memCache.set(surfaceProvider, payload);
+    // Stamped like any other publish. Without it this provider is permanently
+    // "not the current generation": `isStale` never clears, `warming` is true
+    // whenever any fork is out, and every GET past the backoff re-enumerates a
+    // catalogue that was just written.
+    publishedSeq.set(surfaceProvider, currentSeq(surfaceProvider));
     recordSuccessfulRefresh(surfaceProvider);
     await writeDiskCache(surfaceProvider, payload);
     return new Set(payload.models.map((m) => m.id));
@@ -538,17 +541,14 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     return null;
   } finally {
     refreshing.delete(surfaceProvider);
-    inFlight.delete(surfaceProvider);
-    // The SECOND place that releases the guard, so the second place a pending
-    // change would otherwise sit unclaimed: a `providerChanged` for a provider
-    // that is in `refreshing` only because it is somebody else's subscription
-    // surface was recorded and never re-entered, then fired against whatever
-    // unrelated fork happened to finish next. Unreachable while
-    // SUBSCRIPTION_SURFACE names no `surfaceProvider`, which is why it is
-    // closed here rather than left for the day one is added.
-    if (pendingProviderChange.delete(surfaceProvider)) {
-      refreshInBackground(surfaceProvider, { providerChanged: true, alreadyCounted: true });
-    }
+    // The SECOND place that releases the guard, so it asks the same question
+    // the main one does: does the current generation have an answer? A change
+    // recorded while this provider was held only as somebody else's
+    // subscription surface would otherwise sit unserved until an unrelated
+    // fork happened along. Unreachable while SUBSCRIPTION_SURFACE names no
+    // `surfaceProvider`, which is why it is closed here rather than left for
+    // the day one is added.
+    refreshInBackground(surfaceProvider, { serveCurrent: true });
   }
 }
 
@@ -1014,13 +1014,17 @@ export function refreshInBackground(
      */
     providerChanged?: boolean;
     /**
-     * Internal: this change has already been counted, it is only now being
-     * served. Set solely by the re-entry in the `.finally` below, which drains
-     * a change that arrived while a fork was out. Without it the re-entry would
-     * bump the generation a second time for one change, and the next genuine
-     * change would then look like a duplicate of it.
+     * "Make sure the CURRENT generation has an answer." Starts a fork only when
+     * the published payload is behind `changeSeq`; never counts a change.
+     *
+     * This is what a client's `?refresh=1` is, and what the re-entries below
+     * are. A client cannot know that the provider set changed — only the write
+     * that changed it can — and treating its nudge as news is what let a
+     * genuinely different change be mistaken for `configure`'s echo. It is
+     * also what makes the nudge harmless: nothing to bump, no backoff to
+     * clear, no running fork's work to discard.
      */
-    alreadyCounted?: boolean;
+    serveCurrent?: boolean;
   } = {},
 ): void {
   // Providers that never touch the CLI (see NO_CLI_ENUMERATION_PROVIDERS);
@@ -1037,40 +1041,33 @@ export function refreshInBackground(
   // the property that log line's own comment claims.
   const changeCouldMakeItEnumerable = !hasNoEnumerationOnThisCore(provider) && !cliMissing;
 
-  const changeAccepted = opts.providerChanged === true && changeCouldMakeItEnumerable;
-  const countsAsNewChange = changeAccepted && opts.alreadyCounted !== true;
-  const running = inFlight.get(provider);
-
-  // The SAME change reaching the route a second time. `configure` step 8c fires
-  // one statement after the credential write, the client's `?refresh=1` follows
-  // when the response lands — ordered by awaits, not racing — and both say
-  // `providerChanged`. The fork already out was started by the first of them,
-  // so it is reading the box this second signal is reporting. Bumping again
-  // bought a duplicate ~3-minute `openclaw models list` on every connect.
-  const alreadyAnswering = running !== undefined
-    && running.fromChange
-    && running.seq === currentSeq(provider);
-
-  if (countsAsNewChange && !alreadyAnswering) {
+  // A SERVER-SIDE WRITE changed the provider set. Every such write counts —
+  // `configure` step 8c, `providers/enabled`, and the plugin re-gate inside
+  // `chat/model` that `providers/default` delegates to — which is what makes
+  // the generation trustworthy enough for the client's nudge to be demoted.
+  //
+  // There is deliberately no "is this the same change twice" test here any
+  // more. The predicate that used to do it read the SHAPE of the fork in
+  // flight — change-started, current generation — and so could not tell
+  // `configure`'s echo from a second, genuinely different change 30 seconds
+  // later: both landed on the identical branch, and the second was dropped
+  // with no bump and no re-entry, after which the pre-change fork published as
+  // the current generation and nothing re-enumerated for six hours. One write
+  // is one bump; two writes are two generations; a client nudge is neither.
+  if (opts.providerChanged === true && changeCouldMakeItEnumerable) {
     changeSeq.set(provider, currentSeq(provider) + 1);
-  }
-
-  if (refreshing.has(provider)) {
-    // Collapsed, but NOT forgotten — see the generation note above. The fork in
-    // flight was started before this change and answers for the box as it was.
-    if (countsAsNewChange && !alreadyAnswering) {
-      pendingProviderChange.add(provider);
-    }
-    return;
-  }
-  if (changeAccepted) {
+    // The condition that produced any recorded failure is the one that just
+    // changed, so the next attempt must not be made to wait it out. Cleared
+    // here rather than after the single-flight check, because the fork in
+    // flight is about to be discarded and it is the re-entry that needs the
+    // wait gone.
     clearFailedRefresh(provider);
   }
-  // A provider that just failed to answer waits before it is asked again. This
-  // is the only brake on the "not live -> re-enumerate" rule, so it comes
-  // before every other check that can log — the edition guard below would
-  // otherwise repeat its line on every request of a Hermes box's session, which
-  // is why the clear above excludes exactly that case.
+
+  // Nothing to do: the answer on file is already for the box as it is.
+  if (opts.serveCurrent === true && publishedIsCurrent(provider)) return;
+
+  if (refreshing.has(provider)) return;
   if (refreshIsBlocked(provider)) return;
 
   // Skip a missing binary cleanly rather than fork it for each provider on
@@ -1088,7 +1085,6 @@ export function refreshInBackground(
   refreshing.add(provider);
   // Captured at START, because that is when the box this fork reads is fixed.
   const forkSeq = currentSeq(provider);
-  inFlight.set(provider, { seq: forkSeq, fromChange: changeAccepted });
 
   if (hasNoEnumerationOnThisCore(provider)) {
     // Documented above: this core has no ChatGPT-surface enumeration, and the
@@ -1099,7 +1095,6 @@ export function refreshInBackground(
     console.log(`[catalog] ${provider}: no enumeration on this core, serving the curated list`);
     recordFailedRefresh(provider);
     refreshing.delete(provider);
-    inFlight.delete(provider);
     return;
   }
 
@@ -1125,7 +1120,13 @@ export function refreshInBackground(
   // Resolves to null immediately for a natively-routed provider, which has no
   // second catalogue — `buildPayload` stamps that case from the merged list on
   // the first publish, so those boxes are never served an unstamped payload.
-  const surface = fetchSubscriptionSurfaceIds(provider);
+  // `.catch` attached HERE, not minutes later in the `.finally`. Node's default
+  // `--unhandled-rejections=throw` kills the process on a rejection that is
+  // unhandled at the end of its turn, and the window between creating this and
+  // the `.finally` touching it is as wide as the enumeration. Unreachable
+  // today — the function returns before it can throw — but the `finally` block
+  // inside it is not itself inside a `try`.
+  const surface = fetchSubscriptionSurfaceIds(provider).catch(() => null);
 
   const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {
     // The CLI answered, so the provider is enumerable — that much is true
@@ -1138,9 +1139,9 @@ export function refreshInBackground(
       // PRE-credential list: one openai row where the linked box lists ten.
       // Serving it would be this route's own false success, and stamping it
       // `source: "live"` with a fresh `fetchedAt` is what made the previous
-      // build sit on it. The replacement is already scheduled: the same change
-      // that superseded this fork put the provider in `pendingProviderChange`,
-      // which the `.finally` below drains.
+      // build sit on it. The replacement follows on its own: `publishedSeq`
+      // stays behind `changeSeq`, and the `.finally` below asks for the
+      // current generation.
       console.log(
         `[catalog] discarding ${provider}: ${models.length} models from before the provider changed`
         + ` (generation ${forkSeq} < ${currentSeq(provider)}), re-enumerating`,
@@ -1208,20 +1209,38 @@ export function refreshInBackground(
       // and releasing while it still holds ~2 cores of a Jetson lets the next
       // request start a second MAIN enumeration beside it.
       //
-      // Swallowed rather than awaited bare: this is cleanup, and a surface
-      // failure has already been logged by `fetchSubscriptionSurfaceIds` or
-      // handled by the `.catch` above.
-      await surface.catch(() => {});
+      // Already carries its own handler (see where it is created), so this is
+      // just "wait for it".
+      await surface;
       refreshing.delete(provider);
-      inFlight.delete(provider);
-      // A provider-set change that arrived while the fork above was running was
-      // collapsed into it, and that fork answered for the box as it was BEFORE
-      // the change. Serve it now, against the box as it is. Deleted first, so
-      // this can re-enter at most once per signal.
-      if (pendingProviderChange.delete(provider)) {
-        refreshInBackground(provider, { providerChanged: true, alreadyCounted: true });
-      }
+      // "Does the current generation have an answer?" — asked once, here, on
+      // every path. A fork that published for the current generation makes this
+      // a no-op; one that was discarded, failed, or was superseded while it ran
+      // leaves the generation unanswered and this starts its replacement. No
+      // pending set to keep in step with the release: the counter IS the record.
+      refreshInBackground(provider, { serveCurrent: true });
     });
+}
+
+/**
+ * "A server-side write just changed the provider set for `ocProvider`."
+ *
+ * The ONE entry point for every route that mutates the provider set, so the
+ * openclaw-side id mapping and the catalogue-membership test exist once rather
+ * than once per caller. `ocProvider` is the openclaw id (`anthropic`, `openai`,
+ * `codex`, `google`, `deepseek`); the catalogue calls ClawBox AI `clawai`, and
+ * a provider that is not in the catalogue at all (local-only, llamacpp) is not
+ * something this route can enumerate.
+ *
+ * Counting the change server-side is what lets the client's `?refresh=1` be a
+ * nudge instead of a claim — see `refreshInBackground`. A write that forgets to
+ * call this leaves its change invisible to the catalogue until the 6h refresh.
+ */
+export function notifyProviderSetChanged(ocProvider: string | null | undefined): void {
+  if (!ocProvider) return;
+  const catalogProvider = ocProvider === "deepseek" ? "clawai" : ocProvider;
+  if (!isCatalogProvider(catalogProvider)) return;
+  refreshInBackground(catalogProvider, { providerChanged: true });
 }
 
 // Boot warmup: when this module is first imported (typically when the
@@ -1294,12 +1313,17 @@ export async function GET(req: NextRequest) {
   // wait six hours. That includes a cache written before `source` existed —
   // on an upgraded box those files hold the curated list a failed enumeration
   // left behind, and nothing else would ever dislodge them.
-  if (force || isStale || !isLivePayload(cached)) {
-    // `?refresh=1` is the provider-set signal reaching the route: since the
-    // hook stopped sending it on warming polls it arrives once per connect,
-    // enable or removal, which is exactly the event the backoff must not
-    // outlive. A plain poll passes nothing and stays behind the brake.
-    refreshInBackground(provider, { providerChanged: force });
+  if (isStale || !isLivePayload(cached)) {
+    refreshInBackground(provider);
+  } else if (force) {
+    // `?refresh=1` is a NUDGE, not news. The client cannot know the provider
+    // set changed — only the write that changed it can, and every such write
+    // now counts it — so this asks whether the current generation has an
+    // answer and stops there. It used to say `providerChanged`, which let a
+    // client bump the generation, clear the backoff, and discard a running
+    // fork's three minutes of work; and it made a real change arriving in the
+    // same window indistinguishable from this one.
+    refreshInBackground(provider, { serveCurrent: true });
   }
 
   // "An answer is actually on its way" — the ONE thing that tells a client

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -197,11 +197,12 @@ const FAILED_REFRESH_BACKOFF_MS = 2 * 60_000;
  *    and the hook's next poll two seconds later saw `warming: false` with three
  *    minutes still to run, so a picker open across a connect settled on the
  *    pre-change rows.
- *  * ONLY A SERVER-SIDE WRITE COUNTS. `configure` step 8c, `providers/enabled`
- *    and the plugin re-gate inside `chat/model` (which `providers/default`
- *    delegates to) each call `notifyProviderSetChanged`; a client's
- *    `?refresh=1` is demoted to `serveCurrent`, which asks whether the current
- *    generation has an answer and never claims one happened.
+ *  * ONLY A SERVER-SIDE WRITE COUNTS, and every one of them goes through
+ *    `notifyProviderSetChanged` — whose docblock is the register of which
+ *    writes those are, kept in one place because nothing else enforces that a
+ *    new write remembers to call it. A client's `?refresh=1` is demoted to
+ *    `serveCurrent`, which asks whether the current generation has an answer
+ *    and never claims one happened.
  *
  *    That split is what removed the duplicate enumeration per connect —
  *    step 8c and the client's echo are the same change, and only the write
@@ -901,7 +902,17 @@ function toFetchResult(
   parsed: OpenclawListResponse,
   stderr: string,
 ): CatalogFetchResult {
-  const rows = parsed.models ?? [];
+  // `Array.isArray`, not `?? []`: the type says this is a list, the JSON on the
+  // other side is whatever the CLI printed, and a non-array here would be
+  // iterated by `transformOpenclawEntries` and then `.filter`ed below. That
+  // throw used to be swallowed by the chunk handler's partial-JSON `catch`
+  // AFTER it had set `settled`, so the promise never settled, the `.finally`
+  // never ran, and `refreshing` kept the provider for the process lifetime:
+  // every later refresh returned at the single-flight guard and `warming`
+  // stayed true, so the picker polled a fork that no longer existed. A
+  // malformed payload is an empty enumeration, which this route already knows
+  // how to report.
+  const rows = Array.isArray(parsed.models) ? parsed.models : [];
   const models = transformOpenclawEntries(provider, rows);
   const refusal = parsed.ok === false ? parsed.error?.message?.trim() : "";
   let diagnostic = refusal || stderr.trim();
@@ -946,13 +957,29 @@ function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
       // on each chunk so we resolve as soon as the JSON is syntactically
       // complete instead of waiting for `close`.
       if (settled || !stdout.includes("}")) return;
+      let parsed: OpenclawListResponse;
       try {
-        const parsed = JSON.parse(stdout) as OpenclawListResponse;
-        clearTimeout(timer);
-        finish(() => resolve(toFetchResult(provider, parsed, stderr)));
+        parsed = JSON.parse(stdout) as OpenclawListResponse;
       } catch {
-        // Partial JSON — keep accumulating.
+        // Partial JSON — keep accumulating. Only the PARSE is guarded here:
+        // this `catch` used to wrap the settle as well, so anything the
+        // transform threw was read as "not valid JSON yet" and swallowed —
+        // after `finish` had already set `settled`, which left the promise
+        // unsettled forever and the provider stuck in `refreshing`.
+        return;
       }
+      clearTimeout(timer);
+      finish(() => {
+        // A payload that parses but cannot be transformed is a refresh that
+        // FAILED, not one that never ended: rejecting records the backoff and
+        // releases the guard, the way the `close` handler already does for
+        // output that is not JSON at all.
+        try {
+          resolve(toFetchResult(provider, parsed, stderr));
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
     });
     child.stderr.on("data", (b: Buffer) => { stderr += b.toString("utf8"); });
     child.on("error", (e) => {
@@ -1006,11 +1033,14 @@ export function refreshInBackground(
      * failed-refresh backoff, because the condition that produced those
      * failures is the one that just changed.
      *
+     * Set by `notifyProviderSetChanged` and by nothing else — go there for the
+     * list of writes that count, which is the only place that list is kept. A
+     * client's `?refresh=1` deliberately cannot set it; it asks for
+     * `serveCurrent` instead.
+     *
      * The fork rate stays bounded without the backoff here: `refreshing` admits
-     * one enumeration per provider at a time, and the only two callers that set
-     * this are `configure`'s post-save refresh and a `?refresh=1` GET, which
-     * `useProviderCatalog` now sends once per provider-set signal and never on
-     * its warming polls.
+     * one enumeration per provider at a time, and every counting caller sits
+     * behind a write the owner had to make.
      */
     providerChanged?: boolean;
     /**
@@ -1041,10 +1071,10 @@ export function refreshInBackground(
   // the property that log line's own comment claims.
   const changeCouldMakeItEnumerable = !hasNoEnumerationOnThisCore(provider) && !cliMissing;
 
-  // A SERVER-SIDE WRITE changed the provider set. Every such write counts —
-  // `configure` step 8c, `providers/enabled`, and the plugin re-gate inside
-  // `chat/model` that `providers/default` delegates to — which is what makes
-  // the generation trustworthy enough for the client's nudge to be demoted.
+  // A SERVER-SIDE WRITE changed the provider set. Every such write counts, and
+  // they all arrive through `notifyProviderSetChanged` (see its docblock for
+  // which writes those are) — which is what makes the generation trustworthy
+  // enough for the client's nudge to be demoted.
   //
   // There is deliberately no "is this the same change twice" test here any
   // more. The predicate that used to do it read the SHAPE of the fork in
@@ -1226,20 +1256,38 @@ export function refreshInBackground(
  * "A server-side write just changed the provider set for `ocProvider`."
  *
  * The ONE entry point for every route that mutates the provider set, so the
- * openclaw-side id mapping and the catalogue-membership test exist once rather
- * than once per caller. `ocProvider` is the openclaw id (`anthropic`, `openai`,
- * `codex`, `google`, `deepseek`); the catalogue calls ClawBox AI `clawai`, and
- * a provider that is not in the catalogue at all (local-only, llamacpp) is not
- * something this route can enumerate.
+ * openclaw-side id mapping and the two "is this a change this route can act
+ * on?" tests exist once rather than once per caller. `ocProvider` is the
+ * openclaw id (`anthropic`, `openai`, `codex`, `google`, `deepseek`); the
+ * catalogue calls ClawBox AI `clawai`.
+ *
+ * Two kinds of provider are dropped here rather than at each call site:
+ *
+ *  * one that is not in the catalogue at all (local-only, llamacpp);
+ *  * one whose catalogue THIS BOX CANNOT CHANGE. `openrouter` is fetched from
+ *    openrouter.ai, `clawai` is a constant and `codex` has no enumeration, so
+ *    no write on the box can alter what any of them lists. Counting one would
+ *    discard whatever fetch is in flight, re-run it for the identical answer,
+ *    and clear the failed-refresh backoff — announcing a change that, for that
+ *    provider, did not happen. The compat auto-extend in `chat/model` writes
+ *    `models.providers.openrouter.models` on exactly this path.
  *
  * Counting the change server-side is what lets the client's `?refresh=1` be a
  * nudge instead of a claim — see `refreshInBackground`. A write that forgets to
  * call this leaves its change invisible to the catalogue until the 6h refresh.
+ *
+ * Its callers, which are every server-side write that can change what
+ * `openclaw models list` answers: `configure` step 8c (credential + plugin) and
+ * its `setProviderPlugins` result; `chat/model`'s compat auto-extend, its
+ * `setProviderPlugins` result and the ON half of the same gate; and the
+ * Local-only restore in `local-ai/exclusive`. `providers/default` inherits
+ * `chat/model`'s on OpenClaw.
  */
 export function notifyProviderSetChanged(ocProvider: string | null | undefined): void {
   if (!ocProvider) return;
   const catalogProvider = ocProvider === "deepseek" ? "clawai" : ocProvider;
   if (!isCatalogProvider(catalogProvider)) return;
+  if (NO_CLI_ENUMERATION_PROVIDERS.has(catalogProvider)) return;
   refreshInBackground(catalogProvider, { providerChanged: true });
 }
 

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -27,12 +27,21 @@ export const dynamic = "force-dynamic";
 // * On boot, the first import of this module kicks off a refresh for
 //   every CATALOG_PROVIDERS entry so picker opens are instant from
 //   minute 4 onward.
-// * If both caches are empty (fresh install, first picker open), we
-//   return an empty payload with `warming: true`. The client then
-//   falls back to the static catalog in src/lib/provider-models.ts.
+// * If both caches are empty (fresh install, first picker open), we serve
+//   the curated cold-start list from src/lib/provider-models.ts with
+//   `warming: true` and `fallback: true`.
 //
 // Force-refresh via `?refresh=1` triggers a refresh in the background
 // and serves whatever's currently cached — the user never waits.
+//
+// THE ONE RULE THIS FILE EXISTS TO KEEP (M-05): a payload the harness did not
+// produce is never persisted, and never presented as though it were. Only a
+// live enumeration is written to the disk cache, and only such a payload is
+// stamped `source: "live"`; everything else is served marked `fallback` so the
+// client comes back for the real answer. An enumeration that returns ZERO
+// models is not an answer either — the previous good catalogue is kept and the
+// CLI's stderr is logged, because "0 models" means the plugin is off or the
+// provider id is gone, not that the box can run nothing.
 
 const OPENCLAW_BIN = findOpenclawBin();
 const REFRESH_TIMEOUT_MS = 5 * 60_000; // openclaw on Jetson is ~3min
@@ -61,6 +70,26 @@ interface CatalogResponse {
   stale?: boolean;
   /** Set when neither cache has anything yet — client falls back to static catalog. */
   warming?: boolean;
+  /**
+   * Where these models came from. `"live"` means a device enumeration
+   * answered — `openclaw models list --provider <p> --all --json`, or
+   * OpenRouter's own /api/v1/models — and ONLY such a payload is ever written
+   * to the disk cache.
+   *
+   * Absent is not a synonym for "old": a payload persisted by a build before
+   * this field existed is indistinguishable from one built out of the curated
+   * cold-start arrays, which is exactly the state that made three hard-coded
+   * Claude entries the truth on a box that could run eleven. Treating an
+   * unmarked file as NOT live re-enumerates it once and costs nothing else.
+   */
+  source?: "live";
+  /**
+   * Set on a response the route could not answer from a live enumeration —
+   * a cold start, or a cached payload no device produced. It is served (a
+   * blank picker helps nobody) but it says what it is, so the client keeps
+   * asking instead of settling on the curated list for the next six hours.
+   */
+  fallback?: boolean;
 }
 
 // Process-local hot cache. Survives request boundaries within a single
@@ -147,17 +176,37 @@ interface OpenclawListResponse {
     input?: string;
     contextWindow?: number;
     local?: boolean;
+    /**
+     * The harness's own verdict on the row, tristate: `true` = a route it can
+     * take, `false` = one it cannot, `null`/absent = not determined. See the
+     * note below the interface before reading it as a credential check.
+     */
+    available?: boolean | null;
     tags?: string[];
   }>;
 }
 
-// `openclaw models list` also returns an `available` boolean per model. It is
-// deliberately NOT read here: it answers "can THIS box's currently-configured
-// credentials route this model", and during setup no credential is written
-// yet, so every entry comes back false. Gating the picker on it would empty
-// the list at exactly the moment the customer needs it. The auth-mode surface
-// (SUBSCRIPTION_SURFACE) is the part that IS knowable in the wizard, and it is
-// what this route stamps instead.
+// `openclaw models list` returns an `available` field per model, and this route
+// now honours it — but ONLY when it is explicitly `false`.
+//
+// It is TRISTATE, and the third state is the whole point. It mirrors the CLI's
+// Auth column, which docs.openclaw.ai/cli/models describes as a read-only check
+// resolving each route to eligible profiles and credentials and reporting `ok`,
+// `unknown` or `unavailable`; in `--json` those arrive as `true`, `null` and
+// `false`. Measured, on an unconfigured host: every anthropic row comes back
+// `"available": null` while `openai/gpt-5.6-sol` comes back `true`. On a linked
+// box every row of both providers is `true`.
+//
+// So `false` is the harness saying this route is unavailable on this box — a
+// row a picker should not offer. `null` is the harness saying it did not
+// determine one, and treating THAT as "no" would empty the list on exactly the
+// boxes that have not finished setting up, which is the failure the previous
+// comment here (which read the field as a credential gate and skipped it
+// entirely) was written to avoid. Dropping only `false` keeps that promise and
+// still stops us offering a route the box has already said it cannot take.
+//
+// The auth-mode surface (SUBSCRIPTION_SURFACE) is the second, narrower
+// question, and it is what this route stamps on top.
 //
 // anthropic's surface, concretely: `openclaw models list --provider anthropic`
 // is the plugin's catalogue (9 models on 2026.7.1, claude-mythos-5 and
@@ -198,12 +247,9 @@ const DEPRECATED_MODEL_IDS: ReadonlySet<string> = new Set([
 ]);
 
 // Per-provider allowlist regex. When set, only model ids matching the
-// pattern survive the catalog filter. Used to curate noisy upstream
-// catalogs down to a useful set without the picker exploding to 40+
-// entries the user has to scroll past.
+// pattern survive the catalog filter.
 //
-// openai (API-key auth): all 5.4 + 5.5 SKUs including -pro variants.
-//   Pros require an API key and DO work on the api.openai.com path.
+// ONE entry, and it is a routing fact rather than curation.
 //
 // codex (ChatGPT-account auth): 5.4, 5.4-mini, 5.5, plus the 5.6
 //   gpt-5.6-{sol,terra,luna} models — NO -pro variants. Per
@@ -216,12 +262,16 @@ const DEPRECATED_MODEL_IDS: ReadonlySet<string> = new Set([
 //   accounts, so this allowlist just stops us from stripping them; boxes
 //   on plans without 5.6 never see the entries (no dead buttons).
 //
-// Older generations (4.1, 5.0, 5.1, 5.2, 5.3) are intentionally
-// excluded per user request. New generations matching the pattern
-// (e.g. a future gpt-5.6) will auto-appear; new families (gpt-6) will
-// require updating the regex.
+// `openai` USED to carry /^gpt-5\.[45](-pro|-mini)?$/, to keep older
+// generations out of the picker. It aged into the opposite of its purpose: on
+// OpenClaw 2026.8.1 the openai catalogue is already curated upstream — one row
+// on a stock host (`openai/gpt-5.6-sol`, tagged default), ten on a linked box —
+// and that pattern matched NONE of the 5.6 generation, so the newest models the
+// box could run were filtered out of their own catalogue and the picker fell
+// back to a hand-written list. A generation allowlist cannot know what the next
+// generation is called; the harness's catalogue can, and the whole point of
+// this route is to ask it.
 const ALLOWED_MODEL_RE_BY_PROVIDER: Record<string, RegExp> = {
-  openai: /^gpt-5\.[45](-pro|-mini)?$/,
   // Explicit alternation, not /^gpt-5\.[45](-mini)?$/ — that would also
   // accept gpt-5.5-mini (which doesn't exist on the Codex auth path
   // and would 400 the same way gpt-5.4-pro did). Per
@@ -231,6 +281,19 @@ const ALLOWED_MODEL_RE_BY_PROVIDER: Record<string, RegExp> = {
   // appear in the live catalog for accounts entitled to them).
   codex: /^(?:gpt-5\.5|gpt-5\.4(?:-mini)?|gpt-5\.6-(?:sol|terra|luna))$/,
 };
+
+// Model families that are not CHAT models, whatever provider lists them —
+// image generation, speech, embeddings. `openclaw models list` enumerates a
+// provider's whole catalogue and offers no capability filter to ask for the
+// chat ones (`--all`, `--local`, `--provider` and nothing else on 2026.8.1),
+// and the rows carry no capability field either: an image SKU comes back with
+// the same shape as a chat model — `openai/gpt-image-1-mini` alongside
+// `openai/gpt-5.6-sol`, `input` reported as "-" for both on a stock host. So
+// this is a modality exclusion, deliberately NOT a generation allowlist: it
+// cannot hide a chat model the box has learned about, only the SKUs a chat
+// picker has no way to talk to. If the harness grows a capability filter, this
+// should become a read of it.
+const NON_CHAT_MODEL_RE = /^(?:gpt-image|dall-e|whisper|tts-|text-embedding|omni-moderation)/;
 
 // Newest-first ordering: bigger context generally means newer model on
 // every catalog we ship today (claude 200k+, gpt-5 400k, gemini 1M).
@@ -268,7 +331,7 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     return new Set(cached.models.map((m) => m.id));
   }
   try {
-    const models = await fetchOpenclawCatalog(surfaceProvider);
+    const { models } = await fetchOpenclawCatalog(surfaceProvider);
     if (models.length === 0) return null;
     const payload: CatalogResponse = {
       provider: surfaceProvider,
@@ -276,6 +339,7 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
       defaultModelId: models[0].id,
       allowCustom: false,
       fetchedAt: Date.now(),
+      source: "live",
     };
     memCache.set(surfaceProvider, payload);
     await writeDiskCache(surfaceProvider, payload);
@@ -289,6 +353,18 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
   }
 }
 
+/**
+ * `<provider>/<model>` split on the FIRST slash — the documented shape of a
+ * `key` (docs.openclaw.ai/concepts/models), and the only parsing this route
+ * does to a model name. It is split rather than prefix-stripped because the
+ * catalogue a picker is asked for is not always the provider that enumerates
+ * it: the ChatGPT surface is served from `openai/*` rows.
+ */
+function modelIdFromKey(key: string): string {
+  const slash = key.indexOf("/");
+  return slash > 0 ? key.slice(slash + 1) : key;
+}
+
 function transformOpenclawEntries(
   provider: string,
   entries: OpenclawListResponse["models"],
@@ -297,19 +373,26 @@ function transformOpenclawEntries(
   const out: CatalogModel[] = [];
   for (const entry of entries) {
     if (typeof entry.key !== "string") continue;
-    const idPrefix = `${provider}/`;
-    const id = entry.key.startsWith(idPrefix)
-      ? entry.key.slice(idPrefix.length)
-      : entry.key;
+    const id = modelIdFromKey(entry.key);
     if (!id) continue;
+    // Explicitly `false` only. `null`/absent is the harness saying it did not
+    // determine one, and hiding a row over that would empty the picker on
+    // exactly the boxes that have not finished setting up.
+    if (entry.available === false) continue;
     if (entry.tags?.includes("deprecated")) continue;
     if (DEPRECATED_MODEL_IDS.has(id)) continue;
+    if (NON_CHAT_MODEL_RE.test(id)) continue;
     if (allowed && !allowed.test(id)) continue;
     out.push({
       id,
       label: typeof entry.name === "string" && entry.name.trim() ? entry.name : id,
       contextWindow: typeof entry.contextWindow === "number" ? entry.contextWindow : 0,
       input: typeof entry.input === "string" ? entry.input : undefined,
+      // The live `name` is the label, and there is no live hint. Inventing one
+      // is how a picker ends up describing a model nobody measured, so a hint
+      // only survives where the curated entry for the SAME id already carried
+      // one — see `hintFor`.
+      hint: hintFor(provider, id),
     });
   }
   out.sort(compareCatalogModels);
@@ -320,6 +403,7 @@ function isAllowedCatalogModel(provider: string, model: CatalogModel): boolean {
   if (!model.id) return false;
   const allowed = ALLOWED_MODEL_RE_BY_PROVIDER[provider];
   if (allowed && !allowed.test(model.id)) return false;
+  if (NON_CHAT_MODEL_RE.test(model.id)) return false;
   if (DEPRECATED_MODEL_IDS.has(model.id)) return false;
   return true;
 }
@@ -357,10 +441,9 @@ const ALLOW_CUSTOM_BY_PROVIDER: Record<string, boolean> = {
   clawai: false,
 };
 
-// Context-window lookup for static-catalog entries we know about but the
-// live upstream enumeration didn't return. Values from each provider's
-// official model docs. Used only as a fallback for `augmentWithStaticCatalog`;
-// when the live catalog includes the same id its real contextWindow wins.
+// Context-window lookup for the curated cold-start entries. Values from each
+// provider's official model docs. Read ONLY when building a fallback payload —
+// a live row carries the window the device reported.
 const STATIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   // Anthropic — https://platform.claude.com/docs/en/about-claude/models
   "claude-opus-5": 1_000_000,
@@ -374,34 +457,44 @@ const STATIC_MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   "claude-haiku-4-5": 200_000,
 };
 
-// Merge the curated static list from PROVIDER_CATALOGS into the live
-// upstream models. Live entries take precedence (their contextWindow /
-// input / label reflect what the gateway actually negotiated). Static
-// entries with ids the live list doesn't include get appended — this
-// covers the case where a provider's OAuth scope returns a single
-// deprecated model (Anthropic Claude.ai consumer OAuth is the live
-// example: the docs list claude-opus-5 / claude-sonnet-5 /
-// claude-haiku-4-5 as current, but `openclaw models list --provider
-// anthropic` on a Claude.ai-OAuth device only returns the deprecated
-// claude-sonnet-4-20250514). The picker would otherwise force the
-// user to type custom model ids by hand.
-function augmentWithStaticCatalog(provider: string, live: CatalogModel[]): CatalogModel[] {
-  if (!isCatalogProvider(provider)) return live;
+/**
+ * The curated cold-start entry for one id, if the shipped list carries it.
+ *
+ * This is the ONLY thing the curated arrays contribute to a live row: a hint,
+ * which no catalogue enumeration returns. Anything else — a label, a context
+ * window, the existence of the row at all — comes from the device.
+ */
+function hintFor(provider: string, id: string): string | undefined {
+  if (!isCatalogProvider(provider)) return undefined;
+  const hint = PROVIDER_CATALOGS[provider]?.models.find((m) => m.id === id)?.hint;
+  return hint || undefined;
+}
+
+/**
+ * The curated cold-start list for `provider`, as catalog rows.
+ *
+ * It is a DISPLAY fallback and nothing more. It used to be merged into every
+ * live enumeration and then persisted with it, which is how a box whose
+ * Anthropic plugin was disabled at 07:13 came to hold a `catalog-cache`
+ * file that named three Claude models, wore a fresh `fetchedAt`, and was
+ * indistinguishable from a device answer for the next six hours — while the
+ * same box could run eleven. A hand-maintained list cannot know what a device
+ * can route; the harness's own catalogue can, and asking it again is cheap.
+ * So this list is served only while there is no live answer, always marked
+ * `fallback`, and never written to disk.
+ */
+function staticCatalogModels(provider: string): CatalogModel[] {
+  if (!isCatalogProvider(provider)) return [];
   const staticEntry = PROVIDER_CATALOGS[provider];
-  if (!staticEntry) return live;
-  const liveIds = new Set(live.map((m) => m.id));
-  const augmented: CatalogModel[] = [...live];
-  for (const sm of staticEntry.models) {
-    if (liveIds.has(sm.id)) continue;
-    augmented.push({
-      id: sm.id,
-      label: sm.label,
-      contextWindow: STATIC_MODEL_CONTEXT_WINDOWS[sm.id] ?? 200_000,
-      hint: sm.hint,
-    });
-  }
-  augmented.sort(compareCatalogModels);
-  return augmented;
+  if (!staticEntry) return [];
+  const models = staticEntry.models.map((sm) => ({
+    id: sm.id,
+    label: sm.label,
+    contextWindow: STATIC_MODEL_CONTEXT_WINDOWS[sm.id] ?? 200_000,
+    hint: sm.hint,
+  }));
+  models.sort(compareCatalogModels);
+  return models;
 }
 
 function buildPayload(
@@ -413,13 +506,11 @@ function buildPayload(
   // Codex/ChatGPT-account models like gpt-5.5-pro that the upstream
   // rejects at request time. Re-apply the current provider allowlist when
   // constructing every payload, including cached/stale ones.
-  let merged = sanitizeCatalogModels(provider, augmentWithStaticCatalog(provider, models));
-  // Stamped HERE, on the merged list, not on the live one: the curated
-  // entries `augmentWithStaticCatalog` appends exist precisely for the case
-  // where the live enumeration came back thin, and an unstamped curated entry
-  // (ANTHROPIC_MODELS carries claude-haiku-4-5, which the subscription
-  // surface does not) would be offered as pickable in exactly the scenario
-  // this stamp was built for.
+  let merged = sanitizeCatalogModels(provider, models);
+  // Stamped on whatever list is about to be served, live or fallback: a
+  // fallback row the customer can see is a row the customer can pick, so it
+  // has to carry the same verdict a live one would (ANTHROPIC_MODELS carries
+  // claude-haiku-4-5, which a narrowed subscription surface does not).
   if (surfaceIds) {
     merged = merged.map((m) => ({ ...m, availableOnSubscription: surfaceIds.has(m.id) }));
   } else if (subscriptionSurfaceProvider(provider) === provider) {
@@ -451,6 +542,23 @@ function buildPayload(
   };
 }
 
+/**
+ * A payload built from the curated cold-start list. Marked `fallback`, and
+ * — the whole point — never handed to `writeDiskCache`.
+ */
+function buildFallbackPayload(provider: string): CatalogResponse {
+  return {
+    ...buildPayload(provider, staticCatalogModels(provider)),
+    fetchedAt: 0,
+    fallback: true,
+  };
+}
+
+/** Did a device enumeration produce this payload? See `CatalogResponse.source`. */
+function isLivePayload(payload: CatalogResponse | null | undefined): boolean {
+  return payload?.source === "live";
+}
+
 function sanitizeCachedPayload(provider: string, cached: CatalogResponse): CatalogResponse {
   const next = buildPayload(provider, cached.models);
   return {
@@ -458,12 +566,42 @@ function sanitizeCachedPayload(provider: string, cached: CatalogResponse): Catal
     fetchedAt: cached.fetchedAt,
     stale: cached.stale,
     warming: cached.warming,
+    source: cached.source,
+    // An unmarked cache — written by a build from before `source` existed, or
+    // by the path that used to persist the curated list as though a device had
+    // answered — is served, and says so.
+    fallback: isLivePayload(cached) ? undefined : true,
   };
 }
 
-function fetchOpenclawCatalog(provider: string): Promise<CatalogModel[]> {
+/**
+ * Which provider id is ENUMERATED for a given catalogue id.
+ *
+ * `codex` was a provider in the OpenClaw core through 2026.6.x. It is gone in
+ * 2026.8.1 — `openclaw models list --provider codex` answers "Unknown provider
+ * filter" — and a ChatGPT subscription is an `openai` OAuth profile now
+ * (`openclaw models auth login --provider openai`, docs.openclaw.ai/cli/models)
+ * serving `openai/*`. So the rows a ChatGPT account can run are the `openai`
+ * catalogue narrowed by ALLOWED_MODEL_RE_BY_PROVIDER.codex, which is the
+ * documented ChatGPT-account set — not a list maintained by hand here.
+ *
+ * The `codex` CATALOGUE id itself is being retired separately (TASK-652); this
+ * entry keeps the picker showing real models until it is, and goes with it.
+ */
+const ENUMERATION_PROVIDER: Record<string, string> = {
+  codex: "openai",
+};
+
+interface CatalogFetchResult {
+  models: CatalogModel[];
+  /** The CLI's stderr, so a zero-model answer can say why it was empty. */
+  stderr: string;
+}
+
+function fetchOpenclawCatalog(provider: string): Promise<CatalogFetchResult> {
+  const enumerated = ENUMERATION_PROVIDER[provider] ?? provider;
   return new Promise((resolve, reject) => {
-    const child = spawn(OPENCLAW_BIN, ["models", "list", "--provider", provider, "--all", "--json"], {
+    const child = spawn(OPENCLAW_BIN, ["models", "list", "--provider", enumerated, "--all", "--json"], {
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
@@ -492,7 +630,10 @@ function fetchOpenclawCatalog(provider: string): Promise<CatalogModel[]> {
       try {
         const parsed = JSON.parse(stdout) as OpenclawListResponse;
         clearTimeout(timer);
-        finish(() => resolve(transformOpenclawEntries(provider, parsed.models ?? [])));
+        finish(() => resolve({
+          models: transformOpenclawEntries(provider, parsed.models ?? []),
+          stderr,
+        }));
       } catch {
         // Partial JSON — keep accumulating.
       }
@@ -512,7 +653,7 @@ function fetchOpenclawCatalog(provider: string): Promise<CatalogModel[]> {
       finish(() => {
         try {
           const parsed = JSON.parse(stdout) as OpenclawListResponse;
-          resolve(transformOpenclawEntries(provider, parsed.models ?? []));
+          resolve({ models: transformOpenclawEntries(provider, parsed.models ?? []), stderr });
         } catch {
           reject(new Error(`openclaw produced non-JSON output: ${stdout.slice(0, 200)}`));
         }
@@ -521,7 +662,7 @@ function fetchOpenclawCatalog(provider: string): Promise<CatalogModel[]> {
   });
 }
 
-async function fetchOpenRouterCatalog(): Promise<CatalogModel[]> {
+async function fetchOpenRouterCatalog(): Promise<CatalogFetchResult> {
   const res = await fetch(OPENROUTER_API, {
     headers: { Accept: "application/json" },
     signal: AbortSignal.timeout(8000),
@@ -530,7 +671,7 @@ async function fetchOpenRouterCatalog(): Promise<CatalogModel[]> {
     throw new Error(`openrouter ${res.status}`);
   }
   const data = (await res.json()) as OpenRouterListResponse;
-  return transformOpenRouterEntries(data.data ?? []);
+  return { models: transformOpenRouterEntries(data.data ?? []), stderr: "" };
 }
 
 // Refresh the catalog for `provider` in the background. Returns
@@ -556,11 +697,14 @@ export function refreshInBackground(provider: string): void {
 
   refreshing.add(provider);
 
-  let fetcher: Promise<CatalogModel[]>;
+  let fetcher: Promise<CatalogFetchResult>;
   if (provider === "openrouter") {
     fetcher = fetchOpenRouterCatalog();
   } else if (provider === "clawai") {
-    fetcher = Promise.resolve(CLAWAI_STATIC_MODELS);
+    // The only catalogue with no upstream to ask: Mike's gateway routes the
+    // two device tiers and nothing else, so these two rows ARE the device's
+    // answer rather than a stand-in for one.
+    fetcher = Promise.resolve({ models: CLAWAI_STATIC_MODELS, stderr: "" });
   } else {
     fetcher = fetchOpenclawCatalog(provider);
   }
@@ -578,7 +722,7 @@ export function refreshInBackground(provider: string): void {
   const surface = fetchSubscriptionSurfaceIds(provider);
 
   const publish = async (models: CatalogModel[], surfaceIds: Set<string> | null) => {
-    const payload = buildPayload(provider, models, surfaceIds);
+    const payload: CatalogResponse = { ...buildPayload(provider, models, surfaceIds), source: "live" };
     memCache.set(provider, payload);
     await writeDiskCache(provider, payload);
     console.log(
@@ -587,14 +731,41 @@ export function refreshInBackground(provider: string): void {
     );
   };
 
+  /**
+   * Keep whatever good payload this box already has, and mark it stale so the
+   * next request re-enumerates instead of sitting on it for the refresh
+   * interval. Deliberately in memory only: the disk copy is the last answer a
+   * device actually gave, and rewriting it here would spend a write to record
+   * that a LATER attempt failed.
+   */
+  const markStale = () => {
+    const cached = memCache.get(provider);
+    if (cached) memCache.set(provider, { ...cached, stale: true });
+  };
+
   fetcher
-    .then(async (models) => {
+    .then(async ({ models, stderr }) => {
+      if (models.length === 0) {
+        // NOT a success. "[catalog] refreshed codex: 0 models" used to be
+        // followed by a disk write of the curated list, which then read back
+        // as a device answer — a false success in the exact shape this
+        // codebase keeps producing. An empty enumeration says the plugin is
+        // disabled, the provider id is gone, or the CLI failed silently; none
+        // of those are facts about what the box can run.
+        console.warn(
+          `[catalog] ${provider}: live enumeration returned no models, keeping the previous catalogue`
+          + (stderr.trim() ? ` — ${stderr.slice(-300).trim()}` : " (no stderr)"),
+        );
+        markStale();
+        return;
+      }
       await publish(models, null);
       const surfaceIds = await surface;
       if (surfaceIds) await publish(models, surfaceIds);
     })
     .catch((err: unknown) => {
       console.error(`[catalog] refresh failed for ${provider}:`, err instanceof Error ? err.message : err);
+      markStale();
     })
     .finally(() => {
       refreshing.delete(provider);
@@ -650,8 +821,12 @@ export async function GET(req: NextRequest) {
   }
 
   const ageMs = cached ? Date.now() - cached.fetchedAt : Infinity;
-  const isStale = ageMs > REFRESH_INTERVAL_MS;
-  if (force || isStale || !cached) {
+  const isStale = ageMs > REFRESH_INTERVAL_MS || cached?.stale === true;
+  // A payload no device produced is a reason to ask AGAIN, not a reason to
+  // wait six hours. That includes a cache written before `source` existed —
+  // on an upgraded box those files hold the curated list a failed enumeration
+  // left behind, and nothing else would ever dislodge them.
+  if (force || isStale || !isLivePayload(cached)) {
     refreshInBackground(provider);
   }
 
@@ -662,15 +837,9 @@ export async function GET(req: NextRequest) {
     return NextResponse.json(payload, { headers: noStore() });
   }
 
-  // No cache anywhere yet. The client picker falls back to the static
-  // catalog in src/lib/provider-models.ts when models[] is empty.
-  const empty: CatalogResponse = {
-    provider,
-    models: [],
-    defaultModelId: DEFAULT_MODEL_BY_PROVIDER[provider] ?? "",
-    allowCustom: ALLOW_CUSTOM_BY_PROVIDER[provider] ?? true,
-    fetchedAt: 0,
-    warming: true,
-  };
-  return NextResponse.json(empty, { headers: noStore() });
+  // Nothing cached yet — the first picker open after a restart, while the
+  // enumeration is still running. Serve the curated list so the picker is not
+  // blank, marked `fallback` so the client comes back for the real one.
+  const warming: CatalogResponse = { ...buildFallbackPayload(provider), warming: true };
+  return NextResponse.json(warming, { headers: noStore() });
 }

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -664,13 +664,15 @@ function sanitizeCachedPayload(provider: string, cached: CatalogResponse): Catal
 /**
  * Providers this route never asks `openclaw models list` about.
  *
- * openrouter has its own REST catalogue; clawai's two device tiers are the
- * gateway's whole routing table; codex is not a provider on this core at all,
- * per the note above. Naming them in one place keeps "who is CLI-backed" a
- * single fact — it was spelled as two inequalities in one function and a
- * separate branch in another.
+ * Not "providers with no catalogue": openrouter enumerates over its own REST
+ * endpoint, and clawai's two device tiers ARE the gateway's whole routing
+ * table. Only codex has nothing to ask, because it is not a provider on this
+ * core at all — see the note above. What the three share is that the CLI is
+ * not the thing that answers for them, and naming that in one place keeps
+ * "who is CLI-backed" a single fact: it was spelled as two inequalities in
+ * one function and a separate branch in another.
  */
-const NO_ENUMERATION_PROVIDERS: ReadonlySet<string> = new Set(["openrouter", "clawai", "codex"]);
+const NO_CLI_ENUMERATION_PROVIDERS: ReadonlySet<string> = new Set(["openrouter", "clawai", "codex"]);
 
 interface CatalogFetchResult {
   models: CatalogModel[];
@@ -790,12 +792,12 @@ export function refreshInBackground(provider: string): void {
   // line would otherwise repeat on every request of a Hermes box's session.
   if (refreshIsBlocked(provider)) return;
 
-  // Providers that never touch the CLI (see NO_ENUMERATION_PROVIDERS); every
-  // other one's catalog comes from `openclaw models list`. On an edition without
+  // Providers that never touch the CLI (see NO_CLI_ENUMERATION_PROVIDERS);
+  // every other one's catalog comes from `openclaw models list`. On an edition without
   // the binary (Hermes) that spawn is a guaranteed ENOENT, so skip it cleanly
   // rather than fork a missing binary for each provider on every boot warmup.
   // Hermes surfaces its own model list through the Hermes dashboard, not here.
-  const usesOpenclawCli = !NO_ENUMERATION_PROVIDERS.has(provider);
+  const usesOpenclawCli = !NO_CLI_ENUMERATION_PROVIDERS.has(provider);
   if (usesOpenclawCli && openclawIsAbsent()) {
     console.log(`[catalog] skipping ${provider}: the openclaw CLI is not present on this edition`);
     // Recorded as a failed attempt so the line above appears once per backoff

--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -887,10 +887,6 @@ export function refreshInBackground(provider: string): void {
           + (diagnostic ? ` — ${diagnostic.slice(-300)}` : " (the CLI gave no reason)"),
         );
         markStale();
-        // Settled, not abandoned: for a provider with a genuinely narrower
-        // surface this is a second multi-minute fork, and returning without it
-        // would release the single-flight guard while it still burns CPU.
-        await surface;
         return;
       }
       await publish(models, null);
@@ -901,7 +897,19 @@ export function refreshInBackground(provider: string): void {
       console.error(`[catalog] refresh failed for ${provider}:`, err instanceof Error ? err.message : err);
       markStale();
     })
-    .finally(() => {
+    .finally(async () => {
+      // The guard is released only once BOTH forks are settled, and it is
+      // released here rather than in each arm above because the arms that end
+      // early — an empty enumeration, a rejection — are exactly the ones that
+      // used to forget. For a provider with a genuinely narrower surface the
+      // surface enumeration is a second multi-minute `openclaw models list`,
+      // and releasing while it still holds ~2 cores of a Jetson lets the next
+      // request start a second MAIN enumeration beside it.
+      //
+      // Swallowed rather than awaited bare: this is cleanup, and a surface
+      // failure has already been logged by `fetchSubscriptionSurfaceIds` or
+      // handled by the `.catch` above.
+      await surface.catch(() => {});
       refreshing.delete(provider);
     });
 }

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2775,9 +2775,16 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     //     "openai", "codex", "google", "deepseek"). The catalog uses
     //     "clawai" for ClawBox AI rather than "deepseek", so map that case.
     //     Skip providers that aren't part of the catalog (local-only, llamacpp).
+    //
+    //     `providerChanged` because that is precisely what just happened: the
+    //     plugin was switched on and the credential written one step above, so
+    //     the failed-refresh backoff any earlier pre-auth enumeration recorded
+    //     describes a box that no longer exists. Without it this call is
+    //     silently dropped on exactly the devices this comment is about — the
+    //     ones whose pre-auth snapshot was empty.
     const catalogProvider = ocProvider === "deepseek" ? "clawai" : ocProvider;
     if (isCatalogProvider(catalogProvider)) {
-      refreshCatalogInBackground(catalogProvider);
+      refreshCatalogInBackground(catalogProvider, { providerChanged: true });
     }
 
     // Codex 2026.6.x reads its ChatGPT session from the Codex CLI's own

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -79,7 +79,6 @@ import {
 import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
 import {
   isValidModelId,
-  isCatalogProvider,
   GOOGLE_MODELS,
   ANTHROPIC_MODELS,
   extractProviderModelId,
@@ -87,7 +86,7 @@ import {
 } from "@/lib/provider-models";
 import { DISABLED_PROVIDERS_KEY, normalizeProviderId, parseDisabledProviders } from "@/lib/provider-status";
 import { setProviderEnabled } from "@/lib/provider-enablement";
-import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
+import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import {
   isClaudeSubscriptionOnly,
   offSurfaceClaudeModelMessage,
@@ -2758,7 +2757,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     //     behind the rule.
     if (!isLocalScope || shouldPromoteLocalToPrimary) {
       const primaryProvider = config.defaultModel.split("/", 1)[0];
-      await setProviderPlugins(primaryProvider);
+      // Same gate, same rule: it returns the provider whose plugin it flipped,
+      // which is a catalogue change for THAT provider — not for the one this
+      // save is about, which step 8c counts below.
+      const flippedProvider = await setProviderPlugins(primaryProvider);
+      if (flippedProvider) notifyProviderSetChanged(flippedProvider);
     }
 
     // 8c. Kick off a catalog refresh for the just-configured provider so
@@ -2771,21 +2774,13 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     //     flight guarded inside refreshInBackground, so concurrent configure
     //     calls collapse to one openclaw fork.
     //
-    //     `ocProvider` is the openclaw-side provider id (e.g. "anthropic",
-    //     "openai", "codex", "google", "deepseek"). The catalog uses
-    //     "clawai" for ClawBox AI rather than "deepseek", so map that case.
-    //     Skip providers that aren't part of the catalog (local-only, llamacpp).
-    //
-    //     `providerChanged` because that is precisely what just happened: the
-    //     plugin was switched on and the credential written one step above, so
-    //     the failed-refresh backoff any earlier pre-auth enumeration recorded
-    //     describes a box that no longer exists. Without it this call is
-    //     silently dropped on exactly the devices this comment is about — the
-    //     ones whose pre-auth snapshot was empty.
-    const catalogProvider = ocProvider === "deepseek" ? "clawai" : ocProvider;
-    if (isCatalogProvider(catalogProvider)) {
-      refreshCatalogInBackground(catalogProvider, { providerChanged: true });
-    }
+    //     `notifyProviderSetChanged` owns the openclaw-id mapping and the
+    //     catalogue-membership test, so this call site does not repeat them.
+    //     It COUNTS the change — the plugin was switched on and the credential
+    //     written one step above, so any earlier pre-auth enumeration and any
+    //     backoff it recorded describe a box that no longer exists. A client's
+    //     `?refresh=1` cannot count it; only a write can.
+    notifyProviderSetChanged(ocProvider);
 
     // Codex 2026.6.x reads its ChatGPT session from the Codex CLI's own
     // ~/.codex/auth.json, which gateway-pre-start.sh synthesizes from this

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -1195,6 +1195,22 @@ export async function POST(request: Request) {
     //     (it is applied to one snapshot and validated as a whole), and
     //     announcing a change that did not happen would spend a ~3-minute
     //     `openclaw models list` on a Jetson for nothing.
+    //
+    //     `preloadedConfig` is the right snapshot even though it was read at
+    //     the top of the handler: the only write between there and here is the
+    //     auto-extend, which touches `models.providers.<p>.models` and no
+    //     plugin flag. Its `{}`-on-failure is not a blind spot either — an
+    //     unreadable config leaves `loadChatModelState` with no options, and
+    //     the pick is refused above long before this line.
+    //
+    //     One request CAN announce the same provider twice — the auto-extend
+    //     above, then this — which costs one superseded ~3-minute fork in the
+    //     narrow case where both fire. Deliberately not deferred into a single
+    //     flush at the end: this handler has several exits that leave a
+    //     completed write behind (the 502, the 409, the same-model return), and
+    //     a flush that misses one of them trades a bounded cost for six hours
+    //     of a catalogue that says `source: "live"` about a box that moved.
+    //     Each announcement therefore sits at the write it describes.
     const pluginSwitchedOn = providerPluginSwitchedOnBy([targetModel], preloadedConfig);
     if (pluginSwitchedOn) notifyProviderSetChanged(pluginSwitchedOn);
 

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -3,6 +3,7 @@ import { getAll } from "@/lib/config-store";
 import {
   inferConfiguredLocalModel,
   readConfig,
+  readConfigStrict,
   restartGateway,
   runOpenclawConfigSet,
   runOpenclawConfigSetBatch,
@@ -1163,6 +1164,19 @@ export async function POST(request: Request) {
     const armOps = chatgptRouted && !chatgptRuntimeArmed(preloadedConfig, targetModel)
       ? [chatgptRuntimeArmOp(targetModel)]
       : [];
+    // The plugin flag as it stands at the last moment before the batch, for the
+    // ON half below. Not `preloadedConfig`: that was read at the top of the
+    // handler, and the auto-extend between here and there is its own ~10 s CLI
+    // spawn on a Jetson — a provider save landing in that window switches the
+    // flag off through its own gate, and a stale "it was already on" reading
+    // would swallow the switch-on this batch then performs. A file read, not a
+    // spawn, next to writes that cost seconds.
+    //
+    // STRICT and `null` on failure, for the reason the OFF half reads strictly:
+    // the decision is about ABSENCE, and plain `readConfig` answers `{}` to an
+    // EACCES exactly as it does to a box with no config at all. An absent flag
+    // IS enabled, so `{}` must stay silent; "could not read" must not.
+    const configBeforeBatch = await readConfigStrict().catch(() => null);
     try {
       await runOpenclawConfigSetBatch([
         ...enableProviderPluginOps([targetModel]),
@@ -1196,13 +1210,6 @@ export async function POST(request: Request) {
     //     announcing a change that did not happen would spend a ~3-minute
     //     `openclaw models list` on a Jetson for nothing.
     //
-    //     `preloadedConfig` is the right snapshot even though it was read at
-    //     the top of the handler: the only write between there and here is the
-    //     auto-extend, which touches `models.providers.<p>.models` and no
-    //     plugin flag. Its `{}`-on-failure is not a blind spot either — an
-    //     unreadable config leaves `loadChatModelState` with no options, and
-    //     the pick is refused above long before this line.
-    //
     //     One request CAN announce the same provider twice — the auto-extend
     //     above, then this — which costs one superseded ~3-minute fork in the
     //     narrow case where both fire. Deliberately not deferred into a single
@@ -1211,7 +1218,7 @@ export async function POST(request: Request) {
     //     a flush that misses one of them trades a bounded cost for six hours
     //     of a catalogue that says `source: "live"` about a box that moved.
     //     Each announcement therefore sits at the write it describes.
-    const pluginSwitchedOn = providerPluginSwitchedOnBy([targetModel], preloadedConfig);
+    const pluginSwitchedOn = providerPluginSwitchedOnBy([targetModel], configBeforeBatch);
     if (pluginSwitchedOn) notifyProviderSetChanged(pluginSwitchedOn);
 
     // 1c. The other side of the arm: a pick that is NOT the subscription's, on

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -13,6 +13,7 @@ import {
   type OpenClawConfig,
 } from "@/lib/openclaw-config";
 import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
+import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import {
   CLAWBOX_AI_MODEL_BY_TIER,
@@ -1204,7 +1205,17 @@ export async function POST(request: Request) {
       //    when nothing on the box could use it — the primary is elsewhere
       //    AND no usable Anthropic credential remains (see setProviderPlugins).
       //    Other plugins stay where they are.
-      await setProviderPlugins(parsed.provider);
+      const flippedProvider = await setProviderPlugins(parsed.provider);
+      // A flipped plugin IS a provider-set change: switching anthropic off is
+      // precisely what empties `openclaw models list --provider anthropic`.
+      // Neither this route nor ChatPopup emitted anything for it, and the
+      // catalogue hook deliberately ignores the model-SELECTION event, so the
+      // enumeration taken while the plugin was on stood as `source: "live"` for
+      // six hours. `setProviderPlugins` returns the id it changed, or null when
+      // it changed nothing, so this cannot announce a change that did not
+      // happen. It is also the path `POST /setup-api/providers/default`
+      // delegates to on OpenClaw, so counting it here covers that route too.
+      if (flippedProvider) notifyProviderSetChanged(flippedProvider);
     }
 
     await restartGateway();

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -12,7 +12,7 @@ import {
   setProviderPlugins,
   type OpenClawConfig,
 } from "@/lib/openclaw-config";
-import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
+import { enableProviderPluginOps, providerPluginSwitchedOnBy } from "@/lib/provider-plugin-ops";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import {
@@ -1007,6 +1007,15 @@ export async function POST(request: Request) {
                   { status: 502 },
                 );
               }
+              // A row added to this array IS the provider's catalogue changing:
+              // "configured providers in openclaw.json override the plugin's
+              // modelCatalog entirely" (ai-models/configure), so what
+              // `openclaw models list --provider <p>` answers for a compat
+              // provider is exactly this list. Counted here rather than beside
+              // the write above, because only the branch that actually
+              // appended reaches this line — a pick already in the list writes
+              // nothing and must announce nothing.
+              notifyProviderSetChanged(providerId);
             }
           }
         }
@@ -1170,6 +1179,24 @@ export async function POST(request: Request) {
       if (unresolvable) return unresolvable;
       throw err;
     }
+
+    // 1b. The ON half of the plugin gate, counted. The batch above is the only
+    //     thing that switches a plugin back on, and a provider whose plugin is
+    //     off enumerates NOTHING — so this is the same provider-set change as
+    //     the OFF half below, in the other direction, and the catalogue was
+    //     told about neither. Worse than a one-off staleness: an enumeration
+    //     that comes back empty is recorded as a failed refresh, and that wait
+    //     DOUBLES up to the six-hour refresh interval, so a provider whose
+    //     plugin has been off for a while is not even re-asked for six hours
+    //     after the pick that made it listable. Counting the change is what
+    //     drops that wait back to the floor.
+    //
+    //     After the batch, never before it: a refused batch changed no flag
+    //     (it is applied to one snapshot and validated as a whole), and
+    //     announcing a change that did not happen would spend a ~3-minute
+    //     `openclaw models list` on a Jetson for nothing.
+    const pluginSwitchedOn = providerPluginSwitchedOnBy([targetModel], preloadedConfig);
+    if (pluginSwitchedOn) notifyProviderSetChanged(pluginSwitchedOn);
 
     // 1c. The other side of the arm: a pick that is NOT the subscription's, on
     //     a reference an earlier ChatGPT pick armed, has to clear it — a

--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -15,7 +15,6 @@ import {
   callGatewayRpc,
   gatewayIsAbsent,
   readConfig,
-  readConfigStrict,
   restartGateway,
   runOpenclawConfigSetBatch,
   type OpenclawConfigSetArgs,
@@ -488,19 +487,6 @@ export async function POST(request: Request) {
         ? savedFallbacks.filter((ref) => !isClawboxAiImageModelRef(ref))
         : savedFallbacks;
       const restoreFallbacks = Array.isArray(keptFallbacks) && keptFallbacks.length > 0 ? keptFallbacks : null;
-      // Read BEFORE the write, because what the catalogue needs to know is the
-      // transition: the enables below can switch a plugin back ON, and a
-      // provider whose plugin is off enumerates nothing.
-      //
-      // STRICT, and `null` when it fails, for the same reason the OFF half of
-      // this gate reads strictly (`setProviderPlugins`): the decision is about
-      // ABSENCE, and plain `readConfig` answers `{}` to an EACCES or a file
-      // caught half-written exactly as it does to a box that has no config at
-      // all. Those two need opposite answers — an absent flag IS enabled, so
-      // `{}` means no transition, while "could not read" means unknown, and
-      // silence there would cost six hours of a catalogue serving a list the
-      // box has stopped agreeing with.
-      const configBeforeRestore = await readConfigStrict().catch(() => null);
       const restoreOps: OpenclawConfigSetArgs[] = [
         ...enableProviderPluginOps([restorablePrimary, ...(restoreFallbacks ?? [])]),
         ...(restorablePrimary
@@ -512,15 +498,29 @@ export async function POST(request: Request) {
       ];
       if (restoreOps.length > 0) {
         await setConfigBatch(restoreOps);
-        // The third site that switches a provider plugin on, and the third
-        // that has to count it: this restore is what makes that provider
-        // listable again, and nothing else will tell the catalogue. After the
-        // batch, because a refused one leaves the flag exactly as it was —
+        // The third site that switches a provider plugin on, and the third that
+        // has to count it: this restore is what makes that provider listable
+        // again, and nothing else will tell the catalogue. After the batch,
+        // because a refused one leaves the flag exactly as it was —
         // `setConfigBatch` throws rather than swallowing, so reaching this line
         // means the write landed.
+        //
+        // `null` for the pre-write state on purpose: it is the honest answer
+        // here, not a shortcut. Any snapshot this route could read would be
+        // read BEFORE a `config set --batch-json` that takes ~10 s on a Jetson,
+        // and a provider save landing in that window (which switches the plugin
+        // off through its own gate) would leave a stale "it was already on"
+        // reading and swallow the switch-on this batch then performs. Nothing
+        // available here makes the read atomic with the write. So this site
+        // says "I cannot know", which counts the change: this path runs once
+        // per Local-only exit and only when the saved primary or a fallback
+        // names the gated provider, it already restarts the gateway and
+        // re-patches every session, so at worst it spends one enumeration —
+        // against a silent miss that would leave the catalogue behind until a
+        // doubling backoff expired.
         const pluginSwitchedOn = providerPluginSwitchedOnBy(
           [restorablePrimary, ...(restoreFallbacks ?? [])],
-          configBeforeRestore,
+          null,
         );
         if (pluginSwitchedOn) notifyProviderSetChanged(pluginSwitchedOn);
       }

--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -19,7 +19,8 @@ import {
   runOpenclawConfigSetBatch,
   type OpenclawConfigSetArgs,
 } from "@/lib/openclaw-config";
-import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
+import { enableProviderPluginOps, providerPluginSwitchedOnBy } from "@/lib/provider-plugin-ops";
+import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { isClawboxAiImageModelRef } from "@/lib/clawbox-ai-models";
 
 const SAVED_PRIMARY_KEY = "local_only_saved_primary";
@@ -486,6 +487,12 @@ export async function POST(request: Request) {
         ? savedFallbacks.filter((ref) => !isClawboxAiImageModelRef(ref))
         : savedFallbacks;
       const restoreFallbacks = Array.isArray(keptFallbacks) && keptFallbacks.length > 0 ? keptFallbacks : null;
+      // Read BEFORE the write, because what the catalogue needs to know is the
+      // transition: the enables below can switch a plugin back ON, and a
+      // provider whose plugin is off enumerates nothing. An unreadable config
+      // answers `{}` here and so reads as already-on — silence rather than a
+      // change that may not have happened.
+      const configBeforeRestore = await readConfig();
       const restoreOps: OpenclawConfigSetArgs[] = [
         ...enableProviderPluginOps([restorablePrimary, ...(restoreFallbacks ?? [])]),
         ...(restorablePrimary
@@ -497,6 +504,17 @@ export async function POST(request: Request) {
       ];
       if (restoreOps.length > 0) {
         await setConfigBatch(restoreOps);
+        // The third site that switches a provider plugin on, and the third
+        // that has to count it: this restore is what makes that provider
+        // listable again, and nothing else will tell the catalogue. After the
+        // batch, because a refused one leaves the flag exactly as it was —
+        // `setConfigBatch` throws rather than swallowing, so reaching this line
+        // means the write landed.
+        const pluginSwitchedOn = providerPluginSwitchedOnBy(
+          [restorablePrimary, ...(restoreFallbacks ?? [])],
+          configBeforeRestore,
+        );
+        if (pluginSwitchedOn) notifyProviderSetChanged(pluginSwitchedOn);
       }
       const restore = savedSessionOverrides
         ? await restoreSessionOverrides(savedSessionOverrides)

--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -15,6 +15,7 @@ import {
   callGatewayRpc,
   gatewayIsAbsent,
   readConfig,
+  readConfigStrict,
   restartGateway,
   runOpenclawConfigSetBatch,
   type OpenclawConfigSetArgs,
@@ -489,10 +490,17 @@ export async function POST(request: Request) {
       const restoreFallbacks = Array.isArray(keptFallbacks) && keptFallbacks.length > 0 ? keptFallbacks : null;
       // Read BEFORE the write, because what the catalogue needs to know is the
       // transition: the enables below can switch a plugin back ON, and a
-      // provider whose plugin is off enumerates nothing. An unreadable config
-      // answers `{}` here and so reads as already-on — silence rather than a
-      // change that may not have happened.
-      const configBeforeRestore = await readConfig();
+      // provider whose plugin is off enumerates nothing.
+      //
+      // STRICT, and `null` when it fails, for the same reason the OFF half of
+      // this gate reads strictly (`setProviderPlugins`): the decision is about
+      // ABSENCE, and plain `readConfig` answers `{}` to an EACCES or a file
+      // caught half-written exactly as it does to a box that has no config at
+      // all. Those two need opposite answers — an absent flag IS enabled, so
+      // `{}` means no transition, while "could not read" means unknown, and
+      // silence there would cost six hours of a catalogue serving a list the
+      // box has stopped agreeing with.
+      const configBeforeRestore = await readConfigStrict().catch(() => null);
       const restoreOps: OpenclawConfigSetArgs[] = [
         ...enableProviderPluginOps([restorablePrimary, ...(restoreFallbacks ?? [])]),
         ...(restorablePrimary

--- a/src/app/setup-api/providers/enabled/route.ts
+++ b/src/app/setup-api/providers/enabled/route.ts
@@ -4,7 +4,6 @@ import { NextResponse } from "next/server";
 import { logSafe } from "@/lib/log-safe";
 import { hasOwnerSession } from "@/lib/owner-session";
 import { setProviderEnabled } from "@/lib/provider-enablement";
-import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { readProviderStatus } from "@/lib/provider-status";
 
 /**
@@ -62,13 +61,23 @@ export async function POST(request: Request) {
   // spelling of it: one line per flip, whatever the body carried.
   console.error(`[providers] ${logSafe(provider)} switched ${fields.enabled ? "on" : "off"} by the owner`);
 
-  // A switch flip IS a provider-set change, and this route is one of the two
-  // that used to make one without telling the catalogue — the client's
-  // `?refresh=1` was its only signal, and a non-browser caller had none at all.
-  // Switching a provider off empties its `openclaw models list`; switching it
-  // back on is what makes it enumerable again. Out-of-band, not awaited: the
-  // strip repaints from the status read below, not from the catalogue.
-  notifyProviderSetChanged(provider);
+  // DELIBERATELY no catalogue signal here, and the reason is worth writing
+  // down because it looks like one is missing. This flip writes exactly one
+  // thing: ClawBox's own `ai_disabled_providers` key in ClawBox's own config
+  // store (`provider-enablement.ts`). It does not touch `~/.openclaw`, it does
+  // not re-gate a plugin, and `openclaw models list` has never heard of that
+  // key — so what the catalogue enumerates for this provider is byte-for-byte
+  // what it was a moment ago, and the catalogue route never reads the disabled
+  // list either (the strip's greying comes from `readProviderStatus`, below).
+  //
+  // The switch DOES eventually change an enumeration, but not here: switching
+  // anthropic off makes `hasUsableAnthropicCredential` false, so the NEXT save
+  // or chat-model pick re-gates the plugin — and that write counts its own
+  // change (`setProviderPlugins` returns the id it flipped, and the ON half is
+  // answered by `providerPluginSwitchedOnBy`). Counting the flip here as well
+  // spent a full ~3-minute, ~2-core `openclaw models list` on a Jetson per
+  // click, twice for an off-and-on, and cleared the failed-refresh backoff
+  // each time, to be told the same rows again.
 
   const summary = await readProviderStatus();
   return NextResponse.json(summary, { headers: { "Cache-Control": "no-store" } });

--- a/src/app/setup-api/providers/enabled/route.ts
+++ b/src/app/setup-api/providers/enabled/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { logSafe } from "@/lib/log-safe";
 import { hasOwnerSession } from "@/lib/owner-session";
 import { setProviderEnabled } from "@/lib/provider-enablement";
+import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { readProviderStatus } from "@/lib/provider-status";
 
 /**
@@ -60,6 +61,14 @@ export async function POST(request: Request) {
   // The id is one the rule just matched to a row, but it is still the body's
   // spelling of it: one line per flip, whatever the body carried.
   console.error(`[providers] ${logSafe(provider)} switched ${fields.enabled ? "on" : "off"} by the owner`);
+
+  // A switch flip IS a provider-set change, and this route is one of the two
+  // that used to make one without telling the catalogue — the client's
+  // `?refresh=1` was its only signal, and a non-browser caller had none at all.
+  // Switching a provider off empties its `openclaw models list`; switching it
+  // back on is what makes it enumerable again. Out-of-band, not awaited: the
+  // strip repaints from the status read below, not from the catalogue.
+  notifyProviderSetChanged(provider);
 
   const summary = await readProviderStatus();
   return NextResponse.json(summary, { headers: { "Cache-Control": "no-store" } });

--- a/src/components/AIModelsStep.tsx
+++ b/src/components/AIModelsStep.tsx
@@ -1309,9 +1309,16 @@ export default function AIModelsStep({
    * of this. (`useProviderCatalog` always falls back to the curated arrays in
    * provider-models.ts, so today this is unreachable — the condition is here
    * to keep it unreachable for the right reason.)
+   *
+   * A `fallback` catalogue is excluded for the same reason an empty one is: the
+   * curated cold-start rows are not this box's catalogue, so "this credential
+   * can run none of them" is a verdict about a list the device never confirmed.
    */
   const noUsableCatalogModel = Boolean(
-    activeCatalog && activeCatalog.models.length > 0 && !usableDefaultModelId,
+    activeCatalog
+    && !activeCatalog.fallback
+    && activeCatalog.models.length > 0
+    && !usableDefaultModelId,
   );
 
   const getRequestedCatalogModelId = useCallback((fallbackToDefault = false) => {

--- a/src/hooks/useProviderCatalog.ts
+++ b/src/hooks/useProviderCatalog.ts
@@ -4,10 +4,9 @@ import { useEffect, useMemo, useState } from "react";
 import {
   fetchProviderCatalog,
   getProviderCatalog,
-  type ProviderCatalog,
   type ResolvedProviderCatalog,
 } from "@/lib/provider-models";
-import { onProvidersChanged } from "@/lib/ui-events";
+import { PROVIDER_SIGNAL_DEBOUNCE_MS, PROVIDERS_CHANGED_EVENT } from "@/lib/ui-events";
 
 /**
  * Resolve the live model catalog for `provider` via
@@ -33,25 +32,41 @@ interface LiveCatalog {
 }
 
 /**
- * A catalogue marked `fallback` is a placeholder, not an answer: the box has
- * not enumerated one yet (the refresh behind the route takes ~3 minutes on a
- * Jetson), or the provider only just became listable. Asking once and keeping
- * the curated three for the rest of the session is the defect this retry
- * exists to end.
+ * Poll while the box is WARMING — an enumeration is in flight and a later ask
+ * gets a better answer. Asking once and keeping the curated three for the rest
+ * of the session is the defect this exists to end.
  *
- * Backed off rather than polled flat because the wait is minutes on the slow
- * path and instant on the fast one, and capped so an unconfigurable provider —
- * one that will never enumerate — does not leave a picker asking forever. The
- * route answers each of these from cache and single-flights the refresh
- * behind it, so a retry costs one cheap request.
+ * Deliberately not "poll while `fallback`". A provider that cannot enumerate at
+ * all — plugin gone, no CLI on this edition — serves a fallback forever, and
+ * polling that is a request loop with no destination; it also fires in every
+ * test whose fetch stub answers the catalog route with `{}`. The route says
+ * `warming` only while a fork is actually out there, and holds the failed-
+ * refresh backoff behind it, so the two brakes agree.
+ *
+ * Backed off rather than polled flat because the wait is ~3 minutes on a
+ * Jetson and instant on a warm box, and capped so nothing asks forever.
  */
-const FALLBACK_RETRY_BASE_MS = 2_000;
-const FALLBACK_RETRY_MAX_MS = 60_000;
-const FALLBACK_RETRY_ATTEMPTS = 12;
+const WARMING_RETRY_BASE_MS = 2_000;
+const WARMING_RETRY_MAX_MS = 60_000;
+const WARMING_RETRY_ATTEMPTS = 12;
 
-export function useProviderCatalog(provider: string | null | undefined): ProviderCatalog | null {
-  const fallback = useMemo(
-    () => (provider ? getProviderCatalog(provider) : null),
+/**
+ * Returns the RESOLVED catalogue — the models plus whether a device produced
+ * them. The `fallback` flag was previously erased at this boundary, which left
+ * the retry below as its only consumer: a picker could not tell "these are the
+ * box's models" from "these are three hard-coded names while we wait", which
+ * is the distinction this whole path exists to carry.
+ */
+export function useProviderCatalog(
+  provider: string | null | undefined,
+): ResolvedProviderCatalog | null {
+  const fallback = useMemo<ResolvedProviderCatalog | null>(
+    () => {
+      const curated = provider ? getProviderCatalog(provider) : null;
+      // The pre-fetch render is a fallback by definition — nothing has been
+      // asked yet — so it says so rather than looking like an answer.
+      return curated ? { ...curated, fallback: true } : null;
+    },
     [provider],
   );
   const [live, setLive] = useState<LiveCatalog | null>(null);
@@ -71,8 +86,8 @@ export function useProviderCatalog(provider: string | null | undefined): Provide
         .then((next) => {
           if (ctrl.signal.aborted) return;
           setLive({ provider, catalog: next });
-          if (!next.fallback || attempt >= FALLBACK_RETRY_ATTEMPTS) return;
-          const delay = Math.min(FALLBACK_RETRY_BASE_MS * 2 ** attempt, FALLBACK_RETRY_MAX_MS);
+          if (!next.warming || attempt >= WARMING_RETRY_ATTEMPTS) return;
+          const delay = Math.min(WARMING_RETRY_BASE_MS * 2 ** attempt, WARMING_RETRY_MAX_MS);
           attempt += 1;
           timer = setTimeout(() => load(true), delay);
         })
@@ -86,12 +101,35 @@ export function useProviderCatalog(provider: string | null | undefined): Provide
     // is enabled and the credential is written — so that read asks the route
     // to re-enumerate rather than serve the pre-connect snapshot.
     load(reloads > 0);
-    const off = onProvidersChanged(() => setReloads((n) => n + 1));
+
+    // PROVIDERS_CHANGED_EVENT alone, NOT the `onProvidersChanged` union.
+    //
+    // That helper also spans CHAT_MODEL_STATE_EVENT, which means "the chat's
+    // model SELECTION changed" — an event ChatPopup dispatches itself, on every
+    // switch. A catalogue does not change when someone picks a different row
+    // out of it, so listening to it would re-fetch with `?refresh=1` on each
+    // switch and ask a Jetson for a fresh three-minute enumeration for nothing.
+    // Measured as a real re-render storm: it broke an unrelated ChatPopup test
+    // that switches model mid-run.
+    //
+    // Every site that changes the provider SET — a key saved, an OAuth flow
+    // approved, a provider enabled or removed, a new default — calls
+    // `notifyProvidersChanged()`, which dispatches exactly this event.
+    let signalTimer: ReturnType<typeof setTimeout> | null = null;
+    const onSignal = () => {
+      if (signalTimer) clearTimeout(signalTimer);
+      signalTimer = setTimeout(() => {
+        signalTimer = null;
+        setReloads((n) => n + 1);
+      }, PROVIDER_SIGNAL_DEBOUNCE_MS);
+    };
+    window.addEventListener(PROVIDERS_CHANGED_EVENT, onSignal);
 
     return () => {
       ctrl.abort();
       if (timer) clearTimeout(timer);
-      off();
+      if (signalTimer) clearTimeout(signalTimer);
+      window.removeEventListener(PROVIDERS_CHANGED_EVENT, onSignal);
     };
   }, [provider, reloads]);
 

--- a/src/hooks/useProviderCatalog.ts
+++ b/src/hooks/useProviderCatalog.ts
@@ -1,12 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   fetchProviderCatalog,
   getProviderCatalog,
   type ResolvedProviderCatalog,
 } from "@/lib/provider-models";
-import { PROVIDER_SIGNAL_DEBOUNCE_MS, PROVIDERS_CHANGED_EVENT } from "@/lib/ui-events";
+import { onProvidersChanged, PROVIDERS_CHANGED_EVENT } from "@/lib/ui-events";
 
 /**
  * Resolve the live model catalog for `provider` via
@@ -29,6 +29,25 @@ import { PROVIDER_SIGNAL_DEBOUNCE_MS, PROVIDERS_CHANGED_EVENT } from "@/lib/ui-e
 interface LiveCatalog {
   provider: string;
   catalog: ResolvedProviderCatalog;
+}
+
+/**
+ * Same answer? Compared field by field rather than by identity, because the
+ * route mints a new object per request and most warming polls carry rows the
+ * picker is already rendering.
+ */
+function sameCatalog(a: ResolvedProviderCatalog, b: ResolvedProviderCatalog): boolean {
+  return a.defaultModelId === b.defaultModelId
+    && a.allowCustom === b.allowCustom
+    && a.fallback === b.fallback
+    && a.warming === b.warming
+    && a.stale === b.stale
+    && a.models.length === b.models.length
+    && a.models.every((model, i) => (
+      model.id === b.models[i].id
+      && model.label === b.models[i].label
+      && model.availableOnSubscription === b.models[i].availableOnSubscription
+    ));
 }
 
 /**
@@ -70,9 +89,14 @@ export function useProviderCatalog(
     [provider],
   );
   const [live, setLive] = useState<LiveCatalog | null>(null);
-  // Bumped by the providers-changed signal. It is in the dependency list, so a
-  // connect re-runs the effect with `refresh` set instead of the effect having
-  // to reach a fetch that has already been torn down.
+  // Set by the provider-set signal, read and cleared by the next load. A REF,
+  // not the reload counter: `reloads > 0` stays true for the rest of the
+  // session after any connect, so using it as "force a re-enumeration" made
+  // every later provider switch in the picker send `?refresh=1` for a provider
+  // that had received no signal at all — a fresh ~3-minute fork on a Jetson
+  // for a catalogue that was already live.
+  const forceNextLoad = useRef(false);
+  // Bumped by the same signal, purely to re-run the effect.
   const [reloads, setReloads] = useState(0);
 
   useEffect(() => {
@@ -85,11 +109,19 @@ export function useProviderCatalog(
       fetchProviderCatalog(provider, { signal: ctrl.signal, refresh })
         .then((next) => {
           if (ctrl.signal.aborted) return;
-          setLive({ provider, catalog: next });
+          // Only when something actually changed. During a warm-up every poll
+          // returns the same curated rows, and a fresh object identity there
+          // re-runs eight memos and two setState effects in AIModelsStep and
+          // the same again in ChatPopup, per poll, per mounted picker.
+          setLive((current) => (
+            current && current.provider === provider && sameCatalog(current.catalog, next)
+              ? current
+              : { provider, catalog: next }
+          ));
           if (!next.warming || attempt >= WARMING_RETRY_ATTEMPTS) return;
           const delay = Math.min(WARMING_RETRY_BASE_MS * 2 ** attempt, WARMING_RETRY_MAX_MS);
           attempt += 1;
-          timer = setTimeout(() => load(true), delay);
+          timer = setTimeout(() => load(false), delay);
         })
         .catch((err) => {
           if (ctrl.signal.aborted) return;
@@ -98,38 +130,33 @@ export function useProviderCatalog(
     };
 
     // A connect is exactly when the catalogue becomes enumerable — the plugin
-    // is enabled and the credential is written — so that read asks the route
-    // to re-enumerate rather than serve the pre-connect snapshot.
-    load(reloads > 0);
+    // is enabled and the credential is written — so that ONE read asks the
+    // route to re-enumerate rather than serve the pre-connect snapshot. The
+    // warming polls that may follow do not: the route is already enumerating,
+    // and telling it to start again on each poll is how a picker turns a
+    // three-minute fork into several.
+    const force = forceNextLoad.current;
+    forceNextLoad.current = false;
+    load(force);
 
-    // PROVIDERS_CHANGED_EVENT alone, NOT the `onProvidersChanged` union.
-    //
-    // That helper also spans CHAT_MODEL_STATE_EVENT, which means "the chat's
-    // model SELECTION changed" — an event ChatPopup dispatches itself, on every
-    // switch. A catalogue does not change when someone picks a different row
-    // out of it, so listening to it would re-fetch with `?refresh=1` on each
-    // switch and ask a Jetson for a fresh three-minute enumeration for nothing.
-    // Measured as a real re-render storm: it broke an unrelated ChatPopup test
-    // that switches model mid-run.
-    //
-    // Every site that changes the provider SET — a key saved, an OAuth flow
-    // approved, a provider enabled or removed, a new default — calls
-    // `notifyProvidersChanged()`, which dispatches exactly this event.
-    let signalTimer: ReturnType<typeof setTimeout> | null = null;
-    const onSignal = () => {
-      if (signalTimer) clearTimeout(signalTimer);
-      signalTimer = setTimeout(() => {
-        signalTimer = null;
+    // The provider SET changed — a key saved, an OAuth flow approved, a
+    // provider enabled or removed, a new default. Deliberately NOT the whole
+    // `PROVIDER_SIGNAL_EVENTS` union: it also spans CHAT_MODEL_STATE_EVENT,
+    // which means "the chat's model SELECTION changed", and a catalogue does
+    // not change when someone picks a different row out of the list it already
+    // has. Waking on it would ask a Jetson to re-enumerate on every switch.
+    const off = onProvidersChanged(
+      () => {
+        forceNextLoad.current = true;
         setReloads((n) => n + 1);
-      }, PROVIDER_SIGNAL_DEBOUNCE_MS);
-    };
-    window.addEventListener(PROVIDERS_CHANGED_EVENT, onSignal);
+      },
+      { events: [PROVIDERS_CHANGED_EVENT] },
+    );
 
     return () => {
       ctrl.abort();
       if (timer) clearTimeout(timer);
-      if (signalTimer) clearTimeout(signalTimer);
-      window.removeEventListener(PROVIDERS_CHANGED_EVENT, onSignal);
+      off();
     };
   }, [provider, reloads]);
 

--- a/src/hooks/useProviderCatalog.ts
+++ b/src/hooks/useProviderCatalog.ts
@@ -46,6 +46,7 @@ function sameCatalog(a: ResolvedProviderCatalog, b: ResolvedProviderCatalog): bo
     && a.models.every((model, i) => (
       model.id === b.models[i].id
       && model.label === b.models[i].label
+      && model.hint === b.models[i].hint
       && model.availableOnSubscription === b.models[i].availableOnSubscription
     ));
 }

--- a/src/hooks/useProviderCatalog.ts
+++ b/src/hooks/useProviderCatalog.ts
@@ -5,7 +5,9 @@ import {
   fetchProviderCatalog,
   getProviderCatalog,
   type ProviderCatalog,
+  type ResolvedProviderCatalog,
 } from "@/lib/provider-models";
+import { onProvidersChanged } from "@/lib/ui-events";
 
 /**
  * Resolve the live model catalog for `provider` via
@@ -27,8 +29,25 @@ import {
  */
 interface LiveCatalog {
   provider: string;
-  catalog: ProviderCatalog;
+  catalog: ResolvedProviderCatalog;
 }
+
+/**
+ * A catalogue marked `fallback` is a placeholder, not an answer: the box has
+ * not enumerated one yet (the refresh behind the route takes ~3 minutes on a
+ * Jetson), or the provider only just became listable. Asking once and keeping
+ * the curated three for the rest of the session is the defect this retry
+ * exists to end.
+ *
+ * Backed off rather than polled flat because the wait is minutes on the slow
+ * path and instant on the fast one, and capped so an unconfigurable provider —
+ * one that will never enumerate — does not leave a picker asking forever. The
+ * route answers each of these from cache and single-flights the refresh
+ * behind it, so a retry costs one cheap request.
+ */
+const FALLBACK_RETRY_BASE_MS = 2_000;
+const FALLBACK_RETRY_MAX_MS = 60_000;
+const FALLBACK_RETRY_ATTEMPTS = 12;
 
 export function useProviderCatalog(provider: string | null | undefined): ProviderCatalog | null {
   const fallback = useMemo(
@@ -36,21 +55,45 @@ export function useProviderCatalog(provider: string | null | undefined): Provide
     [provider],
   );
   const [live, setLive] = useState<LiveCatalog | null>(null);
+  // Bumped by the providers-changed signal. It is in the dependency list, so a
+  // connect re-runs the effect with `refresh` set instead of the effect having
+  // to reach a fetch that has already been torn down.
+  const [reloads, setReloads] = useState(0);
 
   useEffect(() => {
     if (!provider) return;
     const ctrl = new AbortController();
-    fetchProviderCatalog(provider, { signal: ctrl.signal })
-      .then((next) => {
-        if (ctrl.signal.aborted) return;
-        setLive({ provider, catalog: next });
-      })
-      .catch((err) => {
-        if (ctrl.signal.aborted) return;
-        console.warn(`[useProviderCatalog] fetch failed for ${provider}:`, err);
-      });
-    return () => ctrl.abort();
-  }, [provider]);
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
+
+    const load = (refresh: boolean) => {
+      fetchProviderCatalog(provider, { signal: ctrl.signal, refresh })
+        .then((next) => {
+          if (ctrl.signal.aborted) return;
+          setLive({ provider, catalog: next });
+          if (!next.fallback || attempt >= FALLBACK_RETRY_ATTEMPTS) return;
+          const delay = Math.min(FALLBACK_RETRY_BASE_MS * 2 ** attempt, FALLBACK_RETRY_MAX_MS);
+          attempt += 1;
+          timer = setTimeout(() => load(true), delay);
+        })
+        .catch((err) => {
+          if (ctrl.signal.aborted) return;
+          console.warn(`[useProviderCatalog] fetch failed for ${provider}:`, err);
+        });
+    };
+
+    // A connect is exactly when the catalogue becomes enumerable — the plugin
+    // is enabled and the credential is written — so that read asks the route
+    // to re-enumerate rather than serve the pre-connect snapshot.
+    load(reloads > 0);
+    const off = onProvidersChanged(() => setReloads((n) => n + 1));
+
+    return () => {
+      ctrl.abort();
+      if (timer) clearTimeout(timer);
+      off();
+    };
+  }, [provider, reloads]);
 
   if (!provider) return null;
   return live?.provider === provider ? live.catalog : fallback;

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -2139,7 +2139,7 @@ function configReferencesAnthropic(config: OpenClawConfig): boolean {
  * provider segment of `agents.defaults.model.primary`. Idempotent and
  * non-fatal.
  */
-export async function setProviderPlugins(activeProvider: string): Promise<void> {
+export async function setProviderPlugins(activeProvider: string): Promise<string | null> {
   // Strict, because the decision below is about ABSENCE: `readConfig` answers
   // `{}` to an unreadable file, and that would read as "no Anthropic
   // credential" and switch the plugin off on a box that has one — the very
@@ -2153,7 +2153,7 @@ export async function setProviderPlugins(activeProvider: string): Promise<void> 
       "[openclaw-config] Leaving the anthropic plugin as it is — could not read the config:",
       err instanceof Error ? err.message : err,
     );
-    return;
+    return null;
   }
   const disabled = parseDisabledProviders(await getConfigStoreValue(DISABLED_PROVIDERS_KEY).catch(() => undefined));
   const wanted = activeProvider === "anthropic"
@@ -2163,9 +2163,16 @@ export async function setProviderPlugins(activeProvider: string): Promise<void> 
   // so a fresh box needs no write to be on.
   const current = (config.plugins as { entries?: Record<string, { enabled?: boolean }> } | undefined)
     ?.entries?.anthropic?.enabled ?? true;
-  if (current === wanted) return;
+  if (current === wanted) return null;
   try {
     await runOpenclawConfigSet([ANTHROPIC_PLUGIN_ENABLED_KEY, wanted ? "true" : "false", "--json"]);
+    // WHICH provider's catalogue just changed, for the caller to pass on. This
+    // gate governs exactly one plugin, and switching it off is what empties
+    // `openclaw models list --provider anthropic`; returning the id keeps that
+    // fact here rather than hand-copied into every call site, and returning
+    // `null` on the no-op paths means a caller cannot announce a change that
+    // did not happen.
+    return "anthropic";
   } catch (err) {
     // Non-fatal: a gate left wrong costs prep seconds or one catalog refresh,
     // never correctness, and the next switch or save re-applies it.
@@ -2174,6 +2181,7 @@ export async function setProviderPlugins(activeProvider: string): Promise<void> 
       err instanceof Error ? err.message : err,
     );
   }
+  return null;
 }
 
 /**

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -28,15 +28,21 @@ import {
 // route without dragging `spawn`/`fs` in, so a rule parked there would simply
 // be copied.
 //
+// It is a GUESS, and only for catalogues that leave us no alternative.
 // `openclaw models list` enumerates a provider's whole catalogue and offers no
 // capability filter to ask for the chat ones (`--all`, `--local`, `--provider`
 // and nothing else on 2026.8.1), and its rows carry no capability field: an
 // image SKU comes back shaped exactly like a chat model —
 // `openai/gpt-image-1-mini` beside `openai/gpt-5.6-sol`, `input` reported as
-// "-" for both on a stock host. That gap is worth reporting upstream; until it
-// closes this is the honest stopgap, and a catalogue that DOES publish the
-// capability (OpenRouter's `architecture.output_modalities`) is read instead of
-// being matched against this list.
+// "-" for both on a stock host. That gap is worth reporting upstream.
+//
+// Where a catalogue DOES publish the capability this list is not consulted at
+// all: OpenRouter's `architecture.output_modalities` is read directly by the
+// catalog route (`outputIsRenderableChat`), and `MODALITY_REPORTING_PROVIDERS`
+// keeps this pattern off that provider so a guess can never disagree with an
+// answer. An earlier revision of this comment claimed the field was already
+// read while nothing in the tree referenced it; the measurement below is what
+// closed that gap.
 //
 // A MODALITY exclusion, deliberately not a generation allowlist: it can only
 // hide SKUs a chat picker has no way to talk to, never a chat model the box has
@@ -45,12 +51,24 @@ import {
 // which is the defect this change exists to fix. Older chat generations the box
 // lists are shown: the device's own catalogue decides, and an older model the
 // box can route is not a dead button.
+//
+// The families are measured, not guessed at twice: run against the 423 rows of
+// the live OpenRouter catalogue (2026-09-02), which is the only catalogue that
+// states the truth alongside the name, this pattern drops 13 of the 15 rows
+// whose output is not text-only — the `-image` family (`gpt-5-image`,
+// `gemini-2.5-flash-image`, `gpt-5.4-image-2`), `imagen-*`, `veo-*`, `lyria-*`,
+// `gpt-audio` — and produces ZERO false failures: no text-output row matches
+// it. The two it misses are `openrouter/auto` and `openrouter/auto-beta`, which
+// the field-based rule deliberately keeps too. `vision` is NOT a family here
+// for the same measured reason: `deepseek/deepseek-v4-flash-vision-exp` is a
+// text-output chat model.
 const NON_CHAT_MODEL_RE = new RegExp([
   "^(?:gpt-image|dall-e|whisper|tts-|text-embedding|omni-moderation|sora",
-  "|davinci|babbage|codex-mini)",
+  "|davinci|babbage|codex-mini|imagen|veo|lyria)",
   // Suffix families: gpt-4o-audio-preview, gpt-4o-realtime-preview,
-  // gpt-4o-transcribe, gpt-4o-mini-tts.
-  "|(?:-audio|-realtime|-transcribe|-tts)(?:-|$)",
+  // gpt-4o-transcribe, gpt-4o-mini-tts, gemini-2.5-flash-image,
+  // gpt-5.4-image-2.
+  "|(?:-audio|-realtime|-transcribe|-tts|-image)(?:-|$)",
 ].join(""));
 
 /**

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -60,16 +60,26 @@ export interface ProviderCatalog {
 // stable entries per provider) and let the live catalog fill in the
 // rest. If you find yourself adding the latest model here, stop —
 // that's the catalog route's job.
+//
+// They are DISPLAY ONLY, and they can never hide a live row: the route no
+// longer merges them into an enumeration, and never persists them. Whatever
+// renders them is holding a catalogue marked `fallback: true` and is expected
+// to ask again — see `ResolvedProviderCatalog` and `useProviderCatalog`. The
+// one thing they still contribute to a live row is a `hint`, which no
+// enumeration returns.
 export const ANTHROPIC_MODELS: readonly ProviderModelOption[] = [
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", hint: "Fastest, near-frontier." },
   { id: "claude-sonnet-5", label: "Claude Sonnet 5", hint: "Default. Speed + intelligence." },
   { id: "claude-opus-5", label: "Claude Opus 5", hint: "Most capable." },
 ] as const;
 
-// OpenAI API key models. Curated to the 5.4 + 5.5 generations only —
-// older gens (4.1, 5.0, 5.1, 5.2, 5.3) are filtered out at the catalog
-// route via ALLOWED_MODEL_RE_BY_PROVIDER. Power users can still hit
-// older models via the "custom" toggle.
+// OpenAI API key models — cold-start display only, like every list here.
+// There is no longer a generation allowlist at the catalog route for openai:
+// it matched none of the gpt-5.6 generation, so on a 2026.8.1 box it hid the
+// live catalogue behind these five ids instead of supplementing them. What a
+// box shows now is what `openclaw models list --provider openai --all --json`
+// returns, minus the non-chat SKUs. Power users can still type any id via the
+// "custom" toggle.
 export const OPENAI_MODELS: readonly ProviderModelOption[] = [
   { id: "gpt-5.5-pro", label: "GPT-5.5 Pro", hint: "Latest, max reasoning." },
   { id: "gpt-5.5", label: "GPT-5.5", hint: "Latest flagship." },
@@ -348,7 +358,25 @@ interface CatalogApiResponse {
   /** True when the route fell back to a stale cached payload because the
    * upstream catalog query just failed; UI may want to show a warning. */
   stale?: boolean;
+  /** True when no live device enumeration produced this payload — see
+   * `CatalogResponse.fallback` in the catalog route. */
+  fallback?: boolean;
 }
+
+/**
+ * A catalogue as a component actually receives it: the shape above plus the
+ * two things the picker has to know about the ANSWER rather than the models —
+ * whether it is old, and whether a device produced it at all.
+ */
+export type ResolvedProviderCatalog = ProviderCatalog & {
+  stale?: boolean;
+  /**
+   * True when these rows are the curated cold-start list rather than a device
+   * enumeration. A consumer that renders them must come back and ask again:
+   * they are a placeholder for an answer, not the answer.
+   */
+  fallback?: boolean;
+};
 
 /**
  * Fetch the live model catalog for `provider` from the catalog route.
@@ -365,11 +393,16 @@ interface CatalogApiResponse {
  */
 export async function fetchProviderCatalog(
   provider: string,
-  opts: { signal?: AbortSignal } = {},
-): Promise<ProviderCatalog & { stale?: boolean }> {
+  opts: { signal?: AbortSignal; refresh?: boolean } = {},
+): Promise<ResolvedProviderCatalog> {
   const fallback = getProviderCatalog(provider);
   try {
-    const url = `/setup-api/ai-models/catalog?provider=${encodeURIComponent(provider)}`;
+    // `?refresh=1` asks the route to re-enumerate NOW rather than wait out its
+    // 6h interval. It still answers from cache immediately — the refresh runs
+    // detached — so this costs the caller nothing and is what makes "connect a
+    // provider, see its models" work without a reload.
+    const url = `/setup-api/ai-models/catalog?provider=${encodeURIComponent(provider)}`
+      + (opts.refresh ? "&refresh=1" : "");
     const res = await fetch(url, { signal: opts.signal, cache: "no-store" });
     if (!res.ok) {
       throw new Error(`HTTP ${res.status}`);
@@ -377,7 +410,7 @@ export async function fetchProviderCatalog(
     const body = (await res.json()) as CatalogApiResponse;
     if (!body.models || body.models.length === 0) {
       // Empty catalog — keep the fallback so the picker isn't blank.
-      if (fallback) return { ...fallback, stale: true };
+      if (fallback) return { ...fallback, stale: true, fallback: true };
       throw new Error("empty catalog");
     }
     return {
@@ -396,6 +429,11 @@ export async function fetchProviderCatalog(
         || "",
       allowCustom: body.allowCustom !== false,
       stale: body.stale,
+      // Carried through, never inferred: the route knows whether a device
+      // enumeration produced these rows, and the client cannot tell by looking
+      // at them — that is precisely how three hard-coded Claude entries passed
+      // for the box's own catalogue for a day.
+      fallback: body.fallback === true ? true : undefined,
     };
   } catch (err) {
     // AbortError isn't a real failure — the consumer cancelled because
@@ -411,7 +449,7 @@ export async function fetchProviderCatalog(
         `[provider-models] catalog fetch failed for ${provider}, using fallback:`,
         err instanceof Error ? err.message : err,
       );
-      return { ...fallback, stale: true };
+      return { ...fallback, stale: true, fallback: true };
     }
     throw err;
   }

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -361,6 +361,9 @@ interface CatalogApiResponse {
   /** True when no live device enumeration produced this payload — see
    * `CatalogResponse.fallback` in the catalog route. */
   fallback?: boolean;
+  /** True when an enumeration is in flight right now, so asking again will
+   * eventually get a different answer. */
+  warming?: boolean;
 }
 
 /**
@@ -372,10 +375,17 @@ export type ResolvedProviderCatalog = ProviderCatalog & {
   stale?: boolean;
   /**
    * True when these rows are the curated cold-start list rather than a device
-   * enumeration. A consumer that renders them must come back and ask again:
-   * they are a placeholder for an answer, not the answer.
+   * enumeration — a placeholder for an answer, not the answer. A consumer may
+   * render them, but must not treat them as facts about the box.
    */
   fallback?: boolean;
+  /**
+   * True when the box is enumerating RIGHT NOW, so a later ask gets a better
+   * answer. This, not `fallback`, is what a consumer polls on: a provider that
+   * cannot enumerate at all serves a fallback forever, and polling it would be
+   * a request loop with no destination. The route holds the matching backoff.
+   */
+  warming?: boolean;
 };
 
 /**
@@ -429,6 +439,7 @@ export async function fetchProviderCatalog(
         || "",
       allowCustom: body.allowCustom !== false,
       stale: body.stale,
+      warming: body.warming === true ? true : undefined,
       // Carried through, never inferred: the route knows whether a device
       // enumeration produced these rows, and the client cannot tell by looking
       // at them — that is precisely how three hard-coded Claude entries passed

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -10,11 +10,59 @@
 // (e.g. `anthropic/claude-haiku-4-5`) since OpenRouter's catalog uses
 // `<org>/<model>` slugs.
 
+import { lastModelSegment } from "./chat-header-pills";
 import {
   OPENROUTER_CURATED_MODELS,
   OPENROUTER_DEFAULT_MODEL_ID,
   isValidOpenRouterModelId,
 } from "./openrouter-models";
+
+// Model families that are not CHAT models, whatever provider lists them —
+// image, audio/speech, transcription, video, embeddings, moderation, and the
+// pre-chat completion engines.
+//
+// It lives HERE, not in the catalog route, because it is a fact about model
+// ids rather than about one HTTP handler, and this module already owns the
+// catalogue vocabulary and is import-safe from both client and server. The
+// second catalogue surface (src/lib/hermes-model-options.ts) cannot import a
+// route without dragging `spawn`/`fs` in, so a rule parked there would simply
+// be copied.
+//
+// `openclaw models list` enumerates a provider's whole catalogue and offers no
+// capability filter to ask for the chat ones (`--all`, `--local`, `--provider`
+// and nothing else on 2026.8.1), and its rows carry no capability field: an
+// image SKU comes back shaped exactly like a chat model —
+// `openai/gpt-image-1-mini` beside `openai/gpt-5.6-sol`, `input` reported as
+// "-" for both on a stock host. That gap is worth reporting upstream; until it
+// closes this is the honest stopgap, and a catalogue that DOES publish the
+// capability (OpenRouter's `architecture.output_modalities`) is read instead of
+// being matched against this list.
+//
+// A MODALITY exclusion, deliberately not a generation allowlist: it can only
+// hide SKUs a chat picker has no way to talk to, never a chat model the box has
+// learned about. That distinction is the point — the generation allowlist it
+// replaces (`/^gpt-5\.[45](-pro|-mini)?$/`) hid the whole gpt-5.6 generation,
+// which is the defect this change exists to fix. Older chat generations the box
+// lists are shown: the device's own catalogue decides, and an older model the
+// box can route is not a dead button.
+const NON_CHAT_MODEL_RE = new RegExp([
+  "^(?:gpt-image|dall-e|whisper|tts-|text-embedding|omni-moderation|sora",
+  "|davinci|babbage|codex-mini)",
+  // Suffix families: gpt-4o-audio-preview, gpt-4o-realtime-preview,
+  // gpt-4o-transcribe, gpt-4o-mini-tts.
+  "|(?:-audio|-realtime|-transcribe|-tts)(?:-|$)",
+].join(""));
+
+/**
+ * Is this id a SKU a chat picker has no way to talk to?
+ *
+ * Tested against the last path segment, because OpenRouter ids keep their
+ * `<org>/<model>` slug (`openai/gpt-image-1`) and an anchored pattern matched
+ * against the whole id is silently inert for the largest catalogue we serve.
+ */
+export function isNonChatModelId(id: string): boolean {
+  return NON_CHAT_MODEL_RE.test(lastModelSegment(id));
+}
 
 export interface ProviderModelOption {
   id: string;
@@ -358,9 +406,13 @@ interface CatalogApiResponse {
   /** True when the route fell back to a stale cached payload because the
    * upstream catalog query just failed; UI may want to show a warning. */
   stale?: boolean;
-  /** True when no live device enumeration produced this payload — see
-   * `CatalogResponse.fallback` in the catalog route. */
-  fallback?: boolean;
+  /**
+   * `"live"` when a device enumeration produced this payload. Any other value,
+   * including absent, means it did not — that is the whole test. ONE field
+   * rather than a second derived boolean beside it, so the two cannot
+   * disagree; `CatalogResponse` in the catalog route persists this one.
+   */
+  source?: string;
   /** True when an enumeration is in flight right now, so asking again will
    * eventually get a different answer. */
   warming?: boolean;
@@ -419,8 +471,21 @@ export async function fetchProviderCatalog(
     }
     const body = (await res.json()) as CatalogApiResponse;
     if (!body.models || body.models.length === 0) {
-      // Empty catalog — keep the fallback so the picker isn't blank.
-      if (fallback) return { ...fallback, stale: true, fallback: true };
+      // Empty catalog — keep the curated rows so the picker isn't blank, and
+      // carry `warming` through unchanged. It is the route saying an
+      // enumeration is in flight, and it is the ONLY thing `useProviderCatalog`
+      // polls on; dropped here, a box whose cached rows the sanitiser filtered
+      // away entirely (an upgraded box holding an older build's ids) would sit
+      // on the curated list until the next provider event, while the real
+      // answer landed seconds later with nobody left asking for it.
+      if (fallback) {
+        return {
+          ...fallback,
+          stale: true,
+          fallback: true,
+          warming: body.warming === true ? true : undefined,
+        };
+      }
       throw new Error("empty catalog");
     }
     return {
@@ -440,11 +505,11 @@ export async function fetchProviderCatalog(
       allowCustom: body.allowCustom !== false,
       stale: body.stale,
       warming: body.warming === true ? true : undefined,
-      // Carried through, never inferred: the route knows whether a device
-      // enumeration produced these rows, and the client cannot tell by looking
-      // at them — that is precisely how three hard-coded Claude entries passed
-      // for the box's own catalogue for a day.
-      fallback: body.fallback === true ? true : undefined,
+      // Derived from the route's one marker, never inferred from the rows: the
+      // client cannot tell a curated list from a device's by looking at it —
+      // that is precisely how three hard-coded model names passed for the
+      // box's own catalogue for a day.
+      fallback: body.source === "live" ? undefined : true,
     };
   } catch (err) {
     // AbortError isn't a real failure — the consumer cancelled because

--- a/src/lib/provider-plugin-ops.ts
+++ b/src/lib/provider-plugin-ops.ts
@@ -1,4 +1,4 @@
-import type { OpenclawConfigSetArgs } from "@/lib/openclaw-config";
+import type { OpenclawConfigSetArgs, OpenClawConfig } from "@/lib/openclaw-config";
 
 /**
  * The `config set` operations that switch ON the provider plugins a set of
@@ -30,4 +30,38 @@ export function enableProviderPluginOps(
       .map((ref) => ref.split("/", 1)[0].trim().toLowerCase()),
   );
   return providers.has("anthropic") ? [[ANTHROPIC_PLUGIN_ENABLED_KEY, "true", "--json"]] : [];
+}
+
+/**
+ * WHICH provider those ops actually switch on, given the config as it was
+ * BEFORE the batch — or `null` when they switch nothing on.
+ *
+ * The ON half of the gate, answered the way `setProviderPlugins` answers the
+ * OFF half: with the id it flipped, or `null`. Both halves change what
+ * `openclaw models list --provider <p>` returns — a plugin that is off
+ * enumerates nothing — so both are provider-set changes the catalogue has to
+ * count, and the ON half is the one no caller could see. The enable rides in
+ * the batch (it has to, for the core to validate the reference), so by the
+ * time `setProviderPlugins` re-reads the config the flag is already true and
+ * it correctly reports no flip.
+ *
+ * The ops themselves are emitted whenever a reference names the gated
+ * provider, whether or not the flag is already on, so their presence is NOT a
+ * state change: announcing one on every Claude pick would spend a ~3-minute
+ * `openclaw models list` per click on a Jetson.
+ *
+ * Pure, and deliberately reads only the flag. An absent one IS enabled (the
+ * plugin declares `enabledByDefault: true`), and a config that could not be
+ * read reaches this as `{}` or `null` and so reads as already-on: this stays
+ * silent rather than announcing a change that may not have happened.
+ */
+export function providerPluginSwitchedOnBy(
+  modelRefs: readonly (string | null | undefined)[],
+  configBeforeWrite: OpenClawConfig | null | undefined,
+): string | null {
+  if (enableProviderPluginOps(modelRefs).length === 0) return null;
+  const wasOn = (configBeforeWrite?.plugins as
+    { entries?: Record<string, { enabled?: boolean }> } | undefined)
+    ?.entries?.anthropic?.enabled ?? true;
+  return wasOn ? null : "anthropic";
 }

--- a/src/lib/provider-plugin-ops.ts
+++ b/src/lib/provider-plugin-ops.ts
@@ -1,6 +1,13 @@
 import type { OpenclawConfigSetArgs, OpenClawConfig } from "@/lib/openclaw-config";
 
 /**
+ * The one plugin this gate governs. Named once so the two functions below
+ * cannot drift apart the day a second provider is gated: the ops builder
+ * decides whether to emit from it, and the ON-half detector reports it.
+ */
+const GATED_PLUGIN_PROVIDER = "anthropic";
+
+/**
  * The `config set` operations that switch ON the provider plugins a set of
  * model references resolve through — meant to ride in the SAME
  * `config set --batch-json` as the writes of those references, ahead of them.
@@ -29,7 +36,7 @@ export function enableProviderPluginOps(
       .filter((ref): ref is string => typeof ref === "string" && ref.includes("/"))
       .map((ref) => ref.split("/", 1)[0].trim().toLowerCase()),
   );
-  return providers.has("anthropic") ? [[ANTHROPIC_PLUGIN_ENABLED_KEY, "true", "--json"]] : [];
+  return providers.has(GATED_PLUGIN_PROVIDER) ? [[ANTHROPIC_PLUGIN_ENABLED_KEY, "true", "--json"]] : [];
 }
 
 /**
@@ -50,18 +57,27 @@ export function enableProviderPluginOps(
  * state change: announcing one on every Claude pick would spend a ~3-minute
  * `openclaw models list` per click on a Jetson.
  *
- * Pure, and deliberately reads only the flag. An absent one IS enabled (the
- * plugin declares `enabledByDefault: true`), and a config that could not be
- * read reaches this as `{}` or `null` and so reads as already-on: this stays
- * silent rather than announcing a change that may not have happened.
+ * Pure, and deliberately reads only the flag — but it distinguishes two things
+ * a lenient config read collapses. A config that HAS no flag is on (the plugin
+ * declares `enabledByDefault: true`), so it is not a transition and must stay
+ * silent; that is the ordinary case, and announcing it would fire on every
+ * anthropic pick on a normal box. A config that could not be READ — `null`
+ * here — is not the same claim: we do not know, and the two mistakes do not
+ * cost the same. A needless announcement spends one enumeration, which on a
+ * box whose config cannot be read fails fast anyway; silence over a real
+ * switch-on leaves the catalogue serving a stale list stamped `source: "live"`
+ * for six hours, which is the defect this counting exists to remove. So pass
+ * `null` when the read failed, and `{}` only when it succeeded and found
+ * nothing.
  */
 export function providerPluginSwitchedOnBy(
   modelRefs: readonly (string | null | undefined)[],
   configBeforeWrite: OpenClawConfig | null | undefined,
 ): string | null {
   if (enableProviderPluginOps(modelRefs).length === 0) return null;
-  const wasOn = (configBeforeWrite?.plugins as
+  if (!configBeforeWrite) return GATED_PLUGIN_PROVIDER;
+  const wasOn = (configBeforeWrite.plugins as
     { entries?: Record<string, { enabled?: boolean }> } | undefined)
-    ?.entries?.anthropic?.enabled ?? true;
-  return wasOn ? null : "anthropic";
+    ?.entries?.[GATED_PLUGIN_PROVIDER]?.enabled ?? true;
+  return wasOn ? null : GATED_PLUGIN_PROVIDER;
 }

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -78,22 +78,25 @@ export async function readSubscriptionSurfaceIds(
     const ids = parsed.models
       .map((m) => m?.id)
       .filter((id): id is string => typeof id === "string" && id.length > 0);
-    // Union the CURATED catalogue for the surface provider, because the
-    // catalog route serves its cached payload through `buildPayload` ->
-    // `augmentWithStaticCatalog`, which appends exactly these ids to whatever
-    // the live enumeration returned. Reading the raw file without them asks a
-    // different question than the picker answered: a ClawBox release that adds
-    // a model to PROVIDER_CATALOGS ships a picker offering it on day one,
-    // while the on-disk cache keeps the previous list for up to the route's
-    // 6h refresh interval — and in that window this guard refused the very row
-    // the customer had just been shown. `augmentWithStaticCatalog` is a no-op
-    // for a provider with no curated catalogue (a NARROWER named surface such
-    // as claude-cli), and so is this, which is what keeps a narrowed surface
-    // narrow.
+    // Union the CURATED catalogue for the surface provider, because that is
+    // what the picker renders whenever the catalog route has no live
+    // enumeration to serve: a cold start, or a box whose provider is not
+    // listable yet, gets the curated rows marked `fallback`. Reading the raw
+    // file without them asks a different question than the picker answered,
+    // and this guard would refuse the very row the customer had just been
+    // shown. It is a no-op for a provider with no curated catalogue (a
+    // NARROWER named surface such as claude-cli), which is what keeps a
+    // narrowed surface narrow.
     //
-    // The curated ids count BEFORE the empty check, for the same reason: a
-    // file holding `models: []` is served to the picker through that same
-    // augmentation, so the customer was shown the curated list, not nothing.
+    // The union is the PERMISSIVE direction, deliberately. Since M-05 the
+    // route no longer merges the curated list into a live enumeration or
+    // persists it, so a cache file is either a device answer or absent — this
+    // is the one place the two lists still meet, and it meets them by allowing
+    // a curated id rather than refusing a live one.
+    //
+    // The curated ids count BEFORE the empty check for the same reason: a file
+    // holding `models: []` leaves the picker on the curated list, so the
+    // customer was shown that list, not nothing.
     const curated = getProviderCatalog(surfaceProvider)?.models ?? [];
     if (ids.length === 0 && curated.length === 0) return null;
     for (const model of curated) {

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -100,9 +100,10 @@ export async function readSubscriptionSurfaceIds(
     // is the one place the two lists still meet, and it meets them by allowing
     // a curated id rather than refusing a live one.
     //
-    // The curated ids count BEFORE the empty check for the same reason: a file
-    // holding `models: []` leaves the picker on the curated list, so the
-    // customer was shown that list, not nothing.
+    // The curated ids count BEFORE the empty check for the same reason: the
+    // route serves a file holding `models: []` as an empty payload, and
+    // `fetchProviderCatalog` renders the curated catalogue for an empty one, so
+    // the customer was shown that list, not nothing.
     const curated = getProviderCatalog(surfaceProvider)?.models ?? [];
     if (ids.length === 0 && curated.length === 0) return null;
     for (const model of curated) {

--- a/src/lib/subscription-surface.ts
+++ b/src/lib/subscription-surface.ts
@@ -38,14 +38,20 @@ interface CachedSurface {
  * Null means UNKNOWN and every caller must treat it as "do not refuse" — the
  * same rule `isModelUsableOnSubscription` applies in the pickers. A missing
  * cache is unknown: treating it as authoritative would refuse the entire
- * catalogue on a box whose enumeration simply has not run yet. A cache that
- * EXISTS but enumerated nothing is judged by the curated catalogue alone —
- * that is exactly what the catalog route serves for the same file, so the
- * picker on that box offers the curated rows and nothing else. Answering
- * UNKNOWN there would let a typed id the picker never offered through the
- * very write this guard exists to refuse. Only when neither list has an id
- * (a NARROWER named surface with no curated catalogue, enumerated empty) is
- * there nothing to judge against.
+ * catalogue on a box whose enumeration simply has not run yet.
+ *
+ * A MISSING cache is now the state a thin or failed enumeration leaves behind
+ * (M-05: the route stopped persisting a payload it did not get from a device),
+ * where it used to leave a file holding the curated ids. That moves such a box
+ * from "refuse anything outside the curated three" to UNKNOWN, and that is the
+ * right direction, not a gap: the curated three are not what the device can
+ * run, so refusing against them refused models the box routes perfectly well —
+ * the false-failure this file's own rule above forbids. The guard still
+ * refuses against a REAL enumeration, which is the case it was built for.
+ *
+ * A cache that exists but lists nothing can no longer occur; if a downgrade
+ * leaves one behind it is judged by the curated catalogue alone, which is what
+ * the picker shows for that same file.
  *
  * No age check and no memo. Both are deliberate:
  *

--- a/src/lib/ui-events.ts
+++ b/src/lib/ui-events.ts
@@ -272,6 +272,16 @@ export function notifyProvidersChanged(): void {
  * a Jetson the provider status call is a `hermes` spawn, so the duplicate is
  * measured in seconds, not milliseconds.
  *
+ * `events` narrows the set for the rare listener that must NOT wake on all
+ * three. It exists for the model CATALOGUE, which is a fact about the box and
+ * not about the chat's current selection: `CHAT_MODEL_STATE_EVENT` means "the
+ * selection changed", and re-enumerating a catalogue for that would ask a
+ * Jetson for a ~3-minute `openclaw models list` over a pick the customer made
+ * from the list it already had. Narrowing stays an OPTION rather than a second
+ * helper so the debounce, the unsubscribe and the pending-timer cancellation
+ * below have exactly one implementation — the copy of them that briefly lived
+ * in `useProviderCatalog` is what this parameter deletes.
+ *
  * The debounce lives HERE, on the listen side, rather than inside
  * `notifyProvidersChanged`. An emitter-side debounce would collapse two
  * genuinely different writes from two different components into one, and the
@@ -282,10 +292,11 @@ export const PROVIDER_SIGNAL_DEBOUNCE_MS = 150;
 
 export function onProvidersChanged(
   listener: () => void,
-  options: { debounceMs?: number } = {},
+  options: { debounceMs?: number; events?: readonly string[] } = {},
 ): () => void {
   if (typeof window === "undefined") return () => {};
   const wait = options.debounceMs ?? PROVIDER_SIGNAL_DEBOUNCE_MS;
+  const names = options.events ?? PROVIDER_SIGNAL_EVENTS;
   let timer: ReturnType<typeof setTimeout> | null = null;
   const onSignal = () => {
     if (timer) clearTimeout(timer);
@@ -294,13 +305,13 @@ export function onProvidersChanged(
       listener();
     }, wait);
   };
-  for (const name of PROVIDER_SIGNAL_EVENTS) window.addEventListener(name, onSignal);
+  for (const name of names) window.addEventListener(name, onSignal);
   return () => {
     // Cancel the pending call as well as unsubscribing: a listener that fires
     // after its component unmounted is a setState on a dead tree, and this is
     // the one place the timer is reachable.
     if (timer) clearTimeout(timer);
-    for (const name of PROVIDER_SIGNAL_EVENTS) window.removeEventListener(name, onSignal);
+    for (const name of names) window.removeEventListener(name, onSignal);
   };
 }
 

--- a/src/tests/components/model-picker-live-catalog.test.tsx
+++ b/src/tests/components/model-picker-live-catalog.test.tsx
@@ -68,10 +68,18 @@ vi.mock("@/hooks/useLlamaCppModels", () => ({
   }),
 }));
 
-/** What the route serves before any live enumeration has landed. */
+/**
+ * What the route serves before any live enumeration has landed: the curated
+ * cold-start rows, marked `fallback` (they are not the box's answer) and
+ * `warming` (a fork is out there, so asking again is worth something).
+ */
 const WARMING = {
   provider: "anthropic",
-  models: [],
+  models: [
+    { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", hint: "Fastest, near-frontier.", contextWindow: 200_000 },
+    { id: "claude-sonnet-5", label: "Claude Sonnet 5", hint: "Default. Speed + intelligence.", contextWindow: 1_000_000 },
+    { id: "claude-opus-5", label: "Claude Opus 5", hint: "Most capable.", contextWindow: 1_000_000 },
+  ],
   defaultModelId: "claude-sonnet-5",
   allowCustom: true,
   fetchedAt: 0,
@@ -197,7 +205,7 @@ describe("model picker — live catalogue", () => {
     expect(catalogUrls[catalogUrls.length - 1]).toContain("refresh=1");
   });
 
-  it("keeps asking while the answer is still a fallback", async () => {
+  it("keeps asking while the box is still enumerating", async () => {
     // Nothing connects here: the box is simply slow. The picker must not settle
     // on the curated list for the rest of the session because its one fetch
     // happened three minutes too early.

--- a/src/tests/components/model-picker-live-catalog.test.tsx
+++ b/src/tests/components/model-picker-live-catalog.test.tsx
@@ -1,0 +1,213 @@
+// M-05 / TASK-653 — the picker must show the models the BOX reports, not the
+// three hard-coded Claude entries in provider-models.ts.
+//
+// The first catalog read on a cold box is a fallback: the refresh behind
+// `/setup-api/ai-models/catalog` takes ~3 minutes on a Jetson, and until it
+// lands the route has nothing live to serve. The picker renders the curated
+// cold-start list then, which is fine — as long as it goes back and asks
+// again. It did not: `useProviderCatalog` fetched once per provider and never
+// re-read, so a box whose Anthropic plugin was disabled at boot showed three
+// Claude models for the rest of the day while it could run eleven.
+//
+// Connecting a provider is exactly the moment the catalogue becomes
+// enumerable, and the app already has a signal for it —
+// `notifyProvidersChanged()` from @/lib/ui-events, which every successful
+// configure emits and which the provider-status strip already listens to.
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen, waitFor, within } from "@/tests/helpers/test-utils";
+import AIModelsStep from "@/components/AIModelsStep";
+import { notifyProvidersChanged } from "@/lib/ui-events";
+
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({
+    t: (key: string) => {
+      const strings: Record<string, string> = {
+        "ai.model": "Model",
+        "ai.modelChange": "Change",
+        "ai.modelNeedsApiKey": "Not on subscriptions — needs an API key",
+        "ai.modelCustomToggle": "Enter a custom model ID…",
+        "ai.modelCuratedToggle": "Pick from curated list",
+      };
+      return strings[key] ?? key;
+    },
+  }),
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/useOllamaModels", () => ({
+  useOllamaModels: () => ({
+    ollamaRunning: false,
+    ollamaModels: [],
+    ollamaSearch: "",
+    ollamaSearchResults: [],
+    ollamaSearching: false,
+    ollamaPulling: false,
+    ollamaPullProgress: null,
+    ollamaSaving: false,
+    checkOllamaStatus: vi.fn(),
+    handleOllamaSearchChange: vi.fn(),
+    pullOllamaModel: vi.fn(),
+    saveOllamaConfig: vi.fn(),
+    deleteOllamaModel: vi.fn(),
+    formatOllamaBytes: vi.fn((bytes: number) => `${bytes}`),
+    clearSearch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useLlamaCppModels", () => ({
+  useLlamaCppModels: () => ({
+    llamaCppRunning: false,
+    llamaCppInstalled: false,
+    llamaCppModels: [],
+    llamaCppEndpoint: "http://127.0.0.1:8080/v1",
+    llamaCppSaving: false,
+    llamaCppProgress: null,
+    checkLlamaCppStatus: vi.fn(),
+    saveLlamaCppConfig: vi.fn(),
+  }),
+}));
+
+/** What the route serves before any live enumeration has landed. */
+const WARMING = {
+  provider: "anthropic",
+  models: [],
+  defaultModelId: "claude-sonnet-5",
+  allowCustom: true,
+  fetchedAt: 0,
+  warming: true,
+  fallback: true,
+};
+
+/**
+ * `openclaw models list --provider anthropic --all --json` on a 2026.8.1 box,
+ * through the catalog route: eleven rows, every one `available`.
+ */
+const LIVE_MODELS = [
+  { id: "claude-opus-5", label: "Claude Opus 5", contextWindow: 1_000_000 },
+  { id: "claude-fable-5", label: "Claude Fable 5", contextWindow: 1_000_000 },
+  { id: "claude-fable-5-1", label: "Claude Fable 5.1", contextWindow: 1_000_000 },
+  { id: "claude-opus-4-8", label: "Claude Opus 4.8", contextWindow: 1_000_000 },
+  { id: "claude-opus-4-7", label: "Claude Opus 4.7", contextWindow: 1_000_000 },
+  { id: "claude-opus-4-6", label: "Claude Opus 4.6", contextWindow: 1_000_000 },
+  { id: "claude-mythos-5", label: "Claude Mythos 5", contextWindow: 1_000_000 },
+  { id: "claude-sonnet-5", label: "Claude Sonnet 5", contextWindow: 1_000_000 },
+  { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6", contextWindow: 200_000 },
+  { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", contextWindow: 200_000 },
+  { id: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5 (2025-10-01)", contextWindow: 200_000 },
+];
+
+const LIVE = {
+  provider: "anthropic",
+  models: LIVE_MODELS,
+  defaultModelId: "claude-sonnet-5",
+  allowCustom: true,
+  fetchedAt: Date.now(),
+};
+
+/** Every catalog URL the component asked for, in order. */
+const catalogUrls: string[] = [];
+
+function stubFetch() {
+  catalogUrls.length = 0;
+  let catalogCalls = 0;
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof Request ? input.url : String(input);
+    if (url.includes("/setup-api/ai-models/oauth/providers")) {
+      return { ok: true, json: async () => ({ providers: ["anthropic"] }) } as Response;
+    }
+    if (url.includes("/setup-api/ai-models/catalog")) {
+      catalogUrls.push(url);
+      catalogCalls += 1;
+      // The box is still warming when the picker first mounts; the enumeration
+      // lands a moment later, exactly as it does after a provider connect.
+      return { ok: true, json: async () => (catalogCalls === 1 ? WARMING : LIVE) } as Response;
+    }
+    if (url.includes("harness")) {
+      return { ok: true, json: async () => ({ edition: "openclaw" }) } as Response;
+    }
+    return { ok: true, json: async () => ({}) } as Response;
+  }));
+}
+
+async function renderStep() {
+  const view = render(
+    <AIModelsStep
+      embedded
+      providerIds={["anthropic"]}
+      defaultProviderId="anthropic"
+      title="Connect AI Provider"
+      description="Primary provider"
+    />,
+  );
+  await waitFor(() => {
+    expect(fetch).toHaveBeenCalledWith("/setup-api/ai-models/oauth/providers");
+  });
+  return view;
+}
+
+/** Expand the collapsed "Model — <name> — Change" summary, then open the list. */
+async function openModelList() {
+  const summary = await screen.findByRole("button", { name: /^Model/ });
+  fireEvent.click(summary);
+  const trigger = await screen.findByRole("button", { name: /^Model:/ });
+  fireEvent.click(trigger);
+  return screen.getByRole("listbox", { name: "Model" });
+}
+
+describe("model picker — live catalogue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubFetch();
+  });
+
+  it("re-reads the catalogue when a provider connects, and shows every live row", async () => {
+    await renderStep();
+    // Cold start: the curated three, because that is all there is yet.
+    let listbox = await openModelList();
+    expect(within(listbox).getAllByRole("option")).toHaveLength(3);
+
+    // A provider connect is the moment the catalogue becomes enumerable.
+    await act(async () => {
+      notifyProvidersChanged();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    await waitFor(() => {
+      listbox = screen.getByRole("listbox", { name: "Model" });
+      expect(within(listbox).getAllByRole("option")).toHaveLength(11);
+    }, { timeout: 3000 });
+
+    const labels = within(listbox).getAllByRole("option").map((o) => o.textContent ?? "");
+    expect(labels.some((l) => l.includes("Claude Fable 5"))).toBe(true);
+    expect(labels.some((l) => l.includes("Claude Opus 4.8"))).toBe(true);
+    expect(labels.some((l) => l.includes("Claude Mythos 5"))).toBe(true);
+  });
+
+  it("asks the route to refresh rather than re-reading the same cached answer", async () => {
+    await renderStep();
+    await openModelList();
+
+    await act(async () => {
+      notifyProvidersChanged();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    });
+
+    await waitFor(() => expect(catalogUrls.length).toBeGreaterThan(1), { timeout: 3000 });
+    expect(catalogUrls[catalogUrls.length - 1]).toContain("refresh=1");
+  });
+
+  it("keeps asking while the answer is still a fallback", async () => {
+    // Nothing connects here: the box is simply slow. The picker must not settle
+    // on the curated list for the rest of the session because its one fetch
+    // happened three minutes too early.
+    await renderStep();
+    await openModelList();
+
+    await waitFor(() => expect(catalogUrls.length).toBeGreaterThan(1), { timeout: 5000 });
+    await waitFor(() => {
+      const listbox = screen.getByRole("listbox", { name: "Model" });
+      expect(within(listbox).getAllByRole("option")).toHaveLength(11);
+    }, { timeout: 5000 });
+  });
+});

--- a/src/tests/components/model-picker-live-catalog.test.tsx
+++ b/src/tests/components/model-picker-live-catalog.test.tsx
@@ -70,8 +70,8 @@ vi.mock("@/hooks/useLlamaCppModels", () => ({
 
 /**
  * What the route serves before any live enumeration has landed: the curated
- * cold-start rows, marked `fallback` (they are not the box's answer) and
- * `warming` (a fork is out there, so asking again is worth something).
+ * cold-start rows, with NO `source` (they are not the box's answer) and
+ * `warming: true` (a fork is out there, so asking again is worth something).
  */
 const WARMING = {
   provider: "anthropic",
@@ -84,7 +84,6 @@ const WARMING = {
   allowCustom: true,
   fetchedAt: 0,
   warming: true,
-  fallback: true,
 };
 
 /**
@@ -111,6 +110,7 @@ const LIVE = {
   defaultModelId: "claude-sonnet-5",
   allowCustom: true,
   fetchedAt: Date.now(),
+  source: "live",
 };
 
 /** Every catalog URL the component asked for, in order. */

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -272,7 +272,8 @@ describe("catalog — the ChatGPT surface has no enumeration on this core", () =
     // and written down; forking a whole openclaw process on a Jetson at every
     // boot, and again once per backoff window, to be told
     // `Unknown provider filter "codex"` buys nothing.
-    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(spawnedProviders()).not.toContain("codex");
+    expect(spawnedProviders()).not.toContain("openai");
     expect(fs.existsSync(cacheFile("codex"))).toBe(false);
   });
 
@@ -362,14 +363,14 @@ describe("catalog — a provider that cannot answer is not asked on every reques
     // in this file succeeded and therefore cleared it. This describe is last,
     // so leaving anthropic backed off costs nothing.
     refreshInBackground("anthropic");
-    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1), { timeout: 2000 });
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    await vi.waitFor(() => expect(spawnedProviders()).toContain("anthropic"), { timeout: 2000 });
+    await settle();
 
     mockSpawn.mockClear();
     refreshInBackground("anthropic");
     refreshInBackground("anthropic");
-    await new Promise((resolve) => setTimeout(resolve, 200));
-    expect(mockSpawn).not.toHaveBeenCalled();
+    await settle();
+    expect(spawnedProviders()).not.toContain("anthropic");
   });
 
   // A wait that does not GROW is not a backoff. Deriving the last wait from the

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -277,6 +277,21 @@ describe("catalog — the ChatGPT surface has no enumeration on this core", () =
     expect(fs.existsSync(cacheFile("codex"))).toBe(false);
   });
 
+  // The sibling of the backoff bypass: `?refresh=1` now means "the provider set
+  // changed" and clears the wait for a provider a connect could make listable.
+  // Nothing a box can do makes `codex` listable on this core, so it must not be
+  // cleared there — otherwise every forced read reprints its one log line, and
+  // the picker sends one per provider-set signal.
+  it("stays unasked even when the provider set changes", async () => {
+    mockSpawn.mockClear();
+    await get("codex", "&refresh=1");
+    await settle();
+
+    expect(spawnedProviders()).not.toContain("codex");
+    expect(spawnedProviders()).not.toContain("openai");
+    expect(fs.existsSync(cacheFile("codex"))).toBe(false);
+  });
+
   it("serves the curated ChatGPT list marked fallback, in its curated order", async () => {
     const body = await get("codex");
 

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -310,14 +310,41 @@ describe("catalog — the ChatGPT surface has no enumeration on this core", () =
         { key: "openai/gpt-5.5-pro", name: "GPT-5.5 Pro", contextWindow: 400_000, available: true, tags: [] },
         { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 1_000_000, available: true, tags: [] },
         // Listed by the same command, unusable by a chat picker, and the
-        // harness offers no capability filter to ask it apart.
+        // harness offers no capability filter to ask it apart. All four id
+        // SHAPES are taken from the live OpenRouter catalogue (2026-09-02),
+        // which is the one catalogue that states the modality next to the name:
+        // a prefix family, the `-image` suffix family that the earlier pattern
+        // missed entirely, and google's image/video engines.
         { key: "openai/gpt-image-1-mini", name: "GPT Image 1 Mini", contextWindow: 0, available: true, tags: [] },
+        { key: "openai/gpt-5-image", name: "GPT-5 Image", contextWindow: 0, available: true, tags: [] },
+        { key: "openai/gpt-5.4-image-2", name: "GPT-5.4 Image 2", contextWindow: 0, available: true, tags: [] },
+        { key: "google/imagen-4", name: "Imagen 4", contextWindow: 0, available: true, tags: [] },
       ],
     });
 
     refreshInBackground("openai");
     const ids = await publishedIds("openai", 3);
     expect(ids.sort()).toEqual(["gpt-5.4", "gpt-5.5-pro", "gpt-5.6-sol"]);
+  });
+
+  // Finding 3 of the review pass: the harness answers "which of these is the
+  // default" and the route threw it away for a hand-written map. That is the
+  // same defect as the hard-coded list, pointed at the default.
+  it("takes the default the box tags, not the one the map remembers", async () => {
+    mockList({
+      count: 2,
+      models: [
+        { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: ["default"] },
+        // The id DEFAULT_MODEL_BY_PROVIDER carries for openai. It is in the
+        // catalogue, so the old lookup found it and stopped.
+        { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 1_000_000, available: true, tags: [] },
+      ],
+    });
+
+    refreshInBackground("openai");
+    await publishedIds("openai", 2);
+    const body = await get("openai");
+    expect(body.defaultModelId).toBe("gpt-5.6-sol");
   });
 
   it("drops a row the harness itself reports as unavailable, and keeps an undetermined one", async () => {
@@ -416,5 +443,98 @@ describe("catalog — a provider that cannot answer is not asked on every reques
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  // The brake rate-limits a client ASKING AGAIN. It must not survive the box
+  // CHANGING — a connect enables the plugin and writes the credential, which is
+  // the moment a provider that could not enumerate starts being able to. Held
+  // there, this fix recreates the very symptom it exists to remove: no fork, so
+  // no `warming`, so the picker stops polling and keeps the curated list.
+  it("lets a provider-set change through the backoff, and says an answer is coming", async () => {
+    // google is under a backoff from the empty-enumeration test above, and has
+    // no cached payload of its own — the state a box is in when the customer
+    // connects the provider whose pre-auth enumeration came back empty.
+    mockList({
+      count: 2,
+      models: [
+        { key: "google/gemini-3-pro", name: "Gemini 3 Pro", contextWindow: 1_000_000, available: true, tags: ["default"] },
+        { key: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash", contextWindow: 1_000_000, available: true, tags: [] },
+      ],
+    });
+
+    mockSpawn.mockClear();
+    refreshInBackground("google");
+    await settle();
+    // A plain ask is still held. That part of the brake is the point of it.
+    expect(spawnedProviders()).not.toContain("google");
+
+    const body = await get("google", "&refresh=1");
+    // Two things, and the second is the one that was missing: the fork starts,
+    // AND the response tells the picker an answer is on its way, so something
+    // is left asking for it.
+    await vi.waitFor(() => expect(spawnedProviders()).toContain("google"), { timeout: 2000 });
+    expect(body.warming).toBe(true);
+    expect(body.source).toBeUndefined();
+
+    // And the live rows land, replacing the curated ones.
+    const ids = await publishedIds("google", 2);
+    expect(ids.sort()).toEqual(["gemini-2.5-flash", "gemini-3-pro"]);
+  });
+});
+
+describe("catalog — OpenRouter publishes the capability, so the guess is not used", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+  });
+
+  /**
+   * Rows and modalities as `https://openrouter.ai/api/v1/models` reported them
+   * on 2026-09-02 (423 rows; every one carries `output_modalities` — 408
+   * `["text"]`, 11 `["image","text"]`, 4 `["audio","text"]`).
+   */
+  const OPENROUTER_LIVE = {
+    data: [
+      { id: "anthropic/claude-opus-5", name: "Claude Opus 5", context_length: 1_000_000,
+        architecture: { input_modalities: ["text"], output_modalities: ["text"] } },
+      // Image SKUs. NONE of these matched the original name pattern — the
+      // measurement that sent this PR back.
+      { id: "google/gemini-2.5-flash-image", name: "Gemini 2.5 Flash Image", context_length: 32_768,
+        architecture: { input_modalities: ["text", "image"], output_modalities: ["image", "text"] } },
+      { id: "openai/gpt-5-image", name: "GPT-5 Image", context_length: 400_000,
+        architecture: { input_modalities: ["text"], output_modalities: ["image", "text"] } },
+      // Audio out. It is not a text-output chat model, whatever its name reads
+      // like: `openai/gpt-audio` reports `["audio","text"]` out.
+      { id: "openai/gpt-audio", name: "GPT Audio", context_length: 128_000,
+        architecture: { input_modalities: ["text", "audio"], output_modalities: ["audio", "text"] } },
+      // The meta ROUTER. Its modalities are the union over everything it can
+      // route to, not a claim about one model, so the modality test does not
+      // apply to it and it stays in the picker.
+      { id: "openrouter/auto", name: "Auto Router", context_length: 2_000_000,
+        architecture: { input_modalities: ["text", "image"], output_modalities: ["image", "text"] } },
+      // A text-output model whose NAME matches the fallback pattern. The field
+      // is the answer for this catalogue, so the guess never runs on it.
+      { id: "some-lab/chat-image-2", name: "Chat Image 2", context_length: 128_000,
+        architecture: { input_modalities: ["text"], output_modalities: ["text"] } },
+    ],
+  };
+
+  it("drops what the field calls non-text, keeps the router, and keeps a text model the name rule would hide", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => OPENROUTER_LIVE,
+    })));
+
+    refreshInBackground("openrouter");
+    const ids = await publishedIds("openrouter", 3);
+
+    expect(ids.sort()).toEqual([
+      "anthropic/claude-opus-5",
+      "openrouter/auto",
+      "some-lab/chat-image-2",
+    ]);
+    expect(ids).not.toContain("google/gemini-2.5-flash-image");
+    expect(ids).not.toContain("openai/gpt-5-image");
+    expect(ids).not.toContain("openai/gpt-audio");
   });
 });

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -1,0 +1,282 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fs from "fs";
+import path from "path";
+import { NextRequest } from "next/server";
+
+// M-05 / TASK-653 — "I want the latest and the correct (usable) models to be
+// pulled, not hard-coded."
+//
+// The harness already answers that question: `openclaw models list --provider
+// <id> --all --json` is the catalogue (docs.openclaw.ai/cli/models,
+// /concepts/models — bundled + plugin-captured + a remote refresh every 6h).
+// This route proxies it, and that part was right.
+//
+// What went wrong on the box, 2026-09-02 07:13: the Anthropic plugin was
+// disabled, the live query came back with one row, and the route appended the
+// curated cold-start list from provider-models.ts and wrote the result to
+// data/catalog-cache/anthropic.json as though a device had reported it. The
+// file then looked fresh for the whole 6h refresh interval, so the chat picker
+// offered exactly three Claude models for the rest of the day while the box
+// could run eleven. The same path turned "[catalog] refreshed codex: 0 models"
+// into a persisted copy of the six hard-coded CODEX_MODELS.
+//
+// Three rules follow, and this file pins them:
+//   1. a payload built from the static list is never persisted as a live one;
+//   2. a live enumeration that returns nothing is not a success;
+//   3. a cached payload that is not a live enumeration is refreshed on the
+//      next request, and the live list replaces it.
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: () => "openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+const DATA_DIR = "/tmp/clawbox-catalog-live-fallback-test";
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-live-fallback-test" }));
+
+import { GET, refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+/** Minimal stand-in for the openclaw child process the route drives. */
+function fakeChild(json: unknown, stderr = "") {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  queueMicrotask(() => {
+    if (stderr) child.stderr.emit("data", Buffer.from(stderr, "utf8"));
+    child.stdout.emit("data", Buffer.from(JSON.stringify(json), "utf8"));
+    child.emit("close", 0);
+  });
+  return child;
+}
+
+/**
+ * `openclaw models list --provider anthropic --all --json` as the box answered
+ * it once the plugin was enabled again: eleven rows, every one `available`.
+ */
+const ANTHROPIC_LIVE = {
+  count: 11,
+  models: [
+    { key: "anthropic/claude-fable-5", name: "Claude Fable 5", contextWindow: 1_000_000, available: true, tags: [] },
+    { key: "anthropic/claude-fable-5-1", name: "Claude Fable 5.1", contextWindow: 1_000_000, available: true, tags: [] },
+    { key: "anthropic/claude-opus-5", name: "Claude Opus 5", contextWindow: 1_000_000, available: true, tags: [] },
+    { key: "anthropic/claude-opus-4-8", name: "Claude Opus 4.8", contextWindow: 1_000_000, available: true, tags: [] },
+    { key: "anthropic/claude-opus-4-7", name: "Claude Opus 4.7", contextWindow: 1_000_000, available: true, tags: [] },
+    { key: "anthropic/claude-opus-4-6", name: "Claude Opus 4.6", contextWindow: 1_000_000, available: true, tags: [] },
+    { key: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5", contextWindow: 1_000_000, available: true, tags: ["default"] },
+    { key: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6", contextWindow: 200_000, available: true, tags: [] },
+    { key: "anthropic/claude-haiku-4-5", name: "Claude Haiku 4.5", contextWindow: 200_000, available: true, tags: [] },
+    { key: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5 (2025-10-01)", contextWindow: 200_000, available: true, tags: [] },
+    { key: "anthropic/claude-mythos-5", name: "Claude Mythos 5", contextWindow: 1_000_000, available: true, tags: [] },
+  ],
+};
+
+/** The same command while the Anthropic plugin was disabled: one row. */
+const ANTHROPIC_THIN = {
+  count: 1,
+  models: [
+    { key: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6", contextWindow: 200_000, available: true, tags: [] },
+  ],
+};
+
+/** Make every `openclaw models list` spawn answer with `json` (and `stderr`). */
+function mockList(json: unknown, stderr = ""): void {
+  mockSpawn.mockImplementation(
+    () => fakeChild(json, stderr) as unknown as ReturnType<typeof childProcess.spawn>,
+  );
+}
+
+function cacheFile(provider: string): string {
+  return path.join(DATA_DIR, "catalog-cache", `${provider}.json`);
+}
+
+function readCache(provider: string): { models: Array<{ id: string }>; source?: string } {
+  return JSON.parse(fs.readFileSync(cacheFile(provider), "utf8"));
+}
+
+function writeCache(provider: string, payload: unknown): void {
+  fs.mkdirSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true });
+  fs.writeFileSync(cacheFile(provider), JSON.stringify(payload), "utf8");
+}
+
+async function get(provider: string, params = ""): Promise<Record<string, unknown>> {
+  const url = `http://clawbox.local/setup-api/ai-models/catalog?provider=${provider}${params}`;
+  const res = await GET(new NextRequest(url));
+  return (await res.json()) as Record<string, unknown>;
+}
+
+/** Ids in the payload the route published for `provider`. */
+async function publishedIds(provider: string, expected: number): Promise<string[]> {
+  let ids: string[] = [];
+  await vi.waitFor(() => {
+    if (!fs.existsSync(cacheFile(provider))) {
+      refreshInBackground(provider);
+      throw new Error("not published yet");
+    }
+    ids = readCache(provider).models.map((m) => m.id);
+    expect(ids).toHaveLength(expected);
+  }, { timeout: 4000, interval: 25 });
+  return ids;
+}
+
+describe("catalog — a fallback is never served as a live enumeration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+  });
+
+  // FIRST in the file on purpose: it is the only test that needs the route's
+  // process-local memCache to be empty for anthropic, and nothing resets it.
+  it("re-reads a cached payload that no live enumeration produced, and the live list replaces it", async () => {
+    // What the box actually had on disk at 07:13 — the three hard-coded
+    // ANTHROPIC_MODELS, stamped with a fresh `fetchedAt` so the 6h staleness
+    // check saw nothing wrong with it.
+    writeCache("anthropic", {
+      provider: "anthropic",
+      models: [
+        { id: "claude-opus-5", label: "Claude Opus 5", contextWindow: 1_000_000 },
+        { id: "claude-sonnet-5", label: "Claude Sonnet 5", contextWindow: 1_000_000 },
+        { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", contextWindow: 200_000 },
+      ],
+      defaultModelId: "claude-sonnet-5",
+      allowCustom: true,
+      fetchedAt: Date.now(),
+    });
+    mockList(ANTHROPIC_LIVE);
+
+    const first = await get("anthropic");
+    // It is served — a blank picker helps nobody — but it says what it is.
+    expect(first.fallback).toBe(true);
+    expect((first.models as unknown[]).length).toBe(3);
+
+    // And it is retried rather than trusted for the next six hours.
+    const live = await publishedIds("anthropic", 11);
+    expect(live).toContain("claude-fable-5");
+    expect(live).toContain("claude-opus-4-8");
+
+    const second = await get("anthropic");
+    expect(second.fallback).toBeFalsy();
+    expect((second.models as Array<{ id: string }>).map((m) => m.id)).toHaveLength(11);
+  });
+
+  it("never appends the curated list to a thin live enumeration", async () => {
+    mockList(ANTHROPIC_THIN);
+    refreshInBackground("anthropic");
+
+    const ids = await publishedIds("anthropic", 1);
+    expect(ids).toEqual(["claude-sonnet-4-6"]);
+    // The curated cold-start ids must not be in a file the picker and the
+    // server-side surface guard both read back as a device answer.
+    expect(ids).not.toContain("claude-opus-5");
+    expect(readCache("anthropic").source).toBe("live");
+  });
+
+  it("does not persist anything when the live enumeration returns no models", async () => {
+    mockList(
+      { count: 0, models: [] },
+      "Unknown provider filter: google\n",
+    );
+
+    refreshInBackground("google");
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled(), { timeout: 2000 });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // Zero models is not an answer about what the box can run. Writing the six
+    // curated ids here is what made "[catalog] refreshed codex: 0 models" look
+    // like a successful refresh.
+    expect(fs.existsSync(cacheFile("google"))).toBe(false);
+  });
+});
+
+describe("catalog — the ChatGPT surface is the openai catalogue", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+  });
+
+  // `codex` was a provider id in the OpenClaw core through 2026.6.x. It is
+  // gone in 2026.8.1 — `openclaw models list --provider codex` answers
+  // "Unknown provider filter" — and a ChatGPT subscription is now an `openai`
+  // OAuth profile serving `openai/*` (docs.openclaw.ai/concepts/models,
+  // `openclaw models auth login --provider openai`). So the rows the ChatGPT
+  // route can run have to be enumerated from `openai` and narrowed by the
+  // documented ChatGPT-account allowlist, not read out of a hard-coded list.
+  it("enumerates openai and narrows it to what a ChatGPT account can run", async () => {
+    mockList({
+      count: 6,
+      models: [
+        { key: "openai/gpt-5.5", name: "GPT-5.5", contextWindow: 400_000, available: true, tags: [] },
+        { key: "openai/gpt-5.5-pro", name: "GPT-5.5 Pro", contextWindow: 400_000, available: true, tags: [] },
+        { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 1_000_000, available: true, tags: [] },
+        { key: "openai/gpt-5.4-mini", name: "GPT-5.4 Mini", contextWindow: 1_000_000, available: true, tags: [] },
+        { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: [] },
+        { key: "openai/gpt-image-1-mini", name: "GPT Image 1 Mini", contextWindow: 0, available: true, tags: [] },
+      ],
+    });
+
+    refreshInBackground("codex");
+    const ids = await publishedIds("codex", 4);
+
+    const providerArgs = mockSpawn.mock.calls
+      .map((call) => (call[1] as string[]))
+      .map((args) => args[args.indexOf("--provider") + 1]);
+    expect(providerArgs).toContain("openai");
+    expect(providerArgs).not.toContain("codex");
+
+    expect(ids.sort()).toEqual(["gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.6-sol"]);
+  });
+
+  // The API-key surface is NOT the ChatGPT one and must not borrow its
+  // narrowing — nor the generation allowlist that used to sit on it. On a
+  // stock 2026.8.1 host `openclaw models list --provider openai --all --json`
+  // answers with exactly one row, `openai/gpt-5.6-sol`, tagged default: the
+  // old /^gpt-5\.[45](-pro|-mini)?$/ matched none of it, so the box's whole
+  // openai catalogue was filtered away and the picker fell back to five
+  // hand-written ids.
+  it("publishes the newest generation the box lists, and skips the image SKUs", async () => {
+    mockList({
+      count: 4,
+      models: [
+        { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: ["default"] },
+        { key: "openai/gpt-5.5-pro", name: "GPT-5.5 Pro", contextWindow: 400_000, available: true, tags: [] },
+        { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 1_000_000, available: true, tags: [] },
+        // Listed by the same command, unusable by a chat picker, and the
+        // harness offers no capability filter to ask it apart.
+        { key: "openai/gpt-image-1-mini", name: "GPT Image 1 Mini", contextWindow: 0, available: true, tags: [] },
+      ],
+    });
+
+    refreshInBackground("openai");
+    const ids = await publishedIds("openai", 3);
+    expect(ids.sort()).toEqual(["gpt-5.4", "gpt-5.5-pro", "gpt-5.6-sol"]);
+  });
+
+  it("drops a row the harness itself reports as unavailable, and keeps an undetermined one", async () => {
+    // `available` is the harness's verdict on whether the row is in the
+    // catalogue this box resolved (docs.openclaw.ai/concepts/models), not a
+    // credential check — `null` is what an unconfigured host answers for every
+    // row, and hiding those would empty the picker during setup.
+    mockList({
+      count: 3,
+      models: [
+        { key: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash", contextWindow: 1_000_000, available: true, tags: [] },
+        { key: "google/gemini-2.5-pro", name: "Gemini 2.5 Pro", contextWindow: 1_000_000, available: null, tags: [] },
+        { key: "google/gemini-1.0-pro", name: "Gemini 1.0 Pro", contextWindow: 32_000, available: false, tags: [] },
+      ],
+    });
+
+    refreshInBackground("google");
+    const ids = await publishedIds("google", 2);
+    expect(ids.sort()).toEqual(["gemini-2.5-pro", "gemini-3.5-flash"]);
+  });
+});

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -237,8 +237,14 @@ describe("catalog — a fallback is never served as a live enumeration", () => {
     });
 
     refreshInBackground("google");
-    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled(), { timeout: 2000 });
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    // The GOOGLE spawn, not any spawn: the boot warmup forks unrelated
+    // providers on real timers (which is why `spawnedProviders` exists at the
+    // top of this file), and waiting on the raw mock could be satisfied by one
+    // of those before this fork had started — after which the settle below
+    // could end before the empty enumeration was handled, and the assertion
+    // would pass on an absent cache file that nothing had tried to write yet.
+    await vi.waitFor(() => expect(spawnedProviders()).toContain("google"), { timeout: 2000 });
+    await settle();
 
     // Zero models is not an answer about what the box can run. Writing the
     // curated ids here is what made "[catalog] refreshed codex: 0 models" look

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -129,6 +129,19 @@ async function publishedIds(provider: string, expected: number): Promise<string[
   return ids;
 }
 
+// The first GET in this file starts the route's module-level `bootWarmup`,
+// which schedules a refresh for every CATALOG_PROVIDERS entry (clawai at 0ms,
+// then 5s apart) and cannot be reset between tests. Two consequences are
+// handled here rather than tolerated: the openrouter warmup would make a REAL
+// request to openrouter.ai, so fetch is stubbed; and a late google timer could
+// write that provider's cache, so the assertion below is about the CONTENT the
+// route would have persisted, not about a file existing.
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn(async () => {
+    throw new Error("no network in this suite");
+  }));
+});
+
 describe("catalog — a fallback is never served as a live enumeration", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -198,49 +211,66 @@ describe("catalog — a fallback is never served as a live enumeration", () => {
     await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled(), { timeout: 2000 });
     await new Promise((resolve) => setTimeout(resolve, 200));
 
-    // Zero models is not an answer about what the box can run. Writing the six
+    // Zero models is not an answer about what the box can run. Writing the
     // curated ids here is what made "[catalog] refreshed codex: 0 models" look
     // like a successful refresh.
-    expect(fs.existsSync(cacheFile("google"))).toBe(false);
+    const persisted = fs.existsSync(cacheFile("google"))
+      ? readCache("google").models.map((m) => m.id)
+      : [];
+    expect(persisted).toEqual([]);
   });
 });
 
-describe("catalog — the ChatGPT surface is the openai catalogue", () => {
+describe("catalog — the ChatGPT surface has no enumeration on this core", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
   });
 
-  // `codex` was a provider id in the OpenClaw core through 2026.6.x. It is
-  // gone in 2026.8.1 — `openclaw models list --provider codex` answers
-  // "Unknown provider filter" — and a ChatGPT subscription is now an `openai`
-  // OAuth profile serving `openai/*` (docs.openclaw.ai/concepts/models,
-  // `openclaw models auth login --provider openai`). So the rows the ChatGPT
-  // route can run have to be enumerated from `openai` and narrowed by the
-  // documented ChatGPT-account allowlist, not read out of a hard-coded list.
-  it("enumerates openai and narrows it to what a ChatGPT account can run", async () => {
+  // `codex` is gone from the OpenClaw 2 core, so the obvious move is to serve
+  // its picker from the `openai` catalogue narrowed by the ChatGPT-account
+  // allowlist. That would be a WRONG live list, not a live list: the openai
+  // catalogue is not plan-scoped — it carries gpt-5.6-sol on any box, and
+  // gpt-5.6 is plan-gated upstream — so a Free account would be offered it as
+  // the only row AND handed it as the saved default, and every turn would 400.
+  // Replacing a hard-coded list with a wrong one is the same defect pointed the
+  // other way, so this catalogue enumerates nothing and says so.
+  it("does not synthesise a ChatGPT catalogue out of the openai one", async () => {
     mockList({
-      count: 6,
-      models: [
-        { key: "openai/gpt-5.5", name: "GPT-5.5", contextWindow: 400_000, available: true, tags: [] },
-        { key: "openai/gpt-5.5-pro", name: "GPT-5.5 Pro", contextWindow: 400_000, available: true, tags: [] },
-        { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 1_000_000, available: true, tags: [] },
-        { key: "openai/gpt-5.4-mini", name: "GPT-5.4 Mini", contextWindow: 1_000_000, available: true, tags: [] },
-        { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: [] },
-        { key: "openai/gpt-image-1-mini", name: "GPT Image 1 Mini", contextWindow: 0, available: true, tags: [] },
-      ],
+      ok: false,
+      error: {
+        type: "cli_error",
+        message: 'Unknown provider filter "codex" for this installation.',
+      },
     });
 
     refreshInBackground("codex");
-    const ids = await publishedIds("codex", 4);
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled(), { timeout: 2000 });
+    await new Promise((resolve) => setTimeout(resolve, 200));
 
     const providerArgs = mockSpawn.mock.calls
       .map((call) => (call[1] as string[]))
       .map((args) => args[args.indexOf("--provider") + 1]);
-    expect(providerArgs).toContain("openai");
-    expect(providerArgs).not.toContain("codex");
+    expect(providerArgs).not.toContain("openai");
+    expect(fs.existsSync(cacheFile("codex"))).toBe(false);
+  });
 
-    expect(ids.sort()).toEqual(["gpt-5.4", "gpt-5.4-mini", "gpt-5.5", "gpt-5.6-sol"]);
+  it("serves the curated ChatGPT list marked fallback, in its curated order", async () => {
+    const body = await get("codex");
+
+    expect(body.fallback).toBe(true);
+    // Curated newest-first, and it stays that way: sorting by context window
+    // put GPT-5.4 at the top, because only the Anthropic ids carry a real
+    // window in the cold-start table.
+    expect((body.models as Array<{ id: string }>).map((m) => m.id)).toEqual([
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+      "gpt-5.5",
+      "gpt-5.4",
+      "gpt-5.4-mini",
+    ]);
+    expect(body.defaultModelId).toBe("gpt-5.5");
   });
 
   // The API-key surface is NOT the ChatGPT one and must not borrow its
@@ -269,21 +299,55 @@ describe("catalog — the ChatGPT surface is the openai catalogue", () => {
   });
 
   it("drops a row the harness itself reports as unavailable, and keeps an undetermined one", async () => {
-    // `available` is the harness's verdict on whether the row is in the
-    // catalogue this box resolved (docs.openclaw.ai/concepts/models), not a
-    // credential check — `null` is what an unconfigured host answers for every
-    // row, and hiding those would empty the picker during setup.
+    // `available` is tristate — it mirrors the CLI's Auth column (`ok` /
+    // `unknown` / `unavailable`). `null` is what an unconfigured host answers
+    // for every row, and hiding those would empty the picker during setup.
+    // Runs on openai because the previous test published it successfully,
+    // which clears the failed-refresh backoff; google is still serving one.
     mockList({
       count: 3,
       models: [
-        { key: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash", contextWindow: 1_000_000, available: true, tags: [] },
-        { key: "google/gemini-2.5-pro", name: "Gemini 2.5 Pro", contextWindow: 1_000_000, available: null, tags: [] },
-        { key: "google/gemini-1.0-pro", name: "Gemini 1.0 Pro", contextWindow: 32_000, available: false, tags: [] },
+        { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: [] },
+        { key: "openai/gpt-5.5", name: "GPT-5.5", contextWindow: 400_000, available: null, tags: [] },
+        { key: "openai/gpt-4.1", name: "GPT-4.1", contextWindow: 128_000, available: false, tags: [] },
       ],
     });
 
-    refreshInBackground("google");
-    const ids = await publishedIds("google", 2);
-    expect(ids.sort()).toEqual(["gemini-2.5-pro", "gemini-3.5-flash"]);
+    refreshInBackground("openai");
+    const ids = await publishedIds("openai", 2);
+    expect(ids.sort()).toEqual(["gpt-5.5", "gpt-5.6-sol"]);
+  });
+});
+
+describe("catalog — a provider that cannot answer is not asked on every request", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+  });
+
+  // `openclaw models list` costs ~3 minutes and ~2 cores on a Jetson. The rule
+  // "a payload no device produced is a reason to ask again" would, on a
+  // provider that can NEVER enumerate, turn every picker open into another
+  // fork — and the client retries twelve times with `refresh=1`. The
+  // single-flight set only collapses the concurrent ones.
+  it("backs off after an enumeration that did not answer", async () => {
+    mockList({
+      ok: false,
+      error: { type: "cli_error", message: "the anthropic plugin is disabled" },
+    });
+
+    // anthropic, because the backoff map is module state: google and codex are
+    // already serving one from the tests above, while anthropic's last refresh
+    // in this file succeeded and therefore cleared it. This describe is last,
+    // so leaving anthropic backed off costs nothing.
+    refreshInBackground("anthropic");
+    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalledTimes(1), { timeout: 2000 });
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    mockSpawn.mockClear();
+    refreshInBackground("anthropic");
+    refreshInBackground("anthropic");
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -115,6 +115,25 @@ async function get(provider: string, params = ""): Promise<Record<string, unknow
   return (await res.json()) as Record<string, unknown>;
 }
 
+/**
+ * The provider each `openclaw models list` spawn was for.
+ *
+ * Read instead of the raw call count because the module-level boot warmup
+ * schedules a refresh for every provider on real timers, so an unrelated one
+ * can land inside a test's window.
+ */
+function spawnedProviders(): string[] {
+  return mockSpawn.mock.calls.map((call) => {
+    const args = call[1] as string[];
+    return args[args.indexOf("--provider") + 1];
+  });
+}
+
+/** Let a detached refresh get as far as it is going to get. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 200));
+}
+
 /** Ids in the payload the route published for `provider`. */
 async function publishedIds(provider: string, expected: number): Promise<string[]> {
   let ids: string[] = [];
@@ -136,6 +155,14 @@ async function publishedIds(provider: string, expected: number): Promise<string[
 // request to openrouter.ai, so fetch is stubbed; and a late google timer could
 // write that provider's cache, so the assertion below is about the CONTENT the
 // route would have persisted, not about a file existing.
+//
+// Deliberately NOT paired with an `unstubAllGlobals` teardown. The stub cannot
+// leak: vitest runs each test file in its own isolated environment (`isolate`
+// defaults to true and this project overrides neither it nor `pool`), so it
+// dies with this file. Unstubbing between tests would instead OPEN the hole —
+// those warmup timers are real and fire on the wall clock, including in the gap
+// between an `afterEach` and the next `beforeEach`, which is the one window a
+// real openrouter.ai request could slip through.
 beforeEach(() => {
   vi.stubGlobal("fetch", vi.fn(async () => {
     throw new Error("no network in this suite");
@@ -168,8 +195,10 @@ describe("catalog — a fallback is never served as a live enumeration", () => {
     mockList(ANTHROPIC_LIVE);
 
     const first = await get("anthropic");
-    // It is served — a blank picker helps nobody — but it says what it is.
-    expect(first.fallback).toBe(true);
+    // It is served — a blank picker helps nobody — but it carries no
+    // `source: "live"`, and that absence is what tells the client what it is
+    // holding. One marker, so two cannot disagree.
+    expect(first.source).toBeUndefined();
     expect((first.models as unknown[]).length).toBe(3);
 
     // And it is retried rather than trusted for the next six hours.
@@ -178,7 +207,7 @@ describe("catalog — a fallback is never served as a live enumeration", () => {
     expect(live).toContain("claude-opus-4-8");
 
     const second = await get("anthropic");
-    expect(second.fallback).toBeFalsy();
+    expect(second.source).toBe("live");
     expect((second.models as Array<{ id: string }>).map((m) => m.id)).toHaveLength(11);
   });
 
@@ -235,30 +264,22 @@ describe("catalog — the ChatGPT surface has no enumeration on this core", () =
   // the only row AND handed it as the saved default, and every turn would 400.
   // Replacing a hard-coded list with a wrong one is the same defect pointed the
   // other way, so this catalogue enumerates nothing and says so.
-  it("does not synthesise a ChatGPT catalogue out of the openai one", async () => {
-    mockList({
-      ok: false,
-      error: {
-        type: "cli_error",
-        message: 'Unknown provider filter "codex" for this installation.',
-      },
-    });
-
+  it("does not synthesise a ChatGPT catalogue out of the openai one, and does not ask", async () => {
     refreshInBackground("codex");
-    await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled(), { timeout: 2000 });
     await new Promise((resolve) => setTimeout(resolve, 200));
 
-    const providerArgs = mockSpawn.mock.calls
-      .map((call) => (call[1] as string[]))
-      .map((args) => args[args.indexOf("--provider") + 1]);
-    expect(providerArgs).not.toContain("openai");
+    // Not from openai — and not from `codex` either. The CLI's answer is known
+    // and written down; forking a whole openclaw process on a Jetson at every
+    // boot, and again once per backoff window, to be told
+    // `Unknown provider filter "codex"` buys nothing.
+    expect(mockSpawn).not.toHaveBeenCalled();
     expect(fs.existsSync(cacheFile("codex"))).toBe(false);
   });
 
   it("serves the curated ChatGPT list marked fallback, in its curated order", async () => {
     const body = await get("codex");
 
-    expect(body.fallback).toBe(true);
+    expect(body.source).toBeUndefined();
     // Curated newest-first, and it stays that way: sorting by context window
     // put GPT-5.4 at the top, because only the Anthropic ids carry a real
     // window in the cold-start table.
@@ -349,5 +370,50 @@ describe("catalog — a provider that cannot answer is not asked on every reques
     refreshInBackground("anthropic");
     await new Promise((resolve) => setTimeout(resolve, 200));
     expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  // A wait that does not GROW is not a backoff. Deriving the last wait from the
+  // stored DEADLINE cannot grow: an attempt only gets past the guard once that
+  // deadline has passed, so `deadline - now` is negative by the time the next
+  // failure records it, and the doubling collapses to the two-minute floor
+  // forever — the flat 2-minute fork loop this brake exists to bound.
+  //
+  // Only `Date` is faked. The route's own waits are real (the mocked child
+  // settles on a microtask), and faking the timer queue as well would stop the
+  // module-level boot warmup that the rest of this file runs against.
+  it("doubles the wait after each attempt that does not answer", async () => {
+    mockList({
+      ok: false,
+      error: { type: "cli_error", message: "the anthropic plugin is disabled" },
+    });
+
+    vi.useFakeTimers({ toFake: ["Date"] });
+    try {
+      // anthropic is two minutes into a backoff from the test above, which is
+      // where the sequence starts: the wait after THIS failure must be four.
+      const t0 = Date.now();
+      vi.setSystemTime(t0 + 2 * 60_000 + 1_000);
+
+      mockSpawn.mockClear();
+      refreshInBackground("anthropic");
+      await settle();
+      expect(spawnedProviders()).toContain("anthropic");
+
+      // Two more minutes is no longer enough.
+      vi.setSystemTime(Date.now() + 2 * 60_000 + 1_000);
+      mockSpawn.mockClear();
+      refreshInBackground("anthropic");
+      await settle();
+      expect(spawnedProviders()).not.toContain("anthropic");
+
+      // Four is.
+      vi.setSystemTime(Date.now() + 2 * 60_000 + 1_000);
+      mockSpawn.mockClear();
+      refreshInBackground("anthropic");
+      await settle();
+      expect(spawnedProviders()).toContain("anthropic");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -182,10 +182,17 @@ describe("catalog — a fallback is never served as a live enumeration", () => {
   });
 
   it("does not persist anything when the live enumeration returns no models", async () => {
-    mockList(
-      { count: 0, models: [] },
-      "Unknown provider filter: google\n",
-    );
+    // The real shape of a refusal, measured on 2026.8.1: `{ok: false, error}`
+    // on STDOUT, empty stderr, exit code 0. Reading the exit code alone would
+    // call this a successful refresh — which is precisely what
+    // "[catalog] refreshed codex: 0 models" was.
+    mockList({
+      ok: false,
+      error: {
+        type: "cli_error",
+        message: 'Unknown provider filter "google" for this installation.',
+      },
+    });
 
     refreshInBackground("google");
     await vi.waitFor(() => expect(mockSpawn).toHaveBeenCalled(), { timeout: 2000 });

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -483,11 +483,15 @@ describe("catalog — a provider that cannot answer is not asked on every reques
     // A plain ask is still held. That part of the brake is the point of it.
     expect(spawnedProviders()).not.toContain("google");
 
-    const body = await get("google", "&refresh=1");
-    // Two things, and the second is the one that was missing: the fork starts,
-    // AND the response tells the picker an answer is on its way, so something
-    // is left asking for it.
+    // The connect, counted server-side — `notifyProviderSetChanged` is the one
+    // caller shape that says "the provider set changed". A client's
+    // `?refresh=1` deliberately cannot do this any more.
+    refreshInBackground("google", { providerChanged: true });
     await vi.waitFor(() => expect(spawnedProviders()).toContain("google"), { timeout: 2000 });
+
+    // And the response tells the picker an answer is on its way, so something
+    // is left asking for it.
+    const body = await get("google");
     expect(body.warming).toBe(true);
     expect(body.source).toBeUndefined();
 

--- a/src/tests/routes/ai-models/catalog-provider-change.test.ts
+++ b/src/tests/routes/ai-models/catalog-provider-change.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fs from "fs";
+import path from "path";
+import { NextRequest } from "next/server";
+
+// A PROVIDER-SET CHANGE — a key saved, a plugin switched on — is not a client
+// polling for an answer, and the route has to tell them apart in two places.
+// This file pins both, in its own module so neither depends on what an earlier
+// test left in `memCache`, `refreshing` or the backoff map.
+//
+// The timing that makes finding 1 the common case rather than a race:
+// `bootWarmup` starts on the FIRST picker GET, not at boot, and staggers the
+// providers 5s apart at ~3 minutes each on a Jetson. A key saved a minute after
+// the AI-models step opens therefore lands inside its provider's window.
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: () => "openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+const DATA_DIR = "/tmp/clawbox-catalog-provider-change-test";
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-provider-change-test" }));
+
+import { GET, refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+function newChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  return child;
+}
+
+function fakeChild(json: unknown) {
+  const child = newChild();
+  queueMicrotask(() => {
+    child.stdout.emit("data", Buffer.from(JSON.stringify(json), "utf8"));
+    child.emit("close", 0);
+  });
+  return child;
+}
+
+/**
+ * A child that has been started but has not answered yet — an `openclaw models
+ * list` fork mid-flight, which on a Jetson is a ~3-minute state, not an instant.
+ */
+function heldChild(json: unknown) {
+  const child = newChild();
+  return {
+    child,
+    release() {
+      child.stdout.emit("data", Buffer.from(JSON.stringify(json), "utf8"));
+      child.emit("close", 0);
+    },
+  };
+}
+
+/** `openclaw models list --provider openai` on a stock host: one row. */
+const PRE_KEY = {
+  count: 1,
+  models: [
+    { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: ["default"] },
+  ],
+};
+
+/** The same command once the key is saved and the plugin is on. */
+const LINKED = {
+  count: 3,
+  models: [
+    { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: ["default"] },
+    { key: "openai/gpt-5.5", name: "GPT-5.5", contextWindow: 400_000, available: true, tags: [] },
+    { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 1_000_000, available: true, tags: [] },
+  ],
+};
+
+function cacheFile(provider: string): string {
+  return path.join(DATA_DIR, "catalog-cache", `${provider}.json`);
+}
+
+function readCache(provider: string): { models: Array<{ id: string }>; source?: string } {
+  return JSON.parse(fs.readFileSync(cacheFile(provider), "utf8"));
+}
+
+async function get(provider: string, params = ""): Promise<Record<string, unknown>> {
+  const res = await GET(new NextRequest(
+    `http://clawbox.local/setup-api/ai-models/catalog?provider=${provider}${params}`,
+  ));
+  return (await res.json()) as Record<string, unknown>;
+}
+
+/** Let a detached refresh get as far as it is going to get. */
+function settle(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 200));
+}
+
+beforeEach(() => {
+  // The boot warmup would otherwise make a real request to openrouter.ai. Left
+  // installed for the file's lifetime on purpose — see the note in
+  // catalog-live-vs-fallback.test.ts.
+  vi.stubGlobal("fetch", vi.fn(async () => {
+    throw new Error("no network in this suite");
+  }));
+  vi.clearAllMocks();
+  fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+});
+
+describe("catalog — a connect on a provider that already has a live catalogue", () => {
+  // `warming` used to be suppressed whenever the cached payload was live. That
+  // clause is what keeps a routine 6h refresh from making every mounted picker
+  // poll — but it also hid the one case that matters: the box just changed and
+  // an enumeration IS in flight. `useProviderCatalog` polls on `warming` alone,
+  // so it read once, settled, and the post-credential list landed minutes later
+  // with nobody asking. The customer saw the old list until a remount.
+  it("says an answer is coming, rather than serving the pre-connect rows in silence", async () => {
+    mockSpawn.mockImplementation(
+      () => fakeChild(PRE_KEY) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+
+    // A clean, live, one-row catalogue — published, no fork left out.
+    refreshInBackground("openai");
+    await vi.waitFor(() => expect(fs.existsSync(cacheFile("openai"))).toBe(true), { timeout: 4000 });
+    await settle();
+
+    mockSpawn.mockImplementation(
+      () => fakeChild(LINKED) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+    const body = await get("openai", "&refresh=1");
+
+    // It serves the rows it has — they are a device's — and still says a better
+    // answer is on its way, which is the only thing that keeps the picker asking.
+    expect(body.source).toBe("live");
+    expect(body.warming).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(readCache("openai").models.map((m) => m.id).sort())
+        .toEqual(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"]);
+    }, { timeout: 4000, interval: 25 });
+  });
+});
+
+describe("catalog — a connect while an enumeration is already in flight", () => {
+  // The single-flight guard is right to collapse two enumerations that ask the
+  // same question. A connect changes the question: the fork already running was
+  // started before the credential existed. Dropped, it does worse than lose a
+  // refresh — the pre-credential answer is published with `source: "live"` and
+  // a fresh `fetchedAt`, so `force || isStale || !isLivePayload` is false
+  // against it for six hours and the marker this route introduced ends up
+  // vouching for the very thing it exists to catch. One openai row on a stock
+  // host, on a box that lists three.
+  it("re-enumerates once the in-flight fork settles, and the post-credential list is what stands", async () => {
+    const held = heldChild(PRE_KEY);
+    let openaiSpawns = 0;
+    mockSpawn.mockImplementation((_bin, args) => {
+      const argv = args as string[];
+      const target = argv[argv.indexOf("--provider") + 1];
+      if (target !== "openai") {
+        return fakeChild({ count: 0, models: [] }) as unknown as ReturnType<typeof childProcess.spawn>;
+      }
+      openaiSpawns += 1;
+      const child = openaiSpawns === 1 ? held.child : fakeChild(LINKED);
+      return child as unknown as ReturnType<typeof childProcess.spawn>;
+    });
+
+    // The warmup fork, started when the customer opened the AI models step.
+    refreshInBackground("openai");
+    await settle();
+    expect(openaiSpawns).toBe(1);
+
+    // ~45s later the key is saved. Step 8c fires this one statement after the
+    // plugin is switched on.
+    refreshInBackground("openai", { providerChanged: true });
+    await settle();
+    // Still ONE fork. Collapsing is correct; losing the change is not.
+    expect(openaiSpawns).toBe(1);
+
+    // The pre-key answer lands and publishes its single row...
+    held.release();
+
+    // ...and the change is then served against the box as it now is.
+    await vi.waitFor(() => {
+      expect(readCache("openai").models.map((m) => m.id).sort())
+        .toEqual(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"]);
+    }, { timeout: 4000, interval: 25 });
+    expect(openaiSpawns).toBe(2);
+    expect(readCache("openai").source).toBe("live");
+  });
+});

--- a/src/tests/routes/ai-models/catalog-provider-change.test.ts
+++ b/src/tests/routes/ai-models/catalog-provider-change.test.ts
@@ -134,7 +134,9 @@ describe("catalog — a connect on a provider that already has a live catalogue"
     mockSpawn.mockImplementation(
       () => fakeChild(LINKED) as unknown as ReturnType<typeof childProcess.spawn>,
     );
-    const body = await get("openai", "&refresh=1");
+    // The connect, counted by the write that made it — not by the client.
+    refreshInBackground("openai", { providerChanged: true });
+    const body = await get("openai");
 
     // It serves the rows it has — they are a device's — and still says a better
     // answer is on its way, which is the only thing that keeps the picker asking.
@@ -272,7 +274,7 @@ describe("catalog — the change generation, not a one-shot flag", () => {
   // ~3-minute `openclaw models list` — ~2 cores of a Jetson, at the wizard's
   // most latency-sensitive moment, for a question the fork already out is
   // answering post-credential.
-  it("costs one enumeration when the same change reaches the route twice", async () => {
+  it("costs one enumeration when the client echoes a change the write already counted", async () => {
     const held = heldChild({
       count: 2,
       models: [
@@ -296,9 +298,13 @@ describe("catalog — the change generation, not a one-shot flag", () => {
     await settle();
     expect(googleSpawns).toBe(1);
 
-    // The same change arriving again as the client's `?refresh=1`. The fork out
-    // there was started BY this change and is reading the box it reports.
-    refreshInBackground("google", { providerChanged: true });
+    // The same change arriving again as the client's `?refresh=1`, which is now
+    // a NUDGE: "does the current generation have an answer?". A fork for that
+    // generation is out, so there is nothing to start and nothing to count.
+    // This is what removes the duplicate ~3-minute enumeration per connect —
+    // and, unlike the predicate it replaces, it cannot swallow a real second
+    // change, because a real one comes from a write and says so.
+    refreshInBackground("google", { serveCurrent: true });
     await settle();
     expect(googleSpawns).toBe(1);
 
@@ -311,5 +317,66 @@ describe("catalog — the change generation, not a one-shot flag", () => {
     // No replacement scheduled: nothing was superseded.
     await settle();
     expect(googleSpawns).toBe(1);
+  });
+
+  // The predicate this replaces read the SHAPE of the fork in flight —
+  // change-started, current generation — rather than the identity of the
+  // signal, so it could not tell `configure`'s echo from a second, genuinely
+  // different change 30 seconds later. Both landed on the same branch, and the
+  // real one was dropped: no bump, no re-entry, and the PRE-change fork then
+  // published as the CURRENT generation — live, unstale, no `warming`, backoff
+  // cleared — so nothing re-enumerated for six hours. Two clicks reach it: a
+  // mistyped key corrected, or a provider switched off and back on.
+  it("answers a second, different change that lands inside the first enumeration", async () => {
+    const first = heldChild(PRE_KEY);
+    const second = heldChild(LINKED);
+    let spawns = 0;
+    mockSpawn.mockImplementation((_bin, args) => {
+      const argv = args as string[];
+      const target = argv[argv.indexOf("--provider") + 1];
+      if (target !== "openai") {
+        return fakeChild({ count: 0, models: [] }) as unknown as ReturnType<typeof childProcess.spawn>;
+      }
+      spawns += 1;
+      const child = spawns === 1 ? first.child : second.child;
+      return child as unknown as ReturnType<typeof childProcess.spawn>;
+    });
+
+    // Key A saved. Generation 1, fork F1.
+    refreshInBackground("openai", { providerChanged: true });
+    await settle();
+    expect(spawns).toBe(1);
+
+    // The client's echo of that same change. Correctly nothing: it is a nudge,
+    // and the generation it asks about already has a fork.
+    refreshInBackground("openai", { serveCurrent: true });
+    await settle();
+    expect(spawns).toBe(1);
+
+    // ~30s later the owner does a SECOND thing to this provider — corrects the
+    // key and saves again, or flips the Settings switch off and back on. A
+    // different write, so a different generation.
+    refreshInBackground("openai", { providerChanged: true });
+    await settle();
+    // Still collapsed while F1 runs; single-flight is right.
+    expect(spawns).toBe(1);
+
+    // F1 answers for the box as it was two changes ago, so it is discarded and
+    // the current generation is enumerated instead.
+    first.release();
+    await vi.waitFor(() => expect(spawns).toBe(2), { timeout: 4000, interval: 25 });
+    expect(fs.existsSync(cacheFile("openai"))).toBe(false);
+
+    second.release();
+    await vi.waitFor(() => {
+      expect(readCache("openai").models.map((m) => m.id).sort())
+        .toEqual(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"]);
+    }, { timeout: 4000, interval: 25 });
+    expect(spawns).toBe(2);
+
+    // And once the current generation is answered, the asking stops.
+    const settled = await get("openai");
+    expect(settled.warming).toBeUndefined();
+    expect(settled.source).toBe("live");
   });
 });

--- a/src/tests/routes/ai-models/catalog-provider-change.test.ts
+++ b/src/tests/routes/ai-models/catalog-provider-change.test.ts
@@ -195,3 +195,121 @@ describe("catalog — a connect while an enumeration is already in flight", () =
     expect(readCache("openai").source).toBe("live");
   });
 });
+
+
+describe("catalog — the change generation, not a one-shot flag", () => {
+  // Scenario (a). `|| force` made exactly ONE response say `warming` — the
+  // single `?refresh=1` the hook sends per provider-set signal. Its next poll
+  // is `load(false)` two seconds later, and got `warming: false` while the
+  // enumeration still had ~3 minutes to run, so a picker open across a connect
+  // settled on the pre-change rows. And the superseded PRE-credential fork was
+  // still published with `source: "live"` and a fresh `fetchedAt` one line
+  // before its replacement was scheduled, so every client arriving in that
+  // window was handed it as final: the same false success, shortened rather
+  // than removed.
+  it("keeps saying an answer is coming on every poll, and never publishes the superseded fork", async () => {
+    const preKey = heldChild(PRE_KEY);
+    const postKey = heldChild(LINKED);
+    let openaiSpawns = 0;
+    mockSpawn.mockImplementation((_bin, args) => {
+      const argv = args as string[];
+      const target = argv[argv.indexOf("--provider") + 1];
+      if (target !== "openai") {
+        return fakeChild({ count: 0, models: [] }) as unknown as ReturnType<typeof childProcess.spawn>;
+      }
+      openaiSpawns += 1;
+      const child = openaiSpawns === 1 ? preKey.child : postKey.child;
+      return child as unknown as ReturnType<typeof childProcess.spawn>;
+    });
+
+    // The warmup fork, started when the customer opened the AI models step.
+    refreshInBackground("openai");
+    await settle();
+    expect(openaiSpawns).toBe(1);
+
+    // The key is saved while it is still out.
+    refreshInBackground("openai", { providerChanged: true });
+    await settle();
+    expect(openaiSpawns).toBe(1);
+
+    // The pre-credential fork answers. Its rows describe a box that no longer
+    // exists, so nothing is published — not to disk, and above all not stamped
+    // live. The replacement starts instead.
+    preKey.release();
+    await vi.waitFor(() => expect(openaiSpawns).toBe(2), { timeout: 4000, interval: 25 });
+    expect(fs.existsSync(cacheFile("openai"))).toBe(false);
+
+    // Now the window the hook lives in. EVERY poll — none of them carrying
+    // `refresh=1`, which the hook sends once per signal — has to say an answer
+    // is coming, or the picker stops asking and keeps what it has.
+    for (let poll = 0; poll < 3; poll += 1) {
+      const body = await get("openai");
+      expect(body.warming).toBe(true);
+      // And the pre-credential list is never what it is holding. A payload from
+      // an EARLIER generation may still be served — it is a device's answer,
+      // which is why `warming` above is the thing that has to stay true — but
+      // the superseded fork's own rows never became one: nothing was written.
+      expect((body.models as Array<{ id: string }>).map((m) => m.id)).not.toEqual(["gpt-5.6-sol"]);
+      expect(fs.existsSync(cacheFile("openai"))).toBe(false);
+    }
+
+    // The post-credential answer lands, and only then does the asking stop.
+    postKey.release();
+    await vi.waitFor(() => {
+      expect(readCache("openai").models.map((m) => m.id).sort())
+        .toEqual(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"]);
+    }, { timeout: 4000, interval: 25 });
+    expect(readCache("openai").source).toBe("live");
+
+    const settled = await get("openai");
+    expect(settled.warming).toBeUndefined();
+    expect(settled.source).toBe("live");
+  });
+
+  // Scenario (b). `configure` step 8c and the client's `?refresh=1` are the
+  // SAME provider-set change reaching the route twice, ordered by awaits rather
+  // than racing. Treating the second as news cost every connect a duplicate
+  // ~3-minute `openclaw models list` — ~2 cores of a Jetson, at the wizard's
+  // most latency-sensitive moment, for a question the fork already out is
+  // answering post-credential.
+  it("costs one enumeration when the same change reaches the route twice", async () => {
+    const held = heldChild({
+      count: 2,
+      models: [
+        { key: "google/gemini-3-pro", name: "Gemini 3 Pro", contextWindow: 1_000_000, available: true, tags: ["default"] },
+        { key: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash", contextWindow: 1_000_000, available: true, tags: [] },
+      ],
+    });
+    let googleSpawns = 0;
+    mockSpawn.mockImplementation((_bin, args) => {
+      const argv = args as string[];
+      const target = argv[argv.indexOf("--provider") + 1];
+      if (target !== "google") {
+        return fakeChild({ count: 0, models: [] }) as unknown as ReturnType<typeof childProcess.spawn>;
+      }
+      googleSpawns += 1;
+      return held.child as unknown as ReturnType<typeof childProcess.spawn>;
+    });
+
+    // Step 8c, one statement after the credential write and the plugin switch.
+    refreshInBackground("google", { providerChanged: true });
+    await settle();
+    expect(googleSpawns).toBe(1);
+
+    // The same change arriving again as the client's `?refresh=1`. The fork out
+    // there was started BY this change and is reading the box it reports.
+    refreshInBackground("google", { providerChanged: true });
+    await settle();
+    expect(googleSpawns).toBe(1);
+
+    held.release();
+    await vi.waitFor(() => {
+      expect(readCache("google").models.map((m) => m.id).sort())
+        .toEqual(["gemini-2.5-flash", "gemini-3-pro"]);
+    }, { timeout: 4000, interval: 25 });
+
+    // No replacement scheduled: nothing was superseded.
+    await settle();
+    expect(googleSpawns).toBe(1);
+  });
+});

--- a/src/tests/routes/ai-models/catalog-provider-change.test.ts
+++ b/src/tests/routes/ai-models/catalog-provider-change.test.ts
@@ -431,9 +431,15 @@ describe("catalog — the one entry point every server-side write counts through
     notifyProviderSetChanged("deepseek");
     await settle();
 
-    expect(vi.mocked(globalThis.fetch as unknown as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
-    expect(fs.existsSync(cacheFile("openrouter"))).toBe(false);
+    // `clawai` carries the proof, because it is the deterministic one: a
+    // counted `clawai` resolves from a constant and publishes inside this
+    // window, with no network and no pending warmup timer (its warmup slot is
+    // the first, and fired in an earlier test). The global `fetch` stub is
+    // deliberately NOT asserted on — the warmup schedules `openrouter` on a
+    // real 25 s timer, so a stray call could come from that rather than from
+    // anything this test did.
     expect(fs.existsSync(cacheFile("clawai"))).toBe(false);
+    expect(fs.existsSync(cacheFile("openrouter"))).toBe(false);
     expect(fs.existsSync(cacheFile("deepseek"))).toBe(false);
   });
 

--- a/src/tests/routes/ai-models/catalog-provider-change.test.ts
+++ b/src/tests/routes/ai-models/catalog-provider-change.test.ts
@@ -418,16 +418,22 @@ describe("catalog — the one entry point every server-side write counts through
     expect(published.source).toBe("live");
   });
 
-  it("counts the change against the catalogue's id for a provider, not openclaw's", async () => {
-    // openclaw calls ClawBox AI `deepseek` in its config, and the routes hand
-    // this the id they hold; the catalogue's row — and its cache file — is
-    // `clawai`. The mapping lives here so no call site has to remember it.
+  it("does not count a change against a catalogue no write on this box can alter", async () => {
+    // `openrouter` is fetched from openrouter.ai and `clawai` is a constant, so
+    // nothing written here can change what either lists. Counting one would
+    // discard the fetch in flight, redo it for the identical answer, and clear
+    // the failed-refresh backoff — a change announced for a provider that did
+    // not have one. `chat/model`'s compat auto-extend writes
+    // `models.providers.openrouter.models`, so it takes exactly this path.
+    // (`deepseek` is openclaw's id for ClawBox AI; the catalogue's is `clawai`,
+    // and the mapping lives in the seam so no call site has to remember it.)
+    notifyProviderSetChanged("openrouter");
     notifyProviderSetChanged("deepseek");
+    await settle();
 
-    await vi.waitFor(
-      () => expect(fs.existsSync(cacheFile("clawai"))).toBe(true),
-      { timeout: 4000, interval: 25 },
-    );
+    expect(vi.mocked(globalThis.fetch as unknown as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    expect(fs.existsSync(cacheFile("openrouter"))).toBe(false);
+    expect(fs.existsSync(cacheFile("clawai"))).toBe(false);
     expect(fs.existsSync(cacheFile("deepseek"))).toBe(false);
   });
 
@@ -445,5 +451,48 @@ describe("catalog — the one entry point every server-side write counts through
 
     expect(spawnedProviders()).not.toContain("llamacpp");
     expect(fs.existsSync(cacheFile("llamacpp"))).toBe(false);
+  });
+});
+
+// The `models` field is typed as a list; what arrives is whatever the CLI
+// printed on stdout. A non-array used to reach the transform, whose `for...of`
+// threw INSIDE the chunk handler's partial-JSON `catch` — and by then `finish`
+// had already set `settled`, so the `close` handler bailed too. The promise
+// never settled, its `.finally` never ran, and `refreshing` kept the provider
+// for the process lifetime: every later refresh returned at the single-flight
+// guard, `warming` stayed true forever, and the picker polled a fork that no
+// longer existed.
+describe("catalog — a payload this route cannot transform", () => {
+  it("fails the refresh rather than wedging the provider", async () => {
+    let spawns = 0;
+    mockSpawn.mockImplementation((_bin, args) => {
+      const argv = args as string[];
+      const target = argv[argv.indexOf("--provider") + 1];
+      if (target !== "openai") {
+        return fakeChild({ count: 0, models: [] }) as unknown as ReturnType<typeof childProcess.spawn>;
+      }
+      spawns += 1;
+      const payload = spawns === 1
+        // Syntactically fine JSON, semantically not a list.
+        ? { count: 1, models: { "gpt-5.6-sol": { name: "GPT-5.6 Sol" } } }
+        : LINKED;
+      return fakeChild(payload) as unknown as ReturnType<typeof childProcess.spawn>;
+    });
+
+    refreshInBackground("openai");
+    await settle();
+    expect(spawns).toBe(1);
+    // Nothing was published: a payload that cannot be read is not an answer.
+    expect(fs.existsSync(cacheFile("openai"))).toBe(false);
+
+    // The guard was released, so the box can be asked again — and this is what
+    // was impossible before: the owner saves a key, which counts the change and
+    // clears the failed-refresh wait, and the good answer lands.
+    notifyProviderSetChanged("openai");
+    await vi.waitFor(() => expect(spawns).toBe(2), { timeout: 4000, interval: 25 });
+    await vi.waitFor(() => {
+      expect(readCache("openai").models.map((m) => m.id).sort())
+        .toEqual(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"]);
+    }, { timeout: 4000, interval: 25 });
   });
 });

--- a/src/tests/routes/ai-models/catalog-provider-change.test.ts
+++ b/src/tests/routes/ai-models/catalog-provider-change.test.ts
@@ -25,7 +25,7 @@ vi.mock("@/lib/openclaw-config", () => ({
 const DATA_DIR = "/tmp/clawbox-catalog-provider-change-test";
 vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-provider-change-test" }));
 
-import { GET, refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
+import { GET, notifyProviderSetChanged, refreshInBackground } from "@/app/setup-api/ai-models/catalog/route";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 
@@ -378,5 +378,72 @@ describe("catalog — the change generation, not a one-shot flag", () => {
     const settled = await get("openai");
     expect(settled.warming).toBeUndefined();
     expect(settled.source).toBe("live");
+  });
+});
+
+// `notifyProviderSetChanged` is the seam between the two halves of this fix:
+// every server-side write counts its change through it, and the catalogue is
+// what answers. Every route test mocks it out — a mocked call proves the
+// caller and nothing about the answer — so this is where it runs for real,
+// against no client request at all. It is also the only place the two facts
+// it owns are pinned: openclaw's provider id is not always the catalogue's,
+// and a write about a provider this route cannot enumerate is not a change it
+// can act on.
+describe("catalog — the one entry point every server-side write counts through", () => {
+  /** Which providers `openclaw models list` was actually forked for. */
+  function spawnedProviders(): string[] {
+    return mockSpawn.mock.calls.map(([, args]) => {
+      const argv = args as string[];
+      return argv[argv.indexOf("--provider") + 1];
+    });
+  }
+
+  it("enumerates and publishes with no client request anywhere", async () => {
+    mockSpawn.mockImplementation(
+      () => fakeChild(LINKED) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+
+    // Exactly what `POST /setup-api/providers/enabled` now does, and nothing
+    // else: no browser has to be open, and a caller that is not a browser
+    // sends no `?refresh=1` at all — which is why that route's flip used to
+    // reach the catalogue through nothing.
+    notifyProviderSetChanged("openai");
+
+    await vi.waitFor(
+      () => expect(fs.existsSync(cacheFile("openai"))).toBe(true),
+      { timeout: 4000, interval: 25 },
+    );
+    const published = readCache("openai");
+    expect(published.models.map((m) => m.id).sort()).toEqual(["gpt-5.4", "gpt-5.5", "gpt-5.6-sol"]);
+    expect(published.source).toBe("live");
+  });
+
+  it("counts the change against the catalogue's id for a provider, not openclaw's", async () => {
+    // openclaw calls ClawBox AI `deepseek` in its config, and the routes hand
+    // this the id they hold; the catalogue's row — and its cache file — is
+    // `clawai`. The mapping lives here so no call site has to remember it.
+    notifyProviderSetChanged("deepseek");
+
+    await vi.waitFor(
+      () => expect(fs.existsSync(cacheFile("clawai"))).toBe(true),
+      { timeout: 4000, interval: 25 },
+    );
+    expect(fs.existsSync(cacheFile("deepseek"))).toBe(false);
+  });
+
+  it("ignores a write about a provider this catalogue does not enumerate", async () => {
+    mockSpawn.mockImplementation(
+      () => fakeChild(LINKED) as unknown as ReturnType<typeof childProcess.spawn>,
+    );
+
+    // A local-only provider has no catalogue here, and the two empty shapes
+    // are what a caller passing a provider it could not resolve hands over.
+    notifyProviderSetChanged("llamacpp");
+    notifyProviderSetChanged(null);
+    notifyProviderSetChanged("");
+    await settle();
+
+    expect(spawnedProviders()).not.toContain("llamacpp");
+    expect(fs.existsSync(cacheFile("llamacpp"))).toBe(false);
   });
 });

--- a/src/tests/routes/ai-models/catalog-sanitised-empty-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-sanitised-empty-cache.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import * as childProcess from "child_process";
+import fs from "fs";
+import path from "path";
+import { NextRequest } from "next/server";
+
+// A LIVE cached payload whose every row the CURRENT rules filter out.
+//
+// Freshness used to be judged on the RAW cache — age, `stale`, the recorded
+// failure, `source` — all of which say "fine" about a file this build's own
+// sanitiser then empties. So the route served `models: []`, started no
+// enumeration and set no `warming`, and the client rendered the curated list
+// with nothing left asking. `fetchProviderCatalog` forwards a `warming` the
+// route could never set in that state.
+//
+// Its own file because it needs a module whose `memCache` is empty for the
+// provider under test: the disk cache is only read when nothing is in memory,
+// and every provider picks up a memCache entry after the first publish.
+//
+// Not reachable from a payload this build wrote — the transform and the
+// sanitiser share `isOfferableModelId`, so a live file is one these rules just
+// passed. It becomes reachable the first time a filter is tightened, which is
+// what this branch did to the previous generation of caches.
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  findOpenclawBin: () => "openclaw",
+  openclawIsAbsent: () => false,
+}));
+
+const DATA_DIR = "/tmp/clawbox-catalog-sanitised-empty-test";
+vi.mock("@/lib/config-store", () => ({ DATA_DIR: "/tmp/clawbox-catalog-sanitised-empty-test" }));
+
+import { GET } from "@/app/setup-api/ai-models/catalog/route";
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+
+function fakeChild(json: unknown) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: () => void;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = () => {};
+  queueMicrotask(() => {
+    child.stdout.emit("data", Buffer.from(JSON.stringify(json), "utf8"));
+    child.emit("close", 0);
+  });
+  return child;
+}
+
+/** The providers each `openclaw models list` spawn was for. */
+function spawnedProviders(): string[] {
+  return mockSpawn.mock.calls.map((call) => {
+    const args = call[1] as string[];
+    return args[args.indexOf("--provider") + 1];
+  });
+}
+
+beforeEach(() => {
+  // The boot warmup would otherwise make a real request to openrouter.ai. Left
+  // installed for the file's lifetime on purpose — see the note in
+  // catalog-live-vs-fallback.test.ts.
+  vi.stubGlobal("fetch", vi.fn(async () => {
+    throw new Error("no network in this suite");
+  }));
+  vi.clearAllMocks();
+  fs.rmSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true, force: true });
+  mockSpawn.mockImplementation(
+    () => fakeChild({
+      count: 1,
+      models: [
+        { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: ["default"] },
+      ],
+    }) as unknown as ReturnType<typeof childProcess.spawn>,
+  );
+});
+
+describe("catalog — a cache the sanitiser empties is not a fresh answer", () => {
+  it("re-enumerates, says stale, and says an answer is coming", async () => {
+    fs.mkdirSync(path.join(DATA_DIR, "catalog-cache"), { recursive: true });
+    fs.writeFileSync(
+      path.join(DATA_DIR, "catalog-cache", "openai.json"),
+      JSON.stringify({
+        provider: "openai",
+        // Image SKUs: a real enumeration once carried them, and a later build
+        // learned to exclude them. Every row here fails today's rules.
+        models: [
+          { id: "gpt-image-1", label: "GPT Image 1", contextWindow: 0 },
+          { id: "gpt-5.4-image-2", label: "GPT-5.4 Image 2", contextWindow: 0 },
+        ],
+        defaultModelId: "gpt-image-1",
+        allowCustom: true,
+        // Fresh, and stamped by a device. Nothing about the raw file is stale.
+        fetchedAt: Date.now(),
+        source: "live",
+      }),
+      "utf8",
+    );
+
+    const res = await GET(new NextRequest("http://clawbox.local/setup-api/ai-models/catalog?provider=openai"));
+    const body = (await res.json()) as Record<string, unknown>;
+
+    // What it serves is nothing — so it must not also claim to be current.
+    expect(body.models).toEqual([]);
+    expect(body.stale).toBe(true);
+    // A fork really is out there, so the picker has a reason to come back.
+    expect(body.warming).toBe(true);
+    expect(spawnedProviders()).toContain("openai");
+  });
+});

--- a/src/tests/routes/ai-models/catalog-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/catalog-subscription-surface.test.ts
@@ -139,14 +139,24 @@ describe("catalog refresh — subscription surface", () => {
     },
   );
 
-  it("stamps the curated rows too, so a thin enumeration does not grey them", async () => {
+  it("publishes the rows the DEVICE enumerated, and no curated ones", async () => {
     const byId = await stampedCatalogue();
 
-    // claude-haiku-4-5 is in ANTHROPIC_MODELS but not in the live list above,
-    // so augmentWithStaticCatalog appends it. It was stamped FALSE before —
-    // the third model the owner reported — because `claude-cli` did not carry
-    // it. The native route does.
-    expect(byId["claude-haiku-4-5"]).toBe(true);
+    // claude-haiku-4-5 is in ANTHROPIC_MODELS and not in the live list above.
+    // It used to be appended here and stamped along with the rest; M-05
+    // stopped that, because a payload that mixes the two is written to
+    // catalog-cache and read back — by the picker and by the server-side
+    // surface guard — as a device answer. A box whose plugin was disabled at
+    // boot then showed three hard-coded Claude models all day.
+    //
+    // Every row this file publishes is stamped; the point here is WHICH rows
+    // there are.
+    expect(byId["claude-haiku-4-5"]).toBeUndefined();
+    expect(Object.keys(byId).sort()).toEqual([
+      "claude-fable-5",
+      "claude-mythos-5",
+      "claude-sonnet-4-6",
+    ]);
   });
 
   it("does not go looking for a second surface for a provider that has none", async () => {

--- a/src/tests/routes/ai-models/catalog-surface-cache.test.ts
+++ b/src/tests/routes/ai-models/catalog-surface-cache.test.ts
@@ -85,11 +85,11 @@ describe("catalog refresh — the subscription surface is cached", () => {
           .map((m) => [m.id, m.availableOnSubscription]),
       );
       expect(byId["claude-sonnet-4-6"]).toBe(true);
-      // ANTHROPIC_MODELS' curated entries get appended by
-      // augmentWithStaticCatalog for the thin-enumeration case, and they are
-      // stamped too — leaving one unstamped where the rest are stamped is a
-      // difference the pickers would render, for no reason the box can name.
-      expect(byId["claude-haiku-4-5"]).toBe(true);
+      // And nothing else. The curated ANTHROPIC_MODELS used to be appended to
+      // a thin enumeration like this one and persisted with it, which made a
+      // hand-maintained list indistinguishable from a device answer for the
+      // next six hours (M-05).
+      expect(Object.keys(byId)).toEqual(["claude-sonnet-4-6"]);
     });
 
     // Ask again. `refreshing` single-flights per provider and clears a tick

--- a/src/tests/routes/ai-models/configure-hermes.test.ts
+++ b/src/tests/routes/ai-models/configure-hermes.test.ts
@@ -109,7 +109,10 @@ vi.mock("@/lib/local-ai-token", () => ({
 vi.mock("@/lib/clawkeep", () => ({ unpairLocal: vi.fn() }));
 vi.mock("@/lib/gateway-proxy", () => ({ getOrGenerateGatewayToken: vi.fn().mockResolvedValue("tok") }));
 vi.mock("@/lib/codex-model-probe", () => ({ resolveEntitledCodexModel: vi.fn().mockResolvedValue(null) }));
-vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({ refreshInBackground: vi.fn() }));
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  refreshInBackground: vi.fn(),
+  notifyProviderSetChanged: vi.fn(),
+}));
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 

--- a/src/tests/routes/ai-models/configure-images.test.ts
+++ b/src/tests/routes/ai-models/configure-images.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/lib/clawkeep", () => ({
 // note in configure.test.ts.
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   refreshInBackground: vi.fn(),
+  notifyProviderSetChanged: vi.fn(),
 }));
 
 const { parseFullyQualifiedModelImpl, LLAMACPP_PROXY_BASE_URL } = vi.hoisted(() => ({

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -402,10 +402,11 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
   });
 
   it("refuses a typed id an EMPTY cached surface plus the curated catalogue lacks", async () => {
-    // A file holding `models: []` leaves the picker on the curated list, so
-    // the customer was shown the curated rows —
-    // the guard judges by the same list rather than answering UNKNOWN. Only a
-    // MISSING cache (the test above) is unknown.
+    // A file holding `models: []` is served as an empty payload, and
+    // `fetchProviderCatalog` renders the curated catalogue for an empty one, so
+    // the customer was shown the curated rows — the guard judges by the same
+    // list rather than answering UNKNOWN. Only a MISSING cache (the test above)
+    // is unknown.
     mockSurfaceRead.mockResolvedValue(surfaceCache([]) as never);
 
     const res = await configurePost(subscribe({ model: OFF_CATALOGUE_ID }));

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -405,8 +405,9 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     // A file holding `models: []` is served as an empty payload, and
     // `fetchProviderCatalog` renders the curated catalogue for an empty one, so
     // the customer was shown the curated rows — the guard judges by the same
-    // list rather than answering UNKNOWN. Only a MISSING cache (the test above)
-    // is unknown.
+    // list rather than answering UNKNOWN. What IS unknown is a cache the guard
+    // cannot read at all — missing, unreadable, or half-written; the test above
+    // covers the missing one.
     mockSurfaceRead.mockResolvedValue(surfaceCache([]) as never);
 
     const res = await configurePost(subscribe({ model: OFF_CATALOGUE_ID }));

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -323,8 +323,8 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
   });
 
   it("does not refuse the shipped default over a cache that predates it", async () => {
-    // The regression this pins: the catalog route SERVES its cached payload
-    // through `augmentWithStaticCatalog`, so a release that adds a model to
+    // The regression this pins: the picker falls back to the curated list
+    // whenever the route has no live enumeration, so a release that adds a model to
     // PROVIDER_CATALOGS offers it in the picker on day one — while the on-disk
     // cache keeps the previous enumeration for up to that route's 6h refresh
     // interval. Judging the raw cache asked a different question than the
@@ -402,8 +402,8 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
   });
 
   it("refuses a typed id an EMPTY cached surface plus the curated catalogue lacks", async () => {
-    // A file holding `models: []` is served to the picker through
-    // `augmentWithStaticCatalog`, so the customer was shown the curated rows —
+    // A file holding `models: []` leaves the picker on the curated list, so
+    // the customer was shown the curated rows —
     // the guard judges by the same list rather than answering UNKNOWN. Only a
     // MISSING cache (the test above) is unknown.
     mockSurfaceRead.mockResolvedValue(surfaceCache([]) as never);

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -59,6 +59,7 @@ vi.mock("@/lib/provider-models", async () => {
 // after the test that triggered it has finished.
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   refreshInBackground: vi.fn(),
+  notifyProviderSetChanged: vi.fn(),
 }));
 
 const { parseFullyQualifiedModelImpl } = vi.hoisted(() => ({
@@ -247,7 +248,7 @@ async function primeConfigureRoute(): Promise<(request: Request) => Promise<Resp
   vi.mocked(runOpenclawConfigSet).mockResolvedValue(undefined);
   vi.mocked(runOpenclawConfigSetBatch).mockResolvedValue(undefined);
   vi.mocked(applyModelOverrideToAllAgentSessions).mockResolvedValue({ filesUpdated: 0, sessionsUpdated: 0, sessionsSkipped: 0 });
-  vi.mocked(setProviderPlugins).mockResolvedValue(undefined);
+  vi.mocked(setProviderPlugins).mockResolvedValue(null);
   vi.mocked(unpairLocal).mockResolvedValue(undefined);
   mockSpawn.mockImplementation(() => successfulChild());
   vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network disabled in tests")));

--- a/src/tests/routes/ai-models/configure-vision.test.ts
+++ b/src/tests/routes/ai-models/configure-vision.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/lib/clawkeep", () => ({
 // note in configure.test.ts.
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   refreshInBackground: vi.fn(),
+  notifyProviderSetChanged: vi.fn(),
 }));
 
 // The vision id is RESOLVED against the proxy before the route writes it:

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -157,6 +157,7 @@ import { configSetCalls, configSetCommands, failConfigSetsMatching, findConfigSe
 import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
 import { getLocalAiToken } from "@/lib/local-ai-token";
+import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
@@ -342,6 +343,23 @@ describe("POST /setup-api/ai-models/configure", () => {
         ai_model_configured: true,
         ai_model_provider: "anthropic",
       })
+    );
+  });
+
+  // The one thing this file DOES assert about the out-of-band refresh (see the
+  // mock's note above): the flag it is called with. Step 8c runs one statement
+  // after the plugin is switched on and the credential written, i.e. at the
+  // moment a provider that could not enumerate starts being able to. Called
+  // without `providerChanged` it is silently dropped whenever the pre-auth
+  // enumeration failed — which is exactly the "single fallback entry or empty"
+  // snapshot that comment was written about, so the call would go missing on
+  // the devices it exists for.
+  it("tells the catalog the PROVIDER SET changed, not that a client asked again", async () => {
+    await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-test-key" }));
+
+    expect(vi.mocked(refreshCatalogInBackground)).toHaveBeenCalledWith(
+      "anthropic",
+      { providerChanged: true },
     );
   });
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -58,6 +58,7 @@ vi.mock("@/lib/provider-enablement", () => ({
 // asserts on the refresh; it is out-of-band work by design.
 vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
   refreshInBackground: vi.fn(),
+  notifyProviderSetChanged: vi.fn(),
 }));
 
 // Hoisted so the vi.mock factories below (which are themselves hoisted by
@@ -157,7 +158,7 @@ import { configSetCalls, configSetCommands, failConfigSetsMatching, findConfigSe
 import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyBaseUrl } from "@/lib/local-ai-runtime";
 import { getLocalAiToken } from "@/lib/local-ai-token";
-import { refreshInBackground as refreshCatalogInBackground } from "@/app/setup-api/ai-models/catalog/route";
+import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 
 const mockSpawn = vi.mocked(childProcess.spawn);
 const mockGetAll = vi.mocked(getAll);
@@ -257,7 +258,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     vi.mocked(runOpenclawConfigUnset).mockResolvedValue(undefined);
     mockUnpairLocal.mockResolvedValue(undefined);
     vi.mocked(setPrimaryModelWithoutCatalogValidation).mockResolvedValue(undefined);
-    vi.mocked(setProviderPlugins).mockResolvedValue(undefined);
+    vi.mocked(setProviderPlugins).mockResolvedValue(null);
 
     // Re-apply implementations cleared by vi.clearAllMocks above. Factory
     // defaults set in `vi.mock(...)` hold across vi.resetModules but are
@@ -347,20 +348,16 @@ describe("POST /setup-api/ai-models/configure", () => {
   });
 
   // The one thing this file DOES assert about the out-of-band refresh (see the
-  // mock's note above): the flag it is called with. Step 8c runs one statement
-  // after the plugin is switched on and the credential written, i.e. at the
-  // moment a provider that could not enumerate starts being able to. Called
-  // without `providerChanged` it is silently dropped whenever the pre-auth
-  // enumeration failed — which is exactly the "single fallback entry or empty"
-  // snapshot that comment was written about, so the call would go missing on
-  // the devices it exists for.
-  it("tells the catalog the PROVIDER SET changed, not that a client asked again", async () => {
+  // mock's note above): that step 8c COUNTS the change server-side. It runs one
+  // statement after the plugin is switched on and the credential written, i.e.
+  // at the moment a provider that could not enumerate starts being able to, and
+  // it is the only thing that can count it — a client's `?refresh=1` is a nudge
+  // and deliberately bumps nothing. A write that forgets this call leaves its
+  // change invisible to the catalogue until the 6h refresh.
+  it("counts the provider-set change server-side", async () => {
     await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-test-key" }));
 
-    expect(vi.mocked(refreshCatalogInBackground)).toHaveBeenCalledWith(
-      "anthropic",
-      { providerChanged: true },
-    );
+    expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
   });
 
   it("configures openai provider", async () => {

--- a/src/tests/routes/chat-model-codex-surface.test.ts
+++ b/src/tests/routes/chat-model-codex-surface.test.ts
@@ -23,6 +23,9 @@ vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
+  // Strict: the ON half of the plugin gate decides from ABSENCE, and plain
+  // `readConfig` cannot tell an unreadable config from one carrying no flag.
+  readConfigStrict: vi.fn(async () => ({})),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
   runOpenclawConfigSet: configSetMock,

--- a/src/tests/routes/chat-model-codex-surface.test.ts
+++ b/src/tests/routes/chat-model-codex-surface.test.ts
@@ -14,6 +14,12 @@ vi.mock("fs", () => ({
 
 const { configSetMock } = vi.hoisted(() => ({ configSetMock: vi.fn() }));
 
+// The catalogue is told out-of-band when the plugin gate changes the provider
+// set; the real module forks `openclaw models list`.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -23,6 +23,9 @@ vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
+  // Strict: the ON half of the plugin gate decides from ABSENCE, and plain
+  // `readConfig` cannot tell an unreadable config from one carrying no flag.
+  readConfigStrict: vi.fn(async () => ({})),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
   runOpenclawConfigSet: configSetMock,

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -314,8 +314,8 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
   });
 
   it("judges an EMPTY cached surface by the curated catalogue, like the picker", async () => {
-    // Not unknown. The catalog route serves this same file through
-    // `augmentWithStaticCatalog`, so the picker on this box offered the
+    // Not unknown. The catalog route unions the curated catalogue into what
+    // it serves for this same file, so the picker on this box offered the
     // curated rows and nothing else — an id in none of them is one the picker
     // never showed, and letting it through would write the very id this guard
     // exists to refuse.

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -315,13 +315,14 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
 
   it("judges an EMPTY cached surface by the curated catalogue, like the picker", async () => {
     // Not unknown. Nothing unions the curated list into a SERVED catalogue any
-    // more — the route keeps it as a cold-start fallback it never persists. The
-    // union is in the guard itself: `readSubscriptionSurfaceIds` counts the
-    // curated ids of the surface provider, because a file holding `models: []`
-    // is what leaves the picker on that curated list. So the box offered the
-    // curated rows and nothing else — an id in none of them is one the picker
-    // never showed, and letting it through would write the very id this guard
-    // exists to refuse.
+    // more: on this file the route answers `models: []` and starts a refresh.
+    // The curated rows still reach the customer, one layer up —
+    // `fetchProviderCatalog` renders the curated catalogue whenever the payload
+    // is empty — so the picker on this box offered exactly those rows and
+    // nothing else. The guard unions the same ids for the same reason, which is
+    // what keeps it asking the question the picker answered: an id in neither
+    // list is one the picker never showed, and letting it through would write
+    // the very id this guard exists to refuse.
     vi.mocked(fsp.readFile).mockResolvedValue(surfaceCache([]) as never);
     const response = await postModel(POST, `anthropic/${OFF_CATALOGUE_ID}`);
 

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -14,6 +14,12 @@ vi.mock("fs", () => ({
 
 const { configSetMock } = vi.hoisted(() => ({ configSetMock: vi.fn() }));
 
+// The catalogue is told out-of-band when the plugin gate changes the provider
+// set; the real module forks `openclaw models list`.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -314,8 +314,11 @@ describe("/setup-api/chat/model and the Claude subscription surface", () => {
   });
 
   it("judges an EMPTY cached surface by the curated catalogue, like the picker", async () => {
-    // Not unknown. The catalog route unions the curated catalogue into what
-    // it serves for this same file, so the picker on this box offered the
+    // Not unknown. Nothing unions the curated list into a SERVED catalogue any
+    // more — the route keeps it as a cold-start fallback it never persists. The
+    // union is in the guard itself: `readSubscriptionSurfaceIds` counts the
+    // curated ids of the surface provider, because a file holding `models: []`
+    // is what leaves the picker on that curated list. So the box offered the
     // curated rows and nothing else — an id in none of them is one the picker
     // never showed, and letting it through would write the very id this guard
     // exists to refuse.

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -25,6 +25,9 @@ vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
+  // Strict: the ON half of the plugin gate decides from ABSENCE, and plain
+  // `readConfig` cannot tell an unreadable config from one carrying no flag.
+  readConfigStrict: vi.fn(async () => ({})),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
   runOpenclawConfigSet: configSetMock,
@@ -54,7 +57,7 @@ vi.mock("@/lib/sqlite-store", () => ({
 }));
 
 import { getAll } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel, setProviderPlugins, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, readConfigStrict, restartGateway, runOpenclawConfigSet, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel, setProviderPlugins, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { promisify } from "util";
@@ -1002,8 +1005,11 @@ describe("/setup-api/chat/model", () => {
     // off for a while is not re-asked for six hours after the pick that made
     // it listable.
     describe("counting the ON half for the catalogue", () => {
+      // The handler's state comes from `readConfig`; the ON half reads the flag
+      // again, STRICTLY, at the last moment before the batch — so both are set
+      // here, and the strict one is what decides the announcement.
       const pluginOff = (enabled: boolean) => {
-        vi.mocked(readConfig).mockResolvedValue({
+        const config = {
           auth: {
             profiles: {
               "deepseek:default": { provider: "deepseek", mode: "api_key" },
@@ -1012,7 +1018,9 @@ describe("/setup-api/chat/model", () => {
           },
           agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
           plugins: { entries: { anthropic: { enabled } } },
-        } as never);
+        };
+        vi.mocked(readConfig).mockResolvedValue(config as never);
+        vi.mocked(readConfigStrict).mockResolvedValue(config as never);
       };
 
       it("counts the change when the batch switched the plugin on", async () => {
@@ -1043,6 +1051,24 @@ describe("/setup-api/chat/model", () => {
 
         expect(response.status).toBe(200);
         expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
+      });
+
+      it("counts it when the flag could not be read at all", async () => {
+        // The strict read throws on an EACCES or a config caught half-written,
+        // and the batch still lands. Unknown is not "already on": silence would
+        // leave the catalogue on the pre-enable enumeration, whose failed-
+        // refresh wait doubles toward six hours.
+        pluginOff(true);
+        vi.mocked(readConfigStrict).mockRejectedValue(new Error("EACCES"));
+
+        const response = await POST(new Request("http://localhost/test", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+        }));
+
+        expect(response.status).toBe(200);
+        expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
       });
 
       it("says nothing when the batch was refused", async () => {

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -16,6 +16,12 @@ vi.mock("@/lib/config-store", () => ({
 
 const { configSetMock } = vi.hoisted(() => ({ configSetMock: vi.fn() }));
 
+// The catalogue is told out-of-band when the plugin gate changes the provider
+// set; the real module forks `openclaw models list`.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -56,6 +56,7 @@ vi.mock("@/lib/sqlite-store", () => ({
 import { getAll } from "@/lib/config-store";
 import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, runOpenclawConfigUnset, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel, setProviderPlugins, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
+import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 import { promisify } from "util";
 
 describe("/setup-api/chat/model", () => {
@@ -844,6 +845,69 @@ describe("/setup-api/chat/model", () => {
   // ahead of it: the core applies a batch to one snapshot and validates the
   // references afterwards, so one spawn does both, and a refused batch leaves
   // the flag as it was.
+  // A compat provider's configured entry REPLACES the plugin's catalogue —
+  // "configured providers in openclaw.json override the plugin's modelCatalog
+  // entirely" (ai-models/configure) — so `openclaw models list --provider
+  // google` answers exactly this array. Appending a row to it is therefore the
+  // provider's enumeration changing, made by a server-side write, and nothing
+  // was counting it: the plugin gate below answers only about the anthropic
+  // flag, which this write does not touch.
+  describe("registering a compat model the provider did not list", () => {
+    const googleBox = (models: { id: string; name: string }[]) => ({
+      auth: { profiles: { "google:default": { provider: "google", mode: "api_key" } } },
+      models: {
+        mode: "merge",
+        providers: {
+          google: {
+            apiKey: "k",
+            baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+            api: "openai-completions",
+            models,
+          },
+        },
+      },
+      agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro" } } },
+    });
+
+    const pick = (model: string) => POST(new Request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model }),
+    }));
+
+    it("counts the change when a row is actually appended", async () => {
+      vi.mocked(readConfig).mockResolvedValue(
+        googleBox([{ id: "gemini-3-flash", name: "gemini-3-flash" }]) as never,
+      );
+
+      const response = await pick("google/gemini-3-pro");
+
+      expect(response.status).toBe(200);
+      expect(runOpenclawConfigSet).toHaveBeenCalledWith([
+        "models.providers.google.models",
+        JSON.stringify([
+          { id: "gemini-3-flash", name: "gemini-3-flash" },
+          { id: "gemini-3-pro", name: "gemini-3-pro" },
+        ]),
+        "--json",
+      ]);
+      expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("google");
+    });
+
+    it("says nothing when the model was already listed", async () => {
+      // Nothing was written, so nothing changed — announcing here would spend
+      // an enumeration on every repeat pick.
+      vi.mocked(readConfig).mockResolvedValue(
+        googleBox([{ id: "gemini-3-pro", name: "gemini-3-pro" }]) as never,
+      );
+
+      const response = await pick("google/gemini-3-pro");
+
+      expect(response.status).toBe(200);
+      expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
+    });
+  });
+
   describe("the anthropic plugin around the primary write", () => {
     const UNKNOWN_MODEL =
       'Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary: '
@@ -925,6 +989,78 @@ describe("/setup-api/chat/model", () => {
       expect(runOpenclawConfigSet).not.toHaveBeenCalledWith(expect.arrayContaining([ENABLE_OP[0]]));
       expect(setProviderPlugins).not.toHaveBeenCalled();
       expect(restartGateway).not.toHaveBeenCalled();
+    });
+
+    // A plugin that is off enumerates NOTHING, so switching it back on is the
+    // same provider-set change as switching it off — in the other direction,
+    // in this same file, and the catalogue was told about neither. It is also
+    // the change nothing could see: the enable rides in the batch, so by the
+    // time the OFF half re-reads the config the flag is already true and it
+    // correctly reports no flip. Unanswered it is not a one-off staleness
+    // either — an empty enumeration is recorded as a failed refresh whose wait
+    // DOUBLES up to the six-hour interval, so a provider whose plugin has been
+    // off for a while is not re-asked for six hours after the pick that made
+    // it listable.
+    describe("counting the ON half for the catalogue", () => {
+      const pluginOff = (enabled: boolean) => {
+        vi.mocked(readConfig).mockResolvedValue({
+          auth: {
+            profiles: {
+              "deepseek:default": { provider: "deepseek", mode: "api_key" },
+              "anthropic:default": { provider: "anthropic", mode: "api_key" },
+            },
+          },
+          agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+          plugins: { entries: { anthropic: { enabled } } },
+        } as never);
+      };
+
+      it("counts the change when the batch switched the plugin on", async () => {
+        pluginOff(false);
+
+        const response = await POST(new Request("http://localhost/test", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+        }));
+
+        expect(response.status).toBe(200);
+        expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
+      });
+
+      it("says nothing when the plugin was already on", async () => {
+        // The enable op is emitted either way — it is what makes the core
+        // validate the reference — so its presence is not a state change.
+        // Announcing one per Claude pick would spend a ~3-minute `openclaw
+        // models list` on a Jetson for a box that did not change.
+        pluginOff(true);
+
+        const response = await POST(new Request("http://localhost/test", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+        }));
+
+        expect(response.status).toBe(200);
+        expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
+      });
+
+      it("says nothing when the batch was refused", async () => {
+        // Atomic: a refused batch is applied to one snapshot and validated as
+        // a whole, so the flag is exactly where it was. Counting here would be
+        // this route's own false success.
+        pluginOff(false);
+        vi.mocked(runOpenclawConfigSetBatch).mockRejectedValue(new Error(UNKNOWN_MODEL));
+
+        const response = await POST(new Request("http://localhost/test", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+        }));
+
+        expect(response.status).toBe(409);
+        expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
+      });
     });
 
     it("carries the plugin enable inside the try that answers the 409", async () => {

--- a/src/tests/routes/hermes-honest-settings.test.ts
+++ b/src/tests/routes/hermes-honest-settings.test.ts
@@ -16,6 +16,13 @@ vi.mock("@/lib/edition-source", () => ({ readEdition: () => readEdition() }));
 
 // The real module, except for the edition it resolves — everything else
 // (gatewayIsAbsent, readConfig's ENOENT behaviour) is exercised as shipped.
+// The catalogue is told out-of-band when a provider plugin is switched back
+// on; the real module forks `openclaw models list`.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
+
 vi.mock("@/lib/config-store", () => ({
   get: vi.fn(async () => undefined),
   set: vi.fn(async () => {}),

--- a/src/tests/routes/local-ai-exclusive-sessions.test.ts
+++ b/src/tests/routes/local-ai-exclusive-sessions.test.ts
@@ -36,6 +36,9 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(async () => ({
     agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro", fallbacks: [] } } },
   })),
+  // Strict, because the ON half of the plugin gate decides from ABSENCE and
+  // `readConfig` cannot tell an unreadable config from one carrying no flag.
+  readConfigStrict: vi.fn(async () => ({})),
   restartGateway: vi.fn(async () => {}),
   runOpenclawConfigSet: configSetMock,
   // The primary and the fallbacks travel in one `config set --batch-json` now

--- a/src/tests/routes/local-ai-exclusive-sessions.test.ts
+++ b/src/tests/routes/local-ai-exclusive-sessions.test.ts
@@ -36,9 +36,6 @@ vi.mock("@/lib/openclaw-config", () => ({
   readConfig: vi.fn(async () => ({
     agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro", fallbacks: [] } } },
   })),
-  // Strict, because the ON half of the plugin gate decides from ABSENCE and
-  // `readConfig` cannot tell an unreadable config from one carrying no flag.
-  readConfigStrict: vi.fn(async () => ({})),
   restartGateway: vi.fn(async () => {}),
   runOpenclawConfigSet: configSetMock,
   // The primary and the fallbacks travel in one `config set --batch-json` now

--- a/src/tests/routes/local-ai-exclusive-sessions.test.ts
+++ b/src/tests/routes/local-ai-exclusive-sessions.test.ts
@@ -47,6 +47,13 @@ vi.mock("@/lib/openclaw-config", () => ({
   }),
 }));
 
+// The catalogue is told out-of-band when a provider plugin is switched back
+// on; the real module forks `openclaw models list`.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
+
 vi.mock("@/lib/openclaw-session-store", () => ({
   listAgentIds: vi.fn(() => ["main", "legacy"]),
   // `main` is migrated (has a store); `legacy` is still on sessions.json.

--- a/src/tests/routes/local-ai/exclusive.test.ts
+++ b/src/tests/routes/local-ai/exclusive.test.ts
@@ -40,16 +40,13 @@ vi.mock("@/lib/openclaw-config", () => ({
   callGatewayRpc: vi.fn(),
   gatewayIsAbsent: vi.fn(() => false),
   readConfig: vi.fn(async () => ({})),
-  // Strict, because the ON half of the plugin gate decides from ABSENCE:
-  // `readConfig` cannot tell an unreadable config from one with no flag.
-  readConfigStrict: vi.fn(async () => ({})),
   restartGateway: vi.fn(async () => {}),
   runOpenclawConfigSet: vi.fn(async () => {}),
   runOpenclawConfigSetBatch: vi.fn(async () => {}),
 }));
 
 import { get, setMany } from "@/lib/config-store";
-import { readConfigStrict, restartGateway, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
+import { restartGateway, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 
 const UNKNOWN_MODEL =
@@ -149,56 +146,37 @@ describe("POST /setup-api/local-ai/exclusive — restoring the saved primary and
   // came back empty is recorded as a failed refresh whose wait doubles up to
   // the six-hour interval, so without this the provider is not even re-asked
   // for six hours after the toggle that made it listable again.
-  it("tells the catalogue when the restore switched the plugin back on", async () => {
-    vi.mocked(readConfigStrict).mockResolvedValue({
-      plugins: { entries: { anthropic: { enabled: false } } },
-    } as never);
-
+  it("tells the catalogue that the restore can switch the plugin back on", async () => {
+    // No pre-state is consulted, and that is the honest answer here rather than
+    // a shortcut: any snapshot this route could read would be read before a
+    // `config set --batch-json` that takes ~10 s on a Jetson, and a provider
+    // save landing in that window switches the plugin off through its own gate
+    // — leaving a stale "it was already on" reading that would swallow the
+    // switch-on this batch then performs. So the change is counted whenever the
+    // restore names the gated provider: this path runs once per Local-only
+    // exit, already restarts the gateway and re-patches every session, and at
+    // worst spends one enumeration — against a silent miss that leaves the
+    // catalogue behind until a doubling backoff expires.
     const response = await turnOff();
 
     expect(response.status).toBe(200);
     expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
   });
 
-  it("counts it when the pre-restore snapshot could not be read at all", async () => {
-    // The strict read is what makes this case distinguishable: an EACCES or a
-    // config caught half-written throws, while a box that simply has no config
-    // answers `{}`. Unknown is NOT "already on" — the restore still landed, so
-    // silence here would leave the catalogue on the pre-enable enumeration for
-    // six hours, whereas a needless announcement costs one enumeration that on
-    // such a box fails fast anyway.
-    vi.mocked(readConfigStrict).mockRejectedValue(new Error("EACCES"));
-
-    const response = await turnOff();
-
-    expect(response.status).toBe(200);
-    expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
-  });
-
-  it("says nothing when the flag was already on, absent, or no gated provider was named", async () => {
-    // The enable op rides in the batch whether or not the flag is already
-    // true — it is what makes the core validate the reference — so its
-    // presence is not a state change, and announcing one would spend a
-    // ~3-minute `openclaw models list` on a Jetson for a box that did not
-    // change.
-    vi.mocked(readConfigStrict).mockResolvedValue({
-      plugins: { entries: { anthropic: { enabled: true } } },
-    } as never);
-    await turnOff();
-    expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
-
-    // An ABSENT flag is enabled — the plugin declares `enabledByDefault: true`
-    // — so a config that was read and carries none is the ordinary box, not an
-    // unknown one.
-    vi.mocked(readConfigStrict).mockResolvedValue({} as never);
-    await turnOff();
-    expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
-
-    vi.mocked(readConfigStrict).mockResolvedValue({
-      plugins: { entries: { anthropic: { enabled: false } } },
-    } as never);
+  it("counts it for an Anthropic FALLBACK too, not only the primary", async () => {
     store.local_only_saved_primary = "openai/gpt-5.5";
+    store.local_only_saved_fallbacks = ["anthropic/claude-sonnet-5"];
+
     await turnOff();
+
+    expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
+  });
+
+  it("says nothing when the restore names no gated provider", async () => {
+    store.local_only_saved_primary = "openai/gpt-5.5";
+
+    await turnOff();
+
     expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
   });
 

--- a/src/tests/routes/local-ai/exclusive.test.ts
+++ b/src/tests/routes/local-ai/exclusive.test.ts
@@ -40,13 +40,16 @@ vi.mock("@/lib/openclaw-config", () => ({
   callGatewayRpc: vi.fn(),
   gatewayIsAbsent: vi.fn(() => false),
   readConfig: vi.fn(async () => ({})),
+  // Strict, because the ON half of the plugin gate decides from ABSENCE:
+  // `readConfig` cannot tell an unreadable config from one with no flag.
+  readConfigStrict: vi.fn(async () => ({})),
   restartGateway: vi.fn(async () => {}),
   runOpenclawConfigSet: vi.fn(async () => {}),
   runOpenclawConfigSetBatch: vi.fn(async () => {}),
 }));
 
 import { get, setMany } from "@/lib/config-store";
-import { readConfig, restartGateway, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
+import { readConfigStrict, restartGateway, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
 import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 
 const UNKNOWN_MODEL =
@@ -147,7 +150,7 @@ describe("POST /setup-api/local-ai/exclusive — restoring the saved primary and
   // the six-hour interval, so without this the provider is not even re-asked
   // for six hours after the toggle that made it listable again.
   it("tells the catalogue when the restore switched the plugin back on", async () => {
-    vi.mocked(readConfig).mockResolvedValue({
+    vi.mocked(readConfigStrict).mockResolvedValue({
       plugins: { entries: { anthropic: { enabled: false } } },
     } as never);
 
@@ -157,19 +160,41 @@ describe("POST /setup-api/local-ai/exclusive — restoring the saved primary and
     expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
   });
 
-  it("says nothing when the flag was already on, or the restore named no gated provider", async () => {
+  it("counts it when the pre-restore snapshot could not be read at all", async () => {
+    // The strict read is what makes this case distinguishable: an EACCES or a
+    // config caught half-written throws, while a box that simply has no config
+    // answers `{}`. Unknown is NOT "already on" — the restore still landed, so
+    // silence here would leave the catalogue on the pre-enable enumeration for
+    // six hours, whereas a needless announcement costs one enumeration that on
+    // such a box fails fast anyway.
+    vi.mocked(readConfigStrict).mockRejectedValue(new Error("EACCES"));
+
+    const response = await turnOff();
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
+  });
+
+  it("says nothing when the flag was already on, absent, or no gated provider was named", async () => {
     // The enable op rides in the batch whether or not the flag is already
     // true — it is what makes the core validate the reference — so its
     // presence is not a state change, and announcing one would spend a
     // ~3-minute `openclaw models list` on a Jetson for a box that did not
     // change.
-    vi.mocked(readConfig).mockResolvedValue({
+    vi.mocked(readConfigStrict).mockResolvedValue({
       plugins: { entries: { anthropic: { enabled: true } } },
     } as never);
     await turnOff();
     expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
 
-    vi.mocked(readConfig).mockResolvedValue({
+    // An ABSENT flag is enabled — the plugin declares `enabledByDefault: true`
+    // — so a config that was read and carries none is the ordinary box, not an
+    // unknown one.
+    vi.mocked(readConfigStrict).mockResolvedValue({} as never);
+    await turnOff();
+    expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
+
+    vi.mocked(readConfigStrict).mockResolvedValue({
       plugins: { entries: { anthropic: { enabled: false } } },
     } as never);
     store.local_only_saved_primary = "openai/gpt-5.5";

--- a/src/tests/routes/local-ai/exclusive.test.ts
+++ b/src/tests/routes/local-ai/exclusive.test.ts
@@ -23,6 +23,13 @@ vi.mock("@/lib/config-store", () => ({
   setMany: vi.fn(async () => {}),
 }));
 
+// The catalogue is told out-of-band when a restore switches a provider plugin
+// back on; the real module forks `openclaw models list`.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
+
 vi.mock("@/lib/openclaw-session-store", () => ({
   listAgentIds: vi.fn(() => []),
   sessionStorePath: vi.fn(() => null),
@@ -39,7 +46,8 @@ vi.mock("@/lib/openclaw-config", () => ({
 }));
 
 import { get, setMany } from "@/lib/config-store";
-import { restartGateway, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
+import { readConfig, restartGateway, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
+import { notifyProviderSetChanged } from "@/app/setup-api/ai-models/catalog/route";
 
 const UNKNOWN_MODEL =
   'Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary: '
@@ -128,6 +136,45 @@ describe("POST /setup-api/local-ai/exclusive — restoring the saved primary and
       ["agents.defaults.model.primary", JSON.stringify("openai/gpt-5.5"), "--json"],
       ["agents.defaults.model.fallbacks", JSON.stringify(["anthropic/claude-sonnet-5"]), "--json"],
     ]);
+  });
+
+  // A plugin that is off enumerates NOTHING, and the comment above these
+  // enables says why this route is where it can be off: "a provider save made
+  // while Local-only was on may have switched that plugin off". So this
+  // restore is a provider-set change, it is the only write on this route that
+  // makes one, and nothing else can tell the catalogue — an enumeration that
+  // came back empty is recorded as a failed refresh whose wait doubles up to
+  // the six-hour interval, so without this the provider is not even re-asked
+  // for six hours after the toggle that made it listable again.
+  it("tells the catalogue when the restore switched the plugin back on", async () => {
+    vi.mocked(readConfig).mockResolvedValue({
+      plugins: { entries: { anthropic: { enabled: false } } },
+    } as never);
+
+    const response = await turnOff();
+
+    expect(response.status).toBe(200);
+    expect(vi.mocked(notifyProviderSetChanged)).toHaveBeenCalledWith("anthropic");
+  });
+
+  it("says nothing when the flag was already on, or the restore named no gated provider", async () => {
+    // The enable op rides in the batch whether or not the flag is already
+    // true — it is what makes the core validate the reference — so its
+    // presence is not a state change, and announcing one would spend a
+    // ~3-minute `openclaw models list` on a Jetson for a box that did not
+    // change.
+    vi.mocked(readConfig).mockResolvedValue({
+      plugins: { entries: { anthropic: { enabled: true } } },
+    } as never);
+    await turnOff();
+    expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
+
+    vi.mocked(readConfig).mockResolvedValue({
+      plugins: { entries: { anthropic: { enabled: false } } },
+    } as never);
+    store.local_only_saved_primary = "openai/gpt-5.5";
+    await turnOff();
+    expect(vi.mocked(notifyProviderSetChanged)).not.toHaveBeenCalled();
   });
 
   it("does not restore a saved primary that is the ClawBox AI image entry", async () => {

--- a/src/tests/routes/providers/enabled.test.ts
+++ b/src/tests/routes/providers/enabled.test.ts
@@ -16,6 +16,11 @@ vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 vi.mock("@/lib/harness/credentials", () => ({ hasClawaiToken: vi.fn() }));
 vi.mock("@/lib/openclaw-config", () => ({ readConfig: vi.fn() }));
 vi.mock("@/lib/hermes-model-options", () => ({ getModelOptions: vi.fn() }));
+// The catalogue is told out-of-band; the real one forks `openclaw models list`.
+vi.mock("@/app/setup-api/ai-models/catalog/route", () => ({
+  notifyProviderSetChanged: vi.fn(),
+  refreshInBackground: vi.fn(),
+}));
 // An in-memory store behind the real module's constants, so the round trip is
 // what a device would see: the write the route makes is the read the next
 // status makes. (The cookie verifier reads `DATA_DIR` at import.)
@@ -42,6 +47,7 @@ let readConfig: Mock;
 let getModelOptions: Mock;
 let configSet: Mock;
 let setProviderEnabled: Mock;
+let notifyProviderSetChanged: Mock;
 
 function ownerCookie(): string {
   return `clawbox_session=${createSessionCookie(3600, SESSION_SECRET)}`;
@@ -91,6 +97,8 @@ beforeEach(async () => {
     models: { providers: { openrouter: { apiKey: "sk-or-secret" } } },
     agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
   });
+
+  ({ notifyProviderSetChanged } = (await import("@/app/setup-api/ai-models/catalog/route")) as unknown as { notifyProviderSetChanged: Mock });
 
   ({ POST } = await import("@/app/setup-api/providers/enabled/route"));
 });
@@ -177,6 +185,30 @@ describe("the round trip", () => {
     expect(on.status).toBe(200);
     expect(rowFor(await on.json(), "openrouter")!.enabled).toBe(true);
     expect(store.get("ai_disabled_providers")).toEqual([]);
+  });
+
+  // A switch flip IS a provider-set change, and this route used to make one
+  // without telling the catalogue at all: the client's `?refresh=1` was its
+  // only signal, and a non-browser caller had none. Switching a provider off
+  // empties its `openclaw models list`; switching it back on is what makes it
+  // enumerable again. Only a server-side write can COUNT that — the client's
+  // nudge deliberately cannot — so the catalogue would otherwise sit on the
+  // pre-flip enumeration for the whole 6h refresh interval.
+  it("tells the catalogue the provider set changed, both ways", async () => {
+    setProviderEnabled.mockResolvedValue({ ok: true, provider: "openrouter" });
+
+    await asOwner({ provider: "openrouter", enabled: false });
+    expect(notifyProviderSetChanged).toHaveBeenCalledWith("openrouter");
+
+    notifyProviderSetChanged.mockClear();
+    await asOwner({ provider: "openrouter", enabled: true });
+    expect(notifyProviderSetChanged).toHaveBeenCalledWith("openrouter");
+  });
+
+  it("does not tell the catalogue about a flip the rule refused", async () => {
+    // 409/404 return before the write; nothing changed, so nothing is counted.
+    await asOwner({ provider: "anthropic", enabled: false });
+    expect(notifyProviderSetChanged).not.toHaveBeenCalled();
   });
 
   it("stores the canonical id whatever spelling the caller used", async () => {

--- a/src/tests/routes/providers/enabled.test.ts
+++ b/src/tests/routes/providers/enabled.test.ts
@@ -48,6 +48,7 @@ let getModelOptions: Mock;
 let configSet: Mock;
 let setProviderEnabled: Mock;
 let notifyProviderSetChanged: Mock;
+let refreshInBackground: Mock;
 
 function ownerCookie(): string {
   return `clawbox_session=${createSessionCookie(3600, SESSION_SECRET)}`;
@@ -98,7 +99,7 @@ beforeEach(async () => {
     agents: { defaults: { model: { primary: "anthropic/claude-sonnet-4-6" } } },
   });
 
-  ({ notifyProviderSetChanged } = (await import("@/app/setup-api/ai-models/catalog/route")) as unknown as { notifyProviderSetChanged: Mock });
+  ({ notifyProviderSetChanged, refreshInBackground } = (await import("@/app/setup-api/ai-models/catalog/route")) as unknown as { notifyProviderSetChanged: Mock; refreshInBackground: Mock });
 
   ({ POST } = await import("@/app/setup-api/providers/enabled/route"));
 });
@@ -187,28 +188,23 @@ describe("the round trip", () => {
     expect(store.get("ai_disabled_providers")).toEqual([]);
   });
 
-  // A switch flip IS a provider-set change, and this route used to make one
-  // without telling the catalogue at all: the client's `?refresh=1` was its
-  // only signal, and a non-browser caller had none. Switching a provider off
-  // empties its `openclaw models list`; switching it back on is what makes it
-  // enumerable again. Only a server-side write can COUNT that — the client's
-  // nudge deliberately cannot — so the catalogue would otherwise sit on the
-  // pre-flip enumeration for the whole 6h refresh interval.
-  it("tells the catalogue the provider set changed, both ways", async () => {
+  // The flip writes ONE thing: ClawBox's own `ai_disabled_providers` key, in
+  // ClawBox's own store. `openclaw models list` has never heard of it, and the
+  // catalogue route never reads it — so this switch cannot change what the
+  // catalogue enumerates, and announcing it spent a full ~3-minute, ~2-core
+  // `openclaw models list` on a Jetson per click (twice for an off-and-on) to
+  // be told the same rows again, clearing the failed-refresh backoff each
+  // time. The enumeration DOES change later, when the next save or chat-model
+  // pick re-gates the anthropic plugin — and that write counts its own change.
+  it("does not spend an enumeration on a switch the catalogue cannot see", async () => {
     setProviderEnabled.mockResolvedValue({ ok: true, provider: "openrouter" });
 
     await asOwner({ provider: "openrouter", enabled: false });
-    expect(notifyProviderSetChanged).toHaveBeenCalledWith("openrouter");
-
-    notifyProviderSetChanged.mockClear();
     await asOwner({ provider: "openrouter", enabled: true });
-    expect(notifyProviderSetChanged).toHaveBeenCalledWith("openrouter");
-  });
-
-  it("does not tell the catalogue about a flip the rule refused", async () => {
-    // 409/404 return before the write; nothing changed, so nothing is counted.
     await asOwner({ provider: "anthropic", enabled: false });
+
     expect(notifyProviderSetChanged).not.toHaveBeenCalled();
+    expect(refreshInBackground).not.toHaveBeenCalled();
   });
 
   it("stores the canonical id whatever spelling the caller used", async () => {

--- a/src/tests/unit/openclaw-config-provider-plugins.test.ts
+++ b/src/tests/unit/openclaw-config-provider-plugins.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
+import { enableProviderPluginOps, providerPluginSwitchedOnBy } from "@/lib/provider-plugin-ops";
 
 /**
  * The anthropic plugin toggle is two halves around the primary write: the
@@ -100,6 +100,44 @@ describe("enableProviderPluginOps — the ops that ride in the primary batch, ah
     expect(enableProviderPluginOps(["openai/gpt-5.5", "anthropic/claude-sonnet-5", "anthropic/claude-haiku-4-5"])).toEqual([
       ["plugins.entries.anthropic.enabled", "true", "--json"],
     ]);
+  });
+});
+
+// A plugin that is off enumerates NOTHING: `openclaw models list --provider
+// anthropic` is empty until it is switched back on. So the ON half is a
+// provider-set change exactly as the OFF half is, and the catalogue has to
+// count it — an empty enumeration is recorded as a failed refresh, and that
+// wait doubles up to the six-hour refresh interval, so a provider whose plugin
+// has been off for a while would not be re-asked for six hours after the very
+// pick that made it listable. Nothing could see that transition: the enable
+// rides in the batch, so by the time `setProviderPlugins` re-reads the config
+// the flag is already true and it correctly reports no flip.
+describe("providerPluginSwitchedOnBy — which provider the batch actually switches ON", () => {
+  const OFF = { plugins: { entries: { anthropic: { enabled: false } } } } as never;
+  const ON = { plugins: { entries: { anthropic: { enabled: true } } } } as never;
+
+  it("names the provider when the flag was off", () => {
+    expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], OFF)).toBe("anthropic");
+    // A fallback names it too, and is validated exactly like the primary.
+    expect(providerPluginSwitchedOnBy(["llamacpp/gemma", "anthropic/claude-haiku-4-5"], OFF)).toBe("anthropic");
+  });
+
+  it("stays silent when the flag was already on, however it was spelled", () => {
+    // The ops are emitted whether or not the flag is already true — that is
+    // deliberate, because the enable is also what makes the core validate the
+    // reference. Their presence is not a state change, and announcing one per
+    // Claude pick would spend a ~3-minute `openclaw models list` on a Jetson.
+    expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], ON)).toBeNull();
+    // An ABSENT flag is enabled: the plugin declares `enabledByDefault: true`.
+    expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], {})).toBeNull();
+    // And a config that could not be read must not be reported as a change.
+    expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], null)).toBeNull();
+  });
+
+  it("stays silent when the batch names no gated provider at all", () => {
+    expect(providerPluginSwitchedOnBy(["openai/gpt-5.5", "llamacpp/gemma"], OFF)).toBeNull();
+    expect(providerPluginSwitchedOnBy([], OFF)).toBeNull();
+    expect(providerPluginSwitchedOnBy([null, undefined, "no-slash"], OFF)).toBeNull();
   });
 });
 

--- a/src/tests/unit/openclaw-config-provider-plugins.test.ts
+++ b/src/tests/unit/openclaw-config-provider-plugins.test.ts
@@ -128,10 +128,24 @@ describe("providerPluginSwitchedOnBy — which provider the batch actually switc
     // reference. Their presence is not a state change, and announcing one per
     // Claude pick would spend a ~3-minute `openclaw models list` on a Jetson.
     expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], ON)).toBeNull();
-    // An ABSENT flag is enabled: the plugin declares `enabledByDefault: true`.
+    // An ABSENT flag is enabled: the plugin declares `enabledByDefault: true`,
+    // so a config that WAS read and carries none is the ordinary box.
     expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], {})).toBeNull();
-    // And a config that could not be read must not be reported as a change.
-    expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], null)).toBeNull();
+  });
+
+  it("counts it when the pre-write config could not be read", () => {
+    // `null` is the caller saying "the strict read failed" — not the same
+    // claim as `{}`, which is a config that was read and has no flag. The
+    // costs are not symmetric: after a batch that succeeded the flag IS true,
+    // so announcing on an unknown pre-state costs at most one enumeration,
+    // while silence over a real switch-on leaves the catalogue serving a list
+    // stamped `source: "live"` that the box has stopped agreeing with, for six
+    // hours. This is the trap the OFF half documents and avoids by reading
+    // strictly.
+    expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], null)).toBe("anthropic");
+    expect(providerPluginSwitchedOnBy(["anthropic/claude-sonnet-5"], undefined)).toBe("anthropic");
+    // Still nothing when the batch names no gated provider at all.
+    expect(providerPluginSwitchedOnBy(["openai/gpt-5.5"], null)).toBeNull();
   });
 
   it("stays silent when the batch names no gated provider at all", () => {

--- a/src/tests/unit/provider-models.test.ts
+++ b/src/tests/unit/provider-models.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   PROVIDER_CATALOGS,
+  fetchProviderCatalog,
   getProviderCatalog,
+  isNonChatModelId,
   isValidModelId,
   parseModelSlug,
 } from "@/lib/provider-models";
@@ -55,6 +57,94 @@ describe("provider-models", () => {
       expect(isValidModelId("openai", "openai/gpt-5")).toBe(false);
       expect(isValidModelId("openrouter", "anthropic/claude-haiku-4.5")).toBe(true);
       expect(isValidModelId("openrouter", "anthropic/claude/")).toBe(false);
+    });
+  });
+
+  describe("isNonChatModelId", () => {
+    // Moved here from the catalog route so the second catalogue surface can
+    // share it. The OpenRouter case is the one that was broken: the pattern is
+    // anchored, and OpenRouter ids keep their `<org>/<model>` slug, so matching
+    // it against the whole id made the exclusion silently inert for the largest
+    // catalogue we serve.
+    it("matches an image SKU behind an OpenRouter org slug", () => {
+      expect(isNonChatModelId("openai/gpt-image-1-mini")).toBe(true);
+      expect(isNonChatModelId("gpt-image-1-mini")).toBe(true);
+    });
+
+    it("matches the suffix families, wherever the suffix ends", () => {
+      expect(isNonChatModelId("gpt-4o-audio-preview")).toBe(true);
+      expect(isNonChatModelId("gpt-4o-transcribe")).toBe(true);
+      expect(isNonChatModelId("gpt-4o-mini-tts")).toBe(true);
+    });
+
+    it("keeps every chat model, including generations we have never seen", () => {
+      expect(isNonChatModelId("openai/gpt-5.6-sol")).toBe(false);
+      expect(isNonChatModelId("anthropic/claude-opus-5")).toBe(false);
+      // A modality exclusion must never become a generation allowlist: an id
+      // this list does not recognise is a chat model until proven otherwise.
+      expect(isNonChatModelId("openai/gpt-7-hypothetical")).toBe(false);
+    });
+  });
+
+  describe("fetchProviderCatalog", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    /** Answer every catalog GET with `body`. */
+    function mockRoute(body: unknown): void {
+      vi.stubGlobal("fetch", vi.fn(async () => ({
+        ok: true,
+        json: async () => body,
+      })));
+    }
+
+    it("carries `warming` through an empty catalogue, so the picker keeps asking", async () => {
+      // Reachable on an upgraded box: the route serves a cached payload whose
+      // rows its current sanitiser filters away entirely, with `warming: true`
+      // because the re-enumeration it just started is genuinely in flight.
+      mockRoute({ provider: "anthropic", models: [], warming: true });
+
+      const resolved = await fetchProviderCatalog("anthropic");
+
+      // The curated rows are rendered — a blank picker helps nobody — and they
+      // say what they are.
+      expect(resolved.fallback).toBe(true);
+      expect(resolved.models.length).toBeGreaterThan(0);
+      // And `warming` survives, because it is the only field
+      // `useProviderCatalog` polls on. Dropping it stopped the retry loop on
+      // exactly the box that was seconds away from a real answer.
+      expect(resolved.warming).toBe(true);
+    });
+
+    it("does not invent `warming` for an empty catalogue nobody is enumerating", async () => {
+      // A provider under the route's failed-refresh backoff: no fork is out
+      // there, so polling it would be a request loop with no destination.
+      mockRoute({ provider: "anthropic", models: [] });
+
+      const resolved = await fetchProviderCatalog("anthropic");
+
+      expect(resolved.fallback).toBe(true);
+      expect(resolved.warming).toBeUndefined();
+    });
+
+    it("marks a payload the route did not stamp `source: \"live\"` as a fallback", async () => {
+      mockRoute({
+        provider: "anthropic",
+        models: [{ id: "claude-opus-5", label: "Claude Opus 5", contextWindow: 1_000_000 }],
+        defaultModelId: "claude-opus-5",
+      });
+
+      expect((await fetchProviderCatalog("anthropic")).fallback).toBe(true);
+
+      mockRoute({
+        provider: "anthropic",
+        models: [{ id: "claude-opus-5", label: "Claude Opus 5", contextWindow: 1_000_000 }],
+        defaultModelId: "claude-opus-5",
+        source: "live",
+      });
+
+      expect((await fetchProviderCatalog("anthropic")).fallback).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## M-05 (board TASK-653) — the picker showed a hard-coded list as if it were the box's own

**The ask:** *"I want the latest and the correct (usable) models to be pulled, not hard-coded. This is for Anthropic and Codex both. Find the best way in the OpenClaw docs and leverage that."*

### The harness mechanism this leverages

Nothing new is built here. The catalogue is the harness's; this PR stops overwriting it with ours.

- `openclaw models list --provider <id> --all --json` — the catalogue. `--all` is "show full model catalog" against the default "configured only" (`openclaw models list --help`, 2026.8.1).
- `openclaw models refresh` — forces the hosted-catalogue check the Gateway otherwise makes at most every six hours.
- `openclaw models auth login --provider openai` — the ChatGPT sign-in. Per docs.openclaw.ai/cli/models, `--provider openai` *is* the ChatGPT/Codex account login; there is no `codex` provider on OpenClaw 2.
- docs.openclaw.ai/concepts/models — the catalogue resolves from three layers (bundled, plugin-captured, remote refresh), and: *"The catalog supplies browse choices and model metadata; it is not an implicit allowlist"*, *"Provider availability, runtime compatibility, and authentication are validated independently."*
- The per-row `available` field mirrors the CLI's Auth column, which the docs describe as a read-only check resolving each route to eligible profiles and credentials, reported `ok` / `unknown` / `unavailable`. In `--json` those are `true` / `null` / `false`.

### Cause

`data/catalog-cache/anthropic.json` on the affected box (fetchedAt 07:13) held exactly the three ids of `ANTHROPIC_MODELS`, and the web-server log has `[catalog] refreshed …` lines for openai/codex/openrouter/google and none for anthropic.

At 07:13 the Anthropic plugin was disabled and the live enumeration came back thin. `buildPayload` ran every publish through `augmentWithStaticCatalog`, which appends the curated cold-start list, and the merged result was written to the disk cache with a fresh `fetchedAt`. From then on the file looked like a device answer, the 6h staleness check saw nothing wrong with it, and the picker offered three models on a box that could run eleven — for the rest of the day.

Two more instances of the same shape:

- `[catalog] refreshed codex: 0 models` — zero models was treated as a successful refresh, so the six hard-coded `CODEX_MODELS` were persisted as `codex.json`. The reason has to be read out of the CLI's own body, not its exit code: measured on 2026.8.1, `models list --provider codex --all --json` prints `{"ok": false, "error": {"message": "Unknown provider filter \"codex\" for this installation…"}}` on **stdout**, with an empty stderr and **exit code 0**.
- `ALLOWED_MODEL_RE_BY_PROVIDER.openai = /^gpt-5\.[45](-pro|-mini)?$/` matched **none** of the gpt-5.6 generation. Measured on a stock 2026.8.1 host, `openclaw models list --provider openai --all --json` answers with one row — `openai/gpt-5.6-sol`, tagged default — and that regex filtered it out, leaving the picker on five hand-written ids.

### The fix

1. **A fallback is never persisted, and never presented as live.** Only a live enumeration reaches `writeDiskCache`, stamped `source: "live"`. That stamp is the ONE marker on the wire — its absence is what tells the client it is holding the curated list, so there is no second boolean beside it that can disagree. A payload built from the curated list is never written. An unmarked cache — an older build's, or one the old path wrote — counts as *not* live, so an upgraded box re-enumerates instead of sitting on it.
2. **Zero models is not a success.** The previous good catalogue is kept and marked stale, the reason is logged, and a later request retries. An empty result says *which* empty it was: a refusal, every row reporting `available: false`, or rows that were all non-chat SKUs.
3. **The curated arrays no longer merge into an enumeration.** They are cold-start display only, in their curated order; the one thing they still add to a live row is a `hint`, which no enumeration returns. They can no longer hide or dilute a live row.
4. **The harness's `available` is honoured** — dropping a row only when it is explicitly `false`. `null` is "not determined" (what an unconfigured host answers for every row) and is never read as "no".
5. **The ChatGPT catalogue is not synthesised from the openai one.** The tempting move — serve `codex` from the `openai` catalogue narrowed by the documented ChatGPT-account allowlist — is wrong: the openai catalogue is **not plan-scoped**. It lists `gpt-5.6-sol` on any box while gpt-5.6 is plan-gated upstream, so a Free account would have been offered it as the only row *and* handed it as the saved default, and every turn would 400. `available` cannot rescue it either — every openai row reads `true` as soon as any openai profile exists, and on the affected box that was the ClawBox AI image token, an API key that cannot chat. This core exposes no enumeration of the ChatGPT surface. That is a finding, not a licence to synthesise one, so `codex` enumerates nothing and its picker gets the curated list marked `fallback`, with the CLI's refusal logged.
6. **The `openai` generation allowlist is gone**, replaced by a modality exclusion (image, audio/realtime/transcribe/tts, video, embeddings, moderation, the completion engines), tested against the model segment after the last slash so it is not silently inert for OpenRouter's `vendor/model` ids. A generation allowlist cannot know what the next generation is called; a modality exclusion can only hide SKUs a chat picker has no way to talk to. `openclaw models list` offers no capability filter and the rows carry no capability field — worth reporting upstream; until then this is the honest stopgap.
7. **A provider that cannot answer is not asked on every request.** "Re-enumerate whenever the payload is not live" would make a provider that can never enumerate fork `openclaw models list` on every picker open — ~3 minutes and ~2 cores of a Jetson each. A failed attempt now makes the next one wait, doubling to the refresh interval and cleared by a success; `?refresh=1` does not bypass it, because the client retry is the thing being rate-limited. One map carries both the deadline and the wait that produced it: derived from the deadline alone the doubling cannot happen at all, because an attempt only gets past the guard once the deadline has passed. That map's key set is also the stale mark, which lives there rather than on the cached payload because at boot warmup there is no payload to mark — that failure used to be forgotten until the 6h interval expired.
8. **A refresh is not "done" while half of it is still running.** A provider whose subscription narrows to a second catalogue enumerates twice, and the single-flight guard is released once — in `finally`, after both forks settle — rather than in each arm that can end early. The arms that ended early were exactly the ones that forgot, and a released guard there lets the next request start a second multi-minute `openclaw models list` beside a fork already holding ~2 cores of a Jetson.
9. **The pickers ask again, and only while it is worth asking.** `useProviderCatalog` re-reads with `?refresh=1` on the provider-set signal that every successful connect and the per-provider switch already emit, and polls while the route says `warming` — an enumeration really in flight — rather than while the answer is merely a `fallback`, which a provider that cannot enumerate serves forever.

One defect found while fixing the above and fixed here: the hook first subscribed through `onProvidersChanged`, whose event union includes `CHAT_MODEL_STATE_EVENT` — the chat's model **selection** event, which `ChatPopup` dispatches on every switch. Picking a different row therefore re-asked the box for a fresh three-minute enumeration. It now listens to `PROVIDERS_CHANGED_EVENT` alone.

### Second round — the Opus review pass sent this back, and what changed

**HIGH 1 — the brake recreated the symptom.** `refreshIsBlocked` sat in front of *every* caller of `refreshInBackground`, including the configure route's post-save refresh at step 8c. That call runs one statement after the plugin is switched on and the credential written — the moment a provider that could not enumerate starts being able to. On a box whose pre-auth enumeration failed (an empty snapshot records a 2-minute backoff, which is exactly the "single fallback entry or empty" state step 8c's own comment was written about) the connect started no fork, so the response carried no `warming`, so `useProviderCatalog` stopped polling, so the picker kept the curated list until some unrelated later request — with the wait doubling each time. The reported symptom, arriving through this PR's own brake.

The brake now rate-limits only *a client asking again*. `refreshInBackground(provider, { providerChanged: true })` clears the entry, and the two callers that mean "the box changed" pass it: the configure route, and a `?refresh=1` GET — which is safe to treat as a provider-set signal only because this PR already stopped the hook sending it on warming polls. The fork rate stays bounded by `refreshing`: one enumeration per provider at a time.

**HIGH 2 — the capability field was named, not read.** The comment and this body both said OpenRouter's `architecture.output_modalities` was read instead of the name pattern. `grep -rn output_modalities src/` returned exactly one hit: that comment. Measured against the endpoint this route actually fetches (`https://openrouter.ai/api/v1/models`, 2026-09-02, 423 rows):

* **every row carries the field** — 408 `["text"]`, 11 `["image","text"]`, 4 `["audio","text"]`;
* of the 15 non-text rows the old name pattern caught **2**, so **13 image/audio SKUs were being offered as chat models** — `google/gemini-2.5-flash-image`, `openai/gpt-5-image`, `openai/gpt-5.4-image-2`, `google/lyria-3-pro-preview`, `openai/gpt-audio`, …

The field is now the answer for that catalogue and the name pattern is not applied to it at all (`MODALITY_REPORTING_PROVIDERS`). OpenRouter's own `openrouter/` namespace is exempt from the modality test: `openrouter/auto` and `auto-beta` report `["image","text"]` because a router's modalities are the union over everything it can route to, not a claim about one model — dropping them would have been a new false failure.

The name pattern stays for the CLI catalogues, which publish nothing of the sort, and **its families are now measured against those same 423 rows**: widened with `-image`, `imagen-*`, `veo-*`, `lyria-*` it drops 13 of the 15 non-text rows and produces **zero** false failures. `vision` is deliberately not a family — `deepseek/deepseek-v4-flash-vision-exp` is a text-output chat model.

One correction to the review on this point, from the same measurement: `openai/gpt-audio` and `openai/gpt-audio-mini` are **not** text-output chat models being wrongly dropped. They report `output_modalities: ["audio","text"]`, so the field-based rule drops them for the same reason the name rule did. There are **no** text-output rows the pattern excludes.

**MEDIUM — the harness's own `default` tag now wins.** `openclaw models list` tags one row per provider and the route threw it away for `DEFAULT_MODEL_BY_PROVIDER`: on a stock 2026.8.1 host the box says `gpt-5.6-sol` and the map said `gpt-5.4`. That is the hard-coded defect pointed at the default instead of the list. The map stays as the fallback for a catalogue that tags nothing and for the curated rows, which carry no tag.

**MEDIUM — one Codex allowlist, not three.** `ALLOWED_MODEL_RE_BY_PROVIDER.codex` was a hand-kept copy of `CODEX_SUPPORTED_MODEL_RE`, whose own doc says it lives in `subscription-surface.ts` so that "a second copy in the second route is a copy that can drift". It is imported now. (`scripts/gateway-pre-start.sh` keeps a third mirror because it runs before node exists; that one is pinned by its own test and cannot import.)

**LOW — the surface publish no longer bypasses its own route.** `fetchSubscriptionSurfaceIds` hand-assembled a `source: "live"` payload past `buildPayload`, `sanitizeCatalogModels` and both guards, and took neither the single-flight set nor the backoff — a second, quieter way for this route to persist something no other path would produce. It goes through `buildPayload` and takes `refreshing` now. Unreachable today (`SUBSCRIPTION_SURFACE` has no `surfaceProvider` entry), so this is correct-by-reasoning rather than by test.

**LOW — the `source` doc now says what the stamp means.** It claimed `"live"` meant a device enumeration answered, while `clawai` is resolved from a literal and stamped all the same. The rule the field carries is "not a placeholder for an answer", not "a subprocess ran"; Mike's gateway routes exactly those two device tiers, so they are the routing table.

**Filed, not fixed, with the reason:**

* `codex` is hard-coded into `NO_CLI_ENUMERATION_PROVIDERS` rather than learned from the CLI's refusal. Correct today and heavily documented; asking costs a ~3-minute fork per backoff window on a Jetson to be told something already written down. Worth revisiting when the core's provider set changes.
* `stale` is permanently true for `codex` and for every provider on a Hermes box, because their refresh branch can never succeed. No UI reads `ResolvedProviderCatalog.stale` (grepped across `src/components` and `src/hooks`), so it is inert — but the flag cannot be given a meaning until this is fixed.
* `writeOpenAICompatProvider` in `configure/route.ts` still writes the curated `ANTHROPIC_MODELS` / `GOOGLE_MODELS` ids into `models.providers.<p>.models`. That is the last place a hand-written list reaches the harness's own config, squarely inside the owner's ask, and it is #584's file. **Unverified without a device** whether `models.mode = merge` stops it narrowing what `models list` returns.

### Third round — the final review pass, and what changed

**HIGH — a provider-set change arriving during an in-flight fork was dropped, and the pre-credential answer was published as `live`.** The previous round put the `providerChanged` bypass in front of the *backoff* guard and not in front of the *single-flight* guard one line above it, so the call it was written for (configure step 8c) was still silently dropped whenever an enumeration was already running — and nothing re-armed it when that fork settled.

On the wizard's own timeline this is the common case, not a race: `bootWarmup` starts on the **first picker GET**, not at boot, and staggers the providers 5 s apart at ~3 minutes each on a Jetson, so a key saved a minute after the AI-models step opens lands inside its provider's window. The pre-key fork then published its answer — **one** openai row on a stock host where a linked box lists ten — with `source: "live"` and a fresh `fetchedAt`, so `force || isStale || !isLivePayload` was false against it **for six hours**. This branch's own marker vouching for exactly what it exists to catch: bug class *false success*, through the last unguarded sibling of the previous round's fix.

Fixed with a `pendingProviderChange` set: the change is remembered at the single-flight return and re-entered from the `.finally` that releases the guard, deleted before the re-entry so it can fire at most once per signal and stays serialised by `refreshing`.

**MEDIUM — `warming` was suppressed whenever the cached payload was live.** That clause is what stops a routine 6 h refresh making every mounted picker poll, but it also hid the one case that matters: the box just changed and an enumeration *is* in flight. `useProviderCatalog` polls on `warming` alone, so it read once and settled while the post-credential list landed with nobody asking, and the customer saw the old list until the panel was remounted. `force` now counts as well.

**MEDIUM — freshness was judged on the RAW cache, before the sanitiser could empty it.** A live, under-6 h payload whose every row the current rules filter out was served as `models: []` with no `stale`, no fork started and no `warming`, so the client rendered the curated list forever. Freshness and `warming` are now computed on what is actually served. Not reachable from a payload this build wrote — the transform and the sanitiser share `isOfferableModelId` — but it arrives the first time a filter is tightened, which is precisely what this branch did to the previous generation of caches. (CodeRabbit's run summary raised the same point, "count sanitized offerable rows before deciding freshness"; it never turned into code until now.)

**LOW — the `providerChanged` clear ran ahead of the missing-CLI guard**, which cost that guard the one-log-line-per-backoff-window property its own comment claims on a Hermes box (Settings renders `AIModelsStep` on every edition). The clear now skips both cases where no change to the box could make the provider enumerable — `codex`, and an edition with no CLI.

**Filed, with the reason, not fixed:**

* **The backoff is bypassable by a client that loops `?refresh=1`.** True. `openrouter`'s fetch fails in ≤8 s, so a loop could start one every ~8 s; the CLI providers are bounded to one fork per ~3 min by the in-flight guard. Concurrency stays 1 (`refreshing`), so this is cost, not corruption, and the shipped client sends `refresh=1` once per provider-set signal. Rate-limiting the *clear*, or honouring `providerChanged` only from the server-side caller, is the fix if it ever becomes one — both narrow the mechanism that just fixed the HIGH, so not in this PR.
* **`stale` is permanently true for `codex` and for every provider on Hermes** and nothing reads `ResolvedProviderCatalog.stale`. Inert today; it means the flag cannot be given a UI meaning until this is fixed.
* **`DEPRECATED_MODEL_IDS` is a hand-maintained id list** inside a PR whose thesis is that hand-written lists go stale. The harness's own `tags: ["deprecated"]` and OpenRouter's `deprecated` flag are both read, so it is belt-and-braces — and measured, **0 of the 423 live OpenRouter rows carry `deprecated: true`**, so the flags alone would not have covered the two Anthropic ids it holds. Left, deliberately.
* **`writeOpenAICompatProvider` still writes curated ids into `models.providers.<p>.models`** (`configure/route.ts`, #584's file). Still **unverified without a device**, and load-bearing: if `models.mode = merge` does not stop that array narrowing `openclaw models list`, then on every API-key box this PR's "live" catalogue is the curated list laundered through the harness. The repo's own evidence points the other way — the affected box listed 11 anthropic rows while `ANTHROPIC_MODELS` has 3 — and one command settles it: `openclaw models list --provider anthropic --all --json | jq '.count'` on a box with an anthropic key saved. **Worth taking before this reaches customers, whichever PR owns the fix.**
* **The second-catalogue path is unreachable and therefore untested.** `SUBSCRIPTION_SURFACE` has no `surfaceProvider` entry, so the second `publish`, the surface single-flight and the `.finally { await surface }` are correct by reasoning only.

### Fourth round — one change generation replaces the boolean

Both findings of the v3 review had the same root cause: the route carried a **boolean** where it needed to know **which change an answer is about**. It now keeps, per provider, `changeSeq` (bumped by an accepted provider-set change), the generation the running fork stamped **when it started** plus whether a change started it, and `publishedSeq` (what the served payload answers for).

**M1 — `warming` went false on the first poll, and the superseded fork was published as live.** `|| force` was true for exactly one response, because the hook sends `?refresh=1` once per provider-set signal and every retry is `load(false)`. Two seconds later the poll saw `warming: false` with ~3 minutes of enumeration still to run, so a picker open across a connect settled on the pre-change rows. And in the re-arm path the **pre-credential** fork was still published with `source: "live"` and a fresh `fetchedAt` one line before the `.finally` scheduled its replacement — every client arriving in that ~3-minute window got it as final. The same false success, shortened rather than removed.

Now: a fork behind the current generation is **discarded** — not stamped live, not written to memCache, not written to disk, and logged as discarded; and `warming`/`stale` read `publishedSeq < changeSeq`, so they stay true on **every** poll until the fork that answers for the new box publishes.

**M2 — every connect cost two full ~3-minute enumerations.** `configure` step 8c and the client's `?refresh=1` are the *same* change reaching the route twice, ordered by awaits rather than racing. The second hit single-flight and recorded a pending re-entry for a question the fork already out was answering post-credential. A change arriving while a fork **of the current generation that was itself started by a change** is out is now recognised as that same signal and ignored. `fromChange` is what keeps this distinct from a warmup or poll fork, which started *before* the change and must not absorb it — that distinction is exactly the previous round's HIGH, and it is preserved.

**LOW 3 — the pending drain now runs on the second path that releases the guard** (`fetchSubscriptionSurfaceIds`'s `finally`), so a change recorded against a provider held only as somebody else's subscription surface cannot sit unclaimed and later fire against an unrelated fork. Unreachable today; closed rather than left.

**LOW 6 — `DEPRECATED_MODEL_IDS` is matched on the last path segment**, like `isNonChatModelId`, so it is no longer silently inert for OpenRouter's `<org>/<model>` ids. Measured on the live endpoint (423 rows): **no** row's segment is one of the two ids and **none** carries `deprecated: true`, so nothing offered changes today — this is the set doing what it says.

**Filed, not fixed:** the `?refresh=1` backoff bypass (cost, not corruption — concurrency stays 1, and the shipped client sends it once per signal); `stale` permanently true for `codex` and on Hermes with no UI consumer; and the second-catalogue path, which remains unreachable (`SUBSCRIPTION_SURFACE` names no `surfaceProvider`) and therefore correct by reasoning only.

**The device question is closed from source, and the answer is NO.** `openclaw models list --provider <p> --all` takes `appendAllModelRowSources`, which runs the discovered and prepared-catalogue rows and *then* `appendConfiguredProviderRows` — additive and deduped through a shared `seenKeys`, with no `models.mode === "replace"` early return on that path; and `writeOpenAICompatProvider` writes `models.mode: merge` in the same batch anyway. So the curated array in `models.providers.<p>.models` **does not narrow** the harness's catalogue, and no box command is needed. The residual to watch is the opposite shape: because the append is additive, a curated id the plugin catalogue does *not* carry would be **injected** into the enumeration and read back here as `source: "live"`. Every id in `ANTHROPIC_MODELS` / `GOOGLE_MODELS` is in the plugin catalogue on the boxes measured, so today it dedupes to nothing.

### Fifth round — the change is counted at the WRITE, and the client's nudge is only a nudge

The generation was right; its duplicate-detector read the wrong thing. `alreadyAnswering` tested the **shape** of the fork in flight — change-started, current generation — so it could not tell `configure`'s echo from a **second, genuinely different** provider-set change. A corrected key, or a provider switched off and back on 30 s into a ~3-minute enumeration, landed on the identical branch and was dropped: no bump, no re-entry. The pre-change fork then published as the *current* generation — live, unstale, no `warming`, backoff cleared — and nothing re-enumerated for six hours.

**The fix is a split, not a better predicate.** Only a server-side write can know the provider set changed, so only a write counts one:

| write | counts via |
|---|---|
| `configure` step 8c (credential + plugin) | `notifyProviderSetChanged(ocProvider)` |
| ~~`POST /setup-api/providers/enabled` (the owner's switch)~~ | **withdrawn in the seventh round** — that flip writes ClawBox's own `ai_disabled_providers` key and cannot change any enumeration; see below |
| the anthropic plugin gate (`setProviderPlugins`) in `chat/model` and in `configure` | the id the gate returns |
| `POST /setup-api/providers/default` | transitively — it delegates to `chat/model` on OpenClaw |

A client's `?refresh=1` is demoted to `serveCurrent`: *"does the current generation have an answer?"*. It bumps nothing, clears no backoff, and discards no running fork's work. `alreadyAnswering` is **deleted** rather than refined — and with it `pendingProviderChange`, the `inFlight` map and `alreadyCounted`. The counter is the record; every release path simply asks for the current generation. That also removes the "a repeated `?refresh=1` bypasses the backoff" finding as a side effect: a nudge has nothing to clear.

`setProviderPlugins` now returns **which** provider's plugin it flipped, or `null` when it flipped nothing, so its two callers announce that change without hand-copying the id and cannot announce one that did not happen. That closes the last unguarded sibling: switching a model in the chat can switch the anthropic plugin **off**, which is exactly what empties `openclaw models list --provider anthropic`, and nothing told the catalogue.

Three smaller ones from the same pass: the subscription-surface publish stamps `publishedSeq` (without it that provider is permanently "not the current generation" — `isStale` never clears and every GET past the backoff re-enumerates a catalogue just written); the `surface` promise gets its rejection handler at creation rather than minutes later in the `.finally`; and an unpublished provider defaults to generation **0** rather than below it, so a fresh process is not stale-and-warming for every provider until its first publish — which had put each mounted picker into a poll loop after every restart.

**Filed, not fixed:** `stale` still has no UI consumer (`ResolvedProviderCatalog.stale` is referenced only inside `sameCatalog`), so the flag cannot be given a meaning yet; and the second-catalogue path remains unreachable (`SUBSCRIPTION_SURFACE` names no `surfaceProvider`), so its publish, its single-flight and its `finally` are correct by reasoning only.

**Scope note.** This round grew the diff from 17 files to 26. The nine additions are all required by the fix rather than incidental: `providers/enabled/route.ts` and `chat/model/route.ts` are two of the counting sites; `openclaw-config.ts` is the gate that now reports what it flipped; and six test files either assert the new counting or mock the catalogue module that those routes now import.

### Sixth round — the ON half of the same gate, and the row a model pick registers

The fifth round counted the gate's **OFF** half and left its **ON** half uncounted, which is the sibling-call-site rule unfinished on the fix that closed it. The enable rides **inside** the primary's batch — it has to, because the core validates the reference against the enabled plugins' catalogs — so by the time `setProviderPlugins` re-reads the config to decide the OFF half, the flag is already `true` and it correctly reports **no flip**. Nothing could see the transition.

A plugin that is off enumerates **nothing**, so switching it back on is the same provider-set change as switching it off. Uncounted it is worse than one stale answer: an empty enumeration is recorded as a *failed* refresh, and that wait **doubles up to `REFRESH_INTERVAL_MS` — six hours** (`recordFailedRefresh`), and only a counted change calls `clearFailedRefresh`. So on a box whose plugin has been off for a while, the pick that makes the provider listable is followed by **six hours in which the catalogue is not even asked**.

* `providerPluginSwitchedOnBy(modelRefs, configBeforeWrite)` answers that transition the way `setProviderPlugins` answers the other one — the id it flipped, or `null`. It reads the config **before** the batch, so an already-`true` flag, an absent flag (`enabledByDefault: true`) and a config that could not be read all announce nothing: the ops are emitted whether or not the flag is already on, so their presence is not a state change, and announcing one per anthropic pick would spend a ~3-minute `openclaw models list` per click on a Jetson.
* Its two writers now count: **`POST /setup-api/chat/model`** and the **Local-only restore** in `local-ai/exclusive` — the site whose own comment says "a provider save made while Local-only was on may have switched that plugin off". Both count *after* the batch, because a refused batch is validated as a whole and leaves the flag exactly as it was.
* The **third** `enableProviderPluginOps` caller, `configure`, needs no helper: the op is emitted only when `config.defaultModel` names anthropic, and on that path `ocProvider` **is** anthropic, so step 8c already counts it. The only other writers of a `plugins.entries.*` flag anywhere in `src` are the channel plugins (discord/whatsapp/telegram), which are not providers and cannot change what `openclaw models list` answers.

**The compat auto-extend was the other uncounted write.** `chat/model` appends the picked id to `models.providers.<p>.models`, and "configured providers in openclaw.json override the plugin's modelCatalog **entirely**" (`configure/route.ts`) — so for the two CLI-enumerated compat providers, google and anthropic, that array *is* what `openclaw models list --provider <p>` answers. It is counted in the branch that actually appended; a pick already on the list writes nothing and announces nothing. (`openrouter` is in that same set of compat providers but its catalogue is fetched from openrouter.ai, so no write here can change it — the seventh round drops it in the seam rather than at this call site.)

**The seam itself had no test.** Every route suite mocks `notifyProviderSetChanged`, which proves the caller and nothing about the answer, so the catalogue side now pins it for real: a write with **no client request anywhere** enumerates and publishes, the openclaw id `deepseek` counts against the catalogue's `clawai`, and a provider this catalogue cannot enumerate (`llamacpp`, `null`, `""`) is ignored.

**The full sweep behind this round.** Every server-side write in `src/app/setup-api/**` and `src/lib/**` that can change a credential, a provider switch, a plugin flag or a `models.providers.<p>` entry was enumerated and checked against the counting path. What it settled:

* **No provider-key delete route exists.** There is no `DELETE` handler under `ai-models/**` or `providers/**`; removal lives in `configure` (`clearOpenAICompatProvider`), and that path reaches step 8c.
* **Every OAuth completion path** (`oauth/start`, `device-start`, `exchange`, `device-poll`, `clawai/*`) writes only the server-side handoff; the credential is written by `configure`, which counts it. No sign-in writes a credential outside `configure`.
* **No early return** sits between `setProviderEnabled(ocProvider, true)` in configure and step 8c.
* **`harness/select`** changes nothing under `~/.openclaw`, and `cliMissing` is decided by the edition rather than the active harness — inert.
* **Hermes routes, `local-ai` disable, Local-only ON, channel plugins** — inert: the catalogue's CLI enumeration answers only for `anthropic`, `openai` and `google` (`openrouter` is a REST catalogue, `clawai` a constant, `codex` has none), so a write that cannot change those three cannot change it.

**Filed, not fixed, with the reason:**

* **ClawBox AI image provisioning writes `models.providers.openai`** under another provider's save (`buildClawboxAiImageOps`, reached from `ensureFallbackModel` on any save when the box holds a ClawBox AI token), turning `openai` from "no config entry" into an entry whose only row is an image model — and step 8c announces only the provider being saved. Deliberately **not** counted, on either reading of what the core does with it: if a configured entry really does replace the plugin catalogue, the box's openai enumeration is *already* wrong and counting it would only make the route enumerate a single non-chat row, drop it as a modality exclusion, record an empty enumeration and start doubling the backoff; if the entry merges instead, the added row is one this route's modality filter drops anyway, so the enumeration is unchanged and the announcement buys a ~3-minute fork for nothing. Either way the defect is the config shape, not the counting. The measurement that settles which — what `models.mode = merge` does to that entry — needs a device, which this round did not touch.
* **`setup/reset`'s failure branch** returns 500 *without* rebooting after `~/.openclaw` is already emptied, so pre-reset payloads stand. Inert on the success path (the reboot clears `memCache` and `catalog-cache` is not kept), and on that branch the box is broken anyway.
* **A throw between configure's credential write and step 8c** answers 500 with the credential on disk and the change uncounted. An honest failure rather than a false success — the catalogue is wrong until the owner retries.

### Seventh round — two announcements withdrawn, one wedge closed

The review pass on the sixth-round head and the bot's review of it agreed on the shape of what was left: this design counts changes by hand, so it can be wrong in *both* directions, and it was.

**A payload that parses but cannot be transformed wedged the provider for the life of the process.** `models` is typed as a list and is in fact whatever the CLI printed. A non-array reached `transformOpenclawEntries`, whose `for...of` throws — inside the chunk handler's partial-JSON `catch`, and *after* `finish` had set `settled`, so the `close` handler bailed too. The promise never settled, its `.finally` never ran, and `refreshing` kept the provider forever: every later refresh returned at the single-flight guard, `warming` stayed true (it reads `refreshing.has`), and the picker polled a fork that no longer existed. Fixed twice over — `Array.isArray` on the rows, and only the `JSON.parse` left inside that `catch`, so anything the transform can throw settles as a *failed* refresh (recorded, backed off, guard released), which is what non-JSON output already did.

**Two announcements were being made that no enumeration can see** — the same false-success class as an uncounted write, pointed the other way, and each costing a full ~3-minute, ~2-core `openclaw models list` on a Jetson:

* **A provider whose catalogue this box cannot change.** `openrouter` is fetched from openrouter.ai, `clawai` is a constant, `codex` has no enumeration — no write here alters what any of them lists. But the compat auto-extend writes `models.providers.openrouter.models` and announced it, which discarded the fetch in flight, redid it for the identical answer and cleared the backoff. `notifyProviderSetChanged` drops them now, beside the check that already drops a provider the catalogue does not carry.
* **`POST /setup-api/providers/enabled`, added in the fifth round on a premise that does not hold.** The claim was that a switch "empties its `openclaw models list`". It does not: the flip writes ClawBox's own `ai_disabled_providers` key, in ClawBox's own store. `~/.openclaw` is untouched, no plugin is re-gated, the CLI has never heard of that key, and the catalogue route never reads it (the strip's greying comes from `readProviderStatus`). An off-and-on spent two enumerations to be told the same rows twice. The enumeration *does* change later — the next save or chat-model pick re-gates the plugin — and that write counts its own change. The route now records what the flip actually writes, and a test pins the silence.

**The ON half was deciding from ABSENCE with the reader that cannot express it.** `readConfig` answers `{}` to an EACCES or a half-written file exactly as it does to a box with no config, so "could not read" was indistinguishable from "no flag, therefore enabled" — the very trap the OFF half documents and avoids. The Local-only restore reads with `readConfigStrict()` and passes `null` on failure; the detector counts `null` as a change, because the costs are not symmetric: after a batch that succeeded the flag *is* true, so announcing over an unknown pre-state costs one enumeration, while silence over a real switch-on costs six hours of a catalogue stamped `source: "live"` about a box that moved. `chat/model` keeps `preloadedConfig` deliberately — an unreadable config there leaves `loadChatModelState` with no options and the pick is refused with a 400 long before the batch — and the call site now says so.

Smaller, same pass: the comments that are the register of counting call sites now point at the one docblock that keeps the list, instead of each carrying a copy the round that lengthens it forgets; the gated provider is named once so the ops builder and the ON-half detector cannot drift; the backoff test waits for the spawn it is about rather than for any spawn (a boot-warmup fork could satisfy it before the fork under test had started, and the assertion would then pass on a cache file nothing had tried to write); and the one place a single request can announce the same provider twice now records why that is *not* deferred into an end-of-handler flush — this handler has several exits that leave a completed write behind, and a flush that misses one trades a bounded cost for a six-hour wrong answer.

**Harness-first, asked directly of the pinned core.** Is there a native "the model catalogue changed" signal to subscribe to instead of counting writes by hand? **There is not**, on `openclaw` 2026.8.1 (read locally at `/usr/lib/node_modules/openclaw`): the RPC surface offers `models.list`, `models.providers`, `models.authStatus`, `models.probe` and `models.catalogRefresh` — enumerate, and *force* a refresh — and the only occurrences of `config.changed` in the whole distribution are error strings, not an event. So there is nothing to subscribe to, the push direction is the only one the harness offers, and counting each server-side write is the available mechanism rather than a re-implementation of one. **That absence is the finding**, and it is what makes the register in `notifyProviderSetChanged`'s docblock load-bearing: nothing but that list enforces the invariant, which is why this round and the last both found writes missing from it.

**Still filed, not fixed** (both need a device measurement this round did not take): a `models.mode: "replace"` write on a local-model save changes every cloud catalogue at once and is announced for none, and the ClawBox AI image ops write `models.providers.openai` under another provider's save. Both hang on the same unmeasured question — what the core does with a configured entry under `merge` versus `replace`.

### Eighth round — the flag is read next to the write, or not at all

Both threads on the seventh head were the same objection from opposite ends: the ON half decides from a snapshot, and a snapshot read far from the write it describes is a guess.

**In the Local-only restore it cannot be anything else, so the read is gone.** Any config that route could read is read before a `config set --batch-json` that takes ~10 s on a Jetson, and a provider save landing in that window switches the plugin off through its own gate — leaving a stale "it was already on" reading that swallows the switch-on the batch then performs. Neither escape exists: the openclaw CLI does not report the prior value of a key it writes, and there is no mutation-serialization boundary ClawBox can hold a read inside (`ConfigMutationConflictError` is a conflict *detector*). So the site passes `null` — "I cannot know" — which counts the change. Affordable exactly there: once per Local-only exit, only when the saved primary or a fallback names the gated provider, on a path that already restarts the gateway and re-patches every session — one enumeration at worst, against a silent miss that leaves the catalogue behind until a doubling backoff expires.

**In `chat/model` the same window is closed rather than accepted**, because that announcement rides on a frequent click and has to stay precise: the flag is read with `readConfigStrict()` at the last moment before the batch instead of from the config loaded at the top of the handler, with the auto-extend's own ~10 s spawn in between. One file read beside writes that already cost seconds, and the window shrinks from the whole handler to the instruction before the spawn.

**And the seam test stopped asserting on the global `fetch` stub** — the warmup schedules `openrouter` on a real 25-second timer, so a stray call could come from that rather than from the call under test. `clawai` carries the proof instead: it resolves from a constant, publishes inside the window with no network, and its warmup slot is the first one and has long since fired.

### RED → GREEN

**A note on what each RED was run against.** The first round's excerpts are from unmodified `origin/beta`. Every later round's are from the head that round's review read — `f076b008`, `dda1749a`, `0fe3299a` — because those tests call `refreshInBackground(provider, opts)`, and on `beta` that function takes no options object at all, so they do not compile there. Each excerpt below says which head it came from.

RED, on unmodified `origin/beta`:

```
 × re-reads a cached payload that no live enumeration produced, and the live list replaces it
   AssertionError: expected undefined to be true          // no `fallback` marker; no re-read
 × never appends the curated list to a thin live enumeration
   AssertionError: expected [ '<curated id>', …(3) ] to have a length of 1 but got 4   (id elided)
 × does not persist anything when the live enumeration returns no models
   AssertionError: expected true to be false              // catalog-cache/<provider>.json written

 × re-reads the catalogue when a provider connects, and shows every live row
   AssertionError: expected [ <button …> …(2) ] to have a length of 11 but got 3
 × asks the route to refresh rather than re-reading the same cached answer
   AssertionError: expected 1 to be greater than 1
 × keeps asking while the box is still enumerating
   Error: Test timed out in 5000ms.
```

RED for the seventh round, against the sixth-round head (`cfd57689`):

```
 × fails the refresh rather than wedging the provider
   AssertionError: expected 1 to be 2      // the second enumeration never started:
                                           // the provider was stuck in `refreshing`
 × does not count a change against a catalogue no write on this box can alter
   AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
 × does not spend an enumeration on a switch the catalogue cannot see
   AssertionError: expected "vi.fn()" to not be called at all, but actually been called 3 times
 × tells the catalogue when the restore switched the plugin back on
 × counts it when the pre-restore snapshot could not be read at all
   AssertionError: expected "vi.fn()" to be called with arguments: [ 'anthropic' ]
   Number of calls: 0
 × counts it when the pre-write config could not be read
   AssertionError: expected null to be 'anthropic'
```

RED for the sixth round, against the head the v5 round pushed (`417ae23f`):

```
 × counts the change when the batch switched the plugin on
   AssertionError: expected "vi.fn()" to be called with arguments: [ 'anthropic' ]
   Number of calls: 0        // chat/model: the ON half was invisible to the catalogue
 × tells the catalogue when the restore switched the plugin back on
   AssertionError: expected "vi.fn()" to be called with arguments: [ 'anthropic' ]
   Number of calls: 0        // local-ai/exclusive: the Local-only restore said nothing
 × counts the change when a row is actually appended
   AssertionError: expected "vi.fn()" to be called with arguments: [ 'google' ]
   Number of calls: 0        // the compat auto-extend rewrote the provider's catalogue silently
```

and, against `90e50806`, the three that pin the seam every route suite mocks out:

```
 × enumerates and publishes with no client request anywhere
 × counts the change against the catalogue's id for a provider, not openclaw's
 × ignores a write about a provider this catalogue does not enumerate
   TypeError: notifyProviderSetChanged is not a function
```

RED for the fifth round, against the head the v4 review read (`90e50806`):

```
 × answers a second, different change that lands inside the first enumeration
   AssertionError: expected 1 to be 2
   // the second change was swallowed; the PRE-change fork's answer stood
 × tells the catalogue the provider set changed, both ways
   AssertionError: expected "vi.fn()" to be called with arguments: [ 'openrouter' ]
   Number of calls: 0                  // providers/enabled told the catalogue nothing
```

RED for the fourth round, against the head the v3 review read (`0fe3299a`):

```
 × keeps saying an answer is coming on every poll, and never publishes the superseded fork
   AssertionError: expected true to be false        // the pre-credential fork HAD written the cache
 × costs one enumeration when the same change reaches the route twice
   AssertionError: expected 2 to be 1               // 8c + ?refresh=1 spawned two full enumerations
```

RED for the third round, against the head that pass read (`dda1749a`):

```
 × re-enumerates once the in-flight fork settles, and the post-credential list is what stands
   AssertionError: expected [ 'gpt-5.6-sol' ] to deeply equal [ 'gpt-5.4', 'gpt-5.5', 'gpt-5.6-sol' ]
   // the PRE-credential row is what got published, and stamped `source: "live"`
 × says an answer is coming, rather than serving the pre-connect rows in silence
   AssertionError: expected undefined to be true          // no `warming` on a forced refresh
 × re-enumerates, says stale, and says an answer is coming
   AssertionError: expected undefined to be true          // an emptied live cache read as fresh
```

RED for the second round, against the code that pass read (`f076b008`):

```
 × lets a provider-set change through the backoff, and says an answer is coming
   AssertionError: expected [] to include 'google'        // the connect started no fork at all
 × tells the catalog the PROVIDER SET changed, not that a client asked again
   AssertionError: expected "vi.fn()" to be called with arguments: [ 'anthropic', …(1) ]
   Received: "anthropic"                                  // configure/route.ts step 8c
 × drops what the field calls non-text, keeps the router, and keeps a text model the name rule would hide
   AssertionError: expected [ 'openrouter/auto', …(4) ] to have a length of 3 but got 5
 × publishes the newest generation the box lists, and skips the image SKUs
   AssertionError: expected [ 'gpt-5.4', 'gpt-5.5-pro', …(4) ] to have a length of 3 but got 6
 × takes the default the box tags, not the one the map remembers
   AssertionError: expected 'gpt-5.4' to be 'gpt-5.6-sol'
```

RED for the first round, each against the code as it stood before its fix:

```
 × doubles the wait after each attempt that does not answer
   AssertionError: expected [ 'anthropic' ] to not include 'anthropic'
   // second failure re-derived the wait from the deadline -> back to the 2-minute floor

 × carries `warming` through an empty catalogue, so the picker keeps asking
   AssertionError: expected undefined to be true
   // the empty-catalogue branch dropped the one field the retry loop polls on
```

GREEN, on this branch:

```
 Test Files  642 passed (642)     # both projects, `vitest run --config vitest.config.ts`
      Tests  9300 passed (9300)
```

`tsc --noEmit -p tsconfig.json` clean; eslint at **exact parity with `origin/beta`** — 19 errors / 112 warnings on both, none of them on a line this branch wrote.

### Sibling call sites

Both `fetchOpenclawCatalog` callers (the refresh and the subscription-surface enumeration), both `writeDiskCache` callers, and the three pickers that share `useProviderCatalog` — the setup wizard step (`AIModelsStep`), Settings (which renders the same step) and the chat header dropdown (`ChatPopup`). `useHermesModelOptions` deliberately does not share this catalogue (different id namespace) and is untouched. `readSubscriptionSurfaceIds` in `subscription-surface.ts` unions the curated ids into its guard *because* the picker can render them during a cold start; its comment now records that a missing cache — the state a thin enumeration leaves behind now that nothing fake is persisted — is UNKNOWN, which is the permissive direction and the one this file's own rule requires.

### What this leaves for #584

The last piece of the ask is *usable*. A ChatGPT row is usable when the box holds an **`openai` OAuth profile** — emphatically not the openai catalogue's `available: true`. That fact does not exist on `beta`; #584 introduces it and exposes the shape the picker should render: `GET /setup-api/chat/model` rows carrying `provider: "codex"` (the UI id for the subscription row) with `model: "openai/<id>"`, an `available` flag, and `reauthRequired: true` when only a legacy `codex:default` sign-in exists; plus `subscriptionProviders` containing `"codex"` when the box is openai-subscription-only.

Once #584 lands, the ChatGPT picker should render from those fields — `reauthRequired` becoming "sign in with ChatGPT again" rather than a list of models the write path would refuse. Nothing here invents that signal in the meantime.

**Overlap with #584 — MERGED; this branch is rebased onto current `beta` (now also carrying #580/#581/#582/#590).** Six shared files, all auto-merged. Verified after the latest rebase:

* `git diff --stat origin/beta...HEAD` — **32 files**, every one accounted for: the 17 this PR owned through the fourth round, the 9 the fifth round added for the counting sites, and the 6 the sixth round added (`local-ai/exclusive/route.ts`, `provider-plugin-ops.ts` and four test files — two of which change only to mock the catalogue module those routes now import). **0 deletions, 0 renames** (`--diff-filter=DR` empty), one author.
* Removed-line audit re-run on the whole `origin/beta...HEAD` diff: **zero** removed lines match `openai/`, `reauthRequired`, `authOrder`, `subscriptionProviders`, `\barm\b`, `CLAWBOX_AI_PROXY_URLS`, `noChatModel` or `servedBy`.
* Removals on the shared files are **only this PR's own rewrites** — the `augmentWithStaticCatalog` comment blocks in `subscription-surface.ts` and two test files; `fetchProviderCatalog`'s old signature, URL and empty-branch in `provider-models.ts`; one `noUsableCatalogModel` condition in `AIModelsStep.tsx`; one `refreshCatalogInBackground(catalogProvider);` call in `configure/route.ts`; and **zero** removals in `configure.test.ts`.
* **None of #584's code is gone.** Reference counts across `src`, `origin/beta` → this HEAD: `reauthRequired` 8 → 9, `subscriptionProviders` 21 → 22, `CODEX_SUPPORTED_MODEL_RE` 11 → 14 (this PR imports it rather than keeping a third copy), `offSurfaceCodexModelMessage` 6 → 6. Every count is at or above beta: this branch adds references, never removes them. No `openai/<id>` row shape, runtime arm or auth-order code is touched.

**Device leg unproven (CI only.)** Everything above is measured either on the affected box's logs and cache files or against a real `openclaw` 2026.8.1 CLI on a development host; the change itself has not been run on a box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - AI model catalogs now distinguish live results from curated fallback models.
  - Catalogs refresh automatically when provider data is unavailable, outdated, or changes.
  - Model detection supports additional provider formats, generations, and output capabilities.
  - Unavailable, deprecated, and non-chat models are filtered from selections.

- **Bug Fixes**
  - Prevented fallback models from being published or saved as live results.
  - Improved handling of empty, failed, stale, and partially available catalogs.
  - Preserved indeterminate availability while catalogs warm up.
  - Prevented unconfirmed fallback data from incorrectly triggering “no models available” validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













