### PR TITLE
fix: land the Anthropic default on claude-opus-5

### DIFF
--- a/src/app/setup-api/ai-models/catalog/route.ts
+++ b/src/app/setup-api/ai-models/catalog/route.ts
@@ -66,9 +66,9 @@ interface CatalogModel {
    * The harness tagged this row `default` for its provider.
    *
    * Carried rather than dropped because it is the box's own answer to the same
-   * question `DEFAULT_MODEL_BY_PROVIDER` answers by hand, and a hand-written
-   * default is the identical defect to a hand-written list: on a 2026.8.1 host
-   * `openclaw models list --provider openai` tags `gpt-5.6-sol`, while the map
+   * question `PROVIDER_CATALOGS` answers by hand, and a hand-written default is
+   * the identical defect to a hand-written list: on a 2026.8.1 host `openclaw
+   * models list --provider openai` tags `gpt-5.6-sol`, while the curated table
    * says `gpt-5.4`. Only a live enumeration ever sets it — the curated
    * cold-start rows carry no such claim.
    */
@@ -271,16 +271,6 @@ function recordSuccessfulRefresh(provider: string): void {
 function clearFailedRefresh(provider: string): void {
   failedRefreshes.delete(provider);
 }
-
-const DEFAULT_MODEL_BY_PROVIDER: Record<string, string> = {
-  clawai: "deepseek-v4-flash",
-  anthropic: "claude-sonnet-5",
-  openai: "gpt-5.4",
-  // Newest model on every ChatGPT tier including Free; gpt-5.6 is plan-gated.
-  codex: "gpt-5.5",
-  google: "gemini-2.5-flash",
-  openrouter: "anthropic/claude-haiku-4.5",
-};
 
 // ClawBox AI catalog is hardcoded — Mike's gateway routes via DeepSeek
 // upstream but the only end-user-pickable variants are the two device
@@ -516,7 +506,7 @@ async function fetchSubscriptionSurfaceIds(provider: string): Promise<Set<string
     const { models } = await fetchOpenclawCatalog(surfaceProvider);
     if (models.length === 0) return null;
     // Through `buildPayload`, not hand-assembled beside it. The hand-built
-    // version skipped `sanitizeCatalogModels`, `DEFAULT_MODEL_BY_PROVIDER` and
+    // version skipped `sanitizeCatalogModels`, the default resolution and
     // `ALLOW_CUSTOM_BY_PROVIDER` while writing to the very file the picker and
     // the server-side guard read back — a second, quieter way for this route to
     // persist something no other path would have produced.
@@ -787,12 +777,13 @@ function buildPayload(
     merged = merged.map((m) => ({ ...m, availableOnSubscription: true }));
   }
   // The BOX's answer first. `openclaw models list` tags one row `default` per
-  // provider, and preferring the hand-written map over it is the same defect
+  // provider, and preferring the curated default over it is the same defect
   // this change exists to fix, pointed at the default instead of the list: on a
-  // stock 2026.8.1 host the map picks `gpt-5.4` while the box says
-  // `gpt-5.6-sol`. The map stays as the fallback for a catalogue that tags
-  // nothing and for the curated cold-start rows, which carry no tag at all.
-  const fallbackDefault = DEFAULT_MODEL_BY_PROVIDER[provider];
+  // stock 2026.8.1 host the curated table picks `gpt-5.4` while the box says
+  // `gpt-5.6-sol`. `PROVIDER_CATALOGS` stays as the fallback for a catalogue
+  // that tags nothing and for the curated cold-start rows, which carry no tag
+  // at all — one table, the same one the picker renders.
+  const fallbackDefault = getProviderCatalog(provider)?.defaultModelId;
   const defaultModelId = merged.find((m) => m.isDefault)?.id
     ?? merged.find((m) => m.id === fallbackDefault)?.id
     ?? merged[0]?.id

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -80,6 +80,7 @@ import { fetchPortalTier } from "@/lib/clawbox-ai-portal-tier";
 import {
   isValidModelId,
   GOOGLE_MODELS,
+  ANTHROPIC_DEFAULT_MODEL_ID,
   ANTHROPIC_MODELS,
   extractProviderModelId,
   routesSubscriptionNatively,
@@ -165,7 +166,7 @@ const PROVIDERS: Record<string, ProviderConfig> = {
     profileKey: CLAWBOX_AI_PROFILE_KEY,
   },
   anthropic: {
-    defaultModel: "anthropic/claude-sonnet-5",
+    defaultModel: `anthropic/${ANTHROPIC_DEFAULT_MODEL_ID}`,
     profileKey: "anthropic:default",
   },
   openai: {

--- a/src/app/setup-api/chat/model/route.ts
+++ b/src/app/setup-api/chat/model/route.ts
@@ -21,7 +21,7 @@ import {
   CLAWBOX_AI_DEFAULT_TIER,
 } from "@/lib/clawbox-ai-models";
 import { OPENROUTER_DEFAULT_MODEL_ID } from "@/lib/openrouter-models";
-import { isValidModelId, parseModelSlug } from "@/lib/provider-models";
+import { ANTHROPIC_DEFAULT_MODEL_ID, isValidModelId, parseModelSlug } from "@/lib/provider-models";
 import { DISABLED_PROVIDERS_KEY, normalizeProviderId, parseDisabledProviders } from "@/lib/provider-status";
 import { isClawboxAiImageModelId, isClawboxAiImageModelRef } from "@/lib/clawbox-ai-models";
 import {
@@ -104,7 +104,7 @@ const OPENAI_COMPAT_PROVIDERS = new Set<string>(["openrouter", "google", "anthro
 const DEFAULT_PROVIDER_MODELS: Record<string, string> = {
   clawai: CLAWBOX_AI_MODEL_BY_TIER[CLAWBOX_AI_DEFAULT_TIER],
   deepseek: CLAWBOX_AI_MODEL_BY_TIER[CLAWBOX_AI_DEFAULT_TIER],
-  anthropic: "anthropic/claude-sonnet-5",
+  anthropic: `anthropic/${ANTHROPIC_DEFAULT_MODEL_ID}`,
   openai: "openai/gpt-5.4",
   google: "google/gemini-2.5-flash",
   openrouter: `openrouter/${OPENROUTER_DEFAULT_MODEL_ID}`,

--- a/src/lib/provider-models.ts
+++ b/src/lib/provider-models.ts
@@ -135,9 +135,34 @@ export interface ProviderCatalog {
 // enumeration returns.
 export const ANTHROPIC_MODELS: readonly ProviderModelOption[] = [
   { id: "claude-haiku-4-5", label: "Claude Haiku 4.5", hint: "Fastest, near-frontier." },
-  { id: "claude-sonnet-5", label: "Claude Sonnet 5", hint: "Default. Speed + intelligence." },
-  { id: "claude-opus-5", label: "Claude Opus 5", hint: "Most capable." },
+  { id: "claude-sonnet-5", label: "Claude Sonnet 5", hint: "Speed + intelligence." },
+  { id: "claude-opus-5", label: "Claude Opus 5", hint: "Default. Most capable." },
 ] as const;
+
+/**
+ * The Anthropic model this box lands on when nothing named one.
+ *
+ * Exported so the two routes that WRITE `agents.defaults.model.primary` for a
+ * provider the caller did not pick a model for — ai-models/configure's
+ * PROVIDERS table and chat/model's DEFAULT_PROVIDER_MODELS — name one id
+ * instead of a copy each. Those two are final: neither consults the box's own
+ * enumeration. The catalog route reads the same answer through
+ * `getProviderCatalog(...).defaultModelId` below, but only as its fallback —
+ * a row the harness tags `default` outranks it there (`isDefault` in
+ * src/app/setup-api/ai-models/catalog/route.ts).
+ *
+ * The two agree on the pinned core: `openclaw models list --provider anthropic
+ * --all --json` on 2026.8.1 answers eleven rows with an empty `tags` on every
+ * one (measured 2026-09-03), claude-opus-5 among them, so nothing outranks
+ * this and the picker pre-selects what "Make default -> Anthropic" writes. A
+ * later core that starts tagging an Anthropic row would show that row in the
+ * picker while these two still write this id — deliberate, per the ruling that
+ * put Opus 5 here, and the point to revisit if it happens.
+ *
+ * Hermes never reads it: there the recommendation comes from the harness's own
+ * `/api/model/recommended-default` (src/lib/hermes-model-options.ts).
+ */
+export const ANTHROPIC_DEFAULT_MODEL_ID = "claude-opus-5";
 
 // OpenAI API key models — cold-start display only, like every list here.
 // There is no longer a generation allowlist at the catalog route for openai:
@@ -357,7 +382,7 @@ export const PROVIDER_CATALOGS = Object.freeze({
   anthropic: {
     provider: "anthropic",
     models: ANTHROPIC_MODELS,
-    defaultModelId: "claude-sonnet-5",
+    defaultModelId: ANTHROPIC_DEFAULT_MODEL_ID,
     allowCustom: true,
   },
   openai: {

--- a/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
+++ b/src/tests/routes/ai-models/catalog-live-vs-fallback.test.ts
@@ -356,7 +356,7 @@ describe("catalog — the ChatGPT surface has no enumeration on this core", () =
       count: 2,
       models: [
         { key: "openai/gpt-5.6-sol", name: "GPT-5.6 Sol", contextWindow: 400_000, available: true, tags: ["default"] },
-        // The id DEFAULT_MODEL_BY_PROVIDER carries for openai. It is in the
+        // The id PROVIDER_CATALOGS carries for openai. It is in the
         // catalogue, so the old lookup found it and stopped.
         { key: "openai/gpt-5.4", name: "GPT-5.4", contextWindow: 1_000_000, available: true, tags: [] },
       ],

--- a/src/tests/routes/ai-models/configure-subscription-surface.test.ts
+++ b/src/tests/routes/ai-models/configure-subscription-surface.test.ts
@@ -332,9 +332,12 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     // picker answered, and refused the box's OWN default on every update until
     // the refresh landed. `readSubscriptionSurfaceIds` unions the curated
     // catalogue for exactly this window.
-    mockSurfaceRead.mockResolvedValue(
-      surfaceCache(SURFACE_IDS.filter((id) => id !== "claude-sonnet-5")) as never,
-    );
+    // The precondition, asserted rather than assumed: the shipped default is
+    // absent from this cached surface, and that absence is the whole window
+    // the union covers. A later refresh of SURFACE_IDS from a real box would
+    // add claude-opus-5 and silently retire this regression otherwise.
+    expect(SURFACE_IDS).not.toContain("claude-opus-5");
+    mockSurfaceRead.mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
 
     const res = await configurePost(subscribe());
 
@@ -345,7 +348,7 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
         vi.mocked(runOpenclawConfigSetBatch),
         "agents.defaults.model.primary",
       )?.value,
-    ).toBe("anthropic/claude-sonnet-5");
+    ).toBe("anthropic/claude-opus-5");
   });
 
   it("still judges the settled default, not only a typed id", async () => {
@@ -358,14 +361,13 @@ describe("POST /setup-api/ai-models/configure and the Claude subscription surfac
     // Once-only: `vi.clearAllMocks()` clears calls, not implementations, so a
     // sticky override would follow this test into the next one.
     vi.mocked(getProviderCatalog).mockReturnValueOnce(null);
-    mockSurfaceRead.mockResolvedValue(
-      surfaceCache(SURFACE_IDS.filter((id) => id !== "claude-sonnet-5")) as never,
-    );
+    expect(SURFACE_IDS).not.toContain("claude-opus-5");
+    mockSurfaceRead.mockResolvedValue(surfaceCache(SURFACE_IDS) as never);
 
     const res = await configurePost(subscribe());
 
     expect(res.status).toBe(400);
-    expect((await res.json()).error).toContain("claude-sonnet-5");
+    expect((await res.json()).error).toContain("claude-opus-5");
     expectNoSideEffects();
   });
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1360,7 +1360,7 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     const commands = configSetCommands(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch));
     expect(commands.some((command) => command.includes("config set models.providers.anthropic"))).toBe(true);
-    expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-sonnet-5");
+    expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-opus-5");
 
     const providerCall = findConfigSet(vi.mocked(runOpenclawConfigSet), vi.mocked(runOpenclawConfigSetBatch), "models.providers.anthropic");
     const providerDef = providerCall ? JSON.parse(providerCall.value || "{}") : {};
@@ -1409,7 +1409,7 @@ describe("POST /setup-api/ai-models/configure", () => {
 
     // ...and the rest of the save is unchanged: the subscription still becomes
     // the primary, in merge mode, with an oauth auth profile.
-    expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-sonnet-5");
+    expect(commands).toContain("config set agents.defaults.model.primary anthropic/claude-opus-5");
     expect(commands).toContain("config set models.mode merge");
 
     const writtenContent = JSON.parse(mockFs.writeFile.mock.calls.at(-1)?.[1] as string);
@@ -2218,8 +2218,8 @@ describe("POST /setup-api/ai-models/configure", () => {
   // the flag as it was.
   describe("the anthropic plugin around the primary write", () => {
     const UNKNOWN_MODEL =
-      'Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary: '
-      + "Unknown model: anthropic/claude-sonnet-5. Run openclaw models list to list available models.";
+      'Cannot set model reference "anthropic/claude-opus-5" at agents.defaults.model.primary: '
+      + "Unknown model: anthropic/claude-opus-5. Run openclaw models list to list available models.";
     const ENABLE_OP = ["plugins.entries.anthropic.enabled", "true", "--json"];
 
     /** Where in vitest's global call sequence the first call `pick` accepts sits. */
@@ -2290,7 +2290,7 @@ describe("POST /setup-api/ai-models/configure", () => {
 
       const res = await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-ant-test123" }));
       expect(res.status).toBe(200);
-      expect(vi.mocked(setPrimaryModelWithoutCatalogValidation)).toHaveBeenCalledWith("anthropic/claude-sonnet-5");
+      expect(vi.mocked(setPrimaryModelWithoutCatalogValidation)).toHaveBeenCalledWith("anthropic/claude-opus-5");
       const batches = vi.mocked(runOpenclawConfigSetBatch).mock.calls;
       expect(batches.length).toBeGreaterThanOrEqual(2);
       const retry = batches[1][0];

--- a/src/tests/routes/chat-model.test.ts
+++ b/src/tests/routes/chat-model.test.ts
@@ -210,7 +210,9 @@ describe("/setup-api/chat/model", () => {
     expect(body.options.map((option: { model: string | null }) => option.model)).toEqual([
       "deepseek/deepseek-v4-flash",
       "openai/gpt-5.4",
-      "anthropic/claude-sonnet-5",
+      // The row POST /setup-api/providers/default reads for "Make default ->
+      // Anthropic" when the box has no Anthropic model of its own.
+      "anthropic/claude-opus-5",
       "llamacpp/gemma4-e2b-it-q4_0",
     ]);
   });
@@ -913,8 +915,8 @@ describe("/setup-api/chat/model", () => {
 
   describe("the anthropic plugin around the primary write", () => {
     const UNKNOWN_MODEL =
-      'Cannot set model reference "anthropic/claude-sonnet-5" at agents.defaults.model.primary: '
-      + "Unknown model: anthropic/claude-sonnet-5. Run openclaw models list to list available models.";
+      'Cannot set model reference "anthropic/claude-opus-5" at agents.defaults.model.primary: '
+      + "Unknown model: anthropic/claude-opus-5. Run openclaw models list to list available models.";
     const ENABLE_OP = ["plugins.entries.anthropic.enabled", "true", "--json"];
 
     /** Where in vitest's global call sequence the first call `pick` accepts sits. */
@@ -955,7 +957,7 @@ describe("/setup-api/chat/model", () => {
       const response = await POST(new Request("http://localhost/test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+        body: JSON.stringify({ model: "anthropic/claude-opus-5" }),
       }));
       const body = await response.json();
 
@@ -963,7 +965,7 @@ describe("/setup-api/chat/model", () => {
       expect(response.status).toBe(200);
       expect(runOpenclawConfigSetBatch).toHaveBeenCalledWith([
         ENABLE_OP,
-        ["agents.defaults.model.primary", "anthropic/claude-sonnet-5"],
+        ["agents.defaults.model.primary", "anthropic/claude-opus-5"],
       ]);
       // A plugin enabled by the batch loads on the next gateway start, so the
       // restart that already follows the switch has to stay after it.
@@ -979,7 +981,7 @@ describe("/setup-api/chat/model", () => {
       const response = await POST(new Request("http://localhost/test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+        body: JSON.stringify({ model: "anthropic/claude-opus-5" }),
       }));
       const body = await response.json();
 
@@ -1029,7 +1031,7 @@ describe("/setup-api/chat/model", () => {
         const response = await POST(new Request("http://localhost/test", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+          body: JSON.stringify({ model: "anthropic/claude-opus-5" }),
         }));
 
         expect(response.status).toBe(200);
@@ -1046,7 +1048,7 @@ describe("/setup-api/chat/model", () => {
         const response = await POST(new Request("http://localhost/test", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+          body: JSON.stringify({ model: "anthropic/claude-opus-5" }),
         }));
 
         expect(response.status).toBe(200);
@@ -1064,7 +1066,7 @@ describe("/setup-api/chat/model", () => {
         const response = await POST(new Request("http://localhost/test", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+          body: JSON.stringify({ model: "anthropic/claude-opus-5" }),
         }));
 
         expect(response.status).toBe(200);
@@ -1081,7 +1083,7 @@ describe("/setup-api/chat/model", () => {
         const response = await POST(new Request("http://localhost/test", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+          body: JSON.stringify({ model: "anthropic/claude-opus-5" }),
         }));
 
         expect(response.status).toBe(409);
@@ -1098,7 +1100,7 @@ describe("/setup-api/chat/model", () => {
       await POST(new Request("http://localhost/test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ model: "anthropic/claude-sonnet-5" }),
+        body: JSON.stringify({ model: "anthropic/claude-opus-5" }),
       }));
 
       const batch = vi.mocked(runOpenclawConfigSetBatch).mock.calls.at(-1)?.[0] as string[][];

--- a/src/tests/unit/provider-models.test.ts
+++ b/src/tests/unit/provider-models.test.ts
@@ -22,6 +22,24 @@ describe("provider-models", () => {
       expect(getProviderCatalog("codex")?.defaultModelId).toBe("gpt-5.5");
     });
 
+    // The cold-start default only decides what a box lands on before it has
+    // enumerated anything — `openclaw models list` tags one row `default` per
+    // provider and that tag wins (catalog/route.ts) — but it is what
+    // "Make default -> Anthropic" writes on a box whose Anthropic row has no
+    // model of its own, and it was still the placeholder Sonnet id.
+    it("lands the Anthropic cold-start default on Claude Opus 5", () => {
+      const catalog = getProviderCatalog("anthropic");
+      expect(catalog?.defaultModelId).toBe("claude-opus-5");
+      // A default the curated list does not carry is a default the picker
+      // cannot render, so the two are asserted together.
+      expect(catalog?.models.map((m) => m.id)).toContain("claude-opus-5");
+      // Exactly one row may claim the "Default." hint, and it is that one: two
+      // rows hinted Default is what a hand-edited list drifts into.
+      expect(
+        (catalog?.models ?? []).filter((m) => m.hint?.startsWith("Default")).map((m) => m.id),
+      ).toEqual(["claude-opus-5"]);
+    });
+
     it("does not return inherited Object prototype members", () => {
       expect(getProviderCatalog("toString")).toBeNull();
       expect(getProviderCatalog("constructor")).toBeNull();


### PR DESCRIPTION
**TASK-607 (decision D-03)** — the Anthropic default is Opus 5.

## Symptom

Settings → AI providers → **Make default → Anthropic** wrote `agents.defaults.model.primary = anthropic/claude-sonnet-5` on a box whose Anthropic row carried no model of its own. The same placeholder id was the cold start for an Anthropic save with no model typed, and for the wizard picker's pre-selection. Sonnet 5 was a placeholder from the day the id was added; the owner's ruling is Opus 5.

## Cause

Four separate hand-written tables answered "which Anthropic model is the default", all of them `claude-sonnet-5`:

| table | reached by |
|---|---|
| `PROVIDER_CATALOGS.anthropic.defaultModelId` (`src/lib/provider-models.ts`) | picker pre-selection, cold-start payload |
| `DEFAULT_MODEL_BY_PROVIDER` (`ai-models/catalog/route.ts`) | fallback when the enumeration tags nothing |
| `PROVIDERS.anthropic.defaultModel` (`ai-models/configure/route.ts`) | a save with no `model` in the body |
| `DEFAULT_PROVIDER_MODELS.anthropic` (`chat/model/route.ts`) | the row `POST /setup-api/providers/default` reads |

`POST /setup-api/providers/default` sends **no model** by design, so it takes whichever of these answers first — which is why the ruling could not be delivered by editing one of them.

## Native mechanism (harness-first)

The default a box uses is the harness's to state: `openclaw models list --provider <p> --all --json` tags one row `default` per provider, and `ai-models/catalog` already prefers that tag over anything hand-written (`isDefault`, added by the PR whose comment this change quotes). This PR does not touch that preference — it fixes the fallback underneath it, and deletes `DEFAULT_MODEL_BY_PROVIDER` outright because it was a verbatim duplicate of `PROVIDER_CATALOGS` for every provider (clawai, openai, codex, google, openrouter values all identical). One exported constant, `ANTHROPIC_DEFAULT_MODEL_ID`, now answers for the two write paths, following the `OPENROUTER_DEFAULT_MODEL_ID` / `CHATGPT_DEFAULT_MODEL_ID` precedent.

Measured on the pinned core (2026.8.1, OpenClaw box, read-only, 2026-09-03): `openclaw models list --provider anthropic --all --json` returns **11 rows, every one with `tags: []`**, `anthropic/claude-opus-5` among them. So nothing outranks the curated default for Anthropic on the core we ship, and the picker pre-selects exactly what "Make default" writes. A later core that starts tagging an Anthropic row would show that row in the picker while the two write paths still write Opus 5 — deliberate under this ruling, and recorded in the constant's docblock as the thing to revisit.

**Hermes leg:** nothing to change. `/setup-api/providers/default` sends Hermes the provider only, and the model comes from the harness's own `/api/model/recommended-default` (`hermes-model-options.ts`, mirroring `pick_silent_default_model`). No Anthropic default is hard-coded on the Hermes side.

## RED → GREEN

RED on unmodified `origin/beta` (`de669141`):

```
FAIL  src/tests/unit/provider-models.test.ts > lands the Anthropic cold-start default on Opus 5
AssertionError: expected 'claude-sonnet-5' to be 'claude-opus-5'

FAIL  src/tests/routes/chat-model.test.ts > lists every configured cloud provider alongside Local AI
  - "anthropic/claude-opus-5"  + "anthropic/claude-sonnet-5"
FAIL  src/tests/routes/ai-models/configure.test.ts > configures anthropic as an openai-compat provider with the key inline
FAIL  src/tests/routes/ai-models/configure.test.ts > does not write the openai-compat override for a subscription sign-in
  expected [...] to include 'config set agents.defaults.model.primary anthropic/claude-opus-5'
FAIL  src/tests/routes/ai-models/configure-subscription-surface.test.ts > does not refuse the shipped default over a cache that predates it
AssertionError: expected 'anthropic/claude-sonnet-5' to be 'anthropic/claude-opus-5'
FAIL  src/tests/routes/ai-models/configure-subscription-surface.test.ts > still judges the settled default, not only a typed id
AssertionError: expected 200 to be 400
```

GREEN on this branch, after the rebase onto `865a5b98` and the review pass: full suite **664 files / 9614 tests passed**, `tsc --noEmit` clean.

## Sibling sweep

- Swept `src/`, `scripts/`, `docs/`, translations and JSON for any other hard-coded Anthropic default. The only remaining `claude-sonnet-*` literals are the retired-May-2025-id migration in `scripts/gateway-pre-start.sh` (unrelated) and historical comment text.
- The six tests that posted `anthropic/claude-sonnet-5` at `chat/model` were pointed at the box's Anthropic row id instead, because that is what they were testing (a pick that matches the row); left at Sonnet 5 they fell through to the power-user branch and 409'd.
- Wizard/onboarding needed no change: `AIModelsStep` reads `activeCatalog.defaultModelId`.

## Review findings applied

Opus review pass: 1 high, 3 medium, 4 low. The high one — "the picker and the write paths now disagree on an enumerated box" — is what the device measurement above settles for the pinned core; the docblock now states the condition under which it would become real. The constant's docblock, one stale fixture comment, one `UNKNOWN_MODEL` fixture id and two missing preconditions in the subscription-surface tests were corrected.

Two findings deliberately **not** taken here, both filed rather than folded into a one-id PR:

1. `PROVIDERS.openai.defaultModel` is `openai/gpt-5` (`ai-models/configure/route.ts`) while `chat/model` and `PROVIDER_CATALOGS` both say `gpt-5.4`, and `gpt-5` is in no OpenAI list or enumeration on this core — the identical defect, one provider over. Changing an OpenAI cold start is a product call, not a side effect of this one.
2. Whether every Anthropic subscription tier can run `claude-opus-5` is unproven from the repo; `openai` carries a `subscriptionOverride` for exactly that reason. The id is in the pinned core's catalogue (measured above), so the save itself will not be refused; the entitlement question stands.
