### PR TITLE
fix: a config set killed at its deadline is settled by the config on disk, not assumed failed

### DIFF
--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -32,6 +32,7 @@
 
 import {
   type SpawnOpenclawOptions,
+  OpenclawSpawnTimeoutError,
   openclawIsAbsent,
   readConfig,
   spawnOpenclawCli,
@@ -147,9 +148,9 @@ async function pluginEnabledInConfig(pluginId: string): Promise<boolean> {
   }
 }
 
-/** A timeout from spawnOpenclawCli names itself; nothing else does. */
+/** A spawn killed at its deadline, by type — the message is not the contract. */
 function isTimeout(err: unknown): boolean {
-  return err instanceof Error && /timed out after \d+ms/.test(err.message);
+  return err instanceof OpenclawSpawnTimeoutError;
 }
 
 /**

--- a/src/lib/openclaw-channels.ts
+++ b/src/lib/openclaw-channels.ts
@@ -148,6 +148,12 @@ async function pluginEnabledInConfig(pluginId: string): Promise<boolean> {
   }
 }
 
+// Answering FALSE to everything it cannot read is load-bearing in BOTH uses of
+// the function above, and neither tolerates the opposite: as the precondition
+// it means an unreadable config runs the idempotent enable instead of skipping
+// it, and as the read-back after a killed enable it means only an entry this
+// process can SEE forgives the kill.
+
 /** A spawn killed at its deadline, by type — the message is not the contract. */
 function isTimeout(err: unknown): boolean {
   return err instanceof OpenclawSpawnTimeoutError;
@@ -246,8 +252,26 @@ export async function ensureChannelPlugin(
         timeoutMs: PLUGIN_QUERY_TIMEOUT_MS,
       });
     } catch (err) {
-      console.error(`[openclaw-channels] enabling the ${channelId} plugin failed:`, err);
-      return { ok: false, reason: "install_failed" };
+      // A SIGKILL at the deadline is the one failure that says nothing about
+      // whether the write happened. `plugins enable` writes
+      // `plugins.entries.<id>.enabled` and THEN spends seconds loading the
+      // gateway SDK, so on a Jetson the entry lands inside the 45 s window we
+      // kill in — and this used to answer `install_failed`, which reaches the
+      // owner as "the plugin could not be installed" over a channel that is
+      // enabled on disk. The same read-back the precondition just used settles
+      // it, and it fails closed, so an unreadable config keeps the failure.
+      //
+      // Only the ENABLE. A killed `plugins install` is not settled by this
+      // entry: the npm package landing on disk is the other half of that verb,
+      // and the config entry alone would bless an install that never finished.
+      if (isTimeout(err) && (await pluginEnabledInConfig(pluginId))) {
+        console.warn(
+          `[openclaw-channels] enabling ${spec} was killed at its deadline, but the entry is in openclaw.json — the enable landed`,
+        );
+      } else {
+        console.error(`[openclaw-channels] enabling the ${channelId} plugin failed:`, err);
+        return { ok: false, reason: "install_failed" };
+      }
     }
   }
 

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -121,7 +121,7 @@ export async function runOpenclawConfigSet(
   args: string[],
   options: OpenclawConfigSetOptions = {},
 ): Promise<void> {
-  await runConfigSetVerified([args], () =>
+  await runConfigSetVerified([args], options, () =>
     withConfigMutationRetry(
       (timeoutMs) => spawnOpenclawConfigSet(args, { ...options, timeoutMs }),
       options,
@@ -148,7 +148,7 @@ async function withConfigMutationRetry(
   label: string,
 ): Promise<void> {
   const {
-    timeoutMs = 30_000,
+    timeoutMs = DEFAULT_SPAWN_TIMEOUT_MS,
     maxAttempts = 4,
     baseBackoffMs = 100,
   } = options;
@@ -175,7 +175,7 @@ async function withConfigMutationRetry(
 }
 
 export interface SpawnOpenclawOptions {
-  /** Per-call timeout in ms. Default 30_000 (Jetson CLI cold-start is ~10-12s). */
+  /** Per-call timeout in ms. Default {@link DEFAULT_SPAWN_TIMEOUT_MS}. */
   timeoutMs?: number;
   /** Capture and resolve stdout (needed to read `--json` output). Default false. */
   captureStdout?: boolean;
@@ -216,7 +216,7 @@ function spawnOpenclaw(args: string[], options: SpawnOpenclawOptions = {}): Prom
   }
   const bin = findOpenclawBin();
   const { uid, gid, captureStdout = false, stdinData } = options;
-  const timeoutMs = options.timeoutMs ?? 30_000;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS;
   const cwd = options.cwd ?? process.env.HOME ?? "/home/clawbox";
   const env = { HOME: "/home/clawbox", ...process.env, ...(options.env ?? {}) };
   const label = `${bin} ${(options.labelArgs ?? args).join(" ")}`;
@@ -307,6 +307,9 @@ export function spawnOpenclawCli(
 /** Bound on the gateway round trip itself; the spawn budget adds the CLI's own start-up on top. */
 const GATEWAY_RPC_TIMEOUT_MS = 20_000;
 const GATEWAY_RPC_SPAWN_ALLOWANCE_MS = 30_000;
+
+/** Default per-call deadline. A Jetson CLI cold start is ~10-12s. */
+const DEFAULT_SPAWN_TIMEOUT_MS = 30_000;
 
 /** How long a SIGKILLed child is given to actually exit before we answer anyway. */
 const KILL_REAP_WAIT_MS = 1_000;
@@ -441,7 +444,8 @@ export function parseConfigSetArgs(args: OpenclawConfigSetArgs): { path: string;
  * `.` separates, and a bracket-quoted segment is ONE key however many dots it
  * contains — `agents.defaults.models["openai/gpt-5.5"].agentRuntime.id`, the
  * Codex runtime arm, is the path that made this necessary. Null for anything
- * else (an unterminated bracket, an unquoted index, an empty segment), because
+ * else (an unterminated bracket, an unquoted index, an empty DOTTED segment —
+ * `[""]` is a legal key and parses as one), because
  * the only caller uses this to decide that a write it did not see finish
  * actually landed, and a path it cannot read must not become that claim.
  */
@@ -481,11 +485,18 @@ function configPathSegments(configPath: string): string[] | null {
   return segments.length > 0 ? segments : null;
 }
 
-/** The value at a dotted config path, or `undefined` when the path is absent. */
+/**
+ * The value at a dotted config path, or `undefined` when the path is absent.
+ *
+ * OWN properties only. A plain `current[segment]` walks the prototype chain, so
+ * `constructor` or `toString` would answer with something that is not in
+ * `openclaw.json` — and the one job here is to say what the file holds.
+ */
 function valueAtConfigPath(config: unknown, segments: readonly string[]): unknown {
   let current: unknown = config;
   for (const segment of segments) {
     if (!isPlainObject(current)) return undefined;
+    if (!Object.hasOwn(current, segment)) return undefined;
     current = (current as Record<string, unknown>)[segment];
   }
   return current;
@@ -494,13 +505,16 @@ function valueAtConfigPath(config: unknown, segments: readonly string[]): unknow
 /**
  * The config areas this module is willing to NAME in a log line.
  *
- * A config path is caller text. `POST /setup-api/chat/model` builds one out of
- * the model reference in its request body (`chatgptRuntimeEntryPath`) and
- * `POST /setup-api/tts` out of the voice provider — the two sources CodeQL
- * traced into the journal line below (js/log-injection, alert #473). Escaping
- * that text is not enough to make the record ours: a caller who chooses the
- * content, and with it the length, of what one API call writes to the journal
- * can forge entries inside a line as well as across two.
+ * A config path is caller text. The two request bodies CodeQL traced into the
+ * journal line below (js/log-injection, alert #473) are `POST
+ * /setup-api/chat/model`, whose model reference becomes
+ * `agents.defaults.models[<ref>].agentRuntime` through
+ * `chatgptRuntimeEntryPath`, and `POST /setup-api/tts`, whose provider id
+ * becomes `<tts|messages.tts>.providers.<id>.voice`. (`models.providers.<id>`
+ * is the same shape, from `POST /setup-api/ai-models/configure`.) Escaping that
+ * text is not enough to make the record ours: a caller who chooses the content,
+ * and with it the length, of what one API call writes to the journal can forge
+ * entries inside a line as well as across two.
  *
  * So the path is mapped onto one of these literals and the caller's own text
  * never reaches the line. The write is still diagnosable — which subsystem was
@@ -510,6 +524,7 @@ function valueAtConfigPath(config: unknown, segments: readonly string[]): unknow
 const LOGGED_CONFIG_AREAS = [
   "agents",
   "channels",
+  "gateway",
   "memory",
   "messages",
   "models",
@@ -595,6 +610,7 @@ async function configSetLanded(batch: readonly OpenclawConfigSetArgs[]): Promise
  */
 async function runConfigSetVerified(
   batch: readonly OpenclawConfigSetArgs[],
+  options: OpenclawConfigSetOptions,
   attempt: () => Promise<void>,
 ): Promise<void> {
   try {
@@ -604,10 +620,12 @@ async function runConfigSetVerified(
     if (!(await configSetLanded(batch))) throw err;
     // Not `err.message`: the spawn label carries the caller's config path. (The
     // VALUES are already elided by configSetLabelArgs / configSetBatchLabelArgs;
-    // the paths are not, and they are the half built from a request body.)
+    // the paths are not, and they are the half built from a request body.) The
+    // deadline is read off the caller's options and NOT off the error, every
+    // field of which hangs on an object built from that same path.
     const areas = loggedConfigAreas(batch.map(configSetEntryPath));
     console.warn(
-      `[openclaw-config] a config set (${areas}) was killed at its deadline, but every assignment is on disk — the write landed, reporting success`,
+      `[openclaw-config] a config set (${areas}) was killed at its ${options.timeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS}ms deadline, but every assignment is on disk — the write landed, reporting success`,
     );
   }
 }
@@ -651,7 +669,7 @@ export function configSetBatchLabelArgs(batch: readonly OpenclawConfigSetArgs[])
     "config",
     "set",
     "--batch-json",
-    `[${batch.map((args) => `${args.filter((arg) => !arg.startsWith("--"))[0] ?? "<no path>"}=<redacted>`).join(",")}]`,
+    `[${batch.map((args) => `${configSetEntryPath(args) || "<no path>"}=<redacted>`).join(",")}]`,
   ];
 }
 
@@ -686,7 +704,7 @@ export async function runOpenclawConfigSetBatch(
     return;
   }
   const payload = JSON.stringify(batch.map(parseConfigSetArgs));
-  await runConfigSetVerified(batch, () =>
+  await runConfigSetVerified(batch, options, () =>
     withConfigMutationRetry(
       (timeoutMs) =>
         spawnOpenclaw(["config", "set", "--batch-json", payload], {
@@ -745,7 +763,7 @@ export async function runOpenclawConfigUnset(
     if (!(await configUnsetLanded(configPath))) throw err;
     // The path is the caller's text here too — see {@link LOGGED_CONFIG_AREAS}.
     console.warn(
-      `[openclaw-config] a config unset (${loggedConfigAreas([configPath])}) was killed at its deadline, but the path is gone from the config — the removal landed, reporting success`,
+      `[openclaw-config] a config unset (${loggedConfigAreas([configPath])}) was killed at its ${options.timeoutMs ?? DEFAULT_SPAWN_TIMEOUT_MS}ms deadline, but the path is gone from the config — the removal landed, reporting success`,
     );
   }
 }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -15,7 +15,6 @@ import { get as getConfigStoreValue } from "@/lib/config-store";
 import { DISABLED_PROVIDERS_KEY, parseDisabledProviders } from "@/lib/provider-status";
 import { ANTHROPIC_PLUGIN_ENABLED_KEY } from "@/lib/provider-plugin-ops";
 import { isSafeDiscordToken } from "@/lib/discord-api";
-import { logSafe } from "@/lib/log-safe";
 
 const exec = promisify(execFile);
 
@@ -493,6 +492,61 @@ function valueAtConfigPath(config: unknown, segments: readonly string[]): unknow
 }
 
 /**
+ * The config areas this module is willing to NAME in a log line.
+ *
+ * A config path is caller text. `POST /setup-api/chat/model` builds one out of
+ * the model reference in its request body (`chatgptRuntimeEntryPath`) and
+ * `POST /setup-api/tts` out of the voice provider — the two sources CodeQL
+ * traced into the journal line below (js/log-injection, alert #473). Escaping
+ * that text is not enough to make the record ours: a caller who chooses the
+ * content, and with it the length, of what one API call writes to the journal
+ * can forge entries inside a line as well as across two.
+ *
+ * So the path is mapped onto one of these literals and the caller's own text
+ * never reaches the line. The write is still diagnosable — which subsystem was
+ * being configured is the part an operator reads — and a path under anything
+ * else is named "other" rather than quoted.
+ */
+const LOGGED_CONFIG_AREAS = [
+  "agents",
+  "channels",
+  "memory",
+  "messages",
+  "models",
+  "plugins",
+  "tools",
+  "tts",
+] as const;
+
+/**
+ * The path a `config set` entry assigns: the first non-flag argv element, the
+ * same rule {@link parseConfigSetArgs} reads it by. Total where that one throws
+ * — an entry this cannot read yields `""`, which {@link loggedConfigAreas}
+ * names "other". A log line describing a success must not be able to turn it
+ * into a failure.
+ */
+function configSetEntryPath(args: OpenclawConfigSetArgs): string {
+  return args.find((arg) => !arg.startsWith("--")) ?? "";
+}
+
+/**
+ * Name the areas some config paths write to, using only the literals above.
+ *
+ * `find`, not a membership test: what is returned is the element of
+ * {@link LOGGED_CONFIG_AREAS}, so nothing derived from the caller's path is
+ * what gets logged. `LOGGED_CONFIG_AREAS.includes(root) ? root : "other"` would
+ * read the same and put the request's text straight back into the record.
+ */
+function loggedConfigAreas(configPaths: readonly string[]): string {
+  const areas = new Set<string>();
+  for (const configPath of configPaths) {
+    const root = configPathSegments(configPath)?.[0];
+    areas.add(LOGGED_CONFIG_AREAS.find((area) => area === root) ?? "other");
+  }
+  return [...areas].sort().join(", ");
+}
+
+/**
  * Did the assignments of a killed `config set` actually reach the file?
  *
  * Measured on the OpenClaw box (TASK-654): `POST /setup-api/chat/model`
@@ -548,14 +602,12 @@ async function runConfigSetVerified(
   } catch (err) {
     if (!(err instanceof OpenclawSpawnTimeoutError)) throw err;
     if (!(await configSetLanded(batch))) throw err;
-    // logSafe, not the raw message: a config PATH can be built from request
-    // input (`chatgptRuntimeEntryPath(modelRef)`, `models.providers.<provider>`)
-    // and rides into `err.message` through the spawn label. Unbounded and
-    // un-escaped, that would let a caller decide how many journal records one
-    // API call produces (CWE-117). The VALUES are already elided by
-    // configSetLabelArgs / configSetBatchLabelArgs.
+    // Not `err.message`: the spawn label carries the caller's config path. (The
+    // VALUES are already elided by configSetLabelArgs / configSetBatchLabelArgs;
+    // the paths are not, and they are the half built from a request body.)
+    const areas = loggedConfigAreas(batch.map(configSetEntryPath));
     console.warn(
-      `[openclaw-config] ${logSafe(err.message)}; every assignment is on disk, so the write landed — reporting success`,
+      `[openclaw-config] a config set (${areas}) was killed at its deadline, but every assignment is on disk — the write landed, reporting success`,
     );
   }
 }
@@ -691,8 +743,9 @@ export async function runOpenclawConfigUnset(
   } catch (err) {
     if (!(err instanceof OpenclawSpawnTimeoutError)) throw err;
     if (!(await configUnsetLanded(configPath))) throw err;
+    // The path is the caller's text here too — see {@link LOGGED_CONFIG_AREAS}.
     console.warn(
-      `[openclaw-config] ${logSafe(err.message)}; the path is gone from the config, so the removal landed — reporting success`,
+      `[openclaw-config] a config unset (${loggedConfigAreas([configPath])}) was killed at its deadline, but the path is gone from the config — the removal landed, reporting success`,
     );
   }
 }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -15,6 +15,7 @@ import { get as getConfigStoreValue } from "@/lib/config-store";
 import { DISABLED_PROVIDERS_KEY, parseDisabledProviders } from "@/lib/provider-status";
 import { ANTHROPIC_PLUGIN_ENABLED_KEY } from "@/lib/provider-plugin-ops";
 import { isSafeDiscordToken } from "@/lib/discord-api";
+import { logSafe } from "@/lib/log-safe";
 
 const exec = promisify(execFile);
 
@@ -547,8 +548,14 @@ async function runConfigSetVerified(
   } catch (err) {
     if (!(err instanceof OpenclawSpawnTimeoutError)) throw err;
     if (!(await configSetLanded(batch))) throw err;
+    // logSafe, not the raw message: a config PATH can be built from request
+    // input (`chatgptRuntimeEntryPath(modelRef)`, `models.providers.<provider>`)
+    // and rides into `err.message` through the spawn label. Unbounded and
+    // un-escaped, that would let a caller decide how many journal records one
+    // API call produces (CWE-117). The VALUES are already elided by
+    // configSetLabelArgs / configSetBatchLabelArgs.
     console.warn(
-      `[openclaw-config] ${err.message}; every assignment is on disk, so the write landed — reporting success`,
+      `[openclaw-config] ${logSafe(err.message)}; every assignment is on disk, so the write landed — reporting success`,
     );
   }
 }
@@ -685,7 +692,7 @@ export async function runOpenclawConfigUnset(
     if (!(err instanceof OpenclawSpawnTimeoutError)) throw err;
     if (!(await configUnsetLanded(configPath))) throw err;
     console.warn(
-      `[openclaw-config] ${err.message}; the path is gone from the config, so the removal landed — reporting success`,
+      `[openclaw-config] ${logSafe(err.message)}; the path is gone from the config, so the removal landed — reporting success`,
     );
   }
 }

--- a/src/lib/openclaw-config.ts
+++ b/src/lib/openclaw-config.ts
@@ -6,7 +6,7 @@ import fsSync from "fs";
 import path from "path";
 import { execFile, spawn } from "child_process";
 import { randomUUID } from "crypto";
-import { promisify } from "util";
+import { isDeepStrictEqual, promisify } from "util";
 import { getLlamaCppProxyBaseUrl } from "@/lib/llamacpp";
 import { getLocalAiProxyRootUrl } from "@/lib/local-ai-proxy-url";
 import { readEdition } from "@/lib/edition-source";
@@ -31,6 +31,24 @@ export class OpenclawUnavailableError extends Error {
   constructor(message = "The OpenClaw CLI is not available on this edition.") {
     super(message);
     this.name = "OpenclawUnavailableError";
+  }
+}
+
+/**
+ * The CLI was still running at its deadline and was SIGKILLed.
+ *
+ * A distinct type because it says something the other spawn failures do not:
+ * NOTHING was observed. An exit code is the CLI's own answer — 0 wrote, 1
+ * refused — but a kill leaves the question open, and `openclaw config set`
+ * writes the config early and then spends seconds validating catalogs, so on a
+ * Jetson the value routinely lands inside the window we kill in. Callers that
+ * know what they asked for read the config back rather than guessing (see
+ * {@link runOpenclawConfigSet}).
+ */
+export class OpenclawSpawnTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenclawSpawnTimeoutError";
   }
 }
 
@@ -90,15 +108,25 @@ export interface OpenclawConfigSetOptions {
  * This helper retries *only* on that specific error (other failures bubble
  * up immediately) with a short linear backoff, so callers don't need to
  * handle the race individually.
+ *
+ * ONE failure is not simply rethrown: a spawn killed at its deadline. The CLI
+ * writes the config early and then spends seconds validating catalogs, so on a
+ * Jetson the value lands inside the window we kill in — and a SIGKILL carries
+ * no exit code to read. The assignments are looked for in the config on disk,
+ * and only a write this process can SEE there is reported as success; every
+ * other failure, including an unreadable config, still throws. See
+ * {@link configSetLanded}.
  */
 export async function runOpenclawConfigSet(
   args: string[],
   options: OpenclawConfigSetOptions = {},
 ): Promise<void> {
-  await withConfigMutationRetry(
-    (timeoutMs) => spawnOpenclawConfigSet(args, { ...options, timeoutMs }),
-    options,
-    "runOpenclawConfigSet",
+  await runConfigSetVerified([args], () =>
+    withConfigMutationRetry(
+      (timeoutMs) => spawnOpenclawConfigSet(args, { ...options, timeoutMs }),
+      options,
+      "runOpenclawConfigSet",
+    ),
   );
 }
 
@@ -109,6 +137,10 @@ export async function runOpenclawConfigSet(
  * so both forms of the write survive the same race. Any other failure is
  * rethrown on the first try — a schema rejection does not become valid by
  * being repeated.
+ *
+ * Retrying is all this does. A rethrown timeout is then settled by the config
+ * on disk, one level up in {@link runConfigSetVerified}, because a SIGKILL is
+ * the only failure that carries no answer about whether the write happened.
  */
 async function withConfigMutationRetry(
   attemptFn: (timeoutMs: number) => Promise<void>,
@@ -216,11 +248,25 @@ function spawnOpenclaw(args: string[], options: SpawnOpenclawOptions = {}): Prom
     }
 
     const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        child.kill("SIGKILL");
-        reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-      }
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      // `kill(2)` returns when the signal is QUEUED, not when the process is
+      // gone, and a `config set` sitting in its final rename can still land the
+      // write. The caller reads the config back to decide whether a killed
+      // write landed, so answering before the child is reaped would read the
+      // file on the wrong side of that rename. Bounded: a process that will not
+      // die must not hold the request open either.
+      const error = new OpenclawSpawnTimeoutError(`${label} timed out after ${timeoutMs}ms`);
+      let answered = false;
+      const answer = () => {
+        if (answered) return;
+        answered = true;
+        clearTimeout(reapTimer);
+        reject(error);
+      };
+      const reapTimer = setTimeout(answer, KILL_REAP_WAIT_MS);
+      child.once("close", answer);
     }, timeoutMs);
 
     child.on("error", (err) => {
@@ -261,6 +307,9 @@ export function spawnOpenclawCli(
 /** Bound on the gateway round trip itself; the spawn budget adds the CLI's own start-up on top. */
 const GATEWAY_RPC_TIMEOUT_MS = 20_000;
 const GATEWAY_RPC_SPAWN_ALLOWANCE_MS = 30_000;
+
+/** How long a SIGKILLed child is given to actually exit before we answer anyway. */
+const KILL_REAP_WAIT_MS = 1_000;
 
 /**
  * One gateway RPC through the CLI: `openclaw gateway call <method> --params
@@ -386,6 +435,149 @@ export function parseConfigSetArgs(args: OpenclawConfigSetArgs): { path: string;
 }
 
 /**
+ * Split a `config set` path into the segments the CLI addresses, or null when
+ * this code cannot say for certain what they are.
+ *
+ * `.` separates, and a bracket-quoted segment is ONE key however many dots it
+ * contains — `agents.defaults.models["openai/gpt-5.5"].agentRuntime.id`, the
+ * Codex runtime arm, is the path that made this necessary. Null for anything
+ * else (an unterminated bracket, an unquoted index, an empty segment), because
+ * the only caller uses this to decide that a write it did not see finish
+ * actually landed, and a path it cannot read must not become that claim.
+ */
+function configPathSegments(configPath: string): string[] | null {
+  const segments: string[] = [];
+  let i = 0;
+  while (i < configPath.length) {
+    if (configPath[i] === "[") {
+      const quote = configPath[i + 1];
+      if (quote !== '"' && quote !== "'") return null;
+      const end = configPath.indexOf(`${quote}]`, i + 2);
+      if (end < 0) return null;
+      const segment = configPath.slice(i + 2, end);
+      // The CLI builds these with JSON.stringify, so a quoted segment can carry
+      // escapes; this reader does not unescape, and a segment it would match
+      // against the wrong key must be a null rather than a guess.
+      if (segment.includes("\\")) return null;
+      segments.push(segment);
+      i = end + 2;
+    } else {
+      const rest = configPath.slice(i);
+      const dot = rest.indexOf(".");
+      const bracket = rest.indexOf("[");
+      const stops = [dot, bracket].filter((n) => n >= 0);
+      const end = i + (stops.length ? Math.min(...stops) : rest.length);
+      if (end === i) return null;
+      segments.push(configPath.slice(i, end));
+      i = end;
+    }
+    if (configPath[i] === ".") {
+      i += 1;
+      if (i === configPath.length) return null; // trailing separator
+    } else if (i < configPath.length && configPath[i] !== "[") {
+      return null;
+    }
+  }
+  return segments.length > 0 ? segments : null;
+}
+
+/** The value at a dotted config path, or `undefined` when the path is absent. */
+function valueAtConfigPath(config: unknown, segments: readonly string[]): unknown {
+  let current: unknown = config;
+  for (const segment of segments) {
+    if (!isPlainObject(current)) return undefined;
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+/**
+ * Did the assignments of a killed `config set` actually reach the file?
+ *
+ * Measured on the OpenClaw box (TASK-654): `POST /setup-api/chat/model`
+ * answered 500 with `openclaw config set agents.defaults.model.primary
+ * <redacted> timed out after 30000ms` — and `agents.defaults.model.primary`
+ * was the new model. The owner was told the switch failed over a switch that
+ * had happened.
+ *
+ * The read is STRICT and every failure answers false: an EACCES or a file
+ * caught half-written proves nothing, and `readConfig`'s `{}` for those would
+ * be indistinguishable from a config that genuinely lacks the value. False
+ * here means the caller's original timeout is rethrown, which is the safe
+ * direction — a real failure stays a failure, and only a write this process
+ * can SEE on disk is forgiven.
+ */
+async function configSetLanded(batch: readonly OpenclawConfigSetArgs[]): Promise<boolean> {
+  let config: OpenClawConfig;
+  try {
+    config = await readConfigStrict();
+  } catch {
+    return false;
+  }
+  for (const args of batch) {
+    let entry: { path: string; value: unknown };
+    try {
+      entry = parseConfigSetArgs(args);
+    } catch {
+      return false;
+    }
+    const segments = configPathSegments(entry.path);
+    if (!segments) return false;
+    if (!isDeepStrictEqual(valueAtConfigPath(config, segments), entry.value)) return false;
+  }
+  return true;
+}
+
+/**
+ * Run a `config set` and, if it is killed at its deadline, let the config on
+ * disk settle whether it landed.
+ *
+ * A SIGKILL is the one failure that carries no answer, and this is the only
+ * place that can ask the question cheaply: the CLI has already been paid for,
+ * and `readConfigStrict` is a file read. Every other failure — an exit code, a
+ * spawn error, `OpenclawUnavailableError` — is the CLI's own verdict and is
+ * rethrown untouched.
+ */
+async function runConfigSetVerified(
+  batch: readonly OpenclawConfigSetArgs[],
+  attempt: () => Promise<void>,
+): Promise<void> {
+  try {
+    await attempt();
+  } catch (err) {
+    if (!(err instanceof OpenclawSpawnTimeoutError)) throw err;
+    if (!(await configSetLanded(batch))) throw err;
+    console.warn(
+      `[openclaw-config] ${err.message}; every assignment is on disk, so the write landed — reporting success`,
+    );
+  }
+}
+
+/**
+ * The unset half of {@link configSetLanded}: is the path gone from the file?
+ *
+ * Same deadline, same kill, same false failure — a removal reported as a
+ * failure sends the caller to repair what is already repaired (the configure
+ * route answers 502 and tells the owner to run the command by hand). An
+ * unreadable config still answers false, for the reason given there.
+ */
+async function configUnsetLanded(configPath: string): Promise<boolean> {
+  const segments = configPathSegments(configPath);
+  if (!segments) return false;
+  // An ABSENT config answers `{}` from readConfigStrict, and "the path is not
+  // in `{}`" is not evidence of a removal — it is the one shape where the
+  // "every failure answers false" rule would otherwise fail OPEN. The callers
+  // only unset a path they have just seen, so a file that is now missing is a
+  // state to report, not to bless.
+  if (!fsSync.existsSync(CONFIG_PATH)) return false;
+  try {
+    return valueAtConfigPath(await readConfigStrict(), segments) === undefined;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Argv for a batched `config set`, with every *value* elided, for use in a log
  * line — the batch counterpart of {@link configSetLabelArgs}.
  *
@@ -435,18 +627,20 @@ export async function runOpenclawConfigSetBatch(
     return;
   }
   const payload = JSON.stringify(batch.map(parseConfigSetArgs));
-  await withConfigMutationRetry(
-    (timeoutMs) =>
-      spawnOpenclaw(["config", "set", "--batch-json", payload], {
-        labelArgs: configSetBatchLabelArgs(batch),
-        timeoutMs,
-        uid: options.uid,
-        gid: options.gid,
-        cwd: options.cwd,
-        env: options.env,
-      }).then(() => undefined),
-    options,
-    "runOpenclawConfigSetBatch",
+  await runConfigSetVerified(batch, () =>
+    withConfigMutationRetry(
+      (timeoutMs) =>
+        spawnOpenclaw(["config", "set", "--batch-json", payload], {
+          labelArgs: configSetBatchLabelArgs(batch),
+          timeoutMs,
+          uid: options.uid,
+          gid: options.gid,
+          cwd: options.cwd,
+          env: options.env,
+        }).then(() => undefined),
+      options,
+      "runOpenclawConfigSetBatch",
+    ),
   );
 }
 
@@ -464,23 +658,36 @@ export async function runOpenclawConfigSetBatch(
  * CLI exits 1 with "Config path not found: <path>. Nothing was changed." when
  * the path is absent. Callers must check the config first and only unset a path
  * that is actually there, so a real removal failure stays loud.
+ *
+ * Like {@link runOpenclawConfigSet}, a spawn killed at its deadline is settled
+ * by the file rather than assumed failed: the removal is reported as done only
+ * when the path is provably gone from a config this process could read. See
+ * {@link configUnsetLanded}.
  */
 export async function runOpenclawConfigUnset(
   configPath: string,
   options: OpenclawConfigSetOptions = {},
 ): Promise<void> {
-  await withConfigMutationRetry(
-    (timeoutMs) =>
-      spawnOpenclaw(["config", "unset", configPath], {
-        timeoutMs,
-        uid: options.uid,
-        gid: options.gid,
-        cwd: options.cwd,
-        env: options.env,
-      }).then(() => undefined),
-    options,
-    "runOpenclawConfigUnset",
-  );
+  try {
+    await withConfigMutationRetry(
+      (timeoutMs) =>
+        spawnOpenclaw(["config", "unset", configPath], {
+          timeoutMs,
+          uid: options.uid,
+          gid: options.gid,
+          cwd: options.cwd,
+          env: options.env,
+        }).then(() => undefined),
+      options,
+      "runOpenclawConfigUnset",
+    );
+  } catch (err) {
+    if (!(err instanceof OpenclawSpawnTimeoutError)) throw err;
+    if (!(await configUnsetLanded(configPath))) throw err;
+    console.warn(
+      `[openclaw-config] ${err.message}; the path is gone from the config, so the removal landed — reporting success`,
+    );
+  }
 }
 
 export const OPENCLAW_HOME = process.env.CLAWBOX_OPENCLAW_HOME

--- a/src/lib/openclaw-whatsapp.ts
+++ b/src/lib/openclaw-whatsapp.ts
@@ -33,7 +33,7 @@
 // device credentials in the plugin's auth dir, not a bot token, so there is no
 // env-backed credential here and nothing for envSecretRef() to mint.
 
-import { spawnOpenclawCli } from "@/lib/openclaw-config";
+import { runOpenclawConfigSet, spawnOpenclawCli } from "@/lib/openclaw-config";
 import { invalidateChannelStatus, readCachedChannelRowResult } from "@/lib/openclaw-channels";
 
 /** OpenClaw's id for this channel — the plugin's, the config key's, the CLI's. */
@@ -476,9 +476,17 @@ export async function readOpenclawWhatsappStatus(): Promise<OpenclawWhatsappStat
   };
 }
 
-/** Turn `channels.whatsapp` on or off, leaving every other key alone. */
+/**
+ * Turn `channels.whatsapp` on or off, leaving every other key alone.
+ *
+ * Through `runOpenclawConfigSet`, not a bare spawn: this is a config WRITE, so
+ * it owes the same conflict retry and the same read-back after a kill as every
+ * other one. On its own spawn the CLI could be SIGKILLed at 45 s having already
+ * written the key, and the owner was told the save failed over a channel that
+ * is now enabled.
+ */
 export async function setOpenclawWhatsappEnabled(enabled: boolean): Promise<void> {
-  await spawnOpenclawCli(["config", "set", "channels.whatsapp.enabled", String(enabled), "--json"], {
+  await runOpenclawConfigSet(["channels.whatsapp.enabled", String(enabled), "--json"], {
     timeoutMs: 45_000,
   });
   // `enabled` is half of what the status reads, so a remembered row is now a

--- a/src/tests/unit/openclaw-channel-plugins.test.ts
+++ b/src/tests/unit/openclaw-channel-plugins.test.ts
@@ -31,7 +31,7 @@ vi.mock("@/lib/openclaw-config", async () => {
   };
 });
 
-import { readConfig, spawnOpenclawCli } from "@/lib/openclaw-config";
+import { OpenclawSpawnTimeoutError, readConfig, spawnOpenclawCli } from "@/lib/openclaw-config";
 
 const mockSpawn = vi.mocked(spawnOpenclawCli);
 const mockReadConfig = vi.mocked(readConfig);
@@ -208,9 +208,17 @@ describe("ensureChannelPlugin", () => {
   });
 
   it("reports install_timeout distinctly — a slow network is not a broken box", async () => {
+    // The TYPE, not the sentence: `spawnOpenclaw` rejects
+    // OpenclawSpawnTimeoutError when it kills a child at its deadline, and a
+    // plain Error carrying the same words is any other failure. Matching the
+    // message let a reworded timeout downgrade the owner's remediation to
+    // "install failed" — and a message that merely mentioned a timeout upgrade
+    // it the other way.
     mockSpawn
       .mockResolvedValueOnce(pluginsListJson([]))
-      .mockRejectedValueOnce(new Error("/usr/bin/openclaw plugins install timed out after 180000ms"));
+      .mockRejectedValueOnce(
+        new OpenclawSpawnTimeoutError("/usr/bin/openclaw plugins install timed out after 180000ms"),
+      );
 
     expect(await lib.ensureChannelPlugin("discord")).toEqual({
       ok: false,

--- a/src/tests/unit/openclaw-channel-plugins.test.ts
+++ b/src/tests/unit/openclaw-channel-plugins.test.ts
@@ -226,6 +226,41 @@ describe("ensureChannelPlugin", () => {
     });
   });
 
+  it("settles a plugins enable killed at its deadline by the config, not by the kill", async () => {
+    // D-12's shape, one CLI verb over. `plugins enable` writes
+    // `plugins.entries.<id>.enabled` and then spends seconds loading the
+    // gateway SDK, so on a Jetson the entry lands inside the 45 s window we
+    // kill in — and the owner was told the channel plugin could not be
+    // installed while it was enabled on disk and live after the next restart.
+    mockReadConfig
+      .mockResolvedValueOnce(configWithEnabled()) // the precondition: not on yet
+      .mockResolvedValueOnce(configWithEnabled("discord")); // the read-back after the kill
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "discord" }]))
+      .mockRejectedValueOnce(
+        new OpenclawSpawnTimeoutError("/usr/bin/openclaw plugins enable discord timed out after 45000ms"),
+      );
+
+    expect(await lib.ensureChannelPlugin("discord")).toEqual({ ok: true, installed: false });
+  });
+
+  it("still fails a killed plugins enable whose entry never reached the config", async () => {
+    // The other half: forgiving a kill the config does not corroborate would
+    // swap this module's false failure for a false success, and the owner would
+    // be shown a channel that the gateway never loads.
+    mockReadConfig.mockResolvedValue(configWithEnabled());
+    mockSpawn
+      .mockResolvedValueOnce(pluginsListJson([{ id: "discord" }]))
+      .mockRejectedValueOnce(
+        new OpenclawSpawnTimeoutError("/usr/bin/openclaw plugins enable discord timed out after 45000ms"),
+      );
+
+    expect(await lib.ensureChannelPlugin("discord")).toEqual({
+      ok: false,
+      reason: "install_failed",
+    });
+  });
+
   it("refuses a channel it has no official plugin for", async () => {
     expect(await lib.ensureChannelPlugin("carrier-pigeon")).toEqual({
       ok: false,

--- a/src/tests/unit/openclaw-config-set-landed.test.ts
+++ b/src/tests/unit/openclaw-config-set-landed.test.ts
@@ -280,6 +280,21 @@ describe("a config set killed at its timeout is verified, not assumed failed", (
     expect(err!.message).toContain("timed out");
   });
 
+  it("rejects the timeout TYPE from the real spawn, not just a message", async () => {
+    // `openclaw-channels.ts` decides install_timeout vs install_failed on
+    // `err instanceof OpenclawSpawnTimeoutError`, but its own suite mocks
+    // `spawnOpenclawCli` and hand-builds the error — so nothing there proves the
+    // spawn still produces that type. This drives the real one, on a command
+    // that is not a `config` write, so the coupling cannot rot silently.
+    mockSpawn.mockImplementation(() => hangingChild());
+
+    const err = await settle(
+      openclawConfig.spawnOpenclawCli(["plugins", "install", "openclaw-discord"], { timeoutMs: 1 }),
+    );
+
+    expect(err).toBeInstanceOf(openclawConfig.OpenclawSpawnTimeoutError);
+  });
+
   it("keeps the caller's config path out of the journal line", async () => {
     // CodeQL js/log-injection #473: `POST /setup-api/chat/model` and
     // `POST /setup-api/tts` both build a config path out of their request body
@@ -307,8 +322,10 @@ describe("a config set killed at its timeout is verified, not assumed failed", (
       expect(line).not.toContain("forged line");
       expect(line).not.toContain("evil");
       // Still says WHICH area was written — a literal of this module's, not the
-      // caller's text.
+      // caller's text — and the deadline it was killed at, which is the
+      // caller's own option and never the request's.
       expect(line).toContain("models");
+      expect(line).toContain("1ms deadline");
     } finally {
       warn.mockRestore();
     }

--- a/src/tests/unit/openclaw-config-set-landed.test.ts
+++ b/src/tests/unit/openclaw-config-set-landed.test.ts
@@ -76,6 +76,22 @@ function hangingChild(): ChildProcess {
   return child;
 }
 
+/**
+ * A child that ignores SIGKILL, so only the reap bound can settle the call.
+ *
+ * The counterpart of `hangingChild`: that one is reaped at once and never
+ * exercises `KILL_REAP_WAIT_MS`, so without this the bound could be deleted and
+ * a process that refuses to die would hold the request open with nothing here
+ * failing.
+ */
+function unreapableChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  child.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
+  child.stderr = new EventEmitter() as unknown as ChildProcess["stderr"];
+  child.kill = vi.fn(() => true) as unknown as ChildProcess["kill"];
+  return child;
+}
+
 /** A child that exits with `code` having written nothing. */
 function silentChild(code: number): ChildProcess {
   const child = hangingChild();
@@ -287,6 +303,18 @@ describe("a config set killed at its timeout is verified, not assumed failed", (
     // spawn still produces that type. This drives the real one, on a command
     // that is not a `config` write, so the coupling cannot rot silently.
     mockSpawn.mockImplementation(() => hangingChild());
+
+    const err = await settle(
+      openclawConfig.spawnOpenclawCli(["plugins", "install", "openclaw-discord"], { timeoutMs: 1 }),
+    );
+
+    expect(err).toBeInstanceOf(openclawConfig.OpenclawSpawnTimeoutError);
+  });
+
+  it("answers even when the killed child never exits", async () => {
+    // Pays the real reap budget once, deliberately: fake timers here would mock
+    // away the very bound under test.
+    mockSpawn.mockImplementation(() => unreapableChild());
 
     const err = await settle(
       openclawConfig.spawnOpenclawCli(["plugins", "install", "openclaw-discord"], { timeoutMs: 1 }),

--- a/src/tests/unit/openclaw-config-set-landed.test.ts
+++ b/src/tests/unit/openclaw-config-set-landed.test.ts
@@ -280,6 +280,65 @@ describe("a config set killed at its timeout is verified, not assumed failed", (
     expect(err!.message).toContain("timed out");
   });
 
+  it("keeps the caller's config path out of the journal line", async () => {
+    // CodeQL js/log-injection #473: `POST /setup-api/chat/model` and
+    // `POST /setup-api/tts` both build a config path out of their request body
+    // (`chatgptRuntimeEntryPath(modelRef)`, `models.providers.<provider>`), and
+    // the path rides into the spawn label and out through this line. Escaping
+    // the value is not enough — a record whose CONTENT is the caller's is a
+    // forged record whether or not it also spans two lines.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      mockSpawn.mockImplementation(() => hangingChild());
+      const forgedKey = "evil\n[openclaw-config] forged line";
+      configOnDisk({ models: { providers: { [forgedKey]: { apiKey: "k" } } } });
+
+      const err = await settle(
+        openclawConfig.runOpenclawConfigSet(
+          [`models.providers["${forgedKey}"].apiKey`, "k"],
+          { timeoutMs: 1 },
+        ),
+      );
+
+      expect(err).toBeNull();
+      expect(warn).toHaveBeenCalledTimes(1);
+      const line = String(warn.mock.calls[0]?.[0]);
+      expect(line).not.toMatch(/[\r\n]/); // one write, one record
+      expect(line).not.toContain("forged line");
+      expect(line).not.toContain("evil");
+      // Still says WHICH area was written — a literal of this module's, not the
+      // caller's text.
+      expect(line).toContain("models");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("keeps the caller's config path out of the journal line on unset too", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      mockSpawn.mockImplementation(() => hangingChild());
+      configOnDisk({ models: { providers: {} } });
+
+      const err = await settle(
+        openclawConfig.runOpenclawConfigUnset(
+          'models.providers["evil\n[openclaw-config] forged line"].apiKey',
+          { timeoutMs: 1 },
+        ),
+      );
+
+      expect(err).toBeNull();
+      expect(warn).toHaveBeenCalledTimes(1);
+      const line = String(warn.mock.calls[0]?.[0]);
+      expect(line).not.toMatch(/[\r\n]/);
+      expect(line).not.toContain("forged line");
+      expect(line).not.toContain("evil");
+      expect(line).toContain("models");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it("reads a bracket-quoted segment as one key", async () => {
     // The Codex runtime arm: `agents.defaults.models["openai/gpt-5.5"]
     // .agentRuntime.id`. A path split on "." alone would look for a key

--- a/src/tests/unit/openclaw-config-set-landed.test.ts
+++ b/src/tests/unit/openclaw-config-set-landed.test.ts
@@ -58,12 +58,21 @@ const mockFs = vi.mocked(fs);
 
 let openclawConfig: typeof import("@/lib/openclaw-config");
 
-/** A child that never exits, so the caller's timeout is what settles the call. */
+/**
+ * A child that runs until it is killed — the caller's deadline is what settles
+ * the call, and the SIGKILL is then reaped like a real one. Emitting `close`
+ * from `kill` matters twice: the reap wait settles at once instead of paying
+ * its full second in every test, and the reaped path is the one a real box
+ * takes.
+ */
 function hangingChild(): ChildProcess {
   const child = new EventEmitter() as ChildProcess;
   child.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
   child.stderr = new EventEmitter() as unknown as ChildProcess["stderr"];
-  child.kill = vi.fn() as unknown as ChildProcess["kill"];
+  child.kill = vi.fn(() => {
+    queueMicrotask(() => child.emit("close", null, "SIGKILL"));
+    return true;
+  }) as unknown as ChildProcess["kill"];
   return child;
 }
 
@@ -245,6 +254,23 @@ describe("a config set killed at its timeout is verified, not assumed failed", (
   it("still fails an unset whose path is still there", async () => {
     mockSpawn.mockImplementation(() => hangingChild());
     configOnDisk({ models: { providers: { openai: { apiKey: "claw_still_here" } } } });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigUnset("models.providers.openai.apiKey", { timeoutMs: 1 }),
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain("timed out");
+  });
+
+  it("still fails an unset when openclaw.json is missing", async () => {
+    // The one shape that would otherwise fail OPEN: readConfigStrict answers
+    // `{}` for an absent file, and every path reads as removed in `{}`. Without
+    // this the guard could be deleted and nothing here would notice.
+    mockSpawn.mockImplementation(() => hangingChild());
+    const fsSync = vi.mocked((await import("fs")).default);
+    fsSync.existsSync.mockReturnValue(false);
+    configOnDisk({});
 
     const err = await settle(
       openclawConfig.runOpenclawConfigUnset("models.providers.openai.apiKey", { timeoutMs: 1 }),

--- a/src/tests/unit/openclaw-config-set-landed.test.ts
+++ b/src/tests/unit/openclaw-config-set-landed.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import fs from "fs/promises";
+import { EventEmitter } from "events";
+import type { ChildProcess } from "child_process";
+
+// A `config set` that is killed at its timeout is not proof that nothing was
+// written. `spawnOpenclaw` SIGKILLs the child and rejects, but the CLI writes
+// the config early and then spends seconds validating catalogs, so on a Jetson
+// the value lands and the caller still reports a failure.
+//
+// Measured on the OpenClaw box (TASK-654, core 2026.8.1):
+//
+//   POST /setup-api/chat/model {"model":"openai/gpt-5.5","provider":"codex"}
+//   -> http=500 after 30.04s
+//   -> {"error":"... openclaw config set agents.defaults.model.primary
+//                <redacted> timed out after 30000ms"}
+//   -> and yet: agents.defaults.model.primary == openai/gpt-5.5
+//
+// The owner is told the switch failed, the box is on the new model, and the
+// two disagree until something re-reads the config. That is the "false
+// failure" class from CLAUDE.md.
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  default: {
+    // `readEdition()` stats the edition file BEFORE reading it, so a mock
+    // without `statSync` makes that call throw a TypeError into its own catch
+    // and the edition guard the whole path depends on is never exercised.
+    statSync: vi.fn(() => {
+      throw new Error("no edition file");
+    }),
+    readFileSync: vi.fn(() => {
+      throw new Error("no edition file");
+    }),
+    existsSync: vi.fn(() => true),
+    readdirSync: vi.fn(() => {
+      throw new Error("no nvm dir");
+    }),
+  },
+}));
+
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    rename: vi.fn(),
+    mkdir: vi.fn(),
+  },
+}));
+
+const mockSpawn = vi.mocked(childProcess.spawn);
+const mockFs = vi.mocked(fs);
+
+let openclawConfig: typeof import("@/lib/openclaw-config");
+
+/** A child that never exits, so the caller's timeout is what settles the call. */
+function hangingChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  child.stdout = new EventEmitter() as unknown as ChildProcess["stdout"];
+  child.stderr = new EventEmitter() as unknown as ChildProcess["stderr"];
+  child.kill = vi.fn() as unknown as ChildProcess["kill"];
+  return child;
+}
+
+/** A child that exits with `code` having written nothing. */
+function silentChild(code: number): ChildProcess {
+  const child = hangingChild();
+  queueMicrotask(() => child.emit("close", code));
+  return child;
+}
+
+/** What `openclaw.json` holds when the caller re-reads it after the kill. */
+function configOnDisk(config: unknown): void {
+  mockFs.readFile.mockResolvedValue(JSON.stringify(config) as never);
+}
+
+let ambientEdition: string | undefined;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  ambientEdition = process.env.CLAWBOX_EDITION;
+  process.env.CLAWBOX_EDITION = "openclaw";
+  mockFs.readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }) as never);
+  openclawConfig = await import("@/lib/openclaw-config");
+});
+
+afterEach(() => {
+  if (ambientEdition === undefined) delete process.env.CLAWBOX_EDITION;
+  else process.env.CLAWBOX_EDITION = ambientEdition;
+  vi.clearAllMocks();
+});
+
+async function settle(promise: Promise<unknown>): Promise<Error | null> {
+  return promise.then(() => null).catch((err: Error) => err);
+}
+
+describe("a config set killed at its timeout is verified, not assumed failed", () => {
+  it("resolves when the assignment is on disk", async () => {
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({ agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigSet(["agents.defaults.model.primary", "openai/gpt-5.5"], {
+        timeoutMs: 1,
+      }),
+    );
+
+    expect(err).toBeNull();
+  });
+
+  it("still fails when the assignment is NOT on disk", async () => {
+    // The other half. A timeout that wrote nothing is a real failure, and
+    // reporting it as success would be the false success this replaces the
+    // false failure with.
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({ agents: { defaults: { model: { primary: "llamacpp/gemma4-e2b-it-q4_0" } } } });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigSet(["agents.defaults.model.primary", "openai/gpt-5.5"], {
+        timeoutMs: 1,
+      }),
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain("timed out");
+  });
+
+  it("still fails when the config cannot be read back", async () => {
+    // An EACCES or a half-written file proves nothing either way, and
+    // `readConfig`'s `{}` would read as "not landed" — which is the answer we
+    // want, but only because it is reached by throwing rather than by guessing.
+    mockSpawn.mockImplementation(() => hangingChild());
+    mockFs.readFile.mockRejectedValue(new Error("EACCES: permission denied") as never);
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigSet(["agents.defaults.model.primary", "openai/gpt-5.5"], {
+        timeoutMs: 1,
+      }),
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    // The ORIGINAL failure, not the read error: an owner shown "permission
+    // denied" for a CLI that timed out goes and fixes the wrong thing.
+    expect(err!.message).toContain("timed out");
+  });
+
+  it("reads the config back from openclaw.json, not from wherever", async () => {
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({ agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } });
+
+    await settle(
+      openclawConfig.runOpenclawConfigSet(["agents.defaults.model.primary", "openai/gpt-5.5"], {
+        timeoutMs: 1,
+      }),
+    );
+
+    expect(mockFs.readFile).toHaveBeenCalledWith(openclawConfig.CONFIG_PATH, "utf-8");
+  });
+
+  it("does not verify a CLI that ran and refused", async () => {
+    // Exit 1 is the CLI's own answer — a schema rejection, an unresolvable
+    // model reference. It says nothing was written, and a config that happens
+    // to already hold the value must not turn that refusal into a success.
+    mockSpawn.mockImplementation(() => silentChild(1));
+    configOnDisk({ agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigSet(["agents.defaults.model.primary", "openai/gpt-5.5"]),
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain("exited with code 1");
+  });
+
+  it("verifies every assignment of a batch, not just the first", async () => {
+    // `--batch-json` is atomic, so a batch that landed landed whole. Checking
+    // only the first entry would report a partial write as applied.
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({
+      agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+      plugins: { entries: { openai: { enabled: true } } },
+    });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigSetBatch(
+        [
+          ["agents.defaults.model.primary", "openai/gpt-5.5"],
+          ["plugins.entries.openai.enabled", "true"],
+          ["agents.defaults.model.fallbacks", JSON.stringify(["llamacpp/gemma4-e2b-it-q4_0"]), "--json"],
+        ],
+        { timeoutMs: 1 },
+      ),
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain("timed out");
+  });
+
+  it("resolves a batch whose every assignment is on disk", async () => {
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({
+      agents: {
+        defaults: {
+          model: { primary: "openai/gpt-5.5", fallbacks: ["llamacpp/gemma4-e2b-it-q4_0"] },
+        },
+      },
+      plugins: { entries: { openai: { enabled: true } } },
+    });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigSetBatch(
+        [
+          ["agents.defaults.model.primary", "openai/gpt-5.5"],
+          ["plugins.entries.openai.enabled", "true"],
+          ["agents.defaults.model.fallbacks", JSON.stringify(["llamacpp/gemma4-e2b-it-q4_0"]), "--json"],
+        ],
+        { timeoutMs: 1 },
+      ),
+    );
+
+    expect(err).toBeNull();
+  });
+
+  it("resolves an unset whose path is gone from the file", async () => {
+    // The sibling: `config unset` is the same spawn with the same deadline, and
+    // a removal reported as a failure sends the caller to repair something that
+    // is already repaired — the configure route answers 502 and tells the owner
+    // to run the command by hand.
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({ models: { providers: { openai: { models: [] } } } });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigUnset("models.providers.openai.apiKey", { timeoutMs: 1 }),
+    );
+
+    expect(err).toBeNull();
+  });
+
+  it("still fails an unset whose path is still there", async () => {
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({ models: { providers: { openai: { apiKey: "claw_still_here" } } } });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigUnset("models.providers.openai.apiKey", { timeoutMs: 1 }),
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err!.message).toContain("timed out");
+  });
+
+  it("reads a bracket-quoted segment as one key", async () => {
+    // The Codex runtime arm: `agents.defaults.models["openai/gpt-5.5"]
+    // .agentRuntime.id`. A path split on "." alone would look for a key
+    // `"openai/gpt-5` and never find the value that IS there.
+    mockSpawn.mockImplementation(() => hangingChild());
+    configOnDisk({
+      agents: { defaults: { models: { "openai/gpt-5.5": { agentRuntime: { id: "codex" } } } } },
+    });
+
+    const err = await settle(
+      openclawConfig.runOpenclawConfigSet(
+        ['agents.defaults.models["openai/gpt-5.5"].agentRuntime.id', "codex"],
+        { timeoutMs: 1 },
+      ),
+    );
+
+    expect(err).toBeNull();
+  });
+});


### PR DESCRIPTION
Finding: **D-12** from the TASK-654 model sweep, measured on the OpenClaw box (core 2026.8.1 `ea80657`) — the "false failure" class from `CLAUDE.md`.

## Customer-visible symptom

The owner picks the ChatGPT row in the chat model picker. The dashboard answers **500** and says the switch failed. It did not:

```
POST /setup-api/chat/model {"model":"openai/gpt-5.5","provider":"codex"}
-> http=500 after 30.04s
-> {"error":"… openclaw config set agents.defaults.model.primary <redacted>
             timed out after 30000ms"}
-> and yet:  agents.defaults.model.primary == openai/gpt-5.5      <-- the write LANDED
```

The box is on the new model, the owner has been told it is not, and the two disagree until something re-reads the config. The owner's next move — pick it again, or go looking in the Terminal — is a move against a box that already did what they asked.

## Cause

`spawnOpenclaw` gives every call a deadline (30 s by default, "Jetson CLI cold-start is ~10-12s"), SIGKILLs the child when it expires and rejects. But `openclaw config set` writes the config **early** and then spends seconds loading the gateway SDK's plugins and validating the reference against their catalogs — on a Jetson that tail routinely runs past the deadline. A SIGKILL is the one spawn failure that carries no answer: an exit code is the CLI's own verdict (0 wrote, 1 refused), a kill says only that we stopped watching.

The repo already knew the shape of this. `setSkillEnabled`'s comment records the App Store toggle that "used to spend a 10 s budget on it and answer 500 after the value had already landed", and solved it by bypassing the CLI for that one key. The general case was never fixed.

## Harness first

The native way to answer "did this write land?" is `openclaw config get <path>` — this repo already uses it (`install.sh:2592`, `install.sh:3172`), and the Hermes leg documents `hermes config get <key> --json` as *the* machine-readable read.

**Rejected, with the reason on record:** a `config get` is a second full CLI cold start — 10-12 s on a Jetson — inside a request that has just spent 30 s, and it would double the worst case of the very route this fixes. The file read used instead is not a new mechanism either: it is `readConfigStrict()`, the same reader every other consumer in `openclaw-config.ts` already uses, against the file the CLI has just written. There is no gateway RPC for a config read wired here (`openclaw gateway call` exists, but exposes no config accessor in the method list on this pin).

## Fix

- `spawnOpenclaw`'s deadline now rejects a typed `OpenclawSpawnTimeoutError` instead of a bare `Error`, so "killed" is distinguishable from "the CLI answered".
- `runOpenclawConfigSet`, `runOpenclawConfigSetBatch` and `runOpenclawConfigUnset` catch **only** that type and let the config on disk settle it: every assignment present with the value asked for (a `--batch-json` batch is atomic, so all of them or none), or for an unset, the path provably gone. Anything else is rethrown untouched — an exit code, a spawn error, `OpenclawUnavailableError`.
- Everything fails **closed**. An unreadable config, a path this code cannot parse, a value that does not match, a config file that has disappeared: all rethrow the original timeout. Only a write this process can SEE on disk is forgiven.
- The kill now waits (bounded, 1 s) for the child to actually exit before answering, because `kill(2)` returns when the signal is queued — a CLI inside its final rename could otherwise land the write on the far side of our read.

## RED → GREEN

RED on unmodified `origin/beta` (112d1673) — the three cases that assert a landed write is not reported as a failure:

```
 × resolves when the assignment is on disk
 × resolves a batch whose every assignment is on disk
 × reads a bracket-quoted segment as one key
AssertionError: expected Error: openclaw config set agents.default… to be null
 Test Files  1 failed (1)
      Tests  3 failed | 4 passed (7)
```

The four that pass on beta are deliberate guards, not RED: they pin the behaviour that must NOT change (an exit-1 refusal stays a failure, a value that is not on disk stays a failure, an unreadable config stays a failure).

GREEN on this branch — full unit project and `tsc --noEmit` clean.

## Sibling call sites

- `setOpenclawWhatsappEnabled` (`src/lib/openclaw-whatsapp.ts`) wrote `channels.whatsapp.enabled` through a bare `spawnOpenclawCli` with a 45 s budget — the same false failure, one route over (`POST /setup-api/whatsapp/configure`). **Fixed**: routed through `runOpenclawConfigSet`, so it gets the conflict retry as well.
- `isTimeout` in `src/lib/openclaw-channels.ts` was matching `/timed out after \d+ms/` on the message. **Fixed** to use the new type — the message is not a contract, and this is the decision behind `install_timeout` vs `install_failed` in the owner-facing WhatsApp error.
- `ensureChannelPlugin`'s `plugins enable` (`src/lib/openclaw-channels.ts`) is a config write too — the CLI writes `plugins.entries.<id>.enabled` and *then* loads the gateway SDK, so a 45 s kill on a Jetson leaves the entry on disk while the route answered `plugin_install_failed`. **Fixed**: on a timeout it re-reads the same `pluginEnabledInConfig` the precondition four lines above already used, and only an entry this process can see forgives the kill. (An earlier revision of this body cleared this call site as "not a config write". That was wrong; the module's own header says so.)
- `ensureChannelPlugin`'s `plugins install` is **deliberately not** settled that way: the npm package landing on disk is the other half of that verb, and `plugins.entries.<id>.enabled` alone would bless an install that never finished. Cleared with the reason, not changed.
- `runCommand` in `ai-models/configure/route.ts:226` already routes every `openclaw config set` into `runOpenclawConfigSet`, so both of its call sites (`setFallbackModels`, the `models.mode` reset) inherit the fix. Cleared.
- `local-ai/route.ts:65` writes `agents.defaults.model.fallbacks` through its own `execFile` — but under `.catch(() => {})`, so a kill there is already forgiven and no false failure reaches the owner. Cleared, not changed.
- Every other `spawnOpenclaw` caller — `pairing list/approve`, `gateway call`, `doctor --fix`, `plugins list` — is a **read or a command, not a config write**, so a kill there carries no "did it land" question this could answer. Cleared, not changed.
- `applyConfigSetGroups` (`configure/route.ts`) sits on top of `runOpenclawConfigSetBatch` and inherits the behaviour; its group boundaries are unchanged.

## Log injection (CodeQL js/log-injection, alert #473) — closed here

The line this PR added to report a forgiven kill interpolated `err.message`, and the spawn label inside that message carries the caller's **config path**. CodeQL traced it to two request bodies: `POST /setup-api/chat/model` (whose model reference becomes `agents.defaults.models[<ref>].agentRuntime` through `chatgptRuntimeEntryPath`) and `POST /setup-api/tts` (whose provider id becomes `<tts|messages.tts>.providers.<id>.voice`). The *values* were already elided by `configSetLabelArgs` / `configSetBatchLabelArgs`; the paths were not.

`logSafe()` (`src/lib/log-safe.ts`) is the repo's owned mechanism for logging untrusted text and was the first attempt — it keeps one value on one line and caps its length. Not enough here, and the repo already knew why: `ai-models/configure/route.ts:1429` records that "js/log-injection … does not recognise `logSafe` as a barrier", and the deeper point is that a record whose *content* is the caller's is a forged record whether or not it also spans two lines.

So the raw path no longer reaches the line at all. It is mapped onto `LOGGED_CONFIG_AREAS` — a literal list of the nine top-level config roots this repo writes — and the line names the area, the deadline it was killed at, and nothing else:

```
[openclaw-config] a config set (models) was killed at its 30000ms deadline, but every
assignment is on disk — the write landed, reporting success
```

`find`, not `includes`, is load-bearing: what is logged is the element of the literal array, so nothing derived from the path is what gets written. `LOGGED_CONFIG_AREAS.includes(root) ? root : "other"` would read the same and put the request's text straight back in. The deadline is read off the caller's own options and **not** off the error, every field of which hangs on an object built from that same path.

`configSetEntryPath` reads the path by the same "first non-flag argv element" rule `parseConfigSetArgs` uses, but is total: an entry it cannot read is named `other`. A log line describing a success must not be able to turn it into a failure.

### RED → GREEN for that half

RED, on this branch with `logSafe` in place:

```
 × keeps the caller's config path out of the journal line
 × keeps the caller's config path out of the journal line on unset too
AssertionError: expected '[openclaw-config] /usr/bin/openclaw c…' not to contain 'forged line'
Received: "[openclaw-config] /usr/bin/openclaw config set
           models.providers[\"evil<U+FFFD>[openclaw-config] forged line\"].apiKey <redacted>
           timed out after 1ms; every assignment is on disk, so the write landed — reporting success"
 Tests  2 failed | 11 passed (13)
```

The CR/LF half of the assertion already passed there — `logSafe` had turned the newline into the U+FFFD shown above. What failed is the half CWE-117 is actually about: the caller still chose the content of the record.

GREEN: 15/15 in that suite, 313/313 across the thirteen `openclaw-config*` / channel / WhatsApp suites, and 9970/9970 across both vitest projects (the same 683 files CI runs), `tsc --noEmit` clean, `eslint` clean on the changed files.

The bounded reap after the SIGKILL is pinned too, by a child whose `kill` emits nothing: without it `KILL_REAP_WAIT_MS` could be deleted and a process that refuses to die would hold the request open with no test failing.

## Limits, stated

- Verification is exact deep equality. If the CLI ever normalises a value it stored (filling provider defaults into a `models.providers.<p>` object), a landed write reads as not-landed and the original timeout is rethrown — **fails closed**, so it is a missed fix and not a regression.
- A bracket-quoted path segment containing a backslash escape is rejected rather than unescaped. No model id in the catalogue produces one; the parser answers `null` and the timeout is rethrown.
- The Hermes leg has the identical bug (`runHermesCli` SIGKILLs and rejects with no verification, and `hermes config get <key> --json` is the native read for it). Deliberately out of scope here: this PR is the OpenClaw path, and on a `hermes` SKU `openclawIsAbsent()` rejects `OpenclawUnavailableError`, which is not a timeout, so none of the new code runs.
- The write-verification cannot tell "the CLI wrote it" from "it was already that value". For every caller in this repo the end state is what the caller asked for, so no caller is misled; the flagship path (`chat/model`) additionally returns before this on a same-model pick, so its primary provably differed.
- The reap wait after the SIGKILL is a fixed 1 s. That is generous for a killed Node process, but the state that produced the 30 s timeout is a loaded Jetson, which is also the state in which a process can take longer than that to be reaped. When the reap deadline wins, the read lands before the CLI's rename and the original timeout is rethrown — **fails closed**, so it lowers the fix's hit rate in the worst case rather than introducing a wrong answer.
- The journal line carries the config area and the deadline, not the path and not the number of assignments in a batch. Both omissions are deliberate: the path is the caller's text (above), and a count read off the caller's own argv array is the same taint path by another route. The area plus the request's own log lines are what an operator reads.
- `valueAtConfigPath` now answers with OWN properties only. No prototype value could ever have satisfied `isDeepStrictEqual` against a JSON value, so this is a contract being made true rather than a live defect closed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when saving, updating, or removing configuration values during command timeouts by confirming changes on disk.
  - Prevented timed-out operations from being reported as successful when changes were not written or could not be verified.
  - Improved batch configuration updates by verifying every requested value.
  - Improved WhatsApp enable and disable configuration handling with retry and verification support.
  - Improved plugin activation timeout handling by confirming successful activation before reporting success.
  - Improved timeout detection for more consistent error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
