### PR TITLE
fix: harden ClawKeep large backups (TASK-675)

### DIFF
--- a/clawkeep/clawkeep/runner.py
+++ b/clawkeep/clawkeep/runner.py
@@ -51,6 +51,41 @@ STEP_ENCRYPTING = "encrypting"
 STEP_UPLOADING = "uploading"
 STEP_CHECKING_STATS = "checking-stats"
 
+ARCHIVE_RACE_ATTEMPTS = 3
+ARCHIVE_RACE_DELAYS = (1.0, 3.0)
+
+
+def _create_archive_with_race_retry(cfg: Config, staging: Path) -> openclaw.Archive:
+    """Retry OpenClaw's transient session-file race without hiding real errors.
+
+    Active sessions rotate ``.jsonl``/``.trajectory.jsonl`` files while the
+    backup tar walk is running. OpenClaw currently reports that as ENOENT.
+    A fresh walk is safe; configuration, permission, disk and timeout errors
+    must still fail immediately.
+    """
+    for attempt in range(ARCHIVE_RACE_ATTEMPTS):
+        try:
+            return agent.create_archive(cfg, output_dir=staging)
+        except agent.ARCHIVE_ERRORS as exc:
+            message = str(exc).lower()
+            transient = "enoent" in message and (
+                ".jsonl" in message or ".jsonl.lock" in message
+            )
+            if not transient or attempt + 1 >= ARCHIVE_RACE_ATTEMPTS:
+                raise
+            delay = ARCHIVE_RACE_DELAYS[attempt]
+            log.warning(
+                "session file changed during archive walk; retrying archive "
+                "(%d/%d) in %.0fs: %s",
+                attempt + 1,
+                ARCHIVE_RACE_ATTEMPTS,
+                delay,
+                exc,
+            )
+            time.sleep(delay)
+
+    raise AssertionError("archive retry loop exhausted")
+
 
 def _heartbeat_safe(server: str, token: str, **kwargs: object) -> bool:
     """Section 9: don't retry heartbeat aggressively. Log + move on.
@@ -262,7 +297,7 @@ def run_once(cfg: Config, token: str, *, label: str | None = None) -> int:
             # business, not this function's: OpenClaw shells out to
             # `openclaw backup create`, Hermes packs `~/.hermes` itself. Both
             # return the same `Archive`, so everything below is identical.
-            archive = agent.create_archive(cfg, output_dir=staging)
+            archive = _create_archive_with_race_retry(cfg, staging)
         except agent.ARCHIVE_ERRORS as e:
             which = agent.device_agent()
             log.error("%s backup create failed: %s", which, e)

--- a/clawkeep/clawkeep/s3.py
+++ b/clawkeep/clawkeep/s3.py
@@ -27,6 +27,13 @@ from .api import Credentials
 MANIFEST_OBJECT = "manifest.json"
 MANIFEST_VERSION = 1
 
+# Large ClawBox archives regularly exceed 10 GB. R2 is happier with fewer,
+# larger parts and modest concurrency than boto3's 8 MiB/high-concurrency
+# defaults (which turn a 12 GB backup into ~1,500 separate UploadPart calls).
+MULTIPART_CHUNK_BYTES = 64 * 1024 * 1024
+MULTIPART_THRESHOLD_BYTES = 64 * 1024 * 1024
+MAX_UPLOAD_CONCURRENCY = 2
+
 
 class S3Error(Exception):
     pass
@@ -83,7 +90,10 @@ def _client(creds: Credentials) -> Any:
         # presigned URLs. "auto" is the documented value.
         region_name="auto",
         signature_version="s3v4",
-        retries={"max_attempts": 3, "mode": "standard"},
+        retries={"max_attempts": 8, "mode": "adaptive"},
+        connect_timeout=10,
+        read_timeout=120,
+        tcp_keepalive=True,
         s3={"addressing_style": "path"},
     )
     return boto3.client(
@@ -122,7 +132,21 @@ def upload(
     cli = _client(creds)
     key = _join(creds.prefix, object_name)
     try:
-        cli.upload_file(str(archive_path), creds.bucket, key, Callback=progress_cb)
+        from boto3.s3.transfer import TransferConfig
+
+        transfer = TransferConfig(
+            multipart_threshold=MULTIPART_THRESHOLD_BYTES,
+            multipart_chunksize=MULTIPART_CHUNK_BYTES,
+            max_concurrency=MAX_UPLOAD_CONCURRENCY,
+            use_threads=True,
+        )
+        cli.upload_file(
+            str(archive_path),
+            creds.bucket,
+            key,
+            Callback=progress_cb,
+            Config=transfer,
+        )
     except (BotoCoreError, ClientError, OSError) as e:
         raise S3Error(f"upload failed for s3://{creds.bucket}/{key}: {e}") from e
     return key

--- a/clawkeep/tests/test_runner.py
+++ b/clawkeep/tests/test_runner.py
@@ -133,7 +133,7 @@ def test_step_is_persisted_until_failure(isolate_state: Path, tmp_path: Path) ->
 
     captured_steps: list[str] = []
 
-    def upload_that_records_state(creds, *, archive_path, object_name):
+    def upload_that_records_state(creds, *, archive_path, object_name, progress_cb=None):
         # By the time the upload is invoked, the runner should already have
         # stamped the "uploading" step. Read state.json from disk to verify
         # the persistence path (not just in-memory state).
@@ -266,6 +266,52 @@ def test_openclaw_failure_reports_error(isolate_state: Path, tmp_path: Path) -> 
     upload.assert_not_called()
     assert heartbeats[-1]["status"] == "error"
     assert "disk full" in heartbeats[-1]["error"]
+
+
+def test_archive_session_race_retries_then_succeeds(
+    isolate_state: Path, tmp_path: Path,
+) -> None:
+    cfg = _cfg(tmp_path)
+    archive = _archive(tmp_path)
+    with (
+        patch("clawkeep.runner.api.mint_credentials", return_value=CREDS),
+        patch("clawkeep.runner.api.heartbeat"),
+        patch(
+            "clawkeep.runner.agent.create_archive",
+            side_effect=[
+                OpenclawError("ENOENT: lstat session.trajectory.jsonl"),
+                archive,
+            ],
+        ) as create,
+        patch("clawkeep.runner.time.sleep") as sleep,
+        patch("clawkeep.runner.s3.upload"),
+        patch("clawkeep.runner.s3.stats", return_value=CloudStats(0, 1)),
+    ):
+        rc = runner.run_once(cfg, "claw_x")
+
+    assert rc == runner.EXIT_OK
+    assert create.call_count == 2
+    sleep.assert_called_once_with(1.0)
+
+
+def test_archive_non_race_error_is_not_retried(
+    isolate_state: Path, tmp_path: Path,
+) -> None:
+    cfg = _cfg(tmp_path)
+    with (
+        patch("clawkeep.runner.api.mint_credentials", return_value=CREDS),
+        patch("clawkeep.runner.api.heartbeat"),
+        patch(
+            "clawkeep.runner.agent.create_archive",
+            side_effect=OpenclawError("permission denied"),
+        ) as create,
+        patch("clawkeep.runner.time.sleep") as sleep,
+    ):
+        rc = runner.run_once(cfg, "claw_x")
+
+    assert rc == runner.EXIT_OPENCLAW
+    create.assert_called_once()
+    sleep.assert_not_called()
 
 
 def test_upload_failure_reports_error(isolate_state: Path, tmp_path: Path) -> None:

--- a/clawkeep/tests/test_s3.py
+++ b/clawkeep/tests/test_s3.py
@@ -54,6 +54,8 @@ def test_upload_calls_put_with_correct_key(tmp_path: Path) -> None:
     transfer = fake_client.upload_file.call_args.kwargs["Config"]
     assert transfer.multipart_chunksize == s3.MULTIPART_CHUNK_BYTES
     assert transfer.max_concurrency == s3.MAX_UPLOAD_CONCURRENCY
+    assert transfer.multipart_threshold == s3.MULTIPART_THRESHOLD_BYTES
+    assert transfer.use_threads is True
 
 
 def test_upload_translates_botocore_error(tmp_path: Path) -> None:

--- a/clawkeep/tests/test_s3.py
+++ b/clawkeep/tests/test_s3.py
@@ -45,8 +45,15 @@ def test_upload_calls_put_with_correct_key(tmp_path: Path) -> None:
         key = s3.upload(CREDS, archive_path=archive, object_name="snap.tar.gz")
     assert key == "users/u_x/repo/snap.tar.gz"
     fake_client.upload_file.assert_called_once_with(
-        str(archive), "clawkeep", "users/u_x/repo/snap.tar.gz",
+        str(archive),
+        "clawkeep",
+        "users/u_x/repo/snap.tar.gz",
+        Callback=None,
+        Config=fake_client.upload_file.call_args.kwargs["Config"],
     )
+    transfer = fake_client.upload_file.call_args.kwargs["Config"]
+    assert transfer.multipart_chunksize == s3.MULTIPART_CHUNK_BYTES
+    assert transfer.max_concurrency == s3.MAX_UPLOAD_CONCURRENCY
 
 
 def test_upload_translates_botocore_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- retry the transient OpenClaw session-file ENOENT race up to three times
- use 64 MiB multipart chunks and low concurrency for large R2 uploads
- switch botocore to adaptive retries with longer read timeout and TCP keepalive

## Why

TASK-675 / Heiner's 11.9 GB backup exposed three long-running failure modes: session files disappearing during the archive walk, TLS EOF during high-part-count uploads, and current UploadPart failures on a long-running multipart upload.

The credential lifetime correction is in the paired website PR. This PR hardens the device side and goes to `beta` first per the ClawBox release procedure.

## Verification

- `python3 -m pytest -q clawkeep/tests` — 131 passed
- `git diff --check`

## Beta validation

- target: Georgi's reserved test ClawBox, MAC `ac:3a:e2:98:99:3b`
- validate a synthetic >12 GB multipart upload and a live archive race before promotion to `main`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archive creation now retries transient session-file race errors, reducing failures caused by files changing during processing.
  * Other archive errors continue to be reported normally.

* **Performance & Reliability**
  * Archive uploads now use optimized multipart transfer settings and improved retry behavior for more reliable large-file transfers.
  * Upload progress reporting and existing error handling remain available.
  * Uploads continue to fail normally when retry attempts are exhausted or when an unrelated error occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->