### PR TITLE
fix: answer a parked Hermes clarify with the customer's next message

### DIFF
--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -291,28 +291,44 @@ else:
 
 # ── The clarify window this appliance ships with. ──────────────────────────
 # When the agent stops to ask the customer a question it parks its own worker
-# thread on `Event.wait(agent.clarify_timeout)`. Hermes' default is 3600
-# seconds, and a value of <= 0 is passed through as None — Python's word for
-# FOREVER. On an appliance that is an hour in which the session cannot be used
-# for anything else because one question went unanswered, and a customer who
-# has walked away from the chat has no idea it is holding.
+# thread on `Event.wait(...)` (tui_gateway/server.py:3513) for the number of
+# seconds hermes resolves from config. Verified read-only on the Hermes box
+# (hermes-agent 0.20.5): tools/clarify_gateway.py:531 `resolve_clarify_timeout`
+# takes the legacy `clarify.timeout` first, then `agent.clarify_timeout`, then
+# 3600; it is coerced with `int()` (:549), and <= 0 is passed through as
+# unlimited — `ev.wait(None)`, which is Python's word for FOREVER. The key is
+# hermes' own, shipped in its defaults table under the `agent:` block
+# (hermes_cli/config_defaults.py:278), and is ABSENT from a ClawBox config.yaml,
+# so a box runs on the 3600 default today.
 #
-# Five minutes is the window a person actually answers a chat question inside.
-# It is a backstop rather than the fix: a message arriving on a parked session
-# is now delivered as the ANSWER (hermes-dashboard-turn.ts), so the timeout
-# only decides how long a session that hears nothing at all stays parked.
+# On an appliance that hour is a session nobody can use for anything else
+# because one question went unanswered — a message typed meanwhile is QUEUED
+# behind the parked worker (server.py:8233 `_handle_busy_submit`) and nothing
+# there releases the Event. Five minutes is the window a person actually
+# answers a chat question inside, and it is hermes' own emergency fallback for
+# this same number (server.py:3578).
 #
-# SEEDED, NOT PINNED: written only when the key is absent, so an owner who has
-# chosen their own window keeps it. Written here, with the rest of this
-# device's rendered Hermes config, because `hermes config set` stores a scalar
-# as a STRING ("storing as string" on stderr) while this is a number upstream
-# reads as one — the same reason the MCP entry above is written in PyYAML.
+# A BACKSTOP, not the fix: a message arriving on a parked session is now
+# delivered as the ANSWER (src/lib/hermes-dashboard-turn.ts), so this only
+# decides how long a session that hears nothing at all stays parked.
+#
+# SEEDED, NOT PINNED: written only when the owner has set neither key, so a
+# window they chose — under either name — is left exactly as it is. Written
+# here, with the rest of this device's rendered Hermes config, because `hermes
+# config set` stores a scalar as a STRING ("storing as string" on stderr) and
+# this is a number; the same reason the MCP entry above is written in PyYAML.
 CLARIFY_TIMEOUT_SECONDS = 300
+legacy_clarify = cfg.get("clarify")
+legacy_timeout_set = isinstance(legacy_clarify, dict) and legacy_clarify.get("timeout") is not None
 agent_cfg = cfg.get("agent")
-if agent_cfg is None:
+if agent_cfg is None and not legacy_timeout_set:
     agent_cfg = {}
     cfg["agent"] = agent_cfg
-if isinstance(agent_cfg, dict):
+if legacy_timeout_set:
+    # The legacy key WINS in hermes' own resolver, so writing ours beside it
+    # would leave the file saying 300 while the box waits the owner's window.
+    print("[register-mcp] clarify.timeout is set; leaving the clarify window to it")
+elif isinstance(agent_cfg, dict):
     if "clarify_timeout" not in agent_cfg:
         agent_cfg["clarify_timeout"] = CLARIFY_TIMEOUT_SECONDS
         changed = True

--- a/scripts/register-mcp.sh
+++ b/scripts/register-mcp.sh
@@ -289,6 +289,42 @@ else:
     print("[register-mcp] WARNING: skills is not a mapping; "
           "leaving the bundled email skills enabled.", file=sys.stderr)
 
+# ── The clarify window this appliance ships with. ──────────────────────────
+# When the agent stops to ask the customer a question it parks its own worker
+# thread on `Event.wait(agent.clarify_timeout)`. Hermes' default is 3600
+# seconds, and a value of <= 0 is passed through as None — Python's word for
+# FOREVER. On an appliance that is an hour in which the session cannot be used
+# for anything else because one question went unanswered, and a customer who
+# has walked away from the chat has no idea it is holding.
+#
+# Five minutes is the window a person actually answers a chat question inside.
+# It is a backstop rather than the fix: a message arriving on a parked session
+# is now delivered as the ANSWER (hermes-dashboard-turn.ts), so the timeout
+# only decides how long a session that hears nothing at all stays parked.
+#
+# SEEDED, NOT PINNED: written only when the key is absent, so an owner who has
+# chosen their own window keeps it. Written here, with the rest of this
+# device's rendered Hermes config, because `hermes config set` stores a scalar
+# as a STRING ("storing as string" on stderr) while this is a number upstream
+# reads as one — the same reason the MCP entry above is written in PyYAML.
+CLARIFY_TIMEOUT_SECONDS = 300
+agent_cfg = cfg.get("agent")
+if agent_cfg is None:
+    agent_cfg = {}
+    cfg["agent"] = agent_cfg
+if isinstance(agent_cfg, dict):
+    if "clarify_timeout" not in agent_cfg:
+        agent_cfg["clarify_timeout"] = CLARIFY_TIMEOUT_SECONDS
+        changed = True
+        print(f"[register-mcp] agent.clarify_timeout set to {CLARIFY_TIMEOUT_SECONDS}s "
+              "— an unanswered question parks the session for that long, not an hour")
+else:
+    # A shape this script does not understand, left alone for the same reason a
+    # non-mapping `skills` key is: repairing it is not this script's call, and
+    # the MCP registration above must still land.
+    print("[register-mcp] WARNING: agent is not a mapping; "
+          "leaving the clarify timeout at hermes' own default.", file=sys.stderr)
+
 if not changed:
     print("[register-mcp] Hermes MCP registration already current, skipping write")
     sys.exit(0)

--- a/src/app/setup-api/hermes/chat/route.ts
+++ b/src/app/setup-api/hermes/chat/route.ts
@@ -698,8 +698,9 @@ function streamTurn(
                 send("clarify", {
                   requestId: activity.requestId,
                   questions: activity.questions,
-                  // Only on a replayed batch, and only when something really is
-                  // already answered — an empty map would read as "nothing
+                  // Only when something really is already answered — a replay
+                  // of a half-filled batch, or the question this turn's own
+                  // message answered. An empty map would read as "nothing
                   // filled in", which is what it means, so it is not sent.
                   ...(activity.answered ? { answered: activity.answered } : {}),
                 });
@@ -785,6 +786,23 @@ function streamTurn(
         // from the LAST user row, which is this turn's question, and returns
         // null unless an assistant answer follows it. A turn that really is
         // still thinking has no such row and still reports the failure.
+        //
+        // ONE EXCEPTION, named rather than hidden: a message delivered as the
+        // answer to a pending clarify (see hermes-dashboard-turn.ts) writes no
+        // user row of its own — that is what answering by `clarify.respond`
+        // means — so on that turn the slice starts at the EARLIER prompt and
+        // can already hold whatever the agent said before it asked its
+        // question. When such a turn goes quiet before the resumed agent has
+        // written anything, this recovery can therefore hand back that earlier
+        // sentence as though it were the reply. It is bounded — the customer
+        // sees the agent's own words, never another session's, and the same
+        // rows are what the settled turn shows when the stream does complete
+        // (which is why `settleTurn` is left alone: on the normal path those
+        // words belong to the answer and are otherwise never stored at all) —
+        // but it is not the guard the paragraph above describes. Telling the
+        // two apart needs a snapshot of the record taken before the answer was
+        // forwarded, which is a change to this route's read pattern rather
+        // than to the transport, and it is deliberately not made here.
         if (isQuietStreamError(err) && !isAbort(err)) {
           const recovered = await readHermesTurn(threaded).catch(() => null);
           if (recovered?.text) {
@@ -1211,6 +1229,16 @@ export async function POST(request: Request) {
   // command, and `prompt.submit` takes its attachments through a separate
   // `image.attach` handshake this route has not been taught. A turn carrying a
   // picture is rare and already slow; correctness first.
+  //
+  // What the CLI path CANNOT do, stated where the choice is made: answer a
+  // question the agent is parked on. `hermes chat -q --resume` starts a second,
+  // independent agent from the session's stored row (`--resume` is a database
+  // read, not a live attach), while the parked prompt is a `threading.Event` in
+  // the gateway process — no CLI subcommand and no HTTP endpoint can reach it,
+  // only the JSON-RPC socket the branch below opens. So a turn that falls to
+  // the CLI while a clarify is outstanding leaves it outstanding; what bounds
+  // that is the `agent.clarify_timeout: 300` this device seeds
+  // (scripts/register-mcp.sh), after which the agent gives up on its own.
   if (wantsStream(request) && imagePaths.length === 0) {
     // The catalogue knows which providers are user-defined; the transport
     // needs that one bit to read the dashboard's provider KIND honestly. Only

--- a/src/lib/chat-clarify.tsx
+++ b/src/lib/chat-clarify.tsx
@@ -222,7 +222,10 @@ export function ClarifyPrompt({ card, onAnswer }: ClarifyPromptProps) {
   );
 
   const isBatch = questions.length > 1;
-  const outstanding = questions.filter((question) => !(question.qid in answered));
+  // `Object.hasOwn` rather than `in` here and at `locked` below: a qid is a
+  // string the model chose, and every object answers to `toString` and
+  // `constructor`. A question named either would render as already answered.
+  const outstanding = questions.filter((question) => !Object.hasOwn(answered, question.qid));
 
   /**
    * Send every question that is still open, in one gesture.
@@ -280,7 +283,7 @@ export function ClarifyPrompt({ card, onAnswer }: ClarifyPromptProps) {
       {questions.map((question, index) => {
         const labelId = `${idPrefix}-q${index}`;
         const inputId = `${idPrefix}-a${index}`;
-        const locked = question.qid in answered;
+        const locked = Object.hasOwn(answered, question.qid);
         // Markdown source must never become an accessible name — it is read out
         // character for character. See plainTextForLabel.
         const spoken = plainTextForLabel(question.question);

--- a/src/lib/harness/transport.ts
+++ b/src/lib/harness/transport.ts
@@ -278,10 +278,11 @@ export type TurnEvent =
    *
    * `requestId` is the identity, not the position: the same prompt is REPLAYED
    * on a reconnect, so a surface must de-duplicate on it or draw the card
-   * twice. A replay of a partly answered batch carries `answered` — the qids
-   * already locked in, so the card comes back with those questions collapsed
-   * instead of inviting a second answer the gateway would accept and confuse
-   * the agent with.
+   * twice. `answered` carries the qids already locked in, so those questions
+   * come back collapsed instead of inviting a second answer the gateway would
+   * accept and confuse the agent with — on a replayed batch, and on a question
+   * the customer's own next message answered (TASK-610), where a
+   * single-question prompt appears under its empty qid.
    */
   | { kind: "clarify"; requestId: string; questions: ClarifyQuestion[]; answered?: Record<string, string> }
   /**

--- a/src/lib/hermes-dashboard-turn.ts
+++ b/src/lib/hermes-dashboard-turn.ts
@@ -703,9 +703,11 @@ function normaliseClarify(raw: unknown): ClarifyActivity | null {
  * one of those would be refused.
  *
  * Null when every question already has an answer. Falling back to "no
- * question_id" there would not be a harmless default: against a batch that is
- * upstream's cancel-all, so a message arriving on a fully-answered prompt would
- * throw the whole thing away.
+ * question_id" there would not be a harmless default: `_respond` takes the
+ * batch branch only when a question_id is present (server.py:11911), so an
+ * answer without one sets the Event immediately and `_block` returns the raw
+ * string (server.py:3524), discarding every answer locked so far — silently,
+ * under a `{"status":"ok"}`.
  */
 function answerableQid(clarify: ClarifyActivity): string | null {
   const answered = clarify.answered ?? {};
@@ -1180,18 +1182,32 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
           // ── A message arriving on a session parked on a question ─────────
           //
           // That message IS the answer, and forwarding it is the whole of
-          // TASK-610. Before this, a fresh prompt went in while the agent's
-          // worker thread was still parked on `Event.wait(agent.clarify_timeout)`
-          // — so the customer had their own question replayed at them, their
-          // message did nothing, and the session stayed unusable for the rest
-          // of that window. Measured on the box: answering the pending clarify
-          // gets BOTH the parked turn and the new message dealt with, so
-          // nothing is lost by treating the message as the answer.
+          // TASK-610. What used to happen instead, read out of hermes 0.20.5
+          // on the box: `prompt.submit` for a session whose worker is parked
+          // takes the BUSY path (methods_prompt.py:346 → `_handle_busy_submit`
+          // server.py:8233), which queues the text and fires
+          // `agent.interrupt()` at a thread sitting in `ev.wait()`. Nothing on
+          // that path touches the clarify registry — the only thing that
+          // releases the Event is `_clear_pending` (server.py:3693), reached
+          // only from `session.interrupt`. So the customer got their own
+          // question replayed at them, their message sat in `queued_prompt`,
+          // and the session stayed unusable for the rest of the window.
           //
-          // `clarify.respond` is hermes' own door for this and needs no
-          // session id — `_respond` resolves the session from a global pending
-          // registry keyed by request id — which is why the dashboard SPA, a
-          // second browser and this turn can all answer the same prompt.
+          // `clarify.respond` is hermes' own door for this (dispatch
+          // methods_prompt.py:1413 → `_respond` server.py:11900) and needs no
+          // session id: `_pending` is a flat request_id → (sid, Event) map
+          // (server.py:3496), which is why the dashboard SPA, a second browser
+          // and this turn can all answer the same prompt.
+          //
+          // It is also what hermes' OWN channel adapters do. An inbound
+          // Telegram/WhatsApp/Discord/Slack message is checked against the
+          // pending clarify before it is dispatched as a turn
+          // (gateway/run.py:16824 the text intercept, gateway/platforms/base.py:6171
+          // the busy-bypass that gets it there at all — its comment: "leaving
+          // the agent blocked and discarding the user's answer"). Those run on
+          // hermes' second, session-indexed registry (tools/clarify_gateway.py:71),
+          // which this transport cannot reach; this is the same behaviour on
+          // the surface that has none of it, through the RPC that surface owns.
           //
           // Deliberately NOT capped at the HTTP route's MAX_ANSWER_CHARS: that
           // cap exists because that route takes a body from any client against

--- a/src/lib/hermes-dashboard-turn.ts
+++ b/src/lib/hermes-dashboard-turn.ts
@@ -714,7 +714,7 @@ function answerableQid(clarify: ClarifyActivity): string | null {
 }
 
 /**
- * How many of a batch's questions are still open after an answer landed.
+ * Whether a batch still has a question in it after an answer landed.
  *
  * The gateway's own `remaining` is preferred over anything computed here,
  * because only it knows: answers accumulate in ITS registry across every

--- a/src/lib/hermes-dashboard-turn.ts
+++ b/src/lib/hermes-dashboard-turn.ts
@@ -730,7 +730,10 @@ function normaliseClarify(raw: unknown): ClarifyActivity | null {
  */
 function answerableQuestion(clarify: ClarifyActivity): ClarifyQuestion | null {
   const answered = clarify.answered ?? {};
-  return clarify.questions.find((question) => !(question.qid in answered)) ?? null;
+  // `Object.hasOwn`, never `in`: a qid is a string the model chose, and
+  // `"toString" in {}` is true. A batch that happened to name a question
+  // `constructor` would otherwise look answered before anybody answered it.
+  return clarify.questions.find((question) => !Object.hasOwn(answered, question.qid)) ?? null;
 }
 
 /**
@@ -766,7 +769,8 @@ function clarifyStillOpen(
 ): boolean {
   if (typeof raw === "number" && Number.isFinite(raw)) return raw > 0;
   if (Array.isArray(raw)) return raw.some((value) => typeof value === "string");
-  return clarify.questions.some((question) => !(question.qid in answered));
+  // Own properties only — see `answerableQuestion`.
+  return clarify.questions.some((question) => !Object.hasOwn(answered, question.qid));
 }
 
 /**

--- a/src/lib/hermes-dashboard-turn.ts
+++ b/src/lib/hermes-dashboard-turn.ts
@@ -694,6 +694,45 @@ function normaliseClarify(raw: unknown): ClarifyActivity | null {
 }
 
 /**
+ * The question a fresh message should be delivered to, or null for none.
+ *
+ * `""` is a real answer here and not a miss: the single-question shape carries
+ * that qid, and its `clarify.respond` must go out with NO `question_id` at all.
+ * A batch answers per question, so the message goes to the first one still
+ * outstanding — the answers already locked in are upstream's, and re-answering
+ * one of those would be refused.
+ *
+ * Null when every question already has an answer. Falling back to "no
+ * question_id" there would not be a harmless default: against a batch that is
+ * upstream's cancel-all, so a message arriving on a fully-answered prompt would
+ * throw the whole thing away.
+ */
+function answerableQid(clarify: ClarifyActivity): string | null {
+  const answered = clarify.answered ?? {};
+  const outstanding = clarify.questions.find((question) => !(question.qid in answered));
+  return outstanding ? outstanding.qid : null;
+}
+
+/**
+ * How many of a batch's questions are still open after an answer landed.
+ *
+ * The gateway's own `remaining` is preferred over anything computed here,
+ * because only it knows: answers accumulate in ITS registry across every
+ * surface that has answered anything — this chat, the dashboard SPA, a second
+ * browser — so a client's own arithmetic can be out of date the moment it is
+ * done. Computed only when the reply says nothing.
+ */
+function clarifyStillOpen(
+  raw: unknown,
+  clarify: ClarifyActivity,
+  answered: Readonly<Record<string, string>>,
+): boolean {
+  if (typeof raw === "number" && Number.isFinite(raw)) return raw > 0;
+  if (Array.isArray(raw)) return raw.some((value) => typeof value === "string");
+  return clarify.questions.some((question) => !(question.qid in answered));
+}
+
+/**
  * Open a socket, settle the session, and hand back something that can run ONE turn.
  *
  * Connecting is separated from running on purpose. Everything that can fail for
@@ -1114,32 +1153,20 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
          * covering many questions, not many requests.
          */
         let pendingClarifyId = "";
-        try {
-          // The replayed question goes out FIRST, before the prompt is even
-          // submitted: it is older than this turn, the agent is already parked
-          // on it, and a surface that receives it after this turn's own
-          // activity would render it as though it had just been asked.
-          if (replayClarify) {
-            announcedClarifies.add(replayClarify.requestId);
-            // Armed ONLY when there is somewhere for the question to go.
-            //
-            // The hour-long window is justified by a PERSON being able to read
-            // the prompt and answer it. `onActivity` is optional — a caller
-            // that only wants the answer text passes none — and such a caller
-            // can never show the question to anybody. Arming the long window
-            // for it would park the turn for an hour on a prompt with no
-            // surface, which is precisely the failure this whole branch exists
-            // to prevent, merely reintroduced from the other side.
-            //
-            // Without a surface the turn keeps the ordinary idle window and
-            // gives up in three minutes. That is the honest outcome: the
-            // question cannot be answered on this transport, and saying so
-            // quickly beats waiting an hour to say the same thing.
-            if (onActivity) {
-              pendingClarifyId = replayClarify.requestId;
-              onActivity(replayClarify);
-            }
-          }
+        /**
+         * The `clarify.respond` this turn sent on the customer's behalf.
+         *
+         * Held until the gateway acknowledges it, because until then nothing
+         * is known: whether the answer landed, whether the prompt had already
+         * expired, and whether the batch still has questions in it. Nulled the
+         * moment the acknowledgement is read.
+         */
+        let forwarded: { rpcId: number; clarify: ClarifyActivity; questionId: string; answer: string } | null = null;
+        /** The turn's own prompt, sent at most once whichever path gets there. */
+        let promptSent = false;
+        const submitPrompt = () => {
+          if (promptSent) return;
+          promptSent = true;
           socket.send(
             JSON.stringify({
               jsonrpc: "2.0",
@@ -1148,6 +1175,86 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
               params: { session_id: transportSid, text: req.text },
             }),
           );
+        };
+        try {
+          // ── A message arriving on a session parked on a question ─────────
+          //
+          // That message IS the answer, and forwarding it is the whole of
+          // TASK-610. Before this, a fresh prompt went in while the agent's
+          // worker thread was still parked on `Event.wait(agent.clarify_timeout)`
+          // — so the customer had their own question replayed at them, their
+          // message did nothing, and the session stayed unusable for the rest
+          // of that window. Measured on the box: answering the pending clarify
+          // gets BOTH the parked turn and the new message dealt with, so
+          // nothing is lost by treating the message as the answer.
+          //
+          // `clarify.respond` is hermes' own door for this and needs no
+          // session id — `_respond` resolves the session from a global pending
+          // registry keyed by request id — which is why the dashboard SPA, a
+          // second browser and this turn can all answer the same prompt.
+          //
+          // Deliberately NOT capped at the HTTP route's MAX_ANSWER_CHARS: that
+          // cap exists because that route takes a body from any client against
+          // an arbitrary request id, while this text is this turn's own prompt,
+          // which the transport was about to carry wholesale anyway.
+          if (replayClarify) {
+            announcedClarifies.add(replayClarify.requestId);
+            const qid = req.text ? answerableQid(replayClarify) : null;
+            if (qid !== null) {
+              const rpcId = nextRpcId();
+              forwarded = { rpcId, clarify: replayClarify, questionId: qid, answer: req.text };
+              socket.send(
+                JSON.stringify({
+                  jsonrpc: "2.0",
+                  id: rpcId,
+                  method: "clarify.respond",
+                  params: {
+                    request_id: replayClarify.requestId,
+                    answer: req.text,
+                    // Only when there is one. An empty `question_id` against a
+                    // batch is upstream's cancel-all, not a harmless default.
+                    ...(qid ? { question_id: qid } : {}),
+                  },
+                }),
+              );
+              // The question is NOT announced yet, and the long window is NOT
+              // armed yet. Both wait for the acknowledgement, on purpose:
+              // drawing an answerable form for a question this turn has just
+              // answered invites the customer to answer it twice, and while
+              // the gateway is the one being waited on — for milliseconds —
+              // silence is evidence exactly as it is anywhere else. If the
+              // acknowledgement never comes, the ordinary watchdog says so in
+              // three minutes instead of holding the turn open for an hour.
+            } else if (onActivity) {
+              // Nothing to forward it to — every question is already answered,
+              // or this turn has no text of its own. The question goes out as
+              // it always did.
+              //
+              // Armed ONLY when there is somewhere for the question to go.
+              //
+              // The hour-long window is justified by a PERSON being able to
+              // read the prompt and answer it. `onActivity` is optional — a
+              // caller that only wants the answer text passes none — and such
+              // a caller can never show the question to anybody. Arming the
+              // long window for it would park the turn for an hour on a prompt
+              // with no surface, which is precisely the failure this whole
+              // branch exists to prevent, merely reintroduced from the other
+              // side.
+              //
+              // Without a surface the turn keeps the ordinary idle window and
+              // gives up in three minutes. That is the honest outcome: the
+              // question cannot be answered on this transport, and saying so
+              // quickly beats waiting an hour to say the same thing.
+              pendingClarifyId = replayClarify.requestId;
+              onActivity(replayClarify);
+            }
+          }
+          // Held back only while an answer this turn forwarded is in flight:
+          // the same text as both the answer AND a fresh prompt would be two
+          // turns off one message. Every other path submits immediately, and
+          // the acknowledgement branch below submits it after a refusal or an
+          // expiry, so a message is never swallowed.
+          if (!forwarded) submitPrompt();
           let answer = "";
           let reasoning = "";
           let truncated = false;
@@ -1158,6 +1265,48 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
             // rest of the time silence is evidence and three minutes is plenty.
             const frame = await nextFrame(pendingClarifyId ? CLARIFY_IDLE_TIMEOUT_MS : IDLE_TIMEOUT_MS);
             const type = frameType(frame);
+            // ── What the gateway made of the answer we forwarded ───────────
+            //
+            // Read HERE, in the frame loop, and never with `awaitReply`: that
+            // helper discards every frame that is not the reply it wants, and
+            // the answer UNPARKS the agent — so the resumed turn's own deltas
+            // can arrive before the acknowledgement does, and awaiting it
+            // would eat the beginning of the customer's answer.
+            if (forwarded && frame.id === forwarded.rpcId) {
+              const sent = forwarded;
+              forwarded = null;
+              const result = (frame.result || {}) as Record<string, unknown>;
+              const refused = frame.error ? String(frame.error.message || "the dashboard refused the answer") : "";
+              const expired = !refused && result.status === "expired";
+              if (refused || expired) {
+                // NOT reported as answered — the whole false-success class in
+                // one branch. A refusal leaves the question standing, so it
+                // goes out as a live prompt; an expiry means the window had
+                // already closed, so the card comes down instead of leaving
+                // somebody typing into a prompt nothing can deliver.
+                if (refused) console.warn(`[hermes-stream] clarify answer refused: ${refused}`);
+                if (onActivity) {
+                  if (expired) {
+                    onActivity({ kind: "clarifyExpire", requestId: sent.clarify.requestId });
+                  } else {
+                    pendingClarifyId = sent.clarify.requestId;
+                    onActivity(sent.clarify);
+                  }
+                }
+                // And the message is still the customer's turn either way.
+                submitPrompt();
+                continue;
+              }
+              const answered = { ...(sent.clarify.answered ?? {}), [sent.questionId]: sent.answer };
+              const stillOpen = clarifyStillOpen(result.remaining, sent.clarify, answered);
+              if (onActivity) onActivity({ ...sent.clarify, answered });
+              // Still open means a person is still being waited on — the rest
+              // of the batch — so the human-shaped window stays. Fully
+              // answered means the AGENT is working again, and a working agent
+              // is held to the same three minutes as any other turn.
+              pendingClarifyId = stillOpen && onActivity ? sent.clarify.requestId : "";
+              continue;
+            }
             // The turn talking again is the only proof available here that the
             // answer landed — it was sent over someone else's socket, and no
             // acknowledgement of it ever reaches this reader. Narrowing the

--- a/src/lib/hermes-dashboard-turn.ts
+++ b/src/lib/hermes-dashboard-turn.ts
@@ -184,6 +184,15 @@ const IDLE_TIMEOUT_MS = Number(process.env.HERMES_STREAM_IDLE_TIMEOUT_MS || 180_
  * moment the turn's own frames resume — see `TURN_PROGRESS` — so a turn that
  * really does wedge after the answer lands is still given up on in three
  * minutes rather than in an hour.
+ *
+ * An UPPER BOUND now, not a matching pair. A ClawBox seeds
+ * `agent.clarify_timeout: 300` (scripts/register-mcp.sh), so on this appliance
+ * the AGENT gives up first and says so — `_block` emits `clarify.expire`
+ * (server.py:3552), which stands this window down through the `clarifyExpire`
+ * branch below. Keeping the ceiling at hermes' own default is what covers the
+ * other direction: an owner who sets a longer window of their own keeps a
+ * reader that waits with them, up to the hour, instead of one pinned to a value
+ * the box no longer runs.
  */
 const CLARIFY_IDLE_TIMEOUT_MS = Number(process.env.HERMES_CLARIFY_IDLE_TIMEOUT_MS || 3_600_000);
 
@@ -277,11 +286,15 @@ export type DashboardActivity =
    * `requestId` — that value, and not the session, is what `clarify.respond`
    * is addressed by.
    *
-   * `answered` appears only on a REPLAYED batch: the gateway hands back the
-   * answers already locked in (`{ qid: answer }`) so a reconnecting surface can
-   * restore the half-filled form instead of asking everything again. An empty
-   * string in there is a real answer — hermes treats it as a locked SKIP — so
-   * a reader must not mistake it for an unanswered question.
+   * `answered` carries the answers hermes has LOCKED IN (`{ qid: answer }`),
+   * from either of the two places they can come from: a replay, where the
+   * gateway hands back what was already answered so a reconnecting surface can
+   * restore the half-filled form instead of asking everything again, and this
+   * turn's own forwarded message, where the qid it answered is added to that
+   * map so the card says the question was answered rather than offering it
+   * again. A single-question clarify appears under its own empty qid. An empty
+   * ANSWER in there is a real answer — hermes treats it as a locked SKIP — so a
+   * reader must not mistake it for an unanswered question.
    */
   | {
       kind: "clarify";
@@ -662,6 +675,12 @@ function clarifyQuestions(payload: Record<string, unknown>): ClarifyQuestion[] {
  * that the batch counts as done, so dropping it here would show a reconnecting
  * customer an unanswered question they had already dismissed — and any answer
  * they then gave would be refused, because that qid is already locked.
+ *
+ * An empty QID is dropped, which is the opposite rule and about a different
+ * field: upstream attaches `answers` only to a batch, where every qid is real,
+ * so a blank key there is a malformed row. The empty qid of a single-question
+ * clarify is never read from the wire — it is written locally, by the forwarder
+ * below, onto the map this function returns.
  */
 function clarifyAnswers(raw: unknown): Record<string, string> | null {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
@@ -696,11 +715,11 @@ function normaliseClarify(raw: unknown): ClarifyActivity | null {
 /**
  * The question a fresh message should be delivered to, or null for none.
  *
- * `""` is a real answer here and not a miss: the single-question shape carries
- * that qid, and its `clarify.respond` must go out with NO `question_id` at all.
  * A batch answers per question, so the message goes to the first one still
  * outstanding — the answers already locked in are upstream's, and re-answering
- * one of those would be refused.
+ * one of those would be refused. Its `qid` is what `clarify.respond` addresses;
+ * for the single-question shape that qid is `""`, which means the answer goes
+ * out with NO `question_id` at all.
  *
  * Null when every question already has an answer. Falling back to "no
  * question_id" there would not be a harmless default: `_respond` takes the
@@ -709,10 +728,26 @@ function normaliseClarify(raw: unknown): ClarifyActivity | null {
  * string (server.py:3524), discarding every answer locked so far — silently,
  * under a `{"status":"ok"}`.
  */
-function answerableQid(clarify: ClarifyActivity): string | null {
+function answerableQuestion(clarify: ClarifyActivity): ClarifyQuestion | null {
   const answered = clarify.answered ?? {};
-  const outstanding = clarify.questions.find((question) => !(question.qid in answered));
-  return outstanding ? outstanding.qid : null;
+  return clarify.questions.find((question) => !(question.qid in answered)) ?? null;
+}
+
+/**
+ * The customer's message, in the shape that question's answer is read in.
+ *
+ * Prose for an ordinary question. For a MULTI-SELECT one, a JSON array of the
+ * single thing they said — the same encoding the card sends
+ * (`encodeMultiSelectAnswer`) and the same one hermes' own channel path emits
+ * (tools/clarify_gateway.py:425), and it is not cosmetic. The decoder that
+ * reads a multi-select answer tries JSON first and otherwise falls back to
+ * `raw.split(",")` (tools/clarify_tool.py:162) without ever looking at the
+ * choices it offered: sent as prose, "the second one, I think" reaches the
+ * agent as TWO selections it never offered, with no error anywhere. Wrapped,
+ * it arrives as the one free-text answer the customer actually gave.
+ */
+function clarifyAnswerText(question: ClarifyQuestion, text: string): string {
+  return question.multiSelect ? JSON.stringify([text]) : text;
 }
 
 /**
@@ -1164,9 +1199,23 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
          * moment the acknowledgement is read.
          */
         let forwarded: { rpcId: number; clarify: ClarifyActivity; questionId: string; answer: string } | null = null;
-        /** The turn's own prompt, sent at most once whichever path gets there. */
+        /**
+         * The turn's own prompt, sent at most once whichever path gets there.
+         *
+         * `queued` is upstream's own "never interrupt" flag and the only way in
+         * is this parameter (`params["queued"]`, methods_prompt.py:359). It
+         * OVERRIDES `display.busy_input_mode` outright — `mode = "queue" if
+         * queued else _load_busy_input_mode()` (server.py:8255) — so the text is
+         * enqueued behind whatever is running instead of steering or
+         * interrupting it. Used on the paths below that submit AFTER an answer
+         * has been acknowledged, because by then the agent may well be running
+         * again and the box's default mode is `interrupt`
+         * (config_defaults.py:1275). It guarantees "never interrupt", not
+         * "always queue": a turn that ended between the checks still runs this
+         * as an ordinary live prompt (server.py:8258, methods_prompt.py:346).
+         */
         let promptSent = false;
-        const submitPrompt = () => {
+        const submitPrompt = (queued = false) => {
           if (promptSent) return;
           promptSent = true;
           socket.send(
@@ -1174,7 +1223,7 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
               jsonrpc: "2.0",
               id: nextRpcId(),
               method: "prompt.submit",
-              params: { session_id: transportSid, text: req.text },
+              params: { session_id: transportSid, text: req.text, ...(queued ? { queued: true } : {}) },
             }),
           );
         };
@@ -1199,15 +1248,28 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
           // (server.py:3496), which is why the dashboard SPA, a second browser
           // and this turn can all answer the same prompt.
           //
-          // It is also what hermes' OWN channel adapters do. An inbound
-          // Telegram/WhatsApp/Discord/Slack message is checked against the
-          // pending clarify before it is dispatched as a turn
-          // (gateway/run.py:16824 the text intercept, gateway/platforms/base.py:6171
-          // the busy-bypass that gets it there at all — its comment: "leaving
-          // the agent blocked and discarding the user's answer"). Those run on
-          // hermes' second, session-indexed registry (tools/clarify_gateway.py:71),
-          // which this transport cannot reach; this is the same behaviour on
-          // the surface that has none of it, through the RPC that surface owns.
+          // Checking the message against the pending question before treating
+          // it as a turn is what hermes' OWN channel adapters do: an inbound
+          // Telegram/WhatsApp/Discord/Slack message goes through the text
+          // intercept at gateway/run.py:16824, reached by the busy-bypass at
+          // gateway/platforms/base.py:6171 — whose comment names the failure
+          // this branch is also about, "leaving the agent blocked and
+          // discarding the user's answer". Those run on hermes' second,
+          // session-indexed registry (tools/clarify_gateway.py:71), which this
+          // transport cannot reach, so the same idea is carried out here
+          // through the RPC this surface does own.
+          //
+          // NOT a copy of it, in one deliberate respect. Upstream's intercept
+          // is three-way (clarify_gateway.py:428): text that matches no choice
+          // of a native-choice prompt is REJECTED, the clarify released with
+          // an empty answer, and the message routed on as an ordinary turn
+          // (run.py:16895-16904). Here every message is delivered as the
+          // answer, by the product ruling on TASK-610: on this surface the
+          // question is a card the customer can still click, what they type in
+          // the composer instead is aimed at the agent, and a box that decided
+          // for itself whether their sentence "counted" would silently drop
+          // half of them. What the ruling does NOT permit is claiming it was
+          // answered when hermes says otherwise — hence the branches below.
           //
           // Deliberately NOT capped at the HTTP route's MAX_ANSWER_CHARS: that
           // cap exists because that route takes a body from any client against
@@ -1215,10 +1277,11 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
           // which the transport was about to carry wholesale anyway.
           if (replayClarify) {
             announcedClarifies.add(replayClarify.requestId);
-            const qid = req.text ? answerableQid(replayClarify) : null;
-            if (qid !== null) {
+            const target = req.text ? answerableQuestion(replayClarify) : null;
+            if (target) {
               const rpcId = nextRpcId();
-              forwarded = { rpcId, clarify: replayClarify, questionId: qid, answer: req.text };
+              const answerText = clarifyAnswerText(target, req.text);
+              forwarded = { rpcId, clarify: replayClarify, questionId: target.qid, answer: answerText };
               socket.send(
                 JSON.stringify({
                   jsonrpc: "2.0",
@@ -1226,10 +1289,10 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
                   method: "clarify.respond",
                   params: {
                     request_id: replayClarify.requestId,
-                    answer: req.text,
+                    answer: answerText,
                     // Only when there is one. An empty `question_id` against a
                     // batch is upstream's cancel-all, not a harmless default.
-                    ...(qid ? { question_id: qid } : {}),
+                    ...(target.qid ? { question_id: target.qid } : {}),
                   },
                 }),
               );
@@ -1298,8 +1361,15 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
                 // NOT reported as answered — the whole false-success class in
                 // one branch. A refusal leaves the question standing, so it
                 // goes out as a live prompt; an expiry means the window had
-                // already closed, so the card comes down instead of leaving
-                // somebody typing into a prompt nothing can deliver.
+                // already closed, and the surface is told the question is gone.
+                //
+                // That expiry notice is belt-and-braces rather than a card
+                // coming down: this turn had not announced the question yet,
+                // and the chat clears its cards when a turn ends
+                // (ChatPopup `clearClarifies`), so there is normally nothing on
+                // screen to take away. It is still sent, because a surface that
+                // DID keep the card must not be left with an answerable form
+                // for a request id nothing can deliver to.
                 if (refused) console.warn(`[hermes-stream] clarify answer refused: ${refused}`);
                 if (onActivity) {
                   if (expired) {
@@ -1309,8 +1379,16 @@ export async function openDashboardTurn(req: DashboardTurnRequest): Promise<Dash
                     onActivity(sent.clarify);
                   }
                 }
-                // And the message is still the customer's turn either way.
-                submitPrompt();
+                // And the message is still the customer's turn either way —
+                // enqueued rather than submitted live. `expired` means the
+                // worker has already left `ev.wait()` (`_pending` no longer
+                // holds the id, server.py:11906) and is therefore RUNNING, so a
+                // plain submit at this instant would interrupt the very turn
+                // the customer is waiting to read. A refusal is the other side
+                // of the same coin: the agent is still parked, and the
+                // interrupt a live submit fires would be waiting for it when it
+                // resumes on the answer the customer is about to give.
+                submitPrompt(true);
                 continue;
               }
               const answered = { ...(sent.clarify.answered ?? {}), [sent.questionId]: sent.answer };

--- a/src/tests/components/chat-clarify.test.tsx
+++ b/src/tests/components/chat-clarify.test.tsx
@@ -234,6 +234,19 @@ describe("a clarify that was replayed or has run out", () => {
     expect(screen.getByTestId("chat-clarify-answered")).toBeTruthy();
   });
 
+  it("says the customer's own message answered it, with nothing left to click", async () => {
+    // TASK-610. A message typed into the composer while the agent is parked is
+    // delivered as the ANSWER, so the card that comes back names it as the
+    // answer rather than sitting there as a form the customer has already
+    // replied to — and offers no control that would answer it a second time.
+    await askQuestion({ ...SINGLE, answered: { "": "the second one" } });
+    // The answered LINE, not the form: the text itself rides through the
+    // translator, which this environment stubs to the key.
+    expect(screen.getByTestId("chat-clarify-answered")).toBeTruthy();
+    expect(screen.queryAllByTestId("chat-clarify-choice")).toHaveLength(0);
+    expect(screen.queryAllByTestId("chat-clarify-text")).toHaveLength(0);
+  });
+
   it("goes dead in place when the agent stops waiting", async () => {
     // The card stays on screen — a question that silently vanished would read
     // as an answer that was sent — but nothing on it can be posted any more.

--- a/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
+++ b/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
@@ -498,10 +498,16 @@ describe("a question that was already waiting when we reconnected", () => {
       (activity) => seen.push(activity),
     );
     await settle();
+    // It reaches the surface as the answer to this turn's message lands on it
+    // (TASK-610) — but the payload itself still comes from the session RESULT,
+    // and everything the customer must see is carried across from there.
+    socket.deliver({ jsonrpc: "2.0", id: socket.method("clarify.respond")?.id, result: { status: "ok" } });
+    await settle();
     expect(seen[0]).toEqual({
       kind: "clarify",
       requestId: "re001122",
       questions: [{ qid: "", question: "Which file did you mean?", choices: ["a.ts", "b.ts"], multiSelect: false }],
+      answered: { "": "Hey" },
     });
     socket.event("message.complete", { text: "ok", status: "complete" });
     await running;
@@ -529,9 +535,17 @@ describe("a question that was already waiting when we reconnected", () => {
       (activity) => seen.push(activity),
     );
     await settle();
+    // q2 is the one still outstanding, so this turn's message goes there and
+    // the two locked answers ride along beside it.
+    socket.deliver({
+      jsonrpc: "2.0",
+      id: socket.method("clarify.respond")?.id,
+      result: { status: "ok", remaining: 0 },
+    });
+    await settle();
     const [clarify] = clarifiesOnly(seen);
     expect(clarify.questions).toHaveLength(3);
-    expect(clarify.answered).toEqual({ q1: "beta", q3: "" });
+    expect(clarify.answered).toEqual({ q1: "beta", q3: "", q2: "Hey" });
     socket.event("message.complete", { text: "ok", status: "complete" });
     await running;
   });
@@ -549,6 +563,8 @@ describe("a question that was already waiting when we reconnected", () => {
       () => {},
       (activity) => seen.push(activity),
     );
+    await settle();
+    socket.deliver({ jsonrpc: "2.0", id: socket.method("clarify.respond")?.id, result: { status: "ok" } });
     await settle();
     expect(clarifiesOnly(seen)).toHaveLength(1);
     socket.event("clarify.request", { question: "Which file?", choices: ["a.ts"], request_id: "dupe0011" });

--- a/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
+++ b/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
@@ -390,9 +390,17 @@ describe("the idle watchdog while a person is being waited on", () => {
     // The same rule on the replay path, which arms before the turn's first
     // frame and would otherwise hold the request open for an hour on a
     // question that was never rendered.
+    //
+    // The replayed prompt here is one this turn CANNOT answer for the customer
+    // — every question is already locked — so it takes the announce path
+    // rather than the forwarding one, which is the branch this rule lives on.
     vi.useFakeTimers();
     const { turn } = await connect({
-      pending_clarify: { question: "Which mailbox?", choices: ["work", "home"], request_id: "wd005566" },
+      pending_clarify: {
+        questions: [{ qid: "q1", question: "Which mailbox?", choices: ["work", "home"] }],
+        answers: { q1: "work" },
+        request_id: "wd005566",
+      },
     });
     let outcome: unknown = null;
     const running = turn!.run(() => {});
@@ -536,7 +544,8 @@ describe("a question that was already waiting when we reconnected", () => {
     );
     await settle();
     // q2 is the one still outstanding, so this turn's message goes there and
-    // the two locked answers ride along beside it.
+    // the two locked answers ride along beside it. q2 is multi-select, so the
+    // message is locked in as the JSON array that shape is read in.
     socket.deliver({
       jsonrpc: "2.0",
       id: socket.method("clarify.respond")?.id,
@@ -545,7 +554,7 @@ describe("a question that was already waiting when we reconnected", () => {
     await settle();
     const [clarify] = clarifiesOnly(seen);
     expect(clarify.questions).toHaveLength(3);
-    expect(clarify.answered).toEqual({ q1: "beta", q3: "", q2: "Hey" });
+    expect(clarify.answered).toEqual({ q1: "beta", q3: "", q2: '["Hey"]' });
     socket.event("message.complete", { text: "ok", status: "complete" });
     await running;
   });
@@ -721,6 +730,89 @@ describe("a new message while the agent is parked on a question", () => {
     // Still parked on q3, so the message must not have been submitted as a
     // prompt behind the customer's back either.
     expect(socket.method("prompt.submit")).toBeUndefined();
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+
+  it("wraps the message for a MULTI-SELECT question, so a comma is not two answers", async () => {
+    // The decoder upstream reads a multi-select answer with tries JSON first
+    // and otherwise splits on commas (tools/clarify_tool.py:162), without ever
+    // checking the choices it offered. Sent as prose, "the second one, I think"
+    // would reach the agent as two selections nobody offered.
+    const { turn, socket } = await connect({
+      pending_clarify: {
+        question: "Which of these should I install?",
+        choices: ["Alpha", "Beta"],
+        multi_select: true,
+        request_id: "fw778899",
+      },
+    });
+    const running = turn!.run(
+      () => {},
+      () => {},
+    );
+    await settle();
+    expect(socket.method("clarify.respond")?.params).toEqual({
+      request_id: "fw778899",
+      answer: '["Hey"]',
+    });
+    socket.deliver({ jsonrpc: "2.0", id: socket.method("clarify.respond")?.id, result: { status: "ok" } });
+    await settle();
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+
+  it("enqueues the message rather than interrupting a turn that is running again", async () => {
+    // `expired` is the one acknowledgement that says the worker has LEFT
+    // `ev.wait()` — `_pending` no longer holds the id — so the agent is running
+    // by construction. A plain submit here takes the busy path and, on this
+    // box's default mode, interrupts it; `queued: true` overrides that mode
+    // outright (server.py:8255) and puts the message behind the live turn.
+    const { turn, socket } = await connect({
+      pending_clarify: { question: "Which file?", choices: ["a.ts"], request_id: "fw889900" },
+    });
+    const running = turn!.run(
+      () => {},
+      () => {},
+    );
+    await settle();
+    socket.deliver({
+      jsonrpc: "2.0",
+      id: socket.method("clarify.respond")?.id,
+      result: { status: "expired" },
+    });
+    await settle();
+    expect(socket.method("prompt.submit")?.params).toEqual({
+      session_id: "e0719549",
+      text: "Hey",
+      queued: true,
+    });
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+
+  it("forwards nothing when every question is already answered, and asks as it always did", async () => {
+    // There is no question left to deliver the message to, and "no question_id"
+    // is not a spare slot to put it in: against a batch that is upstream's
+    // cancel-all, which would throw away every answer already locked. So the
+    // prompt goes out as the customer's own turn and the card is shown.
+    const { turn, socket } = await connect({
+      pending_clarify: {
+        questions: [{ qid: "q1", question: "Which branch?", choices: ["beta"] }],
+        answers: { q1: "beta" },
+        request_id: "fw667788",
+      },
+    });
+    const seen: DashboardActivity[] = [];
+    const running = turn!.run(
+      () => {},
+      (activity) => seen.push(activity),
+    );
+    await settle();
+    expect(socket.method("clarify.respond")).toBeUndefined();
+    expect(socket.method("prompt.submit")?.params).toMatchObject({ text: "Hey" });
+    expect(clarifiesOnly(seen)).toHaveLength(1);
+    expect(clarifiesOnly(seen)[0].answered).toEqual({ q1: "beta" });
     socket.event("message.complete", { text: "ok", status: "complete" });
     await running;
   });

--- a/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
+++ b/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
@@ -791,6 +791,40 @@ describe("a new message while the agent is parked on a question", () => {
     await running;
   });
 
+  it("does not treat a question named after an Object property as already answered", async () => {
+    // A qid is a string the model chose, and `"toString" in {}` is true. Read
+    // with `in`, a batch that named a question `constructor` would look
+    // answered before anybody answered it — the message would go to the wrong
+    // question, or nowhere at all.
+    const { turn, socket } = await connect({
+      pending_clarify: {
+        questions: [
+          { qid: "constructor", question: "Which builder?", choices: ["a"] },
+          { qid: "q2", question: "Which file?", choices: ["b"] },
+        ],
+        request_id: "fw990011",
+      },
+    });
+    const running = turn!.run(
+      () => {},
+      () => {},
+    );
+    await settle();
+    expect(socket.method("clarify.respond")?.params).toEqual({
+      request_id: "fw990011",
+      answer: "Hey",
+      question_id: "constructor",
+    });
+    socket.deliver({
+      jsonrpc: "2.0",
+      id: socket.method("clarify.respond")?.id,
+      result: { status: "ok", remaining: ["q2"] },
+    });
+    await settle();
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+
   it("forwards nothing when every question is already answered, and asks as it always did", async () => {
     // There is no question left to deliver the message to, and "no question_id"
     // is not a spare slot to put it in: against a batch that is upstream's

--- a/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
+++ b/src/tests/unit/hermes-dashboard-turn-clarify.test.ts
@@ -615,3 +615,143 @@ describe("answering over the turn's own socket", () => {
     await expect(answering).rejects.toThrow("unknown question_id");
   });
 });
+
+describe("a new message while the agent is parked on a question", () => {
+  // THE fix for TASK-610. Upstream parks the agent's worker thread on the
+  // question for `agent.clarify_timeout` seconds; a fresh message on that
+  // session used to be submitted as a brand-new prompt while the thread was
+  // still parked, so the customer got their old question replayed at them and
+  // nothing else happened until the window ran out. Their message IS the
+  // answer, and `clarify.respond` — addressed by request id alone — is hermes'
+  // own door for it.
+
+  it("forwards the message as the ANSWER instead of replaying the question", async () => {
+    const { turn, socket } = await connect({
+      pending_clarify: { question: "Which file did you mean?", choices: ["a.ts", "b.ts"], request_id: "fw001122" },
+    });
+    const seen: DashboardActivity[] = [];
+    const running = turn!.run(
+      () => {},
+      (activity) => seen.push(activity),
+    );
+    await settle();
+    const answer = socket.method("clarify.respond");
+    expect(answer).toBeDefined();
+    // No `question_id`: a single-question clarify has no qid, and an empty one
+    // against a batch is upstream's cancel-all.
+    expect(answer?.params).toEqual({ request_id: "fw001122", answer: "Hey" });
+    // And NOT also submitted as a fresh prompt — the same text processed twice
+    // is two turns, two bills, and an agent answering itself.
+    expect(socket.method("prompt.submit")).toBeUndefined();
+    socket.deliver({ jsonrpc: "2.0", id: answer?.id, result: { status: "ok" } });
+    await settle();
+    socket.event("message.complete", { text: "a.ts it is", status: "complete" });
+    const final = await running;
+    expect(final.text).toBe("a.ts it is");
+  });
+
+  it("shows the question as answered by that message, once the gateway says so", async () => {
+    // The UI half of the ruling: the card must say the question was answered —
+    // and answered by THIS message — rather than sit there as an open form the
+    // customer has already replied to.
+    const { turn, socket } = await connect({
+      pending_clarify: { question: "Which file did you mean?", choices: ["a.ts"], request_id: "fw112233" },
+    });
+    const seen: DashboardActivity[] = [];
+    const running = turn!.run(
+      () => {},
+      (activity) => seen.push(activity),
+    );
+    await settle();
+    const answer = socket.method("clarify.respond");
+    socket.deliver({ jsonrpc: "2.0", id: answer?.id, result: { status: "ok" } });
+    await settle();
+    const clarifies = clarifiesOnly(seen);
+    expect(clarifies).toHaveLength(1);
+    // The empty qid is the single-question clarify's own identity — the same
+    // key the card locks the answer under.
+    expect(clarifies[0].answered).toEqual({ "": "Hey" });
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+
+  it("names the first UNANSWERED question of a batch, and keeps the rest askable", async () => {
+    // A batch unblocks only once every qid has an answer, so the message goes
+    // to the first question still outstanding and the others stay on the card.
+    const { turn, socket } = await connect({
+      pending_clarify: {
+        questions: [
+          { qid: "q1", question: "Which branch?", choices: ["beta"] },
+          { qid: "q2", question: "Which file?", choices: ["a.ts"] },
+          { qid: "q3", question: "Anything else?" },
+        ],
+        answers: { q1: "beta" },
+        request_id: "fw334455",
+      },
+    });
+    const seen: DashboardActivity[] = [];
+    const running = turn!.run(
+      () => {},
+      (activity) => seen.push(activity),
+    );
+    await settle();
+    const answer = socket.method("clarify.respond");
+    expect(answer?.params).toEqual({ request_id: "fw334455", answer: "Hey", question_id: "q2" });
+    socket.deliver({ jsonrpc: "2.0", id: answer?.id, result: { status: "ok", remaining: ["q3"] } });
+    await settle();
+    const [clarify] = clarifiesOnly(seen);
+    expect(clarify.answered).toEqual({ q1: "beta", q2: "Hey" });
+    expect(clarify.questions.map((q) => q.qid)).toEqual(["q1", "q2", "q3"]);
+    // Still parked on q3, so the message must not have been submitted as a
+    // prompt behind the customer's back either.
+    expect(socket.method("prompt.submit")).toBeUndefined();
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+
+  it("does not claim it was answered when the gateway refuses, and never drops the message", async () => {
+    // False success, guarded: the answer's RESULT is read. A refusal means the
+    // question stands — the card must stay open — and the customer's words are
+    // still their turn, so they go in as a prompt rather than into a hole.
+    const { turn, socket } = await connect({
+      pending_clarify: { question: "Which file?", choices: ["a.ts"], request_id: "fw445566" },
+    });
+    const seen: DashboardActivity[] = [];
+    const running = turn!.run(
+      () => {},
+      (activity) => seen.push(activity),
+    );
+    await settle();
+    const answer = socket.method("clarify.respond");
+    socket.deliver({ jsonrpc: "2.0", id: answer?.id, error: { message: "unknown request id" } });
+    await settle();
+    const [clarify] = clarifiesOnly(seen);
+    expect(clarify.answered).toBeUndefined();
+    expect(socket.method("prompt.submit")?.params).toMatchObject({ text: "Hey" });
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+
+  it("takes the card down and sends the message as a prompt when the window had closed", async () => {
+    // `status: "expired"` is a SUCCESSFUL call whose window had gone — the
+    // agent is not parked any more, so the message is an ordinary turn and the
+    // dead question must stop being displayed as answerable.
+    const { turn, socket } = await connect({
+      pending_clarify: { question: "Which file?", choices: ["a.ts"], request_id: "fw556677" },
+    });
+    const seen: DashboardActivity[] = [];
+    const running = turn!.run(
+      () => {},
+      (activity) => seen.push(activity),
+    );
+    await settle();
+    const answer = socket.method("clarify.respond");
+    socket.deliver({ jsonrpc: "2.0", id: answer?.id, result: { status: "expired" } });
+    await settle();
+    expect(seen.filter((a) => a.kind === "clarifyExpire")).toEqual([{ kind: "clarifyExpire", requestId: "fw556677" }]);
+    expect(clarifiesOnly(seen).some((c) => c.answered)).toBe(false);
+    expect(socket.method("prompt.submit")?.params).toMatchObject({ text: "Hey" });
+    socket.event("message.complete", { text: "ok", status: "complete" });
+    await running;
+  });
+});

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -352,7 +352,7 @@ d("register-mcp.sh — the clarify window this appliance ships with", () => {
     return (readConfig().agent as Record<string, unknown>) ?? {};
   }
 
-  it("pins agent.clarify_timeout to 300 on a config that never set it", () => {
+  it("seeds agent.clarify_timeout at 300 on a config that never set it", () => {
     fs.writeFileSync(configPath, "model:\n  default: deepseek-v4-pro\n");
     const r = run();
     expect(r.status).toBe(0);
@@ -385,10 +385,14 @@ d("register-mcp.sh — the clarify window this appliance ships with", () => {
     expect(agentBlock().clarify_timeout).toBe(300);
   });
 
-  it("is part of the idempotence contract: a second run rewrites nothing", () => {
+  it("writes nothing on a second run, with the key already seeded", () => {
+    // The idempotence contract, exercised through the branch this block adds:
+    // the first run creates the `agent` block, and the second must find its own
+    // value there and leave the file byte-identical.
     fs.writeFileSync(configPath, "model:\n  default: x\n");
     run();
     const first = fs.readFileSync(configPath, "utf-8");
+    expect(first).toContain("clarify_timeout");
     const second = run();
     expect(second.stdout).toContain("already current");
     expect(fs.readFileSync(configPath, "utf-8")).toBe(first);

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -341,3 +341,53 @@ d("register-mcp.sh — bundled email-skill distractors", () => {
     expect(clawboxEntry().enabled).toBe(true);
   });
 });
+
+// Hermes parks the agent's worker thread on a clarify for `agent.clarify_timeout`
+// seconds — 3600 by default, and `<= 0` means forever. On an appliance that is
+// an hour of a session nobody can use for anything else because one question
+// went unanswered. 300s is the ClawBox default, written where the rest of this
+// device's Hermes config is rendered.
+d("register-mcp.sh — the clarify window this appliance ships with", () => {
+  function agentBlock(): Record<string, unknown> {
+    return (readConfig().agent as Record<string, unknown>) ?? {};
+  }
+
+  it("pins agent.clarify_timeout to 300 on a config that never set it", () => {
+    fs.writeFileSync(configPath, "model:\n  default: deepseek-v4-pro\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    // A NUMBER, not the string `hermes config set` would have stored: upstream
+    // reads it as a number and a quoted one is a different value.
+    expect(agentBlock().clarify_timeout).toBe(300);
+  });
+
+  it("leaves a window the owner chose for themselves alone", () => {
+    fs.writeFileSync(configPath, "agent:\n  clarify_timeout: 900\n");
+    run();
+    expect(agentBlock().clarify_timeout).toBe(900);
+  });
+
+  it("keeps the rest of the agent block untouched", () => {
+    fs.writeFileSync(configPath, "agent:\n  reasoning_effort: medium\n");
+    run();
+    expect(agentBlock().reasoning_effort).toBe("medium");
+    expect(agentBlock().clarify_timeout).toBe(300);
+  });
+
+  it("is part of the idempotence contract: a second run rewrites nothing", () => {
+    fs.writeFileSync(configPath, "model:\n  default: x\n");
+    run();
+    const first = fs.readFileSync(configPath, "utf-8");
+    const second = run();
+    expect(second.stdout).toContain("already current");
+    expect(fs.readFileSync(configPath, "utf-8")).toBe(first);
+  });
+
+  it("leaves an agent key it cannot read alone but still registers the MCP", () => {
+    fs.writeFileSync(configPath, "agent: broken\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(readConfig().agent).toBe("broken");
+    expect(clawboxEntry().enabled).toBe(true);
+  });
+});

--- a/src/tests/unit/register-mcp-hermes.test.ts
+++ b/src/tests/unit/register-mcp-hermes.test.ts
@@ -367,6 +367,17 @@ d("register-mcp.sh — the clarify window this appliance ships with", () => {
     expect(agentBlock().clarify_timeout).toBe(900);
   });
 
+  it("defers to the legacy clarify.timeout, which wins in hermes' own resolver", () => {
+    // resolve_clarify_timeout reads `clarify.timeout` BEFORE
+    // `agent.clarify_timeout`, so writing ours beside it would leave the file
+    // claiming 300 while the box waited the owner's window.
+    fs.writeFileSync(configPath, "clarify:\n  timeout: 1800\n");
+    const r = run();
+    expect(r.status).toBe(0);
+    expect(readConfig().agent).toBeUndefined();
+    expect(clawboxEntry().enabled).toBe(true);
+  });
+
   it("keeps the rest of the agent block untouched", () => {
     fs.writeFileSync(configPath, "agent:\n  reasoning_effort: medium\n");
     run();


### PR DESCRIPTION
**Finding:** D-06 / TASK-610 (owner ruling 2026-09-03: "as recommended").

## The symptom

On a Hermes box the agent stops mid-turn to ask the customer a question ("which of these three files did you mean?"). The customer answers in the chat box, the way anyone would. Their message does nothing: the old question is replayed at them, the reply they typed is never processed, and the session cannot be used for anything else for the next **hour**.

## The cause, read out of the harness

Verified read-only on the Hermes box (hermes-agent 0.20.5, git checkout — nothing written, no setting changed, no mutex taken):

* A clarify parks the agent's own worker thread on `Event.wait(...)` (`tui_gateway/server.py:3513`) for `agent.clarify_timeout` seconds. That defaults to **3600** (`tools/clarify_gateway.py:547`, shipped default `hermes_cli/config_defaults.py:278`), and `<= 0` is passed through as unlimited — `ev.wait(None)`, forever (`server.py:3576`).
* A `prompt.submit` for a session whose worker is parked takes the BUSY path (`tui_gateway/methods_prompt.py:346` → `_handle_busy_submit`, `server.py:8233`): the text is **queued** and `agent.interrupt()` is fired at a thread sitting in `ev.wait()`. That function has no reference to the clarify registry, and the only thing that releases the Event is `_clear_pending` (`server.py:3693`), reachable only from `session.interrupt`. So the message waits behind the parked worker and `_drain_queued_prompt` (`server.py:8331`) will not fire while the session is running.
* The pending question is handed back only in the RESULT of `session.resume` / `session.activate` (`_pending_clarify_request_payload`, `server.py:1946`, attached at `:8972`) — which is why the old code re-emitted it and waited.

## Harness first — the native mechanism, and who already uses it

**The answer door is `clarify.respond`**, dispatched at `tui_gateway/methods_prompt.py:1413` into `_respond` (`server.py:11900`). It takes `request_id` + `answer` + an optional `question_id`, carries **no session id** (`_pending` is a flat `request_id → (sid, Event)` map, `server.py:3496`), and answers `{"status":"ok"}`, `{"status":"ok","remaining":[qids]}` for a batch, or `{"status":"expired"}` — a *success* — for a window that had already closed (`allow_expired=True`, `:11907`).

**The timeout key is `agent.clarify_timeout`**, an int in seconds, resolved by `resolve_clarify_timeout` (`tools/clarify_gateway.py:531`), which reads the legacy `clarify.timeout` first, then `agent.clarify_timeout`, then 3600.

And this behaviour is not invented here: **Hermes' own channel adapters already do it.** An inbound Telegram / WhatsApp / Discord / Slack / relay message is tested against that chat's pending clarify *before* it is dispatched as a turn — the text intercept at `gateway/run.py:16824` (`attempt_text_response_for_session`, `:16857`) plus the busy-bypass at `gateway/platforms/base.py:6171`, whose own comment says that without it "the message gets queued … leaving the agent blocked and discarding the user's answer". Those run on Hermes' *second*, session-indexed registry (`tools/clarify_gateway.py:71`), which the dashboard WebSocket transport cannot reach; Hermes' own desktop app compensates client-side for the same gap. This PR is that behaviour on the surface that had none of it, through the RPC that surface owns. No new registry, no new state store.

One deliberate difference from the channel path, because the owner ruled it: upstream's intercept is three-way (`clarify_gateway.py:428`) and *rejects* prose that matches no offered choice. Here every message is delivered as the answer — on this surface the question is still a clickable card and what the customer types in the composer is aimed at the agent. What is not permitted is claiming it was answered when Hermes says otherwise, which is what the branches below are for.

## What changed

**1. `src/lib/hermes-dashboard-turn.ts` — the message becomes the answer.**
When a turn opens on a session that comes back carrying `pending_clarify`, it sends `clarify.respond` with the customer's text instead of `prompt.submit`, and reads what the gateway made of it in the frame loop (never with `awaitReply`, which discards frames — the answer unparks the agent, so the resumed turn's own deltas can arrive before the acknowledgement):

* **ok** → the question is emitted with `answered` filled in, so the card shows it was answered *by that message* instead of standing there as a form. The long clarify window is stood down when nothing is outstanding (the agent is working now, not a person) and kept while a batch still has questions.
* **refused** → nothing is claimed answered, the question goes out as a live prompt, and the message is still submitted as the customer's turn. It is never swallowed.
* **expired** → the surface is told the question is gone and the message goes in as an ordinary prompt, because the agent is no longer parked.

Both fallback submits carry `queued: true`. That is upstream's own "never interrupt" flag — it overrides `display.busy_input_mode` outright (`mode = "queue" if queued else _load_busy_input_mode()`, `server.py:8255`; the box's mode is the shipped `interrupt`, `config_defaults.py:1275`). It matters because `expired` is precisely the acknowledgement that says the worker has left `ev.wait()` and is running again: a plain submit at that instant would interrupt the very turn the customer is waiting to read.

A batch is answered on the first question still outstanding, never with an empty `question_id`: `_respond` takes the batch branch only when one is present (`server.py:11911`), so an answer without it fires the Event immediately and `_block` (`server.py:3524`) discards every answer locked so far, silently, under a `status: ok`. When every question is already answered nothing is forwarded and the old path runs.

A **multi-select** question gets the message wrapped as a one-element JSON array — the same encoding the card sends and the same one Hermes' channel path emits (`clarify_gateway.py:425`). Sent as prose it would hit the decoder's comma-split fallback (`tools/clarify_tool.py:162`, which never looks at the offered choices), so "the second one, I think" would reach the agent as two selections nobody offered.

**2. `scripts/register-mcp.sh` — the backstop window.**
The rendered Hermes config (the script that reconciles `~/.hermes/config.yaml` at setup and at every web-server boot) now seeds `agent.clarify_timeout: 300` — a real number, written in PyYAML, because `hermes config set` stores a scalar as a string. **Seeded, not pinned:** written only when the owner has set neither `agent.clarify_timeout` nor the legacy `clarify.timeout` that wins over it in Hermes' own resolver. It is a backstop, not the fix — with (1) in place it only decides how long a session that hears *nothing at all* stays parked. 300 s is also Hermes' own emergency fallback for this number (`server.py:3578`).

## Siblings

* `POST /setup-api/hermes/chat/clarify` — unchanged by design: it is the card's answer path, on its own socket, and it can answer after the streaming request has died.
* `respondToClarify()` on the turn — unchanged; with the route it is still the only other `clarify.respond` sender in the tree (`prompt.submit` has exactly one sender).
* **Channels on Hermes** — nothing to do: Telegram/WhatsApp/Discord/Slack answer a pending clarify natively (citations above), on a registry ClawBox does not touch. Noted upstream for the record: a batch degrades to one question per round trip on a channel (`tools/clarify_tool.py:294`, `:316`), and `register_notify`/`unregister_notify` (`clarify_gateway.py:588`) are a dead seam.
* **The CLI fallback transport** (`hermes chat -q --resume`, used for image turns and when the dashboard cannot be reached) — cannot answer a clarify and is now documented where the branch is chosen: it is a separate process with its own agent, `--resume` is a database-row read rather than a live attach (`cli.py:8667`), and the parked `threading.Event` is process-local (`server.py:3494`). There is no `clarify` subcommand among the CLI's 70 and no HTTP endpoint for it either — the WebSocket `/api/ws` (`hermes_cli/web_server.py:17134`) or stdio is the only door. A turn that falls to that path while the gateway holds a parked session leaves it parked; that is now bounded by the 300 s window from (2) instead of an hour.
* **OpenClaw / dual editions** — `register-mcp.sh` exits before any of this on an OpenClaw box, and the dashboard turn is Hermes-only. Nothing here runs or breaks there, and there is no control to hide.

## RED → GREEN

RED, on unmodified beta (`4e2215b8`):

```
 ❯ src/tests/unit/hermes-dashboard-turn-clarify.test.ts (24 tests | 4 failed)
     × forwards the message as the ANSWER instead of replaying the question
     × shows the question as answered by that message, once the gateway says so
     × names the first UNANSWERED question of a batch, and keeps the rest askable
     × takes the card down and sends the message as a prompt when the window had closed

AssertionError: expected undefined to be defined
 ❯ src/tests/unit/hermes-dashboard-turn-clarify.test.ts:639:20
    638|     const answer = socket.method("clarify.respond");
    639|     expect(answer).toBeDefined();

 ❯ src/tests/unit/register-mcp-hermes.test.ts (31 tests | 2 failed)
     × pins agent.clarify_timeout to 300 on a config that never set it
     × keeps the rest of the agent block untouched

AssertionError: expected undefined to be 300 // Object.is equality
 ❯ src/tests/unit/register-mcp-hermes.test.ts:361:42
    361|     expect(agentBlock().clarify_timeout).toBe(300);
```

GREEN, with the fix — the new tests, the neighbouring suites, and the whole unit tree:

```
 Test Files  5 passed (5)        # turn-clarify, register-mcp, chat-clarify component, chat clarify + streaming routes
      Tests  108 passed (108)

 Test Files  395 passed (395)    # src/tests/unit + the hermes route suites + components
      Tests  6641 passed (6641)

tsc --noEmit: clean · eslint on the touched files: clean · bash -n scripts/register-mcp.sh: clean
```

## Reproducing it on a box

The composer queues a message while a run is in flight, so typing under a clarify card that is still streaming will not exercise this path — that text drains as an ordinary prompt when the turn ends. The fix fires when the previous stream has already ended and the agent is still parked: reload the tab (or press Stop), then type the answer.

## Not proven here

* **The device leg is read-only.** Every upstream citation above was read off the Hermes box, but the end-to-end behaviour — park a clarify, reload, type, watch the agent answer — was not exercised on hardware in this PR. No box was mutated. CI is the arbiter for the suites.
* **One residual, named where it lives** (`chat/route.ts`, the quiet-stream recovery): a forwarded answer writes no user row, so `readHermesTurn`'s "everything after the last user row" slice starts at the earlier prompt on that turn. If such a turn goes quiet *before* the resumed agent has written anything, the recovery can hand back what the agent said before it asked its question. Bounded to that customer's own session, and the same rows are what the settled turn shows when the stream does complete — which is why `settleTurn` is deliberately left alone. Telling the two apart needs a snapshot of the record taken before the answer is forwarded; that is a change to the route's read pattern and is not made here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of pending clarification questions, including multi-question and multi-select responses.
  - Preserved partially answered clarification prompts and queued original messages after refusal or expiration.
  - Added a default 300-second clarification timeout when no existing setting is configured.

- **Bug Fixes**
  - Improved replayed clarification state, answer acknowledgements, duplicate prevention, and fallback message handling.
  - Prevented invalid question identifiers from being treated as answered.
  - Preserved existing configuration values and safely handled malformed settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->