### PR TITLE
fix: make install.sh TOTAL_STEPS edition-aware (TASK-695)

### DIFF
--- a/docs-site/support/recovery.mdx
+++ b/docs-site/support/recovery.mdx
@@ -77,7 +77,7 @@ Use the box's own channel, not a hardcoded `main`. `.update-branch` is the updat
 device on `beta` that is hard-reset to `origin/main` is silently moved to a different release line.
 </Warning>
 
-Let `install.sh` finish completely (it prints numbered steps, `[1/26] … [26/26]`), then reboot. The box is back in ~2 minutes.
+Let `install.sh` finish completely — it prints numbered steps and ends on `[N/N]`, where N depends on your edition (hermes and dual boxes run one provisioning step more than openclaw) — then reboot. The box is back in ~2 minutes.
 
 <Info>
 Why this works when a normal update didn't: `install.sh` refreshes **everything** — the app build, your edition's agent core (the pinned OpenClaw version, or the Hermes edition steps), the systemd service files, and system packages. It reads `/etc/clawbox/edition.env` on every run and skips the steps that do not belong to your edition, so it cannot convert a Hermes box into an OpenClaw one. Partial updates (a bare `git pull`, an interrupted updater) can leave those out of sync.

--- a/install.sh
+++ b/install.sh
@@ -5890,9 +5890,12 @@ fi
 
 # ── Full Install Mode ───────────────────────────────────────────────────────
 
-# Upper bound (the Hermes provisioning step only runs on hermes/dual), so the
-# progress counter never prints "[26/23]".
+# 26 unconditional steps, plus the Hermes provisioning step below, which runs
+# only on the hermes and dual editions. Edition-aware rather than a constant:
+# the openclaw constant made those editions print "[27/26]" on their last step,
+# and an upper bound would leave openclaw finishing at "[26/27]".
 TOTAL_STEPS=26
+if has_hermes_harness; then TOTAL_STEPS=$((TOTAL_STEPS + 1)); fi
 step=0
 log() {
   step=$((step + 1))

--- a/src/tests/unit/install-step-counter.test.ts
+++ b/src/tests/unit/install-step-counter.test.ts
@@ -5,81 +5,28 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 /**
- * The installer's progress counter has to agree with the number of steps the
+ * An installer's progress counter has to agree with the number of steps the
  * edition in front of it actually runs.
  *
- * `TOTAL_STEPS` was a constant sized for the openclaw edition, but the
- * `log "Provisioning Hermes ..."` step is guarded by `has_hermes_harness`, so
- * the hermes and dual editions run one step more than the constant admits and
- * the last line of their install reads `[27/26]` (TASK-695).
+ * `install.sh`'s `TOTAL_STEPS` was a constant sized for the openclaw edition,
+ * but the `log "Provisioning Hermes ..."` step is guarded by
+ * `has_hermes_harness`, so the hermes and dual editions run one step more than
+ * the constant admits and the last line of their install read `[27/26]`
+ * (TASK-695).
  *
- * These tests derive the step count from the shipped install.sh itself — the
- * unconditional `log "` calls plus the edition-gated ones — and then EXECUTE
- * the real counter block (the `TOTAL_STEPS` declaration through the end of
- * `log()`) under `set -euo pipefail` for each edition. A rewrite that keeps
+ * These tests derive each installer's step count from the shipped file itself —
+ * the unconditional `log "` calls plus the edition-gated ones — and then
+ * EXECUTE the real counter block (the `TOTAL_STEPS` declaration through the end
+ * of `log()`) under `set -euo pipefail` for each edition. A rewrite that keeps
  * the comment and drops the edition awareness fails them; so does bumping the
  * constant to 27, which would leave openclaw counting to `[26/27]`.
+ *
+ * `install-x64.sh` has no edition gating and is correct as it stands; it is
+ * covered here so the same drift — a step added without touching the constant —
+ * cannot appear there unnoticed.
  */
 
 const REPO = process.cwd();
-const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
-
-/** Everything from the progress counter's declaration to the end of the file. */
-const FULL_INSTALL_TAIL = (() => {
-  const at = INSTALL_SH.indexOf("\nTOTAL_STEPS=");
-  if (at < 0) throw new Error("TOTAL_STEPS declaration not found in install.sh");
-  return INSTALL_SH.slice(at + 1);
-})();
-
-/**
- * The counter as shipped: the `TOTAL_STEPS` declaration, any edition
- * adjustment, `step=0` and the whole `log()` function.
- */
-const COUNTER_BLOCK = (() => {
-  const logAt = FULL_INSTALL_TAIL.indexOf("log() {");
-  if (logAt < 0) throw new Error("log() not found after TOTAL_STEPS");
-  const end = FULL_INSTALL_TAIL.indexOf("\n}", logAt);
-  if (end < 0) throw new Error("log() has no closing brace");
-  return FULL_INSTALL_TAIL.slice(0, end + 2);
-})();
-
-/** The one-line `has_hermes_harness` definition, lifted verbatim. */
-const HAS_HERMES_HARNESS = (() => {
-  const m = INSTALL_SH.match(/^has_hermes_harness\(\).*$/m);
-  if (!m) throw new Error("has_hermes_harness() definition not found in install.sh");
-  return m[0];
-})();
-
-const TAIL_LINES = FULL_INSTALL_TAIL.split("\n");
-
-/** Indices of every `log "..."` progress call in the full-install sequence. */
-const LOG_CALLS = TAIL_LINES.map((line, index) => ({ line, index })).filter(({ line }) =>
-  /^[ \t]*log "/.test(line),
-);
-
-/**
- * The `if <cond>; then` a nested call sits under. Walks back to the nearest
- * unclosed `if` so the test can state WHICH condition gates a step rather than
- * trusting indentation to mean "hermes".
- */
-function enclosingGuard(index: number): string | null {
-  let depth = 0;
-  for (let i = index - 1; i >= 0; i--) {
-    const line = TAIL_LINES[i].trim();
-    if (line === "fi") depth++;
-    else if (/^if .*; then$/.test(line)) {
-      if (depth === 0) return line;
-      depth--;
-    }
-  }
-  return null;
-}
-
-const UNCONDITIONAL_STEPS = LOG_CALLS.filter(({ line }) => /^log "/.test(line)).length;
-const GATED_STEPS = LOG_CALLS.filter(({ line }) => !/^log "/.test(line));
-const HERMES_ONLY_STEPS = GATED_STEPS.filter(
-  ({ index }) => enclosingGuard(index) === "if has_hermes_harness; then",
-).length;
 
 const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
 
@@ -91,52 +38,147 @@ afterAll(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
+interface Installer {
+  /** The file name, which is also the test's name for it. */
+  file: string;
+  /** Editions to run the counter for, and the gate that decides the total. */
+  editions: string[];
+  /** The one-line predicate definition an edition-aware total calls, if any. */
+  gate: string | null;
+}
+
+function analyse({ file, gate }: Installer) {
+  const source = readFileSync(path.join(REPO, file), "utf-8");
+
+  /** Everything from the progress counter's declaration to the end of the file. */
+  const at = source.indexOf("\nTOTAL_STEPS=");
+  if (at < 0) throw new Error(`TOTAL_STEPS declaration not found in ${file}`);
+  const tail = source.slice(at + 1);
+
+  /**
+   * The counter as shipped: the `TOTAL_STEPS` declaration, any edition
+   * adjustment, `step=0` and the whole `log()` function.
+   */
+  const logAt = tail.indexOf("log() {");
+  if (logAt < 0) throw new Error(`log() not found after TOTAL_STEPS in ${file}`);
+  const blockEnd = tail.indexOf("\n}", logAt);
+  if (blockEnd < 0) throw new Error(`log() has no closing brace in ${file}`);
+  const counterBlock = tail.slice(0, blockEnd + 2);
+
+  const gateDefinition = (() => {
+    if (gate === null) return "";
+    const m = source.match(new RegExp(`^${gate}\\(\\).*$`, "m"));
+    if (!m) throw new Error(`${gate}() definition not found in ${file}`);
+    return m[0];
+  })();
+
+  const lines = tail.split("\n");
+  const isLogCall = (line: string) => /^[ \t]*log "/.test(line);
+  const logCalls = lines.map((line, index) => ({ line, index })).filter(({ line }) => isLogCall(line));
+
+  /**
+   * The `if <cond>; then` a nested call sits under. Walks back to the nearest
+   * unclosed `if` so the test can state WHICH condition gates a step rather
+   * than trusting indentation to mean "hermes".
+   */
+  function enclosingGuard(index: number): string | null {
+    let depth = 0;
+    for (let i = index - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (line === "fi") depth++;
+      else if (/^if .*; then$/.test(line)) {
+        if (depth === 0) return line;
+        depth--;
+      }
+    }
+    return null;
+  }
+
+  const unconditional = logCalls.filter(({ line }) => /^log "/.test(line)).length;
+  const gated = logCalls.filter(({ line }) => !/^log "/.test(line));
+  const gatedByEdition = gate === null ? 0 : gated.filter(({ index }) => enclosingGuard(index) === `if ${gate}; then`).length;
+
+  return {
+    source,
+    counterBlock,
+    gateDefinition,
+    unconditional,
+    gated: gated.length,
+    gatedByEdition,
+    /** Every `log "` in the WHOLE file, not just the counted tail. */
+    logCallsInFile: source.split("\n").filter(isLogCall).length,
+  };
+}
+
 /**
- * Run the shipped counter block for one edition, calling `log` exactly as many
- * times as that edition's install does, and return every `[step/total]` line
- * it printed.
+ * Run one installer's counter block for one edition, calling `log` exactly as
+ * many times as that edition's install does, and return every `[step/total]`
+ * line it printed.
  */
-function runCounter(edition: string, calls: number): { status: number | null; steps: string[] } {
+function runCounter(
+  installer: Installer,
+  edition: string,
+  calls: number,
+): { status: number | null; steps: string[] } {
+  const { counterBlock, gateDefinition } = analyse(installer);
   const program = [
     "#!/usr/bin/env bash",
     "set -euo pipefail",
     `CLAWBOX_EDITION="${edition}"`,
-    HAS_HERMES_HARNESS,
-    COUNTER_BLOCK,
+    gateDefinition,
+    counterBlock,
     `for _i in $(seq 1 ${calls}); do log "step $_i"; done`,
     "",
   ].join("\n");
-  const file = path.join(root, `counter-${edition}-${calls}.sh`);
+  const file = path.join(root, `counter-${installer.file}-${edition}-${calls}.sh`);
   writeFileSync(file, program, { mode: 0o755 });
   const run = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
   const steps = (run.stdout ?? "").split("\n").filter((l) => /^\[\d+\/\d+\]/.test(l));
   return { status: run.status, steps };
 }
 
-describe("install.sh progress counter", () => {
+const INSTALLERS: Installer[] = [
+  { file: "install.sh", editions: ["openclaw", "hermes", "dual"], gate: "has_hermes_harness" },
+  // No edition handling at all: one total for the one SKU it serves.
+  { file: "install-x64.sh", editions: ["openclaw"], gate: null },
+];
+
+describe.each(INSTALLERS)("$file progress counter", (installer) => {
   it("the extraction found a real sequence to count", () => {
     // Guards every assertion below: a slice that found no steps, or lost the
-    // Hermes one, would make the counter checks pass for the wrong reason.
-    expect(UNCONDITIONAL_STEPS).toBeGreaterThan(10);
-    expect(HERMES_ONLY_STEPS).toBe(1);
-    // Every gated progress step is the Hermes one — if another edition gains a
-    // conditional step, this test must be taught about it rather than silently
-    // under-counting.
-    expect(GATED_STEPS.length).toBe(HERMES_ONLY_STEPS);
+    // gated one, would make the counter checks pass for the wrong reason.
+    const { unconditional, gated, gatedByEdition } = analyse(installer);
+    expect(unconditional).toBeGreaterThan(10);
+    expect(gated).toBe(installer.gate === null ? 0 : 1);
+    // Every gated progress step is accounted for by the edition gate — a new
+    // conditional step under some other predicate must teach this test about
+    // itself rather than silently under-count.
+    expect(gatedByEdition).toBe(gated);
   });
 
-  it.runIf(hasBash)("openclaw ends on its last step, not short of the total", () => {
-    const { status, steps } = runCounter("openclaw", UNCONDITIONAL_STEPS);
+  it("every log call is in the counted tail — log() is defined just above it", () => {
+    // The tail slice starts at the TOTAL_STEPS line, so a `log "…"` added
+    // inside a step_* function further up would increment `step` at runtime
+    // and stay invisible here. It would also be a `log: command not found`
+    // under `install.sh --step <name>`, which dispatches before log() exists.
+    const { unconditional, gated, logCallsInFile } = analyse(installer);
+    expect(logCallsInFile).toBe(unconditional + gated);
+  });
+
+  it.runIf(hasBash)("the base edition ends on its last step, not short of the total", () => {
+    const { unconditional } = analyse(installer);
+    const { status, steps } = runCounter(installer, "openclaw", unconditional);
     expect(status).toBe(0);
-    expect(steps.at(-1)).toBe(`[${UNCONDITIONAL_STEPS}/${UNCONDITIONAL_STEPS}] step ${UNCONDITIONAL_STEPS}`);
+    expect(steps.at(-1)).toBe(`[${unconditional}/${unconditional}] step ${unconditional}`);
   });
 
-  for (const edition of ["hermes", "dual"]) {
-    it.runIf(hasBash)(`${edition} counts its Hermes provisioning step in the total`, () => {
-      const total = UNCONDITIONAL_STEPS + HERMES_ONLY_STEPS;
-      const { status, steps } = runCounter(edition, total);
+  for (const edition of installer.editions.filter((e) => e !== "openclaw")) {
+    it.runIf(hasBash)(`${edition} counts its gated step in the total`, () => {
+      const { unconditional, gatedByEdition } = analyse(installer);
+      const total = unconditional + gatedByEdition;
+      const { status, steps } = runCounter(installer, edition, total);
       expect(status).toBe(0);
-      // Today: "[27/26] step 27" — the counter overruns its own total.
+      // Before TASK-695: "[27/26] step 27" — the counter overran its own total.
       expect(steps.at(-1)).toBe(`[${total}/${total}] step ${total}`);
     });
   }

--- a/src/tests/unit/install-step-counter.test.ts
+++ b/src/tests/unit/install-step-counter.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { readFileSync, writeFileSync, mkdtempSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * The installer's progress counter has to agree with the number of steps the
+ * edition in front of it actually runs.
+ *
+ * `TOTAL_STEPS` was a constant sized for the openclaw edition, but the
+ * `log "Provisioning Hermes ..."` step is guarded by `has_hermes_harness`, so
+ * the hermes and dual editions run one step more than the constant admits and
+ * the last line of their install reads `[27/26]` (TASK-695).
+ *
+ * These tests derive the step count from the shipped install.sh itself — the
+ * unconditional `log "` calls plus the edition-gated ones — and then EXECUTE
+ * the real counter block (the `TOTAL_STEPS` declaration through the end of
+ * `log()`) under `set -euo pipefail` for each edition. A rewrite that keeps
+ * the comment and drops the edition awareness fails them; so does bumping the
+ * constant to 27, which would leave openclaw counting to `[26/27]`.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+
+/** Everything from the progress counter's declaration to the end of the file. */
+const FULL_INSTALL_TAIL = (() => {
+  const at = INSTALL_SH.indexOf("\nTOTAL_STEPS=");
+  if (at < 0) throw new Error("TOTAL_STEPS declaration not found in install.sh");
+  return INSTALL_SH.slice(at + 1);
+})();
+
+/**
+ * The counter as shipped: the `TOTAL_STEPS` declaration, any edition
+ * adjustment, `step=0` and the whole `log()` function.
+ */
+const COUNTER_BLOCK = (() => {
+  const logAt = FULL_INSTALL_TAIL.indexOf("log() {");
+  if (logAt < 0) throw new Error("log() not found after TOTAL_STEPS");
+  const end = FULL_INSTALL_TAIL.indexOf("\n}", logAt);
+  if (end < 0) throw new Error("log() has no closing brace");
+  return FULL_INSTALL_TAIL.slice(0, end + 2);
+})();
+
+/** The one-line `has_hermes_harness` definition, lifted verbatim. */
+const HAS_HERMES_HARNESS = (() => {
+  const m = INSTALL_SH.match(/^has_hermes_harness\(\).*$/m);
+  if (!m) throw new Error("has_hermes_harness() definition not found in install.sh");
+  return m[0];
+})();
+
+const TAIL_LINES = FULL_INSTALL_TAIL.split("\n");
+
+/** Indices of every `log "..."` progress call in the full-install sequence. */
+const LOG_CALLS = TAIL_LINES.map((line, index) => ({ line, index })).filter(({ line }) =>
+  /^[ \t]*log "/.test(line),
+);
+
+/**
+ * The `if <cond>; then` a nested call sits under. Walks back to the nearest
+ * unclosed `if` so the test can state WHICH condition gates a step rather than
+ * trusting indentation to mean "hermes".
+ */
+function enclosingGuard(index: number): string | null {
+  let depth = 0;
+  for (let i = index - 1; i >= 0; i--) {
+    const line = TAIL_LINES[i].trim();
+    if (line === "fi") depth++;
+    else if (/^if .*; then$/.test(line)) {
+      if (depth === 0) return line;
+      depth--;
+    }
+  }
+  return null;
+}
+
+const UNCONDITIONAL_STEPS = LOG_CALLS.filter(({ line }) => /^log "/.test(line)).length;
+const GATED_STEPS = LOG_CALLS.filter(({ line }) => !/^log "/.test(line));
+const HERMES_ONLY_STEPS = GATED_STEPS.filter(
+  ({ index }) => enclosingGuard(index) === "if has_hermes_harness; then",
+).length;
+
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
+
+let root: string;
+beforeAll(() => {
+  root = mkdtempSync(path.join(tmpdir(), "clawbox-step-counter-"));
+});
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/**
+ * Run the shipped counter block for one edition, calling `log` exactly as many
+ * times as that edition's install does, and return every `[step/total]` line
+ * it printed.
+ */
+function runCounter(edition: string, calls: number): { status: number | null; steps: string[] } {
+  const program = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    `CLAWBOX_EDITION="${edition}"`,
+    HAS_HERMES_HARNESS,
+    COUNTER_BLOCK,
+    `for _i in $(seq 1 ${calls}); do log "step $_i"; done`,
+    "",
+  ].join("\n");
+  const file = path.join(root, `counter-${edition}-${calls}.sh`);
+  writeFileSync(file, program, { mode: 0o755 });
+  const run = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
+  const steps = (run.stdout ?? "").split("\n").filter((l) => /^\[\d+\/\d+\]/.test(l));
+  return { status: run.status, steps };
+}
+
+describe("install.sh progress counter", () => {
+  it("the extraction found a real sequence to count", () => {
+    // Guards every assertion below: a slice that found no steps, or lost the
+    // Hermes one, would make the counter checks pass for the wrong reason.
+    expect(UNCONDITIONAL_STEPS).toBeGreaterThan(10);
+    expect(HERMES_ONLY_STEPS).toBe(1);
+    // Every gated progress step is the Hermes one — if another edition gains a
+    // conditional step, this test must be taught about it rather than silently
+    // under-counting.
+    expect(GATED_STEPS.length).toBe(HERMES_ONLY_STEPS);
+  });
+
+  it.runIf(hasBash)("openclaw ends on its last step, not short of the total", () => {
+    const { status, steps } = runCounter("openclaw", UNCONDITIONAL_STEPS);
+    expect(status).toBe(0);
+    expect(steps.at(-1)).toBe(`[${UNCONDITIONAL_STEPS}/${UNCONDITIONAL_STEPS}] step ${UNCONDITIONAL_STEPS}`);
+  });
+
+  for (const edition of ["hermes", "dual"]) {
+    it.runIf(hasBash)(`${edition} counts its Hermes provisioning step in the total`, () => {
+      const total = UNCONDITIONAL_STEPS + HERMES_ONLY_STEPS;
+      const { status, steps } = runCounter(edition, total);
+      expect(status).toBe(0);
+      // Today: "[27/26] step 27" — the counter overruns its own total.
+      expect(steps.at(-1)).toBe(`[${total}/${total}] step ${total}`);
+    });
+  }
+});


### PR DESCRIPTION
**TASK-695** — `install.sh` prints `[27/26]` on the hermes and dual editions.

## Customer-visible symptom
On a hermes or dual box the last line of an install/update run is

```
[27/26] Validating services...
```

The progress counter overruns its own total. Cosmetic, but it is the line the
support docs told owners to wait for, and an overrun reads as "the installer
lost count" at exactly the moment they are deciding whether the run finished.

## Cause
`TOTAL_STEPS=26` counted the 26 unconditional `log "` calls in the full-install
sequence. There is a 27th, gated one — `log "Provisioning Hermes (dashboard +
auth proxy + shared identity)..."` — inside `if has_hermes_harness; then`, which
runs on hermes and dual. The comment above the constant claimed it was an upper
bound; it was the openclaw exact count.

## Fix
Make the total edition-aware with the predicate the gated step itself uses:

```sh
TOTAL_STEPS=26
if has_hermes_harness; then TOTAL_STEPS=$((TOTAL_STEPS + 1)); fi
```

`has_hermes_harness`, not `is_hermes_edition`, so the premium `dual` SKU is
covered. Bumping the constant to 27 was rejected: it would leave openclaw
finishing at `[26/27]`. The same shape is already used a few hundred lines up
(`install.sh:5772`, `probe_count`).

## Harness-first
No OpenClaw or Hermes mechanism owns this: the installer's progress display is
ClawBox's own, and the harness has no equivalent to re-use. The nearest
in-repo owner of "which steps apply to this edition" is
`src/lib/updater.ts` (`applicableSteps()` / `applies: () => hasHermesHarness()`),
which already filters natively for the in-app updater — this change makes the
shell installer agree with that same predicate rather than introducing a second
notion of edition.

## RED (unmodified beta, 112d1673)
```
 ❯ src/tests/unit/install-step-counter.test.ts (4 tests | 2 failed)
     × hermes counts its Hermes provisioning step in the total
     × dual counts its Hermes provisioning step in the total

AssertionError: expected '[27/26] step 27' to be '[27/27] step 27'
Expected: "[27/27] step 27"
Received: "[27/26] step 27"
```

Re-run after the review pass extended the test to `install-x64.sh`, still on
beta's `install.sh`:

```
     × hermes counts its gated step in the total
     × dual counts its gated step in the total
AssertionError: expected '[27/26] step 27' to be '[27/27] step 27'
      Tests  2 failed | 6 passed (8)
```

The test derives both counts from the shipped file (unconditional `log "` calls
plus the ones under `if has_hermes_harness; then`) and then EXECUTES the real
counter block — the `TOTAL_STEPS` declaration through the end of `log()` — under
`set -euo pipefail`, once per edition.

## GREEN
```
 src/tests/unit/install-step-counter.test.ts   8 passed (8)
 all 23 src/tests/unit/install-*.test.ts       545 passed (545)
 bash -n install.sh                            OK
```

## Sibling call sites
- `install-x64.sh:1234` has its own `TOTAL_STEPS=16` and its own `log()`. Checked
  and correct: 16 `log "` calls, all unconditional, no edition handling in that
  file at all. No change needed — but the new test now covers it too, so the same
  drift cannot appear there unnoticed.
- `TOTAL_STEPS` has no other reader (`install.sh:5897/5898/5903` only). Nothing in
  `src/`, `scripts/`, `e2e-install/` or `.github/` parses the `[n/m]` line; the
  flash host's contract is the `[provision-status]` / `[provision-run]` sentinels,
  untouched here.
- `docs-site/support/recovery.mdx:80` told owners the run ends on `[26/26]`, which
  this change makes edition-dependent. Updated in the same PR — a hermes owner
  following that page would otherwise reboot one step early, before
  `step_validate_services` and the final verdict block.

## Review
One Opus `clawbox-review` pass. Medium (the recovery doc) and two lows (extend
the drift guard to `install-x64.sh`; assert every `log "` in the file lies inside
the counted tail) applied. One nit deliberately not folded in: on openclaw the
sequence still spends a numbered step on `log "Installing Hermes ..."` for a
`step_hermes_install` that self-gates to a no-op there. Gating that log would
renumber every openclaw step, which the docs and operator muscle memory depend
on — a separate decision, not this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer progress indicators now show accurate step totals for each edition, including Hermes and dual editions.
  * Updated recovery documentation to describe edition-dependent installer progress generically.

* **Tests**
  * Added coverage to verify that displayed installer progress matches the steps executed across supported editions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->