### PR TITLE
fix: re-check the on-box STT files on every probe instead of caching installed for 6 h

### DIFF
--- a/src/lib/stt-local.ts
+++ b/src/lib/stt-local.ts
@@ -45,12 +45,15 @@ function whisperUnitPath(): string {
 // fits only a warm server would fail every first call of the day.
 const TRANSCRIBE_TIMEOUT_MS = 120_000;
 const PROBE_TIMEOUT_MS = 15_000;
-// The probe spawns python to import faster-whisper, which is a real cost on
-// this board, and the settings panel and every chat-mic press both ask.
-const PROBE_TTL_MS = 60_000;
-// An installed faster-whisper does not uninstall itself: hold a positive answer
-// for hours, and re-ask a negative one every minute so an install shows up.
-const INSTALLED_TTL_MS = 6 * 60 * 60 * 1000;
+// Spawning python to import faster-whisper is a real cost on this board, and
+// the settings panel and every chat-mic press both ask. ONLY that import is
+// cached: the file checks below are two stat() calls and are asked every time.
+// A successful import is held for hours; a failed one is re-asked every minute
+// so an install shows up. A `pip uninstall` or a python minor-version bump does
+// outlast the positive TTL — an accepted residual, and far rarer than the
+// removed-script case the per-call file checks above close.
+const IMPORT_MISSING_TTL_MS = 60_000;
+const IMPORT_OK_TTL_MS = 6 * 60 * 60 * 1000;
 
 /**
  * The whole environment the script gets. `systemctl --user` needs
@@ -81,9 +84,40 @@ export interface LocalSttProbe {
   detail: string;
 }
 
-let probeCache: { at: number; value: LocalSttProbe } | null = null;
+let importCache: { at: number; ok: boolean } | null = null;
 
-async function probe(): Promise<LocalSttProbe> {
+/** Can python3 import faster-whisper? The one expensive half, and the only
+ *  half that is cached. */
+async function fasterWhisperImports(): Promise<boolean> {
+  const ttl = importCache?.ok ? IMPORT_OK_TTL_MS : IMPORT_MISSING_TTL_MS;
+  if (importCache && Date.now() - importCache.at < ttl) return importCache.ok;
+  const check = await runChild(PYTHON3, ["-c", "import faster_whisper"], {
+    timeoutMs: PROBE_TIMEOUT_MS,
+    env: childEnv(),
+    notStarted: "python3 could not be started",
+  });
+  const ok = check.code === 0;
+  importCache = { at: Date.now(), ok };
+  return ok;
+}
+
+/**
+ * Whether this box can transcribe on its own.
+ *
+ * The two file checks are asked on EVERY call, and only the python import is
+ * cached. Holding the whole answer for six hours meant an engine removed from
+ * the box — by hand, from the Terminal or the agent's shell; nothing in the app
+ * uninstalls it — still read as installed. Settings then offered "On this box"
+ * as a working choice, and /setup-api/stt wrote a `type: "cli"` row into
+ * openclaw.json for a script that is gone. OpenClaw takes such a row on trust —
+ * `openclaw config set` accepts it and no doctor check inspects a configured CLI
+ * entry — and then pays a failed exec for it on every channel voice note before
+ * falling through to the cloud row behind it. The chat microphone runs the same
+ * missing script and answers "Transcription failed on this box." whenever the
+ * cloud leg cannot cover for it. Two stat() calls are what keeps this box from
+ * advertising an engine it no longer has.
+ */
+export async function localSttInstalled(): Promise<LocalSttProbe> {
   // Cheapest checks first, so a box that never installed the engine answers
   // from two stat() calls and never spawns an interpreter.
   if (!(await exists(sttClientScriptPath()))) {
@@ -92,24 +126,10 @@ async function probe(): Promise<LocalSttProbe> {
   if (!(await exists(whisperUnitPath()))) {
     return { installed: false, detail: "The whisper-server service is not installed." };
   }
-  const check = await runChild(PYTHON3, ["-c", "import faster_whisper"], {
-    timeoutMs: PROBE_TIMEOUT_MS,
-    env: childEnv(),
-    notStarted: "python3 could not be started",
-  });
-  if (check.code !== 0) {
+  if (!(await fasterWhisperImports())) {
     return { installed: false, detail: "faster-whisper is not installed for python3." };
   }
   return { installed: true, detail: "faster-whisper, kept warm by whisper-server." };
-}
-
-/** Whether this box can transcribe on its own. Cached — see the TTLs above. */
-export async function localSttInstalled(): Promise<LocalSttProbe> {
-  const ttl = probeCache?.value.installed ? INSTALLED_TTL_MS : PROBE_TTL_MS;
-  if (probeCache && Date.now() - probeCache.at < ttl) return probeCache.value;
-  const value = await probe();
-  probeCache = { at: Date.now(), value };
-  return value;
 }
 
 /**

--- a/src/lib/stt-preference.ts
+++ b/src/lib/stt-preference.ts
@@ -68,8 +68,9 @@ export type AudioModelEntry = Record<string, unknown>;
  * The local entry is a CLI row running the same stt-client.py the chat
  * microphone uses (see stt-local.ts); `{{MediaPath}}` is OpenClaw's
  * placeholder for the voice note on disk. It is left out when the engine is
- * not installed, because OpenClaw would otherwise spend its timeout on a
- * script that is not there before reaching the cloud row behind it.
+ * not installed: OpenClaw would otherwise try the row and record a failed
+ * attempt for every voice note before reaching the cloud row behind it — and
+ * on a box with no usable cloud leg, that is the transcript lost.
  */
 export function buildAudioModels(order: readonly SttEngine[], localInstalled: boolean): AudioModelEntry[] {
   const entries: AudioModelEntry[] = [];

--- a/src/tests/unit/stt-local.test.ts
+++ b/src/tests/unit/stt-local.test.ts
@@ -170,11 +170,59 @@ describe("localSttInstalled", () => {
     expect(probe.detail).toContain("faster-whisper");
   });
 
-  it("remembers the answer for a minute instead of spawning python each time", async () => {
+  it("remembers the python import instead of spawning an interpreter each time", async () => {
     installEngine();
     runChild.mockResolvedValue(ran());
     await lib.localSttInstalled();
     await lib.localSttInstalled();
+    expect(runChild).toHaveBeenCalledTimes(1);
+  });
+
+  // The engine can leave the box while the web server keeps running — a
+  // manual removal from the Terminal or the agent's shell; nothing in the app
+  // uninstalls it. A positive answer held for hours after that is what put a
+  // `type: "cli"` row for a script that is gone into tools.media.models, and
+  // OpenClaw takes such a row on trust: `openclaw config set` accepts it and
+  // no doctor check inspects a configured CLI entry, so the row is retried and
+  // discarded on every voice note. The two stat() calls must be asked every time.
+  it("stops reading as installed once the script is removed, inside the positive TTL", async () => {
+    installEngine();
+    runChild.mockResolvedValue(ran());
+    expect((await lib.localSttInstalled()).installed).toBe(true);
+
+    fs.rmSync(path.join(home, ".openclaw", "workspace", "scripts", "stt-client.py"));
+
+    const after = await lib.localSttInstalled();
+    expect(after.installed).toBe(false);
+    expect(after.detail).toContain("The on-box transcriber is not installed.");
+  });
+
+  it("stops reading as installed once the whisper-server unit is removed, inside the positive TTL", async () => {
+    installEngine();
+    runChild.mockResolvedValue(ran());
+    expect((await lib.localSttInstalled()).installed).toBe(true);
+
+    fs.rmSync(path.join(home, ".config", "systemd", "user", "whisper-server.service"));
+
+    const after = await lib.localSttInstalled();
+    expect(after.installed).toBe(false);
+    expect(after.detail).toContain("whisper-server");
+  });
+
+  // The other half of the split: a file check that answers false must not
+  // throw away what python already told us, or every chat-mic press on a box
+  // without the engine would start an interpreter again.
+  it("keeps the python answer across a file check that failed in between", async () => {
+    installEngine();
+    runChild.mockResolvedValue(ran());
+    expect((await lib.localSttInstalled()).installed).toBe(true);
+
+    const script = path.join(home, ".openclaw", "workspace", "scripts", "stt-client.py");
+    fs.rmSync(script);
+    expect((await lib.localSttInstalled()).installed).toBe(false);
+    fs.writeFileSync(script, "#!/usr/bin/env python3\n");
+    expect((await lib.localSttInstalled()).installed).toBe(true);
+
     expect(runChild).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
**Finding F-26** (TASK-628, under TASK-604) — PROBE-ONCE, OpenClaw edition.

## Symptom the owner sees

The on-box transcriber is removed from the box (by hand, from the Terminal or the
agent's shell — nothing in the app uninstalls it). For up to six hours afterwards:

- Settings still shows **On this box — installed** and offers it as a working choice;
- saving the preference writes a `type: "cli"` row into `tools.media.models` in
  openclaw.json that runs a script which is gone, so every channel voice note pays a
  failed exec and records a failed attempt before falling through to the cloud row;
- the chat microphone runs the same missing script and answers **"Transcription
  failed on this box."** whenever the cloud leg cannot cover for it.

So the box advertises — and points OpenClaw at — a speech engine it no longer has.

## Cause

`localSttInstalled()` cached the **whole** answer, including the two cheap `exists()`
checks, for `INSTALLED_TTL_MS = 6 h` whenever the answer was positive
(`src/lib/stt-local.ts:53`, `:107-109` on beta). Both the 409 refusal and the
`buildAudioModels(order, local.installed)` write in `src/app/setup-api/stt/route.ts`
read that cached fact, so a write that changes openclaw.json was made from a
six-hour-old observation of the filesystem.

## Harness first — what OpenClaw does with a `tools.media.models` row that is gone

Checked against the installed OpenClaw 2026.8.1 before writing any code. **The harness
neither refuses nor repairs such a row**, so there is nothing to delegate to and nothing
to duplicate; the fix is only to stop writing a stale fact.

- `openclaw config set tools.media.models '[{"type":"cli","command":"/usr/bin/python3","args":["<a path that does not exist>","{{AttachmentPath}}"],"capabilities":["audio"],"timeoutSeconds":120}]'` exits **0** and writes the row ("Updated tools.media.models"), run against an isolated `OPENCLAW_CONFIG_PATH`. No existence validation.
- Doctor has no check for it. `core/doctor/local-audio-acceleration` →
  `collectLocalAudioAccelerationFindings()` → `inspectLocalAudioSelection()` only
  inspects the **auto-detected** binaries (`whisper-cli`, `sherpa-onnx-offline`,
  `parakeet-mlx`, `whisper`); its own fixHint ends "…or configure an audio-capable
  tools.media.models CLI entry", i.e. a configured entry is taken on trust.
  `core/doctor/model-references` inspects provider refs only.
- `openclaw capability audio providers` lists provider rows only; a `type: "cli"` row is
  not in its inventory at all.
- Docs (`nodes/media-understanding.md`): auto-detect uses only "**Ready** local
  binaries", but "Explicit CLI entries keep their configured order".
- At runtime the dead row is not fatal — `runAttachmentEntries` catches the failing entry
  and continues to the cloud row behind it — but it is a failed attempt on every voice
  note, and the transcript is genuinely lost on a box whose cloud leg is unusable.

Conclusion: ClawBox's own two `stat()` calls are the only thing on the box that knows
whether this engine is there, which is exactly why they must not be cached.

## Fix

`src/lib/stt-local.ts` — split the probe. The two file checks (`stt-client.py`,
`whisper-server.service`) run on **every** `localSttInstalled()` call; only the expensive
`python3 -c "import faster_whisper"` is cached, keeping beta's 6 h positive / 60 s
negative TTLs (renamed `IMPORT_OK_TTL_MS` / `IMPORT_MISSING_TTL_MS`, since they no longer
describe the whole answer). Cost per call is two `stat()`s — the same two a
never-installed box already paid on every chat-mic press. No spawn-rate change in any of
the four states, including removed-then-restored, because the import cache survives a
file check that answered false (pinned by a test).

No invalidator was added: the verdict pass established there is no in-app uninstall path
to hook (`src/lib/local-models.ts:685-694` only maps engines to units for start/stop,
`install-voice.sh` has no uninstall mode) and a factory reset reboots, which drops the
cache anyway. Re-statting per call is what covers the only real trigger, a manual removal.

`src/lib/stt-preference.ts` — one comment corrected, same subject: it claimed OpenClaw
"would spend its timeout" on the missing script. It does not (`/usr/bin/python3` exists,
so it exits in milliseconds); it records a failed attempt and moves on.

## Sibling call sites

Every reader of `localSttInstalled()` and every writer of `tools.media.models`:

| Site | Verdict |
| --- | --- |
| `src/app/setup-api/stt/route.ts:52` (GET status) | Fixed by the change — Settings now flips to "not installed" on the next read instead of six hours later. |
| `src/app/setup-api/stt/route.ts:140` (POST: the 409 guard **and** `syncChannelAudio(..., local.installed)`) | Fixed by the change — this is the write; it now refuses with `local.detail` ("The on-box transcriber is not installed.") instead of writing the row. |
| `src/app/setup-api/chat/transcribe/route.ts:339` | Fixed by the change — a removed engine now falls straight through to cloud instead of spawning a script that is gone. |
| `src/app/setup-api/stt/route.ts:111` — the only TS writer of `tools.media.models` | Same POST path; covered. |
| `scripts/gateway-pre-start.sh:1409-1424` — the other writer | **Cleared, unchanged.** It seeds `CLAWBOX_AUDIO_MODELS = [cloud]` only and never creates a CLI row; its own comment says the on-box row is Settings' to add "because only that route knows whether faster-whisper is installed here", and it matches the script by name rather than by path on purpose. |
| `buildAudioModels` (`src/lib/stt-preference.ts:74`) | One caller, the route above. |
| TTS / other local engines — `buildTtsInventory` → `kokoroEntry`, `whisperEntry`, `readUnitState` (`src/lib/local-models.ts:183`, `:329`, `:362`) | **Cleared, no cache to fix**: `/setup-api/tts` builds its probe fresh per request; these re-read the unit state and stamp on every call. The finding's guess at a TTS-side equivalent cache was wrong. The other `*_TTL_MS` caches in the tree (`hermes-skills-server.ts` skills 10 s, `harness/clawai-images.ts` — which already has an invalidator, `hermes-dashboard-turn.ts` turn provider 30 s) are not local-engine install probes. |

Hermes edition: unaffected. `localSttInstalled()` is edition-blind and both paths are
HOME-relative, so on Hermes the script is simply absent — a permanent two-stat `false` at
no spawn cost — and `openclawIsAbsent()` still gates the channel half.

## RED → GREEN

RED — the final test file run against unmodified beta `bc39e24f`'s `src/lib/stt-local.ts`
(`src/tests/unit/stt-local.test.ts`, three new cases):

```
 ❯ |unit| src/tests/unit/stt-local.test.ts (15 tests | 3 failed) 60ms
     × stops reading as installed once the script is removed, inside the positive TTL 6ms
     × stops reading as installed once the whisper-server unit is removed, inside the positive TTL 2ms
     × keeps the python answer across a file check that failed in between 1ms

 FAIL  ... > stops reading as installed once the script is removed, inside the positive TTL
AssertionError: expected true to be false // Object.is equality
- Expected  false
+ Received  true
 ❯ src/tests/unit/stt-local.test.ts:196:29

 FAIL  ... > stops reading as installed once the whisper-server unit is removed, inside the positive TTL
AssertionError: expected true to be false // Object.is equality
 ❯ src/tests/unit/stt-local.test.ts:208:29

 FAIL  ... > keeps the python answer across a file check that failed in between
AssertionError: expected true to be false // Object.is equality
 ❯ src/tests/unit/stt-local.test.ts:222:55

 Test Files  1 failed (1)
      Tests  3 failed | 12 passed (15)
```

GREEN, with the fix:

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Neighbouring suites (`stt-local`, `routes/stt`, `routes/chat-transcribe`,
`stt-preference`, `stt-bench`, `local-models-installer-contract`): 114 passed.

Full suite as CI runs it, `bun run test:coverage:ci`:

```
 Test Files  646 passed (646)
      Tests  9329 passed (9329)
```

`tsc --noEmit` and `eslint` on the touched files: clean.

## Knowingly left open

- **A stale row already in openclaw.json is not reconciled.** This PR stops a dead row
  being written; one written before the engine was removed survives until the owner next
  saves the STT preference (at which point the truthful probe rewrites the list, or
  refuses with 409 for `primary: "local"`). Cleaning it up belongs in
  `gateway-pre-start.sh`, which already recognises the row and resolves HOME — a separate
  change, since it must not disturb that block's "never reorder a list this migration
  recognises" invariant.
- **The 6 h positive import cache is still probe-once one level down.** A
  `pip uninstall faster-whisper` or a python minor-version bump outlasts it. Accepted and
  named in the code: far rarer than the removed-script case, and the spawn is the
  genuinely expensive half.
- **No in-flight coalescing on the python probe** (pre-existing): two concurrent cold
  calls both spawn the interpreter. The repo's TTL-plus-shared-promise pattern in
  `openclaw-channels.ts` would fix it; out of scope here.
- **No device leg.** A library-level probe split with no hardware, systemd, updater or
  edition-lock behaviour; CI exercises it fully and no box was touched.

Reviewed on Opus via the `clawbox-review` pass: 1 medium, 3 low, 3 informational. The
medium (the new comment overstated what OpenClaw does with a dead CLI row) and the
informational test-naming/coverage points are applied above; the rest are recorded under
"Knowingly left open" or are pre-existing follow-ups (`whisperEntry()` calls the engine
installed on the unit file alone; `stt-preference.ts:85` still writes the deprecated
`{{MediaPath}}` alias).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Local speech-to-text availability now reflects newly removed or restored installations without waiting for the cache to expire.
  * Prevented unavailable local speech-to-text options from being offered, avoiding failed transcription attempts and potential transcript loss when cloud fallback is unavailable.

* **Tests**
  * Added coverage for installation changes and cached interpreter checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->