### PR TITLE
fix: switch the anthropic plugin on in the primary's own batch (F-02 / M-01)

### DIFF
--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -27,6 +27,7 @@ import {
   OpenclawUnavailableError,
   type OpenClawConfig,
 } from "@/lib/openclaw-config";
+import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
 import { getActiveHarness } from "@/lib/harness";
 import { applyLocalAiToHermes, HermesLocalApplyError } from "@/lib/hermes-local-ai";
 import { applyClawaiToHermes, ClawaiApplyError } from "@/lib/hermes-clawai";
@@ -1173,8 +1174,9 @@ async function clearOpenAICompatProvider(provider: string): Promise<void> {
  * override the device already had is removed — the second half matters as much
  * as the first, because a box configured with an API key and later switched to
  * a subscription kept the old entry (nothing here ever deleted one) and stayed
- * broken. Routing then belongs to the anthropic plugin, which is what
- * `setProviderPlugins` enables a few steps later.
+ * broken. Routing then belongs to the anthropic plugin, which the primary
+ * batch switches on ahead of the reference it validates (step 3) and
+ * `setProviderPlugins` keeps on at step 8b while the credential exists.
  */
 /**
  * True when the save wrote the openai-compat override, false when it handed the
@@ -2068,6 +2070,14 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       ],
     ];
     if (!isLocalScope || shouldPromoteLocalToPrimary) {
+      // The plugin the new primary resolves through rides in the SAME batch,
+      // ahead of the reference: OpenClaw 2 validates every model reference a
+      // batch touches against the enabled plugins' catalogs after applying
+      // the whole batch to one snapshot, so this is what lets a Claude save on
+      // a box whose plugin an earlier gate switched off validate at all — in
+      // one spawn, and atomically: a refused batch leaves the flag as it was
+      // (src/lib/provider-plugin-ops.ts).
+      baseOps.unshift(...enableProviderPluginOps([config.defaultModel]));
       baseOps.push(["agents.defaults.model.primary", config.defaultModel]);
       if (shouldPromoteLocalToPrimary) {
         console.log(`[AI Config] Promoted local model to active primary: ${logSafe(config.defaultModel)}`);
@@ -2128,11 +2138,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       }
     }
 
+    const primaryIdx = baseOps.findIndex((op) => op[0] === "agents.defaults.model.primary");
     try {
       await runConfigSetBatch(baseOps);
     } catch (batchErr) {
       const message = batchErr instanceof Error ? batchErr.message : String(batchErr);
-      const primaryIdx = baseOps.findIndex((op) => op[0] === "agents.defaults.model.primary");
       // Only the OpenClaw 2 catalog-validation refusal of the primary falls
       // through — anything else keeps its existing failure path. v2 checks a
       // model reference against a freshly refreshed provider catalog, so a
@@ -2156,6 +2166,8 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       // write from overwriting a concurrent auth/provider/gateway mutation and
       // refuses malformed input instead of rebuilding the config from a fragment.
       await setPrimaryModelWithoutCatalogValidation(primaryModel);
+      // The retry above re-lands the plugin enable with the rest of the
+      // batch (it is not the primary), so the refusal here is the catalog's.
       console.warn(
         "[AI Config] Primary written directly — the CLI refused the reference (empty catalog for this key/plugin):",
         // JSON-quoted: the modeled sanitizer for js/log-injection (see 3ef684a1).
@@ -2452,9 +2464,11 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
       }
     }
 
-    // 8b. Gate the anthropic plugin to only when the active primary provider
-    //     actually needs it. The plugin's tool schemas otherwise add several
-    //     seconds to every agent prep — see setProviderPlugins.
+    // 8b. The OFF half of the gate: switch the anthropic plugin off only when
+    //     nothing on the box could use it — the primary is elsewhere AND no
+    //     usable Anthropic credential remains (the ON half rode in the primary
+    //     batch at step 3). See setProviderPlugins for the catalog measurement
+    //     behind the rule.
     if (!isLocalScope || shouldPromoteLocalToPrimary) {
       const primaryProvider = config.defaultModel.split("/", 1)[0];
       await setProviderPlugins(primaryProvider);

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -5,11 +5,13 @@ import {
   readConfig,
   restartGateway,
   runOpenclawConfigSet,
+  runOpenclawConfigSetBatch,
   applyModelOverrideToAllAgentSessions,
   parseFullyQualifiedModel,
   setProviderPlugins,
   type OpenClawConfig,
 } from "@/lib/openclaw-config";
+import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import {
   CLAWBOX_AI_MODEL_BY_TIER,
@@ -741,13 +743,24 @@ export async function POST(request: Request) {
       await sqliteSet(PRIMARY_MODEL_KEY, state.activeModel);
     }
 
+    const parsed = parseFullyQualifiedModel(targetModel);
+
     // 1. Update the agent-level default so any *future* session starts
-    //    with the user's chosen model. runOpenclawConfigSet retries on
-    //    transient ConfigMutationConflictError and uses a 30 s per-attempt
-    //    timeout by default (CLI startup alone is ~10 s on Jetson Orin),
-    //    so users switching chat models don't see a bogus failure when the
-    //    gateway reloads concurrently with the write.
-    await runOpenclawConfigSet(["agents.defaults.model.primary", targetModel]);
+    //    with the user's chosen model — in ONE batch with the plugin enable
+    //    the new primary needs, ahead of it. OpenClaw 2 validates the
+    //    reference against the enabled plugins' catalogs, after applying the
+    //    whole batch to one snapshot: the enable in the same spawn is what
+    //    lets a switch back to Claude validate on a box whose plugin an
+    //    earlier gate switched off, and a refused batch leaves the flag as it
+    //    was (src/lib/provider-plugin-ops.ts). The batch retries on transient
+    //    ConfigMutationConflictError with a 30 s per-attempt timeout (CLI
+    //    startup alone is ~10 s on Jetson Orin), so users switching chat
+    //    models don't see a bogus failure when the gateway reloads
+    //    concurrently with the write.
+    await runOpenclawConfigSetBatch([
+      ...enableProviderPluginOps([targetModel]),
+      ["agents.defaults.model.primary", targetModel],
+    ]);
 
     // 1b. Codex turns only work through the Codex app-server harness, which is
     //     selected by agentRuntime. Without it core uses its generic HTTP
@@ -770,7 +783,6 @@ export async function POST(request: Request) {
     //    user's current pick, so prior tags shouldn't make repeat
     //    clicks no-op. The soft-sweep "parallel chats deliberately
     //    running different models" use case has no UI today.
-    const parsed = parseFullyQualifiedModel(targetModel);
     if (parsed) {
       try {
         await applyModelOverrideToAllAgentSessions(
@@ -787,8 +799,10 @@ export async function POST(request: Request) {
         // the open chat. Log and continue.
         console.error("[chat/model] Failed to sweep session overrides:", err);
       }
-      // 3. Gate the anthropic plugin to only when the new primary actually
-      //    needs it. Other plugins stay where they are.
+      // 3. The OFF half of the gate: switch the anthropic plugin off only
+      //    when nothing on the box could use it — the primary is elsewhere
+      //    AND no usable Anthropic credential remains (see setProviderPlugins).
+      //    Other plugins stay where they are.
       await setProviderPlugins(parsed.provider);
     }
 

--- a/src/app/setup-api/local-ai/exclusive/route.ts
+++ b/src/app/setup-api/local-ai/exclusive/route.ts
@@ -16,8 +16,10 @@ import {
   gatewayIsAbsent,
   readConfig,
   restartGateway,
-  runOpenclawConfigSet,
+  runOpenclawConfigSetBatch,
+  type OpenclawConfigSetArgs,
 } from "@/lib/openclaw-config";
+import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
 
 const SAVED_PRIMARY_KEY = "local_only_saved_primary";
 const SAVED_FALLBACKS_KEY = "local_only_saved_fallbacks";
@@ -75,11 +77,15 @@ function snapshotOverrides(session: Record<string, unknown>): SessionOverrideSna
 // flipped but fallbacks still populated, and local_only_mode unset.
 // That half-applied state is visible in the UI as a failed toggle while
 // the user's chat actually continues routing to the cloud fallback.
-async function setConfig(key: string, valueJson: string) {
-  // Leave timeoutMs on the helper's default — the OpenClaw CLI takes
-  // 10-12 s per invocation on Jetson, so tighter bounds here produced
-  // spurious "timed out" errors that made Local-only mode fail to toggle.
-  await runOpenclawConfigSet([key, valueJson, "--json"]);
+/**
+ * One `config set --batch-json` for every model write of a toggle: the CLI
+ * takes 10-12 s per invocation on a Jetson (so the helper's default timeout
+ * stays), and a batch is applied to one snapshot and validated as a whole, so
+ * the primary and the fallbacks land together or not at all — the half-applied
+ * state the header above describes cannot come from here.
+ */
+async function setConfigBatch(ops: OpenclawConfigSetArgs[]) {
+  await runOpenclawConfigSetBatch(ops);
 }
 
 /** Parse "llamacpp/gemma4-e2b-it-q4_0" into {provider, modelId}. */
@@ -348,7 +354,7 @@ async function restoreSessionOverrides(
 // `hermes-local-ai.ts` can install and remove a local provider but has no
 // fallback chain to make exclusive, so there is nothing here to port.
 //
-// Ungated, every call reached `runOpenclawConfigSet`, which throws
+// Ungated, every call reached `runOpenclawConfigSetBatch`, which throws
 // `OpenclawUnavailableError`, which the catch-all turned into a 500 whose body
 // SettingsApp painted verbatim into a red banner: "The OpenClaw CLI is not
 // available on this edition." That is the product telling a Hermes owner about
@@ -414,9 +420,13 @@ export async function POST(request: Request) {
         await set(SAVED_FALLBACKS_KEY, currentFallbacks);
       }
 
-      // 1. Flip the defaults so *new* sessions pick up local.
-      await setConfig("agents.defaults.model.primary", JSON.stringify(localModel));
-      await setConfig("agents.defaults.model.fallbacks", "[]");
+      // 1. Flip the defaults so *new* sessions pick up local — both lists in
+      //    one batch, so the primary can never land with the cloud fallbacks
+      //    still in place.
+      await setConfigBatch([
+        ["agents.defaults.model.primary", JSON.stringify(localModel), "--json"],
+        ["agents.defaults.model.fallbacks", "[]", "--json"],
+      ]);
 
       // 2. Sweep every existing session's per-session override. Without
       //    this step the toggle only affects sessions born after the
@@ -445,11 +455,26 @@ export async function POST(request: Request) {
       const savedFallbacks = (await get(SAVED_FALLBACKS_KEY)) as string[] | undefined;
       const savedSessionOverrides = (await get(SAVED_SESSION_OVERRIDES_KEY)) as FilesBackup | undefined;
 
-      if (savedPrimary) {
-        await setConfig("agents.defaults.model.primary", JSON.stringify(savedPrimary));
-      }
-      if (Array.isArray(savedFallbacks) && savedFallbacks.length > 0) {
-        await setConfig("agents.defaults.model.fallbacks", JSON.stringify(savedFallbacks));
+      // The saved primary — and any saved fallback — can be Anthropic's, and a
+      // provider save made while Local-only was on may have switched that
+      // plugin off. OpenClaw 2 validates EVERY model reference the batch
+      // touches (the primary and each fallback) against the enabled plugins'
+      // catalogs, after applying the whole batch to one snapshot: so the
+      // enables for every provider the restore names ride first, in the same
+      // batch, and a refused batch leaves the flag and both lists as they were
+      // (src/lib/provider-plugin-ops.ts).
+      const restoreFallbacks = Array.isArray(savedFallbacks) && savedFallbacks.length > 0 ? savedFallbacks : null;
+      const restoreOps: OpenclawConfigSetArgs[] = [
+        ...enableProviderPluginOps([savedPrimary, ...(restoreFallbacks ?? [])]),
+        ...(savedPrimary
+          ? [["agents.defaults.model.primary", JSON.stringify(savedPrimary), "--json"] as OpenclawConfigSetArgs]
+          : []),
+        ...(restoreFallbacks
+          ? [["agents.defaults.model.fallbacks", JSON.stringify(restoreFallbacks), "--json"] as OpenclawConfigSetArgs]
+          : []),
+      ];
+      if (restoreOps.length > 0) {
+        await setConfigBatch(restoreOps);
       }
       const restore = savedSessionOverrides
         ? await restoreSessionOverrides(savedSessionOverrides)
@@ -470,8 +495,10 @@ export async function POST(request: Request) {
         // mode says they are.
         const localModel = (await get("local_ai_model")) as string | undefined;
         if (localModel) {
-          await setConfig("agents.defaults.model.primary", JSON.stringify(localModel));
-          await setConfig("agents.defaults.model.fallbacks", "[]");
+          await setConfigBatch([
+            ["agents.defaults.model.primary", JSON.stringify(localModel), "--json"],
+            ["agents.defaults.model.fallbacks", "[]", "--json"],
+          ]);
         } else {
           console.error("[local-only] restore incomplete and no local model recorded; the primary stays on the saved provider");
         }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -2112,10 +2112,32 @@ function hasUsableAnthropicCredential(config: OpenClawConfig, disabledProviders:
 }
 
 /**
- * AFTER the primary write: keep the anthropic plugin on while the primary is
- * anthropic or a usable Anthropic credential exists; off only when nothing on
- * the box could use it. Pass the provider segment of
- * `agents.defaults.model.primary`. Idempotent and non-fatal.
+ * Does the config still POINT at an Anthropic model — the default primary or
+ * any of its fallbacks? A configured reference outranks every other signal,
+ * the owner's provider switch included: the gateway will try to route there,
+ * and the plugin is what resolves it. The core does not protect this by
+ * itself — a batch whose only operation is the plugin flag touches no model
+ * ref, so `collectTouchedTextModelRefs` validates nothing and the disable
+ * lands (read on 2026.8.1); the fallback then fails when it is next selected.
+ *
+ * Prefix match on the provider segment, the shape ClawBox writes everywhere.
+ * A model ALIAS that resolves to anthropic is not seen here — resolving one
+ * needs the core's own resolver, and nothing in ClawBox writes aliases.
+ */
+function configReferencesAnthropic(config: OpenClawConfig): boolean {
+  const modelDefaults = config.agents?.defaults?.model;
+  return [
+    modelDefaults?.primary,
+    ...(Array.isArray(modelDefaults?.fallbacks) ? modelDefaults.fallbacks : []),
+  ].some((ref) => typeof ref === "string" && ref.trim().toLowerCase().startsWith("anthropic/"));
+}
+
+/**
+ * AFTER the primary write: keep the anthropic plugin on while the config still
+ * names an Anthropic model (primary or fallback) or a usable Anthropic
+ * credential exists; off only when nothing on the box could use it. Pass the
+ * provider segment of `agents.defaults.model.primary`. Idempotent and
+ * non-fatal.
  */
 export async function setProviderPlugins(activeProvider: string): Promise<void> {
   // Strict, because the decision below is about ABSENCE: `readConfig` answers
@@ -2134,7 +2156,9 @@ export async function setProviderPlugins(activeProvider: string): Promise<void> 
     return;
   }
   const disabled = parseDisabledProviders(await getConfigStoreValue(DISABLED_PROVIDERS_KEY).catch(() => undefined));
-  const wanted = activeProvider === "anthropic" || hasUsableAnthropicCredential(config, disabled);
+  const wanted = activeProvider === "anthropic"
+    || configReferencesAnthropic(config)
+    || hasUsableAnthropicCredential(config, disabled);
   // An absent flag IS enabled: the plugin declares `enabledByDefault: true`,
   // so a fresh box needs no write to be on.
   const current = (config.plugins as { entries?: Record<string, { enabled?: boolean }> } | undefined)

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -11,6 +11,9 @@ import { getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyRootUrl } from "@/lib/local-ai-proxy-url";
 import { readEdition } from "@/lib/edition-source";
 import { getProviderReasoningConfig, isThinkingLevel } from "@/lib/chat-reasoning";
+import { get as getConfigStoreValue } from "@/lib/config-store";
+import { DISABLED_PROVIDERS_KEY, parseDisabledProviders } from "@/lib/provider-status";
+import { ANTHROPIC_PLUGIN_ENABLED_KEY } from "@/lib/provider-plugin-ops";
 import { isSafeDiscordToken } from "@/lib/discord-api";
 
 const exec = promisify(execFile);
@@ -2046,28 +2049,102 @@ export async function clearTelegramPairingState(account = "default"): Promise<vo
   await Promise.all(files.map((f) => fs.rm(f, { force: true }).catch(() => {})));
 }
 
-// Toggles `plugins.entries.anthropic.enabled` in lock-step with the active
-// provider. Every enabled plugin loads its tool schemas synchronously on
-// the gateway's main loop during agent prep (~5-8s for anthropic on Jetson),
-// so leaving it on while the user is not using Claude is pure waste. Other
-// plugins (openai) are shared across providers and stay enabled. Pass the
-// provider segment of `agents.defaults.model.primary`.
+// === The anthropic plugin, around the primary write =========================
+//
+// `plugins.entries.anthropic.enabled` is on whenever the box could use it: the
+// primary is anthropic, or an Anthropic credential exists that the owner has
+// not switched off. It used to follow the active provider alone — every
+// enabled plugin loads its tool schemas synchronously on the gateway's main
+// loop during agent prep (5-8 s for anthropic on a Jetson, an old measurement
+// TASK-654 re-takes on 2026.8.1), so the plugin was switched off whenever the
+// owner was not on Claude. On OpenClaw 2 that starves the catalog: measured on
+// a 2026.8.1 box, `openclaw models list --provider anthropic --all --json` with
+// the plugin disabled answers ONE row (the configured primary) against eleven
+// with it enabled, and that one row is the three-model picker owners saw. A
+// credentialed provider's plugin therefore stays on; the prep-latency saving
+// only applies where nothing could use the plugin anyway. Other plugins
+// (openai) are shared across providers and stay enabled.
+//
+// The toggle is two halves around the `agents.defaults.model.primary` write:
+//
+//   enableProviderPluginOps(refs)   IN the same batch as the write, before it
+//                                   (src/lib/provider-plugin-ops.ts)
+//   setProviderPlugins(provider)    AFTER it
+//
+// OpenClaw 2 validates a model reference on `config set` against the captured
+// catalogs of the ENABLED plugins only. With the plugin off, every
+// `anthropic/*` reference is refused: "Unknown model: anthropic/claude-sonnet-5.
+// Run openclaw models list to list available models." Both callers used to
+// write first and toggle after, and on a 2026.8.1 core the chat popup showed
+// the owner exactly that line on every switch back to Claude (2026.7.x
+// answered from the bundled catalog whatever the plugin state, which is why
+// the order never mattered before). The OFF half stays AFTER the write on
+// purpose: a plugin whose model is the CURRENT primary is never switched off
+// underneath it. It is idempotent and non-fatal, and a plugin enabled by the
+// batch loads on the next gateway start ("Restart the gateway to apply"), so
+// the caller's restart has to follow.
+
+/**
+ * Does this box hold an Anthropic credential the owner has not switched off —
+ * an auth profile or the inline override key, and `anthropic` not in the
+ * owner's disabled-providers set (the switch takes the provider out of every
+ * place the box picks a model, so a credential behind it is one nothing can
+ * route to).
+ *
+ * Read off openclaw.json's `auth.profiles` METADATA, not the agent's SQLite
+ * credential store the core resolves a usable profile from. Unverified on a
+ * box (no device in this run): whether `openclaw models auth logout` also
+ * drops the metadata entry. If it does not, a logged-out box keeps the plugin
+ * on until the owner switches the provider off — the cost is prep latency,
+ * never a broken box.
+ */
+function hasUsableAnthropicCredential(config: OpenClawConfig, disabledProviders: ReadonlySet<string>): boolean {
+  if (disabledProviders.has("anthropic")) return false;
+  const profiles = Object.entries(config.auth?.profiles ?? {});
+  if (profiles.some(([key, entry]) => {
+    const provider = typeof entry?.provider === "string" && entry.provider.trim()
+      ? entry.provider
+      : key.split(":")[0];
+    return provider.trim().toLowerCase() === "anthropic";
+  })) return true;
+  const override = config.models?.providers?.anthropic as { apiKey?: unknown } | undefined;
+  return typeof override?.apiKey === "string" && override.apiKey.trim().length > 0;
+}
+
+/**
+ * AFTER the primary write: keep the anthropic plugin on while the primary is
+ * anthropic or a usable Anthropic credential exists; off only when nothing on
+ * the box could use it. Pass the provider segment of
+ * `agents.defaults.model.primary`. Idempotent and non-fatal.
+ */
 export async function setProviderPlugins(activeProvider: string): Promise<void> {
-  const wantAnthropic = activeProvider === "anthropic";
+  // Strict, because the decision below is about ABSENCE: `readConfig` answers
+  // `{}` to an unreadable file, and that would read as "no Anthropic
+  // credential" and switch the plugin off on a box that has one — the very
+  // starvation this gate exists to avoid. An unreadable config leaves the
+  // plugin where it is; the next switch or save re-applies the gate.
+  let config: OpenClawConfig;
   try {
-    const config = await readConfig();
-    const current = (config.plugins as { entries?: Record<string, { enabled?: boolean }> } | undefined)
-      ?.entries?.anthropic?.enabled;
-    if (current === wantAnthropic) return;
-  } catch {
-    // Fall through and write — readConfig already swallows errors.
-  }
-  try {
-    await runOpenclawConfigSet(
-      ["plugins.entries.anthropic.enabled", wantAnthropic ? "true" : "false", "--json"],
-    );
+    config = await readConfigStrict();
   } catch (err) {
-    // Non-fatal: the gateway will still work, just with the heavier prep cost.
+    console.warn(
+      "[openclaw-config] Leaving the anthropic plugin as it is — could not read the config:",
+      err instanceof Error ? err.message : err,
+    );
+    return;
+  }
+  const disabled = parseDisabledProviders(await getConfigStoreValue(DISABLED_PROVIDERS_KEY).catch(() => undefined));
+  const wanted = activeProvider === "anthropic" || hasUsableAnthropicCredential(config, disabled);
+  // An absent flag IS enabled: the plugin declares `enabledByDefault: true`,
+  // so a fresh box needs no write to be on.
+  const current = (config.plugins as { entries?: Record<string, { enabled?: boolean }> } | undefined)
+    ?.entries?.anthropic?.enabled ?? true;
+  if (current === wanted) return;
+  try {
+    await runOpenclawConfigSet([ANTHROPIC_PLUGIN_ENABLED_KEY, wanted ? "true" : "false", "--json"]);
+  } catch (err) {
+    // Non-fatal: a gate left wrong costs prep seconds or one catalog refresh,
+    // never correctness, and the next switch or save re-applies it.
     console.warn(
       "[openclaw-config] Failed to toggle anthropic plugin:",
       err instanceof Error ? err.message : err,

--- a/src/lib/provider-plugin-ops.ts
+++ b/src/lib/provider-plugin-ops.ts
@@ -1,0 +1,33 @@
+import type { OpenclawConfigSetArgs } from "@/lib/openclaw-config";
+
+/**
+ * The `config set` operations that switch ON the provider plugins a set of
+ * model references resolve through — meant to ride in the SAME
+ * `config set --batch-json` as the writes of those references, ahead of them.
+ *
+ * OpenClaw 2 validates every model reference a batch touches
+ * (`agents.defaults.model.primary`, each `agents.defaults.model.fallbacks.N`)
+ * against the captured catalogs of the ENABLED plugins — after applying every
+ * operation of the batch to one cloned snapshot (the core's
+ * `runConfigOperations`, read on 2026.8.1). So an enable placed before the
+ * reference in the same batch validates it with the plugin on, in one spawn,
+ * and a refused batch leaves the flag exactly as it was: nothing to restore.
+ * Two spawns with the enable first used to be the shape, and left the plugin
+ * switched on for a switch that then failed.
+ *
+ * Only the anthropic plugin is gated (see `setProviderPlugins` in
+ * openclaw-config.ts for the OFF half and why); a reference to any other
+ * provider needs no operation. Pure: no read, no spawn.
+ */
+export const ANTHROPIC_PLUGIN_ENABLED_KEY = "plugins.entries.anthropic.enabled";
+
+export function enableProviderPluginOps(
+  modelRefs: readonly (string | null | undefined)[],
+): OpenclawConfigSetArgs[] {
+  const providers = new Set(
+    modelRefs
+      .filter((ref): ref is string => typeof ref === "string" && ref.includes("/"))
+      .map((ref) => ref.split("/", 1)[0].trim().toLowerCase()),
+  );
+  return providers.has("anthropic") ? [[ANTHROPIC_PLUGIN_ENABLED_KEY, "true", "--json"]] : [];
+}

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
 import * as childProcess from "child_process";
 import fsp from "fs/promises";
 import type { ChildProcess } from "child_process";
@@ -99,9 +100,10 @@ vi.mock("@/lib/openclaw-config", () => ({
   // new primary provider takes effect on the open chat without a reset.
   applyModelOverrideToAllAgentSessions: vi.fn().mockResolvedValue(undefined),
   parseFullyQualifiedModel: vi.fn(parseFullyQualifiedModelImpl),
-  // Plugin gating: configure route now toggles `plugins.entries.anthropic.enabled`
-  // based on the active provider. Tests don't care about the side effect; just
-  // make the import resolve.
+  // Plugin gating: the route switches the plugin the new primary needs ON
+  // before the batch that writes `agents.defaults.model.primary` and gates
+  // the rest OFF after it. "the anthropic plugin around the primary write"
+  // asserts on both halves; every other test only needs the imports to resolve.
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),
   // Edition guard: these tests exercise the OpenClaw path, so openclaw is
   // present. The Hermes branch (openclawIsAbsent → true) is covered separately
@@ -149,6 +151,7 @@ import { inferConfiguredLocalModel, readConfig, readConfigStrict, restartGateway
   setPrimaryModelWithoutCatalogValidation,
   runOpenclawDoctorFix,
   spawnOpenclawCli,
+  setProviderPlugins,
 } from "@/lib/openclaw-config";
 import { configSetCalls, configSetCommands, failConfigSetsMatching, findConfigSet } from "./config-set-calls";
 import { getDefaultLlamaCppModel, getLlamaCppContextWindow, getLlamaCppMaxTokens, getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
@@ -253,6 +256,7 @@ describe("POST /setup-api/ai-models/configure", () => {
     vi.mocked(runOpenclawConfigUnset).mockResolvedValue(undefined);
     mockUnpairLocal.mockResolvedValue(undefined);
     vi.mocked(setPrimaryModelWithoutCatalogValidation).mockResolvedValue(undefined);
+    vi.mocked(setProviderPlugins).mockResolvedValue(undefined);
 
     // Re-apply implementations cleared by vi.clearAllMocks above. Factory
     // defaults set in `vi.mock(...)` hold across vi.resetModules but are
@@ -1951,6 +1955,101 @@ describe("POST /setup-api/ai-models/configure", () => {
       }));
 
       expect(res.status).toBe(500);
+    });
+  });
+
+  // OpenClaw 2 validates a model reference on `config set` against the
+  // captured catalogs of the ENABLED plugins, and an older gate switched the
+  // anthropic plugin off on every switch away from Claude. This route wrote
+  // the primary in its batch FIRST and enabled the plugin at step 8b — so on a
+  // box whose last primary was ClawBox AI / OpenAI / Google, a Claude save had
+  // its batch refused with `Unknown model: anthropic/claude-sonnet-5` and fell
+  // through to the direct-write fallback: a "success" whose primary the CLI
+  // had just refused. The enable now rides in the SAME batch, ahead of the
+  // primary: the core applies a batch to one snapshot and validates the
+  // references afterwards, so one spawn does both, and a refused batch leaves
+  // the flag as it was.
+  describe("the anthropic plugin around the primary write", () => {
+    const UNKNOWN_MODEL =
+      'Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary: '
+      + "Unknown model: anthropic/claude-sonnet-5. Run openclaw models list to list available models.";
+    const ENABLE_OP = ["plugins.entries.anthropic.enabled", "true", "--json"];
+
+    /** Where in vitest's global call sequence the first call `pick` accepts sits. */
+    function orderOf(mock: Mock, pick: (args: unknown[]) => boolean = () => true): number {
+      const index = mock.mock.calls.findIndex((args) => pick(args));
+      expect(index).toBeGreaterThanOrEqual(0);
+      return mock.mock.invocationCallOrder[index];
+    }
+
+    const carriesAnthropicPrimary = (op: string[]) =>
+      op[0] === "agents.defaults.model.primary" && String(op[1]).startsWith("anthropic/");
+    const isEnable = (op: string[]) => op[0] === ENABLE_OP[0] && op[1] === "true";
+
+    /**
+     * The CLI as a 2026.8.1 box answers it: the anthropic plugin is OFF (an
+     * older gate switched it off on the last switch away from Claude) and a
+     * batch carrying an `anthropic/*` primary is refused unless the same batch
+     * switches the plugin on ahead of it.
+     */
+    function refuseAnthropicPrimaryUnlessEnabledFirst() {
+      vi.mocked(runOpenclawConfigSet).mockImplementation(async (args) => {
+        if (carriesAnthropicPrimary(args)) throw new Error(UNKNOWN_MODEL);
+      });
+      vi.mocked(runOpenclawConfigSetBatch).mockImplementation(async (ops) => {
+        const enableIdx = ops.findIndex(isEnable);
+        const primaryIdx = ops.findIndex(carriesAnthropicPrimary);
+        if (primaryIdx >= 0 && !(enableIdx >= 0 && enableIdx < primaryIdx)) throw new Error(UNKNOWN_MODEL);
+      });
+    }
+
+    it.each([
+      ["a Claude subscription", { apiKey: ANTHROPIC_OAUTH_ACCESS, authMode: "subscription", refreshToken: "refresh-token", expiresIn: 3600 }],
+      ["an Anthropic API key", { apiKey: "sk-ant-test123" }],
+    ])("switches the plugin on in the SAME batch as the primary, ahead of it, for %s", async (_label, body) => {
+      refuseAnthropicPrimaryUnlessEnabledFirst();
+
+      const res = await configurePost(jsonRequest({ provider: "anthropic", ...body }));
+      expect(res.status).toBe(200);
+
+      // The reference went through the CLI's own validation. The direct-write
+      // fallback exists for an EMPTY catalog (placeholder key, first boot);
+      // taken here it would have masked exactly this ordering bug.
+      expect(vi.mocked(setPrimaryModelWithoutCatalogValidation)).not.toHaveBeenCalled();
+      const batch = vi.mocked(runOpenclawConfigSetBatch).mock.calls.find(([ops]) => ops.some(carriesAnthropicPrimary));
+      expect(batch).toBeDefined();
+      const ops = batch![0];
+      expect(ops.findIndex(isEnable)).toBeGreaterThanOrEqual(0);
+      expect(ops.findIndex(isEnable)).toBeLessThan(ops.findIndex(carriesAnthropicPrimary));
+      expect(vi.mocked(runOpenclawConfigSet).mock.calls.some(([args]) => isEnable(args))).toBe(false);
+
+      // The OFF half of the gate stays after the write (a no-op for Anthropic,
+      // but its place is what keeps a live primary's plugin on), and a plugin
+      // enabled by the batch loads on the next gateway start, so the restart
+      // that already ends the save has to stay after all of it.
+      const writtenAt = orderOf(vi.mocked(runOpenclawConfigSetBatch), (args) => (args[0] as string[][]).some(carriesAnthropicPrimary));
+      const gatedAt = orderOf(vi.mocked(setProviderPlugins), (args) => args[0] === "anthropic");
+      expect(writtenAt).toBeLessThan(gatedAt);
+      expect(gatedAt).toBeLessThan(orderOf(mockRestartGateway));
+    });
+
+    it("re-lands the enable with the rest of the batch when the catalog refuses the primary", async () => {
+      // The empty-catalog fallback retries the batch WITHOUT the primary and
+      // writes the primary directly; the enable is not the primary, so it
+      // rides the retry — the plugin is on for the model the direct write
+      // then names.
+      vi.mocked(runOpenclawConfigSetBatch).mockRejectedValueOnce(new Error(UNKNOWN_MODEL));
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-ant-test123" }));
+      expect(res.status).toBe(200);
+      expect(vi.mocked(setPrimaryModelWithoutCatalogValidation)).toHaveBeenCalledWith("anthropic/claude-sonnet-5");
+      const batches = vi.mocked(runOpenclawConfigSetBatch).mock.calls;
+      expect(batches.length).toBeGreaterThanOrEqual(2);
+      const retry = batches[1][0];
+      expect(retry.some(isEnable)).toBe(true);
+      expect(retry.some(carriesAnthropicPrimary)).toBe(false);
+      expect(warn.mock.calls.map(([first]) => String(first)).some((line) => line.includes("Primary written directly"))).toBe(true);
     });
   });
 });

--- a/src/tests/routes/chat-model-codex-surface.test.ts
+++ b/src/tests/routes/chat-model-codex-surface.test.ts
@@ -12,12 +12,21 @@ vi.mock("fs", () => ({
   promises: { readFile: vi.fn() },
 }));
 
+const { configSetMock } = vi.hoisted(() => ({ configSetMock: vi.fn() }));
+
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
-  runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSet: configSetMock,
+  // The route writes the primary in a batch now. Record every assignment of
+  // a batch on `runOpenclawConfigSet` too, the way config-set-calls flattens
+  // both forms for the configure suites: the assertions here are about which
+  // assignments were made, not about how many processes carried them.
+  runOpenclawConfigSetBatch: vi.fn(async (ops: string[][]) => {
+    for (const op of ops) await configSetMock(op);
+  }),
   applyModelOverrideToAllAgentSessions: vi.fn(),
   parseFullyQualifiedModel: vi.fn(),
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),

--- a/src/tests/routes/chat-model-subscription-surface.test.ts
+++ b/src/tests/routes/chat-model-subscription-surface.test.ts
@@ -12,12 +12,21 @@ vi.mock("fs", () => ({
   promises: { readFile: vi.fn() },
 }));
 
+const { configSetMock } = vi.hoisted(() => ({ configSetMock: vi.fn() }));
+
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
-  runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSet: configSetMock,
+  // The route writes the primary in a batch now. Record every assignment of
+  // a batch on `runOpenclawConfigSet` too, the way config-set-calls flattens
+  // both forms for the configure suites: the assertions here are about which
+  // assignments were made, not about how many processes carried them.
+  runOpenclawConfigSetBatch: vi.fn(async (ops: string[][]) => {
+    for (const op of ops) await configSetMock(op);
+  }),
   applyModelOverrideToAllAgentSessions: vi.fn(),
   parseFullyQualifiedModel: vi.fn(),
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
 
 vi.mock("child_process", () => ({
   execFile: vi.fn(),
@@ -13,16 +14,27 @@ vi.mock("@/lib/config-store", () => ({
   getAll: vi.fn(),
 }));
 
+const { configSetMock } = vi.hoisted(() => ({ configSetMock: vi.fn() }));
+
 vi.mock("@/lib/openclaw-config", () => ({
   inferConfiguredLocalModel: vi.fn(),
   findOpenclawBin: vi.fn(() => "/usr/local/bin/openclaw"),
   readConfig: vi.fn(),
   restartGateway: vi.fn(),
-  runOpenclawConfigSet: vi.fn(),
+  runOpenclawConfigSet: configSetMock,
+  // The route writes the primary in a batch now. Record every assignment of
+  // a batch on `runOpenclawConfigSet` too, the way config-set-calls flattens
+  // both forms for the configure suites: the assertions here are about which
+  // assignments were made, not about how many processes carried them.
+  runOpenclawConfigSetBatch: vi.fn(async (ops: string[][]) => {
+    for (const op of ops) await configSetMock(op);
+  }),
   applyModelOverrideToAllAgentSessions: vi.fn(),
   parseFullyQualifiedModel: vi.fn(),
-  // Plugin gating: chat/model route toggles `plugins.entries.anthropic.enabled`
-  // when switching providers. Stubbed since tests don't assert on it.
+  // Plugin gating: the route switches the plugin the new primary needs ON
+  // before writing `agents.defaults.model.primary` and gates the rest OFF
+  // after it. The ordering suite at the bottom asserts on both halves; every
+  // other test only needs the imports to resolve.
   setProviderPlugins: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -32,7 +44,7 @@ vi.mock("@/lib/sqlite-store", () => ({
 }));
 
 import { getAll } from "@/lib/config-store";
-import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel } from "@/lib/openclaw-config";
+import { inferConfiguredLocalModel, readConfig, restartGateway, runOpenclawConfigSet, applyModelOverrideToAllAgentSessions, parseFullyQualifiedModel, setProviderPlugins, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
 import { sqliteGet, sqliteSet } from "@/lib/sqlite-store";
 import { promisify } from "util";
 
@@ -626,6 +638,114 @@ describe("/setup-api/chat/model", () => {
       await expect(response.json()).resolves.toMatchObject({ kind: "provider_disabled", provider: "anthropic" });
       expect(runOpenclawConfigSet).not.toHaveBeenCalled();
       expect(restartGateway).not.toHaveBeenCalled();
+    });
+  });
+
+  // OpenClaw 2 validates a model reference on `config set` against the
+  // captured catalogs of the ENABLED plugins, and an older gate switched the
+  // anthropic plugin off on every switch away from Claude. The switch BACK was
+  // then refused straight to the owner — `Unknown model:
+  // anthropic/claude-sonnet-5` — because this route wrote the primary first
+  // and enabled the plugin after. (2026.7.x answered from the bundled catalog
+  // regardless of plugin state, which is why the order never mattered before
+  // the core upgrade.) The enable now rides in the SAME batch as the primary,
+  // ahead of it: the core applies a batch to one snapshot and validates the
+  // references afterwards, so one spawn does both, and a refused batch leaves
+  // the flag as it was.
+  describe("the anthropic plugin around the primary write", () => {
+    const UNKNOWN_MODEL =
+      'Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary: '
+      + "Unknown model: anthropic/claude-sonnet-5. Run openclaw models list to list available models.";
+    const ENABLE_OP = ["plugins.entries.anthropic.enabled", "true", "--json"];
+
+    /** Where in vitest's global call sequence the first call `pick` accepts sits. */
+    function orderOf(mock: Mock, pick: (args: unknown[]) => boolean = () => true): number {
+      const index = mock.mock.calls.findIndex((args) => pick(args));
+      expect(index).toBeGreaterThanOrEqual(0);
+      return mock.mock.invocationCallOrder[index];
+    }
+
+    const isPrimaryWrite = (op: string[]) => op[0] === "agents.defaults.model.primary";
+    /** The batch call that carries the primary, as vitest records it: `[ops]`. */
+    const carriesPrimary = (call: unknown[]) => (call[0] as string[][]).some(isPrimaryWrite);
+
+    beforeEach(() => {
+      vi.mocked(readConfig).mockResolvedValue({
+        auth: {
+          profiles: {
+            "deepseek:default": { provider: "deepseek", mode: "api_key" },
+            "anthropic:default": { provider: "anthropic", mode: "api_key" },
+          },
+        },
+        agents: { defaults: { model: { primary: "deepseek/deepseek-v4-flash" } } },
+      } as never);
+
+      // The CLI as a 2026.8.1 box answers it: the anthropic plugin is OFF
+      // (an older gate switched it off on the last switch away from Claude)
+      // and a batch carrying an `anthropic/*` primary is refused unless the
+      // same batch switches the plugin on ahead of it.
+      vi.mocked(runOpenclawConfigSetBatch).mockImplementation(async (ops) => {
+        const enableIdx = ops.findIndex((op) => op[0] === ENABLE_OP[0] && op[1] === "true");
+        const primaryIdx = ops.findIndex((op) => isPrimaryWrite(op) && String(op[1]).startsWith("anthropic/"));
+        if (primaryIdx >= 0 && !(enableIdx >= 0 && enableIdx < primaryIdx)) throw new Error(UNKNOWN_MODEL);
+        if (ops.length === 1) await vi.mocked(runOpenclawConfigSet)(ops[0]);
+      });
+    });
+
+    it("switches the plugin on in the SAME batch as the Anthropic primary, ahead of it, and restarts after", async () => {
+      const response = await POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+      }));
+      const body = await response.json();
+
+      expect(body.error).toBeUndefined();
+      expect(response.status).toBe(200);
+      expect(runOpenclawConfigSetBatch).toHaveBeenCalledWith([
+        ENABLE_OP,
+        ["agents.defaults.model.primary", "anthropic/claude-sonnet-5"],
+      ]);
+      // A plugin enabled by the batch loads on the next gateway start, so the
+      // restart that already follows the switch has to stay after it.
+      expect(orderOf(vi.mocked(runOpenclawConfigSetBatch), carriesPrimary)).toBeLessThan(orderOf(vi.mocked(restartGateway)));
+      expect(restartGateway).toHaveBeenCalledTimes(1);
+    });
+
+    it("leaves the plugin and the gateway alone when the batch is refused", async () => {
+      // Atomic: a refused batch changed nothing, so there is nothing to put
+      // back and nothing to restart — the owner gets the refusal, unmasked.
+      vi.mocked(runOpenclawConfigSetBatch).mockRejectedValue(new Error(UNKNOWN_MODEL));
+
+      const response = await POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+      }));
+      const body = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(body.error).toContain("Unknown model: anthropic/claude-sonnet-5");
+      expect(runOpenclawConfigSet).not.toHaveBeenCalledWith(expect.arrayContaining([ENABLE_OP[0]]));
+      expect(setProviderPlugins).not.toHaveBeenCalled();
+      expect(restartGateway).not.toHaveBeenCalled();
+    });
+
+    it("keeps the OFF half of the gate AFTER the write when the new primary is not Anthropic", async () => {
+      // The OFF half (off only when nothing on the box could use the plugin)
+      // stays where it was: never before the write, so a plugin whose model IS
+      // the current primary is not switched off under it.
+      const response = await POST(new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ model: "llamacpp/gemma4-e2b-it-q4_0" }),
+      }));
+      expect(response.status).toBe(200);
+
+      const writtenAt = orderOf(vi.mocked(runOpenclawConfigSetBatch), carriesPrimary);
+      const gatedAt = orderOf(vi.mocked(setProviderPlugins), (args) => args[0] === "llamacpp");
+      expect(writtenAt).toBeLessThan(gatedAt);
+      expect(gatedAt).toBeLessThan(orderOf(vi.mocked(restartGateway)));
     });
   });
 });

--- a/src/tests/routes/local-ai-exclusive-sessions.test.ts
+++ b/src/tests/routes/local-ai-exclusive-sessions.test.ts
@@ -26,6 +26,10 @@ vi.mock("@/lib/config-store", () => ({
   }),
 }));
 
+const { configSetMock } = vi.hoisted(() => ({
+  configSetMock: vi.fn<(op: string[]) => Promise<void>>(async () => {}),
+}));
+
 vi.mock("@/lib/openclaw-config", () => ({
   callGatewayRpc: vi.fn(),
   gatewayIsAbsent: () => false,
@@ -33,7 +37,14 @@ vi.mock("@/lib/openclaw-config", () => ({
     agents: { defaults: { model: { primary: "deepseek/deepseek-v4-pro", fallbacks: [] } } },
   })),
   restartGateway: vi.fn(async () => {}),
-  runOpenclawConfigSet: vi.fn(async () => {}),
+  runOpenclawConfigSet: configSetMock,
+  // The primary and the fallbacks travel in one `config set --batch-json` now
+  // (atomic, and it carries the plugin enable an Anthropic reference needs).
+  // Record each operation on `runOpenclawConfigSet` too, so `configWrites`
+  // stays a list of the assignments made, not of the processes that made them.
+  runOpenclawConfigSetBatch: vi.fn(async (ops: string[][]) => {
+    for (const op of ops) await configSetMock(op);
+  }),
 }));
 
 vi.mock("@/lib/openclaw-session-store", () => ({

--- a/src/tests/routes/local-ai/exclusive.test.ts
+++ b/src/tests/routes/local-ai/exclusive.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+
+/**
+ * Turning Local-only mode OFF restores the cloud primary it saved when it was
+ * turned on — the third writer of `agents.defaults.model.primary`, beside
+ * chat/model and ai-models/configure. That saved primary can be Anthropic's,
+ * and a provider save made while Local-only was on gates the anthropic plugin
+ * off; OpenClaw 2 then refuses the reference ("Unknown model") and the toggle
+ * fails with the CLI's sentence in a red banner, Local-only stuck on. The
+ * enable has to ride in the same batch as the restore write here just as it
+ * does at the other two sites — and here it covers the fallbacks too, which
+ * are validated exactly like the primary.
+ *
+ * The session half of this route (the gateway `sessions.patchMany` round trip
+ * and its backup) is covered by local-ai-exclusive-sessions.test.ts; no agent
+ * has a store here, so these cases are only about the config writes.
+ */
+
+vi.mock("@/lib/config-store", () => ({
+  get: vi.fn(),
+  set: vi.fn(async () => {}),
+  setMany: vi.fn(async () => {}),
+}));
+
+vi.mock("@/lib/openclaw-session-store", () => ({
+  listAgentIds: vi.fn(() => []),
+  sessionStorePath: vi.fn(() => null),
+  readSessionEntries: vi.fn(() => []),
+}));
+
+vi.mock("@/lib/openclaw-config", () => ({
+  callGatewayRpc: vi.fn(),
+  gatewayIsAbsent: vi.fn(() => false),
+  readConfig: vi.fn(async () => ({})),
+  restartGateway: vi.fn(async () => {}),
+  runOpenclawConfigSet: vi.fn(async () => {}),
+  runOpenclawConfigSetBatch: vi.fn(async () => {}),
+}));
+
+import { get, setMany } from "@/lib/config-store";
+import { restartGateway, runOpenclawConfigSetBatch } from "@/lib/openclaw-config";
+
+const UNKNOWN_MODEL =
+  'Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary: '
+  + "Unknown model: anthropic/claude-sonnet-5. Run openclaw models list to list available models.";
+
+const ENABLE_OP = ["plugins.entries.anthropic.enabled", "true", "--json"];
+
+/** Where in vitest's global call sequence the first call `pick` accepts sits. */
+function orderOf(mock: Mock, pick: (args: unknown[]) => boolean = () => true): number {
+  const index = mock.mock.calls.findIndex((args) => pick(args));
+  expect(index).toBeGreaterThanOrEqual(0);
+  return mock.mock.invocationCallOrder[index];
+}
+
+const namesAnthropic = (op: string[]) =>
+  /^agents\.defaults\.model\.(primary|fallbacks)$/.test(op[0]) && op[1].includes("anthropic/");
+
+/**
+ * The CLI as a 2026.8.1 box answers it: the plugin was gated off while
+ * Local-only was on, and a batch touching an `anthropic/*` reference — the
+ * primary or a fallback — is refused unless the same batch switches the
+ * plugin on ahead of it.
+ */
+function refuseAnthropicRefsUnlessEnabledFirst() {
+  vi.mocked(runOpenclawConfigSetBatch).mockImplementation(async (ops) => {
+    const enableIdx = ops.findIndex((op) => op[0] === ENABLE_OP[0] && op[1] === "true");
+    const refIdx = ops.findIndex(namesAnthropic);
+    if (refIdx >= 0 && !(enableIdx >= 0 && enableIdx < refIdx)) throw new Error(UNKNOWN_MODEL);
+  });
+}
+
+describe("POST /setup-api/local-ai/exclusive — restoring the saved primary and fallbacks", () => {
+  let POST: (request: Request) => Promise<Response>;
+  let store: Record<string, unknown>;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    // Local-only is ON and was entered from an Anthropic primary.
+    store = {
+      local_only_mode: true,
+      local_only_saved_primary: "anthropic/claude-sonnet-5",
+    };
+    vi.mocked(get).mockImplementation(async (key: string) => store[key]);
+    vi.mocked(restartGateway).mockResolvedValue(undefined);
+    refuseAnthropicRefsUnlessEnabledFirst();
+
+    POST = (await import("@/app/setup-api/local-ai/exclusive/route")).POST;
+  });
+
+  const turnOff = () => POST(new Request("http://localhost/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ enabled: false }),
+  }));
+
+  it("restores the saved Anthropic primary in ONE batch that switches its plugin on first, then restarts", async () => {
+    const response = await turnOff();
+    const body = await response.json();
+
+    expect(body.error).toBeUndefined();
+    expect(response.status).toBe(200);
+    expect(body.enabled).toBe(false);
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runOpenclawConfigSetBatch).mock.calls[0][0]).toEqual([
+      ENABLE_OP,
+      ["agents.defaults.model.primary", JSON.stringify("anthropic/claude-sonnet-5"), "--json"],
+    ]);
+    expect(orderOf(vi.mocked(runOpenclawConfigSetBatch))).toBeLessThan(orderOf(vi.mocked(restartGateway)));
+  });
+
+  it("switches the plugin on for a FALLBACK that names Anthropic, in the same batch as both lists", async () => {
+    // `agents.defaults.model.fallbacks.N` is validated exactly like the
+    // primary. Local-only entered from an OpenAI primary with an Anthropic
+    // fallback used to restore the primary, then have the fallbacks refused —
+    // a 500 with the cloud primary already back and Local-only still on.
+    store.local_only_saved_primary = "openai/gpt-5.5";
+    store.local_only_saved_fallbacks = ["anthropic/claude-sonnet-5"];
+
+    const response = await turnOff();
+
+    expect(response.status).toBe(200);
+    expect(runOpenclawConfigSetBatch).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(runOpenclawConfigSetBatch).mock.calls[0][0]).toEqual([
+      ENABLE_OP,
+      ["agents.defaults.model.primary", JSON.stringify("openai/gpt-5.5"), "--json"],
+      ["agents.defaults.model.fallbacks", JSON.stringify(["anthropic/claude-sonnet-5"]), "--json"],
+    ]);
+  });
+
+  it("leaves Local-only on, the plugin untouched and the gateway alone when the batch is refused", async () => {
+    // Atomic: a refused batch changed nothing — no primary back, no flag
+    // flipped — so there is nothing to restore and nothing to restart.
+    vi.mocked(runOpenclawConfigSetBatch).mockRejectedValue(new Error("ConfigMutationConflictError: config changed"));
+
+    const response = await turnOff();
+
+    expect(response.status).toBe(500);
+    expect(setMany).not.toHaveBeenCalled();
+    expect(restartGateway).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/openclaw-config-provider-plugins.test.ts
+++ b/src/tests/unit/openclaw-config-provider-plugins.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "node:events";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { enableProviderPluginOps } from "@/lib/provider-plugin-ops";
+
+/**
+ * The anthropic plugin toggle is two halves around the primary write: the
+ * enable rides IN the primary's batch, ahead of it (OpenClaw 2 resolves an
+ * `anthropic/...` reference only while the plugin is enabled, and validates
+ * the batch as a whole), and `setProviderPlugins` runs AFTER it and switches
+ * the plugin off only when nothing on the box could use it — no Anthropic
+ * primary and no usable Anthropic credential. The one-way door (M-01 / F-02)
+ * was a single call that did both halves, on the wrong side of the write.
+ */
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+
+vi.mock("child_process", () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+  execFile: vi.fn(),
+}));
+
+/** A CLI child that exits with `code` on the next tick, `stderr` first when given. */
+function exitingChild(code = 0, stderr = "") {
+  const child = Object.assign(new EventEmitter(), {
+    stdout: null,
+    stderr: new EventEmitter(),
+    stdin: null,
+    kill: vi.fn(),
+  });
+  setImmediate(() => {
+    if (stderr) child.stderr.emit("data", Buffer.from(stderr));
+    child.emit("close", code);
+  });
+  return child;
+}
+
+const originalHome = process.env.CLAWBOX_OPENCLAW_HOME;
+const originalRoot = process.env.CLAWBOX_ROOT;
+let home: string;
+
+beforeEach(async () => {
+  home = await fs.mkdtemp(path.join(os.tmpdir(), "clawbox-provider-plugins-"));
+  process.env.CLAWBOX_OPENCLAW_HOME = home;
+  // The owner's provider switch lives in ClawBox's own config store.
+  process.env.CLAWBOX_ROOT = home;
+  vi.resetModules();
+  spawnMock.mockReset();
+  spawnMock.mockImplementation(() => exitingChild());
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.CLAWBOX_OPENCLAW_HOME;
+  else process.env.CLAWBOX_OPENCLAW_HOME = originalHome;
+  if (originalRoot === undefined) delete process.env.CLAWBOX_ROOT;
+  else process.env.CLAWBOX_ROOT = originalRoot;
+  await fs.rm(home, { recursive: true, force: true });
+});
+
+/** A box whose anthropic plugin is `enabled`, and the module read against it. */
+async function withAnthropicPlugin(enabled: boolean) {
+  await fs.writeFile(
+    path.join(home, "openclaw.json"),
+    JSON.stringify({ plugins: { entries: { anthropic: { enabled } } } }),
+  );
+  return import("@/lib/openclaw-config");
+}
+
+/** The `plugins.entries.anthropic.enabled` value the CLI was asked to set, if any. */
+function writtenValue(): string | null {
+  const call = spawnMock.mock.calls.find(([, args]) =>
+    (args as string[]).includes("plugins.entries.anthropic.enabled"));
+  if (!call) return null;
+  const args = call[1] as string[];
+  return args[args.indexOf("plugins.entries.anthropic.enabled") + 1];
+}
+
+describe("enableProviderPluginOps — the ops that ride in the primary batch, ahead of it", () => {
+  // Pure: OpenClaw 2 validates every model reference a batch touches against
+  // the enabled plugins' catalogs after applying the WHOLE batch to one
+  // snapshot, so the enable belongs in the same batch as the reference —
+  // one spawn, and a refused batch leaves the flag as it was.
+  it("switches the plugin on for an Anthropic reference", () => {
+    expect(enableProviderPluginOps(["anthropic/claude-sonnet-5"])).toEqual([
+      ["plugins.entries.anthropic.enabled", "true", "--json"],
+    ]);
+  });
+
+  it("emits nothing for any other provider, and never a switch-off", () => {
+    expect(enableProviderPluginOps(["deepseek/deepseek-v4-pro", "openai/gpt-5.5", "llamacpp/gemma"])).toEqual([]);
+    expect(enableProviderPluginOps([])).toEqual([]);
+    expect(enableProviderPluginOps([null, undefined, "no-slash"])).toEqual([]);
+  });
+
+  it("covers a fallback that names Anthropic, once, whatever the primary", () => {
+    // `agents.defaults.model.fallbacks.N` is validated the same way the
+    // primary is; a restore of primary + fallbacks needs one enable for both.
+    expect(enableProviderPluginOps(["openai/gpt-5.5", "anthropic/claude-sonnet-5", "anthropic/claude-haiku-4-5"])).toEqual([
+      ["plugins.entries.anthropic.enabled", "true", "--json"],
+    ]);
+  });
+});
+
+describe("setProviderPlugins — the half AFTER the primary write", () => {
+  it("switches the plugin off once the primary has left Anthropic and nothing could use it", async () => {
+    const { setProviderPlugins } = await withAnthropicPlugin(true);
+    await setProviderPlugins("deepseek");
+    expect(writtenValue()).toBe("false");
+  });
+
+  it("keeps the plugin on after a switch away while an Anthropic credential exists", async () => {
+    // Measured on a 2026.8.1 box: with the plugin disabled, `models list
+    // --provider anthropic --all --json` answers ONE row against eleven with
+    // it enabled — the three-model Claude picker. A provider the owner can
+    // still pick keeps its catalog.
+    await fs.writeFile(
+      path.join(home, "openclaw.json"),
+      JSON.stringify({
+        plugins: { entries: { anthropic: { enabled: true } } },
+        auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "api_key" } } },
+      }),
+    );
+    const { setProviderPlugins } = await import("@/lib/openclaw-config");
+    await setProviderPlugins("deepseek");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("switches the plugin off despite a credential the owner switched off in Settings", async () => {
+    // The switch takes the provider out of every place the box picks a model,
+    // so a credential behind it is one nothing can route to — and its plugin
+    // is pure prep cost.
+    await fs.writeFile(
+      path.join(home, "openclaw.json"),
+      JSON.stringify({
+        plugins: { entries: { anthropic: { enabled: true } } },
+        auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "api_key" } } },
+      }),
+    );
+    await fs.mkdir(path.join(home, "data"), { recursive: true });
+    await fs.writeFile(path.join(home, "data", "config.json"), JSON.stringify({ ai_disabled_providers: ["anthropic"] }));
+    const { setProviderPlugins } = await import("@/lib/openclaw-config");
+    await setProviderPlugins("deepseek");
+    expect(writtenValue()).toBe("false");
+  });
+
+  it("treats an absent flag as enabled — the plugin declares enabledByDefault", async () => {
+    await fs.writeFile(path.join(home, "openclaw.json"), JSON.stringify({}));
+    const { setProviderPlugins } = await import("@/lib/openclaw-config");
+    await setProviderPlugins("anthropic");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("leaves the plugin alone when the config cannot be read — unreadable is not 'no credential'", async () => {
+    // `readConfig` answers `{}` to a half-written or unreadable file; deciding
+    // "nothing could use the plugin" from that would switch it off on a box
+    // that holds a credential.
+    await fs.writeFile(path.join(home, "openclaw.json"), "{ not json");
+    const { setProviderPlugins } = await import("@/lib/openclaw-config");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await setProviderPlugins("deepseek");
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("switches the plugin back on after a switch away when a credential exists and an older gate left it off", async () => {
+    await fs.writeFile(
+      path.join(home, "openclaw.json"),
+      JSON.stringify({
+        plugins: { entries: { anthropic: { enabled: false } } },
+        auth: { profiles: { "anthropic:default": { provider: "anthropic", mode: "oauth" } } },
+      }),
+    );
+    const { setProviderPlugins } = await import("@/lib/openclaw-config");
+    await setProviderPlugins("deepseek");
+    expect(writtenValue()).toBe("true");
+  });
+
+  it("leaves an already-enabled plugin alone for an Anthropic primary", async () => {
+    const { setProviderPlugins } = await withAnthropicPlugin(true);
+    await setProviderPlugins("anthropic");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it("still switches the plugin on for an Anthropic primary if the BEFORE half was skipped", async () => {
+    // Idempotent both ways, so a caller that only has the after-write call
+    // (or whose enable failed and was retried by the CLI later) converges.
+    const { setProviderPlugins } = await withAnthropicPlugin(false);
+    await setProviderPlugins("anthropic");
+    expect(writtenValue()).toBe("true");
+  });
+});

--- a/src/tests/unit/openclaw-config-provider-plugins.test.ts
+++ b/src/tests/unit/openclaw-config-provider-plugins.test.ts
@@ -127,6 +127,23 @@ describe("setProviderPlugins — the half AFTER the primary write", () => {
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
+  it("keeps the plugin on while a configured FALLBACK still names Anthropic, credential or not", async () => {
+    // The gateway will route there when the primary fails, and only the plugin
+    // resolves the reference. The core does not protect this itself: a batch
+    // whose only operation is the plugin flag touches no model ref, so nothing
+    // is validated and the disable lands.
+    await fs.writeFile(
+      path.join(home, "openclaw.json"),
+      JSON.stringify({
+        plugins: { entries: { anthropic: { enabled: true } } },
+        agents: { defaults: { model: { primary: "openai/gpt-5.5", fallbacks: ["anthropic/claude-sonnet-5"] } } },
+      }),
+    );
+    const { setProviderPlugins } = await import("@/lib/openclaw-config");
+    await setProviderPlugins("openai");
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
   it("switches the plugin off despite a credential the owner switched off in Settings", async () => {
     // The switch takes the provider out of every place the box picks a model,
     // so a credential behind it is one nothing can route to — and its plugin


### PR DESCRIPTION
**Finding F-02 / M-01 — board TASK-616.** This re-lands the intended change of #578 on top of the revert in #588, and nothing else.

## Symptom

On a box running OpenClaw core 2026.8.1 whose last primary was ClawBox AI / OpenAI / Google, switching the chat back to an Anthropic model was refused straight to the owner:

```
Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary:
Unknown model: anthropic/claude-sonnet-5. Run openclaw models list to list available models.
```

In the Settings save path the same refusal was *masked*: the batch failed, the route fell through to its empty-catalog direct write, and reported success for a primary the CLI had just rejected. Turning Local-only mode off had a third shape — the primary was restored, then the saved fallbacks were refused, leaving a 500 with the cloud primary already back and `local_only_mode` still true.

## Cause

ClawBox wrote `agents.defaults.model.primary` first and toggled `plugins.entries.anthropic.enabled` *after* it. The old gate switched that plugin OFF on every switch away from Anthropic, so the next switch back had to validate an `anthropic/*` reference while the plugin that resolves it was disabled. 2026.7.x answered from the bundled catalog whatever the plugin state, which is why the ordering never mattered before the core upgrade.

## The harness mechanism (verified in the installed core, openclaw@2026.8.1)

`config set --batch-json` is one validated read-modify-write, not N writes:

- `runConfigOperations` (`dist/config-cli-*.js`) applies **every** operation of the batch to one `structuredClone(snapshot.resolved)`, and only then calls `validateConfigMutation` once over the resulting config.
- `createRuntimeModelRefResolver` resolves each touched model reference against **that post-batch config**, with `loadRuntimePlugins: true` — so a `plugins.entries.anthropic.enabled = true` operation placed earlier in the same batch is in force when the reference is checked.
- `collectTextModelRefs` walks `model.fallbacks` as well (`…fallbacks.N`), so a fallback naming Anthropic is validated exactly like the primary.
- On a refusal `replaceConfigFile` is never reached: the batch is atomic, and a rejected batch leaves the flag exactly as it was.

So the enable belongs **in** the batch, ahead of the reference it validates — one spawn instead of two (10–17 s of CLI start-up saved on every upgraded box's first switch back), and no failure-path "restore" to get wrong.

## The change

`src/lib/provider-plugin-ops.ts` (new, pure — no read, no spawn) turns a set of model references into the enable operations they need. All three writers of a model reference now prepend it to their own batch:

| writer | batch |
| --- | --- |
| `chat/model` | enable + `agents.defaults.model.primary` |
| `ai-models/configure` | enable unshifted onto `baseOps`; the empty-catalog retry drops only the primary, so the enable re-lands with the rest |
| `local-ai/exclusive` (Local-only OFF) | enables for every provider named by the saved primary **and** the saved fallbacks, then both lists — one atomic batch |

The OFF half (`setProviderPlugins`) stays **after** the write on purpose, so a plugin whose model is the current primary is never switched off underneath it — and it now keys on credentials, not on the active provider: measured on a 2026.8.1 box, `openclaw models list --provider anthropic --all --json` answers ONE row with the plugin disabled against eleven with it enabled, and that one row is the three-model picker owners were seeing. The plugin stays on while an Anthropic credential exists that the owner has not switched off in Settings; it goes off only when nothing on the box could use it.

## Sibling call sites

Every other writer of `agents.defaults.model.primary` / `.fallbacks` was checked: `configure/route.ts:963,978,2267,2276` and `local-ai/route.ts:68` write only ClawBox AI, a local model, or `[]` — no Anthropic reference can reach them, so none needs an enable. The Local-only restore was the only sibling the original grep missed (it writes the fallbacks through the same validating call).

## Review findings

Applied: the atomic batch (E1, which subsumes A1 and A2 — there is no longer a catch-path gate that could switch the plugin on and then throw without a restart); A3 (a provider the owner switched off in Settings has no usable credential — `DISABLED_PROVIDERS_KEY` is consulted); A5 (the config is read ONCE and strictly — an unreadable config leaves the plugin alone rather than reading as "no credential", and an absent flag counts as enabled because the plugin declares `enabledByDefault: true`, so a fresh box costs no spawn); C1 (the fallbacks); C3 (the comments and test headers that still described the old OFF rule).

Not applied, with reasons:

- **A4** — `hasUsableAnthropicCredential` reads `auth.profiles` metadata, not the agent's SQLite credential store. Kept and documented in the function's doc comment: verifying whether `openclaw models auth logout` also drops the metadata entry needs a box, and the failure mode if it does not is prep latency on a logged-out box, never a broken one.
- **E2** — keeping the credential rule is deliberate. TASK-654 re-measures agent-prep latency with the plugin on vs off on 2026.8.1; if the cost is real, this becomes provider-gated again once M-05 (TASK-653) stops the catalog route persisting a starved result.
- **E3** — the boot healer (`scripts/gateway-pre-start.sh`) could apply the rule for zero spawns. Deliberately out of scope here: this branch is a surgical re-land and touches no file outside the ones the change needs.

## RED → GREEN

RED, on the revert branch, before the fix (13 failures):

```
FAIL src/tests/routes/chat-model.test.ts > the anthropic plugin around the primary write
  › switches the plugin on in the SAME batch as the Anthropic primary, ahead of it, and restarts after
    AssertionError: expected "vi.fn()" to be called with arguments: [ [ [ …(3) ], [ …(2) ] ] ]
  › leaves the plugin and the gateway alone when the batch is refused
    AssertionError: expected 200 to be 500
  › keeps the OFF half of the gate AFTER the write when the new primary is not Anthropic
    AssertionError: expected -1 to be greater than or equal to 0

FAIL src/tests/routes/ai-models/configure.test.ts > the anthropic plugin around the primary write
  › switches the plugin on in the SAME batch as the primary, ahead of it, for a Claude subscription
  › switches the plugin on in the SAME batch as the primary, ahead of it, for an Anthropic API key
    AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
    (setPrimaryModelWithoutCatalogValidation — the direct write masking the refusal)
  › re-lands the enable with the rest of the batch when the catalog refuses the primary
    AssertionError: expected false to be true

FAIL src/tests/routes/local-ai/exclusive.test.ts > restoring the saved primary and fallbacks
  › restores the saved Anthropic primary in ONE batch that switches its plugin on first, then restarts
  › switches the plugin on for a FALLBACK that names Anthropic, in the same batch as both lists
    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
  › leaves Local-only on, the plugin untouched and the gateway alone when the batch is refused
    AssertionError: expected 200 to be 500

FAIL src/tests/unit/openclaw-config-provider-plugins.test.ts > setProviderPlugins
  › keeps the plugin on after a switch away while an Anthropic credential exists
  › treats an absent flag as enabled — the plugin declares enabledByDefault
  › leaves the plugin alone when the config cannot be read — unreadable is not 'no credential'
  › switches the plugin back on after a switch away when a credential exists and an older gate left it off

Test Files  4 failed (4)
     Tests  13 failed | 111 passed (124)
```

The route mocks model the 2026.8.1 CLI: a batch carrying an `anthropic/*` reference is refused unless the same batch switches the plugin on ahead of it.

GREEN:

```
src/tests/routes/chat-model.test.ts, ai-models/configure.test.ts,
local-ai/exclusive.test.ts, unit/openclaw-config-provider-plugins.test.ts
  Test Files  4 passed (4)   Tests  124 passed (124)

full suite:  Test Files 621 passed / 623   Tests 8991 passed / 8993
  (the 2 failures are hermes-config-lock / hermes-dashboard-auth-yaml flock-timing
   tests that time out under full-suite parallelism and pass on their own — 19 passed)

npx tsc --noEmit -p tsconfig.json   clean
eslint on every changed file        0 errors
```

`src/tests/unit/openclaw-session-model.test.ts`, `openclaw-session-store.test.ts`, `apply-model-override-v2-store.test.ts` (33 passed) and `src/tests/components/chat-hermes-tabs.test.tsx` pass unchanged — #583 and #579 are intact.

## Why this is not the reverted diff

#578's merged head was a bad rebase that carried the branch's pre-rebase copies of 41 files and so reverted #583 (the OpenClaw 2 session repoint through the gateway) and #579 (the Hermes chat tab strip). This branch is cut from `revert/pr-578-merge` and re-applies only the plugin hunks — `git diff --stat` against that branch lists 12 files and **no deletions**: the five source files and three test files the change needs, plus `provider-plugin-ops.ts`, plus the batch mock that three sibling suites need because three routes changed which config-set helper they call (`chat-model-codex-surface`, `chat-model-subscription-surface`, `local-ai-exclusive-sessions` — mock plumbing only; their assertions are unchanged, the batch mock forwards each operation to the existing `runOpenclawConfigSet` mock).

## Device leg

The plugin switch was proven on `.45` at 20:07 on the reverted build: with the plugin disabled, a `config set` of an `anthropic/*` primary is refused with "Unknown model", and ClawBox disabled it on every switch away. Re-proof after this deploys.

## Follow-up commit (review)

`2ce6b849` — CodeRabbit found a real gap in the OFF half and it is fixed: `setProviderPlugins` looked only at the active provider and the credentials, so a box whose primary had moved elsewhere while `agents.defaults.model.fallbacks` still named `anthropic/...` could have the plugin switched off under a reference the gateway will try to route through. Verified in the core rather than assumed: a batch whose only operation is `plugins.entries.anthropic.enabled` touches no model-reference path, so `collectTouchedTextModelRefs` returns nothing for it, `validateConfigMutation` checks no fallback, and the disable lands — the fallback fails only later, when it is selected. `configReferencesAnthropic(config)` now reads the default primary and every fallback off the snapshot `setProviderPlugins` already holds (no extra read, no extra spawn) and outranks every other signal, the owner's provider switch included: a configured reference is a live routing path. It also makes the two halves symmetric — `enableProviderPluginOps` already covers the primary and the fallbacks of the batch it rides in. Regression test: primary `openai/gpt-5.5`, fallbacks `["anthropic/claude-sonnet-5"]`, no credential — no `config set` at all.
