### PR TITLE
fix: stop /whatsapp/status paying a CLI cold start per poll

### DIFF
--- a/src/app/setup-api/discord/configure/route.ts
+++ b/src/app/setup-api/discord/configure/route.ts
@@ -21,6 +21,7 @@ import {
   type ChannelPluginFailure,
   type ChannelStatus,
   ensureChannelPlugin,
+  invalidateChannelStatus,
   waitForChannelConnected,
 } from "@/lib/openclaw-channels";
 import {
@@ -417,6 +418,14 @@ export async function POST(request: Request) {
         attempts: CHANNEL_VERIFY_ATTEMPTS,
         delayMs: CHANNEL_VERIFY_DELAY_MS,
       });
+    }
+    if (harness !== "hermes") {
+      // The token, the plugin and the gateway all changed above, so anything the
+      // status memo holds about this channel — including a poll that ran while
+      // the gateway was restarting — describes the box as it was before the
+      // save. Drop it here, at the end, because the panel refreshes the card the
+      // moment this response lands.
+      invalidateChannelStatus(DISCORD_CHANNEL_ID);
     }
 
     // Root cause first: a plugin that never installed explains every state

--- a/src/app/setup-api/discord/status/route.ts
+++ b/src/app/setup-api/discord/status/route.ts
@@ -17,7 +17,7 @@ import {
   readHermesDiscordAccess,
   readHermesGatewaySnapshot,
 } from "@/lib/hermes-discord";
-import { type ChannelStatus, readChannelStatus } from "@/lib/openclaw-channels";
+import { type ChannelStatus, readCachedChannelStatus } from "@/lib/openclaw-channels";
 
 export const dynamic = "force-dynamic";
 
@@ -112,35 +112,6 @@ async function fetchBotProbe(token: string): Promise<BotProbe> {
     inFlightFetch.delete(token);
   });
   inFlightFetch.set(token, pending);
-  return pending;
-}
-
-// ── OpenClaw: one CLI cold start, shared ────────────────────────────────────
-//
-// `openclaw channels status` is a full CLI invocation plus a gateway round trip
-// — ~10-12 s on a Jetson before the gateway even answers. The Settings panel
-// polls this route, so the probe is cached and concurrent callers share one
-// in-flight call, exactly like the Hermes probe below. Failures are cached too:
-// the slower the CLI gets, the more often the panel would otherwise pay for the
-// call it had just given up on.
-const CHANNEL_PROBE_TTL = 15_000;
-let cachedChannel: { value: ChannelStatus | null; at: number } | null = null;
-let inFlightChannel: Promise<ChannelStatus | null> | null = null;
-
-function probeChannel(): Promise<ChannelStatus | null> {
-  if (cachedChannel && Date.now() - cachedChannel.at < CHANNEL_PROBE_TTL) {
-    return Promise.resolve(cachedChannel.value);
-  }
-  if (inFlightChannel) return inFlightChannel;
-  const pending = readChannelStatus(DISCORD_CHANNEL_ID)
-    .then((value) => {
-      cachedChannel = { value, at: Date.now() };
-      return value;
-    })
-    .finally(() => {
-      inFlightChannel = null;
-    });
-  inFlightChannel = pending;
   return pending;
 }
 
@@ -253,7 +224,12 @@ export async function GET() {
     // `tokenStatus` and `lastError`, which is exactly the vocabulary the Hermes
     // branch above maps. So the card was blank on a box whose bot was
     // answering in Discord.
-    const channel = await probeChannel();
+    // Through the shared memo in openclaw-channels: one CLI cold start per
+    // channel per window, concurrent callers coalesced, failures remembered
+    // too. This route used to hold a private copy of that cache — which is why
+    // /whatsapp/status, reading the same command with no memo at all, cost 3.6 s
+    // a poll where this one cost 20 ms.
+    const channel = await readCachedChannelStatus(DISCORD_CHANNEL_ID);
     // `null` = the gateway could not be asked (CLI timeout, gateway restarting,
     // no openclaw binary). UNKNOWN, which the panel renders as its neutral
     // state — never "offline", which would accuse a healthy bot, and never
@@ -278,7 +254,7 @@ export async function GET() {
       // gateway's account row carries no bot identity unless `channels status`
       // is given `--probe`, and that probe is itself a call to Discord — so on
       // a device that cannot reach Discord there is no second opinion to fall
-      // back to. See readChannelStatus() for why we do not pay for `--probe`.
+      // back to. See readChannelRow() for why we do not pay for `--probe`.
       username: bot.info?.displayName,
       botId: bot.info?.id,
     });

--- a/src/app/setup-api/whatsapp/configure/route.ts
+++ b/src/app/setup-api/whatsapp/configure/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { getActiveHarness } from "@/lib/harness";
 import { ensureHermesGateway } from "@/lib/hermes-telegram";
-import { ensureChannelPlugin, waitForChannelConnected } from "@/lib/openclaw-channels";
+import {
+  ensureChannelPlugin,
+  invalidateChannelStatus,
+  waitForChannelConnected,
+} from "@/lib/openclaw-channels";
 import { restartGateway } from "@/lib/openclaw-config";
 import {
   WHATSAPP_CHANNEL_ID,
@@ -80,6 +84,10 @@ async function configureOpenclaw(body: ConfigureBody): Promise<NextResponse> {
   if (!body.enabled) {
     await setOpenclawWhatsappEnabled(false);
     const stopped = await applyRestart();
+    // The restart is what actually stops the channel; the config write before it
+    // already dropped the memo, and this drops what a poll during the restart
+    // may have put back.
+    invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
     return NextResponse.json({
       success: true,
       restarted: stopped,
@@ -109,6 +117,12 @@ async function configureOpenclaw(body: ConfigureBody): Promise<NextResponse> {
   const restarted = await applyRestart();
 
   const live = restarted ? await waitForChannelConnected(WHATSAPP_CHANNEL_ID) : null;
+
+  // Same reason as the disable branch above, and as /discord/configure: the
+  // plugin install, the config write and the restart have all landed, so a
+  // remembered row — including one a concurrent poll took while the gateway was
+  // coming back — describes the box as it was before this save.
+  invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
 
   // Root cause first, exactly as on the Discord route. The plugin failures are
   // already returned above, so what remains is the gateway's own verdict.

--- a/src/app/setup-api/whatsapp/unpair/route.ts
+++ b/src/app/setup-api/whatsapp/unpair/route.ts
@@ -2,8 +2,10 @@ import { NextResponse } from "next/server";
 import { getActiveHarness } from "@/lib/harness";
 import { whatsappSessionDirs } from "@/lib/hermes-whatsapp";
 import { unpairWhatsapp } from "@/lib/whatsapp-pairing";
+import { invalidateChannelStatus } from "@/lib/openclaw-channels";
 import { restartGateway } from "@/lib/openclaw-config";
 import {
+  WHATSAPP_CHANNEL_ID,
   getOpenclawWhatsappPairing,
   logoutOpenclawWhatsapp,
   setOpenclawWhatsappEnabled,
@@ -55,6 +57,10 @@ export async function POST() {
       await restartGateway().catch((err) => {
         console.error("[whatsapp/unpair] gateway restart failed:", err);
       });
+      // The config write and the logout each dropped the status memo already;
+      // this drops what a poll taken while the gateway was restarting may have
+      // put back, so the panel's post-unpair refresh reads the box as it is now.
+      invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
       if (logoutError) throw logoutError;
       console.info("[whatsapp/unpair] logged out and disabled the channel");
       return NextResponse.json({ success: true });

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -346,13 +346,39 @@ export async function readChannelStatus(
  */
 export async function readChannelRow(
   channelId: string,
+  options: Omit<SpawnOpenclawOptions, "captureStdout"> = {},
+): Promise<Record<string, unknown> | null> {
+  return (await readChannelRowResult(channelId, options)).row;
+}
+
+/**
+ * What {@link readChannelRow} learned, with "could not ask the gateway" kept
+ * apart from "asked, and there is no row".
+ *
+ * Both are a `null` row, and to every caller that only wants the row they are
+ * the same thing. The memo is the one place they are NOT: an absent channel is
+ * a real, stable answer that stands for a full window, while an unreachable
+ * gateway must be re-asked soon. Collapsing them made a box whose WhatsApp was
+ * never set up — the common case — re-spawn the CLI five times as often as one
+ * where it is configured, which is the opposite of the point.
+ */
+interface ChannelRowResult {
+  /** False only when the gateway could not be asked, or its output not read. */
+  answered: boolean;
+  row: Record<string, unknown> | null;
+}
+
+async function readChannelRowResult(
+  channelId: string,
   // `captureStdout` is deliberately not offerable: this function's whole job is
   // to parse the CLI's `--json`, and a caller that turned stdout off would get
   // an empty string and a silent `null` — "the gateway said nothing" — for a
   // channel that is perfectly healthy.
   options: Omit<SpawnOpenclawOptions, "captureStdout"> = {},
-): Promise<Record<string, unknown> | null> {
-  if (openclawIsAbsent()) return null;
+): Promise<ChannelRowResult> {
+  // No CLI to ask on a Hermes box. Not an answer: the edition is read per call,
+  // so this must not be remembered as one.
+  if (openclawIsAbsent()) return { answered: false, row: null };
   let parsed: unknown;
   try {
     const out = await spawnOpenclawCli(
@@ -375,10 +401,13 @@ export async function readChannelRow(
       `[openclaw-channels] could not read ${channelId} status:`,
       err instanceof Error ? err.message : err,
     );
-    return null;
+    return { answered: false, row: null };
   }
 
-  if (!parsed || typeof parsed !== "object") return null;
+  // The CLI exited fine but what came back is not a payload — the same class of
+  // "could not read the gateway" as a spawn failure, not an answer about the
+  // channel.
+  if (!parsed || typeof parsed !== "object") return { answered: false, row: null };
   const payload = parsed as {
     channelAccounts?: Record<string, unknown>;
     channels?: Record<string, unknown>;
@@ -390,13 +419,19 @@ export async function readChannelRow(
   const accounts = payload.channelAccounts?.[channelId];
   if (Array.isArray(accounts) && accounts.length > 0) {
     const first = accounts[0];
-    if (first && typeof first === "object") return first as Record<string, unknown>;
+    if (first && typeof first === "object") {
+      return { answered: true, row: first as Record<string, unknown> };
+    }
   }
 
   const channel = payload.channels?.[channelId];
-  if (channel && typeof channel === "object") return channel as Record<string, unknown>;
+  if (channel && typeof channel === "object") {
+    return { answered: true, row: channel as Record<string, unknown> };
+  }
 
-  return null;
+  // The gateway answered and this channel is simply not in the payload — it was
+  // never set up. A real answer, and it stands for a full window.
+  return { answered: true, row: null };
 }
 
 // ── One memo for `channels status`, shared by every channel ─────────────────
@@ -415,7 +450,10 @@ export async function readChannelRow(
 // is why one panel answered in 20 ms and the other in three and a half seconds
 // from the same command.
 
-/** How long one gateway ANSWER about a channel stands. */
+/**
+ * How long one gateway ANSWER about a channel stands — including the answer
+ * "there is no such channel here", which is what an un-set-up channel gets.
+ */
 const CHANNEL_STATUS_TTL_MS = 15_000;
 /**
  * How long a FAILED read stands — "the gateway could not be asked".
@@ -428,11 +466,16 @@ const CHANNEL_STATUS_TTL_MS = 15_000;
  * A few seconds is still enough to stop a wedged CLI being re-entered per poll,
  * which is the only thing negative caching is for. The same success/failure
  * split the Discord and Telegram bot-info caches use.
+ *
+ * This is keyed on {@link ChannelRowResult.answered}, NOT on the row being
+ * `null`: the two produce the same `null` row and only one of them is a failure.
  */
 const CHANNEL_STATUS_FAILURE_TTL_MS = 3_000;
 
 interface CachedRow {
   row: Record<string, unknown> | null;
+  /** See {@link ChannelRowResult} — picks which of the two TTLs applies. */
+  answered: boolean;
   at: number;
 }
 interface InFlightRow {
@@ -464,7 +507,7 @@ export function readCachedChannelRow(channelId: string): Promise<Record<string, 
   const cached = cachedRows.get(channelId);
   if (cached) {
     const age = Date.now() - cached.at;
-    const ttl = cached.row ? CHANNEL_STATUS_TTL_MS : CHANNEL_STATUS_FAILURE_TTL_MS;
+    const ttl = cached.answered ? CHANNEL_STATUS_TTL_MS : CHANNEL_STATUS_FAILURE_TTL_MS;
     // `age >= 0` because the clock is wall-clock: a Jetson whose RTC is corrected
     // BACKWARDS by NTP would otherwise pin the entry until the clock caught up.
     if (age >= 0 && age < ttl) return Promise.resolve(cached.row);
@@ -476,12 +519,12 @@ export function readCachedChannelRow(channelId: string): Promise<Record<string, 
   const existing = inFlightRows.get(channelId);
   if (existing && existing.epoch === epoch) return existing.promise;
 
-  const promise = readChannelRow(channelId)
-    .then((row) => {
+  const promise = readChannelRowResult(channelId)
+    .then(({ answered, row }) => {
       // Same rule for storing: an invalidation that landed while this was in
       // flight means the answer predates the change that caused it.
       if ((epochs.get(channelId) ?? 0) === epoch) {
-        cachedRows.set(channelId, { row, at: Date.now() });
+        cachedRows.set(channelId, { row, answered, at: Date.now() });
       }
       return row;
     })

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -399,6 +399,123 @@ export async function readChannelRow(
   return null;
 }
 
+// ── One memo for `channels status`, shared by every channel ─────────────────
+//
+// A status read is a full CLI cold start plus a gateway round trip — 3.2-3.6 s
+// on a Jetson — and the status routes are re-read on every entry into a
+// Settings section, after every save and unpair, and at pairing success; on a
+// phone, where the panel's `!isMobile` escapes never return early, ONE section
+// change re-reads every channel. OpenClaw has nowhere cheaper to ask:
+// `channels status` IS the gateway's own status surface, `openclaw gateway
+// call` pays the identical CLI start-up, and the gateway's only non-WebSocket
+// endpoints are the `/healthz`, `/readyz` and `/startupz` liveness probes, none
+// of which carries a channel row. So the memo belongs on this side of the CLI —
+// and there is exactly ONE of it, here, rather than a private copy per route:
+// /discord/status grew the first one and /whatsapp/status never got it, which
+// is why one panel answered in 20 ms and the other in three and a half seconds
+// from the same command.
+
+/** How long one gateway ANSWER about a channel stands. */
+const CHANNEL_STATUS_TTL_MS = 15_000;
+/**
+ * How long a FAILED read stands — "the gateway could not be asked".
+ *
+ * Short, and much shorter than an answer, because the two are not equally true:
+ * `readOpenclawWhatsappStatus` turns a `null` row into `state:"not_configured"`,
+ * which the panel draws as an actionable "Not configured" card with a pairing
+ * CTA. Pinning that for 15 s after a gateway restart would report a paired,
+ * connected box as unconfigured for a quarter of a minute — a false failure.
+ * A few seconds is still enough to stop a wedged CLI being re-entered per poll,
+ * which is the only thing negative caching is for. The same success/failure
+ * split the Discord and Telegram bot-info caches use.
+ */
+const CHANNEL_STATUS_FAILURE_TTL_MS = 3_000;
+
+interface CachedRow {
+  row: Record<string, unknown> | null;
+  at: number;
+}
+interface InFlightRow {
+  /** The channel's invalidation count when this read started. */
+  epoch: number;
+  promise: Promise<Record<string, unknown> | null>;
+}
+
+const cachedRows = new Map<string, CachedRow>();
+const inFlightRows = new Map<string, InFlightRow>();
+/** Per channel, so one channel's mutation never discards another's fresh read. */
+const epochs = new Map<string, number>();
+
+/**
+ * {@link readChannelRow}, but at most one CLI start per channel per window, with
+ * concurrent callers sharing the one in flight. This is what a status route
+ * should call; {@link readChannelRow} stays the uncached "ask right now" read
+ * that {@link waitForChannelConnected} polls a transition with.
+ *
+ * The returned row is SHARED with every other caller in the window — read it,
+ * never mutate it.
+ *
+ * Every path that CHANGES a channel must call {@link invalidateChannelStatus},
+ * or a poll can keep serving a "not paired" that the owner's scan has already
+ * disproved.
+ */
+export function readCachedChannelRow(channelId: string): Promise<Record<string, unknown> | null> {
+  const epoch = epochs.get(channelId) ?? 0;
+  const cached = cachedRows.get(channelId);
+  if (cached) {
+    const age = Date.now() - cached.at;
+    const ttl = cached.row ? CHANNEL_STATUS_TTL_MS : CHANNEL_STATUS_FAILURE_TTL_MS;
+    // `age >= 0` because the clock is wall-clock: a Jetson whose RTC is corrected
+    // BACKWARDS by NTP would otherwise pin the entry until the clock caught up.
+    if (age >= 0 && age < ttl) return Promise.resolve(cached.row);
+  }
+  // Join a read in flight — but only one started since the last invalidation.
+  // An older one is answering a question the owner has already changed the
+  // answer to: it is what would hand a poll made AFTER the QR was scanned the
+  // "not linked" row that a read started before it is about to return.
+  const existing = inFlightRows.get(channelId);
+  if (existing && existing.epoch === epoch) return existing.promise;
+
+  const promise = readChannelRow(channelId)
+    .then((row) => {
+      // Same rule for storing: an invalidation that landed while this was in
+      // flight means the answer predates the change that caused it.
+      if ((epochs.get(channelId) ?? 0) === epoch) {
+        cachedRows.set(channelId, { row, at: Date.now() });
+      }
+      return row;
+    })
+    .finally(() => {
+      // Only ever clear our OWN entry: an abandoned read must not evict the
+      // replacement that an invalidation started, or the next caller pays for a
+      // third CLI start.
+      if (inFlightRows.get(channelId)?.epoch === epoch) inFlightRows.delete(channelId);
+    });
+  inFlightRows.set(channelId, { epoch, promise });
+  return promise;
+}
+
+/** {@link readChannelStatus} over {@link readCachedChannelRow}. */
+export async function readCachedChannelStatus(channelId: string): Promise<ChannelStatus | null> {
+  const row = await readCachedChannelRow(channelId);
+  return row ? parseChannelRow(row) : null;
+}
+
+/**
+ * Forget what the gateway said about `channelId`, including a read still in
+ * flight.
+ *
+ * Called from every path that CHANGES a channel: enabling or disabling it,
+ * dropping its session, completing a pairing, and the gateway restart at the end
+ * of a save. Without this the memo is a probe-once answer with a 15 s fuse, and
+ * the owner watches the panel insist the phone is unpaired for a quarter of a
+ * minute after the scan that paired it.
+ */
+export function invalidateChannelStatus(channelId: string): void {
+  epochs.set(channelId, (epochs.get(channelId) ?? 0) + 1);
+  cachedRows.delete(channelId);
+}
+
 export interface WaitForChannelOptions {
   /** Status probes to make. Each one costs a full CLI cold start. */
   attempts?: number;

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -406,8 +406,17 @@ async function readChannelRowResult(
 
   // The CLI exited fine but what came back is not a payload — the same class of
   // "could not read the gateway" as a spawn failure, not an answer about the
-  // channel.
-  if (!parsed || typeof parsed !== "object") return { answered: false, row: null };
+  // channel. `Array.isArray` is not redundant: `typeof [] === "object"`, so a
+  // JSON array would otherwise walk on, find no channel in it, and be filed as
+  // the gateway ANSWERING that this channel does not exist — for 15 s.
+  //
+  // The check stops here on purpose. Demanding a `channelAccounts` or
+  // `channels` key would be the same mistake inverted: a gateway with nothing
+  // configured is entitled to answer `{}`, and calling that a failed read would
+  // put exactly the box this change is for back on the 3 s window.
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { answered: false, row: null };
+  }
   const payload = parsed as {
     channelAccounts?: Record<string, unknown>;
     channels?: Record<string, unknown>;

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -34,7 +34,7 @@
 // env-backed credential here and nothing for envSecretRef() to mint.
 
 import { spawnOpenclawCli } from "@/lib/openclaw-config";
-import { readChannelRow } from "@/lib/openclaw-channels";
+import { invalidateChannelStatus, readCachedChannelRow } from "@/lib/openclaw-channels";
 
 /** OpenClaw's id for this channel — the plugin's, the config key's, the CLI's. */
 export const WHATSAPP_CHANNEL_ID = "whatsapp";
@@ -281,6 +281,10 @@ export class OpenclawWhatsappPairing {
   /** Fold one RPC answer into the snapshot. */
   private apply(result: WebLoginResult): void {
     if (result.connected === true) {
+      // THE pairing event. Until this instant the gateway's row said "not
+      // linked", and a status poll one second later would otherwise repeat it
+      // for the rest of the window while the owner looks at a paired phone.
+      invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
       this.snap = {
         ...this.snap,
         phase: "paired",
@@ -398,9 +402,14 @@ export interface OpenclawWhatsappStatus {
  * business and reading it would be this repo guessing at another project's
  * internals. `configured` in that row means "there is an account the gateway
  * can act as", which is exactly the question.
+ *
+ * Read through the shared memo, because the panel POLLS this: the row costs a
+ * CLI cold start, and every path in this file that changes the channel drops
+ * the memo, so a poll can never repeat an answer the owner has already
+ * overtaken.
  */
 export async function readOpenclawWhatsappStatus(): Promise<OpenclawWhatsappStatus> {
-  const row = await readChannelRow(WHATSAPP_CHANNEL_ID);
+  const row = await readCachedChannelRow(WHATSAPP_CHANNEL_ID);
   if (!row) {
     // Unknown, not "off". Reported as not_configured because that is the only
     // honest thing the panel can offer an action for, and the status card's
@@ -451,6 +460,9 @@ export async function setOpenclawWhatsappEnabled(enabled: boolean): Promise<void
   await spawnOpenclawCli(["config", "set", "channels.whatsapp.enabled", String(enabled), "--json"], {
     timeoutMs: 45_000,
   });
+  // `enabled` is half of what the status reads, so a remembered row is now a
+  // statement about the config as it was before this call.
+  invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
 }
 
 /**
@@ -465,4 +477,6 @@ export async function logoutOpenclawWhatsapp(): Promise<void> {
   await spawnOpenclawCli(["channels", "logout", "--channel", WHATSAPP_CHANNEL_ID], {
     timeoutMs: 60_000,
   });
+  // The session this answered "linked" about is gone.
+  invalidateChannelStatus(WHATSAPP_CHANNEL_ID);
 }

--- a/src/tests/routes/discord/configure-openclaw-plugin.test.ts
+++ b/src/tests/routes/discord/configure-openclaw-plugin.test.ts
@@ -33,6 +33,7 @@ vi.mock("@/lib/openclaw-config", async () => {
 });
 vi.mock("@/lib/openclaw-channels", () => ({
   ensureChannelPlugin: vi.fn(),
+  invalidateChannelStatus: vi.fn(),
   waitForChannelConnected: vi.fn(),
 }));
 vi.mock("@/lib/hermes-discord", async () => {

--- a/src/tests/routes/discord/configure.test.ts
+++ b/src/tests/routes/discord/configure.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/openclaw-config", () => ({
 // what they were about.
 vi.mock("@/lib/openclaw-channels", () => ({
   ensureChannelPlugin: vi.fn(),
+  invalidateChannelStatus: vi.fn(),
   waitForChannelConnected: vi.fn(),
 }));
 vi.mock("@/lib/hermes-discord", async () => {

--- a/src/tests/routes/discord/status-openclaw-state.test.ts
+++ b/src/tests/routes/discord/status-openclaw-state.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/config-store", () => ({ get: vi.fn() }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
-vi.mock("@/lib/openclaw-channels", () => ({ readChannelStatus: vi.fn() }));
+vi.mock("@/lib/openclaw-channels", () => ({ readCachedChannelStatus: vi.fn() }));
 vi.mock("@/lib/hermes-discord", async () => {
   const actual = await vi.importActual<typeof import("@/lib/hermes-discord")>("@/lib/hermes-discord");
   return {
@@ -39,11 +39,11 @@ vi.mock("@/lib/hermes-discord", async () => {
 
 import { get } from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
-import { readChannelStatus } from "@/lib/openclaw-channels";
+import { readCachedChannelStatus } from "@/lib/openclaw-channels";
 
 const mockGet = vi.mocked(get);
 const mockHarness = vi.mocked(getActiveHarness);
-const mockChannel = vi.mocked(readChannelStatus);
+const mockChannel = vi.mocked(readCachedChannelStatus);
 
 const TOKEN = "clawbox-test-not-a-real-discord-bot-token-000000";
 
@@ -54,7 +54,7 @@ function botResponse() {
   });
 }
 
-function row(over: Partial<NonNullable<Awaited<ReturnType<typeof readChannelStatus>>>> = {}) {
+function row(over: Partial<NonNullable<Awaited<ReturnType<typeof readCachedChannelStatus>>>> = {}) {
   return {
     configured: true,
     running: true,

--- a/src/tests/routes/discord/status.test.ts
+++ b/src/tests/routes/discord/status.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 // is pinned by status-openclaw-state.test.ts; this file is about the Discord
 // bot probe, so the gateway answers "could not be asked" (null) unless a case
 // says otherwise.
-vi.mock("@/lib/openclaw-channels", () => ({ readChannelStatus: vi.fn() }));
+vi.mock("@/lib/openclaw-channels", () => ({ readCachedChannelStatus: vi.fn() }));
 vi.mock("@/lib/hermes-discord", async () => {
   const actual = await vi.importActual<typeof import("@/lib/hermes-discord")>("@/lib/hermes-discord");
   return {
@@ -39,11 +39,11 @@ vi.mock("@/lib/hermes-discord", async () => {
 
 import { get } from "@/lib/config-store";
 import { getActiveHarness } from "@/lib/harness";
-import { readChannelStatus } from "@/lib/openclaw-channels";
+import { readCachedChannelStatus } from "@/lib/openclaw-channels";
 
 const mockGet = vi.mocked(get);
 const mockHarness = vi.mocked(getActiveHarness);
-const mockChannel = vi.mocked(readChannelStatus);
+const mockChannel = vi.mocked(readCachedChannelStatus);
 
 const TOKEN = "clawbox-test-not-a-real-discord-bot-token-000000";
 

--- a/src/tests/routes/whatsapp/configure.test.ts
+++ b/src/tests/routes/whatsapp/configure.test.ts
@@ -7,6 +7,7 @@ vi.mock("@/lib/openclaw-whatsapp", () => ({
 }));
 vi.mock("@/lib/openclaw-channels", () => ({
   ensureChannelPlugin: vi.fn(async () => ({ ok: true, installed: false })),
+  invalidateChannelStatus: vi.fn(),
   waitForChannelConnected: vi.fn(async () => null),
 }));
 vi.mock("@/lib/openclaw-config", () => ({ restartGateway: vi.fn(async () => {}) }));

--- a/src/tests/routes/whatsapp/openclaw.test.ts
+++ b/src/tests/routes/whatsapp/openclaw.test.ts
@@ -25,7 +25,8 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn() }));
 vi.mock("@/lib/openclaw-channels", () => ({
   ensureChannelPlugin: vi.fn(),
-  readChannelStatus: vi.fn(),
+  invalidateChannelStatus: vi.fn(),
+  readCachedChannelRow: vi.fn(),
   waitForChannelConnected: vi.fn(),
 }));
 vi.mock("@/lib/openclaw-whatsapp", () => ({

--- a/src/tests/routes/whatsapp/status-cache.test.ts
+++ b/src/tests/routes/whatsapp/status-cache.test.ts
@@ -42,7 +42,7 @@ const mockSpawn = vi.mocked(spawnOpenclawCli);
 const CLI_MS = 200;
 
 let statusStarts = 0;
-let accountRow: Record<string, unknown>;
+let accountRow: Record<string, unknown> | null;
 /** When true the mocked CLI fails, i.e. "the gateway could not be asked". */
 let cliFails = false;
 
@@ -68,7 +68,11 @@ beforeEach(async () => {
       statusStarts += 1;
       await new Promise((resolve) => setTimeout(resolve, CLI_MS));
       if (cliFails) throw new Error("gateway unreachable");
-      return JSON.stringify({ channelAccounts: { whatsapp: [accountRow] } });
+      // `accountRow: null` is a valid payload with no WhatsApp entry at all —
+      // the gateway ANSWERING that the channel was never set up.
+      return JSON.stringify({
+        channelAccounts: accountRow ? { whatsapp: [accountRow] } : {},
+      });
     }
     if (args[0] === "gateway" && args[1] === "call") {
       return JSON.stringify({ connected: true });
@@ -174,6 +178,25 @@ describe("GET /setup-api/whatsapp/status — the CLI is asked once per window", 
     cliFails = false;
     vi.setSystemTime(Date.now() + 5_000);
     expect((await (await GET()).json()).state).toBe("enabled_not_paired");
+    expect(statusStarts).toBe(2);
+  });
+
+  it("holds 'this channel was never set up' for a full answer window", async () => {
+    // The short window above is for a gateway that could not be ASKED. A
+    // gateway that answered, and whose payload simply has no WhatsApp entry,
+    // has told the truth about a box the owner never configured — the common
+    // case, and the one that must not pay a cold start five times as often as
+    // a configured box just because both render as `not_configured`.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    accountRow = null;
+    expect((await (await GET()).json()).state).toBe("not_configured");
+
+    vi.setSystemTime(Date.now() + 4_000);
+    expect((await (await GET()).json()).state).toBe("not_configured");
+    expect(statusStarts).toBe(1);
+
+    vi.setSystemTime(Date.now() + 12_000);
+    await GET();
     expect(statusStarts).toBe(2);
   });
 });

--- a/src/tests/routes/whatsapp/status-cache.test.ts
+++ b/src/tests/routes/whatsapp/status-cache.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * /setup-api/whatsapp/status must not pay a CLI cold start per poll.
+ *
+ * The OpenClaw branch of this route answers from `openclaw channels status
+ * --channel whatsapp --json`, which is a full CLI start plus a gateway round
+ * trip — measured at 3.2-3.6 s on a Jetson, against 20-40 ms for the sibling
+ * Discord panel, which asks the SAME CLI and simply remembers the answer for
+ * 15 s. The Settings panel polls this route, so every poll burned those
+ * seconds again.
+ *
+ * What is pinned here:
+ *   * two polls inside the window cost ONE CLI start, and the second is served
+ *     from memory rather than re-timed;
+ *   * concurrent polls share one in-flight start (the panel and the section
+ *     subtitle both read this route);
+ *   * the memo EXPIRES — a status read after the window asks again;
+ *   * a completed pairing drops it immediately, so a cached "not paired" can
+ *     never outlive the scan that paired the phone.
+ *
+ * The CLI is mocked at `spawnOpenclawCli`, i.e. below every layer this fix
+ * touches, so the count is of real would-be process starts.
+ */
+
+vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "openclaw") }));
+vi.mock("@/lib/hermes-telegram", () => ({ hermesGatewayStatus: vi.fn() }));
+vi.mock("@/lib/hermes-whatsapp", () => ({ readHermesWhatsappStatus: vi.fn() }));
+vi.mock("@/lib/whatsapp-pairing", () => ({ getPairingManager: vi.fn() }));
+vi.mock("@/lib/openclaw-config", () => ({
+  openclawIsAbsent: vi.fn(() => false),
+  readConfig: vi.fn(async () => ({})),
+  restartGateway: vi.fn(async () => {}),
+  spawnOpenclawCli: vi.fn(),
+}));
+
+import { spawnOpenclawCli } from "@/lib/openclaw-config";
+
+const mockSpawn = vi.mocked(spawnOpenclawCli);
+
+/** What one mocked `channels status` start costs, standing in for the Jetson's seconds. */
+const CLI_MS = 200;
+
+let statusStarts = 0;
+let accountRow: Record<string, unknown>;
+/** When true the mocked CLI fails, i.e. "the gateway could not be asked". */
+let cliFails = false;
+
+function row(over: Record<string, unknown> = {}) {
+  return { configured: true, enabled: true, linked: false, connected: false, ...over };
+}
+
+let GET: typeof import("@/app/setup-api/whatsapp/status/route").GET;
+let PAIR: typeof import("@/app/setup-api/whatsapp/pair/route").POST;
+
+beforeEach(async () => {
+  // The memo is module-level; a cache carried between cases would answer the
+  // next one.
+  vi.resetModules();
+  vi.clearAllMocks();
+  statusStarts = 0;
+  accountRow = row();
+  cliFails = false;
+  // readChannelRow() logs a failed read; the failure case below is deliberate.
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  mockSpawn.mockImplementation(async (args: string[]) => {
+    if (args[0] === "channels" && args[1] === "status") {
+      statusStarts += 1;
+      await new Promise((resolve) => setTimeout(resolve, CLI_MS));
+      if (cliFails) throw new Error("gateway unreachable");
+      return JSON.stringify({ channelAccounts: { whatsapp: [accountRow] } });
+    }
+    if (args[0] === "gateway" && args[1] === "call") {
+      return JSON.stringify({ connected: true });
+    }
+    return "{}";
+  });
+  GET = (await import("@/app/setup-api/whatsapp/status/route")).GET;
+  PAIR = (await import("@/app/setup-api/whatsapp/pair/route")).POST;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("GET /setup-api/whatsapp/status — the CLI is asked once per window", () => {
+  it("serves a second poll from memory instead of starting the CLI again", async () => {
+    const coldAt = Date.now();
+    const first = await (await GET()).json();
+    const coldMs = Date.now() - coldAt;
+
+    const warmAt = Date.now();
+    const second = await (await GET()).json();
+    const warmMs = Date.now() - warmAt;
+
+    // The spawn count is the evidence; the two timings are a sanity check with
+    // a wide margin, so a stalled CI runner cannot fail them on its own.
+    expect(statusStarts).toBe(1);
+    expect(second).toEqual(first);
+    expect(coldMs).toBeGreaterThanOrEqual(CLI_MS / 2);
+    expect(warmMs).toBeLessThan(CLI_MS / 2);
+  });
+
+  it("coalesces concurrent polls onto one CLI start", async () => {
+    // The Settings panel and the channel list both read this route.
+    const bodies = await Promise.all([GET(), GET(), GET()].map(async (res) => (await res).json()));
+    expect(statusStarts).toBe(1);
+    expect(bodies[1]).toEqual(bodies[0]);
+    expect(bodies[2]).toEqual(bodies[0]);
+  });
+
+  it("asks again once the window is over", async () => {
+    // Only the clock is faked: the mocked CLI still takes its CLI_MS.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    await GET();
+    expect(statusStarts).toBe(1);
+
+    vi.setSystemTime(Date.now() + 16_000);
+    await GET();
+    expect(statusStarts).toBe(2);
+  });
+
+  it("drops a cached 'not paired' the moment a scan completes", async () => {
+    // The probe-once trap this cache could have introduced: the owner scans the
+    // QR, the gateway reports the phone linked, and the panel keeps showing the
+    // answer from before the scan until the window happens to run out.
+    expect((await (await GET()).json()).state).toBe("enabled_not_paired");
+
+    accountRow = row({ linked: true, connected: true });
+    const paired = await (await PAIR(new Request("http://clawbox.local/setup-api/whatsapp/pair", {
+      method: "POST",
+    }))).json();
+    expect(paired.phase).toBe("paired");
+
+    const after = await (await GET()).json();
+    expect(after.state).toBe("paired");
+    expect(after.receiving).toBe(true);
+    expect(statusStarts).toBe(2);
+  });
+
+  it("never answers a poll made after a change from the read that started before it", async () => {
+    // Dropping only the stored row is not enough: a status read is 3.5 s of CLI
+    // on a Jetson, so a poll that arrives after the scan can easily land while
+    // the PREVIOUS read is still out — and joining it would hand the owner the
+    // "not linked" row that read was already fetching when they scanned.
+    const stale = GET();
+
+    accountRow = row({ linked: true, connected: true });
+    expect((await (await PAIR(new Request("http://clawbox.local/setup-api/whatsapp/pair", {
+      method: "POST",
+    }))).json()).phase).toBe("paired");
+
+    expect((await (await GET()).json()).state).toBe("paired");
+    // The abandoned read still resolves; it must neither answer the new poll
+    // nor be stored, and its cleanup must not evict the read that replaced it.
+    await stale;
+    expect(statusStarts).toBe(2);
+    expect((await (await GET()).json()).state).toBe("paired");
+    expect(statusStarts).toBe(2);
+  });
+
+  it("does not hold on to 'the gateway could not be asked' for a whole answer window", async () => {
+    // A failed read IS remembered — a wedged CLI must not be re-entered per
+    // poll — but only briefly: this route reports an unreadable channel as
+    // `not_configured`, which the panel draws as an actionable "Not configured"
+    // card. Pinning that for 15 s after a gateway restart would call a paired,
+    // connected box unconfigured long after it was healthy again.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    cliFails = true;
+    expect((await (await GET()).json()).state).toBe("not_configured");
+    await GET();
+    expect(statusStarts).toBe(1);
+
+    cliFails = false;
+    vi.setSystemTime(Date.now() + 5_000);
+    expect((await (await GET()).json()).state).toBe("enabled_not_paired");
+    expect(statusStarts).toBe(2);
+  });
+});

--- a/src/tests/routes/whatsapp/status-cache.test.ts
+++ b/src/tests/routes/whatsapp/status-cache.test.ts
@@ -45,6 +45,8 @@ let statusStarts = 0;
 let accountRow: Record<string, unknown> | null;
 /** When true the mocked CLI fails, i.e. "the gateway could not be asked". */
 let cliFails = false;
+/** Raw stdout to answer with, for the shapes the payload builder cannot make. */
+let cliPayload: string | undefined;
 
 function row(over: Record<string, unknown> = {}) {
   return { configured: true, enabled: true, linked: false, connected: false, ...over };
@@ -61,6 +63,7 @@ beforeEach(async () => {
   statusStarts = 0;
   accountRow = row();
   cliFails = false;
+  cliPayload = undefined;
   // readChannelRow() logs a failed read; the failure case below is deliberate.
   vi.spyOn(console, "warn").mockImplementation(() => {});
   mockSpawn.mockImplementation(async (args: string[]) => {
@@ -68,6 +71,7 @@ beforeEach(async () => {
       statusStarts += 1;
       await new Promise((resolve) => setTimeout(resolve, CLI_MS));
       if (cliFails) throw new Error("gateway unreachable");
+      if (cliPayload !== undefined) return cliPayload;
       // `accountRow: null` is a valid payload with no WhatsApp entry at all —
       // the gateway ANSWERING that the channel was never set up.
       return JSON.stringify({
@@ -197,6 +201,21 @@ describe("GET /setup-api/whatsapp/status — the CLI is asked once per window", 
 
     vi.setSystemTime(Date.now() + 12_000);
     await GET();
+    expect(statusStarts).toBe(2);
+  });
+
+  it("treats a payload that is not a channel-status object as a failed read", async () => {
+    // `typeof [] === "object"`, so a JSON array clears the object guard, and
+    // nothing in it is a channel. That must not be filed as the gateway
+    // ANSWERING "no such channel" — it is a gateway we could not read, and it
+    // gets the short window so the next poll asks again.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    cliPayload = "[]";
+    expect((await (await GET()).json()).state).toBe("not_configured");
+
+    vi.setSystemTime(Date.now() + 5_000);
+    cliPayload = undefined;
+    expect((await (await GET()).json()).state).toBe("enabled_not_paired");
     expect(statusStarts).toBe(2);
   });
 });

--- a/src/tests/unit/openclaw-whatsapp.test.ts
+++ b/src/tests/unit/openclaw-whatsapp.test.ts
@@ -16,13 +16,16 @@ vi.mock("@/lib/openclaw-config", async () => {
   );
   return { ...actual, openclawIsAbsent: () => false, spawnOpenclawCli: vi.fn() };
 });
-vi.mock("@/lib/openclaw-channels", () => ({ readChannelRow: vi.fn() }));
+vi.mock("@/lib/openclaw-channels", () => ({
+  invalidateChannelStatus: vi.fn(),
+  readCachedChannelRow: vi.fn(),
+}));
 
 import { spawnOpenclawCli } from "@/lib/openclaw-config";
-import { readChannelRow } from "@/lib/openclaw-channels";
+import { readCachedChannelRow } from "@/lib/openclaw-channels";
 
 const mockSpawn = vi.mocked(spawnOpenclawCli);
-const mockChannel = vi.mocked(readChannelRow);
+const mockChannel = vi.mocked(readCachedChannelRow);
 
 const QR_A = "data:image/png;base64,AAAA";
 const QR_B = "data:image/png;base64,BBBB";


### PR DESCRIPTION
**Finding F-28** (TASK-630, under TASK-604).

## Customer-visible symptom

Every poll of the WhatsApp panel burned 3.2–3.6 s of Jetson CPU. Measured on the OpenClaw box, same session, same box:

```
/setup-api/whatsapp/status   3.626 s   then 3.206 s
/setup-api/discord/status    0.044 s   then 0.021 s
```

Both routes ask the gateway the same question with the same command. Discord remembers the answer for 15 s; WhatsApp asked again every time — including on mobile, where the panel's `!isMobile` escapes never return early, so one section change re-reads every channel.

## Cause

`src/app/setup-api/whatsapp/status/route.ts` → `openclaw-whatsapp.ts readOpenclawWhatsappStatus()` → `openclaw-channels.ts readChannelRow()` spawns `openclaw channels status --channel whatsapp --json` with **no cache**. A full OpenClaw CLI cold start per request, for a row that changes only when the owner does something.

## Harness first

There is no cheaper native surface, and this PR does not invent one:

* `openclaw channels status --json` **is** the gateway's own status surface — the CLI is its client. The 3.2–3.6 s is the CLI's Node cold start, not the gateway (cf. `openclaw config get` = 5.481 s and `openclaw --version` = 0.074 s on the same box: only the version short-circuits before the CLI boots).
* `openclaw gateway call <method>` (`openclaw-config.ts:266`) pays the *identical* cold start, so routing the read through an RPC method buys nothing. `openclaw gateway` has `call`/`health`/`probe`/`status` and no watch or subscribe.
* The gateway's only non-WebSocket endpoints are `/healthz`, `/readyz` and `/startupz` — liveness probes, none of which carries a channel row. Its RPC lives on the WebSocket control protocol, which this repo reaches only from the browser through `gateway-proxy.ts`; standing up a second server-side WS client to duplicate what the CLI already does is exactly the harness-duplication trap.
* OpenClaw offers no cached or "fast" mode for the command (`--channel`, `--probe`, `--timeout`, `--json`).

So the memo belongs on the caller's side — which is what `/discord/status` already did. **The finding's own brief was wrong on this point** ("read it from the gateway over the same WS/HTTP status call Telegram/Discord use"): Discord uses the same CLI and merely caches it.

## The fix

One memo, in `src/lib/openclaw-channels.ts`, instead of a private copy in one route and none in the other.

* **`readCachedChannelRow()` / `readCachedChannelStatus()`** — at most one CLI start per channel per window, concurrent callers coalesced onto the one in flight. This is what a status route calls. `readChannelRow()` is left completely untouched: it stays the uncached "ask the gateway right now" read, and it does **not** write through. That matters — its only other caller is `waitForChannelConnected()`, whose probes are by definition of a channel *in transition*, taken immediately after a `restartGateway()`; publishing the attempt that failed to see the channel come up as the panel's canonical answer for 15 s would be the least representative reading the system ever takes.
* **Split TTLs — 15 s for an answer, 3 s for a read that failed.** "The gateway could not be asked" must not be pinned like an answer: the two consumers do not treat it alike. `/discord/status` maps it to UNKNOWN and the panel renders it neutrally, but `readOpenclawWhatsappStatus()` maps it to `state:"not_configured"`, which `SettingsApp` draws as an actionable "Not configured" card offering to link a phone that may already be linked. Caching that for the full 15 s would report a paired, connected box as unconfigured for a quarter of a minute after a gateway restart — a false failure. Three seconds still stops a wedged CLI being re-entered per poll, which is the only thing negative caching is for. (The `null` → `not_configured` *mapping* itself is pre-existing and is F-10's business, not this PR's.)
* **That split keys on whether the gateway answered, not on the row being `null`.** `readChannelRow` returns `null` for four different things, and only three are failures: no CLI at all (Hermes), a spawn or parse failure, an unparseable payload — and then *a valid payload this channel is simply not in*, which is the gateway answering that the channel was never set up. Reading that last one as a failure put the **common** case — a box whose WhatsApp was never configured — on the 3 s window, re-spawning the CLI five times as often as a box where the channel exists. So `readChannelRowResult()` reports `answered` beside the row, `readChannelRow()` is a thin wrapper over it (no caller's contract changes), and the memo picks its TTL from `answered`.
* **A response that is not a channel-status object is a failed read, not an answer.** `typeof [] === "object"`, so a JSON array cleared the object guard and would have been filed as the gateway answering that the channel does not exist. The guard stops at `Array.isArray` on purpose and does **not** demand a `channelAccounts` or `channels` key: a gateway with nothing configured is entitled to answer `{}`, and calling that a failed read would put the un-set-up box straight back on the 3 s window.
* **`invalidateChannelStatus(channelId)` drops the memo *including a read still in flight*.** Deleting only the stored row is not enough: a read costs 3.5 s, so a poll arriving after the owner's scan lands while the previous read is still out, and joining it hands back the "not linked" row that read was already fetching. Each channel carries its own invalidation epoch; a read only joins an in-flight entry from its own epoch, an answer from an older epoch is discarded rather than stored, and the abandoned read's cleanup is identity-guarded so it cannot evict the replacement that the invalidation started.
* Per-channel epochs, so a WhatsApp mutation never discards a concurrent, perfectly valid Discord read. An `age >= 0` guard, so a backwards NTP correction on a Jetson's RTC cannot pin an entry until the clock catches up. The returned row is shared and documented as read-only.
* `/discord/status` loses its private cache and reads the shared one.

The pairing invalidation is not theoretical: `SettingsApp.tsx:2143` refreshes the status **the moment the pairing snapshot flips to `paired`**. Without it the owner scans the QR and the panel answers from the pre-scan row — "enabled, not paired" — for the rest of the window. That is the probe-once class, and it is what a naive 15 s cache would have introduced.

## RED → GREEN

New test `src/tests/routes/whatsapp/status-cache.test.ts` mocks the CLI at `spawnOpenclawCli`, i.e. below every layer this change touches, so it counts real would-be process starts.

Against unmodified `origin/beta` (`5763ecd1`):

```
 ❯ src/tests/routes/whatsapp/status-cache.test.ts (6 tests | 4 failed)

 FAIL  serves a second poll from memory instead of starting the CLI again
   AssertionError: expected 2 to be 1        status-cache.test.ts:98   (statusStarts, two sequential GETs)
 FAIL  coalesces concurrent polls onto one CLI start
   AssertionError: expected 3 to be 1        status-cache.test.ts:107  (statusStarts, three concurrent GETs)
 FAIL  never answers a poll made after a change from the read that started before it
   AssertionError: expected 3 to be 2        status-cache.test.ts:159  (a third start, because the abandoned read evicts its replacement)
 FAIL  does not hold on to 'the gateway could not be asked' for a whole answer window
   AssertionError: expected 2 to be 1        status-cache.test.ts:172  (statusStarts, a failed read repeated per poll)

 Test Files  1 failed (1)
      Tests  4 failed | 2 passed (6)
```

With the fix: `Test Files 1 passed (1) · Tests 8 passed (8)`. Two of those eight were added for the CodeRabbit findings addressed in the review threads, and each is a real RED for the code it pins:

* `holds 'this channel was never set up' for a full answer window` — with the earlier `cached.row ? …` TTL selector restored it fails `expected 2 to be 1`, the other six passing;
* `treats a payload that is not a channel-status object as a failed read` — with `Array.isArray` removed from the guard it fails `expected 'not_configured' to be 'enabled_not_paired'`, the other seven passing.

Full suite exactly as CI runs it (`bun run test:coverage:ci`): **643 files, 9306 tests passed**. Neighbouring suites on the final head (`routes/whatsapp`, `routes/discord`, `unit/openclaw-whatsapp`, `unit/openclaw-channel-plugins`): 15 files / 198 tests. `bun run check:sudoers` OK, `tsc --noEmit` clean, `eslint` clean on all 14 touched files.

## Sibling call sites

| site | outcome |
|---|---|
| `discord/status/route.ts` | private memo deleted, reads the shared one |
| `waitForChannelConnected()` (`openclaw-channels.ts`) | left on the uncached `readChannelRow` on purpose — it polls for a *transition*, and its observations must not become the panel's answer |
| `readChannelRow()` / `readChannelStatus()` | unchanged, still pure reads |
| `whatsapp/configure` (both branches) | `setOpenclawWhatsappEnabled()` invalidates at the config write, and each branch invalidates again after its restart settles, so a poll taken *during* the restart cannot put a pre-save row back |
| `whatsapp/unpair` | covered by `setOpenclawWhatsappEnabled()` + `logoutOpenclawWhatsapp()`, plus one after the restart |
| `whatsapp/pair` | the pairing session invalidates the instant the gateway reports the phone linked |
| `discord/configure` | now invalidates after the token write, the plugin install and the restart — it was the one mutation site outside the contract the new helper documents |
| `mcp/`, `scripts/` | no consumers of channel status |
| Hermes edition | untouched — both status routes return from the Hermes branch before reaching the memo, and `openclawIsAbsent()` keeps it out of that path |

## Deliberately not fixed here

Two findings from the review pass were left out on purpose, and both are named rather than buried:

1. **One CLI start could fill every channel's entry.** `--channel` is optional on `openclaw channels status`, and `readChannelRow`'s parser already indexes a multi-channel payload, so a single un-filtered call would populate WhatsApp *and* Discord where two cold starts are paid today — on a phone, where both statuses fire on mount, that is roughly half the remaining win. It is not in this PR because it changes what the gateway is asked to do per call, and that cannot be measured without a box, which this task was forbidden to touch. Filed as **TASK-671** under TASK-604.

2. **A gateway restart triggered by something else does not drop the memo.** The ~12 `restartGateway()` call sites (AI model change, STT, hostname, updater, harness switch) leave the memo standing, so `receiving: true` can outlive the transport by up to 15 s. This is the window `/discord/status` has always had; WhatsApp now inherits it, which is **a deliberate weakening of "`receiving` may be true ONLY when the transport is genuinely up"** on that card. Closing it inside `restartGateway()` would make `openclaw-config` import `openclaw-channels`, which already imports it — an import cycle — so it needs its own change rather than a line in this one.

## Not proven here

No box was touched (the brief forbade it), so the wall-clock improvement on real hardware is argued from the verdict's own measurement above rather than re-measured. Everything else is CI-exercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Channel status panels now refresh accurately after Discord and WhatsApp configuration, pairing, enabling, disabling, and unpairing actions.
  * Reduced stale status displays during gateway restarts and concurrent status checks.
  * Status results now better reflect unavailable channels and temporary gateway failures.

* **Performance**
  * Repeated channel status requests are cached briefly, while concurrent requests are consolidated to reduce unnecessary checks.
  * Failed status checks use a shorter cache period for quicker recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->