### PR TITLE
fix: the agent answers restart requests with the owner's real path

### DIFF
--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -66,14 +66,15 @@ The Chromium window is visible on the ClawBox desktop (accessible via the VNC vi
 **Restarting the OpenClaw gateway is not yours to do from a chat turn.** The gateway is what hosts
 this conversation, so restarting it kills the session before your reply lands — the owner sees the
 request vanish, not an answer. It is also rarely what they need: every setting that requires a
-gateway restart already performs one when it is saved (Settings → AI, Voice, Channels). So say that,
-and name the setting.
+gateway restart already performs one when it is saved (Settings → Providers, Voice, Channels).
+So say that, and name the setting.
 
 **A device restart or shutdown IS yours**, when the owner asks for it in their own words: that is
 what `system_power` is for, with `confirm: true` and the reason they gave. Their own control for it
 is the power menu in the desktop tray. What is NOT on Settings → System is any power button — that
 tab holds the harness picker, the performance mode, the read-only device stats and the system
-password; the update and the hostname (which reboots on save) are under Settings → About.
+password. The update is under Settings → About. The device name is the Local URL card under
+Settings → Network, and saving it reboots the box.
 
 **Never queue an `operator_approval` proposal for any of this.** OpenClaw's approvals mechanism is
 real — `approval.request` over the gateway RPC, the `operator.approvals` scope, `openclaw approvals`

--- a/config/clawbox-workspace-guide.md
+++ b/config/clawbox-workspace-guide.md
@@ -61,6 +61,31 @@ The Chromium window is visible on the ClawBox desktop (accessible via the VNC vi
 
 ---
 
+## System actions and restarts
+
+**Restarting the OpenClaw gateway is not yours to do from a chat turn.** The gateway is what hosts
+this conversation, so restarting it kills the session before your reply lands — the owner sees the
+request vanish, not an answer. It is also rarely what they need: every setting that requires a
+gateway restart already performs one when it is saved (Settings → AI, Voice, Channels). So say that,
+and name the setting.
+
+**A device restart or shutdown IS yours**, when the owner asks for it in their own words: that is
+what `system_power` is for, with `confirm: true` and the reason they gave. Their own control for it
+is the power menu in the desktop tray. What is NOT on Settings → System is any power button — that
+tab holds the harness picker, the performance mode, the read-only device stats and the system
+password; the update and the hostname (which reboots on save) are under Settings → About.
+
+**Never queue an `operator_approval` proposal for any of this.** OpenClaw's approvals mechanism is
+real — `approval.request` over the gateway RPC, the `operator.approvals` scope, `openclaw approvals`
+on the CLI — but ClawBox's chat renders no card for a pending approval, so one queued here is shown
+to nobody in the place the owner is actually looking. It waits until the run ends, or until the very
+restart it asked for cancels it (`operator_approval_cancelled_gateway_restart`). If a proposal is
+already parked, the one way to answer it is `openclaw approvals pending` and `openclaw approvals
+resolve <id> allow-once|allow-always|deny` from the Terminal app (`ui_open_app("terminal")`) — tell
+the owner that rather than leaving them waiting.
+
+---
+
 ## Coding agent (delegate a whole task)
 
 Three more tools are registered when your session starts, and only if the owner had it switched on in the **Coding Agent app** on the desktop AND that app reported the harness ready (Claude Code, `claude-ds` and ClawBox AI all present):

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2325,7 +2325,7 @@ CLAWBOX_GUIDE_TOPUP="## System actions and restarts"
 # gateway would burn StartLimitBurst=20 in about a hundred seconds and then sit
 # failed for the rest of the StartLimitIntervalSec=3600 window — the box loses
 # its assistant over an advisory text file. So each write warns and boots on.
-if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
+if [ -d "$CLAWBOX_WORKSPACE" ]; then
   # Seed-if-missing rather than overwrite-on-diff. The agent and the
   # user may personalize CLAWBOX.md (add device-specific notes, remove
   # sections that don't apply). Overwriting on every gateway start
@@ -2333,10 +2333,14 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # operator wants to pull it in, they can delete the file; the next
   # gateway start will re-seed.
   #
-  # `-r` rather than the enclosing `-f`: this template is only ever read, and an
-  # existing-but-unreadable one is exactly what `-f` waves through into a write
-  # that then fails. Tested here and not in the condition above, so that the
-  # AGENTS.md rule further down — which needs no template at all — still lands.
+  # The template is tested with `-r`, HERE rather than in the condition above.
+  # It is only ever read, so `-r` covers both the missing file the old enclosing
+  # `-f` tested for and the existing-but-unreadable one `-f` waved through into a
+  # write that then fails. Testing it inside this chain is what keeps the promise
+  # the next block relies on: the AGENTS.md rule needs no template at all, and it
+  # is the copy the harness actually injects, so it must still land when the
+  # template is missing or unreadable — which the enclosing `-f` silently
+  # prevented, with no warning at all.
   if [ ! -r "$CLAWBOX_GUIDE_SRC" ]; then
     echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC; leaving CLAWBOX.md as it is" >&2
   elif [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
@@ -2367,6 +2371,10 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
     # append supplies its own separator and carrying the template's too ends the
     # topped-up guide on a dangling rule.
     #
+    # The heading is matched as a WHOLE line (modulo a CR), not as a prefix: a
+    # later `## System actions and restarts (advanced)` would otherwise open the
+    # extraction and then fail to close it, swallowing every section after it.
+    #
     # The heading reaches awk through the environment rather than `-v`, which
     # runs its value through escape processing: a heading that ever grew a
     # backslash would quietly stop matching and the section would go missing
@@ -2376,8 +2384,9 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
     # two send an operator to different files.
     CLAWBOX_GUIDE_SECTION=""
     if CLAWBOX_GUIDE_SECTION="$(heading="$CLAWBOX_GUIDE_TOPUP" awk '
-      index($0, ENVIRON["heading"]) == 1 { inside = 1 }
-      inside && /^## / && index($0, ENVIRON["heading"]) != 1 { exit }
+      { line = $0; sub(/\r$/, "", line) }
+      line == ENVIRON["heading"] { inside = 1; lines[++n] = $0; next }
+      inside && /^## / { exit }
       inside { lines[++n] = $0 }
       END {
         while (n > 0) {

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2225,7 +2225,9 @@ unset CLAWBOX_MCP_TOKEN_VAL
 # falls back to guessing paths — which has misled it before (e.g.
 # checking .npm-global/.../openclaw/skills for user skills and finding
 # "nothing", even though the skill is installed at
-# <workspace>/skills/).
+# <workspace>/skills/) — and, on the box this top-up was written for, into
+# queueing an operator-approval proposal for a gateway restart nothing here
+# can render (TASK-612).
 #
 # OpenClaw 2 unbundled the DeepSeek provider into its own plugin
 # (@openclaw/deepseek-provider) and refuses gateway readiness while a
@@ -2312,6 +2314,10 @@ fi
 
 CLAWBOX_GUIDE_SRC="$CLAWBOX_ROOT/config/clawbox-workspace-guide.md"
 CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
+# The heading of the section an already-seeded CLAWBOX.md is topped up with,
+# and the marker that says it is already there. Matched with `grep -qF` and
+# `index(...) == 1`, so it must be the literal start of the heading line.
+CLAWBOX_GUIDE_TOPUP="## System actions and restarts"
 if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # Seed-if-missing rather than overwrite-on-diff. The agent and the
   # user may personalize CLAWBOX.md (add device-specific notes, remove
@@ -2322,6 +2328,56 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   if [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
     install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"
     echo "  Seeded CLAWBOX.md in OpenClaw workspace"
+  elif ! grep -qF "$CLAWBOX_GUIDE_TOPUP" "$CLAWBOX_GUIDE_DST"; then
+    # Seed-if-missing alone means a section ADDED to the template after a box
+    # was set up never reaches that box — every box in the field already has
+    # CLAWBOX.md, including the one whose agent queued an operator-approval
+    # proposal for a gateway restart (TASK-612). Shipping the rule to new
+    # boxes only would be a fix that reports success without arriving.
+    #
+    # So: append the one section, never overwrite the file. Personalizations
+    # survive, and the `grep -qF` above is the idempotence marker — a second
+    # gateway start finds the heading and appends nothing. The awk prints from
+    # the heading to the `---` that closes the section in the template, so the
+    # text has exactly one source.
+    #
+    # Both halves below can fail without the gateway caring: this file is
+    # advisory text. Under `set -euo pipefail` an unwritable CLAWBOX.md would
+    # otherwise abort pre-start and take the gateway down over a guide — so
+    # each failure is warned about and the boot continues. The `|| true` is
+    # not a swallowed error: the `-n` test right after it IS the check.
+    #
+    # Bounded by the NEXT `## ` heading, not by the `---` rule that happens to
+    # sit before it: a rule inside the section would have truncated it, and a
+    # CRLF template (`---\r`) would have matched no terminator at all and
+    # dragged every following section into the append.
+    CLAWBOX_GUIDE_SECTION=""
+    if CLAWBOX_GUIDE_SECTION="$(awk -v heading="$CLAWBOX_GUIDE_TOPUP" '
+      index($0, heading) == 1 { inside = 1; print; next }
+      inside && /^## / { exit }
+      inside { print }
+    ' "$CLAWBOX_GUIDE_SRC")"; then
+      if [ -z "$CLAWBOX_GUIDE_SECTION" ]; then
+        # The heading was renamed in the template without this marker following
+        # it. Appending a separator alone would report a success that added
+        # nothing, and would do it again on every gateway start.
+        echo "  WARNING: the shipped guide no longer carries '$CLAWBOX_GUIDE_TOPUP'" >&2
+      # A file that does not end in a newline would otherwise have its last
+      # line joined to the separator, making it a setext heading.
+      elif { [ -s "$CLAWBOX_GUIDE_DST" ] && [ "$(tail -c1 "$CLAWBOX_GUIDE_DST")" != "" ] && printf '\n'; \
+             printf '\n---\n\n%s\n' "$CLAWBOX_GUIDE_SECTION"; } >> "$CLAWBOX_GUIDE_DST"; then
+        echo "  Appended the system-actions section to CLAWBOX.md"
+      else
+        # Its cause is on this shell's stderr already; do not hide it behind a
+        # 2>/dev/null that the failing redirection never reaches anyway.
+        echo "  WARNING: could not append the system-actions section to CLAWBOX.md" >&2
+      fi
+    else
+      # Separated from the empty-extraction case on purpose: an unreadable
+      # template is an I/O fault, not a renamed heading, and telling an
+      # operator the wrong one sends them to the wrong file.
+      echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC to top up CLAWBOX.md" >&2
+    fi
   fi
 
   # Append a one-liner reference to AGENTS.md if it exists and doesn't
@@ -2330,7 +2386,39 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # (which the agent may have personalized).
   CLAWBOX_AGENTS_MD="$CLAWBOX_WORKSPACE/AGENTS.md"
   if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "CLAWBOX.md" "$CLAWBOX_AGENTS_MD"; then
-    printf '\n\n## ClawBox integration\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, and how to install/uninstall skills through the App Store.\n' >> "$CLAWBOX_AGENTS_MD"
-    echo "  Appended CLAWBOX.md reference to AGENTS.md"
+    # Guarded like the two appends below, and for the same reason: this one has
+    # always been bare, so a read-only AGENTS.md aborted pre-start under
+    # `set -euo pipefail` and the gateway never started — over a pointer
+    # sentence. Reachable whenever the file exists without the marker.
+    if printf '\n\n## ClawBox integration\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, how to install/uninstall skills through the App Store, and which system actions are the owner'"'"'s.\n' >> "$CLAWBOX_AGENTS_MD"; then
+      echo "  Appended CLAWBOX.md reference to AGENTS.md"
+    else
+      echo "  WARNING: could not append the CLAWBOX.md reference to AGENTS.md" >&2
+    fi
+  fi
+
+  # THE RULE ITSELF GOES IN AGENTS.md, not only in CLAWBOX.md.
+  #
+  # OpenClaw's workspace file map (docs/concepts/agent-workspace.md, verified in
+  # the pinned 2026.8.1 package) injects AGENTS.md, SOUL.md, USER.md,
+  # IDENTITY.md, BOOT.md, BOOTSTRAP.md and memory/ at the start of every
+  # session — and describes AGENTS.md as "operating instructions ... good place
+  # for rules". CLAWBOX.md is NOT in that set: it is read only if the agent
+  # chooses to open it, prompted by the pointer above. A behavioural
+  # prohibition that the model may never load is not a prohibition, which is
+  # how TASK-612 could otherwise have shipped green and reproduced unchanged.
+  #
+  # Its own marker, deliberately not the "CLAWBOX.md" one: that pointer is
+  # already present on every box in the field, so anything guarded by it can
+  # never be delivered again.
+  CLAWBOX_AGENTS_RULE="## System actions on this ClawBox"
+  if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "$CLAWBOX_AGENTS_RULE" "$CLAWBOX_AGENTS_MD"; then
+    if printf '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving an AI, Voice or Channels setting restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE" >> "$CLAWBOX_AGENTS_MD"; then
+      echo "  Appended the system-actions rule to AGENTS.md"
+    else
+      # Advisory text must never hold up the gateway; the next start retries.
+      echo "  WARNING: could not append the system-actions rule to AGENTS.md" >&2
+    fi
   fi
 fi
+# --- end guide seeding ---

--- a/scripts/gateway-pre-start.sh
+++ b/scripts/gateway-pre-start.sh
@@ -2318,6 +2318,13 @@ CLAWBOX_GUIDE_DST="$CLAWBOX_WORKSPACE/CLAWBOX.md"
 # and the marker that says it is already there. Matched with `grep -qF` and
 # `index(...) == 1`, so it must be the literal start of the heading line.
 CLAWBOX_GUIDE_TOPUP="## System actions and restarts"
+# EVERY write below is guarded, and that is a boot requirement rather than a
+# matter of taste: config/clawbox-gateway.service runs this script as
+# `ExecStartPre=` with no leading `-`, so under `set -euo pipefail` a failing
+# write here is the unit's failure. With Restart=always and RestartSec=5 the
+# gateway would burn StartLimitBurst=20 in about a hundred seconds and then sit
+# failed for the rest of the StartLimitIntervalSec=3600 window — the box loses
+# its assistant over an advisory text file. So each write warns and boots on.
 if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # Seed-if-missing rather than overwrite-on-diff. The agent and the
   # user may personalize CLAWBOX.md (add device-specific notes, remove
@@ -2325,9 +2332,23 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # would clobber those edits. If the shipped template changes and an
   # operator wants to pull it in, they can delete the file; the next
   # gateway start will re-seed.
-  if [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
-    install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"
-    echo "  Seeded CLAWBOX.md in OpenClaw workspace"
+  #
+  # `-r` rather than the enclosing `-f`: this template is only ever read, and an
+  # existing-but-unreadable one is exactly what `-f` waves through into a write
+  # that then fails. Tested here and not in the condition above, so that the
+  # AGENTS.md rule further down — which needs no template at all — still lands.
+  if [ ! -r "$CLAWBOX_GUIDE_SRC" ]; then
+    echo "  WARNING: could not read $CLAWBOX_GUIDE_SRC; leaving CLAWBOX.md as it is" >&2
+  elif [ ! -f "$CLAWBOX_GUIDE_DST" ]; then
+    if install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST"; then
+      echo "  Seeded CLAWBOX.md in OpenClaw workspace"
+    else
+      # The first-boot and post-factory-reset path, and the one write in this
+      # block that used to be bare: a full rootfs, a filesystem remounted
+      # read-only after errors, or the documented "delete CLAWBOX.md to
+      # re-seed" step on such a box all land here.
+      echo "  WARNING: could not seed CLAWBOX.md in the OpenClaw workspace" >&2
+    fi
   elif ! grep -qF "$CLAWBOX_GUIDE_TOPUP" "$CLAWBOX_GUIDE_DST"; then
     # Seed-if-missing alone means a section ADDED to the template after a box
     # was set up never reaches that box — every box in the field already has
@@ -2337,25 +2358,36 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
     #
     # So: append the one section, never overwrite the file. Personalizations
     # survive, and the `grep -qF` above is the idempotence marker — a second
-    # gateway start finds the heading and appends nothing. The awk prints from
-    # the heading to the `---` that closes the section in the template, so the
-    # text has exactly one source.
+    # gateway start finds the heading and appends nothing. The awk below is the
+    # section's only source, and it is bounded by the NEXT `## ` heading rather
+    # than by the `---` rule that happens to sit before it: a rule inside the
+    # section would have truncated it, and a CRLF template (`---\r`) would have
+    # matched no terminator at all and dragged every following section along.
+    # Trailing blank lines and that closing rule are then dropped, because the
+    # append supplies its own separator and carrying the template's too ends the
+    # topped-up guide on a dangling rule.
     #
-    # Both halves below can fail without the gateway caring: this file is
-    # advisory text. Under `set -euo pipefail` an unwritable CLAWBOX.md would
-    # otherwise abort pre-start and take the gateway down over a guide — so
-    # each failure is warned about and the boot continues. The `|| true` is
-    # not a swallowed error: the `-n` test right after it IS the check.
-    #
-    # Bounded by the NEXT `## ` heading, not by the `---` rule that happens to
-    # sit before it: a rule inside the section would have truncated it, and a
-    # CRLF template (`---\r`) would have matched no terminator at all and
-    # dragged every following section into the append.
+    # The heading reaches awk through the environment rather than `-v`, which
+    # runs its value through escape processing: a heading that ever grew a
+    # backslash would quietly stop matching and the section would go missing
+    # with no warning. Extraction and append are both guarded, under the
+    # invariant at the top of this block — neither may abort pre-start — and a
+    # renamed heading is reported apart from an unreadable template, because the
+    # two send an operator to different files.
     CLAWBOX_GUIDE_SECTION=""
-    if CLAWBOX_GUIDE_SECTION="$(awk -v heading="$CLAWBOX_GUIDE_TOPUP" '
-      index($0, heading) == 1 { inside = 1; print; next }
-      inside && /^## / { exit }
-      inside { print }
+    if CLAWBOX_GUIDE_SECTION="$(heading="$CLAWBOX_GUIDE_TOPUP" awk '
+      index($0, ENVIRON["heading"]) == 1 { inside = 1 }
+      inside && /^## / && index($0, ENVIRON["heading"]) != 1 { exit }
+      inside { lines[++n] = $0 }
+      END {
+        while (n > 0) {
+          tail = lines[n]
+          sub(/\r$/, "", tail)
+          if (tail != "" && tail != "---") break
+          n--
+        }
+        for (i = 1; i <= n; i++) print lines[i]
+      }
     ' "$CLAWBOX_GUIDE_SRC")"; then
       if [ -z "$CLAWBOX_GUIDE_SECTION" ]; then
         # The heading was renamed in the template without this marker following
@@ -2385,12 +2417,22 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # its session-start context without us having to overwrite AGENTS.md
   # (which the agent may have personalized).
   CLAWBOX_AGENTS_MD="$CLAWBOX_WORKSPACE/AGENTS.md"
-  if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "CLAWBOX.md" "$CLAWBOX_AGENTS_MD"; then
+  # Guarded on the pointer's OWN heading, not on the bare "CLAWBOX.md" literal.
+  # The rule block below ends "`CLAWBOX.md` has the long form", so a literal
+  # guard is satisfied by the rule's own text: the two blocks both landed only
+  # because this one happens to be written first. That ordering was
+  # load-bearing and stated nowhere — a reorder, or moving the rule into a
+  # helper that ran earlier, would have cost every fresh box its pointer with
+  # both markers "satisfied" and no warning. Nothing else writes this heading,
+  # and every box in the field already carries it verbatim (it has not changed
+  # since it was introduced), so no box receives a second copy.
+  CLAWBOX_AGENTS_POINTER="## ClawBox integration"
+  if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "$CLAWBOX_AGENTS_POINTER" "$CLAWBOX_AGENTS_MD"; then
     # Guarded like the two appends below, and for the same reason: this one has
     # always been bare, so a read-only AGENTS.md aborted pre-start under
     # `set -euo pipefail` and the gateway never started — over a pointer
     # sentence. Reachable whenever the file exists without the marker.
-    if printf '\n\n## ClawBox integration\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, how to install/uninstall skills through the App Store, and which system actions are the owner'"'"'s.\n' >> "$CLAWBOX_AGENTS_MD"; then
+    if printf '\n\n%s\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live, how to control the desktop Chromium via `browser_*` tools, how to install/uninstall skills through the App Store, and which system actions are the owner'"'"'s.\n' "$CLAWBOX_AGENTS_POINTER" >> "$CLAWBOX_AGENTS_MD"; then
       echo "  Appended CLAWBOX.md reference to AGENTS.md"
     else
       echo "  WARNING: could not append the CLAWBOX.md reference to AGENTS.md" >&2
@@ -2413,7 +2455,7 @@ if [ -d "$CLAWBOX_WORKSPACE" ] && [ -f "$CLAWBOX_GUIDE_SRC" ]; then
   # never be delivered again.
   CLAWBOX_AGENTS_RULE="## System actions on this ClawBox"
   if [ -f "$CLAWBOX_AGENTS_MD" ] && ! grep -qF "$CLAWBOX_AGENTS_RULE" "$CLAWBOX_AGENTS_MD"; then
-    if printf '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving an AI, Voice or Channels setting restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE" >> "$CLAWBOX_AGENTS_MD"; then
+    if printf '\n\n%s\n\nRestarting the OpenClaw gateway is not yours to do from a chat turn: the gateway hosts this session, so the restart kills the reply before it lands. It is rarely needed either — saving a setting under Settings -> Providers, Voice or Channels restarts it. Say that, and name the setting.\n\nA device restart or shutdown IS yours when the owner asks in their own words: `system_power`, `confirm: true`, with their reason. Their own control is the power menu in the desktop tray, not Settings -> System.\n\nNever queue an `operator_approval` proposal for any of this. ClawBox renders no approval card, so a queued proposal is shown to nobody; a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve` from the Terminal app. `CLAWBOX.md` has the long form.\n' "$CLAWBOX_AGENTS_RULE" >> "$CLAWBOX_AGENTS_MD"; then
       echo "  Appended the system-actions rule to AGENTS.md"
     else
       # Advisory text must never hold up the gateway; the next start retries.

--- a/src/tests/unit/clawbox-workspace-guide.test.ts
+++ b/src/tests/unit/clawbox-workspace-guide.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The guide ClawBox seeds into the OpenClaw workspace as `CLAWBOX.md`
+ * (scripts/gateway-pre-start.sh) is the agent's only source of ClawBox-specific
+ * conventions, so what it forbids is as load-bearing as what it offers.
+ *
+ * TASK-612: asked "restart the gateway", the agent reached for OpenClaw's
+ * operator-approval path — the native `approval.request` RPC behind the
+ * `operator.approvals` scope, which is the right mechanism on a box whose
+ * operator surface renders it. ClawBox's chat renders nothing of the kind
+ * today, so the proposal sat unanswered until the run ended or a gateway
+ * restart cancelled it (`operator_approval_cancelled_gateway_restart`), and
+ * the owner was told the restart was waiting for an approval they had nowhere
+ * to give. Until that card exists (follow-up under TASK-604), the guide has to
+ * name the owner's real path — Settings -> System — and forbid the queue.
+ *
+ * Asserted against the section, not the whole file, so a failure prints the
+ * paragraph that is wrong rather than the entire guide.
+ */
+
+const GUIDE_PATH = path.join(process.cwd(), "config/clawbox-workspace-guide.md");
+const GUIDE = readFileSync(GUIDE_PATH, "utf-8");
+
+/** The `## System actions and restarts` section, without its neighbours. */
+function systemActionsSection(): string {
+  const start = GUIDE.search(/^## .*\bSystem actions\b/im);
+  if (start < 0) return "";
+  const rest = GUIDE.slice(start);
+  const next = rest.slice(1).search(/^## /m);
+  return next < 0 ? rest : rest.slice(0, next + 1);
+}
+
+describe("the ClawBox workspace guide (CLAWBOX.md)", () => {
+  it("carries a section on system actions and restarts", () => {
+    expect(systemActionsSection().slice(0, 80)).toMatch(/^## .*System actions/);
+  });
+
+  it("separates the gateway restart it refuses from the device restart it owns", () => {
+    const section = systemActionsSection();
+    // The gateway restart, by name and with a reason the agent can act on.
+    expect(section.toLowerCase()).toContain("gateway");
+    expect(section).toMatch(/not yours|is not yours to do/i);
+    // And the capability the device actually ships, which an earlier draft of
+    // this section denied outright ("you have no tool for any of them") — the
+    // guide would then have talked a confirm-gated, owner-consented tool out
+    // of existence. mcp/tools/system.ts registers it on both editions.
+    expect(section).toContain("system_power");
+  });
+
+  it("names controls that exist: the tray power menu, and Settings -> System for what is there", () => {
+    const section = systemActionsSection();
+    // Settings -> System carries the harness picker, the performance mode, the
+    // read-only stats and the password — no power control (SettingsApp.tsx).
+    // Sending the owner there for a restart is the wrong screen.
+    expect(section).toMatch(/power menu/i);
+    expect(section).toMatch(/Settings\s*→\s*System/);
+    // And it must tell the agent to SAY where the control is, not just decline.
+    expect(section).toMatch(/say that|answer with|tell (?:the owner|them)|point (?:the owner|them)/i);
+  });
+
+  it("forbids queueing an operator-approval proposal, and names the way to answer a parked one", () => {
+    const section = systemActionsSection();
+    // The native id, so the instruction names what the agent would actually
+    // reach for rather than a paraphrase of it.
+    expect(section).toContain("operator_approval");
+    expect(section).toMatch(/never\s+(?:queue|propose|raise|open)|do not\s+queue|don't\s+queue/i);
+    // "nowhere to answer it" would be false: the CLI resolves one, and the
+    // desktop ships a Terminal app.
+    expect(section).toContain("openclaw approvals");
+  });
+});

--- a/src/tests/unit/clawbox-workspace-guide.test.ts
+++ b/src/tests/unit/clawbox-workspace-guide.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it } from "vitest";
  * today, so the proposal sat unanswered until the run ended or a gateway
  * restart cancelled it (`operator_approval_cancelled_gateway_restart`), and
  * the owner was told the restart was waiting for an approval they had nowhere
- * to give. Until that card exists (follow-up under TASK-604), the guide has to
+ * to give. Until that card exists (TASK-704, under TASK-604), the guide has to
  * forbid the queue and name the owner's real path — the power menu in the
  * desktop tray, NOT Settings -> System, which carries no power control at all.
  *

--- a/src/tests/unit/clawbox-workspace-guide.test.ts
+++ b/src/tests/unit/clawbox-workspace-guide.test.ts
@@ -15,7 +15,8 @@ import { describe, expect, it } from "vitest";
  * restart cancelled it (`operator_approval_cancelled_gateway_restart`), and
  * the owner was told the restart was waiting for an approval they had nowhere
  * to give. Until that card exists (follow-up under TASK-604), the guide has to
- * name the owner's real path — Settings -> System — and forbid the queue.
+ * forbid the queue and name the owner's real path — the power menu in the
+ * desktop tray, NOT Settings -> System, which carries no power control at all.
  *
  * Asserted against the section, not the whole file, so a failure prints the
  * paragraph that is wrong rather than the entire guide.
@@ -50,7 +51,7 @@ describe("the ClawBox workspace guide (CLAWBOX.md)", () => {
     expect(section).toContain("system_power");
   });
 
-  it("names controls that exist: the tray power menu, and Settings -> System for what is there", () => {
+  it("gives the owner's control as the tray power menu, and Settings -> System only for what is on it", () => {
     const section = systemActionsSection();
     // Settings -> System carries the harness picker, the performance mode, the
     // read-only stats and the password — no power control (SettingsApp.tsx).
@@ -59,6 +60,42 @@ describe("the ClawBox workspace guide (CLAWBOX.md)", () => {
     expect(section).toMatch(/Settings\s*→\s*System/);
     // And it must tell the agent to SAY where the control is, not just decline.
     expect(section).toMatch(/say that|answer with|tell (?:the owner|them)|point (?:the owner|them)/i);
+  });
+
+  it("names the screen each control is actually on, not the one next to it", () => {
+    const section = systemActionsSection();
+    // Measured in src/components/SettingsApp.tsx at this head:
+    //
+    //   - the EDITABLE device name is the "Local URL (mDNS hostname)" card at
+    //     :3425, inside `activeSection === "wifi"` (:3241-3631). That nav entry
+    //     is `{ id: "wifi", ..., labelKey: "settings.network" }` (:255) and
+    //     "settings.network" is "Network" (src/lib/translations.ts:302). Saving
+    //     it POSTs /setup-api/system/power (:1090) — hence "reboots".
+    //   - Settings -> About (`activeSection === "about"`, :5638) holds the
+    //     version card, the docs/support links, the Beta toggle, the System
+    //     Update tile and Factory reset. Grepping :5638-5800 for
+    //     hostname|rename|deviceName returns nothing.
+    //
+    // Sending the owner to About to rename the box is the identical
+    // wrong-screen failure this section was written to remove, one clause later.
+    expect(section).toMatch(/Settings\s*→\s*Network/);
+    const deviceNameClauses = section
+      .split(/(?<=[.;])\s+/)
+      .filter((clause) => /device name|hostname|Local URL/i.test(clause));
+    expect(deviceNameClauses.length).toBeGreaterThan(0);
+    for (const clause of deviceNameClauses) {
+      expect(clause).toMatch(/Settings\s*→\s*Network/);
+      expect(clause).not.toMatch(/Settings\s*→\s*About/);
+    }
+  });
+
+  it("names the restart-on-save tabs by their labels", () => {
+    const section = systemActionsSection();
+    // There is no tab labelled "AI": nav id "ai" carries labelKey
+    // "settings.providers" (SettingsApp.tsx:245) = "Providers"
+    // (src/lib/desktop-translations.ts:411). Voice and Channels are correct.
+    expect(section).toMatch(/Settings\s*→\s*Providers/);
+    expect(section).not.toMatch(/Settings\s*→\s*AI\b/);
   });
 
   it("forbids queueing an operator-approval proposal, and names the way to answer a parked one", () => {

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * How the ClawBox guide reaches the OpenClaw workspace.
+ *
+ * The seeding block writes `config/clawbox-workspace-guide.md` to
+ * `<workspace>/CLAWBOX.md` — but only when the file is absent, deliberately, so
+ * an owner's or an agent's edits survive a gateway start. The consequence was
+ * silent: a section added to the template after a box was set up never reached
+ * that box, and every box in the field already has the file. TASK-612's rule
+ * (system actions are the owner's; never queue an operator_approval) would have
+ * shipped to new boxes only — including not to the box whose agent produced the
+ * incident.
+ *
+ * So an existing file is TOPPED UP with the one missing section, and never
+ * overwritten. These run the block out of the shipped `.sh` rather than a copy,
+ * so the test fails if the real script drifts.
+ */
+
+const SCRIPT = path.resolve(process.cwd(), "scripts/gateway-pre-start.sh");
+const TEMPLATE = path.resolve(process.cwd(), "config/clawbox-workspace-guide.md");
+const HEADING = "## System actions and restarts";
+
+/**
+ * The seeding block, verbatim, between its two sentinels.
+ *
+ * Bounded rather than sliced to EOF: the block is last in the file today, and
+ * the day anything is appended after it these tests would execute that too, in
+ * a stub shell holding only CLAWBOX_ROOT and CLAWBOX_WORKSPACE, and fail under
+ * `set -u` for a reason that has nothing to do with the guide.
+ */
+const BLOCK_END = "# --- end guide seeding ---";
+function seedingBlock(): string {
+  const src = readFileSync(SCRIPT, "utf-8");
+  const start = src.indexOf('CLAWBOX_GUIDE_SRC="$CLAWBOX_ROOT');
+  const end = src.indexOf(BLOCK_END, start);
+  if (start < 0 || end < 0) throw new Error("guide seeding block not found in gateway-pre-start.sh");
+  return src.slice(start, end);
+}
+
+let dir: string;
+let workspace: string;
+let guide: string;
+
+/**
+ * Run the shipped block against a temp workspace under the same shell options
+ * pre-start itself sets (`set -euo pipefail`, line 19) — the point of several
+ * of these tests is what those options do to a failure.
+ *
+ * `template` overrides the guide the block copies from, for the case where the
+ * template no longer carries the section the marker names.
+ */
+function run(template = path.join(process.cwd(), "config/clawbox-workspace-guide.md")): { stdout: string; stderr: string } {
+  const root = mkdtempSync(path.join(dir, "root-"));
+  mkdirSync(path.join(root, "config"), { recursive: true });
+  writeFileSync(path.join(root, "config/clawbox-workspace-guide.md"), readFileSync(template, "utf-8"));
+  const script = `set -euo pipefail\nCLAWBOX_ROOT=${JSON.stringify(root)}\nCLAWBOX_WORKSPACE=${JSON.stringify(workspace)}\n${seedingBlock()}`;
+  const res = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+  if (res.status !== 0) {
+    throw new Error(`pre-start block exited ${res.status}\n${res.stdout}\n${res.stderr}`);
+  }
+  return { stdout: res.stdout, stderr: res.stderr };
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "clawbox-guide-"));
+  workspace = path.join(dir, "workspace");
+  mkdirSync(workspace, { recursive: true });
+  guide = path.join(workspace, "CLAWBOX.md");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
+  it("seeds the whole template when the workspace has no guide", () => {
+    const { stdout } = run();
+
+    expect(stdout).toContain("Seeded CLAWBOX.md");
+    expect(readFileSync(guide, "utf-8")).toBe(readFileSync(TEMPLATE, "utf-8"));
+  });
+
+  it("appends the system-actions section to a guide written before it existed", () => {
+    // A real pre-TASK-612 guide, personalized: the sections the box was seeded
+    // with, plus a note the owner added.
+    const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+    writeFileSync(guide, `${older}\n\n## Owner's notes\n\nThe printer is on the shelf.\n`);
+
+    const { stdout } = run();
+
+    expect(stdout).toContain("Appended the system-actions section");
+    const after = readFileSync(guide, "utf-8");
+    // The rule arrived...
+    expect(after).toContain(HEADING);
+    expect(after).toContain("operator_approval");
+    expect(after).toMatch(/Settings\s*→\s*System/);
+    // ...the personalization survived, and nothing else was rewritten.
+    expect(after).toContain("The printer is on the shelf.");
+    expect(after.startsWith(older)).toBe(true);
+  });
+
+  it("appends once, however many times the gateway starts", () => {
+    const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+    writeFileSync(guide, older);
+
+    run();
+    const afterFirst = readFileSync(guide, "utf-8");
+    const second = run();
+
+    expect(second.stdout).not.toContain("Appended the system-actions section");
+    expect(readFileSync(guide, "utf-8")).toBe(afterFirst);
+    expect(afterFirst.split(HEADING)).toHaveLength(2);
+  });
+
+  it("takes only that section, not the ones that follow it in the template", () => {
+    const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+    writeFileSync(guide, older);
+
+    run();
+
+    const appended = readFileSync(guide, "utf-8").slice(older.length);
+    expect(appended).toContain(HEADING);
+    // The template's next heading must not have been dragged along.
+    expect(appended).not.toContain("## Coding agent");
+    expect(appended).not.toContain("## Remember the user's name");
+  });
+
+  it("warns instead of appending an empty section when the template loses the heading", () => {
+    // The marker and the heading are two strings that have to stay in step. If
+    // the heading is renamed and the marker is not, the extraction comes back
+    // empty — appending the separator alone would report a success that added
+    // nothing, and would do it again on every gateway start.
+    const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+    writeFileSync(guide, older);
+    const renamed = path.join(dir, "renamed-template.md");
+    writeFileSync(renamed, readFileSync(TEMPLATE, "utf-8").replace(HEADING, "## Restarts, renamed"));
+
+    const { stdout, stderr } = run(renamed);
+
+    expect(stdout).not.toContain("Appended the system-actions section");
+    expect(stderr).toContain("no longer carries");
+    expect(readFileSync(guide, "utf-8")).toBe(older);
+  });
+
+  // `skipIf`, not an early return: a root container would otherwise report this
+  // as a pass with no assertions, and it is the one test covering "the gateway
+  // still starts". Root ignores the mode bits, so there is nothing to prove there.
+  it.skipIf(process.getuid?.() === 0)("warns and lets the gateway start when the guide cannot be written", () => {
+    const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+    writeFileSync(guide, older);
+    chmodSync(guide, 0o444);
+
+    // `run` throws on a non-zero exit — reaching the assertions IS the proof
+    // that pre-start survived.
+    const { stdout, stderr } = run();
+
+    expect(stdout).not.toContain("Appended the system-actions section");
+    expect(stderr).toContain("could not append");
+    expect(readFileSync(guide, "utf-8")).toBe(older);
+  });
+
+  it("keeps the appended section as its own heading when the guide has no trailing newline", () => {
+    // A file ending `...text` joined to the separator turns that last line into
+    // a setext H2 — the owner's last note silently becomes a heading.
+    const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+    writeFileSync(guide, `${older.trimEnd()}\n\nThe printer is on the shelf.`);
+
+    run();
+
+    const after = readFileSync(guide, "utf-8");
+    expect(after).toContain("The printer is on the shelf.\n\n---\n");
+    expect(after).not.toContain("The printer is on the shelf.\n---\n");
+  });
+
+  it("appends the section at the end, after whatever the owner already had", () => {
+    // The placement IS a decision: a top-up appends rather than splicing the
+    // section into its template position, so on a personalized guide it lands
+    // last. Asserted so a change of mind is a failing test, not a surprise.
+    const older = readFileSync(TEMPLATE, "utf-8").split(`\n---\n\n${HEADING}`)[0];
+    writeFileSync(guide, `${older}\n\n## Owner's notes\n\nThe printer is on the shelf.\n`);
+
+    run();
+
+    const after = readFileSync(guide, "utf-8");
+    expect(after.indexOf(HEADING)).toBeGreaterThan(after.indexOf("## Owner's notes"));
+  });
+
+  it("leaves a guide that already carries the section untouched", () => {
+    const current = readFileSync(TEMPLATE, "utf-8");
+    writeFileSync(guide, current);
+
+    const { stdout } = run();
+
+    expect(stdout).not.toContain("Appended the system-actions section");
+    expect(stdout).not.toContain("Seeded CLAWBOX.md");
+    expect(readFileSync(guide, "utf-8")).toBe(current);
+  });
+});
+
+/**
+ * The rule has to reach the model, not just the disk.
+ *
+ * OpenClaw's workspace file map injects AGENTS.md at the start of every session
+ * ("operating instructions ... good place for rules"); CLAWBOX.md is not in that
+ * set and is read only if the agent opens it. So the prohibition itself is
+ * written into AGENTS.md, under a marker of its own — NOT the "CLAWBOX.md"
+ * pointer marker, which is already present on every box in the field and
+ * therefore can never deliver anything again.
+ */
+describe("gateway-pre-start puts the rule where the harness loads it", () => {
+  const RULE = "## System actions on this ClawBox";
+  let agents: string;
+
+  beforeEach(() => {
+    agents = path.join(workspace, "AGENTS.md");
+    writeFileSync(guide, readFileSync(TEMPLATE, "utf-8"));
+  });
+
+  it("appends the rule to an AGENTS.md that already carries the old pointer", () => {
+    // The field-box shape, measured: the pointer sentence is there, so the
+    // pointer's own guard is satisfied and only a separate marker can deliver.
+    const existing = "# AGENTS\n\nBe helpful.\n\n## ClawBox integration\n\nSee `CLAWBOX.md` for device-specific conventions: where user-installed skills live.\n";
+    writeFileSync(agents, existing);
+
+    const { stdout } = run();
+
+    expect(stdout).toContain("Appended the system-actions rule to AGENTS.md");
+    const after = readFileSync(agents, "utf-8");
+    expect(after.startsWith(existing)).toBe(true);
+    expect(after).toContain(RULE);
+    expect(after).toContain("operator_approval");
+    expect(after).toContain("system_power");
+    // The gateway restart and the device restart must not be conflated: one is
+    // refused, the other is the agent's own tool.
+    expect(after).toMatch(/gateway is not yours|not yours to do/i);
+  });
+
+  it("appends the rule once, however many times the gateway starts", () => {
+    writeFileSync(agents, "# AGENTS\n");
+
+    run();
+    const afterFirst = readFileSync(agents, "utf-8");
+    const second = run();
+
+    expect(second.stdout).not.toContain("Appended the system-actions rule");
+    expect(readFileSync(agents, "utf-8")).toBe(afterFirst);
+    expect(afterFirst.split(RULE)).toHaveLength(2);
+  });
+
+  it("writes no AGENTS.md of its own when the workspace has none", () => {
+    // Creating one would fight whatever the harness does on a fresh workspace.
+    const { stdout } = run();
+
+    expect(stdout).not.toContain("AGENTS.md");
+    expect(() => readFileSync(agents, "utf-8")).toThrow();
+  });
+
+  it("names system actions in the pointer it appends to a fresh AGENTS.md", () => {
+    writeFileSync(agents, "# AGENTS\n");
+
+    run();
+
+    const after = readFileSync(agents, "utf-8");
+    // Both halves land: the pointer for the long form, the rule for the model.
+    expect(after).toContain("CLAWBOX.md");
+    expect(after).toMatch(/system actions are the owner/i);
+    expect(after).toContain(RULE);
+  });
+
+  it.skipIf(process.getuid?.() === 0)("does not stop the gateway when AGENTS.md cannot be written", () => {
+    writeFileSync(agents, "# AGENTS\n");
+    chmodSync(agents, 0o444);
+
+    // `run` throws on a non-zero exit, so reaching the assertion is the proof.
+    const { stderr } = run();
+
+    expect(stderr).toContain("could not append the system-actions rule");
+    expect(readFileSync(agents, "utf-8")).toBe("# AGENTS\n");
+  });
+});

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -117,19 +117,35 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     expect(res.stderr).toContain("could not seed CLAWBOX.md");
   });
 
-  it("starts no statement in the seeding block with a bare copy, whatever the uid", () => {
+  it("leaves no write in the seeding block unguarded, whatever the uid", () => {
     // The case above needs a `skipIf`: root bypasses directory mode bits, and no
     // permission trick is uid-independent here — GNU `install` unlinks and
     // recreates its destination, so a read-only or dangling destination does not
-    // fail either. This one is structural, so it still holds in a root container:
-    // a write that opens a statement runs with `set -e` armed, and its failure is
-    // the whole unit's failure. Inside an `if`, `set -e` is suspended.
-    const bareWrites = seedingBlock()
+    // fail either. This one is structural, so it still holds in a root container,
+    // where both `skipIf` cases skip and nothing else covers the appends.
+    //
+    // A write that OPENS a statement runs with `set -e` armed, and its failure is
+    // the whole unit's failure. Both sanctioned forms put the write in a
+    // condition instead — `if printf … >> f; then` or `elif { …; } >> f; then` —
+    // where `set -e` is suspended and an else branch can warn. `… || true` is
+    // deliberately NOT sanctioned here: it keeps the boot alive but lets the
+    // success line print over a write that failed, which is the false-success
+    // class this block exists to avoid.
+    const lines = seedingBlock()
       .split("\n")
       .map((line) => line.trim())
-      .filter((line) => /^(install|cp|mv|tee)\b/.test(line));
+      .filter((line) => line && !line.startsWith("#"));
+    // Every line that writes: a copy verb, or an append redirection.
+    const writes = lines.filter((line) => /^(if |elif )?(install|cp|mv|tee)\b/.test(line) || />>/.test(line));
+    // Guarded means the write sits in a condition — the line opens with
+    // `if`/`elif`, or it closes a brace group the condition consumes
+    // (`…; } >> file; then`). Anything else runs with `set -e` armed.
+    const unguarded = writes.filter((line) => !/^(if|elif)\b/.test(line) && !/;\s*then$/.test(line));
 
-    expect(bareWrites).toEqual([]);
+    // Sanity: the filter has to be finding this block's four writes (the seed
+    // and the three appends), or an empty `unguarded` would prove nothing.
+    expect(writes.length).toBeGreaterThanOrEqual(4);
+    expect(unguarded).toEqual([]);
   });
 
   it("appends the system-actions section to a guide written before it existed", () => {
@@ -289,6 +305,18 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     // The gateway restart and the device restart must not be conflated: one is
     // refused, the other is the agent's own tool.
     expect(after).toMatch(/gateway is not yours|not yours to do/i);
+
+    // THIS text is the copy that reaches the model — AGENTS.md is what the
+    // harness injects; CLAWBOX.md is read only if the agent opens it. So the
+    // screens it names are pinned here as hard as they are in the guide's own
+    // test, and for a stronger reason. Without these, the rule could be
+    // regressed back to "Settings -> AI" and "Their own control is
+    // Settings -> System" with the whole suite still green, and the box would
+    // ship the exact defect this PR exists to remove.
+    expect(after).toMatch(/Settings -> Providers/);
+    expect(after).not.toMatch(/Settings -> AI\b/);
+    expect(after).toMatch(/power menu in the desktop tray/);
+    expect(after).toMatch(/not Settings -> System/);
   });
 
   it("appends the rule once, however many times the gateway starts", () => {
@@ -321,6 +349,24 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     expect(after).toContain("CLAWBOX.md");
     expect(after).toMatch(/system actions are the owner/i);
     expect(after).toContain(RULE);
+  });
+
+  it("still lands the rule when the guide template is missing entirely", () => {
+    // The rule needs no template — it is a printf in the script — and it is the
+    // copy the harness injects. Gating it on the template (the block used to be
+    // wrapped in `[ -f "$CLAWBOX_GUIDE_SRC" ]`) meant a half-finished update or a
+    // renamed template withheld the deliverable with exit 0 and no output at all.
+    writeFileSync(agents, "# AGENTS\n");
+    const root = mkdtempSync(path.join(dir, "empty-root-"));
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    const script = `set -euo pipefail\nCLAWBOX_ROOT=${JSON.stringify(root)}\nCLAWBOX_WORKSPACE=${JSON.stringify(workspace)}\n${seedingBlock()}`;
+    const res = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+
+    expect(res.status).toBe(0);
+    // The missing template is reported rather than passed over in silence...
+    expect(res.stderr).toContain("could not read");
+    // ...and the rule still reaches the file the harness loads.
+    expect(readFileSync(agents, "utf-8")).toContain(RULE);
   });
 
   it("appends the pointer even when the rule already put the literal CLAWBOX.md in the file", () => {

--- a/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
+++ b/src/tests/unit/gateway-pre-start-workspace-guide.test.ts
@@ -54,12 +54,18 @@ let guide: string;
  * `template` overrides the guide the block copies from, for the case where the
  * template no longer carries the section the marker names.
  */
-function run(template = path.join(process.cwd(), "config/clawbox-workspace-guide.md")): { stdout: string; stderr: string } {
+function runRaw(template = TEMPLATE): { status: number | null; stdout: string; stderr: string } {
   const root = mkdtempSync(path.join(dir, "root-"));
   mkdirSync(path.join(root, "config"), { recursive: true });
   writeFileSync(path.join(root, "config/clawbox-workspace-guide.md"), readFileSync(template, "utf-8"));
   const script = `set -euo pipefail\nCLAWBOX_ROOT=${JSON.stringify(root)}\nCLAWBOX_WORKSPACE=${JSON.stringify(workspace)}\n${seedingBlock()}`;
   const res = spawnSync("bash", ["-c", script], { encoding: "utf-8" });
+  return { status: res.status, stdout: res.stdout, stderr: res.stderr };
+}
+
+/** The same run, asserting the exit code the systemd unit demands. */
+function run(template = TEMPLATE): { stdout: string; stderr: string } {
+  const res = runRaw(template);
   if (res.status !== 0) {
     throw new Error(`pre-start block exited ${res.status}\n${res.stdout}\n${res.stderr}`);
   }
@@ -72,7 +78,16 @@ beforeEach(() => {
   mkdirSync(workspace, { recursive: true });
   guide = path.join(workspace, "CLAWBOX.md");
 });
-afterEach(() => rmSync(dir, { recursive: true, force: true }));
+afterEach(() => {
+  // A test that made the workspace unwritable has to hand it back, or the
+  // recursive remove below fails and every later test inherits the leftovers.
+  try {
+    chmodSync(workspace, 0o755);
+  } catch {
+    /* the test may have removed it */
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
 
 describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
   it("seeds the whole template when the workspace has no guide", () => {
@@ -80,6 +95,41 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
 
     expect(stdout).toContain("Seeded CLAWBOX.md");
     expect(readFileSync(guide, "utf-8")).toBe(readFileSync(TEMPLATE, "utf-8"));
+  });
+
+  // The seed is the FIRST-BOOT and post-factory-reset path, and its write was
+  // the one left bare in the block. `config/clawbox-gateway.service:20` is
+  // `ExecStartPre=...gateway-pre-start.sh` with no leading `-`, so a non-zero
+  // exit here fails the unit; with Restart=always, RestartSec=5 and
+  // StartLimitBurst=20 / StartLimitIntervalSec=3600 it burns twenty starts in
+  // ~100 s and then sits failed for the rest of the hour. The gateway is down —
+  // over an advisory text file.
+  it.skipIf(process.getuid?.() === 0)("warns and lets the gateway start when the workspace cannot be seeded", () => {
+    // A full rootfs (ENOSPC on a Jetson eMMC), a filesystem remounted read-only
+    // after errors, or the documented "delete CLAWBOX.md to re-seed" path on
+    // such a box all arrive here: no guide yet, and the write fails.
+    chmodSync(workspace, 0o555);
+
+    const res = runRaw();
+
+    expect(res.status).toBe(0);
+    expect(res.stdout).not.toContain("Seeded CLAWBOX.md");
+    expect(res.stderr).toContain("could not seed CLAWBOX.md");
+  });
+
+  it("starts no statement in the seeding block with a bare copy, whatever the uid", () => {
+    // The case above needs a `skipIf`: root bypasses directory mode bits, and no
+    // permission trick is uid-independent here — GNU `install` unlinks and
+    // recreates its destination, so a read-only or dangling destination does not
+    // fail either. This one is structural, so it still holds in a root container:
+    // a write that opens a statement runs with `set -e` armed, and its failure is
+    // the whole unit's failure. Inside an `if`, `set -e` is suspended.
+    const bareWrites = seedingBlock()
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => /^(install|cp|mv|tee)\b/.test(line));
+
+    expect(bareWrites).toEqual([]);
   });
 
   it("appends the system-actions section to a guide written before it existed", () => {
@@ -125,6 +175,10 @@ describe("gateway-pre-start seeds and tops up CLAWBOX.md", () => {
     // The template's next heading must not have been dragged along.
     expect(appended).not.toContain("## Coding agent");
     expect(appended).not.toContain("## Remember the user's name");
+    // Nor the `---` rule that closes the section in the template: the append
+    // supplies its own leading separator, so carrying that one too ends the
+    // topped-up guide on a dangling horizontal rule.
+    expect(appended.trimEnd().endsWith("---")).toBe(false);
   });
 
   it("warns instead of appending an empty section when the template loses the heading", () => {
@@ -267,6 +321,27 @@ describe("gateway-pre-start puts the rule where the harness loads it", () => {
     expect(after).toContain("CLAWBOX.md");
     expect(after).toMatch(/system actions are the owner/i);
     expect(after).toContain(RULE);
+  });
+
+  it("appends the pointer even when the rule already put the literal CLAWBOX.md in the file", () => {
+    // The rule's own body ends "`CLAWBOX.md` has the long form", so a pointer
+    // guarded on that bare literal is satisfied by the rule text. Both blocks
+    // land today only because the pointer happens to be written first in the
+    // script: any reorder, or moving the rule into a helper that runs earlier,
+    // silently costs a fresh box its `## ClawBox integration` pointer forever —
+    // both markers "satisfied", no warning, suite still green. The guard is on
+    // the pointer's own heading instead, which nothing else writes.
+    const ruleAlreadyThere = `# AGENTS\n\nBe helpful.\n\n${RULE}\n\nNever queue an \`operator_approval\` proposal. \`CLAWBOX.md\` has the long form.\n`;
+    writeFileSync(agents, ruleAlreadyThere);
+
+    const { stdout } = run();
+
+    expect(stdout).toContain("Appended CLAWBOX.md reference to AGENTS.md");
+    const after = readFileSync(agents, "utf-8");
+    expect(after.startsWith(ruleAlreadyThere)).toBe(true);
+    expect(after).toContain("## ClawBox integration");
+    // ...and the rule itself is not appended a second time.
+    expect(after.split(RULE)).toHaveLength(2);
   });
 
   it.skipIf(process.getuid?.() === 0)("does not stop the gateway when AGENTS.md cannot be written", () => {


### PR DESCRIPTION
**TASK-612 (decision D-08)** — "Restart the gateway" from chat, answered instead of queued.

## Symptom

Asked in chat to restart the gateway, the OpenClaw agent queued an operator-approval proposal and told the owner the restart was waiting for their approval. ClawBox renders no approval card anywhere, so the proposal was shown to nobody: it waited until the run ended, or until the very restart it asked for cancelled it (`operator_approval_cancelled_gateway_restart`). The chat even connects with the `operator.approvals` scope (`ChatApp.tsx`, `ChatPopup.tsx`, `clientId: openclaw-control-ui`), so the gateway happily routes an `approval.request` to a client that handles none — which is exactly why it parks.

## What the guide now says, and why the first draft of it was wrong

The agent was right about the mechanism and wrong about this device, so the fix is an instruction. The first draft of that instruction said *"you have no tool for any of them"* — which is false and would have been worse than the bug: `mcp/tools/system.ts` registers **`system_power`** (restart/shutdown, `confirm: true`, `reason`) on **both** editions, `config/clawbox-sudoers` grants `NOPASSWD: systemctl restart clawbox-gateway.service`, and `Clawbox.md` (the Field Guide the orientation tool loads on both editions) documents `system_power` as reboot/shutdown. A guide that contradicts the Field Guide in the same context window makes behaviour less deterministic, not more. It also sent the owner to Settings → System for a restart; that tab is the harness picker, the performance mode, read-only stats and the password — **no power control at all** (`SettingsApp.tsx`).

So the section, corrected:

- a **gateway** restart is not the agent's to do from a chat turn — the gateway hosts the session, so the restart kills the reply before it lands — and it is rarely needed, because a setting that requires one restarts it on save (Settings → Providers, Voice, Channels);
- a **device** restart or shutdown **is** the agent's, via `system_power` with `confirm: true`, when the owner asked in their own words; the owner's own control is the **tray power menu**; Settings → About holds the update, and the device name is the Local URL card under Settings → Network (round 2 corrected this — see H1 below);
- an `operator_approval` proposal must **never** be queued — and a parked one is answered with `openclaw approvals pending` / `openclaw approvals resolve <id> allow-once|allow-always|deny` from the Terminal app, which is a truer and more useful sentence than "there is nowhere to approve it".

## Native mechanism (harness-first) — and where it decided the design

Operator approvals are OpenClaw's, entirely; this PR builds no part of them. Verified in the pinned core (2026.8.1 per `config/openclaw-target.txt`, read-only on the box): `approval.request` / `approval.get` / `approval.resolve` / `approval.history` behind the `operator.approvals` scope, the `openclaw approvals` CLI, `openclaw exec-policy` for approval policy, and `approvals.exec.*` / `approvals.plugin.*` in config. Rendering a pending approval as an approve/deny card on that RPC is **TASK-704** under TASK-604, post-v4; that task names this paragraph as the thing to revise when it lands. A policy-level answer (`openclaw exec-policy set --ask …`) was considered and not taken here: `exec-policy` governs *exec* approvals, and it is not established that the TASK-612 proposal was one — that is TASK-704's question, not a one-liner.

The harness also decided **where the rule lives**. OpenClaw's workspace file map (`docs/concepts/agent-workspace.md`, read from the installed package) injects `AGENTS.md`, `SOUL.md`, `USER.md`, `IDENTITY.md`, `BOOT.md`, `BOOTSTRAP.md` and `memory/` at the start of every session, and describes `AGENTS.md` as *"operating instructions … good place for rules"*. **`CLAWBOX.md` is not in that set** — it is read only if the agent chooses to open it, prompted by one pointer sentence. Shipping a behavioural prohibition only there would have been green tests over a rule the model may never load.

So the rule itself is appended to **`AGENTS.md`**, under a marker of its own — deliberately not the existing `"CLAWBOX.md"` marker, which is already present on every box in the field (verified: the dev box's `AGENTS.md` still carries the original pointer sentence) and can therefore never deliver anything again. `CLAWBOX.md` keeps the long form.

## The delivery half

`gateway-pre-start.sh` seeds `CLAWBOX.md` **if missing**, deliberately, so an owner's or the agent's edits are never clobbered. The cost had never been measured: the dev box's `CLAWBOX.md` is dated **Aug 13 with five headings** and has therefore never received `## Coding agent` either — a whole section about `coding_agent_run` that no field box has. An existing guide is now topped up with the one missing section: appended, never overwritten, keyed on its heading so a second start appends nothing, with the text lifted from the template by awk so there is one source. Generalising that to every missing section is a policy call (an owner may have deleted a section on purpose) and is filed as **TASK-706** with the measurement.

All three appends are failure-tolerant with an honest warning, because pre-start runs under `set -euo pipefail` and these files are advisory. That included fixing a pre-existing hazard my own test caught: the `AGENTS.md` pointer append has always been bare, so a read-only `AGENTS.md` aborted pre-start and **left the gateway down over a pointer sentence**.

## RED → GREEN

RED, guide content, on unmodified `origin/beta`:

```
FAIL src/tests/unit/clawbox-workspace-guide.test.ts (4 tests | 4 failed)
  × carries a section on system actions and restarts
      AssertionError: expected '' to match /^## .*System actions/
  × separates the gateway restart it refuses from the device restart it owns
      AssertionError: expected '' to contain 'gateway'
  × names controls that exist: the tray power menu, and Settings -> System for what is there
      AssertionError: expected '' to match /power menu/i
  × forbids queueing an operator-approval proposal, and names the way to answer a parked one
      AssertionError: expected '' to contain 'operator_approval'
```

RED, delivery — beta's `gateway-pre-start.sh` against the NEW template, i.e. exactly what a guide-only fix would have shipped (11 of 14 fail):

```
FAIL src/tests/unit/gateway-pre-start-workspace-guide.test.ts (14 tests | 11 failed)
  × appends the system-actions section to a guide written before it existed
      AssertionError: expected '' to contain 'Appended the system-actions section'
  × appends once, however many times the gateway starts
      AssertionError: expected [ Array(1) ] to have a length of 2 but got 1
  × takes only that section, not the ones that follow it in the template
  × warns instead of appending an empty section when the template loses the heading
  × warns and lets the gateway start when the guide cannot be written
      AssertionError: expected '' to contain 'could not append'
  × keeps the appended section as its own heading when the guide has no trailing newline
  × appends the section at the end, after whatever the owner already had
  × appends the rule to an AGENTS.md that already carries the old pointer
      AssertionError: expected '' to contain 'Appended the system-actions rule to AGENTS.md'
  × appends the rule once, however many times the gateway starts
  × names system actions in the pointer it appends to a fresh AGENTS.md
  × does not stop the gateway when AGENTS.md cannot be written
```

(The pre-start tests bound the shipped block with an `# --- end guide seeding ---` sentinel so they cannot execute whatever is appended to the script next; beta's copy was given that comment line, and nothing else, to run them against it.)

GREEN on this branch: both files 18/18, full suite 663 files / 9592 tests. `tsc --noEmit` clean, eslint clean on the new files. Two other full-suite runs on this same head each showed a *different* component-test flake under parallel load (`app-store-errors` → `obs.observe is not a function`; `chat-spoken-reply` → a 6.2 s timeout); both pass in isolation, both are pre-existing, and this diff contains no component or runtime TypeScript at all.

## Siblings

- `gateway-pre-start.sh` is the only writer of `CLAWBOX.md` in the repo; `install.sh` does not touch it.
- The `AGENTS.md` pointer sentence now names system actions as a topic, so a box that has not yet been given the pointer gets an accurate one.
- `Clawbox.md` (Field Guide) and `mcp/README.md` describe `system_power` as reboot/shutdown; after the correction above the three agent-facing sources agree, so neither needed an edit.
- **No Hermes leg.** `scripts/setup-hermes-edition.sh` stops, disables, removes and masks `clawbox-gateway.service`, so `gateway-pre-start.sh` never runs and neither file is written on the Hermes SKU; and the Hermes chat path auto-answers approvals (`hermes-dashboard-turn.ts`, `APPROVAL_CHOICE = "once"`), so a parked proposal cannot reproduce there. On the dual SKU the OpenClaw gateway unit is not masked, so this seeds normally and applies to the OpenClaw agent — correct as-is.

## Review

One Opus review pass: 3 high, 4 medium, 8 low. All three high findings were real and are fixed above (the false "no tool" claim, the wrong Settings path, and the rule shipping in a file the harness never injects); the low findings on the shell block (awk terminated on `---` rather than the next heading, an I/O failure misreported as a renamed heading, a missing trailing-newline guard producing a setext heading, a `2>/dev/null` that suppressed nothing, a root-invisible test skip, an unbounded block slice) are all applied. Two medium findings are filed rather than folded in: generalising the top-up (**TASK-706**) and the approvals card (**TASK-704**).

## Follow-ups filed

- **TASK-704** — render `operator_approvals` as an approve/deny chat card on the native approvals RPC (post-v4).
- **TASK-706** — `CLAWBOX.md` is frozen at the sections a box was seeded with; the `## Coding agent` section has never reached a field box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added guidance for safe system restarts, supported device power actions, and restrictions on restarting the gateway from chat.
  - Clarified system settings locations and how to resolve parked approval requests through the Terminal app.
  - Added guidance prohibiting approval proposals from chat when no approval card is available.

- **Reliability**
  - Workspace guidance updates now preserve existing content and avoid interrupting startup when optional files cannot be read or written.
  - Repeated setup runs avoid duplicating guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Round 2 — the Opus final review BLOCKED `5017bc85`; this is the response

Two HIGH findings, one MEDIUM, and the LOWs. Commit `d1d74fca`.

### H1 (blocking) — the guide named the wrong Settings screen for the device name

`config/clawbox-workspace-guide.md` said *"the update and the hostname (which reboots on save) are
under Settings → About."* Half of that was false, and it is the identical wrong-screen defect this
section exists to remove — one clause later, shipping to every box through the top-up.

Measured at this head:

- The **editable** device name is the `{/* Local URL (mDNS hostname) card */}` at
  `SettingsApp.tsx:3425`, inside `{activeSection === "wifi" && (` (`:3241–3631`). That nav entry is
  `{ id: "wifi", icon: "wifi", labelKey: "settings.network" }` (`:255`), and
  `"settings.network": "Network"` (`src/lib/translations.ts:302`). The owner sees
  **Settings → Network**. Saving it POSTs `/setup-api/system/power` (`:1090`) — hence "reboots".
- **Settings → About** (`{activeSection === "about" && (`, `:5638`) holds the version card, the
  docs/support/Discord links, the Beta toggle, the System Update tile (`:5746–5759`) and Factory
  reset. Grepping `:5638–5800` for `hostname|rename|deviceName|Local URL` returns **nothing**.

Now: *"The update is under Settings → About. The device name is the Local URL card under
Settings → Network, and saving it reboots the box."* Pinned by a new test that fails if any clause
naming the device name stops naming Network or starts naming About.

### H2 (blocking, boot path) — the seed write was the one still bare under `set -euo pipefail`

`scripts/gateway-pre-start.sh` — the PR guarded the two appends and the pre-existing bare pointer
append, but `install -m 644` (the CLAWBOX.md seed) was still bare.
`config/clawbox-gateway.service:20` is `ExecStartPre=…/gateway-pre-start.sh` with **no leading `-`**,
so a non-zero exit fails the unit; with `Restart=always`, `RestartSec=5`,
`StartLimitBurst=20` / `StartLimitIntervalSec=3600` it burns twenty starts in ~100 s and then sits
failed for the rest of the hour. **The gateway is down over an advisory text file** — and the seed is
exactly the first-boot and post-factory-reset path. Reachable on a full rootfs (ENOSPC on a Jetson
eMMC), a filesystem remounted read-only after errors, an unreadable template, or the documented
"delete CLAWBOX.md to re-seed" step on such a box.

Guarded like the appends: warn on stderr, boot continues.

The template test also moves from `-f` to `-r` — `-f` waves an existing-but-unreadable template
through into a write that then fails. It is placed **inside** the CLAWBOX.md chain rather than in the
enclosing condition on purpose: the AGENTS.md rule below needs no template at all, and gating the
delivery leg of this fix on a file it does not read would have been a worse coupling than the one
being removed.

And the block comment that asserted an invariant which did not hold ("Both halves below can fail
without the gateway caring") is replaced by one that is true for **every** write in the block, stated
where it applies to all of them. It also carried a stale sentence about a `|| true` that no longer
exists in the code, and another claiming the awk "prints … to the `---` that closes the section",
which the previous round had already stopped being true. Both are gone.

### M1 — the pointer/rule ordering was load-bearing and silently coupled

The rule's body ends `` `CLAWBOX.md` has the long form. ``, so it satisfies the pointer block's
`! grep -qF "CLAWBOX.md"` guard. Both blocks landed only because the pointer is written first in the
file; any reorder — or moving the rule into a helper that ran earlier — would have cost every fresh
box its `## ClawBox integration` pointer forever, with both markers "satisfied", no warning, and the
suite still green.

Decoupled rather than documented: the guard is now `grep -qF "## ClawBox integration"`, hoisted into
`CLAWBOX_AGENTS_POINTER` so the literal has one source. This cannot double-append on a field box —
`git log -S'## ClawBox integration' -- scripts/gateway-pre-start.sh` returns exactly one commit
(`1f55a391`, where the pointer was introduced), so the heading every box carries is byte-identical to
the one being grepped. Pinned by a test that seeds an `AGENTS.md` carrying the rule (and therefore
the literal `CLAWBOX.md`) but not the heading, and requires the pointer to land anyway.

### M2 — `## Coding agent` backfill is **TASK-706**, not this PR

Only the new `## System actions and restarts` section is backfilled onto the Aug-13 `CLAWBOX.md` that
field boxes carry. That file is also missing `## Coding agent (delegate a whole task)` from the
shipped template, so the agent on those boxes still will not learn that `coding_agent_run` exists.
Generalising the top-up to every missing heading is a policy call (an owner may have deleted a
section deliberately) and is filed with its measurement as **TASK-706**. Not in scope here; the
AGENTS.md leg means TASK-612's rule lands regardless of CLAWBOX.md drift.

### LOW findings — applied or refuted

| # | Finding | Outcome |
|---|---|---|
| L1 | "Settings → AI" names a tab labelled "Providers" | **Applied.** `{ id: "ai", … labelKey: "settings.providers" }` (`SettingsApp.tsx:245`), `"settings.providers": "Providers"` (`src/lib/desktop-translations.ts:411`). Guide and the AGENTS.md rule now say **Settings → Providers**; Voice and Channels were already right. Pinned by a test. |
| L2 | A short write could leave a truncated section the marker then declares complete | **Refuted in round 2, then escalated by the round-3 pass with a working reproduction — now deferred and filed as TASK-707.** See "Deferred, with reasons" below. |
| L3 | The topped-up guide ended on a dangling `---` | **Applied.** The awk now drops trailing blank lines and a trailing rule (CR-tolerant, so a CRLF template is handled too). Verified: the file now ends `…leaving them waiting.` Pinned by a test. |
| L4 | Stale docstring teaching the reversed instruction | **Applied.** The docstring and the test title no longer name Settings → System as the owner's path. Also corrects the follow-up id to **TASK-704** (under TASK-604), per CodeRabbit's thread. |
| L5 | `awk -v heading=…` interprets escapes in the value | **Applied.** The heading is passed through the environment and read via `ENVIRON["heading"]`. |
| L6 | Nothing exercises a genuinely older CLAWBOX.md | **Acknowledged, not fixed.** A checked-in fixture would have to be copied off a field box; this PR touches no device, and the box's file is not in the repo. It is the same gap M2/TASK-706 records, and TASK-706 is where the real file gets captured. |

### Sibling call sites

- **Other unguarded writes in `gateway-pre-start.sh`** (the sweep H2 demands): `:2138`
  `mkdir -p "$(dirname "$MCP_TOKEN_FILE")"` and `:2149` `chmod 600 "$MCP_TOKEN_FILE"` are bare, and
  **deliberately left bare**. That file is the sole `/setup-api/*` bearer credential: a gateway that
  starts with a missing or world-readable bearer is worse than one that does not start, so failing
  the unit is the correct outcome there. The two `mkdir` calls at `:2119` and `:2312` are already
  `2>/dev/null || true`. No other write in the script opens a statement.
- **Other `ExecStartPre=`**: only `clawbox-gateway.service:20` lacks a leading `-`;
  `clawbox-hermes-dashboard.service` uses `ExecStartPre=-` on both of its hooks, so H2's failure mode
  is unique to this unit.
- **Other "Settings → About" references**: `scripts/force-update.sh:86` and `SystemUpdateApp.tsx:287`
  both name About for the **update**, which is correct. Nothing else sends anyone to About for a
  device name.
- **Out-of-scope finding, filed not fixed**: `mcp/README.md:140` ("one click in Settings → AI"),
  `src/lib/coding-agent.ts:1252`, `src/lib/coding-agent-mcp-refresh.ts:75`,
  `src/lib/hermes-clawai.ts:134` and `e2e/helpers/clawbox.ts:599` all say "Settings → AI Models" /
  "Settings → AI" in owner-facing text, and `src/tests/unit/mcp-tool-honesty.test.ts:767` pins
  "Settings -> AI Providers". Same class as L1, in files this PR does not own — flagged here rather
  than folded into the diff.

### RED → GREEN (round 2)

RED, at `5017bc85` with the new tests added and nothing else changed:

```
 ❯ src/tests/unit/clawbox-workspace-guide.test.ts (6 tests | 2 failed)
     × names the screen each control is actually on, not the one next to it
         AssertionError: expected '## System actions and restarts…' to match /Settings\s*→\s*Network/
     × names the restart-on-save tabs by their labels
         AssertionError: expected '## System actions and restarts…' to match /Settings\s*→\s*Providers/
 ❯ src/tests/unit/gateway-pre-start-workspace-guide.test.ts (17 tests | 4 failed)
     × warns and lets the gateway start when the workspace cannot be seeded
         AssertionError: expected 1 to be +0   ← the block exits 1; the unit fails
     × starts no statement in the seeding block with a bare copy, whatever the uid
         AssertionError: expected [ Array(1) ] to deeply equal []
     × takes only that section, not the ones that follow it in the template
         AssertionError: expected true to be false   ← trailing `---`
     × appends the pointer even when the rule already put the literal CLAWBOX.md in the file
         AssertionError: expected '' to contain 'Appended CLAWBOX.md reference to AGEN…'

 Test Files  2 failed (2)
      Tests  6 failed | 17 passed (23)
```

The H2 case reproduced directly out of the shipped `.sh` (block extracted between its sentinels and
run under `set -euo pipefail`), workspace `0555`, `CLAWBOX.md` absent — before and after:

```
=== PRE-FIX (5017bc85) ===
install: cannot create regular file '…/workspace/CLAWBOX.md': Permission denied
[exit=1]                  ← ExecStartPre fails; the unit fails; StartLimitBurst burns

=== POST-FIX (d1d74fca), identical conditions ===
install: cannot create regular file '…/workspace/CLAWBOX.md': Permission denied
  WARNING: could not seed CLAWBOX.md in the OpenClaw workspace
[exit=0]                  ← install's own cause is kept on stderr; the gateway starts
```

GREEN, at the final head:

```
 Test Files  2 passed (2)
      Tests  24 passed (24)          ← 0 skipped; the mode-based cases run as non-root
```

Neighbouring suites (all 15 `gateway-pre-start-*`, the guide test, plus `hermes-shell-scan`,
`system-profile-scripts`, `skill-install-no-restart`):

```
 Test Files  18 passed (18)
      Tests  310 passed (310)
```

Whole unit project after the rebase: **547 files, 8630 tests, all passing**.
`npx tsc --noEmit` exits 0. `bash -n scripts/gateway-pre-start.sh` clean.

The rewritten awk was exercised against **mawk 1.3.4**, the same implementation the box uses
(`/usr/bin/awk → /etc/alternatives/awk → mawk` on Ubuntu): CRLF template (one heading, next section
not dragged in, trailing `---\r` trimmed), a workspace path with spaces and non-ASCII (all three
writes land, both markers exactly once), a renamed heading (warns, appends nothing), and idempotence
over repeated runs.

### Three bug classes, self-checked on this diff

- *Probe-once*: none introduced — `-r`, `-f` and both `grep -qF` guards are evaluated on every
  gateway start, nothing is cached across the process lifetime.
- *False success*: the seed now prints "Seeded CLAWBOX.md" only inside the `then` branch of the
  `install` it describes; no `|| true` was added, and the extraction still captures awk's exit status
  rather than its output alone. The trim cannot empty a found section (the heading line is never
  blank and never `---`), so the "heading renamed" warning still means what it says.
- *False failure*: the new warnings fire only on a genuinely non-zero write or an unreadable
  template; `install` does not return non-zero after writing.

## Device leg

**Unproven on hardware.** Every proof above is a temp-dir reproduction against the shipped `.sh`, a
static read of the source, or a mawk run on the dev PC. **Nothing has run on a box**, and this PR
touches no device. Verbatim, the five items the review names:

1. The block executing inside the **real 2424-line `gateway-pre-start.sh`** under the real systemd
   unit — the tests run a 7 KB slice in a stub shell with only `CLAWBOX_ROOT` and `CLAWBOX_WORKSPACE`
   set. An `ExecStartPre` exit code on a box has not been observed.
2. The append landing on the box's **actual** `~/.openclaw/workspace/AGENTS.md` and `CLAWBOX.md`
   (owner, mode, the real drift), and the gateway coming back up after it.
3. That OpenClaw **re-reads** the grown `AGENTS.md` into the next session — the file map says it
   does; that has not been observed live at this head.
4. That the behaviour actually changes: re-running the TASK-612 prompt ("restart the gateway") on the
   box and seeing the owner's path in the answer instead of a parked `operator_approval`. That is the
   only test of the deliverable.
5. A workspace resolved from a non-default `agents.defaults.workspace`
   (`gateway-pre-start.sh:2288–2303`).

After merge: deploy beta head to the box, restart the gateway once, diff `AGENTS.md` and `CLAWBOX.md`
before/after, and re-run the incident prompt.

---

## Round 3 — a second Opus pass on the round-2 head: `APPROVE-WITH-NITS`

0 High, 4 Medium, 5 Low. It re-verified both round-2 blockers by execution (not by reading),
confirmed the diff is exactly the 4 intended files, and confirmed none of the new assertions is
vacuous — all six fail on `5017bc85`. Three of its findings were against my own round-2 work and are
applied here.

### M1 (applied) — the copy that actually reaches the model had no test

The rule in `AGENTS.md` is the delivery path; `CLAWBOX.md` is the long form the agent may never open.
The guide's text was pinned hard, and the `printf` body that writes `AGENTS.md` was pinned only by its
heading. Demonstrated: regressing that body back to `Settings -> AI` and *"Their own control is
Settings -> System"* left **all 23 tests green**. Had round 2 fixed only the `.md`, CI would have been
green and the box would still have shipped the round-1 defect — false success in the test layer.

The screens the rule names are now asserted on the appended `AGENTS.md` itself. Confirmed by mutation:
that exact regression now fails.

### M3 (applied) — a *missing* template silently withheld the rule

The `-r` move put readability inside the chain so the AGENTS.md rule survives an **unreadable**
template. But the block was still wrapped in `[ -f "$CLAWBOX_GUIDE_SRC" ]`, so an **absent** template
skipped everything with exit 0 and **no output at all** — while the new comment claimed the rule needs
no template. The same shape as the round-1 H2 comment: an invariant that was three-quarters true, and
the quarter that failed silently withheld the deliverable.

Fixed in one line rather than by narrowing the claim: the enclosing test is now
`[ -d "$CLAWBOX_WORKSPACE" ]`, and the `-r` check inside the chain covers missing and unreadable
alike — so the fault is *reported* instead of passed over, and the rule still lands. Pinned by a test.

### M4 (applied — a finding against an edit I had not yet committed)

I had loosened the structural guard test to exempt `… || true`. That was wrong: it would admit

```bash
install -m 644 "$CLAWBOX_GUIDE_SRC" "$CLAWBOX_GUIDE_DST" || true
echo "  Seeded CLAWBOX.md in OpenClaw workspace"
```

— which boots fine and prints the success line over a failed seed. That is the false-success class
this block exists to remove, and strictly worse than the bug the test was written to catch. The
exemption is dropped; the mutation above now fails the suite.

### L1 (applied) — the guard test covered only copy verbs

The three `printf … >> file` appends were invisible to it, and on root (where both mode-based cases
skip) nothing covered them. The filter now counts every write — copy verbs and append redirections —
and requires each to sit in a condition (`if …` / `elif …` / `…; } >> f; then`). It also asserts it
found at least the block's four writes, so an empty result cannot pass vacuously. Verified by
re-baring the pointer append: caught.

### L2 (applied in part, refuted in part)

The **awk** bound was a prefix test, so a future `## System actions and restarts (advanced)` would
have opened the extraction and never closed it, swallowing every following section. It now matches the
heading as a whole line (CR-tolerant). Reproduced before and after: that heading now warns
*"the shipped guide no longer carries …"* and appends nothing, instead of silently swallowing the file.

The **`grep -qF`** destination markers are deliberately left as substring tests. Making them
whole-line (`-qxF`) would re-append the whole section on every boot for any owner who saved
`CLAWBOX.md` or `AGENTS.md` with CRLF line endings — trading a theoretical false negative for a
repeating real one.

### Deferred, with reasons

- **M2 / round-1 L2 — a partial write permanently truncates the section (filed as TASK-707).**
  The round-3 pass produced a faithful ENOSPC-shaped reproduction that defeats my round-2 refutation:
  the heading is written first, so a fragment satisfies the `grep -qF` marker, every later boot appends
  nothing, and the file stays cut mid-sentence — losing precisely the *"Never queue an
  `operator_approval`"* paragraph. Boot safety holds (exit 0, warned once at boot), but the loss is
  permanent and silent thereafter. **Not fixed here on purpose:** every candidate (atomic
  temp-file+rename, or a size-rollback on the failure branch) adds new logic to the one script whose
  failure takes the gateway down, and **this PR has no device leg** to validate a boot-path
  restructure. Shipping that unvalidated is a worse risk than the ENOSPC path it closes. Filed with the
  reproduction and both candidate fixes.
- **L5 — `install` replaces a dangling symlinked `CLAWBOX.md`.** Acknowledged, not fixed. GNU `install`
  unlinks and recreates its target, so an owner who symlinked the guide into a not-yet-mounted folder
  loses the link. Very low probability; noted because the comment invites operators to delete the file
  to re-seed.
- **L3 / L4** — round-1 M2 and L6, already recorded above as **TASK-706**.

### One correction to the round-1 review, for the record

Round 1 proposed covering H2 with "an unwritable workspace directory, which fails for root too, so it
needs no `skipIf`". That is not true: **root bypasses directory mode bits**, and GNU `install` unlinks
and recreates its destination, so neither a read-only destination nor a dangling symlink fails for root
either (both were tried — the symlink case printed "Seeded CLAWBOX.md" and exited 0). No
permission-based case here is uid-independent. The `0555` case therefore keeps a `skipIf`, matching the
file's two existing ones, and the root-container hole is closed by the structural test instead. Round 3
confirmed the split and agreed CI runs non-root, so all mode-based cases execute there.
