### PR TITLE
fix: keep the Hermes shell scanner across a factory reset, and say when it is off

### DIFF
--- a/docs-site/support/recovery.mdx
+++ b/docs-site/support/recovery.mdx
@@ -103,7 +103,7 @@ The script defaults to `main`; `CLAWBOX_BRANCH` keeps a box on its own channel.
 internet and could not re-download them:
 
 - `data/network.env` and `data/llamacpp/models/` — the offline on-device model weights (several GB).
-- `~/.hermes/hermes-agent/` and `~/.hermes/bin/tirith` on the Hermes edition — the agent checkout and its Python venv (`~/.local/bin/hermes` is a shim that execs the interpreter inside it), plus the pre-exec shell scanner the agent runs every command past. The scanner is downloaded from a GitHub release on first use, so a box that lost it and has no internet runs commands unscanned.
+- `~/.hermes/hermes-agent/` and the whole of `~/.hermes/bin/` on the Hermes edition — the agent checkout and its Python venv (`~/.local/bin/hermes` is a shim that execs the interpreter inside it), plus everything in `bin/`, which is where the agent installs `tirith`, the pre-exec shell scanner it runs every command past. The scanner is downloaded from a GitHub release on first use, so a box that lost it and has no internet runs commands unscanned. The reset keeps `bin/` entire rather than filtering it down to `tirith`: nothing on the device has an authoritative inventory of that directory, so removing its other entries could brick a box with no internet to restore them.
 - `~/.cache/huggingface` voice models (only the `token` / `stored_tokens` credential files are removed).
 
 The device's **portal identity is also not cleared**: the cached id in `data/cloudflared/device-id`
@@ -172,9 +172,10 @@ step fails you can stop and retry without stranding the box.
     # OpenClaw state and ClawKeep backup pairing (both editions — harmless if empty).
     find ~/.openclaw ~/.clawkeep -maxdepth 1 -mindepth 1 -exec rm -rf {} + 2>/dev/null || true
 
-    # Hermes edition only — everything except the agent install and the shell scanner.
+    # Hermes edition only — everything except the agent install and bin/, which
+    # holds the pre-exec shell scanner. Both are kept whole, exactly as the UI
+    # reset keeps them.
     find ~/.hermes -maxdepth 1 -mindepth 1 ! -name hermes-agent ! -name bin -exec rm -rf {} +
-    find ~/.hermes/bin -maxdepth 1 -mindepth 1 ! -name tirith -exec rm -rf {} + 2>/dev/null || true
     ```
 
     `~/.hermes` is where a Hermes box keeps its `config.yaml` (billing token, dashboard signing

--- a/docs-site/support/recovery.mdx
+++ b/docs-site/support/recovery.mdx
@@ -103,7 +103,7 @@ The script defaults to `main`; `CLAWBOX_BRANCH` keeps a box on its own channel.
 internet and could not re-download them:
 
 - `data/network.env` and `data/llamacpp/models/` — the offline on-device model weights (several GB).
-- `~/.hermes/hermes-agent/` on the Hermes edition — the agent checkout and its Python venv. `~/.local/bin/hermes` is a shim that execs the interpreter inside it.
+- `~/.hermes/hermes-agent/` and `~/.hermes/bin/tirith` on the Hermes edition — the agent checkout and its Python venv (`~/.local/bin/hermes` is a shim that execs the interpreter inside it), plus the pre-exec shell scanner the agent runs every command past. The scanner is downloaded from a GitHub release on first use, so a box that lost it and has no internet runs commands unscanned.
 - `~/.cache/huggingface` voice models (only the `token` / `stored_tokens` credential files are removed).
 
 The device's **portal identity is also not cleared**: the cached id in `data/cloudflared/device-id`
@@ -172,8 +172,9 @@ step fails you can stop and retry without stranding the box.
     # OpenClaw state and ClawKeep backup pairing (both editions — harmless if empty).
     find ~/.openclaw ~/.clawkeep -maxdepth 1 -mindepth 1 -exec rm -rf {} + 2>/dev/null || true
 
-    # Hermes edition only — everything except the agent install itself.
-    find ~/.hermes -maxdepth 1 -mindepth 1 ! -name hermes-agent -exec rm -rf {} +
+    # Hermes edition only — everything except the agent install and the shell scanner.
+    find ~/.hermes -maxdepth 1 -mindepth 1 ! -name hermes-agent ! -name bin -exec rm -rf {} +
+    find ~/.hermes/bin -maxdepth 1 -mindepth 1 ! -name tirith -exec rm -rf {} + 2>/dev/null || true
     ```
 
     `~/.hermes` is where a Hermes box keeps its `config.yaml` (billing token, dashboard signing

--- a/docs-site/technical/authentication.mdx
+++ b/docs-site/technical/authentication.mdx
@@ -67,5 +67,6 @@ AI provider keys and OAuth sessions are separate from all of the above — see [
 - Web login is rate-limited with lockout; passwords are never logged; control characters are rejected.
 - Privileged operations run through an allowlisted systemd template (polkit + narrow sudoers), never arbitrary root exec from the web process.
 - Telegram DMs default to **pairing** mode — unknown senders are inert until the owner approves their 8-character code. Config that would open DMs to everyone (`dmPolicy:"open"` + `allowFrom:["*"]`) is actively stripped on boot.
+- On the **Hermes edition** the agent scans every shell command with `tirith` before running it. The scanner is not shipped — the agent downloads it the first time the box is online — and upstream's default is *fail-open*, so a box that has never had internet runs commands unscanned. Settings → System reports that state instead of leaving it silent, and `security.tirith_fail_open: false` in `~/.hermes/config.yaml` switches the agent to refusing commands it cannot scan.
 - Factory reset wipes credentials, SSH keys, histories, and browser profiles — see [Recovery](/support/recovery).
 - Vulnerability reports: see [SECURITY.md](https://github.com/ID-Robots/clawbox/blob/main/SECURITY.md).

--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -22,7 +22,7 @@ Rows marked **OpenClaw/dual** or **Hermes/dual** exist only on those editions. C
 | `…/clawbox/config/openclaw-target.txt` | Pinned OpenClaw version for the fleet |
 | `…/clawbox/.next/` | Production build output (`BUILD_ID` = fingerprint of the running build) |
 | `~/.openclaw/` — **OpenClaw/dual** | **OpenClaw state**: `openclaw.json` (gateway config), `agents/` (per-agent credentials — exact paths in the table below), `credentials/` (Telegram pairing approvals), `workspace/` (agent working dir), `npm/` (plugins) |
-| `~/.hermes/` — **Hermes/dual** | **Hermes state** — the Hermes equivalent of `~/.openclaw`, and the densest secret store on the box: `config.yaml` (0600 — billing token, dashboard session signing secret, scrypt password hash, `mcp_servers.clawbox`), `config.yaml.bak-*`, `.env` (provider keys), `auth.json` (OAuth tokens), `memories/`, `sessions/`, `skills/`, `pairing/`, `cron/`, `logs/`, `state.db`, and `hermes-agent/` — the agent checkout + Python venv |
+| `~/.hermes/` — **Hermes/dual** | **Hermes state** — the Hermes equivalent of `~/.openclaw`, and the densest secret store on the box: `config.yaml` (0600 — billing token, dashboard session signing secret, scrypt password hash, `mcp_servers.clawbox`), `config.yaml.bak-*`, `.env` (provider keys), `auth.json` (OAuth tokens), `memories/`, `sessions/`, `skills/`, `pairing/`, `cron/`, `logs/`, `state.db`, `hermes-agent/` — the agent checkout + Python venv — and `bin/tirith`, the upstream pre-exec shell scanner the agent downloads on first use |
 | `~/.local/bin/hermes` — **Hermes/dual** | 4-line shim that execs `~/.hermes/hermes-agent/venv/bin/python` |
 | `/etc/clawbox/edition.env` | Root-owned edition lock (`openclaw` \| `hermes` \| `dual`) — the authority for the SKU; survives updates **and** factory reset |
 | `~/.codex/auth.json` | Codex CLI auth (kept in sync with the agent copies) |
@@ -57,7 +57,7 @@ Rows marked **OpenClaw/dual** or **Hermes/dual** exist only on those editions. C
 | `.env` | ✅ kept | ✅ kept (gitignored, not in wipe list) |
 | `.update-branch` (channel pin) | ✅ kept | ✅ kept |
 | `~/.openclaw` (AI config, credentials, chats) | ✅ kept | ❌ wiped |
-| `~/.hermes` (Hermes config, chats, agent install) | ✅ kept | ❌ wiped, except `hermes-agent` (the agent install — can't be re-downloaded in AP mode) |
+| `~/.hermes` (Hermes config, chats, agent install) | ✅ kept | ❌ wiped, except `hermes-agent` (the agent install) and `bin/tirith` (the pre-exec shell scanner) — neither can be re-downloaded in AP mode |
 | `~/.clawkeep` (backup pairing) | ✅ kept | ❌ wiped |
 | `~/.codex` (Codex CLI auth) | ✅ kept | ❌ wiped |
 | `~/Documents`, `~/Downloads`, `~/Desktop` | ✅ kept | ❌ contents wiped, directories kept |

--- a/docs-site/technical/filesystem.mdx
+++ b/docs-site/technical/filesystem.mdx
@@ -57,7 +57,7 @@ Rows marked **OpenClaw/dual** or **Hermes/dual** exist only on those editions. C
 | `.env` | ✅ kept | ✅ kept (gitignored, not in wipe list) |
 | `.update-branch` (channel pin) | ✅ kept | ✅ kept |
 | `~/.openclaw` (AI config, credentials, chats) | ✅ kept | ❌ wiped |
-| `~/.hermes` (Hermes config, chats, agent install) | ✅ kept | ❌ wiped, except `hermes-agent` (the agent install) and `bin/tirith` (the pre-exec shell scanner) — neither can be re-downloaded in AP mode |
+| `~/.hermes` (Hermes config, chats, agent install) | ✅ kept | ❌ wiped, except `hermes-agent` (the agent install) and the whole of `bin/` (which holds `tirith`, the pre-exec shell scanner) — neither can be re-downloaded in AP mode. `bin/` is kept entire rather than filtered down to `tirith`, so anything else upstream puts there survives too |
 | `~/.clawkeep` (backup pairing) | ✅ kept | ❌ wiped |
 | `~/.codex` (Codex CLI auth) | ✅ kept | ❌ wiped |
 | `~/Documents`, `~/Downloads`, `~/Desktop` | ✅ kept | ❌ contents wiped, directories kept |

--- a/src/app/setup-api/harness/status/route.ts
+++ b/src/app/setup-api/harness/status/route.ts
@@ -16,12 +16,16 @@ export async function GET() {
   // On a locked device only the active harness's runtime is installed, so don't
   // probe (or advertise) the other one — just report the single active harness.
   const ids = locked ? [active] : (Object.keys(HARNESSES) as Harness[]);
-  const health = await Promise.all(ids.map(async (id) => [id, await harnessHealthy(id)] as const));
-  const healthById = new Map(health);
   // Pre-exec shell scanning is a Hermes-only control (tirith). Asking about it
   // on the OpenClaw harness would report a missing scanner on a box that never
   // has one — a false failure — so the answer there is "not applicable", null.
-  const shellScan = active === "hermes" ? await readShellScanStatus() : null;
+  // Read ALONGSIDE the health probes, not after them: this route already gates
+  // the whole Agent-harness card, which renders empty until it answers.
+  const [health, shellScan] = await Promise.all([
+    Promise.all(ids.map(async (id) => [id, await harnessHealthy(id)] as const)),
+    active === "hermes" ? readShellScanStatus() : Promise.resolve(null),
+  ]);
+  const healthById = new Map(health);
   return NextResponse.json({
     active,
     edition: getEdition(),

--- a/src/app/setup-api/harness/status/route.ts
+++ b/src/app/setup-api/harness/status/route.ts
@@ -4,10 +4,12 @@ import { NextResponse } from "next/server";
 import {
   getActiveHarness, harnessHealthy, HARNESSES, getEdition, isSingleHarnessEdition, type Harness,
 } from "@/lib/harness";
+import { readShellScanStatus } from "@/lib/hermes-shell-scan";
 
 // Report which agent harness is active, the edition/lock state (so the Settings
 // picker can render a read-only badge instead of a switcher on a single-harness
-// device), and whether each harness's local server is up.
+// device), whether each harness's local server is up, and — on Hermes — whether
+// the agent is scanning shell commands before it runs them.
 export async function GET() {
   const active = await getActiveHarness();
   const locked = isSingleHarnessEdition();
@@ -16,10 +18,15 @@ export async function GET() {
   const ids = locked ? [active] : (Object.keys(HARNESSES) as Harness[]);
   const health = await Promise.all(ids.map(async (id) => [id, await harnessHealthy(id)] as const));
   const healthById = new Map(health);
+  // Pre-exec shell scanning is a Hermes-only control (tirith). Asking about it
+  // on the OpenClaw harness would report a missing scanner on a box that never
+  // has one — a false failure — so the answer there is "not applicable", null.
+  const shellScan = active === "hermes" ? await readShellScanStatus() : null;
   return NextResponse.json({
     active,
     edition: getEdition(),
     locked,
+    shellScan,
     harnesses: ids.map((id) => ({
       ...HARNESSES[id],
       healthy: healthById.get(id) ?? false,

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -60,13 +60,8 @@ const DATA_KEEP_NAMES = new Set(DATA_KEEP.map((entry) => entry.rel));
 
 // The two named exceptions to the ~/.hermes wipe. Neither is owner state and
 // neither can be re-fetched on a reset device — it reboots into AP mode with no
-// internet. `bin` survives this pass as a CONTAINER only: HERMES_BIN_KEEP below
-// then wipes it down to the scanner. Rationale for both is at the
-// HOME_CONTENT_WIPE_KEEP entries.
+// internet. Rationale for both is at the HOME_CONTENT_WIPE_KEEP entry below.
 const HERMES_KEEP = new Set(["hermes-agent", "bin"]);
-
-/** The upstream pre-exec shell scanner, and nothing else in ~/.hermes/bin. */
-const HERMES_BIN_KEEP = new Set(["tirith"]);
 
 /** Delete all Ollama models so a factory reset starts with a clean slate. */
 async function deleteOllamaModels(): Promise<void> {
@@ -295,8 +290,15 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // on every box of this SKU.
     //
     // KNOWN RESIDUAL, accepted deliberately: a previous owner with a shell
-    // could plant a file inside this one preserved directory and it would
-    // survive the reset. The obvious guard — wipe the checkout unless `git
+    // could plant a file inside a preserved directory and it would survive the
+    // reset. For bin/tirith that residual is sharper than for the checkout —
+    // the agent EXECUTES that file before every shell command and its exit code
+    // decides whether the command runs — but it is not made worse by keeping
+    // the directory rather than the file: a planted `tirith` survives either
+    // way, and nothing on the device can tell a genuine release binary from a
+    // replacement without a trusted checksum it does not have offline. That is
+    // also why the dashboard's scan status reports "installed and enabled", not
+    // "your commands are being checked" (src/lib/hermes-shell-scan.ts). The obvious guard — wipe the checkout unless `git
     // status --porcelain` is empty — was tried and rejected. Both of its
     // outcomes are worse than the hole: wiping a "dirty" checkout recreates
     // this very brick on every box of the SKU at once the day upstream starts
@@ -309,6 +311,28 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // a reset is the real fix, and it needs network this device does not have
     // at reset time.
     //
+    // The second exception is bin/, and it is the same category. It holds the
+    // upstream `tirith` binary the agent runs BEFORE every shell command
+    // (Hermes' own `security.tirith_*` keys configure it). tirith is not
+    // shipped with the box: the agent downloads it from a GitHub release into
+    // $HERMES_HOME/bin the first time it is needed, and upstream's default is
+    // fail-OPEN, so a box without it runs shell commands UNSCANNED. Wiping it
+    // therefore handed the next owner an agent with its pre-exec safety check
+    // silently off, for as long as the box stayed in AP mode — and a failed
+    // download then writes ~/.hermes/.tirith-install-failed, which suppresses
+    // the retry for another 24 h. That marker is NOT kept, so the reset clears
+    // it and the next download attempt is immediate.
+    //
+    // Kept whole rather than narrowed to bin/tirith, deliberately. Narrowing
+    // would mean wiping the directory entry-by-entry, and the only thing that
+    // buys is removing files beside tirith that nothing on the box executes —
+    // ~/.hermes/bin is not on the agent's PATH. What it costs is real: nothing
+    // here has an authoritative inventory of that directory (ClawKeep's
+    // archiver calls it a virtualenv, `clawkeep/clawkeep/hermes.py`), so a
+    // narrow keep would delete whatever else upstream puts there, on every box
+    // of the SKU at once, with no internet to restore it. Same argument the
+    // `git status --porcelain` guard was rejected on above.
+    //
     // Re-provisioning of the removed state is automatic: the dashboard unit
     // runs scripts/setup-hermes-dashboard-auth.sh as an ExecStartPre, which
     // recreates config.yaml and a fresh password/hash/signing-secret on the
@@ -320,28 +344,6 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // agent already half deleted.
     rel: ".hermes",
     keep: HERMES_KEEP,
-  },
-  {
-    // ~/.hermes/bin holds `tirith`, the ~33 MB upstream binary the Hermes agent
-    // runs BEFORE every shell command (`security.tirith_*` in config.yaml). It
-    // is an upstream release artefact, not owner state, and the agent
-    // re-downloads it from a GitHub release only once the box has internet
-    // again — which a reset box does not have, because it reboots into AP mode.
-    // Wiping it therefore left the next owner's agent executing shell commands
-    // with pre-exec scanning off (upstream's default is fail-OPEN), for as long
-    // as the box stayed offline, and nothing on the device said so.
-    //
-    // The exception is the SCANNER, not the directory: unlike hermes-agent/,
-    // this one is wiped entry-by-entry down to `tirith`, so nothing a previous
-    // owner dropped beside it is inherited and no second whole preserved
-    // directory is created. An upstream binary that appears here later is
-    // removed by default and re-downloaded, which is the right way round.
-    //
-    // SAME KNOWN RESIDUAL as hermes-agent/ and no worse: a previous owner with
-    // a shell can overwrite the preserved file itself. Detecting that needs a
-    // trusted checksum the device does not have offline.
-    rel: ".hermes/bin",
-    keep: HERMES_BIN_KEEP,
   },
 ];
 

--- a/src/app/setup-api/setup/reset/route.ts
+++ b/src/app/setup-api/setup/reset/route.ts
@@ -58,7 +58,15 @@ const DATA_KEEP: ReadonlyArray<{ rel: string; keep?: ReadonlySet<string> }> = [
 ];
 const DATA_KEEP_NAMES = new Set(DATA_KEEP.map((entry) => entry.rel));
 
-const HERMES_KEEP = new Set(["hermes-agent"]);
+// The two named exceptions to the ~/.hermes wipe. Neither is owner state and
+// neither can be re-fetched on a reset device — it reboots into AP mode with no
+// internet. `bin` survives this pass as a CONTAINER only: HERMES_BIN_KEEP below
+// then wipes it down to the scanner. Rationale for both is at the
+// HOME_CONTENT_WIPE_KEEP entries.
+const HERMES_KEEP = new Set(["hermes-agent", "bin"]);
+
+/** The upstream pre-exec shell scanner, and nothing else in ~/.hermes/bin. */
+const HERMES_BIN_KEEP = new Set(["tirith"]);
 
 /** Delete all Ollama models so a factory reset starts with a clean slate. */
 async function deleteOllamaModels(): Promise<void> {
@@ -312,6 +320,28 @@ const HOME_CONTENT_WIPE_KEEP: ReadonlyArray<{ rel: string; keep: ReadonlySet<str
     // agent already half deleted.
     rel: ".hermes",
     keep: HERMES_KEEP,
+  },
+  {
+    // ~/.hermes/bin holds `tirith`, the ~33 MB upstream binary the Hermes agent
+    // runs BEFORE every shell command (`security.tirith_*` in config.yaml). It
+    // is an upstream release artefact, not owner state, and the agent
+    // re-downloads it from a GitHub release only once the box has internet
+    // again — which a reset box does not have, because it reboots into AP mode.
+    // Wiping it therefore left the next owner's agent executing shell commands
+    // with pre-exec scanning off (upstream's default is fail-OPEN), for as long
+    // as the box stayed offline, and nothing on the device said so.
+    //
+    // The exception is the SCANNER, not the directory: unlike hermes-agent/,
+    // this one is wiped entry-by-entry down to `tirith`, so nothing a previous
+    // owner dropped beside it is inherited and no second whole preserved
+    // directory is created. An upstream binary that appears here later is
+    // removed by default and re-downloaded, which is the right way round.
+    //
+    // SAME KNOWN RESIDUAL as hermes-agent/ and no worse: a previous owner with
+    // a shell can overwrite the preserved file itself. Detecting that needs a
+    // trusted checksum the device does not have offline.
+    rel: ".hermes/bin",
+    keep: HERMES_BIN_KEEP,
   },
 ];
 

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -42,6 +42,7 @@ type Translate = (key: string, params?: Record<string, string | number>) => stri
 function shellScanWarning(
   scan: ShellScanRow | null | undefined,
   t: Translate,
+  locale: string,
 ): { title: string; detail: string; severe: boolean } | null {
   if (!scan || scan.state === "on") return null;
   if (scan.state === "unknown") {
@@ -53,7 +54,9 @@ function shellScanWarning(
   // Upstream suppresses the re-download for 24 h after a failure, so "connect
   // it to the internet" is not the whole story and the owner has to be told.
   const until = scan.retrySuppressedUntil
-    ? ` ${t("shellScan.retryAfter", { time: new Date(scan.retrySuppressedUntil).toLocaleString() })}`
+    // The UI locale, not the runtime default: the rest of this sentence is
+    // already in the owner's language, so the timestamp inside it has to be.
+    ? ` ${t("shellScan.retryAfter", { time: new Date(scan.retrySuppressedUntil).toLocaleString(locale) })}`
     : "";
   // The two outcomes are opposites, not degrees: fail-open runs the command
   // unchecked, fail-closed refuses to run it at all.
@@ -66,7 +69,7 @@ function shellScanWarning(
 // Both share one identity; providers stay per-harness. Self-contained so it
 // drops into Settings → System with a single import.
 export default function HarnessPicker() {
-  const { t } = useT();
+  const { t, locale } = useT();
   const [status, setStatus] = useState<HarnessStatus | null>(null);
   const [switching, setSwitching] = useState<string | null>(null);
   const [error, setError] = useState("");
@@ -113,7 +116,7 @@ export default function HarnessPicker() {
   );
 
   const activeEntry = status?.harnesses?.find((h) => h.id === status.active);
-  const warning = shellScanWarning(status?.shellScan, t);
+  const warning = shellScanWarning(status?.shellScan, t, locale);
 
   return (
     <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useT } from "@/lib/i18n";
+import { shellScanEn } from "@/lib/hermes-translations/en-shell-scan";
 
 interface HarnessEntry {
   id: string;
@@ -31,6 +32,24 @@ interface ShellScanRow {
 type Translate = (key: string, params?: Record<string, string | number>) => string;
 
 /**
+ * `t`, but this card never renders a raw key.
+ *
+ * `I18nProvider` serves `t(key) === key` until its dynamic import of the
+ * catalogue resolves — and forever if that import fails, which it explicitly
+ * contemplates ("the device is offline mid-update"). Everything else on this
+ * card is hardcoded English and would look normal beside it, so the one
+ * sentence in the product that says a security control is off would be the only
+ * thing on screen reading `shellScan.offTitle`. The English table is imported
+ * statically, so it cannot be the thing that failed to load.
+ */
+function scanCopy(t: Translate, key: string, params?: Record<string, string | number>): string {
+  const translated = t(key, params);
+  if (translated !== key) return translated;
+  const english = shellScanEn[key] ?? key;
+  return params ? english.replace(/\{(\w+)\}/g, (m, name) => String(params[name] ?? m)) : english;
+}
+
+/**
  * What to say about pre-exec shell scanning, or null when there is nothing to
  * say. Returning null for a healthy box is the point: a box whose scanner is
  * installed must not be warned at, or the warning stops meaning anything.
@@ -46,23 +65,23 @@ function shellScanWarning(
 ): { title: string; detail: string; severe: boolean } | null {
   if (!scan || scan.state === "on") return null;
   if (scan.state === "unknown") {
-    return { title: t("shellScan.unknownTitle"), detail: t("shellScan.unknownDetail"), severe: false };
+    return { title: scanCopy(t, "shellScan.unknownTitle"), detail: scanCopy(t, "shellScan.unknownDetail"), severe: false };
   }
   if (scan.reason === "disabled-by-config") {
-    return { title: t("shellScan.offTitle"), detail: t("shellScan.disabledDetail"), severe: true };
+    return { title: scanCopy(t, "shellScan.offTitle"), detail: scanCopy(t, "shellScan.disabledDetail"), severe: true };
   }
   // Upstream suppresses the re-download for 24 h after a failure, so "connect
   // it to the internet" is not the whole story and the owner has to be told.
   const until = scan.retrySuppressedUntil
     // The UI locale, not the runtime default: the rest of this sentence is
     // already in the owner's language, so the timestamp inside it has to be.
-    ? ` ${t("shellScan.retryAfter", { time: new Date(scan.retrySuppressedUntil).toLocaleString(locale) })}`
+    ? ` ${scanCopy(t, "shellScan.retryAfter", { time: new Date(scan.retrySuppressedUntil).toLocaleString(locale) })}`
     : "";
   // The two outcomes are opposites, not degrees: fail-open runs the command
   // unchecked, fail-closed refuses to run it at all.
   return scan.failOpen
-    ? { title: t("shellScan.offTitle"), detail: `${t("shellScan.missingDetail")}${until}`, severe: true }
-    : { title: t("shellScan.blockedTitle"), detail: `${t("shellScan.blockedDetail")}${until}`, severe: true };
+    ? { title: scanCopy(t, "shellScan.offTitle"), detail: `${scanCopy(t, "shellScan.missingDetail")}${until}`, severe: true }
+    : { title: scanCopy(t, "shellScan.blockedTitle"), detail: `${scanCopy(t, "shellScan.blockedDetail")}${until}`, severe: true };
 }
 
 // Lets the user pick which agent harness (OpenClaw / Hermes) backs the device.

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { useT } from "@/lib/i18n";
+
 interface HarnessEntry {
   id: string;
   label: string;
@@ -26,42 +28,45 @@ interface ShellScanRow {
   retrySuppressedUntil?: string | null;
 }
 
+type Translate = (key: string, params?: Record<string, string | number>) => string;
+
 /**
  * What to say about pre-exec shell scanning, or null when there is nothing to
  * say. Returning null for a healthy box is the point: a box whose scanner is
- * ready must not be warned at, or the warning stops meaning anything.
+ * installed must not be warned at, or the warning stops meaning anything.
+ *
+ * `severe` separates the two live regions below. "Off" and "blocked" are a
+ * security control not doing its job; "unknown" is only this box failing to
+ * read its own settings.
  */
-function shellScanWarning(scan: ShellScanRow | null | undefined): { title: string; detail: string } | null {
+function shellScanWarning(
+  scan: ShellScanRow | null | undefined,
+  t: Translate,
+): { title: string; detail: string; severe: boolean } | null {
   if (!scan || scan.state === "on") return null;
   if (scan.state === "unknown") {
-    return {
-      title: "Shell command scanning: unknown",
-      detail: "The agent's security settings could not be read, so this box cannot confirm that commands are scanned before they run.",
-    };
+    return { title: t("shellScan.unknownTitle"), detail: t("shellScan.unknownDetail"), severe: false };
   }
   if (scan.reason === "disabled-by-config") {
-    return {
-      title: "Shell command scanning is off",
-      detail: "It was turned off in the agent's settings (security.tirith_enabled). Commands run without a pre-execution safety check.",
-    };
+    return { title: t("shellScan.offTitle"), detail: t("shellScan.disabledDetail"), severe: true };
   }
+  // Upstream suppresses the re-download for 24 h after a failure, so "connect
+  // it to the internet" is not the whole story and the owner has to be told.
   const until = scan.retrySuppressedUntil
-    ? ` The agent will not retry the download before ${new Date(scan.retrySuppressedUntil).toLocaleString()}.`
+    ? ` ${t("shellScan.retryAfter", { time: new Date(scan.retrySuppressedUntil).toLocaleString() })}`
     : "";
-  return {
-    title: scan.failOpen ? "Shell command scanning is off" : "Shell commands are blocked",
-    detail: scan.failOpen
-      // The honest wording for the factory-reset case: the control is off, the
-      // agent still runs commands, and the box needs internet to fix itself.
-      ? `The safety scanner is not installed. The agent downloads it the first time the box is online, and until then it runs shell commands without scanning them.${until}`
-      : `The safety scanner is not installed, and the agent is set to refuse shell commands without it. Connect the box to the internet so it can download the scanner.${until}`,
-  };
+  // The two outcomes are opposites, not degrees: fail-open runs the command
+  // unchecked, fail-closed refuses to run it at all.
+  return scan.failOpen
+    ? { title: t("shellScan.offTitle"), detail: `${t("shellScan.missingDetail")}${until}`, severe: true }
+    : { title: t("shellScan.blockedTitle"), detail: `${t("shellScan.blockedDetail")}${until}`, severe: true };
 }
 
 // Lets the user pick which agent harness (OpenClaw / Hermes) backs the device.
 // Both share one identity; providers stay per-harness. Self-contained so it
 // drops into Settings → System with a single import.
 export default function HarnessPicker() {
+  const { t } = useT();
   const [status, setStatus] = useState<HarnessStatus | null>(null);
   const [switching, setSwitching] = useState<string | null>(null);
   const [error, setError] = useState("");
@@ -108,7 +113,7 @@ export default function HarnessPicker() {
   );
 
   const activeEntry = status?.harnesses?.find((h) => h.id === status.active);
-  const warning = shellScanWarning(status?.shellScan);
+  const warning = shellScanWarning(status?.shellScan, t);
 
   return (
     <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
@@ -178,16 +183,16 @@ export default function HarnessPicker() {
       {warning && (
         <div
           data-testid="shell-scan-warning"
-          role="status"
+          role={warning.severe ? "alert" : "status"}
           className="mt-3 flex items-start gap-2 rounded-xl border border-amber-400/40 bg-amber-400/10 p-3"
         >
           <span className="material-symbols-rounded text-amber-400 shrink-0" style={{ fontSize: 16 }} aria-hidden="true">
             warning
           </span>
-          <span className="text-xs text-[var(--text-secondary)]">
-            <span className="block font-medium text-[var(--text-primary)]">{warning.title}</span>
-            {warning.detail}
-          </span>
+          <div className="text-xs text-[var(--text-secondary)]">
+            <h4 className="text-xs font-medium text-[var(--text-primary)] m-0">{warning.title}</h4>
+            <p className="m-0 mt-0.5">{warning.detail}</p>
+          </div>
         </div>
       )}
       {error && <p className="text-xs text-red-400 mt-3">{error}</p>}

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -182,7 +182,7 @@ export default function HarnessPicker() {
           className="mt-3 flex items-start gap-2 rounded-xl border border-amber-400/40 bg-amber-400/10 p-3"
         >
           <span className="material-symbols-rounded text-amber-400 shrink-0" style={{ fontSize: 16 }} aria-hidden="true">
-            shield_with_heart
+            warning
           </span>
           <span className="text-xs text-[var(--text-secondary)]">
             <span className="block font-medium text-[var(--text-primary)]">{warning.title}</span>

--- a/src/components/HarnessPicker.tsx
+++ b/src/components/HarnessPicker.tsx
@@ -15,6 +15,47 @@ interface HarnessStatus {
   /** Single-harness edition (or dual without a premium license) → no switcher. */
   locked?: boolean;
   edition?: string;
+  /** Hermes pre-exec shell scanning. Null/absent on a harness that has none. */
+  shellScan?: ShellScanRow | null;
+}
+
+interface ShellScanRow {
+  state?: string;
+  reason?: string;
+  failOpen?: boolean;
+  retrySuppressedUntil?: string | null;
+}
+
+/**
+ * What to say about pre-exec shell scanning, or null when there is nothing to
+ * say. Returning null for a healthy box is the point: a box whose scanner is
+ * ready must not be warned at, or the warning stops meaning anything.
+ */
+function shellScanWarning(scan: ShellScanRow | null | undefined): { title: string; detail: string } | null {
+  if (!scan || scan.state === "on") return null;
+  if (scan.state === "unknown") {
+    return {
+      title: "Shell command scanning: unknown",
+      detail: "The agent's security settings could not be read, so this box cannot confirm that commands are scanned before they run.",
+    };
+  }
+  if (scan.reason === "disabled-by-config") {
+    return {
+      title: "Shell command scanning is off",
+      detail: "It was turned off in the agent's settings (security.tirith_enabled). Commands run without a pre-execution safety check.",
+    };
+  }
+  const until = scan.retrySuppressedUntil
+    ? ` The agent will not retry the download before ${new Date(scan.retrySuppressedUntil).toLocaleString()}.`
+    : "";
+  return {
+    title: scan.failOpen ? "Shell command scanning is off" : "Shell commands are blocked",
+    detail: scan.failOpen
+      // The honest wording for the factory-reset case: the control is off, the
+      // agent still runs commands, and the box needs internet to fix itself.
+      ? `The safety scanner is not installed. The agent downloads it the first time the box is online, and until then it runs shell commands without scanning them.${until}`
+      : `The safety scanner is not installed, and the agent is set to refuse shell commands without it. Connect the box to the internet so it can download the scanner.${until}`,
+  };
 }
 
 // Lets the user pick which agent harness (OpenClaw / Hermes) backs the device.
@@ -67,6 +108,7 @@ export default function HarnessPicker() {
   );
 
   const activeEntry = status?.harnesses?.find((h) => h.id === status.active);
+  const warning = shellScanWarning(status?.shellScan);
 
   return (
     <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface-card)] p-5">
@@ -132,6 +174,21 @@ export default function HarnessPicker() {
           );
         })}
       </div>
+      )}
+      {warning && (
+        <div
+          data-testid="shell-scan-warning"
+          role="status"
+          className="mt-3 flex items-start gap-2 rounded-xl border border-amber-400/40 bg-amber-400/10 p-3"
+        >
+          <span className="material-symbols-rounded text-amber-400 shrink-0" style={{ fontSize: 16 }} aria-hidden="true">
+            shield_with_heart
+          </span>
+          <span className="text-xs text-[var(--text-secondary)]">
+            <span className="block font-medium text-[var(--text-primary)]">{warning.title}</span>
+            {warning.detail}
+          </span>
+        </div>
       )}
       {error && <p className="text-xs text-red-400 mt-3">{error}</p>}
     </div>

--- a/src/lib/hermes-shell-scan.ts
+++ b/src/lib/hermes-shell-scan.ts
@@ -59,6 +59,7 @@
  */
 
 import fs from "fs/promises";
+import type { FileHandle } from "fs/promises";
 import { constants as fsConstants } from "fs";
 import path from "path";
 
@@ -193,6 +194,7 @@ async function resolveScanner(configuredPath: string): Promise<string | null> {
   return (await which(DEFAULT_PATH)) ?? (await onlyIfExecutable(path.join(hermesHome(), "bin", DEFAULT_PATH)));
 }
 
+/** `p` when it is an executable regular file, otherwise null. */
 async function onlyIfExecutable(p: string): Promise<string | null> {
   return (await isExecutableFile(p)) ? p : null;
 }
@@ -206,16 +208,30 @@ async function onlyIfExecutable(p: string): Promise<string | null> {
  */
 async function readRetrySuppressedUntil(): Promise<string | null> {
   const marker = path.join(hermesHome(), INSTALL_FAILED_MARKER);
+  // ONE descriptor for both the age and the reason. Reading the mtime by name
+  // and then the contents by name lets the path mean two different files
+  // between the calls (CWE-367), and those two answers together decide what the
+  // owner is told about a security control. O_NONBLOCK because the regular-file
+  // check happens after the open: a fifo dropped here would otherwise park this
+  // request until someone opened the write end. Same open, for the same two
+  // reasons, as `readEnvText` in hermes-env.ts.
+  let handle: FileHandle;
   try {
-    const [stat, reason] = await Promise.all([
-      fs.stat(marker),
-      fs.readFile(marker, "utf-8").catch(() => ""),
-    ]);
+    handle = await fs.open(marker, fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
+  } catch {
+    return null; // No marker — upstream retries on the next command.
+  }
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) return null;
+    const reason = await handle.readFile("utf-8");
     if (reason.trim() === RETRYABLE_MARKER_REASON) return null;
     const until = stat.mtimeMs + MARKER_TTL_MS;
     return until > Date.now() ? new Date(until).toISOString() : null;
   } catch {
     return null;
+  } finally {
+    await handle.close().catch(() => {});
   }
 }
 

--- a/src/lib/hermes-shell-scan.ts
+++ b/src/lib/hermes-shell-scan.ts
@@ -1,0 +1,230 @@
+/**
+ * Is the Hermes agent scanning shell commands BEFORE it runs them?
+ *
+ * The agent runs every shell command past `tirith` first (upstream's
+ * `tools/tirith_security.py`). That scanner is not shipped with the box: the
+ * agent downloads it from a GitHub release into `$HERMES_HOME/bin/tirith` in a
+ * background thread the first time it is needed. Until that finishes the agent
+ * runs commands UNSCANNED — upstream's default is fail-OPEN — and the only
+ * trace is one `logger.warning` per process ("tirith path resolved to None;
+ * scanning disabled"). No error, no non-zero exit, nothing a health check sees.
+ *
+ * That is a security control that can be off while the product reports nothing,
+ * which is the failure this module exists to end. It answers one question for
+ * the dashboard: is pre-exec scanning on right now, and if not, why.
+ *
+ * HARNESS FIRST — everything here is read from the harness's own contract, not
+ * invented:
+ *
+ *   * the settings are Hermes' own `security.tirith_*` keys in config.yaml,
+ *     read through the `hermes` CLI (`hermes-config-cache`), with the same
+ *     `TIRITH_ENABLED` / `TIRITH_BIN` / `TIRITH_FAIL_OPEN` env overrides and the
+ *     same defaults (enabled, path `"tirith"`, fail-open) upstream applies in
+ *     `_load_security_config()`;
+ *   * the install location is upstream's `$HERMES_HOME/bin/tirith`;
+ *   * the 24 h retry suppression is upstream's `.tirith-install-failed` marker.
+ *
+ * ClawBox deliberately does NOT gate exec itself. Upstream already owns that
+ * decision through `security.tirith_fail_open`: `false` turns a missing or
+ * unspawnable scanner into `{"action": "block"}`. Re-implementing a gate here
+ * would be a second, divergent policy over the same commands. `failOpen` is
+ * reported so the UI can say which of the two the box is doing.
+ *
+ * KNOWN LIMIT, upstream's not ours: after three consecutive scanner failures
+ * upstream opens a circuit breaker that returns `allow` unconditionally, ABOVE
+ * the `fail_open` check. So `failOpen: false` is not an absolute guarantee, and
+ * this module reports the configured intent, not a promise.
+ *
+ * NOT probe-once: the scanner appears on disk the moment the background
+ * download finishes, so the filesystem checks run per call. Only the config
+ * keys are cached, and that cache is invalidated by config.yaml's mtime.
+ *
+ * SERVER ONLY.
+ */
+
+import fs from "fs/promises";
+import { constants as fsConstants } from "fs";
+import path from "path";
+
+import { hermesConfigGetMany, hermesConfigReadPending } from "@/lib/hermes-config-cache";
+import { hermesHome, readHermesEnv } from "@/lib/hermes-env";
+
+/** Hermes' own config keys, and the env vars that override each of them. */
+const KEYS = {
+  enabled: { config: "security.tirith_enabled", env: "TIRITH_ENABLED" },
+  // Upstream's env var is TIRITH_BIN while the config key is tirith_path —
+  // deliberately not the same name. Do not "fix" this to TIRITH_PATH.
+  path: { config: "security.tirith_path", env: "TIRITH_BIN" },
+  failOpen: { config: "security.tirith_fail_open", env: "TIRITH_FAIL_OPEN" },
+} as const;
+
+/** Upstream's defaults when neither the config key nor the env var is set. */
+const DEFAULT_ENABLED = true;
+const DEFAULT_PATH = "tirith";
+const DEFAULT_FAIL_OPEN = true;
+
+/** Upstream writes this beside config.yaml and skips retries while it is fresh. */
+const INSTALL_FAILED_MARKER = ".tirith-install-failed";
+const MARKER_TTL_MS = 24 * 60 * 60 * 1000;
+
+export type ShellScanState = "on" | "off" | "unknown";
+
+export type ShellScanReason =
+  /** The scanner resolved and is executable. */
+  | "ok"
+  /** Not on the box (yet) — the usual case after a factory reset or a fresh flash. */
+  | "not-installed"
+  /** Somebody set `security.tirith_enabled: false` (or `TIRITH_ENABLED=0`). */
+  | "disabled-by-config"
+  /** The agent's own config could not be read, so nothing here is asserted. */
+  | "config-unreadable";
+
+export interface ShellScanStatus {
+  state: ShellScanState;
+  reason: ShellScanReason;
+  /**
+   * Upstream's `security.tirith_fail_open`. `true` (upstream's default) means a
+   * missing scanner lets commands through unscanned; `false` means the agent
+   * blocks them instead. Decides which sentence the dashboard shows.
+   */
+  failOpen: boolean;
+  /** Where the scanner was found. Null whenever `state` is not `"on"`. */
+  scannerPath: string | null;
+  /**
+   * ISO timestamp until which upstream is suppressing download retries after a
+   * failed install, or null. This is why a box that is back online can still be
+   * unscanned: the marker survives going online, only its 24 h age clears it.
+   */
+  retrySuppressedUntil: string | null;
+}
+
+/** Upstream's `_env_bool`: only these count as true; anything else is false. */
+function envBool(raw: string): boolean {
+  return ["1", "true", "yes"].includes(raw.trim().toLowerCase());
+}
+
+/**
+ * A boolean out of `hermes config get`. "" is "the key is not set" — the CLI
+ * exits non-zero for an unset key and the cache turns that into an empty
+ * string — so the caller's default applies. An unrecognised value is treated
+ * the same way rather than guessed at.
+ */
+function configBool(raw: string, fallback: boolean): boolean {
+  const v = raw.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(v)) return true;
+  if (["0", "false", "no", "off"].includes(v)) return false;
+  return fallback;
+}
+
+/** True when `p` is a regular file this process may execute. */
+async function isExecutableFile(p: string): Promise<boolean> {
+  try {
+    const stat = await fs.stat(p);
+    if (!stat.isFile()) return false;
+    await fs.access(p, fsConstants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** `os.path.expanduser`, for the one form a config file ever uses. */
+function expandUser(p: string): string {
+  if (p !== "~" && !p.startsWith("~/")) return p;
+  return path.join(process.env.HOME || "/home/clawbox", p.slice(1));
+}
+
+/**
+ * Where the scanner is, mirroring `_resolve_tirith_path()` without its
+ * side-effects — this must never trigger a download, only report.
+ *
+ * Upstream looks on PATH and then in `$HERMES_HOME/bin`. Both are checked here,
+ * with one caveat worth stating: PATH here is the web server's, not the agent's,
+ * so a bare name that only the agent can resolve would read as missing. It does
+ * not matter in practice — the only thing that ever puts tirith on a ClawBox is
+ * the agent's own installer, into `$HERMES_HOME/bin`, which is checked directly.
+ */
+async function resolveScanner(configuredPath: string): Promise<string | null> {
+  const expanded = expandUser(configuredPath);
+  const candidates = expanded.includes(path.sep)
+    ? [expanded]
+    : [...searchPath(expanded), path.join(hermesHome(), "bin", expanded)];
+  for (const candidate of candidates) {
+    if (await isExecutableFile(candidate)) return candidate;
+  }
+  return null;
+}
+
+/** `shutil.which`'s candidate list for a bare name. */
+function searchPath(name: string): string[] {
+  return (process.env.PATH || "").split(path.delimiter).filter(Boolean).map((dir) => path.join(dir, name));
+}
+
+/** When upstream will next allow a download retry, or null if it will now. */
+async function readRetrySuppressedUntil(): Promise<string | null> {
+  try {
+    const marker = path.join(hermesHome(), INSTALL_FAILED_MARKER);
+    const until = (await fs.stat(marker)).mtimeMs + MARKER_TTL_MS;
+    return until > Date.now() ? new Date(until).toISOString() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Report whether the Hermes agent is scanning shell commands before running
+ * them. Callers must only ask this for the Hermes harness — the OpenClaw
+ * harness has no tirith and must not be told it is missing one.
+ */
+export async function readShellScanStatus(): Promise<ShellScanStatus> {
+  let env: Record<string, string>;
+  try {
+    env = await readHermesEnv();
+  } catch {
+    // An unreadable ~/.hermes/.env could be hiding a TIRITH_* override, so no
+    // claim about the scanner can be made. Saying "on" here would be exactly
+    // the false success this module exists to prevent.
+    return unknown();
+  }
+
+  const config = await hermesConfigGetMany([KEYS.enabled.config, KEYS.path.config, KEYS.failOpen.config]);
+  // Checked AFTER the reads have settled: an answer is cached against
+  // config.yaml's mtime and never expires, so anything still "pending" here is
+  // a read that failed (a wedged or missing `hermes`), not one in flight.
+  if (Object.values(KEYS).some(({ config: key }) => hermesConfigReadPending(key))) return unknown();
+
+  const failOpen = KEYS.failOpen.env in env
+    ? envBool(env[KEYS.failOpen.env])
+    : configBool(config[KEYS.failOpen.config] ?? "", DEFAULT_FAIL_OPEN);
+
+  const enabled = KEYS.enabled.env in env
+    ? envBool(env[KEYS.enabled.env])
+    : configBool(config[KEYS.enabled.config] ?? "", DEFAULT_ENABLED);
+  if (!enabled) {
+    return { state: "off", reason: "disabled-by-config", failOpen, scannerPath: null, retrySuppressedUntil: null };
+  }
+
+  const configuredPath = (env[KEYS.path.env] || config[KEYS.path.config] || "").trim() || DEFAULT_PATH;
+  const scannerPath = await resolveScanner(configuredPath);
+  if (scannerPath) {
+    return { state: "on", reason: "ok", failOpen, scannerPath, retrySuppressedUntil: null };
+  }
+  return {
+    state: "off",
+    reason: "not-installed",
+    failOpen,
+    scannerPath: null,
+    retrySuppressedUntil: await readRetrySuppressedUntil(),
+  };
+}
+
+/** "We could not read the agent's own settings" — never dressed up as "on". */
+function unknown(): ShellScanStatus {
+  return {
+    state: "unknown",
+    reason: "config-unreadable",
+    failOpen: DEFAULT_FAIL_OPEN,
+    scannerPath: null,
+    retrySuppressedUntil: null,
+  };
+}

--- a/src/lib/hermes-shell-scan.ts
+++ b/src/lib/hermes-shell-scan.ts
@@ -65,7 +65,7 @@ import path from "path";
 
 import { hermesConfigPath } from "@/lib/hermes-config-yaml";
 import { hermesHome, readHermesEnv } from "@/lib/hermes-env";
-import { getYamlPath } from "@/lib/yaml-block-edit";
+import { getYamlPath, hasYamlPath } from "@/lib/yaml-block-edit";
 
 /** Hermes' own config keys, and the env var that overrides each of them. */
 const KEYS = {
@@ -81,11 +81,31 @@ const DEFAULT_ENABLED = true;
 const DEFAULT_PATH = "tirith";
 const DEFAULT_FAIL_OPEN = true;
 
+/**
+ * A config.yaml this large is not a config file. Same guard, and the same
+ * reason, as `MAX_ENV_BYTES` next door in hermes-env: this read happens behind a
+ * Settings panel and must not be able to pull an arbitrary amount of a planted
+ * file into memory.
+ */
+const MAX_CONFIG_BYTES = 1024 * 1024;
+
 /** Upstream writes this beside config.yaml and skips retries while it is fresh. */
 const INSTALL_FAILED_MARKER = ".tirith-install-failed";
 const MARKER_TTL_MS = 24 * 60 * 60 * 1000;
-/** The one marker reason upstream clears early, so the 24 h claim is wrong for it. */
+/**
+ * The one marker reason upstream drops early — and only when `cosign` is on the
+ * agent's PATH (`tirith_security.py:200-205`); without it the 24 h suppression
+ * stands like any other. Nothing upstream writes this reason today (a missing
+ * cosign downgrades to SHA-256 only, `:451`), so this is a guard against a
+ * future bump, not a live case.
+ */
 const RETRYABLE_MARKER_REASON = "cosign_missing";
+
+/** One key out of config.yaml: whether it is there at all, and its raw scalar. */
+interface ConfigValue {
+  present: boolean;
+  raw: string | null;
+}
 
 export type ShellScanState = "on" | "off" | "unknown";
 
@@ -123,13 +143,34 @@ function envBool(raw: string): boolean {
   return ["1", "true", "yes"].includes(raw.trim().toLowerCase());
 }
 
-/** A YAML scalar as a boolean, or null when the key is unset or unrecognised. */
-function yamlBool(raw: string | null): boolean | null {
-  if (raw === null) return null;
-  const v = raw.trim().toLowerCase();
-  if (["1", "true", "yes", "on"].includes(v)) return true;
-  if (["0", "false", "no", "off"].includes(v)) return false;
-  return null;
+/**
+ * Values PyYAML resolves to something Python calls false. `no`/`off`/`n` are in
+ * the list because the config is YAML 1.1, where they are booleans; `[]`/`{}`
+ * because an empty collection is falsy; `0`/`0.0` because zero is.
+ */
+const FALSY_YAML = new Set(["false", "no", "off", "n", "null", "~", "0", "0.0", "[]", "{}", ""]);
+
+/**
+ * A configured Hermes flag, as UPSTREAM reads it.
+ *
+ * Upstream does not parse these as booleans at all — `_load_security_config`
+ * hands the YAML value through untouched and the call sites apply plain Python
+ * truthiness (`if not cfg["tirith_enabled"]`, `if fail_open`). So anything
+ * present that is not falsy is TRUE, including a word like `maybe`; and a key
+ * written with no value at all is `None`, which is FALSE, not "unset".
+ *
+ * Returns null only for a key that is genuinely absent — the one case where the
+ * caller's default applies.
+ *
+ * KNOWN LIMIT: `getYamlPath` unquotes, so `tirith_enabled: "false"` (a truthy
+ * Python string) is indistinguishable here from `tirith_enabled: false`. It is
+ * read as false, i.e. as "scanning off" — the direction that warns rather than
+ * the one that stays quiet.
+ */
+function configuredFlag(value: ConfigValue): boolean | null {
+  if (!value.present) return null;
+  if (value.raw === null) return false; // `key:` with nothing after it → None
+  return !FALSY_YAML.has(value.raw.trim().toLowerCase());
 }
 
 /** True when `p` is a regular file this process may execute. */
@@ -202,9 +243,10 @@ async function onlyIfExecutable(p: string): Promise<string | null> {
 /**
  * When upstream will next allow a download retry, or null if it will retry now.
  *
- * `cosign_missing` is excluded on purpose: upstream clears that marker as soon
- * as `cosign` is on PATH (`:189-199`), so claiming a 24 h wait for it would be a
- * false failure.
+ * A `cosign_missing` marker is excluded ONLY when cosign is actually installed:
+ * that is the condition on which upstream clears it and retries (`:189-205`).
+ * Excluding it unconditionally would tell the owner to connect the box to the
+ * internet on a box that will not retry for another day.
  */
 async function readRetrySuppressedUntil(): Promise<string | null> {
   const marker = path.join(hermesHome(), INSTALL_FAILED_MARKER);
@@ -225,7 +267,7 @@ async function readRetrySuppressedUntil(): Promise<string | null> {
     const stat = await handle.stat();
     if (!stat.isFile()) return null;
     const reason = await handle.readFile("utf-8");
-    if (reason.trim() === RETRYABLE_MARKER_REASON) return null;
+    if (reason.trim() === RETRYABLE_MARKER_REASON && (await which("cosign"))) return null;
     const until = stat.mtimeMs + MARKER_TTL_MS;
     return until > Date.now() ? new Date(until).toISOString() : null;
   } catch {
@@ -235,23 +277,53 @@ async function readRetrySuppressedUntil(): Promise<string | null> {
   }
 }
 
-/** The `security:` block as raw scalars, or null when the file is unreadable. */
-async function readSecurityConfig(): Promise<Record<keyof typeof KEYS, string | null> | null> {
-  let text: string;
+/**
+ * config.yaml's text, "" when the box has none yet, or null when it could not be
+ * read.
+ *
+ * Hardened the same way, and for the same two reasons, as `readEnvText` in
+ * hermes-env and the marker read above. The agent runs as the same user and can
+ * write `~/.hermes`: a plain `fs.readFile` on a FIFO planted there parks in
+ * `open(2)` with no writer, and this read sits inside the status route's
+ * `Promise.all`, so that request would never settle and each one would hold a
+ * libuv threadpool thread. `O_NONBLOCK` returns immediately (it has no effect on
+ * a regular file, the only case that goes on to read), the regular-file check
+ * happens on the descriptor that was opened, and the size is capped.
+ */
+async function readConfigText(): Promise<string | null> {
+  let handle: FileHandle;
   try {
-    text = await fs.readFile(hermesConfigPath(), "utf-8");
+    handle = await fs.open(hermesConfigPath(), fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     // No config.yaml is an ordinary state — a box before its first boot. Upstream
     // swallows that and applies its defaults (`:79-80`), so it is not "unknown".
-    if (code === "ENOENT" || code === "ENOTDIR") text = "";
-    else return null;
+    return code === "ENOENT" || code === "ENOTDIR" ? "" : null;
   }
   try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > MAX_CONFIG_BYTES) return null;
+    return await handle.readFile("utf-8");
+  } catch {
+    return null;
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+/** The `security:` block, or null when the file could not be read or parsed. */
+async function readSecurityConfig(): Promise<Record<keyof typeof KEYS, ConfigValue> | null> {
+  const text = await readConfigText();
+  if (text === null) return null;
+  try {
+    const read = (yaml: readonly string[]): ConfigValue => ({
+      present: hasYamlPath(text, [...yaml]),
+      raw: getYamlPath(text, [...yaml]),
+    });
     return {
-      enabled: getYamlPath(text, [...KEYS.enabled.yaml]),
-      path: getYamlPath(text, [...KEYS.path.yaml]),
-      failOpen: getYamlPath(text, [...KEYS.failOpen.yaml]),
+      enabled: read(KEYS.enabled.yaml),
+      path: read(KEYS.path.yaml),
+      failOpen: read(KEYS.failOpen.yaml),
     };
   } catch {
     // A shape the line reader does not understand. Reporting the defaults here
@@ -280,12 +352,12 @@ export async function readShellScanStatus(): Promise<ShellScanStatus> {
   const enabledOverride = KEYS.enabled.env in env ? envBool(env[KEYS.enabled.env]) : null;
   const failOpen =
     (KEYS.failOpen.env in env ? envBool(env[KEYS.failOpen.env]) : null) ??
-    yamlBool(config?.failOpen ?? null) ??
+    (config ? configuredFlag(config.failOpen) : null) ??
     DEFAULT_FAIL_OPEN;
 
   // An override in .env settles the question on its own, so an unreadable
   // config.yaml must not turn a definitively-off box into "unknown".
-  const enabled = enabledOverride ?? (config ? yamlBool(config.enabled) ?? DEFAULT_ENABLED : null);
+  const enabled = enabledOverride ?? (config ? configuredFlag(config.enabled) ?? DEFAULT_ENABLED : null);
   if (enabled === null) return unknown();
   if (!enabled) {
     return { state: "off", reason: "disabled-by-config", failOpen, scannerPath: null, retrySuppressedUntil: null };
@@ -295,7 +367,7 @@ export async function readShellScanStatus(): Promise<ShellScanStatus> {
   // an unreadable one is unknown even when we know scanning is enabled.
   const pathOverride = (env[KEYS.path.env] ?? "").trim();
   if (!pathOverride && !config) return unknown();
-  const configuredPath = pathOverride || (config?.path ?? "").trim() || DEFAULT_PATH;
+  const configuredPath = pathOverride || (config?.path.raw ?? "").trim() || DEFAULT_PATH;
 
   const scannerPath = await resolveScanner(configuredPath);
   if (scannerPath) {
@@ -306,7 +378,10 @@ export async function readShellScanStatus(): Promise<ShellScanStatus> {
     reason: "not-installed",
     failOpen,
     scannerPath: null,
-    retrySuppressedUntil: await readRetrySuppressedUntil(),
+    // Only the bare default is ever auto-downloaded. On an explicitly configured
+    // path upstream stops at "not found" and never fetches anything (`:536-541`),
+    // so promising a retry after the marker expires would be a false failure.
+    retrySuppressedUntil: configuredPath === DEFAULT_PATH ? await readRetrySuppressedUntil() : null,
   };
 }
 

--- a/src/lib/hermes-shell-scan.ts
+++ b/src/lib/hermes-shell-scan.ts
@@ -1,5 +1,5 @@
 /**
- * Is the Hermes agent scanning shell commands BEFORE it runs them?
+ * Is the Hermes agent's pre-exec shell scanner installed and switched on?
  *
  * The agent runs every shell command past `tirith` first (upstream's
  * `tools/tirith_security.py`). That scanner is not shipped with the box: the
@@ -10,34 +10,50 @@
  * scanning disabled"). No error, no non-zero exit, nothing a health check sees.
  *
  * That is a security control that can be off while the product reports nothing,
- * which is the failure this module exists to end. It answers one question for
- * the dashboard: is pre-exec scanning on right now, and if not, why.
+ * which is the failure this module exists to end.
  *
- * HARNESS FIRST — everything here is read from the harness's own contract, not
- * invented:
+ * WHAT IT CAN AND CANNOT ASSERT. This is a report on the box's CONFIGURED
+ * state, read from disk. It is not a promise about the running agent, and the
+ * wording everywhere — here, in the route and in the card — is chosen to say
+ * only the first:
  *
- *   * the settings are Hermes' own `security.tirith_*` keys in config.yaml,
- *     read through the `hermes` CLI (`hermes-config-cache`), with the same
- *     `TIRITH_ENABLED` / `TIRITH_BIN` / `TIRITH_FAIL_OPEN` env overrides and the
- *     same defaults (enabled, path `"tirith"`, fail-open) upstream applies in
- *     `_load_security_config()`;
- *   * the install location is upstream's `$HERMES_HOME/bin/tirith`;
- *   * the 24 h retry suppression is upstream's `.tirith-install-failed` marker.
+ *   * upstream opens a circuit breaker after three consecutive scanner failures
+ *     (`tirith_security.py:748-754`) that returns `allow` unconditionally, ABOVE
+ *     both the path resolution and the `fail_open` check, and nothing resets it
+ *     for the life of the process. A box whose scanner timed out three times is
+ *     not scanning, and no file on disk says so;
+ *   * a settings change reaches the agent when the agent next reads it, not when
+ *     ClawBox writes it;
+ *   * nothing on the device can tell a genuine release binary from a
+ *     replacement — that needs a trusted checksum an offline box does not have.
+ *
+ * So `"on"` means "installed and enabled", never "your commands are being
+ * checked". Upstream exposes no CLI verb or endpoint for the live answer;
+ * `ensure_installed()` (`:633`) is a caching library call, not a probe.
+ *
+ * HARNESS FIRST — every setting here is Hermes' own, not invented:
+ *
+ *   * `security.tirith_enabled` / `tirith_path` / `tirith_fail_open` in
+ *     `~/.hermes/config.yaml`, with the `TIRITH_ENABLED` / `TIRITH_BIN` /
+ *     `TIRITH_FAIL_OPEN` env overrides and the same defaults upstream applies in
+ *     `_load_security_config()` (`tirith_security.py:68-87`);
+ *   * the resolution order and the install location of `_resolve_tirith_path()`
+ *     (`:493-598`);
+ *   * the 24 h retry suppression of upstream's `.tirith-install-failed` marker,
+ *     including the one reason it clears early (`:175-199`).
  *
  * ClawBox deliberately does NOT gate exec itself. Upstream already owns that
  * decision through `security.tirith_fail_open`: `false` turns a missing or
  * unspawnable scanner into `{"action": "block"}`. Re-implementing a gate here
  * would be a second, divergent policy over the same commands. `failOpen` is
- * reported so the UI can say which of the two the box is doing.
+ * reported so the card can say which of the two the box is configured for.
  *
- * KNOWN LIMIT, upstream's not ours: after three consecutive scanner failures
- * upstream opens a circuit breaker that returns `allow` unconditionally, ABOVE
- * the `fail_open` check. So `failOpen: false` is not an absolute guarantee, and
- * this module reports the configured intent, not a promise.
- *
- * NOT probe-once: the scanner appears on disk the moment the background
- * download finishes, so the filesystem checks run per call. Only the config
- * keys are cached, and that cache is invalidated by config.yaml's mtime.
+ * NOT probe-once, and no interpreter: the scanner appears on disk the moment the
+ * background download finishes, so every call re-reads. `config.yaml` is read
+ * directly rather than through `hermes config get` — it is the file
+ * `load_config_readonly()` reads, ClawBox is already its own reader and writer
+ * for it (`src/lib/hermes-config-yaml.ts`), and three Python interpreter starts
+ * do not belong behind a Settings panel.
  *
  * SERVER ONLY.
  */
@@ -46,16 +62,17 @@ import fs from "fs/promises";
 import { constants as fsConstants } from "fs";
 import path from "path";
 
-import { hermesConfigGetMany, hermesConfigReadPending } from "@/lib/hermes-config-cache";
+import { hermesConfigPath } from "@/lib/hermes-config-yaml";
 import { hermesHome, readHermesEnv } from "@/lib/hermes-env";
+import { getYamlPath } from "@/lib/yaml-block-edit";
 
-/** Hermes' own config keys, and the env vars that override each of them. */
+/** Hermes' own config keys, and the env var that overrides each of them. */
 const KEYS = {
-  enabled: { config: "security.tirith_enabled", env: "TIRITH_ENABLED" },
-  // Upstream's env var is TIRITH_BIN while the config key is tirith_path —
-  // deliberately not the same name. Do not "fix" this to TIRITH_PATH.
-  path: { config: "security.tirith_path", env: "TIRITH_BIN" },
-  failOpen: { config: "security.tirith_fail_open", env: "TIRITH_FAIL_OPEN" },
+  // Upstream's env var for the path is TIRITH_BIN while the config key is
+  // tirith_path — deliberately not the same name. Do not "fix" this.
+  enabled: { yaml: ["security", "tirith_enabled"], env: "TIRITH_ENABLED" },
+  path: { yaml: ["security", "tirith_path"], env: "TIRITH_BIN" },
+  failOpen: { yaml: ["security", "tirith_fail_open"], env: "TIRITH_FAIL_OPEN" },
 } as const;
 
 /** Upstream's defaults when neither the config key nor the env var is set. */
@@ -66,17 +83,19 @@ const DEFAULT_FAIL_OPEN = true;
 /** Upstream writes this beside config.yaml and skips retries while it is fresh. */
 const INSTALL_FAILED_MARKER = ".tirith-install-failed";
 const MARKER_TTL_MS = 24 * 60 * 60 * 1000;
+/** The one marker reason upstream clears early, so the 24 h claim is wrong for it. */
+const RETRYABLE_MARKER_REASON = "cosign_missing";
 
 export type ShellScanState = "on" | "off" | "unknown";
 
 export type ShellScanReason =
-  /** The scanner resolved and is executable. */
+  /** Installed and enabled — everything the device itself can establish. */
   | "ok"
   /** Not on the box (yet) — the usual case after a factory reset or a fresh flash. */
   | "not-installed"
   /** Somebody set `security.tirith_enabled: false` (or `TIRITH_ENABLED=0`). */
   | "disabled-by-config"
-  /** The agent's own config could not be read, so nothing here is asserted. */
+  /** The agent's own settings could not be read, so nothing here is asserted. */
   | "config-unreadable";
 
 export interface ShellScanStatus {
@@ -84,8 +103,8 @@ export interface ShellScanStatus {
   reason: ShellScanReason;
   /**
    * Upstream's `security.tirith_fail_open`. `true` (upstream's default) means a
-   * missing scanner lets commands through unscanned; `false` means the agent
-   * blocks them instead. Decides which sentence the dashboard shows.
+   * missing scanner lets commands through unscanned; `false` means the agent is
+   * configured to block them instead. Decides which sentence the card shows.
    */
   failOpen: boolean;
   /** Where the scanner was found. Null whenever `state` is not `"on"`. */
@@ -103,17 +122,13 @@ function envBool(raw: string): boolean {
   return ["1", "true", "yes"].includes(raw.trim().toLowerCase());
 }
 
-/**
- * A boolean out of `hermes config get`. "" is "the key is not set" — the CLI
- * exits non-zero for an unset key and the cache turns that into an empty
- * string — so the caller's default applies. An unrecognised value is treated
- * the same way rather than guessed at.
- */
-function configBool(raw: string, fallback: boolean): boolean {
+/** A YAML scalar as a boolean, or null when the key is unset or unrecognised. */
+function yamlBool(raw: string | null): boolean | null {
+  if (raw === null) return null;
   const v = raw.trim().toLowerCase();
   if (["1", "true", "yes", "on"].includes(v)) return true;
   if (["0", "false", "no", "off"].includes(v)) return false;
-  return fallback;
+  return null;
 }
 
 /** True when `p` is a regular file this process may execute. */
@@ -128,53 +143,111 @@ async function isExecutableFile(p: string): Promise<boolean> {
   }
 }
 
+/**
+ * The agent's home, working directory and PATH — copied from
+ * `config/clawbox-hermes-dashboard.service:9-11`, NOT taken from this process.
+ * The web server's unit sets no PATH and inherits systemd's default, which has
+ * no `~/.local/bin`; reading `process.env.PATH` here would miss a scanner the
+ * agent resolves perfectly well and paint a warning on a box that is scanning.
+ */
+function agentHome(): string {
+  return process.env.HOME || "/home/clawbox";
+}
+function agentPathDirs(): string[] {
+  return [path.join(agentHome(), ".local", "bin"), "/usr/local/bin", "/usr/bin", "/bin"];
+}
+
 /** `os.path.expanduser`, for the one form a config file ever uses. */
 function expandUser(p: string): string {
   if (p !== "~" && !p.startsWith("~/")) return p;
-  return path.join(process.env.HOME || "/home/clawbox", p.slice(1));
+  return path.join(agentHome(), p.slice(1));
 }
 
-/**
- * Where the scanner is, mirroring `_resolve_tirith_path()` without its
- * side-effects — this must never trigger a download, only report.
- *
- * Upstream looks on PATH and then in `$HERMES_HOME/bin`. Both are checked here,
- * with one caveat worth stating: PATH here is the web server's, not the agent's,
- * so a bare name that only the agent can resolve would read as missing. It does
- * not matter in practice — the only thing that ever puts tirith on a ClawBox is
- * the agent's own installer, into `$HERMES_HOME/bin`, which is checked directly.
- */
-async function resolveScanner(configuredPath: string): Promise<string | null> {
-  const expanded = expandUser(configuredPath);
-  const candidates = expanded.includes(path.sep)
-    ? [expanded]
-    : [...searchPath(expanded), path.join(hermesHome(), "bin", expanded)];
-  for (const candidate of candidates) {
+/** `shutil.which` for a bare name, over the agent's PATH. */
+async function which(name: string): Promise<string | null> {
+  for (const dir of agentPathDirs()) {
+    const candidate = path.join(dir, name);
     if (await isExecutableFile(candidate)) return candidate;
   }
   return null;
 }
 
-/** `shutil.which`'s candidate list for a bare name. */
-function searchPath(name: string): string[] {
-  return (process.env.PATH || "").split(path.delimiter).filter(Boolean).map((dir) => path.join(dir, name));
+/**
+ * Where the scanner is, mirroring `_resolve_tirith_path()` (`:493-598`) without
+ * its side-effects — this reports, it must never trigger a download.
+ *
+ * Upstream's split is on the VALUE, not the shape: anything other than the bare
+ * `"tirith"` is "explicit" (`_is_explicit_path`, `:488-490`) and authoritative —
+ * the literal path, then a PATH lookup, and never `$HERMES_HOME/bin`, so a
+ * configured `tirith-v2` must not be satisfied by a leftover binary of that name
+ * in the agent's own download directory.
+ */
+async function resolveScanner(configuredPath: string): Promise<string | null> {
+  if (configuredPath !== DEFAULT_PATH) {
+    // A relative path resolves against the agent's WorkingDirectory, not the
+    // web server's cwd (which is the ClawBox checkout, a different directory).
+    const literal = path.resolve(agentHome(), expandUser(configuredPath));
+    if (await isExecutableFile(literal)) return literal;
+    return which(expandUser(configuredPath));
+  }
+  return (await which(DEFAULT_PATH)) ?? (await onlyIfExecutable(path.join(hermesHome(), "bin", DEFAULT_PATH)));
 }
 
-/** When upstream will next allow a download retry, or null if it will now. */
+async function onlyIfExecutable(p: string): Promise<string | null> {
+  return (await isExecutableFile(p)) ? p : null;
+}
+
+/**
+ * When upstream will next allow a download retry, or null if it will retry now.
+ *
+ * `cosign_missing` is excluded on purpose: upstream clears that marker as soon
+ * as `cosign` is on PATH (`:189-199`), so claiming a 24 h wait for it would be a
+ * false failure.
+ */
 async function readRetrySuppressedUntil(): Promise<string | null> {
+  const marker = path.join(hermesHome(), INSTALL_FAILED_MARKER);
   try {
-    const marker = path.join(hermesHome(), INSTALL_FAILED_MARKER);
-    const until = (await fs.stat(marker)).mtimeMs + MARKER_TTL_MS;
+    const [stat, reason] = await Promise.all([
+      fs.stat(marker),
+      fs.readFile(marker, "utf-8").catch(() => ""),
+    ]);
+    if (reason.trim() === RETRYABLE_MARKER_REASON) return null;
+    const until = stat.mtimeMs + MARKER_TTL_MS;
     return until > Date.now() ? new Date(until).toISOString() : null;
   } catch {
     return null;
   }
 }
 
+/** The `security:` block as raw scalars, or null when the file is unreadable. */
+async function readSecurityConfig(): Promise<Record<keyof typeof KEYS, string | null> | null> {
+  let text: string;
+  try {
+    text = await fs.readFile(hermesConfigPath(), "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    // No config.yaml is an ordinary state — a box before its first boot. Upstream
+    // swallows that and applies its defaults (`:79-80`), so it is not "unknown".
+    if (code === "ENOENT" || code === "ENOTDIR") text = "";
+    else return null;
+  }
+  try {
+    return {
+      enabled: getYamlPath(text, [...KEYS.enabled.yaml]),
+      path: getYamlPath(text, [...KEYS.path.yaml]),
+      failOpen: getYamlPath(text, [...KEYS.failOpen.yaml]),
+    };
+  } catch {
+    // A shape the line reader does not understand. Reporting the defaults here
+    // would assert a setting nobody read; say so instead.
+    return null;
+  }
+}
+
 /**
- * Report whether the Hermes agent is scanning shell commands before running
- * them. Callers must only ask this for the Hermes harness — the OpenClaw
- * harness has no tirith and must not be told it is missing one.
+ * Report whether the Hermes agent's shell scanner is installed and enabled.
+ * Callers must only ask this for the Hermes harness — the OpenClaw harness has
+ * no tirith and must not be told it is missing one.
  */
 export async function readShellScanStatus(): Promise<ShellScanStatus> {
   let env: Record<string, string>;
@@ -186,25 +259,28 @@ export async function readShellScanStatus(): Promise<ShellScanStatus> {
     // the false success this module exists to prevent.
     return unknown();
   }
+  const config = await readSecurityConfig();
 
-  const config = await hermesConfigGetMany([KEYS.enabled.config, KEYS.path.config, KEYS.failOpen.config]);
-  // Checked AFTER the reads have settled: an answer is cached against
-  // config.yaml's mtime and never expires, so anything still "pending" here is
-  // a read that failed (a wedged or missing `hermes`), not one in flight.
-  if (Object.values(KEYS).some(({ config: key }) => hermesConfigReadPending(key))) return unknown();
+  const enabledOverride = KEYS.enabled.env in env ? envBool(env[KEYS.enabled.env]) : null;
+  const failOpen =
+    (KEYS.failOpen.env in env ? envBool(env[KEYS.failOpen.env]) : null) ??
+    yamlBool(config?.failOpen ?? null) ??
+    DEFAULT_FAIL_OPEN;
 
-  const failOpen = KEYS.failOpen.env in env
-    ? envBool(env[KEYS.failOpen.env])
-    : configBool(config[KEYS.failOpen.config] ?? "", DEFAULT_FAIL_OPEN);
-
-  const enabled = KEYS.enabled.env in env
-    ? envBool(env[KEYS.enabled.env])
-    : configBool(config[KEYS.enabled.config] ?? "", DEFAULT_ENABLED);
+  // An override in .env settles the question on its own, so an unreadable
+  // config.yaml must not turn a definitively-off box into "unknown".
+  const enabled = enabledOverride ?? (config ? yamlBool(config.enabled) ?? DEFAULT_ENABLED : null);
+  if (enabled === null) return unknown();
   if (!enabled) {
     return { state: "off", reason: "disabled-by-config", failOpen, scannerPath: null, retrySuppressedUntil: null };
   }
 
-  const configuredPath = (env[KEYS.path.env] || config[KEYS.path.config] || "").trim() || DEFAULT_PATH;
+  // Which binary the agent would look for. Only the config can answer that, so
+  // an unreadable one is unknown even when we know scanning is enabled.
+  const pathOverride = (env[KEYS.path.env] ?? "").trim();
+  if (!pathOverride && !config) return unknown();
+  const configuredPath = pathOverride || (config?.path ?? "").trim() || DEFAULT_PATH;
+
   const scannerPath = await resolveScanner(configuredPath);
   if (scannerPath) {
     return { state: "on", reason: "ok", failOpen, scannerPath, retrySuppressedUntil: null };

--- a/src/lib/hermes-translations.ts
+++ b/src/lib/hermes-translations.ts
@@ -5,6 +5,7 @@ import { skillsEn } from "./hermes-translations/en-skills";
 import { localModelsEn } from "./hermes-translations/en-local-models";
 import { systemProfileEn } from "./hermes-translations/en-system-profile";
 import { codingAgentEn } from "./hermes-translations/en-coding-agent";
+import { shellScanEn } from "./hermes-translations/en-shell-scan";
 import { bg } from "./hermes-translations/bg";
 import { de } from "./hermes-translations/de";
 import { es } from "./hermes-translations/es";
@@ -39,6 +40,7 @@ export const hermesEn: Record<string, string> = {
   ...localModelsEn,
   ...systemProfileEn,
   ...codingAgentEn,
+  ...shellScanEn,
 };
 
 const overrides: Record<Exclude<Locale, "en">, Record<string, string>> = {

--- a/src/lib/hermes-translations/bg.ts
+++ b/src/lib/hermes-translations/bg.ts
@@ -709,4 +709,23 @@ export const bg: Record<string, string> = {
   "codingAgent.artBrowser": "Браузър",
   "codingAgent.resetConfirm": "Нулиране на всичко — докоснете отново",
   "codingAgent.resetFailed": "Кодиращият агент не можа да бъде нулиран.",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "Проверката на командите на обвивката е изключена",
+  "shellScan.blockedTitle":
+    "Командите на обвивката са блокирани",
+  "shellScan.unknownTitle":
+    "Проверка на командите на обвивката: неизвестно",
+  "shellScan.missingDetail":
+    "Скенерът за безопасност не е инсталиран. Агентът го изтегля при първото свързване на кутията с интернет; дотогава изпълнява командите на обвивката без проверка.",
+  "shellScan.blockedDetail":
+    "Скенерът за безопасност не е инсталиран, а агентът е настроен да отказва команди на обвивката без него. Свържете кутията с интернет, за да го изтегли.",
+  "shellScan.disabledDetail":
+    "Изключена е в настройките на агента (security.tirith_enabled). Командите се изпълняват без предварителна проверка за безопасност.",
+  "shellScan.unknownDetail":
+    "Настройките за сигурност на агента не могат да бъдат прочетени, затова кутията не може да потвърди, че командите на обвивката се проверяват, преди да бъдат изпълнени.",
+  "shellScan.retryAfter":
+    "Агентът няма да опита изтеглянето отново преди {time}.",
 };

--- a/src/lib/hermes-translations/de.ts
+++ b/src/lib/hermes-translations/de.ts
@@ -721,4 +721,23 @@ export const de: Record<string, string> = {
   "codingAgent.artBrowser": "Webbrowser",
   "codingAgent.resetConfirm": "Alles zurücksetzen — erneut tippen",
   "codingAgent.resetFailed": "Der Coding-Agent konnte nicht zurückgesetzt werden.",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "Die Prüfung von Shell-Befehlen ist ausgeschaltet",
+  "shellScan.blockedTitle":
+    "Shell-Befehle werden blockiert",
+  "shellScan.unknownTitle":
+    "Prüfung von Shell-Befehlen: unbekannt",
+  "shellScan.missingDetail":
+    "Der Sicherheitsscanner ist nicht installiert. Der Agent lädt ihn herunter, sobald die Box zum ersten Mal online ist; bis dahin führt er Shell-Befehle ungeprüft aus.",
+  "shellScan.blockedDetail":
+    "Der Sicherheitsscanner ist nicht installiert, und der Agent ist so eingestellt, dass er ohne ihn keine Shell-Befehle ausführt. Verbinden Sie die Box mit dem Internet, damit sie den Scanner herunterladen kann.",
+  "shellScan.disabledDetail":
+    "Sie wurde in den Einstellungen des Agenten ausgeschaltet (security.tirith_enabled). Befehle laufen ohne vorherige Sicherheitsprüfung.",
+  "shellScan.unknownDetail":
+    "Die Sicherheitseinstellungen des Agenten konnten nicht gelesen werden, daher kann diese Box nicht bestätigen, dass Shell-Befehle vor der Ausführung geprüft werden.",
+  "shellScan.retryAfter":
+    "Der Agent versucht den Download nicht vor {time} erneut.",
 };

--- a/src/lib/hermes-translations/en-shell-scan.ts
+++ b/src/lib/hermes-translations/en-shell-scan.ts
@@ -1,0 +1,31 @@
+/**
+ * Settings → System → Agent harness — the pre-exec shell scanning notice
+ * (HERMES-08).
+ *
+ * This is the only place the product tells the owner that a SECURITY control is
+ * off, so it is translated rather than left in English like the rest of that
+ * card: an owner reading Settings in Bulgarian or Japanese must not have the one
+ * sentence that matters arrive in a language they do not read.
+ *
+ * The copy deliberately separates two outcomes that look alike and are not:
+ * with upstream's default (fail-open) a missing scanner means commands still
+ * run, unchecked; with `security.tirith_fail_open: false` it means they stop.
+ *
+ * `security.tirith_enabled` is a config key and stays verbatim in every locale.
+ */
+export const shellScanEn: Record<string, string> = {
+  "shellScan.offTitle": "Shell command scanning is off",
+  "shellScan.blockedTitle": "Shell commands are blocked",
+  "shellScan.unknownTitle": "Shell command scanning: unknown",
+
+  "shellScan.missingDetail":
+    "The safety scanner is not installed. The agent downloads it the first time the box is online; until then it runs shell commands without checking them.",
+  "shellScan.blockedDetail":
+    "The safety scanner is not installed, and the agent is set to refuse shell commands without it. Connect the box to the internet so it can download the scanner.",
+  "shellScan.disabledDetail":
+    "It was switched off in the agent's settings (security.tirith_enabled). Commands run without a pre-execution safety check.",
+  "shellScan.unknownDetail":
+    "The agent's security settings could not be read, so this box cannot confirm that shell commands are checked before they run.",
+
+  "shellScan.retryAfter": "The agent will not retry the download before {time}.",
+};

--- a/src/lib/hermes-translations/es.ts
+++ b/src/lib/hermes-translations/es.ts
@@ -717,4 +717,23 @@ export const es: Record<string, string> = {
   "codingAgent.artBrowser": "Navegador",
   "codingAgent.resetConfirm": "Restablecer todo — toca otra vez",
   "codingAgent.resetFailed": "No se pudo restablecer el agente de código.",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "El análisis de comandos de shell está desactivado",
+  "shellScan.blockedTitle":
+    "Los comandos de shell están bloqueados",
+  "shellScan.unknownTitle":
+    "Análisis de comandos de shell: desconocido",
+  "shellScan.missingDetail":
+    "El analizador de seguridad no está instalado. El agente lo descarga la primera vez que la caja tiene conexión; hasta entonces ejecuta los comandos de shell sin comprobarlos.",
+  "shellScan.blockedDetail":
+    "El analizador de seguridad no está instalado y el agente está configurado para rechazar comandos de shell sin él. Conecta la caja a internet para que pueda descargarlo.",
+  "shellScan.disabledDetail":
+    "Se desactivó en los ajustes del agente (security.tirith_enabled). Los comandos se ejecutan sin comprobación de seguridad previa.",
+  "shellScan.unknownDetail":
+    "No se pudieron leer los ajustes de seguridad del agente, así que esta caja no puede confirmar que los comandos de shell se comprueben antes de ejecutarse.",
+  "shellScan.retryAfter":
+    "El agente no reintentará la descarga antes de {time}.",
 };

--- a/src/lib/hermes-translations/fr.ts
+++ b/src/lib/hermes-translations/fr.ts
@@ -722,4 +722,23 @@ export const fr: Record<string, string> = {
   "codingAgent.artBrowser": "Navigateur",
   "codingAgent.resetConfirm": "Tout réinitialiser — appuyez à nouveau",
   "codingAgent.resetFailed": "L'agent de code n'a pas pu être réinitialisé.",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "L'analyse des commandes shell est désactivée",
+  "shellScan.blockedTitle":
+    "Les commandes shell sont bloquées",
+  "shellScan.unknownTitle":
+    "Analyse des commandes shell : inconnue",
+  "shellScan.missingDetail":
+    "L'analyseur de sécurité n'est pas installé. L'agent le télécharge dès que la box est connectée pour la première fois ; jusque-là, il exécute les commandes shell sans les vérifier.",
+  "shellScan.blockedDetail":
+    "L'analyseur de sécurité n'est pas installé, et l'agent est configuré pour refuser les commandes shell sans lui. Connectez la box à Internet pour qu'elle puisse le télécharger.",
+  "shellScan.disabledDetail":
+    "Elle a été désactivée dans les réglages de l'agent (security.tirith_enabled). Les commandes s'exécutent sans contrôle de sécurité préalable.",
+  "shellScan.unknownDetail":
+    "Les réglages de sécurité de l'agent n'ont pas pu être lus, donc cette box ne peut pas confirmer que les commandes shell sont vérifiées avant leur exécution.",
+  "shellScan.retryAfter":
+    "L'agent ne réessaiera pas le téléchargement avant {time}.",
 };

--- a/src/lib/hermes-translations/it.ts
+++ b/src/lib/hermes-translations/it.ts
@@ -733,4 +733,23 @@ export const it: Record<string, string> = {
   "codingAgent.artBrowser": "Browser web",
   "codingAgent.resetConfirm": "Reimposta tutto — tocca di nuovo",
   "codingAgent.resetFailed": "Non è stato possibile reimpostare l'agente di codice.",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "Il controllo dei comandi shell è disattivato",
+  "shellScan.blockedTitle":
+    "I comandi shell sono bloccati",
+  "shellScan.unknownTitle":
+    "Controllo dei comandi shell: sconosciuto",
+  "shellScan.missingDetail":
+    "Lo scanner di sicurezza non è installato. L'agente lo scarica la prima volta che la box è online; fino ad allora esegue i comandi shell senza controllarli.",
+  "shellScan.blockedDetail":
+    "Lo scanner di sicurezza non è installato e l'agente è impostato per rifiutare i comandi shell senza di esso. Collega la box a internet perché possa scaricarlo.",
+  "shellScan.disabledDetail":
+    "È stato disattivato nelle impostazioni dell'agente (security.tirith_enabled). I comandi vengono eseguiti senza un controllo di sicurezza preventivo.",
+  "shellScan.unknownDetail":
+    "Non è stato possibile leggere le impostazioni di sicurezza dell'agente, quindi questa box non può confermare che i comandi shell vengano controllati prima di essere eseguiti.",
+  "shellScan.retryAfter":
+    "L'agente non ritenterà il download prima delle {time}.",
 };

--- a/src/lib/hermes-translations/ja.ts
+++ b/src/lib/hermes-translations/ja.ts
@@ -724,4 +724,23 @@ export const ja: Record<string, string> = {
   "codingAgent.artBrowser": "ブラウザー",
   "codingAgent.resetConfirm": "すべてリセット — もう一度タップ",
   "codingAgent.resetFailed": "コーディングエージェントをリセットできませんでした。",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "シェルコマンドの事前チェックはオフです",
+  "shellScan.blockedTitle":
+    "シェルコマンドはブロックされています",
+  "shellScan.unknownTitle":
+    "シェルコマンドの事前チェック: 不明",
+  "shellScan.missingDetail":
+    "安全性スキャナーがインストールされていません。エージェントは本体が初めてオンラインになったときにダウンロードします。それまではシェルコマンドをチェックせずに実行します。",
+  "shellScan.blockedDetail":
+    "安全性スキャナーがインストールされておらず、エージェントはそれなしではシェルコマンドを実行しない設定になっています。ダウンロードできるよう本体をインターネットに接続してください。",
+  "shellScan.disabledDetail":
+    "エージェントの設定 (security.tirith_enabled) でオフにされています。コマンドは実行前の安全性チェックなしで動作します。",
+  "shellScan.unknownDetail":
+    "エージェントのセキュリティ設定を読み取れなかったため、この本体はシェルコマンドが実行前にチェックされているか確認できません。",
+  "shellScan.retryAfter":
+    "エージェントは {time} まで再ダウンロードを試みません。",
 };

--- a/src/lib/hermes-translations/nl.ts
+++ b/src/lib/hermes-translations/nl.ts
@@ -722,4 +722,23 @@ export const nl: Record<string, string> = {
   "codingAgent.artBrowser": "Webbrowser",
   "codingAgent.resetConfirm": "Alles resetten — tik nogmaals",
   "codingAgent.resetFailed": "De codeagent kon niet worden gereset.",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "Controle van shell-opdrachten staat uit",
+  "shellScan.blockedTitle":
+    "Shell-opdrachten worden geblokkeerd",
+  "shellScan.unknownTitle":
+    "Controle van shell-opdrachten: onbekend",
+  "shellScan.missingDetail":
+    "De veiligheidsscanner is niet geïnstalleerd. De agent downloadt hem zodra de box voor het eerst online is; tot dan voert hij shell-opdrachten uit zonder ze te controleren.",
+  "shellScan.blockedDetail":
+    "De veiligheidsscanner is niet geïnstalleerd en de agent is ingesteld om shell-opdrachten zonder hem te weigeren. Verbind de box met internet zodat hij de scanner kan downloaden.",
+  "shellScan.disabledDetail":
+    "Hij is uitgezet in de instellingen van de agent (security.tirith_enabled). Opdrachten draaien zonder veiligheidscontrole vooraf.",
+  "shellScan.unknownDetail":
+    "De beveiligingsinstellingen van de agent konden niet worden gelezen, dus deze box kan niet bevestigen dat shell-opdrachten voor uitvoering worden gecontroleerd.",
+  "shellScan.retryAfter":
+    "De agent probeert de download niet opnieuw vóór {time}.",
 };

--- a/src/lib/hermes-translations/sv.ts
+++ b/src/lib/hermes-translations/sv.ts
@@ -718,4 +718,23 @@ export const sv: Record<string, string> = {
   "codingAgent.artBrowser": "Webbläsare",
   "codingAgent.resetConfirm": "Återställ allt — tryck igen",
   "codingAgent.resetFailed": "Kodagenten kunde inte återställas.",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "Kontrollen av skalkommandon är avstängd",
+  "shellScan.blockedTitle":
+    "Skalkommandon blockeras",
+  "shellScan.unknownTitle":
+    "Kontroll av skalkommandon: okänt",
+  "shellScan.missingDetail":
+    "Säkerhetsskannern är inte installerad. Agenten laddar ner den första gången boxen är uppkopplad; fram till dess kör den skalkommandon utan att kontrollera dem.",
+  "shellScan.blockedDetail":
+    "Säkerhetsskannern är inte installerad, och agenten är inställd på att vägra skalkommandon utan den. Anslut boxen till internet så att den kan ladda ner skannern.",
+  "shellScan.disabledDetail":
+    "Den stängdes av i agentens inställningar (security.tirith_enabled). Kommandon körs utan säkerhetskontroll i förväg.",
+  "shellScan.unknownDetail":
+    "Agentens säkerhetsinställningar kunde inte läsas, så boxen kan inte bekräfta att skalkommandon kontrolleras innan de körs.",
+  "shellScan.retryAfter":
+    "Agenten försöker inte hämta den igen före {time}.",
 };

--- a/src/lib/hermes-translations/zh.ts
+++ b/src/lib/hermes-translations/zh.ts
@@ -733,4 +733,23 @@ export const zh: Record<string, string> = {
   "codingAgent.artBrowser": "浏览器",
   "codingAgent.resetConfirm": "重置全部 — 再次点击",
   "codingAgent.resetFailed": "无法重置编程助手。",
+
+  // Settings → System → Agent harness: the pre-exec shell scanning notice
+  // (HERMES-08). The box's only statement that a security control is off.
+  "shellScan.offTitle":
+    "Shell 命令检查已关闭",
+  "shellScan.blockedTitle":
+    "Shell 命令已被阻止",
+  "shellScan.unknownTitle":
+    "Shell 命令检查：未知",
+  "shellScan.missingDetail":
+    "安全扫描器尚未安装。设备首次联网时代理会自动下载；在此之前，它会在不检查的情况下执行 Shell 命令。",
+  "shellScan.blockedDetail":
+    "安全扫描器尚未安装，且代理被设置为没有它就拒绝执行 Shell 命令。请将设备连接到互联网以便下载扫描器。",
+  "shellScan.disabledDetail":
+    "它在代理设置中被关闭了（security.tirith_enabled）。命令将在没有执行前安全检查的情况下运行。",
+  "shellScan.unknownDetail":
+    "无法读取代理的安全设置，因此本设备无法确认 Shell 命令在执行前是否经过检查。",
+  "shellScan.retryAfter":
+    "代理在 {time} 之前不会重试下载。",
 };

--- a/src/lib/yaml-block-edit.ts
+++ b/src/lib/yaml-block-edit.ts
@@ -235,6 +235,21 @@ export function getYamlPath(text: string, path: string[]): string | null {
 }
 
 /**
+ * Is the key PRESENT, whatever its value?
+ *
+ * `getYamlPath` answers `null` both for "no such key" and for a key written with
+ * an empty value (`foo:`), and those are different facts: YAML reads the second
+ * as a null VALUE, which a reader has to tell apart from an absent key or it
+ * silently substitutes its own default for something somebody actually wrote.
+ * Only a caller that applies defaults needs this; the editing functions do not.
+ */
+export function hasYamlPath(text: string, path: string[]): boolean {
+  assertPath(path);
+  const { lines } = splitLines(text);
+  return descend(lines, path).matched.length === path.length;
+}
+
+/**
  * Set one dotted path to a scalar, creating any missing parents.
  *
  * Every other line of the file comes through untouched.

--- a/src/tests/components/harness-picker.test.tsx
+++ b/src/tests/components/harness-picker.test.tsx
@@ -6,9 +6,17 @@ import HarnessPicker from "@/components/HarnessPicker";
 
 // The real English catalogue, so a key the card asks for that nobody added
 // fails here instead of shipping the raw key to the owner.
+/** The locale the card must format its timestamp for; "en" would prove nothing. */
+const UI_LOCALE = "de";
+/** When true, `t` answers the raw key — the state I18nProvider serves while its
+    catalogue import is in flight, and forever if that import fails. */
+let catalogueMissing = false;
+
 vi.mock("@/lib/i18n", () => ({
   useT: () => ({
+    locale: UI_LOCALE,
     t: (key: string, params?: Record<string, string | number>) => {
+      if (catalogueMissing) return key;
       const raw = translations.en[key] ?? key;
       return params ? raw.replace(/\{(\w+)\}/g, (m, name) => String(params[name] ?? m)) : raw;
     },
@@ -37,7 +45,10 @@ const locked = (healthy: boolean) => ({
   harnesses: [{ id: "hermes", label: "Hermes", healthy }],
 });
 
-afterEach(() => vi.unstubAllGlobals());
+afterEach(() => {
+  catalogueMissing = false;
+  vi.unstubAllGlobals();
+});
 
 describe("HarnessPicker locked badge", () => {
   it("shows the harness as up when the status route says it is healthy", async () => {
@@ -119,6 +130,24 @@ describe("HarnessPicker shell-scan warning", () => {
 
     const warning = await screen.findByTestId("shell-scan-warning");
     expect(warning.textContent).toContain("will not retry the download before");
+    // Formatted for the UI locale, not the runtime default — the rest of the
+    // sentence is already in the owner's language.
+    expect(warning.textContent).toContain(new Date(until).toLocaleString(UI_LOCALE));
+  });
+
+  it("falls back to English rather than showing a raw key if the catalogue never loaded", async () => {
+    // I18nProvider answers t(key) === key until its dynamic import of the
+    // catalogue resolves, and forever if it fails ("the device is offline
+    // mid-update"). Everything else on this card is hardcoded English, so the
+    // one sentence that says a security control is off would be the only thing
+    // on screen rendering as `shellScan.offTitle`.
+    catalogueMissing = true;
+    mockStatus(withScan({ state: "off", reason: "not-installed", failOpen: true, retrySuppressedUntil: null }));
+    render(<HarnessPicker />);
+
+    const warning = await screen.findByTestId("shell-scan-warning");
+    expect(warning.textContent).toContain("Shell command scanning is off");
+    expect(warning.textContent).not.toContain("shellScan.");
   });
 
   it("says commands are BLOCKED, not merely unscanned, when the box fails closed", async () => {

--- a/src/tests/components/harness-picker.test.tsx
+++ b/src/tests/components/harness-picker.test.tsx
@@ -75,3 +75,54 @@ describe("HarnessPicker locked badge", () => {
     expect(screen.getByText("hermes")).toBeTruthy();
   });
 });
+
+/**
+ * The card is also where a Hermes box says whether the agent is scanning shell
+ * commands before it runs them. Both directions matter: a box whose scanner was
+ * wiped by a factory reset has to say so, and a box whose scanner is ready must
+ * stay silent, or the warning stops being read.
+ */
+describe("HarnessPicker shell-scan warning", () => {
+  const withScan = (shellScan: unknown) => ({ ...locked(true), shellScan });
+
+  it("warns when the agent is running shell commands without the scanner", async () => {
+    mockStatus(withScan({ state: "off", reason: "not-installed", failOpen: true, retrySuppressedUntil: null }));
+    render(<HarnessPicker />);
+
+    const warning = await screen.findByTestId("shell-scan-warning");
+    expect(warning.textContent).toContain("Shell command scanning is off");
+    expect(warning.textContent).toContain("without scanning");
+  });
+
+  it("says commands are BLOCKED, not merely unscanned, when the box fails closed", async () => {
+    mockStatus(withScan({ state: "off", reason: "not-installed", failOpen: false, retrySuppressedUntil: null }));
+    render(<HarnessPicker />);
+
+    const warning = await screen.findByTestId("shell-scan-warning");
+    expect(warning.textContent).toContain("Shell commands are blocked");
+  });
+
+  it("names the config switch when scanning was turned off deliberately", async () => {
+    mockStatus(withScan({ state: "off", reason: "disabled-by-config", failOpen: true, retrySuppressedUntil: null }));
+    render(<HarnessPicker />);
+
+    expect((await screen.findByTestId("shell-scan-warning")).textContent).toContain("tirith_enabled");
+  });
+
+  it("does NOT warn when the scanner is ready", async () => {
+    mockStatus(withScan({ state: "on", reason: "ok", failOpen: true, retrySuppressedUntil: null }));
+    render(<HarnessPicker />);
+
+    await screen.findByTestId("harness-locked-dot");
+    expect(screen.queryByTestId("shell-scan-warning")).toBeNull();
+  });
+
+  it("does NOT warn on a harness the route reports no scanner for", async () => {
+    // OpenClaw has no tirith; the route answers null and the card must be quiet.
+    mockStatus({ ...locked(true), shellScan: null });
+    render(<HarnessPicker />);
+
+    await screen.findByTestId("harness-locked-dot");
+    expect(screen.queryByTestId("shell-scan-warning")).toBeNull();
+  });
+});

--- a/src/tests/components/harness-picker.test.tsx
+++ b/src/tests/components/harness-picker.test.tsx
@@ -1,6 +1,20 @@
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@/tests/helpers/test-utils";
+import { translations } from "@/lib/translations";
 import HarnessPicker from "@/components/HarnessPicker";
+
+// The real English catalogue, so a key the card asks for that nobody added
+// fails here instead of shipping the raw key to the owner.
+vi.mock("@/lib/i18n", () => ({
+  useT: () => ({
+    t: (key: string, params?: Record<string, string | number>) => {
+      const raw = translations.en[key] ?? key;
+      return params ? raw.replace(/\{(\w+)\}/g, (m, name) => String(params[name] ?? m)) : raw;
+    },
+  }),
+  I18nProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
 
 /**
  * On a single-harness edition the picker collapses to a read-only badge. That
@@ -91,7 +105,20 @@ describe("HarnessPicker shell-scan warning", () => {
 
     const warning = await screen.findByTestId("shell-scan-warning");
     expect(warning.textContent).toContain("Shell command scanning is off");
-    expect(warning.textContent).toContain("without scanning");
+    expect(warning.textContent).toContain("without checking them");
+    // A security control not doing its job is an alert, not a status update.
+    expect(warning.getAttribute("role")).toBe("alert");
+  });
+
+  it("tells the owner the agent will not even retry the download yet", async () => {
+    // Upstream suppresses the re-download for 24 h after a failure, so
+    // "connect it to the internet" is not the whole story.
+    const until = new Date(Date.now() + 3_600_000).toISOString();
+    mockStatus(withScan({ state: "off", reason: "not-installed", failOpen: true, retrySuppressedUntil: until }));
+    render(<HarnessPicker />);
+
+    const warning = await screen.findByTestId("shell-scan-warning");
+    expect(warning.textContent).toContain("will not retry the download before");
   });
 
   it("says commands are BLOCKED, not merely unscanned, when the box fails closed", async () => {
@@ -107,6 +134,17 @@ describe("HarnessPicker shell-scan warning", () => {
     render(<HarnessPicker />);
 
     expect((await screen.findByTestId("shell-scan-warning")).textContent).toContain("tirith_enabled");
+  });
+
+  it("does not call a failed settings read a security failure", async () => {
+    // "We could not read the settings" is this box failing, not the control
+    // being off — a polite live region, and wording that says so.
+    mockStatus(withScan({ state: "unknown", reason: "config-unreadable", failOpen: true, retrySuppressedUntil: null }));
+    render(<HarnessPicker />);
+
+    const warning = await screen.findByTestId("shell-scan-warning");
+    expect(warning.textContent).toContain("unknown");
+    expect(warning.getAttribute("role")).toBe("status");
   });
 
   it("does NOT warn when the scanner is ready", async () => {

--- a/src/tests/routes/harness-status.test.ts
+++ b/src/tests/routes/harness-status.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The status route is what Settings → System reads. Until now it answered only
+ * "which harness, is it up" — so a Hermes box running with pre-exec shell
+ * scanning disabled looked exactly like a healthy one, on the dashboard and
+ * everywhere else. It has to carry that fact.
+ *
+ * And it has to carry it ONLY where it means something: the OpenClaw harness
+ * has no tirith, so reporting a missing scanner there would be a warning about
+ * a component that box will never have.
+ */
+
+const getActiveHarness = vi.fn(async () => "hermes");
+/** Every harness these tests name is up; health is not what they are about. */
+const harnessHealthy = vi.fn(async (harness: string) => Boolean(harness));
+vi.mock("@/lib/harness", () => ({
+  getActiveHarness: () => getActiveHarness(),
+  harnessHealthy: (h: string) => harnessHealthy(h),
+  getEdition: () => "hermes",
+  isSingleHarnessEdition: () => true,
+  HARNESSES: {
+    openclaw: { id: "openclaw", label: "OpenClaw" },
+    hermes: { id: "hermes", label: "Hermes" },
+  },
+}));
+
+interface ScanShape {
+  state: string;
+  reason: string;
+  failOpen: boolean;
+  scannerPath: string | null;
+  retrySuppressedUntil: string | null;
+}
+const readShellScanStatus = vi.fn(
+  async (): Promise<ScanShape> => ({
+    state: "off",
+    reason: "not-installed",
+    failOpen: true,
+    scannerPath: null,
+    retrySuppressedUntil: null,
+  }),
+);
+vi.mock("@/lib/hermes-shell-scan", () => ({
+  readShellScanStatus: () => readShellScanStatus(),
+}));
+
+async function get() {
+  vi.resetModules();
+  const mod = await import("@/app/setup-api/harness/status/route");
+  return (await mod.GET()).json();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getActiveHarness.mockResolvedValue("hermes");
+});
+
+describe("GET /setup-api/harness/status — shell scanning posture", () => {
+  it("reports that pre-exec shell scanning is off on a Hermes box", async () => {
+    const body = await get();
+
+    expect(body.shellScan).toMatchObject({ state: "off", reason: "not-installed", failOpen: true });
+  });
+
+  it("reports it as on when the scanner is there, so nothing warns on a healthy box", async () => {
+    readShellScanStatus.mockResolvedValueOnce({
+      state: "on",
+      reason: "ok",
+      failOpen: true,
+      scannerPath: "/home/clawbox/.hermes/bin/tirith",
+      retrySuppressedUntil: null,
+    });
+
+    expect((await get()).shellScan.state).toBe("on");
+  });
+
+  it("says nothing about scanning on the OpenClaw harness, which has no scanner", async () => {
+    getActiveHarness.mockResolvedValue("openclaw");
+
+    const body = await get();
+
+    expect(body.shellScan).toBeNull();
+    expect(readShellScanStatus).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -502,6 +502,10 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
   const HERMES_ENTRIES = [
     "hermes-agent",
     "bin",
+    // Upstream's install-failure marker. It suppresses the tirith download for
+    // 24 h, so a reset that kept it would leave a box that IS online unable to
+    // re-fetch the scanner for another day.
+    ".tirith-install-failed",
     "config.yaml",
     "config.yaml.bak-20260813",
     ".env",
@@ -515,11 +519,10 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     "state.db",
     "projects.db",
   ];
-  // What ~/.hermes/bin holds: the upstream tirith binary, plus (here) something
-  // a previous owner could have dropped beside it.
-  const HERMES_BIN_ENTRIES = ["tirith", "planted-payload"];
-  // The reset preserves the agent install and the tirith scanner. Everything
-  // else under ~/.hermes is previous-owner state and must go.
+  // What ~/.hermes/bin holds: the upstream tirith binary.
+  const HERMES_BIN_ENTRIES = ["tirith"];
+  // The reset preserves the agent install and the bin/ the scanner lives in.
+  // Everything else under ~/.hermes is previous-owner state and must go.
   const KEPT_ENTRIES = ["hermes-agent", "bin"];
   const SECRET_ENTRIES = HERMES_ENTRIES.filter((e) => !KEPT_ENTRIES.includes(e));
 
@@ -582,7 +585,7 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     expect(targets).not.toContain(HERMES);
   });
 
-  it("never removes ~/.hermes/bin/tirith, the pre-exec shell scanner", async () => {
+  it("never removes ~/.hermes/bin, which holds the pre-exec shell scanner", async () => {
     // tirith is the ~33 MB upstream binary the agent runs BEFORE every shell
     // command. It is not owner state — it is an upstream release artefact —
     // and the agent only re-downloads it from a GitHub release once the box
@@ -592,18 +595,12 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     await resetPost();
     const targets = rmTargets();
 
-    expect(targets).not.toContain(`${HERMES}/bin/tirith`);
-    // And not by taking the directory out from under it either.
     expect(targets).not.toContain(`${HERMES}/bin`);
-  });
-
-  it("still wipes everything else in ~/.hermes/bin", async () => {
-    // The exception is the scanner, not the directory: anything a previous
-    // owner (or a future upstream) put beside tirith is still removed, so the
-    // carve-out cannot quietly become a second preserved directory.
-    await resetPost();
-
-    expect(rmTargets()).toContain(`${HERMES}/bin/planted-payload`);
+    // And not by reaching into it either — the directory is kept whole, so
+    // nothing inside it is enumerated or removed.
+    for (const entry of HERMES_BIN_ENTRIES) {
+      expect(targets, `expected ~/.hermes/bin/${entry} to survive`).not.toContain(`${HERMES}/bin/${entry}`);
+    }
   });
 
   it("still removes every secret-bearing entry under ~/.hermes", async () => {

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -501,6 +501,7 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
   // What a used Hermes box actually has under ~/.hermes.
   const HERMES_ENTRIES = [
     "hermes-agent",
+    "bin",
     "config.yaml",
     "config.yaml.bak-20260813",
     ".env",
@@ -514,7 +515,13 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     "state.db",
     "projects.db",
   ];
-  const SECRET_ENTRIES = HERMES_ENTRIES.filter((e) => e !== "hermes-agent");
+  // What ~/.hermes/bin holds: the upstream tirith binary, plus (here) something
+  // a previous owner could have dropped beside it.
+  const HERMES_BIN_ENTRIES = ["tirith", "planted-payload"];
+  // The reset preserves the agent install and the tirith scanner. Everything
+  // else under ~/.hermes is previous-owner state and must go.
+  const KEPT_ENTRIES = ["hermes-agent", "bin"];
+  const SECRET_ENTRIES = HERMES_ENTRIES.filter((e) => !KEPT_ENTRIES.includes(e));
 
   const rmTargets = () =>
     mockFs.rm.mock.calls.map(([p]) => p).filter((p): p is string => typeof p === "string");
@@ -531,6 +538,7 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
 
     mockFs.readdir.mockImplementation(((p: string) => {
       if (p === HERMES) return Promise.resolve(HERMES_ENTRIES);
+      if (p === `${HERMES}/bin`) return Promise.resolve(HERMES_BIN_ENTRIES);
       if (p === "/test/data") return Promise.resolve(["config.json", "network.env", "llamacpp", ".session-secret"]);
       // llama-server's runtime scratch sits beside the weights.
       if (p === "/test/data/llamacpp") return Promise.resolve(["models", "server.pid", "server.log"]);
@@ -572,6 +580,30 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     // And not by taking the whole directory out from under it — the exact
     // shape of the original defect.
     expect(targets).not.toContain(HERMES);
+  });
+
+  it("never removes ~/.hermes/bin/tirith, the pre-exec shell scanner", async () => {
+    // tirith is the ~33 MB upstream binary the agent runs BEFORE every shell
+    // command. It is not owner state — it is an upstream release artefact —
+    // and the agent only re-downloads it from a GitHub release once the box
+    // has internet again. A reset box reboots into AP mode, so wiping it left
+    // the agent executing shell commands with pre-exec scanning off, and
+    // nothing said so.
+    await resetPost();
+    const targets = rmTargets();
+
+    expect(targets).not.toContain(`${HERMES}/bin/tirith`);
+    // And not by taking the directory out from under it either.
+    expect(targets).not.toContain(`${HERMES}/bin`);
+  });
+
+  it("still wipes everything else in ~/.hermes/bin", async () => {
+    // The exception is the scanner, not the directory: anything a previous
+    // owner (or a future upstream) put beside tirith is still removed, so the
+    // carve-out cannot quietly become a second preserved directory.
+    await resetPost();
+
+    expect(rmTargets()).toContain(`${HERMES}/bin/planted-payload`);
   });
 
   it("still removes every secret-bearing entry under ~/.hermes", async () => {

--- a/src/tests/routes/setup/reset.test.ts
+++ b/src/tests/routes/setup/reset.test.ts
@@ -519,8 +519,11 @@ describe("POST /setup-api/setup/reset — Hermes agent + offline model survive",
     "state.db",
     "projects.db",
   ];
-  // What ~/.hermes/bin holds: the upstream tirith binary.
-  const HERMES_BIN_ENTRIES = ["tirith"];
+  // What ~/.hermes/bin holds: the upstream tirith binary, plus a second entry
+  // so the assertion below pins the WHOLE directory rather than one name — a
+  // future narrowing that kept `tirith` and removed its neighbour would
+  // otherwise slip through.
+  const HERMES_BIN_ENTRIES = ["tirith", "future-helper"];
   // The reset preserves the agent install and the bin/ the scanner lives in.
   // Everything else under ~/.hermes is previous-owner state and must go.
   const KEPT_ENTRIES = ["hermes-agent", "bin"];

--- a/src/tests/unit/hermes-shell-scan.test.ts
+++ b/src/tests/unit/hermes-shell-scan.test.ts
@@ -14,31 +14,67 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  *
  * So this module has to get both halves right:
  *   - it must SAY the scanner is off, and why (no false success);
- *   - it must say nothing at all when the scanner is ready (no false failure),
- *     or the warning is noise within a week.
+ *   - it must say nothing at all when the scanner is installed (no false
+ *     failure), or the warning is noise within a week.
+ *
+ * `yaml-block-edit` is NOT mocked: the config values come out of real YAML text,
+ * so a test cannot pass because a fixture handed the module the answer.
  */
 
-const HERMES_HOME = "/home/clawbox/.hermes";
+const HOME = "/home/clawbox";
+const HERMES_HOME = `${HOME}/.hermes`;
+const CONFIG = `${HERMES_HOME}/config.yaml`;
 const SCANNER = `${HERMES_HOME}/bin/tirith`;
 const MARKER = `${HERMES_HOME}/.tirith-install-failed`;
+/** The FIRST entry of the agent's own PATH (its unit file), not this process's. */
+const AGENT_PATH_SCANNER = `${HOME}/.local/bin/tirith`;
 
-/** Paths that exist as executable regular files, per test. */
+/** Executable regular files. */
 let executables = new Set<string>();
+/** Regular files that exist but are not executable. */
+let plainFiles = new Set<string>();
+/** Paths that stat as directories. */
+let directories = new Set<string>();
 /** mtime for the install-failure marker, or null when there is no marker. */
 let markerMtimeMs: number | null = null;
+/** Contents of the install-failure marker (upstream stores a reason tag). */
+let markerReason = "";
+/** ~/.hermes/config.yaml, or null for "no such file", or an Error to throw. */
+let configText: string | null | Error = "";
+
+const enoent = () => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
 
 const stat = vi.fn(async (p: string) => {
   if (p === MARKER) {
-    if (markerMtimeMs === null) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    if (markerMtimeMs === null) throw enoent();
     return { mtimeMs: markerMtimeMs, isFile: () => true };
   }
-  if (!executables.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
-  return { mtimeMs: 0, isFile: () => true };
+  if (directories.has(p)) return { mtimeMs: 0, isFile: () => false };
+  if (executables.has(p) || plainFiles.has(p)) return { mtimeMs: 0, isFile: () => true };
+  throw enoent();
 });
 const access = vi.fn(async (p: string) => {
   if (!executables.has(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" });
 });
-vi.mock("fs/promises", () => ({ default: { stat: (p: string) => stat(p), access: (p: string) => access(p) } }));
+const readFile = vi.fn(async (p: string) => {
+  if (p === CONFIG) {
+    if (configText === null) throw enoent();
+    if (configText instanceof Error) throw configText;
+    return configText;
+  }
+  if (p === MARKER) {
+    if (markerMtimeMs === null) throw enoent();
+    return markerReason;
+  }
+  throw enoent();
+});
+vi.mock("fs/promises", () => ({
+  default: {
+    stat: (p: string) => stat(p),
+    access: (p: string) => access(p),
+    readFile: (p: string) => readFile(p),
+  },
+}));
 
 /** ~/.hermes/.env contents (the TIRITH_* overrides live here), or a throw. */
 let envFile: Record<string, string> | Error = {};
@@ -50,33 +86,29 @@ vi.mock("@/lib/hermes-env", () => ({
   readHermesEnv: () => readHermesEnv(),
   hermesHome: () => HERMES_HOME,
 }));
-
-/** What `hermes config get <key>` answers; "" is an unset key. */
-let configValues: Record<string, string> = {};
-/** Keys whose read FAILED (a wedged or missing `hermes`), not answered. */
-let pendingKeys = new Set<string>();
-vi.mock("@/lib/hermes-config-cache", () => ({
-  hermesConfigGetMany: async (keys: string[]) =>
-    Object.fromEntries(keys.map((k) => [k, configValues[k] ?? ""])),
-  hermesConfigReadPending: (key: string) => pendingKeys.has(key),
-}));
+vi.mock("@/lib/hermes-config-yaml", () => ({ hermesConfigPath: () => CONFIG }));
 
 async function readStatus() {
   const { readShellScanStatus } = await import("@/lib/hermes-shell-scan");
   return readShellScanStatus();
 }
 
+/** The shipped config's security block, as it really appears in config.yaml. */
+const securityYaml = (body: string) => `agent:\n  name: hermes\n\nsecurity:\n${body}`;
+
 beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
   executables = new Set<string>();
+  plainFiles = new Set<string>();
+  directories = new Set<string>();
   markerMtimeMs = null;
+  markerReason = "";
+  configText = "";
   envFile = {};
-  configValues = {};
-  pendingKeys = new Set<string>();
-  // Nothing named tirith on this process's PATH, so ~/.hermes/bin decides.
+  vi.stubEnv("HOME", HOME);
+  // Deliberately NOT the agent's PATH. Nothing in this module may read it.
   vi.stubEnv("PATH", "/nowhere/bin");
-  vi.stubEnv("HOME", "/home/clawbox");
 });
 
 afterEach(() => {
@@ -89,7 +121,7 @@ describe("readShellScanStatus — the scanner is missing", () => {
 
     expect(status.state).toBe("off");
     expect(status.reason).toBe("not-installed");
-    // Upstream's default: the command still runs, just unscanned. The dashboard
+    // Upstream's default: the command still runs, just unscanned. The card
     // needs this to word the warning honestly.
     expect(status.failOpen).toBe(true);
     expect(status.scannerPath).toBeNull();
@@ -104,7 +136,6 @@ describe("readShellScanStatus — the scanner is missing", () => {
     const status = await readStatus();
 
     expect(status.state).toBe("off");
-    expect(status.retrySuppressedUntil).not.toBeNull();
     expect(Date.parse(status.retrySuppressedUntil!)).toBeGreaterThan(Date.now());
   });
 
@@ -114,21 +145,44 @@ describe("readShellScanStatus — the scanner is missing", () => {
     expect((await readStatus()).retrySuppressedUntil).toBeNull();
   });
 
+  it("does not claim a 24 h wait for the one reason upstream clears early", async () => {
+    // A `cosign_missing` marker is dropped as soon as cosign is on PATH, and
+    // the download is retried on the next command — telling the owner to wait
+    // a day for that would be a false failure.
+    markerMtimeMs = Date.now() - 60_000;
+    markerReason = "cosign_missing";
+
+    expect((await readStatus()).retrySuppressedUntil).toBeNull();
+  });
+
   it("says the agent blocks commands instead when the box is set to fail closed", async () => {
     // `security.tirith_fail_open: false` is upstream's own deny-until-ready
     // mode. The consequence for the owner is the opposite one — commands stop
     // working — so the two cases must not share a sentence.
-    configValues["security.tirith_fail_open"] = "false";
+    configText = securityYaml("  tirith_fail_open: false\n");
 
     const status = await readStatus();
 
     expect(status.state).toBe("off");
     expect(status.failOpen).toBe(false);
   });
+
+  it("does not mistake a directory named tirith for the scanner", async () => {
+    directories.add(SCANNER);
+
+    expect((await readStatus()).state).toBe("off");
+  });
+
+  it("does not mistake a present-but-not-executable file for the scanner", async () => {
+    // A truncated or wrong-mode download is not a scanner the agent can spawn.
+    plainFiles.add(SCANNER);
+
+    expect((await readStatus()).state).toBe("off");
+  });
 });
 
-describe("readShellScanStatus — the scanner is ready", () => {
-  it("reports scanning ON and says nothing is wrong", async () => {
+describe("readShellScanStatus — the scanner is installed", () => {
+  it("reports it as on and says nothing is wrong", async () => {
     // The false-failure half: a box that is online with the scanner installed
     // must not be warned at.
     executables.add(SCANNER);
@@ -141,8 +195,18 @@ describe("readShellScanStatus — the scanner is ready", () => {
     expect(status.retrySuppressedUntil).toBeNull();
   });
 
-  it("finds a scanner at an explicitly configured path", async () => {
-    configValues["security.tirith_path"] = "/opt/tirith/tirith";
+  it("looks on the AGENT's PATH, not the web server's", async () => {
+    // The agent's unit pins PATH=~/.local/bin:/usr/local/bin:/usr/bin:/bin; the
+    // web server's unit sets none and inherits systemd's default, which has no
+    // ~/.local/bin. Reading process.env.PATH here would paint a warning on a
+    // box whose agent resolves the scanner perfectly well.
+    executables.add(AGENT_PATH_SCANNER);
+
+    expect((await readStatus()).scannerPath).toBe(AGENT_PATH_SCANNER);
+  });
+
+  it("finds a scanner at an explicitly configured absolute path", async () => {
+    configText = securityYaml('  tirith_path: "/opt/tirith/tirith"\n');
     executables.add("/opt/tirith/tirith");
 
     expect((await readStatus()).scannerPath).toBe("/opt/tirith/tirith");
@@ -157,11 +221,25 @@ describe("readShellScanStatus — the scanner is ready", () => {
 
     expect((await readStatus()).scannerPath).toBe("/opt/custom/scan");
   });
+
+  it("does not satisfy an explicitly configured name from the agent's download directory", async () => {
+    // Upstream splits on the VALUE, not the shape: anything but the bare
+    // "tirith" is explicit and authoritative, and the explicit branch never
+    // looks in $HERMES_HOME/bin. A leftover binary of that name there means the
+    // agent is NOT scanning, so reporting "on" would be a false success.
+    configText = securityYaml('  tirith_path: "tirith-v2"\n');
+    executables.add(`${HERMES_HOME}/bin/tirith-v2`);
+
+    const status = await readStatus();
+
+    expect(status.state).toBe("off");
+    expect(status.reason).toBe("not-installed");
+  });
 });
 
 describe("readShellScanStatus — turned off on purpose, and not knowable", () => {
   it("distinguishes 'switched off in the config' from 'never downloaded'", async () => {
-    configValues["security.tirith_enabled"] = "false";
+    configText = securityYaml("  tirith_enabled: false\n");
     executables.add(SCANNER);
 
     const status = await readStatus();
@@ -178,18 +256,40 @@ describe("readShellScanStatus — turned off on purpose, and not knowable", () =
     expect((await readStatus()).reason).toBe("disabled-by-config");
   });
 
-  it("answers 'unknown', never 'on', when the agent's config could not be read", async () => {
-    // A wedged or missing `hermes` leaves the cache holding a failed READ, not
-    // an answer. Falling back to the defaults there would report a scanner that
-    // is enabled and present on a box nobody has actually asked — the exact
-    // false success this whole surface exists to prevent.
+  it("applies upstream's defaults when the box has no config.yaml at all", async () => {
+    // A box before its first boot. Upstream swallows the missing file and uses
+    // its defaults, so this is an answer, not an "unknown".
+    configText = null;
     executables.add(SCANNER);
-    pendingKeys.add("security.tirith_enabled");
+
+    expect((await readStatus()).state).toBe("on");
+  });
+
+  it("answers 'unknown', never 'on', when the agent's config could not be read", async () => {
+    // An unreadable config.yaml (EACCES after a root-owned write, EIO on a
+    // failing eMMC) could be hiding `tirith_enabled: false` or a path this box
+    // does not have. Falling back to the defaults there would assert a setting
+    // nobody read — the exact false success this surface exists to prevent.
+    executables.add(SCANNER);
+    configText = Object.assign(new Error("EACCES"), { code: "EACCES" });
 
     const status = await readStatus();
 
     expect(status.state).toBe("unknown");
     expect(status.reason).toBe("config-unreadable");
+  });
+
+  it("still answers 'off' when the .env settles it and only config.yaml is unreadable", async () => {
+    // TIRITH_ENABLED=0 is decisive on its own. Under-reporting a known-bad
+    // state as "unknown" is the same failure as over-reporting a good one.
+    configText = Object.assign(new Error("EACCES"), { code: "EACCES" });
+    envFile = { TIRITH_ENABLED: "0" };
+    executables.add(SCANNER);
+
+    const status = await readStatus();
+
+    expect(status.state).toBe("off");
+    expect(status.reason).toBe("disabled-by-config");
   });
 
   it("answers 'unknown' when ~/.hermes/.env cannot be read", async () => {

--- a/src/tests/unit/hermes-shell-scan.test.ts
+++ b/src/tests/unit/hermes-shell-scan.test.ts
@@ -316,6 +316,30 @@ describe("readShellScanStatus — a present-but-falsy setting is not an unset on
     });
   }
 
+  it("lets TIRITH_FAIL_OPEN override config.yaml, in both directions", async () => {
+    // The env var wins over the YAML key upstream, and this branch is what
+    // picks between two OPPOSITE sentences in the card — "commands run
+    // unchecked" versus "commands are blocked". A wrong env name here would
+    // change a security message with nothing failing.
+    configText = securityYaml("  tirith_fail_open: true\n");
+    envFile = { TIRITH_FAIL_OPEN: "0" };
+    expect((await readStatus()).failOpen).toBe(false);
+
+    vi.resetModules();
+    configText = securityYaml("  tirith_fail_open: false\n");
+    envFile = { TIRITH_FAIL_OPEN: "1" };
+    expect((await readStatus()).failOpen).toBe(true);
+  });
+
+  it("applies upstream's _env_bool truthiness to TIRITH_FAIL_OPEN", async () => {
+    // `_env_bool` counts only 1/true/yes as true, so "on" — which IS true for
+    // the YAML key one line above — is false as an env var. The asymmetry is
+    // upstream's; mirroring only one half of it would invert the card.
+    envFile = { TIRITH_FAIL_OPEN: "on" };
+
+    expect((await readStatus()).failOpen).toBe(false);
+  });
+
   it("reads a key written with no value at all as OFF", async () => {
     // `tirith_enabled:` — a truncated write or a templated blank. YAML reads it
     // as null, which Python calls false; `getYamlPath` alone cannot tell it

--- a/src/tests/unit/hermes-shell-scan.test.ts
+++ b/src/tests/unit/hermes-shell-scan.test.ts
@@ -45,13 +45,24 @@ let configText: string | null | Error = "";
 const enoent = () => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
 
 const stat = vi.fn(async (p: string) => {
-  if (p === MARKER) {
-    if (markerMtimeMs === null) throw enoent();
-    return { mtimeMs: markerMtimeMs, isFile: () => true };
-  }
   if (directories.has(p)) return { mtimeMs: 0, isFile: () => false };
   if (executables.has(p) || plainFiles.has(p)) return { mtimeMs: 0, isFile: () => true };
   throw enoent();
+});
+/**
+ * The marker is read through ONE descriptor — its age and its reason together
+ * decide what the owner is told, and reading them by name twice is a TOCTOU
+ * (CodeQL js/file-system-race). The mock mirrors that: no `stat(MARKER)` path
+ * exists, so a regression back to stat-then-read fails here.
+ */
+const open = vi.fn(async (p: string) => {
+  if (p !== MARKER || markerMtimeMs === null) throw enoent();
+  const mtimeMs = markerMtimeMs;
+  return {
+    stat: async () => ({ mtimeMs, isFile: () => true }),
+    readFile: async () => markerReason,
+    close: async () => {},
+  };
 });
 const access = vi.fn(async (p: string) => {
   if (!executables.has(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" });
@@ -62,10 +73,6 @@ const readFile = vi.fn(async (p: string) => {
     if (configText instanceof Error) throw configText;
     return configText;
   }
-  if (p === MARKER) {
-    if (markerMtimeMs === null) throw enoent();
-    return markerReason;
-  }
   throw enoent();
 });
 vi.mock("fs/promises", () => ({
@@ -73,6 +80,7 @@ vi.mock("fs/promises", () => ({
     stat: (p: string) => stat(p),
     access: (p: string) => access(p),
     readFile: (p: string) => readFile(p),
+    open: (p: string) => open(p),
   },
 }));
 

--- a/src/tests/unit/hermes-shell-scan.test.ts
+++ b/src/tests/unit/hermes-shell-scan.test.ts
@@ -41,6 +41,10 @@ let markerMtimeMs: number | null = null;
 let markerReason = "";
 /** ~/.hermes/config.yaml, or null for "no such file", or an Error to throw. */
 let configText: string | null | Error = "";
+/** False models a fifo/directory where config.yaml should be. */
+let configIsRegularFile = true;
+/** Overrides the reported size, for the too-large guard. */
+let configSize: number | null = null;
 
 const enoent = () => Object.assign(new Error("ENOENT"), { code: "ENOENT" });
 
@@ -56,10 +60,20 @@ const stat = vi.fn(async (p: string) => {
  * exists, so a regression back to stat-then-read fails here.
  */
 const open = vi.fn(async (p: string) => {
+  if (p === CONFIG) {
+    if (configText === null) throw enoent();
+    if (configText instanceof Error) throw configText;
+    const text = configText;
+    return {
+      stat: async () => ({ mtimeMs: 0, size: configSize ?? text.length, isFile: () => configIsRegularFile }),
+      readFile: async () => text,
+      close: async () => {},
+    };
+  }
   if (p !== MARKER || markerMtimeMs === null) throw enoent();
   const mtimeMs = markerMtimeMs;
   return {
-    stat: async () => ({ mtimeMs, isFile: () => true }),
+    stat: async () => ({ mtimeMs, size: markerReason.length, isFile: () => true }),
     readFile: async () => markerReason,
     close: async () => {},
   };
@@ -67,19 +81,17 @@ const open = vi.fn(async (p: string) => {
 const access = vi.fn(async (p: string) => {
   if (!executables.has(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" });
 });
-const readFile = vi.fn(async (p: string) => {
-  if (p === CONFIG) {
-    if (configText === null) throw enoent();
-    if (configText instanceof Error) throw configText;
-    return configText;
-  }
-  throw enoent();
-});
+/**
+ * `fs.readFile` is deliberately ABSENT from this mock. config.yaml and the
+ * marker are both read through one descriptor opened O_NONBLOCK — a fifo
+ * planted in either path by the agent (which runs as the same user) would
+ * otherwise park the status route forever — so a regression to a plain
+ * path-based read fails here with "not a function" instead of passing quietly.
+ */
 vi.mock("fs/promises", () => ({
   default: {
     stat: (p: string) => stat(p),
     access: (p: string) => access(p),
-    readFile: (p: string) => readFile(p),
     open: (p: string) => open(p),
   },
 }));
@@ -113,6 +125,8 @@ beforeEach(() => {
   markerMtimeMs = null;
   markerReason = "";
   configText = "";
+  configIsRegularFile = true;
+  configSize = null;
   envFile = {};
   vi.stubEnv("HOME", HOME);
   // Deliberately NOT the agent's PATH. Nothing in this module may read it.
@@ -159,8 +173,31 @@ describe("readShellScanStatus — the scanner is missing", () => {
     // a day for that would be a false failure.
     markerMtimeMs = Date.now() - 60_000;
     markerReason = "cosign_missing";
+    executables.add("/usr/bin/cosign");
 
     expect((await readStatus()).retrySuppressedUntil).toBeNull();
+  });
+
+  it("keeps the 24 h claim for a cosign_missing marker when cosign is not installed", async () => {
+    // Upstream drops that marker only once cosign is actually on PATH; without
+    // it the suppression stands like any other, and telling the owner to plug
+    // the box in would be a false failure.
+    markerMtimeMs = Date.now() - 60_000;
+    markerReason = "cosign_missing";
+
+    expect((await readStatus()).retrySuppressedUntil).not.toBeNull();
+  });
+
+  it("does not promise a download retry for an explicitly configured path", async () => {
+    // Upstream never auto-downloads on the explicit branch, so a stale marker
+    // from an earlier default-path era must not produce "will retry after…".
+    configText = securityYaml('  tirith_path: "/opt/tirith/tirith"\n');
+    markerMtimeMs = Date.now() - 60_000;
+
+    const status = await readStatus();
+
+    expect(status.reason).toBe("not-installed");
+    expect(status.retrySuppressedUntil).toBeNull();
   });
 
   it("says the agent blocks commands instead when the box is set to fail closed", async () => {
@@ -242,6 +279,87 @@ describe("readShellScanStatus — the scanner is installed", () => {
 
     expect(status.state).toBe("off");
     expect(status.reason).toBe("not-installed");
+  });
+});
+
+/**
+ * Upstream never parses these keys as booleans. `_load_security_config` hands
+ * the YAML value through untouched and the call sites apply plain Python
+ * truthiness — `if not cfg["tirith_enabled"]` skips scanning outright, and
+ * `if fail_open` decides between allowing and BLOCKING. So every value Python
+ * calls false has to read as false here, including the shapes a truncated write
+ * or a hand edit actually produces. Reading them as "unset" and substituting a
+ * default is how a security control ends up reported as on while the agent is
+ * not scanning at all.
+ */
+describe("readShellScanStatus — a present-but-falsy setting is not an unset one", () => {
+  const FALSY = ["null", "~", '""', "0", "[]", "{}"];
+
+  for (const value of FALSY) {
+    it(`reads tirith_enabled: ${value} as OFF, not as the default ON`, async () => {
+      configText = securityYaml(`  tirith_enabled: ${value}\n`);
+      executables.add(SCANNER);
+
+      const status = await readStatus();
+
+      expect(status.state).toBe("off");
+      expect(status.reason).toBe("disabled-by-config");
+    });
+
+    it(`reads tirith_fail_open: ${value} as fail-CLOSED, not as the default fail-open`, async () => {
+      // The two outcomes are opposites: fail-open runs the command unchecked,
+      // fail-closed refuses to run it. Getting this backwards tells the owner
+      // his commands are running while the agent is blocking every one.
+      configText = securityYaml(`  tirith_fail_open: ${value}\n`);
+
+      expect((await readStatus()).failOpen).toBe(false);
+    });
+  }
+
+  it("reads a key written with no value at all as OFF", async () => {
+    // `tirith_enabled:` — a truncated write or a templated blank. YAML reads it
+    // as null, which Python calls false; `getYamlPath` alone cannot tell it
+    // apart from an absent key.
+    configText = securityYaml("  tirith_enabled:\n");
+    executables.add(SCANNER);
+
+    expect((await readStatus()).reason).toBe("disabled-by-config");
+  });
+
+  it("keeps upstream's default when the key really is absent", async () => {
+    // The other side of the same coin: no key at all still means enabled.
+    configText = securityYaml("  redact_secrets: true\n");
+    executables.add(SCANNER);
+
+    expect((await readStatus()).state).toBe("on");
+  });
+
+  it("treats an unrecognised word as TRUE, the way Python does", async () => {
+    // `if not "maybe"` is false in Python — a non-empty string is truthy.
+    configText = securityYaml("  tirith_enabled: maybe\n");
+    executables.add(SCANNER);
+
+    expect((await readStatus()).state).toBe("on");
+  });
+});
+
+describe("readShellScanStatus — config.yaml is read the hardened way", () => {
+  it("refuses a config.yaml that is not a regular file instead of hanging on it", async () => {
+    // The agent runs as the same user and can write ~/.hermes. A fifo planted
+    // where config.yaml belongs would park a plain read in open(2) with no
+    // writer, and this read sits inside the status route's Promise.all — the
+    // request would never settle and the card would hang empty forever.
+    configIsRegularFile = false;
+    executables.add(SCANNER);
+
+    expect((await readStatus()).state).toBe("unknown");
+  });
+
+  it("refuses a config.yaml far too large to be one", async () => {
+    configSize = 8 * 1024 * 1024;
+    executables.add(SCANNER);
+
+    expect((await readStatus()).state).toBe("unknown");
   });
 });
 

--- a/src/tests/unit/hermes-shell-scan.test.ts
+++ b/src/tests/unit/hermes-shell-scan.test.ts
@@ -1,0 +1,202 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Pre-exec shell scanning is the one security control on a Hermes box that can
+ * be OFF while nothing anywhere says so.
+ *
+ * The agent runs every shell command past `tirith` first, but tirith is not
+ * shipped — the agent downloads it from a GitHub release into
+ * `~/.hermes/bin/tirith` in a background thread, and until that finishes it
+ * runs commands unscanned (upstream's default is fail-open). The only trace is
+ * one `logger.warning` per process. A factory-reset box used to land exactly
+ * there: the wipe took the binary, the box rebooted into AP mode with no
+ * internet to re-download it, and the dashboard reported nothing.
+ *
+ * So this module has to get both halves right:
+ *   - it must SAY the scanner is off, and why (no false success);
+ *   - it must say nothing at all when the scanner is ready (no false failure),
+ *     or the warning is noise within a week.
+ */
+
+const HERMES_HOME = "/home/clawbox/.hermes";
+const SCANNER = `${HERMES_HOME}/bin/tirith`;
+const MARKER = `${HERMES_HOME}/.tirith-install-failed`;
+
+/** Paths that exist as executable regular files, per test. */
+let executables = new Set<string>();
+/** mtime for the install-failure marker, or null when there is no marker. */
+let markerMtimeMs: number | null = null;
+
+const stat = vi.fn(async (p: string) => {
+  if (p === MARKER) {
+    if (markerMtimeMs === null) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    return { mtimeMs: markerMtimeMs, isFile: () => true };
+  }
+  if (!executables.has(p)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+  return { mtimeMs: 0, isFile: () => true };
+});
+const access = vi.fn(async (p: string) => {
+  if (!executables.has(p)) throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+});
+vi.mock("fs/promises", () => ({ default: { stat: (p: string) => stat(p), access: (p: string) => access(p) } }));
+
+/** ~/.hermes/.env contents (the TIRITH_* overrides live here), or a throw. */
+let envFile: Record<string, string> | Error = {};
+const readHermesEnv = vi.fn(async () => {
+  if (envFile instanceof Error) throw envFile;
+  return envFile;
+});
+vi.mock("@/lib/hermes-env", () => ({
+  readHermesEnv: () => readHermesEnv(),
+  hermesHome: () => HERMES_HOME,
+}));
+
+/** What `hermes config get <key>` answers; "" is an unset key. */
+let configValues: Record<string, string> = {};
+/** Keys whose read FAILED (a wedged or missing `hermes`), not answered. */
+let pendingKeys = new Set<string>();
+vi.mock("@/lib/hermes-config-cache", () => ({
+  hermesConfigGetMany: async (keys: string[]) =>
+    Object.fromEntries(keys.map((k) => [k, configValues[k] ?? ""])),
+  hermesConfigReadPending: (key: string) => pendingKeys.has(key),
+}));
+
+async function readStatus() {
+  const { readShellScanStatus } = await import("@/lib/hermes-shell-scan");
+  return readShellScanStatus();
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  executables = new Set<string>();
+  markerMtimeMs = null;
+  envFile = {};
+  configValues = {};
+  pendingKeys = new Set<string>();
+  // Nothing named tirith on this process's PATH, so ~/.hermes/bin decides.
+  vi.stubEnv("PATH", "/nowhere/bin");
+  vi.stubEnv("HOME", "/home/clawbox");
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("readShellScanStatus — the scanner is missing", () => {
+  it("reports scanning OFF, and that the scanner is not installed", async () => {
+    const status = await readStatus();
+
+    expect(status.state).toBe("off");
+    expect(status.reason).toBe("not-installed");
+    // Upstream's default: the command still runs, just unscanned. The dashboard
+    // needs this to word the warning honestly.
+    expect(status.failOpen).toBe(true);
+    expect(status.scannerPath).toBeNull();
+  });
+
+  it("reports the 24 h retry suppression that keeps a box unscanned after it is back online", async () => {
+    // Upstream writes ~/.hermes/.tirith-install-failed when a download fails
+    // and then skips the network retry for 24 hours — so plugging the box in
+    // does not fix it straight away, and the owner has to be told that.
+    markerMtimeMs = Date.now() - 60_000;
+
+    const status = await readStatus();
+
+    expect(status.state).toBe("off");
+    expect(status.retrySuppressedUntil).not.toBeNull();
+    expect(Date.parse(status.retrySuppressedUntil!)).toBeGreaterThan(Date.now());
+  });
+
+  it("does not report a retry suppression once the marker has aged out", async () => {
+    markerMtimeMs = Date.now() - 25 * 60 * 60 * 1000;
+
+    expect((await readStatus()).retrySuppressedUntil).toBeNull();
+  });
+
+  it("says the agent blocks commands instead when the box is set to fail closed", async () => {
+    // `security.tirith_fail_open: false` is upstream's own deny-until-ready
+    // mode. The consequence for the owner is the opposite one — commands stop
+    // working — so the two cases must not share a sentence.
+    configValues["security.tirith_fail_open"] = "false";
+
+    const status = await readStatus();
+
+    expect(status.state).toBe("off");
+    expect(status.failOpen).toBe(false);
+  });
+});
+
+describe("readShellScanStatus — the scanner is ready", () => {
+  it("reports scanning ON and says nothing is wrong", async () => {
+    // The false-failure half: a box that is online with the scanner installed
+    // must not be warned at.
+    executables.add(SCANNER);
+
+    const status = await readStatus();
+
+    expect(status.state).toBe("on");
+    expect(status.reason).toBe("ok");
+    expect(status.scannerPath).toBe(SCANNER);
+    expect(status.retrySuppressedUntil).toBeNull();
+  });
+
+  it("finds a scanner at an explicitly configured path", async () => {
+    configValues["security.tirith_path"] = "/opt/tirith/tirith";
+    executables.add("/opt/tirith/tirith");
+
+    expect((await readStatus()).scannerPath).toBe("/opt/tirith/tirith");
+  });
+
+  it("honours the TIRITH_BIN env override, which is not called TIRITH_PATH", async () => {
+    // Upstream's asymmetry: the config key is `tirith_path`, the env var is
+    // `TIRITH_BIN`. Reading the wrong name would report a missing scanner on a
+    // box that has one.
+    envFile = { TIRITH_BIN: "/opt/custom/scan" };
+    executables.add("/opt/custom/scan");
+
+    expect((await readStatus()).scannerPath).toBe("/opt/custom/scan");
+  });
+});
+
+describe("readShellScanStatus — turned off on purpose, and not knowable", () => {
+  it("distinguishes 'switched off in the config' from 'never downloaded'", async () => {
+    configValues["security.tirith_enabled"] = "false";
+    executables.add(SCANNER);
+
+    const status = await readStatus();
+
+    expect(status.state).toBe("off");
+    expect(status.reason).toBe("disabled-by-config");
+  });
+
+  it("treats TIRITH_ENABLED the way upstream's _env_bool does", async () => {
+    // Anything that is not 1/true/yes is false upstream — including "on".
+    envFile = { TIRITH_ENABLED: "on" };
+    executables.add(SCANNER);
+
+    expect((await readStatus()).reason).toBe("disabled-by-config");
+  });
+
+  it("answers 'unknown', never 'on', when the agent's config could not be read", async () => {
+    // A wedged or missing `hermes` leaves the cache holding a failed READ, not
+    // an answer. Falling back to the defaults there would report a scanner that
+    // is enabled and present on a box nobody has actually asked — the exact
+    // false success this whole surface exists to prevent.
+    executables.add(SCANNER);
+    pendingKeys.add("security.tirith_enabled");
+
+    const status = await readStatus();
+
+    expect(status.state).toBe("unknown");
+    expect(status.reason).toBe("config-unreadable");
+  });
+
+  it("answers 'unknown' when ~/.hermes/.env cannot be read", async () => {
+    // An unreadable .env could be hiding a TIRITH_* override either way.
+    executables.add(SCANNER);
+    envFile = Object.assign(new Error("EACCES"), { code: "EACCES" });
+
+    expect((await readStatus()).state).toBe("unknown");
+  });
+});

--- a/src/tests/unit/hermes-translations.test.ts
+++ b/src/tests/unit/hermes-translations.test.ts
@@ -7,6 +7,7 @@ import { skillsEn } from "@/lib/hermes-translations/en-skills";
 import { localModelsEn } from "@/lib/hermes-translations/en-local-models";
 import { systemProfileEn } from "@/lib/hermes-translations/en-system-profile";
 import { codingAgentEn } from "@/lib/hermes-translations/en-coding-agent";
+import { shellScanEn } from "@/lib/hermes-translations/en-shell-scan";
 import { bg } from "@/lib/hermes-translations/bg";
 import { de } from "@/lib/hermes-translations/de";
 import { es } from "@/lib/hermes-translations/es";
@@ -50,6 +51,9 @@ const NAMESPACES: { name: string; matches: (key: string) => boolean }[] = [
   { name: "Desktop & power card", matches: (k) => k.startsWith("systemProfile.") },
   // Coding agent card: the owner's switch for delegated Claude Code runs.
   { name: "Coding agent card", matches: (k) => k.startsWith("codingAgent.") },
+  // Pre-exec shell scanning notice (HERMES-08) — the box's only statement that
+  // a security control is off. An owner who cannot read it is not warned.
+  { name: "Shell scanning notice", matches: (k) => k.startsWith("shellScan.") },
 ];
 
 /**
@@ -100,6 +104,7 @@ describe("hermes-translations (TASK-458)", () => {
       ["localModelsEn", localModelsEn, (k) => k.startsWith("localModels.")],
       ["systemProfileEn", systemProfileEn, (k) => k.startsWith("systemProfile.")],
       ["codingAgentEn", codingAgentEn, (k) => k.startsWith("codingAgent.")],
+      ["shellScanEn", shellScanEn, (k) => k.startsWith("shellScan.")],
     ];
 
     for (const [name, table, prefixed] of surfaces) {

--- a/src/tests/unit/translations.test.ts
+++ b/src/tests/unit/translations.test.ts
@@ -131,6 +131,7 @@ describe("translations", () => {
         "localModels",
         "systemProfile",
         "codingAgent",
+        "shellScan",
       ]);
 
       for (const key of Object.keys(translations.en)) {

--- a/src/tests/unit/yaml-block-edit.test.ts
+++ b/src/tests/unit/yaml-block-edit.test.ts
@@ -6,6 +6,7 @@ import {
   setYamlPath,
   unsetYamlPath,
   YamlEditUnsupported,
+  hasYamlPath,
 } from "@/lib/yaml-block-edit";
 
 /**
@@ -141,5 +142,30 @@ describe("formatYamlScalar", () => {
   it("round-trips a quoted value", () => {
     const out = setYamlPath("", ["providers", "clawlocal", "api_key"], "a#b c\"d");
     expect(getYamlPath(out, ["providers", "clawlocal", "api_key"])).toBe("a#b c\"d");
+  });
+});
+
+/**
+ * `getYamlPath` answers null both for "no such key" and for a key written with
+ * an empty value, and a reader that applies defaults has to tell those apart:
+ * YAML reads `foo:` as a null VALUE, so substituting a default there overrides
+ * something somebody actually wrote. That is a security bug on the one caller
+ * that has it (the Hermes shell-scan status), so the distinction is pinned.
+ */
+describe("hasYamlPath", () => {
+  const text = "security:\n  tirith_enabled:\n  tirith_path: \"tirith\"\n";
+
+  it("is true for a key written with no value, where getYamlPath answers null", () => {
+    expect(getYamlPath(text, ["security", "tirith_enabled"])).toBeNull();
+    expect(hasYamlPath(text, ["security", "tirith_enabled"])).toBe(true);
+  });
+
+  it("is false for a key that is genuinely absent", () => {
+    expect(hasYamlPath(text, ["security", "tirith_fail_open"])).toBe(false);
+    expect(hasYamlPath(text, ["nothing", "here"])).toBe(false);
+  });
+
+  it("is true for an ordinary key with a value", () => {
+    expect(hasYamlPath(text, ["security", "tirith_path"])).toBe(true);
   });
 });


### PR DESCRIPTION
**Finding:** HERMES-08 (verified 2026-09-03; board TASK-641, under TASK-604)

## Customer-visible symptom

Factory-reset a Hermes box. It reboots into AP mode with no internet, and from
that moment the agent executes shell commands with **pre-exec scanning off** —
no scan, no error, no warning, nothing on the dashboard. It stays that way until
somebody gets the box online *and* the agent's background download finishes.

The customer bought a box whose agent checks every shell command before running
it. After a reset they have a box that does not, and nothing tells them.

## Cause

`~/.hermes/bin/tirith` is the ~33 MB upstream binary the Hermes agent runs
before every shell command. It is not shipped with the box: the agent downloads
it from a GitHub release into `$HERMES_HOME/bin/tirith` in a background thread
the first time it is needed.

`src/app/setup-api/setup/reset/route.ts:61` wiped `~/.hermes` entry by entry with
`HERMES_KEEP = new Set(["hermes-agent"])`, so `bin/` went with everything else —
and a reset box has no internet to fetch it again.

Three upstream facts make it worse, all in `tools/tirith_security.py`
(NousResearch/hermes-agent):

* the default is **fail-open** (`tirith_fail_open: True`, `:74`) — a missing
  scanner means the command runs anyway, unscanned;
* the only trace is one `logger.warning` per process (`:769` "tirith path
  resolved to None; scanning disabled"). No error, no non-zero exit, nothing a
  health check sees;
* a failed download writes `~/.hermes/.tirith-install-failed` and **suppresses
  the retry for 24 hours** (`:170-172`, `:702-709`), so plugging the box back in
  does not fix it promptly. (That marker is *not* in the keep set, so the reset
  clears it — pinned by a test.)

## Harness first — the native mechanism, named

Hermes owns this entirely; ClawBox adds no policy of its own.

| what | native mechanism |
|---|---|
| enable / disable | `security.tirith_enabled` (env `TIRITH_ENABLED`), default on |
| binary location | `security.tirith_path` (env **`TIRITH_BIN`**, not `TIRITH_PATH`), default `"tirith"` → PATH, then `$HERMES_HOME/bin/tirith` |
| deny vs allow when the scanner is unavailable | `security.tirith_fail_open` (env `TIRITH_FAIL_OPEN`), default `true` |
| the agent-side notice | upstream's own `logger.warning`, `tirith_security.py:769` — not re-implemented here |

All four are `_load_security_config()`, `tirith_security.py:68-87`. ClawBox
previously used **none** of them — no `TIRITH_*` env var anywhere in the repo, no
`security:` block ever written, no surface. The only trace of the contract was a
captured comment block in a test fixture
(`src/tests/fixtures/hermes-config-3175.yaml:78-87`).

So this PR **reads** the harness's own keys and applies the harness's own
defaults. It does not re-implement a scanner, a gate, a second config store or a
second policy.

### The alternative that was considered and not taken

Upstream's resolution order for the default `"tirith"` is PATH first, then
`$HERMES_HOME/bin`. So `install.sh` could pre-seed the binary into
`/usr/local/bin`, which no reset path touches — that would make the keep-list
unnecessary *and* cover a box flashed from a golden image that has never been
online. It was not taken here, for three reasons, and it is worth a separate
decision rather than a silent omission:

1. it does not help a single box already in the field — those need the keep-list
   either way, so the two are complementary, not alternatives;
2. it moves a **third-party** binary download into the ClawBox installer:
   `_install_tirith` fetches from `github.com/sheeki03/tirith`, `releases/latest`
   — a user repo, not a NousResearch org repo, and not version-pinned. ClawBox
   taking ownership of that supply chain is a bigger decision than a keep-list;
3. it is ClawBox installing a binary the harness installs itself, which cuts
   *against* "leverage the harness first", not for it.

## Fail-closed or warn-and-allow?

**It is a product decision, and a one-key configuration change, not an
engineering one.** `security.tirith_fail_open: false` is upstream's own
deny-until-ready mode (`tirith_security.py:764`, `:771-773`, `:794-796`,
`:804-806`: missing path, spawn failure and timeout all become
`{"action": "block"}`).

Per the brief this PR implements **warn-and-allow**: upstream's default stays,
and the state becomes visible. The fail-closed option is filed as **TASK-674**
under TASK-604, with the arguments both ways and this caveat, which anyone
choosing fail-closed has to know:

> upstream's circuit breaker (`tirith_security.py:748-754`) returns `allow`
> unconditionally after three consecutive scanner failures, and that check sits
> **above** the `fail_open` read at `:764`. With a missing binary, fail-closed
> therefore blocks the first three commands and allows every one after that for
> the rest of the process. It is not an absolute guarantee, and the hole should
> be raised upstream at the same time.

## The fix

**1. Stop the reset from removing the scanner** —
`src/app/setup-api/setup/reset/route.ts`.

`bin` joins `HERMES_KEEP`, kept whole. The first version of this PR narrowed it
to `bin/tirith` (wipe the directory entry-by-entry, keep one name); the review
pass killed that, correctly, on two counts:

* nothing here has an authoritative inventory of that directory. ClawKeep's
  archiver, shipped in this same tree, calls it "`bin/` ~43 MB virtualenv"
  (`clawkeep/clawkeep/hermes.py:55`). A narrow keep would delete whatever else
  upstream puts there, on every box of the SKU at once, with no internet to
  restore it — the same blast radius the rejected `git status --porcelain` guard
  is argued against a few lines above;
* it would have made the reset walk a directory a previous owner controls, and
  `removeDirectoryContents` follows symlinks (`readdir` resolves the link, `rm`
  deletes through it) and rethrows `ENOTDIR`. That is a **pre-existing** hazard
  on beta for `~/.hermes`, `data/llamacpp` and `~/Documents`, filed separately as
  **TASK-676** with its own RED — not folded into this PR, which is about a
  different defect.

Keeping the directory whole also costs nothing on the residual the file already
documents: a planted `tirith` survives either way, because nothing on the device
can tell a genuine release binary from a replacement without a trusted checksum
an offline box does not have. The comment says exactly that rather than claiming
parity it does not have.

**2. Stop it being silent** — `src/lib/hermes-shell-scan.ts` (new),
`/setup-api/harness/status`, `src/components/HarnessPicker.tsx`.

Keeping the binary fixes the reset case, but the control can be off for reasons a
reset cannot fix: a box that has never been online, a download that failed, or
`security.tirith_enabled: false`. Settings → System now reports the posture.

* **No false success.** The card says scanning is off *and why* — "not
  installed" vs "switched off in the agent's settings" — and, when upstream's
  24 h marker is fresh, that the agent will not even retry the download before a
  named time. If the agent's `config.yaml` or `.env` could not be read the answer
  is `"unknown"`, never `"on"`: a failed read is not an answer. A `.env`
  override that settles the question on its own is still honoured, so a
  definitively-off box is not under-reported as "unknown" either.
* **No false failure.** A box whose scanner is installed renders nothing at all.
  The OpenClaw harness has no tirith and is never asked (`shellScan: null`), so
  the OpenClaw SKU and a dual box running OpenClaw are silent by construction; a
  dual box running Hermes reports, because `getActiveHarness()` decides. The PATH
  search uses the **agent's** PATH (pinned in
  `config/clawbox-hermes-dashboard.service:11`), not the web server's, which has
  no `~/.local/bin` — reading `process.env.PATH` here would have warned on a box
  that scans correctly.
* **Not probe-once, and no interpreter.** The filesystem checks run per call —
  the binary appears the moment the background download finishes. `config.yaml`
  is read directly with the repo's own YAML reader rather than through three
  `hermes config get` calls: it is the file `load_config_readonly()` reads,
  ClawBox is already its writer (`src/lib/hermes-config-yaml.ts`), and three
  Python interpreter starts do not belong behind a Settings panel. The read runs
  in the same `Promise.all` as the health probes, which already gate the card.

**What `"on"` does and does not claim.** It means *installed and enabled* — all
a file on disk can support. It is not a promise that commands are being checked:
upstream's circuit breaker is process-local, never reset, and invisible from
outside. The module, the type doc and the copy all say the first and never the
second.

**Translated.** The notice is the box's only statement that a security control is
off, so it is in the catalogue (`shellScan.*`, ten locales) rather than
hardcoded English like the rest of that card, and the namespace is added to the
two tests that hold that property.

## RED → GREEN

Paths below are redacted: the test runner interpolates the dev machine's real
`$HOME`, and this repo is public. Nothing else was removed.

### RED 1 — the reset wipes the scanner (unmodified `origin/beta`)

```
 ❯ |unit| src/tests/routes/setup/reset.test.ts (34 tests | 1 failed) 1991ms
     × never removes ~/.hermes/bin, which holds the pre-exec shell scanner 31ms

 FAIL  src/tests/routes/setup/reset.test.ts > POST /setup-api/setup/reset — Hermes agent + offline
       model survive > never removes ~/.hermes/bin, which holds the pre-exec shell scanner
AssertionError: expected [ '/test/data/config.json', …(33) ] to not include '$HOME/.hermes/bin'
 ❯ src/tests/routes/setup/reset.test.ts:598:25

 Test Files  1 failed (1)
      Tests  1 failed | 33 passed (34)
```

### RED 2 — nothing reports the posture (same tree, fix source reverted to beta)

Both directions fail on beta, not just the "it is off" one: the route has no
`shellScan` field at all, so "reports it as on when the scanner is there" fails
exactly as "reports scanning OFF" does.

```
Error: Cannot find package '@/lib/hermes-shell-scan'
Error: Cannot find package '@/lib/hermes-translations/en-shell-scan'

     × reports scanning OFF, and that the scanner is not installed
     × reports the 24 h retry suppression that keeps a box unscanned after it is back online
     × does not report a retry suppression once the marker has aged out
     × does not claim a 24 h wait for the one reason upstream clears early
     × says the agent blocks commands instead when the box is set to fail closed
     × does not mistake a directory named tirith for the scanner
     × does not mistake a present-but-not-executable file for the scanner
     × reports it as on and says nothing is wrong
     × looks on the AGENT's PATH, not the web server's
     × finds a scanner at an explicitly configured absolute path
     × honours the TIRITH_BIN env override, which is not called TIRITH_PATH
     × does not satisfy an explicitly configured name from the agent's download directory
     × distinguishes 'switched off in the config' from 'never downloaded'
     × treats TIRITH_ENABLED the way upstream's _env_bool does
     × applies upstream's defaults when the box has no config.yaml at all
     × answers 'unknown', never 'on', when the agent's config could not be read
     × still answers 'off' when the .env settles it and only config.yaml is unreadable
     × answers 'unknown' when ~/.hermes/.env cannot be read
     × reports that pre-exec shell scanning is off on a Hermes box
     × reports it as on when the scanner is there, so nothing warns on a healthy box
     × says nothing about scanning on the OpenClaw harness, which has no scanner
     × warns when the agent is running shell commands without the scanner
     × tells the owner the agent will not even retry the download yet
     × says commands are BLOCKED, not merely unscanned, when the box fails closed
     × names the config switch when scanning was turned off deliberately
     × does not call a failed settings read a security failure

 Test Files  4 failed | 1 passed (5)
      Tests  26 failed | 46 passed (72)
```

Stated honestly: the two "does NOT warn" component cases are among the 46 that
pass on beta, and they pass **vacuously** — beta renders no warning at all. They
are guards against a fix that warns unconditionally, not evidence of a defect.

### GREEN — the full suite as CI runs it, on the rebased head

```
$ bun run test:coverage:ci
 Test Files  648 passed (648)
      Tests  9375 passed (9375)
   Duration  119.81s
```

`npx tsc --noEmit` clean; `eslint` clean on every changed file (the one remaining
warning in `reset/route.ts`, an unused `CHPASSWD_SERVICE_NAME` import, is
pre-existing on beta).

## Sibling call sites

| site | verdict |
|---|---|
| `HOME_CONTENT_WIPE_KEEP` / `removeDirectoryContents` | the only consumers of the keep sets. The helper's symlink/`ENOTDIR` hazard is pre-existing and filed as TASK-676 rather than fixed here |
| `docs-site/support/recovery.mdx` — the hand-rolled SSH reset recipe | **fixed**: `find ~/.hermes … ! -name hermes-agent` reproduced this exact defect by hand. It now keeps `bin` too, mirroring the route |
| `docs-site/technical/filesystem.mdx` — the factory-reset table | **fixed**: the "wiped, except `hermes-agent`" row and the `~/.hermes` contents row |
| `docs-site/technical/authentication.mdx` — "Security posture summary" | **added**: the one place that enumerates the box's security controls did not mention pre-exec scanning at all |
| `clawkeep/clawkeep/hermes.py` — the Hermes archiver | **cleared**: an allow-list archive with `bin/` not in it, and restore swaps only listed assets, so it neither backs up nor deletes the scanner. Its header calls `bin/` "~43 MB virtualenv", which does not match what the on-box listing shows — flagged, not changed here, since a fix needs a device to settle it |
| `install.sh`, `install-x64.sh`, `scripts/setup-hermes-edition.sh`, `scripts/setup-hermes-dashboard-auth.sh` | **cleared**: none removes anything under `~/.hermes`; the factory reset was the only writer that did |
| `/setup-api/harness/status` consumers | `src/components/HarnessPicker.tsx` (updated) and `src/tests/middleware/middleware.test.ts` (path list only). `AIModelsStep.tsx` reads `/harness/active`, a different route, untouched. The route is behind a session — not in `PRE_AUTH_API_PATHS` — so the posture is not disclosed unauthenticated |
| OpenClaw edition / dual SKU | OpenClaw has no tirith; the route answers `shellScan: null` and the card stays silent. Pinned by a test |
| i18n catalogue | `shellScan.*` added to all ten locales, plus the namespace to `translations.test.ts` and `hermes-translations.test.ts`, which is what stops the next surface shipping English-only |

## Scope, stated rather than hidden

The review pass recommended splitting this: the reset carve-out is ~12 lines and
the posture surface is the rest. They are kept together because they are the same
defect — a security control off with nothing saying so — and because the brief
for this fix required the visible half explicitly. If the reset half is wanted on
the boxes sooner than the review of the surface allows, say so and it splits
cleanly at `src/app/setup-api/setup/reset/route.ts` plus its two tests.

## Not proven here

No device leg. Nothing in this change runs on a box: a route, a library, a React
card, a keep-list and a translation catalogue, all covered by CI. The on-box fact
it rests on — `~/.hermes/bin` holding `tirith`, 33,722,520 B — comes from the
HERMES-08 verification pass, not from this PR, and the ClawKeep/`filesystem.mdx`
disagreement about what else lives in that directory is exactly why the directory
is now kept whole rather than filtered.

Board: TASK-641 (the finding), TASK-674 (the fail-closed decision), TASK-676 (the
`removeDirectoryContents` hazard the review turned up).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Hermes shell-command scanning with status reporting for enabled, disabled, unavailable, and blocked states.
  - Added configurable fail-open or fail-closed behavior when scanning is unavailable.
  - Added localized scanner status messages and accessible warnings across supported languages.
  - Hermes scanner files are preserved during factory and SSH resets.
- **Documentation**
  - Documented scanning, configuration, download behavior, filesystem placement, and reset handling.
- **Tests**
  - Added coverage for scanner states, reset preservation, status reporting, and translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->