### PR TITLE
fix: refuse a ClawKeep backup on an unpaired box instead of reporting it done

### DIFF
--- a/mcp/tools/system.ts
+++ b/mcp/tools/system.ts
@@ -569,10 +569,12 @@ export function registerSystemTools(reg: Registrar, ctx: McpContext): void {
           "Use letters, digits, spaces, dots, dashes or underscores, starting with a letter or digit.",
         );
       }
-      // The route answers HTTP 200 even when the backup FAILED — ok:false plus
-      // the real reason in stderrTail ("No token at ~/.clawkeep/token; run
-      // 'clawkeep pair' first"). A 200 never raises, so the tool used to return
-      // prose with no isError flag: a failed backup that reads as a success.
+      // An unpaired box is a 409 `not_paired`, which BACKUP_RULES above turns
+      // into CONFLICT + "tell the user to pair it in Settings -> Backup".
+      // Everything else the daemon can fail at still comes back as HTTP 200
+      // with ok:false and the reason in stderrTail; a 200 never raises, so the
+      // tool used to return prose with no isError flag — a failed backup that
+      // reads as a success. Hence the explicit check below.
       const body = await apiPost<{ ok?: boolean; exitCode?: number; stderrTail?: string }>(
         "/setup-api/clawkeep/backup",
         { ...(label ? { label } : {}) },

--- a/src/app/setup-api/clawkeep/backup/route.ts
+++ b/src/app/setup-api/clawkeep/backup/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { ClawKeepError, runBackup } from "@/lib/clawkeep";
+import { ClawKeepError, clawKeepErrorBody, runBackup } from "@/lib/clawkeep";
 
 export const dynamic = "force-dynamic";
 
@@ -12,6 +12,17 @@ export const dynamic = "force-dynamic";
 // On Jetson a real backup can take minutes — the request stays open until
 // the daemon finishes. The UI should call this with no client-side timeout
 // (or an explicit one matching the systemd unit's TimeoutStartSec=4h).
+//
+// A box with no pairing is refused with 409 `not_paired` before the daemon is
+// started: `clawkeepd` would have loaded the token, failed and exited 65, and
+// returning that exit code inside a 200 body made a backup that never began
+// arrive as a success.
+//
+// 65 is not the only pre-run exit — `daemon.py` returns 64 for a bad config
+// before it reaches the token at all — so a non-zero `exitCode` in a 200 body
+// still means "the daemon ran and failed", which is what the result card
+// reports. Classifying the rest of the daemon's `EXIT_*` taxonomy into HTTP
+// statuses is a separate change to the backup result path.
 export async function POST(request: NextRequest) {
   try {
     let body: unknown = {};
@@ -62,7 +73,7 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const status = err instanceof ClawKeepError ? err.status : 500;
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Backup failed" },
+      clawKeepErrorBody(err, "Backup failed"),
       { status, headers: { "Cache-Control": "no-store" } },
     );
   }

--- a/src/app/setup-api/clawkeep/backup/route.ts
+++ b/src/app/setup-api/clawkeep/backup/route.ts
@@ -19,10 +19,12 @@ export const dynamic = "force-dynamic";
 // arrive as a success.
 //
 // 65 is not the only pre-run exit — `daemon.py` returns 64 for a bad config
-// before it reaches the token at all — so a non-zero `exitCode` in a 200 body
-// still means "the daemon ran and failed", which is what the result card
-// reports. Classifying the rest of the daemon's `EXIT_*` taxonomy into HTTP
-// statuses is a separate change to the backup result path.
+// before it reaches the token at all. A non-zero `exitCode` in a 200 body
+// therefore means the daemon was started and did not succeed — or, for the two
+// codes the bridge synthesises itself, that it could not be started at all
+// (127, spawn error) or was killed by our own timer (124). Either way the
+// backup did not happen. Classifying the rest of the daemon's `EXIT_*`
+// taxonomy into HTTP statuses is a separate change to the backup result path.
 export async function POST(request: NextRequest) {
   try {
     let body: unknown = {};

--- a/src/app/setup-api/clawkeep/restore/route.ts
+++ b/src/app/setup-api/clawkeep/restore/route.ts
@@ -3,7 +3,12 @@ import { promisify } from "node:util";
 
 import { NextRequest, NextResponse } from "next/server";
 
-import { ClawKeepError, RestoreNeedsPassphraseError, runRestore } from "@/lib/clawkeep";
+import {
+  ClawKeepError,
+  clawKeepErrorBody,
+  RestoreNeedsPassphraseError,
+  runRestore,
+} from "@/lib/clawkeep";
 import { getEdition } from "@/lib/harness";
 import { HERMES_DASHBOARD_UNIT } from "@/lib/hermes-dashboard-auth";
 import { bounceHermesDashboard } from "@/lib/hermes-dashboard-control";
@@ -141,7 +146,7 @@ export async function POST(request: NextRequest) {
     }
     const status = err instanceof ClawKeepError ? err.status : 500;
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Restore failed" },
+      clawKeepErrorBody(err, "Restore failed"),
       { status, headers: { "Cache-Control": "no-store" } },
     );
   }

--- a/src/app/setup-api/clawkeep/snapshots/delete/route.ts
+++ b/src/app/setup-api/clawkeep/snapshots/delete/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { ClawKeepError, deleteSnapshot, SnapshotLockedError } from "@/lib/clawkeep";
+import {
+  ClawKeepError,
+  clawKeepErrorBody,
+  deleteSnapshot,
+  SnapshotLockedError,
+} from "@/lib/clawkeep";
 
 export const dynamic = "force-dynamic";
 
@@ -35,7 +40,7 @@ export async function POST(request: NextRequest) {
     }
     const status = err instanceof ClawKeepError ? err.status : 500;
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Failed to delete snapshot" },
+      clawKeepErrorBody(err, "Failed to delete snapshot"),
       { status, headers: { "Cache-Control": "no-store" } },
     );
   }

--- a/src/app/setup-api/clawkeep/snapshots/label/route.ts
+++ b/src/app/setup-api/clawkeep/snapshots/label/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { ClawKeepError, setSnapshotLabel } from "@/lib/clawkeep";
+import { ClawKeepError, clawKeepErrorBody, setSnapshotLabel } from "@/lib/clawkeep";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const status = err instanceof ClawKeepError ? err.status : 500;
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Failed to set label" },
+      clawKeepErrorBody(err, "Failed to set label"),
       { status, headers: { "Cache-Control": "no-store" } },
     );
   }

--- a/src/app/setup-api/clawkeep/snapshots/lock/route.ts
+++ b/src/app/setup-api/clawkeep/snapshots/lock/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 
-import { ClawKeepError, lockSnapshot, unlockSnapshot } from "@/lib/clawkeep";
+import {
+  ClawKeepError,
+  clawKeepErrorBody,
+  lockSnapshot,
+  unlockSnapshot,
+} from "@/lib/clawkeep";
 
 export const dynamic = "force-dynamic";
 
@@ -37,7 +42,7 @@ export async function POST(request: NextRequest) {
   } catch (err) {
     const status = err instanceof ClawKeepError ? err.status : 500;
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Failed to update lock" },
+      clawKeepErrorBody(err, "Failed to update lock"),
       { status, headers: { "Cache-Control": "no-store" } },
     );
   }

--- a/src/app/setup-api/clawkeep/snapshots/route.ts
+++ b/src/app/setup-api/clawkeep/snapshots/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { ClawKeepError, listCloudSnapshots } from "@/lib/clawkeep";
+import { ClawKeepError, clawKeepErrorBody, listCloudSnapshots } from "@/lib/clawkeep";
 
 export const dynamic = "force-dynamic";
 
@@ -17,7 +17,7 @@ export async function GET() {
   } catch (err) {
     const status = err instanceof ClawKeepError ? err.status : 500;
     return NextResponse.json(
-      { error: err instanceof Error ? err.message : "Failed to list snapshots" },
+      clawKeepErrorBody(err, "Failed to list snapshots"),
       { status, headers: { "Cache-Control": "no-store" } },
     );
   }

--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -39,10 +39,11 @@ function fireBackup(): void {
     .then((result) => {
       // `runBackup` rejects only for an unpaired box; every other failure —
       // the daemon missing from PATH (127), a bad config (64), a token error
-      // (65), the kill-timer (124) — RESOLVES carrying the exit code, so the
-      // `.catch` below never sees it. Unlogged, those were a nightly no-op:
-      // this is the scheduler's only voice, since the Settings card's backup
-      // button is gated on `daemonInstalled` and never reaches this path.
+      // (65), the kill-timer (124), a revoked pairing (3) — RESOLVES carrying
+      // the exit code, so the `.catch` below never sees it, and unlogged those
+      // were a nightly no-op. For the missing-daemon case this is the ONLY
+      // thing that can report it at all: the Settings card's backup button is
+      // disabled on `!daemonInstalled`, so nobody can even try by hand.
       if (result.exitCode !== 0) {
         const tail = result.stderr.trim().slice(-500);
         console.warn(

--- a/src/lib/clawkeep-scheduler.ts
+++ b/src/lib/clawkeep-scheduler.ts
@@ -36,6 +36,21 @@ function fireBackup(): void {
   // so it would silently never back anything up. The manual "Backup now" path
   // uses idle:false; the scheduler must too.
   void runBackup({ idle: false })
+    .then((result) => {
+      // `runBackup` rejects only for an unpaired box; every other failure —
+      // the daemon missing from PATH (127), a bad config (64), a token error
+      // (65), the kill-timer (124) — RESOLVES carrying the exit code, so the
+      // `.catch` below never sees it. Unlogged, those were a nightly no-op:
+      // this is the scheduler's only voice, since the Settings card's backup
+      // button is gated on `daemonInstalled` and never reaches this path.
+      if (result.exitCode !== 0) {
+        const tail = result.stderr.trim().slice(-500);
+        console.warn(
+          "[clawkeep-scheduler] auto-backup failed:",
+          `clawkeepd exited ${result.exitCode}${tail ? ` — ${tail}` : ""}`,
+        );
+      }
+    })
     .catch((err) => {
       console.warn("[clawkeep-scheduler] auto-backup failed:", err instanceof Error ? err.message : err);
     })

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -163,10 +163,36 @@ export class ClawKeepError extends Error {
   constructor(
     message: string,
     readonly status: number = 500,
+    /** Machine-readable reason, echoed by the routes as `code`. Present only
+     * where a caller has to branch on the failure; a client must never have to
+     * match on the English sentence to do it. */
+    readonly code?: string,
   ) {
     super(message);
     this.name = "ClawKeepError";
   }
+}
+
+/** The one sentence, and the one code, for "this box has no ClawKeep pairing".
+ * Every path that needs the daemon answers exactly this, so the app, the MCP
+ * tools and the scheduler all see one failure instead of six. */
+class ClawKeepNotPairedError extends ClawKeepError {
+  constructor() {
+    super("ClawKeep is not paired with an account", 409, "not_paired");
+    this.name = "ClawKeepNotPairedError";
+  }
+}
+
+/** The body a ClawKeep route answers a failure with: the sentence, plus the
+ * `code` when the error carries one. One helper so every route in the folder
+ * reports a failure the same way and a caller never has to read the English. */
+export function clawKeepErrorBody(err: unknown, fallback: string): {
+  error: string;
+  code?: string;
+} {
+  const error = err instanceof Error && err.message ? err.message : fallback;
+  const code = err instanceof ClawKeepError ? err.code : undefined;
+  return code ? { error, code } : { error };
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -538,6 +564,27 @@ async function getDaemonBin(): Promise<string | null> {
   }
 }
 
+/**
+ * The daemon binary for a call that needs the pairing token, refused before it
+ * can spawn anything when the device has none.
+ *
+ * The pairing signal is the daemon's own: `clawkeep/clawkeep/token.py`
+ * `read_token()` raises `TokenError("No token at <path>; run 'clawkeep pair'
+ * first")`, which `clawkeepd` returns as exit 65 and every token-taking
+ * `clawkeep` subcommand as `{"ok":false,"error":"No token at <path>…"}`.
+ * Reading the same file first is what lets a route answer the owner one
+ * sentence instead of quoting a daemon log line that names a path on the box.
+ *
+ * Everything that reaches the portal comes through here — `clawkeepd` itself
+ * and `snapshots`, `restore`, `label`, `lock`, `delete`, `prune`. The
+ * `*-passphrase` subcommands deliberately do NOT: they are device-local, and a
+ * box has to be able to set its encryption passphrase before it is paired.
+ */
+async function pairedDaemonBin(): Promise<string> {
+  if (!(await readToken())) throw new ClawKeepNotPairedError();
+  return (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+}
+
 /** Build the env for spawning the Python daemon/CLI. Augments PATH with the
  *  resolved openclaw bin's directory + the user-local bin dirs so the daemon's
  *  own `subprocess.run(["openclaw", ...])` resolves under systemd's stripped
@@ -766,7 +813,13 @@ function mapSnapshotsError(resp: SnapshotsResponse): ClawKeepError {
     case "unpaired":
     case "no_token":
     case "not_paired":
-      return new ClawKeepError("ClawKeep is not paired with an account", 409);
+      // Same answer as the pre-flight check, IF the daemon ever says so: today
+      // `clawkeep snapshots` classifies nothing — `cli.py::_emit_err` prints
+      // `{"ok":false,"error":…}` with no `kind` for `TokenError` too, so these
+      // cases are unreached and the token vanishing mid-session still falls to
+      // `default:` (502). Kept as the mapping to use when the daemon starts
+      // carrying the `kind` it already owns internally (`api.ApiError.kind`).
+      return new ClawKeepNotPairedError();
     case "auth":
     case "unauthorized":
     case "revoked":
@@ -903,11 +956,7 @@ function spawnCliJson<T>(
 async function fetchCloudSnapshots(): Promise<SnapshotsResponse> {
   // Fail fast + friendly on the unpaired case rather than shelling out and
   // surfacing the daemon's raw "no token" error as a 502.
-  const token = await readToken();
-  if (!token) {
-    throw new ClawKeepError("ClawKeep is not paired with an account", 409);
-  }
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   const resp = await spawnCliJson<SnapshotsResponse>(bin, "snapshots", [], { timeoutMs: 60_000 });
   if (!resp.ok) {
     throw mapSnapshotsError(resp);
@@ -999,7 +1048,7 @@ interface MutationResponse {
 /** Set (or clear, when `text` is empty) a snapshot's human label. */
 export async function setSnapshotLabel(name: string, text: string): Promise<void> {
   assertSnapshotName(name);
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   const resp = await spawnCliJson<MutationResponse>(
     bin,
     "label",
@@ -1014,7 +1063,7 @@ export async function setSnapshotLabel(name: string, text: string): Promise<void
 /** Mark a snapshot as protected (locked) — exempt from delete + retention. */
 export async function lockSnapshot(name: string): Promise<void> {
   assertSnapshotName(name);
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   const resp = await spawnCliJson<MutationResponse>(bin, "lock", [name], { timeoutMs: 30_000 });
   if (!resp.ok) {
     throw new ClawKeepError(resp.error ?? "lock failed", 502);
@@ -1024,7 +1073,7 @@ export async function lockSnapshot(name: string): Promise<void> {
 /** Remove a snapshot's protected flag. */
 export async function unlockSnapshot(name: string): Promise<void> {
   assertSnapshotName(name);
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   const resp = await spawnCliJson<MutationResponse>(bin, "unlock", [name], { timeoutMs: 30_000 });
   if (!resp.ok) {
     throw new ClawKeepError(resp.error ?? "unlock failed", 502);
@@ -1034,7 +1083,7 @@ export async function unlockSnapshot(name: string): Promise<void> {
 /** Delete a snapshot. Refused (SnapshotLockedError) if it's locked. */
 export async function deleteSnapshot(name: string): Promise<void> {
   assertSnapshotName(name);
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   const resp = await spawnCliJson<MutationResponse>(bin, "delete", [name], { timeoutMs: 60_000 });
   if (!resp.ok) {
     if (resp.kind === "locked") {
@@ -1046,7 +1095,7 @@ export async function deleteSnapshot(name: string): Promise<void> {
 
 /** Run retention on demand: keep the newest `keepLast` unlocked snapshots. */
 export async function pruneSnapshots(keepLast: number): Promise<string[]> {
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   const resp = await spawnCliJson<MutationResponse & { deleted?: string[] }>(
     bin,
     "prune",
@@ -1070,7 +1119,7 @@ export async function runRestore(
   // the new encrypted form (`.tar.gz.enc`) and the legacy unencrypted one
   // (`.tar.gz`); the daemon detects which is which on its end too.
   assertSnapshotName(name);
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   await setRestoring(true);
   try {
     const runWith = async (extraArgs: string[]) => {
@@ -1105,7 +1154,7 @@ export async function runRestore(
 export async function runBackup(
   opts: { idle?: boolean; label?: string } = {},
 ): Promise<BackupResult> {
-  const bin = (await getDaemonBin()) ?? DEFAULT_BIN_NAME;
+  const bin = await pairedDaemonBin();
   return new Promise((resolve) => {
     const env = buildSpawnEnv();
     const args = ["--config", CLAWKEEP_CONFIG_PATH];

--- a/src/lib/clawkeep.ts
+++ b/src/lib/clawkeep.ts
@@ -818,7 +818,10 @@ function mapSnapshotsError(resp: SnapshotsResponse): ClawKeepError {
       // `{"ok":false,"error":…}` with no `kind` for `TokenError` too, so these
       // cases are unreached and the token vanishing mid-session still falls to
       // `default:` (502). Kept as the mapping to use when the daemon starts
-      // carrying the `kind` it already owns internally (`api.ApiError.kind`).
+      // classifying its errors — which needs a `no_token` kind that
+      // `api.ApiError` does not have either (its union is auth | quota_full |
+      // tier | server | network | other), so making this branch live is a
+      // daemon-side change, not just a wiring one.
       return new ClawKeepNotPairedError();
     case "auth":
     case "unauthorized":

--- a/src/tests/components/clawkeep-unpaired-backup.test.tsx
+++ b/src/tests/components/clawkeep-unpaired-backup.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@/tests/helpers/test-utils";
+import ClawKeepApp from "@/components/ClawKeepApp";
+import { I18nProvider } from "@/lib/i18n";
+
+/**
+ * What the owner is shown when "Back up now" comes back 409 `not_paired`.
+ *
+ * The fixture is a PAIRED box on purpose: `DashboardCard` is the only thing
+ * with a "Back up now" button and `ClawKeepApp` renders it only when
+ * `status.paired`, so a box that was never paired shows the Pair card and this
+ * screen does not exist. What it reproduces is the pairing going away
+ * underneath an open panel — unpaired in another tab, or revoked at the portal
+ * — where the 10 s status poll still says paired and the click lands anyway.
+ *
+ * The route used to answer HTTP 200 `{ok:false, stderrTail:"… token error: No
+ * token at <path>; run 'clawkeep pair' first"}`, and the result card printed
+ * that tail verbatim — a daemon log line naming a directory on the device as
+ * the entire explanation of a backup that never started.
+ *
+ * The route now answers 409 `{error, code:"not_paired"}` (see
+ * src/tests/routes/clawkeep-unpaired.test.ts), which never reaches
+ * `setBackupResult` — so the result card cannot render, and the sentence
+ * arrives through the app's own error line. This test holds that: whatever a
+ * later change does to the card, a refused backup must read as one sentence
+ * and never as daemon output.
+ */
+
+const STATUS = {
+  paired: true,
+  configured: true,
+  encryptionConfigured: true,
+  server: "https://portal.example",
+  lastBackupAtMs: Date.now() - 3_600_000,
+  cloudBytes: 1024,
+  snapshotCount: 2,
+  openclawInstalled: true,
+  daemonInstalled: true,
+  archiverReady: true,
+  schedule: { enabled: false, frequency: "daily", timeOfDay: "03:00", weekday: 0, retentionKeepLast: 10 },
+  nextRunAtMs: 0,
+};
+
+const NOT_PAIRED = "ClawKeep is not paired with an account";
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown) => {
+      const url = String(input);
+      if (url.includes("/setup-api/clawkeep/backup")) {
+        return {
+          ok: false,
+          status: 409,
+          json: async () => ({ error: NOT_PAIRED, code: "not_paired" }),
+        };
+      }
+      if (url.includes("/setup-api/clawkeep")) {
+        return { ok: true, status: 200, json: async () => STATUS };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+});
+
+describe("ClawKeep's backup button when the pairing is gone mid-session", () => {
+  // 15 s, not vitest's default 5 s: this mounts the whole ClawKeep app and
+  // settles its status poll before it can click, and the two waits below ask
+  // for 5 s each — on a loaded runner the default budget expires first.
+  it("says ClawKeep is not paired, and shows no daemon output", async () => {
+    render(<I18nProvider><ClawKeepApp /></I18nProvider>);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Back up now" }, { timeout: 5000 }));
+
+    expect(await screen.findByText(new RegExp(NOT_PAIRED), {}, { timeout: 5000 })).toBeTruthy();
+    // `BackupResultCard` is the only component that renders the daemon's
+    // `stderrTail`, and "Failed (exit {code})" is its header. Absent, there is
+    // nothing on screen that could print a log line.
+    expect(screen.queryByText(/Failed \(exit/)).toBeNull();
+  }, 15_000);
+});

--- a/src/tests/routes/clawkeep-unpaired.test.ts
+++ b/src/tests/routes/clawkeep-unpaired.test.ts
@@ -65,6 +65,9 @@ const NOT_PAIRED = { error: "ClawKeep is not paired with an account", code: "not
 let backupPOST: typeof import("@/app/setup-api/clawkeep/backup/route").POST;
 let restorePOST: typeof import("@/app/setup-api/clawkeep/restore/route").POST;
 let snapshotsGET: typeof import("@/app/setup-api/clawkeep/snapshots/route").GET;
+let labelPOST: typeof import("@/app/setup-api/clawkeep/snapshots/label/route").POST;
+let lockPOST: typeof import("@/app/setup-api/clawkeep/snapshots/lock/route").POST;
+let deletePOST: typeof import("@/app/setup-api/clawkeep/snapshots/delete/route").POST;
 
 const post = (route: string, body: Record<string, unknown>) =>
   new Request(`http://localhost/setup-api/clawkeep/${route}`, {
@@ -82,6 +85,9 @@ beforeAll(async () => {
   backupPOST = (await import("@/app/setup-api/clawkeep/backup/route")).POST;
   restorePOST = (await import("@/app/setup-api/clawkeep/restore/route")).POST;
   snapshotsGET = (await import("@/app/setup-api/clawkeep/snapshots/route")).GET;
+  labelPOST = (await import("@/app/setup-api/clawkeep/snapshots/label/route")).POST;
+  lockPOST = (await import("@/app/setup-api/clawkeep/snapshots/lock/route")).POST;
+  deletePOST = (await import("@/app/setup-api/clawkeep/snapshots/delete/route")).POST;
 });
 
 afterAll(async () => {
@@ -137,6 +143,24 @@ describe("ClawKeep on an unpaired box", () => {
 
   it("answers GET /clawkeep/snapshots with the same sentence and code", async () => {
     const res = await snapshotsGET();
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual(NOT_PAIRED);
+    expect(daemon.spawns).toEqual([]);
+  });
+
+  // label / lock / delete were spawning the daemon unguarded too — a 502
+  // quoting "No token at <path>". They share pairedDaemonBin() with the routes
+  // above, but they are separate handlers with their own catch blocks, so the
+  // shared envelope is asserted per route rather than inferred.
+  const MUTATIONS: [string, () => Promise<Response>][] = [
+    ["snapshots/label", () => labelPOST(post("snapshots/label", { name: SNAPSHOT, label: "x" }))],
+    ["snapshots/lock", () => lockPOST(post("snapshots/lock", { name: SNAPSHOT, locked: true }))],
+    ["snapshots/delete", () => deletePOST(post("snapshots/delete", { name: SNAPSHOT }))],
+  ];
+
+  it.each(MUTATIONS)("answers POST /clawkeep/%s the same way", async (_route, call) => {
+    const res = await call();
 
     expect(res.status).toBe(409);
     expect(await res.json()).toEqual(NOT_PAIRED);

--- a/src/tests/routes/clawkeep-unpaired.test.ts
+++ b/src/tests/routes/clawkeep-unpaired.test.ts
@@ -1,0 +1,161 @@
+import { EventEmitter } from "node:events";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NextRequest } from "next/server";
+
+/**
+ * F-35 — what a box that was never paired answers when the owner presses
+ * "Back up now".
+ *
+ * `clawkeepd` loads the portal bearer token before it does anything else
+ * (clawkeep/clawkeep/daemon.py: `token.read_token()` → exit 65, "token error:
+ * No token at <path>; run 'clawkeep pair' first"). The bridge spawned it
+ * anyway and handed that back as HTTP 200 `{ ok:false, stderrTail:… }`, so a
+ * backup that never started arrived as a success whose only explanation was a
+ * raw daemon log line naming a path on the device.
+ *
+ * The daemon's own pairing signal is that token file, and the bridge already
+ * reads it — `readToken()` backs `getStatus().paired`, and the snapshots path
+ * has always fail-fasted on it with 409 "ClawKeep is not paired with an
+ * account". These tests hold every route that spawns the daemon to that one
+ * sentence, with a `code` the caller can branch on instead of parsing English.
+ */
+
+const daemon = vi.hoisted(() => ({
+  spawns: [] as { bin: string; args: string[] }[],
+  exitCode: 0,
+  stdout: "",
+  stderr: "",
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  const spawn = (bin: string, args: string[]) => {
+    daemon.spawns.push({ bin, args });
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: EventEmitter;
+      stderr: EventEmitter;
+      kill: () => void;
+    };
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    setImmediate(() => {
+      if (daemon.stdout) child.stdout.emit("data", Buffer.from(daemon.stdout));
+      if (daemon.stderr) child.stderr.emit("data", Buffer.from(daemon.stderr));
+      child.emit("close", daemon.exitCode);
+    });
+    return child;
+  };
+  return { ...actual, spawn, default: { ...actual, spawn } };
+});
+
+const TEST_ROOT = path.join(os.tmpdir(), `clawbox-clawkeep-unpaired-${process.pid}-${Date.now()}`);
+const DATA_DIR = path.join(TEST_ROOT, "clawkeep");
+const TOKEN_PATH = path.join(DATA_DIR, "token");
+const RESTORING_FLAG = path.join(DATA_DIR, "restoring.flag");
+const SNAPSHOT = "2026-08-28T00-00-00.000Z-openclaw-backup.tar.gz";
+
+const NOT_PAIRED = { error: "ClawKeep is not paired with an account", code: "not_paired" };
+
+let backupPOST: typeof import("@/app/setup-api/clawkeep/backup/route").POST;
+let restorePOST: typeof import("@/app/setup-api/clawkeep/restore/route").POST;
+let snapshotsGET: typeof import("@/app/setup-api/clawkeep/snapshots/route").GET;
+
+const post = (route: string, body: Record<string, unknown>) =>
+  new Request(`http://localhost/setup-api/clawkeep/${route}`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest;
+
+beforeAll(async () => {
+  process.env.CLAWKEEP_DATA_DIR = DATA_DIR;
+  process.env.CLAWKEEP_CONFIG_PATH = path.join(DATA_DIR, "config.toml");
+  // Resolve the daemon binary without a PATH probe — which() spawns `which`,
+  // and every spawn these tests record has to be a daemon invocation.
+  process.env.CLAWKEEP_BIN = "/bin/true";
+  await fs.mkdir(DATA_DIR, { recursive: true, mode: 0o700 });
+  backupPOST = (await import("@/app/setup-api/clawkeep/backup/route")).POST;
+  restorePOST = (await import("@/app/setup-api/clawkeep/restore/route")).POST;
+  snapshotsGET = (await import("@/app/setup-api/clawkeep/snapshots/route")).GET;
+});
+
+afterAll(async () => {
+  delete process.env.CLAWKEEP_DATA_DIR;
+  delete process.env.CLAWKEEP_CONFIG_PATH;
+  delete process.env.CLAWKEEP_BIN;
+  await fs.rm(TEST_ROOT, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  daemon.spawns.length = 0;
+  daemon.exitCode = 0;
+  daemon.stdout = "";
+  daemon.stderr = "";
+  await fs.rm(TOKEN_PATH, { force: true });
+  await fs.rm(RESTORING_FLAG, { force: true });
+});
+
+describe("ClawKeep on an unpaired box", () => {
+  it("answers POST /clawkeep/backup 409 not_paired and never starts the daemon", async () => {
+    const res = await backupPOST(post("backup", {}));
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual(NOT_PAIRED);
+    expect(daemon.spawns).toEqual([]);
+  });
+
+  it("answers POST /clawkeep/restore 409 not_paired without arming the restore flag", async () => {
+    const res = await restorePOST(post("restore", { name: SNAPSHOT }));
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual(NOT_PAIRED);
+    expect(daemon.spawns).toEqual([]);
+    // The shelf shield pulses off this marker. A restore that never ran must
+    // not leave it behind for the half-hour staleness window.
+    await expect(fs.access(RESTORING_FLAG)).rejects.toThrow();
+  });
+
+  it("rejects a scheduled run instead of firing a doomed daemon", async () => {
+    const { runBackup } = await import("@/lib/clawkeep");
+
+    // clawkeep-scheduler.ts `fireBackup()` is the other caller of runBackup, so
+    // an unpaired box used to run a doomed daemon every night. This covers only
+    // the rejection; a run the daemon RESOLVES with a non-zero exit is the
+    // scheduler's own branch, held in src/tests/unit/clawkeep-schedule.test.ts.
+    await expect(runBackup({ idle: false })).rejects.toMatchObject({
+      status: 409,
+      code: "not_paired",
+      message: NOT_PAIRED.error,
+    });
+    expect(daemon.spawns).toEqual([]);
+  });
+
+  it("answers GET /clawkeep/snapshots with the same sentence and code", async () => {
+    const res = await snapshotsGET();
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual(NOT_PAIRED);
+    expect(daemon.spawns).toEqual([]);
+  });
+});
+
+describe("ClawKeep on a paired box", () => {
+  beforeEach(async () => {
+    await fs.writeFile(TOKEN_PATH, "claw_test-token", { mode: 0o600 });
+  });
+
+  it("still runs the daemon for POST /clawkeep/backup", async () => {
+    const res = await backupPOST(post("backup", { label: "before update" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, exitCode: 0 });
+    expect(daemon.spawns).toHaveLength(1);
+    expect(daemon.spawns[0].bin).toBe("/bin/true");
+    expect(daemon.spawns[0].args).toContain("--label");
+  });
+});

--- a/src/tests/unit/clawkeep-schedule.test.ts
+++ b/src/tests/unit/clawkeep-schedule.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { computeNextRunMs, type ClawKeepSchedule } from "@/lib/clawkeep";
 
@@ -68,5 +68,80 @@ describe("computeNextRunMs", () => {
   it("returns 0 for malformed timeOfDay", () => {
     const now = new Date("2026-04-29T12:00:00");
     expect(computeNextRunMs({ ...baseSchedule, timeOfDay: "bogus" } as ClawKeepSchedule, now)).toBe(0);
+  });
+});
+
+/**
+ * The other half of the schedule: what the scheduler does with the result.
+ *
+ * `runBackup` resolves with the daemon's exit code for every outcome except a
+ * box with no pairing — a spawn that ENOENTs resolves 127, a hung daemon
+ * resolves 124, a config error resolves 64. `fireBackup()` had only a
+ * `.catch()` to report with, so each of those was a nightly no-op that left
+ * nothing in the journal at all: the Settings card cannot show it either (its
+ * backup button is gated on `daemonInstalled`), so scheduled backups stopped
+ * for as long as it took someone to notice `lastBackupAtMs` ageing.
+ */
+describe("the ClawKeep backup scheduler", () => {
+  const SCHEDULE: ClawKeepSchedule = {
+    enabled: true,
+    frequency: "daily",
+    timeOfDay: "06:00",
+    weekday: 0,
+    retentionKeepLast: 10,
+  };
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-22T05:00:00"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.doUnmock("@/lib/clawkeep");
+  });
+
+  async function armWith(runBackup: ReturnType<typeof vi.fn>) {
+    vi.doMock("@/lib/clawkeep", async () => {
+      const actual = await vi.importActual<typeof import("@/lib/clawkeep")>("@/lib/clawkeep");
+      return { ...actual, runBackup, readSchedule: vi.fn(async () => SCHEDULE) };
+    });
+    const sched = await import("@/lib/clawkeep-scheduler");
+    await sched.start();
+    return sched;
+  }
+
+  it("logs a scheduled backup the daemon failed, instead of letting it pass as done", async () => {
+    // `clawkeepd` gone from PATH — a pipx/venv reinstall, or install.sh's pip
+    // fallback failing non-fatally. runBackup resolves, it does not reject.
+    const runBackup = vi.fn(async () => ({
+      exitCode: 127,
+      stdout: "",
+      stderr: "spawn clawkeepd ENOENT",
+    }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await armWith(runBackup);
+    await vi.advanceTimersByTimeAsync(61 * 60_000);
+
+    expect(runBackup).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("auto-backup failed"),
+      expect.stringContaining("127"),
+    );
+    warn.mockRestore();
+  });
+
+  it("says nothing when the scheduled backup actually ran", async () => {
+    const runBackup = vi.fn(async () => ({ exitCode: 0, stdout: "uploaded", stderr: "" }));
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await armWith(runBackup);
+    await vi.advanceTimersByTimeAsync(61 * 60_000);
+
+    expect(runBackup).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 });

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -609,6 +609,43 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
     expect(out.error.next).toMatch(/do not start another one/i);
   });
 
+  it("tells the agent to get the box paired when backup_now hits an unpaired one", async () => {
+    // The route refuses an unpaired box with 409 `not_paired` before it spawns
+    // the daemon, and BACKUP_RULES is what turns that into an instruction the
+    // agent can act on. Without this the contract lives only in a comment: drop
+    // `rules: BACKUP_RULES` from the apiPost call, or reorder the rules, and
+    // the agent gets a bare 409 with no idea what to tell the user.
+    apiPost.mockRejectedValue(
+      new ApiError(
+        409,
+        JSON.stringify({ error: "ClawKeep is not paired with an account", code: "not_paired" }),
+      ),
+    );
+
+    const out = await system("openclaw").call("backup_now", {});
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("CONFLICT");
+    expect(out.error.message).toMatch(/not set up on this device/i);
+    expect(out.error.next).toMatch(/Settings -> Backup/);
+    expect(out.error.next).toMatch(/do not retry/i);
+  });
+
+  it("says the same thing for backup_list, which reaches the same 409", async () => {
+    apiGet.mockRejectedValue(
+      new ApiError(
+        409,
+        JSON.stringify({ error: "ClawKeep is not paired with an account", code: "not_paired" }),
+      ),
+    );
+
+    const out = await system("openclaw").call("backup_list", {});
+    expect(out.isError).toBe(true);
+    if (!out.isError) return;
+    expect(out.error.code).toBe("CONFLICT");
+    expect(out.error.next).toMatch(/Settings -> Backup/);
+  });
+
   it("reports a successful backup as one", async () => {
     apiPost.mockResolvedValue({ exitCode: 0, ok: true });
     const out = await system("openclaw").call("backup_now", {});

--- a/src/tests/unit/mcp-tool-honesty.test.ts
+++ b/src/tests/unit/mcp-tool-honesty.test.ts
@@ -591,19 +591,21 @@ describe("ClawKeep is gated on the edition that can actually run it", () => {
   });
 
   it("reports a failed backup as a failure, with the reason the route carried", async () => {
-    // The route answers 200 with ok:false, so nothing ever threw.
+    // A backup that RAN and failed still answers 200 with ok:false, so nothing
+    // throws. (The unpaired case is no longer one of these — the route refuses
+    // it with 409, which BACKUP_RULES maps to CONFLICT.)
     apiPost.mockResolvedValue({
       exitCode: 1,
       ok: false,
       stdoutTail: "",
-      stderrTail: "token error: No token at ~/.clawkeep/token; run 'clawkeep pair' first",
+      stderrTail: "openclaw backup create failed: no space left on device",
     });
 
     const out = await system("openclaw").call("backup_now", {});
     expect(out.isError).toBe(true);
     if (!out.isError) return;
     expect(out.error.message).toMatch(/did not run/i);
-    expect(out.error.message).toMatch(/clawkeep pair/);
+    expect(out.error.message).toMatch(/no space left on device/);
     expect(out.error.next).toMatch(/do not start another one/i);
   });
 


### PR DESCRIPTION
Finding **F-35** (board TASK-637, under TASK-604) — the false-success class, on the feature customers trust with their data.

## Customer-visible symptom

A box that is not paired with a ClawKeep account. The owner presses **Back up now**.
The request answers **HTTP 200** — `{ "exitCode": 65, "ok": false, "stderrTail": "… ERROR clawkeepd: token error: No token at <a path on the device>; run 'clawkeep pair' first" }` — and the result card prints that daemon log line as the entire explanation of a backup that never started. The same box answers `GET /setup-api/clawkeep/snapshots` correctly: 409 "ClawKeep is not paired with an account".

Second symptom, same root: on a **paired** box whose `clawkeepd` has gone missing, the nightly scheduled backup was a silent no-op. `runBackup()` resolves (it does not reject) carrying the daemon's exit code, and `fireBackup()` had only a `.catch()` to report with — so nothing was logged at all, and scheduled backups stopped for as long as it took someone to notice `lastBackupAtMs` ageing.

## Cause

`runBackup()` and `runRestore()` spawned the daemon without looking at the pairing. `clawkeepd` loads the `claw_*` bearer token before it does anything (`clawkeep/clawkeep/daemon.py` → `token.read_token()`) and exits **65** when there is none; the route turned that exit code into a 200 body plus the daemon's stderr tail. `fetchCloudSnapshots()` had always done the opposite — read the token first and fail with 409 — so the same device answered two different ways depending on which button was pressed.

## Harness first — no new mechanism

The pairing signal is the ClawKeep daemon's own: the token file at `$CLAWKEEP_DATA_DIR/token` that `clawkeep/clawkeep/token.py::read_token()` requires, that `clawkeepd` reads at startup and that every token-taking `clawkeep` subcommand loads through `_load_cfg_and_token()`. The TS bridge already reads exactly that file (`readToken()`, which is what `getStatus().paired` reports), and 409 "ClawKeep is not paired with an account" is already the sentence the snapshots path answers. This PR routes every daemon call that needs a token through that one check. Nothing parses a log line, and no new state is written.

(The daemon has no `pair-status` subcommand to ask instead — `clawkeep --help` lists `pair, daemon, snapshots, restore, label, lock, unlock, delete, prune, set-passphrase, clear-passphrase, passphrase-status`. The token file *is* the signal, which is why `getStatus()` already answers `paired` from it.)

## Fix

- `pairedDaemonBin()` in `src/lib/clawkeep.ts` resolves the daemon binary **and** the pairing in one place, so a call that needs a token cannot get a binary without one. Every portal-reaching call goes through it: `clawkeepd` itself plus `snapshots`, `restore`, `label`, `lock`, `unlock`, `delete`, `prune`.
- The `*-passphrase` subcommands deliberately do **not**: they are device-local, and a box has to be able to set its encryption passphrase before it is paired — `getStatus()` runs `passphrase-status` on every poll of an unpaired box.
- One `ClawKeepNotPairedError`: 409, one fixed sentence, `code: "not_paired"`.
- `clawKeepErrorBody()` gives the ClawKeep routes one failure envelope, so the code travels with the sentence and a client branches on the code, never on English.
- `fireBackup()` in `src/lib/clawkeep-scheduler.ts` now branches on `result.exitCode !== 0` and logs it. The `.catch()` it had only ever fires for a rejection, and `runBackup` rejects for exactly one thing (the unpaired box this PR added); 127 (daemon gone from PATH), 124 (kill-timer), 64 (bad config), 65 (token error) and 3 (pairing revoked) all **resolve**. For the missing-daemon case this is the only thing that can report the failure at all: the Settings card's backup button is disabled on `!daemonInstalled`, so nobody can even try by hand.

### Stated scope: this puts the failure in the journal, not yet in front of the owner

`deriveProtection()` (`src/components/ClawKeepApp.tsx`) has no age term — `lastHeartbeatStatus === "error"` → *lapsed*, else `lastBackupAtMs > 0` → *protected*. Nothing here persists an error heartbeat, and for the two failures most likely to persist the daemon cannot write one either: on exit 127 it never starts, and on exit 3 `runner.py` explicitly returns without stamping state ("No portal exchange happened — don't heartbeat or stamp state"). So a box that has ever backed up successfully keeps showing the green "Protected" shield while its nightly runs fail into `journalctl`.

That is a deliberate boundary, not an oversight. Stamping `last_heartbeat_status` from the bridge would flip the panel into its existing red "At risk" state, which is a product-visible change to what "protected" means — the owner's call, not a bug fix's. Filed as **TASK-673**. The unpaired case *is* already visible, because a missing token flips `status.paired` and the app renders `PairCard` instead.

## Sibling call sites

| site | outcome |
|---|---|
| `clawkeep/restore` | fixed — same 409 `not_paired`, refused before the restore marker is armed or the daemon is spawned |
| `clawkeep/snapshots`, `snapshots/delete`, `snapshots/label`, `snapshots/lock` | fixed — `prune`/`label`/`lock`/`delete` were spawning the daemon unguarded too (a 502 quoting the daemon's "No token at &lt;path&gt;"); all four now answer the same 409 + `code` through the shared envelope |
| scheduled backup — `clawkeep-scheduler.ts` `fireBackup()` | fixed twice — `runBackup()` now **rejects** for an unpaired box, so the existing `.catch()` logs it; and a new `.then()` branch logs any run the daemon **resolved** with a non-zero exit, which `.catch()` never saw. Before, both were a nightly no-op with nothing in the journal |
| `clawkeep-memory-scheduler.ts` `fireIndex()` | cleared, no change needed — it already branches on its resolved result (`if (!accepted) console.log(…)`), so it does not have the scheduler defect above |
| MCP `backup_now` (`mcp/tools/system.ts`) | cleared, no change needed — its `BACKUP_RULES` already maps 409 → `CONFLICT` "Cloud backup is not set up on this device. / Tell the user to pair it in Settings → Backup. Do not retry." Its `ok !== true` fallback stays for a genuine daemon failure |
| ClawKeep app (`ClawKeepApp.tsx`) | cleared, no change needed — `BackupResultCard` (the component that printed `stderrTail`) is only rendered from a 2xx result, so the log line can no longer reach it; the route's sentence shows in the app's own error line, and the existing 10 s status poll replaces a stale "paired" dashboard with the Pair card |
| status card — `getStatus()` | cleared — it already reads the token directly and reports `paired: false`; the dashboard with the backup button is gated on it |
| `clawkeep/reset-state`, `clawkeep/schedule`, `clawkeep/encryption`, `clawkeep/pair/*`, `clawkeep/memory/*` | cleared — none of them makes a token-taking daemon call (memory spawns the `openclaw` CLI, not ClawKeep) |

## RED → GREEN

Two regression tests. Both re-proven failing in a clean worktree against the **current** `beta` head (`227839f7`) — not only against the commit this branch was cut from:

```
 ❯ |unit| src/tests/routes/clawkeep-unpaired.test.ts (8 tests | 7 failed)
     × answers POST /clawkeep/backup 409 not_paired and never starts the daemon
     × answers POST /clawkeep/restore 409 not_paired without arming the restore flag
     × rejects a scheduled run instead of firing a doomed daemon
     × answers GET /clawkeep/snapshots with the same sentence and code
     × answers POST /clawkeep/snapshots/label the same way
     × answers POST /clawkeep/snapshots/lock the same way
     × answers POST /clawkeep/snapshots/delete the same way
 ❯ |unit| src/tests/unit/clawkeep-schedule.test.ts (10 tests | 1 failed)
     × logs a scheduled backup the daemon failed, instead of letting it pass as done

 FAIL  … > answers POST /clawkeep/backup 409 not_paired and never starts the daemon
AssertionError: expected 200 to be 409 // Object.is equality      <- the false success
- Expected
+ Received
- 409
+ 200

 FAIL  … > answers POST /clawkeep/restore 409 not_paired without arming the restore flag
AssertionError: expected 502 to be 409 // Object.is equality

 FAIL  … > rejects a scheduled run instead of firing a doomed daemon
AssertionError: promise resolved "{ exitCode: +0, stdout: '', stderr: '' }" instead of rejecting

 FAIL  … > answers GET /clawkeep/snapshots with the same sentence and code
AssertionError: expected { Object (error) } to deeply equal { …(2) }
  {
-   "code": "not_paired",
    "error": "ClawKeep is not paired with an account",
  }

 FAIL  … > the ClawKeep backup scheduler > logs a scheduled backup the daemon failed, instead of letting it pass as done
AssertionError: expected "warn" to be called with arguments: [ StringContaining{…}, …(1) ]

Number of calls: 0                                               <- the silent nightly no-op

 Test Files  1 failed | 1 passed (2)
      Tests  7 failed | 68 passed (75)
```

The two headline lines are the finding itself: **`expected 200 to be 409`** is the backup that never ran arriving as a success, and **`Number of calls: 0`** is the scheduled run that failed with exit 127 and logged nothing at all.

The passing tests in that same run are the control: the paired-box backup (the guard must not break a backup that can actually run), the sibling scheduler test "says nothing when the scheduled backup actually ran" (so the `console.warn` assertion is not trivially failing), and the eight existing `computeNextRunMs` cases.

Two of the new tests are **not** regression tests, and are not presented as any: the scheduler's "says nothing when the backup actually ran" is an over-logging guard, and the two new `mcp-tool-honesty` cases are contract lock-ins — `mcp-tool-honesty.test.ts` passes on beta, because `BACKUP_RULES` already mapped 409 → `CONFLICT`. They exist because this diff *removed* the only test that drove the unpaired case through `backup_now`, so the 409 contract was left asserted in a comment and held by nothing.

`src/tests/routes/clawkeep-unpaired.test.ts` records `node:child_process.spawn`, so "the daemon never started" is an assertion rather than an inference.

GREEN, with the fix — the two regression files plus every neighbouring ClawKeep, scheduler and MCP suite, and beta's own new postbuild test:

```
 Test Files  13 passed (13)
      Tests  159 passed (159)
```

Full suite as CI runs it (`bun run test:coverage:ci`): **644 files / 9308 tests, all passing**. `tsc --noEmit` clean. `eslint` reports no error in any file this PR touches (the repo's 19 pre-existing errors are all in files it does not).

## Review passes

Two Opus review passes ran on this change. The first reviewed the fix and returned 8 findings; the second reviewed the delta that applied them and returned 6 more (0 HIGH). Everything is either applied below or refuted here — nothing was dropped silently.

### First pass — 8 findings


**Applied**

1. *(HIGH)* `fireBackup()` was blind to every daemon failure except the missing token — the nightly silent no-op described above. Fixed, with its own RED test.
2. *(MEDIUM)* The comment added to `mapSnapshotsError`'s `unpaired`/`no_token`/`not_paired` branch claimed it covered the token-vanishing-mid-session race. It does not: `clawkeep/clawkeep/cli.py::_emit_err` prints `{"ok":false,"error":…}` with **no** `kind` for `TokenError` too, so those cases are unreachable and that race still falls to `default:` (502). The comment now says so instead of claiming coverage that does not exist.
3. *(LOW)* The component test's name and doc said "an unpaired box" while its fixture is deliberately `paired: true` — it has to be, since `DashboardCard` is the only component with a "Back up now" button and it renders only when `status.paired`. Renamed to what it actually tests (the pairing going away mid-session), and two assertions the stubbed `fetch` could never make fail were dropped.
4. *(LOW)* The route comment implied 65 was the only pre-run failure; `daemon.py` returns **64** for a bad config before it reaches the token at all. Corrected.

Also found while verifying the above: the component test misused the `findByText` overload (`{timeout}` as the 2nd argument instead of the 3rd), which made `tsc --noEmit` exit 1 — fixed — and its two 5 s query waits sat inside vitest's default 5 s *test* budget, so it timed out on a loaded runner; it now declares `15_000`.

**Refuted**

- *(HIGH)* "Map every daemon exit code so no non-zero exit can leave as 2xx." Correct in principle — the daemon really does ship a deliberate taxonomy (`EXIT_*` in `clawkeep/clawkeep/runner.py:32-43`, mirroring `api.ApiError.kind`) and the bridge consumes none of it. But it is a redesign of the backup result path, not this fix: failures would stop returning 2xx, `BackupResultCard`'s failure branch and `clawkeep.result.backupFailed` across 10 locales would be orphaned, and whether the owner still sees the daemon tail is a product decision. **Filed as its own follow-up task, TASK-672 under TASK-604**, naming that `EXIT_*` taxonomy as the mechanism to adopt. What this PR does instead is make the one case it is about — no pairing — impossible to reach, and make the scheduler stop swallowing the rest.
- *(MEDIUM)* "`label`/`lock`/`delete`/`prune`/`restore` still surface `resp.error` verbatim." Pre-existing on beta and untouched by this diff, except that those catch blocks gained the shared envelope. Not this PR's regression; it belongs with the mapping work above.
- *(MEDIUM)* "`readToken()` does not mirror the daemon's `assert_perms`, so a 0644 token still reaches exit 65 → 200." Real but rare, and its general remedy is the exit-code mapping above.
- *(LOW)* "The new `code` field has no in-repo consumer yet." The finding brief requires the code; MCP `BACKUP_RULES` already acts on the 409 **status**, and the ClawKeep panel shows server sentences in English everywhere, so localising only this one would be inconsistent. Noted as a follow-up.
- *(LOW/INFO)* "`pruneSnapshots` has no caller; `passphrase-status` is unused." Both pre-existing, informational.

### Second pass — 6 findings, 0 HIGH, no blocker

It confirmed the things that matter: `exitCode !== 0` is a **sound and complete** "it failed" predicate (it read `daemon.py:64-80` and `runner.py:197-250` — every daemon failure path returns non-zero, and none returns 0 without doing the work); the exit-127 test is genuinely falsifiable, since the mock *resolves* and only the new `.then()` branch can emit that warning; `rearm()` in `.finally()` cannot reject; no new probe-once, false-success or false-failure; and the daemon never logs the bearer, so the stderr tail added to the journal leaks no credential. It also independently re-confirmed the sibling-site sweep — `runBackup` has exactly two production callers, `clawkeep-memory-scheduler.ts` branches on its resolved result so it does not share the defect, no other instance of the shape exists in `src/` or `mcp/`, every `pairedDaemonBin()`-gated function has one caller and all were updated, and `writeToken` precedes `syncStateFromCloud` in `pair/poll` so the gate cannot break a fresh pair.

**Applied**

1. *(MEDIUM)* The MCP 409 → `CONFLICT` contract was asserted in a comment and held by nothing — this diff had *removed* the only test that drove the unpaired case through `backup_now`. Added that test back for `backup_now` and its `backup_list` twin.
2. *(LOW)* The backup-route comment claimed a non-zero `exitCode` means "the daemon ran and failed". False for the two codes the bridge synthesises itself: **127** (spawn error — it never started) and **124** (killed by our own timer). Reworded.
3. *(LOW)* The scheduler comment said the Settings button "never reaches this path". The gate is `!daemonInstalled || !archiverReady`, so that holds only for 127; 64/65/3 all reach it. Scoped the claim.
4. *(LOW)* The reworded `mapSnapshotsError` comment pointed at `api.ApiError.kind` as the future source, but its union is `auth | quota_full | tier | server | network | other` — no pairing member at all. Corrected to say making the branch live needs a daemon-side change.
5. *(INFO)* The route test covered `backup`/`restore`/`snapshots` but not `label`/`lock`/`delete`, which this PR also newly gates. Added a table-driven case over the three — all three are RED on beta.

**Refuted**

- *(MEDIUM)* The failure is journal-only and the panel still says "Protected" — a real gap, taken as the stated scope boundary above and filed as **TASK-673** rather than folded in, because changing what "protected" means is a product decision.
- *(LOW)* `sanitiseSchedule` validates `timeOfDay` by shape (`/^\d{2}:\d{2}$/` accepts `"99:99"`) while `computeNextRunMs` validates by range, so an enabled schedule can disarm `arm()` silently. Pre-existing, not this diff, and reachable only through the API — recorded on **TASK-672**.

### CodeRabbit

One actionable finding: the token check-to-use race between `readToken()` and the daemon's own read. Real, and answered in-thread — this PR narrows it from unconditional (every press on every unpaired box) to a token removed during the moments a backup is starting. Neither remedy it proposed is available today: serialising unpair behind a backup would hold the "fast and offline-safe" unpair button for minutes and reintroduce the stuck-spinner bug its route exists to prevent, and it would not cover a portal-side revoke at all; and the daemon has no structured not-paired result to convert, since `cli.py::_emit_err` emits no `kind` on any path. The general remedy is TASK-672.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer pairing-status errors for backup, restore, snapshot, labeling, locking, and deletion actions.
  * Portal-backed operations now require a local pairing token before running.
  * Scheduled backup failures now include daemon exit details and recent diagnostic output.

* **Bug Fixes**
  * Standardized error responses across ClawKeep actions.
  * Improved handling of unpaired-device conflicts and disk-space failures.
  * Prevented daemon failure output from appearing as regular application content.

* **Tests**
  * Expanded coverage for pairing loss, scheduled backup failures, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->