### PR TITLE
chore: bump version to 4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawbox-setup",
-  "version": "3.9.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawbox-setup",
-      "version": "3.9.0",
+      "version": "4.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@novnc/novnc": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawbox-setup",
-  "version": "3.9.0",
+  "version": "4.0.0",
   "private": true,
   "description": "ClawBox setup wizard and dashboard",
   "scripts": {

--- a/src/tests/unit/app-version.test.ts
+++ b/src/tests/unit/app-version.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { spawnSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+/**
+ * The shipped ClawBox version, and the build chain that carries it.
+ *
+ * `package.json` is the authored source of the release number, and the bump is
+ * taken with `npm version <x> --no-git-tag-version`, which rewrites it and the
+ * two copies `package-lock.json` keeps of the root version. What this test
+ * proves is that the number then REACHES the surface the owner reads:
+ *
+ *   package.json → scripts/write-build-info.mjs → .next/build-info.json
+ *                → collectBuildIdentity() → the About / build-identity panel
+ *
+ * Not covered here, deliberately. `src/lib/updater.ts` `readClawboxVersion()`
+ * re-reads package.json at RUNTIME and prefixes a "v" before it becomes
+ * `clawbox.current` on /setup-api/update/status — the prefix that
+ * `getVersionInfo`'s `/^(v\d+\.\d+\.\d+)/` baseTag extraction depends on.
+ * Driving that hop against the real manifest would need `getVersionInfo()`,
+ * which also shells out to `git ls-remote origin` and spawns `openclaw
+ * --version`; the existing updater tests reach it only by mocking `readFile`
+ * wholesale, which proves the fixture rather than the file. Closing it needs a
+ * seam the updater does not have today.
+ *
+ * `NEXT_PUBLIC_APP_VERSION` is a SEPARATE version surface and is not this
+ * number: next.config.ts bakes it from `git describe --tags --always` at build
+ * time. It is only a fallback (updater.ts, and SettingsApp when the runtime
+ * read is null), and it has already drifted — v3.9.0 is not an ancestor of
+ * beta, so a clean clone describes as v3.1.11-<n>-g<sha>. Out of scope here.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+
+/**
+ * The release this branch ships, pinned on purpose.
+ *
+ * This is a second place the number is written, and `npm version` does not
+ * maintain it: a future `npm version 4.1.0 --no-git-tag-version` turns this
+ * suite red until the literal below moves too. That is the intent — the bump
+ * is a deliberate release act, and a stamped expectation is what makes an
+ * accidental or half-applied one fail loudly instead of shipping a box that
+ * announces the previous release. Bumping the version is therefore two edits:
+ * `npm version <x> --no-git-tag-version`, then this constant.
+ */
+const EXPECTED_VERSION = "4.0.0";
+
+function readJson(rel: string): { version?: string; packages?: Record<string, { version?: string }> } {
+  return JSON.parse(fs.readFileSync(path.join(REPO_ROOT, rel), "utf-8"));
+}
+
+describe("shipped version", () => {
+  it("package.json names the release", () => {
+    expect(readJson("package.json").version).toBe(EXPECTED_VERSION);
+  });
+
+  // CI and the device both install from bun.lock (`bun install
+  // --frozen-lockfile`), which records no root version at all, so this cannot
+  // break an install. package-lock.json is kept for Dependabot's security PRs
+  // and the dependency graph — and those read the version it reports, so a
+  // hand-edit that moves one of its two copies and not the other leaves the
+  // repo describing itself inconsistently to everything downstream of it.
+  it("package-lock.json agrees, in both places it records the root version", () => {
+    const lock = readJson("package-lock.json");
+    expect(lock.version).toBe(EXPECTED_VERSION);
+    expect(lock.packages?.[""]?.version).toBe(EXPECTED_VERSION);
+  });
+});
+
+describe("build identity reports the shipped version", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawbox-version-"));
+    // The REAL package.json, so this asserts on the shipped file rather than a
+    // fixture that can agree with a stale number forever.
+    fs.copyFileSync(path.join(REPO_ROOT, "package.json"), path.join(dir, "package.json"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("stamps package.json's version into build-info.json", () => {
+    const run = spawnSync("node", [path.join(REPO_ROOT, "scripts/write-build-info.mjs")], {
+      cwd: dir,
+      env: { ...process.env, CLAWBOX_ROOT: dir },
+      encoding: "utf-8",
+    });
+    expect(run.status, run.stderr).toBe(0);
+
+    const info = JSON.parse(fs.readFileSync(path.join(dir, ".next", "build-info.json"), "utf-8"));
+    expect(info.packageVersion).toBe(EXPECTED_VERSION);
+  });
+});


### PR DESCRIPTION
Bumps the ClawBox release version from **3.9.0** to **4.0.0**. Version number only — no tag, no GitHub release, no changelog, no docs deploy, no `main` merge.

## Native mechanism used

`npm version 4.0.0 --no-git-tag-version` — npm already owns this number and keeps `package.json` and both copies of the root version in `package-lock.json` in step; `--no-git-tag-version` is exactly "bump but do not release". No hand-rolled version constant was introduced, and none was needed: `package.json` is already the single source of truth, and both consumers derive from it.

- `scripts/write-build-info.mjs:114` reads `package.json` → `.next/build-info.json` `packageVersion` → `collectBuildIdentity()` → the About / build-identity panel. **Confirmed**: build identity follows automatically, no edit needed.
- `src/lib/updater.ts` `readClawboxVersion()` reads `package.json` at **runtime** (deliberately not the build-time `NEXT_PUBLIC_APP_VERSION`) → `/setup-api/update/status` `clawbox.current`. **Confirmed**: no edit needed.

## Where the version lives — full enumeration

| Place | Action |
| --- | --- |
| `package.json:3` | **Bumped** — the only authored copy. |
| `package-lock.json:3` and `:9` | **Bumped** by `npm version`; npm re-resolved nothing, the diff is 4 lines. |
| `bun.lock` | **No change** — verified it has no `version` key anywhere; it records the workspace `name` and dependencies only. This is the lockfile that matters: all four CI workflows and `install.sh:953` install with `bun install --frozen-lockfile`, so the bump cannot affect an install. `package-lock.json` exists only for Dependabot security PRs and the dependency graph (`.github/dependabot.yml:16-17,52-56`). |
| `scripts/write-build-info.mjs:116` | **No change** — reads `package.json`; build identity follows. |
| `scripts/ensure-local-embeddings.sh:57` | **No change, and not related.** It reads the **OpenClaw core's** installed `package.json` (`~/.npm-global/lib/node_modules/openclaw/package.json`) and compares it against `2026.8` to pick the `memory.search` vs `agents.defaults.memorySearch` config key. It never reads ClawBox's version. |
| `install.sh` / `install-x64.sh` | **No change** — the only `major` logic there is `node_satisfies_openclaw_engine()` on the **Node.js** major; `OPENCLAW_VERSION="2026.8.1"` is the OpenClaw pin. No ClawBox version literal. |
| `docs-site/`, `docs/` | **No change** — grep for `3.9`/`3.10` returns no product-version literal (only Python 3.10 and a restic pin). |
| `.github/workflows/` | **No change** — only third-party tool pins. |
| `clawkeep/pyproject.toml` | **No change** — independent package at `0.1.0`, not the ClawBox release number. |
| `mcp/package.json` | **No change** — has no `version` field. |
| No in-repo `CHANGELOG` / release file exists | nothing to publish. |

### The six test fixtures pinned to `"3.9.0"` — deliberately left as fixture literals

`src/tests/components/build-identity-panel.test.tsx:37`, `src/tests/components/system-update-app-drift.test.tsx:65`, `src/tests/routes/build-identity.test.ts:23`, `src/tests/routes/update/status.test.ts:220`, `src/tests/unit/build-identity.test.ts:30`, `src/tests/unit/updater-build-identity.test.ts:52`.

Every one is an **input** object literal handed to a mock or a fixture builder — a synthetic `BuildInfo` / a mocked `getVersionInfo()` response. None is compared against the repo's real version, and none asserts on the value; they exercise drift, panel rendering and update-status shape, all of which are version-agnostic. Moving them to `4.0.0` would be diff noise with no behavioural meaning, and would have to be redone at every future bump. Proven empirically: all six suites pass unchanged after the bump (see GREEN below).

## Updater: what a box on 3.9.0 does when beta is 4.0.0

Checked `src/lib/updater.ts`, `src/app/setup-api/update/status/route.ts`, `src/components/SystemUpdateApp.tsx`. **No major-version gate exists anywhere** — no migration, factory-reset path or portal-side block keys off the ClawBox major. Grepping `major` / `semver` / `breaking` / `minMajor` across `src/` and `scripts/` finds only the Node-engine major in the installers, `compareSemverTags` (a plain numeric tuple compare, no major special case), and unrelated comments. The config migrations in `gateway-pre-start.sh` are OpenClaw-config migrations, unconditional and idempotent — none is version-gated on ClawBox.

The concrete behaviour, given the newest ClawBox semver tag on origin is `v3.9.0` and this PR creates no tag:

1. **Box still on 3.9.0.** `getTargetVersion()` picks the greatest `^v\d+\.\d+\.\d+$` tag = `v3.9.0`; `baseTag` = `v3.9.0`; `compareSemverTags(target, baseTag) > 0` is false → `target: null`, `updateAvailable: false`. The tag path offers nothing, which is correct for "bumped, not released". Such a box still updates through the **pinned-branch path** (`getPinnedBranchTarget`, the `.update-branch` pin), which compares commit SHAs and is untouched by the version number.
2. **Box synced to beta head at 4.0.0.** `baseTag` = `v4.0.0`, newest tag `v3.9.0` → strictly-newer guard is false → `target: null`, `updateAvailable: false`. **No phantom downgrade offer.** The guard is `> 0`, not `!== 0`, so a device ahead of the newest published tag correctly reads "up to date" rather than being told to install an older release.

Stronger than the above, from review: a downgrade is **structurally impossible**. `targetVersion` is only a label — `performUpdate` always does `fetch` → `reset --hard HEAD` → `checkout <local>` → `reset --hard <upstream>` (`updater.ts:730-752`) and never checks out a tag. The worst a bad comparison could do is a misleading badge.

Drift detection is unaffected — it compares commits and BUILD_IDs, never version strings (that is the documented reason it exists, `status/route.ts`).

Hermes / dual SKU: no effect. `hermes.target` is hard-null (`updater.ts:1616-1618`), the edition lock carries no version, and `HERMES_PIN_COMMIT` is a SHA. A Hermes box sees the same `clawbox.current` change and nothing else.

### One consequence worth recording before the release is cut

Shipping 4.0.0 makes **`v4.0.0` the floor for the tag series**. `getTargetVersion()` reports a target only when it is *strictly greater* than the device's own version, so if a later release were tagged `v3.10.0`, every box that reached 4.0.0 **without** a readable `.update-branch` pin would report "You're up to date" forever, with no UI signal that a newer release exists. The next tag pushed to origin must therefore be `>= v4.0.0`. Nothing is wrong today — newest tag on origin is `v3.9.0` and this PR adds none — but the tag, when it is cut, has to be `v4.0.0` or higher.

### Two pre-existing issues found while checking, deliberately NOT fixed here

1. **`NEXT_PUBLIC_APP_VERSION` is a second, drifting version surface.** `next.config.ts:11` bakes it from `git describe --tags --always`, not from `package.json`. `v3.9.0` is not an ancestor of beta HEAD, so a clean clone describes as `v3.1.11-1181-g<sha>`. It is only a fallback — `readClawboxVersion()` prefers `package.json` precisely so a baked value cannot go stale, and `SettingsApp.tsx:5380` uses it only when the runtime read is null, so the About panel shows `v4.0.0`. But if `/setup-api/update/versions` ever fails, the owner reads `v3.1.11-…` as the version. Worth a follow-up to bake `APP_VERSION` from `package.json` or drop the fallback.
2. **`package-lock.json`'s dependency block is stale against the manifest** (`@modelcontextprotocol/sdk` `^1.29.0` vs `^1.30.0`, `@novnc/novnc` `1.6.0` vs `1.7.0`). Pre-existing and not worsened here — `npm version` touched only the two version fields. Re-syncing it is a separate PR; nothing installs from it.

## Out of scope, for the record

The customer-facing notes at the owner's `ClawBox-3.10-Release-Notes.md` currently say **`# ClawBox 3.10.0`** and contain the line "Version string is `3.10.0`. `package.json` still reads `3.9.0` — the bump is a one-line release step and has not been taken yet." Those notes are the owner's to retitle to 4.0.0; nothing in this repository references them.

## RED → GREEN

New regression test `src/tests/unit/app-version.test.ts` asserts the shipped number in `package.json`, that `package-lock.json` agrees in both places it records the root version, and — by copying the **real** `package.json` into a temp root and running the **real** `scripts/write-build-info.mjs` over it — that the build-identity chain carries it into `build-info.json`. It is not self-referential: the third case executes the shipped stamper and asserts on the file it produces, not just on its exit code.

The `EXPECTED_VERSION = "4.0.0"` pin is a second place the number is written and `npm version` does not maintain it, so the next bump is two edits. That is deliberate and now documented in the file: a stamped expectation is what makes a half-applied bump fail loudly. The alternative — deriving the constant from `package.json` — makes the first assertion tautological and removes the only thing that fails on an accidental bump.

Scope note on coverage: the test proves the build chain. The runtime chain (`readClawboxVersion()` → `clawbox.current`, which prefixes the `v` that `getVersionInfo`'s `baseTag` extraction depends on) is **not** covered against the real manifest — reaching it needs `getVersionInfo()`, which also shells out to `git ls-remote origin` and spawns `openclaw --version`, and today's updater tests reach it only by mocking `readFile` wholesale. That limitation is written into the test's header rather than papered over.

RED, on unmodified `origin/beta` (version still 3.9.0):

```
 FAIL  |unit| src/tests/unit/app-version.test.ts > shipped version > package.json names the release
AssertionError: expected '3.9.0' to be '4.0.0' // Object.is equality
 ❯ src/tests/unit/app-version.test.ts:56:46

 FAIL  |unit| src/tests/unit/app-version.test.ts > shipped version > package-lock.json agrees, in both places it records the root version
AssertionError: expected '3.9.0' to be '4.0.0' // Object.is equality
 ❯ src/tests/unit/app-version.test.ts:67:26

 FAIL  |unit| src/tests/unit/app-version.test.ts > build identity reports the shipped version > stamps package.json's version into build-info.json
AssertionError: expected '3.9.0' to be '4.0.0' // Object.is equality
 ❯ src/tests/unit/app-version.test.ts:95:33

 Test Files  1 failed (1)
      Tests  3 failed (3)
```

GREEN, after the bump — the new test plus every neighbouring suite and every other suite that reads the real `package.json`:

```
app-version + build-identity + build-identity-hygiene + updater-build-identity
  + routes/build-identity + routes/update/status
 Test Files  6 passed (6)      Tests  64 passed (64)

unit/updater
 Test Files  1 passed (1)      Tests  57 passed (57)

components: build-identity-panel + system-update-app-drift
 Test Files  2 passed (2)      Tests  17 passed (17)

ci-workflows + novnc-pin + postbuild-standalone-data
  + ensure-local-embeddings + mcp-path-guard
 Test Files  5 passed (5)      Tests 110 passed (110)

unit/build-typecheck (tsc gate)
 Test Files  1 passed (1)      Tests  1 passed (1)
```

`eslint src/tests/unit/app-version.test.ts` — clean. Full unit, typecheck and e2e are CI's to confirm.

## Review

One Opus review pass over `origin/beta...HEAD`: 0 critical, 0 high, 2 medium, 3 low. Nothing blocked on correctness. Applied: the release-number pin is now documented as a deliberate second edit rather than claiming "a release bump is one edit" (which was false); the lockfile assertion's rationale no longer cites `npm ci`, which this repo never runs; the header no longer claims `package.json` is the only place a version is written (`NEXT_PUBLIC_APP_VERSION` is not), and now states which half of the chain the test does not cover. The two findings that were not code changes — the tag-series floor and the two pre-existing issues — are recorded above.

The review independently confirmed both updater readings, verified the six `3.9.0` fixtures were correctly left alone, and verified `bun.lock` needed no change.

No box was touched, as instructed. This change is a version field plus a unit test; CI exercises it fully and there is no hardware behaviour to prove on a device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Updated the application to version **4.0.0**.
  - Version information is consistently reflected throughout the shipped application and its build metadata.

- **Quality Improvements**
  - Added automated checks to verify that displayed and packaged version information remains accurate for future releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->