### PR TITLE
fix(hermes): declare the ClawBox AI and local model catalogues where Hermes reads them

### DIFF
--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { requireSession } from "@/lib/route-auth";
+import { reconcileClawaiModelsWithHermes } from "@/lib/hermes-clawai";
 import { reconcileLocalAiWithHermes } from "@/lib/hermes-local-ai";
 import {
   getModelOptions,
@@ -80,6 +81,11 @@ export async function GET(request: Request) {
   // A device whose local model was enabled before Hermes knew how to host it
   // repairs itself here — once per process, and a no-op on every other device.
   await reconcileLocalAiWithHermes();
+  // And the same for the ClawBox AI catalogue, which a box linked before Hermes
+  // was told what the proxy serves does not have. Both repairs write the
+  // `providers:` block Hermes' OWN pickers read, so a box fixes its Telegram
+  // `/model` keyboard by being asked this question once.
+  await reconcileClawaiModelsWithHermes();
 
   try {
     if (provider) {

--- a/src/app/setup-api/hermes/models/route.ts
+++ b/src/app/setup-api/hermes/models/route.ts
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { NextResponse } from "next/server";
 import { runHermesCli } from "@/lib/hermes-cli";
 import { safeHermesFailureMessage } from "@/lib/hermes-cli-message";
+import { getActiveHarness } from "@/lib/harness";
 import { requireSession } from "@/lib/route-auth";
 import { reconcileClawaiModelsWithHermes } from "@/lib/hermes-clawai";
 import { reconcileLocalAiWithHermes } from "@/lib/hermes-local-ai";
@@ -79,13 +80,23 @@ export async function GET(request: Request) {
   }
 
   // A device whose local model was enabled before Hermes knew how to host it
-  // repairs itself here — once per process, and a no-op on every other device.
-  await reconcileLocalAiWithHermes();
-  // And the same for the ClawBox AI catalogue, which a box linked before Hermes
-  // was told what the proxy serves does not have. Both repairs write the
-  // `providers:` block Hermes' OWN pickers read, so a box fixes its Telegram
-  // `/model` keyboard by being asked this question once.
-  await reconcileClawaiModelsWithHermes();
+  // repairs itself here — once per process, and a no-op on every other device —
+  // and the same for the ClawBox AI catalogue, which a box linked before Hermes
+  // was told what the proxy serves does not have. Both write the `providers:`
+  // block Hermes' OWN pickers read, so a box fixes its Telegram `/model`
+  // keyboard by being asked this question once.
+  //
+  // GATED ON THE HARNESS, once, in front of both. Their first act is a `hermes`
+  // spawn, and on an OpenClaw box there is no binary to spawn and no
+  // `providers:` block to repair: `runHermesCli` would reject, the catch would
+  // log a failure, and the repair would unlatch and do it again on the next
+  // request. Today this route is unreachable there (`ChatPopup` passes no
+  // Hermes provider), which is exactly why the guard belongs at the call site
+  // rather than in two modules that each assume their own edition.
+  if ((await getActiveHarness()) === "hermes") {
+    await reconcileLocalAiWithHermes();
+    await reconcileClawaiModelsWithHermes();
+  }
 
   try {
     if (provider) {

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -35,6 +35,26 @@ export const CLAWBOX_AI_MODEL_BY_TIER: Record<ClawboxAiTier, string> = {
   pro: `${CLAWBOX_AI_PROVIDER}/${CLAWBOX_AI_PRO_MODEL_ID}`,
 };
 
+/**
+ * The BARE ids the ClawBox AI proxy serves as CHAT models, in the order a
+ * picker should show them. The device runs one of them (its tier's), and the
+ * subscription covers both, so both belong in every catalogue.
+ *
+ * Deliberately excludes the image and vision ids: those exist so a picture can
+ * be drawn or looked at, and offering them as something to talk to is a turn
+ * the proxy answers with "Model not allowed".
+ *
+ * This is the list every surface must agree on, which is why it lives beside
+ * the ids rather than being re-typed per writer: `applyClawaiToHermes` declares
+ * it in Hermes' own `providers.clawai.models` (the block Hermes' `/model`
+ * picker and its dashboard both read), and hermes-model-options.ts uses it as
+ * the cold-start floor for the same provider.
+ */
+export const CLAWBOX_AI_CHAT_MODEL_IDS: readonly string[] = [
+  CLAWBOX_AI_FLASH_MODEL_ID,
+  CLAWBOX_AI_PRO_MODEL_ID,
+];
+
 // Device-tier badge label rendered in the chat header / Settings. Mirrors
 // the subscription plan names ("Pro plan" / "Max plan") so users don't see
 // a different word on the device than they paid for. Keep in sync with

--- a/src/lib/clawbox-ai-models.ts
+++ b/src/lib/clawbox-ai-models.ts
@@ -37,18 +37,35 @@ export const CLAWBOX_AI_MODEL_BY_TIER: Record<ClawboxAiTier, string> = {
 
 /**
  * The BARE ids the ClawBox AI proxy serves as CHAT models, in the order a
- * picker should show them. The device runs one of them (its tier's), and the
- * subscription covers both, so both belong in every catalogue.
+ * picker should show them.
+ *
+ * BOTH, ON EVERY BOX, AND THE PROXY STILL GATES BY PLAN. `deepseek-v4-pro` is
+ * Max-only (see `clawbox-ai-tiers.ts`, and the "Max plan only" note the wizard
+ * picker carries), so a Free or Pro box that picks it gets a model-gate
+ * rejection. Offering both anyway is the existing product behaviour, not a
+ * choice invented here: `normalizeRow` seeds both regardless of tier and the
+ * OpenClaw provider definition declares both for every tier. It is also the
+ * only behaviour that stays TRUE — the portal can move a device's tier without
+ * re-running any of these writers, so a list derived from the tier at link time
+ * would lock an upgraded box out of the model it now pays for.
+ *
+ * What is genuinely worse on the Hermes side is that its own picker shows a
+ * bare id with no plan label, where the ClawBox pickers say "Max plan only".
+ * That is a gap to close in Hermes' row metadata, not a reason to hide a model
+ * the account may already be entitled to.
  *
  * Deliberately excludes the image and vision ids: those exist so a picture can
  * be drawn or looked at, and offering them as something to talk to is a turn
  * the proxy answers with "Model not allowed".
  *
- * This is the list every surface must agree on, which is why it lives beside
- * the ids rather than being re-typed per writer: `applyClawaiToHermes` declares
- * it in Hermes' own `providers.clawai.models` (the block Hermes' `/model`
- * picker and its dashboard both read), and hermes-model-options.ts uses it as
- * the cold-start floor for the same provider.
+ * Lives beside the ids rather than being re-typed by each writer:
+ * `applyClawaiToHermes` declares it in Hermes' own `providers.clawai.models`
+ * (the block Hermes' `/model` picker and its dashboard both read), and
+ * hermes-model-options.ts uses it as the cold-start floor for the same
+ * provider. `CLAWAI_MODELS` and `CLAWAI_STATIC_MODELS` still spell the ids out
+ * as literals beside their labels, so a staging box that sets
+ * `CLAWBOX_AI_FLASH_MODEL_ID` will see them disagree — pre-existing, and worth
+ * folding through here the next time that pair is touched.
  */
 export const CLAWBOX_AI_CHAT_MODEL_IDS: readonly string[] = [
   CLAWBOX_AI_FLASH_MODEL_ID,

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -283,6 +283,19 @@ export async function applyClawaiToHermes(
       );
     }
   }
+  // One of those steps was `providers.clawai.models`, and an exit 0 does not
+  // say it landed as a LIST — the same silent stored-as-text this file's repair
+  // exists for, reached through the path EVERY fresh box takes.
+  //
+  // Not verified here, and never thrown over: a box whose catalogue went in as
+  // text still chats, still sees, still draws, so failing the link over it
+  // would be a false failure on a working device. The repair does that job, and
+  // this hands it back — with no backoff, because nothing failed here — so the
+  // very next models read re-examines the key. That hand-back is load-bearing
+  // on its own: an unlinked box has usually already run the repair and latched
+  // its silent "no providers.clawai", so without it the value the link just
+  // wrote is not looked at again until the web server restarts.
+  handClawaiRepairBack();
 
   // ── Making a picture ───────────────────────────────────────────────────────
   //
@@ -450,14 +463,28 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     // `HERMES_PIN_COMMIT` installs — the coercion chain there yields a real
     // list — which is exactly why it is worth a guard rather than a comment.
     const storedAsText = /storing as string/i.test(written.stderr ?? "");
-    if (written.code !== 0 || storedAsText) {
+    // AND NEITHER IS A CLEAN STDERR. The guard above can only fire on a CLI
+    // whose coercion block exists to print that warning; on one old enough to
+    // lack it — which is the build this repair is REACHED on — the same literal
+    // is stored as text with an empty stderr and exit 0. So the write is judged
+    // by reading it back through the CLI's own machine-readable mode, the same
+    // lever the verdict read uses, and a value that does not come back as our
+    // list is a write that did not land. Without this the repair rewrites the
+    // customer's config.yaml once per boot, claims success every time and never
+    // converges.
+    const landed = written.code === 0 && !storedAsText && (await clawaiCatalogueLanded());
+    if (!landed) {
       // A repair that could not be made is reported, never claimed: the picker
       // keeps showing what the box actually has, and a later request tries
       // again. No credential is in this argv — the value is a constant model
       // list — so the stream can be logged whole.
       console.warn(
         "[hermes/clawai] could not declare the ClawBox AI catalogue",
-        storedAsText ? "(the CLI stored it as text, not a list)" : `exit ${written.code}`,
+        written.code !== 0
+          ? `exit ${written.code}`
+          : storedAsText
+            ? "(the CLI stored it as text, not a list)"
+            : "(it did not read back as the list we wrote)",
         written.stderr?.trim() || written.stdout?.trim() || "",
       );
       return unlatch();
@@ -478,11 +505,57 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
   }
 }
 
+/**
+ * Did the catalogue we just wrote actually land as a LIST?
+ *
+ * `hermes config set` has no typed mode — `set_config_value(key, value: str)`
+ * (hermes_cli/config.py:5383) is the only entry point, and a JSON literal
+ * through its `_looks_structured_value` coercion is the harness's own way of
+ * storing a list. What the harness DOES offer for the other half is
+ * `hermes config get <key> --json` (config.py:5769), which prints
+ * `json.dumps(value)` — so the write is verified with the CLI's own reader
+ * rather than with anything that reaches into its store.
+ *
+ * FALSE COVERS BOTH "it came back wrong" AND "it could not be read", because
+ * the caller does the same thing with either: report, and let a later request
+ * try again after `REPAIR_RETRY_MS`. A write we cannot verify is not a write we
+ * may claim — the whole point of the guard.
+ */
+async function clawaiCatalogueLanded(): Promise<boolean> {
+  const read = await runHermesCli(
+    ["config", "get", `providers.${CLAWAI_PROVIDER}.models`, "--json"],
+    { timeoutMs: 15_000 },
+  );
+  if (!hermesCliAnswered(read) || read.code !== 0) return false;
+  let value: unknown;
+  try {
+    value = JSON.parse(read.stdout);
+  } catch {
+    return false;
+  }
+  return (
+    Array.isArray(value)
+    && value.length === CLAWBOX_AI_CHAT_MODEL_IDS.length
+    && value.every((id, i) => id === CLAWBOX_AI_CHAT_MODEL_IDS[i])
+  );
+}
+
 /** Let a later request try the repair again, no sooner than `REPAIR_RETRY_MS`.
  *  @see reconcileClawaiModelsWithHermes */
 function unlatch(): void {
   clawaiModelsReconciled = false;
   clawaiRetryAfter = Date.now() + REPAIR_RETRY_MS;
+}
+
+/** Something OTHER than the repair may have moved `providers.clawai.models`:
+ *  let the very next read look at it, with no backoff. Nothing failed, so there
+ *  is nothing to back off from — and this runs on an explicit customer action
+ *  (a link) rather than on every request, so it cannot become a spawn per
+ *  request the way an unbounded retry could. Same lever, and the same
+ *  reasoning, as `handRepairBack` in hermes-local-ai.ts. */
+function handClawaiRepairBack(): void {
+  clawaiModelsReconciled = false;
+  clawaiRetryAfter = 0;
 }
 
 /**
@@ -511,7 +584,10 @@ function unlatch(): void {
  *   - `models_discovered: true` marks a catalogue Hermes persisted for itself,
  *     which `_models_config_is_allowlist` refuses WHATEVER the shape (:136). Our
  *     list would be refused with it, so writing there would latch "repaired"
- *     over a keyboard still saying "clawai (0)" — a false success.
+ *     over a keyboard still saying "clawai (0)" — a false success. That refusal
+ *     only bites where a probe can replace what it refused, so the flag is read
+ *     TOGETHER with `discover_models`: with discovery off nothing replaces
+ *     anything and the box is repairable after all.
  *
  * One read answers all of that, and carries the `base_url` the orphan guard
  * needs, so it also replaces the second CLI spawn this repair used to make.
@@ -576,11 +652,20 @@ async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
     // `api_key`.
     return { action: "leave", reason: `providers.${CLAWAI_PROVIDER} carries no endpoint` };
   }
-  // FIRST, because it beats every other reading of `models:`. With
-  // `models_discovered: true` beside it our list is refused whatever its shape
-  // (:136), so any verdict below that wrote would latch "repaired" over a
-  // keyboard still saying "clawai (0)".
-  if (hermesOwnsCatalogue(row)) {
+  // FIRST, because it beats every other reading of `models:` — WHEREVER A PROBE
+  // CAN ACT ON IT. `models_discovered: true` makes `_models_config_is_allowlist`
+  // return False whatever the shape (:136), so with discovery on the empty probe
+  // replaces our list and a write here would latch "repaired" over a keyboard
+  // still saying "clawai (0)".
+  //
+  // With `discover_models: false` beside it that reading means nothing:
+  // `_discovery_allowed` gates the probe (:3788) and `grp["models"] =
+  // live_models` never runs (:3823), so nothing replaces anything and the row is
+  // exactly what `_declared_model_ids` finds. An entry carrying both flags and
+  // no readable `models:` is EMPTY — the same "clawai (0)" — and the ids we
+  // declare there are permanent, because no probe can come back to undo them.
+  // Declining it would strand a box one write fixes for good.
+  if (hermesOwnsCatalogue(row) && hermesDiscoversModels(row)) {
     return { action: "leave", reason: "Hermes persisted this catalogue itself (models_discovered)" };
   }
   // A LIST STORED AS TEXT IS NOT A CATALOGUE — and it is the one broken shape
@@ -711,8 +796,7 @@ function isHermesAllowlist(value: unknown): boolean {
 
 /** Test seam. */
 export function _resetClawaiModelsReconcileForTests(): void {
-  clawaiModelsReconciled = false;
-  clawaiRetryAfter = 0;
+  handClawaiRepairBack();
 }
 
 /**

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -441,14 +441,23 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
       ["config", "set", `providers.${CLAWAI_PROVIDER}.models`, JSON.stringify(CLAWBOX_AI_CHAT_MODEL_IDS)],
       { timeoutMs: 15_000 },
     );
-    if (written.code !== 0) {
+    // AN EXIT CODE IS NOT AN OUTCOME. `hermes config set k '["a","b"]'` exits 0
+    // even when its structured parse did not yield a list: it prints
+    // "…storing as string." to stderr and saves the literal text
+    // (hermes_cli/config.py:5518-5530). Hermes then reads that string as a
+    // ONE-ID allowlist, so the keyboard would offer a single bogus model and
+    // this repair would have latched "done" over it. Not reachable on the build
+    // `HERMES_PIN_COMMIT` installs — the coercion chain there yields a real
+    // list — which is exactly why it is worth a guard rather than a comment.
+    const storedAsText = /storing as string/i.test(written.stderr ?? "");
+    if (written.code !== 0 || storedAsText) {
       // A repair that could not be made is reported, never claimed: the picker
-      // keeps showing what the box actually has, and the next request tries
+      // keeps showing what the box actually has, and a later request tries
       // again. No credential is in this argv — the value is a constant model
       // list — so the stream can be logged whole.
       console.warn(
         "[hermes/clawai] could not declare the ClawBox AI catalogue",
-        written.code,
+        storedAsText ? "(the CLI stored it as text, not a list)" : `exit ${written.code}`,
         written.stderr?.trim() || written.stdout?.trim() || "",
       );
       return unlatch();
@@ -557,9 +566,24 @@ async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
   const row = entry as Record<string, unknown>;
 
   if (!(typeof row.base_url === "string" && row.base_url.trim())) {
-    return { action: "leave", reason: "" };
+    // `models:` beside no endpoint is a picker row offering models with nowhere
+    // to send them — the orphan the local provider's removal exists to avoid —
+    // so this is still "leave". But a block that exists with no `base_url` is
+    // an INVALID state, not an ordinary one, and the two verdicts that stay
+    // silent are silent because every box on the fleet is in them. The line
+    // names the provider and nothing else: the block it came from carries
+    // `api_key`.
+    return { action: "leave", reason: `providers.${CLAWAI_PROVIDER} carries no endpoint` };
   }
-  if (!hermesDiscoversModels(row)) {
+  // A PIN THAT PINS NOTHING IS NOT A PIN. `discover_models: false` only protects
+  // something if there is something to protect: with discovery off Hermes runs
+  // no probe (`_discovery_allowed`, model_switch.py:3788) and shows exactly the
+  // ids `_declared_model_ids` finds, so the flag beside an absent or empty
+  // `models:` leaves the row EMPTY — the "clawai (0)" this repair exists to
+  // fix, reached down the one path that used to walk away calling it a pin.
+  // `_declared_model_ids` is the right question here rather than the allowlist
+  // one, because with discovery off even a mapping's keys are shown.
+  if (!hermesDiscoversModels(row) && hermesDeclaresAnyId(row.models)) {
     return { action: "leave", reason: "the catalogue is pinned with discover_models: false" };
   }
   if (hermesOwnsCatalogue(row)) {
@@ -579,8 +603,30 @@ async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
 function hermesDiscoversModels(row: Record<string, unknown>): boolean {
   const flag = row.discover_models;
   if (flag === undefined) return true;
-  if (typeof flag === "string") return !["false", "no", "0"].includes(flag.trim().toLowerCase());
+  // `discover.lower() not in {"false","no","0"}` — NO trim, deliberately. A
+  // quoted " false " is discovery ON to Hermes, so the empty probe wipes the
+  // block and the repair IS needed; trimming here would have ClawBox decline to
+  // touch a box Hermes is about to empty.
+  if (typeof flag === "string") return !["false", "no", "0"].includes(flag.toLowerCase());
   return Boolean(flag);
+}
+
+/**
+ * Does this `models:` yield any id at all? `_declared_model_ids`,
+ * model_switch.py:61 — a non-empty string, any list entry that resolves to an
+ * id, or a mapping's keys, skipping the two sentinel keys Hermes writes for
+ * itself.
+ *
+ * Deliberately WIDER than `isHermesAllowlist`: a mapping is not an allowlist,
+ * but its keys are still what a pinned (discovery-off) row displays, and the
+ * only question here is whether anything would be shown.
+ */
+function hermesDeclaresAnyId(value: unknown): boolean {
+  if (isHermesAllowlist(value)) return true;
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return Object.keys(value).some(
+    (key) => key !== "__explicit_model_allowlist__" && key !== "__discovered_model_catalog__",
+  );
 }
 
 /**

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -367,6 +367,23 @@ export async function applyClawaiToHermes(
 }
 
 let clawaiModelsReconciled = false;
+let clawaiRetryAfter = 0;
+
+/**
+ * How long a repair whose QUESTION failed waits before another request retries.
+ *
+ * Unlatching on a failure is right — an update must not be able to skip the
+ * repair for the life of the process — but on its own it removes the only
+ * bound on what that failure costs. `GET /setup-api/hermes/models` awaits both
+ * repairs BEFORE it serves anything, each CLI read carries a 15 s timeout, and
+ * that route is what the chat header, the Settings panel and the agent's own
+ * `ai_list_models` all read: a box whose `hermes` is wedged — a filelock held
+ * by an interactive CLI, a half-built venv — would pay it on every request
+ * instead of once per process. Same number and the same reasoning as
+ * `FAILED_READ_TTL_MS` in hermes-config-cache.ts, which exists so that a
+ * hanging `hermes` cannot become one Python start per request.
+ */
+const REPAIR_RETRY_MS = 60_000;
 
 /**
  * Declare the ClawBox AI catalogue on a box that was linked before this code
@@ -388,39 +405,33 @@ let clawaiModelsReconciled = false;
  * for the life of the process and the owner's `/model` keeps saying
  * "clawai (0)" on the release that was meant to fix it. Every exit that is a
  * failed QUESTION or a failed WRITE unlatches, so the next request retries;
- * only the two real answers ("already declared", "written") stay latched.
+ * only the real answers ("nothing to do", "written") stay latched — and a
+ * retry is bounded by `REPAIR_RETRY_MS`, because a repair that keeps failing
+ * must not become a Python start per request on the busiest route we serve.
+ *
+ * EVERY EXIT SAYS SOMETHING. A silent `return` on the one path the field will
+ * actually reach is how a box ends up wrong with nothing in its journal, so
+ * each verdict that is not "this box is already correct" carries a line.
  */
 export async function reconcileClawaiModelsWithHermes(): Promise<void> {
-  if (clawaiModelsReconciled) return;
+  if (clawaiModelsReconciled || Date.now() < clawaiRetryAfter) return;
   clawaiModelsReconciled = true;
   try {
-    // The catalogue first, because on a settled box it is the answer: one
-    // `hermes config get` (~0.6 s of process spawn) and we are done, rather than
-    // two on every cold process for a repair that will never be needed again.
-    const catalogue = await clawaiCatalogueState();
-    if (catalogue === "unknown") return unlatch();
-    if (catalogue === "allowlist") return;
-
-    // Only now ask whether there is a provider to describe. Not "is a token
-    // stored" — the question is whether HERMES has the block, which is what its
-    // pickers read. Without this a box that has never been linked would get a
-    // `providers.clawai.models` with no endpoint beside it, which Hermes renders
-    // as a picker row offering two models with nowhere to send them — the same
-    // orphan the local provider's removal exists to avoid.
-    const linked = await runHermesCli(
-      ["config", "get", `providers.${CLAWAI_PROVIDER}.base_url`],
-      { timeoutMs: 15_000 },
-    );
-    if (!hermesCliAnswered(linked)) return unlatch();
-    if (linked.code !== 0 || !linked.stdout.trim()) return;
-
-    if (catalogue === "ignored") {
-      // Logged where the write actually happens, not where the shape was read:
-      // the `linked` gate above still returns for a box with no provider block,
-      // and a line claiming an overwrite that never ran is the false-success
-      // shape this module keeps being audited for. This is the one state in
-      // which the file and the symptom disagree — a populated `models:` and
-      // "clawai (0)" on the owner's phone — so it is worth a line of its own.
+    const verdict = await clawaiCatalogueVerdict();
+    if (verdict.action === "retry") {
+      console.warn(`[hermes/clawai] catalogue repair deferred — ${verdict.reason}`);
+      return unlatch();
+    }
+    if (verdict.action === "leave") {
+      if (verdict.reason) console.log(`[hermes/clawai] catalogue left alone — ${verdict.reason}`);
+      return;
+    }
+    if (verdict.overwriting) {
+      // Logged where the write happens, not where the shape was read: a line
+      // claiming an overwrite that never ran is the false-success shape this
+      // module keeps being audited for. This is the one state in which the file
+      // and the symptom disagree — a populated `models:` and "clawai (0)" on the
+      // owner's phone — so it is worth a line of its own.
       console.warn(
         `[hermes/clawai] providers.${CLAWAI_PROVIDER}.models is not a shape Hermes reads`
         + " as an allowlist — declaring the ClawBox AI catalogue over it",
@@ -458,71 +469,145 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
   }
 }
 
-/** Let the next request try the repair again. @see reconcileClawaiModelsWithHermes */
+/** Let a later request try the repair again, no sooner than `REPAIR_RETRY_MS`.
+ *  @see reconcileClawaiModelsWithHermes */
 function unlatch(): void {
   clawaiModelsReconciled = false;
+  clawaiRetryAfter = Date.now() + REPAIR_RETRY_MS;
 }
 
 /**
- * How `providers.clawai.models` is currently spelled in config.yaml — judged by
- * HERMES' rule, not by the exit code.
+ * What to do about `providers.clawai.models`, decided from the WHOLE entry.
  *
- *   "absent"    — not there. Ours to write, and the case every field box is in.
- *   "allowlist" — a non-empty list or string. Hermes reads it as a pin, the
- *                 empty probe cannot replace it, and it may be the owner's own
- *                 narrowing: already right, and never ours to widen.
- *   "ignored"   — there, and NOT allowlist-shaped: a mapping (the per-model
- *                 metadata `_save_custom_provider` and the `hermes model`
- *                 wizard write), an empty list, a null. Hermes' own
- *                 `_models_config_is_allowlist` says False, so the empty probe
- *                 REPLACES it and the keyboard says "clawai (0)" — a key that
- *                 exists is not a key Hermes reads.
- *   "unknown"   — the question failed. Not an answer, and never treated as one.
+ *   "write"  — declare our catalogue. `overwriting` says whether something was
+ *              already there in a shape Hermes refuses to read, which is worth
+ *              a line in the journal.
+ *   "leave"  — this box is not ours to change. A `reason` is logged; the two
+ *              ordinary cases (already declared, never linked) carry none,
+ *              because every box on the fleet would print them once a boot.
+ *   "retry"  — the question failed. Never an answer, always logged, and the
+ *              caller unlatches so a later request asks again.
  *
- * SHAPE, NOT EXISTENCE, and that distinction is why this is four states rather
- * than the exit code. It mirrors `localCatalogueState` in hermes-local-ai.ts,
- * down to mapping a non-zero exit that is not "config key not set" — an EACCES
- * on config.yaml, Hermes' own filelock held by an interactive CLI, a parse
- * error — to "unknown" rather than to a verdict about this box.
+ * THE WHOLE ENTRY, NOT THE `models` LEAF, and that is the difference between a
+ * repair and vandalism. Hermes decides what `models:` MEANS from two of its
+ * siblings:
  *
- * `--json` IS LOAD-BEARING. Plain `hermes config get` renders a list or a
- * mapping through `yaml.safe_dump` (`_format_config_get_value`,
- * hermes_cli/config.py:1203), so the two shapes this function exists to tell
- * apart arrive as two blocks of text that only a YAML reader could separate.
- * `--json` is the CLI's own machine-readable mode for exactly this
- * (`hermes config get <key> [--json]`, config.py:5769) and prints
- * `json.dumps(value)`; verified against the Hermes build `HERMES_PIN_COMMIT`
- * installs, which is the one every box converges on.
+ *   - `discover_models: false` is its documented way to pin a catalogue of any
+ *     shape — "discover_models: false is the documented way to pin, and it is
+ *     honored above" (model_switch.py:3777), read on the installed build. With
+ *     discovery off no probe runs, so even a mapping is exactly what the
+ *     keyboard shows: that owner has NO symptom, and overwriting their pin with
+ *     our flat two-id list would destroy per-model metadata to fix nothing.
+ *   - `models_discovered: true` marks a catalogue Hermes persisted for itself,
+ *     which `_models_config_is_allowlist` refuses WHATEVER the shape (:136). Our
+ *     list would be refused with it, so writing there would latch "repaired"
+ *     over a keyboard still saying "clawai (0)" — a false success.
+ *
+ * One read answers all of that, and carries the `base_url` the orphan guard
+ * needs, so it also replaces the second CLI spawn this repair used to make.
+ *
+ * `--json` IS LOAD-BEARING. Plain `hermes config get` renders a block through
+ * `yaml.safe_dump` (`_format_config_get_value`, hermes_cli/config.py:1203) and a
+ * bare string through `str()`, so the shapes this function exists to tell apart
+ * arrive as text only a YAML reader could separate. `--json` is the CLI's own
+ * machine-readable mode for exactly this (`hermes config get <key> [--json]`,
+ * config.py:5769) and prints `json.dumps(value)`; verified against the build
+ * `HERMES_PIN_COMMIT` installs, which `step_hermes_install` brings every box to.
+ * A box moved off that pin by a hand-run `hermes update` could meet a CLI that
+ * rejects the flag: that answers "retry", which is logged and rate-limited by
+ * `REPAIR_RETRY_MS` rather than repeated per request.
+ *
+ * THE STDOUT OF THIS READ IS A CREDENTIAL. The entry carries `api_key`, so no
+ * branch below logs `stdout` — only exit codes and our own words.
  */
-type ClawaiCatalogueState = "absent" | "allowlist" | "ignored" | "unknown";
+type ClawaiVerdict =
+  | { action: "write"; overwriting: boolean }
+  | { action: "leave"; reason: string }
+  | { action: "retry"; reason: string };
 
-async function clawaiCatalogueState(): Promise<ClawaiCatalogueState> {
-  const declared = await runHermesCli(
-    ["config", "get", `providers.${CLAWAI_PROVIDER}.models`, "--json"],
+async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
+  const read = await runHermesCli(
+    ["config", "get", `providers.${CLAWAI_PROVIDER}`, "--json"],
     { timeoutMs: 15_000 },
   );
-  if (!hermesCliAnswered(declared)) return "unknown";
-  if (declared.code !== 0) {
-    const listing = `${declared.stdout ?? ""}\n${declared.stderr ?? ""}`;
-    return /config key not set/i.test(listing) ? "absent" : "unknown";
+  if (!hermesCliAnswered(read)) {
+    return { action: "retry", reason: `the CLI never answered (exit ${read.code})` };
   }
-  let value: unknown;
+  if (read.code !== 0) {
+    // No `providers.clawai` at all: a box that has never been linked. A real
+    // answer, and there is nothing to describe — writing `models` beside no
+    // endpoint would give Hermes a picker row offering two models with nowhere
+    // to send them, the same orphan the local provider's removal exists to
+    // avoid. Anything else is a config we could not read.
+    if (/config key not set/i.test(`${read.stdout ?? ""}\n${read.stderr ?? ""}`)) {
+      return { action: "leave", reason: "" };
+    }
+    return { action: "retry", reason: `the provider block could not be read (exit ${read.code})` };
+  }
+
+  let entry: unknown;
   try {
-    value = JSON.parse(declared.stdout);
+    entry = JSON.parse(read.stdout);
   } catch {
-    // Exit 0 and something we cannot read is not evidence about this box.
-    return "unknown";
+    return { action: "retry", reason: "the CLI printed a value this build could not parse" };
   }
-  return isHermesAllowlist(value) ? "allowlist" : "ignored";
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    return { action: "retry", reason: "providers.clawai is not a block" };
+  }
+  const row = entry as Record<string, unknown>;
+
+  if (!(typeof row.base_url === "string" && row.base_url.trim())) {
+    return { action: "leave", reason: "" };
+  }
+  if (!hermesDiscoversModels(row)) {
+    return { action: "leave", reason: "the catalogue is pinned with discover_models: false" };
+  }
+  if (hermesOwnsCatalogue(row)) {
+    return { action: "leave", reason: "Hermes persisted this catalogue itself (models_discovered)" };
+  }
+  if (row.models === undefined) return { action: "write", overwriting: false };
+  return isHermesAllowlist(row.models)
+    ? { action: "leave", reason: "" }
+    : { action: "write", overwriting: true };
+}
+
+/**
+ * Will Hermes probe `<base_url>/models` for this entry? `discover_models`,
+ * model_switch.py:3371 — absent means yes, and the string spellings "false",
+ * "no" and "0" mean no, exactly as the Python coerces them.
+ */
+function hermesDiscoversModels(row: Record<string, unknown>): boolean {
+  const flag = row.discover_models;
+  if (flag === undefined) return true;
+  if (typeof flag === "string") return !["false", "no", "0"].includes(flag.trim().toLowerCase());
+  return Boolean(flag);
+}
+
+/**
+ * `_entry_models_discovered` — model_switch.py:116. The current entry-level
+ * `models_discovered: true`, or the in-mapping sentinel older builds wrote and
+ * this one still accepts on read.
+ */
+function hermesOwnsCatalogue(row: Record<string, unknown>): boolean {
+  if (row.models_discovered === true) return true;
+  const models = row.models;
+  return Boolean(
+    models
+    && typeof models === "object"
+    && !Array.isArray(models)
+    && (models as Record<string, unknown>).__discovered_model_catalog__ === true,
+  );
 }
 
 /**
  * Would Hermes read this value as an allowlist? `_models_config_is_allowlist`
- * (hermes_cli/model_switch.py:136): a non-empty string, or a list yielding at
- * least one id through `_declared_model_ids` (:61). Never a mapping — that is
- * metadata Hermes wrote for itself, not a pin.
+ * (model_switch.py:136): a non-empty string, or a list yielding at least one id
+ * through `_declared_model_ids` (:61). Never a mapping — that is metadata
+ * Hermes wrote for itself, not a pin. The `discovered` argument the Python
+ * takes is the caller's `hermesOwnsCatalogue` gate above, which is a different
+ * verdict here (leave alone) rather than a different shape.
  *
- * Transcribed here rather than imported from `src/tests/helpers/
+ * Transcribed rather than imported from `src/tests/helpers/
  * hermes-picker-catalogue.ts` ON PURPOSE: that mirror is what judges this
  * module's writes, and a guard sharing its code could only ever agree with it.
  */
@@ -532,14 +617,15 @@ function isHermesAllowlist(value: unknown): boolean {
   return value.some((entry) => {
     if (typeof entry === "string") return Boolean(entry.trim());
     if (!entry || typeof entry !== "object") return false;
-    const row = entry as { id?: unknown; name?: unknown };
-    return [row.id, row.name].some((field) => typeof field === "string" && field.trim());
+    const nested = entry as { id?: unknown; name?: unknown };
+    return [nested.id, nested.name].some((field) => typeof field === "string" && field.trim());
   });
 }
 
 /** Test seam. */
 export function _resetClawaiModelsReconcileForTests(): void {
   clawaiModelsReconciled = false;
+  clawaiRetryAfter = 0;
 }
 
 /**

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -400,15 +400,6 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     const catalogue = await clawaiCatalogueState();
     if (catalogue === "unknown") return unlatch();
     if (catalogue === "allowlist") return;
-    if (catalogue === "ignored") {
-      // The key is there and Hermes does not read it, so the box shows
-      // "clawai (0)" with a populated `models:` in its config — the one state
-      // where the file and the symptom disagree. Say so before overwriting it.
-      console.warn(
-        `[hermes/clawai] providers.${CLAWAI_PROVIDER}.models is not an allowlist Hermes reads`
-        + " — declaring the ClawBox AI catalogue over it",
-      );
-    }
 
     // Only now ask whether there is a provider to describe. Not "is a token
     // stored" — the question is whether HERMES has the block, which is what its
@@ -423,6 +414,18 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     if (!hermesCliAnswered(linked)) return unlatch();
     if (linked.code !== 0 || !linked.stdout.trim()) return;
 
+    if (catalogue === "ignored") {
+      // Logged where the write actually happens, not where the shape was read:
+      // the `linked` gate above still returns for a box with no provider block,
+      // and a line claiming an overwrite that never ran is the false-success
+      // shape this module keeps being audited for. This is the one state in
+      // which the file and the symptom disagree — a populated `models:` and
+      // "clawai (0)" on the owner's phone — so it is worth a line of its own.
+      console.warn(
+        `[hermes/clawai] providers.${CLAWAI_PROVIDER}.models is not a shape Hermes reads`
+        + " as an allowlist — declaring the ClawBox AI catalogue over it",
+      );
+    }
     const written = await runHermesCli(
       ["config", "set", `providers.${CLAWAI_PROVIDER}.models`, JSON.stringify(CLAWBOX_AI_CHAT_MODEL_IDS)],
       { timeoutMs: 15_000 },

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -463,31 +463,47 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     // `HERMES_PIN_COMMIT` installs — the coercion chain there yields a real
     // list — which is exactly why it is worth a guard rather than a comment.
     const storedAsText = /storing as string/i.test(written.stderr ?? "");
-    // AND NEITHER IS A CLEAN STDERR. The guard above can only fire on a CLI
-    // whose coercion block exists to print that warning; on one old enough to
-    // lack it — which is the build this repair is REACHED on — the same literal
-    // is stored as text with an empty stderr and exit 0. So the write is judged
-    // by reading it back through the CLI's own machine-readable mode, the same
-    // lever the verdict read uses, and a value that does not come back as our
-    // list is a write that did not land. Without this the repair rewrites the
-    // customer's config.yaml once per boot, claims success every time and never
-    // converges.
-    const landed = written.code === 0 && !storedAsText && (await clawaiCatalogueLanded());
-    if (!landed) {
+    // AND NEITHER IS A CLEAN STDERR. That warning only exists on a CLI whose
+    // coercion block prints it, so it cannot speak for one old enough to lack
+    // the block — where the same literal is stored as text with an EMPTY stderr
+    // and exit 0. The narrow band where that happens is a box moved off
+    // `HERMES_PIN_COMMIT` by a hand-run `hermes update` onto a CLI that still
+    // takes `--json` on `config get` (or the verdict read would have answered
+    // "retry") and no longer coerces on `config set`. The guard is worth having
+    // for a wider reason than that band, though: an exit code is not an outcome
+    // for ANY reason a write may fail to land, and this repair runs unattended
+    // on every field box.
+    const outcome = written.code !== 0
+      ? "unverified"
+      : storedAsText
+        ? "stored-as-text"
+        : await verifyClawaiCatalogue();
+    if (outcome !== "landed") {
       // A repair that could not be made is reported, never claimed: the picker
-      // keeps showing what the box actually has, and a later request tries
-      // again. No credential is in this argv — the value is a constant model
-      // list — so the stream can be logged whole.
+      // keeps showing what the box actually has. No credential is in this argv
+      // — the value is a constant model list — so the stream can be logged
+      // whole.
       console.warn(
         "[hermes/clawai] could not declare the ClawBox AI catalogue",
         written.code !== 0
           ? `exit ${written.code}`
-          : storedAsText
-            ? "(the CLI stored it as text, not a list)"
+          : outcome === "stored-as-text"
+            ? "(this hermes stores a list as text — the same write cannot land, so it is not retried before the next restart)"
             : "(it did not read back as the list we wrote)",
         written.stderr?.trim() || written.stdout?.trim() || "",
       );
-      return unlatch();
+      // A FAILURE WE HAVE PROVED IS FINAL DOES NOT GET A RETRY. `unlatch()` is
+      // for a repair that might work on a later request — a locked config, a
+      // wedged CLI. A CLI that parsed our constant literal and did not get a
+      // list will parse it the same way every 60 s for the life of this
+      // process, and each attempt re-serialises the customer's config.yaml
+      // through `save_config` for nothing. So that one answer stays latched:
+      // the journal says why, the next process start tries once more (the
+      // residue is still in the file, and the verdict read finds it), and a
+      // hand-run `hermes update` to a CLI that can store a list is picked up on
+      // the restart that follows it.
+      if (outcome === "unverified") unlatch();
+      return;
     }
     // The catalogue this device serves just changed — don't serve the old one.
     //
@@ -508,36 +524,56 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
 /**
  * Did the catalogue we just wrote actually land as a LIST?
  *
- * `hermes config set` has no typed mode — `set_config_value(key, value: str)`
- * (hermes_cli/config.py:5383) is the only entry point, and a JSON literal
- * through its `_looks_structured_value` coercion is the harness's own way of
- * storing a list. What the harness DOES offer for the other half is
- * `hermes config get <key> --json` (config.py:5769), which prints
- * `json.dumps(value)` — so the write is verified with the CLI's own reader
- * rather than with anything that reaches into its store.
+ *   "landed"         — the key reads back as exactly the ids we sent.
+ *   "stored-as-text" — the CLI handed our own literal back as a STRING. Proof
+ *                      that this build cannot store a list, and therefore that
+ *                      re-issuing the identical write is futile.
+ *   "unverified"     — the question failed, or answered something else. Says
+ *                      nothing about the write either way, so the caller
+ *                      retries on the ordinary cadence.
  *
- * FALSE COVERS BOTH "it came back wrong" AND "it could not be read", because
- * the caller does the same thing with either: report, and let a later request
- * try again after `REPAIR_RETRY_MS`. A write we cannot verify is not a write we
- * may claim — the whole point of the guard.
+ * `hermes config set` has no typed mode — `set_config_value(key, value: str,
+ * force=False)` (hermes_cli/config.py:5383) is the only entry point, and a JSON
+ * literal through its `_looks_structured_value` coercion is the harness's own
+ * way of storing a list. What the harness offers for the other half is
+ * `hermes config get <key> --json` (config.py:5769), which prints
+ * `json.dumps(value)`; that is the whole verification, so nothing here reaches
+ * into Hermes' store. (The OpenClaw half of this repo gets a typed
+ * `config set … --json` instead — see the PR body; the asymmetry is Hermes',
+ * not ours.)
+ *
+ * THE LEAF, NOT THE BLOCK, and not only for the smaller parse: the entry this
+ * repair read to decide carries `api_key`, and this key cannot. A verification
+ * that need never hold a credential should not be given one.
+ *
+ * IT NEVER THROWS. `runHermesCli` rejects on a spawn failure or a timeout, and
+ * an unanswerable verification is not the repair failing — letting it reach the
+ * caller's `catch` would log "catalogue reconcile failed" over a write that
+ * landed.
  */
-async function clawaiCatalogueLanded(): Promise<boolean> {
-  const read = await runHermesCli(
-    ["config", "get", `providers.${CLAWAI_PROVIDER}.models`, "--json"],
-    { timeoutMs: 15_000 },
-  );
-  if (!hermesCliAnswered(read) || read.code !== 0) return false;
+type ClawaiWriteOutcome = "landed" | "stored-as-text" | "unverified";
+
+async function verifyClawaiCatalogue(): Promise<ClawaiWriteOutcome> {
+  const declared = JSON.stringify(CLAWBOX_AI_CHAT_MODEL_IDS);
   let value: unknown;
   try {
+    const read = await runHermesCli(
+      ["config", "get", `providers.${CLAWAI_PROVIDER}.models`, "--json"],
+      { timeoutMs: 15_000 },
+    );
+    if (!hermesCliAnswered(read) || read.code !== 0) return "unverified";
     value = JSON.parse(read.stdout);
   } catch {
-    return false;
+    return "unverified";
   }
-  return (
+  if (
     Array.isArray(value)
     && value.length === CLAWBOX_AI_CHAT_MODEL_IDS.length
     && value.every((id, i) => id === CLAWBOX_AI_CHAT_MODEL_IDS[i])
-  );
+  ) {
+    return "landed";
+  }
+  return value === declared ? "stored-as-text" : "unverified";
 }
 
 /** Let a later request try the repair again, no sooner than `REPAIR_RETRY_MS`.
@@ -665,6 +701,13 @@ async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
   // no readable `models:` is EMPTY — the same "clawai (0)" — and the ids we
   // declare there are permanent, because no probe can come back to undo them.
   // Declining it would strand a box one write fixes for good.
+  //
+  // THE FLAG IS DECLARED BESIDE, NOT CLEARED, and that is a known limit rather
+  // than an oversight: an owner who later turns discovery back on puts that box
+  // into the state above, where the empty probe wins and this branch declines
+  // it. Clearing the flag would mean a second write to verify on a state only a
+  // contradictory pair of hand-edits produces — Hermes writes neither key into
+  // `providers:` (it persists its own catalogues under `custom_providers`).
   if (hermesOwnsCatalogue(row) && hermesDiscoversModels(row)) {
     return { action: "leave", reason: "Hermes persisted this catalogue itself (models_discovered)" };
   }

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -171,7 +171,7 @@ export async function applyClawaiToHermes(
     // Hermes 0.20.5), which reads a custom provider's model set out of THIS
     // block and then probes `<base_url>/models` for a live one.
     //
-    // The probe cannot help us. `probe_api_models` (hermes_cli/models.py:5668)
+    // The probe cannot help us. `probe_api_models` (hermes_cli/models.py:5592)
     // reads the OpenAI envelope, `data[].id`; the ClawBox AI proxy answers
     // `200 {"status":"ok","service":"ClawBox AI Proxy","models":[…]}`. So Hermes
     // parses an EMPTY list, and an empty probe with nothing declared beside it
@@ -379,13 +379,6 @@ let clawaiModelsReconciled = false;
  *
  * Deliberately narrower than a re-link: it writes ONE key and needs no token.
  *
- * THREE ANSWERS, NOT TWO. `hermes config get` exits non-zero both for a key
- * that is unset and for a config it could not read, and only the first is ours
- * to fill in — an unreadable config is not an empty one, so anything but the
- * "not set" wording leaves the file alone. And an existing value of ANY shape
- * is left alone too: it may be Hermes' own discovered catalogue, which is
- * richer than ours.
- *
  * THE LATCH IS FOR ANSWERS ONLY, and that is the whole difference between a
  * repair and a coin toss. `hermes` on the box is a shim over a venv Python, and
  * `step_hermes_install` moves the checkout aside and rebuilds it for about 90 s
@@ -404,16 +397,18 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     // The catalogue first, because on a settled box it is the answer: one
     // `hermes config get` (~0.6 s of process spawn) and we are done, rather than
     // two on every cold process for a repair that will never be needed again.
-    const declared = await runHermesCli(
-      ["config", "get", `providers.${CLAWAI_PROVIDER}.models`],
-      { timeoutMs: 15_000 },
-    );
-    if (!hermesCliAnswered(declared)) return unlatch();
-    if (declared.code === 0) return;
-    const listing = `${declared.stdout ?? ""}\n${declared.stderr ?? ""}`;
-    // A non-zero exit that is not "not set" is a config we could not read.
-    // Nothing to unlatch for: the CLI answered, and its answer was "no".
-    if (!/config key not set/i.test(listing)) return;
+    const catalogue = await clawaiCatalogueState();
+    if (catalogue === "unknown") return unlatch();
+    if (catalogue === "allowlist") return;
+    if (catalogue === "ignored") {
+      // The key is there and Hermes does not read it, so the box shows
+      // "clawai (0)" with a populated `models:` in its config — the one state
+      // where the file and the symptom disagree. Say so before overwriting it.
+      console.warn(
+        `[hermes/clawai] providers.${CLAWAI_PROVIDER}.models is not an allowlist Hermes reads`
+        + " — declaring the ClawBox AI catalogue over it",
+      );
+    }
 
     // Only now ask whether there is a provider to describe. Not "is a token
     // stored" — the question is whether HERMES has the block, which is what its
@@ -463,6 +458,80 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
 /** Let the next request try the repair again. @see reconcileClawaiModelsWithHermes */
 function unlatch(): void {
   clawaiModelsReconciled = false;
+}
+
+/**
+ * How `providers.clawai.models` is currently spelled in config.yaml — judged by
+ * HERMES' rule, not by the exit code.
+ *
+ *   "absent"    — not there. Ours to write, and the case every field box is in.
+ *   "allowlist" — a non-empty list or string. Hermes reads it as a pin, the
+ *                 empty probe cannot replace it, and it may be the owner's own
+ *                 narrowing: already right, and never ours to widen.
+ *   "ignored"   — there, and NOT allowlist-shaped: a mapping (the per-model
+ *                 metadata `_save_custom_provider` and the `hermes model`
+ *                 wizard write), an empty list, a null. Hermes' own
+ *                 `_models_config_is_allowlist` says False, so the empty probe
+ *                 REPLACES it and the keyboard says "clawai (0)" — a key that
+ *                 exists is not a key Hermes reads.
+ *   "unknown"   — the question failed. Not an answer, and never treated as one.
+ *
+ * SHAPE, NOT EXISTENCE, and that distinction is why this is four states rather
+ * than the exit code. It mirrors `localCatalogueState` in hermes-local-ai.ts,
+ * down to mapping a non-zero exit that is not "config key not set" — an EACCES
+ * on config.yaml, Hermes' own filelock held by an interactive CLI, a parse
+ * error — to "unknown" rather than to a verdict about this box.
+ *
+ * `--json` IS LOAD-BEARING. Plain `hermes config get` renders a list or a
+ * mapping through `yaml.safe_dump` (`_format_config_get_value`,
+ * hermes_cli/config.py:1203), so the two shapes this function exists to tell
+ * apart arrive as two blocks of text that only a YAML reader could separate.
+ * `--json` is the CLI's own machine-readable mode for exactly this
+ * (`hermes config get <key> [--json]`, config.py:5769) and prints
+ * `json.dumps(value)`; verified against the Hermes build `HERMES_PIN_COMMIT`
+ * installs, which is the one every box converges on.
+ */
+type ClawaiCatalogueState = "absent" | "allowlist" | "ignored" | "unknown";
+
+async function clawaiCatalogueState(): Promise<ClawaiCatalogueState> {
+  const declared = await runHermesCli(
+    ["config", "get", `providers.${CLAWAI_PROVIDER}.models`, "--json"],
+    { timeoutMs: 15_000 },
+  );
+  if (!hermesCliAnswered(declared)) return "unknown";
+  if (declared.code !== 0) {
+    const listing = `${declared.stdout ?? ""}\n${declared.stderr ?? ""}`;
+    return /config key not set/i.test(listing) ? "absent" : "unknown";
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(declared.stdout);
+  } catch {
+    // Exit 0 and something we cannot read is not evidence about this box.
+    return "unknown";
+  }
+  return isHermesAllowlist(value) ? "allowlist" : "ignored";
+}
+
+/**
+ * Would Hermes read this value as an allowlist? `_models_config_is_allowlist`
+ * (hermes_cli/model_switch.py:136): a non-empty string, or a list yielding at
+ * least one id through `_declared_model_ids` (:61). Never a mapping — that is
+ * metadata Hermes wrote for itself, not a pin.
+ *
+ * Transcribed here rather than imported from `src/tests/helpers/
+ * hermes-picker-catalogue.ts` ON PURPOSE: that mirror is what judges this
+ * module's writes, and a guard sharing its code could only ever agree with it.
+ */
+function isHermesAllowlist(value: unknown): boolean {
+  if (typeof value === "string") return Boolean(value.trim());
+  if (!Array.isArray(value)) return false;
+  return value.some((entry) => {
+    if (typeof entry === "string") return Boolean(entry.trim());
+    if (!entry || typeof entry !== "object") return false;
+    const row = entry as { id?: unknown; name?: unknown };
+    return [row.id, row.name].some((field) => typeof field === "string" && field.trim());
+  });
 }
 
 /** Test seam. */

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -1,7 +1,7 @@
 import { setMany } from "@/lib/config-store";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
-import { runHermesCli } from "@/lib/hermes-cli";
+import { runHermesCli, type HermesCliResult } from "@/lib/hermes-cli";
 import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import { redactKey, safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
@@ -381,6 +381,7 @@ export async function applyClawaiToHermes(
 
 let clawaiModelsReconciled = false;
 let clawaiRetryAfter = 0;
+let clawaiUnverifiedWrites = 0;
 
 /**
  * How long a repair whose QUESTION failed waits before another request retries.
@@ -395,8 +396,41 @@ let clawaiRetryAfter = 0;
  * instead of once per process. Same number and the same reasoning as
  * `FAILED_READ_TTL_MS` in hermes-config-cache.ts, which exists so that a
  * hanging `hermes` cannot become one Python start per request.
+ *
+ * IT BOUNDS THE RATE, NOT THE TOTAL — see `REPAIR_MAX_UNVERIFIED_WRITES`.
  */
 const REPAIR_RETRY_MS = 60_000;
+
+/**
+ * How many writes this process may issue that it cannot read back.
+ *
+ * A RATE IS NOT A BOUND WHEN THE FAULT IS PERMANENT. `hermes config set` exits
+ * 0 for reasons that have nothing to do with the key landing — a config.yaml
+ * the web-server user cannot write, a full partition, a `save_config` that
+ * loses a filelock race, a refusal that still exits 0 — and a key that never
+ * landed reads back exactly like one that was never written: measured on the
+ * box, `hermes config get providers.clawai.models --json` exits 1 with
+ * `Config key not set: providers.clawai.models`. So the deciding read answers
+ * "write" again, and with only `REPAIR_RETRY_MS` in the way that is one
+ * customer config.yaml rewrite plus three Python starts every 60 s for the life
+ * of the web server — on `GET /setup-api/hermes/models`, which AWAITS this
+ * repair before it serves the chat header, the Settings panel or the agent's
+ * own `ai_list_models`.
+ *
+ * Three, because a repair that has issued three writes nobody could read back
+ * has proved as much as one whose literal came back as text.
+ *
+ * IT COUNTS WRITES, NOT FAILED QUESTIONS, which is what keeps it away from the
+ * case the unlatch exists for: a `step_hermes_install` rebuild exits 127 before
+ * reaching argparse, the deciding read answers "retry", NO write is issued and
+ * no attempt is spent — so a 90 s rebuild still costs nothing but the rate
+ * bound, however many requests arrive during it.
+ *
+ * The counter clears on a write that LANDS, and otherwise only on a restart:
+ * the journal says once that this box stopped trying, and the next process
+ * start tries again because the deciding read still finds the key missing.
+ */
+const REPAIR_MAX_UNVERIFIED_WRITES = 3;
 
 /**
  * Declare the ClawBox AI catalogue on a box that was linked before this code
@@ -416,11 +450,23 @@ const REPAIR_RETRY_MS = 60_000;
  * update that ships this fix the shim runs and exits 127 without reaching
  * argparse. Latching on that would mean the box never declares its catalogue
  * for the life of the process and the owner's `/model` keeps saying
- * "clawai (0)" on the release that was meant to fix it. Every exit that is a
- * failed QUESTION or a failed WRITE unlatches, so the next request retries;
- * only the real answers ("nothing to do", "written") stay latched — and a
- * retry is bounded by `REPAIR_RETRY_MS`, because a repair that keeps failing
- * must not become a Python start per request on the busiest route we serve.
+ * "clawai (0)" on the release that was meant to fix it.
+ *
+ * So a failed QUESTION unlatches and is asked again on a later request, no
+ * sooner than `REPAIR_RETRY_MS`: no write was issued, and a rebuild that exits
+ * 127 costs one Python start a minute until it finishes.
+ *
+ * A WRITE THIS PROCESS COULD NOT READ BACK unlatches too — and carries a SECOND
+ * bound, because a rate alone bounds nothing that is permanent. `config set`
+ * exits 0 for reasons that have nothing to do with the key landing, and a key
+ * that never landed reads back exactly like an absent one, so the deciding read
+ * answers "write" again on every pass. `REPAIR_MAX_UNVERIFIED_WRITES` is what
+ * makes that end: three writes nobody could read back, and then this process
+ * stops rewriting the customer's config.yaml and says so once.
+ *
+ * The two real answers ("nothing to do", "written") stay latched, and so does
+ * the one failed write this module can PROVE is final: a literal handed back as
+ * text will be handed back as text every 60 s for the life of the process.
  *
  * EVERY EXIT SAYS SOMETHING. A silent `return` on the one path the field will
  * actually reach is how a box ends up wrong with nothing in its journal, so
@@ -473,23 +519,21 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     // for a wider reason than that band, though: an exit code is not an outcome
     // for ANY reason a write may fail to land, and this repair runs unattended
     // on every field box.
-    const outcome = written.code !== 0
-      ? "unverified"
+    const outcome: ClawaiWriteOutcome = written.code !== 0
+      ? { kind: "unverified", why: `the write exited ${written.code}` }
       : storedAsText
-        ? "stored-as-text"
+        ? { kind: "stored-as-text" }
         : await verifyClawaiCatalogue();
-    if (outcome !== "landed") {
+    if (outcome.kind !== "landed") {
       // A repair that could not be made is reported, never claimed: the picker
       // keeps showing what the box actually has. No credential is in this argv
       // — the value is a constant model list — so the stream can be logged
       // whole.
       console.warn(
         "[hermes/clawai] could not declare the ClawBox AI catalogue",
-        written.code !== 0
-          ? `exit ${written.code}`
-          : outcome === "stored-as-text"
-            ? "(this hermes stores a list as text — the same write cannot land, so it is not retried before the next restart)"
-            : "(it did not read back as the list we wrote)",
+        outcome.kind === "stored-as-text"
+          ? "(this hermes stores a list as text — the same write cannot land, so it is not retried before the next restart)"
+          : `(${outcome.why})`,
         written.stderr?.trim() || written.stdout?.trim() || "",
       );
       // A FAILURE WE HAVE PROVED IS FINAL DOES NOT GET A RETRY. `unlatch()` is
@@ -502,9 +546,33 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
       // residue is still in the file, and the verdict read finds it), and a
       // hand-run `hermes update` to a CLI that can store a list is picked up on
       // the restart that follows it.
-      if (outcome === "unverified") unlatch();
+      if (outcome.kind !== "unverified") return;
+      // A WRITE THAT NEVER REACHED ARGPARSE IS NOT AN ATTEMPT. 126 and 127 are
+      // the SHELL's codes (see `hermesCliAnswered`): the `hermes` shim ran
+      // while `step_hermes_install` was rebuilding the venv under it, so
+      // nothing was parsed, nothing was written and no config.yaml was
+      // re-serialised. That is a failed QUESTION wearing a write's clothes, and
+      // spending one of three attempts on it would burn the budget on exactly
+      // the transient the unlatch exists for.
+      if (!hermesCliAnswered(written)) return unlatch();
+      // AND A FAILURE WE CANNOT PROVE EITHER WAY GETS A FEW, NOT AN ENDLESS
+      // SUPPLY. `unverified` is the honest verdict for a question that did not
+      // answer — but it is also what a `config set` that exits 0 without
+      // landing produces on EVERY pass, and that fault is a property of the
+      // box, not a moment. Counting those writes is what turns "retry, rate
+      // limited" into a repair that ends: three attempts, then this process
+      // stops rewriting config.yaml and says so once.
+      clawaiUnverifiedWrites += 1;
+      if (clawaiUnverifiedWrites < REPAIR_MAX_UNVERIFIED_WRITES) return unlatch();
+      console.warn(
+        `[hermes/clawai] giving up on the ClawBox AI catalogue after ${clawaiUnverifiedWrites}`
+        + " writes that could not be read back — not retried before the next restart",
+      );
       return;
     }
+    // The write landed, so nothing is owed to the bound above any more: a later
+    // hand-back (a re-link) starts from a clean count.
+    clawaiUnverifiedWrites = 0;
     // The catalogue this device serves just changed — don't serve the old one.
     //
     // NO MCP RELOAD HERE, deliberately, and the same reason `reconcileLocalAiWithHermes`
@@ -522,15 +590,30 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
 }
 
 /**
- * Did the catalogue we just wrote actually land as a LIST?
+ * What a write to `providers.clawai.models` turned out to be.
  *
- *   "landed"         — the key reads back as exactly the ids we sent.
- *   "stored-as-text" — the CLI handed our own literal back as a STRING. Proof
- *                      that this build cannot store a list, and therefore that
- *                      re-issuing the identical write is futile.
- *   "unverified"     — the question failed, or answered something else. Says
- *                      nothing about the write either way, so the caller
- *                      retries on the ordinary cadence.
+ *   landed         — the key reads back as exactly the ids we sent.
+ *   stored-as-text — the CLI handed our own literal back as a STRING. Proof
+ *                    that this build cannot store a list, and therefore that
+ *                    re-issuing the identical write is futile.
+ *   unverified     — the question failed, or answered something else. Says
+ *                    nothing about the write either way, so the caller retries
+ *                    — on the ordinary cadence, and only until
+ *                    `REPAIR_MAX_UNVERIFIED_WRITES` of them have gone by.
+ *
+ * `why` IS THE HALF THE JOURNAL USED TO LOSE. "It did not read back as the list
+ * we wrote" is a DEFINITE claim, and this outcome is the one that knows least:
+ * a 15 s timeout, a SIGKILL, a decorated stdout and a genuine "key absent" all
+ * arrive here. So each carries the read's own exit code and first stderr line —
+ * and NEVER the value, which is why the leaf is read rather than the block.
+ */
+type ClawaiWriteOutcome =
+  | { kind: "landed" }
+  | { kind: "stored-as-text" }
+  | { kind: "unverified"; why: string };
+
+/**
+ * Did the catalogue we just wrote actually land as a LIST?
  *
  * `hermes config set` has no typed mode — `set_config_value(key, value: str,
  * force=False)` (hermes_cli/config.py:5383) is the only entry point, and a JSON
@@ -542,41 +625,74 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
  * `config set … --json` instead — see the PR body; the asymmetry is Hermes',
  * not ours.)
  *
+ * `force` IS NOT PASSED, DELIBERATELY. What that parameter gates has not been
+ * read on the build `HERMES_PIN_COMMIT` installs, and nothing here depends on
+ * knowing: if it does gate replacing an existing node, a refusal that still
+ * exits 0 is precisely the false success this read-back catches — reported with
+ * its cause and bounded by `REPAIR_MAX_UNVERIFIED_WRITES` rather than retried
+ * forever. Sending a flag whose effect we have not read on the build we ship
+ * would be the guess this function exists to remove.
+ *
  * THE LEAF, NOT THE BLOCK, and not only for the smaller parse: the entry this
  * repair read to decide carries `api_key`, and this key cannot. A verification
- * that need never hold a credential should not be given one.
+ * that need never hold a credential should not be given one — which is also
+ * what makes the read's stderr safe to put in the journal.
  *
  * IT NEVER THROWS. `runHermesCli` rejects on a spawn failure or a timeout, and
  * an unanswerable verification is not the repair failing — letting it reach the
  * caller's `catch` would log "catalogue reconcile failed" over a write that
  * landed.
  */
-type ClawaiWriteOutcome = "landed" | "stored-as-text" | "unverified";
-
 async function verifyClawaiCatalogue(): Promise<ClawaiWriteOutcome> {
   const declared = JSON.stringify(CLAWBOX_AI_CHAT_MODEL_IDS);
-  let value: unknown;
+  let read: HermesCliResult;
   try {
-    const read = await runHermesCli(
+    read = await runHermesCli(
       ["config", "get", `providers.${CLAWAI_PROVIDER}.models`, "--json"],
       { timeoutMs: 15_000 },
     );
-    if (!hermesCliAnswered(read) || read.code !== 0) return "unverified";
+  } catch (err) {
+    // Every rejection `runHermesCli` produces is one of its own fixed sentences
+    // — "hermes timed out", a `spawnFailureMessage` — so none of them can carry
+    // a value out of the store.
+    return unverified(err instanceof Error ? err.message : "the read-back could not be run");
+  }
+  // 126, 127 and a signal's `null` are all covered by this one test, so
+  // `hermesCliAnswered` would add nothing here: what separates them is the
+  // number in the journal line, not a second branch.
+  if (read.code !== 0) return unverified(`read exit ${read.code}${stderrCause(read.stderr)}`);
+  let value: unknown;
+  try {
     value = JSON.parse(read.stdout);
   } catch {
-    return "unverified";
+    // Our own words, never the `SyntaxError` — it quotes a prefix of its input.
+    return unverified("the read-back was not JSON");
   }
   if (
     Array.isArray(value)
     && value.length === CLAWBOX_AI_CHAT_MODEL_IDS.length
     && value.every((id, i) => id === CLAWBOX_AI_CHAT_MODEL_IDS[i])
   ) {
-    return "landed";
+    return { kind: "landed" };
   }
-  return value === declared ? "stored-as-text" : "unverified";
+  return value === declared ? { kind: "stored-as-text" } : unverified("the key holds something else");
 }
 
-/** Let a later request try the repair again, no sooner than `REPAIR_RETRY_MS`.
+/** An outcome that says nothing about the write, and why it could not say more. */
+function unverified(why: string): ClawaiWriteOutcome {
+  return { kind: "unverified", why: `could not be verified — ${why}` };
+}
+
+/** The CLI's first stderr line, for the journal: capped, and never a value —
+ *  the key this read names holds model ids, and the block that holds `api_key`
+ *  is deliberately not the one read here. */
+function stderrCause(stderr: string): string {
+  const line = stderr.trim().split(/\r?\n/, 1)[0]?.slice(0, 200);
+  return line ? `: ${line}` : "";
+}
+
+/** Let a later request try the repair again, no sooner than `REPAIR_RETRY_MS`
+ *  and no more often in total than `REPAIR_MAX_UNVERIFIED_WRITES`.
  *  @see reconcileClawaiModelsWithHermes */
 function unlatch(): void {
   clawaiModelsReconciled = false;
@@ -669,6 +785,12 @@ async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
 
   let entry: unknown;
   try {
+    // THIS CATCH IS LOAD-BEARING FOR A SECOND REASON. `JSON.parse` throws a
+    // `SyntaxError` whose message QUOTES A PREFIX OF ITS INPUT, and this input
+    // is the whole `providers.clawai` block — `api_key` and all. Letting it
+    // reach the caller's `catch (err)` would print that prefix through
+    // `console.error("[hermes/clawai] catalogue reconcile failed:", err)`. The
+    // reason below is our own words; nothing derived from the error is logged.
     entry = JSON.parse(read.stdout);
   } catch {
     return { action: "retry", reason: "the CLI printed a value this build could not parse" };
@@ -837,8 +959,10 @@ function isHermesAllowlist(value: unknown): boolean {
   });
 }
 
-/** Test seam. */
+/** Test seam. The counter is NOT part of the hand-back — a re-link is worth one
+ *  more attempt, not a fresh three — so it is cleared here explicitly. */
 export function _resetClawaiModelsReconcileForTests(): void {
+  clawaiUnverifiedWrites = 0;
   handClawaiRepairBack();
 }
 

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -2,6 +2,7 @@ import { setMany } from "@/lib/config-store";
 import { refreshCodingAgentToolsIfReadinessChanged } from "@/lib/coding-agent-mcp-refresh";
 import { hermesAgentDrawsImages } from "@/lib/harness/hermes-features";
 import { runHermesCli } from "@/lib/hermes-cli";
+import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import { redactKey, safeHermesFailureMessage } from "@/lib/hermes-cli-message";
 import { refreshHermesImageTools } from "@/lib/hermes-image-refresh";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
@@ -384,6 +385,17 @@ let clawaiModelsReconciled = false;
  * "not set" wording leaves the file alone. And an existing value of ANY shape
  * is left alone too: it may be Hermes' own discovered catalogue, which is
  * richer than ours.
+ *
+ * THE LATCH IS FOR ANSWERS ONLY, and that is the whole difference between a
+ * repair and a coin toss. `hermes` on the box is a shim over a venv Python, and
+ * `step_hermes_install` moves the checkout aside and rebuilds it for about 90 s
+ * with NO web-server restart afterwards (install.sh) — so during the very
+ * update that ships this fix the shim runs and exits 127 without reaching
+ * argparse. Latching on that would mean the box never declares its catalogue
+ * for the life of the process and the owner's `/model` keeps saying
+ * "clawai (0)" on the release that was meant to fix it. Every exit that is a
+ * failed QUESTION or a failed WRITE unlatches, so the next request retries;
+ * only the two real answers ("already declared", "written") stay latched.
  */
 export async function reconcileClawaiModelsWithHermes(): Promise<void> {
   if (clawaiModelsReconciled) return;
@@ -396,8 +408,11 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
       ["config", "get", `providers.${CLAWAI_PROVIDER}.models`],
       { timeoutMs: 15_000 },
     );
+    if (!hermesCliAnswered(declared)) return unlatch();
     if (declared.code === 0) return;
     const listing = `${declared.stdout ?? ""}\n${declared.stderr ?? ""}`;
+    // A non-zero exit that is not "not set" is a config we could not read.
+    // Nothing to unlatch for: the CLI answered, and its answer was "no".
     if (!/config key not set/i.test(listing)) return;
 
     // Only now ask whether there is a provider to describe. Not "is a token
@@ -410,6 +425,7 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
       ["config", "get", `providers.${CLAWAI_PROVIDER}.base_url`],
       { timeoutMs: 15_000 },
     );
+    if (!hermesCliAnswered(linked)) return unlatch();
     if (linked.code !== 0 || !linked.stdout.trim()) return;
 
     const written = await runHermesCli(
@@ -418,16 +434,35 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     );
     if (written.code !== 0) {
       // A repair that could not be made is reported, never claimed: the picker
-      // keeps showing what the box actually has.
-      console.warn("[hermes/clawai] could not declare the ClawBox AI catalogue", written.code);
-      return;
+      // keeps showing what the box actually has, and the next request tries
+      // again. No credential is in this argv — the value is a constant model
+      // list — so the stream can be logged whole.
+      console.warn(
+        "[hermes/clawai] could not declare the ClawBox AI catalogue",
+        written.code,
+        written.stderr?.trim() || written.stdout?.trim() || "",
+      );
+      return unlatch();
     }
     // The catalogue this device serves just changed — don't serve the old one.
+    //
+    // NO MCP RELOAD HERE, deliberately, and the same reason `reconcileLocalAiWithHermes`
+    // uses its INNER write: this hangs off `GET /setup-api/hermes/models`, which
+    // is the route the agent's own `ai_list_models` reads, so a `reload.mcp`
+    // would shut down the MCP child that is mid-tool-call. Nor does it move the
+    // provider SET the enum is built from — the provider already existed; only
+    // the models it lists changed — so there is nothing for
+    // `refreshProviderToolsIfSetChanged` to notice. See provider-write-paths.test.ts.
     invalidateModelOptions();
   } catch (err) {
     console.error("[hermes/clawai] catalogue reconcile failed:", err);
-    clawaiModelsReconciled = false;
+    unlatch();
   }
+}
+
+/** Let the next request try the repair again. @see reconcileClawaiModelsWithHermes */
+function unlatch(): void {
+  clawaiModelsReconciled = false;
 }
 
 /** Test seam. */

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -14,6 +14,7 @@ import {
   mergePluginsEnabled,
 } from "@/lib/hermes-image-plugin";
 import {
+  CLAWBOX_AI_CHAT_MODEL_IDS,
   CLAWBOX_AI_FLASH_MODEL_ID,
   CLAWBOX_AI_IMAGE_MODEL_ID,
   CLAWBOX_AI_PRO_MODEL_ID,
@@ -161,6 +162,32 @@ export async function applyClawaiToHermes(
     ["config", "set", `providers.${CLAWAI_PROVIDER}.base_url`, CLAWBOX_AI_PROXY_URL],
     ["config", "set", `providers.${CLAWAI_PROVIDER}.api_key`, trimmed],
     ["config", "set", `providers.${CLAWAI_PROVIDER}.api_mode`, "openai"],
+    // ── Telling Hermes what this provider serves ────────────────────────────
+    //
+    // Without this line the box's OWN pickers offer nothing: the Telegram /
+    // Discord `/model` keyboard and the Hermes dashboard's Models page are both
+    // built by `list_authenticated_providers` (hermes_cli/model_switch.py:2571,
+    // Hermes 0.20.5), which reads a custom provider's model set out of THIS
+    // block and then probes `<base_url>/models` for a live one.
+    //
+    // The probe cannot help us. `probe_api_models` (hermes_cli/models.py:5668)
+    // reads the OpenAI envelope, `data[].id`; the ClawBox AI proxy answers
+    // `200 {"status":"ok","service":"ClawBox AI Proxy","models":[…]}`. So Hermes
+    // parses an EMPTY list, and an empty probe with nothing declared beside it
+    // is what rendered as "clawai (0)" on the owner's phone while our own chat
+    // header showed two models — the same box, two answers.
+    //
+    // A LIST, not the singular `model`/`default_model` key: only a list (or a
+    // string) counts as an allowlist (`_models_config_is_allowlist`,
+    // model_switch.py:136), and only an allowlist stops that empty probe from
+    // replacing the declared ids (model_switch.py:3423-3431). It is a floor and
+    // never a ceiling — a probe that DOES answer still wins, so the day the
+    // proxy speaks the OpenAI envelope this stops mattering on its own.
+    //
+    // JSON is how `hermes config set` is told to store a list rather than a
+    // string (hermes_cli/config.py:5515), the same way `plugins.enabled` is
+    // written below.
+    ["config", "set", `providers.${CLAWAI_PROVIDER}.models`, JSON.stringify(CLAWBOX_AI_CHAT_MODEL_IDS)],
     ["config", "set", "model.provider", CLAWAI_PROVIDER],
     ["config", "set", "model.default", model],
     // Clear any global custom-endpoint override a prior provider may have left,
@@ -336,6 +363,76 @@ export async function applyClawaiToHermes(
   }
 
   return { provider: CLAWAI_PROVIDER, model, tier };
+}
+
+let clawaiModelsReconciled = false;
+
+/**
+ * Declare the ClawBox AI catalogue on a box that was linked before this code
+ * existed — once per process, and a no-op on every other device.
+ *
+ * Every box already in the field has `providers.clawai` with a URL, a key and a
+ * mode, and no `models:` at all, and nothing re-links it: the owner would keep
+ * seeing "clawai (0)" in their bot for as long as the box stayed paired. Same
+ * shape of repair, and the same reasoning, as `reconcileLocalAiWithHermes`.
+ *
+ * Deliberately narrower than a re-link: it writes ONE key and needs no token.
+ *
+ * THREE ANSWERS, NOT TWO. `hermes config get` exits non-zero both for a key
+ * that is unset and for a config it could not read, and only the first is ours
+ * to fill in — an unreadable config is not an empty one, so anything but the
+ * "not set" wording leaves the file alone. And an existing value of ANY shape
+ * is left alone too: it may be Hermes' own discovered catalogue, which is
+ * richer than ours.
+ */
+export async function reconcileClawaiModelsWithHermes(): Promise<void> {
+  if (clawaiModelsReconciled) return;
+  clawaiModelsReconciled = true;
+  try {
+    // The catalogue first, because on a settled box it is the answer: one
+    // `hermes config get` (~0.6 s of process spawn) and we are done, rather than
+    // two on every cold process for a repair that will never be needed again.
+    const declared = await runHermesCli(
+      ["config", "get", `providers.${CLAWAI_PROVIDER}.models`],
+      { timeoutMs: 15_000 },
+    );
+    if (declared.code === 0) return;
+    const listing = `${declared.stdout ?? ""}\n${declared.stderr ?? ""}`;
+    if (!/config key not set/i.test(listing)) return;
+
+    // Only now ask whether there is a provider to describe. Not "is a token
+    // stored" — the question is whether HERMES has the block, which is what its
+    // pickers read. Without this a box that has never been linked would get a
+    // `providers.clawai.models` with no endpoint beside it, which Hermes renders
+    // as a picker row offering two models with nowhere to send them — the same
+    // orphan the local provider's removal exists to avoid.
+    const linked = await runHermesCli(
+      ["config", "get", `providers.${CLAWAI_PROVIDER}.base_url`],
+      { timeoutMs: 15_000 },
+    );
+    if (linked.code !== 0 || !linked.stdout.trim()) return;
+
+    const written = await runHermesCli(
+      ["config", "set", `providers.${CLAWAI_PROVIDER}.models`, JSON.stringify(CLAWBOX_AI_CHAT_MODEL_IDS)],
+      { timeoutMs: 15_000 },
+    );
+    if (written.code !== 0) {
+      // A repair that could not be made is reported, never claimed: the picker
+      // keeps showing what the box actually has.
+      console.warn("[hermes/clawai] could not declare the ClawBox AI catalogue", written.code);
+      return;
+    }
+    // The catalogue this device serves just changed — don't serve the old one.
+    invalidateModelOptions();
+  } catch (err) {
+    console.error("[hermes/clawai] catalogue reconcile failed:", err);
+    clawaiModelsReconciled = false;
+  }
+}
+
+/** Test seam. */
+export function _resetClawaiModelsReconcileForTests(): void {
+  clawaiModelsReconciled = false;
 }
 
 /**

--- a/src/lib/hermes-clawai.ts
+++ b/src/lib/hermes-clawai.ts
@@ -429,12 +429,12 @@ export async function reconcileClawaiModelsWithHermes(): Promise<void> {
     if (verdict.overwriting) {
       // Logged where the write happens, not where the shape was read: a line
       // claiming an overwrite that never ran is the false-success shape this
-      // module keeps being audited for. This is the one state in which the file
-      // and the symptom disagree — a populated `models:` and "clawai (0)" on the
-      // owner's phone — so it is worth a line of its own.
+      // module keeps being audited for. These are the states in which the file
+      // and the symptom disagree — a populated `models:` and "clawai (0)" or one
+      // bogus entry on the owner's phone — so each is worth naming.
       console.warn(
-        `[hermes/clawai] providers.${CLAWAI_PROVIDER}.models is not a shape Hermes reads`
-        + " as an allowlist — declaring the ClawBox AI catalogue over it",
+        `[hermes/clawai] providers.${CLAWAI_PROVIDER}.models holds ${verdict.overwriting}`
+        + " — declaring the ClawBox AI catalogue over it",
       );
     }
     const written = await runHermesCli(
@@ -488,9 +488,10 @@ function unlatch(): void {
 /**
  * What to do about `providers.clawai.models`, decided from the WHOLE entry.
  *
- *   "write"  — declare our catalogue. `overwriting` says whether something was
- *              already there in a shape Hermes refuses to read, which is worth
- *              a line in the journal.
+ *   "write"  — declare our catalogue. `overwriting` names what was already
+ *              there, when something was, because a repair that replaces a
+ *              populated key is worth a line in the journal saying which fault
+ *              it found.
  *   "leave"  — this box is not ours to change. A `reason` is logged; the two
  *              ordinary cases (already declared, never linked) carry none,
  *              because every box on the fleet would print them once a boot.
@@ -530,7 +531,7 @@ function unlatch(): void {
  * branch below logs `stdout` — only exit codes and our own words.
  */
 type ClawaiVerdict =
-  | { action: "write"; overwriting: boolean }
+  | { action: "write"; overwriting?: string }
   | { action: "leave"; reason: string }
   | { action: "retry"; reason: string };
 
@@ -575,6 +576,29 @@ async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
     // `api_key`.
     return { action: "leave", reason: `providers.${CLAWAI_PROVIDER} carries no endpoint` };
   }
+  // FIRST, because it beats every other reading of `models:`. With
+  // `models_discovered: true` beside it our list is refused whatever its shape
+  // (:136), so any verdict below that wrote would latch "repaired" over a
+  // keyboard still saying "clawai (0)".
+  if (hermesOwnsCatalogue(row)) {
+    return { action: "leave", reason: "Hermes persisted this catalogue itself (models_discovered)" };
+  }
+  // A LIST STORED AS TEXT IS NOT A CATALOGUE — and it is the one broken shape
+  // Hermes reads as a perfectly good one. Ran on the installed 0.20.5 over the
+  // string `["deepseek-v4-flash","deepseek-v4-pro"]`: `_declared_model_ids`
+  // (:61) yields ONE id, the whole literal, and `_models_config_is_allowlist`
+  // (:136) says True. So the keyboard offers a single unusable entry and BOTH
+  // "already declared" branches below walk away from it.
+  //
+  // This is the residue of the failed write the guard in
+  // `reconcileClawaiModelsWithHermes` catches: `hermes config set` saves the
+  // literal text and exits 0, so the value is in the file before that guard
+  // ever sees the warning, and on a CLI old enough to lack the coercion block
+  // there is no warning to see. Unlatching without this check re-reads the
+  // string we just wrote and calls it declared — the guard would defeat itself.
+  if (typeof row.models === "string" && looksLikeStructuredText(row.models)) {
+    return { action: "write", overwriting: "a list Hermes stored as text" };
+  }
   // A PIN THAT PINS NOTHING IS NOT A PIN. `discover_models: false` only protects
   // something if there is something to protect: with discovery off Hermes runs
   // no probe (`_discovery_allowed`, model_switch.py:3788) and shows exactly the
@@ -586,13 +610,30 @@ async function clawaiCatalogueVerdict(): Promise<ClawaiVerdict> {
   if (!hermesDiscoversModels(row) && hermesDeclaresAnyId(row.models)) {
     return { action: "leave", reason: "the catalogue is pinned with discover_models: false" };
   }
-  if (hermesOwnsCatalogue(row)) {
-    return { action: "leave", reason: "Hermes persisted this catalogue itself (models_discovered)" };
-  }
-  if (row.models === undefined) return { action: "write", overwriting: false };
+  if (row.models === undefined) return { action: "write" };
   return isHermesAllowlist(row.models)
     ? { action: "leave", reason: "" }
-    : { action: "write", overwriting: true };
+    : { action: "write", overwriting: "a value Hermes does not read as an allowlist" };
+}
+
+/**
+ * Does this text plausibly encode a YAML/JSON list or mapping?
+ * `_looks_structured_value`, hermes_cli/config.py:5322 — the CLI's OWN test for
+ * "this argument is a structure, not a scalar", and the one that decides
+ * whether `config set` attempts a `yaml.safe_load` at all. Borrowing it here
+ * rather than inventing a rule keeps the two ends of the same write agreeing:
+ * every value the CLI meant to store as a list, and failed to, answers true.
+ *
+ * ONLY THE FLOW-STYLE TRIGGER IS MODELLED, deliberately. The Python also fires
+ * on multi-line block style (`- item` / `key: value` lines), which cannot be
+ * residue here: this module writes `JSON.stringify(ids)` and nothing else, and a
+ * hand-edited block in config.yaml is loaded by PyYAML as a real list long
+ * before any of this runs. The conservatism is the point either way — a model
+ * id is a scalar, so `deepseek-v4-flash` and even `-5` stay pins.
+ */
+function looksLikeStructuredText(value: string): boolean {
+  const stripped = value.replace(/^\s+/, "");
+  return stripped.startsWith("[") || stripped.startsWith("{");
 }
 
 /**

--- a/src/lib/hermes-dashboard-turn.ts
+++ b/src/lib/hermes-dashboard-turn.ts
@@ -969,10 +969,15 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
       //
       // There is a real case for it, found on the box: switching TO a
       // user-defined provider is refused, because the switch validates the
-      // model against the target provider's model listing and a
-      // `providers.<slug>` entry in config.yaml carries none. On this device
-      // that is `clawai` — the DEFAULT provider — so "go back to ClawBox AI
-      // mid-conversation" is exactly the combination that cannot be made here.
+      // model against the target provider's model listing, and a
+      // `providers.<slug>` entry in config.yaml used to carry none. On this
+      // device that is `clawai` — the DEFAULT provider — so "go back to ClawBox
+      // AI mid-conversation" was exactly the combination that could not be made
+      // here. `applyClawaiToHermes` now declares that listing, so the clawai
+      // case should no longer arise on a box this code has written; the guard
+      // stays because a refusal is a thing the transport must read either way —
+      // for a model outside the declared list, or a provider we never wrote —
+      // and because nothing in this process can prove the switch took.
       //
       // Throwing lands in the catch below, which returns null, and the route
       // then spawns the CLI for this turn. That path passes `-m` and

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -67,8 +67,9 @@ async function applyLocalAi(options: {
   // `models` below is right — an unreadable key is not an absent one — but the
   // picker's own repair latches once per process and may already have run, so
   // nothing would ever come back for it and the key would stay missing until
-  // the web server restarted. Hand the repair back to the next request.
-  if (catalogue === "unknown") retryLater();
+  // the web server restarted. Hand the repair back to the next read — with no
+  // backoff, because the repair did not fail here, this enable did.
+  if (catalogue === "unknown") handRepairBack();
 
   const set: Record<string, string> = {
     // The OpenAI-compatible root, NOT the bare proxy root: Hermes appends
@@ -149,10 +150,21 @@ let retryAfter = 0;
  */
 const REPAIR_RETRY_MS = 60_000;
 
-/** Let a later request try the repair again, no sooner than `REPAIR_RETRY_MS`. */
+/** A repair ATTEMPT failed: let a later request try again, but not for a
+ *  minute. */
 function retryLater(): void {
   reconciled = false;
   retryAfter = Date.now() + REPAIR_RETRY_MS;
+}
+
+/** Something OTHER than the repair noticed the key may be missing: let the very
+ *  next read try, with no backoff. Nothing failed here, so there is nothing to
+ *  back off from — and this runs on an explicit customer action rather than on
+ *  every request, so it cannot become a spawn per request the way an unbounded
+ *  `retryLater` could. */
+function handRepairBack(): void {
+  reconciled = false;
+  retryAfter = 0;
 }
 
 /**

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -1,4 +1,5 @@
 import { runHermesCli } from "@/lib/hermes-cli";
+import { hermesCliAnswered } from "@/lib/hermes-cli-answered";
 import { get } from "@/lib/config-store";
 import { patchHermesConfig, readHermesConfigValue } from "@/lib/hermes-config-yaml";
 import { invalidateModelOptions } from "@/lib/hermes-model-options";
@@ -61,6 +62,7 @@ async function applyLocalAi(options: {
   if (!model || model.startsWith("-")) {
     throw new HermesLocalApplyError("Local model id is missing or malformed.");
   }
+  const catalogue = await localCatalogueState();
 
   const set: Record<string, string> = {
     // The OpenAI-compatible root, NOT the bare proxy root: Hermes appends
@@ -85,9 +87,18 @@ async function applyLocalAi(options: {
     // A plain scalar rather than a list: there is exactly one configured local
     // model, and a string is an allowlist shape as far as Hermes is concerned
     // (`_declared_model_ids` at model_switch.py:61, `_models_config_is_allowlist`
-    // at :136) — which also keeps it inside what the comment-preserving YAML
-    // writer can splice.
-    [`providers.${HERMES_LOCAL_PROVIDER}.models`]: model,
+    // at :136 — both verified against the installed Hermes) — which also keeps
+    // it inside what the comment-preserving YAML writer can splice.
+    //
+    // WRITTEN ONLY WHEN THE KEY IS OURS. If Hermes has cached its own discovered
+    // catalogue there it is a nested block, and `setYamlPath` refuses a leaf
+    // that opens one — which aborts the WHOLE patch onto `hermes config set`
+    // and takes every comment in config.yaml with it, the exact loss this
+    // module exists to prevent. Leaving a richer catalogue alone is also just
+    // right: a live probe beats our one id whenever the model is awake.
+    ...(catalogue === "absent" || catalogue === "scalar"
+      ? { [`providers.${HERMES_LOCAL_PROVIDER}.models`]: model }
+      : {}),
   };
   if (options.makeDefault) {
     set["model.provider"] = HERMES_LOCAL_PROVIDER;
@@ -119,21 +130,57 @@ async function applyLocalAi(options: {
 let reconciled = false;
 
 /**
- * True only when Hermes has NO model declared for our local provider.
+ * How `providers.clawlocal.models` is currently spelled in config.yaml.
  *
- * Three answers, not two: `hermes config get` exits non-zero both for a key
- * that is unset and for a config it could not read, and repairing off a failed
- * read would overwrite whatever is really in the file — so only the "not set"
- * wording counts as missing. A value of any shape is left alone; it may be
- * Hermes' own discovered catalogue, which is richer than the one id we know.
+ *   "absent"  — not there. Ours to write, and the case every field box is in.
+ *   "scalar"  — the one-id form THIS module writes. Ours to update, which is
+ *               what makes a changed local model land.
+ *   "foreign" — there, and not a scalar: Hermes' own discovered catalogue,
+ *               which is a nested block. Never ours to touch — see the write
+ *               site for what splicing over it would cost.
+ *   "unknown" — the question failed. Not an answer, and never treated as one.
+ *
+ * Two reads because one cannot tell those four apart. `readHermesConfigValue`
+ * parses the file and returns a value only for a scalar; it answers null for
+ * absent, for a block AND for a file it could not read, so a non-null result is
+ * the only thing it settles on its own. The CLI splits the remaining three:
+ * exit 0 means the key is there in some other shape, "config key not set" means
+ * it is not, and anything else — including the 126/127 a `step_hermes_install`
+ * rebuild produces without ever reaching argparse — is the CLI failing to
+ * answer rather than answering "no".
  */
-async function localCatalogueMissing(): Promise<boolean> {
-  const declared = await runHermesCli(
-    ["config", "get", `providers.${HERMES_LOCAL_PROVIDER}.models`],
-    { timeoutMs: 15_000 },
-  );
-  if (declared.code === 0) return false;
-  return /config key not set/i.test(`${declared.stdout ?? ""}\n${declared.stderr ?? ""}`);
+type LocalCatalogueState = "absent" | "scalar" | "foreign" | "unknown";
+
+async function localCatalogueState(): Promise<LocalCatalogueState> {
+  const key = `providers.${HERMES_LOCAL_PROVIDER}.models`;
+  if ((await readHermesConfigValue(key)) !== null) return "scalar";
+  const declared = await runHermesCli(["config", "get", key], { timeoutMs: 15_000 });
+  if (!hermesCliAnswered(declared)) return "unknown";
+  if (declared.code === 0) return "foreign";
+  return /config key not set/i.test(`${declared.stdout ?? ""}\n${declared.stderr ?? ""}`)
+    ? "absent"
+    : "unknown";
+}
+
+/**
+ * Declare the local model where Hermes' own pickers read it, for a box
+ * registered before this code existed.
+ *
+ * NARROW ON PURPOSE: one key, and never a re-registration. Re-running the full
+ * apply would drag every field box down the repair path built for a stale
+ * self-written URL — and that path substitutes `getDefaultLlamaCppModel()` for
+ * an unreadable `local_ai_model`, which on an Ollama box would declare a
+ * llama.cpp id as the Ollama endpoint's model and put it in Hermes' picker.
+ * An id we do not have is a reason to write nothing, not to invent one.
+ */
+async function declareLocalCatalogue(model: string): Promise<boolean> {
+  if (!model || model.startsWith("-")) return true;
+  const state = await localCatalogueState();
+  if (state === "unknown") return false;
+  if (state !== "absent") return true;
+  await patchHermesConfig({ set: { [`providers.${HERMES_LOCAL_PROVIDER}.models`]: model } });
+  invalidateModelOptions();
+  return true;
 }
 
 /**
@@ -165,15 +212,28 @@ export async function reconcileLocalAiWithHermes(): Promise<void> {
       ["config", "get", `providers.${HERMES_LOCAL_PROVIDER}.base_url`],
       { timeoutMs: 15_000 },
     );
+    if (!hermesCliAnswered(existing)) {
+      // The CLI did not answer (a `step_hermes_install` rebuild exits 127
+      // without reaching argparse). Not evidence about this box — try again on
+      // the next request rather than latching a non-answer for the process.
+      reconciled = false;
+      return;
+    }
     const registered = existing.code === 0 ? existing.stdout.trim() : "";
     const ourStaleUrl =
       registered.startsWith(`${getLocalAiProxyRootUrl()}/setup-api/local-ai/`)
       && registered !== getLocalAiOpenAiBaseUrl(provider);
-    if (registered && !ourStaleUrl && !(await localCatalogueMissing())) return;
 
     const stored = await get("local_ai_model");
     // Stored as "llamacpp/gemma4-e2b-it-q4_0"; Hermes wants the bare id.
     const model = typeof stored === "string" ? stored.split("/").pop() || "" : "";
+
+    if (registered && !ourStaleUrl) {
+      // The endpoint is right; only the catalogue Hermes' own pickers read can
+      // still be missing. One key, no re-registration.
+      if (!(await declareLocalCatalogue(model))) reconciled = false;
+      return;
+    }
     // The INNER write, deliberately — this one repair must not ask for an MCP
     // reload. It hangs off `GET /setup-api/hermes/models`, and that route is
     // what the agent's own `ai_list_models` reads: a `reload.mcp` from in here

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -70,6 +70,24 @@ async function applyLocalAi(options: {
     [`providers.${HERMES_LOCAL_PROVIDER}.base_url`]: getLocalAiOpenAiBaseUrl(options.provider),
     [`providers.${HERMES_LOCAL_PROVIDER}.api_key`]: getLocalAiToken(),
     [`providers.${HERMES_LOCAL_PROVIDER}.api_mode`]: "openai",
+    // What this endpoint serves, for the pickers Hermes builds ITSELF — the
+    // Telegram/Discord `/model` keyboard and the Hermes dashboard's Models page,
+    // both from `list_authenticated_providers` (hermes_cli/model_switch.py:2571).
+    //
+    // Those probe `<base_url>/models` for a live list, and standby is the point
+    // of the local model: asleep, it answers nothing, so the row arrives with an
+    // empty list and there is no model to select — the same hole
+    // `normalizeRow` already patches for OUR chat header, on the surface we do
+    // not serve. Declaring the id is what Hermes reads instead of the probe when
+    // the probe comes back empty (model_switch.py:3423-3431), and a probe that
+    // DOES answer still wins, so a woken box still shows whatever it is running.
+    //
+    // A plain scalar rather than a list: there is exactly one configured local
+    // model, and a string is an allowlist shape as far as Hermes is concerned
+    // (`_declared_model_ids` at model_switch.py:61, `_models_config_is_allowlist`
+    // at :136) — which also keeps it inside what the comment-preserving YAML
+    // writer can splice.
+    [`providers.${HERMES_LOCAL_PROVIDER}.models`]: model,
   };
   if (options.makeDefault) {
     set["model.provider"] = HERMES_LOCAL_PROVIDER;
@@ -99,6 +117,24 @@ async function applyLocalAi(options: {
 }
 
 let reconciled = false;
+
+/**
+ * True only when Hermes has NO model declared for our local provider.
+ *
+ * Three answers, not two: `hermes config get` exits non-zero both for a key
+ * that is unset and for a config it could not read, and repairing off a failed
+ * read would overwrite whatever is really in the file — so only the "not set"
+ * wording counts as missing. A value of any shape is left alone; it may be
+ * Hermes' own discovered catalogue, which is richer than the one id we know.
+ */
+async function localCatalogueMissing(): Promise<boolean> {
+  const declared = await runHermesCli(
+    ["config", "get", `providers.${HERMES_LOCAL_PROVIDER}.models`],
+    { timeoutMs: 15_000 },
+  );
+  if (declared.code === 0) return false;
+  return /config key not set/i.test(`${declared.stdout ?? ""}\n${declared.stderr ?? ""}`);
+}
 
 /**
  * Register the local model if it was configured BEFORE this code existed.
@@ -133,7 +169,7 @@ export async function reconcileLocalAiWithHermes(): Promise<void> {
     const ourStaleUrl =
       registered.startsWith(`${getLocalAiProxyRootUrl()}/setup-api/local-ai/`)
       && registered !== getLocalAiOpenAiBaseUrl(provider);
-    if (registered && !ourStaleUrl) return;
+    if (registered && !ourStaleUrl && !(await localCatalogueMissing())) return;
 
     const stored = await get("local_ai_model");
     // Stored as "llamacpp/gemma4-e2b-it-q4_0"; Hermes wants the bare id.
@@ -188,7 +224,12 @@ async function removeLocalAi(): Promise<{ wasDefault: boolean; model: string | n
   const wasDefault = activeProvider === HERMES_LOCAL_PROVIDER;
   const model = wasDefault ? await readHermesConfigValue("model.default").catch(() => null) : null;
 
-  const unset = ["base_url", "api_key", "api_mode"].map(
+  // `models` rides with the endpoint it describes. Left behind, it is a
+  // `providers.clawlocal` block naming a model with nowhere to send it — and
+  // Hermes renders a row for any entry that has models, so the picker would go
+  // on offering the stopped model, which is the exact state this function
+  // exists to end.
+  const unset = ["base_url", "api_key", "api_mode", "models"].map(
     (key) => `providers.${HERMES_LOCAL_PROVIDER}.${key}`,
   );
   if (wasDefault) {

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -63,6 +63,12 @@ async function applyLocalAi(options: {
     throw new HermesLocalApplyError("Local model id is missing or malformed.");
   }
   const catalogue = await localCatalogueState();
+  // A catalogue question that FAILED is not a reason to stop asking. Omitting
+  // `models` below is right — an unreadable key is not an absent one — but the
+  // picker's own repair latches once per process and may already have run, so
+  // nothing would ever come back for it and the key would stay missing until
+  // the web server restarted. Hand the repair back to the next request.
+  if (catalogue === "unknown") reconciled = false;
 
   const set: Record<string, string> = {
     // The OpenAI-compatible root, NOT the bare proxy root: Hermes appends

--- a/src/lib/hermes-local-ai.ts
+++ b/src/lib/hermes-local-ai.ts
@@ -68,7 +68,7 @@ async function applyLocalAi(options: {
   // picker's own repair latches once per process and may already have run, so
   // nothing would ever come back for it and the key would stay missing until
   // the web server restarted. Hand the repair back to the next request.
-  if (catalogue === "unknown") reconciled = false;
+  if (catalogue === "unknown") retryLater();
 
   const set: Record<string, string> = {
     // The OpenAI-compatible root, NOT the bare proxy root: Hermes appends
@@ -134,6 +134,26 @@ async function applyLocalAi(options: {
 }
 
 let reconciled = false;
+let retryAfter = 0;
+
+/**
+ * How long a repair whose QUESTION failed waits before another request retries.
+ *
+ * Same number and the same reasoning as `REPAIR_RETRY_MS` in hermes-clawai.ts
+ * and `FAILED_READ_TTL_MS` in hermes-config-cache.ts: unlatching on a failure
+ * is what stops an update from skipping the repair for the life of the process,
+ * and a bound is what stops that retry from becoming a Python start per request
+ * on `GET /setup-api/hermes/models` — the route the chat header, the Settings
+ * panel and the agent's own `ai_list_models` all read, which awaits BOTH
+ * repairs before it serves anything.
+ */
+const REPAIR_RETRY_MS = 60_000;
+
+/** Let a later request try the repair again, no sooner than `REPAIR_RETRY_MS`. */
+function retryLater(): void {
+  reconciled = false;
+  retryAfter = Date.now() + REPAIR_RETRY_MS;
+}
 
 /**
  * How `providers.clawlocal.models` is currently spelled in config.yaml.
@@ -181,10 +201,18 @@ async function localCatalogueState(): Promise<LocalCatalogueState> {
  */
 async function declareLocalCatalogue(model: string): Promise<boolean> {
   if (!model || model.startsWith("-")) return true;
+  const key = `providers.${HERMES_LOCAL_PROVIDER}.models`;
   const state = await localCatalogueState();
   if (state === "unknown") return false;
-  if (state !== "absent") return true;
-  await patchHermesConfig({ set: { [`providers.${HERMES_LOCAL_PROVIDER}.models`]: model } });
+  // "foreign" is Hermes' own block and never ours. "scalar" IS ours — it is the
+  // one-id form this module writes — so a scalar that no longer names the
+  // configured model is our own value gone stale, and leaving it would have the
+  // picker go on offering a model this box no longer runs. The enable path has
+  // always updated it; the repair used to write only when the key was missing,
+  // so a box whose model changed while the CLI was unreadable kept the old id.
+  if (state === "foreign") return true;
+  if (state === "scalar" && (await readHermesConfigValue(key)) === model) return true;
+  await patchHermesConfig({ set: { [key]: model } });
   invalidateModelOptions();
   return true;
 }
@@ -199,7 +227,7 @@ async function declareLocalCatalogue(model: string): Promise<boolean> {
  * when there is genuinely something to repair.
  */
 export async function reconcileLocalAiWithHermes(): Promise<void> {
-  if (reconciled) return;
+  if (reconciled || Date.now() < retryAfter) return;
   reconciled = true;
   try {
     const configured = await get("local_ai_configured");
@@ -221,8 +249,8 @@ export async function reconcileLocalAiWithHermes(): Promise<void> {
     if (!hermesCliAnswered(existing)) {
       // The CLI did not answer (a `step_hermes_install` rebuild exits 127
       // without reaching argparse). Not evidence about this box — try again on
-      // the next request rather than latching a non-answer for the process.
-      reconciled = false;
+      // a later request rather than latching a non-answer for the process.
+      retryLater();
       return;
     }
     const registered = existing.code === 0 ? existing.stdout.trim() : "";
@@ -237,7 +265,7 @@ export async function reconcileLocalAiWithHermes(): Promise<void> {
     if (registered && !ourStaleUrl) {
       // The endpoint is right; only the catalogue Hermes' own pickers read can
       // still be missing. One key, no re-registration.
-      if (!(await declareLocalCatalogue(model))) reconciled = false;
+      if (!(await declareLocalCatalogue(model))) retryLater();
       return;
     }
     // The INNER write, deliberately — this one repair must not ask for an MCP
@@ -250,13 +278,14 @@ export async function reconcileLocalAiWithHermes(): Promise<void> {
   } catch (err) {
     // Never let a repair break the read it is attached to.
     console.error("[hermes-local-ai] reconcile failed:", err);
-    reconciled = false;
+    retryLater();
   }
 }
 
 /** Test seam. */
 export function _resetLocalAiReconcileForTests(): void {
   reconciled = false;
+  retryAfter = 0;
 }
 
 /**

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -372,7 +372,13 @@ function normalizeRow(raw: DashboardProviderRow, localModelId: string): HermesPr
   // Only ClawBox AI is seeded: these are ids we have PROVEN route on this
   // hardware. We never invent ids for a third-party provider — that is the
   // mismatch class this module exists to prevent.
-  if (id === CLAWAI_PROVIDER) {
+  //
+  // ONLY when the row is EMPTY, which is what "fallback" has to mean in code:
+  // if Hermes ever reports a non-empty clawai list that differs from ours (a
+  // renamed tier id, or the proxy starting to speak the OpenAI envelope with a
+  // different set), topping it up would show the live ids PLUS two stale ones —
+  // the provider/model mismatch this module exists to prevent.
+  if (id === CLAWAI_PROVIDER && models.length === 0) {
     for (const known of COLD_START_MODELS[CLAWAI_PROVIDER] ?? []) {
       if (seen.has(known)) continue;
       seen.add(known);

--- a/src/lib/hermes-model-options.ts
+++ b/src/lib/hermes-model-options.ts
@@ -28,6 +28,7 @@ import path from "path";
 import { dashboardFetch } from "@/lib/hermes-dashboard-auth";
 import { hermesConfigGet, invalidateHermesConfigCache } from "@/lib/hermes-config-cache";
 import { get } from "@/lib/config-store";
+import { CLAWBOX_AI_CHAT_MODEL_IDS } from "@/lib/clawbox-ai-models";
 import {
   CLAWAI_PROVIDER,
   HERMES_AUTO_PROVIDER,
@@ -54,17 +55,20 @@ export const isSafeModelId = isSafeHermesModelId;
  * models (a vendor-prefixed slug gets HTTP 400 "Model not allowed" from the
  * proxy). Used twice:
  *   1. cold start — a factory device with no dashboard and no catalog on disk;
- *   2. to seed the ClawBox AI row (see normalizeRow), because Hermes can only
- *      report the single id our custom-provider config declares, while the
- *      product actually serves both — which is what OpenClaw's picker shows.
+ *   2. to seed the ClawBox AI row (see normalizeRow), for a box whose Hermes
+ *      config does not declare them yet.
+ *
+ * The SAME list `applyClawaiToHermes` writes into `providers.clawai.models`,
+ * imported rather than re-typed: that block is what Hermes' own pickers read,
+ * so a second spelling here would be the two surfaces disagreeing again.
  *
  * We deliberately do NOT ship guesses for providers we cannot query: the old
  * fallback listed OpenRouter slugs like "anthropic/claude-opus-4.8" which would
  * then be offered — and saved — under the direct Anthropic provider, i.e.
  * exactly the provider/model mismatch this module exists to stop.
  */
-const COLD_START_MODELS: Record<string, string[]> = {
-  [CLAWAI_PROVIDER]: ["deepseek-v4-flash", "deepseek-v4-pro"],
+const COLD_START_MODELS: Record<string, readonly string[]> = {
+  [CLAWAI_PROVIDER]: CLAWBOX_AI_CHAT_MODEL_IDS,
 };
 
 export type ModelOptionsSource = "dashboard" | "catalog-file" | "cold-start";
@@ -356,12 +360,14 @@ function normalizeRow(raw: DashboardProviderRow, localModelId: string): HermesPr
     });
   }
 
-  // ClawBox AI is a CUSTOM provider, so Hermes can only report what our own
-  // config declares — and that is a single id (`model.default`, the current
-  // tier's model). The product actually serves both tier models, which is why
-  // OpenClaw's chat header offers a model picker for it. Without this, the
-  // Hermes header hides the model pill entirely (it needs >1 option) and the
-  // two harnesses disagree about the same provider.
+  // ClawBox AI is a CUSTOM provider, so Hermes reports what our own config
+  // declares plus whatever `<base_url>/models` answers — and the proxy answers
+  // that probe in a shape Hermes cannot read, so on a box whose
+  // `providers.clawai.models` has not been written yet the row arrives EMPTY.
+  // `applyClawaiToHermes` is what writes it, and `reconcileClawaiModelsWithHermes`
+  // backfills a box linked before it did; this seed is the fallback for the
+  // window in between, not the source of truth. On a declared box every id is
+  // already in `seen` and the loop does nothing.
   //
   // Only ClawBox AI is seeded: these are ids we have PROVEN route on this
   // hardware. We never invent ids for a third-party provider — that is the

--- a/src/lib/yaml-block-edit.ts
+++ b/src/lib/yaml-block-edit.ts
@@ -17,7 +17,13 @@
  * construction — the output is the input with a known set of line splices.
  *
  * DELIBERATELY NOT A YAML LIBRARY. It understands block mappings of plain
- * scalars, which is what the keys ClawBox owns (`providers.*`, `model.*`) are.
+ * scalars, which is what the keys ClawBox SPLICES (`providers.<slug>.base_url`,
+ * `.api_key`, `.api_mode`, the single-id `providers.clawlocal.models`,
+ * `model.*`) are. Not every key ClawBox owns is one: `providers.clawai.models`
+ * is a LIST, written through `hermes config set` because a sequence is a shape
+ * this module raises on — so a caller adding a `providers.*` patch must check
+ * that the leaf it wants is a scalar first (see `localCatalogueState` in
+ * hermes-local-ai.ts for the read that does it).
  * Anything else on the path it is asked to touch — flow style, block scalars,
  * sequences, quoted or duplicate keys, tab indentation, multi-document files —
  * raises {@link YamlEditUnsupported} rather than guessing. Callers are expected

--- a/src/tests/helpers/hermes-picker-catalogue.ts
+++ b/src/tests/helpers/hermes-picker-catalogue.ts
@@ -97,6 +97,12 @@ export function modelsConfigIsAllowlist(value: unknown, discovered = false): boo
  * nothing to say (the local model asleep), `null` when it did not answer at
  * all. Merge rule: model_switch.py:3423-3431.
  *
+ * `null` IS ALSO HOW A DISCOVERY-OFF ENTRY IS ASKED. `_discovery_allowed`
+ * (model_switch.py:3788) gates the probe on `discover_models`, and this mirror
+ * does not model that gate — so an entry carrying `discover_models: false` must
+ * be handed `null`, never a list, or it would be told a probe won that Hermes
+ * would never have run.
+ *
  * ONE DISJUNCT OF THAT RULE IS DELIBERATELY NOT MODELLED. Hermes also lets an
  * EMPTY probe replace a declared allowlist when the probe is an
  * `_NativePickerModelList`, a Python subtype `string[] | null` cannot carry.

--- a/src/tests/helpers/hermes-picker-catalogue.ts
+++ b/src/tests/helpers/hermes-picker-catalogue.ts
@@ -1,0 +1,87 @@
+/**
+ * Hermes' own picker reader, mirrored — the contract every ClawBox writer of a
+ * `providers.<slug>` block has to satisfy.
+ *
+ * Hermes builds the Telegram/Discord `/model` keyboard AND its own dashboard's
+ * Models page from one substrate, `list_authenticated_providers`
+ * (hermes_cli/model_switch.py:2571, Hermes 0.20.5 as installed on a
+ * Hermes-edition box). For a custom OpenAI-compatible provider — which is what
+ * both ClawBox AI and the on-device model are — section 3 of that function
+ * builds the row's models from `default_model`/`model` plus the declared
+ * `models:`, then probes `<base_url>/models` and lets the probe REPLACE the
+ * declared list unless the declaration is allowlist-shaped and the probe came
+ * back empty.
+ *
+ * Kept small and in one place on purpose. It lives here rather than beside one
+ * writer because the clawai path declares a LIST through the CLI and the local
+ * path declares a STRING through the YAML splice, and the only thing that makes
+ * those two the same fix is that Hermes reads both — so both are judged by this
+ * one mirror. A mirror can only ever agree with the writer if the writer is
+ * what defines it; these three functions are transcribed from the Python, with
+ * the line numbers to check them against, and the shapes were confirmed against
+ * the installed interpreter on the box (`_declared_model_ids('qwen2.5:3b')` →
+ * `['qwen2.5:3b']`, allowlist `True`).
+ */
+
+/** `_declared_model_ids` — hermes_cli/model_switch.py:61. */
+export function declaredModelIds(value: unknown): string[] {
+  const ids: string[] = [];
+  const add = (candidate: unknown) => {
+    if (typeof candidate !== "string") return;
+    const id = candidate.trim();
+    if (!id || ids.some((seen) => seen.toLowerCase() === id.toLowerCase())) return;
+    ids.push(id);
+  };
+  if (typeof value === "string") add(value);
+  else if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === "string") add(item);
+      else if (item && typeof item === "object") {
+        const row = item as { id?: unknown; name?: unknown };
+        add(typeof row.id === "string" && row.id.trim() ? row.id : row.name);
+      }
+    }
+  } else if (value && typeof value === "object") {
+    // Hermes' own sentinels inside a mapping-shaped `models:` are not ids.
+    for (const key of Object.keys(value)) {
+      if (key === "__explicit_model_allowlist__" || key === "__discovered_model_catalog__") continue;
+      add(key);
+    }
+  }
+  return ids;
+}
+
+/**
+ * `_models_config_is_allowlist` — hermes_cli/model_switch.py:136.
+ *
+ * A mapping is per-model METADATA that Hermes itself wrote, never a user pin;
+ * a list or a bare string is an intentional narrow. That last clause is what
+ * the on-device model's single-scalar declaration rests on.
+ */
+export function modelsConfigIsAllowlist(value: unknown): boolean {
+  if (typeof value === "string") return Boolean(value.trim());
+  if (Array.isArray(value)) return declaredModelIds(value).length > 0;
+  return false;
+}
+
+/**
+ * The model ids Hermes' `/model` picker offers for one `providers:` entry.
+ *
+ * `liveProbe` is what `<base_url>/models` yielded: `[]` when the endpoint
+ * answered in a shape Hermes could not read (the ClawBox AI proxy) or had
+ * nothing to say (the local model asleep), `null` when it did not answer at
+ * all. Merge rule: model_switch.py:3423-3431.
+ */
+export function hermesPickerModels(
+  entry: Record<string, unknown>,
+  liveProbe: string[] | null,
+): string[] {
+  const declared = declaredModelIds(entry.models);
+  const fallbackDefault = entry.default_model ?? entry.model;
+  const models = typeof fallbackDefault === "string" && fallbackDefault.trim()
+    ? [fallbackDefault.trim(), ...declared.filter((id) => id !== fallbackDefault.trim())]
+    : declared;
+  const hasExplicitModels = modelsConfigIsAllowlist(entry.models);
+  if (liveProbe !== null && (liveProbe.length > 0 || !hasExplicitModels)) return liveProbe;
+  return models;
+}

--- a/src/tests/helpers/hermes-picker-catalogue.ts
+++ b/src/tests/helpers/hermes-picker-catalogue.ts
@@ -52,13 +52,38 @@ export function declaredModelIds(value: unknown): string[] {
 }
 
 /**
+ * `_entry_models_discovered` — hermes_cli/model_switch.py:117.
+ *
+ * A catalogue Hermes itself persisted after a successful probe, flagged either
+ * by the current entry-level `models_discovered: true` or by the older
+ * in-mapping `__discovered_model_catalog__` sentinel it still accepts on read.
+ */
+export function entryModelsDiscovered(entry: Record<string, unknown>): boolean {
+  if (entry.models_discovered === true) return true;
+  const models = entry.models;
+  return Boolean(
+    models
+    && typeof models === "object"
+    && !Array.isArray(models)
+    && (models as Record<string, unknown>).__discovered_model_catalog__ === true,
+  );
+}
+
+/**
  * `_models_config_is_allowlist` — hermes_cli/model_switch.py:136.
  *
  * A mapping is per-model METADATA that Hermes itself wrote, never a user pin;
  * a list or a bare string is an intentional narrow. That last clause is what
  * the on-device model's single-scalar declaration rests on.
+ *
+ * `discovered` forces False WHATEVER the shape: a catalogue Hermes persisted
+ * for itself is not the customer pinning anything. So a ClawBox writer that
+ * declared a perfectly good list beside a `models_discovered: true` it did not
+ * clear would still be overwritten by the next empty probe — which is why the
+ * flag belongs in the mirror rather than in a comment.
  */
-export function modelsConfigIsAllowlist(value: unknown): boolean {
+export function modelsConfigIsAllowlist(value: unknown, discovered = false): boolean {
+  if (discovered || value === null || value === undefined) return false;
   if (typeof value === "string") return Boolean(value.trim());
   if (Array.isArray(value)) return declaredModelIds(value).length > 0;
   return false;
@@ -71,6 +96,16 @@ export function modelsConfigIsAllowlist(value: unknown): boolean {
  * answered in a shape Hermes could not read (the ClawBox AI proxy) or had
  * nothing to say (the local model asleep), `null` when it did not answer at
  * all. Merge rule: model_switch.py:3423-3431.
+ *
+ * ONE DISJUNCT OF THAT RULE IS DELIBERATELY NOT MODELLED. Hermes also lets an
+ * EMPTY probe replace a declared allowlist when the probe is an
+ * `_NativePickerModelList`, a Python subtype `string[] | null` cannot carry.
+ * It is unreachable for both providers this mirror judges: that type is
+ * produced only on the Ollama-native branch of `_fetch_picker_live_models`
+ * (model_switch.py:325-334), which returns None early whenever
+ * `preserve_native_models` (= `has_explicit_models`) is true — so a ClawBox
+ * writer that declares an allowlist can never meet it. A writer for an
+ * Ollama-native endpoint would have to model it.
  */
 export function hermesPickerModels(
   entry: Record<string, unknown>,
@@ -81,7 +116,7 @@ export function hermesPickerModels(
   const models = typeof fallbackDefault === "string" && fallbackDefault.trim()
     ? [fallbackDefault.trim(), ...declared.filter((id) => id !== fallbackDefault.trim())]
     : declared;
-  const hasExplicitModels = modelsConfigIsAllowlist(entry.models);
+  const hasExplicitModels = modelsConfigIsAllowlist(entry.models, entryModelsDiscovered(entry));
   if (liveProbe !== null && (liveProbe.length > 0 || !hasExplicitModels)) return liveProbe;
   return models;
 }

--- a/src/tests/routes/hermes/models-refresh-auth.test.ts
+++ b/src/tests/routes/hermes/models-refresh-auth.test.ts
@@ -17,8 +17,19 @@ vi.mock("@/lib/hermes-model-options", async (importOriginal) => {
   return { ...actual, getModelOptions: getModelOptionsMock };
 });
 
+const reconcileLocalMock = vi.fn(async () => {});
+const reconcileClawaiMock = vi.fn(async () => {});
 vi.mock("@/lib/hermes-local-ai", () => ({
-  reconcileLocalAiWithHermes: vi.fn(async () => {}),
+  reconcileLocalAiWithHermes: reconcileLocalMock,
+}));
+vi.mock("@/lib/hermes-clawai", () => ({
+  reconcileClawaiModelsWithHermes: reconcileClawaiMock,
+}));
+
+const activeHarnessMock = vi.fn(async () => "hermes");
+vi.mock("@/lib/harness", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/harness")>()),
+  getActiveHarness: activeHarnessMock,
 }));
 
 vi.mock("@/lib/hermes-cli", () => ({
@@ -56,6 +67,10 @@ beforeEach(async () => {
   session = installSessionFixture();
   getModelOptionsMock.mockReset();
   getModelOptionsMock.mockResolvedValue(PAYLOAD);
+  reconcileLocalMock.mockClear();
+  reconcileClawaiMock.mockClear();
+  activeHarnessMock.mockReset();
+  activeHarnessMock.mockResolvedValue("hermes");
   vi.resetModules();
   ({ GET } = await import("@/app/setup-api/hermes/models/route"));
 });
@@ -93,6 +108,25 @@ describe("GET /setup-api/hermes/models", () => {
   it("does not honour ?refresh=1 on the scoped provider read either", async () => {
     await GET(request("?provider=anthropic&refresh=1", false));
     expect(getModelOptionsMock).toHaveBeenCalledWith({ refresh: false });
+  });
+
+  it("repairs the Hermes `providers:` block on a Hermes box", async () => {
+    await GET(request("", false));
+    expect(reconcileLocalMock).toHaveBeenCalled();
+    expect(reconcileClawaiMock).toHaveBeenCalled();
+  });
+
+  it("spawns no `hermes` repair on an OpenClaw box", async () => {
+    // Both repairs open with a `hermes` spawn, and an OpenClaw device has no
+    // binary to spawn and no `providers:` block to repair — the call would
+    // reject, be caught, logged and retried on the next request, forever. One
+    // gate at the call site, ahead of both, rather than two modules each
+    // assuming their own edition.
+    activeHarnessMock.mockResolvedValue("openclaw");
+    const res = await GET(request("", false));
+    expect(res.status).toBe(200);
+    expect(reconcileLocalMock).not.toHaveBeenCalled();
+    expect(reconcileClawaiMock).not.toHaveBeenCalled();
   });
 
   it("reports credential presence and verification as separate fields", async () => {

--- a/src/tests/unit/hermes-dashboard-turn-switch.test.ts
+++ b/src/tests/unit/hermes-dashboard-turn-switch.test.ts
@@ -280,8 +280,10 @@ describe("carrying the picked model onto a conversation already in progress", ()
     //
     // The real case is switching TO a user-defined provider: the switch
     // validates the model against the target provider's listing, and a
-    // `providers.<slug>` entry in config.yaml carries none. On this device that
-    // is `clawai` — the box default — so customers do reach it.
+    // `providers.<slug>` entry in config.yaml carried none until
+    // `applyClawaiToHermes` started declaring one. On this device that is
+    // `clawai` — the box default — so customers did reach it, and a box whose
+    // config predates that write still can.
     const { turn } = await connect(
       { sessionId: "20260823_185842_1eabd5", model: "deepseek-v4-flash", provider: "clawai" },
       { model: "gpt-5.6-sol", provider: "openai-codex" },

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -344,7 +344,8 @@ describe("reconciling an already-configured device", () => {
     await applyLocalAiToHermes({ provider: "ollama", model: "qwen3:8b" });
     expect(sets().some((kv) => kv.startsWith(`providers.${HERMES_LOCAL_PROVIDER}.models=`))).toBe(false);
 
-    vi.advanceTimersByTime(60_001);
+    // No clock advance: nothing FAILED here, the enable simply could not read
+    // the key, so the very next read must be allowed to repair it.
     registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: null });
     await reconcileLocalAiWithHermes();
     expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -227,6 +227,9 @@ describe("reconciling an already-configured device", () => {
   // between tests — only the behaviour each test needs is established here.
   beforeEach(() => {
     _resetLocalAiReconcileForTests();
+    // A FAILED attempt is held for a minute, so a test that proves a retry has
+    // to say how much later that retry is.
+    vi.useFakeTimers();
     patchMock.mockResolvedValue({ mode: "merge", backupPath: null });
     readMock.mockResolvedValue(null);
     getConfigMock.mockImplementation(async (key: string) => {
@@ -235,6 +238,10 @@ describe("reconciling an already-configured device", () => {
       if (key === "local_ai_model") return "ollama/qwen3:8b";
       return undefined;
     });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   /**
@@ -337,9 +344,49 @@ describe("reconciling an already-configured device", () => {
     await applyLocalAiToHermes({ provider: "ollama", model: "qwen3:8b" });
     expect(sets().some((kv) => kv.startsWith(`providers.${HERMES_LOCAL_PROVIDER}.models=`))).toBe(false);
 
+    vi.advanceTimersByTime(60_001);
     registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: null });
     await reconcileLocalAiWithHermes();
     expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);
+  });
+
+  it("does not re-ask on every request while the CLI keeps failing", async () => {
+    // Unlatching is what stops an update from skipping the repair; this is what
+    // stops it becoming a Python start per request. The route awaits this and
+    // the ClawBox AI repair before it serves anything, each read carrying a 15 s
+    // timeout, so an unbounded retry lands on every chat-header load.
+    cliMock.mockResolvedValue({ code: 127, stdout: "", stderr: "" });
+    await reconcileLocalAiWithHermes();
+    const afterFirst = cliMock.mock.calls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(30_000);
+    await reconcileLocalAiWithHermes();
+    await reconcileLocalAiWithHermes();
+    expect(cliMock.mock.calls.length).toBe(afterFirst);
+
+    vi.advanceTimersByTime(30_001);
+    await reconcileLocalAiWithHermes();
+    expect(cliMock.mock.calls.length).toBeGreaterThan(afterFirst);
+  });
+
+  it("refreshes a declared id this module wrote and no longer matches", async () => {
+    // "scalar" is the shape THIS module writes, so a scalar naming a model the
+    // box no longer runs is our own stale value — the picker would go on
+    // offering it. The enable path has always updated it; the repair only ever
+    // wrote a MISSING key, so a box whose model changed while the CLI was
+    // unreadable kept the old id for the life of that config.
+    readMock.mockResolvedValue("qwen3:4b");
+    registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: "qwen3:4b" });
+    await reconcileLocalAiWithHermes();
+    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);
+  });
+
+  it("leaves a declared id that already names the configured model", async () => {
+    readMock.mockResolvedValue("qwen3:8b");
+    registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: "qwen3:8b" });
+    await reconcileLocalAiWithHermes();
+    expect(patchMock).not.toHaveBeenCalled();
   });
 
   it("leaves a config it could not read alone", async () => {

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -31,6 +31,7 @@ vi.mock("@/lib/local-ai-runtime", () => ({
 const getConfigMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/config-store", () => ({ get: getConfigMock }));
 
+import { hermesPickerModels } from "@/tests/helpers/hermes-picker-catalogue";
 import {
   HERMES_LOCAL_PROVIDER,
   HermesLocalApplyError,
@@ -60,7 +61,12 @@ function unsets(): string[] {
 describe("registering the local model with Hermes", () => {
   beforeEach(() => {
     cliMock.mockReset();
-    cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    // `providers.clawlocal.models` absent — the state every device in the field
+    // is in, and the one the registration is allowed to write.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args?.[2] === `providers.${HERMES_LOCAL_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "config key not set" }
+        : { code: 0, stdout: "", stderr: "" });
     patchMock.mockReset();
     patchMock.mockResolvedValue({ mode: "merge", backupPath: null });
     readMock.mockReset();
@@ -88,6 +94,55 @@ describe("registering the local model with Hermes", () => {
     // still wins (model_switch.py:3423-3431).
     await applyLocalAiToHermes({ provider: "llamacpp", model: "gemma4-e2b-it-q4_0" });
     expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=gemma4-e2b-it-q4_0`);
+  });
+
+  it("declares it in a shape Hermes' own picker reads", async () => {
+    // The write above is only half the claim; this is the half that matters.
+    // A bare STRING has to count as an allowlist for Hermes, or the sleeping
+    // model's empty probe replaces it and the picker is empty again. Judged by
+    // the same mirror of `list_authenticated_providers` the ClawBox AI side is.
+    await applyLocalAiToHermes({ provider: "ollama", model: "qwen2.5:3b" });
+    const declared = patchMock.mock.calls[0][0].set[`providers.${HERMES_LOCAL_PROVIDER}.models`];
+    // `[]` is the sleeping model: standby answers no /v1/models at all.
+    expect(hermesPickerModels({ models: declared }, [])).toEqual(["qwen2.5:3b"]);
+    // Awake, whatever it is actually running still wins.
+    expect(hermesPickerModels({ models: declared }, ["qwen2.5:3b", "llama3.2:3b"]))
+      .toEqual(["qwen2.5:3b", "llama3.2:3b"]);
+  });
+
+  it("leaves a catalogue Hermes wrote itself alone", async () => {
+    // Hermes caches its own discovered catalogue under the same key, as a
+    // nested block. The comment-preserving splice refuses a leaf that opens
+    // one, and that refusal drops the WHOLE patch onto `hermes config set` —
+    // which deletes every comment in config.yaml. So the key is skipped, and
+    // the endpoint keys still land.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args?.[2] === `providers.${HERMES_LOCAL_PROVIDER}.models`
+        ? { code: 0, stdout: "{'qwen3:8b': {'context_length': 40960}}\n", stderr: "" }
+        : { code: 0, stdout: "", stderr: "" });
+    await applyLocalAiToHermes({ provider: "ollama", model: "qwen3:8b" });
+    expect(sets().some((kv) => kv.startsWith(`providers.${HERMES_LOCAL_PROVIDER}.models=`))).toBe(false);
+    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.api_mode=openai`);
+  });
+
+  it("updates the declared id when the local model changes", async () => {
+    // A scalar there is OUR shape, so it is ours to move — otherwise switching
+    // Gemma to Qwen leaves the picker offering the model that is gone.
+    readMock.mockImplementation(async (key: string) =>
+      key === `providers.${HERMES_LOCAL_PROVIDER}.models` ? "gemma4-e2b-it-q4_0" : null,
+    );
+    await applyLocalAiToHermes({ provider: "ollama", model: "qwen3:8b" });
+    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);
+  });
+
+  it("writes no catalogue when the CLI never answered", async () => {
+    // 127 is the shim over a rebuilding venv, not "the key is unset".
+    cliMock.mockImplementation(async (args: string[]) =>
+      args?.[2] === `providers.${HERMES_LOCAL_PROVIDER}.models`
+        ? { code: 127, stdout: "", stderr: "" }
+        : { code: 0, stdout: "", stderr: "" });
+    await applyLocalAiToHermes({ provider: "ollama", model: "qwen3:8b" });
+    expect(sets().some((kv) => kv.startsWith(`providers.${HERMES_LOCAL_PROVIDER}.models=`))).toBe(false);
   });
 
   it("uses the ollama proxy when ollama is the local provider", async () => {
@@ -241,7 +296,29 @@ describe("reconciling an already-configured device", () => {
     // asleep, which is most of the time.
     registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: null });
     await reconcileLocalAiWithHermes();
-    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);
+    expect(sets()).toEqual([`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`]);
+  });
+
+  it("repairs the catalogue WITHOUT re-registering the endpoint", async () => {
+    // Re-running the full apply would drag every field box down the path built
+    // for a stale self-written URL, and that path substitutes a llama.cpp
+    // default for an unreadable model id — which on this Ollama box would put
+    // `gemma4-e2b-it-q4_0` in the picker for an endpoint that cannot serve it.
+    registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: null });
+    await reconcileLocalAiWithHermes();
+    expect(sets().some((kv) => kv.startsWith(`providers.${HERMES_LOCAL_PROVIDER}.base_url=`))).toBe(false);
+  });
+
+  it("declares nothing when it does not know what the model is", async () => {
+    getConfigMock.mockImplementation(async (key: string) => {
+      if (key === "local_ai_configured") return true;
+      if (key === "local_ai_provider") return "ollama";
+      return undefined;
+    });
+    registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: null });
+    await reconcileLocalAiWithHermes();
+    // An id we do not have is a reason to write nothing, never to invent one.
+    expect(patchMock).not.toHaveBeenCalled();
   });
 
   it("leaves a config it could not read alone", async () => {

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -321,6 +321,27 @@ describe("reconciling an already-configured device", () => {
     expect(patchMock).not.toHaveBeenCalled();
   });
 
+  it("hands the catalogue back to the repair when an enable could not read it", async () => {
+    // The repair runs once per process. If it has already run — a settled box,
+    // nothing to do — and the customer THEN enables local AI while the CLI is
+    // mid-`step_hermes_install` rebuild, the enable rightly writes no `models`
+    // and the latched repair never asks again: the key stays missing until the
+    // web server restarts, on the one box that just asked for the feature.
+    registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1" });
+    await reconcileLocalAiWithHermes();
+
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${HERMES_LOCAL_PROVIDER}.models`
+        ? { code: 127, stdout: "", stderr: "" }
+        : { code: 0, stdout: "http://127.0.0.1/setup-api/local-ai/ollama/v1\n", stderr: "" });
+    await applyLocalAiToHermes({ provider: "ollama", model: "qwen3:8b" });
+    expect(sets().some((kv) => kv.startsWith(`providers.${HERMES_LOCAL_PROVIDER}.models=`))).toBe(false);
+
+    registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: null });
+    await reconcileLocalAiWithHermes();
+    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);
+  });
+
   it("leaves a config it could not read alone", async () => {
     // Unreadable is not unset: repairing off a failed read would overwrite
     // whatever is actually in the file.

--- a/src/tests/unit/hermes-local-ai.test.ts
+++ b/src/tests/unit/hermes-local-ai.test.ts
@@ -79,6 +79,17 @@ describe("registering the local model with Hermes", () => {
     expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.api_key=local-token-xyz`);
   });
 
+  it("declares the model so Hermes' own picker has one while it sleeps", async () => {
+    // Standby is the local model's normal resting state, and a sleeping model
+    // answers no /v1/models — so Hermes' `/model` keyboard (which builds its
+    // rows from the `providers:` block, hermes_cli/model_switch.py:3220) offers
+    // "clawlocal (0)" and the customer cannot select the one model they have.
+    // A declared id is what Hermes reads instead; a live probe that DOES answer
+    // still wins (model_switch.py:3423-3431).
+    await applyLocalAiToHermes({ provider: "llamacpp", model: "gemma4-e2b-it-q4_0" });
+    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=gemma4-e2b-it-q4_0`);
+  });
+
   it("uses the ollama proxy when ollama is the local provider", async () => {
     await applyLocalAiToHermes({ provider: "ollama", model: "llama3.2:3b" });
     expect(sets()).toContain(
@@ -122,10 +133,14 @@ describe("registering the local model with Hermes", () => {
 
   it("unregisters on disable so the picker stops offering a stopped model", async () => {
     await removeLocalAiFromHermes();
+    // `models` rides with the rest: left behind, it is a `providers.clawlocal`
+    // block with a model id and no endpoint, which Hermes still renders as a
+    // picker row — the dead-model-in-the-list state this removal exists to end.
     expect(unsets()).toEqual([
       `providers.${HERMES_LOCAL_PROVIDER}.base_url`,
       `providers.${HERMES_LOCAL_PROVIDER}.api_key`,
       `providers.${HERMES_LOCAL_PROVIDER}.api_mode`,
+      `providers.${HERMES_LOCAL_PROVIDER}.models`,
     ]);
   });
 
@@ -167,9 +182,25 @@ describe("reconciling an already-configured device", () => {
     });
   });
 
-  /** What `hermes config get providers.clawlocal.base_url` answers. */
+  /**
+   * What `hermes config get providers.clawlocal.<key>` answers. `models`
+   * defaults to "already declared" so each test states only the fact it is
+   * about.
+   */
+  function registered(opts: { baseUrl: string; models?: string | null }) {
+    const models = opts.models === undefined ? "qwen3:8b" : opts.models;
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[2] === `providers.${HERMES_LOCAL_PROVIDER}.models`) {
+        return models === null
+          ? { code: 1, stdout: "", stderr: "config key not set" }
+          : { code: 0, stdout: `${models}\n`, stderr: "" };
+      }
+      return { code: 0, stdout: `${opts.baseUrl}\n`, stderr: "" };
+    });
+  }
+
   function registeredBaseUrl(value: string) {
-    cliMock.mockResolvedValue({ code: 0, stdout: `${value}\n`, stderr: "" });
+    registered({ baseUrl: value });
   }
 
   it("re-registers a device that got the bare (pre-/v1) Ollama root", async () => {
@@ -202,5 +233,25 @@ describe("reconciling an already-configured device", () => {
     expect(sets()).toContain(
       `providers.${HERMES_LOCAL_PROVIDER}.base_url=http://127.0.0.1/setup-api/local-ai/ollama/v1`,
     );
+  });
+
+  it("declares the model on a device registered before the catalogue existed", async () => {
+    // The endpoint is right, so the old reconcile stopped here — and the box
+    // kept showing "clawlocal (0)" in Hermes' own picker whenever the model was
+    // asleep, which is most of the time.
+    registered({ baseUrl: "http://127.0.0.1/setup-api/local-ai/ollama/v1", models: null });
+    await reconcileLocalAiWithHermes();
+    expect(sets()).toContain(`providers.${HERMES_LOCAL_PROVIDER}.models=qwen3:8b`);
+  });
+
+  it("leaves a config it could not read alone", async () => {
+    // Unreadable is not unset: repairing off a failed read would overwrite
+    // whatever is actually in the file.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${HERMES_LOCAL_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "permission denied" }
+        : { code: 0, stdout: "http://127.0.0.1/setup-api/local-ai/ollama/v1\n", stderr: "" });
+    await reconcileLocalAiWithHermes();
+    expect(patchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/hermes-model-options-clawai-seed.test.ts
+++ b/src/tests/unit/hermes-model-options-clawai-seed.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The ClawBox AI seed in `normalizeRow` is a FALLBACK, never a top-up.
+ *
+ * Hermes reports a custom provider's models as whatever our own
+ * `providers.clawai.models` declares merged with whatever `<base_url>/models`
+ * answers, and the ClawBox AI proxy answers that probe in a shape Hermes cannot
+ * read — so on a box whose block has not been written yet the row arrives
+ * EMPTY, and our chat header would have no model pill at all. That is what the
+ * seed is for, and `applyClawaiToHermes` / `reconcileClawaiModelsWithHermes`
+ * are what make it unnecessary.
+ *
+ * The moment the row is NOT empty it must be left exactly as Hermes reported
+ * it: a renamed tier id, an owner's hand-pinned single model, or the proxy
+ * finally speaking the OpenAI envelope would each get our two ids appended to
+ * the live ones, and the picker would offer models the provider does not serve
+ * — the provider/model mismatch `hermes-model-options` exists to prevent.
+ */
+
+const dashboardFetchMock = vi.fn();
+const runHermesCliMock = vi.fn();
+const readFileMock = vi.fn();
+const configGetMock = vi.fn();
+
+vi.mock("@/lib/hermes-dashboard-auth", () => ({
+  dashboardFetch: dashboardFetchMock,
+  __esModule: true,
+}));
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: runHermesCliMock }));
+vi.mock("@/lib/config-store", () => ({ get: configGetMock }));
+vi.mock("fs/promises", () => ({
+  default: { readFile: readFileMock },
+  readFile: readFileMock,
+}));
+
+/** One clawai row, exactly as `/api/model/options` serves it. */
+function dashboardRow(models: string[]) {
+  dashboardFetchMock.mockResolvedValueOnce({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      providers: [{
+        slug: "clawai",
+        name: "ClawBox AI",
+        authenticated: true,
+        is_user_defined: true,
+        source: "config",
+        total_models: models.length,
+        models,
+      }],
+      provider: "clawai",
+      model: models[0] ?? "",
+    }),
+  });
+}
+
+describe("the ClawBox AI row our own picker builds", () => {
+  let mod: typeof import("@/lib/hermes-model-options");
+
+  beforeEach(async () => {
+    vi.resetModules();
+    dashboardFetchMock.mockReset();
+    runHermesCliMock.mockReset();
+    readFileMock.mockReset();
+    configGetMock.mockReset();
+    runHermesCliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    readFileMock.mockRejectedValue(new Error("no catalog on disk"));
+    configGetMock.mockResolvedValue(undefined);
+    mod = await import("@/lib/hermes-model-options");
+  });
+
+  it("seeds both tier models when Hermes reports the row empty", async () => {
+    dashboardRow([]);
+    const payload = await mod.getModelOptions();
+    const row = payload.providers.find((p) => p.id === "clawai");
+    expect(row?.models.map((m) => m.id)).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
+  });
+
+  it("leaves a non-empty row exactly as Hermes reported it", async () => {
+    // The box's owner pinned one id, so Hermes offers one id. Appending our
+    // two would put a model the owner deliberately removed back in the picker
+    // — and, on a box whose ids were renamed upstream, would offer two that no
+    // longer route at all.
+    dashboardRow(["deepseek-v4-flash"]);
+    const payload = await mod.getModelOptions();
+    const row = payload.providers.find((p) => p.id === "clawai");
+    expect(row?.models.map((m) => m.id)).toEqual(["deepseek-v4-flash"]);
+  });
+
+  it("does not invent our ids beside a live catalogue that renamed them", async () => {
+    dashboardRow(["deepseek-v5-flash", "deepseek-v5-pro"]);
+    const payload = await mod.getModelOptions();
+    const row = payload.providers.find((p) => p.id === "clawai");
+    expect(row?.models.map((m) => m.id)).toEqual(["deepseek-v5-flash", "deepseek-v5-pro"]);
+  });
+});

--- a/src/tests/unit/hermes-model-options-clawai-seed.test.ts
+++ b/src/tests/unit/hermes-model-options-clawai-seed.test.ts
@@ -34,6 +34,11 @@ vi.mock("fs/promises", () => ({
   readFile: readFileMock,
 }));
 
+// The ids are IMPORTED, never retyped: `CLAWBOX_AI_FLASH_MODEL_ID` and
+// `CLAWBOX_AI_PRO_MODEL_ID` are env-overridable (clawbox-ai-models.ts), so a
+// runner that sets either would fail a suite that spelled them out.
+import { CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID } from "@/lib/clawbox-ai-models";
+
 /** One clawai row, exactly as `/api/model/options` serves it. */
 function dashboardRow(models: string[]) {
   dashboardFetchMock.mockResolvedValueOnce({
@@ -74,7 +79,7 @@ describe("the ClawBox AI row our own picker builds", () => {
     dashboardRow([]);
     const payload = await mod.getModelOptions();
     const row = payload.providers.find((p) => p.id === "clawai");
-    expect(row?.models.map((m) => m.id)).toEqual(["deepseek-v4-flash", "deepseek-v4-pro"]);
+    expect(row?.models.map((m) => m.id)).toEqual([CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID]);
   });
 
   it("leaves a non-empty row exactly as Hermes reported it", async () => {
@@ -82,10 +87,10 @@ describe("the ClawBox AI row our own picker builds", () => {
     // two would put a model the owner deliberately removed back in the picker
     // — and, on a box whose ids were renamed upstream, would offer two that no
     // longer route at all.
-    dashboardRow(["deepseek-v4-flash"]);
+    dashboardRow([CLAWBOX_AI_FLASH_MODEL_ID]);
     const payload = await mod.getModelOptions();
     const row = payload.providers.find((p) => p.id === "clawai");
-    expect(row?.models.map((m) => m.id)).toEqual(["deepseek-v4-flash"]);
+    expect(row?.models.map((m) => m.id)).toEqual([CLAWBOX_AI_FLASH_MODEL_ID]);
   });
 
   it("does not invent our ids beside a live catalogue that renamed them", async () => {

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -60,67 +60,12 @@ import {
   reconcileClawaiModelsWithHermes,
   _resetClawaiModelsReconcileForTests,
 } from "@/lib/hermes-clawai";
+import { hermesPickerModels } from "@/tests/helpers/hermes-picker-catalogue";
 import {
   CLAWBOX_AI_FLASH_MODEL_ID,
   CLAWBOX_AI_PRO_MODEL_ID,
   CLAWBOX_AI_VISION_MODEL_ID,
 } from "@/lib/clawbox-ai-models";
-
-// ── Hermes' reader, mirrored ────────────────────────────────────────────────
-//
-// Small on purpose: it is the CONTRACT the writer has to satisfy, pinned so a
-// change of shape (a comma-joined string, a list of objects, a bare default)
-// fails here rather than on a customer's phone.
-
-/** `_declared_model_ids` — hermes_cli/model_switch.py:61. */
-function declaredModelIds(value: unknown): string[] {
-  const ids: string[] = [];
-  const add = (candidate: unknown) => {
-    if (typeof candidate !== "string") return;
-    const id = candidate.trim();
-    if (!id || ids.some((seen) => seen.toLowerCase() === id.toLowerCase())) return;
-    ids.push(id);
-  };
-  if (typeof value === "string") add(value);
-  else if (Array.isArray(value)) {
-    for (const item of value) {
-      if (typeof item === "string") add(item);
-      else if (item && typeof item === "object") {
-        const row = item as { id?: unknown; name?: unknown };
-        add(typeof row.id === "string" && row.id.trim() ? row.id : row.name);
-      }
-    }
-  } else if (value && typeof value === "object") {
-    for (const key of Object.keys(value)) {
-      if (key === "__explicit_model_allowlist__" || key === "__discovered_model_catalog__") continue;
-      add(key);
-    }
-  }
-  return ids;
-}
-
-/** `_models_config_is_allowlist` — hermes_cli/model_switch.py:136. */
-function modelsConfigIsAllowlist(value: unknown): boolean {
-  if (typeof value === "string") return Boolean(value.trim());
-  if (Array.isArray(value)) return declaredModelIds(value).length > 0;
-  return false;
-}
-
-/**
- * The model ids Hermes' `/model` picker offers for one `providers:` entry.
- * `liveProbe` is what `<base_url>/models` yielded — `[]` when the endpoint
- * answered in a shape Hermes could not read, `null` when it did not answer.
- */
-function hermesPickerModels(entry: Record<string, unknown>, liveProbe: string[] | null): string[] {
-  const declared = declaredModelIds(entry.models);
-  const fallbackDefault = entry.default_model ?? entry.model;
-  const models = typeof fallbackDefault === "string" && fallbackDefault.trim()
-    ? [fallbackDefault.trim(), ...declared.filter((id) => id !== fallbackDefault.trim())]
-    : declared;
-  const hasExplicitModels = modelsConfigIsAllowlist(entry.models);
-  if (liveProbe !== null && (liveProbe.length > 0 || !hasExplicitModels)) return liveProbe;
-  return models;
-}
 
 /**
  * The `providers.<slug>` block the writer left behind, decoded the way
@@ -239,11 +184,52 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
   });
 
-  it("writes nothing when the config could not be read at all", async () => {
+  it("writes nothing when the catalogue key could not be read", async () => {
     // An unreadable config is not an unconfigured one — the same rule the
-    // plugins.enabled read-modify-write follows.
-    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "permission denied" });
+    // plugins.enabled read-modify-write follows. The provider block is
+    // deliberately readable here, so this can only pass through the gate it is
+    // named after rather than through the "no clawai block" one above.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "permission denied" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
     await reconcileClawaiModelsWithHermes();
     expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+  });
+
+  it("tries again after a read the CLI never answered", async () => {
+    // `hermes` is a shim over a venv Python, and `step_hermes_install` rebuilds
+    // that checkout for ~90 s with no web-server restart — the shim runs and
+    // exits 127 without reaching argparse. Latching on that would skip the
+    // repair for the life of the process, on the very update shipping it.
+    cliMock.mockResolvedValue({ code: 127, stdout: "", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+
+    cliMock.mockReset();
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "config key not set" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("tries again after a write that failed", async () => {
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "set") return { code: 1, stdout: "", stderr: "config is locked" };
+      return args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "config key not set" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
+    });
+    await reconcileClawaiModelsWithHermes();
+    const firstAttempt = cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
+    await reconcileClawaiModelsWithHermes();
+    // A failed repair is not a repair: the next request must try it again.
+    expect(cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length)
+      .toBeGreaterThan(firstAttempt);
   });
 });

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -135,7 +135,11 @@ describe("what Hermes' own /model picker knows about ClawBox AI", () => {
     // again. Not reachable for `providers.clawai` today — Hermes writes that
     // flag only into `custom_providers` entries
     // (`_save_discovered_models_to_config`, model_switch.py:244) — so a writer
-    // that ever meets it has to CLEAR it, not just declare beside it.
+    // that meets it while discovery is ON has to CLEAR it, not just declare
+    // beside it. With discovery OFF no probe runs and the declaration stands
+    // whatever the flag says, which is the one case the clawai repair writes
+    // into; see the branch in `clawaiCatalogueVerdict` for the limit that
+    // leaves.
     const declared = { models: [CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID] };
     expect(hermesPickerModels(declared, [])).toEqual([
       CLAWBOX_AI_FLASH_MODEL_ID,
@@ -249,14 +253,22 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     // means anything to Hermes. Reading the entry answers both AND carries the
     // `base_url` the orphan guard needs, so it also costs one Python start
     // instead of two.
+    //
+    // The WHOLE sequence, not just the deciding read: this is also what bounds
+    // the repair's total spawns, and `--json` on the verification read is
+    // load-bearing in the same way it is on the deciding one — without it the
+    // CLI renders the list through `yaml.safe_dump` and the guard would report
+    // "could not declare" over a write that landed.
     providerBlock(LINKED);
     await reconcileClawaiModelsWithHermes();
-    // Everything BEFORE the write, which is what "decide in one Python start"
-    // means. The write is verified by a read of its own key afterwards — see
-    // the silent-stored-as-text test — and that one is a different question.
-    const args = cliMock.mock.calls.map((c) => c[0] as string[]);
-    const deciding = args.slice(0, args.findIndex((a) => a[1] === "set"));
-    expect(deciding).toEqual([["config", "get", `providers.${CLAWAI_PROVIDER}`, "--json"]]);
+    expect(cliMock.mock.calls.map((c) => c[0] as string[])).toEqual([
+      ["config", "get", `providers.${CLAWAI_PROVIDER}`, "--json"],
+      ["config", "set", `providers.${CLAWAI_PROVIDER}.models`, JSON.stringify([
+        CLAWBOX_AI_FLASH_MODEL_ID,
+        CLAWBOX_AI_PRO_MODEL_ID,
+      ])],
+      ["config", "get", `providers.${CLAWAI_PROVIDER}.models`, "--json"],
+    ]);
   });
 
   it("asks the CLI for the catalogue as JSON", async () => {
@@ -432,11 +444,17 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     // Not claimed: the catalogue cache is only dropped for a write that landed.
     expect(invalidateMock).not.toHaveBeenCalled();
 
+    // Nor retried. This CLI parsed a CONSTANT literal and did not get a list,
+    // so it will parse it the same way every 60 s for the life of the process —
+    // and each attempt re-serialises the customer's config.yaml through
+    // `save_config` for nothing. A failure we have PROVED is final stays
+    // latched; the next process start tries once more, because the residue is
+    // still in the file for the deciding read to find.
     const firstAttempt = cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
     vi.advanceTimersByTime(60_001);
     await reconcileClawaiModelsWithHermes();
     expect(cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length)
-      .toBeGreaterThan(firstAttempt);
+      .toBe(firstAttempt);
   });
 
   it("does not claim a repair the CLI stored as text without saying so", async () => {
@@ -454,6 +472,37 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
       // Not claimed: the catalogue cache is only dropped for a write that landed.
       expect(invalidateMock).not.toHaveBeenCalled();
       expect(warn.mock.calls.flat().map(String).join(" ")).toContain("could not declare");
+
+      // And not retried, for the same reason the warning branch is not: the
+      // read-back handed our own literal back, which is proof the write cannot
+      // land on this CLI rather than a transient failure.
+      const firstAttempt = setCount();
+      vi.advanceTimersByTime(60_001);
+      await reconcileClawaiModelsWithHermes();
+      expect(setCount()).toBe(firstAttempt);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("tries again when the write could not be VERIFIED rather than proved wrong", async () => {
+    // The other half of the same guard. A verification that did not answer —
+    // a wedged `hermes`, a `--json` this build rejects, a decorated stdout —
+    // says nothing about the write, so it is not proof of anything and the
+    // ordinary 60 s cadence applies. Only a value handed back as our own
+    // literal is final.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const setCount = () => cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
+    try {
+      cliMock.mockImplementation(async (args: string[]) => {
+        if (args[2] === `providers.${CLAWAI_PROVIDER}.models` && args[1] === "get") {
+          return { code: 2, stdout: "", stderr: "unrecognized arguments: --json" };
+        }
+        if (args[1] === "set") return { code: 0, stdout: "", stderr: "" };
+        return { code: 0, stdout: `${JSON.stringify(LINKED)}\n`, stderr: "" };
+      });
+      await reconcileClawaiModelsWithHermes();
+      expect(invalidateMock).not.toHaveBeenCalled();
 
       const firstAttempt = setCount();
       vi.advanceTimersByTime(60_001);

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -37,7 +37,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const cliMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
-vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+const invalidateMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: invalidateMock }));
 vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
 vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
 vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
@@ -159,6 +160,7 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     _resetClawaiModelsReconcileForTests();
     cliMock.mockReset();
     cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    invalidateMock.mockClear();
     // The repair holds a FAILED attempt for a minute, so a test that proves a
     // retry has to say how much later that retry is.
     vi.useFakeTimers();
@@ -296,6 +298,104 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
       CLAWBOX_AI_FLASH_MODEL_ID,
       CLAWBOX_AI_PRO_MODEL_ID,
     ]);
+  });
+
+  it("declares a catalogue for a pin that pins nothing", async () => {
+    // `discover_models: false` with NO `models:` is not a pin — there is
+    // nothing there to honour. Hermes takes `_discovery_allowed = false`
+    // (model_switch.py:3788), runs no probe, and `_declared_model_ids` finds no
+    // id, so the row is EMPTY: the exact "clawai (0)" this PR exists to fix,
+    // reached by the one path that used to walk away logging "pinned".
+    providerBlock({ ...LINKED, discover_models: false });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("declares a catalogue for a pin holding an empty list", async () => {
+    // Same hole, the other spelling.
+    providerBlock({ ...LINKED, discover_models: false, models: [] });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("still honours a pin that actually pins something", async () => {
+    // The boundary the two above must not move: with discovery off AND ids
+    // present, `_declared_model_ids` reads even a mapping's keys, so the
+    // keyboard shows them and this owner has nothing wrong with their box.
+    providerBlock({
+      ...LINKED,
+      discover_models: false,
+      models: { [CLAWBOX_AI_FLASH_MODEL_ID]: { context_length: 65536 } },
+    });
+    await reconcileClawaiModelsWithHermes();
+    expect(wrote()).toBe(false);
+  });
+
+  it("reads `discover_models` exactly as Hermes coerces it", async () => {
+    // Hermes does a bare `discover.lower() not in {"false","no","0"}`
+    // (model_switch.py:3371 and :3603) — no trim. So a quoted " false " is
+    // discovery ON to Hermes, which means the empty probe wipes the block and
+    // the repair is needed. A mirror that trimmed would decline to touch it.
+    providerBlock({
+      ...LINKED,
+      discover_models: " false ",
+      models: { [CLAWBOX_AI_FLASH_MODEL_ID]: { context_length: 65536 } },
+    });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("says so when the block carries no endpoint", async () => {
+    // A `providers.clawai` with no `base_url` is not an ordinary box — it is an
+    // invalid state — so unlike the two ordinary verdicts it earns a line. The
+    // line names the provider and nothing else: the block it came from carries
+    // `api_key`.
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      providerBlock({ api_mode: "openai" });
+      await reconcileClawaiModelsWithHermes();
+      expect(wrote()).toBe(false);
+      expect(log).toHaveBeenCalled();
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  it("treats a write the CLI stored as a STRING as a failure", async () => {
+    // `hermes config set k '["a","b"]'` exits 0 EVEN WHEN its structured parse
+    // did not yield a list — it prints `…storing as string.` to stderr and
+    // saves the literal text (hermes_cli/config.py:5518-5530). Hermes then
+    // reads that string as a one-id allowlist and the keyboard offers a single
+    // bogus model. An exit code is not an outcome.
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "set") {
+        return {
+          code: 0,
+          stdout: "",
+          stderr: "Warning: value for 'providers.clawai.models' looks like a"
+            + " list/mapping but parsed as str; storing as string.",
+        };
+      }
+      return { code: 0, stdout: `${JSON.stringify(LINKED)}\n`, stderr: "" };
+    });
+    await reconcileClawaiModelsWithHermes();
+    // Not claimed: the catalogue cache is only dropped for a write that landed.
+    expect(invalidateMock).not.toHaveBeenCalled();
+
+    const firstAttempt = cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
+    vi.advanceTimersByTime(60_001);
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length)
+      .toBeGreaterThan(firstAttempt);
   });
 
   it("declares the catalogue over an empty list", async () => {

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -485,29 +485,153 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     }
   });
 
-  it("tries again when the write could not be VERIFIED rather than proved wrong", async () => {
-    // The other half of the same guard. A verification that did not answer —
-    // a wedged `hermes`, a `--json` this build rejects, a decorated stdout —
-    // says nothing about the write, so it is not proof of anything and the
-    // ordinary 60 s cadence applies. Only a value handed back as our own
-    // literal is final.
+  it("stops re-declaring after a bounded number of writes it cannot read back", async () => {
+    // THE RATE BOUND IS NOT A BOUND. `REPAIR_RETRY_MS` says how OFTEN a failed
+    // repair may run again; nothing said how MANY times. A `hermes config set`
+    // that exits 0 without the key landing — a config.yaml the web-server user
+    // cannot write, a full partition, a `save_config` that loses a filelock
+    // race, a refusal that still exits 0 — is a permanent property of that box,
+    // and it reads back exactly like an absent key.
+    //
+    // MEASURED ON THE BOX: `hermes config get providers.clawai.models --json`
+    // exits 1 with `Config key not set: providers.clawai.models` when the key
+    // is not there. So this fixture is the field shape, not an invention: the
+    // deciding read keeps answering "write", the verifying read keeps answering
+    // "not set", and without a TOTAL bound that is one customer config.yaml
+    // rewrite plus three Python starts every 60 s for the life of the web
+    // server — on `GET /setup-api/hermes/models`, which AWAITS this repair
+    // before it serves the chat header, the Settings panel or the agent's own
+    // `ai_list_models`.
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const setCount = () => cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
     try {
+      // A CLI that takes the write, exits 0, and persists nothing.
       cliMock.mockImplementation(async (args: string[]) => {
-        if (args[2] === `providers.${CLAWAI_PROVIDER}.models` && args[1] === "get") {
-          return { code: 2, stdout: "", stderr: "unrecognized arguments: --json" };
+        const [, verb, key] = args;
+        if (verb === "set") return { code: 0, stdout: "", stderr: "" };
+        if (verb === "get" && key === `providers.${CLAWAI_PROVIDER}`) {
+          return { code: 0, stdout: `${JSON.stringify(LINKED)}\n`, stderr: "" };
         }
-        if (args[1] === "set") return { code: 0, stdout: "", stderr: "" };
-        return { code: 0, stdout: `${JSON.stringify(LINKED)}\n`, stderr: "" };
+        return { code: 1, stdout: "", stderr: `Config key not set: ${key}` };
       });
-      await reconcileClawaiModelsWithHermes();
+      for (let minute = 0; minute < 10; minute += 1) {
+        await reconcileClawaiModelsWithHermes();
+        vi.advanceTimersByTime(60_001);
+      }
+      // Never claimed, in any of them.
       expect(invalidateMock).not.toHaveBeenCalled();
+      // And the tenth minute costs nothing: three writes nobody could read back
+      // have proved as much as one whose literal came back as text.
+      expect(setCount()).toBeLessThanOrEqual(3);
+      const journal = warn.mock.calls.flat().map(String).join(" ");
+      // Said ONCE, and distinctly — a box that has stopped trying must not look
+      // like one that is still trying.
+      expect(journal).toContain("giving up");
+      // With the cause of the LAST read, not a bare assertion that it did not
+      // read back: the exit code and the CLI's own first line.
+      expect(journal).toContain("exit 1");
+      expect(journal).toContain("Config key not set");
+    } finally {
+      warn.mockRestore();
+    }
+  });
 
-      const firstAttempt = setCount();
+  it("does not spend an attempt on a write that never reached argparse", async () => {
+    // 126 and 127 are the SHELL's codes, not the CLI's. `hermes` is a shim over
+    // a venv Python and `step_hermes_install` rebuilds it for about 90 s with
+    // NO web-server restart, so the shim runs and exits 127 without argparse
+    // ever seeing the key: nothing was parsed, nothing was written and no
+    // config.yaml was re-serialised. Counting that against the three attempts
+    // would spend the whole budget on the very transient the unlatch exists
+    // for — and the box would come out of its own update still saying
+    // "clawai (0)".
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      let rebuilding = true;
+      providerBlock(LINKED);
+      const cli = cliMock.getMockImplementation()!;
+      cliMock.mockImplementation(async (args: string[]) => {
+        // The deciding read still answers — the shim is only unlucky on the
+        // write. A CLI that is wedged for BOTH answers "retry" and issues no
+        // write at all.
+        if (rebuilding && args[1] === "set") return { code: 127, stdout: "", stderr: "" };
+        return cli(args);
+      });
+      for (let minute = 0; minute < 5; minute += 1) {
+        await reconcileClawaiModelsWithHermes();
+        vi.advanceTimersByTime(60_001);
+      }
+      expect(warn.mock.calls.flat().map(String).join(" ")).not.toContain("giving up");
+
+      // The rebuild finished. The box still gets its catalogue, which is the
+      // whole reason a failed question unlatches.
+      rebuilding = false;
+      await reconcileClawaiModelsWithHermes();
+      expect(invalidateMock).toHaveBeenCalled();
+      expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+        CLAWBOX_AI_FLASH_MODEL_ID,
+        CLAWBOX_AI_PRO_MODEL_ID,
+      ]);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("tries again when the write could not be VERIFIED rather than proved wrong", async () => {
+    // The other half of the same guard. A verification that did not ANSWER says
+    // nothing about the write, so it is not proof of anything: the repair stays
+    // unlatched and the next request looks again.
+    //
+    // LEAF-ONLY BY CAUSE, NOT BY ARGUMENT SHAPE, and the difference matters —
+    // an earlier version of this test used "a `--json` this build rejects",
+    // which cannot happen. `config get` is ONE argparse sub-command: a build
+    // that rejected the flag on the leaf would have rejected it on the block
+    // read first, and that answers "retry" with no write issued at all.
+    // (Measured on the box: the leaf form takes `--json`, and exits 1
+    // `Config key not set` when the key is absent.) A 15 s timeout IS per-call
+    // — `runHermesCli` rejects, and the deciding read a moment earlier answered
+    // fine — so that is what a transient verification failure really looks
+    // like: a filelock held by an interactive CLI, a box under load.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const setCount = () => cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
+    const decidingReads = () => cliMock.mock.calls
+      .map((c) => c[0] as string[])
+      .filter((args) => args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}`)
+      .length;
+    try {
+      let readBackTimesOut = true;
+      providerBlock(LINKED);
+      const cli = cliMock.getMockImplementation()!;
+      cliMock.mockImplementation(async (args: string[]) => {
+        const [, verb, key] = args;
+        if (readBackTimesOut && verb === "get" && key === `providers.${CLAWAI_PROVIDER}.models`) {
+          throw new Error("hermes timed out");
+        }
+        return cli(args);
+      });
+
+      await reconcileClawaiModelsWithHermes();
+      // Nothing is claimed over a question that failed — and nothing is thrown
+      // over it either: the reject is caught inside the verification, so the
+      // caller's own catch never logs "reconcile failed" over a write that
+      // landed.
+      expect(invalidateMock).not.toHaveBeenCalled();
+      expect(setCount()).toBe(1);
+      expect(warn.mock.calls.flat().map(String).join(" ")).toContain("could not be verified");
+
+      // Not latched: the next request asks again.
+      readBackTimesOut = false;
       vi.advanceTimersByTime(60_001);
       await reconcileClawaiModelsWithHermes();
-      expect(setCount()).toBeGreaterThan(firstAttempt);
+      expect(decidingReads()).toBe(2);
+      // And what it finds is the write that DID land while the answer was lost,
+      // so it declares nothing a second time. An unverified write costs another
+      // question, not another rewrite of the customer's config.yaml.
+      expect(setCount()).toBe(1);
+      expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+        CLAWBOX_AI_FLASH_MODEL_ID,
+        CLAWBOX_AI_PRO_MODEL_ID,
+      ]);
     } finally {
       warn.mockRestore();
     }

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
  * What HERMES itself knows about the models a ClawBox-owned provider serves.
@@ -159,98 +159,138 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     _resetClawaiModelsReconcileForTests();
     cliMock.mockReset();
     cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    // The repair holds a FAILED attempt for a minute, so a test that proves a
+    // retry has to say how much later that retry is.
+    vi.useFakeTimers();
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** The `providers.clawai` block this box has, as the CLI would print it. */
+  const LINKED = {
+    base_url: "https://clawbox.com/api/ai",
+    api_key: "claw_token_abc",
+    api_mode: "openai",
+  };
+
+  /**
+   * What `hermes config get providers.clawai --json` answers here.
+   *
+   * ONE read of the whole block, because Hermes decides what `models:` means
+   * from its siblings — `discover_models` and `models_discovered` — and the
+   * `base_url` orphan guard needs the same entry.
+   */
+  function providerBlock(
+    entry: Record<string, unknown> | null,
+    failure: { code?: number; stderr?: string } = {},
+  ) {
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}`) {
+        return entry
+          ? { code: 0, stdout: `${JSON.stringify(entry)}\n`, stderr: "" }
+          : { code: failure.code ?? 1, stdout: "", stderr: failure.stderr ?? "config key not set" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+  }
+
+  const wrote = () => cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set");
 
   it("backfills a box that was linked before the catalogue was declared", async () => {
     // Every box in the field is in this state: `providers.clawai` has the URL,
     // the key and the mode, and no `models:` at all. Nothing re-links it, so
     // without a repair the bot keeps saying "clawai (0)" forever.
-    cliMock.mockImplementation(async (args: string[]) => {
-      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.base_url`) {
-        return { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
-      }
-      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.models`) {
-        return { code: 1, stdout: "", stderr: "config key not set" };
-      }
-      return { code: 0, stdout: "", stderr: "" };
-    });
+    providerBlock(LINKED);
     await reconcileClawaiModelsWithHermes();
     expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
       CLAWBOX_AI_FLASH_MODEL_ID,
       CLAWBOX_AI_PRO_MODEL_ID,
     ]);
+  });
+
+  it("asks for the whole provider block in one call", async () => {
+    // Not tidiness: reading the `models` LEAF cannot see `discover_models` or
+    // `models_discovered`, which are what decide whether the value beside them
+    // means anything to Hermes. Reading the entry answers both AND carries the
+    // `base_url` the orphan guard needs, so it also costs one Python start
+    // instead of two.
+    providerBlock(LINKED);
+    await reconcileClawaiModelsWithHermes();
+    const reads = cliMock.mock.calls
+      .map((c) => c[0] as string[])
+      .filter((args) => args[1] === "get");
+    expect(reads).toEqual([["config", "get", `providers.${CLAWAI_PROVIDER}`, "--json"]]);
+  });
+
+  it("asks the CLI for the catalogue as JSON", async () => {
+    // Not a style choice. Plain `hermes config get` renders a block through
+    // `yaml.safe_dump` and a bare string through `str()`
+    // (`_format_config_get_value`, hermes_cli/config.py:1203), so a declared
+    // list, a metadata mapping and a scalar id arrive as text only a YAML
+    // reader could separate — and telling them apart is the whole of this
+    // repair. `--json` is the CLI's own machine-readable mode
+    // (`hermes config get <key> [--json]`, config.py:5769).
+    providerBlock(LINKED);
+    await reconcileClawaiModelsWithHermes();
+    const read = cliMock.mock.calls
+      .map((c) => c[0] as string[])
+      .find((args) => args[1] === "get");
+    expect(read).toContain("--json");
   });
 
   it("leaves a catalogue that is already there alone", async () => {
-    cliMock.mockImplementation(async (args: string[]) => {
-      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.base_url`) {
-        return { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
-      }
-      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.models`) {
-        return { code: 0, stdout: '["deepseek-v4-flash", "deepseek-v4-pro"]\n', stderr: "" };
-      }
-      return { code: 0, stdout: "", stderr: "" };
+    providerBlock({ ...LINKED, models: [CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID] });
+    await reconcileClawaiModelsWithHermes();
+    expect(wrote()).toBe(false);
+  });
+
+  it("leaves a single id the owner pinned by hand alone", async () => {
+    // A bare string IS an allowlist as far as Hermes is concerned, so this box
+    // offers exactly what its owner asked for. Widening it back to both tiers
+    // would be this repair overruling a deliberate configuration.
+    providerBlock({ ...LINKED, models: CLAWBOX_AI_FLASH_MODEL_ID });
+    await reconcileClawaiModelsWithHermes();
+    expect(wrote()).toBe(false);
+  });
+
+  it("leaves a catalogue the owner pinned with discover_models: false alone", async () => {
+    // The one shape that looks broken and is not. `discover_models: false` is
+    // Hermes' documented way to pin a catalogue of ANY shape
+    // (model_switch.py:3777), and with discovery off no probe runs — so the
+    // mapping IS what the keyboard shows and this owner has no symptom at all.
+    // Overwriting it would drop their per-model metadata to fix nothing.
+    providerBlock({
+      ...LINKED,
+      discover_models: false,
+      models: { [CLAWBOX_AI_FLASH_MODEL_ID]: { context_length: 65536 } },
     });
     await reconcileClawaiModelsWithHermes();
-    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+    expect(wrote()).toBe(false);
   });
 
-  it("writes nothing on a box that has no ClawBox AI provider block", async () => {
-    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "config key not set" });
+  it("leaves a catalogue Hermes persisted for itself alone", async () => {
+    // `models_discovered: true` makes `_models_config_is_allowlist` return
+    // False WHATEVER the shape (model_switch.py:136), so our list would be
+    // ignored with it — writing here would latch "repaired" over a keyboard
+    // still saying "clawai (0)".
+    providerBlock({
+      ...LINKED,
+      models_discovered: true,
+      models: { [CLAWBOX_AI_FLASH_MODEL_ID]: { context_length: 65536 } },
+    });
     await reconcileClawaiModelsWithHermes();
-    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
-  });
-
-  it("writes nothing when the catalogue key could not be read", async () => {
-    // An unreadable config is not an unconfigured one — the same rule the
-    // plugins.enabled read-modify-write follows. The provider block is
-    // deliberately readable here, so this can only pass through the gate it is
-    // named after rather than through the "no clawai block" one above.
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 1, stdout: "", stderr: "permission denied" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
-    await reconcileClawaiModelsWithHermes();
-    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
-  });
-
-  it("tries again after a catalogue read that FAILED rather than answered", async () => {
-    // A non-zero exit whose message is not "config key not set" is not the
-    // answer "no key here" — it is an unreadable config: an EACCES on
-    // config.yaml, Hermes' own filelock held by an interactive CLI, a parse
-    // error. Leaving the file alone is right; latching is not, and it is the
-    // same probe-once trap the branch above already fixed. `localCatalogueState`
-    // maps this identical result to "unknown" and retries; so must this.
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 1, stdout: "", stderr: "permission denied" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
-    await reconcileClawaiModelsWithHermes();
-    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
-
-    cliMock.mockReset();
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 1, stdout: "", stderr: "config key not set" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
-    await reconcileClawaiModelsWithHermes();
-    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
-      CLAWBOX_AI_FLASH_MODEL_ID,
-      CLAWBOX_AI_PRO_MODEL_ID,
-    ]);
+    expect(wrote()).toBe(false);
   });
 
   it("declares the catalogue over a value Hermes does not read as an allowlist", async () => {
-    // `providers.clawai.models` present as a MAPPING — the per-model metadata
-    // shape Hermes' own model wizard writes. `_models_config_is_allowlist`
-    // (model_switch.py:136) returns False for a mapping, so `has_explicit_models`
-    // stays false, the empty probe REPLACES it (model_switch.py:3423-3431) and
-    // the keyboard says "clawai (0)". A key that exists is not a key Hermes
-    // reads: the repair has to look at the value.
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 0, stdout: '{"deepseek-v4-flash": {"context_length": 65536}}\n', stderr: "" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    // The same mapping WITHOUT a pin beside it. `_models_config_is_allowlist`
+    // returns False for a mapping, so `has_explicit_models` stays false, the
+    // empty probe REPLACES it (model_switch.py:3423-3431) and the keyboard says
+    // "clawai (0)" — with a populated `models:` in the file. A key that exists
+    // is not a key Hermes reads.
+    providerBlock({ ...LINKED, models: { [CLAWBOX_AI_FLASH_MODEL_ID]: { context_length: 65536 } } });
     await reconcileClawaiModelsWithHermes();
     expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
       CLAWBOX_AI_FLASH_MODEL_ID,
@@ -259,13 +299,9 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
   });
 
   it("declares the catalogue over an empty list", async () => {
-    // Same rule, the other unusable shape: `_models_config_is_allowlist`
-    // requires at least one id, so `models: []` leaves the probe free to win
-    // with nothing.
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 0, stdout: "[]\n", stderr: "" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    // Same rule, the other unusable shape: an allowlist needs at least one id,
+    // so `models: []` leaves the probe free to win with nothing.
+    providerBlock({ ...LINKED, models: [] });
     await reconcileClawaiModelsWithHermes();
     expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
       CLAWBOX_AI_FLASH_MODEL_ID,
@@ -273,36 +309,45 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     ]);
   });
 
-  it("leaves a single id the owner pinned by hand alone", async () => {
-    // A bare string IS an allowlist as far as Hermes is concerned, so this box
-    // offers exactly what its owner asked for. Widening it back to both tiers
-    // would be this repair overruling a deliberate configuration.
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 0, stdout: '"deepseek-v4-flash"\n', stderr: "" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+  it("writes nothing on a box that has no ClawBox AI provider block", async () => {
+    // `models:` beside no endpoint is a picker row offering two models with
+    // nowhere to send them — the orphan the local provider's removal avoids.
+    providerBlock(null);
     await reconcileClawaiModelsWithHermes();
-    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+    expect(wrote()).toBe(false);
   });
 
-  it("asks the CLI for the catalogue as JSON", async () => {
-    // Not a style choice. Plain `hermes config get` renders a list or a mapping
-    // through `yaml.safe_dump` (hermes_cli/config.py:1203,
-    // `_format_config_get_value`), so `- deepseek-v4-flash` and
-    // `deepseek-v4-flash:\n  context_length: 65536` arrive as two blocks of text
-    // that only a YAML reader can tell apart — and telling them apart is the
-    // whole of the check above. `--json` is the CLI's own machine-readable mode
-    // (`hermes config get <key> [--json]`, config.py:5769), verified on the
-    // pinned Hermes build every box runs.
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 1, stdout: "", stderr: "config key not set" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+  it("writes nothing on a block that carries no endpoint", async () => {
+    providerBlock({ api_mode: "openai" });
     await reconcileClawaiModelsWithHermes();
-    const read = cliMock.mock.calls
-      .map((c) => c[0] as string[])
-      .find((args) => args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.models`);
-    expect(read).toContain("--json");
+    expect(wrote()).toBe(false);
+  });
+
+  it("writes nothing when the provider block could not be read", async () => {
+    // An unreadable config is not an unconfigured one — the same rule the
+    // plugins.enabled read-modify-write follows.
+    providerBlock(null, { code: 1, stderr: "permission denied" });
+    await reconcileClawaiModelsWithHermes();
+    expect(wrote()).toBe(false);
+  });
+
+  it("tries again after a read that FAILED rather than answered", async () => {
+    // A non-zero exit whose message is not "config key not set" is not the
+    // answer "nothing there" — it is an unreadable config: an EACCES on
+    // config.yaml, Hermes' own filelock held by an interactive CLI, a parse
+    // error. Leaving the file alone is right; latching is not.
+    providerBlock(null, { code: 1, stderr: "permission denied" });
+    await reconcileClawaiModelsWithHermes();
+    expect(wrote()).toBe(false);
+
+    vi.advanceTimersByTime(60_001);
+    cliMock.mockReset();
+    providerBlock(LINKED);
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
   });
 
   it("tries again after a read the CLI never answered", async () => {
@@ -312,13 +357,11 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     // repair for the life of the process, on the very update shipping it.
     cliMock.mockResolvedValue({ code: 127, stdout: "", stderr: "" });
     await reconcileClawaiModelsWithHermes();
-    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+    expect(wrote()).toBe(false);
 
+    vi.advanceTimersByTime(60_001);
     cliMock.mockReset();
-    cliMock.mockImplementation(async (args: string[]) =>
-      args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 1, stdout: "", stderr: "config key not set" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    providerBlock(LINKED);
     await reconcileClawaiModelsWithHermes();
     expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
       CLAWBOX_AI_FLASH_MODEL_ID,
@@ -329,15 +372,91 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
   it("tries again after a write that failed", async () => {
     cliMock.mockImplementation(async (args: string[]) => {
       if (args[1] === "set") return { code: 1, stdout: "", stderr: "config is locked" };
-      return args[2] === `providers.${CLAWAI_PROVIDER}.models`
-        ? { code: 1, stdout: "", stderr: "config key not set" }
-        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
+      return { code: 0, stdout: `${JSON.stringify(LINKED)}\n`, stderr: "" };
     });
     await reconcileClawaiModelsWithHermes();
     const firstAttempt = cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
+
+    vi.advanceTimersByTime(60_001);
     await reconcileClawaiModelsWithHermes();
-    // A failed repair is not a repair: the next request must try it again.
+    // A failed repair is not a repair: a later request must try it again.
     expect(cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length)
       .toBeGreaterThan(firstAttempt);
+  });
+
+  it("does not re-ask on every request while the CLI keeps failing", async () => {
+    // The retry above is what stops an update from skipping the repair; this is
+    // what stops it becoming a Python start per request. `GET
+    // /setup-api/hermes/models` awaits this before it serves anything and each
+    // read carries a 15 s timeout, so on a box whose `hermes` is wedged an
+    // unbounded retry would be added to every chat-header and Settings load.
+    cliMock.mockResolvedValue({ code: 127, stdout: "", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    const afterFirst = cliMock.mock.calls.length;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    vi.advanceTimersByTime(30_000);
+    await reconcileClawaiModelsWithHermes();
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.length).toBe(afterFirst);
+
+    vi.advanceTimersByTime(30_001);
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.length).toBeGreaterThan(afterFirst);
+  });
+
+  it("says why it walked away, on every path that is not an ordinary box", async () => {
+    // A silent `return` on the path the field actually reaches is how a box
+    // ends up wrong with nothing in its journal. The two ordinary verdicts —
+    // already declared, never linked — stay quiet, because every box on the
+    // fleet would otherwise print one a boot.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      cliMock.mockResolvedValue({ code: 127, stdout: "", stderr: "" });
+      await reconcileClawaiModelsWithHermes();
+      expect(warn).toHaveBeenCalled();
+
+      vi.advanceTimersByTime(60_001);
+      _resetClawaiModelsReconcileForTests();
+      log.mockClear();
+      providerBlock({ ...LINKED, discover_models: false, models: { a: {} } });
+      await reconcileClawaiModelsWithHermes();
+      expect(log).toHaveBeenCalled();
+
+      _resetClawaiModelsReconcileForTests();
+      log.mockClear();
+      warn.mockClear();
+      providerBlock({ ...LINKED, models: [CLAWBOX_AI_FLASH_MODEL_ID] });
+      await reconcileClawaiModelsWithHermes();
+      expect(log).not.toHaveBeenCalled();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+      log.mockRestore();
+    }
+  });
+
+  it("never puts the provider block it just read into the journal", async () => {
+    // That block carries `api_key`. Every branch reports an exit code and our
+    // own words, never the stream — this repo is public and its logs are read
+    // over screen shares.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      providerBlock(null, { code: 1, stderr: `unreadable: ${JSON.stringify(LINKED)}` });
+      await reconcileClawaiModelsWithHermes();
+      const printed = [warn, log, error]
+        .flatMap((spy) => spy.mock.calls)
+        .flat()
+        .map((arg) => String(arg))
+        .join(" ");
+      expect(printed).not.toContain(LINKED.api_key);
+    } finally {
+      warn.mockRestore();
+      log.mockRestore();
+      error.mockRestore();
+    }
   });
 });

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -257,21 +257,6 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     expect(wrote()).toBe(false);
   });
 
-  it("leaves a catalogue the owner pinned with discover_models: false alone", async () => {
-    // The one shape that looks broken and is not. `discover_models: false` is
-    // Hermes' documented way to pin a catalogue of ANY shape
-    // (model_switch.py:3777), and with discovery off no probe runs — so the
-    // mapping IS what the keyboard shows and this owner has no symptom at all.
-    // Overwriting it would drop their per-model metadata to fix nothing.
-    providerBlock({
-      ...LINKED,
-      discover_models: false,
-      models: { [CLAWBOX_AI_FLASH_MODEL_ID]: { context_length: 65536 } },
-    });
-    await reconcileClawaiModelsWithHermes();
-    expect(wrote()).toBe(false);
-  });
-
   it("leaves a catalogue Hermes persisted for itself alone", async () => {
     // `models_discovered: true` makes `_models_config_is_allowlist` return
     // False WHATEVER the shape (model_switch.py:136), so our list would be
@@ -325,9 +310,12 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
   });
 
   it("still honours a pin that actually pins something", async () => {
-    // The boundary the two above must not move: with discovery off AND ids
-    // present, `_declared_model_ids` reads even a mapping's keys, so the
-    // keyboard shows them and this owner has nothing wrong with their box.
+    // The boundary the two above must not move, and the one shape that looks
+    // broken and is not. `discover_models: false` is Hermes' documented way to
+    // pin a catalogue of ANY shape (model_switch.py:3777): with discovery off no
+    // probe runs and `_declared_model_ids` reads even a mapping's keys, so the
+    // mapping IS what the keyboard shows and this owner has no symptom at all.
+    // Overwriting it would drop their per-model metadata to fix nothing.
     providerBlock({
       ...LINKED,
       discover_models: false,
@@ -396,6 +384,58 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     await reconcileClawaiModelsWithHermes();
     expect(cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length)
       .toBeGreaterThan(firstAttempt);
+  });
+  /**
+   * The same fault, found on the NEXT request instead of at the write.
+   *
+   * `hermes config set` stores the literal text and exits 0, so the guard above
+   * unlatches and asks again — and what the re-read finds is a `models:` that
+   * is a STRING. Confirmed against the installed Hermes 0.20.5 by running its
+   * own functions over that value: `_declared_model_ids` returns ONE id, the
+   * whole literal `["deepseek-v4-flash","deepseek-v4-pro"]`, and
+   * `_models_config_is_allowlist` returns True. So Hermes reads it as a
+   * perfectly good one-model allowlist, the keyboard offers that one unusable
+   * entry, and every "already declared" branch here walks away from it —
+   * the silent one silently. A write guard alone therefore fixes nothing that
+   * outlives the process: the residue is in the file, and only a re-declare
+   * clears it.
+   */
+  const STORED_AS_TEXT = JSON.stringify([CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID]);
+
+  it("shows the symptom a stored-as-text catalogue leaves on the keyboard", async () => {
+    // The premise, stated through Hermes' own reader rather than asserted: one
+    // bogus id. If this ever stops being true the two repairs below are moot.
+    expect(hermesPickerModels({ ...LINKED, models: STORED_AS_TEXT }, [])).toEqual([STORED_AS_TEXT]);
+  });
+
+  it("re-declares a catalogue an earlier write stored as text", async () => {
+    providerBlock({ ...LINKED, models: STORED_AS_TEXT });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("re-declares stored-as-text even where a pin claims to protect it", async () => {
+    // The other discovery state. `discover_models: false` stops the probe, so
+    // the bogus id is not merely offered — it is the whole row, permanently.
+    providerBlock({ ...LINKED, discover_models: false, models: STORED_AS_TEXT });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("leaves stored-as-text alone when Hermes owns the catalogue", async () => {
+    // The boundary the two above must not move. With `models_discovered: true`
+    // beside it our list is refused whatever its shape (model_switch.py:136),
+    // so re-declaring here would latch "repaired" over a keyboard that still
+    // says "clawai (0)" — the false success this module is audited for.
+    providerBlock({ ...LINKED, models_discovered: true, models: STORED_AS_TEXT });
+    await reconcileClawaiModelsWithHermes();
+    expect(wrote()).toBe(false);
   });
 
   it("declares the catalogue over an empty list", async () => {

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -25,7 +25,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  *
  * The ClawBox AI proxy answers that probe `200 {"status":"ok","models":[…]}` —
  * not the OpenAI `{"data":[{"id":…}]}` envelope Hermes parses
- * (`probe_api_models`, hermes_cli/models.py:5668) — so the probe yields an
+ * (`probe_api_models`, hermes_cli/models.py:5592) — so the probe yields an
  * EMPTY list, and a provider block that declares nothing renders as
  * "clawai (0)": no ClawBox AI model to pick, on the box's own bot.
  *
@@ -126,6 +126,23 @@ describe("what Hermes' own /model picker knows about ClawBox AI", () => {
     expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), ["deepseek-v5"])).toEqual(["deepseek-v5"]);
   });
 
+  it("would lose the declaration to a discovered-catalogue flag beside it", async () => {
+    // The mirror's own boundary, and a hazard for any future writer of a
+    // `providers.<slug>` block: with `models_discovered: true` beside
+    // `models:`, `_models_config_is_allowlist` (model_switch.py:136) returns
+    // False WHATEVER the shape, the empty probe wins and the row is empty
+    // again. Not reachable for `providers.clawai` today — Hermes writes that
+    // flag only into `custom_providers` entries
+    // (`_save_discovered_models_to_config`, model_switch.py:244) — so a writer
+    // that ever meets it has to CLEAR it, not just declare beside it.
+    const declared = { models: [CLAWBOX_AI_FLASH_MODEL_ID, CLAWBOX_AI_PRO_MODEL_ID] };
+    expect(hermesPickerModels(declared, [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+    expect(hermesPickerModels({ ...declared, models_discovered: true }, [])).toEqual([]);
+  });
+
   it("does not offer the vision model as something to chat with", async () => {
     await applyClawaiToHermes("claw_token_abc", "pro");
     // It exists so an attached picture gets looked at (`auxiliary.vision`), and
@@ -170,7 +187,7 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
         return { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
       }
       if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.models`) {
-        return { code: 0, stdout: "['deepseek-v4-flash', 'deepseek-v4-pro']\n", stderr: "" };
+        return { code: 0, stdout: '["deepseek-v4-flash", "deepseek-v4-pro"]\n', stderr: "" };
       }
       return { code: 0, stdout: "", stderr: "" };
     });
@@ -195,6 +212,97 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
         : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
     await reconcileClawaiModelsWithHermes();
     expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+  });
+
+  it("tries again after a catalogue read that FAILED rather than answered", async () => {
+    // A non-zero exit whose message is not "config key not set" is not the
+    // answer "no key here" — it is an unreadable config: an EACCES on
+    // config.yaml, Hermes' own filelock held by an interactive CLI, a parse
+    // error. Leaving the file alone is right; latching is not, and it is the
+    // same probe-once trap the branch above already fixed. `localCatalogueState`
+    // maps this identical result to "unknown" and retries; so must this.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "permission denied" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+
+    cliMock.mockReset();
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "config key not set" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("declares the catalogue over a value Hermes does not read as an allowlist", async () => {
+    // `providers.clawai.models` present as a MAPPING — the per-model metadata
+    // shape Hermes' own model wizard writes. `_models_config_is_allowlist`
+    // (model_switch.py:136) returns False for a mapping, so `has_explicit_models`
+    // stays false, the empty probe REPLACES it (model_switch.py:3423-3431) and
+    // the keyboard says "clawai (0)". A key that exists is not a key Hermes
+    // reads: the repair has to look at the value.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 0, stdout: '{"deepseek-v4-flash": {"context_length": 65536}}\n', stderr: "" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("declares the catalogue over an empty list", async () => {
+    // Same rule, the other unusable shape: `_models_config_is_allowlist`
+    // requires at least one id, so `models: []` leaves the probe free to win
+    // with nothing.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 0, stdout: "[]\n", stderr: "" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("leaves a single id the owner pinned by hand alone", async () => {
+    // A bare string IS an allowlist as far as Hermes is concerned, so this box
+    // offers exactly what its owner asked for. Widening it back to both tiers
+    // would be this repair overruling a deliberate configuration.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 0, stdout: '"deepseek-v4-flash"\n', stderr: "" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+  });
+
+  it("asks the CLI for the catalogue as JSON", async () => {
+    // Not a style choice. Plain `hermes config get` renders a list or a mapping
+    // through `yaml.safe_dump` (hermes_cli/config.py:1203,
+    // `_format_config_get_value`), so `- deepseek-v4-flash` and
+    // `deepseek-v4-flash:\n  context_length: 65536` arrive as two blocks of text
+    // that only a YAML reader can tell apart — and telling them apart is the
+    // whole of the check above. `--json` is the CLI's own machine-readable mode
+    // (`hermes config get <key> [--json]`, config.py:5769), verified on the
+    // pinned Hermes build every box runs.
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === `providers.${CLAWAI_PROVIDER}.models`
+        ? { code: 1, stdout: "", stderr: "config key not set" }
+        : { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" });
+    await reconcileClawaiModelsWithHermes();
+    const read = cliMock.mock.calls
+      .map((c) => c[0] as string[])
+      .find((args) => args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.models`);
+    expect(read).toContain("--json");
   });
 
   it("tries again after a read the CLI never answered", async () => {

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * What HERMES itself knows about the models a ClawBox-owned provider serves.
+ *
+ * The chat dropdown in our dashboard is not the only picker on the box. Hermes
+ * builds its own — the Telegram/Discord `/model` inline keyboard and the Hermes
+ * dashboard's Models page — from `list_authenticated_providers`
+ * (hermes_cli/model_switch.py:2571, Hermes 0.20.5 on a Hermes-edition box), and
+ * BOTH of those surfaces read the `providers:` block of ~/.hermes/config.yaml,
+ * never anything ClawBox serves. `/api/model/options` (hermes_cli/web_server.py:6998)
+ * goes through `build_model_options_payload(load_picker_context())`, i.e. the
+ * same substrate, so config.yaml is the single source both surfaces share.
+ *
+ * For a custom OpenAI-compatible provider (which is what ClawBox AI and the
+ * on-device model both are) that block is read like this, per section 3 of
+ * `list_authenticated_providers`:
+ *
+ *   - the row's models are `default_model`/`model` plus `_declared_model_ids`
+ *     of `models:` (model_switch.py:61);
+ *   - the endpoint is then probed at `<base_url>/models`, and the probe's
+ *     answer REPLACES the declared list unless the declared list is an
+ *     allowlist shape and the probe came back empty (model_switch.py:3423-3431,
+ *     `_models_config_is_allowlist` at model_switch.py:136).
+ *
+ * The ClawBox AI proxy answers that probe `200 {"status":"ok","models":[…]}` —
+ * not the OpenAI `{"data":[{"id":…}]}` envelope Hermes parses
+ * (`probe_api_models`, hermes_cli/models.py:5668) — so the probe yields an
+ * EMPTY list, and a provider block that declares nothing renders as
+ * "clawai (0)": no ClawBox AI model to pick, on the box's own bot.
+ *
+ * Declaring the ids in `providers.<slug>.models` is Hermes' own mechanism for
+ * exactly this ("custom endpoints … where the user may supply their own model
+ * set through config", `list_picker_providers`, model_switch.py:3926), and it
+ * never narrows a working endpoint: a NON-empty probe still wins.
+ */
+
+const cliMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
+vi.mock("@/lib/hermes-model-options", () => ({ invalidateModelOptions: vi.fn() }));
+vi.mock("@/lib/config-store", () => ({ setMany: vi.fn() }));
+vi.mock("@/lib/hermes-env", () => ({ setHermesEnvValues: vi.fn() }));
+vi.mock("@/lib/coding-agent", () => ({ getCodingAgentStatus: vi.fn(async () => ({ ready: false })) }));
+vi.mock("@/lib/coding-agent-mcp-refresh", () => ({
+  refreshCodingAgentToolsIfReadinessChanged: vi.fn(),
+}));
+vi.mock("@/lib/hermes-image-plugin", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/hermes-image-plugin")>()),
+  installHermesImagePlugin: vi.fn(),
+}));
+const resolveVisionMock = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/clawbox-ai-vision", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/clawbox-ai-vision")>()),
+  resolveVisionModelId: resolveVisionMock,
+}));
+
+import {
+  CLAWAI_PROVIDER,
+  applyClawaiToHermes,
+  reconcileClawaiModelsWithHermes,
+  _resetClawaiModelsReconcileForTests,
+} from "@/lib/hermes-clawai";
+import {
+  CLAWBOX_AI_FLASH_MODEL_ID,
+  CLAWBOX_AI_PRO_MODEL_ID,
+  CLAWBOX_AI_VISION_MODEL_ID,
+} from "@/lib/clawbox-ai-models";
+
+// ── Hermes' reader, mirrored ────────────────────────────────────────────────
+//
+// Small on purpose: it is the CONTRACT the writer has to satisfy, pinned so a
+// change of shape (a comma-joined string, a list of objects, a bare default)
+// fails here rather than on a customer's phone.
+
+/** `_declared_model_ids` — hermes_cli/model_switch.py:61. */
+function declaredModelIds(value: unknown): string[] {
+  const ids: string[] = [];
+  const add = (candidate: unknown) => {
+    if (typeof candidate !== "string") return;
+    const id = candidate.trim();
+    if (!id || ids.some((seen) => seen.toLowerCase() === id.toLowerCase())) return;
+    ids.push(id);
+  };
+  if (typeof value === "string") add(value);
+  else if (Array.isArray(value)) {
+    for (const item of value) {
+      if (typeof item === "string") add(item);
+      else if (item && typeof item === "object") {
+        const row = item as { id?: unknown; name?: unknown };
+        add(typeof row.id === "string" && row.id.trim() ? row.id : row.name);
+      }
+    }
+  } else if (value && typeof value === "object") {
+    for (const key of Object.keys(value)) {
+      if (key === "__explicit_model_allowlist__" || key === "__discovered_model_catalog__") continue;
+      add(key);
+    }
+  }
+  return ids;
+}
+
+/** `_models_config_is_allowlist` — hermes_cli/model_switch.py:136. */
+function modelsConfigIsAllowlist(value: unknown): boolean {
+  if (typeof value === "string") return Boolean(value.trim());
+  if (Array.isArray(value)) return declaredModelIds(value).length > 0;
+  return false;
+}
+
+/**
+ * The model ids Hermes' `/model` picker offers for one `providers:` entry.
+ * `liveProbe` is what `<base_url>/models` yielded — `[]` when the endpoint
+ * answered in a shape Hermes could not read, `null` when it did not answer.
+ */
+function hermesPickerModels(entry: Record<string, unknown>, liveProbe: string[] | null): string[] {
+  const declared = declaredModelIds(entry.models);
+  const fallbackDefault = entry.default_model ?? entry.model;
+  const models = typeof fallbackDefault === "string" && fallbackDefault.trim()
+    ? [fallbackDefault.trim(), ...declared.filter((id) => id !== fallbackDefault.trim())]
+    : declared;
+  const hasExplicitModels = modelsConfigIsAllowlist(entry.models);
+  if (liveProbe !== null && (liveProbe.length > 0 || !hasExplicitModels)) return liveProbe;
+  return models;
+}
+
+/**
+ * The `providers.<slug>` block the writer left behind, decoded the way
+ * `hermes config set` decodes a value (hermes_cli/config.py:5515: a list or
+ * mapping literal is parsed, everything else stays a string).
+ */
+function providerEntry(slug: string): Record<string, unknown> {
+  const entry: Record<string, unknown> = {};
+  for (const call of cliMock.mock.calls) {
+    const args = call[0] as string[];
+    if (args[0] !== "config") continue;
+    const prefix = `providers.${slug}.`;
+    if (!args[2]?.startsWith(prefix)) continue;
+    const leaf = args[2].slice(prefix.length);
+    if (args[1] === "unset") delete entry[leaf];
+    if (args[1] !== "set") continue;
+    const raw = args[3];
+    let value: unknown = raw;
+    if (/^\s*[[{]/.test(raw)) {
+      try {
+        value = JSON.parse(raw);
+      } catch {
+        /* stored as a string, exactly as the CLI would */
+      }
+    }
+    entry[leaf] = value;
+  }
+  return entry;
+}
+
+describe("what Hermes' own /model picker knows about ClawBox AI", () => {
+  beforeEach(() => {
+    cliMock.mockReset();
+    cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    resolveVisionMock.mockReset();
+    resolveVisionMock.mockResolvedValue({
+      id: CLAWBOX_AI_VISION_MODEL_ID,
+      verified: true,
+      reason: "proxy-allows",
+    });
+  });
+
+  it("offers both tier models even though the proxy's /models is unreadable", async () => {
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    // `[]` is not a guess: the live proxy answers 200 with
+    // {"status":"ok","service":"ClawBox AI Proxy","models":[…]} and Hermes reads
+    // `data[].id`, so its probe comes back empty on every box.
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("still defers to the endpoint when it does answer", async () => {
+    await applyClawaiToHermes("claw_token_abc", "flash");
+    // A declared list is a floor, never a ceiling: the day the proxy speaks the
+    // OpenAI envelope, its answer is the one the picker shows.
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), ["deepseek-v5"])).toEqual(["deepseek-v5"]);
+  });
+
+  it("does not offer the vision model as something to chat with", async () => {
+    await applyClawaiToHermes("claw_token_abc", "pro");
+    // It exists so an attached picture gets looked at (`auxiliary.vision`), and
+    // it is not a chat tier. Declaring it here would put it in the keyboard.
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).not.toContain(
+      CLAWBOX_AI_VISION_MODEL_ID,
+    );
+  });
+
+});
+
+describe("repairing a ClawBox AI box that was linked earlier", () => {
+  beforeEach(() => {
+    _resetClawaiModelsReconcileForTests();
+    cliMock.mockReset();
+    cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+  });
+
+  it("backfills a box that was linked before the catalogue was declared", async () => {
+    // Every box in the field is in this state: `providers.clawai` has the URL,
+    // the key and the mode, and no `models:` at all. Nothing re-links it, so
+    // without a repair the bot keeps saying "clawai (0)" forever.
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.base_url`) {
+        return { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.models`) {
+        return { code: 1, stdout: "", stderr: "config key not set" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("leaves a catalogue that is already there alone", async () => {
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.base_url`) {
+        return { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
+      }
+      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}.models`) {
+        return { code: 0, stdout: "['deepseek-v4-flash', 'deepseek-v4-pro']\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+  });
+
+  it("writes nothing on a box that has no ClawBox AI provider block", async () => {
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "config key not set" });
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+  });
+
+  it("writes nothing when the config could not be read at all", async () => {
+    // An unreadable config is not an unconfigured one — the same rule the
+    // plugins.enabled read-modify-write follows.
+    cliMock.mockResolvedValue({ code: 1, stdout: "", stderr: "permission denied" });
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(false);
+  });
+});

--- a/src/tests/unit/hermes-provider-model-catalog.test.ts
+++ b/src/tests/unit/hermes-provider-model-catalog.test.ts
@@ -178,21 +178,52 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
   };
 
   /**
-   * What `hermes config get providers.clawai --json` answers here.
+   * The box's `providers.clawai` block, answered by a `hermes` CLI that
+   * REMEMBERS what it was told.
    *
-   * ONE read of the whole block, because Hermes decides what `models:` means
-   * from its siblings — `discover_models` and `models_discovered` — and the
-   * `base_url` orphan guard needs the same entry.
+   * The whole block for `config get providers.clawai --json`, because Hermes
+   * decides what `models:` means from its siblings — `discover_models` and
+   * `models_discovered` — and the `base_url` orphan guard needs the same entry.
+   * A leaf read answers from the same store, which is what makes a write
+   * verifiable here at all rather than assumed from an exit code.
+   *
+   * `coerces: false` is a CLI old enough to lack the block that parses a
+   * flow-style literal into a real list before storing it
+   * (hermes_cli/config.py:5479-5530): it keeps the literal TEXT, exits 0 and
+   * prints no warning. That is the build this repair exists for, and the one
+   * where an exit code is least like an outcome.
    */
   function providerBlock(
     entry: Record<string, unknown> | null,
-    failure: { code?: number; stderr?: string } = {},
+    failure: { code?: number; stderr?: string; coerces?: boolean } = {},
   ) {
+    const prefix = `providers.${CLAWAI_PROVIDER}.`;
+    const stored = entry ? { ...entry } : null;
+    const coerces = failure.coerces !== false;
     cliMock.mockImplementation(async (args: string[]) => {
-      if (args[1] === "get" && args[2] === `providers.${CLAWAI_PROVIDER}`) {
-        return entry
-          ? { code: 0, stdout: `${JSON.stringify(entry)}\n`, stderr: "" }
+      const [, verb, key, raw] = args;
+      if (verb === "set" && stored && key?.startsWith(prefix)) {
+        let value: unknown = raw;
+        if (coerces && /^\s*[[{]/.test(raw)) {
+          try {
+            value = JSON.parse(raw);
+          } catch {
+            /* stored as a string, exactly as the CLI would */
+          }
+        }
+        stored[key.slice(prefix.length)] = value;
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (verb === "get" && key === `providers.${CLAWAI_PROVIDER}`) {
+        return stored
+          ? { code: 0, stdout: `${JSON.stringify(stored)}\n`, stderr: "" }
           : { code: failure.code ?? 1, stdout: "", stderr: failure.stderr ?? "config key not set" };
+      }
+      if (verb === "get" && key?.startsWith(prefix)) {
+        const leaf = key.slice(prefix.length);
+        return stored && leaf in stored
+          ? { code: 0, stdout: `${JSON.stringify(stored[leaf])}\n`, stderr: "" }
+          : { code: 1, stdout: "", stderr: "config key not set" };
       }
       return { code: 0, stdout: "", stderr: "" };
     });
@@ -220,10 +251,12 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     // instead of two.
     providerBlock(LINKED);
     await reconcileClawaiModelsWithHermes();
-    const reads = cliMock.mock.calls
-      .map((c) => c[0] as string[])
-      .filter((args) => args[1] === "get");
-    expect(reads).toEqual([["config", "get", `providers.${CLAWAI_PROVIDER}`, "--json"]]);
+    // Everything BEFORE the write, which is what "decide in one Python start"
+    // means. The write is verified by a read of its own key afterwards — see
+    // the silent-stored-as-text test — and that one is a different question.
+    const args = cliMock.mock.calls.map((c) => c[0] as string[]);
+    const deciding = args.slice(0, args.findIndex((a) => a[1] === "set"));
+    expect(deciding).toEqual([["config", "get", `providers.${CLAWAI_PROVIDER}`, "--json"]]);
   });
 
   it("asks the CLI for the catalogue as JSON", async () => {
@@ -269,6 +302,26 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     });
     await reconcileClawaiModelsWithHermes();
     expect(wrote()).toBe(false);
+  });
+
+  it("declares a catalogue Hermes flagged as discovered but can never re-probe", async () => {
+    // `models_discovered: true` strips the ALLOWLIST reading and nothing else
+    // (`_models_config_is_allowlist`, model_switch.py:136), and that reading
+    // only decides anything if a PROBE can act on it. With `discover_models:
+    // false` beside it Hermes takes `_discovery_allowed = False`
+    // (model_switch.py:3788) and never reaches `grp["models"] = live_models`
+    // (:3823), so nothing replaces anything: the row is exactly what
+    // `_declared_model_ids` finds, which here is nothing at all — "clawai (0)",
+    // permanently. Declining this pair would strand a box a single write fixes
+    // for good, precisely because no probe can come back to undo it.
+    const block = { ...LINKED, models_discovered: true, discover_models: false };
+    providerBlock(block);
+    await reconcileClawaiModelsWithHermes();
+    // `null`, not `[]`: with discovery off there is no probe to answer.
+    expect(hermesPickerModels({ ...block, ...providerEntry(CLAWAI_PROVIDER) }, null)).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
   });
 
   it("declares the catalogue over a value Hermes does not read as an allowlist", async () => {
@@ -385,6 +438,32 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     expect(cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length)
       .toBeGreaterThan(firstAttempt);
   });
+
+  it("does not claim a repair the CLI stored as text without saying so", async () => {
+    // The stderr guard above can only fire on a CLI whose coercion block exists
+    // to print that warning. On one old enough to lack it — the build this
+    // repair is reached on — the same literal is stored as TEXT with an empty
+    // stderr and exit 0, so the write looks perfect and the residue is in the
+    // file. Claiming it would latch "repaired" over a keyboard showing one
+    // unusable id, and rewrite config.yaml once per boot to no effect forever.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const setCount = () => cliMock.mock.calls.filter((c) => (c[0] as string[])[1] === "set").length;
+    try {
+      providerBlock(LINKED, { coerces: false });
+      await reconcileClawaiModelsWithHermes();
+      // Not claimed: the catalogue cache is only dropped for a write that landed.
+      expect(invalidateMock).not.toHaveBeenCalled();
+      expect(warn.mock.calls.flat().map(String).join(" ")).toContain("could not declare");
+
+      const firstAttempt = setCount();
+      vi.advanceTimersByTime(60_001);
+      await reconcileClawaiModelsWithHermes();
+      expect(setCount()).toBeGreaterThan(firstAttempt);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   /**
    * The same fault, found on the NEXT request instead of at the write.
    *
@@ -442,6 +521,39 @@ describe("repairing a ClawBox AI box that was linked earlier", () => {
     // Same rule, the other unusable shape: an allowlist needs at least one id,
     // so `models: []` leaves the probe free to win with nothing.
     providerBlock({ ...LINKED, models: [] });
+    await reconcileClawaiModelsWithHermes();
+    expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
+      CLAWBOX_AI_FLASH_MODEL_ID,
+      CLAWBOX_AI_PRO_MODEL_ID,
+    ]);
+  });
+
+  it("looks again at the catalogue the LINK path just wrote", async () => {
+    // `applyClawaiToHermes` writes the SAME key through the same
+    // `hermes config set`, so it can fail the same silent way — and it must not
+    // throw over it: a box whose `models:` went in as text still chats, sees and
+    // draws, so failing the link would be a false failure over a working device.
+    // The link hands the repair back instead, and the read that follows it is
+    // what verifies the write.
+    //
+    // Handing it back is also the only way the residue is ever looked at. On an
+    // UNLINKED box this repair has usually already run and latched its silent
+    // "no providers.clawai" — so without this the value the link just wrote is
+    // not re-examined until the web server restarts.
+    providerBlock(null);
+    await reconcileClawaiModelsWithHermes();
+    expect(wrote()).toBe(false);
+
+    resolveVisionMock.mockResolvedValue({
+      id: CLAWBOX_AI_VISION_MODEL_ID,
+      verified: true,
+      reason: "proxy-allows",
+    });
+    cliMock.mockResolvedValue({ code: 0, stdout: "", stderr: "" });
+    await applyClawaiToHermes("claw_token_abc", "flash");
+
+    cliMock.mockReset();
+    providerBlock(LINKED);
     await reconcileClawaiModelsWithHermes();
     expect(hermesPickerModels(providerEntry(CLAWAI_PROVIDER), [])).toEqual([
       CLAWBOX_AI_FLASH_MODEL_ID,

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -182,16 +182,29 @@ describe("declaring a catalogue Hermes' own pickers read", () => {
     // ONE read of the whole `providers.clawai` block: Hermes decides what
     // `models:` means from its siblings, and the same entry carries the
     // `base_url` the orphan guard needs.
+    //
+    // The leaf read is the write's VERIFICATION: `hermes config set` exits 0
+    // even when it stored the list as text, so the repair reads the key back
+    // with `--json` and only then counts the write as done. A CLI that answers
+    // it with the list is the one this assertion is about — the browser is told
+    // the catalogue moved because it actually did.
+    const stored: Record<string, unknown> = {
+      base_url: "https://clawbox.com/api/ai",
+      api_mode: "openai",
+    };
     cliMock.mockImplementation(async (args: string[]) => {
-      if (args[1] === "get" && args[2] === "providers.clawai") {
-        return {
-          code: 0,
-          stdout: JSON.stringify({
-            base_url: "https://clawbox.com/api/ai",
-            api_mode: "openai",
-          }),
-          stderr: "",
-        };
+      const [, verb, key, raw] = args;
+      if (verb === "set" && key === "providers.clawai.models") {
+        stored.models = JSON.parse(raw);
+        return { code: 0, stdout: "", stderr: "" };
+      }
+      if (verb === "get" && key === "providers.clawai") {
+        return { code: 0, stdout: JSON.stringify(stored), stderr: "" };
+      }
+      if (verb === "get" && key === "providers.clawai.models") {
+        return "models" in stored
+          ? { code: 0, stdout: JSON.stringify(stored.models), stderr: "" }
+          : { code: 1, stdout: "", stderr: "config key not set" };
       }
       return { code: 0, stdout: "", stderr: "" };
     });

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 /**
- * The OTHER four write paths that move the provider set.
+ * The OTHER write paths that move the provider set.
  *
  * The customer-facing pair (`/setup-api/hermes/provider-key` and the OAuth
  * completion) is pinned in src/tests/routes/hermes/provider-mcp-refresh.test.ts.
@@ -12,6 +12,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
  * finds — every place that already tells the BROWSER the catalogue moved, which
  * is exactly the population that has to tell the running agent too. Wiring four
  * of six is how #514 came back as a residual in the first place.
+ *
+ * A site that must NOT reload belongs here just as much as one that must: the
+ * last two are catalogue repairs that hang off `GET /setup-api/hermes/models`,
+ * and the whole point of pinning them is that "no reload" is a decision with a
+ * reason, not an omission nobody noticed.
  */
 
 const rpcMock = vi.hoisted(() => vi.fn());
@@ -23,7 +28,8 @@ const readConfigMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
-vi.mock("@/lib/config-store", () => ({ get: vi.fn(async () => null), setMany: vi.fn() }));
+const storeGetMock = vi.hoisted(() => vi.fn(async (_key: string) => null as unknown));
+vi.mock("@/lib/config-store", () => ({ get: storeGetMock, setMany: vi.fn() }));
 vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
   readHermesConfigValue: readConfigMock,
@@ -40,7 +46,16 @@ vi.mock("@/lib/hermes-model-options", async (importOriginal) => ({
 }));
 
 import { applyCloudProviderKeyToHermes } from "@/lib/hermes-cloud-provider";
-import { applyLocalAiToHermes, removeLocalAiFromHermes } from "@/lib/hermes-local-ai";
+import {
+  _resetLocalAiReconcileForTests,
+  applyLocalAiToHermes,
+  reconcileLocalAiWithHermes,
+  removeLocalAiFromHermes,
+} from "@/lib/hermes-local-ai";
+import {
+  _resetClawaiModelsReconcileForTests,
+  reconcileClawaiModelsWithHermes,
+} from "@/lib/hermes-clawai";
 
 function payload(ids: string[], current = "openrouter") {
   return {
@@ -82,6 +97,10 @@ beforeEach(() => {
   patchMock.mockResolvedValue(undefined);
   readConfigMock.mockReset();
   readConfigMock.mockResolvedValue(null);
+  storeGetMock.mockReset();
+  storeGetMock.mockResolvedValue(null);
+  _resetLocalAiReconcileForTests();
+  _resetClawaiModelsReconcileForTests();
 });
 
 describe("saving a cloud provider key through the OpenClaw-shaped panel", () => {
@@ -139,6 +158,48 @@ describe("turning the local model on and off", () => {
   it("costs nothing when the set did not actually move", async () => {
     catalogueGrows(["openrouter", "local"], ["openrouter", "local"], "openrouter");
     await applyLocalAiToHermes({ provider: "ollama", model: "gemma4:e2b", makeDefault: false });
+    expect(reloadCount()).toBe(0);
+  });
+});
+
+describe("declaring a catalogue Hermes' own pickers read", () => {
+  // Both repairs run inside `GET /setup-api/hermes/models` — the route the
+  // agent's own `ai_list_models` reads — so a `reload.mcp` from in here would
+  // shut down the MCP child that is mid-tool-call. And neither moves the
+  // provider SET the enum is built from: the provider already exists, only the
+  // models it lists change. Invalidate the browser's catalogue, ask the agent
+  // for nothing. This is the same rule `reconcileLocalAiWithHermes` already
+  // followed by calling the INNER write.
+  it("asks the agent for nothing when the ClawBox AI catalogue is declared", async () => {
+    catalogueGrows(["openrouter", "clawai"], ["openrouter", "clawai"], "clawai");
+    cliMock.mockImplementation(async (args: string[]) => {
+      if (args[1] === "get" && args[2] === "providers.clawai.models") {
+        return { code: 1, stdout: "", stderr: "config key not set" };
+      }
+      if (args[1] === "get" && args[2] === "providers.clawai.base_url") {
+        return { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
+      }
+      return { code: 0, stdout: "", stderr: "" };
+    });
+    await reconcileClawaiModelsWithHermes();
+    expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(true);
+    expect(reloadCount()).toBe(0);
+  });
+
+  it("asks the agent for nothing when the local catalogue is declared", async () => {
+    catalogueGrows(["openrouter", "clawlocal"], ["openrouter", "clawlocal"], "clawlocal");
+    storeGetMock.mockImplementation(async (key: string) => {
+      if (key === "local_ai_configured") return true;
+      if (key === "local_ai_provider") return "ollama";
+      if (key === "local_ai_model") return "ollama/qwen3:8b";
+      return null;
+    });
+    cliMock.mockImplementation(async (args: string[]) =>
+      args[2] === "providers.clawlocal.models"
+        ? { code: 1, stdout: "", stderr: "config key not set" }
+        : { code: 0, stdout: "http://127.0.0.1/setup-api/local-ai/ollama/v1\n", stderr: "" });
+    await reconcileLocalAiWithHermes();
+    expect(patchMock).toHaveBeenCalledWith({ set: { "providers.clawlocal.models": "qwen3:8b" } });
     expect(reloadCount()).toBe(0);
   });
 });

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -39,10 +39,11 @@ vi.mock("@/lib/local-ai-runtime", () => ({
   getLocalAiProxyRootUrl: () => "http://127.0.0.1",
   getLocalAiOpenAiBaseUrl: () => "http://127.0.0.1/setup-api/local-ai/ollama/v1",
 }));
+const invalidateMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-model-options", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/hermes-model-options")>()),
   getModelOptions: optionsMock,
-  invalidateModelOptions: vi.fn(),
+  invalidateModelOptions: invalidateMock,
 }));
 
 import { applyCloudProviderKeyToHermes } from "@/lib/hermes-cloud-provider";
@@ -99,6 +100,7 @@ beforeEach(() => {
   readConfigMock.mockResolvedValue(null);
   storeGetMock.mockReset();
   storeGetMock.mockResolvedValue(null);
+  invalidateMock.mockClear();
   _resetLocalAiReconcileForTests();
   _resetClawaiModelsReconcileForTests();
 });
@@ -170,6 +172,11 @@ describe("declaring a catalogue Hermes' own pickers read", () => {
   // models it lists change. Invalidate the browser's catalogue, ask the agent
   // for nothing. This is the same rule `reconcileLocalAiWithHermes` already
   // followed by calling the INNER write.
+  //
+  // BOTH HALVES ARE ASSERTED, because "ask the agent for nothing" on its own is
+  // also what a repair that invalidated NOTHING looks like: the browser would
+  // keep serving the catalogue from before the write, and this suite — which
+  // exists to own that population — would not notice.
   it("asks the agent for nothing when the ClawBox AI catalogue is declared", async () => {
     catalogueGrows(["openrouter", "clawai"], ["openrouter", "clawai"], "clawai");
     // ONE read of the whole `providers.clawai` block: Hermes decides what
@@ -191,6 +198,7 @@ describe("declaring a catalogue Hermes' own pickers read", () => {
     await reconcileClawaiModelsWithHermes();
     expect(cliMock.mock.calls.some((c) => (c[0] as string[])[1] === "set")).toBe(true);
     expect(reloadCount()).toBe(0);
+    expect(invalidateMock).toHaveBeenCalled();
   });
 
   it("asks the agent for nothing when the local catalogue is declared", async () => {
@@ -208,5 +216,6 @@ describe("declaring a catalogue Hermes' own pickers read", () => {
     await reconcileLocalAiWithHermes();
     expect(patchMock).toHaveBeenCalledWith({ set: { "providers.clawlocal.models": "qwen3:8b" } });
     expect(reloadCount()).toBe(0);
+    expect(invalidateMock).toHaveBeenCalled();
   });
 });

--- a/src/tests/unit/provider-write-paths.test.ts
+++ b/src/tests/unit/provider-write-paths.test.ts
@@ -28,7 +28,7 @@ const readConfigMock = vi.hoisted(() => vi.fn());
 vi.mock("@/lib/hermes-dashboard-rpc", () => ({ dashboardRpc: rpcMock }));
 vi.mock("@/lib/harness", () => ({ getActiveHarness: vi.fn(async () => "hermes") }));
 vi.mock("@/lib/hermes-cli", () => ({ runHermesCli: cliMock }));
-const storeGetMock = vi.hoisted(() => vi.fn(async (_key: string) => null as unknown));
+const storeGetMock = vi.hoisted(() => vi.fn<(key: string) => Promise<unknown>>(async () => null));
 vi.mock("@/lib/config-store", () => ({ get: storeGetMock, setMany: vi.fn() }));
 vi.mock("@/lib/hermes-config-yaml", () => ({
   patchHermesConfig: patchMock,
@@ -172,12 +172,19 @@ describe("declaring a catalogue Hermes' own pickers read", () => {
   // followed by calling the INNER write.
   it("asks the agent for nothing when the ClawBox AI catalogue is declared", async () => {
     catalogueGrows(["openrouter", "clawai"], ["openrouter", "clawai"], "clawai");
+    // ONE read of the whole `providers.clawai` block: Hermes decides what
+    // `models:` means from its siblings, and the same entry carries the
+    // `base_url` the orphan guard needs.
     cliMock.mockImplementation(async (args: string[]) => {
-      if (args[1] === "get" && args[2] === "providers.clawai.models") {
-        return { code: 1, stdout: "", stderr: "config key not set" };
-      }
-      if (args[1] === "get" && args[2] === "providers.clawai.base_url") {
-        return { code: 0, stdout: "https://clawbox.com/api/ai\n", stderr: "" };
+      if (args[1] === "get" && args[2] === "providers.clawai") {
+        return {
+          code: 0,
+          stdout: JSON.stringify({
+            base_url: "https://clawbox.com/api/ai",
+            api_mode: "openai",
+          }),
+          stderr: "",
+        };
       }
       return { code: 0, stdout: "", stderr: "" };
     });


### PR DESCRIPTION
## Symptom

On a Hermes-edition box the bot's Telegram `/model` reply offers
**`clawai (0)`** — no ClawBox AI (deepseek) model to pick — while the ClawBox
dashboard on the *same box* offers two. Owner: "on telegram the hermes bot does
not list the ClawBox AI (deepseek) model."

## Cause

Hermes builds its own pickers — the Telegram/Discord `/model` inline keyboard
(`gateway/slash_commands.py` → `list_picker_providers`) **and** its own dashboard
Models page (`/api/model/options` → `build_model_options_payload`) — from one
substrate, `list_authenticated_providers` (`hermes_cli/model_switch.py:2571`,
Hermes 0.20.5). For a custom OpenAI-compatible provider that function reads the
model set out of the `providers:` block of `~/.hermes/config.yaml` and then
probes `<base_url>/models` for a live one.

ClawBox wrote `providers.clawai.base_url`, `.api_key` and `.api_mode` — and no
`models:` at all. The probe cannot fill the gap: `probe_api_models`
(`hermes_cli/models.py:5592`) reads the OpenAI envelope `data[].id`, and the
ClawBox AI proxy answers

```
GET https://clawbox.com/api/ai/models
200 {"status":"ok","service":"ClawBox AI Proxy","models":["deepseek-v4-flash","deepseek-v4-pro"],"streaming":true}
```

— no `data` key — so Hermes parses an **empty** list. Nothing declared plus an
empty probe is exactly `clawai (0)`.

The two models the owner *does* see in our chat header come from a ClawBox-side
seed in `src/lib/hermes-model-options.ts`. That is the shape of the old fix: it
made our dashboard right and never reached the surface Hermes serves.

## The harness's own mechanism (used, not re-invented)

`providers.<slug>.models` in Hermes' own config is Hermes' documented answer for
this case — `list_picker_providers` keeps a custom endpoint's row precisely
because "the user may supply their own model set through config"
(`model_switch.py:3926`). It is written with `hermes config set` as a JSON list,
which the CLI stores as a real YAML list (`hermes_cli/config.py:5515`), the same
way this repo already writes `plugins.enabled`.

It is a **floor, never a ceiling**: a declared list only survives when the live
probe comes back *empty* (`model_switch.py:3423-3431`); a probe that answers
still wins. The day the proxy speaks the OpenAI envelope this stops mattering on
its own.

There is no Hermes CLI that could do it instead: `hermes model` is the
interactive TUI (the reason `hermes-model-options.ts` never calls it), and
`?refresh=true` only re-runs the probe that cannot parse this proxy.

## What changed

- `applyClawaiToHermes` declares `providers.clawai.models` — the two **chat**
  tiers only. The image and vision ids stay out: they exist so a picture can be
  drawn or looked at, and the proxy answers a chat turn on them with
  "Model not allowed".
- `applyLocalAi` declares `providers.clawlocal.models`. Same hole, worse:
  standby is the local model's normal resting state and a sleeping model answers
  no `/v1/models`, so that row was empty whenever the box was idle — the gap
  `normalizeRow` already patched for *our* header, on the surface we do not
  serve. Written as a plain scalar (an allowlist shape per
  `_declared_model_ids`, `model_switch.py:61`), which keeps it inside what the
  comment-preserving YAML splice can write.
- `removeLocalAi` unsets it again. Left behind it is a `providers.clawlocal`
  block naming a model with nowhere to send it, and Hermes renders a row for any
  entry that has models — the picker would go on offering the stopped model,
  which is the state that removal exists to end.
- Boxes already in the field carry the old config and nothing re-links them, so
  both providers get a **once-per-process backfill** on the model-options read,
  the pattern `reconcileLocalAiWithHermes` already established. What that
  backfill is allowed to conclude from a `hermes config get` is the subject of
  both review rounds below.
- The clawai id list moves to `CLAWBOX_AI_CHAT_MODEL_IDS` in
  `clawbox-ai-models.ts` and `COLD_START_MODELS` imports it, so the declared list
  and the seeded list cannot drift into disagreeing again.

## Sibling call sites

- **`clawlocal`** — same defect, fixed above (write, remove, backfill).
- **`hermes-dashboard-turn.ts:970`** — the mid-conversation switch back to
  ClawBox AI was refused by Hermes for the *same* reason ("the switch validates
  the model against the target provider's model listing and a
  `providers.<slug>` entry carries none"), falling back to a slower non-streamed
  CLI turn. The declaration removes that cause; the `modelSwitchTook` guard
  stays, because a refusal must still be read either way. Comment corrected
  there and in its test rather than left contradicting the code.
- **OpenClaw edition — CLEARED, no change.**
  `buildClawboxAiProviderDefinition` already writes both tier ids into
  `models.providers.deepseek.models[]`, so OpenClaw's own `/model` reads them
  from the harness's own store. Same for the local model, which the configure
  route registers in `openclaw.json`.
- Every other writer of the Hermes `providers:` block: there is none.
  `scripts/gateway-pre-start.sh` touches no Hermes config; the other
  `config.yaml` writers in `scripts/` are edition setup, MCP registration and
  dashboard auth. `ai-models/status/route.ts` only reads
  `providers.clawai.base_url`.

## RED → GREEN

RED, with the FINAL tests against unmodified `origin/beta` (`00aea577`) — the
picker list built by a mirror of Hermes' own reader over what each writer
actually emits. 20 failures across the three files; the load-bearing ones:

```
FAIL  src/tests/unit/hermes-provider-model-catalog.test.ts > offers both tier models even though the proxy's /models is unreadable
AssertionError: expected [] to deeply equal [ 'deepseek-v4-flash', …(1) ]
- [ "deepseek-v4-flash", "deepseek-v4-pro" ]
+ []

FAIL  src/tests/unit/hermes-local-ai.test.ts > declares the model so Hermes' own picker has one while it sleeps
AssertionError: expected [ …(3) ] to include 'providers.clawlocal.models=gemma4-e2b…'

FAIL  src/tests/unit/hermes-local-ai.test.ts > unregisters on disable so the picker stops offering a stopped model
AssertionError: expected [ Array(3) ] to deeply equal [ Array(4) ]
-   "providers.clawlocal.models",

FAIL  src/tests/unit/hermes-local-ai.test.ts > declares it in a shape Hermes' own picker reads
AssertionError: expected [] to deeply equal [ 'qwen2.5:3b' ]
- [ "qwen2.5:3b" ]
+ []

FAIL  src/tests/unit/hermes-local-ai.test.ts > declares the model on a device registered before the catalogue existed
AssertionError: expected [] to deeply equal [ Array(1) ]
- [ "providers.clawlocal.models=qwen3:8b" ]
+ []

Test Files  3 failed (3)
     Tests  20 failed | 20 passed (40)
```

(`provider-write-paths.test.ts` fails wholesale on beta at import — it now pins
the two new `invalidateModelOptions()` sites and imports a reset seam beta does
not have. Noted so the count is not read as twenty assertions.)

GREEN — the three changed files, then every suite that imports any changed
module (selected by grep, not by hand):

```
Test Files  3 passed (3)      Tests  40 passed (40)
Test Files 55 passed (55)     Tests 885 passed (885)
```

`tsc --noEmit` clean; eslint clean on the changed files apart from one warning
that is also on beta (`CLAWBOX_AI_VISION_MODEL_ID` unused in `hermes-clawai.ts`)
and is left for whoever owns that import.

The whole suite was run once locally as CI runs it (`bun run test:coverage:ci`,
647 files / 9336 tests, exit 0) before the review round; the machine is running
seven agents and local full-suite runs are flaking in unrelated files, so it was
not re-run — **CI's `test` job is the arbiter for this head.**

## Verified against the real Hermes on hardware (read-only)

Run on the Hermes-edition box against the installed Hermes 0.20.5, using only
its own pure readers and a throwaway `HERMES_HOME` under `/tmp` — the real
`~/.hermes/config.yaml` was sha256- and mtime-identical before and after every
probe, no mutex taken, no setting changed, no credential added, no message sent:

```
clawai       declared=['deepseek-v4-flash', 'deepseek-v4-pro'] allowlist=True -> picker shows ['deepseek-v4-flash', 'deepseek-v4-pro']
clawlocal    declared=['gemma4-e2b-it-q4_0']                   allowlist=True -> picker shows ['gemma4-e2b-it-q4_0']
beta-clawai  declared=[]                                       allowlist=False -> picker shows []
```

i.e. the owner's `clawai (0)` reproduced from Hermes' own code, and the shape
this PR writes turning it into two. `hermes config set providers.clawai.models
'["…","…"]'` in the scratch home produced a real list, and PyYAML parses the
scalar form the local path writes (`models: qwen2.5:3b`) as the string
`'qwen2.5:3b'`.

## Finding for the portal (not fixable in this repo)

`GET https://clawbox.com/api/ai/models` does not answer the OpenAI `/v1/models`
envelope, so **every** OpenAI-compatible client's model discovery against the
proxy sees zero models — Hermes is just the one that showed it. Serving
`{"object":"list","data":[{"id":"…","object":"model"}]}` would make this
declaration unnecessary and close the same class for any other client.

## Review

One Opus reviewer, high effort, over the full diff and its callers: 2 high,
5 medium, 7 low. Applied:

- **H1 — the repair latched on a question that FAILED.** `hermes` is a shim over
  a venv Python and `step_hermes_install` rebuilds that checkout for ~90 s with
  no web-server restart, so it runs and exits 127 without reaching argparse. The
  once-per-process flag was set before asking and kept whatever came back, so
  the update shipping this fix could permanently skip the repair. Both repairs
  now unlatch on a failed question and a failed write, via the `hermesCliAnswered`
  helper that already existed for exactly this. Two regression tests.
- **H2 — the local scalar write was a new way to destroy the config's comments.**
  Hermes caches its own discovered catalogue under the same key as a nested
  block; `setYamlPath` refuses a leaf that opens one, and that refusal drops the
  WHOLE patch onto `hermes config set`. `localCatalogueState()` now reads
  absent / scalar / foreign / unknown and only the first two are ours to write.
- **M7 — the backfill re-ran the whole registration.** It now writes one key. The
  re-register path substitutes a llama.cpp default for an unreadable model id,
  which on an Ollama box would have declared a model that endpoint cannot serve.
- **M6** — both new `invalidateModelOptions()` sites are pinned in
  `provider-write-paths.test.ts`, the suite that owns that population, with the
  reason no MCP reload belongs there (it hangs off the route the agent's own
  `ai_list_models` reads).
- **M4** — the Hermes-reader mirror moved to `src/tests/helpers/`, and the local
  writer is now judged by it too; the "could not be read" test was rewritten so
  it can only pass through the gate it is named after.
- **M3** — the tier claim was wrong: `deepseek-v4-pro` is Max-only. Both are still
  declared (that is what `normalizeRow` and the OpenClaw definition already do,
  and the portal can move a tier without re-running any writer), and the comment
  now says so, including the real gap: Hermes' row carries no "Max plan only"
  label where the ClawBox pickers do.
- **L11** — the seed now runs only when Hermes reported an empty row, so a live
  list can never be topped up with stale ids.
- **L10, L12, L9** — the YAML editor's contract, the failed-write log, and the
  over-claimed "one truth" (`CLAWAI_MODELS`/`CLAWAI_STATIC_MODELS` still spell
  the ids out beside their labels) corrected.

Refuted: **L14** (extract the duplicated `vi.mock` preamble) — `vi.mock` calls
are hoisted per file and do not apply from an imported helper, so only the
mirror was extractable, and it was. **M5** was a working-tree/commit mismatch
during the review, now committed. **L13** (extra CLI spawns) is accepted and
measured down rather than removed: checking the catalogue key first makes a
settled box pay one `hermes config get`, once per process.

## Stated trade-off — WITHDRAWN

An earlier draft of this PR wrote the local `models:` unconditionally and this
section explained why a hand-written dict-shaped catalogue would be replaced.
H2 made that write conditional (`catalogue === "absent" || "scalar"`), so the
trade-off no longer exists: a dict-shaped `clawlocal` catalogue is `"foreign"`
and is left alone. Kept as a struck note rather than deleted, because the
sentence was in the body the first reviewer read.

Board: TASK-681 (under TASK-604).

---

# Review round 2 — head `80447df1` → `7772ea5f`

A second Opus pass sent the PR back: 0 high, 4 medium, 5 low. Nothing in it
disputed that the fix works on a healthy box; what it found is that the repair
could latch itself off in two of the states it was written to survive.

**M1 (probe-once).** `if (!/config key not set/i.test(listing)) return;` returned
with the once-per-process flag still set. A `hermes config get` that exits
non-zero for any reason other than that exact wording — an EACCES on
`config.yaml`, Hermes' own `filelock` held by an interactive CLI, a parse error —
latched the repair off for the life of the Next.js process. During the ~90 s
`step_hermes_install` window (checkout moved aside, no web-server restart) the
update *shipping this fix* could therefore skip the repair permanently, silently.
The sibling written in this same PR, `localCatalogueState`, already maps that
identical result to `"unknown"` and retries; the clawai reader now mirrors it.

**M2 (false success).** `if (declared.code === 0) return;` accepted *any* existing
value as "already declared". A `providers.clawai.models` that is a **mapping** is
not an allowlist to Hermes, so the empty proxy probe replaces it and the keyboard
says "clawai (0)" **with a populated `models:` in the file** — forever, and with
no log line.

**M3.** The `models.length === 0` seed gate in `hermes-model-options.ts` shipped
untested; reverting it left the whole suite green. New file
`hermes-model-options-clawai-seed.test.ts` builds a real clawai dashboard row.

**M4 → TASK-691** (under TASK-604), not fixed here. Hermes' keyboard now offers
`deepseek-v4-pro` as a bare id on Free and Pro boxes, where ClawBox's own pickers
carry "1.6T frontier model. Max plan only." Declaring both ids stays deliberate —
the portal moves a tier without re-running any writer on the box, so a
tier-derived list would lock an upgraded box out of what it just paid for — but
the missing label is real, and a mapping cannot carry it (Hermes reads a mapping
as *not* an allowlist, which puts the box straight back to "clawai (0)").

**Lows.** L1 (the test mirror was missing `_entry_models_discovered` and the
`_NativePickerModelList` disjunct), L4 (a local enable that could not read the
catalogue left the key missing until restart) and L5 (`probe_api_models` is at
`models.py:5592`; `:5668` is the `data[].id` line inside it) applied. L2 and L3
were argued rather than fixed — round 3 settled both, see below.

# Review round 3 — head `7772ea5f` → `b201daaf`

A third Opus pass over the rework: 3 process, 3 medium, 5 low. Two of the
mediums are defects the rework itself introduced. Verdict was SEND BACK; all
three are fixed here.

## M3 (round 3) — reading the leaf let the repair destroy a working pin

The worst of the three, and the direct answer to "does overwriting an `ignored`
value ever destroy something the owner meant to keep": **yes.**

`providers.clawai.models` only means what Hermes says it means, and Hermes
decides that from two **siblings** the repair never looked at:

- **`discover_models: false`** is Hermes' documented way to pin a catalogue of
  any shape. Its own source says so: *"A dict-shaped `models:` is per-model
  metadata … Pin with `discover_models: false` instead"* (`model_switch.py:3362`)
  and *"`discover_models: false` is the documented way to pin, and it is honored
  above"* (`:3777`). With discovery off **no probe runs**, so the mapping is
  exactly what the keyboard shows — that owner has **no symptom at all**, and the
  repair would have overwritten their pin and its per-model metadata to fix
  nothing.
- **`models_discovered: true`** makes `_models_config_is_allowlist` return False
  *whatever the shape* (`:136`). A list written beside it is ignored too, so the
  repair would have latched "written" over a keyboard still saying "clawai (0)" —
  a false success, and the state the round-2 body *refuted* L2 by arguing was
  unreachable. It is now handled instead of argued.

Both are read from **one** `hermes config get providers.clawai --json`, which
also carries the `base_url` the orphan guard needs — so the repair now makes
**one** CLI spawn where it used to make two. That entry contains `api_key`, so no
branch logs `stdout`; a test asserts the token never reaches the journal.

Proven against the installed Hermes on a Hermes-edition box, in a throwaway
`HERMES_HOME` under `/tmp` — the box's real `~/.hermes/config.yaml` was sha256-
identical before and after every probe (`0087e962…af3ea`), no mutex taken, no
setting changed, no credential touched, no message sent:

```
--- a MAPPING-shaped models:, read as the repair reads it ---
{"deepseek-v4-flash": {"context_length": 65536}}    rc=0
--- what Hermes' own rule says about it ---
discover_models = False  -> a live probe runs: False
is_allowlist(mapping)    = False
declared ids             = ['deepseek-v4-flash']
=> with discovery off the mapping IS the keyboard: no symptom, and the
   repair would have overwritten the pin.
```

and, with no pin beside it, the same mapping is the real defect:

```
is_allowlist = False -> empty probe wins  -> picker shows: []
after the repair's write, verbatim argv:
["deepseek-v4-flash", "deepseek-v4-pro"]
is_allowlist = True  -> empty probe loses -> picker shows both ids
```

## M2 (round 3) — the unlatch had no bound

H1's unlatch is right, and on its own it removed the only thing bounding what a
failure costs. `GET /setup-api/hermes/models` awaits **both** repairs before it
serves anything, each read carries `timeoutMs: 15_000`, and that route is what
the chat header, the Settings panel, `HermesProviderConfig` and the agent's own
`ai_list_models` all read. On a box whose `hermes` is wedged — a filelock held by
an interactive CLI, a half-built venv — every request paid it, where beta paid it
once per process.

Both repairs now hold a failed attempt for `REPAIR_RETRY_MS` (60 s) — the same
span, and the same reasoning, as `FAILED_READ_TTL_MS` in `hermes-config-cache.ts`,
which exists so a hanging `hermes` cannot become one Python start per request.

## M1 (round 3) — the one exit the field will actually reach was the silent one

The failed write warns and the catch errors, but `"unknown"` returned with no
line at all — and `"unknown"` is where a box lands when its config is unreadable
or its CLI predates a flag. Every verdict that is not an ordinary box now logs
one line; the two ordinary ones (already declared, never linked) stay quiet,
because otherwise every box on the fleet prints one a boot.

That also bounds the `--json` risk the reviewer raised. `--json` is not new API —
the CLI's own usage line is `hermes config get <key> [--json]` (`config.py:5769`)
— and `step_hermes_install` reinstalls Hermes to `HERMES_PIN_COMMIT` whenever the
checkout's HEAD differs (`install.sh:1729`), with the probed box sitting exactly
at that pin (`fcbd1076…`). A box moved off it by a hand-run `hermes update` could
still meet a CLI that rejects the flag: that answers `"retry"`, which is now
logged and rate-limited rather than repeated per request, and it can never
produce a wrong write.

## Lows (round 3)

**Applied.** *A failure backoff on a non-failure* — the hand-back in
`applyLocalAi` first reused `retryLater()`, which stamped a 60 s wait onto a path
where nothing had failed: the enable could not read the key, so the very next
read should repair it. Split into `handRepairBack()` (no backoff, and it runs on
an explicit customer action rather than per request) and `retryLater()` (a failed
attempt). *The stale trade-off paragraph* — rewritten above; it described the
unconditional local write H2 removed. *A stale local scalar* —
`declareLocalCatalogue` used to write only a MISSING key, so a box whose model
changed while the CLI was unreadable kept offering the old id; `"scalar"` is the
shape this module writes, so it is now refreshed when it no longer names the
configured model. *Env-overridable ids* — the seed test imports
`CLAWBOX_AI_FLASH_MODEL_ID` / `CLAWBOX_AI_PRO_MODEL_ID` instead of spelling them
out, so a runner that overrides either does not fail the suite. *No harness gate*
— both repairs open with a `hermes` spawn and had none; one `getActiveHarness()`
check now sits at the call site, in front of both, rather than in two modules
each assuming their own edition.

**Refuted.** *Replace `localCatalogueState`'s second read with beta's new
`hasYamlPath`.* Declined here, with a reason. `hasYamlPath(text, path)` answers
"is this key literally in this file"; the CLI read answers "what will Hermes
resolve", through `load_config()` — defaults, the managed layer, env-bridged
keys. The entire bug class this PR exists to close is ClawBox and Hermes
disagreeing about the same config, so swapping the authoritative reader for a
textual one is the wrong direction to take *in this PR*. It is also not a
drop-in: `readHermesConfigValue` returns `null` for an unreadable file exactly as
it does for an absent key (`hermes-config-yaml.ts`), so a file-only
`localCatalogueState` would silently turn `"unknown"` into `"absent"` and write
over a config it could not read — precisely the H2/M1 defect, reintroduced. It
needs an error-propagating reader first, which is a change to a module this PR
does not own.

## Sibling call sites

Every reader in the tree that has to tell "unset" from "could not read":

- `hermes-local-ai.ts` `localCatalogueState` — the pattern the clawai reader
  mirrors; already returns `"unknown"` and retries, and now shares the backoff.
- `hermes-clawai.ts` `auxiliary.vision.model` — an unreadable config sets
  `visionModelId = null`, i.e. *write nothing*. A per-call decision, never a
  process-lifetime latch. **Clear.**
- `hermes-clawai.ts` `plugins.enabled` — throws on an unreadable config rather
  than merging onto an assumed-empty list. **Clear.**
- `hermes-config-cache.ts` — already separates answered from failed and holds a
  failure for `FAILED_READ_TTL_MS`. **Clear**, and the precedent the new backoff
  copies.
- `localCatalogueState`'s `"foreign"` branch has the shape question too (an empty
  list there is left alone), but the local path refuses a non-scalar for a
  different, documented reason: `setYamlPath` aborts the whole comment-preserving
  patch onto the CLI fallback, which is what H2 exists to prevent. The clawai
  path has no such constraint. **Named, not widened into this PR.**

## RED → GREEN

Round 2, against head `80447df1`:

```
FAIL  hermes-provider-model-catalog.test.ts > tries again after a catalogue read that FAILED rather than answered
FAIL  hermes-provider-model-catalog.test.ts > declares the catalogue over a value Hermes does not read as an allowlist
FAIL  hermes-provider-model-catalog.test.ts > declares the catalogue over an empty list
FAIL  hermes-provider-model-catalog.test.ts > asks the CLI for the catalogue as JSON
AssertionError: expected [] to deeply equal [ 'deepseek-v4-flash', …(1) ]
Tests  4 failed | 13 passed (17)
```

Round 3, by surgical revert in a scratch export (`rsync` of the tree with
`node_modules` symlinked; the worktree was never modified):

```
# drop the discover_models / models_discovered guards
FAIL  > leaves a catalogue the owner pinned with discover_models: false alone
AssertionError: expected true to be false          <- it overwrote the pin
FAIL  > leaves a catalogue Hermes persisted for itself alone
AssertionError: expected true to be false          <- false success

# drop the retry backoff
FAIL  > does not re-ask on every request while the CLI keeps failing
AssertionError: expected 3 to be 1
FAIL  hermes-local-ai.test.ts > does not re-ask on every request while the CLI keeps failing
AssertionError: expected 3 to be 1

# drop the "retry" log line only
FAIL  > says why it walked away, on every path that is not an ordinary box
AssertionError: expected "warn" to be called at least once

# drop the stale-scalar refresh
FAIL  hermes-local-ai.test.ts > refreshes a declared id this module wrote and no longer matches
AssertionError: expected [] to include 'providers.clawlocal.models=qwen3:8b'

# drop the harness gate
FAIL  models-refresh-auth.test.ts > spawns no `hermes` repair on an OpenClaw box
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

# revert `&& models.length === 0` in normalizeRow (round 2's M3)
FAIL  hermes-model-options-clawai-seed.test.ts > leaves a non-empty row exactly as Hermes reported it
FAIL  hermes-model-options-clawai-seed.test.ts > does not invent our ids beside a live catalogue that renamed them

# revert `reconciled = false` in applyLocalAi (round 2's L4)
FAIL  hermes-local-ai.test.ts > hands the catalogue back to the repair when an enable could not read it
```

GREEN — every suite that imports any changed module, selected by grep:

```
Test Files 107 passed (107)     Tests  1387 passed (1387)
```

`tsc --noEmit` clean. eslint clean on every changed file bar one warning that is
also on beta (`CLAWBOX_AI_VISION_MODEL_ID` unused in `hermes-clawai.ts`), left
for whoever owns that import; the one warning this PR *had* introduced
(`_key` in `provider-write-paths.test.ts`) is gone. The full suite is **CI's
`test` job**, as before.

## Not proven on hardware

The end-to-end claim — an owner opens Telegram, types `/model`, and sees two
ClawBox AI models where the box previously said "clawai (0)" — is **not** proven
on a device in this PR. The brief for this round is read-only on the box: no
mutex, no setting, no Telegram message. What *is* proven on the pinned Hermes
build every box runs is every link in the chain: the printed shapes, the
allowlist predicate, the `discover_models` gate, the entry read, and the write's
effect on Hermes' own reader. The reviewer's remaining worry — that the long-running
gateway serves the config it started with, the way the token path does
(`hermes-telegram.ts`, which is why a token change restarts the unit) — was
checked read-only on the box and does **not** apply here: Hermes' `load_config()`
is *"Cached on the config file's (mtime_ns, size)"* (`hermes_cli/config.py`), so
a `hermes config set` invalidates it and the picker re-reads on its next call. No
gateway restart is needed for the repair to show up.

What is still unproven is only the last click: nobody has typed `/model` into
Telegram on a repaired box, because this round's brief is read-only on hardware —
no mutex, no setting, no message. **One owner check after merge closes it.**

Board: TASK-681, and TASK-691 for the M4 follow-up.


# Review round 4 — head `b201daaf` → `1360d384`

A delta review returned **MERGE** (0 high, 0 medium, 5 low) and confirmed the
`discover_models` / `models_discovered` reading exact against the installed
Hermes 0.20.5. Three of its lows plus both CodeRabbit threads are fixed here;
each is RED-verified by revert.

**A pin that pins nothing is not a pin.** The `discover_models: false` check ran
before anything looked at `models`, so a block carrying that flag with **no**
`models:` (or an empty list) was treated as a pin. Nothing is pinned there:
Hermes runs no probe (`_discovery_allowed`, `model_switch.py:3788`), finds no
declared id, and the row is **empty** — the exact "clawai (0)" this PR exists to
fix, reached down the one path that walked away calling it a pin. The gate now
also requires the entry to yield at least one id, asked through
`_declared_model_ids` rather than the allowlist rule, because with discovery off
even a mapping's keys are displayed.

**Exit 0 is not a write.** `hermes config set k '["a","b"]'` exits 0 even when its
structured parse did not yield a list: it prints `…storing as string.` to stderr
and saves the literal text (`hermes_cli/config.py:5518-5530`), which
`_models_config_is_allowlist` then accepts as a **one-id** allowlist — a single
bogus model in the keyboard, with the repair latched "done" over it. Not
reachable on the pinned build, which is exactly why it is worth a guard on a
repair that runs unattended on every field box rather than a comment.

**The coercion mirror was wider than the Python.** `flag.trim().toLowerCase()`
against Hermes' bare `discover.lower()` (`:3371`, `:3603`) meant a quoted
`" false "` was discovery-ON to Hermes and OFF to ClawBox — the empty probe wipes
the block while the repair declines to touch it. Trim dropped; the comment
claiming exactness is now true.

**Both CodeRabbit threads**, answered in-thread and fixed. An endpoint-less
`providers.clawai` block returned an empty reason and so produced no journal
entry at all; it now names the provider (and nothing else — that entry carries
`api_key`). And `provider-write-paths.test.ts` mocked `invalidateModelOptions`
with an inert `vi.fn()`, so both repairs could have stopped invalidating with the
suite that owns that population still green; it is now hoisted, reset and
asserted in both repair tests — verified to fail when the two
`invalidateModelOptions()` calls are actually deleted.

Two delta lows are left, both named rather than fixed: the local scalar's value
is read twice (a file parse, not a spawn, whose worst outcome is writing our own
configured model), and `handRepairBack()` can clear a backoff set moments earlier
by a genuinely wedged CLI, costing one extra attempt.

```
FAIL > declares a catalogue for a pin that pins nothing
FAIL > declares a catalogue for a pin holding an empty list
FAIL > reads `discover_models` exactly as Hermes coerces it
AssertionError: expected [] to deeply equal [ 'deepseek-v4-flash', …(1) ]
FAIL > says so when the block carries no endpoint
AssertionError: expected "log" to be called at least once
FAIL > treats a write the CLI stored as a STRING as a failure
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
FAIL > asks the agent for nothing when the ClawBox AI catalogue is declared
FAIL > asks the agent for nothing when the local catalogue is declared
AssertionError: expected "vi.fn()" to be called at least once   (with the real calls deleted)
```

GREEN: `Test Files 107 passed (107) · Tests 1393 passed (1393)`, `tsc` clean,
eslint clean bar the one warning also on beta.



# Review round 5 — head `1360d384` → `4d178e8f`

Three commits: the last CodeRabbit thread, an Opus review of that commit, and an
Opus review of *that*.

## `83212b5e` — a catalogue stored as text is residue, not a declaration

CodeRabbit's remaining thread (`hermes-clawai.ts:586`) was right about the state
and wrong about where to fix it. A `models:` holding the literal text
`["deepseek-v4-flash","deepseek-v4-pro"]` is the one broken shape Hermes reads as
a perfectly good one: run over the installed 0.20.5, `_declared_model_ids` (`:61`)
yields **one** id — the whole literal — and `_models_config_is_allowlist` (`:136`)
says True. So the keyboard offers a single unusable entry and both "already
declared" branches walked away from it, the silent one silently. It is also the
residue of round 4's own write guard: `hermes config set` saves the text and
exits 0, so the value is in the file before that guard sees any warning.

**Not fixed the suggested way, and the thread says why.** Teaching
`isHermesAllowlist` to reject structured-looking strings would make a function
whose docstring claims a faithful transcription of `_models_config_is_allowlist`
lie about the harness — that Python genuinely returns True for the string — and
it is also consumed by `hermesDeclaresAnyId`, where the wide reading is
load-bearing: a pinned (discovery-off) string catalogue really is displayed.
Instead a new classifier mirrors the CLI's OWN `_looks_structured_value`
(`config.py:5322`), the function that decides whether `config set` attempts a
`yaml.safe_load` at all, so the two ends of the same write agree by construction;
a value it accepts is re-declared, and `deepseek-v4-flash` (or `-5`) still stays
a pin.

## `08a753a6` — a write nobody read back is not a declared catalogue

**A clean stderr is not a landed write (false success).** The guard judged its
write by `written.code` plus `/storing as string/i`. That warning only exists on
a CLI whose coercion block prints it, so it cannot speak for one old enough to
lack the block, where the same literal is stored as text with an **empty stderr
and exit 0**. On such a box the repair rewrote the residue, called it done,
latched, and left the keyboard showing one bogus id with a journal line that
reads like a repair that worked.

The write is now verified by reading the key back:

```
hermes config get providers.clawai.models --json
```

**Leverage the harness first — and the finding is an asymmetry.** `--json` on
`config get` (`config.py:5769`) is the harness's own machine-readable reader and
the *only* verification lever Hermes offers: `set_config_value(key, value: str,
force=False)` (`config.py:5383`) is the single write entry point and takes no
type, which is why a JSON literal through `_looks_structured_value` is the
harness's way to store a list in the first place. Nothing here reaches into
Hermes' store. The OpenClaw half of this same repo *does* get a typed set
(`spawnOpenclaw(["config","set", …, "--json"])`, ~20 call sites, plus
`--batch-json`), so the literal-plus-read-back dance is a workaround for a
capability Hermes lacks and OpenClaw has. That asymmetry is the finding; there is
no better Hermes mechanism to use.

The **leaf**, not the block, is read deliberately: the entry the deciding read
takes carries `api_key`, and this key cannot, so the verification never holds a
credential.

**`models_discovered` only beats the reading a probe can act on.** The flag was
checked first and treated as beating every reading of `models:`. It beats the
**allowlist** one — `_models_config_is_allowlist` returns False whatever the
shape (`:136`) — and that reading only decides anything if a probe can replace
what it refused. With `discover_models: false` beside it, `_discovery_allowed`
(`:3788`) is False, `grp["models"] = live_models` (`:3823`) never runs, and the
row is exactly what `_declared_model_ids` finds. An entry carrying both flags and
no readable `models:` is therefore **empty** — the same "clawai (0)" — and a
write there is permanent, because no probe can come back to undo it. Declining it
stranded a box a single write fixes for good. The branch is now
`hermesOwnsCatalogue(row) && hermesDiscoversModels(row)`.

## `4d178e8f` — a repair that has proved it cannot work must stop trying

A second Opus pass over that commit: 3 medium, 3 low, 2 nit. All applied bar one,
which is named below.

**M1 — the guard was right and its failure path was not.** On the proof that the
CLI had stored our literal as text, the repair `unlatch()`ed — so 60 s later the
whole cycle ran again: deciding read, `config set`, verification read. The value
written is a **constant** and the CLI's parse of it cannot come out differently
under a running process, so every repetition was known futile before it was
issued and each one re-serialised the customer's `config.yaml` through
`save_config`. Measured on a fake non-coercing CLI: ten simulated minutes →
**ten writes, thirty spawns**, never converging, against this module's own rule
that a repair which keeps failing must not become a Python start per request.

The verification now answers three ways, and only one of them is a retry:

| outcome | meaning | what happens |
|---|---|---|
| `landed` | the key reads back as our ids | invalidate the catalogue, latch |
| `stored-as-text` | the CLI handed our own literal back as a string | report and **latch** — the same write cannot land on this CLI |
| `unverified` | the question failed or answered something else | report and retry on the 60 s cadence |

Latching is not the false success round 4 removed: nothing is claimed, the
journal names the reason, and the next process start tries once more, because the
residue is still in the file for the deciding read to find. The pre-existing
stderr-warning branch is the same proof and now gets the same treatment. The
verification also no longer throws — `runHermesCli` rejects on a spawn failure or
a timeout, and letting that reach the caller's `catch` logged
`catalogue reconcile failed` over a write that had actually landed.

**M2 — `--json` on the verification read was unpinned.** Deleting the flag left
all 42 tests green, while on a box the CLI renders a list through
`yaml.safe_dump` and every repair would report "could not declare" over a write
that landed. The "one call" test now pins the **whole argv sequence**, which also
restores the total-spawn bound it had lost and removes a `findIndex` that returns
`-1` when no write happens and then silently drops the last call from the
comparison. Verified: dropping `--json` is now RED.

**L2** — two comments contradicted each other about which build reaches the
stored-as-text fault (one said "not reachable on the pinned build", the new one
said it "is the build this repair is reached on"). Reworded to the actual
intersection — off-pin, `--json` still accepted on `config get`, coercion gone
from `config set` — and to the wider reason the guard is worth having anyway.
**L3** — the repair now declares beside a `models_discovered: true` it does not
clear, which a test comment said no writer may do; that rule holds while
discovery is ON, and the limit it leaves (an owner who later turns discovery back
on returns that box to the symptom) is named at the branch rather than papered
over. **NIT** — the picker mirror does not model `_discovery_allowed`, so a
discovery-off entry must be asked with a null probe; written into its docstring
instead of left as a convention two tests depend on.

## Sibling call sites (this round)

- **`applyClawaiToHermes` (`hermes-clawai.ts:191`) — FIXED.** The link path every
  fresh box takes writes the same key through the same `hermes config set` and
  can fail the same silent way. It does **not** throw over it — a box whose
  catalogue went in as text still chats, sees and draws, so failing the link
  would be a false failure on a working device — it calls `handClawaiRepairBack()`
  so the next models read verifies the write. That hand-back closes a second hole
  on its own: on an unlinked box the repair has usually already run and latched
  its silent "no `providers.clawai`", so nothing looked at the residue until the
  web server restarted. Bounded: all three callers of `applyClawaiToHermes` are
  one-shot customer actions (the clawai poll finaliser, the configure POST, the
  Settings save), so each hand-back costs at most one extra reconcile cycle.
- **`enableHermesImageGeneration`'s `plugins.enabled` (`hermes-clawai.ts:855`) —
  NOT CLEARED. A real residual, named rather than folded in.** It is the one
  other structured `hermes config set` in the repo, judged by `r.code !== 0`
  alone, and it is *worse* than the models case: `mergePluginsEnabled` reads the
  residue back through `parseYamlList`, whose flow-list branch decodes the
  literal string as if it were a real list, sees `clawai` already present and
  returns `null` — so the key is never rewritten and the residue is permanent.
  `hermesAgentDrawsImages` reads only the scalar `image_gen.provider`, which
  stores fine, so the box reports `canGenerateImages: true` and offers a composer
  button for a tool the agent does not have. It belongs to the image path, not
  the catalogue, and widening a head that has been through six rounds into it
  would ship an unreviewed change; the one-line direction is to teach
  `parseYamlList` to refuse a string whose content is a flow list. **Owed a board
  task, not a silent omission.**
- **`hermes-local-ai.ts` — CLEARED.** It writes a **scalar** through the
  comment-preserving splice, so there is no structured parse to fail;
  `patchHermesConfig` already verifies its own write by re-reading the parsed
  document, and `declareLocalCatalogue` repairs by VALUE on every reconcile, so
  even a structured-looking scalar self-heals.
- **`hermes-config-yaml.ts:135` `applyViaCli`, `hermes/models/route.ts:264`
  `setKey`, `hermes-tts.ts:236` — CLEARED.** Every value they send is a scalar
  (`base_url`, `api_key`, `api_mode`, a bare model id, a provider slug), so
  `_looks_structured_value` never fires and "stored as a string" is the intended
  outcome, not a failure.
- **`ai-models/status/route.ts`** reads `providers.clawai.base_url` only. The
  OpenClaw edition writes `models.providers.deepseek.models[]` through OpenClaw's
  own typed `config set --json` — a different store and a different CLI, and both
  repairs stay behind the single `getActiveHarness() === "hermes"` gate at
  `hermes/models/route.ts:96`, unchanged.

## RED → GREEN (round 5)

RED, the three new tests against this branch **before** their fix:

```
FAIL > declares a catalogue Hermes flagged as discovered but can never re-probe
AssertionError: expected [] to deeply equal [ 'deepseek-v4-flash', …(1) ]

FAIL > does not claim a repair the CLI stored as text without saying so
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
   (invalidateModelOptions claimed over a write the CLI silently stored as text)

FAIL > looks again at the catalogue the LINK path just wrote
AssertionError: expected [] to deeply equal [ 'deepseek-v4-flash', …(1) ]
```

and the review's own probe, re-run after its fix — dropping `--json` from the
verification read used to leave the suite green and is now RED:

```
FAIL > asks for the whole provider block in one call
AssertionError: expected [ [ 'config', 'get', …(2) ], …(2) ] to deeply equal [ [ 'config', 'get', …(2) ], …(2) ]
      Tests  1 failed | 34 passed (35)
```

GREEN: the whole unit tree, `Test Files 358 passed · Tests 6182 passed`;
`hermes-provider-model-catalog` 35/35, `provider-write-paths` 8/8,
`hermes-local-ai` 27/27; `tsc --noEmit` clean; eslint clean on the changed files
bar the one warning also on beta.

The test's fake `hermes` now **remembers** what `config set` sent it and answers
a leaf read from the same store — which is what makes the read-back expressible
as a test at all — with a `coerces: false` mode modelling the CLI that stores a
list literal as text without warning.

## Unproven

`hermes config get <nested leaf> --json` was **not** re-run on a box for this
round: no device was touched in it. `--json` is argparse-level on `config get`
(`config.py:5769`) and the whole-block form was proven on `BOX_HERMES` in round
3, but the leaf form has not been. If that build did reject it the failure is
bounded and self-limiting — the verification answers `unverified`, one journal
line is logged, `invalidateModelOptions()` is skipped for up to the 60 s catalogue
freshness window, and the next deciding read finds the healthy list and latches —
never a wrong write. **One box read clears it:** run
`hermes config get providers.clawai.models --json` on a linked Hermes box and
check it prints JSON.



# Review round 6 — head `4d178e8f` → `32b5b680`

A delta review of `4d178e8f` returned **BLOCK**: 1 high, 4 medium, 3 low/nit. The
high is the other half of round 5's own fix.

## H1 — the `unverified` branch had a rate bound and no total bound

Round 5 latched the one failure it can prove final (`stored-as-text`) and left
every other non-landing write on `unlatch()`, which sets a 60 s floor and nothing
else. `REPAIR_RETRY_MS` bounds how **often**; nothing bounded how **many**, and
there was no attempt counter in the module.

A `hermes config set` that exits 0 without the key landing — a `config.yaml` the
web-server user cannot write, a full partition, a `save_config` that loses a
filelock race, a refusal that still exits 0 — is a property of the box, not a
moment, and it reads back exactly like a key that was never written. **Measured
on a linked Hermes box:** `hermes config get providers.clawai.models --json`
exits **1** with `Config key not set: providers.clawai.models` when the key is
absent. (That also closes round 5's "Unproven": the **leaf** form takes `--json`
— it is one argparse sub-command with the block form, which round 3 proved on the
box.) So every 60 s, for the life of the web server: deciding read → `"write"`,
`config set` → exit 0, verification read → exit 1 → `unverified` → `unlatch()`.
One customer `config.yaml` rewrite plus three Python starts a minute, on
`GET /setup-api/hermes/models`, which **awaits** this repair before it serves the
chat header, the Settings panel or the agent's own `ai_list_models`. `origin/beta`
has no repair at all, so this PR would have *introduced* that write
amplification rather than inherited it.

Bounded twice now. `REPAIR_MAX_UNVERIFIED_WRITES = 3`: three writes this process
could not read back, then it latches with one distinct journal line
(`giving up on the ClawBox AI catalogue after 3 writes that could not be read
back — not retried before the next restart`). Cleared by a write that **lands**,
and otherwise only by a restart — the next process start tries once more, because
the deciding read still finds the key missing. A re-link's `handClawaiRepairBack()`
deliberately does **not** clear it: a customer action is worth one more attempt,
not a fresh three.

**It counts WRITES, not failed QUESTIONS.** A `config set` that exits 126/127 is
the shell's code, not the CLI's — the `hermes` shim running while
`step_hermes_install` rebuilds the venv under it — so nothing was parsed, nothing
was written and no `config.yaml` was re-serialised. `hermesCliAnswered` keeps
those off the counter; without that, a 90 s rebuild would spend the whole budget
on the exact transient the unlatch exists for and the box would come out of its
own update still saying "clawai (0)".

RED, against this branch's own head `4d178e8f` — the test cannot run on
`origin/beta`, where `reconcileClawaiModelsWithHermes` does not exist:

```
FAIL  src/tests/unit/hermes-provider-model-catalog.test.ts
      > stops re-declaring after a bounded number of writes it cannot read back
AssertionError: expected 10 to be less than or equal to 3
 ❯ src/tests/unit/hermes-provider-model-catalog.test.ts:525:26
    523|       // And the tenth minute costs nothing: three writes nobody could…
    524|       // have proved as much as one whose literal came back as text.
    525|       expect(setCount()).toBeLessThanOrEqual(3);
       |                          ^
 Test Files  1 failed (1)
      Tests  1 failed | 35 skipped (36)
```

ten simulated minutes → ten writes, exactly the shape round 5 measured for the
sibling branch. The 126/127 guard is mutation-checked the same way:

```
# delete `if (!hermesCliAnswered(written)) return unlatch();`
FAIL  > does not spend an attempt on a write that never reached argparse
AssertionError: expected '[hermes/clawai] could not declare the…' not to contain 'giving up'
```

## M1 — the headline docstring asserted the opposite of the code

`hermes-clawai.ts` still said *"Every exit that is a failed QUESTION or a failed
WRITE unlatches … only the real answers stay latched"*, which round 5 had made
false (`stored-as-text` latches) and which named no total bound. It is the
paragraph a future reader would trust when deciding whether a new failure shape
may latch — and the one that would have caught H1. Rewritten to the three-way
rule the code actually implements, with both bounds named and the one they do
**not** apply to (a failed question) spelled out.

## M2 — the retry test passed only because of its own fixture

The round-5 test "tries again when the write could not be VERIFIED" mocked a CLI
that **accepted** `--json` on `config get providers.clawai` and **rejected** it on
`config get providers.clawai.models`. That is one argparse sub-command: no build
does that, and the box takes the leaf form (above). Had it been reachable, the
block read would have failed first, the verdict would have answered `"retry"` and
**no write would have been issued** — the opposite of what the test asserted.
Worse, it pinned H1: it asserted the write count strictly grows after every tick,
using a fixture that models a *permanent* box property.

Re-fixtured on a cause that is genuinely per-call and genuinely transient — the
15 s timeout, `runHermesCli` rejecting, which also proves the verification never
throws — over the fake CLI that **remembers** what it was told. It now asserts
what the module actually promises: nothing is claimed, the repair is **not**
latched (the next request asks again), and the second pass finds the write that
did land while the answer was lost, so it declares nothing a second time. An
unverified write costs another question, not another rewrite of the customer's
`config.yaml`.

## M3 — `unverified` made a definite claim and threw away the cause

The journal line for any non-`stored-as-text` failure was
`(it did not read back as the list we wrote)` — a definite mismatch claim over
the outcome that knows least: a 15 s timeout, a SIGKILL, a decorated stdout and a
genuine "key absent" all produced those same words, and the third logged argument
was the **write's** streams, which are empty on that path. The read's exit code
and stderr were discarded inside `verifyClawaiCatalogue`. False-failure class,
against this module's own "EVERY EXIT SAYS SOMETHING" rule.

`ClawaiWriteOutcome` is now a discriminated union carrying `why`, and the line
reads `(could not be verified — read exit 1: Config key not set:
providers.clawai.models)`. The read's **exit code and first stderr line** only,
capped, and never the value — which is the other half of why the **leaf** is read
rather than the block: the entry that carries `api_key` is not the one this
verification touches.

## M4 — `plugins.enabled`: still not cleared, now filed as **TASK-701**

Unchanged and deliberately out of this head, as stated in round 5 and confirmed
by the delta review: `enableHermesImageGeneration` writes `plugins.enabled` as a
JSON literal and judges it by `r.code !== 0` alone, `mergePluginsEnabled` decodes
its own text residue as already-correct so it can never self-heal, and
`hermesAgentDrawsImages` reads the scalar `image_gen.provider` that stores fine —
so `/setup-api/chat/capabilities` can report `canGenerateImages: true` on a box
with no `image_generate` tool. It belongs to the image path, its read wants
`--json` and its write wants this verification **extracted** rather than copied,
and widening a head that has been through seven rounds into it would ship an
unreviewed change. **TASK-701.**

## L1, L2, N1, and the parse catch

- **L1 (`--force`).** The cited signature is `set_config_value(key, value: str,
  force=False)` and the repair's own `"write"` verdict deliberately replaces an
  existing node, so "does a refusal exit 0?" is a fair question. It is answered
  by **not depending on the answer**: nothing here passes `force`, what it gates
  has not been read on the build `HERMES_PIN_COMMIT` installs, and a refusal that
  still exits 0 is precisely the false success the read-back catches — now
  reported with its cause and bounded by H1's counter instead of retried forever.
  Sending a flag whose effect we have not read on the build we ship would be the
  guess this function exists to remove. Written into the docstring.
- **L2 (`!hermesCliAnswered(read)` subsumed by `read.code !== 0`).** Dropped from
  `verifyClawaiCatalogue` — 126, 127 and a signal's `null` all satisfy
  `code !== 0`, and what separates them there is the number in the journal line,
  not a second branch. The helper now earns its place at the site where the
  distinction is load-bearing: whether a write **spent an attempt** (H1).
- **N1.** `type ClawaiWriteOutcome` sat between the 30-line contract and the
  function, so the contract documented the type alias and hover on
  `verifyClawaiCatalogue` showed nothing. The type now carries its own doc; the
  function keeps the contract.
- **The whole-block `JSON.parse` catch is load-bearing for a second reason**, and
  it was unstated: `JSON.parse` throws a `SyntaxError` that quotes **a prefix of
  its input**, and that input is the `providers.clawai` block — `api_key` and
  all. Moving that parse out of its own catch would print the credential through
  `console.error("[hermes/clawai] catalogue reconcile failed:", err)`. Now said
  at the line.

## Sibling call sites (this round)

- **Every reader of the verification outcome.** `verifyClawaiCatalogue` has
  exactly one caller (`reconcileClawaiModelsWithHermes`); `ClawaiWriteOutcome`
  has no other consumer. Both moved with the type.
- **The latch state.** `clawaiModelsReconciled` / `clawaiRetryAfter` /
  `clawaiUnverifiedWrites` are read only by the repair, `unlatch()`,
  `handClawaiRepairBack()` and the test seam. The hand-back (`applyClawaiToHermes`
  after a link, and the seam) leaves the counter alone **on purpose**, so a
  re-link costs at most one further write; the seam clears it explicitly so no
  test can leak an exhausted budget into the next.
- **`hermes-local-ai.ts` — CLEARED.** Its repair has no unbounded-write path:
  `declareLocalCatalogue` returns `true` once it has written, so the process
  latches; the only `retryLater()` it can reach from the catalogue path is a
  failed **question** (`"unknown"`), which costs a read and no write. Its write
  goes through `patchHermesConfig`, which **throws** rather than exiting 0 on a
  failure — a loud failure, not the false success H1 is about.
- **Every other structured `hermes config set` in the tree** was swept again:
  `plugins.enabled` (above, TASK-701) is still the only other one. All remaining
  `config set` call sites — `hermes-config-yaml.ts:135`, `hermes/models/route.ts:264`,
  `hermes-tts.ts:236`, `hermes-discord.ts`, `hermes-telegram.ts`,
  `hermes-cloud-provider.ts`, `applyClawaiToHermes`'s own scalars — send scalars,
  where `_looks_structured_value` never fires and "stored as a string" is the
  intended outcome. The OpenClaw half uses its own typed `config set … --json`.

## Bug-class self-check on this diff

- **Probe-once.** The new latch *is* a process-lifetime decision, so it is
  bounded on both sides: it needs three writes that each exited 0 and each failed
  to read back, it never fires on a failed question, it is cleared by a landing
  write, and a restart or a re-link tries again. The rebuild window the unlatch
  exists for cannot consume it.
- **False success.** `landed` still requires an exact ordered array match;
  `invalidateModelOptions()` and the counter reset happen only there. "Giving up"
  is a failure report, not a claim.
- **False failure.** The `unverified` line no longer asserts the write did not
  land — it says it could not be verified, and names the read's own exit code.
  The M2 test pins the case where the write landed and the answer was lost: the
  next pass finds it and leaves it alone.

## GREEN

```
src/tests/unit/hermes-provider-model-catalog.test.ts   37 passed
src/tests/unit/provider-write-paths.test.ts             8 passed
whole suite (vitest run)             661 files · 9574 tests · passed
```

`tsc --noEmit` clean. eslint clean on both changed files bar the one warning also
on `origin/beta` (`CLAWBOX_AI_VISION_MODEL_ID` unused). One unrelated component
test (`chat-spoken-reply.test.tsx`, "does not text-match an audio-only final to a
caption-free image") flaked under full-suite parallel load on this machine and
passes both standalone and on a clean re-run of the whole suite; it shares no
module with this diff. **CI's `test` job is the arbiter for this head.**

`git diff --stat origin/beta...HEAD` — 14 files, no deletions, all of them this
PR's own.

## Unproven

No device was touched in this round. The behaviour H1 fixes is CI-provable — it
is a counter over simulated time — and the box fact it is built on (the leaf
`--json` read, and its exit 1 `Config key not set`) was measured before this
round and is quoted above. Still open, as before: nobody has typed `/model` into
Telegram on a repaired box. **One owner check after merge closes it.**

Board: TASK-681, with TASK-691 (the missing "Max plan only" label) and TASK-701
(`plugins.enabled`) as follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Hermes model catalogue synchronization for Local AI and ClawBox AI providers.
  * Added automatic repair and retry handling for missing or unreadable model catalogues.
  * Improved ClawBox AI model selection with Flash and Pro chat models, excluding vision models.
  * Preserved configured, pinned, discovered, and non-empty model lists during synchronization.
* **Bug Fixes**
  * Removing Local AI now also clears its model catalogue.
  * Model refresh operations now run only under the Hermes harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

