### PR TITLE
fix: start the terminal server with node, not npx tsx

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -9,7 +9,7 @@ queries:
 # (e.g. js/insecure-temporary-file across src/tests/**) are noise.
 #
 # NOTE: scripts/** is intentionally NOT excluded — it holds security-critical
-# runtime code (scripts/terminal-server.ts WebSocket server, browser launcher)
+# runtime code (scripts/terminal-server.mjs WebSocket server, browser launcher)
 # that must stay under CodeQL coverage. CI-only script alerts are dismissed
 # individually instead.
 paths-ignore:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ A webapp always runs in a sandboxed iframe with an opaque origin (`src/lib/webap
 ### System Integration (`scripts/`, `config/`)
 
 - **`scripts/start-ap.sh`** / **`scripts/stop-ap.sh`** — create/tear down WiFi AP "ClawBox-Setup" on `wlP1p1s0` at `10.42.0.1/24`
-- **`scripts/terminal-server.ts`** — WebSocket PTY server on port 3006
+- **`scripts/terminal-server.mjs`** — WebSocket PTY server on port 3006 (plain ESM JS, started with the web server's own Node — no npx, no transpiler)
 - **`scripts/setup-optimizations.sh`** — Jetson GPU/memory tuning
 - **`scripts/gateway-pre-start.sh`** — gateway pre-startup hooks
 - **`scripts/kokoro-*.sh`** / **`scripts/kokoro-server.py`** — voice/TTS integration

--- a/e2e-install/40-terminal.spec.ts
+++ b/e2e-install/40-terminal.spec.ts
@@ -1,13 +1,13 @@
 /**
  * Terminal — connect to the real /terminal-ws WebSocket, which
- * production-server.js proxies to the node-pty backed terminal-server.ts.
+ * production-server.js proxies to the node-pty backed terminal-server.mjs.
  * Types a command into the PTY and asserts its output shows up on the wire.
  *
  * This exercises:
  *   - node-pty native rebuild (install.sh's ensure_node_pty)
  *   - production-server.js WebSocket upgrade routing, including the session
  *     check it applies to the single-service sockets
- *   - the standalone terminal-server.ts on port 3006 inside the container
+ *   - the standalone terminal-server.mjs on port 3006 inside the container
  *
  * The upgrade carries a `clawbox_session` cookie because that is what the
  * desktop's Terminal app sends. A WebSocket upgrade never passes through the

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "mcp": "bun run mcp/clawbox-mcp.ts",
     "typecheck:mcp": "tsc -p mcp/tsconfig.json",
     "check:mcp-tools": "bun run mcp/check-tools.ts",
-    "terminal-server": "bun run scripts/terminal-server.ts",
+    "terminal-server": "node scripts/terminal-server.mjs",
     "dev": "next dev --port ${PORT:-3000} --hostname 0.0.0.0",
     "dev:privileged": "next dev --port 80 --hostname 0.0.0.0",
     "prebuild": "rm -rf .next/standalone/.next/cache/images 2>/dev/null || true",

--- a/production-server.js
+++ b/production-server.js
@@ -20,7 +20,7 @@ const IS_DEV = process.env.NODE_ENV === "development";
 // Path prefixes that the production server routes to a non-gateway upstream.
 // Keep entries in sync with any new WebSocket-only services added behind :80.
 //
-//   /terminal-ws  → xterm/PTY WebSocket (scripts/terminal-server.ts)
+//   /terminal-ws  → xterm/PTY WebSocket (scripts/terminal-server.mjs)
 //   /novnc-ws     → noVNC / websockify for the remote desktop app
 // `requireAuth` gates the raw single-service sockets (terminal PTY, noVNC) on a
 // valid ClawBox session cookie. WebSocket upgrades never pass through Next.js

--- a/scripts/terminal-server.mjs
+++ b/scripts/terminal-server.mjs
@@ -1,10 +1,19 @@
-#!/usr/bin/env npx tsx
+// @ts-check
 /**
  * Standalone WebSocket Terminal Server
- * Runs on port 3006, spawns a PTY (zsh) per connection and bridges it over WebSocket.
+ * Runs on port 3006, spawns a login PTY (/bin/bash) per connection and bridges
+ * it over WebSocket.
+ *
+ * Plain ESM JavaScript on purpose, NOT TypeScript. The boot hook
+ * (src/instrumentation-node.ts) starts this with the Node that is already
+ * running the web server, so the Terminal app needs nothing fetched, resolved
+ * or transpiled at boot. It used to be started with `npx tsx`, and `tsx` is not
+ * a dependency of this project: it only ever resolved because the box had once
+ * been online and npm had left a copy in ~/.npm/_npx. On a freshly flashed box
+ * whose first boot is AP mode with no internet there is no copy to find.
  *
  * Usage:
- *   bun run scripts/terminal-server.ts
+ *   node scripts/terminal-server.mjs
  *
  * Protocol:
  *   Client → Server:
@@ -15,10 +24,10 @@
  *     { type: "exit", code: number }        — PTY exited
  */
 
-import * as http from "http";
+import * as http from "node:http";
+import * as os from "node:os";
 import { WebSocketServer, WebSocket } from "ws";
 import * as pty from "node-pty";
-import * as os from "os";
 
 const PORT = parseInt(process.env.TERMINAL_WS_PORT || "3006", 10);
 
@@ -29,7 +38,7 @@ const server = http.createServer((_req, res) => {
 
 const wss = new WebSocketServer({ server });
 
-wss.on("connection", (ws: WebSocket, req) => {
+wss.on("connection", (ws, req) => {
   const remote = req.socket.remoteAddress;
   console.log(`[terminal-server] New connection from ${remote}`);
 
@@ -39,7 +48,7 @@ wss.on("connection", (ws: WebSocket, req) => {
   const targetUser = process.env.USER || process.env.LOGNAME || os.userInfo().username || "clawbox";
   const targetHome = process.env.HOME || os.homedir() || `/home/${targetUser}`;
   const shell = "/bin/bash";
-  const cleanEnv: Record<string, string> = {
+  const cleanEnv = {
     HOME: targetHome,
     USER: targetUser,
     LOGNAME: targetUser,
@@ -56,7 +65,8 @@ wss.on("connection", (ws: WebSocket, req) => {
   // the 'connection' handler and crashes the whole :3006 server, dropping
   // every other live terminal session. Contain the failure to this one socket:
   // tell the client and close, leaving the server up.
-  let term: ReturnType<typeof pty.spawn>;
+  /** @type {import("node-pty").IPty} */
+  let term;
   try {
     term = pty.spawn(shell, ["-l"], {
       name: "xterm-256color",
@@ -69,13 +79,13 @@ wss.on("connection", (ws: WebSocket, req) => {
     console.log(`[terminal-server] Spawned PTY pid=${term.pid} shell=${shell}`);
 
     // PTY → WebSocket
-    term.onData((data: string) => {
+    term.onData((data) => {
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: "output", data }));
       }
     });
 
-    term.onExit(({ exitCode }: { exitCode: number }) => {
+    term.onExit(({ exitCode }) => {
       console.log(`[terminal-server] PTY exited pid=${term.pid} code=${exitCode}`);
       if (ws.readyState === WebSocket.OPEN) {
         ws.send(JSON.stringify({ type: "exit", code: exitCode }));
@@ -98,7 +108,7 @@ wss.on("connection", (ws: WebSocket, req) => {
   }
 
   // WebSocket → PTY
-  ws.on("message", (raw: Buffer | string) => {
+  ws.on("message", (raw) => {
     try {
       const msg = JSON.parse(raw.toString());
       if (msg.type === "input" && typeof msg.data === "string") {

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -55,8 +55,32 @@ let terminalGeneration = 0
 let llamaCppChild: ChildProcess | null = null
 let llamaCppStopping = false
 let llamaCppRestartDelayMs = LLAMACPP_RESTART_MIN_MS
+/**
+ * A restart this supervisor has already armed. Held so a deliberate stop can
+ * cancel it: `llamaCppStopping` alone cannot, because startLlamaCppServer
+ * clears that flag as its first act, so a timer firing after the stop un-stops
+ * the very thing that stopped it — the owner switches Local AI off in Settings
+ * and gigabytes come back a minute later. Beta's window for that was a fixed
+ * 5 s; the backoff above stretches it to a minute, so it is cancelled properly
+ * now rather than raced.
+ */
+let llamaCppRestartTimer: ReturnType<typeof setTimeout> | null = null
 let llamaCppStartPromise: Promise<LlamaCppStartStatus> | null = null
 let cleanupRegistered = false
+
+/**
+ * The supervision chain is over: drop any armed restart and put the backoff
+ * back at its floor. Deliberate stops only — a retry must NOT come through
+ * here, or the delay would reset on every attempt and the crash loop would be
+ * flat 5 s again, which is the defect this file was rewritten for.
+ */
+function endLlamaCppRestartChain() {
+  if (llamaCppRestartTimer) {
+    clearTimeout(llamaCppRestartTimer)
+    llamaCppRestartTimer = null
+  }
+  llamaCppRestartDelayMs = LLAMACPP_RESTART_MIN_MS
+}
 
 function cleanupChildren() {
   terminalStopping = true
@@ -65,6 +89,7 @@ function cleanupChildren() {
     terminalChild = null
   }
   llamaCppStopping = true
+  endLlamaCppRestartChain()
   if (llamaCppChild) {
     try { llamaCppChild.kill('SIGTERM') } catch {}
     llamaCppChild = null
@@ -102,7 +127,11 @@ export function startTerminalServer() {
   // dev server — used to be accepted as the terminal, and the Terminal app
   // then talked to it. The banner is what scripts/terminal-server.mjs writes
   // for exactly this handshake.
-  fetch(`http://127.0.0.1:${PORT}`)
+  // Timed out, because reading the banner means reading a body from whatever
+  // is on that port: something that answers 200 and then stalls would hold the
+  // Terminal off for undici's five-minute default. Two seconds is generous for
+  // loopback, and a timeout lands in the .catch() below, which starts ours.
+  fetch(`http://127.0.0.1:${PORT}`, { signal: AbortSignal.timeout(2_000) })
     .then(async (res) => {
       if (res.ok && (await res.text()).includes(TERMINAL_SERVER_BANNER)) {
         console.log(`[instrumentation] Terminal server already running on port ${PORT}`)
@@ -134,7 +163,9 @@ export function startTerminalServer() {
     // minute instead of a fork storm.
     if (!fs.existsSync(serverPath)) {
       console.error(`[instrumentation] Terminal server not started: ${serverPath} does not exist, so the Terminal app will not work. Restore it with 'sudo bash install.sh --step git_pull'; retrying meanwhile.`)
-      restartDelayMs = CHILD_RESTART_MAX_MS
+      // A minute between looks, and deliberately WITHOUT touching
+      // restartDelayMs: a missing file is not a crash loop, so the child that
+      // spawns once it returns must still get the 2 s floor if it then dies.
       setTimeout(startServer, CHILD_RESTART_MAX_MS)
       return
     }
@@ -171,7 +202,11 @@ export function startTerminalServer() {
     // exactly once, so it needs no double-schedule guard.
     child.on('close', (code) => {
       if (terminalStopping || generation !== terminalGeneration) return
-      scheduleRestart(`exited (code=${code})`, uptimeClockMs() - startedAt)
+      // A child that never spawned reports -errno here, not an exit status, so
+      // saying "exited (code=-2)" would send an operator hunting for a status
+      // that does not exist. The 'error' handler above already logged why.
+      const reason = child.pid === undefined ? 'could not start' : `exited (code=${code})`
+      scheduleRestart(reason, uptimeClockMs() - startedAt)
     })
 
     console.log(`[instrumentation] Terminal server starting on port ${PORT} (pid=${child.pid})`)
@@ -310,9 +345,11 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
   // spawned, and only 'close' is delivered for that. This one is demand-started
   // by ensureLocalAiReady, which awaits it: a spawn that failed is reported to
   // that caller by the pid check above, so there is no supervision to restore
-  // and a retry behind the caller's back would be new behaviour. Past that
-  // check the child really exists, and 'exit' is guaranteed for it — one
-  // listener, one retry per death, no double-schedule guard needed.
+  // and a retry behind the caller's back would be new behaviour. (The one
+  // exception is the retry below, which is fire-and-forget — a respawn that
+  // cannot spawn ends the chain, and the next proxied request starts it again.)
+  // Past that check the child really exists, and 'exit' is guaranteed for it —
+  // one listener, one retry per death, no double-schedule guard needed.
   child.on('exit', (code) => {
     void (async () => {
       try {
@@ -331,7 +368,8 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
         const delayMs = llamaCppRestartDelayMs
         llamaCppRestartDelayMs = Math.min(llamaCppRestartDelayMs * 2, CHILD_RESTART_MAX_MS)
         console.log(`[instrumentation] llama.cpp exited (code=${code}), retrying in ${delayMs / 1000}s...`)
-        setTimeout(() => {
+        llamaCppRestartTimer = setTimeout(() => {
+          llamaCppRestartTimer = null
           // Restart the SAME alias. Re-deriving it would send the crash-restart
           // back through the configuration gate, which on a Hermes device is a
           // different question from "what was just running".
@@ -350,6 +388,7 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
 
 export async function stopLlamaCppServer() {
   llamaCppStopping = true
+  endLlamaCppRestartChain()
 
   const llamaCpp = await import('./lib/llamacpp-server')
   const spec = llamaCpp.getLlamaCppLaunchSpec()

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -30,6 +30,12 @@ const LLAMACPP_RESTART_MIN_MS = 5_000
  * `register()` runs once per process, so there is never a child to replace.
  */
 const TERMINAL_REPLACE_GRACE_MS = 2_000
+/**
+ * How often to look again for a server file that is not there. Same duration as
+ * the backoff ceiling, but a different question — a missing file is not a crash
+ * loop — so it gets its own name rather than borrowing that constant's meaning.
+ */
+const TERMINAL_MISSING_FILE_RECHECK_MS = 60_000
 
 /**
  * What scripts/terminal-server.mjs answers on GET /. The "is it already up?"
@@ -81,20 +87,31 @@ let llamaCppRestartTimer: ReturnType<typeof setTimeout> | null = null
  */
 let llamaCppStopGeneration = 0
 let llamaCppStartPromise: Promise<LlamaCppStartStatus> | null = null
+/** The stop generation {@link llamaCppStartPromise} was created under. */
+let llamaCppStartGeneration = -1
 let cleanupRegistered = false
 
 /**
- * The supervision chain is over: cancel an armed restart, disown a start that
- * is already in flight, and put the backoff back at its floor. Deliberate
- * stops only — a retry must NOT come through here, or the delay would reset on
- * every attempt and the crash loop would be flat 5 s again, which is the defect
- * this file was rewritten for.
+ * Drop the armed retry, and nothing else. Safe to call whenever a retry has
+ * become pointless — a child is running again — because it does NOT touch the
+ * backoff.
  */
-function endLlamaCppSupervision() {
+function cancelPendingLlamaCppRestart() {
   if (llamaCppRestartTimer) {
     clearTimeout(llamaCppRestartTimer)
     llamaCppRestartTimer = null
   }
+}
+
+/**
+ * The supervision chain is over: cancel the armed restart, disown any start
+ * already in flight, and put the backoff back at its floor. Deliberate stops
+ * only — a retry must NOT come through here, or the delay would reset on every
+ * attempt and the crash loop would be flat 5 s again, which is the defect this
+ * file was rewritten for.
+ */
+function endLlamaCppSupervision() {
+  cancelPendingLlamaCppRestart()
   llamaCppStopGeneration++
   llamaCppRestartDelayMs = LLAMACPP_RESTART_MIN_MS
 }
@@ -130,6 +147,10 @@ export function startTerminalServer() {
   // is a build artefact that only refreshes on a full rebuild.
   const serverPath = path.join(CONFIG_ROOT, 'scripts', 'terminal-server.mjs')
   const generation = ++terminalGeneration
+  // Per call, deliberately unlike the llama.cpp counter, which is module state:
+  // a second call here only ever happens on a dev hot-reload, and that is a new
+  // supervision chain rather than a continuing crash loop. Production has one
+  // generation for the life of the process.
   let restartDelayMs = TERMINAL_RESTART_MIN_MS
   terminalStopping = false
 
@@ -205,7 +226,7 @@ export function startTerminalServer() {
       // A minute between looks, and deliberately WITHOUT touching
       // restartDelayMs: a missing file is not a crash loop, so the child that
       // spawns once it returns must still get the 2 s floor if it then dies.
-      setTimeout(startServer, CHILD_RESTART_MAX_MS)
+      setTimeout(startServer, TERMINAL_MISSING_FILE_RECHECK_MS)
       return
     }
 
@@ -279,12 +300,24 @@ export type LlamaCppStartStatus =
 export async function startLlamaCppServer(alias?: string): Promise<LlamaCppStartStatus> {
   llamaCppStopping = false
   registerCleanupHandlers()
-  if (llamaCppStartPromise) return await llamaCppStartPromise
+  // Share an in-flight start only while it belongs to the CURRENT decision. A
+  // boot begun before a stop is now certain to reject at its pre-spawn check,
+  // so handing it to a caller who asked after the owner switched Local AI back
+  // ON would answer them with a failure from a decision that is no longer
+  // theirs — "stopped while it was starting", over a request to start.
+  if (llamaCppStartPromise && llamaCppStartGeneration === llamaCppStopGeneration) {
+    return await llamaCppStartPromise
+  }
 
-  llamaCppStartPromise = bootLlamaCppServer(alias).finally(() => {
-    llamaCppStartPromise = null
+  const generation = llamaCppStopGeneration
+  const startPromise = bootLlamaCppServer(alias).finally(() => {
+    // Only if it is still ours: a superseded boot settling later must not clear
+    // the promise that replaced it.
+    if (llamaCppStartPromise === startPromise) llamaCppStartPromise = null
   })
-  return await llamaCppStartPromise
+  llamaCppStartPromise = startPromise
+  llamaCppStartGeneration = generation
+  return await startPromise
 }
 
 async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStartStatus> {
@@ -383,6 +416,12 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
   }
 
   llamaCppChild = child
+  // A retry armed by an earlier death is stale the moment a child is running
+  // again — its job is done, by this. Deliberately NOT through
+  // endLlamaCppSupervision: that resets the backoff, and this is the crash
+  // loop's own restart path, so resetting here would flatten 5→60 s back to a
+  // flat 5 s, which is the defect this file was rewritten for.
+  cancelPendingLlamaCppRestart()
   const startedAt = uptimeClockMs()
   await llamaCpp.writeLlamaCppPid(child.pid, spec.pidPath)
   console.log(`[instrumentation] llama.cpp auto-starting ${alias} (pid=${child.pid})`)
@@ -431,8 +470,19 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
         const delayMs = llamaCppRestartDelayMs
         llamaCppRestartDelayMs = Math.min(llamaCppRestartDelayMs * 2, CHILD_RESTART_MAX_MS)
         console.log(`[instrumentation] llama.cpp exited (code=${code}), retrying in ${delayMs / 1000}s...`)
-        llamaCppRestartTimer = setTimeout(() => {
-          llamaCppRestartTimer = null
+        const timer = setTimeout(() => {
+          // Only clear the slot if it still points at THIS timer. More than one
+          // retry can be pending — two children can be alive at once, and the
+          // second death overwrites the handle — so nulling it unconditionally
+          // would orphan the newer one in turn.
+          if (llamaCppRestartTimer === timer) llamaCppRestartTimer = null
+          // The generation this retry was armed under, re-read at the moment it
+          // fires. A retry orphaned by a later death is not reachable through
+          // the handle any more, and it cannot be caught downstream either:
+          // startLlamaCppServer clears `llamaCppStopping` as its first act and
+          // the boot it starts captures the POST-stop generation. This callback
+          // is the last place the owner's "off" can still be honoured.
+          if (llamaCppStopping || stopGeneration !== llamaCppStopGeneration) return
           // Restart the SAME alias. Re-deriving it would send the crash-restart
           // back through the configuration gate, which on a Hermes device is a
           // different question from "what was just running".
@@ -440,11 +490,20 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
             console.error('[instrumentation] Failed to restart llama.cpp:', err instanceof Error ? err.message : err)
           })
         }, delayMs)
+        llamaCppRestartTimer = timer
       } catch (err) {
         console.error('[instrumentation] llama.cpp exit handling failed:', err instanceof Error ? err.message : err)
       }
     })()
   })
+
+  // One last look before reporting success. `writeLlamaCppPid` above is an
+  // await, and a stop landing inside it kills the child correctly — but this
+  // function would otherwise run on and tell its caller 'started' about a child
+  // that is already dead.
+  if (stopGeneration !== llamaCppStopGeneration) {
+    throw new Error('llama.cpp was stopped while it was starting')
+  }
 
   return 'started'
 }

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -404,7 +404,16 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
         if (llamaCppChild === child) {
           llamaCppChild = null
         }
-        await llamaCpp.clearLlamaCppPid(spec.pidPath)
+        // Only if the file still records THIS child. There is a single shared
+        // pid path (LLAMACPP_PID_PATH — it is not per-alias), so a child that
+        // took its time dying would otherwise unlink the record of the
+        // replacement that had already started, leaving a running server that
+        // nothing can identify or stop by pid. The generation check below does
+        // not cover this on its own: a plain `ensureLocalAiReady` can start the
+        // replacement with no stop in between.
+        if (await llamaCpp.readLlamaCppPid(spec.pidPath) === child.pid) {
+          await llamaCpp.clearLlamaCppPid(spec.pidPath)
+        }
         // The generation, not just the flag: that `await` above is long enough
         // for a stop to arrive AND a fresh start to clear `llamaCppStopping`
         // again, and this handler would then arm a retry for the child that was

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -133,11 +133,13 @@ export function startTerminalServer() {
   let restartDelayMs = TERMINAL_RESTART_MIN_MS
   terminalStopping = false
 
-  // Kill any leftover child from previous hot-reload
+  // Kill any leftover child from previous hot-reload. `terminalChild` is
+  // deliberately NOT cleared here: it stays the marker of "we still own a child"
+  // until that child is actually gone, so a further reload during the wait below
+  // takes this same branch instead of the probe.
   const replaced = terminalChild
   if (replaced) {
     try { replaced.kill('SIGTERM') } catch {}
-    terminalChild = null
   }
 
   if (replaced) {
@@ -151,6 +153,7 @@ export function startTerminalServer() {
     const launch = () => {
       if (launched) return
       launched = true
+      if (terminalChild === replaced) terminalChild = null
       startServer()
     }
     replaced.once('close', launch)
@@ -402,7 +405,13 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
           llamaCppChild = null
         }
         await llamaCpp.clearLlamaCppPid(spec.pidPath)
-        if (llamaCppStopping) return
+        // The generation, not just the flag: that `await` above is long enough
+        // for a stop to arrive AND a fresh start to clear `llamaCppStopping`
+        // again, and this handler would then arm a retry for the child that was
+        // deliberately stopped — a second chain, for an old alias, racing the
+        // start that just replaced it. The generation is the one thing a later
+        // start cannot un-say.
+        if (llamaCppStopping || stopGeneration !== llamaCppStopGeneration) return
 
         // Same backoff as the terminal server, and for the same reason: this
         // retry was flat 5 s with no cap, so a start script that can never

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -8,11 +8,53 @@
 import { spawn, type ChildProcess } from 'child_process'
 import path from 'path'
 import fs from 'fs'
+import { CONFIG_ROOT } from './lib/config-store'
+
+/**
+ * How long a child that keeps dying is left alone between attempts: its own
+ * floor for the first restart, doubling to a minute.
+ *
+ * The terminal server used to be a flat 2 s with no cap, so a child that could
+ * not start AT ALL — which is what a box whose npx cache had no `tsx` had —
+ * was re-spawned every two seconds for the life of the process. The causes
+ * that remain (a node-pty ABI mismatch after a kernel bump, a model file
+ * llama.cpp cannot download) fail exactly the same way, so both children here
+ * share the ceiling.
+ */
+const CHILD_RESTART_MAX_MS = 60_000
+const TERMINAL_RESTART_MIN_MS = 2_000
+const LLAMACPP_RESTART_MIN_MS = 5_000
+
+/**
+ * What scripts/terminal-server.mjs answers on GET /. The "is it already up?"
+ * probe matches on it so that only OUR server counts; the two copies of the
+ * string are pinned together by src/tests/unit/instrumentation-terminal-server.test.ts.
+ */
+const TERMINAL_SERVER_BANNER = 'ClawBox Terminal WebSocket Server'
+
+/**
+ * Milliseconds from a monotonic source, for measuring how long a child stayed
+ * up. Never `Date.now()`: these boxes boot with no RTC and step the clock the
+ * moment NTP first reaches the internet — which is the very window this
+ * backoff exists for, and a backwards step would freeze it at the ceiling
+ * while a forwards one would reset it mid-crash-loop.
+ */
+function uptimeClockMs(): number {
+  return performance.now()
+}
 
 let terminalChild: ChildProcess | null = null
 let terminalStopping = false
+/**
+ * Which call to startTerminalServer() owns the supervision loop. A second call
+ * (a dev hot-reload) kills the previous child, whose `close` would otherwise
+ * schedule a restart from the OLD closure — two chains, each with its own
+ * backoff, racing for :3006 while `terminalChild` tracks only one of them.
+ */
+let terminalGeneration = 0
 let llamaCppChild: ChildProcess | null = null
 let llamaCppStopping = false
+let llamaCppRestartDelayMs = LLAMACPP_RESTART_MIN_MS
 let llamaCppStartPromise: Promise<LlamaCppStartStatus> | null = null
 let cleanupRegistered = false
 
@@ -40,7 +82,13 @@ function registerCleanupHandlers() {
 export function startTerminalServer() {
   registerCleanupHandlers()
   const PORT = process.env.TERMINAL_WS_PORT || '3006'
-  const serverPath = path.resolve('scripts', 'terminal-server.ts')
+  // The checkout, reached the way every other server module reaches it — NOT
+  // the cwd. In production the cwd is `.next/standalone` (the Next standalone
+  // server chdirs there), and the copy of this script that lands in that tree
+  // is a build artefact that only refreshes on a full rebuild.
+  const serverPath = path.join(CONFIG_ROOT, 'scripts', 'terminal-server.mjs')
+  const generation = ++terminalGeneration
+  let restartDelayMs = TERMINAL_RESTART_MIN_MS
   terminalStopping = false
 
   // Kill any leftover child from previous hot-reload
@@ -49,69 +97,84 @@ export function startTerminalServer() {
     terminalChild = null
   }
 
-  // Check if already running externally
+  // Is it already up? Only OUR server counts: :3006 is loopback, but anything
+  // answering 200 there — a leftover from a half-killed process tree, another
+  // dev server — used to be accepted as the terminal, and the Terminal app
+  // then talked to it. The banner is what scripts/terminal-server.mjs writes
+  // for exactly this handshake.
   fetch(`http://127.0.0.1:${PORT}`)
-    .then((res) => {
-      if (res.ok) {
+    .then(async (res) => {
+      if (res.ok && (await res.text()).includes(TERMINAL_SERVER_BANNER)) {
         console.log(`[instrumentation] Terminal server already running on port ${PORT}`)
         return
       }
-      boot()
+      startServer()
     })
     .catch(() => {
       // Not running — start it
-      boot()
+      startServer()
     })
 
-  function findNpx(): string {
-    const nodeDir = path.dirname(process.execPath)
-    const candidates = [
-      path.join(nodeDir, 'npx'),
-      '/usr/local/bin/npx',
-      '/usr/bin/npx',
-    ]
-    for (const p of candidates) {
-      if (fs.existsSync(p)) return p
-    }
-    return 'npx'
+  function scheduleRestart(reason: string, ranForMs: number) {
+    // A child that ran for a while and then died is not a crash loop: the next
+    // failure starts over at the floor.
+    if (ranForMs >= CHILD_RESTART_MAX_MS) restartDelayMs = TERMINAL_RESTART_MIN_MS
+    const delayMs = restartDelayMs
+    restartDelayMs = Math.min(restartDelayMs * 2, CHILD_RESTART_MAX_MS)
+    console.log(`[instrumentation] Terminal server ${reason}, restarting in ${delayMs / 1000}s...`)
+    setTimeout(startServer, delayMs)
   }
 
-  function boot() {
-    function startServer() {
-      if (terminalStopping) return
+  function startServer() {
+    if (terminalStopping || generation !== terminalGeneration) return
 
-      const npxPath = findNpx()
-      const child = spawn(npxPath, ['tsx', serverPath], {
-        env: { ...process.env, TERMINAL_WS_PORT: PORT },
-        stdio: ['ignore', 'pipe', 'pipe'],
-        detached: false,
-      })
-      terminalChild = child
-
-      child.stdout?.on('data', (data: Buffer) => {
-        const msg = data.toString().trim()
-        if (msg) console.log(msg)
-      })
-
-      child.stderr?.on('data', (data: Buffer) => {
-        const msg = data.toString().trim()
-        if (msg) console.error(msg)
-      })
-
-      child.on('error', (err) => {
-        console.error('[instrumentation] Failed to start terminal server:', err.message)
-      })
-
-      child.on('exit', (code) => {
-        if (terminalStopping) return
-        console.log(`[instrumentation] Terminal server exited (code=${code}), restarting in 2s...`)
-        setTimeout(startServer, 2000)
-      })
-
-      console.log(`[instrumentation] Terminal server starting on port ${PORT} (pid=${child.pid})`)
+    // Checked on every attempt, not once at boot: a box that rebooted while an
+    // update was between `git reset --hard` and its rebuild has the file back
+    // as soon as the sync lands, and a permanent absence then costs one line a
+    // minute instead of a fork storm.
+    if (!fs.existsSync(serverPath)) {
+      console.error(`[instrumentation] Terminal server not started: ${serverPath} does not exist, so the Terminal app will not work. Restore it with 'sudo bash install.sh --step git_pull'; retrying meanwhile.`)
+      restartDelayMs = CHILD_RESTART_MAX_MS
+      setTimeout(startServer, CHILD_RESTART_MAX_MS)
+      return
     }
 
-    startServer()
+    const startedAt = uptimeClockMs()
+    // This same Node, running plain JS: nothing to resolve, download or
+    // transpile, so a box with no internet starts its terminal like any other.
+    const child = spawn(process.execPath, [serverPath], {
+      env: { ...process.env, TERMINAL_WS_PORT: PORT },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: false,
+    })
+    terminalChild = child
+
+    child.stdout?.on('data', (data: Buffer) => {
+      const msg = data.toString().trim()
+      if (msg) console.log(msg)
+    })
+
+    child.stderr?.on('data', (data: Buffer) => {
+      const msg = data.toString().trim()
+      if (msg) console.error(msg)
+    })
+
+    child.on('error', (err) => {
+      console.error('[instrumentation] Failed to start terminal server:', err.message)
+    })
+
+    // 'close', not 'exit'. A child that could never be created — fork(2)
+    // answering EAGAIN/ENOMEM on a Jetson that is booting llama.cpp and the
+    // desktop at the same time — emits 'error' and 'close' and NEVER 'exit',
+    // so an exit-only handler left the Terminal dead for the lifetime of the
+    // web server with a single log line. 'close' fires for both endings, and
+    // exactly once, so it needs no double-schedule guard.
+    child.on('close', (code) => {
+      if (terminalStopping || generation !== terminalGeneration) return
+      scheduleRestart(`exited (code=${code})`, uptimeClockMs() - startedAt)
+    })
+
+    console.log(`[instrumentation] Terminal server starting on port ${PORT} (pid=${child.pid})`)
   }
 }
 
@@ -228,6 +291,7 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
   }
 
   llamaCppChild = child
+  const startedAt = uptimeClockMs()
   await llamaCpp.writeLlamaCppPid(child.pid, spec.pidPath)
   console.log(`[instrumentation] llama.cpp auto-starting ${alias} (pid=${child.pid})`)
 
@@ -240,7 +304,15 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
         await llamaCpp.clearLlamaCppPid(spec.pidPath)
         if (llamaCppStopping) return
 
-        console.log(`[instrumentation] llama.cpp exited (code=${code}), retrying in 5s...`)
+        // Same backoff as the terminal server, and for the same reason: this
+        // retry was flat 5 s with no cap, so a start script that can never
+        // succeed — no internet to fetch the GGUF on a freshly flashed box, a
+        // model file deleted, a full disk — re-forked bash and a download every
+        // five seconds for ever.
+        if (uptimeClockMs() - startedAt >= CHILD_RESTART_MAX_MS) llamaCppRestartDelayMs = LLAMACPP_RESTART_MIN_MS
+        const delayMs = llamaCppRestartDelayMs
+        llamaCppRestartDelayMs = Math.min(llamaCppRestartDelayMs * 2, CHILD_RESTART_MAX_MS)
+        console.log(`[instrumentation] llama.cpp exited (code=${code}), retrying in ${delayMs / 1000}s...`)
         setTimeout(() => {
           // Restart the SAME alias. Re-deriving it would send the crash-restart
           // back through the configuration gate, which on a Hermes device is a
@@ -248,7 +320,7 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
           void startLlamaCppServer(alias).catch((err) => {
             console.error('[instrumentation] Failed to restart llama.cpp:', err instanceof Error ? err.message : err)
           })
-        }, 5000)
+        }, delayMs)
       } catch (err) {
         console.error('[instrumentation] llama.cpp exit handling failed:', err instanceof Error ? err.message : err)
       }

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -304,10 +304,16 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
   await llamaCpp.writeLlamaCppPid(child.pid, spec.pidPath)
   console.log(`[instrumentation] llama.cpp auto-starting ${alias} (pid=${child.pid})`)
 
-  // 'close' rather than 'exit', for the same reason the terminal server uses
-  // it: it is the one ending every child reaches, so the pid file is cleared
-  // and the retry scheduled exactly once however the child went away.
-  child.on('close', (code) => {
+  // 'exit', not 'close' — the opposite of the terminal server above, because
+  // the two children are supervised for different reasons. The terminal server
+  // has nobody to report to, so it must also recover a child that never
+  // spawned, and only 'close' is delivered for that. This one is demand-started
+  // by ensureLocalAiReady, which awaits it: a spawn that failed is reported to
+  // that caller by the pid check above, so there is no supervision to restore
+  // and a retry behind the caller's back would be new behaviour. Past that
+  // check the child really exists, and 'exit' is guaranteed for it — one
+  // listener, one retry per death, no double-schedule guard needed.
+  child.on('exit', (code) => {
     void (async () => {
       try {
         if (llamaCppChild === child) {

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -286,6 +286,15 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
     },
   )
 
+  // Attached BEFORE the pid check below, because a spawn that failed emits
+  // 'error' asynchronously and an 'error' event with no listener is an uncaught
+  // exception: a child that merely could not be created (fork(2) answering
+  // EAGAIN while the box boots) took the whole web server down with it. The
+  // failure itself is still reported to the caller, by the pid check.
+  child.on('error', (err) => {
+    console.error('[instrumentation] llama.cpp failed to start:', err instanceof Error ? err.message : err)
+  })
+
   if (!child.pid) {
     throw new Error('Failed to start llama.cpp')
   }
@@ -295,7 +304,10 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
   await llamaCpp.writeLlamaCppPid(child.pid, spec.pidPath)
   console.log(`[instrumentation] llama.cpp auto-starting ${alias} (pid=${child.pid})`)
 
-  child.on('exit', (code) => {
+  // 'close' rather than 'exit', for the same reason the terminal server uses
+  // it: it is the one ending every child reaches, so the pid file is cleared
+  // and the retry scheduled exactly once however the child went away.
+  child.on('close', (code) => {
     void (async () => {
       try {
         if (llamaCppChild === child) {

--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -24,6 +24,12 @@ import { CONFIG_ROOT } from './lib/config-store'
 const CHILD_RESTART_MAX_MS = 60_000
 const TERMINAL_RESTART_MIN_MS = 2_000
 const LLAMACPP_RESTART_MIN_MS = 5_000
+/**
+ * How long a replacement waits for the child it just SIGTERM'd to actually go
+ * before starting anyway. Only a dev hot-reload gets here — in production
+ * `register()` runs once per process, so there is never a child to replace.
+ */
+const TERMINAL_REPLACE_GRACE_MS = 2_000
 
 /**
  * What scripts/terminal-server.mjs answers on GET /. The "is it already up?"
@@ -65,20 +71,31 @@ let llamaCppRestartDelayMs = LLAMACPP_RESTART_MIN_MS
  * now rather than raced.
  */
 let llamaCppRestartTimer: ReturnType<typeof setTimeout> | null = null
+/**
+ * Bumped by every deliberate stop. bootLlamaCppServer takes a copy on the way
+ * in and refuses to spawn if it has moved, because cancelling a timer cannot
+ * cancel a start that has ALREADY begun: the dynamic imports, the config read
+ * and the pid probe all await, and startLlamaCppServer clears
+ * `llamaCppStopping` before any of them. Without this, an owner's "off" that
+ * lands a few hundred milliseconds behind a retry is simply overtaken by it.
+ */
+let llamaCppStopGeneration = 0
 let llamaCppStartPromise: Promise<LlamaCppStartStatus> | null = null
 let cleanupRegistered = false
 
 /**
- * The supervision chain is over: drop any armed restart and put the backoff
- * back at its floor. Deliberate stops only — a retry must NOT come through
- * here, or the delay would reset on every attempt and the crash loop would be
- * flat 5 s again, which is the defect this file was rewritten for.
+ * The supervision chain is over: cancel an armed restart, disown a start that
+ * is already in flight, and put the backoff back at its floor. Deliberate
+ * stops only — a retry must NOT come through here, or the delay would reset on
+ * every attempt and the crash loop would be flat 5 s again, which is the defect
+ * this file was rewritten for.
  */
-function endLlamaCppRestartChain() {
+function endLlamaCppSupervision() {
   if (llamaCppRestartTimer) {
     clearTimeout(llamaCppRestartTimer)
     llamaCppRestartTimer = null
   }
+  llamaCppStopGeneration++
   llamaCppRestartDelayMs = LLAMACPP_RESTART_MIN_MS
 }
 
@@ -89,7 +106,7 @@ function cleanupChildren() {
     terminalChild = null
   }
   llamaCppStopping = true
-  endLlamaCppRestartChain()
+  endLlamaCppSupervision()
   if (llamaCppChild) {
     try { llamaCppChild.kill('SIGTERM') } catch {}
     llamaCppChild = null
@@ -117,9 +134,28 @@ export function startTerminalServer() {
   terminalStopping = false
 
   // Kill any leftover child from previous hot-reload
-  if (terminalChild) {
-    try { terminalChild.kill('SIGTERM') } catch {}
+  const replaced = terminalChild
+  if (replaced) {
+    try { replaced.kill('SIGTERM') } catch {}
     terminalChild = null
+  }
+
+  if (replaced) {
+    // Replacing OUR OWN child, so the probe below must not run: a child that
+    // has been signalled but has not finished dying still answers the banner,
+    // and "already running" would then leave this generation with no child at
+    // all — the dying one's `close` is discarded as stale by the generation
+    // guard. Wait for it to go instead, and start anyway after a grace period
+    // so a child that ignores SIGTERM cannot strand the Terminal.
+    let launched = false
+    const launch = () => {
+      if (launched) return
+      launched = true
+      startServer()
+    }
+    replaced.once('close', launch)
+    setTimeout(launch, TERMINAL_REPLACE_GRACE_MS)
+    return
   }
 
   // Is it already up? Only OUR server counts: :3006 is loopback, but anything
@@ -249,6 +285,7 @@ export async function startLlamaCppServer(alias?: string): Promise<LlamaCppStart
 }
 
 async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStartStatus> {
+  const stopGeneration = llamaCppStopGeneration
   const [{ getAll }, { readConfig }, llamaCpp] = await Promise.all([
     import('./lib/config-store'),
     import('./lib/openclaw-config'),
@@ -293,6 +330,14 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
   }
 
   await llamaCpp.ensureLlamaCppRuntimeDir()
+
+  // Last look before the point of no return, and deliberately with no `await`
+  // between it and the spawn. Everything above this line yields, so a stop the
+  // owner asked for can land anywhere in it; the timer cancellation in
+  // endLlamaCppSupervision cannot reach a start that is already running.
+  if (stopGeneration !== llamaCppStopGeneration) {
+    throw new Error('llama.cpp was stopped while it was starting')
+  }
 
   const child = spawn(
     'bash',
@@ -388,7 +433,7 @@ async function bootLlamaCppServer(requestedAlias?: string): Promise<LlamaCppStar
 
 export async function stopLlamaCppServer() {
   llamaCppStopping = true
-  endLlamaCppRestartChain()
+  endLlamaCppSupervision()
 
   const llamaCpp = await import('./lib/llamacpp-server')
   const spec = llamaCpp.getLlamaCppLaunchSpec()

--- a/src/tests/unit/instrumentation-terminal-server.test.ts
+++ b/src/tests/unit/instrumentation-terminal-server.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * The boot hook starts the PTY server that backs the Terminal app.
+ *
+ * It used to start it with `npx tsx scripts/terminal-server.ts`. `tsx` is not a
+ * dependency of this project — it only ever resolved because a box had once
+ * been online and npm had left a copy in ~/.npm/_npx. On a freshly flashed box
+ * whose first boot is AP mode with no internet, `npx` cannot fetch it: the
+ * child died immediately and the exit handler re-spawned it every 2 s, for
+ * ever, with no backoff and no cap.
+ *
+ * Four separate things are pinned here:
+ *   1. the child is this same Node — `process.execPath` running a plain .mjs
+ *      out of the checkout — so there is nothing to resolve, download or
+ *      transpile at boot;
+ *   2. a child that keeps dying backs off instead of fork-storming, and one
+ *      that could never be spawned at all is still retried;
+ *   3. a missing server file is named rather than looped on;
+ *   4. the "already running?" probe accepts only our own server.
+ */
+
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+
+const REPO_ROOT = process.cwd();
+const BANNER = "ClawBox Terminal WebSocket Server";
+
+type FakeChild = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: () => void;
+  pid: number | undefined;
+};
+
+function fakeChild(pid: number | undefined): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  child.pid = pid;
+  return child;
+}
+
+describe("startTerminalServer", () => {
+  let startTerminalServer: () => void;
+  let spawnMock: ReturnType<typeof vi.fn>;
+  let logged: string[];
+
+  /** Let the ":3006 already listening?" probe settle and the child boot. */
+  async function settle() {
+    await vi.advanceTimersByTimeAsync(0);
+  }
+
+  function childFromCall(index: number): FakeChild {
+    return spawnMock.mock.results[index].value as FakeChild;
+  }
+
+  /**
+   * End a child the way Node really does — 'exit' and then 'close'. Both,
+   * deliberately: a supervisor listening to each of them would restart twice
+   * per death, so the counts below are also what pins that it does not.
+   */
+  function die(child: FakeChild, code: number) {
+    child.emit("exit", code);
+    child.emit("close", code);
+  }
+
+  /** Load the boot hook with `root` as the box's project directory. */
+  async function loadWithRoot(root: string) {
+    vi.resetModules();
+    vi.stubEnv("CLAWBOX_ROOT", root);
+    const childProcess = await import("child_process");
+    spawnMock = vi.mocked(childProcess.spawn) as unknown as ReturnType<typeof vi.fn>;
+    let pid = 1000;
+    spawnMock.mockImplementation(() => fakeChild(pid++));
+    ({ startTerminalServer } = await import("@/instrumentation-node"));
+  }
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    logged = [];
+    vi.spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+      logged.push(args.map(String).join(" "));
+    });
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+      logged.push(args.map(String).join(" "));
+    });
+    // Nothing is listening on :3006 — the boot hook must start its own child.
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("ECONNREFUSED"))));
+    await loadWithRoot(REPO_ROOT);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("runs the PTY server with this Node, not with npx/tsx", async () => {
+    startTerminalServer();
+    await settle();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [command, args] = spawnMock.mock.calls[0] as [string, string[]];
+    expect(command).toBe(process.execPath);
+    // The checkout's copy, not the build output's: in production the cwd is
+    // .next/standalone, whose scripts/ only refreshes on a full rebuild.
+    expect(args).toEqual([path.join(REPO_ROOT, "scripts", "terminal-server.mjs")]);
+    // No package manager and no transpiler anywhere in the command line: those
+    // are the parts that need a network on a box that has none.
+    expect([command, ...args].join(" ")).not.toMatch(/\bnpx\b|\btsx\b/);
+  });
+
+  it("ships the file it starts", () => {
+    // The child is `node scripts/terminal-server.mjs`; a .ts file would need a
+    // transpiler again, which is the whole defect.
+    expect(fs.existsSync(path.join(REPO_ROOT, "scripts", "terminal-server.mjs"))).toBe(true);
+    expect(fs.existsSync(path.join(REPO_ROOT, "scripts", "terminal-server.ts"))).toBe(false);
+  });
+
+  it("backs off when the child keeps dying instead of re-spawning every 2 s", async () => {
+    startTerminalServer();
+    await settle();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // First death: restart at the usual 2 s.
+    die(childFromCall(0), 1);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // Second death: 2 s must no longer be enough.
+    die(childFromCall(1), 1);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(spawnMock, "second restart still fires at 2 s — no backoff").toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+
+    // Third death: slower again, and it does still come back.
+    die(childFromCall(2), 1);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(spawnMock, "third restart still fires at 4 s — backoff is not growing").toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(spawnMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("returns to the fast restart after the child has run for a while", async () => {
+    startTerminalServer();
+    await settle();
+
+    die(childFromCall(0), 1);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // A child that stayed up is not a crash loop: the next death restarts fast.
+    await vi.advanceTimersByTimeAsync(120_000);
+    die(childFromCall(1), 0);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries a child that could not be spawned at all", async () => {
+    startTerminalServer();
+    await settle();
+
+    // fork(2) answering EAGAIN under boot memory pressure: node emits 'error'
+    // and 'close' and never 'exit', so an exit-only handler gave up for ever.
+    const child = childFromCall(0);
+    child.pid = undefined;
+    child.emit("error", new Error("spawn EAGAIN"));
+    child.emit("close", null);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(spawnMock, "a child that never started is never retried").toHaveBeenCalledTimes(2);
+  });
+
+  it("names the missing server file instead of looping on it, and heals when it returns", async () => {
+    const emptyRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-no-scripts-"));
+    try {
+      await loadWithRoot(emptyRoot);
+      startTerminalServer();
+      await settle();
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(logged.join("\n")).toContain(path.join(emptyRoot, "scripts", "terminal-server.mjs"));
+      await vi.advanceTimersByTimeAsync(59_000);
+      expect(spawnMock, "a missing file must not be retried at the 2 s cadence").not.toHaveBeenCalled();
+
+      // An update that lands the file mid-flight is picked up on the next look.
+      fs.mkdirSync(path.join(emptyRoot, "scripts"));
+      fs.writeFileSync(path.join(emptyRoot, "scripts", "terminal-server.mjs"), "");
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    } finally {
+      fs.rmSync(emptyRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("leaves a terminal server that is already listening alone", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: true, text: async () => `${BANNER}\n` })));
+    startTerminalServer();
+    await settle();
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(logged.join("\n")).toMatch(/already running/);
+  });
+
+  it("does not mistake another process on :3006 for the terminal server", async () => {
+    // The port is loopback-only, but a leftover from a half-killed process tree
+    // answering 200 used to be accepted as our PTY server — and the Terminal
+    // app then talked to it.
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: true, text: async () => "<html>nginx</html>" })));
+    startTerminalServer();
+    await settle();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("probes for the banner the server actually answers", () => {
+    // The string lives in both files and they have to agree, so pin them here
+    // rather than discovering the drift as a terminal that never starts.
+    const server = fs.readFileSync(path.join(REPO_ROOT, "scripts", "terminal-server.mjs"), "utf8");
+    const hook = fs.readFileSync(path.join(REPO_ROOT, "src", "instrumentation-node.ts"), "utf8");
+    expect(server).toContain(BANNER);
+    expect(hook).toContain(BANNER);
+  });
+});

--- a/src/tests/unit/instrumentation-terminal-server.test.ts
+++ b/src/tests/unit/instrumentation-terminal-server.test.ts
@@ -206,6 +206,34 @@ describe("startTerminalServer", () => {
     expect(spawnMock, "a child that would not die stranded the Terminal").toHaveBeenCalledTimes(2);
   });
 
+  /**
+   * And a THIRD reload landing inside that wait. If the replacement disowns the
+   * dying child, this call sees none and falls back to the probe — which the
+   * same dying child answers — while the previous generation's wait is now
+   * stale. Ownership has to outlive the SIGTERM, not the call.
+   */
+  it("keeps a reload during the grace period from being answered by the dying child", async () => {
+    startTerminalServer();
+    await settle();
+    const first = childFromCall(0);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve(BANNER),
+    })));
+    startTerminalServer();
+    await settle();
+    // A third reload, while the first child is still on its way out.
+    startTerminalServer();
+    await settle();
+
+    die(first, 0);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(spawnMock, "the newest reload started nothing").toHaveBeenCalledTimes(2);
+  });
+
   it("retries a child that could not be spawned at all", async () => {
     startTerminalServer();
     await settle();

--- a/src/tests/unit/instrumentation-terminal-server.test.ts
+++ b/src/tests/unit/instrumentation-terminal-server.test.ts
@@ -162,6 +162,50 @@ describe("startTerminalServer", () => {
     expect(spawnMock).toHaveBeenCalledTimes(3);
   });
 
+  /**
+   * A hot reload SIGTERMs the tracked child and then probes :3006. The child it
+   * just signalled has not finished dying and still answers our own banner — so
+   * believing the probe left the new generation with no child at all, while the
+   * dying one's `close` was discarded as stale. The Terminal stayed dead until
+   * the next reload.
+   */
+  it("does not mistake the child it just killed for a server already running", async () => {
+    startTerminalServer();
+    await settle();
+    const first = childFromCall(0);
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // The reload. Our own dying child answers the banner.
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve(BANNER),
+    })));
+    startTerminalServer();
+    await settle();
+
+    // It goes, as asked — its close belongs to the previous generation.
+    die(first, 0);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(spawnMock, "the hot reload left no terminal server running").toHaveBeenCalledTimes(2);
+  });
+
+  it("starts a replacement even if the child it killed never closes", async () => {
+    startTerminalServer();
+    await settle();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({
+      ok: true,
+      text: () => Promise.resolve(BANNER),
+    })));
+    startTerminalServer();
+    // The old child ignores SIGTERM and never emits 'close'.
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(spawnMock, "a child that would not die stranded the Terminal").toHaveBeenCalledTimes(2);
+  });
+
   it("retries a child that could not be spawned at all", async () => {
     startTerminalServer();
     await settle();

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -313,10 +313,10 @@ describe("llama.cpp child supervision", () => {
     const mod = await loadModule();
     expect(await mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
 
-    // Freeze childA's exit handler mid-cleanup.
+    // Freeze childA's exit handler mid-cleanup, on its first await.
     let releaseCleanup!: () => void;
-    const pendingCleanup = new Promise<void>((resolve) => { releaseCleanup = () => resolve(); });
-    llamaCppMocks.clearLlamaCppPid.mockImplementationOnce(() => pendingCleanup);
+    const pendingCleanup = new Promise<number | null>((resolve) => { releaseCleanup = () => resolve(4242); });
+    llamaCppMocks.readLlamaCppPid.mockImplementationOnce(() => pendingCleanup);
     childA.emit("exit", 143);
     await vi.advanceTimersByTimeAsync(0);
 
@@ -331,5 +331,32 @@ describe("llama.cpp child supervision", () => {
     await vi.advanceTimersByTimeAsync(CHILD_RESTART_CEILING_MS);
 
     expect(spawnMock, "the stopped child armed a chain of its own").toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * The pid path is one shared file, not one per alias, so "clear it on exit"
+   * is only safe while it still records the child that is exiting. A child that
+   * takes its time dying would otherwise unlink the record of the replacement
+   * that had already started.
+   */
+  it("does not clear a pid file that now records a different child", async () => {
+    vi.useFakeTimers();
+    const childA = emittingChild(4242);
+    spawnMock.mockReturnValue(childA);
+
+    const mod = await loadModule();
+    expect(await mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+
+    // A replacement has since started and written its own pid to that file.
+    llamaCppMocks.readLlamaCppPid.mockResolvedValue(4243);
+    llamaCppMocks.clearLlamaCppPid.mockClear();
+
+    childA.emit("exit", 143);
+    await vi.advanceTimersByTimeAsync(10);
+
+    expect(
+      llamaCppMocks.clearLlamaCppPid,
+      "the dying child unlinked the replacement's pid record",
+    ).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -191,11 +191,12 @@ describe("llama.cpp auto-start gate", () => {
 /**
  * What happens to the web server when the llama.cpp child goes wrong.
  *
- * Both of these are about the same thing: the supervisor has to hear about the
- * child through an event that is actually delivered. A `spawn` that fails
- * before a process exists emits 'error' — and an 'error' event with no listener
- * is an uncaught exception, so a child that merely could not be created used to
- * take the whole ClawBox web server down with it.
+ * A `spawn` that fails before a process exists emits 'error' — and an 'error'
+ * event with no listener is an uncaught exception, so a child that merely could
+ * not be created used to take the whole ClawBox web server down with it. The
+ * failure is still the caller's to see, not the supervisor's to retry: the
+ * second case pins that a child which really ran is respawned once per death,
+ * not once per ending event Node delivers for it.
  */
 describe("llama.cpp child supervision", () => {
   beforeEach(() => {
@@ -229,7 +230,7 @@ describe("llama.cpp child supervision", () => {
     expect(() => child.emit("error", new Error("spawn EAGAIN"))).not.toThrow();
   });
 
-  it("schedules exactly one retry however the child went away", async () => {
+  it("retries a child that ran exactly once, not once per ending event", async () => {
     vi.useFakeTimers();
     const child = emittingChild(4242);
     spawnMock.mockReturnValue(child);

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
 
 /**
  * The defect these cover: on the Hermes SKU the on-demand start gate was
@@ -27,6 +28,7 @@ const getAllMock = vi.fn();
 vi.mock("@/lib/config-store", () => ({
   getAll: (...args: unknown[]) => getAllMock(...args),
   DATA_DIR: "/tmp/clawbox-test-data",
+  CONFIG_ROOT: "/tmp/clawbox-test-root",
 }));
 
 const llamaCppMocks = {
@@ -67,6 +69,19 @@ const LAUNCH_SPEC = {
 /** A child that looks alive enough for bootLlamaCppServer to accept it. */
 function fakeChild(pid = 4242) {
   return { pid, on: vi.fn(), kill: vi.fn() };
+}
+
+type EmittingChild = EventEmitter & { pid: number | undefined; kill: () => void };
+
+/**
+ * A child that emits for real, so a missing listener fails the way Node fails:
+ * an 'error' event nobody is listening for is an uncaught exception.
+ */
+function emittingChild(pid: number | undefined): EmittingChild {
+  const child = new EventEmitter() as EmittingChild;
+  child.pid = pid;
+  child.kill = vi.fn();
+  return child;
 }
 
 async function loadModule() {
@@ -170,5 +185,66 @@ describe("llama.cpp auto-start gate", () => {
     const { startLlamaCppServer } = await loadModule();
     expect(await startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
     expect(spawnMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * What happens to the web server when the llama.cpp child goes wrong.
+ *
+ * Both of these are about the same thing: the supervisor has to hear about the
+ * child through an event that is actually delivered. A `spawn` that fails
+ * before a process exists emits 'error' — and an 'error' event with no listener
+ * is an uncaught exception, so a child that merely could not be created used to
+ * take the whole ClawBox web server down with it.
+ */
+describe("llama.cpp child supervision", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    llamaCppMocks.getLlamaCppLaunchSpec.mockReturnValue(LAUNCH_SPEC);
+    llamaCppMocks.queryLlamaCppModels.mockResolvedValue([]);
+    llamaCppMocks.readLlamaCppPid.mockResolvedValue(null);
+    llamaCppMocks.isLlamaCppPidRunning.mockReturnValue(false);
+    llamaCppMocks.clearLlamaCppPid.mockResolvedValue(undefined);
+    llamaCppMocks.ensureLlamaCppRuntimeDir.mockResolvedValue(undefined);
+    llamaCppMocks.writeLlamaCppPid.mockResolvedValue(undefined);
+    llamaCppMocks.getConfiguredLlamaCppModelAlias.mockReturnValue("gemma4-e2b-it-q4_0");
+    readConfigMock.mockResolvedValue({});
+    getAllMock.mockResolvedValue({ local_ai_configured: true, local_ai_provider: "llamacpp" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("survives a child that could not be spawned at all", async () => {
+    const child = emittingChild(undefined);
+    spawnMock.mockReturnValue(child);
+
+    const { startLlamaCppServer } = await loadModule();
+    await expect(startLlamaCppServer("gemma4-e2b-it-q4_0")).rejects.toThrow(/Failed to start llama.cpp/);
+
+    // Node delivers this after the synchronous failure the caller already saw.
+    expect(() => child.emit("error", new Error("spawn EAGAIN"))).not.toThrow();
+  });
+
+  it("schedules exactly one retry however the child went away", async () => {
+    vi.useFakeTimers();
+    const child = emittingChild(4242);
+    spawnMock.mockReturnValue(child);
+
+    const { startLlamaCppServer } = await loadModule();
+    expect(await startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // A real child emits both, in this order. A supervisor listening to each of
+    // them would restart twice for one death.
+    spawnMock.mockReturnValue(emittingChild(4243));
+    child.emit("exit", 1);
+    child.emit("close", 1);
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(spawnMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -278,4 +278,24 @@ describe("llama.cpp child supervision", () => {
 
     expect(spawnMock, "a runtime the owner stopped restarted itself anyway").toHaveBeenCalledTimes(1);
   });
+
+  /**
+   * The other half of the same race. Cancelling the timer cannot cancel a start
+   * that has already begun: the dynamic imports, the config read and the pid
+   * probe all await, and startLlamaCppServer clears `llamaCppStopping` before
+   * any of them — so an "off" landing mid-boot used to be simply overtaken.
+   */
+  it("does not spawn a runtime that was stopped while it was starting", async () => {
+    spawnMock.mockReturnValue(emittingChild(4242));
+
+    const mod = await loadModule();
+    // The owner's stop lands while boot is still awaiting its config read.
+    readConfigMock.mockImplementation(async () => {
+      await mod.stopLlamaCppServer();
+      return {};
+    });
+
+    await expect(mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).rejects.toThrow(/stopped while it was starting/);
+    expect(spawnMock, "a start the owner cancelled spawned anyway").not.toHaveBeenCalled();
+  });
 });

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -73,6 +73,9 @@ function fakeChild(pid = 4242) {
 
 type EmittingChild = EventEmitter & { pid: number | undefined; kill: () => void };
 
+/** The supervisor's restart ceiling — the longest a pending retry can be armed for. */
+const CHILD_RESTART_CEILING_MS = 60_000;
+
 /**
  * A child that emits for real, so a missing listener fails the way Node fails:
  * an 'error' event nobody is listening for is an uncaught exception.
@@ -247,5 +250,32 @@ describe("llama.cpp child supervision", () => {
     await vi.advanceTimersByTimeAsync(5000);
 
     expect(spawnMock).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * Turning Local AI off has to stay off. `llamaCppStopping` alone cannot do
+   * that: startLlamaCppServer clears it as its first act, so a restart timer
+   * that fires after the stop un-stops the very thing that stopped it. Beta's
+   * window for that was a fixed 5 s; with the backoff it reaches a minute.
+   */
+  it("a deliberate stop cancels a restart the supervisor had already armed", async () => {
+    vi.useFakeTimers();
+    const child = emittingChild(4242);
+    spawnMock.mockReturnValue(child);
+
+    const mod = await loadModule();
+    expect(await mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    // It dies, so a restart is armed...
+    spawnMock.mockReturnValue(emittingChild(4243));
+    child.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // ...and the owner switches Local AI off while it is still pending.
+    await mod.stopLlamaCppServer();
+    await vi.advanceTimersByTimeAsync(CHILD_RESTART_CEILING_MS);
+
+    expect(spawnMock, "a runtime the owner stopped restarted itself anyway").toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -359,4 +359,82 @@ describe("llama.cpp child supervision", () => {
       "the dying child unlinked the replacement's pid record",
     ).not.toHaveBeenCalled();
   });
+
+  /**
+   * The retry handle is one slot, but more than one retry can be pending: two
+   * children can be alive at once, and the second death overwrites the handle.
+   * The owner's "off" then cancels only the newest, and the orphan restarts a
+   * runtime that was switched off — the PR's own headline defect, in a
+   * two-death interleaving. The flag cannot catch it either, because
+   * startLlamaCppServer clears it as its first act.
+   */
+  it("does not let a retry orphaned by a second death survive the owner's stop", async () => {
+    vi.useFakeTimers();
+    const childA = emittingChild(4242);
+    spawnMock.mockReturnValue(childA);
+
+    const mod = await loadModule();
+    expect(await mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+
+    // A second child starts while the first is still alive.
+    const childB = emittingChild(4243);
+    spawnMock.mockReturnValue(childB);
+    expect(await mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // A dies -> arms its retry. B dies -> arms another, overwriting the handle.
+    childA.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    childB.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The owner switches Local AI off. Only the newest handle is cancellable.
+    await mod.stopLlamaCppServer();
+    spawnMock.mockReturnValue(emittingChild(4244));
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    expect(
+      spawnMock,
+      "an orphaned retry restarted a runtime the owner had switched off",
+    ).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * "Off, then straight back on." The in-flight boot is doomed by the stop, so
+   * handing it to the caller who asked AFTER the owner turned it back on
+   * answers a request to START with a failure from a decision that is not
+   * theirs — and spawns nothing.
+   */
+  it("gives a start that follows a stop its own attempt, not the stopped one's failure", async () => {
+    spawnMock.mockReturnValue(emittingChild(4242));
+    const mod = await loadModule();
+
+    // Park the first start mid-boot, on the model query — past the dynamic
+    // imports, so the boot is genuinely in flight when the stop lands.
+    let releaseQuery!: () => void;
+    let reachedQuery: boolean = false;
+    llamaCppMocks.queryLlamaCppModels.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        releaseQuery = () => resolve([]);
+        reachedQuery = true;
+      }),
+    );
+    const parked = mod.startLlamaCppServer("gemma4-e2b-it-q4_0");
+    await new Promise<void>((resolve) => {
+      const wait = () => (reachedQuery ? resolve() : setTimeout(wait, 1));
+      wait();
+    });
+
+    // Off, then straight back on, while that first boot is still parked.
+    await mod.stopLlamaCppServer();
+    const reopened = mod.startLlamaCppServer("gemma4-e2b-it-q4_0");
+
+    releaseQuery();
+    await expect(parked).rejects.toThrow(/stopped while it was starting/);
+    await expect(
+      reopened,
+      "the owner's fresh 'on' inherited the previous 'off' as a failure",
+    ).resolves.toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/tests/unit/local-ai-autostart.test.ts
+++ b/src/tests/unit/local-ai-autostart.test.ts
@@ -298,4 +298,38 @@ describe("llama.cpp child supervision", () => {
     await expect(mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).rejects.toThrow(/stopped while it was starting/);
     expect(spawnMock, "a start the owner cancelled spawned anyway").not.toHaveBeenCalled();
   });
+
+  /**
+   * A stopped child must not rearm its own chain. Its exit handler awaits the
+   * pid cleanup, and that await is long enough for a stop AND a fresh start to
+   * land — the start clears `llamaCppStopping`, so a flag-only check let the
+   * dead child schedule a retry of its old alias against the new runtime.
+   */
+  it("does not let a child that was stopped rearm its restart chain", async () => {
+    vi.useFakeTimers();
+    const childA = emittingChild(4242);
+    spawnMock.mockReturnValue(childA);
+
+    const mod = await loadModule();
+    expect(await mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+
+    // Freeze childA's exit handler mid-cleanup.
+    let releaseCleanup!: () => void;
+    const pendingCleanup = new Promise<void>((resolve) => { releaseCleanup = () => resolve(); });
+    llamaCppMocks.clearLlamaCppPid.mockImplementationOnce(() => pendingCleanup);
+    childA.emit("exit", 143);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The owner stops it, then starts it again — which clears llamaCppStopping.
+    await mod.stopLlamaCppServer();
+    spawnMock.mockReturnValue(emittingChild(4243));
+    expect(await mod.startLlamaCppServer("gemma4-e2b-it-q4_0")).toBe("started");
+    expect(spawnMock).toHaveBeenCalledTimes(2);
+
+    // Only now does childA's handler get to finish.
+    releaseCleanup();
+    await vi.advanceTimersByTimeAsync(CHILD_RESTART_CEILING_MS);
+
+    expect(spawnMock, "the stopped child armed a chain of its own").toHaveBeenCalledTimes(2);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "plugins": [{ "name": "next" }],
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts", "**/*.mts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts", "**/*.mts", "scripts/*.mjs"],
   "exclude": ["node_modules", "mcp", "code-source-code", "bench"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,6 @@
     "plugins": [{ "name": "next" }],
     "paths": { "@/*": ["./src/*"] }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts", "**/*.mts", "scripts/*.mjs"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", ".next/dev/types/**/*.ts", "**/*.mts", "scripts/terminal-server.mjs"],
   "exclude": ["node_modules", "mcp", "code-source-code", "bench"]
 }


### PR DESCRIPTION
**Finding:** PERF-06 (board TASK-626, under TASK-604) — verified on `5763ecd1`, rebased onto and re-verified on `00aea577` (#592, #594, #595 and #596 merged underneath in the meantime; no file overlap with any of them).

## Customer-visible symptom

A box whose npx cache has no `tsx` — a freshly flashed unit whose first boot is AP mode with no internet, i.e. exactly the first-boot wizard window — has no Terminal app at all, and the web server re-spawns `npm exec` every 2 seconds for the life of the process while the owner is setting the box up. On a box that *does* resolve `tsx`, every boot pays four processes and ~132 MB RSS for a 167-line WebSocket server.

## Cause

`src/instrumentation-node.ts` started the PTY server with `npx tsx scripts/terminal-server.ts`:

- `tsx` is in neither `dependencies` nor `devDependencies`; `package-lock.json` carries it only as another package's *optional* peer. It resolved at all only because the box had once been online and npm had left a copy in `~/.npm/_npx` (on the OpenClaw box that cache entry is dated 2026-08-13). `install.sh` never installs or pre-warms it.
- The exit handler was `setTimeout(startServer, 2000)`, unconditional — no backoff, no cap. A child that can never start was therefore re-spawned for ever.

## Harness first

- **The native mechanism, now used:** Node itself as the interpreter (`process.execPath`) on plain ESM. There is nothing left to resolve, download or transpile at boot — no package manager, no `tsx`, no network.
- **Reaching the checkout:** `CONFIG_ROOT` from `src/lib/config-store.ts` (`CLAWBOX_ROOT` → `/home/clawbox/clawbox` → cwd in dev), which is how `route-auth`, `mcp-token`, `local-ai-token`, `hermes-dashboard-auth` and `edition-license` already reach the box's own files, and how `network.ts` already reaches `scripts/start-ap.sh`. The old `path.resolve('scripts', …)` was cwd-relative, and in production the cwd is `.next/standalone` — so it was really running a *build artefact* copy that only refreshes on a full rebuild, and only reached that tree because `@vercel/nft` happens to fold the literal. Verified on both SKUs: `install.sh` hard-codes `PROJECT_DIR=/home/clawbox/clawbox` (the production fallback), `install-x64.sh` writes `Environment=CLAWBOX_ROOT=$PROJECT_DIR` into its unit.
- **systemd:** `config/clawbox-setup.service` already has `Restart=always` / `RestartSec=3`, but that supervises the *web server unit*. The terminal server is a child process of it, not a unit, so systemd's restart backoff and `StartLimitBurst` cannot reach it. Promoting it to its own unit was considered and rejected: `e2e-install` runs the whole stack without such a unit, `install.sh` would have to add and enable one on every existing box, and a `StartLimit` on `clawbox-setup` risks leaving a box's web UI permanently down in AP mode — the opposite of this fix. So the in-process loop stays, bounded, and the cause it existed for is gone.
- **Preflight:** with `npx`/`tsx` gone there is no external binary left to preflight — the interpreter is the process already running. What remains is "is the server file there", checked on every attempt with one clear sentence naming the path.
- **OpenClaw / Hermes:** neither owns this process. The PTY server is ClawBox's own, reached only through `production-server.js`'s `/terminal-ws` proxy; the pinned OpenClaw (`config/openclaw-target.txt`, 2026.8.1) has nothing to reuse here.

## The change

- `scripts/terminal-server.ts` → `scripts/terminal-server.mjs`, plain ESM JavaScript (git records the rename; only the type annotations, the imports and the header changed). `ws` comes in through its official ESM wrapper; `node-pty` is unchanged.
- `src/instrumentation-node.ts` — `spawn(process.execPath, [serverPath])`, `findNpx()` deleted, and the supervision around it made bounded and honest:
  - restarts back off 2 s → 60 s and start over once a child has stayed up, measured on a **monotonic** clock (`performance.now()`): these boxes step the wall clock the moment NTP first reaches the internet, which is the same window the backoff is for;
  - the restart hangs off **`close`, not `exit`** — a child that could never be created (`fork(2)` answering EAGAIN under boot pressure) emits `error` and `close` and never `exit`, and used to be given up on for ever after one log line. `close` fires for both endings and exactly once, so no double-schedule guard is needed;
  - a missing server file is named in the log and re-checked once a minute, instead of being spawned into (or given up on for good);
  - the "already running?" probe now accepts only a server that answers our own banner — anything returning 200 on `:3006` used to be taken for the terminal;
  - a second `startTerminalServer()` call retires the previous supervision chain (a generation counter) instead of racing it with its own backoff.
- **The llama.cpp child in the same file had the identical flat, uncapped retry** — every 5 s for ever against a model it may never be able to download, reachable in this same offline-first-boot scenario — and now shares the ceiling.
- `tsconfig.json` picks up `scripts/*.mjs` and the server carries `// @ts-check`, so the rename does not quietly take a file the CodeQL config calls security-critical out of the type-checker.

## RED → GREEN

RED — the new `src/tests/unit/instrumentation-terminal-server.test.ts` on unmodified `origin/beta` (re-run on `227839f7` after the rebase), 7 of 9 failing:

```
AssertionError: expected '/usr/bin/npx' to be '/usr/bin/node' // Object.is equality
 ❯ src/tests/unit/instrumentation-terminal-server.test.ts:109:21
AssertionError: expected false to be true                       (scripts/terminal-server.mjs does not exist)
 ❯ src/tests/unit/instrumentation-terminal-server.test.ts:121:83
AssertionError: second restart still fires at 2 s — no backoff: expected "vi.fn()" to be called 2 times, but got 3 times
 ❯ src/tests/unit/instrumentation-terminal-server.test.ts:138:73
AssertionError: a child that never started is never retried: expected "vi.fn()" to be called 2 times, but got 1 times
 ❯ src/tests/unit/instrumentation-terminal-server.test.ts:177:70
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times   (no preflight)
 ❯ src/tests/unit/instrumentation-terminal-server.test.ts:187:29
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times   (a stranger's 200 on :3006 accepted as ours)
 ❯ src/tests/unit/instrumentation-terminal-server.test.ts:219:23
Error: ENOENT: no such file or directory, open '.../scripts/terminal-server.mjs'
 ❯ src/tests/unit/instrumentation-terminal-server.test.ts:225:23

 Test Files  1 failed (1)
      Tests  7 failed | 2 passed (9)
```

GREEN — the full suite as CI runs it, on this branch:

```
 Test Files  644 passed (644)
      Tests  9316 passed (9316)
```

`tsc --noEmit` clean (and `--listFiles` confirms `scripts/terminal-server.mjs` is back in the program), `eslint` clean on the changed files, `check:sudoers` OK (43 grants, 0 gaps), `bun run build` equivalent (`npm run build`) succeeds and `verify-build-identity.sh` passes on the result.

Also proved outside the suite, with the real file and the real `node-pty`: `node scripts/terminal-server.mjs` listens, and a WebSocket client's `echo` round-trips through the PTY — including when started from `.next/standalone` with that as the cwd, so the CJS→ESM interop and the module resolution the rename depends on are not theoretical.

## Sibling call sites

- `src/instrumentation.ts` — the only caller of `startTerminalServer()`; unchanged signature.
- `src/instrumentation-node.ts`'s second `spawn` (llama.cpp) — confirmed it uses no npx and no transpiler, and **fixed** for the flat 5 s retry, as above.
- `production-server.js` `/terminal-ws`, `e2e-install/40-terminal.spec.ts`, `CLAUDE.md`, `.github/codeql/codeql-config.yml` — all named the `.ts` path; updated so nothing points at a file that no longer exists (the CodeQL note in particular, since `scripts/**` is deliberately *not* excluded from analysis).
- `package.json`'s `terminal-server` script — was `bun run …ts`, now `node …mjs`.
- Nothing else in the repo referenced the file: `grep -rn "terminal-server\.ts"` is empty on this branch.
- Child-process supervision, repo-wide: `src/instrumentation-node.ts` holds the only two **self-restarting** child supervisors in the tree. Every other `spawn` site (`tunnel.ts`, `child-run.ts`, `clawkeep.ts`, `hermes-cli.ts`, `openclaw-config.ts`, `system-password.ts`, `network.ts`, `auth.ts`, `whatsapp-pairing.ts`, `mcp/lib/{guard,jobs}.ts`, the `ai-models`/`vnc`/`hermes` route handlers) already registers an `'error'` listener and only settles a one-shot promise, so none can take the process down or leak a retry chain — checked, nothing to change.

## Commits two and three, after review

`9e756697` → the llama.cpp child registered only an `'exit'` listener, and a `spawn` that fails before a process exists emits `'error'` and never `'exit'`. An `'error'` event with no listener is an uncaught exception, so a child that merely could not be created took the whole web server down; the synchronous pid check reported the failure correctly and the process died anyway. The listener is now attached **before** that check. Raised independently by the review pass and by CodeRabbit, in the handler this branch already rewrites, which is why it came in rather than being deferred. RED on unmodified beta:

```
× survives a child that could not be spawned at all
AssertionError: expected [Function] to not throw an error but 'Error: spawn EAGAIN' was thrown
```

That commit also moved the llama.cpp retry from `'exit'` to `'close'`, with a comment claiming it was now scheduled "exactly once however the child went away". **That was wrong, and the third commit takes it back.** The listener is attached past `if (!child.pid) throw`, so a child that never spawned never reaches it and `'close'` buys nothing there — and it should not: `startLlamaCppServer` has exactly one external caller, `ensureLocalAiReady` (`src/lib/local-ai-runtime.ts:315`), which awaits it and surfaces the rejection, and `register()` starts only the terminal server, so there is no boot-time llama.cpp auto-start. A child that never existed has no supervision invariant to restore, and retrying it behind a request that already failed would be new behaviour — an unstoppable one, since `llamaCppChild` is assigned only past the pid check and `llamaCppStopping` is reset at the top of every `startLlamaCppServer`.

So the llama.cpp handler is back on `'exit'` (its `beta` form, where the child is known to exist and `'exit'` is guaranteed), the `'error'` listener that fixes the crash stays, and the comment now says which child is supervised for which reason. **The terminal server keeps `'close'`** — it is started at boot, has no caller to report to and no pid gate, so `'close'` really is the only ending delivered for a child that never spawned; that path is pinned by `instrumentation-terminal-server.test.ts` → "retries a child that could not be spawned at all".

## Commit four, from the second review pass

`stopLlamaCppServer` could not actually stop anything. The exit handler checked `llamaCppStopping` **before** arming the retry and then kept no handle on the timer, so nothing could call it off; `startLlamaCppServer`'s first statement clears that same flag. The owner switching Local AI off in Settings got `success: true` and a UI that said "off" — and up to a minute later the orphan timer fired, un-set the flag, and brought the runtime (and up to 3.2 GB on an 8 GB Jetson) back. The same race hits `setup-api/llamacpp/install`, which stops the runtime precisely so the model file is not in use while it is rewritten.

**Pre-existing in shape, but this PR is what made it worth hitting**: beta's window was a fixed 5 s and the new backoff stretches it to 60 s — twelve times wider — so under the "fix or explicitly clear every sibling" rule it is fixed here rather than filed. The timer is now held and cancelled wherever the chain is deliberately ended (`stopLlamaCppServer`, `cleanupChildren`), which is also the right place to put the backoff back at its floor — deliberately **not** in `startLlamaCppServer`, which the retry itself calls and would therefore flatten the delay to 5 s again, reintroducing the very defect this PR exists to remove.

RED on this branch before the fix:

```
× a deliberate stop cancels a restart the supervisor had already armed
AssertionError: a runtime the owner stopped restarted itself anyway: expected "vi.fn()" to be called 1 times, but got 2 times
```

Four smaller items from the same pass, all inside the supervision this PR rewrote:

- the "already running?" probe reads a response **body** now (to match the banner), so it gets a 2 s `AbortSignal.timeout` — something answering `200` on `:3006` and then stalling would otherwise hold the Terminal off for undici's five-minute default;
- a terminal child that never spawned is logged as `could not start`, not `exited (code=-2)` — `close` carries a negated errno there, not an exit status, and the invented code costs a triage cycle;
- the missing-file branch no longer pins `restartDelayMs` at the ceiling: the assignment was dead where it stood (the `setTimeout` uses the constant), and its only real effect was to make the first crash *after* the file returned wait 60 s instead of 2 s;
- the comment justifying `'exit'` now admits the self-retry is fire-and-forget.

## Commit five, from CodeRabbit's pass on commit four

Two more windows in the same supervision, both real, both reproduced before changing anything.

**A hot reload could leave the Terminal with no child at all.** `terminalChild.kill('SIGTERM')` only asks; the child's HTTP server is still accepting when the probe two statements later reaches `:3006`, so it answers our *own* banner, the branch returns "already running", and the new generation starts nothing — while the dying child's `close` hits the generation guard and is discarded. A replacement therefore no longer probes at all: the probe cannot answer "is there a server here that is not mine?" while a child of ours is mid-death, so it waits for that child's `close` instead, and starts anyway after a 2 s grace so a child that ignores SIGTERM cannot strand the Terminal either. **Dev-only** — `register()` runs once per process in production, so `terminalChild` is always null there and this branch never runs.

**The other half of the stop race in commit four.** Cancelling the timer cannot cancel a start that has already begun: `bootLlamaCppServer` awaits three dynamic imports, the config read, the model query, the pid probe and the runtime-dir check before it spawns, and `startLlamaCppServer` clears `llamaCppStopping` before all of them. A stop landing in that window found no timer and no child, and the spawn went ahead over the owner's "off". Every deliberate stop now bumps a generation that `bootLlamaCppServer` copies on the way in and re-reads **immediately before the spawn, with no `await` in between**, so the check and the spawn are one synchronous step. A start that lost the race throws rather than returning a status — the caller asked for the runtime and the owner cancelled it, so the caller is told.

RED on the previous head for all three new cases:

```
× does not mistake the child it just killed for a server already running
AssertionError: the hot reload left no terminal server running: expected "vi.fn()" to be called 2 times, but got 1 times

× starts a replacement even if the child it killed never closes
AssertionError: a child that would not die stranded the Terminal: expected "vi.fn()" to be called 2 times, but got 1 times

× does not spawn a runtime that was stopped while it was starting
AssertionError: promise resolved "'started'" instead of rejecting
```

## Commit six — the same race, one level deeper

CodeRabbit's pass on commit five found two more, both real, both my own previous fix taken one step further.

**The terminal replacement disowned the child it had just signalled**, so a *third* `startTerminalServer()` inside the grace period saw no owned child, fell back to the port probe, and was answered by that same dying child — while generation two's wait had gone stale. `terminalChild` now stays set until the child is actually gone, so a further reload takes the replacement branch again and the newest generation is the one that launches. Each generation keeps its own `close` listener and grace timer; the existing generation guard already makes every stale one a no-op, so ordering is not something the code has to get right.

**The llama.cpp exit handler checked only `llamaCppStopping`, and checked it *after* awaiting the pid cleanup.** That await is long enough for a stop *and* a fresh start to land, and the start clears the flag — so the child that had just been stopped armed a retry for its old alias against the runtime that had replaced it. It now also compares the stop generation captured when it was spawned, which is the one thing a later start cannot un-say. No new state: `bootLlamaCppServer` already captures that generation for its pre-spawn check, and the handler closes over the same value.

RED on the previous head:

```
× keeps a reload during the grace period from being answered by the dying child
AssertionError: the newest reload started nothing: expected "vi.fn()" to be called 2 times, but got 1 times

× does not let a child that was stopped rearm its restart chain
AssertionError: the stopped child armed a chain of its own: expected "vi.fn()" to be called 2 times, but got 3 times
```

## Commit seven — the pid file is shared, so clearing it needs an owner check

`llamacpp-server.ts:15` defines a single `LLAMACPP_PID_PATH` (`<runtime dir>/server.pid`) and hands it to every alias — there is no per-alias pid file — and `clearLlamaCppPid()` is a bare `fs.unlink`. The exit handler called it unconditionally, before deciding whether this child was still the owner, so a child that took its time dying could remove the record of the replacement that had already started: llama.cpp running, `readLlamaCppPid` returning null, `stopLlamaCppServer` with no pid to signal once `llamaCppChild` is gone, and the next boot's "already starting?" check blind to it.

The generation check from commit six does not cover this: it only moves when a deliberate stop happens, and a plain `ensureLocalAiReady` starts a replacement with no stop in between. The handler now reads the file first and unlinks only while it still holds this child's pid. That is a compare-and-delete rather than an atomic one — the residual window is two local FS calls, against the previous window which spanned an entire `bootLlamaCppServer`.

```
× does not clear a pid file that now records a different child
AssertionError: the dying child unlinked the replacement's pid record: expected "vi.fn()" to not be called at all, but actually been called 1 times
```

## Commit eight — the final review pass

A pre-merge Opus review of `9556c012` returned **SEND BACK**: 1 HIGH, 2 MEDIUM, 4 LOW, 3 NIT, with the core fix, the pid guard, the terminal side and all twelve earlier RED tests independently verified. Two of them re-opened defects this PR exists to close.

**HIGH — a pending retry orphaned by a second death survives the owner's "off".** The retry handle is a single slot, but more than one retry can be pending: two children can be alive at once, and the second death overwrites the handle. `stopLlamaCppServer` then cancelled only the newest, answered `success: true`, and the orphan restarted the runtime a minute later. The reviewer measured it: **spawns at OFF = 2, after 120 s of OFF = 3.** The flag could not catch it either — the callback calls `startLlamaCppServer`, which clears `llamaCppStopping` as its first act and whose boot captures the *post*-stop generation. The callback now re-reads the generation it was armed under (which a later start cannot un-say) and clears the slot only if it still points at itself. A retry is also cancelled outright once a child is running again — through a helper that deliberately does **not** touch the backoff, because that path *is* the crash loop's own restart and resetting there would flatten 5→60 s back to a flat 5 s.

**MEDIUM — "off then straight back on" answered the owner's "on" with the "off"'s failure.** `startLlamaCppServer` shared the in-flight boot without checking it belonged to the current decision. Once the generation gate landed, that boot is certain to reject, so the new request inherited `llama.cpp was stopped while it was starting` and **0 spawns** — a false failure this PR introduced. The in-flight promise is now stamped with its generation and shared only while it matches, and its `finally` clears the slot only if it is still its own.

Also applied from the same pass: `bootLlamaCppServer` re-checks the generation before reporting `'started'`, so a stop landing inside `writeLlamaCppPid` is not reported as a successful start (L1); `tsconfig.json` names `scripts/terminal-server.mjs` instead of globbing all seven `scripts/*.mjs` into the program, since only that one is `@ts-check`'d and `next build` type-checks with this config (L3); the missing-file recheck gets its own constant instead of borrowing the backoff ceiling's meaning; and the terminal backoff's per-call scope is explained against the llama.cpp sibling's deliberate opposite.

RED on the previous head, matching the reviewer's measurements exactly:

```
× does not let a retry orphaned by a second death survive the owner's stop
AssertionError: an orphaned retry restarted a runtime the owner had switched off: expected "vi.fn()" to be called 2 times, but got 3 times

× gives a start that follows a stop its own attempt, not the stopped one's failure
AssertionError: promise rejected "Error: llama.cpp was stopped while it was…" instead of resolving
```

Two LOWs were **not** taken, deliberately. L2 (the "already running" probe branch leaves the terminal unsupervised) would mean supervising a process we never spawned and hold no handle on — pre-existing, and a different design question. L4 (`bootLlamaCppServer` reports `'started'` for alias B when alias A holds the shared pid) needs alias-aware pid records — pre-existing, wider than this PR. Both are filed on the board with M2.

## The shape all seven had in common

Every defect fixed after the original `tsx` finding is the same one: **a flag or a handle read on one side of an `await` or a signal, and treated as still true on the other.** The npx respawn loop, the missing `'error'` listener, the un-cancellable restart timer, the start that outran its own stop, the reload answered by the child it had just killed, the stopped child rearming its chain, and the shared pid file unlinked by its previous owner. The remedy each time was to carry something the later actor cannot un-say — a generation, or the identity of the thing being replaced — rather than a boolean anyone can reset. That is the *probe-once* class in the repo's own vocabulary, and this file now has it guarded at every point where an ending crosses an await.

## Found on the way — filed, not fixed here

`src/lib/llamacpp-server.ts:116` resolves `scripts/start-llamacpp.sh` from `process.cwd()`, which the final review confirmed is `.next/standalone` in production (Next 16.3.3's standalone entry does `process.chdir(__dirname)`; nothing copies `scripts/` into that tree and nothing chdirs back). It is the same defect class this PR fixes for the terminal server, one file over — and this PR *masks* it further, since the flat 5 s retry that made it loud is now a 60 s backoff. The fix is the identical one-liner (`path.join(CONFIG_ROOT, …)`), but it belongs to the llama.cpp launcher and needs its own test and a device check, so it is **on the board** rather than in this PR.

Two pre-existing issues in the same file are filed with it: the terminal's "already running" probe branch returns without supervising the server it found (adopting a process we never spawned is a different design question), and `bootLlamaCppServer` reports `'started'` for alias B when alias A holds the shared pid file (needs alias-aware pid records).

## Not covered here

No device leg — this was fixed from the checkout with no box touched. `e2e-install` is the closest proof and exercises the whole path: it runs `install.sh`, a real `next build`, and `40-terminal.spec.ts`, which opens `/terminal-ws` and round-trips a command through the real PTY in the container. It ran green on two earlier heads (18m14s, then 19m50s on `eec949dc` — a full nine-check green), but commits have landed since each time, so those results do not carry over. It must be green on the final head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal server startup and recovery after crashes, launch errors, or missing files.
  * Added safeguards to detect existing servers and conflicting processes.
  * Improved restart handling for long-running model services and prevented duplicate retries.

* **Refactor**
  * The terminal server now runs directly as a JavaScript module using Node.js.

* **Tests**
  * Expanded coverage for startup, recovery, process detection, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
