### PR TITLE
fix: name the provider hermes billed on an unpinned chat turn

### DIFF
--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -41,14 +41,19 @@ import { DESKTOP_TRANSCRIPT_KEY, transcriptKeyIsSafe } from "@/lib/harness/trans
 import { resolveInMediaRoot } from "@/lib/harness/media-root";
 import { mediaUrl, splitAssistantMedia } from "@/lib/chat-media";
 import { extractReasoningPanels, stripAgentStatusFrames } from "@/lib/hermes-reasoning-panel";
-import { readHermesTurn } from "@/lib/harness/hermes-turn-record";
+import { readHermesBillingProvider, readHermesTurn } from "@/lib/harness/hermes-turn-record";
 import {
   adoptHermesGeneratedImages,
   reclaimImageMentions,
   servableMediaRoot,
 } from "@/lib/harness/hermes-generated-media";
 import { capabilitiesFor, UNKNOWN_FACTS } from "@/lib/harness/capabilities";
-import { isQuietStreamError, openDashboardTurn, type DashboardTurn } from "@/lib/hermes-dashboard-turn";
+import {
+  DASHBOARD_PROVIDER_KIND,
+  isQuietStreamError,
+  openDashboardTurn,
+  type DashboardTurn,
+} from "@/lib/hermes-dashboard-turn";
 import {
   errorFromStderr,
   hermesFailureMessage,
@@ -410,16 +415,18 @@ async function settleTurn(
     // moment the turn was submitted, after any switch had been applied and
     // acknowledged.
     //
-    // UNVERIFIED, and worth stating as such: this rests on `state.db`'s
-    // `messages` table having no model column, which nothing here has ever
-    // asked. `readHermesTurn` selects an explicit column list
-    // (`hermes-turn-record.ts`), so the code neither proves nor disproves it.
-    // If that table — or `sessions` — does carry the model, the harness knows
-    // the answer natively and this reconstruction should be replaced by reading
-    // the row `readHermesTurn` already opens for reasoning and tool calls,
-    // which would be strictly more accurate and would retire `cliServedPair`
-    // with it. One read-only command settles it:
-    // `sqlite3 ~/.hermes/state.db 'PRAGMA table_info(messages)'`.
+    // ASKED, on the box, and the answer is on the record now.
+    // `PRAGMA table_info(messages)` lists 23 columns and not one of them names
+    // a model, a provider or a billing mode — so the row `readHermesTurn`
+    // already opens genuinely cannot supply this, and the reconstruction
+    // stands. `sessions` DOES carry `model` and `billing_provider`, but only
+    // the LAST ones the thread used: reading them per bubble would relabel
+    // every older reply in a conversation that switched, which is the defect
+    // this field exists to prevent.
+    //
+    // What the harness can answer per (session, model) is
+    // `session_model_usage.billing_provider` — see `billedProviderFor`, which
+    // asks it for the one case nothing else can speak for.
     ...(served.model ? { model: served.model } : {}),
     ...(served.provider ? { provider: served.provider } : {}),
   }, sessionKey);
@@ -497,19 +504,88 @@ async function settleTurn(
  * the half it left empty. Only a turn that reported no model at all — a
  * transport that never produced a frame, and the quiet-stream recovery, which
  * passes `null` — falls back to what the session was settled on.
+ *
+ * The half it left empty is then asked of the HARNESS, and only ever of the
+ * harness — see `billedProviderFor`. That is not a retreat from the paragraph
+ * above: it invents nothing and reads nothing about what was configured. It
+ * asks Hermes what it billed for this session and this model, which is the one
+ * source that can answer "who served that reply" as a fact.
  */
-function servedPair(
+async function servedPair(
   final: { model?: string; provider?: string } | null,
   turn: DashboardTurn,
-): { model?: string; provider?: string } {
+  /** The session the answer was recorded under — the key the harness bills by. */
+  sessionId: string,
+  /** Whether the REQUEST named a provider; see `billedProviderFor`. */
+  requestNamedProvider: boolean,
+): Promise<{ model?: string; provider?: string }> {
   const source = final?.model ? final : { model: turn.model, provider: turn.provider };
+  const model = source.model || "";
+  const provider = source.provider
+    || (model && !requestNamedProvider ? await billedProviderFor(sessionId, model) : "");
   return {
-    ...(source.model ? { model: source.model } : {}),
-    ...(source.provider ? { provider: source.provider } : {}),
+    ...(model ? { model } : {}),
+    ...(provider ? { provider } : {}),
   };
 }
 
-function streamTurn(turn: DashboardTurn, fallbackSessionId: string, sessionKey: string): Response {
+/**
+ * The provider Hermes itself recorded against this turn, for a turn the
+ * customer pinned nothing on.
+ *
+ * THE CASE THIS EXISTS FOR is the ordinary new chat: press "+", type, send. The
+ * request names neither half, so the transport has no contract to fall back on
+ * — `servedProviderSlug` returns nothing without a requested provider — and the
+ * dashboard's own frames name a model and no provider. Measured on the box,
+ * three runs out of three: `done` carried `gpt-5.6-sol` with no `provider` key
+ * and the durable transcript stored `provider=None`, while Hermes'
+ * `session_model_usage` held `billing_provider='openai-codex'` for each of
+ * those three session ids. The bubble said which model answered and could not
+ * say who served it, and the answer was one read away.
+ *
+ * ONLY when the request named no provider. Where it did and the transport still
+ * declined, the decline is the contradiction guard doing its job — a canonical
+ * slug asked of a session the dashboard reports as the KIND `custom` — and this
+ * must not talk over it. Nothing here loosens that guard; it answers the case
+ * the guard was never about.
+ *
+ * NOT from `config.yaml` and NOT from the device default, which is the fix this
+ * deliberately is not: what the box is configured to run is not evidence about
+ * what this session ran, and reading it that way is exactly what the served-
+ * model work removed.
+ */
+async function billedProviderFor(sessionId: string, model: string): Promise<string> {
+  const billed = await readHermesBillingProvider(sessionId, model);
+  // It is about to be persisted and rendered, so it is charset-checked like any
+  // other provider id, even though it came from the box's own store.
+  if (!billed || !isPlausibleHermesProviderId(billed)) return "";
+  // `custom` is a KIND as well as a real slug and nothing here can tell the two
+  // apart — the same refusal `servedProviderSlug` makes about the same word.
+  if (billed === DASHBOARD_PROVIDER_KIND) return "";
+  // A recorded pairing the catalogue calls impossible is not an answer about
+  // this turn. Judged by the same two helpers the request itself passes on the
+  // way in, so "we cannot tell" (a stale payload, a provider we could not
+  // enumerate) can never become "wrong": `shouldEnforcePairing` declines those.
+  //
+  // The catalogue is memoised — fresh under a minute, served stale instantly
+  // for hours, and warmed by the chat header on mount — so this is a lookup in
+  // steady state. The one turn that could pay a live fetch is the first
+  // unpinned turn of a cold process, and it pays it AFTER the answer has
+  // already streamed: what arrives late is the label, never the reply.
+  const payload = await getModelOptions().catch(() => null);
+  if (payload && shouldEnforcePairing(payload, billed) && !isPairAllowed(payload, billed, model)) {
+    return "";
+  }
+  return billed;
+}
+
+function streamTurn(
+  turn: DashboardTurn,
+  fallbackSessionId: string,
+  sessionKey: string,
+  /** Whether the REQUEST named a provider — see `billedProviderFor`. */
+  requestNamedProvider: boolean,
+): Response {
   const encoder = new TextEncoder();
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
@@ -586,7 +662,13 @@ function streamTurn(turn: DashboardTurn, fallbackSessionId: string, sessionKey: 
         } else {
           send(
             "done",
-            await settleTurn(threaded, sessionKey, final.text, final.reasoning, servedPair(final, turn)),
+            await settleTurn(
+              threaded,
+              sessionKey,
+              final.text,
+              final.reasoning,
+              await servedPair(final, turn, threaded, requestNamedProvider),
+            ),
           );
         }
       } catch (err) {
@@ -624,7 +706,13 @@ function streamTurn(turn: DashboardTurn, fallbackSessionId: string, sessionKey: 
           if (recovered?.text) {
             send(
               "done",
-              await settleTurn(threaded, sessionKey, recovered.text, "", servedPair(null, turn)),
+              await settleTurn(
+                threaded,
+                sessionKey,
+                recovered.text,
+                "",
+                await servedPair(null, turn, threaded, requestNamedProvider),
+              ),
             );
             return;
           }
@@ -701,6 +789,13 @@ function isAbort(err: unknown): boolean {
  * assumption the fallback already rests on, rather than inventing a second one.
  * Unverified on a box all the same, and it is one read: `hermes chat --help`
  * plus one resumed turn with `-m`.
+ *
+ * The harness's billing record is deliberately NOT consulted here, though the
+ * dashboard leg now reads it (`billedProviderFor`). It is keyed on the model,
+ * and the only CLI case with a blank provider is the resumed run — the one case
+ * whose MODEL is the unverified claim above. A lookup keyed on a model the
+ * session may have overridden either finds nothing or corroborates a label that
+ * was never the question. It would answer with more confidence, not more truth.
  */
 async function cliServedPair(
   model: string,
@@ -1053,7 +1148,10 @@ export async function POST(request: Request) {
       ...(rawSessionId ? { sessionId: rawSessionId } : {}),
       signal: request.signal,
     });
-    if (turn) return streamTurn(turn, rawSessionId, sessionKey);
+    // `wantsProvider` and not `rawProvider`: "auto" is ClawBox's word for "let
+    // Hermes decide", so a turn that sent it named no provider either, and the
+    // harness's own record is precisely the answer to what it decided.
+    if (turn) return streamTurn(turn, rawSessionId, sessionKey, wantsProvider);
   }
 
   // Read BEFORE the run, not after: the default this turn used is the one on

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -29,6 +29,7 @@ import {
   smallLocalModelToolsets,
 } from "@/lib/local-model-profile";
 import {
+  cachedModelOptions,
   getModelOptions,
   isAllowedProvider,
   isPairAllowed,
@@ -41,7 +42,11 @@ import { DESKTOP_TRANSCRIPT_KEY, transcriptKeyIsSafe } from "@/lib/harness/trans
 import { resolveInMediaRoot } from "@/lib/harness/media-root";
 import { mediaUrl, splitAssistantMedia } from "@/lib/chat-media";
 import { extractReasoningPanels, stripAgentStatusFrames } from "@/lib/hermes-reasoning-panel";
-import { readHermesBillingProvider, readHermesTurn } from "@/lib/harness/hermes-turn-record";
+import {
+  readHermesBillingProvider,
+  readHermesTurn,
+  readHermesUsageMarks,
+} from "@/lib/harness/hermes-turn-record";
 import {
   adoptHermesGeneratedImages,
   reclaimImageMentions,
@@ -410,10 +415,11 @@ async function settleTurn(
     // collapse the monologue the same way the live turn did.
     ...(settledReasoning ? { reasoning: settledReasoning } : {}),
     ...(toolCalls?.length ? { toolCalls } : {}),
-    // Which model actually answered, from the transport rather than from the
-    // agent's own record — the dashboard's `info` for the session, read at the
-    // moment the turn was submitted, after any switch had been applied and
-    // acknowledged.
+    // Which model actually answered, from the transport — the dashboard's
+    // `info` for the session, read at the moment the turn was submitted, after
+    // any switch had been applied and acknowledged. The PROVIDER beside it can
+    // come from the agent's own record instead, and only where the transport
+    // named none and the request asked for none: see `billedProviderFor`.
     //
     // ASKED, on the box, and the answer is on the record now.
     // `PRAGMA table_info(messages)` lists 23 columns and not one of them names
@@ -488,8 +494,9 @@ async function settleTurn(
  * that could have produced a clean 4xx/5xx has already run before this is called.
  */
 /**
- * What the dashboard transport says answered — taken WHOLE, never half from one
- * source and half from the other.
+ * What answered, assembled under one rule: the model and the provider are never
+ * taken from two different TRANSPORT reports. A half the transport left empty
+ * may be filled from the harness's own billing record, and from nowhere else.
  *
  * The transport works hard to answer NOTHING rather than a pairing the turn did
  * not establish: `servedProviderSlug` declines a kind it cannot resolve, and a
@@ -516,13 +523,17 @@ async function servedPair(
   turn: DashboardTurn,
   /** The session the answer was recorded under — the key the harness bills by. */
   sessionId: string,
-  /** Whether the REQUEST named a provider; see `billedProviderFor`. */
-  requestNamedProvider: boolean,
+  /**
+   * The session's billing marks from before this turn ran, or null for "do not
+   * ask the harness" — either the request named a provider (see
+   * `billedProviderFor`) or the baseline could not be taken.
+   */
+  usageBefore: ReadonlySet<string> | null,
 ): Promise<{ model?: string; provider?: string }> {
   const source = final?.model ? final : { model: turn.model, provider: turn.provider };
   const model = source.model || "";
   const provider = source.provider
-    || (model && !requestNamedProvider ? await billedProviderFor(sessionId, model) : "");
+    || (model && usageBefore ? await billedProviderFor(sessionId, model, usageBefore) : "");
   return {
     ...(model ? { model } : {}),
     ...(provider ? { provider } : {}),
@@ -553,9 +564,25 @@ async function servedPair(
  * deliberately is not: what the box is configured to run is not evidence about
  * what this session ran, and reading it that way is exactly what the served-
  * model work removed.
+ *
+ * WHY THE STORE AND NOT THE WIRE, which is the question the harness-first rule
+ * asks. Hermes exposes no other surface for this: `messages` has no such
+ * column, `sessions` has only the thread's last one, the `session.usage` RPC's
+ * params and result are undocumented, `/api/analytics/usage` is aggregated by
+ * day and names no provider, the `/usage` slash command is prose, and
+ * `--usage-file` is `-z`-only while `-z` ignores `--resume`. The ONE candidate
+ * still open is the `session.usage` EVENT this transport already receives and
+ * drops (`hermes-dashboard-turn.ts`, the frame loop's `default`): its payload
+ * has never been captured, and if it carries the provider it is better than
+ * this on every axis — per turn, pushed, no second store to open. That capture
+ * is the next lane's, and it retires this function if it lands.
  */
-async function billedProviderFor(sessionId: string, model: string): Promise<string> {
-  const billed = await readHermesBillingProvider(sessionId, model);
+async function billedProviderFor(
+  sessionId: string,
+  model: string,
+  usageBefore: ReadonlySet<string>,
+): Promise<string> {
+  const billed = await readHermesBillingProvider(sessionId, model, usageBefore);
   // It is about to be persisted and rendered, so it is charset-checked like any
   // other provider id, even though it came from the box's own store.
   if (!billed || !isPlausibleHermesProviderId(billed)) return "";
@@ -563,17 +590,27 @@ async function billedProviderFor(sessionId: string, model: string): Promise<stri
   // apart — the same refusal `servedProviderSlug` makes about the same word.
   if (billed === DASHBOARD_PROVIDER_KIND) return "";
   // A recorded pairing the catalogue calls impossible is not an answer about
-  // this turn. Judged by the same two helpers the request itself passes on the
-  // way in, so "we cannot tell" (a stale payload, a provider we could not
-  // enumerate) can never become "wrong": `shouldEnforcePairing` declines those.
+  // this turn — but only where the catalogue really is an ENUMERATION. For a
+  // provider it does not positively call built-in, the model list may be one
+  // this repo seeded (`normalizeRow` does exactly that for the box's own
+  // provider and the on-device one, from a single configured id), and vetoing
+  // the harness's own record with a list we padded ourselves would blank the
+  // label on the most common provider on the fleet. `isUserDefined === false`
+  // is the only value that says "Hermes ships this one and listed its models".
   //
-  // The catalogue is memoised — fresh under a minute, served stale instantly
-  // for hours, and warmed by the chat header on mount — so this is a lookup in
-  // steady state. The one turn that could pay a live fetch is the first
-  // unpinned turn of a cold process, and it pays it AFTER the answer has
-  // already streamed: what arrives late is the label, never the reply.
-  const payload = await getModelOptions().catch(() => null);
-  if (payload && shouldEnforcePairing(payload, billed) && !isPairAllowed(payload, billed, model)) {
+  // Cache only, never a fetch: this runs after the answer has streamed, and the
+  // veto is waived anyway whenever the catalogue is unavailable or stale
+  // (`shouldEnforcePairing` declines both), so waiting for one would hold the
+  // `done` frame — and the durable transcript write with it — to maybe apply a
+  // check that a failed fetch waives.
+  const payload = cachedModelOptions();
+  const row = payload?.providers.find((entry) => entry.id === billed);
+  if (
+    payload
+    && row?.isUserDefined === false
+    && shouldEnforcePairing(payload, billed)
+    && !isPairAllowed(payload, billed, model)
+  ) {
     return "";
   }
   return billed;
@@ -593,6 +630,13 @@ function streamTurn(
         controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
       };
       const threaded = turn.sessionId || fallbackSessionId;
+      // The session's billing rows BEFORE this turn writes any, so that
+      // afterwards the ones it wrote can be told from the ones it did not —
+      // see `pickBillingProvider`. Taken only for a turn that could need it,
+      // and null means "do not ask": the request already named a provider, or
+      // the store could not be read, and a missing baseline is not a baseline.
+      // One small read against a store this route opens once more anyway.
+      const usageBefore = requestNamedProvider ? null : await readHermesUsageMarks(threaded);
       try {
         const final = await turn.run(
           (chunk) => send("delta", { text: chunk }),
@@ -667,7 +711,7 @@ function streamTurn(
               sessionKey,
               final.text,
               final.reasoning,
-              await servedPair(final, turn, threaded, requestNamedProvider),
+              await servedPair(final, turn, threaded, usageBefore),
             ),
           );
         }
@@ -711,7 +755,7 @@ function streamTurn(
                 sessionKey,
                 recovered.text,
                 "",
-                await servedPair(null, turn, threaded, requestNamedProvider),
+                await servedPair(null, turn, threaded, usageBefore),
               ),
             );
             return;
@@ -791,11 +835,16 @@ function isAbort(err: unknown): boolean {
  * plus one resumed turn with `-m`.
  *
  * The harness's billing record is deliberately NOT consulted here, though the
- * dashboard leg now reads it (`billedProviderFor`). It is keyed on the model,
- * and the only CLI case with a blank provider is the resumed run — the one case
- * whose MODEL is the unverified claim above. A lookup keyed on a model the
- * session may have overridden either finds nothing or corroborates a label that
- * was never the question. It would answer with more confidence, not more truth.
+ * dashboard leg now reads it (`billedProviderFor`). Two cases blank the provider
+ * on this path and neither is one the record can settle. On a RESUMED run the
+ * lookup would be keyed on a model that is itself the unverified claim above, so
+ * it either finds nothing or corroborates a label that was never the question.
+ * On a non-resumed run the blank means `readCurrentFromCli` could not answer at
+ * all — a spawn that timed out or a value that failed its charset check — and a
+ * box whose `hermes config get` is not answering is not a box whose store should
+ * be trusted to say who billed the turn it just ran. Leaving both is a choice
+ * about scope, not a claim that nothing could be read: the dashboard transport
+ * is what serves on this hardware, and it is where the defect was measured.
  */
 async function cliServedPair(
   model: string,

--- a/src/lib/harness/hermes-turn-record.ts
+++ b/src/lib/harness/hermes-turn-record.ts
@@ -328,6 +328,41 @@ export function buildTurnFromRows(rows: MessageRow[]): HermesTurnRecord | null {
   };
 }
 
+/** One `session_model_usage` row, trimmed to the column this module reads. */
+interface UsageRow {
+  billing_provider?: string | null;
+}
+
+/**
+ * Which provider a set of usage rows can be said to name — or nothing.
+ *
+ * Exported for its own test: the rule is the part with a decision in it, and a
+ * test for it should not need a SQLite file to say what it means.
+ *
+ * ONE provider or none, deliberately. `session_model_usage` is keyed on
+ * (session, model, provider, base_url, mode, task), so one session can hold
+ * several rows for the same model id — several tasks under one provider, which
+ * is the ordinary case and answers cleanly, or the same model billed under two
+ * DIFFERENT providers over the conversation's life, which is the case nothing
+ * here can resolve.
+ *
+ * "Take the newest" is not that resolution, and `first_seen` / `last_seen` are
+ * why rather than why not: a row AGGREGATES a session's calls for its key
+ * (`api_call_count` beside them), so `last_seen` says when that combination
+ * last billed, never which turn it billed for. No comparison this function can
+ * make attributes one row to one turn, so a tie between providers is refused
+ * instead of broken. Unknown beats wrong, the rule this whole path follows.
+ */
+export function pickBillingProvider(rows: UsageRow[]): string {
+  if (!Array.isArray(rows)) return "";
+  const named = new Set(
+    rows
+      .map((row) => (typeof row?.billing_provider === "string" ? row.billing_provider.trim() : ""))
+      .filter(Boolean),
+  );
+  return named.size === 1 ? [...named][0] : "";
+}
+
 /** The shape of the `node:sqlite` handle we use, kept local to avoid a dep. */
 interface ReadOnlyDb {
   prepare: (sql: string) => { all: (...params: unknown[]) => unknown[] };
@@ -335,15 +370,17 @@ interface ReadOnlyDb {
 }
 
 /**
- * The turn the agent just finished, read back from its own store.
- *
- * Returns null whenever the record cannot be had for ANY reason — that is the
- * contract, and the caller's fallback is the console text it already captured.
- * Nothing in here is allowed to throw into a request that has a good reply in
- * its hand.
+ * Open `state.db` read-only, hand it to `read`, and give `fallback` back for
+ * ANY failure at all — no database, no `node:sqlite`, a table or column that
+ * moved. That is the contract every caller here relies on: nothing in this
+ * module is allowed to throw into a request that has a good reply in its hand.
  */
-export async function readHermesTurn(sessionId: string): Promise<HermesTurnRecord | null> {
-  if (!sessionId) return null;
+async function withStateDb<T>(
+  /** What was being read, for the journal line. Never the contents. */
+  what: string,
+  fallback: T,
+  read: (db: ReadOnlyDb) => T,
+): Promise<T> {
   let db: ReadOnlyDb | null = null;
   try {
     // `node:sqlite` is a Node 22.5+ builtin and still flagged experimental, so
@@ -359,25 +396,19 @@ export async function readHermesTurn(sessionId: string): Promise<HermesTurnRecor
     const DatabaseSync = (sqlite as unknown as {
       DatabaseSync?: new (file: string, options?: { readOnly?: boolean }) => ReadOnlyDb;
     }).DatabaseSync;
-    if (!DatabaseSync) return null;
+    if (!DatabaseSync) return fallback;
     // READ-ONLY, always. This file is the agent's memory; the UI is a reader of
     // it and must never be able to become a writer by accident.
     db = new DatabaseSync(statePath(), { readOnly: true });
-    const rows = db
-      .prepare(
-        "SELECT id, role, content, tool_calls, tool_call_id, tool_name, reasoning, reasoning_content"
-        + " FROM messages WHERE session_id = ? ORDER BY id",
-      )
-      .all(sessionId) as MessageRow[];
-    return buildTurnFromRows(rows);
+    return read(db);
   } catch (err) {
     // Name the failure, never the contents: this journal line is the one part
     // of the pipeline that leaves the box, and the turn is the customer's.
     console.warn(
-      "[hermes/turn] could not read the agent's record:",
+      `[hermes/turn] could not read ${what}:`,
       err instanceof Error ? err.message : "unknown error",
     );
-    return null;
+    return fallback;
   } finally {
     try {
       db?.close();
@@ -385,4 +416,49 @@ export async function readHermesTurn(sessionId: string): Promise<HermesTurnRecor
       // Nothing left to do about a handle that will be collected anyway.
     }
   }
+}
+
+/**
+ * The turn the agent just finished, read back from its own store.
+ *
+ * Returns null whenever the record cannot be had for ANY reason — that is the
+ * contract, and the caller's fallback is the console text it already captured.
+ */
+export async function readHermesTurn(sessionId: string): Promise<HermesTurnRecord | null> {
+  if (!sessionId) return null;
+  return withStateDb<HermesTurnRecord | null>("the agent's record", null, (db) => {
+    const rows = db
+      .prepare(
+        "SELECT id, role, content, tool_calls, tool_call_id, tool_name, reasoning, reasoning_content"
+        + " FROM messages WHERE session_id = ? ORDER BY id",
+      )
+      .all(sessionId) as MessageRow[];
+    return buildTurnFromRows(rows);
+  });
+}
+
+/**
+ * Who Hermes says it BILLED for this session's turns on this model — the
+ * harness's own answer to "who served that reply", read from its own store.
+ *
+ * `messages` cannot answer it: its columns are the turn's content, and there is
+ * no model or provider among them (checked on the box with
+ * `PRAGMA table_info(messages)`). `sessions` carries `model` and
+ * `billing_provider`, but only the LAST ones the thread used, so a conversation
+ * that switched models would relabel its older bubbles — the exact defect the
+ * served-model work exists to prevent. `session_model_usage` is the surface
+ * that fits: keyed per (session, model), carrying the provider that actually
+ * billed. It is read here keyed on BOTH, so a row belonging to another model in
+ * the same conversation cannot speak for this one.
+ *
+ * Returns "" for anything less than a single unambiguous answer.
+ */
+export async function readHermesBillingProvider(sessionId: string, model: string): Promise<string> {
+  if (!sessionId || !model) return "";
+  return withStateDb("the agent's billing record", "", (db) => {
+    const rows = db
+      .prepare("SELECT billing_provider FROM session_model_usage WHERE session_id = ? AND model = ?")
+      .all(sessionId, model) as UsageRow[];
+    return pickBillingProvider(rows);
+  });
 }

--- a/src/lib/harness/hermes-turn-record.ts
+++ b/src/lib/harness/hermes-turn-record.ts
@@ -328,35 +328,68 @@ export function buildTurnFromRows(rows: MessageRow[]): HermesTurnRecord | null {
   };
 }
 
-/** One `session_model_usage` row, trimmed to the column this module reads. */
-interface UsageRow {
+/**
+ * One `session_model_usage` row, trimmed to the columns this module reads.
+ *
+ * `api_call_count` and `last_seen` are read only to tell a row apart from
+ * ITSELF one turn earlier — see `usageMark`. Nothing here interprets either as
+ * a time or a quantity, so neither the clock nor the units have to be known.
+ */
+export interface UsageRow {
+  model?: string | null;
   billing_provider?: string | null;
+  api_call_count?: number | null;
+  last_seen?: unknown;
 }
 
 /**
- * Which provider a set of usage rows can be said to name — or nothing.
+ * A row's identity AND its version, in one string.
+ *
+ * The whole billing question is "which of these rows did the turn that just ran
+ * write?", and `session_model_usage` cannot be asked that directly: a row
+ * AGGREGATES a session's calls for its key, so `last_seen` says when that
+ * combination last billed, never which turn it billed for. Comparing it against
+ * a clock this process holds would also mean knowing its epoch and units, which
+ * nothing here does.
+ *
+ * So the rows are compared against THEMSELVES instead: snapshot the session's
+ * marks before the turn, read them again after, and a mark that was not there
+ * before belongs to a row the turn either created or billed against again. No
+ * absolute time, no unit, no epoch — only "did this change".
+ */
+export function usageMark(row: UsageRow): string {
+  return [
+    typeof row?.model === "string" ? row.model : "",
+    typeof row?.billing_provider === "string" ? row.billing_provider : "",
+    typeof row?.api_call_count === "number" ? String(row.api_call_count) : "",
+    row?.last_seen === null || row?.last_seen === undefined ? "" : String(row.last_seen),
+  ].join(" ");
+}
+
+/**
+ * Which provider the rows THIS TURN touched can be said to name — or nothing.
  *
  * Exported for its own test: the rule is the part with a decision in it, and a
  * test for it should not need a SQLite file to say what it means.
  *
- * ONE provider or none, deliberately. `session_model_usage` is keyed on
- * (session, model, provider, base_url, mode, task), so one session can hold
- * several rows for the same model id — several tasks under one provider, which
- * is the ordinary case and answers cleanly, or the same model billed under two
- * DIFFERENT providers over the conversation's life, which is the case nothing
- * here can resolve.
+ * `before` is the session's marks as they stood when the turn was submitted. A
+ * row still carrying one of them was not written by this turn and cannot speak
+ * for it — that is what stops an earlier turn's provider from labelling this
+ * bubble when the conversation moved to another provider serving the same model
+ * id, and it also turns "the row has not landed yet" into a blank rather than a
+ * stale answer.
  *
- * "Take the newest" is not that resolution, and `first_seen` / `last_seen` are
- * why rather than why not: a row AGGREGATES a session's calls for its key
- * (`api_call_count` beside them), so `last_seen` says when that combination
- * last billed, never which turn it billed for. No comparison this function can
- * make attributes one row to one turn, so a tie between providers is refused
- * instead of broken. Unknown beats wrong, the rule this whole path follows.
+ * Then ONE provider or none. `session_model_usage` is keyed on (session, model,
+ * provider, base_url, mode, task), so several rows can be touched by one turn —
+ * several tasks under one provider, which is the ordinary case and answers
+ * cleanly, or two providers, which nothing here can resolve. Unknown beats
+ * wrong, the rule this whole path follows.
  */
-export function pickBillingProvider(rows: UsageRow[]): string {
+export function pickBillingProvider(rows: UsageRow[], before: ReadonlySet<string>): string {
   if (!Array.isArray(rows)) return "";
   const named = new Set(
     rows
+      .filter((row) => !before.has(usageMark(row)))
       .map((row) => (typeof row?.billing_provider === "string" ? row.billing_provider.trim() : ""))
       .filter(Boolean),
   );
@@ -379,6 +412,11 @@ async function withStateDb<T>(
   /** What was being read, for the journal line. Never the contents. */
   what: string,
   fallback: T,
+  /**
+   * MUST be synchronous. The handle is closed in the `finally` below, so an
+   * `async` reader would be handed a closed database. `fallback` pins `T`, so
+   * writing one is a compile error rather than a use-after-close.
+   */
   read: (db: ReadOnlyDb) => T,
 ): Promise<T> {
   let db: ReadOnlyDb | null = null;
@@ -437,9 +475,30 @@ export async function readHermesTurn(sessionId: string): Promise<HermesTurnRecor
   });
 }
 
+/** The four columns both billing reads select, so their marks are comparable. */
+const USAGE_COLUMNS = "model, billing_provider, api_call_count, last_seen";
+
 /**
- * Who Hermes says it BILLED for this session's turns on this model — the
- * harness's own answer to "who served that reply", read from its own store.
+ * The session's billing rows as they stand right now, as marks.
+ *
+ * Taken BEFORE a turn runs, so that afterwards the rows it wrote can be told
+ * from the ones it did not. Returns null — never an empty set — when the store
+ * could not be read at all, because "no baseline" and "no rows yet" are
+ * different facts and only the second one is safe to answer from.
+ */
+export async function readHermesUsageMarks(sessionId: string): Promise<Set<string> | null> {
+  if (!sessionId) return null;
+  return withStateDb<Set<string> | null>("the agent's billing record", null, (db) => {
+    const rows = db
+      .prepare(`SELECT ${USAGE_COLUMNS} FROM session_model_usage WHERE session_id = ?`)
+      .all(sessionId) as UsageRow[];
+    return new Set(rows.map(usageMark));
+  });
+}
+
+/**
+ * Who Hermes says it BILLED for the turn that just ran — the harness's own
+ * answer to "who served that reply", read from its own store.
  *
  * `messages` cannot answer it: its columns are the turn's content, and there is
  * no model or provider among them (checked on the box with
@@ -449,16 +508,22 @@ export async function readHermesTurn(sessionId: string): Promise<HermesTurnRecor
  * served-model work exists to prevent. `session_model_usage` is the surface
  * that fits: keyed per (session, model), carrying the provider that actually
  * billed. It is read here keyed on BOTH, so a row belonging to another model in
- * the same conversation cannot speak for this one.
+ * the same conversation cannot speak for this one, and narrowed by `before` to
+ * the rows this turn actually wrote.
  *
  * Returns "" for anything less than a single unambiguous answer.
  */
-export async function readHermesBillingProvider(sessionId: string, model: string): Promise<string> {
+export async function readHermesBillingProvider(
+  sessionId: string,
+  model: string,
+  /** `readHermesUsageMarks` from before the turn — see `pickBillingProvider`. */
+  before: ReadonlySet<string>,
+): Promise<string> {
   if (!sessionId || !model) return "";
   return withStateDb("the agent's billing record", "", (db) => {
     const rows = db
-      .prepare("SELECT billing_provider FROM session_model_usage WHERE session_id = ? AND model = ?")
+      .prepare(`SELECT ${USAGE_COLUMNS} FROM session_model_usage WHERE session_id = ? AND model = ?`)
       .all(sessionId, model) as UsageRow[];
-    return pickBillingProvider(rows);
+    return pickBillingProvider(rows, before);
   });
 }

--- a/src/lib/hermes-dashboard-turn.ts
+++ b/src/lib/hermes-dashboard-turn.ts
@@ -538,7 +538,13 @@ const COMMAND_SAFE_ID = /^[A-Za-z0-9_./:-]+$/;
  * and one it switched, and neither reaches this function (see
  * `providerFromRequest`).
  */
-const DASHBOARD_PROVIDER_KIND = "custom";
+/**
+ * The dashboard's word for "a user-defined provider", which is ALSO a real CLI
+ * slug. Exported because the route has to make the same refusal about the same
+ * word when it reads the harness's billing record — one definition, so the two
+ * cannot drift.
+ */
+export const DASHBOARD_PROVIDER_KIND = "custom";
 function servedProviderSlug(reported: string, req: DashboardTurnRequest, onRequestedModel: boolean): string {
   const requested = req.provider;
   const reportedIsKind = reported === DASHBOARD_PROVIDER_KIND;

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -653,6 +653,26 @@ export async function getModelOptions(opts: { refresh?: boolean } = {}): Promise
   return load(false);
 }
 
+/**
+ * The catalogue ONLY if this process already has it, and null otherwise. Never
+ * fetches, never starts a background refresh.
+ *
+ * For a caller that would rather answer without the catalogue than wait for it:
+ * a turn that has already been answered and is only deciding what to LABEL it
+ * (`billedProviderFor` in the chat route). `getModelOptions` awaits a live fetch
+ * on a cold process — a dashboard call plus three `hermes config get` spawns —
+ * and doing that after the reply has streamed holds the `done` frame, and the
+ * durable transcript write with it, for a check the same code waives whenever
+ * the fetch fails. Absent is treated exactly like failed there.
+ *
+ * The same `STALE_MS` bound `getModelOptions` uses to stop serving from cache:
+ * past it, this process's copy is not evidence about anything.
+ */
+export function cachedModelOptions(): ModelOptionsPayload | null {
+  if (!cached) return null;
+  return Date.now() - cached.fetchedAt < STALE_MS ? cached : null;
+}
+
 // ── Scoping (REQ 1) ──────────────────────────────────────────────────────────
 
 /** Every provider id the device currently accepts: the static allowlist plus

--- a/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
+++ b/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
@@ -38,7 +38,13 @@ vi.mock("@/lib/hermes-dashboard-turn", async (importOriginal) => ({
 }));
 vi.mock("child_process", () => ({ spawn: spawnMock }));
 vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock }));
-vi.mock("@/lib/harness/hermes-turn-record", () => ({ readHermesTurn: readTurnMock }));
+// The billing read answers "" here: nothing in this file is about the served
+// pair, and a module mock that omits an export the route imports fails as a
+// missing-export error rather than as the assertion it was written for.
+vi.mock("@/lib/harness/hermes-turn-record", () => ({
+  readHermesTurn: readTurnMock,
+  readHermesBillingProvider: async () => "",
+}));
 vi.mock("@/lib/harness/media-root", () => ({
   resolveInMediaRoot: vi.fn(async (p: string) => p),
   chatMediaRoot: vi.fn(async () => "/tmp/clawbox-dashboard-error-media"),

--- a/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
+++ b/src/tests/routes/hermes-chat-dashboard-error-text.test.ts
@@ -43,6 +43,7 @@ vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock 
 // missing-export error rather than as the assertion it was written for.
 vi.mock("@/lib/harness/hermes-turn-record", () => ({
   readHermesTurn: readTurnMock,
+  readHermesUsageMarks: async () => null,
   readHermesBillingProvider: async () => "",
 }));
 vi.mock("@/lib/harness/media-root", () => ({

--- a/src/tests/routes/hermes-chat-streaming.test.ts
+++ b/src/tests/routes/hermes-chat-streaming.test.ts
@@ -35,11 +35,17 @@ vi.mock("@/lib/hermes-dashboard-turn", async (importOriginal) => ({
 }));
 vi.mock("child_process", () => ({ spawn: spawnMock }));
 vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock }));
-// `readHermesBillingProvider` answers "" throughout this file: these cases are
-// about what the TRANSPORT says, and a box whose usage record cannot be read is
-// what leaves the transport's own answer as the only one on the table.
+// `readHermesBillingProvider` answers "" throughout this file, which is a box
+// whose usage record cannot be read. That is deliberate and it is a CONDITION,
+// not a constant: the transport's silence about a provider is now the final
+// answer only when the harness has nothing to add, and where it does the route
+// fills the half (see `chat-served-model-dashboard.test.ts`). These cases are
+// about what the TRANSPORT says, so the other source is held quiet.
 vi.mock("@/lib/harness/hermes-turn-record", () => ({
   readHermesTurn: readTurnMock,
+  // An empty baseline rather than null, so the route really does consult the
+  // billing record and `billedMock` is the thing deciding, not a skipped call.
+  readHermesUsageMarks: async () => new Set<string>(),
   readHermesBillingProvider: billedMock,
 }));
 // `chatMediaRoot` is named here as well as `resolveInMediaRoot` because the

--- a/src/tests/routes/hermes-chat-streaming.test.ts
+++ b/src/tests/routes/hermes-chat-streaming.test.ts
@@ -22,6 +22,7 @@ const openTurnMock = vi.hoisted(() => vi.fn());
 const spawnMock = vi.hoisted(() => vi.fn());
 const appendMock = vi.hoisted(() => vi.fn());
 const readTurnMock = vi.hoisted(() => vi.fn());
+const billedMock = vi.hoisted(() => vi.fn());
 
 // Only the OPENING is faked. The rest of the module — `isQuietStreamError` and
 // the error class it recognises — is the real thing, because the route's
@@ -34,7 +35,13 @@ vi.mock("@/lib/hermes-dashboard-turn", async (importOriginal) => ({
 }));
 vi.mock("child_process", () => ({ spawn: spawnMock }));
 vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock }));
-vi.mock("@/lib/harness/hermes-turn-record", () => ({ readHermesTurn: readTurnMock }));
+// `readHermesBillingProvider` answers "" throughout this file: these cases are
+// about what the TRANSPORT says, and a box whose usage record cannot be read is
+// what leaves the transport's own answer as the only one on the table.
+vi.mock("@/lib/harness/hermes-turn-record", () => ({
+  readHermesTurn: readTurnMock,
+  readHermesBillingProvider: billedMock,
+}));
 // `chatMediaRoot` is named here as well as `resolveInMediaRoot` because the
 // settle path asks for it now. Left out, the CALL throws synchronously rather
 // than rejecting, which `servableMediaRoot` survives — but then every case in
@@ -145,6 +152,8 @@ beforeEach(() => {
   appendMock.mockResolvedValue(true);
   readTurnMock.mockReset();
   readTurnMock.mockResolvedValue(null);
+  billedMock.mockReset();
+  billedMock.mockResolvedValue("");
 });
 
 describe("a streamed chat turn", () => {

--- a/src/tests/routes/hermes/chat-reasoning-separation.test.ts
+++ b/src/tests/routes/hermes/chat-reasoning-separation.test.ts
@@ -80,8 +80,12 @@ vi.mock("@/lib/harness", async (importOriginal) => ({
  * that has to fall back to the console text rather than lose the reply.
  */
 let turnRecord: unknown = null;
+// Answering "" for the billing read keeps this file about reasoning, and
+// keeps the mock complete: an omitted export the route imports fails as a
+// missing-export error rather than as the assertion it was written for.
 vi.mock("@/lib/harness/hermes-turn-record", () => ({
   readHermesTurn: async () => turnRecord,
+  readHermesBillingProvider: async () => "",
 }));
 
 let root: string;

--- a/src/tests/routes/hermes/chat-reasoning-separation.test.ts
+++ b/src/tests/routes/hermes/chat-reasoning-separation.test.ts
@@ -85,6 +85,7 @@ let turnRecord: unknown = null;
 // missing-export error rather than as the assertion it was written for.
 vi.mock("@/lib/harness/hermes-turn-record", () => ({
   readHermesTurn: async () => turnRecord,
+  readHermesUsageMarks: async () => null,
   readHermesBillingProvider: async () => "",
 }));
 

--- a/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
+++ b/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
@@ -1,0 +1,284 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * HERMES-06 — the DASHBOARD transport, on the turn nobody pinned.
+ *
+ * The existing served-model tests all sit under "what the CLI path records".
+ * The CLI path fills both halves from config.yaml; the dashboard transport is
+ * what actually answers on a Hermes box, and it fills NEITHER when the request
+ * named no provider. So the tested guarantee never applied to the common case:
+ * the customer presses "+", types, and the reply carries a model with no
+ * provider beside it.
+ *
+ * Reproduced on the box three runs out of three — `done` came back
+ * `{"model":"gpt-5.6-sol", …}` with no `provider` key, and the persisted row
+ * had `provider=None` — while Hermes' own `session_model_usage` table held
+ * `billing_provider='openai-codex'` for each of those three session ids. The
+ * answer was one read away and nobody asked.
+ *
+ * The fixtures below are that shape: a real `state.db`, the columns the box
+ * declared, and the route driven end to end over its own SSE stream.
+ */
+
+const openTurnMock = vi.hoisted(() => vi.fn());
+const spawnMock = vi.hoisted(() => vi.fn());
+const appendMock = vi.hoisted(() => vi.fn());
+const modelOptionsMock = vi.hoisted(() => vi.fn());
+
+// Only the OPENING of the turn is faked; the rest of the transport module is
+// the real thing, so the guard that refuses to invent a provider is the real
+// guard and not a stand-in that always agrees.
+vi.mock("@/lib/hermes-dashboard-turn", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-dashboard-turn")>()),
+  openDashboardTurn: openTurnMock,
+}));
+vi.mock("child_process", () => ({ spawn: spawnMock, execFile: vi.fn() }));
+vi.mock("@/lib/harness", () => ({ HERMES_BIN: "/home/clawbox/.local/bin/hermes" }));
+vi.mock("@/lib/harness/transcript-store", () => ({ appendTranscript: appendMock }));
+vi.mock("@/lib/harness/media-root", () => ({
+  resolveInMediaRoot: vi.fn(async (p: string) => p),
+  chatMediaRoot: vi.fn(async () => "/tmp/clawbox-served-model-dashboard-media"),
+}));
+// The catalogue is the only thing that can call a recorded pairing impossible,
+// and the pure judges around it (`shouldEnforcePairing` / `isPairAllowed`) stay
+// real — a hand-written stand-in for those would prove nothing.
+vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
+  return {
+    ...actual,
+    getModelOptions: modelOptionsMock,
+    readCurrentFromCli: vi.fn(async () => ({ provider: "", model: "", reasoning: "" })),
+  };
+});
+
+import { POST } from "@/app/setup-api/hermes/chat/route";
+
+/** The session the box's step-4b run actually produced. */
+const SESSION_ID = "20260902_205829_99ac3f";
+
+/**
+ * A turn handle that streams one fragment and then settles on the given pair.
+ *
+ * `provider: ""` is the shape under test, not an oversight: the transport
+ * answers a model with NO provider whenever it cannot name one honestly.
+ */
+function fakeTurn(opts: { model?: string; provider?: string; sessionId?: string }) {
+  return {
+    sessionId: opts.sessionId ?? SESSION_ID,
+    model: opts.model ?? "",
+    provider: opts.provider ?? "",
+    async run(onDelta: (chunk: string) => void) {
+      onDelta("I am a model.");
+      return {
+        text: "I am a model.",
+        reasoning: "",
+        status: "complete",
+        ...(opts.model ? { model: opts.model } : {}),
+        ...(opts.provider ? { provider: opts.provider } : {}),
+      };
+    },
+    close() {},
+  };
+}
+
+function post(body: Record<string, unknown>): Request {
+  return new Request("http://localhost/setup-api/hermes/chat", {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "text/event-stream" },
+    body: JSON.stringify(body),
+  });
+}
+
+/** The last SSE frame's payload — the `done` the bubble is built from. */
+async function doneEvent(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text();
+  const frames = text.split("\n\n").filter((frame) => frame.trim());
+  const last = frames[frames.length - 1];
+  const data = last
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).replace(/^ /, ""))
+    .join("\n");
+  return JSON.parse(data) as Record<string, unknown>;
+}
+
+/** The assistant record this turn wrote to the customer's durable transcript. */
+function persistedAssistant(): Record<string, unknown> | undefined {
+  return appendMock.mock.calls
+    .map(([record]) => record as Record<string, unknown>)
+    .find((record) => record.role === "assistant");
+}
+
+/**
+ * A catalogue payload. `authenticated` with a non-empty model list is what
+ * makes `shouldEnforcePairing` willing to judge a pairing at all.
+ */
+function catalogue(provider: string, models: string[]) {
+  return {
+    providers: [{
+      id: provider,
+      name: provider,
+      authenticated: true,
+      models: models.map((id) => ({ id })),
+      total: models.length,
+      source: "dashboard",
+      isUserDefined: false,
+    }],
+    current: { provider, model: models[0] ?? "" },
+    reasoning: "medium",
+    fetchedAt: Date.now(),
+    source: "dashboard",
+    stale: false,
+  };
+}
+
+/**
+ * `~/.hermes/state.db` as the box declared it, trimmed to the columns these
+ * paths read. `session_model_usage`'s primary key really is that six-column
+ * one — a session can bill the same model id under more than one provider over
+ * its life, which is the case the picker has to refuse rather than guess at.
+ */
+async function writeStateDb(
+  home: string,
+  usage: Array<{ session: string; model: string; provider: string }>,
+): Promise<boolean> {
+  try {
+    // Variable specifier: `@types/node` here has no declaration for the
+    // builtin, and this fixture is about the runtime, not the types.
+    const specifier = "node:sqlite";
+    const { DatabaseSync } = await import(specifier);
+    const db = new DatabaseSync(path.join(home, "state.db"));
+    db.exec(`CREATE TABLE messages (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT,
+      tool_call_id TEXT,
+      tool_calls TEXT,
+      tool_name TEXT,
+      timestamp REAL NOT NULL,
+      finish_reason TEXT,
+      reasoning TEXT,
+      reasoning_content TEXT
+    )`);
+    db.exec(`CREATE TABLE session_model_usage (
+      session_id TEXT NOT NULL,
+      model TEXT NOT NULL,
+      billing_provider TEXT NOT NULL,
+      billing_base_url TEXT NOT NULL DEFAULT '',
+      billing_mode TEXT NOT NULL DEFAULT '',
+      task TEXT NOT NULL DEFAULT '',
+      api_call_count INTEGER NOT NULL DEFAULT 0,
+      first_seen REAL,
+      last_seen REAL,
+      PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
+    )`);
+    const message = db.prepare(
+      "INSERT INTO messages (session_id, role, content, timestamp, finish_reason) VALUES (?,?,?,?,?)",
+    );
+    message.run(SESSION_ID, "user", "which model are you", 1, null);
+    message.run(SESSION_ID, "assistant", "I am a model.", 2, "stop");
+    const row = db.prepare(
+      "INSERT INTO session_model_usage (session_id, model, billing_provider, billing_mode, task,"
+      + " api_call_count, first_seen, last_seen) VALUES (?,?,?,?,?,?,?,?)",
+    );
+    for (const entry of usage) {
+      row.run(entry.session, entry.model, entry.provider, "subscription_included", "chat", 1, 10, 20);
+    }
+    db.close();
+    return true;
+  } catch {
+    // Node without `node:sqlite`. Every case below is written so the module's
+    // documented degradation ("no provider") is what it asserts.
+    return false;
+  }
+}
+
+describe("/setup-api/hermes/chat — what the DASHBOARD transport records as the served provider", () => {
+  let home: string;
+  let sqliteAvailable = true;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-served-provider-"));
+    process.env.HERMES_HOME = home;
+    appendMock.mockResolvedValue(true);
+    // No catalogue unless a case supplies one: the unpinned turn never asks for
+    // it on the way in, so this is the shape the settle path really meets.
+    modelOptionsMock.mockRejectedValue(new Error("no catalogue"));
+  });
+
+  afterEach(() => {
+    delete process.env.HERMES_HOME;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("names the provider Hermes itself billed, when the frame gave a model and the request pinned nothing", async () => {
+    sqliteAvailable = await writeStateDb(home, [
+      { session: SESSION_ID, model: "gpt-5.6-sol", provider: "openai-codex" },
+    ]);
+    if (!sqliteAvailable) return;
+    openTurnMock.mockResolvedValue(fakeTurn({ model: "gpt-5.6-sol" }));
+
+    const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+    expect(done).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
+    // ...and the same into the durable transcript, which is what a refreshed
+    // page replays. A bubble that loses its provider on reload is the same
+    // defect one layer down.
+    expect(persistedAssistant()).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
+  });
+
+  it("still says nothing when the harness recorded no usage for that turn", async () => {
+    sqliteAvailable = await writeStateDb(home, []);
+    if (!sqliteAvailable) return;
+    openTurnMock.mockResolvedValue(fakeTurn({ model: "gpt-5.6-sol" }));
+
+    const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+    expect(done).toMatchObject({ model: "gpt-5.6-sol" });
+    expect(done).not.toHaveProperty("provider");
+    expect(persistedAssistant()).not.toHaveProperty("provider");
+  });
+
+  it("says nothing when the recorded provider cannot serve the model the frame named", async () => {
+    // A contradiction is not an answer. The catalogue here is live and lists
+    // anthropic's models, and `gpt-5.6-sol` is not among them, so the recorded
+    // pairing describes something other than this turn.
+    sqliteAvailable = await writeStateDb(home, [
+      { session: SESSION_ID, model: "gpt-5.6-sol", provider: "anthropic" },
+    ]);
+    if (!sqliteAvailable) return;
+    modelOptionsMock.mockResolvedValue(catalogue("anthropic", ["claude-fable-5"]));
+    openTurnMock.mockResolvedValue(fakeTurn({ model: "gpt-5.6-sol" }));
+
+    const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+    expect(done).toMatchObject({ model: "gpt-5.6-sol" });
+    expect(done).not.toHaveProperty("provider");
+    expect(persistedAssistant()).not.toHaveProperty("provider");
+  });
+
+  it("leaves a request that DID name a provider alone, so the transport's refusal still stands", async () => {
+    // The transport declines to confirm a provider the turn did not establish
+    // — a canonical request against a session reporting the KIND `custom`. That
+    // silence is deliberate and the billing record must not talk over it: this
+    // fix answers only where nobody asked for a provider at all.
+    sqliteAvailable = await writeStateDb(home, [
+      { session: SESSION_ID, model: "claude-fable-5", provider: "openai-codex" },
+    ]);
+    if (!sqliteAvailable) return;
+    modelOptionsMock.mockResolvedValue(catalogue("anthropic", ["claude-fable-5"]));
+    openTurnMock.mockResolvedValue(fakeTurn({ model: "claude-fable-5" }));
+
+    const done = await doneEvent(
+      await POST(post({ message: "hi", provider: "anthropic", model: "claude-fable-5" })),
+    );
+
+    expect(done).toMatchObject({ model: "claude-fable-5" });
+    expect(done).not.toHaveProperty("provider");
+  });
+});

--- a/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
+++ b/src/tests/routes/hermes/chat-served-model-dashboard.test.ts
@@ -19,8 +19,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * `billing_provider='openai-codex'` for each of those three session ids. The
  * answer was one read away and nobody asked.
  *
- * The fixtures below are that shape: a real `state.db`, the columns the box
- * declared, and the route driven end to end over its own SSE stream.
+ * The fixtures are that shape: a real `state.db` with the columns the box
+ * declared, and the route driven end to end over its own SSE stream. Usage rows
+ * are written by the FAKE TURN rather than by the setup, because the rule under
+ * test is "which rows did this turn write" — a fixture that seeded them before
+ * the turn would be asserting a different function, and is what case 5 pins.
  */
 
 const openTurnMock = vi.hoisted(() => vi.fn());
@@ -42,14 +45,17 @@ vi.mock("@/lib/harness/media-root", () => ({
   resolveInMediaRoot: vi.fn(async (p: string) => p),
   chatMediaRoot: vi.fn(async () => "/tmp/clawbox-served-model-dashboard-media"),
 }));
-// The catalogue is the only thing that can call a recorded pairing impossible,
-// and the pure judges around it (`shouldEnforcePairing` / `isPairAllowed`) stay
-// real — a hand-written stand-in for those would prove nothing.
+// `cachedModelOptions` is what the settle path reads, and the pure judges around
+// it (`shouldEnforcePairing` / `isPairAllowed`) stay real — a hand-written
+// stand-in for those would prove nothing.
 vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/hermes-model-options")>();
   return {
     ...actual,
-    getModelOptions: modelOptionsMock,
+    cachedModelOptions: modelOptionsMock,
+    getModelOptions: vi.fn(async () => {
+      throw new Error("the settle path must not fetch the catalogue");
+    }),
     readCurrentFromCli: vi.fn(async () => ({ provider: "", model: "", reasoning: "" })),
   };
 });
@@ -59,24 +65,67 @@ import { POST } from "@/app/setup-api/hermes/chat/route";
 /** The session the box's step-4b run actually produced. */
 const SESSION_ID = "20260902_205829_99ac3f";
 
+/** Variable specifier: `@types/node` here has no declaration for the builtin. */
+const SQLITE = "node:sqlite";
+
 /**
- * A turn handle that streams one fragment and then settles on the given pair.
+ * Whether this runtime has `node:sqlite` at all. Resolved once, at collection
+ * time, so an environment without it SKIPS these cases loudly instead of
+ * running them to a green that asserted nothing.
+ */
+const sqliteAvailable = await (async () => {
+  try {
+    await import(SQLITE);
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+/** Bill `count` calls of `model` to `provider` in `~/.hermes/state.db`. */
+async function bill(home: string, model: string, provider: string, count: number, seen: number) {
+  const { DatabaseSync } = await import(SQLITE);
+  const db = new DatabaseSync(path.join(home, "state.db"));
+  db.prepare(
+    "INSERT INTO session_model_usage (session_id, model, billing_provider, billing_mode, task,"
+    + " api_call_count, first_seen, last_seen) VALUES (?,?,?,?,?,?,?,?)"
+    + " ON CONFLICT(session_id, model, billing_provider, billing_base_url, billing_mode, task)"
+    + " DO UPDATE SET api_call_count = excluded.api_call_count, last_seen = excluded.last_seen",
+  ).run(SESSION_ID, model, provider, "subscription_included", "chat", count, 1, seen);
+  db.close();
+}
+
+/**
+ * A turn handle that streams one fragment, bills what it was told to bill, and
+ * then settles on the given pair.
  *
  * `provider: ""` is the shape under test, not an oversight: the transport
  * answers a model with NO provider whenever it cannot name one honestly.
  */
-function fakeTurn(opts: { model?: string; provider?: string; sessionId?: string }) {
+function fakeTurn(opts: {
+  home: string;
+  model?: string;
+  provider?: string;
+  /** What the completion frame reports, when it differs from the session's. */
+  finalModel?: string;
+  /** What Hermes bills WHILE the turn runs, as it does on a box. */
+  bills?: Array<{ model: string; provider: string; count?: number; seen?: number }>;
+}) {
   return {
-    sessionId: opts.sessionId ?? SESSION_ID,
+    sessionId: SESSION_ID,
     model: opts.model ?? "",
     provider: opts.provider ?? "",
     async run(onDelta: (chunk: string) => void) {
+      for (const entry of opts.bills ?? []) {
+        await bill(opts.home, entry.model, entry.provider, entry.count ?? 1, entry.seen ?? 20);
+      }
       onDelta("I am a model.");
+      const finalModel = opts.finalModel ?? opts.model;
       return {
         text: "I am a model.",
         reasoning: "",
         status: "complete",
-        ...(opts.model ? { model: opts.model } : {}),
+        ...(finalModel ? { model: finalModel } : {}),
         ...(opts.provider ? { provider: opts.provider } : {}),
       };
     },
@@ -114,18 +163,21 @@ function persistedAssistant(): Record<string, unknown> | undefined {
 
 /**
  * A catalogue payload. `authenticated` with a non-empty model list is what
- * makes `shouldEnforcePairing` willing to judge a pairing at all.
+ * makes `shouldEnforcePairing` willing to judge a pairing at all, and
+ * `isUserDefined === false` is what makes the list an ENUMERATION rather than
+ * one this repo may have seeded.
  */
-function catalogue(provider: string, models: string[]) {
+function catalogue(provider: string, models: string[], isUserDefined: boolean | null = false) {
   return {
     providers: [{
       id: provider,
       name: provider,
       authenticated: true,
+      verified: null,
       models: models.map((id) => ({ id })),
       total: models.length,
       source: "dashboard",
-      isUserDefined: false,
+      isUserDefined,
     }],
     current: { provider, model: models[0] ?? "" },
     reasoning: "medium",
@@ -141,144 +193,222 @@ function catalogue(provider: string, models: string[]) {
  * one — a session can bill the same model id under more than one provider over
  * its life, which is the case the picker has to refuse rather than guess at.
  */
-async function writeStateDb(
-  home: string,
-  usage: Array<{ session: string; model: string; provider: string }>,
-): Promise<boolean> {
-  try {
-    // Variable specifier: `@types/node` here has no declaration for the
-    // builtin, and this fixture is about the runtime, not the types.
-    const specifier = "node:sqlite";
-    const { DatabaseSync } = await import(specifier);
-    const db = new DatabaseSync(path.join(home, "state.db"));
-    db.exec(`CREATE TABLE messages (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      session_id TEXT NOT NULL,
-      role TEXT NOT NULL,
-      content TEXT,
-      tool_call_id TEXT,
-      tool_calls TEXT,
-      tool_name TEXT,
-      timestamp REAL NOT NULL,
-      finish_reason TEXT,
-      reasoning TEXT,
-      reasoning_content TEXT
-    )`);
-    db.exec(`CREATE TABLE session_model_usage (
-      session_id TEXT NOT NULL,
-      model TEXT NOT NULL,
-      billing_provider TEXT NOT NULL,
-      billing_base_url TEXT NOT NULL DEFAULT '',
-      billing_mode TEXT NOT NULL DEFAULT '',
-      task TEXT NOT NULL DEFAULT '',
-      api_call_count INTEGER NOT NULL DEFAULT 0,
-      first_seen REAL,
-      last_seen REAL,
-      PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
-    )`);
-    const message = db.prepare(
-      "INSERT INTO messages (session_id, role, content, timestamp, finish_reason) VALUES (?,?,?,?,?)",
-    );
-    message.run(SESSION_ID, "user", "which model are you", 1, null);
-    message.run(SESSION_ID, "assistant", "I am a model.", 2, "stop");
-    const row = db.prepare(
-      "INSERT INTO session_model_usage (session_id, model, billing_provider, billing_mode, task,"
-      + " api_call_count, first_seen, last_seen) VALUES (?,?,?,?,?,?,?,?)",
-    );
-    for (const entry of usage) {
-      row.run(entry.session, entry.model, entry.provider, "subscription_included", "chat", 1, 10, 20);
-    }
-    db.close();
-    return true;
-  } catch {
-    // Node without `node:sqlite`. Every case below is written so the module's
-    // documented degradation ("no provider") is what it asserts.
-    return false;
-  }
+async function writeStateDb(home: string): Promise<void> {
+  const { DatabaseSync } = await import(SQLITE);
+  const db = new DatabaseSync(path.join(home, "state.db"));
+  db.exec(`CREATE TABLE messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT,
+    tool_call_id TEXT,
+    tool_calls TEXT,
+    tool_name TEXT,
+    timestamp REAL NOT NULL,
+    finish_reason TEXT,
+    reasoning TEXT,
+    reasoning_content TEXT
+  )`);
+  db.exec(`CREATE TABLE session_model_usage (
+    session_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    billing_provider TEXT NOT NULL,
+    billing_base_url TEXT NOT NULL DEFAULT '',
+    billing_mode TEXT NOT NULL DEFAULT '',
+    task TEXT NOT NULL DEFAULT '',
+    api_call_count INTEGER NOT NULL DEFAULT 0,
+    first_seen REAL,
+    last_seen REAL,
+    PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
+  )`);
+  const message = db.prepare(
+    "INSERT INTO messages (session_id, role, content, timestamp, finish_reason) VALUES (?,?,?,?,?)",
+  );
+  message.run(SESSION_ID, "user", "which model are you", 1, null);
+  message.run(SESSION_ID, "assistant", "I am a model.", 2, "stop");
+  db.close();
 }
 
-describe("/setup-api/hermes/chat — what the DASHBOARD transport records as the served provider", () => {
-  let home: string;
-  let sqliteAvailable = true;
+describe.skipIf(!sqliteAvailable)(
+  "/setup-api/hermes/chat — what the DASHBOARD transport records as the served provider",
+  () => {
+    let home: string;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-served-provider-"));
-    process.env.HERMES_HOME = home;
-    appendMock.mockResolvedValue(true);
-    // No catalogue unless a case supplies one: the unpinned turn never asks for
-    // it on the way in, so this is the shape the settle path really meets.
-    modelOptionsMock.mockRejectedValue(new Error("no catalogue"));
-  });
+    beforeEach(async () => {
+      vi.clearAllMocks();
+      home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-served-provider-"));
+      process.env.HERMES_HOME = home;
+      appendMock.mockResolvedValue(true);
+      // No catalogue unless a case supplies one: the unpinned turn never warms
+      // it on the way in, so this is the shape the settle path really meets.
+      modelOptionsMock.mockReturnValue(null);
+      await writeStateDb(home);
+    });
 
-  afterEach(() => {
-    delete process.env.HERMES_HOME;
-    fs.rmSync(home, { recursive: true, force: true });
-  });
+    afterEach(() => {
+      delete process.env.HERMES_HOME;
+      fs.rmSync(home, { recursive: true, force: true });
+    });
 
-  it("names the provider Hermes itself billed, when the frame gave a model and the request pinned nothing", async () => {
-    sqliteAvailable = await writeStateDb(home, [
-      { session: SESSION_ID, model: "gpt-5.6-sol", provider: "openai-codex" },
-    ]);
-    if (!sqliteAvailable) return;
-    openTurnMock.mockResolvedValue(fakeTurn({ model: "gpt-5.6-sol" }));
+    it("names the provider Hermes itself billed, when the frame gave a model and the request pinned nothing", async () => {
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "gpt-5.6-sol",
+        bills: [{ model: "gpt-5.6-sol", provider: "openai-codex" }],
+      }));
 
-    const done = await doneEvent(await POST(post({ message: "which model are you" })));
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
 
-    expect(done).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
-    // ...and the same into the durable transcript, which is what a refreshed
-    // page replays. A bubble that loses its provider on reload is the same
-    // defect one layer down.
-    expect(persistedAssistant()).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
-  });
+      expect(done).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
+      // ...and the same into the durable transcript, which is what a refreshed
+      // page replays. A bubble that loses its provider on reload is the same
+      // defect one layer down.
+      expect(persistedAssistant()).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
+    });
 
-  it("still says nothing when the harness recorded no usage for that turn", async () => {
-    sqliteAvailable = await writeStateDb(home, []);
-    if (!sqliteAvailable) return;
-    openTurnMock.mockResolvedValue(fakeTurn({ model: "gpt-5.6-sol" }));
+    it("still says nothing when the harness recorded no usage for that turn", async () => {
+      openTurnMock.mockResolvedValue(fakeTurn({ home, model: "gpt-5.6-sol" }));
 
-    const done = await doneEvent(await POST(post({ message: "which model are you" })));
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
 
-    expect(done).toMatchObject({ model: "gpt-5.6-sol" });
-    expect(done).not.toHaveProperty("provider");
-    expect(persistedAssistant()).not.toHaveProperty("provider");
-  });
+      expect(done).toMatchObject({ model: "gpt-5.6-sol" });
+      expect(done).not.toHaveProperty("provider");
+      expect(persistedAssistant()).not.toHaveProperty("provider");
+    });
 
-  it("says nothing when the recorded provider cannot serve the model the frame named", async () => {
-    // A contradiction is not an answer. The catalogue here is live and lists
-    // anthropic's models, and `gpt-5.6-sol` is not among them, so the recorded
-    // pairing describes something other than this turn.
-    sqliteAvailable = await writeStateDb(home, [
-      { session: SESSION_ID, model: "gpt-5.6-sol", provider: "anthropic" },
-    ]);
-    if (!sqliteAvailable) return;
-    modelOptionsMock.mockResolvedValue(catalogue("anthropic", ["claude-fable-5"]));
-    openTurnMock.mockResolvedValue(fakeTurn({ model: "gpt-5.6-sol" }));
+    it("does not let an EARLIER turn's row label this one", async () => {
+      // The box moves to another provider serving the same model id, and this
+      // turn's row has not landed when the label is decided. The old row is
+      // still there and must not answer — that would be a wrong provider
+      // written durably, which is worse than the blank this replaces.
+      await bill(home, "glm-5", "zai", 1, 20);
+      openTurnMock.mockResolvedValue(fakeTurn({ home, model: "glm-5" }));
 
-    const done = await doneEvent(await POST(post({ message: "which model are you" })));
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
 
-    expect(done).toMatchObject({ model: "gpt-5.6-sol" });
-    expect(done).not.toHaveProperty("provider");
-    expect(persistedAssistant()).not.toHaveProperty("provider");
-  });
+      expect(done).toMatchObject({ model: "glm-5" });
+      expect(done).not.toHaveProperty("provider");
+      expect(persistedAssistant()).not.toHaveProperty("provider");
+    });
 
-  it("leaves a request that DID name a provider alone, so the transport's refusal still stands", async () => {
-    // The transport declines to confirm a provider the turn did not establish
-    // — a canonical request against a session reporting the KIND `custom`. That
-    // silence is deliberate and the billing record must not talk over it: this
-    // fix answers only where nobody asked for a provider at all.
-    sqliteAvailable = await writeStateDb(home, [
-      { session: SESSION_ID, model: "claude-fable-5", provider: "openai-codex" },
-    ]);
-    if (!sqliteAvailable) return;
-    modelOptionsMock.mockResolvedValue(catalogue("anthropic", ["claude-fable-5"]));
-    openTurnMock.mockResolvedValue(fakeTurn({ model: "claude-fable-5" }));
+    it("says nothing when the recorded provider cannot serve the model the frame named", async () => {
+      // A contradiction is not an answer. The catalogue here enumerates
+      // anthropic's models, and `gpt-5.6-sol` is not among them, so the
+      // recorded pairing describes something other than this turn.
+      modelOptionsMock.mockReturnValue(catalogue("anthropic", ["claude-fable-5"]));
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "gpt-5.6-sol",
+        bills: [{ model: "gpt-5.6-sol", provider: "anthropic" }],
+      }));
 
-    const done = await doneEvent(
-      await POST(post({ message: "hi", provider: "anthropic", model: "claude-fable-5" })),
-    );
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
 
-    expect(done).toMatchObject({ model: "claude-fable-5" });
-    expect(done).not.toHaveProperty("provider");
-  });
-});
+      expect(done).toMatchObject({ model: "gpt-5.6-sol" });
+      expect(done).not.toHaveProperty("provider");
+      expect(persistedAssistant()).not.toHaveProperty("provider");
+    });
+
+    it("keeps the provider when the catalogue's list is one this repo may have seeded", async () => {
+      // A user-defined provider's models are whatever config declares, and
+      // `normalizeRow` pads the box's own provider from a single configured id.
+      // Vetoing the harness's own billing record against a list we padded
+      // ourselves would blank the label on the commonest provider on the fleet.
+      modelOptionsMock.mockReturnValue(catalogue("clawai", ["deepseek-v4-flash"], true));
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "deepseek-v4-reasoner",
+        bills: [{ model: "deepseek-v4-reasoner", provider: "clawai" }],
+      }));
+
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+      expect(done).toMatchObject({ model: "deepseek-v4-reasoner", provider: "clawai" });
+    });
+
+    it("keeps the provider when a live catalogue agrees the pair is real", async () => {
+      // The only shape that runs on a warm box: the chat header warms the
+      // catalogue, so the veto is consulted and must not fire on a good pair.
+      modelOptionsMock.mockReturnValue(catalogue("openai-codex", ["gpt-5.6-sol"]));
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "gpt-5.6-sol",
+        bills: [{ model: "gpt-5.6-sol", provider: "openai-codex" }],
+      }));
+
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+      expect(done).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
+      expect(persistedAssistant()).toMatchObject({ provider: "openai-codex" });
+    });
+
+    it("answers for the model the COMPLETION frame named, not the one the session settled on", async () => {
+      // The frame changed the model, so the transport records that model with no
+      // provider — the settled provider belongs to the settled model. The
+      // billing record is keyed on the frame's model, so it speaks for the pair
+      // that actually ran rather than reinstating the session's.
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "deepseek-v4-flash",
+        finalModel: "gpt-5.6-sol",
+        bills: [{ model: "gpt-5.6-sol", provider: "openai-codex" }],
+      }));
+
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+      expect(done).toMatchObject({ model: "gpt-5.6-sol", provider: "openai-codex" });
+    });
+
+    it("says nothing when the harness recorded the ambiguous word `custom`", async () => {
+      // `custom` is the dashboard's KIND for a user-defined provider AND a real
+      // CLI slug for a generic OpenAI-compatible endpoint. Nothing here can tell
+      // them apart, so it is never asserted — the same refusal the transport's
+      // `servedProviderSlug` makes about the same word.
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "gpt-5.6-sol",
+        bills: [{ model: "gpt-5.6-sol", provider: "custom" }],
+      }));
+
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+      expect(done).toMatchObject({ model: "gpt-5.6-sol" });
+      expect(done).not.toHaveProperty("provider");
+    });
+
+    it("says nothing for a recorded id that could not be a provider id", async () => {
+      // It is about to be persisted and rendered, so it is charset-checked like
+      // any other provider id even though it came from the box's own store.
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "gpt-5.6-sol",
+        bills: [{ model: "gpt-5.6-sol", provider: "--provider=evil" }],
+      }));
+
+      const done = await doneEvent(await POST(post({ message: "which model are you" })));
+
+      expect(done).toMatchObject({ model: "gpt-5.6-sol" });
+      expect(done).not.toHaveProperty("provider");
+    });
+
+    it("leaves a request that DID name a provider alone, so the transport's refusal still stands", async () => {
+      // The transport declines to confirm a provider the turn did not establish
+      // — a canonical request against a session reporting the KIND `custom`. That
+      // silence is deliberate and the billing record must not talk over it: this
+      // fix answers only where nobody asked for a provider at all.
+      modelOptionsMock.mockReturnValue(catalogue("anthropic", ["claude-fable-5"]));
+      openTurnMock.mockResolvedValue(fakeTurn({
+        home,
+        model: "claude-fable-5",
+        bills: [{ model: "claude-fable-5", provider: "openai-codex" }],
+      }));
+
+      const done = await doneEvent(
+        await POST(post({ message: "hi", provider: "anthropic", model: "claude-fable-5" })),
+      );
+
+      expect(done).toMatchObject({ model: "claude-fable-5" });
+      expect(done).not.toHaveProperty("provider");
+    });
+  },
+);

--- a/src/tests/unit/hermes-turn-record.test.ts
+++ b/src/tests/unit/hermes-turn-record.test.ts
@@ -7,6 +7,7 @@ import {
   pickBillingProvider,
   readHermesBillingProvider,
   readHermesTurn,
+  readHermesUsageMarks,
 } from "@/lib/harness/hermes-turn-record";
 
 /**
@@ -422,10 +423,36 @@ describe("a turn that drew something", () => {
  * The schema below is the table as `~/.hermes/state.db` declared it, including
  * its six-column primary key, which is the whole reason the picker has a rule:
  * one session can hold several rows for the same model id.
+ *
+ * Every case runs the real pair — snapshot the marks, change the table the way
+ * a turn would, read again — because the whole rule is "which rows did THIS
+ * turn write", and a fixture that skipped the snapshot would be asserting a
+ * different function.
  */
 describe("readHermesBillingProvider", () => {
   let home: string;
   let available = true;
+
+  /** Bill `count` calls of `model` to `provider`, `seen` being its `last_seen`. */
+  async function bill(
+    session: string,
+    model: string,
+    provider: string,
+    count: number,
+    seen: number,
+    task = "chat",
+  ) {
+    const specifier = "node:sqlite";
+    const { DatabaseSync } = await import(specifier);
+    const db = new DatabaseSync(path.join(home, "state.db"));
+    db.prepare(
+      "INSERT INTO session_model_usage (session_id, model, billing_provider, billing_mode, task,"
+      + " api_call_count, first_seen, last_seen) VALUES (?,?,?,?,?,?,?,?)"
+      + " ON CONFLICT(session_id, model, billing_provider, billing_base_url, billing_mode, task)"
+      + " DO UPDATE SET api_call_count = excluded.api_call_count, last_seen = excluded.last_seen",
+    ).run(session, model, provider, "subscription_included", task, count, 1, seen);
+    db.close();
+  }
 
   beforeEach(async () => {
     home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-billing-"));
@@ -446,18 +473,6 @@ describe("readHermesBillingProvider", () => {
         last_seen REAL,
         PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
       )`);
-      const row = db.prepare(
-        "INSERT INTO session_model_usage (session_id, model, billing_provider, billing_mode, task,"
-        + " api_call_count, first_seen, last_seen) VALUES (?,?,?,?,?,?,?,?)",
-      );
-      // The shipped shape: one provider, two tasks.
-      row.run("s1", "gpt-5.6-sol", "openai-codex", "subscription_included", "chat", 4, 10, 20);
-      row.run("s1", "gpt-5.6-sol", "openai-codex", "subscription_included", "title", 1, 11, 21);
-      // A different model in the SAME conversation, on a different provider.
-      row.run("s1", "claude-sonnet-5", "anthropic", "anthropic_messages", "chat", 1, 30, 40);
-      // The same model id billed under TWO providers over one session's life.
-      row.run("s2", "glm-5", "zai", "api_key", "chat", 1, 10, 20);
-      row.run("s2", "glm-5", "openrouter", "api_key", "chat", 1, 30, 40);
       db.close();
     } catch {
       available = false;
@@ -469,39 +484,77 @@ describe("readHermesBillingProvider", () => {
     fs.rmSync(home, { recursive: true, force: true });
   });
 
-  it("names the provider that billed this session's turns on this model", async () => {
-    const billed = await readHermesBillingProvider("s1", "gpt-5.6-sol");
+  it("names the provider the turn just billed", async () => {
+    const before = await readHermesUsageMarks("s1");
     if (!available) {
-      // No SQLite: the contract is "", so the bubble keeps its blank.
-      expect(billed).toBe("");
+      // No SQLite: no baseline, so the bubble keeps its blank.
+      expect(before).toBeNull();
       return;
     }
-    expect(billed).toBe("openai-codex");
+    await bill("s1", "gpt-5.6-sol", "openai-codex", 4, 20);
+    expect(await readHermesBillingProvider("s1", "gpt-5.6-sol", before!)).toBe("openai-codex");
+  });
+
+  it("answers cleanly when one turn billed the same provider under two tasks", async () => {
+    if (!available) return;
+    const before = await readHermesUsageMarks("s1");
+    await bill("s1", "gpt-5.6-sol", "openai-codex", 4, 20, "chat");
+    await bill("s1", "gpt-5.6-sol", "openai-codex", 1, 21, "title");
+    expect(await readHermesBillingProvider("s1", "gpt-5.6-sol", before!)).toBe("openai-codex");
   });
 
   it("does not let one model in a conversation answer for another", async () => {
     if (!available) return;
-    expect(await readHermesBillingProvider("s1", "claude-sonnet-5")).toBe("anthropic");
+    const before = await readHermesUsageMarks("s1");
+    await bill("s1", "gpt-5.6-sol", "openai-codex", 1, 20);
+    await bill("s1", "claude-sonnet-5", "anthropic", 1, 40);
+    expect(await readHermesBillingProvider("s1", "claude-sonnet-5", before!)).toBe("anthropic");
   });
 
-  it("says nothing when one session billed the same model under two providers", async () => {
+  it("does not let an EARLIER turn's provider label this one", async () => {
+    // The defect this bound exists for. Turn 1 bills glm-5 to zai. The box then
+    // moves to a provider serving the same model id, and turn 2's row has not
+    // landed when the label is decided. Without the baseline the old row answers
+    // — confidently, wrongly, and into a durable transcript.
     if (!available) return;
-    expect(await readHermesBillingProvider("s2", "glm-5")).toBe("");
+    await bill("s1", "glm-5", "zai", 1, 20);
+    const before = await readHermesUsageMarks("s1");
+    expect(await readHermesBillingProvider("s1", "glm-5", before!)).toBe("");
+  });
+
+  it("notices a row this turn billed against AGAIN, which is not a new row", async () => {
+    if (!available) return;
+    await bill("s1", "glm-5", "zai", 1, 20);
+    const before = await readHermesUsageMarks("s1");
+    await bill("s1", "glm-5", "zai", 2, 30);
+    expect(await readHermesBillingProvider("s1", "glm-5", before!)).toBe("zai");
+  });
+
+  it("says nothing when one turn billed the same model under two providers", async () => {
+    if (!available) return;
+    const before = await readHermesUsageMarks("s1");
+    await bill("s1", "glm-5", "zai", 1, 20);
+    await bill("s1", "glm-5", "openrouter", 1, 30);
+    expect(await readHermesBillingProvider("s1", "glm-5", before!)).toBe("");
   });
 
   it("says nothing for a session, a model or a database that is not there", async () => {
-    await expect(readHermesBillingProvider("s1", "no-such-model")).resolves.toBe("");
-    await expect(readHermesBillingProvider("nope", "gpt-5.6-sol")).resolves.toBe("");
-    await expect(readHermesBillingProvider("", "gpt-5.6-sol")).resolves.toBe("");
-    await expect(readHermesBillingProvider("s1", "")).resolves.toBe("");
+    const empty = new Set<string>();
+    await expect(readHermesBillingProvider("s1", "no-such-model", empty)).resolves.toBe("");
+    await expect(readHermesBillingProvider("nope", "gpt-5.6-sol", empty)).resolves.toBe("");
+    await expect(readHermesBillingProvider("", "gpt-5.6-sol", empty)).resolves.toBe("");
+    await expect(readHermesBillingProvider("s1", "", empty)).resolves.toBe("");
     process.env.HERMES_HOME = path.join(home, "gone");
-    await expect(readHermesBillingProvider("s1", "gpt-5.6-sol")).resolves.toBe("");
+    await expect(readHermesBillingProvider("s1", "gpt-5.6-sol", empty)).resolves.toBe("");
+    await expect(readHermesUsageMarks("s1")).resolves.toBeNull();
+    await expect(readHermesUsageMarks("")).resolves.toBeNull();
   });
 
   it("ignores a row whose provider is blank rather than treating it as an answer", () => {
-    expect(pickBillingProvider([{ billing_provider: "  " }, { billing_provider: "clawai" }]))
+    const none = new Set<string>();
+    expect(pickBillingProvider([{ billing_provider: "  " }, { billing_provider: "clawai" }], none))
       .toBe("clawai");
-    expect(pickBillingProvider([{ billing_provider: null }])).toBe("");
-    expect(pickBillingProvider([])).toBe("");
+    expect(pickBillingProvider([{ billing_provider: null }], none)).toBe("");
+    expect(pickBillingProvider([], none)).toBe("");
   });
 });

--- a/src/tests/unit/hermes-turn-record.test.ts
+++ b/src/tests/unit/hermes-turn-record.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { buildTurnFromRows, readHermesTurn } from "@/lib/harness/hermes-turn-record";
+import {
+  buildTurnFromRows,
+  pickBillingProvider,
+  readHermesBillingProvider,
+  readHermesTurn,
+} from "@/lib/harness/hermes-turn-record";
 
 /**
  * The turn, read back from the agent's own record instead of its console.
@@ -407,5 +412,96 @@ describe("a turn that drew something", () => {
     // twice in the bubble.
     const doubled = [...DREW_ROWS, { ...DREW_ROWS[2], id: 601 }];
     expect(buildTurnFromRows(doubled)?.generatedImages).toHaveLength(1);
+  });
+});
+
+/**
+ * Who BILLED the turn — `session_model_usage`, the only surface on this box
+ * that answers it per (session, model).
+ *
+ * The schema below is the table as `~/.hermes/state.db` declared it, including
+ * its six-column primary key, which is the whole reason the picker has a rule:
+ * one session can hold several rows for the same model id.
+ */
+describe("readHermesBillingProvider", () => {
+  let home: string;
+  let available = true;
+
+  beforeEach(async () => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-billing-"));
+    process.env.HERMES_HOME = home;
+    try {
+      const specifier = "node:sqlite";
+      const { DatabaseSync } = await import(specifier);
+      const db = new DatabaseSync(path.join(home, "state.db"));
+      db.exec(`CREATE TABLE session_model_usage (
+        session_id TEXT NOT NULL,
+        model TEXT NOT NULL,
+        billing_provider TEXT NOT NULL,
+        billing_base_url TEXT NOT NULL DEFAULT '',
+        billing_mode TEXT NOT NULL DEFAULT '',
+        task TEXT NOT NULL DEFAULT '',
+        api_call_count INTEGER NOT NULL DEFAULT 0,
+        first_seen REAL,
+        last_seen REAL,
+        PRIMARY KEY (session_id, model, billing_provider, billing_base_url, billing_mode, task)
+      )`);
+      const row = db.prepare(
+        "INSERT INTO session_model_usage (session_id, model, billing_provider, billing_mode, task,"
+        + " api_call_count, first_seen, last_seen) VALUES (?,?,?,?,?,?,?,?)",
+      );
+      // The shipped shape: one provider, two tasks.
+      row.run("s1", "gpt-5.6-sol", "openai-codex", "subscription_included", "chat", 4, 10, 20);
+      row.run("s1", "gpt-5.6-sol", "openai-codex", "subscription_included", "title", 1, 11, 21);
+      // A different model in the SAME conversation, on a different provider.
+      row.run("s1", "claude-sonnet-5", "anthropic", "anthropic_messages", "chat", 1, 30, 40);
+      // The same model id billed under TWO providers over one session's life.
+      row.run("s2", "glm-5", "zai", "api_key", "chat", 1, 10, 20);
+      row.run("s2", "glm-5", "openrouter", "api_key", "chat", 1, 30, 40);
+      db.close();
+    } catch {
+      available = false;
+    }
+  });
+
+  afterEach(() => {
+    delete process.env.HERMES_HOME;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  it("names the provider that billed this session's turns on this model", async () => {
+    const billed = await readHermesBillingProvider("s1", "gpt-5.6-sol");
+    if (!available) {
+      // No SQLite: the contract is "", so the bubble keeps its blank.
+      expect(billed).toBe("");
+      return;
+    }
+    expect(billed).toBe("openai-codex");
+  });
+
+  it("does not let one model in a conversation answer for another", async () => {
+    if (!available) return;
+    expect(await readHermesBillingProvider("s1", "claude-sonnet-5")).toBe("anthropic");
+  });
+
+  it("says nothing when one session billed the same model under two providers", async () => {
+    if (!available) return;
+    expect(await readHermesBillingProvider("s2", "glm-5")).toBe("");
+  });
+
+  it("says nothing for a session, a model or a database that is not there", async () => {
+    await expect(readHermesBillingProvider("s1", "no-such-model")).resolves.toBe("");
+    await expect(readHermesBillingProvider("nope", "gpt-5.6-sol")).resolves.toBe("");
+    await expect(readHermesBillingProvider("", "gpt-5.6-sol")).resolves.toBe("");
+    await expect(readHermesBillingProvider("s1", "")).resolves.toBe("");
+    process.env.HERMES_HOME = path.join(home, "gone");
+    await expect(readHermesBillingProvider("s1", "gpt-5.6-sol")).resolves.toBe("");
+  });
+
+  it("ignores a row whose provider is blank rather than treating it as an answer", () => {
+    expect(pickBillingProvider([{ billing_provider: "  " }, { billing_provider: "clawai" }]))
+      .toBe("clawai");
+    expect(pickBillingProvider([{ billing_provider: null }])).toBe("");
+    expect(pickBillingProvider([])).toBe("");
   });
 });


### PR DESCRIPTION
Closes the defect on **TASK-633** and the coverage gap on **TASK-667**.

## The symptom, on hardware

The ordinary new chat. Press "+", type, send — the request names neither a model
nor a provider, because the client has no per-provider pick to send yet. The
reply comes back naming the model and unable to say who served it:

```
POST /setup-api/hermes/chat  {"message":"which model are you","sessionKey":"desktop-…"}
done → {"model":"gpt-5.6-sol","sessionId":"20260902_205829_99ac3f","harness":"hermes", …}
        keys: ['harness','model','reasoning','sessionId','text']      ← no "provider"
transcript[1]  model='gpt-5.6-sol'  provider=None
```

Three independent runs, three fresh sessions, three times the same. Not a cold
box and not a resumed turn — the catalogue was live and warm
(`source:'dashboard'`, `stale:false`), and none of the three sent a `sessionId`.
This is the default path, and on it the bubble shows a model with nothing beside
it while the tools tell the agent the label is there.

**The harness knew the answer and was not asked.** For the same three session
ids, Hermes' own store held it exactly:

```
session_model_usage
  20260902_205829_99ac3f  gpt-5.6-sol  billing_provider='openai-codex'  subscription_included
  20260902_205959_a3457b  gpt-5.6-sol  billing_provider='openai-codex'  subscription_included
  20260902_210003_9d1a74  gpt-5.6-sol  billing_provider='openai-codex'  subscription_included
```

## The cause

These turns take the dashboard transport. `servedProviderSlug` returns `""`
whenever the request named no provider — `if (!reported || !onRequestedModel ||
!requested) return ""` — and `servedPair` then records the frame whole, model
without provider, deliberately: *a turn that reported a model owns both halves of
the record, including the half it left empty.*

**That refusal is correct and this PR does not touch it.** #581 exists because
the alternative was worse: two independent `||`s put the session's provider back
beside a model it never served and wrote that invented pairing into the
customer's durable transcript. The guard stays exactly as it is.

What was missing is a **source**, not a looser guard. The turn refuses to invent
a provider; nobody was asking the one party that actually knows.

The gap survived a review that was looking for it because the served-model tests
all sit under `describe("… what the CLI path records …")`. The CLI path fills
both halves from `config.yaml`; the dashboard transport — which is what answers
on a Hermes box — fills neither. That is TASK-667, and it is why the tests in
this PR are written against the dashboard transport.

## Harness first — what Hermes natively provides, and what it does not

`session_model_usage(session_id, model, billing_provider, billing_base_url,
billing_mode, task, api_call_count, …, first_seen, last_seen)` in
`~/.hermes/state.db` is the harness's own record of which provider billed which
model in which session. It is read **read-only**, keyed on the session id the
turn returned **and** the model the frame named.

The other candidates were checked and each fails on a citable ground:

| Native surface | Why it cannot answer this |
|---|---|
| `messages` table | `PRAGMA table_info(messages)` → 23 columns, none naming a model, provider or billing mode. Asked on the box; the answer now sits in the code where the question used to be. |
| `sessions` table | Carries `model` and `billing_provider`, but only the **last** ones the thread used. Reading them per bubble relabels every older reply in a conversation that switched — the exact defect this field exists to prevent. |
| `session.usage` gateway **RPC** | Exists by name, but its params and result payload are undocumented in every public source. Adopting it means guessing a wire shape. |
| `GET /api/analytics/usage?days=N` | Aggregated by day and by model over N days, not addressable by session id, and carries no billing provider. |
| `GET /api/sessions/{id}` | Serves the `sessions` row — the thread's last model. Same limitation as above. |
| `/usage` via `slash.exec` | Human-formatted prose, no `--json`, and it names the *active* provider: the present-tense value that is precisely what is ambiguous here. |
| `hermes -z --usage-file f.json` | Writes exactly the right fields, but upstream states it has no effect outside `-z`, and `-z` starts a new session per invocation and ignores `--resume`. Unusable for a dashboard turn. |
| `hermes sessions list` | Workspace-scoped by cwd; answers "No sessions found" for this route (already recorded in `transcript-store.ts`). Its columns carry no provider. |

**So the finding is: there is no non-SQLite native surface for this, and reading
the store directly is the available mechanism.** That is not a novel liberty
here — `hermes-turn-record.ts` already reads `state.db` read-only for the same
turn's reasoning and tool calls, by the same guarded `node:sqlite` idiom, and the
established third-party Hermes usage tool reads the same file the same way. This
PR adds one more query to that existing reader rather than a second door.

**One candidate is still open, and it is named in the code.** The transport's own
comment says a `session.usage` **EVENT** already arrives on the socket this turn
is running on, and the frame loop's `default` case drops it. Its payload has
never been captured — nothing in this repo has ever looked. If it carries the
provider it beats this read on every axis (per turn, pushed, no second store, no
ambiguity to refuse) and retires `billedProviderFor` outright. That capture is
one read-only box run and it belongs to the next lane; the pointer is in the
function's docstring so it cannot be lost.

Worth stating plainly: `session_model_usage` is **not** publicly schema-
documented (unlike `sessions`). The module's degrade-to-nothing contract is what
makes that acceptable — a renamed table or column costs the label and nothing
else.

## What the fix does *not* do

TASK-633's originally proposed fix — mapping a `custom`/null provider back to
`config.yaml` — **is wrong and is not what this is.** What the box is configured
to run is not evidence about what a session ran; #581 removed exactly that
reading and it stays removed. Nothing here reads `config.yaml`, the device
default, or the catalogue's `current` pair.

## Bound to the turn that just ran

A usage row **aggregates** a session's calls for its key, so `last_seen` says
when that combination last billed, never which turn it billed for — and
comparing it against a clock this process holds would mean knowing its epoch and
units, which nothing here does. An unbounded `WHERE session_id AND model` would
therefore answer with any row that session ever wrote, including an earlier
turn's: a conversation that moved to another provider serving the same model id
would get one bubble confidently naming the wrong one, written durably. That is
the #581 defect class re-sourced, and it is not acceptable.

So the rows are compared against **themselves**. The session's billing rows are
marked (`model | provider | api_call_count | last_seen`) *before* the turn runs;
afterwards, only a row not carrying one of those marks can speak for it. No
absolute time, no unit, no epoch — only "did this change". It also turns the
open timing question below from a wrong answer into a blank.

## The rules it refuses on

`billedProviderFor` answers nothing rather than guessing, in six cases — each one
mutation-tested, i.e. deleting it makes a named test fail:

- **the request named a provider.** Then a blank came from the contradiction
  guard doing its job (a canonical slug asked of a session the dashboard reports
  as the kind `custom`), and the billing record must not talk over it. Gated on
  `wantsProvider`, so `auto` — ClawBox's word for "let Hermes decide" — counts as
  *unpinned*, which is right: the record is precisely the answer to what Hermes
  decided.
- **no usage row** for that (session, model). Unchanged behaviour.
- **no row this turn wrote** — the baseline above.
- **two providers** billed the same model during this turn.
- **the recorded value is the literal `custom`**, which is a kind as well as a
  real slug; the same refusal `servedProviderSlug` makes about the same word.
- **the catalogue says that provider cannot serve that model** — but only where
  the catalogue is an *enumeration*. `normalizeRow` seeds the box's own provider
  and the on-device one from a single configured id, so vetoing the harness's own
  record against a list this repo padded would blank the label on the commonest
  provider on the fleet. Only `isUserDefined === false` says "Hermes ships this
  one and listed its models".

The catalogue is read **from cache only** (`cachedModelOptions`, new export).
This runs after the answer has streamed, and the veto is waived anyway whenever
the catalogue is unavailable or stale, so awaiting a live fetch would hold the
`done` frame — and the durable transcript write with it — for a check that a
failed fetch waives. The test file makes `getModelOptions` throw, so the settle
path fetching again is a test failure rather than a slow turn.

## RED → GREEN

RED, on unmodified `origin/beta` `e8ba1e1a`:

```
 FAIL  src/tests/routes/hermes/chat-served-model-dashboard.test.ts >
       what the DASHBOARD transport records as the served provider >
       names the provider Hermes itself billed, when the frame gave a model and the request pinned nothing
AssertionError: expected { text: 'I am a model.', …(3) } to match object { model: 'gpt-5.6-sol', …(1) }

- Expected
+ Received

  {
    "model": "gpt-5.6-sol",
-   "provider": "openai-codex",
  }

 Test Files  1 failed (1)
      Tests  1 failed | 3 passed (4)
```

The cases that assert an *absence* pass on beta by construction — beta shows no
provider at all — so each is mutation-tested instead. Deleting any one of the six
refusals above fails a named case; deleting the baseline filter fails two.

GREEN: **638 test files / 9252 tests**, one pre-existing flake
(`chat-spoken-reply.test.tsx`, a `waitFor` timeout under full-suite load — 18/18
three times in isolation, a different case each full run, and this branch touches
none of the modules it imports). `npx tsc --noEmit` → exit 0. `eslint` on the
changed files → clean. `bun run check:mcp-tools` → Tool contract OK.

## Sibling call sites

- **Both settle sites** in `hermes/chat/route.ts` go through `servedPair`, so both
  are covered by one change: the `done` path and the quiet-stream recovery
  (which passes `null` and takes the session's settled pair — the same defect,
  the same answer, and the same baseline).
- **The transport's two sites** in `hermes-dashboard-turn.ts` — the session site
  and the completion site — are deliberately untouched. They keep refusing to
  invent; `DASHBOARD_PROVIDER_KIND` is now exported so the route makes the same
  refusal about the same word from one definition instead of two.
- **The CLI path** (`cliServedPair`) is deliberately unchanged, and the docstring
  now says why — for both of its blanking cases, not just the resumed one.
- **Every test that `vi.mock`s `@/lib/harness/hermes-turn-record`** carries both
  new exports. Two of the three failed loudly when they did not; the third passed
  only because its cases never reach the branch, and was completed anyway, since
  a partial mock of a module the route imports fails as a missing-export error
  rather than as the assertion it was written for.
- `readHermesTurn`'s sqlite open moved into a shared `withStateDb` helper so the
  new readers do not duplicate the guard. Its behaviour and its journal text are
  unchanged (`what = "the agent's record"` reproduces the old string byte for
  byte), and its existing tests — including the degradation cases — pass
  untouched.

## Stale claims corrected

`settleTurn`'s "UNVERIFIED … one read-only command settles it" note asked
precisely the question the device lane then ran; the answer replaces the
question. `servedPair`'s headline ("taken WHOLE, never half from one source and
half from the other") and `settleTurn`'s lead ("from the transport rather than
from the agent's own record") both stated a rule this change narrows, and both
now state the rule that actually holds.

## Not proven here

- **The device leg was not run** — the brief for this fix ruled out touching a
  box. Two things therefore rest on the earlier lane's capture rather than on a
  run of this code: that Hermes has committed the usage row by the time
  `message.complete` arrives (if it has not, the first turn of a new chat finds
  no row and the label stays blank — the change is inert there, never wrong), and
  that `payload.model` and `session_model_usage.model` are the same string. The
  second is evidenced: the lane's capture shows `done → model: 'gpt-5.6-sol'`
  beside `session_model_usage … gpt-5.6-sol` for all three sessions, and
  `gpt-5.6-terra` / `claude-sonnet-5` matching their bubbles in the switch test.
  The first is not, and it is one read-only command on a box — run it beside a
  live turn and it settles both, and the `session.usage` frame capture above at
  the same time.
- **The browser.** Every assertion here is at the route, transcript-store and
  harness-store level; whether the rendered bubble *displays* the provider it now
  carries is owed a browser pass, as it was for #581.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard chat now shows the provider that billed a turn when no provider was explicitly selected.
  * Provider and model labels remain accurate for automatic routing, custom providers, and confirmed catalogue pairings.
  * Billing labels are omitted when provider information is missing, ambiguous, invalid, or unrelated to the served model.
  * Corrected provider labels are also saved to the conversation transcript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->