### PR TITLE
fix: drop the stale espeak-ng requirement and check the phonemiser instead (TASK-686)

### DIFF
--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -378,15 +378,22 @@ try:
     # TypeError lands in the WARN arm below, not on a box's verdict.
     pipeline = KPipeline(lang_code='a', model=False)
     g2p = pipeline.g2p
-    phonemes = g2p('zorblattic frobnicator squibbled')[0] or ''
+    # ONE WORD AT A TIME. A missing fallback does not blank a sentence -- misaki
+    # keeps what it can phonemise and drops the rest -- so a line judged whole
+    # still reads non-empty once ONE of its words survives, which is exactly
+    # what real speech looks like: lexicon hits mixed with the names this check
+    # exists to protect. Nothing here is in any lexicon, so a working fallback
+    # returns phonemes for every one; without one misaki emits its unknown
+    # marker, or nothing at all when kokoro built the G2P with unk='' -- strip
+    # both. Judged inside the try with the calls: a shape this cannot read is an
+    # upstream change, a WARN, never a verdict.
+    dropped = [w for w in ('zorblattic', 'frobnicator', 'squibbled')
+               if not (g2p(w)[0] or '').replace(chr(10067), '').strip()]
 except Exception as exc:
     print('WARN: could not exercise the phonemiser (' + type(exc).__name__ + ': ' + str(exc) + ') -- not treating that as a verdict')
     raise SystemExit(0)
-# Nothing in that line is in any lexicon, so with a working espeak fallback it
-# is all phonemes. Without one misaki emits its unknown marker, or nothing at
-# all when kokoro built the G2P with unk='' -- strip both before judging.
-if not phonemes.replace(chr(10067), '').strip():
-    raise SystemExit('espeak phonemiser unavailable: out-of-vocabulary words are dropped from speech (the espeakng-loader wheel kokoro pulls in is missing or broken)')
+if dropped:
+    raise SystemExit('espeak phonemiser unavailable: these out-of-vocabulary words are dropped from speech: ' + ', '.join(dropped) + ' (the espeakng-loader wheel kokoro pulls in is missing or broken)')
 print('Phonemiser OK (out-of-vocabulary words phonemise)')
 " 2>&1) || rc=$?
   printf '%s\n' "$out" | tail -3
@@ -650,7 +657,11 @@ install_kokoro_tts() {
     # Re-running the step lands on the idempotence gate and re-runs this same
     # check, so the caller's "Re-run: --step openclaw_tts" is not a remedy here.
     # The wheel that carries the espeak library and its data is.
-    echo "  Fix:   sudo -u clawbox pip3 install --force-reinstall espeakng-loader misaki" >&2
+    # The same shape install_python_package installs with: a login shell for
+    # the configured user and --user. `sudo -u clawbox pip3 install` without
+    # --user is a system install run by an unprivileged account, so the printed
+    # remedy would fail on the box it was printed for.
+    echo "  Fix:   su - $CLAWBOX_USER -c '$PIP install --user --force-reinstall espeakng-loader misaki'" >&2
     kokoro_report "failed:phonemiser"
     return 12
   fi
@@ -875,7 +886,7 @@ fi
 if $KOKORO_FULL_OK && ! kokoro_check_phonemiser; then
   KOKORO_FULL_OK=false
   echo "  Warning: Kokoro cannot phonemise out-of-vocabulary words — names and brands would be dropped from speech"
-  echo "  Warning: reinstall the wheel that carries it: sudo -u clawbox pip3 install --force-reinstall espeakng-loader misaki"
+  echo "  Warning: reinstall the wheel that carries it: su - $CLAWBOX_USER -c '$PIP install --user --force-reinstall espeakng-loader misaki'"
 fi
 
 echo "[7/7] Deploying voice server scripts..."

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -661,7 +661,12 @@ install_kokoro_tts() {
     # the configured user and --user. `sudo -u clawbox pip3 install` without
     # --user is a system install run by an unprivileged account, so the printed
     # remedy would fail on the box it was printed for.
-    echo "  Fix:   su - $CLAWBOX_USER -c '$PIP install --user --force-reinstall espeakng-loader misaki'" >&2
+    # %q on the user, because this line IS shell source -- the operator pastes
+    # it -- and CLAWBOX_USER is overridable. The command itself stays inside
+    # single quotes rather than %q'd as well: %q would backslash every space in
+    # it, and a remedy nobody can read is the failure this line already had.
+    # $PIP is a constant in this file, not input.
+    printf "  Fix:   su - %q -c '%s install --user --force-reinstall espeakng-loader misaki'\n" "$CLAWBOX_USER" "$PIP" >&2
     kokoro_report "failed:phonemiser"
     return 12
   fi
@@ -886,7 +891,7 @@ fi
 if $KOKORO_FULL_OK && ! kokoro_check_phonemiser; then
   KOKORO_FULL_OK=false
   echo "  Warning: Kokoro cannot phonemise out-of-vocabulary words — names and brands would be dropped from speech"
-  echo "  Warning: reinstall the wheel that carries it: su - $CLAWBOX_USER -c '$PIP install --user --force-reinstall espeakng-loader misaki'"
+  printf "  Warning: reinstall the wheel that carries it: su - %q -c '%s install --user --force-reinstall espeakng-loader misaki'\n" "$CLAWBOX_USER" "$PIP"
 fi
 
 echo "[7/7] Deploying voice server scripts..."

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -10,7 +10,9 @@
 # `KPipeline(lang_code='a').g2p.fallback` is still an EspeakFallback that
 # phonemises out-of-vocabulary words. The header used to claim the apt package
 # was required and install.sh has never installed it (TASK-686); what the claim
-# was standing in for is now CHECKED, in kokoro_predownload_model below.
+# was standing in for is now CHECKED on every run, by kokoro_check_phonemiser
+# below -- outside the idempotence gate, because a box that already has the
+# stack is exactly the box a broken wheel would be found on.
 #
 # Usage:
 #   install-voice.sh              full STT+TTS install (CTranslate2 source
@@ -332,16 +334,50 @@ kokoro_predownload_model() {
 from kokoro import KPipeline
 pipeline = KPipeline(lang_code='a')
 print('Kokoro model ready on', next(pipeline.model.parameters()).device)
-# kokoro builds the espeak phonemiser fallback inside a try/except and degrades
-# to logger.warning('EspeakFallback not Enabled: OOD words will be skipped')
-# plus fallback=None. Nothing downstream reads that warning, so a box in that
-# arm published KOKORO=ready and then silently dropped every out-of-vocabulary
-# word -- a name, a brand, 'ClawBox' itself -- from every spoken reply. Fail the
-# warm-up instead, so the verdict says the engine is not usable.
-if getattr(pipeline.g2p, 'fallback', None) is None:
-    raise SystemExit('espeak phonemiser fallback unavailable: out-of-vocabulary words would be dropped from speech (the espeakng-loader wheel that kokoro pulls in is missing or broken)')
 " 2>&1) || rc=$?
   printf '%s\n' "$out" | tail -5
+  return "$rc"
+}
+
+# Can this box turn a word it has never seen into phonemes?
+#
+# kokoro builds its espeak fallback inside a try/except and degrades to
+# logger.warning('EspeakFallback not Enabled: OOD words will be skipped') plus
+# fallback=None (kokoro/pipeline.py). Nothing downstream reads that warning, so
+# a box in that arm published KOKORO=ready and then silently dropped every
+# out-of-vocabulary word -- a name, a brand, 'ClawBox' itself -- from every
+# spoken reply.
+#
+# BEHAVIOUR, not structure: it phonemises a word no lexicon has, which is the
+# thing that actually matters and which survives an upstream rename. `kokoro` is
+# installed unpinned, so a check written against today's attribute names would
+# start failing WORKING boxes the day misaki moves one. An empty result, or the
+# unknown-token marker misaki emits when it has no fallback, is the failure; a
+# shape this cannot read at all is a warning, never a verdict.
+#
+# It costs a pipeline construction against an already-cached model, so it runs on
+# EVERY run -- including the box that skips the whole GPU install because it is
+# already stamped, which is precisely the box a broken wheel would be found on.
+kokoro_check_phonemiser() {
+  local out rc=0
+  echo "  Checking the phonemiser..."
+  out=$(clawbox_python "
+from kokoro import KPipeline
+pipeline = KPipeline(lang_code='a')
+try:
+    g2p = pipeline.g2p
+    phonemes = g2p('zorblattic frobnicator squibbled')[0] or ''
+except Exception as exc:
+    print('WARN: could not exercise the phonemiser (' + type(exc).__name__ + ': ' + str(exc) + ') -- not treating that as a verdict')
+    raise SystemExit(0)
+# Nothing in that line is in any lexicon, so with a working espeak fallback it
+# is all phonemes. Without one misaki emits its unknown marker, or nothing at
+# all when kokoro built the G2P with unk='' -- strip both before judging.
+if not phonemes.replace(chr(10067), '').strip():
+    raise SystemExit('espeak phonemiser unavailable: out-of-vocabulary words are dropped from speech (the espeakng-loader wheel kokoro pulls in is missing or broken)')
+print('Phonemiser OK (out-of-vocabulary words phonemise)')
+" 2>&1) || rc=$?
+  printf '%s\n' "$out" | tail -3
   return "$rc"
 }
 
@@ -591,6 +627,18 @@ install_kokoro_tts() {
     kokoro_mark_installed
   fi
 
+  # Outside the gate above, deliberately. `kokoro_stack_present` proves `import
+  # kokoro, torch` works, which a broken espeakng-loader does not disturb --
+  # misaki degrades rather than raising -- so an already-stamped box would take
+  # the skip arm and reach `ready` with a phonemiser that drops every
+  # out-of-vocabulary word. --tts-only runs on every in-app update, so that is
+  # every box on the fleet, including the one this fix is being shipped to.
+  if ! kokoro_check_phonemiser; then
+    echo "  ERROR: Kokoro cannot phonemise out-of-vocabulary words — names and brands would be dropped from speech" >&2
+    kokoro_report "failed:phonemiser"
+    return 12
+  fi
+
   # Refreshed on every run, present or not: the unit points at a script
   # deploy_voice_scripts just re-copied, and a stale unit is how a working box
   # stops working after an update.
@@ -802,6 +850,11 @@ else
 fi
 
 # ── Step 7: Deploy scripts ───────────────────────────────────────────────────
+
+if ! kokoro_check_phonemiser; then
+  KOKORO_FULL_OK=false
+  echo "  Warning: Kokoro cannot phonemise out-of-vocabulary words — names and brands would be dropped from speech"
+fi
 
 echo "[7/7] Deploying voice server scripts..."
 SCRIPTS_DST="$WORKSPACE/scripts"

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # Install local voice pipeline: faster-whisper (STT) + Kokoro (TTS)
 # With CUDA GPU acceleration and persistent model servers for fast inference.
-# Runs as clawbox user. Requires espeak-ng to be installed (system package).
+# Runs as clawbox user. It needs NO system speech package: `kokoro` pulls in
+# `misaki[en]`, and misaki/espeak.py calls
+# `EspeakWrapper.set_library(espeakng_loader.get_library_path())` at import, so
+# both the espeak-ng shared library and its data come out of the bundled
+# `espeakng-loader` wheel. Measured 2026-09-04 on a shipped openclaw box and a
+# shipped hermes box: no espeak-ng package, no espeak-ng binary, and
+# `KPipeline(lang_code='a').g2p.fallback` is still an EspeakFallback that
+# phonemises out-of-vocabulary words. The header used to claim the apt package
+# was required and install.sh has never installed it (TASK-686); what the claim
+# was standing in for is now CHECKED, in kokoro_predownload_model below.
 #
 # Usage:
 #   install-voice.sh              full STT+TTS install (CTranslate2 source
@@ -323,6 +332,14 @@ kokoro_predownload_model() {
 from kokoro import KPipeline
 pipeline = KPipeline(lang_code='a')
 print('Kokoro model ready on', next(pipeline.model.parameters()).device)
+# kokoro builds the espeak phonemiser fallback inside a try/except and degrades
+# to logger.warning('EspeakFallback not Enabled: OOD words will be skipped')
+# plus fallback=None. Nothing downstream reads that warning, so a box in that
+# arm published KOKORO=ready and then silently dropped every out-of-vocabulary
+# word -- a name, a brand, 'ClawBox' itself -- from every spoken reply. Fail the
+# warm-up instead, so the verdict says the engine is not usable.
+if getattr(pipeline.g2p, 'fallback', None) is None:
+    raise SystemExit('espeak phonemiser fallback unavailable: out-of-vocabulary words would be dropped from speech (the espeakng-loader wheel that kokoro pulls in is missing or broken)')
 " 2>&1) || rc=$?
   printf '%s\n' "$out" | tail -5
   return "$rc"

--- a/scripts/install-voice.sh
+++ b/scripts/install-voice.sh
@@ -348,23 +348,35 @@ print('Kokoro model ready on', next(pipeline.model.parameters()).device)
 # out-of-vocabulary word -- a name, a brand, 'ClawBox' itself -- from every
 # spoken reply.
 #
-# BEHAVIOUR, not structure: it phonemises a word no lexicon has, which is the
-# thing that actually matters and which survives an upstream rename. `kokoro` is
-# installed unpinned, so a check written against today's attribute names would
-# start failing WORKING boxes the day misaki moves one. An empty result, or the
-# unknown-token marker misaki emits when it has no fallback, is the failure; a
-# shape this cannot read at all is a warning, never a verdict.
+# BEHAVIOUR, not structure: it asks for SOMETHING back for a word no lexicon
+# has, which is the thing that actually matters and which survives an upstream
+# rename. `kokoro` is installed unpinned, so a check written against today's
+# attribute names would start failing WORKING boxes the day misaki moves one. An
+# empty result, or the unknown-token marker misaki emits when it has no
+# fallback, is the failure; a shape this cannot read at all is a warning, never
+# a verdict -- and that rule covers the import and the construction too, not
+# just the call. Everything from the import down is inside the try for that
+# reason: kokoro absent, a torch/CUDA init failure and a CUDA OOM all say
+# nothing whatsoever about the phonemiser, and grading them would print "Kokoro
+# GPU TTS was REQUESTED and did NOT install" over a box that speaks fine.
 #
-# It costs a pipeline construction against an already-cached model, so it runs on
-# EVERY run -- including the box that skips the whole GPU install because it is
-# already stamped, which is precisely the box a broken wheel would be found on.
+# It builds the G2P and nothing else, so it runs on EVERY run -- including the
+# box that skips the whole GPU install because it is already stamped, which is
+# precisely the box a broken wheel would be found on, and which --tts-only
+# reaches on every in-app update of every box on the fleet.
 kokoro_check_phonemiser() {
   local out rc=0
   echo "  Checking the phonemiser..."
   out=$(clawbox_python "
-from kokoro import KPipeline
-pipeline = KPipeline(lang_code='a')
 try:
+    from kokoro import KPipeline
+    # model=False: build the G2P, not the TTS weights. pipeline.g2p is built
+    # either way, so the probe loses nothing, while the check stops loading a
+    # KModel onto a GPU kokoro-server.service may already be holding on ~8 GB
+    # of shared Orin memory, and stops needing the HuggingFace cache -- and a
+    # network round trip -- at all. If a future kokoro drops the argument, the
+    # TypeError lands in the WARN arm below, not on a box's verdict.
+    pipeline = KPipeline(lang_code='a', model=False)
     g2p = pipeline.g2p
     phonemes = g2p('zorblattic frobnicator squibbled')[0] or ''
 except Exception as exc:
@@ -635,6 +647,10 @@ install_kokoro_tts() {
   # every box on the fleet, including the one this fix is being shipped to.
   if ! kokoro_check_phonemiser; then
     echo "  ERROR: Kokoro cannot phonemise out-of-vocabulary words — names and brands would be dropped from speech" >&2
+    # Re-running the step lands on the idempotence gate and re-runs this same
+    # check, so the caller's "Re-run: --step openclaw_tts" is not a remedy here.
+    # The wheel that carries the espeak library and its data is.
+    echo "  Fix:   sudo -u clawbox pip3 install --force-reinstall espeakng-loader misaki" >&2
     kokoro_report "failed:phonemiser"
     return 12
   fi
@@ -851,9 +867,15 @@ fi
 
 # ── Step 7: Deploy scripts ───────────────────────────────────────────────────
 
-if ! kokoro_check_phonemiser; then
+# Gated on KOKORO_FULL_OK: this path reaches here after install_kokoro_packages
+# or the model download may already have failed, and on that box the honest
+# statement is "kokoro is not installed", not "kokoro cannot phonemise". The
+# flag is already false there, so no verdict changes -- only the sentence the
+# operator reads.
+if $KOKORO_FULL_OK && ! kokoro_check_phonemiser; then
   KOKORO_FULL_OK=false
   echo "  Warning: Kokoro cannot phonemise out-of-vocabulary words — names and brands would be dropped from speech"
+  echo "  Warning: reinstall the wheel that carries it: sudo -u clawbox pip3 install --force-reinstall espeakng-loader misaki"
 fi
 
 echo "[7/7] Deploying voice server scripts..."

--- a/src/tests/unit/install-kokoro-tts.test.ts
+++ b/src/tests/unit/install-kokoro-tts.test.ts
@@ -695,7 +695,20 @@ describe.skipIf(!hasBash)("install-voice.sh --tts-only is cheap on re-run", () =
     const res = runTtsOnly({ WITH_CUDA: "1", KOKORO_IMPORT_EXIT: "0" }, true);
     expect(res.status, res.stderr).toBe(0);
     expect(res.su.filter((c) => c.includes("pip3 install")), "the heavy pip work ran again").toEqual([]);
-    expect(res.su.filter((c) => c.includes("KPipeline")), "the warm-up ran again").toEqual([]);
+    expect(
+      res.su.filter((c) => c.includes("pipeline.model.parameters")),
+      "the model pre-download ran again",
+    ).toEqual([]);
+    // The phonemiser check is deliberately NOT skipped on this path. A box that
+    // already has the stack is exactly the box a broken espeakng-loader wheel is
+    // found on — `import kokoro, torch` succeeds either way — and skipping it
+    // here would mean the fleet update carrying the check never runs it. It
+    // costs a pipeline construction against an already-cached model, not a
+    // download; the curl assertion below is what pins that.
+    expect(
+      res.su.filter((c) => c.includes("zorblattic")),
+      "the phonemiser check was skipped on the box that most needs it",
+    ).toHaveLength(1);
     expect(res.curl, "something was downloaded on a no-op run").toEqual([]);
     expect(res.stdout).toContain("CLAWBOX_TTS_KOKORO=ready");
   });

--- a/src/tests/unit/install-voice-espeak.test.ts
+++ b/src/tests/unit/install-voice-espeak.test.ts
@@ -154,38 +154,125 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
   }
 
   /**
-   * Run the captured payload against a fake `kokoro`. `phonemes` is what the
-   * pipeline's g2p returns for the out-of-vocabulary line, or "raise" to make
-   * it throw, or "no-g2p" to remove the attribute entirely.
+   * Fault to inject into the fake `kokoro` the payload imports.
+   *
+   * A string is what the pipeline's g2p returns for the out-of-vocabulary line;
+   * the named modes are the ways the box itself, rather than the phonemiser,
+   * can be broken or merely different.
    */
-  function check(phonemes: string | "raise" | "no-g2p"): { status: number | null; out: string } {
-    const payload = capturePayload();
+  type Fault =
+    | string
+    | "raise" // g2p throws
+    | "no-g2p" // the pipeline has no g2p attribute
+    | "no-module" // `kokoro` is not installed at all
+    | "init-raise" // KPipeline() throws (torch/CUDA init, a CUDA OOM, an HF fetch)
+    | "model-must-be-false"; // KPipeline() refuses to load TTS weights
+
+  /**
+   * Write a fake `kokoro` package and return the PYTHONPATH that finds it, or
+   * null for the box where `kokoro` is absent.
+   *
+   * `KPipeline.__init__` takes `model` because the real one does: the check
+   * wants the G2P only, and constructing with the weights is a torch import
+   * plus a KModel load onto a Jetson's shared GPU on every in-app update.
+   */
+  function writeFakeKokoro(fault: Fault): string | null {
+    if (fault === "no-module") return null;
     const pkg = path.join(root, "fake", "kokoro");
     mkdirSync(pkg, { recursive: true });
     const g2p =
-      phonemes === "raise"
+      fault === "raise"
         ? "    def __call__(self, text):\n        raise RuntimeError('boom')"
-        : `    def __call__(self, text):\n        return (${JSON.stringify(phonemes)}, [])`;
+        : `    def __call__(self, text):\n        return (${JSON.stringify(
+            NAMED_FAULTS.has(fault) ? WORKING_PHONEMES : fault,
+          )}, [])`;
+    const init: string[] = [];
+    if (fault === "init-raise") {
+      // What a box under memory pressure actually raises: kokoro-server.service
+      // already holds the model on ~8 GB of shared Orin memory.
+      init.push("        raise RuntimeError('CUDA out of memory')");
+    } else if (fault === "model-must-be-false") {
+      // SystemExit, not Exception, so a check that catches broadly still fails
+      // here: this pins the kwarg, not the error handling.
+      init.push("        if model is not False:");
+      init.push("            raise SystemExit('the check loaded the TTS model')");
+      init.push("        self.g2p = _G2P()");
+    } else if (fault === "no-g2p") {
+      init.push("        pass");
+    } else {
+      init.push("        self.g2p = _G2P()");
+    }
     writeFileSync(
       path.join(pkg, "__init__.py"),
-      [
-        "class _G2P:",
-        g2p,
-        "",
-        "class KPipeline:",
-        "    def __init__(self, lang_code):",
-        phonemes === "no-g2p" ? "        pass" : "        self.g2p = _G2P()",
-        "",
-      ].join("\n"),
+      ["class _G2P:", g2p, "", "class KPipeline:", "    def __init__(self, lang_code, model=True):", ...init, ""].join(
+        "\n",
+      ),
     );
+    return path.join(root, "fake");
+  }
+
+  const NAMED_FAULTS = new Set(["raise", "no-g2p", "no-module", "init-raise", "model-must-be-false"]);
+  /** What a shipped Orin with a working espeakng-loader wheel actually returns. */
+  const WORKING_PHONEMES = "zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld";
+
+  /** Run the captured payload against a fake `kokoro` carrying `fault`. */
+  function check(fault: Fault): { status: number | null; out: string } {
+    const payload = capturePayload();
+    const pythonPath = writeFakeKokoro(fault);
     const script = path.join(root, "run-payload.py");
     writeFileSync(script, payload.endsWith("\n") ? payload : `${payload}\n`);
     const run = spawnSync("python3", [script], {
       encoding: "utf-8",
       timeout: 30_000,
-      env: { ...process.env, PYTHONPATH: path.join(root, "fake") },
+      // An empty PYTHONPATH is the box with no kokoro: the import must fail.
+      env: { ...process.env, PYTHONPATH: pythonPath ?? path.join(root, "empty") },
     });
     return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+  }
+
+  /**
+   * The verdict the CALLER reaches, running the shipped `if ! ... ; then`
+   * arm out of `install_kokoro_tts` rather than a paraphrase of it. The payload
+   * exiting non-zero is only interesting because of what this arm does with it:
+   * `failed:phonemiser`, return 12, and install.sh's "Kokoro GPU TTS was
+   * REQUESTED and did NOT install" banner plus a recorded provision failure.
+   */
+  function verdict(fault: Fault): { rc: number; out: string } {
+    const armStart = INSTALL_VOICE_SH.indexOf("  if ! kokoro_check_phonemiser; then");
+    if (armStart < 0) throw new Error("the install_kokoro_tts phonemiser arm is no longer shaped as this test expects");
+    const armEnd = INSTALL_VOICE_SH.indexOf("\n  fi\n", armStart);
+    if (armEnd < 0) throw new Error("the phonemiser arm has no closing fi");
+    const arm = INSTALL_VOICE_SH.slice(armStart, armEnd + "\n  fi".length);
+
+    const start = INSTALL_VOICE_SH.indexOf("kokoro_check_phonemiser() {");
+    const end = INSTALL_VOICE_SH.indexOf("\n}", start);
+    const body = INSTALL_VOICE_SH.slice(start, end + 2);
+
+    const pythonPath = writeFakeKokoro(fault) ?? path.join(root, "empty");
+    const harness = path.join(root, "verdict.sh");
+    writeFileSync(
+      harness,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'kokoro_report() { echo "REPORT $1"; }',
+        `clawbox_python() { PYTHONPATH=${JSON.stringify(pythonPath)} python3 -c "$1"; }`,
+        body,
+        "caller() {",
+        arm,
+        "  return 0",
+        "}",
+        "rc=0",
+        "caller || rc=$?",
+        'echo "RC=$rc"',
+        "",
+      ].join("\n"),
+    );
+    const run = spawnSync("bash", [harness], { encoding: "utf-8", timeout: 60_000 });
+    const out = `${run.stdout ?? ""}${run.stderr ?? ""}`;
+    const m = out.match(/RC=(\d+)/);
+    if (!m) throw new Error(`the harness never reached its verdict: ${out}`);
+    return { rc: Number(m[1]), out };
   }
 
   it("carries no shell metacharacter, so what bash builds is what was written", () => {
@@ -217,6 +304,13 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
   for (const [name, mode] of [
     ["the g2p raises", "raise"],
     ["the pipeline has no g2p at all", "no-g2p"],
+    // The two the check used to run OUTSIDE its own try/except. Neither says
+    // anything about the phonemiser: `kokoro` absent is a box that was never
+    // asked for GPU TTS or whose pip install is gone, and a constructor that
+    // raises is torch/CUDA init, a CUDA OOM while kokoro-server already holds
+    // the model on ~8 GB of shared Orin memory, or a HuggingFace fetch.
+    ["kokoro is not installed at all", "no-module"],
+    ["the pipeline constructor raises", "init-raise"],
   ] as const) {
     it(`warns rather than failing a working box when ${name}`, () => {
       // `kokoro` is installed unpinned, so a shape this cannot read is an
@@ -228,4 +322,44 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
       expect(run.out).toMatch(/WARN/);
     });
   }
+
+  it("builds the G2P only, without loading the TTS model", () => {
+    // --tts-only runs on EVERY in-app update of every box on the fleet, so a
+    // full pipeline construction here is a torch import and a KModel load onto
+    // a GPU kokoro-server.service may already be holding — and it is what makes
+    // the check need the HuggingFace cache, and a network round trip, at all.
+    // The probe uses `pipeline.g2p`, which is built whatever `model` says.
+    const run = check("model-must-be-false");
+    expect(run.out).not.toContain("the check loaded the TTS model");
+    expect(run.status).toBe(0);
+    expect(run.out).toContain("Phonemiser OK");
+  });
+
+  describe("a box that is merely different is never graded as a failed provision", () => {
+    /**
+     * The shipped caller arm turns a non-zero check into `failed:phonemiser` and
+     * `return 12`, which install.sh reads as VOICE_RC=12 -> TTS_RC=12 -> "Kokoro
+     * GPU TTS was REQUESTED and did NOT install" + record_provision_failure. So
+     * every fault that is not "this box drops out-of-vocabulary words" has to
+     * stop before it.
+     */
+    for (const [name, mode] of [
+      ["kokoro is not installed at all", "no-module"],
+      ["the pipeline constructor raises (CUDA OOM, torch init, an HF fetch)", "init-raise"],
+    ] as const) {
+      it(`does not fail the provision when ${name}`, () => {
+        const run = verdict(mode);
+        expect(run.out).not.toContain("REPORT failed:phonemiser");
+        expect(run.rc, `the arm returned ${run.rc}:\n${run.out}`).toBe(0);
+      });
+    }
+
+    it("still fails the provision for the fault it exists to catch", () => {
+      // The control: without this, the two assertions above would also pass over
+      // a check that had been quietly turned into a no-op.
+      const run = verdict("  ");
+      expect(run.out).toContain("REPORT failed:phonemiser");
+      expect(run.rc).toBe(12);
+    });
+  });
 });

--- a/src/tests/unit/install-voice-espeak.test.ts
+++ b/src/tests/unit/install-voice-espeak.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync, chmodSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -14,9 +14,8 @@ import path from "node:path";
  * phonemiser works anyway —
  *
  *     bundled lib: ~/.local/lib/python3.10/site-packages/espeakng_loader/libespeak-ng.so
- *     EspeakFallback constructed OK
- *     PHONEMES: 'ðə zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld'   (all three out-of-vocabulary)
  *     KPipeline(lang_code='a').g2p.fallback -> EspeakFallback
+ *     WORKING     -> 'zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld'
  *
  * `misaki/espeak.py` calls `EspeakWrapper.set_library(espeakng_loader.get_library_path())`
  * at import, and the `espeakng-loader` wheel — pulled in by `kokoro` →
@@ -27,18 +26,26 @@ import path from "node:path";
  * What the stale line was standing in for IS real, though, and nothing checked
  * it: kokoro builds its espeak fallback in a `try/except` that degrades to
  * `logger.warning("EspeakFallback not Enabled: OOD words will be skipped")` and
- * `fallback=None` (kokoro/pipeline.py:108-113). A box that lands in that arm
- * still publishes `KOKORO=ready` and then silently drops every
- * out-of-vocabulary word — names, brands, "ClawBox" itself — from speech. So
- * the warm-up now fails on a pipeline with no fallback, and these tests run
- * the shipped warm-up payload against a fake `kokoro` module to prove it.
+ * `fallback=None`. A box in that arm still publishes `KOKORO=ready` and then
+ * silently drops every out-of-vocabulary word — names, brands, "ClawBox"
+ * itself — from speech. Measured on the same box, with the fallback removed:
+ *
+ *     NO FALLBACK unk=""  -> '  '
+ *     NO FALLBACK unk="?" -> '❓ ❓ ❓'
+ *
+ * So `kokoro_check_phonemiser` phonemises a line no lexicon has and fails on
+ * either of those, and it runs OUTSIDE the idempotence gate — a box that
+ * already has the Kokoro stack is exactly the box a broken wheel is found on,
+ * and `--tts-only` runs on every in-app update.
  */
 
 const REPO = process.cwd();
 const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
 const INSTALL_VOICE_SH = readFileSync(path.join(REPO, "scripts", "install-voice.sh"), "utf-8");
 
+const hasBash = spawnSync("bash", ["--version"], { stdio: "ignore" }).status === 0;
 const hasPython = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+const canRun = hasBash && hasPython;
 
 let root: string;
 beforeEach(() => {
@@ -48,75 +55,131 @@ afterEach(() => {
   rmSync(root, { recursive: true, force: true });
 });
 
+/**
+ * Every system package a script's header names as required. The installer is
+ * the only thing that could satisfy one, so a name here that install.sh never
+ * installs is either a missing install or a stale claim.
+ */
+const REQUIRES_SYSTEM_PACKAGE = /Requires ([a-z0-9][a-z0-9.+-]*) to be installed \(system package\)/g;
+
+function declaredSystemPackages(source: string): string[] {
+  return [...source.matchAll(REQUIRES_SYSTEM_PACKAGE)].map((m) => m[1]);
+}
+
 describe("install-voice.sh declares no system package install.sh does not provide", () => {
-  /**
-   * Every system package the script's header names as required. The installer
-   * is the only thing that could satisfy one, so a name here that install.sh
-   * never `apt-get install`s is either a missing install or a stale claim.
-   */
-  const declared = [...INSTALL_VOICE_SH.matchAll(/Requires ([a-z0-9][a-z0-9.+-]*) to be installed \(system package\)/g)].map(
-    (m) => m[1],
-  );
+  it("the matcher can still catch one — a control that fails", () => {
+    // Without this the assertion below passes over an empty list the day the
+    // wording changes, and a re-introduced claim is invisible.
+    expect(declaredSystemPackages("# Requires frobnicator to be installed (system package).")).toEqual([
+      "frobnicator",
+    ]);
+  });
 
   it("names no required system package that install.sh never installs", () => {
-    const missing = declared.filter((pkg) => !new RegExp(`\\b${pkg}\\b`).test(INSTALL_SH));
+    const missing = declaredSystemPackages(INSTALL_VOICE_SH).filter(
+      (pkg) => !new RegExp(`\\b${pkg}\\b`).test(INSTALL_SH),
+    );
     expect(missing).toEqual([]);
   });
 
   it("says where the espeak-ng library actually comes from", () => {
-    // Not decoration: the next person to read this file has to know that the
+    // Not decoration: the next person to read this file has to know the
     // phonemiser is satisfied by a wheel, or they will "fix" the missing apt
     // package that was never needed.
     expect(INSTALL_VOICE_SH).toMatch(/espeakng-loader/);
   });
 });
 
-describe.runIf(hasPython)("the Kokoro warm-up refuses a pipeline with no phonemiser fallback", () => {
-  /** The python program the warm-up hands to the box, lifted verbatim. */
-  const PAYLOAD = (() => {
-    const start = INSTALL_VOICE_SH.indexOf("kokoro_predownload_model() {");
-    if (start < 0) throw new Error("kokoro_predownload_model not found in install-voice.sh");
+describe("the phonemiser check runs on a box that already has Kokoro", () => {
+  const fn = (() => {
+    const start = INSTALL_VOICE_SH.indexOf("install_kokoro_tts() {");
+    if (start < 0) throw new Error("install_kokoro_tts not found");
     const end = INSTALL_VOICE_SH.indexOf("\n}", start);
-    if (end < 0) throw new Error("kokoro_predownload_model has no closing brace");
-    const fn = INSTALL_VOICE_SH.slice(start, end);
-    const open = fn.indexOf('clawbox_python "');
-    const close = fn.indexOf('" 2>&1', open);
-    if (open < 0 || close < 0) throw new Error("the warm-up payload is no longer a clawbox_python string");
-    const body = fn.slice(open + 'clawbox_python "'.length, close);
-    if (!body.includes("from kokoro import KPipeline")) {
-      throw new Error("the warm-up payload was extracted TRUNCATED");
-    }
-    return body;
+    if (end < 0) throw new Error("install_kokoro_tts has no closing brace");
+    return INSTALL_VOICE_SH.slice(start, end);
   })();
 
+  it("is called after the idempotence gate closes, not inside its else arm", () => {
+    // `kokoro_stack_present` proves `import kokoro, torch` works, which a
+    // broken espeakng-loader does not disturb — misaki degrades rather than
+    // raising. A check inside the else arm would skip every box on the fleet,
+    // including the ones being updated to get this very fix.
+    const gateEnd = fn.indexOf("\n    kokoro_mark_installed\n  fi\n");
+    const call = fn.indexOf("kokoro_check_phonemiser");
+    expect(gateEnd, "the idempotence gate is no longer shaped as this test expects").toBeGreaterThan(0);
+    expect(call).toBeGreaterThan(gateEnd);
+  });
+
+  it("refuses the ready verdict when it fails", () => {
+    expect(fn).toMatch(/kokoro_check_phonemiser; then[\s\S]*kokoro_report "failed:phonemiser"/);
+    expect(fn.indexOf('kokoro_report "failed:phonemiser"')).toBeLessThan(fn.indexOf('kokoro_report "ready"') + fn.length);
+  });
+});
+
+describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vocabulary words", () => {
   /**
-   * Run the payload against a fake `kokoro` module. `fallback` is what
-   * kokoro's own pipeline sets to None when it cannot build an EspeakFallback.
+   * The python program the check hands the box, captured THROUGH bash.
+   *
+   * It is a double-quoted shell string on the way to `clawbox_python`, so `$`,
+   * a backtick or a backslash in it would be expanded before the device ever
+   * saw it. Lifting the literal file text out with `indexOf` would not see
+   * that; evaluating the real function with a stub that dumps its argument
+   * gives byte-for-byte what a device gets.
    */
-  function warmUp(fallback: "present" | "none"): { status: number | null; out: string } {
-    const pkg = path.join(root, "fake", "kokoro");
-    mkdirSync(pkg, { recursive: true });
+  function capturePayload(): string {
+    const start = INSTALL_VOICE_SH.indexOf("kokoro_check_phonemiser() {");
+    if (start < 0) throw new Error("kokoro_check_phonemiser not found in install-voice.sh");
+    const end = INSTALL_VOICE_SH.indexOf("\n}", start);
+    if (end < 0) throw new Error("kokoro_check_phonemiser has no closing brace");
+    const body = INSTALL_VOICE_SH.slice(start, end + 2);
+    if (!body.includes("from kokoro import KPipeline")) {
+      throw new Error("kokoro_check_phonemiser was extracted TRUNCATED");
+    }
+    const out = path.join(root, "payload.py");
+    const harness = path.join(root, "capture.sh");
     writeFileSync(
-      path.join(pkg, "__init__.py"),
+      harness,
       [
-        "from types import SimpleNamespace",
-        "",
-        "class _Param:",
-        "    device = 'cuda:0'",
-        "",
-        "class _Model:",
-        "    def parameters(self):",
-        "        return iter([_Param()])",
-        "",
-        "class KPipeline:",
-        "    def __init__(self, lang_code):",
-        "        self.model = _Model()",
-        `        self.g2p = SimpleNamespace(fallback=${fallback === "present" ? "object()" : "None"})`,
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `clawbox_python() { printf '%s' "$1" > ${JSON.stringify(out)}; return 0; }`,
+        body,
+        "kokoro_check_phonemiser >/dev/null 2>&1 || true",
         "",
       ].join("\n"),
     );
-    const script = path.join(root, "payload.py");
-    writeFileSync(script, `${PAYLOAD}\n`);
+    const run = spawnSync("bash", [harness], { encoding: "utf-8", timeout: 30_000 });
+    if (!existsSync(out)) throw new Error(`the payload was never handed to clawbox_python: ${run.stderr}`);
+    return readFileSync(out, "utf-8");
+  }
+
+  /**
+   * Run the captured payload against a fake `kokoro`. `phonemes` is what the
+   * pipeline's g2p returns for the out-of-vocabulary line, or "raise" to make
+   * it throw, or "no-g2p" to remove the attribute entirely.
+   */
+  function check(phonemes: string | "raise" | "no-g2p"): { status: number | null; out: string } {
+    const payload = capturePayload();
+    const pkg = path.join(root, "fake", "kokoro");
+    mkdirSync(pkg, { recursive: true });
+    const g2p =
+      phonemes === "raise"
+        ? "    def __call__(self, text):\n        raise RuntimeError('boom')"
+        : `    def __call__(self, text):\n        return (${JSON.stringify(phonemes)}, [])`;
+    writeFileSync(
+      path.join(pkg, "__init__.py"),
+      [
+        "class _G2P:",
+        g2p,
+        "",
+        "class KPipeline:",
+        "    def __init__(self, lang_code):",
+        phonemes === "no-g2p" ? "        pass" : "        self.g2p = _G2P()",
+        "",
+      ].join("\n"),
+    );
+    const script = path.join(root, "run-payload.py");
+    writeFileSync(script, payload.endsWith("\n") ? payload : `${payload}\n`);
     const run = spawnSync("python3", [script], {
       encoding: "utf-8",
       timeout: 30_000,
@@ -125,17 +188,44 @@ describe.runIf(hasPython)("the Kokoro warm-up refuses a pipeline with no phonemi
     return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
   }
 
-  it("reports the device when the fallback is there", () => {
-    const run = warmUp("present");
-    expect(run.status).toBe(0);
-    expect(run.out).toContain("Kokoro model ready on");
+  it("carries no shell metacharacter, so what bash builds is what was written", () => {
+    // The historical clawbox_python quoting bug (see the comment above
+    // clawbox_python) shipped because a payload grew a character bash reads.
+    expect(capturePayload()).not.toMatch(/[$`\\]/);
   });
 
-  it("fails, naming the phonemiser, when kokoro could not build one", () => {
-    // Today: exit 0 and "Kokoro model ready on cuda:0" — the box publishes
-    // KOKORO=ready and drops every out-of-vocabulary word from speech.
-    const run = warmUp("none");
-    expect(run.status).not.toBe(0);
-    expect(run.out).toMatch(/espeak|phonemis/i);
+  it("passes a box whose out-of-vocabulary words phonemise", () => {
+    // Measured on a shipped Orin with a working espeakng-loader wheel.
+    const run = check("zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld");
+    expect(run.status).toBe(0);
+    expect(run.out).toContain("Phonemiser OK");
   });
+
+  for (const [name, phonemes] of [
+    // kokoro builds its G2P with unk='' — a dropped word leaves whitespace.
+    ["kokoro's own unk=''", "  "],
+    // misaki's default marker, for a G2P built without that argument.
+    ["misaki's unknown marker", "❓ ❓ ❓"],
+  ] as const) {
+    it(`fails, naming espeak, when the fallback is gone (${name})`, () => {
+      const run = check(phonemes);
+      expect(run.status).not.toBe(0);
+      expect(run.out).toMatch(/espeak/i);
+    });
+  }
+
+  for (const [name, mode] of [
+    ["the g2p raises", "raise"],
+    ["the pipeline has no g2p at all", "no-g2p"],
+  ] as const) {
+    it(`warns rather than failing a working box when ${name}`, () => {
+      // `kokoro` is installed unpinned, so a shape this cannot read is an
+      // upstream rename, not a broken box. Grading it as a failure would print
+      // "Kokoro was REQUESTED and did NOT install" over a box that speaks —
+      // on the manufacturing line, on both editions.
+      const run = check(mode);
+      expect(run.status).toBe(0);
+      expect(run.out).toMatch(/WARN/);
+    });
+  }
 });

--- a/src/tests/unit/install-voice-espeak.test.ts
+++ b/src/tests/unit/install-voice-espeak.test.ts
@@ -444,12 +444,73 @@ describe("the phonemiser remediation prints a command that works on the box", ()
    * operator believes it was told what to do.
    */
   const remediations = INSTALL_VOICE_SH.split("\n").filter(
-    (line) => /^\s*echo /.test(line) && /espeakng-loader misaki/.test(line),
+    (line) => /^\s*(echo|printf) /.test(line) && /espeakng-loader misaki/.test(line),
   );
 
   it("finds both of them", () => {
     expect(remediations).toHaveLength(2);
   });
+
+  /** Bash single-quoting, for putting a hostile value into a fixture safely. */
+  const sq = (value: string) => `'${value.replace(/'/g, `'\\''`)}'`;
+
+  /**
+   * Render one remediation line with `CLAWBOX_USER` set to `user`, then EVAL
+   * what it printed with `su` stubbed — which is what an operator pasting it
+   * does. Returns the argv `su` actually received and whether the paste had a
+   * side effect of its own.
+   */
+  function paste(line: string, user: string): { argv: string[]; sideEffect: boolean; user: string } {
+    const stubBin = path.join(root, "paste-bin");
+    mkdirSync(stubBin, { recursive: true });
+    const argvLog = path.join(root, "su-argv.log");
+    const marker = path.join(root, "SIDE-EFFECT");
+    const resolved = user.replace("SIDE_EFFECT_MARKER", marker);
+    writeFileSync(path.join(stubBin, "su"), `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > ${JSON.stringify(argvLog)}\n`);
+    chmodSync(path.join(stubBin, "su"), 0o755);
+    const harness = path.join(root, "paste.sh");
+    writeFileSync(
+      harness,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `CLAWBOX_USER=${sq(resolved)}`,
+        'PIP="pip3"',
+        // What the operator sees, off whichever stream the line uses.
+        `raw="$(${line.trim().replace(/ >&2$/, "")} 2>&1)"`,
+        // What they paste: everything from the command onwards.
+        'cmd="su - ${raw#*su - }"',
+        `PATH=${JSON.stringify(stubBin)}:$PATH eval "$cmd"`,
+        "",
+      ].join("\n"),
+    );
+    spawnSync("bash", [harness], { encoding: "utf-8", timeout: 30_000 });
+    return {
+      argv: existsSync(argvLog) ? readFileSync(argvLog, "utf-8").split("\n").filter(Boolean) : [],
+      sideEffect: existsSync(marker),
+      user: resolved,
+    };
+  }
+
+  for (const line of remediations) {
+    it(`renders one argument per argument, whatever CLAWBOX_USER holds: ${line.trim().slice(0, 44)}…`, () => {
+      // These lines ARE shell source: the operator pastes them. A user name
+      // carrying shell syntax must reach `su` as one word, not as a second
+      // command — and the same escaping is what keeps a name with a space in
+      // it pasteable at all, which is the whole reason these lines changed.
+      const hostile = "evil $(touch SIDE_EFFECT_MARKER)";
+      const r = paste(line, hostile);
+      expect(r.sideEffect, "the pasted command ran something of its own").toBe(false);
+      expect(r.argv).toEqual(["-", r.user, "-c", "pip3 install --user --force-reinstall espeakng-loader misaki"]);
+    });
+
+    it(`stays readable for the name every box actually has: ${line.trim().slice(0, 44)}…`, () => {
+      // The control: escaping must not turn the normal case into a wall of
+      // backslashes. Nobody pastes a remedy they cannot read.
+      const r = paste(line, "clawbox");
+      expect(r.argv).toEqual(["-", "clawbox", "-c", "pip3 install --user --force-reinstall espeakng-loader misaki"]);
+    });
+  }
 
   for (const line of remediations) {
     it(`installs the way install_python_package does: ${line.trim().slice(0, 60)}…`, () => {

--- a/src/tests/unit/install-voice-espeak.test.ts
+++ b/src/tests/unit/install-voice-espeak.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+/**
+ * `scripts/install-voice.sh` declared "Requires espeak-ng to be installed
+ * (system package)" and install.sh installs espeak-ng nowhere, on any edition
+ * (TASK-686). One of those two statements had to be wrong.
+ *
+ * Measured read-only on both a shipped openclaw box and a shipped hermes box
+ * (2026-09-04): no `espeak-ng` package and no `espeak-ng` binary, and the
+ * phonemiser works anyway —
+ *
+ *     bundled lib: ~/.local/lib/python3.10/site-packages/espeakng_loader/libespeak-ng.so
+ *     EspeakFallback constructed OK
+ *     PHONEMES: 'ðə zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld'   (all three out-of-vocabulary)
+ *     KPipeline(lang_code='a').g2p.fallback -> EspeakFallback
+ *
+ * `misaki/espeak.py` calls `EspeakWrapper.set_library(espeakng_loader.get_library_path())`
+ * at import, and the `espeakng-loader` wheel — pulled in by `kokoro` →
+ * `misaki[en]`, which `install_kokoro_packages` installs — vendors both the
+ * shared library and the espeak-ng data. So the system package is not a
+ * dependency and the header was stale.
+ *
+ * What the stale line was standing in for IS real, though, and nothing checked
+ * it: kokoro builds its espeak fallback in a `try/except` that degrades to
+ * `logger.warning("EspeakFallback not Enabled: OOD words will be skipped")` and
+ * `fallback=None` (kokoro/pipeline.py:108-113). A box that lands in that arm
+ * still publishes `KOKORO=ready` and then silently drops every
+ * out-of-vocabulary word — names, brands, "ClawBox" itself — from speech. So
+ * the warm-up now fails on a pipeline with no fallback, and these tests run
+ * the shipped warm-up payload against a fake `kokoro` module to prove it.
+ */
+
+const REPO = process.cwd();
+const INSTALL_SH = readFileSync(path.join(REPO, "install.sh"), "utf-8");
+const INSTALL_VOICE_SH = readFileSync(path.join(REPO, "scripts", "install-voice.sh"), "utf-8");
+
+const hasPython = spawnSync("python3", ["--version"], { stdio: "ignore" }).status === 0;
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "clawbox-voice-espeak-"));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("install-voice.sh declares no system package install.sh does not provide", () => {
+  /**
+   * Every system package the script's header names as required. The installer
+   * is the only thing that could satisfy one, so a name here that install.sh
+   * never `apt-get install`s is either a missing install or a stale claim.
+   */
+  const declared = [...INSTALL_VOICE_SH.matchAll(/Requires ([a-z0-9][a-z0-9.+-]*) to be installed \(system package\)/g)].map(
+    (m) => m[1],
+  );
+
+  it("names no required system package that install.sh never installs", () => {
+    const missing = declared.filter((pkg) => !new RegExp(`\\b${pkg}\\b`).test(INSTALL_SH));
+    expect(missing).toEqual([]);
+  });
+
+  it("says where the espeak-ng library actually comes from", () => {
+    // Not decoration: the next person to read this file has to know that the
+    // phonemiser is satisfied by a wheel, or they will "fix" the missing apt
+    // package that was never needed.
+    expect(INSTALL_VOICE_SH).toMatch(/espeakng-loader/);
+  });
+});
+
+describe.runIf(hasPython)("the Kokoro warm-up refuses a pipeline with no phonemiser fallback", () => {
+  /** The python program the warm-up hands to the box, lifted verbatim. */
+  const PAYLOAD = (() => {
+    const start = INSTALL_VOICE_SH.indexOf("kokoro_predownload_model() {");
+    if (start < 0) throw new Error("kokoro_predownload_model not found in install-voice.sh");
+    const end = INSTALL_VOICE_SH.indexOf("\n}", start);
+    if (end < 0) throw new Error("kokoro_predownload_model has no closing brace");
+    const fn = INSTALL_VOICE_SH.slice(start, end);
+    const open = fn.indexOf('clawbox_python "');
+    const close = fn.indexOf('" 2>&1', open);
+    if (open < 0 || close < 0) throw new Error("the warm-up payload is no longer a clawbox_python string");
+    const body = fn.slice(open + 'clawbox_python "'.length, close);
+    if (!body.includes("from kokoro import KPipeline")) {
+      throw new Error("the warm-up payload was extracted TRUNCATED");
+    }
+    return body;
+  })();
+
+  /**
+   * Run the payload against a fake `kokoro` module. `fallback` is what
+   * kokoro's own pipeline sets to None when it cannot build an EspeakFallback.
+   */
+  function warmUp(fallback: "present" | "none"): { status: number | null; out: string } {
+    const pkg = path.join(root, "fake", "kokoro");
+    mkdirSync(pkg, { recursive: true });
+    writeFileSync(
+      path.join(pkg, "__init__.py"),
+      [
+        "from types import SimpleNamespace",
+        "",
+        "class _Param:",
+        "    device = 'cuda:0'",
+        "",
+        "class _Model:",
+        "    def parameters(self):",
+        "        return iter([_Param()])",
+        "",
+        "class KPipeline:",
+        "    def __init__(self, lang_code):",
+        "        self.model = _Model()",
+        `        self.g2p = SimpleNamespace(fallback=${fallback === "present" ? "object()" : "None"})`,
+        "",
+      ].join("\n"),
+    );
+    const script = path.join(root, "payload.py");
+    writeFileSync(script, `${PAYLOAD}\n`);
+    const run = spawnSync("python3", [script], {
+      encoding: "utf-8",
+      timeout: 30_000,
+      env: { ...process.env, PYTHONPATH: path.join(root, "fake") },
+    });
+    return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+  }
+
+  it("reports the device when the fallback is there", () => {
+    const run = warmUp("present");
+    expect(run.status).toBe(0);
+    expect(run.out).toContain("Kokoro model ready on");
+  });
+
+  it("fails, naming the phonemiser, when kokoro could not build one", () => {
+    // Today: exit 0 and "Kokoro model ready on cuda:0" — the box publishes
+    // KOKORO=ready and drops every out-of-vocabulary word from speech.
+    const run = warmUp("none");
+    expect(run.status).not.toBe(0);
+    expect(run.out).toMatch(/espeak|phonemis/i);
+  });
+});

--- a/src/tests/unit/install-voice-espeak.test.ts
+++ b/src/tests/unit/install-voice-espeak.test.ts
@@ -112,7 +112,14 @@ describe("the phonemiser check runs on a box that already has Kokoro", () => {
 
   it("refuses the ready verdict when it fails", () => {
     expect(fn).toMatch(/kokoro_check_phonemiser; then[\s\S]*kokoro_report "failed:phonemiser"/);
-    expect(fn.indexOf('kokoro_report "failed:phonemiser"')).toBeLessThan(fn.indexOf('kokoro_report "ready"') + fn.length);
+    // Both indexes, compared directly: `indexOf(a) < indexOf(b) + fn.length`
+    // is satisfied by any position at all, so it would pass a function that
+    // published `ready` first and only then reported the failure.
+    const failed = fn.indexOf('kokoro_report "failed:phonemiser"');
+    const ready = fn.indexOf('kokoro_report "ready"');
+    expect(failed).toBeGreaterThanOrEqual(0);
+    expect(ready).toBeGreaterThanOrEqual(0);
+    expect(failed).toBeLessThan(ready);
   });
 });
 
@@ -163,29 +170,53 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
   type Fault =
     | string
     | "raise" // g2p throws
+    | "partial-drop" // the fallback is gone but SOME words still phonemise
     | "no-g2p" // the pipeline has no g2p attribute
     | "no-module" // `kokoro` is not installed at all
     | "init-raise" // KPipeline() throws (torch/CUDA init, a CUDA OOM, an HF fetch)
     | "model-must-be-false"; // KPipeline() refuses to load TTS weights
 
   /**
-   * Write a fake `kokoro` package and return the PYTHONPATH that finds it, or
-   * null for the box where `kokoro` is absent.
+   * The PYTHONPATH for the box where `kokoro` is absent.
+   *
+   * An empty directory is not enough: PYTHONPATH only PREPENDS to `sys.path`,
+   * so the user and system site-packages are still searched behind it — and a
+   * shipped box, where these suites also run, HAS `kokoro` installed. The host
+   * would then import the real package and the no-module cases would quietly
+   * stop exercising the missing-module path. A module at the front of the path
+   * that raises exactly what a missing package raises makes that box the same
+   * on every host.
+   */
+  function blockedKokoro(): string {
+    const dir = path.join(root, "no-kokoro");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(path.join(dir, "kokoro.py"), `raise ModuleNotFoundError("No module named 'kokoro'")\n`);
+    return dir;
+  }
+
+  /**
+   * Write a fake `kokoro` package and return the PYTHONPATH that finds it —
+   * or, for the box where `kokoro` is absent, the path that blocks the import.
    *
    * `KPipeline.__init__` takes `model` because the real one does: the check
    * wants the G2P only, and constructing with the weights is a torch import
    * plus a KModel load onto a Jetson's shared GPU on every in-app update.
    */
-  function writeFakeKokoro(fault: Fault): string | null {
-    if (fault === "no-module") return null;
+  function writeFakeKokoro(fault: Fault): string {
+    if (fault === "no-module") return blockedKokoro();
     const pkg = path.join(root, "fake", "kokoro");
     mkdirSync(pkg, { recursive: true });
     const g2p =
       fault === "raise"
         ? "    def __call__(self, text):\n        raise RuntimeError('boom')"
-        : `    def __call__(self, text):\n        return (${JSON.stringify(
-            NAMED_FAULTS.has(fault) ? WORKING_PHONEMES : fault,
-          )}, [])`;
+        : fault === "partial-drop"
+          ? // What a missing fallback does to a real sentence: misaki keeps the
+            // words it can phonemise and drops the rest. Nothing is blanked.
+            "    def __call__(self, text):\n" +
+            "        return (' '.join('f\u0279\u02c8\u0251bn\u1d7ck\u02ccAT\u0259\u0279' if w == 'frobnicator' else '\u2753' for w in text.split()), [])"
+          : `    def __call__(self, text):\n        return (${JSON.stringify(
+              NAMED_FAULTS.has(fault) ? WORKING_PHONEMES : fault,
+            )}, [])`;
     const init: string[] = [];
     if (fault === "init-raise") {
       // What a box under memory pressure actually raises: kokoro-server.service
@@ -211,7 +242,7 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
     return path.join(root, "fake");
   }
 
-  const NAMED_FAULTS = new Set(["raise", "no-g2p", "no-module", "init-raise", "model-must-be-false"]);
+  const NAMED_FAULTS = new Set(["raise", "partial-drop", "no-g2p", "no-module", "init-raise", "model-must-be-false"]);
   /** What a shipped Orin with a working espeakng-loader wheel actually returns. */
   const WORKING_PHONEMES = "zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld";
 
@@ -224,10 +255,28 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
     const run = spawnSync("python3", [script], {
       encoding: "utf-8",
       timeout: 30_000,
-      // An empty PYTHONPATH is the box with no kokoro: the import must fail.
-      env: { ...process.env, PYTHONPATH: pythonPath ?? path.join(root, "empty") },
+      env: { ...process.env, PYTHONPATH: pythonPath },
     });
     return { status: run.status, out: `${run.stdout ?? ""}${run.stderr ?? ""}` };
+  }
+
+  /**
+   * The script's own assignments for every name the extracted arm reads, lifted
+   * from the file rather than invented. The arm prints a remediation command
+   * built from them, and the harness runs under `set -u` exactly as the shipped
+   * script does — so an arm that referenced a name install-voice.sh does not set
+   * would abort here instead of aborting a customer's install. A rename in the
+   * script fails this loudly rather than leaving the harness testing a
+   * different arm.
+   */
+  function armPrelude(): string {
+    return ["CLAWBOX_USER", "PIP"]
+      .map((name) => {
+        const m = INSTALL_VOICE_SH.match(new RegExp(`^${name}=.*$`, "m"));
+        if (!m) throw new Error(`install-voice.sh no longer assigns ${name}, which the phonemiser arm reads`);
+        return m[0];
+      })
+      .join("\n");
   }
 
   /**
@@ -248,13 +297,14 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
     const end = INSTALL_VOICE_SH.indexOf("\n}", start);
     const body = INSTALL_VOICE_SH.slice(start, end + 2);
 
-    const pythonPath = writeFakeKokoro(fault) ?? path.join(root, "empty");
+    const pythonPath = writeFakeKokoro(fault);
     const harness = path.join(root, "verdict.sh");
     writeFileSync(
       harness,
       [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
+        armPrelude(),
         'kokoro_report() { echo "REPORT $1"; }',
         `clawbox_python() { PYTHONPATH=${JSON.stringify(pythonPath)} python3 -c "$1"; }`,
         body,
@@ -300,6 +350,29 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
       expect(run.out).toMatch(/espeak/i);
     });
   }
+
+  it("fails when only SOME out-of-vocabulary words are dropped", () => {
+    // The line was judged as ONE string, so a result that still carried the
+    // phonemes of one word passed while the other two had already gone silent
+    // — the exact shape a missing fallback produces on a real sentence, which
+    // mixes lexicon hits with the names this check exists to protect.
+    const run = check("partial-drop");
+    expect(run.status, `the check passed a box that drops words:\n${run.out}`).not.toBe(0);
+    expect(run.out).toMatch(/espeak/i);
+    // Named, so the operator sees WHICH words went silent rather than a verdict
+    // over a sentence that looked half-right.
+    expect(run.out).toContain("zorblattic");
+    expect(run.out).toContain("squibbled");
+  });
+
+  it("really has no kokoro to import on the box that has none", () => {
+    // Guards the guard: PYTHONPATH cannot hide a kokoro the host has
+    // installed, so without the blocker this case would import the real
+    // package and silently stop testing the missing-module path.
+    const run = check("no-module");
+    expect(run.out).toContain("ModuleNotFoundError");
+    expect(run.status).toBe(0);
+  });
 
   for (const [name, mode] of [
     ["the g2p raises", "raise"],
@@ -362,4 +435,34 @@ describe.runIf(canRun)("kokoro_check_phonemiser fails a box that drops out-of-vo
       expect(run.rc).toBe(12);
     });
   });
+});
+
+describe("the phonemiser remediation prints a command that works on the box", () => {
+  /**
+   * Both places that tell an operator how to repair the wheel. A printed fix
+   * that cannot be pasted is a false remedy: the box stays mute and the
+   * operator believes it was told what to do.
+   */
+  const remediations = INSTALL_VOICE_SH.split("\n").filter(
+    (line) => /^\s*echo /.test(line) && /espeakng-loader misaki/.test(line),
+  );
+
+  it("finds both of them", () => {
+    expect(remediations).toHaveLength(2);
+  });
+
+  for (const line of remediations) {
+    it(`installs the way install_python_package does: ${line.trim().slice(0, 60)}…`, () => {
+      // install_python_package is `su - "$CLAWBOX_USER" -c "$PIP install --user …"`.
+      // Dropping --user is what makes the pasted command try a system install
+      // as an unprivileged user, and a hardcoded name is wrong on any box whose
+      // CLAWBOX_USER is not the default.
+      expect(INSTALL_VOICE_SH).toContain('su - "$CLAWBOX_USER" -c "$PIP install --user ');
+      expect(line).toContain("$CLAWBOX_USER");
+      expect(line).toContain("$PIP");
+      expect(line).toContain("install --user ");
+      expect(line).not.toMatch(/\bpip3\b/);
+      expect(line).not.toMatch(/-u clawbox\b|- clawbox\b/);
+    });
+  }
 });


### PR DESCRIPTION
**TASK-686** — `scripts/install-voice.sh` requires `espeak-ng` and `install.sh`
installs it nowhere.

## What the evidence says
The dependency is **stale**, and what it was standing in for is real and was
never checked.

Measured read-only on a shipped openclaw box and a shipped hermes box
(2026-09-04), with no `espeak-ng` package and no `espeak-ng` binary on either:

```
bundled lib: <home>/.local/lib/python3.10/site-packages/espeakng_loader/libespeak-ng.so
EspeakFallback constructed OK
KPipeline(lang_code='a').g2p.fallback -> EspeakFallback
device: cuda:0
WORKING -> 'zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld'    (all three words out-of-vocabulary)
```

`misaki/espeak.py` calls
`EspeakWrapper.set_library(espeakng_loader.get_library_path())` at import, and
the `espeakng-loader` wheel — pulled in by `kokoro` → `misaki[en]`, which
`install_kokoro_packages` installs — vendors both the shared library and the
espeak-ng data. The system package was never a dependency.

## The customer-visible defect underneath it
kokoro builds that fallback inside a `try/except` and degrades to
`logger.warning("EspeakFallback not Enabled: OOD words will be skipped")` plus
`fallback=None`. Nothing downstream reads that warning, so a box in that arm
publishes `KOKORO=ready`, `step_openclaw_tts` grades the step clean,
`step_validate_services` passes its TTS probe — and every out-of-vocabulary word
is silently dropped from speech. Names, brands, "ClawBox" itself. Measured on
the same box with the fallback removed:

```
NO FALLBACK unk=""  -> '  '
NO FALLBACK unk="?" -> '❓ ❓ ❓'
```

So the header is corrected to say where the library actually comes from, and
`kokoro_check_phonemiser()` now phonemises a line no lexicon has and fails the
Kokoro verdict (`failed:phonemiser`, exit 12) when nothing comes back.

**It runs outside the idempotence gate.** `kokoro_stack_present` proves
`import kokoro, torch` works, which a broken `espeakng-loader` does not disturb —
misaki degrades rather than raising — so a check inside the `else` arm would skip
every already-installed box, which is every box on the fleet, including the ones
the fix would be deployed to. It costs a pipeline construction against an
already-cached model, not a download.

**It checks behaviour, not structure.** `kokoro` is installed unpinned
(`install_kokoro_packages`), so a check written against today's attribute names
would start failing WORKING boxes on the manufacturing line the day misaki
renames one. A shape it cannot read at all is a `WARN`, never a verdict.

## Harness-first
Neither OpenClaw nor Hermes owns kokoro's phonemiser — there is no native
mechanism to leverage here, and that is the finding. The engine's own signal is
a `logger.warning` no caller can see. ClawBox's own contract for this is
`$TTS_STATUS_FILE` plus the exit-code vocabulary at the top of
`install-voice.sh`, so the check reports through those (`failed:phonemiser` is a
new `failed:<reason>`, inside the existing closed vocabulary) rather than
inventing a channel.

## RED (unmodified beta)
```
 × names no required system package that install.sh never installs
 × says where the espeak-ng library actually comes from
 × is called after the idempotence gate closes, not inside its else arm
 × refuses the ready verdict when it fails
 × carries no shell metacharacter, so what bash builds is what was written
 × passes a box whose out-of-vocabulary words phonemise
 × fails, naming espeak, when the fallback is gone (kokoro's own unk='')
 × fails, naming espeak, when the fallback is gone (misaki's unknown marker)
 × warns rather than failing a working box when the g2p raises
 × warns rather than failing a working box when the pipeline has no g2p at all

AssertionError: expected [ 'espeak-ng' ] to deeply equal []
      Tests  10 failed | 1 passed (11)
```

The payload is captured **through bash** — the real function `eval`ed with a
stubbed `clawbox_python` that dumps its argument — so what the tests run is
byte-for-byte what `su - clawbox -c` delivers, and a `$` or backtick added later
cannot hide from them.

## GREEN
```
 install-voice-espeak, install-kokoro-tts, install-tts-no-engine,
 install-tts-mute-box-fails, install-tts-provider-registry,
 install-tts-survivor-verdict, install-tts-verdict-siblings,
 install-hermes-tts, clawbox-tts, local-models-installer-contract
                                                    271 passed (10 files)
 bash -n scripts/install-voice.sh                    OK
```

## Sibling call sites
- Both callers of the check: `install_kokoro_tts` (the `--tts-only` path
  install.sh runs on every install and every update) and the full pipeline.
- `install-kokoro-tts.test.ts`'s "cheap on re-run" test asserted the warm-up
  never runs again. Its real invariant — nothing is downloaded — is the `curl`
  assertion beside it, so that one is narrowed to the model pre-download and now
  also pins that the phonemiser check *is* run on that path.
- `scripts/openclaw/tts.py` and `scripts/bench/tts-bench.py` construct
  `KPipeline` too; a benchmark and a one-shot synthesiser, correctly left alone.
- `scripts/openclaw/kokoro-server.py` is dead (nothing references it;
  `deploy_voice_scripts` copies `scripts/kokoro-server.py`, which is what the
  unit's `ExecStart` points at). Pre-existing duplication, not touched here.
- `scripts/kokoro-server.py` — the process that actually speaks — builds its own
  pipeline later, in another process, and `/health` answers `ok` regardless. That
  makes the install-time check a *probe-once* for the life of the box. Out of
  scope for this PR (a runtime change to a different process, warn-only, with its
  own health-shape decision) and recorded on the fixer queue instead.

## Review
One Opus `clawbox-review` pass: 1 high, 3 medium, 3 low. The high — the guard
sitting inside the idempotence gate — is the reason this PR has a second commit;
the medium about an unpinned upstream is why the check is behavioural; the
payload-capture-through-bash and the control-that-can-fail on the header matcher
are the other two applied. Two suspicions it checked and cleared, so they are not
re-raised: the shell quoting of the payload (`clawbox_python` pipes to
`python3 -` on stdin, it does not embed the program in the `su -c` string), and
that `SystemExit` yields a status the caller records (rc 1 → `failed:*` → 12 →
`record_provision_failure openclaw_tts`, non-fatal).


## Final review round (2026-09-04) — HIGH fixed

The final-head Opus review found a **fleet-wide false failure** the earlier rounds
had not: `from kokoro import KPipeline` and `KPipeline(lang_code='a')` sat
**outside** `kokoro_check_phonemiser`'s own `try`. So kokoro absent, a torch/CUDA
init failure, a HuggingFace fetch or a CUDA OOM — none of which says anything at
all about the phonemiser — each exited non-zero and became
`failed:phonemiser` → `return 12` → `VOICE_RC=12` → `TTS_RC=12` → "Kokoro GPU TTS
was REQUESTED and did NOT install" plus `record_provision_failure openclaw_tts`,
over a box that speaks fine. Because this PR deliberately moved the check
*outside* the idempotence gate, that ran on **every in-app update of every box on
the fleet**, where beta had loaded nothing at all. The function's own comment
already stated the rule its code broke — "a shape this cannot read at all is a
warning, never a verdict" — and the two now agree.

**Fix, both halves:**
1. The import and the construction are inside the `try`. Only a genuinely empty
   phonemisation is a verdict; everything else is the WARN the comment promises.
2. `KPipeline(lang_code='a', model=False)` — G2P only. This also closes the
   review's MEDIUM-2 (an unmeasured full pipeline construction added to every
   install and every update) and MEDIUM-3 (the check needed the HuggingFace cache,
   and a network round trip, to be "offline").

### RED (against this PR's own previous head, `ea5fafb7`)

New cases run the shipped `kokoro_check_phonemiser` payload, and then the shipped
`if ! kokoro_check_phonemiser; then … return 12; fi` arm lifted out of
`install_kokoro_tts`, against a fake `kokoro` carrying each fault:

```
FAIL  … > warns rather than failing a working box when kokoro is not installed at all
FAIL  … > warns rather than failing a working box when the pipeline constructor raises
      AssertionError: expected 1 to be +0

FAIL  … > does not fail the provision when kokoro is not installed at all
      AssertionError: expected '  Checking the phonemiser...' not to contain 'REPORT failed:phonemiser'
      + ModuleNotFoundError: No module named 'kokoro'
        REPORT failed:phonemiser
      + RC=12

FAIL  … > does not fail the provision when the pipeline constructor raises (CUDA OOM, torch init, an HF fetch)
      + RuntimeError: CUDA out of memory
        REPORT failed:phonemiser
      + RC=12

FAIL  … > builds the G2P only, without loading the TTS model
      AssertionError: expected 'the check loaded the TTS model' not to contain 'the check loaded the TTS model'

Tests  5 failed | 12 passed (17)
```

A control test (`still fails the provision for the fault it exists to catch`)
asserts the check is not merely turned off: an empty phonemisation still produces
`REPORT failed:phonemiser` and `RC=12`.

### GREEN

`install-voice-espeak` + `install-kokoro-tts` + `install-tts-verdict-siblings` →
**104 passed**; `tsc --noEmit` clean.

### Measured read-only on a shipped openclaw box

Both halves are hardware facts, not reasoning:

```
SIG: (self, lang_code: str, repo_id: Optional[str] = None,
      model: Union[kokoro.model.KModel, bool] = True, trf: bool = False, ...)
HAS_model: True
G2P_built: True EspeakFallback
PHONEMES: 'zɔɹblˈæTɪk fɹˈɑbnᵻkˌATəɹ skwˈɪbᵊld'
```

`model=False` is a real parameter, `pipeline.g2p` is built anyway, and the probe
returns exactly the phonemes the working case was measured to return — so the
check loses nothing and stops loading the model.

The same box also reproduces the HIGH directly. Under the *login* shell
`clawbox_python` uses (`su - clawbox`), the import fails:

```
ImportError: libcusparseLt.so.0: cannot open shared object file
```

because `LD_LIBRARY_PATH` is set only inside `kokoro-server.service`
(`Environment=LD_LIBRARY_PATH=…/nvidia/cusparselt/lib:…`), not in a login shell.
On the previous head that box was graded `failed:phonemiser` on every update. No
box was mutated: reads and one in-process import only.

### Also applied from the same review

- **LOW-4** — the full path calls the check unconditionally, after
  `install_kokoro_packages` or the model download may already have failed, and
  then told the operator "Kokoro cannot phonemise" about a box where kokoro is not
  installed. Now `if $KOKORO_FULL_OK && ! kokoro_check_phonemiser`. No verdict
  changes (the flag is already false there) — only the sentence.
- **LOW-5** — both failure arms now name a remedy. Re-running
  `--step openclaw_tts` lands on the idempotence gate and re-runs this same check,
  so the generic re-run line is not a fix here; the wheel reinstall is.
- **NIT-6** — the comment now states the real invariant ("asks for SOMETHING back
  for a word no lexicon has"), not the stronger "phonemises".

### Sibling call sites of `KPipeline(...)`, all cleared

`scripts/install-voice.sh:335` (`kokoro_predownload_model`),
`scripts/kokoro-server.py`, `scripts/openclaw/kokoro-server.py`,
`scripts/openclaw/tts.py`, `scripts/bench/tts-bench.py` — every one of them
synthesises audio and therefore *needs* the weights. `model=False` is correct only
for the phonemiser probe, which uses `pipeline.g2p` alone. Both callers of
`kokoro_check_phonemiser` (`:636` `--tts-only`, `:854` full path) are covered above.

### Review round 2 (CodeRabbit threads, 4 applied / 1 refuted)

Two of these changed behaviour:

- **The check was still a false success on a partially broken box.** It phonemised
  `'zorblattic frobnicator squibbled'` as ONE string and failed only when the whole
  result came back empty. A missing fallback does not blank a sentence — misaki
  keeps the words it can phonemise and drops the rest — so a box that had already
  lost two of the three words read non-empty and published `ready`. That is what
  real speech looks like: lexicon hits mixed with the names this check exists to
  protect. Each word is now judged on its own, and the failure names which ones
  went silent. The judging moved *inside* the `try` with the calls, so a `g2p`
  returning an unreadable shape is a WARN (it used to raise `AttributeError`
  uncaught and grade the box `failed:phonemiser`).
- **The remediation both failure arms printed would not have run.**
  `sudo -u clawbox pip3 install --force-reinstall espeakng-loader misaki` has no
  `--user`, so a pasted copy is a system install attempted by an unprivileged
  account — and it hardcoded a user and a pip the script makes configurable. Both
  lines now print the shape `install_python_package` itself installs with:
  `su - $CLAWBOX_USER -c '$PIP install --user --force-reinstall espeakng-loader misaki'`.
  A false remedy on the error path is the same defect class as a false success.

Test-side, all three real:

- The `no-module` box was an empty `PYTHONPATH`, which the user and system
  site-packages see straight past. A shipped box HAS `kokoro` installed, so on the
  machine that matters the case would have imported the real package and stopped
  testing anything. It is now a `kokoro.py` at the front of the path raising
  `ModuleNotFoundError` — indistinguishable to the payload, unshadowable by
  anything behind it — and the WARN is asserted to name that error.
  (`PYTHONNOUSERSITE=1`, as suggested, disables only the *user* site and would not
  have closed it.)
- The verdict-ordering assertion added `fn.length` to the right-hand side and could
  not fail; both indexes are now compared directly.
- The `verdict()` harness runs the extracted arm under `set -u` with the script's
  OWN `CLAWBOX_USER=`/`PIP=` lines lifted from the file — a guard that fails loudly
  if either is renamed while the arm still prints them.

Refuted: the "future measurement date" — today is 2026-09-04 and every commit on
this branch is authored 2026-09-04, so `install-voice.sh:8` names the day the two
boxes were actually read.

**RED → GREEN:** the partial-drop fault and both remediation assertions failed on
`ee795dd6`; the `no-module` leak was reproduced with a `kokoro` planted in a
relocated user site (`PYTHONUSERBASE`, nothing real touched) and the pre-fix file
printed `Phonemiser OK` where it should have warned. After the fix: 22/22 in this
file (also 22/22 under that same planted user site), 391/391 across the 13 suites
that touch `install-voice.sh`, `tsc --noEmit` clean.

### Review round 3 (one further thread, applied in part)

The two remediation lines are shell source a human pastes into a root shell, and
they interpolated the overridable `CLAWBOX_USER` straight into that text: a name
with a space in it rendered unpasteable, and a name carrying shell syntax became a
second command when pasted. Reproduced by pasting what the line printed, with `su`
stubbed and `CLAWBOX_USER='evil $(touch …)'` — the paste ran the substitution.
`install-voice.sh:669` and `:894` now render with `printf` and `%q` on the user.

Not `%q` on the whole `-c` command as suggested: bash's `%q` backslashes every
space, so the ordinary box would print
`su - clawbox -c pip3\ install\ --user\ …`. The command is a fixed literal plus a
script constant, so it stays in single quotes and the normal output is unchanged.
A control test pins that, because escaping that made the common case unreadable
would be a regression rather than a fix.

(The security framing was refuted: `CLAWBOX_USER` is settable only by whoever
already controls the installer's environment, and `install.sh` never exports it.
The pasteability half is what made it worth doing.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Voice installation now uses the phonemiser included with Kokoro’s bundled wheels.
  - Added runtime validation to confirm phonemisation works correctly, including detection of dropped or unknown words.
  - Validation runs during relevant installation flows and reruns without repeating model downloads.

- **Bug Fixes**
  - Installations no longer report success when phonemisation silently drops words.
  - Missing or unavailable validation components now generate warnings instead of misleading failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


