### PR TITLE
fix: go back for the real Hermes catalogue instead of rendering the fallback

### DIFF
--- a/src/app/setup-api/hermes/oauth/poll/route.ts
+++ b/src/app/setup-api/hermes/oauth/poll/route.ts
@@ -55,8 +55,12 @@ export async function GET(request: Request) {
   // Sampled BEFORE the tick that may report the sign-in, because after it the
   // answer already includes the provider that just connected and no change can
   // be seen. It is a read of the SWR-cached catalogue the panel is holding open
-  // anyway (FRESH_MS = 60 s), not a dashboard round-trip per tick — and the
-  // guard below is what keeps a pending tick from asking the agent for anything.
+  // anyway (FRESH_MS = 60 s), so no tick BLOCKS on a dashboard round-trip — and
+  // the guard below is what keeps a pending tick from asking the agent for
+  // anything. While the catalogue is a fallback rather than an answer, a tick
+  // does start a background re-ask (throttled to one a second, see
+  // `getModelOptions`); that is deliberate — this poll runs on exactly the box
+  // whose dashboard has just come back.
   const providersBefore = await readUsableProviderIds();
 
   try {

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -233,7 +233,11 @@ import { useProviderCatalog } from '@/hooks/useProviderCatalog'
 // get mixed. The MODEL list is scoped by the same server contract the Hermes
 // settings panel uses (GET /setup-api/hermes/models?provider=…) — no parallel
 // client-side filtering exists.
-import { useHermesModelOptions } from '@/hooks/useHermesModelOptions'
+import {
+  useHermesModelOptions,
+  DEGRADED_RETRY_ATTEMPTS,
+  degradedRetryDelayMs,
+} from '@/hooks/useHermesModelOptions'
 import {
   hermesProviderLabel,
   hermesProviderPillLabel,
@@ -3753,10 +3757,21 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
   // writes only if it is still the newest when its answer lands.
   const seedGenerationRef = useRef(0)
   const seedControllerRef = useRef<AbortController | null>(null)
+  // The pending "ask again, the box was still booting" timer, and the seed it
+  // calls. A ref rather than a direct recursive call because `seedHermesHeader`
+  // is a stable useCallback and cannot name itself.
+  const seedRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const seedRef = useRef<(signal?: AbortSignal, attempt?: number) => Promise<void>>(async () => {})
+  const clearSeedRetry = useCallback(() => {
+    if (!seedRetryTimerRef.current) return
+    clearTimeout(seedRetryTimerRef.current)
+    seedRetryTimerRef.current = null
+  }, [])
 
-  const seedHermesHeader = useCallback(async (signal?: AbortSignal) => {
+  const seedHermesHeader = useCallback(async (signal?: AbortSignal, attempt = 0) => {
     const generation = ++seedGenerationRef.current
     seedControllerRef.current?.abort()
+    clearSeedRetry()
     const controller = new AbortController()
     seedControllerRef.current = controller
     // The caller's signal still cancels this seed (unmount, harness switch).
@@ -3770,14 +3785,31 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         provider?: unknown
         current?: unknown
         reasoning?: unknown
+        stale?: unknown
       }
       // `aborted` alone is not enough: a response can resolve before the abort
       // lands, and `json()` adds a second await for a newer seed to start in.
       if (controller.signal.aborted || generation !== seedGenerationRef.current) return
+      // `stale` means the box could not reach its Hermes dashboard and answered
+      // from the on-disk manifest instead — a file from the docs site that only
+      // ever carries `openrouter` and `nous` and knows nothing about THIS
+      // device's credentials. Its rows arrive `authenticated: null` ("the
+      // source couldn't tell"), which the filter below keeps, so the header
+      // used to offer two providers the box has no key for: on the settled box
+      // both report `authenticated: false`, and picking one gives an empty
+      // model list and a failing turn. That is the "OpenAI Codex / OpenRouter /
+      // Nous Portal" header the owner photographed.
+      //
+      // So a degraded seed contributes NO rows. The device's own configured
+      // provider is still added below — the CLI read behind it is a fact about
+      // this box either way — and the retry at the end of this function goes
+      // back for the real list.
+      const degraded = mData?.stale === true
+      const reported = !degraded && Array.isArray(mData?.providers) ? mData.providers : []
       // Offer only providers Hermes has credentials for (`authenticated:
       // false` rows would give an empty model list and a failing turn).
       // `null` means the source couldn't tell — keep those.
-      const rows: HermesChatProvider[] = (Array.isArray(mData?.providers) ? mData.providers : [])
+      const rows: HermesChatProvider[] = reported
         .filter(p => typeof p?.id === 'string' && p.id && p.authenticated !== false)
         .map(p => ({
           id: p.id as string,
@@ -3807,12 +3839,24 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
         ?? (isHermesReasoningLevel(mData?.reasoning) ? mData.reasoning : null)
       hermesReasoningKnownRef.current = knownReasoning !== null
       setHermesReasoning(knownReasoning ?? HERMES_REASONING_DEFAULT)
+
+      // Go back for the real list, with backoff — the same loop the scoped hook
+      // runs, and the same one #587 gave the OpenClaw picker for `warming`.
+      // Without it a chat opened during the ~11-12 s the Hermes dashboard needs
+      // to come up after a reboot kept the placeholder for the whole session.
+      if (degraded && attempt < DEGRADED_RETRY_ATTEMPTS) {
+        seedRetryTimerRef.current = setTimeout(
+          () => { void seedRef.current(signal, attempt + 1) },
+          degradedRetryDelayMs(attempt),
+        )
+      }
     } catch { /* header falls back to a plain label */ }
     finally {
       signal?.removeEventListener('abort', abortThis)
       if (seedControllerRef.current === controller) seedControllerRef.current = null
     }
   }, [])
+  useEffect(() => { seedRef.current = seedHermesHeader }, [seedHermesHeader])
 
   // Seed the Hermes header once the harness is known. This is the one place
   // left that asks WHICH harness is running rather than what it can do, and
@@ -3822,8 +3866,13 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     if (harnessId !== 'hermes') return
     const controller = new AbortController()
     void seedHermesHeader(controller.signal)
-    return () => { controller.abort() }
-  }, [harnessId, seedHermesHeader])
+    return () => {
+      controller.abort()
+      // A seed's retry is scheduled OUTSIDE any fetch, so aborting the signal
+      // does not by itself cancel one that is already pending.
+      clearSeedRetry()
+    }
+  }, [harnessId, seedHermesHeader, clearSeedRetry])
 
   // Re-seed when the settings panel changes the device's provider/model/tier or
   // adds a credential. Without this the header keeps naming the OLD provider
@@ -3847,8 +3896,9 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     return () => {
       controller.abort()
       unsubscribe()
+      clearSeedRetry()
     }
-  }, [harnessId, seedHermesHeader])
+  }, [harnessId, seedHermesHeader, clearSeedRetry])
 
   // Pre-warm the transport on mount so opening chat is instant. Gated on the
   // harness resolving: connecting before that is what would open a gateway

--- a/src/components/ChatPopup.tsx
+++ b/src/components/ChatPopup.tsx
@@ -3767,6 +3767,10 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     clearTimeout(seedRetryTimerRef.current)
     seedRetryTimerRef.current = null
   }, [])
+  // Whether anything is currently on offer in the header, read inside the seed
+  // (a stable useCallback, so it cannot close over the state).
+  const hermesProvidersRef = useRef<HermesChatProvider[]>([])
+  useEffect(() => { hermesProvidersRef.current = hermesProviders }, [hermesProviders])
 
   const seedHermesHeader = useCallback(async (signal?: AbortSignal, attempt = 0) => {
     const generation = ++seedGenerationRef.current
@@ -3778,8 +3782,22 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
     const abortThis = () => controller.abort()
     if (signal?.aborted) abortThis()
     else signal?.addEventListener('abort', abortThis)
+    // Ask again later, keeping what is on screen. True when one was booked.
+    const retryLater = (): boolean => {
+      if (attempt >= DEGRADED_RETRY_ATTEMPTS) return false
+      if (controller.signal.aborted || generation !== seedGenerationRef.current) return false
+      seedRetryTimerRef.current = setTimeout(
+        () => { void seedRef.current(signal, attempt + 1) },
+        degradedRetryDelayMs(attempt),
+      )
+      return true
+    }
     try {
       const mRes = await fetch('/setup-api/hermes/models', { cache: 'no-store', signal: controller.signal })
+      // A non-OK answer has no `providers` and no `stale` (the route's own 502
+      // arm is `{ error }`), so without this it read as a LIVE empty catalogue
+      // and unmounted the header outright.
+      if (!mRes.ok) throw new Error(`HTTP ${mRes.status}`)
       const mData = await mRes.json() as {
         providers?: { id?: unknown; name?: unknown; authenticated?: unknown }[]
         provider?: unknown
@@ -3805,6 +3823,17 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // this box either way — and the retry at the end of this function goes
       // back for the real list.
       const degraded = mData?.stale === true
+      // A degraded answer must never REPLACE a good one. The header is seeded
+      // again on every providers-changed signal, so a key saved during a
+      // dashboard blip used to collapse a live four-provider list to the one
+      // configured provider and silently move the active provider off the
+      // owner's pick — every turn in that window then ran on the device default.
+      // Keep what is rendered and go back for the real list; only a header with
+      // nothing on offer yet falls back to the device's own provider.
+      if (degraded && hermesProvidersRef.current.length > 0) {
+        retryLater()
+        return
+      }
       const reported = !degraded && Array.isArray(mData?.providers) ? mData.providers : []
       // Offer only providers Hermes has credentials for (`authenticated:
       // false` rows would give an empty model list and a failing turn).
@@ -3844,18 +3873,19 @@ function ChatPopup({ isOpen, onClose, onOpenFull, onOpenSettingsSection, onThink
       // runs, and the same one #587 gave the OpenClaw picker for `warming`.
       // Without it a chat opened during the ~11-12 s the Hermes dashboard needs
       // to come up after a reboot kept the placeholder for the whole session.
-      if (degraded && attempt < DEGRADED_RETRY_ATTEMPTS) {
-        seedRetryTimerRef.current = setTimeout(
-          () => { void seedRef.current(signal, attempt + 1) },
-          degradedRetryDelayMs(attempt),
-        )
-      }
-    } catch { /* header falls back to a plain label */ }
+      if (degraded) retryLater()
+    } catch {
+      // A dropped connection is the same news as a degraded body, and it is the
+      // shape the reported incident took: the box restarted three times inside
+      // four minutes, so the seeds in that window were rejections and 502s.
+      // Without this the header fell back to a plain label for the session.
+      retryLater()
+    }
     finally {
       signal?.removeEventListener('abort', abortThis)
       if (seedControllerRef.current === controller) seedControllerRef.current = null
     }
-  }, [])
+  }, [clearSeedRetry])
   useEffect(() => { seedRef.current = seedHermesHeader }, [seedHermesHeader])
 
   // Seed the Hermes header once the harness is known. This is the one place

--- a/src/components/HermesProviderConfig.tsx
+++ b/src/components/HermesProviderConfig.tsx
@@ -1391,7 +1391,14 @@ export default function HermesProviderConfig({
                 // this field exists to collect. A pending key is its own reason
                 // to enable it (the save path stores the key first, then lets
                 // the server pick that provider's own default model).
-                disabled={saving || loading || (!modelInScope && !hasPendingKey)}
+                //
+                // `loading` is now held for the whole catalogue retry while the
+                // box answers with a placeholder (the Hermes dashboard is down
+                // or still booting) — and pasting a key is the very gesture that
+                // recovers such a box, so it must not be greyed out waiting for
+                // a catalogue `saveModelProvider` does not need. The model
+                // <select> beside it still shows its spinner.
+                disabled={saving || (loading && !hasPendingKey) || (!modelInScope && !hasPendingKey)}
                 className="w-full rounded-xl bg-[var(--coral-bright)] text-white font-semibold py-3 hover:opacity-90 transition-opacity disabled:opacity-50"
               >
                 {saving ? t("hermesProvider.save.saving") : t("hermesProvider.save.button")}

--- a/src/hooks/useHermesModelOptions.ts
+++ b/src/hooks/useHermesModelOptions.ts
@@ -190,10 +190,14 @@ export function useHermesModelOptions(provider: string | null): UseHermesModelOp
     /** Ask again later, keeping what is on screen. True when one was booked. */
     const retryLater = (): boolean => {
       if (attempt >= DEGRADED_RETRY_ATTEMPTS) return false;
-      // The user's explicit Refresh is NOT consumed by a retry — a placeholder
-      // and a dropped connection are both "the request did not complete", which
-      // is the condition `pendingRefreshRef` exists to carry across.
-      timer = setTimeout(() => load(pendingRefreshRef.current), degradedRetryDelayMs(attempt));
+      // ALWAYS a plain load, never the user's `refresh=1`. That flag busts
+      // Hermes' per-provider disk cache and re-enumerates every provider's live
+      // /v1/models, and this schedule (1+2+4+8+8 s) crosses the server's 10 s
+      // throttle twice — so carrying it would turn one Refresh click on a
+      // degraded box into three device-wide sweeps. It also could not help: a
+      // placeholder means the dashboard is unreachable, and `?refresh=true`
+      // goes to that same dashboard.
+      timer = setTimeout(() => load(false), degradedRetryDelayMs(attempt));
       attempt += 1;
       return true;
     };
@@ -204,6 +208,11 @@ export function useHermesModelOptions(provider: string | null): UseHermesModelOp
         .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
         .then((data: HermesModelScope) => {
           if (controller.signal.aborted) return;
+          // The request COMPLETED, which is the condition this flag is cleared
+          // on — a degraded body is still the server answering. Only an ABORT
+          // (fast provider switch, StrictMode double-mount) carries the intent
+          // over, because that request never got an answer at all.
+          pendingRefreshRef.current = false;
           // Read the RESPONSE's own flag, not the substituted scope's:
           // `emptyScope` is `stale: true` by construction, so gating on it would
           // put the provider-mismatch guard below into the retry loop as well.
@@ -216,7 +225,6 @@ export function useHermesModelOptions(provider: string | null): UseHermesModelOp
             // than "this provider has none".
             return;
           }
-          pendingRefreshRef.current = false;
           // Guard against a stale/garbled payload naming a different provider.
           setLoaded({
             provider,

--- a/src/hooks/useHermesModelOptions.ts
+++ b/src/hooks/useHermesModelOptions.ts
@@ -234,13 +234,19 @@ export function useHermesModelOptions(provider: string | null): UseHermesModelOp
         })
         .catch((err) => {
           if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) return;
+          // Cleared here too, and BEFORE the retry: only an abort preserves the
+          // intent (see above). An HTTP error, a dropped connection and a
+          // failed parse all leave this branch with retries pending, and a
+          // provider switch inside that window would re-run the effect and send
+          // `refresh=1` for a provider the owner never clicked Refresh on — the
+          // same device-wide /v1/models sweep, through a third door.
+          pendingRefreshRef.current = false;
           // A REJECTED request is the same news as a placeholder, and it is the
           // shape the reported incident actually took: the box restarted three
           // times inside four minutes, so the reads in that window were dropped
           // connections and 502s, not tidy degraded 200s. Retrying only the
           // polite failure would have left the observed case unfixed.
           if (retryLater()) return;
-          pendingRefreshRef.current = false;
           setLoaded({ provider, scope: emptyScope(provider), error: "Couldn't load models" });
         });
     };

--- a/src/hooks/useHermesModelOptions.ts
+++ b/src/hooks/useHermesModelOptions.ts
@@ -187,30 +187,51 @@ export function useHermesModelOptions(provider: string | null): UseHermesModelOp
     let timer: ReturnType<typeof setTimeout> | null = null;
     let attempt = 0;
 
+    /** Ask again later, keeping what is on screen. True when one was booked. */
+    const retryLater = (): boolean => {
+      if (attempt >= DEGRADED_RETRY_ATTEMPTS) return false;
+      // The user's explicit Refresh is NOT consumed by a retry — a placeholder
+      // and a dropped connection are both "the request did not complete", which
+      // is the condition `pendingRefreshRef` exists to carry across.
+      timer = setTimeout(() => load(pendingRefreshRef.current), degradedRetryDelayMs(attempt));
+      attempt += 1;
+      return true;
+    };
+
     const load = (refresh: boolean) => {
       const url = `/setup-api/hermes/models?provider=${encodeURIComponent(provider)}${refresh ? "&refresh=1" : ""}`;
       fetch(url, { cache: "no-store", signal: controller.signal })
         .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
         .then((data: HermesModelScope) => {
           if (controller.signal.aborted) return;
-          pendingRefreshRef.current = false;
-          // Guard against a stale/garbled payload naming a different provider.
-          const scope = data?.provider === provider ? data : emptyScope(provider);
-          if (isPlaceholder(scope) && attempt < DEGRADED_RETRY_ATTEMPTS) {
+          // Read the RESPONSE's own flag, not the substituted scope's:
+          // `emptyScope` is `stale: true` by construction, so gating on it would
+          // put the provider-mismatch guard below into the retry loop as well.
+          if (isPlaceholder(data) && retryLater()) {
             // Deliberately NOT installed: `loaded` is what makes `loading` go
             // false, and a placeholder is not something to settle on. Holding
             // it keeps the model pill in its place with the loading label
             // instead of collapsing the header, and keeps the send path saying
             // "still loading this provider's models" (`modelsReady`) rather
             // than "this provider has none".
-            timer = setTimeout(() => load(false), degradedRetryDelayMs(attempt));
-            attempt += 1;
             return;
           }
-          setLoaded({ provider, scope, error: null });
+          pendingRefreshRef.current = false;
+          // Guard against a stale/garbled payload naming a different provider.
+          setLoaded({
+            provider,
+            scope: data?.provider === provider ? data : emptyScope(provider),
+            error: null,
+          });
         })
         .catch((err) => {
           if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) return;
+          // A REJECTED request is the same news as a placeholder, and it is the
+          // shape the reported incident actually took: the box restarted three
+          // times inside four minutes, so the reads in that window were dropped
+          // connections and 502s, not tidy degraded 200s. Retrying only the
+          // polite failure would have left the observed case unfixed.
+          if (retryLater()) return;
           pendingRefreshRef.current = false;
           setLoaded({ provider, scope: emptyScope(provider), error: "Couldn't load models" });
         });

--- a/src/hooks/useHermesModelOptions.ts
+++ b/src/hooks/useHermesModelOptions.ts
@@ -82,6 +82,57 @@ interface LoadedState {
   error: string | null;
 }
 
+/**
+ * True when the box handed back a PLACEHOLDER rather than its answer.
+ *
+ * `stale` means "this did not come from the live Hermes dashboard" — the reply
+ * was built from Hermes' on-disk manifest (which only ever carries `openrouter`
+ * and `nous`, and knows nothing about this device) or from the cold-start
+ * floor. For a provider the manifest has never heard of, that reply is `models:
+ * []` with HTTP 200: indistinguishable, to every consumer that does not read
+ * this flag, from "this provider serves nothing".
+ *
+ * `stale === false` is already the box's own readiness signal on this route:
+ * `SetupWizard.pollHermesReady` polls it to decide the Hermes dashboard has
+ * come up. This reads the same flag for the same fact — the chat header simply
+ * never adopted it.
+ *
+ * Only `stale` is consulted, never `source`: a reply that omits the field
+ * entirely is not evidence of degradation, and treating it as such would put
+ * every such caller into a retry loop.
+ */
+function isPlaceholder(scope: HermesModelScope | null | undefined): boolean {
+  return scope?.stale === true;
+}
+
+/**
+ * Go back for the real catalogue, with backoff, while the box is still
+ * answering with a placeholder.
+ *
+ * This is the OpenClaw picker's `warming` loop (`useProviderCatalog`), pointed
+ * at the fact the Hermes payload already publishes. Every reboot has a window
+ * of it: `clawbox-setup` logs "Ready in 0ms" and starts serving while
+ * `clawbox-hermes-dashboard` needs another 11-12 s, and a chat opened in that
+ * window used to keep the empty answer for the rest of the session — the model
+ * pill needs more than one id to render at all, so it simply never appeared.
+ *
+ * Bounded for the same reason that one is: a box whose dashboard is not coming
+ * back must not be polled forever, and while these retries run the surfaces
+ * read as LOADING — including the Settings panel's model select, which holds
+ * back its own "this list is stale" note until they settle. 1+2+4+8+8 spans
+ * ~23 s: twice the measured boot window, and short enough that a box whose
+ * dashboard is genuinely gone reaches the honest empty state promptly rather
+ * than sitting on a spinner.
+ */
+export const DEGRADED_RETRY_BASE_MS = 1_000;
+export const DEGRADED_RETRY_MAX_MS = 8_000;
+export const DEGRADED_RETRY_ATTEMPTS = 5;
+
+/** Delay before retry number `attempt` (0-based). */
+export function degradedRetryDelayMs(attempt: number): number {
+  return Math.min(DEGRADED_RETRY_BASE_MS * 2 ** attempt, DEGRADED_RETRY_MAX_MS);
+}
+
 export function useHermesModelOptions(provider: string | null): UseHermesModelOptions {
   // One state cell written only from async callbacks — `loading` is DERIVED
   // from "what we hold isn't for the provider we were asked about", so
@@ -133,28 +184,48 @@ export function useHermesModelOptions(provider: string | null): UseHermesModelOp
     controllerRef.current?.abort();
     const controller = new AbortController();
     controllerRef.current = controller;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let attempt = 0;
 
-    const explicitRefresh = pendingRefreshRef.current;
-    const url = `/setup-api/hermes/models?provider=${encodeURIComponent(provider)}${explicitRefresh ? "&refresh=1" : ""}`;
-    fetch(url, { cache: "no-store", signal: controller.signal })
-      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
-      .then((data: HermesModelScope) => {
-        if (controller.signal.aborted) return;
-        pendingRefreshRef.current = false;
-        // Guard against a stale/garbled payload naming a different provider.
-        setLoaded({
-          provider,
-          scope: data?.provider === provider ? data : emptyScope(provider),
-          error: null,
+    const load = (refresh: boolean) => {
+      const url = `/setup-api/hermes/models?provider=${encodeURIComponent(provider)}${refresh ? "&refresh=1" : ""}`;
+      fetch(url, { cache: "no-store", signal: controller.signal })
+        .then((r) => (r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`))))
+        .then((data: HermesModelScope) => {
+          if (controller.signal.aborted) return;
+          pendingRefreshRef.current = false;
+          // Guard against a stale/garbled payload naming a different provider.
+          const scope = data?.provider === provider ? data : emptyScope(provider);
+          if (isPlaceholder(scope) && attempt < DEGRADED_RETRY_ATTEMPTS) {
+            // Deliberately NOT installed: `loaded` is what makes `loading` go
+            // false, and a placeholder is not something to settle on. Holding
+            // it keeps the model pill in its place with the loading label
+            // instead of collapsing the header, and keeps the send path saying
+            // "still loading this provider's models" (`modelsReady`) rather
+            // than "this provider has none".
+            timer = setTimeout(() => load(false), degradedRetryDelayMs(attempt));
+            attempt += 1;
+            return;
+          }
+          setLoaded({ provider, scope, error: null });
+        })
+        .catch((err) => {
+          if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) return;
+          pendingRefreshRef.current = false;
+          setLoaded({ provider, scope: emptyScope(provider), error: "Couldn't load models" });
         });
-      })
-      .catch((err) => {
-        if (controller.signal.aborted || (err instanceof DOMException && err.name === "AbortError")) return;
-        pendingRefreshRef.current = false;
-        setLoaded({ provider, scope: emptyScope(provider), error: "Couldn't load models" });
-      });
+    };
 
-    return () => controller.abort();
+    // Only the FIRST attempt carries the user's explicit refresh. A retry must
+    // not: `refresh=1` busts Hermes' per-provider disk cache and re-enumerates
+    // every provider's live /v1/models, which is a device-wide sweep to answer
+    // "is the dashboard up yet?".
+    load(pendingRefreshRef.current);
+
+    return () => {
+      if (timer) clearTimeout(timer);
+      controller.abort();
+    };
   }, [provider, nonce]);
 
   const fresh = provider && loaded?.provider === provider ? loaded : null;

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -200,6 +200,10 @@ export interface ScopedModelsReply extends ProviderScope {
 const FRESH_MS = 60_000;
 const STALE_MS = 6 * 60 * 60 * 1000;
 const DASHBOARD_TIMEOUT_MS = 8_000;
+/** How often a DEGRADED payload may trigger a background re-ask. See the rule
+ *  in `getModelOptions`; kept at the client's first retry step so a scheduled
+ *  retry always lands on a real attempt. */
+const DEGRADED_REFRESH_GAP_MS = 1_000;
 // A click-spammer on "Refresh" must not fan out into 40 upstream /v1/models
 // calls, so an explicit refresh is throttled per process.
 const EXPLICIT_REFRESH_MIN_GAP_MS = 10_000;
@@ -627,7 +631,7 @@ function load(refresh: boolean): Promise<ModelOptionsPayload> {
  * Serve the provider/model catalogue.
  *   live, fresh (<60 s)  → cached, no network
  *   live, stale (<6 h)   → cached instantly + background refresh (never awaited)
- *   fallback (`stale`)   → await a live fetch; it is not an answer to keep
+ *   fallback (`stale`)   → cached instantly + background refresh, once a second
  *   older / absent       → await a live fetch
  *   { refresh }          → await a live fetch that also busts Hermes'
  *                          per-provider disk cache (one per 10 s per process)
@@ -636,14 +640,19 @@ export async function getModelOptions(opts: { refresh?: boolean } = {}): Promise
   const now = Date.now();
 
   if (opts.refresh) {
-    if (now - lastExplicitRefreshAt < EXPLICIT_REFRESH_MIN_GAP_MS && cached) return cached;
-    lastExplicitRefreshAt = now;
-    return load(true);
+    // Throttled: fall through to the plain path rather than returning here, so
+    // a click-spammer is denied the EXPENSIVE upstream sweep without also being
+    // handed a placeholder the rule below would have gone back for.
+    if (now - lastExplicitRefreshAt >= EXPLICIT_REFRESH_MIN_GAP_MS || !cached) {
+      lastExplicitRefreshAt = now;
+      return load(true);
+    }
   }
 
   if (cached) {
     const age = now - cached.fetchedAt;
-    // A FALLBACK IS NOT AN ANSWER, so it gets no answer's freshness window.
+    // A FALLBACK IS NOT AN ANSWER, so it does not earn an answer's freshness
+    // window.
     //
     // It is Hermes' on-disk manifest (`openrouter` + `nous`, and nothing about
     // this device) or the cold-start floor, and it is served precisely because
@@ -655,17 +664,31 @@ export async function getModelOptions(opts: { refresh?: boolean } = {}): Promise
     // `isDowngrade` cannot help there: it compares against the previous CACHED
     // payload, and on a cold process there is none.
     //
-    // Awaited rather than served-and-refreshed-behind, because the caller does
-    // NOT already have a usable payload — that is the whole difference from the
-    // branch below. `load()` single-flights, so concurrent callers still share
-    // one round-trip, and a dashboard that is down refuses the connection
-    // rather than spending the timeout.
+    // Refreshed BEHIND the request rather than awaited, though. Awaiting was
+    // tried and is wrong: it deletes the cache for as long as the box is
+    // degraded, and every caller pays for that — the per-turn chat path
+    // (hermes/chat), the OAuth device-code poll (twice per tick through
+    // `readUsableProviderIds`), `provider-mcp-refresh` twice per credential
+    // write under its 3 s deadline, and the deliberately session-less GET on
+    // this route, which would then drive a dashboard round-trip per anonymous
+    // request. `DASHBOARD_TIMEOUT_MS` does not bound that either: the login
+    // `dashboardFetch` performs before its first attempt carries no signal. The
+    // client re-asks on its own now (`degradedRetryDelayMs` in
+    // useHermesModelOptions), so nothing has to block for recovery to happen —
+    // the next poll finds what this refresh installed.
     //
     // The flag read here is `payload.stale` — "did not come from the live
     // dashboard" — and NOT the `degraded` marker: a payload the downgrade guard
     // KEPT is a live catalogue whose refresh failed, and holding on to that is
     // the whole point of the guard.
-    if (cached.stale) return load(false);
+    if (cached.stale) {
+      // One attempt per second at most, so a burst of readers cannot turn a
+      // degraded box into a request loop against its own dashboard. Matched to
+      // the client's first retry step, so a retry arriving on schedule always
+      // triggers a real attempt rather than joining a throttled window.
+      if (age >= DEGRADED_REFRESH_GAP_MS) void load(false).catch(() => {});
+      return cached;
+    }
     if (age < FRESH_MS) return cached;
     if (age < STALE_MS) {
       // Serve stale immediately; refresh behind the request. Failures here are

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -625,11 +625,12 @@ function load(refresh: boolean): Promise<ModelOptionsPayload> {
 
 /**
  * Serve the provider/model catalogue.
- *   fresh (<60 s)  → cached, no network
- *   stale (<6 h)   → cached instantly + background refresh (never awaited)
- *   older / absent → await a live fetch
- *   { refresh }    → await a live fetch that also busts Hermes' per-provider
- *                    disk cache (throttled to one per 10 s per process)
+ *   live, fresh (<60 s)  → cached, no network
+ *   live, stale (<6 h)   → cached instantly + background refresh (never awaited)
+ *   fallback (`stale`)   → await a live fetch; it is not an answer to keep
+ *   older / absent       → await a live fetch
+ *   { refresh }          → await a live fetch that also busts Hermes'
+ *                          per-provider disk cache (one per 10 s per process)
  */
 export async function getModelOptions(opts: { refresh?: boolean } = {}): Promise<ModelOptionsPayload> {
   const now = Date.now();
@@ -642,6 +643,29 @@ export async function getModelOptions(opts: { refresh?: boolean } = {}): Promise
 
   if (cached) {
     const age = now - cached.fetchedAt;
+    // A FALLBACK IS NOT AN ANSWER, so it gets no answer's freshness window.
+    //
+    // It is Hermes' on-disk manifest (`openrouter` + `nous`, and nothing about
+    // this device) or the cold-start floor, and it is served precisely because
+    // the dashboard could not be reached. Holding it for `FRESH_MS` turned
+    // every reboot's ~11-12 s window — `clawbox-setup` answers in 0 ms,
+    // `clawbox-hermes-dashboard` needs another eleven seconds — into a full
+    // MINUTE of a device that appeared to have two providers and no models,
+    // for the chat header, the Settings panel and the MCP tools alike.
+    // `isDowngrade` cannot help there: it compares against the previous CACHED
+    // payload, and on a cold process there is none.
+    //
+    // Awaited rather than served-and-refreshed-behind, because the caller does
+    // NOT already have a usable payload — that is the whole difference from the
+    // branch below. `load()` single-flights, so concurrent callers still share
+    // one round-trip, and a dashboard that is down refuses the connection
+    // rather than spending the timeout.
+    //
+    // The flag read here is `payload.stale` — "did not come from the live
+    // dashboard" — and NOT the `degraded` marker: a payload the downgrade guard
+    // KEPT is a live catalogue whose refresh failed, and holding on to that is
+    // the whole point of the guard.
+    if (cached.stale) return load(false);
     if (age < FRESH_MS) return cached;
     if (age < STALE_MS) {
       // Serve stale immediately; refresh behind the request. Failures here are

--- a/src/tests/components/chat-hermes-stale-catalogue.test.tsx
+++ b/src/tests/components/chat-hermes-stale-catalogue.test.tsx
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, fireEvent, within } from "@/tests/helpers/test-utils";
+import { installHermesBox, mountHermesChat, type HermesBox } from "@/tests/helpers/hermes-chat-box";
+import { resetHarnessCache } from "@/lib/client-harness";
+import { DEGRADED_RETRY_ATTEMPTS, degradedRetryDelayMs } from "@/hooks/useHermesModelOptions";
+
+/**
+ * TASK-677 — the Hermes chat header rendered a DEGRADED catalogue as if it were
+ * the box's answer, and never went back for the real one.
+ *
+ * Every reboot has a window of it. `clawbox-setup` logs "Ready in 0ms" and
+ * starts serving while `clawbox-hermes-dashboard` needs another 11-12 s to come
+ * up (measured on the box: 08:05:21 → 08:05:32, 08:09:56 → 08:10:08). A
+ * `/setup-api/hermes/models` served in that window cannot reach the dashboard,
+ * so it falls back to Hermes' on-disk manifest — a CURATED FILE from the docs
+ * site that only ever carries `openrouter` and `nous`, and knows nothing about
+ * this device. The payload says so: `source: "catalog-file"`, `stale: true`.
+ *
+ * Nothing on the client read either field. The header seeded from the manifest
+ * — which is exactly the "OpenAI Codex / OpenRouter / Nous Portal" list the
+ * owner photographed, the manifest's two rows plus the device's own provider
+ * unshifted in — and the scoped read for `openai-codex` answered `models: []`,
+ * which hides the model pill (`showModelPill` needs more than one id). With no
+ * retry, no backoff and no marker, the header stayed wrong until the page was
+ * reloaded.
+ *
+ * The mechanism to copy is the harness's own: #587 gave the OpenClaw picker a
+ * `warming` flag and `useProviderCatalog` retries with backoff until the
+ * catalogue stops saying it is warming. The Hermes payload already publishes
+ * the equivalent facts.
+ */
+
+/** The scoped answer during the boot window: nothing, and it says so. */
+const STALE_SCOPE = {
+  provider: "openai-codex",
+  authenticated: null,
+  models: [],
+  defaultModel: "",
+  current: "",
+  savedElsewhere: null,
+  source: "catalog-file",
+  stale: true,
+  reasoning: "medium",
+  savedPair: { provider: "openai-codex", model: "gpt-5.6-sol" },
+};
+
+/** The unscoped seed during the same window: the manifest's two rows. Both
+ *  carry `authenticated: null` — "the source could not tell" — which the
+ *  header's `!== false` filter keeps. */
+const STALE_SEED = {
+  providers: [
+    { id: "openrouter", name: "openrouter", authenticated: null },
+    { id: "nous", name: "nous", authenticated: null },
+  ],
+  models: [],
+  provider: "openai-codex",
+  current: "gpt-5.6-sol",
+  reasoning: "medium",
+  source: "catalog-file",
+  stale: true,
+};
+
+/** What the settled box answers, captured from it: seven Codex models. */
+const LIVE_SCOPE = {
+  provider: "openai-codex",
+  authenticated: true,
+  models: [
+    "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+    "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark",
+  ].map((id) => ({ id, description: "" })),
+  defaultModel: "gpt-5.6-sol",
+  current: "gpt-5.6-sol",
+  savedElsewhere: null,
+  source: "dashboard",
+  stale: false,
+  reasoning: "medium",
+  savedPair: { provider: "openai-codex", model: "gpt-5.6-sol" },
+};
+
+const LIVE_SEED = {
+  providers: [
+    { id: "anthropic", name: "Anthropic", authenticated: true },
+    { id: "openai-codex", name: "OpenAI Codex", authenticated: true },
+    { id: "openrouter", name: "OpenRouter", authenticated: false },
+    { id: "nous", name: "Nous", authenticated: false },
+  ],
+  models: [],
+  provider: "openai-codex",
+  current: "gpt-5.6-sol",
+  reasoning: "medium",
+  source: "dashboard",
+  stale: false,
+};
+
+/** Every `/setup-api/hermes/models` URL the surface asked for, in order. */
+let modelUrls: string[] = [];
+
+/**
+ * A Hermes box whose models route is degraded for the first `staleAnswers`
+ * reads of each form and live afterwards — the boot window, then the dashboard
+ * coming up. Nothing else changes: no signal is emitted and nothing remounts.
+ */
+function installBootWindowBox(staleAnswers = 1): HermesBox {
+  const box = installHermesBox();
+  const inner = globalThis.fetch;
+  let seedReads = 0;
+  let scopeReads = 0;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/setup-api/hermes/models")) {
+        box.fetchedUrls.push(url);
+        modelUrls.push(url);
+        const scoped = new URL(url, "http://box").searchParams.get("provider");
+        if (scoped) {
+          scopeReads += 1;
+          return { ok: true, json: async () => (scopeReads <= staleAnswers ? STALE_SCOPE : LIVE_SCOPE) };
+        }
+        seedReads += 1;
+        return { ok: true, json: async () => (seedReads <= staleAnswers ? STALE_SEED : LIVE_SEED) };
+      }
+      return inner(input as RequestInfo, init);
+    }),
+  );
+  return box;
+}
+
+/** The provider pill's options, with the popover opened. */
+async function providerOptions(): Promise<string[]> {
+  const trigger = await waitFor(() => screen.getByLabelText(/^Chat provider:/));
+  fireEvent.click(trigger);
+  const list = await screen.findByRole("listbox", { name: "Chat provider" });
+  return within(list).getAllByRole("option").map((o) => o.textContent ?? "");
+}
+
+beforeEach(() => {
+  modelUrls = [];
+  resetHarnessCache();
+  window.localStorage.clear();
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.clearAllMocks();
+  resetHarnessCache();
+});
+
+describe("the Hermes chat header during the dashboard's boot window", () => {
+  it("goes back for the real catalogue and grows the model picker", async () => {
+    const box = installBootWindowBox();
+    await mountHermesChat(box);
+
+    // The header is up on the degraded answer: provider pill, no model pill.
+    await waitFor(() => expect(screen.getByLabelText(/^Chat provider:/)).toBeTruthy());
+    expect(screen.queryByLabelText(/^Hermes model:/)).toBeNull();
+
+    // No signal, no reload, no remount — the dashboard simply finishes booting.
+    const picker = await waitFor(
+      () => screen.getByLabelText(/^Hermes model:/),
+      { timeout: 8000 },
+    );
+
+    fireEvent.click(picker);
+    const options = await screen.findAllByRole("option");
+    const ids = options.map((o) => o.textContent ?? "");
+    expect(ids.some((label) => label.startsWith("gpt-5.6-sol"))).toBe(true);
+    expect(ids.some((label) => label.startsWith("gpt-5.3-codex-spark"))).toBe(true);
+  }, 15000);
+
+  it("re-asks rather than treating the fallback as the answer", async () => {
+    const box = installBootWindowBox();
+    await mountHermesChat(box);
+
+    // Both forms of the route are asked again: the seed, because the manifest
+    // is not this device's provider list, and the scope, because an empty list
+    // from a degraded payload is not "this provider serves nothing".
+    await waitFor(
+      () => {
+        expect(modelUrls.filter((u) => u.includes("provider=")).length).toBeGreaterThan(1);
+        expect(modelUrls.filter((u) => !u.includes("provider=")).length).toBeGreaterThan(1);
+      },
+      { timeout: 8000 },
+    );
+  }, 15000);
+
+  it("does not offer the manifest's providers as if the box had them", async () => {
+    // `openrouter` and `nous` are the only two rows the docs-site manifest ever
+    // carries, and it knows nothing about THIS device's credentials — on the
+    // settled box both report `authenticated: false`. Offering them is offering
+    // a provider that cannot answer a turn.
+    const box = installBootWindowBox(99); // the dashboard never comes up
+    await mountHermesChat(box);
+
+    await waitFor(() => expect(screen.getByLabelText(/^Chat provider:/)).toBeTruthy());
+    const labels = await providerOptions();
+
+    expect(labels.some((l) => l.includes("OpenAI Codex"))).toBe(true);
+    expect(labels.some((l) => l.includes("OpenRouter"))).toBe(false);
+    expect(labels.some((l) => l.includes("Nous"))).toBe(false);
+  }, 15000);
+
+  it("gives up in well under a minute rather than polling a dead dashboard", () => {
+    // While these retries run, every surface reads as LOADING — the header's
+    // pill holds its place and the Settings panel's model select holds back its
+    // "this list is stale" note. So the budget is a promise to the owner of a
+    // box whose dashboard is not coming back, not just a brake on traffic: the
+    // honest empty state has to arrive promptly. Asserted as arithmetic because
+    // waiting it out in a render test would cost the same seconds.
+    const total = Array.from({ length: DEGRADED_RETRY_ATTEMPTS }, (_, i) => degradedRetryDelayMs(i))
+      .reduce((a, b) => a + b, 0);
+    // Comfortably past the measured 11-12 s boot window, comfortably short of
+    // a spinner someone would reload the page over.
+    expect(total).toBeGreaterThan(20_000);
+    expect(total).toBeLessThan(30_000);
+  });
+});

--- a/src/tests/components/chat-hermes-stale-catalogue.test.tsx
+++ b/src/tests/components/chat-hermes-stale-catalogue.test.tsx
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { screen, waitFor, fireEvent, within } from "@/tests/helpers/test-utils";
+import { act, screen, waitFor, fireEvent, within } from "@/tests/helpers/test-utils";
 import { installHermesBox, mountHermesChat, type HermesBox } from "@/tests/helpers/hermes-chat-box";
 import { resetHarnessCache } from "@/lib/client-harness";
-import { DEGRADED_RETRY_ATTEMPTS, degradedRetryDelayMs } from "@/hooks/useHermesModelOptions";
+import { notifyHermesModelState } from "@/hooks/useHermesModelOptions";
 
 /**
  * TASK-677 — the Hermes chat header rendered a DEGRADED catalogue as if it were
@@ -95,16 +95,19 @@ const LIVE_SEED = {
 /** Every `/setup-api/hermes/models` URL the surface asked for, in order. */
 let modelUrls: string[] = [];
 
+/** How the box answers the models route right now. */
+type BoxMode = "live" | "degraded" | "down";
+
 /**
- * A Hermes box whose models route is degraded for the first `staleAnswers`
- * reads of each form and live afterwards — the boot window, then the dashboard
- * coming up. Nothing else changes: no signal is emitted and nothing remounts.
+ * A Hermes box whose models route answers per `mode()`. `down` is a dropped
+ * connection — the shape the reported incident took, since the box restarted
+ * three times inside four minutes — and `degraded` is the tidy fallback body.
+ * Nothing else changes: no signal is emitted and nothing remounts unless the
+ * test says so.
  */
-function installBootWindowBox(staleAnswers = 1): HermesBox {
+function installModedBox(mode: () => BoxMode): HermesBox {
   const box = installHermesBox();
   const inner = globalThis.fetch;
-  let seedReads = 0;
-  let scopeReads = 0;
   vi.stubGlobal(
     "fetch",
     vi.fn(async (input: unknown, init?: RequestInit) => {
@@ -112,18 +115,32 @@ function installBootWindowBox(staleAnswers = 1): HermesBox {
       if (url.includes("/setup-api/hermes/models")) {
         box.fetchedUrls.push(url);
         modelUrls.push(url);
+        const now = mode();
+        if (now === "down") throw new TypeError("Failed to fetch");
         const scoped = new URL(url, "http://box").searchParams.get("provider");
-        if (scoped) {
-          scopeReads += 1;
-          return { ok: true, json: async () => (scopeReads <= staleAnswers ? STALE_SCOPE : LIVE_SCOPE) };
-        }
-        seedReads += 1;
-        return { ok: true, json: async () => (seedReads <= staleAnswers ? STALE_SEED : LIVE_SEED) };
+        const body = scoped
+          ? (now === "degraded" ? STALE_SCOPE : LIVE_SCOPE)
+          : (now === "degraded" ? STALE_SEED : LIVE_SEED);
+        return { ok: true, json: async () => body };
       }
       return inner(input as RequestInfo, init);
     }),
   );
   return box;
+}
+
+/**
+ * The boot window: degraded for the first `bad` reads of the route, live
+ * afterwards — the dashboard finishing its start-up while the chat is open.
+ */
+function installBootWindowBox(bad = 1, kind: BoxMode = "degraded"): HermesBox {
+  let reads = 0;
+  return installModedBox(() => {
+    reads += 1;
+    // Two forms of the route are in flight, so the budget is counted per form
+    // rather than in total.
+    return reads <= bad * 2 ? kind : "live";
+  });
 }
 
 /** The provider pill's options, with the popover opened. */
@@ -201,18 +218,46 @@ describe("the Hermes chat header during the dashboard's boot window", () => {
     expect(labels.some((l) => l.includes("Nous"))).toBe(false);
   }, 15000);
 
-  it("gives up in well under a minute rather than polling a dead dashboard", () => {
-    // While these retries run, every surface reads as LOADING — the header's
-    // pill holds its place and the Settings panel's model select holds back its
-    // "this list is stale" note. So the budget is a promise to the owner of a
-    // box whose dashboard is not coming back, not just a brake on traffic: the
-    // honest empty state has to arrive promptly. Asserted as arithmetic because
-    // waiting it out in a render test would cost the same seconds.
-    const total = Array.from({ length: DEGRADED_RETRY_ATTEMPTS }, (_, i) => degradedRetryDelayMs(i))
-      .reduce((a, b) => a + b, 0);
-    // Comfortably past the measured 11-12 s boot window, comfortably short of
-    // a spinner someone would reload the page over.
-    expect(total).toBeGreaterThan(20_000);
-    expect(total).toBeLessThan(30_000);
-  });
+  it("recovers from a dropped connection, not only from a tidy 200", async () => {
+    // The observed incident: the box took SIGTERM mid-flight and restarted
+    // three times in four minutes, so the reads in that window were rejections
+    // and 502s. Retrying only the polite `stale: true` body would have left the
+    // reported case exactly as broken as before.
+    const box = installBootWindowBox(1, "down");
+    await mountHermesChat(box);
+
+    const picker = await waitFor(
+      () => screen.getByLabelText(/^Hermes model:/),
+      { timeout: 8000 },
+    );
+    expect(picker).toBeTruthy();
+    const labels = await providerOptions();
+    expect(labels.some((l) => l.includes("Anthropic"))).toBe(true);
+  }, 15000);
+
+  it("never lets a degraded seed replace a provider list it already has", async () => {
+    // A key saved in Settings emits providers-changed, which re-seeds the
+    // header. If that re-seed lands during a dashboard blip, a degraded answer
+    // used to collapse the live list to the one configured provider and move
+    // the active provider off the owner's pick — every turn in that window then
+    // ran on the device default, with nothing on screen to say so.
+    let mode: BoxMode = "live";
+    const box = installModedBox(() => mode);
+    await mountHermesChat(box);
+    await waitFor(() => expect(screen.getByLabelText(/^Hermes model:/)).toBeTruthy());
+    expect((await providerOptions()).some((l) => l.includes("Anthropic"))).toBe(true);
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    mode = "degraded";
+    await act(async () => {
+      notifyHermesModelState();
+      await new Promise((resolve) => setTimeout(resolve, 400));
+    });
+
+    // Still the box's real answer, not the manifest's two rows.
+    const labels = await providerOptions();
+    expect(labels.some((l) => l.includes("Anthropic"))).toBe(true);
+    expect(labels.some((l) => l.includes("OpenAI Codex"))).toBe(true);
+    expect(screen.getByLabelText(/^Chat provider:/).textContent).toContain("Codex");
+  }, 15000);
 });

--- a/src/tests/unit/hermes-model-options-stale-cache.test.ts
+++ b/src/tests/unit/hermes-model-options-stale-cache.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * TASK-678 — a DEGRADED catalogue was cached as if it were an answer.
+ *
+ * `getModelOptions` served anything in `cached` for a full `FRESH_MS` (60 s)
+ * without ever consulting `cached.stale`. On a cold process — every reboot —
+ * the first read lands inside the ~11-12 s window where `clawbox-setup` is
+ * answering and `clawbox-hermes-dashboard` is not yet up, so the payload is
+ * built from Hermes' on-disk manifest (`openrouter` + `nous`, and nothing about
+ * this device). That placeholder then WAS the catalogue for the next minute,
+ * for every consumer: the chat header, the Settings panel, the MCP tools.
+ *
+ * `isDowngrade` does not help here — it compares against `previous = cached`,
+ * and on a cold process there is nothing to compare against.
+ *
+ * A fallback is not an answer, so it does not earn an answer's freshness
+ * window: the next read goes back to the dashboard.
+ */
+
+const dashboardFetchMock = vi.fn();
+const runHermesCliMock = vi.fn();
+const readFileMock = vi.fn();
+
+vi.mock("@/lib/hermes-dashboard-auth", () => ({
+  dashboardFetch: dashboardFetchMock,
+  __esModule: true,
+}));
+
+vi.mock("@/lib/hermes-cli", () => ({
+  runHermesCli: runHermesCliMock,
+}));
+
+vi.mock("fs/promises", () => ({
+  default: { readFile: readFileMock },
+  readFile: readFileMock,
+}));
+
+/** Hermes' on-disk fallback manifest, in the shape the real one has. */
+const DISK_CATALOG = JSON.stringify({
+  providers: {
+    openrouter: { models: [{ id: "openrouter/auto", description: "" }] },
+    nous: { models: [{ id: "nous/hermes", description: "" }] },
+  },
+});
+
+/** The device this was reported on: configured on Codex. */
+const DEVICE: Record<string, string> = {
+  "model.provider": "openai-codex",
+  "model.default": "gpt-5.6-sol",
+  "agent.reasoning_effort": "medium",
+};
+
+/** How many times the live catalogue was asked for. */
+function optionsCalls(): number {
+  return dashboardFetchMock.mock.calls.filter(
+    (c) => String(c[0]).startsWith("/api/model/options"),
+  ).length;
+}
+
+function dashboardDown() {
+  dashboardFetchMock.mockRejectedValue(new Error("connect ECONNREFUSED"));
+}
+
+/** The settled box: the codex row with the seven models it really lists. */
+function dashboardUp() {
+  dashboardFetchMock.mockImplementation(async (path: string) => {
+    if (!path.startsWith("/api/model/options")) {
+      return { ok: true, status: 200, json: async () => ({}) };
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        providers: [{
+          slug: "openai-codex",
+          name: "OpenAI Codex",
+          authenticated: true,
+          source: "dashboard",
+          total_models: 7,
+          models: [
+            "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+            "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark",
+          ],
+        }],
+        provider: "openai-codex",
+        model: "gpt-5.6-sol",
+      }),
+    };
+  });
+}
+
+describe("hermes-model-options — a fallback must not be cached as an answer", () => {
+  let mod: typeof import("@/lib/hermes-model-options");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    dashboardFetchMock.mockReset();
+    runHermesCliMock.mockReset();
+    readFileMock.mockReset();
+    readFileMock.mockResolvedValue(DISK_CATALOG);
+    runHermesCliMock.mockImplementation(async (args: string[]) => ({
+      stdout: DEVICE[args[2]] ?? "",
+      stderr: "",
+      code: 0,
+    }));
+    mod = await import("@/lib/hermes-model-options");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("asks the dashboard again on the next read", async () => {
+    dashboardDown();
+    const first = await mod.getModelOptions();
+    expect(first.source).toBe("catalog-file");
+    expect(first.stale).toBe(true);
+    expect(optionsCalls()).toBe(1);
+
+    // The dashboard finished booting a second later. Nothing invalidates the
+    // cache — nothing changed on the device — so recovery depends entirely on
+    // this read not being answered from the placeholder.
+    dashboardUp();
+    const second = await mod.getModelOptions();
+
+    expect(optionsCalls()).toBeGreaterThan(1);
+    expect(second.source).toBe("dashboard");
+    expect(second.providers.find((p) => p.id === "openai-codex")?.models).toHaveLength(7);
+  });
+
+  it("still spends nothing re-asking once a live answer is in hand", async () => {
+    dashboardUp();
+    const first = await mod.getModelOptions();
+    expect(first.source).toBe("dashboard");
+    const asked = optionsCalls();
+
+    // A real answer keeps its full freshness window: this is the cache doing
+    // its job, and the fix must not turn every read into a round-trip.
+    await mod.getModelOptions();
+    await mod.getModelOptions();
+
+    expect(optionsCalls()).toBe(asked);
+  });
+});

--- a/src/tests/unit/hermes-model-options-stale-cache.test.ts
+++ b/src/tests/unit/hermes-model-options-stale-cache.test.ts
@@ -15,7 +15,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * and on a cold process there is nothing to compare against.
  *
  * A fallback is not an answer, so it does not earn an answer's freshness
- * window: the next read goes back to the dashboard.
+ * window: the next read goes back to the dashboard — behind the request, and at
+ * most once a second, because six other callers read this catalogue and none of
+ * them may be made to block on a dashboard that is down.
  */
 
 const dashboardFetchMock = vi.fn();
@@ -120,13 +122,41 @@ describe("hermes-model-options — a fallback must not be cached as an answer", 
 
     // The dashboard finished booting a second later. Nothing invalidates the
     // cache — nothing changed on the device — so recovery depends entirely on
-    // this read not being answered from the placeholder.
+    // this read going back for the answer instead of being satisfied by the
+    // placeholder for FRESH_MS.
     dashboardUp();
+    // Past the one-second floor that keeps a degraded box from re-asking on
+    // every single request (pinned by the test below). Real time rather than a
+    // fake clock: the module's own single-flight and the background refresh are
+    // promises, and freezing time around them tests the mock, not the module.
+    await new Promise((resolve) => setTimeout(resolve, 1_100));
     const second = await mod.getModelOptions();
 
     expect(optionsCalls()).toBeGreaterThan(1);
-    expect(second.source).toBe("dashboard");
-    expect(second.providers.find((p) => p.id === "openai-codex")?.models).toHaveLength(7);
+    // The caller is NOT blocked on that attempt — it is refreshed behind the
+    // request, because a degraded box has six other callers (the per-turn chat
+    // path, the OAuth poll, the session-less GET) that must not pay for it.
+    expect(second.source).toBe("catalog-file");
+
+    // ...and the answer the refresh installed is what the next read serves.
+    await vi.waitFor(() => expect(mod.cachedModelOptions()?.source).toBe("dashboard"));
+    const third = await mod.getModelOptions();
+    expect(third.source).toBe("dashboard");
+    expect(third.providers.find((p) => p.id === "openai-codex")?.models).toHaveLength(7);
+  });
+
+  it("does not re-ask on every read while the dashboard is down", async () => {
+    // The floor under the rule above. Without it a box whose dashboard is not
+    // answering turns every request — including the deliberately session-less
+    // GET on the models route — into a dashboard attempt.
+    dashboardDown();
+    await mod.getModelOptions();
+    expect(optionsCalls()).toBe(1);
+
+    await mod.getModelOptions();
+    await mod.getModelOptions();
+
+    expect(optionsCalls()).toBe(1);
   });
 
   it("still spends nothing re-asking once a live answer is in hand", async () => {


### PR DESCRIPTION
Fixes **TASK-677** (client half) and **TASK-678** (server half), under TASK-604.

## Customer-visible symptom

On a Hermes-edition box the chat header's **MODEL dropdown is gone**. The header
shows the provider pill (`Codex`, offering *OpenAI Codex / OpenRouter / Nous
Portal*) and the reasoning pill (`Medium`), and no model picker at all — so the
owner cannot change model without reloading the page. The Settings providers
list said "Couldn't load provider status" at the same moment.

Not Codex-specific, and not a regression from #587/#590/#581/#580 — none of
those touched the Hermes path. The `> 1` gate that hides the pill is from
2026-08-11.

## Cause

`ChatPopup.tsx` draws the model pill only when the scoped catalogue offers more
than one id, so **"we could not enumerate this provider" and "this provider
serves one model" render identically** — as nothing at all.

Every reboot produces the first of those. Measured on the box:

```
08:05:21 clawbox-setup Ready in 0ms      08:05:32 HERMES_DASHBOARD_READY   (11 s)
08:09:56 clawbox-setup Ready in 0ms      08:10:08 HERMES_DASHBOARD_READY   (12 s)
```

A `/setup-api/hermes/models` served in that window cannot reach the Hermes
dashboard, so `getModelOptions` falls back to Hermes' on-disk manifest
(`~/.hermes/cache/model_catalog.json`) — a curated file from the docs site that
carries only `openrouter` and `nous` and knows nothing about this device. The
payload declares itself: `stale: true`, `source: "catalog-file"`.

**No Hermes client read either field.** So:

* the header seeded from the manifest's two rows (both `authenticated: null`,
  which its `!== false` filter keeps) plus the device's own provider unshifted
  in — exactly the `OpenAI Codex / OpenRouter / Nous Portal` list reported;
* the scoped read for `openai-codex` found no row and answered HTTP 200
  `{ models: [], stale: true, source: "catalog-file" }`, hiding the pill;
* `getModelOptions` cached that placeholder as **fresh for a full 60 s**
  (`FRESH_MS`) without consulting `cached.stale` — for the chat header, the
  Settings panel and the MCP tools alike. `isDowngrade` cannot help: it compares
  against the previous *cached* payload, and a cold process has none;
* and nothing ever asked again. No retry, no backoff, no marker. The header
  stayed wrong until the page was reloaded.

*False success* (a 200 with a known-degraded body read as an outcome) plus
*probe-once* on the client.

On the settled box `GET /setup-api/hermes/models?provider=openai-codex` returns
7 models (`gpt-5.6-sol` … `gpt-5.3-codex-spark`), which is why this looked
intermittent.

## Harness first

Hermes' own `/api/model/options` remains the only source of models. **No curated
list was added and no model id is invented** — `DEFAULT_PROVIDER_MODELS` /
`CODEX_MODELS` are the OpenClaw namespace and `useHermesModelOptions` documents
why it must not borrow them.

Two mechanisms that already exist here are adopted rather than rebuilt:

* **`stale === false` is already the box's readiness signal on this very
  route.** `SetupWizard.pollHermesReady` (`SetupWizard.tsx:507-527`) polls it to
  decide the Hermes dashboard has come up. The chat header never adopted it.
* **The retry shape is #587's own.** `useProviderCatalog` retries with
  exponential backoff while the OpenClaw catalogue says `warming`
  (`useProviderCatalog.ts:105-126`). This points the same loop at the facts the
  Hermes payload already publishes. No new poller.

*Named as a finding, not built here:* the box's supervisor already logs
`HERMES_DASHBOARD_READY`, so a server-side readiness wait could remove the need
for client loops entirely. That is a larger change than this defect warrants and
would not help the non-boot degradations (a rotated dashboard credential, a
wedged worker), which the same `stale` flag covers.

## The change

**Server — `src/lib/hermes-model-options.ts`**
A fallback no longer earns an answer's freshness window: a `stale` cached
payload is served immediately **and refreshed behind the request**, at most once
a second. Deliberately *not* awaited — awaiting was the first attempt and is
wrong, because it deletes the cache for as long as the box is degraded and every
caller pays: the per-turn chat path, the OAuth device-code poll (twice a tick),
`provider-mcp-refresh` twice per credential write under its 3 s deadline, and
the intentionally session-less GET on this route, which would then drive a
dashboard round-trip per anonymous request. `DASHBOARD_TIMEOUT_MS` does not
bound that either — the login `dashboardFetch` performs before its first attempt
carries no signal. The client re-asks on its own now, so nothing has to block
for recovery to happen. The throttled `?refresh=1` branch falls through to the
same rule instead of returning the placeholder.

The flag read is `payload.stale`, never the `degraded` marker: a payload the
downgrade guard *kept* is a live catalogue whose refresh failed, and holding on
to that is the point of the guard. Its suite is unchanged and still green.

**Client — `src/hooks/useHermesModelOptions.ts`**
A `stale` reply — or a rejected request, or a non-OK status — is treated as a
placeholder, not an answer: it is not installed (so the pill holds its place and
the send path keeps saying "still loading this provider's models" via
`modelsReady`, rather than "this provider has none") and the scope is re-asked
with backoff, 1+2+4+8+8 s. Bounded, because a box whose dashboard is not coming
back must reach the honest empty state. The retry is gated on the *response's*
`stale`, not on the substituted `emptyScope` (which is `stale: true` by
construction), and it carries the user's pending Refresh intent rather than
consuming it on a request that never completed.

**Client — `src/components/ChatPopup.tsx`**
`seedHermesHeader` reads `stale` too, checks `mRes.ok` before `json()`, and
retries on a dropped connection as well as on a degraded body. **A degraded
answer never replaces a good one**: the header re-seeds on every
providers-changed signal, so a key saved during a dashboard blip used to
collapse a live four-provider list to the one configured provider and silently
move the active provider off the owner's pick. Only a header with nothing on
offer yet falls back to the device's own provider — the manifest's
`openrouter`/`nous` are dropped, because they arrive `authenticated: null` and
the settled box reports both `authenticated: false`, so offering them is
offering a provider that cannot answer a turn. Retry timers are cleared by
`clearSeedRetry()` on every new seed and in both effect cleanups; a retry is
scheduled outside any fetch, so aborting the signal does not cancel it.

**Client — `src/components/HermesProviderConfig.tsx`**
Save is no longer disabled by `loading` when a key is pending. Pasting an API
key is the gesture that *recovers* a degraded box, and `saveModelProvider` needs
no catalogue; the model `<select>` beside it still shows its spinner.

## RED → GREEN

RED on unmodified `origin/beta` (`00aea577`), verified in a scratch worktree:

```
 × asks the dashboard again on the next read 1376ms
 × goes back for the real catalogue and grows the model picker 9253ms
 × re-asks rather than treating the fallback as the answer 8662ms
 × does not offer the manifest's providers as if the box had them 1043ms
 × recovers from a dropped connection, not only from a tidy 200 8255ms
 × never lets a degraded seed replace a provider list it already has 1551ms
TestingLibraryElementError: Unable to find a label with the text of: /^Hermes model:/
AssertionError: expected 1 to be greater than 1
AssertionError: expected true to be false // Object.is equality
TestingLibraryElementError: Unable to find a label with the text of: /^Hermes model:/
AssertionError: expected false to be true // Object.is equality
AssertionError: expected 1 to be greater than 1
 Test Files  2 failed (2)
      Tests  6 failed | 2 passed (8)
```

The two that pass on beta are the deliberate must-not-regress guards: a live
answer keeps its full `FRESH_MS` window, and a degraded box does not re-ask on
every single read.

GREEN, plus the neighbouring Hermes suites, and the whole suite as CI runs it —
see the run output below.

The component tests drive the real boot window: the route answers the
disk-catalogue shape (or drops the connection) first and the live shape
afterwards, with **no `providers-changed` signal and no remount** — recovery has
to come from the header itself.

## Sibling call sites

| site | verdict |
|---|---|
| `hermes/models` GET + POST | benefits — the scoped read stops answering `[]` from a manifest |
| `hermes/chat` route, `getModelOptions()` | never blocks; the SWR contract its comment describes still holds |
| `hermes/chat` route, `cachedModelOptions()` | unchanged and safe — its veto is gated on `shouldEnforcePairing`, which already declines a stale payload |
| `hermes/oauth/poll`, `readUsableProviderIds()` | never blocks; the comment claiming "not a dashboard round-trip per tick" is corrected, because a tick now starts a throttled background one |
| `provider-mcp-refresh.ts` | never blocks; its 3 s deadline and 8 s-ceiling comment stay accurate |
| `provider-status.ts` | benefits — this is the "Couldn't load provider status" surface; still a memoised read |
| `hermes-cloud-provider.ts` | uses `{ refresh: true }` on a path that is not throttled here |
| `HermesProviderConfig.tsx` (`useHermesModelOptions`) | the retry window is bounded, its existing `scope?.stale` note still lands, and Save is no longer gated on it |
| OpenClaw branch of the same header | untouched — #580's `unselectableActive` / `chat.noChatModel` is in the `chatModelState` branch |
| dual SKU | the Hermes branch is gated on `harnessId === 'hermes'`; nothing edition-specific added |

## Review

One Opus pass over the first draft returned 1 HIGH, 4 MEDIUM, 4 LOW. All nine
are addressed in this head: the HIGH was that the server half had swung from
"cache a fallback for 60 s" to "no cache at all" (now serve-and-refresh-behind
with a one-second floor); the MEDIUMs were a stale sibling comment, Save dead
for 23 s on the one recovery path, a degraded seed still overwriting a good
provider list, and a retry that fired only on a tidy 200 and so missed the
failure mode actually observed on the box. A LOW correctly called out a fourth
test as a constant compared against itself; it is gone, replaced by the two
behavioural tests above.

## Not fixed here, named

`invalidateModelOptions()` sets `cached = null`, which disarms the `isDowngrade`
guard for the very next load (`load()` captures `previous = cached`), so an
OAuth approval landing during a dashboard blip can still install the 2-provider
manifest over a healthy 48-provider one. **This is TASK-678's second half and it
stays open.** Keeping the payload for the comparison is not a one-liner: after
an invalidation the device's selection has just changed, so the guard's
`{ ...previous, degraded }` would serve the *old* `current` pairing — actively
wrong at exactly the moment the guard would fire. It needs a marker that
separates "do not serve this" from "still valid as a downgrade baseline", which
is its own change with its own tests. The re-ask rule above shortens the
poisoning to a single read in the meantime.

## Device

Read-only owner-session probes only — no mutex taken, no setting changed, no
credential added, nothing deployed. The box's live payloads were captured to
confirm the settled state (`openai-codex` → 7 models, `source: dashboard`) and
the manifest's contents.

**The device leg for the fixed behaviour is unproven on hardware**: reproducing
it means restarting `clawbox-hermes-dashboard` with the chat open, which is a
box mutation this run was scoped out of. It is reproduced in tests instead.
Worth watching a Hermes box through one reboot with the chat open after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Hermes model catalogue loading when responses are delayed, incomplete, unavailable, or temporarily degraded.
  - Added automatic, throttled retries to recover model and provider options without disrupting already loaded selections.
  - Prevented stale or outdated catalogue responses from replacing current provider lists.
  - Provider API keys can now be saved while the model catalogue is retrying, with existing validation preserved.
- **Reliability**
  - Background catalogue refreshes now avoid repeated requests when the dashboard remains unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->