### PR TITLE
fix: report the embedder the core resolved, not the one the config implies (TASK-659)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4515,24 +4515,48 @@ step_ollama_install() {
     # The helper exits 0 on every soft failure by design (a missing Ollama must
     # not abort an install), so its exit code says nothing about the outcome.
     # Read the config it was supposed to write instead — from the ACTIVE home.
-    # Only an OpenClaw 2 core writes memory.search, and once that names a
-    # provider the core ignores agents.defaults.memorySearch entirely — so a
-    # stale legacy block still saying "ollama" from the box's OpenClaw 1 days,
-    # beside a memory.search the owner has since pointed at OpenAI, is a box on
-    # the cloud embedder. "Ready, needs no API key" would be false there.
-    if as_clawbox python3 - /home/clawbox/.openclaw/openclaw.json <<'PY' 2>/dev/null
+    #
+    # Read the ONE key the installed core will parse. OpenClaw 2 reads
+    # memory.search and ignores agents.defaults.memorySearch entirely; a v1
+    # core does the reverse. Reading whichever block happened to name a
+    # provider printed "ready, needs no API key" over a v2 box whose
+    # memory.search was still empty and whose stale OpenClaw 1 block said
+    # "ollama" — a box on the default cloud embedder (TASK-659). The gate is
+    # the same 2026.8 boundary scripts/ensure-local-embeddings.sh writes
+    # through and src/lib/memory-shard.ts (embeddingConfigHome) reads through.
+    local EMBED_KEY="agents.defaults.memorySearch"
+    if openclaw_is_v2; then EMBED_KEY="memory.search"; fi
+    local EMBED_STATE
+    EMBED_STATE="$(as_clawbox python3 - "$CLAWBOX_HOME/.openclaw/openclaw.json" "$EMBED_KEY" <<'PY' 2>/dev/null || true
 import json, sys
-cfg = json.load(open(sys.argv[1]))
-v2 = (cfg.get("memory") or {}).get("search") or {}
-legacy = ((cfg.get("agents") or {}).get("defaults") or {}).get("memorySearch") or {}
-home = v2 if v2.get("provider") else legacy
-sys.exit(0 if home.get("provider") == "ollama" and home.get("model") == "qwen3-embedding:0.6b" else 1)
+try:
+    node = json.load(open(sys.argv[1]))
+except Exception:
+    node = {}
+for part in sys.argv[2].split("."):
+    node = node.get(part) if isinstance(node, dict) else None
+home = node if isinstance(node, dict) else {}
+provider = home.get("provider") or ""
+model = home.get("model") or ""
+if provider == "ollama" and model == "qwen3-embedding:0.6b":
+    print("local")
+elif provider in ("", "auto"):
+    print("unset")
+else:
+    print("cloud:%s" % provider)
 PY
-    then
-      echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
-    else
-      echo "  WARN: local embeddings are not configured yet; semantic memory falls back to lexical FTS until the next boot retries it (non-fatal)"
-    fi
+)"
+    case "$EMBED_STATE" in
+      local)
+        echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
+        ;;
+      cloud:*)
+        echo "  WARN: semantic memory is on a CLOUD embedder ($EMBED_KEY.provider=${EMBED_STATE#cloud:}) — every indexed note is embedded off the box and it needs that provider's API key; re-run scripts/ensure-local-embeddings.sh to move it on-device (non-fatal)"
+        ;;
+      *)
+        echo "  WARN: local embeddings are not configured ($EMBED_KEY is unset), so semantic memory falls back to the core's default cloud embedder — which needs an API key, and without one memory search stays on lexical FTS; the next boot retries the switch (non-fatal)"
+        ;;
+    esac
   elif ollama pull qwen3-embedding:0.6b >/dev/null 2>&1; then
     echo "  Pulled local embedding model qwen3-embedding:0.6b (semantic memory, no API key)"
   else

--- a/install.sh
+++ b/install.sh
@@ -4510,7 +4510,17 @@ step_ollama_install() {
   # Best-effort: a failure must not abort the install (memory falls back to
   # lexical FTS).
   local ENSURE_EMBEDDINGS="$PROJECT_DIR/scripts/ensure-local-embeddings.sh"
-  if [ -x "$ENSURE_EMBEDDINGS" ]; then
+  if ! has_openclaw_harness; then
+    # Above the helper, not below it. A hermes box has no core and no
+    # openclaw.json, so ensure-local-embeddings.sh finds no provider anywhere,
+    # falls through its "deliberate choice" guard and pulls a ~640 MB model
+    # whose config write then fails soft by design -- and the report below then
+    # told the same operator, in the next line, that this edition does not have
+    # the feature. Nothing is lost by skipping it: gateway-pre-start.sh runs the
+    # helper only on the OpenClaw gateway, which hermes does not have.
+    # Same answer src/app/setup-api/local-models/route.ts gives the UI.
+    echo "  Memory search is an OpenClaw feature; this edition does not include it."
+  elif [ -x "$ENSURE_EMBEDDINGS" ]; then
     as_clawbox_login "$ENSURE_EMBEDDINGS" || true
     # The helper exits 0 on every soft failure by design (a missing Ollama must
     # not abort an install), so its exit code says nothing about the outcome.
@@ -4529,19 +4539,32 @@ step_ollama_install() {
     # config read can only ever prove what was WRITTEN, never what the core
     # does with it -- it cannot see a dimension mismatch or a fail-closed index.
     #
-    # Measured on a shipped Orin: rc=0 in ~8 s for 3.3 KB of JSON, so it also
-    # costs less than the `openclaw --version` probe it replaces. Bounded and
-    # best-effort throughout: a CLI that hangs, is absent or answers nothing
-    # must neither stall nor abort the install, and "could not ask" is reported
-    # as itself rather than as a verdict.
-    if ! has_openclaw_harness; then
-      # No core on this SKU, so there is no memory search to have an embedder.
-      # Same answer src/app/setup-api/local-models/route.ts gives the UI.
-      echo "  Memory search is an OpenClaw feature; this edition does not include it."
-    else
-      local EMBED_JSON EMBED_STATE
-      EMBED_JSON="$(as_clawbox timeout 60 "$OPENCLAW_BIN" memory status --agent main --deep --json 2>/dev/null || true)"
-      EMBED_STATE="$(python3 - "$EMBED_JSON" <<'PY' 2>/dev/null || true
+    # Measured on a shipped Orin: rc=0 in ~8 s for 3.3 KB of JSON. What it
+    # replaces is a sub-second local read of openclaw.json, so this run costs
+    # ~8 s more -- worth it, because a config read can only prove what was
+    # written and this answer comes from the thing that has to use it. Bounded
+    # and best-effort throughout: a CLI that hangs, is absent or answers nothing
+    # must neither stall nor abort the install, and "could not read an embedder"
+    # is reported as itself rather than as a verdict.
+    #
+    # -k 5: `timeout` alone sends SIGTERM only, and collectMemoryStatusJson()
+    # in src/lib/clawkeep-memory.ts escalates to SIGKILL after 5 s. A CLI that
+    # ignores SIGTERM must not hang here when it would not hang there.
+    local EMBED_JSON EMBED_STATE
+    # The status is the verdict, not just the bytes. A `--deep` run that fails
+    # its provider probe after emitting the shallow status, a core that reports
+    # and then exits on an unrelated warning, and `timeout` killing the CLI
+    # after a complete document has been written all leave parseable JSON on
+    # stdout that describes nothing anyone should vouch for. Throwing the
+    # status away with `|| true` is how TASK-659 would re-enter through the
+    # exit code -- and collectMemoryStatusJson() rejects on `code !== 0`
+    # (src/lib/clawkeep-memory.ts), so trusting it here would put the installer
+    # and the Memory Shard panel back into disagreement. Assignment in
+    # if-condition position, so errexit stays suppressed.
+    if ! EMBED_JSON="$(as_clawbox timeout -k 5 60 "$OPENCLAW_BIN" memory status --agent main --deep --json 2>/dev/null)"; then
+      EMBED_JSON=""
+    fi
+    EMBED_STATE="$(python3 - "$EMBED_JSON" <<'PY' 2>/dev/null || true
 import json, sys
 try:
     doc = json.loads(sys.argv[1])
@@ -4558,9 +4581,11 @@ if not row and rows and isinstance(rows[0], dict):
 status = row.get("status")
 status = status if isinstance(status, dict) else {}
 provider = status.get("provider")
-provider = provider if isinstance(provider, str) else ""
+# .strip() so the classification cannot drift from cleanString() in
+# src/lib/clawkeep-memory.ts, which trims before comparing.
+provider = provider.strip() if isinstance(provider, str) else ""
 model = status.get("model")
-model = model if isinstance(model, str) else ""
+model = model.strip() if isinstance(model, str) else ""
 if not provider:
     raise SystemExit(0)
 if provider == "none":
@@ -4571,27 +4596,31 @@ else:
     print("cloud:%s" % provider)
 PY
 )"
-      case "$EMBED_STATE" in
-        local:qwen3-embedding:0.6b)
-          echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
-          ;;
-        local:*)
-          # On-device and keyless, so not a warning -- but the index belongs to
-          # a different model than ClawBox provisions, and the two have
-          # different vector dimensions.
-          echo "  Local embeddings ready on ${EMBED_STATE#local:}, not qwen3-embedding:0.6b (on-device, no API key; the index belongs to that model)"
-          ;;
-        cloud:*)
-          echo "  WARN: semantic memory is on a CLOUD embedder (${EMBED_STATE#cloud:}) — every indexed note is embedded off the box and it needs that provider's API key; the Memory Shard app moves it back on-device (non-fatal)"
-          ;;
-        disabled)
-          echo "  WARN: memory search is switched off on this box (the core reports provider \"none\"); semantic memory stays on lexical FTS (non-fatal)"
-          ;;
-        *)
-          echo "  WARN: could not ask the core which embedder it resolved (openclaw memory status did not answer), so this run publishes no embedding verdict; the Memory Shard app shows the live one (non-fatal)"
-          ;;
-      esac
-    fi
+    case "$EMBED_STATE" in
+      local:qwen3-embedding:0.6b)
+        echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
+        ;;
+      local:*)
+        # On-device and keyless, so not a warning -- but the index belongs to
+        # a different model than ClawBox provisions, and the two have
+        # different vector dimensions.
+        echo "  Local embeddings ready on ${EMBED_STATE#local:}, not qwen3-embedding:0.6b (on-device, no API key; the index belongs to that model)"
+        ;;
+      cloud:*)
+        echo "  WARN: semantic memory is on a CLOUD embedder (${EMBED_STATE#cloud:}) — every indexed note is embedded off the box and it needs that provider's API key; the Memory Shard app moves it back on-device (non-fatal)"
+        ;;
+      disabled)
+        echo "  WARN: memory search is switched off on this box (the core reports provider \"none\"); semantic memory stays on lexical FTS (non-fatal)"
+        ;;
+      *)
+        # Three states share this line, and only two of them are "did not
+        # answer": the CLI was missing, failed or timed out; its output could
+        # not be parsed; or the core answered and named no provider at all --
+        # providerLocation()'s own "unknown". Claiming the core did not answer
+        # was wrong about the third.
+        echo "  WARN: could not read an embedder from the core (openclaw memory status did not answer, or named no provider), so this run publishes no embedding verdict; the Memory Shard app shows the live one (non-fatal)"
+        ;;
+    esac
   elif ollama pull qwen3-embedding:0.6b >/dev/null 2>&1; then
     echo "  Pulled local embedding model qwen3-embedding:0.6b (semantic memory, no API key)"
   else

--- a/install.sh
+++ b/install.sh
@@ -4564,7 +4564,16 @@ step_ollama_install() {
     if ! EMBED_JSON="$(as_clawbox timeout -k 5 60 "$OPENCLAW_BIN" memory status --agent main --deep --json 2>/dev/null)"; then
       EMBED_JSON=""
     fi
-    EMBED_STATE="$(python3 - "$EMBED_JSON" <<'PY' 2>/dev/null || true
+    # `command -v` first, and a state of its own. `--step ollama_install` runs
+    # standalone -- step_apt_update, which installs python3, is not on that
+    # path -- so without the interpreter the parse below fails and the catch-all
+    # would tell the operator the CORE did not answer, about a core that
+    # answered perfectly. A warning that names the wrong thing sends them to the
+    # wrong box. Nothing here can abort: `command -v` in if-condition position.
+    if ! command -v python3 >/dev/null 2>&1; then
+      EMBED_STATE="noparser"
+    else
+      EMBED_STATE="$(python3 - "$EMBED_JSON" <<'PY' 2>/dev/null || true
 import json, sys
 try:
     doc = json.loads(sys.argv[1])
@@ -4596,9 +4605,17 @@ else:
     print("cloud:%s" % provider)
 PY
 )"
+    fi
     case "$EMBED_STATE" in
       local:qwen3-embedding:0.6b)
         echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
+        ;;
+      local:)
+        # provider says on-device and keyless, which is true and worth saying,
+        # but the core named no model. "ready on , not qwen3-embedding:0.6b" is
+        # a sentence with a hole in it that still claims READY over a box whose
+        # index cannot be matched to anything.
+        echo "  Local embeddings are on-device and keyless, but the core named no model, so this run cannot say whether the index matches qwen3-embedding:0.6b (non-fatal)"
         ;;
       local:*)
         # On-device and keyless, so not a warning -- but the index belongs to
@@ -4608,6 +4625,10 @@ PY
         ;;
       cloud:*)
         echo "  WARN: semantic memory is on a CLOUD embedder (${EMBED_STATE#cloud:}) — every indexed note is embedded off the box and it needs that provider's API key; the Memory Shard app moves it back on-device (non-fatal)"
+        ;;
+      noparser)
+        # Named as the installer's own gap, not the core's.
+        echo "  WARN: python3 is not installed on this box, so this run cannot read the embedder answer the core gave; the Memory Shard app shows the live one (non-fatal)"
         ;;
       disabled)
         echo "  WARN: memory search is switched off on this box (the core reports provider \"none\"); semantic memory stays on lexical FTS (non-fatal)"

--- a/install.sh
+++ b/install.sh
@@ -4514,49 +4514,84 @@ step_ollama_install() {
     as_clawbox_login "$ENSURE_EMBEDDINGS" || true
     # The helper exits 0 on every soft failure by design (a missing Ollama must
     # not abort an install), so its exit code says nothing about the outcome.
-    # Read the config it was supposed to write instead — from the ACTIVE home.
     #
-    # Read the ONE key the installed core will parse. OpenClaw 2 reads
-    # memory.search and ignores agents.defaults.memorySearch entirely; a v1
-    # core does the reverse. Reading whichever block happened to name a
-    # provider printed "ready, needs no API key" over a v2 box whose
-    # memory.search was still empty and whose stale OpenClaw 1 block said
-    # "ollama" — a box on the default cloud embedder (TASK-659). The gate is
-    # the same 2026.8 boundary scripts/ensure-local-embeddings.sh writes
-    # through and src/lib/memory-shard.ts (embeddingConfigHome) reads through.
-    local EMBED_KEY="agents.defaults.memorySearch"
-    if openclaw_is_v2; then EMBED_KEY="memory.search"; fi
-    local EMBED_STATE
-    EMBED_STATE="$(as_clawbox python3 - "$CLAWBOX_HOME/.openclaw/openclaw.json" "$EMBED_KEY" <<'PY' 2>/dev/null || true
+    # Ask the CORE which embedder it resolved instead of re-deriving it from
+    # openclaw.json. `openclaw memory status --agent main --deep --json` is the
+    # core's own answer, and it is the call src/lib/clawkeep-memory.ts already
+    # makes; the provider is read with the same rule providerLocation() uses
+    # there, so ClawBox cannot tell the operator one thing at install time and
+    # the owner another in the Memory Shard panel.
+    #
+    # Re-deriving it is what produced TASK-659: OpenClaw 2 reads memory.search
+    # and ignores agents.defaults.memorySearch, a v1 core does the reverse, and
+    # a check that took "whichever block names a provider" printed "ready,
+    # needs no API key" over a v2 box that was on the default cloud embedder. A
+    # config read can only ever prove what was WRITTEN, never what the core
+    # does with it -- it cannot see a dimension mismatch or a fail-closed index.
+    #
+    # Measured on a shipped Orin: rc=0 in ~8 s for 3.3 KB of JSON, so it also
+    # costs less than the `openclaw --version` probe it replaces. Bounded and
+    # best-effort throughout: a CLI that hangs, is absent or answers nothing
+    # must neither stall nor abort the install, and "could not ask" is reported
+    # as itself rather than as a verdict.
+    if ! has_openclaw_harness; then
+      # No core on this SKU, so there is no memory search to have an embedder.
+      # Same answer src/app/setup-api/local-models/route.ts gives the UI.
+      echo "  Memory search is an OpenClaw feature; this edition does not include it."
+    else
+      local EMBED_JSON EMBED_STATE
+      EMBED_JSON="$(as_clawbox timeout 60 "$OPENCLAW_BIN" memory status --agent main --deep --json 2>/dev/null || true)"
+      EMBED_STATE="$(python3 - "$EMBED_JSON" <<'PY' 2>/dev/null || true
 import json, sys
 try:
-    node = json.load(open(sys.argv[1]))
+    doc = json.loads(sys.argv[1])
 except Exception:
-    node = {}
-for part in sys.argv[2].split("."):
-    node = node.get(part) if isinstance(node, dict) else None
-home = node if isinstance(node, dict) else {}
-provider = home.get("provider") or ""
-model = home.get("model") or ""
-if provider == "ollama" and model == "qwen3-embedding:0.6b":
-    print("local")
-elif provider in ("", "auto"):
-    print("unset")
+    raise SystemExit(0)
+rows = doc if isinstance(doc, list) else [doc]
+row = {}
+for entry in rows:
+    if isinstance(entry, dict) and entry.get("agentId") == "main":
+        row = entry
+        break
+if not row and rows and isinstance(rows[0], dict):
+    row = rows[0]
+status = row.get("status")
+status = status if isinstance(status, dict) else {}
+provider = status.get("provider")
+provider = provider if isinstance(provider, str) else ""
+model = status.get("model")
+model = model if isinstance(model, str) else ""
+if not provider:
+    raise SystemExit(0)
+if provider == "none":
+    print("disabled")
+elif provider in ("ollama", "local"):
+    print("local:%s" % model)
 else:
     print("cloud:%s" % provider)
 PY
 )"
-    case "$EMBED_STATE" in
-      local)
-        echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
-        ;;
-      cloud:*)
-        echo "  WARN: semantic memory is on a CLOUD embedder ($EMBED_KEY.provider=${EMBED_STATE#cloud:}) — every indexed note is embedded off the box and it needs that provider's API key; re-run scripts/ensure-local-embeddings.sh to move it on-device (non-fatal)"
-        ;;
-      *)
-        echo "  WARN: local embeddings are not configured ($EMBED_KEY is unset), so semantic memory falls back to the core's default cloud embedder — which needs an API key, and without one memory search stays on lexical FTS; the next boot retries the switch (non-fatal)"
-        ;;
-    esac
+      case "$EMBED_STATE" in
+        local:qwen3-embedding:0.6b)
+          echo "  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)"
+          ;;
+        local:*)
+          # On-device and keyless, so not a warning -- but the index belongs to
+          # a different model than ClawBox provisions, and the two have
+          # different vector dimensions.
+          echo "  Local embeddings ready on ${EMBED_STATE#local:}, not qwen3-embedding:0.6b (on-device, no API key; the index belongs to that model)"
+          ;;
+        cloud:*)
+          echo "  WARN: semantic memory is on a CLOUD embedder (${EMBED_STATE#cloud:}) — every indexed note is embedded off the box and it needs that provider's API key; the Memory Shard app moves it back on-device (non-fatal)"
+          ;;
+        disabled)
+          echo "  WARN: memory search is switched off on this box (the core reports provider \"none\"); semantic memory stays on lexical FTS (non-fatal)"
+          ;;
+        *)
+          echo "  WARN: could not ask the core which embedder it resolved (openclaw memory status did not answer), so this run publishes no embedding verdict; the Memory Shard app shows the live one (non-fatal)"
+          ;;
+      esac
+    fi
   elif ollama pull qwen3-embedding:0.6b >/dev/null 2>&1; then
     echo "  Pulled local embedding model qwen3-embedding:0.6b (semantic memory, no API key)"
   else

--- a/scripts/ensure-local-embeddings.sh
+++ b/scripts/ensure-local-embeddings.sh
@@ -95,9 +95,10 @@ PROVIDER="$(read_cfg provider)"
 # box upgraded to OpenClaw 2 whose config `doctor --fix` has not migrated yet,
 # that choice still sits in agents.defaults.memorySearch while memory.search is
 # empty; reading only the live home saw "unset", overwrote it with ollama, and
-# the later migration then had nothing left to carry forward. install.sh's
-# post-run check applies the same rule — the legacy block speaks when the live
-# home is silent. Everything AFTER this guard (the "already configured" test
+# the later migration then had nothing left to carry forward. The rule belongs
+# HERE, where it decides whether to WRITE; install.sh's post-run check no longer
+# re-derives anything — it asks the core what it resolved
+# (`openclaw memory status --json`, TASK-659). Everything AFTER this guard (the "already configured" test
 # and both writes) stays on the live home, so a legacy "ollama" on a v2 box is
 # migrated, not mistaken for done.
 RECORDED_PROVIDER="$PROVIDER"

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -538,6 +538,8 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     out: string;
     /** Every argv the stub `openclaw` was called with, one per line. */
     cliCalls: string;
+    /** One line per invocation of the stub ensure-local-embeddings.sh. */
+    helperCalls: string;
   }
 
   /**
@@ -549,13 +551,21 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
    *
    * `cli` scripts the stub `openclaw`: a JSON string to print, or `null` to
    * exit 1 saying nothing (a core that is not there, or cannot answer).
+   * `cliExit` is the status it then exits with — the case where a core prints
+   * a complete, parseable answer and still fails.
    */
-  function report(opts: { edition?: "openclaw" | "hermes"; cli: string | null; config?: unknown }): Report {
+  function report(opts: {
+    edition?: "openclaw" | "hermes";
+    cli: string | null;
+    cliExit?: number;
+    config?: unknown;
+  }): Report {
     if (!BLOCK) throw new Error("install.sh post-run check not found, or extracted truncated");
     const home = path.join(dir, "device", "home", "clawbox");
     const project = path.join(dir, "device", "project");
     const stubBin = path.join(dir, "device", "bin");
     const cliLog = path.join(dir, "device", "openclaw-calls.log");
+    const helperLog = path.join(dir, "device", "helper-calls.log");
     mkdirSync(path.join(home, ".openclaw"), { recursive: true });
     mkdirSync(path.join(project, "scripts"), { recursive: true });
     mkdirSync(stubBin, { recursive: true });
@@ -572,20 +582,27 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     );
     // Best-effort and its exit code says nothing; the check under test is what
     // reports afterwards.
-    writeFileSync(path.join(project, "scripts", "ensure-local-embeddings.sh"), "#!/usr/bin/env bash\nexit 0\n");
+    writeFileSync(
+      path.join(project, "scripts", "ensure-local-embeddings.sh"),
+      `#!/usr/bin/env bash\nprintf 'ran\\n' >> ${JSON.stringify(helperLog)}\nexit 0\n`,
+    );
     chmodSync(path.join(project, "scripts", "ensure-local-embeddings.sh"), 0o755);
     const openclaw = path.join(stubBin, "openclaw");
     writeFileSync(
       openclaw,
       opts.cli === null
         ? `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(cliLog)}\nexit 1\n`
-        : `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(cliLog)}\ncat <<'JSON'\n${opts.cli}\nJSON\n`,
+        : `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(cliLog)}\ncat <<'JSON'\n${opts.cli}\nJSON\nexit ${opts.cliExit ?? 0}\n`,
     );
     chmodSync(openclaw, 0o755);
     // A bounded call is part of the contract, but the real `timeout` is not on
     // every dev host; the stub keeps the argv assertable and runs the command.
     const timeoutStub = path.join(stubBin, "timeout");
-    writeFileSync(timeoutStub, '#!/usr/bin/env bash\nshift\nexec "$@"\n');
+    writeFileSync(
+      timeoutStub,
+      // Skip the options (-k takes a value) and the duration, then run it.
+      '#!/usr/bin/env bash\nwhile [ "${1#-}" != "$1" ]; do\n  case "$1" in -k|--kill-after) shift 2 ;; *) shift ;; esac\ndone\nshift\nexec "$@"\n',
+    );
     chmodSync(timeoutStub, 0o755);
 
     const program = [
@@ -623,6 +640,7 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     return {
       out: `${run.stdout ?? ""}${run.stderr ?? ""}`,
       cliCalls: existsSync(cliLog) ? readFileSync(cliLog, "utf-8") : "",
+      helperCalls: existsSync(helperLog) ? readFileSync(helperLog, "utf-8") : "",
     };
   }
 
@@ -637,7 +655,11 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
   it("asks the core, bounded, instead of re-reading openclaw.json", () => {
     const run = report({ cli: status("ollama") });
     expect(run.cliCalls).toContain("memory status --agent main --deep --json");
-    expect(BLOCK).toMatch(/timeout \d+ "\$OPENCLAW_BIN" memory status/);
+    // -k, because `timeout` alone sends SIGTERM only and
+    // collectMemoryStatusJson() escalates to SIGKILL after 5 s: a CLI that
+    // ignores SIGTERM must not hang the installer where it would not hang the
+    // panel this block exists to agree with.
+    expect(BLOCK).toMatch(/timeout -k \d+ \d+ "\$OPENCLAW_BIN" memory status/);
   });
 
   it("reports the model the core resolved as ready", () => {
@@ -678,9 +700,25 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
       // Every one of these used to collapse into a claim about the config.
       const run = report({ cli });
       expect(run.out).not.toContain(READY);
-      expect(run.out).toMatch(/could not ask/i);
+      // One message for three states: the CLI could not be asked, its answer
+      // could not be read, or it answered without naming a provider. Naming
+      // only the first was wrong for the third, which did answer.
+      expect(run.out).toMatch(/could not read an embedder/i);
     });
   }
+
+  it("does not trust a core that printed an answer and then failed", () => {
+    // TASK-659's own defect, re-entered through the exit code instead of the
+    // config key. `--deep` failing its provider probe after emitting the
+    // shallow status, a core that reports and then exits on an unrelated
+    // warning, or `timeout` killing the CLI after a complete document has
+    // already been written — each is a box whose embedder is NOT known.
+    // collectMemoryStatusJson() in src/lib/clawkeep-memory.ts rejects on
+    // `code !== 0`; this block must not disagree with it.
+    const run = report({ cli: status("ollama"), cliExit: 1 });
+    expect(run.out).not.toContain(READY);
+    expect(run.out).toMatch(/could not read an embedder/i);
+  });
 
   it("says memory search is not on this edition on hermes, and asks no core", () => {
     // step_ollama_install has no edition guard, and a hermes box has no core,
@@ -689,5 +727,15 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     expect(run.out).not.toContain(READY);
     expect(run.out).toMatch(/does not include it/i);
     expect(run.cliCalls).toBe("");
+  });
+
+  it("does no embedding work at all on hermes, not just no reporting", () => {
+    // The gate used to sit below the helper, so a hermes box ran
+    // ensure-local-embeddings.sh, found no provider anywhere, and pulled a
+    // ~640 MB model whose config write then failed soft by design — and the
+    // very next line told the operator the edition does not have the feature.
+    expect(report({ edition: "hermes", cli: status("ollama") }).helperCalls).toBe("");
+    // The control: it still runs where there IS a core to configure.
+    expect(report({ cli: status("ollama") }).helperCalls).toContain("ran");
   });
 });

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, readdirSync, existsSync, chmodSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  readdirSync,
+  existsSync,
+  chmodSync,
+  symlinkSync,
+} from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -559,6 +569,13 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     cli: string | null;
     cliExit?: number;
     config?: unknown;
+    /**
+     * Run the block on a box with no `python3`. `--step ollama_install` runs
+     * standalone, without `step_apt_update`, so the interpreter this block
+     * parses with is not guaranteed on that path — and the message it prints
+     * when it cannot parse names the wrong culprit if it blames the core.
+     */
+    withoutPython?: boolean;
   }): Report {
     if (!BLOCK) throw new Error("install.sh post-run check not found, or extracted truncated");
     const home = path.join(dir, "device", "home", "clawbox");
@@ -613,7 +630,11 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
       'CLAWBOX_HOME="/home/clawbox"',
       `PROJECT_DIR=${JSON.stringify(project)}`,
       `OPENCLAW_BIN=${JSON.stringify(openclaw)}`,
-      `PATH=${JSON.stringify(stubBin)}:$PATH`,
+      // A PATH with no python3 on it still has to resolve `bash` for the stub
+      // shebangs, so it is the real bash by symlink and nothing else.
+      opts.withoutPython
+        ? `PATH=${JSON.stringify(stubBin)}:${JSON.stringify(pythonlessBin())}`
+        : `PATH=${JSON.stringify(stubBin)}:$PATH`,
       "as_clawbox() {",
       "  local a; local -a mapped=()",
       '  for a in "$@"; do',
@@ -642,6 +663,20 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
       cliCalls: existsSync(cliLog) ? readFileSync(cliLog, "utf-8") : "",
       helperCalls: existsSync(helperLog) ? readFileSync(helperLog, "utf-8") : "",
     };
+  }
+
+  /**
+   * A PATH directory carrying `bash` and nothing else, so `python3` is
+   * genuinely unresolvable rather than merely stubbed to fail — which is what
+   * a box that never ran `step_apt_update` looks like to this block.
+   */
+  function pythonlessBin(): string {
+    const bin = path.join(dir, "device", "nopython");
+    mkdirSync(bin, { recursive: true });
+    const bash = spawnSync("bash", ["-c", "command -v bash"], { encoding: "utf-8" }).stdout.trim();
+    if (!bash) throw new Error("could not locate bash");
+    symlinkSync(bash, path.join(bin, "bash"));
+    return bin;
   }
 
   /** One `openclaw memory status --json` row, as the core shapes it. */
@@ -718,6 +753,34 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     const run = report({ cli: status("ollama"), cliExit: 1 });
     expect(run.out).not.toContain(READY);
     expect(run.out).toMatch(/could not read an embedder/i);
+  });
+
+  it("does not report a local provider the core named no model for as ready on nothing", () => {
+    // `local:` + an empty model fell through to the `local:*` arm and printed
+    // "Local embeddings ready on , not qwen3-embedding:0.6b" — a sentence with
+    // a hole in it that still claims READY over a box whose index cannot be
+    // matched to anything.
+    const run = report({ cli: status("ollama", "") });
+    expect(run.out).not.toMatch(/ready on\s*,/);
+    expect(run.out).not.toMatch(/on\s+,\s+not/);
+    // On-device and keyless is still true and worth saying; the model is not.
+    expect(run.out).toMatch(/named no model/i);
+    expect(run.out).toMatch(/non-fatal/);
+  });
+
+  it("blames its own missing interpreter, not the core, when it cannot parse", () => {
+    // The catch-all says "openclaw memory status did not answer, or named no
+    // provider". With no python3 the core answered perfectly and the installer
+    // could not read it — a warning that names the wrong thing sends the
+    // operator to the wrong box.
+    const run = report({ cli: status("ollama"), withoutPython: true });
+    expect(run.out).not.toContain(READY);
+    expect(run.out).toMatch(/python3/i);
+    expect(run.out).not.toMatch(/did not answer/i);
+    expect(run.out).toMatch(/non-fatal/);
+    // It still ASKED: the core was reached and answered, which is why blaming
+    // it would be false.
+    expect(run.cliCalls).toContain("memory status");
   });
 
   it("says memory search is not on this edition on hermes, and asks no core", () => {

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -492,50 +492,146 @@ describe("gateway-pre-start.sh local embeddings hand-off", () => {
 });
 
 // install.sh runs the script synchronously and then reads openclaw.json to
-// report the outcome (the script exits 0 on every soft failure by design). That
-// check must accept the key the installed core actually uses, or a v2 install
-// prints "WARN: local embeddings are not configured yet" over a configured box.
-describe.skipIf(!hasPython3)("install.sh local embeddings post-run check", () => {
+// report the outcome (the script exits 0 on every soft failure by design).
+//
+// That report has to name the embedder the INSTALLED core will use. OpenClaw 2
+// (2026.8+) reads `memory.search.*` and ignores `agents.defaults.memorySearch`
+// entirely; a v1 core does the reverse. The check used to read both and prefer
+// whichever named a provider, so a v2 box with an empty `memory.search` and a
+// stale legacy `ollama` block — the state an un-migrated upgrade leaves — was
+// told "Local embeddings ready … needs no API key" while every note was being
+// embedded by the default cloud provider (TASK-659). The mirror case, a v1
+// core with only `memory.search` filled in, reported the same thing.
+//
+// These run the shipped block out of install.sh — the generation gate, the
+// config read and the message it picks — under `set -euo pipefail` against a
+// fake device root, once per generation.
+describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
   const INSTALL_SH = readFileSync(path.resolve(process.cwd(), "install.sh"), "utf-8");
-  const HEAD = "python3 - /home/clawbox/.openclaw/openclaw.json <<'PY'";
-  const start = INSTALL_SH.indexOf(HEAD);
-  const end = start < 0 ? -1 : INSTALL_SH.indexOf("\nPY\n", start);
-  const program = start < 0 || end < 0 ? "" : INSTALL_SH.slice(INSTALL_SH.indexOf("\n", start) + 1, end);
 
-  function configured(cfg: unknown): boolean {
-    if (!program) throw new Error("install.sh post-run check not found — the heredoc test above names it");
-    const file = path.join(dir, "post-run.json");
-    writeFileSync(file, JSON.stringify(cfg));
-    return spawnSync("python3", ["-c", program, file], { encoding: "utf-8" }).status === 0;
+  /**
+   * The embedding half of `step_ollama_install`: from the helper path it runs
+   * to the end of the function. Sliced rather than taking the whole function,
+   * which would try to install Ollama itself.
+   */
+  const BLOCK = (() => {
+    const start = INSTALL_SH.indexOf('  local ENSURE_EMBEDDINGS="$PROJECT_DIR/scripts/ensure-local-embeddings.sh"');
+    if (start < 0) return "";
+    const end = INSTALL_SH.indexOf("\n}", start);
+    if (end < 0) return "";
+    const body = INSTALL_SH.slice(start, end);
+    // The "must not say ready" assertions would pass over a truncated slice,
+    // so the slice has to reach the block's last statement to count.
+    return body.includes("could not pull qwen3-embedding:0.6b") ? body : "";
+  })();
+
+  const READY = "Local embeddings ready";
+
+  /**
+   * Run the shipped block against a fake device root.
+   *
+   * `as_clawbox` is the real seam — on a device it runs the command as the
+   * clawbox user, so the config it opens is that user's home. The stub keeps
+   * the argv the installer builds and only redirects `/home/clawbox/...` into
+   * the temp root.
+   */
+  function report(opts: { v2: boolean; config: unknown }): string {
+    if (!BLOCK) throw new Error("install.sh post-run check not found, or extracted truncated");
+    const home = path.join(dir, "device", "home", "clawbox");
+    const project = path.join(dir, "device", "project");
+    mkdirSync(path.join(home, ".openclaw"), { recursive: true });
+    mkdirSync(path.join(project, "scripts"), { recursive: true });
+    // `undefined` means "the file is not readable JSON" — a config the
+    // installer has to survive rather than a shape it has to understand.
+    writeFileSync(
+      path.join(home, ".openclaw", "openclaw.json"),
+      opts.config === undefined ? "{ this is not json" : JSON.stringify(opts.config),
+    );
+    // Best-effort and its exit code says nothing; the check under test is what
+    // reads the config afterwards.
+    writeFileSync(path.join(project, "scripts", "ensure-local-embeddings.sh"), "#!/usr/bin/env bash\nexit 0\n");
+    chmodSync(path.join(project, "scripts", "ensure-local-embeddings.sh"), 0o755);
+
+    const program = [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `FAKE_ROOT=${JSON.stringify(home)}`,
+      // The device home the installer names. Never touched: as_clawbox maps it.
+      'CLAWBOX_HOME="/home/clawbox"',
+      `PROJECT_DIR=${JSON.stringify(project)}`,
+      "as_clawbox() {",
+      "  local a; local -a mapped=()",
+      '  for a in "$@"; do',
+      '    case "$a" in /home/clawbox*) mapped+=("$FAKE_ROOT${a#/home/clawbox}") ;; *) mapped+=("$a") ;; esac',
+      "  done",
+      '  "${mapped[@]}"',
+      "}",
+      'as_clawbox_login() { "$@"; }',
+      `openclaw_is_v2() { return ${opts.v2 ? 0 : 1}; }`,
+      "check_embeddings() {",
+      BLOCK,
+      "}",
+      "check_embeddings",
+      "",
+    ].join("\n");
+
+    const file = path.join(dir, "post-run-check.sh");
+    writeFileSync(file, program);
+    chmodSync(file, 0o755);
+    const run = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
+    // Best-effort by contract: the block must never abort the install, whatever
+    // it finds — including a config it cannot parse.
+    expect(run.status).toBe(0);
+    return `${run.stdout ?? ""}${run.stderr ?? ""}`;
   }
 
-  it("ships the check as a heredoc this test can run verbatim", () => {
-    expect(program).toContain("import json");
+  const LOCAL = { provider: "ollama", model: MODEL };
+  const REMOTE = { provider: "openai", model: "text-embedding-3-large" };
+  const cfg = (search: unknown, legacy?: unknown) => ({
+    memory: { search },
+    ...(legacy === undefined ? {} : { agents: { defaults: { memorySearch: legacy } } }),
+  });
+
+  it("ships the check as a block this test can run verbatim", () => {
+    expect(BLOCK).toContain("import json");
   });
 
   it("accepts OpenClaw 2's memory.search home", () => {
-    expect(configured({ memory: { search: { provider: "ollama", model: MODEL } } })).toBe(true);
+    expect(report({ v2: true, config: cfg(LOCAL) })).toContain(READY);
   });
 
-  it("still accepts the legacy agents.defaults.memorySearch home", () => {
-    expect(configured({ agents: { defaults: { memorySearch: { provider: "ollama", model: MODEL } } } })).toBe(true);
+  it("still accepts the legacy agents.defaults.memorySearch home on a v1 core", () => {
+    expect(report({ v2: false, config: cfg({}, LOCAL) })).toContain(READY);
   });
 
   it("does not report a box that is on a remote provider, or not configured, as ready", () => {
-    expect(configured({ memory: { search: { provider: "openai", model: "text-embedding-3-large" } } })).toBe(false);
-    expect(configured({ agents: { defaults: {} } })).toBe(false);
-    expect(configured({ memory: { search: { model: MODEL } } })).toBe(false);
+    const remote = report({ v2: true, config: cfg(REMOTE) });
+    expect(remote).not.toContain(READY);
+    expect(remote).toMatch(/cloud/i);
+    // The provider is named so the operator knows which key to fix.
+    expect(remote).toContain("openai");
+
+    const unset = report({ v2: true, config: cfg({}) });
+    expect(unset).not.toContain(READY);
+    expect(unset).toMatch(/cloud/i);
+    expect(unset).toContain("memory.search");
+
+    expect(report({ v2: true, config: cfg({ model: MODEL }) })).not.toContain(READY);
   });
 
-  it("reads only the active home — a stale legacy block cannot vouch for a box OpenClaw 2 has on the cloud", () => {
-    // The upgrade case: agents.defaults.memorySearch still says ollama from
-    // the box's OpenClaw 1 days, and the owner has since picked OpenAI under
-    // memory.search, the only home the running core reads. Every note is
-    // being sent to OpenAI; "needs no API key" would be a false claim.
-    const stale = { provider: "ollama", model: MODEL };
-    const remote = { provider: "openai", model: "text-embedding-3-large" };
-    expect(configured({ memory: { search: remote }, agents: { defaults: { memorySearch: stale } } })).toBe(false);
-    // The mirror image is ready: the active home is local, whatever the stale one says.
-    expect(configured({ memory: { search: stale }, agents: { defaults: { memorySearch: remote } } })).toBe(true);
+  it("reads only the home the installed core parses — a stale block cannot vouch for the box", () => {
+    // The un-migrated upgrade: the OpenClaw 1 choice still says ollama and the
+    // v2 core does not read it. "Needs no API key" would be a false claim.
+    expect(report({ v2: true, config: cfg({}, LOCAL) })).not.toContain(READY);
+    // Mirror image, and the reason the gate is not "prefer memory.search":
+    // that same config on a v1 core IS on local embeddings.
+    expect(report({ v2: false, config: cfg({}, LOCAL) })).toContain(READY);
+    // And a v1 core ignores memory.search however it is filled in.
+    expect(report({ v2: false, config: cfg(LOCAL, {}) })).not.toContain(READY);
+    expect(report({ v2: true, config: cfg(LOCAL, REMOTE) })).toContain(READY);
+  });
+
+  it("survives a config it cannot read at all", () => {
+    expect(report({ v2: true, config: undefined })).not.toContain(READY);
   });
 });

--- a/src/tests/unit/ensure-local-embeddings.test.ts
+++ b/src/tests/unit/ensure-local-embeddings.test.ts
@@ -491,21 +491,28 @@ describe("gateway-pre-start.sh local embeddings hand-off", () => {
   });
 });
 
-// install.sh runs the script synchronously and then reads openclaw.json to
-// report the outcome (the script exits 0 on every soft failure by design).
+// install.sh runs the script synchronously and then reports which embedder the
+// box ended up on (the script exits 0 on every soft failure by design).
 //
-// That report has to name the embedder the INSTALLED core will use. OpenClaw 2
-// (2026.8+) reads `memory.search.*` and ignores `agents.defaults.memorySearch`
-// entirely; a v1 core does the reverse. The check used to read both and prefer
-// whichever named a provider, so a v2 box with an empty `memory.search` and a
-// stale legacy `ollama` block — the state an un-migrated upgrade leaves — was
-// told "Local embeddings ready … needs no API key" while every note was being
-// embedded by the default cloud provider (TASK-659). The mirror case, a v1
-// core with only `memory.search` filled in, reported the same thing.
+// That report used to be re-derived from openclaw.json, and it read BOTH
+// `memory.search` and `agents.defaults.memorySearch`, preferring whichever
+// named a provider. OpenClaw 2 reads only the first and a v1 core only the
+// second, so a v2 box with an empty `memory.search` and a stale legacy
+// `ollama` block — the state an un-migrated upgrade leaves — was told
+// "Local embeddings ready … needs no API key" while every note was being
+// embedded by the default cloud provider (TASK-659).
 //
-// These run the shipped block out of install.sh — the generation gate, the
-// config read and the message it picks — under `set -euo pipefail` against a
-// fake device root, once per generation.
+// It now asks the core: `openclaw memory status --agent main --deep --json`,
+// the same call src/lib/clawkeep-memory.ts makes, read with the same
+// provider→location rule as providerLocation() there. So there is no second
+// copy of the generation rule to drift, and no way to vouch for a box from a
+// key its core ignores.
+//
+// These run the shipped block out of install.sh — the edition gate, the CLI
+// call, the classifier and the message it picks — under `set -euo pipefail`
+// against a stub `openclaw`. The openclaw.json fixture is still written on
+// every run: it is what the old check read, so a regression back to reading
+// the config is visible rather than silently equivalent.
 describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
   const INSTALL_SH = readFileSync(path.resolve(process.cwd(), "install.sh"), "utf-8");
 
@@ -527,30 +534,59 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
 
   const READY = "Local embeddings ready";
 
+  interface Report {
+    out: string;
+    /** Every argv the stub `openclaw` was called with, one per line. */
+    cliCalls: string;
+  }
+
   /**
    * Run the shipped block against a fake device root.
    *
    * `as_clawbox` is the real seam — on a device it runs the command as the
-   * clawbox user, so the config it opens is that user's home. The stub keeps
-   * the argv the installer builds and only redirects `/home/clawbox/...` into
-   * the temp root.
+   * clawbox user. The stub keeps the argv the installer builds and only
+   * redirects `/home/clawbox/...` into the temp root.
+   *
+   * `cli` scripts the stub `openclaw`: a JSON string to print, or `null` to
+   * exit 1 saying nothing (a core that is not there, or cannot answer).
    */
-  function report(opts: { v2: boolean; config: unknown }): string {
+  function report(opts: { edition?: "openclaw" | "hermes"; cli: string | null; config?: unknown }): Report {
     if (!BLOCK) throw new Error("install.sh post-run check not found, or extracted truncated");
     const home = path.join(dir, "device", "home", "clawbox");
     const project = path.join(dir, "device", "project");
+    const stubBin = path.join(dir, "device", "bin");
+    const cliLog = path.join(dir, "device", "openclaw-calls.log");
     mkdirSync(path.join(home, ".openclaw"), { recursive: true });
     mkdirSync(path.join(project, "scripts"), { recursive: true });
-    // `undefined` means "the file is not readable JSON" — a config the
-    // installer has to survive rather than a shape it has to understand.
+    mkdirSync(stubBin, { recursive: true });
+    // What the OLD check read. Deliberately the state that made it lie: an
+    // empty v2 home beside a stale legacy block still naming ollama.
     writeFileSync(
       path.join(home, ".openclaw", "openclaw.json"),
-      opts.config === undefined ? "{ this is not json" : JSON.stringify(opts.config),
+      JSON.stringify(
+        opts.config ?? {
+          memory: { search: {} },
+          agents: { defaults: { memorySearch: { provider: "ollama", model: MODEL } } },
+        },
+      ),
     );
     // Best-effort and its exit code says nothing; the check under test is what
-    // reads the config afterwards.
+    // reports afterwards.
     writeFileSync(path.join(project, "scripts", "ensure-local-embeddings.sh"), "#!/usr/bin/env bash\nexit 0\n");
     chmodSync(path.join(project, "scripts", "ensure-local-embeddings.sh"), 0o755);
+    const openclaw = path.join(stubBin, "openclaw");
+    writeFileSync(
+      openclaw,
+      opts.cli === null
+        ? `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(cliLog)}\nexit 1\n`
+        : `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(cliLog)}\ncat <<'JSON'\n${opts.cli}\nJSON\n`,
+    );
+    chmodSync(openclaw, 0o755);
+    // A bounded call is part of the contract, but the real `timeout` is not on
+    // every dev host; the stub keeps the argv assertable and runs the command.
+    const timeoutStub = path.join(stubBin, "timeout");
+    writeFileSync(timeoutStub, '#!/usr/bin/env bash\nshift\nexec "$@"\n');
+    chmodSync(timeoutStub, 0o755);
 
     const program = [
       "#!/usr/bin/env bash",
@@ -559,6 +595,8 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
       // The device home the installer names. Never touched: as_clawbox maps it.
       'CLAWBOX_HOME="/home/clawbox"',
       `PROJECT_DIR=${JSON.stringify(project)}`,
+      `OPENCLAW_BIN=${JSON.stringify(openclaw)}`,
+      `PATH=${JSON.stringify(stubBin)}:$PATH`,
       "as_clawbox() {",
       "  local a; local -a mapped=()",
       '  for a in "$@"; do',
@@ -567,7 +605,7 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
       '  "${mapped[@]}"',
       "}",
       'as_clawbox_login() { "$@"; }',
-      `openclaw_is_v2() { return ${opts.v2 ? 0 : 1}; }`,
+      `has_openclaw_harness() { return ${opts.edition === "hermes" ? 1 : 0}; }`,
       "check_embeddings() {",
       BLOCK,
       "}",
@@ -580,58 +618,76 @@ describe.skipIf(!canRun)("install.sh local embeddings post-run check", () => {
     chmodSync(file, 0o755);
     const run = spawnSync("bash", [file], { encoding: "utf-8", timeout: 30_000 });
     // Best-effort by contract: the block must never abort the install, whatever
-    // it finds — including a config it cannot parse.
+    // it finds — a core that hangs, is absent, or answers nonsense included.
     expect(run.status).toBe(0);
-    return `${run.stdout ?? ""}${run.stderr ?? ""}`;
+    return {
+      out: `${run.stdout ?? ""}${run.stderr ?? ""}`,
+      cliCalls: existsSync(cliLog) ? readFileSync(cliLog, "utf-8") : "",
+    };
   }
 
-  const LOCAL = { provider: "ollama", model: MODEL };
-  const REMOTE = { provider: "openai", model: "text-embedding-3-large" };
-  const cfg = (search: unknown, legacy?: unknown) => ({
-    memory: { search },
-    ...(legacy === undefined ? {} : { agents: { defaults: { memorySearch: legacy } } }),
-  });
+  /** One `openclaw memory status --json` row, as the core shapes it. */
+  const status = (provider: unknown, model: unknown = MODEL) =>
+    JSON.stringify([{ agentId: "main", status: { provider, model } }]);
 
   it("ships the check as a block this test can run verbatim", () => {
-    expect(BLOCK).toContain("import json");
+    expect(BLOCK).toContain("memory status");
   });
 
-  it("accepts OpenClaw 2's memory.search home", () => {
-    expect(report({ v2: true, config: cfg(LOCAL) })).toContain(READY);
+  it("asks the core, bounded, instead of re-reading openclaw.json", () => {
+    const run = report({ cli: status("ollama") });
+    expect(run.cliCalls).toContain("memory status --agent main --deep --json");
+    expect(BLOCK).toMatch(/timeout \d+ "\$OPENCLAW_BIN" memory status/);
   });
 
-  it("still accepts the legacy agents.defaults.memorySearch home on a v1 core", () => {
-    expect(report({ v2: false, config: cfg({}, LOCAL) })).toContain(READY);
+  it("reports the model the core resolved as ready", () => {
+    expect(report({ cli: status("ollama") }).out).toContain(READY);
   });
 
-  it("does not report a box that is on a remote provider, or not configured, as ready", () => {
-    const remote = report({ v2: true, config: cfg(REMOTE) });
-    expect(remote).not.toContain(READY);
-    expect(remote).toMatch(/cloud/i);
-    // The provider is named so the operator knows which key to fix.
-    expect(remote).toContain("openai");
-
-    const unset = report({ v2: true, config: cfg({}) });
-    expect(unset).not.toContain(READY);
-    expect(unset).toMatch(/cloud/i);
-    expect(unset).toContain("memory.search");
-
-    expect(report({ v2: true, config: cfg({ model: MODEL }) })).not.toContain(READY);
+  it("does not call a box on a stale legacy block ready", () => {
+    // The un-migrated upgrade, and the whole of TASK-659: openclaw.json still
+    // says ollama under the OpenClaw 1 key, and the core reports openai.
+    const run = report({ cli: status("openai", "text-embedding-3-large") });
+    expect(run.out).not.toContain(READY);
+    expect(run.out).toMatch(/cloud/i);
+    // Named so the operator knows which provider is being paid for.
+    expect(run.out).toContain("openai");
   });
 
-  it("reads only the home the installed core parses — a stale block cannot vouch for the box", () => {
-    // The un-migrated upgrade: the OpenClaw 1 choice still says ollama and the
-    // v2 core does not read it. "Needs no API key" would be a false claim.
-    expect(report({ v2: true, config: cfg({}, LOCAL) })).not.toContain(READY);
-    // Mirror image, and the reason the gate is not "prefer memory.search":
-    // that same config on a v1 core IS on local embeddings.
-    expect(report({ v2: false, config: cfg({}, LOCAL) })).toContain(READY);
-    // And a v1 core ignores memory.search however it is filled in.
-    expect(report({ v2: false, config: cfg(LOCAL, {}) })).not.toContain(READY);
-    expect(report({ v2: true, config: cfg(LOCAL, REMOTE) })).toContain(READY);
+  it("treats an on-device provider as local whatever the model is", () => {
+    // providerLocation() in src/lib/clawkeep-memory.ts maps ollama and local to
+    // "local" regardless of model, and the Memory Shard panel shows that. The
+    // installer must not call the same box a cloud embedder.
+    const run = report({ cli: status("ollama", "nomic-embed-text") });
+    expect(run.out).not.toMatch(/cloud/i);
+    expect(run.out).toContain("nomic-embed-text");
   });
 
-  it("survives a config it cannot read at all", () => {
-    expect(report({ v2: true, config: undefined })).not.toContain(READY);
+  it("reports a core that switched memory search off as off, not as ready", () => {
+    const run = report({ cli: status("none", "") });
+    expect(run.out).not.toContain(READY);
+    expect(run.out).toMatch(/switched off/i);
+  });
+
+  for (const [name, cli] of [
+    ["a core that cannot answer", null],
+    ["a core that answers nonsense", "not json at all"],
+    ["a core that answers an empty provider", JSON.stringify([{ agentId: "main", status: {} }])],
+  ] as const) {
+    it(`says it could not ask over ${name}, rather than guessing`, () => {
+      // Every one of these used to collapse into a claim about the config.
+      const run = report({ cli });
+      expect(run.out).not.toContain(READY);
+      expect(run.out).toMatch(/could not ask/i);
+    });
+  }
+
+  it("says memory search is not on this edition on hermes, and asks no core", () => {
+    // step_ollama_install has no edition guard, and a hermes box has no core,
+    // no openclaw.json and no memory search to have an embedder.
+    const run = report({ edition: "hermes", cli: status("ollama") });
+    expect(run.out).not.toContain(READY);
+    expect(run.out).toMatch(/does not include it/i);
+    expect(run.cliCalls).toBe("");
   });
 });


### PR DESCRIPTION
**TASK-659** — `install.sh` prints "Local embeddings ready … needs no API key"
over a box that is on a cloud embedder (the F-13 residual).

## Customer-visible symptom
The last thing an install or update says about semantic memory is

```
  Local embeddings ready (qwen3-embedding:0.6b, semantic memory needs no API key)
```

on a box where every indexed note is being embedded by OpenAI, and where memory
search is dead without a key the box may not have. A false success in the
install summary, in the family of #504 / #519 / #552.

## Cause
The post-run check re-derived the answer from `openclaw.json`: it read both
`memory.search` and `agents.defaults.memorySearch` and preferred whichever named
a provider. OpenClaw 2 (2026.8+) reads only the first and ignores the second
entirely; a v1 core does the reverse. So the un-migrated upgrade — `doctor --fix`
has not run, the OpenClaw 1 choice still says `ollama`, `memory.search` is empty
— was reported ready while the core used its default cloud embedder. The mirror
case (a v1 core with only `memory.search` filled in) reported the same thing.

## Harness-first
This is the finding, and it is why the first version of this fix was wrong.

OpenClaw already answers the question: `openclaw memory status --agent main
--deep --json` reports what the **running core resolved** — `status.provider`,
`status.model` — with no generation guessing at all. ClawBox already consumes it
in `src/lib/clawkeep-memory.ts:355`, and `providerLocation()` there (`:406-411`)
already reduces the provider to `local` / `cloud` / `disabled`. The installer was
re-implementing a weaker version of that classifier and disagreeing with it: the
first draft of this PR gated on the 2026.8 boundary instead, which would have
made a **fourth** copy of that rule (`install.sh:openclaw_is_v2`,
`scripts/ensure-local-embeddings.sh:54`, `scripts/gateway-pre-start.sh:64`,
`src/lib/memory-shard.ts:125`) with a fifth set of fallbacks.

So the check now asks the core. Measured read-only on a shipped Orin:

```
run1 rc=0 elapsed_ms=7904 bytes=3309
run2 rc=0 elapsed_ms=8044 bytes=3309
    "provider": "ollama",
    "model": "qwen3-embedding:0.6b",
```

~8 s inside a step that takes minutes, and *less* than the `openclaw --version`
probe the generation gate would have cost. Bounded with `timeout` and
best-effort: a CLI that hangs, is absent or answers nonsense is reported as
"could not ask", never as a verdict, and never aborts the install.

A config read could only ever prove what was *written*; `memory status` is the
only thing that can see a dimension mismatch or a fail-closed index.

## RED (unmodified beta, install.sh from beta with the new suite)
```
 × ships the check as a block this test can run verbatim
 × asks the core, bounded, instead of re-reading openclaw.json
 × does not call a box on a stale legacy block ready
 × treats an on-device provider as local whatever the model is
 × reports a core that switched memory search off as off, not as ready
 × says it could not ask over a core that cannot answer, rather than guessing
 × says it could not ask over a core that answers nonsense, rather than guessing
 × says it could not ask over a core that answers an empty provider, rather than guessing
 × says memory search is not on this edition on hermes, and asks no core

AssertionError: expected '  Local embeddings ready (qwen3-embed…' not to contain 'Local embeddings ready'
      Tests  9 failed | 1 passed | 32 skipped (42)
```

The fixture is the real state: `openclaw.json` carries the stale legacy `ollama`
block with an empty `memory.search`, and the stub core reports `openai`. Beta
believes the config; the tests execute the shipped block under
`set -euo pipefail` against a stub `openclaw`.

## GREEN
```
 src/tests/unit/ensure-local-embeddings.test.ts   42 passed
 + memory-shard-embedding-keys, clawkeep-memory, local-models,
   memory-shard-sources, memory-shard-wizard                108 passed (6 files)
 bash -n install.sh && bash -n scripts/ensure-local-embeddings.sh   OK
```

## Sibling call sites
- `scripts/ensure-local-embeddings.sh:103-115` keeps its cross-home read, and
  must: there it decides whether to **write**, and an owner's choice recorded
  under the other generation's key must not be overwritten before `doctor --fix`
  migrates it. Its comment claimed "install.sh's post-run check applies the same
  rule" — no longer true, so it is corrected in this PR rather than left to
  invite the bug back.
- `src/lib/memory-shard.ts:125` `embeddingConfigHome()` and
  `scripts/gateway-pre-start.sh:64` are writers/launchers, not reporters. Left
  alone deliberately: this PR removes a copy of the rule rather than adding one.
- `scripts/gateway-pre-start.sh:2116-2124` launches the helper detached and
  claims nothing about the outcome — no verdict to correct.
- The **Hermes SKU**: `step_ollama_install` has no edition guard, and a hermes
  box has no core, no `openclaw.json` and no memory search. The check is now
  gated on `has_openclaw_harness` and says so, the same answer
  `src/app/setup-api/local-models/route.ts:33-38` gives the UI. `dual` is
  unchanged.

## Review
One Opus `clawbox-review` pass (0 high, 7 medium, 7 low) on the first draft — it
is what turned this PR around. Applied: the harness-native call (M7), the
provider-first classification that no longer calls an `ollama` box with a
different model a cloud embedder (M1) and no longer contradicts
`providerLocation()`, a remedy that can actually work (M2 — the old text told the
operator to re-run a helper that exits 0 on exactly that state), the removal of
the false "the next boot retries the switch" (M3), "could not ask" as its own
verdict instead of collapsing every read failure into "$KEY is unset" (M4), the
Hermes gate (M5), one generation rule fewer rather than one more (M6), the stale
helper comment (L1), and the `isinstance` coercion so a non-string provider
cannot reach the operator as a Python repr (L7). The tests no longer stub the
thing under test (L5): they stub the core's CLI and execute the real block.


## Final review round (2026-09-04) — MEDIUM fixed

The final-head Opus review found the false success this PR set out to remove,
re-entered through a different door. `install.sh` read the CLI like this:

```sh
EMBED_JSON="$(as_clawbox timeout 60 "$OPENCLAW_BIN" memory status … || true)"
```

`|| true` throws the **exit status** away, so a `memory status` that prints a
complete, parseable answer and *still fails* was read as an authoritative verdict.
`collectMemoryStatusJson()` — the call this block says it mirrors — does the
opposite at `src/lib/clawkeep-memory.ts:389` (`if (timedOut || bytes > MAX ||
code !== 0) reject(...)`), so the two implementations disagreed in exactly the
direction TASK-659 was about. Real shapes that produce it: `--deep` failing its
provider probe after emitting the shallow status; a core that reports and then
exits on an unrelated warning; `timeout` killing the CLI *after* a complete JSON
document has been written.

**Fix:** the assignment moves into `if`-condition position (errexit stays
suppressed) and a non-zero status clears the JSON, so those boxes land on
"could not read an embedder" instead of on a verdict.

### RED (against this PR's own previous head, `2b3434cd`)

A stub `openclaw` that prints `[{"agentId":"main","status":{"provider":"ollama",
"model":"qwen3-embedding:0.6b"}}]` and exits **1**:

```
FAIL  … > does not trust a core that printed an answer and then failed
      AssertionError: expected '  Local embeddings ready (qwen3-embed…'
                      not to contain 'Local embeddings ready'

FAIL  … > does no embedding work at all on hermes, not just no reporting
      AssertionError: expected 'ran\n' to be ''

FAIL  … > asks the core, bounded, instead of re-reading openclaw.json
      AssertionError: expected '  local ENSURE_EMBEDDINGS=…' to match /timeout -k \d+ \d+ …/

FAIL  … > says it could not ask over a core that cannot answer / answers nonsense /
          answers an empty provider
      AssertionError: expected '  WARN: could not ask the core which …' to match
                      /could not read an embedder/i

Tests  6 failed | 38 passed (44)
```

### GREEN

`ensure-local-embeddings` → **44 passed**. Neighbouring suites
(`install-sudoers-migration`, `memory-shard-embedding-keys`, `local-models`,
`instrumentation-memory-warm`, `clawkeep-memory`) → **146 passed** together.
`bash -n install.sh` clean; `tsc --noEmit` clean.

### Also applied from the same review

- **LOW-2** — the "could not ask" arm covered three states and asserted one cause.
  It is reached when the CLI was missing/failed/timed out, when its output could
  not be parsed, **and** when the core answered naming no provider —
  `providerLocation()`'s own `unknown`, where the core *did* answer. Reworded to
  "could not read an embedder from the core (… did not answer, or named no
  provider)", which is true of all three.
- **LOW-3** — the comment claimed the call "costs less than the `openclaw
  --version` probe it replaces". Checked against the merge base: there is no
  `openclaw --version` in that block on beta — it replaces a sub-second local read
  of `openclaw.json`. The comment now says that, and why ~8 s is worth paying (a
  config read can only prove what was *written*; it cannot see a dimension
  mismatch or a fail-closed index).
- **LOW-4 (deliberate behaviour change)** — the edition gate covered the report but
  not the work. `ensure-local-embeddings.sh` ran *before* it, so a hermes box found
  no provider anywhere, fell through its "deliberate choice" guard and pulled a
  ~640 MB model — and the next line told the operator this edition has no memory
  search. The gate is now above the helper: hermes neither pulls nor reports.
  Nothing is lost — `gateway-pre-start.sh` runs the helper only on the OpenClaw
  gateway, which hermes does not have. Pinned by a test that also asserts the
  helper still runs where there *is* a core.
- **LOW-5** — `timeout -k 5 60`. Plain `timeout` sends SIGTERM only, while
  `clawkeep-memory.ts:345-349` escalates to SIGKILL after 5 s; a CLI that ignores
  SIGTERM must not hang the installer where it would not hang the panel.
- **NIT-6** — `provider.strip()` / `model.strip()`, so the classification cannot
  drift from `cleanString()` in the TypeScript it mirrors.

### Sibling call sites

`grep -rn "memory status"` over the repo: the only other reader of this CLI is
`src/lib/clawkeep-memory.ts`, which already rejects on `code !== 0` — that is the
behaviour this change adopts. `install-x64.sh` has no embeddings check at all
(`grep -c ensure-local-embeddings|qwen3-embedding` → 0), and
`scripts/gateway-pre-start.sh` runs the helper but publishes no verdict.

### Review round 2 (CodeRabbit threads, 1 applied / 1 part-applied-part-refuted)

Both changed what the operator reads, in the two states the report could not
describe:

- **A core that reports `ollama` with no model** gave `EMBED_STATE=local:`, which
  fell through the `local:*` arm and printed
  `Local embeddings ready on , not qwen3-embedding:0.6b` — a sentence with a hole
  in it that still claims READY over a box whose index cannot be matched to
  anything. It now has its own arm (`install.sh:4585`). On-device and keyless is
  determined by the provider alone, so that stays true and stays said, and it keeps
  agreeing with `providerLocation()` in `src/lib/clawkeep-memory.ts:406`; what is
  dropped is the claim about the index, which is the only part the empty model made
  unknowable. (Not `model or "an unnamed model"` as suggested — that keeps the box
  called READY and reads as if a model by that name existed.)
- **No `python3` on the box** made the parse fail and the catch-all say
  *"openclaw memory status did not answer"* about a core that answered perfectly.
  `--step ollama_install` runs standalone, so `step_apt_update` — which installs
  python3 at `install.sh:1046` — is not on that path. The interpreter now has a
  state of its own (`install.sh:4539`, arm at `:4608`), with `command -v` in
  if-condition position so nothing new can abort under `set -euo pipefail`.
  A warning that names the wrong culprit sends the operator to the wrong box.

Refuted: `timeout` being missing. It is `coreutils`, `Essential: yes`, and
`install.sh` already depends on it unguarded at `:1972` and `:3954`; if it somehow
were absent the `EMBED_JSON` assignment falls to `""` and the catch-all is then
accurate. Also not done: installing dependencies inside the standalone path — this
block is a read-only post-run report that must never abort the install.

**RED → GREEN:** both new cases failed on `5e686c54` (`Local embeddings ready on ,
not qwe…` and `could not read an embedder…` where the interpreter was the gap);
after the fix 46/46 in `ensure-local-embeddings.test.ts`, 627/627 across the 30
neighbouring suites, `tsc --noEmit` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Installation now verifies the active memory and embedding provider through the system’s status check.
  - Installer results identify local Qwen, other local, cloud, disabled, unavailable, and provider-less configurations when detected.
  - Resolved embedding models are reported when available.
  - Hermes editions skip local embedding setup.
  - Stale configuration settings no longer override the provider detected by the active system.
  - Unsupported or unreadable status responses are handled without unnecessary setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
