### PR TITLE
fix: the Codex credential mirror reads the auth store OpenClaw 2026.8 actually writes, and ranks it the way core does

### DIFF
--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -56,27 +56,110 @@ function readJson(file) {
 }
 
 /**
- * Auth profiles moved from agents/<id>/agent/auth-profiles.json into the
- * auth_profile_store table of openclaw-agent.sqlite on core 2026.7.x. Read
- * both so the mirror keeps working across a core downgrade.
+ * A store whose `profiles` map is EMPTY is not an answer.
+ *
+ * That is the shape a migrated box leaves behind, and treating it as one is
+ * what made this script skip on every 2026.8 box: the per-agent row survives
+ * `doctor --fix` with zero profiles, so `{}` shadowed the shared store that
+ * actually holds the login. Core inherits past exactly this state.
  */
-function readProfiles(agentDir) {
-  const fromJson = readJson(path.join(agentDir, "auth-profiles.json"));
-  if (fromJson && fromJson.profiles) return fromJson.profiles;
+function hasProfiles(store) {
+  return Boolean(store && store.profiles && Object.keys(store.profiles).length > 0);
+}
+
+/** The agent-local credential table, core 2026.7.x's home for the profiles. */
+function readAgentProfiles(agentDir) {
   try {
     const { DatabaseSync } = require("node:sqlite");
     const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"), {
       readOnly: true,
     });
-    const row = db
-      .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
-      .get("primary");
-    db.close();
+    db.exec("PRAGMA busy_timeout = 5000");
+    let row;
+    try {
+      row = db
+        .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+        .get("primary");
+    } finally {
+      db.close();
+    }
     const parsed = row && row.store_json ? JSON.parse(row.store_json) : null;
-    return (parsed && parsed.profiles) || null;
+    return hasProfiles(parsed) ? parsed.profiles : null;
   } catch {
     return null; // no node:sqlite, no table, or locked — non-fatal
   }
+}
+
+/**
+ * The state directory OpenClaw resolves the gateway-wide store from: an
+ * `OPENCLAW_STATE_DIR` override is trimmed, a leading `~` is the user's home
+ * and a relative path is taken from the cwd; without one it is the OpenClaw
+ * home. Same rule as src/lib/openclaw-state-store.ts, so this reads the file
+ * the gateway actually writes.
+ */
+function stateDbPath() {
+  const override = (process.env.OPENCLAW_STATE_DIR || "").trim();
+  const dir = override
+    ? path.resolve(override.replace(/^~(?=$|[\\/])/, () => process.env.HOME || os.homedir()))
+    : openclawHome;
+  return path.join(dir, "state", "openclaw.sqlite");
+}
+
+const SHARED_STORE_KEY = "authProfiles.store";
+
+/**
+ * The gateway-wide store, where core keeps the profiles on 2026.8:
+ * `<stateDir>/state/openclaw.sqlite`, table `config_machine_state`, row
+ * `authProfiles.store`. `openclaw doctor --fix` performs the relocation once
+ * and every agent then resolves through it — read-through inheritance, core's
+ * own `docs/auth-credential-semantics.md`. The box records the move as
+ * `auth.sharedStore = {"location":"state-db"}` in the same table.
+ */
+function readSharedProfiles() {
+  const dbPath = stateDbPath();
+  if (!fs.existsSync(dbPath)) return null;
+  try {
+    const { DatabaseSync } = require("node:sqlite");
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    // The gateway's hot state database — channel pairing writes, node host
+    // config — not the quiet per-agent table the old reader touched. A
+    // SQLITE_BUSY here is swallowed to null and surfaces as "no codex OAuth
+    // profile yet", which is the message that hid this bug in the first place.
+    db.exec("PRAGMA busy_timeout = 5000");
+    let row;
+    try {
+      row = db
+        .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
+        .get(SHARED_STORE_KEY);
+    } finally {
+      db.close();
+    }
+    const parsed = row && row.value_json ? JSON.parse(row.value_json) : null;
+    return hasProfiles(parsed) ? parsed.profiles : null;
+  } catch {
+    return null; // no node:sqlite, no table, or locked — non-fatal
+  }
+}
+
+/**
+ * The profiles core would resolve for this agent.
+ *
+ * Three stores, because the credential moved twice: legacy
+ * agents/<id>/agent/auth-profiles.json, then the per-agent
+ * `auth_profile_store` table on 2026.7.x, then the shared state store on
+ * 2026.8. The legacy file is still first so a core downgrade keeps working;
+ * the two sqlite stores are then combined the way core combines them — the
+ * shared store as the read-through base with the agent's own profiles on top,
+ * never one shadowing the other, because an agent that has a local profile of
+ * its own still inherits the rest.
+ */
+function readProfiles(agentDir) {
+  const fromJson = readJson(path.join(agentDir, "auth-profiles.json"));
+  if (hasProfiles(fromJson)) return fromJson.profiles;
+  const local = readAgentProfiles(agentDir);
+  const shared = readSharedProfiles();
+  if (!local && !shared) return null;
+  return { ...(shared || {}), ...(local || {}) };
 }
 
 /** chatgpt_account_id lives in the access token's claims, not the profile. */
@@ -138,7 +221,7 @@ function profileKeyIn(profiles) {
   // subscription entitlement while THIS script found no credential, never
   // synthesized ~/.codex/auth.json and never wrote a rotation back.
   const keys = [
-    ...PROFILE_KEYS.filter((key) => profiles[key]),
+    ...PROFILE_KEYS.filter((key) => isChatgptProfile(key, profiles[key])),
     ...Object.keys(profiles).filter(
       (key) => !PROFILE_KEYS.includes(key) && isChatgptProfile(key, profiles[key]),
     ).sort(),
@@ -152,6 +235,13 @@ function credentialFromProfiles(agentDir) {
   const profile = key && profiles[key] && profiles[key].access ? profiles[key] : null;
   if (!profile) return null;
   return {
+    // The id this credential was READ from. A rotation is written back into
+    // this exact entry and no other: the profiles are merged across the shared
+    // and per-agent stores, so "some ChatGPT-shaped key in the local table" can
+    // be a different entry entirely — grafting an OAuth bundle onto it leaves
+    // the entry core actually resolves holding a spent refresh token, which is
+    // the split PROFILE_KEYS' own comment exists to prevent.
+    profileId: key,
     accessToken: profile.access,
     refreshToken: profile.refresh,
     idToken: profile.id || profile.access,
@@ -223,15 +313,18 @@ function writeMirror(dest, credential) {
  * is sometimes a symlink to ~/.codex; without this the same file gets written
  * twice, and a previous version deleted the real credential through the link.
  */
+function fileKey(file) {
+  try {
+    return path.join(fs.realpathSync.native(path.dirname(file)), path.basename(file));
+  } catch {
+    return file; // Directory doesn't exist yet — the raw path is unique enough.
+  }
+}
+
 function dedupePaths(files) {
   const seen = new Map();
   for (const file of files) {
-    let key = file;
-    try {
-      key = path.join(fs.realpathSync.native(path.dirname(file)), path.basename(file));
-    } catch {
-      // Directory doesn't exist yet — the raw path is unique enough.
-    }
+    const key = fileKey(file);
     if (!seen.has(key)) seen.set(key, file);
   }
   return [...seen.values()];
@@ -240,9 +333,18 @@ function dedupePaths(files) {
 /**
  * Write an app-server rotation back into core's auth profile store, so core
  * stops handing out a refresh token that has already been spent.
+ *
+ * Reaches the legacy JSON file and the per-agent table only. The shared state
+ * store 2026.8 relocates the profiles into is deliberately READ-ONLY here: core
+ * refreshes an `oauth` profile itself and serialises every refresh through
+ * `<stateDir>/locks/oauth-refresh/lock-<digest>` precisely to stop a
+ * `refresh_token_reused` storm, so an unlocked read-modify-write of that
+ * gateway-wide row from a timer could overwrite a live token with a spent one
+ * for every agent at once. `main()` therefore leaves the mirrors alone rather
+ * than guessing when it cannot write a rotation back.
  */
-function writeBackToCore(agentDirs, tokens) {
-  if (!tokens || !tokens.refresh_token) return false;
+function writeBackToCore(agentDirs, tokens, profileId) {
+  if (!tokens || !tokens.refresh_token || !profileId) return false;
   let wrote = false;
 
   // Legacy JSON store, still the source on some boxes.
@@ -250,9 +352,8 @@ function writeBackToCore(agentDirs, tokens) {
     const jsonPath = path.join(agentDir, "auth-profiles.json");
     const data = readJson(jsonPath);
     const profiles = data && data.profiles;
-    if (!profiles) continue;
-    const id = profileKeyIn(profiles);
-    if (!id) continue;
+    if (!profiles || !profiles[profileId]) continue;
+    const id = profileId;
     profiles[id].access = tokens.access_token || profiles[id].access;
     profiles[id].refresh = tokens.refresh_token;
     if (tokens.id_token) profiles[id].id = tokens.id_token;
@@ -277,8 +378,8 @@ function writeBackToCore(agentDirs, tokens) {
         if (!row || !row.store_json) continue;
         const store = JSON.parse(row.store_json);
         const profiles = store.profiles || {};
-        const id = profileKeyIn(profiles);
-        if (!id) continue;
+        if (!profiles[profileId]) continue;
+        const id = profileId;
         profiles[id].access = tokens.access_token || profiles[id].access;
         profiles[id].refresh = tokens.refresh_token;
         if (tokens.id_token) profiles[id].id = tokens.id_token;
@@ -293,6 +394,7 @@ function writeBackToCore(agentDirs, tokens) {
       // Locked or unavailable — the next timer tick retries.
     }
   }
+
   return wrote;
 }
 
@@ -333,13 +435,29 @@ function main() {
     ...agentDirs.map((dir) => path.join(dir, "codex-home", "auth.json")),
   ]);
 
+  /**
+   * Only a file the Codex app-server owns can be AHEAD of core.
+   *
+   * The app-server rotates whatever sits in its CODEX_HOME; nothing rotates
+   * `~/.codex/auth.json` — the codex plugin reads it and never writes it, and
+   * no process runs with CODEX_HOME=~/.codex (see buildAuthFile's note). So a
+   * divergence there is by definition a STALE copy and must be repaired, while
+   * a divergence in a codex-home file may be a live rotation. Compared by
+   * resolved path, because <agentDir>/codex-home is sometimes a symlink to
+   * ~/.codex — on such a box that one file IS an app-server home.
+   */
+  const appServerHomes = new Set(
+    agentDirs.map((dir) => fileKey(path.join(dir, "codex-home", "auth.json"))),
+  );
+  const isAppServerHome = (dest) => appServerHomes.has(fileKey(dest));
+
   // The app-server rotates its own CODEX_HOME credential. Refresh tokens are
   // single-use, so if it has already rotated, core's stored copy is the DEAD
   // one -- overwriting the file with it would burn the family on next use.
   // Core follows the app-server, never the other way round.
-  const rotated = destinations
+  const diverged = destinations
     .map((dest) => ({ dest, data: readJson(dest) }))
-    .find(({ data }) => {
+    .filter(({ data }) => {
       const tokens = (data && data.tokens) || {};
       return (
         typeof tokens.refresh_token === "string" &&
@@ -347,29 +465,56 @@ function main() {
         tokens.refresh_token !== credential.refreshToken
       );
     });
+  const rotated = diverged.find(({ dest }) => isAppServerHome(dest));
+
+  // Destinations this pass must not touch. Only ever app-server homes whose
+  // rotation could not be recorded in core: overwriting one could burn the
+  // family (#278). NEVER the plugin's own file — abandoning that is how a box
+  // ends up with no ~/.codex/auth.json at all, which is the `401 Missing
+  // bearer` this script exists to prevent, and the ChatGPT sign-in route
+  // deletes that file on every re-login so it has to be recreated here.
+  const skip = new Set();
 
   if (rotated) {
     const tokens = rotated.data.tokens;
-    if (writeBackToCore(agentDirs, tokens)) {
+    if (writeBackToCore(agentDirs, tokens, credential.profileId)) {
       log(`Codex auth.json: adopted app-server rotation from ${rotated.dest}`);
       credential = {
+        profileId: credential.profileId,
         accessToken: tokens.access_token || credential.accessToken,
         refreshToken: tokens.refresh_token,
         idToken: tokens.id_token || credential.idToken,
         accountId: tokens.account_id || credential.accountId,
       };
+    } else {
+      // Per destination, never the whole pass: core's own refresh moves the
+      // store ahead of every mirror, and treating that as "the file is ahead"
+      // would stop the mirror on a box where the files are simply old. Each
+      // app-server home that still disagrees is left as it is; everything else
+      // is written.
+      for (const { dest } of diverged) {
+        if (isAppServerHome(dest)) skip.add(dest);
+      }
+      // console.error, not log(): the timer unit runs with
+      // CODEX_AUTH_MIRROR_QUIET=1, and this is the one state that is not
+      // "normal and idempotent" — a box stuck here needs a person.
+      console.error(
+        `  Codex auth.json: ${rotated.dest} holds a refresh token core does not have and core's store could not be updated; leaving that file alone. `
+        + "If Codex turns keep failing, delete it and sign in to ChatGPT again.",
+      );
     }
   }
 
   let synced = 0;
   for (const dest of destinations) {
+    if (skip.has(dest)) continue;
     const reason = writeMirror(dest, credential);
     if (reason) {
       synced += 1;
       log(`Codex auth.json ${reason}: ${dest}`);
     }
   }
-  if (synced === 0) log("Codex auth.json: credential already current");
+  if (synced === 0 && skip.size === 0) log("Codex auth.json: credential already current");
 }
 
 try {

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -433,52 +433,79 @@ function syncReason(existing, credential) {
   return null;
 }
 
+/**
+ * Tighten one path that holds — or contains — an OAuth token, on EVERY pass.
+ *
+ * `writeFileSync(..., { mode })` applies the mode on CREATION only, so a file
+ * another tool left 0644 kept that mode through every rewrite while holding a
+ * refresh token. Repairing it only where the credential is rewritten was the
+ * same defect one step further out: a mirror that is already current but 0644
+ * short-circuits on "credential already current" and stays world-readable for
+ * the life of the box. So this is called before that short-circuit, not after
+ * it, and the pass that runs 144 times a day is the one that repairs it.
+ *
+ * Nothing else will: core's own permission repair (`openclaw doctor --fix`,
+ * the state-integrity check) covers the state dir, the config file and the
+ * runtime state dirs, and never `~/.codex` or an agent's `codex-home`; core's
+ * Codex credential reader only reads `auth.json`. This script is the sole
+ * writer of these files, so it is the only place their mode can be enforced.
+ *
+ * The trigger is core's own: `doctor` tightens when any group/other bit is set
+ * (`(stat.mode & 0o77) !== 0`) and repairs to the same 0700 / 0600. Matching it
+ * keeps the common pass a single `statSync` with no write at all, and never
+ * widens a path an operator deliberately made stricter — 0400 stays 0400.
+ *
+ * Non-fatal, and reported on stderr rather than through log(): the timer unit
+ * runs with CODEX_AUTH_MIRROR_QUIET=1, so a log() line here would be silent on
+ * exactly the path that runs 144 times a day, and a credential left readable by
+ * other users would say nothing at all. An EPERM (a path owned by another user)
+ * must also never abort the pass: for the directory this runs BEFORE the write,
+ * and throwing here once aborted main()'s whole destinations loop — losing this
+ * mirror AND every later one, including the app-server's CODEX_HOME copy
+ * without which every Codex turn falls back to the Cloudflare-challenged
+ * browser endpoint. One un-tightenable path must cost that path's permissions,
+ * not the pass.
+ */
+function enforceMode(target, mode) {
+  const complain = (error) =>
+    console.error(
+      `  Codex auth.json: could not tighten permissions on ${target} — it may be readable by other users (${error.code || error.message}).`,
+    );
+  let current;
+  try {
+    current = fs.statSync(target).mode;
+  } catch (error) {
+    // ENOENT is the create path: nothing to tighten yet, and writeMirror's
+    // own write creates the file 0600. Anything else is a path whose
+    // permissions cannot even be READ — not "normal and idempotent", so it is
+    // named rather than swallowed.
+    if (error.code !== "ENOENT") complain(error);
+    return;
+  }
+  if ((current & 0o077) === 0) return;
+  try {
+    fs.chmodSync(target, mode);
+  } catch (error) {
+    complain(error);
+  }
+}
+
 function writeMirror(dest, credential) {
   const existing = readJson(dest);
   const reason = syncReason(existing, credential);
-  if (!reason) return null;
   const dir = path.dirname(dest);
-  fs.mkdirSync(dir, { recursive: true });
-  // Holds an OAuth token — owner-only dir, not just the 0600 file.
-  //
-  // Guarded for the same reason the file chmod below is, and it costs more
-  // when it is not: this runs BEFORE the write, so an EPERM here (a codex dir
-  // owned by another user) threw out of writeMirror and aborted main()'s whole
-  // destinations loop — losing this mirror AND every later one, including the
-  // app-server's CODEX_HOME copy without which every Codex turn falls back to
-  // the Cloudflare-challenged browser endpoint. One un-tightenable directory
-  // must cost that directory's permissions, not the pass. The credential is
-  // still written 0600, so the file itself stays owner-only either way.
-  try {
-    fs.chmodSync(dir, 0o700);
-  } catch (error) {
-    console.error(
-      `  Codex auth.json: could not tighten permissions on ${dir} — it may be readable by other users (${error.code || error.message}).`,
-    );
-  }
+  // Before the write, so a directory this pass just created is owner-only
+  // before a credential lands in it — and before the short-circuit below, so an
+  // already-current mirror is repaired too.
+  if (reason) fs.mkdirSync(dir, { recursive: true });
+  enforceMode(dir, 0o700);
+  enforceMode(dest, 0o600);
+  if (!reason) return null;
   fs.writeFileSync(
     dest,
     JSON.stringify(buildAuthFile(credential, existing), null, 2),
     { mode: 0o600 },
   );
-  // `mode` applies on CREATION only, so a file another tool left 0644 stayed
-  // 0644 through every rewrite while holding a refresh token. Non-fatal: the
-  // credential is written either way, and an EPERM here (a file owned by
-  // another user) must not abort the rest of the pass.
-  //
-  // console.error, not log(): the timer unit runs with
-  // CODEX_AUTH_MIRROR_QUIET=1, so a log() line here is silent on the path that
-  // runs 144 times a day — a mirror left world-readable while holding an OAuth
-  // refresh token would say nothing at all. The rule this file keeps is that a
-  // state which is not "normal and idempotent" goes to stderr, and failing to
-  // tighten permissions on a credential file is that state.
-  try {
-    fs.chmodSync(dest, 0o600);
-  } catch (error) {
-    console.error(
-      `  Codex auth.json: could not tighten permissions on ${dest} — it may be readable by other users (${error.code || error.message}).`,
-    );
-  }
   return reason;
 }
 
@@ -779,7 +806,18 @@ function main() {
 
   let synced = 0;
   for (const dest of destinations) {
-    if (skip.has(dest)) continue;
+    if (skip.has(dest)) {
+      // The sibling call site of writeMirror's own permission pass, and the one
+      // that matters most: a skipped file is left alone because its CONTENT
+      // must not be overwritten, and on a 2026.8 box it can hold that refresh
+      // token for the life of the box (writeBackToCore can never settle it
+      // there). Tightening a mode touches no credential, so the reason it is
+      // skipped does not reach this — and "the file we refuse to touch" is
+      // exactly the one that would otherwise stay world-readable forever.
+      enforceMode(path.dirname(dest), 0o700);
+      enforceMode(dest, 0o600);
+      continue;
+    }
     const reason = writeMirror(dest, credential);
     if (reason) {
       synced += 1;

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -47,6 +47,16 @@ function log(message) {
   if (!quiet) console.log("  " + message);
 }
 
+/**
+ * node:sqlite, resolved lazily at every call site that needs it. One `require`
+ * for the whole file, and still lazy: a core old enough to lack the builtin
+ * must fall through to the caller's catch, not fail at module load — this
+ * script runs from gateway-pre-start.sh and may never block a gateway start.
+ */
+function sqliteDatabase() {
+  return require("node:sqlite").DatabaseSync;
+}
+
 function readJson(file) {
   try {
     return JSON.parse(fs.readFileSync(file, "utf8"));
@@ -70,7 +80,7 @@ function hasProfiles(store) {
 /** The agent-local credential table, core 2026.7.x's home for the profiles. */
 function readAgentProfiles(agentDir) {
   try {
-    const { DatabaseSync } = require("node:sqlite");
+    const DatabaseSync = sqliteDatabase();
     const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"), {
       readOnly: true,
     });
@@ -122,16 +132,24 @@ const SHARED_STORE_OWNERSHIP_KEY = "auth.sharedStore";
  * never consults; mirroring from it hands the Codex runtime a credential core
  * does not resolve.
  *
- * Core throws on an unparseable value. A credential mirror must not — anything
- * that is not an explicit `state-db` is treated as `legacy-main` and the row is
- * left unread, which is the same answer core reaches for every legal value but
- * one.
+ * Core throws `InvalidSharedAuthStoreOwnershipError` on a value that is not
+ * exactly `{location: "legacy-main"|"state-db"}` — one key, nothing else. A
+ * credential mirror must not throw, so the same shape test answers `false`
+ * instead: anything that is not an explicit, well-formed `state-db` is treated
+ * as `legacy-main` and the row is left unread. That is core's answer for every
+ * value it accepts but one, and for the values it rejects it refuses to boot at
+ * all — so mirroring from such a row could only ever be wrong.
  */
 function ownsSharedStore(valueJson) {
   if (typeof valueJson !== "string") return false;
   try {
     const parsed = JSON.parse(valueJson);
-    return Boolean(parsed) && parsed.location === "state-db";
+    return (
+      Boolean(parsed) &&
+      typeof parsed === "object" &&
+      Object.keys(parsed).length === 1 &&
+      parsed.location === "state-db"
+    );
   } catch {
     return false;
   }
@@ -151,7 +169,7 @@ function readSharedProfiles() {
   const dbPath = stateDbPath();
   if (!fs.existsSync(dbPath)) return null;
   try {
-    const { DatabaseSync } = require("node:sqlite");
+    const DatabaseSync = sqliteDatabase();
     const db = new DatabaseSync(dbPath, { readOnly: true });
     // The gateway's hot state database — channel pairing writes, node host
     // config — not the quiet per-agent table the old reader touched. A
@@ -270,20 +288,34 @@ function profileKeyIn(profiles) {
   const candidates = Object.keys(profiles).filter((key) => isChatgptProfile(key, profiles[key]));
   if (candidates.length === 0) return null;
 
-  // Rank the way core ranks, not by id. `orderProfilesByMode` sorts oauth
-  // before token before api_key, then an UNEXPIRED credential ahead of an
-  // expired one, and only then reaches a stable tie-break — and an expired
-  // OAuth profile stays *eligible* there, because core refreshes it (the
-  // `expired` reason code is scoped to `type: "token"` in
-  // docs/auth-credential-semantics.md). So expiry demotes a candidate here; it
-  // never drops one, and a dead credential is still better than none.
-  //
-  // Ranking by id alone is what broke: the read set spans the shared and the
-  // per-agent store, so `openai:chatgpt` at the head of PROFILE_KEYS let a
+  // Ranking by id ALONE is what broke: the read set now spans the shared and
+  // the per-agent store, so `openai:chatgpt` at the head of PROFILE_KEYS let a
   // shared entry that expired hours ago outrank an agent's OWN live
   // `openai:default`, and the timer rewrote the spent token over the live one
-  // every ten minutes. PROFILE_KEYS is the tie-break among equally usable
-  // candidates, which is all it was ever measuring.
+  // every ten minutes.
+  //
+  // So one step goes in front of the id preference, and only one: whether the
+  // credential is expired. That mirrors the single step of core's own
+  // comparator this script can evaluate — `orderProfilesByMode` scores an
+  // expired OAuth credential below an unexpired one
+  // (`resolveTokenExpiryState`, openclaw dist/order-*.js). Expiry DEMOTES a
+  // candidate here, it never drops one, because core keeps an expired OAuth
+  // profile eligible and refreshes it (the `expired` reason code is scoped to
+  // `type: "token"` — docs/auth-credential-semantics.md); a dead credential
+  // still beats none. A missing or unusable `expires` is "unknown", never
+  // "expired", which is core's answer too (`resolveTokenExpiryState` returns
+  // `missing`/`invalid_expires`, and only `expired` scores).
+  //
+  // NOT ranked by `expires` descending, however tempting: `expires` is issue
+  // time PLUS that client's token lifetime, and the lifetimes differ. ClawBox's
+  // own sign-in writer stamps `Date.now() + expiresIn*1000` and falls back to
+  // eight hours, so a fresh ChatGPT sign-in routinely carries the SMALLEST
+  // `expires` on a box that has ever run `codex login` — ordering by it would
+  // mirror the older account.
+  //
+  // PROFILE_KEYS then decides, exactly as it did before this PR: it is the id
+  // ClawBox files the sign-in under, and the only signal here that tracks which
+  // profile core resolves for an `openai/*` route.
   const now = Date.now();
   const ranked = candidates
     .map((key) => {
@@ -296,9 +328,6 @@ function profileKeyIn(profiles) {
         // a candidate so a rotation still has somewhere to land.
         uncredentialed: entry && entry.access ? 0 : 1,
         expired: expires !== null && expires <= now ? 1 : 0,
-        // Later expiry means more recently issued: after a re-login the
-        // freshest credential is the account the owner actually signed in to.
-        staleness: -(expires ?? 0),
         preference: preference === -1 ? PROFILE_KEYS.length : preference,
       };
     })
@@ -306,7 +335,6 @@ function profileKeyIn(profiles) {
       (a, b) =>
         a.uncredentialed - b.uncredentialed ||
         a.expired - b.expired ||
-        a.staleness - b.staleness ||
         a.preference - b.preference ||
         a.key.localeCompare(b.key),
     );
@@ -346,10 +374,13 @@ function credentialFromProfiles(agentDir) {
  * attempt at this fix stripped the field and broke Codex exactly that way.
  *
  * Safety comes from WHERE it is written, not from omitting it: only
- * ~/.codex/auth.json gets a credential, and nothing rotates that file. The
- * codex plugin reads it and never writes it, and no process runs with
- * CODEX_HOME=~/.codex. The file the Codex app-server *does* rotate is
- * <agentDir>/codex-home/auth.json -- see the destination list in main().
+ * ~/.codex/auth.json gets a credential, and on a ClawBox nothing rotates that
+ * file. The codex plugin reads it and never writes it, and the app-server's
+ * CODEX_HOME is <agentDir>/codex-home -- the file it *does* rotate, see the
+ * destination list in main(). Core has one documented opt-in that would point
+ * the app-server at ~/.codex instead, `appServer.homeScope: "user"`
+ * (docs/plugins/codex-harness-reference.md); ClawBox never sets it and nothing
+ * in this repo writes it, so that shape is out of scope here.
  */
 function buildAuthFile(credential, existing) {
   return {
@@ -391,15 +422,23 @@ function writeMirror(dest, credential) {
     { mode: 0o600 },
   );
   // `mode` applies on CREATION only, so a file another tool left 0644 stayed
-  // 0644 through every rewrite while holding a refresh token.
-  fs.chmodSync(dest, 0o600);
+  // 0644 through every rewrite while holding a refresh token. Non-fatal: the
+  // credential is written either way, and an EPERM here (a file owned by
+  // another user) must not abort the rest of the pass — main()'s only handler
+  // is a log line the timer unit suppresses.
+  try {
+    fs.chmodSync(dest, 0o600);
+  } catch {
+    log(`Codex auth.json: could not tighten permissions on ${dest}`);
+  }
   return reason;
 }
 
 
 /**
- * Collapse destinations that resolve to the same file. <agentDir>/codex-home
- * is sometimes a symlink to ~/.codex; without this the same file gets written
+ * Collapse destinations that resolve to the same file. Nothing in this repo
+ * creates it, but <agentDir>/codex-home CAN be a symlink to ~/.codex on a box
+ * an operator has linked by hand; without this the same file gets written
  * twice, and a previous version deleted the real credential through the link.
  */
 function fileKey(file) {
@@ -435,9 +474,10 @@ function dedupePaths(files) {
  * did; that hazard is older than this script's shared-store read and is not
  * settled here.)
  *
- * When a rotation cannot be recorded, `main()` leaves the app-server home that
- * carries it alone rather than guessing — per destination, never the whole
- * pass, and never the plugin's own file.
+ * When a rotation cannot be recorded — and when two app-server homes have
+ * rotated independently, where there is no single right answer — `main()`
+ * leaves those homes alone rather than guessing: per destination, never the
+ * whole pass, and never the plugin's own file.
  *
  * ONLY the agent the credential was resolved from. A profile id is a key
  * within one agent's store, not a fleet-wide identity: a second agent may hold
@@ -471,7 +511,7 @@ function writeBackToCore(agentDirs, tokens, profileId) {
     const dbPath = path.join(agentDir, "openclaw-agent.sqlite");
     if (!fs.existsSync(dbPath)) continue;
     try {
-      const { DatabaseSync } = require("node:sqlite");
+      const DatabaseSync = sqliteDatabase();
       const db = new DatabaseSync(dbPath);
       // Same timeout as both readers: without it a transient SQLITE_BUSY is
       // swallowed below, becomes `wrote = false`, and is reported to the
@@ -550,11 +590,12 @@ function main() {
    *
    * The app-server rotates whatever sits in its CODEX_HOME; nothing rotates
    * `~/.codex/auth.json` — the codex plugin reads it and never writes it, and
-   * no process runs with CODEX_HOME=~/.codex (see buildAuthFile's note). So a
+   * no ClawBox process runs with CODEX_HOME=~/.codex (see buildAuthFile's note
+   * for the one core opt-in that would, which ClawBox never sets). So a
    * divergence there is by definition a STALE copy and must be repaired, while
    * a divergence in a codex-home file may be a live rotation. Compared by
-   * resolved path, because <agentDir>/codex-home is sometimes a symlink to
-   * ~/.codex — on such a box that one file IS an app-server home.
+   * resolved path, because <agentDir>/codex-home CAN be a symlink to ~/.codex —
+   * on such a box that one file IS an app-server home.
    */
   const appServerHomes = new Set(
     agentDirs.map((dir) => fileKey(path.join(dir, "codex-home", "auth.json"))),
@@ -562,11 +603,11 @@ function main() {
   const homeAuthKey = fileKey(homeAuthPath);
   const isAppServerHome = (dest) => appServerHomes.has(fileKey(dest));
   // ...but the plugin's own file is never abandoned, even when it is also an
-  // app-server home. On a symlinked box dedupePaths collapses both
+  // app-server home. On a hand-symlinked box dedupePaths collapses both
   // destinations onto it, so skipping it leaves the box with NO usable
   // credential anywhere and every Codex turn dies on `401 Missing bearer` —
   // the failure this script exists to prevent — while the worst case of
-  // writing it is one rotation lost on a configuration ClawBox never creates.
+  // writing it is one rotation lost on a shape nothing in this repo creates.
   const isPluginOwnFile = (dest) => fileKey(dest) === homeAuthKey;
 
   // The app-server rotates its own CODEX_HOME credential. Refresh tokens are
@@ -583,7 +624,16 @@ function main() {
         tokens.refresh_token !== credential.refreshToken
       );
     });
-  const rotated = diverged.find(({ dest }) => isAppServerHome(dest));
+  const divergedAppServerHomes = diverged.filter(({ dest }) => isAppServerHome(dest));
+  // Core's store holds ONE refresh token per profile, so it can record one
+  // rotation. Adopting one of several means the rest are overwritten with it —
+  // and skipping them only postpones that: on the next tick the skipped file is
+  // the sole divergence, becomes the adopted one, and the first agent's live
+  // token is discarded instead. Two tokens of one family, written into core ten
+  // minutes apart, is the `refresh_token_reused` shape this file exists to
+  // prevent. With more than one there is no correct single answer, so nothing
+  // is adopted and every one of them is left alone for a person to settle.
+  const rotated = divergedAppServerHomes.length === 1 ? divergedAppServerHomes[0] : undefined;
 
   // Destinations this pass must not touch. Only ever app-server homes whose
   // rotation could not be recorded in core: overwriting one could burn the
@@ -593,17 +643,16 @@ function main() {
   // deletes that file on every re-login so it has to be recreated here.
   const skip = new Set();
 
-  if (rotated) {
-    const tokens = rotated.data.tokens;
-    // Every OTHER diverged app-server home owns a rotation of its own: two
-    // agents run two app-servers, each rotating its own CODEX_HOME, and core
-    // can record only one of them. Writing the adopted token over the rest
-    // discards their live refresh tokens — the same burn the failure branch
-    // below exists to prevent. (The plugin's own file is still never skipped;
-    // see isPluginOwnFile.)
-    for (const { dest } of diverged) {
-      if (dest !== rotated.dest && isAppServerHome(dest) && !isPluginOwnFile(dest)) skip.add(dest);
+  // The plugin's own file is never skipped even when it is also an app-server
+  // home (see isPluginOwnFile), so a symlinked box still gets a credential.
+  const leaveAlone = (dest) => isAppServerHome(dest) && !isPluginOwnFile(dest);
+
+  if (!rotated && divergedAppServerHomes.length > 1) {
+    for (const { dest } of divergedAppServerHomes) {
+      if (leaveAlone(dest)) skip.add(dest);
     }
+  } else if (rotated) {
+    const tokens = rotated.data.tokens;
     if (writeBackToCore([credentialAgentDir], tokens, credential.profileId)) {
       log(`Codex auth.json: adopted app-server rotation from ${rotated.dest}`);
       credential = {
@@ -620,25 +669,25 @@ function main() {
       // app-server home that still disagrees is left as it is; everything else
       // is written.
       for (const { dest } of diverged) {
-        if (isAppServerHome(dest) && !isPluginOwnFile(dest)) skip.add(dest);
-      }
-      // Only about files actually left behind, and naming those rather than
-      // whichever divergence was found first: on a symlinked box the sole
-      // destination is the plugin's own file, which this pass then rewrites,
-      // and warning about it would be a false failure.
-      //
-      // console.error, not log(): the timer unit runs with
-      // CODEX_AUTH_MIRROR_QUIET=1, and this is the one state that is not
-      // "normal and idempotent". A ChatGPT sign-in clears these mirrors at the
-      // source (the configure route), so this survives at most until the next
-      // one.
-      if (skip.size > 0) {
-        console.error(
-          `  Codex auth.json: ${[...skip].join(", ")} holds a refresh token core does not have and core's store could not be updated; leaving that file alone. `
-          + "If Codex turns keep failing, delete it and sign in to ChatGPT again.",
-        );
+        if (leaveAlone(dest)) skip.add(dest);
       }
     }
+  }
+
+  // One message for every state that leaves a file behind, naming the files
+  // actually skipped rather than whichever divergence was found first: on a
+  // symlinked box the sole destination is the plugin's own file, which this
+  // pass then rewrites, and warning about it would be a false failure.
+  //
+  // console.error, not log(): the timer unit runs with
+  // CODEX_AUTH_MIRROR_QUIET=1, and this is the one state that is not "normal
+  // and idempotent". A ChatGPT sign-in clears these mirrors at the source (the
+  // configure route), so it survives at most until the next one.
+  if (skip.size > 0) {
+    console.error(
+      `  Codex auth.json: ${[...skip].join(", ")} holds a refresh token core does not have and core's store could not be updated; leaving that file alone. `
+      + "If Codex turns keep failing, delete it and sign in to ChatGPT again.",
+    );
   }
 
   let synced = 0;
@@ -650,7 +699,11 @@ function main() {
       log(`Codex auth.json ${reason}: ${dest}`);
     }
   }
-  if (synced === 0 && skip.size === 0) log("Codex auth.json: credential already current");
+  // Skipped destinations are already reported above; this line is about the
+  // ones this pass owns, so a single left-behind file must not silence it.
+  if (synced === 0 && skip.size < destinations.length) {
+    log("Codex auth.json: credential already current");
+  }
 }
 
 try {

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -245,8 +245,10 @@ const PROFILE_KEYS = ["openai:chatgpt", "codex:default", "openai-codex:default"]
  *
  * The most usable entry, by core's own ranking (see profileKeyIn). A canonical
  * entry left half-written by an interrupted sign-in must not hide a legacy one
- * that still works; an entry that merely EXISTS is a last resort, so a rotation
- * still lands somewhere when nothing is credentialed yet.
+ * that still works, so an entry with no access token sorts LAST rather than
+ * being dropped. It is never a fallback: when such an entry ranks first there
+ * is no credential on the box at all, `credentialFromProfiles` returns null and
+ * `main()` stops before any mirror or write-back.
  *
  * One rule for both directions, deliberately. Reading by one rule and writing
  * back by another is how a box ends up reading `codex:default` and writing the
@@ -302,9 +304,28 @@ function profileKeyIn(profiles) {
   // candidate here, it never drops one, because core keeps an expired OAuth
   // profile eligible and refreshes it (the `expired` reason code is scoped to
   // `type: "token"` — docs/auth-credential-semantics.md); a dead credential
-  // still beats none. A missing or unusable `expires` is "unknown", never
-  // "expired", which is core's answer too (`resolveTokenExpiryState` returns
-  // `missing`/`invalid_expires`, and only `expired` scores).
+  // still beats none.
+  //
+  // Three tiers, not two: live, then UNKNOWN, then expired. A missing or
+  // unusable `expires` is never "expired" — that is core's answer too
+  // (`resolveTokenExpiryState` returns `missing`/`invalid_expires`, and only
+  // `expired` scores) — but it is not evidence of life either, so it must not
+  // tie with a credential this box can see is still valid. Defensive only:
+  // neither this repo's sign-in writer nor the Codex CLI omits `expires`, so no
+  // shipped writer produces the shape. Ranking such an entry level with a live
+  // one let a PROFILE_KEYS-preferred profile carrying no `expires` outrank an
+  // agent's own demonstrably live login.
+  //
+  // LIMIT, stated rather than papered over: the only expiry signal here is the
+  // box's wall clock. On a Jetson carrier board with no battery-backed RTC the
+  // clock can be hours behind at boot — which is exactly when
+  // gateway-pre-start.sh runs this — and a genuinely expired credential then
+  // reads as live, every candidate ties, and the rank falls back to
+  // PROFILE_KEYS, i.e. to beta's ordering. No local check closes that: a grace
+  // period only forgives a clock running AHEAD, and the access token's own JWT
+  // `exp` claim is evaluated against the same wrong clock. It self-heals on the
+  // next ten-minute timer tick once NTP lands, and the degraded state is what
+  // beta always did, so it is left as a known bound.
   //
   // NOT ranked by `expires` descending, however tempting: `expires` is issue
   // time PLUS that client's token lifetime, and the lifetimes differ. ClawBox's
@@ -324,17 +345,20 @@ function profileKeyIn(profiles) {
       const preference = PROFILE_KEYS.indexOf(key);
       return {
         key,
-        // A profile with no access token cannot be mirrored at all; it is only
-        // a candidate so a rotation still has somewhere to land.
+        // A profile with no access token cannot be mirrored at all. It stays a
+        // candidate only so a half-written canonical entry cannot HIDE a legacy
+        // one that still works; ranked last, it is never selected over a
+        // credentialed entry, and when it wins the pass has no credential.
         uncredentialed: entry && entry.access ? 0 : 1,
-        expired: expires !== null && expires <= now ? 1 : 0,
+        // 0 live, 1 unknown, 2 expired.
+        expiry: expires === null ? 1 : expires <= now ? 2 : 0,
         preference: preference === -1 ? PROFILE_KEYS.length : preference,
       };
     })
     .sort(
       (a, b) =>
         a.uncredentialed - b.uncredentialed ||
-        a.expired - b.expired ||
+        a.expiry - b.expiry ||
         a.preference - b.preference ||
         a.key.localeCompare(b.key),
     );
@@ -424,12 +448,20 @@ function writeMirror(dest, credential) {
   // `mode` applies on CREATION only, so a file another tool left 0644 stayed
   // 0644 through every rewrite while holding a refresh token. Non-fatal: the
   // credential is written either way, and an EPERM here (a file owned by
-  // another user) must not abort the rest of the pass — main()'s only handler
-  // is a log line the timer unit suppresses.
+  // another user) must not abort the rest of the pass.
+  //
+  // console.error, not log(): the timer unit runs with
+  // CODEX_AUTH_MIRROR_QUIET=1, so a log() line here is silent on the path that
+  // runs 144 times a day — a mirror left world-readable while holding an OAuth
+  // refresh token would say nothing at all. The rule this file keeps is that a
+  // state which is not "normal and idempotent" goes to stderr, and failing to
+  // tighten permissions on a credential file is that state.
   try {
     fs.chmodSync(dest, 0o600);
-  } catch {
-    log(`Codex auth.json: could not tighten permissions on ${dest}`);
+  } catch (error) {
+    console.error(
+      `  Codex auth.json: could not tighten permissions on ${dest} — it may be readable by other users (${error.code || error.message}).`,
+    );
   }
   return reason;
 }
@@ -483,7 +515,11 @@ function dedupePaths(files) {
  * within one agent's store, not a fleet-wide identity: a second agent may hold
  * the same id for a different account, and writing this rotation into it would
  * replace a refresh token that belongs to someone else and break its next
- * refresh.
+ * refresh. Note the consequence when the rotation came from agent B's
+ * codex-home while the credential resolved from agent A: it is recorded in A's
+ * store, the one core will resolve next. That is deliberate — A is the store
+ * that hands out the token, and on the two shapes that ship it is either
+ * unwritable (`state-db`) or A is `main`, whose store IS the shared store.
  */
 function writeBackToCore(agentDirs, tokens, profileId) {
   if (!tokens || !tokens.refresh_token || !profileId) return false;
@@ -517,7 +553,24 @@ function writeBackToCore(agentDirs, tokens, profileId) {
       // swallowed below, becomes `wrote = false`, and is reported to the
       // operator as an unsettleable divergence — a false failure over a lock.
       db.exec("PRAGMA busy_timeout = 5000");
+      let open = false;
       try {
+        // BEGIN IMMEDIATE, because busy_timeout serialises each statement's
+        // lock acquisition and nothing more: the SELECT and the UPDATE below
+        // are a read-modify-write of ONE json blob holding every profile, so a
+        // writer landing between them is silently overwritten — and not only
+        // for this profile id, for all of them. That writer exists: on a
+        // `legacy-main` box this table IS the store core reads and writes when
+        // it refreshes an OAuth credential itself, and two mirror passes can
+        // overlap too (the boot pass from gateway-pre-start.sh and a timer
+        // tick). Losing core's freshly rotated refresh token to the one this
+        // pass read is precisely the `refresh_token_reused` shape the rest of
+        // this file exists to prevent. IMMEDIATE takes the write lock before
+        // the read, so a concurrent writer waits out the busy_timeout instead;
+        // if it cannot, this pass fails into the catch below and the next tick
+        // retries, which is the existing non-fatal contract.
+        db.exec("BEGIN IMMEDIATE");
+        open = true;
         const row = db
           .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
           .get("primary");
@@ -532,8 +585,19 @@ function writeBackToCore(agentDirs, tokens, profileId) {
         store.profiles = profiles;
         db.prepare("UPDATE auth_profile_store SET store_json = ?, updated_at = ? WHERE store_key = ?")
           .run(JSON.stringify(store), Date.now(), "primary");
+        db.exec("COMMIT");
+        open = false;
+        // Only after the COMMIT: a rotation reported as recorded but rolled
+        // back would leave main() adopting a token core does not hold.
         wrote = true;
       } finally {
+        if (open) {
+          try {
+            db.exec("ROLLBACK");
+          } catch {
+            // Closing the handle rolls it back anyway; never mask the original.
+          }
+        }
         db.close();
       }
     } catch {
@@ -700,9 +764,14 @@ function main() {
     }
   }
   // Skipped destinations are already reported above; this line is about the
-  // ones this pass owns, so a single left-behind file must not silence it.
+  // ones this pass owns, so a single left-behind file must not silence it —
+  // and must not let it read as "every mirror is current" either, which is the
+  // opposite of the warning printed a few lines up.
   if (synced === 0 && skip.size < destinations.length) {
-    log("Codex auth.json: credential already current");
+    log(
+      "Codex auth.json: credential already current" +
+        (skip.size > 0 ? " on the files this pass owns" : ""),
+    );
   }
 }
 

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -500,7 +500,54 @@ function writeMirror(dest, credential) {
   const existing = readJson(dest);
   const reason = syncReason(existing, credential);
   const dir = path.dirname(dest);
-  if (reason) fs.mkdirSync(dir, { recursive: true });
+  /**
+   * BOTH per-destination operations that can throw end here. A throw out of
+   * writeMirror leaves main()'s destinations loop, so one unwritable
+   * destination costs every destination behind it — the other agents'
+   * CODEX_HOME copies — silently, with only the top-level catch's raw syscall
+   * line to show for it. One unwritable destination must cost that destination
+   * alone. Never reported as synced either: a mirror counted as written that
+   * was not is the false success this file keeps guarding against.
+   *
+   * console.error, not log(): the timer unit runs with
+   * CODEX_AUTH_MIRROR_QUIET=1, which is exactly the path this can happen on.
+   */
+  const writeFailed = (detail) => {
+    console.error(
+      `  Codex auth.json: could not write ${dest} (${detail}); the remaining mirrors are still being synced.`,
+    );
+    return WRITE_FAILED;
+  };
+  if (reason) {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+    } catch (error) {
+      // The FIRST of the two, and it throws on shapes a box really has, each
+      // with its own errno (measured, node 22, recursive mkdir): an <agentDir>
+      // the owner cannot write, EACCES; a codex-home that is a regular file,
+      // EEXIST; one that is a dangling symlink, ENOENT; an <agentDir> that is
+      // itself a file, ENOTDIR — main()'s agent filter is existsSync, which a
+      // regular file passes. Nothing filters any of them out earlier, because
+      // readJson returns null on all of them and fileKey() swallows its
+      // realpath failure. An EXISTING codex-home at 0000 or 0500 does NOT
+      // throw — recursive mkdir takes the EEXIST and returns — so the owner-rwx
+      // repair below is still reached on every pass for the locked-directory
+      // shape it was written for.
+      //
+      // The blocked path is `dir`, not `dest`, and `error.code` alone would
+      // drop the only text that names it, so it is named here: an operator
+      // reading one stderr line every ten minutes needs the path to act on.
+      // EACCES in particular does not self-heal — enforceMode repairs the
+      // owner's rwx on `dir`, never on `<agentDir>` above it — so that shape
+      // needs a person, and says so ten minutes apart until it gets one.
+      //
+      // Returning here also keeps the two enforceMode calls below off a path
+      // that is not the kind of thing they expect: a codex-home that is a
+      // regular file would otherwise be chmodded 0700 as if it were a
+      // directory, and a missing one would draw a spurious "could not tighten".
+      return writeFailed(`${error.code || error.message} creating ${dir}`);
+    }
+  }
   // Before the write, so a directory this pass just created is owner-only
   // before a credential lands in it — and before the short-circuit below, so an
   // already-current mirror is repaired too.
@@ -514,15 +561,8 @@ function writeMirror(dest, credential) {
       { mode: 0o600 },
     );
   } catch (error) {
-    // The last per-destination operation that could still end the pass. A
-    // read-only mount, a root-owned file, ENOSPC — one unwritable destination
-    // must cost that destination, not the app-server's CODEX_HOME copy behind
-    // it in the loop. Never reported as synced: a mirror counted as written
-    // that was not is the false success this file keeps guarding against.
-    console.error(
-      `  Codex auth.json: could not write ${dest} (${error.code || error.message}); the remaining mirrors are still being synced.`,
-    );
-    return WRITE_FAILED;
+    // The second: a read-only mount, a root-owned file, ENOSPC, EISDIR.
+    return writeFailed(error.code || error.message);
   }
   return reason;
 }

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -437,9 +437,25 @@ function writeMirror(dest, credential) {
   const existing = readJson(dest);
   const reason = syncReason(existing, credential);
   if (!reason) return null;
-  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  const dir = path.dirname(dest);
+  fs.mkdirSync(dir, { recursive: true });
   // Holds an OAuth token — owner-only dir, not just the 0600 file.
-  fs.chmodSync(path.dirname(dest), 0o700);
+  //
+  // Guarded for the same reason the file chmod below is, and it costs more
+  // when it is not: this runs BEFORE the write, so an EPERM here (a codex dir
+  // owned by another user) threw out of writeMirror and aborted main()'s whole
+  // destinations loop — losing this mirror AND every later one, including the
+  // app-server's CODEX_HOME copy without which every Codex turn falls back to
+  // the Cloudflare-challenged browser endpoint. One un-tightenable directory
+  // must cost that directory's permissions, not the pass. The credential is
+  // still written 0600, so the file itself stays owner-only either way.
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch (error) {
+    console.error(
+      `  Codex auth.json: could not tighten permissions on ${dir} — it may be readable by other users (${error.code || error.message}).`,
+    );
+  }
   fs.writeFileSync(
     dest,
     JSON.stringify(buildAuthFile(credential, existing), null, 2),
@@ -587,8 +603,15 @@ function writeBackToCore(agentDirs, tokens, profileId) {
           .run(JSON.stringify(store), Date.now(), "primary");
         db.exec("COMMIT");
         open = false;
-        // Only after the COMMIT: a rotation reported as recorded but rolled
-        // back would leave main() adopting a token core does not hold.
+        // Only after the COMMIT, and the guarantee is THIS loop's alone: a
+        // rotation reported as recorded but rolled back would leave main()
+        // adopting a token core does not hold. `wrote` is an OR across both
+        // stores, and the legacy auth-profiles.json loop above sets it with no
+        // transaction and no relation to this outcome — so on a box holding
+        // both stores a successful JSON write still reports true when the
+        // sqlite write is rolled back. Bounded rather than closed here: the
+        // divergence persists, the next tick retries, and readProfiles prefers
+        // that JSON file on exactly the boxes that have one.
         wrote = true;
       } finally {
         if (open) {
@@ -778,6 +801,13 @@ function main() {
 try {
   main();
 } catch (error) {
-  // Never block gateway start on a credential mirror.
-  log("Codex auth.json: " + error.message);
+  // Never block gateway start on a credential mirror: this stays exit 0.
+  //
+  // console.error, not log(): anything landing here ended the pass early, with
+  // some or all of the mirrors unwritten and no other line saying so — and
+  // log() is silenced by CODEX_AUTH_MIRROR_QUIET=1, the timer unit's own
+  // setting, whose SuccessExitStatus=0 1 then shows the unit green. A failure
+  // that leaves the credential unmirrored is not "normal and idempotent", so
+  // it goes to the channel the timer path can actually see.
+  console.error("  Codex auth.json: " + error.message);
 }

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -438,6 +438,12 @@ function dedupePaths(files) {
  * When a rotation cannot be recorded, `main()` leaves the app-server home that
  * carries it alone rather than guessing — per destination, never the whole
  * pass, and never the plugin's own file.
+ *
+ * ONLY the agent the credential was resolved from. A profile id is a key
+ * within one agent's store, not a fleet-wide identity: a second agent may hold
+ * the same id for a different account, and writing this rotation into it would
+ * replace a refresh token that belongs to someone else and break its next
+ * refresh.
  */
 function writeBackToCore(agentDirs, tokens, profileId) {
   if (!tokens || !tokens.refresh_token || !profileId) return false;
@@ -512,9 +518,13 @@ function main() {
     Number(b.includes(`${path.sep}main${path.sep}`)) -
     Number(a.includes(`${path.sep}main${path.sep}`));
   let credential = null;
+  let credentialAgentDir = null;
   for (const dir of [...agentDirs].sort(mainFirst)) {
     credential = credentialFromProfiles(dir);
-    if (credential) break;
+    if (credential) {
+      credentialAgentDir = dir;
+      break;
+    }
   }
 
   if (!credential) {
@@ -585,7 +595,16 @@ function main() {
 
   if (rotated) {
     const tokens = rotated.data.tokens;
-    if (writeBackToCore(agentDirs, tokens, credential.profileId)) {
+    // Every OTHER diverged app-server home owns a rotation of its own: two
+    // agents run two app-servers, each rotating its own CODEX_HOME, and core
+    // can record only one of them. Writing the adopted token over the rest
+    // discards their live refresh tokens — the same burn the failure branch
+    // below exists to prevent. (The plugin's own file is still never skipped;
+    // see isPluginOwnFile.)
+    for (const { dest } of diverged) {
+      if (dest !== rotated.dest && isAppServerHome(dest) && !isPluginOwnFile(dest)) skip.add(dest);
+    }
+    if (writeBackToCore([credentialAgentDir], tokens, credential.profileId)) {
       log(`Codex auth.json: adopted app-server rotation from ${rotated.dest}`);
       credential = {
         profileId: credential.profileId,

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -434,78 +434,96 @@ function syncReason(existing, credential) {
 }
 
 /**
- * Tighten one path that holds — or contains — an OAuth token, on EVERY pass.
+ * Keep one path that holds — or contains — an OAuth token owner-only, on EVERY
+ * pass, and reachable by the owner.
  *
  * `writeFileSync(..., { mode })` applies the mode on CREATION only, so a file
  * another tool left 0644 kept that mode through every rewrite while holding a
  * refresh token. Repairing it only where the credential is rewritten was the
  * same defect one step further out: a mirror that is already current but 0644
  * short-circuits on "credential already current" and stays world-readable for
- * the life of the box. So this is called before that short-circuit, not after
- * it, and the pass that runs 144 times a day is the one that repairs it.
+ * the life of the box. So this runs before that short-circuit, and the pass
+ * that runs 144 times a day is the one that repairs it.
  *
- * Nothing else will: core's own permission repair (`openclaw doctor --fix`,
- * the state-integrity check) covers the state dir, the config file and the
- * runtime state dirs, and never `~/.codex` or an agent's `codex-home`; core's
- * Codex credential reader only reads `auth.json`. This script is the sole
- * writer of these files, so it is the only place their mode can be enforced.
+ * Nothing else will. This script is the only ClawBox-owned writer of these
+ * files — the Codex app-server rewrites its own CODEX_HOME copy, which is
+ * exactly why the mode has to be re-checked every pass rather than only where
+ * we write — and core repairs neither: its state-integrity check
+ * (`openclaw doctor --fix`) covers the state dir, the config file and the
+ * runtime state dirs and never `~/.codex` or an agent's `codex-home`, and its
+ * Codex credential reader only reads `auth.json`.
  *
- * The trigger is core's own: `doctor` tightens when any group/other bit is set
- * (`(stat.mode & 0o77) !== 0`) and repairs to the same 0700 / 0600. Matching it
- * keeps the common pass a single `statSync` with no write at all, and never
- * widens a path an operator deliberately made stricter — 0400 stays 0400.
+ * BOTH of core's repairs, in core's order, because porting only the second is a
+ * regression: `doctor` first restores the owner's rwx on a directory it cannot
+ * use (`canWriteDir` -> `addUserRwx`, `mode & 0o777 | 0o700`), and only then
+ * tightens anything with a group/other bit set (`(mode & 0o77) !== 0`) to 0700 /
+ * 0600. A directory the owner cannot write is not "stricter", it is a mirror
+ * that can never be written again — the unconditional chmod this replaced was
+ * repairing that by accident. `requiredOwnerBits` is 0 for the credential files
+ * themselves, so a mirror an operator deliberately made 0400 stays 0400.
  *
- * Non-fatal, and reported on stderr rather than through log(): the timer unit
- * runs with CODEX_AUTH_MIRROR_QUIET=1, so a log() line here would be silent on
- * exactly the path that runs 144 times a day, and a credential left readable by
- * other users would say nothing at all. An EPERM (a path owned by another user)
- * must also never abort the pass: for the directory this runs BEFORE the write,
- * and throwing here once aborted main()'s whole destinations loop — losing this
- * mirror AND every later one, including the app-server's CODEX_HOME copy
- * without which every Codex turn falls back to the Cloudflare-challenged
- * browser endpoint. One un-tightenable path must cost that path's permissions,
- * not the pass.
+ * Non-fatal, and reported on stderr: the timer unit runs with
+ * CODEX_AUTH_MIRROR_QUIET=1, so log() would be silent on exactly the path that
+ * runs 144 times a day. An EPERM (a path owned by another user) must cost that
+ * path's permissions, not the pass.
  */
-function enforceMode(target, mode) {
+function enforceMode(target, mode, requiredOwnerBits = 0) {
   const complain = (error) =>
     console.error(
       `  Codex auth.json: could not tighten permissions on ${target} — it may be readable by other users (${error.code || error.message}).`,
     );
   let current;
   try {
-    current = fs.statSync(target).mode;
+    current = fs.statSync(target).mode & 0o7777;
   } catch (error) {
-    // ENOENT is the create path: nothing to tighten yet, and writeMirror's
-    // own write creates the file 0600. Anything else is a path whose
-    // permissions cannot even be READ — not "normal and idempotent", so it is
-    // named rather than swallowed.
+    // ENOENT is the create path in writeMirror (the write below makes the file
+    // 0600) and, at the skip call site in main(), a file that has since gone.
+    // Neither is worth a line; anything else is a path whose permissions cannot
+    // even be READ, which is not "normal and idempotent".
     if (error.code !== "ENOENT") complain(error);
     return;
   }
-  if ((current & 0o077) === 0) return;
+  const tooOpen = (current & 0o077) !== 0;
+  const ownerLocked = (current & requiredOwnerBits) !== requiredOwnerBits;
+  if (!tooOpen && !ownerLocked) return;
   try {
-    fs.chmodSync(target, mode);
+    fs.chmodSync(target, tooOpen ? mode : current | requiredOwnerBits);
   } catch (error) {
     complain(error);
   }
 }
 
+/** writeMirror's answer when the credential could not be written at all. */
+const WRITE_FAILED = Symbol("write-failed");
+
 function writeMirror(dest, credential) {
   const existing = readJson(dest);
   const reason = syncReason(existing, credential);
   const dir = path.dirname(dest);
+  if (reason) fs.mkdirSync(dir, { recursive: true });
   // Before the write, so a directory this pass just created is owner-only
   // before a credential lands in it — and before the short-circuit below, so an
   // already-current mirror is repaired too.
-  if (reason) fs.mkdirSync(dir, { recursive: true });
-  enforceMode(dir, 0o700);
+  enforceMode(dir, 0o700, 0o700);
   enforceMode(dest, 0o600);
   if (!reason) return null;
-  fs.writeFileSync(
-    dest,
-    JSON.stringify(buildAuthFile(credential, existing), null, 2),
-    { mode: 0o600 },
-  );
+  try {
+    fs.writeFileSync(
+      dest,
+      JSON.stringify(buildAuthFile(credential, existing), null, 2),
+      { mode: 0o600 },
+    );
+  } catch (error) {
+    // The last per-destination operation that could still end the pass. A
+    // read-only mount, a root-owned file, ENOSPC — one unwritable destination
+    // must cost that destination, not the app-server's CODEX_HOME copy behind
+    // it in the loop. Never reported as synced: a mirror counted as written
+    // that was not is the false success this file keeps guarding against.
+    console.error(
+      `  Codex auth.json: could not write ${dest} (${error.code || error.message}); the remaining mirrors are still being synced.`,
+    );
+    return WRITE_FAILED;
+  }
   return reason;
 }
 
@@ -580,6 +598,12 @@ function writeBackToCore(agentDirs, tokens, profileId) {
     if (tokens.id_token) profiles[id].id = tokens.id_token;
     try {
       fs.writeFileSync(jsonPath, JSON.stringify(data, null, 2), { mode: 0o600 });
+      // Same creation-only `mode`, on a file that always pre-exists here (the
+      // loop only runs when it already holds this profile) — and this one holds
+      // the REFRESH token, not the access-token mirror. Core's own audit flags
+      // it (`fs.auth_profiles.perms_readable`) and never repairs it, so this is
+      // the only place it gets repaired.
+      enforceMode(jsonPath, 0o600);
       wrote = true;
     } catch {
       // Non-fatal; the sqlite store below is the one core reads.
@@ -805,6 +829,7 @@ function main() {
   }
 
   let synced = 0;
+  let failed = 0;
   for (const dest of destinations) {
     if (skip.has(dest)) {
       // The sibling call site of writeMirror's own permission pass, and the one
@@ -814,12 +839,14 @@ function main() {
       // there). Tightening a mode touches no credential, so the reason it is
       // skipped does not reach this — and "the file we refuse to touch" is
       // exactly the one that would otherwise stay world-readable forever.
-      enforceMode(path.dirname(dest), 0o700);
+      enforceMode(path.dirname(dest), 0o700, 0o700);
       enforceMode(dest, 0o600);
       continue;
     }
     const reason = writeMirror(dest, credential);
-    if (reason) {
+    if (reason === WRITE_FAILED) {
+      failed += 1;
+    } else if (reason) {
       synced += 1;
       log(`Codex auth.json ${reason}: ${dest}`);
     }
@@ -828,7 +855,10 @@ function main() {
   // ones this pass owns, so a single left-behind file must not silence it —
   // and must not let it read as "every mirror is current" either, which is the
   // opposite of the warning printed a few lines up.
-  if (synced === 0 && skip.size < destinations.length) {
+  // `failed` too: a destination whose write threw has already said so on
+  // stderr, and "credential already current" over it would contradict that on
+  // the other stream — the same false success the skip warning is guarded for.
+  if (synced === 0 && failed === 0 && skip.size < destinations.length) {
     log(
       "Codex auth.json: credential already current" +
         (skip.size > 0 ? " on the files this pass owns" : ""),

--- a/scripts/codex-auth-mirror.js
+++ b/scripts/codex-auth-mirror.js
@@ -106,6 +106,36 @@ function stateDbPath() {
 }
 
 const SHARED_STORE_KEY = "authProfiles.store";
+const SHARED_STORE_OWNERSHIP_KEY = "auth.sharedStore";
+
+/**
+ * Does core resolve the shared store from the state DB, or from the main
+ * agent's own file?
+ *
+ * `auth.sharedStore` is the row core keys that entire decision on:
+ * `resolveSharedAuthStorePath` returns `<stateDir>/state/openclaw.sqlite` only
+ * when `location === "state-db"`, and otherwise
+ * `<stateDir>/agents/main/agent/openclaw-agent.sqlite` — the per-agent table
+ * this script already reads. An ABSENT row means `legacy-main`
+ * (`parseSharedAuthStoreOwnership`). So on a box `doctor --fix` has not
+ * relocated, the `authProfiles.store` row may exist and still be something core
+ * never consults; mirroring from it hands the Codex runtime a credential core
+ * does not resolve.
+ *
+ * Core throws on an unparseable value. A credential mirror must not — anything
+ * that is not an explicit `state-db` is treated as `legacy-main` and the row is
+ * left unread, which is the same answer core reaches for every legal value but
+ * one.
+ */
+function ownsSharedStore(valueJson) {
+  if (typeof valueJson !== "string") return false;
+  try {
+    const parsed = JSON.parse(valueJson);
+    return Boolean(parsed) && parsed.location === "state-db";
+  } catch {
+    return false;
+  }
+}
 
 /**
  * The gateway-wide store, where core keeps the profiles on 2026.8:
@@ -113,7 +143,9 @@ const SHARED_STORE_KEY = "authProfiles.store";
  * `authProfiles.store`. `openclaw doctor --fix` performs the relocation once
  * and every agent then resolves through it — read-through inheritance, core's
  * own `docs/auth-credential-semantics.md`. The box records the move as
- * `auth.sharedStore = {"location":"state-db"}` in the same table.
+ * `auth.sharedStore = {"location":"state-db"}` in the same table, and both rows
+ * are read in one statement so a locked database cannot answer "profiles, but
+ * no ownership" and make this store look authoritative when it is not.
  */
 function readSharedProfiles() {
   const dbPath = stateDbPath();
@@ -126,15 +158,18 @@ function readSharedProfiles() {
     // SQLITE_BUSY here is swallowed to null and surfaces as "no codex OAuth
     // profile yet", which is the message that hid this bug in the first place.
     db.exec("PRAGMA busy_timeout = 5000");
-    let row;
+    let rows;
     try {
-      row = db
-        .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
-        .get(SHARED_STORE_KEY);
+      rows = db
+        .prepare("SELECT state_key, value_json FROM config_machine_state WHERE state_key IN (?, ?)")
+        .all(SHARED_STORE_OWNERSHIP_KEY, SHARED_STORE_KEY);
     } finally {
       db.close();
     }
-    const parsed = row && row.value_json ? JSON.parse(row.value_json) : null;
+    const byKey = new Map(rows.map((row) => [row.state_key, row.value_json]));
+    if (!ownsSharedStore(byKey.get(SHARED_STORE_OWNERSHIP_KEY))) return null;
+    const value = byKey.get(SHARED_STORE_KEY);
+    const parsed = value ? JSON.parse(value) : null;
     return hasProfiles(parsed) ? parsed.profiles : null;
   } catch {
     return null; // no node:sqlite, no table, or locked — non-fatal
@@ -190,16 +225,15 @@ const PROFILE_KEYS = ["openai:chatgpt", "codex:default", "openai-codex:default"]
  * The ONE profile this box's ChatGPT credential lives in — for reading it and
  * for writing a rotation back.
  *
- * The first entry that actually carries `access`, because a canonical entry
- * left half-written by an interrupted sign-in must not hide a legacy one that
- * still works; the first entry that merely EXISTS only as a last resort, so a
- * rotation still lands somewhere when nothing is credentialed yet.
+ * The most usable entry, by core's own ranking (see profileKeyIn). A canonical
+ * entry left half-written by an interrupted sign-in must not hide a legacy one
+ * that still works; an entry that merely EXISTS is a last resort, so a rotation
+ * still lands somewhere when nothing is credentialed yet.
  *
- * One rule for both directions, deliberately. Reading by "has a credential"
- * while writing back by "exists" is how a box ends up reading `codex:default`
- * and writing the rotated token into `openai:chatgpt`, leaving the entry it
- * reads next holding a refresh token that has already been spent — the exact
- * split this list exists to prevent.
+ * One rule for both directions, deliberately. Reading by one rule and writing
+ * back by another is how a box ends up reading `codex:default` and writing the
+ * rotated token into `openai:chatgpt`, leaving the entry it reads next holding
+ * a refresh token that has already been spent.
  */
 /** An openai-provider OAuth profile is a ChatGPT sign-in, whatever it is keyed. */
 function isChatgptProfile(key, entry) {
@@ -210,23 +244,73 @@ function isChatgptProfile(key, entry) {
   return provider === "openai" || provider === "codex" || provider === "openai-codex";
 }
 
+/**
+ * `expires` as core validates it: a finite number of Unix epoch MILLISECONDS,
+ * greater than 0 and no larger than the maximum JavaScript timestamp. Anything
+ * else is "unknown", never "expired" — `resolveTokenExpiryState`.
+ */
+function expiryOf(entry) {
+  const expires = entry && entry.expires;
+  const valid =
+    typeof expires === "number" &&
+    Number.isFinite(expires) &&
+    expires > 0 &&
+    expires <= 864e13;
+  return valid ? expires : null;
+}
+
 function profileKeyIn(profiles) {
   if (!profiles) return null;
-  // PROFILE_KEYS first, as the preference order, then ANY profile that is a
-  // ChatGPT sign-in by shape. The three literal ids miss the two `doctor --fix`
-  // itself allocates when it migrates a legacy `openai-codex:default`:
-  // `openai:default`, or `openai:chatgpt-default` when that is taken. The rest
-  // of this PR already treats "provider openai + oauth" as the sign-in — so a
-  // doctor-migrated box produced an available ChatGPT row, a runtime arm and a
-  // subscription entitlement while THIS script found no credential, never
-  // synthesized ~/.codex/auth.json and never wrote a rotation back.
-  const keys = [
-    ...PROFILE_KEYS.filter((key) => isChatgptProfile(key, profiles[key])),
-    ...Object.keys(profiles).filter(
-      (key) => !PROFILE_KEYS.includes(key) && isChatgptProfile(key, profiles[key]),
-    ).sort(),
-  ];
-  return keys.find((key) => profiles[key] && profiles[key].access) || keys[0] || null;
+  // Every profile that is a ChatGPT sign-in by shape, not just the three
+  // literal ids: those miss the two `doctor --fix` itself allocates when it
+  // migrates a legacy `openai-codex:default` (`openai:default`, or
+  // `openai:chatgpt-default` when that is taken), so a doctor-migrated box
+  // produced an available ChatGPT row, a runtime arm and a subscription
+  // entitlement while THIS script found no credential.
+  const candidates = Object.keys(profiles).filter((key) => isChatgptProfile(key, profiles[key]));
+  if (candidates.length === 0) return null;
+
+  // Rank the way core ranks, not by id. `orderProfilesByMode` sorts oauth
+  // before token before api_key, then an UNEXPIRED credential ahead of an
+  // expired one, and only then reaches a stable tie-break — and an expired
+  // OAuth profile stays *eligible* there, because core refreshes it (the
+  // `expired` reason code is scoped to `type: "token"` in
+  // docs/auth-credential-semantics.md). So expiry demotes a candidate here; it
+  // never drops one, and a dead credential is still better than none.
+  //
+  // Ranking by id alone is what broke: the read set spans the shared and the
+  // per-agent store, so `openai:chatgpt` at the head of PROFILE_KEYS let a
+  // shared entry that expired hours ago outrank an agent's OWN live
+  // `openai:default`, and the timer rewrote the spent token over the live one
+  // every ten minutes. PROFILE_KEYS is the tie-break among equally usable
+  // candidates, which is all it was ever measuring.
+  const now = Date.now();
+  const ranked = candidates
+    .map((key) => {
+      const entry = profiles[key];
+      const expires = expiryOf(entry);
+      const preference = PROFILE_KEYS.indexOf(key);
+      return {
+        key,
+        // A profile with no access token cannot be mirrored at all; it is only
+        // a candidate so a rotation still has somewhere to land.
+        uncredentialed: entry && entry.access ? 0 : 1,
+        expired: expires !== null && expires <= now ? 1 : 0,
+        // Later expiry means more recently issued: after a re-login the
+        // freshest credential is the account the owner actually signed in to.
+        staleness: -(expires ?? 0),
+        preference: preference === -1 ? PROFILE_KEYS.length : preference,
+      };
+    })
+    .sort(
+      (a, b) =>
+        a.uncredentialed - b.uncredentialed ||
+        a.expired - b.expired ||
+        a.staleness - b.staleness ||
+        a.preference - b.preference ||
+        a.key.localeCompare(b.key),
+    );
+  return ranked[0].key;
 }
 
 function credentialFromProfiles(agentDir) {
@@ -281,8 +365,10 @@ function buildAuthFile(credential, existing) {
 }
 
 /**
- * Rewrite whenever the file drifts from core's profile. Core is the only
- * rotator, so "different from core" always means "stale copy", never "newer".
+ * Rewrite whenever the file drifts from core's profile. Whether a drift means
+ * "stale copy" or "the app-server rotated ahead of core" depends on WHICH file
+ * it is; main() decides that (see appServerHomes) and only calls this for the
+ * destinations it has already ruled writable.
  */
 function syncReason(existing, credential) {
   if (!existing) return "created";
@@ -304,6 +390,9 @@ function writeMirror(dest, credential) {
     JSON.stringify(buildAuthFile(credential, existing), null, 2),
     { mode: 0o600 },
   );
+  // `mode` applies on CREATION only, so a file another tool left 0644 stayed
+  // 0644 through every rewrite while holding a refresh token.
+  fs.chmodSync(dest, 0o600);
   return reason;
 }
 
@@ -334,14 +423,21 @@ function dedupePaths(files) {
  * Write an app-server rotation back into core's auth profile store, so core
  * stops handing out a refresh token that has already been spent.
  *
- * Reaches the legacy JSON file and the per-agent table only. The shared state
- * store 2026.8 relocates the profiles into is deliberately READ-ONLY here: core
- * refreshes an `oauth` profile itself and serialises every refresh through
+ * Reaches the legacy JSON file and the per-agent table only. The state DB row
+ * `authProfiles.store` is deliberately never written: on a `state-db` box that
+ * row is the gateway-wide store every agent resolves through, and core
+ * serialises every OAuth refresh through
  * `<stateDir>/locks/oauth-refresh/lock-<digest>` precisely to stop a
- * `refresh_token_reused` storm, so an unlocked read-modify-write of that
- * gateway-wide row from a timer could overwrite a live token with a spent one
- * for every agent at once. `main()` therefore leaves the mirrors alone rather
- * than guessing when it cannot write a rotation back.
+ * `refresh_token_reused` storm, so an unlocked read-modify-write of it from a
+ * timer could overwrite a live token with a spent one for every agent at once.
+ * (On a `legacy-main` box the shared store IS the main agent's own
+ * `openclaw-agent.sqlite`, which the loop below does write — unlocked, as beta
+ * did; that hazard is older than this script's shared-store read and is not
+ * settled here.)
+ *
+ * When a rotation cannot be recorded, `main()` leaves the app-server home that
+ * carries it alone rather than guessing — per destination, never the whole
+ * pass, and never the plugin's own file.
  */
 function writeBackToCore(agentDirs, tokens, profileId) {
   if (!tokens || !tokens.refresh_token || !profileId) return false;
@@ -371,6 +467,10 @@ function writeBackToCore(agentDirs, tokens, profileId) {
     try {
       const { DatabaseSync } = require("node:sqlite");
       const db = new DatabaseSync(dbPath);
+      // Same timeout as both readers: without it a transient SQLITE_BUSY is
+      // swallowed below, becomes `wrote = false`, and is reported to the
+      // operator as an unsettleable divergence — a false failure over a lock.
+      db.exec("PRAGMA busy_timeout = 5000");
       try {
         const row = db
           .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
@@ -449,7 +549,15 @@ function main() {
   const appServerHomes = new Set(
     agentDirs.map((dir) => fileKey(path.join(dir, "codex-home", "auth.json"))),
   );
+  const homeAuthKey = fileKey(homeAuthPath);
   const isAppServerHome = (dest) => appServerHomes.has(fileKey(dest));
+  // ...but the plugin's own file is never abandoned, even when it is also an
+  // app-server home. On a symlinked box dedupePaths collapses both
+  // destinations onto it, so skipping it leaves the box with NO usable
+  // credential anywhere and every Codex turn dies on `401 Missing bearer` —
+  // the failure this script exists to prevent — while the worst case of
+  // writing it is one rotation lost on a configuration ClawBox never creates.
+  const isPluginOwnFile = (dest) => fileKey(dest) === homeAuthKey;
 
   // The app-server rotates its own CODEX_HOME credential. Refresh tokens are
   // single-use, so if it has already rotated, core's stored copy is the DEAD
@@ -493,15 +601,24 @@ function main() {
       // app-server home that still disagrees is left as it is; everything else
       // is written.
       for (const { dest } of diverged) {
-        if (isAppServerHome(dest)) skip.add(dest);
+        if (isAppServerHome(dest) && !isPluginOwnFile(dest)) skip.add(dest);
       }
+      // Only about files actually left behind, and naming those rather than
+      // whichever divergence was found first: on a symlinked box the sole
+      // destination is the plugin's own file, which this pass then rewrites,
+      // and warning about it would be a false failure.
+      //
       // console.error, not log(): the timer unit runs with
       // CODEX_AUTH_MIRROR_QUIET=1, and this is the one state that is not
-      // "normal and idempotent" — a box stuck here needs a person.
-      console.error(
-        `  Codex auth.json: ${rotated.dest} holds a refresh token core does not have and core's store could not be updated; leaving that file alone. `
-        + "If Codex turns keep failing, delete it and sign in to ChatGPT again.",
-      );
+      // "normal and idempotent". A ChatGPT sign-in clears these mirrors at the
+      // source (the configure route), so this survives at most until the next
+      // one.
+      if (skip.size > 0) {
+        console.error(
+          `  Codex auth.json: ${[...skip].join(", ")} holds a refresh token core does not have and core's store could not be updated; leaving that file alone. `
+          + "If Codex turns keep failing, delete it and sign in to ChatGPT again.",
+        );
+      }
     }
   }
 

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2828,13 +2828,23 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // settled without guessing.
     if (isChatgptSubscription) {
       const agentsRoot = path.join(OPENCLAW_HOME_DIR, "agents");
-      const agentIds = await fs.readdir(agentsRoot).catch(() => [] as string[]);
+      const agentIds = await fs.readdir(agentsRoot).catch((err: unknown) => {
+        // Not fatal — the sign-in itself succeeded — but a box that could not
+        // be enumerated keeps its stale codex-home mirrors, and that state is
+        // otherwise invisible: `force: true` swallows ENOENT, not EACCES.
+        console.warn("[configure] Could not enumerate agent dirs to clear stale Codex mirrors:", err instanceof Error ? logSafe(err.message) : err);
+        return [] as string[];
+      });
       const staleMirrors = [
         path.join(CLAWBOX_HOME_DIR, ".codex", "auth.json"),
         ...agentIds.map((id) => path.join(agentsRoot, id, "agent", "codex-home", "auth.json")),
       ];
       await Promise.all(
-        staleMirrors.map((file) => fs.rm(file, { force: true }).catch(() => {})),
+        staleMirrors.map((file) =>
+          fs.rm(file, { force: true }).catch((err: unknown) => {
+            console.warn("[configure] Could not clear a stale Codex mirror:", logSafe(file), err instanceof Error ? logSafe(err.message) : err);
+          }),
+        ),
       );
     }
 

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -1683,6 +1683,30 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
         { status: 400 }
       );
     }
+    // A `claw_…` key authenticates to the ClawBox AI proxy and to nothing else.
+    // Stored as another provider's api_key profile it becomes that provider's
+    // credential and 401s on every turn: measured on a box, `openai:default`
+    // held one and turns on `openai/gpt-5.5` came back from api.openai.com with
+    // `Incorrect API key provided: claw_***`. Worse, an eligible api_key profile
+    // is a candidate ahead of nothing — it is tried, spends the request, and the
+    // gateway then falls back to another model — so the owner sees a provider
+    // that saved cleanly and answers as something else. Refuse the save rather
+    // than store a credential that cannot work. The prefix is a build-time
+    // constant and the message echoes no user input.
+    //
+    // This is about the AUTH PROFILE only. The image setup deliberately puts
+    // the same token in `models.providers.openai.apiKey`, which is a different
+    // slot with its own ownership rules (`canOwnOpenAiImageApiKey`) and its own
+    // measured consequences — see the note above that function.
+    // Not the local providers: for ollama / llamacpp this field carries a MODEL
+    // ID, not a credential (see the branch below), so a model whose name began
+    // with the prefix would be refused as if it were a key.
+    if (!isClawAI && !isOllama && !isLlamaCpp && normalizedApiKey.startsWith(CLAWBOX_AI_TOKEN_PREFIX)) {
+      return NextResponse.json(
+        { error: "That is a ClawBox AI key. Select ClawBox AI as the provider, or paste this provider's own key." },
+        { status: 400 }
+      );
+    }
     if (isLocalScope && !isOllama && !isLlamaCpp) {
       return NextResponse.json(
         { error: "Local AI scope is only supported for Ollama and llama.cpp" },

--- a/src/app/setup-api/ai-models/configure/route.ts
+++ b/src/app/setup-api/ai-models/configure/route.ts
@@ -2813,10 +2813,29 @@ async function configureModel(request: Request, gateway: GatewayTracker): Promis
     // stale file so the restart below regenerates it with the fresh token —
     // afterward the Codex app-server owns its own refresh, so we don't touch
     // it again.
+    //
+    // Every agent's `codex-home/auth.json` goes with it. That file is the
+    // Codex app-server's own CODEX_HOME copy, and scripts/codex-auth-mirror.js
+    // deliberately refuses to overwrite one holding a refresh token core does
+    // not have: overwriting a live app-server rotation with core's spent copy
+    // is what burnt the token family in #278. On a 2026.8 box that script can
+    // no longer write core's store back (the per-agent `auth_profile_store`
+    // row holds zero profiles after `doctor --fix`), so a diverged file never
+    // leaves that state — it keeps the PREVIOUS account's token for the life of
+    // the box and the sync timer warns about it every ten minutes, advising a
+    // re-login that did not clear it. A sign-in is the one moment the account
+    // genuinely changes, which makes it the only place the divergence can be
+    // settled without guessing.
     if (isChatgptSubscription) {
-      await fs
-        .rm(path.join(CLAWBOX_HOME_DIR, ".codex", "auth.json"), { force: true })
-        .catch(() => {});
+      const agentsRoot = path.join(OPENCLAW_HOME_DIR, "agents");
+      const agentIds = await fs.readdir(agentsRoot).catch(() => [] as string[]);
+      const staleMirrors = [
+        path.join(CLAWBOX_HOME_DIR, ".codex", "auth.json"),
+        ...agentIds.map((id) => path.join(agentsRoot, id, "agent", "codex-home", "auth.json")),
+      ];
+      await Promise.all(
+        staleMirrors.map((file) => fs.rm(file, { force: true }).catch(() => {})),
+      );
     }
 
     // (The OAuth doctor migration runs right after the store write in step 1

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -795,6 +795,20 @@ describe("POST /setup-api/ai-models/configure", () => {
     );
   });
 
+  it("refuses a ClawBox AI key offered as another provider's API key", async () => {
+    // A `claw_…` key authenticates to the ClawBox AI proxy and nowhere else.
+    // Registered as the OpenAI api_key profile it becomes that provider's
+    // bearer: measured on a box, `openai:default` held one and every turn on
+    // `openai/gpt-5.5` went to https://api.openai.com/v1/responses and came
+    // back `401 … Incorrect API key provided: claw_***`. Worse, an eligible
+    // api_key profile shadows the owner's working ChatGPT sign-in on the same
+    // provider, so the box answers on a silent fallback instead.
+    const res = await configurePost(jsonRequest({ provider: "openai", apiKey: "claw_token_abc" }));
+
+    expect(res.status).toBe(400);
+    expect(pasteCallFor("openai:default")).toBeUndefined();
+  });
+
   it("leaves the order alone for a provider that is not OpenAI", async () => {
     await configurePost(jsonRequest({ provider: "anthropic", apiKey: "sk-ant" }));
 

--- a/src/tests/routes/ai-models/configure.test.ts
+++ b/src/tests/routes/ai-models/configure.test.ts
@@ -1608,6 +1608,45 @@ describe("POST /setup-api/ai-models/configure", () => {
     expect(written.profiles["openai:chatgpt"].id).toBe("id.token.jwt");
   });
 
+  it("clears EVERY agent's codex-home mirror on a ChatGPT sign-in, not just ~/.codex", async () => {
+    // The sync timer refuses to overwrite a `<agentDir>/codex-home/auth.json`
+    // whose refresh token core does not have — overwriting a live app-server
+    // rotation with core's spent copy is what burnt the token family in #278.
+    // On a 2026.8 box core's store can no longer be written from that script
+    // (the per-agent table holds zero profiles after `doctor --fix`), so the
+    // file never leaves that state: it keeps the PREVIOUS account's token for
+    // the life of the box and the timer warns about it every ten minutes.
+    //
+    // A sign-in is the one moment the account genuinely changes, so it is the
+    // only place the divergence can be settled. Clearing both mirrors here lets
+    // the restart below regenerate them from the fresh profile.
+    mockFs.readdir.mockResolvedValue(["main", "support"] as unknown as never);
+    mockFs.readFile.mockImplementation(async (file) =>
+      String(file).endsWith("oauth-device-tokens.json")
+        ? JSON.stringify({
+            provider: "openai",
+            access_token: "access.token.jwt",
+            id_token: "id.token.jwt",
+            refresh_token: "refresh-token",
+            expires_in: 3600,
+            createdAt: Date.now(),
+          })
+        : JSON.stringify({ version: 1, profiles: {} }),
+    );
+
+    const res = await configurePost(jsonRequest({
+      provider: "openai",
+      authMode: "subscription",
+      oauthHandoff: true,
+    }));
+    expect(res.status).toBe(200);
+
+    const removed = mockFs.rm.mock.calls.map((call) => String(call[0]));
+    expect(removed.some((file) => file.endsWith("/.codex/auth.json"))).toBe(true);
+    expect(removed.some((file) => file.endsWith("/agents/main/agent/codex-home/auth.json"))).toBe(true);
+    expect(removed.some((file) => file.endsWith("/agents/support/agent/codex-home/auth.json"))).toBe(true);
+  });
+
   it("binds the handoff tokens to the provider recorded in the file, not the body", async () => {
     // The file says openai (→ the ChatGPT profile); the body claims google. The
     // tokens were minted for openai, so the file's provider must win — binding

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -115,8 +115,13 @@ function readSharedStore(): { profiles: Record<string, { access?: string; refres
 }
 
 function run(): string {
+  // Pinned, not inherited: the script honours OPENCLAW_STATE_DIR when resolving
+  // the shared store, and CODEX_AUTH_MIRROR_QUIET suppresses the log lines
+  // other tests assert on. Either one exported on a dev machine or a CI job
+  // would silently point the child at another database.
   return execFileSync("node", [SCRIPT, openclawHome, homeAuthPath], {
     encoding: "utf-8",
+    env: { ...process.env, OPENCLAW_STATE_DIR: "", CODEX_AUTH_MIRROR_QUIET: "" },
   });
 }
 
@@ -767,6 +772,78 @@ describe("codex-auth-mirror.js", () => {
     const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
     expect(parsed.tokens.refresh_token).toBe("refresh-live");
     expect(parsed.tokens.account_id).toBe("acct-live");
+  });
+
+  it("writes a rotation back only into the agent it read the credential from", () => {
+    // A profile id is a key inside ONE agent's store, not a fleet-wide
+    // identity. A second agent can hold the same id for a different account,
+    // and grafting this rotation onto it replaces a refresh token that belongs
+    // to someone else — its next refresh then fails with refresh_token_reused.
+    const second = path.join(openclawHome, "agents", "support", "agent");
+    mkdirSync(second, { recursive: true });
+    writeFileSync(
+      path.join(second, "auth-profiles.json"),
+      JSON.stringify({
+        profiles: {
+          "codex:default": {
+            access: accessToken("acct-support"),
+            refresh: "refresh-support-account",
+            id: "id-token",
+          },
+        },
+      }),
+    );
+    seedProfile(accessToken("acct-main"), "refresh-spent");
+    mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
+    writeFileSync(
+      codexHomeAuthPath,
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: accessToken("acct-main", "rotated"),
+          refresh_token: "refresh-rotated-by-appserver",
+          account_id: "acct-main",
+        },
+      }),
+    );
+
+    run();
+
+    const supportStore = JSON.parse(
+      readFileSync(path.join(second, "auth-profiles.json"), "utf-8"),
+    );
+    expect(supportStore.profiles["codex:default"].refresh).toBe("refresh-support-account");
+    const mainStore = JSON.parse(
+      readFileSync(path.join(agentDir, "auth-profiles.json"), "utf-8"),
+    );
+    expect(mainStore.profiles["codex:default"].refresh).toBe("refresh-rotated-by-appserver");
+  });
+
+  it("leaves a SECOND diverged app-server home alone after adopting the first rotation", () => {
+    // Two agents run two app-servers, each rotating its own CODEX_HOME. Core
+    // can record only one of those rotations, so writing the adopted token over
+    // the other file discards a live refresh token — exactly the burn the
+    // could-not-record branch already prevents.
+    const second = path.join(openclawHome, "agents", "support", "agent");
+    mkdirSync(path.join(second, "codex-home"), { recursive: true });
+    const secondAuthPath = path.join(second, "codex-home", "auth.json");
+    const mirror = (marker: string, refresh: string) => JSON.stringify({
+      OPENAI_API_KEY: null,
+      tokens: {
+        access_token: accessToken("acct-1", marker),
+        refresh_token: refresh,
+        account_id: "acct-1",
+      },
+    });
+    mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
+    writeFileSync(codexHomeAuthPath, mirror("main-rotated", "refresh-rotated-by-main"));
+    writeFileSync(secondAuthPath, mirror("support-rotated", "refresh-rotated-by-support"));
+    seedProfile(accessToken("acct-1"), "refresh-spent");
+
+    run();
+
+    expect(JSON.parse(readFileSync(secondAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-rotated-by-support");
   });
 
   it("tightens an existing world-readable mirror to 0600, not only a freshly created one", () => {

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
+
+// vite cannot bundle the builtin; a test file is never bundled, so reaching it
+// lazily here is safe (same rule as openclaw-session-store.test.ts).
+const requireNodeSqlite = createRequire(import.meta.url);
+const { DatabaseSync } = requireNodeSqlite("node:sqlite");
 
 // scripts/codex-auth-mirror.js copies the ChatGPT/Codex credential out of
 // core's auth profile store into the Codex CLI-style auth.json files the Codex
@@ -45,6 +51,58 @@ function seedProfile(access: string, refresh: string = "refresh-secret", profile
       },
     }),
   );
+}
+
+/** The per-agent credential table, the only source before the 2026.8 relocation. */
+function seedAgentStore(profiles: Record<string, unknown>): void {
+  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS auth_profile_store (store_key TEXT PRIMARY KEY, store_json TEXT, updated_at INTEGER)",
+  );
+  db.prepare(
+    "INSERT OR REPLACE INTO auth_profile_store (store_key, store_json, updated_at) VALUES (?, ?, ?)",
+  ).run("primary", JSON.stringify({ version: 1, profiles }), Date.now());
+  db.close();
+}
+
+/**
+ * The gateway-wide store `openclaw doctor --fix` relocates the profiles into:
+ * `<stateDir>/state/openclaw.sqlite`, table `config_machine_state`, row
+ * `authProfiles.store`. Column names are the shipped ones (the core's own
+ * downgrade SQL selects `value_json, updated_at_ms` from this table).
+ */
+function sharedStorePath(): string {
+  return path.join(openclawHome, "state", "openclaw.sqlite");
+}
+
+function seedSharedStore(profiles: Record<string, unknown>): void {
+  mkdirSync(path.dirname(sharedStorePath()), { recursive: true });
+  const db = new DatabaseSync(sharedStorePath());
+  db.exec(
+    "CREATE TABLE IF NOT EXISTS config_machine_state (state_key TEXT PRIMARY KEY, value_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL)",
+  );
+  db.prepare(
+    "INSERT OR REPLACE INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
+  ).run("authProfiles.store", JSON.stringify({ version: 1, profiles }), Date.now());
+  db.close();
+}
+
+function readAgentStore(): { profiles: Record<string, { access?: string; refresh?: string; key?: string }> } {
+  const db = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"), { readOnly: true });
+  const row = db
+    .prepare("SELECT store_json FROM auth_profile_store WHERE store_key = ?")
+    .get("primary") as { store_json: string };
+  db.close();
+  return JSON.parse(row.store_json);
+}
+
+function readSharedStore(): { profiles: Record<string, { access?: string; refresh?: string }> } {
+  const db = new DatabaseSync(sharedStorePath(), { readOnly: true });
+  const row = db
+    .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
+    .get("authProfiles.store") as { value_json: string };
+  db.close();
+  return JSON.parse(row.value_json);
 }
 
 function run(): string {
@@ -367,6 +425,186 @@ describe("codex-auth-mirror.js", () => {
     expect(parsed.tokens.access_token).toBe(accessToken("acct-sqlite"));
     expect(parsed.tokens.account_id).toBe("acct-sqlite");
     expect(parsed.tokens.refresh_token).toBe("refresh-secret");
+  });
+
+  it("reads the shared state-db store when the per-agent table is empty", () => {
+    // Measured on the pinned core (OpenClaw 2026.8.1) on the OpenClaw box: the
+    // per-agent `auth_profile_store` row exists with ZERO profiles while
+    // `openclaw models auth list` reports eight, because `doctor --fix`
+    // relocated the store to `state/openclaw.sqlite`
+    // (`config_machine_state['authProfiles.store']`; the box records
+    // `auth.sharedStore = {"location":"state-db"}`). Core resolves an agent
+    // that has no local profile through that shared store — read-through
+    // inheritance, docs/auth-credential-semantics.md in the installed package.
+    //
+    // The mirror read only the per-agent table, found an empty map, logged
+    // "no codex OAuth profile yet, skipping" and left ~/.codex/auth.json
+    // stale, so the owner's real ChatGPT sign-in never reached the Codex
+    // runtime and every turn went out on the API-key profile and 401ed.
+    seedAgentStore({});
+    seedSharedStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-shared"),
+        refresh: "refresh-shared",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.access_token).toBe(accessToken("acct-shared"));
+    expect(parsed.tokens.refresh_token).toBe("refresh-shared");
+    expect(parsed.tokens.account_id).toBe("acct-shared");
+  });
+
+  it("still writes the plugin's own file when a codex-home rotation cannot be recorded", () => {
+    // The skip is PER DESTINATION. `~/.codex/auth.json` is not a CODEX_HOME for
+    // anything — the codex plugin reads it and never writes it — so a
+    // divergence there is a stale copy and must be repaired. Only the
+    // app-server's own file is left alone, and only because overwriting a live
+    // rotation with core's spent copy is what burnt the family in #278.
+    //
+    // Abandoning the whole pass instead is worse than the bug: the ChatGPT
+    // sign-in route DELETES ~/.codex/auth.json so this script recreates it, so
+    // a box would come out of a re-login with no credential for the plugin at
+    // all and every turn dying on `401 Missing bearer`.
+    mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
+    writeFileSync(
+      codexHomeAuthPath,
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: accessToken("acct-shared", "rotated"),
+          refresh_token: "refresh-rotated-by-appserver",
+          account_id: "acct-shared",
+        },
+      }),
+    );
+    seedAgentStore({});
+    seedSharedStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-shared", "core"),
+        refresh: "refresh-core",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    // The app-server's file is untouched...
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-rotated-by-appserver");
+    // ...core's gateway-wide row is not rewritten from a timer...
+    expect(readSharedStore().profiles["openai:chatgpt"].refresh).toBe("refresh-core");
+    // ...and the plugin still gets a credential.
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token).toBe("refresh-core");
+  });
+
+  it("realigns a stale ~/.codex/auth.json — the state the reported box was in", () => {
+    // The box in the report had a `~/.codex/auth.json` from Aug 27, predating
+    // the sign-in. A fix that only creates the file when it is absent would
+    // have left that box exactly where it was.
+    mkdirSync(path.dirname(homeAuthPath), { recursive: true });
+    writeFileSync(
+      homeAuthPath,
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: accessToken("acct-old", "stale"),
+          refresh_token: "refresh-from-a-previous-account",
+          account_id: "acct-old",
+        },
+      }),
+    );
+    seedAgentStore({});
+    seedSharedStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-shared"),
+        refresh: "refresh-shared",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.refresh_token).toBe("refresh-shared");
+    expect(parsed.tokens.account_id).toBe("acct-shared");
+  });
+
+  it("prefers an agent's own profile over the shared one under the same id", () => {
+    // Core's inheritance is a shallow per-id override with the agent's own
+    // entry on top (mergeProfileRecordsWithOverridePrecedence). Merging the
+    // other way round would hand the Codex runtime a credential core does not
+    // resolve — and the direction is the load-bearing half of the merge.
+    seedAgentStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-local"),
+        refresh: "refresh-local",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+    seedSharedStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-shared"),
+        refresh: "refresh-shared",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.account_id).toBe("acct-local");
+    expect(parsed.tokens.refresh_token).toBe("refresh-local");
+  });
+
+  it("writes a rotation back into the id it READ, not another the local table happens to carry", () => {
+    // The merge made the read set wider than any one store, so "some
+    // ChatGPT-shaped key in the local table" can be a different entry entirely.
+    // Grafting an OAuth bundle onto an API key the owner pasted produces a
+    // credential core cannot classify, and leaves the entry core DOES resolve
+    // holding a refresh token the app-server has already spent.
+    mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
+    writeFileSync(
+      codexHomeAuthPath,
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: accessToken("acct-shared", "rotated"),
+          refresh_token: "refresh-rotated-by-appserver",
+          account_id: "acct-shared",
+        },
+      }),
+    );
+    seedAgentStore({ "openai:chatgpt": { type: "api_key", provider: "openai", key: "sk-owner-key" } });
+    seedSharedStore({
+      "codex:default": {
+        type: "oauth",
+        provider: "codex",
+        access: accessToken("acct-shared", "core"),
+        refresh: "refresh-core",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    // The owner's API key is not turned into half an OAuth profile.
+    const local = readAgentStore().profiles["openai:chatgpt"];
+    expect(local.refresh).toBeUndefined();
+    expect(local.key).toBe("sk-owner-key");
   });
 
   it("mirrors into every agent, not just main", () => {

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync, chmodSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -75,15 +75,24 @@ function sharedStorePath(): string {
   return path.join(openclawHome, "state", "openclaw.sqlite");
 }
 
-function seedSharedStore(profiles: Record<string, unknown>): void {
+function seedSharedStore(
+  profiles: Record<string, unknown>,
+  ownership: { location: string } | null = { location: "state-db" },
+): void {
   mkdirSync(path.dirname(sharedStorePath()), { recursive: true });
   const db = new DatabaseSync(sharedStorePath());
   db.exec(
     "CREATE TABLE IF NOT EXISTS config_machine_state (state_key TEXT PRIMARY KEY, value_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL)",
   );
-  db.prepare(
+  const upsert = db.prepare(
     "INSERT OR REPLACE INTO config_machine_state (state_key, value_json, updated_at_ms) VALUES (?, ?, ?)",
-  ).run("authProfiles.store", JSON.stringify({ version: 1, profiles }), Date.now());
+  );
+  upsert.run("authProfiles.store", JSON.stringify({ version: 1, profiles }), Date.now());
+  // `auth.sharedStore` is the row core keys the decision on: it resolves the
+  // shared store from THIS database only when the location is `state-db`, and
+  // from `<stateDir>/agents/main/agent/openclaw-agent.sqlite` otherwise. A box
+  // that has been through `doctor --fix` carries the row, so the fixture does.
+  if (ownership) upsert.run("auth.sharedStore", JSON.stringify(ownership), Date.now());
   db.close();
 }
 
@@ -614,6 +623,163 @@ describe("codex-auth-mirror.js", () => {
     run();
 
     expect(existsSync(path.join(second, "codex-home", "auth.json"))).toBe(true);
+  });
+
+  it("prefers a LIVE local profile over an EXPIRED shared one filed under a preferred id", () => {
+    // Reading both stores widened the candidate set; the ranking did not
+    // follow. `openai:chatgpt` heads PROFILE_KEYS, so a shared entry whose
+    // access token expired two hours ago outranked the agent's OWN live
+    // credential — and `openai:default` is exactly the id `doctor --fix`
+    // allocates when it migrates a legacy `openai-codex:default`. The Codex
+    // runtime then got a spent refresh token rewritten over a live one every
+    // ten minutes, and every turn 401ed.
+    //
+    // Core ranks by usability, never by id: `orderProfilesByMode` sorts oauth
+    // before token before api_key, then an unexpired credential ahead of an
+    // expired one (`resolveTokenExpiryState`) — openclaw dist/order-*.js.
+    seedAgentStore({
+      "openai:default": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-local"),
+        refresh: "refresh-local-live",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+    seedSharedStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-shared"),
+        refresh: "refresh-shared-stale",
+        expires: Date.now() - 7_200_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.account_id).toBe("acct-local");
+    expect(parsed.tokens.refresh_token).toBe("refresh-local-live");
+  });
+
+  it("prefers the LIVE shared profile when the agent's own copy is the expired one", () => {
+    // The same rule in the other direction, so the fix cannot degenerate into
+    // "always prefer the agent's own": here the local entry heads PROFILE_KEYS
+    // and is dead, and the shared one is the sign-in that still works.
+    seedAgentStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-local"),
+        refresh: "refresh-local-stale",
+        expires: Date.now() - 7_200_000,
+      },
+    });
+    seedSharedStore({
+      "codex:default": {
+        type: "oauth",
+        provider: "codex",
+        access: accessToken("acct-shared"),
+        refresh: "refresh-shared-live",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.account_id).toBe("acct-shared");
+    expect(parsed.tokens.refresh_token).toBe("refresh-shared-live");
+  });
+
+  it("leaves the state-db store unread on a legacy-main box — core does not resolve through it", () => {
+    // An ABSENT `auth.sharedStore` row means `legacy-main`
+    // (`parseSharedAuthStoreOwnership`), and core then resolves the shared
+    // store from `<stateDir>/agents/main/agent/openclaw-agent.sqlite` — never
+    // from this row (`resolveSharedAuthStorePath`). Reading it anyway mirrors a
+    // credential core does not resolve. The shared entry here is the fresher of
+    // the two, so only knowing which store is authoritative can pick the right
+    // one.
+    seedAgentStore({
+      "openai:default": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-local"),
+        refresh: "refresh-local-live",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+    seedSharedStore(
+      {
+        "openai:chatgpt": {
+          type: "oauth",
+          provider: "openai",
+          access: accessToken("acct-shared"),
+          refresh: "refresh-shared",
+          expires: Date.now() + 7_200_000,
+        },
+      },
+      null,
+    );
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.account_id).toBe("acct-local");
+    expect(parsed.tokens.refresh_token).toBe("refresh-local-live");
+  });
+
+  it("realigns a stale ~/.codex/auth.json when codex-home is a symlink to it", () => {
+    // dedupePaths collapses both destinations onto the plugin's own file, and
+    // that one surviving path is then also an app-server home — so a
+    // divergence there put the ONLY destination in `skip` and the plugin kept
+    // reading the previous account's token for the life of the box. On a box
+    // where the two are one file, the plugin's need for a usable credential
+    // outranks the rotation risk: abandoning it is exactly the `401 Missing
+    // bearer` this script exists to prevent.
+    mkdirSync(path.dirname(homeAuthPath), { recursive: true });
+    symlinkSync(path.dirname(homeAuthPath), path.join(agentDir, "codex-home"));
+    writeFileSync(
+      homeAuthPath,
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: accessToken("acct-old"),
+          refresh_token: "refresh-previous-signin",
+          account_id: "acct-old",
+        },
+      }),
+    );
+    seedAgentStore({});
+    seedSharedStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-live"),
+        refresh: "refresh-live",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.refresh_token).toBe("refresh-live");
+    expect(parsed.tokens.account_id).toBe("acct-live");
+  });
+
+  it("tightens an existing world-readable mirror to 0600, not only a freshly created one", () => {
+    // `writeFileSync(..., { mode })` applies the mode on CREATION only, so a
+    // file left 0644 by an earlier tool stayed 0644 through every rewrite while
+    // holding a refresh token.
+    seedProfile(accessToken("acct-1"), "refresh-1");
+    run();
+    chmodSync(homeAuthPath, 0o644);
+    seedProfile(accessToken("acct-1", "rotated"), "refresh-1");
+    run();
+
+    expect(statSync(homeAuthPath).mode & 0o777).toBe(0o600);
   });
 });
 

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -555,11 +555,19 @@ describe("codex-auth-mirror.js", () => {
       },
     });
 
+    chmodSync(codexHomeAuthPath, 0o644);
+    const skippedMtime = statSync(codexHomeAuthPath).mtimeMs;
+
     run();
 
     // The app-server's file is untouched...
     expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
       .toBe("refresh-rotated-by-appserver");
+    expect(statSync(codexHomeAuthPath).mtimeMs).toBe(skippedMtime);
+    // ...but "left alone" is about its CONTENT. On a 2026.8 box this file keeps
+    // that refresh token for the life of the box, so a mode nobody enforces is
+    // a mode that never gets fixed — and a chmod overwrites no credential.
+    expect(statSync(codexHomeAuthPath).mode & 0o777).toBe(0o600);
     // ...core's gateway-wide row is not rewritten from a timer...
     expect(readSharedStore().profiles["openai:chatgpt"].refresh).toBe("refresh-core");
     // ...and the plugin still gets a credential.
@@ -1087,6 +1095,43 @@ describe("codex-auth-mirror.js", () => {
     expect(statSync(homeAuthPath).mode & 0o777).toBe(0o600);
   });
 
+  it("tightens a world-readable mirror on the IDEMPOTENT pass, without rewriting it", () => {
+    // The pass that runs 144 times a day finds no drift and returns before the
+    // write. Binding the permission repair to the rewrite path leaves a mirror
+    // that is already current but 0644 — from an older mirror, or from a tool
+    // that created it — world-readable for the life of the box while it holds
+    // an OAuth refresh token, because "credential already current" is the
+    // answer forever after.
+    //
+    // Nothing else repairs these two files: core's own permission repair
+    // (`openclaw doctor --fix`, the state-integrity check) looks at the state
+    // dir, the config file and the runtime dirs, and never at ~/.codex or an
+    // agent's codex-home; core's Codex reader only reads them. This script is
+    // the sole writer, so it is the only place the mode can be enforced.
+    seedProfile(accessToken("acct-1"), "refresh-1");
+    run();
+    for (const file of [homeAuthPath, codexHomeAuthPath]) {
+      chmodSync(file, 0o644);
+      chmodSync(path.dirname(file), 0o755);
+    }
+    const mtimes = [homeAuthPath, codexHomeAuthPath].map((f) => statSync(f).mtimeMs);
+
+    const stdout = run();
+
+    // The chmod ran on a pass that wrote nothing...
+    for (const file of [homeAuthPath, codexHomeAuthPath]) {
+      expect(statSync(file).mode & 0o777).toBe(0o600);
+      expect(statSync(path.dirname(file)).mode & 0o777).toBe(0o700);
+    }
+    // ...and it is a chmod, not a rewrite: chmod moves ctime only, a write
+    // moves mtime. Both assertions are needed — tightening the mode by
+    // rewriting the credential on every tick would pass the one above while
+    // reintroducing the write this branch's short-circuit exists to avoid.
+    expect([homeAuthPath, codexHomeAuthPath].map((f) => statSync(f).mtimeMs)).toEqual(mtimes);
+    expect(stdout).toContain("credential already current");
+    expect(stdout).not.toMatch(/Codex auth\.json (created|refreshed|realigned):/);
+  });
+
   it("fails CLOSED when another writer holds core's store — no adoption, nothing overwritten", () => {
     // The write-back is one transaction, and a rotation may only be reported as
     // recorded once it has COMMITTED. Here a second connection holds the write
@@ -1152,8 +1197,19 @@ describe("codex-auth-mirror.js", () => {
     // through log() is silent on the path that runs 144 times a day — a mirror
     // that stays world-readable while holding an OAuth refresh token would say
     // nothing at all. Both credential files are faulted, because both are
-    // written by the same helper.
+    // tightened by the same helper.
+    //
+    // Both mirrors are seeded 0644 first, because a chmod is only attempted on
+    // a path that actually needs one: a freshly created mirror is already
+    // 0600 (`writeFileSync`'s `mode` can only lose bits to the umask, never
+    // gain them), so faulting the syscall there would fault a call the script
+    // is right not to make. The rotated token then puts this on the REWRITE
+    // path, where a failure costs the most.
     seedProfile(accessToken("acct-1"));
+    run();
+    chmodSync(homeAuthPath, 0o644);
+    chmodSync(codexHomeAuthPath, 0o644);
+    seedProfile(accessToken("acct-1", "rotated"));
 
     const { stdout, stderr, status } = runWithFailingChmod("auth.json");
 

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1107,7 +1107,9 @@ describe("codex-auth-mirror.js", () => {
     // (`openclaw doctor --fix`, the state-integrity check) looks at the state
     // dir, the config file and the runtime dirs, and never at ~/.codex or an
     // agent's codex-home; core's Codex reader only reads them. This script is
-    // the sole writer, so it is the only place the mode can be enforced.
+    // the only ClawBox-owned writer — the Codex app-server rewrites its own
+    // CODEX_HOME copy, so a mirror can come back with a mode nothing here
+    // chose, which is the whole reason the check belongs on every pass.
     seedProfile(accessToken("acct-1"), "refresh-1");
     run();
     for (const file of [homeAuthPath, codexHomeAuthPath]) {
@@ -1130,6 +1132,62 @@ describe("codex-auth-mirror.js", () => {
     expect([homeAuthPath, codexHomeAuthPath].map((f) => statSync(f).mtimeMs)).toEqual(mtimes);
     expect(stdout).toContain("credential already current");
     expect(stdout).not.toMatch(/Codex auth\.json (created|refreshed|realigned):/);
+  });
+
+  it("leaves a mirror an operator made STRICTER alone — 0400 stays 0400", () => {
+    // The other half of the trigger. Tightening on core's own criterion (any
+    // group/other bit set) rather than on `mode !== 0o600` is what keeps this
+    // true: an exact comparison would WIDEN a deliberate 0400 to 0600 on every
+    // tick and call it a security repair.
+    seedProfile(accessToken("acct-1"), "refresh-1");
+    run();
+    chmodSync(homeAuthPath, 0o400);
+
+    run();
+
+    expect(statSync(homeAuthPath).mode & 0o777).toBe(0o400);
+  });
+
+  it("still mirrors EVERY destination when the codex dir is not owner-writable", () => {
+    // A directory the owner cannot write is not "stricter" — it is a mirror
+    // that can never be written again. Core repairs it in two steps and this
+    // must too: restore the owner's rwx first (`canWriteDir` -> `addUserRwx`),
+    // then tighten. Enforcing only the tighten leaves ~/.codex at 0500, the
+    // write below fails EACCES, and the throw takes out main()'s whole
+    // destinations loop — losing the app-server's CODEX_HOME copy behind it,
+    // which is the exact failure the guarded chmods already exist to prevent.
+    seedProfile(accessToken("acct-1"), "refresh-1");
+    mkdirSync(path.dirname(homeAuthPath), { recursive: true });
+    chmodSync(path.dirname(homeAuthPath), 0o500);
+
+    run();
+
+    expect(statSync(path.dirname(homeAuthPath)).mode & 0o777).toBe(0o700);
+    expect(existsSync(homeAuthPath)).toBe(true);
+    // The LATER destination — the one an aborted loop never reaches.
+    expect(existsSync(codexHomeAuthPath)).toBe(true);
+  });
+
+  it("keeps mirroring, and never says \"already current\", when one destination cannot be written", () => {
+    // The last per-destination operation that could still end the pass. It is
+    // reported on the channel the timer keeps, the later destination is still
+    // written, and the summary line must not answer "credential already
+    // current" on stdout while stderr says the write failed.
+    seedProfile(accessToken("acct-1"), "refresh-1");
+    mkdirSync(path.dirname(homeAuthPath), { recursive: true });
+    // A directory, where the credential file has to go: the write fails with
+    // EISDIR whatever the permissions are, which an unprivileged test can do
+    // and a chmod-based fixture cannot (CI may run as root).
+    mkdirSync(homeAuthPath, { recursive: true });
+
+    const { stdout, stderr, status } = runCapturing();
+
+    expect(stderr).toContain("could not write");
+    expect(stderr).toContain(homeAuthPath);
+    expect(stdout).not.toContain("credential already current");
+    expect(status).toBe(0);
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-1");
   });
 
   it("fails CLOSED when another writer holds core's store — no adoption, nothing overwritten", () => {

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync, chmodSync } from "node:fs";
+import { mkdtempSync, rmSync, mkdirSync, readdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync, chmodSync } from "node:fs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
@@ -170,6 +170,74 @@ function runWithFailingChmod(targetSuffix: string): { stdout: string; stderr: st
     env: { ...process.env, OPENCLAW_STATE_DIR: "", CODEX_AUTH_MIRROR_QUIET: "1" },
   });
   return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+}
+
+/**
+ * The same run again, faulting `fs.mkdirSync` on one exact directory: the shape
+ * an `<agentDir>` the owner cannot write produces when the mirror tries to
+ * create its `codex-home` (EACCES). Faulted rather than chmodded for the same
+ * reason as the chmod fixture — a CI job running as root cannot be denied a
+ * mkdir by any permission bits.
+ */
+function runWithFailingMkdir(target: string): { stdout: string; stderr: string; status: number | null } {
+  const preload = path.join(home, "mkdir-fault.cjs");
+  writeFileSync(
+    preload,
+    [
+      'const fs = require("node:fs");',
+      "const real = fs.mkdirSync;",
+      `const target = ${JSON.stringify(target)};`,
+      "fs.mkdirSync = (dir, options) => {",
+      "  if (String(dir) === target) {",
+      '    const error = new Error("EACCES: permission denied, mkdir");',
+      '    error.code = "EACCES";',
+      "    throw error;",
+      "  }",
+      "  return real(dir, options);",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  const result = spawnSync("node", ["--require", preload, SCRIPT, openclawHome, homeAuthPath], {
+    encoding: "utf-8",
+    env: { ...process.env, OPENCLAW_STATE_DIR: "", CODEX_AUTH_MIRROR_QUIET: "1" },
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+}
+
+/**
+ * The agents' `codex-home` directories in the order main() will visit them.
+ * Read through the same `readdirSync` the script uses, because that order is
+ * the filesystem's rather than alphabetical: a test that assumed one would only
+ * sometimes put the faulted destination IN FRONT of the survivor, and only then
+ * prove that a failure there does not cost the destinations behind it.
+ */
+function agentCodexHomes(): string[] {
+  const agentsRoot = path.join(openclawHome, "agents");
+  return readdirSync(agentsRoot)
+    .map((id) => path.join(agentsRoot, id, "agent"))
+    .filter((dir) => existsSync(dir))
+    .map((dir) => path.join(dir, "codex-home"));
+}
+
+/**
+ * Every destination main() will visit, in its own order, and the ones a pass
+ * actually left holding the credential. Asserting on the NAMES rather than a
+ * count is the point: what an aborted destinations loop costs is a specific
+ * file the box no longer has, and only the names say which.
+ */
+function allDestinations(): string[] {
+  return [homeAuthPath, ...agentCodexHomes().map((dir) => path.join(dir, "auth.json"))];
+}
+
+function mirrored(refreshToken: string): string[] {
+  return allDestinations().filter((file) => {
+    try {
+      return JSON.parse(readFileSync(file, "utf-8")).tokens.refresh_token === refreshToken;
+    } catch {
+      return false; // Missing, or not a credential file at all.
+    }
+  });
 }
 
 beforeEach(() => {
@@ -1169,10 +1237,11 @@ describe("codex-auth-mirror.js", () => {
   });
 
   it("keeps mirroring, and never says \"already current\", when one destination cannot be written", () => {
-    // The last per-destination operation that could still end the pass. It is
-    // reported on the channel the timer keeps, the later destination is still
-    // written, and the summary line must not answer "credential already
-    // current" on stdout while stderr says the write failed.
+    // The write itself, the second of the two per-destination operations that
+    // can throw (the mkdir above it is the other). It is reported on the
+    // channel the timer keeps, the later destination is still written, and the
+    // summary line must not answer "credential already current" on stdout
+    // while stderr says the write failed.
     seedProfile(accessToken("acct-1"), "refresh-1");
     mkdirSync(path.dirname(homeAuthPath), { recursive: true });
     // A directory, where the credential file has to go: the write fails with
@@ -1188,6 +1257,55 @@ describe("codex-auth-mirror.js", () => {
     expect(status).toBe(0);
     expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
       .toBe("refresh-1");
+  });
+
+  it("keeps mirroring the LATER destinations when a codex-home cannot be created", () => {
+    // Creating the directory is the other per-destination operation that can
+    // throw, and it runs before the write: an `<agentDir>` the owner cannot
+    // write denies the mkdir, the throw leaves main()'s destinations loop, and
+    // every destination BEHIND it — the other agents' CODEX_HOME copies — is
+    // silently unwritten while the top-level catch prints one raw syscall
+    // message and exits 0. One unwritable agent must cost that agent only.
+    seedProfile(accessToken("acct-1"), "refresh-1");
+    mkdirSync(path.join(openclawHome, "agents", "spare", "agent"), { recursive: true });
+    const failing = agentCodexHomes()[0];
+    const survivors = allDestinations().filter((dest) => dest !== path.join(failing, "auth.json"));
+
+    const { stderr, status } = runWithFailingMkdir(failing);
+
+    // The lost destination, by name: on beta this list is short by every
+    // destination the aborted loop never reached.
+    expect(mirrored("refresh-1")).toEqual(survivors);
+    // Timer conditions (CODEX_AUTH_MIRROR_QUIET=1), so this is the only channel
+    // that carries it, and it names both the destination that was lost and the
+    // directory that blocked it, rather than a bare syscall message.
+    expect(stderr).toContain(`could not write ${path.join(failing, "auth.json")}`);
+    expect(stderr).toContain(`EACCES creating ${failing}`);
+    expect(status).toBe(0);
+  });
+
+  it("keeps mirroring the LATER destinations when a codex-home is a FILE", () => {
+    // The same abort without any permission bits: `codex-home` present as a
+    // regular file makes the recursive mkdir throw EEXIST. (A dangling symlink
+    // aborts the same pass for the same reason, but with ENOENT — a different
+    // errno, one catch.) Nothing filters either out earlier — readJson returns
+    // null on both and fileKey swallows its realpath failure — so it reaches
+    // the mkdir on a box where an operator has put a file in the way.
+    seedProfile(accessToken("acct-1"), "refresh-1");
+    mkdirSync(path.join(openclawHome, "agents", "spare", "agent"), { recursive: true });
+    const failing = agentCodexHomes()[0];
+    const survivors = allDestinations().filter((dest) => dest !== path.join(failing, "auth.json"));
+    writeFileSync(failing, "not a directory");
+
+    const { stderr, status } = runCapturing();
+
+    expect(mirrored("refresh-1")).toEqual(survivors);
+    expect(stderr).toContain(`could not write ${path.join(failing, "auth.json")}`);
+    // ...and it names the path that actually blocked it, not only the
+    // destination: `${dest} (EEXIST)` alone would report "file already exists"
+    // about a file that does not exist.
+    expect(stderr).toContain(`creating ${failing}`);
+    expect(status).toBe(0);
   });
 
   it("fails CLOSED when another writer holds core's store — no adoption, nothing overwritten", () => {

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -846,6 +846,45 @@ describe("codex-auth-mirror.js", () => {
       .toBe("refresh-rotated-by-support");
   });
 
+  it("mirrors the owner's ChatGPT sign-in, not the older Codex CLI login beside it", () => {
+    // The reported box's shared store, measured read-only: an `openai:default`
+    // api_key holding a ClawBox proxy key, a `codex:default` OAuth login from a
+    // Codex CLI sign-in eight days earlier, and the owner's own `openai:chatgpt`
+    // OAuth sign-in — with the per-agent table emptied by `doctor --fix`. Both
+    // mirror files were frozen on the codex:default credential and the script
+    // logged "no codex OAuth profile yet, skipping" on every boot.
+    //
+    // The api_key entry must not be a candidate at all (it is not an OAuth
+    // sign-in), and between the two OAuth entries the one issued most recently
+    // — the owner's — is the credential to mirror.
+    seedAgentStore({});
+    seedSharedStore({
+      "openai:default": { type: "api_key", provider: "openai", key: "proxy-key-not-an-oauth-signin" },
+      "codex:default": {
+        type: "oauth",
+        provider: "codex",
+        access: accessToken("acct-codex-cli"),
+        refresh: "refresh-codex-cli",
+        expires: Date.now() + 3 * 24 * 3_600_000,
+      },
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-owner-signin"),
+        refresh: "refresh-owner-signin",
+        expires: Date.now() + 9 * 24 * 3_600_000,
+      },
+    });
+
+    run();
+
+    for (const dest of [homeAuthPath, codexHomeAuthPath]) {
+      const parsed = JSON.parse(readFileSync(dest, "utf-8"));
+      expect(parsed.tokens.account_id).toBe("acct-owner-signin");
+      expect(parsed.tokens.refresh_token).toBe("refresh-owner-signin");
+    }
+  });
+
   it("tightens an existing world-readable mirror to 0600, not only a freshly created one", () => {
     // `writeFileSync(..., { mode })` applies the mode on CREATION only, so a
     // file left 0644 by an earlier tool stayed 0644 through every rewrite while

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -735,7 +735,12 @@ describe("codex-auth-mirror.js", () => {
     expect(parsed.tokens.refresh_token).toBe("refresh-local-live");
   });
 
-  it("realigns a stale ~/.codex/auth.json when codex-home is a symlink to it", () => {
+  it("realigns a stale ~/.codex/auth.json when codex-home is a symlink to it and core cannot be written back", () => {
+    // The precondition is load-bearing and is the 2026.8 state: `doctor --fix`
+    // has emptied the per-agent table, so `writeBackToCore` cannot succeed and
+    // the could-not-record branch runs. On a box whose store IS writable the
+    // stale file is instead adopted as a rotation — that is the older,
+    // untouched hazard recorded against this file, not what this test pins.
     // dedupePaths collapses both destinations onto the plugin's own file, and
     // that one surviving path is then also an app-server home — so a
     // divergence there put the ONLY destination in `skip` and the plugin kept
@@ -819,11 +824,15 @@ describe("codex-auth-mirror.js", () => {
     expect(mainStore.profiles["codex:default"].refresh).toBe("refresh-rotated-by-appserver");
   });
 
-  it("leaves a SECOND diverged app-server home alone after adopting the first rotation", () => {
-    // Two agents run two app-servers, each rotating its own CODEX_HOME. Core
-    // can record only one of those rotations, so writing the adopted token over
-    // the other file discards a live refresh token — exactly the burn the
-    // could-not-record branch already prevents.
+  it("adopts NEITHER rotation when two app-server homes have rotated independently", () => {
+    // Two agents run two app-servers, each rotating its own CODEX_HOME. Core's
+    // store holds one refresh token per profile, so it can record one of them —
+    // and adopting either discards the other, immediately (it is rewritten from
+    // the adopted token) or on the next tick (it becomes the sole divergence
+    // and overwrites the first). Two tokens of one family written into core ten
+    // minutes apart is the `refresh_token_reused` shape #278 was. With no
+    // correct single answer, both files are left exactly as they are and core
+    // is not written at all.
     const second = path.join(openclawHome, "agents", "support", "agent");
     mkdirSync(path.join(second, "codex-home"), { recursive: true });
     const secondAuthPath = path.join(second, "codex-home", "auth.json");
@@ -844,6 +853,11 @@ describe("codex-auth-mirror.js", () => {
 
     expect(JSON.parse(readFileSync(secondAuthPath, "utf-8")).tokens.refresh_token)
       .toBe("refresh-rotated-by-support");
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-rotated-by-main");
+    // ...and core still holds its own token; neither rotation was recorded.
+    const store = JSON.parse(readFileSync(path.join(agentDir, "auth-profiles.json"), "utf-8"));
+    expect(store.profiles["codex:default"].refresh).toBe("refresh-spent");
   });
 
   it("mirrors the owner's ChatGPT sign-in, not the older Codex CLI login beside it", () => {
@@ -883,6 +897,77 @@ describe("codex-auth-mirror.js", () => {
       expect(parsed.tokens.account_id).toBe("acct-owner-signin");
       expect(parsed.tokens.refresh_token).toBe("refresh-owner-signin");
     }
+  });
+
+  it("still mirrors the sign-in when it carries the SHORTEST expiry on the box", () => {
+    // `expires` is issue time PLUS that client's token lifetime, and the
+    // lifetimes differ: the reported box carries +4029 min on `codex:default`
+    // and +13675 min on `openai:chatgpt`, and ClawBox's own sign-in writer
+    // stamps `Date.now() + expiresIn*1000`, falling back to eight hours
+    // (configure/route.ts). So a brand-new ChatGPT sign-in routinely holds the
+    // SMALLEST expiry on a box that has ever run `codex login` — which is why
+    // this ranks by expired-or-not and then by id, never by "expires latest".
+    // Ordering by expiry would run the box as the previous account for its
+    // whole life while Settings showed the new sign-in as connected.
+    seedAgentStore({});
+    seedSharedStore({
+      "codex:default": {
+        type: "oauth",
+        provider: "codex",
+        access: accessToken("acct-old-cli"),
+        refresh: "refresh-old-cli",
+        expires: Date.now() + 3 * 24 * 3_600_000,
+      },
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-owner-signin"),
+        refresh: "refresh-owner-signin",
+        expires: Date.now() + 8 * 3_600_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.account_id).toBe("acct-owner-signin");
+    expect(parsed.tokens.refresh_token).toBe("refresh-owner-signin");
+  });
+
+  it("repairs BOTH mirrors when both are stale — the state the reported box was in", () => {
+    // Measured: both files 3911 bytes, both dated 2026-08-27, both carrying the
+    // Codex CLI login rather than the sign-in. Every other fixture here seeds
+    // one file, which is what let a both-stale box go unnoticed.
+    const stale = JSON.stringify({
+      OPENAI_API_KEY: null,
+      tokens: {
+        access_token: accessToken("acct-stale"),
+        refresh_token: "refresh-eight-days-old",
+        account_id: "acct-stale",
+      },
+    });
+    mkdirSync(path.dirname(homeAuthPath), { recursive: true });
+    mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
+    writeFileSync(homeAuthPath, stale);
+    writeFileSync(codexHomeAuthPath, stale);
+    seedAgentStore({});
+    seedSharedStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-live"),
+        refresh: "refresh-live",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    // The plugin's own file is repaired. The app-server's own copy holds a
+    // refresh token core does not have and core's store cannot be written on a
+    // 2026.8 box, so it is left alone here and cleared by the sign-in route
+    // instead — see the configure-route test.
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token).toBe("refresh-live");
   });
 
   it("tightens an existing world-readable mirror to 0600, not only a freshly created one", () => {

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -125,26 +125,37 @@ function run(): string {
   });
 }
 
+/** The same run as `run()`, with both streams captured instead of stdout only. */
+function runCapturing(): { stdout: string; stderr: string; status: number | null } {
+  const result = spawnSync("node", [SCRIPT, openclawHome, homeAuthPath], {
+    encoding: "utf-8",
+    env: { ...process.env, OPENCLAW_STATE_DIR: "", CODEX_AUTH_MIRROR_QUIET: "" },
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status };
+}
+
 /**
  * The same script, run as the TIMER runs it (`CODEX_AUTH_MIRROR_QUIET=1`), with
- * `fs.chmodSync` failing on every credential file and on nothing else, and both
- * streams captured.
+ * `fs.chmodSync` failing on the paths ending in `targetSuffix` and on nothing
+ * else, and both streams captured.
  *
  * The syscall is faulted from a `--require` preload rather than stubbed in this
  * process: the script is a real child, and an unprivileged test cannot provoke
  * an EPERM on a file it owns — while a CI job running as root could not provoke
- * one at all. The directory chmod is deliberately left working; only the
- * `auth.json` files fail.
+ * one at all. `writeMirror` chmods two things per destination, the containing
+ * directory and the `auth.json`, so the suffix picks exactly one of them and
+ * the other is left working.
  */
-function runWithFailingCredentialChmod(): { stdout: string; stderr: string; status: number | null } {
+function runWithFailingChmod(targetSuffix: string): { stdout: string; stderr: string; status: number | null } {
   const preload = path.join(home, "chmod-fault.cjs");
   writeFileSync(
     preload,
     [
       'const fs = require("node:fs");',
       "const real = fs.chmodSync;",
+      `const suffix = ${JSON.stringify(targetSuffix)};`,
       "fs.chmodSync = (target, mode) => {",
-      '  if (String(target).endsWith("auth.json")) {',
+      "  if (String(target).endsWith(suffix)) {",
       '    const error = new Error("EPERM: operation not permitted, chmod");',
       '    error.code = "EPERM";',
       "    throw error;",
@@ -734,6 +745,63 @@ describe("codex-auth-mirror.js", () => {
     expect(parsed.tokens.refresh_token).toBe("refresh-shared-live");
   });
 
+  it("ranks a profile with no `expires` BELOW a live one, even under a preferred id", () => {
+    // The middle tier. An entry with no usable `expires` is not "expired" —
+    // core says the same (`resolveTokenExpiryState` returns `missing`, and only
+    // `expired` scores) — but it is not evidence of life either, so it must not
+    // tie with a credential this box can see is still valid and then win on
+    // `openai:chatgpt` heading PROFILE_KEYS. Two tiers did exactly that.
+    seedAgentStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-unknown"),
+        refresh: "refresh-unknown",
+      },
+      "codex:default": {
+        type: "oauth",
+        provider: "codex",
+        access: accessToken("acct-live"),
+        refresh: "refresh-live",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.account_id).toBe("acct-live");
+    expect(parsed.tokens.refresh_token).toBe("refresh-live");
+  });
+
+  it("ranks a profile with no `expires` ABOVE an expired one — unknown is not dead", () => {
+    // The other side of the same tier, so it cannot degenerate into "treat
+    // unknown as expired": expiry only ever DEMOTES here, it never drops a
+    // candidate, because a dead credential still beats none and core keeps an
+    // expired OAuth profile eligible and refreshes it.
+    seedAgentStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-expired"),
+        refresh: "refresh-expired",
+        expires: Date.now() - 7_200_000,
+      },
+      "codex:default": {
+        type: "oauth",
+        provider: "codex",
+        access: accessToken("acct-unknown"),
+        refresh: "refresh-unknown",
+      },
+    });
+
+    run();
+
+    const parsed = JSON.parse(readFileSync(homeAuthPath, "utf-8"));
+    expect(parsed.tokens.account_id).toBe("acct-unknown");
+    expect(parsed.tokens.refresh_token).toBe("refresh-unknown");
+  });
+
   it("leaves the state-db store unread on a legacy-main box — core does not resolve through it", () => {
     // An ABSENT `auth.sharedStore` row means `legacy-main`
     // (`parseSharedAuthStoreOwnership`), and core then resolves the shared
@@ -1019,6 +1087,66 @@ describe("codex-auth-mirror.js", () => {
     expect(statSync(homeAuthPath).mode & 0o777).toBe(0o600);
   });
 
+  it("fails CLOSED when another writer holds core's store — no adoption, nothing overwritten", () => {
+    // The write-back is one transaction, and a rotation may only be reported as
+    // recorded once it has COMMITTED. Here a second connection holds the write
+    // lock for the whole pass, so `BEGIN IMMEDIATE` waits out the 5 s
+    // busy_timeout and throws: `writeBackToCore` must then return false, and
+    // main() must take the could-not-record branch rather than claiming the
+    // adoption. Claiming it would leave the box mirroring a refresh token core
+    // does not hold — one of the two tokens of a single-use family, which is
+    // the `refresh_token_reused` shape this whole file exists to prevent.
+    //
+    // Only the sqlite store is seeded: an auth-profiles.json would make `wrote`
+    // true through the untransactional legacy loop and prove nothing about this
+    // one (see the note at its `wrote = true`).
+    seedAgentStore({
+      "openai:chatgpt": {
+        type: "oauth",
+        provider: "openai",
+        access: accessToken("acct-1", "old"),
+        refresh: "refresh-spent",
+        expires: Date.now() + 3_600_000,
+      },
+    });
+    mkdirSync(path.dirname(codexHomeAuthPath), { recursive: true });
+    writeFileSync(
+      codexHomeAuthPath,
+      JSON.stringify({
+        OPENAI_API_KEY: null,
+        tokens: {
+          access_token: accessToken("acct-1", "rotated"),
+          refresh_token: "refresh-rotated-by-appserver",
+          account_id: "acct-1",
+        },
+      }),
+    );
+
+    // Held across the whole child run: spawnSync blocks this process, and the
+    // RESERVED lock BEGIN IMMEDIATE takes is held by the connection, not the
+    // thread, so the child cannot get it and cannot be raced into getting it.
+    const blocker = new DatabaseSync(path.join(agentDir, "openclaw-agent.sqlite"));
+    blocker.exec("BEGIN IMMEDIATE");
+    let result: { stdout: string; stderr: string; status: number | null };
+    try {
+      result = runCapturing();
+    } finally {
+      blocker.exec("ROLLBACK");
+      blocker.close();
+    }
+
+    expect(result.stdout).not.toContain("adopted app-server rotation");
+    // Loud on the channel the timer keeps, and non-fatal — the next tick retries.
+    expect(result.stderr).toContain("core's store could not be updated");
+    expect(result.status).toBe(0);
+    // Nothing was half-written: core still holds the token it held, and the
+    // app-server's live rotation was left alone rather than overwritten with
+    // the spent one.
+    expect(readAgentStore().profiles["openai:chatgpt"].refresh).toBe("refresh-spent");
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-rotated-by-appserver");
+  }, 20_000);
+
   it("reports a failed chmod where the TIMER can see it, not through the quiet log", () => {
     // The timer unit runs with CODEX_AUTH_MIRROR_QUIET=1, so a failure reported
     // through log() is silent on the path that runs 144 times a day — a mirror
@@ -1027,7 +1155,7 @@ describe("codex-auth-mirror.js", () => {
     // written by the same helper.
     seedProfile(accessToken("acct-1"));
 
-    const { stdout, stderr, status } = runWithFailingCredentialChmod();
+    const { stdout, stderr, status } = runWithFailingChmod("auth.json");
 
     expect(stdout).toBe(""); // quiet mode: nothing on the channel the timer drops
     expect(stderr).toContain("could not tighten permissions");
@@ -1037,6 +1165,37 @@ describe("codex-auth-mirror.js", () => {
     // pass must never be blocked by a permissions failure.
     expect(status).toBe(0);
     expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-secret");
+  });
+
+  it("keeps mirroring the REMAINING destinations when a directory chmod fails, and says so", () => {
+    // The sibling of the case above, and the one that costs more: the
+    // directory chmod runs first, so an EPERM there (a codex dir owned by
+    // another user) threw out of writeMirror, aborted main()'s whole
+    // destinations loop, and left every LATER mirror — the app-server's
+    // CODEX_HOME copy, without which every Codex turn falls back to the
+    // Cloudflare-challenged browser endpoint — unwritten. It reported that
+    // only through the top-level log(), which CODEX_AUTH_MIRROR_QUIET=1
+    // silences, so on the timer path 144 aborted passes a day were
+    // indistinguishable from 144 clean ones.
+    //
+    // `~/.codex` is the FIRST destination, so faulting its directory is what
+    // pins "the pass continued": the assertion below is about the destination
+    // that came after it.
+    seedProfile(accessToken("acct-1"));
+
+    const { stdout, stderr, status } = runWithFailingChmod(".codex");
+
+    expect(stdout).toBe("");
+    expect(stderr).toContain("could not tighten permissions");
+    expect(stderr).toContain(path.dirname(homeAuthPath));
+    expect(stderr).toContain("EPERM");
+    expect(status).toBe(0);
+    // Both destinations written: the faulted one, whose file mode still makes
+    // the credential owner-only, and the one that used to be skipped.
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-secret");
+    expect(JSON.parse(readFileSync(codexHomeAuthPath, "utf-8")).tokens.refresh_token)
       .toBe("refresh-secret");
   });
 });

--- a/src/tests/unit/codex-auth-mirror.test.ts
+++ b/src/tests/unit/codex-auth-mirror.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, statSync, symlinkSync, chmodSync } from "node:fs";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -123,6 +123,42 @@ function run(): string {
     encoding: "utf-8",
     env: { ...process.env, OPENCLAW_STATE_DIR: "", CODEX_AUTH_MIRROR_QUIET: "" },
   });
+}
+
+/**
+ * The same script, run as the TIMER runs it (`CODEX_AUTH_MIRROR_QUIET=1`), with
+ * `fs.chmodSync` failing on every credential file and on nothing else, and both
+ * streams captured.
+ *
+ * The syscall is faulted from a `--require` preload rather than stubbed in this
+ * process: the script is a real child, and an unprivileged test cannot provoke
+ * an EPERM on a file it owns — while a CI job running as root could not provoke
+ * one at all. The directory chmod is deliberately left working; only the
+ * `auth.json` files fail.
+ */
+function runWithFailingCredentialChmod(): { stdout: string; stderr: string; status: number | null } {
+  const preload = path.join(home, "chmod-fault.cjs");
+  writeFileSync(
+    preload,
+    [
+      'const fs = require("node:fs");',
+      "const real = fs.chmodSync;",
+      "fs.chmodSync = (target, mode) => {",
+      '  if (String(target).endsWith("auth.json")) {',
+      '    const error = new Error("EPERM: operation not permitted, chmod");',
+      '    error.code = "EPERM";',
+      "    throw error;",
+      "  }",
+      "  return real(target, mode);",
+      "};",
+      "",
+    ].join("\n"),
+  );
+  const result = spawnSync("node", ["--require", preload, SCRIPT, openclawHome, homeAuthPath], {
+    encoding: "utf-8",
+    env: { ...process.env, OPENCLAW_STATE_DIR: "", CODEX_AUTH_MIRROR_QUIET: "1" },
+  });
+  return { stdout: result.stdout, stderr: result.stderr, status: result.status };
 }
 
 beforeEach(() => {
@@ -981,6 +1017,27 @@ describe("codex-auth-mirror.js", () => {
     run();
 
     expect(statSync(homeAuthPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("reports a failed chmod where the TIMER can see it, not through the quiet log", () => {
+    // The timer unit runs with CODEX_AUTH_MIRROR_QUIET=1, so a failure reported
+    // through log() is silent on the path that runs 144 times a day — a mirror
+    // that stays world-readable while holding an OAuth refresh token would say
+    // nothing at all. Both credential files are faulted, because both are
+    // written by the same helper.
+    seedProfile(accessToken("acct-1"));
+
+    const { stdout, stderr, status } = runWithFailingCredentialChmod();
+
+    expect(stdout).toBe(""); // quiet mode: nothing on the channel the timer drops
+    expect(stderr).toContain("could not tighten permissions");
+    expect(stderr).toContain(homeAuthPath);
+    expect(stderr).toContain(codexHomeAuthPath);
+    // Non-fatal: the credential is still mirrored, and the gateway pre-start
+    // pass must never be blocked by a permissions failure.
+    expect(status).toBe(0);
+    expect(JSON.parse(readFileSync(homeAuthPath, "utf-8")).tokens.refresh_token)
+      .toBe("refresh-secret");
   });
 });
 


### PR DESCRIPTION
## What breaks, for the owner

He signs in to ChatGPT in Settings on the OpenClaw box and no ChatGPT turn runs.

## TASK-661 / D-01 — the mirror half

`scripts/codex-auth-mirror.js` synthesises the Codex CLI-style `auth.json` files
from OpenClaw's auth profile store. On a 2026.8 box `openclaw doctor --fix` relocates
the profiles into the gateway-wide state DB and leaves the per-agent
`auth_profile_store` row behind with **zero profiles**. The script read only that row,
found `{}`, logged `no codex OAuth profile yet, skipping`, and left both mirrors on a
credential from a previous account.

## The blocker the final review found, and the fix

Reading both stores widened the candidate set. The **ranking did not follow**: the
merged set was still ordered by the hard-coded `PROFILE_KEYS` preference, with no
eligibility test and without reading which store core actually resolves through.

Two A/B regressions against `beta`, reproduced by running beta's and this branch's
copy of the script against seeded fixtures:

```
### A  live agent-local profile vs EXPIRED shared profile (auth.sharedStore = state-db)
  BETA -> R-local-LIVE
  HEAD -> R-shared-STALE        <-- regression

### C  legacy-main box (no auth.sharedStore row at all)
  BETA -> R-local-LIVE
  HEAD -> R-shared              <-- regression

### B  EXPIRED agent-local profile vs live shared profile
  BETA -> R-local-STALE
  HEAD -> R-local-STALE         <-- not a regression; a defect both carried
```

After the fix, all three write the live credential:

```
### A   BETA -> R-local-LIVE     HEAD -> R-local-LIVE
### B   BETA -> R-local-STALE    HEAD -> R-shared-LIVE
### C   BETA -> R-local-LIVE     HEAD -> R-local-LIVE
```

**Harness-first — the native mechanisms this now follows, cited from the pinned core
(`/usr/lib/node_modules/openclaw`, 2026.8.1):**

- `parseSharedAuthStoreOwnership` / `resolveSharedAuthStorePath`
  (`dist/path-resolve-FSTOqqc1.js:39-42`, `:73-76`): the state DB is the shared store
  only when `auth.sharedStore.location === "state-db"`; an **absent** row means
  `legacy-main`, i.e. `<stateDir>/agents/main/agent/openclaw-agent.sqlite`. The mirror
  now reads that row in the same statement as the profiles, so a locked database
  cannot answer "profiles but no ownership".
- `orderProfilesByMode` (`dist/order-PeugL3t0.js:218-243`): core ranks by usability,
  not by id — oauth before token before api_key, then an unexpired credential ahead of
  an expired one (`resolveTokenExpiryState`, `dist/credential-state-DJrnG0Ay.js:12-20`),
  then least-recently-used. `profileKeyIn` now puts the one step of that comparator it can
  evaluate — expired or not — in front of the id preference, and nothing else. It does
  **not** claim to reproduce core's selection: core's base list comes from `store.order` →
  `cfg.auth.order` → the ids in `cfg.auth.profiles` → insertion order
  (`dist/order-PeugL3t0.js:140-159`), and the mirror reads none of those. Honouring them is
  filed as a follow-up.
- **Not ranked by "expires latest".** An earlier revision of this branch was, on the theory
  that later expiry means more recently issued. It does not: `expires` is issue time **plus
  that client's token lifetime**, and the lifetimes differ — the reported box carries
  +4029 min on `codex:default` against +13675 min on `openai:chatgpt`, and this repo's own
  sign-in writer stamps `Date.now() + expiresIn*1000` with an eight-hour fallback
  (`configure/route.ts`). A fresh ChatGPT sign-in therefore routinely holds the *smallest*
  expiry on a box that has ever run `codex login`, and ordering by it mirrored the older
  account. Caught by the round-3 review, reproduced against beta on three store shapes, and
  now pinned by `still mirrors the sign-in when it carries the SHORTEST expiry on the box`.
- Expiry **demotes, never drops**: `evaluateStoredCredentialEligibility`
  (`dist/credential-state-DJrnG0Ay.js:41-95`) scopes the `expired` reason code to
  `type: "token"`; an OAuth profile with an expired access token stays eligible because
  core refreshes it. `docs/auth-credential-semantics.md` says the same. A dead
  credential is still better than none.

## H2 — the box could not repair itself

On a 2026.8 box `writeBackToCore` can never succeed: the legacy JSON is absent and the
per-agent row has zero profiles. So **any** divergence in a `<agentDir>/codex-home/auth.json`
made that file skipped on this and every future pass, for the life of the box, while the
10-minute timer printed the same warning 144 times a day — advising a re-login that did
not clear it.

Fixed at the source rather than in the timer: the ChatGPT sign-in route already deletes
`~/.codex/auth.json` on every explicit (re)login, and now deletes every agent's
`codex-home/auth.json` with it. A sign-in is the one moment the account genuinely
changes, which makes it the only place the divergence can be settled without guessing.
The restart that follows regenerates both from the fresh profile.

The warning is also now emitted only when a destination was actually left behind, and
names those destinations rather than whichever divergence was found first.

## Review findings — applied or refuted

| # | Finding | Outcome |
|---|---------|---------|
| **B1** | Merged set ranked by `PROFILE_KEYS` with no eligibility or recency test, `auth.sharedStore` never read | **Applied.** Ranked by core's own rule; ownership row read. Two A/B regressions above, both closed. |
| **H1** | A symlinked `codex-home` collapses both destinations onto `~/.codex/auth.json`, which is then also an app-server home and gets skipped — abandoning the plugin's only credential | **Applied.** The plugin's own file is never skipped (`isPluginOwnFile`). On such a box, `401 Missing bearer` for certain beats one lost rotation on a configuration ClawBox never creates. |
| **H2** | `<agentDir>/codex-home/auth.json` permanently unrepairable, warning 144×/day | **Applied** at the source — the sign-in route clears every agent's mirror. |
| **H3** | The pinned core contradicts the PR's root-cause claim | **Applied as an honest correction** — see below. The mirror alone was never going to serve the turn. |
| **M1** | `auth.sharedStore` named in a comment and never read | **Applied** (part of B1). |
| **M2** | "shared store is READ-ONLY here" is false on a `legacy-main` box | **Applied** — the comment now scopes the guarantee to the state-DB row and states plainly that on a `legacy-main` box the shared store *is* the main agent's `openclaw-agent.sqlite`, which the write-back loop does write, unlocked, exactly as beta did. Not settled here: that hazard predates this branch and taking core's `oauth-refresh` lock is a change of its own. |
| **M3** | Stale comment: "`main()` therefore leaves the mirrors alone" | **Applied** — rewritten; the skip is per destination, never the whole pass, and never the plugin's own file. |
| **M4** | Fixture gaps hiding H1/H2/B1 | **Applied** — six new mirror tests plus one route test; each was run RED against this branch's own head before the fix. |
| **L1** | No `PRAGMA busy_timeout` on the read-**write** open — a transient `SQLITE_BUSY` reported as an unsettleable divergence | **Applied** — same 5 s timeout as both readers. |
| **L2** | `writeFileSync(..., {mode})` applies the mode on creation only, so a pre-existing 0644 mirror stayed 0644 | **Applied** — explicit `chmodSync(dest, 0o600)`, pinned by a test. |
| **L3** | "Core is the only rotator, so different-from-core always means stale" now contradicted by the `appServerHomes` block | **Applied** — sentence rewritten to defer the question to `main()`. |
| **L4** | Branch behind `origin/beta` | **Applied** — rebased; diff-stat below. |

### Round-3 Opus review (`BLOCK`) — every finding applied or refuted

| # | Finding | Outcome |
|---|---------|---------|
| **B1** | `staleness` (later `expires` first) ranked above `preference`, so a fresh sign-in loses to an older Codex-CLI login carrying a longer-lived token — reproduced as an A/B regression against beta on three store shapes | **Applied.** `staleness` dropped; the rank is expired-or-not, then `PROFILE_KEYS`. RED: `expected 'acct-old-cli' to be 'acct-owner-signin'`. |
| **H1** | The commit that "pins" the sign-in preference passes only because its fixture gives the sign-in the longer expiry | **Applied.** The reversed-lifetime fixture is now the RED test; the original stays as the benign control. |
| **H2** | The symlink test's invariant is fixture-bound — on a box whose store is writable the same shape adopts the stale file as a rotation | **Applied as disclosure.** The precondition is now in the test name and its comment. The underlying "adopt without an identity check" hazard is older than this branch — see M4. |
| **H3** | `profileKeyIn` does not read `store.order` / `cfg.auth.order` / `cfg.auth.profiles`, and the comment claimed a fidelity it does not have | **Applied for the overclaim** — the comment and this body now say exactly which one step of core's comparator is reproduced and which inputs are not read. Honouring the config order is a follow-up; with `staleness` gone, the entry it would have excluded (`openai:default`) already ranks behind `openai:chatgpt` on preference. |
| **M1** | The success-branch skip is silent and only postpones the burn: next tick the skipped file becomes the sole divergence and discards the first agent's token instead | **Applied.** With more than one diverged app-server home, **neither** rotation is adopted and core is not written. RED: `expected 'refresh-rotated-by-main' to be 'refresh-spent'`. |
| **M2** | The legacy-JSON short-circuit bypasses the new ownership invariant | **Refuted as a change here, recorded as a residual.** Dropping it changes the downgrade path the `readProfiles` comment exists to protect; pre-existing, and beta behaves identically. |
| **M3** | "no process runs with `CODEX_HOME=~/.codex`" is false under core's `appServer.homeScope: "user"` | **Applied.** Both assertions now name that opt-in and scope themselves to "nothing in this repo sets it". Reading the value is a residual. |
| **M4** | A diverged codex-home file is adopted as a rotation with no recency or identity check | **Refuted as a change here, recorded as a residual.** Pre-existing and identical on beta; the sign-in route's new delete mitigates it at the moment the account changes. |
| **M5** | The route's delete swallows EACCES and a `readdir` failure with no log — a false success | **Applied.** Both are logged through `logSafe`. |
| **M6** | Comments introduced by this PR contradict each other about the codex-home symlink, and the write-back doc describes only the failure branch | **Applied.** Both settled: nothing in this repo creates that symlink, and the doc now names the two-rotation case too. |
| **L1** | `ownsSharedStore` accepted any object with `location: "state-db"`, while core requires exactly one key and throws otherwise | **Applied.** Same shape test as `parseSharedAuthStoreOwnership`, answering `false` where core throws. |
| **L2** | No test seeds **both** mirrors stale — the state the box was actually in | **Applied.** Added. |
| **L3** | "credential already current" suppressed whenever anything is skipped | **Applied.** Suppressed only when every destination was skipped. |
| **L4** | `clawbox-codex-auth-sync.service` passes no arguments, so the home comes from an env var nothing in this repo sets | **Refuted as a change here, recorded as a residual.** Pre-existing; the default resolves correctly on every shipped box, and changing a shipped unit needs its own install/upgrade path. |
| **L5** | The new `chmodSync` can throw and abort the rest of the pass, silently under the timer's quiet flag | **Applied.** Guarded; the credential is written either way. |

The same pass confirmed by reproduction that the `auth.sharedStore` gate has **no false
negative**: on a `legacy-main` box the shared store *is* `agents/main/agent/openclaw-agent.sqlite`,
which the per-agent reader already reads and `mainFirst` visits first; and a fresh 2026.8 box gets
the ownership row written before the first shared profile write (`initializeFreshSharedAuthStore`),
so "profiles in the state DB with no ownership row" is not reachable.

### Final-delta Opus review (`MERGE-OK`) — the two mediums and the lows

0 blockers, 0 high. Everything below is on the final head.

| # | Finding | Outcome |
|---|---------|---------|
| **M2** | A failed `chmodSync` on a credential mirror was reported through `log()`, a no-op under `CODEX_AUTH_MIRROR_QUIET=1` — which is exactly how `config/clawbox-codex-auth-sync.service` runs the script. A mirror left world-readable while holding an OAuth refresh token said nothing, 144 times a day | **Applied.** `console.error`, the channel this file already reserves for a state that is not normal and idempotent. Pinned by a test that runs the script as the timer runs it. RED on `ec79896d`: `expected '' to contain 'could not tighten permissions'`. |
| **M1** | Clock skew re-opens the earlier "expired vs live" shape for one boot pass: a box whose clock is behind reads an expired credential as live, every candidate ties, and the rank falls back to `PROFILE_KEYS` — beta's ordering | **Stated as a bound, deliberately not "fixed".** No local check closes it, and shipping one that looks like it does would be the false success this codebase keeps producing. A grace period forgives a clock running AHEAD, not one running behind; the access token's own JWT `exp` claim — the other option the review named — is evaluated against the same wrong clock. The window is one boot pass on a Jetson carrier board with no battery-backed RTC, the degraded ordering is what beta always did, and the ten-minute timer corrects it on the first tick after NTP lands. Written into `profileKeyIn`'s comment as a named limit, in those terms. |
| **L1** | A profile with no usable `expires` ranked level with a live one, so a `PROFILE_KEYS`-preferred entry carrying no expiry outranked an agent's own demonstrably live login | **Applied.** Three tiers — live, unknown, expired — instead of two. "Unknown" is still never "expired" (core's own answer), but it is not evidence of life either. Defensive: neither this repo's sign-in writer nor the Codex CLI omits `expires`, so no shipped writer produces the shape, and the comment says so. |
| **L2** | With one destination skipped and the other already current, the pass printed the skip warning on stderr **and** `credential already current` on stdout — two lines contradicting each other | **Applied.** The line now reads `credential already current on the files this pass owns` whenever anything was skipped. The guard itself is unchanged: a single left-behind file must still not silence it. |
| **L3** | The body's `git diff --stat` was from an earlier head, and the RED block named a test superseded during round 3 | **Applied.** Both refreshed against the final head above. |
| **L4** | The docblock claimed an uncredentialed entry is "a last resort, so a rotation still lands somewhere" — unreachable: when it ranks first `credentialFromProfiles` returns null and `main()` stops before any write | **Applied.** One sentence, corrected to what the code does. |
| **L5** | In the two-rotation case `~/.codex/auth.json` is still written with core's known-spent refresh token | **Recorded, no change.** The review's own words: strictly better than beta, which on that fixture adopts one rotation and overwrites the other agent's live token — and the alternative, skipping the plugin's own file, is round 3's H1 (`401 Missing bearer`, no credential anywhere). |
| **L6** | When the credential resolves from agent A and the rotation comes from agent B's codex-home, the rotation is recorded into **A**'s store | **Applied as disclosure.** One sentence in `writeBackToCore`'s docblock: A is the store that hands out the token, and on the two shapes that ship it is either unwritable (`state-db`) or A is `main`, whose store IS the shared store. |

### CodeRabbit — `scripts/codex-auth-mirror.js:528`, judged on the code and **applied**

> Wrap the per-agent store read-modify-write in a transaction. `PRAGMA busy_timeout` serialises
> lock acquisition only.

Correct, and reachable. `busy_timeout` makes each statement wait for its own lock; it does
nothing about the gap between the `SELECT store_json` and the `UPDATE`, and that row is **one
JSON blob holding every profile**, so a writer landing in the gap loses its update for all of
them, not just the id this pass touched. Two such writers exist:

- **core itself** — on a `legacy-main` box `<stateDir>/agents/main/agent/openclaw-agent.sqlite`
  *is* the shared store, the one core reads and writes when it refreshes an OAuth credential.
  Overwriting a rotation core just persisted with the token this pass read is the
  `refresh_token_reused` shape the rest of this file exists to prevent;
- **a second mirror pass** — the boot pass from `gateway-pre-start.sh` and a
  `clawbox-codex-auth-sync.timer` tick can overlap.

`BEGIN IMMEDIATE` takes the write lock **before** the read, so a concurrent writer waits out the
same 5 s `busy_timeout` instead; if it cannot, the pass falls into the existing catch and the next
tick retries — the non-fatal contract is unchanged. `wrote = true` moved to **after** the
`COMMIT`: a rotation reported as recorded but rolled back would have left `main()` adopting a
token core does not hold, which is a false success of its own.

### Transaction-review fold-in (`MERGE-OK`, 0 blockers) — the two mediums

The review of the delta above, folded in on top of it. Both mediums are the sibling call sites of
what that delta fixed.

| # | Finding | Outcome |
|---|---------|---------|
| **M-2** | The delta guarded the **file** chmod and left the **directory** chmod five lines above it unguarded. That one runs *before* the write, so an EPERM there (a codex dir owned by another user) threw out of `writeMirror` and aborted `main()`'s whole destinations loop — and said so only through the top-level `log()`, which the timer's `CODEX_AUTH_MIRROR_QUIET=1` silences while `SuccessExitStatus=0 1` keeps the unit green | **Applied.** Guarded and reported on the same channel as the file chmod, so one un-tightenable directory costs that directory's permissions instead of the pass, and the top-level catch now uses `console.error` as well. Exit 0 is unchanged — a credential mirror still never blocks a gateway start. RED below. |
| **M-1** | `wrote` is an OR across two stores, so the delta's new "only after the COMMIT" comment claimed a guarantee the flag cannot make: the legacy `auth-profiles.json` loop sets `wrote = true` untransactionally | **Applied to the comment.** Scoped to the sqlite loop, with the bound named — the divergence persists, the next tick retries, and `readProfiles` prefers that JSON file on exactly the boxes that have one. Splitting `wrote` per store changes behaviour on the legacy path and is a residual, not a comment fix. |
| **L-1** | The transaction and the three-tier expiry ranking shipped untested | **Applied, both.** A second connection holds core's write lock for a whole pass and pins the write-back failing **closed**: no adoption claimed, core's store unchanged, the app-server's live rotation left alone, the warning on stderr, exit 0. Deterministic rather than flaky — 5/5 runs at 5.05 s each, exactly the `busy_timeout` — so it ships. Two profiles pin the middle expiry tier from both sides: an entry with no usable `expires` ranks below a live one under a preferred id, and above an expired one. |
| **L-2** | `BEGIN IMMEDIATE` is now taken on the no-op path too — the passes that `continue` because the row or profile is absent | **Recorded, no change.** Bounded by the same 5 s the `UPDATE` could already cost, once, at a ten-minute cadence. |

RED for the directory chmod, on the head before this fold-in (`9b4932f2`) — the existing chmod test
extended to fault `fs.chmodSync` on the `~/.codex` **directory** only, run under the timer's own
quiet flag:

```
 FAIL  src/tests/unit/codex-auth-mirror.test.ts > codex-auth-mirror.js >
       keeps mirroring the REMAINING destinations when a directory chmod fails, and says so
AssertionError: expected '' to contain 'could not tighten permissions'
```

Hand-run on the same fixture, the full symptom is worse than "the remaining destinations are lost":

```
exit=0
stdout=[]
stderr=[]
ls: cannot access '<tmp>/.codex/auth.json': No such file or directory
ls: cannot access '<tmp>/.openclaw/agents/main/agent/codex-home/auth.json': No such file or directory
```

Nothing written anywhere, nothing on either stream, exit 0. After the fix both destinations are
written and the failure is named on stderr with its code.

### Review-bot findings, each reproduced RED before fixing

| Finding | Outcome |
|---------|---------|
| Write-back reached **every** agent store holding that profile id, though the credential was resolved from one agent — a sibling agent using the same id for another account got someone else's rotation | **Applied.** `writeBackToCore` now receives only the resolving agent's directory. RED: `expected 'refresh-rotated-by-appserver' to be 'refresh-support-account'`. |
| After adopting one app-server's rotation, the pass rewrote a **second** diverged app-server home with the adopted token, discarding its live refresh token | **Applied.** Every diverged app-server home but the adopted one is skipped (the plugin's own file still excepted). RED: `expected 'refresh-rotated-by-main' to be 'refresh-rotated-by-support'`. |
| The mirror test inherited `OPENCLAW_STATE_DIR` / `CODEX_AUTH_MIRROR_QUIET` into the child | **Applied.** `run()` pins both. |
| Skipping the losing app-server homes only postpones the discard | **Applied**, and further than proposed — with more than one, neither rotation is adopted. |
| `writeBackToCore` can never reach the state-DB store, so the failure path is permanent | **Accurate, deliberately not "fixed".** Writing that gateway-wide row from a 10-minute timer would be an unlocked read-modify-write bypassing core's `oauth-refresh` lock — the storm guard. The repeated warning and the wrong-adoption halves are closed instead; the identity check a real fix needs is a recorded residual. |
| `@typescript-eslint/no-require-imports` on the lazy `require("node:sqlite")` | **Refuted as stated.** The rule is not a CI gate — `npm run lint` fails on `origin/beta`, and this file already carries **5** of these errors there. The three sqlite requires are collapsed into one accessor instead, taking the file to **4**, below beta. |


### CodeRabbit — the permission round, both threads judged on the code and **applied**

Two Security threads on the last push, `scripts/codex-auth-mirror.js:~481` (major) and
`src/tests/unit/codex-auth-mirror.test.ts:~1087` (minor). Both correct.

> Permission tightening is bound to the rewrite path, not to every pass.

`writeMirror` returned at `if (!reason) return null` **before** either chmod, so a
`~/.codex/auth.json` or `codex-home/auth.json` that is already current but 0644 — an older mirror,
or the Codex app-server's own rewrite of its CODEX_HOME copy — short-circuits on "credential already
current" and keeps that mode for the life of the box while holding an OAuth refresh token. The
existing permission test seeded a rotated access token, so it only ever proved that a *rewrite*
tightens the mode.

RED on `71b605e3`, the fixture the thread asked for — a 0644 up-to-date mirror, one pass, mode and
"was it rewritten" both asserted:

```
 FAIL  src/tests/unit/codex-auth-mirror.test.ts >
       tightens a world-readable mirror on the IDEMPOTENT pass, without rewriting it
AssertionError: expected 420 to be 384        // 0644 vs 0600
```

**Harness-first — the criterion is core's, the repair is ours because core has none for these
files.** `openclaw doctor`'s state-integrity check tightens when any group/other bit is set
(`(stat.mode & 63) !== 0`) and repairs to the same `448` / `384`
(`dist/doctor-state-integrity-BDXsK-A4.js:1404-1429`, pinned core 2026.8.1) — but it covers the state
dir, the config file and the runtime state dirs and never `~/.codex` or an agent's `codex-home`, and
core's Codex reader (`dist/cli-credentials-B8A7qmXj.js`) only reads `auth.json`. Grepped both: neither
mentions either path. So the trigger is borrowed from core and the repair is written here, which is
the finding. Matching the trigger also keeps the 144-a-day pass a single `statSync` with no write,
and never widens a mirror an operator deliberately made 0400 — an exact `!== 0o600` comparison would
rewrite that every tick and call it a security repair.

**The blind version of this change is a regression, and it shipped for one commit before the Opus
review caught it.** Core's repair is *two* checks in order: restore the owner's rwx on a directory it
cannot use (`canWriteDir` -> `addUserRwx`, `mode & 511 | 448`, `:1385-1398`), then tighten. The
unconditional chmod being replaced was covering the first by accident. With only the tighten ported,
a `~/.codex` at 0500 is left alone, `writeFileSync` fails EACCES, and the throw escapes `writeMirror`
and ends `main()`'s whole destinations loop — the exact failure `71b605e3` exists to prevent, through
a different door. Reproduced parent-vs-head on an identical fixture:

```
===== before the stat gate =====        ===== stat gate, tighten only =====
exit=0                                  exit=0
Codex auth.json created: …/.codex/…     stdout: (empty)
Codex auth.json created: …/codex-home/  stderr: EACCES … open '…/.codex/auth.json'
~/.codex dir mode: 700                  ~/.codex dir mode: 500
~/.codex/auth.json: YES                 ~/.codex/auth.json: NO
codex-home/auth.json: YES               codex-home/auth.json: NO   <-- the later destination
```

`enforceMode(target, mode, requiredOwnerBits)` therefore carries the owner bits a path must keep:
0700 for the directories, none for the credential files.

| # | Opus review of the delta (`BLOCK`) | Outcome |
|---|---|---|
| **H1** | The stat gate ports only the tighten half of core's repair; a 0500 codex dir is no longer repaired, the write EACCESes, and the throw ends the destinations loop | **Applied.** `requiredOwnerBits`, core's two steps in core's order. RED: `expected 320 to be 448`. |
| **M1** | `fs.writeFileSync` is the one per-destination operation still unguarded, so the docblock's "must cost that path, not the pass" is not true of the function | **Applied.** Guarded, non-fatal, and never counted as synced — so the summary line cannot answer `credential already current` over a failure stderr just reported. RED: the exception escaped to the top-level catch as `Codex auth.json: EISDIR…`. |
| **M2** | Sibling call site: `writeBackToCore` writes `<agentDir>/auth-profiles.json` with the same creation-only `{ mode: 0o600 }`, on a file that always pre-exists and holds the **refresh** token; core's audit flags it (`fs.auth_profiles.perms_readable`) and never repairs it | **Applied.** `enforceMode(jsonPath, 0o600)` after the write. |
| **L1** | "This script is the sole writer of these files" overclaims — the Codex app-server rewrites its own CODEX_HOME copy, which is the premise of the `skip` machinery in the same file | **Applied** in both the code comment and the test, and it strengthens the case: a mirror can come back with a mode nothing here chose. |
| **L2** | The ENOENT comment described only the `writeMirror` caller, not the new `main()` skip caller where no write follows | **Applied.** |
| **L3** | Nothing pinned the `(mode & 0o077)` trigger — every test passed unchanged with an unconditional chmod, and the untested half is what produced H1 | **Applied.** Three tests: `0400 stays 0400`, the 0500 directory, and the unwritable destination. |
| **L4** | An un-tightenable path now complains on **every** pass rather than only on a rewrite — ~144 identical journal lines a day for a state that cannot self-heal (a root-owned `codex-home`, a read-only mount) | **Stated, not changed.** Reporting a real exposure loudly is the point; the only quieter option needs per-pass state this script deliberately does not keep. Noted here so it is not diagnosed later as a new fault. |
| **L5** | `statSync`/`chmodSync` follow symlinks, and the skip branch now chmods through one (core `lstat`s first, `dist/doctor-state-integrity-BDXsK-A4.js:1400-1411`) | **Recorded, no change.** A tightening, not a widening, inside a 0700 directory; the TOCTOU window is the same shape and equally bounded. |
| **L6** | ~10 lines of the docblock restate rationales that already exist at two other sites | **Applied.** Trimmed to the paragraph that is load-bearing: core's criterion. |

**Sibling sweep for this round.** `configure/route.ts:2839-2849` only `fs.rm`s the two mirrors — no
write, no mode, clear. `gateway-pre-start.sh:2095-2101` delegates to this script, pinned by a test.
`install.sh:3869` creates `~/.codex` with `install -d -m 700`, which is why H1's precondition is not a
state the shipped path produces. `scripts/migrate-auth-profiles.js` has no write or chmod at all.
`config/clawbox-codex-auth-sync.service` runs as `clawbox` with both paths in `ReadWritePaths`, so
tightening to 0700/0600 cannot lock out the Codex app-server. The only uncovered one was
`writeBackToCore`, above.

One existing test was re-fixtured: "reports a failed chmod where the TIMER can see it" faulted
`chmodSync` on a *fresh create*, which now makes no chmod call at all — `writeFileSync`'s `mode` can
only lose bits to the umask, never gain them, so a newly created mirror is already 0600. It now seeds
both mirrors 0644 and rotates the token, putting the fault on the rewrite path. No case is lost: the
create path has no chmod left to fail.

GREEN on that round's head: `codex-auth-mirror.test.ts` **43/43**, `migrate-auth-profiles` 9/9,
`src/tests/routes/ai-models/` 17 files / 306 tests, `tsc --noEmit` clean. (Superseded by the
final numbers at the end of this body.) CI is the arbiter.

### Post-review follow-up — `M-1`, the last unguarded abort path in `writeMirror`

The delta review above closed `MERGE-OK` with one MEDIUM left open, and this commit is it.
`fs.mkdirSync` sat **outside** the try, so the comment one screen down — "the last
per-destination operation that could still end the pass" — and the matching test comment were
both false. Creating the directory runs *before* the write, and it throws on shapes a box
really has: an `<agentDir>` the owner cannot write (`EACCES`), or a `codex-home` present as a
regular file or a dangling symlink (`EEXIST` / `ENOTDIR` — nothing filters those out earlier,
because `readJson` returns `null` on `ENOTDIR` and `fileKey()` swallows its realpath failure).
The throw left `main()`'s destinations loop, and every destination behind it — the other
agents' CODEX_HOME copies, the ones without which a Codex turn falls back to the
Cloudflare-challenged browser endpoint — was silently unwritten while the top-level catch
printed one raw syscall line and exited 0.

RED on `3595aadf`, two fixtures, each asserting the **lost destination by name** rather than
only the message (a second agent, `spare`, is seeded so there is a destination *behind* the
failing one, and the fixtures are read through the same `readdirSync` the script uses so the
faulted destination is genuinely in front of the survivor):

```
 × keeps mirroring the LATER destinations when a codex-home cannot be created
 × keeps mirroring the LATER destinations when a codex-home is a FILE
   AssertionError: expected [ Array(1) ] to deeply equal [ …(2) ]
     [
       "…/.codex/auth.json",
   -   "…/.openclaw/agents/spare/agent/codex-home/auth.json",
     ]
```

and, before the fix, the only thing on the channel the timer can see was the bare syscall:

```
   Codex auth.json: EACCES: permission denied, mkdir
   Codex auth.json: EEXIST: file already exists, mkdir '…/agents/main/agent/codex-home'
```

**Applied.** Both per-destination operations that can throw now route through one
`writeFailed(error)`: the destination named on `console.error` (the channel
`CODEX_AUTH_MIRROR_QUIET=1` does *not* suppress, which is how the timer runs it),
`WRITE_FAILED` returned so that destination is never counted as `synced` and the summary line
cannot answer "credential already current" over it, and the loop continues to the remaining
destinations. The early return also keeps the two `enforceMode` calls off a path that is not
the kind of thing they expect — a `codex-home` that is a regular file would otherwise be
chmodded 0700 as though it were a directory. Both comments are now true.

**Sibling sweep for this round.** `fs.mkdirSync` appears exactly once in the script, and
`writeMirror` has exactly one production caller (`main()`'s destinations loop). Every other
statement in that loop body is already non-throwing: `readJson` swallows everything,
`enforceMode` wraps both its `statSync` and its `chmodSync` (so the `skip` branch, which calls
only `enforceMode`, cannot end the pass either), and `JSON.stringify(buildAuthFile(...))` is
evaluated inside the write's own try. One unwritable destination can no longer cost any other.


## H3 — the honest correction: this PR does not, on its own, serve the owner a ChatGPT turn

The final review said the pinned core contradicts this PR's root-cause claim. It does, and
the mechanism turned out to be different from the one the review proposed. Established
**read-only on the OpenClaw box** (no mutation, no `openclaw` subcommand, every SQLite read
opened `file:…?mode=ro`, no mutex taken) against core **2026.8.1 (ea80657)** — and the four
deciding `dist/*.js` files hash byte-identical between the box and a plain 2026.8.1 npm
install, so every citation below is reproducible off-box.

**What actually authenticates the failing turn:** not `openai:default`, not any auth profile
at all. It is the **inline `claw_…` key in `models.providers.openai.apiKey`**, which core
labels `inline-api-key:openai` (source `models.json`). Proven three ways:

- the gateway journal's `profile=sha256:5ec18a0875dc`, and
  `sha256("inline-api-key:openai")[0:12] == 5ec18a0875dc` — the hash scheme (`redactIdentifier`,
  `dist/redact-identifier-BRudYwZN.js:5-13`) verified against the `anthropic:default` line in
  the same journal. `sha256("openai:default")` and `sha256("openai:chatgpt")` appear **nowhere**
  in it;
- a matching `usageStats["inline-api-key:openai"]` cooldown row (`cooldownReason: "auth"`) in
  `agents/main/agent/openclaw-agent.sqlite`;
- the 401 itself: `Incorrect API key provided: claw_***`, `url: https://api.openai.com/v1/responses`.

So the review's H3 hypothesis — "the box's `claw_`-holding `openai:default` profile is still
what core resolves" — is **refuted in its mechanism** and **right in its conclusion**.

**The sign-in itself is fine.** `openai:chatgpt`, type `oauth`, in the shared store
(`auth.sharedStore = {"location":"state-db"}`), `expires` 2026-09-13 — about 9.5 days out.
Three gates keep it off the wire:

1. **Route gate.** The merged `models.providers.openai` entry carries `api: "openai-responses"`
   (from the remote catalog; the box overrides only `apiKey` and one image model).
   `shouldResolveDynamicModelThroughCodex` returns `false` on exactly that value at
   `dist/openai-provider-C9ArVyXG.js:711` — **before** `:714`, where `agentRuntimeId === "codex"`
   would have chosen the ChatGPT route. ClawBox's own
   `agents.defaults.models["openai/gpt-5.5"].agentRuntime.id = "codex"` arm is therefore inert,
   and the turn goes to the OpenAI **Platform** Responses API.
2. **Auth-mode gate.** With `modelApi = "openai-responses"`,
   `directOpenAIPlatformModelRequiresApiKey` is true, so `isAuthModeAllowedForModel`
   (`dist/model-auth-D6SoPLuz.js:44-47`) admits **only** `mode: "api-key"`. The OAuth profile is
   skipped at `:475-479`. A ChatGPT subscription credential is not a legal credential for the
   Platform route, by design.
3. **Order gate.** `cfg.auth.profiles` lists `openai:chatgpt` but not the stored
   `openai:default`, and a non-empty `cfg.auth.profiles` **silently becomes the base order**
   (`dist/order-PeugL3t0.js:146-159`), dropping stored-but-unlisted profiles with no diagnostic
   on the turn path.

The usable openai profile order is therefore empty, and `resolveApiKeyForProviderCore` falls all
the way through to `dist/model-auth-D6SoPLuz.js:595-621` and returns the inline config key.

**`resolveAuthProfileOrder`'s comparator is not the problem and must not be "fixed":**
`dist/order-PeugL3t0.js:228,233` scores `oauth = 0 < token = 1 < api_key = 2` ahead of expiry and
last-used; insertion order and profile id are never tiebreakers. Left to the comparator,
`openai:chatgpt` wins.

### So: was the mirror alone ever going to be enough?

**No — categorically not, and this PR says so rather than claiming D-01 is closed.**

- `<agentDir>/codex-home/auth.json` is **not read** by agent-scoped Codex runs at the default
  `homeScope: "agent"`. Core says so in its own error string
  (`resolveUnimportedAgentCodexAuthMessage`, `dist/shared-client-p7RVqn_L.js:876-883`); the default
  is documented at `docs/plugins/codex-harness-reference.md:257`; the box sets no `homeScope`.
- `~/.codex/auth.json` discovery is **switched off** by `hasManagedProviderOAuth`
  (`dist/external-cli-sync-C6O5wjrA.js:75-77`, `:82`, `:130`) the moment the store holds any
  oauth profile for `openai|codex|codex-cli|codex-app-server` with inline token material — true
  twice on this box.
- The failing turn never reaches the Codex app-server at all; it is core's own HTTP request to
  the Platform Responses API, a path with no `auth.json` anywhere in it.

The mirror remains the right fix for the bug it was written for — the Codex app-server having no
credential (#280) — and its RED is real: on this box it has been a no-op since the profiles
moved, logging `no codex OAuth profile yet, skipping` on **every boot** while both mirror files
sat frozen on the 2026-08-27 `codex:default` login, eight days stale and predating the owner's
sign-in. That is worth fixing on its own terms. It is not D-01's cause.

### What still has to change, and why it is not in this PR

The native knobs are `models.providers.openai.auth: "oauth"|"token"` → transport `codex`
(`dist/openai-provider-C9ArVyXG.js:700-704`, consumed at `:924`), or
`api: "openai-chatgpt-responses"` (`:696-698`) — either flips `openAICodexTransportRequiresOAuth`
and makes oauth the only admissible mode, at which point `openai:chatgpt` is selected.

Not attempted here, deliberately. One question could not be settled read-only: what either knob
does to the `gpt-image-1-mini` / `https://clawbox.com/api/ai` model row that shares the same
provider entry. And the neighbouring change — dropping the inline `claw_` key from
`models.providers.openai.apiKey` — was killed in an earlier pass for a credential-leak reason
that still stands: with the ClawBox-proxy image row on that entry, removing the key would let an
OpenAI OAuth credential reach `clawbox.com/api/ai`. Shipping an unverified provider-route change
on top of a fix whose blocker was profile ranking would be exactly the false success this
codebase keeps producing. It is filed as a follow-up needing a config experiment on a box, with
the full evidence and citations — that experiment is **running separately, on hardware, right
now**, to settle which of the two knobs is the minimal safe change and what it does to the
`gpt-image-1-mini` row sharing the provider entry. Its result belongs to that follow-up, not to
this PR: nothing here depends on the answer, and this PR's claim does not change with it.

## Sibling sweep

| Call site | Outcome |
|---|---|
| `scripts/gateway-pre-start.sh:2095-2097` — boot invocation of the mirror | **Cleared.** Argument contract unchanged (`<openclawHome> <homeAuthPath>`); every change is internal to the script. |
| `config/clawbox-codex-auth-sync.service:19` — the 10-minute timer's invocation | **Cleared.** Same contract; the timer's `CODEX_AUTH_MIRROR_QUIET=1` still suppresses `log()` and still does not suppress the one `console.error`. |
| `src/app/setup-api/setup/reset/route.ts:229-236` — factory reset | **Cleared, no change needed.** It removes `~/.codex` wholesale, and `~/.openclaw` with it, so both mirrors go. |
| `pasteAuthApiKey` (`configure/route.ts:385`) — every api-key credential write | **Cleared.** Two call sites: `:1070` writes the ClawBox AI token into `deepseek:default` (its own provider, correct), and `:2252` is the generic provider path the `claw_` guard at `:1704` now covers. |
| Whole-repo grep for other writers/deleters of `~/.codex/auth.json` or any `codex-home/auth.json` | **Cleared.** None outside the mirror and the configure route. |
| Whole-repo grep for other readers of `config_machine_state` / `authProfiles.store` / `auth.sharedStore` | **Cleared.** The mirror is the only one; `src/lib/openclaw-state-store.ts` holds the path helper the mirror's `stateDbPath()` mirrors, and reads no auth state. |
| Dual SKU — the Hermes edition | **Cleared, nothing to mirror.** Hermes's OAuth sign-ins go through the Hermes dashboard API (`src/app/setup-api/hermes/oauth/*` → `dashboardFetch`), never through OpenClaw's auth profile store or a Codex `auth.json`. Both files this PR touches are OpenClaw-edition only. |
| `credentialFromProfiles` / `profileKeyIn` / `readSharedProfiles` / `writeBackToCore` | Single-file, all call sites inside `scripts/codex-auth-mirror.js`, all updated together. |

## RED → GREEN

Every one of the twelve new tests was run against this branch's own head **before** the fix.

```
 × prefers a LIVE local profile over an EXPIRED shared one filed under a preferred id
     expected 'acct-shared' to be 'acct-local'
 × prefers the LIVE shared profile when the agent's own copy is the expired one
     expected 'acct-local' to be 'acct-shared'
 × leaves the state-db store unread on a legacy-main box — core does not resolve through it
     expected 'acct-shared' to be 'acct-local'
 × realigns a stale ~/.codex/auth.json when codex-home is a symlink to it
     expected 'refresh-previous-signin' to be 'refresh-live'
 × tightens an existing world-readable mirror to 0600, not only a freshly created one
     expected 420 to be 384
 × writes a rotation back only into the agent it read the credential from
     expected 'refresh-rotated-by-appserver' to be 'refresh-support-account'
 × adopts NEITHER rotation when two app-server homes have rotated independently
     expected 'refresh-rotated-by-main' to be 'refresh-spent'
 × reports a failed chmod where the TIMER can see it, not through the quiet log
     expected '' to contain 'could not tighten permissions'

 × clears EVERY agent's codex-home mirror on a ChatGPT sign-in, not just ~/.codex   (route)
     expected false to be true
```

And the customer-visible one, seeded with the **reported box's own store shape** as the
read-only device leg measured it (an `openai:default` api_key holding a ClawBox proxy key, a
`codex:default` OAuth login from a Codex CLI sign-in, the owner's `openai:chatgpt` sign-in, and
a per-agent table emptied by `doctor --fix`) — run against **`origin/beta`'s** copy of the
script:

```
 FAIL  mirrors the owner's ChatGPT sign-in, not the older Codex CLI login beside it
 Error: ENOENT: no such file or directory, open '…/.codex/auth.json'
```

Beta writes no mirror at all — which is exactly what the box shows: `Codex auth.json: no codex
OAuth profile yet, skipping` on every boot, and both mirror files frozen on 2026-08-27. On this
branch both mirrors are written and both carry the owner's sign-in, not the eight-day-old Codex
CLI login.

GREEN, on the final rebased head `c044e7a6`:

```
 src/tests/unit/codex-auth-mirror.test.ts + migrate-auth-profiles.test.ts
 Test Files  2 passed (2)
      Tests  54 passed (54)          # codex-auth-mirror.test.ts 45/45

 src/tests/routes/ai-models/
 Test Files  17 passed (17)
      Tests  306 passed (306)
```
plus eleven neighbouring unit suites (152/152: the codex probe and both
`gateway-pre-start-codex-*`, the four `hermes-*` route suites, `use-clawbox-login`, both
`apply-model-override`) and `tsc --noEmit` clean. CI is the arbiter.

```
$ git diff --stat origin/beta...HEAD
 scripts/codex-auth-mirror.js                   |  691 ++++++++++++++--
 src/app/setup-api/ai-models/configure/route.ts |   59 +-
 src/tests/routes/ai-models/configure.test.ts   |   53 ++
 src/tests/unit/codex-auth-mirror.test.ts       | 1057 +++++++++++++++++++++++-
 4 files changed, 1780 insertions(+), 80 deletions(-)
```
Four files, all `M`, no deletions, nothing the branch does not own. Rebased on `origin/beta`
`89e37e14`.

## Device proof steps — OpenClaw box, after merge and deploy

Under the `clawbox-box` skill; take the device mutex for the mutating window and release it on
the way out, including on failure. Redact tokens from anything pasted back.

**0 — deploy and confirm the head is on the box**
```
box-update.sh                                     # or the bundle path
git -C ~/clawbox rev-parse HEAD                   # must equal the merged beta head
systemctl status clawbox-codex-auth-sync.timer    # active (waiting)
```

**1 — the mirror now finds the sign-in (the RED half, on hardware)**
```
sudo -u clawbox node ~/clawbox/scripts/codex-auth-mirror.js ~/.openclaw ~/.codex/auth.json
```
Expect `Codex auth.json refreshed:` or `created: /home/clawbox/.codex/auth.json` — **not**
`no codex OAuth profile yet, skipping`, which is what every boot has printed since 2026-08-27.
Then, without printing the token:
```
sudo -u clawbox python3 -c "import json;d=json.load(open('/home/clawbox/.codex/auth.json'));print('refresh_len',len(d['tokens']['refresh_token'] or ''),'last',d['last_refresh'])"
stat -c '%a %U:%G %y' /home/clawbox/.codex/auth.json    # expect 600 clawbox:clawbox, today
```
The access token's JWT `exp` must now match the `openai:chatgpt` profile's `expires`
(2026-09-13), **not** `codex:default`'s (2026-09-06) — that is the whole point of the read fix.

**2 — the shared store was the source and was NOT written**
```
sudo -u clawbox python3 - <<'PY'
import sqlite3,datetime
c=sqlite3.connect("file:/home/clawbox/.openclaw/state/openclaw.sqlite?mode=ro",uri=True)
for k,n,t in c.execute("select state_key,length(value_json),updated_at_ms from config_machine_state where state_key in ('authProfiles.store','auth.sharedStore')"):
    print(k,n,datetime.datetime.utcfromtimestamp(t/1000))
PY
```
`auth.sharedStore` must be `{"location":"state-db"}`, and `authProfiles.store`'s timestamp must be
**unchanged** across step 1 — run it before and after. Read-only discipline is the property under
test.

**3 — the codex-home mirror clears itself on a sign-in (H2)**
In Settings, sign out of ChatGPT and sign in again. Then:
```
sudo -u clawbox ls -l /home/clawbox/.openclaw/agents/*/agent/codex-home/auth.json
```
Both mirrors must carry **today's** date, and the next timer tick must print **no**
`holds a refresh token core does not have` line. No `rm` by hand — if that is still needed, the
route change did not take.

**4 — serve the turn, and read who answered**
```
sudo systemctl restart clawbox-gateway
sudo -u clawbox openclaw gateway status            # wait for it to ANSWER, not for systemd
sudo -u clawbox openclaw agent --session-key agent:main:pr617proof \
  --message "Reply with the word OK and the model id you are." --json
```
The only thing that proves which model served it is **`result.meta.agentMeta.provider` /
`agentMeta.model`** — no journal line does.

- **PASS** = `agentMeta` reports `openai/gpt-5.5`.
- **EXPECTED FAIL, and not a regression from this PR** = `agentMeta` reports
  `llamacpp/gemma4-e2b-it-q4_0`, with
  `journalctl -u clawbox-gateway --since -3min | grep -E 'model-fallback|failover decision'`
  showing `reason=auth` and a `401 … Incorrect API key provided: claw_***` against
  `https://api.openai.com/v1/responses`. That is **H3** — the route and auth-mode gates above —
  and it is a separate follow-up, not something this PR claims to fix. Confirm it by checking
  that the journal's `profile=` hash is `sha256:5ec18a0875dc` (`inline-api-key:openai`) and not
  `4ca82c2f8cb5` (`openai:chatgpt`).

**5 — restore**
```
sha256sum /home/clawbox/.openclaw/openclaw.json    # capture before the run and compare after
```
Nothing in steps 0-4 changes the config; the hash must match. Release the mutex.

**What to tell the owner:** merging this makes the box's ChatGPT credential reach the Codex
mirrors again, and stops the sync timer's 144-a-day warning. It does **not**, on its own, make a
ChatGPT turn run: core is routing `openai/gpt-5.5` to OpenAI's Platform API, where a subscription
credential is not a legal credential, and falling back to the inline ClawBox proxy key. That is
one provider-entry change away and is filed separately with its evidence. That change has since
been isolated on the box and written up at `/home/krasi/clawbox-run-scratch-2026-09-03/pr617/route-experiment.md`,
which settles it: removing exactly one config key — `models.providers.openai.apiKey` — is the one
change that serves the turn, moving it onto the owner's ChatGPT sign-in at the cost of the ClawBox
AI image row, and it needs no gateway restart. The owner has been asked to choose; nothing in this
PR makes that choice.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved ChatGPT sign-in handling to select usable credentials more reliably and keep authentication mirrors synchronized.
  * Added support for recovering credentials from configured local and shared stores.

* **Bug Fixes**
  * Prevented ClawBox credentials from being submitted to incompatible cloud providers.
  * ChatGPT sign-in cleanup now removes stale credentials across all configured agents.
  * Improved recovery from stale, duplicated, or independently rotated authentication files.

* **Security**
  * Authentication mirror files now enforce restrictive `0600` permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


